### PR TITLE
Replace CertificateIssuanceError

### DIFF
--- a/ca/certificate-authority.go
+++ b/ca/certificate-authority.go
@@ -314,12 +314,12 @@ func (ca *CertificateAuthorityImpl) extensionsFromCSR(csr *x509.CertificateReque
 					ca.stats.Inc(metricCSRExtensionTLSFeature, 1, 1.0)
 					value, ok := ext.Value.([]byte)
 					if !ok {
-						msg := fmt.Sprintf("Mal-formed extension with OID %v", ext.Type)
-						return nil, core.CertificateIssuanceError(msg)
+						msg := fmt.Sprintf("Malformed extension with OID %v", ext.Type)
+						return nil, core.MalformedRequestError(msg)
 					} else if !bytes.Equal(value, mustStapleFeatureValue) {
 						msg := fmt.Sprintf("Unsupported value for extension with OID %v", ext.Type)
 						ca.stats.Inc(metricCSRExtensionTLSFeatureInvalid, 1, 1.0)
-						return nil, core.CertificateIssuanceError(msg)
+						return nil, core.MalformedRequestError(msg)
 					}
 
 					if ca.enableMustStaple {

--- a/ca/certificate-authority_test.go
+++ b/ca/certificate-authority_test.go
@@ -869,6 +869,9 @@ func TestExtensions(t *testing.T) {
 	// ... but if it doesn't ask for stapling, there should be an error
 	_, err = ca.IssueCertificate(*tlsFeatureUnknownCSR, ctx.reg.ID)
 	test.AssertError(t, err, "Allowed a CSR with an empty TLS feature extension")
+	if _, ok := err.(core.MalformedRequestError); !ok {
+		t.Errorf("Wrong error type when rejecting a CSR with empty TLS feature extension")
+	}
 	test.AssertEquals(t, ctx.stats.Counters[metricCSRExtensionTLSFeature], int64(4))
 	test.AssertEquals(t, ctx.stats.Counters[metricCSRExtensionTLSFeatureInvalid], int64(1))
 

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -98,7 +98,6 @@ func TestErrors(t *testing.T) {
 		UnauthorizedError(testMessage),
 		NotFoundError(testMessage),
 		SignatureValidationError(testMessage),
-		CertificateIssuanceError(testMessage),
 	}
 
 	for i, err := range errors {

--- a/core/util.go
+++ b/core/util.go
@@ -80,10 +80,6 @@ type LengthRequiredError string
 // the user client.
 type SignatureValidationError string
 
-// CertificateIssuanceError indicates the certificate failed to be issued
-// for some reason.
-type CertificateIssuanceError string
-
 // NoSuchRegistrationError indicates that a registration could not be found.
 type NoSuchRegistrationError string
 
@@ -104,7 +100,6 @@ func (e UnauthorizedError) Error() string        { return string(e) }
 func (e NotFoundError) Error() string            { return string(e) }
 func (e LengthRequiredError) Error() string      { return string(e) }
 func (e SignatureValidationError) Error() string { return string(e) }
-func (e CertificateIssuanceError) Error() string { return string(e) }
 func (e NoSuchRegistrationError) Error() string  { return string(e) }
 func (e RateLimitedError) Error() string         { return string(e) }
 func (e TooManyRPCRequestsError) Error() string  { return string(e) }

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -212,8 +212,6 @@ func wrapError(err error) *rpcError {
 			wrapped.Type = "NotFoundError"
 		case core.SignatureValidationError:
 			wrapped.Type = "SignatureValidationError"
-		case core.CertificateIssuanceError:
-			wrapped.Type = "CertificateIssuanceError"
 		case core.NoSuchRegistrationError:
 			wrapped.Type = "NoSuchRegistrationError"
 		case core.TooManyRPCRequestsError:
@@ -246,8 +244,6 @@ func unwrapError(rpcError *rpcError) error {
 			return core.NotFoundError(rpcError.Value)
 		case "SignatureValidationError":
 			return core.SignatureValidationError(rpcError.Value)
-		case "CertificateIssuanceError":
-			return core.CertificateIssuanceError(rpcError.Value)
 		case "NoSuchRegistrationError":
 			return core.NoSuchRegistrationError(rpcError.Value)
 		case "TooManyRPCRequestsError":

--- a/rpc/amqp-rpc_test.go
+++ b/rpc/amqp-rpc_test.go
@@ -23,7 +23,6 @@ func TestWrapError(t *testing.T) {
 		core.UnauthorizedError("foo"),
 		core.NotFoundError("foo"),
 		core.SignatureValidationError("foo"),
-		core.CertificateIssuanceError("foo"),
 		core.NoSuchRegistrationError("foo"),
 		core.RateLimitedError("foo"),
 		core.TooManyRPCRequestsError("foo"),


### PR DESCRIPTION
with MalformedRequestError. The distinction was not useful and was out of line
with similar errors in the CA.

Fixes #1650.