### PR TITLE
`name` is not a valid docker-compose key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ boulder:
       - bmysql:boulder-mysql
       - brabbitmq:boulder-rabbitmq
 bmysql:
-    name: boulder-mysql
+    container_name: boulder-mysql
     image: mariadb:10.0
     net: bridge
     environment:
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     command: mysqld --bind-address=0.0.0.0
 brabbitmq:
-    name: boulder-rabbitmq
+    container_name: boulder-rabbitmq
     image: rabbitmq:3
     net: bridge
     environment:


### PR DESCRIPTION
The Docker Compose reference does not mention a key for `name`, and I believe the [correct one is `container_name`](https://docs.docker.com/compose/compose-file/#container-name), which is what this small patch changes.

```
± docker-compose build
ERROR: Validation failed in file './docker-compose.yml', reason(s):
Unsupported config option for bmysql: 'name'
Unsupported config option for brabbitmq: 'name'

± docker-compose -version
docker-compose version 1.6.2, build unknown
```