### PR TITLE
Allow removing registration contact.

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -205,7 +205,7 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 			continue
 		}
 
-		err = m.sendNags(reg.Contact, parsedCerts)
+		err = m.sendNags(*reg.Contact, parsedCerts)
 		if err != nil {
 			m.log.AuditErr(fmt.Sprintf("Error sending nag emails: %s", err))
 			continue

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -203,7 +203,7 @@ func TestFindExpiringCertificates(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
 	regA := core.Registration{
 		ID: 1,
-		Contact: []*core.AcmeURL{
+		Contact: &[]*core.AcmeURL{
 			emailA,
 		},
 		Key:       keyA,
@@ -211,7 +211,7 @@ func TestFindExpiringCertificates(t *testing.T) {
 	}
 	regB := core.Registration{
 		ID: 2,
-		Contact: []*core.AcmeURL{
+		Contact: &[]*core.AcmeURL{
 			emailB,
 		},
 		Key:       keyB,
@@ -219,7 +219,7 @@ func TestFindExpiringCertificates(t *testing.T) {
 	}
 	regC := core.Registration{
 		ID: 3,
-		Contact: []*core.AcmeURL{
+		Contact: &[]*core.AcmeURL{
 			emailB,
 		},
 		Key:       keyC,
@@ -528,7 +528,7 @@ func TestLifetimeOfACert(t *testing.T) {
 
 	regA := core.Registration{
 		ID: 1,
-		Contact: []*core.AcmeURL{
+		Contact: &[]*core.AcmeURL{
 			emailA,
 		},
 		Key:       keyA,
@@ -633,7 +633,7 @@ func TestDontFindRevokedCert(t *testing.T) {
 
 	regA := core.Registration{
 		ID: 1,
-		Contact: []*core.AcmeURL{
+		Contact: &[]*core.AcmeURL{
 			emailA,
 		},
 		Key:       keyA,
@@ -689,7 +689,7 @@ func TestDedupOnRegistration(t *testing.T) {
 
 	regA := core.Registration{
 		ID: 1,
-		Contact: []*core.AcmeURL{
+		Contact: &[]*core.AcmeURL{
 			emailA,
 		},
 		Key:       keyA,

--- a/core/objects.go
+++ b/core/objects.go
@@ -146,7 +146,7 @@ type Registration struct {
 	Key jose.JsonWebKey `json:"key"`
 
 	// Contact URIs
-	Contact []*AcmeURL `json:"contact,omitempty"`
+	Contact *[]*AcmeURL `json:"contact,omitempty"`
 
 	// Agreement with terms of service
 	Agreement string `json:"agreement,omitempty"`
@@ -163,8 +163,12 @@ type Registration struct {
 func (r *Registration) MergeUpdate(input Registration) {
 	// Note: we allow input.Contact to overwrite r.Contact even if the former is
 	// empty in order to allow users to remove the contact associated with
-	// a registration
-	r.Contact = input.Contact
+	// a registration. Since the field type is a pointer to slice of pointers we
+	// can perform a nil check to differentiate between an empty value and a nil
+	// (e.g. not provided) value
+	if input.Contact != nil {
+		r.Contact = input.Contact
+	}
 
 	if len(input.Agreement) > 0 {
 		r.Agreement = input.Agreement

--- a/core/objects.go
+++ b/core/objects.go
@@ -161,9 +161,10 @@ type Registration struct {
 // MergeUpdate copies a subset of information from the input Registration
 // into this one.
 func (r *Registration) MergeUpdate(input Registration) {
-	if len(input.Contact) > 0 {
-		r.Contact = input.Contact
-	}
+	// Note: we allow input.Contact to overwrite r.Contact even if the former is
+	// empty in order to allow users to remove the contact associated with
+	// a registration
+	r.Contact = input.Contact
 
 	if len(input.Agreement) > 0 {
 		r.Agreement = input.Agreement

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -28,6 +28,14 @@ func TestRegistrationUpdate(t *testing.T) {
 	reg.MergeUpdate(update)
 	test.Assert(t, len(reg.Contact) == 1 && reg.Contact[0] == update.Contact[0], "Contact was not updated %v != %v")
 	test.Assert(t, reg.Agreement == update.Agreement, "Agreement was not updated")
+
+	// Test that a registration contact can be removed by updating with an empty
+	// Contact slice.
+	contactRemoveUpdate := Registration{
+		Contact: []*AcmeURL(nil),
+	}
+	reg.MergeUpdate(contactRemoveUpdate)
+	test.Assert(t, len(reg.Contact) == 0, "Contact was not deleted in update")
 }
 
 var testKey1, _ = rsa.GenerateKey(rand.Reader, 2048)

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -28,14 +28,57 @@ func TestRegistrationUpdate(t *testing.T) {
 	reg.MergeUpdate(update)
 	test.Assert(t, len(*reg.Contact) == 1 && (*reg.Contact)[0] == (*update.Contact)[0], "Contact was not updated %v != %v")
 	test.Assert(t, reg.Agreement == update.Agreement, "Agreement was not updated")
+}
+
+func TestRegistrationContactUpdate(t *testing.T) {
+	contactURL, _ := ParseAcmeURL("mailto://example@example.com")
+	fullReg := Registration{
+		ID:        1,
+		Contact:   &[]*AcmeURL{contactURL},
+		Agreement: "totally!",
+	}
 
 	// Test that a registration contact can be removed by updating with an empty
 	// Contact slice.
-	contactRemoveUpdate := Registration{
-		Contact: &[]*AcmeURL{},
+	reg := fullReg
+	var contactRemoveUpdate Registration
+	contactRemoveJSON := []byte(`
+	{
+		"key": {
+			"e": "AQAB",
+			"kty": "RSA",
+			"n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_"
+		},
+		"id": 1,
+		"contact": [],
+		"agreement": "totally!"
 	}
+	`)
+	err := json.Unmarshal(contactRemoveJSON, &contactRemoveUpdate)
+	test.AssertNotError(t, err, "Failed to unmarshal contactRemoveJSON")
 	reg.MergeUpdate(contactRemoveUpdate)
 	test.Assert(t, len(*reg.Contact) == 0, "Contact was not deleted in update")
+
+	// Test that a registration contact isn't changed when an update is performed
+	// with no Contact field
+	reg = fullReg
+	var contactSameUpdate Registration
+	contactSameJSON := []byte(`
+	{
+		"key": {
+			"e": "AQAB",
+			"kty": "RSA",
+			"n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_"
+		},
+		"id": 1,
+		"agreement": "changed my mind!"
+	}
+	`)
+	err = json.Unmarshal(contactSameJSON, &contactSameUpdate)
+	test.AssertNotError(t, err, "Failed to unmarshal contactSameJSON")
+	reg.MergeUpdate(contactSameUpdate)
+	test.Assert(t, len(*reg.Contact) == 1, "len(Contact) was updated unexpectedly")
+	test.Assert(t, (*reg.Contact)[0].String() == "mailto://example@example.com", "Contact was changed unexpectedly")
 }
 
 var testKey1, _ = rsa.GenerateKey(rand.Reader, 2048)

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -17,25 +17,25 @@ func TestRegistrationUpdate(t *testing.T) {
 	newURL, _ := ParseAcmeURL("http://new.invalid")
 	reg := Registration{
 		ID:        1,
-		Contact:   []*AcmeURL{oldURL},
+		Contact:   &[]*AcmeURL{oldURL},
 		Agreement: "",
 	}
 	update := Registration{
-		Contact:   []*AcmeURL{newURL},
+		Contact:   &[]*AcmeURL{newURL},
 		Agreement: "totally!",
 	}
 
 	reg.MergeUpdate(update)
-	test.Assert(t, len(reg.Contact) == 1 && reg.Contact[0] == update.Contact[0], "Contact was not updated %v != %v")
+	test.Assert(t, len(*reg.Contact) == 1 && (*reg.Contact)[0] == (*update.Contact)[0], "Contact was not updated %v != %v")
 	test.Assert(t, reg.Agreement == update.Agreement, "Agreement was not updated")
 
 	// Test that a registration contact can be removed by updating with an empty
 	// Contact slice.
 	contactRemoveUpdate := Registration{
-		Contact: []*AcmeURL(nil),
+		Contact: &[]*AcmeURL{},
 	}
 	reg.MergeUpdate(contactRemoveUpdate)
-	test.Assert(t, len(reg.Contact) == 0, "Contact was not deleted in update")
+	test.Assert(t, len(*reg.Contact) == 0, "Contact was not deleted in update")
 }
 
 var testKey1, _ = rsa.GenerateKey(rand.Reader, 2048)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -284,7 +284,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, init c
 }
 
 func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, contacts *[]*core.AcmeURL) error {
-	if contacts == nil {
+	if contacts == nil || len(*contacts) == 0 {
 		return nil // Nothing to validate
 	}
 	if ra.maxContactsPerReg > 0 && len(*contacts) > ra.maxContactsPerReg {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -283,13 +283,16 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, init c
 	return
 }
 
-func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, contacts []*core.AcmeURL) error {
-	if ra.maxContactsPerReg > 0 && len(contacts) > ra.maxContactsPerReg {
+func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, contacts *[]*core.AcmeURL) error {
+	if contacts == nil {
+		return nil // Nothing to validate
+	}
+	if ra.maxContactsPerReg > 0 && len(*contacts) > ra.maxContactsPerReg {
 		return core.MalformedRequestError(fmt.Sprintf("Too many contacts provided: %d > %d",
-			len(contacts), ra.maxContactsPerReg))
+			len(*contacts), ra.maxContactsPerReg))
 	}
 
-	for _, contact := range contacts {
+	for _, contact := range *contacts {
 		if contact == nil {
 			return core.MalformedRequestError("Invalid contact")
 		}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -286,22 +286,22 @@ func TestValidateContacts(t *testing.T) {
 	otherValidEmail, _ := core.ParseAcmeURL("mailto:other-admin@email.com")
 	malformedEmail, _ := core.ParseAcmeURL("mailto:admin.com")
 
-	err := ra.validateContacts(context.Background(), []*core.AcmeURL{})
+	err := ra.validateContacts(context.Background(), &[]*core.AcmeURL{})
 	test.AssertNotError(t, err, "No Contacts")
 
-	err = ra.validateContacts(context.Background(), []*core.AcmeURL{validEmail, otherValidEmail})
+	err = ra.validateContacts(context.Background(), &[]*core.AcmeURL{validEmail, otherValidEmail})
 	test.AssertError(t, err, "Too Many Contacts")
 
-	err = ra.validateContacts(context.Background(), []*core.AcmeURL{validEmail})
+	err = ra.validateContacts(context.Background(), &[]*core.AcmeURL{validEmail})
 	test.AssertNotError(t, err, "Valid Email")
 
-	err = ra.validateContacts(context.Background(), []*core.AcmeURL{malformedEmail})
+	err = ra.validateContacts(context.Background(), &[]*core.AcmeURL{malformedEmail})
 	test.AssertError(t, err, "Malformed Email")
 
-	err = ra.validateContacts(context.Background(), []*core.AcmeURL{ansible})
+	err = ra.validateContacts(context.Background(), &[]*core.AcmeURL{ansible})
 	test.AssertError(t, err, "Unknown scheme")
 
-	err = ra.validateContacts(context.Background(), []*core.AcmeURL{nil})
+	err = ra.validateContacts(context.Background(), &[]*core.AcmeURL{nil})
 	test.AssertError(t, err, "Nil AcmeURL")
 }
 
@@ -345,7 +345,7 @@ func TestNewRegistration(t *testing.T) {
 	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
-		Contact:   []*core.AcmeURL{mailto},
+		Contact:   &[]*core.AcmeURL{mailto},
 		Key:       AccountKeyB,
 		InitialIP: net.ParseIP("7.6.6.5"),
 	}
@@ -356,8 +356,8 @@ func TestNewRegistration(t *testing.T) {
 	}
 
 	test.Assert(t, core.KeyDigestEquals(result.Key, AccountKeyB), "Key didn't match")
-	test.Assert(t, len(result.Contact) == 1, "Wrong number of contacts")
-	test.Assert(t, mailto.String() == result.Contact[0].String(),
+	test.Assert(t, len(*result.Contact) == 1, "Wrong number of contacts")
+	test.Assert(t, mailto.String() == (*result.Contact)[0].String(),
 		"Contact didn't match")
 	test.Assert(t, result.Agreement == "", "Agreement didn't default empty")
 
@@ -373,7 +373,7 @@ func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
 	input := core.Registration{
 		ID:        23,
 		Key:       AccountKeyC,
-		Contact:   []*core.AcmeURL{mailto},
+		Contact:   &[]*core.AcmeURL{mailto},
 		Agreement: "I agreed",
 		InitialIP: net.ParseIP("5.0.5.0"),
 	}
@@ -400,7 +400,7 @@ func TestNewRegistrationBadKey(t *testing.T) {
 	defer cleanUp()
 	mailto, _ := core.ParseAcmeURL("mailto:foo@letsencrypt.org")
 	input := core.Registration{
-		Contact: []*core.AcmeURL{mailto},
+		Contact: &[]*core.AcmeURL{mailto},
 		Key:     ShortKey,
 	}
 

--- a/sa/model.go
+++ b/sa/model.go
@@ -75,11 +75,14 @@ func registrationToModel(r *core.Registration) (*regModel, error) {
 	if r.InitialIP == nil {
 		return nil, fmt.Errorf("initialIP was nil")
 	}
+	if r.Contact == nil {
+		r.Contact = &[]*core.AcmeURL{}
+	}
 	rm := &regModel{
 		ID:        r.ID,
 		Key:       key,
 		KeySHA256: sha,
-		Contact:   r.Contact,
+		Contact:   *r.Contact,
 		Agreement: r.Agreement,
 		InitialIP: []byte(r.InitialIP.To16()),
 		CreatedAt: r.CreatedAt,
@@ -97,7 +100,7 @@ func modelToRegistration(rm *regModel) (core.Registration, error) {
 	r := core.Registration{
 		ID:        rm.ID,
 		Key:       *k,
-		Contact:   rm.Contact,
+		Contact:   &rm.Contact,
 		Agreement: rm.Agreement,
 		InitialIP: net.IP(rm.InitialIP),
 		CreatedAt: rm.CreatedAt,

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -69,7 +69,7 @@ func TestAddRegistration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to parse contact link: %s", err)
 	}
-	contacts := []*core.AcmeURL{contact}
+	contacts := &[]*core.AcmeURL{contact}
 	reg, err := sa.NewRegistration(ctx, core.Registration{
 		Key:       jwk,
 		Contact:   contacts,
@@ -101,7 +101,7 @@ func TestAddRegistration(t *testing.T) {
 	newReg := core.Registration{
 		ID:        reg.ID,
 		Key:       jwk,
-		Contact:   []*core.AcmeURL{u},
+		Contact:   &[]*core.AcmeURL{u},
 		InitialIP: net.ParseIP("72.72.72.72"),
 		Agreement: "yes",
 	}
@@ -596,19 +596,19 @@ func TestCountRegistrationsByIP(t *testing.T) {
 
 	_, err := sa.NewRegistration(ctx, core.Registration{
 		Key:       jose.JsonWebKey{Key: &rsa.PublicKey{N: big.NewInt(1), E: 1}},
-		Contact:   []*core.AcmeURL{&contact},
+		Contact:   &[]*core.AcmeURL{&contact},
 		InitialIP: net.ParseIP("43.34.43.34"),
 	})
 	test.AssertNotError(t, err, "Couldn't insert registration")
 	_, err = sa.NewRegistration(ctx, core.Registration{
 		Key:       jose.JsonWebKey{Key: &rsa.PublicKey{N: big.NewInt(2), E: 1}},
-		Contact:   []*core.AcmeURL{&contact},
+		Contact:   &[]*core.AcmeURL{&contact},
 		InitialIP: net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9652"),
 	})
 	test.AssertNotError(t, err, "Couldn't insert registration")
 	_, err = sa.NewRegistration(ctx, core.Registration{
 		Key:       jose.JsonWebKey{Key: &rsa.PublicKey{N: big.NewInt(3), E: 1}},
-		Contact:   []*core.AcmeURL{&contact},
+		Contact:   &[]*core.AcmeURL{&contact},
 		InitialIP: net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9653"),
 	})
 	test.AssertNotError(t, err, "Couldn't insert registration")

--- a/sa/satest/satest.go
+++ b/sa/satest/satest.go
@@ -44,7 +44,7 @@ func CreateWorkingRegistration(t *testing.T, sa core.StorageAdder) core.Registra
 	if err != nil {
 		t.Fatalf("unable to parse contact link: %s", err)
 	}
-	contacts := []*core.AcmeURL{contact}
+	contacts := &[]*core.AcmeURL{contact}
 	reg, err := sa.NewRegistration(context.Background(), core.Registration{
 		Key:       GoodJWK(),
 		Contact:   contacts,

--- a/wfe/context.go
+++ b/wfe/context.go
@@ -23,7 +23,7 @@ type requestEvent struct {
 	ResponseTime  time.Time `json:",omitempty"`
 	Errors        []string
 	Requester     int64                  `json:",omitempty"`
-	Contacts      []*core.AcmeURL        `json:",omitempty"`
+	Contacts      *[]*core.AcmeURL       `json:",omitempty"`
 	RequestNonce  string                 `json:",omitempty"`
 	ResponseNonce string                 `json:",omitempty"`
 	UserAgent     string                 `json:",omitempty"`

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -860,8 +860,8 @@ func TestNewECDSARegistration(t *testing.T) {
 	var reg core.Registration
 	err = json.Unmarshal([]byte(responseWriter.Body.String()), &reg)
 	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")
-	test.Assert(t, len(reg.Contact) >= 1, "No contact field in registration")
-	test.AssertEquals(t, reg.Contact[0].String(), "mailto:person@mail.com")
+	test.Assert(t, len(*reg.Contact) >= 1, "No contact field in registration")
+	test.AssertEquals(t, (*reg.Contact)[0].String(), "mailto:person@mail.com")
 	test.AssertEquals(t, reg.Agreement, "http://example.invalid/terms")
 	test.AssertEquals(t, reg.InitialIP.String(), "1.1.1.1")
 
@@ -980,8 +980,8 @@ func TestNewRegistration(t *testing.T) {
 	var reg core.Registration
 	err = json.Unmarshal([]byte(responseWriter.Body.String()), &reg)
 	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")
-	test.Assert(t, len(reg.Contact) >= 1, "No contact field in registration")
-	test.AssertEquals(t, reg.Contact[0].String(), "mailto:person@mail.com")
+	test.Assert(t, len(*reg.Contact) >= 1, "No contact field in registration")
+	test.AssertEquals(t, (*reg.Contact)[0].String(), "mailto:person@mail.com")
 	test.AssertEquals(t, reg.Agreement, "http://example.invalid/terms")
 	test.AssertEquals(t, reg.InitialIP.String(), "1.1.1.1")
 


### PR DESCRIPTION
The RA `UpdateRegistration` function merges a base registration object with an update by calling `Registration.MergeUpdate`. Prior to this commit `MergeUpdate` only allowed the updated registration object to overwrite the `Contact` field of the existing registration if the updated reg. defined at least one `AcmeURL`. This prevented clients from being able to outright *remove* the contact associated with an existing registration.

This commit removes the `len()` check on the `input.Contact` in `MergeUpdate` to allow the `r.Contact` field to be overwritten by a `[]*core.AcmeURL(nil)` `Contact` field. Subsequently clients can now send an empty contacts list in the update registration POST in order to remove their reg contact.

Fixes #1846