### PR TITLE
Fix RPC build (issue #171)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,11 @@ before_install:
   - go get github.com/modocache/gover
 
 script:
+  - go build cmd/activity-monitor/main.go
+  - go build cmd/boulder/main.go
+  - go build cmd/boulder-ca/main.go
+  - go build cmd/boulder-ra/main.go
+  - go build cmd/boulder-sa/main.go
+  - go build cmd/boulder-va/main.go
+  - go build cmd/boulder-wfe/main.go
   - bash test.sh

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -41,10 +41,13 @@ const (
 	MethodOnValidationUpdate         = "OnValidationUpdate"         // RA
 	MethodUpdateValidations          = "UpdateValidations"          // VA
 	MethodIssueCertificate           = "IssueCertificate"           // CA
+	MethodRevokeCertificateCA        = "RevokeCertificateCA"        // CA
 	MethodGetRegistration            = "GetRegistration"            // SA
 	MethodGetAuthorization           = "GetAuthorization"           // SA
 	MethodGetCertificate             = "GetCertificate"             // SA
 	MethodGetCertificateByShortSerial = "GetCertificateByShortSerial" // SA
+	MethodGetCertificateStatus       = "GetCertificateStatus"       // SA
+	MethodMarkCertificateRevoked     = "MarkCertificateRevoked"     // SA
 	MethodNewPendingAuthorization    = "NewPendingAuthorization"    // SA
 	MethodUpdatePendingAuthorization = "UpdatePendingAuthorization" // SA
 	MethodFinalizeAuthorization      = "FinalizeAuthorization"      // SA
@@ -388,6 +391,11 @@ func NewCertificateAuthorityServer(serverQueue string, channel *amqp.Channel, im
 		return serialized
 	})
 
+  rpc.Handle(MethodRevokeCertificateCA, func(req []byte) []byte {
+    _ = impl.RevokeCertificate(string(req)) // XXX
+    return nil
+  })
+
 	return
 }
 
@@ -414,6 +422,11 @@ func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateReque
 
 	err = json.Unmarshal(jsonResponse, &cert)
 	return
+}
+
+func (cac CertificateAuthorityClient) RevokeCertificate(serial string) (err error) {
+  _, err = cac.rpc.DispatchSync(MethodRevokeCertificateCA, []byte(serial))
+  return
 }
 
 func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl core.StorageAuthority) (*AmqpRPCServer) {
@@ -510,6 +523,36 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 		return response
 	})
 
+	rpc.Handle(MethodGetCertificateStatus, func(req []byte) (response []byte) {
+		status, err := impl.GetCertificateStatus(string(req))
+		if err != nil {
+			return nil
+		}
+
+		jsonStatus, err := json.Marshal(status)
+		if err != nil {
+			return nil
+		}
+		return jsonStatus
+	})
+
+	rpc.Handle(MethodMarkCertificateRevoked, func(req []byte) (response []byte) {
+		var revokeReq struct {
+			Serial				string
+			OcspResponse	[]byte
+			ReasonCode		int
+		}
+
+		err := json.Unmarshal(req, revokeReq)
+		if err != nil {
+			return nil
+		}
+
+		// Error explicitly ignored since response is nil anyway
+		_ = impl.MarkCertificateRevoked(revokeReq.Serial, revokeReq.OcspResponse, revokeReq.ReasonCode)
+		return nil
+	})
+
 	return rpc
 }
 
