### PR TITLE
Add dummy tests for all commands.

### DIFF
--- a/cmd/boulder-publisher/main_test.go
+++ b/cmd/boulder-publisher/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/boulder-ra/main_test.go
+++ b/cmd/boulder-ra/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/boulder-sa/main_test.go
+++ b/cmd/boulder-sa/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/boulder-va/main_test.go
+++ b/cmd/boulder-va/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/boulder-wfe/main_test.go
+++ b/cmd/boulder-wfe/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/single-ocsp/main_test.go
+++ b/cmd/single-ocsp/main_test.go
@@ -1,0 +1,1 @@
+package main


### PR DESCRIPTION
Fixes #799, ensuring that these files at least count towards our coverage numbers and show up on coveralls' "least covered" list. Improving their coverage is part of the overall long-term project of coverage improvement.