### PR TITLE
Add config flag to enable must staple.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -332,6 +332,10 @@ type CAConfig struct {
 	// to add a certificate's serial to its Subject, and whether to
 	// not pull a SAN entry to be the CN if no CN was given in a CSR.
 	DoNotForceCN bool
+
+	// EnableMustStaple governs whether the Must Staple extension in CSRs
+	// triggers issuance of certificates with Must Staple.
+	EnableMustStaple bool
 }
 
 // PAConfig specifies how a policy authority should connect to its


### PR DESCRIPTION
This ensures we don't try to pass the must staple extension to CFSSL until we've
also enabled it in AllowedExtensions in our CFSSL profile.

Fixes #1513.

Tip: Add &w=1 to review URL to ignore whitespace.