### PR TITLE
Print errors from Activity Monitor's Start

### DIFF
--- a/cmd/activity-monitor/main.go
+++ b/cmd/activity-monitor/main.go
@@ -36,7 +36,8 @@ func main() {
 
 		go cmd.ProfileCmd("AM", stats)
 
-		server.Start(amqpConf)
+		err = server.Start(amqpConf)
+		cmd.FailOnError(err, "Unable to run Activity Monitor")
 	}
 
 	app.Run()


### PR DESCRIPTION
The other servers have this, I accidentally left it out when refactoring Activity Monitor.