### PR TITLE
Simplify KeyPolicy code 

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/letsencrypt/boulder/ca"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/policy"
 	pubPB "github.com/letsencrypt/boulder/publisher/proto"
@@ -26,8 +27,6 @@ const clientName = "CA"
 
 type config struct {
 	CA cmd.CAConfig
-
-	AllowedSigningAlgos *cmd.AllowedSigningAlgos
 
 	PA cmd.PAConfig
 
@@ -155,7 +154,7 @@ func main() {
 		clock.Default(),
 		stats,
 		issuers,
-		c.AllowedSigningAlgos.KeyPolicy(),
+		goodkey.NewKeyPolicy(),
 		logger)
 	cmd.FailOnError(err, "Failed to create CA impl")
 	cai.PA = pa

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/policy"
@@ -62,8 +63,6 @@ type config struct {
 		// you need to request a new challenge.
 		PendingAuthorizationLifetimeDays int
 	}
-
-	AllowedSigningAlgos *cmd.AllowedSigningAlgos
 
 	PA cmd.PAConfig
 
@@ -144,7 +143,7 @@ func main() {
 		logger,
 		stats,
 		c.RA.MaxContactsPerRegistration,
-		c.AllowedSigningAlgos.KeyPolicy(),
+		goodkey.NewKeyPolicy(),
 		c.RA.MaxNames,
 		c.RA.DoNotForceCN,
 		c.RA.ReuseValidAuthz,

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jmhodges/clock"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/goodkey"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/rpc"
@@ -38,8 +39,6 @@ type config struct {
 
 		CheckMalformedCSR bool
 	}
-
-	AllowedSigningAlgos *cmd.AllowedSigningAlgos
 
 	Statsd cmd.StatsdConfig
 
@@ -82,7 +81,7 @@ func main() {
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString(clientName))
 
-	wfe, err := wfe.NewWebFrontEndImpl(stats, clock.Default(), c.AllowedSigningAlgos.KeyPolicy(), logger)
+	wfe, err := wfe.NewWebFrontEndImpl(stats, clock.Default(), goodkey.NewKeyPolicy(), logger)
 	cmd.FailOnError(err, "Unable to create WFE")
 	rac, sac := setupWFE(c, logger, stats)
 	wfe.RA = rac
@@ -106,7 +105,7 @@ func main() {
 	wfe.IssuerCert, err = cmd.LoadCert(c.Common.IssuerCert)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))
 
-	logger.Info(fmt.Sprintf("WFE using key policy: %#v", c.AllowedSigningAlgos.KeyPolicy()))
+	logger.Info(fmt.Sprintf("WFE using key policy: %#v", goodkey.NewKeyPolicy()))
 
 	go cmd.ProfileCmd("WFE", stats)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,30 +15,6 @@ import (
 	"github.com/letsencrypt/boulder/goodkey"
 )
 
-// AllowedSigningAlgos defines which algorithms be used for keys that we will
-// sign.
-type AllowedSigningAlgos struct {
-	RSA           bool
-	ECDSANISTP256 bool
-	ECDSANISTP384 bool
-	ECDSANISTP521 bool
-}
-
-// KeyPolicy returns a KeyPolicy reflecting the Boulder configuration.
-func (asa *AllowedSigningAlgos) KeyPolicy() goodkey.KeyPolicy {
-	if asa != nil {
-		return goodkey.KeyPolicy{
-			AllowRSA:           asa.RSA,
-			AllowECDSANISTP256: asa.ECDSANISTP256,
-			AllowECDSANISTP384: asa.ECDSANISTP384,
-			AllowECDSANISTP521: asa.ECDSANISTP521,
-		}
-	}
-	return goodkey.KeyPolicy{
-		AllowRSA: true,
-	}
-}
-
 // PasswordConfig either contains a password or the path to a file
 // containing a password
 type PasswordConfig struct {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/letsencrypt/pkcs11key"
 
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/goodkey"
 )
 
 // PasswordConfig either contains a password or the path to a file

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -44,12 +44,12 @@ type KeyPolicy struct {
 	AllowECDSANISTP521 bool // Whether ECDSA NISTP521 keys should be allowed.
 }
 
-// NewKeyPolicy creates a hard coded key policy for boulder.
+// NewKeyPolicy returns a KeyPolicy that allows RSA, ECDSA256 and ECDSA384.
 func NewKeyPolicy() KeyPolicy {
 	return KeyPolicy{
 		AllowRSA:           true,
 		AllowECDSANISTP256: true,
-		AllowECDSANISTP384: false, // TODO: change this back to true once the integration test fails
+		AllowECDSANISTP384: true,
 		AllowECDSANISTP521: false,
 	}
 }

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -50,11 +50,10 @@ func NewKeyPolicy() KeyPolicy {
 		AllowRSA:           true,
 		AllowECDSANISTP256: true,
 		AllowECDSANISTP384: true,
-		AllowECDSANISTP521: false,
 	}
 }
 
