### PR TITLE
Temporarily disable DNS challenge.

### DIFF
--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -166,12 +166,10 @@ func (pa PolicyAuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) (cha
 	challenges = []core.Challenge{
 		core.SimpleHTTPChallenge(),
 		core.DvsniChallenge(),
-		core.DNSChallenge(),
 	}
 	combinations = [][]int{
 		[]int{0},
 		[]int{1},
-		[]int{2},
 	}
 	return
 }

--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -144,12 +144,11 @@ func TestChallengesFor(t *testing.T) {
 
 	challenges, combinations := pa.ChallengesFor(core.AcmeIdentifier{})
 
-	if len(challenges) != 3 || challenges[0].Type != core.ChallengeTypeSimpleHTTP ||
-		challenges[1].Type != core.ChallengeTypeDVSNI ||
-		challenges[2].Type != core.ChallengeTypeDNS {
+	if len(challenges) != 2 || challenges[0].Type != core.ChallengeTypeSimpleHTTP ||
+		challenges[1].Type != core.ChallengeTypeDVSNI {
 		t.Error("Incorrect challenges returned")
 	}
-	if len(combinations) != 3 || combinations[0][0] != 0 || combinations[1][0] != 1 {
+	if len(combinations) != 2 || combinations[0][0] != 0 || combinations[1][0] != 1 {
 		t.Error("Incorrect combinations returned")
 	}
 }

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -376,13 +376,11 @@ func TestNewAuthorization(t *testing.T) {
 	test.Assert(t, authz.Status == core.StatusPending, "Initial authz not pending")
 
 	// TODO Verify that challenges are correct
-	test.Assert(t, len(authz.Challenges) == 3, "Incorrect number of challenges returned")
+	test.Assert(t, len(authz.Challenges) == 2, "Incorrect number of challenges returned")
 	test.Assert(t, authz.Challenges[0].Type == core.ChallengeTypeSimpleHTTP, "Challenge 0 not SimpleHTTP")
 	test.Assert(t, authz.Challenges[1].Type == core.ChallengeTypeDVSNI, "Challenge 1 not DVSNI")
-	test.Assert(t, authz.Challenges[2].Type == core.ChallengeTypeDNS, "Challenge 2 not DNS")
 	test.Assert(t, authz.Challenges[0].IsSane(false), "Challenge 0 is not sane")
 	test.Assert(t, authz.Challenges[1].IsSane(false), "Challenge 1 is not sane")
-	test.Assert(t, authz.Challenges[2].IsSane(false), "Challenge 2 is not sane")
 
 	t.Log("DONE TestNewAuthorization")
 }


### PR DESCRIPTION
We're not planning to offer this one at launch (hopefully not long after,
though).