### PR TITLE
Re-apply #505

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -14,7 +14,26 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/miekg/dns"
 )
 
-// DNSResolverImpl represents a resolver system
+var (
+	// Private CIDRs to ignore per RFC1918
+	// 10.0.0.0/8
+	rfc1918_10 = net.IPNet{
+		IP:   []byte{10, 0, 0, 0},
+		Mask: []byte{255, 0, 0, 0},
+	}
+	// 172.16.0.0/12
+	rfc1918_172_16 = net.IPNet{
+		IP:   []byte{172, 16, 0, 0},
+		Mask: []byte{255, 240, 0, 0},
+	}
+	// 192.168.0.0/16
+	rfc1918_192_168 = net.IPNet{
+		IP:   []byte{192, 168, 0, 0},
+		Mask: []byte{255, 255, 0, 0},
+	}
+)
+
+// DNSResolverImpl represents a client that talks to an external resolver
 type DNSResolverImpl struct {
 	DNSClient *dns.Client
 	Servers   []string
@@ -79,47 +98,34 @@ func (dnsResolver *DNSResolverImpl) LookupTXT(hostname string) ([]string, time.D
 	return txt, rtt, err
 }
 
-// LookupHost sends a DNS query to find all A/AAAA records associated with
-// the provided hostname.
-func (dnsResolver *DNSResolverImpl) LookupHost(hostname string) ([]net.IP, time.Duration, time.Duration, error) {
-	var addrs []net.IP
-	var answers []dns.RR
+func isPrivateV4(ip net.IP) bool {
+	return rfc1918_10.Contains(ip) || rfc1918_172_16.Contains(ip) || rfc1918_192_168.Contains(ip)
+}
 
-	r, aRtt, err := dnsResolver.ExchangeOne(hostname, dns.TypeA)
+// LookupHost sends a DNS query to find all A records associated with the provided
+// hostname. This method assumes that the external resolver will chase CNAME/DNAME
+// aliases and return relevant A records.
+func (dnsResolver *DNSResolverImpl) LookupHost(hostname string) ([]net.IP, time.Duration, error) {
+	var addrs []net.IP
+
+	r, rtt, err := dnsResolver.ExchangeOne(hostname, dns.TypeA)
 	if err != nil {
-		return addrs, 0, 0, err
+		return addrs, rtt, err
 	}
 	if r.Rcode != dns.RcodeSuccess {
 		err = fmt.Errorf("DNS failure: %d-%s for A query", r.Rcode, dns.RcodeToString[r.Rcode])
-		return nil, aRtt, 0, err
+		return nil, rtt, err
 	}
 
-	answers = append(answers, r.Answer...)
-
-	r, aaaaRtt, err := dnsResolver.ExchangeOne(hostname, dns.TypeAAAA)
-	if err != nil {
-		return addrs, aRtt, 0, err
-	}
-	if r.Rcode != dns.RcodeSuccess {
-		err = fmt.Errorf("DNS failure: %d-%s for AAAA query", r.Rcode, dns.RcodeToString[r.Rcode])
-		return nil, aRtt, aaaaRtt, err
-	}
-
-	answers = append(answers, r.Answer...)
-
-	for _, answer := range answers {
+	for _, answer := range r.Answer {
 		if answer.Header().Rrtype == dns.TypeA {
-			if a, ok := answer.(*dns.A); ok {
+			if a, ok := answer.(*dns.A); ok && a.A.To4() != nil && !isPrivateV4(a.A) {
 				addrs = append(addrs, a.A)
-			}
-		} else if answer.Header().Rrtype == dns.TypeAAAA {
-			if aaaa, ok := answer.(*dns.AAAA); ok {
-				addrs = append(addrs, aaaa.AAAA)
 			}
 		}
 	}
 
-	return addrs, aRtt, aaaaRtt, nil
+	return addrs, rtt, nil
 }
 
 // LookupCNAME returns the target name if a CNAME record exists for

--- a/core/dns_test.go
+++ b/core/dns_test.go
@@ -47,6 +47,13 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			record.Expire = 1
 			record.Minttl = 1
 			appendAnswer(record)
+		case dns.TypeAAAA:
+			if q.Name == "v6.letsencrypt.org." {
+				record := new(dns.AAAA)
+				record.Hdr = dns.RR_Header{Name: "v6.letsencrypt.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 0}
+				record.AAAA = net.ParseIP("::1")
+				appendAnswer(record)
+			}
 		case dns.TypeA:
 			if q.Name == "cps.letsencrypt.org." {
 				record := new(dns.A)
@@ -159,7 +166,7 @@ func TestDNSLookupsNoServer(t *testing.T) {
 	_, _, err := obj.LookupTXT("letsencrypt.org")
 	test.AssertError(t, err, "No servers")
 
-	_, _, _, err = obj.LookupHost("letsencrypt.org")
+	_, _, err = obj.LookupHost("letsencrypt.org")
 	test.AssertError(t, err, "No servers")
 
 	_, _, err = obj.LookupCNAME("letsencrypt.org")
@@ -179,7 +186,7 @@ func TestDNSServFail(t *testing.T) {
 	_, _, err = obj.LookupCNAME(bad)
 	test.AssertError(t, err, "LookupCNAME didn't return an error")
 
-	_, _, _, err = obj.LookupHost(bad)
+	_, _, err = obj.LookupHost(bad)
 	test.AssertError(t, err, "LookupHost didn't return an error")
 
 	// CAA lookup ignores validation failures from the resolver for now
@@ -201,20 +208,31 @@ func TestDNSLookupTXT(t *testing.T) {
 func TestDNSLookupHost(t *testing.T) {
 	obj := NewDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr})
 
-	ip, _, _, err := obj.LookupHost("servfail.com")
+	ip, _, err := obj.LookupHost("servfail.com")
 	t.Logf("servfail.com - IP: %s, Err: %s", ip, err)
 	test.AssertError(t, err, "Server failure")
 	test.Assert(t, len(ip) == 0, "Should not have IPs")
 
-	ip, _, _, err = obj.LookupHost("nonexistent.letsencrypt.org")
+	ip, _, err = obj.LookupHost("nonexistent.letsencrypt.org")
 	t.Logf("nonexistent.letsencrypt.org - IP: %s, Err: %s", ip, err)
 	test.AssertNotError(t, err, "Not an error to not exist")
 	test.Assert(t, len(ip) == 0, "Should not have IPs")
 
-	ip, _, _, err = obj.LookupHost("cps.letsencrypt.org")
+	// Single IPv4 address
+	ip, _, err = obj.LookupHost("cps.letsencrypt.org")
 	t.Logf("cps.letsencrypt.org - IP: %s, Err: %s", ip, err)
 	test.AssertNotError(t, err, "Not an error to exist")
-	test.Assert(t, len(ip) > 0, "Should have IPs")
+	test.Assert(t, len(ip) == 1, "Should have IP")
+	ip, _, err = obj.LookupHost("cps.letsencrypt.org")
+	t.Logf("cps.letsencrypt.org - IP: %s, Err: %s", ip, err)
+	test.AssertNotError(t, err, "Not an error to exist")
+	test.Assert(t, len(ip) == 1, "Should have IP")
+
+	// No IPv6
+	ip, _, err = obj.LookupHost("v6.letsencrypt.org")
+	t.Logf("v6.letsencrypt.org - IP: %s, Err: %s", ip, err)
+	test.AssertNotError(t, err, "Not an error to exist")
+	test.Assert(t, len(ip) == 0, "Should not have IPs")
 }
 
 func TestDNSLookupCAA(t *testing.T) {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -143,7 +143,7 @@ type CertificateAuthorityDatabase interface {
 type DNSResolver interface {
 	ExchangeOne(string, uint16) (*dns.Msg, time.Duration, error)
 	LookupTXT(string) ([]string, time.Duration, error)
-	LookupHost(string) ([]net.IP, time.Duration, time.Duration, error)
+	LookupHost(string) ([]net.IP, time.Duration, error)
 	LookupCNAME(string) (string, time.Duration, error)
 	LookupDNAME(string) (string, time.Duration, error)
 	LookupCAA(string) ([]*dns.CAA, time.Duration, error)

--- a/core/objects.go
+++ b/core/objects.go
@@ -222,6 +222,19 @@ func (r *Registration) MergeUpdate(input Registration) {
 	}
 }
 
+// ValidationRecord represents a validation attempt against a specific URL/hostname
+// and the IP addresses that were resolved and used
+type ValidationRecord struct {
+	// SimpleHTTP only
+	URL string `json:"url,omitempty"`
+
+	// Shared
+	Hostname          string   `json:"hostname"`
+	Port              string   `json:"port"`
+	AddressesResolved []net.IP `json:"addressesResolved"`
+	AddressUsed       net.IP   `json:"addressUsed"`
+}
+
 // Challenge is an aggregate of all data needed for any challenges.
 //
 // Rather than define individual types for different types of
@@ -253,8 +266,42 @@ type Challenge struct {
 	// Used by dns and dvsni challenges
 	Validation *jose.JsonWebSignature `json:"validation,omitempty"`
 
-	// IP addresses resolved from authorization identifier
-	ResolvedAddrs []net.IP `json:"resolvedAddrs,omitempty"`
+	// Contains information about URLs used or redirected to and IPs resolved and
+	// used
+	ValidationRecord []ValidationRecord `json:"validationRecord,omitempty"`
+}
+
+// RecordsSane checks the sanity of a ValidationRecord object before sending it
+// back to the RA to be stored.
+func (ch Challenge) RecordsSane() bool {
+	if ch.ValidationRecord == nil || len(ch.ValidationRecord) == 0 {
+		return false
+	}
+
+	switch ch.Type {
+	case ChallengeTypeSimpleHTTP:
+		for _, rec := range ch.ValidationRecord {
+			if rec.URL == "" || rec.Hostname == "" || rec.Port == "" || rec.AddressUsed == nil ||
+				len(rec.AddressesResolved) == 0 {
+				return false
+			}
+		}
+	case ChallengeTypeDVSNI:
+		if len(ch.ValidationRecord) > 1 {
+			return false
+		}
+		if ch.ValidationRecord[0].URL != "" {
+			return false
+		}
+		if ch.ValidationRecord[0].Hostname == "" || ch.ValidationRecord[0].Port == "" ||
+			ch.ValidationRecord[0].AddressUsed == nil || len(ch.ValidationRecord[0].AddressesResolved) == 0 {
+			return false
+		}
+	case ChallengeTypeDNS:
+		// Nothing for now
+	}
+
+	return true
 }
 
 // IsSane checks the sanity of a challenge object before issued to the client
@@ -303,7 +350,6 @@ func (ch Challenge) IsSane(completed bool) bool {
 		if completed && ch.Validation == nil {
 			return false
 		}
-
 	default:
 		return false
 	}

--- a/core/objects.go
+++ b/core/objects.go
@@ -252,6 +252,9 @@ type Challenge struct {
 
 	// Used by dns and dvsni challenges
 	Validation *jose.JsonWebSignature `json:"validation,omitempty"`
+
+	// IP addresses resolved from authorization identifier
+	ResolvedAddrs []net.IP `json:"resolvedAddrs,omitempty"`
 }
 
 // IsSane checks the sanity of a challenge object before issued to the client

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -7,6 +7,7 @@ package core
 
 import (
 	"encoding/json"
+	"net"
 	"testing"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
@@ -39,7 +40,33 @@ func TestRegistrationUpdate(t *testing.T) {
 	test.Assert(t, reg.Agreement == update.Agreement, "Agreement was not updated")
 }
 
-func TestSanityCheck(t *testing.T) {
+func TestRecordSanityCheck(t *testing.T) {
+	rec := []ValidationRecord{
+		ValidationRecord{
+			URL:               "http://localhost/test",
+			Hostname:          "localhost",
+			Port:              "80",
+			AddressesResolved: []net.IP{net.IP{127, 0, 0, 1}},
+			AddressUsed:       net.IP{127, 0, 0, 1},
+		},
+	}
+
+	chall := Challenge{Type: ChallengeTypeSimpleHTTP, ValidationRecord: rec}
+	test.Assert(t, chall.RecordsSane(), "Record should be sane")
+	chall.ValidationRecord[0].URL = ""
+	test.Assert(t, !chall.RecordsSane(), "Record should not be sane")
+
+	chall = Challenge{Type: ChallengeTypeDVSNI, ValidationRecord: rec}
+	chall.ValidationRecord[0].URL = ""
+	test.Assert(t, chall.RecordsSane(), "Record should be sane")
+	chall.ValidationRecord[0].Hostname = ""
+	test.Assert(t, !chall.RecordsSane(), "Record should not be sane")
+
+	chall.ValidationRecord = append(chall.ValidationRecord, rec...)
+	test.Assert(t, !chall.RecordsSane(), "Record should not be sane")
+}
+
+func TestChallengeSanityCheck(t *testing.T) {
 	types := []string{ChallengeTypeSimpleHTTP, ChallengeTypeDVSNI, ChallengeTypeDNS}
 	for _, challengeType := range types {
 		chall := Challenge{Type: challengeType, Status: StatusInvalid}
@@ -58,9 +85,26 @@ func TestSanityCheck(t *testing.T) {
 		if challengeType == ChallengeTypeSimpleHTTP {
 			tls := true
 			chall.TLS = &tls
+			chall.ValidationRecord = []ValidationRecord{ValidationRecord{
+				URL:               "",
+				Hostname:          "localhost",
+				Port:              "80",
+				AddressesResolved: []net.IP{net.IP{127, 0, 0, 1}},
+				AddressUsed:       net.IP{127, 0, 0, 1},
+			}}
 			test.Assert(t, chall.IsSane(false), "IsSane should be true")
 		} else if challengeType == ChallengeTypeDVSNI || challengeType == ChallengeTypeDNS {
 			chall.Validation = new(jose.JsonWebSignature)
+			if challengeType == ChallengeTypeDVSNI {
+				chall.ValidationRecord = []ValidationRecord{ValidationRecord{
+					Hostname:          "localhost",
+					Port:              "80",
+					AddressesResolved: []net.IP{net.IP{127, 0, 0, 1}},
+					AddressUsed:       net.IP{127, 0, 0, 1},
+				}}
+			} else {
+				chall.ValidationRecord = []ValidationRecord{}
+			}
 			test.Assert(t, chall.IsSane(true), "IsSane should be true")
 		}
 	}

--- a/docs/database/db_schema-main.sql
+++ b/docs/database/db_schema-main.sql
@@ -70,6 +70,7 @@ CREATE TABLE `challenges` (
   `token` varchar(255) NOT NULL,
   `tls` tinyint(1) DEFAULT NULL,
   `validation` mediumblob,
+  `validationRecord` mediumblob,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -66,12 +66,12 @@ func (mock *MockDNS) LookupTXT(hostname string) ([]string, time.Duration, error)
 }
 
 // LookupHost is a mock
-func (mock *MockDNS) LookupHost(hostname string) ([]net.IP, time.Duration, time.Duration, error) {
-	if hostname == "always.invalid" {
-		return []net.IP{}, 0, 0, nil
+func (mock *MockDNS) LookupHost(hostname string) ([]net.IP, time.Duration, error) {
+	if hostname == "always.invalid" || hostname == "invalid.invalid" {
+		return []net.IP{}, 0, nil
 	}
 	ip := net.ParseIP("127.0.0.1")
-	return []net.IP{ip}, 0, 0, nil
+	return []net.IP{ip}, 0, nil
 }
 
 // LookupCNAME is a mock

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -67,7 +67,11 @@ func (mock *MockDNS) LookupTXT(hostname string) ([]string, time.Duration, error)
 
 // LookupHost is a mock
 func (mock *MockDNS) LookupHost(hostname string) ([]net.IP, time.Duration, time.Duration, error) {
-	return nil, 0, 0, nil
+	if hostname == "always.invalid" {
+		return []net.IP{}, 0, 0, nil
+	}
+	ip := net.ParseIP("127.0.0.1")
+	return []net.IP{ip}, 0, 0, nil
 }
 
 // LookupCNAME is a mock

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -200,15 +200,16 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 	} else {
 		scheme = "http"
 	}
-	if va.TestMode {
-		hostName = "localhost:5001"
-	}
 
-	url := fmt.Sprintf("%s://%s/.well-known/acme-challenge/%s", scheme, hostName, challenge.Token)
+	url := url.URL{
+		Scheme: scheme,
+		Host:   hostName,
+		Path:   fmt.Sprintf(".well-known/acme-challenge/%s", challenge.Token),
+	}
 
 	// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
 	va.log.Audit(fmt.Sprintf("Attempting to validate Simple%s for %s", strings.ToUpper(scheme), url))
-	httpRequest, err := http.NewRequest("GET", url, nil)
+	httpRequest, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
 		challenge.Error = &core.ProblemDetails{
 			Type:   core.MalformedProblem,

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -147,7 +147,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 		challenge.Status = core.StatusInvalid
 		return challenge, errors.New(challenge.Error.Detail)
 	}
-	va.log.Audit(fmt.Sprintf("Resolved IP addresses for SimpleHTTP validation for %s: %s", hostName, addrs))
+	challenge.ResolvedAddrs = addrs
 
 	var scheme string
 	if input.TLS == nil || (input.TLS != nil && *input.TLS) {
@@ -320,7 +320,7 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 		challenge.Status = core.StatusInvalid
 		return challenge, errors.New(challenge.Error.Detail)
 	}
-	va.log.Audit(fmt.Sprintf("Resolved IP addresses for DVSNI validation for %s: %s", identifier.Value, addrs))
+	challenge.ResolvedAddrs = addrs
 
 	// Make a connection with SNI = nonceName
 	hostPort := fmt.Sprintf("%s:443", addrs[0].String())

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +30,9 @@ import (
 )
 
 const maxCNAME = 16 // Prevents infinite loops. Same limit as BIND.
+const maxRedirect = 10
+
+var validationTimeout = time.Second * 5
 
 // Returned by CheckCAARecords if it has to follow too many
 // consecutive CNAME lookups.
@@ -63,7 +67,6 @@ type verificationRequestEvent struct {
 }
 
 func verifyValidationJWS(validation *jose.JsonWebSignature, accountKey *jose.JsonWebKey, target map[string]interface{}) error {
-
 	if len(validation.Signatures) > 1 {
 		return fmt.Errorf("Too many signatures on validation JWS")
 	}
@@ -98,24 +101,83 @@ func verifyValidationJWS(validation *jose.JsonWebSignature, accountKey *jose.Jso
 	return nil
 }
 
-// Validation methods
-
-// setChallengeErrorFromDNSError checks the error returned from Lookup...
+// problemDetailsFromDNSError checks the error returned from Lookup...
 // methods and tests if the error was an underlying net.OpError or an error
-// caused by resolver returning SERVFAIL or other invalid Rcodes and sets
-// the challenge.Error field accordingly.
-func setChallengeErrorFromDNSError(err error, challenge *core.Challenge) {
-	challenge.Error = &core.ProblemDetails{Type: core.ConnectionProblem}
+// caused by resolver returning SERVFAIL or other invalid Rcodes and returns
+// the relevant core.ProblemDetails.
+func problemDetailsFromDNSError(err error) *core.ProblemDetails {
+	problem := &core.ProblemDetails{Type: core.ConnectionProblem}
 	if netErr, ok := err.(*net.OpError); ok {
 		if netErr.Timeout() {
-			challenge.Error.Detail = "DNS query timed out"
+			problem.Detail = "DNS query timed out"
 		} else if netErr.Temporary() {
-			challenge.Error.Detail = "Temporary network connectivity error"
+			problem.Detail = "Temporary network connectivity error"
 		}
 	} else {
-		challenge.Error.Detail = "Server failure at resolver"
+		problem.Detail = "Server failure at resolver"
 	}
+	return problem
 }
+
+// getAddr will query for all A records associated with hostname and return the
+// prefered address, the first net.IP in the addrs slice, and all addresses resolved.
+// This is the same choice made by the Go internal resolution library used by
+// net/http, except we only send A queries and accept IPv4 addresses.
+// TODO(#593): Add IPv6 support
+func (va ValidationAuthorityImpl) getAddr(hostname string) (addr net.IP, addrs []net.IP, problem *core.ProblemDetails) {
+	addrs, _, err := va.DNSResolver.LookupHost(hostname)
+	if err != nil {
+		problem = problemDetailsFromDNSError(err)
+		va.log.Debug(fmt.Sprintf("%s DNS failure: %s", hostname, err))
+		return
+	}
+	if len(addrs) == 0 {
+		problem = &core.ProblemDetails{
+			Type:   core.UnknownHostProblem,
+			Detail: fmt.Sprintf("No IPv4 addresses found for %s", hostname),
+		}
+		return
+	}
+	addr = addrs[0]
+	va.log.Info(fmt.Sprintf("Resolved addresses for %s [using %s]: %s", hostname, addr, addrs))
+	return
+}
+
+type dialer struct {
+	record core.ValidationRecord
+}
+
+func (d *dialer) Dial(_, _ string) (net.Conn, error) {
+	realDialer := net.Dialer{Timeout: validationTimeout}
+	return realDialer.Dial("tcp", net.JoinHostPort(d.record.AddressUsed.String(), d.record.Port))
+}
+
+// resolveAndConstructDialer gets the prefered address using va.getAddr and returns
+// the chosen address and dialer for that address and correct port.
+func (va ValidationAuthorityImpl) resolveAndConstructDialer(name, defaultPort string) (dialer, *core.ProblemDetails) {
+	port := "80"
+	if va.TestMode {
+		port = "5001"
+	} else if defaultPort != "" {
+		port = defaultPort
+	}
+	d := dialer{
+		record: core.ValidationRecord{
+			Hostname: name,
+			Port:     port,
+		},
+	}
+
+	addr, allAddrs, err := va.getAddr(name)
+	if err != nil {
+		return d, err
+	}
+	d.record.AddressesResolved = allAddrs
+	d.record.AddressUsed = addr
+	return d, nil
+}
+
+// Validation methods
 
 func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentifier, input core.Challenge, accountKey jose.JsonWebKey) (core.Challenge, error) {
 	challenge := input
@@ -131,23 +193,6 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 		return challenge, challenge.Error
 	}
 	hostName := identifier.Value
-
-	addrs, _, _, err := va.DNSResolver.LookupHost(hostName)
-	if err != nil {
-		challenge.Status = core.StatusInvalid
-		setChallengeErrorFromDNSError(err, &challenge)
-		va.log.Debug(fmt.Sprintf("%s [%s] DNS failure: %s", challenge.Type, identifier, err))
-		return challenge, challenge.Error
-	}
-	if len(addrs) == 0 {
-		challenge.Error = &core.ProblemDetails{
-			Type:   core.UnknownHostProblem,
-			Detail: fmt.Sprintf("Could not resolve %s", hostName),
-		}
-		challenge.Status = core.StatusInvalid
-		return challenge, errors.New(challenge.Error.Detail)
-	}
-	challenge.ResolvedAddrs = addrs
 
 	var scheme string
 	if input.TLS == nil || (input.TLS != nil && *input.TLS) {
@@ -179,37 +224,71 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 	}
 
 	httpRequest.Host = hostName
-	tr := *http.DefaultTransport.(*http.Transport)
-	// We are talking to a client that does not yet have a certificate,
-	// so we accept a temporary, invalid one.
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	// We don't expect to make multiple requests to a client, so close
-	// connection immediately.
-	tr.DisableKeepAlives = true
-	// Intercept Dial in order to connect to the IP address we
-	// selected above.
-	defaultDial := tr.Dial
-	tr.Dial = func(_, _ string) (net.Conn, error) {
-		// Ignore the addr selected by net/http.
-		port := "80"
-		if va.TestMode {
-			port = "5001"
-		} else if scheme == "https" {
+	var port string
+	if scheme == "https" {
+		port = "443"
+	}
+	dialer, prob := va.resolveAndConstructDialer(hostName, port)
+	dialer.record.URL = url.String()
+	challenge.ValidationRecord = append(challenge.ValidationRecord, dialer.record)
+	if prob != nil {
+		challenge.Status = core.StatusInvalid
+		challenge.Error = prob
+		return challenge, prob
+	}
+
+	tr := &http.Transport{
+		// We are talking to a client that does not yet have a certificate,
+		// so we accept a temporary, invalid one.
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		// We don't expect to make multiple requests to a client, so close
+		// connection immediately.
+		DisableKeepAlives: true,
+		// Intercept Dial in order to connect to the IP address we
+		// select.
+		Dial: dialer.Dial,
+	}
+
+	logRedirect := func(req *http.Request, via []*http.Request) error {
+		if len(challenge.ValidationRecord) >= maxRedirect {
+			return fmt.Errorf("Too many redirects")
+		}
+
+		host := req.URL.Host
+		port = ""
+		if strings.Contains(host, ":") {
+			splitHost := strings.SplitN(host, ":", 2)
+			if len(splitHost) <= 1 {
+				return fmt.Errorf("Malformed host")
+			}
+			host, port = splitHost[0], splitHost[1]
+			portNum, err := strconv.Atoi(port)
+			if err != nil {
+				return err
+			}
+			if portNum < 0 || portNum > 65535 {
+				return fmt.Errorf("Invalid port number in redirect")
+			}
+		} else if strings.ToLower(req.URL.Scheme) == "https" {
 			port = "443"
 		}
-		return defaultDial("tcp", net.JoinHostPort(addrs[0].String(), port))
-	}
-	logRedirect := func(req *http.Request, via []*http.Request) error {
-		va.log.Info(fmt.Sprintf("validateSimpleHTTP [%s] redirect from %q to %q", identifier, via[len(via)-1].URL.String(), req.URL.String()))
+
+		dialer, err := va.resolveAndConstructDialer(host, port)
+		dialer.record.URL = req.URL.String()
+		challenge.ValidationRecord = append(challenge.ValidationRecord, dialer.record)
+		if err != nil {
+			return err
+		}
+		tr.Dial = dialer.Dial
+		va.log.Info(fmt.Sprintf("validateSimpleHTTP [%s] redirect from %q to %q [%s]", identifier, via[len(via)-1].URL.String(), req.URL.String(), dialer.record.AddressUsed))
 		return nil
 	}
 	client := http.Client{
-		Transport:     &tr,
+		Transport:     tr,
 		CheckRedirect: logRedirect,
-		Timeout:       5 * time.Second,
+		Timeout:       validationTimeout,
 	}
 	httpResponse, err := client.Do(httpRequest)
-
 	if err != nil {
 		challenge.Status = core.StatusInvalid
 		challenge.Error = &core.ProblemDetails{
@@ -224,8 +303,8 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 		challenge.Status = core.StatusInvalid
 		challenge.Error = &core.ProblemDetails{
 			Type: core.UnauthorizedProblem,
-			Detail: fmt.Sprintf("Invalid response from %s: %d",
-				url, httpResponse.StatusCode),
+			Detail: fmt.Sprintf("Invalid response from %s [%s]: %d",
+				url.String(), dialer.record.AddressUsed, httpResponse.StatusCode),
 		}
 		err = challenge.Error
 		return challenge, err
@@ -317,31 +396,30 @@ func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, 
 	Z := hex.EncodeToString(h.Sum(nil))
 	ZName := fmt.Sprintf("%s.%s.%s", Z[:32], Z[32:], core.DVSNISuffix)
 
-	addrs, _, _, err := va.DNSResolver.LookupHost(identifier.Value)
-	if err != nil {
+	addr, allAddrs, problem := va.getAddr(identifier.Value)
+	challenge.ValidationRecord = []core.ValidationRecord{
+		core.ValidationRecord{
+			Hostname:          identifier.Value,
+			AddressesResolved: allAddrs,
+			AddressUsed:       addr,
+		},
+	}
+	if problem != nil {
 		challenge.Status = core.StatusInvalid
-		setChallengeErrorFromDNSError(err, &challenge)
-		va.log.Debug(fmt.Sprintf("%s [%s] DNS failure: %s", challenge.Type, identifier, err))
+		challenge.Error = problem
 		return challenge, challenge.Error
 	}
-	if len(addrs) == 0 {
-		challenge.Error = &core.ProblemDetails{
-			Type:   core.UnknownHostProblem,
-			Detail: fmt.Sprintf("Could not resolve %s", identifier.Value),
-		}
-		challenge.Status = core.StatusInvalid
-		return challenge, errors.New(challenge.Error.Detail)
-	}
-	challenge.ResolvedAddrs = addrs
 
 	// Make a connection with SNI = nonceName
-	hostPort := fmt.Sprintf("%s:443", addrs[0].String())
+	hostPort := net.JoinHostPort(addr.String(), "443")
+	challenge.ValidationRecord[0].Port = "443"
 	if va.TestMode {
-		hostPort = "localhost:5001"
+		hostPort = net.JoinHostPort(addr.String(), "5001")
+		challenge.ValidationRecord[0].Port = "5001"
 	}
 	va.log.Notice(fmt.Sprintf("DVSNI [%s] Attempting to validate DVSNI for %s %s",
 		identifier, hostPort, ZName))
-	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", hostPort, &tls.Config{
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: validationTimeout}, "tcp", hostPort, &tls.Config{
 		ServerName:         ZName,
 		InsecureSkipVerify: true,
 	})
@@ -442,7 +520,7 @@ func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, in
 
 	if err != nil {
 		challenge.Status = core.StatusInvalid
-		setChallengeErrorFromDNSError(err, &challenge)
+		challenge.Error = problemDetailsFromDNSError(err)
 		va.log.Debug(fmt.Sprintf("%s [%s] DNS failure: %s", challenge.Type, identifier, err))
 		return challenge, challenge.Error
 	}
@@ -465,9 +543,6 @@ func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, in
 // Overall validation process
 
 func (va ValidationAuthorityImpl) validate(authz core.Authorization, challengeIndex int, accountKey jose.JsonWebKey) {
-
-	// Select the first supported validation method
-	// XXX: Remove the "break" lines to process all supported validations
 	logEvent := verificationRequestEvent{
 		ID:          authz.ID,
 		Requester:   authz.RegistrationID,
@@ -486,19 +561,22 @@ func (va ValidationAuthorityImpl) validate(authz core.Authorization, challengeIn
 		switch authz.Challenges[challengeIndex].Type {
 		case core.ChallengeTypeSimpleHTTP:
 			authz.Challenges[challengeIndex], err = va.validateSimpleHTTP(authz.Identifier, authz.Challenges[challengeIndex], accountKey)
-			break
 		case core.ChallengeTypeDVSNI:
 			authz.Challenges[challengeIndex], err = va.validateDvsni(authz.Identifier, authz.Challenges[challengeIndex], accountKey)
-			break
 		case core.ChallengeTypeDNS:
 			authz.Challenges[challengeIndex], err = va.validateDNS(authz.Identifier, authz.Challenges[challengeIndex], accountKey)
-			break
 		}
 
-		logEvent.Challenge = authz.Challenges[challengeIndex]
 		if err != nil {
 			logEvent.Error = err.Error()
+		} else if !authz.Challenges[challengeIndex].RecordsSane() {
+			chall := &authz.Challenges[challengeIndex]
+			chall.Status = core.StatusInvalid
+			chall.Error = &core.ProblemDetails{Type: core.ServerInternalProblem,
+				Detail: "Records for validation failed sanity check"}
+			logEvent.Error = chall.Error.Detail
 		}
+		logEvent.Challenge = authz.Challenges[challengeIndex]
 	}
 
 	// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -287,7 +287,7 @@ func TestSimpleHttp(t *testing.T) {
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
 	test.AssertError(t, err, "Should have found a 404 for the challenge.")
 	test.AssertEquals(t, invalidChall.Error.Type, core.UnauthorizedProblem)
-	test.AssertEquals(t, len(log.GetAllMatching(`^\[AUDIT\] `)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`^\[AUDIT\] `)), 2)
 
 	log.Clear()
 	chall.Token = pathWrongToken

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -65,6 +65,9 @@ const pathWrongToken = "wrongtoken"
 const path404 = "404"
 const pathFound = "302"
 const pathMoved = "301"
+const pathRedirectLookup = "re-lookup"
+const pathRedirectLookupInvalid = "re-lookup-invalid"
+const pathRedirectPort = "port-redirect"
 
 func createValidation(token string, enableTLS bool) string {
 	payload, _ := json.Marshal(map[string]interface{}{
@@ -84,33 +87,48 @@ func simpleSrv(t *testing.T, token string, stopChan, waitChan chan bool, enableT
 	currentToken := defaultToken
 
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Host != "localhost" {
+		if r.Host != "localhost" && r.Host != "other.valid" && r.Host != "other.valid:8080" {
 			t.Errorf("Bad Host header: " + r.Host)
 		}
-		if strings.HasSuffix(r.URL.Path, path404) {
+		if strings.HasSuffix(r.URL.Token, path404) {
 			t.Logf("SIMPLESRV: Got a 404 req\n")
 			http.NotFound(w, r)
-		} else if strings.HasSuffix(r.URL.Path, pathMoved) {
+		} else if strings.HasSuffix(r.URL.Token, pathMoved) {
 			t.Logf("SIMPLESRV: Got a 301 redirect req\n")
 			if currentToken == defaultToken {
 				currentToken = pathMoved
 			}
 			http.Redirect(w, r, "valid", 301)
-		} else if strings.HasSuffix(r.URL.Path, pathFound) {
+		} else if strings.HasSuffix(r.URL.Token, pathFound) {
 			t.Logf("SIMPLESRV: Got a 302 redirect req\n")
 			if currentToken == defaultToken {
 				currentToken = pathFound
 			}
 			http.Redirect(w, r, pathMoved, 302)
-		} else if strings.HasSuffix(r.URL.Path, "wait") {
+		} else if strings.HasSuffix(r.URL.Token, "wait") {
 			t.Logf("SIMPLESRV: Got a wait req\n")
 			time.Sleep(time.Second * 3)
-		} else if strings.HasSuffix(r.URL.Path, "wait-long") {
+		} else if strings.HasSuffix(r.URL.Token, "wait-long") {
 			t.Logf("SIMPLESRV: Got a wait-long req\n")
 			time.Sleep(time.Second * 10)
+		} else if strings.HasSuffix(r.URL.Path, "re-lookup") {
+			t.Logf("SIMPLESRV: Got a redirect req to a valid hostname\n")
+			if currentToken == defaultToken {
+				currentToken = "re-lookup"
+			}
+			http.Redirect(w, r, "http://other.valid/path", 302)
+		} else if strings.HasSuffix(r.URL.Path, "re-lookup-invalid") {
+			t.Logf("SIMPLESRV: Got a redirect req to a invalid hostname\n")
+			http.Redirect(w, r, "http://invalid.invalid/path", 302)
+		} else if strings.HasSuffix(r.URL.Path, "looper") {
+			t.Logf("SIMPLESRV: Got a loop req\n")
+			http.Redirect(w, r, r.URL.String(), 301)
+		} else if strings.HasSuffix(r.URL.Path, pathRedirectPort) {
+			t.Logf("SIMPLESRV: Got a port redirect req\n")
+			http.Redirect(w, r, "http://other.valid:8080/path", 302)
 		} else {
 			t.Logf("SIMPLESRV: Got a valid req\n")
-			fmt.Fprintf(w, "%s", createValidation(currentToken, enableTLS))
+			fmt.Fprint(w, createValidation(currentToken, enableTLS))
 			currentToken = defaultToken
 		}
 	})
@@ -243,7 +261,7 @@ func TestSimpleHttpTLS(t *testing.T) {
 	va := NewValidationAuthorityImpl(true)
 	va.DNSResolver = &mocks.MockDNS{}
 
-	chall := core.Challenge{Type: core.ChallengeTypeSimpleHTTP, Token: expectedToken}
+	chall := core.Challenge{Type: core.ChallengeTypeSimpleHTTP, Token: expectedToken, ValidationRecord: []core.ValidationRecord{}}
 
 	stopChan := make(chan bool, 1)
 	waitChan := make(chan bool, 1)
@@ -265,7 +283,7 @@ func TestSimpleHttp(t *testing.T) {
 	va.DNSResolver = &mocks.MockDNS{}
 
 	tls := false
-	chall := core.Challenge{Type: core.ChallengeTypeSimpleHTTP, Token: expectedToken, TLS: &tls}
+	chall := core.Challenge{Type: core.ChallengeTypeSimpleHTTP, Token: expectedToken, TLS: &tls, ValidationRecord: []core.ValidationRecord{}}
 
 	invalidChall, err := va.validateSimpleHTTP(ident, chall, AccountKey)
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
@@ -285,8 +303,8 @@ func TestSimpleHttp(t *testing.T) {
 	test.AssertEquals(t, len(log.GetAllMatching(`^\[AUDIT\] `)), 1)
 
 	log.Clear()
-	chall.Token = path404
-	invalidChall, err = va.validateSimpleHTTP(ident, chall, AccountKey)
+	chall.Path = path404
+	invalidChall, err = va.validateSimpleHTTP(ident, chall)
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
 	test.AssertError(t, err, "Should have found a 404 for the challenge.")
 	test.AssertEquals(t, invalidChall.Error.Type, core.UnauthorizedProblem)
@@ -342,16 +360,96 @@ func TestSimpleHttp(t *testing.T) {
 	test.AssertEquals(t, invalidChall.Error.Type, core.ConnectionProblem)
 }
 
+func TestSimpleHttpRedirectLookup(t *testing.T) {
+	va := NewValidationAuthorityImpl(true)
+	va.DNSResolver = &mocks.MockDNS{}
+
+	tls := false
+	chall := core.Challenge{Token: expectedToken, TLS: &tls, ValidationRecord: []core.ValidationRecord{}}
+
+	stopChan := make(chan bool, 1)
+	waitChan := make(chan bool, 1)
+	go simpleSrv(t, expectedToken, stopChan, waitChan, tls)
+	defer func() { stopChan <- true }()
+	<-waitChan
+
+	log.Clear()
+	chall.Token = pathMoved
+	finChall, err := va.validateSimpleHTTP(ident, chall, AccountKey)
+	test.AssertEquals(t, finChall.Status, core.StatusValid)
+	test.AssertNotError(t, err, chall.Token)
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/301" to ".*/valid"`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 2)
+
+	log.Clear()
+	chall.Token = pathFound
+	finChall, err = va.validateSimpleHTTP(ident, chall, AccountKey)
+	test.AssertEquals(t, finChall.Status, core.StatusValid)
+	test.AssertNotError(t, err, chall.Token)
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/302" to ".*/301"`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/301" to ".*/valid"`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 3)
+
+	log.Clear()
+	chall.Token = pathRedirectLookupInvalid
+	finChall, err = va.validateSimpleHTTP(ident, chall, AccountKey)
+	test.AssertEquals(t, finChall.Status, core.StatusInvalid)
+	test.AssertError(t, err, chall.Token)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`No IPv4 addresses found for invalid.invalid`)), 1)
+
+	log.Clear()
+	chall.Token = pathRedirectLookup
+	finChall, err = va.validateSimpleHTTP(ident, chall, AccountKey)
+	test.AssertEquals(t, finChall.Status, core.StatusValid)
+	test.AssertNotError(t, err, chall.Token)
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/re-lookup" to ".*other.valid/path"`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for other.valid \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
+
+	log.Clear()
+	chall.Token = pathRedirectPort
+	finChall, err = va.validateSimpleHTTP(ident, chall, AccountKey)
+	fmt.Println(finChall.ValidationRecord)
+	test.AssertEquals(t, finChall.Status, core.StatusInvalid)
+	test.AssertError(t, err, chall.Token)
+	test.AssertEquals(t, len(log.GetAllMatching(`redirect from ".*/port-redirect" to ".*other.valid:8080/path"`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for other.valid \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
+}
+
+func TestSimpleHttpRedirectLoop(t *testing.T) {
+	va := NewValidationAuthorityImpl(true)
+	va.DNSResolver = &mocks.MockDNS{}
+
+	tls := false
+	chall := core.Challenge{Token: "looper", TLS: &tls, ValidationRecord: []core.ValidationRecord{}}
+
+	stopChan := make(chan bool, 1)
+	waitChan := make(chan bool, 1)
+	go simpleSrv(t, expectedToken, stopChan, waitChan, tls)
+	defer func() { stopChan <- true }()
+	<-waitChan
+
+	log.Clear()
+	finChall, err := va.validateSimpleHTTP(ident, chall, AccountKey)
+	test.AssertEquals(t, finChall.Status, core.StatusInvalid)
+	test.AssertError(t, err, chall.Token)
+	fmt.Println(finChall)
+}
+
 func TestDvsni(t *testing.T) {
 	va := NewValidationAuthorityImpl(true)
 	va.DNSResolver = &mocks.MockDNS{}
 
 	chall := createChallenge(core.ChallengeTypeDVSNI)
 
+	log.Clear()
 	invalidChall, err := va.validateDvsni(ident, chall, AccountKey)
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
 	test.AssertError(t, err, "Server's not up yet; expected refusal. Where did we connect?")
 	test.AssertEquals(t, invalidChall.Error.Type, core.ConnectionProblem)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
 
 	waitChan := make(chan bool, 1)
 	stopChan := make(chan bool, 1)
@@ -359,15 +457,19 @@ func TestDvsni(t *testing.T) {
 	defer func() { stopChan <- true }()
 	<-waitChan
 
+	log.Clear()
 	finChall, err := va.validateDvsni(ident, chall, AccountKey)
 	test.AssertEquals(t, finChall.Status, core.StatusValid)
 	test.AssertNotError(t, err, "")
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
 
+	log.Clear()
 	invalidChall, err = va.validateDvsni(core.AcmeIdentifier{Type: core.IdentifierType("ip"), Value: "127.0.0.1"}, chall, AccountKey)
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
 	test.AssertError(t, err, "IdentifierType IP shouldn't have worked.")
 	test.AssertEquals(t, invalidChall.Error.Type, core.MalformedProblem)
 
+	log.Clear()
 	va.TestMode = false
 	invalidChall, err = va.validateDvsni(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "always.invalid"}, chall, AccountKey)
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
@@ -385,6 +487,7 @@ func TestDvsni(t *testing.T) {
 	signer, _ := jose.NewSigner(jose.RS256, &TheKey)
 	chall.Validation, _ = signer.Sign(validationPayload, "")
 
+	log.Clear()
 	started := time.Now()
 	invalidChall, err = va.validateDvsni(ident, chall, AccountKey)
 	took := time.Since(started)
@@ -394,6 +497,7 @@ func TestDvsni(t *testing.T) {
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
 	test.AssertError(t, err, "Connection should've timed out")
 	test.AssertEquals(t, invalidChall.Error.Type, core.ConnectionProblem)
+	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
 }
 
 func TestTLSError(t *testing.T) {
@@ -422,6 +526,7 @@ func TestValidateHTTP(t *testing.T) {
 	tls := false
 	challHTTP := core.SimpleHTTPChallenge()
 	challHTTP.TLS = &tls
+	challHTTP.ValidationRecord = []core.ValidationRecord{}
 
 	stopChanHTTP := make(chan bool, 1)
 	waitChanHTTP := make(chan bool, 1)
@@ -449,9 +554,10 @@ func TestValidateHTTP(t *testing.T) {
 // challengeType == "dvsni" or "dns", since they're the same
 func createChallenge(challengeType string) core.Challenge {
 	chall := core.Challenge{
-		Type:   challengeType,
-		Status: core.StatusPending,
-		Token:  core.NewToken(),
+		Type:             challengeType,
+		Status:           core.StatusPending,
+		Token:            core.NewToken(),
+		ValidationRecord: []core.ValidationRecord{},
 	}
 
 	validationPayload, _ := json.Marshal(map[string]interface{}{
@@ -535,6 +641,7 @@ func TestUpdateValidations(t *testing.T) {
 	tls := false
 	challHTTP := core.SimpleHTTPChallenge()
 	challHTTP.TLS = &tls
+	challHTTP.ValidationRecord = []core.ValidationRecord{}
 
 	stopChanHTTP := make(chan bool, 1)
 	waitChanHTTP := make(chan bool, 1)

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -287,7 +287,7 @@ func TestSimpleHttp(t *testing.T) {
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
 	test.AssertError(t, err, "Should have found a 404 for the challenge.")
 	test.AssertEquals(t, invalidChall.Error.Type, core.UnauthorizedProblem)
-	test.AssertEquals(t, len(log.GetAllMatching(`^\[AUDIT\] `)), 2)
+	test.AssertEquals(t, len(log.GetAllMatching(`^\[AUDIT\] `)), 1)
 
 	log.Clear()
 	chall.Token = pathWrongToken

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -84,6 +84,9 @@ func simpleSrv(t *testing.T, token string, stopChan, waitChan chan bool, enableT
 	currentToken := defaultToken
 
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != "localhost" {
+			t.Errorf("Bad Host header: " + r.Host)
+		}
 		if strings.HasSuffix(r.URL.Path, path404) {
 			t.Logf("SIMPLESRV: Got a 404 req\n")
 			http.NotFound(w, r)

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -90,25 +90,25 @@ func simpleSrv(t *testing.T, token string, stopChan, waitChan chan bool, enableT
 		if r.Host != "localhost" && r.Host != "other.valid" && r.Host != "other.valid:8080" {
 			t.Errorf("Bad Host header: " + r.Host)
 		}
-		if strings.HasSuffix(r.URL.Token, path404) {
+		if strings.HasSuffix(r.URL.Path, path404) {
 			t.Logf("SIMPLESRV: Got a 404 req\n")
 			http.NotFound(w, r)
-		} else if strings.HasSuffix(r.URL.Token, pathMoved) {
+		} else if strings.HasSuffix(r.URL.Path, pathMoved) {
 			t.Logf("SIMPLESRV: Got a 301 redirect req\n")
 			if currentToken == defaultToken {
 				currentToken = pathMoved
 			}
 			http.Redirect(w, r, "valid", 301)
-		} else if strings.HasSuffix(r.URL.Token, pathFound) {
+		} else if strings.HasSuffix(r.URL.Path, pathFound) {
 			t.Logf("SIMPLESRV: Got a 302 redirect req\n")
 			if currentToken == defaultToken {
 				currentToken = pathFound
 			}
 			http.Redirect(w, r, pathMoved, 302)
-		} else if strings.HasSuffix(r.URL.Token, "wait") {
+		} else if strings.HasSuffix(r.URL.Path, "wait") {
 			t.Logf("SIMPLESRV: Got a wait req\n")
 			time.Sleep(time.Second * 3)
-		} else if strings.HasSuffix(r.URL.Token, "wait-long") {
+		} else if strings.HasSuffix(r.URL.Path, "wait-long") {
 			t.Logf("SIMPLESRV: Got a wait-long req\n")
 			time.Sleep(time.Second * 10)
 		} else if strings.HasSuffix(r.URL.Path, "re-lookup") {
@@ -303,8 +303,8 @@ func TestSimpleHttp(t *testing.T) {
 	test.AssertEquals(t, len(log.GetAllMatching(`^\[AUDIT\] `)), 1)
 
 	log.Clear()
-	chall.Path = path404
-	invalidChall, err = va.validateSimpleHTTP(ident, chall)
+	chall.Token = path404
+	invalidChall, err = va.validateSimpleHTTP(ident, chall, AccountKey)
 	test.AssertEquals(t, invalidChall.Status, core.StatusInvalid)
 	test.AssertError(t, err, "Should have found a 404 for the challenge.")
 	test.AssertEquals(t, invalidChall.Error.Type, core.UnauthorizedProblem)

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -971,12 +971,11 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 		return
 	}
 
-	// Blank out ID and regID
 	switch request.Method {
 	case "GET":
+		// Blank out ID and regID
 		authz.ID = ""
 		authz.RegistrationID = 0
-
 		jsonReply, err := json.Marshal(authz)
 		if err != nil {
 			logEvent.Error = err.Error()


### PR DESCRIPTION
Fixes #488, blocked on landing #617 due to `Challenges` column size being too long with the `ValidationRecord`s added.