### PR TITLE
Stop LockCol from being marshalled

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -112,8 +112,7 @@ type Registration struct {
 	// Agreement with terms of service
 	Agreement string `json:"agreement,omitempty" db:"agreement"`
 
-	//
-	Thumbprint        string `db:"thumbprint"`
+	Thumbprint string `json:"thumbprint" db:"thumbprint"`
 
 	LockCol int64 `json:"-"`
 }

--- a/core/objects.go
+++ b/core/objects.go
@@ -115,7 +115,7 @@ type Registration struct {
 	//
 	Thumbprint        string `db:"thumbprint"`
 
-	LockCol int64
+	LockCol int64 `json:"-"`
 }
 
 func (r *Registration) MergeUpdate(input Registration) {
@@ -333,7 +333,7 @@ type CertificateStatus struct {
 	//   code for 'unspecified').
 	RevokedReason          int `db:"revokedReason"`
 
-	LockCol int64
+	LockCol int64 `json:"-"`
 }
 
 // A large table of OCSP responses. This contains all historical OCSP		

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -369,6 +369,7 @@ func TestRegistration(t *testing.T) {
 		Body: makeBody(string(requestPayload)),
 	})
 
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"key\":{},\"recoveryToken\":\"\",\"contact\":[\"tel:123456789\"],\"thumbprint\":\"\"}")
 	var reg core.Registration
 	err = json.Unmarshal([]byte(responseWriter.Body.String()), &reg)
 	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")
@@ -460,4 +461,10 @@ func TestAuthorization(t *testing.T) {
 		Method: "POST",
 		Body: makeBody(string(requestPayload)),
 	})
+
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"identifier\":{\"type\":\"dns\",\"value\":\"test.com\"},\"key\":{},\"expires\":\"0001-01-01T00:00:00Z\"}")
+
+	var authz core.Authorization
+	err = json.Unmarshal([]byte(responseWriter.Body.String()), &authz)
+	test.AssertNotError(t, err, "Couldn't unmarshal returned authorization object")
 }


### PR DESCRIPTION
Adds the anonymous JSON field struct tags (``` `json:"-"` ```) as specified in the `json` [documentation](https://golang.org/pkg/encoding/json/#Marshal) to stop them from being outputted when core objects are marshaled to JSON in the `WFE`. Fix for #180.