### PR TITLE
admin-revoker tool

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -176,7 +176,7 @@ func dupeNames(names []string) bool {
 	return false
 }
 
-func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string) (err error) {
+func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string, reasonCode int) (err error) {
 	certDER, err := ca.SA.GetCertificate(serial)
 	if err != nil {
 		return err
@@ -186,21 +186,17 @@ func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string) (err error)
 		return err
 	}
 
-	// Per https://tools.ietf.org/html/rfc5280, CRLReason 0 is "unspecified."
-	// TODO: Add support for specifying reason.
-	reason := 0
-
 	signRequest := ocsp.SignRequest{
 		Certificate: cert,
 		Status:      string(core.OCSPStatusRevoked),
-		Reason:      reason,
+		Reason:      reasonCode,
 		RevokedAt:   time.Now(),
 	}
 	ocspResponse, err := ca.OCSPSigner.Sign(signRequest)
 	if err != nil {
 		return err
 	}
-	err = ca.SA.MarkCertificateRevoked(serial, ocspResponse, reason)
+	err = ca.SA.MarkCertificateRevoked(serial, ocspResponse, reasonCode)
 	return err
 }
 

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -368,7 +368,7 @@ func TestRevoke(t *testing.T) {
 	cert, err := x509.ParseCertificate(certObj.DER)
 	test.AssertNotError(t, err, "Certificate failed to parse")
 	serialString := core.SerialToString(cert.SerialNumber)
-	err = ca.RevokeCertificate(serialString)
+	err = ca.RevokeCertificate(serialString, 0)
 	test.AssertNotError(t, err, "Revocation failed")
 
 	status, err := storageAuthority.GetCertificateStatus(serialString)

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -1,0 +1,252 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"sort"
+	"strings"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	// "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+
+	// Load both drivers to allow configuring either
+	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
+	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
+
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/core"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/rpc"
+	"github.com/letsencrypt/boulder/sa"
+
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+)
+
+var reasons map[int]string = map[int]string{
+	0:  "unspecified",
+	1:  "keyCompromise",
+	2:  "cACompromise",
+	3:  "affiliationChanged",
+	4:  "superseded",
+	5:  "cessationOfOperation",
+	6:  "certificateHold",
+	// 7 is unused
+	8:  "removeFromCRL", // needed?
+	9:  "privilegeWithdrawn",
+	10: "aAcompromise",
+}
+
+func loadConfig(c *cli.Context) (config cmd.Config, err error) {
+	configFileName := c.GlobalString("config")
+	configJSON, err := ioutil.ReadFile(configFileName)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(configJSON, &config)
+	return
+}
+
+func setupContext(c cmd.Config) (rpc.CertificateAuthorityClient, *blog.AuditLogger, *gorp.DbMap) {
+	ch := cmd.AmqpChannel(c.AMQP.Server)
+
+	cac, err := rpc.NewCertificateAuthorityClient(c.AMQP.CA.Client, c.AMQP.CA.Server, ch)
+	cmd.FailOnError(err, "Unable to create CA client")
+
+	stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
+	cmd.FailOnError(err, "Couldn't connect to statsd")
+
+	auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
+	cmd.FailOnError(err, "Could not connect to Syslog")
+
+	dbMap, err := sa.NewDbMap(c.Revoker.DBDriver, c.Revoker.DBName)
+	cmd.FailOnError(err, "Couldn't setup database connection")
+
+	dbMap.AddTableWithName(core.DeniedCsr{}, "deniedCsrs").SetKeys(true, "ID")
+	err = dbMap.CreateTablesIfNotExists()
+	cmd.FailOnError(err, "Could not create the deniedCsrs table")
+
+	return cac, auditlogger, dbMap
+}
+
+func AddDeniedNames(tx *gorp.Transaction, names []string) (err error) {
+	sort.Strings(names)
+	deniedCSR := &core.DeniedCsr{Names: strings.ToLower(strings.Join(names, ","))}
+
+	err = tx.Insert(deniedCSR)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+
+	err = tx.Commit()
+	return
+}
+
+func revokeBySerial(serial string, reasonCode int, deny bool, cac rpc.CertificateAuthorityClient, auditlogger *blog.AuditLogger, tx *gorp.Transaction) {
+	if reasonCode < 0 || reasonCode == 7 || reasonCode > 10 {
+		panic(fmt.Sprintf("Invalid reason code: %d", reasonCode))
+	}
+
+	if deny {
+		// Retrieve DNS names associated with serial
+		var certificate core.Certificate
+		err := tx.SelectOne(&certificate, "SELECT * FROM certificates WHERE serial = :serial",
+			map[string]interface{}{"serial": serial})
+		cmd.FailOnError(err, fmt.Sprintf("Couldn't retrieve certificate with serial %s", serial))
+		cert, err := x509.ParseCertificate(certificate.DER)
+		cmd.FailOnError(err, "Couldn't parse certificate")
+		err = AddDeniedNames(tx, append(cert.DNSNames, cert.Subject.CommonName))
+		cmd.FailOnError(err, "Couldn't add DNS names to denied CSR table")
+	}
+
+	err := cac.RevokeCertificate(serial, reasonCode)
+	cmd.FailOnError(err, "Couldn't revoke certificate serial")
+
+	auditlogger.Info(fmt.Sprintf("Revoked certificate %s with reason '%s'", serial, reasons[reasonCode]))
+}
+
+func revokeByReg(regID int, reasonCode int, deny bool, cac rpc.CertificateAuthorityClient, auditlogger *blog.AuditLogger, tx *gorp.Transaction) {
+	_, err := tx.Get(core.Registration{}, regID)
+	if err != nil {
+		tx.Rollback()
+	}
+	cmd.FailOnError(err, "Couldn't retrieve registration")
+
+	var certs []core.Certificate
+	_, err = tx.Select(certs, "SELECT serial FROM certificates WHERE registrationID = :regID", map[string]interface{}{"regID": regID})
+	cmd.FailOnError(err, "Couldn't retrieve certificates")
+
+	for _, cert := range certs {
+		revokeBySerial(cert.Serial, reasonCode, deny, cac, auditlogger, tx)
+	}
+}
+
+var version string = "0.0.1"
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "admin-revoker"
+	app.Version = version
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "config",
+			Value:  "config.json",
+			EnvVar: "BOULDER_CONFIG",
+			Usage: "Path to Boulder JSON configuration file",
+		},
+		cli.BoolFlag{
+			Name:  "deny-future",
+			Usage: "Add certificate DNS names to the denied list",
+		},
+	}
+	app.Commands = []cli.Command{
+		{
+			Name: "serial-revoke",
+			Usage: "Revoke a single certificate by the full hex serial number",
+			Action: func(c *cli.Context) {
+				config, err := loadConfig(c)
+				cmd.FailOnError(err, "Failed to load Boulder configuration")
+
+				// 1: serial,  2: reasonCode (3: deny flag)
+				serial := c.Args().First()
+				reasonCode, err := strconv.Atoi(c.Args().Get(2))
+				cmd.FailOnError(err, "Reason code argument must be a integer")
+				deny := c.GlobalBool("deny")
+
+				cac, auditlogger, dbMap := setupContext(config)
+				// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+				defer auditlogger.AuditPanic()
+				blog.SetAuditLogger(auditlogger)
+
+				tx, err := dbMap.Begin()
+				if err != nil {
+					tx.Rollback()
+				}
+				cmd.FailOnError(err, "Couldn't being transaction")
+
+				revokeBySerial(serial, reasonCode, deny, cac, auditlogger, tx)
+
+				err = tx.Commit()
+				cmd.FailOnError(err, "Couldn't cleanly close transaction")
+			},
+		},
+		// It would be nice to be able to revoke all certificates by the signing key
+		// fingerprint, but this currently isn't stored in the DB
+		// {
+		// 	Name: "key-revoke",
+		// 	Usage: "Revoke all certificates signed by a key",
+		// 	Action: func(c *cli.Context) {
+		// 		config, err := loadConfig(c)
+		// 		cmd.FailOnError(err, "Failed to load Boulder configuration")
+
+		// 		// 1: key fingerprint(?),  2: reasonCode (3: deny flag)
+		// 		key := c.Args().First()
+		// 		reasonCode, err := strconv.Atoi(c.Args().Get(2))
+		// 		cmd.FailOnError(err, "Reason code argument must be a integer")
+
+		// 		revokeByKey(key, reasonCode, config)
+		// 	},
+		// },
+		{
+			Name: "reg-revoke",
+			Usage: "Revoke all certificates associated with a registration ID",
+			Action: func(c *cli.Context) {
+				config, err := loadConfig(c)
+				cmd.FailOnError(err, "Failed to load Boulder configuration")
+
+				// 1: registration ID,  2: reasonCode (3: deny flag)
+				regID, err := strconv.Atoi(c.Args().First())
+				cmd.FailOnError(err, "Registration ID argument must be a integer")
+				reasonCode, err := strconv.Atoi(c.Args().Get(2))
+				cmd.FailOnError(err, "Reason code argument must be a integer")
+				deny := c.GlobalBool("deny")
+
+				cac, auditlogger, dbMap := setupContext(config)
+				// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+				defer auditlogger.AuditPanic()
+				blog.SetAuditLogger(auditlogger)
+				
+				tx, err := dbMap.Begin()
+				if err != nil {
+					tx.Rollback()
+				}
+				cmd.FailOnError(err, "Couldn't being transaction")
+
+				revokeByReg(regID, reasonCode, deny, cac, auditlogger, tx)
+
+				err = tx.Commit()
+				cmd.FailOnError(err, "Couldn't cleanly close transaction")
+			},
+		},
+		{
+			Name: "list-reasons",
+			Usage: "List possible revocation reason codes",
+			Action: func(c *cli.Context) {
+				var codes []int
+				for k, _ := range reasons {
+					codes = append(codes, k)
+				}
+				sort.Ints(codes)
+				fmt.Println("Revocation reason codes\n-----------------------\n")
+				for _, k := range codes {
+					fmt.Printf("%d: %s\n", k, reasons[k])
+				}
+			},
+		},
+	}
+
+	err := app.Run(os.Args)
+	cmd.FailOnError(err, "Failed to run application")
+}

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
-	// "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
 
 	// Load both drivers to allow configuring either
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
@@ -154,7 +153,7 @@ func main() {
 	app.Commands = []cli.Command{
 		{
 			Name: "serial-revoke",
-			Usage: "Revoke a single certificate by the full hex serial number",
+			Usage: "Revoke a single certificate by the hex serial number",
 			Action: func(c *cli.Context) {
 				config, err := loadConfig(c)
 				cmd.FailOnError(err, "Failed to load Boulder configuration")
@@ -182,23 +181,6 @@ func main() {
 				cmd.FailOnError(err, "Couldn't cleanly close transaction")
 			},
 		},
-		// It would be nice to be able to revoke all certificates by the signing key
-		// fingerprint, but this currently isn't stored in the DB
-		// {
-		// 	Name: "key-revoke",
-		// 	Usage: "Revoke all certificates signed by a key",
-		// 	Action: func(c *cli.Context) {
-		// 		config, err := loadConfig(c)
-		// 		cmd.FailOnError(err, "Failed to load Boulder configuration")
-
-		// 		// 1: key fingerprint(?),  2: reasonCode (3: deny flag)
-		// 		key := c.Args().First()
-		// 		reasonCode, err := strconv.Atoi(c.Args().Get(2))
-		// 		cmd.FailOnError(err, "Reason code argument must be a integer")
-
-		// 		revokeByKey(key, reasonCode, config)
-		// 	},
-		// },
 		{
 			Name: "reg-revoke",
 			Usage: "Revoke all certificates associated with a registration ID",

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -177,7 +177,7 @@ func main() {
 				if err != nil {
 					tx.Rollback()
 				}
-				cmd.FailOnError(err, "Couldn't being transaction")
+				cmd.FailOnError(err, "Couldn't begin transaction")
 
 				err = revokeBySerial(serial, reasonCode, deny, cac, auditlogger, tx)
 				if err != nil {
@@ -208,7 +208,7 @@ func main() {
 				if err != nil {
 					tx.Rollback()
 				}
-				cmd.FailOnError(err, "Couldn't being transaction")
+				cmd.FailOnError(err, "Couldn't begin transaction")
 
 				err = revokeByReg(regID, reasonCode, deny, cac, auditlogger, tx)
 				if err != nil {

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -11,12 +11,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"sort"
+	"strconv"
 	"strings"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
 
 	// Load both drivers to allow configuring either
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
@@ -32,13 +32,13 @@ import (
 )
 
 var reasons map[int]string = map[int]string{
-	0:  "unspecified",
-	1:  "keyCompromise",
-	2:  "cACompromise",
-	3:  "affiliationChanged",
-	4:  "superseded",
-	5:  "cessationOfOperation",
-	6:  "certificateHold",
+	0: "unspecified",
+	1: "keyCompromise",
+	2: "cACompromise",
+	3: "affiliationChanged",
+	4: "superseded",
+	5: "cessationOfOperation",
+	6: "certificateHold",
 	// 7 is unused
 	8:  "removeFromCRL", // needed?
 	9:  "privilegeWithdrawn",
@@ -73,10 +73,6 @@ func setupContext(context *cli.Context) (rpc.CertificateAuthorityClient, *blog.A
 
 	dbMap, err := sa.NewDbMap(c.Revoker.DBDriver, c.Revoker.DBName)
 	cmd.FailOnError(err, "Couldn't setup database connection")
-
-	dbMap.AddTableWithName(core.DeniedCsr{}, "deniedCsrs").SetKeys(true, "ID")
-	err = dbMap.CreateTablesIfNotExists()
-	cmd.FailOnError(err, "Could not create the deniedCsrs table")
 
 	return cac, auditlogger, dbMap
 }
@@ -146,7 +142,7 @@ func main() {
 			Name:   "config",
 			Value:  "config.json",
 			EnvVar: "BOULDER_CONFIG",
-			Usage: "Path to Boulder JSON configuration file",
+			Usage:  "Path to Boulder JSON configuration file",
 		},
 		cli.BoolFlag{
 			Name:  "deny-future",
@@ -155,7 +151,7 @@ func main() {
 	}
 	app.Commands = []cli.Command{
 		{
-			Name: "serial-revoke",
+			Name:  "serial-revoke",
 			Usage: "Revoke a single certificate by the hex serial number",
 			Action: func(c *cli.Context) {
 				// 1: serial,  2: reasonCode (3: deny flag)
@@ -182,7 +178,7 @@ func main() {
 			},
 		},
 		{
-			Name: "reg-revoke",
+			Name:  "reg-revoke",
 			Usage: "Revoke all certificates associated with a registration ID",
 			Action: func(c *cli.Context) {
 				// 1: registration ID,  2: reasonCode (3: deny flag)
@@ -196,7 +192,7 @@ func main() {
 				// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 				defer auditlogger.AuditPanic()
 				blog.SetAuditLogger(auditlogger)
-				
+
 				tx, err := dbMap.Begin()
 				if err != nil {
 					tx.Rollback()
@@ -210,7 +206,7 @@ func main() {
 			},
 		},
 		{
-			Name: "list-reasons",
+			Name:  "list-reasons",
 			Usage: "List possible revocation reason codes",
 			Action: func(c *cli.Context) {
 				var codes []int
@@ -218,7 +214,7 @@ func main() {
 					codes = append(codes, k)
 				}
 				sort.Ints(codes)
-				fmt.Println("Revocation reason codes\n-----------------------\n")
+				fmt.Printf("Revocation reason codes\n-----------------------\n\n")
 				for _, k := range codes {
 					fmt.Printf("%d: %s\n", k, reasons[k])
 				}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -80,6 +80,11 @@ type Config struct {
 		Tag     string
 	}
 
+	Revoker struct {
+		DBDriver string
+		DBName   string
+	}
+
 	Mail struct {
 		Server   string
 		Port     string

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -107,8 +107,6 @@ type StorageAdder interface {
 	MarkCertificateRevoked(serial string, ocspResponse []byte, reasonCode int) error
 
 	AddCertificate([]byte, int64) (string, error)
-
-	AddDeniedCSR([]string) error
 }
 
 // StorageAuthority interface represents a simple key/value

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -79,7 +79,7 @@ type ValidationAuthority interface {
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
 	IssueCertificate(x509.CertificateRequest, int64) (Certificate, error)
-	RevokeCertificate(serial string) error
+	RevokeCertificate(string, int) error
 }
 
 type PolicyAuthority interface {

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -280,7 +280,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(base core.Authorization
 
 func (ra *RegistrationAuthorityImpl) RevokeCertificate(cert x509.Certificate) error {
 	serialString := core.SerialToString(cert.SerialNumber)
-	err := ra.CA.RevokeCertificate(serialString)
+	err := ra.CA.RevokeCertificate(serialString, 0)
 
 	// AUDIT[ Revocation Requests ] 4e85d791-09c0-4ab3-a837-d3d67e945134
 	if err != nil {

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -727,24 +727,6 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 		return nil
 	})
 
-	rpc.Handle(MethodAddDeniedCSR, func(req []byte) []byte {
-		var csrReq struct {
-			Names []string
-		}
-
-		if err := json.Unmarshal(req, csrReq); err != nil {
-			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
-			improperMessage(MethodAddDeniedCSR, err, req)
-			return nil
-		}
-
-		if err := impl.AddDeniedCSR(csrReq.Names); err != nil {
-			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			errorCondition(MethodAddDeniedCSR, err, csrReq)
-		}
-		return nil
-	})
-
 	rpc.Handle(MethodAlreadyDeniedCSR, func(req []byte) []byte {
 		var csrReq struct {
 			Names []string
@@ -956,21 +938,6 @@ func (cac StorageAuthorityClient) AddCertificate(cert []byte, regID int64) (id s
 	return
 }
 
-func (cac StorageAuthorityClient) AddDeniedCSR(names []string) (err error) {
-	var sliceReq struct {
-		Names []string
-	}
-	sliceReq.Names = names
-
-	data, err := json.Marshal(sliceReq)
-	if err != nil {
-		return
-	}
-
-	_, err = cac.rpc.DispatchSync(MethodAddDeniedCSR, data)
-	return
-}
-
 func (cac StorageAuthorityClient) AlreadyDeniedCSR(names []string) (exists bool, err error) {
 	var sliceReq struct {
 		Names []string
@@ -984,7 +951,7 @@ func (cac StorageAuthorityClient) AlreadyDeniedCSR(names []string) (exists bool,
 
 	response, err := cac.rpc.DispatchSync(MethodAlreadyDeniedCSR, data)
 	if err != nil || len(response) == 0 {
-		err = errors.New("AddDeniedCSR RPC failed") // XXX
+		err = errors.New("AlreadyDeniedCSR RPC failed") // XXX
 		return
 	}
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -35,7 +35,7 @@ func digest256(data []byte) []byte {
 	return d.Sum(nil)
 }
 
-var DialectMap map[string]interface{} = map[string]interface{}{
+var dialectMap map[string]interface{} = map[string]interface{}{
 	"sqlite3":  gorp.SqliteDialect{},
 	"mysql":    gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8"},
 	"postgres": gorp.PostgresDialect{},
@@ -149,7 +149,7 @@ func NewDbMap(driver, dbName string) (dbMap *gorp.DbMap, err error) {
 		return
 	}
 
-	dialect, ok := DialectMap[driver].(gorp.Dialect)
+	dialect, ok := dialectMap[driver].(gorp.Dialect)
 	if !ok {
 		err = fmt.Errorf("Couldn't find dialect for %s", driver)
 		return
@@ -688,24 +688,24 @@ func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte, regID int64) (dig
 	return
 }
 
-func (ssa *SQLStorageAuthority) AddDeniedCSR(names []string) (err error) {
-	sort.Strings(names)
-	deniedCSR := &core.DeniedCsr{Names: strings.ToLower(strings.Join(names, ","))}
+// func (ssa *SQLStorageAuthority) AddDeniedCSR(names []string) (err error) {
+// 	sort.Strings(names)
+// 	deniedCSR := &core.DeniedCsr{Names: strings.ToLower(strings.Join(names, ","))}
 
-	tx, err := ssa.dbMap.Begin()
-	if err != nil {
-		return
-	}
+// 	tx, err := ssa.dbMap.Begin()
+// 	if err != nil {
+// 		return
+// 	}
 
-	err = tx.Insert(deniedCSR)
-	if err != nil {
-		tx.Rollback()
-		return
-	}
+// 	err = tx.Insert(deniedCSR)
+// 	if err != nil {
+// 		tx.Rollback()
+// 		return
+// 	}
 
-	err = tx.Commit()
-	return
-}
+// 	err = tx.Commit()
+// 	return
+// }
 
 func (ssa *SQLStorageAuthority) AlreadyDeniedCSR(names []string) (already bool, err error) {
 	sort.Strings(names)

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -190,6 +190,7 @@ func (ssa *SQLStorageAuthority) InitTables() (err error) {
 	ssa.dbMap.AddTableWithName(core.CertificateStatus{}, "certificateStatus").SetKeys(false, "Serial").SetVersionCol("LockCol")
 	ssa.dbMap.AddTableWithName(core.OcspResponse{}, "ocspResponses").SetKeys(true, "ID")
 	ssa.dbMap.AddTableWithName(core.Crl{}, "crls").SetKeys(false, "Serial")
+	ssa.dbMap.AddTableWithName(core.DeniedCsr{}, "deniedCsrs").SetKeys(true, "ID")
 
 	err = ssa.dbMap.CreateTablesIfNotExists()
 	return

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -190,7 +190,6 @@ func (ssa *SQLStorageAuthority) InitTables() (err error) {
 	ssa.dbMap.AddTableWithName(core.CertificateStatus{}, "certificateStatus").SetKeys(false, "Serial").SetVersionCol("LockCol")
 	ssa.dbMap.AddTableWithName(core.OcspResponse{}, "ocspResponses").SetKeys(true, "ID")
 	ssa.dbMap.AddTableWithName(core.Crl{}, "crls").SetKeys(false, "Serial")
-	// ssa.dbMap.AddTableWithName(core.DeniedCsr{}, "deniedCsrs").SetKeys(true, "ID").ColMap("Names").SetUnique(true)
 
 	err = ssa.dbMap.CreateTablesIfNotExists()
 	return
@@ -687,25 +686,6 @@ func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte, regID int64) (dig
 	err = tx.Commit()
 	return
 }
-
-// func (ssa *SQLStorageAuthority) AddDeniedCSR(names []string) (err error) {
-// 	sort.Strings(names)
-// 	deniedCSR := &core.DeniedCsr{Names: strings.ToLower(strings.Join(names, ","))}
-
-// 	tx, err := ssa.dbMap.Begin()
-// 	if err != nil {
-// 		return
-// 	}
-
-// 	err = tx.Insert(deniedCSR)
-// 	if err != nil {
-// 		tx.Rollback()
-// 		return
-// 	}
-
-// 	err = tx.Commit()
-// 	return
-// }
 
 func (ssa *SQLStorageAuthority) AlreadyDeniedCSR(names []string) (already bool, err error) {
 	sort.Strings(names)

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -203,11 +203,4 @@ func TestDeniedCSR(t *testing.T) {
 	exists, err := sa.AlreadyDeniedCSR(append(csr.DNSNames, csr.Subject.CommonName))
 	test.AssertNotError(t, err, "AlreadyDeniedCSR failed")
 	test.Assert(t, !exists, "Found non-existent CSR")
-
-	err = sa.AddDeniedCSR(append(csr.DNSNames, csr.Subject.CommonName))
-	test.AssertNotError(t, err, "Couldn't add the denied CSR to the DB")
-
-	exists, err = sa.AlreadyDeniedCSR(append(csr.DNSNames, csr.Subject.CommonName))
-	test.AssertNotError(t, err, "AlreadyDeniedCSR failed")
-	test.Assert(t, exists, "Couldn't find denied CSR in DB")
 }

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -46,10 +46,15 @@
     "issuerCert": "test/test-ca.pem",
     "_comment": "This should only be present in testMode. In prod use an HSM.",
     "issuerKey": "test/test-ca.key",
-    "expiry": "8760h",
+    "expiry": "8760h"
   },
 
   "sa": {
+    "dbDriver": "sqlite3",
+    "dbName": ":memory:"
+  },
+
+  "revoker": {
     "dbDriver": "sqlite3",
     "dbName": ":memory:"
   },


### PR DESCRIPTION
Fixes #198.

Currently provides two ways to revoke certificates, either directly by the hex serial or by associated registration ID. It also provides a subcommand to list revocation reason codes and their short names since I kept forgetting what they meant. I followed @jcjones OCSP-Signer lead and added a `NewDbMap` function to the `SA` to simplify the creation of the `dbMap` object.

It might also make sense to add a command to revoke all certificates by the cert public key fingerprint, but this would require us to add a fingerprint field to the `core.Certificate` object. I may do this tomorrow but it's 1 AM at the moment so now I'm going to bed!