### PR TITLE
Serial conversion functions

### DIFF
--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -356,7 +356,7 @@ func TestRevoke(t *testing.T) {
 	}
 	cert, err := x509.ParseCertificate(certObj.DER)
 	test.AssertNotError(t, err, "Certificate failed to parse")
-	serialString := fmt.Sprintf("%032x", cert.SerialNumber)
+	serialString := core.SerialToString(cert.SerialNumber)
 	err = ca.RevokeCertificate(serialString)
 	test.AssertNotError(t, err, "Revocation failed")
 
@@ -415,7 +415,7 @@ func TestIssueCertificate(t *testing.T) {
 		}
 
 		// Verify that the cert got stored in the DB
-		serialString := fmt.Sprintf("%032x", cert.SerialNumber)
+		serialString := core.SerialToString(cert.SerialNumber)
 		certBytes, err := storageAuthority.GetCertificate(serialString)
 		test.AssertNotError(t, err,
 			fmt.Sprintf("Certificate %s not found in database", serialString))

--- a/core/util.go
+++ b/core/util.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	blog "github.com/letsencrypt/boulder/log"
 	"hash"
 	"io"
@@ -187,4 +188,17 @@ func VerifyCSR(csr *x509.CertificateRequest) error {
 	}
 
 	return errors.New("Unsupported CSR signing algorithm")
+}
+
+func SerialToString(serial *big.Int) string {
+	return fmt.Sprintf("%032x", serial)
+}
+
+func StringToSerial(serial string) (*big.Int, error)  {
+	var serialNum big.Int
+	if len(serial) != 32 {
+		return &serialNum, errors.New("Serial number should be 32 characters long")
+	}
+	_, err := fmt.Sscanf(serial, "%032x", &serialNum)
+	return &serialNum, err
 }

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"github.com/letsencrypt/boulder/test"
 	"math"
+	"math/big"
 )
 
 // challenges.go
@@ -33,4 +34,17 @@ func TestNewToken(t *testing.T) {
 func TestRandString(t *testing.T) {
   // This is covered by NewToken
   return
+}
+
+func TestSerialUtils(t *testing.T) {
+	serial := SerialToString(big.NewInt(100000000000000000))
+	test.AssertEquals(t, serial, "0000000000000000016345785d8a0000")
+
+	serialNum, err := StringToSerial("0000000000000000016345785d8a0000")
+	test.AssertNotError(t, err, "Couldn't convert serial number to *big.Int")
+	test.AssertBigIntEquals(t, serialNum, big.NewInt(100000000000000000))
+
+	badSerial, err := StringToSerial("doop!!!!000")
+	test.AssertEquals(t, fmt.Sprintf("%v", err), "Serial number should be 32 characters long")
+	fmt.Println(badSerial)
 }

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -240,7 +240,7 @@ func TestNewCertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to parse certificate")
 
 	// Verify that cert shows up and is as expected
-	dbCert, err := sa.GetCertificate(fmt.Sprintf("%032x", parsedCert.SerialNumber))
+	dbCert, err := sa.GetCertificate(core.SerialToString(parsedCert.SerialNumber))
 	test.AssertNotError(t, err, fmt.Sprintf("Could not fetch certificate %032x from database",
 		parsedCert.SerialNumber))
 	test.Assert(t, bytes.Compare(cert.DER, dbCert) == 0, "Certificates differ")

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -520,7 +520,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte) (digest string, e
 	if err != nil {
 		return
 	}
-	serial := fmt.Sprintf("%032x", parsedCertificate.SerialNumber)
+	serial := core.SerialToString(parsedCertificate.SerialNumber)
 
 	tx, err := ssa.db.Begin()
 	if err != nil {

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	"runtime"
 	"strings"
 	"testing"
@@ -70,6 +71,12 @@ func AssertByteEquals(t *testing.T, one []byte, two []byte) {
 
 func AssertIntEquals(t *testing.T, one int, two int) {
 	if one != two {
+		t.Errorf("%s Int [%d] != [%d]", caller(), one, two)
+	}
+}
+
+func AssertBigIntEquals(t *testing.T, one *big.Int, two *big.Int) {
+	if one.Cmp(two) != 0 {
 		t.Errorf("%s Int [%d] != [%d]", caller(), one, two)
 	}
 }


### PR DESCRIPTION
Per #142 this adds two functions `SerialToString(serial *big.Int) string` and `StringToSerial(serial string) (*big.Int, error)` and basic tests.