### PR TITLE
RabbitMQ must also run on the host network on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 boulder:
     build: .
     dockerfile: Dockerfile
-    net: "host"
+    net: host
     ports:
         - "4000:4000"
     environment:
@@ -15,5 +15,6 @@ mysql:
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 rabbitmq:
     image: rabbitmq:3
+    net: host
     ports:
         - "5672:5672"


### PR DESCRIPTION
For the same reasons it runs on the `host` network in `test/run-docker.sh`.