### PR TITLE
Test config updates.

### DIFF
--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -2,7 +2,7 @@
   "syslog": {
     "network": "",
     "server": "",
-    "stdoutlevel": 7,
+    "stdoutlevel": 6,
     "sysloglevel": 4
   },
 

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -123,7 +123,8 @@
               "PublicKey": true,
               "SignatureAlgorithm": true
             },
-            "ClientProvidesSerialNumbers": true
+            "ClientProvidesSerialNumbers": true,
+            "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ]
           }
         },
         "default": {


### PR DESCRIPTION
Decrease log level for boulder-config-next.
Copy must-staple config into boulder-config now that it's on in prod.