### PR TITLE
./test/run-boulder.sh fixed to work with 10.1.7 of MariaDB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Boulder - An ACME CA
 ====================
 
+ [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/pschlump/Go-FTL/master/LICENSE)
+
 This is an initial implementation of an ACME-based CA. The [ACME protocol](https://github.com/letsencrypt/acme-spec/) allows the CA to automatically verify that an applicant for a certificate actually controls an identifier, and allows domain holders to issue and revoke certificates for their domains.
 
 [![Build Status](https://travis-ci.org/letsencrypt/boulder.svg)](https://travis-ci.org/letsencrypt/boulder)

--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -3,14 +3,46 @@ set -o errexit
 cd $(dirname $0)/..
 source test/db-common.sh
 
-# set db connection for if running in a separate container or not
+
+# set db connection for if running in a seperate container or not
 dbconn="-u root"
 if [[ ! -z "$MYSQL_CONTAINER" ]]; then
 	dbconn="-u root -h 127.0.0.1 --port 3306"
 fi
 
+
+DB_VERSION=$(  mysql $dbconn -e "status;" | grep "Server version" | sed -e 's/-Maria.*//
+s/\.[0-9][0-9]*$//
+s/Server version://
+s/^.*-//
+s/ //g
+s/	//g
+' )
+
+# echo "DB_VERSION=$DB_VERSION"
+
+# vesion contains 10.0 or 10.1 or 10.?
+DB_MAJOR=$( echo $DB_VERSION | cut -d '.' -f 1 )
+DB_MINOR=$( echo $DB_VERSION | cut -d '.' -f 2 )
+
+if (( "$DB_MAJOR" < 10 )) ; then
+	echo "FAILED: Databse version 10 or newer is supported.  Found $DB_VERSION"
+	exit 1
+fi
+if [ -f test/create_db_users_$DB_VERSION.sql ] ; then
+	mysql $dbconn < test/create_db_users_$DB_VERSION.sql
+elif [ -f test/create_db_users.sql ] ; then
+	mysql $dbconn < test/create_db_users.sql
+fi
+
 # Drop all users to get a fresh start
 mysql $dbconn < test/drop_users.sql
+
+if [ -f test/create_db_users_$DB_VERSION.sql ] ; then
+	mysql $dbconn < test/create_db_users_$DB_VERSION.sql
+elif [ -f test/create_db_users.sql ] ; then
+	mysql $dbconn < test/create_db_users.sql
+fi
 
 for svc in $SERVICES; do
 	for dbenv in $DBENVS; do
@@ -27,7 +59,7 @@ for svc in $SERVICES; do
 
 		USERS_SQL=test/${svc}_db_users.sql
 		if [[ -f "$USERS_SQL" ]]; then
-			mysql $dbconn -D $db < $USERS_SQL || die "unable to add users to ${db}"
+			mysql $dbconn -D $db < $USERS_SQL || die "PJS1 unable to add users to ${db}"
 			echo "added users to ${db}"
 		fi
 		) &

--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -21,21 +21,15 @@ s/	//g
 #echo "dbversion=$DB_VERSION"
 
 if [[ $DB_VERSION =~ "10.1" ]] ; then
+	# Create uses so that if they do not exists the drop will not fail
+	mysql $dbconn < test/create_db_users_10.1.sql
+	# Drop all users to get a fresh start
+	mysql $dbconn < test/drop_users.sql
+	# in 10.1.7+ will not automaticaly create uses via a grant - must explicitly create them.
 	mysql $dbconn < test/create_db_users_10.1.sql
 elif [[ $DB_VERSION =~ "10.0" ]] ; then
-	mysql $dbconn < test/create_db_users.sql
-else
-	echo "$DB_VERSION is not a supported version of MariaDB"
-	exit 1
-fi
-
-# Drop all users to get a fresh start
-mysql $dbconn < test/drop_users.sql
-
-if [[ $DB_VERSION =~ "10.1" ]] ; then
-	mysql $dbconn < test/create_db_users_10.1.sql
-elif [[ $DB_VERSION =~ "10.0" ]] ; then
-	mysql $dbconn < test/create_db_users.sql
+	# Drop all users to get a fresh start
+	mysql $dbconn < test/drop_users.sql
 else
 	echo "$DB_VERSION is not a supported version of MariaDB"
 	exit 1

--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -19,29 +19,25 @@ s/ //g
 s/	//g
 ' )
 
-# echo "DB_VERSION=$DB_VERSION"
-
-# vesion contains 10.0 or 10.1 or 10.?
-DB_MAJOR=$( echo $DB_VERSION | cut -d '.' -f 1 )
-DB_MINOR=$( echo $DB_VERSION | cut -d '.' -f 2 )
-
-if (( "$DB_MAJOR" < 10 )) ; then
-	echo "FAILED: Databse version 10 or newer is supported.  Found $DB_VERSION"
-	exit 1
-fi
-if [ -f test/create_db_users_$DB_VERSION.sql ] ; then
-	mysql $dbconn < test/create_db_users_$DB_VERSION.sql
-elif [ -f test/create_db_users.sql ] ; then
+if [[ $DB_VERSION =~ "10.1" ]] ; then
+	mysql $dbconn < test/create_db_users_10.1.sql
+elif [[ $DB_VERSION =~ "10.0" ]] ; then
 	mysql $dbconn < test/create_db_users.sql
+else
+	echo "$DB_VERSION is not a supported version of MariaDB"
+	exit 1
 fi
 
 # Drop all users to get a fresh start
 mysql $dbconn < test/drop_users.sql
 
-if [ -f test/create_db_users_$DB_VERSION.sql ] ; then
-	mysql $dbconn < test/create_db_users_$DB_VERSION.sql
-elif [ -f test/create_db_users.sql ] ; then
+if [[ $DB_VERSION =~ "10.1" ]] ; then
+	mysql $dbconn < test/create_db_users_10.1.sql
+elif [[ $DB_VERSION =~ "10.0" ]] ; then
 	mysql $dbconn < test/create_db_users.sql
+else
+	echo "$DB_VERSION is not a supported version of MariaDB"
+	exit 1
 fi
 
 for svc in $SERVICES; do
@@ -59,7 +55,7 @@ for svc in $SERVICES; do
 
 		USERS_SQL=test/${svc}_db_users.sql
 		if [[ -f "$USERS_SQL" ]]; then
-			mysql $dbconn -D $db < $USERS_SQL || die "PJS1 unable to add users to ${db}"
+			mysql $dbconn -D $db < $USERS_SQL || die "unable to add users to ${db}"
 			echo "added users to ${db}"
 		fi
 		) &

--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -10,14 +10,15 @@ if [[ ! -z "$MYSQL_CONTAINER" ]]; then
 	dbconn="-u root -h 127.0.0.1 --port 3306"
 fi
 
+#s/\.[0-9][0-9]*$//
 
 DB_VERSION=$(  mysql $dbconn -e "status;" | grep "Server version" | sed -e 's/-Maria.*//
-s/\.[0-9][0-9]*$//
 s/Server version://
 s/^.*-//
 s/ //g
 s/	//g
 ' )
+#echo "dbversion=$DB_VERSION"
 
 if [[ $DB_VERSION =~ "10.1" ]] ; then
 	mysql $dbconn < test/create_db_users_10.1.sql

--- a/test/create_db_users.sql
+++ b/test/create_db_users.sql
@@ -1,0 +1,13 @@
+
+-- only run in 10.0.X versions of MariaDB
+
+create user  'policy'@'localhost';
+create user  'sa'@'localhost';
+create user  'ocsp_resp'@'localhost';
+create user  'revoker'@'localhost';
+create user  'importer'@'localhost';
+create user  'mailer'@'localhost';
+create user  'cert_checker'@'localhost';
+create user  'ocsp_update'@'localhost';
+create user  'test_setup'@'localhost';
+

--- a/test/create_db_users_10.1.sql
+++ b/test/create_db_users_10.1.sql
@@ -1,0 +1,13 @@
+
+-- only run in 10.1 versions of MariaDB
+
+create user if not exists 'policy'@'localhost';
+create user if not exists 'sa'@'localhost';
+create user if not exists 'ocsp_resp'@'localhost';
+create user if not exists 'revoker'@'localhost';
+create user if not exists 'importer'@'localhost';
+create user if not exists 'mailer'@'localhost';
+create user if not exists 'cert_checker'@'localhost';
+create user if not exists 'ocsp_update'@'localhost';
+create user if not exists 'test_setup'@'localhost';
+

--- a/test/drop_users.sql
+++ b/test/drop_users.sql
@@ -3,20 +3,54 @@
 -- Note that dropping a non-existing user produces an error that aborts the
 -- script, so we first grant a harmless privilege to each user to ensure it
 -- exists.
-GRANT USAGE ON *.* TO 'policy'@'localhost';
-DROP USER 'policy'@'localhost';
-GRANT USAGE ON *.* TO 'sa'@'localhost';
-DROP USER 'sa'@'localhost';
-GRANT USAGE ON *.* TO 'ocsp_resp'@'localhost';
-DROP USER 'ocsp_resp'@'localhost';
-GRANT USAGE ON *.* TO 'ocsp_update'@'localhost';
-DROP USER 'ocsp_update'@'localhost';
-GRANT USAGE ON *.* TO 'revoker'@'localhost';
-DROP USER 'revoker'@'localhost';
-GRANT USAGE ON *.* TO 'importer'@'localhost';
-DROP USER 'importer'@'localhost';
-GRANT USAGE ON *.* TO 'mailer'@'localhost';
-DROP USER 'mailer'@'localhost';
-GRANT USAGE ON *.* TO 'cert_checker'@'localhost';
-DROP USER 'cert_checker'@'localhost';
 
+USE mysql;
+
+DROP PROCEDURE IF EXISTS dropusers;
+
+DELIMITER //
+
+CREATE PROCEDURE dropusers ()
+    BEGIN
+
+        DECLARE CONTINUE HANDLER FOR SQLSTATE 'HY000' BEGIN END;
+
+        create user 'policy'@'localhost';
+        create user 'sa'@'localhost';
+        create user 'ocsp_resp'@'localhost';
+        create user 'revoker'@'localhost';
+        create user 'importer'@'localhost';
+        create user 'mailer'@'localhost';
+        create user 'cert_checker'@'localhost';
+        create user 'ocsp_update'@'localhost';
+        create user 'test_setup'@'localhost';
+
+        GRANT USAGE ON *.* TO 'policy'@'localhost';
+        DROP USER 'policy'@'localhost';
+        GRANT USAGE ON *.* TO 'sa'@'localhost';
+        DROP USER 'sa'@'localhost';
+        GRANT USAGE ON *.* TO 'ocsp_resp'@'localhost';
+        DROP USER 'ocsp_resp'@'localhost';
+        GRANT USAGE ON *.* TO 'ocsp_update'@'localhost';
+        DROP USER 'ocsp_update'@'localhost';
+        GRANT USAGE ON *.* TO 'revoker'@'localhost';
+        DROP USER 'revoker'@'localhost';
+        GRANT USAGE ON *.* TO 'importer'@'localhost';
+        DROP USER 'importer'@'localhost';
+        GRANT USAGE ON *.* TO 'mailer'@'localhost';
+        DROP USER 'mailer'@'localhost';
+        GRANT USAGE ON *.* TO 'cert_checker'@'localhost';
+        DROP USER 'cert_checker'@'localhost';
+        GRANT USAGE ON *.* TO 'test_setup'@'localhost';
+        DROP USER 'test_setup'@'localhost';
+
+    END;
+    //
+
+DELIMITER ;
+
+CALL dropusers();
+
+-- MariaDB seems to have the NO_AUTO_CREATE_USER flag set. Later in the create_db.sh, removing this flag will get users created.
+
+SET GLOBAL sql_mode = '';

--- a/test/drop_users.sql
+++ b/test/drop_users.sql
@@ -6,52 +6,22 @@
 
 USE mysql;
 
-DROP PROCEDURE IF EXISTS dropusers;
+GRANT USAGE ON *.* TO 'policy'@'localhost';
+DROP USER 'policy'@'localhost';
+GRANT USAGE ON *.* TO 'sa'@'localhost';
+DROP USER 'sa'@'localhost';
+GRANT USAGE ON *.* TO 'ocsp_resp'@'localhost';
+DROP USER 'ocsp_resp'@'localhost';
+GRANT USAGE ON *.* TO 'ocsp_update'@'localhost';
+DROP USER 'ocsp_update'@'localhost';
+GRANT USAGE ON *.* TO 'revoker'@'localhost';
+DROP USER 'revoker'@'localhost';
+GRANT USAGE ON *.* TO 'importer'@'localhost';
+DROP USER 'importer'@'localhost';
+GRANT USAGE ON *.* TO 'mailer'@'localhost';
+DROP USER 'mailer'@'localhost';
+GRANT USAGE ON *.* TO 'cert_checker'@'localhost';
+DROP USER 'cert_checker'@'localhost';
+GRANT USAGE ON *.* TO 'test_setup'@'localhost';
+DROP USER 'test_setup'@'localhost';
 
-DELIMITER //
-
-CREATE PROCEDURE dropusers ()
-    BEGIN
-
-        DECLARE CONTINUE HANDLER FOR SQLSTATE 'HY000' BEGIN END;
-
-        create user 'policy'@'localhost';
-        create user 'sa'@'localhost';
-        create user 'ocsp_resp'@'localhost';
-        create user 'revoker'@'localhost';
-        create user 'importer'@'localhost';
-        create user 'mailer'@'localhost';
-        create user 'cert_checker'@'localhost';
-        create user 'ocsp_update'@'localhost';
-        create user 'test_setup'@'localhost';
-
-        GRANT USAGE ON *.* TO 'policy'@'localhost';
-        DROP USER 'policy'@'localhost';
-        GRANT USAGE ON *.* TO 'sa'@'localhost';
-        DROP USER 'sa'@'localhost';
-        GRANT USAGE ON *.* TO 'ocsp_resp'@'localhost';
-        DROP USER 'ocsp_resp'@'localhost';
-        GRANT USAGE ON *.* TO 'ocsp_update'@'localhost';
-        DROP USER 'ocsp_update'@'localhost';
-        GRANT USAGE ON *.* TO 'revoker'@'localhost';
-        DROP USER 'revoker'@'localhost';
-        GRANT USAGE ON *.* TO 'importer'@'localhost';
-        DROP USER 'importer'@'localhost';
-        GRANT USAGE ON *.* TO 'mailer'@'localhost';
-        DROP USER 'mailer'@'localhost';
-        GRANT USAGE ON *.* TO 'cert_checker'@'localhost';
-        DROP USER 'cert_checker'@'localhost';
-        GRANT USAGE ON *.* TO 'test_setup'@'localhost';
-        DROP USER 'test_setup'@'localhost';
-
-    END;
-    //
-
-DELIMITER ;
-
-CALL dropusers();
-
--- MariaDB seems to have the NO_AUTO_CREATE_USER flag set. Later in the create_db.sh, removing this flag will get users created.
--- This flag became default in 10.1.7 of MariaDB.  This will also turn off the NO_ENGINE_SUBSTITUTION flag.
-
-SET GLOBAL sql_mode = '';

--- a/test/drop_users.sql
+++ b/test/drop_users.sql
@@ -52,5 +52,6 @@ DELIMITER ;
 CALL dropusers();
 
 -- MariaDB seems to have the NO_AUTO_CREATE_USER flag set. Later in the create_db.sh, removing this flag will get users created.
+-- This flag became default in 10.1.7 of MariaDB.  This will also turn off the NO_ENGINE_SUBSTITUTION flag.
 
 SET GLOBAL sql_mode = '';


### PR DESCRIPTION
In 10.1.7 of MariaDB the default is no longer to allow grants to create users.  This works around this in
a fashion that will allow boulder to run on 10.0.x of MariaDB and 10.1 versions also.   This addresses
Issue 1322 - and part of 1335.