### PR TITLE
Check that modulus length is divisible by 8 in GoodKey.

### DIFF
--- a/core/good_key.go
+++ b/core/good_key.go
@@ -196,6 +196,11 @@ func (policy *KeyPolicy) goodKeyRSA(key rsa.PublicKey) (err error) {
 	if modulusBitLen > maxKeySize {
 		return MalformedRequestError(fmt.Sprintf("Key too large: %d > %d", modulusBitLen, maxKeySize))
 	}
+	// Bit lengths that are not a multiple of 8 may cause problems on some
+	// client implementations.
+	if modulusBitLen%8 != 0 {
+		return MalformedRequestError(fmt.Sprintf("Key length wasn't a multiple of 8: %d", modulusBitLen))
+	}
 	// The CA SHALL confirm that the value of the public exponent is an
 	// odd number equal to 3 or more. Additionally, the public exponent
 	// SHOULD be in the range between 2^16 + 1 and 2^256-1.

--- a/core/good_key_test.go
+++ b/core/good_key_test.go
@@ -41,6 +41,15 @@ func TestLargeModulus(t *testing.T) {
 	test.AssertError(t, testingPolicy.GoodKey(private.PublicKey), "Should have rejected too-long key.")
 }
 
+func TestModulusModulo8(t *testing.T) {
+	bigOne := big.NewInt(1)
+	key := rsa.PublicKey{
+		N: bigOne.Lsh(bigOne, 2049),
+		E: 5,
+	}
+	test.AssertError(t, testingPolicy.GoodKey(&key), "Should have rejected modulus with length not divisible by 8.")
+}
+
 func TestSmallExponent(t *testing.T) {
 	bigOne := big.NewInt(1)
 	key := rsa.PublicKey{


### PR DESCRIPTION
Serial numbers in the CT logs that have non-divisible-by-8 modulus length:

Fixes #1599.

@pzb: Do you have an specific examples of popular clients that fail with non-divisible-by-8 modulus length, so I can include them in the code comment?

These are all the entries from the CT logs issued by Let's Encrypt that have a non-divisible-by-8 modulus length today. I've fetched each host name to confirm that none of them have a Public-Key-Pins header (and therefore none are pinning to their leaf key).

https://crt.sh/?serial=017af157d77b1413a239902834178e72bb20
https://crt.sh/?serial=0173c209ff6792316c3e0cab55968f351cc5
https://crt.sh/?serial=01431cb7f9470ee45b6f4b319102553d3a38
https://crt.sh/?serial=01bcd7c197d51a603c930ec09b55e1d69eed
https://crt.sh/?serial=013f51353565895a67fe253c8f4983d5c82f
https://crt.sh/?serial=01a35299515cb75409169d9e0a6627ccc597
https://crt.sh/?serial=011e0adddca49ee0b786813ec2b49154bdf7
https://crt.sh/?serial=01eebb9e9a9108979b3a47217e29b391eb99
https://crt.sh/?serial=01c64e5cda78a9d0f578d6e1cc61c785af7c
https://crt.sh/?serial=0145dda768e38137c8596560b15d52d56e8a
https://crt.sh/?serial=01524fd91b9177ef3adcaf5e9eb832f25b4d
https://crt.sh/?serial=01275f34e47ce1a2df9f0f2b124b72a622f1
https://crt.sh/?serial=018544846d192a1652a549cf4ccb584d397c
https://crt.sh/?serial=01ab9f4b503e8ab947906336053c287a9c10
https://crt.sh/?serial=0166de8ca507dcaa724c74e94d259b4e8ca6
https://crt.sh/?serial=018f3a50178f77d0b41fac0e11867a405151
https://crt.sh/?serial=01d0b50c60f0282c350f2f1928c8229263f6
https://crt.sh/?serial=01ec8978d09bcb2141bea31a3a87d1f121ff
https://crt.sh/?serial=01c7f2ef18a58b9dd3347aab41df0bf9c683
https://crt.sh/?serial=0178783968354b800e99c14eb40c62105e8a
https://crt.sh/?serial=01bb0c96d7ccd5109ed702430cb95500ebe9
https://crt.sh/?serial=016c8263a384d5a4dc07dd97341f5541d008
https://crt.sh/?serial=01f94a33fa393a412213f21c0237b35f4164
https://crt.sh/?serial=01961af313383a735ff249244c974d19cdce
https://crt.sh/?serial=0151d15074797912559203d37f547ab05982
https://crt.sh/?serial=01381e15c57bb71b70449790ea10c6eef499
https://crt.sh/?serial=01dd1b47443c2d9f3a2132a8c77f3c9afe6f
https://crt.sh/?serial=018b36bca7a19f688d8e10d40963701f1921
https://crt.sh/?serial=01fa24288bc7c536d1b4b0cbf75f9d532288
https://crt.sh/?serial=0144c0826a57df425bda751b974823a6c7ec
https://crt.sh/?serial=01e1ddf3fad5db4da5d6a0466076fb5b149d
https://crt.sh/?serial=01bc18004b4fd44d671d1b0b68736eacfe39
https://crt.sh/?serial=01883492513641e5971dfea02f360fdfc3ee
https://crt.sh/?serial=01a3ce708f71ab16dbe3eac66451d9657ae7
https://crt.sh/?serial=018a078bb7ee336d645d2dbb4a15643cd63c
https://crt.sh/?serial=01be4bde2b3811493e902580bbb9ed41a289
https://crt.sh/?serial=015acd1d2052b6febd3517e06fbc3c044be2
https://crt.sh/?serial=01b9c9b5bbde0e0fafafaebea7f940238385
https://crt.sh/?serial=0108c061334fe22f20035f041727fd9f6cca
https://crt.sh/?serial=017d0806db5a1948bd5958984d794da8e760
https://crt.sh/?serial=01e0c375d8ae91a633e161c5e711889edc12
https://crt.sh/?serial=014513db6c2b0e5fc9b01bd3e16c5a301f20
https://crt.sh/?serial=01fe3c857949c085bb9f835d41ebfbc79502
https://crt.sh/?serial=015bb41be9a46f0df2e2335fc1efd35ac0f0
https://crt.sh/?serial=0116674dfc27cfdbb2eadd26cf4ea157d943
https://crt.sh/?serial=013660f7d53adc2f037da825e7b35a29f6b8
https://crt.sh/?serial=01fbb17a9df2644e7941ac07d5e0df44a1a6
https://crt.sh/?serial=01dd34ea3b6d7feac0721edeca78c9bd88d0
https://crt.sh/?serial=012c5988711884e9d55dadb1638d7ad1df52
https://crt.sh/?serial=01c444b69d012963779163e91ee0b91c1a01
https://crt.sh/?serial=01516e6e00180b95fbf547fbb46e4e47b0b6
https://crt.sh/?serial=01e5d33aa90a735d2c29bedc78d7817b312a
https://crt.sh/?serial=0125f110e63dc999257e598ba39335c7dff8
https://crt.sh/?serial=01f8c9f7a2172c12adf04427c45b80288ad4
https://crt.sh/?serial=01f6701c5b7136a31629b5e6c1765c60320b
https://crt.sh/?serial=0191dc216d7b60635234cae78a1435bb5b3c
https://crt.sh/?serial=01ebcb1969e94c6d3bf0dd44cc6a4b5f5ab2
https://crt.sh/?serial=0109c156ec04afb57324ed6c6b1f2a5ce1f8
https://crt.sh/?serial=01f60c6f42fa140fe42853e023450f756416
https://crt.sh/?serial=01f35430bd4f9694e37d840a5556815b79f2
https://crt.sh/?serial=016427f1cafff52874f25b15a6e4fdba10de
https://crt.sh/?serial=01ff6175eb17edf908025dbf493865ba95d4
https://crt.sh/?serial=01ebc2be4a25a16403fb4beab7a40249c522
https://crt.sh/?serial=01362ecda73b646c1a8049a8033f1bd0ba78
https://crt.sh/?serial=015e71d8961c18b0f6b78415f60a30b29d27
https://crt.sh/?serial=015d0bb44d282d072ff242ba803a33275c93
https://crt.sh/?serial=019a7f3ee9e4e31b9007562323189c8a380c
https://crt.sh/?serial=0274a695c57a3e2a50b9f57b4f2deb628038
https://crt.sh/?serial=025cd371a47b72b296770cbc7828444fc1da
https://crt.sh/?serial=0260909d0b06ff102e423212e14355998336
https://crt.sh/?serial=02db0eb690a65d32b627905899a6849f62ee
https://crt.sh/?serial=02a562288c440698a57b212cc711d4094cf5
https://crt.sh/?serial=02475901b9647ce788ac13367714ad2a61bd
https://crt.sh/?serial=022ec8409c3ffd22fff04d2d621b8d1eb36c
https://crt.sh/?serial=02e8ae9030d45c56f32e1b676c004c01ed09
https://crt.sh/?serial=02b8fd0e373feefe408b77869ec7b4c39365
https://crt.sh/?serial=02fb6e63231ccfb98aa26fe486de59ab5620
https://crt.sh/?serial=028751f4757cd98c94a56c9ddf7c87e7fbf3
https://crt.sh/?serial=02255c1a9b63982992c3b9af91f144774989