### PR TITLE
Perform CAA lookups in parallel.

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -73,7 +73,7 @@ func (mock *MockDNSResolver) LookupHost(_ context.Context, hostname string) ([]n
 	return []net.IP{ip}, nil
 }
 
-// LookupCAA is a mock
+// LookupCAA returns mock records for use in tests.
 func (mock *MockDNSResolver) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, error) {
 	var results []*dns.CAA
 	var record dns.CAA
@@ -89,15 +89,14 @@ func (mock *MockDNSResolver) LookupCAA(_ context.Context, domain string) ([]*dns
 		record.Tag = "issue"
 		record.Value = "symantec.com"
 		results = append(results, &record)
-	case "present.com":
+	case "present.com", "present.servfail.com":
 		record.Tag = "issue"
 		record.Value = "letsencrypt.org"
 		results = append(results, &record)
 	case "com":
-		// Nothing should ever call this, since CAA checking should stop when it
-		// reaches a public suffix.
-		fallthrough
-	case "servfail.com":
+		// com has no CAA records.
+		return nil, nil
+	case "servfail.com", "servfail.present.com":
 		return results, fmt.Errorf("SERVFAIL")
 	case "multi-crit-present.com":
 		record.Flag = 1

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -679,6 +679,7 @@ func TestCAAChecking(t *testing.T) {
 		{"example.co.uk", false, true},
 		// Good (present)
 		{"present.com", true, true},
+		{"present.servfail.com", true, true},
 		// Good (multiple critical, one matching)
 		{"multi-crit-present.com", true, true},
 		// Bad (unknown critical)
@@ -717,6 +718,16 @@ func TestCAAChecking(t *testing.T) {
 	_, _, err = va.checkCAARecords(context.Background(), core.AcmeIdentifier{Type: "dns", Value: "servfail.com"})
 	if err == nil {
 		t.Errorf("Should have returned error on CAA lookup, but did not: %s", "servfail.com")
+	}
+
+	present, valid, err = va.checkCAARecords(context.Background(), core.AcmeIdentifier{Type: "dns", Value: "servfail.present.com"})
+	test.AssertError(t, err, "servfail.present.com")
+	test.Assert(t, !present, "Present should be false")
+	test.Assert(t, !valid, "Valid should be false")
+
+	_, _, err = va.checkCAARecords(context.Background(), core.AcmeIdentifier{Type: "dns", Value: "servfail.present.com"})
+	if err == nil {
+		t.Errorf("Should have returned error on CAA lookup, but did not: %s", "servfail.present.com")
 	}
 }
 


### PR DESCRIPTION
Also, stop skipping CAA lookups for the root TLDs. The RFC is unclear on
the desired behavior here, but the ICANNTLD function is nonstandard and
the behavior is strictly more conservative than what we had before.

This unblocks the removal of the ICANNTLD function, which allows us to
stop forking upstream.

Closes #1522