### PR TITLE
Fix `getSerialsIssuedSince` termination criteria.

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -26,11 +26,11 @@ import (
 )
 
 /*
- * dbMockAdapter is an interface collecting the gorp.DbMap functions that the
+ * ocspDB is an interface collecting the gorp.DbMap functions that the
  * various parts of OCSPUpdater rely on. Using this adapter shim allows tests to
  * swap out the dbMap implementation.
  */
-type dbMockAdapter interface {
+type ocspDB interface {
 	Select(i interface{}, query string, args ...interface{}) ([]interface{}, error)
 	SelectOne(holder interface{}, query string, args ...interface{}) error
 	Exec(query string, args ...interface{}) (sql.Result, error)
@@ -42,7 +42,7 @@ type OCSPUpdater struct {
 	log   blog.Logger
 	clk   clock.Clock
 
-	dbMap dbMockAdapter
+	dbMap ocspDB
 
 	cac  core.CertificateAuthority
 	pubc core.Publisher
@@ -66,7 +66,7 @@ type OCSPUpdater struct {
 func newUpdater(
 	stats statsd.Statter,
 	clk clock.Clock,
-	dbMap dbMockAdapter,
+	dbMap ocspDB,
 	ca core.CertificateAuthority,
 	pub core.Publisher,
 	sac core.StorageAuthority,

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jmhodges/clock"
 	"golang.org/x/crypto/ocsp"
 	"golang.org/x/net/context"
-	gorp "gopkg.in/gorp.v1"
 
 	"github.com/letsencrypt/boulder/akamai"
 	"github.com/letsencrypt/boulder/cmd"
@@ -26,13 +25,24 @@ import (
 	"github.com/letsencrypt/boulder/sa"
 )
 
+/*
+ * dbMockAdapter is an interface collecting the gorp.DbMap functions that the
+ * various parts of OCSPUpdater rely on. Using this adapter shim allows tests to
+ * swap out the dbMap implementation.
+ */
+type dbMockAdapter interface {
+	Select(i interface{}, query string, args ...interface{}) ([]interface{}, error)
+	SelectOne(holder interface{}, query string, args ...interface{}) error
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
 // OCSPUpdater contains the useful objects for the Updater
 type OCSPUpdater struct {
 	stats statsd.Statter
 	log   blog.Logger
 	clk   clock.Clock
 
-	dbMap *gorp.DbMap
+	dbMap dbMockAdapter
 
 	cac  core.CertificateAuthority
 	pubc core.Publisher
@@ -56,7 +66,7 @@ type OCSPUpdater struct {
 func newUpdater(
 	stats statsd.Statter,
 	clk clock.Clock,
-	dbMap *gorp.DbMap,
+	dbMap dbMockAdapter,
 	ca core.CertificateAuthority,
 	pub core.Publisher,
 	sac core.StorageAuthority,

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -430,7 +430,7 @@ func (updater *OCSPUpdater) getSerialsIssuedSince(since time.Time, batchSize int
 				"offset": len(allSerials),
 			},
 		)
-		if err == sql.ErrNoRows || len(serials) == 0 {
+		if err == sql.ErrNoRows || len(serials) < batchSize {
 			break
 		}
 		if err != nil {

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -429,13 +429,17 @@ func (updater *OCSPUpdater) getSerialsIssuedSince(since time.Time, batchSize int
 				"offset": len(allSerials),
 			},
 		)
-		if err == sql.ErrNoRows || len(serials) < batchSize {
+		if err == sql.ErrNoRows || len(serials) == 0 {
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
 		allSerials = append(allSerials, serials...)
+
+		if len(serials) < batchSize {
+			break
+		}
 	}
 	return allSerials, nil
 }

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -103,7 +103,7 @@ func TestGenerateAndStoreOCSPResponse(t *testing.T) {
 	parsedCert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	status, err := sa.GetCertificateStatus(ctx, core.SerialToString(parsedCert.SerialNumber))
 	test.AssertNotError(t, err, "Couldn't get the core.CertificateStatus from the database")
@@ -158,7 +158,7 @@ func TestFindStaleOCSPResponses(t *testing.T) {
 	parsedCert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	earliest := fc.Now().Add(-time.Hour)
 	certs, err := updater.findStaleOCSPResponses(earliest, 10)
@@ -186,7 +186,7 @@ func TestGetCertificatesWithMissingResponses(t *testing.T) {
 	cert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, cert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	statuses, err := updater.getCertificatesWithMissingResponses(10)
 	test.AssertNotError(t, err, "Couldn't get status")
@@ -201,7 +201,7 @@ func TestFindRevokedCertificatesToUpdate(t *testing.T) {
 	cert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, cert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	statuses, err := updater.findRevokedCertificatesToUpdate(10)
 	test.AssertNotError(t, err, "Failed to find revoked certificates")
@@ -223,7 +223,7 @@ func TestNewCertificateTick(t *testing.T) {
 	parsedCert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	prev := fc.Now().Add(-time.Hour)
 	err = updater.newCertificateTick(ctx, 10)
@@ -242,7 +242,7 @@ func TestOldOCSPResponsesTick(t *testing.T) {
 	parsedCert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	updater.ocspMinTimeToExpiry = 1 * time.Hour
 	err = updater.oldOCSPResponsesTick(ctx, 10)
@@ -262,7 +262,7 @@ func TestMissingReceiptsTick(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	fc.Set(parsedCert.NotBefore.Add(time.Minute))
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	updater.numLogs = 1
 	updater.oldestIssuedSCT = 2 * time.Hour
@@ -293,7 +293,7 @@ func TestRevokedCertificatesTick(t *testing.T) {
 	parsedCert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	err = sa.MarkCertificateRevoked(ctx, core.SerialToString(parsedCert.SerialNumber), core.RevocationCode(1))
 	test.AssertNotError(t, err, "Failed to revoke certificate")
@@ -319,7 +319,7 @@ func TestStoreResponseGuard(t *testing.T) {
 	parsedCert, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
-	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
 
 	status, err := sa.GetCertificateStatus(ctx, core.SerialToString(parsedCert.SerialNumber))
 	test.AssertNotError(t, err, "Failed to get certificate status")

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"crypto/x509"
+	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -283,6 +285,57 @@ func TestMissingReceiptsTick(t *testing.T) {
 	updater.numLogs = 1
 	err = updater.missingReceiptsTick(ctx, 10)
 	test.AssertNotError(t, err, "Failed to run missingReceiptsTick")
+}
+
+/*
+ * Boulder Issue #1872 identified that the `getSerialsIssuedSince` function may
+ * never terminate if there are always new serials added between iterations of
+ * the SQL query loop. In order to unit test the fix we require
+ * a `dbMockAdapter` implementation that will forever return a serial when
+ * queried.
+ */
+type unexhaustableSerialsSelector struct{}
+
+func (s unexhaustableSerialsSelector) Select(output interface{}, _ string, _ ...interface{}) ([]interface{}, error) {
+	outputPtr, ok := output.(*[]string)
+	if !ok {
+		return nil, fmt.Errorf("incorrect output type %T", output)
+	}
+	// Always return one serial regardless of the query
+	*outputPtr = []string{"1234"}
+	return nil, nil
+}
+
+func (s unexhaustableSerialsSelector) Exec(_ string, _ ...interface{}) (sql.Result, error) {
+	return nil, nil // NOP - we don't use this selector anywhere Exec is called
+}
+
+func (s unexhaustableSerialsSelector) SelectOne(_ interface{}, _ string, _ ...interface{}) error {
+	return nil // NOP - we don't use this selector anywhere SelectOne is called
+}
+
+func TestMissingReceiptsTickTerminate(t *testing.T) {
+	updater, _, _, fc, cleanUp := setup(t)
+	defer cleanUp()
+
+	// Replace the dbMap with the unexhaustableSerialsSelector to ensure the
+	// conditions that manifest Issue #1872 are met
+	updater.dbMap = unexhaustableSerialsSelector{}
+	updater.numLogs = 1
+	updater.oldestIssuedSCT = 2 * time.Hour
+
+	// Note: Must use a batch size larger than the # of rows returned by
+	// unexhaustableSerialsSelector or `updater.getSerialsIssuedSince` will never
+	// return
+	batchSize := 5
+
+	serials, err := updater.getSerialsIssuedSince(fc.Now().Add(-2*time.Hour), batchSize)
+	test.AssertNotError(t, err, "Failed to retrieve serials")
+	// Even though the unexhaustableSerialsSelector returns 1 result for every
+	// query, since we abort when results < batchSize the expected behaviour is to
+	// terminate with 1 result, the first fake serial returned for the first
+	// query. No subsequent results are evaluated.
+	test.AssertEquals(t, len(serials), 1)
 }
 
 func TestRevokedCertificatesTick(t *testing.T) {


### PR DESCRIPTION
As documented in Issue #1872 the `getSerialsIssuedSince` `for { }` loop will never terminate under sufficient issuance load. The behaviour prior to this commit would only terminate the loop when `sql.ErrNoRows` or exactly 0 rows were returned by the query. If we sustain sufficient issuance requests that there are always a few certificates issued since the last query the loop will never terminate.

This commit changes the loop behaviour such that rather than terminating when exactly *0* rows are returned, we terminate when a number of rows less than the configured `batchSize` is returned.