### PR TITLE
use GetRegistration RPC outside of SA

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -79,7 +79,7 @@ func setupContext(context *cli.Context) (rpc.CertificateAuthorityClient, *blog.A
 	dbMap, err := sa.NewDbMap(c.Revoker.DBDriver, c.Revoker.DBConnect)
 	cmd.FailOnError(err, "Couldn't setup database connection")
 
-	saRPC, err := rpc.NewAmqpRPCClient("CA->SA", c.AMQP.SA.Server, ch)
+	saRPC, err := rpc.NewAmqpRPCClient("AdminRevoker->SA", c.AMQP.SA.Server, ch)
 	cmd.FailOnError(err, "Unable to create RPC client")
 
 	sac, err := rpc.NewStorageAuthorityClient(saRPC)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -246,7 +246,7 @@ func main() {
 		ch, err := rpc.AmqpChannel(c)
 		cmd.FailOnError(err, "Could not connect to AMQP")
 
-		saRPC, err := rpc.NewAmqpRPCClient("CA->SA", c.AMQP.SA.Server, ch)
+		saRPC, err := rpc.NewAmqpRPCClient("ExpirationMailer->SA", c.AMQP.SA.Server, ch)
 		cmd.FailOnError(err, "Unable to create RPC client")
 
 		sac, err := rpc.NewStorageAuthorityClient(saRPC)

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -62,7 +62,8 @@ type fakeRegStore struct {
 func (f fakeRegStore) GetRegistration(id int64) (core.Registration, error) {
 	r, ok := f.RegById[id]
 	if !ok {
-		return r, sa.NoSuchRegistrationError{fmt.Sprintf("no such registration %d", id)}
+		msg := fmt.Sprintf("no such registration %d", id)
+		return r, sa.NoSuchRegistrationError{Msg: msg}
 	}
 	return r, nil
 }

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -98,6 +98,14 @@ func existingRegistration(tx *gorp.Transaction, id int64) bool {
 	return count > 0
 }
 
+type NoSuchRegistrationError struct {
+	Msg string
+}
+
+func (e NoSuchRegistrationError) Error() string {
+	return e.Msg
+}
+
 // GetRegistration obtains a Registration by ID
 func (ssa *SQLStorageAuthority) GetRegistration(id int64) (reg core.Registration, err error) {
 	regObj, err := ssa.dbMap.Get(core.Registration{}, id)
@@ -105,7 +113,7 @@ func (ssa *SQLStorageAuthority) GetRegistration(id int64) (reg core.Registration
 		return
 	}
 	if regObj == nil {
-		err = fmt.Errorf("No registrations with ID %d", id)
+		err = NoSuchRegistrationError{fmt.Sprintf("No registrations with ID %d", id)}
 		return
 	}
 	regPtr, ok := regObj.(*core.Registration)


### PR DESCRIPTION
We move the admin-revoker and expiration-mailer to using the SA.GetRegistration RPC method instead of digging into the database itself.

This allows the hiding of the registration model layer inside of SA, so we can do fancy things with sha256 for the unique index inside of it. This will happen in a later commit. See #579.

By exposing fewer details about how Registration is stored, we gain more flexibility to fix up how its stored.

In the expiration-mailer, the performance hit for the early filtering of mailto is likely neglibible and possibly even a benefit given the cost of joins to the memory of MySQL.

If need be, we can built a bulk RPC layer for SA that provides the data we need in findExpiringCertificates. It'll be easier than trying to scale and change the storage layer underneath for each consumer.