### PR TITLE
Fix index out of range panic in `getCerts`.

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/jmhodges/clock"
-	gorp "gopkg.in/gorp.v1"
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
@@ -58,9 +57,19 @@ type reportEntry struct {
 	Problems []string `json:"problems,omitempty"`
 }
 
+/*
+ * certDB is an interface collecting the gorp.DbMap functions that the
+ * various parts of cert-checker rely on. Using this adapter shim allows tests to
+ * swap out the dbMap implementation.
+ */
+type certDB interface {
+	Select(i interface{}, query string, args ...interface{}) ([]interface{}, error)
+	SelectOne(holder interface{}, query string, args ...interface{}) error
+}
+
 type certChecker struct {
 	pa           core.PolicyAuthority
-	dbMap        *gorp.DbMap
+	dbMap        certDB
 	certs        chan core.Certificate
 	clock        clock.Clock
 	rMu          *sync.Mutex
@@ -69,7 +78,7 @@ type certChecker struct {
 	stats        metrics.Statter
 }
 
-func newChecker(saDbMap *gorp.DbMap, clk clock.Clock, pa core.PolicyAuthority, period time.Duration) certChecker {
+func newChecker(saDbMap certDB, clk clock.Clock, pa core.PolicyAuthority, period time.Duration) certChecker {
 	c := certChecker{
 		pa:          pa,
 		dbMap:       saDbMap,
@@ -121,6 +130,9 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 		)
 		if err != nil {
 			return err
+		}
+		if len(certs) == 0 {
+			break
 		}
 		for _, cert := range certs {
 			c.certs <- cert

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -131,11 +131,11 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 		if err != nil {
 			return err
 		}
-		if len(certs) == 0 {
-			break
-		}
 		for _, cert := range certs {
 			c.certs <- cert
+		}
+		if len(certs) == 0 {
+			break
 		}
 		args["lastSerial"] = certs[len(certs)-1].Serial
 		offset += len(certs)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -242,7 +242,7 @@ func (db mismatchedCountDB) Select(output interface{}, _ string, _ ...interface{
 }
 
 /*
- * In Boulder #2004[0] it was identified that there is a race in `getCerts`
+ * In Boulder #2004[0] we identified that there is a race in `getCerts`
  * between the first call to `SelectOne` to identify how many rows there are,
  * and the subsequent call to `Select` to get the actual rows in batches. This
  * manifests in an index out of range panic where the cert checker thinks there

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -218,6 +218,59 @@ func TestGetAndProcessCerts(t *testing.T) {
 	test.AssertEquals(t, len(checker.issuedReport.Entries), 5)
 }
 
+// mismatchedCountDB is a certDB implementation for `getCerts` that returns one
+// high value when asked how many rows there are, and then returns nothing when
+// asked for the actual rows.
+type mismatchedCountDB struct{}
+
+// `getCerts` calls `SelectOne` first to determine how many rows there are
+// matching the `getCertsCountQuery` criteria. For this mock we return
+// a non-zero number
+func (db mismatchedCountDB) SelectOne(output interface{}, _ string, _ ...interface{}) error {
+	outputPtr, _ := output.(*int)
+	*outputPtr = 99999
+	return nil
+}
+
+// `getCerts` then calls `Select` to retrieve the Certificate rows. We pull
+// a dasterdly switch-a-roo here and return an empty set
+func (db mismatchedCountDB) Select(output interface{}, _ string, _ ...interface{}) ([]interface{}, error) {
+	// But actually return nothing
+	outputPtr, _ := output.(*[]core.Certificate)
+	*outputPtr = []core.Certificate{}
+	return nil, nil
+}
+
+/*
+ * In Boulder #2004[0] it was identified that there is a race in `getCerts`
+ * between the first call to `SelectOne` to identify how many rows there are,
+ * and the subsequent call to `Select` to get the actual rows in batches. This
+ * manifests in an index out of range panic where the cert checker thinks there
+ * are more rows than there are and indexes into an empty set of certificates to
+ * update the lastSerial field of the query `args`. This has been fixed by
+ * adding a len() check in the inner `getCerts` loop that processes the certs
+ * one batch at a time.
+ *
+ * TestGetCertsEmptyResults tests the fix remains in place by using a mock that
+ * exploits this corner case deliberately. The `mismatchedCountDB` mock (defined
+ * above) will return a high count for the `SelectOne` call, but an empty slice
+ * for the `Select` call. Without the fix in place this reliably produced the
+ * "index out of range" panic from #2004. With the fix in place the test passes.
+ *
+ * 0: https://github.com/letsencrypt/boulder/issues/2004
+ */
+func TestGetCertsEmptyResults(t *testing.T) {
+	saDbMap, err := sa.NewDbMap(vars.DBConnSA, 0)
+	test.AssertNotError(t, err, "Couldn't connect to database")
+	fc := clock.NewFake()
+	checker := newChecker(saDbMap, fc, pa, expectedValidityPeriod)
+	checker.dbMap = mismatchedCountDB{}
+
+	batchSize = 3
+	err = checker.getCerts(false)
+	test.AssertNotError(t, err, "Failed to retrieve certificates")
+}
+
 func TestSaveReport(t *testing.T) {
 	r := report{
 		begin:     time.Time{},


### PR DESCRIPTION
Boulder issue #2004 describes a panic observed in `getCerts` caused by an index out of range. It appears as though this is caused by a race condition between the initial `SelectOne` lookup for the count of certificates, and the subsequent individual `Select` queries to fetch the Certificates. If the number of eligible certificates changes between these points (e.g. due to certificates expiring) there is a potential that one of the Select calls will return an empty result set. If this happens, then the `lastSerial` update will access an index out of range.

This PR adds an explicit `len` check to the processing loop before the `lastSerial` update. If there are no results returned from the DB query then the loop is broken. This resolves #2004

A test case for the fix was written and included in this PR. The testcase initially caused the out of range panic observed in #2004. After adding the `len` fix in this commit the test began passing without error.

