### PR TITLE
Split up boulder-config.json (Cert Checker)

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -253,7 +253,7 @@ func main() {
 	workers := flag.Int("workers", runtime.NumCPU(), "The number of concurrent workers used to process certificates")
 	badResultsOnly := flag.Bool("bad-results-only", false, "Only collect and display bad results")
 	connect := flag.String("db-connect", "", "SQL URI if not provided in the configuration file")
-	cp := flag.String("check-period", "2160h", "How far back to check")
+	cp := flag.Duration("check-period", time.Hour*2160, "How far back to check")
 	unexpiredOnly := flag.Bool("unexpired-only", false, "Only check currently unexpired certificates")
 
 	flag.Parse()
@@ -283,10 +283,7 @@ func main() {
 	}
 	config.CertChecker.UnexpiredOnly = *unexpiredOnly
 	config.CertChecker.BadResultsOnly = *badResultsOnly
-	if *cp != "" {
-		config.CertChecker.CheckPeriod.Duration, err = time.ParseDuration(*cp)
-		cmd.FailOnError(err, "Failed to parse check period")
-	}
+	config.CertChecker.CheckPeriod.Duration = *cp
 
 	// Validate PA config and set defaults if needed
 	cmd.FailOnError(config.PA.CheckChallenges(), "Invalid PA configuration")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,16 +53,6 @@ type Config struct {
 		}
 	}
 
-	CertChecker struct {
-		DBConfig
-		HostnamePolicyConfig
-
-		Workers             int
-		ReportDirectoryPath string
-		UnexpiredOnly       bool
-		BadResultsOnly      bool
-		CheckPeriod         ConfigDuration
-	}
 	AllowedSigningAlgos *AllowedSigningAlgos
 
 	// TODO: remove after production configs use SubscriberAgreementURL in the wfe section

--- a/test/boulder-config-next.json
+++ b/test/boulder-config-next.json
@@ -50,11 +50,6 @@
     }
   },
 
-  "certChecker": {
-    "dbConnectFile": "test/secrets/cert_checker_dburl",
-    "maxDBConns": 10
-  },
-
   "allowedSigningAlgos": {
     "rsa": true,
     "ecdsanistp256": true,

--- a/test/boulder-config.json
+++ b/test/boulder-config.json
@@ -51,11 +51,6 @@
     }
   },
 
-  "certChecker": {
-    "dbConnectFile": "test/secrets/cert_checker_dburl",
-    "maxDBConns": 10
-  },
-
   "subscriberAgreementURL": "http://boulder:4000/terms/v1",
 
   "allowedSigningAlgos": {

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -1,0 +1,24 @@
+{
+  "certChecker": {
+    "dbConnectFile": "test/secrets/cert_checker_dburl",
+    "maxDBConns": 10
+  },
+
+  "pa": {
+    "challenges": {
+      "http-01": true,
+      "tls-sni-01": true,
+      "dns-01": true
+    }
+  },
+
+  "statsd": {
+    "server": "localhost:8125",
+    "prefix": "Boulder"
+  },
+
+  "syslog": {
+    "stdoutlevel": 6,
+    "sysloglevel": 4
+  }
+}

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -1,0 +1,25 @@
+{
+  "certChecker": {
+    "dbConnectFile": "test/secrets/cert_checker_dburl",
+    "maxDBConns": 10
+  },
+
+  "pa": {
+    "challenges": {
+      "http-01": true,
+      "tls-sni-01": true,
+      "dns-01": true
+    }
+  },
+
+  "statsd": {
+    "server": "localhost:8125",
+    "prefix": "Boulder"
+  },
+
+  "syslog": {
+    "network": "",
+    "server": "",
+    "stdoutlevel": 6
+  }
+}


### PR DESCRIPTION
**Note for reviewers:**
I _believe_ there was a small bug in the implementation of this binary. In the following line of code, a global bool called "valid-only" is referenced. However, this bool is never defined.
 
`config.CertChecker.UnexpiredOnly = c.GlobalBool("valid-only")`

I believe the intended bool is called "unexpired-only" which is defined, but never referenced. This PR, along with removing global configuration, fixes this small error. 