### PR TITLE
Remove support for TCP-based logging

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -444,7 +444,6 @@ type GoogleSafeBrowsingConfig struct {
 
 // SyslogConfig defines the config for syslogging.
 type SyslogConfig struct {
-	Network     string
 	Server      string
 	StdoutLevel *int
 	SyslogLevel *int

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -444,7 +444,6 @@ type GoogleSafeBrowsingConfig struct {
 
 // SyslogConfig defines the config for syslogging.
 type SyslogConfig struct {
-	Server      string
 	StdoutLevel *int
 	SyslogLevel *int
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -183,7 +183,7 @@ func StatsAndLogging(statConf StatsdConfig, logConf SyslogConfig) (metrics.Statt
 
 	tag := path.Base(os.Args[0])
 	syslogger, err := syslog.Dial(
-		logConf.Network,
+		"",
 		logConf.Server,
 		syslog.LOG_INFO|syslog.LOG_LOCAL0, // default, overridden by log calls
 		tag)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -184,7 +184,7 @@ func StatsAndLogging(statConf StatsdConfig, logConf SyslogConfig) (metrics.Statt
 	tag := path.Base(os.Args[0])
 	syslogger, err := syslog.Dial(
 		"",
-		logConf.Server,
+		"",
 		syslog.LOG_INFO|syslog.LOG_LOCAL0, // default, overridden by log calls
 		tag)
 	FailOnError(err, "Could not connect to Syslog")

--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -1,6 +1,5 @@
 {
   "syslog": {
-    "server": "",
     "stdoutlevel": 6,
     "sysloglevel": 4
   },

--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -1,6 +1,5 @@
 {
   "syslog": {
-    "network": "",
     "server": "",
     "stdoutlevel": 6,
     "sysloglevel": 4


### PR DESCRIPTION
This PR removes the configuration options for TCP based logging. Both Network and Server configuration options were removed because the syslog package will automatically connect to the syslog daemon running on localhost if no network parameter is provided.
fixes #298 

