### PR TITLE
Disable validations to 2002::/16 (6to4 anycast)

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -133,6 +133,11 @@ var (
 		parseCidr("fc00::/7", "RFC 4193: Unique-Local"),
 		parseCidr("fe80::/10", "RFC 4291: Section 2.5.6 Link-Scoped Unicast"),
 		parseCidr("ff00::/8", "RFC 4291: Section 2.7"),
+		// We disable validations to IPs under the 6to4 anycase prefix because
+		// there's too much risk of a malicious actor advertising the prefix and
+		// answering validations for a 6to4 host they do not control.
+		// https://community.letsencrypt.org/t/problems-validating-ipv6-against-host-running-6to4/18312/9
+		parseCidr("2002::/16", "RFC 7526: 6to4 anycast prefix deprecated"),
 	}
 )
 

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -468,8 +468,8 @@ func TestIsPrivateIP(t *testing.T) {
 	test.Assert(t, isPrivateV6(net.ParseIP("ff10::1")), "should be private")
 	test.Assert(t, isPrivateV6(net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")), "should be private")
 
-	test.Assert(t, !isPrivateV6(net.ParseIP("2002::")), "should not be private")
-	test.Assert(t, !isPrivateV6(net.ParseIP("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff")), "should not be private")
+	test.Assert(t, isPrivateV6(net.ParseIP("2002::")), "should be private")
+	test.Assert(t, isPrivateV6(net.ParseIP("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff")), "should be private")
 	test.Assert(t, isPrivateV6(net.ParseIP("0100::")), "should be private")
 	test.Assert(t, isPrivateV6(net.ParseIP("0100::0000:ffff:ffff:ffff:ffff")), "should be private")
 	test.Assert(t, !isPrivateV6(net.ParseIP("0100::0001:0000:0000:0000:0000")), "should be private")


### PR DESCRIPTION
We disable validations to IPs under the 6to4 anycase prefix because
there's too much risk of a malicious actor advertising the prefix and
answering validations for a 6to4 host they do not control.

https://community.letsencrypt.org/t/problems-validating-ipv6-against-host-running-6to4/18312/9