### PR TITLE
correct unique indexing of Registrations

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -208,8 +208,6 @@ type Registration struct {
 
 	// Agreement with terms of service
 	Agreement string `json:"agreement,omitempty" db:"agreement"`
-
-	LockCol int64 `json:"-"`
 }
 
 // MergeUpdate copies a subset of information from the input Registration

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -141,7 +141,10 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 
 	sa, err := sa.NewSQLStorageAuthority("sqlite3", ":memory:")
 	test.AssertNotError(t, err, "Failed to create SA")
-	sa.CreateTablesIfNotExists()
+	err = sa.CreateTablesIfNotExists()
+	if err != nil {
+		t.Fatalf("unable to create tables: %s", err)
+	}
 
 	va := &DummyValidationAuthority{}
 
@@ -263,7 +266,9 @@ func TestNewRegistration(t *testing.T) {
 	}
 
 	result, err := ra.NewRegistration(input)
-	test.AssertNotError(t, err, "Could not create new registration")
+	if err != nil {
+		t.Fatalf("could not create new registration: %s", err)
+	}
 
 	test.Assert(t, core.KeyDigestEquals(result.Key, AccountKeyB), "Key didn't match")
 	test.Assert(t, len(result.Contact) == 1, "Wrong number of contacts")

--- a/sa/database.go
+++ b/sa/database.go
@@ -99,10 +99,10 @@ func (log *SQLLogger) Printf(format string, v ...interface{}) {
 // initTables constructs the table map for the ORM. If you want to also create
 // the tables, call CreateTablesIfNotExists on the DbMap.
 func initTables(dbMap *gorp.DbMap) {
-	regTable := dbMap.AddTableWithName(core.Registration{}, "registrations").SetKeys(true, "ID")
+	regTable := dbMap.AddTableWithName(regModel{}, "registrations").SetKeys(true, "ID")
 	regTable.SetVersionCol("LockCol")
-	regTable.ColMap("Key").SetMaxSize(1024).SetNotNull(true).SetUnique(true)
-
+	regTable.ColMap("Key").SetNotNull(true)
+	regTable.ColMap("KeySHA256").SetNotNull(true).SetUnique(true)
 	pendingAuthzTable := dbMap.AddTableWithName(pendingauthzModel{}, "pending_authz").SetKeys(false, "ID")
 	pendingAuthzTable.SetVersionCol("LockCol")
 	pendingAuthzTable.ColMap("Challenges").SetMaxSize(1536)

--- a/sa/model.go
+++ b/sa/model.go
@@ -1,0 +1,56 @@
+package sa
+
+import (
+	"encoding/json"
+	"fmt"
+
+	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
+	"github.com/letsencrypt/boulder/core"
+)
+
+// regModel is the description of a core.Registration in the database.
+type regModel struct {
+	ID        int64           `db:"id"`
+	Key       []byte          `db:"jwk"`
+	KeySHA256 string          `db:"jwk_sha256"`
+	Contact   []*core.AcmeURL `db:"contact"`
+	Agreement string          `db:"agreement"`
+	LockCol   int64
+}
+
+// newReg creates a reg model object from a core.Registration
+func registrationToModel(r *core.Registration) (*regModel, error) {
+	key, err := json.Marshal(r.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	sha, err := core.KeyDigest(r.Key)
+	if err != nil {
+		return nil, err
+	}
+	rm := &regModel{
+		ID:        r.ID,
+		Key:       key,
+		KeySHA256: sha,
+		Contact:   r.Contact,
+		Agreement: r.Agreement,
+	}
+	return rm, nil
+}
+
+func modelToRegistration(rm *regModel) (core.Registration, error) {
+	k := &jose.JsonWebKey{}
+	err := json.Unmarshal(rm.Key, k)
+	if err != nil {
+		err = fmt.Errorf("unable to unmarshal JsonWebKey in db: %s", err)
+		return core.Registration{}, err
+	}
+	r := core.Registration{
+		ID:        rm.ID,
+		Key:       *k,
+		Contact:   rm.Contact,
+		Agreement: rm.Agreement,
+	}
+	return r, nil
+}

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -8,6 +8,7 @@ package sa
 import (
 	"crypto/sha256"
 	"crypto/x509"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,9 +16,8 @@ import (
 	"strings"
 	"time"
 
-	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
-
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 )
@@ -107,33 +107,40 @@ func (e NoSuchRegistrationError) Error() string {
 }
 
 // GetRegistration obtains a Registration by ID
-func (ssa *SQLStorageAuthority) GetRegistration(id int64) (reg core.Registration, err error) {
-	regObj, err := ssa.dbMap.Get(core.Registration{}, id)
+func (ssa *SQLStorageAuthority) GetRegistration(id int64) (core.Registration, error) {
+	regObj, err := ssa.dbMap.Get(regModel{}, id)
 	if err != nil {
-		return
+		return core.Registration{}, err
 	}
 	if regObj == nil {
-		err = NoSuchRegistrationError{fmt.Sprintf("No registrations with ID %d", id)}
-		return
+		msg := fmt.Sprintf("No registrations with ID %d", id)
+		return core.Registration{}, NoSuchRegistrationError{Msg: msg}
 	}
-	regPtr, ok := regObj.(*core.Registration)
+	regPtr, ok := regObj.(*regModel)
 	if !ok {
-		err = fmt.Errorf("Invalid cast")
+		return core.Registration{}, fmt.Errorf("Invalid cast to reg model object")
 	}
-
-	reg = *regPtr
-	return
+	return modelToRegistration(regPtr)
 }
 
 // GetRegistrationByKey obtains a Registration by JWK
-func (ssa *SQLStorageAuthority) GetRegistrationByKey(key jose.JsonWebKey) (reg core.Registration, err error) {
-	keyJSON, err := json.Marshal(key)
+func (ssa *SQLStorageAuthority) GetRegistrationByKey(key jose.JsonWebKey) (core.Registration, error) {
+	reg := &regModel{}
+	sha, err := core.KeyDigest(key.Key)
 	if err != nil {
-		return
+		return core.Registration{}, err
+	}
+	err = ssa.dbMap.SelectOne(reg, "SELECT * FROM registrations WHERE jwk_sha256 = :key", map[string]interface{}{"key": sha})
+
+	if err == sql.ErrNoRows {
+		msg := fmt.Sprintf("No registrations with public key sha256 %s", sha)
+		return core.Registration{}, NoSuchRegistrationError{Msg: msg}
+	}
+	if err != nil {
+		return core.Registration{}, err
 	}
 
-	err = ssa.dbMap.SelectOne(&reg, "SELECT * FROM registrations WHERE jwk = :key", map[string]interface{}{"key": string(keyJSON)})
-	return
+	return modelToRegistration(reg)
 }
 
 // GetAuthorization obtains an Authorization by ID
@@ -246,19 +253,15 @@ func (ssa *SQLStorageAuthority) GetCertificateStatus(serial string) (status core
 
 // NewRegistration stores a new Registration
 func (ssa *SQLStorageAuthority) NewRegistration(reg core.Registration) (core.Registration, error) {
-	tx, err := ssa.dbMap.Begin()
+	rm, err := registrationToModel(&reg)
 	if err != nil {
 		return reg, err
 	}
-
-	err = tx.Insert(&reg)
+	err = ssa.dbMap.Insert(rm)
 	if err != nil {
-		tx.Rollback()
 		return reg, err
 	}
-
-	err = tx.Commit()
-	return reg, err
+	return modelToRegistration(rm)
 }
 
 // UpdateOCSP stores an updated OCSP response.
@@ -347,26 +350,22 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(serial string, ocspRespon
 }
 
 // UpdateRegistration stores an updated Registration
-func (ssa *SQLStorageAuthority) UpdateRegistration(reg core.Registration) (err error) {
-	tx, err := ssa.dbMap.Begin()
+func (ssa *SQLStorageAuthority) UpdateRegistration(reg core.Registration) error {
+	rm, err := registrationToModel(&reg)
 	if err != nil {
-		return
+		return err
 	}
 
-	if !existingRegistration(tx, reg.ID) {
-		err = fmt.Errorf("Requested registration not found %v", reg.ID)
-		tx.Rollback()
-		return
-	}
-
-	_, err = tx.Update(&reg)
+	n, err := ssa.dbMap.Update(rm)
 	if err != nil {
-		tx.Rollback()
-		return
+		return err
+	}
+	if n == 0 {
+		msg := fmt.Sprintf("Requested registration not found %v", reg.ID)
+		return NoSuchRegistrationError{Msg: msg}
 	}
 
-	err = tx.Commit()
-	return
+	return nil
 }
 
 // NewPendingAuthorization stores a new Pending Authorization


### PR DESCRIPTION
Fixes #579 (which blocks #132).

This branch depends on #585 and #588 and will be rebased against them when they are merged in.

 This changes the SA to use a unique index on the sha256 of a Registration's JWK's public key data instead of on the full serialized JSON of the JWK. This corrects multiple problems:
    
 1. MySQL/Mariadb no longer complain about key's being larger than the largest allowed key size in an index
 2. We no longer have to worry about large keys not being seen as unique
 3. We no longer have to worry about the JWK's JSON being serialized with its inner keys in different orders and causing incorrectly empty queries or non-unique writes.
    
This change also hides the details of how Registrations are stored in the database from the other services outside of SA. This will give us greater flexibility if we need to move them to another database, or change their schema, etc.