### PR TITLE
reloader: Split data/error callbacks

### DIFF
--- a/policy/policy-authority.go
+++ b/policy/policy-authority.go
@@ -71,20 +71,20 @@ type blacklistJSON struct {
 // SetHostnamePolicyFile will load the given policy file, returning error if it
 // fails. It will also start a reloader in case the file changes.
 func (pa *AuthorityImpl) SetHostnamePolicyFile(f string) error {
-	_, err := reloader.New(f, pa.loadHostnamePolicy)
+	_, err := reloader.New(f, pa.loadHostnamePolicy, pa.hostnamePolicyLoadError)
 	return err
 }
 
-func (pa *AuthorityImpl) loadHostnamePolicy(b []byte, err error) error {
-	if err != nil {
-		pa.log.Err(fmt.Sprintf("loading hostname policy: %s", err))
-		return err
-	}
+func (pa *AuthorityImpl) hostnamePolicyLoadError(err error) {
+	pa.log.Err(fmt.Sprintf("error loading hostname policy: %s", err))
+}
+
+func (pa *AuthorityImpl) loadHostnamePolicy(b []byte) error {
 	hash := sha256.Sum256(b)
 	pa.log.Info(fmt.Sprintf("loading hostname policy, sha256: %s",
 		hex.EncodeToString(hash[:])))
 	var bl blacklistJSON
-	err = json.Unmarshal(b, &bl)
+	err := json.Unmarshal(b, &bl)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The reloader package currently discriminates between file reading errors (in the reloader package) and data parsing errors (in the client code). Because of this, errors in a hot-replaced policy file may go unnoticed.

The former design, a (data, error) callback is replaced with a data callback and an error callback. This allows for uniform reporting of errors sourced from the library and errors sourced from the user-provided parser.

Fixes #1685

