### PR TITLE
Split up WFE Authorization function.

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -747,10 +747,16 @@ func (wfe *WebFrontEndImpl) NewCertificate(response http.ResponseWriter, request
 	wfe.Stats.Inc("Certificates", 1, 1.0)
 }
 
-func (wfe *WebFrontEndImpl) challenge(authz core.Authorization, response http.ResponseWriter, request *http.Request, logEvent requestEvent) requestEvent {
+func (wfe *WebFrontEndImpl) challenge(
+	response http.ResponseWriter,
+	request *http.Request,
+	authz core.Authorization,
+	logEvent *requestEvent) {
+
 	// Check that the requested challenge exists within the authorization
 	found := false
 	var challengeIndex int
+	var challenge core.Challenge
 	for i, challenge := range authz.Challenges {
 		tempURL := challenge.URI
 		if tempURL.Path == request.URL.Path && tempURL.RawQuery == request.URL.RawQuery {
@@ -763,104 +769,119 @@ func (wfe *WebFrontEndImpl) challenge(authz core.Authorization, response http.Re
 	if !found {
 		logEvent.Error = "Unable to find challenge"
 		wfe.sendError(response, logEvent.Error, request.URL.RawQuery, http.StatusNotFound)
-		return logEvent
+		return
 	}
 
 	switch request.Method {
 	case "GET":
-		challenge := authz.Challenges[challengeIndex]
-		jsonReply, err := json.Marshal(challenge)
-		if err != nil {
-			logEvent.Error = err.Error()
-			// InternalServerError because this is a failure to decode data passed in
-			// by the caller, which got it from the DB.
-			wfe.sendError(response, "Failed to marshal challenge", err, http.StatusInternalServerError)
-			return logEvent
-		}
-
-		authzURL := wfe.AuthzBase + string(authz.ID)
-		response.Header().Add("Location", challenge.URI.String())
-		response.Header().Set("Content-Type", "application/json")
-		response.Header().Add("Link", link(authzURL, "up"))
-		response.WriteHeader(http.StatusAccepted)
-		if _, err := response.Write(jsonReply); err != nil {
-			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
-			logEvent.Error = err.Error()
-			return logEvent
-		}
+		wfe.getChallenge(response, request, authz, challenge, logEvent)
 
 	case "POST":
-		body, _, currReg, err := wfe.verifyPOST(request, true, core.ResourceChallenge)
-		if err != nil {
-			logEvent.Error = err.Error()
-			respMsg := malformedJWS
-			respCode := http.StatusBadRequest
-			if err == sql.ErrNoRows {
-				respMsg = unknownKey
-				respCode = http.StatusForbidden
-			}
-			wfe.sendError(response, respMsg, err, respCode)
-			return logEvent
-		}
-		logEvent.Requester = currReg.ID
-		logEvent.Contacts = currReg.Contact
-		// Any version of the agreement is acceptable here. Version match is enforced in
-		// wfe.Registration when agreeing the first time. Agreement updates happen
-		// by mailing subscribers and don't require a registration update.
-		if currReg.Agreement == "" {
-			logEvent.Error = "Must agree to subscriber agreement before any further actions"
-			wfe.sendError(response, logEvent.Error, nil, http.StatusForbidden)
-			return logEvent
-		}
-
-		// Check that the registration ID matching the key used matches
-		// the registration ID on the authz object
-		if currReg.ID != authz.RegistrationID {
-			logEvent.Error = fmt.Sprintf("User: %v != Authorization: %v", currReg.ID, authz.RegistrationID)
-			wfe.sendError(response, "User registration ID doesn't match registration ID in authorization",
-				logEvent.Error,
-				http.StatusForbidden)
-			return logEvent
-		}
-
-		var challengeResponse core.Challenge
-		if err = json.Unmarshal(body, &challengeResponse); err != nil {
-			logEvent.Error = err.Error()
-			wfe.sendError(response, "Error unmarshaling challenge response", err, http.StatusBadRequest)
-			return logEvent
-		}
-
-		// Ask the RA to update this authorization
-		updatedAuthz, err := wfe.RA.UpdateAuthorization(authz, challengeIndex, challengeResponse)
-		if err != nil {
-			logEvent.Error = err.Error()
-			wfe.sendError(response, "Unable to update authorization", err, statusCodeFromError(err))
-			return logEvent
-		}
-
-		challenge := updatedAuthz.Challenges[challengeIndex]
-		// assumption: UpdateAuthorization does not modify order of challenges
-		jsonReply, err := json.Marshal(challenge)
-		if err != nil {
-			logEvent.Error = err.Error()
-			// StatusInternalServerError because we made the challenges, they should be OK
-			wfe.sendError(response, "Failed to marshal challenge", err, http.StatusInternalServerError)
-			return logEvent
-		}
-
-		authzURL := wfe.AuthzBase + string(authz.ID)
-		response.Header().Add("Location", challenge.URI.String())
-		response.Header().Set("Content-Type", "application/json")
-		response.Header().Add("Link", link(authzURL, "up"))
-		response.WriteHeader(http.StatusAccepted)
-		if _, err = response.Write(jsonReply); err != nil {
-			logEvent.Error = err.Error()
-			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
-			return logEvent
-		}
-
+		wfe.postChallenge(response, request, authz, challengeIndex, logEvent)
 	}
-	return logEvent
+}
+
+func (wfe *WebFrontEndImpl) getChallenge(
+	response http.ResponseWriter,
+	request *http.Request,
+	authz core.Authorization,
+	challenge core.Challenge,
+	logEvent *requestEvent) {
+	jsonReply, err := json.Marshal(challenge)
+	if err != nil {
+		logEvent.Error = err.Error()
+		// InternalServerError because this is a failure to decode data passed in
+		// by the caller, which got it from the DB.
+		wfe.sendError(response, "Failed to marshal challenge", err, http.StatusInternalServerError)
+		return
+	}
+
+	authzURL := wfe.AuthzBase + string(authz.ID)
+	response.Header().Add("Location", challenge.URI.String())
+	response.Header().Set("Content-Type", "application/json")
+	response.Header().Add("Link", link(authzURL, "up"))
+	response.WriteHeader(http.StatusAccepted)
+	if _, err := response.Write(jsonReply); err != nil {
+		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
+		logEvent.Error = err.Error()
+		return
+	}
+}
+
+func (wfe *WebFrontEndImpl) postChallenge(
+	response http.ResponseWriter,
+	request *http.Request,
+	authz core.Authorization,
+	challengeIndex int,
+	logEvent *requestEvent) {
+	body, _, currReg, err := wfe.verifyPOST(request, true, core.ResourceChallenge)
+	if err != nil {
+		logEvent.Error = err.Error()
+		respMsg := malformedJWS
+		respCode := http.StatusBadRequest
+		if err == sql.ErrNoRows {
+			respMsg = unknownKey
+			respCode = http.StatusForbidden
+		}
+		wfe.sendError(response, respMsg, err, respCode)
+		return
+	}
+	logEvent.Requester = currReg.ID
+	logEvent.Contacts = currReg.Contact
+	// Any version of the agreement is acceptable here. Version match is enforced in
+	// wfe.Registration when agreeing the first time. Agreement updates happen
+	// by mailing subscribers and don't require a registration update.
+	if currReg.Agreement == "" {
+		logEvent.Error = "Must agree to subscriber agreement before any further actions"
+		wfe.sendError(response, logEvent.Error, nil, http.StatusForbidden)
+		return
+	}
+
+	// Check that the registration ID matching the key used matches
+	// the registration ID on the authz object
+	if currReg.ID != authz.RegistrationID {
+		logEvent.Error = fmt.Sprintf("User: %v != Authorization: %v", currReg.ID, authz.RegistrationID)
+		wfe.sendError(response, "User registration ID doesn't match registration ID in authorization",
+			logEvent.Error,
+			http.StatusForbidden)
+		return
+	}
+
+	var challengeUpdate core.Challenge
+	if err = json.Unmarshal(body, &challengeUpdate); err != nil {
+		logEvent.Error = err.Error()
+		wfe.sendError(response, "Error unmarshaling challenge response", err, http.StatusBadRequest)
+		return
+	}
+
+	// Ask the RA to update this authorization
+	updatedAuthorization, err := wfe.RA.UpdateAuthorization(authz, challengeIndex, challengeUpdate)
+	if err != nil {
+		logEvent.Error = err.Error()
+		wfe.sendError(response, "Unable to update challenge", err, statusCodeFromError(err))
+		return
+	}
+
+	// assumption: UpdateAuthorization does not modify order of challenges
+	challenge := updatedAuthorization.Challenges[challengeIndex]
+	jsonReply, err := json.Marshal(challenge)
+	if err != nil {
+		logEvent.Error = err.Error()
+		// StatusInternalServerError because we made the challenges, they should be OK
+		wfe.sendError(response, "Failed to marshal challenge", err, http.StatusInternalServerError)
+		return
+	}
+
+	authzURL := wfe.AuthzBase + string(authz.ID)
+	response.Header().Add("Location", challenge.URI.String())
+	response.Header().Set("Content-Type", "application/json")
+	response.Header().Add("Link", link(authzURL, "up"))
+	response.WriteHeader(http.StatusAccepted)
+	if _, err = response.Write(jsonReply); err != nil {
+		logEvent.Error = err.Error()
+		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
+		return
+	}
 }
 
 // Registration is used by a client to submit an update to their registration.
@@ -968,29 +989,42 @@ func (wfe *WebFrontEndImpl) Authorization(response http.ResponseWriter, request 
 
 	// If there is a fragment, then this is actually a request to a challenge URI
 	if len(request.URL.RawQuery) != 0 {
-		logEvent = wfe.challenge(authz, response, request, logEvent)
+		wfe.challenge(response, request, authz, &logEvent)
+	} else if request.Method == "GET" {
+		wfe.GetAuthorization(response, request, authz, &logEvent)
+	} else {
+		// For challenges, POST and GET are allowed. For authorizations only GET is
+		// allowed.
+		// TODO(jsha): Split challenge updates into a different path so we can use
+		// the HandleFunc functionality for declaring allowed methods.
+		// https://github.com/letsencrypt/boulder/issues/638
+		logEvent.Error = "Method not allowed"
+		response.Header().Set("Allow", "GET")
+		wfe.sendError(response, logEvent.Error, request.Method, http.StatusMethodNotAllowed)
+	}
+}
+
+func (wfe *WebFrontEndImpl) GetAuthorization(
+	response http.ResponseWriter,
+	request *http.Request,
+	authz core.Authorization,
+	logEvent *requestEvent) {
+	// Blank out ID and regID
+	authz.ID = ""
+	authz.RegistrationID = 0
+	jsonReply, err := json.Marshal(authz)
+	if err != nil {
+		logEvent.Error = err.Error()
+		// InternalServerError because this is a failure to decode from our DB.
+		wfe.sendError(response, "Failed to marshal authz", err, http.StatusInternalServerError)
 		return
 	}
-
-	switch request.Method {
-	case "GET":
-		// Blank out ID and regID
-		authz.ID = ""
-		authz.RegistrationID = 0
-		jsonReply, err := json.Marshal(authz)
-		if err != nil {
-			logEvent.Error = err.Error()
-			// InternalServerError because this is a failure to decode from our DB.
-			wfe.sendError(response, "Failed to marshal authz", err, http.StatusInternalServerError)
-			return
-		}
-		response.Header().Add("Link", link(wfe.NewCert, "next"))
-		response.Header().Set("Content-Type", "application/json")
-		response.WriteHeader(http.StatusOK)
-		if _, err = response.Write(jsonReply); err != nil {
-			logEvent.Error = err.Error()
-			wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
-		}
+	response.Header().Add("Link", link(wfe.NewCert, "next"))
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(http.StatusOK)
+	if _, err = response.Write(jsonReply); err != nil {
+		logEvent.Error = err.Error()
+		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 	}
 }
 

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -697,11 +697,11 @@ func TestChallenge(t *testing.T) {
 	}
 
 	challengeURL := url.URL(*challengeAcme)
-	wfe.challenge(authz, responseWriter, &http.Request{
+	wfe.challenge(responseWriter, &http.Request{
 		Method: "POST",
 		URL:    &challengeURL,
 		Body:   makeBody(signRequest(t, `{"resource":"challenge"}`, &wfe.nonceService)),
-	}, requestEvent{})
+	}, authz, &requestEvent{})
 
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Location"),


### PR DESCRIPTION
This function splits out Authorization into its three separate cases:
GET a challenge
POST a challenge
GET an authorization

This is a refactoring I needed to do on the way to
https://github.com/letsencrypt/boulder/issues/638. I split it out to avoid
having that change grow too big and full of ancillary refactorings.