### PR TITLE
Dashes in subdomains not accepted

### DIFF
--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -69,7 +69,7 @@ const (
 	whitelistedPartnerRegID = 131
 )
 
-var dnsLabelRegexp = regexp.MustCompile("^[a-z0-9][a-z0-9-]{0,62}$")
+var dnsLabelRegexp = regexp.MustCompile("^[a-z0-9-]{1,63}$")
 var punycodeRegexp = regexp.MustCompile("^xn--")
 
 func isDNSCharacter(ch byte) bool {
@@ -170,10 +170,6 @@ func (pa PolicyAuthorityImpl) WillingToIssue(id core.AcmeIdentifier, regID int64
 		}
 
 		if !dnsLabelRegexp.MatchString(label) {
-			return errInvalidDNSCharacter
-		}
-
-		if label[len(label)-1] == '-' {
 			return errInvalidDNSCharacter
 		}
 

--- a/policy/policy-authority_test.go
+++ b/policy/policy-authority_test.go
@@ -65,10 +65,8 @@ func TestWillingToIssue(t *testing.T) {
 
 		{`www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com`, errLabelTooLong}, // Label too long (>63 characters)
 
-		{`www.-ombo.com`, errInvalidDNSCharacter}, // Label starts with '-'
-		{`www.zomb-.com`, errInvalidDNSCharacter}, // Label ends with '-'
-		{`xn--.net`, errInvalidDNSCharacter},      // Label ends with '-'
-		{`www.xn--hmr.net`, errIDNNotSupported},   // Punycode (disallowed for now)
+		{`xn--.net`, errIDNNotSupported},        // Punycode (disallowed for now)
+		{`www.xn--hmr.net`, errIDNNotSupported}, // Punycode (disallowed for now)
 		{`0`, errTooFewLabels},
 		{`1`, errTooFewLabels},
 		{`*`, errInvalidDNSCharacter},
@@ -125,6 +123,9 @@ func TestWillingToIssue(t *testing.T) {
 		"8675309.com",
 		"zom2bo.com",
 		"www.zom-bo.com",
+		"www.-ombo.com",
+		"www.zomb-.com",
+		"-.zombo.com",
 	}
 
 	pa, cleanup := paImpl(t)


### PR DESCRIPTION
Similar to #1225 I've encountered issues where a subdomain label of `-` is not accepted (ie: `-.jehiah.cz`) even thought it's a valid (all be it odd) domain name as it meets the criteria from RFC 952 and 1123.

> RFC 952 and 1123 outline that the safe hostname character set is [a-zA-Z0-9-]

```
-.jehiah.cz error acme: Error 400 - urn:acme:error:malformed - Error creating new authz :: Invalid character in DNS name
```
