### PR TITLE
va: format url as url in errors

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -218,7 +218,7 @@ func (va *ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdenti
 	portString := fmt.Sprintf("%d", port)
 	hostPort := net.JoinHostPort(host, portString)
 
-	url := url.URL{
+	url := &url.URL{
 		Scheme: scheme,
 		Host:   hostPort,
 		Path:   fmt.Sprintf(".well-known/acme-challenge/%s", challenge.Token),


### PR DESCRIPTION
When a URL couldn't be connected to in validateSimpleHTTP, the fmt.Sprintf's using the URL would format it as something like

    {https  <nil> kuba.us.to:443 .well-known/acme-challenge/bgTYeerZbjhysBOgwIx_-7uVDnVnsaxagWvCk6lzNc   }

Instead of:

    https://kuba.us.to:443/.well-known/acme-challenge/bgTYeerZbjhysBOgwIx_-7uVDnVnsaxagWvCk6lzNc

This would show up in errors like:

    Failed authorization procedure. kuba.us.to (simpleHttp): connection :: The server could not connect to the client for DV :: Could not connect to {https  <nil> kuba.us.to:443 .well-known/acme-challenge/-bgTYeerZbjhysBOgwIx_-7uVDnVnsaxagWvCk6lzNc   }

By passing in a plain URL struct to Sprintf(), it wasn't using the *url.URL.String() method, but the
built-in struct formatting.

The fix is simple: make the url variable a `*url.URL` instead of a `url.URL`.

Thanks to @kuba for point this one out.