### PR TITLE
Add a 'godep restore' test in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ env:
   matrix:
     - RUN="integration vet lint fmt migrations"
     - RUN="unit"
+    - RUN="godep-restore"
 
 script:
   - bash test.sh

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/letsencrypt/boulder",
-	"GoVersion": "go1.5.2",
+	"GoVersion": "go1.5",
 	"Packages": [
 		"./..."
 	],

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,9 @@ fi
 
 # The list of segments to run. To run only some of these segments, pre-set the
 # RUN variable with the ones you want (see .travis.yml for an example).
-# Order doesn't matter.
+# Order doesn't matter. Note: godep-restore is specifically left out of the
+# defaults, because we don't want to run it locally (would be too disruptive to
+# GOPATH).
 RUN=${RUN:-vet lint fmt migrations unit integration}
 
 # The list of segments to hard fail on, as opposed to continuing to the end of
@@ -273,6 +275,25 @@ if [[ "$RUN" =~ "integration" ]] ; then
       ;;
   esac
   end_context #integration
+fi
+
+# Run godep-restore (happens only in Travis) to check that the hashes in
+# Godeps.json really exist in the remote repo and match what we have.
+if [[ "$RUN" =~ "godep-restore" ]] ; then
+  start_context "godep-restore"
+  run_and_comment godep restore
+  # Run godep save and do a diff, to ensure that the version we got from
+  # `godep restore` matched what was in the remote repo. We only do this on
+  # builds of the main fork (not PRs from external contributors), because godep
+  # rewrites import paths to the path of the fork we're building from, which
+  # creates spurious diffs if we're not building from the main fork.
+  # Once we switch to Go 1.6's imports and don't need rewriting anymore, we can
+  # do this for all builds.
+  if [[ "${TRAVIS_REPO_SLUG}" == "letsencrypt/boulder" ]] ; then
+    run_and_comment godep save -r ./...
+    run_and_comment git diff --exit-code
+  fi
+  end_context #godep-restore
 fi
 
 exit ${FAILURE}

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -8,6 +8,7 @@ go get \
   golang.org/x/tools/cmd/vet \
   golang.org/x/tools/cmd/cover \
   github.com/golang/lint/golint \
+  github.com/tools/godep \
   github.com/mattn/goveralls \
   github.com/modocache/gover \
   github.com/jcjones/github-pr-status \


### PR DESCRIPTION
This ensures our godeps match the remote repo.

Also, change GoVersion to the major version, as is the default in the latest godep (which means contributors must use latest godep when updating dependencies).