### PR TITLE
correct the SQLLogger Printf

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -116,7 +116,7 @@ type SQLLogger struct {
 
 // Printf adapts the AuditLogger to GORP's interface
 func (log *SQLLogger) Printf(format string, v ...interface{}) {
-	log.log.Debug(fmt.Sprintf(format, v))
+	log.log.Debug(fmt.Sprintf(format, v...))
 }
 
 // initTables constructs the table map for the ORM. If you want to also create


### PR DESCRIPTION
Found while debugging things in the migration tool refactor. This explains all the "MISSING" messages we were getting.