### PR TITLE
Bugfix: Make OCSP Response lifespans configurable.

### DIFF
--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -305,9 +305,10 @@ func setup(t *testing.T) (cadb core.CertificateAuthorityDatabase, storageAuthori
 		Key: KeyConfig{
 			File: caKeyFile,
 		},
-		TestMode: true,
-		Expiry:   "8760h",
-		MaxNames: 2,
+		TestMode:     true,
+		Expiry:       "8760h",
+		LifespanOCSP: "45m",
+		MaxNames:     2,
 		CFSSL: cfsslConfig.Config{
 			Signing: &cfsslConfig.Signing{
 				Profiles: map[string]*cfsslConfig.SigningProfile{

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -184,11 +184,14 @@ func main() {
 		auditlogger.Info(app.VersionString())
 
 		// Calculate the cut-off timestamp
+		if c.OCSPUpdater.MinTimeToExpiry == "" {
+			panic("Config must specify a MinTimeToExpiry period.")
+		}
 		dur, err := time.ParseDuration(c.OCSPUpdater.MinTimeToExpiry)
 		cmd.FailOnError(err, "Could not parse MinTimeToExpiry from config.")
 
 		oldestLastUpdatedTime := time.Now().Add(-dur)
-		auditlogger.Info(fmt.Sprintf("Searching for OCSP reponses older than %s", oldestLastUpdatedTime))
+		auditlogger.Info(fmt.Sprintf("Searching for OCSP responses older than %s", oldestLastUpdatedTime))
 
 		count := int(math.Min(float64(ocspResponseLimit), float64(c.OCSPUpdater.ResponseLimit)))
 

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -45,6 +45,7 @@
       "File": "test/test-ca.key"
     },
     "expiry": "2160h",
+    "lifespanOCSP": "96h",
     "maxNames": 1000,
     "cfssl": {
       "signing": {

--- a/test/boulder-pkcs11-example-config.json
+++ b/test/boulder-pkcs11-example-config.json
@@ -42,6 +42,7 @@
     "testMode": true,
     "_comment": "This should only be present in testMode. In prod use an HSM.",
     "expiry": "2160h",
+    "lifespanOCSP": "96h",
     "maxNames": 1000,
     "Key": {
       "PKCS11": {

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -45,6 +45,7 @@
       "File": "test/test-ca.key"
     },
     "expiry": "2160h",
+    "lifespanOCSP": "96h",
     "maxNames": 1000,
     "cfssl": {
       "signing": {


### PR DESCRIPTION
Because, let's face it, one hour long OCSP responses are too aggressive for the world of today.