### PR TITLE
avoid exposing mysqld and rabbitmq beyond the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,18 @@
+# see comments in test/run-docker.sh about host networking
 boulder:
     build: .
     dockerfile: Dockerfile
     net: host
-    ports:
-        - "4000:4000"
     environment:
         MYSQL_CONTAINER: "yes"
 mysql:
     image: mariadb:10.0
     net: host
-    ports:
-        - "3306:3306"
     environment:
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    command: mysqld --bind-address=127.0.0.1
 rabbitmq:
     image: rabbitmq:3
     net: host
-    ports:
-        - "5672:5672"
+    environment:
+        RABBITMQ_NODE_IP_ADDRESS: "127.0.0.1"


### PR DESCRIPTION
This ensures that services in mariadb and rabbitmq containers bind only to 127.0.0.1, not all interfaces. Otherwise with host networking the test services are exposed outside the host.

Fixes #1594 

I decided not to add duplicated GRANT 'username'@'127.0.0.1' statements. Rather the sql is patched in test/create_db.sh when running under docker to turn 'localhost' into '127.0.0.1'. The reason for this is that it may be necessary to add in future yet another GRANT with '::1' to cover ipv6. 

A cleaner solution can be to turn the grant files into shell scripts that print SQL and accept the host or host list as a parameter, but this is for another time. 