### PR TITLE
AMQP integration test script + AMQP on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - 1.4.1
 
+services:
+  - rabbitmq
+
 matrix:
   fast_finish: true
 

--- a/test.sh
+++ b/test.sh
@@ -63,7 +63,7 @@ else
   run go test ${dirlist}
 fi
 
-[ ${FAILURE} == 0 ] && run python test/integration-test.py
+[ ${FAILURE} == 0 ] && run python test/amqp-integration-test.py
 
 unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1  gofmt -l)
 if [ "x${unformatted}" != "x" ] ; then

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python2.7
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+tempdir = tempfile.mkdtemp()
+
+def run(path):
+    binary = os.path.join(tempdir, os.path.basename(path))
+    cmd = 'go build -o %s %s' % (binary, path)
+    print(cmd)
+    if subprocess.Popen(cmd, shell=True).wait() != 0:
+        sys.exit(1)
+    return subprocess.Popen('''
+        exec %s --config test/boulder-test-config.json
+        ''' % binary, shell=True)
+
+processes = []
+
+def start():
+    # A strange Go bug: If cfssl is up-to-date, we'll get a failure building
+    # Boulder. Work around by touching cfssl.go.
+    subprocess.Popen('touch Godeps/_workspace/src/github.com/cloudflare/cfssl/cmd/cfssl/cfssl.go', shell=True).wait()
+    cmd = 'go build -o %s/cfssl ./Godeps/_workspace/src/github.com/cloudflare/cfssl/cmd/cfssl' % (tempdir)
+    print(cmd)
+    if subprocess.Popen(cmd, shell=True).wait() != 0:
+        sys.exit(1)
+    global processes
+    processes = [
+        run('./cmd/boulder-wfe'),
+        run('./cmd/boulder-ra'),
+        run('./cmd/boulder-sa'),
+        run('./cmd/boulder-ca'),
+        run('./cmd/boulder-va'),
+        subprocess.Popen('''
+        exec %s/cfssl \
+          -loglevel 0 \
+          serve \
+          -port 9300 \
+          -ca test/test-ca.pem \
+          -ca-key test/test-ca.key \
+          -config test/cfssl-config.json
+        ''' % tempdir, shell=True, stdout=None)]
+    # time.sleep(30)
+
+def run_test():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.connect(('localhost', 4300))
+    except socket.error, e:
+        print("Cannot connect to WFE")
+        sys.exit(1)
+
+    os.chdir('test/js')
+
+    issue = subprocess.Popen('''
+        node test.js --email foo@bar.com --agree true \
+          --domain foo.com --new-reg http://localhost:4300/acme/new-reg \
+          --certKey %s/key.pem --cert %s/cert.der
+        ''' % (tempdir, tempdir), shell=True)
+    if issue.wait() != 0:
+        print("\nIssuing failed")
+        return 1
+    revoke = subprocess.Popen('''
+        node revoke.js %s/cert.der %s/key.pem http://localhost:4300/acme/revoke-cert/
+        ''' % (tempdir, tempdir), shell=True)
+    if revoke.wait() != 0:
+        print("\nRevoking failed")
+        return 1
+    return 0
+
+try:
+    start()
+    status = run_test()
+finally:
+    for p in processes:
+        if p.poll() is None:
+            p.kill()
+        else:
+            status = 1
+    if status == 0:
+        print("\n\nSUCCESS")
+    else:
+        print("\n\nFAILURE")
+    sys.exit(status)

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -45,7 +45,6 @@ def start():
           -ca-key test/test-ca.key \
           -config test/cfssl-config.json
         ''' % tempdir, shell=True, stdout=None)]
-    # time.sleep(30)
 
 def run_test():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -56,20 +56,22 @@ def run_test():
 
     os.chdir('test/js')
 
-    issue = subprocess.Popen('''
+    if subprocess.Popen('npm install', shell=True).wait() != 0:
+        print("\n Installing NPM modules failed")
+        return 1
+    if subprocess.Popen('''
         node test.js --email foo@bar.com --agree true \
-          --domain foo.com --new-reg http://localhost:4300/acme/new-reg \
+          --domains foo.com --new-reg http://localhost:4300/acme/new-reg \
           --certKey %s/key.pem --cert %s/cert.der
-        ''' % (tempdir, tempdir), shell=True)
-    if issue.wait() != 0:
+        ''' % (tempdir, tempdir), shell=True).wait() != 0:
         print("\nIssuing failed")
         return 1
-    revoke = subprocess.Popen('''
+    if subprocess.Popen('''
         node revoke.js %s/cert.der %s/key.pem http://localhost:4300/acme/revoke-cert/
-        ''' % (tempdir, tempdir), shell=True)
-    if revoke.wait() != 0:
+        ''' % (tempdir, tempdir), shell=True).wait() != 0:
         print("\nRevoking failed")
         return 1
+
     return 0
 
 try:


### PR DESCRIPTION
Adds a `amqp-integration-test.py` script cannibalized from @jsha's various python scripts to run all the polylithic clients and `test.js + revoke.js` tests.

This also changes `test.sh` to run the AMQP version of the tests and adds the `rabbitmq` service to `.travis.yml` so that Travis-CI can run boulder in AMQP mode. **Integration tests currently fail** due to bugs that weren't caught since Travis never seems to have actually run them, leaving fixing those for another PR... (or the morning)

One step closer to deleting the monolithic client entirely!