### PR TITLE
bump Go version to 1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.1
+  - 1.5.2
 
 addons:
   hosts:


### PR DESCRIPTION
The Go 1.5.2 milestone: https://github.com/golang/go/issues?q=milestone%3AGo1.5.2