### PR TITLE
Check validity is within authorization window

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -232,7 +232,7 @@ func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string, reasonCode 
 
 // IssueCertificate attempts to convert a CSR into a signed Certificate, while
 // enforcing all policies.
-func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest, regID int64) (core.Certificate, error) {
+func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest, regID int64, earliestExpiry time.Time) (core.Certificate, error) {
 	emptyCert := core.Certificate{}
 	var err error
 	key, ok := csr.PublicKey.(crypto.PublicKey)
@@ -267,8 +267,16 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 		return emptyCert, err
 	}
 
-	if ca.NotAfter.Before(time.Now().Add(ca.ValidityPeriod)) {
+	notAfter := time.Now().Add(ca.ValidityPeriod)
+
+	if ca.NotAfter.Before(notAfter) {
 		err = errors.New("Cannot issue a certificate that expires after the intermediate certificate.")
+		ca.log.WarningErr(err)
+		return emptyCert, err
+	}
+
+	if earliestExpiry.Before(notAfter) {
+		err = errors.New(fmt.Sprintf("Cannot issue a certificate that expires after the shortest underlying authorization. [%v] [%v]", earliestExpiry, notAfter))
 		ca.log.WarningErr(err)
 		return emptyCert, err
 	}

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -564,6 +564,12 @@ func TestRejectValidityTooLong(t *testing.T) {
 	ca.SA = storageAuthority
 
 	// Test that the CA rejects CSRs that would expire after the intermediate cert
+	csrDER, _ := hex.DecodeString(NO_CN_CSR_HEX)
+	csr, _ := x509.ParseCertificateRequest(csrDER)
+	_, err = ca.IssueCertificate(*csr, 1, FarPast)
+	test.Assert(t, err != nil, "Cannot issue a certificate that expires after the underlying authorization.")
+
+	// Test that the CA rejects CSRs that would expire after the intermediate cert
 	csrDER, _ = hex.DecodeString(NO_CN_CSR_HEX)
 	csr, _ = x509.ParseCertificateRequest(csrDER)
 	ca.NotAfter = time.Now()

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 	"net/http"
+	"time"
 )
 
 // A WebFrontEnd object supplies methods that can be hooked into
@@ -78,9 +79,9 @@ type ValidationAuthority interface {
 
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
-	IssueCertificate(x509.CertificateRequest, int64) (Certificate, error)
-	RevokeCertificate(string, int) error
 	GenerateOCSP(OCSPSigningRequest) ([]byte, error)
+	IssueCertificate(x509.CertificateRequest, int64, time.Time) (Certificate, error)
+	RevokeCertificate(string, int) error
 }
 
 type PolicyAuthority interface {

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -165,7 +165,14 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 	signer, _ := local.NewSigner(caKey, caCert, x509.SHA256WithRSA, nil)
 	pa := policy.NewPolicyAuthorityImpl()
 	cadb := &MockCADatabase{}
-	ca := ca.CertificateAuthorityImpl{Signer: signer, SA: sa, PA: pa, DB: cadb, ValidityPeriod: time.Hour * 8760, NotAfter: time.Now().Add(time.Hour * 8761)}
+	ca := ca.CertificateAuthorityImpl{
+		Signer:         signer,
+		SA:             sa,
+		PA:             pa,
+		DB:             cadb,
+		ValidityPeriod: time.Hour * 2190,
+		NotAfter:       time.Now().Add(time.Hour * 8761),
+	}
 	csrDER, _ := hex.DecodeString(CSR_HEX)
 	ExampleCSR, _ = x509.ParseCertificateRequest(csrDER)
 
@@ -186,7 +193,7 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 
 	AuthzFinal = AuthzUpdated
 	AuthzFinal.Status = "valid"
-	AuthzFinal.Expires = time.Now().Add(24 * time.Hour)
+	AuthzFinal.Expires = time.Now().Add(365 * 24 * time.Hour)
 	AuthzFinal.Challenges[0].Status = "valid"
 
 	return &ca, va, sa, &ra
@@ -288,10 +295,6 @@ func TestNewAuthorization(t *testing.T) {
 	test.Assert(t, len(authz.Challenges) == 2, "Incorrect number of challenges returned")
 	test.Assert(t, authz.Challenges[0].Type == core.ChallengeTypeSimpleHTTPS, "Challenge 0 not SimpleHTTPS")
 	test.Assert(t, authz.Challenges[1].Type == core.ChallengeTypeDVSNI, "Challenge 1 not DVSNI")
-
-	// If we get to here, we'll use this authorization for the next test
-	fmt.Printf("AuthzInitial: %+v\n", authz)
-	AuthzInitial = authz
 
 	// TODO Test failure cases
 	t.Log("DONE TestNewAuthorization")

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/streadway/amqp"
@@ -436,8 +437,9 @@ func NewCertificateAuthorityServer(serverQueue string, channel *amqp.Channel, im
 
 	rpc.Handle(MethodIssueCertificate, func(req []byte) []byte {
 		var icReq struct {
-			Bytes []byte
-			RegID int64
+			Bytes          []byte
+			RegID          int64
+			EarliestExpiry time.Time
 		}
 		err := json.Unmarshal(req, &icReq)
 		if err != nil {
@@ -453,7 +455,7 @@ func NewCertificateAuthorityServer(serverQueue string, channel *amqp.Channel, im
 			return nil // XXX
 		}
 
-		cert, err := impl.IssueCertificate(*csr, icReq.RegID)
+		cert, err := impl.IssueCertificate(*csr, icReq.RegID, icReq.EarliestExpiry)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodIssueCertificate, err, csr)
@@ -526,10 +528,11 @@ func NewCertificateAuthorityClient(clientQueue, serverQueue string, channel *amq
 	return
 }
 
-func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateRequest, regID int64) (cert core.Certificate, err error) {
+func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateRequest, regID int64, earliestExpiry time.Time) (cert core.Certificate, err error) {
 	var icReq struct {
-		Bytes []byte
-		RegID int64
+		Bytes          []byte
+		RegID          int64
+		EarliestExpiry time.Time
 	}
 	icReq.Bytes = csr.Raw
 	icReq.RegID = regID


### PR DESCRIPTION
The CA needs to verify that the notAfter date of the certificate that it's about to issue is within the window allowed by the underlying authorizations.  This PR adds that check and a corresponding test.