### PR TITLE
always set parseTime to true

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -96,11 +96,8 @@ func recombineURLForDB(dbConnect string) (string, error) {
 		return "", err
 	}
 
-	// Check the parseTime=true DSN is present
-	if k := dsnVals.Get("parseTime"); k != "true" {
-		dsnVals.Set("parseTime", "true")
-		dbURL.RawQuery = dsnVals.Encode()
-	}
+	dsnVals.Set("parseTime", "true")
+
 	user := dbURL.User.Username()
 	passwd, hasPass := dbURL.User.Password()
 	dbConn := ""

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -49,7 +49,7 @@
     "serialPrefix": 255,
     "profile": "ee",
     "dbDriver": "mysql",
-    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test?parseTime=true",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8001",
     "testMode": true,
     "_comment": "This should only be present in testMode. In prod use an HSM.",
@@ -116,7 +116,7 @@
 
   "sa": {
     "dbDriver": "mysql",
-    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test?parseTime=true",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8003"
   },
 
@@ -132,12 +132,12 @@
 
   "revoker": {
     "dbDriver": "mysql",
-    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test?parseTime=true"
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test"
   },
 
   "ocspResponder": {
     "dbDriver": "mysql",
-    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test?parseTime=true",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "path": "/",
     "listenAddress": "localhost:4001",
     "debugAddr": "localhost:8005"
@@ -145,7 +145,7 @@
 
   "ocspUpdater": {
     "dbDriver": "mysql",
-    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test?parseTime=true",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "minTimeToExpiry": "72h",
     "debugAddr": "localhost:8006"
   },
@@ -160,7 +160,7 @@
     "username": "cert-master@example.com",
     "password": "password",
     "dbDriver": "mysql",
-    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test?parseTime=true",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "messageLimit": 0,
     "nagTimes": ["24h", "72h", "168h", "336h"],
     "emailTemplate": "test/example-expiration-template",


### PR DESCRIPTION
There's no reason to not just enforce it in the code completely and not worry about it elsewhere. If we need to extract code out of NewDbMap, we'd need recombineURLForDB in it, anyhow.