### PR TITLE
update previously made serial numbers to new style

### DIFF
--- a/sa/_db/migrations/20150922165824_UpdateSerialNumbersOfOldCerts.sql
+++ b/sa/_db/migrations/20150922165824_UpdateSerialNumbersOfOldCerts.sql
@@ -1,0 +1,15 @@
+-- This bit of weirdness is because we had to change how long our serial ids
+-- were. Fortunately, zero padding them works fine. For some details, see
+-- https://github.com/letsencrypt/boulder/issues/834
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+UPDATE certificates SET serial = CONCAT('0000', serial);
+UPDATE certificateStatus SET serial = CONCAT('0000', serial);
+UPDATE ocspResponses SET serial = CONCAT('0000', serial);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+UPDATE certificates SET serial = SUBSTR(serial, 5);
+UPDATE certificateStatus SET serial = SUBSTR(serial, 5);
+UPDATE ocspResponses SET serial = SUBSTR(serial, 5);


### PR DESCRIPTION
Previously, 32 bytes were used for serial numbers but now we make certificates with 36 bytes (see #823 and #813). Going forward, we want them to be consistent, so we update our current ones by prepending 4 zeros to the them.

For the two existing certs, their leading datacenter id will be 0 in production, but we take this hit because we can't adjust the serial inside the certificates themselves, and can only pad them with zeroes in the database.

Fixes #834