### PR TITLE
Remove SERVER env var in integration test.

### DIFF
--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -103,7 +103,6 @@ def run_client_tests():
     assert root is not None, (
         "Please set LETSENCRYPT_PATH env variable to point at "
         "initialized (virtualenv) client repo root")
-    os.environ['SERVER'] = 'http://localhost:4000/acme/new-reg'
     test_script_path = os.path.join(root, 'tests', 'boulder-integration.sh')
     if subprocess.Popen(test_script_path, shell=True, cwd=root).wait() != 0:
         die(ExitStatus.PythonFailure)


### PR DESCRIPTION
Per @Kuba, this is no longer needed for the letsencrypt client, and will be a blocker for his next client PR.