### PR TITLE
do not update PR if coming from non-maintainer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ sudo: required
 
 before_install:
   # Github-PR-Status secret
-  - openssl aes-256-cbc -K $encrypted_53b2630f0fb4_key -iv $encrypted_53b2630f0fb4_iv -in test/github-secret.json.enc -out test/github-secret.json -d
+  - openssl aes-256-cbc -K $encrypted_53b2630f0fb4_key -iv $encrypted_53b2630f0fb4_iv -in test/github-secret.json.enc -out test/github-secret.json -d || true
 
   - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
The github-secret.json file can't be decrypted if the PR is coming from someone who is not a maintainer on boulder. So, just use the boring old status updates from TravisCI and let the tests continue to run.

This PR should succeed even though I'm not a part of the boulder project.