### PR TITLE
remove testing mode from va

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -36,9 +36,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTPS(identifier core.AcmeIdenti
 		return
 	}
 
-	// XXX: Local version; uncomment for real version
-	url := fmt.Sprintf("http://localhost:5001/.well-known/acme-challenge/%s", challenge.Path)
-	//url := fmt.Sprintf("https://%s/.well-known/acme-challenge/%s", identifier, challenge.Path)
+	url := fmt.Sprintf("https://%s/.well-known/acme-challenge/%s", identifier, challenge.Path)
 
 	httpRequest, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -93,8 +91,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 	zName := hex.EncodeToString(z)
 
 	// Make a connection with SNI = nonceName
-	hostPort := "localhost:5001"
-	//hostPort := identifier + ":443" // XXX: Local version; uncomment for real version
+	hostPort := identifier + ":443"
 	conn, err := tls.Dial("tcp", hostPort, &tls.Config{
 		ServerName:         nonceName,
 		InsecureSkipVerify: true,


### PR DESCRIPTION
Removed the default testing mode from the valudation_authority, which allows Boulder to work with clients on other hosts.

If a testing mode is needed, it shouldn't be determined at compile time.

Unfortunately my testing setup isn't the greatest with Boulder right now.  I have not tested the previously commented lines, but I assume they work as I did not make any changes.

This should fix #58.