### PR TITLE
add all of cmd/ to test.sh and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,7 @@ VERSION ?= 1.0.0
 EPOCH ?= 1
 MAINTAINER ?= "Community"
 
-OBJECTS = activity-monitor \
-	admin-revoker \
-	boulder-ca \
-	boulder-ra \
-	boulder-sa \
-	boulder-va \
-	boulder-wfe \
-	expiration-mailer \
-	ocsp-updater \
-	ocsp-responder
+OBJECTS = $(shell find ./cmd -type d -maxdepth 1 -mindepth 1 | xargs basename)
 
 # Build environment variables (referencing core/util.go)
 COMMIT_ID = $(shell git rev-parse --short HEAD)
@@ -48,7 +39,7 @@ $(OBJECTS): pre
 	@go build -o ./bin/$@ -ldflags \
 		"-X $(BUILD_ID_VAR) '$(BUILD_ID)' -X $(BUILD_TIME_VAR) '$(BUILD_TIME)' \
 		 -X $(BUILD_HOST_VAR) '$(BUILD_HOST)'" \
-		cmd/$@/main.go
+		./cmd/$@/
 
 clean:
 	rm -f $(OBJDIR)/*

--- a/test.sh
+++ b/test.sh
@@ -7,20 +7,7 @@ fi
 
 FAILURE=0
 
-TESTDIRS="analysis \
-          ca \
-          core \
-          log \
-          policy \
-          ra \
-          rpc \
-          sa \
-          test \
-          va \
-          wfe \
-          cmd/expiration-mailer"
-          # cmd
-          # Godeps
+TESTPATHS=$(go list -f '{{ .ImportPath }}' ./...)
 
 # We need to know, for github-pr-status, what the triggering commit is.
 # Assume first it's the travis commit (for builds of master), unless we're
@@ -117,8 +104,9 @@ function build_letsencrypt() {
 function run_unit_tests() {
   if [ "${TRAVIS}" == "true" ]; then
     # Run each test by itself for Travis, so we can get coverage
-    for dir in ${TESTDIRS}; do
-      run go test -race -cover -coverprofile=${dir}.coverprofile ./${dir}/
+    for path in ${TESTPATHS}; do
+      dir=$(basename $path)
+      run go test -race -cover -coverprofile=${dir}.coverprofile ${path}
     done
 
     # Gather all the coverprofiles


### PR DESCRIPTION
And fix a bug from a bad merge somewhere.

I'm a little leery of having to update a Makefile everytime we add a cmd.

I'm sure there's a good way to add all of cmd's subdirs without including shell.go but someone more skilled at m4 will have to make that change.