### PR TITLE
Docker test updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /go/src/github.com/letsencrypt/boulder
 COPY . .
 RUN mkdir bin
 RUN GOBIN=/usr/local/bin go install ./cmd/rabbitmq-setup
-COPY ./test/certbot /usr/local/bin
+COPY ./test/certbot /usr/local/bin/
 
 RUN chown -R buser /go/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ FROM letsencrypt/boulder-tools:latest
 EXPOSE 4000 4002 4003 8053 8055
 
 ENV GO15VENDOREXPERIMENT 1
-ENV GOBIN /go/src/github.com/letsencrypt/boulder/bin
-ENV PATH /go/bin:/go/src/github.com/letsencrypt/boulder/bin:/usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
+ENV PATH /go/bin:/usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 ENV GOPATH /go
 
 RUN adduser --disabled-password --gecos "" --home /go/src/github.com/letsencrypt/boulder -q buser
@@ -16,7 +15,7 @@ WORKDIR /go/src/github.com/letsencrypt/boulder
 # Copy in the Boulder sources
 COPY . .
 RUN mkdir bin
-RUN go install ./cmd/rabbitmq-setup
+RUN GOBIN=/usr/local/bin go install ./cmd/rabbitmq-setup
 COPY ./test/certbot /go/bin/
 
 RUN chown -R buser /go/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /go/src/github.com/letsencrypt/boulder
 COPY . .
 RUN mkdir bin
 RUN GOBIN=/usr/local/bin go install ./cmd/rabbitmq-setup
-COPY ./test/certbot /go/bin/
+COPY ./test/certbot /usr/local/bin
 
 RUN chown -R buser /go/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,7 @@ boulder:
     environment:
         FAKE_DNS: 127.0.0.1
     volumes:
-      # Cache built .a files for faster repeat runs
-      - /go/pkg/
+      - $GOPATH:/go/
       - /tmp:/tmp
     net: bridge
     extra_hosts:

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.5
+
+ADD build.sh /tmp/build.sh
+RUN bash /tmp/build.sh

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -ex
+
+# Boulder deps
+apt-get update
+apt-get install -y --no-install-recommends apt-transport-https ca-certificates
+
+curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+cat >/etc/apt/sources.list.d/bouldertools.list <<EOAPT
+deb https://deb.nodesource.com/node_4.x trusty main
+deb-src https://deb.nodesource.com/node_4.x trusty main
+deb http://ftp.debian.org/debian jessie-backports main
+EOAPT
+apt-get update
+apt-get install -y --no-install-recommends  -t jessie-backports letsencrypt python-letsencrypt-apache
+
+apt-get install -y --no-install-recommends \
+  libltdl-dev \
+  mariadb-client-core-10.0 \
+  nodejs \
+  rpm \
+  ruby \
+  ruby-dev \
+  rsyslog \
+  softhsm \
+  protobuf-compiler &
+
+# Install port forwarder, database migration tool, and testing tools.
+GOBIN=/usr/local/bin GOPATH=/tmp/gopath go get \
+  github.com/jsha/listenbuddy \
+  bitbucket.org/liamstask/goose/cmd/goose \
+  github.com/golang/lint/golint \
+  github.com/golang/mock/mockgen \
+  github.com/golang/protobuf/proto \
+  github.com/golang/protobuf/protoc-gen-go \
+  github.com/kisielk/errcheck \
+  github.com/mattn/goveralls \
+  github.com/modocache/gover \
+  github.com/tools/godep \
+  golang.org/x/tools/cmd/stringer \
+  golang.org/x/tools/cover &
+
+wait
+
+gem install fpm
+
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Commit test/boulder-tools (forgot to include them in #1838).
Mount $GOPATH as a volume in the container so that source code changes take
effect in the container without a rebuild, and build cache can make repeated
runs faster. Install rabbitmq-setup outside of the mounted-over path so it still
exists.
Remove unnecessary entries from Dockerfile's PATH and GOBIN.