### PR TITLE
Fix authz always failing when CAA record is not present + fix CAA lookup algorithm per RFC

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -132,7 +132,7 @@ func (dnsResolver *DNSResolverImpl) LookupCNAME(hostname string) (string, time.D
 		return "", 0, err
 	}
 	if r.Rcode == dns.RcodeNXRrset || r.Rcode == dns.RcodeNameError {
-		return "", 0, nil
+		return "", rtt, nil
 	}
 	if r.Rcode != dns.RcodeSuccess {
 		err = fmt.Errorf("DNS failure: %d-%s for CNAME query", r.Rcode, dns.RcodeToString[r.Rcode])
@@ -155,7 +155,7 @@ func (dnsResolver *DNSResolverImpl) LookupDNAME(hostname string) (string, time.D
 		return "", 0, err
 	}
 	if r.Rcode == dns.RcodeNXRrset || r.Rcode == dns.RcodeNameError {
-		return "", 0, nil
+		return "", rtt, nil
 	}
 	if r.Rcode != dns.RcodeSuccess {
 		err = fmt.Errorf("DNS failure: %d-%s for DNAME query", r.Rcode, dns.RcodeToString[r.Rcode])

--- a/core/dns_test.go
+++ b/core/dns_test.go
@@ -230,7 +230,7 @@ func TestDNSLookupCAA(t *testing.T) {
 
 	caas, _, err = obj.LookupCAA("cname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
-	test.Assert(t, len(caas) == 0, "Should ignore CAA obtained via CNAME")
+	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")
 }
 
 func TestDNSLookupCNAME(t *testing.T) {

--- a/core/dns_test.go
+++ b/core/dns_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,11 +26,14 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	m.SetReply(r)
 	m.Compress = false
 
+	appendAnswer := func(rr dns.RR) {
+		m.Answer = append(m.Answer, rr)
+	}
 	for _, q := range r.Question {
+		q.Name = strings.ToLower(q.Name)
 		if q.Name == "servfail.com." {
 			m.Rcode = dns.RcodeServerFailure
-			w.WriteMsg(m)
-			return
+			break
 		}
 		switch q.Qtype {
 		case dns.TypeSOA:
@@ -42,41 +46,50 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			record.Retry = 1
 			record.Expire = 1
 			record.Minttl = 1
-
-			m.Answer = append(m.Answer, record)
-			w.WriteMsg(m)
-			return
+			appendAnswer(record)
 		case dns.TypeA:
 			if q.Name == "cps.letsencrypt.org." {
 				record := new(dns.A)
 				record.Hdr = dns.RR_Header{Name: "cps.letsencrypt.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0}
 				record.A = net.ParseIP("127.0.0.1")
-
-				m.Answer = append(m.Answer, record)
-				w.WriteMsg(m)
-				return
+				appendAnswer(record)
 			}
 		case dns.TypeCNAME:
 			if q.Name == "cname.letsencrypt.org." {
 				record := new(dns.CNAME)
 				record.Hdr = dns.RR_Header{Name: "cname.letsencrypt.org.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 30}
 				record.Target = "cps.letsencrypt.org."
-
-				m.Answer = append(m.Answer, record)
-				w.WriteMsg(m)
-				return
+				appendAnswer(record)
+			}
+			if q.Name == "cname.example.com." {
+				record := new(dns.CNAME)
+				record.Hdr = dns.RR_Header{Name: "cname.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 30}
+				record.Target = "CAA.example.com."
+				appendAnswer(record)
+			}
+		case dns.TypeDNAME:
+			if q.Name == "dname.letsencrypt.org." {
+				record := new(dns.DNAME)
+				record.Hdr = dns.RR_Header{Name: "dname.letsencrypt.org.", Rrtype: dns.TypeDNAME, Class: dns.ClassINET, Ttl: 30}
+				record.Target = "cps.letsencrypt.org."
+				appendAnswer(record)
 			}
 		case dns.TypeCAA:
-			if q.Name == "bracewel.net." {
+			if q.Name == "bracewel.net." || q.Name == "caa.example.com." {
 				record := new(dns.CAA)
-				record.Hdr = dns.RR_Header{Name: "bracewel.net.", Rrtype: dns.TypeCAA, Class: dns.ClassINET, Ttl: 0}
+				record.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeCAA, Class: dns.ClassINET, Ttl: 0}
 				record.Tag = "issue"
 				record.Value = "letsencrypt.org"
 				record.Flag = 1
-
-				m.Answer = append(m.Answer, record)
-				w.WriteMsg(m)
-				return
+				appendAnswer(record)
+			}
+			if q.Name == "cname.example.com." {
+				record := new(dns.CAA)
+				record.Hdr = dns.RR_Header{Name: "caa.example.com.", Rrtype: dns.TypeCAA, Class: dns.ClassINET, Ttl: 0}
+				record.Tag = "issue"
+				record.Value = "letsencrypt.org"
+				record.Flag = 1
+				appendAnswer(record)
 			}
 		}
 	}
@@ -214,6 +227,10 @@ func TestDNSLookupCAA(t *testing.T) {
 	caas, _, err = obj.LookupCAA("nonexistent.letsencrypt.org")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) == 0, "Shouldn't have CAA records")
+
+	caas, _, err = obj.LookupCAA("cname.example.com")
+	test.AssertNotError(t, err, "CAA lookup failed")
+	test.Assert(t, len(caas) == 0, "Should ignore CAA obtained via CNAME")
 }
 
 func TestDNSLookupCNAME(t *testing.T) {
@@ -225,5 +242,17 @@ func TestDNSLookupCNAME(t *testing.T) {
 
 	target, _, err = obj.LookupCNAME("cname.letsencrypt.org")
 	test.AssertNotError(t, err, "CNAME lookup failed")
+	test.AssertEquals(t, target, "cps.letsencrypt.org.")
+}
+
+func TestDNSLookupDNAME(t *testing.T) {
+	obj := NewDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr})
+
+	target, _, err := obj.LookupDNAME("cps.letsencrypt.org")
+	test.AssertNotError(t, err, "DNAME lookup failed")
+	test.AssertEquals(t, target, "")
+
+	target, _, err = obj.LookupDNAME("dname.letsencrypt.org")
+	test.AssertNotError(t, err, "DNAME lookup failed")
 	test.AssertEquals(t, target, "cps.letsencrypt.org.")
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -144,6 +144,7 @@ type DNSResolver interface {
 	LookupTXT(string) ([]string, time.Duration, error)
 	LookupHost(string) ([]net.IP, time.Duration, time.Duration, error)
 	LookupCNAME(string) (string, time.Duration, error)
+	LookupDNAME(string) (string, time.Duration, error)
 	LookupCAA(string) ([]*dns.CAA, time.Duration, error)
 	LookupMX(string) ([]string, time.Duration, error)
 }

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -77,7 +77,7 @@ func (mock *MockDNS) LookupCNAME(domain string) (string, time.Duration, error) {
 		return "absent.com.", 30, nil
 	case "cname-critical.com":
 		return "critical.com.", 30, nil
-	case "cname-present.com", "cname-and-caa.com", "cname-and-dname.com", "cname-and-dname-and-caa.com":
+	case "cname-present.com", "cname-and-dname.com":
 		return "cname-target.present.com.", 30, nil
 	case "cname2-present.com":
 		return "cname-present.com.", 30, nil
@@ -102,7 +102,7 @@ func (mock *MockDNS) LookupCNAME(domain string) (string, time.Duration, error) {
 // LookupDNAME is a mock
 func (mock *MockDNS) LookupDNAME(domain string) (string, time.Duration, error) {
 	switch strings.TrimRight(domain, ".") {
-	case "cname-and-dname.com", "cname-and-dname-and-caa.com", "dname-present.com":
+	case "cname-and-dname.com", "dname-present.com":
 		return "dname-target.present.com.", time.Minute, nil
 	case "a.dname-loop.com":
 		return "b.dname-loop.com.", time.Minute, nil
@@ -131,7 +131,7 @@ func (mock *MockDNS) LookupCAA(domain string) ([]*dns.CAA, time.Duration, error)
 		record.Tag = "issue"
 		record.Value = "symantec.com"
 		results = append(results, &record)
-	case "present.com", "cname-and-caa.com", "cname-and-dname-and-caa.com":
+	case "present.com":
 		record.Tag = "issue"
 		record.Value = "letsencrypt.org"
 		results = append(results, &record)

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -578,7 +578,6 @@ func TestCAAChecking(t *testing.T) {
 		CAATest{"cname-present.com", true, true},
 		CAATest{"cname2-present.com", true, true},
 		CAATest{"nx.cname2-present.com", true, true},
-		CAATest{"cname-and-dname-and-caa.com", true, true},
 		CAATest{"dname-present.com", true, true},
 		CAATest{"dname2cname.com", true, true},
 		// CNAME to critical

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -572,11 +572,15 @@ func TestCAAChecking(t *testing.T) {
 		CAATest{"cname-absent.com", false, true},
 		CAATest{"nx.cname-absent.com", false, true},
 		CAATest{"cname-nx.com", false, true},
+		CAATest{"example.co.uk", false, true},
 		// Good (present)
 		CAATest{"present.com", true, true},
 		CAATest{"cname-present.com", true, true},
 		CAATest{"cname2-present.com", true, true},
 		CAATest{"nx.cname2-present.com", true, true},
+		CAATest{"cname-and-dname-and-caa.com", true, true},
+		CAATest{"dname-present.com", true, true},
+		CAATest{"dname2cname.com", true, true},
 		// CNAME to critical
 	}
 
@@ -596,7 +600,16 @@ func TestCAAChecking(t *testing.T) {
 	test.Assert(t, !present, "Present should be false")
 	test.Assert(t, !valid, "Valid should be false")
 
-	for _, name := range []string{"a.cname-loop.com", "cname-servfail.com", "cname2servfail.com", "servfail.com"} {
+	for _, name := range []string{
+		"www.caa-loop.com",
+		"a.cname-loop.com",
+		"a.dname-loop.com",
+		"cname-servfail.com",
+		"cname2servfail.com",
+		"dname-servfail.com",
+		"cname-and-dname.com",
+		"servfail.com",
+	} {
 		_, _, err = va.CheckCAARecords(core.AcmeIdentifier{Type: "dns", Value: name})
 		test.AssertError(t, err, name)
 	}

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -564,10 +564,20 @@ func TestCAAChecking(t *testing.T) {
 		CAATest{"reserved.com", true, false},
 		// Critical
 		CAATest{"critical.com", true, false},
+		CAATest{"nx.critical.com", true, false},
+		CAATest{"cname-critical.com", true, false},
+		CAATest{"nx.cname-critical.com", true, false},
 		// Good (absent)
 		CAATest{"absent.com", false, true},
+		CAATest{"cname-absent.com", false, true},
+		CAATest{"nx.cname-absent.com", false, true},
+		CAATest{"cname-nx.com", false, true},
 		// Good (present)
 		CAATest{"present.com", true, true},
+		CAATest{"cname-present.com", true, true},
+		CAATest{"cname2-present.com", true, true},
+		CAATest{"nx.cname2-present.com", true, true},
+		// CNAME to critical
 	}
 
 	va := NewValidationAuthorityImpl(true)
@@ -585,6 +595,11 @@ func TestCAAChecking(t *testing.T) {
 	test.AssertError(t, err, "servfail.com")
 	test.Assert(t, !present, "Present should be false")
 	test.Assert(t, !valid, "Valid should be false")
+
+	for _, name := range []string{"a.cname-loop.com", "cname-servfail.com", "cname2servfail.com", "servfail.com"} {
+		_, _, err = va.CheckCAARecords(core.AcmeIdentifier{Type: "dns", Value: name})
+		test.AssertError(t, err, name)
+	}
 }
 
 func TestDNSValidationFailure(t *testing.T) {


### PR DESCRIPTION
I think this bug is responsible for the integration test failures reported in #517.

```
2015/07/23 00:03:07 [AUDIT] Internal error - Error creating new authz - DNS failure: 3-NXDOMAIN for CNAME query
```

LookupCAA in `core/dns.go` used to do CNAME lookups, and look up CAA for the target if one was found.

In #413, that logic moved into `getCAASet()` in `va/validation-authority.go`, but the new code considered NXDOMAIN during CNAME lookup to be an error. This caused `CheckCAARecords` to error out when a CAA record didn't exist, instead of returning `valid==true && present==false` as expected.

This PR restores the "NXDOMAIN is not an error" behavior, and adds tests.

It also improves `getCAASet()` CNAME support by following a chain of up to 16 CNAME records, not just one. (I figure we want to resolve CNAMEs just like other DNS resolvers, right?) The previous code (even before #413) was returning "valid" for a case like `CNAME->CNAME->invalidCAA` and infinite loops of CNAMEs. Those are now treated as "invalid" and "error" respectively.

(It seems to me CNAME logic really belongs in the DNS resolver library -- it's just part of how names get resolved and isn't specific to the process of evaluating CAA records -- but it just moved _from_ there, so I left it where it is.)

(Update) This branch now treats CNAME and DNAME as specified in rfc6844, i.e., if a name has no CAA record of its own (or via usual CNAME logic), but does have a CNAME, check the parent domains of the CNAME target rather than the parent domains of the original name. Cases where correct behavior is not specified in rfc6844 (e.g., infinite loops and non-identical CNAME/DNAME records listed for the same name) result in an error.