-// GoodKey returns true iff the key is acceptable for both TLS use and account
+// GoodKey returns true if the key is acceptable for both TLS use and account
 // key use (our requirements are the same for either one), according to basic
 // strength and algorithm checking.
 // TODO: Support JsonWebKeys once go-jose migration is done.
@@ -178,8 +177,6 @@ func (policy *KeyPolicy) goodCurve(c elliptic.Curve) (err error) {
 	case policy.AllowECDSANISTP256 && params == elliptic.P256().Params():
 		return nil
 	case policy.AllowECDSANISTP384 && params == elliptic.P384().Params():
-		return nil
-	case policy.AllowECDSANISTP521 && params == elliptic.P521().Params():
 		return nil
 	default:
 		return core.MalformedRequestError(fmt.Sprintf("ECDSA curve %v not allowed", params.Name))

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -35,13 +35,23 @@ var (
 	smallPrimes          []*big.Int
 )
 
-// KeyPolicy etermines which types of key may be used with various boulder
+// KeyPolicy determines which types of key may be used with various boulder
 // operations.
 type KeyPolicy struct {
 	AllowRSA           bool // Whether RSA keys should be allowed.
 	AllowECDSANISTP256 bool // Whether ECDSA NISTP256 keys should be allowed.
 	AllowECDSANISTP384 bool // Whether ECDSA NISTP384 keys should be allowed.
 	AllowECDSANISTP521 bool // Whether ECDSA NISTP521 keys should be allowed.
+}
+
+// NewKeyPolicy creates a hard coded key policy for boulder.
+func NewKeyPolicy() KeyPolicy {
+	return KeyPolicy{
+		AllowRSA:           true,
+		AllowECDSANISTP256: true,
+		AllowECDSANISTP384: false, // TODO: change this back to true once the integration test fails
+		AllowECDSANISTP521: false,
+	}
 }
 
 // GoodKey returns true iff the key is acceptable for both TLS use and account

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -41,7 +41,6 @@ type KeyPolicy struct {
 	AllowRSA           bool // Whether RSA keys should be allowed.
 	AllowECDSANISTP256 bool // Whether ECDSA NISTP256 keys should be allowed.
 	AllowECDSANISTP384 bool // Whether ECDSA NISTP384 keys should be allowed.
-	AllowECDSANISTP521 bool // Whether ECDSA NISTP521 keys should be allowed.
 }
 
 // NewKeyPolicy returns a KeyPolicy that allows RSA, ECDSA256 and ECDSA384.

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -119,13 +119,6 @@
     }
   },
 
-  "allowedSigningAlgos": {
-    "rsa": true,
-    "ecdsanistp256": true,
-    "ecdsanistp384": true,
-    "ecdsanistp521": false
-  },
-
   "pa": {
     "challenges": {
       "http-01": true,

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -37,13 +37,6 @@
     }
   },
 
-  "allowedSigningAlgos": {
-    "rsa": true,
-    "ecdsanistp256": true,
-    "ecdsanistp384": true,
-    "ecdsanistp521": false
-  },
-
   "pa": {
     "challenges": {
       "http-01": true,

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -26,13 +26,6 @@
     }
   },
 
-  "allowedSigningAlgos": {
-    "rsa": true,
-    "ecdsanistp256": true,
-    "ecdsanistp384": true,
-    "ecdsanistp521": false
-  },
-
   "statsd": {
     "server": "localhost:8125",
     "prefix": "Boulder"


### PR DESCRIPTION
This PR, removes the `allowedSigningAlgos` configuration struct and hard codes a key policy.

Fixes #1844 