### PR TITLE
Add support for listing Authorizations

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -75,11 +75,12 @@ func main() {
 		cmd.FailOnError(err, "Couldn't parse shutdown stop timeout")
 		wfe.ShutdownKillTimeout, err = time.ParseDuration(c.WFE.ShutdownKillTimeout)
 		cmd.FailOnError(err, "Couldn't parse shutdown kill timeout")
-
 		wfe.IssuerCert, err = cmd.LoadCert(c.Common.IssuerCert)
 		cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))
 
 		auditlogger.Info(fmt.Sprintf("WFE using key policy: %#v", c.KeyPolicy()))
+
+		wfe.UseAuthList = c.WFE.UseAuthList
 
 		go cmd.ProfileCmd("WFE", stats)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -47,6 +47,8 @@ type Config struct {
 
 		ShutdownStopTimeout string
 		ShutdownKillTimeout string
+
+		UseAuthList bool
 	}
 
 	CA CAConfig

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -108,6 +108,7 @@ type StorageGetter interface {
 	GetSCTReceipt(string, string) (SignedCertificateTimestamp, error)
 	CountFQDNSets(time.Duration, []string) (int64, error)
 	FQDNSetExists([]string) (bool, error)
+	GetAuthorizationsByRegID(int64, time.Time, int64) ([]string, error)
 }
 
 // StorageAdder are the Boulder SA's write/update methods

