### PR TITLE
Change core.Certificate.DER to []byte.

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -444,11 +444,11 @@ type Certificate struct {
 	// * "revoked" - revoked
 	Status AcmeStatus `db:"status"`
 
-	Serial  string     `db:"serial"`
-	Digest  string     `db:"digest"`
-	DER     JSONBuffer `db:"der"`
-	Issued  time.Time  `db:"issued"`
-	Expires time.Time  `db:"expires"`
+	Serial  string    `db:"serial"`
+	Digest  string    `db:"digest"`
+	DER     []byte    `db:"der"`
+	Issued  time.Time `db:"issued"`
+	Expires time.Time `db:"expires"`
 }
 
 // MatchesCSR tests the contents of a generated certificate to make sure


### PR DESCRIPTION
Fixes https://github.com/letsencrypt/boulder/issues/519.

The previous type, JSONBuffer, was triggering a subtle bug when scanning
multiple rows from MySQL.  Since this struct is not serialized as JOSE it
doesn't need to have the JSONBuffer type.

The test for this fix is blocked on
https://github.com/letsencrypt/boulder/issues/132, so I filed a separate issue
to follow up with a test:
https://github.com/letsencrypt/boulder/issues/536