### PR TITLE
Cat mariadb logs after failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       - rsyslog
   mariadb: "10.0"
 
-sudo: false
+sudo: true
 
 services:
   - rabbitmq
@@ -60,3 +60,6 @@ env:
 script:
   - bash test.sh
 
+after_failure:
+  - sudo cat /var/log/mysql/error.log
+  - ps aux | grep mysql


### PR DESCRIPTION
We get intermittent failures on Travis where mariadb times out writes. Travis
support recommended we start catting the logs after a failure to see if there's
anything useful.