### PR TITLE
expect client to use http://boulder/ for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ or
 
 Edit /etc/hosts to add this line:
 
-    127.0.0.1 boulder-rabbitmq boulder-mysql
+    127.0.0.1 boulder boulder-rabbitmq boulder-mysql
 
 Resolve Go-dependencies, set up a database and RabbitMQ:
 

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -336,7 +336,7 @@
     "dbConnectFile": "test/secrets/cert_checker_dburl"
   },
 
-  "subscriberAgreementURL": "http://127.0.0.1:4001/terms/v1",
+  "subscriberAgreementURL": "http://boulder:4001/terms/v1",
 
   "allowedSigningAlgos": {
     "rsa": true,


### PR DESCRIPTION
This followup for #1639 to use the boulder name, not 127.0.0.1, in subscriberAgreementURL in the test boulder instance.