### PR TITLE
contact-exporter cmd `-grace` flag

### DIFF
--- a/cmd/contact-exporter/main_test.go
+++ b/cmd/contact-exporter/main_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/mail"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
@@ -69,24 +70,24 @@ func TestFindContacts(t *testing.T) {
 	test.AssertEquals(t, emails[1], emailARaw)
 }
 
-func exampleContacts() []*contactRecord {
-	return []*contactRecord{
-		&contactRecord{
+func exampleContacts() []*mail.MailerDestination {
+	return []*mail.MailerDestination{
+		&mail.MailerDestination{
 			ID:    1,
 			Email: "example@example.com",
 		},
-		&contactRecord{
+		&mail.MailerDestination{
 			ID:    2,
 			Email: "test-example@example.com",
 		},
-		&contactRecord{
+		&mail.MailerDestination{
 			ID:    3,
 			Email: "test-test-test@example.com",
 		},
 	}
 }
 
-type WriteFunc func([]*contactRecord, string) error
+type WriteFunc func([]*mail.MailerDestination, string) error
 
 func TestWriteOutput(t *testing.T) {
 	testCases := []struct {

--- a/cmd/contact-exporter/main_test.go
+++ b/cmd/contact-exporter/main_test.go
@@ -68,6 +68,18 @@ func TestFindContacts(t *testing.T) {
 	test.AssertEquals(t, contacts[0].ID, regA.ID)
 	test.AssertEquals(t, contacts[1].ID, regC.ID)
 	test.AssertEquals(t, contacts[2].ID, regD.ID)
+
+	// Allow a 1 year grace period
+	testCtx.c.grace = 360 * 24 * time.Hour
+	contacts, err = testCtx.c.findContacts()
+	test.AssertNotError(t, err, "findContacts() produced error")
+	// Now all four registration should be returned, including RegB since its
+	// certificate expired within the grace period
+	test.AssertEquals(t, len(contacts), 4)
+	test.AssertEquals(t, contacts[0].ID, regA.ID)
+	test.AssertEquals(t, contacts[1].ID, regB.ID)
+	test.AssertEquals(t, contacts[2].ID, regC.ID)
+	test.AssertEquals(t, contacts[3].ID, regD.ID)
 }
 
 func exampleContacts() []*mail.MailerDestination {

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -310,8 +310,8 @@ func TestResolveEmails(t *testing.T) {
 	dbMap := mockSelector{}
 
 	var destinations []string
-	destinations, err = resolveEmails(contacts, dbMap)
-	test.AssertNotError(t, err, "failed to resolveEmails")
+	destinations, err = resolveDestinations(contacts, dbMap)
+	test.AssertNotError(t, err, "failed to resolveDestinations")
 
 	expected := []string{
 		"example@example.com",

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -56,6 +56,14 @@ type MailerImpl struct {
 	csprgSource idGenerator
 }
 
+// A MailerDestination associates a reg ID with a blob of Contact JSON and an
+// extracted Email
+type MailerDestination struct {
+	ID      int64  `json:"id"`
+	Email   string `json:"email"`
+	Contact []byte `json:"-"`
+}
+
 type dialer interface {
 	Dial() (smtpClient, error)
 }

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/tls"
-	"encoding/json"
+	//"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -63,25 +63,7 @@ type MailerImpl struct {
 // as well as the `notify-mailer` cmd which unserializes this type.
 type MailerDestination struct {
 	ID      int64  `json:"id"`
-	Email   string `json:"email"`
 	Contact []byte `json:"-"`
-}
-
-// Unmarshal the `Contact` JSON and set the `Email` field
-func (m *MailerDestination) UnmarshalEmail() error {
-	var contactFields []string
-	err := json.Unmarshal(m.Contact, &contactFields)
-	if err != nil {
-		return err
-	}
-	for _, entry := range contactFields {
-		// Set the Email field if there is a `mailto:` address
-		if strings.HasPrefix(entry, "mailto:") {
-			address := strings.TrimPrefix(entry, "mailto:")
-			m.Email = address
-		}
-	}
-	return nil
 }
 
 type dialer interface {

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -52,55 +52,6 @@ func TestFailNonASCIIAddress(t *testing.T) {
 	test.AssertError(t, err, "Allowed a non-ASCII to address incorrectly")
 }
 
-func TestUnmarshalEmail(t *testing.T) {
-	testcases := []struct {
-		c             *MailerDestination
-		expectedEmail string
-	}{
-		{
-			// A MailerDestination with an empty Email should be updated
-			// post-Unmarshal
-			&MailerDestination{
-				Contact: []byte(`["mailto:foo@bar.com"]`),
-				Email:   "",
-			},
-			"foo@bar.com",
-		},
-		{
-			// A MailerDestination without a 'mailto:' contact shouldn't change Email
-			&MailerDestination{
-				Contact: []byte(`["tel:666-666-7777"]`),
-				Email:   "",
-			},
-			"",
-		},
-		{
-			//A MailerDestination with a non-empty Email should have it replaced
-			//post-Unmarshal
-			&MailerDestination{
-				Contact: []byte(`["mailto:new@bar.com"]`),
-				Email:   "old@bar.com",
-			},
-			"new@bar.com",
-		},
-		{
-			// A MailerDestination with two Contacts should have the last one used as
-			// the Email
-			&MailerDestination{
-				Contact: []byte(`["mailto:one@bar.com", "mailto:two@bar.com"]`),
-				Email:   "zzz@yyy.com",
-			},
-			"two@bar.com",
-		},
-	}
-
-	for _, testcase := range testcases {
-		err := testcase.c.UnmarshalEmail()
-		test.AssertNotError(t, err, "Failed to unmarshal MailerDestination JSON")
-		test.AssertEquals(t, testcase.c.Email, testcase.expectedEmail)
-	}
-}
-
 func expect(t *testing.T, buf *bufio.Reader, expected string) error {
 	line, _, err := buf.ReadLine()
 	if err != nil {

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -52,6 +52,55 @@ func TestFailNonASCIIAddress(t *testing.T) {
 	test.AssertError(t, err, "Allowed a non-ASCII to address incorrectly")
 }
 
+func TestUnmarshalEmail(t *testing.T) {
+	testcases := []struct {
+		c             *MailerDestination
+		expectedEmail string
+	}{
+		{
+			// A MailerDestination with an empty Email should be updated
+			// post-Unmarshal
+			&MailerDestination{
+				Contact: []byte(`["mailto:foo@bar.com"]`),
+				Email:   "",
+			},
+			"foo@bar.com",
+		},
+		{
+			// A MailerDestination without a 'mailto:' contact shouldn't change Email
+			&MailerDestination{
+				Contact: []byte(`["tel:666-666-7777"]`),
+				Email:   "",
+			},
+			"",
+		},
+		{
+			//A MailerDestination with a non-empty Email should have it replaced
+			//post-Unmarshal
+			&MailerDestination{
+				Contact: []byte(`["mailto:new@bar.com"]`),
+				Email:   "old@bar.com",
+			},
+			"new@bar.com",
+		},
+		{
+			// A MailerDestination with two Contacts should have the last one used as
+			// the Email
+			&MailerDestination{
+				Contact: []byte(`["mailto:one@bar.com", "mailto:two@bar.com"]`),
+				Email:   "zzz@yyy.com",
+			},
+			"two@bar.com",
+		},
+	}
+
+	for _, testcase := range testcases {
+		err := testcase.c.UnmarshalEmail()
+		test.AssertNotError(t, err, "Failed to unmarshal MailerDestination JSON")
+		test.AssertEquals(t, testcase.c.Email, testcase.expectedEmail)
+	}
+}
+
 func expect(t *testing.T, buf *bufio.Reader, expected string) error {
 	line, _, err := buf.ReadLine()
 	if err != nil {


### PR DESCRIPTION
**Do not merge until after #1958 lands**

Presently the `contact-exporter` command only exports registration contacts that have existing certificates that [have not yet expired](https://github.com/letsencrypt/boulder/blob/master/cmd/contact-exporter/main.go#L36). The threshold is [the current time](https://github.com/letsencrypt/boulder/blob/master/cmd/contact-exporter/main.go#L39) when run.

This PR adds a user configurable grace period that we can use to offset this expiration check. E.g. export all registered users with certificates that expired in the last N days. Resolves #1959 