### PR TITLE
Add GetValidAuthorizations to batch authz checks

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -97,6 +97,7 @@ type StorageGetter interface {
 	GetRegistrationByKey(jose.JsonWebKey) (Registration, error)
 	GetAuthorization(string) (Authorization, error)
 	GetLatestValidAuthorization(int64, AcmeIdentifier) (Authorization, error)
+	GetValidAuthorizations(int64, []string, time.Time) (map[string]*Authorization, error)
 	GetCertificate(string) (Certificate, error)
 	GetCertificateStatus(string) (CertificateStatus, error)
 	AlreadyDeniedCSR([]string) (bool, error)

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -268,6 +268,29 @@ func (sa *StorageAuthority) GetLatestValidAuthorization(registrationID int64, id
 	return core.Authorization{}, errors.New("no authz")
 }
 
+// GetValidAuthorizations is a mock
+func (sa *StorageAuthority) GetValidAuthorizations(regID int64, names []string, now time.Time) (map[string]*core.Authorization, error) {
+	if regID == 1 {
+		auths := make(map[string]*core.Authorization)
+		for _, name := range names {
+			if sa.authorizedDomains[name] || name == "not-an-example.com" {
+				exp := now.AddDate(100, 0, 0)
+				auths[name] = &core.Authorization{
+					Status:         core.StatusValid,
+					RegistrationID: 1,
+					Expires:        &exp,
+					Identifier: core.AcmeIdentifier{
+						Type:  "dns",
+						Value: name,
+					},
+				}
+			}
+		}
+		return auths, nil
+	}
+	return nil, errors.New("no authz")
+}
+
 // CountCertificatesRange is a mock
 func (sa *StorageAuthority) CountCertificatesRange(_, _ time.Time) (int64, error) {
 	return 0, nil

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -461,7 +461,11 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizations(names []string, registr
 	}
 	for _, name := range names {
 		authz := auths[name]
-		if authz == nil || authz.Expires.Before(now) {
+		if authz == nil {
+			badNames = append(badNames, name)
+		} else if authz.Expires == nil {
+			return fmt.Errorf("Found an authorization with a nil Expires field: id %d", authz.ID)
+		} else if authz.Expires.Before(now) {
 			badNames = append(badNames, name)
 		}
 	}


### PR DESCRIPTION
By performing only one query to MySQL, we should be able to avoid
blowing the timeouts.

Fixes #1567