### PR TITLE
Print error in Assert{,Not}Error.

### DIFF
--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -50,7 +50,7 @@ func AssertNotError(t *testing.T, err error, message string) {
 // AssertError checks that err is non-nil
 func AssertError(t *testing.T, err error, message string) {
 	if err == nil {
-		t.Fatalf("%s %s", caller(), message)
+		t.Fatalf("%s %s: %s", caller(), message, err)
 	}
 }
 


### PR DESCRIPTION
I accidentally removed this in #675.