### PR TITLE
Fix nameset-backfill logging

### DIFF
--- a/cmd/nameset-backfill/main.go
+++ b/cmd/nameset-backfill/main.go
@@ -51,7 +51,6 @@ func new(amqpConf *cmd.AMQPConfig, syslogConf cmd.SyslogConfig, statsdURI, dbURI
 
 func (b *backfiller) run() error {
 	added := 0
-	defer b.log.Info(fmt.Sprintf("Added %d missing certificate name sets to the fqdnSets table", added))
 	for {
 		results, err := b.findCerts()
 		if err != nil {
@@ -66,6 +65,7 @@ func (b *backfiller) run() error {
 		}
 		added += len(results)
 	}
+	b.log.Info(fmt.Sprintf("Added %d missing certificate name sets to the fqdnSets table", added))
 	return nil
 }
 

--- a/cmd/nameset-backfill/main_test.go
+++ b/cmd/nameset-backfill/main_test.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
 )
+
+var log = mocks.UseMockLog()
 
 func TestBackfill(t *testing.T) {
 	stats, _ := statsd.NewNoopClient()
@@ -46,8 +49,9 @@ func TestBackfill(t *testing.T) {
 	test.AssertEquals(t, len(results), 1)
 	test.AssertEquals(t, results[0].Serial, "serial")
 
-	err = b.processResults(results)
-	test.AssertNotError(t, err, "Failed to add missing name sets")
+	err = b.run()
+	test.AssertNotError(t, err, "Failed to find and add missing name sets")
+	test.AssertEquals(t, len(log.GetAllMatching("Added 1 missing certificate name sets to the fqdnSets table")), 1)
 
 	results, err = b.findCerts()
 	test.AssertNotError(t, err, "Failed to find missing name sets")


### PR DESCRIPTION
Don't defer log statement indicating number of rows added, just do it at the end of `run`.