### PR TITLE
`notify-mailer` graceful handling of `sql.ErrNoRows`.

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -171,6 +172,9 @@ func emailsForReg(id int, dbMap dbSelector) ([]string, error) {
 		map[string]interface{}{
 			"id": id,
 		})
+	if err == sql.ErrNoRows {
+		return []string{}, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -350,10 +350,9 @@ func (bs mockEmailResolver) SelectOne(output interface{}, _ string, args ...inte
 		return fmt.Errorf("incorrect output type %T", output)
 	}
 
-	fmt.Printf("ID is %d. len(db) is %d\n", id, len(db))
-
 	// If the ID (shifted by 1 to account for zero indexing) is within the range
-	// of the DB list, return the DB entry
+	// of the DB list, return the DB entry by assigning to the `outputPtr`.
+	// Otherwise, return that no rows were found
 	if (id-1) >= 0 && int(id-1) < len(db) {
 		*outputPtr = db[id-1]
 	} else {


### PR DESCRIPTION
This PR fixes https://github.com/letsencrypt/boulder/issues/2183 by handling `sql.ErrNoRows` gracefully when encountered by the `emailsForReg` function of the notifier-mailer command.

Commit https://github.com/letsencrypt/boulder/commit/6fe16635f936ed9c6e6deb591d877f84841390e0 modifies the `TestResolveEmails` unit test so that it fails in the same way as #2183. 

Commit https://github.com/letsencrypt/boulder/commit/829dfead0e8dbf39093d869c72885ccd961701f6 fixes this failing unit test by introducing graceful handling of `sql.ErrNoRows` to `emailsForReg`.