### PR TITLE
Add rate limiting by registration IP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,4 @@ env:
 
 script:
   - bash test.sh
+

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -205,9 +205,7 @@ func TestGetAndProcessCerts(t *testing.T) {
 		BasicConstraintsValid: true,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}
-	reg, err := sa.NewRegistration(core.Registration{
-		Key: satest.GoodJWK(),
-	})
+	reg := satest.CreateWorkingRegistration(t, sa)
 	test.AssertNotError(t, err, "Couldn't create registration")
 	for i := int64(0); i < 5; i++ {
 		rawCert.SerialNumber = big.NewInt(i)

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"net"
 	"testing"
 	"text/template"
 	"time"
@@ -171,14 +172,16 @@ func TestFindExpiringCertificates(t *testing.T) {
 		Contact: []*core.AcmeURL{
 			emailA,
 		},
-		Key: keyA,
+		Key:       keyA,
+		InitialIP: net.ParseIP("2.3.2.3"),
 	}
 	regB := core.Registration{
 		ID: 2,
 		Contact: []*core.AcmeURL{
 			emailB,
 		},
-		Key: keyB,
+		Key:       keyB,
+		InitialIP: net.ParseIP("2.3.2.3"),
 	}
 	regA, err = ctx.ssa.NewRegistration(regA)
 	if err != nil {
@@ -298,7 +301,8 @@ func TestLifetimeOfACert(t *testing.T) {
 		Contact: []*core.AcmeURL{
 			emailA,
 		},
-		Key: keyA,
+		Key:       keyA,
+		InitialIP: net.ParseIP("1.2.2.1"),
 	}
 	regA, err = ctx.ssa.NewRegistration(regA)
 	if err != nil {
@@ -401,7 +405,8 @@ func TestDontFindRevokedCert(t *testing.T) {
 		Contact: []*core.AcmeURL{
 			emailA,
 		},
-		Key: keyA,
+		Key:       keyA,
+		InitialIP: net.ParseIP("6.5.5.6"),
 	}
 	regA, err = ctx.ssa.NewRegistration(regA)
 	if err != nil {

--- a/cmd/rate-limits.go
+++ b/cmd/rate-limits.go
@@ -17,6 +17,10 @@ type RateLimitConfig struct {
 	// These are counted by "base domain" aka eTLD+1, so any entries in the
 	// overrides section must be an eTLD+1 according to the publicsuffix package.
 	CertificatesPerName RateLimitPolicy `yaml:"certificatesPerName"`
+	// Number of registrations that can be created per IP.
+	// Note: Since this is checked before a registration is created, setting a
+	// RegistrationOverride on it has no effect.
+	RegistrationsPerIP RateLimitPolicy `yaml:"registrationsPerIP"`
 }
 
 // RateLimitPolicy describes a general limiting policy

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -112,6 +112,7 @@ type StorageGetter interface {
 	AlreadyDeniedCSR([]string) (bool, error)
 	CountCertificatesRange(time.Time, time.Time) (int64, error)
 	CountCertificatesByNames([]string, time.Time, time.Time) (map[string]int, error)
+	CountRegistrationsByIP(net.IP, time.Time, time.Time) (int, error)
 	GetSCTReceipt(string, string) (SignedCertificateTimestamp, error)
 }
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -168,6 +168,12 @@ type Registration struct {
 
 	// Agreement with terms of service
 	Agreement string `json:"agreement,omitempty"`
+
+	// InitialIP is the IP address from which the registration was created
+	InitialIP net.IP `json:"initialIp"`
+
+	// CreatedAt is the time the registration was created.
+	CreatedAt time.Time `json:"createdAt"`
 }
 
 // MergeUpdate copies a subset of information from the input Registration

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -163,7 +163,13 @@ func (sa *StorageAuthority) GetRegistration(id int64) (core.Registration, error)
 	var parsedKey jose.JsonWebKey
 	parsedKey.UnmarshalJSON(keyJSON)
 
-	return core.Registration{ID: id, Key: parsedKey, Agreement: agreementURL}, nil
+	return core.Registration{
+		ID:        id,
+		Key:       parsedKey,
+		Agreement: agreementURL,
+		InitialIP: net.ParseIP("5.6.7.8"),
+		CreatedAt: time.Date(2003, 9, 27, 0, 0, 0, 0, time.UTC),
+	}, nil
 }
 
 // GetRegistrationByKey is a mock
@@ -323,6 +329,11 @@ func (sa *StorageAuthority) CountCertificatesRange(_, _ time.Time) (int64, error
 // CountCertificatesByNames is a mock
 func (sa *StorageAuthority) CountCertificatesByNames(_ []string, _, _ time.Time) (ret map[string]int, err error) {
 	return
+}
+
+// CountRegistrationsByIP is a mock
+func (sa *StorageAuthority) CountRegistrationsByIP(_ net.IP, _, _ time.Time) (int, error) {
+	return 0, nil
 }
 
 // Publisher is a mock

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -139,6 +139,10 @@ func (ra *RegistrationAuthorityImpl) setIssuanceCount() (int, error) {
 	return ra.totalIssuedCache, nil
 }
 
+// noRegistrationID is used for the regID parameter to GetThreshold when no
+// registration-based overrides are necessary.
+const noRegistrationID = -1
+
 func (ra *RegistrationAuthorityImpl) checkRegistrationLimit(ip net.IP) error {
 	limit := ra.rlPolicies.RegistrationsPerIP
 	if limit.Enabled() {
@@ -147,7 +151,7 @@ func (ra *RegistrationAuthorityImpl) checkRegistrationLimit(ip net.IP) error {
 		if err != nil {
 			return err
 		}
-		if count >= limit.GetThreshold(ip.String(), -1) {
+		if count >= limit.GetThreshold(ip.String(), noRegistrationID) {
 			return core.RateLimitedError("Too many registrations from this IP")
 		}
 	}

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"net/mail"
 	"reflect"
 	"sort"
@@ -138,15 +139,38 @@ func (ra *RegistrationAuthorityImpl) setIssuanceCount() (int, error) {
 	return ra.totalIssuedCache, nil
 }
 
+func (ra *RegistrationAuthorityImpl) checkRegistrationLimit(ip net.IP) error {
+	limit := ra.rlPolicies.RegistrationsPerIP
+	if limit.Enabled() {
+		now := ra.clk.Now()
+		count, err := ra.SA.CountRegistrationsByIP(ip, limit.WindowBegin(now), now)
+		if err != nil {
+			return err
+		}
+		if count >= limit.GetThreshold(ip.String(), -1) {
+			return core.RateLimitedError("Too many registrations from this IP")
+		}
+	}
+	return nil
+}
+
 // NewRegistration constructs a new Registration from a request.
 func (ra *RegistrationAuthorityImpl) NewRegistration(init core.Registration) (reg core.Registration, err error) {
 	if err = core.GoodKey(init.Key.Key); err != nil {
 		return core.Registration{}, core.MalformedRequestError(fmt.Sprintf("Invalid public key: %s", err.Error()))
 	}
+	if err = ra.checkRegistrationLimit(init.InitialIP); err != nil {
+		return core.Registration{}, err
+	}
+
 	reg = core.Registration{
 		Key: init.Key,
 	}
 	reg.MergeUpdate(init)
+
+	// This field isn't updatable by the end user, so it isn't copied by
+	// MergeUpdate. But we need to fill it in for new registrations.
+	reg.InitialIP = init.InitialIP
 
 	err = validateContacts(reg.Contact, ra.DNSResolver, ra.stats)
 	if err != nil {

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"net/url"
 	"testing"
 	"time"
@@ -212,7 +213,10 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	csrDER, _ := hex.DecodeString(CSRhex)
 	ExampleCSR, _ = x509.ParseCertificateRequest(csrDER)
 
-	Registration, _ = ssa.NewRegistration(core.Registration{Key: AccountKeyA})
+	Registration, _ = ssa.NewRegistration(core.Registration{
+		Key:       AccountKeyA,
+		InitialIP: net.ParseIP("3.2.3.3"),
+	})
 
 	stats, _ := statsd.NewNoopClient()
 	ra := NewRegistrationAuthorityImpl(fc, blog.GetAuditLogger(), stats, cmd.RateLimitConfig{
@@ -303,8 +307,9 @@ func TestNewRegistration(t *testing.T) {
 	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
-		Contact: []*core.AcmeURL{mailto},
-		Key:     AccountKeyB,
+		Contact:   []*core.AcmeURL{mailto},
+		Key:       AccountKeyB,
+		InitialIP: net.ParseIP("7.6.6.5"),
 	}
 
 	result, err := ra.NewRegistration(input)
@@ -332,6 +337,7 @@ func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
 		Key:       AccountKeyC,
 		Contact:   []*core.AcmeURL{mailto},
 		Agreement: "I agreed",
+		InitialIP: net.ParseIP("5.0.5.0"),
 	}
 
 	result, err := ra.NewRegistration(input)

--- a/sa/_db/migrations/20151008234926_AddInitialIPAndCreatedAt.sql
+++ b/sa/_db/migrations/20151008234926_AddInitialIPAndCreatedAt.sql
@@ -1,0 +1,14 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `registrations` ADD COLUMN (
+  `initialIP` BINARY(16) NOT NULL DEFAULT "",
+  `createdAt` DATETIME NOT NULL
+);
+CREATE INDEX `initialIP_createdAt` on `registrations` (`initialIP`, `createdAt`);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP INDEX `initialIP_createdAt` on `registrations`;

--- a/sa/ip_range_test.go
+++ b/sa/ip_range_test.go
@@ -1,0 +1,57 @@
+// Copyright 2014 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sa
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIncrementIP(t *testing.T) {
+	testCases := []struct {
+		ip       string
+		index    int
+		expected string
+	}{
+		{"0.0.0.0", 15, "0.0.0.1"},
+		{"0.0.0.255", 15, "0.0.1.0"},
+		{"127.0.0.1", 15, "127.0.0.2"},
+		{"1.2.3.4", 14, "1.2.4.4"},
+		{"::1", 15, "::2"},
+		{"2002:1001:4008::", 15, "2002:1001:4008::1"},
+		{"2002:1001:4008::", 5, "2002:1001:4009::"},
+	}
+	for _, tc := range testCases {
+		ip := net.ParseIP(tc.ip).To16()
+		incrementIP(&ip, tc.index)
+		expectedIP := net.ParseIP(tc.expected)
+		if !ip.Equal(expectedIP) {
+			t.Errorf("Expected incrementIP(%s, %d) to be %s, instead got %s",
+				tc.ip, tc.index, expectedIP, ip.String())
+		}
+	}
+}
+
+func TestIPRange(t *testing.T) {
+	testCases := []struct {
+		ip            string
+		expectedBegin string
+		expectedEnd   string
+	}{
+		{"28.45.45.28", "28.45.45.28", "28.45.45.29"},
+		{"2002:1001:4008::", "2002:1001:4008::", "2002:1001:4009::"},
+	}
+	for _, tc := range testCases {
+		ip := net.ParseIP(tc.ip)
+		expectedBegin := net.ParseIP(tc.expectedBegin)
+		expectedEnd := net.ParseIP(tc.expectedEnd)
+		actualBegin, actualEnd := ipRange(ip)
+		if !expectedBegin.Equal(actualBegin) || !expectedEnd.Equal(actualEnd) {
+			t.Errorf("Expected ipRange(%s) to be (%s, %s), got (%s, %s)",
+				tc.ip, tc.expectedBegin, tc.expectedEnd, actualBegin, actualEnd)
+		}
+	}
+}

--- a/sa/ip_range_test.go
+++ b/sa/ip_range_test.go
@@ -16,21 +16,23 @@ func TestIncrementIP(t *testing.T) {
 		index    int
 		expected string
 	}{
-		{"0.0.0.0", 15, "0.0.0.1"},
-		{"0.0.0.255", 15, "0.0.1.0"},
-		{"127.0.0.1", 15, "127.0.0.2"},
-		{"1.2.3.4", 14, "1.2.4.4"},
-		{"::1", 15, "::2"},
-		{"2002:1001:4008::", 15, "2002:1001:4008::1"},
-		{"2002:1001:4008::", 5, "2002:1001:4009::"},
+		{"0.0.0.0", 128, "0.0.0.1"},
+		{"0.0.0.255", 128, "0.0.1.0"},
+		{"127.0.0.1", 128, "127.0.0.2"},
+		{"1.2.3.4", 120, "1.2.4.4"},
+		{"::1", 128, "::2"},
+		{"2002:1001:4008::", 128, "2002:1001:4008::1"},
+		{"2002:1001:4008::", 48, "2002:1001:4009::"},
+		{"2002:1001:ffff::", 48, "2002:1002::"},
+		{"ffff:ffff:ffff::", 48, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
 	}
 	for _, tc := range testCases {
 		ip := net.ParseIP(tc.ip).To16()
-		incrementIP(&ip, tc.index)
+		actual := incrementIP(ip, tc.index)
 		expectedIP := net.ParseIP(tc.expected)
-		if !ip.Equal(expectedIP) {
+		if !actual.Equal(expectedIP) {
 			t.Errorf("Expected incrementIP(%s, %d) to be %s, instead got %s",
-				tc.ip, tc.index, expectedIP, ip.String())
+				tc.ip, tc.index, expectedIP, actual.String())
 		}
 	}
 }

--- a/sa/model.go
+++ b/sa/model.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net"
 	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
@@ -31,6 +32,10 @@ type regModel struct {
 	KeySHA256 string          `db:"jwk_sha256"`
 	Contact   []*core.AcmeURL `db:"contact"`
 	Agreement string          `db:"agreement"`
+	// InitialIP is stored as sixteen binary bytes, regardless of whether it
+	// represents a v4 or v6 IP address.
+	InitialIP []byte    `db:"initialIp"`
+	CreatedAt time.Time `db:"createdAt"`
 	LockCol   int64
 }
 
@@ -65,12 +70,17 @@ func registrationToModel(r *core.Registration) (*regModel, error) {
 	if err != nil {
 		return nil, err
 	}
+	if r.InitialIP == nil {
+		return nil, fmt.Errorf("initialIP was nil")
+	}
 	rm := &regModel{
 		ID:        r.ID,
 		Key:       key,
 		KeySHA256: sha,
 		Contact:   r.Contact,
 		Agreement: r.Agreement,
+		InitialIP: []byte(r.InitialIP.To16()),
+		CreatedAt: r.CreatedAt,
 	}
 	return rm, nil
 }
@@ -87,6 +97,8 @@ func modelToRegistration(rm *regModel) (core.Registration, error) {
 		Key:       *k,
 		Contact:   rm.Contact,
 		Agreement: rm.Agreement,
+		InitialIP: net.IP(rm.InitialIP),
+		CreatedAt: rm.CreatedAt,
 	}
 	return r, nil
 }

--- a/sa/satest/satest.go
+++ b/sa/satest/satest.go
@@ -2,7 +2,9 @@ package satest
 
 import (
 	"encoding/json"
+	"net"
 	"testing"
+	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	"github.com/letsencrypt/boulder/core"
@@ -42,8 +44,10 @@ func CreateWorkingRegistration(t *testing.T, sa core.StorageAuthority) core.Regi
 	}
 	contacts := []*core.AcmeURL{contact}
 	reg, err := sa.NewRegistration(core.Registration{
-		Key:     GoodJWK(),
-		Contact: contacts,
+		Key:       GoodJWK(),
+		Contact:   contacts,
+		InitialIP: net.ParseIP("88.77.66.11"),
+		CreatedAt: time.Date(2003, 5, 10, 0, 0, 0, 0, time.UTC),
 	})
 	if err != nil {
 		t.Fatalf("Unable to create new registration")

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -15,6 +15,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/big"
+	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -41,7 +44,7 @@ func initSA(t *testing.T) (*SQLStorageAuthority, clock.FakeClock, func()) {
 	dbMap.TraceOn("SQL: ", &SQLLogger{log})
 
 	fc := clock.NewFake()
-	fc.Add(1 * time.Hour)
+	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
 
 	sa, err := NewSQLStorageAuthority(dbMap, fc)
 	if err != nil {
@@ -60,7 +63,7 @@ var (
 )
 
 func TestAddRegistration(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
+	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()
 
 	jwk := satest.GoodJWK()
@@ -71,8 +74,9 @@ func TestAddRegistration(t *testing.T) {
 	}
 	contacts := []*core.AcmeURL{contact}
 	reg, err := sa.NewRegistration(core.Registration{
-		Key:     jwk,
-		Contact: contacts,
+		Key:       jwk,
+		Contact:   contacts,
+		InitialIP: net.ParseIP("43.34.43.34"),
 	})
 	if err != nil {
 		t.Fatalf("Couldn't create new registration: %s", err)
@@ -87,15 +91,23 @@ func TestAddRegistration(t *testing.T) {
 	test.AssertNotError(t, err, fmt.Sprintf("Couldn't get registration with ID %v", reg.ID))
 
 	expectedReg := core.Registration{
-		ID:  reg.ID,
-		Key: jwk,
+		ID:        reg.ID,
+		Key:       jwk,
+		InitialIP: net.ParseIP("43.34.43.34"),
+		CreatedAt: clk.Now(),
 	}
 	test.AssertEquals(t, dbReg.ID, expectedReg.ID)
 	test.Assert(t, core.KeyDigestEquals(dbReg.Key, expectedReg.Key), "Stored key != expected")
 
 	u, _ := core.ParseAcmeURL("test.com")
 
-	newReg := core.Registration{ID: reg.ID, Key: jwk, Contact: []*core.AcmeURL{u}, Agreement: "yes"}
+	newReg := core.Registration{
+		ID:        reg.ID,
+		Key:       jwk,
+		Contact:   []*core.AcmeURL{u},
+		InitialIP: net.ParseIP("72.72.72.72"),
+		Agreement: "yes",
+	}
 	err = sa.UpdateRegistration(newReg)
 	test.AssertNotError(t, err, fmt.Sprintf("Couldn't get registration with ID %v", reg.ID))
 	dbReg, err = sa.GetRegistrationByKey(jwk)
@@ -581,4 +593,49 @@ func TestCountCertificates(t *testing.T) {
 	count, err = sa.CountCertificatesRange(now.Add(-24*time.Hour), now)
 	test.AssertNotError(t, err, "Couldn't get certificate count for the last 24hrs")
 	test.AssertEquals(t, count, int64(0))
+}
+
+func TestCountRegistrationsByIP(t *testing.T) {
+	sa, fc, cleanUp := initSA(t)
+	defer cleanUp()
+
+	contact := core.AcmeURL(url.URL{
+		Scheme: "mailto",
+		Opaque: "foo@example.com",
+	})
+
+	_, err := sa.NewRegistration(core.Registration{
+		Key:       jose.JsonWebKey{Key: &rsa.PublicKey{N: big.NewInt(1), E: 1}},
+		Contact:   []*core.AcmeURL{&contact},
+		InitialIP: net.ParseIP("43.34.43.34"),
+	})
+	test.AssertNotError(t, err, "Couldn't insert registration")
+	_, err = sa.NewRegistration(core.Registration{
+		Key:       jose.JsonWebKey{Key: &rsa.PublicKey{N: big.NewInt(2), E: 1}},
+		Contact:   []*core.AcmeURL{&contact},
+		InitialIP: net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9652"),
+	})
+	test.AssertNotError(t, err, "Couldn't insert registration")
+	_, err = sa.NewRegistration(core.Registration{
+		Key:       jose.JsonWebKey{Key: &rsa.PublicKey{N: big.NewInt(3), E: 1}},
+		Contact:   []*core.AcmeURL{&contact},
+		InitialIP: net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9653"),
+	})
+	test.AssertNotError(t, err, "Couldn't insert registration")
+
+	earliest := fc.Now().Add(-time.Hour * 24)
+	latest := fc.Now()
+
+	count, err := sa.CountRegistrationsByIP(net.ParseIP("1.1.1.1"), earliest, latest)
+	test.AssertNotError(t, err, "Failed to count registrations")
+	test.AssertEquals(t, count, 0)
+	count, err = sa.CountRegistrationsByIP(net.ParseIP("43.34.43.34"), earliest, latest)
+	test.AssertNotError(t, err, "Failed to count registrations")
+	test.AssertEquals(t, count, 1)
+	count, err = sa.CountRegistrationsByIP(net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9652"), earliest, latest)
+	test.AssertNotError(t, err, "Failed to count registrations")
+	test.AssertEquals(t, count, 2)
+	count, err = sa.CountRegistrationsByIP(net.ParseIP("2001:cdba:1234:0000:0000:0000:0000:0000"), earliest, latest)
+	test.AssertNotError(t, err, "Failed to count registrations")
+	test.AssertEquals(t, count, 2)
 }

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -15,3 +15,8 @@ certificatesPerName:
     nginx.wtf: 10000
   registrationOverrides:
     101: 1000
+registrationsPerIP:
+  window: 168h # 1 week
+  threshold: 3
+  overrides:
+    127.0.0.1: 1000000

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -225,7 +225,7 @@ func setupWFE(t *testing.T) WebFrontEndImpl {
 func makePostRequest(body string) *http.Request {
 	return &http.Request{
 		Method:     "POST",
-		RemoteAddr: "1.1.1.1",
+		RemoteAddr: "1.1.1.1:7882",
 		Header: map[string][]string{
 			"Content-Length": []string{fmt.Sprintf("%d", len(body))},
 		},
@@ -807,12 +807,13 @@ func TestNewRegistration(t *testing.T) {
 	wfe.NewRegistration(responseWriter,
 		makePostRequest(result.FullSerialize()))
 
-	test.AssertEquals(t, responseWriter.Body.String(), `{"id":0,"key":{"kty":"RSA","n":"qnARLrT7Xz4gRcKyLdydmCr-ey9OuPImX4X40thk3on26FkMznR3fRjs66eLK7mmPcBZ6uOJseURU6wAaZNmemoYx1dMvqvWWIyiQleHSD7Q8vBrhR6uIoO4jAzJZR-ChzZuSDt7iHN-3xUVspu5XGwXU_MVJZshTwp4TaFx5elHIT_ObnTvTOU3Xhish07AbgZKmWsVbXh5s-CrIicU4OexJPgunWZ_YJJueOKmTvnLlTV4MzKR2oZlBKZ27S0-SfdV_QDx_ydle5oMAyKVtlAV35cyPMIsYNwgUGBCdY_2Uzi5eX0lTc7MPRwz6qR1kip-i59VcGcUQgqHV6Fyqw","e":"AQAB"},"contact":["tel:123456789"],"agreement":"http://example.invalid/terms"}`)
 	var reg core.Registration
 	err = json.Unmarshal([]byte(responseWriter.Body.String()), &reg)
 	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")
 	test.Assert(t, len(reg.Contact) >= 1, "No contact field in registration")
 	test.AssertEquals(t, reg.Contact[0].String(), "tel:123456789")
+	test.AssertEquals(t, reg.Agreement, "http://example.invalid/terms")
+	test.AssertEquals(t, reg.InitialIP.String(), "1.1.1.1")
 
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Location"),
@@ -1315,11 +1316,7 @@ func TestLogCsrPem(t *testing.T) {
 
 	wfe.logCsr(req, certificateRequest, reg)
 
-	matches := mockLog.GetAllMatching("Certificate request")
-	test.Assert(t, len(matches) == 1,
-		"Incorrect number of certificate request log entries")
-	test.AssertEquals(t, matches[0].Priority, syslog.LOG_NOTICE)
-	test.AssertEquals(t, matches[0].Message, `[AUDIT] Certificate request JSON={"ClientAddr":"10.0.0.1,172.16.0.1,12.34.98.76","CsrBase64":"MIICWTCCAUECAQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAycX3ca+fViOuRWF38mssORISFxbJvspDfhPGRBZDxJ63NIqQzupB+6dp48xkcX7Z/KDaRJStcpJT2S0u33moNT4FHLklQBETLhExDk66cmlz6Xibp3LGZAwhWuec7wJoEwIgY8oq4rxihIyGq7HVIJoq9DqZGrUgfZMDeEJqbphukQOaXGEop7mD+eeu8+z5EVkB1LiJ6Yej6R8MAhVPHzG5fyOu6YVo6vY6QgwjRLfZHNj5XthxgPIEETZlUbiSoI6J19GYHvLURBTy5Ys54lYAPIGfNwcIBAH4gtH9FrYcDY68R22rp4iuxdvkf03ZWiT0F2W1y7/C9B2jayTzvQIDAQABoAAwDQYJKoZIhvcNAQELBQADggEBAHd6Do9DIZ2hvdt1GwBXYjsqprZidT/DYOMfYcK17KlvdkFT58XrBH88ulLZ72NXEpiFMeTyzfs3XEyGq/Bbe7TBGVYZabUEh+LOskYwhgcOuThVN7tHnH5rhN+gb7cEdysjTb1QL+vOUwYgV75CB6PE5JVYK+cQsMIVvo0Kz4TpNgjJnWzbcH7h0mtvub+fCv92vBPjvYq8gUDLNrok6rbg05tdOJkXsF2G/W+Q6sf2Fvx0bK5JeH4an7P7cXF9VG9nd4sRt5zd+L3IcyvHVKxNhIJXZVH0AOqh/1YrKI9R0QKQiZCEy0xN1okPlcaIVaFhb7IKAHPxTI3r5f72LXY=","Registration":{"id":789,"key":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"agreement":"http://example.invalid/terms"}}`)
+	assertCsrLogged(t, mockLog)
 }
 
 func TestLengthRequired(t *testing.T) {


### PR DESCRIPTION
In the process, add InitialIP and CreatedAt fields to registration objects, and
fix UpdateRegistration to try retrieving a registration before updating it.

Introduces a CountRegistrationsByIP method to SA.

Part of #70.