### PR TITLE
Add mailer_dburl file.

### DIFF
--- a/test/secrets/mailer_dburl
+++ b/test/secrets/mailer_dburl
@@ -1,0 +1,1 @@
+mysql+tcp://mailer@localhost:3306/boulder_sa_integration


### PR DESCRIPTION
This is referenced in test/boulder-config.json but didn't exist.