### PR TITLE
Begin fixing "Content-Type: application/pkix-cert" issues

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -88,12 +88,12 @@ type problem struct {
 func sendError(response http.ResponseWriter, message string, code int) {
 	problem := problem{Detail: message}
 	problemDoc, err := json.Marshal(problem)
-  // XXX Double check that this is not redundant with the behavior of http.Error
-	response.Header().Add("Content-Type", "application/problem+json")
 	if err != nil {
 		return
 	}
-	http.Error(response, string(problemDoc), code)
+	response.Header().Add("Content-Type", "application/problem+json")
+	w.WriteHeader(code)
+	fmt
 }
 
 func link(url, relation string) string {
@@ -145,7 +145,6 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	response.Write(responseBody)
 }
 
-
 func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, request *http.Request) {
 	if request.Method != "POST" {
 		sendError(response, "Method not allowed", http.StatusMethodNotAllowed)
@@ -157,7 +156,6 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 		sendError(response, "Unable to read/verify body", http.StatusBadRequest)
 		return
 	}
-
 
 	var init core.Authorization
 	if err = json.Unmarshal(body, &init); err != nil {
@@ -192,9 +190,7 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 	}
 }
 
-
 func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request *http.Request) {
-
 
 	if request.Method != "POST" {
 		sendError(response, "Method not allowed", http.StatusMethodNotAllowed)
@@ -227,11 +223,11 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	// Make a URL for this authz
 	certURL := wfe.CertBase + string(cert.ID)
 
-  // XXX The spec says this should 201 over to /cert, not reply with the
-  // certificate at this point... fix will need to land in boulder and client
-  // simultaneously.
-  // XXX The spec says a client should send an Accept: application/pkix-cert
-  // header; either explicitly insist or tolerate
+	// TODO The spec says this should 201 over to /cert, not reply with the
+	// certificate at this point... fix will need to land in boulder and client
+	// simultaneously.
+	// TODO The spec says a client should send an Accept: application/pkix-cert
+	// header; either explicitly insist or tolerate
 
 	response.Header().Add("Location", certURL)
 	response.Header().Add("Content-Type", "application/pkix-cert")
@@ -297,7 +293,7 @@ func (wfe *WebFrontEndImpl) Challenge(authz core.Authorization, response http.Re
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-	  response.Header().Add("Content-Type", "application/json")
+		response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusAccepted)
 		if _, err = response.Write(jsonReply); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -329,7 +325,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-	  response.Header().Add("Content-Type", "application/json")
+		response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusOK)
 		response.Write(jsonReply)
 
@@ -366,7 +362,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-	  response.Header().Add("Content-Type", "application/json")
+		response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusAccepted)
 		response.Write(jsonReply)
 
@@ -401,7 +397,7 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-	  response.Header().Add("Content-Type", "application/json")
+		response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusOK)
 		if _, err = response.Write(jsonReply); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -427,7 +423,7 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 
 		// TODO: Content negotiation
 		// TODO: Link header
-	  response.Header().Add("Content-Type", "application/pkix-cert")
+		response.Header().Add("Content-Type", "application/pkix-cert")
 		response.WriteHeader(http.StatusOK)
 		if _, err = response.Write(cert); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -91,7 +91,7 @@ func sendError(response http.ResponseWriter, message string, code int) {
 	if err != nil {
 		return
 	}
-	response.Header().Add("Content-Type", "application/problem+json")
+	response.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(code)
 	fmt
 }
@@ -135,7 +135,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	}
 
 	response.Header().Add("Location", regURL)
