### PR TITLE
Implement StripPrefix in wfe

### DIFF
--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -845,8 +845,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 	}
 
 	// Challenge URIs are of the form /acme/challenge/<auth id>/<challenge id>.
-	// Here we parse out the id components. TODO: Use a better tool to parse out
-	// URL structure: https://github.com/letsencrypt/boulder/issues/437
+	// Here we parse out the id components.
 	slug := strings.Split(request.URL.Path, "/")
 	if len(slug) != 2 {
 		notFound()

--- a/wfe/web-front-end.go
+++ b/wfe/web-front-end.go
@@ -133,7 +133,7 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h wfe
 		methodsMap["HEAD"] = true
 	}
 	methodsStr := strings.Join(methods, ", ")
-	mux.Handle(pattern, &topHandler{
+	handler := http.StripPrefix(pattern, &topHandler{
 		log: wfe.log,
 		clk: clock.Default(),
 		wfe: wfeHandlerFunc(func(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
@@ -177,6 +177,7 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h wfe
 			cancel()
 		}),
 	})
+	mux.Handle(pattern, handler)
 }
 
 func marshalIndent(v interface{}) ([]byte, error) {
@@ -326,12 +327,6 @@ func (wfe *WebFrontEndImpl) Directory(ctx context.Context, logEvent *requestEven
 	}
 
 	response.Write(relDir)
-}
-
-// The ID is always the last slash-separated token in the path
-func parseIDFromPath(path string) string {
-	re := regexp.MustCompile("^.*/")
-	return re.ReplaceAllString(path, "")
 }
 
 const (
@@ -852,7 +847,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 	// Challenge URIs are of the form /acme/challenge/<auth id>/<challenge id>.
 	// Here we parse out the id components. TODO: Use a better tool to parse out
 	// URL structure: https://github.com/letsencrypt/boulder/issues/437
-	slug := strings.Split(request.URL.Path[len(challengePath):], "/")
+	slug := strings.Split(request.URL.Path, "/")
 	if len(slug) != 2 {
 		notFound()
 		return
@@ -1040,7 +1035,7 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 
 	// Requests to this handler should have a path that leads to a known
 	// registration
-	idStr := parseIDFromPath(request.URL.Path)
+	idStr := request.URL.Path
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		logEvent.AddError("registration ID must be an integer, was %#v", idStr)
@@ -1106,7 +1101,7 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 // authorizations.
 func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
 	// Requests to this handler should have a path that leads to a known authz
-	id := parseIDFromPath(request.URL.Path)
+	id := request.URL.Path
 	authz, err := wfe.SA.GetAuthorization(ctx, id)
 	if err != nil {
 		logEvent.AddError("No such authorization at id %s", id)
@@ -1152,16 +1147,9 @@ var allHex = regexp.MustCompile("^[0-9a-f]+$")
 // request a reissuance of the certificate.
 func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
 
-	path := request.URL.Path
+	serial := request.URL.Path
 	// Certificate paths consist of the CertBase path, plus exactly sixteen hex
 	// digits.
-	if !strings.HasPrefix(path, certPath) {
-		logEvent.AddError("this request path should not have gotten to Certificate: %#v is not a prefix of %#v", path, certPath)
-		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
-		addNoCacheHeader(response)
-		return
-	}
-	serial := path[len(certPath):]
 	if !core.ValidSerial(serial) {
 		logEvent.AddError("certificate serial provided was not valid: %s", serial)
 		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)


### PR DESCRIPTION
This PR implements `http.StripPrefix` as a wrapper to the existing handler in `wfe.go`. `StripPrefix` is used to remove the path that it expects for each handler. Such as /acme/reg/. The remaining path is used as a slug, since multiple slugs are outside the scope of the specification. 

Several tests bypassed the `mux.Handle()` and called the wrapped handler directly. Ex `Registration`. As a result of this, many tests had to be modified to no longer pass in the full path. `request.URL.Path` should now only ever contain the slug (if there is one).

Fixes #437 