### PR TITLE
log nonce to and from client

### DIFF
--- a/wfe/context.go
+++ b/wfe/context.go
@@ -11,18 +11,19 @@ import (
 )
 
 type requestEvent struct {
-	ID           string    `json:",omitempty"`
-	RealIP       string    `json:",omitempty"`
-	ClientAddr   string    `json:",omitempty"`
-	Endpoint     string    `json:",omitempty"`
-	Method       string    `json:",omitempty"`
-	RequestTime  time.Time `json:",omitempty"`
-	ResponseTime time.Time `json:",omitempty"`
-	Errors       []string
-	Requester    int64           `json:",omitempty"`
-	Contacts     []*core.AcmeURL `json:",omitempty"`
-
-	Extra map[string]interface{} `json:",omitempty"`
+	ID            string    `json:",omitempty"`
+	RealIP        string    `json:",omitempty"`
+	ClientAddr    string    `json:",omitempty"`
+	Endpoint      string    `json:",omitempty"`
+	Method        string    `json:",omitempty"`
+	RequestTime   time.Time `json:",omitempty"`
+	ResponseTime  time.Time `json:",omitempty"`
+	Errors        []string
+	Requester     int64                  `json:",omitempty"`
+	Contacts      []*core.AcmeURL        `json:",omitempty"`
+	RequestNonce  string                 `json:",omitempty"`
+	ResponseNonce string                 `json:",omitempty"`
+	Extra         map[string]interface{} `json:",omitempty"`
 }
 
 func (e *requestEvent) AddError(msg string, args ...interface{}) {


### PR DESCRIPTION
Also, log when a nonce service error occurs.

Updates #1217 

This doesn't change the not-great behavior of failing open when the nonce server returns an error, but that doesn't appear to be the current bug.

I'd gladly take feedback to also fail closed on error in this patch.