### PR TITLE
Fix dns value encoding to be compliant with acme v01 spec

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -37,6 +37,12 @@ func (mock *DNSResolver) LookupTXT(hostname string) ([]string, error) {
 	if hostname == "_acme-challenge.servfail.com" {
 		return nil, fmt.Errorf("SERVFAIL")
 	}
+	if hostname == "_acme-challenge.good-dns01.com" {
+		// base64(sha254("LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
+		//               + "." + "9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI"))
+		// expected token + test account jwk thumbprint
+		return []string{"LPsIwTo7o8BoG0-vjCyGQGBWSVIPxI-i_X336eUOQZo"}, nil
+	}
 	return []string{"hostname"}, nil
 }
 

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -17,6 +17,7 @@
 var colors = require("colors");
 var cli = require("cli");
 var cryptoUtil = require("./crypto-util");
+var crypto = require("crypto");
 var child_process = require('child_process');
 var fs = require('fs');
 var http = require('http');
@@ -388,7 +389,7 @@ function validateDns01(challenge) {
     method: "POST",
     json: {
       "host": recordName,
-      "value": cryptoUtil.sha256(new Buffer(keyAuthorization))
+      "value": util.b64enc(crypto.createHash('sha256').update(keyAuthorization).digest())
     }
   }, txtCallback);
 }

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -425,7 +426,7 @@ func (va *ValidationAuthorityImpl) validateDNS01(identifier core.AcmeIdentifier,
 	// Compute the digest of the key authorization file
 	h := sha256.New()
 	h.Write([]byte(challenge.KeyAuthorization.String()))
-	authorizedKeysDigest := hex.EncodeToString(h.Sum(nil))
+	authorizedKeysDigest := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 
 	// Look for the required record in the DNS
 	challengeSubdomain := fmt.Sprintf("%s.%s", core.DNSPrefix, identifier.Value)


### PR DESCRIPTION
"The record provisioned to the DNS is the base64url encoding of this digest"