### PR TITLE
Restore `exec` command to startservers.py.

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -53,7 +53,8 @@ def install(progs, race_detection):
 
 def run(path, race_detection):
     binary = os.path.basename(path)
-    cmd = """GORACE="halt_on_error=1" %s --config %s""" % (binary, config)
+    # Note: Must use exec here so that killing this process kills the command.
+    cmd = """GORACE="halt_on_error=1" exec %s --config %s""" % (binary, config)
     p = subprocess.Popen(cmd, shell=True)
     p.cmd = cmd
     print('started %s with pid %d' % (p.cmd, p.pid))


### PR DESCRIPTION
Fixes https://github.com/letsencrypt/boulder/issues/671