### PR TITLE
change run-docker.sh to use bash not docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ in a Docker container, run:
 
     ./test/run-docker.sh
 
-**NOTE:** You will need to have `docker-compose` installed locally. Directions
-for installing can be found at [docs.docker.com/compose/install](https://docs.docker.com/compose/install/).
-
 Slow start
 ----------
 

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -5,9 +5,15 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # start rsyslog
 service rsyslog start &&
 
-# wait until the mysql instance has started fully
-# this is awful
-sleep 5
+# make sure we can reach the mysqldb
+# see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
+while ! exec 6<>/dev/tcp/0.0.0.0/3306; do
+    echo "$(date) - still trying to connect to mysql at 0.0.0.0:3306"
+    sleep 1
+done
+
+exec 6>&-
+exec 6<&-
 
 # create the database
 source $DIR/create_db.sh

--- a/test/run-docker.sh
+++ b/test/run-docker.sh
@@ -13,18 +13,66 @@
 set -o errexit
 cd $(dirname $0)/..
 
+# helper function to return the state of the container (true if running, false if not)
+is_running(){
+	local name=$1
+	local state=$(docker inspect --format "{{.State.Running}}" $name 2>/dev/null)
+
+	if [[ "$state" == "false" ]]; then
+		# the container is up but not running
+		# we should remove it so we can bring up another
+		docker rm $name
+	fi
+	echo $state
+}
+
+# helper function to get boot2docker ip if we are on a mac
+hostip=0.0.0.0
+if command -v boot2docker >/dev/null 2>&1 ; then
+	hostip="$(boot2docker ip)"
+fi
+# if the DOCKER_HOST variable exists, lets get the host ip from that
+if [[ ! -z "$DOCKER_HOST" ]]; then
+	hostip="$(echo $DOCKER_HOST | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}')"
+fi
+
 # In order to talk to a letsencrypt client running on the host, the fake DNS
 # client used in Boulder's start.py needs to know what the host's IP is from the
 # perspective of the container. We try to figure it out automatically. If you'd
 # like your Boulder instance to always talk to some other host, you can set
 # FAKE_DNS to that host's IP address.
 if [ -z "${FAKE_DNS}" ] ; then
-  FAKE_DNS=$(ifconfig docker0 | sed -n 's/ *inet addr:\([0-9.]\+\).*/\1/p')
+  FAKE_DNS=$(/sbin/ifconfig docker0 | sed -n 's/ *inet addr:\([0-9.]\+\).*/\1/p')
 fi
 
-# build the docker images
-docker-compose build
+if [[ "$(is_running boulder-mysql)" != "true" ]]; then
+	# bring up mysql mariadb container
+	docker run -d \
+		--net host \
+		-p 3306:3306 \
+		-e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+		--name boulder-mysql \
+		mariadb:10
+fi
 
+if [[ "$(is_running boulder-rabbitmq)" != "true" ]]; then
+	# bring up rabbitmq container
+	docker run -d \
+		--net host \
+		-p 5672:5672 \
+		--name boulder-rabbitmq \
+		rabbitmq:3
+fi
+
+# build the boulder docker image
+docker build --rm --force-rm -t letsencrypt/boulder .
+
+# run the boulder container
 # The excluding `-d` command makes the instance interactive, so you can kill
-# all containers with Ctrl-C.
-docker-compose up
+# the boulder container with Ctrl-C.
+docker run --rm -it \
+	--net host \
+	-p 4000:4000 \
+	-e MYSQL_CONTAINER=yes \
+	--name boulder \
+	letsencrypt/boulder


### PR DESCRIPTION
if someone could try this on a mac that would be great, but works on linux locally for me, tried to include the `boot2docker ip` stuff for checking if a database is running, etc

but i'm definitely not a b2d expert lol and I don't have a mac to test it