### PR TITLE
Fix flakiness in RA test.

### DIFF
--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -400,13 +400,12 @@ func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
 	// TODO: Enable this test case once we validate terms agreement.
 	//test.Assert(t, result.Agreement != "I agreed", "Agreement shouldn't be set with invalid URL")
 
-	id := result.ID
 	result2, err := ra.UpdateRegistration(result, core.Registration{
-		ID:  33,
+		ID:  330303303303,
 		Key: ShortKey,
 	})
 	test.AssertNotError(t, err, "Could not update registration")
-	test.Assert(t, result2.ID != 33, fmt.Sprintf("ID shouldn't be overwritten. expected %d, got %d", id, result2.ID))
+	test.AssertEquals(t, result.ID, result2.ID)
 	test.Assert(t, !core.KeyDigestEquals(result2.Key, ShortKey), "Key shouldn't be overwritten")
 }
 


### PR DESCRIPTION
The test checked that the ID of a created message was not equal to 33, but that
could happen on Travis depending on the order and number of test cases, leading
to flakiness. Now instead we check that the ID is equal to the object that was
first created, and we also set the overwrite attempt ID high enough that it will
almost certainly never be reached in practice.