### PR TITLE
update letsencrypt/go-safe-browsing-api

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -109,8 +109,8 @@
 		},
 		{
 			"ImportPath": "github.com/letsencrypt/go-safe-browsing-api",
-			"Comment": "2.0.0-2-g814cea4",
-			"Rev": "814cea4d6d3063540dc15c3d93754eff4eaa756b"
+			"Comment": "2.0.0-9-gf1b4fa4",
+			"Rev": "f1b4fa409d9efcee2ceee9047549413861603033"
 		},
 		{
 			"ImportPath": "github.com/letsencrypt/net/publicsuffix",


### PR DESCRIPTION
This should reduce our timeout problem in the VA by not locking out IsListed requests while the GSB file IO, and looping is occuring. These changes came in at https://github.com/letsencrypt/go-safe-browsing-api/pull/2 (also added
to the upstream at https://github.com/rjohnsondev/go-safe-browsing-api/pull/15).

Fixes #1253