### PR TITLE
use letsencrypt minro version publicsuffix.

### DIFF
--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/Godeps/_workspace/src/golang.org/x/net/publicsuffix"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/net/publicsuffix"
 	"github.com/letsencrypt/boulder/probs"
 
 	"github.com/letsencrypt/boulder/bdns"


### PR DESCRIPTION
https://github.com/letsencrypt/boulder/pull/1262 update publicsuffix of
letsencrypt mirror version.
But registration-authority.go use the golang versin.
This make letsencrypt is still not support latest PSL.