### PR TITLE
add newline to cmd failure string

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -251,7 +251,7 @@ func (as *AppShell) VersionString() string {
 func FailOnError(err error, msg string) {
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		fmt.Fprintf(os.Stderr, "%s: %s", msg, err)
+		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Without a \n at the end, the final output gets squished by the next command prompt. This makes it easier to read.