### PR TITLE
Fix a bug introduced in 81fa97f and make ./start.sh work

### DIFF
--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -46,7 +46,7 @@
     "issuerCert": "test/test-ca.pem",
     "_comment": "This should only be present in testMode. In prod use an HSM.",
     "issuerKey": "test/test-ca.key",
-    "expiry": "8760h",
+    "expiry": "2160h",
     "maxNames": 1000
   },
 
@@ -57,7 +57,7 @@
 
   "sql": {
     "SQLDebug": true,
-    "CreateTables": false
+    "CreateTables": true
   },
 
   "revoker": {

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -575,7 +575,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 	}
 
 	// Ask the RA to update this authorization.
-	updatedReg, err := wfe.RA.UpdateRegistration(currReg, currReg)
+	updatedReg, err := wfe.RA.UpdateRegistration(currReg, update)
 	if err != nil {
 		wfe.sendError(response, "Unable to update registration", err, statusCodeFromError(err))
 		return


### PR DESCRIPTION
This PR has three minor fixes which conspire to make `start.sh` and `test.js` work again

* **Make agreements work.**  In removing a MergeUpdate call, I forgot to update the call to UpdateRegistration to have the update instead of the original.  That meant that a clients agreement never got recorded.

* **CreateTables=true** For some reason, JCJ turned this to `false`, which causes the example instance created by `start.sh` to fail.  Reverting.

* **Shorter cert lifetimes.** The validity checking in #253 means that we can no longer have certs and authorizations have roughly the same lifetime.  So we need to make shorter certs.