### PR TITLE
More steps towards revocation / OCSP support

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -159,19 +159,21 @@ func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string) (err error)
 		return err
 	}
 
+	// Per https://tools.ietf.org/html/rfc5280, CRLReason 0 is "unspecified."
+	// TODO: Add support for specifying reason.
+	reason := 0
+
 	signRequest := ocsp.SignRequest{
 		Certificate: cert,
 		Status: string(core.OCSPStatusRevoked),
-		// Per https://tools.ietf.org/html/rfc5280, CRLReason 0 is "unspecified."
-		// TODO: Add support for specifying reason.
-		Reason: 0,
+		Reason: reason,
 		RevokedAt: time.Now(),
 	}
 	ocspResponse, err := ca.OCSPSigner.Sign(signRequest)
 	if err != nil {
 		return err
 	}
-	err = ca.SA.MarkCertificateRevoked(serial, ocspResponse)
+	err = ca.SA.MarkCertificateRevoked(serial, ocspResponse, reason)
 	return err
 }
 

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -6,10 +6,12 @@
 package ca
 
 import (
+	"crypto"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/letsencrypt/boulder/core"
@@ -17,21 +19,40 @@ import (
 	"github.com/letsencrypt/boulder/policy"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/auth"
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
+	cfsslConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/remote"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/helpers"
 )
+type Config struct {
+	Server       string
+	AuthKey      string
+	Profile      string
+	TestMode     bool
+	DBDriver     string
+	DBName       string
+	SerialPrefix int
+	// A PEM-encoded copy of the issuer certificate.
+	IssuerCert   string
+	// This field is only allowed if TestMode is true, indicating that we are
+	// signing with a local key. In production we will use an HSM and this
+	// IssuerKey must be empty (and TestMode must be false). PEM-encoded private
+	// key used for signing certificates and OCSP responses.
+	IssuerKey    string
+}
 
 // CertificateAuthorityImpl represents a CA that signs certificates, CRLs, and
 // OCSP responses.
 type CertificateAuthorityImpl struct {
-	profile string
-	Signer  signer.Signer
-	SA      core.StorageAuthority
-	PA      core.PolicyAuthority
-	DB      core.CertificateAuthorityDatabase
-	log     *blog.AuditLogger
-	Prefix  int // Prepended to the serial number
+	profile    string
+	Signer     signer.Signer
+	OCSPSigner ocsp.Signer
+	SA         core.StorageAuthority
+	PA         core.PolicyAuthority
+	DB         core.CertificateAuthorityDatabase
+	log        *blog.AuditLogger
+	Prefix     int // Prepended to the serial number
 }
 
 // NewCertificateAuthorityImpl creates a CA that talks to a remote CFSSL
@@ -40,42 +61,118 @@ type CertificateAuthorityImpl struct {
 // using CFSSL's authenticated signature scheme.  A CA created in this way
 // issues for a single profile on the remote signer, which is indicated
 // by name in this constructor.
-func NewCertificateAuthorityImpl(logger *blog.AuditLogger, hostport string, authKey string, profile string, serialPrefix int, cadb core.CertificateAuthorityDatabase) (ca *CertificateAuthorityImpl, err error) {
+func NewCertificateAuthorityImpl(logger *blog.AuditLogger,
+	cadb core.CertificateAuthorityDatabase, config Config) (ca *CertificateAuthorityImpl, err error) {
 	logger.Notice("Certificate Authority Starting")
 
+	if config.SerialPrefix == 0 {
+		err = errors.New("Must have non-zero serial prefix for CA.")
+	}
+
 	// Create the remote signer
-	localProfile := config.SigningProfile{
+	localProfile := cfsslConfig.SigningProfile{
 		Expiry:       time.Hour, // BOGUS: Required by CFSSL, but not used
-		RemoteName:   hostport,  // BOGUS: Only used as a flag by CFSSL
-		RemoteServer: hostport,
+		RemoteName:   config.Server,  // BOGUS: Only used as a flag by CFSSL
+		RemoteServer: config.Server,
 		UseSerialSeq: true,
 	}
 
-	localProfile.Provider, err = auth.New(authKey, nil)
+	localProfile.Provider, err = auth.New(config.AuthKey, nil)
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	signer, err := remote.NewSigner(&config.Signing{Default: &localProfile})
+	signer, err := remote.NewSigner(&cfsslConfig.Signing{Default: &localProfile})
 	if err != nil {
-		return
+		return nil, err
 	}
+
+	issuer, err := loadIssuer(config.IssuerCert)
+	if err != nil {
+		return nil, err
+	}
+
+	// In test mode, load a private key from a file. In production, use an HSM.
+	if !config.TestMode {
+		err = errors.New("OCSP signing with a PKCS#11 key not yet implemented.")
+		return nil, err
+	}
+	issuerKey, err := loadIssuerKey(config.IssuerKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up our OCSP signer. Note this calls for both the issuer cert and the
+	// OCSP signing cert, which are the same in our case.
+	ocspSigner, err := ocsp.NewSigner(issuer, issuer, issuerKey,
+		time.Hour * 24 * 4)
 
 	pa := policy.NewPolicyAuthorityImpl(logger)
 
 	ca = &CertificateAuthorityImpl{
 		Signer:  signer,
-		profile: profile,
+		OCSPSigner: ocspSigner,
+		profile: config.Profile,
 		PA:      pa,
 		DB:      cadb,
-		Prefix:  serialPrefix,
+		Prefix:  config.SerialPrefix,
 		log:     logger,
 	}
+	return ca, err
+}
+
+func loadIssuer(filename string) (issuerCert *x509.Certificate, err error) {
+	if filename == "" {
+		err = errors.New("Issuer certificate was not provided in config.")
+		return
+	}
+	issuerCertPEM, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return
+	}
+	issuerCert, err = helpers.ParseCertificatePEM(issuerCertPEM)
 	return
 }
 
-func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string) (cert core.Certificate, err error) {
+func loadIssuerKey(filename string) (issuerKey crypto.Signer, err error) {
+	if filename == "" {
+		err = errors.New("IssuerKey must be provided in test mode.")
+		return
+	}
+
+	pem, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return
+	}
+	issuerKey, err = helpers.ParsePrivateKeyPEM(pem)
 	return
+}
+
+
+func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string) (err error) {
+	certDER, err := ca.SA.GetCertificate(serial)
+	if err != nil {
+		return err
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return err
+	}
+
+	signRequest := ocsp.SignRequest{
+		Certificate: cert,
+		Status: string(core.OCSPStatusRevoked),
+		// Per https://tools.ietf.org/html/rfc5280, CRLReason 0 is "unspecified."
+		// TODO: Add support for specifying reason.
+		Reason: 0,
+		RevokedAt: time.Now(),
+	}
+	ocspResponse, err := ca.OCSPSigner.Sign(signRequest)
+	if err != nil {
+		return err
+	}
+	err = ca.SA.MarkCertificateRevoked(serial, ocspResponse)
+	return err
 }
 
 // IssueCertificate attempts to convert a CSR into a signed Certificate, while

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -74,6 +74,10 @@ func NewCertificateAuthorityImpl(logger *blog.AuditLogger, hostport string, auth
 	return
 }
 
+func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string) (cert core.Certificate, err error) {
+	return
+}
+
 // IssueCertificate attempts to convert a CSR into a signed Certificate, while
 // enforcing all policies.
 func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest) (cert core.Certificate, err error) {

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -67,6 +67,7 @@ func NewCertificateAuthorityImpl(logger *blog.AuditLogger,
 
 	if config.SerialPrefix == 0 {
 		err = errors.New("Must have non-zero serial prefix for CA.")
+		return
 	}
 
 	// Create the remote signer

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -348,8 +348,7 @@ func TestIssueCertificate(t *testing.T) {
 		}
 
 		// Verify that the cert got stored in the DB
-		shortSerial := fmt.Sprintf("%032x", cert.SerialNumber)[0:16]
-		_, err = sa.GetCertificate(shortSerial)
+		_, err = sa.GetCertificate(fmt.Sprintf("%032x", cert.SerialNumber))
 		test.AssertNotError(t, err,
 			fmt.Sprintf("Certificate %032x not found in database", cert.SerialNumber))
 	}

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -306,7 +306,16 @@ func TestIssueCertificate(t *testing.T) {
 
 	// Create a CA
 	// Uncomment to test with a remote signer
-	ca, err := NewCertificateAuthorityImpl(blog.TestLogger(), hostPort, authKey, profileName, 17, cadb)
+	caConfig := Config{
+		Server: hostPort,
+		AuthKey: authKey,
+		Profile: profileName,
+		SerialPrefix: 17,
+		IssuerCert: "../test/test-ca.pem",
+		IssuerKey: "../test/test-ca.key",
+		TestMode: true,
+	}
+	ca, err := NewCertificateAuthorityImpl(blog.TestLogger(), cadb, caConfig)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = sa
 

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -365,8 +365,8 @@ func TestRevoke(t *testing.T) {
 	status, err := storageAuthority.GetCertificateStatus(serialString)
 	test.AssertNotError(t, err, "Failed to get cert status")
 
-	//test.AssertEquals(t, status.Status, core.OCSPStatusRevoked)
-	test.Assert(t, time.Sub(time.Now(), status.OCSPLastUpdated) > time.Second,
+	test.AssertEquals(t, status.Status, core.OCSPStatusRevoked)
+	test.Assert(t, time.Now().Sub(status.OCSPLastUpdated) > time.Second,
 		fmt.Sprintf("OCSP LastUpdated was wrong: %v", status.OCSPLastUpdated))
 }
 

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -31,7 +31,7 @@ func main() {
 		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(auditlogger, c.CA.DBDriver, c.CA.DBName)
 		cmd.FailOnError(err, "Failed to create CA database")
 
-		cai, err := ca.NewCertificateAuthorityImpl(auditlogger, c.CA.Server, c.CA.AuthKey, c.CA.Profile, c.CA.SerialPrefix, cadb)
+		cai, err := ca.NewCertificateAuthorityImpl(auditlogger, cadb, c.CA)
 		cmd.FailOnError(err, "Failed to create CA impl")
 
 		go cmd.ProfileCmd("CA", stats)

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -79,7 +79,7 @@ func main() {
 		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(auditlogger, c.CA.DBDriver, c.CA.DBName)
 		cmd.FailOnError(err, "Failed to create CA database")
 
-		ca, err := ca.NewCertificateAuthorityImpl(auditlogger, c.CA.Server, c.CA.AuthKey, c.CA.Profile, c.CA.SerialPrefix, cadb)
+		ca, err := ca.NewCertificateAuthorityImpl(auditlogger, cadb, c.CA)
 		cmd.FailOnError(err, "Unable to create CA")
 
 		// Wire them up

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -37,6 +37,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
+	"github.com/letsencrypt/boulder/ca"
 )
 
 // Config stores configuration parameters that applications
@@ -59,15 +60,7 @@ type Config struct {
 		ListenAddress string
 	}
 
-	CA struct {
-		Server       string
-		AuthKey      string
-		Profile      string
-		TestMode     bool
-		DBDriver     string
-		DBName       string
-		SerialPrefix int
-	}
+	CA ca.Config
 
 	SA struct {
 		DBDriver string

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -79,6 +79,7 @@ type ValidationAuthority interface {
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
 	IssueCertificate(x509.CertificateRequest) (Certificate, error)
+	RevokeCertificate(serial string) error
 }
 
 type PolicyAuthority interface {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -100,7 +100,7 @@ type StorageAdder interface {
 	NewPendingAuthorization() (string, error)
 	UpdatePendingAuthorization(Authorization) error
 	FinalizeAuthorization(Authorization) error
-	MarkCertificateRevoked(serial string, ocspResponse []byte) error
+	MarkCertificateRevoked(serial string, ocspResponse []byte, reasonCode int) error
 
 	AddCertificate([]byte) (string, error)
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -100,6 +100,7 @@ type StorageAdder interface {
 	NewPendingAuthorization() (string, error)
 	UpdatePendingAuthorization(Authorization) error
 	FinalizeAuthorization(Authorization) error
+	MarkCertificateRevoked(serial string, ocspResponse []byte) error
 
 	AddCertificate([]byte) (string, error)
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -92,6 +92,7 @@ type StorageGetter interface {
 	GetAuthorization(string) (Authorization, error)
 	GetCertificate(string) ([]byte, error)
 	GetCertificateByShortSerial(string) ([]byte, error)
+	GetCertificateStatus(string) (CertificateStatus, error)
 }
 
 type StorageAdder interface {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -90,6 +90,7 @@ type StorageGetter interface {
 	GetRegistration(string) (Registration, error)
 	GetAuthorization(string) (Authorization, error)
 	GetCertificate(string) ([]byte, error)
+	GetCertificateByShortSerial(string) ([]byte, error)
 }
 
 type StorageAdder interface {

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -244,10 +244,9 @@ func TestNewCertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	parsedCert, err := x509.ParseCertificate(cert.DER)
 	test.AssertNotError(t, err, "Failed to parse certificate")
-	shortSerial := fmt.Sprintf("%032x", parsedCert.SerialNumber)[0:16]
 
 	// Verify that cert shows up and is as expected
-	dbCert, err := sa.GetCertificate(shortSerial)
+	dbCert, err := sa.GetCertificate(fmt.Sprintf("%032x", parsedCert.SerialNumber))
 	test.AssertNotError(t, err, fmt.Sprintf("Could not fetch certificate %032x from database",
 		parsedCert.SerialNumber))
 	test.Assert(t, bytes.Compare(cert.DER, dbCert) == 0, "Certificates differ")

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -44,6 +44,7 @@ const (
 	MethodGetRegistration            = "GetRegistration"            // SA
 	MethodGetAuthorization           = "GetAuthorization"           // SA
 	MethodGetCertificate             = "GetCertificate"             // SA
+	MethodGetCertificateByShortSerial = "GetCertificateByShortSerial" // SA
 	MethodNewPendingAuthorization    = "NewPendingAuthorization"    // SA
 	MethodUpdatePendingAuthorization = "UpdatePendingAuthorization" // SA
 	MethodFinalizeAuthorization      = "FinalizeAuthorization"      // SA
@@ -419,7 +420,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 	rpc = NewAmqpRPCServer(serverQueue, channel)
 
 	rpc.Handle(MethodGetRegistration, func(req []byte) (response []byte) {
-		reg, err := impl.GetCertificate(string(req))
+		reg, err := impl.GetRegistration(string(req))
 		if err != nil {
 			return
 		}
@@ -433,7 +434,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 	})
 
 	rpc.Handle(MethodGetAuthorization, func(req []byte) []byte {
-		authz, err := impl.AddCertificate(req)
+		authz, err := impl.GetAuthorization(string(req))
 		if err != nil {
 			return nil
 		}
@@ -501,6 +502,14 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 		return
 	})
 
+	rpc.Handle(MethodGetCertificateByShortSerial, func(req []byte) (response []byte) {
+		cert, err := impl.GetCertificateByShortSerial(string(req))
+		if err == nil {
+			response = []byte(cert)
+		}
+		return
+	})
+
 	return
 }
 
@@ -550,7 +559,7 @@ func (cac StorageAuthorityClient) UpdateRegistration(reg core.Registration) (err
 	}
 
 	// XXX: Is this catching all the errors?
-	_, err = cac.rpc.DispatchSync(MethodUpdatePendingAuthorization, jsonReg)
+	_, err = cac.rpc.DispatchSync(MethodUpdateRegistration, jsonReg)
 	return
 }
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -67,10 +67,11 @@ func (ssa *SQLStorageAuthority) InitTables() (err error) {
 	statements := []string{
 
 	// Create registrations table
+	// TODO: Add NOT NULL to thumbprint and value.
 	`CREATE TABLE IF NOT EXISTS registrations (
 		id VARCHAR(255) NOT NULL,
-		thumbprint VARCHAR(255) NOT NULL,
-		value BLOB NOT NULL
+		thumbprint VARCHAR(255),
+		value BLOB
 	);`,
 
 	// Create pending authorizations table

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -350,7 +350,7 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(serial string, ocspRespon
 
 	_, err = tx.Exec(`UPDATE certificateStatus SET
 		status=?, revokedDate=?, revokedReason=? WHERE serial=?`,
-		string(core.OCSPStatusRevoked), time.Now(), reasonCode)
+		string(core.OCSPStatusRevoked), time.Now(), reasonCode, serial)
 	if err != nil {
 		tx.Rollback()
 		return

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -16,8 +16,12 @@ import (
 
 func TestAddCertificate(t *testing.T) {
 	sa, err := NewSQLStorageAuthority(blog.TestLogger(), "sqlite3", ":memory:")
-	test.AssertNotError(t, err, "Failed to create SA")
-	sa.InitTables()
+	if err != nil {
+		t.Fatalf("Failed to create SA")
+	}
+	if err = sa.InitTables(); err != nil {
+		t.Fatalf("Failed to create SA")
+	}
 
 	// An example cert taken from EFF's website
 	certDER, err := ioutil.ReadFile("www.eff.org.der")

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -28,8 +28,12 @@ func TestAddCertificate(t *testing.T) {
 	test.AssertEquals(t, digest, "qWoItDZmR4P9eFbeYgXXP3SR4ApnkQj8x4LsB_ORKBo")
 
 	// Example cert serial is 0x21bd4, so a prefix of all zeroes should fetch it.
-	retrievedDER, err := sa.GetCertificate("0000000000000000")
-	test.AssertNotError(t, err, "Couldn't get www.eff.org.der")
+	retrievedDER, err := sa.GetCertificateByShortSerial("0000000000000000")
+	test.AssertNotError(t, err, "Couldn't get www.eff.org.der by short serial")
+	test.AssertByteEquals(t, certDER, retrievedDER)
+
+	retrievedDER, err = sa.GetCertificate("00000000000000000000000000021bd4")
+	test.AssertNotError(t, err, "Couldn't get www.eff.org.der by full serial")
 	test.AssertByteEquals(t, certDER, retrievedDER)
 
 	certificateStatus, err := sa.GetCertificateStatus("00000000000000000000000000021bd4")
@@ -47,7 +51,11 @@ func TestAddCertificate(t *testing.T) {
 	test.AssertEquals(t, digest2, "CMVYqWzyqUW7pfBF2CxL0Uk6I0Upsk7p4EWSnd_vYx4")
 
 	// Example cert serial is 0x21bd4, so a prefix of all zeroes should fetch it.
-	retrievedDER2, err := sa.GetCertificate("ff00000000000002")
+	retrievedDER2, err := sa.GetCertificateByShortSerial("ff00000000000002")
+	test.AssertNotError(t, err, "Couldn't get test-cert.der")
+	test.AssertByteEquals(t, certDER2, retrievedDER2)
+
+	retrievedDER2, err = sa.GetCertificate("ff00000000000002238054509817da5a")
 	test.AssertNotError(t, err, "Couldn't get test-cert.der")
 	test.AssertByteEquals(t, certDER2, retrievedDER2)
 
@@ -58,16 +66,16 @@ func TestAddCertificate(t *testing.T) {
 	test.Assert(t, certificateStatus2.OCSPLastUpdated.IsZero(), "OCSPLastUpdated should be nil")
 }
 
-// TestGetCertificate tests some failure conditions for GetCertificate.
+// TestGetCertificateByShortSerial tests some failure conditions for GetCertificate.
 // Success conditions are tested above in TestAddCertificate.
-func TestGetCertificate(t *testing.T) {
+func TestGetCertificateByShortSerial(t *testing.T) {
 	sa, err := NewSQLStorageAuthority(blog.TestLogger(), "sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
 	sa.InitTables()
 
-	_, err = sa.GetCertificate("")
+	_, err = sa.GetCertificateByShortSerial("")
 	test.AssertError(t, err, "Should've failed on empty serial")
 
-	_, err = sa.GetCertificate("01020304050607080102030405060708")
+	_, err = sa.GetCertificateByShortSerial("01020304050607080102030405060708")
 	test.AssertError(t, err, "Should've failed on too-long serial")
 }

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -44,7 +44,7 @@
     "dbName": "boulder-ca.sqlite3",
     "testMode": true,
     "issuerCert": "test/test-ca.pem",
-    "_comment": "This should only be present in testMode. In prod use an HSM."
+    "_comment": "This should only be present in testMode. In prod use an HSM.",
     "issuerKey": "test/test-ca.key"
   },
 

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -41,7 +41,7 @@
     "serialPrefix": 255,
     "profile": "ee",
     "dbDriver": "sqlite3",
-    "dbName": "boulder-ca.sqlite3",
+    "dbName": ":memory:",
     "testMode": true,
     "issuerCert": "test/test-ca.pem",
     "_comment": "This should only be present in testMode. In prod use an HSM.",
@@ -50,7 +50,7 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": "boulder.sqlite3"
+    "dbName": ":memory:"
   },
 
   "mail": {

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -42,7 +42,10 @@
     "profile": "ee",
     "dbDriver": "sqlite3",
     "dbName": "boulder-ca.sqlite3",
-    "testMode": true
+    "testMode": true,
+    "issuerCert": "test/test-ca.pem",
+    "_comment": "This should only be present in testMode. In prod use an HSM."
+    "issuerKey": "test/test-ca.key"
   },
 
   "sa": {

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -7,11 +7,11 @@ package test
 
 import (
 	"bytes"
-	"fmt"
-	"strings"
-	"runtime"
-	"testing"
 	"encoding/base64"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
 )
 
 // Return short format caller info for printing errors, so errors don't all
@@ -19,12 +19,18 @@ import (
 func caller() string {
 	_, file, line, _ := runtime.Caller(2)
 	splits := strings.Split(file, "/")
-	filename := splits[len(splits) - 1]
+	filename := splits[len(splits)-1]
 	return fmt.Sprintf("%s:%d:", filename, line)
 }
 
 func Assert(t *testing.T, result bool, message string) {
 	if !result {
+		t.Error(caller(), message)
+	}
+}
+
+func AssertNotNil(t *testing.T, obj interface{}, message string) {
+	if obj == nil {
 		t.Error(caller(), message)
 	}
 }
@@ -41,9 +47,15 @@ func AssertError(t *testing.T, err error, message string) {
 	}
 }
 
-func AssertEquals(t *testing.T, one string, two string) {
+func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 	if one != two {
-		t.Errorf("%s String [%s] != [%s]", caller(), one, two)
+		t.Errorf("%s [%v] != [%v]", caller(), one, two)
+	}
+}
+
+func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {
+	if one == two {
+		t.Errorf("%s [%v] == [%v]", caller(), one, two)
 	}
 }
 

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -489,7 +489,7 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 		}
 		wfe.log.Notice(fmt.Sprintf("Requested certificate ID %s", serial))
 
-		cert, err := wfe.SA.GetCertificate(serial)
+		cert, err := wfe.SA.GetCertificateByShortSerial(serial)
 		if err != nil {
 			wfe.notFound(response)
 			return


### PR DESCRIPTION
- Refactor CA implementation to take a config object rather than laundry list of params.
- Break out GetCertificate into GetCertificate / GetCertificateByShortSerial.
- Implement MarkCertificateRevoked in SA.
- Implement RevokeCertificate in CA.
- Add new tables to DB for OCSP responses and CRLs.

Still to be done:
- Web frontend work to call RevokeCertificate.
- OCSP responder to serve from DB.
- CRL signing and serving.
- Periodic re-signing of OCSP responses.
- Integration tests.
- Unit tests