### PR TITLE
run make in parallel in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ env:
   matrix:
     - SKIP_INTEGRATION_TESTS=1
     - SKIP_UNIT_TESTS=1
+    - RUN_MAKE=1 SKIP_UNIT_TESTS=1 SKIP_INTEGRATION_TESTS=1
 
 script:
-  - make -j4 # Travis has 2 cores per build instance
+  - bash test/travis_make.sh
   - bash test.sh

--- a/test/travis_make.sh
+++ b/test/travis_make.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# A script to make it easier to parallelize the build by building make
+# conditionally.
+
+set -o errexit
+
+if [ "${TRAVIS}" != "true" ]; then
+  echo "Not to be run outside of TravisCI" > /dev/stderr
+  exit 1
+fi
+
+if [ "${RUN_MAKE}" == "1" ]; then
+  make -j4 # Travis has 2 cores per build instance
+fi


### PR DESCRIPTION
This gets us down to 5-6 minute build times.

A new script had to be added to run make conditionally without allowing builds with make failures to pass.