### PR TITLE
RA doesn't need CAASERVFAILExceptions.

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -68,13 +68,11 @@ func main() {
 		if dnsTries < 1 {
 			dnsTries = 1
 		}
-		caaSERVFAILExceptions, err := bdns.ReadHostList(c.VA.CAASERVFAILExceptions)
-		cmd.FailOnError(err, "Couldn't read CAASERVFAILExceptions file")
 		if !c.Common.DNSAllowLoopbackAddresses {
 			rai.DNSResolver = bdns.NewDNSResolverImpl(
 				raDNSTimeout,
 				[]string{c.Common.DNSResolver},
-				caaSERVFAILExceptions,
+				nil,
 				scoped,
 				clock.Default(),
 				dnsTries)


### PR DESCRIPTION
In #1971 we added the CAASERVFAILExceptions config field and argument to NewDNSResolverImpl. This argument only needs to be passed to the VA, where we do CAA validations. However, I accidentally added code to the RA as well to use this new config field. This changes backs that out.