### PR TITLE
Pull out WFE's MockCA into a shared mock.

### DIFF
--- a/mocks/ca.go
+++ b/mocks/ca.go
@@ -1,0 +1,40 @@
+package mocks
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/letsencrypt/boulder/core"
+)
+
+// MockCA is a mock of a CA that always returns the cert from PEM in response to
+// IssueCertificate.
+type MockCA struct {
+	PEM []byte
+}
+
+// IssueCertificate is a mock
+func (ca *MockCA) IssueCertificate(csr x509.CertificateRequest, regID int64) (core.Certificate, error) {
+	if ca.PEM == nil {
+		return core.Certificate{}, fmt.Errorf("MockCA's PEM field must be set before calling IssueCertificate")
+	}
+	block, _ := pem.Decode(ca.PEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return core.Certificate{}, err
+	}
+	return core.Certificate{
+		DER: cert.Raw,
+	}, nil
+}
+
+// GenerateOCSP is a mock
+func (ca *MockCA) GenerateOCSP(xferObj core.OCSPSigningRequest) (ocsp []byte, err error) {
+	return
+}
+
+// RevokeCertificate is a mock
+func (ca *MockCA) RevokeCertificate(serial string, reasonCode core.RevocationCode) (err error) {
+	return
+}

--- a/mocks/log.go
+++ b/mocks/log.go
@@ -6,7 +6,6 @@
 package mocks
 
 import (
-	"log"
 	"log/syslog"
 	"regexp"
 
@@ -77,7 +76,6 @@ func NewSyslogWriter() *SyslogWriter {
 		for {
 			select {
 			case logMsg := <-msgChan:
-				log.Print("MockSyslog:" + logMsg.String())
 				msw.logged = append(msw.logged, logMsg)
 			case getChan <- msw.logged:
 			case <-clearChan:

--- a/test.sh
+++ b/test.sh
@@ -297,7 +297,7 @@ if [[ "$RUN" =~ "godep-restore" ]] ; then
   # do this for all builds.
   if [[ "${TRAVIS_REPO_SLUG}" == "letsencrypt/boulder" ]] ; then
     run_and_comment godep save -r ./...
-    run_and_comment git diff --exit-code
+    run_and_comment git diff --exit-code Godeps/_workspace/
   fi
   end_context #godep-restore
 fi

--- a/test/db.go
+++ b/test/db.go
@@ -45,7 +45,6 @@ func resetTestDatabase(t *testing.T, dbType string) func() {
 	if err != nil {
 		t.Fatalf("Couldn't create db: %s", err)
 	}
-	fmt.Printf("db %#v\n", db)
 	if err := deleteEverythingInAllTables(db); err != nil {
 		t.Fatalf("Failed to delete everything: %s", err)
 	}


### PR DESCRIPTION
Also:

- Use MockCA in the RA test instead of a real CA.
- Since the mock CA doesn't write to an SA, remove a part of the RA test that
checked that the certificate was written. That code is already tested in the CA,
where the test belongs.
- Format the constants in RA test to be more copy-and-pasteable.
- Remove Printf in mocks/log.go and test/db.go to make failed test output more readable.