### PR TITLE
remove pkcs11 tag for build and test scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN virtualenv --no-site-packages -p python2 venv && \
 COPY . /go/src/github.com/letsencrypt/boulder
 
 # Build Boulder
-RUN go install -tags pkcs11 \
+RUN go install \
   github.com/letsencrypt/boulder/cmd/activity-monitor \
   github.com/letsencrypt/boulder/cmd/boulder \
   github.com/letsencrypt/boulder/cmd/boulder-ca \

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ pre:
 # Compile each of the binaries
 $(OBJECTS): pre
 	@echo [go] bin/$@
-	@go build -tags pkcs11 -o ./bin/$@ -ldflags \
+	@go build -o ./bin/$@ -ldflags \
 		"-X $(BUILD_ID_VAR) '$(BUILD_ID)' -X $(BUILD_TIME_VAR) '$(BUILD_TIME)' \
 		 -X $(BUILD_HOST_VAR) '$(BUILD_HOST)'" \
 		cmd/$@/main.go

--- a/README.md
+++ b/README.md
@@ -123,14 +123,10 @@ To update dependencies:
 # Disable insecure fallback by blocking port 80.
 sudo /sbin/iptables -A OUTPUT -p tcp --dport 80 -j DROP
 # Fetch godep
-go get https://github.com/tools/godep.git
-# Pull in the tags branch and install
-cd $GOPATH/src/github.com/tools/godep
-git pull https://github.com/jnfeinstein/godep.git jnfeinstein
-go install
-
+go get -u https://github.com/tools/godep
 # Update to the latest version of a dependency. Alternately you can cd to the
-# directory under GOPATH and check out a specific revision.
+# directory under GOPATH and check out a specific revision. Here's an example
+# using cfssl:
 go get -u github.com/cloudflare/cfssl/...
 # Update the Godep config to the appropriate version.
 godep update github.com/cloudflare/cfssl/...

--- a/README.md
+++ b/README.md
@@ -117,11 +117,6 @@ easier](https://groups.google.com/forum/m/#!topic/golang-dev/nMWoEAG55v8)
 and to [avoid insecure fallback in go
 get](https://github.com/golang/go/issues/9637).
 
-We need to use the build tag 'pkcs11' to really pull in all our dependencies.
-To do this, you'll need to pull and install this godep branch, which supports
-build tags: https://github.com/tools/godep/pull/117/files. NOTE: If you skip
-this step, godep will delete some of the vendorized dependencies.
-
 To update dependencies:
 
 ```
@@ -141,7 +136,7 @@ go get -u github.com/cloudflare/cfssl/...
 godep update github.com/cloudflare/cfssl/...
 # Save the dependencies, rewriting any internal or external dependencies that
 # may have been added.
-godep save -r -tags pkcs11 ./...
+godep save -r ./...
 git add Godeps
 git commit
 # Assuming you had no other iptables rules, re-enable port 80.

--- a/start.py
+++ b/start.py
@@ -20,7 +20,7 @@ if config is None:
 
 def run(path):
     binary = os.path.join(tempdir, os.path.basename(path))
-    cmd = 'go build -tags pkcs11 -o %s %s' % (binary, path)
+    cmd = 'go build -o %s %s' % (binary, path)
     print(cmd)
     if subprocess.Popen(cmd, shell=True).wait() != 0:
         sys.exit(1)

--- a/start.sh
+++ b/start.sh
@@ -7,4 +7,4 @@ fi
 # Kill all children on exit.
 export BOULDER_CONFIG=${BOULDER_CONFIG:-test/boulder-config.json}
 
-exec go run -tags pkcs11 ./cmd/boulder/main.go
+exec go run ./cmd/boulder/main.go

--- a/test.sh
+++ b/test.sh
@@ -122,7 +122,7 @@ function run_unit_tests() {
   if [ "${TRAVIS}" == "true" ]; then
     # Run each test by itself for Travis, so we can get coverage
     for dir in ${TESTDIRS}; do
-      run go test -tags pkcs11 -race -covermode=count -coverprofile=${dir}.coverprofile ./${dir}/
+      run go test -race -covermode=count -coverprofile=${dir}.coverprofile ./${dir}/
     done
 
     # Gather all the coverprofiles
@@ -134,7 +134,7 @@ function run_unit_tests() {
     [ -e $GOBIN/goveralls ] && $GOBIN/goveralls -coverprofile=gover.coverprofile -service=travis-ci
   else
     # Run all the tests together if local, for speed
-    run go test $GOTESTFLAGS -tags pkcs11 ./...
+    run go test $GOTESTFLAGS ./...
   fi
 }
 

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -36,7 +36,7 @@ class ProcInfo:
 def run(path, args=""):
     global processes
     binary = os.path.join(tempdir, os.path.basename(path))
-    cmd = 'GORACE="halt_on_error=1" go build -tags pkcs11 -race -o %s %s' % (binary, path)
+    cmd = 'GORACE="halt_on_error=1" go build -race -o %s %s' % (binary, path)
     print(cmd)
     if subprocess.Popen(cmd, shell=True).wait() != 0:
         die(ExitStatus.Error)

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -17,7 +17,7 @@ def die():
     sys.exit(1)
 
 def build(path):
-    cmd = 'go build -tags pkcs11 -o %s/%s %s' % (tempdir, os.path.basename(path), path)
+    cmd = 'go build -o %s/%s %s' % (tempdir, os.path.basename(path), path)
     print(cmd)
     if subprocess.Popen(cmd, shell=True).wait() != 0:
         die()


### PR DESCRIPTION
With #525 in place, we no longer need to worry about setting the pkcs11 tag everywhere.