### PR TITLE
Add no cache header for all requests, succeed or fail

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -160,7 +160,7 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h wfe
 			}
 
 			// No cache header is set for all requests, succeed or fail.
-			response.Header().Add("Cache-Control", "public, max-age=0, no-cache")
+			addNoCacheHeader(response)
 
 			if !methodsMap[request.Method] {
 				response.Header().Set("Allow", methodsStr)
@@ -291,6 +291,7 @@ func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *requestEvent, r
 		return
 	}
 
+	addNoCacheHeader(response)
 	response.Header().Set("Content-Type", "text/html")
 	response.Write([]byte(fmt.Sprintf(`<html>
 		<body>
@@ -300,6 +301,10 @@ func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *requestEvent, r
 		</body>
 	</html>
 	`, directoryPath, directoryPath)))
+}
+
+func addNoCacheHeader(w http.ResponseWriter) {
+	w.Header().Add("Cache-Control", "public, max-age=0, no-cache")
 }
 
 func addRequesterHeader(w http.ResponseWriter, requester int64) {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1162,8 +1162,8 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *requestEv
 	// digits.
 	if !core.ValidSerial(serial) {
 		logEvent.AddError("certificate serial provided was not valid: %s", serial)
-		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
 		addNoCacheHeader(response)
+		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
 		return
 	}
 	logEvent.Extra["RequestedSerial"] = serial

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -114,6 +114,8 @@ func NewWebFrontEndImpl(
 //
 // * Respond to OPTIONS requests, including CORS preflight requests.
 //
+// * Set a no cache header
+//
 // * Respond http.StatusMethodNotAllowed for HTTP methods other than
 // those listed.
 //
@@ -156,6 +158,9 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h wfe
 				wfe.Options(response, request, methodsStr, methodsMap)
 				return
 			}
+
+			// No cache header is set for all requests, succeed or fail.
+			response.Header().Add("Cache-Control", "public, max-age=0, no-cache")
 
 			if !methodsMap[request.Method] {
 				response.Header().Set("Allow", methodsStr)
@@ -295,15 +300,6 @@ func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *requestEvent, r
 		</body>
 	</html>
 	`, directoryPath, directoryPath)))
-	addCacheHeader(response, wfe.IndexCacheDuration.Seconds())
-}
-
-func addNoCacheHeader(w http.ResponseWriter) {
-	w.Header().Add("Cache-Control", "public, max-age=0, no-cache")
-}
-
-func addCacheHeader(w http.ResponseWriter, age float64) {
-	w.Header().Add("Cache-Control", fmt.Sprintf("public, max-age=%.f", age))
 }
 
 func addRequesterHeader(w http.ResponseWriter, requester int64) {
@@ -1162,7 +1158,6 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *requestEv
 	// digits.
 	if !core.ValidSerial(serial) {
 		logEvent.AddError("certificate serial provided was not valid: %s", serial)
-		addNoCacheHeader(response)
 		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
 		return
 	}
@@ -1175,13 +1170,10 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *requestEv
 		if strings.HasPrefix(err.Error(), "gorp: multiple rows returned") {
 			wfe.sendError(response, logEvent, probs.Conflict("Multiple certificates with same short serial"), err)
 		} else {
-			addNoCacheHeader(response)
 			wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), err)
 		}
 		return
 	}
-
-	addCacheHeader(response, wfe.CertCacheDuration.Seconds())
 
 	// TODO Content negotiation
 	response.Header().Set("Content-Type", "application/pkix-cert")
@@ -1202,8 +1194,6 @@ func (wfe *WebFrontEndImpl) Terms(ctx context.Context, logEvent *requestEvent, r
 
 // Issuer obtains the issuer certificate used by this instance of Boulder.
 func (wfe *WebFrontEndImpl) Issuer(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
-	addCacheHeader(response, wfe.IssuerCacheDuration.Seconds())
-
 	// TODO Content negotiation
 	response.Header().Set("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusOK)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -513,7 +513,7 @@ func TestIndex(t *testing.T) {
 	test.AssertNotEquals(t, responseWriter.Body.String(), "404 page not found\n")
 	test.Assert(t, strings.Contains(responseWriter.Body.String(), directoryPath),
 		"directory path not found")
-	test.AssertEquals(t, responseWriter.Header().Get("Cache-Control"), "public, max-age=10")
+	test.AssertEquals(t, responseWriter.Header().Get("Cache-Control"), "public, max-age=0, no-cache")
 
 	responseWriter.Body.Reset()
 	responseWriter.Header().Del("Cache-Control")
@@ -1392,7 +1392,6 @@ func TestIssuer(t *testing.T) {
 	})
 	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
 	test.Assert(t, bytes.Compare(responseWriter.Body.Bytes(), wfe.IssuerCert) == 0, "Incorrect bytes returned")
-	test.AssertEquals(t, responseWriter.Header().Get("Cache-Control"), "public, max-age=10")
 }
 
 func TestGetCertificate(t *testing.T) {
@@ -1416,7 +1415,7 @@ func TestGetCertificate(t *testing.T) {
 	req.RemoteAddr = "192.168.0.1"
 	mux.ServeHTTP(responseWriter, req)
 	test.AssertEquals(t, responseWriter.Code, 200)
-	test.AssertEquals(t, responseWriter.Header().Get("Cache-Control"), "public, max-age=10")
+	test.AssertEquals(t, responseWriter.Header().Get("Cache-Control"), "public, max-age=0, no-cache")
 	test.AssertEquals(t, responseWriter.Header().Get("Content-Type"), "application/pkix-cert")
 	test.Assert(t, bytes.Compare(responseWriter.Body.Bytes(), certBlock.Bytes) == 0, "Certificates don't match")
 


### PR DESCRIPTION
There was one instance in the wfe where `addNoCacheHeader` was called after `sendError`. 

fixes #1192 