### PR TITLE
Add a script to do builds in a Docker container

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,0 +1,11 @@
+FROM golang:1.6
+
+RUN apt-get update && apt-get install -y libltdl-dev ruby ruby-dev build-essential rpm && \
+    gem install fpm && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+COPY . /go/src/github.com/letsencrypt/boulder
+RUN mkdir /tmp/boulder-build
+WORKDIR /go/src/github.com/letsencrypt/boulder
+CMD [ "make", "rpm" ]

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,6 @@ rpm: build
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
 		--depends "libtool-ltdl" --maintainer "$(MAINTAINER)" \
 		test/boulder-config.json sa/_db data/ $(OBJECTS)
+
+docker-rpm:
+	VERSION=$(VERSION) COMMIT_ID=$(COMMIT_ID) ARCHIVEDIR=$(ARCHIVEDIR) ./docker-build.sh

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -o xtrace
+
+if [ -z "$VERSION"]; then
+    VERSION="1.0.0"
+fi
+if [ -z "$COMMIT" ]; then
+    COMMIT=$(git rev-parse --short HEAD)
+fi
+
+rm -r build/
+mkdir build
+
+docker build -f Dockerfile-build -t boulder-build .
+docker rm builder
+docker run --name builder boulder-build
+docker cp builder:/tmp/boulder-$VERSION-$COMMIT.x86_64.rpm build/
+docker rm builder

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -o xtrace
+set -e
 
 if [ -z "$VERSION" ]; then
     VERSION="1.0.0"
@@ -12,7 +13,9 @@ if [ -z "$ARCHIVEDIR" ]; then
 fi
 
 docker build -f Dockerfile-build -t boulder-build .
-docker rm builder
+if [ -n "$(docker ps -a -f name=builder -q)" ]; then
+    docker rm builder
+fi
 docker run --name builder boulder-build
-docker cp builder:/tmp/boulder-$VERSION-$COMMIT_ID.x86_64.rpm $ARCHIVEDIR/
+docker cp builder:$ARCHIVEDIR/boulder-$VERSION-$COMMIT_ID.x86_64.rpm $ARCHIVEDIR/
 docker rm builder

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -o xtrace
 
-if [ -z "$VERSION"]; then
+if [ -z "$VERSION" ]; then
     VERSION="1.0.0"
 fi
-if [ -z "$COMMIT" ]; then
-    COMMIT=$(git rev-parse --short HEAD)
+if [ -z "$COMMIT_ID" ]; then
+    COMMIT_ID=$(git rev-parse --short HEAD)
 fi
-
-rm -r build/
-mkdir build
+if [ -z "$ARCHIVEDIR" ]; then
+    ARCHIVEDIR=$(pwd)
+fi
 
 docker build -f Dockerfile-build -t boulder-build .
 docker rm builder
 docker run --name builder boulder-build
-docker cp builder:/tmp/boulder-$VERSION-$COMMIT.x86_64.rpm build/
+docker cp builder:/tmp/boulder-$VERSION-$COMMIT_ID.x86_64.rpm $ARCHIVEDIR/
 docker rm builder


### PR DESCRIPTION
While the Golang compiler takes steps to make sure it isn't running arbitrary code on a system by building binaries we are going to subvert this process in the future by building a copy of the PSL table locally as part of the build. If someone was able to insert a exploit into this code path they would be able to execute code on our build box, possibly causing a long term threat.

One possible safety net is to use a throwaway environment, like a Docker container, each time we build Boulder in order to stop the build process from touching anything we actually care about. This PR adds a little script and a action to the `Makefile` allowing the RPM bundle to be built and assembled inside of a basic container. It might actually make sense to remove the RPM specific steps from this script and simply build the binaries and move them to `./bin` in order to remove the Ruby dep.

cc @jfrazelle -- probably there is a much cleaner way of doing this, thoughts?