### PR TITLE
Change `DBConfig`'s `URL` func to strip whitespace.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -133,11 +133,12 @@ type DBConfig struct {
 }
 
 // URL returns the DBConnect URL represented by this DBConfig object, either
-// loading it from disk or returning a default value.
+// loading it from disk or returning a default value. Leading and trailing
+// whitespace is stripped.
 func (d *DBConfig) URL() (string, error) {
 	if d.DBConnectFile != "" {
 		url, err := ioutil.ReadFile(d.DBConnectFile)
-		return string(url), err
+		return strings.TrimSpace(string(url)), err
 	}
 	return d.DBConnect, nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -17,7 +17,7 @@ func TestDBConfigURL(t *testing.T) {
 			expected: "mysql+tcp://test@testhost:3306/testDB?readTimeout=800ms&writeTimeout=800ms",
 		},
 		{
-			// Test with a config file that *has* a traoling newline
+			// Test with a config file that *has* a trailing newline
 			conf:     DBConfig{DBConnectFile: "testdata/test_dburl_newline"},
 			expected: "mysql+tcp://test@testhost:3306/testDB?readTimeout=800ms&writeTimeout=800ms",
 		},

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
+func TestDBConfigURL(t *testing.T) {
+	tests := []struct {
+		conf     DBConfig
+		expected string
+	}{
+		{
+			// Test with one config file that has no trailing newline
+			conf:     DBConfig{DBConnectFile: "testdata/test_dburl"},
+			expected: "mysql+tcp://test@testhost:3306/testDB?readTimeout=800ms&writeTimeout=800ms",
+		},
+		{
+			// Test with a config file that *has* a traoling newline
+			conf:     DBConfig{DBConnectFile: "testdata/test_dburl_newline"},
+			expected: "mysql+tcp://test@testhost:3306/testDB?readTimeout=800ms&writeTimeout=800ms",
+		},
+	}
+
+	for _, tc := range tests {
+		url, err := tc.conf.URL()
+		test.AssertNotError(t, err, "Failed calling URL() on DBConfig")
+		test.AssertEquals(t, url, tc.expected)
+	}
+}
+
 func TestPasswordConfig(t *testing.T) {
 	tests := []struct {
 		pc       PasswordConfig

--- a/cmd/testdata/test_dburl
+++ b/cmd/testdata/test_dburl
@@ -1,0 +1,1 @@
+mysql+tcp://test@testhost:3306/testDB?readTimeout=800ms&writeTimeout=800ms

--- a/cmd/testdata/test_dburl_newline
+++ b/cmd/testdata/test_dburl_newline
@@ -1,0 +1,2 @@
+mysql+tcp://test@testhost:3306/testDB?readTimeout=800ms&writeTimeout=800ms
+


### PR DESCRIPTION
As described in issue #2025 if the contents of a `DBConnectFile` argument ends in a trailing newline an error is produced when later using the contents as a DB configuration URL.

This PR changes the `URL` function of the `DBConfig` type to strip leading and trailing whitespace (including newlines) when reading the `DBConnectFile` contents. This resolves #2025.