### PR TITLE
Return method errors in RPC layer

### DIFF
--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -227,7 +227,7 @@ func (rpc *AmqpRPCServer) Start() (err error) {
 			jsonResponse, err := json.Marshal(response)
 			if err != nil {
 				// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-				rpc.log.Audit(fmt.Sprintf(" [s>][%s][%s] Error condition marshalling RPC response %s(%s) [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, "", msg.CorrelationId))
+				rpc.log.Audit(fmt.Sprintf(" [s>][%s][%s] Error condition marshalling RPC response %s [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, msg.CorrelationId))
 				continue
 			}
 			rpc.log.Info(fmt.Sprintf(" [s>][%s][%s] replying %s(%s) [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, core.B64enc(jsonResponse), msg.CorrelationId))

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -6,6 +6,7 @@
 package rpc
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -116,7 +117,7 @@ type AmqpRPCServer struct {
 	serverQueue   string
 	channel       *amqp.Channel
 	log           *blog.AuditLogger
-	dispatchTable map[string]func([]byte) []byte
+	dispatchTable map[string]func([]byte) ([]byte, error)
 }
 
 // Create a new AMQP-RPC server on the given queue and channel.
@@ -128,12 +129,71 @@ func NewAmqpRPCServer(serverQueue string, channel *amqp.Channel) *AmqpRPCServer 
 		serverQueue:   serverQueue,
 		channel:       channel,
 		log:           log,
-		dispatchTable: make(map[string]func([]byte) []byte),
+		dispatchTable: make(map[string]func([]byte) ([]byte, error)),
 	}
 }
 
-func (rpc *AmqpRPCServer) Handle(method string, handler func([]byte) []byte) {
+func (rpc *AmqpRPCServer) Handle(method string, handler func([]byte) ([]byte, error)) {
 	rpc.dispatchTable[method] = handler
+}
+
+type RPCError struct {
+	Value string `json:"value"`
+	Type  string `json:"type"`
+}
+
+type RPCResponse struct {
+	ReturnVal []byte   `json:"returnVal"`
+	Error     RPCError `json:"error"`
+}
+
+func wrapError(err error) (rpcError RPCError) {
+	if err != nil {
+		rpcError.Value = err.Error()
+		switch err.(type) {
+		case core.InternalServerError:
+			rpcError.Type = "InternalServerError"
+		case core.NotSupportedError:
+			rpcError.Type = "NotSupportedError"
+		case core.MalformedRequestError:
+			rpcError.Type = "MalformedRequestError"
+		case core.UnauthorizedError:
+			rpcError.Type = "UnauthorizedError"
+		case core.NotFoundError:
+			rpcError.Type = "NotFoundError"
+		case core.SyntaxError:
+			rpcError.Type = "SyntaxError"
+		case core.SignatureValidationError:
+			rpcError.Type = "SignatureValidationError"
+		case core.CertificateIssuanceError:
+			rpcError.Type = "CertificateIssuanceError"
+		}
+	}
+	return
+}
+
+func (rpcError RPCError) unwrapError() (err error) {
+	switch rpcError.Type {
+	case "InternalServerError":
+		err = core.InternalServerError(rpcError.Value)
+	case "NotSupportedError":
+		err = core.NotSupportedError(rpcError.Value)
+	case "MalformedRequestError":
+		err = core.MalformedRequestError(rpcError.Value)
+	case "UnauthorizedError":
+		err = core.UnauthorizedError(rpcError.Value)
+	case "NotFoundError":
+		err = core.NotFoundError(rpcError.Value)
+	case "SyntaxError":
+		err = core.SyntaxError(rpcError.Value)
+	case "SignatureValidationError":
+		err = core.SignatureValidationError(rpcError.Value)
+	case "CertificateIssuanceError":
+		err = core.CertificateIssuanceError(rpcError.Value)
+	default:
+		err = errors.New(rpcError.Value)
+	}
+	return
 }
 
 // Starts the AMQP-RPC server running in a separate thread.
@@ -154,8 +214,16 @@ func (rpc *AmqpRPCServer) Start() (err error) {
 				rpc.log.Audit(fmt.Sprintf(" [s<][%s][%s] Misrouted message: %s - %s - %s", rpc.serverQueue, msg.ReplyTo, msg.Type, core.B64enc(msg.Body), msg.CorrelationId))
 				continue
 			}
-			response := cb(msg.Body)
-			rpc.log.Info(fmt.Sprintf(" [s>][%s][%s] replying %s(%s) [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, core.B64enc(response), msg.CorrelationId))
+			var response RPCResponse
+			response.ReturnVal, err = cb(msg.Body)
+			response.Error = wrapError(err)
+			jsonResponse, err := json.Marshal(response)
+			if err != nil {
+				// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+				rpc.log.Audit(fmt.Sprintf(" [s>][%s][%s] Error condition marshalling RPC response %s(%s) [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, "", msg.CorrelationId))
+				continue
+			}
+			rpc.log.Info(fmt.Sprintf(" [s>][%s][%s] replying %s(%s) [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, core.B64enc(jsonResponse), msg.CorrelationId))
 			rpc.channel.Publish(
 				AmqpExchange,
 				msg.ReplyTo,
@@ -164,7 +232,7 @@ func (rpc *AmqpRPCServer) Start() (err error) {
 				amqp.Publishing{
 					CorrelationId: msg.CorrelationId,
 					Type:          msg.Type,
-					Body:          response, // XXX-JWS: jws.Sign(privKey, body)
+					Body:          jsonResponse, // XXX-JWS: jws.Sign(privKey, body)
 				})
 		}
 	}()
@@ -272,7 +340,17 @@ func (rpc *AmqpRPCCLient) Dispatch(method string, body []byte) chan []byte {
 
 func (rpc *AmqpRPCCLient) DispatchSync(method string, body []byte) (response []byte, err error) {
 	select {
-	case response = <-rpc.Dispatch(method, body):
+	case jsonResponse := <-rpc.Dispatch(method, body):
+		var rpcResponse RPCResponse
+		err = json.Unmarshal(jsonResponse, &rpcResponse)
+		if err != nil {
+			return
+		}
+		if rpcResponse.Error.Value != "" {
+			err = rpcResponse.Error.unwrapError()
+			return
+		}
+		response = rpcResponse.ReturnVal
 		return
 	case <-time.After(rpc.timeout):
 		rpc.log.Warning(fmt.Sprintf(" [c!][%s] AMQP-RPC timeout [%s]", rpc.clientQueue, method))

--- a/rpc/rpc-interfaces.go
+++ b/rpc/rpc-interfaces.go
@@ -19,5 +19,5 @@ type RPCClient interface {
 
 // RPCServer describes the functions an RPC Server performs
 type RPCServer interface {
-	Handle(string, func([]byte) []byte)
+	Handle(string, func([]byte) ([]byte, error))
 }

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -253,7 +253,7 @@ func (rac RegistrationAuthorityClient) NewRegistration(reg core.Registration) (n
 	}
 
 	newRegData, err := rac.rpc.DispatchSync(MethodNewRegistration, data)
-	if err != nil || len(newRegData) == 0 {
+	if err != nil {
 		return
 	}
 
@@ -268,7 +268,7 @@ func (rac RegistrationAuthorityClient) NewAuthorization(authz core.Authorization
 	}
 
 	newAuthzData, err := rac.rpc.DispatchSync(MethodNewAuthorization, data)
-	if err != nil || len(newAuthzData) == 0 {
+	if err != nil {
 		return
 	}
 
@@ -284,10 +284,6 @@ func (rac RegistrationAuthorityClient) NewCertificate(cr core.CertificateRequest
 
 	certData, err := rac.rpc.DispatchSync(MethodNewCertificate, data)
 	if err != nil {
-		return
-	}
-	if len(certData) == 0 {
-		err = errors.New("NewCertificate RPC to RA failed.")
 		return
 	}
 
@@ -306,7 +302,7 @@ func (rac RegistrationAuthorityClient) UpdateRegistration(base core.Registration
 	}
 
 	newRegData, err := rac.rpc.DispatchSync(MethodUpdateRegistration, data)
-	if err != nil || len(newRegData) == 0 {
+	if err != nil {
 		return
 	}
 
@@ -330,7 +326,7 @@ func (rac RegistrationAuthorityClient) UpdateAuthorization(authz core.Authorizat
 	}
 
 	newAuthzData, err := rac.rpc.DispatchSync(MethodUpdateAuthorization, data)
-	if err != nil || len(newAuthzData) == 0 {
+	if err != nil {
 		return
 	}
 
@@ -419,19 +415,19 @@ func NewCertificateAuthorityServer(rpc RPCServer, impl core.CertificateAuthority
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodIssueCertificate, err, req)
-			return // XXX
+			return
 		}
 
 		cert, err := impl.IssueCertificate(*csr, icReq.RegID, icReq.EarliestExpiry)
 		if err != nil {
-			return // XXX
+			return
 		}
 
 		response, err = json.Marshal(cert)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetRegistration, err, req)
-			return // XXX
+			return
 		}
 
 		return
@@ -499,10 +495,6 @@ func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateReque
 	if err != nil {
 		return
 	}
-	if len(jsonResponse) == 0 {
-		err = errors.New("IssueCertificate RPC to CA failed.")
-		return
-	}
 
 	err = json.Unmarshal(jsonResponse, &cert)
 	return
@@ -536,8 +528,12 @@ func (cac CertificateAuthorityClient) GenerateOCSP(signRequest core.OCSPSigningR
 	}
 
 	resp, err = cac.rpc.DispatchSync(MethodGenerateOCSP, data)
-	if err == nil && (resp == nil || len(resp) < 1) {
+	if err != nil {
+		return
+	}
+	if len(resp) < 1 {
 		err = fmt.Errorf("Failure at Signer")
+		return
 	}
 	return
 }
@@ -882,7 +878,6 @@ func (cac StorageAuthorityClient) UpdateRegistration(reg core.Registration) (err
 		return
 	}
 
-	// XXX: Is this catching all the errors?
 	_, err = cac.rpc.DispatchSync(MethodUpdateRegistration, jsonReg)
 	return
 }
@@ -894,8 +889,7 @@ func (cac StorageAuthorityClient) NewRegistration(reg core.Registration) (output
 		return
 	}
 	response, err := cac.rpc.DispatchSync(MethodNewRegistration, jsonReg)
-	if err != nil || len(response) == 0 {
-		err = errors.New("NewRegistration RPC failed") // XXX
+	if err != nil {
 		return
 	}
 	err = json.Unmarshal(response, &output)
@@ -912,8 +906,7 @@ func (cac StorageAuthorityClient) NewPendingAuthorization(authz core.Authorizati
 		return
 	}
 	response, err := cac.rpc.DispatchSync(MethodNewPendingAuthorization, jsonAuthz)
-	if err != nil || len(response) == 0 {
-		err = errors.New("NewPendingAuthorization RPC failed") // XXX
+	if err != nil {
 		return
 	}
 	err = json.Unmarshal(response, &output)
@@ -930,7 +923,6 @@ func (cac StorageAuthorityClient) UpdatePendingAuthorization(authz core.Authoriz
 		return
 	}
 
-	// XXX: Is this catching all the errors?
 	_, err = cac.rpc.DispatchSync(MethodUpdatePendingAuthorization, jsonAuthz)
 	return
 }
@@ -941,7 +933,6 @@ func (cac StorageAuthorityClient) FinalizeAuthorization(authz core.Authorization
 		return
 	}
 
-	// XXX: Is this catching all the errors?
 	_, err = cac.rpc.DispatchSync(MethodFinalizeAuthorization, jsonAuthz)
 	return
 }
@@ -959,8 +950,7 @@ func (cac StorageAuthorityClient) AddCertificate(cert []byte, regID int64) (id s
 	}
 
 	response, err := cac.rpc.DispatchSync(MethodAddCertificate, data)
-	if err != nil || len(response) == 0 {
-		err = errors.New("AddCertificate RPC failed") // XXX
+	if err != nil {
 		return
 	}
 	id = string(response)
@@ -979,8 +969,7 @@ func (cac StorageAuthorityClient) AlreadyDeniedCSR(names []string) (exists bool,
 	}
 
 	response, err := cac.rpc.DispatchSync(MethodAlreadyDeniedCSR, data)
-	if err != nil || len(response) == 0 {
-		err = errors.New("AlreadyDeniedCSR RPC failed") // XXX
+	if err != nil {
 		return
 	}
 

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -90,61 +90,61 @@ func errorCondition(method string, err error, obj interface{}) {
 func NewRegistrationAuthorityServer(rpc RPCServer, impl core.RegistrationAuthority) error {
 	log := blog.GetAuditLogger()
 
-	rpc.Handle(MethodNewRegistration, func(req []byte) (response []byte) {
+	rpc.Handle(MethodNewRegistration, func(req []byte) (response []byte, err error) {
 		var rr registrationRequest
-		if err := json.Unmarshal(req, &rr); err != nil {
+		if err = json.Unmarshal(req, &rr); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodNewRegistration, err, req)
-			return nil
+			return
 		}
 
 		reg, err := impl.NewRegistration(rr.Reg)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewRegistration, err, reg)
-			return nil
+			return
 		}
 
 		response, err = json.Marshal(reg)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewRegistration, err, req)
-			return nil
+			return
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodNewAuthorization, func(req []byte) (response []byte) {
+	rpc.Handle(MethodNewAuthorization, func(req []byte) (response []byte, err error) {
 		var ar authorizationRequest
-		if err := json.Unmarshal(req, &ar); err != nil {
+		if err = json.Unmarshal(req, &ar); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodNewAuthorization, err, req)
-			return nil
+			return
 		}
 
 		authz, err := impl.NewAuthorization(ar.Authz, ar.RegID)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewAuthorization, err, ar)
-			return nil
+			return
 		}
 
 		response, err = json.Marshal(authz)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewAuthorization, err, req)
-			return nil
+			return
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodNewCertificate, func(req []byte) []byte {
+	rpc.Handle(MethodNewCertificate, func(req []byte) (response []byte, err error) {
 		log.Info(fmt.Sprintf(" [.] Entering MethodNewCertificate"))
 		var cr certificateRequest
-		if err := json.Unmarshal(req, &cr); err != nil {
+		if err = json.Unmarshal(req, &cr); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodNewCertificate, err, req)
-			return nil
+			return
 		}
 		log.Info(fmt.Sprintf(" [.] No problem unmarshaling request"))
 
@@ -152,105 +152,104 @@ func NewRegistrationAuthorityServer(rpc RPCServer, impl core.RegistrationAuthori
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewCertificate, err, cr)
-			return nil
+			return
 		}
 		log.Info(fmt.Sprintf(" [.] No problem issuing new cert"))
 
-		response, err := json.Marshal(cert)
+		response, err = json.Marshal(cert)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewCertificate, err, req)
-			return nil
+			return
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodUpdateRegistration, func(req []byte) (response []byte) {
+	rpc.Handle(MethodUpdateRegistration, func(req []byte) (response []byte, err error) {
 		var request struct {
 			Base, Update core.Registration
 		}
-		err := json.Unmarshal(req, &request)
+		err = json.Unmarshal(req, &request)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodUpdateRegistration, err, req)
-			return nil
+			return
 		}
 
 		reg, err := impl.UpdateRegistration(request.Base, request.Update)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodUpdateRegistration, err, request)
-			return nil
+			return
 		}
 
 		response, err = json.Marshal(reg)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodUpdateRegistration, err, req)
-			return nil
+			return
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodUpdateAuthorization, func(req []byte) (response []byte) {
+	rpc.Handle(MethodUpdateAuthorization, func(req []byte) (response []byte, err error) {
 		var authz struct {
 			Authz    core.Authorization
 			Index    int
 			Response core.Challenge
 		}
-		err := json.Unmarshal(req, &authz)
+		err = json.Unmarshal(req, &authz)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodUpdateAuthorization, err, req)
-			return nil
+			return
 		}
 
 		newAuthz, err := impl.UpdateAuthorization(authz.Authz, authz.Index, authz.Response)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodUpdateAuthorization, err, authz)
-			return nil
+			return
 		}
 
 		response, err = json.Marshal(newAuthz)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodUpdateAuthorization, err, req)
-			return nil
+			return
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodRevokeCertificate, func(req []byte) []byte {
+	rpc.Handle(MethodRevokeCertificate, func(req []byte) (response []byte, err error) {
 		certs, err := x509.ParseCertificates(req)
 		if err != nil || len(certs) == 0 {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodRevokeCertificate, err, req)
-			return nil
+			return
 		}
 
-		// Error explicitly ignored since response is nil anyway
 		err = impl.RevokeCertificate(*certs[0])
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodRevokeCertificate, err, certs)
 		}
-		return nil
+		return
 	})
 
-	rpc.Handle(MethodOnValidationUpdate, func(req []byte) []byte {
+	rpc.Handle(MethodOnValidationUpdate, func(req []byte) (response []byte, err error) {
 		var authz core.Authorization
-		if err := json.Unmarshal(req, &authz); err != nil {
+		if err = json.Unmarshal(req, &authz); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodOnValidationUpdate, err, req)
-			return nil
+			return
 		}
 
-		if err := impl.OnValidationUpdate(authz); err != nil {
+		if err = impl.OnValidationUpdate(authz); err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodOnValidationUpdate, err, authz)
 		}
-		return nil
+		return
 	})
 
 	return nil
@@ -358,7 +357,7 @@ func (rac RegistrationAuthorityClient) UpdateAuthorization(authz core.Authorizat
 }
 
 func (rac RegistrationAuthorityClient) RevokeCertificate(cert x509.Certificate) (err error) {
-	rac.rpc.Dispatch(MethodRevokeCertificate, cert.Raw)
+	_, err = rac.rpc.DispatchSync(MethodRevokeCertificate, cert.Raw)
 	return
 }
 
@@ -368,29 +367,29 @@ func (rac RegistrationAuthorityClient) OnValidationUpdate(authz core.Authorizati
 		return
 	}
 
-	rac.rpc.Dispatch(MethodOnValidationUpdate, data)
+	_, err = rac.rpc.DispatchSync(MethodOnValidationUpdate, data)
 	return
 }
 
 // ValidationAuthorityClient / Server
 //  -> UpdateValidations
 func NewValidationAuthorityServer(rpc RPCServer, impl core.ValidationAuthority) (err error) {
-	rpc.Handle(MethodUpdateValidations, func(req []byte) []byte {
+	rpc.Handle(MethodUpdateValidations, func(req []byte) (response []byte, err error) {
 		var vaReq struct {
 			Authz core.Authorization
 			Index int
 		}
-		if err := json.Unmarshal(req, &vaReq); err != nil {
+		if err = json.Unmarshal(req, &vaReq); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodUpdateValidations, err, req)
-			return nil
+			return
 		}
 
-		if err := impl.UpdateValidations(vaReq.Authz, vaReq.Index); err != nil {
+		if err = impl.UpdateValidations(vaReq.Authz, vaReq.Index); err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodUpdateValidations, err, vaReq)
 		}
-		return nil
+		return
 	})
 
 	return nil
@@ -417,60 +416,60 @@ func (vac ValidationAuthorityClient) UpdateValidations(authz core.Authorization,
 		return err
 	}
 
-	vac.rpc.Dispatch(MethodUpdateValidations, data)
+	_, err = vac.rpc.DispatchSync(MethodUpdateValidations, data)
 	return nil
 }
 
 // CertificateAuthorityClient / Server
 //  -> IssueCertificate
 func NewCertificateAuthorityServer(rpc RPCServer, impl core.CertificateAuthority) (err error) {
-	rpc.Handle(MethodIssueCertificate, func(req []byte) []byte {
+	rpc.Handle(MethodIssueCertificate, func(req []byte) (response []byte, err error) {
 		var icReq struct {
 			Bytes          []byte
 			RegID          int64
 			EarliestExpiry time.Time
 		}
-		err := json.Unmarshal(req, &icReq)
+		err = json.Unmarshal(req, &icReq)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodIssueCertificate, err, req)
-			return nil
+			return
 		}
 
 		csr, err := x509.ParseCertificateRequest(icReq.Bytes)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodIssueCertificate, err, req)
-			return nil // XXX
+			return // XXX
 		}
 
 		cert, err := impl.IssueCertificate(*csr, icReq.RegID, icReq.EarliestExpiry)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodIssueCertificate, err, csr)
-			return nil // XXX
+			return // XXX
 		}
 
-		serialized, err := json.Marshal(cert)
+		response, err = json.Marshal(cert)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetRegistration, err, req)
-			return nil // XXX
+			return // XXX
 		}
 
-		return serialized
+		return
 	})
 
-	rpc.Handle(MethodRevokeCertificate, func(req []byte) []byte {
+	rpc.Handle(MethodRevokeCertificate, func(req []byte) (response []byte, err error) {
 		var revokeReq struct {
 			Serial     string
 			ReasonCode int
 		}
-		err := json.Unmarshal(req, &revokeReq)
+		err = json.Unmarshal(req, &revokeReq)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodRevokeCertificate, err, req)
-			return nil
+			return
 		}
 
 		if err := impl.RevokeCertificate(revokeReq.Serial, revokeReq.ReasonCode); err != nil {
@@ -478,29 +477,29 @@ func NewCertificateAuthorityServer(rpc RPCServer, impl core.CertificateAuthority
 			errorCondition(MethodRevokeCertificate, err, req)
 		}
 
-		return nil
+		return
 	})
 
-	rpc.Handle(MethodGenerateOCSP, func(req []byte) []byte {
+	rpc.Handle(MethodGenerateOCSP, func(req []byte) (response []byte, err error) {
 		var xferObj core.OCSPSigningRequest
-		err := json.Unmarshal(req, &xferObj)
+		err = json.Unmarshal(req, &xferObj)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGenerateOCSP, err, req)
-			return nil
+			return
 		}
 
-		data, err := impl.GenerateOCSP(xferObj)
+		response, err = impl.GenerateOCSP(xferObj)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGenerateOCSP, err, req)
-			return nil
+			return
 		}
 
-		return data
+		return
 	})
 
-	return
+	return nil
 }
 
 type CertificateAuthorityClient struct {
@@ -570,191 +569,192 @@ func (cac CertificateAuthorityClient) GenerateOCSP(signRequest core.OCSPSigningR
 }
 
 func NewStorageAuthorityServer(rpc RPCServer, impl core.StorageAuthority) error {
-	rpc.Handle(MethodUpdateRegistration, func(req []byte) (response []byte) {
+	rpc.Handle(MethodUpdateRegistration, func(req []byte) (response []byte, err error) {
 		var reg core.Registration
-		if err := json.Unmarshal(req, &reg); err != nil {
+		if err = json.Unmarshal(req, &reg); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodUpdateRegistration, err, req)
-			return nil
+			return
 		}
 
-		if err := impl.UpdateRegistration(reg); err != nil {
+		if err = impl.UpdateRegistration(reg); err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodUpdateRegistration, err, req)
 		}
 
-		return nil
+		return
 	})
 
-	rpc.Handle(MethodGetRegistration, func(req []byte) (response []byte) {
+	rpc.Handle(MethodGetRegistration, func(req []byte) (response []byte, err error) {
 		var intReq struct {
 			ID int64
 		}
-		err := json.Unmarshal(req, &intReq)
+		err = json.Unmarshal(req, &intReq)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodGetRegistration, err, req)
-			return nil
+			return
 		}
 
 		reg, err := impl.GetRegistration(intReq.ID)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetRegistration, err, req)
-			return nil
+			return
 		}
 
 		response, err = json.Marshal(reg)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetRegistration, err, req)
-			return nil
+			return
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodGetRegistrationByKey, func(req []byte) (response []byte) {
+	rpc.Handle(MethodGetRegistrationByKey, func(req []byte) (response []byte, err error) {
 		var jwk jose.JsonWebKey
-		if err := json.Unmarshal(req, &jwk); err != nil {
+		if err = json.Unmarshal(req, &jwk); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodGetRegistrationByKey, err, req)
-			return nil
+			return
 		}
 
 		reg, err := impl.GetRegistrationByKey(jwk)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetRegistrationByKey, err, jwk)
-			return nil
+			return
 		}
 
 		response, err = json.Marshal(reg)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetRegistrationByKey, err, req)
-			return nil
+			return
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodGetAuthorization, func(req []byte) []byte {
+	rpc.Handle(MethodGetAuthorization, func(req []byte) (response []byte, err error) {
 		authz, err := impl.GetAuthorization(string(req))
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetAuthorization, err, req)
-			return nil
+			return
 		}
 
-		jsonAuthz, err := json.Marshal(authz)
+		response, err = json.Marshal(authz)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetAuthorization, err, req)
-			return nil
+			return
 		}
