### PR TITLE
panic on errors in initializeAuditLogger

### DIFF
--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -91,10 +91,7 @@ func NewAuditLogger(log SyslogWriter, stats statsd.Statter) (*AuditLogger, error
 	return audit, nil
 }
 
-// initializeAuditLogger should only be used in unit tests. Failures in this
-// method are unlikely as the defaults are safe, and they are also
-// of minimal consequence during unit testing -- logs get printed to stdout
-// even if syslog is missing.
+// initializeAuditLogger should only be used in unit tests.
 func initializeAuditLogger() {
 	stats, err := statsd.NewNoopClient(nil)
 	if err != nil {

--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -96,8 +96,14 @@ func NewAuditLogger(log SyslogWriter, stats statsd.Statter) (*AuditLogger, error
 // of minimal consequence during unit testing -- logs get printed to stdout
 // even if syslog is missing.
 func initializeAuditLogger() {
-	stats, _ := statsd.NewNoopClient(nil)
-	audit, _ := Dial("", "", "default", stats)
+	stats, err := statsd.NewNoopClient(nil)
+	if err != nil {
+		panic(err)
+	}
+	audit, err := Dial("", "", "default", stats)
+	if err != nil {
+		panic(err)
+	}
 	audit.Notice("Using default logging configuration.")
 
 	SetAuditLogger(audit)


### PR DESCRIPTION
Found when poking at the new containerized Travis CI build with @rolandshoemaker. This was causing strange panics far away from here when code would try to log audits when there was no syslog available.