### PR TITLE
Add `$GOPATH` troubleshooting to docker quickstart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ reflected inside Docker images run with docker-compose.
 If docker-compose fails with an error message like "Cannot start service
 boulder: oci runtime error: no such file or directory" or "Cannot create
 container for service boulder" you should double check that your `$GOPATH`
-exists and is valid (e.g. does not contain any special characters).
+exists and doesn't contain any characters other than letters, numbers, `-`
+and `_`.
 
 By default, Boulder uses a fake DNS resolver that resolves all hostnames to
 127.0.0.1. This is suitable for running integration tests inside the Docker

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The configuration in docker-compose.yml mounts your
 `$GOPATH`. So you can edit code on your host and it will be immediately
 reflected inside Docker images run with docker-compose.
 
+If docker-compose fails with an error message like "Cannot start service
+boulder: oci runtime error: no such file or directory" or "Cannot create
+container for service boulder" you should double check that your `$GOPATH`
+exists and is valid (e.g. does not contain any special characters).
+
 By default, Boulder uses a fake DNS resolver that resolves all hostnames to
 127.0.0.1. This is suitable for running integration tests inside the Docker
 container. If you want Boulder to be able to communicate with a client running


### PR DESCRIPTION
We have seen a couple issues from folks that run into trouble using `docker-compose up` with invalid `$GOPATH`'s configured (e.g. see issues  #2150, #2141, #2112).

This PR adds a sentence to the README indicate that if you see a docker "oci runtime error" or a failure to create the container it may be caused by your `$GOPATH` and to check that first.