### PR TITLE
Fix error output in startservers.

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -43,8 +43,10 @@ def install(progs, race_detection):
     out, err = p.communicate()
     if p.returncode != 0:
         sys.stderr.write("unable to run go install: %s\n" % cmd)
-        sys.stderr.write("stdout:\n" + out + "\n")
-        sys.stderr.write("stderr: \n" + err + "\n")
+        if out:
+            sys.stderr.write("stdout:\n" + out + "\n")
+        if err:
+            sys.stderr.write("stderr: \n" + err + "\n")
         return False
     print('installed %s with pid %d' % (cmd, p.pid))
     return True


### PR DESCRIPTION
Previously startservers would crash with an error about concatenating NoneType and string, if there was a build error.

Test-only change, only one review needed.