### PR TITLE
Cleanup of Docker Dev Playground

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,57 +3,42 @@ FROM golang:1.5
 MAINTAINER J.C. Jones "jjones@letsencrypt.org"
 MAINTAINER William Budington "bill@eff.org"
 
-# Add node.js key to apt-key safely
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --import && \
-  gpg --export 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280 | apt-key add -
-
 # Install dependencies packages
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-    apt-transport-https && \
-  echo deb https://deb.nodesource.com/node_0.12 jessie main > /etc/apt/sources.list.d/nodesource.list && \
-  apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     libltdl-dev \
-    rsyslog \
+	mariadb-client-core-10.0 \
     nodejs \
-    lsb-release \
-    rabbitmq-server \
-    mariadb-server \
-    git-core && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* \
-    /tmp/* \
-    /var/tmp/*
+	rsyslog \
+	--no-install-recommends \
+  	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Boulder exposes its web application at port TCP 4000
 EXPOSE 4000
 
-# Assume the configuration is in /etc/boulder
-ENV BOULDER_CONFIG /go/src/github.com/letsencrypt/boulder/test/boulder-config.json
-
-# Get the Let's Encrypt client
-RUN git clone https://www.github.com/letsencrypt/letsencrypt.git /letsencrypt
-WORKDIR /letsencrypt
-RUN ./bootstrap/debian.sh && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* \
-    /tmp/* \
-    /var/tmp/*
-RUN virtualenv --no-site-packages -p python2 venv && \
-  ./venv/bin/pip install -r requirements.txt -e acme -e .[dev,docs,testing] -e letsencrypt-apache -e letsencrypt-nginx
-
+# get database migration tool
 RUN go get bitbucket.org/liamstask/goose/cmd/goose
 
-ENV LETSENCRYPT_PATH /letsencrypt
+# Assume the configuration is in /etc/boulder
+ENV BOULDER_CONFIG /go/src/github.com/letsencrypt/boulder/test/boulder-config.json
+ENV GOPATH /go/src/github.com/letsencrypt/boulder/Godeps/_workspace:$GOPATH
+
+# Get the Let's Encrypt client
+RUN git clone --depth 1 https://www.github.com/letsencrypt/letsencrypt.git /letsencrypt \
+	&& cd /letsencrypt \
+	&& ./bootstrap/debian.sh \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& virtualenv --no-site-packages -p python2 venv \
+	&& ./venv/bin/pip install \
+		-r requirements.txt \
+		-e acme \
+		-e .[dev,docs,testing] \
+		-e letsencrypt-apache \
+		-e letsencrypt-nginx
+
+WORKDIR /go/src/github.com/letsencrypt/boulder
 
 # Copy in the Boulder sources
 COPY . /go/src/github.com/letsencrypt/boulder
 
-WORKDIR /go/src/github.com/letsencrypt/boulder
-CMD ["bash", "-c", "service mysql start && \
-service rsyslog start && \
-service rabbitmq-server start && \
-cd /go/src/github.com/letsencrypt/boulder/ && \
-./test/create_db.sh && \
-WFE_LISTEN_ADDR=0.0.0.0:4000 ./start.py"]
+ENTRYPOINT [ "./test/entrypoint.sh" ]
+CMD [ "./start.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ EXPOSE 4000
 
 # get database migration tool
 RUN go get bitbucket.org/liamstask/goose/cmd/goose
+# install go lint
+RUN go get -v github.com/golang/lint/golint
 
 # Assume the configuration is in /etc/boulder
 ENV BOULDER_CONFIG /go/src/github.com/letsencrypt/boulder/test/boulder-config.json

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ in a Docker container, run:
 
     ./test/run-docker.sh
 
+**NOTE:** You will need to have `docker-compose` installed locally. Directions
+for installing can be found at [docs.docker.com/compose/install](https://docs.docker.com/compose/install/).
+
 Slow start
 ----------
 

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 var (
@@ -97,11 +98,6 @@ const profileName = "ee"
 const caKeyFile = "../test/test-ca.key"
 const caCertFile = "../test/test-ca.pem"
 
-const (
-	paDBConnStr = "mysql+tcp://policy@localhost:3306/boulder_policy_test"
-	saDBConnStr = "mysql+tcp://sa@localhost:3306/boulder_sa_test"
-)
-
 func mustRead(path string) []byte {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -121,7 +117,7 @@ type testCtx struct {
 
 func setup(t *testing.T) *testCtx {
 	// Create an SA
-	dbMap, err := sa.NewDbMap(saDBConnStr)
+	dbMap, err := sa.NewDbMap(vars.DBConnSA)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
@@ -133,7 +129,7 @@ func setup(t *testing.T) *testCtx {
 	}
 	saDBCleanUp := test.ResetSATestDatabase(t)
 
-	paDbMap, err := sa.NewDbMap(paDBConnStr)
+	paDbMap, err := sa.NewDbMap(vars.DBConnPolicy)
 	test.AssertNotError(t, err, "Could not construct dbMap")
 	pa, err := policy.NewPolicyAuthorityImpl(paDbMap, false)
 	test.AssertNotError(t, err, "Couldn't create PADB")

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -26,20 +26,16 @@ import (
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
-)
-
-var (
-	saDbConnStr = "mysql+tcp://sa@localhost:3306/boulder_sa_test"
-	paDbConnStr = "mysql+tcp://policy@localhost:3306/boulder_policy_test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 func BenchmarkCheckCert(b *testing.B) {
-	saDbMap, err := sa.NewDbMap(saDbConnStr)
+	saDbMap, err := sa.NewDbMap(vars.DBConnSA)
 	if err != nil {
 		fmt.Println("Couldn't connect to database")
 		return
 	}
-	paDbMap, err := sa.NewDbMap(paDbConnStr)
+	paDbMap, err := sa.NewDbMap(vars.DBConnPolicy)
 	if err != nil {
 		fmt.Println("Couldn't connect to database")
 		return
@@ -78,10 +74,10 @@ func BenchmarkCheckCert(b *testing.B) {
 }
 
 func TestCheckCert(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(saDbConnStr)
+	saDbMap, err := sa.NewDbMap(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	saCleanup := test.ResetSATestDatabase(t)
-	paDbMap, err := sa.NewDbMap(paDbConnStr)
+	paDbMap, err := sa.NewDbMap(vars.DBConnPolicy)
 	test.AssertNotError(t, err, "Couldn't connect to policy database")
 	paCleanup := test.ResetPolicyTestDatabase(t)
 	defer func() {
@@ -179,9 +175,9 @@ func TestCheckCert(t *testing.T) {
 }
 
 func TestGetAndProcessCerts(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(saDbConnStr)
+	saDbMap, err := sa.NewDbMap(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
-	paDbMap, err := sa.NewDbMap(paDbConnStr)
+	paDbMap, err := sa.NewDbMap(vars.DBConnPolicy)
 	test.AssertNotError(t, err, "Couldn't connect to policy database")
 	fc := clock.NewFake()
 

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 func bigIntFromB64(b64 string) *big.Int {
@@ -50,7 +51,7 @@ func (m *mockMail) Clear() {
 }
 
 func (m *mockMail) SendMail(to []string, msg string) (err error) {
-	for _ = range to {
+	for range to {
 		m.Messages = append(m.Messages, msg)
 	}
 	return
@@ -145,8 +146,6 @@ var testKey = rsa.PrivateKey{
 	D:         d,
 	Primes:    []*big.Int{p, q},
 }
-
-const dbConnStr = "mysql+tcp://mailer@localhost:3306/boulder_sa_test"
 
 func TestFindExpiringCertificates(t *testing.T) {
 	ctx := setup(t, []time.Duration{time.Hour * 24, time.Hour * 24 * 4, time.Hour * 24 * 7})
@@ -462,7 +461,7 @@ type testCtx struct {
 func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 	// We use the test_setup user (which has full permissions to everything)
 	// because the SA we return is used for inserting data to set up the test.
-	dbMap, err := sa.NewDbMap("mysql+tcp://test_setup@localhost:3306/boulder_sa_test")
+	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms)
 	if err != nil {
 		t.Fatalf("Couldn't connect the database: %s", err)
 	}

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 func TestCacheControl(t *testing.T) {
@@ -65,7 +66,7 @@ func TestHandler(t *testing.T) {
 }
 
 func TestDBHandler(t *testing.T) {
-	dbMap, err := sa.NewDbMap("mysql+tcp://ocsp_resp@localhost:3306/boulder_sa_test")
+	dbMap, err := sa.NewDbMap(vars.DBConnSAOcspResp)
 	test.AssertNotError(t, err, "Could not connect to database")
 	src, err := makeDBSource(dbMap, "./testdata/test-ca.der.pem", blog.GetAuditLogger())
 	if err != nil {

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 type mockCA struct{}
@@ -47,12 +48,10 @@ func (p *mockPub) SubmitToCT(_ []byte) error {
 	})
 }
 
-const dbConnStr = "mysql+tcp://sa@localhost:3306/boulder_sa_test"
-
 var log = mocks.UseMockLog()
 
 func setup(t *testing.T) (OCSPUpdater, core.StorageAuthority, *gorp.DbMap, clock.FakeClock, func()) {
-	dbMap, err := sa.NewDbMap(dbConnStr)
+	dbMap, err := sa.NewDbMap(vars.DBConnSA)
 	test.AssertNotError(t, err, "Failed to create dbMap")
 
 	fc := clock.NewFake()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+boulder:
+    build: .
+    dockerfile: Dockerfile
+    net: "host"
+    ports:
+        - "4000:4000"
+    environment:
+        MYSQL_CONTAINER: "yes"
+mysql:
+    image: mariadb:10
+    net: host
+    ports:
+        - "3306:3306"
+    environment:
+        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+rabbitmq:
+    image: rabbitmq:3
+    ports:
+        - "5672:5672"

--- a/policy/policy-authority-data_test.go
+++ b/policy/policy-authority-data_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 func padbImpl(t *testing.T) (*PolicyAuthorityDatabaseImpl, func()) {
-	dbMap, err := sa.NewDbMap(dbConnStr)
+	dbMap, err := sa.NewDbMap(vars.DBConnPolicy)
 	test.AssertNotError(t, err, "Could not construct dbMap")
 
 	padb, err := NewPolicyAuthorityDatabaseImpl(dbMap)

--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 var log = mocks.UseMockLog()
-var dbConnStr = "mysql+tcp://policy@localhost:3306/boulder_policy_test"
 
 func paImpl(t *testing.T) (*PolicyAuthorityImpl, func()) {
 	dbMap, cleanUp := paDBMap(t)
@@ -32,7 +32,7 @@ func paImpl(t *testing.T) (*PolicyAuthorityImpl, func()) {
 }
 
 func paDBMap(t *testing.T) (*gorp.DbMap, func()) {
-	dbMap, err := sa.NewDbMap(dbConnStr)
+	dbMap, err := sa.NewDbMap(vars.DBConnPolicy)
 	test.AssertNotError(t, err, "Could not construct dbMap")
 	cleanUp := test.ResetPolicyTestDatabase(t)
 	return dbMap, cleanUp

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
 
 type DummyValidationAuthority struct {
@@ -121,11 +122,6 @@ var (
 	log = mocks.UseMockLog()
 )
 
-const (
-	paDBConnStr = "mysql+tcp://policy@localhost:3306/boulder_policy_test"
-	saDBConnStr = "mysql+tcp://sa@localhost:3306/boulder_sa_test"
-)
-
 func makeResponse(ch core.Challenge) (out core.Challenge, err error) {
 	keyAuthorization, err := core.NewKeyAuthorization(ch.Token, ch.AccountKey)
 	if err != nil {
@@ -156,7 +152,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 
 	fc := clock.NewFake()
 
-	dbMap, err := sa.NewDbMap(saDBConnStr)
+	dbMap, err := sa.NewDbMap(vars.DBConnSA)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
@@ -188,7 +184,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	}
 	signer, _ := local.NewSigner(caKey, caCert, x509.SHA256WithRSA, basicPolicy)
 	ocspSigner, _ := ocsp.NewSigner(caCert, caCert, caKey, time.Hour)
-	paDbMap, err := sa.NewDbMap(paDBConnStr)
+	paDbMap, err := sa.NewDbMap(vars.DBConnPolicy)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -28,16 +28,15 @@ import (
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
 )
-
-const dbConnStr = "mysql+tcp://sa@localhost:3306/boulder_sa_test"
 
 var log = mocks.UseMockLog()
 
 // initSA constructs a SQLStorageAuthority and a clean up function
 // that should be defer'ed to the end of the test.
 func initSA(t *testing.T) (*SQLStorageAuthority, clock.FakeClock, func()) {
-	dbMap, err := NewDbMap(dbConnStr)
+	dbMap, err := NewDbMap(vars.DBConnSA)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -75,9 +75,9 @@
             "backdate": "1h",
             "is_ca": false,
             "issuer_urls": [
-              "http://localhost:4000/acme/issuer-cert"
+              "http://127.0.0.1:4000/acme/issuer-cert"
             ],
-            "ocsp_url": "http://localhost:4002/ocsp",
+            "ocsp_url": "http://127.0.0.1:4002/ocsp",
             "crl_url": "http://example.com/crl",
             "policies": [
               {
@@ -197,7 +197,7 @@
   },
 
   "common": {
-    "baseURL": "http://localhost:4000",
+    "baseURL": "http://127.0.0.1:4000",
     "issuerCert": "test/test-ca.pem",
     "dnsResolver": "127.0.0.1:8053",
     "dnsTimeout": "10s",
@@ -219,5 +219,5 @@
     "dbConnect": "mysql+tcp://cert_checker@localhost:3306/boulder_sa_integration"
   },
 
-  "subscriberAgreementURL": "http://localhost:4001/terms/v1"
+  "subscriberAgreementURL": "http://127.0.0.1:4001/terms/v1"
 }

--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -3,24 +3,35 @@ set -o errexit
 cd $(dirname $0)/..
 source test/db-common.sh
 
+# set db connection for if running in a seperate container or not
+dbconn="-u root"
+if [[ ! -z "MYSQL_CONTAINER" ]]; then
+	dbconn="-u root -h 127.0.0.1 --port 3306"
+fi
+
 # Drop all users to get a fresh start
-mysql -u root < test/drop_users.sql
+mysql $dbconn < test/drop_users.sql
 
 for svc in $SERVICES; do
-  for dbenv in $DBENVS; do
-    db="boulder_${svc}_${dbenv}"
+	for dbenv in $DBENVS; do
+		(
+		db="boulder_${svc}_${dbenv}"
+		create_script="drop database if exists \`${db}\`; create database if not exists \`${db}\`;"
 
-    (mysql -u root -e "drop database if exists \`${db}\`; create database if not exists \`${db}\`;" || die "unable to create ${db}"
-    echo "created empty ${db} database"
+		mysql $dbconn -e "$create_script" || die "unable to create ${db}"
 
-    goose -path=./$svc/_db/ -env=$dbenv up || die "unable to migrate ${db}"
-    echo "migrated ${db} database"
+		echo "created empty ${db} database"
 
-    USERS_SQL=test/${svc}_db_users.sql
-    if [ -f $USERS_SQL ] ; then
-      mysql -u root -D boulder_${svc}_${dbenv} < $USERS_SQL
-    fi) &
-  done
+		goose -path=./$svc/_db/ -env=$dbenv up || die "unable to migrate ${db}"
+		echo "migrated ${db} database"
+
+		USERS_SQL=test/${svc}_db_users.sql
+		if [[ -f "$USERS_SQL" ]]; then
+			mysql $dbconn -D $db < $USERS_SQL || die "unable to add users to ${db}"
+			echo "added users to ${db}"
+		fi
+		) &
+	done
 done
 wait
 

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# start rsyslog
+service rsyslog start &&
+
+# wait until the mysql instance has started fully
+# this is awful
+sleep 5
+
+# create the database
+source $DIR/create_db.sh
+
+$@

--- a/test/policy_db_users.sql
+++ b/test/policy_db_users.sql
@@ -19,8 +19,8 @@
 -- and the CA and RA (for reads). So right now we have the one user that has
 -- both read and write permission, even though it would be better to give only
 -- read permission to CA and RA.
-GRANT SELECT,INSERT,DELETE ON blacklist TO 'policy'@'localhost';
-GRANT SELECT,INSERT,DELETE ON whitelist TO 'policy'@'localhost';
+GRANT SELECT,INSERT,DELETE ON blacklist TO 'policy'@'127.0.0.1';
+GRANT SELECT,INSERT,DELETE ON whitelist TO 'policy'@'127.0.0.1';
 
 -- Test setup and teardown
-GRANT ALL PRIVILEGES ON * to 'test_setup'@'localhost';
+GRANT ALL PRIVILEGES ON * to 'test_setup'@'127.0.0.1';

--- a/test/run-docker.sh
+++ b/test/run-docker.sh
@@ -21,13 +21,10 @@ cd $(dirname $0)/..
 if [ -z "${FAKE_DNS}" ] ; then
   FAKE_DNS=$(ifconfig docker0 | sed -n 's/ *inet addr:\([0-9.]\+\).*/\1/p')
 fi
