### PR TITLE
Fix misplaced `*` in flag migration e.g.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ struct personModelv1 {
 
 // Added!
 struct personModelv2 {
-  *personModelv1
+  personModelv1
   IsWizard bool
 }
 


### PR DESCRIPTION
The embedded `personModelv1` in the `personModelv2` struct should not be a pointer. The instantiation code later on already uses `personModelv1{}` instead of `&personModelv1{}` and does not need updating, just the initial struct definition.