### PR TITLE
Check for RNG failures

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -18,7 +18,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	blog "github.com/letsencrypt/boulder/log"
 	"hash"
+	"io"
 	"math/big"
 	"net/url"
 	"strings"
@@ -70,12 +72,21 @@ func B64dec(x string) ([]byte, error) {
 
 func RandomString(byteLength int) string {
 	b := make([]byte, byteLength)
-	_, _ = rand.Read(b) // NOTE: Ignoring errors
+	_, err := io.ReadFull(rand.Reader, b) // NOTE: Ignoring errors
+	if err != nil {
+		ohdear := "RandomString entropy failure? " + err.Error()
+		logger := blog.GetAuditLogger()
+		logger.EmergencyExit(ohdear)
+	}
 	return B64enc(b)
 }
 
 func NewToken() string {
 	return RandomString(32)
+}
+
+func EmergencyExit() {
+	// For now just exit, but perhaps other cleanup and continuity
 }
 
 // Fingerprints

--- a/core/util.go
+++ b/core/util.go
@@ -70,9 +70,10 @@ func B64dec(x string) ([]byte, error) {
 
 // Random stuff
 
+// RandomString returns a randomly generated string of the requested length.
 func RandomString(byteLength int) string {
 	b := make([]byte, byteLength)
-	_, err := io.ReadFull(rand.Reader, b) // NOTE: Ignoring errors
+	_, err := io.ReadFull(rand.Reader, b)
 	if err != nil {
 		ohdear := "RandomString entropy failure? " + err.Error()
 		logger := blog.GetAuditLogger()

--- a/core/util.go
+++ b/core/util.go
@@ -85,10 +85,6 @@ func NewToken() string {
 	return RandomString(32)
 }
 
-func EmergencyExit() {
-	// For now just exit, but perhaps other cleanup and continuity
-}
-
 // Fingerprints
 
 func Fingerprint256(data []byte) string {

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -5,4 +5,32 @@
 
 package core
 
+import (
+	"testing"
+	"fmt"
+	"github.com/letsencrypt/boulder/test"
+	"math"
+)
+
 // challenges.go
+func TestNewToken(t *testing.T) {
+	token := NewToken()
+	fmt.Println(token)
+	tokenLength := int(math.Ceil(32 * 8 / 6.0)) // 32 bytes, b64 encoded
+	test.AssertIntEquals(t,len(token),tokenLength)
+	collider := map[string]bool{}
+	// Test for very blatant RNG failures:
+	// Try 2^20 birthdays in a 2^72 search space...
+	// our naive collision probability here is  2^-32...
+	for i:=0; i < 1000000; i++ {
+		token = NewToken()[:12] // just sample a portion
+		test.Assert(t,!collider[token],"Token collision!")
+		collider[token] = true
+	}
+	return
+}
+
+func TestRandString(t *testing.T) {
+  // This is covered by NewToken
+  return
+}

--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/syslog"
+	"os"
 	"sync"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
@@ -170,4 +171,15 @@ func (log *AuditLogger) Notice(msg string) (err error) {
 	fmt.Println(msg)
 	log.Stats.Inc("Logging.Notice", 1, 1.0)
 	return log.Writer.Notice(msg)
+}
+
+const EMERGENCY_RETVAL = 13
+
+func (log *AuditLogger) EmergencyExit(msg string) {
+	// Some errors may be serious enough to trigger an immediate Boulder
+	// shutdown.  This function will provide the necessary housekeeping.
+	// Currently, make an emergency log entry and exit; the Activity Monitor
+	// should notice the Emerg level event and shut down all components.
+	log.Emerg(msg)
+	os.Exit(EMERGENCY_RETVAL)
 }

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -67,6 +67,13 @@ func AssertByteEquals(t *testing.T, one []byte, two []byte) {
 			base64.StdEncoding.EncodeToString(two))
 	}
 }
+
+func AssertIntEquals(t *testing.T, one int, two int) {
+	if one != two {
+		t.Errorf("%s Int [%d] != [%d]", caller(), one, two)
+	}
+}
+
 func AssertContains(t *testing.T, haystack string, needle string) {
 	if !strings.Contains(haystack, needle) {
 		t.Errorf("%s String [%s] does not contain [%s]", caller(), haystack, needle)


### PR DESCRIPTION
This addresses #51.  It depends on #135.

It also includes a basic log.EmergencyExit() function to call in case of catastrophic errors, though the corresponding piece of ActivityMonitor still needs to beimplemented.

I haven't yet learned a way to fake rand.Reader returning fewer than 32 bytes in the test case, or to test the resulting os.Exit(13) that we expect...