-docker build --tag boulder .
-# The -i command makes the instance interactive, so you can kill start.py with Ctrl-C.
-docker run \
-  --interactive \
-  --tty \
-  --rm=true \
-  --publish 4000-4001:4000-4001 \
-  --publish 8000-8100:8000-8100 \
-  --env FAKE_DNS="${FAKE_DNS}" \
-  boulder
+
+# build the docker images
+docker-compose build
+
+# The excluding `-d` command makes the instance interactive, so you can kill
+# all containers with Ctrl-C.
+docker-compose up

--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -15,42 +15,42 @@
 -- the user exists and then drop the user.
 
 -- Storage Authority
-GRANT SELECT,INSERT,UPDATE ON authz TO 'sa'@'localhost';
-GRANT SELECT,INSERT,UPDATE,DELETE ON pendingAuthorizations TO 'sa'@'localhost';
-GRANT SELECT(id,Lockcol) ON pendingAuthorizations TO 'sa'@'localhost';
-GRANT SELECT,INSERT ON certificates TO 'sa'@'localhost';
-GRANT SELECT,INSERT,UPDATE ON certificateStatus TO 'sa'@'localhost';
-GRANT SELECT,INSERT ON issuedNames TO 'sa'@'localhost';
-GRANT SELECT,INSERT ON sctReceipts TO 'sa'@'localhost';
-GRANT SELECT,INSERT ON deniedCSRs TO 'sa'@'localhost';
-GRANT INSERT ON ocspResponses TO 'sa'@'localhost';
-GRANT SELECT,INSERT,UPDATE ON registrations TO 'sa'@'localhost';
-GRANT SELECT,INSERT,UPDATE ON challenges TO 'sa'@'localhost';
+GRANT SELECT,INSERT,UPDATE ON authz TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT,UPDATE,DELETE ON pendingAuthorizations TO 'sa'@'127.0.0.1';
+GRANT SELECT(id,Lockcol) ON pendingAuthorizations TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT ON certificates TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT,UPDATE ON certificateStatus TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT ON issuedNames TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT ON sctReceipts TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT ON deniedCSRs TO 'sa'@'127.0.0.1';
+GRANT INSERT ON ocspResponses TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT,UPDATE ON registrations TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT,UPDATE ON challenges TO 'sa'@'127.0.0.1';
 
 -- OCSP Responder
