### PR TITLE
Install missing port forwarder (listenbuddy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y \
 # Boulder exposes its web application at port TCP 4000
 EXPOSE 4000
 
+# Install port forwarder
+RUN go get github.com/jsha/listenbuddy
 # get database migration tool
 RUN go get bitbucket.org/liamstask/goose/cmd/goose
 # install go lint


### PR DESCRIPTION
Fixes #1059.

Although @jsha has a good point regarding `install-dependencies.sh` script, I tried to make this patch as small as possible in order to avoid potential conflicts with other ongoing changes.