### PR TITLE
Fix localhost mysql

### DIFF
--- a/test/policy_db_users.sql
+++ b/test/policy_db_users.sql
@@ -19,8 +19,8 @@
 -- and the CA and RA (for reads). So right now we have the one user that has
 -- both read and write permission, even though it would be better to give only
 -- read permission to CA and RA.
-GRANT SELECT,INSERT,DELETE ON blacklist TO 'policy'@'127.0.0.1';
-GRANT SELECT,INSERT,DELETE ON whitelist TO 'policy'@'127.0.0.1';
+GRANT SELECT,INSERT,DELETE ON blacklist TO 'policy'@'localhost';
+GRANT SELECT,INSERT,DELETE ON whitelist TO 'policy'@'localhost';
 
 -- Test setup and teardown
-GRANT ALL PRIVILEGES ON * to 'test_setup'@'127.0.0.1';
+GRANT ALL PRIVILEGES ON * to 'test_setup'@'localhost';

--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -15,43 +15,43 @@
 -- the user exists and then drop the user.
 
 -- Storage Authority
-GRANT SELECT,INSERT,UPDATE ON authz TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT,UPDATE,DELETE ON pendingAuthorizations TO 'sa'@'127.0.0.1';
-GRANT SELECT(id,Lockcol) ON pendingAuthorizations TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT ON certificates TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT,UPDATE ON certificateStatus TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT ON issuedNames TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT ON sctReceipts TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT ON deniedCSRs TO 'sa'@'127.0.0.1';
-GRANT INSERT ON ocspResponses TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT,UPDATE ON registrations TO 'sa'@'127.0.0.1';
-GRANT SELECT,INSERT,UPDATE ON challenges TO 'sa'@'127.0.0.1';
+GRANT SELECT,INSERT,UPDATE ON authz TO 'sa'@'localhost';
+GRANT SELECT,INSERT,UPDATE,DELETE ON pendingAuthorizations TO 'sa'@'localhost';
+GRANT SELECT(id,Lockcol) ON pendingAuthorizations TO 'sa'@'localhost';
+GRANT SELECT,INSERT ON certificates TO 'sa'@'localhost';
+GRANT SELECT,INSERT,UPDATE ON certificateStatus TO 'sa'@'localhost';
+GRANT SELECT,INSERT ON issuedNames TO 'sa'@'localhost';
+GRANT SELECT,INSERT ON sctReceipts TO 'sa'@'localhost';
+GRANT SELECT,INSERT ON deniedCSRs TO 'sa'@'localhost';
+GRANT INSERT ON ocspResponses TO 'sa'@'localhost';
+GRANT SELECT,INSERT,UPDATE ON registrations TO 'sa'@'localhost';
+GRANT SELECT,INSERT,UPDATE ON challenges TO 'sa'@'localhost';
 
 -- OCSP Responder
-GRANT SELECT ON certificateStatus TO 'ocsp_resp'@'127.0.0.1';
-GRANT SELECT ON ocspResponses TO 'ocsp_resp'@'127.0.0.1';
+GRANT SELECT ON certificateStatus TO 'ocsp_resp'@'localhost';
+GRANT SELECT ON ocspResponses TO 'ocsp_resp'@'localhost';
 
 -- OCSP Generator Tool (Updater)
-GRANT INSERT ON ocspResponses TO 'ocsp_update'@'127.0.0.1';
-GRANT SELECT ON certificates TO 'ocsp_update'@'127.0.0.1';
-GRANT SELECT,UPDATE ON certificateStatus TO 'ocsp_update'@'127.0.0.1';
-GRANT SELECT ON sctReceipts TO 'ocsp_update'@'127.0.0.1';
+GRANT INSERT ON ocspResponses TO 'ocsp_update'@'localhost';
+GRANT SELECT ON certificates TO 'ocsp_update'@'localhost';
+GRANT SELECT,UPDATE ON certificateStatus TO 'ocsp_update'@'localhost';
+GRANT SELECT ON sctReceipts TO 'ocsp_update'@'localhost';
 
 -- Revoker Tool
-GRANT SELECT ON registrations TO 'revoker'@'127.0.0.1';
-GRANT SELECT ON certificates TO 'revoker'@'127.0.0.1';
-GRANT SELECT,INSERT ON deniedCSRs TO 'revoker'@'127.0.0.1';
+GRANT SELECT ON registrations TO 'revoker'@'localhost';
+GRANT SELECT ON certificates TO 'revoker'@'localhost';
+GRANT SELECT,INSERT ON deniedCSRs TO 'revoker'@'localhost';
 
 -- External Cert Importer
-GRANT SELECT,INSERT,UPDATE,DELETE ON identifierData TO 'importer'@'127.0.0.1';
-GRANT SELECT,INSERT,UPDATE,DELETE ON externalCerts TO 'importer'@'127.0.0.1';
+GRANT SELECT,INSERT,UPDATE,DELETE ON identifierData TO 'importer'@'localhost';
+GRANT SELECT,INSERT,UPDATE,DELETE ON externalCerts TO 'importer'@'localhost';
 
 -- Expiration mailer
-GRANT SELECT ON certificates TO 'mailer'@'127.0.0.1';
-GRANT SELECT,UPDATE ON certificateStatus TO 'mailer'@'127.0.0.1';
+GRANT SELECT ON certificates TO 'mailer'@'localhost';
+GRANT SELECT,UPDATE ON certificateStatus TO 'mailer'@'localhost';
 
 -- Cert checker
-GRANT SELECT ON certificates TO 'cert_checker'@'127.0.0.1';
+GRANT SELECT ON certificates TO 'cert_checker'@'localhost';
 
 -- Test setup and teardown
-GRANT ALL PRIVILEGES ON * to 'test_setup'@'127.0.0.1';
+GRANT ALL PRIVILEGES ON * to 'test_setup'@'localhost';


### PR DESCRIPTION
Specifying MySQL grants @'127.0.0.1' is liable to break when used on a
host which specifies localhost as resolving to ::1 as well as 127.0.0.1.
This causes test failure on some systems.

This change ensures that the test database creation scripts enable
connection from ::1.

e.g.:

    mysql -u sa boulder_sa_integration -h ::1