### PR TITLE
Make it easier to instantiate ProblemDetails

### DIFF
--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -65,13 +65,7 @@ const detailServerFailure = "server failure at resolver"
 // record type and domain given.
 func ProblemDetailsFromDNSError(err error) *probs.ProblemDetails {
 	if dnsErr, ok := err.(*DNSError); ok {
-		return &probs.ProblemDetails{
-			Type:   probs.ConnectionProblem,
-			Detail: dnsErr.Error(),
-		}
+		return probs.ConnectionFailure(dnsErr.Error())
 	}
-	return &probs.ProblemDetails{
-		Type:   probs.ConnectionProblem,
-		Detail: detailServerFailure,
-	}
+	return probs.ConnectionFailure(detailServerFailure)
 }

--- a/core/util.go
+++ b/core/util.go
@@ -136,11 +136,7 @@ func ProblemDetailsForError(err error, msg string) *probs.ProblemDetails {
 	case SignatureValidationError:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case RateLimitedError:
-		return &probs.ProblemDetails{
-			Type:       probs.RateLimitedProblem,
-			Detail:     fmt.Sprintf("%s :: %s", msg, err),
-			HTTPStatus: statusTooManyRequests,
-		}
+		return probs.RateLimited(fmt.Sprintf("%s :: %s", msg, err))
 	case BadNonceError:
 		return probs.BadNonce(fmt.Sprintf("%s :: %s", msg, err))
 	default:

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -180,3 +180,12 @@ func RateLimited(detail string) *ProblemDetails {
 		HTTPStatus: statusTooManyRequests,
 	}
 }
