### PR TITLE
remove incorrect uses of %v, use specific verbs

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -11,12 +11,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 	"net"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose"
 )
 
 // AcmeStatus defines the state of a given authorization
@@ -81,7 +82,7 @@ const (
 )
 
 func (pd *ProblemDetails) Error() string {
-	return fmt.Sprintf("%v :: %v", pd.Type, pd.Detail)
+	return fmt.Sprintf("%s :: %s", pd.Type, pd.Detail)
 }
 
 func cmpStrSlice(a, b []string) bool {

--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -183,7 +183,7 @@ func caller(level int) string {
 func (log *AuditLogger) AuditPanic() {
 	if err := recover(); err != nil {
 		buf := make([]byte, 8192)
-		log.Audit(fmt.Sprintf("Panic caused by err: %v", err))
+		log.Audit(fmt.Sprintf("Panic caused by err: %s", err))
 
 		runtime.Stack(buf, false)
 		log.Audit(fmt.Sprintf("Stack Trace (Current frame) %s", buf))

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -153,7 +153,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 		return authz, err
 	}
 	// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
-	ra.log.Audit(fmt.Sprintf("Checked CAA records for %s, registration ID %d [Present: %v, Valid for issuance: %v]", identifier.Value, regID, present, valid))
+	ra.log.Audit(fmt.Sprintf("Checked CAA records for %s, registration ID %d [Present: %t, Valid for issuance: %t]", identifier.Value, regID, present, valid))
 	if !valid {
 		err = errors.New("CAA check for identifier failed")
 		return authz, err

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -43,7 +43,6 @@ const (
 	BuildIDPath    = "/build"
 )
 
-// WebFrontEndImpl represents a Boulder web service and its resources
 type WebFrontEndImpl struct {
 	RA    core.RegistrationAuthority
 	SA    core.StorageGetter
@@ -289,15 +288,16 @@ func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]
 		return nil, nil, reg, errors.New("No body on POST")
 	}
 
-	body, err := ioutil.ReadAll(request.Body)
+	bodyBytes, err := ioutil.ReadAll(request.Body)
 	if err != nil {
 		return nil, nil, reg, err
 	}
 
+	body := string(bodyBytes)
 	// Parse as JWS
-	parsedJws, err := jose.ParseSigned(string(body))
+	parsedJws, err := jose.ParseSigned(body)
 	if err != nil {
-		wfe.log.Debug(fmt.Sprintf("Parse error reading JWS: %v", err))
+		wfe.log.Debug(fmt.Sprintf("Parse error reading JWS: %#v", err))
 		return nil, nil, reg, err
 	}
 
@@ -312,7 +312,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(request *http.Request, regCheck bool) ([]
 		return nil, nil, reg, errors.New("Too many signatures on POST")
 	}
 	if len(parsedJws.Signatures) == 0 {
-		wfe.log.Debug(fmt.Sprintf("POST not signed: %v", parsedJws))
+		wfe.log.Debug(fmt.Sprintf("POST not signed: %s", body))
 		return nil, nil, reg, errors.New("POST not signed")
 	}
 	key := parsedJws.Signatures[0].Header.JsonWebKey


### PR DESCRIPTION
Not all of these uses will give bad data but are bad form to continue
using by default.

However there is one clear case I correct here: The parsed JWS is never
going to get the full data that JC wants because it contains many
pointers and, at the same times, does not have a String() method on it
or the pointer field types that can do a better job.

Updates #492