### PR TITLE
Only use TCP for DNS.

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -127,6 +127,7 @@ func NewDNSResolverImpl(dialTimeout time.Duration, servers []string) *DNSResolve
 
 	// Set timeout for underlying net.Conn
 	dnsClient.DialTimeout = dialTimeout
+	dnsClient.Net = "tcp"
 
 	return &DNSResolverImpl{
 		DNSClient:                dnsClient,

--- a/core/dns_test.go
+++ b/core/dns_test.go
@@ -21,7 +21,6 @@ import (
 const dnsLoopbackAddr = "127.0.0.1:4053"
 
 func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
-	defer w.Close()
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.Compress = false
@@ -114,7 +113,7 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 func serveLoopResolver(stopChan chan bool) chan bool {
 	dns.HandleFunc(".", mockDNSQuery)
-	server := &dns.Server{Addr: dnsLoopbackAddr, Net: "udp", ReadTimeout: time.Millisecond, WriteTimeout: time.Millisecond}
+	server := &dns.Server{Addr: dnsLoopbackAddr, Net: "tcp", ReadTimeout: time.Millisecond, WriteTimeout: time.Millisecond}
 	waitChan := make(chan bool, 1)
 	go func() {
 		waitChan <- true

--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -15,7 +15,6 @@ import (
 )
 
 func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
-	defer w.Close()
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.Compress = false
@@ -65,7 +64,7 @@ func serveTestResolver() {
 	dns.HandleFunc(".", dnsHandler)
 	server := &dns.Server{
 		Addr:         "127.0.0.1:8053",
-		Net:          "udp",
+		Net:          "tcp",
 		ReadTimeout:  time.Millisecond,
 		WriteTimeout: time.Millisecond,
 	}


### PR DESCRIPTION
Since Boulder always requests DNSSEC records, in practice DNS responses often
exceed the IP MTU.

Boulder installations expect to have a local DNS resolver, and all modern DNS
resolvers support TCP connections. Since miekg/dns does not perform an
"attempt udp, timeout, retry via tcp" approach, it's simpler and more reliable
to always use TCP for internal DNS resolution. This makes failures more
obvious as well.