### PR TITLE
PerformValidation RA→VA rpc call

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -68,7 +68,8 @@ func main() {
 		}
 
 		rai := ra.NewRegistrationAuthorityImpl(clock.Default(), auditlogger, stats,
-			dc, rateLimitPolicies, c.RA.MaxContactsPerRegistration, c.KeyPolicy())
+			dc, rateLimitPolicies, c.RA.MaxContactsPerRegistration, c.KeyPolicy(),
+			c.RA.UseNewVARPC)
 		rai.PA = pa
 		raDNSTimeout, err := time.ParseDuration(c.Common.DNSTimeout)
 		cmd.FailOnError(err, "Couldn't parse RA DNS timeout")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -64,6 +64,9 @@ type Config struct {
 		// UseIsSafeDomain determines whether to call VA.IsSafeDomain
 		UseIsSafeDomain bool // TODO(jmhodges): remove after va IsSafeDomain deploy
 
+		// UseNewVARPC determines whether to call VA.PerformValidation
+		UseNewVARPC bool
+
 		// The number of times to try a DNS query (that has a temporary error)
 		// before giving up. May be short-circuited by deadlines. A zero value
 		// will be turned into 1.

--- a/core/va.go
+++ b/core/va.go
@@ -8,6 +8,7 @@ package core
 // ValidationAuthority defines the public interface for the Boulder VA
 type ValidationAuthority interface {
 	// [RegistrationAuthority]
+	// TODO(#1167): remove
 	UpdateValidations(Authorization, int) error
 	// PerformValidation checks the challenge with the given index in the
 	// given Authorization and returns the updated ValidationRecords.

--- a/core/va.go
+++ b/core/va.go
@@ -9,6 +9,14 @@ package core
 type ValidationAuthority interface {
 	// [RegistrationAuthority]
 	UpdateValidations(Authorization, int) error
+	// PerformValidation checks the challenge with the given index in the
+	// given Authorization and returns the updated ValidationRecords.
+	//
+	// A failure to validate the Challenge will result in a error of type
+	// *probs.ProblemDetails.
+	//
+	// TODO(#1626): remove authz parameter
+	PerformValidation(string, Challenge, Authorization) ([]ValidationRecord, error)
 	IsSafeDomain(*IsSafeDomainRequest) (*IsSafeDomainResponse, error)
 }
 

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -35,6 +35,8 @@ import (
 type DummyValidationAuthority struct {
 	Called          bool
 	Argument        core.Authorization
+	RecordsReturn   []core.ValidationRecord
+	ProblemReturn   *probs.ProblemDetails
 	IsNotSafe       bool
 	IsSafeDomainErr error
 }
@@ -48,7 +50,7 @@ func (dva *DummyValidationAuthority) UpdateValidations(authz core.Authorization,
 func (dva *DummyValidationAuthority) PerformValidation(domain string, challenge core.Challenge, authz core.Authorization) ([]core.ValidationRecord, error) {
 	dva.Called = true
 	dva.Argument = authz
-	return nil, nil
+	return dva.RecordsReturn, dva.ProblemReturn
 }
 
 func (dva *DummyValidationAuthority) IsSafeDomain(req *core.IsSafeDomainRequest) (*core.IsSafeDomainResponse, error) {
@@ -215,7 +217,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 				Threshold: 100,
 				Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
 			},
-		}, 1, testKeyPolicy)
+		}, 1, testKeyPolicy, false)
 	ra.SA = ssa
 	ra.VA = va
 	ra.CA = ca