-		return jsonAuthz
+		return
 	})
 
-	rpc.Handle(MethodAddCertificate, func(req []byte) []byte {
+	rpc.Handle(MethodAddCertificate, func(req []byte) (response []byte, err error) {
 		var icReq struct {
 			Bytes []byte
 			RegID int64
 		}
-		err := json.Unmarshal(req, &icReq)
+		err = json.Unmarshal(req, &icReq)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodAddCertificate, err, req)
-			return nil
+			return
 		}
 
 		id, err := impl.AddCertificate(icReq.Bytes, icReq.RegID)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodAddCertificate, err, req)
-			return nil
+			return
 		}
-		return []byte(id)
+		response = []byte(id)
+		return
 	})
 
-	rpc.Handle(MethodNewRegistration, func(req []byte) []byte {
+	rpc.Handle(MethodNewRegistration, func(req []byte) (response []byte, err error) {
 		var registration core.Registration
-		err := json.Unmarshal(req, &registration)
+		err = json.Unmarshal(req, &registration)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodNewRegistration, err, req)
-			return nil
+			return
 		}
 
 		output, err := impl.NewRegistration(registration)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewRegistration, err, registration)
-			return nil
+			return
 		}
 
-		jsonOutput, err := json.Marshal(output)
+		response, err = json.Marshal(output)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewRegistration, err, req)
-			return nil
+			return
 		}
