### PR TITLE
Make a couple of fields private on DNS impl

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -126,8 +126,8 @@ type DNSResolver interface {
 
 // DNSResolverImpl represents a client that talks to an external resolver
 type DNSResolverImpl struct {
-	DNSClient                exchanger
-	Servers                  []string
+	dnsClient                exchanger
+	servers                  []string
 	allowRestrictedAddresses bool
 	maxTries                 int
 	clk                      clock.Clock
@@ -155,8 +155,8 @@ func NewDNSResolverImpl(readTimeout time.Duration, servers []string, stats metri
 	dnsClient.Net = "tcp"
 
 	return &DNSResolverImpl{
-		DNSClient:                dnsClient,
-		Servers:                  servers,
+		dnsClient:                dnsClient,
+		servers:                  servers,
 		allowRestrictedAddresses: false,
 		maxTries:                 maxTries,
 		clk:                      clk,
@@ -188,16 +188,16 @@ func (dnsResolver *DNSResolverImpl) exchangeOne(ctx context.Context, hostname st
 	// Set DNSSEC OK bit for resolver
 	m.SetEdns0(4096, true)
 
-	if len(dnsResolver.Servers) < 1 {
+	if len(dnsResolver.servers) < 1 {
 		return nil, fmt.Errorf("Not configured with at least one DNS Server")
 	}
 
 	dnsResolver.stats.Inc("Rate", 1)
 
 	// Randomly pick a server
-	chosenServer := dnsResolver.Servers[rand.Intn(len(dnsResolver.Servers))]
+	chosenServer := dnsResolver.servers[rand.Intn(len(dnsResolver.servers))]
 
-	client := dnsResolver.DNSClient
+	client := dnsResolver.dnsClient
 
 	tries := 1
 	start := dnsResolver.clk.Now()

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -453,7 +453,7 @@ func TestRetry(t *testing.T) {
 	for i, tc := range tests {
 		dr := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), tc.maxTries)
 
-		dr.DNSClient = tc.te
+		dr.dnsClient = tc.te
 		_, _, err := dr.LookupTXT(context.Background(), "example.com")
 		if err == errTooManyRequests {
 			t.Errorf("#%d, sent more requests than the test case handles", i)
@@ -470,7 +470,7 @@ func TestRetry(t *testing.T) {
 	}
 
 	dr := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 3)
-	dr.DNSClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
+	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, _, err := dr.LookupTXT(ctx, "example.com")
@@ -479,7 +479,7 @@ func TestRetry(t *testing.T) {
 		t.Errorf("expected %s, got %s", context.Canceled, err)
 	}
 
-	dr.DNSClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
+	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, _ = context.WithTimeout(context.Background(), -10*time.Hour)
 	_, _, err = dr.LookupTXT(ctx, "example.com")
 	if err == nil ||
@@ -487,7 +487,7 @@ func TestRetry(t *testing.T) {
 		t.Errorf("expected %s, got %s", context.DeadlineExceeded, err)
 	}
 
-	dr.DNSClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
+	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, deadlineCancel := context.WithTimeout(context.Background(), -10*time.Hour)
 	deadlineCancel()
 	_, _, err = dr.LookupTXT(ctx, "example.com")


### PR DESCRIPTION
These fields were not used externally and could not be modified concurrently, so
they should not be exposed.