### PR TITLE
Add an anti-replay nonce facility

### DIFF
--- a/Godeps/_workspace/src/github.com/square/go-jose/doc_test.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/doc_test.go
@@ -95,7 +95,7 @@ func Example_jWS() {
 	// which can then be serialized for output afterwards. An error would
 	// indicate a problem in an underlying cryptographic primitive.
 	var payload = []byte("Lorem ipsum dolor sit amet")
-	object, err := signer.Sign(payload)
+	object, err := signer.Sign(payload, "")
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +115,7 @@ func Example_jWS() {
 	// Now we can verify the signature on the payload. An error here would
 	// indicate the the message failed to verify, e.g. because the signature was
 	// broken or the message was tampered with.
-	output, err := object.Verify(&privateKey.PublicKey)
+	output, _, err := object.Verify(&privateKey.PublicKey)
 	if err != nil {
 		panic(err)
 	}

--- a/Godeps/_workspace/src/github.com/square/go-jose/jws.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/jws.go
@@ -134,7 +134,7 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 		// header struct only if those bytes are not available.
 		signature.original = &rawSignatureInfo{
 			Protected: parsed.Protected,
-			Header: parsed.Header,
+			Header:    parsed.Header,
 			Signature: parsed.Signature,
 		}
 

--- a/Godeps/_workspace/src/github.com/square/go-jose/jws_test.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/jws_test.go
@@ -17,8 +17,8 @@
 package jose
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 )
 
 func TestCompactParseJWS(t *testing.T) {
@@ -115,7 +115,7 @@ func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 	if sig.Header.JsonWebKey == nil {
 		t.Error("No JWK in signature header.")
 	}
-	payload, err := jws.Verify(sig.Header.JsonWebKey)
+	payload, _, err := jws.Verify(sig.Header.JsonWebKey)
 	if err != nil {
 		t.Error(fmt.Sprintf("Signature did not validate: %v", err))
 	}
@@ -141,7 +141,7 @@ func TestVerifyFlattenedWithPrivateProtected(t *testing.T) {
 	if sig.Header.JsonWebKey == nil {
 		t.Error("No JWK in signature header.")
 	}
-	payload, err := jws.Verify(sig.Header.JsonWebKey)
+	payload, _, err := jws.Verify(sig.Header.JsonWebKey)
 	if err != nil {
 		t.Error(fmt.Sprintf("Signature did not validate: %v", err))
 	}
@@ -179,7 +179,7 @@ func TestSampleNimbusJWSMessagesRSA(t *testing.T) {
 			t.Error("unable to parse message", msg, err)
 			continue
 		}
-		payload, err := obj.Verify(rsaPublicKey)
+		payload, _, err := obj.Verify(rsaPublicKey)
 		if err != nil {
 			t.Error("unable to verify message", msg, err)
 			continue
@@ -219,7 +219,7 @@ func TestSampleNimbusJWSMessagesEC(t *testing.T) {
 			t.Error("unable to parse message", msg, err)
 			continue
 		}
-		payload, err := obj.Verify(ecPublicKeys[i])
+		payload, _, err := obj.Verify(ecPublicKeys[i])
 		if err != nil {
 			t.Error("unable to verify message", msg, err)
 			continue
@@ -246,7 +246,7 @@ func TestSampleNimbusJWSMessagesHMAC(t *testing.T) {
 			t.Error("unable to parse message", msg, err)
 			continue
 		}
-		payload, err := obj.Verify(hmacTestKey)
+		payload, _, err := obj.Verify(hmacTestKey)
 		if err != nil {
 			t.Error("unable to verify message", msg, err)
 			continue

--- a/Godeps/_workspace/src/github.com/square/go-jose/shared.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/shared.go
@@ -110,23 +110,25 @@ const (
 
 // rawHeader represents the JOSE header for JWE/JWS objects (used for parsing).
 type rawHeader struct {
-	Alg  string               `json:"alg,omitempty"`
-	Enc  ContentEncryption    `json:"enc,omitempty"`
-	Zip  CompressionAlgorithm `json:"zip,omitempty"`
-	Crit []string             `json:"crit,omitempty"`
-	Apu  *byteBuffer          `json:"apu,omitempty"`
-	Apv  *byteBuffer          `json:"apv,omitempty"`
-	Epk  *JsonWebKey          `json:"epk,omitempty"`
-	Iv   *byteBuffer          `json:"iv,omitempty"`
-	Tag  *byteBuffer          `json:"tag,omitempty"`
-	Jwk  *JsonWebKey          `json:"jwk,omitempty"`
-	Kid  string               `json:"kid,omitempty"`
+	Alg   string               `json:"alg,omitempty"`
+	Enc   ContentEncryption    `json:"enc,omitempty"`
+	Zip   CompressionAlgorithm `json:"zip,omitempty"`
+	Crit  []string             `json:"crit,omitempty"`
+	Apu   *byteBuffer          `json:"apu,omitempty"`
+	Apv   *byteBuffer          `json:"apv,omitempty"`
+	Epk   *JsonWebKey          `json:"epk,omitempty"`
+	Iv    *byteBuffer          `json:"iv,omitempty"`
+	Tag   *byteBuffer          `json:"tag,omitempty"`
+	Jwk   *JsonWebKey          `json:"jwk,omitempty"`
+	Kid   string               `json:"kid,omitempty"`
+	Nonce string               `json:"nonce,omitempty"`
 }
 
 // JoseHeader represents the read-only JOSE header for JWE/JWS objects.
 type JoseHeader struct {
 	KeyID      string
 	JsonWebKey *JsonWebKey
+	Nonce      string
 }
 
 // sanitized produces a cleaned-up header object from the raw JSON.
@@ -134,6 +136,7 @@ func (parsed rawHeader) sanitized() JoseHeader {
 	return JoseHeader{
 		KeyID:      parsed.Kid,
 		JsonWebKey: parsed.Jwk,
+		Nonce:      parsed.Nonce,
 	}
 }
 
@@ -178,5 +181,8 @@ func (dst *rawHeader) merge(src *rawHeader) {
 	}
 	if dst.Jwk == nil {
 		dst.Jwk = src.Jwk
+	}
+	if dst.Nonce == "" {
+		dst.Nonce = src.Nonce
 	}
 }

--- a/Godeps/_workspace/src/github.com/square/go-jose/signing.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/signing.go
@@ -157,10 +157,10 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 }
 
 // Verify validates the signature on the object and returns the payload.
-func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, error) {
+func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, []byte, error) {
 	verifier, err := newVerifier(verificationKey)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, signature := range obj.Signatures {
@@ -174,9 +174,9 @@ func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, error) 
 		alg := SignatureAlgorithm(headers.Alg)
 		err := verifier.verifyPayload(input, signature.signature, alg)
 		if err == nil {
-			return obj.payload, nil
+			return obj.payload, signature.original.Protected.data, nil
 		}
 	}
 
-	return nil, ErrCryptoFailure
+	return nil, nil, ErrCryptoFailure
 }

--- a/Godeps/_workspace/src/github.com/square/go-jose/signing.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/signing.go
@@ -170,11 +170,16 @@ func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, []byte,
 			continue
 		}
 
+		var protected []byte
+		if signature.original.Protected != nil {
+			protected = signature.original.Protected.data
+		}
+
 		input := obj.computeAuthData(&signature)
 		alg := SignatureAlgorithm(headers.Alg)
 		err := verifier.verifyPayload(input, signature.signature, alg)
 		if err == nil {
-			return obj.payload, signature.original.Protected.data, nil
+			return obj.payload, protected, nil
 		}
 	}
 

--- a/Godeps/_workspace/src/github.com/square/go-jose/signing.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/signing.go
@@ -24,12 +24,12 @@ import (
 
 // Signer represents a signer which takes a payload and produces a signed JWS object.
 type Signer interface {
-	Sign(payload []byte) (*JsonWebSignature, error)
+	Sign(payload []byte, nonce string) (*JsonWebSignature, error)
 }
 
 // MultiSigner represents a signer which supports multiple recipients.
 type MultiSigner interface {
-	Sign(payload []byte) (*JsonWebSignature, error)
+	Sign(payload []byte, nonce string) (*JsonWebSignature, error)
 	AddRecipient(alg SignatureAlgorithm, signingKey interface{}) error
 }
 
@@ -123,7 +123,7 @@ func makeRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipientSig
 	}
 }
 
