### PR TITLE
Replace DialTimeout with ReadTimeout.

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -122,11 +122,11 @@ type DNSResolverImpl struct {
 
 // NewDNSResolverImpl constructs a new DNS resolver object that utilizes the
 // provided list of DNS servers for resolution.
-func NewDNSResolverImpl(dialTimeout time.Duration, servers []string) *DNSResolverImpl {
+func NewDNSResolverImpl(readTimeout time.Duration, servers []string) *DNSResolverImpl {
 	dnsClient := new(dns.Client)
 
 	// Set timeout for underlying net.Conn
-	dnsClient.DialTimeout = dialTimeout
+	dnsClient.ReadTimeout = readTimeout
 	dnsClient.Net = "tcp"
 
 	return &DNSResolverImpl{
@@ -139,8 +139,8 @@ func NewDNSResolverImpl(dialTimeout time.Duration, servers []string) *DNSResolve
 // NewTestDNSResolverImpl constructs a new DNS resolver object that utilizes the
 // provided list of DNS servers for resolution and will allow loopback addresses.
 // This constructor should *only* be called from tests (unit or integration).
-func NewTestDNSResolverImpl(dialTimeout time.Duration, servers []string) *DNSResolverImpl {
-	resolver := NewDNSResolverImpl(dialTimeout, servers)
+func NewTestDNSResolverImpl(readTimeout time.Duration, servers []string) *DNSResolverImpl {
+	resolver := NewDNSResolverImpl(readTimeout, servers)
 	resolver.allowRestrictedAddresses = true
 	return resolver
 }


### PR DESCRIPTION
Generally Dial will be very fast because our resolver is local, so there's no
need to override its default of 2s. However, since our resolver recurses more or
less every time, getting the answer back is very slow. So we want to be able to
set a high ReadTimeout.

Fixes #1176 (which we thought we had fixed by updating `miekg/dns` to latest, but which wasn't actually fixed).