### PR TITLE
use MariaDB in the unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ build: $(OBJECTS)
 
 pre:
 	@mkdir -p $(OBJDIR)
-	@echo [go] lib/github.com/mattn/go-sqlite3
-	@go install ./Godeps/_workspace/src/github.com/mattn/go-sqlite3
 
 # Compile each of the binaries
 $(OBJECTS): pre

--- a/ca/certificate-authority-data.go
+++ b/ca/certificate-authority-data.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
-	"github.com/letsencrypt/boulder/sa"
 
 	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
@@ -32,13 +31,8 @@ type SerialNumber struct {
 
 // NewCertificateAuthorityDatabaseImpl constructs a Database for the
 // Certificate Authority.
-func NewCertificateAuthorityDatabaseImpl(driver string, name string) (cadb core.CertificateAuthorityDatabase, err error) {
+func NewCertificateAuthorityDatabaseImpl(dbMap *gorp.DbMap) (cadb core.CertificateAuthorityDatabase, err error) {
 	logger := blog.GetAuditLogger()
-
-	dbMap, err := sa.NewDbMap(driver, name)
-	if err != nil {
-		return nil, err
-	}
 
 	dbMap.AddTableWithName(SerialNumber{}, "serialNumber").SetKeys(true, "ID")
 

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -8,39 +8,14 @@ package ca
 import (
 	"testing"
 
-	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
+	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 )
 
-const badDriver = "nothing"
-const badFilename = "/doesnotexist/nofile"
-const sqliteDriver = "sqlite3"
-const sqliteName = ":memory:"
-
-func TestConstruction(t *testing.T) {
-	// Successful case
-	_, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
-	test.AssertNotError(t, err, "Could not construct CA DB")
-
-	// Covers "sql.Open" error
-	_, err = NewCertificateAuthorityDatabaseImpl(badDriver, sqliteName)
-	test.AssertError(t, err, "Should have failed construction")
-
-	// Covers "db.Ping" error
-	_, err = NewCertificateAuthorityDatabaseImpl(sqliteDriver, badFilename)
-	test.AssertError(t, err, "Should have failed construction")
-}
-
 func TestGetSetSequenceOutsideTx(t *testing.T) {
-	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
-	test.AssertNotError(t, err, "Could not construct CA DB")
-
-	err = cadb.CreateTablesIfNotExists()
-	test.AssertNotError(t, err, "Could not construct tables")
-
-	_, err = cadb.IncrementAndGetSerial(nil)
-	test.AssertError(t, err, "Not permitted")
-
+	cadb, cleanUp := caDBImpl(t)
+	defer cleanUp()
 	tx, err := cadb.Begin()
 	test.AssertNotError(t, err, "Could not begin")
 	tx.Commit()
@@ -55,12 +30,8 @@ func TestGetSetSequenceOutsideTx(t *testing.T) {
 }
 
 func TestGetSetSequenceNumber(t *testing.T) {
-	cadb, err := NewCertificateAuthorityDatabaseImpl(sqliteDriver, sqliteName)
-	test.AssertNotError(t, err, "Could not construct CA DB")
-
-	err = cadb.CreateTablesIfNotExists()
-	test.AssertNotError(t, err, "Could not construct tables")
-
+	cadb, cleanUp := caDBImpl(t)
+	defer cleanUp()
 	tx, err := cadb.Begin()
 	test.AssertNotError(t, err, "Could not begin")
 
@@ -73,4 +44,40 @@ func TestGetSetSequenceNumber(t *testing.T) {
 
 	err = tx.Commit()
 	test.AssertNotError(t, err, "Could not commit")
+}
+
+func caDBImpl(t *testing.T) (core.CertificateAuthorityDatabase, func()) {
+	dbMap, err := sa.NewDbMap(dbConnStr)
+	if err != nil {
+		t.Fatalf("Could not construct dbMap: %s", err)
+	}
+
+	cadb, err := NewCertificateAuthorityDatabaseImpl(dbMap)
+	if err != nil {
+		t.Fatalf("Could not construct CA DB: %s", err)
+	}
+
+	// We intentionally call CreateTablesIfNotExists twice before returning
+	// because of the weird insert inside it.
+
+	err = cadb.CreateTablesIfNotExists()
+	if err != nil {
+		t.Fatalf("Could not construct tables: %s", err)
+	}
+	err = dbMap.TruncateTables()
+	if err != nil {
+		t.Fatalf("Could not truncate tables: %s", err)
+	}
+	err = cadb.CreateTablesIfNotExists()
+	if err != nil {
+		t.Fatalf("Could not construct tables: %s", err)
+	}
+	cleanUp := func() {
+		if err := dbMap.TruncateTables(); err != nil {
+			t.Fatalf("Could not truncate tables after the test: %s", err)
+		}
+		dbMap.Db.Close()
+	}
+
+	return cadb, cleanUp
 }

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -57,8 +57,14 @@ func caDBImpl(t *testing.T) (core.CertificateAuthorityDatabase, func()) {
 		t.Fatalf("Could not construct CA DB: %s", err)
 	}
 
-	// We intentionally call CreateTablesIfNotExists twice before returning
-	// because of the weird insert inside it.
+	// We intentionally call CreateTablesIfNotExists twice before
+	// returning because of the weird insert inside it. The
+	// CADatabaseImpl code expects the existence of a single row in
+	// its serialIds table or else it errors. CreateTablesIfNotExists
+	// currently inserts that row and TruncateTables will remove
+	// it. But we need to make sure the tables exist before
+	// TruncateTables can be called to reset the table. So, two calls
+	// to CreateTablesIfNotExists.
 
 	err = cadb.CreateTablesIfNotExists()
 	if err != nil {

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -11,13 +11,11 @@ import (
 	"encoding/asn1"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	cfsslConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
 	ocspConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/config"
-	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	"github.com/letsencrypt/boulder/mocks"
 
 	"github.com/letsencrypt/boulder/core"
@@ -339,22 +337,37 @@ const profileName = "ee"
 const caKeyFile = "../test/test-ca.key"
 const caCertFile = "../test/test-ca.pem"
 
-func TestMain(m *testing.M) {
+// TODO(jmhodges): change this to boulder_ca_test database
+var dbConnStr = "mysql+tcp://boulder@localhost:3306/boulder_test"
 
-	os.Exit(m.Run())
-}
-
-func setup(t *testing.T) (cadb core.CertificateAuthorityDatabase, storageAuthority core.StorageAuthority, caConfig Config) {
+func setup(t *testing.T) (core.CertificateAuthorityDatabase, core.StorageAuthority, Config, func()) {
 	// Create an SA
-	ssa, err := sa.NewSQLStorageAuthority("sqlite3", ":memory:")
-	test.AssertNotError(t, err, "Failed to create SA")
-	ssa.CreateTablesIfNotExists()
-	storageAuthority = ssa
+	dbMap, err := sa.NewDbMap(dbConnStr)
+	if err != nil {
+		t.Fatalf("Failed to create dbMap: %s", err)
+	}
+	ssa, err := sa.NewSQLStorageAuthority(dbMap)
+	if err != nil {
+		t.Fatalf("Failed to create SA: %s", err)
+	}
+	if err = ssa.CreateTablesIfNotExists(); err != nil {
+		t.Fatalf("Failed to create tables: %s", err)
+	}
+	if err = dbMap.TruncateTables(); err != nil {
+		t.Fatalf("Failed to truncate tables: %s", err)
+	}
 
-	cadb, _ = mocks.NewMockCertificateAuthorityDatabase()
+	cadb, caDBCleanUp := caDBImpl(t)
+	cleanUp := func() {
+		if err = dbMap.TruncateTables(); err != nil {
+			t.Fatalf("Failed to truncate tables after the test: %s", err)
+		}
+		dbMap.Db.Close()
+		caDBCleanUp()
+	}
 
 	// Create a CA
-	caConfig = Config{
+	caConfig := Config{
 		Profile:      profileName,
 		SerialPrefix: 17,
 		Key: KeyConfig{
@@ -399,18 +412,21 @@ func setup(t *testing.T) (cadb core.CertificateAuthorityDatabase, storageAuthori
 			},
 		},
 	}
-	return cadb, storageAuthority, caConfig
+	return cadb, ssa, caConfig, cleanUp
 }
 
 func TestFailNoSerial(t *testing.T) {
-	cadb, _, caConfig := setup(t)
+	cadb, _, caConfig, cleanUp := setup(t)
+	defer cleanUp()
+
 	caConfig.SerialPrefix = 0
 	_, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	test.AssertError(t, err, "CA should have failed with no SerialPrefix")
 }
 
 func TestRevoke(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	test.AssertNotError(t, err, "Failed to create CA")
 	if err != nil {
@@ -442,7 +458,8 @@ func TestRevoke(t *testing.T) {
 }
 
 func TestIssueCertificate(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = storageAuthority
@@ -518,7 +535,8 @@ func TestIssueCertificate(t *testing.T) {
 }
 
 func TestRejectNoName(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = storageAuthority
@@ -534,7 +552,8 @@ func TestRejectNoName(t *testing.T) {
 }
 
 func TestRejectTooManyNames(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = storageAuthority
@@ -547,7 +566,8 @@ func TestRejectTooManyNames(t *testing.T) {
 }
 
 func TestDeduplication(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = storageAuthority
@@ -576,7 +596,8 @@ func TestDeduplication(t *testing.T) {
 }
 
 func TestRejectValidityTooLong(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	test.AssertNotError(t, err, "Failed to create CA")
 	ca.SA = storageAuthority
@@ -597,7 +618,8 @@ func TestRejectValidityTooLong(t *testing.T) {
 }
 
 func TestShortKey(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	ca.SA = storageAuthority
 	ca.MaxKeySize = 4096
@@ -610,7 +632,8 @@ func TestShortKey(t *testing.T) {
 }
 
 func TestRejectBadAlgorithm(t *testing.T) {
-	cadb, storageAuthority, caConfig := setup(t)
+	cadb, storageAuthority, caConfig, cleanUp := setup(t)
+	defer cleanUp()
 	ca, err := NewCertificateAuthorityImpl(cadb, caConfig, caCertFile)
 	ca.SA = storageAuthority
 	ca.MaxKeySize = 4096

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -17,18 +17,12 @@ import (
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
-
-	// Load both drivers to allow configuring either
-	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/go-sql-driver/mysql"
-	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
-
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
 	"github.com/letsencrypt/boulder/sa"
-
-	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
 
 var reasons = map[int]string{
@@ -76,7 +70,7 @@ func setupContext(context *cli.Context) (rpc.CertificateAuthorityClient, *blog.A
 	cac, err := rpc.NewCertificateAuthorityClient(caRPC)
 	cmd.FailOnError(err, "Unable to create CA client")
 
-	dbMap, err := sa.NewDbMap(c.Revoker.DBDriver, c.Revoker.DBConnect)
+	dbMap, err := sa.NewDbMap(c.Revoker.DBConnect)
 	cmd.FailOnError(err, "Couldn't setup database connection")
 
 	saRPC, err := rpc.NewAmqpRPCClient("AdminRevoker->SA", c.AMQP.SA.Server, ch)

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -7,11 +7,11 @@ package main
 
 import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
-
 	"github.com/letsencrypt/boulder/ca"
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
+	"github.com/letsencrypt/boulder/sa"
 )
 
 func main() {
@@ -31,8 +31,10 @@ func main() {
 
 		go cmd.DebugServer(c.CA.DebugAddr)
 
-		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(c.CA.DBDriver, c.CA.DBConnect)
+		dbMap, err := sa.NewDbMap(c.CA.DBConnect)
+		cmd.FailOnError(err, "Couldn't connect to CA database")
 
+		cadb, err := ca.NewCertificateAuthorityDatabaseImpl(dbMap)
 		cmd.FailOnError(err, "Failed to create CA database")
 
 		if c.SQL.CreateTables {

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -31,8 +31,10 @@ func main() {
 
 		go cmd.DebugServer(c.SA.DebugAddr)
 
-		sai, err := sa.NewSQLStorageAuthority(c.SA.DBDriver, c.SA.DBConnect)
+		dbMap, err := sa.NewDbMap(c.SA.DBConnect)
+		cmd.FailOnError(err, "Couldn't connect to SA database")
 
+		sai, err := sa.NewSQLStorageAuthority(dbMap)
 		cmd.FailOnError(err, "Failed to create SA impl")
 		sai.SetSQLDebug(c.SQL.SQLDebug)
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -240,7 +240,7 @@ func main() {
 		go cmd.DebugServer(c.Mailer.DebugAddr)
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.Mailer.DBDriver, c.Mailer.DBConnect)
+		dbMap, err := sa.NewDbMap(c.Mailer.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 
 		ch, err := rpc.AmqpChannel(c)

--- a/cmd/external-cert-importer/main.go
+++ b/cmd/external-cert-importer/main.go
@@ -159,7 +159,7 @@ func main() {
 		blog.SetAuditLogger(auditlogger)
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.PA.DBDriver, c.PA.DBConnect)
+		dbMap, err := sa.NewDbMap(c.PA.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 
 		dbMap.AddTableWithName(core.ExternalCert{}, "externalCerts").SetKeys(false, "SHA1")

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -134,7 +134,7 @@ func main() {
 		auditlogger.Info(app.VersionString())
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.OCSPResponder.DBDriver, c.OCSPResponder.DBConnect)
+		dbMap, err := sa.NewDbMap(c.OCSPResponder.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 		sa.SetSQLDebug(dbMap, c.SQL.SQLDebug)
 

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -214,7 +214,7 @@ func main() {
 		go cmd.DebugServer(c.OCSPUpdater.DebugAddr)
 
 		// Configure DB
-		dbMap, err := sa.NewDbMap(c.OCSPUpdater.DBDriver, c.OCSPUpdater.DBConnect)
+		dbMap, err := sa.NewDbMap(c.OCSPUpdater.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")
 
 		cac, closeChan := setupClients(c)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -90,7 +90,6 @@ type Config struct {
 	}
 
 	SA struct {
-		DBDriver  string
 		DBConnect string
 
 		// DebugAddr is the address to run the /debug handlers on.
@@ -121,7 +120,6 @@ type Config struct {
 	}
 
 	Revoker struct {
-		DBDriver  string
 		DBConnect string
 	}
 
@@ -131,7 +129,6 @@ type Config struct {
 		Username string
 		Password string
 
-		DBDriver  string
 		DBConnect string
 
 		CertLimit int
@@ -144,7 +141,6 @@ type Config struct {
 	}
 
 	OCSPResponder struct {
-		DBDriver      string
 		DBConnect     string
 		Path          string
 		ListenAddress string
@@ -154,7 +150,6 @@ type Config struct {
 	}
 
 	OCSPUpdater struct {
-		DBDriver        string
 		DBConnect       string
 		MinTimeToExpiry string
 		ResponseLimit   int

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -6,47 +6,13 @@
 package mocks
 
 import (
-	"database/sql"
 	"fmt"
 	"net"
 	"strings"
 	"time"
 
-	// Load SQLite3 for test purposes
-	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/miekg/dns"
-	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
-
-// MockCADatabase is a mock
-type MockCADatabase struct {
-	db    *gorp.DbMap
-	count int64
-}
-
-// NewMockCertificateAuthorityDatabase is a mock
-func NewMockCertificateAuthorityDatabase() (mock *MockCADatabase, err error) {
-	db, err := sql.Open("sqlite3", ":memory:")
-	dbmap := &gorp.DbMap{Db: db, Dialect: gorp.SqliteDialect{}}
-	mock = &MockCADatabase{db: dbmap, count: 1}
-	return mock, err
-}
-
-// Begin is a mock
-func (cadb *MockCADatabase) Begin() (*gorp.Transaction, error) {
-	return cadb.db.Begin()
-}
-
-// IncrementAndGetSerial is a mock
-func (cadb *MockCADatabase) IncrementAndGetSerial(*gorp.Transaction) (int64, error) {
-	cadb.count = cadb.count + 1
-	return cadb.count, nil
-}
-
-// CreateTablesIfNotExists is a mock
-func (cadb *MockCADatabase) CreateTablesIfNotExists() error {
-	return nil
-}
 
 // MockDNS is a mock
 type MockDNS struct {

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
-	_ "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/mattn/go-sqlite3"
 	"github.com/letsencrypt/boulder/ca"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/mocks"
@@ -123,9 +122,12 @@ var (
 	AuthzFinal   = core.Authorization{}
 
 	log = mocks.UseMockLog()
+
+	// TODO(jmhodges): Turn this into boulder_sa_test
+	dbConnStr = "mysql+tcp://boulder@localhost:3306/boulder_test"
 )
 
-func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationAuthority, *sa.SQLStorageAuthority, core.RegistrationAuthority) {
+func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationAuthority, *sa.SQLStorageAuthority, *RegistrationAuthorityImpl, func()) {
 	err := json.Unmarshal(AccountKeyJSONA, &AccountKeyA)
 	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
 	err = json.Unmarshal(AccountKeyJSONB, &AccountKeyB)
@@ -139,11 +141,22 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 	err = json.Unmarshal(ShortKeyJSON, &ShortKey)
 	test.AssertNotError(t, err, "Failed to unmarshall JWK")
 
-	sa, err := sa.NewSQLStorageAuthority("sqlite3", ":memory:")
-	test.AssertNotError(t, err, "Failed to create SA")
-	err = sa.CreateTablesIfNotExists()
+	dbMap, err := sa.NewDbMap(dbConnStr)
 	if err != nil {
-		t.Fatalf("unable to create tables: %s", err)
+		t.Fatalf("Failed to create dbMap: %s", err)
+	}
+	ssa, err := sa.NewSQLStorageAuthority(dbMap)
+	if err != nil {
+		t.Fatalf("Failed to create SA: %s", err)
+	}
+
+	err = ssa.CreateTablesIfNotExists()
+	if err != nil {
+		t.Fatalf("Failed to create SA tables: %s", err)
+	}
+
+	if err = dbMap.TruncateTables(); err != nil {
+		t.Fatalf("Failed to truncate SA tables: %s", err)
 	}
 
 	va := &DummyValidationAuthority{}
@@ -168,25 +181,33 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 	signer, _ := local.NewSigner(caKey, caCert, x509.SHA256WithRSA, basicPolicy)
 	ocspSigner, _ := ocsp.NewSigner(caCert, caCert, caKey, time.Hour)
 	pa := policy.NewPolicyAuthorityImpl()
-	cadb, _ := mocks.NewMockCertificateAuthorityDatabase()
+	cadb, caDBCleanUp := caDBImpl(t)
 	ca := ca.CertificateAuthorityImpl{
 		Signer:         signer,
 		OCSPSigner:     ocspSigner,
-		SA:             sa,
+		SA:             ssa,
 		PA:             pa,
 		DB:             cadb,
 		ValidityPeriod: time.Hour * 2190,
 		NotAfter:       time.Now().Add(time.Hour * 8761),
 		MaxKeySize:     4096,
 	}
+	cleanUp := func() {
+		if err = dbMap.TruncateTables(); err != nil {
+			t.Fatalf("Failed to truncate tables after the test: %s", err)
+		}
+		dbMap.Db.Close()
+		caDBCleanUp()
+	}
+
 	csrDER, _ := hex.DecodeString(CSRhex)
 	ExampleCSR, _ = x509.ParseCertificateRequest(csrDER)
 
 	// This registration implicitly gets ID = 1
-	Registration, _ = sa.NewRegistration(core.Registration{Key: AccountKeyA})
+	Registration, _ = ssa.NewRegistration(core.Registration{Key: AccountKeyA})
 
 	ra := NewRegistrationAuthorityImpl()
-	ra.SA = sa
+	ra.SA = ssa
 	ra.VA = va
 	ra.CA = &ca
 	ra.PA = pa
@@ -204,7 +225,48 @@ func initAuthorities(t *testing.T) (core.CertificateAuthority, *DummyValidationA
 	AuthzFinal.Expires = &exp
 	AuthzFinal.Challenges[0].Status = "valid"
 
-	return &ca, va, sa, &ra
+	return &ca, va, ssa, &ra, cleanUp
+}
+
+// This is an unfortunate bit of tech debt that is being taken on in
+// order to get the more important change of using MySQL/MariaDB in
+// all of our tests working without SQLite. We already had issues with
+// the RA here getting a real CertificateAuthority instead of a
+// CertificateAuthorityClient, so this is only marginally worse.
+func caDBImpl(t *testing.T) (core.CertificateAuthorityDatabase, func()) {
+	dbMap, err := sa.NewDbMap(dbConnStr)
+	if err != nil {
+		t.Fatalf("Could not construct dbMap: %s", err)
+	}
+
+	cadb, err := ca.NewCertificateAuthorityDatabaseImpl(dbMap)
+	if err != nil {
+		t.Fatalf("Could not construct CA DB: %s", err)
+	}
+
+	// We intentionally call CreateTablesIfNotExists twice before returning
+	// because of the weird insert inside it.
+
+	err = cadb.CreateTablesIfNotExists()
+	if err != nil {
+		t.Fatalf("Could not construct tables: %s", err)
+	}
+	err = dbMap.TruncateTables()
+	if err != nil {
+		t.Fatalf("Could not truncate tables: %s", err)
+	}
+	err = cadb.CreateTablesIfNotExists()
+	if err != nil {
+		t.Fatalf("Could not construct tables: %s", err)
+	}
+	cleanUp := func() {
+		if err := dbMap.TruncateTables(); err != nil {
+			t.Fatalf("Could not truncate tables after the test: %s", err)
+		}
+		dbMap.Db.Close()
+	}
+
+	return cadb, cleanUp
 }
 
 func assertAuthzEqual(t *testing.T, a1, a2 core.Authorization) {
@@ -258,7 +320,8 @@ func TestValidateEmail(t *testing.T) {
 }
 
 func TestNewRegistration(t *testing.T) {
-	_, _, sa, ra := initAuthorities(t)
+	_, _, sa, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
 		Contact: []*core.AcmeURL{mailto},
@@ -282,7 +345,8 @@ func TestNewRegistration(t *testing.T) {
 }
 
 func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
-	_, _, _, ra := initAuthorities(t)
+	_, _, _, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
 		ID:        23,
@@ -298,17 +362,19 @@ func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
 	// TODO: Enable this test case once we validate terms agreement.
 	//test.Assert(t, result.Agreement != "I agreed", "Agreement shouldn't be set with invalid URL")
 
+	id := result.ID
 	result2, err := ra.UpdateRegistration(result, core.Registration{
 		ID:  33,
 		Key: ShortKey,
 	})
 	test.AssertNotError(t, err, "Could not update registration")
-	test.Assert(t, result2.ID != 33, "ID shouldn't be overwritten.")
+	test.Assert(t, result2.ID != 33, fmt.Sprintf("ID shouldn't be overwritten. expected %d, got %d", id, result2.ID))
 	test.Assert(t, !core.KeyDigestEquals(result2.Key, ShortKey), "Key shouldn't be overwritten")
 }
 
 func TestNewRegistrationBadKey(t *testing.T) {
-	_, _, _, ra := initAuthorities(t)
+	_, _, _, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
 		Contact: []*core.AcmeURL{mailto},
@@ -320,8 +386,8 @@ func TestNewRegistrationBadKey(t *testing.T) {
 }
 
 func TestNewAuthorization(t *testing.T) {
-	_, _, sa, ra := initAuthorities(t)
-
+	_, _, sa, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	_, err := ra.NewAuthorization(AuthzRequest, 0)
 	test.AssertError(t, err, "Authorization cannot have registrationID == 0")
 
@@ -348,7 +414,8 @@ func TestNewAuthorization(t *testing.T) {
 }
 
 func TestUpdateAuthorization(t *testing.T) {
-	_, va, sa, ra := initAuthorities(t)
+	_, va, sa, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	AuthzInitial, _ = sa.NewPendingAuthorization(AuthzInitial)
 	sa.UpdatePendingAuthorization(AuthzInitial)
 
@@ -371,7 +438,8 @@ func TestUpdateAuthorization(t *testing.T) {
 }
 
 func TestOnValidationUpdate(t *testing.T) {
-	_, _, sa, ra := initAuthorities(t)
+	_, _, sa, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	AuthzUpdated, _ = sa.NewPendingAuthorization(AuthzUpdated)
 	sa.UpdatePendingAuthorization(AuthzUpdated)
 
@@ -393,7 +461,8 @@ func TestOnValidationUpdate(t *testing.T) {
 }
 
 func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
-	_, _, sa, ra := initAuthorities(t)
+	_, _, sa, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	authz := core.Authorization{}
 	authz, _ = sa.NewPendingAuthorization(authz)
 	authz.Identifier = core.AcmeIdentifier{
@@ -424,7 +493,8 @@ func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 }
 
 func TestAuthorizationRequired(t *testing.T) {
-	_, _, sa, ra := initAuthorities(t)
+	_, _, sa, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	AuthzFinal.RegistrationID = 1
 	AuthzFinal, _ = sa.NewPendingAuthorization(AuthzFinal)
 	sa.UpdatePendingAuthorization(AuthzFinal)
@@ -443,7 +513,8 @@ func TestAuthorizationRequired(t *testing.T) {
 }
 
 func TestNewCertificate(t *testing.T) {
-	_, _, sa, ra := initAuthorities(t)
+	_, _, sa, ra, cleanUp := initAuthorities(t)
+	defer cleanUp()
 	AuthzFinal.RegistrationID = 1
 	AuthzFinal, _ = sa.NewPendingAuthorization(AuthzFinal)
 	sa.UpdatePendingAuthorization(AuthzFinal)

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -11,27 +11,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestNewDbMap(t *testing.T) {
-	_, err := NewDbMap("", "")
-	test.AssertError(t, err, "Nil not permitted.")
-
-	_, err = NewDbMap("sqlite3", "/not/a/file")
-	test.AssertError(t, err, "Shouldn't have found a DB.")
-
-	_, err = NewDbMap("sqlite3", ":memory:")
-	test.AssertNotError(t, err, "Should have constructed a DB.")
-}
-
-func TestForgottenDialect(t *testing.T) {
-	bkup := dialectMap["sqlite3"]
-	dialectMap["sqlite3"] = ""
-	defer func() { dialectMap["sqlite3"] = bkup }()
-
-	_, err := NewDbMap("sqlite3", ":memory:")
-	test.AssertError(t, err, "Shouldn't have found the dialect")
-}
-
 func TestInvalidDSN(t *testing.T) {
-	_, err := NewDbMap("mysql", "invalid")
+	_, err := NewDbMap("invalid")
 	test.AssertError(t, err, "DB connect string missing the slash separating the database name")
 }

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -47,15 +47,12 @@ type authzModel struct {
 	Sequence int64 `db:"sequence"`
 }
 
-// NewSQLStorageAuthority provides persistence using a SQL backend for Boulder.
-func NewSQLStorageAuthority(driver string, dbConnect string) (*SQLStorageAuthority, error) {
+// NewSQLStorageAuthority provides persistence using a SQL backend for
+// Boulder. It will modify the given gorp.DbMap by adding relevent tables.
+func NewSQLStorageAuthority(dbMap *gorp.DbMap) (*SQLStorageAuthority, error) {
 	logger := blog.GetAuditLogger()
-	logger.Notice("Storage Authority Starting")
 
-	dbMap, err := NewDbMap(driver, dbConnect)
-	if err != nil {
-		return nil, err
-	}
+	logger.Notice("Storage Authority Starting")
 
 	ssa := &SQLStorageAuthority{
 		dbMap: dbMap,

--- a/test.sh
+++ b/test.sh
@@ -180,13 +180,14 @@ check_gofmt() {
 run_and_comment check_gofmt
 end_context #test/gofmt
 
+if [ "${TRAVIS}" == "true" ]; then
+  ./test/create_db.sh || die "unable to create the boulder database with test/create_db.sh"
+fi
+
 #
 # Unit Tests. These do not receive a context or status updates,
 # as they are reflected in our eventual exit code.
 #
-
-# Ensure SQLite is installed so we don't recompile it each time
-go install ./Godeps/_workspace/src/github.com/mattn/go-sqlite3
 
 if  [ "${SKIP_UNIT_TESTS}" == "1" ]; then
   echo "Skipping unit tests."
@@ -206,10 +207,6 @@ fi
 if [ "${SKIP_INTEGRATION_TESTS}" = "1" ]; then
   echo "Skipping integration tests."
   exit ${FAILURE}
-fi
-
-if [ "${TRAVIS}" == "true" ]; then
-  ./test/create_db.sh || die "unable to create the boulder database with test/create_db.sh"
 fi
 
 #

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -48,7 +48,6 @@
   "ca": {
     "serialPrefix": 255,
     "profile": "ee",
-    "dbDriver": "mysql",
     "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8001",
     "testMode": true,
@@ -115,7 +114,6 @@
   },
 
   "sa": {
-    "dbDriver": "mysql",
     "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8003"
   },
@@ -131,12 +129,10 @@
   },
 
   "revoker": {
-    "dbDriver": "mysql",
     "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test"
   },
 
   "ocspResponder": {
-    "dbDriver": "mysql",
     "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "path": "/",
     "listenAddress": "localhost:4001",
@@ -144,7 +140,6 @@
   },
 
   "ocspUpdater": {
-    "dbDriver": "mysql",
     "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "minTimeToExpiry": "72h",
     "debugAddr": "localhost:8006"
@@ -159,7 +154,6 @@
     "port": "25",
     "username": "cert-master@example.com",
     "password": "password",
-    "dbDriver": "mysql",
     "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "messageLimit": 0,
     "nagTimes": ["24h", "72h", "168h", "336h"],

--- a/test/boulder-pkcs11-example-config.json
+++ b/test/boulder-pkcs11-example-config.json
@@ -42,8 +42,7 @@
   "ca": {
     "serialPrefix": 255,
     "profile": "ee",
-    "dbDriver": "sqlite3",
-    "dbConnect": ":memory:",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8001",
     "testMode": true,
     "_comment": "This should only be present in testMode. In prod use an HSM.",
@@ -105,8 +104,7 @@
   },
 
   "sa": {
-    "dbDriver": "sqlite3",
-    "dbConnect": ":memory:",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8003"
   },
 
@@ -121,21 +119,18 @@
   },
 
   "revoker": {
-    "dbDriver": "sqlite3",
-    "dbConnect": ":memory:"
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test"
   },
 
   "ocspResponder": {
-    "dbDriver": "sqlite3",
-    "dbConnect": ":memory:",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8004",
     "path": "/",
     "listenAddress": "localhost:4001"
   },
 
   "ocspUpdater": {
-    "dbDriver": "sqlite3",
-    "dbConnect": ":memory:",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "debugAddr": "localhost:8005",
     "minTimeToExpiry": "72h"
   },
@@ -149,8 +144,7 @@
     "port": "25",
     "username": "cert-master@example.com",
     "password": "password",
-    "dbDriver": "sqlite3",
-    "dbConnect": ":memory:",
+    "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_test",
     "messageLimit": 0,
     "nagTimes": ["24h", "72h", "168h", "336h"],
     "emailTemplate": "test/example-expiration-template",


### PR DESCRIPTION
And delete the uses of sqlite3

The strategy taken is to delete all of the data from the tables, but not the tables themselves, between tests.

Fixes #132