### PR TITLE
Adds `notify-mailer` command.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -120,13 +120,10 @@ type Config struct {
 	Mailer struct {
 		ServiceConfig
 		DBConfig
-		PasswordConfig
+		SMTPConfig
 
-		Server   string
-		Port     string
-		Username string
-		From     string
-		Subject  string
+		From    string
+		Subject string
 
 		CertLimit int
 		NagTimes  []string
@@ -269,6 +266,13 @@ func (d *DBConfig) URL() (string, error) {
 		return string(url), err
 	}
 	return d.DBConnect, nil
+}
+
+type SMTPConfig struct {
+	PasswordConfig
+	Server   string
+	Port     string
+	Username string
 }
 
 // AMQPConfig describes how to connect to AMQP, and how to speak to each of the

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -367,14 +367,13 @@ func main() {
 			log:           logger,
 			dbMap:         dbMap,
 			rs:            sac,
-			mailer:        &mailClient,
+			mailer:        mailClient,
 			emailTemplate: tmpl,
 			nagTimes:      nags,
 			limit:         c.Mailer.CertLimit,
 			clk:           cmd.Clock(),
 		}
 
-		logger.Info("expiration-mailer: Starting")
 		err = m.findExpiringCertificates()
 		cmd.FailOnError(err, "expiration-mailer has failed")
 	}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -324,12 +324,12 @@ func main() {
 		tmpl, err := template.New("expiry-email").Parse(string(emailTmpl))
 		cmd.FailOnError(err, "Could not parse email template")
 
-		_, err = netmail.ParseAddress(c.Mailer.From)
+		fromAddress, err := netmail.ParseAddress(c.Mailer.From)
 		cmd.FailOnError(err, fmt.Sprintf("Could not parse from address: %s", c.Mailer.From))
 
 		smtpPassword, err := c.Mailer.PasswordConfig.Pass()
 		cmd.FailOnError(err, "Failed to load SMTP password")
-		mailClient := mail.New(c.Mailer.Server, c.Mailer.Port, c.Mailer.Username, smtpPassword, c.Mailer.From)
+		mailClient := mail.New(c.Mailer.Server, c.Mailer.Port, c.Mailer.Username, smtpPassword, *fromAddress)
 		err = mailClient.Connect()
 		cmd.FailOnError(err, "Couldn't connect to mail server.")
 		defer func() {

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -112,7 +112,7 @@ func main() {
 			cmd.SMTPConfig
 		}
 	}
-	var configFile = flag.String("configFile", "", "File containing a JSON config.")
+	configFile := flag.String("config", "", "File containing a JSON config.")
 
 	flag.Parse()
 	if from == nil || subject == nil || bodyFile == nil || configFile == nil {

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	netmail "net/mail"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"gopkg.in/gorp.v1"
+
+	"github.com/letsencrypt/boulder/cmd"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/mail"
+	"github.com/letsencrypt/boulder/sa"
+)
+
+type mailer struct {
+	clk           clock.Clock
+	log           blog.Logger
+	dbMap         *gorp.DbMap
+	mailer        mail.Mailer
+	subject       string
+	emailTemplate string
+	destinations  []string
+	checkpoint    interval
+	sleepInterval time.Duration
+}
+
+type interval struct {
+	start int
+	end   int
+}
+
+func (i *interval) isSane() error {
+	if i.start < 0 || i.end < 0 {
+		return errors.New(fmt.Sprintf(
+			"interval start (%d) and end (%d) must both be positive integers",
+			i.start, i.end))
+	}
+
+	if i.start > i.end && i.end != 0 {
+		return errors.New(fmt.Sprintf(
+			"interval start value (%d) is greater than end value (%d)",
+			i.start, i.end))
+	}
+
+	return nil
+}
+
+func (m *mailer) run() error {
+	// Do not allow a start larger than the # of destinations
+	if m.checkpoint.start > len(m.destinations) {
+		return errors.New(fmt.Sprintf(
+			"interval start value (%d) is greater than number of destinations (%d)",
+			m.checkpoint.start,
+			len(m.destinations)))
+	}
+	// Do not allow a negative sleep interval
+	if m.sleepInterval < 0 {
+		return errors.New(fmt.Sprintf(
+			"sleep interval (%d) is < 0", m.sleepInterval))
+	}
+	// If there is no endpoint specified, use the total # of destinations
+	if m.checkpoint.end == 0 {
+		m.checkpoint.end = len(m.destinations)
+	}
+	for i, dest := range m.destinations {
+		if i < m.checkpoint.start || i >= m.checkpoint.end {
+			continue
+		}
+		if strings.TrimSpace(dest) == "" {
+			continue
+		}
+		err := m.mailer.SendMail([]string{dest}, m.subject, m.emailTemplate)
+		if err != nil {
+			return err
+		}
+		m.clk.Sleep(m.sleepInterval)
+	}
+	return nil
+}
+
+func main() {
+	var from = flag.String("from", "", "From header for emails. Must be a bare email address.")
+	var subject = flag.String("subject", "", "Subject of emails")
+	var toFile = flag.String("toFile", "", "File containing a list of email addresses to send to, one per file.")
+	var bodyFile = flag.String("body", "", "File containing the email body in plain text format.")
+	var dryRun = flag.Bool("dryRun", true, "Whether to do a dry run.")
+	var sleep = flag.Duration("sleep", 60*time.Second, "How long to sleep between emails.")
+	var start = flag.Int("start", 0, "Line of input file to start from.")
+	var end = flag.Int("end", 99999999, "Line of input file to end before.")
+	type config struct {
+		NotifyMailer struct {
+			cmd.DBConfig
+			cmd.PasswordConfig
+			cmd.SMTPConfig
+		}
+	}
+	var configFile = flag.String("configFile", "", "File containing a JSON config.")
+
+	flag.Parse()
+	if from == nil || subject == nil || bodyFile == nil || configFile == nil {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	seven := 7
+	_, log := cmd.StatsAndLogging(cmd.StatsdConfig{}, cmd.SyslogConfig{StdoutLevel: &seven})
+
+	configData, err := ioutil.ReadFile(*configFile)
+	cmd.FailOnError(err, fmt.Sprintf("Reading %s", *configFile))
+	var cfg config
+	err = json.Unmarshal(configData, &cfg)
+	cmd.FailOnError(err, "Unmarshaling config")
+
+	dbURL, err := cfg.NotifyMailer.DBConfig.URL()
+	cmd.FailOnError(err, "Couldn't load DB URL")
+	dbMap, err := sa.NewDbMap(dbURL, 10)
+	cmd.FailOnError(err, "Could not connect to database")
+
+	// Load email body
+	body, err := ioutil.ReadFile(*bodyFile)
+	cmd.FailOnError(err, fmt.Sprintf("Reading %s", *bodyFile))
+
+	address, err := netmail.ParseAddress(*from)
+	cmd.FailOnError(err, fmt.Sprintf("Parsing %s", *from))
+
+	toBody, err := ioutil.ReadFile(*toFile)
+	cmd.FailOnError(err, fmt.Sprintf("Reading %s", *toFile))
+	destinations := strings.Split(string(toBody), "\n")
+
+	checkpointRange := interval{
+		start: *start,
+		end:   *end,
+	}
+
+	checkpointErr := checkpointRange.isSane()
+	cmd.FailOnError(checkpointErr, "Building checkpoint range")
+
+	var mailClient mail.Mailer
+	if *dryRun {
+		mailClient = mail.NewDryRun(address.Address, log)
+	} else {
+		smtpPassword, err := cfg.NotifyMailer.PasswordConfig.Pass()
+		cmd.FailOnError(err, "Failed to load SMTP password")
+		mailClient = mail.New(
+			cfg.NotifyMailer.Server,
+			cfg.NotifyMailer.Port,
+			cfg.NotifyMailer.Username,
+			smtpPassword,
+			address.Address)
+	}
+	err = mailClient.Connect()
+	cmd.FailOnError(err, fmt.Sprintf("Connecting to %s:%s",
+		cfg.NotifyMailer.Server, cfg.NotifyMailer.Port))
+	defer func() {
+		err = mailClient.Close()
+		cmd.FailOnError(err, "Closing mail client")
+	}()
+
+	m := mailer{
+		clk:           cmd.Clock(),
+		log:           log,
+		dbMap:         dbMap,
+		mailer:        mailClient,
+		subject:       *subject,
+		destinations:  destinations,
+		emailTemplate: string(body),
+		checkpoint:    checkpointRange,
+		sleepInterval: *sleep,
+	}
+
+	err = m.run()
+	cmd.FailOnError(err, "mailer.send returned error")
+}

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -152,7 +152,7 @@ func main() {
 
 	var mailClient bmail.Mailer
 	if *dryRun {
-		mailClient = bmail.NewDryRun(address.Address, log)
+		mailClient = bmail.NewDryRun(*address, log)
 	} else {
 		smtpPassword, err := cfg.NotifyMailer.PasswordConfig.Pass()
 		cmd.FailOnError(err, "Failed to load SMTP password")
@@ -161,7 +161,7 @@ func main() {
 			cfg.NotifyMailer.Port,
 			cfg.NotifyMailer.Username,
 			smtpPassword,
-			address.Address)
+			*address)
 	}
 	err = mailClient.Connect()
 	cmd.FailOnError(err, fmt.Sprintf("Connecting to %s:%s",

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestCheckpointIntervalSanity(t *testing.T) {
-	// Test a number of intervals know to be sane, ensure that no error is
-	// produced when calling `isSane()`.
+func TestCheckpointIntervalOK(t *testing.T) {
+	// Test a number of intervals know to be OK, ensure that no error is
+	// produced when calling `ok()`.
 	okCases := []struct {
 		testInterval interval
 	}{
@@ -25,8 +25,8 @@ func TestCheckpointIntervalSanity(t *testing.T) {
 		{interval{start: 10, end: 15}},
 	}
 	for _, testcase := range okCases {
-		err := testcase.testInterval.isSane()
-		test.AssertNotError(t, err, "valid interval produced isSane error")
+		err := testcase.testInterval.ok()
+		test.AssertNotError(t, err, "valid interval produced ok() error")
 	}
 
 	// Test a number of intervals known to be invalid, ensure that the produced
@@ -41,8 +41,8 @@ func TestCheckpointIntervalSanity(t *testing.T) {
 		{interval{start: 999, end: 10}, "interval start value (999) is greater than end value (10)"},
 	}
 	for _, testcase := range failureCases {
-		err := testcase.testInterval.isSane()
-		test.AssertNotNil(t, err, fmt.Sprintf("Invalid interval %#v was sane", testcase.testInterval))
+		err := testcase.testInterval.ok()
+		test.AssertNotNil(t, err, fmt.Sprintf("Invalid interval %#v was ok", testcase.testInterval))
 		test.AssertEquals(t, err.Error(), testcase.expectedError)
 	}
 }

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+
+	"github.com/letsencrypt/boulder/mocks"
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestCheckpointIntervalSanity(t *testing.T) {
+	// Test a number of intervals know to be sane, ensure that no error is
+	// produced when calling `isSane()`.
+	okCases := []struct {
+		testInterval interval
+	}{
+		{interval{}},
+		{interval{start: 10}},
+		{interval{end: 10}},
+		{interval{start: 10, end: 15}},
+	}
+	for _, testcase := range okCases {
+		err := testcase.testInterval.isSane()
+		test.AssertNotError(t, err, "valid interval produced isSane error")
+	}
+
+	// Test a number of intervals known to be invalid, ensure that the produced
+	// error has the expected message.
+	failureCases := []struct {
+		testInterval  interval
+		expectedError string
+	}{
+		{interval{start: -1}, "interval start (-1) and end (0) must both be positive integers"},
+		{interval{end: -1}, "interval start (0) and end (-1) must both be positive integers"},
+		{interval{start: -1, end: -1}, "interval start (-1) and end (-1) must both be positive integers"},
+		{interval{start: 999, end: 10}, "interval start value (999) is greater than end value (10)"},
+	}
+	for _, testcase := range failureCases {
+		err := testcase.testInterval.isSane()
+		test.AssertNotNil(t, err, fmt.Sprintf("Invalid interval %#v was sane", testcase.testInterval))
+		test.AssertEquals(t, err.Error(), testcase.expectedError)
+	}
+}
+
+func TestSleepInterval(t *testing.T) {
+	const sleepLen = 10
+	mc := &mocks.Mailer{}
+
+	// Set up a mock mailer that sleeps for `sleepLen` seconds
+	m := &mailer{
+		mailer:        mc,
+		emailTemplate: "",
+		sleepInterval: sleepLen * time.Second,
+		checkpoint:    interval{start: 0, end: 3},
+		clk:           newFakeClock(t),
+		destinations:  []string{"test@example.com", "test2@example.com", "test3@example.com"},
+	}
+
+	// Call run() - this should sleep `sleepLen` per destination address
+	// After it returns, we expect (sleepLen * number of destinations) seconds has
+	// elapsed
+	m.run()
+	expectedEnd := newFakeClock(t)
+	expectedEnd.Add(time.Second * time.Duration(sleepLen*len(m.destinations)))
+	test.AssertEquals(t, m.clk.Now(), expectedEnd.Now())
+
+	// Set up a mock mailer that doesn't sleep at all
+	m = &mailer{
+		mailer:        mc,
+		emailTemplate: "",
+		sleepInterval: 0,
+		checkpoint:    interval{start: 0, end: 3},
+		clk:           newFakeClock(t),
+		destinations:  []string{"test@example.com", "test2@example.com", "test3@example.com"},
+	}
+
+	// Call run() - this should blast through all destinations without sleep
+	// After it returns, we expect no clock time to have elapsed on the fake clock
+	m.run()
+	expectedEnd = newFakeClock(t)
+	test.AssertEquals(t, m.clk.Now(), expectedEnd.Now())
+}
+
+func TestMailCheckpointing(t *testing.T) {
+	const testSubject = "Test Subject"
+
+	testDestinationsBody, err := ioutil.ReadFile("testdata/test_msg_recipients.txt")
+	test.AssertNotError(t, err, "failed to read testdata/test_msg_recipients.txt")
+	testDestinations := strings.Split(string(testDestinationsBody), "\n")
+
+	testBody, err := ioutil.ReadFile("testdata/test_msg_body.txt")
+	test.AssertNotError(t, err, "failed to read testdata/test_msg_body.txt")
+	mc := &mocks.Mailer{}
+
+	// Create a mailer with a checkpoint interval larger than the number of
+	// destinations
+	m := &mailer{
+		mailer:        mc,
+		subject:       testSubject,
+		destinations:  testDestinations,
+		emailTemplate: string(testBody),
+		checkpoint:    interval{start: 99999, end: 900000},
+		sleepInterval: 0,
+		clk:           newFakeClock(t),
+	}
+
+	// Run the mailer. It should produce an error about the interval start
+	mc.Clear()
+	err = m.run()
+	test.AssertEquals(t, len(mc.Messages), 0)
+	test.AssertEquals(t, err.Error(), "interval start value (99999) is greater than number of destinations (7)")
+
+	// Create a mailer with a negative sleep interval
+	m = &mailer{
+		mailer:        mc,
+		subject:       testSubject,
+		destinations:  testDestinations,
+		emailTemplate: string(testBody),
+		checkpoint:    interval{},
+		sleepInterval: -10,
+		clk:           newFakeClock(t),
+	}
+
+	// Run the mailer. It should produce an error about the sleep interval
+	mc.Clear()
+	err = m.run()
+	test.AssertEquals(t, len(mc.Messages), 0)
+	test.AssertEquals(t, err.Error(), "sleep interval (-10) is < 0")
+
+	// Create a mailer with a checkpoint interval starting after 4 destinations from
+	// the start of the file
+	m = &mailer{
+		mailer:        mc,
+		subject:       testSubject,
+		destinations:  testDestinations,
+		emailTemplate: string(testBody),
+		checkpoint:    interval{start: 4},
+		sleepInterval: 0,
+		clk:           newFakeClock(t),
+	}
+
+	// Run the mailer. Two messages should have been produced, one to
+	// test-test-test@example.com (Line 5 of test_msg_recipients.txt), and one to
+	// example-example-example@example.com (Line 6).
+	mc.Clear()
+	err = m.run()
+	test.AssertNotError(t, err, "run() produced an error")
+	test.AssertEquals(t, len(mc.Messages), 2)
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      "test-test-test@example.com",
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[0])
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      "example-example-example@example.com",
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[1])
+
+	// Create a mailer with a checkpoint interval ending after 3 destinations from
+	// the start of the file
+	m = &mailer{
+		mailer:        mc,
+		subject:       testSubject,
+		destinations:  testDestinations,
+		emailTemplate: string(testBody),
+		checkpoint:    interval{end: 3},
+		sleepInterval: 0,
+		clk:           newFakeClock(t),
+	}
+
+	// Run the mailer. Three messages should have been produced, one to
+	// test@example.com (Line 1 of test_msg_recipients.txt), one to
+	// example@example.com (Line 2), and one to example-test@example.com (Line 3)
+	mc.Clear()
+	err = m.run()
+	test.AssertNotError(t, err, "run() produced an error")
+	test.AssertEquals(t, len(mc.Messages), 3)
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      "test@example.com",
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[0])
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      "example@example.com",
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[1])
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      "example-test@example.com",
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[2])
+
+	// Create a mailer with a checkpoint interval covering 2 destinations from the
+	// middle of the file
+	m = &mailer{
+		mailer:        mc,
+		subject:       testSubject,
+		destinations:  testDestinations,
+		emailTemplate: string(testBody),
+		checkpoint:    interval{start: 3, end: 5},
+		sleepInterval: 0,
+		clk:           newFakeClock(t),
+	}
+
+	// Run the mailer. Two messages should have been produced, one to
+	// test-example@example.com (Line 4 of test_msg_recipients.txt) and another
+	// one destined to test-test-test@example.com (Line 5)
+	mc.Clear()
+	err = m.run()
+	test.AssertNotError(t, err, "run() produced an error")
+	test.AssertEquals(t, len(mc.Messages), 2)
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      "test-example@example.com",
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[0])
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      "test-test-test@example.com",
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[1])
+
+}
+
+func TestMessageContent(t *testing.T) {
+	// Create a mailer with fixed content
+	const (
+		testDestination = "test@example.com"
+		testSubject     = "Test Subject"
+	)
+	testBody, err := ioutil.ReadFile("testdata/test_msg_body.txt")
+	test.AssertNotError(t, err, "failed to read testdata/test_msg_body.txt")
+	mc := &mocks.Mailer{}
+	m := &mailer{
+		mailer:        mc,
+		subject:       testSubject,
+		destinations:  []string{testDestination},
+		emailTemplate: string(testBody),
+		checkpoint:    interval{start: 0, end: 1},
+		sleepInterval: 0,
+		clk:           newFakeClock(t),
+	}
+
+	// Run the mailer, one message should have been created with the content
+	// expected
+	m.run()
+	test.AssertEquals(t, len(mc.Messages), 1)
+	test.AssertEquals(t, mocks.MailerMessage{
+		To:      testDestination,
+		Subject: testSubject,
+		Body:    string(testBody),
+	}, mc.Messages[0])
+}
+
+func newFakeClock(t *testing.T) clock.FakeClock {
+	const fakeTimeFormat = "2006-01-02T15:04:05.999999999Z"
+	ft, err := time.Parse(fakeTimeFormat, fakeTimeFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fc := clock.NewFake()
+	fc.Set(ft.UTC())
+	return fc
+}

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -64,7 +64,8 @@ func TestSleepInterval(t *testing.T) {
 	// Call run() - this should sleep `sleepLen` per destination address
 	// After it returns, we expect (sleepLen * number of destinations) seconds has
 	// elapsed
-	m.run()
+	err := m.run()
+	test.AssertNotError(t, err, "error calling mailer run()")
 	expectedEnd := newFakeClock(t)
 	expectedEnd.Add(time.Second * time.Duration(sleepLen*len(m.destinations)))
 	test.AssertEquals(t, m.clk.Now(), expectedEnd.Now())
@@ -81,7 +82,8 @@ func TestSleepInterval(t *testing.T) {
 
 	// Call run() - this should blast through all destinations without sleep
 	// After it returns, we expect no clock time to have elapsed on the fake clock
-	m.run()
+	err = m.run()
+	test.AssertNotError(t, err, "error calling mailer run()")
 	expectedEnd = newFakeClock(t)
 	test.AssertEquals(t, m.clk.Now(), expectedEnd.Now())
 }
@@ -250,7 +252,8 @@ func TestMessageContent(t *testing.T) {
 
 	// Run the mailer, one message should have been created with the content
 	// expected
-	m.run()
+	err = m.run()
+	test.AssertNotError(t, err, "error calling mailer run()")
 	test.AssertEquals(t, len(mc.Messages), 1)
 	test.AssertEquals(t, mocks.MailerMessage{
 		To:      testDestination,

--- a/cmd/notify-mailer/testdata/test_msg_body.txt
+++ b/cmd/notify-mailer/testdata/test_msg_body.txt
@@ -1,0 +1,15 @@
+This is a test message body.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus non est in enim
+tincidunt accumsan. Aenean maximus placerat malesuada. Sed semper arcu ac eros
+vulputate, sed scelerisque arcu mollis. Ut ullamcorper odio odio, ut congue
+magna malesuada at. Etiam maximus eros dui, eget efficitur mi condimentum vitae.
+Praesent tincidunt aliquet eros vel sodales. Pellentesque sollicitudin eu quam
+sed tincidunt. Integer id auctor nisl, et porta turpis. In imperdiet non justo
+ut ultrices. Cras fermentum justo volutpat, fringilla diam at, laoreet felis.
+Vestibulum vestibulum erat a pellentesque vehicula. Proin velit risus, porta
+eget eleifend non, tincidunt sit amet nunc. Duis blandit lobortis justo, quis
+interdum sapien.
+
+Sincerely,
+  Let's Encrypt

--- a/cmd/notify-mailer/testdata/test_msg_recipients.txt
+++ b/cmd/notify-mailer/testdata/test_msg_recipients.txt
@@ -1,0 +1,6 @@
+test@example.com
+example@example.com
+example-test@example.com
+test-example@example.com
+test-test-test@example.com
+example-example-example@example.com

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"net/mail"
 	"strings"
 	"testing"
 
@@ -22,7 +23,8 @@ func (f fakeSource) generate() *big.Int {
 
 func TestGenerateMessage(t *testing.T) {
 	fc := clock.NewFake()
-	m := New("", "", "", "", "send@email.com")
+	fromAddress, _ := mail.ParseAddress("send@email.com")
+	m := New("", "", "", "", *fromAddress)
 	m.clk = fc
 	m.csprgSource = fakeSource{}
 	messageBytes, err := m.generateMessage([]string{"recv@email.com"}, "test subject", "this is the body\n")
@@ -32,7 +34,7 @@ func TestGenerateMessage(t *testing.T) {
 	test.AssertEquals(t, len(fields), 12)
 	fmt.Println(message)
 	test.AssertEquals(t, fields[0], "To: \"recv@email.com\"")
-	test.AssertEquals(t, fields[1], "From: send@email.com")
+	test.AssertEquals(t, fields[1], "From: <send@email.com>")
 	test.AssertEquals(t, fields[2], "Subject: test subject")
 	test.AssertEquals(t, fields[3], "Date: 01 Jan 70 00:00 UTC")
 	test.AssertEquals(t, fields[4], "Message-Id: <19700101T000000.1991.send@email.com>")
@@ -44,7 +46,8 @@ func TestGenerateMessage(t *testing.T) {
 }
 
 func TestFailNonASCIIAddress(t *testing.T) {
-	m := New("", "", "", "", "send@email.com")
+	fromAddress, _ := mail.ParseAddress("send@email.com")
+	m := New("", "", "", "", *fromAddress)
 	_, err := m.generateMessage([]string{"遗憾@email.com"}, "test subject", "this is the body\n")
 	test.AssertError(t, err, "Allowed a non-ASCII to address incorrectly")
 }
@@ -107,7 +110,8 @@ func TestConnect(t *testing.T) {
 			}()
 		}
 	}()
-	m := New("localhost", port, "user@example.com", "paswd", "send@email.com")
+	fromAddress, _ := mail.ParseAddress("send@email.com")
+	m := New("localhost", port, "user@example.com", "paswd", *fromAddress)
 	err = m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -23,7 +23,7 @@ func (f fakeSource) generate() *big.Int {
 
 func TestGenerateMessage(t *testing.T) {
 	fc := clock.NewFake()
-	fromAddress, _ := mail.ParseAddress("send@email.com")
+	fromAddress, _ := mail.ParseAddress("happy sender <send@email.com>")
 	m := New("", "", "", "", *fromAddress)
 	m.clk = fc
 	m.csprgSource = fakeSource{}
@@ -34,7 +34,7 @@ func TestGenerateMessage(t *testing.T) {
 	test.AssertEquals(t, len(fields), 12)
 	fmt.Println(message)
 	test.AssertEquals(t, fields[0], "To: \"recv@email.com\"")
-	test.AssertEquals(t, fields[1], "From: <send@email.com>")
+	test.AssertEquals(t, fields[1], "From: \"happy sender\" <send@email.com>")
 	test.AssertEquals(t, fields[2], "Subject: test subject")
 	test.AssertEquals(t, fields[3], "Date: 01 Jan 70 00:00 UTC")
 	test.AssertEquals(t, fields[4], "Message-Id: <19700101T000000.1991.send@email.com>")

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -390,6 +390,11 @@ func (m *Mailer) Close() error {
 	return nil
 }
 
+// Connect is a mock
+func (m *Mailer) Connect() error {
+	return nil
+}
+
 // GPDNSHandler mocks the Google Public DNS API
 func GPDNSHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Query().Get("name") {


### PR DESCRIPTION
This commit adds a new notify-mailer command. Outside of the new command, this PR also:

* Adds a new SMTPConfig to `cmd/config.go` that is shared between the expiration mailer and the notify mailer.
* Modifies `mail/mailer.go` to add an `smtpClient` interface.
* Adds a `dryRunClient` to `mail/mailer.go` that implements the `smtpClient` interface.
* Modifies the `mail/mailer.go` `MailerImpl` and constructor to use the SMTPConfig and a dialer. The missing functions from the `smtpClient` interface are added.

The notify-mailer command supports checkpointing through `--start` and `--end` parameters. It supports dry runs by using the new `dryRunClient` from the mail package when given the `--dryRun` flag. The speed at which emails are sent can be tweaked using the `--sleep` flag.

Unit tests for notify-mailer's checkpointing behaviour, the checkpoint interval/sleep parameter sanity, the sleep behaviour, and the message content construction are included in `main_test.go`.

Future work:
* A separate command to generate the list of destination emails provided to notify-mailer
* Support for using registration IDs as input and resolving the email address at runtime.

Resolves #1928. Credit to @jsha for the initial work - I'm just completing the branch he started.