### PR TITLE
Fix invalid SQL statement

### DIFF
--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -83,7 +83,7 @@ func (ssa *SQLStorageAuthority) InitTables() (err error) {
 	}
 
 	// Create certificates table
-	_, err = tx.Exec("CREATE TABLE IF NOT EXISTS certificates (serial STRING, digest TEXT, value BLOB);")
+	_, err = tx.Exec("CREATE TABLE IF NOT EXISTS certificates (serial TEXT, digest TEXT, value BLOB);")
 	if err != nil {
 		tx.Rollback()
 		return


### PR DESCRIPTION
In #107 I seem to have changed the column type of `certificates.serial` from `TEXT -> INTEGER` then, meaning to revert this, changed it from `INTERGER -> STRING`. Which isn't a valid column datatype (at least in MySQL).

So this PR just fixes that silly error of mine and *properly* reverts the datatype to `TEXT` (this should fix the introduced Travis-CI failures, except on the weird `TestIssueCertificate` issue)