### PR TITLE
MySQL Indexes

### DIFF
--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -153,7 +153,7 @@ const sqlIndexTemplate = `SELECT IF (
     ),
     'SELECT 1;',
     'CREATE UNIQUE INDEX %s ON %s(%s)'
-) INTO @a`
+) INTO @a;`
 
 func (ssa *SQLStorageAuthority) initIndexes() (err error) {
 	indexes := []indexTemplate{
@@ -191,17 +191,17 @@ func (ssa *SQLStorageAuthority) initIndexes() (err error) {
 			tx.Rollback()
 			return
 		}
-		_, err = tx.Exec("PREPARE ind_stmt FROM @a")
+		_, err = tx.Exec("PREPARE ind_stmt FROM @a;")
 		if err != nil {
 			tx.Rollback()
 			return
 		}
-		_, err = tx.Exec("EXECUTE ind_stmt")
+		_, err = tx.Exec("EXECUTE ind_stmt;")
 		if err != nil {
 			tx.Rollback()
 			return
 		}
-		_, err = tx.Exec("DEALLOCATE PREPARE ind_stmt")
+		_, err = tx.Exec("DEALLOCATE PREPARE ind_stmt;")
 		if err != nil {
 			tx.Rollback()
 			return

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -152,7 +152,7 @@ const sqlIndexTemplate = `SELECT IF (
         AND table_name = '%s' AND index_name LIKE '%s'
     ),
     'SELECT 1;',
-    'CREATE INDEX %s ON %s(%s)'
+    'CREATE UNIQUE INDEX %s ON %s(%s)'
 ) INTO @a`
 
 func (ssa *SQLStorageAuthority) initIndexes() (err error) {


### PR DESCRIPTION
A basic solution for #127. Since MySQL doesn't support `CREATE INDEX IF NOT EXISTS` this solution uses a `SELECT IF ( EXISTS ...` statement to only create the indexes if they don't already exist. Because this solution uses the `information_schema` table the `initIndexes` method is only run if the driver is `mysql`. If in the future we decide to support other databases like postgres then the check would make more sense as `driver != "sqlite3"`.

**Note** I *think* I'm right in believing that all the columns I've added indexes for should have unique values so I've made made all `UNIQUE INDEX`, but this may be wrong