### PR TITLE
Revert "Cat mariadb logs after failure"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
       - rsyslog
   mariadb: "10.0"
 
-sudo: true
+sudo: false
 
 services:
   - rabbitmq
@@ -65,6 +65,3 @@ env:
 script:
   - bash test.sh
 
-after_failure:
-  - sudo cat /var/log/mysql/error.log
-  - ps aux | grep mysql


### PR DESCRIPTION
This reverts commit b5cc545b48dd2ad062954e0d1fd9a225ecd54f13.

Our Travis builds have been slow, probably in part because of this change, and we haven't caught any useful MySQL logs with it.