### PR TITLE
remove auto-increment rollback and fix ra test

### DIFF
--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -400,13 +400,13 @@ func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
 	// TODO: Enable this test case once we validate terms agreement.
 	//test.Assert(t, result.Agreement != "I agreed", "Agreement shouldn't be set with invalid URL")
 
-	id := result.ID
+	id := result.ID + 5
 	result2, err := ra.UpdateRegistration(result, core.Registration{
-		ID:  33,
+		ID:  id,
 		Key: ShortKey,
 	})
 	test.AssertNotError(t, err, "Could not update registration")
-	test.Assert(t, result2.ID != 33, fmt.Sprintf("ID shouldn't be overwritten. expected %d, got %d", id, result2.ID))
+	test.Assert(t, id != result2.ID, fmt.Sprintf("ID shouldn't be overwritten and set to %d but was", result2.ID))
 	test.Assert(t, !core.KeyDigestEquals(result2.Key, ShortKey), "Key shouldn't be overwritten")
 }
 

--- a/test/db.go
+++ b/test/db.go
@@ -95,11 +95,6 @@ func deleteEverythingInAllTables(db CleanUpDB) error {
 		if err != nil {
 			return fmt.Errorf("unable to commit transaction to delete all rows from table %#v: %s", tn, err)
 		}
-
-		_, err = db.Exec("alter table `" + tn + "` AUTO_INCREMENT = 1")
-		if err != nil {
-			return fmt.Errorf("unable to reset autoincrement on table %#v: %s", tn, err)
-		}
 	}
 	return err
 }


### PR DESCRIPTION
This failed when running tests across multiple packages in some new ways. I don't know how they got past us for so long.