### PR TITLE
allow whitelisting by a specific reg id

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -274,7 +274,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 
 	// Verify that names are allowed by policy
 	identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: commonName}
-	if err = ca.PA.WillingToIssue(identifier); err != nil {
+	if err = ca.PA.WillingToIssue(identifier, regID); err != nil {
 		err = core.MalformedRequestError(fmt.Sprintf("Policy forbids issuing for name %s", commonName))
 		// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
 		ca.log.AuditErr(err)
@@ -282,7 +282,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 	}
 	for _, name := range hostNames {
 		identifier = core.AcmeIdentifier{Type: core.IdentifierDNS, Value: name}
-		if err = ca.PA.WillingToIssue(identifier); err != nil {
+		if err = ca.PA.WillingToIssue(identifier, regID); err != nil {
 			err = core.MalformedRequestError(fmt.Sprintf("Policy forbids issuing for name %s", name))
 			// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
 			ca.log.AuditErr(err)

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -193,7 +193,8 @@ func (c *certChecker) checkCert(cert core.Certificate) (problems []string) {
 
 		// Check that the PA is still willing to issue for each name in DNSNames + CommonName
 		for _, name := range append(parsedCert.DNSNames, parsedCert.Subject.CommonName) {
-			if err = c.pa.WillingToIssue(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: name}); err != nil {
+			id := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: name}
+			if err = c.pa.WillingToIssue(id, cert.RegistrationID); err != nil {
 				problems = append(problems, fmt.Sprintf("Policy Authority isn't willing to issue for %s: %s", name, err))
 			}
 		}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -97,7 +97,7 @@ type CertificateAuthority interface {
 
 // PolicyAuthority defines the public interface for the Boulder PA
 type PolicyAuthority interface {
-	WillingToIssue(AcmeIdentifier) error
+	WillingToIssue(id AcmeIdentifier, regID int64) error
 	ChallengesFor(AcmeIdentifier) ([]Challenge, [][]int)
 }
 

--- a/policy/policy-authority-data.go
+++ b/policy/policy-authority-data.go
@@ -156,14 +156,14 @@ func (padb *PolicyAuthorityDatabaseImpl) CheckHostLists(host string, requireWhit
 	if requireWhitelisted {
 		if !padb.allowedByWhitelist(host) {
 			// return fmt.Errorf("Domain is not whitelisted for issuance")
-			return NotWhitelistedError{}
+			return ErrNotWhitelisted
 		}
 	}
 	// Overrides the whitelist if a blacklist rule is found
 	host = core.ReverseName(host)
 	if !padb.allowedByBlacklist(host) {
 		// return fmt.Errorf("Domain is blacklisted for issuance")
-		return BlacklistedError{}
+		return ErrBlacklisted
 	}
 	return nil
 }

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -196,7 +196,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 	identifier := request.Identifier
 
 	// Check that the identifier is present and appropriate
-	if err = ra.PA.WillingToIssue(identifier); err != nil {
+	if err = ra.PA.WillingToIssue(identifier, regID); err != nil {
 		err = core.UnauthorizedError(err.Error())
 		return authz, err
 	}

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -176,7 +176,7 @@ func (pa *MockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []co
 	return
 }
 
-func (pa *MockPA) WillingToIssue(id core.AcmeIdentifier) error {
+func (pa *MockPA) WillingToIssue(id core.AcmeIdentifier, regID int64) error {
 	return nil
 }
 


### PR DESCRIPTION
Currently, the special registration ID is one that is impossible for the database to return. Once the partner's registration is in place, we can deploy a change to it.

Fixes #810