### PR TITLE
Switch to Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.3
+  - 1.6
 
 addons:
   hosts:
@@ -52,6 +52,7 @@ install:
 env:
   global:
     - LETSENCRYPT_PATH=$HOME/letsencrypt
+    - GO15VENDOREXPERIMENT=0
   matrix:
     - RUN="integration vet lint fmt migrations"
     - RUN="unit"

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/letsencrypt/boulder",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.6",
 	"Packages": [
 		"./..."
 	],

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This Makefile also tricks Travis into not running 'go get' for our
 # build. See http://docs.travis-ci.com/user/languages/go/
 
-OBJDIR ?= ./bin
+OBJDIR ?= $(shell pwd)/bin
 DESTDIR ?= /usr/local/bin
 ARCHIVEDIR ?= /tmp
 
@@ -11,7 +11,7 @@ MAINTAINER ?= "Community"
 
 CMDS = $(shell find ./cmd -maxdepth 1 -mindepth 1 -type d | grep -v testdata)
 CMD_BASENAMES = $(shell echo $(CMDS) | xargs -n1 basename)
-CMD_BINS = $(addprefix $(OBJDIR)/, $(CMD_BASENAMES) )
+CMD_BINS = $(addprefix bin/, $(CMD_BASENAMES) )
 OBJECTS = $(CMD_BINS)
 
 # Build environment variables (referencing core/util.go)


### PR DESCRIPTION
Switches the Travis Go version to 1.6 and re-applys the work of #1508 as well as changing the `CMD_BINS` so that the RPM is properly built.