### PR TITLE
Send complete problem docs

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -146,14 +146,33 @@ func parseIDFromPath(path string) string {
 // Problem objects represent problem documents, which are
 // returned with HTTP error responses
 // https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00
+type ProblemType string
+
 type problem struct {
-	Type     string `json:"type,omitempty"`
-	Detail   string `json:"detail,omitempty"`
-	Instance string `json:"instance,omitempty"`
+	Type     ProblemType `json:"type,omitempty"`
+	Detail   string      `json:"detail,omitempty"`
 }
+
+const (
+	MalformedProblem      = ProblemType("malformed")
+	UnauthorizedProblem   = ProblemType("unauthorized")
+	ServerInternalProblem = ProblemType("serverInternal")
+)
 
 func (wfe *WebFrontEndImpl) sendError(response http.ResponseWriter, message string, code int) {
 	problem := problem{Detail: message}
+	switch code {
+	case http.StatusForbidden:
+		problem.Type = UnauthorizedProblem
+	case http.StatusMethodNotAllowed:
+		fallthrough
+	case http.StatusNotFound:
+		fallthrough
+	case http.StatusBadRequest:
+		problem.Type = MalformedProblem
+	case http.StatusInternalServerError:
+		problem.Type = ServerInternalProblem
+	}
 	problemDoc, err := json.Marshal(problem)
 	if err != nil {
 		problemDoc = []byte("{\"detail\": \"Problem marshalling error message.\"}")

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -154,9 +154,9 @@ type problem struct {
 }
 
 const (
-	MalformedProblem      = ProblemType("malformed")
-	UnauthorizedProblem   = ProblemType("unauthorized")
-	ServerInternalProblem = ProblemType("serverInternal")
+	MalformedProblem      = ProblemType("urn:acme:error:malformed")
+	UnauthorizedProblem   = ProblemType("urn:acme:error:unauthorized")
+	ServerInternalProblem = ProblemType("urn:acme:error:serverInternal")
 )
 
 func (wfe *WebFrontEndImpl) sendError(response http.ResponseWriter, message string, code int) {

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -74,7 +74,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Method not allowed\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Method not allowed\"}")
 
 	// POST, but no body.
 	responseWriter.Body.Reset()
@@ -83,7 +83,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
@@ -93,7 +93,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -116,7 +116,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling certificate request\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Error unmarshaling certificate request\"}")
 
 	// Same signed body, but payload modified by one byte, breaking signature.
 	// should fail JWS verification.
@@ -140,7 +140,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// Valid, signed JWS body, payload is '{}'
 	responseWriter.Body.Reset()
@@ -163,7 +163,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling certificate request\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Error unmarshaling certificate request\"}")
 
 	// Valid, signed JWS body, payload has a legit CSR but no authorizations:
 	// {
@@ -192,7 +192,7 @@ func TestIssueCertificate(t *testing.T) {
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
 		// TODO: I think this is wrong. The CSR in the payload above was created by openssl and should be valid.
-		"{\"type\":\"malformed\",\"detail\":\"Error creating new cert: Invalid signature on CSR\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Error creating new cert: Invalid signature on CSR\"}")
 }
 
 type MockRegistrationAuthority struct{}
