### PR TITLE
Fix godep import in cmd/boulder-va/main.go

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -8,7 +8,7 @@ package main
 import (
 	"time"
 
-	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 
 	"github.com/letsencrypt/boulder/cmd"


### PR DESCRIPTION
Missed a non-vendorized import in `cmd/boulder-va/main.go`