### PR TITLE
Move InitTables and have it check for table existence before creation

### DIFF
--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -72,8 +72,7 @@ func main() {
 		wfe := wfe.NewWebFrontEndImpl(auditlogger)
 		sa, err := sa.NewSQLStorageAuthority(auditlogger, c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Unable to create SA")
-		err = sa.InitTables()
-		cmd.FailOnError(err, "Unable to initialize SA")
+
 		ra := ra.NewRegistrationAuthorityImpl(auditlogger)
 		va := va.NewValidationAuthorityImpl(auditlogger, c.CA.TestMode)
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -44,7 +44,7 @@ func NewSQLStorageAuthority(logger *blog.AuditLogger, driver string, name string
 
 	ssa = &SQLStorageAuthority{
 		db:        db,
-		initCheck: name != ":memory:",
+		initCheck: driver != "sqlite3",
 		log:       logger,
 		bucket:    make(map[string]interface{}),
 	}

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -120,7 +120,7 @@ func (ssa *SQLStorageAuthority) InitTables() (err error) {
 
 	// Create certificates table
 	if !certsExists {
-		_, err = tx.Exec("CREATE TABLE certificates (sequence INTEGER, digest TEXT, value BLOB);")
+		_, err = tx.Exec("CREATE TABLE certificates (serial INTEGER, digest TEXT, value BLOB);")
 		if err != nil {
 			tx.Rollback()
 			return

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -42,9 +42,9 @@ func NewSQLStorageAuthority(logger *blog.AuditLogger, driver string, name string
 	}
 
 	ssa = &SQLStorageAuthority{
-		db:        db,
-		log:       logger,
-		bucket:    make(map[string]interface{}),
+		db:     db,
+		log:    logger,
+		bucket: make(map[string]interface{}),
 	}
 
 	err = ssa.InitTables()

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -83,7 +83,7 @@ func (ssa *SQLStorageAuthority) InitTables() (err error) {
 	}
 
 	// Create certificates table
-	_, err = tx.Exec("CREATE TABLE IF NOT EXISTS certificates (serial INTEGER, digest TEXT, value BLOB);")
+	_, err = tx.Exec("CREATE TABLE IF NOT EXISTS certificates (serial STRING, digest TEXT, value BLOB);")
 	if err != nil {
 		tx.Rollback()
 		return


### PR DESCRIPTION
This PR moves `sa.SqlStorageAuthority.InitTables` one usage in `boulder/cmd/boulder` to `sa.NewSQLStorageAuthority` so that both `boulder` (mono) and `boulder-sa` (poly) will create the necessary tables if they don't already exist.

It also alters `InitTables` to add checks for the existence of the tables before creating them using the `information_schema.tables` table. Because this relies on existence of the `information_schema` schema the new checks cannot be used with the `sqlite3` driver since SQLite doesn't support this, to deal with this I've added a basic check in `NewSQLStorageAuthority` and a `bool` field to `SQLStorageAuthority` that indicates if the driver supports the `initCheck`, if it doesn't it will just revert to the previous behavior of always trying to create the tables. Since at the moment the only other driver being used is `mysql` which does support `information_schema` so the check is simply `drive != "sqlite3"`, *but* this should also work with most other drivers/DBs we might want to use/support in the future (Postgres and MariaDB both support `information_schema`).

This consequently also allows restarting the monolithic client with a MySQL DB without having to wipe all the tables in the DB each time.