### PR TITLE
correct ca and sa revocation code and tests

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/ca"
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
@@ -43,7 +44,7 @@ func main() {
 		pa, err := policy.NewPolicyAuthorityImpl(paDbMap, c.PA.EnforcePolicyWhitelist)
 		cmd.FailOnError(err, "Couldn't create PA")
 
-		cai, err := ca.NewCertificateAuthorityImpl(cadb, c.CA, c.Common.IssuerCert)
+		cai, err := ca.NewCertificateAuthorityImpl(cadb, c.CA, clock.Default(), c.Common.IssuerCert)
 		cmd.FailOnError(err, "Failed to create CA impl")
 		cai.MaxKeySize = c.Common.MaxKeySize
 		cai.PA = pa

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -7,7 +7,7 @@ package main
 
 import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
-
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
@@ -34,7 +34,7 @@ func main() {
 		dbMap, err := sa.NewDbMap(c.SA.DBConnect)
 		cmd.FailOnError(err, "Couldn't connect to SA database")
 
-		sai, err := sa.NewSQLStorageAuthority(dbMap)
+		sai, err := sa.NewSQLStorageAuthority(dbMap, clock.Default())
 		cmd.FailOnError(err, "Failed to create SA impl")
 		sai.SetSQLDebug(c.SQL.SQLDebug)
 

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -74,14 +74,14 @@ type certChecker struct {
 	clock        clock.Clock
 }
 
-func newChecker(saDbMap *gorp.DbMap, paDbMap *gorp.DbMap, enforceWhitelist bool) certChecker {
+func newChecker(saDbMap *gorp.DbMap, paDbMap *gorp.DbMap, clk clock.Clock, enforceWhitelist bool) certChecker {
 	pa, err := policy.NewPolicyAuthorityImpl(paDbMap, enforceWhitelist)
 	cmd.FailOnError(err, "Failed to create PA")
 	c := certChecker{
 		pa:    pa,
 		dbMap: saDbMap,
 		certs: make(chan core.Certificate, batchSize),
-		clock: clock.Default(),
+		clock: clk,
 	}
 	c.issuedReport.Entries = make(map[string]reportEntry)
 	return c
@@ -234,7 +234,7 @@ func main() {
 		paDbMap, err := sa.NewDbMap(c.PA.DBConnect)
 		cmd.FailOnError(err, "Could not connect to policy database")
 
-		checker := newChecker(saDbMap, paDbMap, c.PA.EnforcePolicyWhitelist)
+		checker := newChecker(saDbMap, paDbMap, clock.Default(), c.PA.EnforcePolicyWhitelist)
 		auditlogger.Info("# Getting certificates issued in the last 90 days")
 
 		// Since we grab certificates in batches we don't want this to block, when it

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -456,7 +456,8 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 	if err != nil {
 		t.Fatalf("Couldn't connect the database: %s", err)
 	}
-	ssa, err := sa.NewSQLStorageAuthority(dbMap)
+	fc := clock.NewFake()
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
 	}
@@ -464,7 +465,6 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 
 	stats, _ := statsd.NewNoopClient(nil)
 	mc := &mockMail{}
-	fc := clock.NewFake()
 
 	m := &mailer{
 		log:           blog.GetAuditLogger(),

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -20,6 +20,7 @@ import (
 	cfsslConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	"github.com/letsencrypt/boulder/ca"
 	"github.com/letsencrypt/boulder/core"
@@ -144,11 +145,13 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	err = json.Unmarshal(ShortKeyJSON, &ShortKey)
 	test.AssertNotError(t, err, "Failed to unmarshall JWK")
 
+	fc := clock.NewFake()
+
 	dbMap, err := sa.NewDbMap(saDBConnStr)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
-	ssa, err := sa.NewSQLStorageAuthority(dbMap)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}
@@ -193,6 +196,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 		ValidityPeriod: time.Hour * 2190,
 		NotAfter:       time.Now().Add(time.Hour * 8761),
 		MaxKeySize:     4096,
+		Clk:            fc,
 	}
 	cleanUp := func() {
 		saDBCleanUp()

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 	"github.com/letsencrypt/boulder/core"
@@ -27,6 +28,7 @@ const getChallengesQuery = "SELECT * FROM challenges WHERE authorizationID = :au
 // SQLStorageAuthority defines a Storage Authority
 type SQLStorageAuthority struct {
 	dbMap *gorp.DbMap
+	clk   clock.Clock
 	log   *blog.AuditLogger
 }
 
@@ -49,13 +51,14 @@ type authzModel struct {
 
 // NewSQLStorageAuthority provides persistence using a SQL backend for
 // Boulder. It will modify the given gorp.DbMap by adding relevent tables.
-func NewSQLStorageAuthority(dbMap *gorp.DbMap) (*SQLStorageAuthority, error) {
+func NewSQLStorageAuthority(dbMap *gorp.DbMap, clk clock.Clock) (*SQLStorageAuthority, error) {
 	logger := blog.GetAuditLogger()
 
 	logger.Notice("Storage Authority Starting")
 
 	ssa := &SQLStorageAuthority{
 		dbMap: dbMap,
+		clk:   clk,
 		log:   logger,
 	}
 
@@ -287,7 +290,6 @@ func (ssa *SQLStorageAuthority) GetCertificateStatus(serial string) (status core
 	if err != nil {
 		return
 	}
-
 	status = *certificateStats.(*core.CertificateStatus)
 	return
 }
@@ -318,7 +320,7 @@ func (ssa *SQLStorageAuthority) UpdateOCSP(serial string, ocspResponse []byte) (
 		return
 	}
 
-	timeStamp := time.Now()
+	timeStamp := ssa.clk.Now()
 
 	// Record the response.
 	ocspResp := &core.OCSPResponse{Serial: serial, CreatedAt: timeStamp, Response: ocspResponse}
@@ -358,7 +360,8 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(serial string, ocspRespon
 		return
 	}
 
-	ocspResp := &core.OCSPResponse{Serial: serial, CreatedAt: time.Now(), Response: ocspResponse}
+	ocspResp := &core.OCSPResponse{Serial: serial, CreatedAt: ssa.clk.Now(), Response: ocspResponse}
+
 	err = tx.Insert(ocspResp)
 	if err != nil {
 		tx.Rollback()
@@ -375,18 +378,25 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(serial string, ocspRespon
 		tx.Rollback()
 		return
 	}
+	now := ssa.clk.Now()
 	status := statusObj.(*core.CertificateStatus)
 	status.Status = core.OCSPStatusRevoked
-	status.RevokedDate = time.Now()
+	status.RevokedDate = now
 	status.RevokedReason = reasonCode
+	status.OCSPLastUpdated = now
 
-	_, err = tx.Update(status)
+	n, err := tx.Update(status)
 	if err != nil {
 		tx.Rollback()
 		return
 	}
-
+	if n == 0 {
+		tx.Rollback()
+		err = errors.New("No certificate updated. Maybe the lock column was off?")
+		return
+	}
 	err = tx.Commit()
+
 	return
 }
 
@@ -561,7 +571,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(certDER []byte, regID int64) (dig
 		Serial:         serial,
 		Digest:         digest,
 		DER:            certDER,
-		Issued:         time.Now(),
+		Issued:         ssa.clk.Now(),
 		Expires:        parsedCertificate.NotAfter,
 	}
 	certStatus := &core.CertificateStatus{


### PR DESCRIPTION
The ca's TestRevoke was failing occasionally.

The test was saying "has the certificate's OCSPLastUpdated been set to a time within the last second?" as a way to see if the revocation updated the OCSPLastUpdated. OCSPLastUpdated was not being set on revocation, but the test still passed most of the time.

The test still passed most of the time because the creation of the certificate (which also sets the OCSPLastUpdated) has usually happened within the last second. So, even without revocation, the OCSPLastUpdated was set to something in the last second because the test is fast.

Threading a clock.FakeClock through the CA induced the test to fail consistently. Debugging and threading a FakeClock through the SA caused changes in times reported but did not fix the test because the OCSPLastUpdated was simply not being updated. There were not tests for the sa.MarkCertificateRevoked API that was being called by ca.RevokeCertificate.

Now the SA has tests for its MarkCertificateRevoked method. It uses a fake clock to ensure not just that OCSPLastUpdated is set correctly, but that RevokedDate is, as well. The test also checks for the CertificateStatus's status and RevocationCode changes.

The SA and CA now use Clocks throughout instead of time.Now() allowing for more reliable and expansive testing in the future.

The CA had to gain a public Clock field in order for the RA to use the CertificateAuthorityImpl struct without using its constructor function. Otherwise, the field would be nil and cause panics in the RA
tests.

The RA tests are similarly also panicking when the CAImpl attempts to log something with its private, nil-in-those-tests log field but we're getting "lucky" because the RA tests only cause the CAImpl to log when
they are broken.

There is a TODO there to make the CAImpl's constructor function take just what it needs to operate instead of taking large config objects and doing file IO and such. The Clk field should be made private and the log field filled in for the RA tests.

Fixes #734.