### PR TITLE
use gunzip -c instead of zcat on mac

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -13,9 +13,15 @@ go get \
   github.com/jcjones/github-pr-status \
   github.com/jsha/listenbuddy &
 
+if [ $(uname) == "Darwin" ]; then
+  UNZIP="gunzip -c"
+else
+  UNZIP="zcat"
+fi
+
 (wget https://github.com/jsha/boulder-tools/raw/master/goose.gz &&
  mkdir -p $GOPATH/bin &&
- zcat goose.gz > $GOPATH/bin/goose &&
+ $UNZIP goose.gz > $GOPATH/bin/goose &&
  chmod +x $GOPATH/bin/goose &&
  ./test/create_db.sh) &
 


### PR DESCRIPTION
While setting up boulder on my OSX machine, I ran `./test/setup.sh` and got the following error -

```
zcat: can't stat: goose.gz (goose.gz.Z): No such file or directory
```

A quick lookup led me to this - https://github.com/dalibo/pgbadger/issues/70. Made a quick change to the script to check for the host platform and fire `gunzip -c` if needed. It might be helpful for others trying to  setup boulder on OSX machines.