### PR TITLE
Add support for CAA account key binding

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -130,6 +130,31 @@ func (mock *MockDNSResolver) LookupCAA(_ context.Context, domain string) ([]*dns
 		record.Tag = "issue"
 		record.Value = ";"
 		results = append(results, &record)
+	case "restricted-ak1.com":
+		record.Tag = "issue"
+		record.Value = "letsencrypt.org; acme-ak=QdfmOFQqMHUTPXyDHZFRmaLDeYDGO1rLISOmC0-QtkU"
+		results = append(results, &record)
+	case "restricted-ak2.com":
+		// Multiple account keys, only one of which will be satisfied.
+		record.Tag = "issue"
+		record.Value = "letsencrypt.org; acme-ak=QdfmOFQqMHUTPXyDHZFRmaLDeYDGO1rLISOmC0-QtkU"
+		results = append(results, &record)
+		secondRecord := record
+		secondRecord.Value = "letsencrypt.org; acme-ak=AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa0"
+		results = append(results, &secondRecord)
+	case "useless-ak.com":
+		// Record with an account key, and another without, meaning no restriction.
+		record.Tag = "issue"
+		record.Value = "letsencrypt.org; acme-ak=AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa0"
+		results = append(results, &record)
+		secondRecord := record
+		secondRecord.Value = "letsencrypt.org; unknown-param=1"
+		results = append(results, &secondRecord)
+	case "unsatisfiable-ak.com":
+		// Cannot be satisfied.
+		record.Tag = "issue"
+		record.Value = "letsencrypt.org; acme-ak=AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa0"
+		results = append(results, &record)
 	}
 	return results, nil
 }

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -59,7 +59,8 @@ func main() {
 		}
 
 		rai := ra.NewRegistrationAuthorityImpl(clock.Default(), auditlogger, stats,
-			dc, rateLimitPolicies, c.RA.MaxContactsPerRegistration, c.KeyPolicy())
+			dc, rateLimitPolicies, c.RA.MaxContactsPerRegistration, c.KeyPolicy(),
+			c.RA.UseUpdateValidationRPC)
 		rai.PA = pa
 		raDNSTimeout, err := time.ParseDuration(c.Common.DNSTimeout)
 		cmd.FailOnError(err, "Couldn't parse RA DNS timeout")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -63,6 +63,9 @@ type Config struct {
 		// UseIsSafeDomain determines whether to call VA.IsSafeDomain
 		UseIsSafeDomain bool // TODO(jmhodges): remove after va IsSafeDomain deploy
 
+		// UseUpdateValidationRPC determines whether to call VA.UpdateValidation
+		UseUpdateValidationRPC bool
+
 		// The number of times to try a DNS query (that has a temporary error)
 		// before giving up. May be short-circuited by deadlines. A zero value
 		// will be turned into 1.

--- a/core/objects.go
+++ b/core/objects.go
@@ -204,15 +204,26 @@ func NewKeyAuthorization(token string, key *jose.JsonWebKey) (KeyAuthorization, 
 		return KeyAuthorization{}, fmt.Errorf("Cannot authorize a nil key")
 	}
 
-	thumbprint, err := key.Thumbprint(crypto.SHA256)
+	thumbprint, err := KeyThumbprintBase64(key)
 	if err != nil {
 		return KeyAuthorization{}, err
 	}
 
 	return KeyAuthorization{
 		Token:      token,
-		Thumbprint: base64.RawURLEncoding.EncodeToString(thumbprint),
+		Thumbprint: thumbprint,
 	}, nil
+}
+
+// KeyThumbprintBase64 returns the SHA-256 JWK key thumbprint for a key encoded
+// using base64url without padding.
+func KeyThumbprintBase64(key *jose.JsonWebKey) (string, error) {
+	thumbprint, err := key.Thumbprint(crypto.SHA256)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.RawURLEncoding.EncodeToString(thumbprint), nil
 }
 
 // NewKeyAuthorizationFromString parses the string and composes a key authorization struct

--- a/core/va.go
+++ b/core/va.go
@@ -7,8 +7,10 @@ package core
 
 // ValidationAuthority defines the public interface for the Boulder VA
 type ValidationAuthority interface {
-	// [RegistrationAuthority]
+	// [RegistrationAuthority] Deprecated; to be removed.
 	UpdateValidations(Authorization, int) error
+	// [RegistrationAuthority]
+	UpdateValidation(*UpdateValidationRequest) error
 	IsSafeDomain(*IsSafeDomainRequest) (*IsSafeDomainResponse, error)
 }
 
@@ -23,4 +25,17 @@ type IsSafeDomainRequest struct {
 // domain is safe.
 type IsSafeDomainResponse struct {
 	IsSafe bool
+}
+
+// UpdateValidationRequest is the request struct for the UpdateValidation call.
+type UpdateValidationRequest struct {
+	// The authorization containing the challenge to update.
+	Authorization Authorization
+
+	// The index of the challenge in the authorization to update.
+	ChallengeIndex int
+
+	// Optional. JWK account key thumbprint in base64url form. If not specified,
+	// account key validation is not performed.
+	AccountKeyThumbprint string
 }

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -163,6 +163,7 @@
     "maxContactsPerRegistration": 100,
     "dnsTries": 3,
     "debugAddr": "localhost:8002",
+    "useUpdateValidationRPC": true,
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -580,7 +580,7 @@ func TestIssueCertificate(t *testing.T) {
 	// TODO: Use a mock RA so we can test various conditions of authorized, not
 	// authorized, etc.
 	stats, _ := statsd.NewNoopClient(nil)
-	ra := ra.NewRegistrationAuthorityImpl(fc, wfe.log, stats, nil, cmd.RateLimitConfig{}, 0, testKeyPolicy)
+	ra := ra.NewRegistrationAuthorityImpl(fc, wfe.log, stats, nil, cmd.RateLimitConfig{}, 0, testKeyPolicy, true)
 	ra.SA = mocks.NewStorageAuthority(fc)
 	ra.CA = &MockCA{}
 	ra.PA = &MockPA{}


### PR DESCRIPTION
This snowballed a bit. The following changes are performed:
- The CheckCAARecords RPC call is removed, since it was never used.
  All calls to this method are made not via RPC. The method itself
  is retained.
- A new RPC call, UpdateValidation is introduced to replace
  UpdateValidations. It is flag-gated. The old method will be removed
  once deployability permits.
- The CAA parsing code is updated to support parameters. Account key
  thumbprints are sent by the RA and are checked if specified in a
  CAA issue parameter named "acme-ak", which should be set to a
  padding-free base64url encoding of the JWK thumbprint of the ACME
  account key. This becomes a condition of satisfaction of the record.

I also reordered the methods in validation-authority.go to be in a more
readable order, based on the call tree. This does have the consequence
of bloating the diff, somewhat; I can always undo it. (Try reading only
the addition lines.)

Fixes #1452.