--- a/core/objects.go
+++ b/core/objects.go
@@ -156,6 +156,9 @@ type Registration struct {
 	// Agreement with terms of service
 	Agreement string `json:"agreement,omitempty"`
 
+	// URL for list of all authorizations
+	Authorizations string `json:"authorizations,omitempty"`
+
 	// InitialIP is the IP address from which the registration was created
 	InitialIP net.IP `json:"initialIp"`
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -311,6 +311,11 @@ func (sa *StorageAuthority) CountPendingAuthorizations(_ int64) (int, error) {
 	return 0, nil
 }
 
+// GetAuthorizationsByRegID is a mock
+func (sa *StorageAuthority) GetAuthorizationsByRegID(_ int64, _ time.Time, _ int64) ([]string, error) {
+	return nil, nil
+}
+
 // Publisher is a mock
 type Publisher struct {
 	// empty

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -975,3 +975,38 @@ func (ssa *SQLStorageAuthority) FQDNSetExists(names []string) (bool, error) {
 	)
 	return count > 0, err
 }
+
+// GetAuthorizationsByRegID returns the authorization IDs matching the regID given.
+// The number of IDs returned is dependent on the limit variable. If exiresAfter is
+// before now it willl return the list as if now was given
+func (ssa *SQLStorageAuthority) GetAuthorizationsByRegID(regID int64, expiresAfter time.Time, limit int64) ([]string, error) {
+
+	expiryTime := ssa.clk.Now()
+	if expiresAfter.After(expiryTime) {
+		expiryTime = expiresAfter
+	}
+
+	registrationMap := map[string]interface{}{"regID": regID, "time": expiryTime, "max": limit}
+
+	var ids []struct {
+		ID      string
+		Expires time.Time
+	}
+	_, err := ssa.dbMap.Select(&ids,
+		`(SELECT id, expires FROM authz WHERE registrationID = :regID AND status = 'valid' AND expires > :time LIMIT :max)
+		UNION
+		(SELECT id, expires FROM pendingAuthorizations WHERE registrationID = :regID AND expires > :time LIMIT :max)
+		ORDER BY expires ASC LIMIT :max`,
+		registrationMap)
+
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]string, len(ids))
+	for n, id := range ids {
+		ret[n] = id.ID
+	}
+
+	return ret, nil
+}

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -1235,7 +1235,7 @@ func (wfe *WebFrontEndImpl) setCORSHeaders(response http.ResponseWriter, request
 func (wfe *WebFrontEndImpl) AuthList(logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
 	var expiry time.Time
 	var limit int64 = 100
-	// Reguest Format /acme/auth-list/regID/expiresAfter with expiresAfter being
+	// Request Format /acme/auth-list/regID/expiresAfter with expiresAfter being
 	// optional and defaulting to now
 	slug := strings.Split(request.URL.Path[len(AuthListPath):], "/")
 	if len(slug) < 1 || len(slug) > 2 {

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -40,6 +40,7 @@ const (
 	TermsPath      = "/terms"
 	IssuerPath     = "/acme/issuer-cert"
 	BuildIDPath    = "/build"
+	AuthListPath   = "/acme/auth-list/"
 )
 
 // WebFrontEndImpl provides all the logic for Boulder's web-facing interface,
@@ -62,6 +63,7 @@ type WebFrontEndImpl struct {
 	ChallengeBase string
 	NewCert       string
 	CertBase      string
+	AuthListBase  string
 
 	// JSON encoded endpoint directory
 	DirectoryJSON []byte
@@ -90,6 +92,9 @@ type WebFrontEndImpl struct {
 	// Graceful shutdown settings
 	ShutdownStopTimeout time.Duration
 	ShutdownKillTimeout time.Duration
+
+	// RPC Config gating
+	UseAuthList bool
 }
 
 // NewWebFrontEndImpl constructs a web service for Boulder
@@ -186,6 +191,7 @@ func (wfe *WebFrontEndImpl) Handler() (http.Handler, error) {
 	wfe.ChallengeBase = wfe.BaseURL + ChallengePath
 	wfe.NewCert = wfe.BaseURL + NewCertPath
 	wfe.CertBase = wfe.BaseURL + CertPath
+	wfe.AuthListBase = wfe.BaseURL + AuthListPath
 
 	// Only generate directory once
 	directory := map[string]string{
@@ -213,6 +219,9 @@ func (wfe *WebFrontEndImpl) Handler() (http.Handler, error) {
 	wfe.HandleFunc(m, TermsPath, wfe.Terms, "GET")
 	wfe.HandleFunc(m, IssuerPath, wfe.Issuer, "GET")
 	wfe.HandleFunc(m, BuildIDPath, wfe.BuildID, "GET")
+	if wfe.UseAuthList {
+		wfe.HandleFunc(m, AuthListPath, wfe.AuthList, "GET")
+	}
 	// We don't use our special HandleFunc for "/" because it matches everything,
 	// meaning we can wind up returning 405 when we mean to return 404. See
 	// https://github.com/letsencrypt/boulder/issues/717
@@ -525,7 +534,10 @@ func (wfe *WebFrontEndImpl) NewRegistration(logEvent *requestEvent, response htt
 	}
 	logEvent.Requester = reg.ID
 	logEvent.Contacts = reg.Contact
-
+	if wfe.UseAuthList {
+		// Add URL for Auth-list to Registration object
+		reg.Authorizations = fmt.Sprintf("%s%d", wfe.AuthListBase, reg.ID)
+	}
 	// Use an explicitly typed variable. Otherwise `go vet' incorrectly complains
 	// that reg.ID is a string being passed to %d.
 	regURL := fmt.Sprintf("%s%d", wfe.RegBase, reg.ID)
@@ -1019,6 +1031,11 @@ func (wfe *WebFrontEndImpl) Registration(logEvent *requestEvent, response http.R
 		return
 	}
 
+	// Add URL for Auth-list to Registration object
+	if wfe.UseAuthList {
+		updatedReg.Authorizations = wfe.AuthListBase + idStr
+	}
+
 	jsonReply, err := json.Marshal(updatedReg)
 	if err != nil {
 		// ServerInternal because we just generated the reg, it should be OK
@@ -1212,4 +1229,79 @@ func (wfe *WebFrontEndImpl) setCORSHeaders(response http.ResponseWriter, request
 	}
 	response.Header().Set("Access-Control-Expose-Headers", "Link, Replay-Nonce")
 	response.Header().Set("Access-Control-Max-Age", "86400")
+}
+
+// AuthList is used by Clients to retrieve a list of
+func (wfe *WebFrontEndImpl) AuthList(logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
+	var expiry time.Time
+	var limit int64 = 100
+	slug := strings.Split(request.URL.Path[len(AuthListPath):], "/")
+	if len(slug) < 1 || len(slug) > 2 {
+		wfe.sendError(response, logEvent, probs.Malformed("Invalid request Format"), nil)
+		return
+	}
+	id, err := strconv.ParseInt(slug[0], 10, 64)
+	if err != nil {
+		logEvent.AddError("registration ID must be an integer, was %#v", slug[0])
+		wfe.sendError(response, logEvent, probs.Malformed("Registration ID must be an integer"), err)
+		return
+	} else if id <= 0 {
+		msg := fmt.Sprintf("Registration ID must be a positive non-zero integer, was %d", id)
+		logEvent.AddError(msg)
+		wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
+		return
+	}
+	if len(slug) == 2 {
+		exp, _ := strconv.ParseInt(slug[1], 10, 64)
+		if err != nil {
+			logEvent.AddError("expiry must be an integer, was %#v", slug[1])
+			wfe.sendError(response, logEvent, probs.Malformed("Registration ID must be an integer"), err)
+			return
+		} else if exp <= 0 {
+			msg := fmt.Sprintf("expiry must be a positive non-zero integer, was %d", id)
+			logEvent.AddError(msg)
+			wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
+			return
+		}
+		expiry = time.Unix(exp, 0)
+	}
+	authIDs, err := wfe.SA.GetAuthorizationsByRegID(id, expiry, limit)
+	if err != nil {
+		logEvent.AddError("No such authorizations at id %s", id)
+		wfe.sendError(response, logEvent, probs.ServerInternal("unable to find Authorizations"), err)
+		return
+	}
+
+	if int64(len(authIDs)) == limit {
+		auth, err := wfe.SA.GetAuthorization(authIDs[limit-1])
+		if err != nil {
+			logEvent.AddError("Unable to get authorization: %s", err)
+			wfe.sendError(response, logEvent, probs.ServerInternal("unable to get Authorization"), err)
+			return
+		}
+		if auth.Expires != nil {
+			response.Header().Add("Link", link(fmt.Sprintf("%s%d/%d", wfe.AuthListBase, id, auth.Expires.Unix()), "next"))
+		}
+	}
+
+	var authlist struct {
+		Authorizations []string `json:"authorizations"`
+	}
+	authlist.Authorizations = make([]string, len(authIDs))
+	for i, authID := range authIDs {
+		authlist.Authorizations[i] = wfe.AuthzBase + authID
+	}
+
+	jsonReply, err := json.Marshal(authlist)
+	if err != nil {
+		logEvent.AddError("Failed to JSON marshal auth-list: %s", err)
+		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to JSON marshal auth-list"), err)
+		return
+	}
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(http.StatusOK)
+	if _, err = response.Write(jsonReply); err != nil {
+		logEvent.AddError(err.Error())
+		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
+	}
 }


### PR DESCRIPTION
Relevant Section in RFC: 5.2 Registration Objects:
...
authorizations (optional, string):
A URI from which a list of authorizations granted to this account can be fetched via a GET request. The result of the GET request MUST be a JSON object whose “authorizations” field is an array of strings, where each string is the URI of an authorization belonging to this registration. The server SHOULD include pending authorizations, and SHOULD NOT include authorizations that are invalid or expired.
