### PR TITLE
Fix gofmt test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -25,7 +25,7 @@ TESTDIRS="analysis \
 # Assume first it's the travis commit (for builds of master), unless we're
 # a PR, when it's actually the first parent.
 TRIGGER_COMMIT=${TRAVIS_COMMIT}
-if [ "${TRAVIS_PULL_REQUEST}" != "false" ] ; then
+if [ "x${TRAVIS_PULL_REQUEST}" != "x" ] ; then
   revs=$(git rev-list --parents -n 1 HEAD)
   # The trigger commit is the last ID in the space-delimited rev-list
   TRIGGER_COMMIT=${revs##* }
@@ -53,33 +53,33 @@ update_status() {
 }
 
 run() {
-  echo "$*"
-  $* 2>&1
+  echo "$@"
+  "$@" 2>&1
   local status=$?
 
   if [ ${status} -eq 0 ]; then
     update_status --state success
-    echo "Success: $*"
+    echo "Success: $@"
   else
     FAILURE=1
     update_status --state failure
-    echo "[!] FAILURE: $*"
+    echo "[!] FAILURE: $@"
   fi
 
   return ${status}
 }
 
 run_and_comment() {
-  if [ "x${TRAVIS}" = "x" ] || [ "${TRAVIS_PULL_REQUEST}" == "false" ] || [ ! -f "${GITHUB_SECRET_FILE}"] ; then
-    run $*
+  if [ "x${TRAVIS}" = "x" ] || [ "${TRAVIS_PULL_REQUEST}" == "false" ] || [ ! -f "${GITHUB_SECRET_FILE}" ] ; then
+    run "$@"
   else
-    result=$(run $*)
+    result=$(run "$@")
     local status=$?
     # Only send a comment if exit code > 0
     if [ ${status} -ne 0 ] ; then
       echo $'```\n'${result}$'\n```' | github-pr-status --authfile $GITHUB_SECRET_FILE \
         --owner "letsencrypt" --repo "boulder" \
-        comment --pr ${TRAVIS_PULL_REQUEST}
+        comment --pr "${TRAVIS_PULL_REQUEST}" -b -
     fi
   fi
 }
@@ -168,29 +168,26 @@ end_context #test/golint
 # Ensure all files are formatted per the `go fmt` tool
 #
 start_context "test/gofmt"
-unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1 gofmt -l)
-if [ "x${unformatted}" == "x" ] ; then
-  update_status --state success
-else
+check_gofmt() {
+  unformatted=$(find . -name "*.go" -not -path "./Godeps/*" -print | xargs -n1 gofmt -l)
+  if [ "x${unformatted}" == "x" ] ; then
+    return 0
+  else
+    V="Unformatted files found.
+    Please run 'go fmt' on each of these files and amend your commit to continue."
 
-  V="Unformatted files found.
-  Please run 'go fmt' on each of these files and amend your commit to continue."
+    for f in ${unformatted}; do
+      V=$(printf "%s\n - %s" "${V}" "${f}")
+    done
 
-  for f in ${unformatted}; do
-    V=$(printf "%s\n - %s" "${V}" "${f}")
-  done
-
-  # Print to stdout
-  printf "%s\n\n" "${V}"
-  update_status --state failure --description "${V}"
-
-  # Post a comment with the unformatted list
-  if [ "${TRAVIS_PULL_REQUEST}" != "false" ] ; then
-    run_and_comment printf "%s\n\n" "${V}"
+    # Print to stdout
+    printf "%s\n\n" "${V}"
+    [ "${TRAVIS}" == "true" ] || exit 1 # Stop here if running locally
+    return 1
   fi
+}
 
-  [ "${TRAVIS}" == "true" ] || exit 1 # Stop here if running locally
-fi
+run_and_comment check_gofmt
 end_context #test/gofmt
 
 #


### PR DESCRIPTION
Previously, the gofmt test was not properly causing Travis to fail, because it
would call run_and_comment on a printf command, which always succeeded. Instead,
we create a function for the gofmt check that outputs on stdout and returns a
meaningful status code, then call run_and_comment on that.

Also fix up a few places that expected TRAVIS_PULL_REQUEST=false, which doesn't
happen when running locally.

This is now ready for review.