### PR TITLE
Certificate query by serial

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -166,12 +166,11 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 	}
 
 	// Store the cert with the certificate authority, if provided
-	digest, err := ca.SA.AddCertificate(certDER)
+	_, err = ca.SA.AddCertificate(certDER)
 	if err != nil {
 		ca.DB.Rollback()
 		return
 	}
-	cert.ID = digest // TODO: Remove
 
 	ca.DB.Commit()
 	return

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -352,8 +353,10 @@ func TestIssueCertificate(t *testing.T) {
 		}
 
 		// Verify that the cert got stored in the DB
-		_, err = sa.GetCertificate(certObj.ID)
-		test.AssertNotError(t, err, "Certificate not found in database")
+		shortSerial := fmt.Sprintf("%x", cert.SerialNumber)[0:16]
+		_, err = sa.GetCertificate(shortSerial)
+		test.AssertNotError(t, err,
+			fmt.Sprintf("Certificate %x not found in database", shortSerial))
 	}
 
 	// Test that the CA rejects CSRs with no names

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -99,13 +99,6 @@ func main() {
 
 		// Set up paths
 		wfe.BaseURL = c.WFE.BaseURL
-		wfe.NewRegPath = "/acme/new-reg"
-		wfe.RegPath = "/acme/reg/"
-		wfe.NewAuthzPath = "/acme/new-authz"
-		wfe.AuthzPath = "/acme/authz/"
-		wfe.NewCertPath = "/acme/new-cert"
-		wfe.CertPath = "/acme/cert/"
-		wfe.TermsPath = "/terms"
 		wfe.HandlePaths()
 
 		// Add HandlerTimer to output resp time + success/failure stats to statsd

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -97,32 +97,16 @@ func main() {
 			}
 		}()
 
