### PR TITLE
Fix nil panic with `-dryRun=true`

### DIFF
--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -122,7 +122,7 @@ func New(server, port, username, password string, from mail.Address, stats stats
 // command that would have been run, at debug level.
 func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
 	statter, _ := statsd.NewNoopClient(nil)
-	stats := metrics.NewStatsdScope(statter, "Mailer")
+	stats := metrics.NewStatsdScope(statter)
 	return &MailerImpl{
 		dialer:      dryRunClient{logger},
 		from:        from,

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -121,11 +121,14 @@ func New(server, port, username, password string, from mail.Address, stats stats
 // New constructs a Mailer suitable for doing a dry run. It simply logs each
 // command that would have been run, at debug level.
 func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
+	statter, _ := statsd.NewNoopClient(nil)
+	stats := metrics.NewStatsdScope(statter, "Mailer")
 	return &MailerImpl{
 		dialer:      dryRunClient{logger},
 		from:        from,
 		clk:         clock.Default(),
 		csprgSource: realSource{},
+		stats:       stats,
 	}
 }
 


### PR DESCRIPTION
While finalizing the testing for #2101 I noticed that the `notify-mailer` would panic when `-dryRun=true` (e.g. the default value):

```
E150646 notify-mailer [AUDIT] Panic caused by err: runtime error: invalid memory address or nil pointer dereference
E150646 notify-mailer [AUDIT] Stack Trace (Current frame) goroutine 1 [running]:
github.com/letsencrypt/boulder/log.(*impl).AuditPanic(0xc820167610)
	/home/daniel/go/src/github.com/letsencrypt/boulder/log/log.go:190 +0x190
panic(0x9804a0, 0xc82000e120)
	/usr/local/go/src/runtime/panic.go:443 +0x4e9
github.com/letsencrypt/boulder/metrics.(*StatsdScope).Inc(0x0, 0xa9ad30, 0x11, 0x1, 0x0, 0x0)
	/home/daniel/go/src/github.com/letsencrypt/boulder/metrics/scope.go:68 +0xd5
github.com/letsencrypt/boulder/mail.(*MailerImpl).SendMail(0xc8201dc360, 0xc8203d5150, 0x1, 0x1, 0x7ffeda89737c, 0x1a, 0xc8201f0000, 0x517, 0x0, 0x0)
	/home/daniel/go/src/github.com/letsencrypt/boulder/mail/mailer.go:290 +0x108
main.(*mailer).run(0xc820175ea8, 0x0, 0x0)
	/home/daniel/go/src/github.com/letsencrypt/boulder/cmd/notify-mailer/main.go:108 +0x362
main.main()
	/home/daniel/go/src/github.com/letsencrypt/boulder/cmd/notify-mailer/main.go:365 +0x142e
```

This was caused by the `NewDryRun` constructor not initializing the `stats` member of the `MailerImpl` and is fixed in this commit.