### PR TITLE
RPC Fix and Issue #202: OCSP Update Tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ OBJECTS = activity-monitor \
 	boulder-ra \
 	boulder-sa \
 	boulder-va \
-	boulder-wfe
+	boulder-wfe \
+	ocsp-updater
 
 .PHONY: all build
 all: build

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ OBJECTS = activity-monitor \
 	boulder-wfe \
 	ocsp-updater
 
+REVID = $(shell git symbolic-ref --short HEAD):$(shell git rev-parse --short HEAD)
+BUILD_ID_VAR = github.com/letsencrypt/boulder/core.BuildID
+
 .PHONY: all build
 all: build
 
@@ -23,7 +26,7 @@ pre:
 
 # Compile each of the binaries
 $(OBJECTS): pre
-	go build -o ./bin/$@ cmd/$@/main.go
+	go build -o ./bin/$@ -ldflags "-X $(BUILD_ID_VAR) $(REVID)" cmd/$@/main.go
 
 clean:
 	rm -f $(OBJDIR)/*

--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -12,13 +12,14 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+
 	"github.com/letsencrypt/boulder/analysis"
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
-	"time"
 )
 
 const (
@@ -149,6 +150,8 @@ func main() {
 		ch := cmd.AmqpChannel(c.AMQP.Server)
 
 		go cmd.ProfileCmd("AM", stats)
+
+		auditlogger.Info(app.VersionString())
 
 		startMonitor(ch, auditlogger, stats)
 	}

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -58,6 +58,8 @@ func main() {
 			cas, err := rpc.NewCertificateAuthorityServer(c.AMQP.CA.Server, ch, cai)
 			cmd.FailOnError(err, "Unable to create CA server")
 
+			auditlogger.Info(app.VersionString())
+
 			cmd.RunUntilSignaled(auditlogger, cas, closeChan)
 		}
 	}

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -50,7 +50,7 @@ func main() {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-			sac, err := rpc.NewStorageAuthorityClient(c.AMQP.SA.Client, c.AMQP.SA.Client, ch)
+			sac, err := rpc.NewStorageAuthorityClient("CA->SA", c.AMQP.SA.Server, ch)
 			cmd.FailOnError(err, "Failed to create SA client")
 
 			cai.SA = &sac

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -38,13 +38,13 @@ func main() {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-			vac, err := rpc.NewValidationAuthorityClient(c.AMQP.VA.Client, c.AMQP.VA.Server, ch)
+			vac, err := rpc.NewValidationAuthorityClient("RA->VA", c.AMQP.VA.Server, ch)
 			cmd.FailOnError(err, "Unable to create VA client")
 
-			cac, err := rpc.NewCertificateAuthorityClient(c.AMQP.CA.Client, c.AMQP.CA.Server, ch)
+			cac, err := rpc.NewCertificateAuthorityClient("RA->CA", c.AMQP.CA.Server, ch)
 			cmd.FailOnError(err, "Unable to create CA client")
 
-			sac, err := rpc.NewStorageAuthorityClient(c.AMQP.SA.Client, c.AMQP.SA.Server, ch)
+			sac, err := rpc.NewStorageAuthorityClient("RA->SA", c.AMQP.SA.Server, ch)
 			cmd.FailOnError(err, "Unable to create SA client")
 
 			rai.VA = &vac

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -13,6 +13,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/ra"
 	"github.com/letsencrypt/boulder/rpc"
+	"github.com/letsencrypt/boulder/wfe"
 )
 
 func main() {
@@ -31,6 +32,7 @@ func main() {
 		blog.SetAuditLogger(auditlogger)
 
 		rai := ra.NewRegistrationAuthorityImpl()
+		rai.AuthzBase = c.WFE.BaseURL + wfe.AuthzPath
 
 		go cmd.ProfileCmd("RA", stats)
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -56,6 +56,8 @@ func main() {
 			ras, err := rpc.NewRegistrationAuthorityServer(c.AMQP.RA.Server, ch, &rai)
 			cmd.FailOnError(err, "Unable to create RA server")
 
+			auditlogger.Info(app.VersionString())
+
 			cmd.RunUntilSignaled(auditlogger, ras, closeChan)
 		}
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -50,6 +50,8 @@ func main() {
 
 			sas := rpc.NewStorageAuthorityServer(c.AMQP.SA.Server, ch, sai)
 
+			auditlogger.Info(app.VersionString())
+
 			cmd.RunUntilSignaled(auditlogger, sas, closeChan)
 		}
 	}

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -46,6 +46,8 @@ func main() {
 			vas, err := rpc.NewValidationAuthorityServer(c.AMQP.VA.Server, ch, &vai)
 			cmd.FailOnError(err, "Unable to create VA server")
 
+			auditlogger.Info(app.VersionString())
+
 			cmd.RunUntilSignaled(auditlogger, vas, closeChan)
 		}
 	}

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -38,7 +38,7 @@ func main() {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-			rac, err := rpc.NewRegistrationAuthorityClient(c.AMQP.RA.Client, c.AMQP.RA.Server, ch)
+			rac, err := rpc.NewRegistrationAuthorityClient("VA->RA", c.AMQP.RA.Server, ch)
 			cmd.FailOnError(err, "Unable to create RA client")
 
 			vai.RA = &rac

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -8,10 +8,10 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
-	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
@@ -109,6 +109,8 @@ func main() {
 		// Set up paths
 		wfe.BaseURL = c.WFE.BaseURL
 		wfe.HandlePaths()
+
+		auditlogger.Info(app.VersionString())
 
 		// Add HandlerTimer to output resp time + success/failure stats to statsd
 		err = http.ListenAndServe(c.WFE.ListenAddress, HandlerTimer(http.DefaultServeMux, stats))

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -23,10 +23,10 @@ func setupWFE(c cmd.Config) (rpc.RegistrationAuthorityClient, rpc.StorageAuthori
 	ch := cmd.AmqpChannel(c.AMQP.Server)
 	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-	rac, err := rpc.NewRegistrationAuthorityClient(c.AMQP.RA.Client, c.AMQP.RA.Server, ch)
+	rac, err := rpc.NewRegistrationAuthorityClient("WFE->RA", c.AMQP.RA.Server, ch)
 	cmd.FailOnError(err, "Unable to create RA client")
 
-	sac, err := rpc.NewStorageAuthorityClient(c.AMQP.SA.Client, c.AMQP.SA.Server, ch)
+	sac, err := rpc.NewStorageAuthorityClient("WFE->SA", c.AMQP.SA.Server, ch)
 	cmd.FailOnError(err, "Unable to create SA client")
 
 	return rac, sac, closeChan

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -117,6 +117,8 @@ func main() {
 		wfei.BaseURL = c.WFE.BaseURL
 		wfei.HandlePaths()
 
+		auditlogger.Info(app.VersionString())
+
 		fmt.Fprintf(os.Stderr, "Server running, listening on %s...\n", c.WFE.ListenAddress)
 		err = http.ListenAndServe(c.WFE.ListenAddress, HandlerTimer(http.DefaultServeMux, stats))
 		cmd.FailOnError(err, "Error starting HTTP server")

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -74,12 +74,13 @@ func main() {
 		go cmd.ProfileCmd("Monolith", stats)
 
 		// Create the components
-		wfe := wfe.NewWebFrontEndImpl()
+		wfei := wfe.NewWebFrontEndImpl()
 		sa, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
 		cmd.FailOnError(err, "Unable to create SA")
 		sa.SetSQLDebug(c.SQL.SQLDebug)
 
 		ra := ra.NewRegistrationAuthorityImpl()
+
 		va := va.NewValidationAuthorityImpl(c.CA.TestMode)
 
 		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBName)
@@ -97,12 +98,12 @@ func main() {
 		}
 
 		// Wire them up
-		wfe.RA = &ra
-		wfe.SA = sa
-		wfe.Stats = stats
-		wfe.SubscriberAgreementURL = c.SubscriberAgreementURL
+		wfei.RA = &ra
+		wfei.SA = sa
+		wfei.Stats = stats
+		wfei.SubscriberAgreementURL = c.SubscriberAgreementURL
 
-		wfe.IssuerCert, err = cmd.LoadCert(c.CA.IssuerCert)
+		wfei.IssuerCert, err = cmd.LoadCert(c.CA.IssuerCert)
 		cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.CA.IssuerCert))
 
 		ra.CA = ca
@@ -112,12 +113,9 @@ func main() {
 		ca.SA = sa
 
 		// Set up paths
-		wfe.BaseURL = c.WFE.BaseURL
-		wfe.HandlePaths()
-
-		// We need to tell the RA how to make challenge URIs
-		// XXX: Better way to do this?  Part of improved configuration
-		ra.AuthzBase = wfe.AuthzBase
+		ra.AuthzBase = c.WFE.BaseURL + wfe.AuthzPath
+		wfei.BaseURL = c.WFE.BaseURL
+		wfei.HandlePaths()
 
 		fmt.Fprintf(os.Stderr, "Server running, listening on %s...\n", c.WFE.ListenAddress)
 		err = http.ListenAndServe(c.WFE.ListenAddress, HandlerTimer(http.DefaultServeMux, stats))

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/crypto/ocsp"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 )
 
@@ -133,6 +134,8 @@ func main() {
 
 		// Configure HTTP
 		http.Handle(c.OCSP.Path, cfocsp.Responder{Source: src})
+
+		auditlogger.Info(app.VersionString())
 
 		// Add HandlerTimer to output resp time + success/failure stats to statsd
 		err = http.ListenAndServe(c.WFE.ListenAddress, HandlerTimer(http.DefaultServeMux, stats))

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2014 ISRG.  All rights reserved
+// Copyright 2015 ISRG.  All rights reserved
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -1,0 +1,100 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+	"time"
+
+	"github.com/letsencrypt/boulder/cmd"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/rpc"
+	"github.com/letsencrypt/boulder/wfe"
+
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+)
+
+func setupClients(c cmd.Config) (cac rpc.CertificateAuthorityClient, dbMap gorp.DbMap, chan *amqp.Error) {
+	ch := cmd.AmqpChannel(c.AMQP.Server)
+	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
+
+	cac, err := rpc.NewCertificateAuthorityClient(c.AMQP.CA.Client, c.AMQP.CA.Server, ch)
+	cmd.FailOnError(err, "Unable to create CA client")
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	dbmap := &gorp.DbMap{
+		Db: db,
+		Dialect: gorp.SqliteDialect{},
+		//Dialect: gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8"},
+		TypeConverter: core.BoulderTypeConverter{}
+	}
+	return cac, dbMap, closeChan
+}
+
+func updateOne(dbMap gorp.DbMap) {
+	tx, err := ssa.dbMap.Begin()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// If there are fewer than this many days left before the currently-signed
+	// OCSP response expires, sign a new OCSP response.
+	minDaysToExpiry := 3
+	var certificateStatus []core.CertificateStatus
+	result, err = tx.Select(&certificateStatus,
+		`SELECT * FROM certificateStatus
+		 WHERE ocspLastUpdated > ?
+		 ORDER BY ocspLastUpdated ASC
+		 LIMIT 1`, time.Now().Add(-minDaysToExpiry * 24 * time.Hour))
+	if err == sql.ErrNoRows {
+		return
+	} else if err != nil {
+		blog.GetAuditLogger().Error("Error getting certificate status: " + err.Error())
+	} else {
+		fmt.Println(result)
+	}
+}
+
+func main() {
+	app := cmd.NewAppShell("ocsp-updater")
+	app.Action = func(c cmd.Config) {
+		// Set up logging
+		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
+		cmd.FailOnError(err, "Couldn't connect to statsd")
+
+		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
+		cmd.FailOnError(err, "Could not connect to Syslog")
+
+		blog.SetAuditLogger(auditlogger)
+
+		cac, dbMap, closeChan := setupClients(c)
+
+		go func() {
+			// sit around and reconnect to AMQP if the channel
+			// drops for some reason and repopulate the wfe object
+			// with new RA and SA rpc clients.
+			for {
+				for err := range closeChan {
+					auditlogger.Warning(fmt.Sprintf("AMQP Channel closed, will reconnect in 5 seconds: [%s]", err))
+					time.Sleep(time.Second * 5)
+					cac, dbMap, closeChan = setupClients(c)
+					wfe.RA = &rac
+					wfe.SA = &sac
+					auditlogger.Warning("Reconnected to AMQP")
+				}
+			}
+		}()
+
+		updateOne()
+	}
+
+	app.Run()
+}

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -181,6 +181,8 @@ func main() {
 			}
 		}()
 
+		auditlogger.Info(app.VersionString())
+
 		// Calculate the cut-off timestamp
 		dur, err := time.ParseDuration(c.OCSP.MinTimeToExpiry)
 		cmd.FailOnError(err, "Could not parse MinTimeToExpiry from config.")

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -6,65 +6,148 @@
 package main
 
 import (
+	"crypto/x509"
+	"database/sql"
 	"fmt"
-	"net/http"
-
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+	"math"
 	"time"
 
+	// Load both drivers to allow configuring either
+	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
+	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
-	"github.com/letsencrypt/boulder/wfe"
-
-	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+	"github.com/letsencrypt/boulder/sa"
 )
 
-func setupClients(c cmd.Config) (cac rpc.CertificateAuthorityClient, dbMap gorp.DbMap, chan *amqp.Error) {
+const ocspResponseLimit int = 128
+
+func setupClients(c cmd.Config) (rpc.CertificateAuthorityClient, chan *amqp.Error) {
 	ch := cmd.AmqpChannel(c.AMQP.Server)
 	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-	cac, err := rpc.NewCertificateAuthorityClient(c.AMQP.CA.Client, c.AMQP.CA.Server, ch)
+	cac, err := rpc.NewCertificateAuthorityClient("OCSP->CA", c.AMQP.CA.Server, ch)
 	cmd.FailOnError(err, "Unable to create CA client")
 
-	db, err := sql.Open("sqlite3", ":memory:")
-	dbmap := &gorp.DbMap{
-		Db: db,
-		Dialect: gorp.SqliteDialect{},
-		//Dialect: gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8"},
-		TypeConverter: core.BoulderTypeConverter{}
-	}
-	return cac, dbMap, closeChan
+	return cac, closeChan
 }
 
-func updateOne(dbMap gorp.DbMap) {
-	tx, err := ssa.dbMap.Begin()
+func processResponse(cac rpc.CertificateAuthorityClient, tx *gorp.Transaction, serial string) error {
+	certObj, err := tx.Get(core.Certificate{}, serial)
 	if err != nil {
-		tx.Rollback()
+		return err
+	}
+	statusObj, err := tx.Get(core.CertificateStatus{}, serial)
+	if err != nil {
 		return err
 	}
 
+	cert := certObj.(*core.Certificate)
+	status := statusObj.(*core.CertificateStatus)
+
+	_, err = x509.ParseCertificate(cert.DER)
+	if err != nil {
+		return err
+	}
+
+	signRequest := core.OCSPSigningRequest{
+		CertDER:   cert.DER,
+		Reason:    status.RevokedReason,
+		Status:    string(status.Status),
+		RevokedAt: status.RevokedDate,
+	}
+
+	ocspResponse, err := cac.GenerateOCSP(signRequest)
+	if err != nil {
+		return err
+	}
+
+	timeStamp := time.Now()
+
+	// Record the response.
+	ocspResp := &core.OcspResponse{Serial: serial, CreatedAt: timeStamp, Response: ocspResponse}
+	err = tx.Insert(ocspResp)
+	if err != nil {
+		return err
+	}
+
+	// Reset the update clock
+	status.OCSPLastUpdated = timeStamp
+	_, err = tx.Update(status)
+	if err != nil {
+		return err
+	}
+
+	// Done
+	return nil
+}
+
+func findStaleResponses(cac rpc.CertificateAuthorityClient, dbMap *gorp.DbMap, oldestLastUpdatedTime time.Time, responseLimit int) error {
+	log := blog.GetAuditLogger()
+
 	// If there are fewer than this many days left before the currently-signed
 	// OCSP response expires, sign a new OCSP response.
-	minDaysToExpiry := 3
 	var certificateStatus []core.CertificateStatus
-	result, err = tx.Select(&certificateStatus,
-		`SELECT * FROM certificateStatus
-		 WHERE ocspLastUpdated > ?
-		 ORDER BY ocspLastUpdated ASC
-		 LIMIT 1`, time.Now().Add(-minDaysToExpiry * 24 * time.Hour))
+	_, err := dbMap.Select(&certificateStatus,
+		`SELECT cs.* FROM certificateStatus AS cs
+		 WHERE cs.ocspLastUpdated < ?
+		 ORDER BY cs.ocspLastUpdated ASC
+		 LIMIT ?`, oldestLastUpdatedTime, responseLimit)
+
 	if err == sql.ErrNoRows {
-		return
+		log.Info("All up to date. No OCSP responses needed.")
 	} else if err != nil {
-		blog.GetAuditLogger().Error("Error getting certificate status: " + err.Error())
+		log.Err(fmt.Sprintf("Error loading certificate status: %s", err))
 	} else {
-		fmt.Println(result)
+		log.Info(fmt.Sprintf("Processing OCSP Responses...\n"))
+		for i, status := range certificateStatus {
+			log.Info(fmt.Sprintf("OCSP %d: %s", i, status.Serial))
+
+			// Each response gets a transaction. To speed this up, we can batch
+			// transactions.
+			tx, err := dbMap.Begin()
+			if err != nil {
+				log.Err(fmt.Sprintf("Error starting transaction, aborting: %s", err))
+				tx.Rollback()
+				return err
+			}
+
+			if err := processResponse(cac, tx, status.Serial); err != nil {
+				log.Err(fmt.Sprintf("Could not process OCSP Response for %s: %s", status.Serial, err))
+				tx.Rollback()
+			} else {
+				log.Info(fmt.Sprintf("OCSP %d: %s OK", i, status.Serial))
+				tx.Commit()
+			}
+		}
 	}
+
+	return err
 }
 
 func main() {
 	app := cmd.NewAppShell("ocsp-updater")
+
+	app.App.Flags = append(app.App.Flags, cli.IntFlag{
+		Name:   "limit",
+		Value:  ocspResponseLimit,
+		EnvVar: "OCSP_LIMIT",
+		Usage:  "Count of responses to process per run",
+	})
+
+	app.Config = func(c *cli.Context, config cmd.Config) cmd.Config {
+		config.OCSP.ResponseLimit = c.GlobalInt("limit")
+		return config
+	}
+
 	app.Action = func(c cmd.Config) {
 		// Set up logging
 		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
@@ -73,27 +156,44 @@ func main() {
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
 
+		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+		defer auditlogger.AuditPanic()
+
 		blog.SetAuditLogger(auditlogger)
 
-		cac, dbMap, closeChan := setupClients(c)
+		// Configure DB
+		dbMap, err := sa.NewDbMap(c.OCSP.DBDriver, c.OCSP.DBName)
+		cmd.FailOnError(err, "Could not connect to database")
+
+		dbMap.AddTableWithName(core.OcspResponse{}, "ocspResponses").SetKeys(true, "ID")
+		dbMap.AddTableWithName(core.Certificate{}, "certificates").SetKeys(false, "Serial")
+		dbMap.AddTableWithName(core.CertificateStatus{}, "certificateStatus").SetKeys(false, "Serial").SetVersionCol("LockCol")
+
+		cac, closeChan := setupClients(c)
 
 		go func() {
-			// sit around and reconnect to AMQP if the channel
-			// drops for some reason and repopulate the wfe object
-			// with new RA and SA rpc clients.
+			// Abort if we disconnect from AMQP
 			for {
 				for err := range closeChan {
-					auditlogger.Warning(fmt.Sprintf("AMQP Channel closed, will reconnect in 5 seconds: [%s]", err))
-					time.Sleep(time.Second * 5)
-					cac, dbMap, closeChan = setupClients(c)
-					wfe.RA = &rac
-					wfe.SA = &sac
-					auditlogger.Warning("Reconnected to AMQP")
+					auditlogger.Warning(fmt.Sprintf("AMQP Channel closed, aborting early: [%s]", err))
+					panic(err)
 				}
 			}
 		}()
 
-		updateOne()
+		// Calculate the cut-off timestamp
+		dur, err := time.ParseDuration(c.OCSP.MinTimeToExpiry)
+		cmd.FailOnError(err, "Could not parse MinTimeToExpiry from config.")
+
+		oldestLastUpdatedTime := time.Now().Add(-dur)
+		auditlogger.Info(fmt.Sprintf("Searching for OCSP reponses older than %s", oldestLastUpdatedTime))
+
+		count := int(math.Min(float64(ocspResponseLimit), float64(c.OCSP.ResponseLimit)))
+
+		err = findStaleResponses(cac, dbMap, oldestLastUpdatedTime, count)
+		if err != nil {
+			auditlogger.WarningErr(err)
+		}
 	}
 
 	app.Run()

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -1,4 +1,4 @@
-// Copyright 2014 ISRG.  All rights reserved
+// Copyright 2015 ISRG.  All rights reserved
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -38,6 +38,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
 	"github.com/letsencrypt/boulder/ca"
+	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
 )
@@ -161,6 +162,11 @@ func (as *AppShell) Run() {
 
 	err := as.App.Run(os.Args)
 	FailOnError(err, "Failed to run application")
+}
+
+// VersionString produces a friendly Application version string
+func (as *AppShell) VersionString() string {
+	return fmt.Sprintf("%s (version %s, build %s)", as.App.Name, as.App.Version, core.GetBuildID())
 }
 
 // FailOnError exits and prints an error message if we encountered a problem

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -51,10 +51,11 @@ type Config struct {
 	// General
 	AMQP struct {
 		Server string
-		RA     QueuePair
-		VA     QueuePair
-		SA     QueuePair
-		CA     QueuePair
+		RA     Queue
+		VA     Queue
+		SA     Queue
+		CA     Queue
+		OCSP   Queue
 	}
 
 	WFE struct {
@@ -98,24 +99,26 @@ type Config struct {
 	}
 
 	OCSP struct {
-		DBDriver string
-		DBName   string
-		Path     string
+		DBDriver        string
+		DBName          string
+		Path            string
+		MinTimeToExpiry string
+		ResponseLimit   int
 	}
 
 	SubscriberAgreementURL string
 }
 
-// QueuePair describes a client-server pair of queue names
-type QueuePair struct {
-	Client string
+// Queue describes a queue name
+type Queue struct {
 	Server string
 }
 
 // AppShell contains CLI Metadata
 type AppShell struct {
 	Action func(Config)
-	app    *cli.App
+	Config func(*cli.Context, Config) Config
+	App    *cli.App
 }
 
 // NewAppShell creates a basic AppShell object containing CLI metadata
@@ -130,16 +133,17 @@ func NewAppShell(name string) (shell *AppShell) {
 			Name:   "config",
 			Value:  "config.json",
 			EnvVar: "BOULDER_CONFIG",
+			Usage:  "Path to Config JSON",
 		},
 	}
 
-	return &AppShell{app: app}
+	return &AppShell{App: app}
 }
 
 // Run begins the application context, reading config and passing
 // control to the default commandline action.
 func (as *AppShell) Run() {
-	as.app.Action = func(c *cli.Context) {
+	as.App.Action = func(c *cli.Context) {
 		configFileName := c.GlobalString("config")
 		configJSON, err := ioutil.ReadFile(configFileName)
 		FailOnError(err, "Unable to read config file")
@@ -148,10 +152,14 @@ func (as *AppShell) Run() {
 		err = json.Unmarshal(configJSON, &config)
 		FailOnError(err, "Failed to read configuration")
 
+		if as.Config != nil {
+			config = as.Config(c, config)
+		}
+
 		as.Action(config)
 	}
 
-	err := as.app.Run(os.Args)
+	err := as.App.Run(os.Args)
 	FailOnError(err, "Failed to run application")
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -80,6 +80,7 @@ type CertificateAuthority interface {
 	// [RegistrationAuthority]
 	IssueCertificate(x509.CertificateRequest, int64) (Certificate, error)
 	RevokeCertificate(string, int) error
+	GenerateOCSP(OCSPSigningRequest) ([]byte, error)
 }
 
 type PolicyAuthority interface {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -102,7 +102,7 @@ type StorageAdder interface {
 	NewRegistration(Registration) (Registration, error)
 	UpdateRegistration(Registration) error
 
-	NewPendingAuthorization() (string, error)
+	NewPendingAuthorization(Authorization) (Authorization, error)
 	UpdatePendingAuthorization(Authorization) error
 	FinalizeAuthorization(Authorization) error
 	MarkCertificateRevoked(serial string, ocspResponse []byte, reasonCode int) error

--- a/core/objects.go
+++ b/core/objects.go
@@ -400,3 +400,11 @@ type DeniedCsr struct {
 
 	Names string `db:"names"`
 }
+
+// OCSPSigningRequest is a transfer object representing an OCSP Signing Request
+type OCSPSigningRequest struct {
+	CertDER   []byte
+	Status    string
+	Reason    int
+	RevokedAt time.Time
+}

--- a/core/objects.go
+++ b/core/objects.go
@@ -250,7 +250,7 @@ func (ch Challenge) MergeResponse(resp Challenge) Challenge {
 // of an account key holder to act on behalf of a domain.  This
 // struct is intended to be used both internally and for JSON
 // marshaling on the wire.  Any fields that should be suppressed
-// on the wire (e.g., ID) must be made empty before marshaling.
+// on the wire (e.g., ID, regID) must be made empty before marshaling.
 type Authorization struct {
 	// An identifier for this authorization, unique across
 	// authorizations and certificates within this instance.
@@ -260,7 +260,7 @@ type Authorization struct {
 	Identifier AcmeIdentifier `json:"identifier,omitempty" db:"identifier"`
 
 	// The registration ID associated with the authorization
-	RegistrationID int64 `json:"-" db:"registrationID"`
+	RegistrationID int64 `json:"regId,omitempty" db:"registrationID"`
 
 	// The status of the validation of this authorization
 	Status AcmeStatus `json:"status,omitempty" db:"status"`
@@ -320,9 +320,6 @@ func (jb *JsonBuffer) UnmarshalJSON(data []byte) (err error) {
 // thing exposed on the wire is the certificate itself.
 type Certificate struct {
 	RegistrationID int64 `db:"registrationID"`
-
-	// The parsed version of DER. Useful for extracting things like serial number.
-	ParsedCertificate *x509.Certificate `db:"-"`
 
 	// The revocation status of the certificate.
 	// * "valid" - not revoked

--- a/core/objects.go
+++ b/core/objects.go
@@ -100,7 +100,7 @@ func (cr CertificateRequest) MarshalJSON() ([]byte, error) {
 // to account keys.
 type Registration struct {
 	// Unique identifier
-	ID int64 `json:"-" db:"id"`
+	ID int64 `json:"id" db:"id"`
 
 	// Account key to which the details are attached
 	Key jose.JsonWebKey `json:"key" db:"jwk"`

--- a/core/util.go
+++ b/core/util.go
@@ -28,6 +28,12 @@ import (
 	"strings"
 )
 
+// Package Variables Variables
+
+// BuildID is set by the compiler (using -ldflags "-X core.BuildID $(git rev-parse --short HEAD)")
+// and is used by GetBuildID
+var BuildID string
+
 // Errors
 
 type NotSupportedError string
@@ -231,4 +237,13 @@ func StringToSerial(serial string) (*big.Int, error) {
 	}
 	_, err := fmt.Sscanf(serial, "%032x", &serialNum)
 	return &serialNum, err
+}
+
+// GetBuildID identifies what build is running.
+func GetBuildID() (retID string) {
+	retID = BuildID
+	if retID == "" {
+		retID = "Unspecified"
+	}
+	return
 }

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -48,3 +48,7 @@ func TestSerialUtils(t *testing.T) {
 	test.AssertEquals(t, fmt.Sprintf("%v", err), "Serial number should be 32 characters long")
 	fmt.Println(badSerial)
 }
+
+func TestBuildID(t *testing.T) {
+	test.AssertEquals(t, "Unspecified", GetBuildID())
+}

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -87,16 +87,27 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 		return authz, err
 	}
 
-	// Create validations
-	// TODO: Assign URLs
+	// Create validations, but we have to update them with URIs later
 	challenges, combinations := ra.PA.ChallengesFor(identifier)
-	authID, err := ra.SA.NewPendingAuthorization()
+
+	// Partially-filled object
+	authz = core.Authorization{
+		Identifier:     identifier,
+		RegistrationID: regID,
+		Status:         core.StatusPending,
+		Combinations:   combinations,
+	}
+
+	// Get a pending Auth first so we can get our ID back, then update with challenges
+	authz, err = ra.SA.NewPendingAuthorization(authz)
 	if err != nil {
 		return authz, err
 	}
+
+	// Construct all the challenge URIs
 	for i := range challenges {
 		// Ignoring these errors because we construct the URLs to be correct
-		challengeURI, _ := url.Parse(ra.AuthzBase + authID + "?challenge=" + strconv.Itoa(i))
+		challengeURI, _ := url.Parse(ra.AuthzBase + authz.ID + "?challenge=" + strconv.Itoa(i))
 		challenges[i].URI = core.AcmeURL(*challengeURI)
 
 		if !challenges[i].IsSane(false) {
@@ -105,15 +116,8 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 		}
 	}
 
-	// Create a new authorization object
-	authz = core.Authorization{
-		ID:             authID,
-		Identifier:     identifier,
-		RegistrationID: regID,
-		Status:         core.StatusPending,
-		Challenges:     challenges,
-		Combinations:   combinations,
-	}
+	// Update object
+	authz.Challenges = challenges
 
 	// Store the authorization object, then return it
 	err = ra.SA.UpdatePendingAuthorization(authz)
@@ -238,12 +242,16 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 		return emptyCert, nil
 	}
 
-	cert.ParsedCertificate, err = x509.ParseCertificate([]byte(cert.DER))
+	parsedCertificate, err := x509.ParseCertificate([]byte(cert.DER))
+	if err != nil {
+		logEvent.Error = err.Error()
+		return emptyCert, err
+	}
 
-	logEvent.SerialNumber = cert.ParsedCertificate.SerialNumber
-	logEvent.CommonName = cert.ParsedCertificate.Subject.CommonName
-	logEvent.NotBefore = cert.ParsedCertificate.NotBefore
-	logEvent.NotAfter = cert.ParsedCertificate.NotAfter
+	logEvent.SerialNumber = parsedCertificate.SerialNumber
+	logEvent.CommonName = parsedCertificate.Subject.CommonName
+	logEvent.NotBefore = parsedCertificate.NotBefore
+	logEvent.NotAfter = parsedCertificate.NotAfter
 	logEvent.ResponseTime = time.Now()
 
 	logEventResult = "successful"

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -189,7 +189,7 @@ func TestNewAuthorization(t *testing.T) {
 
 func TestUpdateAuthorization(t *testing.T) {
 	_, va, sa, ra := initAuthorities(t)
-	AuthzInitial.ID, _ = sa.NewPendingAuthorization()
+	AuthzInitial, _ = sa.NewPendingAuthorization(AuthzInitial)
 	sa.UpdatePendingAuthorization(AuthzInitial)
 
 	authz, err := ra.UpdateAuthorization(AuthzInitial, ResponseIndex, Response)
@@ -218,7 +218,7 @@ func TestUpdateAuthorization(t *testing.T) {
 
 func TestOnValidationUpdate(t *testing.T) {
 	_, _, sa, ra := initAuthorities(t)
-	AuthzUpdated.ID, _ = sa.NewPendingAuthorization()
+	AuthzUpdated, _ = sa.NewPendingAuthorization(AuthzUpdated)
 	sa.UpdatePendingAuthorization(AuthzUpdated)
 
 	// Simulate a successful simpleHTTPS challenge
@@ -245,7 +245,7 @@ func TestOnValidationUpdate(t *testing.T) {
 func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 	_, _, sa, ra := initAuthorities(t)
 	authz := core.Authorization{}
-	authz.ID, _ = sa.NewPendingAuthorization()
+	authz, _ = sa.NewPendingAuthorization(authz)
 	authz.Identifier = core.AcmeIdentifier{
 		Type:  core.IdentifierDNS,
 		Value: "www.example.com",
@@ -276,14 +276,14 @@ func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 func TestNewCertificate(t *testing.T) {
 	_, _, sa, ra := initAuthorities(t)
 	AuthzFinal.RegistrationID = 1
-	AuthzFinal.ID, _ = sa.NewPendingAuthorization()
+	AuthzFinal, _ = sa.NewPendingAuthorization(AuthzFinal)
 	sa.UpdatePendingAuthorization(AuthzFinal)
 	sa.FinalizeAuthorization(AuthzFinal)
 
 	// Inject another final authorization to cover www.example.com
 	AuthzFinalWWW = AuthzFinal
 	AuthzFinalWWW.Identifier.Value = "www.example.com"
-	AuthzFinalWWW.ID, _ = sa.NewPendingAuthorization()
+	AuthzFinalWWW, _ = sa.NewPendingAuthorization(AuthzFinalWWW)
 	sa.FinalizeAuthorization(AuthzFinalWWW)
 
 	// Construct a cert request referencing the two authorizations

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -201,7 +201,7 @@ type AmqpRPCCLient struct {
 func NewAmqpRPCCLient(clientQueuePrefix, serverQueue string, channel *amqp.Channel) (rpc *AmqpRPCCLient, err error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	clientQueue := fmt.Sprintf("%s.%s", clientQueuePrefix, hostname)
@@ -218,7 +218,7 @@ func NewAmqpRPCCLient(clientQueuePrefix, serverQueue string, channel *amqp.Chann
 	// Subscribe to the response queue and dispatch
 	msgs, err := amqpSubscribe(rpc.channel, clientQueue, nil)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	go func() {
@@ -238,7 +238,7 @@ func NewAmqpRPCCLient(clientQueuePrefix, serverQueue string, channel *amqp.Chann
 		}
 	}()
 
-	return
+	return rpc, err
 }
 
 func (rpc *AmqpRPCCLient) SetTimeout(ttl time.Duration) {

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -8,6 +8,7 @@ package rpc
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
@@ -147,14 +148,14 @@ func (rpc *AmqpRPCServer) Start() (err error) {
 		for msg := range msgs {
 			// XXX-JWS: jws.Verify(body)
 			cb, present := rpc.dispatchTable[msg.Type]
-			rpc.log.Info(fmt.Sprintf(" [s<] received %s(%s) [%s]", msg.Type, core.B64enc(msg.Body), msg.CorrelationId))
+			rpc.log.Info(fmt.Sprintf(" [s<][%s] received %s(%s) [%s]", rpc.serverQueue, msg.Type, core.B64enc(msg.Body), msg.CorrelationId))
 			if !present {
 				// AUDIT[ Misrouted Messages ] f523f21f-12d2-4c31-b2eb-ee4b7d96d60e
-				rpc.log.Audit(fmt.Sprintf("Misrouted message: %s - %s - %s", msg.Type, core.B64enc(msg.Body), msg.CorrelationId))
+				rpc.log.Audit(fmt.Sprintf(" [s<][%s] Misrouted message: %s - %s - %s", rpc.serverQueue, msg.Type, core.B64enc(msg.Body), msg.CorrelationId))
 				continue
 			}
 			response := cb(msg.Body)
-			rpc.log.Info(fmt.Sprintf(" [s>] sending %s(%s) [%s]", msg.Type, core.B64enc(response), msg.CorrelationId))
+			rpc.log.Info(fmt.Sprintf(" [s>][%s] sending %s(%s) [%s]", rpc.serverQueue, msg.Type, core.B64enc(response), msg.CorrelationId))
 			rpc.channel.Publish(
 				AmqpExchange,
 				msg.ReplyTo,
@@ -197,7 +198,14 @@ type AmqpRPCCLient struct {
 	log         *blog.AuditLogger
 }
 
-func NewAmqpRPCCLient(clientQueue, serverQueue string, channel *amqp.Channel) (rpc *AmqpRPCCLient, err error) {
+func NewAmqpRPCCLient(clientQueuePrefix, serverQueue string, channel *amqp.Channel) (rpc *AmqpRPCCLient, err error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return
+	}
+
+	clientQueue := fmt.Sprintf("%s.%s", clientQueuePrefix, hostname)
+
 	rpc = &AmqpRPCCLient{
 		serverQueue: serverQueue,
 		clientQueue: clientQueue,
@@ -219,8 +227,10 @@ func NewAmqpRPCCLient(clientQueue, serverQueue string, channel *amqp.Channel) (r
 			corrID := msg.CorrelationId
 			responseChan, present := rpc.pending[corrID]
 
-			rpc.log.Debug(fmt.Sprintf(" [c<] received %s(%s) [%s]", msg.Type, core.B64enc(msg.Body), corrID))
+			rpc.log.Debug(fmt.Sprintf(" [c<][%s] received %s(%s) [%s]", clientQueue, msg.Type, core.B64enc(msg.Body), corrID))
 			if !present {
+				// AUDIT[ Misrouted Messages ] f523f21f-12d2-4c31-b2eb-ee4b7d96d60e
+				rpc.log.Audit(fmt.Sprintf(" [c<][%s] Misrouted message: %s - %s - %s", clientQueue, msg.Type, core.B64enc(msg.Body), msg.CorrelationId))
 				continue
 			}
 			responseChan <- msg.Body
@@ -244,7 +254,7 @@ func (rpc *AmqpRPCCLient) Dispatch(method string, body []byte) chan []byte {
 	rpc.pending[corrID] = responseChan
 
 	// Send the request
-	rpc.log.Debug(fmt.Sprintf(" [c>] sending %s(%s) [%s]", method, core.B64enc(body), corrID))
+	rpc.log.Debug(fmt.Sprintf(" [c>][%s] sending %s(%s) [%s]", rpc.clientQueue, method, core.B64enc(body), corrID))
 	rpc.channel.Publish(
 		AmqpExchange,
 		rpc.serverQueue,
@@ -265,7 +275,7 @@ func (rpc *AmqpRPCCLient) DispatchSync(method string, body []byte) (response []b
 	case response = <-rpc.Dispatch(method, body):
 		return
 	case <-time.After(rpc.timeout):
-		rpc.log.Warning(fmt.Sprintf(" [c!] AMQP-RPC timeout [%s]", method))
+		rpc.log.Warning(fmt.Sprintf(" [c!][%s] AMQP-RPC timeout [%s]", rpc.clientQueue, method))
 		err = errors.New("AMQP-RPC timeout")
 		return
 	}

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
@@ -77,14 +76,6 @@ type authorizationRequest struct {
 type certificateRequest struct {
 	Req   core.CertificateRequest
 	RegID int64
-}
-
-// ocspSigningRequest is a transfer object representing an OCSP Signing Request
-type ocspSigningRequest struct {
-	CertDER   []byte
-	Status    string
-	Reason    int
-	RevokedAt time.Time
 }
 
 func improperMessage(method string, err error, obj interface{}) {

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -659,7 +659,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 
 	rpc.Handle(MethodNewRegistration, func(req []byte) (response []byte) {
 		var registration core.Registration
-		err := json.Unmarshal(req, registration)
+		err := json.Unmarshal(req, &registration)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodNewRegistration, err, req)
@@ -693,7 +693,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 
 	rpc.Handle(MethodUpdatePendingAuthorization, func(req []byte) []byte {
 		var authz core.Authorization
-		if err := json.Unmarshal(req, authz); err != nil {
+		if err := json.Unmarshal(req, &authz); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodUpdatePendingAuthorization, err, req)
 			return nil
@@ -708,7 +708,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 
 	rpc.Handle(MethodFinalizeAuthorization, func(req []byte) []byte {
 		var authz core.Authorization
-		if err := json.Unmarshal(req, authz); err != nil {
+		if err := json.Unmarshal(req, &authz); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodFinalizeAuthorization, err, req)
 			return nil
@@ -765,7 +765,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 			ReasonCode   int
 		}
 
-		if err := json.Unmarshal(req, revokeReq); err != nil {
+		if err := json.Unmarshal(req, &revokeReq); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodMarkCertificateRevoked, err, req)
 			return nil
@@ -785,7 +785,7 @@ func NewStorageAuthorityServer(serverQueue string, channel *amqp.Channel, impl c
 			Names []string
 		}
 
-		err := json.Unmarshal(req, csrReq)
+		err := json.Unmarshal(req, &csrReq)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodAlreadyDeniedCSR, err, req)
@@ -849,7 +849,7 @@ func (cac StorageAuthorityClient) GetRegistrationByKey(key jose.JsonWebKey) (reg
 		return
 	}
 
-	jsonReg, err := cac.rpc.DispatchSync(MethodGetRegistration, jsonKey)
+	jsonReg, err := cac.rpc.DispatchSync(MethodGetRegistrationByKey, jsonKey)
 	if err != nil {
 		return
 	}
@@ -930,7 +930,7 @@ func (cac StorageAuthorityClient) NewRegistration(reg core.Registration) (output
 		err = errors.New("NewRegistration RPC failed") // XXX
 		return
 	}
-	err = json.Unmarshal(response, output)
+	err = json.Unmarshal(response, &output)
 	if err != nil {
 		err = errors.New("NewRegistration RPC failed")
 		return

--- a/sa/database.go
+++ b/sa/database.go
@@ -1,0 +1,46 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sa
+
+import (
+	"database/sql"
+	"fmt"
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+var dialectMap map[string]interface{} = map[string]interface{}{
+	"sqlite3":  gorp.SqliteDialect{},
+	"mysql":    gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8"},
+	"postgres": gorp.PostgresDialect{},
+}
+
+// NewDbMap creates the root gorp mapping object. Create one of these for each
+// database schema you wish to map. Each DbMap contains a list of mapped tables.
+func NewDbMap(driver string, name string) (*gorp.DbMap, error) {
+	logger := blog.GetAuditLogger()
+
+	db, err := sql.Open(driver, name)
+	if err != nil {
+		return nil, err
+	}
+	if err = db.Ping(); err != nil {
+		return nil, err
+	}
+
+	logger.Debug(fmt.Sprintf("Connecting to database %s %s", driver, name))
+
+	dialect, ok := dialectMap[driver].(gorp.Dialect)
+	if !ok {
+		err = fmt.Errorf("Couldn't find dialect for %s", driver)
+		return nil, err
+	}
+
+	logger.Info(fmt.Sprintf("Connected to database %s %s", driver, name))
+
+	dbmap := &gorp.DbMap{Db: db, Dialect: dialect, TypeConverter: BoulderTypeConverter{}}
+	return dbmap, err
+}

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -1,0 +1,6 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sa

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -54,92 +54,6 @@ type authzModel struct {
 	Sequence int64 `db:"sequence"`
 }
 
-// Type converter
-type boulderTypeConverter struct{}
-
-func (tc boulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
-	switch t := val.(type) {
-	case core.AcmeIdentifier, []core.Challenge, []core.AcmeURL, [][]int:
-		jsonBytes, err := json.Marshal(t)
-		if err != nil {
-			return nil, err
-		}
-		return string(jsonBytes), nil
-	case jose.JsonWebKey:
-		// HACK: Some of our storage methods, like NewAuthorization, expect to
-		// write to the DB with the default, empty key, so we treat it specially,
-		// serializing to an empty string. TODO: Modify authorizations to refer
-		// to a registration id, and make sure registration ids are always filled.
-		// https://github.com/letsencrypt/boulder/issues/181
-		if t.Key == nil {
-			return "", nil
-		}
-		jsonBytes, err := t.MarshalJSON()
-		if err != nil {
-			return "", err
-		}
-		return string(jsonBytes), nil
-	case core.AcmeStatus:
-		return string(t), nil
-	case core.OCSPStatus:
-		return string(t), nil
-	default:
-		return val, nil
-	}
-}
-
-func (tc boulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, bool) {
-	switch target.(type) {
-	case *core.AcmeIdentifier, *[]core.Challenge, *[]core.AcmeURL, *[][]int, core.JsonBuffer:
-		binder := func(holder, target interface{}) error {
-			s, ok := holder.(*string)
-			if !ok {
-				return errors.New("FromDb: Unable to convert *string")
-			}
-			b := []byte(*s)
-			return json.Unmarshal(b, target)
-		}
-		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
-	case *jose.JsonWebKey:
-		binder := func(holder, target interface{}) error {
-			s, ok := holder.(*string)
-			if !ok {
-				return errors.New("FromDb: Unable to convert *string")
-			}
-			b := []byte(*s)
-			k := target.(*jose.JsonWebKey)
-			if *s != "" {
-				return k.UnmarshalJSON(b)
-			} else {
-				// HACK: Sometimes we can have an empty string the in the DB where a
-				// key should be. We should fix that (see HACK above). In the meantime,
-				// return the default JsonWebKey in such situations.
-				// https://github.com/letsencrypt/boulder/issues/181
-				return nil
-			}
-		}
-		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
-	case *core.AcmeStatus:
-		binder := func(holder, target interface{}) error {
-			s := holder.(*string)
-			st := target.(*core.AcmeStatus)
-			*st = core.AcmeStatus(*s)
-			return nil
-		}
-		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
-	case *core.OCSPStatus:
-		binder := func(holder, target interface{}) error {
-			s := holder.(*string)
-			st := target.(*core.OCSPStatus)
-			*st = core.OCSPStatus(*s)
-			return nil
-		}
-		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
-	default:
-		return gorp.CustomScanner{}, false
-	}
-}
-
 func NewDbMap(driver, dbName string) (dbMap *gorp.DbMap, err error) {
 	db, err := sql.Open(driver, dbName)
 	if err != nil {
@@ -155,7 +69,7 @@ func NewDbMap(driver, dbName string) (dbMap *gorp.DbMap, err error) {
 		return
 	}
 
-	dbMap = &gorp.DbMap{Db: db, Dialect: dialect, TypeConverter: boulderTypeConverter{}}
+	dbMap = &gorp.DbMap{Db: db, Dialect: dialect, TypeConverter: BoulderTypeConverter{}}
 	return
 }
 

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -351,16 +351,16 @@ func (ssa *SQLStorageAuthority) GetCertificateStatus(serial string) (status core
 	return
 }
 
-func (ssa *SQLStorageAuthority) NewRegistration(reg core.Registration) (output core.Registration, err error) {
+func (ssa *SQLStorageAuthority) NewRegistration(reg core.Registration) (core.Registration, error) {
 	tx, err := ssa.dbMap.Begin()
 	if err != nil {
-		return
+		return reg, err
 	}
 
 	err = tx.Insert(&reg)
 	if err != nil {
 		tx.Rollback()
-		return
+		return reg, err
 	}
 
 	err = tx.Commit()

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -91,15 +91,18 @@ func TestAddRegistration(t *testing.T) {
 func TestAddAuthorization(t *testing.T) {
 	sa := initSA(t)
 
-	paID, err := sa.NewPendingAuthorization()
+	PA := core.Authorization{}
+
+	PA, err := sa.NewPendingAuthorization(PA)
 	test.AssertNotError(t, err, "Couldn't create new pending authorization")
-	test.Assert(t, paID != "", "ID shouldn't be blank")
+	test.Assert(t, PA.ID != "", "ID shouldn't be blank")
 
-	dbPa, err := sa.GetAuthorization(paID)
-	test.AssertNotError(t, err, "Couldn't get pending authorization with ID "+paID)
+	dbPa, err := sa.GetAuthorization(PA.ID)
+	test.AssertNotError(t, err, "Couldn't get pending authorization with ID "+PA.ID)
+	test.AssertMarshaledEquals(t, PA, dbPa)
 
-	expectedPa := core.Authorization{ID: paID}
-	test.AssertEquals(t, dbPa.ID, expectedPa.ID)
+	expectedPa := core.Authorization{ID: PA.ID}
+	test.AssertMarshaledEquals(t, dbPa.ID, expectedPa.ID)
 
 	var jwk jose.JsonWebKey
 	err = json.Unmarshal([]byte(theKey), &jwk)
@@ -116,16 +119,16 @@ func TestAddAuthorization(t *testing.T) {
 	combos := make([][]int, 1)
 	combos[0] = []int{0, 1}
 
-	newPa := core.Authorization{ID: paID, Identifier: core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}, RegistrationID: 0, Status: core.StatusPending, Expires: time.Now().AddDate(0, 0, 1), Challenges: []core.Challenge{chall}, Combinations: combos, Contact: []core.AcmeURL{u}}
+	newPa := core.Authorization{ID: PA.ID, Identifier: core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}, RegistrationID: 0, Status: core.StatusPending, Expires: time.Now().AddDate(0, 0, 1), Challenges: []core.Challenge{chall}, Combinations: combos, Contact: []core.AcmeURL{u}}
 	err = sa.UpdatePendingAuthorization(newPa)
-	test.AssertNotError(t, err, "Couldn't update pending authorization with ID "+paID)
+	test.AssertNotError(t, err, "Couldn't update pending authorization with ID "+PA.ID)
 
 	newPa.Status = core.StatusValid
 	err = sa.FinalizeAuthorization(newPa)
-	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+paID)
+	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+PA.ID)
 
-	dbPa, err = sa.GetAuthorization(paID)
-	test.AssertNotError(t, err, "Couldn't get authorization with ID "+paID)
+	dbPa, err = sa.GetAuthorization(PA.ID)
+	test.AssertNotError(t, err, "Couldn't get authorization with ID "+PA.ID)
 }
 
 func TestAddCertificate(t *testing.T) {

--- a/sa/type-converter.go
+++ b/sa/type-converter.go
@@ -1,0 +1,102 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sa
+
+import (
+	"encoding/json"
+	"errors"
+	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+	"github.com/letsencrypt/boulder/core"
+)
+
+// BoulderTypeConverter is used by Gorp for storing objects in DB.
+type BoulderTypeConverter struct{}
+
+// ToDb converts a Boulder object to one suitable for the DB representation.
+func (tc BoulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
+	switch t := val.(type) {
+	case core.AcmeIdentifier, []core.Challenge, []core.AcmeURL, [][]int:
+		jsonBytes, err := json.Marshal(t)
+		if err != nil {
+			return nil, err
+		}
+		return string(jsonBytes), nil
+	case jose.JsonWebKey:
+		// HACK: Some of our storage methods, like NewAuthorization, expect to
+		// write to the DB with the default, empty key, so we treat it specially,
+		// serializing to an empty string. TODO: Modify authorizations to refer
+		// to a registration id, and make sure registration ids are always filled.
+		// https://github.com/letsencrypt/boulder/issues/181
+		if t.Key == nil {
+			return "", nil
+		}
+		jsonBytes, err := t.MarshalJSON()
+		if err != nil {
+			return "", err
+		}
+		return string(jsonBytes), nil
+	case core.AcmeStatus:
+		return string(t), nil
+	case core.OCSPStatus:
+		return string(t), nil
+	default:
+		return val, nil
+	}
+}
+
+// FromDb converts a DB representation back into a Boulder object.
+func (tc BoulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, bool) {
+	switch target.(type) {
+	case *core.AcmeIdentifier, *[]core.Challenge, *[]core.AcmeURL, *[][]int, core.JsonBuffer:
+		binder := func(holder, target interface{}) error {
+			s, ok := holder.(*string)
+			if !ok {
+				return errors.New("FromDb: Unable to convert *string")
+			}
+			b := []byte(*s)
+			return json.Unmarshal(b, target)
+		}
+		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
+	case *jose.JsonWebKey:
+		binder := func(holder, target interface{}) error {
+			s, ok := holder.(*string)
+			if !ok {
+				return errors.New("FromDb: Unable to convert *string")
+			}
+			b := []byte(*s)
+			k := target.(*jose.JsonWebKey)
+			if *s != "" {
+				return k.UnmarshalJSON(b)
+			} else {
+				// HACK: Sometimes we can have an empty string the in the DB where a
+				// key should be. We should fix that (see HACK above). In the meantime,
+				// return the default JsonWebKey in such situations.
+				// https://github.com/letsencrypt/boulder/issues/181
+				return nil
+			}
+		}
+		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
+	case *core.AcmeStatus:
+		binder := func(holder, target interface{}) error {
+			s := holder.(*string)
+			st := target.(*core.AcmeStatus)
+			*st = core.AcmeStatus(*s)
+			return nil
+		}
+		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
+	case *core.OCSPStatus:
+		binder := func(holder, target interface{}) error {
+			s := holder.(*string)
+			st := target.(*core.OCSPStatus)
+			*st = core.OCSPStatus(*s)
+			return nil
+		}
+		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
+	default:
+		return gorp.CustomScanner{}, false
+	}
+}

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -1,0 +1,6 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sa

--- a/test.sh
+++ b/test.sh
@@ -63,7 +63,7 @@ else
   run go test ${dirlist}
 fi
 
-run python test/integration-test.py
+[ ${FAILURE} == 0 ] && run python test/integration-test.py
 
 unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1  gofmt -l)
 if [ "x${unformatted}" != "x" ] ; then

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -64,6 +64,12 @@
     "dbName": ":memory:"
   },
 
+  "ocsp": {
+    "dbDriver": "sqlite3",
+    "dbName": ":memory:",
+    "minTimeToExpiry": "72h"
+  },
+
   "mail": {
     "server": "mail.example.com",
     "port": "25",

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -8,8 +8,10 @@ package test
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -51,6 +53,23 @@ func AssertError(t *testing.T, err error, message string) {
 func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 	if one != two {
 		t.Errorf("%s [%v] != [%v]", caller(), one, two)
+	}
+}
+
+func AssertDeepEquals(t *testing.T, one interface{}, two interface{}) {
+	if !reflect.DeepEqual(one, two) {
+		t.Errorf("%s [%+v] !(deep)= [%+v]", caller(), one, two)
+	}
+}
+
+func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
+	oneJSON, err := json.Marshal(one)
+	AssertNotError(t, err, "Could not marshal 1st argument")
+	twoJSON, err := json.Marshal(two)
+	AssertNotError(t, err, "Could not marshal 2nd argument")
+
+	if !bytes.Equal(oneJSON, twoJSON) {
+		t.Errorf("%s [%s] !(json)= [%s]", caller(), oneJSON, twoJSON)
 	}
 }
 

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -282,7 +282,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	regURL := fmt.Sprintf("%s%d", wfe.RegBase, id)
 	responseBody, err := json.Marshal(reg)
 	if err != nil {
-		wfe.sendError(response, "Error marshaling authz", err, http.StatusInternalServerError)
+		wfe.sendError(response, "Error marshaling registration", err, http.StatusInternalServerError)
 		return
 	}
 

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -36,6 +36,7 @@ const (
 	RevokeCertPath = "/acme/revoke-cert/"
 	TermsPath      = "/terms"
 	IssuerPath     = "/acme/issuer-cert"
+	BuildIDPath    = "/build"
 )
 
 // WebFrontEndImpl represents a Boulder web service and its resources
@@ -88,6 +89,7 @@ func (wfe *WebFrontEndImpl) HandlePaths() {
 	http.HandleFunc(RevokeCertPath, wfe.RevokeCertificate)
 	http.HandleFunc(TermsPath, wfe.Terms)
 	http.HandleFunc(IssuerPath, wfe.Issuer)
+	http.HandleFunc(BuildIDPath, wfe.BuildID)
 }
 
 // Method implementations
@@ -741,6 +743,15 @@ func (wfe *WebFrontEndImpl) Issuer(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/pkix-cert")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(wfe.IssuerCert); err != nil {
+		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
+	}
+}
+
+// BuildID tells the requestor what build we're running.
+func (wfe *WebFrontEndImpl) BuildID(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	if _, err := fmt.Fprintln(w, core.GetBuildID()); err != nil {
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 	}
 }

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -497,7 +497,7 @@ func TestNewRegistration(t *testing.T) {
 		Body:   makeBody(signRequest(t, "{\"contact\":[\"tel:123456789\"],\"agreement\":\"https://letsencrypt.org/be-good\"}")),
 	})
 
-	test.AssertEquals(t, responseWriter.Body.String(), "{\"key\":{\"kty\":\"RSA\",\"n\":\"z2NsNdHeqAiGdPP8KuxfQXat_uatOK9y12SyGpfKw1sfkizBIsNxERjNDke6Wp9MugN9srN3sr2TDkmQ-gK8lfWo0v1uG_QgzJb1vBdf_hH7aejgETRGLNJZOdaKDsyFnWq1WGJq36zsHcd0qhggTk6zVwqczSxdiWIAZzEakIUZ13KxXvoepYLY0Q-rEEQiuX71e4hvhfeJ4l7m_B-awn22UUVvo3kCqmaRlZT-36vmQhDGoBsoUo1KBEU44jfeK5PbNRk7vDJuH0B7qinr_jczHcvyD-2TtPzKaCioMtNh_VZbPNDaG67sYkQlC15-Ff3HPzKKJW2XvkVG91qMvQ\",\"e\":\"AAEAAQ\"},\"recoveryToken\":\"\",\"contact\":[\"tel:123456789\"],\"agreement\":\"https://letsencrypt.org/be-good\",\"thumbprint\":\"\"}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\"id\":0,\"key\":{\"kty\":\"RSA\",\"n\":\"z2NsNdHeqAiGdPP8KuxfQXat_uatOK9y12SyGpfKw1sfkizBIsNxERjNDke6Wp9MugN9srN3sr2TDkmQ-gK8lfWo0v1uG_QgzJb1vBdf_hH7aejgETRGLNJZOdaKDsyFnWq1WGJq36zsHcd0qhggTk6zVwqczSxdiWIAZzEakIUZ13KxXvoepYLY0Q-rEEQiuX71e4hvhfeJ4l7m_B-awn22UUVvo3kCqmaRlZT-36vmQhDGoBsoUo1KBEU44jfeK5PbNRk7vDJuH0B7qinr_jczHcvyD-2TtPzKaCioMtNh_VZbPNDaG67sYkQlC15-Ff3HPzKKJW2XvkVG91qMvQ\",\"e\":\"AAEAAQ\"},\"recoveryToken\":\"\",\"contact\":[\"tel:123456789\"],\"agreement\":\"https://letsencrypt.org/be-good\",\"thumbprint\":\"\"}")
 	var reg core.Registration
 	err := json.Unmarshal([]byte(responseWriter.Body.String()), &reg)
 	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")


### PR DESCRIPTION
This PR primarily resolves an error in the use of our RPC layer, that duplication of reply-to addresses caused indeterminate behavior when using AMQP due to a race condition as to which client would consume the message first. The intention was for the client topics to uniquely identify a particular instance.

Due to this being discovered while writing the OCSP Update Tool (which requires AMQP RPC), the RPC work bled into the OCSP Update Tool's PR. I apologize in advance for the murkiness, but hopefully it's clear what was going on.

Note that there are still outstanding issues with the OCSP Responder in this commit; it requires some additional work before OCSP is complete.

Notes:
- Moved dbMap construction and type converter into individual files in the `sa` package.
- Add DB configuration for the OCSP tool to the boulder config:
   - left to the user if they want to use different `boulder-config.json` files for different purposes.
- Added updater to Makefile
- Fix trailing ',' in the Boulder config
- Add more panic logging
- Ignore `.pem` files produced by the integration test
- Change RPC to use per-instance named reply-to queues
- Added an optional Config method to `shell.go` to modify the `cmd.Config` object based on custom CLI flags; see `cmd/ocsp-updater/main.go` for an example.
- Finish OCSP Updater logic
  - Uses a transfer object due to issues JSON marhsalling `x509.Certificate`
- NewPendingAuthorization now uses a core.Authorization object, so
  that foreign key constraints are followed
- core.Authorization now serializes RegistrationID to JSON, so it has to get
  blanked out in WFE before transmission to client.
- Remove ParsedCertificate from core.Certificate, as type x509.Certificate cannot
  be marshaled.
- Added AssertDeepEquals and AssertMarhsaledEquals to test-tools.go
- Caught several overloaded and misleadingly named errors in WFE
- Fix: Challenge URIs were incomplete when running in RPC mode.