### PR TITLE
fix le fork of go-jose again

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -110,7 +110,7 @@
 		},
 		{
 			"ImportPath": "github.com/letsencrypt/go-jose",
-			"Rev": "e7bd87a386998d423741e8e370af1a22638767e0"
+			"Rev": "77671e91fe89678878df4bde9e6b653a0d190dfb"
 		},
 		{
 			"ImportPath": "github.com/letsencrypt/go-safe-browsing-api",

--- a/Godeps/_workspace/src/github.com/letsencrypt/go-jose/asymmetric.go
+++ b/Godeps/_workspace/src/github.com/letsencrypt/go-jose/asymmetric.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose/cipher"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose/cipher"
 )
 
 // A generic RSA-based encrypter/verifier

--- a/Godeps/_workspace/src/github.com/letsencrypt/go-jose/symmetric.go
+++ b/Godeps/_workspace/src/github.com/letsencrypt/go-jose/symmetric.go
@@ -25,7 +25,7 @@ import (
 	"crypto/sha512"
 	"crypto/subtle"
 	"errors"
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/square/go-jose/cipher"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose/cipher"
 	"hash"
 	"io"
 )


### PR DESCRIPTION
Found while working on other tickets.

This just updates to the latest letsencrypt/go-jose which doesn't have those busted imports.