### PR TITLE
Make Travis builds work on forked repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
     - RUN="unit"
 
 install:
+  - ./test/travis-before-install.sh
   - docker-compose pull
   - docker pull letsencrypt/boulder-tools
   - docker-compose build

--- a/test/travis-before-install.sh
+++ b/test/travis-before-install.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-set -o xtrace
-
 # Boulder consists of multiple Go packages, which
 # refer to each other by their absolute GitHub path,
 # That means, by default, if someone forks the repo,
 # Travis won't pass on their own repo. To fix that,
-# we add a symlink.
-mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt
+# we move the source directory.
 if [ ! -d $GOPATH/src/github.com/letsencrypt/boulder ] ; then
-  ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt/boulder
+  mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt
+  mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt/boulder
 fi
 
 # Travis does shallow clones, so there is no master branch present.
@@ -16,7 +14,3 @@ fi
 # Fetch just the master branch from origin.
 ( git fetch origin master
 git branch master FETCH_HEAD ) &
-
-./test/setup.sh
-
-set +o xtrace


### PR DESCRIPTION
This is necessary to make Travis builds work on forks of the main repo.

Fixes #1852 