### PR TITLE
Challenge sanity check

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -7,6 +7,7 @@ package core
 
 import (
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"github.com/letsencrypt/boulder/jose"
 	"time"
@@ -187,7 +188,10 @@ func (ch Challenge) IsSane(completed bool) bool {
 			return false
 		}
 
-		if ch.Nonce == "" {
+		if ch.Nonce == "" || len(ch.Nonce) != 32 {
+			return false
+		}
+		if _, err := hex.DecodeString(ch.Nonce); err != nil {
 			return false
 		}
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -157,6 +157,10 @@ type Challenge struct {
 // Check the sanity of a challenge object before issued to the client (completed = false)
 // and before validation (completed = true).
 func (ch Challenge) IsSane(completed bool) bool {
+	if ch.Status != StatusPending {
+		return false
+	}
+
 	switch ch.Type {
 	case ChallengeTypeSimpleHTTPS:
 		// check extra fields aren't used

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestSanityCheck(t *testing.T) {
-	chall := Challenge {Type: ChallengeTypeSimpleHTTPS}
+	chall := Challenge{Type: ChallengeTypeSimpleHTTPS}
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.R = "bad"
 	chall.S = "bad"
 	chall.Nonce = "bad"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
-	chall = Challenge {Type: ChallengeTypeSimpleHTTPS, Path: "bad"}
+	chall = Challenge{Type: ChallengeTypeSimpleHTTPS, Path: "bad"}
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.Path = ""
 	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
@@ -31,11 +31,11 @@ func TestSanityCheck(t *testing.T) {
 	chall.Token = "KQqLsiS5j0CONR_eUXTUSUDNVaHODtc-0pD6ACif7U4"
 	test.Assert(t, chall.IsSane(false), "IsSane should be true")
 
-	chall = Challenge {Type: ChallengeTypeDVSNI}
+	chall = Challenge{Type: ChallengeTypeDVSNI}
 	chall.Path = "bad"
 	chall.Token = "bad"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
-	chall = Challenge {Type: ChallengeTypeDVSNI}
+	chall = Challenge{Type: ChallengeTypeDVSNI}
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.Nonce = "wutwut"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -39,6 +39,10 @@ func TestSanityCheck(t *testing.T) {
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.Nonce = "wutwut"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Nonce = "!2345678901234567890123456789012"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Nonce = "12345678901234567890123456789012"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.R = "notlongenough"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.R = "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+o!"
@@ -52,5 +56,4 @@ func TestSanityCheck(t *testing.T) {
 	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
 	chall.S = "KQqLsiS5j0CONR_eUXTUSUDNVaHODtc-0pD6ACif7U4"
 	test.Assert(t, chall.IsSane(true), "IsSane should be true")
-
 }

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -1,0 +1,56 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestSanityCheck(t *testing.T) {
+	chall := Challenge {Type: ChallengeTypeSimpleHTTPS}
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.R = "bad"
+	chall.S = "bad"
+	chall.Nonce = "bad"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall = Challenge {Type: ChallengeTypeSimpleHTTPS, Path: "bad"}
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Path = ""
+	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
+	chall.Token = ""
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Token = "notlongenough"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Token = "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+o!"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Token = "KQqLsiS5j0CONR_eUXTUSUDNVaHODtc-0pD6ACif7U4"
+	test.Assert(t, chall.IsSane(false), "IsSane should be true")
+
+	chall = Challenge {Type: ChallengeTypeDVSNI}
+	chall.Path = "bad"
+	chall.Token = "bad"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall = Challenge {Type: ChallengeTypeDVSNI}
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Nonce = "wutwut"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.R = "notlongenough"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.R = "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+o!"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.R = "KQqLsiS5j0CONR_eUXTUSUDNVaHODtc-0pD6ACif7U4"
+	test.Assert(t, chall.IsSane(false), "IsSane should be true")
+	chall.S = "anything"
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
+	chall.S = "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+o!"
+	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
+	chall.S = "KQqLsiS5j0CONR_eUXTUSUDNVaHODtc-0pD6ACif7U4"
+	test.Assert(t, chall.IsSane(true), "IsSane should be true")
+
+}

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -12,13 +12,15 @@ import (
 )
 
 func TestSanityCheck(t *testing.T) {
-	chall := Challenge{Type: ChallengeTypeSimpleHTTPS}
+	chall := Challenge{Type: ChallengeTypeSimpleHTTPS, Status: StatusValid}
+	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
+	chall.Status = StatusPending
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.R = "bad"
 	chall.S = "bad"
 	chall.Nonce = "bad"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
-	chall = Challenge{Type: ChallengeTypeSimpleHTTPS, Path: "bad"}
+	chall = Challenge{Type: ChallengeTypeSimpleHTTPS, Path: "bad", Status: StatusPending}
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.Path = ""
 	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
@@ -31,11 +33,11 @@ func TestSanityCheck(t *testing.T) {
 	chall.Token = "KQqLsiS5j0CONR_eUXTUSUDNVaHODtc-0pD6ACif7U4"
 	test.Assert(t, chall.IsSane(false), "IsSane should be true")
 
-	chall = Challenge{Type: ChallengeTypeDVSNI}
+	chall = Challenge{Type: ChallengeTypeDVSNI, Status: StatusPending}
 	chall.Path = "bad"
 	chall.Token = "bad"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
-	chall = Challenge{Type: ChallengeTypeDVSNI}
+	chall = Challenge{Type: ChallengeTypeDVSNI, Status: StatusPending}
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
 	chall.Nonce = "wutwut"
 	test.Assert(t, !chall.IsSane(false), "IsSane should be false")

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -83,6 +83,11 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 		// Ignoring these errors because we construct the URLs to be correct
 		challengeURI, _ := url.Parse(ra.AuthzBase + authID + "?challenge=" + strconv.Itoa(i))
 		challenges[i].URI = core.AcmeURL(*challengeURI)
+
+		if !challenges[i].IsSane(false) {
+			err = fmt.Errorf("Challenge didn't pass sanity check: %+v", challenges[i])
+			return
+		}
 	}
 
 	// Create a new authorization object

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -171,6 +171,11 @@ func (va ValidationAuthorityImpl) validate(authz core.Authorization) {
 	// Select the first supported validation method
 	// XXX: Remove the "break" lines to process all supported validations
 	for i, challenge := range authz.Challenges {
+		if !challenge.IsSane(true) {
+			challenge.Status = core.StatusInvalid
+			continue
+		}
+
 		switch challenge.Type {
 		case core.ChallengeTypeSimpleHTTPS:
 			authz.Challenges[i] = va.validateSimpleHTTPS(authz.Identifier, challenge)


### PR DESCRIPTION
Fix for #151, this adds the method `func (ch Challenge) IsSane(completed bool) bool` to `Challenge` so that we can check if a generated or client updated challenge is actually sane before we send it to the client or attempt to validate it.

I've used it in `VA.validate` to check before validation is attempted, if the check fails the status of the challenge is set to `core.StatusInvalid` and the validation is skipped. I've also add it to `RA.NewAuthorization` to check the resulting challenges provided by `PA.ChallengesFor` before they are sent to the client, if they aren't sane an error will be returned.