### PR TITLE
Fixes #387 - Check whether the certificate / privkey is set before tr…

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -214,6 +214,10 @@ func AmqpChannel(conf Config) (*amqp.Channel, error) {
 			err := fmt.Errorf("SSL configuration provided, but not using an AMQPS URL")
 			return nil, err
 		}
+		if len(conf.AMQP.SSL.CertFile) == 0 || len(conf.AMQP.SSL.KeyFile) == 0 {
+			err := fmt.Errorf("Configuration values AMQP.SSL.KeyFile and AMQP.SSL.CertFile may not be nil.")
+			return nil, err
+		}
 
 		cfg := new(tls.Config)
 

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -7,7 +7,7 @@
 
   "amqp": {
     "server": "amqp://guest:guest@localhost:5672",
-    "-uncomment_for_AMQPS-ssl": {
+    "-uncomment_for_AMQPS-tls": {
       "cacertfile": "/etc/boulder/rabbitmq-cacert.pem",
       "certfile": "/etc/boulder/rabbitmq-cert.pem",
       "keyfile": "/etc/boulder/rabbitmq-key.pem"


### PR DESCRIPTION
Fixes #387:  explicitly checks the AMQP.SSL.KeyFile and CertFile config options for emptiness before passing to the `tls.LoadX509KeyPair` method.