### PR TITLE
Add missing mock method to fix build for PR #185.

### DIFF
--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -53,6 +53,10 @@ func (sa *MockSA) GetCertificateStatus(string) (core.CertificateStatus, error) {
 	return core.CertificateStatus{}, nil
 }
 
+func (sa *MockSA) AlreadyDeniedCSR([]string) (bool, error) {
+	return false, nil
+}
+
 func makeBody(s string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(s))
 }


### PR DESCRIPTION
This fixes breakage from merging in https://github.com/letsencrypt/boulder/pull/185