### PR TITLE
Add CAA test domains to rate limit policies.

### DIFF
--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -13,6 +13,8 @@ certificatesPerName:
     le2.wtf: 10000
     le3.wtf: 10000
     nginx.wtf: 10000
+    good-caa-reserved.com: 10000
+    bad-caa-reserved.com: 10000
   registrationOverrides:
     101: 1000
 registrationsPerIP:


### PR DESCRIPTION
This ensures that repeatedly running the integration test locally doesn't run
afoul of rate limits.