### PR TITLE
Fix the Travis errors

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -4,9 +4,10 @@
 # and configure database and RabbitMQ.
 #
 
+set -ev
+
 go get \
-  golang.org/x/tools/cmd/vet \
-  golang.org/x/tools/cmd/cover \
+  golang.org/x/tools/cover \
   github.com/golang/lint/golint \
   github.com/tools/godep \
   github.com/mattn/goveralls \


### PR DESCRIPTION
Per https://groups.google.com/forum/#!topic/golang-announce/JMs4_CGbXWk, `golang.org/x/tools/cmd/vet` no longer exists. We don't need it anymore since we upgraded to Go 1.5, so remove it.