### PR TITLE
ensure cert serial numbers are unique in the SA db

### DIFF
--- a/sa/_db/migrations/20150918141504_UniqueIndexOnSerial.sql
+++ b/sa/_db/migrations/20150918141504_UniqueIndexOnSerial.sql
@@ -1,0 +1,8 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+CREATE UNIQUE INDEX `serial_idx` on `certificates` (`serial`);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP INDEX `serial_idx` on `certificates`;


### PR DESCRIPTION
This is the first step in removing the CA sequence requirement.