### PR TITLE
Check key is assosiated with existing registration in verifyPOST

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -89,6 +89,7 @@ type PolicyAuthority interface {
 
 type StorageGetter interface {
 	GetRegistration(string) (Registration, error)
+	GetRegistrationByKey(jose.JsonWebKey) (Registration, error)
 	GetAuthorization(string) (Authorization, error)
 	GetCertificate(string) ([]byte, error)
 	GetCertificateByShortSerial(string) ([]byte, error)

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -311,7 +311,7 @@ func (ssa *SQLStorageAuthority) GetRegistration(id string) (reg core.Registratio
 }
 
 func (ssa *SQLStorageAuthority) GetRegistrationByKey(key jose.JsonWebKey) (reg core.Registration, err error) {
-	keyJson, err := key.MarshalJSON()
+	keyJson, err := json.Marshal(key)
 	if err != nil {
 		return
 	}

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -310,6 +310,16 @@ func (ssa *SQLStorageAuthority) GetRegistration(id string) (reg core.Registratio
 	return
 }
 
+func (ssa *SQLStorageAuthority) GetRegistrationByKey(key jose.JsonWebKey) (reg core.Registration, err error) {
+	keyJson, err := key.MarshalJSON()
+	if err != nil {
+		return
+	}
+
+	err = ssa.dbMap.SelectOne(&reg, "SELECT * FROM registrations WHERE key = :key", map[string]interface{} {"key": string(keyJson)})
+	return
+}
+
 func (ssa *SQLStorageAuthority) GetAuthorization(id string) (authz core.Authorization, err error) {
 	tx, err := ssa.dbMap.Begin()
 	if err != nil {

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -66,7 +66,14 @@ func TestAddRegistration(t *testing.T) {
 
 	newReg := core.Registration{ID: reg.ID, Key: jwk, RecoveryToken: "RBNvo1WzZ4oRRq0W9", Contact: []core.AcmeURL{u}, Agreement: "yes"}
 	err = sa.UpdateRegistration(newReg)
-	test.AssertNotError(t, err, "Couldn't update registration with ID "+reg.ID)
+	test.AssertNotError(t, err, "Couldn't update registration with ID "+regID)
+
+	dbReg, err = sa.GetRegistrationByKey(jwk)
+	test.AssertNotError(t, err, "Couldn't update registration by key")
+
+	test.AssertEquals(t, dbReg.ID, newReg.ID)
+	test.AssertEquals(t, dbReg.RecoveryToken, newReg.RecoveryToken)
+	test.AssertEquals(t, dbReg.Agreement, newReg.Agreement)
 }
 
 func TestAddAuthorization(t *testing.T) {

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -66,7 +66,7 @@ func TestAddRegistration(t *testing.T) {
 
 	newReg := core.Registration{ID: reg.ID, Key: jwk, RecoveryToken: "RBNvo1WzZ4oRRq0W9", Contact: []core.AcmeURL{u}, Agreement: "yes"}
 	err = sa.UpdateRegistration(newReg)
-	test.AssertNotError(t, err, "Couldn't update registration with ID "+regID)
+	test.AssertNotError(t, err, "Couldn't update registration with ID "+reg.ID)
 
 	dbReg, err = sa.GetRegistrationByKey(jwk)
 	test.AssertNotError(t, err, "Couldn't update registration by key")

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -25,6 +25,34 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
+type MockSA struct {
+	// empty
+}
+
+func (sa *MockSA) GetRegistration(string) (core.Registration, error) {
+	return core.Registration{}, nil
+}
+
+func (sa *MockSA) GetRegistrationByKey(jose.JsonWebKey) (core.Registration, error) {
+	return core.Registration{}, nil
+}
+
+func (sa *MockSA) GetAuthorization(string) (core.Authorization, error) {
+	return core.Authorization{}, nil
+}
+
+func (sa *MockSA) GetCertificate(string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (sa *MockSA) GetCertificateByShortSerial(string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (sa *MockSA) GetCertificateStatus(string) (core.CertificateStatus, error) {
+	return core.CertificateStatus{}, nil
+}
+
 func makeBody(s string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(s))
 }
@@ -65,7 +93,6 @@ func TestIndex(t *testing.T) {
 	})
 	//test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
 	test.AssertEquals(t, responseWriter.Body.String(), "404 page not found\n")
-
 }
 
 // TODO: Write additional test cases for:
@@ -75,6 +102,7 @@ func TestIssueCertificate(t *testing.T) {
 	// TODO: Use a mock RA so we can test various conditions of authorized, not authorized, etc.
 	ra := ra.NewRegistrationAuthorityImpl()
 	wfe := NewWebFrontEndImpl()
+	wfe.SA = &MockSA{}
 	wfe.RA = &ra
 	responseWriter := httptest.NewRecorder()
 
@@ -239,6 +267,7 @@ func (ra *MockRegistrationAuthority) OnValidationUpdate(authz core.Authorization
 func TestChallenge(t *testing.T) {
 	wfe := NewWebFrontEndImpl()
 	wfe.RA = &MockRegistrationAuthority{}
+	wfe.SA = &MockSA{}
 	wfe.HandlePaths()
 	responseWriter := httptest.NewRecorder()
 
@@ -299,6 +328,7 @@ func TestChallenge(t *testing.T) {
 func TestRegistration(t *testing.T) {
 	wfe := NewWebFrontEndImpl()
 	wfe.RA = &MockRegistrationAuthority{}
+	wfe.SA = &MockSA{}
 	wfe.Stats, _ = statsd.NewNoopClient()
 	responseWriter := httptest.NewRecorder()
 
@@ -387,6 +417,7 @@ func TestRegistration(t *testing.T) {
 func TestAuthorization(t *testing.T) {
 	wfe := NewWebFrontEndImpl()
 	wfe.RA = &MockRegistrationAuthority{}
+	wfe.SA = &MockSA{}
 	wfe.Stats, _ = statsd.NewNoopClient()
 	responseWriter := httptest.NewRecorder()
 


### PR DESCRIPTION
Fix for #187.

Adds the method `GetRegistrationByKey` to the `SA` and uses it in `WFE.verifyPOST` to check if the key provided by the client is actually associated with an existing registration. This PR also changes the signature of `verifyPOST` to `(wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]byte, jose.JsonWebKey, string, error)`  so that the registration check can by bypassed for the `/acme/new-reg` endpoint.

Currently I've just discarded (`_`) the returned registration ID everywhere `verifyPOST` is called but a PR for #181 should clean this all up, it may be desirable to still have this function return the key behind a bool argument (for new reg/updating reg) but I'll leave this up to a future PR for now.

Since we previously weren't mocking the SA since WFE wasn't using it directly anywhere that is touched by tests so I provided a preliminary implementation that allows current tests to pass. (although this should probably the checked end-to-end in the future?)

