### PR TITLE
Add helpful note to CSR parsing error.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -817,6 +817,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *reques
 	certificateRequest.CSR, err = x509.ParseCertificateRequest(rawCSR.CSR)
 	if err != nil {
 		logEvent.AddError("unable to parse certificate request: %s", err)
+		// TODO(jsha): Revert once #565 is closed by upgrading to Go 1.6, i.e. #1514
 		wfe.sendError(response, logEvent, probs.Malformed("Error parsing certificate request. Extensions in the CSR marked critical can cause this error: https://github.com/letsencrypt/boulder/issues/565"), err)
 		return
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -817,7 +817,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *reques
 	certificateRequest.CSR, err = x509.ParseCertificateRequest(rawCSR.CSR)
 	if err != nil {
 		logEvent.AddError("unable to parse certificate request: %s", err)
-		wfe.sendError(response, logEvent, probs.Malformed("Error parsing certificate request"), err)
+		wfe.sendError(response, logEvent, probs.Malformed("Error parsing certificate request. Extensions in the CSR marked critical can cause this error: https://github.com/letsencrypt/boulder/issues/565"), err)
 		return
 	}
 	wfe.logCsr(request, certificateRequest, reg)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -685,7 +685,7 @@ func TestIssueCertificate(t *testing.T) {
 		makePostRequest(signRequest(t, `{"resource":"new-cert"}`, wfe.nonceService)))
 	assertJSONEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Error parsing certificate request","status":400}`)
+		`{"type":"urn:acme:error:malformed","detail":"Error parsing certificate request. Extensions in the CSR marked critical can cause this error: https://github.com/letsencrypt/boulder/issues/565","status":400}`)
 
 	// Valid, signed JWS body, payload has an invalid signature on CSR and no authorizations:
 	// alias b64url="base64 -w0 | sed -e 's,+,-,g' -e 's,/,_,g'"


### PR DESCRIPTION
A few people have run into #565. This error message will make it more quickly obvious what's wrong.