### PR TITLE
Add support for multi-domain certs to test.js

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -50,7 +50,7 @@ def run_test():
 
     issue = subprocess.Popen('''
         node test.js --email foo@bar.com --agree true \
-          --domain foo.com --new-reg http://localhost:4300/acme/new-reg \
+          --domains foo.com --new-reg http://localhost:4300/acme/new-reg \
           --certKey %s/key.pem --cert %s/cert.der
         ''' % (tempdir, tempdir), shell=True)
     if issue.wait() != 0:

--- a/test/js/crypto-util.js
+++ b/test/js/crypto-util.js
@@ -223,14 +223,24 @@ module.exports = {
 
   ///// CSR GENERATION / VERIFICATION
 
-  generateCSR: function(keyPair, identifier) {
+  generateCSR: function(keyPair, names) {
     var privateKey = importPrivateKey(keyPair.privateKey);
     var publicKey = importPublicKey(keyPair.publicKey);
 
     // Create and sign the CSR
     var csr = forge.pki.createCertificationRequest();
     csr.publicKey = publicKey;
-    csr.setSubject([{ name: 'commonName', value: identifier }]);
+    csr.setSubject([{ name: 'commonName', value: names[0] }]);
+
+    var sans = [];
+    for (i in names) {
+      sans.push({ type: 2, value: names[i] });
+    }
+    csr.setAttributes([{
+      name: 'extensionRequest',
+      extensions: [{name: 'subjectAltName', altNames: sans}]
+    }]);
+
     csr.sign(privateKey);
 
     // Convert CSR -> DER -> Base64


### PR DESCRIPTION
Right now, `test.js` is a great tool for testing out getting a cert for a single domain.  But there are cases where people are going to want multi-domain (so-called "UCC") certificates.  We should allow them to test that functionality with test.js.