### PR TITLE
Set GOBIN to a relative path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This Makefile also tricks Travis into not running 'go get' for our
 # build. See http://docs.travis-ci.com/user/languages/go/
 
-OBJDIR ?= $(shell pwd)/bin
+OBJDIR ?= ./bin
 DESTDIR ?= /usr/local/bin
 ARCHIVEDIR ?= /tmp
 


### PR DESCRIPTION
This is a revert of https://github.com/letsencrypt/boulder/pull/1474. Building
with that change meant that the Boulder RPM unpacked to
/opt/boulder/tmp/tmp.<generated>/src/github.com/letsencrypt/boulder/ instead of
/opt/boulder.