### PR TITLE
Trim trailing whitespace for validation payloads

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -32,6 +32,7 @@ import (
 )
 
 const maxRedirect = 10
+const whitespaceCutset = "\n\t "
 
 var validationTimeout = time.Second * 5
 
@@ -411,7 +412,7 @@ func (va *ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdenti
 		return challenge, err
 	}
 
-	payload := strings.TrimRight(string(body), "\n\t ")
+	payload := strings.TrimRight(string(body), whitespaceCutset)
 
 	// Parse and verify JWS
 	parsedJws, err := jose.ParseSigned(payload)
@@ -513,7 +514,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(identifier core.AcmeIdentifier
 		return challenge, err
 	}
 
-	payload := strings.TrimRight(string(body), "\n\t ")
+	payload := strings.TrimRight(string(body), whitespaceCutset)
 
 	// Parse body as a key authorization object
 	serverKeyAuthorization, err := core.NewKeyAuthorizationFromString(payload)

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -411,8 +411,10 @@ func (va *ValidationAuthorityImpl) validateSimpleHTTP(identifier core.AcmeIdenti
 		return challenge, err
 	}
 
+	payload := strings.TrimRight(string(body), "\n\t ")
+
 	// Parse and verify JWS
-	parsedJws, err := jose.ParseSigned(string(body))
+	parsedJws, err := jose.ParseSigned(payload)
 	if err != nil {
 		err = fmt.Errorf("Validation response failed to parse as JWS: %s", err.Error())
 		va.log.Debug(err.Error())
@@ -511,8 +513,10 @@ func (va *ValidationAuthorityImpl) validateHTTP01(identifier core.AcmeIdentifier
 		return challenge, err
 	}
 
+	payload := strings.TrimRight(string(body), "\n\t ")
+
 	// Parse body as a key authorization object
-	serverKeyAuthorization, err := core.NewKeyAuthorizationFromString(string(body))
+	serverKeyAuthorization, err := core.NewKeyAuthorizationFromString(payload)
 	if err != nil {
 		err = fmt.Errorf("Error parsing key authorization file: %s", err.Error())
 		va.log.Debug(err.Error())

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -306,6 +306,7 @@ func TestSimpleHttp(t *testing.T) {
 
 	va = NewValidationAuthorityImpl(&PortConfig{HTTPPort: goodPort}, nil, stats, clock.Default())
 	va.DNSResolver = &mocks.DNSResolver{}
+
 	log.Clear()
 	finChall, err := va.validateSimpleHTTP(ident, chall)
 	test.AssertEquals(t, finChall.Status, core.StatusValid)
@@ -588,9 +589,9 @@ func httpSrv(t *testing.T, token string) *httptest.Server {
 			t.Logf("HTTPSRV: Path = %s\n", r.URL.Path)
 
 			keyAuthz, _ := core.NewKeyAuthorization(currentToken, accountKey)
-			t.Logf("HTTPSRV: Key Authz = %s\n", keyAuthz.String())
+			t.Logf("HTTPSRV: Key Authz = '%s%s'\n", keyAuthz.String(), "\\n \\t")
 
-			fmt.Fprint(w, keyAuthz.String())
+			fmt.Fprint(w, keyAuthz.String(), "\n \t")
 			currentToken = defaultToken
 		}
 	})
@@ -680,6 +681,7 @@ func TestHttp(t *testing.T) {
 
 	va = NewValidationAuthorityImpl(&PortConfig{HTTPPort: goodPort}, nil, stats, clock.Default())
 	va.DNSResolver = &mocks.DNSResolver{}
+
 	log.Clear()
 	t.Logf("Trying to validate: %+v\n", chall)
 	finChall, err := va.validateHTTP01(ident, chall)


### PR DESCRIPTION
https://community.letsencrypt.org/t/manual-line-break-at-end-of-http-response-causing-mis-match/3794/3

https://github.com/letsencrypt/letsencrypt/issues/1322