### PR TITLE
setup.sh should call create_db.sh

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -19,6 +19,9 @@ go get \
   github.com/tools/godep \
   golang.org/x/tools/cover &
 
+# Create the database and roles
+./test/create_db.sh &
+
 (curl -sL https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz | \
  tar -xzv &&
  cd protobuf-2.6.1 && ./configure --prefix=$HOME && make && make install) &


### PR DESCRIPTION
Restore the creation of the database and roles, removed in e2995b3d88716304b2d97315b7a110b929b3ddca

Ref #1287 #1887, Closes #1955

/cc @jsha 