### PR TITLE
speeding up docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,28 +13,22 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Install port forwarder, database migration tool and go lint
+RUN go get -v \
+	github.com/jsha/listenbuddy \
+	bitbucket.org/liamstask/goose/cmd/goose \
+	github.com/golang/lint/golint
+
 # Boulder exposes its web application at port TCP 4000
-EXPOSE 4000
-EXPOSE 4002
-EXPOSE 4003
+EXPOSE 4000 4002 4003
 
-# Install port forwarder
-RUN go get github.com/jsha/listenbuddy
-# get database migration tool
-RUN go get bitbucket.org/liamstask/goose/cmd/goose
-# install go lint
-RUN go get -v github.com/golang/lint/golint
-
-# Assume the configuration is in /etc/boulder
-ENV BOULDER_CONFIG /go/src/github.com/letsencrypt/boulder/test/boulder-config.json
 ENV GOPATH /go/src/github.com/letsencrypt/boulder/Godeps/_workspace:$GOPATH
 
 WORKDIR /go/src/github.com/letsencrypt/boulder
+
+ENTRYPOINT [ "./test/entrypoint.sh" ]
 
 # Copy in the Boulder sources
 COPY . /go/src/github.com/letsencrypt/boulder
 
 RUN GOBIN=/go/src/github.com/letsencrypt/boulder/bin go install  ./...
-
-ENTRYPOINT [ "./test/entrypoint.sh" ]
-CMD [ "./start.py" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ boulder:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-    environment:
-        MYSQL_CONTAINER: "yes"
     links:
       - bmysql:boulder-mysql
       - brabbitmq:boulder-rabbitmq

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,30 +1,37 @@
 #!/bin/bash
 
+set -e -u
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # start rsyslog
-service rsyslog start &&
+service rsyslog start
+
+wait_tcp_port() {
+    local host="$1" port="$2"
+
+    # see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
+    while ! exec 6<>/dev/tcp/$host/$port; do
+	echo "$(date) - still trying to connect to $host:$port"
+	sleep 1
+    done
+    exec 6>&-
+}
 
 # make sure we can reach the mysqldb
-# see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
-while ! exec 6<>/dev/tcp/boulder-mysql/3306; do
-    echo "$(date) - still trying to connect to mysql at boulder-mysql:3306"
-    sleep 1 || exit
-done
+wait_tcp_port boulder-mysql 3306
 
 # make sure we can reach the rabbitmq
-while ! exec 6<>/dev/tcp/boulder-rabbitmq/5672; do
-    echo "$(date) - still trying to connect to rabbitmq at boulder-rabbitmq:5672"
-    sleep 1 || exit
-done
-
-exec 6>&-
-exec 6<&-
+wait_tcp_port boulder-rabbitmq 5672
 
 # create the database
-$DIR/create_db.sh
+MYSQL_CONTAINER=1 $DIR/create_db.sh
 
 # Set up rabbitmq exchange
 go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq
 
-$@
+if [[ $# -eq 0 ]]; then
+    exec ./start.py
+fi
+
+exec $@

--- a/test/run-docker.sh
+++ b/test/run-docker.sh
@@ -63,7 +63,6 @@ fi
 # The excluding `-d` command makes the instance interactive, so you can kill
 # the boulder container with Ctrl-C.
 docker run --rm -it \
-	-e MYSQL_CONTAINER=yes \
 	"${fake_dns_args[@]}" \
 	-p 4000:4000 \
 	-p 4002:4002 \
@@ -71,4 +70,4 @@ docker run --rm -it \
 		--name boulder \
 		--link=boulder-mysql:boulder-mysql \
 		--link=boulder-rabbitmq:boulder-rabbitmq \
-	letsencrypt/boulder
+	letsencrypt/boulder "$@"


### PR DESCRIPTION
Make COPY and compilation the last commands in the Dockerfile so in the common case Docker will cache results of EXPOSE, WORKDIR and ENV commands. The CMD is eliminated as entrypoint.sh now defaults to start.py if no arguments are given. The patch eliminates setting MYSQL_CONTAINER in run-docker.sh and docker-compose.yaml as entrypoint.sh sets the variable on its own when calling create_db.sh.

In addition the patch passes arguments passed to run-docker.sh as arguments to the entryscript.sh in the container. This way running `./run-docker.sh ./test.sh ...` allows to execute tests locally.