### PR TITLE
Replace all log.Err calls with log.AuditErr

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -228,7 +228,7 @@ func (cpc *CachePurgeClient) Purge(urls []string) error {
 		err := cpc.purge(urls)
 		if err != nil {
 			if _, ok := err.(errFatal); ok {
-				cpc.log.AuditErr(err)
+				cpc.log.AuditErr(err.Error())
 				cpc.stats.Inc("CCU.FatalFailures", 1, 1.0)
 				return err
 			}

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -340,7 +340,7 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, xferObj co
 	cert, err := x509.ParseCertificate(xferObj.CertDER)
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		ca.log.AuditErr(err)
+		ca.log.AuditErr(err.Error())
 		return nil, err
 	}
 
@@ -378,7 +378,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 
 	if err := csrlib.VerifyCSR(&csr, ca.maxNames, &ca.keyPolicy, ca.PA, ca.forceCNFromSAN, regID); err != nil {
 		// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
-		ca.log.AuditErr(err)
+		ca.log.AuditErr(err.Error())
 		return emptyCert, core.MalformedRequestError(err.Error())
 	}
 
@@ -393,7 +393,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	if issuer.cert.NotAfter.Before(notAfter) {
 		err = core.InternalServerError("Cannot issue a certificate that expires after the issuer certificate.")
 		// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
-		ca.log.AuditErr(err)
+		ca.log.AuditErr(err.Error())
 		return emptyCert, err
 	}
 
@@ -411,7 +411,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	if err != nil {
 		err = core.InternalServerError(err.Error())
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		ca.log.AuditErr(fmt.Errorf("Serial randomness failed, err=[%v]", err))
+		ca.log.AuditErr(fmt.Sprintf("Serial randomness failed, err=[%v]", err))
 		return emptyCert, err
 	}
 	serialBigInt := big.NewInt(0)
@@ -427,7 +427,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	default:
 		err = core.InternalServerError(fmt.Sprintf("unsupported key type %T", csr.PublicKey))
 		// AUDIT[ Certificate Requests ] 11917fa4-10ef-4e0d-9105-bacbe7836a3c
-		ca.log.AuditErr(err)
+		ca.log.AuditErr(err.Error())
 		return emptyCert, err
 	}
 
@@ -454,7 +454,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	if err != nil {
 		err = core.InternalServerError(err.Error())
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		ca.log.AuditErr(fmt.Errorf("Signing failed: serial=[%s] err=[%v]", serialHex, err))
+		ca.log.AuditErr(fmt.Sprintf("Signing failed: serial=[%s] err=[%v]", serialHex, err))
 		return emptyCert, err
 	}
 
@@ -465,7 +465,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	if len(certPEM) == 0 {
 		err = core.InternalServerError("No certificate returned by server")
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		ca.log.AuditErr(fmt.Errorf("PEM empty from Signer: serial=[%s] err=[%v]", serialHex, err))
+		ca.log.AuditErr(fmt.Sprintf("PEM empty from Signer: serial=[%s] err=[%v]", serialHex, err))
 		return emptyCert, err
 	}
 
