### PR TITLE
Make authz lookup more efficient (remove ORDER BY)

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -98,7 +98,6 @@ type StorageGetter interface {
 	GetRegistration(ctx context.Context, regID int64) (Registration, error)
 	GetRegistrationByKey(ctx context.Context, jwk jose.JsonWebKey) (Registration, error)
 	GetAuthorization(ctx context.Context, authzID string) (Authorization, error)
-	GetLatestValidAuthorization(ctx context.Context, regID int64, domain AcmeIdentifier) (Authorization, error)
 	GetValidAuthorizations(ctx context.Context, regID int64, domains []string, now time.Time) (map[string]*Authorization, error)
 	GetCertificate(ctx context.Context, serial string) (Certificate, error)
 	GetCertificateStatus(ctx context.Context, serial string) (CertificateStatus, error)

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -275,17 +275,6 @@ func (sa *StorageAuthority) FQDNSetExists(_ context.Context, names []string) (bo
 	return false, nil
 }
 
-// GetLatestValidAuthorization is a mock
-func (sa *StorageAuthority) GetLatestValidAuthorization(_ context.Context, registrationID int64, identifier core.AcmeIdentifier) (authz core.Authorization, err error) {
-	if registrationID == 1 && identifier.Type == "dns" {
-		if sa.authorizedDomains[identifier.Value] || identifier.Value == "not-an-example.com" {
-			exp := sa.clk.Now().AddDate(100, 0, 0)
-			return core.Authorization{Status: core.StatusValid, RegistrationID: 1, Expires: &exp, Identifier: identifier}, nil
-		}
-	}
-	return core.Authorization{}, errors.New("no authz")
-}
-
 // GetValidAuthorizations is a mock
 func (sa *StorageAuthority) GetValidAuthorizations(_ context.Context, regID int64, names []string, now time.Time) (map[string]*core.Authorization, error) {
 	if regID == 1 {

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -253,7 +253,6 @@ func (ssa *SQLStorageAuthority) GetValidAuthorizations(ctx context.Context, regi
 		AND expires > ?
 		AND identifier IN (`+strings.Join(qmarks, ",")+`)
 		AND status = 'valid'
-		ORDER BY expires ASC
 		`, append([]interface{}{registrationID, now}, params...)...)
 	if err != nil {
 		return nil, err
@@ -261,12 +260,18 @@ func (ssa *SQLStorageAuthority) GetValidAuthorizations(ctx context.Context, regi
 
 	byName := make(map[string]*core.Authorization)
 	for _, auth := range auths {
+		// No real life authorizations should have a nil expires. If we find them,
+		// don't consider them valid.
+		if auth.Expires == nil {
+			continue
+		}
 		if auth.Identifier.Type != core.IdentifierDNS {
 			return nil, fmt.Errorf("unknown identifier type: %q on authz id %q", auth.Identifier.Type, auth.ID)
 		}
-		// Due to ORDER BY expires, this results in the latest value
-		// for each name being used.
-		byName[auth.Identifier.Value] = auth
+		existing, present := byName[auth.Identifier.Value]
+		if !present || auth.Expires.After(*existing.Expires) {
+			byName[auth.Identifier.Value] = auth
+		}
 	}
 
 	return byName, nil

--- a/sa/storage-authority.go
+++ b/sa/storage-authority.go
@@ -209,24 +209,6 @@ func (ssa *SQLStorageAuthority) GetAuthorization(ctx context.Context, id string)
 	return
 }
 
-// GetLatestValidAuthorization gets the valid authorization with biggest expire date for a given domain and registrationId
-func (ssa *SQLStorageAuthority) GetLatestValidAuthorization(ctx context.Context, registrationID int64, identifier core.AcmeIdentifier) (authz core.Authorization, err error) {
-	ident, err := json.Marshal(identifier)
-	if err != nil {
-		return
-	}
-	var auth core.Authorization
-	err = ssa.dbMap.SelectOne(&auth, "SELECT id FROM authz "+
-		"WHERE identifier = :identifier AND registrationID = :registrationID AND status = 'valid' "+
-		"ORDER BY expires DESC LIMIT 1",
-		map[string]interface{}{"identifier": string(ident), "registrationID": registrationID})
-	if err != nil {
-		return
-	}
-
-	return ssa.GetAuthorization(ctx, auth.ID)
-}
-
 // GetValidAuthorizations returns the latest authorization object for all
 // domain names from the parameters that the account has authorizations for.
 func (ssa *SQLStorageAuthority) GetValidAuthorizations(ctx context.Context, registrationID int64, names []string, now time.Time) (latest map[string]*core.Authorization, err error) {

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -240,18 +240,19 @@ func CreateDomainAuthWithRegID(t *testing.T, domainName string, sa *SQLStorageAu
 }
 
 // Ensure we get only valid authorization with correct RegID
-func TestGetLatestValidAuthorizationBasic(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
+func TestGetValidAuthorizationsBasic(t *testing.T) {
+	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()
 
-	// attempt to get unauthorized domain
-	authz, err := sa.GetLatestValidAuthorization(ctx, 0, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.org"})
-	test.AssertError(t, err, "Should not have found a valid auth for example.org")
+	// Attempt to get unauthorized domain.
+	authzMap, err := sa.GetValidAuthorizations(ctx, 0, []string{"example.org"}, clk.Now())
+	// Should get not results, but not error.
+	test.AssertEquals(t, len(authzMap), 0)
 
 	reg := satest.CreateWorkingRegistration(t, sa)
 
 	// authorize "example.org"
-	authz = CreateDomainAuthWithRegID(t, "example.org", sa, reg.ID)
+	authz := CreateDomainAuthWithRegID(t, "example.org", sa, reg.ID)
 
 	// finalize auth
 	authz.Status = core.StatusValid
@@ -259,72 +260,77 @@ func TestGetLatestValidAuthorizationBasic(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+authz.ID)
 
 	// attempt to get authorized domain with wrong RegID
-	authz, err = sa.GetLatestValidAuthorization(ctx, 0, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.org"})
-	test.AssertError(t, err, "Should not have found a valid auth for example.org and regID 0")
+	authzMap, err = sa.GetValidAuthorizations(ctx, 0, []string{"example.org"}, clk.Now())
+	test.AssertEquals(t, len(authzMap), 0)
 
 	// get authorized domain
-	authz, err = sa.GetLatestValidAuthorization(ctx, reg.ID, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.org"})
+	authzMap, err = sa.GetValidAuthorizations(ctx, reg.ID, []string{"example.org"}, clk.Now())
 	test.AssertNotError(t, err, "Should have found a valid auth for example.org and regID 42")
-	test.AssertEquals(t, authz.Status, core.StatusValid)
-	test.AssertEquals(t, authz.Identifier.Type, core.IdentifierDNS)
-	test.AssertEquals(t, authz.Identifier.Value, "example.org")
-	test.AssertEquals(t, authz.RegistrationID, reg.ID)
+	test.AssertEquals(t, len(authzMap), 1)
+	result := authzMap["example.org"]
+	test.AssertEquals(t, result.Status, core.StatusValid)
+	test.AssertEquals(t, result.Identifier.Type, core.IdentifierDNS)
+	test.AssertEquals(t, result.Identifier.Value, "example.org")
+	test.AssertEquals(t, result.RegistrationID, reg.ID)
 }
 
 // Ensure we get the latest valid authorization for an ident
-func TestGetLatestValidAuthorizationMultiple(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
+func TestGetValidAuthorizationsDuplicate(t *testing.T) {
+	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()
 
 	domain := "example.org"
-	ident := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: domain}
 	var err error
 
 	reg := satest.CreateWorkingRegistration(t, sa)
 	// create invalid authz
 	authz := CreateDomainAuthWithRegID(t, domain, sa, reg.ID)
-	exp := time.Now().AddDate(0, 0, 10) // expire in 10 day
+	exp := clk.Now().AddDate(0, 0, 10) // expire in 10 day
 	authz.Expires = &exp
 	authz.Status = core.StatusInvalid
 	err = sa.FinalizeAuthorization(ctx, authz)
 	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+authz.ID)
 
 	// should not get the auth
-	authz, err = sa.GetLatestValidAuthorization(ctx, reg.ID, ident)
-	test.AssertError(t, err, "Should not have found a valid auth for "+domain)
+	authzMap, err := sa.GetValidAuthorizations(ctx, reg.ID, []string{domain}, clk.Now())
+	test.AssertEquals(t, len(authzMap), 0)
 
 	// create valid auth
 	authz = CreateDomainAuthWithRegID(t, domain, sa, reg.ID)
-	exp = time.Now().AddDate(0, 0, 1) // expire in 1 day
+	exp = clk.Now().AddDate(0, 0, 1) // expire in 1 day
 	authz.Expires = &exp
 	authz.Status = core.StatusValid
 	err = sa.FinalizeAuthorization(ctx, authz)
 	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+authz.ID)
 
 	// should get the valid auth even if it's expire date is lower than the invalid one
-	authz, err = sa.GetLatestValidAuthorization(ctx, reg.ID, ident)
+	authzMap, err = sa.GetValidAuthorizations(ctx, reg.ID, []string{domain}, clk.Now())
 	test.AssertNotError(t, err, "Should have found a valid auth for "+domain)
-	test.AssertEquals(t, authz.Status, core.StatusValid)
-	test.AssertEquals(t, authz.Identifier.Type, ident.Type)
-	test.AssertEquals(t, authz.Identifier.Value, ident.Value)
-	test.AssertEquals(t, authz.RegistrationID, reg.ID)
+	test.AssertEquals(t, len(authzMap), 1)
+	result1 := authzMap[domain]
+	test.AssertEquals(t, result1.Status, core.StatusValid)
+	test.AssertEquals(t, result1.Identifier.Type, core.IdentifierDNS)
+	test.AssertEquals(t, result1.Identifier.Value, domain)
+	test.AssertEquals(t, result1.RegistrationID, reg.ID)
 
 	// create a newer auth
 	newAuthz := CreateDomainAuthWithRegID(t, domain, sa, reg.ID)
-	exp = time.Now().AddDate(0, 0, 2) // expire in 2 day
+	exp = clk.Now().AddDate(0, 0, 2) // expire in 2 day
 	newAuthz.Expires = &exp
 	newAuthz.Status = core.StatusValid
 	err = sa.FinalizeAuthorization(ctx, newAuthz)
 	test.AssertNotError(t, err, "Couldn't finalize pending authorization with ID "+newAuthz.ID)
 
-	authz, err = sa.GetLatestValidAuthorization(ctx, reg.ID, ident)
+	authzMap, err = sa.GetValidAuthorizations(ctx, reg.ID, []string{domain}, clk.Now())
 	test.AssertNotError(t, err, "Should have found a valid auth for "+domain)
-	test.AssertEquals(t, authz.Status, core.StatusValid)
-	test.AssertEquals(t, authz.Identifier.Type, ident.Type)
-	test.AssertEquals(t, authz.Identifier.Value, ident.Value)
-	test.AssertEquals(t, authz.RegistrationID, reg.ID)
+	test.AssertEquals(t, len(authzMap), 1)
+	result2 := authzMap[domain]
+	test.AssertEquals(t, result2.Status, core.StatusValid)
+	test.AssertEquals(t, result2.Identifier.Type, core.IdentifierDNS)
+	test.AssertEquals(t, result2.Identifier.Value, domain)
+	test.AssertEquals(t, result2.RegistrationID, reg.ID)
 	// make sure we got the latest auth
-	test.AssertEquals(t, authz.ID, newAuthz.ID)
+	test.AssertEquals(t, result2.ID, newAuthz.ID)
 }
 
 func TestAddCertificate(t *testing.T) {

--- a/sa/storage-authority_test.go
+++ b/sa/storage-authority_test.go
@@ -246,7 +246,8 @@ func TestGetValidAuthorizationsBasic(t *testing.T) {
 
 	// Attempt to get unauthorized domain.
 	authzMap, err := sa.GetValidAuthorizations(ctx, 0, []string{"example.org"}, clk.Now())
-	// Should get not results, but not error.
+	// Should get no results, but not error.
+	test.AssertNotError(t, err, "Error getting valid authorizations")
 	test.AssertEquals(t, len(authzMap), 0)
 
 	reg := satest.CreateWorkingRegistration(t, sa)
@@ -261,6 +262,7 @@ func TestGetValidAuthorizationsBasic(t *testing.T) {
 
 	// attempt to get authorized domain with wrong RegID
 	authzMap, err = sa.GetValidAuthorizations(ctx, 0, []string{"example.org"}, clk.Now())
+	test.AssertNotError(t, err, "Error getting valid authorizations")
 	test.AssertEquals(t, len(authzMap), 0)
 
 	// get authorized domain


### PR DESCRIPTION
Fixes #1783. Also remove the obsolete GetLatestValidAuthorization (was replaced by GetValidAuthorizations) and add tests for GetValidAuthorizations.