### PR TITLE
Add index to certificates table's issued field

### DIFF
--- a/sa/_db/migrations/20160602142227_AddCertificatesIssuedIndex.sql
+++ b/sa/_db/migrations/20160602142227_AddCertificatesIssuedIndex.sql
@@ -1,0 +1,10 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `certificates` ADD INDEX `issued` (`issued`);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `certificates` DROP INDEX `issued`;

--- a/sa/_db/migrations/20160602142227_AddCertificatesIssuedIndex.sql
+++ b/sa/_db/migrations/20160602142227_AddCertificatesIssuedIndex.sql
@@ -2,9 +2,9 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 
-ALTER TABLE `certificates` ADD INDEX `issued` (`issued`);
+ALTER TABLE `certificates` ADD INDEX `issued_idx` (`issued`);
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
 
-ALTER TABLE `certificates` DROP INDEX `issued`;
+ALTER TABLE `certificates` DROP INDEX `issued_idx`;


### PR DESCRIPTION
As detailed in issue #1872 the `getSerialsIssuedSince` function of the ocsp-updater cmd performs with poor runtime, likely due to a `filesort` and lack of index on the `issued` field.

This commit adds a migration to create a new index on the `issued` field.
