### PR TITLE
Reuse a single connection to SMTP server.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -119,6 +119,7 @@ type Config struct {
 		Username string
 		Password string
 		From     string
+		Subject  string
 
 		CertLimit int
 		NagTimes  []string


### PR DESCRIPTION
Also, add a Subject config field and use TLS-wrapped SMTP if appropriate.

Fixes #1354.