### PR TITLE
enable strict mode in MariaDB connections

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -85,6 +85,15 @@ func recombineURLForDB(dbConnect string) (string, error) {
 	// instead of the number of rows changed by the UPDATE.
 	dsnVals.Set("clientFoundRows", "true")
 
+	// Ensures that MySQL/MariaDB warnings are treated as errors. This
+	// avoids a number of nasty edge conditions we could wander
+	// into. Common things this discovers includes places where data
+	// being sent had a different type than what is in the schema,
+	// strings being truncated, writing null to a NOT NULL column, and
+	// so on. See
+	// <https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sql-mode-strict>.
+	dsnVals.Set("strict", "true")
+
 	user := dbURL.User.Username()
 	passwd, hasPass := dbURL.User.Password()
 	dbConn := ""


### PR DESCRIPTION
Avoids silently allowing bad things to happen (like mismatched data types, strings being truncated, etc.).

Ensures that MySQL/MariaDB warnings are treated as errors. This avoids a number of nasty edge conditions we could wander into. Common things this discovers includes places where data being sent had a different type than what is in the schema, strings being truncated, writes of null to a NOT NULL column, and so on. See <https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sql-mode-strict>.

MySQL is very funny.

Fixes #623

This PR depends on #648. I will rebase this PR when that one ships. I just wanted to get this up (but not necessarily merged!) before the weekend.
