### PR TITLE
426 - Support minimum permissions in AMQP

### DIFF
--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -71,31 +71,6 @@ func startMonitor(rpcCh *amqp.Channel, logger *blog.AuditLogger, stats statsd.St
 		cmd.FailOnError(err, "Could not determine hostname")
 	}
 
-	err = rpcCh.ExchangeDeclarePassive(
-		AmqpExchange,
-		AmqpExchangeType,
-		AmqpDurable,
-		AmqpDeleteUnused,
-		AmqpInternal,
-		AmqpNoWait,
-		nil)
-	if err != nil {
-		logger.Info(fmt.Sprintf("Exchange %s does not exist on AMQP server, attempting to create.", AmqpExchange))
-
-		// Attempt to create the Exchange if not exists
-		err = rpcCh.ExchangeDeclare(
-			AmqpExchange,
-			AmqpExchangeType,
-			AmqpDurable,
-			AmqpDeleteUnused,
-			AmqpInternal,
-			AmqpNoWait,
-			nil)
-		if err != nil {
-			cmd.FailOnError(err, "Could not declare exchange")
-		}
-	}
-
 	_, err = rpcCh.QueueDeclarePassive(
 		QueueName,
 		AmqpDurable,

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -297,6 +297,11 @@ func AmqpChannel(conf Config) (*amqp.Channel, error) {
 		return nil, err
 	}
 
+	err = rpc.AMQPDeclareExchange(conn)
+	if err != nil {
+		return nil, err
+	}
+
 	return conn.Channel()
 }
 

--- a/docs/rabbitmq_acl_configure.sh
+++ b/docs/rabbitmq_acl_configure.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright 2015 ISRG.  All rights reserved
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This file creates individual AMQP accounts for each Boulder component,
+# and sets restrictive access controls on those accounts.
+#
+# You can use this tool without any configuration to produce users named
+# [am, ca, sa, ra, va, wfe, ocsp-updater] which all have the password "guest".
+# You can also customize this tool by creating a config file that will be
+# sourced. By default this file is obtained from $HOME/.rabbitmq_config, but
+# you can override the config file path using the environment variable
+# RABBITMQ_ACL_CONFIG, such as:
+#
+# $ RABBITMQ_ACL_CONFIG=myconfig ./rabbitmq_acl_configure.sh
+
+# VARIABLES
+PORT=15672
+HOST=localhost
+VHOST="/"
+EXTRA=""
+RABBIT_ADMIN=$(which rabbitmqadmin)
+
+# USER NAMES
+USER_BOULDER_AM="am"
+USER_BOULDER_CA="ca"
+USER_BOULDER_SA="sa"
+USER_BOULDER_RA="ra"
+USER_BOULDER_VA="va"
+USER_BOULDER_WFE="wfe"
+USER_BOULDER_OCSP="ocsp-updater"
+
+# PASSWORDS
+PASS_BOULDER_AM="guest"
+PASS_BOULDER_CA="guest"
+PASS_BOULDER_SA="guest"
+PASS_BOULDER_RA="guest"
+PASS_BOULDER_VA="guest"
+PASS_BOULDER_WFE="guest"
+PASS_BOULDER_OCSP="guest"
+
+# To use different options, you should create an override
+# file with whatever changes you want for the above variables
+RABBITMQ_ACL_CONFIG=${RABBITMQ_ACL_CONFIG:-$HOME/.rabbitmq_config}
+
+if [ -r "${RABBITMQ_ACL_CONFIG}" ] ; then
+  echo "Loading overrides from ${RABBITMQ_ACL_CONFIG}..."
+  source "${RABBITMQ_ACL_CONFIG}"
+fi
+
+if ! [ -x "${RABBIT_ADMIN}" ] ; then
+  echo "Could not locate rabbitmqadmin; please set RABBIT_ADMIN in your ${RABBITMQ_ACL_CONFIG} file."
+  exit 1
+fi
+
+run() {
+  echo $*
+  $*
+}
+
+admin() {
+  run ${RABBIT_ADMIN} -H ${HOST} -P ${PORT} -V ${VHOST} ${EXTRA} $*
+}
+
+admin declare queue name="Monitor" durable=false
+admin declare queue name="CA.server" durable=false
+admin declare queue name="SA.server" durable=false
+admin declare queue name="RA.server" durable=false
+admin declare queue name="VA.server" durable=false
+
+admin declare exchange name="boulder" type=topic durable=false
+admin declare binding source="boulder" destination="Monitor" routing_key="#"
+
+admin declare user name=${USER_BOULDER_AM} password=${PASS_BOULDER_AM} tags=""
+admin declare user name=${USER_BOULDER_CA} password=${PASS_BOULDER_CA} tags=""
+admin declare user name=${USER_BOULDER_SA} password=${PASS_BOULDER_SA} tags=""
+admin declare user name=${USER_BOULDER_RA} password=${PASS_BOULDER_RA} tags=""
+admin declare user name=${USER_BOULDER_VA} password=${PASS_BOULDER_VA} tags=""
+admin declare user name=${USER_BOULDER_WFE} password=${PASS_BOULDER_WFE} tags=""
+admin declare user name=${USER_BOULDER_OCSP} password=${PASS_BOULDER_OCSP} tags=""
+
+admin declare permission vhost=${VHOST} user=${USER_BOULDER_AM} configure="^$" write="^$" read="^Monitor$"
+admin declare permission vhost=${VHOST} user=${USER_BOULDER_VA} configure="^(VA\.server|VA->.*)$" write="^(boulder|VA\.server|VA->.*)$" read="^(boulder|VA\.server|VA->.*)$"
+admin declare permission vhost=${VHOST} user=${USER_BOULDER_RA} configure="^(RA\.server|RA->.*)$" write="^(boulder|RA\.server|RA->.*)$" read="^(boulder|RA\.server|RA->.*)$"
+admin declare permission vhost=${VHOST} user=${USER_BOULDER_CA} configure="^(CA\.server|CA->.*)$" write="^(boulder|CA\.server|CA->.*)$" read="^(boulder|CA\.server|CA->.*)$"
+admin declare permission vhost=${VHOST} user=${USER_BOULDER_SA} configure="^(SA\.server|SA->.*)$" write="^(boulder|SA\.server|SA->.*)$" read="^(boulder|SA\.server|SA->.*)$"
+admin declare permission vhost=${VHOST} user=${USER_BOULDER_WFE} configure="^(WFE->.*)$" write="^(boulder|WFE->.*)$" read="^(boulder|WFE->.*)$"
+admin declare permission vhost=${VHOST} user=${USER_BOULDER_OCSP} configure="^(OCSP->.*)$" write="^(boulder|OCSP->.*)$" read="^(boulder|OCSP->.*)$"

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -55,8 +55,10 @@ func amqpConnect(url string) (ch *amqp.Channel, err error) {
 }
 
 // A simplified way to declare and subscribe to an AMQP queue
