### PR TITLE
Bring the SQL schema up-to-date with current Boulder changes.

### DIFF
--- a/docs/database/db_schema-main.sql
+++ b/docs/database/db_schema-main.sql
@@ -61,21 +61,21 @@ CREATE TABLE `certificateStatus` (
 
 CREATE TABLE `crls` (
   `serial` varchar(255) NOT NULL,
-  `createdAt` datetime DEFAULT NULL,
-  `crl` varchar(255) DEFAULT NULL,
+  `createdAt` datetime NOT NULL,
+  `crl` varchar(255) NOT NULL,
   PRIMARY KEY (`serial`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `deniedCSRs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `names` varchar(255) DEFAULT NULL,
+  `names` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `ocspResponses` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `serial` varchar(255) DEFAULT NULL,
-  `createdAt` datetime DEFAULT NULL,
+  `serial` varchar(255) NOT NULL,
+  `createdAt` datetime NOT NULL,
   `response` mediumblob,
   PRIMARY KEY (`id`),
   KEY `SERIAL` (`serial`) COMMENT 'Actual lookup mechanism'

--- a/docs/database/db_schema-main.sql
+++ b/docs/database/db_schema-main.sql
@@ -11,14 +11,14 @@
 
 CREATE TABLE `registrations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `jwk` varchar(1024) NOT NULL,
-  `recoveryToken` varchar(255) DEFAULT NULL,
+  `jwk` mediumblob NOT NULL,
+  `jwk_sha256` varchar(255) NOT NULL,
   `contact` varchar(255) DEFAULT NULL,
   `agreement` varchar(255) DEFAULT NULL,
   `LockCol` bigint(20) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_registrations_jwk` (`jwk`(255)) COMMENT 'Used by GetRegistrationByKey'
-) ENGINE=InnoDB AUTO_INCREMENT=70 DEFAULT CHARSET=utf8;
+  UNIQUE KEY `jwk_sha256` (`jwk_sha256`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `authz` (
   `id` varchar(255) NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE `authz` (
   `combinations` varchar(255) DEFAULT NULL,
   `sequence` bigint(20) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `regId_idx` (`registrationID`),
+  KEY `regId_idx` (`registrationID`) COMMENT 'Common lookup',
   CONSTRAINT `regId_authz` FOREIGN KEY (`registrationID`) REFERENCES `registrations` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -43,7 +43,7 @@ CREATE TABLE `certificates` (
   `issued` datetime DEFAULT NULL,
   `expires` datetime DEFAULT NULL,
   PRIMARY KEY (`serial`),
-  KEY `regId_certificates_idx` (`registrationID`),
+  KEY `regId_certificates_idx` (`registrationID`) COMMENT 'Common lookup',
   CONSTRAINT `regId_certificates` FOREIGN KEY (`registrationID`) REFERENCES `registrations` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -54,6 +54,7 @@ CREATE TABLE `certificateStatus` (
   `ocspLastUpdated` datetime DEFAULT NULL,
   `revokedDate` datetime DEFAULT NULL,
   `revokedReason` int(11) DEFAULT NULL,
+  `lastExpirationNagSent` datetime DEFAULT NULL,
   `LockCol` bigint(20) DEFAULT NULL,
   PRIMARY KEY (`serial`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -73,12 +74,12 @@ CREATE TABLE `deniedCSRs` (
 
 CREATE TABLE `ocspResponses` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `serial` varchar(255) NOT NULL,
+  `serial` varchar(255) DEFAULT NULL,
   `createdAt` datetime DEFAULT NULL,
   `response` mediumblob,
   PRIMARY KEY (`id`),
   KEY `SERIAL` (`serial`) COMMENT 'Actual lookup mechanism'
-) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `pending_authz` (
   `id` varchar(255) NOT NULL,
@@ -94,6 +95,7 @@ CREATE TABLE `pending_authz` (
   CONSTRAINT `regId_pending_authz` FOREIGN KEY (`registrationID`) REFERENCES `registrations` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+
 CREATE TABLE `identifierData` (
   `reversedName` varchar(255) NOT NULL,
   `certSHA1` varchar(40) NOT NULL,
@@ -107,7 +109,7 @@ CREATE TABLE `externalCerts` (
   `notAfter` datetime DEFAULT NULL,
   `spki` blob DEFAULT NULL,
   `valid` tinyint(1) DEFAULT NULL,
-  `ev` tinyint(1) DEFAULT NULL,  
+  `ev` tinyint(1) DEFAULT NULL,
   `rawDERCert` blob DEFAULT NULL,
   UNIQUE INDEX (sha1)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
This catches up the changes from 390464dd and 145790d9 that didn't make it into the schema.