### PR TITLE
fix some dregs in startservers.py

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -33,13 +33,13 @@ processes = []
 
 
 def install(progs, race_detection):
-    install = "go install"
+    cmd = "go install"
     if race_detection:
-        install = """go install -race"""
-    cmd = install
+        cmd = """go install -race"""
+
     for prog in progs:
         cmd += " ./" + prog
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(cmd, shell=True)
     out, err = p.communicate()
     if p.returncode != 0:
         sys.stderr.write("unable to run go install: %s\n" % cmd)


### PR DESCRIPTION
Changes this to use just communicate(), not the subprocess.PIPE stuff (which
apparently can do Weird Things)

Also rename the install variable to cmd in the install function.