### PR TITLE
Remove std_json build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ BUILD_HOST_VAR = github.com/letsencrypt/boulder/core.BuildHost
 BUILD_TIME = $(shell date -u)
 BUILD_TIME_VAR = github.com/letsencrypt/boulder/core.BuildTime
 
-GO_BUILD_FLAGS = -ldflags "-X \"$(BUILD_ID_VAR)=$(BUILD_ID)\" -X \"$(BUILD_TIME_VAR)=$(BUILD_TIME)\" -X \"$(BUILD_HOST_VAR)=$(BUILD_HOST)\"" -tags std_json
+GO_BUILD_FLAGS = -ldflags "-X \"$(BUILD_ID_VAR)=$(BUILD_ID)\" -X \"$(BUILD_TIME_VAR)=$(BUILD_TIME)\" -X \"$(BUILD_HOST_VAR)=$(BUILD_HOST)\""
 
 .PHONY: all build
 all: build

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -38,7 +38,7 @@ def install(race_detection):
     # BUILD_ID.
     cmd = "make GO_BUILD_FLAGS=''  "
     if race_detection:
-        cmd = "make GO_BUILD_FLAGS='-race -tags \"std_json integration\"'"
+        cmd = "make GO_BUILD_FLAGS='-race -tags \"integration\"'"
 
     return subprocess.call(cmd, shell=True) == 0
 


### PR DESCRIPTION
After a review of the logs (#1587), it seems that no clients are using
capitalized or duplicate keys in the JWS bodies. Remove the std_json
build tag.