### PR TITLE
Fix dbConnect strings in OCSP Responder.

### DIFF
--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -1,6 +1,6 @@
 {
   "ocspResponder": {
-    "source": "mysql+tcp://ocsp_resp@boulder-mysql:3306/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms",
+    "dbConnectFile": "test/secrets/ocsp_responder_dburl",
     "maxDBConns": 10,
     "path": "/",
     "listenAddress": "0.0.0.0:4002",

--- a/test/secrets/ocsp_responder_dburl
+++ b/test/secrets/ocsp_responder_dburl
@@ -1,0 +1,1 @@
+ocsp_resp@tcp(boulder-mysql:3306)/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms


### PR DESCRIPTION
Right now we use the Source field for both DB and file URLs. However, we want to
move to the DBConnect config field, so that we can take advantage of the code
that reads DSNs from a file on disk. It turns out the existing code didn't work
if you configure a dbConnect string, because it would error out with:

"source" parameter not found in JSON config

After rearranging, both methods should work.