### PR TITLE
Remove obsolete config line pa.dbConnectFile

### DIFF
--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -151,7 +151,6 @@
   },
 
   "pa": {
-    "dbConnectFile": "test/secrets/pa_dburl",
     "challenges": {
       "http-01": true,
       "tls-sni-01": true,
@@ -199,7 +198,6 @@
 
   "va": {
     "userAgent": "boulder",
-    "issuerDomain": "happy-hacker-ca.invalid",
     "debugAddr": "localhost:8004",
     "portConfig": {
       "httpPort": 5002,
@@ -208,6 +206,7 @@
     },
     "maxConcurrentRPCServerRequests": 16,
     "dnsTries": 3,
+    "issuerDomain": "happy-hacker-ca.invalid",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,


### PR DESCRIPTION
Also move `issuerDomain` so that diffs between boulder-config.json and
boulder-config-next.json are minimized.