### PR TITLE
Use 1 as initial serial suffix

### DIFF
--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -125,9 +125,7 @@ func (cadb *CertificateAuthorityDatabaseImpl) IncrementAndGetSerial() (val int, 
 		return
 	}
 
-	val = val + 1
-
-	_, err = cadb.activeTx.Exec("UPDATE serialNumber SET number=?, lastUpdated=? WHERE id=1", val, time.Now())
+	_, err = cadb.activeTx.Exec("UPDATE serialNumber SET number=?, lastUpdated=? WHERE id=1", val+1, time.Now())
 	if err != nil {
 		cadb.activeTx.Rollback()
 		return

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -246,6 +246,8 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 		return emptyCert, err
 	}
 	serialHex := fmt.Sprintf("%02X%014X", ca.Prefix, serialDec)
+	fmt.Println(serialDec)
+	fmt.Println(serialHex)
 
 	// Send the cert off for signing
 	req := signer.SignRequest{

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -246,8 +246,6 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 		return emptyCert, err
 	}
 	serialHex := fmt.Sprintf("%02X%014X", ca.Prefix, serialDec)
-	fmt.Println(serialDec)
-	fmt.Println(serialHex)
 
 	// Send the cert off for signing
 	req := signer.SignRequest{


### PR DESCRIPTION
Changes `IncrementAndGetSerial()` to return the pre-increment/update value from SQL so that the first serial suffix we get should always be `1` instead of `2`. Fix for #161.