### PR TITLE
Improve build identification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,15 @@ OBJECTS = activity-monitor \
 	ocsp-updater \
 	ocsp-responder
 
-REVID = $(shell git symbolic-ref --short HEAD):$(shell git rev-parse --short HEAD)
+# Build environment variables (referencing core/util.go)
+BUILD_ID = $(shell git symbolic-ref --short HEAD) +$(shell git rev-parse --short HEAD)
 BUILD_ID_VAR = github.com/letsencrypt/boulder/core.BuildID
+
+BUILD_HOST = $(shell whoami)@$(shell hostname)
+BUILD_HOST_VAR = github.com/letsencrypt/boulder/core.BuildHost
+
+BUILD_TIME = $(shell date -u)
+BUILD_TIME_VAR = github.com/letsencrypt/boulder/core.BuildTime
 
 .PHONY: all build
 all: build
@@ -23,12 +30,17 @@ all: build
 build: $(OBJECTS)
 
 pre:
-	mkdir -p $(OBJDIR)
-	go install ./Godeps/_workspace/src/github.com/mattn/go-sqlite3
+	@mkdir -p $(OBJDIR)
+	@echo [go] lib/github.com/mattn/go-sqlite3
+	@go install ./Godeps/_workspace/src/github.com/mattn/go-sqlite3
 
 # Compile each of the binaries
 $(OBJECTS): pre
-	go build -tags pkcs11 -o ./bin/$@ -ldflags "-X $(BUILD_ID_VAR) $(REVID)" cmd/$@/main.go
+	@echo [go] bin/$@
+	@go build -tags pkcs11 -o ./bin/$@ -ldflags \
+		"-X $(BUILD_ID_VAR) '$(BUILD_ID)' -X $(BUILD_TIME_VAR) '$(BUILD_TIME)' \
+		 -X $(BUILD_HOST_VAR) '$(BUILD_HOST)'" \
+		cmd/$@/main.go
 
 clean:
 	rm -f $(OBJDIR)/*

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -179,7 +179,7 @@ func (as *AppShell) Run() {
 
 // VersionString produces a friendly Application version string
 func (as *AppShell) VersionString() string {
-	return fmt.Sprintf("%s (build %s)", as.App.Name, core.GetBuildID())
+	return fmt.Sprintf("Versions: %s=(%s %s) Golang=(%s) BuildHost=(%s)", as.App.Name, core.GetBuildID(), core.GetBuildTime(), runtime.Version(), core.GetBuildHost())
 }
 
 // FailOnError exits and prints an error message if we encountered a problem

--- a/core/util.go
+++ b/core/util.go
@@ -34,6 +34,12 @@ import (
 // and is used by GetBuildID
 var BuildID string
 
+// BuildHost is set by the compiler and is used by GetBuildHost
+var BuildHost string
+
+// BuildTime is set by the compiler and is used by GetBuildTime
+var BuildTime string
+
 // Errors
 
 type InternalServerError string
@@ -249,6 +255,24 @@ func StringToSerial(serial string) (*big.Int, error) {
 // GetBuildID identifies what build is running.
 func GetBuildID() (retID string) {
 	retID = BuildID
+	if retID == "" {
+		retID = "Unspecified"
+	}
+	return
+}
+
+// GetBuildTime identifies when this build was made
+func GetBuildTime() (retID string) {
+	retID = BuildTime
+	if retID == "" {
+		retID = "Unspecified"
+	}
+	return
+}
+
+// GetBuildHost identifies the building host
+func GetBuildHost() (retID string) {
+	retID = BuildHost
 	if retID == "" {
 		retID = "Unspecified"
 	}

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -811,7 +812,8 @@ func (wfe *WebFrontEndImpl) BuildID(response http.ResponseWriter, request *http.
 
 	response.Header().Set("Content-Type", "text/plain")
 	response.WriteHeader(http.StatusOK)
-	if _, err := fmt.Fprintln(response, core.GetBuildID()); err != nil {
+	detailsString := fmt.Sprintf("Boulder=(%s %s) Golang=(%s) BuildHost=(%s)", core.GetBuildID(), core.GetBuildTime(), runtime.Version(), core.GetBuildHost())
+	if _, err := fmt.Fprintln(response, detailsString); err != nil {
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 	}
 }


### PR DESCRIPTION
New example:

```2015/06/09 09:20:13 Versions: boulder=(generate_ocsp +0c101f2 Tue Jun  9 16:20:06 UTC 2015) Golang=(devel +46b4f67 Thu Apr 16 20:01:13 2015 +0000) BuildHost=(user@vm.local)```