### PR TITLE
Roll forward "Run Travis tests in Docker (#1830)"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
 bin
 tags
-.git
-test/js

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,11 @@ addons:
     - boulder
     - boulder-mysql
     - boulder-rabbitmq
-  apt:
-    packages:
-      - lsb-release
-      - python-dev
-      - python-virtualenv
-      - gcc
-      - libaugeas0
-      - libssl-dev
-      - libffi-dev
-      - ca-certificates
-      - rsyslog
-  mariadb: "10.0"
 
-sudo: false
+sudo: required
 
 services:
-  - rabbitmq
+  - docker
 
 matrix:
   fast_finish: true
@@ -43,13 +31,6 @@ branches:
     - release
     - /^test-.*$/
 
-# By providing our own install command we avoid Travis' default Go install
-# command, which runs `go get`. We specifically want to avoid that because we
-# want to ensure all our dependencies are vendored.
-install:
-  - travis_retry test/travis-before-install.sh
-  - cd $GOPATH/src/github.com/letsencrypt/boulder
-
 env:
   global:
     - PATH=$HOME/bin:$PATH # protoc gets installed here
@@ -61,6 +42,10 @@ env:
     - RUN="integration" BOULDER_CONFIG="test/boulder-config-next.json"
     - RUN="unit"
 
-script:
-  - bash test.sh
+install:
+  - docker-compose pull
+  - docker pull letsencrypt/boulder-tools
+  - docker-compose build
 
