### PR TITLE
Make the AuditLogger example show up in the docs

### DIFF
--- a/log/audit-logger_test.go
+++ b/log/audit-logger_test.go
@@ -83,7 +83,7 @@ func TestEmitEmpty(t *testing.T) {
 	log.AuditNotice("")
 }
 
-func ExampleErrors() {
+func ExampleAuditLogger() {
 	audit := setup(nil)
 
 	audit.clk = clock.NewFake()


### PR DESCRIPTION
`godoc` associates the docs with the function or type listed after
the word "Example"; in this case "Errors" doesn't match anything in
github.com/letsencrypt/boulder/log, so the example doesn't appear in the
generated godoc.

Changes the function name to ExampleAuditLogger so it shows up under the
AuditLogger type.

Here's a screenshot:
https://monosnap.com/file/iXHqZHlnAjXnXPkAWUR5J1jMggOHLQ.png