### PR TITLE
Add error checking to GenerateOCSP RPC

### DIFF
--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -561,11 +561,14 @@ func (cac CertificateAuthorityClient) GenerateOCSP(signRequest core.OCSPSigningR
 	data, err := json.Marshal(signRequest)
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		errorCondition(MethodGetRegistration, err, signRequest)
+		errorCondition(MethodGenerateOCSP, err, signRequest)
 		return
 	}
 
 	resp, err = cac.rpc.DispatchSync(MethodGenerateOCSP, data)
+	if err == nil && (resp == nil || len(resp) < 1) {
+		err = fmt.Errorf("Failure at Signer")
+	}
 	return
 }
 


### PR DESCRIPTION
- While testing PKCS11 support, caused an error in signing that provoked an empty OCSP response to be saved to the DB
- In fact, the response saved was 726573706F6E7365 which, in ASCII, is "response"
- Fix typo in GenerateOCSP at the same time