### PR TITLE
Remove "network" and "server" from syslog configs.

### DIFF
--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -1,7 +1,5 @@
 {
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 7
   },
 

--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -22,8 +22,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   }
 }

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -141,8 +141,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   },
 

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -18,8 +18,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   }
 }

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -28,8 +28,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   }
 }

--- a/test/config/notify-mailer.json
+++ b/test/config/notify-mailer.json
@@ -14,8 +14,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   }
 }

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -16,8 +16,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   },
 

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -39,8 +39,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   },
 

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -1,7 +1,5 @@
 {
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 7
   },
 

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -20,8 +20,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   },
 

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -48,8 +48,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   },
 

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -17,8 +17,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   }
 }

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -27,8 +27,6 @@
   },
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   },
 

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -38,8 +38,6 @@
   "subscriberAgreementURL": "http://boulder:4000/terms/v1",
 
   "syslog": {
-    "network": "",
-    "server": "",
     "stdoutlevel": 6
   },
 


### PR DESCRIPTION
We removed these from the config object because we never use anything other than
the default empty string, which means "local socket."