### PR TITLE
Remove existence check for gover and goveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ install:
   - docker-compose build
 
 script:
-  - docker-compose run -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" boulder  ./test.sh
+  - docker-compose run -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" boulder  ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ install:
   - docker-compose build
 
 script:
-  - docker-compose run -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" boulder  ./test.sh
+  - docker-compose run -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" boulder  ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -96,7 +96,7 @@ function run_unit_tests() {
     # We don't use the run function here because sometimes goveralls fails to
     # contact the server and exits with non-zero status, but we don't want to
     # treat that as a failure.
-    goveralls -coverprofile=gover.coverprofile -service=travis-ci
+    goveralls -v -coverprofile=gover.coverprofile -service=travis-ci
   else
     # When running locally, we skip the -race flag for speedier test runs. We
     # also pass -p 1 to require the tests to run serially instead of in

--- a/test.sh
+++ b/test.sh
@@ -91,12 +91,12 @@ function run_unit_tests() {
     done
 
     # Gather all the coverprofiles
-    [ -e $GOBIN/gover ] && run $GOBIN/gover
+    run gover
 
     # We don't use the run function here because sometimes goveralls fails to
     # contact the server and exits with non-zero status, but we don't want to
     # treat that as a failure.
-    [ -e $GOBIN/goveralls ] && $GOBIN/goveralls -coverprofile=gover.coverprofile -service=travis-ci
+    goveralls -coverprofile=gover.coverprofile -service=travis-ci
   else
     # When running locally, we skip the -race flag for speedier test runs. We
     # also pass -p 1 to require the tests to run serially instead of in
@@ -108,10 +108,6 @@ function run_unit_tests() {
     run go test -p 1 $GOTESTFLAGS ${TESTPATHS}
   fi
 }
-
-# Path for installed go package binaries. If yours is different, override with
-# GOBIN=/my/path/to/bin ./test.sh
-GOBIN=${GOBIN:-$HOME/gopath/bin}
 
 #
 # Run Go Vet, a correctness-focused static analysis tool


### PR DESCRIPTION
Since they are only run inside an "if Travis" block, and we know those tools are
installed in the Docker image we use on Travis. This restores coverage reporting
to our builds.