### PR TITLE
move sourcing of activate into test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -127,6 +127,8 @@ function build_letsencrypt() {
   run ./venv/bin/pip install -U pip
   run ./venv/bin/pip install -e acme -e . -e letsencrypt-apache -e letsencrypt-nginx
 
+  source ./venv/bin/activate
+
   cd -
 }
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -209,7 +209,7 @@ def run_client_tests():
         "Please set LETSENCRYPT_PATH env variable to point at "
         "initialized (virtualenv) client repo root")
     test_script_path = os.path.join(root, 'tests', 'boulder-integration.sh')
-    cmd = "source %s/venv/bin/activate && SIMPLE_HTTP_PORT=5002 %s" % (root, test_script_path)
+    cmd = "SIMPLE_HTTP_PORT=5002 %s" % (test_script_path)
     if subprocess.Popen(cmd, shell=True, cwd=root, executable='/bin/bash').wait() != 0:
         die(ExitStatus.PythonFailure)
 


### PR DESCRIPTION
This gets us closer to allowing the client repo to use integration-test.py. They have a different path without "venv" in it for their virtualenv set up.

Updates #1101