### PR TITLE
Make expiration mailer RFC 822 compliant (and satisfy SpamAssassin)

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
@@ -72,7 +73,7 @@ func (m *mailer) sendNags(parsedCert *x509.Certificate, contacts []*core.AcmeURL
 			return err
 		}
 		startSending := m.clk.Now()
-		err = m.mailer.SendMail(emails, msgBuf.String())
+		err = m.mailer.SendMail(emails, "Certificate expiration notice", msgBuf.String())
 		if err != nil {
 			m.stats.Inc("Mailer.Expiration.Errors.SendingNag.SendFailure", 1, 1.0)
 			return err

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
+
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/mocks"
@@ -40,21 +41,6 @@ func bigIntFromB64(b64 string) *big.Int {
 
 func intFromB64(b64 string) int {
 	return int(bigIntFromB64(b64).Int64())
-}
-
-type mockMail struct {
-	Messages []string
-}
-
-func (m *mockMail) Clear() {
-	m.Messages = []string{}
-}
-
-func (m *mockMail) SendMail(to []string, subject, msg string) (err error) {
-	for range to {
-		m.Messages = append(m.Messages, msg)
-	}
-	return
 }
 
 type fakeRegStore struct {
@@ -104,7 +90,7 @@ var (
 
 func TestSendNags(t *testing.T) {
 	stats, _ := statsd.NewNoopClient(nil)
-	mc := mockMail{}
+	mc := mocks.Mailer{}
 	rs := newFakeRegStore()
 	fc := newFakeClock(t)
 
@@ -461,7 +447,7 @@ func TestDontFindRevokedCert(t *testing.T) {
 type testCtx struct {
 	dbMap   *gorp.DbMap
 	ssa     core.StorageAdder
-	mc      *mockMail
+	mc      *mocks.Mailer
 	fc      clock.FakeClock
 	m       *mailer
 	cleanUp func()
@@ -482,7 +468,7 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 	cleanUp := test.ResetSATestDatabase(t)
 
 	stats, _ := statsd.NewNoopClient(nil)
-	mc := &mockMail{}
+	mc := &mocks.Mailer{}
 
 	offsetNags := make([]time.Duration, len(nagTimes))
 	for i, t := range nagTimes {

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -50,7 +50,7 @@ func (m *mockMail) Clear() {
 	m.Messages = []string{}
 }
 
-func (m *mockMail) SendMail(to []string, msg string) (err error) {
+func (m *mockMail) SendMail(to []string, subject, msg string) (err error) {
 	for range to {
 		m.Messages = append(m.Messages, msg)
 	}

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -6,13 +6,17 @@
 package mail
 
 import (
+	"fmt"
+	"math/rand"
 	"net"
 	"net/smtp"
+	"strings"
+	"time"
 )
 
 // Mailer provides the interface for a mailer
 type Mailer interface {
-	SendMail([]string, string) error
+	SendMail([]string, string, string) error
 }
 
 // MailerImpl defines a mail transfer agent to use for sending mail
@@ -35,9 +39,26 @@ func New(server, port, username, password string) MailerImpl {
 	}
 }
 
+func (m *MailerImpl) generateMessage(to []string, subject, body string) []byte {
+	now := time.Now().UTC()
+	headers := []string{
+		fmt.Sprintf("To: %s", strings.Join(to, ", ")),
+		fmt.Sprintf("From: %s", m.From),
+		fmt.Sprintf("Subject: %s", subject),
+		fmt.Sprintf("Date: %s", now.Format("Mon Jan 2 2006 15:04:05 -0700")),
+		fmt.Sprintf("Message-Id: <%s.%d.%s>", now.Format("20060102T150405"), rand.Int63(), m.From),
+	}
+	return []byte(fmt.Sprintf("%s\r\n\r\n%s\r\n", strings.Join(headers, "\r\n"), body))
+}
+
 // SendMail sends an email to the provided list of recipients. The email body
 // is simple text.
-func (m *MailerImpl) SendMail(to []string, msg string) (err error) {
-	err = smtp.SendMail(net.JoinHostPort(m.Server, m.Port), m.Auth, m.From, to, []byte(msg))
-	return
+func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
+	return smtp.SendMail(
+		net.JoinHostPort(m.Server, m.Port),
+		m.Auth,
+		m.From,
+		to,
+		m.generateMessage(to, subject, msg),
+	)
 }

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -11,7 +11,8 @@ import (
 	"net"
 	"net/smtp"
 	"strings"
-	"time"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 )
 
 // Mailer provides the interface for a mailer
@@ -25,6 +26,7 @@ type MailerImpl struct {
 	Port   string
 	Auth   smtp.Auth
 	From   string
+	clk    clock.Clock
 }
 
 // New constructs a Mailer to represent an account on a particular mail
@@ -36,11 +38,13 @@ func New(server, port, username, password string) MailerImpl {
 		Port:   port,
 		Auth:   auth,
 		From:   username,
+		clk:    clock.Default(),
 	}
 }
 
 func (m *MailerImpl) generateMessage(to []string, subject, body string) []byte {
-	now := time.Now().UTC()
+	now := m.clk.Now().UTC()
+	rand.Seed(int64(now.Nanosecond()))
 	headers := []string{
 		fmt.Sprintf("To: %s", strings.Join(to, ", ")),
 		fmt.Sprintf("From: %s", m.From),

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -42,3 +42,10 @@ func TestGenerateMessage(t *testing.T) {
 	test.AssertEquals(t, fields[8], "")
 	test.AssertEquals(t, fields[9], "this is the body")
 }
+
+func TestFailNonASCIIAddress(t *testing.T) {
+	fc := clock.NewFake()
+	m := MailerImpl{From: "send@email.com", clk: fc, csprgSource: fakeSource{}}
+	_, err := m.generateMessage([]string{"遗憾@email.com"}, "test subject", "this is the body\n")
+	test.AssertError(t, err, "Allowed a non-ASCII to address incorrectly")
+}

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -6,6 +6,7 @@
 package mail
 
 import (
+	"fmt"
 	"io"
 	"math/big"
 	"strings"
@@ -29,13 +30,16 @@ func TestGenerateMessage(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to generate email body")
 	message := string(messageBytes)
 	fields := strings.Split(message, "\r\n")
-	test.AssertEquals(t, len(fields), 8)
+	test.AssertEquals(t, len(fields), 12)
+	fmt.Println(message)
 	test.AssertEquals(t, fields[0], "To: \"recv@email.com\"")
 	test.AssertEquals(t, fields[1], "From: send@email.com")
 	test.AssertEquals(t, fields[2], "Subject: test subject")
 	test.AssertEquals(t, fields[3], "Date: Thu Jan 1 1970 00:00:00 +0000")
 	test.AssertEquals(t, fields[4], "Message-Id: <19700101T000000.1991.send@email.com>")
-	test.AssertEquals(t, fields[5], "")
-	test.AssertEquals(t, fields[6], "this is the body\\n")
-	test.AssertEquals(t, fields[7], "")
+	test.AssertEquals(t, fields[5], "MIME-Version: 1.0")
+	test.AssertEquals(t, fields[6], "Content-Type: text/plain")
+	test.AssertEquals(t, fields[7], "Content-Transfer-Encoding: quoted-printable")
+	test.AssertEquals(t, fields[8], "")
+	test.AssertEquals(t, fields[9], "this is the body")
 }

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -6,6 +6,8 @@
 package mail
 
 import (
+	"io"
+	"math/big"
 	"strings"
 	"testing"
 
@@ -14,20 +16,26 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
+type fakeSource struct{}
+
+func (f fakeSource) Int(reader io.Reader, max *big.Int) (*big.Int, error) {
+	return big.NewInt(1991), nil
+}
+
 func TestGenerateMessage(t *testing.T) {
 	fc := clock.NewFake()
-	m := MailerImpl{From: "send@email.com", clk: fc}
-	messageBytes, err := m.generateMessage([]string{"recv@email.com"}, "test subject", "this is the body")
+	m := MailerImpl{From: "send@email.com", clk: fc, csprgSource: fakeSource{}}
+	messageBytes, err := m.generateMessage([]string{"recv@email.com"}, "test subject", "this is the body\n")
 	test.AssertNotError(t, err, "Failed to generate email body")
 	message := string(messageBytes)
 	fields := strings.Split(message, "\r\n")
 	test.AssertEquals(t, len(fields), 8)
-	test.AssertEquals(t, fields[0], "To: recv@email.com")
+	test.AssertEquals(t, fields[0], "To: \"recv@email.com\"")
 	test.AssertEquals(t, fields[1], "From: send@email.com")
 	test.AssertEquals(t, fields[2], "Subject: test subject")
 	test.AssertEquals(t, fields[3], "Date: Thu Jan 1 1970 00:00:00 +0000")
-	test.AssertEquals(t, fields[4], "Message-Id: <19700101T000000.8717895732742165505.send@email.com>")
+	test.AssertEquals(t, fields[4], "Message-Id: <19700101T000000.1991.send@email.com>")
 	test.AssertEquals(t, fields[5], "")
-	test.AssertEquals(t, fields[6], "this is the body")
+	test.AssertEquals(t, fields[6], "this is the body\\n")
 	test.AssertEquals(t, fields[7], "")
 }

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -17,7 +17,9 @@ import (
 func TestGenerateMessage(t *testing.T) {
 	fc := clock.NewFake()
 	m := MailerImpl{From: "send@email.com", clk: fc}
-	message := string(m.generateMessage([]string{"recv@email.com"}, "test subject", "this is the body"))
+	messageBytes, err := m.generateMessage([]string{"recv@email.com"}, "test subject", "this is the body")
+	test.AssertNotError(t, err, "Failed to generate email body")
+	message := string(messageBytes)
 	fields := strings.Split(message, "\r\n")
 	test.AssertEquals(t, len(fields), 8)
 	test.AssertEquals(t, fields[0], "To: recv@email.com")

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -7,7 +7,6 @@ package mail
 
 import (
 	"fmt"
-	"io"
 	"math/big"
 	"strings"
 	"testing"
@@ -19,8 +18,8 @@ import (
 
 type fakeSource struct{}
 
-func (f fakeSource) Int(reader io.Reader, max *big.Int) (*big.Int, error) {
-	return big.NewInt(1991), nil
+func (f fakeSource) generate() *big.Int {
+	return big.NewInt(1991)
 }
 
 func TestGenerateMessage(t *testing.T) {
@@ -35,10 +34,10 @@ func TestGenerateMessage(t *testing.T) {
 	test.AssertEquals(t, fields[0], "To: \"recv@email.com\"")
 	test.AssertEquals(t, fields[1], "From: send@email.com")
 	test.AssertEquals(t, fields[2], "Subject: test subject")
-	test.AssertEquals(t, fields[3], "Date: Thu Jan 1 1970 00:00:00 +0000")
+	test.AssertEquals(t, fields[3], "Date: 01 Jan 70 00:00 UTC")
 	test.AssertEquals(t, fields[4], "Message-Id: <19700101T000000.1991.send@email.com>")
 	test.AssertEquals(t, fields[5], "MIME-Version: 1.0")
-	test.AssertEquals(t, fields[6], "Content-Type: text/plain")
+	test.AssertEquals(t, fields[6], "Content-Type: text/plain; charset=UTF-8")
 	test.AssertEquals(t, fields[7], "Content-Transfer-Encoding: quoted-printable")
 	test.AssertEquals(t, fields[8], "")
 	test.AssertEquals(t, fields[9], "this is the body")

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -4,3 +4,28 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 package mail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestGenerateMessage(t *testing.T) {
+	fc := clock.NewFake()
+	m := MailerImpl{From: "send@email.com", clk: fc}
+	message := string(m.generateMessage([]string{"recv@email.com"}, "test subject", "this is the body"))
+	fields := strings.Split(message, "\r\n")
+	test.AssertEquals(t, len(fields), 8)
+	test.AssertEquals(t, fields[0], "To: recv@email.com")
+	test.AssertEquals(t, fields[1], "From: send@email.com")
+	test.AssertEquals(t, fields[2], "Subject: test subject")
+	test.AssertEquals(t, fields[3], "Date: Thu Jan 1 1970 00:00:00 +0000")
+	test.AssertEquals(t, fields[4], "Message-Id: <19700101T000000.8717895732742165505.send@email.com>")
+	test.AssertEquals(t, fields[5], "")
+	test.AssertEquals(t, fields[6], "this is the body")
+	test.AssertEquals(t, fields[7], "")
+}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -422,3 +422,21 @@ func (s *Statter) Inc(metric string, value int64, rate float32) error {
 func NewStatter() Statter {
 	return Statter{statsd.NoopClient{}, map[string]int64{}}
 }
+
+// Mailer is a mock
+type Mailer struct {
+	Messages []string
+}
+
+// Clear removes any previously recorded messages
+func (m *Mailer) Clear() {
+	m.Messages = []string{}
+}
+
+// SendMail is a mock
+func (m *Mailer) SendMail(to []string, subject, msg string) (err error) {
+	for range to {
+		m.Messages = append(m.Messages, msg)
+	}
+	return
+}


### PR DESCRIPTION
Fixes #1087 (Posting this before adding any tests since there is a Tor talk I'm interested in soon and I'm not sure if I'll figure out how to test it/finish writing the tests before it starts).

This adds the necessary email headers as specified in RFC 822 but ignores the MIME multi-part stuff since the current mailer assumes plain text messages. If we wish to send HTML messages that should probably be a separate issue/patch (although it could be rolled into this if necessary).