-func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
+func (ctx *genericSigner) Sign(payload []byte, nonce string) (*JsonWebSignature, error) {
 	obj := &JsonWebSignature{}
 	obj.payload = payload
 	obj.Signatures = make([]Signature, len(ctx.recipients))
@@ -136,6 +136,10 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 		if recipient.publicKey != nil {
 			protected.Jwk = recipient.publicKey
 			protected.Kid = recipient.publicKey.KeyID
+		}
+
+		if nonce != "" {
+			protected.Nonce = nonce
 		}
 
 		serializedProtected := mustSerializeJSON(protected)
@@ -157,10 +161,10 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 }
 
 // Verify validates the signature on the object and returns the payload.
-func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, []byte, error) {
+func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, JoseHeader, error) {
 	verifier, err := newVerifier(verificationKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, JoseHeader{}, err
 	}
 
 	for _, signature := range obj.Signatures {
@@ -169,19 +173,13 @@ func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, []byte,
 			// Unsupported crit header
 			continue
 		}
-
-		var protected []byte
-		if signature.original.Protected != nil {
-			protected = signature.original.Protected.data
-		}
-
 		input := obj.computeAuthData(&signature)
 		alg := SignatureAlgorithm(headers.Alg)
 		err := verifier.verifyPayload(input, signature.signature, alg)
 		if err == nil {
-			return obj.payload, protected, nil
+			return obj.payload, headers.sanitized(), nil
 		}
 	}
 
