### PR TITLE
Add empty tests where missing.

### DIFF
--- a/core/util_test.go
+++ b/core/util_test.go
@@ -1,0 +1,8 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package core
+
+// challenges.go

--- a/policy/blacklist_test.go
+++ b/policy/blacklist_test.go
@@ -1,0 +1,6 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package policy

--- a/policy/psl_test.go
+++ b/policy/psl_test.go
@@ -1,0 +1,6 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package policy

--- a/rpc/amqp-rpc_test.go
+++ b/rpc/amqp-rpc_test.go
@@ -1,0 +1,6 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package rpc

--- a/rpc/rpc-wrappers_test.go
+++ b/rpc/rpc-wrappers_test.go
@@ -1,0 +1,6 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package rpc

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -1,0 +1,6 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sa

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -1,0 +1,6 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package va


### PR DESCRIPTION
This will bring our coverage numbers down to a more meaningful number, and will
mean that we can start aiming to increase them monotonically.