### PR TITLE
drop unused status column from certificates

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -408,8 +408,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 	certDER := block.Bytes
 
 	cert := core.Certificate{
-		DER:    certDER,
-		Status: core.StatusValid,
+		DER: certDER,
 	}
 
 	// This is one last check for uncaught errors

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -47,7 +47,6 @@ func BenchmarkCheckCert(b *testing.B) {
 	}
 	certDer, _ := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
 	cert := core.Certificate{
-		Status:  core.StatusValid,
 		Serial:  core.SerialToString(serial),
 		Digest:  core.Fingerprint256(certDer),
 		DER:     certDer,
@@ -91,7 +90,6 @@ func TestCheckCert(t *testing.T) {
 	//   Serial doesn't match
 	//   Expiry doesn't match
 	cert := core.Certificate{
-		Status:  core.StatusValid,
 		DER:     brokenCertDer,
 		Issued:  issued,
 		Expires: goodExpiry.AddDate(0, 0, 2), // Expiration doesn't match

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -168,7 +168,7 @@ func (m *mailer) findExpiringCertificates() error {
 			 ON cs.serial = cert.serial
 			 AND cert.expires > :cutoffA
 			 AND cert.expires <= :cutoffB
-			 AND cert.status != "revoked"
+			 AND cs.status != "revoked"
 			 AND cs.lastExpirationNagSent <= :nagCutoff
 			 ORDER BY cert.expires ASC
 			 LIMIT :limit`,

--- a/core/objects.go
+++ b/core/objects.go
@@ -469,11 +469,6 @@ func (jb *JSONBuffer) UnmarshalJSON(data []byte) (err error) {
 type Certificate struct {
 	RegistrationID int64 `db:"registrationID"`
 
-	// The revocation status of the certificate.
-	// * "valid" - not revoked
-	// * "revoked" - revoked
-	Status AcmeStatus `db:"status"`
-
 	Serial  string    `db:"serial"`
 	Digest  string    `db:"digest"`
 	DER     []byte    `db:"der"`

--- a/sa/_db/migrations/20150828161056_DropStatusColumnOnCertificate.sql
+++ b/sa/_db/migrations/20150828161056_DropStatusColumnOnCertificate.sql
@@ -1,0 +1,10 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `certificates` DROP COLUMN `status`;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `certificates` ADD COLUMN `status` varchar(255) DEFAULT NULL;


### PR DESCRIPTION
Also, use certificateStatus's status in the expiration-mailer join. expiration-mailer's tests gain a setup function.

Fixes #694.
Fixes #713.