### PR TITLE
Audit log version info as early as possible.

### DIFF
--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -118,8 +118,8 @@ func main() {
 		cmd.FailOnError(err, "Could not connect to statsd")
 
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		blog.SetAuditLogger(auditlogger)
 
@@ -130,8 +130,6 @@ func main() {
 		cmd.FailOnError(err, "Could not connect to AMQP")
 
 		go cmd.ProfileCmd("AM", stats)
-
-		auditlogger.Info(app.VersionString())
 
 		startMonitor(ch, auditlogger, stats)
 	}

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -25,6 +25,7 @@ func main() {
 		// Set up logging
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -64,8 +65,6 @@ func main() {
 		cas, err := rpc.NewAmqpRPCServer(c.AMQP.CA.Server, connectionHandler)
 		cmd.FailOnError(err, "Unable to create CA RPC server")
 		rpc.NewCertificateAuthorityServer(cas, cai)
-
-		auditlogger.Info(app.VersionString())
 
 		err = cas.Start(c)
 		cmd.FailOnError(err, "Unable to run CA RPC server")

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -23,6 +23,7 @@ func main() {
 		// Set up logging
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -48,8 +49,6 @@ func main() {
 		pubs, err := rpc.NewAmqpRPCServer(c.AMQP.Publisher.Server, connectionHandler)
 		cmd.FailOnError(err, "Unable to create Publisher RPC server")
 		rpc.NewPublisherServer(pubs, &pubi)
-
-		auditlogger.Info(app.VersionString())
 
 		err = pubs.Start(c)
 		cmd.FailOnError(err, "Unable to run Publisher RPC server")

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -29,6 +29,7 @@ func main() {
 		// Set up logging
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -81,8 +82,6 @@ func main() {
 		ras, err := rpc.NewAmqpRPCServer(c.AMQP.RA.Server, connectionHandler)
 		cmd.FailOnError(err, "Unable to create RA RPC server")
 		rpc.NewRegistrationAuthorityServer(ras, &rai)
-
-		auditlogger.Info(app.VersionString())
 
 		err = ras.Start(c)
 		cmd.FailOnError(err, "Unable to run RA RPC server")

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -23,6 +23,7 @@ func main() {
 		// Set up logging
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -45,8 +46,6 @@ func main() {
 		sas, err := rpc.NewAmqpRPCServer(c.AMQP.SA.Server, connectionHandler)
 		cmd.FailOnError(err, "Unable to create SA RPC server")
 		rpc.NewStorageAuthorityServer(sas, sai)
-
-		auditlogger.Info(app.VersionString())
 
 		err = sas.Start(c)
 		cmd.FailOnError(err, "Unable to run SA RPC server")

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -27,6 +27,7 @@ func main() {
 		// Set up logging
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -74,8 +75,6 @@ func main() {
 		vas, err := rpc.NewAmqpRPCServer(c.AMQP.VA.Server, connectionHandler)
 		cmd.FailOnError(err, "Unable to create VA RPC server")
 		rpc.NewValidationAuthorityServer(vas, vai)
-
-		auditlogger.Info(app.VersionString())
 
 		err = vas.Start(c)
 		cmd.FailOnError(err, "Unable to run VA RPC server")

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -66,6 +66,7 @@ func main() {
 
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -119,8 +120,6 @@ func main() {
 		wfe.BaseURL = c.Common.BaseURL
 		h, err := wfe.Handler()
 		cmd.FailOnError(err, "Problem setting up HTTP handlers")
-
-		auditlogger.Info(app.VersionString())
 
 		httpMonitor := metrics.NewHTTPMonitor(stats, h, "WFE")
 

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -239,9 +239,9 @@ func main() {
 
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		blog.SetAuditLogger(auditlogger)
-		auditlogger.Info(app.VersionString())
 
 		saDbMap, err := sa.NewDbMap(c.CertChecker.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -230,13 +230,12 @@ func main() {
 
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
 
 		blog.SetAuditLogger(auditlogger)
-
-		auditlogger.Info(app.VersionString())
 
 		go cmd.DebugServer(c.Mailer.DebugAddr)
 

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -131,6 +131,7 @@ func main() {
 
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -140,8 +141,6 @@ func main() {
 		go cmd.DebugServer(c.OCSPResponder.DebugAddr)
 
 		go cmd.ProfileCmd("OCSP", stats)
-
-		auditlogger.Info(app.VersionString())
 
 		config := c.OCSPResponder
 		var source cfocsp.Source

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -205,6 +205,7 @@ func main() {
 
 		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
 		cmd.FailOnError(err, "Could not connect to Syslog")
+		auditlogger.Info(app.VersionString())
 
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		defer auditlogger.AuditPanic()
@@ -228,8 +229,6 @@ func main() {
 				}
 			}
 		}()
-
-		auditlogger.Info(app.VersionString())
 
 		updater := &OCSPUpdater{
 			cac:   cac,


### PR DESCRIPTION
This means after parsing the config file, setting up stats, and dialing the
syslogger. But it is still before trying to initialize the given server. This
means that we are more likely to get version numbers logged for some common
runtime failures.

Fixes #851