### PR TITLE
Misc fixes

### DIFF
--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -235,7 +235,7 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 	var cert core.Certificate
 	if cert, err = ra.CA.IssueCertificate(*csr, regID); err != nil {
 		logEvent.Error = err.Error()
-		return emptyCert, nil
+		return emptyCert, err
 	}
 
 	cert.ParsedCertificate, err = x509.ParseCertificate([]byte(cert.DER))

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ fi
 # Kill all children on exit.
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-BOULDER_CONFIG=${BOULDER_CONFIG:-test/boulder-config.json}
+export BOULDER_CONFIG=${BOULDER_CONFIG:-test/boulder-config.json}
 
 go run ./cmd/boulder/main.go &
 go run Godeps/_workspace/src/github.com/cloudflare/cfssl/cmd/cfssl/cfssl.go \

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -447,8 +447,10 @@ function getCertificate() {
 function downloadCertificate(err, resp, body) {
   if (err || Math.floor(resp.statusCode / 100) != 2) {
     // Non-2XX response
-    console.log("Certificate request failed with code " + resp.statusCode);
-    console.log(body.toString());
+    console.log("Certificate request failed with error ", err);
+    if (body) {
+      console.log(body.toString());
+    }
     process.exit(1);
   }
 


### PR DESCRIPTION
Actually return error from NewCertificate in RA.
Export BOULDER_CONFIG in start.sh so it gets used.
Print error properly in test.js.