### PR TITLE
Update README to suggest Docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to do this is with this command:
 Slow start
 ----------
 
-If you can't use the Docker setup, you here are instructions for setting up a
+If you can't use the Docker setup, here are instructions for setting up a
 Boulder development environment without it.
 
 We recommend setting git's [fsckObjects

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ To run a specific unittest:
 
     docker-compose run boulder go test ./ra
 
+The configuration in docker-compose.yml mounts your
+[`$GOPATH`](https://golang.org/doc/code.html#GOPATH) on top of its own
+`$GOPATH`. So you can edit code on your host and it will be immediately
+reflected inside Docker images run with docker-compose.
+
+By default, Boulder uses a fake DNS resolver that resolves all hostnames to
+127.0.0.1. This is suitable for running integration tests inside the Docker
+container. If you want Boulder to be able to communicate with a client running
+on your host instead, you should find your host's Docker IP with:
+
+    ifconfig | grep -A1 docker0
+
+And edit docker-compose.yml to change the FAKE_DNS environment variable to
+match.
+
 If a base image changes (i.e. `letsencrypt/boulder-tools`) you will need to rebuild
 images for both the boulder and bhsm containers and re-create them. The quickest way
 to do this is with this command:
@@ -88,8 +103,8 @@ Resolve Go-dependencies, set up a database and RabbitMQ:
 user with the default password, so if you have disabled that account
 or changed the password you may have to adjust the file or recreate the commands.
 
-Edit the "key" section of test/config/ca.json to replace
-"ConfigFile": "test/test-ca.key-pkcs11.json" with "File": "test/test-ca.key".
+Install SoftHSM to store the CA private key in a way that can be accessed using
+PKCS#11. Then run ./test/make-softhsm.sh and follow its instructions.
 
 Start all boulder components with test configs (Ctrl-C kills all):
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,26 @@ Quickstart
 ------
 
 Boulder has a Dockerfile to make it easy to install and set up all its
-dependencies. This approach is most suitable if you just need to set up Boulder
-for the purpose of testing client software against it. To start Boulder
-in a Docker container, run:
+dependencies. This is how the maintainers work on Boulder, and is our main
+recommended way to run it.
 
-    ./test/run-docker.sh
-
-Or, using docker-compose:
+To start Boulder in a Docker container, run:
 
     docker-compose up
+
+To run tests:
+
+    docker-compose run boulder ./test.sh
+
+To run a specific unittest:
+
+    docker-compose run boulder go test ./ra
 
 Slow start
 ----------
 
-This approach is better if you intend to develop on Boulder frequently, because
-it's challenging to develop inside the Docker container.
+If you can't use the Docker setup, you here are instructions for setting up a
+Boulder development environment without it.
 
 We recommend setting git's [fsckObjects
 setting](https://groups.google.com/forum/#!topic/binary-transparency/f-BI4o8HZW0/discussion)
@@ -77,7 +82,10 @@ Resolve Go-dependencies, set up a database and RabbitMQ:
 user with the default password, so if you have disabled that account
 or changed the password you may have to adjust the file or recreate the commands.
 
-Start each boulder component with test configs (Ctrl-C kills all):
+Edit the "key" section of test/config/ca.json to replace
+"ConfigFile": "test/test-ca.key-pkcs11.json" with "File": "test/test-ca.key".
+
+Start all boulder components with test configs (Ctrl-C kills all):
 
     ./start.py
 

--- a/test/make-softhsm.sh
+++ b/test/make-softhsm.sh
@@ -16,16 +16,9 @@ fi
 cd $(dirname $0)
 export SOFTHSM_CONF=$PWD/softhsm.conf
 echo 0:${PWD}/softhsm.db > ${SOFTHSM_CONF}
-softhsm --init-token --slot 0 --label "softhsm token" --pin 1234 --so-pin 1234
-softhsm --slot 0 --import test-ca.key  --label "happy hacker key" --pin 1234 --id FF
-echo "Set SOFTHSM_CONF=${SOFTHSM_CONF} to use, and put in your Boulder config:"
-cat << EOF
-"Key": {
-  "PKCS11": {
-    "Module": "/usr/lib/softhsm/libsofthsm.so",
-    "tokenLabel": "softhsm token",
-    "privateKeyLabel": "happy hacker key",
-    "pin": "1234"
-  }
-},
-EOF
+softhsm --init-token --slot 0 --label token_label --pin 5678 --so-pin 1234
+softhsm --slot 0 --import test-ca.key  --label key_label --pin 5678 --id FF
+echo "Add this to your .bashrc:"
+echo "export SOFTHSM_CONF=${SOFTHSM_CONF}"
+echo "And edit test/test-ca.key-pkcs11.json to have:"
+echo '"module": "/usr/lib/softhsm/libsofthsm.so"'


### PR DESCRIPTION
Docker's now our main dev env, and running outside of Docker requires a change
to not use SoftHSM. Update the README to reflect that.

Also include instructions in the README on how to run SoftHSM on the host, update make-softhsm to match the current setup, and describe the mounting of GOPATH for instant updates to code.