### PR TITLE
Stop offering insecure challenges

### DIFF
--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -206,8 +206,6 @@ func (pa PolicyAuthorityImpl) WillingToIssue(id core.AcmeIdentifier, regID int64
 func (pa PolicyAuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier, accountKey *jose.JsonWebKey) (challenges []core.Challenge, combinations [][]int, err error) {
 	// TODO(https://github.com/letsencrypt/boulder/issues/894): Update these lines
 	challenges = []core.Challenge{
-		core.SimpleHTTPChallenge(accountKey),
-		core.DvsniChallenge(accountKey),
 		core.HTTPChallenge01(accountKey),
 		core.TLSSNIChallenge01(accountKey),
 	}

--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -209,6 +209,6 @@ func (pa PolicyAuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier, acco
 		core.HTTPChallenge01(accountKey),
 		core.TLSSNIChallenge01(accountKey),
 	}
-	combinations = [][]int{[]int{0}, []int{1}, []int{2}, []int{3}}
+	combinations = [][]int{[]int{0}, []int{1}}
 	return
 }

--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -208,16 +208,13 @@ func TestChallengesFor(t *testing.T) {
 	}
 
 	// TODO(https://github.com/letsencrypt/boulder/issues/894): Update these tests
-	if len(challenges) != 4 ||
-		challenges[0].Type != core.ChallengeTypeSimpleHTTP ||
-		challenges[1].Type != core.ChallengeTypeDVSNI ||
-		challenges[2].Type != core.ChallengeTypeHTTP01 ||
-		challenges[3].Type != core.ChallengeTypeTLSSNI01 {
+	if len(challenges) != 2 ||
+		challenges[0].Type != core.ChallengeTypeHTTP01 ||
+		challenges[1].Type != core.ChallengeTypeTLSSNI01 {
 		t.Error("Incorrect challenges returned")
 	}
-	if len(combinations) != 4 ||
-		combinations[0][0] != 0 || combinations[1][0] != 1 ||
-		combinations[2][0] != 2 || combinations[3][0] != 3 {
+	if len(combinations) != 2 ||
+		combinations[0][0] != 0 || combinations[1][0] != 1 {
 		t.Error("Incorrect combinations returned")
 	}
 }

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -390,21 +390,12 @@ func TestNewAuthorization(t *testing.T) {
 	test.Assert(t, authz.Status == core.StatusPending, "Initial authz not pending")
 
 	// TODO Verify that challenges are correct
-	// TODO(https://github.com/letsencrypt/boulder/issues/894): Update these lines
-	test.Assert(t, len(authz.Challenges) == 4, "Incorrect number of challenges returned")
-	test.Assert(t, authz.Challenges[0].Type == core.ChallengeTypeSimpleHTTP, "Challenge 0 not SimpleHTTP")
-	test.Assert(t, authz.Challenges[1].Type == core.ChallengeTypeDVSNI, "Challenge 1 not DVSNI")
-
-	// TODO(https://github.com/letsencrypt/boulder/issues/894): Delete these lines
-	test.Assert(t, authz.Challenges[2].Type == core.ChallengeTypeHTTP01, "Challenge 2 not http-00")
-	test.Assert(t, authz.Challenges[3].Type == core.ChallengeTypeTLSSNI01, "Challenge 3 not tlssni-00")
+	test.Assert(t, len(authz.Challenges) == 2, "Incorrect number of challenges returned")
+	test.Assert(t, authz.Challenges[0].Type == core.ChallengeTypeHTTP01, "Challenge 0 not http-00")
+	test.Assert(t, authz.Challenges[1].Type == core.ChallengeTypeTLSSNI01, "Challenge 1 not tlssni-00")
 
 	test.Assert(t, authz.Challenges[0].IsSane(false), "Challenge 0 is not sane")
 	test.Assert(t, authz.Challenges[1].IsSane(false), "Challenge 1 is not sane")
-
-	// TODO(https://github.com/letsencrypt/boulder/issues/894): Delete these lines
-	test.Assert(t, authz.Challenges[2].IsSane(false), "Challenge 2 is not sane")
-	test.Assert(t, authz.Challenges[3].IsSane(false), "Challenge 3 is not sane")
 
 	t.Log("DONE TestNewAuthorization")
 }


### PR DESCRIPTION
This is a first step toward fixing #894.  First we need to stop offering insecure challenges, then we can remove support for them altogether.