### PR TITLE
Remove the need for a client to send authorizations url when requesting new certificate

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -42,12 +42,7 @@ func TestChallenges(t *testing.T) {
 
 var testCertificateRequestBadCSR = []byte(`{"csr":"AAAA"}`)
 var testCertificateRequestGood = []byte(`{
-  "csr": "MIHRMHgCAQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQWUlnRrm5ErSVkTzBTk3isg1hNydfyY4NM1P_N1S-ZeD39HMrYJsQkUh2tKvy3ztfmEqWpekvO4WRktSa000BPoAAwCgYIKoZIzj0EAwMDSQAwRgIhAIZIBwu4xOUD_4dJuGgceSKaoXTFBQKA3BFBNVJvbpdsAiEAlfq3Dq_8dnYbtmyDdXgopeKkSV5_76VSpcog-wkwEwo",
-  "authorizations": [
-    "https://example.com/authz/1",
-    "https://example.com/authz/2",
-    "https://example.com/authz/3"
-  ]
+  "csr": "MIHRMHgCAQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQWUlnRrm5ErSVkTzBTk3isg1hNydfyY4NM1P_N1S-ZeD39HMrYJsQkUh2tKvy3ztfmEqWpekvO4WRktSa000BPoAAwCgYIKoZIzj0EAwMDSQAwRgIhAIZIBwu4xOUD_4dJuGgceSKaoXTFBQKA3BFBNVJvbpdsAiEAlfq3Dq_8dnYbtmyDdXgopeKkSV5_76VSpcog-wkwEwo"
 }`)
 
 func TestCertificateRequest(t *testing.T) {
@@ -60,9 +55,6 @@ func TestCertificateRequest(t *testing.T) {
 	}
 	if err = VerifyCSR(goodCR.CSR); err != nil {
 		t.Errorf("Valid CSR in CertificateRequest failed to verify: %v", err)
-	}
-	if len(goodCR.Authorizations) == 0 {
-		t.Errorf("Certificate request parsing failed to parse authorizations")
 	}
 
 	// Bad CSR

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -103,6 +103,7 @@ type StorageGetter interface {
 	GetRegistration(int64) (Registration, error)
 	GetRegistrationByKey(jose.JsonWebKey) (Registration, error)
 	GetAuthorization(string) (Authorization, error)
+	GetLatestValidAuthorization(int64, AcmeIdentifier) (Authorization, error)
 	GetCertificate(string) (Certificate, error)
 	GetCertificateByShortSerial(string) (Certificate, error)
 	GetCertificateStatus(string) (CertificateStatus, error)

--- a/core/objects.go
+++ b/core/objects.go
@@ -141,21 +141,17 @@ type AcmeIdentifier struct {
 	Value string         `json:"value"` // The identifier itself
 }
 
-// CertificateRequest is just a CSR together with
-// URIs pointing to authorizations that should collectively
-// authorize the certificate being requsted.
+// CertificateRequest is just a CSR
 //
 // This data is unmarshalled from JSON by way of rawCertificateRequest, which
 // represents the actual structure received from the client.
 type CertificateRequest struct {
-	CSR            *x509.CertificateRequest // The CSR
-	Authorizations []AcmeURL                // Links to Authorization over the account key
-	Bytes          []byte                   // The original bytes of the CSR, for logging.
+	CSR   *x509.CertificateRequest // The CSR
+	Bytes []byte                   // The original bytes of the CSR, for logging.
 }
 
 type rawCertificateRequest struct {
-	CSR            JSONBuffer `json:"csr"`            // The encoded CSR
-	Authorizations []AcmeURL  `json:"authorizations"` // Authorizations
+	CSR JSONBuffer `json:"csr"` // The encoded CSR
 }
 
 // UnmarshalJSON provides an implementation for decoding CertificateRequest objects.
@@ -171,7 +167,6 @@ func (cr *CertificateRequest) UnmarshalJSON(data []byte) error {
 	}
 
 	cr.CSR = csr
-	cr.Authorizations = raw.Authorizations
 	cr.Bytes = raw.CSR
 	return nil
 }
@@ -179,8 +174,7 @@ func (cr *CertificateRequest) UnmarshalJSON(data []byte) error {
 // MarshalJSON provides an implementation for encoding CertificateRequest objects.
 func (cr CertificateRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(rawCertificateRequest{
-		CSR:            cr.CSR.Raw,
-		Authorizations: cr.Authorizations,
+		CSR: cr.CSR.Raw,
 	})
 }
 

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -279,49 +279,20 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(req core.CertificateRequest,
 		return emptyCert, err
 	}
 
-	// Gather authorized domains from the referenced authorizations
-	authorizedDomains := map[string]bool{}
-	verificationMethodSet := map[string]bool{}
-	earliestExpiry := time.Date(2100, 01, 01, 0, 0, 0, 0, time.UTC)
+	// Check that each requested name has a valid authorization
 	now := time.Now()
-	for _, url := range req.Authorizations {
-		id := lastPathSegment(url)
-		authz, err := ra.SA.GetAuthorization(id)
-		if err != nil || // Couldn't find authorization
-			authz.RegistrationID != registration.ID || // Not for this account
-			authz.Status != core.StatusValid || // Not finalized or not successful
-			authz.Expires.Before(now) || // Expired
-			authz.Identifier.Type != core.IdentifierDNS {
-			// XXX: It may be good to fail here instead of ignoring invalid authorizations.
-			//      However, it seems like this treatment is more in the spirit of Postel's
-			//      law, and it hides information from attackers.
-			continue
+	earliestExpiry := time.Date(2100, 01, 01, 0, 0, 0, 0, time.UTC)
+	for _, name := range names {
+		authz, err := ra.SA.GetLatestValidAuthorization(registration.ID, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: name})
+		if err != nil || authz.Expires.Before(now) {
+			// unable to find a valid authorization or authz is expired
+			err = core.UnauthorizedError(fmt.Sprintf("Key not authorized for name %s", name))
+			logEvent.Error = err.Error()
+			return emptyCert, err
 		}
 
 		if authz.Expires.Before(earliestExpiry) {
 			earliestExpiry = *authz.Expires
-		}
-
-		for _, challenge := range authz.Challenges {
-			if challenge.Status == core.StatusValid {
-				verificationMethodSet[challenge.Type] = true
-			}
-		}
-
-		authorizedDomains[authz.Identifier.Value] = true
-	}
-	verificationMethods := []string{}
-	for method := range verificationMethodSet {
-		verificationMethods = append(verificationMethods, method)
-	}
-	logEvent.VerificationMethods = verificationMethods
-
-	// Validate all domains
-	for _, name := range names {
-		if !authorizedDomains[name] {
-			err = core.UnauthorizedError(fmt.Sprintf("Key not authorized for name %s", name))
-			logEvent.Error = err.Error()
-			return emptyCert, err
 		}
 	}
 

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -425,10 +425,8 @@ func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to parse CSR")
 	sa.UpdatePendingAuthorization(authz)
 	sa.FinalizeAuthorization(authz)
-	authzURL, _ := url.Parse("http://doesnt.matter/" + authz.ID)
 	certRequest := core.CertificateRequest{
-		CSR:            parsedCSR,
-		Authorizations: []core.AcmeURL{core.AcmeURL(*authzURL)},
+		CSR: parsedCSR,
 	}
 
 	// Registration id 1 has key == AccountKeyA
@@ -446,14 +444,10 @@ func TestAuthorizationRequired(t *testing.T) {
 	sa.UpdatePendingAuthorization(AuthzFinal)
 	sa.FinalizeAuthorization(AuthzFinal)
 
-	// Construct a cert request referencing the authorization
-	url1, _ := url.Parse("http://doesnt.matter/" + AuthzFinal.ID)
-
 	// ExampleCSR requests not-example.com and www.not-example.com,
 	// but the authorization only covers not-example.com
 	certRequest := core.CertificateRequest{
-		CSR:            ExampleCSR,
-		Authorizations: []core.AcmeURL{core.AcmeURL(*url1)},
+		CSR: ExampleCSR,
 	}
 
 	_, err := ra.NewCertificate(certRequest, 1)
@@ -475,13 +469,8 @@ func TestNewCertificate(t *testing.T) {
 	authzFinalWWW, _ = sa.NewPendingAuthorization(authzFinalWWW)
 	sa.FinalizeAuthorization(authzFinalWWW)
 
-	// Construct a cert request referencing the two authorizations
-	url1, _ := url.Parse("http://doesnt.matter/" + AuthzFinal.ID)
-	url2, _ := url.Parse("http://doesnt.matter/" + authzFinalWWW.ID)
-
 	certRequest := core.CertificateRequest{
-		CSR:            ExampleCSR,
-		Authorizations: []core.AcmeURL{core.AcmeURL(*url1), core.AcmeURL(*url2)},
+		CSR: ExampleCSR,
 	}
 
 	cert, err := ra.NewCertificate(certRequest, 1)

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -48,6 +48,7 @@ const (
 	MethodGetRegistration             = "GetRegistration"             // SA
 	MethodGetRegistrationByKey        = "GetRegistrationByKey"        // RA, SA
 	MethodGetAuthorization            = "GetAuthorization"            // SA
+	MethodGetLatestValidAuthorization = "GetLatestValidAuthorization" // SA
 	MethodGetCertificate              = "GetCertificate"              // SA
 	MethodGetCertificateByShortSerial = "GetCertificateByShortSerial" // SA
 	MethodGetCertificateStatus        = "GetCertificateStatus"        // SA
@@ -82,6 +83,11 @@ type updateAuthorizationRequest struct {
 	Authz    core.Authorization
 	Index    int
 	Response core.Challenge
+}
+
+type latestValidAuthorizationRequest struct {
+	RegID      int64
+	Identifier core.AcmeIdentifier
 }
 
 type certificateRequest struct {
@@ -714,6 +720,28 @@ func NewStorageAuthorityServer(rpc RPCServer, impl core.StorageAuthority) error 
 		return
 	})
 
+	rpc.Handle(MethodGetLatestValidAuthorization, func(req []byte) (response []byte, err error) {
+		var lvar latestValidAuthorizationRequest
+		if err = json.Unmarshal(req, &lvar); err != nil {
+			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64
+			improperMessage(MethodNewAuthorization, err, req)
+			return
+		}
+
+		authz, err := impl.GetLatestValidAuthorization(lvar.RegID, lvar.Identifier)
+		if err != nil {
+			return
+		}
+
+		response, err = json.Marshal(authz)
+		if err != nil {
+			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+			errorCondition(MethodGetLatestValidAuthorization, err, req)
+			return
+		}
+		return
+	})
+
 	rpc.Handle(MethodAddCertificate, func(req []byte) (response []byte, err error) {
 		var acReq addCertificateRequest
 		err = json.Unmarshal(req, &acReq)
@@ -948,6 +976,27 @@ func (cac StorageAuthorityClient) GetRegistrationByKey(key jose.JsonWebKey) (reg
 // GetAuthorization sends a request to get an Authorization by ID
 func (cac StorageAuthorityClient) GetAuthorization(id string) (authz core.Authorization, err error) {
 	jsonAuthz, err := cac.rpc.DispatchSync(MethodGetAuthorization, []byte(id))
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(jsonAuthz, &authz)
+	return
+}
+
+// GetLatestValidAuthorization sends a request to get an Authorization by RegID, Identifier
+func (cac StorageAuthorityClient) GetLatestValidAuthorization(registrationId int64, identifier core.AcmeIdentifier) (authz core.Authorization, err error) {
+
+	var lvar latestValidAuthorizationRequest
+	lvar.RegID = registrationId
+	lvar.Identifier = identifier
+
+	data, err := json.Marshal(lvar)
+	if err != nil {
+		return
+	}
+
+	jsonAuthz, err := cac.rpc.DispatchSync(MethodGetLatestValidAuthorization, data)
 	if err != nil {
 		return
 	}

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -166,6 +166,20 @@ func (ssa *SQLStorageAuthority) GetAuthorization(id string) (authz core.Authoriz
 	return
 }
 
+// Get the valid authorization with biggest expire date for a given domain and registrationId
+func (ssa *SQLStorageAuthority) GetLatestValidAuthorization(registrationId int64, identifier core.AcmeIdentifier) (authz core.Authorization, err error) {
+	ident, err := json.Marshal(identifier)
+	if err != nil {
+		return
+	}
+	err = ssa.dbMap.SelectOne(&authz, "SELECT id, identifier, registrationID, status, expires, challenges, combinations "+
+		"FROM authz "+
+		"WHERE identifier = :identifier AND registrationID = :registrationId "+
+		"ORDER BY expires DESC LIMIT 1",
+		map[string]interface{}{"identifier": string(ident), "registrationId": registrationId})
+	return
+}
+
 // GetCertificateByShortSerial takes an id consisting of the first, sequential half of a
 // serial number and returns the first certificate whose full serial number is
 // lexically greater than that id. This allows clients to query on the known

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -174,7 +174,7 @@ func (ssa *SQLStorageAuthority) GetLatestValidAuthorization(registrationId int64
 	}
 	err = ssa.dbMap.SelectOne(&authz, "SELECT id, identifier, registrationID, status, expires, challenges, combinations "+
 		"FROM authz "+
-		"WHERE identifier = :identifier AND registrationID = :registrationId "+
+		"WHERE identifier = :identifier AND registrationID = :registrationId AND status = 'valid' "+
 		"ORDER BY expires DESC LIMIT 1",
 		map[string]interface{}{"identifier": string(ident), "registrationId": registrationId})
 	return

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -134,10 +134,119 @@ func TestAddAuthorization(t *testing.T) {
 
 	dbPa, err = sa.GetAuthorization(PA.ID)
 	test.AssertNotError(t, err, "Couldn't get authorization with ID "+PA.ID)
+}
 
-	authz, err := sa.GetLatestValidAuthorization(0, identifier)
-	test.AssertNotError(t, err, "Couldn't get latest authorization with identifier "+identifier.Value)
-	test.AssertEquals(t, authz.ID, PA.ID)
+func CreateDomainAuth(t *testing.T, domainName string, sa *SQLStorageAuthority) (authz core.Authorization) {
+	// create pending auth
+	authz, err := sa.NewPendingAuthorization(core.Authorization{})
+	test.AssertNotError(t, err, "Couldn't create new pending authorization")
+	test.Assert(t, authz.ID != "", "ID shouldn't be blank")
+
+	// prepare challenge for auth
+	uu, err := url.Parse(domainName)
+	test.AssertNotError(t, err, "Couldn't parse domainName "+domainName)
+	u := core.AcmeURL(*uu)
+	chall := core.Challenge{Type: "simpleHttp", Status: core.StatusValid, URI: u, Token: "THISWOULDNTBEAGOODTOKEN", Path: "test-me"}
+	combos := make([][]int, 1)
+	combos[0] = []int{0, 1}
+	exp := time.Now().AddDate(0, 0, 1) // expire in 1 day
+
+	// validate pending auth
+	authz.Status = core.StatusPending
+	authz.Identifier = core.AcmeIdentifier{Type: core.IdentifierDNS, Value: domainName}
+	authz.RegistrationID = 42
+	authz.Expires = &exp
+	authz.Challenges = []core.Challenge{chall}
+	authz.Combinations = combos
+
+	// save updated auth
+	err = sa.UpdatePendingAuthorization(authz)
+	test.AssertNotError(t, err, "Couldn't update pending authorization with ID "+authz.ID)
+
+	return
+}
+
+// Ensure we get only valid authorization with correct RegID
+func TestGetLatestValidAuthorizationBasic(t *testing.T) {
+	sa := initSA(t)
+
+	// attempt to get unauthorized domain
+	authz, err := sa.GetLatestValidAuthorization(0, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.org"})
+	test.AssertError(t, err, "Should not have found a valid auth for example.org")
+
+	// authorize "example.org"
+	authz = CreateDomainAuth(t, "example.org", sa)
+
+	// finalize auth
+	authz.Status = core.StatusValid
+	err = sa.FinalizeAuthorization(authz)
+	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+authz.ID)
+
+	// attempt to get authorized domain with wrong RegID
+	authz, err = sa.GetLatestValidAuthorization(0, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.org"})
+	test.AssertError(t, err, "Should not have found a valid auth for example.org and regID 0")
+
+	// get authorized domain
+	authz, err = sa.GetLatestValidAuthorization(42, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.org"})
+	test.AssertNotError(t, err, "Should have found a valid auth for example.org and regID 42")
+	test.AssertEquals(t, authz.Status, core.StatusValid)
+	test.AssertEquals(t, authz.Identifier.Type, core.IdentifierDNS)
+	test.AssertEquals(t, authz.Identifier.Value, "example.org")
+	test.AssertEquals(t, authz.RegistrationID, int64(42))
+}
+
+// Ensure we get the latest valid authorization for an ident
+func TestGetLatestValidAuthorizationMultiple(t *testing.T) {
+	sa := initSA(t)
+	domain := "example.org"
+	ident := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: domain}
+	regID := int64(42)
+	var err error
+
+	// create invalid authz
+	authz := CreateDomainAuth(t, domain, sa)
+	exp := time.Now().AddDate(0, 0, 10) // expire in 10 day
+	authz.Expires = &exp
+	authz.Status = core.StatusInvalid
+	err = sa.FinalizeAuthorization(authz)
+	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+authz.ID)
+
+	// should not get the auth
+	authz, err = sa.GetLatestValidAuthorization(regID, ident)
+	test.AssertError(t, err, "Should not have found a valid auth for "+domain)
+
+	// create valid auth
+	authz = CreateDomainAuth(t, domain, sa)
+	exp = time.Now().AddDate(0, 0, 1) // expire in 1 day
+	authz.Expires = &exp
+	authz.Status = core.StatusValid
+	err = sa.FinalizeAuthorization(authz)
+	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+authz.ID)
+
+	// should get the valid auth even if it's expire date is lower than the invalid one
+	authz, err = sa.GetLatestValidAuthorization(regID, ident)
+	test.AssertNotError(t, err, "Should have found a valid auth for "+domain)
+	test.AssertEquals(t, authz.Status, core.StatusValid)
+	test.AssertEquals(t, authz.Identifier.Type, ident.Type)
+	test.AssertEquals(t, authz.Identifier.Value, ident.Value)
+	test.AssertEquals(t, authz.RegistrationID, regID)
+
+	// create a newer auth
+	newAuthz := CreateDomainAuth(t, domain, sa)
+	exp = time.Now().AddDate(0, 0, 2) // expire in 2 day
+	newAuthz.Expires = &exp
+	newAuthz.Status = core.StatusValid
+	err = sa.FinalizeAuthorization(newAuthz)
+	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+newAuthz.ID)
+
+	authz, err = sa.GetLatestValidAuthorization(regID, ident)
+	test.AssertNotError(t, err, "Should have found a valid auth for "+domain)
+	test.AssertEquals(t, authz.Status, core.StatusValid)
+	test.AssertEquals(t, authz.Identifier.Type, ident.Type)
+	test.AssertEquals(t, authz.Identifier.Value, ident.Value)
+	test.AssertEquals(t, authz.RegistrationID, regID)
+	// make sure we got the latest auth
+	test.AssertEquals(t, authz.ID, newAuthz.ID)
 }
 
 func TestAddCertificate(t *testing.T) {

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -123,7 +123,8 @@ func TestAddAuthorization(t *testing.T) {
 	combos[0] = []int{0, 1}
 
 	exp := time.Now().AddDate(0, 0, 1)
-	newPa := core.Authorization{ID: PA.ID, Identifier: core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}, RegistrationID: 0, Status: core.StatusPending, Expires: &exp, Challenges: []core.Challenge{chall}, Combinations: combos}
+	identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}
+	newPa := core.Authorization{ID: PA.ID, Identifier: identifier, RegistrationID: 0, Status: core.StatusPending, Expires: &exp, Challenges: []core.Challenge{chall}, Combinations: combos}
 	err = sa.UpdatePendingAuthorization(newPa)
 	test.AssertNotError(t, err, "Couldn't update pending authorization with ID "+PA.ID)
 
@@ -133,6 +134,10 @@ func TestAddAuthorization(t *testing.T) {
 
 	dbPa, err = sa.GetAuthorization(PA.ID)
 	test.AssertNotError(t, err, "Couldn't get authorization with ID "+PA.ID)
+
+	authz, err := sa.GetLatestValidAuthorization(0, identifier)
+	test.AssertNotError(t, err, "Couldn't get latest authorization with identifier "+identifier.Value)
+	test.AssertEquals(t, authz.ID, PA.ID)
 }
 
 func TestAddCertificate(t *testing.T) {

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -673,7 +673,6 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 		return
 	}
 	wfe.logCsr(request.RemoteAddr, init, reg)
-	logEvent.Extra["Authorizations"] = init.Authorizations
 	logEvent.Extra["CSRDNSNames"] = init.CSR.DNSNames
 	logEvent.Extra["CSREmailAddresses"] = init.CSR.EmailAddresses
 	logEvent.Extra["CSRIPAddresses"] = init.CSR.IPAddresses


### PR DESCRIPTION
Check previous authorizations based on the user account, instead of using the list of authorizations provided by user.
This is compliant with the latest spec and fixes https://github.com/letsencrypt/boulder/issues/423