-GRANT SELECT ON certificateStatus TO 'ocsp_resp'@'localhost';
-GRANT SELECT ON ocspResponses TO 'ocsp_resp'@'localhost';
+GRANT SELECT ON certificateStatus TO 'ocsp_resp'@'127.0.0.1';
+GRANT SELECT ON ocspResponses TO 'ocsp_resp'@'127.0.0.1';
 
 -- OCSP Generator Tool (Updater)
-GRANT INSERT ON ocspResponses TO 'ocsp_update'@'localhost';
-GRANT SELECT ON certificates TO 'ocsp_update'@'localhost';
-GRANT SELECT,UPDATE ON certificateStatus TO 'ocsp_update'@'localhost';
+GRANT INSERT ON ocspResponses TO 'ocsp_update'@'127.0.0.1';
+GRANT SELECT ON certificates TO 'ocsp_update'@'127.0.0.1';
+GRANT SELECT,UPDATE ON certificateStatus TO 'ocsp_update'@'127.0.0.1';
 
 -- Revoker Tool
-GRANT SELECT ON registrations TO 'revoker'@'localhost';
-GRANT SELECT ON certificates TO 'revoker'@'localhost';
-GRANT SELECT,INSERT ON deniedCSRs TO 'revoker'@'localhost';
+GRANT SELECT ON registrations TO 'revoker'@'127.0.0.1';
+GRANT SELECT ON certificates TO 'revoker'@'127.0.0.1';
+GRANT SELECT,INSERT ON deniedCSRs TO 'revoker'@'127.0.0.1';
 
 -- External Cert Importer
