### PR TITLE
Bump godep to v66

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/letsencrypt/boulder",
 	"GoVersion": "go1.5",
-	"GodepVersion": "v65",
+	"GodepVersion": "v66",
 	"Packages": [
 		"./..."
 	],


### PR DESCRIPTION
Really we should only be comparing the `Deps` lists, perhaps we could use something like `jq` to simplify this test.