### PR TITLE
Expose dns-test-srv outside Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN go get -v \
 	github.com/golang/lint/golint
 
 # Boulder exposes its web application at port TCP 4000
-EXPOSE 4000 4002 4003
+EXPOSE 4000 4002 4003 8053 8055
 
 ENV GOPATH /go/src/github.com/letsencrypt/boulder/Godeps/_workspace:$GOPATH
 

--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -152,7 +152,7 @@ func (ts *testSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 func (ts *testSrv) serveTestResolver() {
 	dns.HandleFunc(".", ts.dnsHandler)
 	dnsServer := &dns.Server{
-		Addr:         "127.0.0.1:8053",
+		Addr:         "0.0.0.0:8053",
 		Net:          "tcp",
 		ReadTimeout:  time.Millisecond,
 		WriteTimeout: time.Millisecond,
@@ -165,7 +165,7 @@ func (ts *testSrv) serveTestResolver() {
 		}
 	}()
 	webServer := &http.Server{
-		Addr:    "localhost:8055",
+		Addr:    "0.0.0.0:8055",
 		Handler: http.HandlerFunc(ts.setTXT),
 	}
 	go func() {

--- a/test/run-docker.sh
+++ b/test/run-docker.sh
@@ -67,6 +67,8 @@ docker run --rm -it \
 	-p 4000:4000 \
 	-p 4002:4002 \
 	-p 4003:4003 \
+	-p 8053:8053 \
+	-p 8055:8055 \
 		--name boulder \
 		--link=boulder-mysql:boulder-mysql \
 		--link=boulder-rabbitmq:boulder-rabbitmq \


### PR DESCRIPTION
Use case: `./test/run-docker.sh`, then `POST https://localhost:8055/set-txt` to test development of dns-01 client implementation.