### PR TITLE
Fix flaky OCSP.

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -98,7 +98,10 @@ func (src *DBSource) Response(req *ocsp.Request) (response []byte, present bool)
 	log.Debug(fmt.Sprintf("Searching for OCSP issued by us for serial %s", serialString))
 
 	var ocspResponse core.OCSPResponse
-	err := src.dbMap.SelectOne(&ocspResponse, "SELECT * from ocspResponses WHERE serial = :serial ORDER BY createdAt DESC LIMIT 1;",
+	// Note: we order by id rather than createdAt, because otherwise we sometimes
+	// get the wrong result if a certificate is revoked in the same second as its
+	// last update (e.g. client issues and instant revokes).
+	err := src.dbMap.SelectOne(&ocspResponse, "SELECT * from ocspResponses WHERE serial = :serial ORDER BY id DESC LIMIT 1;",
 		map[string]interface{}{"serial": serialString})
 	if err != nil {
 		present = false

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -52,11 +52,13 @@ def get_ocsp(certFile):
 def verify_ocsp_good(certFile):
     output = get_ocsp(certFile)
     if not re.search(": good", output):
+        print "Expected OCSP response 'good', got something else."
         die(ExitStatus.OCSPFailure)
 
 def verify_ocsp_revoked(certFile):
     output = get_ocsp(certFile)
     if not re.search(": revoked", output):
+        print "Expected OCSP response 'revoked', got something else."
         die(ExitStatus.OCSPFailure)
     pass
 


### PR DESCRIPTION
If two OCSP responses were generated in the same second, the earlier would
previously take priority sometimes, leading to a "good" response for revoked
certificates and causing the OCSP integration test to be flaky.

Also update the test output to be clearer.