-GRANT SELECT,INSERT,UPDATE,DELETE ON identifierData TO 'importer'@'localhost';
-GRANT SELECT,INSERT,UPDATE,DELETE ON externalCerts TO 'importer'@'localhost';
+GRANT SELECT,INSERT,UPDATE,DELETE ON identifierData TO 'importer'@'127.0.0.1';
+GRANT SELECT,INSERT,UPDATE,DELETE ON externalCerts TO 'importer'@'127.0.0.1';
 
 -- Expiration mailer
-GRANT SELECT ON certificates TO 'mailer'@'localhost';
-GRANT SELECT,UPDATE ON certificateStatus TO 'mailer'@'localhost';
+GRANT SELECT ON certificates TO 'mailer'@'127.0.0.1';
+GRANT SELECT,UPDATE ON certificateStatus TO 'mailer'@'127.0.0.1';
 
 -- Cert checker
-GRANT SELECT ON certificates TO 'cert_checker'@'localhost';
+GRANT SELECT ON certificates TO 'cert_checker'@'127.0.0.1';
 
 -- Test setup and teardown
-GRANT ALL PRIVILEGES ON * to 'test_setup'@'localhost';
+GRANT ALL PRIVILEGES ON * to 'test_setup'@'127.0.0.1';

--- a/test/vars/vars.go
+++ b/test/vars/vars.go
@@ -1,0 +1,24 @@
+package vars
+
+import "fmt"
+
+const (
+	dbURL = "mysql+tcp://%s@localhost:3306/%s"
+)
+
+var (
+	// DBConnPolicy is the policy database connection
+	DBConnPolicy = fmt.Sprintf(dbURL, "policy", "boulder_policy_test")
+	// DBConnPolicyIntegration is the policy integration database connection
+	DBConnPolicyIntegration = fmt.Sprintf(dbURL, "policy", "boulder_policy_integration")
+	// DBConnSA is the sa database connection
+	DBConnSA = fmt.Sprintf(dbURL, "sa", "boulder_sa_test")
+	// DBConnSAIntegration is the sa integration database connection
+	DBConnSAIntegration = fmt.Sprintf(dbURL, "sa", "boulder_sa_integration")
+	// DBConnSAMailer is the sa mailer database connection
+	DBConnSAMailer = fmt.Sprintf(dbURL, "mailer", "boulder_sa_test")
+	// DBConnSAFullPerms is the sa database connection with full perms
+	DBConnSAFullPerms = fmt.Sprintf(dbURL, "test_setup", "boulder_sa_test")
+	// DBConnSAOcspResp is the sa ocsp_resp database connection
+	DBConnSAOcspResp = fmt.Sprintf(dbURL, "ocsp_resp", "boulder_sa_test")
+)


### PR DESCRIPTION
- Separated MariaDB into it's own container
- Separated RabbitMq into it's own container
- some various Dockerfile-isms cleanup
- updated routes to linked containers
- removed nodejs, I have not been able to figure out why it was being installed
    (so this could be something that is actually needed)

To setup a dev environment:

You now need `docker-compose`, but running the setup with all the
configurations is as simple as:

```
$ docker-compose build
$ docker-compose up
```

Then you can even run the `test.sh` in the container with:

```
$ docker exec -it boulder_boulder_1 bash
root@container $ ./test.sh
```

This is just an _initial_ first pass at refactoring a bunch of this. There is
a bunch more I want to change and make better as far as connecting to the
database via the golang test files, etc.

Also with regard to database migration takinng awhile I want to try and move
the goose stuff over to the mariadb container, there is just some less savory
things I don't like about starting the db in the background then running the
migration script :/, I like to attach to the process on container start. I do
have some thoughts on a `docker exec` command in the mariadb container which
migrates the db... but trying to think of something better.

Signed-off-by: Jess Frazelle <jess@docker.com>