### PR TITLE
Use consistent naming for AMQP queues in the revoker

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -51,7 +51,7 @@ func setupContext(context *cli.Context) (rpc.RegistrationAuthorityClient, *blog.
 	ch, err := rpc.AmqpChannel(c)
 	cmd.FailOnError(err, "Could not connect to AMQP")
 
-	raRPC, err := rpc.NewAmqpRPCClient("revoker->RA", c.AMQP.RA.Server, ch, stats)
+	raRPC, err := rpc.NewAmqpRPCClient("AdminRevoker->RA", c.AMQP.RA.Server, ch, stats)
 	cmd.FailOnError(err, "Unable to create RPC client")
 
 	rac, err := rpc.NewRegistrationAuthorityClient(raRPC)


### PR DESCRIPTION
I like consistent naming of queues; right now there is a AMQP Client for "revoker" and one for "AdminRevoker" each in the revoker code.

This change makes things cleaner in the AMQP ACLs. This standardizes the revoker to "AdminRevoker" similar to how the mailer is "ExpirationMailer".
