### PR TITLE
bring RTT metrics inside DNSResolver

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/bdns"
+	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
 
@@ -62,10 +63,11 @@ func main() {
 		rai.PA = pa
 		raDNSTimeout, err := time.ParseDuration(c.Common.DNSTimeout)
 		cmd.FailOnError(err, "Couldn't parse RA DNS timeout")
+		scoped := metrics.NewStatsdScope(stats, "RA", "DNS")
 		if !c.Common.DNSAllowLoopbackAddresses {
-			rai.DNSResolver = bdns.NewDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver})
+			rai.DNSResolver = bdns.NewDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver}, scoped)
 		} else {
-			rai.DNSResolver = bdns.NewTestDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver})
+			rai.DNSResolver = bdns.NewTestDNSResolverImpl(raDNSTimeout, []string{c.Common.DNSResolver}, scoped)
 		}
 
 		rai.VA = vac

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/bdns"
+	"github.com/letsencrypt/boulder/metrics"
 
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
@@ -45,10 +46,11 @@ func main() {
 		vai := va.NewValidationAuthorityImpl(pc, sbc, stats, clock.Default())
 		dnsTimeout, err := time.ParseDuration(c.Common.DNSTimeout)
 		cmd.FailOnError(err, "Couldn't parse DNS timeout")
+		scoped := metrics.NewStatsdScope(stats, "VA", "DNS")
 		if !c.Common.DNSAllowLoopbackAddresses {
-			vai.DNSResolver = bdns.NewDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver})
+			vai.DNSResolver = bdns.NewDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver}, scoped)
 		} else {
-			vai.DNSResolver = bdns.NewTestDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver})
+			vai.DNSResolver = bdns.NewTestDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver}, scoped)
 		}
 		vai.UserAgent = c.VA.UserAgent
 		vai.IssuerDomain = c.VA.IssuerDomain

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -32,17 +32,12 @@ import (
 type DNSResolver struct {
 }
 
-// ExchangeOne is a mock
-func (mock *DNSResolver) ExchangeOne(hostname string, qt uint16) (rsp *dns.Msg, rtt time.Duration, err error) {
-	return nil, 0, nil
-}
-
 // LookupTXT is a mock
-func (mock *DNSResolver) LookupTXT(hostname string) ([]string, time.Duration, error) {
+func (mock *DNSResolver) LookupTXT(hostname string) ([]string, error) {
 	if hostname == "_acme-challenge.servfail.com" {
-		return nil, 0, fmt.Errorf("SERVFAIL")
+		return nil, fmt.Errorf("SERVFAIL")
 	}
-	return []string{"hostname"}, 0, nil
+	return []string{"hostname"}, nil
 }
 
 // TimeoutError returns a a net.OpError for which Timeout() returns true.
@@ -65,31 +60,31 @@ func (t timeoutError) Timeout() bool {
 //
 // Note: see comments on LookupMX regarding email.only
 //
-func (mock *DNSResolver) LookupHost(hostname string) ([]net.IP, time.Duration, error) {
+func (mock *DNSResolver) LookupHost(hostname string) ([]net.IP, error) {
 	if hostname == "always.invalid" ||
 		hostname == "invalid.invalid" ||
 		hostname == "email.only" {
-		return []net.IP{}, 0, nil
+		return []net.IP{}, nil
 	}
 	if hostname == "always.timeout" {
-		return []net.IP{}, 0, TimeoutError()
+		return []net.IP{}, TimeoutError()
 	}
 	if hostname == "always.error" {
-		return []net.IP{}, 0, &net.OpError{
+		return []net.IP{}, &net.OpError{
 			Err: errors.New("some net error"),
 		}
 	}
 	ip := net.ParseIP("127.0.0.1")
-	return []net.IP{ip}, 0, nil
+	return []net.IP{ip}, nil
 }
 
 // LookupCAA is a mock
-func (mock *DNSResolver) LookupCAA(domain string) ([]*dns.CAA, time.Duration, error) {
+func (mock *DNSResolver) LookupCAA(domain string) ([]*dns.CAA, error) {
 	var results []*dns.CAA
 	var record dns.CAA
 	switch strings.TrimRight(domain, ".") {
 	case "caa-timeout.com":
-		return nil, 0, TimeoutError()
+		return nil, TimeoutError()
 	case "reserved.com":
 		record.Tag = "issue"
 		record.Value = "symantec.com"
@@ -108,9 +103,9 @@ func (mock *DNSResolver) LookupCAA(domain string) ([]*dns.CAA, time.Duration, er
 		// reaches a public suffix.
 		fallthrough
 	case "servfail.com":
-		return results, 0, fmt.Errorf("SERVFAIL")
+		return results, fmt.Errorf("SERVFAIL")
 	}
-	return results, 0, nil
+	return results, nil
 }
 
 // LookupMX is a mock
@@ -120,16 +115,16 @@ func (mock *DNSResolver) LookupCAA(domain string) ([]*dns.CAA, time.Duration, er
 // all domains except for special cases, so MX-only domains must be
 // handled in both LookupHost and LookupMX.
 //
-func (mock *DNSResolver) LookupMX(domain string) ([]string, time.Duration, error) {
+func (mock *DNSResolver) LookupMX(domain string) ([]string, error) {
 	switch strings.TrimRight(domain, ".") {
 	case "letsencrypt.org":
 		fallthrough
 	case "email.only":
 		fallthrough
 	case "email.com":
-		return []string{"mail.email.com"}, 0, nil
+		return []string{"mail.email.com"}, nil
 	}
-	return nil, 0, nil
+	return nil, nil
 }
 
 // StorageAuthority is a mock

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -325,7 +325,7 @@ func TestValidateEmail(t *testing.T) {
 		"b@email.only",
 	}
 	for _, tc := range testFailures {
-		_, _, problem := validateEmail(tc.input, &mocks.DNSResolver{})
+		problem := validateEmail(tc.input, &mocks.DNSResolver{})
 		if problem.Type != probs.InvalidEmailProblem {
 			t.Errorf("validateEmail(%q): got problem type %#v, expected %#v", tc.input, problem.Type, probs.InvalidEmailProblem)
 		}
@@ -336,7 +336,7 @@ func TestValidateEmail(t *testing.T) {
 	}
 
 	for _, addr := range testSuccesses {
-		if _, _, prob := validateEmail(addr, &mocks.DNSResolver{}); prob != nil {
+		if prob := validateEmail(addr, &mocks.DNSResolver{}); prob != nil {
 			t.Errorf("validateEmail(%q): expected success, but it failed: %s",
 				addr, prob)
 		}

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	"github.com/letsencrypt/boulder/bdns"
+	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
 
 	"github.com/letsencrypt/boulder/core"
@@ -813,9 +814,10 @@ func TestDNSValidationServFail(t *testing.T) {
 }
 
 func TestDNSValidationNoServer(t *testing.T) {
-	stats, _ := statsd.NewNoopClient()
-	va := NewValidationAuthorityImpl(&PortConfig{}, nil, stats, clock.Default())
-	va.DNSResolver = bdns.NewTestDNSResolverImpl(time.Second*5, []string{})
+	c, _ := statsd.NewNoopClient()
+	stats := metrics.NewNoopScope()
+	va := NewValidationAuthorityImpl(&PortConfig{}, nil, c, clock.Default())
+	va.DNSResolver = bdns.NewTestDNSResolverImpl(time.Second*5, []string{}, stats)
 	mockRA := &MockRegistrationAuthority{}
 	va.RA = mockRA
 


### PR DESCRIPTION
This moves the RTT metrics calculation inside of the DNSResolver. This cleans up code in the RA and VA and makes some adding retries to the DNSResolver less ugly to do.

Note: this will put `Rate` and `RTT` after the name of DNS query type (`A`, `MX`, etc.). I think that's fine and desirable. We aren't using this data in alerts or many dashboards, yet, so a flag day is okay.

Fixes #1124

It relies on #1283, so please review it in that context.
