### PR TITLE
move dns code to dns pkg and rename to bdns

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package core
+package bdns
 
 import (
 	"fmt"
@@ -112,6 +112,15 @@ var (
 		},
 	}
 )
+
+// DNSResolver defines methods used for DNS resolution
+type DNSResolver interface {
+	ExchangeOne(string, uint16) (*dns.Msg, time.Duration, error)
+	LookupTXT(string) ([]string, time.Duration, error)
+	LookupHost(string) ([]net.IP, time.Duration, error)
+	LookupCAA(string) ([]*dns.CAA, time.Duration, error)
+	LookupMX(string) ([]string, time.Duration, error)
+}
 
 // DNSResolverImpl represents a client that talks to an external resolver
 type DNSResolverImpl struct {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package core
+package bdns
 
 import (
 	"fmt"

--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -1,4 +1,9 @@
-package dns
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package bdns
 
 import (
 	"net"

--- a/bdns/problem_test.go
+++ b/bdns/problem_test.go
@@ -1,4 +1,9 @@
-package dns
+// Copyright 2015 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package bdns
 
 import (
 	"errors"

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
 
@@ -63,9 +63,9 @@ func main() {
 		raDNSTimeout, err := time.ParseDuration(c.Common.DNSTimeout)
 		cmd.FailOnError(err, "Couldn't parse RA DNS timeout")
 		if !c.Common.DNSAllowLoopbackAddresses {
-			rai.DNSResolver = core.NewDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver})
+			rai.DNSResolver = bdns.NewDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver})
 		} else {
-			rai.DNSResolver = core.NewTestDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver})
+			rai.DNSResolver = bdns.NewTestDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver})
 		}
 
 		rai.VA = vac

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
+	"github.com/letsencrypt/boulder/bdns"
 
 	"github.com/letsencrypt/boulder/cmd"
-	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rpc"
 	"github.com/letsencrypt/boulder/va"
@@ -46,9 +46,9 @@ func main() {
 		dnsTimeout, err := time.ParseDuration(c.Common.DNSTimeout)
 		cmd.FailOnError(err, "Couldn't parse DNS timeout")
 		if !c.Common.DNSAllowLoopbackAddresses {
-			vai.DNSResolver = core.NewDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver})
+			vai.DNSResolver = bdns.NewDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver})
 		} else {
-			vai.DNSResolver = core.NewTestDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver})
+			vai.DNSResolver = bdns.NewTestDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver})
 		}
 		vai.UserAgent = c.VA.UserAgent
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/miekg/dns"
 	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
 
@@ -138,15 +137,6 @@ type StorageAuthority interface {
 type CertificateAuthorityDatabase interface {
 	IncrementAndGetSerial(*gorp.Transaction) (int64, error)
 	Begin() (*gorp.Transaction, error)
-}
-
-// DNSResolver defines methods used for DNS resolution
-type DNSResolver interface {
-	ExchangeOne(string, uint16) (*dns.Msg, time.Duration, error)
-	LookupTXT(string) ([]string, time.Duration, error)
-	LookupHost(string) ([]net.IP, time.Duration, error)
-	LookupCAA(string) ([]*dns.CAA, time.Duration, error)
-	LookupMX(string) ([]string, time.Duration, error)
 }
 
 // Publisher defines the public interface for the Boulder Publisher

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -21,9 +21,9 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/golang.org/x/net/publicsuffix"
 
+	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/dns"
 	blog "github.com/letsencrypt/boulder/log"
 )
 
@@ -48,7 +48,7 @@ type RegistrationAuthorityImpl struct {
 	SA          core.StorageAuthority
 	PA          core.PolicyAuthority
 	stats       statsd.Statter
-	DNSResolver core.DNSResolver
+	DNSResolver bdns.DNSResolver
 	clk         clock.Clock
 	log         *blog.AuditLogger
 	dc          *DomainCheck
@@ -81,7 +81,7 @@ func NewRegistrationAuthorityImpl(clk clock.Clock, logger *blog.AuditLogger, sta
 var errUnparseableEmail = errors.New("not a valid e-mail address")
 var errEmptyDNSResponse = errors.New("empty DNS response")
 
-func validateEmail(address string, resolver core.DNSResolver) (rtt time.Duration, count int64, err error) {
+func validateEmail(address string, resolver bdns.DNSResolver) (rtt time.Duration, count int64, err error) {
 	_, err = mail.ParseAddress(address)
 	if err != nil {
 		return time.Duration(0), 0, errUnparseableEmail
@@ -101,7 +101,7 @@ func validateEmail(address string, resolver core.DNSResolver) (rtt time.Duration
 		}
 	}
 	if err != nil {
-		problem := dns.ProblemDetailsFromDNSError(err)
+		problem := bdns.ProblemDetailsFromDNSError(err)
 		err = core.MalformedRequestError(problem.Detail)
 	}
 	rtt = rtt1 + rtt2

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -25,8 +25,8 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/miekg/dns"
 	"github.com/letsencrypt/boulder/probs"
 
+	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/core"
-	bdns "github.com/letsencrypt/boulder/dns"
 	blog "github.com/letsencrypt/boulder/log"
 )
 
@@ -39,7 +39,7 @@ var validationTimeout = time.Second * 5
 type ValidationAuthorityImpl struct {
 	RA           core.RegistrationAuthority
 	log          *blog.AuditLogger
-	DNSResolver  core.DNSResolver
+	DNSResolver  bdns.DNSResolver
 	IssuerDomain string
 	SafeBrowsing SafeBrowsing
 	httpPort     int

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
+	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/probs"
 
 	"github.com/letsencrypt/boulder/core"
@@ -795,7 +796,7 @@ func TestDNSValidationServFail(t *testing.T) {
 func TestDNSValidationNoServer(t *testing.T) {
 	stats, _ := statsd.NewNoopClient()
 	va := NewValidationAuthorityImpl(&PortConfig{}, nil, stats, clock.Default())
-	va.DNSResolver = core.NewTestDNSResolverImpl(time.Second*5, []string{})
+	va.DNSResolver = bdns.NewTestDNSResolverImpl(time.Second*5, []string{})
 	mockRA := &MockRegistrationAuthority{}
 	va.RA = mockRA
 


### PR DESCRIPTION
Moves the DNS code from core to dns and renames the dns package to bdns to be clearer.

Fixes #1260 and will be good to have while we add retries and such.