### PR TITLE
Test.js fixes

### DIFF
--- a/test/js/acme.js
+++ b/test/js/acme.js
@@ -51,7 +51,8 @@ Acme.prototype.post = function(url, body, callback) {
   var req = request.post({
     url: url,
     body: signed,
-    encoding: null // Return body as buffer, needed for certificate response
+    // Return body as buffer, needed for certificate response
+    encoding: null,
   }, function(error, response, body) {
     if (error) {
       console.error(error);

--- a/test/js/acme.js
+++ b/test/js/acme.js
@@ -1,0 +1,89 @@
+var colors = require("colors");
+var crypto = require("./crypto-util");
+var request = require('request');
+function Acme(privateKey) {
+  this.privateKey = privateKey;
+  this.nonces = [];
+}
+
+Acme.prototype.getNonce = function(url, callback) {
+  var req = request.head({
+    url: url,
+  }, function(error, response, body) {
+    if (error) {
+      console.log(error);
+      process.exit(1);
+    }
+    if (response && "replay-nonce" in response.headers) {
+      console.log("Storing nonce: " + response.headers["replay-nonce"]);
+      this.nonces.push(response.headers["replay-nonce"]);
+      callback();
+      return;
+    }
+
+    console.log("Failed to get nonce for request");
+    process.exit(1);
+  }.bind(this));
+}
+
+Acme.prototype.post = function(url, body, callback) {
+  // Pre-flight with HEAD if we don't have a nonce
+  if (this.nonces.length == 0) {
+    this.getNonce(url, function() {
+      this.post(url, body, callback);
+    }.bind(this))
+    return;
+  }
+
+  console.log("Using nonce: " + this.nonces[0]);
+  var payload = JSON.stringify(body, null, 2);
+  var jws = crypto.generateSignature(this.privateKey,
+                                     new Buffer(payload),
+                                     this.nonces.shift());
+  var signed = JSON.stringify(jws, null, 2);
+
+  console.log('Posting to', url, ':');
+  console.log(signed.green);
+  console.log('Payload:')
+  console.log(payload.blue);
+  var req = request.post({
+    url: url,
+    headers: {
+      'Content-Length': signed.length
+    },
+    encoding: null // Return body as buffer, needed for certificate response
+  }, function(error, response, body) {
+    console.log(("HTTP/1.1 " + response.statusCode).yellow)
+    Object.keys(response.headers).forEach(function(key) {
+      var value = response.headers[key];
+      var upcased = key.charAt(0).toUpperCase() + key.slice(1);
+      console.log((upcased + ": " + value).yellow)
+    });
+    console.log()
+
+    // Don't print non-ASCII characters (like DER-encoded cert) to the terminal
+    if (body && !body.toString().match(/[^\x00-\x7F]/)) {
+      try {
+        var parsed = JSON.parse(body);
+        console.log(JSON.stringify(parsed, null, 2).cyan);
+      } catch (e) {
+        console.log(body.toString().cyan);
+      }
+    }
+
+    // Remember the nonce provided by the server
+    if ("replay-nonce" in response.headers) {
+      console.log("Storing nonce: " + response.headers["replay-nonce"]);
+      this.nonces.push(response.headers["replay-nonce"]);
+    }
+
+    callback(error, response, body)
+  }.bind(this));
+  req.on('response', function(response) {
+  })
+  req.write(signed)
+  req.end();
+  return req;
+}
+
+module.exports = Acme;

--- a/test/js/revoke.js
+++ b/test/js/revoke.js
@@ -13,6 +13,7 @@ var util = require('./acme-util');
 var forge = require('node-forge');
 var fs = require('fs');
 var request = require('request');
+var Acme = require('./acme');
 
 function main() {
   if (process.argv.length != 5) {
@@ -20,43 +21,23 @@ function main() {
     process.exit(1);
   }
   var certFile = process.argv[2];
-  console.log('Attempting to revoke', certFile);
   var key = crypto.importPemPrivateKey(fs.readFileSync(process.argv[3]));
+  var acme = new Acme(key);
   var certDER = fs.readFileSync(certFile)
+  if (certDER.toString().match(/-----BEGIN/)) {
+    console.log('Got PEM, expected DER:', certFile);
+    process.exit(1);
+  }
   var revokeUrl = process.argv[4];
   var certDERB64URL = util.b64enc(new Buffer(certDER))
-  var revokeMessage = JSON.stringify({
-    resource: "revoke-cert",
+  console.log('Attempting to revoke', certFile);
+  acme.post(revokeUrl, {
+    resource: 'revoke-cert',
     certificate: certDERB64URL
-  });
-  console.log('Requesting revocation:', revokeMessage)
-
-  request.head(revokeUrl, function(error, response, body) {
-    if (error) {
-      console.log(error);
-      process.exit(1);
-    } else if (response.statusCode != 200) {
-      console.log("Got non-200 response asking for nonce (non-fatal):", response.statusCode);
+  }, function(err, response, body) {
+    if (!err && response.statusCode === 200) {
+      console.log('Success');
     }
-    var nonce = response.headers["replay-nonce"];
-    if (!nonce) {
-      console.log("Server HEAD response did not include a replay nonce");
-      process.exit(1);
-    }
-
-    var jws = crypto.generateSignature(key, new Buffer(revokeMessage), nonce);
-    var payload = JSON.stringify(jws);
-
-    var req = request.post(revokeUrl, function(error, response) {
-      if (error || Math.floor(response.statusCode / 100) != 2) {
-        console.log('Error: ', error);
-        process.exit(1);
-      } else {
-        console.log("Revocation request successful.");
-      }
-    });
-    req.write(payload);
-    req.end();
   });
 }
 main();

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -80,12 +80,12 @@ var questions = {
     type: "input",
     name: "keyFile",
     message: "Name for key file",
-    default: "key.pem"
+    default: "key.pem",
   },{
     type: "input",
     name: "certFile",
     message: "Name for certificate file",
-    default: "cert.der"
+    default: "cert.der",
   }],
 };
 
@@ -239,7 +239,7 @@ function register(answers) {
   // Register public key
   post(state.newRegistrationURL, {
     resource: "new-reg",
-    contact: [ "mailto:" + email ]
+    contact: [ "mailto:" + email ],
   }, getTerms);
 }
 
@@ -325,7 +325,7 @@ function getChallenges(answers) {
     resource: "new-authz",
     identifier: {
       type: "dns",
-      value: state.domain
+      value: state.domain,
     }
   }, getReadyToValidate);
 }
@@ -398,7 +398,7 @@ function getReadyToValidate(err, resp, body) {
   post(state.responseURL, {
     resource: "challenge",
     path: state.path,
-    tls: true
+    tls: true,
   }, ensureValidation);
 }
 
@@ -459,7 +459,7 @@ function getCertificate() {
   post(state.newCertificateURL, {
     resource: "new-cert",
     csr: csr,
-    authorizations: state.validAuthorizationURLs
+    authorizations: state.validAuthorizationURLs,
   }, downloadCertificate);
 }
 

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -16,7 +16,7 @@
 
 var colors = require("colors");
 var cli = require("cli");
-var crypto = require("./crypto-util");
+var cryptoUtil = require("./crypto-util");
 var child_process = require('child_process');
 var fs = require('fs');
 var http = require('http');
@@ -207,7 +207,7 @@ function makeKeyPair() {
       console.log(error);
       process.exit(1);
     }
-    state.certPrivateKey = crypto.importPemPrivateKey(fs.readFileSync(state.keyFile));
+    state.certPrivateKey = cryptoUtil.importPemPrivateKey(fs.readFileSync(state.keyFile));
 
     console.log();
     makeAccountKeyPair()
@@ -221,7 +221,7 @@ function makeAccountKeyPair(answers) {
       console.log(error);
       process.exit(1);
     }
-    state.accountPrivateKey = crypto.importPemPrivateKey(fs.readFileSync("account-key.pem"));
+    state.accountPrivateKey = cryptoUtil.importPemPrivateKey(fs.readFileSync("account-key.pem"));
     state.acme = new Acme(state.accountPrivateKey);
 
     console.log();
@@ -355,7 +355,7 @@ function getReadyToValidate(err, resp, body) {
   }
 
   var challenge = simpleHttp[0];
-  var path = crypto.randomString(8) + ".txt";
+  var path = cryptoUtil.randomString(8) + ".txt";
   var challengePath = ".well-known/acme-challenge/" + challenge.token;
   state.responseURL = challenge["uri"];
   state.path = path;
@@ -366,7 +366,7 @@ function getReadyToValidate(err, resp, body) {
     token: challenge.token,
     tls: true
   })
-  var validationJWS = crypto.generateSignature(state.accountPrivateKey,
+  var validationJWS = cryptoUtil.generateSignature(state.accountPrivateKey,
                                                new Buffer(validationObject))
 
   // For local, test-mode validation
@@ -455,7 +455,7 @@ function ensureValidation(err, resp, body) {
 
 function getCertificate() {
   cli.spinner("Requesting certificate");
-  var csr = crypto.generateCSR(state.certPrivateKey, state.validatedDomains);
+  var csr = cryptoUtil.generateCSR(state.certPrivateKey, state.validatedDomains);
   post(state.newCertificateURL, {
     resource: "new-cert",
     csr: csr,


### PR DESCRIPTION
Always pass Content-Length header
Always use tls: true
Don't write terms of service contents to terminal: it might be a PDF
Separate out signing, posting, and printing code into acme.js
Use acme.js in revoke.js for better error reporting.
Check for PEM passed to revoke.js.

This is in response to some trouble JC had using the client to test in prod. In
particular, Akamai insists on Content-Length (we turned this off for a while to
match Boulder, but now it's back on), and the PEM / DER distinction was a
stumbling block.

Note that there are a lot of green lines at the beginning of the file, but they are moved, not added!