### PR TITLE
Fix AddSCTReceipt RPC transit

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -741,6 +741,13 @@ type SignedCertificateTimestamp struct {
 	LockCol int64
 }
 
+// RPCSignedCertificateTimestamp is a wrapper around SignedCertificateTimestamp
+// so that it can be passed through the RPC layer properly. Without this wrapper
+// the UnmarshalJSON method below will be used when marshaling/unmarshaling the
+// object, which is not what we want as it is not symmetrical (as it is intended
+// to unmarshal a rawSignedCertificateTimestamp into a SignedCertificateTimestamp)
+type RPCSignedCertificateTimestamp SignedCertificateTimestamp
+
 type rawSignedCertificateTimestamp struct {
 	Version    uint8  `json:"sct_version"`
 	LogID      string `json:"id"`

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -1056,7 +1056,7 @@ func NewStorageAuthorityServer(rpc Server, impl core.StorageAuthority) error {
 		}
 
 		sct, err := impl.GetSCTReceipt(gsctReq.Serial, gsctReq.LogID)
-		jsonResponse, err := json.Marshal(core.SignedCertificateTimestamp(sct))
+		jsonResponse, err := json.Marshal(core.RPCSignedCertificateTimestamp(sct))
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 			errorCondition(MethodGetSCTReceipt, err, req)
@@ -1067,7 +1067,7 @@ func NewStorageAuthorityServer(rpc Server, impl core.StorageAuthority) error {
 	})
 
 	rpc.Handle(MethodAddSCTReceipt, func(req []byte) (response []byte, err error) {
-		var sct core.SignedCertificateTimestamp
+		var sct core.RPCSignedCertificateTimestamp
 		err = json.Unmarshal(req, &sct)
 		if err != nil {
 			// AUDIT[ Improper Messages ] 0786b6f2-91ca-4f48-9883-842a19084c64


### PR DESCRIPTION
Revert a couple deletions 0f3f766d made that broke `AddSCTReceipt` RPC transit.

Fixes #950.