### PR TITLE
Use dns-test-srv in integration tests (fixes #420).

### DIFF
--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -174,7 +174,7 @@
     "baseURL": "http://localhost:4000",
     "issuerCert": "test/test-ca.pem",
     "maxKeySize": 4096,
-    "dnsResolver": "8.8.8.8:53",
+    "dnsResolver": "127.0.0.1:8053",
     "dnsTimeout": "10s"
   },
 


### PR DESCRIPTION
Fast forward hidden update from #505, that will make sure client integration builds are not failing with timeout issues. It shouldn't cause merge conflicts.

@rolandshoemaker  PTAL