### PR TITLE
Fix subscriber agreement checks

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -317,7 +317,7 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 		}
 		return
 	}
-	if currReg.Agreement != wfe.SubscriberAgreementURL {
+	if currReg.Agreement == "" {
 		wfe.sendError(response, "Must agree to subscriber agreement before any further actions", nil, http.StatusForbidden)
 		return
 	}
@@ -446,7 +446,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 		}
 		return
 	}
-	if reg.Agreement != wfe.SubscriberAgreementURL {
+	if reg.Agreement == "" {
 		wfe.sendError(response, "Must agree to subscriber agreement before any further actions", nil, http.StatusForbidden)
 		return
 	}
@@ -555,7 +555,7 @@ func (wfe *WebFrontEndImpl) Challenge(authz core.Authorization, response http.Re
 			}
 			return
 		}
-		if currReg.Agreement != wfe.SubscriberAgreementURL {
+		if currReg.Agreement == "" {
 			wfe.sendError(response, "Must agree to subscriber agreement before any further actions", nil, http.StatusForbidden)
 			return
 		}

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -317,6 +317,9 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 		}
 		return
 	}
+	// Any version of the agreement is acceptable here. Version match is enforced in
+	// wfe.Registration when agreeing the first time. Agreement updates happen
+	// by mailing subscribers and don't require a registration update.
 	if currReg.Agreement == "" {
 		wfe.sendError(response, "Must agree to subscriber agreement before any further actions", nil, http.StatusForbidden)
 		return
@@ -446,6 +449,9 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 		}
 		return
 	}
+	// Any version of the agreement is acceptable here. Version match is enforced in
+	// wfe.Registration when agreeing the first time. Agreement updates happen
+	// by mailing subscribers and don't require a registration update.
 	if reg.Agreement == "" {
 		wfe.sendError(response, "Must agree to subscriber agreement before any further actions", nil, http.StatusForbidden)
 		return
@@ -555,6 +561,9 @@ func (wfe *WebFrontEndImpl) Challenge(authz core.Authorization, response http.Re
 			}
 			return
 		}
+		// Any version of the agreement is acceptable here. Version match is enforced in
+		// wfe.Registration when agreeing the first time. Agreement updates happen
+		// by mailing subscribers and don't require a registration update.
 		if currReg.Agreement == "" {
 			wfe.sendError(response, "Must agree to subscriber agreement before any further actions", nil, http.StatusForbidden)
 			return


### PR DESCRIPTION
Agreement to the correct version of the SA is enforced in UpdateRegistrations. Subscribers are upgraded to new versions by sending them email. We don't want to require subscribers to additionally submit a registration update, because that would break automated renewal. So it's sufficient that the subscriber has agreed to *some* version of the SA that was valid when they submitted it.