### PR TITLE
check for wfe port liveness in integration tests

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -102,7 +102,8 @@ def start(race_detection):
             # If one of the servers has died, quit immediately.
             if not check():
                 return False
-            for debug_port in range(8000, 8005):
+            ports = range(8000, 8005) + [4000]
+            for debug_port in ports:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.connect(('localhost', debug_port))
                 s.close()


### PR DESCRIPTION
We're getting many more spurious "Can't connect to WFE" errors in TravisCI. So, we add the WFE's main port to the port liveness check in amqp-integration-test.py.

Fixes #1099