### PR TITLE
Test improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ env:
     - LETSENCRYPT_PATH=$HOME/letsencrypt
   matrix:
     - RUN="integration vet lint fmt migrations"
+    # Config changes that have landed in master but not yet been applied to
+    # production can be made in boulder-config-next.json.
+    - RUN="integration" BOULDER_CONFIG="test/boulder-config-next.json"
     - RUN="unit"
     - RUN="godep-restore"
 

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -362,12 +362,8 @@ func TestIssueCertificate(t *testing.T) {
 			t.Errorf("Improper list of domain names %v", cert.DNSNames)
 		}
 
-		// Test is broken by CFSSL Issue #156
-		// https://github.com/cloudflare/cfssl/issues/156
 		if len(cert.Subject.Country) > 0 {
-			// Uncomment the Errorf as soon as upstream #156 is fixed
-			// t.Errorf("Subject contained unauthorized values: %v", cert.Subject)
-			t.Logf("Subject contained unauthorized values: %v", cert.Subject)
+			t.Errorf("Subject contained unauthorized values: %v", cert.Subject)
 		}
 
 		// Verify that the cert got stored in the DB

--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -1,0 +1,359 @@
+{
+  "syslog": {
+    "network": "",
+    "server": "",
+    "stdoutlevel": 7
+  },
+
+  "statsd": {
+      "server": "localhost:8125",
+      "prefix": "Boulder"
+  },
+
+  "wfe": {
+    "listenAddress": "127.0.0.1:4000",
+    "allowOrigins": ["*"],
+    "certCacheDuration": "6h",
+    "certNoCacheExpirationWindow": "96h",
+    "indexCacheDuration": "24h",
+    "issuerCacheDuration": "48h",
+    "shutdownStopTimeout": "10s",
+    "shutdownKillTimeout": "1m",
+    "debugAddr": "localhost:8000",
+    "amqp": {
+      "server": "amqp://guest:guest@localhost:5673",
+      "insecure": true,
+      "RA": {
+        "server": "RA.server",
+        "rpcTimeout": "15s"
+      },
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "ca": {
+    "serialPrefix": 255,
+    "rsaProfile": "rsaEE",
+    "ecdsaProfile": "ecdsaEE",
+    "debugAddr": "localhost:8001",
+    "Key": {
+      "File": "test/test-ca.key"
+    },
+    "expiry": "2160h",
+    "lifespanOCSP": "96h",
+    "maxNames": 1000,
+    "doNotForceCN": true,
+    "enableMustStaple": true,
+    "hostnamePolicyFile": "test/hostname-policy.json",
+    "cfssl": {
+      "signing": {
+        "profiles": {
+          "rsaEE": {
+            "usages": [
+              "digital signature",
+              "key encipherment",
+              "server auth",
+              "client auth"
+            ],
+            "backdate": "1h",
+            "is_ca": false,
+            "issuer_urls": [
+              "http://127.0.0.1:4000/acme/issuer-cert"
+            ],
+            "ocsp_url": "http://127.0.0.1:4002/",
+            "crl_url": "http://example.com/crl",
+            "policies": [
+              {
+                "ID": "2.23.140.1.2.1"
+              },
+              {
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                }, {
+                  "type": "id-qt-unotice",
+                  "value": "Do What Thou Wilt"
+                } ]
+              }
+            ],
+            "expiry": "2160h",
+            "CSRWhitelist": {
+              "PublicKeyAlgorithm": true,
+              "PublicKey": true,
+              "SignatureAlgorithm": true
+            },
+            "ClientProvidesSerialNumbers": true,
+            "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ]
+          },
+          "ecdsaEE": {
+            "usages": [
+              "digital signature",
+              "server auth",
+              "client auth"
+            ],
+            "backdate": "1h",
+            "is_ca": false,
+            "issuer_urls": [
+              "http://127.0.0.1:4000/acme/issuer-cert"
+            ],
+            "ocsp_url": "http://127.0.0.1:4002/",
+            "crl_url": "http://example.com/crl",
+            "policies": [
+              {
+                "ID": "2.23.140.1.2.1"
+              },
+              {
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                }, {
+                  "type": "id-qt-unotice",
+                  "value": "Do What Thou Wilt"
+                } ]
+              }
+            ],
+            "expiry": "2160h",
+            "CSRWhitelist": {
+              "PublicKeyAlgorithm": true,
+              "PublicKey": true,
+              "SignatureAlgorithm": true
+            },
+            "ClientProvidesSerialNumbers": true
+          }
+        },
+        "default": {
+          "usages": [
+            "digital signature"
+          ],
+          "expiry": "8760h"
+        }
+      }
+    },
+    "maxConcurrentRPCServerRequests": 16,
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "serviceQueue": "CA.server",
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      },
+      "Publisher": {
+        "server": "Publisher.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "pa": {
+    "challenges": {
+      "http-01": true,
+      "tls-sni-01": true,
+      "dns-01": true
+    }
+  },
+
+  "ra": {
+    "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
+    "maxConcurrentRPCServerRequests": 16,
+    "maxContactsPerRegistration": 100,
+    "dnsTries": 3,
+    "debugAddr": "localhost:8002",
+    "hostnamePolicyFile": "test/hostname-policy.json",
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "serviceQueue": "RA.server",
+      "VA": {
+        "server": "VA.server",
+        "rpcTimeout": "60s"
+      },
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      },
+      "CA": {
+        "server": "CA.server",
+        "rpcTimeout": "15s"
+
+      }
+    }
+  },
+
+  "sa": {
+    "dbConnectFile": "test/secrets/sa_dburl",
+    "maxConcurrentRPCServerRequests": 16,
+    "debugAddr": "localhost:8003",
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "serviceQueue": "SA.server"
+    }
+  },
+
+  "va": {
+    "userAgent": "boulder",
+    "issuerDomain": "happy-hacker-ca.invalid",
+    "debugAddr": "localhost:8004",
+    "portConfig": {
+      "httpPort": 5002,
+      "httpsPort": 5001,
+      "tlsPort": 5001
+    },
+    "maxConcurrentRPCServerRequests": 16,
+    "dnsTries": 3,
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "serviceQueue": "VA.server",
+      "RA": {
+        "server": "RA.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "sql": {
+    "SQLDebug": true
+  },
+
+  "revoker": {
+    "dbConnectFile": "test/secrets/revoker_dburl",
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "RA": {
+        "server": "RA.server",
+        "rpcTimeout": "15s"
+      },
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "ocspResponder": {
+    "source": "mysql+tcp://ocsp_resp@localhost:3306/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms",
+    "path": "/",
+    "listenAddress": "localhost:4002",
+    "maxAge": "10s",
+    "shutdownStopTimeout": "10s",
+    "shutdownKillTimeout": "1m",
+    "debugAddr": "localhost:8005"
+  },
+
+  "ocspUpdater": {
+    "dbConnectFile": "test/secrets/ocsp_updater_dburl",
+    "newCertificateWindow": "1s",
+    "oldOCSPWindow": "2s",
+    "missingSCTWindow": "1m",
+    "revokedCertificateWindow": "1s",
+    "newCertificateBatchSize": 1000,
+    "oldOCSPBatchSize": 5000,
+    "missingSCTBatchSize": 5000,
+    "revokedCertificateBatchSize": 1000,
+    "ocspMinTimeToExpiry": "72h",
+    "oldestIssuedSCT": "72h",
+    "signFailureBackoffFactor": 1.2,
+    "signFailureBackoffMax": "30m",
+    "debugAddr": "localhost:8006",
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      },
+      "CA": {
+        "server": "CA.server",
+        "rpcTimeout": "15s"
+      },
+      "Publisher": {
+        "server": "Publisher.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "activityMonitor": {
+    "debugAddr": "localhost:8007",
+    "amqp": {
+      "serviceQueue": "Monitor",
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true
+    }
+  },
+
+  "mailer": {
+    "server": "mail.example.com",
+    "port": "25",
+    "username": "cert-master@example.com",
+    "from": "Expiry bot <test@example.com>",
+    "passwordFile": "test/secrets/smtp_password",
+    "dbConnectFile": "test/secrets/mailer_dburl",
+    "messageLimit": 0,
+    "nagTimes": ["24h", "72h", "168h", "336h"],
+    "nagCheckInterval": "24h",
+    "emailTemplate": "test/example-expiration-template",
+    "debugAddr": "localhost:8008",
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "publisher": {
+    "maxConcurrentRPCServerRequests": 16,
+    "submissionTimeout": "5s",
+    "debugAddr": "localhost:8009",
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "serviceQueue": "Publisher.server",
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "common": {
+    "baseURL": "http://127.0.0.1:4000",
+    "issuerCert": "test/test-ca.pem",
+    "dnsResolver": "127.0.0.1:8053",
+    "dnsTimeout": "10s",
+    "dnsAllowLoopbackAddresses": true,
+    "ct": {
+      "logs": [
+        {
+          "uri": "http://127.0.0.1:4500",
+          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q=="
+        }
+      ],
+      "intermediateBundleFilename": "test/test-ca.pem"
+    }
+  },
+
+  "certChecker": {
+    "dbConnectFile": "test/secrets/cert_checker_dburl"
+  },
+
+  "subscriberAgreementURL": "http://127.0.0.1:4001/terms/v1",
+
+  "allowedSigningAlgos": {
+    "rsa": true,
+    "ecdsanistp256": true,
+    "ecdsanistp384": true,
+    "ecdsanistp521": false
+  }
+}

--- a/test/make-softhsm.sh
+++ b/test/make-softhsm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Run this script to generate a SoftHSM config and import test-ca.key to use
+# with Boulder. Note that we don't check in the generated config or database
+# because they require absolute paths.
+#
+cd $(dirname $0)
+export SOFTHSM_CONF=$PWD/sothsm.conf
+echo 0:${PWD}/softhsm.db > ${SOFTHSM_CONF}
+softhsm --init-token --slot 0 --label "softhsm token" --pin 1234 --so-pin 1234
+softhsm --slot 0 --import test-ca.key  --label "happy hacker key" --pin 1234 --id FF
+echo "Set SOFTHSM_CONF=${SOFTHSM_CONF} to use, and put in your Boulder config:"
+cat << EOF
+"Key": {
+  "PKCS11": {
+    "Module": "/usr/lib/softhsm/libsofthsm.so",
+    "tokenLabel": "softhsm token",
+    "privateKeyLabel": "happy hacker key",
+    "pin": "1234"
+  }
+},
+EOF

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -34,3 +34,5 @@ certificatesPerFQDNSet:
     le2.wtf: 10000
     le3.wtf: 10000
     le.wtf,le1.wtf: 10000
+    good-caa-reserved.com: 10000
+    nginx.wtf: 10000


### PR DESCRIPTION
- Add a boulder-config-next so that we can update the config when we have new options, but ensure we still test the old config style, up until prod is updated to match the new options.
- Remove an old TODO in the CA test.
- Add a script to make a SoftHSM token (supersedes #1633).