### PR TITLE
Allow override of all build flags in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ CMD_BASENAMES = $(shell echo $(CMDS) | xargs -n1 basename)
 CMD_BINS = $(addprefix $(OBJDIR)/, $(CMD_BASENAMES) )
 OBJECTS = $(CMD_BINS) $(OBJDIR)/pkcs11bench
 
-GO_BUILD_FLAGS =
-
 # Build environment variables (referencing core/util.go)
 COMMIT_ID = $(shell git rev-parse --short HEAD)
 
@@ -28,6 +26,8 @@ BUILD_HOST_VAR = github.com/letsencrypt/boulder/core.BuildHost
 BUILD_TIME = $(shell date -u)
 BUILD_TIME_VAR = github.com/letsencrypt/boulder/core.BuildTime
 
+GO_BUILD_FLAGS = -ldflags "-X \"$(BUILD_ID_VAR)=$(BUILD_ID)\" -X \"$(BUILD_TIME_VAR)=$(BUILD_TIME)\" -X \"$(BUILD_HOST_VAR)=$(BUILD_HOST)\""
+
 .PHONY: all build
 all: build
 
@@ -39,9 +39,7 @@ $(OBJDIR):
 $(CMD_BINS): build_cmds
 
 build_cmds: | $(OBJDIR)
-	GOBIN=$(OBJDIR) go install $(GO_BUILD_FLAGS) -ldflags \
-		"-X \"$(BUILD_ID_VAR)=$(BUILD_ID)\" -X \"$(BUILD_TIME_VAR)=$(BUILD_TIME)\" \
-		-X \"$(BUILD_HOST_VAR)=$(BUILD_HOST)\"" ./...
+	GOBIN=$(OBJDIR) go install $(GO_BUILD_FLAGS) ./...
 
 clean:
 	rm -f $(OBJDIR)/*
@@ -76,6 +74,3 @@ rpm: build
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
 		--depends "libtool-ltdl" --maintainer "$(MAINTAINER)" \
 		test/boulder-config.json sa/_db $(OBJECTS)
-
-$(OBJDIR)/pkcs11bench: ./Godeps/_workspace/src/github.com/cloudflare/cfssl/crypto/pkcs11key/*.go | $(OBJDIR)
-	go test -o $(OBJDIR)/pkcs11bench -c ./Godeps/_workspace/src/github.com/cloudflare/cfssl/crypto/pkcs11key/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MAINTAINER ?= "Community"
 CMDS = $(shell find ./cmd -maxdepth 1 -mindepth 1 -type d)
 CMD_BASENAMES = $(shell echo $(CMDS) | xargs -n1 basename)
 CMD_BINS = $(addprefix $(OBJDIR)/, $(CMD_BASENAMES) )
-OBJECTS = $(CMD_BINS) $(OBJDIR)/pkcs11bench
+OBJECTS = $(CMD_BINS)
 
 # Build environment variables (referencing core/util.go)
 COMMIT_ID = $(shell git rev-parse --short HEAD)

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -36,9 +36,9 @@ def install(race_detection):
     # Pass empty BUILD_TIME and BUILD_ID flags to avoid constantly invalidating the
     # build cache with new BUILD_TIMEs, or invalidating it on merges with a new
     # BUILD_ID.
-    cmd = "make BUILD_TIME='' BUILD_ID=''  "
+    cmd = "make GO_BUILD_FLAGS=''  "
     if race_detection:
-        cmd = cmd + " GO_BUILD_FLAGS=-race"
+        cmd = "make GO_BUILD_FLAGS=-race"
 
     return subprocess.call(cmd, shell=True) == 0
 


### PR DESCRIPTION
I think even the ldflags that did not change between subsequent invocations of
./start.py, e.g. BUILD_HOST_VAR, were different between ./start.py and
`go test ./...`, which would cause test runs to be unnecessarily slow.

Open question: To keep local developer builds fast, maybe we should enable race
detection only in Travis? Otherwise, `go test ./...` runs with one set of
ldflags, and then `ampq-integration-test.py` runs with a different set, which I
think makes both of them slower.