### PR TITLE
Always use %016x when formatting shortSerial.

### DIFF
--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -353,10 +353,10 @@ func TestIssueCertificate(t *testing.T) {
 		}
 
 		// Verify that the cert got stored in the DB
-		shortSerial := fmt.Sprintf("%x", cert.SerialNumber)[0:16]
+		shortSerial := fmt.Sprintf("%016x", cert.SerialNumber)[0:16]
 		_, err = sa.GetCertificate(shortSerial)
 		test.AssertNotError(t, err,
-			fmt.Sprintf("Certificate %x not found in database", shortSerial))
+			fmt.Sprintf("Certificate %016x not found in database", shortSerial))
 	}
 
 	// Test that the CA rejects CSRs with no names

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -244,7 +244,7 @@ func TestNewCertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	parsedCert, err := x509.ParseCertificate(cert.DER)
 	test.AssertNotError(t, err, "Failed to parse certificate")
-	shortSerial := fmt.Sprintf("%x", parsedCert.SerialNumber)[0:16]
+	shortSerial := fmt.Sprintf("%016x", parsedCert.SerialNumber)[0:16]
 
 	// Verify that cert shows up and is as expected
 	dbCert, err := sa.GetCertificate(shortSerial)

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -374,7 +374,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte) (digest string, e
 	if err != nil {
 		return
 	}
-	serial := fmt.Sprintf("%x", parsedCertificate.SerialNumber)
+	serial := fmt.Sprintf("%016x", parsedCertificate.SerialNumber)
 
 	tx, err := ssa.db.Begin()
 	if err != nil {


### PR DESCRIPTION
cc @rolandshoemaker for code review.