### PR TITLE
Add stat for expiration-mailer at capacity.

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -104,7 +104,9 @@ func (m *mailer) sendNags(contacts []*core.AcmeURL, certs []*x509.Certificate) e
 		m.stats.Inc("Mailer.Expiration.Errors.SendingNag.SendFailure", 1, 1.0)
 		return err
 	}
-	m.stats.TimingDuration("Mailer.Expiration.SendLatency", time.Since(startSending), 1.0)
+	finishSending := m.clk.Now()
+	elapsed := finishSending.Sub(startSending)
+	m.stats.TimingDuration("Mailer.Expiration.SendLatency", elapsed, 1.0)
 	m.stats.Inc("Mailer.Expiration.Sent", int64(len(emails)), 1.0)
 	return nil
 }
@@ -268,9 +270,27 @@ func (m *mailer) findExpiringCertificates() error {
 			continue // nothing to do
 		}
 
+		// If the `certs` result was exactly `m.limit` rows we need to increment
+		// a stat indicating that this nag group is at capacity based on the
+		// configured cert limit. If this condition continually occurs across mailer
+		// runs then we will not catch up, resulting in under-sending expiration
+		// mails. The effects of this were initially described in issue #2002[0].
+		//
+		// 0: https://github.com/letsencrypt/boulder/issues/2002
+		if len(certs) == m.limit {
+			m.log.Info(fmt.Sprintf(
+				"expiration-mailer: nag group %s expiring certificates at configured capacity (cert limit %d)\n",
+				expiresIn.String(),
+				m.limit))
+			statName := fmt.Sprintf("Mailer.Expiration.Errors.Nag-%s.AtCapacity", expiresIn.String())
+			m.stats.Inc(statName, 1, 1.0)
+		}
+
 		processingStarted := m.clk.Now()
 		m.processCerts(certs)
-		m.stats.TimingDuration("Mailer.Expiration.ProcessingCertificatesLatency", time.Since(processingStarted), 1.0)
+		processingEnded := m.clk.Now()
+		elapsed := processingEnded.Sub(processingStarted)
+		m.stats.TimingDuration("Mailer.Expiration.ProcessingCertificatesLatency", elapsed, 1.0)
 	}
 
 	return nil

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -279,7 +279,7 @@ func (m *mailer) findExpiringCertificates() error {
 		// 0: https://github.com/letsencrypt/boulder/issues/2002
 		if len(certs) == m.limit {
 			m.log.Info(fmt.Sprintf(
-				"expiration-mailer: nag group %s expiring certificates at configured capacity (cert limit %d)\n",
+				"nag group %s expiring certificates at configured capacity (cert limit %d)\n",
 				expiresIn.String(),
 				m.limit))
 			statName := fmt.Sprintf("Mailer.Expiration.Errors.Nag-%s.AtCapacity", expiresIn.String())


### PR DESCRIPTION
This PR adds a stat that is emitted when any of the nag groups are operating at capacity. The mailer is considered at capacity when the number of certs returned by the query in `findExpiringCertificates` is equal to the configured `-cert_limit`.

The at capacity stat names take the form: `"Mailer.Expiration.Errors.Nag-XXXXX.AtCapacity"` where XXXXX is the `String()` representation of the nagCheck offset nag time. Allowing the capacity alert to be specified per-nag group. As an example, a nag time of 48hrs with a nag check of 24hrs would produce a stat: `"Mailer.Expiration.Errors.Nag-72h0m0s.AtCapacity"` when it reached a capacity state. 

This will allow creation of an alert for the conditions that caused issue #2002 to manifest.

In order to unit test with a mock statter it was also required to swap out the `time.Since` calls to equivalent `dateB.sub(dateA)` calls using the fake clock.