### PR TITLE
Select PKCS11 key by token label + slot id, not by slot description

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -157,8 +157,16 @@ func loadKey(keyConfig cmd.KeyConfig) (priv crypto.Signer, err error) {
 	}
 
 	pkcs11Config := keyConfig.PKCS11
+	if pkcs11Config.Module == "" ||
+		pkcs11Config.TokenLabel == "" ||
+		pkcs11Config.PIN == "" ||
+		pkcs11Config.PrivateKeyLabel == "" ||
+		pkcs11Config.SlotID == nil {
+		err = fmt.Errorf("Missing a field in pkcs11Config %#v", pkcs11Config)
+		return
+	}
 	priv, err = pkcs11key.New(pkcs11Config.Module,
-		pkcs11Config.Token, pkcs11Config.PIN, pkcs11Config.Label)
+		pkcs11Config.TokenLabel, pkcs11Config.PIN, pkcs11Config.PrivateKeyLabel, *pkcs11Config.SlotID)
 	return
 }
 

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -226,10 +226,11 @@ type KeyConfig struct {
 
 // PKCS11Config defines how to load a module for an HSM.
 type PKCS11Config struct {
-	Module string
-	Token  string
-	PIN    string
-	Label  string
+	Module          string
+	TokenLabel      string
+	SlotID          *int
+	PIN             string
+	PrivateKeyLabel string
 }
 
 // TLSConfig reprents certificates and a key for authenticated TLS.

--- a/cmd/single-ocsp/main.go
+++ b/cmd/single-ocsp/main.go
@@ -22,10 +22,11 @@ import (
 // PKCS11Config defines how to load a module for an HSM.
 // XXX(rlb@ipv.sx) Copied from certificate-authority.go
 type PKCS11Config struct {
-	Module string
-	Token  string
-	PIN    string
-	Label  string
+	Module          string
+	TokenLabel      string
+	PrivateKeyLabel string
+	PIN             string
+	SlotID          float64
 }
 
 func readFiles(c *cli.Context) (issuer, responder, target *x509.Certificate, template ocsp.Response, pkcs11 PKCS11Config, err error) {
@@ -158,7 +159,7 @@ func main() {
 		cmd.FailOnError(err, "Failed to read files")
 
 		// Instantiate the private key from PKCS11
-		priv, err := pkcs11key.New(pkcs11.Module, pkcs11.Token, pkcs11.PIN, pkcs11.Label)
+		priv, err := pkcs11key.New(pkcs11.Module, pkcs11.TokenLabel, pkcs11.PIN, pkcs11.PrivateKeyLabel, int(pkcs11.SlotID))
 		cmd.FailOnError(err, "Failed to load PKCS#11 key")
 
 		// Populate the remaining fields in the template

--- a/cmd/single-ocsp/test/gentest.go
+++ b/cmd/single-ocsp/test/gentest.go
@@ -52,16 +52,18 @@ func toPEM(cert *x509.Certificate) []byte {
 func main() {
 	// Instantiate the PKCS11 key
 	var pkcs11 struct {
-		Module string
-		Token  string
-		PIN    string
-		Label  string
+		Module          string
+		TokenLabel      string
+		PIN             string
+		PrivateKeyLabel string
+		SlotID          float64
 	}
 	pkcs11Bytes, err := ioutil.ReadFile(pkcs11FileName)
 	panicOnError(err)
 	err = json.Unmarshal(pkcs11Bytes, &pkcs11)
 	panicOnError(err)
-	p11key, err := pkcs11key.New(pkcs11.Module, pkcs11.Token, pkcs11.PIN, pkcs11.Label)
+	slotID := int(pkcs11.SlotID)
+	p11key, err := pkcs11key.New(pkcs11.Module, pkcs11.TokenLabel, pkcs11.PIN, pkcs11.PrivateKeyLabel, slotID)
 	panicOnError(err)
 
 	// All of the certificates start and end at the same time

--- a/cmd/single-ocsp/test/pkcs11.json
+++ b/cmd/single-ocsp/test/pkcs11.json
@@ -1,6 +1,7 @@
 {
-  "Module": "/Library/OpenSC/lib/opensc-pkcs11.so",
-  "Token": "Yubico Yubikey NEO CCID",
-  "Label": "PIV AUTH key",
-  "PIN": "123456"
+  "Module": "/usr/local/Cellar/opensc/0.14.0_1/lib/opensc-pkcs11.so",
+  "TokenLabel": "PIV_II (PIV Card Holder pin)",
+  "SlotID": 1,
+  "PrivateKeyLabel": "SIGN key",
+  "PIN": "163246"
 }


### PR DESCRIPTION
Fixes #783. Introduces two new config fields, removes one, and renames one.

Note: GitHub suppresses the diff of pkcs11key.go, but there are significant changes there, please review them. Normally we'd merge those in our own fork of the CFSSL repo, then do godep update, but this is an urgent high-priority fix, so I took the shortcut of editing our vendorized copy directly. We should clean it up afterwards.

I'm going to be offline for a couple of hours, so if this branch needs changes, please feel free to push directly to it.

Example new config (for Yubikey NEO):

```
"PKCS11": {
  "Module": "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so",
  "TokenLabel": "PIV_II (PIV Card Holder pin)",
  "PrivateKeyLabel": "SIGN key",
  "SlotID": 1,
  "PIN": "123456"
}
```