### PR TITLE
Switch to a real docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM letsencrypt/boulder-tools:07-05-2016
+FROM letsencrypt/boulder-tools:2016-07-05
 
 # Boulder exposes its web application at port TCP 4000
 EXPOSE 4000 4002 4003 8053 8055

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM letsencrypt/boulder-tools:latest
+FROM letsencrypt/boulder-tools:07-05-2016
 
 # Boulder exposes its web application at port TCP 4000
 EXPOSE 4000 4002 4003 8053 8055


### PR DESCRIPTION
Switches from using `boulder-tools:latest` to using `boulder-tools:2016-07-05`. Using this tag format going forward we can preserve old versions of the image and not break master tests when we need to update images.