### PR TITLE
Reduce use of naked returns

### DIFF
--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -100,13 +100,15 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 	return
 }
 
-func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest, jwk jose.JsonWebKey) (cert core.Certificate, err error) {
+func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest, jwk jose.JsonWebKey) (core.Certificate, error) {
+	emptyCert := core.Certificate{}
+	var err error
 	// Verify the CSR
 	// TODO: Verify that other aspects of the CSR are appropriate
 	csr := req.CSR
 	if err = core.VerifyCSR(csr); err != nil {
 		err = core.UnauthorizedError("Invalid signature on CSR")
-		return
+		return emptyCert, err
 	}
 
 	// Gather authorized domains from the referenced authorizations
@@ -137,17 +139,22 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 	for _, name := range names {
 		if !authorizedDomains[name] {
 			err = core.UnauthorizedError(fmt.Sprintf("Key not authorized for name %s", name))
-			return
+			return emptyCert, err
 		}
 	}
 
 	// Create the certificate
+	var cert core.Certificate
 	ra.log.Audit(fmt.Sprintf("Issuing certificate for %s", names))
 	if cert, err = ra.CA.IssueCertificate(*csr); err != nil {
-		return
+		return emptyCert, err
 	}
 	cert.ParsedCertificate, err = x509.ParseCertificate([]byte(cert.DER))
-	return
+	if err != nil {
+		return emptyCert, err
+	}
+
+	return cert, nil
 }
 
 func (ra *RegistrationAuthorityImpl) UpdateRegistration(base core.Registration, update core.Registration) (reg core.Registration, err error) {

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -62,6 +62,7 @@ func amqpSubscribe(ch *amqp.Channel, name string) (msgs <-chan amqp.Delivery, er
 		nil)
 	if err != nil {
 		log.Fatalf("Could not declare exchange: %s", err)
+		return
 	}
 
 	q, err := ch.QueueDeclare(
@@ -73,6 +74,7 @@ func amqpSubscribe(ch *amqp.Channel, name string) (msgs <-chan amqp.Delivery, er
 		nil)
 	if err != nil {
 		log.Fatalf("Could not declare queue: %s", err)
+		return
 	}
 
 	err = ch.QueueBind(
@@ -83,6 +85,7 @@ func amqpSubscribe(ch *amqp.Channel, name string) (msgs <-chan amqp.Delivery, er
 		nil)
 	if err != nil {
 		log.Fatalf("Could not bind queue: %s", err)
+		return
 	}
 
 	msgs, err = ch.Consume(
@@ -95,6 +98,7 @@ func amqpSubscribe(ch *amqp.Channel, name string) (msgs <-chan amqp.Delivery, er
 		nil)
 	if err != nil {
 		log.Fatalf("Could not subscribe to queue: %s", err)
+		return
 	}
 
 	return

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -72,26 +72,26 @@ type certificateRequest struct {
 	Key jose.JsonWebKey
 }
 
-func NewRegistrationAuthorityServer(serverQueue string, channel *amqp.Channel, impl core.RegistrationAuthority) (rpc *AmqpRPCServer, err error) {
-	rpc = NewAmqpRPCServer(serverQueue, channel)
+func NewRegistrationAuthorityServer(serverQueue string, channel *amqp.Channel, impl core.RegistrationAuthority) (*AmqpRPCServer, error) {
+	rpc := NewAmqpRPCServer(serverQueue, channel)
 
 	rpc.Handle(MethodNewRegistration, func(req []byte) (response []byte) {
 		var rr registrationRequest
 		err := json.Unmarshal(req, &rr)
 		if err != nil {
-			return
+			return nil
 		}
 
 		reg, err := impl.NewRegistration(rr.Reg, rr.Key)
 		if err != nil {
-			return
+			return nil
 		}
 
 		response, err = json.Marshal(reg)
 		if err != nil {
 			response = []byte{}
 		}
-		return
+		return response
 	})
 
 	rpc.Handle(MethodNewAuthorization, func(req []byte) (response []byte) {
@@ -142,19 +142,19 @@ func NewRegistrationAuthorityServer(serverQueue string, channel *amqp.Channel, i
 		}
 		err := json.Unmarshal(req, &request)
 		if err != nil {
-			return
+			return nil
 		}
 
 		reg, err := impl.UpdateRegistration(request.Base, request.Update)
 		if err != nil {
-			return
+			return nil
 		}
 
 		response, err = json.Marshal(reg)
 		if err != nil {
 			response = []byte{}
 		}
-		return
+		return response
 	})
 
 	rpc.Handle(MethodUpdateAuthorization, func(req []byte) (response []byte) {
@@ -165,7 +165,7 @@ func NewRegistrationAuthorityServer(serverQueue string, channel *amqp.Channel, i
 		}
 		err := json.Unmarshal(req, &authz)
 		if err != nil {
-			return
+			return nil
 		}
 
 		newAuthz, err := impl.UpdateAuthorization(authz.Authz, authz.Index, authz.Response)
@@ -416,21 +416,21 @@ func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateReque
 	return
 }
 
-func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl core.StorageAuthority) (rpc *AmqpRPCServer) {
-	rpc = NewAmqpRPCServer(serverQueue, channel)
+func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl core.StorageAuthority) (*AmqpRPCServer) {
+	rpc := NewAmqpRPCServer(serverQueue, channel)
 
 	rpc.Handle(MethodGetRegistration, func(req []byte) (response []byte) {
 		reg, err := impl.GetRegistration(string(req))
 		if err != nil {
-			return
+			return nil
 		}
 
 		jsonReg, err := json.Marshal(reg)
 		if err != nil {
-			return
+			return nil
 		}
 		response = jsonReg
-		return
+		return response
 	})
 
 	rpc.Handle(MethodGetAuthorization, func(req []byte) []byte {
@@ -467,7 +467,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 		if err == nil {
 			response = []byte(id)
 		}
-		return
+		return response
 	})
 
 	rpc.Handle(MethodUpdatePendingAuthorization, func(req []byte) []byte {
@@ -499,7 +499,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 		if err == nil {
 			response = []byte(cert)
 		}
-		return
+		return response
 	})
 
 	rpc.Handle(MethodGetCertificateByShortSerial, func(req []byte) (response []byte) {
@@ -507,10 +507,10 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 		if err == nil {
 			response = []byte(cert)
 		}
-		return
+		return response
 	})
 
-	return
+	return rpc
 }
 
 type StorageAuthorityClient struct {


### PR DESCRIPTION
or ***The great enrobing!***

Fixes for #152 as well as various `return` related cleanups, I've left naked returns on most smaller functions (~ <30 lines) where readability doesn't really suffer too much.