### PR TITLE
ignore the cmd/testdata dir in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ VERSION ?= 1.0.0
 EPOCH ?= 1
 MAINTAINER ?= "Community"
 
-CMDS = $(shell find ./cmd -maxdepth 1 -mindepth 1 -type d)
+CMDS = $(shell find ./cmd -maxdepth 1 -mindepth 1 -type d | grep -v testdata)
 CMD_BASENAMES = $(shell echo $(CMDS) | xargs -n1 basename)
 CMD_BINS = $(addprefix $(OBJDIR)/, $(CMD_BASENAMES) )
 OBJECTS = $(CMD_BINS)


### PR DESCRIPTION
testdata won't ever be producing a binary, and "testdata" is a fairly common name to find in Go projects for the tests to use, so just ignore it.