### PR TITLE
Custom command for integration-test.py

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -262,6 +262,8 @@ def main():
                         help="run the letsencrypt's (the python client's) integration tests")
     parser.add_argument('--node', dest="run_node", action="store_true",
                         help="run the node client's integration tests")
+    # allow any ACME client to run custom command for integration
+    # testing (without having to implement its own busy-wait loop)
     parser.add_argument('--custom', metavar="CMD", help="run custom command")
     parser.set_defaults(run_all=False, run_letsencrypt=False, run_node=False)
     args = parser.parse_args()

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -229,14 +229,17 @@ def run_node_test(domain, chall_type, expected_ct_submissions):
     wait_for_ocsp_revoked(cert_file_pem, "../test-ca.pem", ee_ocsp_url)
     return 0
 
+def run_custom(cmd, cwd=None):
+    if subprocess.Popen(cmd, shell=True, cwd=cwd, executable='/bin/bash').wait() != 0:
+        die(ExitStatus.PythonFailure)
+
 def run_client_tests():
     root = os.environ.get("LETSENCRYPT_PATH")
     assert root is not None, (
         "Please set LETSENCRYPT_PATH env variable to point at "
         "initialized (virtualenv) client repo root")
     cmd = os.path.join(root, 'tests', 'boulder-integration.sh')
-    if subprocess.Popen(cmd, shell=True, cwd=root, executable='/bin/bash').wait() != 0:
-        die(ExitStatus.PythonFailure)
+    run_custom(cmd, cwd=root)
 
 @atexit.register
 def cleanup():
@@ -259,11 +262,12 @@ def main():
                         help="run the letsencrypt's (the python client's) integration tests")
     parser.add_argument('--node', dest="run_node", action="store_true",
                         help="run the node client's integration tests")
+    parser.add_argument('--custom', metavar="CMD", help="run custom command")
     parser.set_defaults(run_all=False, run_letsencrypt=False, run_node=False)
     args = parser.parse_args()
 
-    if not (args.run_all or args.run_letsencrypt or args.run_node):
-        print >> sys.stderr, "must run at least one of the letsencrypt or node tests with --all, --letsencrypt, or --node"
+    if not (args.run_all or args.run_letsencrypt or args.run_node or args.custom is not None):
+        print >> sys.stderr, "must run at least one of the letsencrypt or node tests with --all, --letsencrypt, --node, or --custom"
         die(ExitStatus.IncorrectCommandLineArgs)
 
     if not startservers.start(race_detection=True):
@@ -301,6 +305,9 @@ def main():
 
     if args.run_all or args.run_letsencrypt:
         run_client_tests()
+
+    if args.custom:
+        run_custom(args.custom)
 
     if not startservers.check():
         die(ExitStatus.Error)


### PR DESCRIPTION
Allows other ACME clients (such as simp_le), to run any command for integration testing (without having to implement custom busy-wait loop etc.).