### PR TITLE
Change `%v` to `%#v` in AssertEquals error msg.

### DIFF
--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -57,7 +57,7 @@ func AssertError(t *testing.T, err error, message string) {
 // AssertEquals uses the equality operator (==) to measure one and two
 func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 	if one != two {
-		fatalf(t, "%s [%#v] != [%#v]", caller(), one, two)
+		fatalf(t, "%s %#v != %#v", caller(), one, two)
 	}
 }
 
@@ -85,7 +85,7 @@ func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
 // are different
 func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {
 	if one == two {
-		fatalf(t, "%s [%#v] == [%#v]", caller(), one, two)
+		fatalf(t, "%s %#v == %#v", caller(), one, two)
 	}
 }
 

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -57,7 +57,7 @@ func AssertError(t *testing.T, err error, message string) {
 // AssertEquals uses the equality operator (==) to measure one and two
 func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 	if one != two {
-		fatalf(t, "%s [%v] != [%v]", caller(), one, two)
+		fatalf(t, "%s [%#v] != [%#v]", caller(), one, two)
 	}
 }
 

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -85,7 +85,7 @@ func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
 // are different
 func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {
 	if one == two {
-		fatalf(t, "%s [%v] == [%v]", caller(), one, two)
+		fatalf(t, "%s [%#v] == [%#v]", caller(), one, two)
 	}
 }
 


### PR DESCRIPTION
Whenever I run into a test failure using `AssertEquals` I end up changing the error format string to include the full type information. I think given the context of when the message will be printed it makes sense to include type information all the time.

This commit changes the format string from `%v` to `%#v`. This avoids otherwise unhelpful test failures like:
    `ra_test.go:789: [0] != [0]`
where the underlying types differ while their String() representation matches.