### PR TITLE
Create rpm during CI run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,12 @@ env:
     - PATH=$HOME/bin:$PATH # protoc gets installed here
     - GO15VENDOREXPERIMENT=1
   matrix:
-    - RUN="vet fmt migrations integration godep-restore errcheck generate rpm"
+    - RUN="vet fmt migrations integration godep-restore errcheck generate"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
     - RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
     - RUN="unit"
+    - RUN="rpm"
 
 install:
   - ./test/travis-before-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
     - PATH=$HOME/bin:$PATH # protoc gets installed here
     - GO15VENDOREXPERIMENT=1
   matrix:
-    - RUN="vet fmt migrations integration godep-restore errcheck generate"
+    - RUN="vet fmt migrations integration godep-restore errcheck generate rpm"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
     - RUN="integration" BOULDER_CONFIG_DIR="test/config-next"

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ archive:
 #
 # VERSION=0.1.9 EPOCH=52 MAINTAINER="$(whoami)" ARCHIVEDIR=/tmp make build rpm
 rpm: build
-	fpm -s dir -t rpm --rpm-digest sha256 --name "boulder" \
+	fpm -f -s dir -t rpm --rpm-digest sha256 --name "boulder" \
 		--license "Mozilla Public License v2.0" --vendor "ISRG" \
 		--url "https://github.com/letsencrypt/boulder" --prefix=/opt/boulder \
 		--version "$(VERSION)" --iteration "$(COMMIT_ID)" --epoch "$(EPOCH)" \

--- a/test.sh
+++ b/test.sh
@@ -247,4 +247,10 @@ if [[ "$RUN" =~ "generate" ]] ; then
   end_context #"generate"
 fi
 
+if [[ "$RUN" =~ "rpm" ]]; then
+  start_context "rpm"
+  run make rpm
+  end_context #"rpm"
+fi
+
 exit ${FAILURE}


### PR DESCRIPTION
This PR modifies the `test.sh` script to allow a `rpm` value in the `RUN` parameter passed to the script via the environment. When present, `make rpm` is invoked and a good status is required for the build to pass.

The `Makefile` was modified to add a `-f` to the `fpm` invocation used by the `rpm` build task to allow the output rpm to be overwritten if present. Otherwise multiple runs of identical bulld (e.g. on a local dev machine) would collide on the .rpm already being present.

Finally `.travis.yml` is updated to include `rpm` in the `RUN` used during CI such that an RPM is built by default for CI runs. I left the default `RUN` in `test.sh` unmodified, so an RPM will not be built for local runs (e.g. `docker-compose run boulder ./test.sh`).

This fixes #2085