### PR TITLE
Fix OCSP updating.

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -474,7 +474,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 		return cert, nil
 	}
 
-	ca.SA.UpdateOCSP(serial, ocspResponse)
+	err = ca.SA.UpdateOCSP(serial, ocspResponse)
 	if err != nil {
 		ca.log.Warning(fmt.Sprintf("Post-Issuance OCSP failed storing: %s", err))
 		return cert, nil

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -436,8 +436,9 @@ func TestRevoke(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to get cert status")
 
 	test.AssertEquals(t, status.Status, core.OCSPStatusRevoked)
-	test.Assert(t, time.Now().Sub(status.OCSPLastUpdated) > time.Second,
-		fmt.Sprintf("OCSP LastUpdated was wrong: %v", status.OCSPLastUpdated))
+	secondAgo := time.Now().Add(-time.Second)
+	test.Assert(t, status.OCSPLastUpdated.After(secondAgo),
+		fmt.Sprintf("OCSP LastUpdated was more than a second old: %v", status.OCSPLastUpdated))
 }
 
 func TestIssueCertificate(t *testing.T) {

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -266,7 +266,7 @@ func (ssa *SQLStorageAuthority) UpdateOCSP(serial string, ocspResponse []byte) (
 
 	// Reset the update clock
 	status.OCSPLastUpdated = timeStamp
-	_, err = tx.Update(status)
+	_, err = tx.Update(&status)
 	if err != nil {
 		tx.Rollback()
 		return err


### PR DESCRIPTION
Fixes https://github.com/letsencrypt/boulder/issues/539.

Passes a pointer to tx.Update() in the SA, resolving the gorp error we were
previously receiving in UpdateOCSP.

Fixes CA code to properly receive the error from UpdateOCSP, so future errors
will be logged correctly.