### PR TITLE
read fully from urandom

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -309,7 +309,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(csr x509.CertificateRequest
 	const randBits = 136
 	serialBytes := make([]byte, randBits/8+1)
 	serialBytes[0] = byte(ca.Prefix)
-	_, err = rand.Reader.Read(serialBytes[1:])
+	_, err = rand.Read(serialBytes[1:])
 	if err != nil {
 		err = core.InternalServerError(err.Error())
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3


### PR DESCRIPTION
This didn't cause any certificates to be made with duplicate serial numbers because the primary key in the certificates table is the serial number and so attempts to insert duplicates fail.

The cause is the use of rand/Reader.Read. rand/Reader.Read does not perform the io.ReadFull that rand.Read does. Without the io.ReadFull, less than all of the random part of the serial number would be filled in.

Fixes #911.
