### PR TITLE
add TravisCI url to fancy github statuses

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -47,7 +47,8 @@ update_status() {
   if ([ "${TRAVIS}" == "true" ] && [ "x${CONTEXT}" != "x" ]) && [ -f "${GITHUB_SECRET_FILE}" ]; then
     github-pr-status --authfile $GITHUB_SECRET_FILE \
       --owner "letsencrypt" --repo "boulder" \
-      status --sha "${TRIGGER_COMMIT}" --context "${CONTEXT}" $*
+      status --sha "${TRIGGER_COMMIT}" --context "${CONTEXT}" \
+      --url "https://travis-ci.org/letsencrypt/boulder/builds/${TRAVIS_BUILD_ID}" $*
   fi
 }
 


### PR DESCRIPTION
This will create the little "Details" links on status update that links to the build failure.

At least, it should. The TRAVIS_BUILD_ID is a guess from the TravisCI env vars documentation
<http://docs.travis-ci.com/user/environment-variables/>. If it works, we should see them linking correctly in this PR.
