### PR TITLE
Run UpdateValidations synchronously.

### DIFF
--- a/core/va.go
+++ b/core/va.go
@@ -8,7 +8,7 @@ package core
 // ValidationAuthority defines the public interface for the Boulder VA
 type ValidationAuthority interface {
 	// [RegistrationAuthority]
-	UpdateValidations(Authorization, int) error
+	UpdateValidations(Authorization, int)
 	CheckCAARecords(AcmeIdentifier) (bool, bool, error)
 	IsSafeDomain(*IsSafeDomainRequest) (*IsSafeDomainResponse, error)
 }

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -686,7 +686,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(base core.Authorization
 	}
 
 	// Dispatch to the VA for service
-	ra.VA.UpdateValidations(authz, challengeIndex)
+	go ra.VA.UpdateValidations(authz, challengeIndex)
 
 	ra.stats.Inc("RA.UpdatedPendingAuthorizations", 1, 1.0)
 	return

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -42,7 +42,7 @@ type DummyValidationAuthority struct {
 	IsSafeDomainErr error
 }
 
-func (dva *DummyValidationAuthority) UpdateValidations(authz core.Authorization, index int) (err error) {
+func (dva *DummyValidationAuthority) UpdateValidations(authz core.Authorization, index int) {
 	dva.Called = true
 	dva.Argument = authz
 	return

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -518,7 +518,7 @@ func NewValidationAuthorityServer(rpc Server, impl core.ValidationAuthority) (er
 			return
 		}
 
-		err = impl.UpdateValidations(vaReq.Authz, vaReq.Index)
+		impl.UpdateValidations(vaReq.Authz, vaReq.Index)
 		return
 	})
 
@@ -581,18 +581,18 @@ func NewValidationAuthorityClient(client Client) (vac ValidationAuthorityClient,
 }
 
 // UpdateValidations sends an Update Validations request
