### PR TITLE
set an Accept header on VA HTTP requests

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -261,11 +261,25 @@ func (va *ValidationAuthorityImpl) fetchHTTP(identifier core.AcmeIdentifier, pat
 		Dial: dialer.Dial,
 	}
 
+	// Some of our users use mod_security. Mod_security sees a lack of Accept
+	// headers as bot behavior and rejects requests. While this is a bug in
+	// mod_security's rules (given that the HTTP specs disagree with that
+	// requirement), we add the Accept header now in order to fix our
+	// mod_security users' mysterious breakages. See
+	// <https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/265> and
+	// <https://github.com/letsencrypt/boulder/issues/1019>. This was done
+	// because it's a one-line fix with no downside. We're not likely to want to
+	// do many more things to satisfy misunderstandings around HTTP.
+	httpRequest.Header.Set("Accept", "*/*")
+
 	logRedirect := func(req *http.Request, via []*http.Request) error {
 		if len(challenge.ValidationRecord) >= maxRedirect {
 			return fmt.Errorf("Too many redirects")
 		}
 
+		// Set Accept header for mod_security (see the other place the header is
+		// set)
+		req.Header.Set("Accept", "*/*")
 		reqHost := req.URL.Host
 		var reqPort int
 		if h, p, err := net.SplitHostPort(reqHost); err == nil {

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -103,6 +103,14 @@ func simpleSrv(t *testing.T, token string, enableTLS bool) *httptest.Server {
 		if !strings.HasPrefix(r.Host, "localhost:") && !strings.HasPrefix(r.Host, "other.valid:") {
 			t.Errorf("Bad Host header: " + r.Host)
 		}
+
+		if r.Header.Get("Accept") != "*/*" {
+			t.Logf("SIMPLESRV: Missing Accept header, was %#v", r.Header.Get("Accept"))
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("request forgot the Accept header"))
+			return
+		}
+
 		if strings.HasSuffix(r.URL.Path, path404) {
 			t.Logf("SIMPLESRV: Got a 404 req\n")
 			http.NotFound(w, r)


### PR DESCRIPTION
This fixes some mysterious breakages that Let's Encrypt users that also used mod_security on their domains had.

There's some back and forth about whether the mod_security rule is wise, but that's captured in a mod_security ticket linked from this PR's ticket.

This patch is a one-line fix with no probable downside. We're not likely to want to do many more things to satisfy misunderstandings around HTTP but this seems fine to help our people out.

Fixes #1019.