### PR TITLE
separate race and coverage testing in TravisCI

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -116,9 +116,10 @@ function build_letsencrypt() {
 
 function run_unit_tests() {
   if [ "${TRAVIS}" == "true" ]; then
+    run go test -race ./...
     # Run each test by itself for Travis, so we can get coverage
     for dir in ${TESTDIRS}; do
-      run go test -race -covermode=count -coverprofile=${dir}.coverprofile ./${dir}/
+      run go test -covermode=count -coverprofile=${dir}.coverprofile ./${dir}/
     done
 
     # Gather all the coverprofiles


### PR DESCRIPTION
There are races in the count cover mode and that makes spurious-to-us looking race conditions crop up for things that are not races. There is an issue for it: golang/go#12118.

I've not investigated the performance impact of atomic covermode in conjunction with the race detector. If you want me to, I will. 