### PR TITLE
expiration-mailer: Skip renewed certs faster.

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -162,7 +162,9 @@ func (m *mailer) certIsRenewed(serial string) (renewed bool, err error) {
 		LIMIT 1`,
 		map[string]interface{}{"serial": serial},
 	)
-	m.log.Debug(fmt.Sprintf("Cert %s is already renewed", serial))
+	if present == 1 {
+		m.log.Debug(fmt.Sprintf("Cert %s is already renewed", serial))
+	}
 	return present == 1, err
 }
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -75,7 +75,7 @@ func (m *mailer) sendNags(contacts []*core.AcmeURL, certs []*x509.Certificate) e
 	expiresIn := time.Duration(math.MaxInt64)
 	expDate := m.clk.Now()
 	domains := []string{}
-	var serials []string
+	serials := []string{}
 
 	// Pick out the expiration date that is closest to being hit.
 	for _, cert := range certs {

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -75,10 +75,12 @@ func (m *mailer) sendNags(contacts []*core.AcmeURL, certs []*x509.Certificate) e
 	expiresIn := time.Duration(math.MaxInt64)
 	expDate := m.clk.Now()
 	domains := []string{}
+	var serials []string
 
 	// Pick out the expiration date that is closest to being hit.
 	for _, cert := range certs {
 		domains = append(domains, cert.DNSNames...)
+		serials = append(serials, core.SerialToString(cert.SerialNumber))
 		possible := cert.NotAfter.Sub(m.clk.Now())
 		if possible < expiresIn {
 			expiresIn = possible
@@ -87,6 +89,8 @@ func (m *mailer) sendNags(contacts []*core.AcmeURL, certs []*x509.Certificate) e
 	}
 	domains = core.UniqueLowerNames(domains)
 	sort.Strings(domains)
+
+	m.log.Debug(fmt.Sprintf("Sending mail for %s (%s)", strings.Join(domains, ", "), strings.Join(serials, ", ")))
 
 	email := emailContent{
 		ExpirationDate:   expDate.UTC().Format(time.RFC822Z),
@@ -158,12 +162,12 @@ func (m *mailer) certIsRenewed(serial string) (renewed bool, err error) {
 		LIMIT 1`,
 		map[string]interface{}{"serial": serial},
 	)
+	m.log.Debug(fmt.Sprintf("Cert %s is already renewed", serial))
 	return present == 1, err
 }
 
 func (m *mailer) processCerts(allCerts []core.Certificate) {
 	ctx := context.Background()
-	m.log.Info(fmt.Sprintf("expiration-mailer: Found %d certificates, starting sending messages", len(allCerts)))
 
 	regIDToCerts := make(map[int64][]core.Certificate)
 
@@ -197,6 +201,10 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 				// assume not renewed
 			} else if renewed {
 				m.stats.Inc("Mailer.Expiration.Renewed", 1, 1.0)
+				if err := m.updateCertStatus(cert.Serial); err != nil {
+					m.log.AuditErr(fmt.Sprintf("Error updating certificate status for %s: %s", cert.Serial, err))
+					m.stats.Inc("Mailer.Expiration.Errors.UpdateCertificateStatus", 1, 1.0)
+				}
 				continue
 			}
 
@@ -227,7 +235,6 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 			}
 		}
 	}
-	m.log.Info("expiration-mailer: Finished sending messages")
 	return
 }
 
@@ -266,6 +273,8 @@ func (m *mailer) findExpiringCertificates() error {
 			m.log.AuditErr(fmt.Sprintf("expiration-mailer: Error loading certificates: %s", err))
 			return err // fatal
 		}
+		m.log.Info(fmt.Sprintf("Found %d certificates expiring between %s and %s", len(certs),
+			left.Format("2006-01-02 03:04"), right.Format("2006-01-02 03:04")))
 
 		if len(certs) == 0 {
 			continue // nothing to do
@@ -368,6 +377,7 @@ func main() {
 	dbURL, err := c.Mailer.DBConfig.URL()
 	cmd.FailOnError(err, "Couldn't load DB URL")
 	dbMap, err := sa.NewDbMap(dbURL, c.Mailer.DBConfig.MaxDBConns)
+	sa.SetSQLDebug(dbMap, logger)
 	cmd.FailOnError(err, "Could not connect to database")
 	go sa.ReportDbConnCount(dbMap, metrics.NewStatsdScope(stats, "ExpirationMailer"))
 


### PR DESCRIPTION
Previously, if a certificate was skipped by the expiration mailer due to being
renewed already, we wouldn't update its lastnag time. However, this meant that
already-renewed certificates would clog up the results of the query
expiration-mailer does to find expired certs. Since this query has a limit (1000
in practice), we might find only renewed certificates on each query, even when
there are non-renewed certificates available to alert about. Then we'd never
make forward progress.

This change updates the stored lastExpirationNagSent field when a certificate is
skipped over due to renewal, so that it isn't included in the first-step query.

Fixes #2054 