### PR TITLE
Add certificatesPerName rate limit to integration test

### DIFF
--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -84,6 +84,7 @@ func TestLoadPolicies(t *testing.T) {
 	test.AssertEquals(t, certsPerName.Threshold, 2)
 	test.AssertDeepEquals(t, certsPerName.Overrides, map[string]int{
 		"ratelimit.me":          1,
+		"lim.it":                0,
 		"le.wtf":                10000,
 		"le1.wtf":               10000,
 		"le2.wtf":               10000,

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -267,9 +267,10 @@ def run_expired_authz_purger_test():
 
 def run_certificates_per_name_test():
     try:
+        # This command will return a non zero error code. In order
+        # to avoid a CalledProcessException we use Popen.
         handle = subprocess.Popen(
-            '''node test.js --email %s --domains %s --challType %s''' %
-            ('test@ratelimit.me', 'lim.it', 'http-01'),
+            '''node test.js --email %s --domains %s''' % ('test@lim.it', 'lim.it'),
             shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         handle.wait()
         out, err = handle.communicate()

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/letsencrypt/boulder",
   "version": "0.0.1",
   "dependencies": {
-    "cli": "^0.6.5",
+    "cli": "^0.7.1",
     "colors": "^1.1.0",
     "inquirer": "^0.8.2",
     "node-forge": "^0.6.21",

--- a/test/rate-limit-policies-b.yml
+++ b/test/rate-limit-policies-b.yml
@@ -7,6 +7,7 @@ certificatesPerName:
   threshold: 99
   overrides:
     ratelimit.me: 1
+    lim.it: 0
     # Hostnames used by the letsencrypt client integration test.
     le.wtf: 9999
     le1.wtf: 9999

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -7,6 +7,7 @@ certificatesPerName:
   threshold: 2
   overrides:
     ratelimit.me: 1
+    lim.it: 0
     # Hostnames used by the letsencrypt client integration test.
     le.wtf: 10000
     le1.wtf: 10000

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -808,7 +808,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *reques
 	// TODO IMPORTANT: The RA trusts the WFE to provide the correct key. If the
 	// WFE is compromised, *and* the attacker knows the public key of an account
 	// authorized for target site, they could cause issuance for that site by
-	// lying to the RA. We should probably pass a copy of the whole rquest to the
+	// lying to the RA. We should probably pass a copy of the whole request to the
 	// RA for secondary validation.
 	cert, err := wfe.RA.NewCertificate(ctx, certificateRequest, reg.ID)
 	if err != nil {


### PR DESCRIPTION
This PR, covers the code path where the certificatesPerName rate limit is exceeded. 

Additionally, a node package (cli) was upgraded as the spinner was preventing the redirection of I/O. See this commit: https://github.com/node-js-libs/cli/commit/ff064fec9cec8084eb374fe4f7a90d7012f2261f. 

Fixes #1614 