### PR TITLE
Only validate POSTed challenges

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -73,7 +73,7 @@ type RegistrationAuthority interface {
 
 type ValidationAuthority interface {
 	// [RegistrationAuthority]
-	UpdateValidations(Authorization) error
+	UpdateValidations(Authorization, int) error
 }
 
 type CertificateAuthority interface {

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -273,7 +273,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(base core.Authorization
 	}
 
 	// Dispatch to the VA for service
-	ra.VA.UpdateValidations(authz)
+	ra.VA.UpdateValidations(authz, challengeIndex)
 
 	return
 }

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -32,7 +32,7 @@ type DummyValidationAuthority struct {
 	Argument core.Authorization
 }
 
-func (dva *DummyValidationAuthority) UpdateValidations(authz core.Authorization) (err error) {
+func (dva *DummyValidationAuthority) UpdateValidations(authz core.Authorization, index int) (err error) {
 	dva.Called = true
 	dva.Argument = authz
 	return

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -243,7 +243,7 @@ func TestValidateHTTPS(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{challHTTPS},
 	}
-	va.validate(authz)
+	va.validate(authz, 0)
 
 	test.AssertEquals(t, core.StatusValid, mockRA.lastAuthz.Challenges[0].Status)
 }
@@ -276,7 +276,7 @@ func TestValidateDvsni(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{challDvsni},
 	}
-	va.validate(authz)
+	va.validate(authz, 0)
 
 	test.AssertEquals(t, core.StatusValid, mockRA.lastAuthz.Challenges[0].Status)
 }
@@ -309,7 +309,7 @@ func TestValidateDvsniNotSane(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{challDvsni},
 	}
-	va.validate(authz)
+	va.validate(authz, 0)
 
 	test.AssertEquals(t, core.StatusInvalid, mockRA.lastAuthz.Challenges[0].Status)
 }
@@ -323,10 +323,10 @@ func TestUpdateValidations(t *testing.T) {
 		ID:             core.NewToken(),
 		RegistrationID: 1,
 		Identifier:     ident,
-		Challenges:     []core.Challenge{},
+		Challenges:     []core.Challenge{core.DvsniChallenge()},
 	}
 
-	va.UpdateValidations(authz)
+	va.UpdateValidations(authz, 0)
 
 	// Nothing to assert.
 }


### PR DESCRIPTION
Fixes #114. Switches `VA.UpdateValidations` from attempting to validate all `authz.Challenges` after a challenge is updated to only validating the one that was updated.