### PR TITLE
Reload ratelimit policy automatically at runtime

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -84,7 +84,6 @@ func NewRegistrationAuthorityImpl(
 	maxNames int,
 	forceCNFromSAN bool,
 ) *RegistrationAuthorityImpl {
-	// TODO(jmhodges): making RA take a "RA" stats.Scope, not Statter
 	scope := metrics.NewStatsdScope(stats, "RA")
 	ra := &RegistrationAuthorityImpl{
 		stats: stats,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -106,7 +106,6 @@ func NewRegistrationAuthorityImpl(
 
 func (ra *RegistrationAuthorityImpl) SetRateLimitPoliciesFile(filename string) error {
 	_, err := reloader.New(filename, ra.rlPolicies.LoadPolicies, ra.rateLimitPoliciesLoadError)
-
 	if err != nil {
 		return err
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -57,7 +57,7 @@ type RegistrationAuthorityImpl struct {
 	// How long before a newly created authorization expires.
 	authorizationLifetime        time.Duration
 	pendingAuthorizationLifetime time.Duration
-	rlPolicies                   *ratelimit.RateLimitConfig
+	rlPolicies                   ratelimit.RateLimitConfig
 	tiMu                         *sync.RWMutex
 	totalIssuedCache             int
 	lastIssuedCount              *time.Time
@@ -90,7 +90,7 @@ func NewRegistrationAuthorityImpl(
 		log:   logger,
 		authorizationLifetime:        DefaultAuthorizationLifetime,
 		pendingAuthorizationLifetime: DefaultPendingAuthorizationLifetime,
-		rlPolicies:                   &ratelimit.RateLimitConfig{},
+		rlPolicies:                   &ratelimit.MutexRateLimitConfig{},
 		tiMu:                         new(sync.RWMutex),
 		maxContactsPerReg:            maxContactsPerReg,
 		keyPolicy:                    keyPolicy,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -57,7 +57,7 @@ type RegistrationAuthorityImpl struct {
 	// How long before a newly created authorization expires.
 	authorizationLifetime        time.Duration
 	pendingAuthorizationLifetime time.Duration
-	rlPolicies                   ratelimit.RateLimitConfig
+	rlPolicies                   ratelimit.Limits
 	tiMu                         *sync.RWMutex
 	totalIssuedCache             int
 	lastIssuedCount              *time.Time
@@ -90,7 +90,7 @@ func NewRegistrationAuthorityImpl(
 		log:   logger,
 		authorizationLifetime:        DefaultAuthorizationLifetime,
 		pendingAuthorizationLifetime: DefaultPendingAuthorizationLifetime,
-		rlPolicies:                   &ratelimit.MutexRateLimitConfig{},
+		rlPolicies:                   ratelimit.New(),
 		tiMu:                         new(sync.RWMutex),
 		maxContactsPerReg:            maxContactsPerReg,
 		keyPolicy:                    keyPolicy,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -114,7 +114,7 @@ func (ra *RegistrationAuthorityImpl) SetRateLimitPoliciesFile(filename string) e
 }
 
 func (ra *RegistrationAuthorityImpl) rateLimitPoliciesLoadError(err error) {
-	ra.log.Err(fmt.Sprintf("error live loading rate limit policy: %s", err))
+	ra.log.Err(fmt.Sprintf("error reloading rate limit policy: %s", err))
 }
 
 const (

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -57,7 +57,7 @@ type RegistrationAuthorityImpl struct {
 	// How long before a newly created authorization expires.
 	authorizationLifetime        time.Duration
 	pendingAuthorizationLifetime time.Duration
-	rlPolicies                   ratelimit.RateLimitConfig
+	rlPolicies                   *ratelimit.RateLimitConfig
 	tiMu                         *sync.RWMutex
 	totalIssuedCache             int
 	lastIssuedCount              *time.Time
@@ -90,22 +90,17 @@ func NewRegistrationAuthorityImpl(
 		log:   logger,
 		authorizationLifetime:        DefaultAuthorizationLifetime,
 		pendingAuthorizationLifetime: DefaultPendingAuthorizationLifetime,
-		tiMu:                 new(sync.RWMutex),
-		maxContactsPerReg:    maxContactsPerReg,
-		keyPolicy:            keyPolicy,
-		maxNames:             maxNames,
-		forceCNFromSAN:       forceCNFromSAN,
-		regByIPStats:         scope.NewScope("RA", "RateLimit", "RegistrationsByIP"),
-		pendAuthByRegIDStats: scope.NewScope("RA", "RateLimit", "PendingAuthorizationsByRegID"),
-		certsForDomainStats:  scope.NewScope("RA", "RateLimit", "CertificatesForDomain"),
-		totalCertsStats:      scope.NewScope("RA", "RateLimit", "TotalCertificates"),
+		rlPolicies:                   &ratelimit.RateLimitConfig{},
+		tiMu:                         new(sync.RWMutex),
+		maxContactsPerReg:            maxContactsPerReg,
+		keyPolicy:                    keyPolicy,
+		maxNames:                     maxNames,
+		forceCNFromSAN:               forceCNFromSAN,
+		regByIPStats:                 scope.NewScope("RA", "RateLimit", "RegistrationsByIP"),
+		pendAuthByRegIDStats:         scope.NewScope("RA", "RateLimit", "PendingAuthorizationsByRegID"),
+		certsForDomainStats:          scope.NewScope("RA", "RateLimit", "CertificatesForDomain"),
+		totalCertsStats:              scope.NewScope("RA", "RateLimit", "TotalCertificates"),
 	}
-	ra.rlPolicies.New(
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{})
 	return ra
 }
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -120,8 +120,6 @@ func (ra *RegistrationAuthorityImpl) SetRateLimitPoliciesFile(filename string) e
 }
 
 func (ra *RegistrationAuthorityImpl) rateLimitPoliciesLoadError(err error) {
-	// TODO(cpu): Determine if this is the best course of action for when the policy
-	// fails to load at runtime during a reload
 	ra.log.Err(fmt.Sprintf("error live loading rate limit policy: %s", err))
 }
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -151,9 +151,9 @@ var testKeyPolicy = goodkey.KeyPolicy{
 
 var ctx = context.Background()
 
-// DummyRateLimitConfig satisfies the ratelimit.RateLimitConfig interface while
+// dummyRateLimitConfig satisfies the ratelimit.RateLimitConfig interface while
 // allowing easy mocking of the individual RateLimitPolicy's
-type DummyRateLimitConfig struct {
+type dummyRateLimitConfig struct {
 	TotalCertificatesPolicy               ratelimit.RateLimitPolicy
 	CertificatesPerNamePolicy             ratelimit.RateLimitPolicy
 	RegistrationsPerIPPolicy              ratelimit.RateLimitPolicy
@@ -161,27 +161,27 @@ type DummyRateLimitConfig struct {
 	CertificatesPerFQDNSetPolicy          ratelimit.RateLimitPolicy
 }
 
-func (r *DummyRateLimitConfig) TotalCertificates() ratelimit.RateLimitPolicy {
+func (r *dummyRateLimitConfig) TotalCertificates() ratelimit.RateLimitPolicy {
 	return r.TotalCertificatesPolicy
 }
 
-func (r *DummyRateLimitConfig) CertificatesPerName() ratelimit.RateLimitPolicy {
+func (r *dummyRateLimitConfig) CertificatesPerName() ratelimit.RateLimitPolicy {
 	return r.CertificatesPerNamePolicy
 }
 
-func (r *DummyRateLimitConfig) RegistrationsPerIP() ratelimit.RateLimitPolicy {
+func (r *dummyRateLimitConfig) RegistrationsPerIP() ratelimit.RateLimitPolicy {
 	return r.RegistrationsPerIPPolicy
 }
 
-func (r *DummyRateLimitConfig) PendingAuthorizationsPerAccount() ratelimit.RateLimitPolicy {
+func (r *dummyRateLimitConfig) PendingAuthorizationsPerAccount() ratelimit.RateLimitPolicy {
 	return r.PendingAuthorizationsPerAccountPolicy
 }
 
-func (r *DummyRateLimitConfig) CertificatesPerFQDNSet() ratelimit.RateLimitPolicy {
+func (r *dummyRateLimitConfig) CertificatesPerFQDNSet() ratelimit.RateLimitPolicy {
 	return r.CertificatesPerFQDNSetPolicy
 }
 
-func (r *DummyRateLimitConfig) LoadPolicies(contents []byte) error {
+func (r *dummyRateLimitConfig) LoadPolicies(contents []byte) error {
 	return nil // NOP - unrequired behaviour for this mock
 }
 
@@ -675,7 +675,7 @@ func TestTotalCertRateLimit(t *testing.T) {
 	_, sa, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	ra.rlPolicies = &DummyRateLimitConfig{
+	ra.rlPolicies = &dummyRateLimitConfig{
 		TotalCertificatesPolicy: ratelimit.RateLimitPolicy{
 			Threshold: 1,
 			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
@@ -719,7 +719,7 @@ func TestAuthzRateLimiting(t *testing.T) {
 	_, _, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	ra.rlPolicies = &DummyRateLimitConfig{
+	ra.rlPolicies = &dummyRateLimitConfig{
 		PendingAuthorizationsPerAccountPolicy: ratelimit.RateLimitPolicy{
 			Threshold: 1,
 			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -781,13 +781,12 @@ func TestRateLimitLiveReload(t *testing.T) {
 	test.AssertNotError(t, err, "failed to SetRateLimitPoliciesFile")
 
 	// Test some fields of the initial policy to ensure it loaded correctly
-	policies := ra.rlPolicies
-	test.AssertEquals(t, policies.TotalCertificates().Threshold, 100000)
-	test.AssertEquals(t, policies.CertificatesPerName().Overrides["le.wtf"], 10000)
-	test.AssertEquals(t, policies.RegistrationsPerIP().Overrides["127.0.0.1"], 1000000)
-	test.AssertEquals(t, policies.PendingAuthorizationsPerAccount().Threshold, 3)
-	test.AssertEquals(t, policies.CertificatesPerFQDNSet().Overrides["le.wtf"], 10000)
-	test.AssertEquals(t, policies.CertificatesPerFQDNSet().Threshold, 5)
+	test.AssertEquals(t, ra.rlPolicies.TotalCertificates().Threshold, 100000)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le.wtf"], 10000)
+	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP().Overrides["127.0.0.1"], 1000000)
+	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount().Threshold, 3)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Overrides["le.wtf"], 10000)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, 5)
 
 	// Write a different  policy YAML to the monitored file, expect a reload.
 	// Sleep a few milliseconds before writing so the timestamp isn't identical to
@@ -803,14 +802,13 @@ func TestRateLimitLiveReload(t *testing.T) {
 
 	// Test fields of the policy to make sure writing the new policy to the monitored file
 	// resulted in the runtime values being updated
-	policies = ra.rlPolicies
-	test.AssertEquals(t, policies.TotalCertificates().Threshold, 99999)
-	test.AssertEquals(t, policies.CertificatesPerName().Overrides["le.wtf"], 9999)
-	test.AssertEquals(t, policies.CertificatesPerName().Overrides["le4.wtf"], 9999)
-	test.AssertEquals(t, policies.RegistrationsPerIP().Overrides["127.0.0.1"], 999990)
-	test.AssertEquals(t, policies.PendingAuthorizationsPerAccount().Threshold, 999)
-	test.AssertEquals(t, policies.CertificatesPerFQDNSet().Overrides["le.wtf"], 9999)
-	test.AssertEquals(t, policies.CertificatesPerFQDNSet().Threshold, 99999)
+	test.AssertEquals(t, ra.rlPolicies.TotalCertificates().Threshold, 99999)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le.wtf"], 9999)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le4.wtf"], 9999)
+	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP().Overrides["127.0.0.1"], 999990)
+	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount().Threshold, 999)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Overrides["le.wtf"], 9999)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, 99999)
 }
 
 type mockSAWithNameCounts struct {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -211,16 +211,12 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	ra.CA = ca
 	ra.PA = pa
 	ra.DNSResolver = &bdns.MockDNSResolver{}
-	ra.rlPolicies.New(
+
+	ra.rlPolicies.SetTotalCertificatesPolicy(
 		ratelimit.RateLimitPolicy{
 			Threshold: 100,
 			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
-		},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-	)
+		})
 
 	AuthzInitial.RegistrationID = Registration.ID
 
@@ -651,16 +647,11 @@ func TestTotalCertRateLimit(t *testing.T) {
 	_, sa, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	ra.rlPolicies.New(
+	ra.rlPolicies.SetTotalCertificatesPolicy(
 		ratelimit.RateLimitPolicy{
 			Threshold: 1,
 			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
-		},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-	)
+		})
 	fc.Add(24 * 90 * time.Hour)
 
 	AuthzFinal.RegistrationID = Registration.ID
@@ -699,16 +690,11 @@ func TestAuthzRateLimiting(t *testing.T) {
 	_, _, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	ra.rlPolicies.New(
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
-		ratelimit.RateLimitPolicy{},
+	ra.rlPolicies.SetPendingAuthorizationsPerAccountPolicy(
 		ratelimit.RateLimitPolicy{
 			Threshold: 1,
 			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
-		},
-		ratelimit.RateLimitPolicy{},
-	)
+		})
 	fc.Add(24 * 90 * time.Hour)
 
 	// Should be able to create an authzRequest

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -200,20 +200,23 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 		InitialIP: net.ParseIP("3.2.3.3"),
 	})
 
+	testRLConfig := ratelimit.RateLimitConfig{
+		TotalCertificates: ratelimit.RateLimitPolicy{
+			Threshold: 100,
+			Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
+		},
+	}
+
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
 		stats,
-		ratelimit.RateLimitConfig{
-			TotalCertificates: ratelimit.RateLimitPolicy{
-				Threshold: 100,
-				Window:    cmd.ConfigDuration{Duration: 24 * 90 * time.Hour},
-			},
-		}, 1, testKeyPolicy, false, 0, true)
+		1, testKeyPolicy, false, 0, true)
 	ra.SA = ssa
 	ra.VA = va
 	ra.CA = ca
 	ra.PA = pa
 	ra.DNSResolver = &bdns.MockDNSResolver{}
+	ra.rlPolicies = testRLConfig
 
 	AuthzInitial.RegistrationID = Registration.ID
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -768,12 +768,14 @@ func TestRateLimitLiveReload(t *testing.T) {
 	test.AssertNotError(t, err, "failed to SetRateLimitPoliciesFile")
 
 	// Test some fields of the initial policy to ensure it loaded correctly
+	ra.rlMu.RLock()
 	test.AssertEquals(t, ra.rlPolicies.TotalCertificates.Threshold, 100000)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName.Overrides["le.wtf"], 10000)
 	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP.Overrides["127.0.0.1"], 1000000)
 	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount.Threshold, 3)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet.Overrides["le.wtf"], 10000)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet.Threshold, 5)
+	ra.rlMu.RUnlock()
 
 	// Write a different  policy YAML to the monitored file, expect a reload.
 	// Sleep a few milliseconds before writing so the timestamp isn't identical to
@@ -787,6 +789,7 @@ func TestRateLimitLiveReload(t *testing.T) {
 
 	// Test fields of the policy to make sure writing the new policy to the monitored file
 	// resulted in the runtime values being updated
+	ra.rlMu.RLock()
 	test.AssertEquals(t, ra.rlPolicies.TotalCertificates.Threshold, 99999)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName.Overrides["le.wtf"], 9999)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName.Overrides["le4.wtf"], 9999)
@@ -794,6 +797,7 @@ func TestRateLimitLiveReload(t *testing.T) {
 	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount.Threshold, 999)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet.Overrides["le.wtf"], 9999)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet.Threshold, 99999)
+	ra.rlMu.RUnlock()
 }
 
 type mockSAWithNameCounts struct {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -755,13 +755,16 @@ func TestRateLimitLiveReload(t *testing.T) {
 
 	// We'll work with a temporary file as the reloader monitored rate limit
 	// policy file
-	policyFile, _ := ioutil.TempFile("", "rate-limit-policies.yml")
+	policyFile, tempErr := ioutil.TempFile("", "rate-limit-policies.yml")
+	test.AssertNotError(t, tempErr, "should not fail to create TempFile")
 	filename := policyFile.Name()
 	defer os.Remove(filename)
 
 	// Start with bodyOne in the temp file
-	bodyOne, _ := ioutil.ReadFile("../test/rate-limit-policies.yml")
-	ioutil.WriteFile(filename, bodyOne, 0644)
+	bodyOne, readErr := ioutil.ReadFile("../test/rate-limit-policies.yml")
+	test.AssertNotError(t, readErr, "should not fail to read ../test/rate-limit-policies.yml")
+	writeErr := ioutil.WriteFile(filename, bodyOne, 0644)
+	test.AssertNotError(t, writeErr, "should not fail to write temp file")
 
 	// Configure the RA to use the monitored temp file as the policy file
 	err := ra.SetRateLimitPoliciesFile(filename)
@@ -780,9 +783,11 @@ func TestRateLimitLiveReload(t *testing.T) {
 	// Write a different  policy YAML to the monitored file, expect a reload.
 	// Sleep a few milliseconds before writing so the timestamp isn't identical to
 	// when we wrote bodyOne to the file earlier.
-	bodyTwo, _ := ioutil.ReadFile("../test/rate-limit-policies-b.yml")
+	bodyTwo, readErr := ioutil.ReadFile("../test/rate-limit-policies-b.yml")
+	test.AssertNotError(t, readErr, "should not fail to read ../test/rate-limit-policies-b.yml")
 	time.Sleep(15 * time.Millisecond)
-	ioutil.WriteFile(filename, bodyTwo, 0644)
+	writeErr = ioutil.WriteFile(filename, bodyTwo, 0644)
+	test.AssertNotError(t, writeErr, "should not fail to write temp file")
 
 	// Sleep to allow the reloader a chance to catch that an update occurred
 	time.Sleep(2 * time.Second)

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -1,7 +1,6 @@
 package ratelimit
 
 import (
-	"io/ioutil"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -77,15 +76,11 @@ func (rlp *RateLimitPolicy) WindowBegin(windowEnd time.Time) time.Time {
 	return windowEnd.Add(-1 * rlp.Window.Duration)
 }
 
-// LoadRateLimitPolicies loads various rate limiting policies from a YAML
-// configuration file
-func LoadRateLimitPolicies(filename string) (RateLimitConfig, error) {
-	contents, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return RateLimitConfig{}, err
-	}
+// LoadRateLimitPolicies loads various rate limiting policies from a byte array of
+// YAML configuration (typically read from disk by a reloader)
+func LoadRateLimitPolicies(contents []byte) (RateLimitConfig, error) {
 	var rlc RateLimitConfig
-	err = yaml.Unmarshal(contents, &rlc)
+	err := yaml.Unmarshal(contents, &rlc)
 	if err != nil {
 		return RateLimitConfig{}, err
 	}

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -18,30 +18,50 @@ type RateLimitConfig struct {
 }
 
 func (r *RateLimitConfig) TotalCertificates() RateLimitPolicy {
+	if r.rlPolicy == nil {
+		return RateLimitPolicy{}
+	}
+
 	r.RLock()
 	defer r.RUnlock()
 	return r.rlPolicy.TotalCertificates
 }
 
 func (r *RateLimitConfig) CertificatesPerName() RateLimitPolicy {
+	if r.rlPolicy == nil {
+		return RateLimitPolicy{}
+	}
+
 	r.RLock()
 	defer r.RUnlock()
 	return r.rlPolicy.CertificatesPerName
 }
 
 func (r *RateLimitConfig) RegistrationsPerIP() RateLimitPolicy {
+	if r.rlPolicy == nil {
+		return RateLimitPolicy{}
+	}
+
 	r.RLock()
 	defer r.RUnlock()
 	return r.rlPolicy.RegistrationsPerIP
 }
 
 func (r *RateLimitConfig) PendingAuthorizationsPerAccount() RateLimitPolicy {
+	if r.rlPolicy == nil {
+		return RateLimitPolicy{}
+	}
+
 	r.RLock()
 	defer r.RUnlock()
 	return r.rlPolicy.PendingAuthorizationsPerAccount
 }
 
 func (r *RateLimitConfig) CertificatesPerFQDNSet() RateLimitPolicy {
+	if r.rlPolicy == nil {
+		return RateLimitPolicy{}
+	}
+
 	r.RLock()
 	defer r.RUnlock()
 	return r.rlPolicy.CertificatesPerFQDNSet

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -29,8 +29,10 @@ func (r *RateLimitConfig) TotalCertificates() RateLimitPolicy {
 func (r *RateLimitConfig) SetTotalCertificatesPolicy(p RateLimitPolicy) {
 	r.Lock()
 	defer r.Unlock()
-
-	r.rlPolicy.CertificatesPerName = p
+	if r.rlPolicy == nil {
+		r.rlPolicy = &rateLimitConfig{}
+	}
+	r.rlPolicy.TotalCertificates = p
 }
 
 func (r *RateLimitConfig) CertificatesPerName() RateLimitPolicy {
@@ -42,6 +44,15 @@ func (r *RateLimitConfig) CertificatesPerName() RateLimitPolicy {
 	return r.rlPolicy.CertificatesPerName
 }
 
+func (r *RateLimitConfig) SetCertificatesPerNamePolicy(p RateLimitPolicy) {
+	r.Lock()
+	defer r.Unlock()
+	if r.rlPolicy == nil {
+		r.rlPolicy = &rateLimitConfig{}
+	}
+	r.rlPolicy.CertificatesPerName = p
+}
+
 func (r *RateLimitConfig) RegistrationsPerIP() RateLimitPolicy {
 	r.RLock()
 	defer r.RUnlock()
@@ -49,6 +60,15 @@ func (r *RateLimitConfig) RegistrationsPerIP() RateLimitPolicy {
 		return RateLimitPolicy{}
 	}
 	return r.rlPolicy.RegistrationsPerIP
+}
+
+func (r *RateLimitConfig) SetRegistrationsPerIPPolicy(p RateLimitPolicy) {
+	r.Lock()
+	defer r.Unlock()
+	if r.rlPolicy == nil {
+		r.rlPolicy = &rateLimitConfig{}
+	}
+	r.rlPolicy.RegistrationsPerIP = p
 }
 
 func (r *RateLimitConfig) PendingAuthorizationsPerAccount() RateLimitPolicy {
@@ -60,6 +80,15 @@ func (r *RateLimitConfig) PendingAuthorizationsPerAccount() RateLimitPolicy {
 	return r.rlPolicy.PendingAuthorizationsPerAccount
 }
 
+func (r *RateLimitConfig) SetPendingAuthorizationsPerAccountPolicy(p RateLimitPolicy) {
+	r.Lock()
+	defer r.Unlock()
+	if r.rlPolicy == nil {
+		r.rlPolicy = &rateLimitConfig{}
+	}
+	r.rlPolicy.PendingAuthorizationsPerAccount = p
+}
+
 func (r *RateLimitConfig) CertificatesPerFQDNSet() RateLimitPolicy {
 	r.RLock()
 	defer r.RUnlock()
@@ -67,6 +96,15 @@ func (r *RateLimitConfig) CertificatesPerFQDNSet() RateLimitPolicy {
 		return RateLimitPolicy{}
 	}
 	return r.rlPolicy.CertificatesPerFQDNSet
+}
+
+func (r *RateLimitConfig) SetCertificatesPerFQDNSetPolicy(p RateLimitPolicy) {
+	r.Lock()
+	defer r.Unlock()
+	if r.rlPolicy == nil {
+		r.rlPolicy = &rateLimitConfig{}
+	}
+	r.rlPolicy.CertificatesPerFQDNSet = p
 }
 
 // LoadPolicies loads various rate limiting policies from a byte array of
@@ -82,23 +120,6 @@ func (r *RateLimitConfig) LoadPolicies(contents []byte) error {
 	r.rlPolicy = &newPolicy
 	r.Unlock()
 	return nil
-}
-
-func (r *RateLimitConfig) New(
-	totalCerts RateLimitPolicy,
-	certsPerName RateLimitPolicy,
-	regsPerIP RateLimitPolicy,
-	pendingAuthsPerIP RateLimitPolicy,
-	certsPerFQDNSet RateLimitPolicy) {
-	r.Lock()
-	r.rlPolicy = &rateLimitConfig{
-		TotalCertificates:               totalCerts,
-		CertificatesPerName:             certsPerName,
-		RegistrationsPerIP:              regsPerIP,
-		PendingAuthorizationsPerAccount: pendingAuthsPerIP,
-		CertificatesPerFQDNSet:          certsPerFQDNSet,
-	}
-	r.Unlock()
 }
 
 // rateLimitConfig contains all application layer rate limiting policies. It is

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -18,52 +18,54 @@ type RateLimitConfig struct {
 }
 
 func (r *RateLimitConfig) TotalCertificates() RateLimitPolicy {
+	r.RLock()
+	defer r.RUnlock()
 	if r.rlPolicy == nil {
 		return RateLimitPolicy{}
 	}
-
-	r.RLock()
-	defer r.RUnlock()
 	return r.rlPolicy.TotalCertificates
 }
 
+func (r *RateLimitConfig) SetTotalCertificatesPolicy(p RateLimitPolicy) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.rlPolicy.CertificatesPerName = p
+}
+
 func (r *RateLimitConfig) CertificatesPerName() RateLimitPolicy {
+	r.RLock()
+	defer r.RUnlock()
 	if r.rlPolicy == nil {
 		return RateLimitPolicy{}
 	}
-
-	r.RLock()
-	defer r.RUnlock()
 	return r.rlPolicy.CertificatesPerName
 }
 
 func (r *RateLimitConfig) RegistrationsPerIP() RateLimitPolicy {
+	r.RLock()
+	defer r.RUnlock()
 	if r.rlPolicy == nil {
 		return RateLimitPolicy{}
 	}
-
-	r.RLock()
-	defer r.RUnlock()
 	return r.rlPolicy.RegistrationsPerIP
 }
 
 func (r *RateLimitConfig) PendingAuthorizationsPerAccount() RateLimitPolicy {
+	r.RLock()
+	defer r.RUnlock()
 	if r.rlPolicy == nil {
 		return RateLimitPolicy{}
 	}
-
-	r.RLock()
-	defer r.RUnlock()
 	return r.rlPolicy.PendingAuthorizationsPerAccount
 }
 
 func (r *RateLimitConfig) CertificatesPerFQDNSet() RateLimitPolicy {
+	r.RLock()
+	defer r.RUnlock()
 	if r.rlPolicy == nil {
 		return RateLimitPolicy{}
 	}
-
-	r.RLock()
-	defer r.RUnlock()
 	return r.rlPolicy.CertificatesPerFQDNSet
 }
 

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -64,7 +64,7 @@ func TestWindowBegin(t *testing.T) {
 }
 
 func TestLoadPolicies(t *testing.T) {
-	policy := MutexRateLimitConfig{}
+	policy := New()
 
 	policyContent, readErr := ioutil.ReadFile("../test/rate-limit-policies.yml")
 	test.AssertNotError(t, readErr, "Failed to load rate-limit-policies.yml")
@@ -136,7 +136,7 @@ func TestLoadPolicies(t *testing.T) {
 	// Test that the RateLimitConfig accessors do not panic when there has been no
 	// `LoadPolicy` call, and instead return empty RateLimitPolicy objects with default
 	// values.
-	emptyPolicy := MutexRateLimitConfig{}
+	emptyPolicy := New()
 	test.AssertEquals(t, emptyPolicy.TotalCertificates().Threshold, 0)
 	test.AssertEquals(t, emptyPolicy.CertificatesPerName().Threshold, 0)
 	test.AssertEquals(t, emptyPolicy.RegistrationsPerIP().Threshold, 0)

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -1,10 +1,12 @@
 package ratelimit
 
 import (
+	"io/ioutil"
 	"testing"
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/test"
 )
 
 func TestEnabled(t *testing.T) {
@@ -59,4 +61,86 @@ func TestWindowBegin(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Incorrect WindowBegin: %s, expected %s", actual, expected)
 	}
+}
+
+func TestLoadPolicies(t *testing.T) {
+	policy := MutexRateLimitConfig{}
+
+	policyContent, readErr := ioutil.ReadFile("../test/rate-limit-policies.yml")
+	test.AssertNotError(t, readErr, "Failed to load rate-limit-policies.yml")
+
+	// Test that loading a good policy from YAML doesn't error
+	err := policy.LoadPolicies(policyContent)
+	test.AssertNotError(t, err, "Failed to parse rate-limit-policies.yml")
+
+	// Test that the TotalCertificates section parsed correctly
+	totalCerts := policy.TotalCertificates()
+	test.AssertEquals(t, totalCerts.Threshold, 100000)
+	test.AssertEquals(t, len(totalCerts.Overrides), 0)
+	test.AssertEquals(t, len(totalCerts.RegistrationOverrides), 0)
+
+	// Test that the CertificatesPerName section parsed correctly
+	certsPerName := policy.CertificatesPerName()
+	test.AssertEquals(t, certsPerName.Threshold, 2)
+	test.AssertDeepEquals(t, certsPerName.Overrides, map[string]int{
+		"ratelimit.me":          1,
+		"le.wtf":                10000,
+		"le1.wtf":               10000,
+		"le2.wtf":               10000,
+		"le3.wtf":               10000,
+		"nginx.wtf":             10000,
+		"good-caa-reserved.com": 10000,
+		"bad-caa-reserved.com":  10000,
+	})
+	test.AssertDeepEquals(t, certsPerName.RegistrationOverrides, map[int64]int{
+		101: 1000,
+	})
+
+	// Test that the RegistrationsPerIP section parsed correctly
+	regsPerIP := policy.RegistrationsPerIP()
+	test.AssertEquals(t, regsPerIP.Threshold, 10000)
+	test.AssertDeepEquals(t, regsPerIP.Overrides, map[string]int{
+		"127.0.0.1": 1000000,
+	})
+	test.AssertEquals(t, len(regsPerIP.RegistrationOverrides), 0)
+
+	// Test that the PendingAuthorizationsPerAccount section parsed correctly
+	pendingAuthsPerAcct := policy.PendingAuthorizationsPerAccount()
+	test.AssertEquals(t, pendingAuthsPerAcct.Threshold, 3)
+	test.AssertEquals(t, len(pendingAuthsPerAcct.Overrides), 0)
+	test.AssertEquals(t, len(pendingAuthsPerAcct.RegistrationOverrides), 0)
+
+	// Test that the CertificatesPerFQDN section parsed correctly
+	certsPerFQDN := policy.CertificatesPerFQDNSet()
+	test.AssertEquals(t, certsPerFQDN.Threshold, 5)
+	test.AssertDeepEquals(t, certsPerFQDN.Overrides, map[string]int{
+		"le.wtf":                10000,
+		"le1.wtf":               10000,
+		"le2.wtf":               10000,
+		"le3.wtf":               10000,
+		"le.wtf,le1.wtf":        10000,
+		"good-caa-reserved.com": 10000,
+		"nginx.wtf":             10000,
+	})
+	test.AssertEquals(t, len(certsPerFQDN.RegistrationOverrides), 0)
+
+	// Test that loading invalid YAML generates an error
+	err = policy.LoadPolicies([]byte("err"))
+	test.AssertError(t, err, "Failed to generate error loading invalid yaml policy file")
+	// Re-check a field of policy to make sure a LoadPolicies error doesn't
+	// corrupt the existing policies
+	test.AssertDeepEquals(t, policy.RegistrationsPerIP().Overrides, map[string]int{
+		"127.0.0.1": 1000000,
+	})
+
+	// Test that the RateLimitConfig accessors do not panic when there has been no
+	// `LoadPolicy` call, and instead return empty RateLimitPolicy objects with default
+	// values.
+	emptyPolicy := MutexRateLimitConfig{}
+	test.AssertEquals(t, emptyPolicy.TotalCertificates().Threshold, 0)
+	test.AssertEquals(t, emptyPolicy.CertificatesPerName().Threshold, 0)
+	test.AssertEquals(t, emptyPolicy.RegistrationsPerIP().Threshold, 0)
+	test.AssertEquals(t, emptyPolicy.RegistrationsPerIP().Threshold, 0)
+	test.AssertEquals(t, emptyPolicy.PendingAuthorizationsPerAccount().Threshold, 0)
+	test.AssertEquals(t, emptyPolicy.CertificatesPerFQDNSet().Threshold, 0)
 }

--- a/test/rate-limit-policies-b.yml
+++ b/test/rate-limit-policies-b.yml
@@ -1,0 +1,39 @@
+# See cmd/shell.go for definitions of these rate limits.
+totalCertificates:
+  window: 9999h
+  threshold: 99999
+certificatesPerName:
+  window: 2160h
+  threshold: 99
+  overrides:
+    ratelimit.me: 1
+    # Hostnames used by the letsencrypt client integration test.
+    le.wtf: 9999
+    le1.wtf: 9999
+    le2.wtf: 9999
+    le3.wtf: 9999
+    le4.wtf: 9999
+    nginx.wtf: 9999
+    good-caa-reserved.com: 9999
+    bad-caa-reserved.com: 9999
+  registrationOverrides:
+    101: 1000
+registrationsPerIP:
+  window: 168h # 1 week
+  threshold: 9999
+  overrides:
+    127.0.0.1: 999990
+pendingAuthorizationsPerAccount:
+  window: 168h # 1 week, should match pending authorization lifetime.
+  threshold: 999
+certificatesPerFQDNSet:
+  window: 24h
+  threshold: 99999
+  overrides:
+    le.wtf: 9999
+    le1.wtf: 9999
+    le2.wtf: 9999
+    le3.wtf: 9999
+    le.wtf,le1.wtf: 9999
+    good-caa-reserved.com: 9999
+    nginx.wtf: 9999

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -33,7 +33,6 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/ra"
-	"github.com/letsencrypt/boulder/ratelimit"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -620,7 +619,6 @@ func TestIssueCertificate(t *testing.T) {
 		fc,
 		wfe.log,
 		stats,
-		ratelimit.RateLimitConfig{},
 		0,
 		testKeyPolicy,
 		false,


### PR DESCRIPTION
Resolves #1810 by automatically updating the RA `ratelimit.RateLimitConfig` whenever the backing config file is changed. Much like the Policy Authority uses a reloader instance to support updating the Hostname policy on the fly, this PR changes the Registration Authority to use a reloader for the rate limit policy file.

Access to the `ra.rlPolicies` member is protected with a `RWMutex` now that there is a potential for the values to be reloaded while a reader is active.

A test is introduced to ensure that writing a new policy YAML to the policy config file results in new values being set in the RA's `rlPolicies` instance.