### PR TITLE
remove some allocations from B64enc codepath

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -117,7 +117,11 @@ func pad(x string) string {
 }
 
 func unpad(x string) string {
-	return strings.Replace(x, "=", "", -1)
+	end := len(x)
+	for end != 0 && x[end-1] == '=' {
+		end--
+	}
+	return x[:end]
 }
 
 // B64enc encodes a byte array as unpadded, URL-safe Base64


### PR DESCRIPTION
B64enc makes some nasty allocations through its use of strings.Replace in unpad. This changes that strings.Replace into a simple for-loop.

B64enc gets used in many places, including the rpc library on every request and response. While we should probably not use it in the rpc library (#909), there are enough other places it's used (now or in the near future) that make this valuable.

Was a performance problem found during early load-testing (#20) of the CA. More to come.