### PR TITLE
add host to travis set up for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,8 @@ env:
 script:
   - make -j4 # Travis has 2 cores per build instance
   - bash test.sh
+
+# make sure simplehttp simple verification works (custom /etc/hosts)
+addons:
+  hosts:
+    - le.wtf


### PR DESCRIPTION
Discovered while @kuba and I poked at the @jmhodges/boulder branch le_update_challenges that tests boulder with the new @letsencrypt/letsencrypt update-challenges branch (which is bringing le and boulder into compliance with each other).