### PR TITLE
Add `issuanceLoadStat` to RA, exposed via debug server

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -89,7 +89,7 @@ var makeTicker = func(tickerDuration time.Duration) (func(), <-chan time.Time) {
 // The issuanceLoadStat allows us to expose a window of RA issuance volume as an
 // expvar. Internally a circular slice of 60 counts is maintained (one for each
 // minute). When a certificate is issued we increment the count in the current
-// minutes' bucket. A Go routine monitoring a ticket updates the expvar
+// minutes' bucket. A goroutine monitoring a ticket updates the expvar
 // periodically with the past 5 minutes of buckets totalled up.
 type issuanceLoadStat struct {
 	sync.RWMutex
@@ -99,7 +99,7 @@ type issuanceLoadStat struct {
 	clk          clock.Clock
 }
 
-// Spawn a Go routine blocking on the ticker
+// Spawn a goroutine blocking on the ticker
 func (i *issuanceLoadStat) updateForever() {
 	go func() {
 		for {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -74,16 +74,11 @@ type RegistrationAuthorityImpl struct {
 	totalCertsStats      metrics.Scope
 }
 
-// Note: the issuanceExpvar must be a global initialized by the package
-// init() function. If it is a member of the RA, or initialized with everything
-// else in NewRegistrationAuthority() then multiple invocations of the
-// constructor (e.g from unit tests) will panic with a "Reuse of exported var
-// name:" error from the expvar package.
-var issuanceExpvar *expvar.Int
-
-func init() {
-	issuanceExpvar = expvar.NewInt("successfulIssuances")
-}
+// Note: the issuanceExpvar must be a global. If it is a member of the RA, or
+// initialized with everything else in NewRegistrationAuthority() then multiple
+// invocations of the constructor (e.g from unit tests) will panic with a "Reuse
+// of exported var name:" error from the expvar package.
+var issuanceExpvar = expvar.NewInt("successfulIssuances")
 
 // Wrap time.Tick so we can override it in tests.
 var makeTicker = func(tickerDuration time.Duration) (func(), <-chan time.Time) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -917,7 +917,7 @@ func TestRateLimitLiveReload(t *testing.T) {
 	// when we wrote bodyOne to the file earlier.
 	bodyTwo, readErr := ioutil.ReadFile("../test/rate-limit-policies-b.yml")
 	test.AssertNotError(t, readErr, "should not fail to read ../test/rate-limit-policies-b.yml")
-	time.Sleep(1 * time.Second)
+	time.Sleep(15 * time.Millisecond)
 	writeErr = ioutil.WriteFile(filename, bodyTwo, 0644)
 	test.AssertNotError(t, writeErr, "should not fail to write temp file")
 
@@ -1249,7 +1249,7 @@ func TestIssuanceLoadStat(t *testing.T) {
 	defer restoreMakeTicker()
 
 	fc := clock.NewFake()
-	stat := newIssuanceLoadStat("testIssuanceStat", fc)
+	stat := newIssuanceLoadStat(fc)
 
 	// Assert that there are exactly 60 buckets, one for each minute
 	test.AssertEquals(t, len(stat.issuedCounts), 60)

--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -20,7 +20,7 @@
     "shutdownStopTimeout": "10s",
     "shutdownKillTimeout": "1m",
     "subscriberAgreementURL": "http://boulder:4000/terms/v1",
-    "debugAddr": "localhost:8000",
+    "debugAddr": "0.0.0.0:8000",
     "amqp": {
       "server": "amqp://guest:guest@localhost:5673",
       "insecure": true,
@@ -39,7 +39,7 @@
     "serialPrefix": 255,
     "rsaProfile": "rsaEE",
     "ecdsaProfile": "ecdsaEE",
-    "debugAddr": "localhost:8001",
+    "debugAddr": "0.0.0.0:8001",
     "Key": {
       "File": "test/test-ca.key"
     },
@@ -168,7 +168,7 @@
     "maxConcurrentRPCServerRequests": 16,
     "maxContactsPerRegistration": 100,
     "dnsTries": 3,
-    "debugAddr": "localhost:8002",
+    "debugAddr": "0.0.0.0:8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 1000,
     "doNotForceCN": true,
@@ -204,7 +204,7 @@
     "dbConnectFile": "test/secrets/sa_dburl",
     "maxDBConns": 10,
     "maxConcurrentRPCServerRequests": 16,
-    "debugAddr": "localhost:8003",
+    "debugAddr": "0.0.0.0:8003",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
@@ -214,7 +214,7 @@
 
   "va": {
     "userAgent": "boulder",
-    "debugAddr": "localhost:8004",
+    "debugAddr": "0.0.0.0:8004",
     "portConfig": {
       "httpPort": 5002,
       "httpsPort": 5001,
@@ -278,7 +278,7 @@
     "maxAge": "10s",
     "shutdownStopTimeout": "10s",
     "shutdownKillTimeout": "1m",
-    "debugAddr": "localhost:8005"
+    "debugAddr": "0.0.0.0:8005"
   },
 
   "ocspUpdater": {
@@ -296,7 +296,7 @@
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
-    "debugAddr": "localhost:8006",
+    "debugAddr": "0.0.0.0:8006",
     "publisher": {
       "serverAddresses": ["boulder:9091"],
       "serverIssuerPath": "test/grpc-creds/ca.pem",
@@ -330,7 +330,7 @@
     "nagTimes": ["24h", "72h", "168h", "336h"],
     "nagCheckInterval": "24h",
     "emailTemplate": "test/example-expiration-template",
-    "debugAddr": "localhost:8008",
+    "debugAddr": "0.0.0.0:8008",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
@@ -344,7 +344,7 @@
   "publisher": {
     "maxConcurrentRPCServerRequests": 16,
     "submissionTimeout": "5s",
-    "debugAddr": "localhost:8009",
+    "debugAddr": "0.0.0.0:8009",
     "grpc": {
       "address": "boulder:9091",
       "clientIssuerPath": "test/grpc-creds/ca.pem",

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -19,7 +19,7 @@
     "issuerCacheDuration": "48h",
     "shutdownStopTimeout": "10s",
     "shutdownKillTimeout": "1m",
-    "debugAddr": "localhost:8000",
+    "debugAddr": "0.0.0.0:8000",
     "amqp": {
       "server": "amqp://guest:guest@localhost:5673",
       "insecure": true,
@@ -38,7 +38,7 @@
     "serialPrefix": 255,
     "rsaProfile": "rsaEE",
     "ecdsaProfile": "ecdsaEE",
-    "debugAddr": "localhost:8001",
+    "debugAddr": "0.0.0.0:8001",
     "Key": {
       "File": "test/test-ca.key"
     },
@@ -164,7 +164,7 @@
     "maxConcurrentRPCServerRequests": 16,
     "maxContactsPerRegistration": 100,
     "dnsTries": 3,
-    "debugAddr": "localhost:8002",
+    "debugAddr": "0.0.0.0:8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 1000,
     "doNotForceCN": true,
@@ -192,7 +192,7 @@
     "dbConnectFile": "test/secrets/sa_dburl",
     "maxDBConns": 10,
     "maxConcurrentRPCServerRequests": 16,
-    "debugAddr": "localhost:8003",
+    "debugAddr": "0.0.0.0:8003",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
@@ -202,7 +202,7 @@
 
   "va": {
     "userAgent": "boulder",
-    "debugAddr": "localhost:8004",
+    "debugAddr": "0.0.0.0:8004",
     "portConfig": {
       "httpPort": 5002,
       "httpsPort": 5001,
@@ -247,7 +247,7 @@
     "maxAge": "10s",
     "shutdownStopTimeout": "10s",
     "shutdownKillTimeout": "1m",
-    "debugAddr": "localhost:8005"
+    "debugAddr": "0.0.0.0:8005"
   },
 
   "ocspUpdater": {
@@ -265,7 +265,7 @@
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
-    "debugAddr": "localhost:8006",
+    "debugAddr": "0.0.0.0:8006",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
@@ -296,7 +296,7 @@
     "nagTimes": ["24h", "72h", "168h", "336h"],
     "nagCheckInterval": "24h",
     "emailTemplate": "test/example-expiration-template",
-    "debugAddr": "localhost:8008",
+    "debugAddr": "0.0.0.0:8008",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
@@ -310,7 +310,7 @@
   "publisher": {
     "maxConcurrentRPCServerRequests": 16,
     "submissionTimeout": "5s",
-    "debugAddr": "localhost:8009",
+    "debugAddr": "0.0.0.0:8009",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,


### PR DESCRIPTION
The `issuanceLoadStat` is a type backed by a circular `[]int` slice of size 60. Every time a certificate is issued the current minute is used as an index into this circular bucket slice and the corresponding int is incremented.

Simultaneously a Go routine monitors a ticker and every 60s updates an expvar integer to be the value of the past 5 minutes of bucket totals summed.

The count of successful issuances for the 5 minute window is exposed via the expvar debug server for the RA at port 8002 under the key "successfulIssuances".

Closes #1945