### PR TITLE
Remove embedded (anonymous) fields from configs

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -31,9 +31,9 @@ type config struct {
 
 	PA cmd.PAConfig
 
-	cmd.StatsdConfig
+	Statsd cmd.StatsdConfig
 
-	cmd.SyslogConfig
+	Syslog cmd.SyslogConfig
 
 	Common struct {
 		// Path to a PEM-encoded copy of the issuer certificate.
@@ -132,7 +132,7 @@ func main() {
 
 	go cmd.DebugServer(c.CA.DebugAddr)
 
-	stats, logger := cmd.StatsAndLogging(c.StatsdConfig, c.SyslogConfig)
+	stats, logger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString(clientName))
 

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -27,7 +27,7 @@ const clientName = "CA"
 type config struct {
 	CA cmd.CAConfig
 
-	*cmd.AllowedSigningAlgos
+	AllowedSigningAlgos *cmd.AllowedSigningAlgos
 
 	PA cmd.PAConfig
 
@@ -155,7 +155,7 @@ func main() {
 		clock.Default(),
 		stats,
 		issuers,
-		c.KeyPolicy(),
+		c.AllowedSigningAlgos.KeyPolicy(),
 		logger)
 	cmd.FailOnError(err, "Failed to create CA impl")
 	cai.PA = pa

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -24,9 +24,9 @@ type config struct {
 		MaxConcurrentRPCServerRequests int64
 	}
 
-	cmd.StatsdConfig
+	Statsd cmd.StatsdConfig
 
-	cmd.SyslogConfig
+	Syslog cmd.SyslogConfig
 
 	Common struct {
 		CT struct {
@@ -50,7 +50,7 @@ func main() {
 
 	go cmd.DebugServer(c.Publisher.DebugAddr)
 
-	stats, logger := cmd.StatsAndLogging(c.StatsdConfig, c.SyslogConfig)
+	stats, logger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString(clientName))
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -52,7 +52,7 @@ type config struct {
 		ReuseValidAuthz bool
 	}
 
-	*cmd.AllowedSigningAlgos
+	AllowedSigningAlgos *cmd.AllowedSigningAlgos
 
 	PA cmd.PAConfig
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -56,9 +56,9 @@ type config struct {
 
 	PA cmd.PAConfig
 
-	cmd.StatsdConfig
+	Statsd cmd.StatsdConfig
 
-	cmd.SyslogConfig
+	Syslog cmd.SyslogConfig
 
 	Common struct {
 		DNSResolver               string
@@ -81,7 +81,7 @@ func main() {
 
 	go cmd.DebugServer(c.RA.DebugAddr)
 
-	stats, logger := cmd.StatsAndLogging(c.StatsdConfig, c.SyslogConfig)
+	stats, logger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString(clientName))
 

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -22,9 +22,9 @@ type config struct {
 		MaxConcurrentRPCServerRequests int64
 	}
 
-	cmd.StatsdConfig
+	Statsd cmd.StatsdConfig
 
-	cmd.SyslogConfig
+	Syslog cmd.SyslogConfig
 }
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 
 	go cmd.DebugServer(c.SA.DebugAddr)
 
-	stats, logger := cmd.StatsAndLogging(c.StatsdConfig, c.SyslogConfig)
+	stats, logger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString(clientName))
 

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -42,11 +42,11 @@ type config struct {
 
 	AllowedSigningAlgos *cmd.AllowedSigningAlgos
 
-	cmd.StatsdConfig
+	Statsd cmd.StatsdConfig
 
 	SubscriberAgreementURL string
 
-	cmd.SyslogConfig
+	Syslog cmd.SyslogConfig
 
 	Common struct {
 		BaseURL    string
@@ -79,7 +79,7 @@ func main() {
 
 	go cmd.DebugServer(c.WFE.DebugAddr)
 
-	stats, logger := cmd.StatsAndLogging(c.StatsdConfig, c.SyslogConfig)
+	stats, logger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString(clientName))
 

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -40,7 +40,7 @@ type config struct {
 		CheckMalformedCSR bool
 	}
 
-	*cmd.AllowedSigningAlgos
+	AllowedSigningAlgos *cmd.AllowedSigningAlgos
 
 	cmd.StatsdConfig
 
@@ -116,7 +116,7 @@ func main() {
 	wfe.IssuerCert, err = cmd.LoadCert(c.Common.IssuerCert)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))
 
-	logger.Info(fmt.Sprintf("WFE using key policy: %#v", c.KeyPolicy()))
+	logger.Info(fmt.Sprintf("WFE using key policy: %#v", c.AllowedSigningAlgos.KeyPolicy()))
 
 	go cmd.ProfileCmd("WFE", stats)
 

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -552,9 +552,9 @@ const clientName = "OCSP"
 type config struct {
 	OCSPUpdater cmd.OCSPUpdaterConfig
 
-	cmd.StatsdConfig
+	Statsd cmd.StatsdConfig
 
-	cmd.SyslogConfig
+	Syslog cmd.SyslogConfig
 
 	Common struct {
 		IssuerCert string
@@ -603,7 +603,7 @@ func main() {
 
 	go cmd.DebugServer(conf.DebugAddr)
 
-	stats, auditlogger := cmd.StatsAndLogging(c.StatsdConfig, c.SyslogConfig)
+	stats, auditlogger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 	defer auditlogger.AuditPanic()
 	auditlogger.Info(cmd.VersionString(clientName))
 


### PR DESCRIPTION
This PR removes the use of all anonymous struct fields that were introduced by myself as per my work on splitting up boulder-config (#1962). 

The root of the bug was related to the loading of the json configuration file into the `config` struct. The config structs contained several embedded (anonymous) fields. An embedded (anonymous) field in a struct actually results in the flattening of the json structure. This caused `json.Unmarshal` to look not at the nested level, but at the root level of the json object and hence not find the nested field (i.e. AllowedSigningAlgos). 

See https://play.golang.org/p/6uVCsEu3Df for a working example. 

This fixes the reported bug: #2018