@@ -517,6 +519,41 @@ func TestUpdateAuthorizationReject(t *testing.T) {
 	test.AssertEquals(t, err, core.UnauthorizedError("Challenge cannot be updated with a different key"))
 
 	t.Log("DONE TestUpdateAuthorizationReject")
+}
+
+func TestUpdateAuthorizationNewRPC(t *testing.T) {
+	va, sa, ra, _, cleanUp := initAuthorities(t)
+	ra.useNewVARPC = true
+	defer cleanUp()
+
+	// We know this is OK because of TestNewAuthorization
+	authz, err := ra.NewAuthorization(AuthzRequest, Registration.ID)
+	test.AssertNotError(t, err, "NewAuthorization failed")
+
+	response, err := makeResponse(authz.Challenges[ResponseIndex])
+	test.AssertNotError(t, err, "Unable to construct response to challenge")
+	authz.Challenges[ResponseIndex].Type = core.ChallengeTypeDNS01
+	va.RecordsReturn = []core.ValidationRecord{
+		{Hostname: "example.com"}}
+	va.ProblemReturn = nil
+
+	authz, err = ra.UpdateAuthorization(authz, ResponseIndex, response)
+	test.AssertNotError(t, err, "UpdateAuthorization failed")
+
+	// Verify that returned authz same as DB
+	dbAuthz, err := sa.GetAuthorization(authz.ID)
+	test.AssertNotError(t, err, "Could not fetch authorization from database")
+	assertAuthzEqual(t, authz, dbAuthz)
+
+	// Verify that the VA got the authz, and it's the same as the others
+	test.Assert(t, va.Called, "Authorization was not passed to the VA")
+	assertAuthzEqual(t, authz, va.Argument)
+
+	// Verify that the responses are reflected
+	test.Assert(t, len(va.Argument.Challenges) > 0, "Authz passed to VA has no challenges")
+	test.Assert(t, authz.Challenges[ResponseIndex].Status == core.StatusValid, "challenge was not marked as valid")
+
+	t.Log("DONE TestUpdateAuthorizationNewRPC")
 }
 
 func TestOnValidationUpdateSuccess(t *testing.T) {

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -45,6 +45,12 @@ func (dva *DummyValidationAuthority) UpdateValidations(authz core.Authorization,
 	return
 }
 
+func (dva *DummyValidationAuthority) PerformValidation(domain string, challenge core.Challenge, authz core.Authorization) ([]core.ValidationRecord, error) {
+	dva.Called = true
+	dva.Argument = authz
+	return nil, nil
+}
+
 func (dva *DummyValidationAuthority) IsSafeDomain(req *core.IsSafeDomainRequest) (*core.IsSafeDomainResponse, error) {
 	if dva.IsSafeDomainErr != nil {
 		return nil, dva.IsSafeDomainErr

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -653,7 +653,7 @@ func TestCAATimeout(t *testing.T) {
 	va := NewValidationAuthorityImpl(&PortConfig{}, nil, stats, clock.Default())
 	va.DNSResolver = &bdns.MockDNSResolver{}
 	va.IssuerDomain = "letsencrypt.org"
-	err := va.checkCAA(context.Background(), core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "caa-timeout.com"}, 101)
+	err := va.checkCAA(context.Background(), core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "caa-timeout.com"})
 	if err.Type != probs.ConnectionProblem {
 		t.Errorf("Expected timeout error type %s, got %s", probs.ConnectionProblem, err.Type)
 	}

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -562,7 +562,7 @@ func TestIssueCertificate(t *testing.T) {
 	// TODO: Use a mock RA so we can test various conditions of authorized, not
 	// authorized, etc.
 	stats, _ := statsd.NewNoopClient(nil)
-	ra := ra.NewRegistrationAuthorityImpl(fc, wfe.log, stats, nil, cmd.RateLimitConfig{}, 0, testKeyPolicy)
+	ra := ra.NewRegistrationAuthorityImpl(fc, wfe.log, stats, nil, cmd.RateLimitConfig{}, 0, testKeyPolicy, false)
 	ra.SA = mocks.NewStorageAuthority(fc)
 	ra.CA = &mocks.MockCA{
 		PEM: mockCertPEM,


### PR DESCRIPTION
The new RPC call returns only the updated Challenge object instead of the whole authz, because the VA shouldn't be allowed to update any of the other fields of the Authorization object.


Part of #1167 
