### PR TITLE
Start VA gRPC in a goroutine.

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -94,8 +94,10 @@ func main() {
 			cmd.FailOnError(err, "Unable to setup VA gRPC server")
 			err = bgrpc.RegisterValidationAuthorityGRPCServer(s, vai)
 			cmd.FailOnError(err, "Unable to register VA gRPC server")
-			err = s.Serve(l)
-			cmd.FailOnError(err, "VA gRPC service failed")
+			go func() {
+				err = s.Serve(l)
+				cmd.FailOnError(err, "VA gRPC service failed")
+			}()
 		}
 
 		vas, err := rpc.NewAmqpRPCServer(amqpConf, c.VA.MaxConcurrentRPCServerRequests, stats)


### PR DESCRIPTION
Otherwise it will block and the AMQP service won't start.

Part of #1856 