### PR TITLE
Add tiny DNS server for client integration tests

### DIFF
--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -33,39 +33,26 @@ class ProcInfo:
         self.cmd = cmd
         self.proc = proc
 
-def run(path):
+def run(path, args=""):
     global processes
     binary = os.path.join(tempdir, os.path.basename(path))
     cmd = 'GORACE="halt_on_error=1" go build -tags pkcs11 -race -o %s %s' % (binary, path)
     print(cmd)
     if subprocess.Popen(cmd, shell=True).wait() != 0:
         die(ExitStatus.Error)
-    runCmd = "exec %s --config test/boulder-test-config.json" % binary
-    print(runCmd)
-    info = ProcInfo(runCmd, subprocess.Popen(runCmd, shell=True))
-    processes.append(info)
-    return info
-
-def runDNS():
-    global processes
-    binary = os.path.join(tempdir, os.path.basename("./test/dns-test-srv"))
-    cmd = 'GORACE="halt_on_error=1" go build -race -o %s %s' % (binary, "./test/dns-test-srv")
-    print(cmd)
-    if subprocess.Popen(cmd, shell=True).wait() != 0:
-        die(ExitStatus.Error)
-    runCmd = "exec %s" % binary
+    runCmd = "exec %s %s" % (binary, args)
     print(runCmd)
     info = ProcInfo(runCmd, subprocess.Popen(runCmd, shell=True))
     processes.append(info)
     return info
 
 def start():
-    run('./cmd/boulder-wfe')
-    run('./cmd/boulder-ra')
-    run('./cmd/boulder-sa')
-    run('./cmd/boulder-ca')
-    run('./cmd/boulder-va')
-    runDNS()
+    run('./cmd/boulder-wfe', '--config test/boulder-test-config.json')
+    run('./cmd/boulder-ra', '--config test/boulder-test-config.json')
+    run('./cmd/boulder-sa', '--config test/boulder-test-config.json')
+    run('./cmd/boulder-ca', '--config test/boulder-test-config.json')
+    run('./cmd/boulder-va', '--config test/boulder-test-config.json')
+    run('./test/dns-test-srv')
 
 def run_node_test():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -46,12 +46,26 @@ def run(path):
     processes.append(info)
     return info
 
+def runDNS():
+    global processes
+    binary = os.path.join(tempdir, os.path.basename("./test/dns-test-srv"))
+    cmd = 'GORACE="halt_on_error=1" go build -race -o %s %s' % (binary, "./test/dns-test-srv")
+    print(cmd)
+    if subprocess.Popen(cmd, shell=True).wait() != 0:
+        die(ExitStatus.Error)
+    runCmd = "exec %s" % binary
+    print(runCmd)
+    info = ProcInfo(runCmd, subprocess.Popen(runCmd, shell=True))
+    processes.append(info)
+    return info
+
 def start():
     run('./cmd/boulder-wfe')
     run('./cmd/boulder-ra')
     run('./cmd/boulder-sa')
     run('./cmd/boulder-ca')
     run('./cmd/boulder-va')
+    runDNS()
 
 def run_node_test():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/test/boulder-test-config.json
+++ b/test/boulder-test-config.json
@@ -111,7 +111,7 @@
   },
 
   "va": {
-    "dnsResolver": "8.8.8.8:53",
+    "dnsResolver": "127.0.0.1:8053",
     "dnsTimeout": "10s",
     "userAgent": "boulder",
     "debugAddr": "localhost:8004"

--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/miekg/dns"
+)
+
+func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
+	defer w.Close()
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Compress = false
+
+	for _, q := range r.Question {
+		fmt.Printf("dns-srv: Query -- [%s] %s\n", q.Name, dns.TypeToString[q.Qtype])
+		if q.Qtype == dns.TypeA {
+			record := new(dns.A)
+			record.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0}
+			record.A = net.ParseIP("127.0.0.1")
+
+			m.Answer = append(m.Answer, record)
+		} else if q.Qtype == dns.TypeMX {
+			record := new(dns.MX)
+			record.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 0}
+			record.Mx = "mail." + q.Name
+			record.Preference = 10
+
+			m.Answer = append(m.Answer, record)
+		}
+
+	}
+
+	w.WriteMsg(m)
+	return
+}
+
+func serveTestResolver() {
+	dns.HandleFunc(".", dnsHandler)
+	server := &dns.Server{Addr: "127.0.0.1:8053", Net: "udp", ReadTimeout: time.Millisecond, WriteTimeout: time.Millisecond}
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}()
+}
+
+func main() {
+	forever := make(chan bool, 1)
+	fmt.Println("dns-srv: Starting test DNS server")
+	serveTestResolver()
+	<-forever
+}

--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -1,3 +1,8 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package main
 
 import (
@@ -16,13 +21,14 @@ func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 
 	for _, q := range r.Question {
 		fmt.Printf("dns-srv: Query -- [%s] %s\n", q.Name, dns.TypeToString[q.Qtype])
-		if q.Qtype == dns.TypeA {
+		switch q.Qtype {
+		case dns.TypeA:
 			record := new(dns.A)
 			record.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0}
 			record.A = net.ParseIP("127.0.0.1")
 
 			m.Answer = append(m.Answer, record)
-		} else if q.Qtype == dns.TypeMX {
+		case dns.TypeMX:
 			record := new(dns.MX)
 			record.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 0}
 			record.Mx = "mail." + q.Name
@@ -30,7 +36,6 @@ func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 
 			m.Answer = append(m.Answer, record)
 		}
-
 	}
 
 	w.WriteMsg(m)
@@ -50,8 +55,8 @@ func serveTestResolver() {
 }
 
 func main() {
-	forever := make(chan bool, 1)
 	fmt.Println("dns-srv: Starting test DNS server")
 	serveTestResolver()
+	forever := make(chan bool, 1)
 	<-forever
 }

--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -1,4 +1,4 @@
-// Copyright 2014 ISRG.  All rights reserved
+// Copyright 2015 ISRG.  All rights reserved
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -24,13 +24,23 @@ func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 		switch q.Qtype {
 		case dns.TypeA:
 			record := new(dns.A)
-			record.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0}
+			record.Hdr = dns.RR_Header{
+				Name:   q.Name,
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    0,
+			}
 			record.A = net.ParseIP("127.0.0.1")
 
 			m.Answer = append(m.Answer, record)
 		case dns.TypeMX:
 			record := new(dns.MX)
-			record.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 0}
+			record.Hdr = dns.RR_Header{
+				Name:   q.Name,
+				Rrtype: dns.TypeMX,
+				Class:  dns.ClassINET,
+				Ttl:    0,
+			}
 			record.Mx = "mail." + q.Name
 			record.Preference = 10
 
@@ -44,7 +54,12 @@ func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 
 func serveTestResolver() {
 	dns.HandleFunc(".", dnsHandler)
-	server := &dns.Server{Addr: "127.0.0.1:8053", Net: "udp", ReadTimeout: time.Millisecond, WriteTimeout: time.Millisecond}
+	server := &dns.Server{
+		Addr:         "127.0.0.1:8053",
+		Net:          "udp",
+		ReadTimeout:  time.Millisecond,
+		WriteTimeout: time.Millisecond,
+	}
 	go func() {
 		err := server.ListenAndServe()
 		if err != nil {


### PR DESCRIPTION
Sorry for stepping on your toes @jsha but I saw your idea and jumped on it. Currently this only will respond to CAA and CNAME records as MX and A/AAAA are currently handled by `net.LookupMX` and `http.Client` respectively and will use the system resolver (#495 or #470). With those issues closed we can update this PR and finally close out #420.