### PR TITLE
Add colorful stdout logging.

### DIFF
--- a/log/audit-logger_test.go
+++ b/log/audit-logger_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
+	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -80,6 +81,16 @@ func TestEmitEmpty(t *testing.T) {
 	log := setup(t)
 
 	log.AuditNotice("")
+}
+
+func ExampleErrors() {
+	audit := setup(nil)
+
+	audit.clk = clock.NewFake()
+	audit.AuditErr(errors.New("Error Audit"))
+	audit.WarningErr(errors.New("Warning Audit"))
+	// Output: [31m00:00:00 log.test ERR [AUDIT] Error Audit[0m
+	// [33m00:00:00 log.test WARNING Warning Audit[0m
 }
 
 func TestEmitErrors(t *testing.T) {


### PR DESCRIPTION
This won't affect prod, where we use syslog. But for dev and test, where we log
to stdout, the colors may help us find errors and warnings in the logs.

This also adds the log level as an explicit part of the stdout logging.