### PR TITLE
Issue #309: Produce OCSP Responses immediately upon issuance

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -110,6 +110,7 @@ type StorageAdder interface {
 	UpdatePendingAuthorization(Authorization) error
 	FinalizeAuthorization(Authorization) error
 	MarkCertificateRevoked(serial string, ocspResponse []byte, reasonCode int) error
+	UpdateOCSP(serial string, ocspResponse []byte) error
 
 	AddCertificate([]byte, int64) (string, error)
 }

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	cfsslConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
@@ -170,10 +171,12 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 		},
 	}
 	signer, _ := local.NewSigner(caKey, caCert, x509.SHA256WithRSA, basicPolicy)
+	ocspSigner, _ := ocsp.NewSigner(caCert, caCert, caKey, time.Hour)
 	pa := policy.NewPolicyAuthorityImpl()
 	cadb, _ := test.NewMockCertificateAuthorityDatabase()
 	ca := ca.CertificateAuthorityImpl{
 		Signer:         signer,
+		OCSPSigner:     ocspSigner,
 		SA:             sa,
 		PA:             pa,
 		DB:             cadb,

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -51,6 +51,7 @@ const (
 	MethodGetCertificateByShortSerial = "GetCertificateByShortSerial" // SA
 	MethodGetCertificateStatus        = "GetCertificateStatus"        // SA
 	MethodMarkCertificateRevoked      = "MarkCertificateRevoked"      // SA
+	MethodUpdateOCSP                  = "UpdateOCSP"                  // SA
 	MethodNewPendingAuthorization     = "NewPendingAuthorization"     // SA
 	MethodUpdatePendingAuthorization  = "UpdatePendingAuthorization"  // SA
 	MethodFinalizeAuthorization       = "FinalizeAuthorization"       // SA
@@ -813,6 +814,22 @@ func NewStorageAuthorityServer(rpc RPCServer, impl core.StorageAuthority) error 
 		return
 	})
 
+	rpc.Handle(MethodUpdateOCSP, func(req []byte) (response []byte, err error) {
+		var updateOCSPReq struct {
+			Serial       string
+			OCSPResponse []byte
+		}
+
+		if err = json.Unmarshal(req, &updateOCSPReq); err != nil {
+			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
+			improperMessage(MethodUpdateOCSP, err, req)
+			return
+		}
+
+		err = impl.UpdateOCSP(updateOCSPReq.Serial, updateOCSPReq.OCSPResponse)
+		return
+	})
+
 	rpc.Handle(MethodAlreadyDeniedCSR, func(req []byte) (response []byte, err error) {
 		var csrReq struct {
 			Names []string
@@ -932,6 +949,24 @@ func (cac StorageAuthorityClient) MarkCertificateRevoked(serial string, ocspResp
 	}
 
 	_, err = cac.rpc.DispatchSync(MethodMarkCertificateRevoked, data)
+	return
+}
+
+func (cac StorageAuthorityClient) UpdateOCSP(serial string, ocspResponse []byte) (err error) {
+	var updateOCSPReq struct {
+		Serial       string
+		OCSPResponse []byte
+	}
+
+	updateOCSPReq.Serial = serial
+	updateOCSPReq.OCSPResponse = ocspResponse
+
+	data, err := json.Marshal(updateOCSPReq)
+	if err != nil {
+		return
+	}
+
+	_, err = cac.rpc.DispatchSync(MethodUpdateOCSP, data)
 	return
 }
 

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -198,6 +198,10 @@ func (sa *MockSA) MarkCertificateRevoked(serial string, ocspResponse []byte, rea
 	return
 }
 
+func (sa *MockSA) UpdateOCSP(serial string, ocspResponse []byte) (err error) {
+	return
+}
+
 func (sa *MockSA) NewPendingAuthorization(authz core.Authorization) (output core.Authorization, err error) {
 	return
 }


### PR DESCRIPTION
... if at all possible.

This resolves #309.

This approach performs a best-effort generation of the first OCSP response during certificate issuance. In the event that OCSP generation fails, it logs a warning at the Boulder-CA console, but returns successfully since the Certificate was itself issued.

In the event the OCSP response wasn't generated at the same time, it'll still be picked up by the periodic task that signs all required OCSP responses, whenever it fires.