### PR TITLE
Add email templates to RPM.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,4 @@ rpm: build
 		--package $(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).x86_64.rpm \
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
 		--depends "libtool-ltdl" --maintainer "$(MAINTAINER)" \
-		test/boulder-config.json sa/_db $(OBJECTS)
+		test/boulder-config.json sa/_db data/ $(OBJECTS)

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -129,6 +129,14 @@ func TestSendNags(t *testing.T) {
 	err = m.sendNags(cert, []*core.AcmeURL{})
 	test.AssertNotError(t, err, "Not an error to pass no email contacts")
 	test.AssertEquals(t, len(mc.Messages), 0)
+
+	templates, err := template.ParseGlob("../../data/*.template")
+	test.AssertNotError(t, err, "Failed to parse templates")
+	for _, template := range templates.Templates() {
+		m.emailTemplate = template
+		err = m.sendNags(cert, []*core.AcmeURL{})
+		test.AssertNotError(t, err, "failed to send nag")
+	}
 }
 
 var n = bigIntFromB64("n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw==")

--- a/data/production-email.template
+++ b/data/production-email.template
@@ -1,0 +1,16 @@
+Hello,
+
+Your certificate (or certificates) for the names listed below will expire in
+{{.DaysToExpiration}} days (on {{.ExpirationDate}}). Please make sure to renew
+your certificate before then, or visitors to your website will encounter errors.
+
+{{.DNSNames}}
+
+For any questions or support, please visit https://community.letsencrypt.org/.
+Unfortunately, we can't provide support by email.
+
+If you want to stop receiving all email from this address, click
+|UNSUB:https://mandrillapp.com/unsub|.
+
+Regards,
+The Let's Encrypt Team

--- a/data/staging-email.template
+++ b/data/staging-email.template
@@ -1,0 +1,23 @@
+Hello,
+
+[ Note: This message is from the Let's Encrypt staging environment. It
+likely is not relevant to any live web site. ]
+
+You issued a testing cert (not a live one) from Let's Encrypt staging
+environment. This mail takes the place of what would normally be a renewal
+reminder, but instead is demonstrating delivery of renewal notices. Have a nice
+day!
+
+Details:
+DNS Names: {{.DNSNames}}
+Expiration Date: {{.ExpirationDate}})
+Days to Expiration: {{.DaysToExpiration}}
+
+For any questions or support, please visit https://community.letsencrypt.org/.
+Unfortunately, we can't provide support by email.
+
+If you want to stop receiving all email from this address, click
+|UNSUB:https://mandrillapp.com/unsub|.
+
+Regards,
+The Let's Encrypt Team


### PR DESCRIPTION
This allows us to update the template variables in code without waiting for a full deploy cycle.

Note that these templates won't immediately take effect, but will require a config change to point to their installed location once they are deployed.

Fixes #1386