### PR TITLE
Update cfssl to latest master.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,51 +12,51 @@
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/auth",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/config",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs11key",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs12",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs7",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/csr",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/errors",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/info",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/log",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer",
-			"Rev": "fd649feb9eb317e3ed24afee0d92c0ea55bf4a33"
+			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
 		},
 		{
 			"ImportPath": "github.com/codegangsta/cli",

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/config/config.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/config/config.go
@@ -391,6 +391,7 @@ var KeyUsage = map[string]x509.KeyUsage{
 	"digital signature":   x509.KeyUsageDigitalSignature,
 	"content committment": x509.KeyUsageContentCommitment,
 	"key encipherment":    x509.KeyUsageKeyEncipherment,
+	"key agreement":       x509.KeyUsageKeyAgreement,
 	"data encipherment":   x509.KeyUsageDataEncipherment,
 	"cert sign":           x509.KeyUsageCertSign,
 	"crl sign":            x509.KeyUsageCRLSign,

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/crypto/pkcs11key/pkcs11key.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/crypto/pkcs11key/pkcs11key.go
@@ -1,4 +1,4 @@
-// +build pkcs11
+// +build !nopkcs11
 
 // Package pkcs11key implements crypto.Signer for PKCS #11 private
 // keys. Currently, only RSA keys are support.
@@ -131,7 +131,10 @@ func New(module, slot, pin, privLabel string) (ps *PKCS11Key, err error) {
 		ps.Destroy()
 		return
 	}
-	ps.publicKey = rsa.PublicKey{n, e}
+	ps.publicKey = rsa.PublicKey{
+		N: n,
+		E: e,
+	}
 
 	return
 }

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/pkcs11/pkcs11.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/pkcs11/pkcs11.go
@@ -1,8 +1,7 @@
-// Package pkcs11 in the ocsp directory provides a way to construct a
-// PKCS#11-based OCSP signer. It is only available in binaries built with the
-// pkcs11 tag, i.e. `go build -tags pkcs11 ./cmd/cfssl`.
-// +build pkcs11
+// +build !nopkcs11
 
+// Package pkcs11 in the ocsp directory provides a way to construct a
+// PKCS#11-based OCSP signer.
 package pkcs11
 
 import (
@@ -18,7 +17,7 @@ import (
 // Enabled is set to true if PKCS #11 support is present.
 const Enabled = true
 
-// New returns a new PKCS #11 signer.
+// NewPKCS11Signer returns a new PKCS #11 signer.
 func NewPKCS11Signer(cfg ocspConfig.Config) (ocsp.Signer, error) {
 	log.Debugf("Loading PKCS #11 module %s", cfg.PKCS11.Module)
 	certData, err := ioutil.ReadFile(cfg.CACertFile)

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/pkcs11/pkcs11_stub.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/pkcs11/pkcs11_stub.go
@@ -1,4 +1,4 @@
-// +build !pkcs11
+// +build nopkcs11
 
 package pkcs11
 

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/pkcs11/pkcs11.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/pkcs11/pkcs11.go
@@ -1,4 +1,4 @@
-// +build pkcs11
+// +build !nopkcs11
 
 package pkcs11
 

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/pkcs11/pkcs11_stub.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/pkcs11/pkcs11_stub.go
@@ -1,4 +1,4 @@
-// +build !pkcs11
+// +build nopkcs11
 
 package pkcs11
 


### PR DESCRIPTION
This changes the default pkcs11 tag so pkcs11 is included by default.
This will let us remove -tags pkcs11 from our build scripts.