### PR TITLE
Remove period at end of sentence in expiry email.

### DIFF
--- a/data/production-email.template
+++ b/data/production-email.template
@@ -10,7 +10,7 @@ For any questions or support, please visit https://community.letsencrypt.org/.
 Unfortunately, we can't provide support by email.
 
 If you want to stop receiving all email from this address, click
-|UNSUB:https://mandrillapp.com/unsub|.
+|UNSUB:https://mandrillapp.com/unsub|
 
 Regards,
 The Let's Encrypt Team

--- a/data/staging-email.template
+++ b/data/staging-email.template
@@ -17,7 +17,7 @@ For any questions or support, please visit https://community.letsencrypt.org/.
 Unfortunately, we can't provide support by email.
 
 If you want to stop receiving all email from this address, click
-|UNSUB:https://mandrillapp.com/unsub|.
+|UNSUB:https://mandrillapp.com/unsub|
 
 Regards,
 The Let's Encrypt Team


### PR DESCRIPTION
Some email clients may make this part of the link, which breaks the link.