### PR TITLE
Integration test using test.js

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -63,7 +63,8 @@ else
   run go test ${dirlist}
 fi
 
-echo "Checking for unformatted files:"
+bash test/integration-test.sh
+
 unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1  gofmt -l)
 if [ "x${unformatted}" != "x" ] ; then
   echo "Unformatted files found; setting failure state."

--- a/test.sh
+++ b/test.sh
@@ -63,7 +63,7 @@ else
   run go test ${dirlist}
 fi
 
-bash test/integration-test.sh
+setsid bash test/integration-test.sh
 
 unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1  gofmt -l)
 if [ "x${unformatted}" != "x" ] ; then

--- a/test.sh
+++ b/test.sh
@@ -63,8 +63,6 @@ else
   run go test ${dirlist}
 fi
 
-setsid bash test/integration-test.sh
-
 unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1  gofmt -l)
 if [ "x${unformatted}" != "x" ] ; then
   echo "Unformatted files found; setting failure state."

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -58,5 +58,7 @@
     "port": "25",
     "username": "cert-master@example.com",
     "password": "password"
-  }
+  },
+
+  "subscriberAgreementURL": "http://localhost:4300/terms"
 }

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -1,0 +1,62 @@
+{
+  "syslog": {
+    "network": "",
+    "server": "",
+    "tag": "boulder"
+  },
+
+  "amqp": {
+    "server": "amqp://guest:guest@localhost:5672",
+    "RA": {
+      "client": "RA.client",
+      "server": "RA.server"
+    },
+    "VA": {
+      "client": "VA.client",
+      "server": "VA.server"
+    },
+    "SA": {
+      "client": "SA.client",
+      "server": "SA.server"
+    },
+    "CA": {
+      "client": "CA.client",
+      "server": "CA.server"
+    }
+  },
+
+  "statsd": {
+      "server": "localhost:8125",
+      "prefix": "Boulder"
+  },
+
+  "wfe": {
+    "baseURL": "http://localhost:4300",
+    "listenAddress": "0.0.0.0:4300"
+  },
+
+  "ca": {
+    "server": "localhost:9300",
+    "authKey": "79999d86250c367a2b517a1ae7d409c1",
+    "serialPrefix": 255,
+    "profile": "ee",
+    "dbDriver": "sqlite3",
+    "dbName": ":memory:",
+    "testMode": true,
+    "issuerCert": "test/test-ca.pem",
+    "_comment": "This should only be present in testMode. In prod use an HSM.",
+    "issuerKey": "test/test-ca.key"
+  },
+
+  "sa": {
+    "dbDriver": "sqlite3",
+    "dbName": ":memory:"
+  },
+
+  "mail": {
+    "server": "mail.example.com",
+    "port": "25",
+    "username": "cert-master@example.com",
+    "password": "password"
+  }
+}

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+cd $(dirname $0)/..
+
+# Ensure cleanup
+trap "trap '' SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+go run ./cmd/boulder/main.go --config test/boulder-test-config.json &>/dev/null &
+go run Godeps/_workspace/src/github.com/cloudflare/cfssl/cmd/cfssl/cfssl.go \
+  -loglevel 0 \
+  serve \
+  -port 9300 \
+  -ca test/test-ca.pem \
+  -ca-key test/test-ca.key \
+  -config test/cfssl-config.json &>/dev/null &
+
+cd test/js
+npm install
+
+# Wait for Boulder to come up
+until nc localhost 4300 < /dev/null ; do sleep 1 ; done
+
+CERT_KEY=$(mktemp /tmp/cert_XXXXX.pem)
+CERT=$(mktemp /tmp/cert_XXXXX.crt)
+
+node test.js --email foo@bar.com --agree true \
+  --domain foo.com --new-reg http://localhost:4300/acme/new-reg \
+  --certKey ${CERT_KEY} --cert ${CERT} && \
+node revoke.js ${CERT} ${CERT_KEY} http://localhost:4300/acme/revoke-cert/
+
+STATUS=$?
+
+# Cleanup
+rm -f ${CERT_KEY}
+rm -f ${CERT}
+rm -f account-key.pem
+rm -f temp-cert.pem
+
+exit $STATUS

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -24,7 +24,4 @@ The node.js scripts in this directory provide a simple end-to-end test of Boulde
 
 # Client side
 
-    mkdir -p .well-known/acme-challenge/
     node test.js
-    mv -- *.txt .well-known/acme-challenge/ # In a different window
-    python -m SimpleHTTPServer 5001         # In yet another window

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "dependencies": {
     "cli": "^0.6.5",
+    "colors": "^1.1.0",
     "inquirer": "^0.8.2",
     "node-forge": "^0.6.21",
     "request": "^2.55.0"

--- a/test/js/revoke.js
+++ b/test/js/revoke.js
@@ -15,12 +15,13 @@ var fs = require('fs');
 var request = require('request');
 
 function main() {
-  if (process.argv.length != 4) {
-    console.log('Usage: js revoke.js cert.der key.pem');
+  if (process.argv.length != 5) {
+    console.log('Usage: js revoke.js cert.der key.pem REVOKE_URL');
     process.exit(1);
   }
   var key = crypto.importPemPrivateKey(fs.readFileSync(process.argv[3]));
   var certDER = fs.readFileSync(process.argv[2])
+  var revokeUrl = process.argv[4];
   var certDERB64URL = util.b64enc(new Buffer(certDER))
   var revokeMessage = JSON.stringify({
     // For some reason forge adds an extra, incorrect '00' at the front of the
@@ -29,7 +30,7 @@ function main() {
   });
   console.log('Requesting revocation:', revokeMessage)
   var jws = crypto.generateSignature(key, new Buffer(revokeMessage));
-  var req = request.post('http://localhost:4000/acme/revoke-cert/', function(err, resp) {
+  var req = request.post(revokeUrl, function(err, resp) {
     if (err) {
       console.log('Error: ', err);
     }

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -158,8 +158,12 @@ function post(url, body, callback) {
     }, function(error, response, body) {
     // Don't print non-ASCII characters (like DER-encoded cert) to the terminal
     if (body && !body.toString().match(/[^\x00-\x7F]/)) {
-      var parsed = JSON.parse(body);
-      console.log(JSON.stringify(parsed, null, 2).cyan);
+      try {
+        var parsed = JSON.parse(body);
+        console.log(JSON.stringify(parsed, null, 2).cyan);
+      } catch (e) {
+        console.log(body.toString().cyan);
+      }
     }
     callback(error, response, body)
   });

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -275,7 +275,10 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 		return
 	}
 
-	regURL := fmt.Sprintf("%s%s", wfe.RegBase, string(reg.ID))
+	// Use an explicitly typed variable. Otherwise `go vet' incorrectly complains
+	// that reg.ID is a string being passed to %d.
+	var id int64 = reg.ID
+	regURL := fmt.Sprintf("%s%d", wfe.RegBase, id)
 	responseBody, err := json.Marshal(reg)
 	if err != nil {
 		wfe.sendError(response, "Error marshaling authz", err, http.StatusInternalServerError)


### PR DESCRIPTION
Add an integration test using test.js

Include updates to test.js to make its output more useful as a diagnostic.

It remains a future TODO to do integration testing with the real letsencrypt
client.

Partly fixes https://github.com/letsencrypt/boulder/issues/210