### PR TITLE
Resolved Issue #230

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -50,7 +50,7 @@ type WebFrontEnd interface {
 
 type RegistrationAuthority interface {
 	// [WebFrontEnd]
-	NewRegistration(Registration, jose.JsonWebKey) (Registration, error)
+	NewRegistration(Registration) (Registration, error)
 
 	// [WebFrontEnd]
 	NewAuthorization(Authorization, int64) (Authorization, error)

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"time"
 
-	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/policy"
@@ -63,9 +62,8 @@ type certificateRequestEvent struct {
 	Error               string    `json:",omitempty"`
 }
 
-func (ra *RegistrationAuthorityImpl) NewRegistration(init core.Registration, key jose.JsonWebKey) (reg core.Registration, err error) {
+func (ra *RegistrationAuthorityImpl) NewRegistration(init core.Registration) (reg core.Registration, err error) {
 	reg = core.Registration{
-		Key:           key,
 		RecoveryToken: core.NewToken(),
 	}
 	reg.MergeUpdate(init)

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -66,7 +66,6 @@ const (
 //  -> OnValidationUpdate
 type registrationRequest struct {
 	Reg core.Registration
-	Key jose.JsonWebKey
 }
 
 type authorizationRequest struct {
@@ -100,7 +99,7 @@ func NewRegistrationAuthorityServer(serverQueue string, channel *amqp.Channel, i
 			return nil
 		}
 
-		reg, err := impl.NewRegistration(rr.Reg, rr.Key)
+		reg, err := impl.NewRegistration(rr.Reg)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewRegistration, err, reg)
@@ -262,8 +261,8 @@ func NewRegistrationAuthorityClient(clientQueue, serverQueue string, channel *am
 	return
 }
 
-func (rac RegistrationAuthorityClient) NewRegistration(reg core.Registration, key jose.JsonWebKey) (newReg core.Registration, err error) {
-	data, err := json.Marshal(registrationRequest{reg, key})
+func (rac RegistrationAuthorityClient) NewRegistration(reg core.Registration) (newReg core.Registration, err error) {
+	data, err := json.Marshal(registrationRequest{reg})
 	if err != nil {
 		return
 	}

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -335,7 +334,7 @@ type MockRegistrationAuthority struct {
 	lastAuthz *core.Authorization
 }
 
-func (ra *MockRegistrationAuthority) NewRegistration(reg core.Registration, jwk jose.JsonWebKey) (core.Registration, error) {
+func (ra *MockRegistrationAuthority) NewRegistration(reg core.Registration) (core.Registration, error) {
 	return reg, nil
 }
 

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -268,8 +268,9 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 		return
 	}
 	init.MergeUpdate(unmarshalled)
+	init.Key = *key
 
-	reg, err := wfe.RA.NewRegistration(init, *key)
+	reg, err := wfe.RA.NewRegistration(init)
 	if err != nil {
 		wfe.sendError(response, "Error creating new registration", err, http.StatusInternalServerError)
 		return

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -316,8 +316,7 @@ func TestIssueCertificate(t *testing.T) {
 
 type MockRegistrationAuthority struct{}
 
-func (ra *MockRegistrationAuthority) NewRegistration(reg core.Registration, jwk jose.JsonWebKey) (core.Registration, error) {
-	reg.Key = jwk
+func (ra *MockRegistrationAuthority) NewRegistration(reg core.Registration) (core.Registration, error) {
 	return reg, nil
 }
 


### PR DESCRIPTION
- Move setting the core.Registration.Key field from RA.NewRegistration to
  WFE.NewRegistration to avoid a chicken-and-egg problem.
- Note: I kept the RPC wrapper object even though it now only has one field.
  Seems like it's a good practice to use wrapper objects, even though we don't
  everywhere.