### PR TITLE
ocsp-responder: 200 on GET /

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -177,13 +177,10 @@ func main() {
 		cmd.FailOnError(err, "Couldn't parse shutdown stop timeout")
 		killTimeout, err := time.ParseDuration(c.OCSPResponder.ShutdownKillTimeout)
 		cmd.FailOnError(err, "Couldn't parse shutdown kill timeout")
-
-		m := http.StripPrefix(c.OCSPResponder.Path, cfocsp.NewResponder(source))
-
-		httpMonitor := metrics.NewHTTPMonitor(stats, m, "OCSP")
+		m := mux(stats, c.OCSPResponder.Path, source)
 		srv := &http.Server{
 			Addr:    c.OCSPResponder.ListenAddress,
-			Handler: httpMonitor.Handle(),
+			Handler: m,
 		}
 
 		hd := &httpdown.HTTP{
@@ -196,4 +193,19 @@ func main() {
 	}
 
 	app.Run()
+}
+
+func mux(stats statsd.Statter, responderPath string, source cfocsp.Source) http.Handler {
+	m := http.StripPrefix(responderPath, cfocsp.NewResponder(source))
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/" {
+			w.Header().Set("Cache-Control", "max-age=43200") // Cache for 12 hours
+			w.WriteHeader(200)
+			return
+		}
+		m.ServeHTTP(w, r)
+	})
+	mon := metrics.NewHTTPMonitor(stats, h, "OCSP")
+	return mon.Handle()
+
 }

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	cfocsp "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/golang.org/x/crypto/ocsp"
-
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/mocks"
@@ -22,30 +22,40 @@ import (
 )
 
 var (
-	req  = mustRead("./testdata/ocsp.req")
-	resp = mustRead("./testdata/ocsp.resp")
+	req      = mustRead("./testdata/ocsp.req")
+	resp     = mustRead("./testdata/ocsp.resp")
+	stats, _ = statsd.NewNoopClient()
 )
 
-func TestHandler(t *testing.T) {
+func TestMux(t *testing.T) {
 	ocspReq, err := ocsp.ParseRequest(req)
 	if err != nil {
 		t.Fatalf("ocsp.ParseRequest: %s", err)
 	}
 	src := make(cfocsp.InMemorySource)
 	src[ocspReq.SerialNumber.String()] = resp
+	h := mux(stats, "/foobar/", src)
+	type muxTest struct {
+		method   string
+		path     string
+		reqBody  []byte
+		respBody []byte
+	}
+	mts := []muxTest{{"POST", "/foobar/", req, resp}, {"GET", "/", nil, nil}}
+	for i, mt := range mts {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest(mt.method, mt.path, bytes.NewReader(mt.reqBody))
+		if err != nil {
+			t.Fatalf("#%d, NewRequest: %s", i, err)
+		}
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("Code: want %d, got %d", http.StatusOK, w.Code)
+		}
+		if !bytes.Equal(w.Body.Bytes(), mt.respBody) {
+			t.Errorf("Mismatched body: want %#v, got %#v", mt.respBody, w.Body.Bytes())
+		}
 
-	h := cfocsp.NewResponder(src)
-	w := httptest.NewRecorder()
-	r, err := http.NewRequest("POST", "/", bytes.NewReader(req))
-	if err != nil {
-		t.Fatal(err)
-	}
-	h.ServeHTTP(w, r)
-	if w.Code != http.StatusOK {
-		t.Errorf("Code: want %d, got %d", http.StatusOK, w.Code)
-	}
-	if !bytes.Equal(w.Body.Bytes(), resp) {
-		t.Errorf("Mismatched body: want %#v, got %#v", resp, w.Body.Bytes())
 	}
 }
 


### PR DESCRIPTION
Some stat services, we believe, are saying the ocsp-responder is down because / returns 400 Bad Request currently.

Shuffle some code into a new `mux` function to make it easier to test.