+
+// TLSError returns a ProblemDetails representing a TLSProblem error
+func TLSError(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       TLSProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -152,3 +152,13 @@ func InvalidEmail(detail string) *ProblemDetails {
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
+
+// ConnectionFailure returns a ProblemDetails representing a ConnectionProblem
+// error
+func ConnectionFailure(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       ConnectionProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -142,3 +142,13 @@ func ContentLengthRequired() *ProblemDetails {
 		HTTPStatus: http.StatusLengthRequired,
 	}
 }
+
+// InvalidEmail returns a ProblemDetails representing an invalid email address
+// error
+func InvalidEmail(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       InvalidEmailProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -171,3 +171,12 @@ func UnknownHost(detail string) *ProblemDetails {
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
+
+// RateLimited returns a ProblemDetails representing a RateLimitedProblem error
+func RateLimited(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       RateLimitedProblem,
+		Detail:     detail,
+		HTTPStatus: statusTooManyRequests,
+	}
+}

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -162,3 +162,12 @@ func ConnectionFailure(detail string) *ProblemDetails {
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
+
+// UnknownHost returns a ProblemDetails representing an UnknownHostProblem error
+func UnknownHost(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       UnknownHostProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/probs/probs_test.go
+++ b/probs/probs_test.go
@@ -59,6 +59,7 @@ func TestProblemDetailsConvenience(t *testing.T) {
 		{UnknownHost("unknown host detail"), UnknownHostProblem, http.StatusBadRequest, "unknown host detail"},
 		{RateLimited("rate limited detail"), RateLimitedProblem, statusTooManyRequests, "rate limited detail"},
 		{BadNonce("bad nonce detail"), BadNonceProblem, http.StatusBadRequest, "bad nonce detail"},
+		{TLSError("TLS error detail"), TLSProblem, http.StatusBadRequest, "TLS error detail"},
 	}
 
 	for _, c := range testCases {

--- a/probs/probs_test.go
+++ b/probs/probs_test.go
@@ -43,3 +43,35 @@ func TestProblemDetailsToStatusCode(t *testing.T) {
 		}
 	}
 }
+
+func TestProblemDetailsConvenience(t *testing.T) {
+	testCases := []struct {
+		pb           *ProblemDetails
+		expectedType ProblemType
+		statusCode   int
+		detail       string
+	}{
+		{InvalidEmail("invalid email detail"), InvalidEmailProblem, http.StatusBadRequest, "invalid email detail"},
+		{ConnectionFailure("connection failure detail"), ConnectionProblem, http.StatusBadRequest, "connection failure detail"},
+		{Malformed("malformed detail"), MalformedProblem, http.StatusBadRequest, "malformed detail"},
+		{ServerInternal("internal error detail"), ServerInternalProblem, http.StatusInternalServerError, "internal error detail"},
+		{Unauthorized("unauthorized detail"), UnauthorizedProblem, http.StatusForbidden, "unauthorized detail"},
+		{UnknownHost("unknown host detail"), UnknownHostProblem, http.StatusBadRequest, "unknown host detail"},
+		{RateLimited("rate limited detail"), RateLimitedProblem, statusTooManyRequests, "rate limited detail"},
+		{BadNonce("bad nonce detail"), BadNonceProblem, http.StatusBadRequest, "bad nonce detail"},
+	}
+
+	for _, c := range testCases {
+		if c.pb.Type != c.expectedType {
+			t.Errorf("Incorrect problem type. Expected %s got %s", c.expectedType, c.pb.Type)
+		}
+
+		if c.pb.HTTPStatus != c.statusCode {
+			t.Errorf("Incorrect HTTP Status. Expected %d got %d", c.statusCode, c.pb.HTTPStatus)
+		}
+
+		if c.pb.Detail != c.detail {
+			t.Errorf("Incorrect detail message. Expected %s got %s", c.detail, c.pb.Detail)
+		}
+	}
+}

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -110,16 +110,10 @@ const (
 func validateEmail(ctx context.Context, address string, resolver bdns.DNSResolver) (prob *probs.ProblemDetails) {
 	emails, err := mail.ParseAddressList(address)
 	if err != nil {
-		return &probs.ProblemDetails{
-			Type:   probs.InvalidEmailProblem,
-			Detail: unparseableEmailDetail,
-		}
+		return probs.InvalidEmail(unparseableEmailDetail)
 	}
 	if len(emails) > 1 {
-		return &probs.ProblemDetails{
-			Type:   probs.InvalidEmailProblem,
-			Detail: multipleAddressDetail,
-		}
+		return probs.InvalidEmail(multipleAddressDetail)
 	}
 	splitEmail := strings.SplitN(emails[0].Address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -147,10 +147,7 @@ func validateEmail(ctx context.Context, address string, resolver bdns.DNSResolve
 		return nil
 	}
 
-	return &probs.ProblemDetails{
-		Type:   probs.InvalidEmailProblem,
-		Detail: emptyDNSResponseDetail,
-	}
+	return probs.InvalidEmail(emptyDNSResponseDetail)
 }
 
 type certificateRequestEvent struct {

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -380,10 +380,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, identifie
 	if err != nil {
 		errString := fmt.Sprintf("Failed to construct expected key authorization value: %s", err)
 		va.log.Err(fmt.Sprintf("%s for %s", errString, identifier))
-		return validationRecords, &probs.ProblemDetails{
-			Type:   probs.ServerInternalProblem,
-			Detail: errString,
-		}
+		return validationRecords, probs.ServerInternal(errString)
 	}
 
 	if expectedKeyAuth != payload {

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -109,10 +109,9 @@ func (va ValidationAuthorityImpl) getAddr(ctx context.Context, hostname string) 
 	}
 
 	if len(addrs) == 0 {
-		problem := &probs.ProblemDetails{
-			Type:   probs.UnknownHostProblem,
-			Detail: fmt.Sprintf("No IPv4 addresses found for %s", hostname),
-		}
+		problem := probs.UnknownHost(
+			fmt.Sprintf("No IPv4 addresses found for %s", hostname),
+		)
 		return net.IP{}, nil, problem
 	}
 	addr := addrs[0]

--- a/va/validation-authority.go
+++ b/va/validation-authority.go
@@ -512,10 +512,9 @@ func (va *ValidationAuthorityImpl) checkCAA(ctx context.Context, identifier core
 	// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
 	va.log.AuditInfo(fmt.Sprintf("Checked CAA records for %s, [Present: %t, Valid for issuance: %t]", identifier.Value, present, valid))
 	if !valid {
-		return &probs.ProblemDetails{
-			Type:   probs.ConnectionProblem,
-			Detail: fmt.Sprintf("CAA record for %s prevents issuance", identifier.Value),
-		}
+		return probs.ConnectionFailure(
+			fmt.Sprintf("CAA record for %s prevents issuance", identifier.Value),
+		)
 	}
 	return nil
 }
@@ -547,10 +546,9 @@ func (va *ValidationAuthorityImpl) checkCAAService(ctx context.Context, ident co
 		*r.Valid,
 	))
 	if !*r.Valid {
-		return &probs.ProblemDetails{
-			Type:   probs.ConnectionProblem,
-			Detail: fmt.Sprintf("CAA record for %s prevents issuance", ident.Value),
-		}
+		return probs.ConnectionFailure(
+			fmt.Sprintf("CAA record for %s prevents issuance", ident.Value),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
Several of the `ProblemType`s had convenience functions to instantiate `ProblemDetails`s using their type and a detail message. Where these existed I did a quick scan of the codebase to convert places where callers were explicitly constructing the `ProblemDetails` to use the convenience function.

For the `ProblemType`s that did not have such a function, I created one and then converted callers to use it.

Solves #1837. 