### PR TITLE
Issue #135: Convert the AuditLogger object to have Singleton pattern semantics

### DIFF
--- a/analysis/analysis-engine.go
+++ b/analysis/analysis-engine.go
@@ -39,7 +39,8 @@ func (eng *LoggingAnalysisEngine) ProcessMessage(delivery amqp.Delivery) (err er
 }
 
 // Construct a new Analysis Engine.
-func NewLoggingAnalysisEngine(logger *blog.AuditLogger) AnalysisEngine {
+func NewLoggingAnalysisEngine() AnalysisEngine {
+	logger := blog.GetAuditLogger()
 	logger.Notice("Analysis Engine Starting")
 
 	return &LoggingAnalysisEngine{log: logger}

--- a/analysis/analysis-engine_test.go
+++ b/analysis/analysis-engine_test.go
@@ -9,12 +9,10 @@ import (
 	"testing"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
-	blog "github.com/letsencrypt/boulder/log"
 )
 
 func TestNewLoggingAnalysisEngine(t *testing.T) {
-	log := blog.GetAuditLogger()
-	ae := NewLoggingAnalysisEngine(log)
+	ae := NewLoggingAnalysisEngine()
 
 	// Trivially check an empty mock message
 	d := &amqp.Delivery{}
@@ -41,8 +39,7 @@ func (m *MockAck) Reject(tag uint64, requeue bool) error {
 }
 
 func TestAnalysisEngineBadMessage(t *testing.T) {
-	log := blog.GetAuditLogger()
-	ae := NewLoggingAnalysisEngine(log)
+	ae := NewLoggingAnalysisEngine()
 
 	// Trivially check an empty mock message
 	d := &amqp.Delivery{Acknowledger: &MockAck{}}

--- a/analysis/analysis-engine_test.go
+++ b/analysis/analysis-engine_test.go
@@ -6,18 +6,14 @@
 package analysisengine
 
 import (
-	"log/syslog"
 	"testing"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
-	"github.com/letsencrypt/boulder/log"
+	blog "github.com/letsencrypt/boulder/log"
 )
 
 func TestNewLoggingAnalysisEngine(t *testing.T) {
-	stats, _ := statsd.NewNoopClient(nil)
-	writer, _ := syslog.New(syslog.LOG_EMERG|syslog.LOG_KERN, "tag")
-	log, _ := log.NewAuditLogger(writer, stats)
+	log := blog.GetAuditLogger()
 	ae := NewLoggingAnalysisEngine(log)
 
 	// Trivially check an empty mock message
@@ -45,9 +41,7 @@ func (m *MockAck) Reject(tag uint64, requeue bool) error {
 }
 
 func TestAnalysisEngineBadMessage(t *testing.T) {
-	stats, _ := statsd.NewNoopClient(nil)
-	writer, _ := syslog.New(syslog.LOG_EMERG|syslog.LOG_KERN, "tag")
-	log, _ := log.NewAuditLogger(writer, stats)
+	log := blog.GetAuditLogger()
 	ae := NewLoggingAnalysisEngine(log)
 
 	// Trivially check an empty mock message

--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -24,11 +24,8 @@ type CertificateAuthorityDatabaseImpl struct {
 
 // NewCertificateAuthorityDatabaseImpl constructs a Database for the
 // Certificate Authority.
-func NewCertificateAuthorityDatabaseImpl(logger *blog.AuditLogger, driver string, name string) (cadb core.CertificateAuthorityDatabase, err error) {
-	if logger == nil {
-		err = errors.New("Nil logger not permitted")
-		return
-	}
+func NewCertificateAuthorityDatabaseImpl(driver string, name string) (cadb core.CertificateAuthorityDatabase, err error) {
+	logger := blog.GetAuditLogger()
 
 	db, err := sql.Open(driver, name)
 	if err != nil {

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -8,7 +8,6 @@ package ca
 import (
 	"testing"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/test"
@@ -20,12 +19,10 @@ const sqliteDriver = "sqlite3"
 const sqliteName = ":memory:"
 
 func TestConstruction(t *testing.T) {
-	stats, _ := statsd.NewNoopClient(nil)
-	log, err := blog.Dial("", "", "tag", stats)
-	test.AssertNotError(t, err, "Could not construct audit logger")
+	log := blog.GetAuditLogger()
 
 	// Successful case
-	_, err = NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
+	_, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
 
 	// Covers "sql.Open" error
@@ -42,9 +39,7 @@ func TestConstruction(t *testing.T) {
 }
 
 func TestBeginCommit(t *testing.T) {
-	stats, _ := statsd.NewNoopClient(nil)
-	log, err := blog.Dial("", "", "tag", stats)
-	test.AssertNotError(t, err, "Could not construct audit logger")
+	log := blog.GetAuditLogger()
 
 	cadb, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
@@ -64,9 +59,7 @@ func TestBeginCommit(t *testing.T) {
 }
 
 func TestGetSetSequenceOutsideTx(t *testing.T) {
-	stats, _ := statsd.NewNoopClient(nil)
-	log, err := blog.Dial("", "", "tag", stats)
-	test.AssertNotError(t, err, "Could not construct audit logger")
+	log := blog.GetAuditLogger()
 
 	cadb, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
@@ -76,9 +69,7 @@ func TestGetSetSequenceOutsideTx(t *testing.T) {
 }
 
 func TestGetSetSequenceNumber(t *testing.T) {
-	stats, _ := statsd.NewNoopClient(nil)
-	log, err := blog.Dial("", "", "tag", stats)
-	test.AssertNotError(t, err, "Could not construct audit logger")
+	log := blog.GetAuditLogger()
 
 	cadb, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
-	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -19,29 +18,21 @@ const sqliteDriver = "sqlite3"
 const sqliteName = ":memory:"
 
 func TestConstruction(t *testing.T) {
-	log := blog.GetAuditLogger()
-
 	// Successful case
-	_, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
+	_, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
 
 	// Covers "sql.Open" error
-	_, err = NewCertificateAuthorityDatabaseImpl(log, badDriver, sqliteName)
+	_, err = NewCertificateAuthorityDatabaseImpl(badDriver, sqliteName)
 	test.AssertError(t, err, "Should have failed construction")
 
 	// Covers "db.Ping" error
-	_, err = NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, badFilename)
-	test.AssertError(t, err, "Should have failed construction")
-
-	// Ensures no nil pointer exception in logging
-	_, err = NewCertificateAuthorityDatabaseImpl(nil, sqliteDriver, sqliteName)
+	_, err = NewCertificateAuthorityDatabaseImpl(sqliteDriver, badFilename)
 	test.AssertError(t, err, "Should have failed construction")
 }
 
 func TestBeginCommit(t *testing.T) {
-	log := blog.GetAuditLogger()
-
-	cadb, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
+	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
 
 	err = cadb.Begin()
@@ -59,9 +50,7 @@ func TestBeginCommit(t *testing.T) {
 }
 
 func TestGetSetSequenceOutsideTx(t *testing.T) {
-	log := blog.GetAuditLogger()
-
-	cadb, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
+	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
 
 	_, err = cadb.IncrementAndGetSerial()
@@ -69,9 +58,7 @@ func TestGetSetSequenceOutsideTx(t *testing.T) {
 }
 
 func TestGetSetSequenceNumber(t *testing.T) {
-	log := blog.GetAuditLogger()
-
-	cadb, err := NewCertificateAuthorityDatabaseImpl(log, sqliteDriver, sqliteName)
+	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
 
 	err = cadb.Begin()

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -40,7 +40,8 @@ type CertificateAuthorityImpl struct {
 // using CFSSL's authenticated signature scheme.  A CA created in this way
 // issues for a single profile on the remote signer, which is indicated
 // by name in this constructor.
-func NewCertificateAuthorityImpl(logger *blog.AuditLogger, hostport string, authKey string, profile string, serialPrefix int, cadb core.CertificateAuthorityDatabase) (ca *CertificateAuthorityImpl, err error) {
+func NewCertificateAuthorityImpl(hostport string, authKey string, profile string, serialPrefix int, cadb core.CertificateAuthorityDatabase) (ca *CertificateAuthorityImpl, err error) {
+	logger := blog.GetAuditLogger()
 	logger.Notice("Certificate Authority Starting")
 
 	// Create the remote signer
@@ -61,7 +62,7 @@ func NewCertificateAuthorityImpl(logger *blog.AuditLogger, hostport string, auth
 		return
 	}
 
-	pa := policy.NewPolicyAuthorityImpl(logger)
+	pa := policy.NewPolicyAuthorityImpl()
 
 	ca = &CertificateAuthorityImpl{
 		Signer:  signer,

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
-	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/core"
+	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -260,7 +260,7 @@ func TestIssueCertificate(t *testing.T) {
 	profileName := "ee"
 
 	// Create an SA
-	sa, err := sa.NewSQLStorageAuthority(blog.TestLogger(), "sqlite3", ":memory:")
+	sa, err := sa.NewSQLStorageAuthority(blog.GetAuditLogger(), "sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
 	sa.InitTables()
 
@@ -285,7 +285,7 @@ func TestIssueCertificate(t *testing.T) {
 				Provider: authHandler,
 				CSRWhitelist: &config.CSRWhitelist{
 					PublicKeyAlgorithm: true,
-					PublicKey: true,
+					PublicKey:          true,
 					SignatureAlgorithm: true,
 				},
 			},
@@ -306,7 +306,7 @@ func TestIssueCertificate(t *testing.T) {
 
 	// Create a CA
 	// Uncomment to test with a remote signer
-	ca, err := NewCertificateAuthorityImpl(blog.TestLogger(), hostPort, authKey, profileName, 17, cadb)
+	ca, err := NewCertificateAuthorityImpl(blog.GetAuditLogger(), hostPort, authKey, profileName, 17, cadb)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = sa
 

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	"github.com/letsencrypt/boulder/core"
-	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -260,7 +259,7 @@ func TestIssueCertificate(t *testing.T) {
 	profileName := "ee"
 
 	// Create an SA
-	sa, err := sa.NewSQLStorageAuthority(blog.GetAuditLogger(), "sqlite3", ":memory:")
+	sa, err := sa.NewSQLStorageAuthority("sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
 	sa.InitTables()
 
@@ -306,7 +305,7 @@ func TestIssueCertificate(t *testing.T) {
 
 	// Create a CA
 	// Uncomment to test with a remote signer
-	ca, err := NewCertificateAuthorityImpl(blog.GetAuditLogger(), hostPort, authKey, profileName, 17, cadb)
+	ca, err := NewCertificateAuthorityImpl(hostPort, authKey, profileName, 17, cadb)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = sa
 

--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -61,7 +61,7 @@ func timeDelivery(d amqp.Delivery, stats statsd.Statter, deliveryTimings map[str
 }
 
 func startMonitor(rpcCh *amqp.Channel, logger *blog.AuditLogger, stats statsd.Statter) {
-	ae := analysisengine.NewLoggingAnalysisEngine(logger)
+	ae := analysisengine.NewLoggingAnalysisEngine()
 
 	// For convenience at the broker, identifiy ourselves by hostname
 	consumerTag, err := os.Hostname()

--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -39,7 +39,7 @@ const (
 var openCalls int64 = 0
 
 func timeDelivery(d amqp.Delivery, stats statsd.Statter, deliveryTimings map[string]time.Time) {
-	// If d is a call add to deliveryTimings and increment openCalls, if it is a 
+	// If d is a call add to deliveryTimings and increment openCalls, if it is a
 	// response then get time.Since original call from deliveryTiming, send timing metric, and
 	// decrement openCalls, in both cases send the gauges RpcCallsOpen and RpcBodySize
 	if d.ReplyTo != "" {
@@ -144,6 +144,8 @@ func main() {
 
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		blog.SetAuditLogger(auditlogger)
+
 		ch := cmd.AmqpChannel(c.AMQP.Server)
 
 		go cmd.ProfileCmd("AM", stats)
@@ -153,4 +155,3 @@ func main() {
 
 	app.Run()
 }
- 

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -30,10 +30,10 @@ func main() {
 
 		blog.SetAuditLogger(auditlogger)
 
-		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(auditlogger, c.CA.DBDriver, c.CA.DBName)
+		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBName)
 		cmd.FailOnError(err, "Failed to create CA database")
 
-		cai, err := ca.NewCertificateAuthorityImpl(auditlogger, c.CA.Server, c.CA.AuthKey, c.CA.Profile, c.CA.SerialPrefix, cadb)
+		cai, err := ca.NewCertificateAuthorityImpl(c.CA.Server, c.CA.AuthKey, c.CA.Profile, c.CA.SerialPrefix, cadb)
 		cmd.FailOnError(err, "Failed to create CA impl")
 
 		go cmd.ProfileCmd("CA", stats)

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -28,6 +28,8 @@ func main() {
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		blog.SetAuditLogger(auditlogger)
+
 		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(auditlogger, c.CA.DBDriver, c.CA.DBName)
 		cmd.FailOnError(err, "Failed to create CA database")
 
@@ -35,7 +37,6 @@ func main() {
 		cmd.FailOnError(err, "Failed to create CA impl")
 
 		go cmd.ProfileCmd("CA", stats)
-
 
 		for {
 			ch := cmd.AmqpChannel(c.AMQP.Server)

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -25,10 +25,11 @@ func main() {
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		blog.SetAuditLogger(auditlogger)
+
 		rai := ra.NewRegistrationAuthorityImpl(auditlogger)
 
 		go cmd.ProfileCmd("RA", stats)
-
 
 		for {
 			ch := cmd.AmqpChannel(c.AMQP.Server)

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -27,7 +27,7 @@ func main() {
 
 		blog.SetAuditLogger(auditlogger)
 
-		rai := ra.NewRegistrationAuthorityImpl(auditlogger)
+		rai := ra.NewRegistrationAuthorityImpl()
 
 		go cmd.ProfileCmd("RA", stats)
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -28,11 +28,12 @@ func main() {
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		blog.SetAuditLogger(auditlogger)
+
 		sai, err := sa.NewSQLStorageAuthority(auditlogger, c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Failed to create SA impl")
-		
-		go cmd.ProfileCmd("SA", stats)
 
+		go cmd.ProfileCmd("SA", stats)
 
 		for {
 			ch := cmd.AmqpChannel(c.AMQP.Server)

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -30,7 +30,7 @@ func main() {
 
 		blog.SetAuditLogger(auditlogger)
 
-		sai, err := sa.NewSQLStorageAuthority(auditlogger, c.SA.DBDriver, c.SA.DBName)
+		sai, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Failed to create SA impl")
 
 		go cmd.ProfileCmd("SA", stats)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -25,6 +25,8 @@ func main() {
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		blog.SetAuditLogger(auditlogger)
+
 		go cmd.ProfileCmd("VA", stats)
 
 		vai := va.NewValidationAuthorityImpl(auditlogger, c.CA.TestMode)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -29,7 +29,7 @@ func main() {
 
 		go cmd.ProfileCmd("VA", stats)
 
-		vai := va.NewValidationAuthorityImpl(auditlogger, c.CA.TestMode)
+		vai := va.NewValidationAuthorityImpl(c.CA.TestMode)
 
 		for {
 			ch := cmd.AmqpChannel(c.AMQP.Server)

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -73,6 +73,8 @@ func main() {
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		blog.SetAuditLogger(auditlogger)
+
 		wfe := wfe.NewWebFrontEndImpl(auditlogger)
 		rac, sac, closeChan := setupWFE(c, auditlogger)
 		wfe.RA = &rac

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/letsencrypt/boulder/wfe"
 )
 
-func setupWFE(c cmd.Config, auditlogger *blog.AuditLogger) (rpc.RegistrationAuthorityClient, rpc.StorageAuthorityClient, chan *amqp.Error) {
+func setupWFE(c cmd.Config) (rpc.RegistrationAuthorityClient, rpc.StorageAuthorityClient, chan *amqp.Error) {
 	ch := cmd.AmqpChannel(c.AMQP.Server)
 	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
@@ -75,8 +75,8 @@ func main() {
 
 		blog.SetAuditLogger(auditlogger)
 
-		wfe := wfe.NewWebFrontEndImpl(auditlogger)
-		rac, sac, closeChan := setupWFE(c, auditlogger)
+		wfe := wfe.NewWebFrontEndImpl()
+		rac, sac, closeChan := setupWFE(c)
 		wfe.RA = &rac
 		wfe.SA = &sac
 		wfe.Stats = stats
@@ -91,7 +91,7 @@ func main() {
 				for err := range closeChan {
 					auditlogger.Warning(fmt.Sprintf("AMQP Channel closed, will reconnect in 5 seconds: [%s]", err))
 					time.Sleep(time.Second * 5)
-					rac, sac, closeChan = setupWFE(c, auditlogger)
+					rac, sac, closeChan = setupWFE(c)
 					wfe.RA = &rac
 					wfe.SA = &sac
 					auditlogger.Warning("Reconnected to AMQP")

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -65,6 +65,8 @@ func main() {
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		blog.SetAuditLogger(auditlogger)
+
 		// Run StatsD profiling
 		go cmd.ProfileCmd("Monolith", stats)
 

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -71,17 +71,17 @@ func main() {
 		go cmd.ProfileCmd("Monolith", stats)
 
 		// Create the components
-		wfe := wfe.NewWebFrontEndImpl(auditlogger)
-		sa, err := sa.NewSQLStorageAuthority(auditlogger, c.SA.DBDriver, c.SA.DBName)
+		wfe := wfe.NewWebFrontEndImpl()
+		sa, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Unable to create SA")
 
-		ra := ra.NewRegistrationAuthorityImpl(auditlogger)
-		va := va.NewValidationAuthorityImpl(auditlogger, c.CA.TestMode)
+		ra := ra.NewRegistrationAuthorityImpl()
+		va := va.NewValidationAuthorityImpl(c.CA.TestMode)
 
-		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(auditlogger, c.CA.DBDriver, c.CA.DBName)
+		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBName)
 		cmd.FailOnError(err, "Failed to create CA database")
 
-		ca, err := ca.NewCertificateAuthorityImpl(auditlogger, c.CA.Server, c.CA.AuthKey, c.CA.Profile, c.CA.SerialPrefix, cadb)
+		ca, err := ca.NewCertificateAuthorityImpl(c.CA.Server, c.CA.AuthKey, c.CA.Profile, c.CA.SerialPrefix, cadb)
 		cmd.FailOnError(err, "Unable to create CA")
 
 		// Wire them up

--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -9,9 +9,19 @@ import (
 	"errors"
 	"fmt"
 	"log/syslog"
+	"sync"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 )
+
+// singleton defines the object of a Singleton pattern
+type singleton struct {
+	once sync.Once
+	log  *AuditLogger
+}
+
+// _Singleton is the single AuditLogger entity in memory
+var _Singleton singleton
 
 // The constant used to identify audit-specific messages
 const auditTag = "[AUDIT]"
@@ -24,14 +34,6 @@ const auditTag = "[AUDIT]"
 type AuditLogger struct {
 	*syslog.Writer
 	Stats statsd.Statter
-}
-
-// TestLogger returns an AuditLogger, required to initialize many components
-func TestLogger() (logger *AuditLogger) {
-	stats, _ := statsd.NewNoopClient(nil)
-	// Audit logger
-	logger, _ = Dial("", "", "tag", stats)
-	return
 }
 
 // Dial establishes a connection to the log daemon by passing through
@@ -52,6 +54,37 @@ func NewAuditLogger(log *syslog.Writer, stats statsd.Statter) (*AuditLogger, err
 		return nil, errors.New("Attempted to use a nil System Logger.")
 	}
 	return &AuditLogger{log, stats}, nil
+}
+
+// initializeAuditLogger should only be used in unit tests. Failures in this
+// method are unlikely as the defaults are safe, and they are also
+// of minimal consequence during unit testing -- logs get pritned to stdout
+// even if syslog is missing.
+func initializeAuditLogger() {
+	stats, _ := statsd.NewNoopClient(nil)
+	audit, _ := Dial("", "", "default", stats)
+	audit.Notice("Using default logging configuration.")
+
+	SetAuditLogger(audit)
+}
+
+// SetAuditLogger configures the singleton audit logger. This method
+// must only be called once, and before calling GetAuditLogger the
+// first time.
+func SetAuditLogger(logger *AuditLogger) {
+	_Singleton.once.Do(func() {
+		_Singleton.log = logger
+	})
+}
+
+// GetAuditLogger obtains the singleton audit logger. If SetAuditLogger
+// has not been called first, this method initializes with basic defaults.
+// The basic defaults cannot error, and subequent access to an already-set
+// AuditLogger also cannot error, so this method is error-safe.
+func GetAuditLogger() *AuditLogger {
+	initializeAuditLogger()
+
+	return _Singleton.log
 }
 
 // Audit sends a NOTICE-severity message that is prefixed with the

--- a/log/audit-logger_test.go
+++ b/log/audit-logger_test.go
@@ -38,7 +38,10 @@ func TestSingleton(t *testing.T) {
 	test.AssertNotError(t, err, "Could not construct audit logger")
 
 	// Should not work
-	SetAuditLogger(log3)
+	err = SetAuditLogger(log3)
+	test.AssertError(t, err, "Can't re-set")
+
+	// Verify no change
 	log4 := GetAuditLogger()
 
 	// Verify that log4 != log3
@@ -116,8 +119,4 @@ func TestSyslogMethods(t *testing.T) {
 	audit.Notice("audit-logger_test.go: notice")
 	audit.Warning("audit-logger_test.go: warning")
 	audit.Alert("audit-logger_test.go: alert")
-}
-
-func TestEmergSyslog(t *testing.T) {
-
 }

--- a/log/audit-logger_test.go
+++ b/log/audit-logger_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-
 func TestConstruction(t *testing.T) {
 	writer, err := syslog.New(syslog.LOG_EMERG|syslog.LOG_KERN, "tag")
 	test.AssertNotError(t, err, "Could not construct syslog object")
@@ -22,6 +21,32 @@ func TestConstruction(t *testing.T) {
 	stats, _ := statsd.NewNoopClient(nil)
 	_, err = NewAuditLogger(writer, stats)
 	test.AssertNotError(t, err, "Could not construct audit logger")
+}
+
+func TestSingleton(t *testing.T) {
+	log1 := GetAuditLogger()
+	test.AssertNotNil(t, log1, "Logger shouldn't be nil")
+
+	log2 := GetAuditLogger()
+	test.AssertEquals(t, log1, log2)
+
+	writer, err := syslog.New(syslog.LOG_EMERG|syslog.LOG_KERN, "tag")
+	test.AssertNotError(t, err, "Could not construct syslog object")
+
+	stats, _ := statsd.NewNoopClient(nil)
+	log3, err := NewAuditLogger(writer, stats)
+	test.AssertNotError(t, err, "Could not construct audit logger")
+
+	// Should not work
+	SetAuditLogger(log3)
+	log4 := GetAuditLogger()
+
+	// Verify that log4 != log3
+	test.AssertNotEquals(t, log4, log3)
+
+	// Verify that log4 == log2 == log1
+	test.AssertEquals(t, log4, log2)
+	test.AssertEquals(t, log4, log1)
 }
 
 func TestDial(t *testing.T) {
@@ -73,7 +98,9 @@ func TestEmitErrors(t *testing.T) {
 }
 
 func TestSyslogMethods(t *testing.T) {
-	writer, err := syslog.New(syslog.LOG_EMERG|syslog.LOG_KERN, "tag")
+	// Write all logs to UDP on a high port so as to not bother the system
+	// which is running the test, particularly for Emerg()
+	writer, err := syslog.Dial("udp", "127.0.0.1:65530", syslog.LOG_INFO|syslog.LOG_LOCAL0, "")
 	test.AssertNotError(t, err, "Could not construct syslog object")
 
 	stats, _ := statsd.NewNoopClient(nil)
@@ -83,10 +110,14 @@ func TestSyslogMethods(t *testing.T) {
 	audit.Audit("audit-logger_test.go: audit-notice")
 	audit.Crit("audit-logger_test.go: critical")
 	audit.Debug("audit-logger_test.go: debug")
-	// Don't test Emerg... it sends a wall to the host OS.
-	// audit.Emerg("audit-logger_test.go: emerg")
+	audit.Emerg("audit-logger_test.go: emerg")
 	audit.Err("audit-logger_test.go: err")
 	audit.Info("audit-logger_test.go: info")
 	audit.Notice("audit-logger_test.go: notice")
 	audit.Warning("audit-logger_test.go: warning")
+	audit.Alert("audit-logger_test.go: alert")
+}
+
+func TestEmergSyslog(t *testing.T) {
+
 }

--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -22,7 +22,8 @@ type PolicyAuthorityImpl struct {
 	Blacklist        map[string]bool // A blacklist of denied names
 }
 
-func NewPolicyAuthorityImpl(logger *blog.AuditLogger) *PolicyAuthorityImpl {
+func NewPolicyAuthorityImpl() *PolicyAuthorityImpl {
+	logger := blog.GetAuditLogger()
 	logger.Notice("Registration Authority Starting")
 
 	pa := PolicyAuthorityImpl{log: logger}

--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -8,7 +8,6 @@ package policy
 import (
 	"testing"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 )
@@ -89,9 +88,8 @@ func TestWillingToIssue(t *testing.T) {
 		"www.zombo-.com",
 	}
 
-	stats, _ := statsd.NewNoopClient(nil)
 	// Audit logger
-	audit, _ := blog.Dial("", "", "tag", stats)
+	audit := blog.GetAuditLogger()
 
 	pa := NewPolicyAuthorityImpl(audit)
 
@@ -136,9 +134,7 @@ func TestWillingToIssue(t *testing.T) {
 }
 
 func TestChallengesFor(t *testing.T) {
-	stats, _ := statsd.NewNoopClient(nil)
-	// Audit logger
-	audit, _ := blog.Dial("", "", "tag", stats)
+	audit := blog.GetAuditLogger()
 
 	pa := NewPolicyAuthorityImpl(audit)
 

--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/letsencrypt/boulder/core"
-	blog "github.com/letsencrypt/boulder/log"
 )
 
 func TestWillingToIssue(t *testing.T) {
@@ -88,10 +87,7 @@ func TestWillingToIssue(t *testing.T) {
 		"www.zombo-.com",
 	}
 
-	// Audit logger
-	audit := blog.GetAuditLogger()
-
-	pa := NewPolicyAuthorityImpl(audit)
+	pa := NewPolicyAuthorityImpl()
 
 	// Test for invalid identifier type
 	identifier := core.AcmeIdentifier{Type: "ip", Value: "example.com"}
@@ -134,9 +130,7 @@ func TestWillingToIssue(t *testing.T) {
 }
 
 func TestChallengesFor(t *testing.T) {
-	audit := blog.GetAuditLogger()
-
-	pa := NewPolicyAuthorityImpl(audit)
+	pa := NewPolicyAuthorityImpl()
 
 	challenges, combinations := pa.ChallengesFor(core.AcmeIdentifier{})
 

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -31,11 +31,12 @@ type RegistrationAuthorityImpl struct {
 	AuthzBase string
 }
 
-func NewRegistrationAuthorityImpl(logger *blog.AuditLogger) RegistrationAuthorityImpl {
+func NewRegistrationAuthorityImpl() RegistrationAuthorityImpl {
+	logger := blog.GetAuditLogger()
 	logger.Notice("Registration Authority Starting")
 
 	ra := RegistrationAuthorityImpl{log: logger}
-	ra.PA = policy.NewPolicyAuthorityImpl(logger)
+	ra.PA = policy.NewPolicyAuthorityImpl()
 	return ra
 }
 

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	"github.com/letsencrypt/boulder/ca"
@@ -95,9 +94,7 @@ var (
 )
 
 func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationAuthority, *sa.SQLStorageAuthority, core.RegistrationAuthority) {
-	stats, _ := statsd.NewNoopClient(nil)
-	// Audit logger
-	audit, _ := blog.Dial("", "", "tag", stats)
+	audit := blog.GetAuditLogger()
 
 	err := json.Unmarshal(AccountKeyJSON, &AccountKey)
 	test.AssertNotError(t, err, "Failed to unmarshall JWK")

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -6,16 +6,16 @@
 package sa
 
 import (
+	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
+	"github.com/letsencrypt/boulder/core"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/test"
 	"io/ioutil"
 	"testing"
-	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/test"
-	blog "github.com/letsencrypt/boulder/log"
-	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 )
 
 func TestAddCertificate(t *testing.T) {
-	sa, err := NewSQLStorageAuthority(blog.TestLogger(), "sqlite3", ":memory:")
+	sa, err := NewSQLStorageAuthority(blog.GetAuditLogger(), "sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
 	sa.InitTables()
 
@@ -61,7 +61,7 @@ func TestAddCertificate(t *testing.T) {
 // TestGetCertificate tests some failure conditions for GetCertificate.
 // Success conditions are tested above in TestAddCertificate.
 func TestGetCertificate(t *testing.T) {
-	sa, err := NewSQLStorageAuthority(blog.TestLogger(), "sqlite3", ":memory:")
+	sa, err := NewSQLStorageAuthority(blog.GetAuditLogger(), "sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
 	sa.InitTables()
 

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -8,14 +8,13 @@ package sa
 import (
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	"github.com/letsencrypt/boulder/core"
-	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/test"
 	"io/ioutil"
 	"testing"
 )
 
 func TestAddCertificate(t *testing.T) {
-	sa, err := NewSQLStorageAuthority(blog.GetAuditLogger(), "sqlite3", ":memory:")
+	sa, err := NewSQLStorageAuthority("sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
 	sa.InitTables()
 
@@ -61,7 +60,7 @@ func TestAddCertificate(t *testing.T) {
 // TestGetCertificate tests some failure conditions for GetCertificate.
 // Success conditions are tested above in TestAddCertificate.
 func TestGetCertificate(t *testing.T) {
-	sa, err := NewSQLStorageAuthority(blog.GetAuditLogger(), "sqlite3", ":memory:")
+	sa, err := NewSQLStorageAuthority("sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
 	sa.InitTables()
 

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -7,11 +7,11 @@ package test
 
 import (
 	"bytes"
-	"fmt"
-	"strings"
-	"runtime"
-	"testing"
 	"encoding/base64"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
 )
 
 // Return short format caller info for printing errors, so errors don't all
@@ -19,12 +19,18 @@ import (
 func caller() string {
 	_, file, line, _ := runtime.Caller(2)
 	splits := strings.Split(file, "/")
-	filename := splits[len(splits) - 1]
+	filename := splits[len(splits)-1]
 	return fmt.Sprintf("%s:%d:", filename, line)
 }
 
 func Assert(t *testing.T, result bool, message string) {
 	if !result {
+		t.Error(caller(), message)
+	}
+}
+
+func AssertNotNil(t *testing.T, obj interface{}, message string) {
+	if obj == nil {
 		t.Error(caller(), message)
 	}
 }
@@ -41,9 +47,15 @@ func AssertError(t *testing.T, err error, message string) {
 	}
 }
 
-func AssertEquals(t *testing.T, one string, two string) {
+func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 	if one != two {
-		t.Errorf("%s String [%s] != [%s]", caller(), one, two)
+		t.Errorf("%s [%v] != [%v]", caller(), one, two)
+	}
+}
+
+func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {
+	if one == two {
+		t.Errorf("%s [%v] == [%v]", caller(), one, two)
 	}
 }
 

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -24,7 +24,8 @@ type ValidationAuthorityImpl struct {
 	TestMode bool
 }
 
-func NewValidationAuthorityImpl(logger *blog.AuditLogger, tm bool) ValidationAuthorityImpl {
+func NewValidationAuthorityImpl(tm bool) ValidationAuthorityImpl {
+	logger := blog.GetAuditLogger()
 	logger.Notice("Validation Authority Starting")
 	return ValidationAuthorityImpl{log: logger, TestMode: tm}
 }
@@ -72,7 +73,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTPS(identifier core.AcmeIdenti
 	}
 	client := http.Client{
 		Transport: tr,
-		Timeout: 5 * time.Second,
+		Timeout:   5 * time.Second,
 	}
 	httpResponse, err := client.Do(httpRequest)
 

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -45,7 +45,8 @@ type WebFrontEndImpl struct {
 	TermsPath    string
 }
 
-func NewWebFrontEndImpl(logger *blog.AuditLogger) WebFrontEndImpl {
+func NewWebFrontEndImpl() WebFrontEndImpl {
+	logger := blog.GetAuditLogger()
 	logger.Notice("Web Front End Starting")
 	return WebFrontEndImpl{
 		log:          logger,

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/jose"
+
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/ra"
 	"github.com/letsencrypt/boulder/test"
@@ -39,7 +40,7 @@ func mockLog(t *testing.T) (log *blog.AuditLogger) {
 //  - RA returns with a cert success
 //  - RA returns with a failure
 func TestIssueCertificate(t *testing.T) {
-	log := mockLog(t)
+	log := blog.GetAuditLogger()
 	// TODO: Use a mock RA so we can test various conditions of authorized, not authorized, etc.
 	ra := ra.NewRegistrationAuthorityImpl(log)
 	wfe := NewWebFrontEndImpl(log)
@@ -203,7 +204,7 @@ func (ra *MockRegistrationAuthority) OnValidationUpdate(authz core.Authorization
 }
 
 func TestChallenge(t *testing.T) {
-	log := mockLog(t)
+	log := blog.GetAuditLogger()
 	wfe := NewWebFrontEndImpl(log)
 	wfe.RA = &MockRegistrationAuthority{}
 	wfe.HandlePaths()

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -16,11 +16,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/jose"
 
-	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/ra"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -29,21 +27,13 @@ func makeBody(s string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(s))
 }
 
-func mockLog(t *testing.T) (log *blog.AuditLogger) {
-	stats, _ := statsd.NewNoopClient(nil)
-	log, err := blog.Dial("", "", "tag", stats)
-	test.AssertNotError(t, err, "Could not construct audit logger")
-	return
-}
-
 // TODO: Write additional test cases for:
 //  - RA returns with a cert success
 //  - RA returns with a failure
 func TestIssueCertificate(t *testing.T) {
-	log := blog.GetAuditLogger()
 	// TODO: Use a mock RA so we can test various conditions of authorized, not authorized, etc.
-	ra := ra.NewRegistrationAuthorityImpl(log)
-	wfe := NewWebFrontEndImpl(log)
+	ra := ra.NewRegistrationAuthorityImpl()
+	wfe := NewWebFrontEndImpl()
 	wfe.RA = &ra
 	responseWriter := httptest.NewRecorder()
 
@@ -204,8 +194,7 @@ func (ra *MockRegistrationAuthority) OnValidationUpdate(authz core.Authorization
 }
 
 func TestChallenge(t *testing.T) {
-	log := blog.GetAuditLogger()
-	wfe := NewWebFrontEndImpl(log)
+	wfe := NewWebFrontEndImpl()
 	wfe.RA = &MockRegistrationAuthority{}
 	wfe.HandlePaths()
 	responseWriter := httptest.NewRecorder()


### PR DESCRIPTION
This change modifies the use of AuditLogger to expose two methods, `GetAuditLogger()` and `SetAuditLogger(*log.AuditLogger)`.

In use, these classes permit a one-time initialization of the AuditLogger for a running process, and then permit access from anywhere to the resulting object. This is similar to the semantics for SLF4J or Apache Commons Logging in Java, with the difference that currently the code does not permit retroactive modification -- though that would not be difficult to add if ever needed.

Mechanically, an implementor would construct an AuditLogger using any of the existing methods (`Dial()`, for example) and then call `SetAuditLogger()` before any calls to `GetAuditLogger()` occur. When `GetAuditLogger()` is called, it will return the instance provided to `SetAuditLogger()`. If `GetAuditLogger()` is called before `SetAuditLogger()` then a notice is printed, and a default logger is constructed.