### PR TITLE
edit test/setup.sh so goose gets installed before create_db.sh is run

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -17,10 +17,7 @@ go get \
   github.com/mattn/goveralls \
   github.com/modocache/gover \
   github.com/tools/godep \
-  golang.org/x/tools/cover
-
-# Create the database and roles
-./test/create_db.sh &
+  golang.org/x/tools/cover &
 
 (curl -sL https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz | \
  tar -xzv &&
@@ -31,3 +28,6 @@ go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq &
 
 # Wait for all the background commands to finish.
 wait
+
+# Create the database and roles
+./test/create_db.sh

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -17,7 +17,7 @@ go get \
   github.com/mattn/goveralls \
   github.com/modocache/gover \
   github.com/tools/godep \
-  golang.org/x/tools/cover &
+  golang.org/x/tools/cover
 
 # Create the database and roles
 ./test/create_db.sh &


### PR DESCRIPTION
The create_db.sh script needs goose to create and fill the database. This is not
available yet, because it is simultaneously being installed in line 10. By
removing the ampersand from line 20, create_db always works in this situation.