### PR TITLE
Implement user-facing revocation.

### DIFF
--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -87,7 +87,6 @@ func main() {
 		// Wire them up
 		wfe.RA = &ra
 		wfe.SA = sa
-		wfe.CA = ca
 		wfe.Stats = stats
 
 		wfe.IssuerCert, err = cmd.LoadCert(c.CA.IssuerCert)

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -194,8 +194,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(base core.Authorization
 }
 
 func (ra *RegistrationAuthorityImpl) RevokeCertificate(cert x509.Certificate) error {
-	// TODO: ra.CA.RevokeCertificate()
-	return nil
+	return ra.CA.RevokeCertificate(core.SerialToString(cert.SerialNumber))
 }
 
 func (ra *RegistrationAuthorityImpl) OnValidationUpdate(authz core.Authorization) {

--- a/test/js/revoke.js
+++ b/test/js/revoke.js
@@ -1,0 +1,45 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// To revoke a certificate against a local Boulder:
+// js revoke.js cert.pem key.pem
+
+'use strict';
+
+var crypto = require('./crypto-util');
+var util = require('./acme-util');
+var forge = require('node-forge');
+var fs = require('fs');
+var request = require('request');
+
+function main() {
+  if (process.argv.length != 4) {
+    console.log('Usage: js revoke.js cert.der key.pem');
+    process.exit(1);
+  }
+  var key = crypto.importPemPrivateKey(fs.readFileSync(process.argv[3]));
+  var certDER = fs.readFileSync(process.argv[2])
+  var certDERB64URL = util.b64enc(new Buffer(certDER))
+  var revokeMessage = JSON.stringify({
+    // For some reason forge adds an extra, incorrect '00' at the front of the
+    // serial number.
+    certificate: certDERB64URL
+  });
+  console.log('Requesting revocation:', revokeMessage)
+  var jws = crypto.generateSignature(key, new Buffer(revokeMessage));
+  var req = request.post('http://localhost:4000/acme/revoke-cert/', function(err, resp) {
+    if (err) {
+      console.log('Error: ', err);
+    }
+    console.log(resp.statusCode);
+    console.log(resp.headers);
+    console.log(resp.body);
+  });
+  var payload = JSON.stringify(jws);
+  console.log(payload);
+  req.write(payload);
+  req.end();
+}
+main();

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -331,14 +331,14 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 		return
 	}
 
-	body, requestKey, err := verifyPOST(request)
+	body, requestKey, _, err := wfe.verifyPOST(request, false)
 	if err != nil {
 		wfe.sendError(response, "Unable to read/verify body", http.StatusBadRequest)
 		return
 	}
 
 	type RevokeRequest struct {
-		CertificateDER jose.JsonBuffer `json:"certificate"`
+		CertificateDER core.JsonBuffer `json:"certificate"`
 	}
 	var revokeRequest RevokeRequest
 	if err = json.Unmarshal(body, &revokeRequest); err != nil {
@@ -376,17 +376,10 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 		return
 	}
 
-	// TODO: Allow other types of keys.
-	if requestKey.Rsa == nil {
-		wfe.sendError(response, "Non-RSA keys not permitted.", http.StatusForbidden)
-		return
-	}
 	// TODO: Implement other methods of validating revocation, e.g. through
 	// authorizations on account.
-	if core.KeyDigest(requestKey.Rsa) != core.KeyDigest(parsedCertificate.PublicKey) {
-		wfe.log.Debug(fmt.Sprintf("Key mismatch for revoke: %s vs %s",
-			core.KeyDigest(requestKey),
-			core.KeyDigest(parsedCertificate.PublicKey)))
+	if !core.KeyDigestEquals(requestKey, parsedCertificate.PublicKey) {
+		wfe.log.Debug("Key mismatch for revoke")
 		wfe.sendError(response,
 			"Revocation request must be signed by private key of cert to be revoked",
 			http.StatusForbidden)
@@ -402,83 +395,6 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 		wfe.log.Debug(fmt.Sprintf("Revoked %v", serial))
 		// incr revoked cert stat
 		wfe.Stats.Inc("RevokedCertificates", 1, 1.0)
-		response.WriteHeader(http.StatusOK)
-	}
-}
-
-func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request *http.Request) {
-	if request.Method != "POST" {
-		wfe.sendError(response, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	body, requestKey, err := verifyPOST(request)
-	if err != nil {
-		wfe.sendError(response, "Unable to read/verify body", http.StatusBadRequest)
-		return
-	}
-
-	type RevokeRequest struct {
-		Serial string
-	}
-	var revokeRequest RevokeRequest
-	if err = json.Unmarshal(body, &revokeRequest); err != nil {
-		fmt.Println("Couldn't unmarshal in revoke request", string(body))
-		wfe.sendError(response, "Unable to read/verify body", http.StatusBadRequest)
-		return
-	}
-	if len(revokeRequest.Serial) != 32 {
-		wfe.log.Debug("Bad serial in revoke request " + revokeRequest.Serial)
-		wfe.sendError(response, "Unable to read/verify body", http.StatusBadRequest)
-		return
-	}
-
-	certDER, err := wfe.SA.GetCertificate(revokeRequest.Serial)
-	if err != nil {
-		wfe.sendError(response, "No such certificate", http.StatusNotFound)
-		return
-	}
-	parsedCertificate, err := x509.ParseCertificate(certDER)
-	if err != nil {
-		wfe.sendError(response, "Invalid certificate", http.StatusInternalServerError)
-		return
-	}
-
-	certStatus, err := wfe.SA.GetCertificateStatus(revokeRequest.Serial)
-	if err != nil {
-		wfe.sendError(response, "No such certificate", http.StatusNotFound)
-		return
-	}
-	
-	if certStatus.Status == core.OCSPStatusRevoked {
-		wfe.sendError(response, "Certificate already revoked", http.StatusConflict)
-		return
-	}
-
-	// TODO: Allow other types of keys.
-	if requestKey.Rsa == nil {
-		wfe.sendError(response, "Non-RSA keys not permitted.", http.StatusForbidden)
-		return
-	}
-	// TODO: Implement other methods of validating revocation, e.g. through
-	// authorizations on account.
-	if core.KeyDigest(requestKey.Rsa) != core.KeyDigest(parsedCertificate.PublicKey) {
-		wfe.log.Debug(fmt.Sprintf("Key mismatch for revoke: %s vs %s",
-			core.KeyDigest(requestKey),
-			core.KeyDigest(parsedCertificate.PublicKey)))
-		wfe.sendError(response,
-			"Revocation request must be signed by private key of cert to be revoked",
-			http.StatusForbidden)
-		return
-	}
-
-	err = wfe.CA.RevokeCertificate(revokeRequest.Serial)
-	if err != nil {
-		wfe.sendError(response,
-			"Failed to revoke certificate",
-			http.StatusInternalServerError)
-	} else {
-		fmt.Println("Revoked", revokeRequest.Serial)
 		response.WriteHeader(http.StatusOK)
 	}
 }

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -368,6 +368,83 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 		wfe.sendError(response, "No such certificate", http.StatusNotFound)
 		return
 	}
+
+	if certStatus.Status == core.OCSPStatusRevoked {
+		wfe.sendError(response, "Certificate already revoked", http.StatusConflict)
+		return
+	}
+
+	// TODO: Allow other types of keys.
+	if requestKey.Rsa == nil {
+		wfe.sendError(response, "Non-RSA keys not permitted.", http.StatusForbidden)
+		return
+	}
+	// TODO: Implement other methods of validating revocation, e.g. through
+	// authorizations on account.
+	if core.KeyDigest(requestKey.Rsa) != core.KeyDigest(parsedCertificate.PublicKey) {
+		wfe.log.Debug(fmt.Sprintf("Key mismatch for revoke: %s vs %s",
+			core.KeyDigest(requestKey),
+			core.KeyDigest(parsedCertificate.PublicKey)))
+		wfe.sendError(response,
+			"Revocation request must be signed by private key of cert to be revoked",
+			http.StatusForbidden)
+		return
+	}
+
+	err = wfe.CA.RevokeCertificate(revokeRequest.Serial)
+	if err != nil {
+		wfe.sendError(response,
+			"Failed to revoke certificate",
+			http.StatusInternalServerError)
+	} else {
+		wfe.log.Debug(fmt.Sprintf("Revoked %v", revokeRequest.Serial))
+		response.WriteHeader(http.StatusOK)
+	}
+}
+
+func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request *http.Request) {
+	if request.Method != "POST" {
+		wfe.sendError(response, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, requestKey, err := verifyPOST(request)
+	if err != nil {
+		wfe.sendError(response, "Unable to read/verify body", http.StatusBadRequest)
+		return
+	}
+
+	type RevokeRequest struct {
+		Serial string
+	}
+	var revokeRequest RevokeRequest
+	if err = json.Unmarshal(body, &revokeRequest); err != nil {
+		fmt.Println("Couldn't unmarshal in revoke request", string(body))
+		wfe.sendError(response, "Unable to read/verify body", http.StatusBadRequest)
+		return
+	}
+	if len(revokeRequest.Serial) != 32 {
+		wfe.log.Debug("Bad serial in revoke request " + revokeRequest.Serial)
+		wfe.sendError(response, "Unable to read/verify body", http.StatusBadRequest)
+		return
+	}
+
+	certDER, err := wfe.SA.GetCertificate(revokeRequest.Serial)
+	if err != nil {
+		wfe.sendError(response, "No such certificate", http.StatusNotFound)
+		return
+	}
+	parsedCertificate, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		wfe.sendError(response, "Invalid certificate", http.StatusInternalServerError)
+		return
+	}
+
+	certStatus, err := wfe.SA.GetCertificateStatus(revokeRequest.Serial)
+	if err != nil {
+		wfe.sendError(response, "No such certificate", http.StatusNotFound)
+		return
+	}
 	
 	if certStatus.Status == core.OCSPStatusRevoked {
 		wfe.sendError(response, "Certificate already revoked", http.StatusConflict)

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -28,7 +28,6 @@ import (
 type WebFrontEndImpl struct {
 	RA    core.RegistrationAuthority
 	SA    core.StorageGetter
-	CA    core.CertificateAuthority
 	Stats statsd.Statter
 	log   *blog.AuditLogger
 
@@ -394,7 +393,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 		return
 	}
 
-	err = wfe.CA.RevokeCertificate(serial)
+	err = wfe.RA.RevokeCertificate(*parsedCertificate)
 	if err != nil {
 		wfe.sendError(response,
 			"Failed to revoke certificate",


### PR DESCRIPTION
Note that this differs from the spec a bit. I moved the serial number into the POST body from the URL, because it should be integrity-protected by the JWS signature.