### PR TITLE
Properly close test servers

### DIFF
--- a/cdr/resolver_test.go
+++ b/cdr/resolver_test.go
@@ -40,7 +40,7 @@ func TestParseAnswer(t *testing.T) {
 
 func TestQueryCAA(t *testing.T) {
 	testServ := httptest.NewServer(http.HandlerFunc(mocks.GPDNSHandler))
-	// TODO(#1989): Close testServ
+	defer testServ.Close()
 
 	req, err := http.NewRequest("GET", testServ.URL, nil)
 	test.AssertNotError(t, err, "Failed to create request")
@@ -63,7 +63,7 @@ func TestQueryCAA(t *testing.T) {
 
 func TestLookupCAA(t *testing.T) {
 	testSrv := httptest.NewServer(http.HandlerFunc(mocks.GPDNSHandler))
-	// TODO(#1989): Close testServ
+	defer testSrv.Close()
 
 	cpr := CAADistributedResolver{
 		logger: log,
@@ -119,7 +119,7 @@ func (sbh *slightlyBrokenHandler) Handler(w http.ResponseWriter, r *http.Request
 func TestHTTPQuorum(t *testing.T) {
 	sbh := &slightlyBrokenHandler{}
 	testSrv := httptest.NewServer(http.HandlerFunc(sbh.Handler))
-	// TODO(#1989): Close testServ
+	defer testSrv.Close()
 
 	cpr := CAADistributedResolver{
 		logger: log,

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1619,6 +1619,7 @@ func TestGetCertificateHEADHasCorrectBodyLength(t *testing.T) {
 
 	mux, _ := wfe.Handler()
 	s := httptest.NewServer(mux)
+	defer s.Close()
 	req, _ := http.NewRequest("HEAD", s.URL+"/acme/cert/0000000000000000000000000000000000b2", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Now that we are on Go 1.6 we can properly close `httptest.Server`
Fixes #1989