### PR TITLE
Speed up start.py and integration test.

### DIFF
--- a/start.py
+++ b/start.py
@@ -15,13 +15,9 @@ import time
 sys.path.append('./test')
 import startservers
 
-
-if not startservers.start():
+if not startservers.start(race_detection=False):
     sys.exit(1)
 try:
-    time.sleep(1)
-    print("All servers are running. To stop, hit ^C.")
-
     os.wait()
 
     # If we reach here, a child died early. Log what died:

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -85,7 +85,7 @@ def cleanup():
 
 exit_status = ExitStatus.OK
 tempdir = tempfile.mkdtemp()
-if not startservers.start():
+if not startservers.start(race_detection=True):
     die(ExitStatus.Error)
 run_node_test()
 run_client_tests()

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -33,13 +33,12 @@ tempdir = tempfile.mkdtemp()
 
 
 def run(path, race_detection):
-    binary = os.path.join(tempdir, os.path.basename(path))
-
-    build = "go build"
+    install = "go install"
     if race_detection:
-        build = """GORACE="halt_on_error=1" go build -race"""
+        install = """GORACE="halt_on_error=1" go install -race"""
 
-    cmd = """%s -o %s ./%s; exec %s --config %s""" % (build, binary, path, binary, config)
+    binary = os.path.basename(path)
+    cmd = """%s ./%s; exec %s --config %s""" % (install, path, binary, config)
     p = subprocess.Popen(cmd, shell=True)
     p.cmd = cmd
     print('started %s with pid %d' % (p.cmd, p.pid))

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -6,6 +6,7 @@ import shutil
 import signal
 import socket
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -22,14 +23,13 @@ class ToSServerThread(threading.Thread):
             BaseHTTPServer.HTTPServer(("localhost", 4001), self.ToSHandler).serve_forever()
         except Exception as e:
             print "Problem starting ToSServer: %s" % e
-            exit(1)
+            sys.exit(1)
 
 
 config = os.environ.get('BOULDER_CONFIG')
 if config is None:
     config = 'test/boulder-config.json'
 processes = []
-tempdir = tempfile.mkdtemp()
 
 
 def run(path, race_detection):
@@ -125,4 +125,3 @@ def stop():
     for p in processes:
         if p.poll() is None:
             p.kill()
-    shutil.rmtree(tempdir)

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -20,7 +20,7 @@ class ToSServerThread(threading.Thread):
     def run(self):
         try:
             BaseHTTPServer.HTTPServer(("localhost", 4001), self.ToSHandler).serve_forever()
-        except e:
+        except Exception as e:
             print "Problem starting ToSServer: %s" % e
             exit(1)
 


### PR DESCRIPTION
Run builds in parallell as well as starting servers in parallel.
Wait for the servers to come up, so tests don't start running too early.
Enable race detection only for the integration test, not for start.py.
Previously I'd suggested it should always be on, but after running with it for a
while I'm convinced it's too slow for start.py (but still very valuable for
integration tests!).