### PR TITLE
fix integration by changing pip install

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -125,7 +125,7 @@ function build_letsencrypt() {
   run virtualenv --no-site-packages -p $PY ./venv
   run ./venv/bin/pip install -U setuptools
   run ./venv/bin/pip install -U pip
-  run ./venv/bin/pip install -r requirements.txt -e acme -e . -e letsencrypt-apache -e letsencrypt-nginx
+  run ./venv/bin/pip install -e acme -e . -e letsencrypt-apache -e letsencrypt-nginx
 
   cd -
 }


### PR DESCRIPTION
The letsencrypt repo renamed its requirements.txt and I'm told we don't actually need to use it.

Fixes #1105