### PR TITLE
Only test list of dependencies match in Godeps.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
       - libffi-dev
       - ca-certificates
       - rsyslog
+      - jq
   mariadb: "10.0"
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ addons:
       - libffi-dev
       - ca-certificates
       - rsyslog
-      - jq
   mariadb: "10.0"
 
 sudo: false

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/letsencrypt/boulder",
 	"GoVersion": "go1.5",
-	"GodepVersion": "v65",
+	"GodepVersion": "v66",
 	"Packages": [
 		"./..."
 	],

--- a/test.sh
+++ b/test.sh
@@ -261,8 +261,9 @@ if [[ "$RUN" =~ "godep-restore" ]] ; then
   run_and_comment godep restore
   # Run godep save and do a diff, to ensure that the version we got from
   # `godep restore` matched what was in the remote repo.
+  cp Godeps/Godeps.json Godeps/Godeps.json.head
   run_and_comment godep save ./...
-  run_and_comment git diff --exit-code
+  run_and_comment jq --argfile head Godeps/Godeps.json.head --argfile master Godeps/Godeps.json -n 'if $master.Deps-$head.Deps | length > 0 then "added",$master.Deps-$head.Deps else empty end, if $head.Deps-$master.Deps | length > 0 then "removed",$head.Deps-$master.Deps else empty end'
   end_context #godep-restore
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -263,7 +263,7 @@ if [[ "$RUN" =~ "godep-restore" ]] ; then
   # `godep restore` matched what was in the remote repo.
   cp Godeps/Godeps.json Godeps/Godeps.json.head
   run_and_comment godep save ./...
-  run_and_comment jq --argfile head Godeps/Godeps.json.head --argfile master Godeps/Godeps.json -n 'if $master.Deps-$head.Deps | length > 0 then "added",$master.Deps-$head.Deps else empty end, if $head.Deps-$master.Deps | length > 0 then "removed",$head.Deps-$master.Deps else empty end'
+  run_and_comment diff <(sed /GodepVersion/d Godeps/Godeps.json.head) <(sed /GodepVersion/d Godeps/Godeps.json)
   end_context #godep-restore
 fi
 


### PR DESCRIPTION
This should prevent `godep` version churn from breaking our builds.