### PR TITLE
Fix notification timing

### DIFF
--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -74,6 +74,17 @@ func newFakeRegStore() fakeRegStore {
 	return fakeRegStore{RegByID: make(map[int64]core.Registration)}
 }
 
+func newFakeClock(t *testing.T) clock.FakeClock {
+	const fakeTimeFormat = "2006-01-02T15:04:05.999999999Z"
+	ft, err := time.Parse(fakeTimeFormat, fakeTimeFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fc := clock.NewFake()
+	fc.Set(ft.UTC())
+	return fc
+}
+
 const testTmpl = `hi, cert for DNS names {{.DNSNames}} is going to expire in {{.DaysToExpiration}} days ({{.ExpirationDate}})`
 
 var (
@@ -95,8 +106,7 @@ func TestSendNags(t *testing.T) {
 	stats, _ := statsd.NewNoopClient(nil)
 	mc := mockMail{}
 	rs := newFakeRegStore()
-	fc := clock.NewFake()
-	fc.Add(7 * 24 * time.Hour)
+	fc := newFakeClock(t)
 
 	m := mailer{
 		stats:         stats,
@@ -120,14 +130,14 @@ func TestSendNags(t *testing.T) {
 	err := m.sendNags(cert, []*core.AcmeURL{email})
 	test.AssertNotError(t, err, "Failed to send warning messages")
 	test.AssertEquals(t, len(mc.Messages), 1)
-	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example.com is going to expire in 3 days (%s)`, cert.NotAfter), mc.Messages[0])
+	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example.com is going to expire in 2 days (%s)`, cert.NotAfter), mc.Messages[0])
 
 	mc.Clear()
 	err = m.sendNags(cert, []*core.AcmeURL{email, emailB})
 	test.AssertNotError(t, err, "Failed to send warning messages")
 	test.AssertEquals(t, len(mc.Messages), 2)
-	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example.com is going to expire in 3 days (%s)`, cert.NotAfter), mc.Messages[0])
-	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example.com is going to expire in 3 days (%s)`, cert.NotAfter), mc.Messages[1])
+	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example.com is going to expire in 2 days (%s)`, cert.NotAfter), mc.Messages[0])
+	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example.com is going to expire in 2 days (%s)`, cert.NotAfter), mc.Messages[1])
 
 	mc.Clear()
 	err = m.sendNags(cert, []*core.AcmeURL{})
@@ -149,8 +159,6 @@ var testKey = rsa.PrivateKey{
 
 func TestFindExpiringCertificates(t *testing.T) {
 	ctx := setup(t, []time.Duration{time.Hour * 24, time.Hour * 24 * 4, time.Hour * 24 * 7})
-
-	ctx.fc.Add(7 * 24 * time.Hour)
 
 	log.Clear()
 	err := ctx.m.findExpiringCertificates()
@@ -213,7 +221,7 @@ func TestFindExpiringCertificates(t *testing.T) {
 		Status:                core.OCSPStatusGood,
 	}
 
-	// Expires in 3d, already sent 4d nag
+	// Expires in 3d, already sent 4d nag at 4.5d
 	rawCertB := x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: "happy B",
@@ -231,16 +239,16 @@ func TestFindExpiringCertificates(t *testing.T) {
 	}
 	certStatusB := &core.CertificateStatus{
 		Serial:                "002",
-		LastExpirationNagSent: ctx.fc.Now().Add(-23 * time.Hour),
+		LastExpirationNagSent: ctx.fc.Now().Add(-36 * time.Hour),
 		Status:                core.OCSPStatusGood,
 	}
 
-	// Expires in exactly 7d, no nag sent at all yet
+	// Expires in 7d and change, no nag sent at all yet
 	rawCertC := x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: "happy C",
 		},
-		NotAfter:     ctx.fc.Now().AddDate(0, 0, 7),
+		NotAfter:     ctx.fc.Now().Add((7*24 + 1) * time.Hour),
 		DNSNames:     []string{"example-c.com"},
 		SerialNumber: big.NewInt(1337),
 	}