-		// Go!
-		newRegPath := "/acme/new-reg"
-		regPath := "/acme/reg/"
-		newAuthzPath := "/acme/new-authz"
-		authzPath := "/acme/authz/"
-		newCertPath := "/acme/new-cert"
-		certPath := "/acme/cert/"
-		wfe.NewReg = c.WFE.BaseURL + newRegPath
-		wfe.RegBase = c.WFE.BaseURL + regPath
-		wfe.NewAuthz = c.WFE.BaseURL + newAuthzPath
-		wfe.AuthzBase = c.WFE.BaseURL + authzPath
-		wfe.NewCert = c.WFE.BaseURL + newCertPath
-		wfe.CertBase = c.WFE.BaseURL + certPath
-		http.HandleFunc(newRegPath, wfe.NewRegistration)
-		http.HandleFunc(newAuthzPath, wfe.NewAuthorization)
-		http.HandleFunc(newCertPath, wfe.NewCertificate)
-		http.HandleFunc(regPath, wfe.Registration)
-		http.HandleFunc(authzPath, wfe.Authorization)
-		http.HandleFunc(certPath, wfe.Certificate)
-
-		// Add a simple ToS
-		termsPath := "/terms"
-		http.HandleFunc(termsPath, func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "You agree to do the right thing")
-		})
-		wfe.SubscriberAgreementURL = c.WFE.BaseURL + termsPath
+		// Set up paths
+		wfe.BaseURL = c.WFE.BaseURL
+		wfe.NewRegPath = "/acme/new-reg"
+		wfe.RegPath = "/acme/reg/"
+		wfe.NewAuthzPath = "/acme/new-authz"
+		wfe.AuthzPath = "/acme/authz/"
+		wfe.NewCertPath = "/acme/new-cert"
+		wfe.CertPath = "/acme/cert/"
+		wfe.TermsPath = "/terms"
+		wfe.HandlePaths()
 
 		// Add HandlerTimer to output resp time + success/failure stats to statsd
 		err = http.ListenAndServe(c.WFE.ListenAddress, HandlerTimer(http.DefaultServeMux, stats))

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -95,13 +95,6 @@ func main() {
 
 		// Set up paths
 		wfe.BaseURL = c.WFE.BaseURL
-		wfe.NewRegPath = "/acme/new-reg"
-		wfe.RegPath = "/acme/reg/"
-		wfe.NewAuthzPath = "/acme/new-authz"
-		wfe.AuthzPath = "/acme/authz/"
-		wfe.NewCertPath = "/acme/new-cert"
-		wfe.CertPath = "/acme/cert/"
-		wfe.TermsPath = "/terms"
 		wfe.HandlePaths()
 
 		// We need to tell the RA how to make challenge URIs

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -93,32 +93,16 @@ func main() {
 		va.RA = &ra
 		ca.SA = sa
 
-		// Go!
-		newRegPath := "/acme/new-reg"
-		regPath := "/acme/reg/"
-		newAuthzPath := "/acme/new-authz"
-		authzPath := "/acme/authz/"
-		newCertPath := "/acme/new-cert"
-		certPath := "/acme/cert/"
-		wfe.NewReg = c.WFE.BaseURL + newRegPath
-		wfe.RegBase = c.WFE.BaseURL + regPath
-		wfe.NewAuthz = c.WFE.BaseURL + newAuthzPath
-		wfe.AuthzBase = c.WFE.BaseURL + authzPath
-		wfe.NewCert = c.WFE.BaseURL + newCertPath
-		wfe.CertBase = c.WFE.BaseURL + certPath
-		http.HandleFunc(newRegPath, wfe.NewRegistration)
-		http.HandleFunc(newAuthzPath, wfe.NewAuthorization)
-		http.HandleFunc(newCertPath, wfe.NewCertificate)
-		http.HandleFunc(regPath, wfe.Registration)
-		http.HandleFunc(authzPath, wfe.Authorization)
-		http.HandleFunc(certPath, wfe.Certificate)
-
-		// Add a simple ToS
-		termsPath := "/terms"
-		http.HandleFunc(termsPath, func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "You agree to do the right thing")
-		})
-		wfe.SubscriberAgreementURL = c.WFE.BaseURL + termsPath
+		// Set up paths
+		wfe.BaseURL = c.WFE.BaseURL
+		wfe.NewRegPath = "/acme/new-reg"
+		wfe.RegPath = "/acme/reg/"
+		wfe.NewAuthzPath = "/acme/new-authz"
+		wfe.AuthzPath = "/acme/authz/"
+		wfe.NewCertPath = "/acme/new-cert"
+		wfe.CertPath = "/acme/cert/"
+		wfe.TermsPath = "/terms"
+		wfe.HandlePaths()
 
 		// We need to tell the RA how to make challenge URIs
 		// XXX: Better way to do this?  Part of improved configuration

