### PR TITLE
Fix User Notice policy qualifier

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,51 +12,51 @@
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/auth",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/config",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs11key",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs12",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs7",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/csr",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/errors",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/info",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/log",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer",
-			"Rev": "6f428f654df58d23d1321bcbe3598f6b8a02167a"
+			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
 		},
 		{
 			"ImportPath": "github.com/codegangsta/cli",

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/remote/remote.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/remote/remote.go
@@ -83,9 +83,9 @@ func (s *Signer) remoteOp(req interface{}, profile, target string) (resp interfa
 	if target == "info" {
 		resp, err = server.Info(jsonData)
 	} else if p.Provider != nil {
-		resp, err = server.AuthReq(jsonData, nil, p.Provider, target)
+		resp, err = server.AuthSign(jsonData, nil, p.Provider)
 	} else {
-		resp, err = server.Req(jsonData, target)
+		resp, err = server.Sign(jsonData)
 	}
 
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/signer_test.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/signer_test.go
@@ -1,7 +1,15 @@
 package signer
 
 import (
+	"bytes"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/hex"
+	"fmt"
+	"reflect"
 	"testing"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
 )
 
 func TestSplitHosts(t *testing.T) {
@@ -21,5 +29,65 @@ func TestSplitHosts(t *testing.T) {
 	}
 	if list[0] != "comma" || list[1] != "separated" || list[2] != "values" {
 		t.Fatal("SplitHost fails to split multiple domains")
+	}
+}
+
+func TestAddPolicies(t *testing.T) {
+	var cert x509.Certificate
+	addPolicies(&cert, []config.CertificatePolicy{
+		config.CertificatePolicy{
+			ID: config.OID{1, 2, 3, 4},
+		},
+	})
+
+	if len(cert.ExtraExtensions) != 1 {
+		t.Fatal("No extension added")
+	}
+	ext := cert.ExtraExtensions[0]
+	if !reflect.DeepEqual(ext.Id, asn1.ObjectIdentifier{2, 5, 29, 32}) {
+		t.Fatal(fmt.Sprintf("Wrong OID for policy qualifier %v", ext.Id))
+	}
+	if ext.Critical {
+		t.Fatal("Policy qualifier marked critical")
+	}
+	expectedBytes, _ := hex.DecodeString("3009300706032a03043000")
+	if !bytes.Equal(ext.Value, expectedBytes) {
+		t.Fatal(fmt.Sprintf("Value didn't match expected bytes: %s vs %s",
+			hex.EncodeToString(ext.Value), hex.EncodeToString(expectedBytes)))
+	}
+}
+
+func TestAddPoliciesWithQualifiers(t *testing.T) {
+	var cert x509.Certificate
+	addPolicies(&cert, []config.CertificatePolicy{
+		config.CertificatePolicy{
+			ID: config.OID{1, 2, 3, 4},
+			Qualifiers: []config.CertificatePolicyQualifier{
+				config.CertificatePolicyQualifier{
+					Type:  "id-qt-cps",
+					Value: "http://example.com/cps",
+				},
+				config.CertificatePolicyQualifier{
+					Type:  "id-qt-unotice",
+					Value: "Do What Thou Wilt",
+				},
+			},
+		},
+	})
+
+	if len(cert.ExtraExtensions) != 1 {
+		t.Fatal("No extension added")
+	}
+	ext := cert.ExtraExtensions[0]
+	if !reflect.DeepEqual(ext.Id, asn1.ObjectIdentifier{2, 5, 29, 32}) {
+		t.Fatal(fmt.Sprintf("Wrong OID for policy qualifier %v", ext.Id))
+	}
+	if ext.Critical {
+		t.Fatal("Policy qualifier marked critical")
+	}
+	expectedBytes, _ := hex.DecodeString("304e304c06032a03043045302206082b060105050702011616687474703a2f2f6578616d706c652e636f6d2f637073301f06082b0601050507020230130c11446f20576861742054686f752057696c74")
+	if !bytes.Equal(ext.Value, expectedBytes) {
+		t.Fatal(fmt.Sprintf("Value didn't match expected bytes: %s vs %s",
+			hex.EncodeToString(ext.Value), hex.EncodeToString(expectedBytes)))
 	}
 }

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -74,9 +74,14 @@
                 "ID": "2.23.140.1.2.1"
               },
               {
-                "ID": "1.3.6.1.4.1.44947.1.1.1",
-                "type": "id-qt-cps",
-                "qualifier": "http://cps.root-x1.letsencrypt.org"
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                }, {
+                  "type": "id-qt-unotice",
+                  "value": "Do What Thou Wilt"
+                } ]
               }
             ],
             "expiry": "8760h",

--- a/test/boulder-pkcs11-example-config.json
+++ b/test/boulder-pkcs11-example-config.json
@@ -74,11 +74,6 @@
               {
                 "ID": "2.23.140.1.2.1"
               },
-              {
-                "ID": "1.3.6.1.4.1.44947.1.1.1",
-                "type": "id-qt-cps",
-                "qualifier": "http://cps.root-x1.letsencrypt.org"
-              }
             ],
             "expiry": "8760h",
             "CSRWhitelist": {

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -69,9 +69,14 @@
                 "ID": "2.23.140.1.2.1"
               },
               {
-                "ID": "1.3.6.1.4.1.44947.1.1.1",
-                "type": "id-qt-cps",
-                "qualifier": "http://cps.root-x1.letsencrypt.org"
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                }, {
+                  "type": "id-qt-unotice",
+                  "value": "Do What Thou Wilt"
+                } ]
               }
             ],
             "expiry": "8760h",


### PR DESCRIPTION
Fixes #407. Note: The actual fix is in cfssl (https://github.com/cloudflare/cfssl/pull/244). This change just pulls in the latest CFSSL and updates the test configs.