### PR TITLE
in ca tests, tell cfssl we are making serials

### DIFF
--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -204,6 +204,7 @@ func setup(t *testing.T) *testCtx {
 							PublicKey:          true,
 							SignatureAlgorithm: true,
 						},
+						ClientProvidesSerialNumbers: true,
 					},
 					ecdsaProfileName: &cfsslConfig.SigningProfile{
 						Usage:     []string{"digital signature", "server auth"},
@@ -224,6 +225,7 @@ func setup(t *testing.T) *testCtx {
 							PublicKey:          true,
 							SignatureAlgorithm: true,
 						},
+						ClientProvidesSerialNumbers: true,
 					},
 				},
 				Default: &cfsslConfig.SigningProfile{

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -198,6 +198,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 					SignatureAlgorithm: true,
 					DNSNames:           true,
 				},
+				ClientProvidesSerialNumbers: true,
 			},
 		},
 	}


### PR DESCRIPTION
Also in ra tests.
    
This fixes the spurious ca and ra test failure where the serials are the wrong size. CFSSL makes ones that are larger than we expect.
