### PR TITLE
allow to redirect syslog to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get install -y \
 	libltdl-dev \
 	mariadb-client-core-10.0 \
 	nodejs \
-	rsyslog \
 	softhsm \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log/syslog"
 	"os"
 	"reflect"
 	"runtime"
@@ -277,9 +276,7 @@ func main() {
 
 		stats, err := metrics.NewStatter(config.Statsd.Server, config.Statsd.Prefix)
 		cmd.FailOnError(err, "Failed to create StatsD client")
-		syslogger, err := syslog.Dial("", "", syslog.LOG_INFO|syslog.LOG_LOCAL0, "")
-		cmd.FailOnError(err, "Failed to dial syslog")
-		logger, err := blog.New(syslogger, 0)
+		logger, err := blog.New("", "", "", 0)
 		cmd.FailOnError(err, "Failed to construct logger")
 		err = blog.Set(logger)
 		cmd.FailOnError(err, "Failed to set audit logger")

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -34,7 +34,6 @@ import (
 	"net/http"
 	_ "net/http/pprof" // HTTP performance profiling, added transparently to HTTP APIs
 	"os"
-	"path"
 	"runtime"
 	"time"
 
@@ -186,18 +185,11 @@ func StatsAndLogging(statConf StatsdConfig, logConf SyslogConfig) (metrics.Statt
 	stats, err := metrics.NewStatter(statConf.Server, statConf.Prefix)
 	FailOnError(err, "Couldn't connect to statsd")
 
-	tag := path.Base(os.Args[0])
-	syslogger, err := syslog.Dial(
-		logConf.Network,
-		logConf.Server,
-		syslog.LOG_INFO|syslog.LOG_LOCAL0, // default, overridden by log calls
-		tag)
-	FailOnError(err, "Could not connect to Syslog")
 	level := int(syslog.LOG_DEBUG)
 	if logConf.StdoutLevel != nil {
 		level = *logConf.StdoutLevel
 	}
-	logger, err := blog.New(syslogger, level)
+	logger, err := blog.New(logConf.Network, logConf.Server, "", level)
 	FailOnError(err, "Could not connect to Syslog")
 
 	_ = blog.Set(logger)

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -4,9 +4,6 @@ set -e -u
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# start rsyslog
-service rsyslog start
-
 wait_tcp_port() {
     local host="$1" port="$2"
 
@@ -26,6 +23,11 @@ wait_tcp_port boulder-rabbitmq 5672
 
 # create the database
 MYSQL_CONTAINER=1 $DIR/create_db.sh
+
+export STDOUT_LOG=plain
+if [[ -t 1 ]]; then
+    STDOUT_LOG=terminal
+fi
 
 # Set up rabbitmq exchange
 go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq


### PR DESCRIPTION
Add support for interpreting `stdout` given as the syslog network to mean log to stdout, as expected with container-based setups. This removed the need to install and run rsyslog daemon inside the boulder docker container.

To stay compatible with the current usage of stdoutLogLevel that intructs to copy log to stdout while annotating it with color terminal escapes the patch interprets stdoutLogLevel as a switch to use colors when the level is above LOG_ERR.