### PR TITLE
Fix `go vet` problems

### DIFF
--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -258,7 +258,7 @@ func assertAuthzEqual(t *testing.T, a1, a2 core.Authorization) {
 	if a1.Expires == nil && a2.Expires == nil {
 		return
 	} else if a1.Expires == nil || a2.Expires == nil {
-		t.Errorf("one and only one of authorization's Expires was nil; ret %s, DB %s", a1, a2)
+		t.Errorf("one and only one of authorization's Expires was nil; ret %v, DB %v", a1, a2)
 	} else {
 		test.Assert(t, a1.Expires.Equal(*a2.Expires), "ret != DB: Expires")
 	}

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -491,7 +491,7 @@ func TestMarkCertificateRevoked(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to fetch certificate status")
 
 	if code != afterStatus.RevokedReason {
-		t.Errorf("RevokedReasons, expected %s, got %s", code, afterStatus.RevokedReason)
+		t.Errorf("RevokedReasons, expected %v, got %v", code, afterStatus.RevokedReason)
 	}
 	if !fc.Now().Equal(afterStatus.RevokedDate) {
 		t.Errorf("RevokedData, expected %s, got %s", fc.Now(), afterStatus.RevokedDate)


### PR DESCRIPTION
This PR just fixes two trivial issues with `go vet` that have been causing unit test failures on my machine for a while.