### PR TITLE
Fixed  links to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Files
 
 Dependencies:
 
-* Go platform libraries
+* [Go platform libraries](https://golang.org)
 * [GOSE](https://github.com/bifurcation/gose)
-* [CLI](github.com/codegangsta/cli)
+* [CLI](https://github.com/codegangsta/cli)
 
 
 ACME Processing


### PR DESCRIPTION
codegangsta/cli was broken and link to golang.org is nice to have.
