### PR TITLE
Fix invalid Godeps.json

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -144,6 +144,7 @@
 			"ImportPath": "golang.org/x/net/context",
 			"Rev": "ce84af2e5bf21582345e478b116afc7d4efaba3d"
 		},
+		{
 			"ImportPath": "gopkg.in/gorp.v1",
 			"Comment": "v1.7.1",
 			"Rev": "c87af80f3cc5036b55b83d77171e156791085e2e"


### PR DESCRIPTION
Just a missing `{`, this fixes the following:

```
$ godep restore
godep: Unable to parse Godeps/Godeps.json: invalid character ':' after array element
```