### PR TITLE
Statistics Engine - Initial Version (Feature Parity)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -254,6 +254,16 @@ type StatsdConfig struct {
 	Prefix string
 }
 
+// StatisticsConfig defines the config for Statistics
+type StatisticsConfig struct {
+	DBConfig
+
+	// A path to write the resulting JSON output, or blank to write to stdout
+	OutputPath string
+	// How wide a window to analyze; this should likely match Expiry
+	TimeWindow ConfigDuration
+}
+
 // ConfigDuration is just an alias for time.Duration that allows
 // serialization to YAML as well as JSON.
 type ConfigDuration struct {

--- a/cmd/statistics/main.go
+++ b/cmd/statistics/main.go
@@ -1,0 +1,70 @@
+// Copyright 2016 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/jmhodges/clock"
+
+	"github.com/letsencrypt/boulder/cmd"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/sa"
+	"github.com/letsencrypt/boulder/statistics"
+)
+
+func main() {
+	app := cmd.NewAppShell("statistics", "Generates statistics about Boulder")
+
+	app.App.Flags = append(app.App.Flags, cli.StringFlag{
+		Name:   "outfile",
+		EnvVar: "OUTFILE",
+		Usage:  "Path to write the JSON output",
+	}, cli.BoolFlag{
+		Name:  "stdout",
+		Usage: "Send JSON output to stdout instead of writing to disk",
+	})
+
+	app.Config = func(c *cli.Context, config cmd.Config) cmd.Config {
+		if c.GlobalString("outfile") != "" {
+			config.Statistics.OutputPath = c.GlobalString("outfile")
+		}
+		if c.GlobalBool("stdout") {
+			config.Statistics.OutputPath = ""
+		}
+		return config
+	}
+
+	app.Action = func(c cmd.Config, stats metrics.Statter, logger blog.Logger) {
+		// Configure DB
+		dbURL, err := c.Statistics.DBConfig.URL()
+		cmd.FailOnError(err, "Couldn't load DB URL")
+		dbMap, err := sa.NewDbMap(dbURL, c.Statistics.DBConfig.MaxDBConns)
+		cmd.FailOnError(err, "Could not connect to database")
+
+		writer := os.Stdout
+
+		if c.Statistics.OutputPath != "" {
+			fd, err := os.Create(c.Statistics.OutputPath)
+			cmd.FailOnError(err, "Could not open outfile for writing")
+
+			defer func() {
+				err := fd.Close()
+				cmd.FailOnError(err, "Could not close outfile")
+			}()
+			writer = fd
+		}
+
+		dbstats, err := statistics.NewDBStatsEngine(dbMap, stats, clock.Default(), c.Statistics.TimeWindow, writer, logger)
+		cmd.FailOnError(err, "Could not construct engine")
+		err = dbstats.Calculate()
+		cmd.FailOnError(err, "Could not process statistics")
+	}
+
+	app.Run()
+}

--- a/cmd/statistics/main_test.go
+++ b/cmd/statistics/main_test.go
@@ -1,0 +1,6 @@
+// Copyright 2016 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main

