### PR TITLE
install boulder cmds in one cmd in startserver.py

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -32,18 +32,30 @@ if config is None:
 processes = []
 
 
-def run(path, race_detection):
+def install(progs, race_detection):
     install = "go install"
     if race_detection:
-        install = """GORACE="halt_on_error=1" go install -race"""
+        install = """go install -race"""
+    cmd = install
+    for prog in progs:
+        cmd += " ./" + prog
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode != 0:
+        sys.stderr.write("unable to run go install: %s\n" % cmd)
+        sys.stderr.write("stdout:\n" + out + "\n")
+        sys.stderr.write("stderr: \n" + err + "\n")
+        return False
+    print('installed %s with pid %d' % (cmd, p.pid))
+    return True
 
+def run(path, race_detection):
     binary = os.path.basename(path)
-    cmd = """%s ./%s && exec %s --config %s""" % (install, path, binary, config)
+    cmd = """GORACE="halt_on_error=1" %s --config %s""" % (binary, config)
     p = subprocess.Popen(cmd, shell=True)
     p.cmd = cmd
     print('started %s with pid %d' % (p.cmd, p.pid))
     return p
-
 
 def start(race_detection):
     """Return True if everything builds and starts.
@@ -56,14 +68,18 @@ def start(race_detection):
     t = ToSServerThread()
     t.daemon = True
     t.start()
-    for prog in [
-            'cmd/boulder-wfe',
-            'cmd/boulder-ra',
-            'cmd/boulder-sa',
-            'cmd/boulder-ca',
-            'cmd/boulder-va',
-            'cmd/ocsp-responder',
-            'test/dns-test-srv']:
+    progs = [
+        'cmd/boulder-wfe',
+        'cmd/boulder-ra',
+        'cmd/boulder-sa',
+        'cmd/boulder-ca',
+        'cmd/boulder-va',
+        'cmd/ocsp-responder',
+        'test/dns-test-srv'
+    ]
+    if not install(progs, race_detection):
+        return False
+    for prog in progs:
         try:
             processes.append(run(prog, race_detection))
         except Exception as e:


### PR DESCRIPTION
This eases the CPU and thread requirements of our tests (by forking less, not doing everything at once). It should also speed up the tests by avoiding certain repetitive work.

Updates https://github.com/letsencrypt/letsencrypt/issues/712