### PR TITLE
Don't serve 500's on DNS timeout.

### DIFF
--- a/dns/problem.go
+++ b/dns/problem.go
@@ -1,0 +1,34 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/letsencrypt/boulder/core"
+)
+
+const detailDNSTimeout = "DNS query timed out"
+const detailTemporaryError = "Temporary network connectivity error"
+const detailDNSNetFailure = "DNS networking error"
+const detailServerFailure = "Server failure at resolver"
+
+// ProblemDetailsFromDNSError checks the error returned from Lookup...
+// methods and tests if the error was an underlying net.OpError or an error
+// caused by resolver returning SERVFAIL or other invalid Rcodes and returns
+// the relevant core.ProblemDetails.
+func ProblemDetailsFromDNSError(err error) *core.ProblemDetails {
+	problem := &core.ProblemDetails{Type: core.ConnectionProblem}
+	if netErr, ok := err.(*net.OpError); ok {
+		if netErr.Timeout() {
+			problem.Detail = detailDNSTimeout
+		} else if netErr.Temporary() {
+			problem.Detail = detailTemporaryError
+		} else {
+			problem.Detail = detailDNSNetFailure
+		}
+	} else {
+		problem.Detail = detailServerFailure
+	}
+	fmt.Println(problem)
+	return problem
+}

--- a/dns/problem.go
+++ b/dns/problem.go
@@ -1,14 +1,12 @@
 package dns
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/letsencrypt/boulder/core"
 )
 
 const detailDNSTimeout = "DNS query timed out"
-const detailTemporaryError = "Temporary network connectivity error"
 const detailDNSNetFailure = "DNS networking error"
 const detailServerFailure = "Server failure at resolver"
 
@@ -21,14 +19,11 @@ func ProblemDetailsFromDNSError(err error) *core.ProblemDetails {
 	if netErr, ok := err.(*net.OpError); ok {
 		if netErr.Timeout() {
 			problem.Detail = detailDNSTimeout
-		} else if netErr.Temporary() {
-			problem.Detail = detailTemporaryError
 		} else {
 			problem.Detail = detailDNSNetFailure
 		}
 	} else {
 		problem.Detail = detailServerFailure
 	}
-	fmt.Println(problem)
 	return problem
 }

--- a/dns/problem_test.go
+++ b/dns/problem_test.go
@@ -1,0 +1,37 @@
+package dns
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/mocks"
+)
+
+func TestProblemDetailsFromDNSError(t *testing.T) {
+	testCases := []struct {
+		err      error
+		expected string
+	}{
+		{
+			mocks.TimeoutError(),
+			detailDNSTimeout,
+		}, {
+			errors.New("other failure"),
+			detailServerFailure,
+		}, {
+			&net.OpError{Err: errors.New("some net error")},
+			detailDNSNetFailure,
+		},
+	}
+	for _, tc := range testCases {
+		err := ProblemDetailsFromDNSError(tc.err)
+		if err.Type != core.ConnectionProblem {
+			t.Errorf("ProblemDetailsFromDNSError(%q).Type = %q, expected %q", tc.err, err.Type, core.ConnectionProblem)
+		}
+		if err.Detail != tc.expected {
+			t.Errorf("ProblemDetailsFromDNSError(%q).Detail = %q, expected %q", tc.err, err.Detail, tc.expected)
+		}
+	}
+}

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -221,7 +221,7 @@ func (ra *RegistrationAuthorityImpl) validateContacts(contacts []*core.AcmeURL) 
 			continue
 		case "mailto":
 			rtt, err := validateEmail(contact.Opaque, ra.DNSResolver)
