### PR TITLE
correct package name typo

### DIFF
--- a/certificate-authority.go
+++ b/certificate-authority.go
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package bouler
+package boulder
 
 import (
 	"crypto/rand"


### PR DESCRIPTION
Build is currently broken due to a typo in the package name