### PR TITLE
Move rate limit code to `ratelimit` package.

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/ra"
+	"github.com/letsencrypt/boulder/ratelimit"
 	"github.com/letsencrypt/boulder/rpc"
 )
 
@@ -34,7 +35,7 @@ func main() {
 		err = pa.SetHostnamePolicyFile(c.RA.HostnamePolicyFile)
 		cmd.FailOnError(err, "Couldn't load hostname policy file")
 
-		rateLimitPolicies, err := cmd.LoadRateLimitPolicies(c.RA.RateLimitPoliciesFilename)
+		rateLimitPolicies, err := ratelimit.LoadRateLimitPolicies(c.RA.RateLimitPoliciesFilename)
 		cmd.FailOnError(err, "Couldn't load rate limit policies file")
 
 		go cmd.ProfileCmd("RA", stats)

--- a/ra/registration-authority.go
+++ b/ra/registration-authority.go
@@ -20,10 +20,10 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/bdns"
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	csrlib "github.com/letsencrypt/boulder/csr"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/ratelimit"
 )
 
 // DefaultAuthorizationLifetime is the 10 month default authorization lifetime.
@@ -55,7 +55,7 @@ type RegistrationAuthorityImpl struct {
 	// How long before a newly created authorization expires.
 	authorizationLifetime        time.Duration
 	pendingAuthorizationLifetime time.Duration
-	rlPolicies                   cmd.RateLimitConfig
+	rlPolicies                   ratelimit.RateLimitConfig
 	tiMu                         *sync.RWMutex
 	totalIssuedCache             int
 	lastIssuedCount              *time.Time
@@ -71,7 +71,7 @@ type RegistrationAuthorityImpl struct {
 }
 
 // NewRegistrationAuthorityImpl constructs a new RA object.
-func NewRegistrationAuthorityImpl(clk clock.Clock, logger blog.Logger, stats statsd.Statter, dc *DomainCheck, policies cmd.RateLimitConfig, maxContactsPerReg int, keyPolicy core.KeyPolicy, newVARPC bool, maxNames int, forceCNFromSAN bool) *RegistrationAuthorityImpl {
+func NewRegistrationAuthorityImpl(clk clock.Clock, logger blog.Logger, stats statsd.Statter, dc *DomainCheck, policies ratelimit.RateLimitConfig, maxContactsPerReg int, keyPolicy core.KeyPolicy, newVARPC bool, maxNames int, forceCNFromSAN bool) *RegistrationAuthorityImpl {
 	// TODO(jmhodges): making RA take a "RA" stats.Scope, not Statter
 	scope := metrics.NewStatsdScope(stats, "RA")
 	ra := &RegistrationAuthorityImpl{
@@ -627,7 +627,7 @@ func domainsForRateLimiting(names []string) ([]string, error) {
 	return domains, nil
 }
 
-func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.Context, names []string, limit cmd.RateLimitPolicy, regID int64) error {
+func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.Context, names []string, limit ratelimit.RateLimitPolicy, regID int64) error {
 	names, err := domainsForRateLimiting(names)
 	if err != nil {
 		return err
@@ -673,7 +673,7 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 	return nil
 }
 
-func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx context.Context, names []string, limit cmd.RateLimitPolicy, regID int64) error {
+func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx context.Context, names []string, limit ratelimit.RateLimitPolicy, regID int64) error {
 	count, err := ra.SA.CountFQDNSets(ctx, limit.Window.Duration, names)
 	if err != nil {
 		return err

--- a/ra/registration-authority_test.go
+++ b/ra/registration-authority_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/probs"
+	"github.com/letsencrypt/boulder/ratelimit"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
@@ -205,8 +206,8 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 		log,
 		stats,
 		&DomainCheck{va},
-		cmd.RateLimitConfig{
-			TotalCertificates: cmd.RateLimitPolicy{
+		ratelimit.RateLimitConfig{
+			TotalCertificates: ratelimit.RateLimitPolicy{
 				Threshold: 100,
 				Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
 			},
@@ -646,8 +647,8 @@ func TestTotalCertRateLimit(t *testing.T) {
 	_, sa, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	ra.rlPolicies = cmd.RateLimitConfig{
-		TotalCertificates: cmd.RateLimitPolicy{
+	ra.rlPolicies = ratelimit.RateLimitConfig{
+		TotalCertificates: ratelimit.RateLimitPolicy{
 			Threshold: 1,
 			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
 		},
@@ -690,8 +691,8 @@ func TestAuthzRateLimiting(t *testing.T) {
 	_, _, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	ra.rlPolicies = cmd.RateLimitConfig{
-		PendingAuthorizationsPerAccount: cmd.RateLimitPolicy{
+	ra.rlPolicies = ratelimit.RateLimitConfig{
+		PendingAuthorizationsPerAccount: ratelimit.RateLimitPolicy{
 			Threshold: 1,
 			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
 		},
@@ -767,7 +768,7 @@ func TestCheckCertificatesPerNameLimit(t *testing.T) {
 	_, _, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	rlp := cmd.RateLimitPolicy{
+	rlp := ratelimit.RateLimitPolicy{
 		Threshold: 3,
 		Window:    cmd.ConfigDuration{Duration: 23 * time.Hour},
 		Overrides: map[string]int{

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -1,10 +1,12 @@
-package cmd
+package ratelimit
 
 import (
 	"io/ioutil"
 	"time"
 
 	"gopkg.in/yaml.v2"
+
+	"github.com/letsencrypt/boulder/cmd"
 )
 
 // RateLimitConfig contains all application layer rate limiting policies
@@ -33,7 +35,7 @@ type RateLimitConfig struct {
 // RateLimitPolicy describes a general limiting policy
 type RateLimitPolicy struct {
 	// How long to count items for
-	Window ConfigDuration `yaml:"window"`
+	Window cmd.ConfigDuration `yaml:"window"`
 	// The max number of items that can be present before triggering the rate
 	// limit. Zero means "no limit."
 	Threshold int `yaml:"threshold"`

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -1,8 +1,10 @@
-package cmd
+package ratelimit
 
 import (
 	"testing"
 	"time"
+
+	"github.com/letsencrypt/boulder/cmd"
 )
 
 func TestEnabled(t *testing.T) {
@@ -49,7 +51,7 @@ func TestGetThreshold(t *testing.T) {
 
 func TestWindowBegin(t *testing.T) {
 	policy := RateLimitPolicy{
-		Window: ConfigDuration{Duration: 24 * time.Hour},
+		Window: cmd.ConfigDuration{Duration: 24 * time.Hour},
 	}
 	now := time.Date(2015, 9, 22, 0, 0, 0, 0, time.UTC)
 	expected := time.Date(2015, 9, 21, 0, 0, 0, 0, time.UTC)

--- a/wfe/web-front-end_test.go
+++ b/wfe/web-front-end_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/square/go-jose"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/ra"
+	"github.com/letsencrypt/boulder/ratelimit"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -617,7 +617,7 @@ func TestIssueCertificate(t *testing.T) {
 	// TODO: Use a mock RA so we can test various conditions of authorized, not
 	// authorized, etc.
 	stats, _ := statsd.NewNoopClient(nil)
-	ra := ra.NewRegistrationAuthorityImpl(fc, wfe.log, stats, nil, cmd.RateLimitConfig{}, 0, testKeyPolicy, false, 0, true)
+	ra := ra.NewRegistrationAuthorityImpl(fc, wfe.log, stats, nil, ratelimit.RateLimitConfig{}, 0, testKeyPolicy, false, 0, true)
 	ra.SA = mocks.NewStorageAuthority(fc)
 	ra.CA = &mocks.MockCA{
 		PEM: mockCertPEM,


### PR DESCRIPTION
The rate limiting code previously lived in the `cmd` package without a clear justification for why. This commit moves the rate limiting code to its own `ratelimit` package and updates import paths as required.

Notably all references from the `cmd` package's exported `LoadRateLimitPolicies`, `RateLimitPolicy`, and `RateLimitConfig` were moved to use `ratelimit`. This removed the need for the `cmd` import from a couple of callers (nice!).

Fixes #1855 