### PR TITLE
add authenticationID index on challenges

### DIFF
--- a/sa/_db/migrations/20150827160921_AddAuthIDIndexToChallenges.sql
+++ b/sa/_db/migrations/20150827160921_AddAuthIDIndexToChallenges.sql
@@ -1,0 +1,11 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+CREATE INDEX `authorizationID_challenges_idx` on `challenges` (`authorizationID`);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP INDEX `authorizationID_challenges_idx` on `challenges`;
+


### PR DESCRIPTION
We look up challenges by authentication ID, so, we should have index on them.

The queries we do for challenges by authorization ID with the `ORDER BY id ASC` are still showing up in MariaDB 10.0's slow-query logs (at least on OS X) when `log-queries-not-using-indexes` is in place. We can't repro that on MySQL 5.6.25 on Linux. @jsha is reproing with 10.0 on Linux now. We think the bug is really in the slow query logging.

In the event this index isn't being used for it, we'll adjust the query later and do the sorting in Go.

If the bug is real, I'll be making a MariaDB ticket about it.