### PR TITLE
Improve unit testing to resolve Issue #217

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -196,7 +196,7 @@ func (va ValidationAuthorityImpl) validate(authz core.Authorization) {
 		}
 
 		if !challenge.IsSane(true) {
-			challenge.Status = core.StatusInvalid
+			authz.Challenges[i].Status = core.StatusInvalid
 			logEvent.Error = fmt.Sprintf("Challenge failed sanity check.")
 			logEvent.Challenge = challenge
 		} else {


### PR DESCRIPTION
- Support multiple HTTPserver instances in `validation-authority_test.go`
- Improve coverage of ValidateDvsni and ValidateHttps
- Cover UpdateValidations