### PR TITLE
Allows setting `$TESTPATHS` external to `test.sh`.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,8 @@ HARDFAIL=${HARDFAIL:-fmt godep-restore}
 
 FAILURE=0
 
-TESTPATHS=$(go list -f '{{ .ImportPath }}' ./... | grep -v /vendor/)
+DEFAULT_TESTPATHS=$(go list -f '{{ .ImportPath }}' ./... | grep -v /vendor/)
+TESTPATHS=${TESTPATHS:-$DEFAULT_TESTPATHS}
 
 GITHUB_SECRET_FILE="/tmp/github-secret.json"
 


### PR DESCRIPTION
Unlike the `$GOTESTFLAGS` var there was no way to pass in a default value for `$TESTPATHS` in `test.sh` via `docker-compose -e` to indicate you only want to run specific unit tests.

This commit puts the default `$TESTPATHS` into `$DEFAULT_TESTPATHS` and assigns it to `$TESTPATHS` only if there isn't already a `$TESTPATHS` value provided.

Example usage, running just the SA unit tests, with the "next" config, using `-race -v`:

```
  docker-compose run -e BOULDER_CONFIG_DIR="test/config-next"
    -e RUN="unit" -e GOTESTFLAGS="-v -race"
    -e TESTPATHS="github.com/letsencrypt/boulder/sa" boulder ./test.sh
```