### PR TITLE
Fix typo in admin-revoker

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -163,7 +163,7 @@ func main() {
 			Usage:  "Path to Boulder JSON configuration file",
 		},
 		cli.BoolFlag{
-			Name:  "deny-future",
+			Name:  "deny",
 			Usage: "Add certificate DNS names to the denied list",
 		},
 	}


### PR DESCRIPTION
The tool is looking for a flag named "deny", not "deny-future", and so it doesn't work.
This corrects the flag.
