### PR TITLE
Correct most `go lint` warnings. (274 -> 5)

### DIFF
--- a/analysis/analysis-engine.go
+++ b/analysis/analysis-engine.go
@@ -16,16 +16,17 @@ import (
 // This file analyzes messages obtained from the Message Broker to determine
 // whether the system as a whole is functioning correctly.
 
-// Interface all Analysis Engines share
+// AnalysisEngine is the interface all Analysis Engines share
 type AnalysisEngine interface {
 	ProcessMessage(amqp.Delivery) (err error)
 }
 
-// An Analysis Engine that just logs to the JSON Logger.
+// LoggingAnalysisEngine is an Analysis Engine that just logs to the Logger.
 type LoggingAnalysisEngine struct {
 	log *blog.AuditLogger
 }
 
+// ProcessMessage logs the marshaled contents of the AMQP message.
 func (eng *LoggingAnalysisEngine) ProcessMessage(delivery amqp.Delivery) (err error) {
 	// Send the entire message contents to the syslog server for debugging.
 	encoded, err := json.Marshal(delivery)
@@ -38,7 +39,7 @@ func (eng *LoggingAnalysisEngine) ProcessMessage(delivery amqp.Delivery) (err er
 	return
 }
 
-// Construct a new Analysis Engine.
+// NewLoggingAnalysisEngine constructs a new Analysis Engine.
 func NewLoggingAnalysisEngine() AnalysisEngine {
 	logger := blog.GetAuditLogger()
 	logger.Notice("Analysis Engine Starting")

--- a/analysis/analysis-engine_test.go
+++ b/analysis/analysis-engine_test.go
@@ -25,7 +25,7 @@ type MockAck struct {
 	// json.Marshall cannot represent a chan, so this will break
 	// the json.Marshal attempt in ProcessMessage and let us get
 	// coverage there.
-	JsonBreaker chan bool
+	JSONBreaker chan bool
 }
 
 func (m *MockAck) Ack(tag uint64, multiple bool) error {

--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -64,7 +64,7 @@ func (cadb *CertificateAuthorityDatabaseImpl) CreateTablesIfNotExists() (err err
 	return
 }
 
-// GetDbMap gets a pointer to the CA DB's GORP map object.
+// Begin starts a transaction at the GORP wrapper.
 func (cadb *CertificateAuthorityDatabaseImpl) Begin() (*gorp.Transaction, error) {
 	return cadb.dbMap.Begin()
 }

--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -46,11 +46,14 @@ type Config struct {
 	CFSSL    cfsslConfig.Config
 }
 
+// KeyConfig should contain either a File path to a PEM-format private key,
+// or a PKCS11Config defining how to load a module for an HSM.
 type KeyConfig struct {
 	File   string
 	PKCS11 PKCS11Config
 }
 
+// PKCS11Config defines how to load a module for an HSM.
 type PKCS11Config struct {
 	Module string
 	Token  string
@@ -170,12 +173,12 @@ func loadKey(keyConfig KeyConfig) (priv crypto.Signer, err error) {
 
 		priv, err = helpers.ParsePrivateKeyPEM(keyBytes)
 		return
-	} else {
-		pkcs11Config := keyConfig.PKCS11
-		priv, err = pkcs11key.New(pkcs11Config.Module,
-			pkcs11Config.Token, pkcs11Config.PIN, pkcs11Config.Label)
-		return
 	}
+
+	pkcs11Config := keyConfig.PKCS11
+	priv, err = pkcs11key.New(pkcs11Config.Module,
+		pkcs11Config.Token, pkcs11Config.PIN, pkcs11Config.Label)
+	return
 }
 
 func loadIssuer(filename string) (issuerCert *x509.Certificate, err error) {

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-var CA_KEY_PEM = "-----BEGIN RSA PRIVATE KEY-----\n" +
+var CAkeyPEM = "-----BEGIN RSA PRIVATE KEY-----\n" +
 	"MIIJKQIBAAKCAgEAqmM0dEf/J9MCk2ItzevL0dKJ84lVUtf/vQ7AXFi492vFXc3b\n" +
 	"PrJz2ybtjO08oVkhRrFGGgLufL2JeOBn5pUZQrp6TqyCLoQ4f/yrmu9tCeG8CtDg\n" +
 	"xi6Ye9LjvlchEHhUKhAHc8uL+ablHzWxHTeuhnuThrsLFUcJQWb10U27LiXp3XCW\n" +
@@ -77,7 +77,7 @@ var CA_KEY_PEM = "-----BEGIN RSA PRIVATE KEY-----\n" +
 	"huu1W6p9RdxJHgphzmGAvTrOmrDAZeKtubsMS69VZVFjQFa1ZD/VMzWK1X2o\n" +
 	"-----END RSA PRIVATE KEY-----"
 
-var CA_CERT_PEM = "-----BEGIN CERTIFICATE-----\n" +
+var CAcertPEM = "-----BEGIN CERTIFICATE-----\n" +
 	"MIIFxDCCA6ygAwIBAgIJALe2d/gZHJqAMA0GCSqGSIb3DQEBCwUAMDExCzAJBgNV\n" +
 	"BAYTAlVTMRAwDgYDVQQKDAdUZXN0IENBMRAwDgYDVQQDDAdUZXN0IENBMB4XDTE1\n" +
 	"MDIxMzAwMzI0NFoXDTI1MDIxMDAwMzI0NFowMTELMAkGA1UEBhMCVVMxEDAOBgNV\n" +
@@ -115,7 +115,7 @@ var CA_CERT_PEM = "-----BEGIN CERTIFICATE-----\n" +
 // * Random public key
 // * CN = not-example.com
 // * DNSNames = not-example.com, www.not-example.com
-var CN_AND_SAN_CSR_HEX = "308202a130820189020100301a311830160603550403130f6e6f742d6578" +
+var CNandSANCSRhex = "308202a130820189020100301a311830160603550403130f6e6f742d6578" +
 	"616d706c652e636f6d30820122300d06092a864886f70d01010105000382" +
 	"010f003082010a0282010100e56ccbe37003c150202e6f543f9eb1d0e590" +
 	"76ac7f1f62654fa82fe131a23c66bd53a2f62ff7852015c84a394e36836d" +
@@ -143,7 +143,7 @@ var CN_AND_SAN_CSR_HEX = "308202a130820189020100301a311830160603550403130f6e6f74
 // * Random public key
 // * CN = not-example.com
 // * DNSNames = [none]
-var NO_SAN_CSR_HEX = "3082025f30820147020100301a311830160603550403130f6e6f742d6578" +
+var NoSANCSRhex = "3082025f30820147020100301a311830160603550403130f6e6f742d6578" +
 	"616d706c652e636f6d30820122300d06092a864886f70d01010105000382" +
 	"010f003082010a0282010100aa6e56ff24906f93b855e7871dc8411a3cf7" +
 	"678d9563627e8ca37ab17dfe814ef7f828d6aa92b717f0da9df56990b953" +
@@ -170,7 +170,7 @@ var NO_SAN_CSR_HEX = "3082025f30820147020100301a311830160603550403130f6e6f742d65
 // * C = US
 // * CN = [none]
 // * DNSNames = not-example.com
-var NO_CN_CSR_HEX = "3082027f30820167020100300d310b300906035504061302555330820122" +
+var NoCNCSRhex = "3082027f30820167020100300d310b300906035504061302555330820122" +
 	"300d06092a864886f70d01010105000382010f003082010a0282010100d8" +
 	"b3c11610ce17614f6d78de3f079db430e479c38978da8cd625b7c70dd445" +
 	"57fd99b9831693e6b9b09fb7c74a82058a1f1a4e1e087f04f93aa73bc35a" +
@@ -198,7 +198,7 @@ var NO_CN_CSR_HEX = "3082027f30820167020100300d310b30090603550406130255533082012
 // * C = US
 // * CN = [none]
 // * DNSNames = [none]
-var NO_NAME_CSR_HEX = "308202523082013a020100300d310b300906035504061302555330820122" +
+var NoNameCSRhex = "308202523082013a020100300d310b300906035504061302555330820122" +
 	"300d06092a864886f70d01010105000382010f003082010a0282010100bc" +
 	"fae49f68f02c42500b2faf251628ee19e8ef048a35fef311c9c419c80606" +
 	"ab37340ad6e25cf4cc63c0283994b4ba705d86950ad5298094e0b9684647" +
@@ -223,7 +223,7 @@ var NO_NAME_CSR_HEX = "308202523082013a020100300d310b300906035504061302555330820
 // * Random public key
 // * CN = [none]
 // * DNSNames = a.example.com, a.example.com
-var DUPE_NAME_CSR_HEX = "308202943082017c020100300d310b300906035504061302555330820122" +
+var DupeNameCSRhex = "308202943082017c020100300d310b300906035504061302555330820122" +
 	"300d06092a864886f70d01010105000382010f003082010a0282010100ee" +
 	"7d298c2a8237dd84e75e71dcfbbf8e1124327b103b01f3a99bc76b29be64" +
 	"55329dc523ad1372ed12853dc74a775f2c79d1e4e28ae2a3ce69b78ec161" +
@@ -251,7 +251,7 @@ var DUPE_NAME_CSR_HEX = "308202943082017c020100300d310b3009060355040613025553308
 // * Random pulic key
 // * CN = [none]
 // * DNSNames = not-example.com, www.not-example.com, mail.example.com
-var TOO_MANY_NAME_CSR_HEX = "308202aa30820192020100300d310b300906035504061302555330820122" +
+var TooManyNameCSRhex = "308202aa30820192020100300d310b300906035504061302555330820122" +
 	"300d06092a864886f70d01010105000382010f003082010a0282010100a7" +
 	"75d8f833651d9a4cfa1fa0e134912b772366c7d070ca3183d3c79ffc99bb" +
 	"c706d328c2389b360b99f60e9a447023a019931d410b4cea0eafb7869a6d" +
@@ -362,7 +362,7 @@ func TestRevoke(t *testing.T) {
 	ca.SA = storageAuthority
 	ca.MaxKeySize = 4096
 
-	csrDER, _ := hex.DecodeString(CN_AND_SAN_CSR_HEX)
+	csrDER, _ := hex.DecodeString(CNandSANCSRhex)
 	csr, _ := x509.ParseCertificateRequest(csrDER)
 	certObj, err := ca.IssueCertificate(*csr, 1, FarFuture)
 	test.AssertNotError(t, err, "Failed to sign certificate")
@@ -399,7 +399,7 @@ func TestIssueCertificate(t *testing.T) {
 			}
 	*/
 
-	csrs := []string{CN_AND_SAN_CSR_HEX, NO_SAN_CSR_HEX, NO_CN_CSR_HEX}
+	csrs := []string{CNandSANCSRhex, NoSANCSRhex, NoCNCSRhex}
 	for _, csrHEX := range csrs {
 		csrDER, _ := hex.DecodeString(csrHEX)
 		csr, _ := x509.ParseCertificateRequest(csrDER)
@@ -467,7 +467,7 @@ func TestRejectNoName(t *testing.T) {
 	ca.MaxKeySize = 4096
 
 	// Test that the CA rejects CSRs with no names
-	csrDER, _ := hex.DecodeString(NO_NAME_CSR_HEX)
+	csrDER, _ := hex.DecodeString(NoNameCSRhex)
 	csr, _ := x509.ParseCertificateRequest(csrDER)
 	_, err = ca.IssueCertificate(*csr, 1, FarFuture)
 	if err == nil {
@@ -482,7 +482,7 @@ func TestRejectTooManyNames(t *testing.T) {
 	ca.SA = storageAuthority
 
 	// Test that the CA rejects a CSR with too many names
-	csrDER, _ := hex.DecodeString(TOO_MANY_NAME_CSR_HEX)
+	csrDER, _ := hex.DecodeString(TooManyNameCSRhex)
 	csr, _ := x509.ParseCertificateRequest(csrDER)
 	_, err = ca.IssueCertificate(*csr, 1, FarFuture)
 	test.Assert(t, err != nil, "Issued certificate with too many names")
@@ -496,7 +496,7 @@ func TestDeduplication(t *testing.T) {
 	ca.MaxKeySize = 4096
 
 	// Test that the CA collapses duplicate names
-	csrDER, _ := hex.DecodeString(DUPE_NAME_CSR_HEX)
+	csrDER, _ := hex.DecodeString(DupeNameCSRhex)
 	csr, _ := x509.ParseCertificateRequest(csrDER)
 	cert, err := ca.IssueCertificate(*csr, 1, FarFuture)
 	test.AssertNotError(t, err, "Failed to gracefully handle a CSR with duplicate names")
@@ -525,13 +525,13 @@ func TestRejectValidityTooLong(t *testing.T) {
 	ca.MaxKeySize = 4096
 
 	// Test that the CA rejects CSRs that would expire after the intermediate cert
-	csrDER, _ := hex.DecodeString(NO_CN_CSR_HEX)
+	csrDER, _ := hex.DecodeString(NoCNCSRhex)
 	csr, _ := x509.ParseCertificateRequest(csrDER)
 	_, err = ca.IssueCertificate(*csr, 1, FarPast)
 	test.Assert(t, err == nil, "Can issue a certificate that expires after the underlying authorization.")
 
 	// Test that the CA rejects CSRs that would expire after the intermediate cert
-	csrDER, _ = hex.DecodeString(NO_CN_CSR_HEX)
+	csrDER, _ = hex.DecodeString(NoCNCSRhex)
 	csr, _ = x509.ParseCertificateRequest(csrDER)
 	ca.NotAfter = time.Now()
 	_, err = ca.IssueCertificate(*csr, 1, FarFuture)

--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -22,6 +22,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
+// Constants for AMQP
 const (
 	QueueName        = "Monitor"
 	AmqpExchange     = "boulder"
@@ -37,17 +38,17 @@ const (
 	AmqpImmediate    = false
 )
 
-var openCalls int64 = 0
+var openCalls int64
 
 func timeDelivery(d amqp.Delivery, stats statsd.Statter, deliveryTimings map[string]time.Time) {
 	// If d is a call add to deliveryTimings and increment openCalls, if it is a
 	// response then get time.Since original call from deliveryTiming, send timing metric, and
 	// decrement openCalls, in both cases send the gauges RpcCallsOpen and RpcBodySize
 	if d.ReplyTo != "" {
-		openCalls += 1
+		openCalls++
 		deliveryTimings[fmt.Sprintf("%s:%s", d.CorrelationId, d.ReplyTo)] = time.Now()
 	} else {
-		openCalls -= 1
+		openCalls--
 		rpcSent := deliveryTimings[fmt.Sprintf("%s:%s", d.CorrelationId, d.RoutingKey)]
 		if rpcSent != *new(time.Time) {
 			respTime := time.Since(rpcSent)

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -31,7 +31,7 @@ import (
 	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
 
-var reasons map[int]string = map[int]string{
+var reasons = map[int]string{
 	0: "unspecified",
 	1: "keyCompromise",
 	2: "cACompromise",
@@ -69,7 +69,7 @@ func setupContext(context *cli.Context) (rpc.CertificateAuthorityClient, *blog.A
 
 	ch := cmd.AmqpChannel(c.AMQP.Server)
 
-	caRPC, err := rpc.NewAmqpRPCCLient("revoker->CA", c.AMQP.CA.Server, ch)
+	caRPC, err := rpc.NewAmqpRPCClient("revoker->CA", c.AMQP.CA.Server, ch)
 	cmd.FailOnError(err, "Unable to create RPC client")
 
 	cac, err := rpc.NewCertificateAuthorityClient(caRPC)
@@ -147,7 +147,7 @@ func revokeByReg(regID int, reasonCode int, deny bool, cac rpc.CertificateAuthor
 	return
 }
 
-var version string = "0.0.1"
+var version = "0.0.1"
 
 func main() {
 	app := cli.NewApp()
@@ -231,7 +231,7 @@ func main() {
 			Usage: "List all revocation reason codes",
 			Action: func(c *cli.Context) {
 				var codes []int
-				for k, _ := range reasons {
+				for k := range reasons {
 					codes = append(codes, k)
 				}
 				sort.Ints(codes)

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -48,7 +48,7 @@ func main() {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-			saRPC, err := rpc.NewAmqpRPCCLient("CA->SA", c.AMQP.SA.Server, ch)
+			saRPC, err := rpc.NewAmqpRPCClient("CA->SA", c.AMQP.SA.Server, ch)
 			cmd.FailOnError(err, "Unable to create RPC client")
 
 			sac, err := rpc.NewStorageAuthorityClient(saRPC)

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -41,13 +41,13 @@ func main() {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-			vaRPC, err := rpc.NewAmqpRPCCLient("RA->VA", c.AMQP.VA.Server, ch)
+			vaRPC, err := rpc.NewAmqpRPCClient("RA->VA", c.AMQP.VA.Server, ch)
 			cmd.FailOnError(err, "Unable to create RPC client")
 
-			caRPC, err := rpc.NewAmqpRPCCLient("RA->CA", c.AMQP.CA.Server, ch)
+			caRPC, err := rpc.NewAmqpRPCClient("RA->CA", c.AMQP.CA.Server, ch)
 			cmd.FailOnError(err, "Unable to create RPC client")
 
-			saRPC, err := rpc.NewAmqpRPCCLient("RA->SA", c.AMQP.SA.Server, ch)
+			saRPC, err := rpc.NewAmqpRPCClient("RA->SA", c.AMQP.SA.Server, ch)
 			cmd.FailOnError(err, "Unable to create RPC client")
 
 			vac, err := rpc.NewValidationAuthorityClient(vaRPC)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -44,7 +44,7 @@ func main() {
 			ch := cmd.AmqpChannel(c.AMQP.Server)
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-			raRPC, err := rpc.NewAmqpRPCCLient("VA->RA", c.AMQP.RA.Server, ch)
+			raRPC, err := rpc.NewAmqpRPCClient("VA->RA", c.AMQP.RA.Server, ch)
 			cmd.FailOnError(err, "Unable to create RPC client")
 
 			rac, err := rpc.NewRegistrationAuthorityClient(raRPC)

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -28,17 +28,18 @@ type timedHandler struct {
 	stats statsd.Statter
 }
 
-var openConnections int64 = 0
+var openConnections int64
 
+// HandlerTimer monitors HTTP performance and sends the details to StatsD.
 func HandlerTimer(handler http.Handler, stats statsd.Statter) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cStart := time.Now()
-		openConnections += 1
+		openConnections++
 		stats.Gauge("HttpConnectionsOpen", openConnections, 1.0)
 
 		handler.ServeHTTP(w, r)
 
-		openConnections -= 1
+		openConnections--
 		stats.Gauge("HttpConnectionsOpen", openConnections, 1.0)
 
 		// (FIX: this doesn't seem to really work at catching errors...)

--- a/cmd/mkcrl/main.go
+++ b/cmd/mkcrl/main.go
@@ -22,6 +22,7 @@ var pin = flag.String("pkcs11-pin", "", "PKCS#11 password")
 var token = flag.String("pkcs11-token", "", "PKCS#11 token name")
 var label = flag.String("pkcs11-label", "", "PKCS#11 key label")
 
+// Config defines the configuration loaded from listFile.
 type Config struct {
 	ThisUpdate   time.Time
 	NextUpdate   time.Time

--- a/cmd/mkroot/main.go
+++ b/cmd/mkroot/main.go
@@ -23,6 +23,7 @@ var pin = flag.String("pkcs11-pin", "", "PKCS#11 password")
 var token = flag.String("pkcs11-token", "", "PKCS#11 token name")
 var label = flag.String("pkcs11-label", "", "PKCS#11 key label")
 
+// Config defines the configuration loaded from configFile.
 type Config struct {
 	Name struct {
 		C  string

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -30,7 +30,7 @@ func setupClients(c cmd.Config) (rpc.CertificateAuthorityClient, chan *amqp.Erro
 	ch := cmd.AmqpChannel(c.AMQP.Server)
 	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
-	caRPC, err := rpc.NewAmqpRPCCLient("OCSP->CA", c.AMQP.CA.Server, ch)
+	caRPC, err := rpc.NewAmqpRPCClient("OCSP->CA", c.AMQP.CA.Server, ch)
 	cmd.FailOnError(err, "Unable to create RPC client")
 
 	cac, err := rpc.NewCertificateAuthorityClient(caRPC)
@@ -127,10 +127,10 @@ func findStaleResponses(cac rpc.CertificateAuthorityClient, dbMap *gorp.DbMap, o
 				log.Err(fmt.Sprintf("Could not process OCSP Response for %s: %s", status.Serial, err))
 				tx.Rollback()
 				return err
-			} else {
-				log.Info(fmt.Sprintf("OCSP %d: %s OK", i, status.Serial))
-				tx.Commit()
 			}
+
+			log.Info(fmt.Sprintf("OCSP %d: %s OK", i, status.Serial))
+			tx.Commit()
 		}
 	}
 

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -227,6 +227,7 @@ func RunUntilSignaled(logger *blog.AuditLogger, server *rpc.AmqpRPCServer, close
 	logger.Warning("Reconnecting to AMQP...")
 }
 
+// ProfileCmd runs forever, sending Go statistics to StatsD.
 func ProfileCmd(profileName string, stats statsd.Statter) {
 	for {
 		var memoryStats runtime.MemStats
@@ -248,6 +249,8 @@ func ProfileCmd(profileName string, stats statsd.Statter) {
 	}
 }
 
+// LoadCert loads a PEM-formatted certificate from the provided path, returning
+// it as a byte array, or an error if it couldn't be decoded.
 func LoadCert(path string) (cert []byte, err error) {
 	if path == "" {
 		err = errors.New("Issuer certificate was not provided in config.")

--- a/core/challenges.go
+++ b/core/challenges.go
@@ -11,6 +11,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
+// SimpleHTTPChallenge constructs a random HTTP challenge
 func SimpleHTTPChallenge() Challenge {
 	tls := true
 	return Challenge{
@@ -21,6 +22,7 @@ func SimpleHTTPChallenge() Challenge {
 	}
 }
 
+// DvsniChallenge constructs a random DVSNI challenge
 func DvsniChallenge() Challenge {
 	nonce := make([]byte, 16)
 	_, err := rand.Read(nonce)
@@ -39,6 +41,7 @@ func DvsniChallenge() Challenge {
 	}
 }
 
+// DNSChallenge constructs a random DNS challenge
 func DNSChallenge() Challenge {
 	return Challenge{
 		Type:   ChallengeTypeDNS,

--- a/core/dns.go
+++ b/core/dns.go
@@ -41,16 +41,16 @@ func NewDNSResolver(dialTimeout time.Duration, servers []string) *DNSResolver {
 
 // ExchangeOne performs a single DNS exchange with a randomly chosen server
 // out of the server list, returning the response, time, and error (if any)
-func (r *DNSResolver) ExchangeOne(m *dns.Msg) (rsp *dns.Msg, rtt time.Duration, err error) {
-	if len(r.Servers) < 1 {
+func (dnsResolver *DNSResolver) ExchangeOne(m *dns.Msg) (rsp *dns.Msg, rtt time.Duration, err error) {
+	if len(dnsResolver.Servers) < 1 {
 		err = fmt.Errorf("Not configured with at least one DNS Server")
 		return
 	}
 
 	// Randomly pick a server
-	chosenServer := r.Servers[rand.Intn(len(r.Servers))]
+	chosenServer := dnsResolver.Servers[rand.Intn(len(dnsResolver.Servers))]
 
-	return r.DNSClient.Exchange(m, chosenServer)
+	return dnsResolver.DNSClient.Exchange(m, chosenServer)
 }
 
 // LookupDNSSEC sends the provided DNS message to a randomly chosen server (see

--- a/core/good_key.go
+++ b/core/good_key.go
@@ -60,6 +60,7 @@ func GoodKey(key crypto.PublicKey, maxKeySize int) error {
 	}
 }
 
+// GoodKeyECDSA determines if an ECDSA pubkey meets our requirements
 func GoodKeyECDSA(key ecdsa.PublicKey, maxKeySize int) (err error) {
 	log := blog.GetAuditLogger()
 	err = fmt.Errorf("ECDSA keys not yet supported")
@@ -67,6 +68,7 @@ func GoodKeyECDSA(key ecdsa.PublicKey, maxKeySize int) (err error) {
 	return
 }
 
+// GoodKeyRSA determines if a RSA pubkey meets our requirements
 func GoodKeyRSA(key rsa.PublicKey, maxKeySize int) (err error) {
 	log := blog.GetAuditLogger()
 	// Baseline Requirements Appendix A

--- a/core/good_key_test.go
+++ b/core/good_key_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-var maxKeySize int = 2048
+var maxKeySize = 2048
 
 func TestUnknownKeyType(t *testing.T) {
 	notAKey := struct{}{}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -51,6 +51,7 @@ type WebFrontEnd interface {
 	Cert(response http.ResponseWriter, request *http.Request)
 }
 
+// RegistrationAuthority defines the public interface for the Boulder RA
 type RegistrationAuthority interface {
 	// [WebFrontEnd]
 	NewRegistration(Registration) (Registration, error)
@@ -74,12 +75,14 @@ type RegistrationAuthority interface {
 	OnValidationUpdate(Authorization) error
 }
 
+// ValidationAuthority defines the public interface for the Boulder VA
 type ValidationAuthority interface {
 	// [RegistrationAuthority]
 	UpdateValidations(Authorization, int) error
 	CheckCAARecords(AcmeIdentifier) (bool, bool, error)
 }
 
+// CertificateAuthority defines the public interface for the Boulder CA
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
 	IssueCertificate(x509.CertificateRequest, int64, time.Time) (Certificate, error)
@@ -87,11 +90,13 @@ type CertificateAuthority interface {
 	GenerateOCSP(OCSPSigningRequest) ([]byte, error)
 }
 
+// PolicyAuthority defines the public interface for the Boulder PA
 type PolicyAuthority interface {
 	WillingToIssue(AcmeIdentifier) error
 	ChallengesFor(AcmeIdentifier) ([]Challenge, [][]int)
 }
 
+// StorageGetter are the Boulder SA's read-only methods
 type StorageGetter interface {
 	GetRegistration(int64) (Registration, error)
 	GetRegistrationByKey(jose.JsonWebKey) (Registration, error)
@@ -102,6 +107,7 @@ type StorageGetter interface {
 	AlreadyDeniedCSR([]string) (bool, error)
 }
 
+// StorageAdder are the Boulder SA's write/update methods
 type StorageAdder interface {
 	NewRegistration(Registration) (Registration, error)
 	UpdateRegistration(Registration) error

--- a/core/nonce.go
+++ b/core/nonce.go
@@ -2,6 +2,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package core
 
 import (
@@ -11,8 +12,11 @@ import (
 	"math/big"
 )
 
+// MaxUsed defines the maximum number of Nonces we're willing to hold in
+// memory.
 const MaxUsed = 65536
 
+// NonceService generates, cancels, and tracks Nonces.
 type NonceService struct {
 	latest   int64
 	earliest int64
@@ -21,6 +25,7 @@ type NonceService struct {
 	maxUsed  int
 }
 
+// NewNonceService constructs a NonceService with defaults
 func NewNonceService() NonceService {
 	// XXX ignoring possible error due to entropy starvation
 	key := make([]byte, 16)
@@ -44,7 +49,7 @@ func (ns NonceService) encrypt(counter int64) string {
 	// Generate a nonce with upper 4 bytes zero
 	// XXX ignoring possible error due to entropy starvation
 	nonce := make([]byte, 12)
-	for i := 0; i < 4; i += 1 {
+	for i := 0; i < 4; i++ {
 		nonce[i] = 0
 	}
 	rand.Read(nonce[4:])
@@ -70,7 +75,7 @@ func (ns NonceService) decrypt(nonce string) (int64, error) {
 	}
 
 	n := make([]byte, 12)
-	for i := 0; i < 4; i += 1 {
+	for i := 0; i < 4; i++ {
 		n[i] = 0
 	}
 	copy(n[4:], decoded[:8])
@@ -85,8 +90,9 @@ func (ns NonceService) decrypt(nonce string) (int64, error) {
 	return ctr.Int64(), nil
 }
 
+// Nonce provides a new Nonce.
 func (ns *NonceService) Nonce() string {
-	ns.latest += 1
+	ns.latest++
 	return ns.encrypt(ns.latest)
 }
 
@@ -100,6 +106,8 @@ func (ns *NonceService) minUsed() int64 {
 	return min
 }
 
+// Valid determines whether the provided Nonce string is valid, returning
+// true if so.
 func (ns *NonceService) Valid(nonce string) bool {
 	c, err := ns.decrypt(nonce)
 	if err != nil {

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestRegistrationUupdate(t *testing.T) {
+func TestRegistrationUpdate(t *testing.T) {
 	oldURL, _ := url.Parse("http://old.invalid")
 	newURL, _ := url.Parse("http://new.invalid")
 
@@ -102,9 +102,9 @@ func TestSanityCheck(t *testing.T) {
 	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
 }
 
-func TestJsonBufferUnmarshal(t *testing.T) {
+func TestJSONBufferUnmarshal(t *testing.T) {
 	testStruct := struct {
-		Buffer JsonBuffer
+		Buffer JSONBuffer
 	}{}
 
 	notValidBase64 := []byte(`{"Buffer":"!!!!"}`)

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -51,13 +51,13 @@ func TestBuildID(t *testing.T) {
 	test.AssertEquals(t, "Unspecified", GetBuildID())
 }
 
-const JWK_1_JSON = `{
+const JWK1JSON = `{
   "kty": "RSA",
   "n": "vuc785P8lBj3fUxyZchF_uZw6WtbxcorqgTyq-qapF5lrO1U82Tp93rpXlmctj6fyFHBVVB5aXnUHJ7LZeVPod7Wnfl8p5OyhlHQHC8BnzdzCqCMKmWZNX5DtETDId0qzU7dPzh0LP0idt5buU7L9QNaabChw3nnaL47iu_1Di5Wp264p2TwACeedv2hfRDjDlJmaQXuS8Rtv9GnRWyC9JBu7XmGvGDziumnJH7Hyzh3VNu-kSPQD3vuAFgMZS6uUzOztCkT0fpOalZI6hqxtWLvXUMj-crXrn-Maavz8qRhpAyp5kcYk3jiHGgQIi7QSK2JIdRJ8APyX9HlmTN5AQ",
   "e": "AAEAAQ"
 }`
-const JWK_1_DIGEST = `ul04Iq07ulKnnrebv2hv3yxCGgVvoHs8hjq2tVKx3mc=`
-const JWK_2_JSON = `{
+const JWK1Digest = `ul04Iq07ulKnnrebv2hv3yxCGgVvoHs8hjq2tVKx3mc=`
+const JWK2JSON = `{
   "kty":"RSA",
   "n":"yTsLkI8n4lg9UuSKNRC0UPHsVjNdCYk8rGXIqeb_rRYaEev3D9-kxXY8HrYfGkVt5CiIVJ-n2t50BKT8oBEMuilmypSQqJw0pCgtUm-e6Z0Eg3Ly6DMXFlycyikegiZ0b-rVX7i5OCEZRDkENAYwFNX4G7NNCwEZcH7HUMUmty9dchAqDS9YWzPh_dde1A9oy9JMH07nRGDcOzIh1rCPwc71nwfPPYeeS4tTvkjanjeigOYBFkBLQuv7iBB4LPozsGF1XdoKiIIi-8ye44McdhOTPDcQp3xKxj89aO02pQhBECv61rmbPinvjMG9DYxJmZvjsKF4bN2oy0DxdC1jDw",
   "e":"AAEAAQ"
@@ -66,13 +66,13 @@ const JWK_2_JSON = `{
 func TestKeyDigest(t *testing.T) {
 	// Test with JWK (value, reference, and direct)
 	var jwk jose.JsonWebKey
-	json.Unmarshal([]byte(JWK_1_JSON), &jwk)
+	json.Unmarshal([]byte(JWK1JSON), &jwk)
 	digest, err := KeyDigest(jwk)
-	test.Assert(t, err == nil && digest == JWK_1_DIGEST, "Failed to digest JWK by value")
+	test.Assert(t, err == nil && digest == JWK1Digest, "Failed to digest JWK by value")
 	digest, err = KeyDigest(&jwk)
-	test.Assert(t, err == nil && digest == JWK_1_DIGEST, "Failed to digest JWK by reference")
+	test.Assert(t, err == nil && digest == JWK1Digest, "Failed to digest JWK by reference")
 	digest, err = KeyDigest(jwk.Key)
-	test.Assert(t, err == nil && digest == JWK_1_DIGEST, "Failed to digest bare key")
+	test.Assert(t, err == nil && digest == JWK1Digest, "Failed to digest bare key")
 
 	// Test with unknown key type
 	digest, err = KeyDigest(struct{}{})
@@ -81,8 +81,8 @@ func TestKeyDigest(t *testing.T) {
 
 func TestKeyDigestEquals(t *testing.T) {
 	var jwk1, jwk2 jose.JsonWebKey
-	json.Unmarshal([]byte(JWK_1_JSON), &jwk1)
-	json.Unmarshal([]byte(JWK_2_JSON), &jwk2)
+	json.Unmarshal([]byte(JWK1JSON), &jwk1)
+	json.Unmarshal([]byte(JWK2JSON), &jwk2)
 
 	test.Assert(t, KeyDigestEquals(jwk1, jwk1), "Key digests for same key should match")
 	test.Assert(t, !KeyDigestEquals(jwk1, jwk2), "Key digests for different keys should not match")

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -9,6 +9,7 @@ import (
 	"net/smtp"
 )
 
+// Mailer defines a mail transfer agent to use for sending mail
 type Mailer struct {
 	Server string
 	Port   string
@@ -16,6 +17,8 @@ type Mailer struct {
 	From   string
 }
 
+// NewMailer constructs a Mailer to represent an account at a particular mail
+// transfer agent.
 func NewMailer(server, port, username, password string) Mailer {
 	auth := smtp.PlainAuth("", username, password, server)
 	return Mailer{
@@ -26,6 +29,8 @@ func NewMailer(server, port, username, password string) Mailer {
 	}
 }
 
+// SendMail sends an email to the provided list of recipients. The email body
+// is simple text.
 func (m *Mailer) SendMail(to []string, msg string) (err error) {
 	err = smtp.SendMail(m.Server+":"+m.Port, m.Auth, m.From, to, []byte(msg))
 	return

--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -6,7 +6,6 @@
 package policy
 
 import (
-	"errors"
 	"net"
 	"regexp"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
+// PolicyAuthorityImpl enforces CA policy decisions.
 type PolicyAuthorityImpl struct {
 	log *blog.AuditLogger
 
@@ -22,6 +22,7 @@ type PolicyAuthorityImpl struct {
 	Blacklist        map[string]bool // A blacklist of denied names
 }
 
+// NewPolicyAuthorityImpl constructs a Policy Authority.
 func NewPolicyAuthorityImpl() *PolicyAuthorityImpl {
 	logger := blog.GetAuditLogger()
 	logger.Notice("Policy Authority Starting")
@@ -52,7 +53,7 @@ func isDNSCharacter(ch byte) bool {
 // set, then the name is required to not be in the suffix set (i.e., it must
 // have at least one label beyond any suffix in the set).
 func suffixMatch(labels []string, suffixSet map[string]bool, properSuffix bool) bool {
-	for i, _ := range labels {
+	for i := range labels {
 		if domain := strings.Join(labels[i:], "."); suffixSet[domain] {
 			// If we match on the whole domain, gate on properSuffix
 			return !properSuffix || (i > 0)
@@ -61,11 +62,28 @@ func suffixMatch(labels []string, suffixSet map[string]bool, properSuffix bool) 
 	return false
 }
 
-var InvalidIdentifierError = errors.New("Invalid identifier type")
-var SyntaxError = errors.New("Syntax error")
-var NonPublicError = errors.New("Name does not end in a public suffix")
-var BlacklistedError = errors.New("Name is blacklisted")
+// InvalidIdentifierError indicates that we didn't understand the IdentifierType
+// provided.
+type InvalidIdentifierError struct{}
 
+// SyntaxError indicates that the user input was not well formatted.
+type SyntaxError struct{}
+
+// NonPublicError indicates that one or more identifiers were not on the public
+// Internet.
+type NonPublicError struct{}
+
+// BlacklistedError indicates we have blacklisted one or more of these identifiers.
+type BlacklistedError struct{}
+
+func (e InvalidIdentifierError) Error() string { return "Invalid identifier type" }
+func (e SyntaxError) Error() string            { return "Syntax error" }
+func (e NonPublicError) Error() string         { return "Name does not end in a public suffix" }
+func (e BlacklistedError) Error() string       { return "Name is blacklisted" }
+
+// WillingToIssue determines whether the CA is willing to issue for the provided
+// identifier.
+//
 // We place several criteria on identifiers we are willing to issue for:
 //
 //  * MUST self-identify as DNS identifiers
@@ -88,59 +106,62 @@ var BlacklistedError = errors.New("Name is blacklisted")
 // XXX: We should probably fold everything to lower-case somehow.
 func (pa PolicyAuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 	if id.Type != core.IdentifierDNS {
-		return InvalidIdentifierError
+		return InvalidIdentifierError{}
 	}
 	domain := id.Value
 
 	for _, ch := range []byte(domain) {
 		if !isDNSCharacter(ch) {
-			return SyntaxError
+			return SyntaxError{}
 		}
 	}
 
 	domain = strings.ToLower(domain)
 	if len(domain) > 255 {
-		return SyntaxError
+		return SyntaxError{}
 	}
 
 	if ip := net.ParseIP(domain); ip != nil {
-		return SyntaxError
+		return SyntaxError{}
 	}
 
 	labels := strings.Split(domain, ".")
 	if len(labels) > maxLabels || len(labels) < 2 {
-		return SyntaxError
+		return SyntaxError{}
 	}
 	for _, label := range labels {
 		// DNS defines max label length as 63 characters. Some implementations allow
 		// more, but we will be conservative.
 		if len(label) < 1 || len(label) > 63 {
-			return SyntaxError
+			return SyntaxError{}
 		}
 
 		if !dnsLabelRegexp.MatchString(label) {
-			return SyntaxError
+			return SyntaxError{}
 		}
 
 		if punycodeRegexp.MatchString(label) {
-			return SyntaxError
+			return SyntaxError{}
 		}
 	}
 
 	// Require match to PSL, plus at least one label
 	if !suffixMatch(labels, pa.PublicSuffixList, true) {
-		return NonPublicError
+		return NonPublicError{}
 	}
 
 	// Require no match against blacklist
 	if suffixMatch(labels, pa.Blacklist, false) {
-		return BlacklistedError
+		return BlacklistedError{}
 	}
 
 	return nil
 }
 
-// For now, we just issue DVSNI and SimpleHTTP challenges for everything
+// ChallengesFor makes a decision of what challenges, and combinations, are
+// acceptable for the given identifier.
+//
+// Note: Current implementation is static, but future versions may not be.
 func (pa PolicyAuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, combinations [][]int) {
 	challenges = []core.Challenge{
 		core.SimpleHTTPChallenge(),

--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -92,14 +92,17 @@ func TestWillingToIssue(t *testing.T) {
 	// Test for invalid identifier type
 	identifier := core.AcmeIdentifier{Type: "ip", Value: "example.com"}
 	err := pa.WillingToIssue(identifier)
-	if err != InvalidIdentifierError {
+	_, ok := err.(InvalidIdentifierError)
+	if !ok {
 		t.Error("Identifier was not correctly forbidden: ", identifier)
 	}
 
 	// Test syntax errors
 	for _, domain := range shouldBeSyntaxError {
 		identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: domain}
-		if err := pa.WillingToIssue(identifier); err != SyntaxError {
+		err := pa.WillingToIssue(identifier)
+		_, ok := err.(SyntaxError)
+		if !ok {
 			t.Error("Identifier was not correctly forbidden: ", identifier, err)
 		}
 	}
@@ -107,7 +110,9 @@ func TestWillingToIssue(t *testing.T) {
 	// Test public suffix matching
 	for _, domain := range shouldBeNonPublic {
 		identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: domain}
-		if err := pa.WillingToIssue(identifier); err != NonPublicError {
+		err := pa.WillingToIssue(identifier)
+		_, ok := err.(NonPublicError)
+		if !ok {
 			t.Error("Identifier was not correctly forbidden: ", identifier, err)
 		}
 	}
@@ -115,7 +120,9 @@ func TestWillingToIssue(t *testing.T) {
 	// Test blacklisting
 	for _, domain := range shouldBeBlacklisted {
 		identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: domain}
-		if err := pa.WillingToIssue(identifier); err != BlacklistedError {
+		err := pa.WillingToIssue(identifier)
+		_, ok := err.(BlacklistedError)
+		if !ok {
 			t.Error("Identifier was not correctly forbidden: ", identifier, err)
 		}
 	}

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -154,9 +154,9 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 	va := &DummyValidationAuthority{}
 
 	// PEM files in certificate-authority_test.go
-	caKeyPEM, _ := pem.Decode([]byte(CA_KEY_PEM))
+	caKeyPEM, _ := pem.Decode([]byte(CAkeyPEM))
 	caKey, _ := x509.ParsePKCS1PrivateKey(caKeyPEM.Bytes)
-	caCertPEM, _ := pem.Decode([]byte(CA_CERT_PEM))
+	caCertPEM, _ := pem.Decode([]byte(CAcertPEM))
 	caCert, _ := x509.ParseCertificate(caCertPEM.Bytes)
 	basicPolicy := &cfsslConfig.Signing{
 		Default: &cfsslConfig.SigningProfile{
@@ -184,7 +184,7 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 		NotAfter:       time.Now().Add(time.Hour * 8761),
 		MaxKeySize:     4096,
 	}
-	csrDER, _ := hex.DecodeString(CSR_HEX)
+	csrDER, _ := hex.DecodeString(CSRhex)
 	ExampleCSR, _ = x509.ParseCertificateRequest(csrDER)
 
 	// This registration implicitly gets ID = 1
@@ -373,8 +373,8 @@ func TestUpdateAuthorization(t *testing.T) {
 
 	// Verify that the responses are reflected
 	test.Assert(t, len(va.Argument.Challenges) > 0, "Authz passed to VA has no challenges")
-	simpleHttp := va.Argument.Challenges[0]
-	test.Assert(t, simpleHttp.Path == Response.Path, "simpleHttp changed")
+	simpleHTTP := va.Argument.Challenges[0]
+	test.Assert(t, simpleHTTP.Path == Response.Path, "simpleHTTP changed")
 
 	t.Log("DONE TestUpdateAuthorization")
 }
@@ -503,7 +503,7 @@ func TestNewCertificate(t *testing.T) {
 	t.Log("DONE TestOnValidationUpdate")
 }
 
-var CA_KEY_PEM = "-----BEGIN RSA PRIVATE KEY-----\n" +
+var CAkeyPEM = "-----BEGIN RSA PRIVATE KEY-----\n" +
 	"MIIJKQIBAAKCAgEAqmM0dEf/J9MCk2ItzevL0dKJ84lVUtf/vQ7AXFi492vFXc3b\n" +
 	"PrJz2ybtjO08oVkhRrFGGgLufL2JeOBn5pUZQrp6TqyCLoQ4f/yrmu9tCeG8CtDg\n" +
 	"xi6Ye9LjvlchEHhUKhAHc8uL+ablHzWxHTeuhnuThrsLFUcJQWb10U27LiXp3XCW\n" +
@@ -555,7 +555,7 @@ var CA_KEY_PEM = "-----BEGIN RSA PRIVATE KEY-----\n" +
 	"huu1W6p9RdxJHgphzmGAvTrOmrDAZeKtubsMS69VZVFjQFa1ZD/VMzWK1X2o\n" +
 	"-----END RSA PRIVATE KEY-----"
 
-var CA_CERT_PEM = "-----BEGIN CERTIFICATE-----\n" +
+var CAcertPEM = "-----BEGIN CERTIFICATE-----\n" +
 	"MIIFxDCCA6ygAwIBAgIJALe2d/gZHJqAMA0GCSqGSIb3DQEBCwUAMDExCzAJBgNV\n" +
 	"BAYTAlVTMRAwDgYDVQQKDAdUZXN0IENBMRAwDgYDVQQDDAdUZXN0IENBMB4XDTE1\n" +
 	"MDIxMzAwMzI0NFoXDTI1MDIxMDAwMzI0NFowMTELMAkGA1UEBhMCVVMxEDAOBgNV\n" +
@@ -594,7 +594,7 @@ var CA_CERT_PEM = "-----BEGIN CERTIFICATE-----\n" +
 // * CN = not-example.com
 // * DNSNames = not-example.com, www.not-example.com
 /*
-var CSR_HEX = "3082028c30820174020100301a311830160603550403130f" +
+var CSRhex = "3082028c30820174020100301a311830160603550403130f" +
 	"6e6f742d6578616d706c652e636f6d30820122300d06092a" +
 	"864886f70d01010105000382010f003082010a0282010100" +
 	"aac67dd1e11fae980048b0ac91be005f21d9df8bb38461cc" +
@@ -624,7 +624,7 @@ var CSR_HEX = "3082028c30820174020100301a311830160603550403130f" +
 	"f277b6d23fa24f9b"
 */
 
-var CSR_HEX = "308202ae308201960201003027310b300906035504061302" +
+var CSRhex = "308202ae308201960201003027310b300906035504061302" +
 	"5553311830160603550403130f6e6f742d6578616d706c65" +
 	"2e636f6d30820122300d06092a864886f70d010101050003" +
 	"82010f003082010a0282010100a4f507b52ca2766e2cea7b" +

--- a/rpc/rpc-interfaces.go
+++ b/rpc/rpc-interfaces.go
@@ -14,7 +14,6 @@ type RPCClient interface {
 	SetTimeout(time.Duration)
 	Dispatch(string, []byte) chan []byte
 	DispatchSync(string, []byte) ([]byte, error)
-	SyncDispatchWithTimeout(string, []byte, time.Duration) ([]byte, error)
 }
 
 // RPCServer describes the functions an RPC Server performs

--- a/rpc/rpc-wrappers_test.go
+++ b/rpc/rpc-wrappers_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-const JWK_1_JSON = `{
+const JWK1JSON = `{
   "kty": "RSA",
   "n": "vuc785P8lBj3fUxyZchF_uZw6WtbxcorqgTyq-qapF5lrO1U82Tp93rpXlmctj6fyFHBVVB5aXnUHJ7LZeVPod7Wnfl8p5OyhlHQHC8BnzdzCqCMKmWZNX5DtETDId0qzU7dPzh0LP0idt5buU7L9QNaabChw3nnaL47iu_1Di5Wp264p2TwACeedv2hfRDjDlJmaQXuS8Rtv9GnRWyC9JBu7XmGvGDziumnJH7Hyzh3VNu-kSPQD3vuAFgMZS6uUzOztCkT0fpOalZI6hqxtWLvXUMj-crXrn-Maavz8qRhpAyp5kcYk3jiHGgQIi7QSK2JIdRJ8APyX9HlmTN5AQ",
   "e": "AAEAAQ"
@@ -59,12 +59,6 @@ func (rpc *MockRPCClient) DispatchSync(method string, body []byte) (response []b
 	return
 }
 
-func (rpc *MockRPCClient) SyncDispatchWithTimeout(method string, body []byte, ttl time.Duration) (response []byte, err error) {
-	rpc.LastMethod = method
-	rpc.LastBody = body
-	return body, nil
-}
-
 func TestRANewRegistration(t *testing.T) {
 	mock := &MockRPCClient{}
 	client, err := NewRegistrationAuthorityClient(mock)
@@ -72,7 +66,7 @@ func TestRANewRegistration(t *testing.T) {
 	test.AssertNotNil(t, client, "Client construction")
 
 	var jwk jose.JsonWebKey
-	json.Unmarshal([]byte(JWK_1_JSON), &jwk)
+	json.Unmarshal([]byte(JWK1JSON), &jwk)
 
 	reg := core.Registration{
 		ID:            1,

--- a/sa/database.go
+++ b/sa/database.go
@@ -19,7 +19,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-var dialectMap map[string]interface{} = map[string]interface{}{
+var dialectMap = map[string]interface{}{
 	"sqlite3":  gorp.SqliteDialect{},
 	"mysql":    gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8"},
 	"postgres": gorp.PostgresDialect{},

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -34,7 +34,7 @@ func initSA(t *testing.T) *SQLStorageAuthority {
 	return sa
 }
 
-var theKey string = `{
+var theKey = `{
     "kty": "RSA",
     "n": "n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw",
     "e": "AQAB"

--- a/sa/type-converter.go
+++ b/sa/type-converter.go
@@ -38,7 +38,7 @@ func (tc BoulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
 		return string(t), nil
 	case core.OCSPStatus:
 		return string(t), nil
-	case core.JsonBuffer:
+	case core.JSONBuffer:
 		return []byte(t), nil
 	default:
 		return val, nil
@@ -48,7 +48,7 @@ func (tc BoulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
 // FromDb converts a DB representation back into a Boulder object.
 func (tc BoulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, bool) {
 	switch target.(type) {
-	case *core.AcmeIdentifier, *[]core.Challenge, *[]core.AcmeURL, *[][]int, core.JsonBuffer:
+	case *core.AcmeIdentifier, *[]core.Challenge, *[]core.AcmeURL, *[][]int, core.JSONBuffer:
 		binder := func(holder, target interface{}) error {
 			s, ok := holder.(*string)
 			if !ok {

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -15,7 +15,7 @@ import (
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 )
 
-const JWK_1_JSON = `{
+const JWK1JSON = `{
   "kty": "RSA",
   "n": "vuc785P8lBj3fUxyZchF_uZw6WtbxcorqgTyq-qapF5lrO1U82Tp93rpXlmctj6fyFHBVVB5aXnUHJ7LZeVPod7Wnfl8p5OyhlHQHC8BnzdzCqCMKmWZNX5DtETDId0qzU7dPzh0LP0idt5buU7L9QNaabChw3nnaL47iu_1Di5Wp264p2TwACeedv2hfRDjDlJmaQXuS8Rtv9GnRWyC9JBu7XmGvGDziumnJH7Hyzh3VNu-kSPQD3vuAFgMZS6uUzOztCkT0fpOalZI6hqxtWLvXUMj-crXrn-Maavz8qRhpAyp5kcYk3jiHGgQIi7QSK2JIdRJ8APyX9HlmTN5AQ",
   "e": "AAEAAQ"
@@ -46,7 +46,7 @@ func TestJsonWebKey(t *testing.T) {
 	tc := BoulderTypeConverter{}
 
 	var jwk, out jose.JsonWebKey
-	json.Unmarshal([]byte(JWK_1_JSON), &jwk)
+	json.Unmarshal([]byte(JWK1JSON), &jwk)
 
 	marshaledI, err := tc.ToDb(jwk)
 	test.AssertNotError(t, err, "Could not ToDb")

--- a/test/mocks.go
+++ b/test/mocks.go
@@ -8,15 +8,18 @@ package test
 import (
 	"database/sql"
 
+	// Load SQLite3 for test purposes
 	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
 
+// MockCADatabase is a mock
 type MockCADatabase struct {
 	db    *gorp.DbMap
 	count int64
 }
 
+// NewMockCertificateAuthorityDatabase is a mock
 func NewMockCertificateAuthorityDatabase() (mock *MockCADatabase, err error) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	dbmap := &gorp.DbMap{Db: db, Dialect: gorp.SqliteDialect{}}
@@ -24,15 +27,18 @@ func NewMockCertificateAuthorityDatabase() (mock *MockCADatabase, err error) {
 	return mock, err
 }
 
+// Begin is a mock
 func (cadb *MockCADatabase) Begin() (*gorp.Transaction, error) {
 	return cadb.db.Begin()
 }
 
+// IncrementAndGetSerial is a mock
 func (cadb *MockCADatabase) IncrementAndGetSerial(*gorp.Transaction) (int64, error) {
 	cadb.count = cadb.count + 1
 	return cadb.count, nil
 }
 
+// CreateTablesIfNotExists is a mock
 func (cadb *MockCADatabase) CreateTablesIfNotExists() error {
 	return nil
 }

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -26,42 +26,50 @@ func caller() string {
 	return fmt.Sprintf("%s:%d:", filename, line)
 }
 
+// Assert a boolean
 func Assert(t *testing.T, result bool, message string) {
 	if !result {
 		t.Error(caller(), message)
 	}
 }
 
+// AssertNotNil checks an object to be non-nil
 func AssertNotNil(t *testing.T, obj interface{}, message string) {
 	if obj == nil {
 		t.Error(caller(), message)
 	}
 }
 
+// AssertNotError checks that err is nil
 func AssertNotError(t *testing.T, err error, message string) {
 	if err != nil {
 		t.Error(caller(), message, ":", err)
 	}
 }
 
+// AssertError checks that err is non-nil
 func AssertError(t *testing.T, err error, message string) {
 	if err == nil {
 		t.Error(caller(), message, ":", err)
 	}
 }
 
+// AssertEquals uses the equality operator (=) to measure one and two
 func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 	if one != two {
 		t.Errorf("%s [%v] != [%v]", caller(), one, two)
 	}
 }
 
+// AssertDeepEquals uses the reflect.DeepEqual method to measure one and two
 func AssertDeepEquals(t *testing.T, one interface{}, two interface{}) {
 	if !reflect.DeepEqual(one, two) {
 		t.Errorf("%s [%+v] !(deep)= [%+v]", caller(), one, two)
 	}
 }
 
+// AssertMarshaledEquals marshals one and two to JSON, and then uses
+// the equality operator to measure them
 func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
 	oneJSON, err := json.Marshal(one)
 	AssertNotError(t, err, "Could not marshal 1st argument")
@@ -73,12 +81,15 @@ func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
 	}
 }
 
+// AssertNotEquals uses the equality operator to measure that one and two
+// are different
 func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {
 	if one == two {
 		t.Errorf("%s [%v] == [%v]", caller(), one, two)
 	}
 }
 
+// AssertByteEquals uses bytes.Equal to measure one and two for equality.
 func AssertByteEquals(t *testing.T, one []byte, two []byte) {
 	if !bytes.Equal(one, two) {
 		t.Errorf("%s Byte [%s] != [%s]",
@@ -88,30 +99,36 @@ func AssertByteEquals(t *testing.T, one []byte, two []byte) {
 	}
 }
 
+// AssertIntEquals uses the equality operator to measure one and two.
 func AssertIntEquals(t *testing.T, one int, two int) {
 	if one != two {
 		t.Errorf("%s Int [%d] != [%d]", caller(), one, two)
 	}
 }
 
+// AssertBigIntEquals uses the big.Int.cmp() method to measure whether
+// one and two are equal
 func AssertBigIntEquals(t *testing.T, one *big.Int, two *big.Int) {
 	if one.Cmp(two) != 0 {
 		t.Errorf("%s Int [%d] != [%d]", caller(), one, two)
 	}
 }
 
+// AssertContains determines whether needle can be found in haystack
 func AssertContains(t *testing.T, haystack string, needle string) {
 	if !strings.Contains(haystack, needle) {
 		t.Errorf("%s String [%s] does not contain [%s]", caller(), haystack, needle)
 	}
 }
 
+// AssertNotContains determines if needle is not found in haystack
 func AssertNotContains(t *testing.T, haystack string, needle string) {
 	if strings.Contains(haystack, needle) {
 		t.Errorf("%s String [%s] contains [%s]", caller(), haystack, needle)
 	}
 }
 
+// AssertSeverity determines if a string matches the Severity formatting
 func AssertSeverity(t *testing.T, data string, severity int) {
 	expected := fmt.Sprintf("\"severity\":%d", severity)
 	AssertContains(t, data, expected)

--- a/va/caa-util.go
+++ b/va/caa-util.go
@@ -58,7 +58,7 @@ func newCAA(encodedRDATA []byte) *CAA {
 	return &CAA{flag: flag, tag: tag, valueBuf: valueBuf, value: value}
 }
 
-// Filtered CAA records
+// CAASet consists of filtered CAA records
 type CAASet struct {
 	issue     []*CAA
 	issuewild []*CAA

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -20,6 +20,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
+// ValidationAuthorityImpl represents a VA
 type ValidationAuthorityImpl struct {
 	RA           core.RegistrationAuthority
 	log          *blog.AuditLogger
@@ -28,6 +29,8 @@ type ValidationAuthorityImpl struct {
 	TestMode     bool
 }
 
+// NewValidationAuthorityImpl constructs a new VA, and may place it
+// into Test Mode (tm)
 func NewValidationAuthorityImpl(tm bool) ValidationAuthorityImpl {
 	logger := blog.GetAuditLogger()
 	logger.Notice("Validation Authority Starting")
@@ -131,8 +134,8 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 		return challenge, err
 	}
 
-	const DVSNI_SUFFIX = ".acme.invalid"
-	nonceName := challenge.Nonce + DVSNI_SUFFIX
+	const DVSNIsuffix = ".acme.invalid"
+	nonceName := challenge.Nonce + DVSNIsuffix
 
 	R, err := core.B64dec(challenge.R)
 	if err != nil {
@@ -266,12 +269,13 @@ func (va ValidationAuthorityImpl) validate(authz core.Authorization, challengeIn
 	va.RA.OnValidationUpdate(authz)
 }
 
+// UpdateValidations runs the validate() method asynchronously using goroutines.
 func (va ValidationAuthorityImpl) UpdateValidations(authz core.Authorization, challengeIndex int) error {
 	go va.validate(authz, challengeIndex)
 	return nil
 }
 
-// CheckCAA verifies that, if the indicated subscriber domain has any CAA
+// CheckCAARecords verifies that, if the indicated subscriber domain has any CAA
 // records, they authorize the configured CA domain to issue a certificate
 func (va *ValidationAuthorityImpl) CheckCAARecords(identifier core.AcmeIdentifier) (present, valid bool, err error) {
 	domain := strings.ToLower(identifier.Value)

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -36,19 +36,19 @@ func intFromB64(b64 string) int {
 	return int(bigIntFromB64(b64).Int64())
 }
 
-var n *big.Int = bigIntFromB64("n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw==")
-var e int = intFromB64("AQAB")
-var d *big.Int = bigIntFromB64("bWUC9B-EFRIo8kpGfh0ZuyGPvMNKvYWNtB_ikiH9k20eT-O1q_I78eiZkpXxXQ0UTEs2LsNRS-8uJbvQ-A1irkwMSMkK1J3XTGgdrhCku9gRldY7sNA_AKZGh-Q661_42rINLRCe8W-nZ34ui_qOfkLnK9QWDDqpaIsA-bMwWWSDFu2MUBYwkHTMEzLYGqOe04noqeq1hExBTHBOBdkMXiuFhUq1BU6l-DqEiWxqg82sXt2h-LMnT3046AOYJoRioz75tSUQfGCshWTBnP5uDjd18kKhyv07lhfSJdrPdM5Plyl21hsFf4L_mHCuoFau7gdsPfHPxxjVOcOpBrQzwQ==")
-var p *big.Int = bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
-var q *big.Int = bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
+var n = bigIntFromB64("n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw==")
+var e = intFromB64("AQAB")
+var d = bigIntFromB64("bWUC9B-EFRIo8kpGfh0ZuyGPvMNKvYWNtB_ikiH9k20eT-O1q_I78eiZkpXxXQ0UTEs2LsNRS-8uJbvQ-A1irkwMSMkK1J3XTGgdrhCku9gRldY7sNA_AKZGh-Q661_42rINLRCe8W-nZ34ui_qOfkLnK9QWDDqpaIsA-bMwWWSDFu2MUBYwkHTMEzLYGqOe04noqeq1hExBTHBOBdkMXiuFhUq1BU6l-DqEiWxqg82sXt2h-LMnT3046AOYJoRioz75tSUQfGCshWTBnP5uDjd18kKhyv07lhfSJdrPdM5Plyl21hsFf4L_mHCuoFau7gdsPfHPxxjVOcOpBrQzwQ==")
+var p = bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
+var q = bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
 
-var TheKey rsa.PrivateKey = rsa.PrivateKey{
+var TheKey = rsa.PrivateKey{
 	PublicKey: rsa.PublicKey{N: n, E: e},
 	D:         d,
 	Primes:    []*big.Int{p, q},
 }
 
-var ident core.AcmeIdentifier = core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "localhost"}
+var ident = core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "localhost"}
 
 const expectedToken = "THETOKEN"
 const pathWrongToken = "wrongtoken"
@@ -545,7 +545,7 @@ func TestDNSValidationLive(t *testing.T) {
 		Value: "good.bin.coffee",
 	}
 
-	var badIdent core.AcmeIdentifier = core.AcmeIdentifier{
+	var badIdent = core.AcmeIdentifier{
 		Type:  core.IdentifierType("dns"),
 		Value: "bad.bin.coffee",
 	}

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -27,6 +27,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
+// Paths are the ACME-spec identified URL path-segments for various methods
 const (
 	NewRegPath     = "/acme/new-reg"
 	RegPath        = "/acme/reg/"
@@ -99,6 +100,8 @@ func NewWebFrontEndImpl() WebFrontEndImpl {
 	}
 }
 
+// HandlePaths configures the HTTP engine to use various functions
+// as methods for various ACME-specified paths.
 func (wfe *WebFrontEndImpl) HandlePaths() {
 	wfe.NewReg = wfe.BaseURL + NewRegPath
 	wfe.RegBase = wfe.BaseURL + RegPath
@@ -122,6 +125,7 @@ func (wfe *WebFrontEndImpl) HandlePaths() {
 
 // Method implementations
 
+// Index serves a simple identification page. It is not part of the ACME spec.
 func (wfe *WebFrontEndImpl) Index(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -167,6 +171,7 @@ type problem struct {
 	Detail string      `json:"detail,omitempty"`
 }
 
+// These are defined problems
 const (
 	MalformedProblem      = ProblemType("urn:acme:error:malformed")
 	UnauthorizedProblem   = ProblemType("urn:acme:error:unauthorized")
@@ -240,11 +245,10 @@ func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]
 		// registration is an overall failure to verify.
 		if regCheck {
 			return nil, nil, reg, err
-		} else {
-			// Otherwise we just return an empty registration. The caller is expected
-			// to use the returned key instead.
-			reg = core.Registration{}
 		}
+		// Otherwise we just return an empty registration. The caller is expected
+		// to use the returned key instead.
+		reg = core.Registration{}
 	}
 
 	return []byte(payload), key, reg, nil
@@ -293,6 +297,7 @@ func link(url, relation string) string {
 	return fmt.Sprintf("<%s>;rel=\"%s\"", url, relation)
 }
 
+// NewRegistration is used by clients to submit a new registration/account
 func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -356,6 +361,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	wfe.Stats.Inc("Registrations", 1, 1.0)
 }
 
+// NewAuthorization is used by clients to submit a new ID Authorization
 func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -417,6 +423,7 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 	wfe.Stats.Inc("PendingAuthorizations", 1, 1.0)
 }
 
+// RevokeCertificate is used by clients to request the revocation of a cert.
 func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -435,7 +442,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 	}
 
 	type RevokeRequest struct {
-		CertificateDER core.JsonBuffer `json:"certificate"`
+		CertificateDER core.JSONBuffer `json:"certificate"`
 	}
 	var revokeRequest RevokeRequest
 	if err = json.Unmarshal(body, &revokeRequest); err != nil {
@@ -496,6 +503,8 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 	}
 }
 
+// NewCertificate is used by clients to request the issuance of a cert for an
+// authorized identifier.
 func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -684,6 +693,7 @@ func (wfe *WebFrontEndImpl) challenge(authz core.Authorization, response http.Re
 	}
 }
 
+// Registration is used by a client to submit an update to their registration.
 func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -759,6 +769,8 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 	response.Write(jsonReply)
 }
 
+// Authorization is used by clients to submit an update to one of their
+// authorizations.
 func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -812,6 +824,8 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 
 var allHex = regexp.MustCompile("^[0-9a-f]+$")
 
+// Certificate is used by clients to request a copy of their current certificate, or to
+// request a reissuance of the certificate.
 func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -859,9 +873,15 @@ func (wfe *WebFrontEndImpl) Certificate(response http.ResponseWriter, request *h
 		if _, err = response.Write(cert.DER); err != nil {
 			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 		}
+		return
+	case "POST":
+		wfe.sendError(response, "Not yet supported", "", http.StatusNotFound)
+		return
 	}
 }
 
+// Terms is used by the client to obtain the current Terms of Service /
+// Subscriber Agreement to which the subscriber must agree.
 func (wfe *WebFrontEndImpl) Terms(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 
@@ -874,6 +894,7 @@ func (wfe *WebFrontEndImpl) Terms(response http.ResponseWriter, request *http.Re
 	fmt.Fprintf(response, "TODO: Add terms of use here")
 }
 
+// Issuer obtains the issuer certificate used by this instance of Boulder.
 func (wfe *WebFrontEndImpl) Issuer(response http.ResponseWriter, request *http.Request) {
 	wfe.sendStandardHeaders(response)
 

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -710,7 +710,7 @@ func TestRevokeCertificate(t *testing.T) {
 	certBlock, _ := pem.Decode(certPemBytes)
 	test.Assert(t, certBlock != nil, "Failed to decode PEM")
 	var revokeRequest struct {
-		CertificateDER core.JsonBuffer `json:"certificate"`
+		CertificateDER core.JSONBuffer `json:"certificate"`
 	}
 	revokeRequest.CertificateDER = certBlock.Bytes
 	revokeRequestJSON, err := json.Marshal(revokeRequest)
@@ -767,7 +767,7 @@ func TestRevokeCertificateAlreadyRevoked(t *testing.T) {
 	certBlock, _ := pem.Decode(certPemBytes)
 	test.Assert(t, certBlock != nil, "Failed to decode PEM")
 	var revokeRequest struct {
-		CertificateDER core.JsonBuffer `json:"certificate"`
+		CertificateDER core.JSONBuffer `json:"certificate"`
 	}
 	revokeRequest.CertificateDER = certBlock.Bytes
 	revokeRequestJSON, err := json.Marshal(revokeRequest)


### PR DESCRIPTION
This patchset cleans up most all of the  `go lint` warnings, leaving behind only these:
> policy/policy-authority.go:18:6: type name will be used as policy.PolicyAuthorityImpl by other packages, and that stutters; consider calling this AuthorityImpl
rpc/amqp-rpc.go:143:6: type name will be used as rpc.RPCError by other packages, and that stutters; consider calling this Error
rpc/amqp-rpc.go:204:6: type name will be used as rpc.RPCResponse by other packages, and that stutters; consider calling this Response
rpc/rpc-interfaces.go:13:6: type name will be used as rpc.RPCClient by other packages, and that stutters; consider calling this Client
rpc/rpc-interfaces.go:20:6: type name will be used as rpc.RPCServer by other packages, and that stutters; consider calling this Server


There only changes made that were not to resolve Lint warnings were to correct the capitalization of `NewAmqpRPCCLient` to `NewAmqpRPCClient`.