### PR TITLE
Support TLS mutual authentication for AMQPS

### DIFF
--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -148,7 +148,9 @@ func main() {
 
 		blog.SetAuditLogger(auditlogger)
 
-		ch := cmd.AmqpChannel(c.AMQP.Server)
+		ch, err := cmd.AmqpChannel(c)
+
+		cmd.FailOnError(err, "Could not connect to AMQP")
 
 		go cmd.ProfileCmd("AM", stats)
 

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -67,7 +67,8 @@ func setupContext(context *cli.Context) (rpc.CertificateAuthorityClient, *blog.A
 	cmd.FailOnError(err, "Could not connect to Syslog")
 	blog.SetAuditLogger(auditlogger)
 
-	ch := cmd.AmqpChannel(c.AMQP.Server)
+	ch, err := cmd.AmqpChannel(c)
+	cmd.FailOnError(err, "Could not connect to AMQP")
 
 	caRPC, err := rpc.NewAmqpRPCClient("revoker->CA", c.AMQP.CA.Server, ch)
 	cmd.FailOnError(err, "Unable to create RPC client")

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -45,7 +45,9 @@ func main() {
 		go cmd.ProfileCmd("CA", stats)
 
 		for {
-			ch := cmd.AmqpChannel(c.AMQP.Server)
+			ch, err := cmd.AmqpChannel(c)
+			cmd.FailOnError(err, "Could not connect to AMQP")
+
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
 			saRPC, err := rpc.NewAmqpRPCClient("CA->SA", c.AMQP.SA.Server, ch)

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -38,7 +38,9 @@ func main() {
 		go cmd.ProfileCmd("RA", stats)
 
 		for {
-			ch := cmd.AmqpChannel(c.AMQP.Server)
+			ch, err := cmd.AmqpChannel(c)
+			cmd.FailOnError(err, "Could not connect to AMQP")
+
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
 			vaRPC, err := rpc.NewAmqpRPCClient("RA->VA", c.AMQP.VA.Server, ch)

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -42,7 +42,9 @@ func main() {
 		go cmd.ProfileCmd("SA", stats)
 
 		for {
-			ch := cmd.AmqpChannel(c.AMQP.Server)
+			ch, err := cmd.AmqpChannel(c)
+			cmd.FailOnError(err, "Could not connect to AMQP")
+
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
 			sas := rpc.NewAmqpRPCServer(c.AMQP.SA.Server, ch)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -41,7 +41,9 @@ func main() {
 		vai.DNSResolver = core.NewDNSResolver(dnsTimeout, []string{c.VA.DNSResolver})
 
 		for {
-			ch := cmd.AmqpChannel(c.AMQP.Server)
+			ch, err := cmd.AmqpChannel(c)
+			cmd.FailOnError(err, "Could not connect to AMQP")
+
 			closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
 			raRPC, err := rpc.NewAmqpRPCClient("VA->RA", c.AMQP.RA.Server, ch)

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -20,7 +20,9 @@ import (
 )
 
 func setupWFE(c cmd.Config) (rpc.RegistrationAuthorityClient, rpc.StorageAuthorityClient, chan *amqp.Error) {
-	ch := cmd.AmqpChannel(c.AMQP.Server)
+	ch, err := cmd.AmqpChannel(c)
+	cmd.FailOnError(err, "Could not connect to AMQP")
+
 	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
 	raRPC, err := rpc.NewAmqpRPCClient("WFE->RA", c.AMQP.RA.Server, ch)

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -27,7 +27,9 @@ import (
 const ocspResponseLimit int = 128
 
 func setupClients(c cmd.Config) (rpc.CertificateAuthorityClient, chan *amqp.Error) {
-	ch := cmd.AmqpChannel(c.AMQP.Server)
+	ch, err := cmd.AmqpChannel(c)
+	cmd.FailOnError(err, "Could not connect to AMQP")
+
 	closeChan := ch.NotifyClose(make(chan *amqp.Error, 1))
 
 	caRPC, err := rpc.NewAmqpRPCClient("OCSP->CA", c.AMQP.CA.Server, ch)

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -7,6 +7,11 @@
 
   "amqp": {
     "server": "amqp://guest:guest@localhost:5672",
+    "-uncomment_for_AMQPS-ssl": {
+      "cacertfile": "/etc/boulder/rabbitmq-cacert.pem",
+      "certfile": "/etc/boulder/rabbitmq-cert.pem",
+      "keyfile": "/etc/boulder/rabbitmq-key.pem"
+    },
     "RA": {
       "client": "RA.client",
       "server": "RA.server"


### PR DESCRIPTION
(Related to Issue #321, as we certainly can't use remote VAs without strong encryption.)

This patch adds support to use client-certificate (mutual) authentication over TLS between the AMQP clients (Boulder) and the AMQP server. It adds an optional "ssl" section to the "amqp" portion of the config file. If you want client cert support, you would need to ensure your "amqp" section is similar to:

```json
  "amqp": {
    "server": "amqp://guest:guest@192.168.59.103:5672",
    "ssl": {
      "cacertfile": "/etc/boulder/rabbitmq-cacert.pem",
      "certfile": "/etc/boulder/rabbitmq-cert.pem",
      "keyfile": "/etc/boulder/rabbitmq-key.pem"
    },
    "RA": {
      "server": "RA.server"
    },
    "VA": {
      "server": "VA.server"
    },
    "SA": {
      "server": "SA.server"
    },
    "CA": {
      "server": "CA.server"
    },
  },
```
