### PR TITLE
Allow PKCS11 config to be loaded from a file.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	cfsslConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/crypto/pkcs11key"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/publisher"
 	"github.com/letsencrypt/boulder/va"
@@ -263,16 +264,10 @@ func (pc *PAConfig) SetDefaultChallengesIfEmpty() {
 // KeyConfig should contain either a File path to a PEM-format private key,
 // or a PKCS11Config defining how to load a module for an HSM.
 type KeyConfig struct {
-	File   string
-	PKCS11 PKCS11Config
-}
-
-// PKCS11Config defines how to load a module for an HSM.
-type PKCS11Config struct {
-	Module          string
-	TokenLabel      string
-	PIN             string
-	PrivateKeyLabel string
+	// A file from which a pkcs11key.Config will be read and parsed, if present
+	ConfigFile string
+	File       string
+	PKCS11     *pkcs11key.Config
 }
 
 // TLSConfig reprents certificates and a key for authenticated TLS.


### PR DESCRIPTION
This allows secret values (PIN) to be separated from the main config.

Part of #1157.

In the process, move the CA constructor in the direction of
https://github.com/letsencrypt/boulder/wiki/Config-plan:

- Make most fields private.
- Take private key and issuer cert as constructor arguments rather than
  constructing them internally.

This allows the CA test to parse the private key and issuer cert once, rather
than once per test case.