### PR TITLE
Allow AMQP URLs to be loaded from files.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"strings"
 	"time"
 
 	cfsslConfig "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/config"
@@ -183,6 +185,10 @@ type ServiceConfig struct {
 // AMQPConfig describes how to connect to AMQP, and how to speak to each of the
 // RPC services we offer via AMQP.
 type AMQPConfig struct {
+	// A file from which the AMQP Server URL will be read. This allows secret
+	// values (like the password) to be stored separately from the main config.
+	ServerURLFile string
+	// AMQP server URL, including username and password.
 	Server    string
 	Insecure  bool
 	RA        *RPCServerConfig
@@ -198,6 +204,19 @@ type AMQPConfig struct {
 		Base ConfigDuration
 		Max  ConfigDuration
 	}
+}
+
+// ServerURL returns the appropriate server URL for this object, which may
+// involve reading from a file.
+func (a *AMQPConfig) ServerURL() (string, error) {
+	if a.ServerURLFile != "" {
+		url, err := ioutil.ReadFile(a.ServerURLFile)
+		return strings.TrimRight(string(url), "\n"), err
+	}
+	if a.Server == "" {
+		return "", fmt.Errorf("Missing AMQP server URL")
+	}
+	return a.Server, nil
 }
 
 // CAConfig structs have configuration information for the certificate

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -297,14 +297,19 @@ func makeAmqpChannel(conf *cmd.AMQPConfig) (*amqp.Channel, error) {
 
 	log := blog.GetAuditLogger()
 
+	serverURL, err := conf.ServerURL()
+	if err != nil {
+		return nil, err
+	}
+
 	if conf.Insecure == true {
 		// If the Insecure flag is true, then just go ahead and connect
-		conn, err = amqp.Dial(conf.Server)
+		conn, err = amqp.Dial(serverURL)
 	} else {
 		// The insecure flag is false or not set, so we need to load up the options
 		log.Info("AMQPS: Loading TLS Options.")
 
-		if strings.HasPrefix(conf.Server, "amqps") == false {
+		if strings.HasPrefix(serverURL, "amqps") == false {
 			err = fmt.Errorf("AMQPS: Not using an AMQPS URL. To use AMQP instead of AMQPS, set insecure=true")
 			return nil, err
 		}
@@ -348,7 +353,7 @@ func makeAmqpChannel(conf *cmd.AMQPConfig) (*amqp.Channel, error) {
 			log.Info("AMQPS: Configured CA certificate for AMQPS.")
 		}
 
-		conn, err = amqp.DialTLS(conf.Server, cfg)
+		conn, err = amqp.DialTLS(serverURL, cfg)
 	}
 
 	if err != nil {

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -96,7 +96,7 @@
     "maxConcurrentRPCServerRequests": 16,
     "hsmFaultTimeout": "300s",
     "amqp": {
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "serviceQueue": "CA.server",
       "SA": {
@@ -127,7 +127,7 @@
     "maxContactsPerRegistration": 100,
     "debugAddr": "localhost:8002",
     "amqp": {
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "serviceQueue": "RA.server",
       "VA": {
@@ -151,7 +151,7 @@
     "maxConcurrentRPCServerRequests": 16,
     "debugAddr": "localhost:8003",
     "amqp": {
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "serviceQueue": "SA.server"
     }
@@ -167,7 +167,7 @@
     },
     "maxConcurrentRPCServerRequests": 16,
     "amqp": {
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "serviceQueue": "VA.server",
       "RA": {
@@ -184,7 +184,7 @@
   "revoker": {
     "dbConnect": "mysql+tcp://revoker@localhost:3306/boulder_sa_integration",
     "amqp": {
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "RA": {
         "server": "RA.server",
@@ -223,7 +223,7 @@
     "signFailureBackoffMax": "30m",
     "debugAddr": "localhost:8006",
     "amqp": {
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "SA": {
         "server": "SA.server",
@@ -244,7 +244,7 @@
     "debugAddr": "localhost:8007",
     "amqp": {
       "serviceQueue": "Monitor",
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true
     }
   },
@@ -266,7 +266,7 @@
     "maxConcurrentRPCServerRequests": 16,
     "debugAddr": "localhost:8009",
     "amqp": {
-      "server": "amqp://guest:guest@localhost:5673",
+      "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "serviceQueue": "Publisher.server",
       "SA": {

--- a/test/secrets/amqp_url
+++ b/test/secrets/amqp_url
@@ -1,0 +1,1 @@
+amqp://guest:guest@localhost:5673


### PR DESCRIPTION
This allows secret values to be separated from the main config.

Part of #1157