### PR TITLE
Fix hyphens in letsencrypt install command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - cd "$LETSENCRYPT_PATH"
   - sudo ./bootstrap/debian.sh
   - virtualenv --no-site-packages -p python2 ./venv
-  - travis_retry ./venv/bin/pip install -r requirements.txt -e acme -e . -e letsencrypt_apache -e letsencrypt_nginx
+  - travis_retry ./venv/bin/pip install -r requirements.txt -e acme -e . -e letsencrypt-apache -e letsencrypt-nginx
   - "cd -"
 
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN ./bootstrap/debian.sh && \
     /tmp/* \
     /var/tmp/*
 RUN virtualenv --no-site-packages -p python2 venv && \
-  ./venv/bin/pip install -r requirements.txt -e acme -e .[dev,docs,testing] -e letsencrypt_apache -e letsencrypt_nginx
+  ./venv/bin/pip install -r requirements.txt -e acme -e .[dev,docs,testing] -e letsencrypt-apache -e letsencrypt-nginx
 
 # Copy in the Boulder sources
 COPY . /go/src/github.com/letsencrypt/boulder

--- a/test.sh
+++ b/test.sh
@@ -196,7 +196,7 @@ if [ -z "$LETSENCRYPT_PATH" ]; then
 
   cd $LETSENCRYPT_PATH
   run virtualenv --no-site-packages -p python2 ./venv && \
-    ./venv/bin/pip install -r requirements.txt -e acme -e . -e letsencrypt_apache -e letsencrypt_nginx || exit 1
+    ./venv/bin/pip install -r requirements.txt -e acme -e . -e letsencrypt-apache -e letsencrypt-nginx || exit 1
   cd -
 fi
 


### PR DESCRIPTION
Corresponds to https://github.com/letsencrypt/letsencrypt/pull/600.

Current integration should still work because of https://github.com/letsencrypt/letsencrypt/commit/c85fa02495394c5fdbfbfe655568e7a91f1c2cd2, but I would like to revert that change once Boulder is updated.