### PR TITLE
look up CAA records parallel to validateChallenge

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -561,15 +561,17 @@ func (va *ValidationAuthorityImpl) validate(authz core.Authorization, challengeI
 }
 
 func (va *ValidationAuthorityImpl) validateChallengeAndCAA(identifier core.AcmeIdentifier, challenge core.Challenge, regID int64) (core.Challenge, error) {
+	ch := make(chan *probs.ProblemDetails, 1)
+	go func() {
+		ch <- va.checkCAA(identifier, regID)
+	}()
+
 	result, err := va.validateChallenge(identifier, challenge)
 	if err != nil {
 		return result, err
 	}
 
-	// Checking CAA happens after challenge validation because DNS errors affect
-	// both, and giving a DNS error on validation makes more sense than a DNS
-	// error on CAA.
-	problemDetails := va.checkCAA(identifier, regID)
+	problemDetails := <-ch
 	if problemDetails != nil {
 		result.Error = problemDetails
 		result.Status = core.StatusInvalid


### PR DESCRIPTION
Updates #1258

This is just a simple little change we can use later when we're wiring up retries and such. For now, it'll just lower the amount of time we have to wait, in aggregate, for validation.