### PR TITLE
Fix amqp-integration-test.py when run alone.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -220,7 +220,7 @@ start_context "test/integration"
 update_status --state pending --description "Integration Tests in progress"
 
 if [ -z "$LETSENCRYPT_PATH" ]; then
-  LETSENCRYPT_PATH=$(mktemp -d -t leXXXX)
+  export LETSENCRYPT_PATH=$(mktemp -d -t leXXXX)
   echo "------------------------------------------------"
   echo "--- Checking out letsencrypt client is slow. ---"
   echo "--- Recommend setting \$LETSENCRYPT_PATH to  ---"
@@ -230,9 +230,6 @@ if [ -z "$LETSENCRYPT_PATH" ]; then
 elif [ ! -d "${LETSENCRYPT_PATH}" ]; then
   build_letsencrypt
 fi
-
-source $LETSENCRYPT_PATH/venv/bin/activate || die "The LETSENCRYPT_PATH (${LETSENCRYPT_PATH}) does not have a venv/bin/activate and probably did not build correctly."
-export LETSENCRYPT_PATH
 
 python test/amqp-integration-test.py
 case $? in

--- a/test/amqp-integration-test.py
+++ b/test/amqp-integration-test.py
@@ -104,7 +104,8 @@ def run_client_tests():
         "Please set LETSENCRYPT_PATH env variable to point at "
         "initialized (virtualenv) client repo root")
     test_script_path = os.path.join(root, 'tests', 'boulder-integration.sh')
-    if subprocess.Popen(test_script_path, shell=True, cwd=root).wait() != 0:
+    cmd = "source %s/venv/bin/activate && %s" % (root, test_script_path)
+    if subprocess.Popen(cmd, shell=True, cwd=root, executable='/bin/bash').wait() != 0:
         die(ExitStatus.PythonFailure)
 
 


### PR DESCRIPTION
Previously, test.sh was responsible for running venv/bin/activate, meaning that
`python test/amqp-integration-test.py` would fail to run the letsencrypt client.
Now, so long as LETSENCRYPT_PATH is already set to a valid dir (e.g. in your
.bashrc), `python test/amqp-integration-test.py` should work.