### PR TITLE
Constant-time compare zName.

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -124,7 +124,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 		return
 	}
 	for _, name := range certs[0].DNSNames {
-		if name == zName {
+		if subtle.ConstantTimeCompare([]byte(name), []byte(zName)) == 1 {
 			challenge.Status = core.StatusValid
 			return
 		}


### PR DESCRIPTION
Fixes https://github.com/letsencrypt/boulder/issues/52.

Note that this is probably not a vulnerability, since the value of zName is not
a secret from the subscriber. But better to eliminate this code smell.

cc @diracdeltas for code review.