+script:
+  - docker-compose run -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" boulder  ./test.sh

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ setting](https://groups.google.com/forum/#!topic/binary-transparency/f-BI4o8HZW0
 for better integrity guarantees when getting updates.
 
 Boulder requires an installation of RabbitMQ, libtool-ltdl, goose, and
-MariaDB 10 to work correctly. On Ubuntu and CentOS, you may have to
+MariaDB 10.1 to work correctly. On Ubuntu and CentOS, you may have to
 install RabbitMQ from https://rabbitmq.com/download.html to get a
 recent version.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,40 @@
 boulder:
     build: .
     dockerfile: Dockerfile
+    volumes:
+      # Cache built .a files for faster repeat runs
+      - /go/pkg/
+      - /tmp:/tmp
     net: bridge
+    extra_hosts:
+      - le.wtf:127.0.0.1
+      - boulder:127.0.0.1
     ports:
-      - 4000:4000
-      - 4002:4002
-      - 4003:4003
+      - 4000:4000 # ACME
+      - 4002:4002 # OCSP
+      - 4003:4003 # OCSP
+      - 4500:4500 # ct-test-srv
+      - 8000:8000 # debug ports
+      - 8001:8001
+      - 8002:8002
+      - 8003:8003
+      - 8004:8004
+      - 8055:8055 # dns-test-srv updates
+      - 9380:9380 # mail-test-srv
+      - 9381:9381 # mail-test-srv
     links:
       - bmysql:boulder-mysql
       - brabbitmq:boulder-rabbitmq
-    extra_hosts:
-      - boulder:127.0.0.1
 bmysql:
-    container_name: boulder-mysql
-    image: mariadb:10.0
+    image: mariadb:10.1
     net: bridge
     environment:
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     command: mysqld --bind-address=0.0.0.0
+    log_driver: none
 brabbitmq:
-    container_name: boulder-rabbitmq
     image: rabbitmq:3
     net: bridge
     environment:
         RABBITMQ_NODE_IP_ADDRESS: "0.0.0.0"
-    log_driver: "none"
+    log_driver: none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 boulder:
     build: .
     dockerfile: Dockerfile
+    environment:
+        FAKE_DNS: 127.0.0.1
     volumes:
       # Cache built .a files for faster repeat runs
       - /go/pkg/

--- a/reloader/reloader.go
+++ b/reloader/reloader.go
@@ -23,6 +23,9 @@ func (r *Reloader) Stop() {
 	r.stopChan <- struct{}{}
 }
 
+// A pointer we can override for testing.
+var readFile = ioutil.ReadFile
+
 // New loads the filename provided, and calls the callback.  It then spawns a
 // goroutine to check for updates to that file, calling the callback again with
 // any new contents. The first load, and the first call to callback, are run
@@ -37,7 +40,7 @@ func New(filename string, dataCallback func([]byte) error, errorCallback func(er
 	if err != nil {
 		return nil, err
 	}
-	b, err := ioutil.ReadFile(filename)
+	b, err := readFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +61,7 @@ func New(filename string, dataCallback func([]byte) error, errorCallback func(er
 				if !currentFileInfo.ModTime().After(fileInfo.ModTime()) {
 					continue
 				}
-				b, err := ioutil.ReadFile(filename)
+				b, err := readFile(filename)
 				if err != nil {
 					errorCallback(err)
 					continue

--- a/reloader/reloader_test.go
+++ b/reloader/reloader_test.go
@@ -36,14 +36,16 @@ func TestNoStat(t *testing.T) {
 func TestNoRead(t *testing.T) {
 	f, _ := ioutil.TempFile("", "test-no-read.txt")
 	defer os.Remove(f.Name())
-	err := f.Chmod(0)
-	if err != nil {
-		t.Fatalf("failed to chmod file: %s", err)
+	oldReadFile := readFile
+	readFile = func(string) ([]byte, error) {
+		return nil, fmt.Errorf("read failed")
 	}
-	_, err = New(f.Name(), noop, testErrCb(t))
+	_, err := New(f.Name(), noop, testErrCb(t))
 	if err == nil {
 		t.Fatalf("Expected New to return error when permission denied.")
+		readFile = oldReadFile
 	}
+	readFile = oldReadFile
 }
 
 func TestFirstError(t *testing.T) {
@@ -182,10 +184,11 @@ func TestReloadFailure(t *testing.T) {
 
 	time.Sleep(15 * time.Millisecond)
 	// Create a file with no permissions
-	err = ioutil.WriteFile(filename, []byte("second body"), 0)
-	if err != nil {
-		t.Fatal(err)
+	oldReadFile := readFile
+	readFile = func(string) ([]byte, error) {
+		return nil, fmt.Errorf("permisssion denied")
 	}
+
 	fakeTick <- time.Now()
 	select {
 	case r := <-reloads:
@@ -195,11 +198,8 @@ func TestReloadFailure(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out waiting for reload")
 	}
+	readFile = oldReadFile
 
-	err = os.Remove(filename)
-	if err != nil {
-		t.Fatal(err)
-	}
 	err = ioutil.WriteFile(filename, []byte("third body"), 0644)
 	if err != nil {
 		t.Fatal(err)

--- a/test/certbot
+++ b/test/certbot
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+# Temporary shim until the letsencrypt Debian package ships `certbot`
+exec letsencrypt "$@"

--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -19,9 +19,6 @@ fi
 # to the format we use in production, MIXED.
 mysql $dbconn -e "SET GLOBAL binlog_format = 'MIXED';"
 
-# Drop all users to get a fresh start
-mysql $dbconn < test/drop_users.sql
-
 for dbenv in $DBENVS; do
   (
   db="boulder_sa_${dbenv}"
@@ -42,6 +39,8 @@ for dbenv in $DBENVS; do
   if [[ ${MYSQL_CONTAINER} ]]; then
     sed -e "s/'localhost'/'%'/g" < ${USERS_SQL} | \
       mysql $dbconn -D $db || die "unable to add users to ${db}"
+  elif mysqld -V | grep "10.0"; then
+      mysql $dbconn -D $db < test/mariadb100_users.sql
   else
     sed -e "s/'localhost'/'127.%'/g" < $USERS_SQL | \
       mysql $dbconn -D $db < $USERS_SQL || die "unable to add users to ${db}"

--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -39,8 +39,6 @@ for dbenv in $DBENVS; do
   if [[ ${MYSQL_CONTAINER} ]]; then
     sed -e "s/'localhost'/'%'/g" < ${USERS_SQL} | \
       mysql $dbconn -D $db || die "unable to add users to ${db}"
-  elif mysqld -V | grep "10.0"; then
-      mysql $dbconn -D $db < test/mariadb100_users.sql
   else
     sed -e "s/'localhost'/'127.%'/g" < $USERS_SQL | \
       mysql $dbconn -D $db < $USERS_SQL || die "unable to add users to ${db}"

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -142,7 +142,7 @@ func main() {
 
 	is := integrationSrv{key: key}
 	s := &http.Server{
-		Addr:    "localhost:4500",
+		Addr:    "0.0.0.0:4500",
 		Handler: http.HandlerFunc(is.handler),
 	}
 	log.Fatal(s.ListenAndServe())

--- a/test/docker-environment
+++ b/test/docker-environment
@@ -1,0 +1,4 @@
+PATH=/go/bin:/go/src/github.com/letsencrypt/boulder/bin:/usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
+GOPATH=/go
+GOBIN=/go/src/github.com/letsencrypt/boulder/bin
+GO15VENDOREXPERIMENT=1

--- a/test/drop_users.sql
+++ b/test/drop_users.sql
@@ -3,6 +3,9 @@
 -- Note that dropping a non-existing user produces an error that aborts the
 -- script, so we first grant a harmless privilege to each user to ensure it
 -- exists.
+
+USE mysql;
+
 GRANT USAGE ON *.* TO 'policy'@'localhost';
 DROP USER 'policy'@'localhost';
 GRANT USAGE ON *.* TO 'sa'@'localhost';
@@ -21,3 +24,5 @@ GRANT USAGE ON *.* TO 'cert_checker'@'localhost';
 DROP USER 'cert_checker'@'localhost';
 GRANT USAGE ON *.* TO 'backfiller'@'localhost';
 DROP USER 'backfiller'@'localhost';
+GRANT USAGE ON *.* TO 'test_setup'@'localhost';
+DROP USER 'test_setup'@'localhost';

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -28,10 +28,14 @@ wait_tcp_port boulder-rabbitmq 5672
 MYSQL_CONTAINER=1 $DIR/create_db.sh
 
 # Set up rabbitmq exchange
-go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq
+rabbitmq-setup -server amqp://boulder-rabbitmq
 
 if [[ $# -eq 0 ]]; then
     exec ./start.py
 fi
 
+# TODO(jsha): Change to an unprivileged user before running commands. Currently,
+# running as an unprivileged user causes the certbot integration test to fail
+# during the test of the manual plugin. There's a call to killpg in there that
+# kills the whole test, but only when run under `su buser -c "..."`
 exec $@

--- a/test/mail-test-srv/main.go
+++ b/test/mail-test-srv/main.go
@@ -16,7 +16,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-var apiPort = flag.String("http", "9381", "http port to listen on")
+var listenAPI = flag.String("http", "0.0.0.0:9381", "http port to listen on")
 
 type rcvdMail struct {
 	From string
@@ -162,7 +162,7 @@ func serveSMTP(l net.Listener) error {
 }
 
 func main() {
-	l, err := net.Listen("tcp", ":9380")
+	l, err := net.Listen("tcp", "0.0.0.0:9380")
 	if err != nil {
 		log.Fatalln("Couldn't bind for SMTP", err)
 	}
@@ -170,7 +170,7 @@ func main() {
 
 	setupHTTP(http.DefaultServeMux)
 	go func() {
-		err := http.ListenAndServe(":"+*apiPort, http.DefaultServeMux)
+		err := http.ListenAndServe(*listenAPI, http.DefaultServeMux)
 		if err != nil {
 			log.Fatalln("Couldn't start HTTP server", err)
 		}

--- a/test/run-docker.sh
+++ b/test/run-docker.sh
@@ -36,7 +36,7 @@ if [[ "$(is_running boulder-mysql)" != "true" ]]; then
 	docker run -d \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
 		--name boulder-mysql \
-		mariadb:10.0 mysqld --bind-address=0.0.0.0
+		mariadb:10.1 mysqld --bind-address=0.0.0.0
 fi
 
 if [[ "$(is_running boulder-rabbitmq)" != "true" ]]; then

--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -14,6 +14,18 @@
 -- drop command will fail. So we grant the dummy `USAGE` privilege to make sure
 -- the user exists and then drop the user.
 
+
+-- These lines require MariaDB 10.1
+CREATE USER IF NOT EXISTS 'policy'@'localhost';
+CREATE USER IF NOT EXISTS 'sa'@'localhost';
+CREATE USER IF NOT EXISTS 'ocsp_resp'@'localhost';
+CREATE USER IF NOT EXISTS 'revoker'@'localhost';
+CREATE USER IF NOT EXISTS 'importer'@'localhost';
+CREATE USER IF NOT EXISTS 'mailer'@'localhost';
+CREATE USER IF NOT EXISTS 'cert_checker'@'localhost';
+CREATE USER IF NOT EXISTS 'ocsp_update'@'localhost';
+CREATE USER IF NOT EXISTS 'test_setup'@'localhost';
+
 -- Storage Authority
 GRANT SELECT,INSERT,UPDATE ON authz TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE,DELETE ON pendingAuthorizations TO 'sa'@'localhost';
@@ -54,10 +66,6 @@ GRANT SELECT ON fqdnSets TO 'mailer'@'localhost';
 
 -- Cert checker
 GRANT SELECT ON certificates TO 'cert_checker'@'localhost';
-
--- Name set table backfiller
-GRANT SELECT ON certificates to 'backfiller'@'localhost';
-GRANT INSERT,SELECT ON fqdnSets to 'backfiller'@'localhost';
 
 -- Test setup and teardown
 GRANT ALL PRIVILEGES ON * to 'test_setup'@'localhost';


### PR DESCRIPTION
That change broke the certbot tests because it switched to a MariaDB
10.1-specific syntax. certbot/certbot#3058 changes the certbot tests to use
Boulder's docker-compose.yml, so they will get MariaDB 10.1 automatically.