-		return []byte(jsonOutput)
+		return
 	})
 
-	rpc.Handle(MethodNewPendingAuthorization, func(req []byte) []byte {
+	rpc.Handle(MethodNewPendingAuthorization, func(req []byte) (response []byte, err error) {
 		var authz core.Authorization
-		if err := json.Unmarshal(req, &authz); err != nil {
+		if err = json.Unmarshal(req, &authz); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodNewPendingAuthorization, err, req)
-			return nil
+			return
 		}
 
 		output, err := impl.NewPendingAuthorization(authz)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewPendingAuthorization, err, req)
-			return nil
+			return
 		}
 
-		jsonOutput, err := json.Marshal(output)
+		response, err = json.Marshal(output)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodNewPendingAuthorization, err, req)
-			return nil
+			return
 		}
-		return []byte(jsonOutput)
+		return
 	})
 
-	rpc.Handle(MethodUpdatePendingAuthorization, func(req []byte) []byte {
+	rpc.Handle(MethodUpdatePendingAuthorization, func(req []byte) (response []byte, err error) {
 		var authz core.Authorization
-		if err := json.Unmarshal(req, &authz); err != nil {
+		if err = json.Unmarshal(req, &authz); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodUpdatePendingAuthorization, err, req)
-			return nil
+			return
 		}
 
-		if err := impl.UpdatePendingAuthorization(authz); err != nil {
+		if err = impl.UpdatePendingAuthorization(authz); err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodUpdatePendingAuthorization, err, authz)
 		}
-		return nil
+		return
 	})
 
