### PR TITLE
Fix dns01 authority check

### DIFF
--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -112,21 +112,21 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				record.Hdr = dns.RR_Header{Name: "split-txt.letsencrypt.org.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 0}
 				record.Txt = []string{"a", "b", "c"}
 				appendAnswer(record)
+			} else {
+				auth := new(dns.SOA)
+				auth.Hdr = dns.RR_Header{Name: "letsencrypt.org.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 0}
+				auth.Ns = "ns.letsencrypt.org."
+				auth.Mbox = "master.letsencrypt.org."
+				auth.Serial = 1
+				auth.Refresh = 1
+				auth.Retry = 1
+				auth.Expire = 1
+				auth.Minttl = 1
+				m.Ns = append(m.Ns, auth)
 			}
 			if q.Name == "nxdomain.letsencrypt.org." {
 				m.SetRcode(r, dns.RcodeNameError)
 			}
-
-			auth := new(dns.SOA)
-			auth.Hdr = dns.RR_Header{Name: "letsencrypt.org.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 0}
-			auth.Ns = "ns.letsencrypt.org."
-			auth.Mbox = "master.letsencrypt.org."
-			auth.Serial = 1
-			auth.Refresh = 1
-			auth.Retry = 1
-			auth.Expire = 1
-			auth.Minttl = 1
-			m.Ns = append(m.Ns, auth)
 		}
 	}
 
@@ -307,6 +307,7 @@ func TestDNSTXTAuthorities(t *testing.T) {
 	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	_, auths, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
+
 	test.AssertNotError(t, err, "TXT lookup failed")
 	test.AssertEquals(t, len(auths), 1)
 	test.AssertEquals(t, auths[0], "letsencrypt.org.	0	IN	SOA	ns.letsencrypt.org. master.letsencrypt.org. 1 1 1 1 1")

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -26,6 +26,12 @@ func (mock *MockDNSResolver) LookupTXT(_ context.Context, hostname string) ([]st
 		// expected token + test account jwk thumbprint
 		return []string{"LPsIwTo7o8BoG0-vjCyGQGBWSVIPxI-i_X336eUOQZo"}, []string{"respect my authority!"}, nil
 	}
+	if hostname == "_acme-challenge.no-authority-dns01.com" {
+		// base64(sha256("LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
+		//               + "." + "9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI"))
+		// expected token + test account jwk thumbprint
+		return []string{"LPsIwTo7o8BoG0-vjCyGQGBWSVIPxI-i_X336eUOQZo"}, nil, nil
+	}
 	return []string{"hostname"}, []string{"respect my authority!"}, nil
 }
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -358,7 +358,7 @@ func (ch Challenge) RecordsSane() bool {
 		if len(ch.ValidationRecord) > 1 {
 			return false
 		}
-		if len(ch.ValidationRecord[0].Authorities) == 0 || ch.ValidationRecord[0].Hostname == "" {
+		if ch.ValidationRecord[0].Hostname == "" {
 			return false
 		}
 		return true

--- a/core/objects.go
+++ b/core/objects.go
@@ -179,7 +179,7 @@ func (r *Registration) MergeUpdate(input Registration) {
 // and the IP addresses that were resolved and used
 type ValidationRecord struct {
 	// DNS only
-	Authorities []string
+	Authorities []string `json:",omitempty"`
 
 	// SimpleHTTP only
 	URL string `json:"url,omitempty"`


### PR DESCRIPTION
Don't expect all txt dns replies to contain an authority section.
Server *MAY* return an authority section, especially on NXDOMAIN the server will return an SOA authority response in order to provide the nxdomain ttl value.
Otherwise there is no need for such section.
Dns client should be checking the header aa flags to check if the response is authoritative and not check the presence of authority section.

Fix https://github.com/letsencrypt/boulder/issues/1391