### PR TITLE
run tests in CI with the race detector on

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -175,10 +175,10 @@ end_context #test/gofmt
 # Ensure SQLite is installed so we don't recompile it each time
 go install ./Godeps/_workspace/src/github.com/mattn/go-sqlite3
 
-if [ "${TRAVIS}" == "true" ] ; then
+if [ "${TRAVIS}" == "true" ] || [ "${SKIP_UNIT_TESTS}" != "1" ] ; then
   # Run each test by itself for Travis, so we can get coverage
   for dir in ${TESTDIRS}; do
-    run go test -tags pkcs11 -covermode=count -coverprofile=${dir}.coverprofile ./${dir}/
+    run go test -tags pkcs11 -race -covermode=count -coverprofile=${dir}.coverprofile ./${dir}/
   done
 
   # Gather all the coverprofiles
@@ -196,7 +196,11 @@ else
     dirlist="${dirlist} ./${dir}/"
   done
 
-  run go test -tags pkcs11 ${dirlist}
+  run go test $GOTESTFLAGS -tags pkcs11 ${dirlist}
+fi
+
+if [ "${SKIP_UNIT_TESTS}" = "1" ]; then
+  echo "Skipping unit tests."
 fi
 
 # If the unittests failed, exit before trying to run the integration test.
@@ -205,6 +209,11 @@ if [ ${FAILURE} != 0 ]; then
   echo "---          A unit test failed.               ---"
   echo "--- Stopping before running integration tests. ---"
   echo "--------------------------------------------------"
+  exit ${FAILURE}
+fi
+
+if [ "${SKIP_INTEGRATION_TESTS}" = "1" ]; then
+  echo "Skipping integration tests."
   exit ${FAILURE}
 fi
 

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -36,7 +36,7 @@ class ProcInfo:
 def run(path):
     global processes
     binary = os.path.join(tempdir, os.path.basename(path))
-    cmd = 'go build -tags pkcs11 -o %s %s' % (binary, path)
+    cmd = 'GORACE="halt_on_error=1" go build -tags pkcs11 -race -o %s %s' % (binary, path)
     print(cmd)
     if subprocess.Popen(cmd, shell=True).wait() != 0:
         die(ExitStatus.Error)


### PR DESCRIPTION
The race detector has found at least one race in our current code. See issue #465. Turn it on for the unit and integration tests running in TravisCI.
    
Also, allow the local user to add new test flags with the `GOTESTFLAGS` environment variable.
 
To ease speed of debugging issues, the ability to skip the unit or integration tests is also provided.