-	rpc.Handle(MethodFinalizeAuthorization, func(req []byte) []byte {
+	rpc.Handle(MethodFinalizeAuthorization, func(req []byte) (response []byte, err error) {
 		var authz core.Authorization
-		if err := json.Unmarshal(req, &authz); err != nil {
+		if err = json.Unmarshal(req, &authz); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodFinalizeAuthorization, err, req)
-			return nil
+			return
 		}
 
-		if err := impl.FinalizeAuthorization(authz); err != nil {
+		if err = impl.FinalizeAuthorization(authz); err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodFinalizeAuthorization, err, authz)
 		}
-		return nil
+		return
 	})
 
-	rpc.Handle(MethodGetCertificate, func(req []byte) (response []byte) {
+	rpc.Handle(MethodGetCertificate, func(req []byte) (response []byte, err error) {
 		cert, err := impl.GetCertificate(string(req))
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
@@ -762,10 +762,10 @@ func NewStorageAuthorityServer(rpc RPCServer, impl core.StorageAuthority) error 
 		} else {
 			response = []byte(cert)
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodGetCertificateByShortSerial, func(req []byte) (response []byte) {
+	rpc.Handle(MethodGetCertificateByShortSerial, func(req []byte) (response []byte, err error) {
 		cert, err := impl.GetCertificateByShortSerial(string(req))
 		if err != nil {
 			if err != sql.ErrNoRows {
@@ -775,72 +775,72 @@ func NewStorageAuthorityServer(rpc RPCServer, impl core.StorageAuthority) error 
 		} else {
 			response = []byte(cert)
 		}
-		return response
+		return
 	})
 
-	rpc.Handle(MethodGetCertificateStatus, func(req []byte) (response []byte) {
+	rpc.Handle(MethodGetCertificateStatus, func(req []byte) (response []byte, err error) {
 		status, err := impl.GetCertificateStatus(string(req))
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetCertificateStatus, err, req)
-			return nil
+			return
 		}
 
-		jsonStatus, err := json.Marshal(status)
+		response, err = json.Marshal(status)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetCertificateStatus, err, req)
-			return nil
+			return
 		}
-		return jsonStatus
+		return
 	})
 
-	rpc.Handle(MethodMarkCertificateRevoked, func(req []byte) (response []byte) {
+	rpc.Handle(MethodMarkCertificateRevoked, func(req []byte) (response []byte, err error) {
 		var revokeReq struct {
 			Serial       string
 			OCSPResponse []byte
 			ReasonCode   int
 		}
 
-		if err := json.Unmarshal(req, &revokeReq); err != nil {
+		if err = json.Unmarshal(req, &revokeReq); err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodMarkCertificateRevoked, err, req)
-			return nil
+			return
 		}
 
-		// Error explicitly ignored since response is nil anyway
-		err := impl.MarkCertificateRevoked(revokeReq.Serial, revokeReq.OCSPResponse, revokeReq.ReasonCode)
+		err = impl.MarkCertificateRevoked(revokeReq.Serial, revokeReq.OCSPResponse, revokeReq.ReasonCode)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodMarkCertificateRevoked, err, revokeReq)
 		}
-		return nil
+		return
 	})
 
-	rpc.Handle(MethodAlreadyDeniedCSR, func(req []byte) []byte {
+	rpc.Handle(MethodAlreadyDeniedCSR, func(req []byte) (response []byte, err error) {
 		var csrReq struct {
 			Names []string
 		}
 
-		err := json.Unmarshal(req, &csrReq)
+		err = json.Unmarshal(req, &csrReq)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
 			improperMessage(MethodAlreadyDeniedCSR, err, req)
-			return nil
+			return
 		}
 
 		exists, err := impl.AlreadyDeniedCSR(csrReq.Names)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodAlreadyDeniedCSR, err, csrReq)
-			return nil
+			return
 		}
 
 		if exists {
-			return []byte{1}
+			response = []byte{1}
 		} else {
-			return []byte{0}
+			response = []byte{0}
 		}
+		return
 	})
 
 	return nil


### PR DESCRIPTION
Fixes #316. @jcjones: With this audit messages can get doubled up (from the RPC layer and from the calling logic), probably I should remove the error condition logging from the `rpc-wrappers` methods and leave the audit logging to happen in the already existing calling logic.