### PR TITLE
Optimize the locking strategy used in NonceService and stop using math/big

### DIFF
--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -5,8 +5,8 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
-	"math/big"
 	"sync"
 	"sync/atomic"
 )
@@ -65,9 +65,7 @@ func (ns *NonceService) encrypt(counter int64) (string, error) {
 
 	// Encode counter to plaintext
 	pt := make([]byte, 8)
-	ctr := big.NewInt(counter)
-	pad := 8 - len(ctr.Bytes())
-	copy(pt[pad:], ctr.Bytes())
+	binary.BigEndian.PutUint64(pt, uint64(counter))
 
 	// Encrypt
 	ret := make([]byte, nonceLen)
@@ -97,9 +95,7 @@ func (ns *NonceService) decrypt(nonce string) (int64, error) {
 		return 0, err
 	}
 
-	ctr := big.NewInt(0)
-	ctr.SetBytes(pt)
-	return ctr.Int64(), nil
+	return int64(binary.BigEndian.Uint64(pt)), nil
 }
 
 // Nonce provides a new Nonce.
@@ -110,7 +106,7 @@ func (ns *NonceService) Nonce() (string, error) {
 // minUsed returns the lowest key in the used map. Requires that a lock be held
 // by caller.
 func (ns *NonceService) minUsed() int64 {
-	min := ns.latest
+	min := atomic.LoadInt64(&ns.latest)
 	for t := range ns.used {
 		if t < min {
 			min = t
@@ -127,12 +123,11 @@ func (ns *NonceService) Valid(nonce string) bool {
 		return false
 	}
 
-	latest, earliest := atomic.LoadInt64(&ns.latest), atomic.LoadInt64(&ns.earliest)
-	if c > latest {
+	if c > atomic.LoadInt64(&ns.latest) {
 		return false
 	}
 
-	if c <= earliest {
+	if c <= atomic.LoadInt64(&ns.earliest) {
 		return false
 	}
 
@@ -147,8 +142,9 @@ func (ns *NonceService) Valid(nonce string) bool {
 	defer ns.mu.Unlock()
 	ns.used[c] = true
 	if len(ns.used) > ns.maxUsed {
-		ns.earliest = ns.minUsed()
-		delete(ns.used, ns.earliest)
+		earliest := ns.minUsed()
+		atomic.StoreInt64(&ns.earliest, earliest)
+		delete(ns.used, earliest)
 	}
 
 	return true

--- a/nonce/nonce_test.go
+++ b/nonce/nonce_test.go
@@ -79,3 +79,47 @@ func TestRejectTooEarly(t *testing.T) {
 	test.Assert(t, ns.Valid(n1), "Rejected a valid nonce")
 	test.Assert(t, !ns.Valid(n0), "Accepted a nonce that we should have forgotten")
 }
+
+func BenchmarkNonce(b *testing.B) {
+	ns, err := NewNonceService()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := ns.Nonce()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkValid(b *testing.B) {
+	ns, err := NewNonceService()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// fill map + gather test nonces
+	testNonces := []string{}
+	for i := 0; i < MaxUsed; i++ {
+		nonce, err := ns.Nonce()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if i < 100 {
+			testNonces = append(testNonces, nonce)
+		}
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			ns.Valid(testNonces[i%100])
+			i++
+		}
+	})
+}

--- a/nonce/nonce_test.go
+++ b/nonce/nonce_test.go
@@ -86,6 +86,14 @@ func BenchmarkNonce(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	// fill map
+	for i := 0; i < MaxUsed; i++ {
+		_, err := ns.Nonce()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			_, err := ns.Nonce()


### PR DESCRIPTION
Updates #1219 and adds two benchmarks, could use a serious once over.

`master`

```
$ go test -bench=. -cpu 8 -test.benchmem
PASS
BenchmarkNonce-8	  500000	      2606 ns/op	     283 B/op	      10 allocs/op
BenchmarkValid-8	 1000000	      1020 ns/op	     200 B/op	       6 allocs/op
ok  	github.com/letsencrypt/boulder/nonce	3.918s
```

`e9501b5`

```
$ go test -bench=. -cpu 8 -test.benchmem
PASS
BenchmarkNonce-8	  500000	      2261 ns/op	     174 B/op	       5 allocs/op
BenchmarkValid-8	 3000000	       429 ns/op	     120 B/op	       4 allocs/op
ok  	github.com/letsencrypt/boulder/nonce	3.949s
```