### PR TITLE
always use boulder-mysql, not localhost, for mysql

### DIFF
--- a/policy/_db/dbconf.yml
+++ b/policy/_db/dbconf.yml
@@ -1,6 +1,6 @@
 test:
   driver: mysql
-  open: root@tcp(localhost:3306)/boulder_policy_test
+  open: root@tcp(boulder-mysql:3306)/boulder_policy_test
 integration:
   driver: mysql
-  open: root@tcp(localhost:3306)/boulder_policy_integration
+  open: root@tcp(boulder-mysql:3306)/boulder_policy_integration

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -21,8 +21,8 @@ func TestInvalidDSN(t *testing.T) {
 var errExpected = errors.New("expected")
 
 func TestNewDbMap(t *testing.T) {
-	const mysqlConnectURL = "mysql+tcp://policy:password@localhost:3306/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms"
-	const expectedTransformed = "policy:password@tcp(localhost:3306)/boulder_policy_integration?clientFoundRows=true&parseTime=true&readTimeout=800ms&strict=true&writeTimeout=800ms"
+	const mysqlConnectURL = "mysql+tcp://policy:password@boulder-mysql:3306/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms"
+	const expectedTransformed = "policy:password@tcp(boulder-mysql:3306)/boulder_policy_integration?clientFoundRows=true&parseTime=true&readTimeout=800ms&strict=true&writeTimeout=800ms"
 
 	oldSQLOpen := sqlOpen
 	defer func() {

--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -236,7 +236,7 @@
   },
 
   "ocspResponder": {
-    "source": "mysql+tcp://ocsp_resp@localhost:3306/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms",
+    "source": "mysql+tcp://ocsp_resp@boulder-mysql:3306/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms",
     "path": "/",
     "listenAddress": "localhost:4002",
     "maxAge": "10s",

--- a/test/db.go
+++ b/test/db.go
@@ -41,7 +41,7 @@ func ResetPolicyTestDatabase(t testing.TB) func() {
 }
 
 func resetTestDatabase(t testing.TB, dbType string) func() {
-	db, err := sql.Open("mysql", fmt.Sprintf("test_setup@tcp(localhost:3306)/boulder_%s_test", dbType))
+	db, err := sql.Open("mysql", fmt.Sprintf("test_setup@tcp(boulder-mysql:3306)/boulder_%s_test", dbType))
 	if err != nil {
 		t.Fatalf("Couldn't create db: %s", err)
 	}

--- a/test/vars/vars.go
+++ b/test/vars/vars.go
@@ -3,7 +3,7 @@ package vars
 import "fmt"
 
 const (
-	dbURL = "mysql+tcp://%s@localhost:3306/%s"
+	dbURL = "mysql+tcp://%s@boulder-mysql:3306/%s"
 )
 
 var (


### PR DESCRIPTION
This followup for #1639 to always use the boulder-mysql, not localhost, when connecting to mysql database when testing.