### PR TITLE
Temporarily increase default RPC timeout in test.

### DIFF
--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -25,11 +25,11 @@
       "insecure": true,
       "RA": {
         "server": "RA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       },
       "SA": {
         "server": "SA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       }
     }
   },
@@ -101,11 +101,11 @@
       "serviceQueue": "CA.server",
       "SA": {
         "server": "SA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       },
       "Publisher": {
         "server": "Publisher.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       }
     }
   },
@@ -136,11 +136,11 @@
       },
       "SA": {
         "server": "SA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       },
       "CA": {
         "server": "CA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
 
       }
     }
@@ -172,7 +172,7 @@
       "serviceQueue": "VA.server",
       "RA": {
         "server": "RA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       }
     }
   },
@@ -188,11 +188,11 @@
       "insecure": true,
       "RA": {
         "server": "RA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       },
       "SA": {
         "server": "SA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       }
     }
   },
@@ -227,15 +227,15 @@
       "insecure": true,
       "SA": {
         "server": "SA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       },
       "CA": {
         "server": "CA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       },
       "Publisher": {
         "server": "Publisher.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       }
     }
   },
@@ -270,7 +270,7 @@
       "serviceQueue": "Publisher.server",
       "SA": {
         "server": "SA.server",
-        "rpcTimeout": "1s"
+        "rpcTimeout": "15s"
       }
     }
   },


### PR DESCRIPTION
Formerly this was 10s (embedded in code) and we occasionally got AMQP-RPC
timeouts in Travis builds. After changing to 1s we regularly get AMQP-RPC
timeouts in Travis. Now we have the knowledge to reproduce the problem with some
regularity, but we don't want to slow down development with even flakier builds.

Instead, we can create test branches with this timeout set low and debug there.
The goal is to restore this to 1s in the next week or two after successful
debugging.

Fixes #1193.