--- a/statistics/dbstats.go
+++ b/statistics/dbstats.go
@@ -1,0 +1,233 @@
+// Copyright 2016 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package statistics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"gopkg.in/gorp.v1"
+
+	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/letsencrypt/boulder/cmd"
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+type DBStatsEngine struct {
+	DB     *gorp.DbMap
+	clk    clock.Clock
+	Logger blog.Logger
+	Window cmd.ConfigDuration
+	Writer io.Writer
+	Stats  statsd.Statter
+}
+
+type EncodedStats struct {
+	CertsPerDayByStatus       []CertsPerDayByStatus
+	ChallengeCounts           []ChallengeCounts
+	OCSPAging                 OCSPAging
+	OCSPUpdatesByDayAndHour   []OCSPUpdatesByDayAndHour
+	RegistrationsPerDayByType []RegistrationsPerDayByType
+}
+
+type ChallengeCounts struct {
+	Completions int64
+	Type        string
+}
+type CertsPerDayByStatus struct {
+	IssuedDate time.Time
+	Revoked    int64
+	StillValid int64
+}
+
+type RegistrationsPerDayByType struct {
+	Anonymous   int64
+	CreateDate  time.Time
+	WithContact int64
+}
+
+type OCSPUpdatesByDayAndHour struct {
+	Day          time.Time
+	Hour         int64
+	NumResponses int64
+}
+
+type OCSPAging struct {
+	Age12h int64
+	Age24h int64
+	Age36h int64
+	Age48h int64
+	Age60h int64
+	Age72h int64
+	Age84h int64
+	Age96h int64
+	Older  int64
+}
+
+func NewDBStatsEngine(dbMap *gorp.DbMap, stats statsd.Statter, clk clock.Clock, window cmd.ConfigDuration, writer io.Writer, logger blog.Logger) (*DBStatsEngine, error) {
+	if dbMap == nil {
+		return nil, fmt.Errorf("DB Map must not be nil")
+	}
+
+	engine := &DBStatsEngine{
+		DB:     dbMap,
+		Logger: logger,
+		clk:    clk,
+		Window: window,
+		Writer: writer,
+		Stats:  stats,
+	}
+	return engine, nil
+}
+
+func (stats *DBStatsEngine) certificatesIssuedPerDayByStatus() ([]CertsPerDayByStatus, error) {
+	var counts []CertsPerDayByStatus
+	_, err := stats.DB.Select(&counts,
+		`SELECT
+          DATE(c.issued) as IssuedDate,
+          SUM(scs.status = 'good') as StillValid,
+          SUM(scs.status = 'revoked') as Revoked
+      FROM
+        certificates AS c
+          NATURAL JOIN
+        certificateStatus AS scs
+      WHERE c.expires > :now AND c.issued > DATE_SUB(:now, INTERVAL :window HOUR)
+      GROUP BY DATE(c.issued);`,
+		map[string]interface{}{
+			"window": stats.Window.Hours(),
+			"now":    stats.clk.Now(),
+		})
+
+	return counts, err
+}
+
+func (stats *DBStatsEngine) registrationsPerDayByType() ([]RegistrationsPerDayByType, error) {
+	var counts []RegistrationsPerDayByType
+	_, err := stats.DB.Select(&counts,
+		`SELECT
+          DATE(r.createdAt) as CreateDate,
+          SUM(r.contact = 'null') as Anonymous,
+          SUM(r.contact != 'null') as WithContact
+      FROM
+          registrations AS r
+      WHERE
+          r.createdAt > DATE_SUB(:now, INTERVAL :window HOUR)
+      GROUP BY DATE(r.createdAt);`,
+		map[string]interface{}{
+			"window": stats.Window.Hours(),
+			"now":    stats.clk.Now(),
+		})
+
+	return counts, err
+}
+
+func (stats *DBStatsEngine) ocspUpdatesByDayAndHour() ([]OCSPUpdatesByDayAndHour, error) {
+	var counts []OCSPUpdatesByDayAndHour
+	_, err := stats.DB.Select(&counts,
+		`SELECT
+          DATE(ocspLastUpdated) as Day,
+          HOUR(ocspLastUpdated) as Hour,
+          COUNT(1) as NumResponses
+      FROM
+          certificateStatus AS cs
+            NATURAL JOIN
+          certificates AS c
+      WHERE
+          c.expires > :now
+      GROUP BY DATE(ocspLastUpdated) , HOUR(ocspLastUpdated);`,
+		map[string]interface{}{"now": stats.clk.Now()})
+
+	return counts, err
+}
+
+func (stats *DBStatsEngine) ocspAging() (OCSPAging, error) {
+	var counts OCSPAging
+	err := stats.DB.SelectOne(&counts,
+		`SELECT
+          IFNULL(SUM(IF(cs.ocspLastUpdated > :now - INTERVAL 12 HOUR,1,0)),0) AS age12h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated BETWEEN :now - INTERVAL 24 HOUR AND :now - INTERVAL 12 HOUR,1,0)),0) AS age24h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated BETWEEN :now - INTERVAL 36 HOUR AND :now - INTERVAL 24 HOUR,1,0)),0) AS age36h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated BETWEEN :now - INTERVAL 48 HOUR AND :now - INTERVAL 36 HOUR,1,0)),0) AS age48h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated BETWEEN :now - INTERVAL 60 HOUR AND :now - INTERVAL 48 HOUR,1,0)),0) AS age60h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated BETWEEN :now - INTERVAL 72 HOUR AND :now - INTERVAL 60 HOUR,1,0)),0) AS age72h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated BETWEEN :now - INTERVAL 84 HOUR AND :now - INTERVAL 72 HOUR,1,0)),0) AS age84h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated BETWEEN :now - INTERVAL 97 HOUR AND :now - INTERVAL 84 HOUR,1,0)),0) AS age96h,
+          IFNULL(SUM(IF(cs.ocspLastUpdated < :now - INTERVAL 97 HOUR,1,0)),0) AS older
+      FROM
+          certificateStatus as cs
+            NATURAL JOIN
+          certificates AS c
+      WHERE
+          c.expires > :now;`,
+		map[string]interface{}{"now": stats.clk.Now()})
+
+	return counts, err
+}
+
+func (stats *DBStatsEngine) challengeCounts() ([]ChallengeCounts, error) {
+	// This would be better if there was a mechanism to select only recent
+	// challenges, but there's no direct way of determining the insertion
+	// date of challenges or authorizations, only their expiration which
+	// is dependent on the challenge lifespan configuration at the time
+	// it was inserted, which may be different than the current config.
+	var counts []ChallengeCounts
+	_, err := stats.DB.Select(&counts,
+		`SELECT
+          c.type AS Type,
+          COUNT(1) AS Completions
+      FROM
+          authz AS a
+            JOIN
+          challenges AS c ON a.id = c.authorizationID
+      WHERE
+          c.status = 'valid' AND a.expires > :now
+      GROUP BY c.type;`,
+		map[string]interface{}{"now": stats.clk.Now()})
+
+	return counts, err
+}
+
+func (stats *DBStatsEngine) runAndAppend(keyName string, dataMap map[string]interface{}, op func() (interface{}, error)) {
+	data, err := op()
+	if err != nil {
+		stats.Logger.Err(fmt.Sprintf("Failed to execute %s: %s", keyName, err))
+		return
+	}
+	dataMap[keyName] = data
+}
+
+func (stats *DBStatsEngine) Calculate() error {
+	enc := json.NewEncoder(stats.Writer)
+
+	var err error
+	data := &EncodedStats{}
+
+	data.RegistrationsPerDayByType, err = stats.registrationsPerDayByType()
+	if err != nil {
+		return fmt.Errorf("RegistrationsPerDayByType: %s", err)
+	}
+	data.CertsPerDayByStatus, err = stats.certificatesIssuedPerDayByStatus()
+	if err != nil {
+		return fmt.Errorf("CertsPerDayByStatus: %s", err)
+	}
+	data.OCSPUpdatesByDayAndHour, err = stats.ocspUpdatesByDayAndHour()
+	if err != nil {
+		return fmt.Errorf("OCSPUpdatesByDayAndHour: %s", err)
+	}
+	data.OCSPAging, err = stats.ocspAging()
+	if err != nil {
+		return fmt.Errorf("OCSPAging: %s", err)
+	}
+	data.ChallengeCounts, err = stats.challengeCounts()
+	if err != nil {
+		return fmt.Errorf("ChallengeCounts: %s", err)
+	}
+
+	return enc.Encode(data)
+}

