### PR TITLE
Fix environment passing in startservers.py.

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -29,8 +29,8 @@ def install(race_detection):
 
 def run(cmd, race_detection):
     # Note: Must use exec here so that killing this process kills the command.
-    cmd = """exec ./bin/%s""" % cmd
-    p = subprocess.Popen(cmd, shell=True, env={'GORACE': 'halt_on_error=1'})
+    cmd = """GORACE="halt_on_error=1" exec ./bin/%s""" % cmd
+    p = subprocess.Popen(cmd, shell=True)
     p.cmd = cmd
     return p
 


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/pull/1885 I tried to simplify setting
the GORACE environment variable, but that actually had the effect of inhibiting
pass-through of all environment variables (particularly FAKE_DNS). This reverts
that part of the change.