@@ -294,14 +294,14 @@ func TestRegistration(t *testing.T) {
 	wfe.NewRegistration(responseWriter, &http.Request{
 		Method: "GET",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Method not allowed\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Method not allowed\"}")
 
 	// POST, but no body.
 	responseWriter.Body.Reset()
 	wfe.NewRegistration(responseWriter, &http.Request{
 		Method: "POST",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
@@ -309,7 +309,7 @@ func TestRegistration(t *testing.T) {
 		Method: "POST",
 		Body:   makeBody("hi"),
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -332,7 +332,7 @@ func TestRegistration(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling JSON\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Error unmarshaling JSON\"}")
 
 	// Same signed body, but payload modified by one byte, breaking signature.
 	// should fail JWS verification.
@@ -356,7 +356,7 @@ func TestRegistration(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	key, _ := rsa.GenerateKey(rand.Reader, 512)
 	jws, err := jose.Sign(jose.RSAPSSWithSHA256, *key, []byte("{\"contact\":[\"tel:123456789\"]}"))
@@ -386,14 +386,14 @@ func TestAuthorization(t *testing.T) {
 	wfe.NewAuthorization(responseWriter, &http.Request{
 		Method: "GET",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Method not allowed\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Method not allowed\"}")
 
 	// POST, but no body.
 	responseWriter.Body.Reset()
 	wfe.NewAuthorization(responseWriter, &http.Request{
 		Method: "POST",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
@@ -401,7 +401,7 @@ func TestAuthorization(t *testing.T) {
 		Method: "POST",
 		Body:   makeBody("hi"),
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -424,7 +424,7 @@ func TestAuthorization(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling JSON\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Error unmarshaling JSON\"}")
 
 	// Same signed body, but payload modified by one byte, breaking signature.
 	// should fail JWS verification.
@@ -448,7 +448,7 @@ func TestAuthorization(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	key, _ := rsa.GenerateKey(rand.Reader, 512)
 	jws, err := jose.Sign(jose.RSAPSSWithSHA256, *key, []byte("{\"identifier\":{\"type\":\"dns\",\"value\":\"test.com\"}}"))

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -74,7 +74,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Method not allowed\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Method not allowed\"}")
 
 	// POST, but no body.
 	responseWriter.Body.Reset()
@@ -83,7 +83,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
@@ -93,7 +93,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -116,7 +116,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Error unmarshaling certificate request\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling certificate request\"}")
 
 	// Same signed body, but payload modified by one byte, breaking signature.
 	// should fail JWS verification.
@@ -140,7 +140,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// Valid, signed JWS body, payload is '{}'
 	responseWriter.Body.Reset()
@@ -163,7 +163,7 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Error unmarshaling certificate request\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling certificate request\"}")
 
 	// Valid, signed JWS body, payload has a legit CSR but no authorizations:
 	// {
@@ -192,7 +192,7 @@ func TestIssueCertificate(t *testing.T) {
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
 		// TODO: I think this is wrong. The CSR in the payload above was created by openssl and should be valid.
-		"{\"detail\":\"Error creating new cert: Invalid signature on CSR\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Error creating new cert: Invalid signature on CSR\"}")
 }
 
 type MockRegistrationAuthority struct{}
@@ -294,14 +294,14 @@ func TestRegistration(t *testing.T) {
 	wfe.NewRegistration(responseWriter, &http.Request{
 		Method: "GET",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"detail\":\"Method not allowed\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Method not allowed\"}")
 
 	// POST, but no body.
 	responseWriter.Body.Reset()
 	wfe.NewRegistration(responseWriter, &http.Request{
 		Method: "POST",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
@@ -309,7 +309,7 @@ func TestRegistration(t *testing.T) {
 		Method: "POST",
 		Body:   makeBody("hi"),
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -332,7 +332,7 @@ func TestRegistration(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Error unmarshaling JSON\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling JSON\"}")
 
 	// Same signed body, but payload modified by one byte, breaking signature.
 	// should fail JWS verification.
@@ -356,7 +356,7 @@ func TestRegistration(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	key, _ := rsa.GenerateKey(rand.Reader, 512)
 	jws, err := jose.Sign(jose.RSAPSSWithSHA256, *key, []byte("{\"contact\":[\"tel:123456789\"]}"))
@@ -386,14 +386,14 @@ func TestAuthorization(t *testing.T) {
 	wfe.NewAuthorization(responseWriter, &http.Request{
 		Method: "GET",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"detail\":\"Method not allowed\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Method not allowed\"}")
 
 	// POST, but no body.
 	responseWriter.Body.Reset()
 	wfe.NewAuthorization(responseWriter, &http.Request{
 		Method: "POST",
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
@@ -401,7 +401,7 @@ func TestAuthorization(t *testing.T) {
 		Method: "POST",
 		Body:   makeBody("hi"),
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"detail\":\"Unable to read/verify body\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -424,7 +424,7 @@ func TestAuthorization(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Error unmarshaling JSON\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Error unmarshaling JSON\"}")
 
 	// Same signed body, but payload modified by one byte, breaking signature.
 	// should fail JWS verification.
@@ -448,7 +448,7 @@ func TestAuthorization(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		"{\"detail\":\"Unable to read/verify body\"}")
+		"{\"type\":\"malformed\",\"detail\":\"Unable to read/verify body\"}")
 
 	key, _ := rsa.GenerateKey(rand.Reader, 512)
 	jws, err := jose.Sign(jose.RSAPSSWithSHA256, *key, []byte("{\"identifier\":{\"type\":\"dns\",\"value\":\"test.com\"}}"))


### PR DESCRIPTION
Fix for #128 (also removes `Instance` field per per @jsha's IRC comments).

*Note*: I've ignored the `badCSR` problem type since it seems to really fall under the `malformed` type (and it breaks the way I've *guessed* the type based on status code) but if this is necessary it would be simple to adjust `sendError` to just take the problem type as a argument.