### PR TITLE
use ProblemDetails inside of wfe

### DIFF
--- a/probs/probs.go
+++ b/probs/probs.go
@@ -1,6 +1,9 @@
 package probs
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 // Error types that can be used in ACME payloads
 const (
@@ -20,11 +23,121 @@ type ProblemType string
 // ProblemDetails objects represent problem documents
 // https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00
 type ProblemDetails struct {
-	Type       ProblemType `json:"type,omitempty"`
-	Detail     string      `json:"detail,omitempty"`
-	HTTPStatus int         `json:"status,omitempty"`
+	Type   ProblemType `json:"type,omitempty"`
+	Detail string      `json:"detail,omitempty"`
+	// HTTPStatus is the HTTP status code the ProblemDetails should probably be sent
+	// as.
+	HTTPStatus int `json:"status,omitempty"`
 }
 
 func (pd *ProblemDetails) Error() string {
 	return fmt.Sprintf("%s :: %s", pd.Type, pd.Detail)
+}
+
+// statusTooManyRequests is the HTTP status code meant for rate limiting
+// errors. It's not currently in the net/http library so we add it here.
+const statusTooManyRequests = 429
+
+// ProblemDetailsToStatusCode inspects the given ProblemDetails to figure out
+// what HTTP status code it should represent. It should only be used by the WFE
+// but is included in this package because of its reliance on ProblemTypes.
+func ProblemDetailsToStatusCode(prob *ProblemDetails) int {
+	if prob.HTTPStatus != 0 {
+		return prob.HTTPStatus
+	}
+	switch prob.Type {
+	case ConnectionProblem, MalformedProblem, TLSProblem, UnknownHostProblem, BadNonceProblem:
+		return http.StatusBadRequest
+	case ServerInternalProblem:
+		return http.StatusInternalServerError
+	case UnauthorizedProblem:
+		return http.StatusForbidden
+	case RateLimitedProblem:
+		return statusTooManyRequests
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// BadNonce returns a ProblemDetails with a BadNonceProblem and a 400 Bad
+// Request status code.
+func BadNonce(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       BadNonceProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// Conflict returns a ProblemDetails with a MalformedProblem and a 409 Conflict
+// status code.
+func Conflict(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       MalformedProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusConflict,
+	}
+}
+
+// Malformed returns a ProblemDetails with a MalformedProblem and a 400 Bad
+// Request status code.
+func Malformed(detail string, args ...interface{}) *ProblemDetails {
+	if len(args) > 0 {
+		detail = fmt.Sprintf(detail, args...)
+	}
+	return &ProblemDetails{
+		Type:       MalformedProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// NotFound returns a ProblemDetails with a MalformedProblem and a 404 Not Found
+// status code.
+func NotFound(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       MalformedProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusNotFound,
+	}
+}
+
+// ServerInternal returns a ProblemDetails with a ServerInternalProblem and a
+// 500 Internal Server Failure status code.
+func ServerInternal(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       ServerInternalProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusInternalServerError,
+	}
+}
+
+// Unauthorized returns a ProblemDetails with an UnauthorizedProblem and a 403
+// Forbidden status code.
+func Unauthorized(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       UnauthorizedProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+// MethodNotAllowed returns a ProblemDetails representing a disallowed HTTP
+// method error.
+func MethodNotAllowed() *ProblemDetails {
+	return &ProblemDetails{
+		Type:       MalformedProblem,
+		Detail:     "Method not allowed",
+		HTTPStatus: http.StatusMethodNotAllowed,
+	}
+}
+
+// ContentLengthRequired returns a ProblemDetails representing a missing
+// Content-Length header error
+func ContentLengthRequired() *ProblemDetails {
+	return &ProblemDetails{
+		Type:       MalformedProblem,
+		Detail:     "missing Content-Length header",
+		HTTPStatus: http.StatusLengthRequired,
+	}
 }

--- a/probs/probs_test.go
+++ b/probs/probs_test.go
@@ -8,7 +8,9 @@ import (
 
 func TestProblemDetails(t *testing.T) {
 	pd := &ProblemDetails{
-		Type:   MalformedProblem,
-		Detail: "Wat? o.O"}
+		Type:       MalformedProblem,
+		Detail:     "Wat? o.O",
+		HTTPStatus: 403,
+	}
 	test.AssertEquals(t, pd.Error(), "urn:acme:error:malformed :: Wat? o.O")
 }

--- a/wfe/jose_test.go
+++ b/wfe/jose_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRejectsNone(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	_, _, _, err := wfe.verifyPOST(newRequestEvent(), makePostRequest(`
+	_, _, _, prob := wfe.verifyPOST(newRequestEvent(), makePostRequest(`
 		{
 			"header": {
 				"alg": "none",
@@ -24,17 +24,17 @@ func TestRejectsNone(t *testing.T) {
 			"signature": ""
 		}
 	`), true, "foo")
-	if err == nil {
+	if prob == nil {
 		t.Fatalf("verifyPOST did not reject JWS with alg: 'none'")
 	}
-	if err.Error() != "algorithm 'none' in JWS header not acceptable" {
-		t.Fatalf("verifyPOST rejected JWS with alg: 'none', but for wrong reason: %s", err)
+	if prob.Detail != "algorithm 'none' in JWS header not acceptable" {
+		t.Fatalf("verifyPOST rejected JWS with alg: 'none', but for wrong reason: %#v", prob)
 	}
 }
 
 func TestRejectsHS256(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	_, _, _, err := wfe.verifyPOST(newRequestEvent(), makePostRequest(`
+	_, _, _, prob := wfe.verifyPOST(newRequestEvent(), makePostRequest(`
 		{
 			"header": {
 				"alg": "HS256",
@@ -48,12 +48,12 @@ func TestRejectsHS256(t *testing.T) {
 			"signature": ""
 		}
 	`), true, "foo")
-	if err == nil {
+	if prob == nil {
 		t.Fatalf("verifyPOST did not reject JWS with alg: 'HS256'")
 	}
 	expected := "algorithm 'HS256' in JWS header not acceptable"
-	if err.Error() != expected {
-		t.Fatalf("verifyPOST rejected JWS with alg: 'none', but for wrong reason: got '%s', wanted %s", err, expected)
+	if prob.Detail != expected {
+		t.Fatalf("verifyPOST rejected JWS with alg: 'none', but for wrong reason: got '%s', wanted %s", prob, expected)
 	}
 }
 

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -27,6 +26,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
+	"github.com/letsencrypt/boulder/probs"
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
@@ -571,14 +571,14 @@ func TestIssueCertificate(t *testing.T) {
 	})
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: No body on POST","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"No body on POST","status":400}`)
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
 	wfe.NewCertificate(newRequestEvent(), responseWriter, makePostRequest("hi"))
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Parse error reading JWS","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"Parse error reading JWS","status":400}`)
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -586,7 +586,7 @@ func TestIssueCertificate(t *testing.T) {
 		makePostRequest(signRequest(t, "foo", wfe.nonceService)))
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Request payload did not parse as JSON","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"Request payload did not parse as JSON","status":400}`)
 
 	// Valid, signed JWS body, payload is '{}'
 	responseWriter.Body.Reset()
@@ -595,7 +595,7 @@ func TestIssueCertificate(t *testing.T) {
 			signRequest(t, "{}", wfe.nonceService)))
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Request payload does not specify a resource","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"Request payload does not specify a resource","status":400}`)
 
 	// Valid, signed JWS body, payload is '{"resource":"new-cert"}'
 	responseWriter.Body.Reset()
@@ -755,7 +755,7 @@ func TestBadNonce(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to sign body")
 	wfe.NewRegistration(newRequestEvent(), responseWriter,
 		makePostRequest(result.FullSerialize()))
-	test.AssertEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:badNonce","detail":"Unable to read/verify body :: JWS has no anti-replay nonce","status":400}`)
+	test.AssertEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:badNonce","detail":"JWS has no anti-replay nonce","status":400}`)
 }
 
 func TestNewRegistration(t *testing.T) {
@@ -799,19 +799,19 @@ func TestNewRegistration(t *testing.T) {
 					"Content-Length": []string{"0"},
 				},
 			},
-			`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: No body on POST","status":400}`,
+			`{"type":"urn:acme:error:malformed","detail":"No body on POST","status":400}`,
 		},
 
 		// POST, but body that isn't valid JWS
 		{
 			makePostRequestWithPath(NewRegPath, "hi"),
-			`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Parse error reading JWS","status":400}`,
+			`{"type":"urn:acme:error:malformed","detail":"Parse error reading JWS","status":400}`,
 		},
 
 		// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 		{
 			makePostRequestWithPath(NewRegPath, fooBody.FullSerialize()),
-			`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Request payload did not parse as JSON","status":400}`,
+			`{"type":"urn:acme:error:malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 
 		// Same signed body, but payload modified by one byte, breaking signature.
@@ -831,7 +831,7 @@ func TestNewRegistration(t *testing.T) {
 				"signature": "RjUQ679fxJgeAJlxqgvDP_sfGZnJ-1RgWF2qmcbnBWljs6h1qp63pLnJOl13u81bP_bCSjaWkelGG8Ymx_X-aQ"
 			}
 		`),
-			`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: JWS verification error","status":400}`,
+			`{"type":"urn:acme:error:malformed","detail":"JWS verification error","status":400}`,
 		},
 		{
 			makePostRequestWithPath(NewRegPath, wrongAgreementBody.FullSerialize()),
@@ -1062,12 +1062,12 @@ func TestAuthorization(t *testing.T) {
 			"Content-Length": []string{"0"},
 		},
 	})
-	test.AssertEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: No body on POST","status":400}`)
+	test.AssertEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:malformed","detail":"No body on POST","status":400}`)
 
 	// POST, but body that isn't valid JWS
 	responseWriter.Body.Reset()
 	wfe.NewAuthorization(newRequestEvent(), responseWriter, makePostRequest("hi"))
-	test.AssertEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Parse error reading JWS","status":400}`)
+	test.AssertEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:malformed","detail":"Parse error reading JWS","status":400}`)
 
 	// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 	responseWriter.Body.Reset()
@@ -1075,7 +1075,7 @@ func TestAuthorization(t *testing.T) {
 		makePostRequest(signRequest(t, "foo", wfe.nonceService)))
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Request payload did not parse as JSON","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"Request payload did not parse as JSON","status":400}`)
 
 	// Same signed body, but payload modified by one byte, breaking signature.
 	// should fail JWS verification.
@@ -1096,7 +1096,7 @@ func TestAuthorization(t *testing.T) {
 		`))
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: JWS verification error","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"JWS verification error","status":400}`)
 
 	responseWriter.Body.Reset()
 	wfe.NewAuthorization(newRequestEvent(), responseWriter,
@@ -1167,7 +1167,7 @@ func TestRegistration(t *testing.T) {
 	wfe.Registration(newRequestEvent(), responseWriter, makePostRequestWithPath("/2", "invalid"))
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Unable to read/verify body :: Parse error reading JWS","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"Parse error reading JWS","status":400}`)
 	responseWriter.Body.Reset()
 
 	key, err := jose.LoadPrivateKey([]byte(test2KeyPrivatePEM))
