### PR TITLE
Remove only one trailing slash in Publisher.

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -26,7 +26,7 @@ type Log struct {
 // NewLog returns an initialized Log struct
 func NewLog(uri, b64PK string) (*Log, error) {
 	if strings.HasSuffix(uri, "/") {
-		uri = uri[0 : len(uri)-2]
+		uri = uri[0 : len(uri)-1]
 	}
 	client := ctClient.New(uri, nil)
 

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -269,11 +269,12 @@ func setup(t *testing.T) (*Impl, *x509.Certificate, *ecdsa.PrivateKey) {
 }
 
 func addLog(t *testing.T, pub *Impl, port int, pubKey *ecdsa.PublicKey) {
-	uri := fmt.Sprintf("http://localhost:%d", port)
+	uri := fmt.Sprintf("http://localhost:%d/", port)
 	der, err := x509.MarshalPKIXPublicKey(pubKey)
 	test.AssertNotError(t, err, "Failed to marshal key")
 	newLog, err := NewLog(uri, base64.StdEncoding.EncodeToString(der))
 	test.AssertNotError(t, err, "Couldn't create log")
+	test.AssertEquals(t, newLog.uri, fmt.Sprintf("http://localhost:%d", port))
 	pub.ctLogs = append(pub.ctLogs, newLog)
 }
 

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -29,7 +29,7 @@
     "ct": {
       "logs": [
         {
-          "uri": "http://127.0.0.1:4500",
+          "uri": "http://127.0.0.1:4500/",
           "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q=="
         }
       ],


### PR DESCRIPTION
Previously the code was removing the trailing slash plus one extra character.