-func (vac ValidationAuthorityClient) UpdateValidations(authz core.Authorization, index int) error {
+func (vac ValidationAuthorityClient) UpdateValidations(authz core.Authorization, index int) {
 	vaReq := validationRequest{
 		Authz: authz,
 		Index: index,
 	}
 	data, err := json.Marshal(vaReq)
 	if err != nil {
-		return err
+		panic("failed to marshal vaReq")
 	}
 
 	_, err = vac.rpc.DispatchSync(MethodUpdateValidations, data)
-	return nil
+	return
 }
 
 // CheckCAARecords sends a request to check CAA records

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -640,9 +640,9 @@ func (va *ValidationAuthorityImpl) validateDNS01(identifier core.AcmeIdentifier,
 	return challenge, challenge.Error
 }
 
-// Overall validation process
-
-func (va *ValidationAuthorityImpl) validate(authz core.Authorization, challengeIndex int) {
+// UpdateValidations attempts to validate a challenge, then calls back to the RA
+// to update the challenge's status.
+func (va *ValidationAuthorityImpl) UpdateValidations(authz core.Authorization, challengeIndex int) {
 	logEvent := verificationRequestEvent{
 		ID:          authz.ID,
 		Requester:   authz.RegistrationID,
@@ -693,12 +693,6 @@ func (va *ValidationAuthorityImpl) validate(authz core.Authorization, challengeI
 	va.log.Notice(fmt.Sprintf("Validations: %+v", authz))
 
 	va.RA.OnValidationUpdate(authz)
-}
-
-// UpdateValidations runs the validate() method asynchronously using goroutines.
-func (va *ValidationAuthorityImpl) UpdateValidations(authz core.Authorization, challengeIndex int) error {
-	go va.validate(authz, challengeIndex)
-	return nil
 }
 
 // CAASet consists of filtered CAA records

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -936,7 +936,7 @@ func TestValidateHTTP(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{chall},
 	}
-	va.validate(authz, 0)
+	va.UpdateValidations(authz, 0)
 
 	test.AssertEquals(t, core.StatusValid, mockRA.lastAuthz.Challenges[0].Status)
 }
@@ -999,7 +999,7 @@ func TestValidateTLSSNI01(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{chall},
 	}
-	va.validate(authz, 0)
+	va.UpdateValidations(authz, 0)
 
 	test.AssertEquals(t, core.StatusValid, mockRA.lastAuthz.Challenges[0].Status)
 }
@@ -1021,7 +1021,7 @@ func TestValidateTLSSNINotSane(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{chall},
 	}
-	va.validate(authz, 0)
+	va.UpdateValidations(authz, 0)
 
 	test.AssertEquals(t, core.StatusInvalid, mockRA.lastAuthz.Challenges[0].Status)
 }
@@ -1116,7 +1116,7 @@ func TestDNSValidationFailure(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{chalDNS},
 	}
-	va.validate(authz, 0)
+	va.UpdateValidations(authz, 0)
 
 	t.Logf("Resulting Authz: %+v", authz)
 	test.AssertNotNil(t, mockRA.lastAuthz, "Should have gotten an authorization")
@@ -1145,7 +1145,7 @@ func TestDNSValidationInvalid(t *testing.T) {
 	mockRA := &MockRegistrationAuthority{}
 	va.RA = mockRA
 
-	va.validate(authz, 0)
+	va.UpdateValidations(authz, 0)
 
 	test.AssertNotNil(t, mockRA.lastAuthz, "Should have gotten an authorization")
 	test.Assert(t, authz.Challenges[0].Status == core.StatusInvalid, "Should be invalid.")
@@ -1177,7 +1177,7 @@ func TestDNSValidationNotSane(t *testing.T) {
 	}
 
 	for i := 0; i < len(authz.Challenges); i++ {
-		va.validate(authz, i)
+		va.UpdateValidations(authz, i)
 		test.AssertEquals(t, authz.Challenges[i].Status, core.StatusInvalid)
 		test.AssertEquals(t, authz.Challenges[i].Error.Type, core.MalformedProblem)
 	}
@@ -1202,7 +1202,7 @@ func TestDNSValidationServFail(t *testing.T) {
 		Identifier:     badIdent,
 		Challenges:     []core.Challenge{chalDNS},
 	}
-	va.validate(authz, 0)
+	va.UpdateValidations(authz, 0)
 
 	test.AssertNotNil(t, mockRA.lastAuthz, "Should have gotten an authorization")
 	test.Assert(t, authz.Challenges[0].Status == core.StatusInvalid, "Should be invalid.")
@@ -1224,7 +1224,7 @@ func TestDNSValidationNoServer(t *testing.T) {
 		Identifier:     ident,
 		Challenges:     []core.Challenge{chalDNS},
 	}
-	va.validate(authz, 0)
+	va.UpdateValidations(authz, 0)
 
 	test.AssertNotNil(t, mockRA.lastAuthz, "Should have gotten an authorization")
 	test.Assert(t, authz.Challenges[0].Status == core.StatusInvalid, "Should be invalid.")
@@ -1262,7 +1262,7 @@ func TestDNSValidationLive(t *testing.T) {
 		Challenges:     []core.Challenge{goodChalDNS},
 	}
 
-	va.validate(authzGood, 0)
+	va.UpdateValidations(authzGood, 0)
 
 	if authzGood.Challenges[0].Status != core.StatusValid {
 		t.Logf("TestDNSValidationLive on Good did not succeed.")
@@ -1279,7 +1279,7 @@ func TestDNSValidationLive(t *testing.T) {
 		Challenges:     []core.Challenge{badChalDNS},
 	}
 
-	va.validate(authzBad, 0)
+	va.UpdateValidations(authzBad, 0)
 	if authzBad.Challenges[0].Status != core.StatusInvalid {
 		t.Logf("TestDNSValidationLive on Bad did succeed inappropriately.")
 	}


### PR DESCRIPTION
The RPC layer already puts each call in its own goroutine, and has a mechanism
for limiting the total number of outstanding goroutines.

Also, remove the unused error return type from UpdateValidations.

Fixes https://github.com/letsencrypt/boulder/issues/923