### PR TITLE
switch rabbitmq-setup to connect at boulder-rabbitmq

### DIFF
--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -8,13 +8,13 @@ service rsyslog start &&
 # make sure we can reach the mysqldb
 # see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
 while ! exec 6<>/dev/tcp/boulder-mysql/3306; do
-    echo "$(date) - still trying to connect to mysql at 0.0.0.0:3306"
+    echo "$(date) - still trying to connect to mysql at boulder-mysql:3306"
     sleep 1 || exit
 done
 
 # make sure we can reach the rabbitmq
 while ! exec 6<>/dev/tcp/boulder-rabbitmq/5672; do
-    echo "$(date) - still trying to connect to rabbitmq at 0.0.0.0:5672"
+    echo "$(date) - still trying to connect to rabbitmq at boulder-rabbitmq:5672"
     sleep 1 || exit
 done
 
@@ -25,6 +25,6 @@ exec 6<&-
 $DIR/create_db.sh
 
 # Set up rabbitmq exchange
-go run cmd/rabbitmq-setup/main.go -server amqp://localhost
+go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq
 
 $@

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -21,7 +21,7 @@ go get \
  ./test/create_db.sh) &
 
 # Set up rabbitmq exchange
-go run cmd/rabbitmq-setup/main.go -server amqp://localhost &
+go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq &
 
 # Wait for all the background commands to finish.
 wait


### PR DESCRIPTION
This followup for #1639 replaces localhost with boulder-rabbitmq when tests runs rabbitmq-setup. I also fixed log message to point to the server name, not 0.0.0.0, when notifying about trying to connect.

With this fix test/run-docker.sh under coreos starts boulder successfully.