### PR TITLE
Custom host no longer needed by client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ go:
   - 1.4.1
 
 addons:
-  hosts:
-    - le.wtf
   apt:
     packages:
       - lsb-release


### PR DESCRIPTION
Fixes letsencrypt/letsencrypt#684.

Safe to merge when letsencrypt/letsencrypt#687 is merged.