### PR TITLE
Fixes #441: Vet issue for int64 value

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -347,7 +347,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(response http.ResponseWriter, reques
 
 	if existingReg, err := wfe.SA.GetRegistrationByKey(*key); err == nil {
 		logEvent.Error = "Registration key is already in use"
-		response.Header().Set("Location", fmt.Sprintf("%s%d", wfe.RegBase, existingReg.ID))
+		response.Header().Set("Location", fmt.Sprintf("%s%v", wfe.RegBase, existingReg.ID))
 		wfe.sendError(response, logEvent.Error, nil, http.StatusConflict)
 		return
 	}


### PR DESCRIPTION
Issue as discovered on golang from April:

```
go version devel +46b4f67 Thu Apr 16 20:01:13 2015 +0000 darwin/amd64
go vet wfe/web-front-end.go
wfe/web-front-end.go:350: arg existingReg.ID for printf verb %d of wrong type: string
exit status 1
```