--- a/statistics/dbstats_test.go
+++ b/statistics/dbstats_test.go
@@ -1,0 +1,533 @@
+// Copyright 2016 ISRG.  All rights reserved
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package statistics
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"github.com/square/go-jose"
+	"golang.org/x/net/context"
+	gorp "gopkg.in/gorp.v1"
+
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/core"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/mocks"
+	"github.com/letsencrypt/boulder/sa"
+	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
+)
+
+var log = blog.UseMock()
+var ctx = context.Background()
+var certCounter int64
+
+type TestLogger struct {
+	*testing.T
+}
+
+func (testLog *TestLogger) Printf(format string, args ...interface{}) {
+	testLog.Logf(format, args)
+}
+
+// initSA constructs a r/w SQLStorageAuthority and a clean up function
+// that should be defer'ed to the end of the test.
+func initSA(t *testing.T) (*gorp.DbMap, *sa.SQLStorageAuthority, clock.FakeClock, func()) {
+	dbMap, err := sa.NewDbMap(vars.DBConnSA, 0)
+	test.AssertNotError(t, err, "Should not error")
+
+	fc := clock.NewFake()
+	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
+
+	sa, err := sa.NewSQLStorageAuthority(dbMap, fc, log)
+	test.AssertNotError(t, err, "Should not error")
+
+	if testing.Verbose() && !testing.Short() {
+		dbMap.TraceOn("r/w", &TestLogger{t})
+	}
+
+	cleanUp := test.ResetSATestDatabase(t)
+	return dbMap, sa, fc, cleanUp
+}
+
+func parseConfigDuration(durationString string) cmd.ConfigDuration {
+	duration, _ := time.ParseDuration(durationString)
+	return cmd.ConfigDuration{Duration: duration}
+}
+
+func updateOCSP(t *testing.T, rwMap *gorp.DbMap, serial string, updateDate time.Time) {
+	_, err := rwMap.Exec(
+		`UPDATE certificateStatus
+     SET ocspResponse=?,ocspLastUpdated=?
+     WHERE serial=?`,
+		[]byte{},
+		updateDate,
+		serial,
+	)
+	test.AssertNotError(t, err, "Should not error")
+}
+
+func addCertificate(t *testing.T, rwMap *gorp.DbMap, saObj *sa.SQLStorageAuthority, ctx context.Context, regID int64, issueDate time.Time) *big.Int {
+	testKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "Should not error")
+
+	expiry := issueDate.AddDate(0, 0, 7)
+	serial := big.NewInt(certCounter)
+	certCounter += 1
+	rawCert := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "example.com",
+		},
+		NotBefore:    issueDate,
+		NotAfter:     expiry,
+		DNSNames:     []string{"example-a.com"},
+		SerialNumber: serial,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
+	test.AssertNotError(t, err, "Should not error")
+
+	_, err = saObj.AddCertificate(ctx, certDER, regID)
+	test.AssertNotError(t, err, "Should not error")
+
+	updateOCSP(t, rwMap, core.SerialToString(serial), issueDate)
+	return serial
+}
+
+func addRegistration(t *testing.T, sa core.StorageAdder, date time.Time) core.Registration {
+	contact, err := core.ParseAcmeURL("mailto:foo@example.com")
+	test.AssertNotError(t, err, "unable to parse contact link")
+
+	contacts := []*core.AcmeURL{contact}
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "unable to generate key")
+
+	reg, err := sa.NewRegistration(context.Background(), core.Registration{
+		Key:       jose.JsonWebKey{Key: privKey.Public()},
+		Contact:   contacts,
+		InitialIP: net.ParseIP("88.77.66.11"),
+		CreatedAt: date,
+	})
+	test.AssertNotError(t, err, "Should not error")
+	return reg
+}
+
+func TestNil(t *testing.T) {
+	stats := mocks.NewStatter()
+	duration := parseConfigDuration("5h")
+	log := blog.UseMock()
+	fc := clock.NewFake()
+
+	var outBuf bytes.Buffer
+
+	_, err := NewDBStatsEngine(nil, stats, fc, duration, &outBuf, log)
+	test.AssertError(t, err, "Engine construction should have errored")
+}
+
+func TestCalculateEmptyDB(t *testing.T) {
+	stats := mocks.NewStatter()
+	duration := parseConfigDuration("5h")
+	log := blog.UseMock()
+	fc := clock.NewFake()
+
+	var outBuf bytes.Buffer
+
+	dbMap, err := sa.NewDbMap(vars.DBConnSAStats, 0)
+	test.AssertNotError(t, err, "Should not error")
+
+	engine, err := NewDBStatsEngine(dbMap, stats, fc, duration, &outBuf, log)
+	test.AssertNotError(t, err, "Engine construction should have been OK")
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+
+	// Decode the JSON and ensure it's valid
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec := json.NewDecoder(&outBuf)
+
+	var resultObj EncodedStats
+	err = jdec.Decode(&resultObj)
+
+	test.Assert(t, len(resultObj.CertsPerDayByStatus) == 0, "CertsPerDayByStatus should be empty")
+	test.Assert(t, len(resultObj.ChallengeCounts) == 0, "ChallengeCounts should be empty")
+	test.Assert(t, len(resultObj.OCSPUpdatesByDayAndHour) == 0, "OCSPUpdatesByDayAndHour should be empty")
+	test.Assert(t, len(resultObj.RegistrationsPerDayByType) == 0, "RegistrationsPerDayByType should be empty")
+}
+
+func TestCalculateCertsPerDayByStatus(t *testing.T) {
+	stats := mocks.NewStatter()
+	log := blog.UseMock()
+	duration := parseConfigDuration("999h")
+	var outBuf bytes.Buffer
+
+	// Prepare DB
+	rwMap, saObj, fc, cleanUp := initSA(t)
+	defer cleanUp()
+
+	reg := addRegistration(t, saObj, fc.Now())
+
+	// Add one certificate
+	firstSerial := addCertificate(t, rwMap, saObj, ctx, reg.ID, fc.Now())
+
+	dbMap, err := sa.NewDbMap(vars.DBConnSAStats, 0)
+	test.AssertNotError(t, err, "Should not error")
+
+	if testing.Verbose() && !testing.Short() {
+		dbMap.TraceOn("r/o", &TestLogger{t})
+	}
+
+	engine, err := NewDBStatsEngine(dbMap, stats, fc, duration, &outBuf, log)
+	test.AssertNotError(t, err, "Engine construction should have been OK")
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+
+	// Decode the JSON and ensure it's valid
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec := json.NewDecoder(&outBuf)
+
+	var resultObj EncodedStats
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	test.Assert(t, len(resultObj.CertsPerDayByStatus) > 0, "CertsPerDayByStatus shouldn't be empty")
+	test.Assert(t, resultObj.CertsPerDayByStatus[0].IssuedDate.Sub(fc.Now()).Hours() < 24, "Date should be within 24 hours of reference date")
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].StillValid, int64(1))
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].Revoked, int64(0))
+
+	// Add more certificates to the same day
+	for i := 0; i < 32; i++ {
+		dur, _ := time.ParseDuration("1m")
+		fc.Add(dur)
+		_ = addCertificate(t, rwMap, saObj, ctx, reg.ID, fc.Now())
+	}
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	test.Assert(t, len(resultObj.CertsPerDayByStatus) > 0, "CertsPerDayByStatus shouldn't be empty")
+	test.Assert(t, resultObj.CertsPerDayByStatus[0].IssuedDate.Sub(fc.Now()).Hours() < 24, "Date should be within 24 hours of reference date")
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].StillValid, int64(33))
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].Revoked, int64(0))
+
+	// Add more certificates, one per day
+	for i := 0; i < 6; i++ {
+		dur, _ := time.ParseDuration("24h")
+		fc.Add(dur)
+		_ = addCertificate(t, rwMap, saObj, ctx, reg.ID, fc.Now())
+	}
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	t.Logf("%+v \n", resultObj)
+
+	test.Assert(t, len(resultObj.CertsPerDayByStatus) > 0, "CertsPerDayByStatus shouldn't be empty")
+	test.Assert(t, resultObj.CertsPerDayByStatus[0].IssuedDate.Sub(fc.Now()).Hours() < 24, "Date should be within 24 hours of reference date")
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].StillValid, int64(33))
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].Revoked, int64(0))
+	for i := 1; i < 6; i++ {
+		test.AssertEquals(t, resultObj.CertsPerDayByStatus[i].StillValid, int64(1))
+		test.AssertEquals(t, resultObj.CertsPerDayByStatus[i].Revoked, int64(0))
+	}
+
+	// Revoke a certificate
+	err = saObj.MarkCertificateRevoked(ctx, core.SerialToString(firstSerial), core.RevocationCode(1))
+	test.AssertNotError(t, err, "Should not error on revocation")
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].StillValid, int64(32))
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].Revoked, int64(1))
+
+	// Move forward one more day, so that the first certs expire
+	dur, _ := time.ParseDuration("24h")
+	fc.Add(dur)
+
+	// Now there should be just one cert on the first day
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].StillValid, int64(1))
+	test.AssertEquals(t, resultObj.CertsPerDayByStatus[0].Revoked, int64(0))
+}
+
+func TestRegistrationsPerDayByType(t *testing.T) {
+	stats := mocks.NewStatter()
+	log := blog.UseMock()
+	duration := parseConfigDuration("999h")
+	var outBuf bytes.Buffer
+
+	// Prepare DB
+	_, saObj, fc, cleanUp := initSA(t)
+	defer cleanUp()
+
+	dbMap, err := sa.NewDbMap(vars.DBConnSAStats, 0)
+	test.AssertNotError(t, err, "Should not error")
+
+	if testing.Verbose() && !testing.Short() {
+		dbMap.TraceOn("r/o", &TestLogger{t})
+	}
+
+	engine, err := NewDBStatsEngine(dbMap, stats, fc, duration, &outBuf, log)
+	test.AssertNotError(t, err, "Engine construction should have been OK")
+	_ = addRegistration(t, saObj, fc.Now())
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec := json.NewDecoder(&outBuf)
+
+	var resultObj EncodedStats
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	test.Assert(t, resultObj.RegistrationsPerDayByType[0].CreateDate.Sub(fc.Now()).Hours() < 24, "Date should be within 24 hours of reference date")
+	test.AssertEquals(t, resultObj.RegistrationsPerDayByType[0].WithContact, int64(1))
+
+	// Add more registations, one per day
+	for i := 0; i < 14; i++ {
+		dur, _ := time.ParseDuration("24h")
+		fc.Add(dur)
+		_ = addRegistration(t, saObj, fc.Now())
+	}
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+	t.Logf("%+v \n", resultObj)
+	for i := 0; i < 15; i++ {
+		test.AssertEquals(t, resultObj.RegistrationsPerDayByType[i].WithContact, int64(1))
+		test.AssertEquals(t, resultObj.RegistrationsPerDayByType[i].Anonymous, int64(0))
+	}
+}
+
+func TestOCSPUpdates(t *testing.T) {
+	stats := mocks.NewStatter()
+	log := blog.UseMock()
+	duration := parseConfigDuration("0h") // Unused
+	var outBuf bytes.Buffer
+
+	// Prepare DB
+	rwMap, saObj, fc, cleanUp := initSA(t)
+	defer cleanUp()
+
+	dbMap, err := sa.NewDbMap(vars.DBConnSAStats, 0)
+	test.AssertNotError(t, err, "Should not error")
+
+	if testing.Verbose() && !testing.Short() {
+		dbMap.TraceOn("r/o", &TestLogger{t})
+	}
+
+	engine, err := NewDBStatsEngine(dbMap, stats, fc, duration, &outBuf, log)
+	test.AssertNotError(t, err, "Engine construction should have been OK")
+
+	reg := addRegistration(t, saObj, fc.Now())
+
+	// Certificates
+	for i := 0; i < 24; i++ {
+		dur, _ := time.ParseDuration("1h")
+		fc.Add(dur)
+		_ = addCertificate(t, rwMap, saObj, ctx, reg.ID, fc.Now())
+	}
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec := json.NewDecoder(&outBuf)
+
+	var resultObj EncodedStats
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	for i := 0; i < 24; i++ {
+		test.AssertEquals(t, resultObj.OCSPUpdatesByDayAndHour[i].NumResponses, int64(1))
+		// StartHour=5, and we pre-increment the clock (+1). Mod 24 to constrain to hour of day.
+		test.AssertEquals(t, resultObj.OCSPUpdatesByDayAndHour[i].Hour, int64((i+5+1)%24))
+	}
+
+	// Add another certificate to now
+	_ = addCertificate(t, rwMap, saObj, ctx, reg.ID, fc.Now())
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	test.AssertEquals(t, resultObj.OCSPUpdatesByDayAndHour[23].NumResponses, int64(2))
+
+	// Now also evaluate the OCSPAging
+	test.AssertEquals(t, resultObj.OCSPAging.Age12h, int64(13))
+	test.AssertEquals(t, resultObj.OCSPAging.Age24h, int64(12))
+
+	// Move forward 96 hours
+	dur, _ := time.ParseDuration("96h")
+	fc.Add(dur)
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	test.AssertEquals(t, resultObj.OCSPAging.Age96h, int64(3))
+	test.AssertEquals(t, resultObj.OCSPAging.Older, int64(22))
+}
+
+func TestChallengeCounts(t *testing.T) {
+	stats := mocks.NewStatter()
+	log := blog.UseMock()
+	duration := parseConfigDuration("0h") // Unused
+	var outBuf bytes.Buffer
+
+	// Prepare DB
+	_, saObj, fc, cleanUp := initSA(t)
+	defer cleanUp()
+
+	dbMap, err := sa.NewDbMap(vars.DBConnSAStats, 0)
+	test.AssertNotError(t, err, "Should not error")
+
+	if testing.Verbose() && !testing.Short() {
+		dbMap.TraceOn("r/o", &TestLogger{t})
+	}
+
+	engine, err := NewDBStatsEngine(dbMap, stats, fc, duration, &outBuf, log)
+	test.AssertNotError(t, err, "Engine construction should have been OK")
+
+	reg := addRegistration(t, saObj, fc.Now())
+
+	futureExpiryTime := fc.Now().AddDate(0, 0, 7)
+
+	for i := 0; i < 10; i++ {
+		authz, err := saObj.NewPendingAuthorization(ctx, core.Authorization{
+			RegistrationID: reg.ID,
+			Challenges:     []core.Challenge{core.HTTPChallenge01(&reg.Key)},
+			Expires:        &futureExpiryTime,
+		})
+		test.AssertNotError(t, err, "Should not error")
+
+		// Mark some challenges as done
+		authz.Challenges[0].Status = core.StatusValid
+
+		err = saObj.FinalizeAuthorization(ctx, authz)
+		test.AssertNotError(t, err, "Should not error")
+	}
+
+	var resultObj EncodedStats
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec := json.NewDecoder(&outBuf)
+
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	test.AssertEquals(t, resultObj.ChallengeCounts[0].Type, "http-01")
+	test.AssertEquals(t, resultObj.ChallengeCounts[0].Completions, int64(10))
+
+	// Add more valid challenges
+	for i := 0; i < 10; i++ {
+		authz, err := saObj.NewPendingAuthorization(ctx, core.Authorization{
+			RegistrationID: reg.ID,
+			Challenges:     []core.Challenge{core.DNSChallenge01(&reg.Key), core.TLSSNIChallenge01(&reg.Key)},
+			Expires:        &futureExpiryTime,
+		})
+		test.AssertNotError(t, err, "Should not error")
+
+		// Mark both challenges as done
+		authz.Challenges[0].Status = core.StatusValid
+		authz.Challenges[1].Status = core.StatusValid
+
+		err = saObj.FinalizeAuthorization(ctx, authz)
+		test.AssertNotError(t, err, "Should not error")
+	}
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	t.Logf("%+v", resultObj.ChallengeCounts)
+	test.AssertEquals(t, resultObj.ChallengeCounts[0].Type, "dns-01")
+	test.AssertEquals(t, resultObj.ChallengeCounts[0].Completions, int64(10))
+	test.AssertEquals(t, resultObj.ChallengeCounts[1].Type, "http-01")
+	test.AssertEquals(t, resultObj.ChallengeCounts[1].Completions, int64(10))
+	test.AssertEquals(t, resultObj.ChallengeCounts[2].Type, "tls-sni-01")
+	test.AssertEquals(t, resultObj.ChallengeCounts[2].Completions, int64(10))
+
+	// Add invalid challenges
+	for i := 0; i < 10; i++ {
+		authz, err := saObj.NewPendingAuthorization(ctx, core.Authorization{
+			RegistrationID: reg.ID,
+			Challenges:     []core.Challenge{core.DNSChallenge01(&reg.Key), core.TLSSNIChallenge01(&reg.Key)},
+			Expires:        &futureExpiryTime,
+		})
+		test.AssertNotError(t, err, "Should not error")
+
+		// Mark both challenges as done
+		authz.Challenges[0].Status = core.StatusInvalid
+		authz.Challenges[1].Status = core.StatusPending
+
+		err = saObj.FinalizeAuthorization(ctx, authz)
+		test.AssertNotError(t, err, "Should not error")
+	}
+
+	err = engine.Calculate()
+	test.AssertNotError(t, err, "Should not error")
+	test.Assert(t, outBuf.Len() > 0, "Should have output")
+	jdec = json.NewDecoder(&outBuf)
+	err = jdec.Decode(&resultObj)
+	test.AssertNotError(t, err, "Should not error")
+
+	t.Logf("%+v", resultObj.ChallengeCounts)
+	test.AssertEquals(t, resultObj.ChallengeCounts[0].Type, "dns-01")
+	test.AssertEquals(t, resultObj.ChallengeCounts[0].Completions, int64(10))
+	test.AssertEquals(t, resultObj.ChallengeCounts[1].Type, "http-01")
+	test.AssertEquals(t, resultObj.ChallengeCounts[1].Completions, int64(10))
+	test.AssertEquals(t, resultObj.ChallengeCounts[2].Type, "tls-sni-01")
+	test.AssertEquals(t, resultObj.ChallengeCounts[2].Completions, int64(10))
+}

