### PR TITLE
Remove duplicate DNS error check

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -97,9 +97,6 @@ func (dnsResolver *DNSResolver) LookupTXT(hostname string) ([]string, time.Durat
 	m := new(dns.Msg)
 	m.SetQuestion(dns.Fqdn(hostname), dns.TypeTXT)
 	r, rtt, err := dnsResolver.LookupDNSSEC(m)
-	if err != nil {
-		return txt, rtt, err
-	}
 
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
Whoops, didn't notice #370 had been merged before merging #369 which caused in a doubled `err` check.