### PR TITLE
fix pending authz rate limit check

### DIFF
--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -268,7 +268,7 @@ func checkPendingAuthorizationLimit(sa core.StorageGetter, limit *cmd.RateLimitP
 		// Most rate limits have a key for overrides, but there is no meaningful key
 		// here.
 		noKey := ""
-		if count > limit.GetThreshold(noKey, regID) {
+		if count >= limit.GetThreshold(noKey, regID) {
 			return core.RateLimitedError("Too many currently pending authorizations.")
 		}
 	}

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -722,6 +722,36 @@ func TestTotalCertRateLimit(t *testing.T) {
 	test.AssertError(t, err, "Total certificate rate limit failed")
 }
 
+func TestAuthzRateLimiting(t *testing.T) {
+	_, _, ra, fc, cleanUp := initAuthorities(t)
+	defer cleanUp()
+
+	ra.rlPolicies = cmd.RateLimitConfig{
+		PendingAuthorizationsPerAccount: cmd.RateLimitPolicy{
+			Threshold: 1,
+			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
+		},
+	}
+	fc.Add(24 * 90 * time.Hour)
+
+	// Should be able to create an authzRequest
+	authz, err := ra.NewAuthorization(AuthzRequest, Registration.ID)
+	test.AssertNotError(t, err, "NewAuthorization failed")
+
+	fc.Add(time.Hour)
+
+	// Second one should trigger rate limit
+	_, err = ra.NewAuthorization(AuthzRequest, Registration.ID)
+	test.AssertError(t, err, "Pending Authorization rate limit failed.")
+
+	// Finalize pending authz
+	ra.OnValidationUpdate(authz)
+
+	// Try to create a new authzRequest, should be fine now.
+	_, err = ra.NewAuthorization(AuthzRequest, Registration.ID)
+	test.AssertNotError(t, err, "NewAuthorization failed")
+}
+
 func TestDomainsForRateLimiting(t *testing.T) {
 	domains, err := domainsForRateLimiting([]string{})
 	test.AssertNotError(t, err, "failed on empty")


### PR DESCRIPTION
Currently the check allows creating limit + 1 pending authz