### PR TITLE
Fix outdated Lets Encrypt client reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Run tests:
 
 Working with a client:
 
-Check out the Certbot client from https://github.com/certbot/certbot and follow the setup instructions there. Once you've got the client set up, you'll probably want to run it against your local Boulder. There are a number of command line flags that are necessary to run the client against a local Boulder, and without root access. The simplest way to run the client locally is to source a file that provides an alias for letsencrypt that has all those flags:
+Check out the Certbot client from https://github.com/certbot/certbot and follow the setup instructions there. Once you've got the client set up, you'll probably want to run it against your local Boulder. There are a number of command line flags that are necessary to run the client against a local Boulder, and without root access. The simplest way to run the client locally is to source a file that provides an alias for certbot (`certbot_test`) that has all those flags:
 
     source ~/certbot/tests/integration/_common.sh
     certbot_test certonly -a standalone -d example.com


### PR DESCRIPTION
As a follow-up to #2098 this PR changes the sentence describing "an alias for letsencrypt" to reference an "alias to certbot" instead. This fixes what was an outdated reference to the client formerly known as Let's Encrypt, now Certbot.