### PR TITLE
disallow all null values in registrations table

### DIFF
--- a/sa/_db/migrations/20150828005159_RegistrationsNotNullManyFields.sql
+++ b/sa/_db/migrations/20150828005159_RegistrationsNotNullManyFields.sql
@@ -1,0 +1,14 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `registrations` MODIFY `contact` varchar(255) NOT NULL;
+ALTER TABLE `registrations` MODIFY `agreement` varchar(255) NOT NULL;
+ALTER TABLE `registrations` MODIFY `LockCol` bigint(20) NOT NULL;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `registrations` MODIFY `contact` varchar(255) DEFAULT NULL;
+ALTER TABLE `registrations` MODIFY `agreement` varchar(255) DEFAULT NULL;
+ALTER TABLE `registrations` MODIFY `LockCol` bigint(20) DEFAULT NULL;


### PR DESCRIPTION
This prevents weird bad things happening in the future.

registrations is the first table of many that will receive this treatment.