### PR TITLE
Initial Docker container support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.4
+
+MAINTAINER J.C. Jones "jjones@mozilla.com"
+
+# Boulder exposes its web application at port TCP 4000
+EXPOSE 4000
+
+# Load the dependencies
+RUN go-wrapper download github.com/bifurcation/gose && \
+    go-wrapper download github.com/codegangsta/cli && \
+    go-wrapper download github.com/streadway/amqp
+
+# Copy in the Boulder sources
+RUN mkdir -p /go/src/github.com/letsencrypt/boulder
+COPY . /go/src/github.com/letsencrypt/boulder
+
+# Build Boulder
+RUN cd /go/src/github.com/letsencrypt/boulder && \
+    go build && \
+    cd boulder-start && \
+    go build
+
+# Simplify run execution
+WORKDIR /go/src/github.com/letsencrypt/boulder/boulder-start
+
+# Default run configuration in Monolithic mode without AMQP
+CMD ["./boulder-start", "monolithic"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,4 @@ RUN cd /go/src/github.com/letsencrypt/boulder && \
     cd boulder-start && \
     go build
 
-# Simplify run execution
-WORKDIR /go/src/github.com/letsencrypt/boulder/boulder-start
-
-# Default run configuration in Monolithic mode without AMQP
-CMD ["./boulder-start", "monolithic"]
+ENTRYPOINT ["/go/src/github.com/letsencrypt/boulder/boulder-start/boulder-start"]

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ This is an initial implementation of an ACME-based CA.  The [ACME protocol](http
 Docker
 ------
 
-Boulder is available as a [Docker image from Quay.io](https://quay.io/repository/letsencrypt/boulder). You can load and run it using in monolithic mode (without AMQP) using the default run command:
+Boulder is available as a [Docker image from Quay.io](https://quay.io/repository/letsencrypt/boulder). The entrypoint is the Boulder main method; you can load and run it using in monolithic mode (without AMQP) like:
 
 ```
-docker run -p 4000:4000 quay.io/letsencrypt/boulder
+docker run -p 4000:4000 quay.io/letsencrypt/boulder monolithic
 ```
 
 To run a single module, specifying the AMQP server, you might use something more like:
 
 ```
-docker run -p 4000:4000 quay.io/letsencrypt/boulder ./boulder-start --amqp 'amqp://guest:guest@amqp-server:15672' wfe
+docker run -p 4000:4000 quay.io/letsencrypt/boulder --amqp 'amqp://guest:guest@amqp-server:15672' wfe
 ```
 
 Quickstart

--- a/README.md
+++ b/README.md
@@ -3,7 +3,24 @@ Boulder - An ACME CA
 
 This is an initial implementation of an ACME-based CA.  The [ACME protocol](https://github.com/letsencrypt/acme-spec/) allows the CA to automatically verify that an applicant for a certificate actually controls an identifier, and allows domain holders to issue and revoke certificates for their domains.
 
+
 [![Build Status](https://travis-ci.org/letsencrypt/boulder.svg)](https://travis-ci.org/letsencrypt/boulder)
+[![Docker Repository on Quay.io](https://quay.io/repository/letsencrypt/boulder/status "Docker Repository on Quay.io")](https://quay.io/repository/letsencrypt/boulder)
+
+Docker
+------
+
+Boulder is available as a [Docker image from Quay.io](https://quay.io/repository/letsencrypt/boulder). You can load and run it using in monolithic mode (without AMQP) using the default run command:
+
+```
+docker run -p 4000:4000 quay.io/letsencrypt/boulder
+```
+
+To run a single module, specifying the AMQP server, you might use something more like:
+
+```
+docker run -p 4000:4000 quay.io/letsencrypt/boulder ./boulder-start --amqp 'amqp://guest:guest@amqp-server:15672' wfe
+```
 
 Quickstart
 ----------

--- a/boulder-start/main.go
+++ b/boulder-start/main.go
@@ -47,8 +47,15 @@ func main() {
 	app.Usage = "Command-line utility to start Boulder's servers in stand-alone mode"
 	app.Version = "0.0.0"
 
-	// Server URL hard-coded for now
-	amqpServerURL := "amqp://guest:guest@localhost:5672"
+
+	// Specify AMQP Server
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+				Name: "amqp",
+				Value: "amqp://guest:guest@localhost:5672",
+				Usage: "AMQP Broker String",
+			},
+	}
 
 	// One command per element of the system
 	// * WebFrontEnd
@@ -102,7 +109,7 @@ func main() {
 			Usage: "Start the CA in monolithic mode, using AMQP",
 			Action: func(c *cli.Context) {
 				// Create an AMQP channel
-				ch := amqpChannel(amqpServerURL)
+				ch := amqpChannel(c.GlobalString("amqp"))
 
 				// Create AMQP-RPC clients for CA, VA, RA, SA
 				cac, err := boulder.NewCertificateAuthorityClient("CA.client", "CA.server", ch)
@@ -157,7 +164,7 @@ func main() {
 			Usage: "Start the WebFrontEnd",
 			Action: func(c *cli.Context) {
 				// Create necessary clients
-				ch := amqpChannel(amqpServerURL)
+				ch := amqpChannel(c.GlobalString("amqp"))
 
 				rac, err := boulder.NewRegistrationAuthorityClient("RA.client", "RA.server", ch)
 				failOnError(err, "Unable to create RA client")
@@ -189,7 +196,7 @@ func main() {
 			Name:  "ca",
 			Usage: "Start the CertificateAuthority",
 			Action: func(c *cli.Context) {
-				ch := amqpChannel(amqpServerURL)
+				ch := amqpChannel(c.GlobalString("amqp"))
 
 				cas, err := boulder.NewCertificateAuthorityServer("CA.server", ch)
 				failOnError(err, "Unable to create CA server")
@@ -200,7 +207,7 @@ func main() {
 			Name:  "sa",
 			Usage: "Start the StorageAuthority",
 			Action: func(c *cli.Context) {
-				ch := amqpChannel(amqpServerURL)
+				ch := amqpChannel(c.GlobalString("amqp"))
 
 				sas := boulder.NewStorageAuthorityServer("SA.server", ch)
 				runForever(sas)
@@ -210,7 +217,7 @@ func main() {
 			Name:  "va",
 			Usage: "Start the ValidationAuthority",
 			Action: func(c *cli.Context) {
-				ch := amqpChannel(amqpServerURL)
+				ch := amqpChannel(c.GlobalString("amqp"))
 
 				rac, err := boulder.NewRegistrationAuthorityClient("RA.client", "RA.server", ch)
 				failOnError(err, "Unable to create RA client")
@@ -225,7 +232,7 @@ func main() {
 			Usage: "Start the RegistrationAuthority",
 			Action: func(c *cli.Context) {
 				// TODO
-				ch := amqpChannel(amqpServerURL)
+				ch := amqpChannel(c.GlobalString("amqp"))
 
 				vac, err := boulder.NewValidationAuthorityClient("VA.client", "VA.server", ch)
 				failOnError(err, "Unable to create VA client")

--- a/boulder-start/main.go
+++ b/boulder-start/main.go
@@ -89,7 +89,7 @@ func main() {
 				va.RA = &ra
 
 				// Go!
-				authority := "localhost:4000"
+				authority := "0.0.0.0:4000"
 				authzPath := "/acme/authz/"
 				certPath := "/acme/cert/"
 				wfe.SetAuthzBase("http://" + authority + authzPath)
@@ -144,7 +144,7 @@ func main() {
 				wfe.SA = &sac
 
 				// Go!
-				authority := "localhost:4000"
+				authority := "0.0.0.0:4000"
 				authzPath := "/acme/authz/"
 				certPath := "/acme/cert/"
 				wfe.SetAuthzBase("http://" + authority + authzPath)
@@ -178,7 +178,7 @@ func main() {
 				wfe.SA = &sac
 
 				// Connect the front end to HTTP
-				authority := "localhost:4000"
+				authority := "0.0.0.0:4000"
 				authzPath := "/acme/authz/"
 				certPath := "/acme/cert/"
 				wfe.SetAuthzBase("http://" + authority + authzPath)


### PR DESCRIPTION
This pull request adds a Dockerfile to build a Docker container for Boulder. It's very basic at present. The container hosting is at https://quay.io/repository/letsencrypt/boulder .

