### PR TITLE
Issue #286: Audit Logs not Transmitted

### DIFF
--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -138,6 +138,10 @@ func (log *AuditLogger) logAtLevel(level, msg string) (err error) {
 		err = log.Writer.Info(msg)
 	case "Logging.Warning":
 		err = log.Writer.Warning(msg)
+	case "Logging.Notice":
+		err = log.Writer.Notice(msg)
+	default:
+		err = fmt.Errorf("Unknown logging level: %s", level)
 	}
 	return
 }


### PR DESCRIPTION
- Add tests for transmission of each log level
- Add default level for `logAtLevel` to catch programming errors
- Transmit things logged at `Logging.Notice`