-	return nil, nil, ErrCryptoFailure
+	return nil, JoseHeader{}, ErrCryptoFailure
 }

--- a/core/nonce.go
+++ b/core/nonce.go
@@ -8,7 +8,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"fmt"
 	"math/big"
 )
 
@@ -104,22 +103,18 @@ func (ns *NonceService) minUsed() int64 {
 func (ns *NonceService) Valid(nonce string) bool {
 	c, err := ns.decrypt(nonce)
 	if err != nil {
-		fmt.Printf(">>>>> Invalid nonce; bad decrypt")
 		return false
 	}
 
 	if c > ns.latest {
-		fmt.Printf(">>>>> Invalid nonce; too late")
 		return false
 	}
 
 	if c <= ns.earliest {
-		fmt.Printf(">>>>> Invalid nonce; too early")
 		return false
 	}
 
 	if ns.used[c] {
-		fmt.Printf(">>>>> Invalid nonce; already used")
 		return false
 	}
 

--- a/core/nonce.go
+++ b/core/nonce.go
@@ -1,0 +1,133 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package core
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+const MaxUsed = 65536
+
+type NonceService struct {
+	latest   int64
+	earliest int64
+	used     map[int64]bool
+	gcm      cipher.AEAD
+	maxUsed  int
+}
+
+func NewNonceService() NonceService {
+	// XXX ignoring possible error due to entropy starvation
+	key := make([]byte, 16)
+	rand.Read(key)
+
+	// It is safe to ignore these errors because they only happen
+	// on key size and block size mismatches.
+	c, _ := aes.NewCipher(key)
+	gcm, _ := cipher.NewGCM(c)
+
+	return NonceService{
+		earliest: 0,
+		latest:   0,
+		used:     make(map[int64]bool, MaxUsed),
+		gcm:      gcm,
+		maxUsed:  MaxUsed,
+	}
+}
+
+func (ns NonceService) encrypt(counter int64) string {
+	// Generate a nonce with upper 4 bytes zero
+	// XXX ignoring possible error due to entropy starvation
+	nonce := make([]byte, 12)
+	for i := 0; i < 4; i += 1 {
+		nonce[i] = 0
+	}
+	rand.Read(nonce[4:])
+
+	// Encode counter to plaintext
+	pt := make([]byte, 8)
+	ctr := big.NewInt(counter)
+	pad := 8 - len(ctr.Bytes())
+	copy(pt[pad:], ctr.Bytes())
+
+	// Encrypt
+	ret := make([]byte, 32)
+	ct := ns.gcm.Seal(nil, nonce, pt, nil)
+	copy(ret, nonce[4:])
+	copy(ret[8:], ct)
+	return B64enc(ret)
+}
+
+func (ns NonceService) decrypt(nonce string) (int64, error) {
+	decoded, err := B64dec(nonce)
+	if err != nil {
+		return 0, err
+	}
+
+	n := make([]byte, 12)
+	for i := 0; i < 4; i += 1 {
+		n[i] = 0
+	}
+	copy(n[4:], decoded[:8])
+
+	pt, err := ns.gcm.Open(nil, n, decoded[8:], nil)
+	if err != nil {
+		return 0, err
+	}
+
+	ctr := big.NewInt(0)
+	ctr.SetBytes(pt)
+	return ctr.Int64(), nil
+}
+
+func (ns *NonceService) Nonce() string {
+	ns.latest += 1
+	return ns.encrypt(ns.latest)
+}
+
+func (ns *NonceService) minUsed() int64 {
+	min := ns.latest
+	for t := range ns.used {
+		if t < min {
+			min = t
+		}
+	}
+	return min
+}
+
+func (ns *NonceService) Valid(nonce string) bool {
+	c, err := ns.decrypt(nonce)
+	if err != nil {
+		fmt.Printf(">>>>> Invalid nonce; bad decrypt")
+		return false
+	}
+
+	if c > ns.latest {
+		fmt.Printf(">>>>> Invalid nonce; too late")
+		return false
+	}
+
+	if c <= ns.earliest {
+		fmt.Printf(">>>>> Invalid nonce; too early")
+		return false
+	}
+
+	if ns.used[c] {
+		fmt.Printf(">>>>> Invalid nonce; already used")
+		return false
+	}
+
+	ns.used[c] = true
+	if len(ns.used) > ns.maxUsed {
+		ns.earliest = ns.minUsed()
+		delete(ns.used, ns.earliest)
+	}
+
+	return true
+}

--- a/core/nonce_test.go
+++ b/core/nonce_test.go
@@ -1,0 +1,61 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package core
+
+import (
+	"github.com/letsencrypt/boulder/test"
+	"testing"
+)
+
+func TestValidNonce(t *testing.T) {
+	ns := NewNonceService()
+	n := ns.Nonce()
+	test.Assert(t, ns.Valid(n), "Did not recognize fresh nonce")
+}
+
+func TestAlreadyUsed(t *testing.T) {
+	ns := NewNonceService()
+	n := ns.Nonce()
+	test.Assert(t, ns.Valid(n), "Did not recognize fresh nonce")
+	test.Assert(t, !ns.Valid(n), "Recognized the same nonce twice")
+}
+
+func TestRejectMalformed(t *testing.T) {
+	ns := NewNonceService()
+	n := ns.Nonce()
+	test.Assert(t, !ns.Valid("asdf"+n), "Accepted an invalid nonce")
+}
+
+func TestRejectUnknown(t *testing.T) {
+	ns1 := NewNonceService()
+	ns2 := NewNonceService()
+	n := ns1.Nonce()
+	test.Assert(t, !ns2.Valid(n), "Accepted a foreign nonce")
+}
+
+func TestRejectTooLate(t *testing.T) {
+	ns := NewNonceService()
+
+	ns.latest = 2
+	n := ns.Nonce()
+	ns.latest = 1
+	test.Assert(t, !ns.Valid(n), "Accepted a nonce with a too-high counter")
+}
+
+func TestRejectTooEarly(t *testing.T) {
+	ns := NewNonceService()
+	ns.maxUsed = 2
+
+	n0 := ns.Nonce()
+	n1 := ns.Nonce()
+	n2 := ns.Nonce()
+	n3 := ns.Nonce()
+
+	test.Assert(t, ns.Valid(n3), "Rejected a valid nonce")
+	test.Assert(t, ns.Valid(n2), "Rejected a valid nonce")
+	test.Assert(t, ns.Valid(n1), "Rejected a valid nonce")
+	test.Assert(t, !ns.Valid(n0), "Accepted a nonce that we should have forgotten")
+}

--- a/start.sh
+++ b/start.sh
@@ -7,4 +7,4 @@ fi
 # Kill all children on exit.
 export BOULDER_CONFIG=${BOULDER_CONFIG:-test/boulder-config.json}
 
-exec go run ./cmd/boulder/main.go
+exec go run -tags pkcs11 ./cmd/boulder/main.go

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -45,7 +45,7 @@ def run_test():
         die()
 
     issue = subprocess.Popen('''
-        node test.js --email foo@bar.com --agree true \
+        node test.js --email foo@letsencrypt.org --agree true \
           --domains foo.com --new-reg http://localhost:4300/acme/new-reg \
           --certKey %s/key.pem --cert %s/cert.der
         ''' % (tempdir, tempdir), shell=True)

--- a/test/js/crypto-util.js
+++ b/test/js/crypto-util.js
@@ -139,13 +139,16 @@ module.exports = {
 
   ///// SIGNATURE GENERATION / VERIFICATION
 
-  generateSignature: function(keyPair, payload) {
-    var nonce = bytesToBuffer(forge.random.getBytesSync(NONCE_SIZE));
+  generateSignature: function(keyPair, payload, nonceIn) {
+    var nonce = nonceIn
+    if (!nonce) {
+      nonce = util.b64enc(bytesToBuffer(forge.random.getBytesSync(NONCE_SIZE)));
+    }
     var privateKey = importPrivateKey(keyPair.privateKey);
 
     // Compute JWS signature
     var protectedHeader = JSON.stringify({
-      nonce: util.b64enc(nonce)
+      nonce: nonce
     });
     var protected64 = util.b64enc(new Buffer(protectedHeader));
     var payload64 = util.b64enc(payload);

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -193,7 +193,7 @@ function post(url, body, callback) {
   console.log(payload.blue);
   var req = request.post({
     url: url,
-    encoding: null, // Return body as buffer, needed for certificate response
+    encoding: null // Return body as buffer, needed for certificate response
   }, function(error, response, body) {
     Object.keys(response.headers).forEach(function(key) {
       var value = response.headers[key];

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -159,7 +159,6 @@ function parseLink(link) {
 function getNonce(url, callback) {
   var req = request.head({
     url: url,
-    strictSSL: false
   }, function(error, response, body) {
     if ("replay-nonce" in response.headers) {
       console.log("Storing nonce: " + response.headers["replay-nonce"]);
@@ -195,7 +194,6 @@ function post(url, body, callback) {
   var req = request.post({
     url: url,
     encoding: null, // Return body as buffer, needed for certificate response
-    strictSSL: false,
   }, function(error, response, body) {
     Object.keys(response.headers).forEach(function(key) {
       var value = response.headers[key];

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -116,6 +116,9 @@ var state = {
   validatedDomains: [],
   validAuthorizationURLs: [],
 
+  // We will use this as a push/shift FIFO in post() and getNonce()
+  nonces: [],
+
   newAuthorizationURL: "",
   authorizationURL: "",
   responseURL: "",
@@ -153,9 +156,36 @@ function parseLink(link) {
   }
 }
 
+function getNonce(url, callback) {
+  var req = request.head({
+    url: url,
+    strictSSL: false
+  }, function(error, response, body) {
+    if ("replay-nonce" in response.headers) {
+      console.log("Storing nonce: " + response.headers["replay-nonce"]);
+      state.nonces.push(response.headers["replay-nonce"]);
+      callback();
+      return;
+    }
+
+    console.log("Failed to get nonce for request")
+  });
+}
+
 function post(url, body, callback) {
+  // Pre-flight with HEAD if we don't have a nonce
+  if (state.nonces.length == 0) {
+    getNonce(url, function() {
+      post(url, body, callback);
+    })
+    return;
+  }
+
+  console.log("Using nonce: " + state.nonces[0]);
   var payload = JSON.stringify(body, null, 2);
-  var jws = crypto.generateSignature(state.accountPrivateKey, new Buffer(payload));
+  var jws = crypto.generateSignature(state.accountPrivateKey,
+                                     new Buffer(payload),
+                                     state.nonces.shift());
   var signed = JSON.stringify(jws, null, 2);
 
   console.log('Posting to', url, ':');
@@ -164,8 +194,16 @@ function post(url, body, callback) {
   console.log(payload.blue);
   var req = request.post({
     url: url,
-    encoding: null // Return body as buffer, needed for certificate response
-    }, function(error, response, body) {
+    encoding: null, // Return body as buffer, needed for certificate response
+    strictSSL: false,
+  }, function(error, response, body) {
+    Object.keys(response.headers).forEach(function(key) {
+      var value = response.headers[key];
+      var upcased = key.charAt(0).toUpperCase() + key.slice(1);
+      console.log((upcased + ": " + value).yellow)
+    });
+    console.log()
+
     // Don't print non-ASCII characters (like DER-encoded cert) to the terminal
     if (body && !body.toString().match(/[^\x00-\x7F]/)) {
       try {
@@ -175,15 +213,16 @@ function post(url, body, callback) {
         console.log(body.toString().cyan);
       }
     }
+
+    // Remember the nonce provided by the server
+    if ("replay-nonce" in response.headers) {
+      console.log("Storing nonce: " + response.headers["replay-nonce"]);
+      state.nonces.push(response.headers["replay-nonce"]);
+    }
+
     callback(error, response, body)
   });
   req.on('response', function(response) {
-    Object.keys(response.headers).forEach(function(key) {
-      var value = response.headers[key];
-      var upcased = key.charAt(0).toUpperCase() + key.slice(1);
-      console.log((upcased + ": " + value).yellow)
-    });
-    console.log()
   })
   req.write(signed)
   req.end();

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -217,7 +217,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]
 		wfe.log.Debug("JWS has no anti-replay nonce")
 		return nil, nil, reg, errors.New("JWS has no anti-replay nonce")
 	} else if !wfe.replayNonces[protected.Nonce] {
-		wfe.log.Debug(fmt.Sprintf("JWS has invalid anti-replay nonce: %s"))
+		wfe.log.Debug(fmt.Sprintf("JWS has invalid anti-replay nonce: %s", protected.Nonce))
 		return nil, nil, reg, errors.New("JWS has invalid anti-replay nonce")
 	} else {
 		delete(wfe.replayNonces, protected.Nonce)

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -62,7 +62,7 @@ type WebFrontEndImpl struct {
 	SubscriberAgreementURL string
 
 	// Register of anti-replay nonces
-	replayNonces map[string]bool
+	nonceService core.NonceService
 }
 
 func statusCodeFromError(err interface{}) int {
@@ -81,9 +81,10 @@ func statusCodeFromError(err interface{}) int {
 func NewWebFrontEndImpl() WebFrontEndImpl {
 	logger := blog.GetAuditLogger()
 	logger.Notice("Web Front End Starting")
+
 	return WebFrontEndImpl{
 		log:          logger,
-		replayNonces: map[string]bool{},
+		nonceService: core.NewNonceService(),
 	}
 }
 
@@ -153,16 +154,8 @@ const (
 	ServerInternalProblem = ProblemType("urn:acme:error:serverInternal")
 )
 
-func (wfe *WebFrontEndImpl) sendNonce(response http.ResponseWriter) (err error) {
-	nonce := core.NewToken()
-	if wfe.replayNonces[nonce] {
-		wfe.log.Debug("Nonce collision detected")
-		return errors.New("Nonce collision detected")
-	}
-
-	wfe.replayNonces[nonce] = true
-	response.Header().Set("Replay-Nonce", nonce)
-	return
+func (wfe *WebFrontEndImpl) sendNonce(response http.ResponseWriter) {
+	response.Header().Set("Replay-Nonce", wfe.nonceService.Nonce())
 }
 
 func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]byte, *jose.JsonWebKey, core.Registration, error) {
@@ -216,11 +209,9 @@ func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]
 	if err != nil || len(protected.Nonce) == 0 {
 		wfe.log.Debug("JWS has no anti-replay nonce")
 		return nil, nil, reg, errors.New("JWS has no anti-replay nonce")
-	} else if !wfe.replayNonces[protected.Nonce] {
+	} else if !wfe.nonceService.Valid(protected.Nonce) {
 		wfe.log.Debug(fmt.Sprintf("JWS has invalid anti-replay nonce: %s", protected.Nonce))
 		return nil, nil, reg, errors.New("JWS has invalid anti-replay nonce")
-	} else {
-		delete(wfe.replayNonces, protected.Nonce)
 	}
 
 	if regCheck {
@@ -278,10 +269,7 @@ func link(url, relation string) string {
 }
 
 func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", "", http.StatusMethodNotAllowed)
@@ -342,10 +330,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 }
 
 func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -404,10 +389,7 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 }
 
 func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -484,10 +466,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 }
 
 func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -560,10 +539,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 }
 
 func (wfe *WebFrontEndImpl) Challenge(authz core.Authorization, response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "GET" && request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -672,10 +648,7 @@ func (wfe *WebFrontEndImpl) Challenge(authz core.Authorization, response http.Re
 }
 
 func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -748,10 +721,7 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 }
 
 func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "GET" && request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -801,10 +771,7 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 var allHex = regexp.MustCompile("^[0-9a-f]+$")
 
 func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "GET" && request.Method != "POST" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -852,10 +819,7 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 }
 
 func (wfe *WebFrontEndImpl) Terms(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "GET" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -866,10 +830,7 @@ func (wfe *WebFrontEndImpl) Terms(response http.ResponseWriter, request *http.Re
 }
 
 func (wfe *WebFrontEndImpl) Issuer(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "GET" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)
@@ -886,10 +847,7 @@ func (wfe *WebFrontEndImpl) Issuer(response http.ResponseWriter, request *http.R
 
 // BuildID tells the requestor what build we're running.
 func (wfe *WebFrontEndImpl) BuildID(response http.ResponseWriter, request *http.Request) {
-	err := wfe.sendNonce(response)
-	if err != nil {
-		wfe.sendError(response, "Anti-replay nonce collision", err, http.StatusInternalServerError)
-	}
+	wfe.sendNonce(response)
 
 	if request.Method != "GET" {
 		wfe.sendError(response, "Method not allowed", request.Method, http.StatusMethodNotAllowed)

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -202,15 +202,11 @@ func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]
 
 	// Check that the request has a known anti-replay nonce
 	// i.e., Nonce is in protected header and
-	var protected struct {
-		Nonce string `json:"nonce"`
-	}
-	err = json.Unmarshal(header, &protected)
-	if err != nil || len(protected.Nonce) == 0 {
+	if err != nil || len(header.Nonce) == 0 {
 		wfe.log.Debug("JWS has no anti-replay nonce")
 		return nil, nil, reg, errors.New("JWS has no anti-replay nonce")
-	} else if !wfe.nonceService.Valid(protected.Nonce) {
-		wfe.log.Debug(fmt.Sprintf("JWS has invalid anti-replay nonce: %s", protected.Nonce))
+	} else if !wfe.nonceService.Valid(header.Nonce) {
+		wfe.log.Debug(fmt.Sprintf("JWS has invalid anti-replay nonce: %s", header.Nonce))
 		return nil, nil, reg, errors.New("JWS has invalid anti-replay nonce")
 	}
 


### PR DESCRIPTION
This PR implements the replay-nonce facility recently added to the ACME spec, along with corresponding updates to tests.  It does not implement the "acmeUrl" / "acmePath" facility.

The one unfortunate thing about the current patch is that it monkey-patches the JOSE library to expose the protected header.  I will try to get that pushed upstream, but in the mean-time, we may have to be careful about updating go-jose.