### PR TITLE
Split out setup.sh from travis-before-install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ branches:
     - /^test-.*$/
 
 before_install:
-  - source test/travis-before-install.sh
+  - travis_retry test/travis-before-install.sh
 
 # Override default Travis install command to prevent it from adding
 # Godeps/_workspace to GOPATH. When that happens, it hides failures that should

--- a/test.sh
+++ b/test.sh
@@ -218,13 +218,6 @@ if [[ "$RUN" =~ "migrations" ]] ; then
 fi
 
 #
-# Prepare the database for unittests and integration tests
-#
-if [[ "${TRAVIS}" == "true" ]] ; then
-  ./test/create_db.sh || die "unable to create the boulder database with test/create_db.sh"
-fi
-
-#
 # Unit Tests.
 #
 if [[ "$RUN" =~ "unit" ]] ; then

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Fetch dependencies of Boulderthat are necessary for development or testing,
+# and configure database and RabbitMQ.
+#
+
+go get \
+  golang.org/x/tools/cmd/vet \
+  golang.org/x/tools/cmd/cover \
+  github.com/golang/lint/golint \
+  github.com/mattn/goveralls \
+  github.com/modocache/gover \
+  github.com/jcjones/github-pr-status \
+  github.com/jsha/listenbuddy &
+
+(wget https://github.com/jsha/boulder-tools/raw/master/goose.gz &&
+ mkdir -p $GOPATH/bin &&
+ zcat goose.gz > $GOPATH/bin/goose &&
+ chmod +x $GOPATH/bin/goose &&
+ ./test/create_db.sh) &
+
+# Set up rabbitmq exchange and activity monitor queue
+go run cmd/rabbitmq-setup/main.go -server amqp://localhost &
+
+# Wait for all the background commands to finish.
+wait

--- a/test/travis-before-install.sh
+++ b/test/travis-before-install.sh
@@ -1,50 +1,28 @@
 #!/bin/bash
 set -o xtrace
 
-if [ "${TRAVIS}" == "true" ]; then
-  # Boulder consists of multiple Go packages, which
-  # refer to each other by their absolute GitHub path,
-  # e.g. github.com/letsencrypt/boulder/analysis. That means, by default, if
-  # someone forks the repo, Travis won't pass on their own repo. To fix that,
-  # we add a symlink.
-  mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt
-  if [ ! -d $GOPATH/src/github.com/letsencrypt/boulder ] ; then
-    ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt/boulder
-  fi
-
-  # Travis does shallow clones, so there is no master branch present.
-  # But test-no-outdated-migrations.sh needs to check diffs against master.
-  # Fetch just the master branch from origin.
-  ( git fetch origin master
-  git branch master FETCH_HEAD ) &
-  # Github-PR-Status secret
-  if [ -n "$encrypted_53b2630f0fb4_key" ]; then
-    openssl aes-256-cbc \
-      -K $encrypted_53b2630f0fb4_key -iv $encrypted_53b2630f0fb4_iv \
-      -in test/github-secret.json.enc -out /tmp/github-secret.json -d
-  fi
-else
-  alias travis_retry=""
+# Boulder consists of multiple Go packages, which
+# refer to each other by their absolute GitHub path,
+# e.g. github.com/letsencrypt/boulder/analysis. That means, by default, if
+# someone forks the repo, Travis won't pass on their own repo. To fix that,
+# we add a symlink.
+mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt
+if [ ! -d $GOPATH/src/github.com/letsencrypt/boulder ] ; then
+  ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt/boulder
 fi
 
-travis_retry go get \
-  golang.org/x/tools/cmd/vet \
-  golang.org/x/tools/cmd/cover \
-  github.com/golang/lint/golint \
-  github.com/mattn/goveralls \
-  github.com/modocache/gover \
-  github.com/jcjones/github-pr-status \
-  github.com/jsha/listenbuddy &
+# Travis does shallow clones, so there is no master branch present.
+# But test-no-outdated-migrations.sh needs to check diffs against master.
+# Fetch just the master branch from origin.
+( git fetch origin master
+git branch master FETCH_HEAD ) &
+# Github-PR-Status secret
+if [ -n "$encrypted_53b2630f0fb4_key" ]; then
+  openssl aes-256-cbc \
+    -K $encrypted_53b2630f0fb4_key -iv $encrypted_53b2630f0fb4_iv \
+    -in test/github-secret.json.enc -out /tmp/github-secret.json -d
+fi
 
-(wget https://github.com/jsha/boulder-tools/raw/master/goose.gz &&
- mkdir -p $GOPATH/bin &&
- zcat goose.gz > $GOPATH/bin/goose &&
- chmod +x $GOPATH/bin/goose) &
-
-# Set up rabbitmq exchange and activity monitor queue
-go run cmd/rabbitmq-setup/main.go -server amqp://localhost &
-
-# Wait for all the background commands to finish.
-wait
+./test/setup.sh
 
 set +o xtrace


### PR DESCRIPTION
This accomplishes two things:
 - setup.sh should now be usable by the client integration test.
 - setup.sh can be used by new project members to simplify first setup.

Update the README to indicate the new file, and to correct some out-of-date
information.