### PR TITLE
Fix inappropriate DNS failures

### DIFF
--- a/core/dns_test.go
+++ b/core/dns_test.go
@@ -83,3 +83,22 @@ func TestDNSSEC(t *testing.T) {
 	test.Assert(t, !ok, "Shouldn't have been a DNSSECError")
 
 }
+
+func TestDNSLookupHost(t *testing.T) {
+	obj := NewDNSResolver(time.Second*10, []string{"8.8.8.8:53"})
+
+	ip, _, err := obj.LookupHost("sigfail.verteiltesysteme.net")
+	t.Logf("sigfail.verteiltesysteme.net - IP: %s, Err: %s", ip, err)
+	test.AssertError(t, err, "DNSSEC failure")
+	test.Assert(t, len(ip) == 0, "Should not have IPs")
+
+	ip, _, err = obj.LookupHost("nonexistent.letsencrypt.org")
+	t.Logf("nonexistent.letsencrypt.org - IP: %s, Err: %s", ip, err)
+	test.AssertNotError(t, err, "Not an error to not exist")
+	test.Assert(t, len(ip) == 0, "Should not have IPs")
+
+	ip, _, err = obj.LookupHost("cps.letsencrypt.org")
+	t.Logf("cps.letsencrypt.org - IP: %s, Err: %s", ip, err)
+	test.AssertNotError(t, err, "Not an error to be a CNAME")
+	test.Assert(t, len(ip) > 0, "Should have IPs")
+}

--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -169,7 +169,14 @@ func caller(level int) string {
 // AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 func (log *AuditLogger) AuditPanic() {
 	if err := recover(); err != nil {
-		log.Audit(fmt.Sprintf("Panic: %s %v", caller(4), err))
+		buf := make([]byte, 8192)
+		log.Audit(fmt.Sprintf("Panic caused by err: %v", err))
+
+		runtime.Stack(buf, false)
+		log.Audit(fmt.Sprintf("Stack Trace (Current frame) %s", buf))
+
+		runtime.Stack(buf, true)
+		log.Warning(fmt.Sprintf("Stack Trace (All frames): %s", buf))
 	}
 }
 

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -295,7 +295,7 @@ func NewAmqpRPCClient(clientQueuePrefix, serverQueue string, channel *amqp.Chann
 	}
 
 	// Subscribe to the response queue and dispatch
-	msgs, err := amqpSubscribe(rpc.channel, clientQueue, nil)
+	msgs, err := amqpSubscribe(rpc.channel, clientQueue, rpc.log)
 	if err != nil {
 		return nil, err
 	}

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -62,6 +62,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 			Type:   core.MalformedProblem,
 			Detail: "No path provided for SimpleHTTP challenge.",
 		}
+		va.log.Debug(fmt.Sprintf("SimpleHTTP [%s] path empty: %s", identifier, challenge))
 		return challenge, challenge.Error
 	}
 
@@ -71,6 +72,8 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 			Type:   core.MalformedProblem,
 			Detail: "Identifier type for SimpleHTTP was not DNS",
 		}
+
+		va.log.Debug(fmt.Sprintf("SimpleHTTP [%s] Identifier failure", identifier))
 		return challenge, challenge.Error
 	}
 	hostName := identifier.Value
@@ -82,11 +85,13 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 			Type:   core.DNSSECProblem,
 			Detail: dnssecErr.Error(),
 		}
+		va.log.Debug(fmt.Sprintf("SimpleHTTP [%s] DNSSEC failure: %s", identifier, err))
 	} else {
 		challenge.Error = &core.ProblemDetails{
 			Type:   core.ServerInternalProblem,
 			Detail: "Unable to communicate with DNS server",
 		}
+		va.log.Debug(fmt.Sprintf("SimpleHTTP [%s] DNS failure: %s", identifier, err))
 	}
 
 	var scheme string
@@ -110,6 +115,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 			Type:   core.MalformedProblem,
 			Detail: "URL provided for SimpleHTTP was invalid",
 		}
+		va.log.Debug(fmt.Sprintf("SimpleHTTP [%s] HTTP failure: %s", identifier, err))
 		challenge.Status = core.StatusInvalid
 		return challenge, err
 	}
@@ -136,6 +142,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 			challenge.Error = &core.ProblemDetails{
 				Type: core.ServerInternalProblem,
 			}
+			va.log.Debug(fmt.Sprintf("SimpleHTTP [%s] Read failure: %s", identifier, readErr))
 			challenge.Status = core.StatusInvalid
 			return challenge, readErr
 		}
@@ -180,6 +187,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 			Detail: "Identifier type for DVSNI was not DNS",
 		}
 		challenge.Status = core.StatusInvalid
+		va.log.Debug(fmt.Sprintf("DVSNI [%s] Identifier failure", identifier))
 		return challenge, challenge.Error
 	}
 
