### PR TITLE
Fix crash on CA initialization failure

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -39,8 +39,8 @@ func main() {
 		}
 
 		cai, err := ca.NewCertificateAuthorityImpl(cadb, c.CA, c.Common.IssuerCert)
-		cai.MaxKeySize = c.Common.MaxKeySize
 		cmd.FailOnError(err, "Failed to create CA impl")
+		cai.MaxKeySize = c.Common.MaxKeySize
 
 		go cmd.ProfileCmd("CA", stats)
 


### PR DESCRIPTION
Fix null pointer panic in the event the CA fails to initialize.