### PR TITLE
Added support for underscores in subdomains

### DIFF
--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -126,6 +126,8 @@ func TestWillingToIssue(t *testing.T) {
 		"zombo-.com",
 		"www.zom-bo.com",
 		"www.zombo-.com",
+		"app.zombo.com",
+		"my_app.zombo.com",
 	}
 
 	pa, cleanup := paImpl(t)


### PR DESCRIPTION
This is done by scanning the characters in the eTLD+1 separately from those in the subdomain.

I feel it is safe to put the `_` in `dnsLabelRegexp` since if it was in the eTLD+1 it would get caught prior to that check.

Fixes #1225