### PR TITLE
Update CFSSL.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,51 +12,51 @@
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/auth",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/config",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs11key",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs12",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs7",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/csr",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/errors",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/info",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/log",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer",
-			"Rev": "e46a042fbff1afcb445a5164d392ab2bf1b938be"
+			"Rev": "190c5f9713ef6c1460fb31ee785044b43bdb1b09"
 		},
 		{
 			"ImportPath": "github.com/codegangsta/cli",

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/log/log.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/log/log.go
@@ -8,6 +8,7 @@ package log
 import (
 	"fmt"
 	golog "log"
+	"os"
 )
 
 // The following constants represent logging levels in increasing levels of seriousness.
@@ -17,6 +18,7 @@ const (
 	LevelWarning
 	LevelError
 	LevelCritical
+	LevelFatal
 )
 
 var levelPrefix = [...]string{
@@ -25,6 +27,7 @@ var levelPrefix = [...]string{
 	LevelWarning:  "[WARNING] ",
 	LevelError:    "[ERROR] ",
 	LevelCritical: "[CRITICAL] ",
+	LevelFatal:    "[FATAL] ",
 }
 
 // Level stores the current logging level.
@@ -40,6 +43,19 @@ func output(l int, v []interface{}) {
 	if l >= Level {
 		golog.Print(levelPrefix[l], fmt.Sprint(v...))
 	}
+}
+
+// Fatalf logs a formatted message at the "fatal" level and then exits. The
+// arguments are handled in the same manner as fmt.Printf.
+func Fatalf(format string, v ...interface{}) {
+	outputf(LevelFatal, format, v)
+	os.Exit(1)
+}
+
+// Fatal logs its arguments at the "fatal" level and then exits.
+func Fatal(v ...interface{}) {
+	output(LevelFatal, v)
+	os.Exit(1)
 }
 
 // Criticalf logs a formatted message at the "critical" level. The

--- a/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/ocsp.go
+++ b/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp/ocsp.go
@@ -118,8 +118,8 @@ func (s StandardSigner) Sign(req SignRequest) ([]byte, error) {
 		return nil, cferr.New(cferr.OCSPError, cferr.IssuerMismatch)
 	}
 
-	// Round thisUpdate times to the nearest hour
-	thisUpdate := time.Now().Round(time.Hour)
+	// Round thisUpdate times down to the nearest hour
+	thisUpdate := time.Now().Truncate(time.Hour)
 	nextUpdate := thisUpdate.Add(s.interval)
 
 	status, ok := statusCode[req.Status]


### PR DESCRIPTION
This pulls in https://github.com/cloudflare/cfssl/pull/312, which fixes a bug
that was causing us to generate not-yet-valid OCSP.