### PR TITLE
Initialize rabbitmq in Docker entrypoint

### DIFF
--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -12,10 +12,19 @@ while ! exec 6<>/dev/tcp/0.0.0.0/3306; do
     sleep 1
 done
 
+# make sure we can reach the rabbitmq
+while ! exec 6<>/dev/tcp/0.0.0.0/5672; do
+    echo "$(date) - still trying to connect to rabbitmq at 0.0.0.0:5672"
+    sleep 1
+done
+
 exec 6>&-
 exec 6<&-
 
 # create the database
 source $DIR/create_db.sh
+
+# Set up rabbitmq exchange and activity monitor queue
+go run cmd/rabbitmq-setup/main.go -server amqp://localhost
 
 $@


### PR DESCRIPTION
When running `./test/run-docker.sh` the container named `boulder` fails due an `Could not bind to queue Exception (404) Reason: "NOT_FOUND - no exchange 'boulder' in vhost '/'"` error.

This error causes both `bin/boulder-wfe` and `bin/boulder-va` to abort, but it can also be seen in the logs for `activity-monitor` and `boulder-ra`.

This PR waits for rabbitmq to be ready and initializes it in a similar way to how mariadb is initialized.

I was able to consistently reproduce this by killing and already initialized cluster to simulate a fresh install:

`docker ps -q --filter "name=boulder-*" | xargs -n1 docker kill`