### PR TITLE
Revert "Stop fetching master for migr ations test. (#1730)"

### DIFF
--- a/test/travis-before-install.sh
+++ b/test/travis-before-install.sh
@@ -11,6 +11,11 @@ if [ ! -d $GOPATH/src/github.com/letsencrypt/boulder ] ; then
   ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt/boulder
 fi
 
+# Travis does shallow clones, so there is no master branch present.
+# But test-no-outdated-migrations.sh needs to check diffs against master.
+# Fetch just the master branch from origin.
+( git fetch origin master
+git branch master FETCH_HEAD ) &
 # Github-PR-Status secret
 if [ -n "$encrypted_53b2630f0fb4_key" ]; then
   openssl aes-256-cbc \


### PR DESCRIPTION
This reverts commit 8c8fc01b0111752ce8cd9b7c058c7119a787a4f6.

It turns out the master fetch actually was necessary in some other cases,
particularly when building non-master branches (as opposed to PRs).