### PR TITLE
Return 403 for invalid authorizations.

### DIFF
--- a/web-front-end.go
+++ b/web-front-end.go
@@ -234,7 +234,11 @@ func (wfe *WebFrontEndImpl) Authz(response http.ResponseWriter, request *http.Re
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-		response.WriteHeader(http.StatusOK)
+		httpStatus := http.StatusOK
+		if authz.Status == StatusInvalid {
+			httpStatus = http.StatusForbidden
+		}
+		response.WriteHeader(httpStatus)
 		response.Write(jsonReply)
 	}
 }


### PR DESCRIPTION
This fixes an issue where the demo client doesn't terminate when an authorization
is marked invalid.