### PR TITLE
make certificates der field more reasonably sized

### DIFF
--- a/sa/_db/migrations/20150828001007_MakeDerFieldSmaller.sql
+++ b/sa/_db/migrations/20150828001007_MakeDerFieldSmaller.sql
@@ -1,0 +1,10 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `certificates` MODIFY `der` blob;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `certificates` MODIFY `der` mediumblob;

--- a/sa/model.go
+++ b/sa/model.go
@@ -8,14 +8,16 @@ package sa
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	"github.com/letsencrypt/boulder/core"
 )
 
-var mediumBlobSize = int(math.Pow(2, 24))
+var (
+	mediumBlobSize = 16777215 // 2^24 - 1 bytes, 16MB
+	blobSize       = 65535    // 2^16 - 1 bytes, 65KB
+)
 
 // regModel is the description of a core.Registration in the database.
 type regModel struct {

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -560,8 +560,18 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization(authz core.Authorization) 
 	return
 }
 
+type TooLargeDERError int
+
+func (t TooLargeDERError) Error() string {
+	return fmt.Sprintf("certificate DER size is too large, %d is larger than %d", int(t), blobSize)
+}
+
 // AddCertificate stores an issued certificate.
 func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte, regID int64) (digest string, err error) {
+	if len(certDER) > blobSize {
+		return "", TooLargeDERError(len(certDER))
+	}
+
 	var parsedCertificate *x509.Certificate
 	parsedCertificate, err = x509.ParseCertificate(certDER)
 	if err != nil {


### PR DESCRIPTION
No DERs should be 16MB. 65KB seems like a reasonable upper-bound.

And ensure that the DER is not allowed to come in larger than that.