### PR TITLE
Introduce cmd.Clock() for use in tests

### DIFF
--- a/cmd/clock_generic.go
+++ b/cmd/clock_generic.go
@@ -1,0 +1,14 @@
+// +build !integration
+
+package cmd
+
+import "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
+
+// Clock functions similarly to clock.Default(), but the returned value can be
+// changed using the FAKECLOCK environment variable if the 'integration' build
+// flag is set.
+//
+// This function returns the default Clock.
+func Clock() clock.Clock {
+	return clock.Default()
+}

--- a/cmd/clock_integration.go
+++ b/cmd/clock_integration.go
@@ -1,0 +1,30 @@
+// +build integration
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+// Clock functions similarly to clock.Default(), but the returned value can be
+// changed using the FAKECLOCK environment variable if the 'integration' build
+// flag is set.
+//
+// The FAKECLOCK env var is in the time.UnixDate format, returned by `date -d`.
+func Clock() clock.Clock {
+	if tgt := os.Getenv("FAKECLOCK"); tgt != "" {
+		targetTime, err := time.Parse(tgt, time.UnixDate)
+		FailOnError(err, fmt.Sprintf("cmd.Clock: bad format for FAKECLOCK: %v\n", err))
+
+		cl := clock.NewFake()
+		cl.Set(targetTime)
+		blog.GetAuditLogger().Notice(fmt.Sprintf("Time was set to %v via FAKECLOCK", targetTime))
+		return cl
+	}
+	return clock.Default()
+}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -335,7 +335,7 @@ func main() {
 			emailTemplate: tmpl,
 			nagTimes:      nags,
 			limit:         c.Mailer.CertLimit,
-			clk:           clock.Default(),
+			clk:           cmd.Clock(),
 		}
 
 		auditlogger.Info("expiration-mailer: Starting")

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -38,7 +38,7 @@ def install(race_detection):
     # BUILD_ID.
     cmd = "make GO_BUILD_FLAGS=''  "
     if race_detection:
-        cmd = "make GO_BUILD_FLAGS=-race"
+        cmd = "make GO_BUILD_FLAGS='-race -tags integration'"
 
     return subprocess.call(cmd, shell=True) == 0
 


### PR DESCRIPTION
In order to run the expiry mailer during the integration tests, we would either need to (1) set the nag-after duration to something like 1 second, (2) set it to ~30sec and add sleeps during the test, or (3) set a fake clock in the expiry mailer.

This patch implements (3).

This is part of #1557.