### PR TITLE
Add overrides for FQDNSet in test

### DIFF
--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -28,3 +28,9 @@ pendingAuthorizationsPerAccount:
 certificatesPerFQDNSet:
   window: 24h
   threshold: 5
+  overrides:
+    le.wtf: 10000
+    le1.wtf: 10000
+    le2.wtf: 10000
+    le3.wtf: 10000
+    le.wtf,le1.wtf: 10000


### PR DESCRIPTION
Running the integration test multiple times in a row will result in ratelimit errors. Add exemptions for the names in the ratelimit policy.