### PR TITLE
Disallow non-ASCII email addresses

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -416,4 +416,3 @@ func IsASCII(str string) bool {
 	}
 	return true
 }
-

--- a/core/util.go
+++ b/core/util.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/probs"
@@ -404,3 +405,15 @@ func RetryBackoff(retries int, base, max time.Duration, factor float64) time.Dur
 	backoff *= (1 - retryJitter) + 2*retryJitter*mrand.Float64()
 	return time.Duration(backoff)
 }
+
+// IsASCII determines if every character in a string is encoded in
+// the ASCII character set.
+func IsASCII(str string) bool {
+	for _, r := range str {
+		if r > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
+}
+

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -16,10 +16,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/jmhodges/clock"
 
+	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 )
 
@@ -98,14 +98,6 @@ func (d dryRunClient) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func isASCII(str string) bool {
-	for _, r := range str {
-		if r > unicode.MaxASCII {
-			return false
-		}
-	}
-	return true
-}
 
 // New constructs a Mailer to represent an account on a particular mail
 // transfer agent.
@@ -139,7 +131,7 @@ func (m *MailerImpl) generateMessage(to []string, subject, body string) ([]byte,
 	now := m.clk.Now().UTC()
 	addrs := []string{}
 	for _, a := range to {
-		if !isASCII(a) {
+		if !core.IsASCII(a) {
 			return nil, fmt.Errorf("Non-ASCII email address")
 		}
 		addrs = append(addrs, strconv.Quote(a))

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -98,7 +98,6 @@ func (d dryRunClient) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-
 // New constructs a Mailer to represent an account on a particular mail
 // transfer agent.
 func New(server, port, username, password string, from mail.Address) *MailerImpl {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -299,6 +299,10 @@ func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, conta
 		if contact.Scheme != "mailto" {
 			return core.MalformedRequestError(fmt.Sprintf("Contact method %s is not supported", contact.Scheme))
 		}
+		if !core.IsASCII(contact.String()) {
+			return core.MalformedRequestError(
+				fmt.Sprintf("Contact email [%s] contains non-ASCII characters", contact.String()))
+		}
 
 		start := ra.clk.Now()
 		ra.stats.Inc("RA.ValidateEmail.Calls", 1, 1.0)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -287,6 +287,7 @@ func TestValidateContacts(t *testing.T) {
 	validEmail, _ := core.ParseAcmeURL("mailto:admin@email.com")
 	otherValidEmail, _ := core.ParseAcmeURL("mailto:other-admin@email.com")
 	malformedEmail, _ := core.ParseAcmeURL("mailto:admin.com")
+	nonASCII, _ := core.ParseAcmeURL("mailto:señor@email.com")
 
 	err := ra.validateContacts(context.Background(), &[]*core.AcmeURL{})
 	test.AssertNotError(t, err, "No Contacts")
@@ -305,6 +306,9 @@ func TestValidateContacts(t *testing.T) {
 
 	err = ra.validateContacts(context.Background(), &[]*core.AcmeURL{nil})
 	test.AssertError(t, err, "Nil AcmeURL")
+
+	err = ra.validateContacts(context.Background(), &[]*core.AcmeURL{nonASCII})
+	test.AssertError(t, err, "Non ASCII email")
 }
 
 func TestValidateEmail(t *testing.T) {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -568,6 +568,13 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 		wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
 		return
 	}
+	for _, url := range init.Contact {
+		if url.Scheme == "mailto" && !core.IsASCII(url.String()) {
+			msg := fmt.Sprintf("Provided contact email [%s] does not contain all ASCII encoded characters", url.String())
+			wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
+			return
+		}
+	}
 	init.Key = *key
 	init.InitialIP = net.ParseIP(request.Header.Get("X-Real-IP"))
 	if init.InitialIP == nil {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -568,13 +568,6 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 		wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
 		return
 	}
-	for _, url := range init.Contact {
-		if url.Scheme == "mailto" && !core.IsASCII(url.String()) {
-			msg := fmt.Sprintf("Provided contact email [%s] does not contain all ASCII encoded characters", url.String())
-			wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
-			return
-		}
-	}
 	init.Key = *key
 	init.InitialIP = net.ParseIP(request.Header.Get("X-Real-IP"))
 	if init.InitialIP == nil {


### PR DESCRIPTION
This PR, adds a check in registration authority for non-ASCII encoded characters in an email address. This is due to a 'funky email implementation'. 

Fixes #1350