### PR TITLE
AMQP integration test improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,18 @@ To run a single module, specifying the AMQP server, you might use something more
 Quickstart
 ----------
 
+Install RabbitMQ from https://rabbitmq.com/download.html. It's required to run
+tests.
+
 ```
 > go get github.com/letsencrypt/boulder # Ignore errors about no buildable files
 > cd $GOPATH/src/github.com/letsencrypt/boulder
-# This starts both Boulder and cfssl with test configs. Ctrl-C kills both.
-> ./start.sh
+# This starts each Boulder component with test configs. Ctrl-C kills all.
+> python ./start.py
 > cd test/js
 > npm install
 > nodejs test.js
+> ./test.sh
 ```
 
 You can also check out the official client from

--- a/start.py
+++ b/start.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python2.7
+"""
+Run a local instance of Boulder for testing purposes.
+
+This runs in non-monolithic mode and requires RabbitMQ on localhost.
+"""
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+tempdir = tempfile.mkdtemp()
+
+def run(path):
+    binary = os.path.join(tempdir, os.path.basename(path))
+    cmd = 'go build -o %s %s' % (binary, path)
+    print(cmd)
+    if subprocess.Popen(cmd, shell=True).wait() != 0:
+        sys.exit(1)
+    return subprocess.Popen('''
+        exec %s --config test/boulder-config.json
+        ''' % binary, shell=True)
+
+processes = []
+
+def start():
+    # A strange Go bug: If cfssl is up-to-date, we'll get a failure building
+    # Boulder. Work around by touching cfssl.go.
+    subprocess.Popen('touch Godeps/_workspace/src/github.com/cloudflare/cfssl/cmd/cfssl/cfssl.go', shell=True).wait()
+    global processes
+    processes = [
+        run('./cmd/boulder-wfe'),
+        run('./cmd/boulder-ra'),
+        run('./cmd/boulder-sa'),
+        run('./cmd/boulder-ca'),
+        run('./cmd/boulder-va'),
+        subprocess.Popen('''
+        exec %s/cfssl \
+          -loglevel 0 \
+          serve \
+          -port 9300 \
+          -ca test/test-ca.pem \
+          -ca-key test/test-ca.key \
+          -config test/cfssl-config.json
+        ''' % tempdir, shell=True, stdout=None)]
+    time.sleep(100000)
+
+try:
+    start()
+finally:
+    for p in processes:
+        if p.poll() is None:
+            p.kill()

--- a/test/js/revoke.js
+++ b/test/js/revoke.js
@@ -33,6 +33,7 @@ function main() {
   var req = request.post(revokeUrl, function(err, resp) {
     if (err) {
       console.log('Error: ', err);
+      process.exit(1);
     }
     console.log(resp.statusCode);
     console.log(resp.headers);


### PR DESCRIPTION
Clean up tempfiles on exit.
Print exceptions instead of hiding them.
Exit early if a build fails, and clean up processes that are running at the time.
Update README to reflect RabbitMQ requirement.