### PR TITLE
harden test.sh and amqp-integration-test.py

### DIFF
--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -21,6 +21,18 @@ def die(status):
 
 processes = []
 
+
+class ProcInfo:
+    """
+        Args:
+            cmd (str): The command that was run
+            proc(subprocess.Popen): The Popen of the command run
+    """
+
+    def __init__(self, cmd, proc):
+        self.cmd = cmd
+        self.proc = proc
+
 def run(path):
     global processes
     binary = os.path.join(tempdir, os.path.basename(path))
@@ -28,9 +40,11 @@ def run(path):
     print(cmd)
     if subprocess.Popen(cmd, shell=True).wait() != 0:
         die(ExitStatus.Error)
-    processes.append(subprocess.Popen('''
-        exec %s --config test/boulder-test-config.json
-        ''' % binary, shell=True))
+    runCmd = "exec %s --config test/boulder-test-config.json" % binary
+    print(runCmd)
+    info = ProcInfo(runCmd, subprocess.Popen(runCmd, shell=True))
+    processes.append(info)
+    return info
 
 def start():
     run('./cmd/boulder-wfe')
@@ -79,15 +93,25 @@ def run_client_tests():
 
 try:
     start()
+    busted = []
+    for pinfo in processes:
+        if pinfo.proc.poll() is not None:
+            busted.append(pinfo)
+    if len(busted) != 0:
+        print "\n\nThese processes didn't start up successfully (check above for their output):"
+        for pinfo in busted:
+            print "\t'%s' exited with %d" % (pinfo.cmd, pinfo.proc.returncode)
+        sys.exit(1)
+
     run_node_test()
     run_client_tests()
 except Exception as e:
     exit_status = ExitStatus.Error
     print e
 finally:
-    for p in processes:
-        if p.poll() is None:
-            p.kill()
+    for pinfo in processes:
+        if pinfo.proc.poll() is None:
+            pinfo.proc.kill()
         else:
             exit_status = 1
 


### PR DESCRIPTION
amqp-integration-test.py gains a way to print out what processes failed to start.

test.sh gains:

 * the ability to continue the build correctly if LETSENCRYPT_PATH was provided but does not exist on disk.
 * an explanatory exit message if the LETSENCRYPT_PATH does exist, but there is not finished build in it.
 * a working detection for a python 2.7 binary on OS X

Discovered while trying to add some things to the config structs of the boulder services.