### PR TITLE
Add Godep version to Godeps/Godeps.json

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/letsencrypt/boulder",
 	"GoVersion": "go1.5",
+	"GodepVersion": "v58",
 	"Packages": [
 		"./..."
 	],


### PR DESCRIPTION
The most recent version of `godep` added it's version number to the `Godep/Godeps.json` file which caused our godep-restore tests to fail.

This just adds that number so tests won't fail but since `godep` has been churning quite a lot recently we should probably come up with a better way to test we are actually vendoring what we want.