-func amqpSubscribe(ch *amqp.Channel, name string, log *blog.AuditLogger) (msgs <-chan amqp.Delivery, err error) {
-	err = ch.ExchangeDeclare(
+func amqpSubscribe(ch *amqp.Channel, name string, log *blog.AuditLogger) (<-chan amqp.Delivery, error) {
+	var err error
+
+	err = ch.ExchangeDeclarePassive(
 		AmqpExchange,
 		AmqpExchangeType,
 		AmqpDurable,
@@ -65,11 +67,23 @@ func amqpSubscribe(ch *amqp.Channel, name string, log *blog.AuditLogger) (msgs <
 		AmqpNoWait,
 		nil)
 	if err != nil {
-		log.Crit(fmt.Sprintf("Could not declare exchange: %s", err))
-		return
+		log.Info(fmt.Sprintf("Exchange %s does not exist on AMQP server, attempting to create. (err=%s)", AmqpExchange, err))
+
+		err = ch.ExchangeDeclare(
+			AmqpExchange,
+			AmqpExchangeType,
+			AmqpDurable,
+			AmqpDeleteUnused,
+			AmqpInternal,
+			AmqpNoWait,
+			nil)
+		if err != nil {
+			log.Crit(fmt.Sprintf("Could not declare exchange: %s", err))
+			return nil, err
+		}
 	}
 
-	q, err := ch.QueueDeclare(
+	_, err = ch.QueueDeclare(
 		name,
 		AmqpDurable,
 		AmqpDeleteUnused,
@@ -78,22 +92,24 @@ func amqpSubscribe(ch *amqp.Channel, name string, log *blog.AuditLogger) (msgs <
 		nil)
 	if err != nil {
 		log.Crit(fmt.Sprintf("Could not declare queue: %s", err))
-		return
+		return nil, err
 	}
+
+	routingKey := name
 
 	err = ch.QueueBind(
 		name,
-		name,
+		routingKey,
 		AmqpExchange,
 		false,
 		nil)
 	if err != nil {
-		log.Crit(fmt.Sprintf("Could not bind queue: %s", err))
-		return
+		log.Crit(fmt.Sprintf("Could not bind to queue [%s]. NOTE: You may need to delete %s to re-trigger the bind attempt after fixing permissions, or manually bind the queue to %s.", name, name, routingKey))
+		return nil, err
 	}
 
-	msgs, err = ch.Consume(
-		q.Name,
+	msgs, err := ch.Consume(
+		name,
 		"",
 		AmqpAutoAck,
 		AmqpExclusive,
@@ -102,10 +118,10 @@ func amqpSubscribe(ch *amqp.Channel, name string, log *blog.AuditLogger) (msgs <
 		nil)
 	if err != nil {
 		log.Crit(fmt.Sprintf("Could not subscribe to queue: %s", err))
-		return
+		return nil, err
 	}
 
-	return
+	return msgs, err
 }
 
 // AmqpRPCServer listens on a specified queue within an AMQP channel.

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -43,17 +43,6 @@ const (
 	AmqpImmediate    = false
 )
 
-// A simplified way to get a channel for a given AMQP server
-func amqpConnect(url string) (ch *amqp.Channel, err error) {
-	conn, err := amqp.Dial(url)
-	if err != nil {
-		return
-	}
-
-	ch, err = conn.Channel()
-	return
-}
-
 // AMQPDeclareExchange attempts to declare the configured AMQP exchange,
 // returning silently if already declared, erroring if nonexistant and
 // unable to create.


### PR DESCRIPTION
Fixes #426.

- Use Passive forms of ExchangeDeclare, QueueDeclare
- Write an example AMQP configuration tool, `docs/rabbitmq_acl_configure.sh`
