### PR TITLE
Add RPC server processing metrics and rename client RPC metrics

### DIFF
--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -653,13 +653,11 @@ func (rpc *AmqpRPCCLient) DispatchSync(method string, body []byte) (response []b
 			rpc.stats.Inc(fmt.Sprintf("RPC.ClientCallLatency.%s.Error", method), 1, 1.0)
 			return
 		}
-		rpc.stats.Inc("RPC.Rate.Success", 1, 1.0)
 		rpc.stats.TimingDuration(fmt.Sprintf("RPC.ClientCallLatency.%s.Success", method), time.Since(callStarted), 1.0)
 		response = rpcResponse.ReturnVal
 		return
 	case <-time.After(rpc.timeout):
 		rpc.stats.TimingDuration(fmt.Sprintf("RPC.ClientCallLatency.%s.Timeout", method), time.Since(callStarted), 1.0)
-		rpc.stats.Inc("RPC.Rate.Timeouts", 1, 1.0)
 		rpc.log.Warning(fmt.Sprintf(" [c!][%s] AMQP-RPC timeout [%s]", rpc.clientQueue, method))
 		rpc.mu.Lock()
 		delete(rpc.pending, corrID)


### PR DESCRIPTION
Adds a few new server side RPC metrics to balance out the client side ones, also renames the latter metrics to specify they come from the client side. I've also removed the `RPC.CallsWaiting` metric since (at least locally) because of how gauges work it was completely useless and the `RPC.Rate` metric since it can be deduced from the `RPC.Traffic.{Tx/Rx}` metric.

Fixes #1116 -- GA under the auspices of #20.