### PR TITLE
Make (pending)AuthorizationLifetime configurable

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -50,6 +50,17 @@ type config struct {
 		// instructs the RA to reuse the previously created authz in lieu of
 		// creating another.
 		ReuseValidAuthz bool
+
+		// AuthorizationLifetimeDays defines how long authorizations will be
+		// considered valid for. Given a value of 300 days when used with a 90-day
+		// cert lifetime, this allows creation of certs that will cover a whole
+		// year, plus a grace period of a month.
+		AuthorizationLifetimeDays int
+
+		// PendingAuthorizationLifetimeDays defines how long authorizations may be in
+		// the pending state. If you can't respond to a challenge this quickly, then
+		// you need to request a new challenge.
+		PendingAuthorizationLifetimeDays int
 	}
 
 	AllowedSigningAlgos *cmd.AllowedSigningAlgos
@@ -116,6 +127,18 @@ func main() {
 	sac, err := rpc.NewStorageAuthorityClient(clientName, amqpConf, stats)
 	cmd.FailOnError(err, "Unable to create SA client")
 
+	// TODO(patf): remove once RA.authorizationLifetimeDays is deployed
+	authorizationLifetime := 300 * 24 * time.Hour
+	if c.RA.AuthorizationLifetimeDays != 0 {
+		authorizationLifetime = time.Duration(c.RA.AuthorizationLifetimeDays) * 24 * time.Hour
+	}
+
+	// TODO(patf): remove once RA.pendingAuthorizationLifetimeDays is deployed
+	pendingAuthorizationLifetime := 7 * 24 * time.Hour
+	if c.RA.PendingAuthorizationLifetimeDays != 0 {
+		pendingAuthorizationLifetime = time.Duration(c.RA.PendingAuthorizationLifetimeDays) * 24 * time.Hour
+	}
+
 	rai := ra.NewRegistrationAuthorityImpl(
 		clock.Default(),
 		logger,
@@ -124,7 +147,9 @@ func main() {
 		c.AllowedSigningAlgos.KeyPolicy(),
 		c.RA.MaxNames,
 		c.RA.DoNotForceCN,
-		c.RA.ReuseValidAuthz)
+		c.RA.ReuseValidAuthz,
+		authorizationLifetime,
+		pendingAuthorizationLifetime)
 
 	policyErr := rai.SetRateLimitPoliciesFile(c.RA.RateLimitPoliciesFilename)
 	cmd.FailOnError(policyErr, "Couldn't load rate limit policies file")

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -30,17 +30,6 @@ import (
 	vaPB "github.com/letsencrypt/boulder/va/proto"
 )
 
-// DefaultAuthorizationLifetime is the 10 month default authorization lifetime.
-// When used with a 90-day cert lifetime, this allows creation of certs that will
-// cover a whole year, plus a grace period of a month.
-// TODO(jsha): Read from a config file.
-const DefaultAuthorizationLifetime = 300 * 24 * time.Hour
-
-// DefaultPendingAuthorizationLifetime is one week.  If you can't respond to a
-// challenge this quickly, then you need to request a new challenge.
-// TODO(rlb): Read from a config file
-const DefaultPendingAuthorizationLifetime = 7 * 24 * time.Hour
-
 // Note: the issuanceExpvar must be a global. If it is a member of the RA, or
 // initialized with everything else in NewRegistrationAuthority() then multiple
 // invocations of the constructor (e.g from unit tests) will panic with a "Reuse
@@ -89,14 +78,16 @@ func NewRegistrationAuthorityImpl(
 	maxNames int,
 	forceCNFromSAN bool,
 	reuseValidAuthz bool,
+	authorizationLifetime time.Duration,
+	pendingAuthorizationLifetime time.Duration,
 ) *RegistrationAuthorityImpl {
 	scope := metrics.NewStatsdScope(stats, "RA")
 	ra := &RegistrationAuthorityImpl{
 		stats: stats,
 		clk:   clk,
 		log:   logger,
-		authorizationLifetime:        DefaultAuthorizationLifetime,
-		pendingAuthorizationLifetime: DefaultPendingAuthorizationLifetime,
+		authorizationLifetime:        authorizationLifetime,
+		pendingAuthorizationLifetime: pendingAuthorizationLifetime,
 		rlPolicies:                   ratelimit.New(),
 		tiMu:                         new(sync.RWMutex),
 		maxContactsPerReg:            maxContactsPerReg,

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -241,7 +241,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
 		stats,
-		1, testKeyPolicy, 0, true, false)
+		1, testKeyPolicy, 0, true, false, 300*24*time.Hour, 7*24*time.Hour)
 	ra.SA = ssa
 	ra.VA = va
 	ra.CA = ca

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -9,6 +9,8 @@
     "maxNames": 1000,
     "doNotForceCN": true,
     "reuseValidAuthz": true,
+    "authorizationLifetimeDays": 300,
+    "pendingAuthorizationLifetimeDays": 7,
     "vaService": {
       "serverAddresses": ["boulder:9092"],
       "serverIssuerPath": "test/grpc-creds/ca.pem",

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -623,7 +623,9 @@ func TestIssueCertificate(t *testing.T) {
 		testKeyPolicy,
 		0,
 		true,
-		false)
+		false,
+		300*24*time.Hour,
+		7*24*time.Hour)
 	ra.SA = mocks.NewStorageAuthority(fc)
 	ra.CA = &mocks.MockCA{
 		PEM: mockCertPEM,


### PR DESCRIPTION
Introduces the `authorizationLifetimeDays` and `pendingAuthorizationLifetimeDays` configuration options for `RA`.

If the values are missing from configuration, the code defaults back to the current values (300/7 days).

fixes #2024