### PR TITLE
Fix local test OCSP URL

### DIFF
--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -59,7 +59,7 @@
             "issuer_urls": [
               "http://127.0.0.1:4000/acme/issuer-cert"
             ],
-            "ocsp_url": "http://127.0.0.1:4002/ocsp",
+            "ocsp_url": "http://127.0.0.1:4002/",
             "crl_url": "http://example.com/crl",
             "policies": [
               {


### PR DESCRIPTION
Our current OCSP responder does not work right with non-/ paths.
Also the test OCSP responder is configured to server /.