### PR TITLE
Allow using an issuer key file in non-TestMode.

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -96,11 +96,9 @@ func NewCertificateAuthorityImpl(cadb core.CertificateAuthorityDatabase, config 
 		return nil, err
 	}
 
-	// In test mode, load a private key from a file. In production, use an HSM.
-	if !config.TestMode {
-		err = errors.New("OCSP signing with a PKCS#11 key not yet implemented.")
-		return nil, err
-	}
+	// In test mode, load a private key from a file.
+	// TODO: This should rely on the CFSSL config, to make it easy to use a key
+	// from a file vs an HSM. https://github.com/letsencrypt/boulder/issues/163
 	issuerKey, err := loadIssuerKey(config.IssuerKey)
 	if err != nil {
 		return nil, err

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -352,13 +352,6 @@ func TestFailNoSerial(t *testing.T) {
 	test.AssertError(t, err, "CA should have failed with no SerialPrefix")
 }
 
-func TestFailNoTestMode(t *testing.T) {
-	cadb, _, caConfig := setup(t)
-	caConfig.TestMode = false
-	_, err := NewCertificateAuthorityImpl(cadb, caConfig)
-	test.AssertError(t, err, "CA should have failed with TestMode = false, but key provided")
-}
-
 func TestRevoke(t *testing.T) {
 	cadb, storageAuthority, caConfig := setup(t)
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig)


### PR DESCRIPTION
This was causing difficulty running the demo instance.
We'll fix this the right way as part of moving to a CFSSL local signer:
https://github.com/letsencrypt/boulder/issues/163