### PR TITLE
Log redirects encountered during HTTP validation. Fixes #414

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -118,7 +118,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 		DisableKeepAlives: true,
 	}
 	logRedirect := func(req *http.Request, via []*http.Request) error {
-		va.log.Notice(fmt.Sprintf("validateSimpleHTTP [%s] redirect from %q to %q", identifier, via[len(via)-1].URL.String(), req.URL.String()))
+		va.log.Info(fmt.Sprintf("validateSimpleHTTP [%s] redirect from %q to %q", identifier, via[len(via)-1].URL.String(), req.URL.String()))
 		return nil
 	}
 	client := http.Client{

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -117,9 +117,14 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 		// connection immediately.
 		DisableKeepAlives: true,
 	}
+	logRedirect := func(req *http.Request, via []*http.Request) error {
+		va.log.Notice(fmt.Sprintf("validateSimpleHTTP [%s] redirect from %q to %q", identifier, via[len(via)-1].URL.String(), req.URL.String()))
+		return nil
+	}
 	client := http.Client{
-		Transport: tr,
-		Timeout:   5 * time.Second,
+		Transport:     tr,
+		CheckRedirect: logRedirect,
+		Timeout:       5 * time.Second,
 	}
 	httpResponse, err := client.Do(httpRequest)
 

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -235,18 +235,6 @@ func TestSimpleHttpTLS(t *testing.T) {
 	test.AssertEquals(t, logs[0].Priority, syslog.LOG_NOTICE)
 }
 
-func TestSimpleHttpRedirect(t *testing.T) {
-	va := NewValidationAuthorityImpl(true)
-	va.DNSResolver = &mocks.MockDNS{}
-
-	stopChan := make(chan bool, 1)
-	waitChan := make(chan bool, 1)
-	go simpleSrv(t, expectedToken, stopChan, waitChan, true)
-	defer func() { stopChan <- true }()
-	<-waitChan
-
-}
-
 func TestSimpleHttp(t *testing.T) {
 	va := NewValidationAuthorityImpl(true)
 	va.DNSResolver = &mocks.MockDNS{}

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -276,14 +276,15 @@ func TestSimpleHttp(t *testing.T) {
 	finChall, err = va.validateSimpleHTTP(ident, chall)
 	test.AssertEquals(t, finChall.Status, core.StatusValid)
 	test.AssertNotError(t, err, chall.Path)
-	// TODO: verify the redirect was logged.
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/301" to ".*/valid"`)), 1)
 
 	log.Clear()
 	chall.Path = pathFound
 	finChall, err = va.validateSimpleHTTP(ident, chall)
 	test.AssertEquals(t, finChall.Status, core.StatusValid)
 	test.AssertNotError(t, err, chall.Path)
-	// TODO: verify two redirects were logged.
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/302" to ".*/301"`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/301" to ".*/valid"`)), 1)
 
 	log.Clear()
 	chall.Path = path404


### PR DESCRIPTION
I don't see a way to mock the audit logger, so I didn't test that the logs were emitted -- only that the redirects were followed. Is there an existing way (or open issue)? Should this block on testability?

If the redirect target is improperly encoded, the CheckRedirect function doesn't get called. VA does log the usual Debug message about the error (`...: Get %: parse %: invalid URL escape "%"`) but the fact that a 30x was being followed is not logged explicitly in the way that a properly encoded one is. If this is desired, we can trap the `EscapeError` coming from `Do()`. OTOH, the validation fails in such cases, so perhaps logging the redirect is not critical?

A valid URL that redirects to an invalid URL results in "connection problem", not "malformed request". This is correct -- the request itself wasn't malformed, merely impossible to carry out -- right?

"Notice" loglevel suitable?