### PR TITLE
bump go to 1.5.1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5
+  - 1.5.1
 
 addons:
   hosts:


### PR DESCRIPTION
We don't want to put multiple versions in our config because it'll launch another set of sub-builds and eat up our quota.

@jcjones has been updating the prod build in parallel.