### PR TITLE
Client / server integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,16 @@ sudo: required
 matrix:
   fast_finish: true
 
+# Only build pushes to the master branch (and PRs)
+branches:
+  only:
+    - master
+
+sudo: required
+
 before_install:
+  - sudo mkdir /etc/letsencrypt
+  - sudo chown $USER /etc/letsencrypt
   - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/golang/lint/golint
@@ -24,6 +33,15 @@ before_install:
   # we add a symlink.
   - mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt
   - test ! -d $GOPATH/src/github.com/letsencrypt/boulder && ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt/boulder || true
+  - git clone https://www.github.com/letsencrypt/lets-encrypt-preview.git /tmp/letsencrypt
+  - cd /tmp/letsencrypt
+  - sudo ./bootstrap/debian.sh
+  - virtualenv --no-site-packages -p python2 ./venv
+  - travis_retry ./venv/bin/pip install -r requirements.txt -e .
+  - "cd -"
+
+env:
+  - LETSENCRYPT_VENV=/tmp/letsencrypt/venv
 
 script:
   - make -j4 # Travis has 2 cores per build instance

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ branches:
 sudo: required
 
 before_install:
-  - sudo mkdir /etc/letsencrypt
-  - sudo chown $USER /etc/letsencrypt
   - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/golang/lint/golint

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,23 @@ FROM golang:1.4.2
 MAINTAINER J.C. Jones "jjones@letsencrypt.org"
 MAINTAINER William Budington "bill@eff.org"
 
+# Add node.js key to apt-key safely
+RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --import && \
+  gpg --export 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280 | apt-key add -
+
 # Install dependencies packages
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
+    apt-transport-https && \
+  echo deb https://deb.nodesource.com/node_0.12 jessie main > /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
     libltdl-dev \
