### PR TITLE
Handle errors in EffectiveTLDPlusOne for ratelimits

### DIFF
--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -600,7 +600,13 @@ func domainsForRateLimiting(names []string) ([]string, error) {
 	for _, name := range names {
 		eTLDPlusOne, err := publicsuffix.EffectiveTLDPlusOne(name)
 		if err != nil {
-			return nil, err
+			// The only possible errors are:
+			// (1) publicsuffix.PublicSuffix is giving garbage
+			//     values
+			// (2) the public suffix is the domain itself
+			//
+			// Assume (2).
+			eTLDPlusOne = name
 		}
 		if _, ok := domainsMap[eTLDPlusOne]; !ok {
 			domainsMap[eTLDPlusOne] = struct{}{}

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -786,7 +786,11 @@ func TestDomainsForRateLimiting(t *testing.T) {
 	test.AssertEquals(t, domains[1], "example.co.uk")
 
 	domains, err = domainsForRateLimiting([]string{"www.example.com", "example.com", "www.example.co.uk", "co.uk"})
-	test.AssertError(t, err, "should fail on public suffix")
+	test.AssertNotError(t, err, "should not fail on public suffix")
+	test.AssertEquals(t, len(domains), 3)
+	test.AssertEquals(t, domains[0], "example.com")
+	test.AssertEquals(t, domains[1], "example.co.uk")
+	test.AssertEquals(t, domains[2], "co.uk")
 
 	domains, err = domainsForRateLimiting([]string{"foo.bar.baz.www.example.com", "baz.example.com"})
 	test.AssertNotError(t, err, "failed on foo.bar.baz")


### PR DESCRIPTION
The only failure conditions for EffectiveTLDPlusOne are (1) the
underlying PublicSuffix function returning nonsensical data (a suffix
longer than the original domain, or the character preceding the suffix
is not a '.'), and (2) the suffix being equal to the domain.

Since we have bigger problems if (1) ever happens, assume errors are
only returned if (2) has occured, and use the public suffix itself for
the ratelimit.

Fixes #1572