-	response.Header().Add("Content-Type", "application/json")
+	response.Header().Set("Content-Type", "application/json")
 	response.Header().Add("Link", link(wfe.NewAuthz, "next"))
 	if len(wfe.SubscriberAgreementURL) > 0 {
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
@@ -183,7 +183,7 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 
 	response.Header().Add("Location", authzURL)
 	response.Header().Add("Link", link(wfe.NewCert, "next"))
-	response.Header().Add("Content-Type", "application/json")
+	response.Header().Set("Content-Type", "application/json")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(responseBody); err != nil {
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -230,7 +230,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	// header; either explicitly insist or tolerate
 
 	response.Header().Add("Location", certURL)
-	response.Header().Add("Content-Type", "application/pkix-cert")
+	response.Header().Set("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(cert.DER); err != nil {
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -293,7 +293,7 @@ func (wfe *WebFrontEndImpl) Challenge(authz core.Authorization, response http.Re
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-		response.Header().Add("Content-Type", "application/json")
+		response.Header().Set("Content-Type", "application/json")
 		response.WriteHeader(http.StatusAccepted)
 		if _, err = response.Write(jsonReply); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -325,7 +325,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-		response.Header().Add("Content-Type", "application/json")
+		response.Header().Set("Content-Type", "application/json")
 		response.WriteHeader(http.StatusOK)
 		response.Write(jsonReply)
 
@@ -362,7 +362,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-		response.Header().Add("Content-Type", "application/json")
+		response.Header().Set("Content-Type", "application/json")
 		response.WriteHeader(http.StatusAccepted)
 		response.Write(jsonReply)
 
@@ -397,7 +397,7 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
-		response.Header().Add("Content-Type", "application/json")
+		response.Header().Set("Content-Type", "application/json")
 		response.WriteHeader(http.StatusOK)
 		if _, err = response.Write(jsonReply); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -423,7 +423,7 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 
 		// TODO: Content negotiation
 		// TODO: Link header
-		response.Header().Add("Content-Type", "application/pkix-cert")
+		response.Header().Set("Content-Type", "application/pkix-cert")
 		response.WriteHeader(http.StatusOK)
 		if _, err = response.Write(cert); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -142,6 +142,9 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	response.Write(responseBody)
 }
 
+// FIXSPEC The spec is currently wrong in claiming that this resource will 201
+// over to /cert for cert delivery.
+
 func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, request *http.Request) {
 	if request.Method != "POST" {
 		sendError(response, "Method not allowed", http.StatusMethodNotAllowed)
@@ -153,6 +156,9 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 		sendError(response, "Unable to read/verify body", http.StatusBadRequest)
 		return
 	}
+
+  // XXX The spec says a client should send an Accept: application/pkix-cert
+  // header; either explicitly insist or tolerate
 
 	var init core.Authorization
 	if err = json.Unmarshal(body, &init); err != nil {
@@ -180,6 +186,7 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 
 	response.Header().Add("Location", authzURL)
 	response.Header().Add("Link", link(wfe.NewCert, "next"))
+	response.Header().Add("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(responseBody); err != nil {
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -88,6 +88,8 @@ type problem struct {
 func sendError(response http.ResponseWriter, message string, code int) {
 	problem := problem{Detail: message}
 	problemDoc, err := json.Marshal(problem)
+  // XXX Double check that this is not redundant with the behavior of http.Error
+	response.Header().Add("Content-Type", "application/problem+json")
 	if err != nil {
 		return
 	}
@@ -133,6 +135,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	}
 
 	response.Header().Add("Location", regURL)
+	response.Header().Add("Content-Type", "application/json")
 	response.Header().Add("Link", link(wfe.NewAuthz, "next"))
 	if len(wfe.SubscriberAgreementURL) > 0 {
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
@@ -142,8 +145,6 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	response.Write(responseBody)
 }
 
-// FIXSPEC The spec is currently wrong in claiming that this resource will 201
-// over to /cert for cert delivery.
 
 func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, request *http.Request) {
 	if request.Method != "POST" {
@@ -157,8 +158,6 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 		return
 	}
 
-  // XXX The spec says a client should send an Accept: application/pkix-cert
-  // header; either explicitly insist or tolerate
 
 	var init core.Authorization
 	if err = json.Unmarshal(body, &init); err != nil {
@@ -186,14 +185,17 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 
 	response.Header().Add("Location", authzURL)
 	response.Header().Add("Link", link(wfe.NewCert, "next"))
-	response.Header().Add("Content-Type", "application/pkix-cert")
+	response.Header().Add("Content-Type", "application/json")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(responseBody); err != nil {
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 	}
 }
 
+
 func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request *http.Request) {
+
+
 	if request.Method != "POST" {
 		sendError(response, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -225,8 +227,13 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	// Make a URL for this authz
 	certURL := wfe.CertBase + string(cert.ID)
 
-	// TODO: Content negotiation for cert format
+  // FIXSPEC The spec is currently wrong in claiming that this resource will 201
+  // over to /cert for cert delivery.
+  // XXX The spec says a client should send an Accept: application/pkix-cert
+  // header; either explicitly insist or tolerate
+
 	response.Header().Add("Location", certURL)
+	response.Header().Add("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(cert.DER); err != nil {
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -289,6 +296,7 @@ func (wfe *WebFrontEndImpl) Challenge(authz core.Authorization, response http.Re
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
+	  response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusAccepted)
 		if _, err = response.Write(jsonReply); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -320,6 +328,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
+	  response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusOK)
 		response.Write(jsonReply)
 
@@ -356,6 +365,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
+	  response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusAccepted)
 		response.Write(jsonReply)
 
@@ -390,6 +400,7 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 			sendError(response, "Failed to marshal authz", http.StatusInternalServerError)
 			return
 		}
+	  response.Header().Add("Content-Type", "application/json")
 		response.WriteHeader(http.StatusOK)
 		if _, err = response.Write(jsonReply); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
@@ -414,8 +425,8 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 		}
 
 		// TODO: Content negotiation
-		// TODO: Indicate content type
 		// TODO: Link header
+	  response.Header().Add("Content-Type", "application/pkix-cert")
 		response.WriteHeader(http.StatusOK)
 		if _, err = response.Write(cert); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -91,9 +91,11 @@ func sendError(response http.ResponseWriter, message string, code int) {
 	if err != nil {
 		return
 	}
+    // Paraphrased from
+    // https://golang.org/src/net/http/server.go#L1272
 	response.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(code)
-	fmt
+	response.WriteHeader(code)
+	fmt.Fprintln(response, problemDoc)
 }
 
 func link(url, relation string) string {

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -227,8 +227,9 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	// Make a URL for this authz
 	certURL := wfe.CertBase + string(cert.ID)
 
-  // FIXSPEC The spec is currently wrong in claiming that this resource will 201
-  // over to /cert for cert delivery.
+  // XXX The spec says this should 201 over to /cert, not reply with the
+  // certificate at this point... fix will need to land in boulder and client
+  // simultaneously.
   // XXX The spec says a client should send an Accept: application/pkix-cert
   // header; either explicitly insist or tolerate
 

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -91,8 +91,8 @@ func sendError(response http.ResponseWriter, message string, code int) {
 	if err != nil {
 		return
 	}
-    // Paraphrased from
-    // https://golang.org/src/net/http/server.go#L1272
+	// Paraphrased from
+	// https://golang.org/src/net/http/server.go#L1272
 	response.Header().Set("Content-Type", "application/problem+json")
 	response.WriteHeader(code)
 	fmt.Fprintln(response, problemDoc)


### PR DESCRIPTION
 - Minimally, send it when it applies
 - Flag that none of this implementation really matches the spec;
   probably the spec should change?