--- a/core/objects.go
+++ b/core/objects.go
@@ -203,10 +203,6 @@ type Authorization struct {
 // Certificate objects are entirely internal to the server.  The only
 // thing exposed on the wire is the certificate itself.
 type Certificate struct {
-	// An identifier for this authorization, unique across
-	// authorizations and certificates within this instance.
-	ID string
-
 	// The encoded, signed certificate
 	DER jose.JsonBuffer
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -207,8 +207,11 @@ type Certificate struct {
 	// authorizations and certificates within this instance.
 	ID string
 
-	// The certificate itself
+	// The encoded, signed certificate
 	DER jose.JsonBuffer
+
+	// The parsed version of DER. Useful for extracting things like serial number.
+	ParsedCertificate *x509.Certificate
 
 	// The revocation status of the certificate.
 	// * "valid" - not revoked

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -142,7 +142,10 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 
 	// Create the certificate
 	ra.log.Audit(fmt.Sprintf("Issuing certificate for %s", names))
-	cert, err = ra.CA.IssueCertificate(*csr)
+	if cert, err = ra.CA.IssueCertificate(*csr); err != nil {
+		return
+	}
+	cert.ParsedCertificate, err = x509.ParseCertificate([]byte(cert.DER))
 	return
 }
 

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -241,9 +242,12 @@ func TestNewCertificate(t *testing.T) {
 
 	cert, err := ra.NewCertificate(certRequest, AccountKey)
 	test.AssertNotError(t, err, "Failed to issue certificate")
+	parsedCert, err := x509.ParseCertificate(cert.DER)
+	test.AssertNotError(t, err, "Failed to parse certificate")
+	shortSerial := fmt.Sprintf("%x", parsedCert.SerialNumber)[0:16]
 
 	// Verify that cert shows up and is as expected
-	dbCert, err := sa.GetCertificate(cert.ID)
+	dbCert, err := sa.GetCertificate(shortSerial)
 	test.AssertNotError(t, err, "Could not fetch certificate from database")
 	test.Assert(t, bytes.Compare(cert.DER, dbCert) == 0, "Certificates differ")
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -177,8 +177,8 @@ func (ssa *SQLStorageAuthority) GetCertificate(id string) (cert []byte, err erro
 		err = errors.New("Invalid certificate serial " + id)
 	}
 	err = ssa.db.QueryRow(
-		"SELECT value FROM certificates WHERE serial > ? LIMIT 1;",
-		id).Scan(&cert)
+		"SELECT value FROM certificates WHERE serial LIKE ? LIMIT 1;",
+		id + "%").Scan(&cert)
 	return
 }
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -7,6 +7,7 @@ package sa
 
 import (
 	"crypto/sha256"
+	"crypto/x509"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -76,7 +77,7 @@ func (ssa *SQLStorageAuthority) InitTables() (err error) {
 	}
 
 	// Create certificates table
-	_, err = tx.Exec("CREATE TABLE certificates (sequence INTEGER, digest TEXT, value BLOB);")
+	_, err = tx.Exec("CREATE TABLE certificates (serial string, digest TEXT, value BLOB);")
 	if err != nil {
 		tx.Rollback()
 		return
@@ -164,8 +165,20 @@ func (ssa *SQLStorageAuthority) GetAuthorization(id string) (authz core.Authoriz
 	return
 }
 
+// GetCertificate takes an id consisting of the first, sequential half of a
+// serial number and returns the first certificate whose full serial number is
+// lexically greater than that id. This allows clients to query on the known
+// sequential half of our serial numbers to enumerate all certificates.
+// TODO: Add index on certificates table
+// TODO: Implement error when there are multiple certificates with the same
+// sequential half.
 func (ssa *SQLStorageAuthority) GetCertificate(id string) (cert []byte, err error) {
-	err = ssa.db.QueryRow("SELECT value FROM certificates WHERE digest = ?;", id).Scan(&cert)
+	if len(id) != 16 {
+		err = errors.New("Invalid certificate serial " + id)
+	}
+	err = ssa.db.QueryRow(
+		"SELECT value FROM certificates WHERE serial > ? LIMIT 1;",
+		id).Scan(&cert)
 	return
 }
 
@@ -349,28 +362,22 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization(authz core.Authorization) 
 	return
 }
 
-func (ssa *SQLStorageAuthority) AddCertificate(cert []byte) (id string, err error) {
+func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte) (digest string, err error) {
+	var parsedCertificate *x509.Certificate
+	parsedCertificate, err = x509.ParseCertificate(certDER)
+	if err != nil {
+		return
+	}
+	serial := fmt.Sprintf("%x", parsedCertificate.SerialNumber)
+
 	tx, err := ssa.db.Begin()
 	if err != nil {
 		return
 	}
 
-	// Manually set the index, to avoid AUTOINCREMENT issues
-	var sequence int64
-	var scanTarget sql.NullInt64
-	err = tx.QueryRow("SELECT max(sequence) FROM certificates;").Scan(&scanTarget)
-	switch {
-	case !scanTarget.Valid:
-		sequence = 0
-	case err != nil:
-		tx.Rollback()
-		return
-	default:
-		sequence += scanTarget.Int64 + 1
-	}
-
-	id = core.Fingerprint256(cert)
-	_, err = tx.Exec("INSERT INTO certificates (sequence, digest, value) VALUES (?,?,?);", sequence, id, cert)
+	digest = core.Fingerprint256(certDER)
+	_, err = tx.Exec("INSERT INTO certificates (serial, digest, value) VALUES (?,?,?);",
+		serial, digest, certDER)
 	if err != nil {
 		tx.Rollback()
 		return

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -417,7 +417,6 @@ function downloadCertificate(resp) {
 
     cli.spinner("Requesting certificate ... done", true);
     console.log();
-    console.log(resp.headers['location']);
     var certB64 = util.b64enc(body);
 
     state.certificate = certB64;

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -195,6 +195,7 @@ function getTerms(resp) {
 
   if (state.termsRequired) {
     state.termsURL = links["terms-of-service"];
+    console.log(state.termsURL);
     http.get(state.termsURL, getAgreement)
   } else {
     inquirer.prompt(questions.domain, getChallenges);
@@ -416,6 +417,7 @@ function downloadCertificate(resp) {
 
     cli.spinner("Requesting certificate ... done", true);
     console.log();
+    console.log(resp.headers['location']);
     var certB64 = util.b64enc(body);
 
     state.certificate = certB64;

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 
@@ -28,19 +29,42 @@ type WebFrontEndImpl struct {
 	log   *blog.AuditLogger
 
 	// URL configuration parameters
+	BaseURL   string
 	NewReg    string
+	NewRegPath    string
 	RegBase   string
+	RegPath   string
 	NewAuthz  string
+	NewAuthzPath  string
 	AuthzBase string
+	AuthzPath string
 	NewCert   string
+	NewCertPath   string
 	CertBase  string
-
-	SubscriberAgreementURL string
+	CertPath  string
+	TermsPath  string
 }
 
 func NewWebFrontEndImpl(logger *blog.AuditLogger) WebFrontEndImpl {
 	logger.Notice("Web Front End Starting")
 	return WebFrontEndImpl{log: logger}
+}
+
+func (wfe *WebFrontEndImpl) HandlePaths() {
+	wfe.NewReg = wfe.BaseURL + wfe.NewRegPath
+	wfe.RegBase = wfe.BaseURL + wfe.RegPath
+	wfe.NewAuthz = wfe.BaseURL + wfe.NewAuthzPath
+	wfe.AuthzBase = wfe.BaseURL + wfe.AuthzPath
+	wfe.NewCert = wfe.BaseURL + wfe.NewCertPath
+	wfe.CertBase = wfe.BaseURL + wfe.CertPath
+	http.HandleFunc(wfe.NewRegPath, wfe.NewRegistration)
+	http.HandleFunc(wfe.NewAuthzPath, wfe.NewAuthorization)
+	http.HandleFunc(wfe.NewCertPath, wfe.NewCertificate)
+	http.HandleFunc(wfe.RegPath, wfe.Registration)
+	http.HandleFunc(wfe.AuthzPath, wfe.Authorization)
+	http.HandleFunc(wfe.CertPath, wfe.Certificate)
+	http.HandleFunc(wfe.TermsPath, wfe.Terms)
+	fmt.Println("Handled ", wfe.TermsPath)
 }
 
 // Method implementations
@@ -147,8 +171,8 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	response.Header().Add("Location", regURL)
 	response.Header().Set("Content-Type", "application/json")
 	response.Header().Add("Link", link(wfe.NewAuthz, "next"))
-	if len(wfe.SubscriberAgreementURL) > 0 {
-		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
+	if len(wfe.TermsPath) > 0 {
+		response.Header().Add("Link", link(wfe.BaseURL + wfe.TermsPath, "terms-of-service"))
 	}
 
 	response.WriteHeader(http.StatusCreated)
@@ -241,15 +265,15 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 		return
 	}
 
-	// Make a URL for this authz
-	certURL := wfe.CertBase + string(cert.ID)
+	// Make a URL for this certificate.
+	// We use only the sequential part of the serial number, because it should
+	// uniquely identify the certificate, and this makes it easy for anybody to
+	// enumerate and mirror our certificates.
+	serial := cert.ParsedCertificate.SerialNumber
+	certURL := fmt.Sprintf("%s%016x", wfe.CertBase, serial.Rsh(serial, 64))
 
-	// TODO The spec says this should 201 over to /cert, not reply with the
-	// certificate at this point... fix will need to land in boulder and client
-	// simultaneously.
 	// TODO The spec says a client should send an Accept: application/pkix-cert
 	// header; either explicitly insist or tolerate
-
 	response.Header().Add("Location", certURL)
 	response.Header().Set("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusCreated)
@@ -428,19 +452,36 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 	}
 }
 
+var allHex = regexp.MustCompile("^[0-9a-f]+$")
+
+func notFound(response http.ResponseWriter) {
+	sendError(response, "Not found", http.StatusNotFound)
+}
+
 func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *http.Request) {
+	path := request.URL.Path
 	switch request.Method {
 	default:
 		sendError(response, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 
 	case "GET":
-		id := parseIDFromPath(request.URL.Path)
-		wfe.log.Notice(fmt.Sprintf("Requested certificate ID %s", id))
+		// Certificate paths consist of the CertBase path, plus exactly sixteen hex
+		// digits.
+		if !strings.HasPrefix(path, wfe.CertPath) {
+			notFound(response)
+			return
+		}
+		serial := path[len(wfe.CertPath):]
+		if len(serial) != 16 || !allHex.Match([]byte(serial)) {
+			notFound(response)
+			return
+		}
+		wfe.log.Notice(fmt.Sprintf("Requested certificate ID %s", serial))
 
-		cert, err := wfe.SA.GetCertificate(id)
+		cert, err := wfe.SA.GetCertificate(serial)
 		if err != nil {
-			sendError(response, "Not found", http.StatusNotFound)
+			notFound(response)
 			return
 		}
 
@@ -458,4 +499,8 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 		// incr revoked cert stat
 		wfe.Stats.Inc("RevokedCertificates", 1, 1.0)
 	}
+}
+
+func (wfe *WebFrontEndImpl) Terms(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "You agree to do the right thing")
 }

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -47,7 +47,16 @@ type WebFrontEndImpl struct {
 
 func NewWebFrontEndImpl(logger *blog.AuditLogger) WebFrontEndImpl {
 	logger.Notice("Web Front End Starting")
-	return WebFrontEndImpl{log: logger}
+	return WebFrontEndImpl{
+		log: logger,
+		NewRegPath:   "/acme/new-reg",
+		RegPath:      "/acme/reg/",
+		NewAuthzPath: "/acme/new-authz",
+		AuthzPath:    "/acme/authz/",
+		NewCertPath:  "/acme/new-cert",
+		CertPath:     "/acme/cert/",
+		TermsPath:    "/terms",
+	}
 }
 
 func (wfe *WebFrontEndImpl) HandlePaths() {
@@ -64,7 +73,6 @@ func (wfe *WebFrontEndImpl) HandlePaths() {
 	http.HandleFunc(wfe.AuthzPath, wfe.Authorization)
 	http.HandleFunc(wfe.CertPath, wfe.Certificate)
 	http.HandleFunc(wfe.TermsPath, wfe.Terms)
-	fmt.Println("Handled ", wfe.TermsPath)
 }
 
 // Method implementations


### PR DESCRIPTION
Updates certificate querying to use the sequential part of the serial number rather than certificate digest.

Incidentally, cleans up WFE initialization to remove duplicate startup code.