### PR TITLE
Go get works on packages, not on URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To update the Go dependencies:
 
 ```
 # Fetch godep
-go get -u https://github.com/tools/godep
+go get -u github.com/tools/godep
 # Check out the currently vendorized version of each dependency.
 godep restore
 # Update to the latest version of a dependency. Alternately you can cd to the


### PR DESCRIPTION
The previously mentioned command fails with

```
$ go get -u https://github.com/tools/godep
package https:/github.com/tools/godep: "https://" not allowed in import path
```