### PR TITLE
Fix misleading message about issuing and expiry

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -228,7 +228,7 @@ func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string, reasonCode 
 
 // IssueCertificate attempts to convert a CSR into a signed Certificate, while
 // enforcing all policies.
-func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest, regID int64, earliestExpiry time.Time) (core.Certificate, error) {
+func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest, regID int64) (core.Certificate, error) {
 	emptyCert := core.Certificate{}
 	var err error
 	key, ok := csr.PublicKey.(crypto.PublicKey)
@@ -301,13 +301,6 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 		err = errors.New("Cannot issue a certificate that expires after the intermediate certificate.")
 		ca.log.AuditErr(err)
 		return emptyCert, err
-	}
-
-	// Note: We do not current enforce that certificate lifetimes match
-	// authorization lifetimes, because it was breaking integration tests.
-	if earliestExpiry.Before(notAfter) {
-		message := fmt.Sprintf("Issuing a certificate that expires after the shortest underlying authorization. [%v] [%v]", earliestExpiry, notAfter)
-		ca.log.Notice(message)
 	}
 
 	// Convert the CSR to PEM

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -90,7 +90,7 @@ type ValidationAuthority interface {
 // CertificateAuthority defines the public interface for the Boulder CA
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
-	IssueCertificate(x509.CertificateRequest, int64, time.Time) (Certificate, error)
+	IssueCertificate(x509.CertificateRequest, int64) (Certificate, error)
 	RevokeCertificate(string, RevocationCode) error
 	GenerateOCSP(OCSPSigningRequest) ([]byte, error)
 }

--- a/core/objects.go
+++ b/core/objects.go
@@ -371,7 +371,10 @@ type Authorization struct {
 	Status AcmeStatus `json:"status,omitempty" db:"status"`
 
 	// The date after which this authorization will be no
-	// longer be considered valid
+	// longer be considered valid. Note: a certificate may be issued even on the
+	// last day of an authorization's lifetime. The last day for which someone can
+	// hold a valid certificate based on an authorization is authorization
+	// lifetime + certificate lifetime.
 	Expires *time.Time `json:"expires,omitempty" db:"expires"`
 
 	// An array of challenges objects used to validate the

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -20,6 +20,12 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
+// 10 month default authorization lifetime. When used with a 90-day cert
+// lifetime, this allows creation of certs that will cover a whole year,
+// plus a grace period of a month.
+// TODO(jsha): Read from a config file.
+const DefaultAuthorizationLifetime = 300 * 24 * time.Hour
+
 // RegistrationAuthorityImpl defines an RA.
 //
 // NOTE: All of the fields in RegistrationAuthorityImpl need to be
@@ -41,11 +47,7 @@ func NewRegistrationAuthorityImpl(clk clock.Clock, logger *blog.AuditLogger) Reg
 	ra := RegistrationAuthorityImpl{
 		clk: clk,
 		log: logger,
-		// 10 month default authorization lifetime. When used with a 90-day cert
-		// lifetime, this allows creation of certs that will cover a whole year,
-		// plus a grace period of a month.
-		// TODO(jsha): Read from a config file.
-		authorizationLifetime: 300 * 24 * time.Hour,
+		authorizationLifetime: DefaultAuthorizationLifetime,
 	}
 	return ra
 }

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	"github.com/letsencrypt/boulder/core"
@@ -98,9 +97,8 @@ type certificateRequest struct {
 }
 
 type issueCertificateRequest struct {
-	Bytes          []byte
-	RegID          int64
-	EarliestExpiry time.Time
+	Bytes []byte
+	RegID int64
 }
 
 type addCertificateRequest struct {
@@ -596,7 +594,7 @@ func NewCertificateAuthorityServer(rpc RPCServer, impl core.CertificateAuthority
 			return
 		}
 
-		cert, err := impl.IssueCertificate(*csr, icReq.RegID, icReq.EarliestExpiry)
+		cert, err := impl.IssueCertificate(*csr, icReq.RegID)
 		if err != nil {
 			return
 		}
@@ -656,7 +654,7 @@ func NewCertificateAuthorityClient(client RPCClient) (cac CertificateAuthorityCl
 }
 
 // IssueCertificate sends a request to issue a certificate
-func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateRequest, regID int64, earliestExpiry time.Time) (cert core.Certificate, err error) {
+func (cac CertificateAuthorityClient) IssueCertificate(csr x509.CertificateRequest, regID int64) (cert core.Certificate, err error) {
 	var icReq issueCertificateRequest
 	icReq.Bytes = csr.Raw
 	icReq.RegID = regID

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -300,7 +300,7 @@ func (ra *MockRegistrationAuthority) OnValidationUpdate(authz core.Authorization
 
 type MockCA struct{}
 
-func (ca *MockCA) IssueCertificate(csr x509.CertificateRequest, regID int64, earliestExpiry time.Time) (core.Certificate, error) {
+func (ca *MockCA) IssueCertificate(csr x509.CertificateRequest, regID int64) (core.Certificate, error) {
 	// Return a basic certificate so NewCertificate can continue
 	certPtr, err := core.LoadCert("test/not-an-example.com.crt")
 	if err != nil {
@@ -672,7 +672,7 @@ func TestIssueCertificate(t *testing.T) {
 		}`, &wfe.nonceService)))
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:unauthorized","detail":"Error creating new cert :: Key not authorized for name meep.com"}`)
+		`{"type":"urn:acme:error:unauthorized","detail":"Error creating new cert :: Authorizations for these names not found or expired: meep.com"}`)
 	assertCsrLogged(t, mockLog)
 
 	mockLog.Clear()


### PR DESCRIPTION
The RA was passing an `earliestExpiry` parameter to ca.IssueCertificate that was not getting serialized into the RPC object, and wound up with the zero value of time. The purpose of this parameter was so that the CA could refuse to issue if the cert lifetime would exceed the authorization lifetime. There are two problems: (1) the RA should be doing this logic, not the CA, but the RA doesn't necessarily know what the cert lifetime is (though we could plumb that through. (2) This makes the authorization lifetime misleading. If you have 30 days left on your authorization, but the CA only issues 90 day certs, your authorization is useless and might as well be expired.

This change removes the `earliestExpiry` parameter in favor of checking in the RA, makes it so authorizations are valid for issuance until they expire, and changes the default authorization lifetime so that authorization lifetime + certificate lifetime is a year (plus a grace period).

Note: authorization lifetime should be a config option, but wasn't previously, so I'm punting on that change for now to keep this PR from bloating up too big.

Fixes #780.

