### PR TITLE
Simplify live test of ACME server.

### DIFF
--- a/web-front-end.go
+++ b/web-front-end.go
@@ -234,7 +234,11 @@ func (wfe *WebFrontEndImpl) Authz(response http.ResponseWriter, request *http.Re
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-		response.WriteHeader(http.StatusOK)
+		httpStatus := http.StatusOK
+		if authz.Status == StatusInvalid {
+			httpStatus = http.StatusForbidden
+		}
+		response.WriteHeader(httpStatus)
 		response.Write(jsonReply)
 	}
 }


### PR DESCRIPTION
Consolidate settings for localhost testing.
Add logging.
Disable cert checking and keepalives for SimpleHTTPS Validation.
Give 403 response when authorizations failed.