### PR TITLE
Increase timeout to fix test failures on Mac OSX

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -917,7 +917,7 @@ func TestRateLimitLiveReload(t *testing.T) {
 	// when we wrote bodyOne to the file earlier.
 	bodyTwo, readErr := ioutil.ReadFile("../test/rate-limit-policies-b.yml")
 	test.AssertNotError(t, readErr, "should not fail to read ../test/rate-limit-policies-b.yml")
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	writeErr = ioutil.WriteFile(filename, bodyTwo, 0644)
 	test.AssertNotError(t, writeErr, "should not fail to write temp file")
 

--- a/reloader/reloader_test.go
+++ b/reloader/reloader_test.go
@@ -120,7 +120,7 @@ func TestReload(t *testing.T) {
 
 	// Write to the file, expect a reload. Sleep a few milliseconds first so the
 	// timestamps actually differ.
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	err = ioutil.WriteFile(filename, []byte("second body"), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -182,7 +182,7 @@ func TestReloadFailure(t *testing.T) {
 		t.Errorf("timed out waiting for reload")
 	}
 
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	// Create a file with no permissions
 	oldReadFile := readFile
 	readFile = func(string) ([]byte, error) {


### PR DESCRIPTION
It looks like the filesystem on Mac OSX El Captain
(and potentially previous versions) requires at least
one second before you get a different timestamp.

Any value lower than one second caused:

- a deadlock error in a test in the reloader module
- a rate limit error in the ra module

Thanks @jsha and @ccppuu for your help!

---

Closes #1955
