### PR TITLE
Fix Z computation (Dvsni challenge)

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -93,11 +93,8 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 	}
 	RS := append(R, S...)
 
-	sha := sha256.New()
-	_, _ = sha.Write(RS) // Never returns an error
-	z := make([]byte, sha.Size())
-	sha.Sum(z)
-	zName := hex.EncodeToString(z)
+	z := sha256.Sum256(RS)
+	zName := fmt.Sprintf("%x.acme.invalid", z)
 
 	// Make a connection with SNI = nonceName
 

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"net/http"


### PR DESCRIPTION
The `va` doesn't correctly create the variable `zName` that is used to compare with client provided SANs.  The current use of `sha256` results in `zName = 0000000000000000000000000000000000000000000000000000000000000000` (it also doesn't append the `.acme.invalid` suffix).

This very very simply switches out the previous `sha256` hash computation with `sha256.Sum256(RS)` and appends the ACME suffix using `fmt.Sprintf`.

[Playground example of bug](https://play.golang.org/p/Wa8QiveU44)