### PR TITLE
Split up boulder-config.json (Admin Revoker)

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -151,11 +151,8 @@ func main() {
 
 	ctx := context.Background()
 	args := flagSet.Args()
-	switch command {
-	case "serial-revoke":
-		if len(args) < 2 {
-			usage()
-		}
+	switch {
+	case command == "serial-revoke" && len(args) == 2:
 		// 1: serial,  2: reasonCode
 		serial := args[0]
 		reasonCode, err := strconv.Atoi(args[1])
@@ -176,10 +173,7 @@ func main() {
 		err = tx.Commit()
 		cmd.FailOnError(err, "Couldn't cleanly close transaction")
 
-	case "reg-revoke":
-		if len(args) < 2 {
-			usage()
-		}
+	case command == "reg-revoke" && len(args) == 2:
 		// 1: registration ID,  2: reasonCode
 		regID, err := strconv.ParseInt(args[0], 10, 64)
 		cmd.FailOnError(err, "Registration ID argument must be an integer")
@@ -208,7 +202,7 @@ func main() {
 		err = tx.Commit()
 		cmd.FailOnError(err, "Couldn't cleanly close transaction")
 
-	case "list-reasons":
+	case command == "list-reasons":
 		var codes revocationCodes
 		for k := range core.RevocationReasons {
 			codes = append(codes, k)
@@ -219,10 +213,7 @@ func main() {
 			fmt.Printf("%d: %s\n", k, core.RevocationReasons[k])
 		}
 
-	case "auth-revoke":
-		if len(args) < 1 {
-			usage()
-		}
+	case command == "auth-revoke" && len(args) == 1:
 		domain := args[0]
 		_, logger, _, sac, stats := setupContext(c)
 		ident := core.AcmeIdentifier{Value: domain, Type: core.IdentifierDNS}

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -129,7 +129,7 @@ func main() {
 	command := os.Args[1]
 	flagSet := flag.NewFlagSet(command, flag.ExitOnError)
 	configFile := flagSet.String("config", "", "File path to the configuration file for this service")
-	flagSet.Parse(os.Args[2:])
+	_ = flagSet.Parse(os.Args[2:])
 	if *configFile == "" {
 		fmt.Fprintf(os.Stderr, "%s\nargs:", usage)
 		flagSet.PrintDefaults()

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -24,7 +24,7 @@ import (
 
 const clientName = "AdminRevoker"
 
-const usage = `
+const usageString = `
 usage:
 admin-revoker serial-revoke --config <path> <serial> <reason-code>
 admin-revoker reg-revoke --config <path> <registration-id> <reason-code>
@@ -128,7 +128,7 @@ func (rc revocationCodes) Swap(i, j int)      { rc[i], rc[j] = rc[j], rc[i] }
 
 func main() {
 	usage := func() {
-		fmt.Fprintf(os.Stderr, usage)
+		fmt.Fprintf(os.Stderr, usageString)
 		os.Exit(1)
 	}
 	if len(os.Args) <= 2 {

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -36,6 +36,9 @@ command descriptions:
   reg-revoke      Revoke all certificates associated with a registration ID
   list-reasons    List all revocation reason codes
   auth-revoke     Revoke all pending/valid authorizations for a domain
+
+args:
+  config    File path to the configuration file for this service
 `
 
 type config struct {
@@ -124,9 +127,12 @@ func (rc revocationCodes) Less(i, j int) bool { return rc[i] < rc[j] }
 func (rc revocationCodes) Swap(i, j int)      { rc[i], rc[j] = rc[j], rc[i] }
 
 func main() {
-	if len(os.Args) <= 2 {
+	usage := func() {
 		fmt.Fprintf(os.Stderr, usage)
 		os.Exit(1)
+	}
+	if len(os.Args) <= 2 {
+		usage()
 	}
 
 	command := os.Args[1]
@@ -134,12 +140,6 @@ func main() {
 	configFile := flagSet.String("config", "", "File path to the configuration file for this service")
 	err := flagSet.Parse(os.Args[2:])
 	cmd.FailOnError(err, "Error parsing flagset")
-
-	usage := func() {
-		fmt.Fprintf(os.Stderr, "%s\nargs:", usage)
-		flagSet.PrintDefaults()
-		os.Exit(1)
-	}
 
 	if *configFile == "" {
 		usage()

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"crypto/x509"
-	"encoding/json"
+	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"sort"
@@ -13,7 +12,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cactus/go-statsd-client/statsd"
-	"github.com/codegangsta/cli"
 	gorp "gopkg.in/gorp.v1"
 
 	"github.com/letsencrypt/boulder/cmd"
@@ -24,23 +22,33 @@ import (
 	"github.com/letsencrypt/boulder/sa"
 )
 
-func loadConfig(c *cli.Context) (config cmd.Config, err error) {
-	configFileName := c.GlobalString("config")
-	configJSON, err := ioutil.ReadFile(configFileName)
-	if err != nil {
-		return
-	}
-
-	err = json.Unmarshal(configJSON, &config)
-	return
-}
-
 const clientName = "AdminRevoker"
 
-func setupContext(context *cli.Context) (rpc.RegistrationAuthorityClient, blog.Logger, *gorp.DbMap, rpc.StorageAuthorityClient, statsd.Statter) {
-	c, err := loadConfig(context)
-	cmd.FailOnError(err, "Failed to load Boulder configuration")
+const usage = `
+usage:
+admin-revoker <command> --config <path> [args]
 
+commands:
+  serial-revoke   Revoke a single certificate by the hex serial number
+  reg-revoke      Revoke all certificates associated with a registration ID
+  list-reasons    List all revocation reason codes
+  auth-revoke     Revoke all pending/valid authorizations for a domain
+`
+
+type config struct {
+	Revoker struct {
+		cmd.DBConfig
+		// The revoker isn't a long running service, so doesn't get a full
+		// ServiceConfig, just an AMQPConfig.
+		AMQP *cmd.AMQPConfig
+	}
+
+	Statsd cmd.StatsdConfig
+
+	Syslog cmd.SyslogConfig
+}
+
+func setupContext(c config) (rpc.RegistrationAuthorityClient, blog.Logger, *gorp.DbMap, rpc.StorageAuthorityClient, statsd.Statter) {
 	stats, logger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 
 	amqpConf := c.Revoker.AMQP
@@ -113,116 +121,106 @@ func (rc revocationCodes) Less(i, j int) bool { return rc[i] < rc[j] }
 func (rc revocationCodes) Swap(i, j int)      { rc[i], rc[j] = rc[j], rc[i] }
 
 func main() {
+	if len(os.Args) <= 2 {
+		fmt.Fprintf(os.Stderr, usage)
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+	flagSet := flag.NewFlagSet(command, flag.ExitOnError)
+	configFile := flagSet.String("config", "", "File path to the configuration file for this service")
+	flagSet.Parse(os.Args[2:])
+	if *configFile == "" {
+		fmt.Fprintf(os.Stderr, "%s\nargs:", usage)
+		flagSet.PrintDefaults()
+		os.Exit(1)
+	}
+	args := flagSet.Args()
+
+	var c config
+	err := cmd.ReadJSONFile(*configFile, &c)
+	cmd.FailOnError(err, "Reading JSON config file into config structure")
+
 	ctx := context.Background()
-	app := cli.NewApp()
-	app.Name = "admin-revoker"
-	app.Usage = "Revokes issued certificates"
-	app.Version = cmd.Version()
-	app.Author = "Boulder contributors"
-	app.Email = "ca-dev@letsencrypt.org"
+	switch command {
+	case "serial-revoke":
+		// 1: serial,  2: reasonCode
+		serial := args[0]
+		reasonCode, err := strconv.Atoi(args[1])
+		cmd.FailOnError(err, "Reason code argument must be an integer")
 
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   "config",
-			Value:  "config.json",
-			EnvVar: "BOULDER_CONFIG",
-			Usage:  "Path to Boulder JSON configuration file",
-		},
+		cac, logger, dbMap, _, _ := setupContext(c)
+
+		tx, err := dbMap.Begin()
+		if err != nil {
+			cmd.FailOnError(sa.Rollback(tx, err), "Couldn't begin transaction")
+		}
+
+		err = revokeBySerial(ctx, serial, core.RevocationCode(reasonCode), cac, logger, tx)
+		if err != nil {
+			cmd.FailOnError(sa.Rollback(tx, err), "Couldn't revoke certificate")
+		}
+
+		err = tx.Commit()
+		cmd.FailOnError(err, "Couldn't cleanly close transaction")
+
+	case "reg-revoke":
+		// 1: registration ID,  2: reasonCode
+		regID, err := strconv.ParseInt(args[0], 10, 64)
+		cmd.FailOnError(err, "Registration ID argument must be an integer")
+		reasonCode, err := strconv.Atoi(args[1])
+		cmd.FailOnError(err, "Reason code argument must be an integer")
+
+		cac, logger, dbMap, sac, _ := setupContext(c)
+		// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
+		defer logger.AuditPanic()
+
+		tx, err := dbMap.Begin()
+		if err != nil {
+			cmd.FailOnError(sa.Rollback(tx, err), "Couldn't begin transaction")
+		}
+
+		_, err = sac.GetRegistration(ctx, regID)
+		if err != nil {
+			cmd.FailOnError(err, "Couldn't fetch registration")
+		}
+
+		err = revokeByReg(ctx, regID, core.RevocationCode(reasonCode), cac, logger, tx)
+		if err != nil {
+			cmd.FailOnError(sa.Rollback(tx, err), "Couldn't revoke certificate")
+		}
+
+		err = tx.Commit()
+		cmd.FailOnError(err, "Couldn't cleanly close transaction")
+
+	case "list-reasons":
+		var codes revocationCodes
+		for k := range core.RevocationReasons {
+			codes = append(codes, k)
+		}
+		sort.Sort(codes)
+		fmt.Printf("Revocation reason codes\n-----------------------\n\n")
+		for _, k := range codes {
+			fmt.Printf("%d: %s\n", k, core.RevocationReasons[k])
+		}
+
+	case "auth-revoke":
+		domain := args[0]
+		_, logger, _, sac, stats := setupContext(c)
+		ident := core.AcmeIdentifier{Value: domain, Type: core.IdentifierDNS}
+		authsRevoked, pendingAuthsRevoked, err := sac.RevokeAuthorizationsByDomain(ctx, ident)
+		cmd.FailOnError(err, fmt.Sprintf("Failed to revoke authorizations for %s", ident.Value))
+		logger.Info(fmt.Sprintf(
+			"Revoked %d pending authorizations and %d final authorizations\n",
+			authsRevoked,
+			pendingAuthsRevoked,
+		))
+		stats.Inc("admin-revoker.revokedAuthorizations", authsRevoked, 1.0)
+		stats.Inc("admin-revoker.revokedPendingAuthorizations", pendingAuthsRevoked, 1.0)
+
+	default:
+		fmt.Fprintf(os.Stderr, "%s\nargs:", usage)
+		flagSet.PrintDefaults()
+		os.Exit(1)
 	}
-	app.Commands = []cli.Command{
-		{
-			Name:  "serial-revoke",
-			Usage: "Revoke a single certificate by the hex serial number",
-			Action: func(c *cli.Context) {
-				// 1: serial,  2: reasonCode
-				serial := c.Args().First()
-				reasonCode, err := strconv.Atoi(c.Args().Get(1))
-				cmd.FailOnError(err, "Reason code argument must be an integer")
-
-				cac, logger, dbMap, _, _ := setupContext(c)
-
-				tx, err := dbMap.Begin()
-				if err != nil {
-					cmd.FailOnError(sa.Rollback(tx, err), "Couldn't begin transaction")
-				}
-
-				err = revokeBySerial(ctx, serial, core.RevocationCode(reasonCode), cac, logger, tx)
-				if err != nil {
-					cmd.FailOnError(sa.Rollback(tx, err), "Couldn't revoke certificate")
-				}
-
-				err = tx.Commit()
-				cmd.FailOnError(err, "Couldn't cleanly close transaction")
-			},
-		},
-		{
-			Name:  "reg-revoke",
-			Usage: "Revoke all certificates associated with a registration ID",
-			Action: func(c *cli.Context) {
-				// 1: registration ID,  2: reasonCode
-				regID, err := strconv.ParseInt(c.Args().First(), 10, 64)
-				cmd.FailOnError(err, "Registration ID argument must be an integer")
-				reasonCode, err := strconv.Atoi(c.Args().Get(1))
-				cmd.FailOnError(err, "Reason code argument must be an integer")
-
-				cac, logger, dbMap, sac, _ := setupContext(c)
-				// AUDIT[ Error Conditions ] 9cc4d537-8534-4970-8665-4b382abe82f3
-				defer logger.AuditPanic()
-
-				tx, err := dbMap.Begin()
-				if err != nil {
-					cmd.FailOnError(sa.Rollback(tx, err), "Couldn't begin transaction")
-				}
-
-				_, err = sac.GetRegistration(ctx, regID)
-				if err != nil {
-					cmd.FailOnError(err, "Couldn't fetch registration")
-				}
-
-				err = revokeByReg(ctx, regID, core.RevocationCode(reasonCode), cac, logger, tx)
-				if err != nil {
-					cmd.FailOnError(sa.Rollback(tx, err), "Couldn't revoke certificate")
-				}
-
-				err = tx.Commit()
-				cmd.FailOnError(err, "Couldn't cleanly close transaction")
-			},
-		},
-		{
-			Name:  "list-reasons",
-			Usage: "List all revocation reason codes",
-			Action: func(c *cli.Context) {
-				var codes revocationCodes
-				for k := range core.RevocationReasons {
-					codes = append(codes, k)
-				}
-				sort.Sort(codes)
-				fmt.Printf("Revocation reason codes\n-----------------------\n\n")
-				for _, k := range codes {
-					fmt.Printf("%d: %s\n", k, core.RevocationReasons[k])
-				}
-			},
-		},
-		{
-			Name:  "auth-revoke",
-			Usage: "Revoke all pending/valid authorizations for a domain",
-			Action: func(c *cli.Context) {
-				domain := c.Args().First()
-				_, logger, _, sac, stats := setupContext(c)
-				ident := core.AcmeIdentifier{Value: domain, Type: core.IdentifierDNS}
-				authsRevoked, pendingAuthsRevoked, err := sac.RevokeAuthorizationsByDomain(ctx, ident)
-				cmd.FailOnError(err, fmt.Sprintf("Failed to revoke authorizations for %s", ident.Value))
-				logger.Info(fmt.Sprintf(
-					"Revoked %d pending authorizations and %d final authorizations\n",
-					authsRevoked,
-					pendingAuthsRevoked,
-				))
-				stats.Inc("admin-revoker.revokedAuthorizations", authsRevoked, 1.0)
-				stats.Inc("admin-revoker.revokedPendingAuthorizations", pendingAuthsRevoked, 1.0)
-			},
-		},
-	}
-
-	err := app.Run(os.Args)
-	cmd.FailOnError(err, "Failed to run application")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,13 +29,6 @@ type Config struct {
 
 	Syslog SyslogConfig
 
-	Revoker struct {
-		DBConfig
-		// The revoker isn't a long running service, so doesn't get a full
-		// ServiceConfig, just an AMQPConfig.
-		AMQP *AMQPConfig
-	}
-
 	PA PAConfig
 
 	Common struct {

--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -17,23 +17,6 @@
     }
   },
 
-  "revoker": {
-    "dbConnectFile": "test/secrets/revoker_dburl",
-    "maxDBConns": 1,
-    "amqp": {
-      "serverURLFile": "test/secrets/amqp_url",
-      "insecure": true,
-      "RA": {
-        "server": "RA.server",
-        "rpcTimeout": "15s"
-      },
-      "SA": {
-        "server": "SA.server",
-        "rpcTimeout": "15s"
-      }
-    }
-  },
-
   "common": {
     "issuerCert": "test/test-ca.pem",
     "dnsResolver": "127.0.0.1:8053",

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -18,23 +18,6 @@
     }
   },
 
-  "revoker": {
-    "dbConnectFile": "test/secrets/revoker_dburl",
-    "maxDBConns": 1,
-    "amqp": {
-      "serverURLFile": "test/secrets/amqp_url",
-      "insecure": true,
-      "RA": {
-        "server": "RA.server",
-        "rpcTimeout": "15s"
-      },
-      "SA": {
-        "server": "SA.server",
-        "rpcTimeout": "15s"
-      }
-    }
-  },
-
   "common": {
     "issuerCert": "test/test-ca.pem",
     "dnsResolver": "127.0.0.1:8053",

--- a/test/config-next/admin-revoker.json
+++ b/test/config-next/admin-revoker.json
@@ -1,0 +1,28 @@
+{
+  "revoker": {
+    "dbConnectFile": "test/secrets/revoker_dburl",
+    "maxDBConns": 1,
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "RA": {
+        "server": "RA.server",
+        "rpcTimeout": "15s"
+      },
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "statsd": {
+    "server": "localhost:8125",
+    "prefix": "Boulder"
+  },
+
+  "syslog": {
+    "stdoutlevel": 6,
+    "sysloglevel": 4
+  }
+}

--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -1,0 +1,29 @@
+{
+  "revoker": {
+    "dbConnectFile": "test/secrets/revoker_dburl",
+    "maxDBConns": 1,
+    "amqp": {
+      "serverURLFile": "test/secrets/amqp_url",
+      "insecure": true,
+      "RA": {
+        "server": "RA.server",
+        "rpcTimeout": "15s"
+      },
+      "SA": {
+        "server": "SA.server",
+        "rpcTimeout": "15s"
+      }
+    }
+  },
+
+  "statsd": {
+    "server": "localhost:8125",
+    "prefix": "Boulder"
+  },
+
+  "syslog": {
+    "network": "",
+    "server": "",
+    "stdoutlevel": 6
+  }
+}


### PR DESCRIPTION
Another step in completing #1962, which will remove the global configuration file and `codegangsta/cli` from boulder. 3 more to go!

This PR, is a little bit different than others in that there is a lot more reliance on `codegangsta/cli` especially in the implementation of subcommands. I put some thought into creating our own `SubCommand` struct, but given the lack of complexity it seemed unnecessary as the same could be accomplished with slightly more advanced usage of `os` and `flag`. I'm open to suggestions. 

Also, it would help to see some examples of how this command is used.