-			ra.stats.TimingDuration("RA.DNS.RTT", rtt, 1.0)
+			ra.stats.TimingDuration("RA.DNS.RTT.A", rtt, 1.0)
 			ra.stats.Inc("RA.DNS.Rate", 1, 1.0)
 			if err != nil {
 				return core.MalformedRequestError(fmt.Sprintf(

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -77,19 +77,27 @@ func NewRegistrationAuthorityImpl(clk clock.Clock, logger *blog.AuditLogger, sta
 	return ra
 }
 
+var errUnparseableEmail = errors.New("not a valid e-mail address")
+var errEmptyDNSResponse = errors.New("empty DNS response")
+var errDNSTimeout = errors.New("DNS timeout")
+var errDNSError = errors.New("DNS error")
+
 func validateEmail(address string, resolver core.DNSResolver) (rtt time.Duration, err error) {
 	_, err = mail.ParseAddress(address)
 	if err != nil {
-		err = core.MalformedRequestError(fmt.Sprintf("%s is not a valid e-mail address", address))
-		return
+		return time.Duration(0), errUnparseableEmail
 	}
 	splitEmail := strings.SplitN(address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])
-	var mx []string
-	mx, rtt, err = resolver.LookupMX(domain)
-	if err != nil || len(mx) == 0 {
-		err = core.MalformedRequestError(fmt.Sprintf("No MX record for domain %s", domain))
-		return
+	result, rtt, err := resolver.LookupHost(domain)
+	if err == nil && len(result) == 0 {
+		err = errEmptyDNSResponse
+	}
+	if opErr, ok := err.(*net.OpError); ok && opErr != nil && opErr.Timeout() {
+		err = errDNSTimeout
+	}
+	if _, ok := err.(*net.OpError); ok {
+		err = errDNSError
 	}
 
 	return
@@ -216,10 +224,11 @@ func (ra *RegistrationAuthorityImpl) validateContacts(contacts []*core.AcmeURL) 
 			continue
 		case "mailto":
 			rtt, err := validateEmail(contact.Opaque, ra.DNSResolver)
-			ra.stats.TimingDuration("RA.DNS.RTT.MX", rtt, 1.0)
+			ra.stats.TimingDuration("RA.DNS.RTT", rtt, 1.0)
 			ra.stats.Inc("RA.DNS.Rate", 1, 1.0)
 			if err != nil {
-				return err
+				return core.MalformedRequestError(fmt.Sprintf(
+					"Validation of contact %s failed: %s", contact, err))
 			}
 		default:
 			err = core.MalformedRequestError(fmt.Sprintf("Contact method %s is not supported", contact.Scheme))
@@ -279,18 +288,6 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(request core.Authorization
 		if !isSafe {
 			return authz, core.UnauthorizedError(fmt.Sprintf("%#v was considered an unsafe domain by a third-party API", identifier.Value))
 		}
-	}
-
-	// Check CAA records for the requested identifier
-	present, valid, err := ra.VA.CheckCAARecords(identifier)
-	if err != nil {
-		return authz, err
-	}
-	// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
-	ra.log.Audit(fmt.Sprintf("Checked CAA records for %s, registration ID %d [Present: %t, Valid for issuance: %t]", identifier.Value, regID, present, valid))
-	if !valid {
-		err = errors.New("CAA check for identifier failed")
-		return authz, err
 	}
 
 	// Create validations. The WFE will  update them with URIs before sending them out.

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -297,26 +297,28 @@ func TestValidateContacts(t *testing.T) {
 	test.AssertError(t, err, "Malformed Email")
 
 	err = ra.validateContacts([]*core.AcmeURL{ansible})
-	test.AssertError(t, err, "Unknown scehme")
+	test.AssertError(t, err, "Unknown scheme")
 }
 
 func TestValidateEmail(t *testing.T) {
 	testCases := []struct {
 		input    string
-		expected error
+		expected string
 	}{
-		{"an email`", errUnparseableEmail},
-		{"a@always.invalid", errEmptyDNSResponse},
-		{"a@always.timeout", errDNSTimeout},
-		{"a@always.error", errDNSError},
-		{"a@email.com", nil},
+		{"an email`", errUnparseableEmail.Error()},
+		{"a@always.invalid", "Server failure at resolver"},
+		{"a@always.timeout", "DNS query timed out"},
+		{"a@always.error", "DNS networking error"},
 	}
 	for _, tc := range testCases {
 		_, err := validateEmail(tc.input, &mocks.DNSResolver{})
-		if err != tc.expected {
+		if err.Error() != tc.expected {
 			t.Errorf("validateEmail(%q): got %#v, expected %#v",
 				tc.input, err, tc.expected)
 		}
+	}
+	if _, err := validateEmail("a@email.com", &mocks.DNSResolver{}); err != nil {
+		t.Errorf("Expected a@email.com to validate, but it failed: %s", err)
 	}
 }
 

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -11,7 +11,6 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -31,14 +30,9 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-const maxCNAME = 16 // Prevents infinite loops. Same limit as BIND.
 const maxRedirect = 10
 
 var validationTimeout = time.Second * 5
-
-// ErrTooManyCNAME is returned by CheckCAARecords if it has to follow too many
-// consecutive CNAME lookups.
-var ErrTooManyCNAME = errors.New("too many CNAME/DNAME lookups")
 
 // ValidationAuthorityImpl represents a VA
 type ValidationAuthorityImpl struct {
@@ -124,6 +118,10 @@ func verifyValidationJWS(validation *jose.JsonWebSignature, accountKey *jose.Jso
 	return nil
 }
 
+const detailDNSTimeout = "DNS query timed out"
+const detailTemporaryError = "Temporary network connectivity error"
+const detailServerFailure = "Server failure at resolver"
+
 // problemDetailsFromDNSError checks the error returned from Lookup...
 // methods and tests if the error was an underlying net.OpError or an error
 // caused by resolver returning SERVFAIL or other invalid Rcodes and returns
@@ -132,12 +130,12 @@ func problemDetailsFromDNSError(err error) *core.ProblemDetails {
 	problem := &core.ProblemDetails{Type: core.ConnectionProblem}
 	if netErr, ok := err.(*net.OpError); ok {
 		if netErr.Timeout() {
-			problem.Detail = "DNS query timed out"
+			problem.Detail = detailDNSTimeout
 		} else if netErr.Temporary() {
-			problem.Detail = "Temporary network connectivity error"
+			problem.Detail = detailTemporaryError
 		}
 	} else {
-		problem.Detail = "Server failure at resolver"
+		problem.Detail = detailServerFailure
 	}
 	return problem
 }
@@ -640,6 +638,24 @@ func (va *ValidationAuthorityImpl) validateDNS01(identifier core.AcmeIdentifier,
 	return challenge, challenge.Error
 }
 
+func (va *ValidationAuthorityImpl) checkCAA(identifier core.AcmeIdentifier, regID int64) *core.ProblemDetails {
+	// Check CAA records for the requested identifier
+	present, valid, err := va.CheckCAARecords(identifier)
+	if err != nil {
+		va.log.Warning(fmt.Sprintf("Problem checking CAA: %s", err))
+		return problemDetailsFromDNSError(err)
+	}
+	// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
+	va.log.Audit(fmt.Sprintf("Checked CAA records for %s, registration ID %d [Present: %t, Valid for issuance: %t]", identifier.Value, regID, present, valid))
+	if !valid {
+		return &core.ProblemDetails{
+			Type:   core.ConnectionProblem,
+			Detail: "CAA check for identifier failed",
+		}
+	}
+	return nil
+}
+
 // Overall validation process
 
 func (va *ValidationAuthorityImpl) validate(authz core.Authorization, challengeIndex int) {
@@ -659,20 +675,7 @@ func (va *ValidationAuthorityImpl) validate(authz core.Authorization, challengeI
 		var err error
 
 		vStart := va.clk.Now()
-		switch authz.Challenges[challengeIndex].Type {
-		case core.ChallengeTypeSimpleHTTP:
-			// TODO(https://github.com/letsencrypt/boulder/issues/894): Delete this case
-			authz.Challenges[challengeIndex], err = va.validateSimpleHTTP(authz.Identifier, authz.Challenges[challengeIndex])
-		case core.ChallengeTypeDVSNI:
-			// TODO(https://github.com/letsencrypt/boulder/issues/894): Delete this case
-			authz.Challenges[challengeIndex], err = va.validateDvsni(authz.Identifier, authz.Challenges[challengeIndex])
-		case core.ChallengeTypeHTTP01:
-			authz.Challenges[challengeIndex], err = va.validateHTTP01(authz.Identifier, authz.Challenges[challengeIndex])
-		case core.ChallengeTypeTLSSNI01:
-			authz.Challenges[challengeIndex], err = va.validateTLSSNI01(authz.Identifier, authz.Challenges[challengeIndex])
-		case core.ChallengeTypeDNS01:
-			authz.Challenges[challengeIndex], err = va.validateDNS01(authz.Identifier, authz.Challenges[challengeIndex])
-		}
+		authz.Challenges[challengeIndex], err = va.validateChallengeAndCAA(authz.Identifier, authz.Challenges[challengeIndex], authz.RegistrationID)
 		va.stats.TimingDuration(fmt.Sprintf("VA.Validations.%s.%s", authz.Challenges[challengeIndex].Type, authz.Challenges[challengeIndex].Status), time.Since(vStart), 1.0)
 
 		if err != nil {
@@ -693,6 +696,42 @@ func (va *ValidationAuthorityImpl) validate(authz core.Authorization, challengeI
 	va.log.Notice(fmt.Sprintf("Validations: %+v", authz))
 
 	va.RA.OnValidationUpdate(authz)
+}
+
+func (va *ValidationAuthorityImpl) validateChallengeAndCAA(identifier core.AcmeIdentifier, challenge core.Challenge, regID int64) (core.Challenge, error) {
+	result, err := va.validateChallenge(identifier, challenge)
+	if err != nil {
+		return result, err
+	}
+
+	// Checking CAA happens after challenge validation because DNS errors affect
+	// both, and giving a DNS error on validation makes more sense than a DNS
+	// error on CAA.
+	problemDetails := va.checkCAA(identifier, regID)
+	if problemDetails != nil {
+		challenge.Error = problemDetails
+		challenge.Status = core.StatusInvalid
+		return result, problemDetails
+	}
+	return result, nil
+}
+
+func (va *ValidationAuthorityImpl) validateChallenge(identifier core.AcmeIdentifier, challenge core.Challenge) (core.Challenge, error) {
+	switch challenge.Type {
+	case core.ChallengeTypeSimpleHTTP:
+		// TODO(https://github.com/letsencrypt/boulder/issues/894): Delete this case
+		return va.validateSimpleHTTP(identifier, challenge)
+	case core.ChallengeTypeDVSNI:
+		// TODO(https://github.com/letsencrypt/boulder/issues/894): Delete this case
+		return va.validateDvsni(identifier, challenge)
+	case core.ChallengeTypeHTTP01:
+		return va.validateHTTP01(identifier, challenge)
+	case core.ChallengeTypeTLSSNI01:
+		return va.validateTLSSNI01(identifier, challenge)
+	case core.ChallengeTypeDNS01:
+		return va.validateDNS01(identifier, challenge)
+	}
+	return core.Challenge{}, fmt.Errorf("invalid challenge type %s", challenge.Type)
 }
 
 // UpdateValidations runs the validate() method asynchronously using goroutines.

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -1062,8 +1062,9 @@ func TestCAATimeout(t *testing.T) {
 	if err.Type != core.ConnectionProblem {
 		t.Errorf("Expected timeout error type %s, got %s", core.ConnectionProblem, err.Type)
 	}
-	if err.Detail != detailDNSTimeout {
-		t.Errorf("Expected timeout error detail %s, got %s", detailDNSTimeout, err.Detail)
+	expected := "DNS query timed out"
+	if err.Detail != expected {
+		t.Errorf("checkCAA: got %s, expected %s", err.Detail, expected)
 	}
 }
 

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -1053,6 +1053,20 @@ func TestUpdateValidations(t *testing.T) {
 	test.Assert(t, (took < (time.Second * 3)), "UpdateValidations blocked")
 }
 
+func TestCAATimeout(t *testing.T) {
+	stats, _ := statsd.NewNoopClient()
+	va := NewValidationAuthorityImpl(&PortConfig{}, nil, stats, clock.Default())
+	va.DNSResolver = &mocks.DNSResolver{}
+	va.IssuerDomain = "letsencrypt.org"
+	err := va.checkCAA(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "caa-timeout.com"}, 101)
+	if err.Type != core.ConnectionProblem {
+		t.Errorf("Expected timeout error type %s, got %s", core.ConnectionProblem, err.Type)
+	}
+	if err.Detail != detailDNSTimeout {
+		t.Errorf("Expected timeout error detail %s, got %s", detailDNSTimeout, err.Detail)
+	}
+}
+
 func TestCAAChecking(t *testing.T) {
 	type CAATest struct {
 		Domain  string


### PR DESCRIPTION
Fixes https://github.com/letsencrypt/boulder/issues/1047
Fixes #700

Moves CAA checking into VA, after basic challenge validation. This should speed up new-authz, and may allow us to get rid of the CheckVAA RPC in a subsequent PR. It also reduces the total number of places that can fail due to DNS.

Also, since this was touching the validateEmail code, I changed it to use A instead of MX, and fix #700.