### PR TITLE
Fix VA gRPC marshalling bug

### DIFF
--- a/grpc/wrappers.go
+++ b/grpc/wrappers.go
@@ -30,8 +30,14 @@ func (s *ValidationAuthorityGRPCServer) PerformValidation(ctx context.Context, i
 		return nil, err
 	}
 	records, err := s.impl.PerformValidation(ctx, domain, challenge, authz)
+	// If the type of error was a ProblemDetails, we need to return
+	// both that and the records to the caller (so it can update
+	// the challenge / authz in the SA with the failing records).
+	// The least error-prone way of doing this is to send a struct
+	// as the RPC response and return a nil error on the RPC layer,
+	// then unpack that into (records, error) to the caller.
 	prob, ok := err.(*probs.ProblemDetails)
-	if !ok {
+	if !ok && err != nil {
 		return nil, err
 	}
 	return validationResultToPB(records, prob)


### PR DESCRIPTION
`validationResultToPB` understands that the passed `*probs.ProblemDetails` may be nil, but the type assertion that was used before it would fail on anything that didn't pass the assertion check, i.e. if passed `nil`. This could cause gRPC to be passed a `nil, nil` which causes a marshalling error (since it needs either a return argument or a error to pass to the client).

Instead just check if `!ok && err != nil` to make sure we only fail the type check if the error is actually present as we do in the AMQP wrapper (`rpc/rpc-wrappers.go:543`).