### PR TITLE
Use sync.RWMutex for RPC pending map operations

### DIFF
--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -476,7 +476,7 @@ type AmqpRPCCLient struct {
 	timeout     time.Duration
 	log         *blog.AuditLogger
 
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	pending map[string]chan []byte
 }
 
@@ -513,9 +513,9 @@ func NewAmqpRPCClient(clientQueuePrefix, serverQueue string, channel *amqp.Chann
 		for msg := range msgs {
 			// XXX-JWS: jws.Sign(privKey, body)
 			corrID := msg.CorrelationId
-			rpc.mu.Lock()
+			rpc.mu.RLock()
 			responseChan, present := rpc.pending[corrID]
-			rpc.mu.Unlock()
+			rpc.mu.RUnlock()
 
 			rpc.log.Debug(fmt.Sprintf(" [c<][%s] response %s(%s) [%s]", clientQueue, msg.Type, core.B64enc(msg.Body), corrID))
 			if !present {


### PR DESCRIPTION
Instead of a `sync.Mutex`, fixes #742 .