### PR TITLE
avoid needing a row to start serialNumber

### DIFF
--- a/ca/_db/migrations/20150821232907_FutzWithSerialNumber.sql
+++ b/ca/_db/migrations/20150821232907_FutzWithSerialNumber.sql
@@ -1,0 +1,30 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+DROP TABLE `serialNumber`;
+CREATE TABLE `serialNumber` (
+  `id` bigint(20) unsigned NOT NULL auto_increment,
+  `stub` char(1) NOT NULL default '',
+  PRIMARY KEY  (`id`),
+  UNIQUE KEY `stub` (`stub`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP TABLE `serialNumber`;
+CREATE TABLE `serialNumber` (
+  `id` int(11) DEFAULT NULL,
+  `number` int(11) DEFAULT NULL,
+  `lastUpdated` datetime DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `serialNumber`
+  (`id`,
+  `number`,
+  `lastUpdated`)
+VALUES (1,
+  1,
+  now()
+);

--- a/ca/certificate-authority-data_test.go
+++ b/ca/certificate-authority-data_test.go
@@ -7,7 +7,6 @@ package ca
 
 import (
 	"testing"
-	"time"
 
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
@@ -58,15 +57,5 @@ func caDBImpl(t *testing.T) (*CertificateAuthorityDatabaseImpl, func()) {
 	}
 
 	cleanUp := test.ResetTestDatabase(t, dbMap.Db)
-
-	// This row is required to exist for caDBImpl to work correctly. We
-	// can no longer use dbMap.Insert(&SerialNumber{...}) for this
-	// because gorp will ignore the ID and insert a new row at a new
-	// autoincrement id.
-	// TODO(jmhodges): gen ids flickr-style, no row needed a head of time
-	_, err = dbMap.Db.Exec("insert into serialNumber (id, number, lastUpdated) VALUES (?, ?, ?)", 1, 1, time.Now())
-	if err != nil {
-		t.Fatalf("unable to create the serial number row: %s", err)
-	}
 	return cadb, cleanUp
 }

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -237,16 +237,6 @@ func caDBImpl(t *testing.T) (core.CertificateAuthorityDatabase, func()) {
 	}
 
 	cleanUp := test.ResetTestDatabase(t, dbMap.Db)
-
-	// This row is required to exist for caDBImpl to work
-	// correctly. We can no longer use
-	// dbMap.Insert(&SerialNumber{...}) for this because gorp will
-	// ignore the ID and insert a new row at a new autoincrement id.
-	// TODO(jmhodges): gen ids flickr-style, no row needed a head of time
-	_, err = dbMap.Db.Exec("insert into serialNumber (id, number, lastUpdated) VALUES (?, ?, ?)", 1, 1, time.Now())
-	if err != nil {
-		t.Fatalf("unable to create the serial number row: %s", err)
-	}
 	return cadb, cleanUp
 }
 


### PR DESCRIPTION
Managing the single row needed in serialNumber is a bit of hassle in aworld where we delete all of the rows in all tables in our tests. Plus, if someone does that on their development database, they have to drop all the way to the start of the migrations and run them again. It's a bummer.

Instead, use the MySQL id generation design as [described and used by Flickr](https://code.flickr.net/2010/02/08/ticket-servers-distributed-unique-primary-keys-on-the-cheap/). That design doesn't need a row at its first insert to work correctly.

(That post mentions maybe using `ON DUPLICATE KEY UPDATE`, but it has subtle bugs that even using `LAST_INCREMENT_ID(id)` doesn't fix. This is because `UPDATE` doesn't run on the first `INSERT` but the `INSERT` will return 1. Then, id 1 will be returned again on the second `INSERT` attempt because the `LAST_INCREMENT_ID(id)` will be 0 because no increment was done! All subsequent `INSERT` attempts will be off by one.)

Fixes #649.