### PR TITLE
Improve logging.

### DIFF
--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -112,17 +112,7 @@ func startMonitor(rpcCh *amqp.Channel, logger *blog.AuditLogger, stats statsd.St
 func main() {
 	app := cmd.NewAppShell("activity-monitor", "RPC activity monitor")
 
-	app.Action = func(c cmd.Config) {
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-
-		cmd.FailOnError(err, "Could not connect to statsd")
-
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		go cmd.DebugServer(c.ActivityMonitor.DebugAddr)
 
 		ch, err := rpc.AmqpChannel(c)

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
 	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 	"github.com/letsencrypt/boulder/cmd"
@@ -41,12 +40,7 @@ func setupContext(context *cli.Context) (rpc.RegistrationAuthorityClient, *blog.
 	c, err := loadConfig(context)
 	cmd.FailOnError(err, "Failed to load Boulder configuration")
 
-	stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-	cmd.FailOnError(err, "Couldn't connect to statsd")
-
-	auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-	cmd.FailOnError(err, "Could not connect to Syslog")
-	blog.SetAuditLogger(auditlogger)
+	stats, auditlogger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 
 	raRPC, err := rpc.NewAmqpRPCClient("AdminRevoker->RA", c.AMQP.RA.Server, c, stats)
 	cmd.FailOnError(err, "Unable to create RPC client")

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -18,15 +18,7 @@ import (
 
 func main() {
 	app := cmd.NewAppShell("boulder-ca", "Handles issuance operations")
-	app.Action = func(c cmd.Config) {
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		// Set up logging
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		// Validate PA config and set defaults if needed
 		cmd.FailOnError(c.PA.CheckChallenges(), "Invalid PA configuration")
 		c.PA.SetDefaultChallengesIfEmpty()

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -16,20 +16,7 @@ import (
 
 func main() {
 	app := cmd.NewAppShell("boulder-publisher", "Submits issued certificates to CT logs")
-	app.Action = func(c cmd.Config) {
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Could not connect to statsd")
-
-		// Set up logging
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to syslog")
-		auditlogger.Info(app.VersionString())
-
-		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		defer auditlogger.AuditPanic()
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		pubi, err := publisher.NewPublisherImpl(c.Common.CT)
 		cmd.FailOnError(err, "Could not setup Publisher")
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -16,20 +16,7 @@ import (
 
 func main() {
 	app := cmd.NewAppShell("boulder-sa", "Handles SQL operations")
-	app.Action = func(c cmd.Config) {
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		// Set up logging
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		defer auditlogger.AuditPanic()
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		go cmd.DebugServer(c.SA.DebugAddr)
 
 		dbMap, err := sa.NewDbMap(c.SA.DBConnect)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -20,20 +20,7 @@ import (
 
 func main() {
 	app := cmd.NewAppShell("boulder-va", "Handles challenge validation")
-	app.Action = func(c cmd.Config) {
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		// Set up logging
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		defer auditlogger.AuditPanic()
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		go cmd.DebugServer(c.VA.DebugAddr)
 
 		go cmd.ProfileCmd("VA", stats)

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -53,20 +53,7 @@ func main() {
 		}
 		return config
 	}
-	app.Action = func(c cmd.Config) {
-		// Set up logging
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		defer auditlogger.AuditPanic()
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		go cmd.DebugServer(c.WFE.DebugAddr)
 
 		wfe, err := wfe.NewWebFrontEndImpl(stats, clock.Default())

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -234,19 +234,10 @@ func main() {
 		return config
 	}
 
-	app.Action = func(c cmd.Config) {
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		// Validate PA config and set defaults if needed
 		cmd.FailOnError(c.PA.CheckChallenges(), "Invalid PA configuration")
 		c.PA.SetDefaultChallengesIfEmpty()
-
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		blog.SetAuditLogger(auditlogger)
 
 		saDbMap, err := sa.NewDbMap(c.CertChecker.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,3 +11,16 @@ type GoogleSafeBrowsingConfig struct {
 	APIKey  string
 	DataDir string
 }
+
+// SyslogConfig defines the config for syslogging.
+type SyslogConfig struct {
+	Network     string
+	Server      string
+	StdoutLevel *int
+}
+
+// StatsdConfig defines the config for Statsd.
+type StatsdConfig struct {
+	Server string
+	Prefix string
+}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -225,20 +225,7 @@ func main() {
 		return config
 	}
 
-	app.Action = func(c cmd.Config) {
-		// Set up logging
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		defer auditlogger.AuditPanic()
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		go cmd.DebugServer(c.Mailer.DebugAddr)
 
 		// Configure DB

--- a/cmd/external-cert-importer/main.go
+++ b/cmd/external-cert-importer/main.go
@@ -148,16 +148,7 @@ func main() {
 		return config
 	}
 
-	app.Action = func(c cmd.Config) {
-		// Set up logging
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		// Configure DB
 		dbMap, err := sa.NewDbMap(c.PA.DBConnect)
 		cmd.FailOnError(err, "Could not connect to database")

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -144,20 +144,7 @@ func makeDBSource(dbMap dbSelector, issuerCert string, log *blog.AuditLogger) (*
 
 func main() {
 	app := cmd.NewAppShell("boulder-ocsp-responder", "Handles OCSP requests")
-	app.Action = func(c cmd.Config) {
-		// Set up logging
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		defer auditlogger.AuditPanic()
-
-		blog.SetAuditLogger(auditlogger)
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		go cmd.DebugServer(c.OCSPResponder.DebugAddr)
 
 		go cmd.ProfileCmd("OCSP", stats)

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -560,20 +560,7 @@ func setupClients(c cmd.Config, stats statsd.Statter) (
 func main() {
 	app := cmd.NewAppShell("ocsp-updater", "Generates and updates OCSP responses")
 
-	app.Action = func(c cmd.Config) {
-		// Set up logging
-		stats, err := statsd.NewClient(c.Statsd.Server, c.Statsd.Prefix)
-		cmd.FailOnError(err, "Couldn't connect to statsd")
-
-		auditlogger, err := blog.Dial(c.Syslog.Network, c.Syslog.Server, c.Syslog.Tag, stats)
-		cmd.FailOnError(err, "Could not connect to Syslog")
-		auditlogger.Info(app.VersionString())
-
-		blog.SetAuditLogger(auditlogger)
-
-		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		defer auditlogger.AuditPanic()
-
+	app.Action = func(c cmd.Config, stats statsd.Statter, auditlogger *blog.AuditLogger) {
 		go cmd.DebugServer(c.OCSPUpdater.DebugAddr)
 		go cmd.ProfileCmd("OCSP-Updater", stats)
 

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -227,19 +227,6 @@ type Config struct {
 	SubscriberAgreementURL string
 }
 
-// SyslogConfig defines the config for syslogging.
-type SyslogConfig struct {
-	Network     string
-	Server      string
-	StdoutLevel *int
-}
-
-// StatsdConfig defines the config for Statsd.
-type StatsdConfig struct {
-	Server string
-	Prefix string
-}
-
 // CAConfig structs have configuration information for the certificate
 // authority, including database parameters as well as controls for
 // issued certificates.

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -28,10 +28,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"log/syslog"
 	"net"
 	"net/http"
 	_ "net/http/pprof" // HTTP performance profiling, added transparently to HTTP APIs
 	"os"
+	"path"
 	"runtime"
 	"time"
 
@@ -138,16 +140,9 @@ type Config struct {
 		SQLDebug bool
 	}
 
-	Statsd struct {
-		Server string
-		Prefix string
-	}
+	Statsd StatsdConfig
 
-	Syslog struct {
-		Network string
-		Server  string
-		Tag     string
-	}
+	Syslog SyslogConfig
 
 	Revoker struct {
 		DBConnect string
@@ -230,6 +225,19 @@ type Config struct {
 	}
 
 	SubscriberAgreementURL string
+}
+
+// SyslogConfig defines the config for syslogging.
+type SyslogConfig struct {
+	Network     string
+	Server      string
+	StdoutLevel *int
+}
+
+// StatsdConfig defines the config for Statsd.
+type StatsdConfig struct {
+	Server string
+	Prefix string
 }
 
 // CAConfig structs have configuration information for the certificate
@@ -354,7 +362,7 @@ type OCSPUpdaterConfig struct {
 
 // AppShell contains CLI Metadata
 type AppShell struct {
-	Action func(Config)
+	Action func(Config, statsd.Statter, *blog.AuditLogger)
 	Config func(*cli.Context, Config) Config
 	App    *cli.App
 }
@@ -402,11 +410,42 @@ func (as *AppShell) Run() {
 			config = as.Config(c, config)
 		}
 
-		as.Action(config)
+		stats, auditlogger := StatsAndLogging(config.Statsd, config.Syslog)
+		auditlogger.Info(as.VersionString())
+
+		// If as.Action generates a panic, this will log it to syslog.
+		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+		defer auditlogger.AuditPanic()
+
+		as.Action(config, stats, auditlogger)
 	}
 
 	err := as.App.Run(os.Args)
 	FailOnError(err, "Failed to run application")
+}
+
+// StatsAndLogging constructs a Statter and and AuditLogger based on its config
+// parameters, and return them both. Crashes if any setup fails.
+// Also sets the constructed AuditLogger as the default logger.
+func StatsAndLogging(statConf StatsdConfig, logConf SyslogConfig) (statsd.Statter, *blog.AuditLogger) {
+	stats, err := statsd.NewClient(statConf.Server, statConf.Prefix)
+	FailOnError(err, "Couldn't connect to statsd")
+
+	tag := path.Base(os.Args[0])
+	syslogger, err := syslog.Dial(
+		logConf.Network,
+		logConf.Server,
+		syslog.LOG_INFO|syslog.LOG_LOCAL0, // default, overridden by log calls
+		tag)
+	FailOnError(err, "Could not connect to Syslog")
+	level := int(syslog.LOG_DEBUG)
+	if logConf.StdoutLevel != nil {
+		level = *logConf.StdoutLevel
+	}
+	auditlogger, err := blog.NewAuditLogger(syslogger, stats, level)
+	FailOnError(err, "Could not connect to Syslog")
+	blog.SetAuditLogger(auditlogger)
+	return stats, auditlogger
 }
 
 // VersionString produces a friendly Application version string

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -2,7 +2,7 @@
   "syslog": {
     "network": "",
     "server": "",
-    "tag": "boulder"
+    "stdoutlevel": 7
   },
 
   "amqp": {


### PR DESCRIPTION
Consolidate initialization of stats and logging from each main.go into cmd
package.

Define a new config parameter, `StdoutLevel`, that determines the maximum log
level that will be printed to stdout. It can be set to 6 to inhibit debug
messages, or 0 to print only emergency messages, or -1 to print no messages at
all.

Remove the existing config parameter `Tag`. Instead, choose the tag from the
basename of the currently running process. Previously all Boulder log messages
had the tag "boulder", but now they will be differentiated by process, like
"boulder-wfe".

Shorten the date format used in stdout logging, and add the current binary's
basename.

Consolidate setup function in audit-logger_test.go.

Note: Most CLI binaries now get their stats and logging from the parameters of
Action. However, a few of our binaries don't use our custom AppShell, and
instead use codegangsta/cli directly. For those binaries, we export the new
StatsAndLogging method from cmd.

Fixes https://github.com/letsencrypt/boulder/issues/852