### PR TITLE
AMQP reconnect-er (fix for #22)

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -40,14 +40,12 @@ func main() {
 
 			forever := make(chan bool)
 			go func() {
-				for true {
-					for err := range closeChan {
-						log.Printf(" [c!] AMQP Channel closed: [%s]", err)
-						time.Sleep(time.Second*10)
-						log.Printf(" [c!] Reconnecting to AMQP...")
-						close(forever)
-						return
-					}
+				for err := range closeChan {
+					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					time.Sleep(time.Second*10)
+					log.Printf(" [c!] Reconnecting to AMQP...")
+					close(forever)
+					return
 				}
 			}()
 			cmd.MaybeRunForever(cas, forever)

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -41,9 +41,9 @@ func main() {
 			forever := make(chan bool)
 			go func() {
 				for err := range closeChan {
-					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					log.Printf(" [!] AMQP Channel closed: [%s]", err)
 					time.Sleep(time.Second*10)
-					log.Printf(" [c!] Reconnecting to AMQP...")
+					log.Printf(" [!] Reconnecting to AMQP...")
 					close(forever)
 					return
 				}

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -7,8 +7,6 @@ package main
 
 import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
-	"log"
-	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
@@ -45,17 +43,7 @@ func main() {
 			ras, err := rpc.NewRegistrationAuthorityServer(c.AMQP.RA.Server, ch, &rai)
 			cmd.FailOnError(err, "Unable to create RA server")
 			
-			forever := make(chan bool)
-			go func() {
-				for err := range closeChan {
-					log.Printf(" [!] AMQP Channel closed: [%s]", err)
-					time.Sleep(time.Second*10)
-					log.Printf(" [!] Reconnecting to AMQP...")
-					close(forever)
-					return
-				}
-			}()
-			cmd.MaybeRunForever(ras, forever)
+			cmd.RunUntilSignaled(auditlogger, ras, closeChan)
 		}
 
 	}

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -47,14 +47,12 @@ func main() {
 			
 			forever := make(chan bool)
 			go func() {
-				for true {
-					for err := range closeChan {
-						log.Printf(" [c!] AMQP Channel closed: [%s]", err)
-						time.Sleep(time.Second*10)
-						log.Printf(" [c!] Reconnecting to AMQP...")
-						close(forever)
-						return
-					}
+				for err := range closeChan {
+					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					time.Sleep(time.Second*10)
+					log.Printf(" [c!] Reconnecting to AMQP...")
+					close(forever)
+					return
 				}
 			}()
 			cmd.MaybeRunForever(ras, forever)

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -23,7 +23,7 @@ func main() {
 
 		rai := ra.NewRegistrationAuthorityImpl(auditlogger)
 
-		for true {
+		for {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -6,6 +6,10 @@
 package main
 
 import (
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+	"log"
+	"time"
+
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/ra"
@@ -15,29 +19,47 @@ import (
 func main() {
 	app := cmd.NewAppShell("boulder-ra")
 	app.Action = func(c cmd.Config) {
-		ch := cmd.AmqpChannel(c.AMQP.Server)
-
 		// Set up logging
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
-		vac, err := rpc.NewValidationAuthorityClient(c.AMQP.VA.Client, c.AMQP.VA.Server, ch)
-		cmd.FailOnError(err, "Unable to create VA client")
-
-		cac, err := rpc.NewCertificateAuthorityClient(c.AMQP.CA.Client, c.AMQP.CA.Server, ch)
-		cmd.FailOnError(err, "Unable to create CA client")
-
-		sac, err := rpc.NewStorageAuthorityClient(c.AMQP.SA.Client, c.AMQP.SA.Server, ch)
-		cmd.FailOnError(err, "Unable to create SA client")
-
 		rai := ra.NewRegistrationAuthorityImpl(auditlogger)
-		rai.VA = &vac
-		rai.CA = &cac
-		rai.SA = &sac
 
-		ras, err := rpc.NewRegistrationAuthorityServer(c.AMQP.RA.Server, ch, &rai)
-		cmd.FailOnError(err, "Unable to create RA server")
-		cmd.RunForever(ras)
+		for true {
+			ch := cmd.AmqpChannel(c.AMQP.Server)
+			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
+
+			vac, err := rpc.NewValidationAuthorityClient(c.AMQP.VA.Client, c.AMQP.VA.Server, ch)
+			cmd.FailOnError(err, "Unable to create VA client")
+
+			cac, err := rpc.NewCertificateAuthorityClient(c.AMQP.CA.Client, c.AMQP.CA.Server, ch)
+			cmd.FailOnError(err, "Unable to create CA client")
+
+			sac, err := rpc.NewStorageAuthorityClient(c.AMQP.SA.Client, c.AMQP.SA.Server, ch)
+			cmd.FailOnError(err, "Unable to create SA client")
+
+			rai.VA = &vac
+			rai.CA = &cac
+			rai.SA = &sac
+
+			ras, err := rpc.NewRegistrationAuthorityServer(c.AMQP.RA.Server, ch, &rai)
+			cmd.FailOnError(err, "Unable to create RA server")
+			
+			forever := make(chan bool)
+			go func() {
+				for true {
+					for err := range closeChan {
+						log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+						time.Sleep(time.Second*10)
+						log.Printf(" [c!] Reconnecting to AMQP...")
+						close(forever)
+						return
+					}
+				}
+			}()
+			cmd.MaybeRunForever(ras, forever)
+		}
+
 	}
 
 	app.Run()

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -48,9 +48,9 @@ func main() {
 			forever := make(chan bool)
 			go func() {
 				for err := range closeChan {
-					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					log.Printf(" [!] AMQP Channel closed: [%s]", err)
 					time.Sleep(time.Second*10)
-					log.Printf(" [c!] Reconnecting to AMQP...")
+					log.Printf(" [!] Reconnecting to AMQP...")
 					close(forever)
 					return
 				}

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -38,9 +38,9 @@ func main() {
 			forever := make(chan bool)
 			go func() {
 				for err := range closeChan {
-					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					log.Printf(" [!] AMQP Channel closed: [%s]", err)
 					time.Sleep(time.Second*10)
-					log.Printf(" [c!] Reconnecting to AMQP...")
+					log.Printf(" [!] Reconnecting to AMQP...")
 					close(forever)
 					return
 				}

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -6,6 +6,11 @@
 package main
 
 import (
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+	"log"
+	"time"
+	"runtime"
+
 	// Load both drivers to allow configuring either
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
@@ -18,17 +23,34 @@ import (
 func main() {
 	app := cmd.NewAppShell("boulder-sa")
 	app.Action = func(c cmd.Config) {
-		ch := cmd.AmqpChannel(c.AMQP.Server)
-
 		// Set up logging
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag)
+		logger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
-		sai, err := sa.NewSQLStorageAuthority(auditlogger, c.SA.DBDriver, c.SA.DBName)
+		sai, err := sa.NewSQLStorageAuthority(logger, c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Failed to create SA impl")
 
-		sas := rpc.NewStorageAuthorityServer(c.AMQP.SA.Server, ch, sai)
-		cmd.RunForever(sas)
+		for true {
+			log.Printf("num routines: %d", runtime.NumGoroutine())
+			ch := cmd.AmqpChannel(c.AMQP.Server)
+			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
+
+			sas := rpc.NewStorageAuthorityServer(c.AMQP.SA.Server, ch, sai)
+
+			forever := make(chan bool)
+			go func() {
+				for true {
+					for err := range closeChan {
+						log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+						time.Sleep(time.Second*10)
+						log.Printf(" [c!] Reconnecting to AMQP...")
+						close(forever)
+						return
+					}
+				}
+			}()
+			cmd.MaybeRunForever(sas, forever)
+		}
 	}
 
 	app.Run()

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
 	"log"
 	"time"
-	"runtime"
 
 	// Load both drivers to allow configuring either
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
@@ -31,7 +30,6 @@ func main() {
 		cmd.FailOnError(err, "Failed to create SA impl")
 
 		for true {
-			log.Printf("num routines: %d", runtime.NumGoroutine())
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -27,7 +27,7 @@ func main() {
 		sai, err := sa.NewSQLStorageAuthority(auditlogger, c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Failed to create SA impl")
 
-		for true {
+		for {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -39,14 +39,12 @@ func main() {
 
 			forever := make(chan bool)
 			go func() {
-				for true {
-					for err := range closeChan {
-						log.Printf(" [c!] AMQP Channel closed: [%s]", err)
-						time.Sleep(time.Second*10)
-						log.Printf(" [c!] Reconnecting to AMQP...")
-						close(forever)
-						return
-					}
+				for err := range closeChan {
+					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					time.Sleep(time.Second*10)
+					log.Printf(" [c!] Reconnecting to AMQP...")
+					close(forever)
+					return
 				}
 			}()
 			cmd.MaybeRunForever(sas, forever)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -7,8 +7,6 @@ package main
 
 import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
-	"log"
-	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
@@ -37,17 +35,7 @@ func main() {
 			vas, err := rpc.NewValidationAuthorityServer(c.AMQP.VA.Server, ch, &vai)
 			cmd.FailOnError(err, "Unable to create VA server")
 
-			forever := make(chan bool)
-			go func() {
-				for err := range closeChan {
-					log.Printf(" [!] AMQP Channel closed: [%s]", err)
-					time.Sleep(time.Second*10)
-					log.Printf(" [!] Reconnecting to AMQP...")
-					close(forever)
-					return
-				}
-			}()
-			cmd.MaybeRunForever(vas, forever)
+			cmd.RunUntilSignaled(auditlogger, vas, closeChan)
 		}
 	}
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -39,14 +39,12 @@ func main() {
 
 			forever := make(chan bool)
 			go func() {
-				for true {
-					for err := range closeChan {
-						log.Printf(" [c!] AMQP Channel closed: [%s]", err)
-						time.Sleep(time.Second*10)
-						log.Printf(" [c!] Reconnecting to AMQP...")
-						close(forever)
-						return
-					}
+				for err := range closeChan {
+					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					time.Sleep(time.Second*10)
+					log.Printf(" [c!] Reconnecting to AMQP...")
+					close(forever)
+					return
 				}
 			}()
 			cmd.MaybeRunForever(vas, forever)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -23,7 +23,7 @@ func main() {
 
 		vai := va.NewValidationAuthorityImpl(auditlogger, c.CA.TestMode)
 
-		for true {
+		for {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -40,9 +40,9 @@ func main() {
 			forever := make(chan bool)
 			go func() {
 				for err := range closeChan {
-					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					log.Printf(" [!] AMQP Channel closed: [%s]", err)
 					time.Sleep(time.Second*10)
-					log.Printf(" [c!] Reconnecting to AMQP...")
+					log.Printf(" [!] Reconnecting to AMQP...")
 					close(forever)
 					return
 				}

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -50,12 +50,12 @@ func main() {
 			// with new RA and SA rpc clients.
 			for true {
 				for err := range closeChan {
-					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					log.Printf(" [!] AMQP Channel closed: [%s]", err)
 					time.Sleep(time.Second*10)
 					rac, sac, closeChan = setupWFE(c, auditlogger)
 					wfe.RA = &rac
 					wfe.SA = &sac
-					log.Printf(" [c!] Reconnected to AMQP")
+					log.Printf(" [!] Reconnected to AMQP")
 				}
 			}
 		}()

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
 	"log"
 	"time"
-	// "runtime"
 
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -9,31 +9,57 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+	"log"
+	"time"
+	// "runtime"
+
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
 	"github.com/letsencrypt/boulder/wfe"
 )
 
+func setupWFE(c cmd.Config, auditlogger *blog.AuditLogger) (rpc.RegistrationAuthorityClient, rpc.StorageAuthorityClient, chan *amqp.Error) {
+	ch := cmd.AmqpChannel(c.AMQP.Server)
+	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
+
+	rac, err := rpc.NewRegistrationAuthorityClient(c.AMQP.RA.Client, c.AMQP.RA.Server, ch)
+	cmd.FailOnError(err, "Unable to create RA client")
+
+	sac, err := rpc.NewStorageAuthorityClient(c.AMQP.SA.Client, c.AMQP.SA.Server, ch)
+	cmd.FailOnError(err, "Unable to create SA client")
+
+	return rac, sac, closeChan
+}
+
 func main() {
 	app := cmd.NewAppShell("boulder-wfe")
 	app.Action = func(c cmd.Config) {
-		ch := cmd.AmqpChannel(c.AMQP.Server)
-
 		// Set up logging
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
-		rac, err := rpc.NewRegistrationAuthorityClient(c.AMQP.RA.Client, c.AMQP.RA.Server, ch)
-		cmd.FailOnError(err, "Unable to create RA client")
-
-		sac, err := rpc.NewStorageAuthorityClient(c.AMQP.SA.Client, c.AMQP.SA.Server, ch)
-		cmd.FailOnError(err, "Unable to create SA client")
-
-		// Create the front-end and wire in its resources
 		wfe := wfe.NewWebFrontEndImpl(auditlogger)
+		rac, sac, closeChan := setupWFE(c, auditlogger)
 		wfe.RA = &rac
 		wfe.SA = &sac
+
+		go func() {
+			// sit around and reconnect to AMQP if the channel
+			// drops for some reason and repopulate the wfe object
+			// with new RA and SA rpc clients.
+			for true {
+				for err := range closeChan {
+					log.Printf(" [c!] AMQP Channel closed: [%s]", err)
+					time.Sleep(time.Second*10)
+					rac, sac, closeChan = setupWFE(c, auditlogger)
+					wfe.RA = &rac
+					wfe.SA = &sac
+					log.Printf(" [c!] Reconnected to AMQP")
+				}
+			}
+		}()
 
 		// Go!
 		newRegPath := "/acme/new-reg"

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -47,7 +47,7 @@ func main() {
 			// sit around and reconnect to AMQP if the channel
 			// drops for some reason and repopulate the wfe object
 			// with new RA and SA rpc clients.
-			for true {
+			for {
 				for err := range closeChan {
 					auditlogger.Warning(fmt.Sprintf("AMQP Channel closed, will reconnect in 5 seconds: [%s]", err))
 					time.Sleep(time.Second*5)

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
-	"log"
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
@@ -50,12 +49,12 @@ func main() {
 			// with new RA and SA rpc clients.
 			for true {
 				for err := range closeChan {
-					log.Printf(" [!] AMQP Channel closed: [%s]", err)
-					time.Sleep(time.Second*10)
+					auditlogger.Warning(fmt.Sprintf("AMQP Channel closed, will reconnect in 5 seconds: [%s]", err))
+					time.Sleep(time.Second*5)
 					rac, sac, closeChan = setupWFE(c, auditlogger)
 					wfe.RA = &rac
 					wfe.SA = &sac
-					log.Printf(" [!] Reconnected to AMQP")
+					auditlogger.Warning("Reconnected to AMQP")
 				}
 			}
 		}()

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -141,3 +141,10 @@ func RunForever(server *rpc.AmqpRPCServer) {
 	fmt.Fprintf(os.Stderr, "Server running...\n")
 	<-forever
 }
+
+// Start the server and maybe wait around forever...
+func MaybeRunForever(server *rpc.AmqpRPCServer, forever chan bool) {
+	server.Start()
+	fmt.Fprintf(os.Stderr, "Server running...\n")
+	<-forever
+}


### PR DESCRIPTION
Fix for #22 where individual clients hang on a broken AMQP connection/channel when it gets closed and just sit there not doing anything.

Using [`Channel.NotifyClose`](http://godoc.org/github.com/streadway/amqp#Channel.NotifyClose) we start a goroutine to sit and watch the channel for it to close, then reopen a new channel and (dependent on WFE vs. everything else) rewire/restart the RPC clients/servers that rely on the watched channel and then restart the channel watching all over again.

Clients that previously used `RunForever` (i.e. everything except `boulder-wfe`) have been replaced with `MaybeRunForever` which takes the `forever` channel as an argument instead of creating it itself so that we can close it in a goroutine when the previous channel closes and we want to start a new (rewired) version of the RPC server. This way each time the AMQP server restarts the previous goroutine should finish when the channel is closed, instead of accumulating a bunch of blocked goroutines each time the server restarts.

A current problem is that this is currently just using a 10 second sleep period (using `time.Sleep`) to wait for the server to come back up but if it crashed during the restart, or ended up taking longer than 10 seconds the `cmd.AmqpChannel` method will fail since it wont be able to contact the server. This could be fixed by creating a similar connection method which instead of failing on errors sits and discards errors until it gets a connection (perhaps for a set amount of time/tries) so then we wouldn't need a hard coded *sleep until the server is probably up* timer that could fail....

@jcjones thoughts?
