### PR TITLE
use the default, not racy covermode in TravisCI

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -118,7 +118,7 @@ function run_unit_tests() {
   if [ "${TRAVIS}" == "true" ]; then
     # Run each test by itself for Travis, so we can get coverage
     for dir in ${TESTDIRS}; do
-      run go test -race -covermode=count -coverprofile=${dir}.coverprofile ./${dir}/
+      run go test -race -cover -coverprofile=${dir}.coverprofile ./${dir}/
     done
 
     # Gather all the coverprofiles


### PR DESCRIPTION
The count covermode is racy and was causing spurious-to-us looking (but not really) race detections in the tests. See https://github.com/golang/go/issues/12118