### PR TITLE
Return error from PA when DB is down.

### DIFF
--- a/policy/policy-authority-data.go
+++ b/policy/policy-authority-data.go
@@ -7,6 +7,7 @@ package policy
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 
 	"github.com/letsencrypt/boulder/core"
@@ -14,6 +15,8 @@ import (
 
 	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
+
+var errDBFailure = core.InternalServerError("Error checking policy DB.")
 
 const whitelisted = "whitelist"
 const blacklisted = "blacklist"
@@ -40,20 +43,27 @@ type RuleSet struct {
 	Whitelist []WhitelistRule
 }
 
+type gorpDbMap interface {
+	AddTableWithName(interface{}, string) *gorp.TableMap
+	Begin() (*gorp.Transaction, error)
+	SelectOne(interface{}, string, ...interface{}) error
+	Select(interface{}, string, ...interface{}) ([]interface{}, error)
+}
+
 // PolicyAuthorityDatabaseImpl enforces policy decisions based on various rule
 // lists
 type PolicyAuthorityDatabaseImpl struct {
 	log   *blog.AuditLogger
-	dbMap *gorp.DbMap
+	dbMap gorpDbMap
 }
 
 // NewPolicyAuthorityDatabaseImpl constructs a Policy Authority Database (and
 // creates tables if they are non-existent)
-func NewPolicyAuthorityDatabaseImpl(dbMap *gorp.DbMap) (padb *PolicyAuthorityDatabaseImpl, err error) {
+func NewPolicyAuthorityDatabaseImpl(dbMap gorpDbMap) (padb *PolicyAuthorityDatabaseImpl, err error) {
 	logger := blog.GetAuditLogger()
 
-	dbMap.AddTableWithName(BlacklistRule{}, "blacklist").SetKeys(false, "Host")
-	dbMap.AddTableWithName(WhitelistRule{}, "whitelist").SetKeys(false, "Host")
+	dbMap.AddTableWithName(BlacklistRule{}, "blacklist")
+	dbMap.AddTableWithName(WhitelistRule{}, "whitelist")
 
 	padb = &PolicyAuthorityDatabaseImpl{
 		dbMap: dbMap,
@@ -114,7 +124,10 @@ func (padb *PolicyAuthorityDatabaseImpl) DumpRules() (rs RuleSet, err error) {
 	return rs, err
 }
 
-func (padb *PolicyAuthorityDatabaseImpl) allowedByBlacklist(host string) bool {
+// allowedByBlacklist returns nil if the host is allowed, errBlacklisted if the
+// host is disallowed, or an InternalServerError if there was another problem
+// checking the database.
+func (padb *PolicyAuthorityDatabaseImpl) allowedByBlacklist(host string) error {
 	var rule BlacklistRule
 	// Use lexical ordering to quickly find blacklisted root domains
 	err := padb.dbMap.SelectOne(
@@ -123,15 +136,19 @@ func (padb *PolicyAuthorityDatabaseImpl) allowedByBlacklist(host string) bool {
 		map[string]interface{}{"host": host},
 	)
 	if err != nil {
+		// No rows means not blacklisted, so no error.
 		if err == sql.ErrNoRows {
-			return true
+			return nil
 		}
-		return false
+		padb.log.Err(fmt.Sprintf("Error checking policy DB: %s", err))
+		return errDBFailure
 	}
 	if host == rule.Host || strings.HasPrefix(host, rule.Host+".") {
-		return false
+		return errBlacklisted
 	}
-	return true
+	// If we got a result but it's not a match, that means the host is not
+	// blacklisted.
+	return nil
 }
 
 func (padb *PolicyAuthorityDatabaseImpl) allowedByWhitelist(host string) bool {
@@ -155,15 +172,10 @@ func (padb *PolicyAuthorityDatabaseImpl) allowedByWhitelist(host string) bool {
 func (padb *PolicyAuthorityDatabaseImpl) CheckHostLists(host string, requireWhitelisted bool) error {
 	if requireWhitelisted {
 		if !padb.allowedByWhitelist(host) {
-			// return fmt.Errorf("Domain is not whitelisted for issuance")
 			return errNotWhitelisted
 		}
 	}
 	// Overrides the whitelist if a blacklist rule is found
 	host = core.ReverseName(host)
-	if !padb.allowedByBlacklist(host) {
-		// return fmt.Errorf("Domain is blacklisted for issuance")
-		return errBlacklisted
-	}
-	return nil
+	return padb.allowedByBlacklist(host)
 }

--- a/policy/policy-authority-data.go
+++ b/policy/policy-authority-data.go
@@ -169,6 +169,8 @@ func (padb *PolicyAuthorityDatabaseImpl) allowedByWhitelist(host string) bool {
 
 // CheckHostLists will query the database for white/blacklist rules that match host,
 // if both whitelist and blacklist rules are found the blacklist will always win
+// Returns errNotWhitelisted, errBlacklisted, or errDBFailure for the
+// appropriate problems, or nil if the host is allowable.
 func (padb *PolicyAuthorityDatabaseImpl) CheckHostLists(host string, requireWhitelisted bool) error {
 	if requireWhitelisted {
 		if !padb.allowedByWhitelist(host) {

--- a/policy/policy-authority-data_test.go
+++ b/policy/policy-authority-data_test.go
@@ -6,11 +6,14 @@
 package policy
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
+
+	gorp "github.com/letsencrypt/boulder/Godeps/_workspace/src/gopkg.in/gorp.v1"
 )
 
 func padbImpl(t *testing.T) (*PolicyAuthorityDatabaseImpl, func()) {
@@ -51,6 +54,32 @@ func TestLoadAndDumpRules(t *testing.T) {
 
 	test.AssertEquals(t, dumped.Whitelist[0], load.Whitelist[0])
 	test.AssertEquals(t, dumped.Blacklist[0], load.Blacklist[0])
+}
+
+// An implementation of the gorpDbMap interface that always returns an error
+// from SelectOne.
+type failureDB struct{}
+
+func (f *failureDB) AddTableWithName(interface{}, string) *gorp.TableMap {
+	return nil // not implemented
+}
+
+func (f *failureDB) Begin() (*gorp.Transaction, error) {
+	return nil, nil // not implemented
+}
+func (f *failureDB) SelectOne(interface{}, string, ...interface{}) error {
+	return fmt.Errorf("DB failure")
+}
+
+func (f *failureDB) Select(interface{}, string, ...interface{}) ([]interface{}, error) {
+	return nil, nil // not implemented
+}
+
+func TestBlacklistError(t *testing.T) {
+	p, err := NewPolicyAuthorityDatabaseImpl(&failureDB{})
+	test.AssertNotError(t, err, "Couldn't make PA")
+	err = p.CheckHostLists("bad.com", false)
+	test.AssertEquals(t, err, errDBFailure)
 }
 
 func TestBlacklist(t *testing.T) {


### PR DESCRIPTION
Previously, we'd return "Name is blacklisted" in the case of a DB failure. After
this change, we correctly return an internal server error.

Fixes #1491.