--- a/test/config/statistics.json
+++ b/test/config/statistics.json
@@ -1,0 +1,16 @@
+{
+  "statistics": {
+    "dbConnectFile": "test/secrets/statistics_dburl",
+    "timeWindow": "2160h",
+    "outputPath": ""
+  },
+
+  "statsd": {
+    "server": "localhost:8125",
+    "prefix": "Boulder"
+  },
+
+  "syslog": {
+    "stdoutlevel": 6
+  }
+}

--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -26,6 +26,7 @@ CREATE USER IF NOT EXISTS 'cert_checker'@'localhost';
 CREATE USER IF NOT EXISTS 'ocsp_update'@'localhost';
 CREATE USER IF NOT EXISTS 'test_setup'@'localhost';
 CREATE USER IF NOT EXISTS 'purger'@'localhost';
+CREATE USER IF NOT EXISTS 'statistics'@'localhost';
 
 -- Storage Authority
 GRANT SELECT,INSERT,UPDATE ON authz TO 'sa'@'localhost';
@@ -69,6 +70,9 @@ GRANT SELECT ON certificates TO 'cert_checker'@'localhost';
 
 -- Expired authorization purger
 GRANT SELECT,DELETE ON pendingAuthorizations TO 'purger'@'localhost';
+
+-- Statistics
+GRANT SELECT ON * TO 'statistics'@'localhost';
 
 -- Test setup and teardown
 GRANT ALL PRIVILEGES ON * to 'test_setup'@'localhost';

