### PR TITLE
Fix JWK thumbprint computation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER J.C. Jones "jjones@letsencrypt.org"
 EXPOSE 4000
 
 # Assume the configuration is in /etc/boulder
-ENV BOULDER_CONFIG=/boulder/config.json
+ENV BOULDER_CONFIG /go/src/github.com/letsencrypt/boulder/test/example-config.json
 
 # Copy in the Boulder sources
 RUN mkdir -p /go/src/github.com/letsencrypt/boulder

--- a/jose/jwk.go
+++ b/jose/jwk.go
@@ -12,6 +12,8 @@ import (
 
 type rawJsonWebKey struct {
 	// Only public key fields, since we only require verification
+	// Keep lexicographic order here so MarshalJSON outputs in the
+	// same lexicographic order!
 	Crv string     `json:"crv,omitempty"` // XXX Use an enum
 	E   JsonBuffer `json:"e,omitempty"`
 	Kty string     `json:"kty,omitempty"` // XXX Use an enum

--- a/jose/jwk.go
+++ b/jose/jwk.go
@@ -30,9 +30,7 @@ type JsonWebKey struct {
 }
 
 func (jwk *JsonWebKey) ComputeThumbprint() {
-	var jsonThumbprint []byte
-	var err error
-	jsonThumbprint, err = jwk.MarshalJSON()
+	jsonThumbprint, err := jwk.MarshalJSON()
 	if err != nil {
 		return
 	}

--- a/jose/jwk_test.go
+++ b/jose/jwk_test.go
@@ -119,3 +119,28 @@ func TestEcJwk(t *testing.T) {
 		return
 	}
 }
+
+func TestRsaThumbprint(t *testing.T) {
+	// Based on test values and results provided in  https://tools.ietf.org/html/draft-jones-jose-jwk-thumbprint-01
+	// section 3.1.
+	in := `{
+		"kty": "RSA",
+		"n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+		"e": "AQAB",
+		"alg": "RS256",
+		"kid": "2011-04-29"
+	}`
+
+	var testJWK JsonWebKey
+	err := json.Unmarshal([]byte(in), &testJWK)
+	if err != nil {
+		t.Errorf("JSON unmarshal error: %+v", err)
+		return
+	}
+
+	testJWK.ComputeThumbprint()
+
+	if testJWK.Thumbprint != "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs" {
+		t.Errorf("Thumbprint doesn't match: %s", testJWK.Thumbprint)
+	}
+}


### PR DESCRIPTION
Fixes the `ComputeThumbprint` function (#74)  in `jose/jwk.go` and adds a test using the supplied JWK object and resulting thumbprint from https://tools.ietf.org/html/draft-jones-jose-jwk-thumbprint-01#section-3.1 for RSA, I haven't added one for ECDSA yet.