### PR TITLE
Issue #238 - MySql column width too narrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bin
 
 # Test files
 test/js/node_modules
+test/js/*.pem
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -39,16 +39,14 @@ func NewCertificateAuthorityDatabaseImpl(driver string, name string) (cadb core.
 		db:  db,
 		log: logger,
 	}
-
-	err = createTablesIfNotExist(db)
 	return
 }
 
 // createTablesIfNotExist builds the database tables and inserts the initial
 // state, if the tables do not already exist. It is not an error for the tables
 // to already exist.
-func createTablesIfNotExist(db *sql.DB) (err error) {
-	tx, err := db.Begin()
+func (cadb *CertificateAuthorityDatabaseImpl) CreateTablesIfNotExists() (err error) {
+	tx, err := cadb.db.Begin()
 	if err != nil {
 		return
 	}

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -35,6 +35,9 @@ func TestBeginCommit(t *testing.T) {
 	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
 
+	err = cadb.CreateTablesIfNotExists()
+	test.AssertNotError(t, err, "Could not construct tables")
+
 	err = cadb.Begin()
 	test.AssertNotError(t, err, "Could not begin")
 
@@ -53,6 +56,9 @@ func TestGetSetSequenceOutsideTx(t *testing.T) {
 	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
 
+	err = cadb.CreateTablesIfNotExists()
+	test.AssertNotError(t, err, "Could not construct tables")
+
 	_, err = cadb.IncrementAndGetSerial()
 	test.AssertError(t, err, "Not permitted")
 }
@@ -60,6 +66,9 @@ func TestGetSetSequenceOutsideTx(t *testing.T) {
 func TestGetSetSequenceNumber(t *testing.T) {
 	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
+
+	err = cadb.CreateTablesIfNotExists()
+	test.AssertNotError(t, err, "Could not construct tables")
 
 	err = cadb.Begin()
 	test.AssertNotError(t, err, "Could not begin")

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -322,11 +322,15 @@ func (cadb *MockCADatabase) IncrementAndGetSerial() (int, error) {
 	return 1, nil
 }
 
+func (cadb *MockCADatabase) CreateTablesIfNotExists() error {
+	return nil
+}
+
 func setup(t *testing.T) (cadb core.CertificateAuthorityDatabase, storageAuthority core.StorageAuthority, caConfig Config) {
 	// Create an SA
 	ssa, err := sa.NewSQLStorageAuthority("sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
-	ssa.InitTables()
+	ssa.CreateTablesIfNotExists()
 	storageAuthority = ssa
 
 	cadb, _ = NewMockCertificateAuthorityDatabase()

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -36,6 +36,11 @@ func main() {
 		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBName)
 		cmd.FailOnError(err, "Failed to create CA database")
 
+		if c.SQL.CreateTables {
+			err = cadb.CreateTablesIfNotExists()
+			cmd.FailOnError(err, "Failed to create CA tables")
+		}
+
 		cai, err := ca.NewCertificateAuthorityImpl(cadb, c.CA)
 		cmd.FailOnError(err, "Failed to create CA impl")
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -35,7 +35,12 @@ func main() {
 
 		sai, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Failed to create SA impl")
-		sai.SetSQLDebug(c.SA.SQLDebug)
+		sai.SetSQLDebug(c.SQL.SQLDebug)
+
+		if c.SQL.CreateTables {
+			err = sai.CreateTablesIfNotExists()
+			cmd.FailOnError(err, "Failed to create tables")
+		}
 
 		go cmd.ProfileCmd("SA", stats)
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -35,6 +35,7 @@ func main() {
 
 		sai, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Failed to create SA impl")
+		sai.SetSQLDebug(c.SA.SQLDebug)
 
 		go cmd.ProfileCmd("SA", stats)
 

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -77,6 +77,7 @@ func main() {
 		wfe := wfe.NewWebFrontEndImpl()
 		sa, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Unable to create SA")
+		sa.SetSQLDebug(c.SA.SQLDebug)
 
 		ra := ra.NewRegistrationAuthorityImpl()
 		va := va.NewValidationAuthorityImpl(c.CA.TestMode)

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -77,7 +77,7 @@ func main() {
 		wfe := wfe.NewWebFrontEndImpl()
 		sa, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Unable to create SA")
-		sa.SetSQLDebug(c.SA.SQLDebug)
+		sa.SetSQLDebug(c.SQL.SQLDebug)
 
 		ra := ra.NewRegistrationAuthorityImpl()
 		va := va.NewValidationAuthorityImpl(c.CA.TestMode)
@@ -87,6 +87,14 @@ func main() {
 
 		ca, err := ca.NewCertificateAuthorityImpl(cadb, c.CA)
 		cmd.FailOnError(err, "Unable to create CA")
+
+		if c.SQL.CreateTables {
+			err = sa.CreateTablesIfNotExists()
+			cmd.FailOnError(err, "Failed to create SA tables")
+
+			err = cadb.CreateTablesIfNotExists()
+			cmd.FailOnError(err, "Failed to create CA tables")
+		}
 
 		// Wire them up
 		wfe.RA = &ra

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -67,6 +67,7 @@ type Config struct {
 	SA struct {
 		DBDriver string
 		DBName   string
+		SQLDebug bool
 	}
 
 	Statsd struct {

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -67,7 +67,11 @@ type Config struct {
 	SA struct {
 		DBDriver string
 		DBName   string
-		SQLDebug bool
+	}
+
+	SQL struct {
+		CreateTables bool
+		SQLDebug     bool
 	}
 
 	Statsd struct {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -119,9 +119,9 @@ type StorageAuthority interface {
 
 // CertificateAuthorityDatabase represents an atomic sequence source
 type CertificateAuthorityDatabase interface {
+	CreateTablesIfNotExists() error
 	Begin() error
 	Commit() error
 	Rollback() error
-
 	IncrementAndGetSerial() (int, error)
 }

--- a/core/objects.go
+++ b/core/objects.go
@@ -103,7 +103,7 @@ type Registration struct {
 	ID int64 `json:"-" db:"id"`
 
 	// Account key to which the details are attached
-	Key jose.JsonWebKey `json:"key" db:"key"`
+	Key jose.JsonWebKey `json:"key" db:"jwk"`
 
 	// Recovery Token is used to prove connection to an earlier transaction
 	RecoveryToken string `json:"recoveryToken" db:"recoveryToken"`

--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -12,6 +12,7 @@ import (
 	"log/syslog"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 )
@@ -117,7 +118,7 @@ func GetAuditLogger() *AuditLogger {
 // Log the provided message at the appropriate level, writing to
 // both stdout and the Logger, as well as informing statsd.
 func (log *AuditLogger) logAtLevel(level, msg string) (err error) {
-	fmt.Printf("%s\n", msg)
+	fmt.Printf("%s %s\n", time.Now().Format("2006/01/02 15:04:05"), msg)
 	log.Stats.Inc(level, 1, 1.0)
 
 	switch level {

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -62,6 +62,10 @@ func (cadb *MockCADatabase) IncrementAndGetSerial() (int, error) {
 	return 1, nil
 }
 
+func (cadb *MockCADatabase) CreateTablesIfNotExists() error {
+	return nil
+}
+
 var (
 	// These values we simulate from the client
 	AccountKeyJSON = []byte(`{
@@ -116,7 +120,7 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 
 	sa, err := sa.NewSQLStorageAuthority("sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
-	sa.InitTables()
+	sa.CreateTablesIfNotExists()
 
 	va := &DummyValidationAuthority{}
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -204,7 +204,7 @@ func (ssa *SQLStorageAuthority) SetSQLDebug(state bool) {
 func (ssa *SQLStorageAuthority) initTables() {
 	regTable := ssa.dbMap.AddTableWithName(core.Registration{}, "registrations").SetKeys(true, "ID")
 	regTable.SetVersionCol("LockCol")
-	regTable.ColMap("Key").SetMaxSize(512).SetNotNull(true)
+	regTable.ColMap("Key").SetMaxSize(1024).SetNotNull(true)
 
 	pendingAuthzTable := ssa.dbMap.AddTableWithName(pendingauthzModel{}, "pending_authz").SetKeys(false, "ID")
 	pendingAuthzTable.SetVersionCol("LockCol")

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -28,7 +28,7 @@ func initSA(t *testing.T) *SQLStorageAuthority {
 	if err != nil {
 		t.Fatalf("Failed to create SA")
 	}
-	if err = sa.InitTables(); err != nil {
+	if err = sa.CreateTablesIfNotExists(); err != nil {
 		t.Fatalf("Failed to create SA")
 	}
 	return sa

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,10 @@ fi
 
 # Kill all children on exit.
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
-go run ./cmd/boulder/main.go --config test/boulder-config.json &
+
+BOULDER_CONFIG=${BOULDER_CONFIG:-test/boulder-config.json}
+
+go run ./cmd/boulder/main.go &
 go run Godeps/_workspace/src/github.com/cloudflare/cfssl/cmd/cfssl/cfssl.go \
   -loglevel 0 \
   serve \

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -51,8 +51,12 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
-    "SQLDebug": false
+    "dbName": ":memory:"
+  },
+
+  "sql": {
+    "SQLDebug": true,
+    "CreateTables": false
   },
 
   "revoker": {

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -51,7 +51,8 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:"
+    "dbName": ":memory:",
+    "SQLDebug": false
   },
 
   "revoker": {

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -32,7 +32,7 @@
 
   "wfe": {
     "baseURL": "http://localhost:4300",
-    "listenAddress": "0.0.0.0:4300"
+    "listenAddress": "127.0.0.1:4300"
   },
 
   "ca": {
@@ -51,7 +51,8 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:"
+    "dbName": ":memory:",
+    "SQLDebug": false
   },
 
   "mail": {

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -51,8 +51,12 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
-    "SQLDebug": false
+    "dbName": ":memory:"
+  },
+
+  "sql": {
+    "SQLDebug": false,
+    "CreateTables": true
   },
 
   "mail": {


### PR DESCRIPTION
- Added SQL debug logging (SA option: "SQLDebug")
- Added timestamps to the log prints to stdout
- Ignore *.pem in test/js
- Modified start.sh to support environment overrides for BOULDER_CONFIG, like the AMQP mode
- Changed boulder-test-config to open the server on the loopback device, so as to not cause firewall prompts on each integration test run for those of us being restrictive
- Renamed "key" column to "jwk" in DB, to avoid keyword conflict
- Set MaxLength on "jwk" column to 512