### PR TITLE
Update certbot tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,8 @@ TESTPATHS=$(go list -f '{{ .ImportPath }}' ./... | grep -v /vendor/)
 
 GITHUB_SECRET_FILE="/tmp/github-secret.json"
 
+CERTBOT_COMMIT="031b41a5850682a1a3b9fd47f9da3e0d230d4311"
+
 start_context() {
   CONTEXT="$1"
   printf "[%16s] Starting\n" ${CONTEXT}
@@ -181,9 +183,8 @@ if [[ "$RUN" =~ "integration" ]] ; then
     echo "--- Recommend setting \$CERTBOT_PATH to  ---"
     echo "--- client repo with initialized virtualenv  ---"
     echo "------------------------------------------------"
-    run git clone -b v0.8.0 \
-      https://www.github.com/certbot/certbot.git \
-      $CERTBOT_PATH || exit 1
+    run git clone https://www.github.com/certbot/certbot.git $CERTBOT_PATH || exit 1
+    run pushd $CERTBOT_PATH && git checkout $CERTBOT_COMMIT || exit 1 && popd
   fi
 
   if ! type certbot >/dev/null 2>/dev/null; then

--- a/test.sh
+++ b/test.sh
@@ -22,13 +22,6 @@ TESTPATHS=$(go list -f '{{ .ImportPath }}' ./... | grep -v /vendor/)
 
 GITHUB_SECRET_FILE="/tmp/github-secret.json"
 
-# The commit hash of the Certbot repo to checkout and use for integration tests.
-
-# Note: This commit is only used to acquire the *tests* - we actually run the
-# `certbot` command installed in the `boulder-tools` docker image from
-# jessie-backports.
-CERTBOT_COMMIT="031b41a5850682a1a3b9fd47f9da3e0d230d4311"
-
 start_context() {
   CONTEXT="$1"
   printf "[%16s] Starting\n" ${CONTEXT}
@@ -189,7 +182,6 @@ if [[ "$RUN" =~ "integration" ]] ; then
     echo "--- client repo with initialized virtualenv  ---"
     echo "------------------------------------------------"
     run git clone https://www.github.com/certbot/certbot.git $CERTBOT_PATH || exit 1
-    run pushd $CERTBOT_PATH && git checkout $CERTBOT_COMMIT || exit 1 && popd
   fi
 
   if ! type certbot >/dev/null 2>/dev/null; then

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,11 @@ TESTPATHS=$(go list -f '{{ .ImportPath }}' ./... | grep -v /vendor/)
 
 GITHUB_SECRET_FILE="/tmp/github-secret.json"
 
+# The commit hash of the Certbot repo to checkout and use for integration tests.
+
+# Note: This commit is only used to acquire the *tests* - we actually run the
+# `certbot` command installed in the `boulder-tools` docker image from
+# jessie-backports.
 CERTBOT_COMMIT="031b41a5850682a1a3b9fd47f9da3e0d230d4311"
 
 start_context() {


### PR DESCRIPTION
This PR changes the `certbot` integration tests that are run from the `0.8.0` release to master.

As mentioned in the `test.sh` note, this is only updating the *tests* that are run. We continue to invoke the `certbot` binary that is installed from jessie-backports as part of the `boulder-tools` image.

This fixes #2021