### PR TITLE
Add stomped/forgotten PolicyDB config struct

### DIFF
--- a/cmd/external-cert-importer/main.go
+++ b/cmd/external-cert-importer/main.go
@@ -159,7 +159,7 @@ func main() {
 		blog.SetAuditLogger(auditlogger)
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.Common.DBDriver, c.Common.DBConnect)
+		dbMap, err := sa.NewDbMap(c.PA.DBDriver, c.PA.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 
 		dbMap.AddTableWithName(core.ExternalCert{}, "externalCerts").SetKeys(false, "SHA1")

--- a/cmd/external-cert-importer/main.go
+++ b/cmd/external-cert-importer/main.go
@@ -159,7 +159,7 @@ func main() {
 		blog.SetAuditLogger(auditlogger)
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.Common.PolicyDB.Driver, c.Common.PolicyDB.Name)
+		dbMap, err := sa.NewDbMap(c.Common.DBDriver, c.Common.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 
 		dbMap.AddTableWithName(core.ExternalCert{}, "externalCerts").SetKeys(false, "SHA1")

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -178,6 +178,9 @@ type Config struct {
 
 		DNSResolver string
 		DNSTimeout  string
+
+		DBDriver  string
+		DBConnect string
 	}
 
 	SubscriberAgreementURL string

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -170,6 +170,11 @@ type Config struct {
 		StatsdRate                 float32
 	}
 
+	PA struct {
+		DBDriver  string
+		DBConnect string
+	}
+
 	Common struct {
 		BaseURL string
 		// Path to a PEM-encoded copy of the issuer certificate.
@@ -178,9 +183,6 @@ type Config struct {
 
 		DNSResolver string
 		DNSTimeout  string
-
-		DBDriver  string
-		DBConnect string
 	}
 
 	SubscriberAgreementURL string


### PR DESCRIPTION
Re-adds missing `Common.PolicyDB` struct that is breaking master tests locally.