### PR TITLE
Integration test fixes

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -127,8 +127,6 @@ function build_letsencrypt() {
   run ./venv/bin/pip install -U pip
   run ./venv/bin/pip install -e acme -e . -e letsencrypt-apache -e letsencrypt-nginx
 
-  source ./venv/bin/activate
-
   cd -
 }
 
@@ -260,6 +258,8 @@ if [[ "$RUN" =~ "integration" ]] ; then
   elif [ ! -d "${LETSENCRYPT_PATH}" ]; then
     build_letsencrypt
   fi
+
+  source ${LETSENCRYPT_PATH}/venv/bin/activate
 
   python test/integration-test.py --all
   case $? in

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -208,8 +208,7 @@ def run_client_tests():
     assert root is not None, (
         "Please set LETSENCRYPT_PATH env variable to point at "
         "initialized (virtualenv) client repo root")
-    test_script_path = os.path.join(root, 'tests', 'boulder-integration.sh')
-    cmd = "SIMPLE_HTTP_PORT=5002 %s" % (test_script_path)
+    cmd = os.path.join(root, 'tests', 'boulder-integration.sh')
     if subprocess.Popen(cmd, shell=True, cwd=root, executable='/bin/bash').wait() != 0:
         die(ExitStatus.PythonFailure)
 


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/pull/1110 we put
the activate command in the wrong place so it didn't run if
LETSENCRYPT_PATH was set.

Also remove SIMPLE_HTTP_PORT which is no longer necessary. It was used to keep
the build passing as the client transitioned ports. The client now defaults to
5002.