### PR TITLE
Add an OCSP responder

### DIFF
--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/responder.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/responder.go
@@ -1,0 +1,141 @@
+package ocsp
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/cloudflare/cfssl/log"
+	"golang.org/x/crypto/ocsp"
+)
+
+var (
+	malformedRequestErrorResponse = []byte{0x30, 0x03, 0x0A, 0x01, 0x01}
+	internalErrorErrorResponse    = []byte{0x30, 0x03, 0x0A, 0x01, 0x02}
+	tryLaterErrorResponse         = []byte{0x30, 0x03, 0x0A, 0x01, 0x03}
+	sigRequredErrorResponse       = []byte{0x30, 0x03, 0x0A, 0x01, 0x05}
+	unauthorizedErrorResponse     = []byte{0x30, 0x03, 0x0A, 0x01, 0x06}
+)
+
+// Source represents the logical source of OCSP responses, i.e.,
+// the logic that actually chooses a response based on a request.  In
+// order to create an actual responder, wrap one of these in a Responder
+// object and pass it to http.Handle.
+type Source interface {
+	Response(*ocsp.Request) ([]byte, bool)
+}
+
+// An InMemorySource is a map from serialNumber -> der(response)
+type InMemorySource map[string][]byte
+
+// Response looks up an OCSP response to provide for a given request.
+// InMemorySource looks up a response purely based on serial number,
+// without regard to what issuer the request is asking for.
+func (src InMemorySource) Response(request *ocsp.Request) (response []byte, present bool) {
+	response, present = src[request.SerialNumber.String()]
+	return
+}
+
+// NewSourceFromFile reads the named file into an InMemorySource.
+// The file read by this function must contain whitespace-separated OCSP
+// responses. Each OCSP response must be in base64-encoded DER form (i.e.,
+// PEM without headers or whitespace).  Invalid responses are ignored.
+// This function pulls the entire file into an InMemorySource.
+func NewSourceFromFile(responseFile string) (Source, error) {
+	fileContents, err := ioutil.ReadFile(responseFile)
+	if err != nil {
+		return nil, err
+	}
+
+	responsesB64 := regexp.MustCompile("\\s").Split(string(fileContents), -1)
+	src := InMemorySource{}
+	for _, b64 := range responsesB64 {
+		der, tmpErr := base64.StdEncoding.DecodeString(b64)
+		if tmpErr != nil {
+			log.Errorf("Base64 decode error on: %s", b64)
+			continue
+		}
+
+		response, tmpErr := ocsp.ParseResponse(der, nil)
+		if tmpErr != nil {
+			log.Errorf("OCSP decode error on: %s", b64)
+			continue
+		}
+
+		src[response.SerialNumber.String()] = der
+	}
+
+	log.Infof("Read %d OCSP responses", len(src))
+	return src, nil
+}
+
+// A Responder object provides the HTTP logic to expose a
+// Source of OCSP responses.
+type Responder struct {
+	Source Source
+}
+
+// A Responder can process both GET and POST requests.  The mapping
+// from an OCSP request to an OCSP response is done by the Source;
+// the Responder simply decodes the request, and passes back whatever
+// response is provided by the source.
+func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	// Read response from request
+	var requestBody []byte
+	var err error
+	switch request.Method {
+	case "GET":
+		re := regexp.MustCompile("^.*/")
+		base64Request := re.ReplaceAllString(request.RequestURI, "")
+		base64Request, err = url.QueryUnescape(base64Request)
+		if err != nil {
+			return
+		}
+		requestBody, err = base64.StdEncoding.DecodeString(base64Request)
+		if err != nil {
+			return
+		}
+	case "POST":
+		requestBody, err = ioutil.ReadAll(request.Body)
+		if err != nil {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	default:
+		response.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	// TODO log request
+	b64Body := base64.StdEncoding.EncodeToString(requestBody)
+	log.Infof("Received OCSP request: %s", b64Body)
+
+	// All responses after this point will be OCSP.
+	// We could check for the content type of the request, but that
+	// seems unnecessariliy restrictive.
+	response.Header().Add("Content-Type", "application/ocsp-response")
+
+	// Parse response as an OCSP request
+	// XXX: This fails if the request contains the nonce extension.
+	//      We don't intend to support nonces anyway, but maybe we
+	//      should return unauthorizedRequest instead of malformed.
+	ocspRequest, err := ocsp.ParseRequest(requestBody)
+	if err != nil {
+		log.Errorf("Error decoding request body: %s", b64Body)
+		response.Write(malformedRequestErrorResponse)
+		return
+	}
+
+	// Look up OCSP response from source
+	ocspResponse, found := rs.Source.Response(ocspRequest)
+	if !found {
+		log.Errorf("No response found for request: %s", b64Body)
+		response.Write(unauthorizedErrorResponse)
+		return
+	}
+
+	// Write OCSP response to response
+	response.WriteHeader(http.StatusOK)
+	response.Write(ocspResponse)
+}

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -1,0 +1,143 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"crypto/x509"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	cfocsp "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
+	"golang.org/x/crypto/ocsp"
+
+	"github.com/letsencrypt/boulder/cmd"
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+type timedHandler struct {
+	f     func(w http.ResponseWriter, r *http.Request)
+	stats statsd.Statter
+}
+
+var openConnections int64 = 0
+
+func HandlerTimer(handler http.Handler, stats statsd.Statter) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cStart := time.Now()
+		openConnections += 1
+		stats.Gauge("HttpConnectionsOpen", openConnections, 1.0)
+
+		handler.ServeHTTP(w, r)
+
+		openConnections -= 1
+		stats.Gauge("HttpConnectionsOpen", openConnections, 1.0)
+
+		// (FIX: this doesn't seem to really work at catching errors...)
+		state := "Success"
+		for _, h := range w.Header()["Content-Type"] {
+			if h == "application/problem+json" {
+				state = "Error"
+				break
+			}
+		}
+		// set resp timing key based on success / failure
+		stats.TimingDuration(fmt.Sprintf("HttpResponseTime.%s.%s", r.URL, state), time.Since(cStart), 1.0)
+	})
+}
+
+/*
+
+We assume that OCSP responses are stored in a very simple database table,
+with two columns: serialNumber and response
+
+  CREATE TABLE ocsp_responses (serialNumber TEXT, response BLOB);
+
+The serialNumber field may have any type to which Go will match a string,
+so you can be more efficient than TEXT if you like.  We use it to store the
+serial number in base64.  You probably want to have an index on the
+serialNumber field, since we will always query on it.
+
+*/
+type DBSource struct {
+	db        *sql.DB
+	caKeyHash []byte
+}
+
+func NewSourceFromDatabase(db *sql.DB, caKeyHash []byte) (src *DBSource, err error) {
+	src = &DBSource{db: db, caKeyHash: caKeyHash}
+	return
+}
+
+const responseQuery = "SELECT resposne FROM ocsp_responses WHERE serialNumber"
+
+func (src *DBSource) Response(req *ocsp.Request) (response []byte, present bool) {
+	// Check that this request is for the proper CA
+	if bytes.Compare(req.IssuerKeyHash, src.caKeyHash) != 0 {
+		present = false
+		return
+	}
+
+	// SELECT resposne FROM ocsp_responses WHERE serialNumber
+	err := src.db.QueryRow(responseQuery).Scan(&response)
+	if err != nil {
+		present = false
+		return
+	}
+
+	present = true
+	return
+}
+
+func main() {
+	app := cmd.NewAppShell("boulder-ocsp")
+	app.Action = func(c cmd.Config) {
+		// Set up logging
+		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
+		cmd.FailOnError(err, "Couldn't connect to statsd")
+
+		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
+		cmd.FailOnError(err, "Could not connect to Syslog")
+
+		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+		defer auditlogger.AuditPanic()
+
+		blog.SetAuditLogger(auditlogger)
+
+		go cmd.ProfileCmd("OCSP", stats)
+
+		// Connect to the DB
+		db, err := sql.Open(c.OCSP.DBDriver, c.OCSP.DBName)
+		cmd.FailOnError(err, "Could not connect to database")
+		defer db.Close()
+
+		// Load the CA's key and hash it
+		caCertDER, err := cmd.LoadCert(c.CA.IssuerCert)
+		cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
+		caCert, err := x509.ParseCertificate(caCertDER)
+		cmd.FailOnError(err, fmt.Sprintf("Couldn't parse cert read from [%s]", c.CA.IssuerCert))
+		h := sha1.New()
+		h.Write(caCert.RawSubjectPublicKeyInfo)
+		caKeyHash := h.Sum(nil)
+
+		// Construct source from DB
+		src, err := NewSourceFromDatabase(db, caKeyHash)
+		cmd.FailOnError(err, "Could not connect to OCSP database")
+
+		// Configure HTTP
+		http.Handle(c.OCSP.Path, cfocsp.Responder{Source: src})
+
+		// Add HandlerTimer to output resp time + success/failure stats to statsd
+		err = http.ListenAndServe(c.WFE.ListenAddress, HandlerTimer(http.DefaultServeMux, stats))
+		cmd.FailOnError(err, "Error starting HTTP server")
+	}
+
+	app.Run()
+}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -87,6 +87,12 @@ type Config struct {
 		Password string
 	}
 
+	OCSP struct {
+		DBDriver string
+		DBName   string
+		Path     string
+	}
+
 	SubscriberAgreementURL string
 }
 


### PR DESCRIPTION
This PR adds a simple OCSP responder.

It is probably wrong in a few ways:
* It uses "database/sql" directly instead of using GORP
* It fails silently if the DB connection drops
* It manually adds responder.go instead of updating CFSSL

Suggested fixes, especially for the last issue, would be welcome.