### PR TITLE
Remove unneeded code in core.

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -6,8 +6,8 @@
 package core
 
 import (
-	"bytes"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -99,7 +99,6 @@ func TestErrors(t *testing.T) {
 		MalformedRequestError(testMessage),
 		UnauthorizedError(testMessage),
 		NotFoundError(testMessage),
-		SyntaxError(testMessage),
 		SignatureValidationError(testMessage),
 		CertificateIssuanceError(testMessage),
 	}
@@ -111,50 +110,10 @@ func TestErrors(t *testing.T) {
 	}
 }
 
-func TestB64(t *testing.T) {
-	b64Enc := "Ee9hR5p2cdudb5FHm1Z_M2nGcQG-yvZit1M6qaaM5w4"
-	binEnc := []byte{0x11, 0xef, 0x61, 0x47, 0x9a, 0x76, 0x71, 0xdb,
-		0x9d, 0x6f, 0x91, 0x47, 0x9b, 0x56, 0x7f, 0x33,
-		0x69, 0xc6, 0x71, 0x01, 0xbe, 0xca, 0xf6, 0x62,
-		0xb7, 0x53, 0x3a, 0xa9, 0xa6, 0x8c, 0xe7, 0x0e}
-
-	testB64 := B64enc(binEnc)
-	if testB64 != b64Enc {
-		t.Errorf("Base64 encoding produced incorrect result: %s", testB64)
-	}
-
-	b64Dec := "wJD0zUMZ-6YMIiNbcCG0jLzxVerTxfnQ"
-	binDec := []byte{192, 144, 244, 205, 67, 25, 251, 166,
-		12, 34, 35, 91, 112, 33, 180, 140,
-		188, 241, 85, 234, 211, 197, 249, 208}
-
-	testBin, err := B64dec(b64Dec)
-	if err != nil {
-		t.Errorf("Error in base64 decode: %v", err)
-	}
-	if bytes.Compare(testBin, binDec) != 0 {
-		t.Errorf("Base64 decoded to wrong value: %v", testBin)
-	}
-
-	b64Dec2 := "wJD0zUMZ-6YMIiNbcCG0jLzxVerTxfn"
-	binDec2 := []byte{192, 144, 244, 205, 67, 25, 251, 166,
-		12, 34, 35, 91, 112, 33, 180, 140,
-		188, 241, 85, 234, 211, 197, 249}
-
-	testBin2, err := B64dec(b64Dec2)
-	if err != nil {
-		t.Errorf("Error in base64 decode: %v", err)
-	}
-	if bytes.Compare(testBin2, binDec2) != 0 {
-		t.Errorf("Base64 decoded to wrong value: %v", testBin)
-	}
-
-}
-
 func TestRandomString(t *testing.T) {
 	byteLength := 256
 	b64 := RandomString(byteLength)
-	bin, err := B64dec(b64)
+	bin, err := base64.RawURLEncoding.DecodeString(b64)
 	if err != nil {
 		t.Errorf("Error in base64 decode: %v", err)
 	}
@@ -176,7 +135,7 @@ func TestFingerprint(t *testing.T) {
 		37, 99, 42, 171, 40, 236, 55, 187}
 
 	digest := Fingerprint256(in)
-	if digest != B64enc(out) {
+	if digest != base64.RawURLEncoding.EncodeToString(out) {
 		t.Errorf("Incorrect SHA-256 fingerprint: %v", digest)
 	}
 }

--- a/core/nonce.go
+++ b/core/nonce.go
@@ -9,6 +9,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"math/big"
 	"sync"
@@ -77,11 +78,11 @@ func (ns *NonceService) encrypt(counter int64) (string, error) {
 	ct := ns.gcm.Seal(nil, nonce, pt, nil)
 	copy(ret, nonce[4:])
 	copy(ret[8:], ct)
-	return B64enc(ret), nil
+	return base64.RawURLEncoding.EncodeToString(ret), nil
 }
 
 func (ns *NonceService) decrypt(nonce string) (int64, error) {
-	decoded, err := B64dec(nonce)
+	decoded, err := base64.RawURLEncoding.DecodeString(nonce)
 	if err != nil {
 		return 0, err
 	}

--- a/core/util.go
+++ b/core/util.go
@@ -8,7 +8,6 @@ package core
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -81,9 +80,6 @@ type NotFoundError string
 // LengthRequiredError indicates a POST was sent with no Content-Length.
 type LengthRequiredError string
 
-// SyntaxError indicates the user improperly formatted their data.
-type SyntaxError string
-
 // SignatureValidationError indicates that the user's signature could not
 // be verified, either through adversarial activity, or misconfiguration of
 // the user client.
@@ -116,7 +112,6 @@ func (e MalformedRequestError) Error() string    { return string(e) }
 func (e UnauthorizedError) Error() string        { return string(e) }
 func (e NotFoundError) Error() string            { return string(e) }
 func (e LengthRequiredError) Error() string      { return string(e) }
-func (e SyntaxError) Error() string              { return string(e) }
 func (e SignatureValidationError) Error() string { return string(e) }
 func (e CertificateIssuanceError) Error() string { return string(e) }
 func (e NoSuchRegistrationError) Error() string  { return string(e) }
@@ -137,7 +132,7 @@ func ProblemDetailsForError(err error, msg string) *probs.ProblemDetails {
 	switch e := err.(type) {
 	case *probs.ProblemDetails:
 		return e
-	case MalformedRequestError, SyntaxError:
+	case MalformedRequestError:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case NotSupportedError:
 		return &probs.ProblemDetails{
@@ -170,36 +165,6 @@ func ProblemDetailsForError(err error, msg string) *probs.ProblemDetails {
 	}
 }
 
-// Base64 functions
-
-func pad(x string) string {
-	switch len(x) % 4 {
-	case 2:
-		return x + "=="
-	case 3:
-		return x + "="
-	}
-	return x
-}
-
-func unpad(x string) string {
-	end := len(x)
-	for end != 0 && x[end-1] == '=' {
-		end--
-	}
-	return x[:end]
-}
-
-// B64enc encodes a byte array as unpadded, URL-safe Base64
-func B64enc(x []byte) string {
-	return unpad(base64.URLEncoding.EncodeToString(x))
-}
-
-// B64dec decodes a byte array from unpadded, URL-safe Base64
-func B64dec(x string) ([]byte, error) {
-	return base64.URLEncoding.DecodeString(pad(x))
-}
-
 // Random stuff
 
 // RandomString returns a randomly generated string of the requested length.
@@ -211,7 +176,7 @@ func RandomString(byteLength int) string {
 		logger := blog.GetAuditLogger()
 		logger.EmergencyExit(ohdear)
 	}
-	return B64enc(b)
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 // NewToken produces a random string for Challenges, etc.
@@ -234,97 +199,7 @@ func LooksLikeAToken(token string) bool {
 func Fingerprint256(data []byte) string {
 	d := sha256.New()
 	_, _ = d.Write(data) // Never returns an error
-	return B64enc(d.Sum(nil))
-}
-
-// Thumbprint produces a JWK thumbprint [RFC7638] of a JWK.
-// XXX(rlb): This is adapted from a PR to go-jose, but we need it here until
-//           that PR is merged and we update to that version.
-//           https://github.com/square/go-jose/pull/37
-// XXX(rlb): Once that lands, we should replace the digest methods below
-//           with this standard thumbprint.
-const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`
-const ecThumbprintTemplate = `{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`
-
-// Get JOSE name of curve
-func curveName(crv elliptic.Curve) (string, error) {
-	switch crv {
-	case elliptic.P256():
-		return "P-256", nil
-	case elliptic.P384():
-		return "P-384", nil
-	case elliptic.P521():
-		return "P-521", nil
-	default:
-		return "", fmt.Errorf("square/go-jose: unsupported/unknown elliptic curve")
-	}
-}
-
-// Get size of curve in bytes
-func curveSize(crv elliptic.Curve) int {
-	bits := crv.Params().BitSize
-
-	div := bits / 8
-	mod := bits % 8
-
-	if mod == 0 {
-		return div
-	}
-
-	return div + 1
-}
-
-func newFixedSizeBuffer(data []byte, length int) []byte {
-	if len(data) > length {
-		panic("square/go-jose: invalid call to newFixedSizeBuffer (len(data) > length)")
-	}
-	pad := make([]byte, length-len(data))
-	return append(pad, data...)
-}
-
-func ecThumbprintInput(curve elliptic.Curve, x, y *big.Int) (string, error) {
-	coordLength := curveSize(curve)
-	crv, err := curveName(curve)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf(ecThumbprintTemplate, crv,
-		B64enc(newFixedSizeBuffer(x.Bytes(), coordLength)),
-		B64enc(newFixedSizeBuffer(y.Bytes(), coordLength))), nil
-}
-
-func rsaThumbprintInput(n *big.Int, e int) (string, error) {
-	return fmt.Sprintf(rsaThumbprintTemplate,
-		B64enc(big.NewInt(int64(e)).Bytes()),
-		B64enc(n.Bytes())), nil
-}
-
-// Thumbprint computes the JWK Thumbprint of a key using the
-// indicated hash algorithm.
-func Thumbprint(k *jose.JsonWebKey) (string, error) {
-	var input string
-	var err error
-	switch key := k.Key.(type) {
-	case *ecdsa.PublicKey:
-		input, err = ecThumbprintInput(key.Curve, key.X, key.Y)
-	case *ecdsa.PrivateKey:
-		input, err = ecThumbprintInput(key.Curve, key.X, key.Y)
-	case *rsa.PublicKey:
-		input, err = rsaThumbprintInput(key.N, key.E)
-	case *rsa.PrivateKey:
-		input, err = rsaThumbprintInput(key.N, key.E)
-	default:
-		return "", fmt.Errorf("square/go-jose: unkown key type")
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	h := sha256.New()
-	h.Write([]byte(input))
-	return B64enc(h.Sum(nil)), nil
+	return base64.RawURLEncoding.EncodeToString(d.Sum(nil))
 }
 
 // KeyDigest produces a padded, standard Base64-encoded SHA256 digest of a

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -74,15 +74,6 @@ const JWK2JSON = `{
   "e":"AQAB"
 }`
 
-func TestKeyThumbprint(t *testing.T) {
-	var jwk jose.JsonWebKey
-	json.Unmarshal([]byte(JWK1JSON), &jwk)
-	thumbprint, err := Thumbprint(&jwk)
-
-	test.AssertNotError(t, err, "Failed to compute JWK digest")
-	test.AssertEquals(t, thumbprint, JWK1Thumbprint)
-}
-
 func TestKeyDigest(t *testing.T) {
 	// Test with JWK (value, reference, and direct)
 	var jwk jose.JsonWebKey
@@ -142,7 +133,6 @@ func TestProblemDetailsFromError(t *testing.T) {
 		{MalformedRequestError("foo"), 400, probs.MalformedProblem},
 		{UnauthorizedError("foo"), 403, probs.UnauthorizedProblem},
 		{NotFoundError("foo"), 404, probs.MalformedProblem},
-		{SyntaxError("foo"), 400, probs.MalformedProblem},
 		{SignatureValidationError("foo"), 400, probs.MalformedProblem},
 		{RateLimitedError("foo"), 429, probs.RateLimitedProblem},
 		{LengthRequiredError("foo"), 411, probs.MalformedProblem},

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -210,8 +210,6 @@ func wrapError(err error) *rpcError {
 			wrapped.Type = "UnauthorizedError"
 		case core.NotFoundError:
 			wrapped.Type = "NotFoundError"
-		case core.SyntaxError:
-			wrapped.Type = "SyntaxError"
 		case core.SignatureValidationError:
 			wrapped.Type = "SignatureValidationError"
 		case core.CertificateIssuanceError:
@@ -248,8 +246,6 @@ func unwrapError(rpcError *rpcError) error {
 			return core.UnauthorizedError(rpcError.Value)
 		case "NotFoundError":
 			return core.NotFoundError(rpcError.Value)
-		case "SyntaxError":
-			return core.SyntaxError(rpcError.Value)
 		case "SignatureValidationError":
 			return core.SignatureValidationError(rpcError.Value)
 		case "CertificateIssuanceError":

--- a/rpc/amqp-rpc_test.go
+++ b/rpc/amqp-rpc_test.go
@@ -22,7 +22,6 @@ func TestWrapError(t *testing.T) {
 		core.MalformedRequestError("foo"),
 		core.UnauthorizedError("foo"),
 		core.NotFoundError("foo"),
-		core.SyntaxError("foo"),
 		core.SignatureValidationError("foo"),
 		core.CertificateIssuanceError("foo"),
 		core.NoSuchRegistrationError("foo"),


### PR DESCRIPTION
B64enc and B64dec can be replaced by base64.RawURLEncoding.
Thumbprint is now implemented in go-jose, and we have the relevant version
imported already, so we can use that.
SyntaxError was not used anywhere so we can remove that.

Fixes #1034.
Fixes #1168 