### PR TITLE
Ignore Carriage Return in http-01 validation

### DIFF
--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -33,7 +33,7 @@ import (
 )
 
 const maxRedirect = 10
-const whitespaceCutset = "\n\t "
+const whitespaceCutset = "\n\r\t "
 
 var validationTimeout = time.Second * 5
 

--- a/va/validation-authority_test.go
+++ b/va/validation-authority_test.go
@@ -140,9 +140,9 @@ func httpSrv(t *testing.T, token string) *httptest.Server {
 			t.Logf("HTTPSRV: Path = %s\n", r.URL.Path)
 
 			keyAuthz, _ := core.NewKeyAuthorization(currentToken, accountKey)
-			t.Logf("HTTPSRV: Key Authz = '%s%s'\n", keyAuthz.String(), "\\n \\t")
+			t.Logf("HTTPSRV: Key Authz = '%s%s'\n", keyAuthz.String(), "\\n\\r \\t")
 
-			fmt.Fprint(w, keyAuthz.String(), "\n \t")
+			fmt.Fprint(w, keyAuthz.String(), "\n\r \t")
 			currentToken = defaultToken
 		}
 	})


### PR DESCRIPTION
Windows uses `\r\n` as a new line character. This change should fix issues some Windows users are seeing when they include a new line at the end of their challenge tokens.

The [client implementation](https://github.com/letsencrypt/letsencrypt/blob/2bc0c31f2ef23bdb13d4ef0e4484670e74897b15/acme/acme/challenges.py#L231) treats `\r` as a whitespace character as well.