### PR TITLE
Return better message to client if JWK is unknown

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -202,6 +202,11 @@ func (wfe *WebFrontEndImpl) sendStandardHeaders(response http.ResponseWriter) {
 	response.Header().Set("Access-Control-Allow-Origin", "*")
 }
 
+const (
+	unknownKey   = "No registration exists matching provided key"
+	malformedJWS = "Unable to read/verify body"
+)
+
 func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]byte, *jose.JsonWebKey, core.Registration, error) {
 	var reg core.Registration
 
@@ -334,7 +339,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 	body, key, _, err := wfe.verifyPOST(request, false)
 	if err != nil {
 		logEvent.Error = err.Error()
-		wfe.sendError(response, "Unable to read/verify body", err, http.StatusBadRequest)
+		wfe.sendError(response, malformedJWS, err, http.StatusBadRequest)
 		return
 	}
 
@@ -410,11 +415,13 @@ func (wfe *WebFrontEndImpl) NewAuthorization(response http.ResponseWriter, reque
 	body, _, currReg, err := wfe.verifyPOST(request, true)
 	if err != nil {
 		logEvent.Error = err.Error()
+		respMsg := malformedJWS
+		respCode := http.StatusBadRequest
 		if err == sql.ErrNoRows {
-			wfe.sendError(response, "No registration exists matching provided key", err, http.StatusForbidden)
-		} else {
-			wfe.sendError(response, "Unable to read/verify body", err, http.StatusBadRequest)
+			respMsg = unknownKey
+			respCode = http.StatusForbidden
 		}
+		wfe.sendError(response, respMsg, err, respCode)
 		return
 	}
 	logEvent.Requester = currReg.ID
@@ -488,7 +495,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(response http.ResponseWriter, requ
 	body, requestKey, registration, err := wfe.verifyPOST(request, false)
 	if err != nil {
 		logEvent.Error = err.Error()
-		wfe.sendError(response, "Unable to read/verify body", err, http.StatusBadRequest)
+		wfe.sendError(response, malformedJWS, err, http.StatusBadRequest)
 		return
 	}
 	logEvent.Requester = registration.ID
@@ -587,11 +594,13 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	body, key, reg, err := wfe.verifyPOST(request, true)
 	if err != nil {
 		logEvent.Error = err.Error()
+		respMsg := malformedJWS
+		respCode := http.StatusBadRequest
 		if err == sql.ErrNoRows {
-			wfe.sendError(response, "No registration exists matching provided key", err, http.StatusForbidden)
-		} else {
-			wfe.sendError(response, "Unable to read/verify body", err, http.StatusBadRequest)
+			respMsg = unknownKey
+			respCode = http.StatusForbidden
 		}
+		wfe.sendError(response, respMsg, err, respCode)
 		return
 	}
 	logEvent.Requester = reg.ID
@@ -722,11 +731,13 @@ func (wfe *WebFrontEndImpl) challenge(authz core.Authorization, response http.Re
 		body, _, currReg, err := wfe.verifyPOST(request, true)
 		if err != nil {
 			logEvent.Error = err.Error()
+			respMsg := malformedJWS
+			respCode := http.StatusBadRequest
 			if err == sql.ErrNoRows {
-				wfe.sendError(response, "No registration exists matching provided key", err, http.StatusForbidden)
-			} else {
-				wfe.sendError(response, "Unable to read/verify body", err, http.StatusBadRequest)
+				respMsg = unknownKey
+				respCode = http.StatusForbidden
 			}
+			wfe.sendError(response, respMsg, err, respCode)
 			return logEvent
 		}
 		logEvent.Requester = currReg.ID
@@ -808,14 +819,13 @@ func (wfe *WebFrontEndImpl) Registration(response http.ResponseWriter, request *
 	body, _, currReg, err := wfe.verifyPOST(request, true)
 	if err != nil {
 		logEvent.Error = err.Error()
+		respMsg := malformedJWS
+		respCode := http.StatusBadRequest
 		if err == sql.ErrNoRows {
-			wfe.sendError(response,
-				"No registration exists matching provided key",
-				err, http.StatusForbidden)
-		} else {
-			wfe.sendError(response,
-				"Unable to read/verify body", err, http.StatusBadRequest)
+			respMsg = unknownKey
+			respCode = http.StatusForbidden
 		}
+		wfe.sendError(response, respMsg, err, respCode)
 		return
 	}
 	logEvent.Requester = currReg.ID

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -690,12 +690,12 @@ func TestNewRegistration(t *testing.T) {
 	signer, err = jose.NewSigner("RS256", rsaKey)
 	test.AssertNotError(t, err, "Failed to make signer")
 
+	// Reset the body and status code
+	responseWriter = httptest.NewRecorder()
 	// POST, Valid JSON, Key already in use
-	responseWriter.Body.Reset()
 	nonce, err = wfe.nonceService.Nonce()
 	test.AssertNotError(t, err, "Unable to create nonce")
 	result, err = signer.Sign([]byte("{\"contact\":[\"tel:123456789\"],\"agreement\":\""+agreementURL+"\"}"), nonce)
-
 	wfe.NewRegistration(responseWriter, &http.Request{
 		Method: "POST",
 		Body:   makeBody(result.FullSerialize()),
@@ -703,6 +703,7 @@ func TestNewRegistration(t *testing.T) {
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
 		"{\"type\":\"urn:acme:error:malformed\",\"detail\":\"Registration key is already in use\"}")
+	test.AssertEquals(t, responseWriter.Code, 409)
 }
 
 // Valid revocation request for existing, non-revoked cert


### PR DESCRIPTION
Fixes #376. Also adds a constant for the "Unable to read/verify..." message.