### PR TITLE
Disable activity-monitor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ _testmain.go
 *.test
 *.prof
 *.coverprofile
-
-boulder-start/boulder-start
-activity-monitor/activity-monitor

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -201,12 +201,6 @@ def run_client_tests():
     if subprocess.Popen(cmd, shell=True, cwd=root, executable='/bin/bash').wait() != 0:
         die(ExitStatus.PythonFailure)
 
-def check_activity_monitor():
-    """Ensure that the activity monitor is running and received some messages."""
-    resp = urllib2.urlopen("http://localhost:8007/debug/vars")
-    debug_vars = json.loads(resp.read())
-    assert debug_vars['messages'] > 0, "Activity Monitor received zero messages."
-
 @atexit.register
 def cleanup():
     import shutil
@@ -270,8 +264,6 @@ def main():
 
     if args.run_all or args.run_letsencrypt:
         run_client_tests()
-
-    check_activity_monitor()
 
     if not startservers.check():
         die(ExitStatus.Error)

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -63,7 +63,6 @@ def start(race_detection):
     t.daemon = True
     t.start()
     progs = [
-        'activity-monitor',
         'boulder-wfe',
         'boulder-ra',
         'boulder-sa',


### PR DESCRIPTION
We no longer run this in prod, so we shouldn't run it in test / dev.