@@ -549,6 +592,41 @@ func (cac StorageAuthorityClient) GetAuthorization(id string) (authz core.Author
 
 func (cac StorageAuthorityClient) GetCertificate(id string) (cert []byte, err error) {
 	cert, err = cac.rpc.DispatchSync(MethodGetCertificate, []byte(id))
+	return
+}
+
+func (cac StorageAuthorityClient) GetCertificateByShortSerial(id string) (cert []byte, err error) {
+	cert, err = cac.rpc.DispatchSync(MethodGetCertificateByShortSerial, []byte(id))
+	return
+}
+
+func (cac StorageAuthorityClient) GetCertificateStatus(id string) (status core.CertificateStatus, err error) {
+	jsonStatus, err := cac.rpc.DispatchSync(MethodGetCertificateStatus, []byte(id))
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(jsonStatus, &status)
+	return
+}
+
+func (cac StorageAuthorityClient) MarkCertificateRevoked(serial string, ocspResponse []byte, reasonCode int) (err error) {
+	var revokeReq struct {
+		Serial   			string
+		OcspResponse	[]byte
+		ReasonCode    int
+	}
+
+	revokeReq.Serial = serial
+	revokeReq.OcspResponse = ocspResponse
+	revokeReq.ReasonCode = reasonCode
+
+	data, err := json.Marshal(revokeReq)
+	if err != nil {
+		return
+	}
+
+	_, err = cac.rpc.DispatchSync(MethodMarkCertificateRevoked, data)
 	return
 }
 

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -32,26 +32,26 @@ import (
 // so it doesn't need wrappers.
 
 const (
-	MethodNewRegistration            = "NewRegistration"            // RA, SA
-	MethodNewAuthorization           = "NewAuthorization"           // RA
-	MethodNewCertificate             = "NewCertificate"             // RA
-	MethodUpdateRegistration         = "UpdateRegistration"         // RA, SA
-	MethodUpdateAuthorization        = "UpdateAuthorization"        // RA
-	MethodRevokeCertificate          = "RevokeCertificate"          // RA
-	MethodOnValidationUpdate         = "OnValidationUpdate"         // RA
-	MethodUpdateValidations          = "UpdateValidations"          // VA
-	MethodIssueCertificate           = "IssueCertificate"           // CA
-	MethodRevokeCertificateCA        = "RevokeCertificateCA"        // CA
-	MethodGetRegistration            = "GetRegistration"            // SA
-	MethodGetAuthorization           = "GetAuthorization"           // SA
-	MethodGetCertificate             = "GetCertificate"             // SA
+	MethodNewRegistration             = "NewRegistration"             // RA, SA
+	MethodNewAuthorization            = "NewAuthorization"            // RA
+	MethodNewCertificate              = "NewCertificate"              // RA
+	MethodUpdateRegistration          = "UpdateRegistration"          // RA, SA
+	MethodUpdateAuthorization         = "UpdateAuthorization"         // RA
+	MethodRevokeCertificate           = "RevokeCertificate"           // RA
+	MethodOnValidationUpdate          = "OnValidationUpdate"          // RA
+	MethodUpdateValidations           = "UpdateValidations"           // VA
+	MethodIssueCertificate            = "IssueCertificate"            // CA
+	MethodRevokeCertificateCA         = "RevokeCertificateCA"         // CA
+	MethodGetRegistration             = "GetRegistration"             // SA
+	MethodGetAuthorization            = "GetAuthorization"            // SA
+	MethodGetCertificate              = "GetCertificate"              // SA
 	MethodGetCertificateByShortSerial = "GetCertificateByShortSerial" // SA
-	MethodGetCertificateStatus       = "GetCertificateStatus"       // SA
-	MethodMarkCertificateRevoked     = "MarkCertificateRevoked"     // SA
-	MethodNewPendingAuthorization    = "NewPendingAuthorization"    // SA
-	MethodUpdatePendingAuthorization = "UpdatePendingAuthorization" // SA
-	MethodFinalizeAuthorization      = "FinalizeAuthorization"      // SA
-	MethodAddCertificate             = "AddCertificate"             // SA
+	MethodGetCertificateStatus        = "GetCertificateStatus"        // SA
+	MethodMarkCertificateRevoked      = "MarkCertificateRevoked"      // SA
+	MethodNewPendingAuthorization     = "NewPendingAuthorization"     // SA
+	MethodUpdatePendingAuthorization  = "UpdatePendingAuthorization"  // SA
+	MethodFinalizeAuthorization       = "FinalizeAuthorization"       // SA
+	MethodAddCertificate              = "AddCertificate"              // SA
 )
 
 // RegistrationAuthorityClient / Server
@@ -391,10 +391,10 @@ func NewCertificateAuthorityServer(serverQueue string, channel *amqp.Channel, im
 		return serialized
 	})
 
-  rpc.Handle(MethodRevokeCertificateCA, func(req []byte) []byte {
-    _ = impl.RevokeCertificate(string(req)) // XXX
-    return nil
-  })
+	rpc.Handle(MethodRevokeCertificateCA, func(req []byte) []byte {
+		_ = impl.RevokeCertificate(string(req)) // XXX
+		return nil
+	})
 
 	return
 }
@@ -425,11 +425,11 @@ func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateReque
 }
 
 func (cac CertificateAuthorityClient) RevokeCertificate(serial string) (err error) {
-  _, err = cac.rpc.DispatchSync(MethodRevokeCertificateCA, []byte(serial))
-  return
+	_, err = cac.rpc.DispatchSync(MethodRevokeCertificateCA, []byte(serial))
+	return
 }
 
-func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl core.StorageAuthority) (*AmqpRPCServer) {
+func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl core.StorageAuthority) *AmqpRPCServer {
 	rpc := NewAmqpRPCServer(serverQueue, channel)
 
 	rpc.Handle(MethodGetRegistration, func(req []byte) (response []byte) {
@@ -538,9 +538,9 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 
 	rpc.Handle(MethodMarkCertificateRevoked, func(req []byte) (response []byte) {
 		var revokeReq struct {
-			Serial				string
-			OcspResponse	[]byte
-			ReasonCode		int
+			Serial       string
+			OcspResponse []byte
+			ReasonCode   int
 		}
 
 		err := json.Unmarshal(req, revokeReq)
@@ -612,9 +612,9 @@ func (cac StorageAuthorityClient) GetCertificateStatus(id string) (status core.C
 
 func (cac StorageAuthorityClient) MarkCertificateRevoked(serial string, ocspResponse []byte, reasonCode int) (err error) {
 	var revokeReq struct {
-		Serial   			string
-		OcspResponse	[]byte
-		ReasonCode    int
+		Serial       string
+		OcspResponse []byte
+		ReasonCode   int
 	}
 
 	revokeReq.Serial = serial


### PR DESCRIPTION
A prior change caused AMQP-enabled builds to fail due to missing handlers. This resolves that, and also adds scripted actions to Travis to verify the AMQP commands build.