### PR TITLE
under docker make boulder to resolve to 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ boulder:
     links:
       - bmysql:boulder-mysql
       - brabbitmq:boulder-rabbitmq
+    extra_hosts:
+      - boulder:127.0.0.1
 bmysql:
     name: boulder-mysql
     image: mariadb:10.0

--- a/test/run-docker.sh
+++ b/test/run-docker.sh
@@ -72,4 +72,5 @@ docker run --rm -it \
 		--name boulder \
 		--link=boulder-mysql:boulder-mysql \
 		--link=boulder-rabbitmq:boulder-rabbitmq \
+		--add-host=boulder:127.0.0.1 \
 	letsencrypt/boulder "$@"


### PR DESCRIPTION
This way gRPC can contact the boulder using boulder name inside the container. This fixed a regression from #1647.