### PR TITLE
remove TestMode completely

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -30,8 +30,6 @@ import (
 // Config defines the JSON configuration file schema
 type Config struct {
 	Profile      string
-	TestMode     bool
-	DBDriver     string
 	DBConnect    string
 	SerialPrefix int
 	Key          KeyConfig

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -378,7 +378,6 @@ func setup(t *testing.T) *testCtx {
 		Key: KeyConfig{
 			File: caKeyFile,
 		},
-		TestMode:     true,
 		Expiry:       "8760h",
 		LifespanOCSP: "45m",
 		MaxNames:     2,

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -54,7 +54,7 @@ func main() {
 
 		vas, err := rpc.NewAmqpRPCServer(c.AMQP.VA.Server, connectionHandler)
 		cmd.FailOnError(err, "Unable to create VA RPC server")
-		rpc.NewValidationAuthorityServer(vas, &vai)
+		rpc.NewValidationAuthorityServer(vas, vai)
 
 		auditlogger.Info(app.VersionString())
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -36,7 +36,21 @@ func main() {
 
 		go cmd.ProfileCmd("VA", stats)
 
-		vai := va.NewValidationAuthorityImpl(c.CA.TestMode)
+		pc := &va.PortConfig{
+			SimpleHTTPPort:  80,
+			SimpleHTTPSPort: 443,
+			DVSNIPort:       443,
+		}
+		if c.VA.PortConfig.SimpleHTTPPort != 0 {
+			pc.SimpleHTTPPort = c.VA.PortConfig.SimpleHTTPPort
+		}
+		if c.VA.PortConfig.SimpleHTTPSPort != 0 {
+			pc.SimpleHTTPSPort = c.VA.PortConfig.SimpleHTTPSPort
+		}
+		if c.VA.PortConfig.DVSNIPort != 0 {
+			pc.DVSNIPort = c.VA.PortConfig.DVSNIPort
+		}
+		vai := va.NewValidationAuthorityImpl(pc)
 		dnsTimeout, err := time.ParseDuration(c.Common.DNSTimeout)
 		cmd.FailOnError(err, "Couldn't parse DNS timeout")
 		vai.DNSResolver = core.NewDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver})

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -99,6 +99,11 @@ type Config struct {
 	VA struct {
 		UserAgent string
 
+		PortConfig struct {
+			SimpleHTTPPort  int
+			SimpleHTTPSPort int
+			DVSNIPort       int
+		}
 		// DebugAddr is the address to run the /debug handlers on.
 		DebugAddr string
 	}

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -50,8 +50,6 @@
     "profile": "ee",
     "dbConnect": "mysql+tcp://boulder@localhost:3306/boulder_ca_integration",
     "debugAddr": "localhost:8001",
-    "testMode": true,
-    "_comment": "This should only be present in testMode. In prod use an HSM.",
     "Key": {
       "File": "test/test-ca.key"
     },
@@ -120,7 +118,12 @@
 
   "va": {
     "userAgent": "boulder",
-    "debugAddr": "localhost:8004"
+    "debugAddr": "localhost:8004",
+    "portConfig": {
+      "simpleHTTPPort": 5001,
+      "simpleHTTPSPort": 5001,
+      "dvsniPort": 5001
+    }
   },
 
   "sql": {

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -50,27 +50,23 @@ type ValidationAuthorityImpl struct {
 	UserAgent       string
 }
 
-// NewValidationAuthorityImpl constructs a new VA, and may place it
-// into Test Mode (tm)
-func NewValidationAuthorityImpl(tm bool) *ValidationAuthorityImpl {
+// PortConfig specifies what ports the VA should call to on the remote
+// host when performing its checks.
+type PortConfig struct {
+	SimpleHTTPPort  int
+	SimpleHTTPSPort int
+	DVSNIPort       int
+}
+
+// NewValidationAuthorityImpl constructs a new VA
+func NewValidationAuthorityImpl(pc *PortConfig) *ValidationAuthorityImpl {
 	logger := blog.GetAuditLogger()
 	logger.Notice("Validation Authority Starting")
-	// TODO(jsha): Remove TestMode entirely. Instead, the various validation ports
-	// should be exported, so the cmd file can set them based on a config.
-	if tm {
-		return &ValidationAuthorityImpl{
-			log:             logger,
-			simpleHTTPPort:  5001,
-			simpleHTTPSPort: 5001,
-			dvsniPort:       5001,
-		}
-	} else {
-		return &ValidationAuthorityImpl{
-			log:             logger,
-			simpleHTTPPort:  80,
-			simpleHTTPSPort: 443,
-			dvsniPort:       443,
-		}
+	return &ValidationAuthorityImpl{
+		log:             logger,
+		simpleHTTPPort:  pc.SimpleHTTPPort,
+		simpleHTTPSPort: pc.SimpleHTTPSPort,
+		dvsniPort:       pc.DVSNIPort,
 	}
 }
 

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -52,20 +52,20 @@ type ValidationAuthorityImpl struct {
 
 // NewValidationAuthorityImpl constructs a new VA, and may place it
 // into Test Mode (tm)
-func NewValidationAuthorityImpl(tm bool) ValidationAuthorityImpl {
+func NewValidationAuthorityImpl(tm bool) *ValidationAuthorityImpl {
 	logger := blog.GetAuditLogger()
 	logger.Notice("Validation Authority Starting")
 	// TODO(jsha): Remove TestMode entirely. Instead, the various validation ports
 	// should be exported, so the cmd file can set them based on a config.
 	if tm {
-		return ValidationAuthorityImpl{
+		return &ValidationAuthorityImpl{
 			log:             logger,
 			simpleHTTPPort:  5001,
 			simpleHTTPSPort: 5001,
 			dvsniPort:       5001,
 		}
 	} else {
-		return ValidationAuthorityImpl{
+		return &ValidationAuthorityImpl{
 			log:             logger,
 			simpleHTTPPort:  80,
 			simpleHTTPSPort: 443,
@@ -142,7 +142,7 @@ func problemDetailsFromDNSError(err error) *core.ProblemDetails {
 // This is the same choice made by the Go internal resolution library used by
 // net/http, except we only send A queries and accept IPv4 addresses.
 // TODO(#593): Add IPv6 support
-func (va ValidationAuthorityImpl) getAddr(hostname string) (addr net.IP, addrs []net.IP, problem *core.ProblemDetails) {
+func (va *ValidationAuthorityImpl) getAddr(hostname string) (addr net.IP, addrs []net.IP, problem *core.ProblemDetails) {
 	addrs, _, err := va.DNSResolver.LookupHost(hostname)
 	if err != nil {
 		problem = problemDetailsFromDNSError(err)
@@ -172,7 +172,7 @@ func (d *dialer) Dial(_, _ string) (net.Conn, error) {
 
 // resolveAndConstructDialer gets the prefered address using va.getAddr and returns
 // the chosen address and dialer for that address and correct port.
-func (va ValidationAuthorityImpl) resolveAndConstructDialer(name, defaultPort string) (dialer, *core.ProblemDetails) {
+func (va *ValidationAuthorityImpl) resolveAndConstructDialer(name, defaultPort string) (dialer, *core.ProblemDetails) {
 	port := fmt.Sprintf("%d", va.simpleHTTPPort)
 	if defaultPort != "" {
 		port = defaultPort
@@ -195,7 +195,7 @@ func (va ValidationAuthorityImpl) resolveAndConstructDialer(name, defaultPort st
 
 // Validation methods
 
-func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentifier, input core.Challenge, accountKey jose.JsonWebKey) (core.Challenge, error) {
+func (va *ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentifier, input core.Challenge, accountKey jose.JsonWebKey) (core.Challenge, error) {
 	challenge := input
 
 	if identifier.Type != core.IdentifierDNS {
@@ -376,7 +376,7 @@ func (va ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdentif
 	return challenge, nil
 }
 
-func (va ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, input core.Challenge, accountKey jose.JsonWebKey) (core.Challenge, error) {
+func (va *ValidationAuthorityImpl) validateDvsni(identifier core.AcmeIdentifier, input core.Challenge, accountKey jose.JsonWebKey) (core.Challenge, error) {
 	challenge := input
 
 	if identifier.Type != "dns" {
@@ -497,7 +497,7 @@ func parseHTTPConnError(err error) core.ProblemType {
 	return core.ConnectionProblem
 }
 
-func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, input core.Challenge, accountKey jose.JsonWebKey) (core.Challenge, error) {
+func (va *ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, input core.Challenge, accountKey jose.JsonWebKey) (core.Challenge, error) {
 	challenge := input
 
 	if identifier.Type != core.IdentifierDNS {
@@ -557,7 +557,7 @@ func (va ValidationAuthorityImpl) validateDNS(identifier core.AcmeIdentifier, in
 
 // Overall validation process
 
-func (va ValidationAuthorityImpl) validate(authz core.Authorization, challengeIndex int, accountKey jose.JsonWebKey) {
+func (va *ValidationAuthorityImpl) validate(authz core.Authorization, challengeIndex int, accountKey jose.JsonWebKey) {
 	logEvent := verificationRequestEvent{
 		ID:          authz.ID,
 		Requester:   authz.RegistrationID,
@@ -603,7 +603,7 @@ func (va ValidationAuthorityImpl) validate(authz core.Authorization, challengeIn
 }
 
 // UpdateValidations runs the validate() method asynchronously using goroutines.
-func (va ValidationAuthorityImpl) UpdateValidations(authz core.Authorization, challengeIndex int, accountKey jose.JsonWebKey) error {
+func (va *ValidationAuthorityImpl) UpdateValidations(authz core.Authorization, challengeIndex int, accountKey jose.JsonWebKey) error {
 	go va.validate(authz, challengeIndex, accountKey)
 	return nil
 }


### PR DESCRIPTION
This removes TestMode from the boulder-va command, from ca.Config (it was only used in the VA) and gets the integration config to specify the ports it should use explicitly.

(It also removes a DBDriver field from ca.Config that was left over from letsencrypt/boulder#624.)

Fixes #627.

Also includes the VA pointer work that is in #667 and #667 should go in first.