### PR TITLE
allow NULL expires in authz on validation failure

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
@@ -42,7 +43,7 @@ func main() {
 		pa, err := policy.NewPolicyAuthorityImpl(paDbMap, c.PA.EnforcePolicyWhitelist)
 		cmd.FailOnError(err, "Couldn't create PA")
 
-		rai := ra.NewRegistrationAuthorityImpl()
+		rai := ra.NewRegistrationAuthorityImpl(clock.Default(), auditlogger)
 		rai.AuthzBase = c.Common.BaseURL + wfe.AuthzPath
 		rai.MaxKeySize = c.Common.MaxKeySize
 		rai.PA = pa

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -20,9 +20,11 @@ import (
 	cfsslConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/signer/local"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	"github.com/letsencrypt/boulder/ca"
 	"github.com/letsencrypt/boulder/core"
+	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
@@ -130,7 +132,7 @@ const (
 	saDBConnStr = "mysql+tcp://boulder@localhost:3306/boulder_sa_test"
 )
 
-func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAuthority, *RegistrationAuthorityImpl, func()) {
+func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAuthority, *RegistrationAuthorityImpl, clock.FakeClock, func()) {
 	err := json.Unmarshal(AccountKeyJSONA, &AccountKeyA)
 	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
 	err = json.Unmarshal(AccountKeyJSONB, &AccountKeyB)
@@ -143,6 +145,8 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 
 	err = json.Unmarshal(ShortKeyJSON, &ShortKey)
 	test.AssertNotError(t, err, "Failed to unmarshall JWK")
+
+	fc := clock.NewFake()
 
 	dbMap, err := sa.NewDbMap(saDBConnStr)
 	if err != nil {
@@ -205,7 +209,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 
 	Registration, _ = ssa.NewRegistration(core.Registration{Key: AccountKeyA})
 
-	ra := NewRegistrationAuthorityImpl()
+	ra := NewRegistrationAuthorityImpl(fc, blog.GetAuditLogger())
 	ra.SA = ssa
 	ra.VA = va
 	ra.CA = &ca
@@ -224,7 +228,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	AuthzFinal.Expires = &exp
 	AuthzFinal.Challenges[0].Status = "valid"
 
-	return va, ssa, &ra, cleanUp
+	return va, ssa, &ra, fc, cleanUp
 }
 
 // This is an unfortunate bit of tech debt that is being taken on in
@@ -253,6 +257,14 @@ func assertAuthzEqual(t *testing.T, a1, a2 core.Authorization) {
 	test.Assert(t, a1.Identifier == a2.Identifier, "ret != DB: Identifier")
 	test.Assert(t, a1.Status == a2.Status, "ret != DB: Status")
 	test.Assert(t, a1.RegistrationID == a2.RegistrationID, "ret != DB: RegID")
+	if a1.Expires == nil && a2.Expires == nil {
+		return
+	} else if a1.Expires == nil || a2.Expires == nil {
+		t.Errorf("one and only one of authorization's Expires was nil; ret %s, DB %s", a1, a2)
+	} else {
+		test.Assert(t, a1.Expires.Equal(*a2.Expires), "ret != DB: Expires")
+	}
+
 	// Not testing: Challenges
 }
 
@@ -299,7 +311,7 @@ func TestValidateEmail(t *testing.T) {
 }
 
 func TestNewRegistration(t *testing.T) {
-	_, sa, ra, cleanUp := initAuthorities(t)
+	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
@@ -324,7 +336,7 @@ func TestNewRegistration(t *testing.T) {
 }
 
 func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
-	_, _, ra, cleanUp := initAuthorities(t)
+	_, _, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
@@ -352,7 +364,7 @@ func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
 }
 
 func TestNewRegistrationBadKey(t *testing.T) {
-	_, _, ra, cleanUp := initAuthorities(t)
+	_, _, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
@@ -365,7 +377,7 @@ func TestNewRegistrationBadKey(t *testing.T) {
 }
 
 func TestNewAuthorization(t *testing.T) {
-	_, sa, ra, cleanUp := initAuthorities(t)
+	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	_, err := ra.NewAuthorization(AuthzRequest, 0)
 	test.AssertError(t, err, "Authorization cannot have registrationID == 0")
@@ -394,7 +406,7 @@ func TestNewAuthorization(t *testing.T) {
 }
 
 func TestUpdateAuthorization(t *testing.T) {
-	va, sa, ra, cleanUp := initAuthorities(t)
+	va, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// We know this is OK because of TestNewAuthorization
@@ -420,7 +432,7 @@ func TestUpdateAuthorization(t *testing.T) {
 }
 
 func TestUpdateAuthorizationReject(t *testing.T) {
-	_, sa, ra, cleanUp := initAuthorities(t)
+	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// We know this is OK because of TestNewAuthorization
@@ -441,8 +453,8 @@ func TestUpdateAuthorizationReject(t *testing.T) {
 	t.Log("DONE TestUpdateAuthorizationReject")
 }
 
-func TestOnValidationUpdate(t *testing.T) {
-	_, sa, ra, cleanUp := initAuthorities(t)
+func TestOnValidationUpdateSuccess(t *testing.T) {
+	_, sa, ra, fclk, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	AuthzUpdated, _ = sa.NewPendingAuthorization(AuthzUpdated)
 	sa.UpdatePendingAuthorization(AuthzUpdated)
@@ -455,17 +467,34 @@ func TestOnValidationUpdate(t *testing.T) {
 
 	// Verify that the Authz in the DB is the same except for Status->StatusValid
 	authzFromVA.Status = core.StatusValid
+	expiresAt := fclk.Now().Add(365 * 24 * time.Hour)
+	authzFromVA.Expires = &expiresAt
+	dbAuthz, err := sa.GetAuthorization(authzFromVA.ID)
+	test.AssertNotError(t, err, "Could not fetch authorization from database")
+	t.Log("authz from VA: ", authzFromVA)
+	t.Log("authz from DB: ", dbAuthz)
+
+	assertAuthzEqual(t, authzFromVA, dbAuthz)
+}
+
+func TestOnValidationUpdateFailure(t *testing.T) {
+	_, sa, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+	authzFromVA, _ := sa.NewPendingAuthorization(AuthzUpdated)
+	sa.UpdatePendingAuthorization(AuthzUpdated)
+	authzFromVA.Challenges[0].Status = core.StatusInvalid
+
+	err := ra.OnValidationUpdate(authzFromVA)
+	test.AssertNotError(t, err, "unable to update validation")
+
+	authzFromVA.Status = core.StatusInvalid
 	dbAuthz, err := sa.GetAuthorization(authzFromVA.ID)
 	test.AssertNotError(t, err, "Could not fetch authorization from database")
 	assertAuthzEqual(t, authzFromVA, dbAuthz)
-	t.Log(" ~~> from VA: ", authzFromVA.Status)
-	t.Log(" ~~> from DB: ", dbAuthz.Status)
-
-	t.Log("DONE TestOnValidationUpdate")
 }
 
 func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
-	_, sa, ra, cleanUp := initAuthorities(t)
+	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	authz := core.Authorization{}
 	authz, _ = sa.NewPendingAuthorization(authz)
@@ -497,7 +526,7 @@ func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 }
 
 func TestAuthorizationRequired(t *testing.T) {
-	_, sa, ra, cleanUp := initAuthorities(t)
+	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	AuthzFinal.RegistrationID = 1
 	AuthzFinal, _ = sa.NewPendingAuthorization(AuthzFinal)
@@ -517,7 +546,7 @@ func TestAuthorizationRequired(t *testing.T) {
 }
 
 func TestNewCertificate(t *testing.T) {
-	_, sa, ra, cleanUp := initAuthorities(t)
+	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	AuthzFinal.RegistrationID = Registration.ID
 	AuthzFinal, _ = sa.NewPendingAuthorization(AuthzFinal)

--- a/sa/_db/migrations/20150904120119_AuthzExpiresMayBeNull.sql
+++ b/sa/_db/migrations/20150904120119_AuthzExpiresMayBeNull.sql
@@ -1,0 +1,9 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE `authz` MODIFY `expires` datetime DEFAULT NULL;
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+ALTER TABLE `authz` MODIFY `expires` datetime NOT NULL;

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
@@ -545,7 +546,7 @@ func TestIssueCertificate(t *testing.T) {
 	mockLog := wfe.log.SyslogWriter.(*mocks.MockSyslogWriter)
 
 	// TODO: Use a mock RA so we can test various conditions of authorized, not authorized, etc.
-	ra := ra.NewRegistrationAuthorityImpl()
+	ra := ra.NewRegistrationAuthorityImpl(clock.NewFake(), wfe.log)
 	ra.SA = &MockSA{}
 	ra.CA = &MockCA{}
 	ra.PA = &MockPA{}


### PR DESCRIPTION
The RA did not have any code to test what occurred when a challenge failed. This let in the authz schema change in #705.

This change sets the expires column in authz back to NULLable and fixes the RA tests (including, using clock.Clocks in the RA).

Fixes #744.

This change adds a migration with a timestamp later than #745, so please review #745 first.