### PR TITLE
Use a mock for OCSP responder test.

### DIFF
--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -8,17 +8,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cactus/go-statsd-client/statsd"
 	cfocsp "github.com/letsencrypt/boulder/Godeps/_workspace/src/github.com/cloudflare/cfssl/ocsp"
 	"github.com/letsencrypt/boulder/Godeps/_workspace/src/golang.org/x/crypto/ocsp"
-	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/mocks"
-	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
-	"github.com/letsencrypt/boulder/test/vars"
 )
 
 var (
@@ -60,31 +56,9 @@ func TestMux(t *testing.T) {
 }
 
 func TestDBHandler(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAOcspResp)
-	test.AssertNotError(t, err, "Could not connect to database")
-	src, err := makeDBSource(dbMap, "./testdata/test-ca.der.pem", blog.GetAuditLogger())
+	src, err := makeDBSource(mockSelector{}, "./testdata/test-ca.der.pem", blog.GetAuditLogger())
 	if err != nil {
 		t.Fatalf("makeDBSource: %s", err)
-	}
-	defer test.ResetSATestDatabase(t)
-
-	ocspResp, err := ocsp.ParseResponse(resp, nil)
-	if err != nil {
-		t.Fatalf("ocsp.ParseResponse: %s", err)
-	}
-
-	status := &core.CertificateStatus{
-		Serial:          core.SerialToString(ocspResp.SerialNumber),
-		OCSPLastUpdated: time.Now(),
-		OCSPResponse:    resp,
-	}
-	setupDBMap, err := sa.NewDbMap("mysql+tcp://test_setup@localhost:3306/boulder_sa_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = setupDBMap.Insert(status)
-	if err != nil {
-		t.Fatalf("unable to insert response: %s", err)
 	}
 
 	h := cfocsp.NewResponder(src)
@@ -100,6 +74,18 @@ func TestDBHandler(t *testing.T) {
 	if !bytes.Equal(w.Body.Bytes(), resp) {
 		t.Errorf("Mismatched body: want %#v, got %#v", resp, w.Body.Bytes())
 	}
+}
+
+// mockSelector always returns the same certificateStatus
+type mockSelector struct{}
+
+func (bs mockSelector) SelectOne(output interface{}, _ string, _ ...interface{}) error {
+	outputPtr, ok := output.(*[]uint8)
+	if !ok {
+		return fmt.Errorf("incorrect output type %T", output)
+	}
+	*outputPtr = resp
+	return nil
 }
 
 // brokenSelector allows us to test what happens when gorp SelectOne statements


### PR DESCRIPTION
This reduces the use of a "real" SA in our tests, which will eventually allow us
to run them in parallel.

Part of #1499.