### PR TITLE
Use absolute URL for link to issuer cert

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -466,7 +466,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	// TODO The spec says a client should send an Accept: application/pkix-cert
 	// header; either explicitly insist or tolerate
 	response.Header().Add("Location", certURL)
-	response.Header().Add("Link", link(wfe.BaseURL + wfe.IssuerPath, "up"))
+	response.Header().Add("Link", link(wfe.BaseURL+wfe.IssuerPath, "up"))
 	response.Header().Set("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(cert.DER); err != nil {

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -466,7 +466,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	// TODO The spec says a client should send an Accept: application/pkix-cert
 	// header; either explicitly insist or tolerate
 	response.Header().Add("Location", certURL)
-	response.Header().Add("Link", link(wfe.IssuerPath, "up"))
+	response.Header().Add("Link", link(wfe.BaseURL + wfe.IssuerPath, "up"))
 	response.Header().Set("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(cert.DER); err != nil {


### PR DESCRIPTION
This fixes a client compatibility issue.