### PR TITLE
Switch Authorization object from key to registration ID as association

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -193,7 +193,7 @@ func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string) (err error)
 
 // IssueCertificate attempts to convert a CSR into a signed Certificate, while
 // enforcing all policies.
-func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest) (core.Certificate, error) {
+func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest, regID int64) (core.Certificate, error) {
 	emptyCert := core.Certificate{}
 	var err error
 	// XXX Take in authorizations and verify that union covers CSR?
@@ -291,7 +291,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 	}
 
 	// Store the cert with the certificate authority, if provided
-	_, err = ca.SA.AddCertificate(certDER)
+	_, err = ca.SA.AddCertificate(certDER, regID)
 	if err != nil {
 		ca.DB.Rollback()
 		return emptyCert, err

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -368,7 +368,7 @@ func TestRevoke(t *testing.T) {
 
 	csrDER, _ := hex.DecodeString(CN_AND_SAN_CSR_HEX)
 	csr, _ := x509.ParseCertificateRequest(csrDER)
-	certObj, err := ca.IssueCertificate(*csr)
+	certObj, err := ca.IssueCertificate(*csr, 1)
 	test.AssertNotError(t, err, "Failed to sign certificate")
 	if err != nil {
 		return
@@ -408,7 +408,7 @@ func TestIssueCertificate(t *testing.T) {
 		csr, _ := x509.ParseCertificateRequest(csrDER)
 
 		// Sign CSR
-		certObj, err := ca.IssueCertificate(*csr)
+		certObj, err := ca.IssueCertificate(*csr, 1)
 		test.AssertNotError(t, err, "Failed to sign certificate")
 		if err != nil {
 			continue
@@ -450,7 +450,7 @@ func TestIssueCertificate(t *testing.T) {
 	// Test that the CA rejects CSRs with no names
 	csrDER, _ := hex.DecodeString(NO_NAME_CSR_HEX)
 	csr, _ := x509.ParseCertificateRequest(csrDER)
-	_, err = ca.IssueCertificate(*csr)
+	_, err = ca.IssueCertificate(*csr, 1)
 	if err == nil {
 		t.Errorf("CA improperly agreed to create a certificate with no name")
 	}
@@ -458,7 +458,7 @@ func TestIssueCertificate(t *testing.T) {
 	// Test that the CA rejects CSRs with duplicate names
 	csrDER, _ = hex.DecodeString(DUPE_NAME_CSR_HEX)
 	csr, _ = x509.ParseCertificateRequest(csrDER)
-	_, err = ca.IssueCertificate(*csr)
+	_, err = ca.IssueCertificate(*csr, 1)
 	if err == nil {
 		t.Errorf("CA improperly agreed to create a certificate with duplicate names")
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -56,7 +56,7 @@ type RegistrationAuthority interface {
 	NewAuthorization(Authorization, int64) (Authorization, error)
 
 	// [WebFrontEnd]
-	NewCertificate(CertificateRequest, jose.JsonWebKey) (Certificate, error)
+	NewCertificate(CertificateRequest, int64) (Certificate, error)
 
 	// [WebFrontEnd]
 	UpdateRegistration(Registration, Registration) (Registration, error)
@@ -78,7 +78,7 @@ type ValidationAuthority interface {
 
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
-	IssueCertificate(x509.CertificateRequest) (Certificate, error)
+	IssueCertificate(x509.CertificateRequest, int64) (Certificate, error)
 	RevokeCertificate(serial string) error
 }
 
@@ -106,7 +106,7 @@ type StorageAdder interface {
 	FinalizeAuthorization(Authorization) error
 	MarkCertificateRevoked(serial string, ocspResponse []byte, reasonCode int) error
 
-	AddCertificate([]byte) (string, error)
+	AddCertificate([]byte, int64) (string, error)
 
 	AddDeniedCSR([]string) error
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -53,7 +53,7 @@ type RegistrationAuthority interface {
 	NewRegistration(Registration, jose.JsonWebKey) (Registration, error)
 
 	// [WebFrontEnd]
-	NewAuthorization(Authorization, jose.JsonWebKey) (Authorization, error)
+	NewAuthorization(Authorization, int) (Authorization, error)
 
 	// [WebFrontEnd]
 	NewCertificate(CertificateRequest, jose.JsonWebKey) (Certificate, error)
@@ -88,7 +88,7 @@ type PolicyAuthority interface {
 }
 
 type StorageGetter interface {
-	GetRegistration(string) (Registration, error)
+	GetRegistration(int) (Registration, error)
 	GetRegistrationByKey(jose.JsonWebKey) (Registration, error)
 	GetAuthorization(string) (Authorization, error)
 	GetCertificate(string) ([]byte, error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -53,7 +53,7 @@ type RegistrationAuthority interface {
 	NewRegistration(Registration, jose.JsonWebKey) (Registration, error)
 
 	// [WebFrontEnd]
-	NewAuthorization(Authorization, int) (Authorization, error)
+	NewAuthorization(Authorization, int64) (Authorization, error)
 
 	// [WebFrontEnd]
 	NewCertificate(CertificateRequest, jose.JsonWebKey) (Certificate, error)
@@ -88,7 +88,7 @@ type PolicyAuthority interface {
 }
 
 type StorageGetter interface {
-	GetRegistration(int) (Registration, error)
+	GetRegistration(int64) (Registration, error)
 	GetRegistrationByKey(jose.JsonWebKey) (Registration, error)
 	GetAuthorization(string) (Authorization, error)
 	GetCertificate(string) ([]byte, error)

--- a/core/objects.go
+++ b/core/objects.go
@@ -100,7 +100,7 @@ func (cr CertificateRequest) MarshalJSON() ([]byte, error) {
 // to account keys.
 type Registration struct {
 	// Unique identifier
-	ID int `json:"-" db:"id"`
+	ID int64 `json:"-" db:"id"`
 
 	// Account key to which the details are attached
 	Key jose.JsonWebKey `json:"key" db:"key"`
@@ -260,10 +260,8 @@ type Authorization struct {
 	// The identifier for which authorization is being given
 	Identifier AcmeIdentifier `json:"identifier,omitempty" db:"identifier"`
 
-	// The account key that is authorized for the identifier
-	// Key jose.JsonWebKey `json:"key,omitempty" db:"key"`
 	// The registration ID associated with the authorization
-	RegID int `json:"regID,omitempty" db:"regID"`
+	RegistrationID int64 `json:"-" db:"registrationID"`
 
 	// The status of the validation of this authorization
 	Status AcmeStatus `json:"status,omitempty" db:"status"`

--- a/core/objects.go
+++ b/core/objects.go
@@ -100,7 +100,7 @@ func (cr CertificateRequest) MarshalJSON() ([]byte, error) {
 // to account keys.
 type Registration struct {
 	// Unique identifier
-	ID string `json:"-" db:"id"`
+	ID int `json:"-" db:"id"`
 
 	// Account key to which the details are attached
 	Key jose.JsonWebKey `json:"key" db:"key"`
@@ -261,7 +261,9 @@ type Authorization struct {
 	Identifier AcmeIdentifier `json:"identifier,omitempty" db:"identifier"`
 
 	// The account key that is authorized for the identifier
-	Key jose.JsonWebKey `json:"key,omitempty" db:"key"`
+	// Key jose.JsonWebKey `json:"key,omitempty" db:"key"`
+	// The registration ID associated with the authorization
+	RegID int `json:"regID,omitempty" db:"regID"`
 
 	// The status of the validation of this authorization
 	Status AcmeStatus `json:"status,omitempty" db:"status"`

--- a/core/objects.go
+++ b/core/objects.go
@@ -320,6 +320,8 @@ func (jb *JsonBuffer) UnmarshalJSON(data []byte) (err error) {
 // Certificate objects are entirely internal to the server.  The only
 // thing exposed on the wire is the certificate itself.
 type Certificate struct {
+	RegistrationID int64 `db:"registrationID"`
+	
 	// The parsed version of DER. Useful for extracting things like serial number.
 	ParsedCertificate *x509.Certificate `db:"-"`
 
@@ -338,7 +340,7 @@ type Certificate struct {
 // latest data about the status of the certificate, required for OCSP updating
 // and for validating that the subscriber has accepted the certificate.
 type CertificateStatus struct {
-	Serial                 string `db:"serial"`
+	Serial string `db:"serial"`
 
 	// subscriberApproved: true iff the subscriber has posted back to the server
 	//   that they accept the certificate, otherwise 0.

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -103,7 +103,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 	return
 }
 
-func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest, requestKey jose.JsonWebKey) (core.Certificate, error) {
+func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest, regID int64) (core.Certificate, error) {
 	emptyCert := core.Certificate{}
 	var err error
 	// Verify the CSR
@@ -124,7 +124,7 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 		return emptyCert, err
 	}
 
-	registration, err := ra.SA.GetRegistrationByKey(requestKey)
+	registration, err := ra.SA.GetRegistration(regID)
 	if err != nil {
 		return emptyCert, err
 	}
@@ -164,7 +164,7 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 	// Create the certificate
 	var cert core.Certificate
 	ra.log.Audit(fmt.Sprintf("Issuing certificate for %s", names))
-	if cert, err = ra.CA.IssueCertificate(*csr); err != nil {
+	if cert, err = ra.CA.IssueCertificate(*csr, regID); err != nil {
 		return emptyCert, err
 	}
 	cert.ParsedCertificate, err = x509.ParseCertificate([]byte(cert.DER))

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -236,7 +236,7 @@ func TestNewCertificate(t *testing.T) {
 		Authorizations: []core.AcmeURL{core.AcmeURL(*url1), core.AcmeURL(*url2)},
 	}
 
-	cert, err := ra.NewCertificate(certRequest, AccountKey)
+	cert, err := ra.NewCertificate(certRequest, 1)
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	parsedCert, err := x509.ParseCertificate(cert.DER)
 	test.AssertNotError(t, err, "Failed to parse certificate")

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -127,7 +127,7 @@ func assertAuthzEqual(t *testing.T, a1, a2 core.Authorization) {
 	test.Assert(t, a1.ID == a2.ID, "ret != DB: ID")
 	test.Assert(t, a1.Identifier == a2.Identifier, "ret != DB: Identifier")
 	test.Assert(t, a1.Status == a2.Status, "ret != DB: Status")
-	test.Assert(t, a1.RegID == a2.RegID, "ret != DB: Key")
+	test.Assert(t, a1.RegistrationID == a2.RegistrationID, "ret != DB: RegID")
 	// Not testing: Contact, Challenges
 }
 
@@ -143,7 +143,7 @@ func TestNewAuthorization(t *testing.T) {
 	assertAuthzEqual(t, authz, dbAuthz)
 
 	// Verify that the returned authz has the right information
-	test.Assert(t, authz.RegID == 1, "Initial authz did not get the right key")
+	test.Assert(t, authz.RegistrationID == 1, "Initial authz did not get the right registration ID")
 	test.Assert(t, authz.Identifier == AuthzRequest.Identifier, "Initial authz had wrong identifier")
 	test.Assert(t, authz.Status == core.StatusPending, "Initial authz not pending")
 
@@ -217,7 +217,7 @@ func TestOnValidationUpdate(t *testing.T) {
 func TestNewCertificate(t *testing.T) {
 	_, _, sa, ra := initAuthorities(t)
 	sa.NewRegistration(core.Registration{Key: AccountKey})
-	AuthzFinal.RegID = 1
+	AuthzFinal.RegistrationID = 1
 	AuthzFinal.ID, _ = sa.NewPendingAuthorization()
 	sa.UpdatePendingAuthorization(AuthzFinal)
 	sa.FinalizeAuthorization(AuthzFinal)
@@ -227,7 +227,6 @@ func TestNewCertificate(t *testing.T) {
 	AuthzFinalWWW.Identifier.Value = "www.example.com"
 	AuthzFinalWWW.ID, _ = sa.NewPendingAuthorization()
 	sa.FinalizeAuthorization(AuthzFinalWWW)
-	sa.DumpTables()
 
 	// Construct a cert request referencing the two authorizations
 	url1, _ := url.Parse("http://doesnt.matter/" + AuthzFinal.ID)

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -70,7 +70,7 @@ type registrationRequest struct {
 
 type authorizationRequest struct {
 	Authz core.Authorization
-	RegID int
+	RegID int64
 }
 
 type certificateRequest struct {
@@ -239,7 +239,7 @@ func (rac RegistrationAuthorityClient) NewRegistration(reg core.Registration, ke
 	return
 }
 
-func (rac RegistrationAuthorityClient) NewAuthorization(authz core.Authorization, regID int) (newAuthz core.Authorization, err error) {
+func (rac RegistrationAuthorityClient) NewAuthorization(authz core.Authorization, regID int64) (newAuthz core.Authorization, err error) {
 	data, err := json.Marshal(authorizationRequest{authz, regID})
 	if err != nil {
 		return
@@ -437,7 +437,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 
 	rpc.Handle(MethodGetRegistration, func(req []byte) (response []byte) {
 		var intReq struct {
-			ID int
+			ID int64
 		}
 		err := json.Unmarshal(req, &intReq)
 		if err != nil {
@@ -643,9 +643,9 @@ func NewStorageAuthorityClient(clientQueue, serverQueue string, channel *amqp.Ch
 	return
 }
 
-func (cac StorageAuthorityClient) GetRegistration(id int) (reg core.Registration, err error) {
+func (cac StorageAuthorityClient) GetRegistration(id int64) (reg core.Registration, err error) {
 	var intReq struct {
-		ID int
+		ID int64
 	}
 	intReq.ID = id
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -175,7 +175,7 @@ func NewSQLStorageAuthority(driver string, name string) (ssa *SQLStorageAuthorit
 }
 
 func (ssa *SQLStorageAuthority) InitTables() (err error) {
-	ssa.dbMap.AddTableWithName(core.Registration{}, "registrations").SetKeys(false, "ID").SetVersionCol("LockCol")
+	ssa.dbMap.AddTableWithName(core.Registration{}, "registrations").SetKeys(true, "ID").SetVersionCol("LockCol")
 	ssa.dbMap.AddTableWithName(pendingauthzModel{}, "pending_authz").SetKeys(false, "ID").SetVersionCol("LockCol")
 	ssa.dbMap.AddTableWithName(authzModel{}, "authz").SetKeys(false, "ID")
 	ssa.dbMap.AddTableWithName(core.Certificate{}, "certificates").SetKeys(false, "Serial")
@@ -305,19 +305,19 @@ func existingFinal(tx *gorp.Transaction, id string) (bool) {
 	return count > 0
 }
 
-func existingRegistration(tx *gorp.Transaction, id string) (bool) {
+func existingRegistration(tx *gorp.Transaction, id int) (bool) {
 	var count int64
 	_ = tx.SelectOne(&count, "SELECT count(*) FROM registrations WHERE id = :id", map[string]interface{} {"id": id})
 	return count > 0
 }
 
-func (ssa *SQLStorageAuthority) GetRegistration(id string) (reg core.Registration, err error) {
+func (ssa *SQLStorageAuthority) GetRegistration(id int) (reg core.Registration, err error) {
 	regObj, err := ssa.dbMap.Get(core.Registration{}, id)
 	if err != nil {
 		return
 	}
 	if regObj == nil {
-		err = fmt.Errorf("No registrations with ID %s", id)
+		err = fmt.Errorf("No registrations with ID %d", id)
 		return
 	}
 	reg = *regObj.(*core.Registration)
@@ -432,11 +432,11 @@ func (ssa *SQLStorageAuthority) NewRegistration(reg core.Registration) (output c
 	}
 
 	// Check that it doesn't exist already
-	id := core.NewToken()
+	/*id := core.NewToken()
 	for existingRegistration(tx, id) {
 		id = core.NewToken()
 	}
-	reg.ID = id
+	reg.ID = id*/
 
 	err = tx.Insert(&reg)
 	if err != nil {
@@ -506,7 +506,7 @@ func (ssa *SQLStorageAuthority) UpdateRegistration(reg core.Registration) (err e
 	}
 
 	if !existingRegistration(tx, reg.ID) {
-		err = errors.New("Requested registration not found " + reg.ID)
+		err = fmt.Errorf("Requested registration not found %v", reg.ID)
 		tx.Rollback()
 		return
 	}

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -633,7 +633,7 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization(authz core.Authorization) 
 	return
 }
 
-func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte) (digest string, err error) {
+func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte, regID int64) (digest string, err error) {
 	var parsedCertificate *x509.Certificate
 	parsedCertificate, err = x509.ParseCertificate(certDER)
 	if err != nil {
@@ -643,6 +643,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte) (digest string, e
 	serial := core.SerialToString(parsedCertificate.SerialNumber)
 
 	cert := &core.Certificate{
+		RegistrationID: regID,
 		Serial: serial,
 		Digest: digest,
 		DER: certDER,

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -305,13 +305,13 @@ func existingFinal(tx *gorp.Transaction, id string) (bool) {
 	return count > 0
 }
 
-func existingRegistration(tx *gorp.Transaction, id int) (bool) {
+func existingRegistration(tx *gorp.Transaction, id int64) (bool) {
 	var count int64
 	_ = tx.SelectOne(&count, "SELECT count(*) FROM registrations WHERE id = :id", map[string]interface{} {"id": id})
 	return count > 0
 }
 
-func (ssa *SQLStorageAuthority) GetRegistration(id int) (reg core.Registration, err error) {
+func (ssa *SQLStorageAuthority) GetRegistration(id int64) (reg core.Registration, err error) {
 	regObj, err := ssa.dbMap.Get(core.Registration{}, id)
 	if err != nil {
 		return
@@ -430,13 +430,6 @@ func (ssa *SQLStorageAuthority) NewRegistration(reg core.Registration) (output c
 	if err != nil {
 		return
 	}
-
-	// Check that it doesn't exist already
-	/*id := core.NewToken()
-	for existingRegistration(tx, id) {
-		id = core.NewToken()
-	}
-	reg.ID = id*/
 
 	err = tx.Insert(&reg)
 	if err != nil {

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -53,10 +54,10 @@ func TestAddRegistration(t *testing.T) {
 		Key: jwk,
 	})
 	test.AssertNotError(t, err, "Couldn't create new registration")
-	test.Assert(t, reg.ID != "", "ID shouldn't be blank")
+	// test.Assert(t, reg.ID != "", "ID shouldn't be blank")
 
 	dbReg, err := sa.GetRegistration(reg.ID)
-	test.AssertNotError(t, err, "Couldn't get registration with ID "+reg.ID)
+	test.AssertNotError(t, err, fmt.Sprintf("Couldn't get registration with ID %v", reg.ID))
 
 	expectedReg := core.Registration{
 		ID: reg.ID,
@@ -70,7 +71,7 @@ func TestAddRegistration(t *testing.T) {
 
 	newReg := core.Registration{ID: reg.ID, Key: jwk, RecoveryToken: "RBNvo1WzZ4oRRq0W9", Contact: []core.AcmeURL{u}, Agreement: "yes"}
 	err = sa.UpdateRegistration(newReg)
-	test.AssertNotError(t, err, "Couldn't update registration with ID "+reg.ID)
+	test.AssertNotError(t, err, fmt.Sprintf("Couldn't get registration with ID %v", reg.ID))
 
 	dbReg, err = sa.GetRegistrationByKey(jwk)
 	test.AssertNotError(t, err, "Couldn't update registration by key")
@@ -109,7 +110,7 @@ func TestAddAuthorization(t *testing.T) {
 	combos[0] = []int{0,1}
 
 
-	newPa := core.Authorization{ID: paID, Identifier: core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}, Key: jwk, Status: core.StatusPending, Expires: time.Now().AddDate(0, 0, 1), Challenges: []core.Challenge{chall}, Combinations: combos, Contact: []core.AcmeURL{u}}
+	newPa := core.Authorization{ID: paID, Identifier: core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}, RegID: 0, Status: core.StatusPending, Expires: time.Now().AddDate(0, 0, 1), Challenges: []core.Challenge{chall}, Combinations: combos, Contact: []core.AcmeURL{u}}
 	err = sa.UpdatePendingAuthorization(newPa)
 	test.AssertNotError(t, err, "Couldn't update pending authorization with ID "+paID)
 

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -54,7 +54,7 @@ func TestAddRegistration(t *testing.T) {
 		Key: jwk,
 	})
 	test.AssertNotError(t, err, "Couldn't create new registration")
-	// test.Assert(t, reg.ID != "", "ID shouldn't be blank")
+	test.Assert(t, reg.ID != 0, "ID shouldn't be 0")
 
 	dbReg, err := sa.GetRegistration(reg.ID)
 	test.AssertNotError(t, err, fmt.Sprintf("Couldn't get registration with ID %v", reg.ID))
@@ -110,7 +110,7 @@ func TestAddAuthorization(t *testing.T) {
 	combos[0] = []int{0,1}
 
 
-	newPa := core.Authorization{ID: paID, Identifier: core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}, RegID: 0, Status: core.StatusPending, Expires: time.Now().AddDate(0, 0, 1), Challenges: []core.Challenge{chall}, Combinations: combos, Contact: []core.AcmeURL{u}}
+	newPa := core.Authorization{ID: paID, Identifier: core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}, RegistrationID: 0, Status: core.StatusPending, Expires: time.Now().AddDate(0, 0, 1), Challenges: []core.Challenge{chall}, Combinations: combos, Contact: []core.AcmeURL{u}}
 	err = sa.UpdatePendingAuthorization(newPa)
 	test.AssertNotError(t, err, "Couldn't update pending authorization with ID "+paID)
 

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -129,7 +129,7 @@ func TestAddCertificate(t *testing.T) {
 	certDER, err := ioutil.ReadFile("www.eff.org.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 
-	digest, err := sa.AddCertificate(certDER)
+	digest, err := sa.AddCertificate(certDER, 1)
 	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
 	test.AssertEquals(t, digest, "qWoItDZmR4P9eFbeYgXXP3SR4ApnkQj8x4LsB_ORKBo")
 
@@ -152,7 +152,7 @@ func TestAddCertificate(t *testing.T) {
 	certDER2, err := ioutil.ReadFile("test-cert.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 
-	digest2, err := sa.AddCertificate(certDER2)
+	digest2, err := sa.AddCertificate(certDER2, 1)
 	test.AssertNotError(t, err, "Couldn't add test-cert.der")
 	test.AssertEquals(t, digest2, "CMVYqWzyqUW7pfBF2CxL0Uk6I0Upsk7p4EWSnd_vYx4")
 

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -327,7 +327,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 		return
 	}
 
-	body, key, _, err := wfe.verifyPOST(request, true)
+	body, key, reg, err := wfe.verifyPOST(request, true)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			wfe.sendError(response, "No registration exists matching provided key", http.StatusForbidden)
@@ -354,7 +354,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	// authorized for target site, they could cause issuance for that site by
 	// lying to the RA. We should probably pass a copy of the whole rquest to the
 	// RA for secondary validation.
-	cert, err := wfe.RA.NewCertificate(init, *key)
+	cert, err := wfe.RA.NewCertificate(init, reg.ID)
 	if err != nil {
 		wfe.sendError(response,
 			fmt.Sprintf("Error creating new cert: %+v", err),

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -29,7 +29,7 @@ type MockSA struct {
 	// empty
 }
 
-func (sa *MockSA) GetRegistration(int) (core.Registration, error) {
+func (sa *MockSA) GetRegistration(int64) (core.Registration, error) {
 	return core.Registration{}, nil
 }
 
@@ -244,8 +244,8 @@ func (ra *MockRegistrationAuthority) NewRegistration(reg core.Registration, jwk 
 	return reg, nil
 }
 
-func (ra *MockRegistrationAuthority) NewAuthorization(authz core.Authorization, regID int) (core.Authorization, error) {
-	authz.RegID = regID
+func (ra *MockRegistrationAuthority) NewAuthorization(authz core.Authorization, regID int64) (core.Authorization, error) {
+	authz.RegistrationID = regID
 	return authz, nil
 }
 
@@ -296,7 +296,7 @@ func TestChallenge(t *testing.T) {
 				URI:  core.AcmeURL(*challengeURL),
 			},
 		},
-		RegID: 0,
+		RegistrationID: 0,
 	}
 
 	wfe.Challenge(authz, responseWriter, &http.Request{

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -249,7 +249,7 @@ func (ra *MockRegistrationAuthority) NewAuthorization(authz core.Authorization, 
 	return authz, nil
 }
 
-func (ra *MockRegistrationAuthority) NewCertificate(req core.CertificateRequest, jwk jose.JsonWebKey) (core.Certificate, error) {
+func (ra *MockRegistrationAuthority) NewCertificate(req core.CertificateRequest, regID int64) (core.Certificate, error) {
 	return core.Certificate{}, nil
 }
 

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -29,7 +29,7 @@ type MockSA struct {
 	// empty
 }
 
-func (sa *MockSA) GetRegistration(string) (core.Registration, error) {
+func (sa *MockSA) GetRegistration(int) (core.Registration, error) {
 	return core.Registration{}, nil
 }
 
@@ -244,8 +244,8 @@ func (ra *MockRegistrationAuthority) NewRegistration(reg core.Registration, jwk 
 	return reg, nil
 }
 
-func (ra *MockRegistrationAuthority) NewAuthorization(authz core.Authorization, jwk jose.JsonWebKey) (core.Authorization, error) {
-	authz.Key = jwk
+func (ra *MockRegistrationAuthority) NewAuthorization(authz core.Authorization, regID int) (core.Authorization, error) {
+	authz.RegID = regID
 	return authz, nil
 }
 
@@ -296,7 +296,7 @@ func TestChallenge(t *testing.T) {
 				URI:  core.AcmeURL(*challengeURL),
 			},
 		},
-		Key: key,
+		RegID: 0,
 	}
 
 	wfe.Challenge(authz, responseWriter, &http.Request{
@@ -500,7 +500,7 @@ func TestAuthorization(t *testing.T) {
 		Body: makeBody(signRequest(t, "{\"identifier\":{\"type\":\"dns\",\"value\":\"test.com\"}}")),
 	})
 
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"identifier\":{\"type\":\"dns\",\"value\":\"test.com\"},\"key\":{\"kty\":\"RSA\",\"n\":\"z2NsNdHeqAiGdPP8KuxfQXat_uatOK9y12SyGpfKw1sfkizBIsNxERjNDke6Wp9MugN9srN3sr2TDkmQ-gK8lfWo0v1uG_QgzJb1vBdf_hH7aejgETRGLNJZOdaKDsyFnWq1WGJq36zsHcd0qhggTk6zVwqczSxdiWIAZzEakIUZ13KxXvoepYLY0Q-rEEQiuX71e4hvhfeJ4l7m_B-awn22UUVvo3kCqmaRlZT-36vmQhDGoBsoUo1KBEU44jfeK5PbNRk7vDJuH0B7qinr_jczHcvyD-2TtPzKaCioMtNh_VZbPNDaG67sYkQlC15-Ff3HPzKKJW2XvkVG91qMvQ\",\"e\":\"AAEAAQ\"},\"expires\":\"0001-01-01T00:00:00Z\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"identifier\":{\"type\":\"dns\",\"value\":\"test.com\"},\"expires\":\"0001-01-01T00:00:00Z\"}")
 
 	var authz core.Authorization
 	err := json.Unmarshal([]byte(responseWriter.Body.String()), &authz)


### PR DESCRIPTION
First half of a fix for #181, I've switched `authz` and `pending_authz` to store the registration ID, now a `AUTOINCREMENT` primary key, instead of the JWK. Still need to switch certificates to the same method, but opening this now for review since it'll be pretty much the same stuff.