### PR TITLE
Docker image mariadb should be at 10.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ boulder:
     environment:
         MYSQL_CONTAINER: "yes"
 mysql:
-    image: mariadb:10
+    image: mariadb:10.0
     net: host
     ports:
         - "3306:3306"

--- a/test/run-docker.sh
+++ b/test/run-docker.sh
@@ -52,7 +52,7 @@ if [[ "$(is_running boulder-mysql)" != "true" ]]; then
 		-p 3306:3306 \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
 		--name boulder-mysql \
-		mariadb:10
+		mariadb:10.0
 fi
 
 if [[ "$(is_running boulder-rabbitmq)" != "true" ]]; then


### PR DESCRIPTION
Dockerfile of mariadb is mapping 10 as "10.1.10, 10.1, 10, latest"
Thus lead to the test/drop_users.sql having error, mentioned in #1322
If we don't support mariadb 10.1+ now, we should specify it.