### PR TITLE
Add dummy CT log server for integration testing.

### DIFF
--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -37,10 +37,10 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+	// id is a sha256 of a random EC key. Generate your own with:
+	// openssl ecparam -name prime256v1 -genkey -outform der | openssl sha256 -binary | base64
 	w.Write([]byte(`{
 		"sct_version": 0,
-		// Sha256 of a random EC key. Generate your own with:
-		// openssl ecparam -name prime256v1 -genkey -outform der | openssl sha256 -binary | base64
 		"id": "8fjM8cvLPOhzCFwI62IYJhjkOcvWFLx1dMJbs0uhxJU=",
 		"timestamp": 1442400000,
 		"extensions": "",

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -20,7 +20,6 @@ type ctSubmissionRequest struct {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	log.Printf("request: %s %s", r.Method, r.URL.Path)
 	if r.Method != "POST" || r.URL.Path != "/ct/v1/add-chain" {
 		http.NotFound(w, r)
 		return

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -1,0 +1,55 @@
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This is a test server that implements the subset of RFC6962 APIs needed to
+// run Boulder's CT log submission code. Currently it only implements add-chain.
+// This is used by startservers.py.
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+type ctSubmissionRequest struct {
+	Chain []string `json:"chain"`
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("request: %s %s", r.Method, r.URL.Path)
+	if r.Method != "POST" || r.URL.Path != "/ct/v1/add-chain" {
+		http.NotFound(w, r)
+		return
+	}
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
+	var addChainReq ctSubmissionRequest
+	err = json.Unmarshal(bodyBytes, &addChainReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{
+		"sct_version": 0,
+		"id": "",
+		"timestamp": 1442400000,
+		"extensions": "",
+		"signature": "BAMARzBFAiBB5wKED8KqKhADT37n0y28fZIPiGbCfZRVKq0wNo0hrwIhAOIa2tPBF/rB1y30Y/ROh4LBmJ0mItAbTWy8XZKh7Wcp"
+	}`))
+}
+
+func main() {
+	s := &http.Server{
+		Addr:    ":4500",
+		Handler: http.HandlerFunc(handler),
+	}
+	log.Fatal(s.ListenAndServe())
+}

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -39,7 +39,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{
 		"sct_version": 0,
-		"id": "",
+		// Sha256 of a random EC key. Generate your own with:
+		// openssl ecparam -name prime256v1 -genkey -outform der | openssl sha256 -binary | base64
+		"id": "8fjM8cvLPOhzCFwI62IYJhjkOcvWFLx1dMJbs0uhxJU=",
 		"timestamp": 1442400000,
 		"extensions": "",
 		"signature": "BAMARzBFAiBB5wKED8KqKhADT37n0y28fZIPiGbCfZRVKq0wNo0hrwIhAOIa2tPBF/rB1y30Y/ROh4LBmJ0mItAbTWy8XZKh7Wcp"

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -79,6 +79,7 @@ def start(race_detection):
         'cmd/boulder-va',
         'cmd/boulder-publisher',
         'cmd/ocsp-responder',
+        'test/ct-test-srv',
         'test/dns-test-srv'
     ]
     if not install(progs, race_detection):


### PR DESCRIPTION
Right now the integration test environment logs errors for each generated certificate because it is unable to submit to CT. Having a fake CT server allows us to exercise the CT submission code in integration tests.

Part of #95.