### PR TITLE
Empty reg update should return existing reg data

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -113,8 +113,11 @@ func (sa *StorageAuthority) GetRegistrationByKey(_ context.Context, jwk jose.Jso
 		panic(err)
 	}
 
+	contactURL, _ := core.ParseAcmeURL("mailto:person@mail.com")
+	contacts := []*core.AcmeURL{contactURL}
+
 	if core.KeyDigestEquals(jwk, test1KeyPublic) {
-		return core.Registration{ID: 1, Key: jwk, Agreement: agreementURL}, nil
+		return core.Registration{ID: 1, Key: jwk, Agreement: agreementURL, Contact: &contacts}, nil
 	}
 
 	if core.KeyDigestEquals(jwk, test2KeyPublic) {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1116,9 +1116,6 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 	// serialize the update as JSON to send via AMQP to the RA.
 	update.Key = currReg.Key
 
-	// If the registration doesn't have an agreement set, or any contacts (e.g. it
-	// is the trivial update `{"resource":"reg"}` then do not send it to the RA
-	// for update, there is nothing to save/update.
 	updatedReg, err := wfe.RA.UpdateRegistration(ctx, currReg, update)
 	if err != nil {
 		logEvent.AddError("unable to update registration: %s", err)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1119,17 +1119,11 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 	// If the registration doesn't have an agreement set, or any contacts (e.g. it
 	// is the trivial update `{"resource":"reg"}` then do not send it to the RA
 	// for update, there is nothing to save/update.
-	var updatedReg core.Registration
-	if len(update.Agreement) > 0 || update.Contact != nil {
-		// Ask the RA to update this authorization.
-		updatedReg, err = wfe.RA.UpdateRegistration(ctx, currReg, update)
-		if err != nil {
-			logEvent.AddError("unable to update registration: %s", err)
-			wfe.sendError(response, logEvent, core.ProblemDetailsForError(err, "Unable to update registration"), err)
-			return
-		}
-	} else {
-		updatedReg = update // Return the empty update as-is
+	updatedReg, err := wfe.RA.UpdateRegistration(ctx, currReg, update)
+	if err != nil {
+		logEvent.AddError("unable to update registration: %s", err)
+		wfe.sendError(response, logEvent, core.ProblemDetailsForError(err, "Unable to update registration"), err)
+		return
 	}
 
 	jsonReply, err := marshalIndent(updatedReg)


### PR DESCRIPTION
For #2001 an optimization was added to the WFE to avoid invoking the RA's `UpdateRegistration` method when a trivial (e.g. `{"resource:"reg"}`) update is received. Instead the WFE returned the trivial update back to the client immediately.

This is contrary to the ACME spec which indicates:
>  Servers SHOULD NOT respond to GET requests for registration resources as these requests are not authenticated. If a client wishes to query the server for information about its account (e.g., to examine the   “contact” or “certificates” fields), then it SHOULD do so by sending  a POST request with an empty update. That is, it should send a JWS whose payload is trivial ({“resource”:”reg”}).

The optimization regression was captured in issue #2066 when it broke at least one client implementation.

This removes the empty reg update optimization and passes all POST's to the RA. The RA will in turn fetch the existing registration to return to the client. The second half of the #2001 optimizations remains in place, no DB UPDATE's will be performed if the new registration content doesn't differ from the existing registration content (as determine by the return of `registration.MergeUpdate`).

Since the WFE optimization is no longer in place the `FailureRegistrationAuthority` mock isn't required and is removed. Similarly `TestEmptyRegistration` in `wfe_test.go` is changed from testing for the optimization to testing for the ACME described "get registration info" behaviour.

This fixes #2066 