### PR TITLE
Remove race condition from bdns_test.go

### DIFF
--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -192,7 +192,7 @@ func serveLoopResolver(stopChan chan bool) {
 
 func pollServer() {
 	backoff := time.Duration(200 * time.Millisecond)
-	ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+	ctx, _ := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
 	ticker := time.NewTicker(backoff)
 
 	for {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -201,9 +201,10 @@ func pollServer() {
 			os.Exit(1)
 		}
 		conn, _ = dns.DialTimeout("tcp", dnsLoopbackAddr, timeout)
-		if conn == nil {
-			time.Sleep(timeout)
+		if conn != nil {
+			break
 		}
+		time.Sleep(timeout)
 	}
 	_ = conn.Close()
 }

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -203,7 +203,7 @@ func pollServer() {
 		time.Sleep(backoff)
 	}
 	if conn == nil {
-		fmt.Fprintf(os.Stderr, "Max tries(%d) reached while testing for the dns server to come up\n", backoff)
+		fmt.Fprintf(os.Stderr, "Max tries(%d) reached while testing for the dns server to come up\n", tries)
 		os.Exit(1)
 	}
 	_ = conn.Close()

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -192,19 +192,19 @@ func serveLoopResolver(stopChan chan bool) {
 
 func pollServer() {
 	var conn *dns.Conn
-	timeout := time.Duration(time.Millisecond * 200)
+	backoff := time.Duration(time.Millisecond * 200)
 	tries := 25
 
-	for i := 0; conn == nil; i++ {
-		if i == tries {
-			fmt.Println("Max tries reached")
-			os.Exit(1)
-		}
-		conn, _ = dns.DialTimeout("tcp", dnsLoopbackAddr, timeout)
+	for i := 0; i < tries; i++ {
+		conn, _ = dns.DialTimeout("tcp", dnsLoopbackAddr, backoff)
 		if conn != nil {
 			break
 		}
-		time.Sleep(timeout)
+		time.Sleep(backoff)
+	}
+	if conn == nil {
+		fmt.Fprintf(os.Stderr, "Max tries(%d) reached while testing for the dns server to come up\n", backoff)
+		os.Exit(1)
 	}
 	_ = conn.Close()
 }

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -173,7 +173,7 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 func serveLoopResolver(stopChan chan bool) {
 	dns.HandleFunc(".", mockDNSQuery)
-	server := &dns.Server{Addr: dnsLoopbackAddr, Net: "tcp", ReadTimeout: time.Millisecond, WriteTimeout: time.Millisecond}
+	server := &dns.Server{Addr: dnsLoopbackAddr, Net: "tcp", ReadTimeout: time.Second, WriteTimeout: time.Second}
 	go func() {
 		err := server.ListenAndServe()
 		if err != nil {
@@ -205,8 +205,7 @@ func pollServer() {
 			time.Sleep(timeout)
 		}
 	}
-
-	conn.Close()
+	_ = conn.Close()
 }
 
 func TestMain(m *testing.M) {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -171,7 +171,7 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	return
 }
 
-func serveLoopResolver(stopChan chan bool){
+func serveLoopResolver(stopChan chan bool) {
 	dns.HandleFunc(".", mockDNSQuery)
 	server := &dns.Server{Addr: dnsLoopbackAddr, Net: "tcp", ReadTimeout: time.Millisecond, WriteTimeout: time.Millisecond}
 	go func() {
@@ -192,10 +192,10 @@ func serveLoopResolver(stopChan chan bool){
 
 func pollServer() {
 	var conn *dns.Conn
-	timeout := time.Duration(time.Millisecond * 500)
-	tries := 10
+	timeout := time.Duration(time.Millisecond * 200)
+	tries := 25
 
-	for i := 0; conn == nil; i++{
+	for i := 0; conn == nil; i++ {
 		if i == tries {
 			fmt.Println("Max tries reached")
 			os.Exit(1)


### PR DESCRIPTION
This PR, makes testing the bdns package more reliable. A race condition in TestMain was resulting in the test running before the test dns server had started. Furthermore, a 1 millisecond server read/write timeout was proving to time out on occasion, which I increased to 1 second to increase test reliability. 

FYI: ran package bdns tests 1000 times with 22 failures previously, after this PR ran 1000 times with 0 failures.

fixes #1317 