### PR TITLE
require a valid challenge type in RecordsSane

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -374,6 +374,8 @@ func (ch Challenge) RecordsSane() bool {
 		}
 	case ChallengeTypeDNS01:
 		// Nothing for now
+	default: // Unsupported challenge type
+		return false
 	}
 
 	return true

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -79,6 +79,21 @@ func TestRecordSanityCheck(t *testing.T) {
 	test.Assert(t, !chall.RecordsSane(), "Record should not be sane")
 }
 
+func TestRecordSanityCheckOnUnsupportChallengeType(t *testing.T) {
+	rec := []ValidationRecord{
+		ValidationRecord{
+			URL:               "http://localhost/test",
+			Hostname:          "localhost",
+			Port:              "80",
+			AddressesResolved: []net.IP{net.IP{127, 0, 0, 1}},
+			AddressUsed:       net.IP{127, 0, 0, 1},
+		},
+	}
+
+	chall := Challenge{Type: "obsoletedChallenge", ValidationRecord: rec}
+	test.Assert(t, !chall.RecordsSane(), "Record with unsupported challenge type should not be sane")
+}
+
 // TODO(https://github.com/letsencrypt/boulder/issues/894): Delete this test
 func TestChallengeSanityCheck_Legacy(t *testing.T) {
 	// Make a temporary account key


### PR DESCRIPTION
This is a change to ValidationRecord. This case is unlikely to be trigged by code, but was allowing tests to pass in a branch that deleted the simpleHttp and dvsni challenge types and is a good check to have in place.

Updates #894