### PR TITLE
Fix splitted dns validation

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -62,6 +62,20 @@ func (mock *MockDNS) LookupTXT(hostname string) ([]string, time.Duration, error)
 	if hostname == "_acme-challenge.servfail.com" {
 		return nil, 0, fmt.Errorf("SERVFAIL")
 	}
+	if hostname == "_acme-challenge.good.bin.coffee" {
+		return []string{"P-sAHUTht3jvePd6oTqyjST6T69ni2C25N0LYajg2CYwStTXJCpNWvlRHVbILSrmuwX1vjPKqhB6DcLNjKP5uMNRu1Ceu1rZkW4Znfwq0mzwuOQX7DdhLKlfOGBnzUyPvmRpcmsWDDmFY3kec9SKbjJ-eI580pZa72VVuMsJGseEbPwbPiyuSWidGqqGCOu6DFEZKdN40Y-ut9yylqxmiZBL3nmx4Y4hJ48lzFJnY3MfJ3ldjhuvlnAcyDaXufH1IhZSJLUckrvwzxx5sHBj-YwiMY9bwW1Blo2WZxlf93mOSwl0aQwXd0gRpIMLPScESK1KfZgcj15b55GQCLndBA"}, 0, nil
+	}
+	if hostname == "_acme-challenge.splitted.bin.coffee" {
+		return []string{"P-sAHUTht3jvePd6oTqyjST6T69ni2C25N0LYajg2CYwStTXJCpNWvlRHVbILSrmuwX1",
+						"vjPKqhB6DcLNjKP5uMNRu1Ceu1rZkW4Znfwq0mzwuOQX7DdhLKlfOGBnzUyPvmRpcmsW",
+						"DDmFY3kec9SKbjJ-eI580pZa72VVuMsJGseEbPwbPiyuSWidGqqGCOu6DFEZKdN40Y-u",
+						"t9yylqxmiZBL3nmx4Y4hJ48lzFJnY3MfJ3ldjhuvlnAcyDaXufH1IhZSJLUckrvwzxx5",
+						"sHBj-YwiMY9bwW1Blo2WZxlf93mOSwl0aQwXd0gRpIMLPScESK1KfZgcj15b55GQCLndBA"}, 0, nil
+	}
+	if hostname == "_acme-challenge.bad-splitted.bin.coffee" {
+		return []string{"P-sAHUTht3jvePd6oTqyjST6T69ni2C25N0LYajg2CYwStTXJCpNWvlRHVbILSrmuwX1",
+						"You know I'm bad, I'm bad - come on, you know"}, 0, nil
+	}
 	return []string{"hostname"}, 0, nil
 }
 

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -401,11 +401,14 @@ func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, in
 		return challenge, challenge.Error
 	}
 
+	txtRecord := ""
 	for _, element := range txts {
-		if subtle.ConstantTimeCompare([]byte(element), []byte(encodedSignature)) == 1 {
-			challenge.Status = core.StatusValid
-			return challenge, nil
-		}
+		txtRecord += element
+	}
+
+	if subtle.ConstantTimeCompare([]byte(txtRecord), []byte(encodedSignature)) == 1 {
+		challenge.Status = core.StatusValid
+		return challenge, nil
 	}
 
 	challenge.Error = &core.ProblemDetails{


### PR DESCRIPTION
fix #573
Note that right now, dns validation was not tested
Although it fixes the dns validation issue with latest acme spec, I still think that we should limit the TXT record length to 255 chars (https://github.com/letsencrypt/acme-spec/issues/213).
