### PR TITLE
Add a test that there are no outdated migrations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ branches:
     - master
 
 before_install:
+  # Travis does shallow clones, so there is no master branch present.
+  # But test-no-outdated-migrations.sh needs to check diffs against master.
+  # Fetch just the master branch from origin.
+  - git fetch origin master
   # Github-PR-Status secret
   - openssl aes-256-cbc -K $encrypted_53b2630f0fb4_key -iv $encrypted_53b2630f0fb4_iv -in test/github-secret.json.enc -out test/github-secret.json -d || true
 

--- a/test.sh
+++ b/test.sh
@@ -178,6 +178,10 @@ check_gofmt() {
 run_and_comment check_gofmt
 end_context #test/gofmt
 
+start_context "test/migrations"
+run_and_comment ./test/test-no-outdated-migrations.sh
+end_context "test/migrations"
+
 if [ "${TRAVIS}" == "true" ]; then
   ./test/create_db.sh || die "unable to create the boulder database with test/create_db.sh"
 fi

--- a/test/db-common.sh
+++ b/test/db-common.sh
@@ -1,7 +1,4 @@
 # Common variables used by Goose-related scripts.
-set -o errexit
-set -o xtrace
-
 function die() {
   if [ ! -z "$1" ]; then
     echo $1 > /dev/stderr

--- a/test/migrate-up.sh
+++ b/test/migrate-up.sh
@@ -3,6 +3,8 @@
 # Run this script after pulling changes that have migrations, to migrate your
 # local DB.
 #
+set -o errexit
+set -o xtrace
 cd $(dirname $0)/..
 
 source test/db-common.sh

--- a/test/test-no-outdated-migrations.sh
+++ b/test/test-no-outdated-migrations.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+cd $(dirname $0)/..
+if [ ! -d .git ]; then
+  echo "Not in a git repository, skipping out-of-order migration test."
+fi
+
+source test/db-common.sh
+
+NEW_FILES_LIST=$(mktemp)
+trap 'rm ${NEW_FILES_LIST}' EXIT
+
+for svc in $SERVICES; do
+  for dbenv in $DBENVS; do
+    DB_DIR=$svc/_db/
+    git diff --name-only master -- ${DB_DIR} > ${NEW_FILES_LIST}
+    # Search for files in the migrations directory match the new files or come
+    # lexically after them, then filter out the new files.
+    GREP_OUT="$(ls ${DB_DIR}migrations/* | sort | \
+      grep -A 1 -xf ${NEW_FILES_LIST} | \
+      grep -vxf ${NEW_FILES_LIST})"
+    if [ -n "${GREP_OUT}" ] ; then
+      echo "--- New migrations on this branch: ---"
+      cat $NEW_FILES_LIST
+      echo "--- Existing migrations on master: ---"
+      echo "${GREP_OUT}"
+      echo
+      echo "All migrations on a branch must be timestamped newer than"
+      echo "migrations on master before they can be merged. Please"
+      echo "rename migrations as appropriate."
+      exit 1
+    fi
+  done
+done


### PR DESCRIPTION
If a branch merges with a migration that is timestamped earlier than other
migrations already in master, that migration may get skipped.

Fixes #806.