--- a/test/secrets/statistics_dburl
+++ b/test/secrets/statistics_dburl
@@ -1,0 +1,1 @@
+mysql+tcp://statistics@boulder-mysql:3306/boulder_sa_integration?readTimeout=14s&writeTimeout=14s

--- a/test/vars/vars.go
+++ b/test/vars/vars.go
@@ -21,4 +21,6 @@ var (
 	DBConnSAFullPerms = fmt.Sprintf(dbURL, "test_setup", "boulder_sa_test")
 	// DBConnSAOcspResp is the sa ocsp_resp database connection
 	DBConnSAOcspResp = fmt.Sprintf(dbURL, "ocsp_resp", "boulder_sa_test")
+	// DBConnStats is the statistics database connection
+	DBConnSAStats = fmt.Sprintf(dbURL, "statistics", "boulder_sa_test")
 )


### PR DESCRIPTION
This is a direct port of the `dataviz/plot.py` in current use by Let's Encrypt for statistics generation. Unlike `plot.py` however, this does not format for any particular graphing library, it instead produces a raw JSON output that can itself be processed into graphs.

NOTE: This _does not improve_ the queries. That should certainly be done, as several of them make poor use of indices or produce relatively worthless data. This commit is merely to reach feature parity, permit a wider audience to contribute to stats generation, obtain [glorious feedback benefit from teams of both devs and ops](https://twitter.com/devops_borat). I will work to improve the queries after we get the approach nailed down and landed.

The design for this feature is that it should be run periodically against a read-only replica of the Boulder database, producing a JSON output file which can be transmitted somehow out of the trusted datacenter environment to a remote server and processed into graphs.

Processing the output of this tool into pretty graphs will happen elsewhere, outside the responsibility of Boulder. I intended to write the first pass of that software; I will get started on that after this lands.

Generally, the changes are:

- Adds a new "statistics" read-only user to the DB
- Sets up the Boulder "next" config to include this command
- Adds a "statistics" command to the Boulder package, which can be executed similarly to any other Boulder command.
- Re-implement all of the `dataviz/plot.py` SQL queries in Golang
- Implement tests for those queries