### PR TITLE
Rename invalidEmail to invalidContact -- closes #2070

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -14,8 +14,6 @@ Boulder does not provide a `Retry-After` header when a user hits a rate-limit, n
 
 Boulder doesn't return errors under the `urn:ietf:params:acme:error:` namespace but instead uses the `urn:acme:error:` namespace from [draft-ietf-acme-01 Section 5.4](https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-5.4).
 
-Boulder uses `invalidEmail` in place of the error `invalidContact` defined in [draft-ietf-acme-01 Section 5.4](https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-5.4).
-
 Boulder does not implement the `caa` and `dnssec` errors.
 
 ## [Section 6.1.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.1)

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -15,7 +15,7 @@ const (
 	UnknownHostProblem           = ProblemType("urn:acme:error:unknownHost")
 	RateLimitedProblem           = ProblemType("urn:acme:error:rateLimited")
 	BadNonceProblem              = ProblemType("urn:acme:error:badNonce")
-	InvalidEmailProblem          = ProblemType("urn:acme:error:invalidEmail")
+	InvalidContactProblem        = ProblemType("urn:acme:error:invalidContact")
 	RejectedIdentifierProblem    = ProblemType("urn:acme:error:rejectedIdentifier")
 	UnsupportedIdentifierProblem = ProblemType("urn:acme:error:unsupportedIdentifier")
 )
@@ -49,7 +49,7 @@ func ProblemDetailsToStatusCode(prob *ProblemDetails) int {
 		return prob.HTTPStatus
 	}
 	switch prob.Type {
-	case ConnectionProblem, MalformedProblem, TLSProblem, UnknownHostProblem, BadNonceProblem, InvalidEmailProblem, RejectedIdentifierProblem, UnsupportedIdentifierProblem:
+	case ConnectionProblem, MalformedProblem, TLSProblem, UnknownHostProblem, BadNonceProblem, InvalidContactProblem, RejectedIdentifierProblem, UnsupportedIdentifierProblem:
 		return http.StatusBadRequest
 	case ServerInternalProblem:
 		return http.StatusInternalServerError
@@ -165,11 +165,11 @@ func ContentLengthRequired() *ProblemDetails {
 	}
 }
 
-// InvalidEmail returns a ProblemDetails representing an invalid email address
+// InvalidContact returns a ProblemDetails representing an invalid email address
 // error
-func InvalidEmail(detail string) *ProblemDetails {
+func InvalidContact(detail string) *ProblemDetails {
 	return &ProblemDetails{
-		Type:       InvalidEmailProblem,
+		Type:       InvalidContactProblem,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
 	}

--- a/probs/probs_test.go
+++ b/probs/probs_test.go
@@ -30,7 +30,7 @@ func TestProblemDetailsToStatusCode(t *testing.T) {
 		{&ProblemDetails{Type: UnknownHostProblem}, http.StatusBadRequest},
 		{&ProblemDetails{Type: RateLimitedProblem}, statusTooManyRequests},
 		{&ProblemDetails{Type: BadNonceProblem}, http.StatusBadRequest},
-		{&ProblemDetails{Type: InvalidEmailProblem}, http.StatusBadRequest},
+		{&ProblemDetails{Type: InvalidContactProblem}, http.StatusBadRequest},
 		{&ProblemDetails{Type: "foo"}, http.StatusInternalServerError},
 		{&ProblemDetails{Type: "foo", HTTPStatus: 200}, 200},
 		{&ProblemDetails{Type: ConnectionProblem, HTTPStatus: 200}, 200},
@@ -51,7 +51,7 @@ func TestProblemDetailsConvenience(t *testing.T) {
 		statusCode   int
 		detail       string
 	}{
-		{InvalidEmail("invalid email detail"), InvalidEmailProblem, http.StatusBadRequest, "invalid email detail"},
+		{InvalidContact("invalid email detail"), InvalidContactProblem, http.StatusBadRequest, "invalid email detail"},
 		{ConnectionFailure("connection failure detail"), ConnectionProblem, http.StatusBadRequest, "connection failure detail"},
 		{Malformed("malformed detail"), MalformedProblem, http.StatusBadRequest, "malformed detail"},
 		{ServerInternal("internal error detail"), ServerInternalProblem, http.StatusInternalServerError, "internal error detail"},

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -127,10 +127,10 @@ const (
 func validateEmail(ctx context.Context, address string, resolver bdns.DNSResolver) (prob *probs.ProblemDetails) {
 	emails, err := mail.ParseAddressList(address)
 	if err != nil {
-		return probs.InvalidEmail(unparseableEmailDetail)
+		return probs.InvalidContact(unparseableEmailDetail)
 	}
 	if len(emails) > 1 {
-		return probs.InvalidEmail(multipleAddressDetail)
+		return probs.InvalidContact(multipleAddressDetail)
 	}
 	splitEmail := strings.SplitN(emails[0].Address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])
@@ -151,20 +151,20 @@ func validateEmail(ctx context.Context, address string, resolver bdns.DNSResolve
 
 	if errMX != nil {
 		prob := bdns.ProblemDetailsFromDNSError(errMX)
-		prob.Type = probs.InvalidEmailProblem
+		prob.Type = probs.InvalidContactProblem
 		return prob
 	} else if len(resultMX) > 0 {
 		return nil
 	}
 	if errA != nil {
 		prob := bdns.ProblemDetailsFromDNSError(errA)
-		prob.Type = probs.InvalidEmailProblem
+		prob.Type = probs.InvalidContactProblem
 		return prob
 	} else if len(resultA) > 0 {
 		return nil
 	}
 
-	return probs.InvalidEmail(emptyDNSResponseDetail)
+	return probs.InvalidContact(emptyDNSResponseDetail)
 }
 
 type certificateRequestEvent struct {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -329,8 +329,8 @@ func TestValidateEmail(t *testing.T) {
 
 	for _, tc := range testFailures {
 		problem := validateEmail(context.Background(), tc.input, &bdns.MockDNSResolver{})
-		if problem.Type != probs.InvalidEmailProblem {
-			t.Errorf("validateEmail(%q): got problem type %#v, expected %#v", tc.input, problem.Type, probs.InvalidEmailProblem)
+		if problem.Type != probs.InvalidContactProblem {
+			t.Errorf("validateEmail(%q): got problem type %#v, expected %#v", tc.input, problem.Type, probs.InvalidContactProblem)
 		}
 		if problem.Detail != tc.expected {
 			t.Errorf("validateEmail(%q): got %#v, expected %#v",


### PR DESCRIPTION
This closes #2070 

I ran the tests with `docker-compose run boulder ./test.sh` there was a lot of output but I think it passed because the exit code was zero.
