### PR TITLE
handle empty serial number table a bit better

### DIFF
--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -84,7 +84,12 @@ func (cadb *CertificateAuthorityDatabaseImpl) IncrementAndGetSerial(tx *gorp.Tra
 		return
 	}
 
-	row := rowObj.(*SerialNumber)
+	row, ok := rowObj.(*SerialNumber)
+	if !ok {
+		err = fmt.Errorf("No serial number found. This is a serious issue")
+		return
+	}
+
 	val = row.Number
 	row.Number = val + 1
 


### PR DESCRIPTION
Before, this code would panic and cause various bits of code to spin-loop. This way, we can at least figure out what's going on.