@@ -1350,13 +1350,13 @@ func TestLogCsrPem(t *testing.T) {
 
 func TestLengthRequired(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	_, _, _, err := wfe.verifyPOST(newRequestEvent(), &http.Request{
+	_, _, _, prob := wfe.verifyPOST(newRequestEvent(), &http.Request{
 		Method: "POST",
 		URL:    mustParseURL("/"),
 	}, false, "resource")
-	test.Assert(t, err != nil, "No error returned for request body missing Content-Length.")
-	_, ok := err.(core.LengthRequiredError)
-	test.Assert(t, ok, "Error code for missing content-length wasn't 411.")
+	test.Assert(t, prob != nil, "No error returned for request body missing Content-Length.")
+	test.AssertEquals(t, probs.MalformedProblem, prob.Type)
+	test.AssertEquals(t, http.StatusLengthRequired, prob.HTTPStatus)
 }
 
 type mockSADifferentStoredKey struct {
@@ -1398,30 +1398,6 @@ func TestBadKeyCSR(t *testing.T) {
 	test.AssertEquals(t,
 		responseWriter.Body.String(),
 		`{"type":"urn:acme:error:malformed","detail":"Invalid key in certificate request :: Key too small: 512","status":400}`)
-}
-
-func TestStatusCodeFromError(t *testing.T) {
-	testCases := []struct {
-		err        error
-		statusCode int
-	}{
-		{core.InternalServerError("foo"), 500},
-		{core.NotSupportedError("foo"), 501},
-		{core.MalformedRequestError("foo"), 400},
-		{core.UnauthorizedError("foo"), 403},
-		{core.NotFoundError("foo"), 404},
-		{core.SyntaxError("foo"), 400},
-		{core.SignatureValidationError("foo"), 400},
-		{core.RateLimitedError("foo"), 429},
-		{core.LengthRequiredError("foo"), 411},
-		{core.BadNonceError("foo"), statusBadNonce},
-	}
-	for _, c := range testCases {
-		got := statusCodeFromError(c.err)
-		if got != c.statusCode {
-			t.Errorf("Incorrect status code for %s. Expected %d, got %d", reflect.TypeOf(c.err).Name(), c.statusCode, got)
-		}
-	}
 }
 
 func newRequestEvent() *requestEvent {


### PR DESCRIPTION
This uses ProblemDetails throughout the wfe. This is the last step in allowing the backend services to pass ProblemDetails from RPCs through to the user.

Updates #1153.
    
Fixes #1161.