### PR TITLE
WFE returns headers Boulder-Request-ID and Boulder-Requester

### DIFF
--- a/wfe/context.go
+++ b/wfe/context.go
@@ -61,6 +61,7 @@ func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		UserAgent:   r.Header.Get("User-Agent"),
 		Extra:       make(map[string]interface{}, 0),
 	}
+	w.Header().Set("Boulder-Request-ID", logEvent.ID)
 	if r.URL != nil {
 		logEvent.Endpoint = r.URL.String()
 	}

--- a/wfe/context.go
+++ b/wfe/context.go
@@ -65,11 +65,6 @@ func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logEvent.Endpoint = r.URL.String()
 	}
 	defer th.logEvent(logEvent)
-	defer func() {
-		if logEvent.Requester > 0 {
-			w.Header().Set("Boulder-Requester", fmt.Sprintf("%d", logEvent.Requester))
-		}
-	}()
 
 	th.wfe.ServeHTTP(logEvent, w, r)
 }

--- a/wfe/context.go
+++ b/wfe/context.go
@@ -65,6 +65,11 @@ func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logEvent.Endpoint = r.URL.String()
 	}
 	defer th.logEvent(logEvent)
+	defer func() {
+		if logEvent.Requester > 0 {
+			w.Header().Set("Boulder-Requester", fmt.Sprintf("%d", logEvent.Requester))
+		}
+	}()
 
 	th.wfe.ServeHTTP(logEvent, w, r)
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -547,6 +547,7 @@ func link(url, relation string) string {
 func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
 
 	body, key, _, prob := wfe.verifyPOST(ctx, logEvent, request, false, core.ResourceNewReg)
+	addRequesterHeader(response, logEvent.Requester)
 	if prob != nil {
 		// verifyPOST handles its own setting of logEvent.Errors
 		wfe.sendError(response, logEvent, prob, nil)
@@ -555,7 +556,6 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 
 	if existingReg, err := wfe.SA.GetRegistrationByKey(ctx, *key); err == nil {
 		response.Header().Set("Location", wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, existingReg.ID)))
-		addRequesterHeader(response, existingReg.ID)
 		// TODO(#595): check for missing registration err
 		wfe.sendError(response, logEvent, probs.Conflict("Registration key is already in use"), err)
 		return

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -139,8 +139,6 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h wfe
 		log: wfe.log,
 		clk: clock.Default(),
 		wfe: wfeHandlerFunc(func(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
-			response.Header().Set("Boulder-Request-ID", logEvent.ID)
-
 			// We do not propagate errors here, because (1) they should be
 			// transient, and (2) they fail closed.
 			nonce, err := wfe.nonceService.Nonce()

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -110,8 +110,6 @@ func NewWebFrontEndImpl(
 // http.HandleFunc(), but with a wrapper around the handler that
 // provides some generic per-request functionality:
 //
-// * Set a unique tracking header Boulder-Request-ID.
-//
 // * Set a Replay-Nonce header.
 //
 // * Respond to OPTIONS requests, including CORS preflight requests.

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -110,6 +110,8 @@ func NewWebFrontEndImpl(
 // http.HandleFunc(), but with a wrapper around the handler that
 // provides some generic per-request functionality:
 //
+// * Set a unique tracking header Boulder-Request-ID.
+//
 // * Set a Replay-Nonce header.
 //
 // * Respond to OPTIONS requests, including CORS preflight requests.
@@ -137,6 +139,8 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h wfe
 		log: wfe.log,
 		clk: clock.Default(),
 		wfe: wfeHandlerFunc(func(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
+			response.Header().Set("Boulder-Request-ID", logEvent.ID)
+
 			// We do not propagate errors here, because (1) they should be
 			// transient, and (2) they fail closed.
 			nonce, err := wfe.nonceService.Nonce()

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1604,7 +1604,8 @@ func TestHeaderBoulderRequestId(t *testing.T) {
 		URL:    mustParseURL(directoryPath),
 	})
 
-	test.AssertNotEquals(t, responseWriter.Header().Get("Boulder-Request-ID"), "")
+	requestID := responseWriter.Header().Get("Boulder-Request-ID")
+	test.Assert(t, len(requestID) > 0, "Boulder-Request-ID header is empty")
 }
 
 func TestHeaderBoulderRequester(t *testing.T) {

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1592,3 +1592,41 @@ func TestVerifyPOSTInvalidJWK(t *testing.T) {
 	test.AssertEquals(t, probs.MalformedProblem, prob.Type)
 	test.AssertEquals(t, http.StatusBadRequest, prob.HTTPStatus)
 }
+
+func TestHeaderBoulderRequestId(t *testing.T) {
+	wfe, _ := setupWFE(t)
+	mux, err := wfe.Handler()
+	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	responseWriter := httptest.NewRecorder()
+
+	mux.ServeHTTP(responseWriter, &http.Request{
+		Method: "GET",
+		URL:    mustParseURL(directoryPath),
+	})
+
+	id := responseWriter.Header().Get("Boulder-Request-ID")
+	test.AssertNotEquals(t, id, "")
+}
+
+func TestHeaderBoulderRequester(t *testing.T) {
+	wfe, _ := setupWFE(t)
+	mux, err := wfe.Handler()
+	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	responseWriter := httptest.NewRecorder()
+
+	// create a signed request
+	key, err := jose.LoadPrivateKey([]byte(test1KeyPrivatePEM))
+	test.AssertNotError(t, err, "Failed to load key")
+	rsaKey, ok := key.(*rsa.PrivateKey)
+	test.Assert(t, ok, "Couldn't load RSA key")
+	signer, err := jose.NewSigner("RS256", rsaKey)
+	test.AssertNotError(t, err, "Failed to make signer")
+
+	signer.SetNonceSource(wfe.nonceService)
+	result, err := signer.Sign([]byte(`{"resource":"reg","agreement":"` + agreementURL + `"}`))
+
+	request := makePostRequestWithPath(regPath+"1", result.FullSerialize())
+	mux.ServeHTTP(responseWriter, request)
+
+	test.AssertEquals(t, responseWriter.Header().Get("Boulder-Requester"), "1")
+}

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1604,8 +1604,8 @@ func TestHeaderBoulderRequestId(t *testing.T) {
 		URL:    mustParseURL(directoryPath),
 	})
 
-	id := responseWriter.Header().Get("Boulder-Request-ID")
-	test.AssertNotEquals(t, id, "")
+	test.AssertNotEquals(t, responseWriter.Header().Get("Boulder-Request-ID"), "")
+	test.AssertEquals(t, responseWriter.Header().Get("Boulder-Requester"), "")
 }
 
 func TestHeaderBoulderRequester(t *testing.T) {
@@ -1629,4 +1629,5 @@ func TestHeaderBoulderRequester(t *testing.T) {
 	mux.ServeHTTP(responseWriter, request)
 
 	test.AssertEquals(t, responseWriter.Header().Get("Boulder-Requester"), "1")
+	test.AssertNotEquals(t, responseWriter.Header().Get("Boulder-Request-ID"), "")
 }


### PR DESCRIPTION
In this PR, two additional HTTP headers are added to aid in external error reporting and log analysis. 

1. Every response, apart from the path "/", contains a unique Boulder-Request-ID. 
2. Where present, the response will contain the registration ID in the header Boulder-Requester.

Fixes #1884 