### PR TITLE
delete ca.RevokeCertificate

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -218,12 +218,6 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(xferObj core.OCSPSigningRequest
 	return ocspResponse, err
 }
 
-// RevokeCertificate revokes the trust of the Cert referred to by the provided Serial.
-func (ca *CertificateAuthorityImpl) RevokeCertificate(serial string, reasonCode core.RevocationCode) (err error) {
-	err = ca.SA.MarkCertificateRevoked(serial, reasonCode)
-	return err
-}
-
 // IssueCertificate attempts to convert a CSR into a signed Certificate, while
 // enforcing all policies. Names (domains) in the CertificateRequest will be
 // lowercased before storage.

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -29,10 +29,6 @@ func (ca *mockCA) GenerateOCSP(xferObj core.OCSPSigningRequest) (ocsp []byte, er
 	return
 }
 
-func (ca *mockCA) RevokeCertificate(serial string, reasonCode core.RevocationCode) (err error) {
-	return
-}
-
 type mockPub struct {
 	sa core.StorageAuthority
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	jose "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/letsencrypt/go-jose"
-	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
 
 // A WebFrontEnd object supplies methods that can be hooked into
@@ -83,7 +82,6 @@ type RegistrationAuthority interface {
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
 	IssueCertificate(x509.CertificateRequest, int64) (Certificate, error)
-	RevokeCertificate(string, RevocationCode) error
 	GenerateOCSP(OCSPSigningRequest) ([]byte, error)
 }
 
@@ -131,12 +129,6 @@ type StorageAdder interface {
 type StorageAuthority interface {
 	StorageGetter
 	StorageAdder
-}
-
-// CertificateAuthorityDatabase represents an atomic sequence source
-type CertificateAuthorityDatabase interface {
-	IncrementAndGetSerial(*gorp.Transaction) (int64, error)
-	Begin() (*gorp.Transaction, error)
 }
 
 // Publisher defines the public interface for the Boulder Publisher


### PR DESCRIPTION
Also, delete the unused core.CertificateAuthorityDatabase while we're here.

Fixes #1319