### PR TITLE
Issuer cert endpoint + up links

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -34,7 +34,7 @@ type Config struct {
 	DBDriver     string
 	DBName       string
 	SerialPrefix int
-	// A PEM-encoded copy of the issuer certificate.
+	// Path to a PEM-encoded copy of the issuer certificate.
 	IssuerCert string
 	// This field is only allowed if TestMode is true, indicating that we are
 	// signing with a local key. In production we will use an HSM and this

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -83,15 +82,8 @@ func main() {
 		wfe.SA = &sac
 		wfe.Stats = stats
 
-		if c.CA.IssuerCert == "" {
-			fmt.Fprintf(os.Stderr, "Issuer certificate was not provided in config.\n")
-			os.Exit(1)
-		}
-		certPem, err := ioutil.ReadFile(c.CA.IssuerCert)
-		if err != nil {
-			cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
-		}
-		wfe.IssuerCert = string(certPem)
+		wfe.IssuerCert, err = cmd.LoadCert(c.CA.IssuerCert)
+		cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
 
 		go cmd.ProfileCmd("WFE", stats)
 

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -7,7 +7,9 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
@@ -80,6 +82,16 @@ func main() {
 		wfe.RA = &rac
 		wfe.SA = &sac
 		wfe.Stats = stats
+
+		if c.CA.IssuerCert == "" {
+			fmt.Fprintf(os.Stderr, "Issuer certificate was not provided in config.\n")
+			os.Exit(1)
+		}
+		certPem, err := ioutil.ReadFile(c.CA.IssuerCert)
+		if err != nil {
+			cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
+		}
+		wfe.IssuerCert = string(certPem)
 
 		go cmd.ProfileCmd("WFE", stats)
 

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -90,15 +89,8 @@ func main() {
 		wfe.SA = sa
 		wfe.Stats = stats
 
-		if c.CA.IssuerCert == "" {
-			fmt.Fprintf(os.Stderr, "Issuer certificate was not provided in config.\n")
-			os.Exit(1)
-		}
-		certPem, err := ioutil.ReadFile(c.CA.IssuerCert)
-		if err != nil {
-			cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
-		}
-		wfe.IssuerCert = string(certPem)
+		wfe.IssuerCert, err = cmd.LoadCert(c.CA.IssuerCert)
+		cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
 
 		ra.CA = ca
 		ra.SA = sa

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -88,6 +89,17 @@ func main() {
 		wfe.RA = &ra
 		wfe.SA = sa
 		wfe.Stats = stats
+
+		if c.CA.IssuerCert == "" {
+			fmt.Fprintf(os.Stderr, "Issuer certificate was not provided in config.\n")
+			os.Exit(1)
+		}
+		certPem, err := ioutil.ReadFile(c.CA.IssuerCert)
+		if err != nil {
+			cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
+		}
+		wfe.IssuerCert = string(certPem)
+
 		ra.CA = ca
 		ra.SA = sa
 		ra.VA = &va

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -194,4 +195,17 @@ func ProfileCmd(profileName string, stats statsd.Statter) {
 
 		time.Sleep(time.Second)
 	}
+}
+
+func LoadCert(path string) (cert string, err error) {
+	if path == "" {
+		err = errors.New("Issuer certificate was not provided in config.")
+		return
+	}
+	pemBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+	cert = string(pemBytes)
+	return
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -197,7 +198,7 @@ func ProfileCmd(profileName string, stats statsd.Statter) {
 	}
 }
 
-func LoadCert(path string) (cert string, err error) {
+func LoadCert(path string) (cert []byte, err error) {
 	if path == "" {
 		err = errors.New("Issuer certificate was not provided in config.")
 		return
@@ -206,6 +207,13 @@ func LoadCert(path string) (cert string, err error) {
 	if err != nil {
 		return
 	}
-	cert = string(pemBytes)
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE" {
+		err = errors.New("Invalid certificate value returned")
+		return
+	}
+
+	cert = block.Bytes
 	return
 }

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -537,7 +537,6 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 		}
 
 		// TODO: Content negotiation
-		// TODO: Link header
 		response.Header().Set("Content-Type", "application/pkix-cert")
 		response.Header().Add("Link", link(wfe.IssuerPath, "up"))
 		response.WriteHeader(http.StatusOK)

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -46,8 +46,8 @@ type WebFrontEndImpl struct {
 	TermsPath    string
 	IssuerPath   string
 
-	// Issuer certificate (pem) for /acme/issuer-cert
-	IssuerCert   string
+	// Issuer certificate (DER) for /acme/issuer-cert
+	IssuerCert   []byte
 }
 
 func NewWebFrontEndImpl() WebFrontEndImpl {
@@ -558,5 +558,10 @@ func (wfe *WebFrontEndImpl) Terms(w http.ResponseWriter, r *http.Request) {
 }
 
 func (wfe *WebFrontEndImpl) Issuer(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, wfe.IssuerCert)
+	w.Header().Add("Location", wfe.IssuerPath)
+	w.Header().Set("Content-Type", "application/pkix-cert")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(wfe.IssuerCert); err != nil {
+		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
+	}
 }

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -554,7 +554,7 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 }
 
 func (wfe *WebFrontEndImpl) Terms(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "You agree to do the right thing yo")
+	fmt.Fprintf(w, "You agree to do the right thing")
 }
 
 func (wfe *WebFrontEndImpl) Issuer(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fix for #160.

I couldn't find anywhere in the spec that specifies how the server should pass the issuer cert to the client so I've just stored it in the `wfe` struct as a PEM encoded string. I've also modified a comment in the `ca.Config` struct to reflect the fact that a field is a path not a PEM string.