@@ -473,7 +473,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	if block == nil || block.Type != "CERTIFICATE" {
 		err = core.InternalServerError("Invalid certificate value returned")
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		ca.log.AuditErr(fmt.Errorf("PEM decode error, aborting: serial=[%s] pem=[%s] err=[%v]",
+		ca.log.AuditErr(fmt.Sprintf("PEM decode error, aborting: serial=[%s] pem=[%s] err=[%v]",
 			serialHex, certPEM, err))
 		return emptyCert, err
 	}
@@ -487,7 +487,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	if err != nil {
 		err = core.InternalServerError(err.Error())
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		ca.log.AuditErr(fmt.Errorf("Uncaught error, aborting: serial=[%s] pem=[%s] err=[%v]",
+		ca.log.AuditErr(fmt.Sprintf("Uncaught error, aborting: serial=[%s] pem=[%s] err=[%v]",
 			serialHex, certPEM, err))
 		return emptyCert, err
 	}
@@ -497,7 +497,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	if err != nil {
 		err = core.InternalServerError(err.Error())
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		ca.log.AuditErr(fmt.Errorf(
+		ca.log.AuditErr(fmt.Sprintf(
 			"Failed RPC to store at SA, orphaning certificate: serial=[%s] b64der=[%s] err=[%v], regID=[%d]",
 			serialHex,
 			base64.StdEncoding.EncodeToString(certDER),

--- a/cdr/resolver.go
+++ b/cdr/resolver.go
@@ -206,7 +206,7 @@ func (cdr *CAADistributedResolver) LookupCAA(ctx context.Context, domain string)
 			cdr.stats.TimingDuration(fmt.Sprintf("CDR.GPDNS.Latency.%s", ia), time.Since(started))
 			if err != nil {
 				cdr.stats.Inc(fmt.Sprintf("CDR.GPDNS.Failures.%s", ia), 1)
-				cdr.logger.AuditErr(fmt.Errorf("queryCAA failed [via %s]: %s", ia, err))
+				cdr.logger.AuditErr(fmt.Sprintf("queryCAA failed [via %s]: %s", ia, err))
 			}
 			results <- queryResult{records, err}
 		}(interfaceClient, addr)
@@ -222,7 +222,7 @@ func (cdr *CAADistributedResolver) LookupCAA(ctx context.Context, domain string)
 			failed++
 			if failed > cdr.maxFailures {
 				cdr.stats.Inc("CDR.QuorumFailed", 1)
-				cdr.logger.AuditErr(fmt.Errorf("%d out of %d CAA queries failed", len(cdr.Clients), failed))
+				cdr.logger.AuditErr(fmt.Sprintf("%d out of %d CAA queries failed", len(cdr.Clients), failed))
 				return nil, r.err
 			}
 		}

--- a/cdr/resolver.go
+++ b/cdr/resolver.go
@@ -206,7 +206,7 @@ func (cdr *CAADistributedResolver) LookupCAA(ctx context.Context, domain string)
 			cdr.stats.TimingDuration(fmt.Sprintf("CDR.GPDNS.Latency.%s", ia), time.Since(started))
 			if err != nil {
 				cdr.stats.Inc(fmt.Sprintf("CDR.GPDNS.Failures.%s", ia), 1)
-				cdr.logger.Err(fmt.Sprintf("queryCAA failed [via %s]: %s", ia, err))
+				cdr.logger.AuditErr(fmt.Errorf("queryCAA failed [via %s]: %s", ia, err))
 			}
 			results <- queryResult{records, err}
 		}(interfaceClient, addr)
@@ -222,7 +222,7 @@ func (cdr *CAADistributedResolver) LookupCAA(ctx context.Context, domain string)
 			failed++
 			if failed > cdr.maxFailures {
 				cdr.stats.Inc("CDR.QuorumFailed", 1)
-				cdr.logger.Err(fmt.Sprintf("%d out of %d CAA queries failed", len(cdr.Clients), failed))
+				cdr.logger.AuditErr(fmt.Errorf("%d out of %d CAA queries failed", len(cdr.Clients), failed))
 				return nil, r.err
 			}
 		}

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"os"
 
 	ct "github.com/google/certificate-transparency/go"
@@ -29,7 +28,7 @@ func main() {
 		}
 
 		if c.Common.CT.IntermediateBundleFilename == "" {
-			logger.AuditErr(errors.New("No CT submission bundle provided"))
+			logger.AuditErr("No CT submission bundle provided")
 			os.Exit(1)
 		}
 		pemBundle, err := core.LoadCertBundle(c.Common.CT.IntermediateBundleFilename)

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	ct "github.com/google/certificate-transparency/go"
@@ -28,7 +29,7 @@ func main() {
 		}
 
 		if c.Common.CT.IntermediateBundleFilename == "" {
-			logger.Err("No CT submission bundle provided")
+			logger.AuditErr(errors.New("No CT submission bundle provided"))
 			os.Exit(1)
 		}
 		pemBundle, err := core.LoadCertBundle(c.Common.CT.IntermediateBundleFilename)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -114,14 +114,14 @@ func (m *mailer) updateCertStatus(serial string) error {
 	tx, err := m.dbMap.Begin()
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.AuditErr(fmt.Errorf("Error opening transaction for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Sprintf("Error opening transaction for certificate %s: %s", serial, err))
 		return err
 	}
 
 	csObj, err := tx.Get(&core.CertificateStatus{}, serial)
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.AuditErr(fmt.Errorf("Error fetching status for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Sprintf("Error fetching status for certificate %s: %s", serial, err))
 		return err
 	}
 	certStatus := csObj.(*core.CertificateStatus)
@@ -130,14 +130,14 @@ func (m *mailer) updateCertStatus(serial string) error {
 	_, err = tx.Update(certStatus)
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.AuditErr(fmt.Errorf("Error updating status for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Sprintf("Error updating status for certificate %s: %s", serial, err))
 		return err
 	}
 
 	err = tx.Commit()
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.AuditErr(fmt.Errorf("Error committing transaction for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Sprintf("Error committing transaction for certificate %s: %s", serial, err))
 		return err
 	}
 
@@ -173,7 +173,7 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 	for regID, certs := range regIDToCerts {
 		reg, err := m.rs.GetRegistration(ctx, regID)
 		if err != nil {
-			m.log.AuditErr(fmt.Errorf("Error fetching registration %d: %s", regID, err))
+			m.log.AuditErr(fmt.Sprintf("Error fetching registration %d: %s", regID, err))
 			m.stats.Inc("Mailer.Expiration.Errors.GetRegistration", 1, 1.0)
 			continue
 		}
@@ -183,14 +183,14 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 			parsedCert, err := x509.ParseCertificate(cert.DER)
 			if err != nil {
 				// TODO(#1420): tell registration about this error
-				m.log.AuditErr(fmt.Errorf("Error parsing certificate %s: %s", cert.Serial, err))
+				m.log.AuditErr(fmt.Sprintf("Error parsing certificate %s: %s", cert.Serial, err))
 				m.stats.Inc("Mailer.Expiration.Errors.ParseCertificate", 1, 1.0)
 				continue
 			}
 
 			renewed, err := m.certIsRenewed(cert.Serial)
 			if err != nil {
-				m.log.AuditErr(fmt.Errorf("expiration-mailer: error fetching renewal state: %v", err))
+				m.log.AuditErr(fmt.Sprintf("expiration-mailer: error fetching renewal state: %v", err))
 				// assume not renewed
 			} else if renewed {
 				m.stats.Inc("Mailer.Expiration.Renewed", 1, 1.0)
@@ -207,14 +207,14 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 
 		err = m.sendNags(reg.Contact, parsedCerts)
 		if err != nil {
-			m.log.AuditErr(fmt.Errorf("Error sending nag emails: %s", err))
+			m.log.AuditErr(fmt.Sprintf("Error sending nag emails: %s", err))
 			continue
 		}
 		for _, cert := range parsedCerts {
 			serial := core.SerialToString(cert.SerialNumber)
 			err = m.updateCertStatus(serial)
 			if err != nil {
-				m.log.AuditErr(fmt.Errorf("Error updating certificate status for %s: %s", serial, err))
+				m.log.AuditErr(fmt.Sprintf("Error updating certificate status for %s: %s", serial, err))
 				m.stats.Inc("Mailer.Expiration.Errors.UpdateCertificateStatus", 1, 1.0)
 				continue
 			}
@@ -255,7 +255,7 @@ func (m *mailer) findExpiringCertificates() error {
 			},
 		)
 		if err != nil {
-			m.log.AuditErr(fmt.Errorf("expiration-mailer: Error loading certificates: %s", err))
+			m.log.AuditErr(fmt.Sprintf("expiration-mailer: Error loading certificates: %s", err))
 			return err // fatal
 		}
 
@@ -340,7 +340,7 @@ func main() {
 		if s := c.Mailer.NagCheckInterval; s != "" {
 			nagCheckInterval, err = time.ParseDuration(s)
 			if err != nil {
-				logger.AuditErr(fmt.Errorf("Failed to parse NagCheckInterval string %q: %s", s, err))
+				logger.AuditErr(fmt.Sprintf("Failed to parse NagCheckInterval string %q: %s", s, err))
 				return
 			}
 		}
@@ -349,7 +349,7 @@ func main() {
 		for _, nagDuration := range c.Mailer.NagTimes {
 			dur, err := time.ParseDuration(nagDuration)
 			if err != nil {
-				logger.AuditErr(fmt.Errorf("Failed to parse nag duration string [%s]: %s", nagDuration, err))
+				logger.AuditErr(fmt.Sprintf("Failed to parse nag duration string [%s]: %s", nagDuration, err))
 				return
 			}
 			nags = append(nags, dur+nagCheckInterval)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -340,7 +340,7 @@ func main() {
 		if s := c.Mailer.NagCheckInterval; s != "" {
 			nagCheckInterval, err = time.ParseDuration(s)
 			if err != nil {
-				logger.Err(fmt.Sprintf("Failed to parse NagCheckInterval string %q: %s", s, err))
+				logger.AuditErr(fmt.Errorf("Failed to parse NagCheckInterval string %q: %s", s, err))
 				return
 			}
 		}
@@ -349,7 +349,7 @@ func main() {
 		for _, nagDuration := range c.Mailer.NagTimes {
 			dur, err := time.ParseDuration(nagDuration)
 			if err != nil {
-				logger.Err(fmt.Sprintf("Failed to parse nag duration string [%s]: %s", nagDuration, err))
+				logger.AuditErr(fmt.Errorf("Failed to parse nag duration string [%s]: %s", nagDuration, err))
 				return
 			}
 			nags = append(nags, dur+nagCheckInterval)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -114,14 +114,14 @@ func (m *mailer) updateCertStatus(serial string) error {
 	tx, err := m.dbMap.Begin()
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.Err(fmt.Sprintf("Error opening transaction for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Errorf("Error opening transaction for certificate %s: %s", serial, err))
 		return err
 	}
 
 	csObj, err := tx.Get(&core.CertificateStatus{}, serial)
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.Err(fmt.Sprintf("Error fetching status for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Errorf("Error fetching status for certificate %s: %s", serial, err))
 		return err
 	}
 	certStatus := csObj.(*core.CertificateStatus)
@@ -130,14 +130,14 @@ func (m *mailer) updateCertStatus(serial string) error {
 	_, err = tx.Update(certStatus)
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.Err(fmt.Sprintf("Error updating status for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Errorf("Error updating status for certificate %s: %s", serial, err))
 		return err
 	}
 
 	err = tx.Commit()
 	if err != nil {
 		err = sa.Rollback(tx, err)
-		m.log.Err(fmt.Sprintf("Error committing transaction for certificate %s: %s", serial, err))
+		m.log.AuditErr(fmt.Errorf("Error committing transaction for certificate %s: %s", serial, err))
 		return err
 	}
 
@@ -173,7 +173,7 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 	for regID, certs := range regIDToCerts {
 		reg, err := m.rs.GetRegistration(ctx, regID)
 		if err != nil {
-			m.log.Err(fmt.Sprintf("Error fetching registration %d: %s", regID, err))
+			m.log.AuditErr(fmt.Errorf("Error fetching registration %d: %s", regID, err))
 			m.stats.Inc("Mailer.Expiration.Errors.GetRegistration", 1, 1.0)
 			continue
 		}
@@ -183,14 +183,14 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 			parsedCert, err := x509.ParseCertificate(cert.DER)
 			if err != nil {
 				// TODO(#1420): tell registration about this error
-				m.log.Err(fmt.Sprintf("Error parsing certificate %s: %s", cert.Serial, err))
+				m.log.AuditErr(fmt.Errorf("Error parsing certificate %s: %s", cert.Serial, err))
 				m.stats.Inc("Mailer.Expiration.Errors.ParseCertificate", 1, 1.0)
 				continue
 			}
 
 			renewed, err := m.certIsRenewed(cert.Serial)
 			if err != nil {
-				m.log.Err(fmt.Sprintf("expiration-mailer: error fetching renewal state: %v", err))
+				m.log.AuditErr(fmt.Errorf("expiration-mailer: error fetching renewal state: %v", err))
 				// assume not renewed
 			} else if renewed {
 				m.stats.Inc("Mailer.Expiration.Renewed", 1, 1.0)
@@ -207,14 +207,14 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 
 		err = m.sendNags(reg.Contact, parsedCerts)
 		if err != nil {
-			m.log.Err(fmt.Sprintf("Error sending nag emails: %s", err))
+			m.log.AuditErr(fmt.Errorf("Error sending nag emails: %s", err))
 			continue
 		}
 		for _, cert := range parsedCerts {
 			serial := core.SerialToString(cert.SerialNumber)
 			err = m.updateCertStatus(serial)
 			if err != nil {
-				m.log.Err(fmt.Sprintf("Error updating certificate status for %s: %s", serial, err))
+				m.log.AuditErr(fmt.Errorf("Error updating certificate status for %s: %s", serial, err))
 				m.stats.Inc("Mailer.Expiration.Errors.UpdateCertificateStatus", 1, 1.0)
 				continue
 			}
@@ -255,7 +255,7 @@ func (m *mailer) findExpiringCertificates() error {
 			},
 		)
 		if err != nil {
-			m.log.Err(fmt.Sprintf("expiration-mailer: Error loading certificates: %s", err))
+			m.log.AuditErr(fmt.Errorf("expiration-mailer: Error loading certificates: %s", err))
 			return err // fatal
 		}
 

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -88,7 +88,7 @@ func (src *DBSource) Response(req *ocsp.Request) ([]byte, bool) {
 		map[string]interface{}{"serial": serialString},
 	)
 	if err != nil && err != sql.ErrNoRows {
-		src.log.AuditErr(fmt.Errorf("Failed to retrieve response from certificateStatus table: %s", err))
+		src.log.AuditErr(fmt.Sprintf("Failed to retrieve response from certificateStatus table: %s", err))
 	}
 	if err != nil {
 		return nil, false

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -88,7 +88,7 @@ func (src *DBSource) Response(req *ocsp.Request) ([]byte, bool) {
 		map[string]interface{}{"serial": serialString},
 	)
 	if err != nil && err != sql.ErrNoRows {
-		src.log.Err(fmt.Sprintf("Failed to retrieve response from certificateStatus table: %s", err))
+		src.log.AuditErr(fmt.Errorf("Failed to retrieve response from certificateStatus table: %s", err))
 	}
 	if err != nil {
 		return nil, false

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -62,12 +62,12 @@ func parseLogLine(sa certificateStorage, logger blog.Logger, line string) (found
 	}
 	derStr := b64derOrphan.FindStringSubmatch(line)
 	if len(derStr) <= 1 {
-		logger.Err(fmt.Sprintf("Didn't match regex for b64der: %s", line))
+		logger.AuditErr(fmt.Errorf("Didn't match regex for b64der: %s", line))
 		return true, false
 	}
 	der, err := base64.StdEncoding.DecodeString(derStr[1])
 	if err != nil {
-		logger.Err(fmt.Sprintf("Couldn't decode b64: %s, [%s]", err, line))
+		logger.AuditErr(fmt.Errorf("Couldn't decode b64: %s, [%s]", err, line))
 		return true, false
 	}
 	err = checkDER(sa, der)
@@ -82,17 +82,17 @@ func parseLogLine(sa certificateStorage, logger blog.Logger, line string) (found
 	// extract the regID
 	regStr := regOrphan.FindStringSubmatch(line)
 	if len(regStr) <= 1 {
-		logger.Err(fmt.Sprintf("regID variable is empty, [%s]", line))
+		logger.AuditErr(fmt.Errorf("regID variable is empty, [%s]", line))
 		return true, false
 	}
 	regID, err := strconv.Atoi(regStr[1])
 	if err != nil {
-		logger.Err(fmt.Sprintf("Couldn't parse regID: %s, [%s]", err, line))
+		logger.AuditErr(fmt.Errorf("Couldn't parse regID: %s, [%s]", err, line))
 		return true, false
 	}
 	_, err = sa.AddCertificate(ctx, der, int64(regID))
 	if err != nil {
-		logger.Err(fmt.Sprintf("Failed to store certificate: %s, [%s]", err, line))
+		logger.AuditErr(fmt.Errorf("Failed to store certificate: %s, [%s]", err, line))
 		return true, false
 	}
 	return true, true

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -62,12 +62,12 @@ func parseLogLine(sa certificateStorage, logger blog.Logger, line string) (found
 	}
 	derStr := b64derOrphan.FindStringSubmatch(line)
 	if len(derStr) <= 1 {
-		logger.AuditErr(fmt.Errorf("Didn't match regex for b64der: %s", line))
+		logger.AuditErr(fmt.Sprintf("Didn't match regex for b64der: %s", line))
 		return true, false
 	}
 	der, err := base64.StdEncoding.DecodeString(derStr[1])
 	if err != nil {
-		logger.AuditErr(fmt.Errorf("Couldn't decode b64: %s, [%s]", err, line))
+		logger.AuditErr(fmt.Sprintf("Couldn't decode b64: %s, [%s]", err, line))
 		return true, false
 	}
 	err = checkDER(sa, der)
@@ -82,17 +82,17 @@ func parseLogLine(sa certificateStorage, logger blog.Logger, line string) (found
 	// extract the regID
 	regStr := regOrphan.FindStringSubmatch(line)
 	if len(regStr) <= 1 {
-		logger.AuditErr(fmt.Errorf("regID variable is empty, [%s]", line))
+		logger.AuditErr(fmt.Sprintf("regID variable is empty, [%s]", line))
 		return true, false
 	}
 	regID, err := strconv.Atoi(regStr[1])
 	if err != nil {
-		logger.AuditErr(fmt.Errorf("Couldn't parse regID: %s, [%s]", err, line))
+		logger.AuditErr(fmt.Sprintf("Couldn't parse regID: %s, [%s]", err, line))
 		return true, false
 	}
 	_, err = sa.AddCertificate(ctx, der, int64(regID))
 	if err != nil {
-		logger.AuditErr(fmt.Errorf("Failed to store certificate: %s, [%s]", err, line))
+		logger.AuditErr(fmt.Sprintf("Failed to store certificate: %s, [%s]", err, line))
 		return true, false
 	}
 	return true, true

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -157,7 +157,7 @@ type mysqlLogger struct {
 }
 
 func (m mysqlLogger) Print(v ...interface{}) {
-	m.AuditErr(fmt.Errorf("[mysql] %s", fmt.Sprint(v...)))
+	m.AuditErr(fmt.Sprintf("[mysql] %s", fmt.Sprint(v...)))
 }
 
 // cfsslLogger provides two additional methods that are expected by CFSSL's
@@ -167,11 +167,11 @@ type cfsslLogger struct {
 }
 
 func (cl cfsslLogger) Crit(msg string) {
-	cl.AuditErr(errors.New(msg))
+	cl.AuditErr(msg)
 }
 
 func (cl cfsslLogger) Emerg(msg string) {
-	cl.AuditErr(errors.New(msg))
+	cl.AuditErr(msg)
 }
 
 // StatsAndLogging constructs a Statter and an AuditLogger based on its config
@@ -216,7 +216,7 @@ func FailOnError(err error, msg string) {
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		logger := blog.Get()
-		logger.AuditErr(fmt.Errorf("%s: %s", msg, err))
+		logger.AuditErr(fmt.Sprintf("%s: %s", msg, err))
 		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
 		os.Exit(1)
 	}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -157,7 +157,7 @@ type mysqlLogger struct {
 }
 
 func (m mysqlLogger) Print(v ...interface{}) {
-	m.Err(fmt.Sprintf("[mysql] %s", fmt.Sprint(v...)))
+	m.AuditErr(fmt.Errorf("[mysql] %s", fmt.Sprint(v...)))
 }
 
 // cfsslLogger provides two additional methods that are expected by CFSSL's
@@ -167,11 +167,11 @@ type cfsslLogger struct {
 }
 
 func (cl cfsslLogger) Crit(msg string) {
-	cl.Err(msg)
+	cl.AuditErr(errors.New(msg))
 }
 
 func (cl cfsslLogger) Emerg(msg string) {
-	cl.Err(msg)
+	cl.AuditErr(errors.New(msg))
 }
 
 // StatsAndLogging constructs a Statter and an AuditLogger based on its config
@@ -216,7 +216,7 @@ func FailOnError(err error, msg string) {
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
 		logger := blog.Get()
-		logger.Err(fmt.Sprintf("%s: %s", msg, err))
+		logger.AuditErr(fmt.Errorf("%s: %s", msg, err))
 		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
 		os.Exit(1)
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -25,7 +25,7 @@ type Logger interface {
 	AuditPanic()
 	AuditInfo(string)
 	AuditObject(string, interface{})
-	AuditErr(error)
+	AuditErr(string)
 }
 
 // impl implements Logger.
@@ -185,10 +185,10 @@ func caller(level int) string {
 func (log *impl) AuditPanic() {
 	if err := recover(); err != nil {
 		buf := make([]byte, 8192)
-		log.AuditErr(fmt.Errorf("Panic caused by err: %s", err))
+		log.AuditErr(fmt.Sprintf("Panic caused by err: %s", err))
 
 		runtime.Stack(buf, false)
-		log.AuditErr(fmt.Errorf("Stack Trace (Current frame) %s", buf))
+		log.AuditErr(fmt.Sprintf("Stack Trace (Current frame) %s", buf))
 
 		runtime.Stack(buf, true)
 		log.Warning(fmt.Sprintf("Stack Trace (All frames): %s", buf))
@@ -237,6 +237,6 @@ func (log *impl) AuditObject(msg string, obj interface{}) {
 
 // AuditErr can format an error for auditing; it does so at ERR level.
 // AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-func (log *impl) AuditErr(msg error) {
-	log.auditAtLevel(syslog.LOG_ERR, msg.Error())
+func (log *impl) AuditErr(msg string) {
+	log.auditAtLevel(syslog.LOG_ERR, msg)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"errors"
 	"fmt"
 	"log/syslog"
 	"net"
@@ -90,7 +89,7 @@ func ExampleLogger() {
 		return
 	}
 	bw.clk = clock.NewFake()
-	impl.AuditErr(errors.New("Error Audit"))
+	impl.AuditErr("Error Audit")
 	impl.Warning("Warning Audit")
 	// Output:
 	// [31m[1mE000000 log.test [AUDIT] Error Audit[0m
@@ -102,7 +101,7 @@ func TestSyslogMethods(t *testing.T) {
 	impl := setup(t)
 
 	impl.AuditInfo("audit-logger_test.go: audit-info")
-	impl.AuditErr(errors.New("audit-logger_test.go: audit-err"))
+	impl.AuditErr("audit-logger_test.go: audit-err")
 	impl.Debug("audit-logger_test.go: debug")
 	impl.Err("audit-logger_test.go: err")
 	impl.Info("audit-logger_test.go: info")
@@ -183,7 +182,7 @@ func TestTransmission(t *testing.T) {
 	_, _, err = l.ReadFrom(data)
 	test.AssertNotError(t, err, "Failed to find packet")
 
-	impl.AuditErr(errors.New("audit-logger_test.go: audit-err"))
+	impl.AuditErr("audit-logger_test.go: audit-err")
 	_, _, err = l.ReadFrom(data)
 	test.AssertNotError(t, err, "Failed to find packet")
 

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -58,7 +58,7 @@ func (pa *AuthorityImpl) SetHostnamePolicyFile(f string) error {
 }
 
 func (pa *AuthorityImpl) hostnamePolicyLoadError(err error) {
-	pa.log.Err(fmt.Sprintf("error loading hostname policy: %s", err))
+	pa.log.AuditErr(fmt.Errorf("error loading hostname policy: %s", err))
 }
 
 func (pa *AuthorityImpl) loadHostnamePolicy(b []byte) error {

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -58,7 +58,7 @@ func (pa *AuthorityImpl) SetHostnamePolicyFile(f string) error {
 }
 
 func (pa *AuthorityImpl) hostnamePolicyLoadError(err error) {
-	pa.log.AuditErr(fmt.Errorf("error loading hostname policy: %s", err))
+	pa.log.AuditErr(fmt.Sprintf("error loading hostname policy: %s", err))
 }
 
 func (pa *AuthorityImpl) loadHostnamePolicy(b []byte) error {

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -81,7 +81,7 @@ func New(bundle []ct.ASN1Cert, logs []*Log, submissionTimeout time.Duration, log
 func (pub *Impl) SubmitToCT(ctx context.Context, der []byte) error {
 	cert, err := x509.ParseCertificate(der)
 	if err != nil {
-		pub.log.Err(fmt.Sprintf("Failed to parse certificate: %s", err))
+		pub.log.AuditErr(fmt.Errorf("Failed to parse certificate: %s", err))
 		return err
 	}
 
@@ -92,7 +92,7 @@ func (pub *Impl) SubmitToCT(ctx context.Context, der []byte) error {
 		sct, err := ctLog.client.AddChainWithContext(localCtx, chain)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.Err(fmt.Sprintf("Failed to submit certificate to CT log at %s: %s", ctLog.uri, err))
+			pub.log.AuditErr(fmt.Errorf("Failed to submit certificate to CT log at %s: %s", ctLog.uri, err))
 			continue
 		}
 
@@ -107,21 +107,21 @@ func (pub *Impl) SubmitToCT(ctx context.Context, der []byte) error {
 		})
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.Err(fmt.Sprintf("Failed to verify SCT receipt: %s", err))
+			pub.log.AuditErr(fmt.Errorf("Failed to verify SCT receipt: %s", err))
 			continue
 		}
 
 		internalSCT, err := sctToInternal(sct, core.SerialToString(cert.SerialNumber))
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.Err(fmt.Sprintf("Failed to convert SCT receipt: %s", err))
+			pub.log.AuditErr(fmt.Errorf("Failed to convert SCT receipt: %s", err))
 			continue
 		}
 
 		err = pub.SA.AddSCTReceipt(localCtx, internalSCT)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.Err(fmt.Sprintf("Failed to store SCT receipt in database: %s", err))
+			pub.log.AuditErr(fmt.Errorf("Failed to store SCT receipt in database: %s", err))
 			continue
 		}
 	}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -81,7 +81,7 @@ func New(bundle []ct.ASN1Cert, logs []*Log, submissionTimeout time.Duration, log
 func (pub *Impl) SubmitToCT(ctx context.Context, der []byte) error {
 	cert, err := x509.ParseCertificate(der)
 	if err != nil {
-		pub.log.AuditErr(fmt.Errorf("Failed to parse certificate: %s", err))
+		pub.log.AuditErr(fmt.Sprintf("Failed to parse certificate: %s", err))
 		return err
 	}
 
@@ -92,7 +92,7 @@ func (pub *Impl) SubmitToCT(ctx context.Context, der []byte) error {
 		sct, err := ctLog.client.AddChainWithContext(localCtx, chain)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.AuditErr(fmt.Errorf("Failed to submit certificate to CT log at %s: %s", ctLog.uri, err))
+			pub.log.AuditErr(fmt.Sprintf("Failed to submit certificate to CT log at %s: %s", ctLog.uri, err))
 			continue
 		}
 
@@ -107,21 +107,21 @@ func (pub *Impl) SubmitToCT(ctx context.Context, der []byte) error {
 		})
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.AuditErr(fmt.Errorf("Failed to verify SCT receipt: %s", err))
+			pub.log.AuditErr(fmt.Sprintf("Failed to verify SCT receipt: %s", err))
 			continue
 		}
 
 		internalSCT, err := sctToInternal(sct, core.SerialToString(cert.SerialNumber))
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.AuditErr(fmt.Errorf("Failed to convert SCT receipt: %s", err))
+			pub.log.AuditErr(fmt.Sprintf("Failed to convert SCT receipt: %s", err))
 			continue
 		}
 
 		err = pub.SA.AddSCTReceipt(localCtx, internalSCT)
 		if err != nil {
 			// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-			pub.log.AuditErr(fmt.Errorf("Failed to store SCT receipt in database: %s", err))
+			pub.log.AuditErr(fmt.Sprintf("Failed to store SCT receipt in database: %s", err))
 			continue
 		}
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -814,7 +814,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 			prob = p
 		} else if err != nil {
 			prob = probs.ServerInternal("Could not communicate with VA")
-			ra.log.Err(fmt.Sprintf("Could not communicate with VA: %s", err))
+			ra.log.AuditErr(fmt.Errorf("Could not communicate with VA: %s", err))
 		}
 
 		// Save the updated records
@@ -835,7 +835,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 
 		err = ra.onValidationUpdate(vaCtx, authz)
 		if err != nil {
-			ra.log.Err(fmt.Sprintf("Could not record updated validation: err=[%s] regID=[%d]", err, authz.RegistrationID))
+			ra.log.AuditErr(fmt.Errorf("Could not record updated validation: err=[%s] regID=[%d]", err, authz.RegistrationID))
 		}
 	}()
 	ra.stats.Inc("RA.UpdatedPendingAuthorizations", 1, 1.0)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -814,7 +814,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 			prob = p
 		} else if err != nil {
 			prob = probs.ServerInternal("Could not communicate with VA")
-			ra.log.AuditErr(fmt.Errorf("Could not communicate with VA: %s", err))
+			ra.log.AuditErr(fmt.Sprintf("Could not communicate with VA: %s", err))
 		}
 
 		// Save the updated records
@@ -835,7 +835,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 
 		err = ra.onValidationUpdate(vaCtx, authz)
 		if err != nil {
-			ra.log.AuditErr(fmt.Errorf("Could not record updated validation: err=[%s] regID=[%d]", err, authz.RegistrationID))
+			ra.log.AuditErr(fmt.Sprintf("Could not record updated validation: err=[%s] regID=[%d]", err, authz.RegistrationID))
 		}
 	}()
 	ra.stats.Inc("RA.UpdatedPendingAuthorizations", 1, 1.0)

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -351,7 +351,7 @@ func (rpc *AmqpRPCServer) processMessage(msg amqp.Delivery) {
 	rpc.log.Debug(fmt.Sprintf(" [s<][%s][%s] received %s(%s) [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, safeDER(msg.Body), msg.CorrelationId))
 	if !present {
 		// AUDIT[ Misrouted Messages ] f523f21f-12d2-4c31-b2eb-ee4b7d96d60e
-		rpc.log.AuditErr(fmt.Errorf(" [s<][%s][%s] Misrouted message: %s - %s - %s", rpc.serverQueue, msg.ReplyTo, msg.Type, safeDER(msg.Body), msg.CorrelationId))
+		rpc.log.AuditErr(fmt.Sprintf(" [s<][%s][%s] Misrouted message: %s - %s - %s", rpc.serverQueue, msg.ReplyTo, msg.Type, safeDER(msg.Body), msg.CorrelationId))
 		return
 	}
 	var response rpcResponse
@@ -361,7 +361,7 @@ func (rpc *AmqpRPCServer) processMessage(msg amqp.Delivery) {
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		rpc.log.AuditErr(fmt.Errorf(" [s>][%s][%s] Error condition marshalling RPC response %s [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, msg.CorrelationId))
+		rpc.log.AuditErr(fmt.Sprintf(" [s>][%s][%s] Error condition marshalling RPC response %s [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, msg.CorrelationId))
 		return
 	}
 	rpc.log.Debug(fmt.Sprintf(" [s>][%s][%s] replying %s: %s [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, response.debugString(), msg.CorrelationId))
@@ -373,7 +373,7 @@ func (rpc *AmqpRPCServer) processMessage(msg amqp.Delivery) {
 		msg.Type,
 		jsonResponse)
 	if err != nil {
-		rpc.log.AuditErr(fmt.Errorf(" [s>][%s][%s] Error condition replying to RPC %s [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, msg.CorrelationId))
+		rpc.log.AuditErr(fmt.Sprintf(" [s>][%s][%s] Error condition replying to RPC %s [%s]", rpc.serverQueue, msg.ReplyTo, msg.Type, msg.CorrelationId))
 	}
 }
 

--- a/rpc/rpc-wrappers.go
+++ b/rpc/rpc-wrappers.go
@@ -207,11 +207,11 @@ type fqdnSetExistsResponse struct {
 
 func improperMessage(method string, err error, obj interface{}) {
 	log := blog.Get()
-	log.AuditErr(fmt.Errorf("Improper message. method: %s err: %s data: %+v", method, err, obj))
+	log.AuditErr(fmt.Sprintf("Improper message. method: %s err: %s data: %+v", method, err, obj))
 }
 func errorCondition(method string, err error, obj interface{}) {
 	log := blog.Get()
-	log.AuditErr(fmt.Errorf("Error condition. method: %s err: %s data: %+v", method, err, obj))
+	log.AuditErr(fmt.Sprintf("Error condition. method: %s err: %s data: %+v", method, err, obj))
 }
 
 // NewRegistrationAuthorityServer constructs an RPC server

--- a/va/va.go
+++ b/va/va.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -32,7 +33,6 @@ import (
 	"github.com/letsencrypt/boulder/probs"
 
 	caaPB "github.com/letsencrypt/boulder/cmd/caa-checker/proto"
-	"errors"
 )
 
 const (

--- a/va/va.go
+++ b/va/va.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -367,7 +366,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, identifie
 	expectedKeyAuth, err := challenge.ExpectedKeyAuthorization()
 	if err != nil {
 		errString := fmt.Sprintf("Failed to construct expected key authorization value: %s", err)
-		va.log.AuditErr(fmt.Errorf("%s for %s", errString, identifier))
+		va.log.AuditErr(fmt.Sprintf("%s for %s", errString, identifier))
 		return validationRecords, probs.ServerInternal(errString)
 	}
 
@@ -392,7 +391,7 @@ func (va *ValidationAuthorityImpl) validateTLSSNI01(ctx context.Context, identif
 	ka, err := challenge.ExpectedKeyAuthorization()
 	if err != nil {
 		errString := fmt.Sprintf("Failed to construct expected key authorization value: %s", err)
-		va.log.AuditErr(fmt.Errorf("%s for %s", errString, identifier))
+		va.log.AuditErr(fmt.Sprintf("%s for %s", errString, identifier))
 		return nil, probs.Malformed(errString)
 	}
 	h.Write([]byte(ka))
@@ -435,7 +434,7 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier
 	ka, err := challenge.ExpectedKeyAuthorization()
 	if err != nil {
 		errString := fmt.Sprintf("Failed to construct expected key authorization value: %s", err)
-		va.log.AuditErr(fmt.Errorf("%s for %s", errString, identifier))
+		va.log.AuditErr(fmt.Sprintf("%s for %s", errString, identifier))
 		return nil, probs.Malformed(errString)
 	}
 	h.Write([]byte(ka))
@@ -493,7 +492,7 @@ func (va *ValidationAuthorityImpl) checkCAAService(ctx context.Context, ident co
 		return prob
 	}
 	if r.Present == nil || r.Valid == nil {
-		va.log.AuditErr(errors.New("gRPC: communication failure: response is missing fields"))
+		va.log.AuditErr("gRPC: communication failure: response is missing fields")
 		return &probs.ProblemDetails{
 			Type:   probs.ServerInternalProblem,
 			Detail: "Internal communication failure",

--- a/va/va.go
+++ b/va/va.go
@@ -32,6 +32,7 @@ import (
 	"github.com/letsencrypt/boulder/probs"
 
 	caaPB "github.com/letsencrypt/boulder/cmd/caa-checker/proto"
+	"errors"
 )
 
 const (
@@ -366,7 +367,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, identifie
 	expectedKeyAuth, err := challenge.ExpectedKeyAuthorization()
 	if err != nil {
 		errString := fmt.Sprintf("Failed to construct expected key authorization value: %s", err)
-		va.log.Err(fmt.Sprintf("%s for %s", errString, identifier))
+		va.log.AuditErr(fmt.Errorf("%s for %s", errString, identifier))
 		return validationRecords, probs.ServerInternal(errString)
 	}
 
@@ -391,7 +392,7 @@ func (va *ValidationAuthorityImpl) validateTLSSNI01(ctx context.Context, identif
 	ka, err := challenge.ExpectedKeyAuthorization()
 	if err != nil {
 		errString := fmt.Sprintf("Failed to construct expected key authorization value: %s", err)
-		va.log.Err(fmt.Sprintf("%s for %s", errString, identifier))
+		va.log.AuditErr(fmt.Errorf("%s for %s", errString, identifier))
 		return nil, probs.Malformed(errString)
 	}
 	h.Write([]byte(ka))
@@ -434,7 +435,7 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier
 	ka, err := challenge.ExpectedKeyAuthorization()
 	if err != nil {
 		errString := fmt.Sprintf("Failed to construct expected key authorization value: %s", err)
-		va.log.Err(fmt.Sprintf("%s for %s", errString, identifier))
+		va.log.AuditErr(fmt.Errorf("%s for %s", errString, identifier))
 		return nil, probs.Malformed(errString)
 	}
 	h.Write([]byte(ka))
@@ -492,7 +493,7 @@ func (va *ValidationAuthorityImpl) checkCAAService(ctx context.Context, ident co
 		return prob
 	}
 	if r.Present == nil || r.Valid == nil {
-		va.log.Err("gRPC: communication failure: response is missing fields")
+		va.log.AuditErr(errors.New("gRPC: communication failure: response is missing fields"))
 		return &probs.ProblemDetails{
 			Type:   probs.ServerInternalProblem,
 			Detail: "Internal communication failure",

--- a/wfe/context.go
+++ b/wfe/context.go
@@ -79,7 +79,7 @@ func (th *topHandler) logEvent(logEvent *requestEvent) {
 	}
 	jsonEvent, err := json.Marshal(logEvent)
 	if err != nil {
-		th.log.AuditErr(fmt.Errorf("%s - failed to marshal logEvent - %s", msg, err))
+		th.log.AuditErr(fmt.Sprintf("%s - failed to marshal logEvent - %s", msg, err))
 		return
 	}
 	th.log.Info(fmt.Sprintf("%s JSON=%s", msg, jsonEvent))

--- a/wfe/context.go
+++ b/wfe/context.go
@@ -79,7 +79,7 @@ func (th *topHandler) logEvent(logEvent *requestEvent) {
 	}
 	jsonEvent, err := json.Marshal(logEvent)
 	if err != nil {
-		th.log.Err(fmt.Sprintf("%s - failed to marshal logEvent - %s", msg, err))
+		th.log.AuditErr(fmt.Errorf("%s - failed to marshal logEvent - %s", msg, err))
 		return
 	}
 	th.log.Info(fmt.Sprintf("%s JSON=%s", msg, jsonEvent))

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -506,13 +506,13 @@ func (wfe *WebFrontEndImpl) sendError(response http.ResponseWriter, logEvent *re
 	// auditable events.
 	if prob.Type == probs.ServerInternalProblem {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		wfe.log.AuditErr(fmt.Errorf("Internal error - %s - %s", prob.Detail, ierr))
+		wfe.log.AuditErr(fmt.Sprintf("Internal error - %s - %s", prob.Detail, ierr))
 	}
 
 	problemDoc, err := marshalIndent(prob)
 	if err != nil {
 		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-		wfe.log.AuditErr(fmt.Errorf("Could not marshal error message: %s - %+v", err, prob))
+		wfe.log.AuditErr(fmt.Sprintf("Could not marshal error message: %s - %+v", err, prob))
 		problemDoc = []byte("{\"detail\": \"Problem marshalling error message.\"}")
 	}
 


### PR DESCRIPTION
This PR replaces all calls to `log.Err()` with `log.AuditErr()` which has the same functionality. 

Fixes #1543 