### PR TITLE
Actually run the missing SCT receipt loop

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -435,6 +435,7 @@ func main() {
 
 		go updater.newCertificatesLoop.loop()
 		go updater.oldOCSPResponsesLoop.loop()
+		go updater.missingSCTReceiptsLoop.loop()
 
 		cmd.FailOnError(err, "Failed to create updater")
 

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -189,6 +189,7 @@
   },
 
   "publisher": {
+    "maxConcurrentRPCServerRequests": 16,
     "debugAddr": "localhost:8009"
   },
 
@@ -208,8 +209,7 @@
       "submissionRetries": 1,
       "submissionBackoff": "1s",
       "intermediateBundleFilename": "test/test-ca.pem"
-    },
-    "maxConcurrentRPCServerRequests": 16
+    }
   },
 
   "certChecker": {


### PR DESCRIPTION
#897 added a CT backfill loop but didn't actually... uh... run it. This enables it and also moves the publisher `maxConcurrentRPCServerRequests` from the `Common` section (another #897 error, sorry) back to the proper `Publisher` section of the config.