### PR TITLE
Migration tool

### DIFF
--- a/cmd/boulder-migrator/main.go
+++ b/cmd/boulder-migrator/main.go
@@ -4,7 +4,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // For the applied DATETIME field to work properly with MySQL the DSN parameter
-// "parseTime=true" is required (e.g. "user:pass@tcp(localhost:3306)/boulder?parseTime=true").
+// "parseTime=true" is required (e.g. "user:pass@tcp(localhost:3306)/boulder?parseTime=true")
+// otherwise sql.Row.Scan will throw an error ("[]uint8 -> time.Time is bad" or something).
 
 package main
 

--- a/cmd/boulder-migrator/main.go
+++ b/cmd/boulder-migrator/main.go
@@ -91,21 +91,13 @@ func createMigrationTable(Sql *sql.DB) (err error) {
 	return
 }
 
-type timeSlice []time.Time
-
-// Order most least recent to most
-func (t timeSlice) Len() int {return len(t)}
-func (t timeSlice) Less(i, j int) bool {return t[i].Before(t[j])}
-func (t timeSlice) Swap(i, j int) {t[i], t[j] = t[j], t[i]}
-
-var timestampFormat string = "02-01-06T15:04"
+var timestampFormat string = "20060102-150405"
 
 func orderedMigrationList(migrationDir string) (sortedList []string, err error) {
 	migrationList, err := ioutil.ReadDir(migrationDir)
 	if err != nil {
 		return
 	}
-	var timeList timeSlice
 	for  _, file := range migrationList {
 		if strings.ToLower(filepath.Ext(file.Name())) != ".json" {
 			continue
@@ -113,17 +105,14 @@ func orderedMigrationList(migrationDir string) (sortedList []string, err error) 
 		if file.Name() == "/" {
 			continue
 		}
-		var nameTime time.Time
-		nameTime, err = time.Parse(timestampFormat, nameFromFile(file.Name()))
+		migrationName := nameFromFile(file.Name())
+		_, err := time.Parse(timestampFormat, migrationName)
 		if err != nil {
-			return
+			continue
 		}
-		timeList = append(timeList, nameTime)
+		sortedList = append(sortedList, migrationName)
 	}
-	sort.Sort(timeList)
-	for _, ts := range timeList {
-		sortedList = append(sortedList, ts.Format(timestampFormat))
-	}
+	sort.Strings(sortedList)
 	return
 }
 

--- a/cmd/boulder-migrator/main.go
+++ b/cmd/boulder-migrator/main.go
@@ -300,7 +300,7 @@ func revertMigrationTo(Sql *sql.DB, id string, migrationDir string, yes bool) (e
 		fmt.Printf("There are no migrations after ID %s to revert\n", id)
 	}
 	if yes {
-		if answer := getYN(fmt.Sprintf("This will revert %s migrations, would you like to continue", revertCount)); !answer {
+		if answer := getYN(fmt.Sprintf("This will revert %d migrations, would you like to continue", revertCount)); !answer {
 			fmt.Println("Ok, bye!")
 			return
 		}

--- a/cmd/boulder-migrator/main.go
+++ b/cmd/boulder-migrator/main.go
@@ -118,7 +118,7 @@ func listMigrations(Sql *sql.DB) (err error) {
 // apply new migration
 func applyMigration(Sql *sql.DB, migration Migration, yes bool) (err error) {
 	fmt.Printf("[migration %d]\n", migration.Id)
-	fmt.Printf("\tName: %s\n", migration.Desc)
+	fmt.Printf("\tDescription: %s\n", migration.Desc)
 	fmt.Printf("\n\tMigrate SQL:\n")
 	for _, sqlLine := range migration.UpSQL {
 		fmt.Printf("\t%s\n", sqlLine)

--- a/cmd/boulder-migrator/main.go
+++ b/cmd/boulder-migrator/main.go
@@ -1,0 +1,254 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
+	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
+
+	"github.com/letsencrypt/boulder/cmd"
+)
+
+type Migration struct {
+	Id      int
+	Name    string   // Basic explanation?
+	UpSQL   []string
+	DownSQL []string
+}
+
+func createMigrationTable(Sql *sql.DB) (err error) {
+	tx, err := Sql.Begin()
+	if err != nil {
+		return
+	}
+	_, err = tx.Exec("CREATE TABLE IF NOT EXISTS migrations (id INTEGER, name TEXT, applied DATETIME, down TEXT)")
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	err = tx.Commit()
+	return
+}
+
+// list applied migrations
+func listMigrations(Sql *sql.DB) (err error) {
+	rows, err := Sql.Query("SELECT id, name, applied FROM migrations")
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int
+		var name string
+		var applied time.Time
+		if err = rows.Scan(&id, &name, applied); err != nil {
+			return
+		}
+		fmt.Printf("%d: %s [%s]\n", id, name, applied)
+	}
+	return
+}
+
+// apply new migration
+func applyMigration(Sql *sql.DB, migration Migration) (err error) {
+	fmt.Printf("[migration %d]\n", migration.Id)
+	fmt.Printf("\tName: %s\n", migration.Name)
+	fmt.Printf("\tApply SQL:\n")
+	for _, sqlLine := range migration.UpSQL {
+		fmt.Printf("\t%s", sqlLine)
+	}
+	fmt.Printf("\tRevert SQL:\n")
+	for _, sqlLine := range migration.DownSQL {
+		fmt.Printf("\t%s", sqlLine)
+	}
+	fmt.Printf("\nWould you like to apply this migration?\n")
+
+	tx, err := Sql.Begin()
+	if err != nil {
+		return
+	}
+	for _, sqlStmt := range migration.UpSQL {
+		_, err = tx.Exec(sqlStmt)
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+	}
+	for _, sqlStmt := range migration.DownSQL {
+		sqlStmt = strings.TrimRight(sqlStmt, ";")
+	}
+	_, err = tx.Exec("INSERT INTO migrations (id, name, applied, down) VALUES (?, ?, ?, ?)", migration.Id, migration.Name, time.Now(), strings.Join(migration.DownSQL, ";"))
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	err = tx.Commit()
+	fmt.Printf("Migration %d applied\n", migration.Id)
+	return
+}
+
+// revert last migration
+func revertMigration(Sql *sql.DB) (err error) {
+	var id      int
+	var downSql string
+	err = Sql.QueryRow("SELECT id, down FROM migrations ORDER BY id DESC LIMIT 1").Scan(&id, &downSql)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			fmt.Println("No migrations to revert.")
+			err = nil
+		}
+		return
+	}
+	tx, err := Sql.Begin()
+	if err != nil {
+		return
+	}
+	for _, sqlStmt := range strings.Split(";", downSql) {
+		_, err = tx.Exec(sqlStmt)
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+	}
+	_, err = tx.Exec("DELETE FROM migrations WHERE id = ?", id)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	fmt.Printf("Migration %d reverted\n", id)
+	err = tx.Commit()
+	return
+}
+
+// revert to specific migration
+func revertMigrationTo(Sql *sql.DB, id int) (err error) {
+	var revertCount int
+	err = Sql.QueryRow("SELECT count(*) FROM migrations WHERE id > ?", id).Scan(&revertCount)
+	if err != nil {
+		return
+	}
+	if revertCount == 0 {
+		fmt.Printf("Migration [ID: %d] does not exist\n", id)
+	}
+	for i := 0; i < revertCount; i++ {
+		err = revertMigration(Sql)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+var version string = "0.0.1"
+
+func setupDB(c *cli.Context) (db *sql.DB, err error) {
+	configFileName := c.GlobalString("config")
+	configJSON, err := ioutil.ReadFile(configFileName)
+	cmd.FailOnError(err, "Unable to read config file")
+
+	var config cmd.Config
+	err = json.Unmarshal(configJSON, &config)
+	cmd.FailOnError(err, "Failed to read configuration")
+
+	db, err = sql.Open(config.SA.DBDriver, config.SA.DBName)
+	cmd.FailOnError(err, "Failed to connect to SQL database")
+
+	err = createMigrationTable(db)
+	cmd.FailOnError(err, "Failed to create migration table")
+
+	return
+}
+
+func main() {
+	app := cli.NewApp()
+
+	app.Name = "boulder-migrator"
+	app.Version = version
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "config",
+			Value:  "config.json",
+			EnvVar: "BOULDER_CONFIG",
+		},
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name: "list-applied",
+			Usage: "List all currently applied migrations",
+			Action: func(c *cli.Context) {
+				db, err := setupDB(c)
+				if err != nil {
+					cmd.FailOnError(err, "Failed connecting to DB")
+				}
+				err = listMigrations(db)
+				if err != nil {
+					cmd.FailOnError(err, "Listing migrations failed")
+				}
+			},
+		},
+		{
+			Name: "apply",
+			Usage: "Apply a migration from a JSON migration file",
+			Action: func(c *cli.Context) {
+				db, err := setupDB(c)
+				if err != nil {
+					cmd.FailOnError(err, "Failed connecting to DB")
+				}
+				migrationJSON, err := ioutil.ReadFile(c.Args().First())
+				cmd.FailOnError(err, "Unable to read migration file")
+				var migration Migration
+				err = json.Unmarshal(migrationJSON, &migration)
+				cmd.FailOnError(err, "Failed to read migration")
+
+				err = applyMigration(db, migration)
+				cmd.FailOnError(err, "Failed to apply migration")
+			},
+		},
+		{
+			Name: "revert-last",
+			Usage: "Revert the last migration that was applied",
+			Action: func(c *cli.Context) {
+				db, err := setupDB(c)
+				if err != nil {
+					cmd.FailOnError(err, "Failed connecting to DB")
+				}
+				err = revertMigration(db)
+				if err != nil {
+					cmd.FailOnError(err, "Reverting migration failed")
+				}
+			},
+		},
+		{
+			Name: "revert-to",
+			Usage: "Revert to a specific migration specified by its ID",
+			Action: func(c *cli.Context) {
+				db, err := setupDB(c)
+				if err != nil {
+					cmd.FailOnError(err, "Failed connecting to DB")
+				}
+				var id int
+				_, err = fmt.Sscanf(c.Args().First(), "%d", &id)
+				if err != nil {
+					cmd.FailOnError(err, "ID is not an integer")
+				}
+				revertMigrationTo(db, id)
+			},
+		},
+	}
+
+	err := app.Run(os.Args)
+	cmd.FailOnError(err, "Failed to run application")
+}


### PR DESCRIPTION
This adds a basic migration tool (#111) `boulder-migrator` (in `boulder/cmd/boulder-migrator/main.go`) that can be used to apply migrations, revert the last migration, revert to a specific migration, and list currently applied migrations.

The tool uses a SQL table, `migrations` to store information about migrations that have *already* been applied that looks like this

```
id          INTEGER  # A unique identifier 
description TEXT     # A short desc of what the migration does
applied     DATETIME # When the migration was applied
down        TEXT     # The SQL statements required to revert this migration
```

By packaging migrations into a JSON file containing both the migration SQL and the reversion SQL we can easily rollback the last migration, or to an arbitary migration ID, by storing the reversion SQL in the `migrations` table. A basic migration file might look something like this 

```
{
	"id": 1,
	"desc": "set type of base64 fields to CHAR(43)",
	"upSql": [
		"ALTER TABLE registrations MODIFY COLUMN id CHAR(43)",
		"ALTER TABLE registrations MODIFY COLUMN thumbprint CHAR(43)",
		"ALTER TABLE pending_authz MODIFY COLUMN id CHAR(43)",
		"ALTER TABLE authz MODIFY COLUMN id CHAR(43)",
		"ALTER TABLE authz MODIFY COLUMN digest CHAR(43)",
		"ALTER TABLE certificates MODIFY COLUMN digest CHAR(43)"
	],
	"downSql": [
		"ALTER TABLE registrations MODIFY COLUMN id TEXT",
		"ALTER TABLE registrations MODIFY COLUMN thumbprint TEXT",
		"ALTER TABLE pending_authz MODIFY COLUMN id TEXT",
		"ALTER TABLE authz MODIFY COLUMN id TEXT",
		"ALTER TABLE authz MODIFY COLUMN digest TEXT",
		"ALTER TABLE certificates MODIFY COLUMN digest TEXT"
	]
}
```

This file can be applied using the subcommand `apply`

```
$ ./boulder-migrator apply test.json
[migration 1]
	Description: set type of base64 fields to CHAR(43)

	Migrate SQL:
	ALTER TABLE registrations MODIFY COLUMN id CHAR(43)
	ALTER TABLE registrations MODIFY COLUMN thumbprint CHAR(43)
	ALTER TABLE pending_authz MODIFY COLUMN id CHAR(43)
	ALTER TABLE authz MODIFY COLUMN id CHAR(43)
	ALTER TABLE authz MODIFY COLUMN digest CHAR(43)
	ALTER TABLE certificates MODIFY COLUMN digest CHAR(43)

	Revert SQL:
	ALTER TABLE registrations MODIFY COLUMN id TEXT
	ALTER TABLE registrations MODIFY COLUMN thumbprint TEXT
	ALTER TABLE pending_authz MODIFY COLUMN id TEXT
	ALTER TABLE authz MODIFY COLUMN id TEXT
	ALTER TABLE authz MODIFY COLUMN digest TEXT
	ALTER TABLE certificates MODIFY COLUMN digest TEXT


Would you like to apply this migration? [y/n]
# y
Migration 1 applied
```

The applied migrations can be listed using `list-applied`

```
$ ./boulder-migrator list-applied
# Currently applied migrations

1: [2015-04-25 03:35:23 +0000 UTC]
	set type of base64 fields to CHAR(43)

```

and the last migration can be reverted using `revert-last`

```
$ ./boulder-migrator revert-last
Migration 1 reverted
```

etc etc etc.

The help dialog should pretty much explain what is going on...

```
$ ./boulder-migrator help
NAME:
   boulder-migrator - A new cli application

USAGE:
   boulder-migrator [global options] command [command options] [arguments...]

VERSION:
   0.0.1

AUTHOR:
  Author - <unknown@email>

COMMANDS:
   list-applied	List all currently applied migrations
   apply	Apply a migration from a JSON migration file
   revert-last	Revert the last migration that was applied
   revert-to	Revert to a specific migration specified by its ID
   help, h	Shows a list of commands or help for one command
   
GLOBAL OPTIONS:
   --config "config.json"	 [$BOULDER_CONFIG]
   --yes			automatically say yes to all prompts
   --help, -h			show help
   --version, -v		print the version
```

## Side note

One note, which may actually apply to other parts of the `SA` code base, to get `DATETIME` columns to `Scan` to a `time.Time` object when using MySQL the DSN `parseTime=true` needs to be present in the connection URI or `Scan` will throw the error `Scan error on column index 2: unsupported driver -> Scan pair: []uint8 -> *time.Time`.