### PR TITLE
Resolves Issue #344: Only send InternalServerError when needed

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -42,6 +42,12 @@ var BuildTime string
 
 // Errors
 
+// InternalServerError indicates that something has gone wrong unrelated to the
+// user's input, and will be considered by the Load Balancer as an indication
+// that this Boulder instance may be malfunctioning. Minimally, returning this
+// will cause an error page to be generated at the CDN/LB for the client.
+// Consequently, you should only use this error when Boulder's internal
+// constraints have been violated.
 type InternalServerError string
 type NotSupportedError string
 type MalformedRequestError string

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -219,6 +219,48 @@ func assertAuthzEqual(t *testing.T, a1, a2 core.Authorization) {
 	// Not testing: Challenges
 }
 
+func TestValidateContacts(t *testing.T) {
+	tel, _ := url.Parse("tel:")
+	ansible, _ := url.Parse("ansible:earth.sol.milkyway.laniakea/letsencrypt")
+	validEmail, _ := url.Parse("mailto:admin@email.com")
+	invalidEmail, _ := url.Parse("mailto:admin@example.com")
+	malformedEmail, _ := url.Parse("mailto:admin.com")
+
+	err := validateContacts([]core.AcmeURL{})
+	test.AssertNotError(t, err, "No Contacts")
+
+	err = validateContacts([]core.AcmeURL{core.AcmeURL(*tel)})
+	test.AssertNotError(t, err, "Simple Telephone")
+
+	err = validateContacts([]core.AcmeURL{core.AcmeURL(*validEmail)})
+	test.AssertNotError(t, err, "Valid Email")
+
+	err = validateContacts([]core.AcmeURL{core.AcmeURL(*invalidEmail)})
+	test.AssertError(t, err, "Invalid Email")
+
+	err = validateContacts([]core.AcmeURL{core.AcmeURL(*malformedEmail)})
+	test.AssertError(t, err, "Malformed Email")
+
+	err = validateContacts([]core.AcmeURL{core.AcmeURL(*ansible)})
+	test.AssertError(t, err, "Unknown scehme")
+}
+
+func TestValidateEmail(t *testing.T) {
+	err := validateEmail("an email`")
+	test.AssertError(t, err, "Malformed")
+
+	err = validateEmail("a@not.a.domain")
+	test.AssertError(t, err, "Cannot resolve")
+	t.Logf("No Resolve: %s", err)
+
+	err = validateEmail("a@example.com")
+	test.AssertError(t, err, "No MX Record")
+	t.Logf("No MX: %s", err)
+
+	err = validateEmail("a@email.com")
+	test.AssertNotError(t, err, "Valid")
+}
+
 func TestNewRegistration(t *testing.T) {
 	_, _, sa, ra := initAuthorities(t)
 	mailto, _ := url.Parse("mailto:foo@letsencrypt.org")

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -521,7 +521,7 @@ func TestChallenge(t *testing.T) {
 		RegistrationID: 1,
 	}
 
-	wfe.Challenge(authz, responseWriter, &http.Request{
+	wfe.challenge(authz, responseWriter, &http.Request{
 		Method: "POST",
 		URL:    challengeURL,
 		Body:   makeBody(signRequest(t, "{}", &wfe.nonceService)),


### PR DESCRIPTION
Basically, just send InternalServerError when it indicates an internal state
was broken.

- Also, unexported the wfe Challenge method that was only used internally, and looked dangerous with direct call-by-users semantics.