@@ -193,7 +201,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 			Type:   core.MalformedProblem,
 			Detail: "Failed to decode R value from DVSNI challenge",
 		}
-		va.log.Debug(challenge.Error.Detail)
+		va.log.Debug(fmt.Sprintf("DVSNI [%s] R Decode failure: %s", identifier, err))
 		return challenge, err
 	}
 	S, err := core.B64dec(challenge.S)
@@ -203,7 +211,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 			Type:   core.MalformedProblem,
 			Detail: "Failed to decode S value from DVSNI challenge",
 		}
-		va.log.Debug(challenge.Error.Detail)
+		va.log.Debug(fmt.Sprintf("DVSNI [%s] S Decode failure: %s", identifier, err))
 		return challenge, err
 	}
 	RS := append(R, S...)
@@ -218,11 +226,13 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 			Type:   core.DNSSECProblem,
 			Detail: dnssecErr.Error(),
 		}
+		va.log.Debug(fmt.Sprintf("DVSNI [%s] DNSSEC failure: %s", identifier, err))
 	} else {
 		challenge.Error = &core.ProblemDetails{
 			Type:   core.ServerInternalProblem,
 			Detail: "Unable to communicate with DNS server",
 		}
+		va.log.Debug(fmt.Sprintf("DVSNI [%s] DNS failure: %s", identifier, err))
 	}
 
 	// Make a connection with SNI = nonceName
@@ -230,7 +240,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 	if va.TestMode {
 		hostPort = "localhost:5001"
 	}
-	va.log.Notice(fmt.Sprintf("Attempting to validate DVSNI for %s %s %s",
+	va.log.Notice(fmt.Sprintf("DVSNI [%s] Attempting to validate DVSNI for %s %s",
 		identifier, hostPort, zName))
 	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", hostPort, &tls.Config{
 		ServerName:         nonceName,
@@ -243,7 +253,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 			Type:   parseHTTPConnError(err),
 			Detail: "Failed to connect to host for DVSNI challenge",
 		}
-		va.log.Debug(challenge.Error.Detail)
+		va.log.Debug(fmt.Sprintf("DVSNI [%s] TLS Connection failure: %s", identifier, err))
 		return challenge, err
 	}
 	defer conn.Close()
@@ -303,6 +313,7 @@ func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, in
 			Type:   core.MalformedProblem,
 			Detail: "Identifier type for DNS was not itself DNS",
 		}
+		va.log.Debug(fmt.Sprintf("DNS [%s] Identifier failure", identifier))
 		challenge.Status = core.StatusInvalid
 		return challenge, challenge.Error
 	}
@@ -318,11 +329,13 @@ func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, in
 				Type:   core.DNSSECProblem,
 				Detail: dnssecErr.Error(),
 			}
+			va.log.Debug(fmt.Sprintf("DNS [%s] DNSSEC failure: %s", identifier, err))
 		} else {
 			challenge.Error = &core.ProblemDetails{
 				Type:   core.ServerInternalProblem,
 				Detail: "Unable to communicate with DNS server",
 			}
+			va.log.Debug(fmt.Sprintf("DNS [%s] DNS failure: %s", identifier, err))
 		}
 		challenge.Status = core.StatusInvalid
 		return challenge, err

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -86,7 +86,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 			Detail: dnssecErr.Error(),
 		}
 		va.log.Debug(fmt.Sprintf("SimpleHTTP [%s] DNSSEC failure: %s", identifier, err))
-	} else {
+	} else if err != nil {
 		challenge.Error = &core.ProblemDetails{
 			Type:   core.ServerInternalProblem,
 			Detail: "Unable to communicate with DNS server",
@@ -227,7 +227,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 			Detail: dnssecErr.Error(),
 		}
 		va.log.Debug(fmt.Sprintf("DVSNI [%s] DNSSEC failure: %s", identifier, err))
-	} else {
+	} else if err != nil {
 		challenge.Error = &core.ProblemDetails{
 			Type:   core.ServerInternalProblem,
 			Detail: "Unable to communicate with DNS server",
@@ -330,7 +330,7 @@ func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, in
 				Detail: dnssecErr.Error(),
 			}
 			va.log.Debug(fmt.Sprintf("DNS [%s] DNSSEC failure: %s", identifier, err))
-		} else {
+		} else if err != nil {
 			challenge.Error = &core.ProblemDetails{
 				Type:   core.ServerInternalProblem,
 				Detail: "Unable to communicate with DNS server",


### PR DESCRIPTION
Four commits here, all issues I encountered while debugging [client #503](https://github.com/letsencrypt/lets-encrypt-preview/issues/503). 
- Log more consistently in the VA, because debugging [#503](https://github.com/letsencrypt/lets-encrypt-preview/issues/503) was painful
- There's an error leg issue where we forgot the `if` in the `else`, causing everything to fail
- Make panics nicer
- Don't cause panics in the first place when the AMQP server is rejecting you for permissions issues