### PR TITLE
Add missing return in WFE

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -134,6 +134,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 		sendError(response,
 			fmt.Sprintf("Error creating new registration: %+v", err),
 			http.StatusInternalServerError)
+		return
 	}
 
 	regURL := wfe.RegBase + string(reg.ID)


### PR DESCRIPTION
The error catch for `wfe.RA.NewRegistration` was missing a `return` resulting in multiple `response.WriteHeader` calls, this just adds the necessary `return`.