### PR TITLE
Change panics in audit logger to log.Fatalf.

### DIFF
--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -91,15 +91,15 @@ func NewAuditLogger(log SyslogWriter, stats statsd.Statter, stdoutLogLevel int) 
 func initializeAuditLogger() {
 	stats, err := statsd.NewNoopClient(nil)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Initializing stats for AuditLogger: %s", err)
 	}
 	syslogger, err := syslog.Dial("", "", defaultPriority, "test")
 	if err != nil {
-		panic(err)
+		log.Fatalf("Initializing SyslogWriter for AuditLogger: %s", err)
 	}
 	audit, err := NewAuditLogger(syslogger, stats, int(syslog.LOG_DEBUG))
 	if err != nil {
-		panic(err)
+		log.Fatalf("Initializing AuditLogger: %s", err)
 	}
 
 	SetAuditLogger(audit)

--- a/log/audit-logger.go
+++ b/log/audit-logger.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"log/syslog"
 	"os"
 	"path"


### PR DESCRIPTION
These errors can happen if the syslog apparatus is unavailable, so are not that
out of the ordinary. log.Fatalf produces less noise and makes it easier to see
what's wrong.