### PR TITLE
rename dbName to dbConnect

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -32,7 +32,7 @@ type Config struct {
 	Profile      string
 	TestMode     bool
 	DBDriver     string
-	DBName       string
+	DBConnect    string
 	SerialPrefix int
 	Key          KeyConfig
 	// LifespanOCSP is how long OCSP responses are valid for; It should be longer

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -76,7 +76,7 @@ func setupContext(context *cli.Context) (rpc.CertificateAuthorityClient, *blog.A
 	cac, err := rpc.NewCertificateAuthorityClient(caRPC)
 	cmd.FailOnError(err, "Unable to create CA client")
 
-	dbMap, err := sa.NewDbMap(c.Revoker.DBDriver, c.Revoker.DBName)
+	dbMap, err := sa.NewDbMap(c.Revoker.DBDriver, c.Revoker.DBConnect)
 	cmd.FailOnError(err, "Couldn't setup database connection")
 
 	return cac, auditlogger, dbMap

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -30,7 +30,7 @@ func main() {
 
 		blog.SetAuditLogger(auditlogger)
 
-		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBName)
+		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBConnect)
 		cmd.FailOnError(err, "Failed to create CA database")
 
 		if c.SQL.CreateTables {

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -30,7 +30,7 @@ func main() {
 
 		blog.SetAuditLogger(auditlogger)
 
-		sai, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
+		sai, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBConnect)
 		cmd.FailOnError(err, "Failed to create SA impl")
 		sai.SetSQLDebug(c.SQL.SQLDebug)
 

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -76,7 +76,7 @@ func main() {
 		// Create the components
 		wfei, err := wfe.NewWebFrontEndImpl()
 		cmd.FailOnError(err, "Unable to create WFE")
-		sa, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBName)
+		sa, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBConnect)
 		cmd.FailOnError(err, "Unable to create SA")
 		sa.SetSQLDebug(c.SQL.SQLDebug)
 

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -88,7 +88,7 @@ func main() {
 		va.DNSResolver = core.NewDNSResolverImpl(dnsTimeout, []string{c.VA.DNSResolver})
 		va.UserAgent = c.VA.UserAgent
 
-		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBName)
+		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBConnect)
 		cmd.FailOnError(err, "Failed to create CA database")
 
 		ca, err := ca.NewCertificateAuthorityImpl(cadb, c.CA, c.Common.IssuerCert)

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -132,7 +132,7 @@ func main() {
 		auditlogger.Info(app.VersionString())
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.OCSPResponder.DBDriver, c.OCSPResponder.DBName)
+		dbMap, err := sa.NewDbMap(c.OCSPResponder.DBDriver, c.OCSPResponder.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 		sa.SetSQLDebug(dbMap, c.SQL.SQLDebug)
 

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -215,7 +215,7 @@ func main() {
 		blog.SetAuditLogger(auditlogger)
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.OCSPUpdater.DBDriver, c.OCSPUpdater.DBName)
+		dbMap, err := sa.NewDbMap(c.OCSPUpdater.DBDriver, c.OCSPUpdater.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 
 		cac, closeChan := setupClients(c)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -68,8 +68,8 @@ type Config struct {
 	CA ca.Config
 
 	SA struct {
-		DBDriver string
-		DBName   string
+		DBDriver  string
+		DBConnect string
 	}
 
 	VA struct {
@@ -95,8 +95,8 @@ type Config struct {
 	}
 
 	Revoker struct {
-		DBDriver string
-		DBName   string
+		DBDriver  string
+		DBConnect string
 	}
 
 	Mail struct {
@@ -108,14 +108,14 @@ type Config struct {
 
 	OCSPResponder struct {
 		DBDriver      string
-		DBName        string
+		DBConnect     string
 		Path          string
 		ListenAddress string
 	}
 
 	OCSPUpdater struct {
 		DBDriver        string
-		DBName          string
+		DBConnect       string
 		MinTimeToExpiry string
 		ResponseLimit   int
 	}

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -2,4 +2,4 @@ These `.sql` files define the table layout, indicies, relationships, and users d
 
 ## Notes
 
-Currently, if you use MySQL / MariaDB with Boulder, you must manually append `?parseTime=true"` onto the end of the `dbName` configuration fields for each entry. This is related to [Issue #242](https://github.com/letsencrypt/boulder/issues/242).
+Currently, if you use MySQL / MariaDB with Boulder, you must manually append `?parseTime=true"` onto the end of the `dbConnect` configuration fields for each entry. This is related to [Issue #242](https://github.com/letsencrypt/boulder/issues/242).

--- a/sa/database.go
+++ b/sa/database.go
@@ -31,15 +31,15 @@ var dialectMap = map[string]interface{}{
 // It automatically maps the tables for the primary parts of Boulder around the
 // Storage Authority. This may require some further work when we use a disjoint
 // schema, like that for `certificate-authority-data.go`.
-func NewDbMap(driver string, name string) (*gorp.DbMap, error) {
+func NewDbMap(driver string, dbConnect string) (*gorp.DbMap, error) {
 	logger := blog.GetAuditLogger()
 
 	// We require this parameter for MySQL, so fail now if it is not present
-	if driver == "mysql" && !strings.Contains(name, "parseTime=true") {
-		return nil, fmt.Errorf("Database name must have parseTime=true")
+	if driver == "mysql" && !strings.Contains(dbConnect, "parseTime=true") {
+		return nil, fmt.Errorf("Database connect string must have parseTime=true")
 	}
 
-	db, err := sql.Open(driver, name)
+	db, err := sql.Open(driver, dbConnect)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func NewDbMap(driver string, name string) (*gorp.DbMap, error) {
 		return nil, err
 	}
 
-	logger.Debug(fmt.Sprintf("Connecting to database %s %s", driver, name))
+	logger.Debug(fmt.Sprintf("Connecting to database %s %s", driver, dbConnect))
 
 	dialect, ok := dialectMap[driver].(gorp.Dialect)
 	if !ok {
@@ -55,7 +55,7 @@ func NewDbMap(driver string, name string) (*gorp.DbMap, error) {
 		return nil, err
 	}
 
-	logger.Info(fmt.Sprintf("Connected to database %s %s", driver, name))
+	logger.Info(fmt.Sprintf("Connected to database %s %s", driver, dbConnect))
 
 	dbmap := &gorp.DbMap{Db: db, Dialect: dialect, TypeConverter: BoulderTypeConverter{}}
 

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -33,5 +33,5 @@ func TestForgottenDialect(t *testing.T) {
 
 func TestParseTimeRequired(t *testing.T) {
 	_, err := NewDbMap("mysql", "invalid")
-	test.AssertError(t, err, "DB name must have parseTime=true")
+	test.AssertError(t, err, "DB connect string must have parseTime=true")
 }

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -49,11 +49,11 @@ type authzModel struct {
 }
 
 // NewSQLStorageAuthority provides persistence using a SQL backend for Boulder.
-func NewSQLStorageAuthority(driver string, name string) (ssa *SQLStorageAuthority, err error) {
+func NewSQLStorageAuthority(driver string, dbConnect string) (ssa *SQLStorageAuthority, err error) {
 	logger := blog.GetAuditLogger()
 	logger.Notice("Storage Authority Starting")
 
-	dbMap, err := NewDbMap(driver, name)
+	dbMap, err := NewDbMap(driver, dbConnect)
 	if err != nil {
 		return
 	}

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -43,7 +43,7 @@
     "serialPrefix": 255,
     "profile": "ee",
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
+    "dbConnect": ":memory:",
     "testMode": true,
     "_comment": "This should only be present in testMode. In prod use an HSM.",
     "Key": {
@@ -105,7 +105,7 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:"
+    "dbConnect": ":memory:"
   },
 
   "va": {
@@ -121,19 +121,19 @@
 
   "revoker": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:"
+    "dbConnect": ":memory:"
   },
 
   "ocspResponder": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
+    "dbConnect": ":memory:",
     "path": "/",
     "listenAddress": "localhost:4001"
   },
 
   "ocspUpdater": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
+    "dbConnect": ":memory:",
     "minTimeToExpiry": "72h"
   },
 

--- a/test/boulder-pkcs11-example-config.json
+++ b/test/boulder-pkcs11-example-config.json
@@ -38,7 +38,7 @@
     "serialPrefix": 255,
     "profile": "ee",
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
+    "dbConnect": ":memory:",
     "testMode": true,
     "_comment": "This should only be present in testMode. In prod use an HSM.",
     "expiry": "2160h",
@@ -96,7 +96,7 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:"
+    "dbConnect": ":memory:"
   },
 
   "sql": {
@@ -106,19 +106,19 @@
 
   "revoker": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:"
+    "dbConnect": ":memory:"
   },
 
   "ocspResponder": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
+    "dbConnect": ":memory:",
     "path": "/",
     "listenAddress": "localhost:4001"
   },
 
   "ocspUpdater": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
+    "dbConnect": ":memory:",
     "minTimeToExpiry": "72h"
   },
 

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -38,7 +38,7 @@
     "serialPrefix": 255,
     "profile": "ee",
     "dbDriver": "sqlite3",
-    "dbName": ":memory:",
+    "dbConnect": ":memory:",
     "testMode": true,
     "_comment": "This should only be present in testMode. In prod use an HSM.",
     "Key": {
@@ -100,7 +100,7 @@
 
   "sa": {
     "dbDriver": "sqlite3",
-    "dbName": ":memory:"
+    "dbConnect": ":memory:"
   },
 
   "va": {


### PR DESCRIPTION
Found while exploring the problem space of #453. The configuration variable is actually a connection string, not a database name, and it was a bit confusing.