### PR TITLE
retry download of go binaries in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,13 @@ before_install:
   # Github-PR-Status secret
   - openssl aes-256-cbc -K $encrypted_53b2630f0fb4_key -iv $encrypted_53b2630f0fb4_iv -in test/github-secret.json.enc -out test/github-secret.json -d || true
 
-  - go get golang.org/x/tools/cmd/vet
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/golang/lint/golint
-  - go get github.com/mattn/goveralls
-  - go get github.com/modocache/gover
-  - go get github.com/jcjones/github-pr-status
-  - go get bitbucket.org/liamstask/goose/cmd/goose
+  - travis_retry go get golang.org/x/tools/cmd/vet
+  - travis_retry go get golang.org/x/tools/cmd/cover
+  - travis_retry go get github.com/golang/lint/golint
+  - travis_retry go get github.com/mattn/goveralls
+  - travis_retry go get github.com/modocache/gover
+  - travis_retry go get github.com/jcjones/github-pr-status
+  - travis_retry go get bitbucket.org/liamstask/goose/cmd/goose
 
   # Boulder consists of multiple Go packages, which
   # refer to each other by their absolute GitHub path,


### PR DESCRIPTION
bitbucket is espescially slow and flaky. Not doing this caused a test failure on master.

We should probably figure out a solution for keeping binaries around. (Godeps doesn't solve that trivially.)