### PR TITLE
Fix `rpm` make target for split config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ rpm: build
 		--package "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).x86_64.rpm" \
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
 		--depends "libtool-ltdl" --maintainer "$(MAINTAINER)" \
-		test/boulder-config.json sa/_db data/ $(OBJECTS)
+		test/config/ sa/_db data/ $(OBJECTS)


### PR DESCRIPTION
After #2069 landed we no longer have a `boulder-config.json` file. This breaks the `make rpm` flow because the `rpm` make target has an explicit reference to this file as an argument to `fpm`.

This commit replaces the `test/boulder-config.json` reference with its replacement, the `test/config/` directory.