### PR TITLE
Make UpdateSerialNumbers migration safer.

### DIFF
--- a/sa/_db/migrations/20150922165824_UpdateSerialNumbersOfOldCerts.sql
+++ b/sa/_db/migrations/20150922165824_UpdateSerialNumbersOfOldCerts.sql
@@ -4,12 +4,12 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-UPDATE certificates SET serial = CONCAT('0000', serial);
-UPDATE certificateStatus SET serial = CONCAT('0000', serial);
-UPDATE ocspResponses SET serial = CONCAT('0000', serial);
+UPDATE certificates SET serial = CONCAT('0000', serial) WHERE length(serial) = 32;
+UPDATE certificateStatus SET serial = CONCAT('0000', serial) WHERE length(serial) = 32;
+UPDATE ocspResponses SET serial = CONCAT('0000', serial) WHERE length(serial) = 32;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-UPDATE certificates SET serial = SUBSTR(serial, 5);
-UPDATE certificateStatus SET serial = SUBSTR(serial, 5);
-UPDATE ocspResponses SET serial = SUBSTR(serial, 5);
+UPDATE certificates SET serial = SUBSTR(serial, 5) WHERE length(serial) = 36 AND serial LIKE '0000%';
+UPDATE certificateStatus SET serial = SUBSTR(serial, 5) WHERE length(serial) = 36 AND serial LIKE '0000%';
+UPDATE ocspResponses SET serial = SUBSTR(serial, 5) WHERE length(serial) = 36 AND serial LIKE '0000%';


### PR DESCRIPTION
Previously, if we did an up migration, generated some certs, then did a
down migration, we would truncate some of the new-style serial numbers in a way
that would be hard to reverse.