### PR TITLE
Finish initial version of OCSP Responder

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -7,20 +7,19 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha1"
 	"crypto/x509"
-	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"time"
 
-	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
-
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	cfocsp "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/golang.org/x/crypto/ocsp"
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/sa"
 )
@@ -70,31 +69,41 @@ serialNumber field, since we will always query on it.
 
 */
 type DBSource struct {
-	db        *sql.DB
+	dbMap     *gorp.DbMap
 	caKeyHash []byte
 }
 
 func NewSourceFromDatabase(dbMap *gorp.DbMap, caKeyHash []byte) (src *DBSource, err error) {
-	src = &DBSource{db: dbMap.Db, caKeyHash: caKeyHash}
+	src = &DBSource{dbMap: dbMap, caKeyHash: caKeyHash}
 	return
 }
 
 const responseQuery = "SELECT resposne FROM ocsp_responses WHERE serialNumber"
 
 func (src *DBSource) Response(req *ocsp.Request) (response []byte, present bool) {
+	log := blog.GetAuditLogger()
+
 	// Check that this request is for the proper CA
 	if bytes.Compare(req.IssuerKeyHash, src.caKeyHash) != 0 {
+		log.Debug(fmt.Sprintf("Request intended for CA Cert ID: %s", hex.EncodeToString(req.IssuerKeyHash)))
 		present = false
 		return
 	}
 
-	// SELECT resposne FROM ocsp_responses WHERE serialNumber
-	err := src.db.QueryRow(responseQuery).Scan(&response)
+	serialString := fmt.Sprintf("%032x", req.SerialNumber)
+	log.Debug(fmt.Sprintf("Searching for OCSP issued by us for serial %s", serialString))
+
+	var ocspResponse core.OCSPResponse
+	err := src.dbMap.SelectOne(&ocspResponse, "SELECT * from ocspResponses WHERE serial = :serial  ORDER BY createdAt DESC LIMIT 1;",
+		map[string]interface{}{"serial": serialString})
 	if err != nil {
 		present = false
 		return
 	}
 
+	log.Info(fmt.Sprintf("OCSP Response sent for CA=%s, Serial=%s", hex.EncodeToString(src.caKeyHash), serialString))
+
+	response = ocspResponse.Response
 	present = true
 	return
 }
@@ -116,27 +125,26 @@ func main() {
 
 		go cmd.ProfileCmd("OCSP", stats)
 
+		auditlogger.Info(app.VersionString())
+
 		// Configure DB
 		dbMap, err := sa.NewDbMap(c.OCSPResponder.DBDriver, c.OCSPResponder.DBName)
 		cmd.FailOnError(err, "Could not connect to database")
+		sa.SetSQLDebug(dbMap, c.SQL.SQLDebug)
 
-		// Load the CA's key and hash it
+		// Load the CA's key so we can store its AuthorityKeyId in the DB
 		caCertDER, err := cmd.LoadCert(c.Common.IssuerCert)
 		cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))
 		caCert, err := x509.ParseCertificate(caCertDER)
 		cmd.FailOnError(err, fmt.Sprintf("Couldn't parse cert read from [%s]", c.Common.IssuerCert))
-		h := sha1.New()
-		h.Write(caCert.RawSubjectPublicKeyInfo)
-		caKeyHash := h.Sum(nil)
 
 		// Construct source from DB
-		src, err := NewSourceFromDatabase(dbMap, caKeyHash)
+		auditlogger.Info(fmt.Sprintf("Loading OCSP Database for CA Cert ID: %s", hex.EncodeToString(caCert.AuthorityKeyId)))
+		src, err := NewSourceFromDatabase(dbMap, caCert.AuthorityKeyId)
 		cmd.FailOnError(err, "Could not connect to OCSP database")
 
 		// Configure HTTP
 		http.Handle(c.OCSPResponder.Path, cfocsp.Responder{Source: src})
-
-		auditlogger.Info(app.VersionString())
 
 		// Add HandlerTimer to output resp time + success/failure stats to statsd
 		auditlogger.Info(fmt.Sprintf("Server running, listening on %s...\n", c.OCSPResponder.ListenAddress))

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -90,7 +90,7 @@ func (src *DBSource) Response(req *ocsp.Request) (response []byte, present bool)
 		return
 	}
 
-	serialString := fmt.Sprintf("%032x", req.SerialNumber)
+	serialString := core.SerialToString(req.SerialNumber)
 	log.Debug(fmt.Sprintf("Searching for OCSP issued by us for serial %s", serialString))
 
 	var ocspResponse core.OCSPResponse

--- a/sa/database.go
+++ b/sa/database.go
@@ -58,6 +58,26 @@ func NewDbMap(driver string, name string) (*gorp.DbMap, error) {
 	return dbmap, err
 }
 
+// SetSQLDebug enables/disables GORP SQL-level Debugging
+func SetSQLDebug(dbMap *gorp.DbMap, state bool) {
+	dbMap.TraceOff()
+
+	if state {
+		// Enable logging
+		dbMap.TraceOn("SQL: ", &SQLLogger{blog.GetAuditLogger()})
+	}
+}
+
+// SQLLogger adapts the AuditLogger to a format GORP can use.
+type SQLLogger struct {
+	log *blog.AuditLogger
+}
+
+// Printf adapts the AuditLogger to GORP's interface
+func (log *SQLLogger) Printf(format string, v ...interface{}) {
+	log.log.Debug(fmt.Sprintf(format, v))
+}
+
 // initTables constructs the table map for the ORM. If you want to also create
 // the tables, call CreateTablesIfNotExists on the DbMap.
 func initTables(dbMap *gorp.DbMap) {

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -47,16 +47,6 @@ type authzModel struct {
 	Sequence int64 `db:"sequence"`
 }
 
-// SQLLogger adapts the AuditLogger to a format GORP can use.
-type SQLLogger struct {
-	log *blog.AuditLogger
-}
-
-// Printf adapts the AuditLogger to GORP's interface
-func (log *SQLLogger) Printf(format string, v ...interface{}) {
-	log.log.Debug(fmt.Sprintf(format, v))
-}
-
 // NewSQLStorageAuthority provides persistence using a SQL backend for Boulder.
 func NewSQLStorageAuthority(driver string, name string) (ssa *SQLStorageAuthority, err error) {
 	logger := blog.GetAuditLogger()
@@ -78,12 +68,7 @@ func NewSQLStorageAuthority(driver string, name string) (ssa *SQLStorageAuthorit
 
 // SetSQLDebug enables/disables GORP SQL-level Debugging
 func (ssa *SQLStorageAuthority) SetSQLDebug(state bool) {
-	ssa.dbMap.TraceOff()
-
-	if state {
-		// Enable logging
-		ssa.dbMap.TraceOn("SQL: ", &SQLLogger{blog.GetAuditLogger()})
-	}
+	SetSQLDebug(ssa.dbMap, state)
 }
 
 // CreateTablesIfNotExists instructs the ORM to create any missing tables.


### PR DESCRIPTION
- Correct the Database implementation to match current schema & GORP
- Add some debug logging
- Correct CA Key identification
- Move SQL Debugging into the Database object and file, so that things that don't use the Storage Authority can toggle it