### PR TITLE
Audit all Challenges (success/failure) in VA for Issue #204

### DIFF
--- a/core/challenges.go
+++ b/core/challenges.go
@@ -8,6 +8,7 @@ package core
 import (
 	"crypto/rand"
 	"encoding/hex"
+	blog "github.com/letsencrypt/boulder/log"
 )
 
 func SimpleHTTPSChallenge() Challenge {
@@ -20,7 +21,14 @@ func SimpleHTTPSChallenge() Challenge {
 
 func DvsniChallenge() Challenge {
 	nonce := make([]byte, 16)
-	_, _ = rand.Read(nonce) // NOTE: Ignoring errors
+	_, err := rand.Read(nonce)
+
+	if err != nil {
+		audit := blog.GetAuditLogger()
+		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+		audit.EmergencyExit(err.Error())
+	}
+
 	return Challenge{
 		Type:   ChallengeTypeDVSNI,
 		Status: StatusPending,

--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -24,7 +24,7 @@ type PolicyAuthorityImpl struct {
 
 func NewPolicyAuthorityImpl() *PolicyAuthorityImpl {
 	logger := blog.GetAuditLogger()
-	logger.Notice("Registration Authority Starting")
+	logger.Notice("Policy Authority Starting")
 
 	pa := PolicyAuthorityImpl{log: logger}
 

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -7,7 +7,6 @@ package ra
 
 import (
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"net/url"
@@ -49,19 +48,19 @@ func lastPathSegment(url core.AcmeURL) string {
 }
 
 type certificateRequestEvent struct {
-	ID                  string    `json:"omitempty"`
-	Requester           int64     `json:"omitempty"`
-	SerialNumber        *big.Int  `json:"omitempty"`
-	RequestMethod       string    `json:"omitempty"`
-	VerificationMethods []string  `json:"omitempty"`
-	VerifiedFields      []string  `json:"omitempty"`
-	CommonName          string    `json:"omitempty"`
-	Names               []string  `json:"omitempty"`
-	NotBefore           time.Time `json:"omitempty"`
-	NotAfter            time.Time `json:"omitempty"`
-	RequestTime         time.Time `json:"omitempty"`
-	ResponseTime        time.Time `json:"omitempty"`
-	Error               string    `json:"omitempty"`
+	ID                  string    `json:",omitempty"`
+	Requester           int64     `json:",omitempty"`
+	SerialNumber        *big.Int  `json:",omitempty"`
+	RequestMethod       string    `json:",omitempty"`
+	VerificationMethods []string  `json:",omitempty"`
+	VerifiedFields      []string  `json:",omitempty"`
+	CommonName          string    `json:",omitempty"`
+	Names               []string  `json:",omitempty"`
+	NotBefore           time.Time `json:",omitempty"`
+	NotAfter            time.Time `json:",omitempty"`
+	RequestTime         time.Time `json:",omitempty"`
+	ResponseTime        time.Time `json:",omitempty"`
+	Error               string    `json:",omitempty"`
 }
 
 func (ra *RegistrationAuthorityImpl) NewRegistration(init core.Registration, key jose.JsonWebKey) (reg core.Registration, err error) {
@@ -140,15 +139,8 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 
 	// No matter what, log the request
 	defer func() {
-		jsonLogEvent, logErr := json.Marshal(logEvent)
-		if logErr != nil {
-			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			ra.log.Audit(fmt.Sprintf("Certificate request logEvent could not be serialized. Raw: %+v", logEvent))
-			return
-		}
-
 		// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
-		ra.log.Audit(fmt.Sprintf("Certificate request %s - %s", logEventResult, string(jsonLogEvent)))
+		ra.log.AuditObject(fmt.Sprintf("Certificate request - %s", logEventResult), logEvent)
 	}()
 
 	if regID <= 0 {

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -268,7 +268,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 		return
 	}
 
-	regURL := fmt.Sprintf("%s%d", wfe.RegBase, reg.ID)
+	regURL := fmt.Sprintf("%s%s", wfe.RegBase, string(reg.ID))
 	responseBody, err := json.Marshal(reg)
 	if err != nil {
 		wfe.sendError(response, "Error marshaling authz", err, http.StatusInternalServerError)


### PR DESCRIPTION
- Don't ignore entropy underruns in challenges.go
- Correct identity crisis in Policy Authority; hopefully it will remember.
- Add a method `AuditObject` in audit-logger and convert RA/VA to use it
- Fix json typo in registration-authority that caused empty audit logs
- Fix vet issue in WFE where RegID was being printed as a 32-bit int instead of 64-bit
- Opened issue #217 for the test failure identified below