### PR TITLE
Issue #296: Fix erroneous transaction handling in CA

### DIFF
--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -6,7 +6,7 @@
 package ca
 
 import (
-	"errors"
+	"fmt"
 	"time"
 
 	"github.com/letsencrypt/boulder/core"
@@ -19,11 +19,11 @@ import (
 // CertificateAuthorityDatabaseImpl represents a database used by the CA; it
 // enforces transaction semantics, and is effectively single-threaded.
 type CertificateAuthorityDatabaseImpl struct {
-	log      *blog.AuditLogger
-	dbMap    *gorp.DbMap
-	activeTx *gorp.Transaction
+	log   *blog.AuditLogger
+	dbMap *gorp.DbMap
 }
 
+// SerialNumber defines the database table used to hold the serial number.
 type SerialNumber struct {
 	ID          int       `db:"id"`
 	Number      int64     `db:"number"`
@@ -49,7 +49,7 @@ func NewCertificateAuthorityDatabaseImpl(driver string, name string) (cadb core.
 	return cadb, nil
 }
 
-// createTablesIfNotExist builds the database tables and inserts the initial
+// CreateTablesIfNotExists builds the database tables and inserts the initial
 // state, if the tables do not already exist. It is not an error for the tables
 // to already exist.
 func (cadb *CertificateAuthorityDatabaseImpl) CreateTablesIfNotExists() (err error) {
@@ -64,54 +64,23 @@ func (cadb *CertificateAuthorityDatabaseImpl) CreateTablesIfNotExists() (err err
 	return
 }
 
-// Begin starts a Database transaction. There can only be one in this object
-// at a time.
-func (cadb *CertificateAuthorityDatabaseImpl) Begin() (err error) {
-	if cadb.activeTx != nil {
-		err = errors.New("Transaction already open")
-		return
-	}
-	cadb.activeTx, err = cadb.dbMap.Begin()
-	return
-}
-
-// Commit makes permanent a database transaction; there must be an active
-// transaction when called.
-func (cadb *CertificateAuthorityDatabaseImpl) Commit() (err error) {
-	if cadb.activeTx == nil {
-		err = errors.New("Transaction already closed")
-		return
-	}
-	err = cadb.activeTx.Commit()
-	cadb.activeTx = nil
-	return
-}
-
-// Rollback cancels the ongoing database transaction; there must be an active
-// transaction when called.
-func (cadb *CertificateAuthorityDatabaseImpl) Rollback() (err error) {
-	if cadb.activeTx == nil {
-		err = errors.New("Transaction already closed")
-		return
-	}
-	err = cadb.activeTx.Rollback()
-	cadb.activeTx = nil
-	return
+// GetDbMap gets a pointer to the CA DB's GORP map object.
+func (cadb *CertificateAuthorityDatabaseImpl) GetDbMap() *gorp.DbMap {
+	return cadb.dbMap
 }
 
 // IncrementAndGetSerial returns the next-available serial number, incrementing
 // it in the database before returning. There must be an active transaction to
 // call this method. Callers should Begin the transaction, call this method,
 // perform any other work, and Commit at the end once the certificate is issued.
-func (cadb *CertificateAuthorityDatabaseImpl) IncrementAndGetSerial() (val int64, err error) {
-	if cadb.activeTx == nil {
-		err = errors.New("No transaction open")
+func (cadb *CertificateAuthorityDatabaseImpl) IncrementAndGetSerial(tx *gorp.Transaction) (val int64, err error) {
+	if tx == nil {
+		err = fmt.Errorf("No transaction given")
 		return
 	}
 
-	rowObj, err := cadb.activeTx.Get(SerialNumber{}, 1)
+	rowObj, err := tx.Get(SerialNumber{}, 1)
 	if err != nil {
-		cadb.activeTx.Rollback()
 		return
 	}
 
@@ -119,9 +88,8 @@ func (cadb *CertificateAuthorityDatabaseImpl) IncrementAndGetSerial() (val int64
 	val = row.Number
 	row.Number = val + 1
 
-	_, err = cadb.activeTx.Update(row)
+	_, err = tx.Update(row)
 	if err != nil {
-		cadb.activeTx.Rollback()
 		return
 	}
 

--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -65,8 +65,8 @@ func (cadb *CertificateAuthorityDatabaseImpl) CreateTablesIfNotExists() (err err
 }
 
 // GetDbMap gets a pointer to the CA DB's GORP map object.
-func (cadb *CertificateAuthorityDatabaseImpl) GetDbMap() *gorp.DbMap {
-	return cadb.dbMap
+func (cadb *CertificateAuthorityDatabaseImpl) Begin() (*gorp.Transaction, error) {
+	return cadb.dbMap.Begin()
 }
 
 // IncrementAndGetSerial returns the next-available serial number, incrementing

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -41,13 +41,13 @@ func TestGetSetSequenceOutsideTx(t *testing.T) {
 	_, err = cadb.IncrementAndGetSerial(nil)
 	test.AssertError(t, err, "Not permitted")
 
-	tx, err := cadb.GetDbMap().Begin()
+	tx, err := cadb.Begin()
 	test.AssertNotError(t, err, "Could not begin")
 	tx.Commit()
 	_, err = cadb.IncrementAndGetSerial(tx)
 	test.AssertError(t, err, "Not permitted")
 
-	tx2, err := cadb.GetDbMap().Begin()
+	tx2, err := cadb.Begin()
 	test.AssertNotError(t, err, "Could not begin")
 	tx2.Rollback()
 	_, err = cadb.IncrementAndGetSerial(tx2)
@@ -61,7 +61,7 @@ func TestGetSetSequenceNumber(t *testing.T) {
 	err = cadb.CreateTablesIfNotExists()
 	test.AssertNotError(t, err, "Could not construct tables")
 
-	tx, err := cadb.GetDbMap().Begin()
+	tx, err := cadb.Begin()
 	test.AssertNotError(t, err, "Could not begin")
 
 	num, err := cadb.IncrementAndGetSerial(tx)

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -31,27 +31,6 @@ func TestConstruction(t *testing.T) {
 	test.AssertError(t, err, "Should have failed construction")
 }
 
-func TestBeginCommit(t *testing.T) {
-	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
-	test.AssertNotError(t, err, "Could not construct CA DB")
-
-	err = cadb.CreateTablesIfNotExists()
-	test.AssertNotError(t, err, "Could not construct tables")
-
-	err = cadb.Begin()
-	test.AssertNotError(t, err, "Could not begin")
-
-	err = cadb.Begin()
-	test.AssertError(t, err, "Should have already begun")
-
-	err = cadb.Commit()
-	test.AssertNotError(t, err, "Could not commit")
-
-	err = cadb.Commit()
-	test.AssertError(t, err, "Should have already committed")
-
-}
-
 func TestGetSetSequenceOutsideTx(t *testing.T) {
 	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
 	test.AssertNotError(t, err, "Could not construct CA DB")
@@ -59,7 +38,19 @@ func TestGetSetSequenceOutsideTx(t *testing.T) {
 	err = cadb.CreateTablesIfNotExists()
 	test.AssertNotError(t, err, "Could not construct tables")
 
-	_, err = cadb.IncrementAndGetSerial()
+	_, err = cadb.IncrementAndGetSerial(nil)
+	test.AssertError(t, err, "Not permitted")
+
+	tx, err := cadb.GetDbMap().Begin()
+	test.AssertNotError(t, err, "Could not begin")
+	tx.Commit()
+	_, err = cadb.IncrementAndGetSerial(tx)
+	test.AssertError(t, err, "Not permitted")
+
+	tx2, err := cadb.GetDbMap().Begin()
+	test.AssertNotError(t, err, "Could not begin")
+	tx2.Rollback()
+	_, err = cadb.IncrementAndGetSerial(tx2)
 	test.AssertError(t, err, "Not permitted")
 }
 
@@ -70,16 +61,16 @@ func TestGetSetSequenceNumber(t *testing.T) {
 	err = cadb.CreateTablesIfNotExists()
 	test.AssertNotError(t, err, "Could not construct tables")
 
-	err = cadb.Begin()
+	tx, err := cadb.GetDbMap().Begin()
 	test.AssertNotError(t, err, "Could not begin")
 
-	num, err := cadb.IncrementAndGetSerial()
+	num, err := cadb.IncrementAndGetSerial(tx)
 	test.AssertNotError(t, err, "Could not get number")
 
-	num2, err := cadb.IncrementAndGetSerial()
+	num2, err := cadb.IncrementAndGetSerial(tx)
 	test.AssertNotError(t, err, "Could not get number")
 	test.Assert(t, num+1 == num2, "Numbers should be incrementing")
 
-	err = cadb.Commit()
+	err = tx.Commit()
 	test.AssertNotError(t, err, "Could not commit")
 }

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -321,7 +321,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 	}))
 
 	// Get the next serial number
-	tx, err := ca.DB.GetDbMap().Begin()
+	tx, err := ca.DB.Begin()
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		ca.log.AuditErr(err)

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/helpers"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
+
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
@@ -339,34 +340,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-type MockCADatabase struct {
-	// empty
-}
-
-func NewMockCertificateAuthorityDatabase() (core.CertificateAuthorityDatabase, error) {
-	return &MockCADatabase{}, nil
-}
-
-func (cadb *MockCADatabase) Begin() error {
-	return nil
-}
-
-func (cadb *MockCADatabase) Commit() error {
-	return nil
-}
-
-func (cadb *MockCADatabase) Rollback() error {
-	return nil
-}
-
-func (cadb *MockCADatabase) IncrementAndGetSerial() (int64, error) {
-	return 1, nil
-}
-
-func (cadb *MockCADatabase) CreateTablesIfNotExists() error {
-	return nil
-}
-
 func setup(t *testing.T) (cadb core.CertificateAuthorityDatabase, storageAuthority core.StorageAuthority, caConfig Config) {
 	// Create an SA
 	ssa, err := sa.NewSQLStorageAuthority("sqlite3", ":memory:")
@@ -374,7 +347,7 @@ func setup(t *testing.T) (cadb core.CertificateAuthorityDatabase, storageAuthori
 	ssa.CreateTablesIfNotExists()
 	storageAuthority = ssa
 
-	cadb, _ = NewMockCertificateAuthorityDatabase()
+	cadb, _ = test.NewMockCertificateAuthorityDatabase()
 
 	// Create a CA
 	// Uncomment to test with a remote signer

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -125,5 +125,5 @@ type StorageAuthority interface {
 type CertificateAuthorityDatabase interface {
 	CreateTablesIfNotExists() error
 	IncrementAndGetSerial(*gorp.Transaction) (int64, error)
-	GetDbMap() *gorp.DbMap
+	Begin() (*gorp.Transaction, error)
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -7,9 +7,11 @@ package core
 
 import (
 	"crypto/x509"
-	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 	"net/http"
 	"time"
+
+	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
 
 // A WebFrontEnd object supplies methods that can be hooked into
@@ -122,8 +124,6 @@ type StorageAuthority interface {
 // CertificateAuthorityDatabase represents an atomic sequence source
 type CertificateAuthorityDatabase interface {
 	CreateTablesIfNotExists() error
-	Begin() error
-	Commit() error
-	Rollback() error
-	IncrementAndGetSerial() (int64, error)
+	IncrementAndGetSerial(*gorp.Transaction) (int64, error)
+	GetDbMap() *gorp.DbMap
 }

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -38,34 +38,6 @@ func (dva *DummyValidationAuthority) UpdateValidations(authz core.Authorization,
 	return
 }
 
-type MockCADatabase struct {
-	// empty
-}
-
-func NewMockCertificateAuthorityDatabase() (core.CertificateAuthorityDatabase, error) {
-	return &MockCADatabase{}, nil
-}
-
-func (cadb *MockCADatabase) Begin() error {
-	return nil
-}
-
-func (cadb *MockCADatabase) Commit() error {
-	return nil
-}
-
-func (cadb *MockCADatabase) Rollback() error {
-	return nil
-}
-
-func (cadb *MockCADatabase) IncrementAndGetSerial() (int64, error) {
-	return 1, nil
-}
-
-func (cadb *MockCADatabase) CreateTablesIfNotExists() error {
-	return nil
-}
-
 var (
 	// These values we simulate from the client
 	AccountKeyJSON = []byte(`{
@@ -164,7 +136,7 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 	caCert, _ := x509.ParseCertificate(caCertPEM.Bytes)
 	signer, _ := local.NewSigner(caKey, caCert, x509.SHA256WithRSA, nil)
 	pa := policy.NewPolicyAuthorityImpl()
-	cadb := &MockCADatabase{}
+	cadb, _ := test.NewMockCertificateAuthorityDatabase()
 	ca := ca.CertificateAuthorityImpl{
 		Signer:         signer,
 		SA:             sa,

--- a/test/mocks.go
+++ b/test/mocks.go
@@ -24,8 +24,8 @@ func NewMockCertificateAuthorityDatabase() (mock *MockCADatabase, err error) {
 	return mock, err
 }
 
-func (cadb *MockCADatabase) GetDbMap() *gorp.DbMap {
-	return cadb.db
+func (cadb *MockCADatabase) Begin() (*gorp.Transaction, error) {
+	return cadb.db.Begin()
 }
 
 func (cadb *MockCADatabase) IncrementAndGetSerial(*gorp.Transaction) (int64, error) {

--- a/test/mocks.go
+++ b/test/mocks.go
@@ -1,0 +1,38 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package test
+
+import (
+	"database/sql"
+
+	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+)
+
+type MockCADatabase struct {
+	db    *gorp.DbMap
+	count int64
+}
+
+func NewMockCertificateAuthorityDatabase() (mock *MockCADatabase, err error) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	dbmap := &gorp.DbMap{Db: db, Dialect: gorp.SqliteDialect{}}
+	mock = &MockCADatabase{db: dbmap, count: 1}
+	return mock, err
+}
+
+func (cadb *MockCADatabase) GetDbMap() *gorp.DbMap {
+	return cadb.db
+}
+
+func (cadb *MockCADatabase) IncrementAndGetSerial(*gorp.Transaction) (int64, error) {
+	cadb.count = cadb.count + 1
+	return cadb.count, nil
+}
+
+func (cadb *MockCADatabase) CreateTablesIfNotExists() error {
+	return nil
+}


### PR DESCRIPTION
- Moved the transaction handling up to the `certificate-authority.go` file
- Simplified `certificate-authority-data.go`
- Created a mocks file in `test/` and reworked RA and CA to use it
- More audit logging to CA