@@ -276,7 +284,7 @@ func TestFindExpiringCertificates(t *testing.T) {
 	// Should get 001 and 003
 	test.AssertEquals(t, len(ctx.mc.Messages), 2)
 
-	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example-a.com is going to expire in 1 days (%s)`, rawCertA.NotAfter.UTC().Format("2006-01-02 15:04:05 -0700 MST")), ctx.mc.Messages[0])
+	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example-a.com is going to expire in 0 days (%s)`, rawCertA.NotAfter.UTC().Format("2006-01-02 15:04:05 -0700 MST")), ctx.mc.Messages[0])
 	test.AssertEquals(t, fmt.Sprintf(`hi, cert for DNS names example-c.com is going to expire in 7 days (%s)`, rawCertC.NotAfter.UTC().Format("2006-01-02 15:04:05 -0700 MST")), ctx.mc.Messages[1])
 
 	// A consecutive run shouldn't find anything
@@ -344,28 +352,28 @@ func TestLifetimeOfACert(t *testing.T) {
 	}
 	tests := []lifeTest{
 		{
-			timeLeft: 8 * 24 * time.Hour, // 8 days before expiration
+			timeLeft: 9 * 24 * time.Hour, // 9 days before expiration
 
 			numMsgs: 0,
 			context: "Expected no emails sent because we are more than 7 days out.",
 		},
 		{
-			7 * 24 * time.Hour, // 7 days before
+			(7*24 + 12) * time.Hour, // 7.5 days before
 			1,
 			"Sent 1 for 7 day notice.",
 		},
 		{
-			5 * 24 * time.Hour,
+			7 * 24 * time.Hour,
 			1,
 			"The 7 day email was already sent.",
 		},
 		{
-			(4*24 - 1) * time.Hour, // <4 days before, the mailer was run late
+			(4*24 - 1) * time.Hour, // <4 days before, the mailer did not run yesterday
 			2,
 			"Sent 1 for the 7 day notice, and 1 for the 4 day notice.",
 		},
 		{
-			24 * time.Hour,
+			36 * time.Hour, // within 1day + nagMargin
 			3,
 			"Sent 1 for the 7 day notice, 1 for the 4 day notice, and 1 for the 1 day notice.",
 		},
@@ -466,7 +474,7 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 	if err != nil {
 		t.Fatalf("Couldn't connect the database: %s", err)
 	}
-	fc := clock.NewFake()
+	fc := newFakeClock(t)
 	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -484,6 +484,11 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 	stats, _ := statsd.NewNoopClient(nil)
 	mc := &mockMail{}
 
+	offsetNags := make([]time.Duration, len(nagTimes))
+	for i, t := range nagTimes {
+		offsetNags[i] = t + defaultNagCheckInterval
+	}
+
 	m := &mailer{
 		log:           blog.GetAuditLogger(),
 		stats:         stats,
@@ -491,7 +496,7 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 		emailTemplate: tmpl,
 		dbMap:         dbMap,
 		rs:            ssa,
-		nagTimes:      nagTimes,
+		nagTimes:      offsetNags,
 		limit:         100,
 		clk:           fc,
 	}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -154,6 +154,10 @@ type Config struct {
 
 		CertLimit int
 		NagTimes  []string
+		// How much earlier (than configured nag intervals) to
+		// send reminders, to account for the expected delay
+		// before the next expiration-mailer invocation.
+		NagCheckInterval string
 		// Path to a text/template email template
 		EmailTemplate string
 

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -188,6 +188,7 @@
     "dbConnect": "mysql+tcp://mailer@localhost:3306/boulder_sa_integration",
     "messageLimit": 0,
     "nagTimes": ["24h", "72h", "168h", "336h"],
+    "nagCheckInterval": "24h",
     "emailTemplate": "test/example-expiration-template",
     "debugAddr": "localhost:8008"
   },


### PR DESCRIPTION
Fix #710

Add 24h padding to configured nag times. Now you can configure a 24h reminder, run expiration-mailer only once per day, and expect emails to be sent _at least_ 24h before expiry and say "expires in 1 day". (Before, the email said "1 day", but might have been sent just 5 minutes before expiry.)

Fix "was this nag already sent?" bug: if you have nags configured at 7d and 4d, your 4d nags will no longer be delayed until 3.5d.