-    rsyslog && \
+    rsyslog \
+    nodejs \
+    lsb-release \
+    rabbitmq-server \
+    git-core && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* \
     /tmp/* \
@@ -18,6 +30,17 @@ EXPOSE 4000
 
 # Assume the configuration is in /etc/boulder
 ENV BOULDER_CONFIG /go/src/github.com/letsencrypt/boulder/test/boulder-config.json
+
+# Get the Let's Encrypt client
+RUN git clone https://www.github.com/letsencrypt/lets-encrypt-preview.git /letsencrypt
+WORKDIR /letsencrypt
+RUN ./bootstrap/debian.sh && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+RUN virtualenv --no-site-packages -p python2 venv && \
+  ./venv/bin/pip install -r requirements.txt -e .[dev,docs,testing]
 
 # Copy in the Boulder sources
 COPY . /go/src/github.com/letsencrypt/boulder
@@ -32,4 +55,5 @@ RUN go install -tags pkcs11 \
   github.com/letsencrypt/boulder/cmd/boulder-va \
   github.com/letsencrypt/boulder/cmd/boulder-wfe
 
+WORKDIR /go/src/github.com/letsencrypt/boulder
 CMD ["bash", "-c", "rsyslogd && /go/bin/boulder"]

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,12 @@ TESTDIRS="analysis \
 
 run() {
   echo "$*"
-  $* || FAILURE=1
+  if $*; then
+    echo "success: $*"
+  else
+    FAILURE=1
+    echo "failure: $*"
+  fi
 }
 
 
@@ -62,6 +67,20 @@ else
 
   run go test -tags pkcs11 ${dirlist}
 fi
+
+if [ -z "$LETSENCRYPT_VENV" ]; then
+  DEFAULT_LETSENCRYPT_PATH="/tmp/letsencrypt"
+  LETSENCRYPT_VENV="$DEFAULT_LETSENCRYPT_PATH/venv"
+
+  run git clone https://www.github.com/letsencrypt/lets-encrypt-preview.git $DEFAULT_LETSENCRYPT_PATH
+
+  cd $DEFAULT_LETSENCRYPT_PATH
+  run virtualenv --no-site-packages -p python2 ./venv && \
+    ./venv/bin/pip install -r requirements.txt -e .
+  cd -
+fi
+
+export LETSENCRYPT_VENV
 
 [ ${FAILURE} == 0 ] && run python test/amqp-integration-test.py
 

--- a/test.sh
+++ b/test.sh
@@ -68,10 +68,20 @@ else
   run go test -tags pkcs11 ${dirlist}
 fi
 
+# If the unittests failed, exit before trying to run the integration test.
+if [ ${FAILURE} != 0 ]; then
+  exit ${FAILURE}
+fi
+
 if [ -z "$LETSENCRYPT_VENV" ]; then
-  DEFAULT_LETSENCRYPT_PATH="/tmp/letsencrypt"
+  DEFAULT_LETSENCRYPT_PATH=$(mktemp -d -t leXXXX)
   LETSENCRYPT_VENV="$DEFAULT_LETSENCRYPT_PATH/venv"
 
+  echo "----------------------------------------------------"
+  echo "--- Checking out letsencrypt client is slow  -------"
+  echo "--- Recommend setting \$LETSENCRYPT_VENV to  -------"
+  echo "--- an already-initialized client virtualenv -------"
+  echo "----------------------------------------------------"
   run git clone https://www.github.com/letsencrypt/lets-encrypt-preview.git $DEFAULT_LETSENCRYPT_PATH
 
   cd $DEFAULT_LETSENCRYPT_PATH
@@ -82,7 +92,7 @@ fi
 
 export LETSENCRYPT_VENV
 
-[ ${FAILURE} == 0 ] && run python test/amqp-integration-test.py
+run python test/amqp-integration-test.py
 
 unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1  gofmt -l)
 if [ "x${unformatted}" != "x" ] ; then

--- a/test.sh
+++ b/test.sh
@@ -82,11 +82,13 @@ if [ -z "$LETSENCRYPT_VENV" ]; then
   echo "--- Recommend setting \$LETSENCRYPT_VENV to  -------"
   echo "--- an already-initialized client virtualenv -------"
   echo "----------------------------------------------------"
-  run git clone https://www.github.com/letsencrypt/lets-encrypt-preview.git $DEFAULT_LETSENCRYPT_PATH
+  run git clone \
+    https://www.github.com/letsencrypt/lets-encrypt-preview.git \
+    $DEFAULT_LETSENCRYPT_PATH || exit 1
 
   cd $DEFAULT_LETSENCRYPT_PATH
   run virtualenv --no-site-packages -p python2 ./venv && \
-    ./venv/bin/pip install -r requirements.txt -e .
+    ./venv/bin/pip install -r requirements.txt -e . || exit 1
   cd -
 fi
 

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -76,17 +76,30 @@ def run_client_tests():
     tempkey = os.path.join(tempdir, "key")
     os.mkdir(tempkey, 0700)
 
-    base_cmd = letsencrypt_bin + ''' \
+    # For now, the client renewer can only be configured by file, not command
+    # line, so we create a config file.
+    renewer_config_filename = os.path.join(tempdir, "renewer.conf")
+    with open(renewer_config_filename, "w") as r:
+        r.write('''
+            renewal_configs_dir = %s/renewal_configs
+            archive_dir = %s/archive
+            live_dir = %s/live
+            ''' % (tempconfig, tempwork, tempwork))
+
+    base_cmd = '''
+        %s \
         -a standalone \
         --server http://localhost:4300/acme/new-reg \
         --dvsni-port 5001 \
-        --config-dir "''' + tempconfig + '''" \
-        --work-dir "''' + tempwork + '''" \
-        --key-dir "''' + tempkey + '''" \
+        --config-dir %s \
+        --work-dir %s \
+        --key-dir %s \
+        --cert-dir %s \
         --text \
         --agree-tos \
         --email "" \
-        -vvvvvvv '''
+        --renewer-config-file %s \
+        ''' % (letsencrypt_bin, tempconfig, tempwork, tempkey, tempwork, renewer_config_filename)
 
     client_run(base_cmd, '--domains foo.com auth')
 

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -36,7 +36,7 @@ def start():
     run('./cmd/boulder-ca')
     run('./cmd/boulder-va')
 
-def run_test():
+def run_node_test():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         s.connect(('localhost', 4300))
@@ -64,9 +64,40 @@ def run_test():
 
     return 0
 
+def run_client_tests():
+    letsencrypt_bin = os.path.join(os.environ.get("LETSENCRYPT_VENV"), 'bin', 'letsencrypt')
+
+    tempconfig = os.path.join(tempdir, "conf")
+    os.mkdir(tempconfig, 0755)
+
+    tempwork = os.path.join(tempdir, "work")
+    os.mkdir(tempwork, 0755)
+
+    tempkey = os.path.join(tempdir, "key")
+    os.mkdir(tempkey, 0700)
+
+    base_cmd = letsencrypt_bin + ''' \
+        -a standalone \
+        --server http://localhost:4300/acme/new-reg \
+        --dvsni-port 5001 \
+        --config-dir "''' + tempconfig + '''" \
+        --work-dir "''' + tempwork + '''" \
+        --key-dir "''' + tempkey + '''" \
+        --text \
+        --agree-tos \
+        --email "" \
+        -vvvvvvv '''
+
+    client_run(base_cmd, '--domains foo.com auth')
+
+def client_run(base_cmd, cmd):
+    if subprocess.Popen(base_cmd + cmd, shell=True).wait() != 0:
+        die()
+
 try:
     start()
-    run_test()
+    run_node_test()
+    run_client_tests()
 except Exception as e:
     exit_status = 1
     print e

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -38,8 +38,7 @@ def run_test():
             s.connect(('localhost', 4300))
             break
         except socket.error, e:
-            pass
-        time.sleep(1)
+            time.sleep(1)
 
     if subprocess.Popen('npm install', shell=True).wait() != 0:
         die()


### PR DESCRIPTION
This builds on @Hainish's https://github.com/letsencrypt/boulder/pull/373 by adding support for running the test as non-root. The changes relative to https://github.com/letsencrypt/boulder/pull/373 are:
 - Early exit if unittests fail in test.sh
 - Specify more flags to letsencrypt to avoid writing to /etc/letsencrypt
 - Remove the sudo mkdir /etc/letsencrypt in .travis.yml