### PR TITLE
Retires `LookupIPv6` VA flag.

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -159,7 +159,6 @@ type DNSResolverImpl struct {
 	// for CAA queries that get a temporary pass during a notification period.
 	caaSERVFAILExceptions map[string]bool
 	maxTries              int
-	LookupIPv6            bool
 	clk                   clock.Clock
 	stats                 metrics.Scope
 	txtStats              metrics.Scope
@@ -360,16 +359,14 @@ func (dnsResolver *DNSResolverImpl) LookupHost(ctx context.Context, hostname str
 		defer wg.Done()
 		recordsA, errA = dnsResolver.lookupIP(ctx, hostname, dns.TypeA, dnsResolver.aStats)
 	}()
-	if dnsResolver.LookupIPv6 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			recordsAAAA, errAAAA = dnsResolver.lookupIP(ctx, hostname, dns.TypeAAAA, dnsResolver.aaaaStats)
-		}()
-	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		recordsAAAA, errAAAA = dnsResolver.lookupIP(ctx, hostname, dns.TypeAAAA, dnsResolver.aaaaStats)
+	}()
 	wg.Wait()
 
-	if errA != nil && (errAAAA != nil || !dnsResolver.LookupIPv6) {
+	if errA != nil && errAAAA != nil {
 		return nil, errA
 	}
 

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -306,8 +306,6 @@ func TestDNSLookupTXT(t *testing.T) {
 func TestDNSLookupHost(t *testing.T) {
 	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
-	obj.LookupIPv6 = true
-
 	ip, err := obj.LookupHost(context.Background(), "servfail.com")
 	t.Logf("servfail.com - IP: %s, Err: %s", ip, err)
 	test.AssertError(t, err, "Server failure")
@@ -367,33 +365,6 @@ func TestDNSLookupHost(t *testing.T) {
 	t.Logf("%s - IP: %s, Err: %s", hostname, ip, err)
 	test.AssertError(t, err, "Should be an error")
 	expectedErr := DNSError{dns.TypeA, hostname, nil, dns.RcodeRefused}
-	if err, ok := err.(*DNSError); !ok || *err != expectedErr {
-		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expectedErr)
-	}
-
-	obj.LookupIPv6 = false
-
-	// Single IPv6 address
-	ip, err = obj.LookupHost(context.Background(), "v6.letsencrypt.org")
-	t.Logf("v6.letsencrypt.org - IP: %s, Err: %s", ip, err)
-	test.AssertNotError(t, err, "Should not be error")
-	test.Assert(t, len(ip) == 0, "Should have no IPs")
-
-	// Both IPv6 and IPv4 address
-	ip, err = obj.LookupHost(context.Background(), "dualstack.letsencrypt.org")
-	t.Logf("dualstack.letsencrypt.org - IP: %s, Err: %s", ip, err)
-	test.AssertNotError(t, err, "Should not be error")
-	test.Assert(t, len(ip) == 1, "Should have 1 IP")
-	expected = net.ParseIP("127.0.0.1")
-	test.Assert(t, ip[0].To4().Equal(expected), "wrong ipv4 address")
-
-	// IPv6 success, IPv4 error
-	hostname = "v4error.letsencrypt.org"
-	ip, err = obj.LookupHost(context.Background(), hostname)
-	t.Logf("v4error.letsencrypt.org - IP: %s, Err: %s", ip, err)
-	test.AssertError(t, err, "Should be error")
-	test.Assert(t, len(ip) == 0, "Should have 0 IPs")
-	expectedErr = DNSError{dns.TypeA, hostname, nil, dns.RcodeNotImplemented}
 	if err, ok := err.(*DNSError); !ok || *err != expectedErr {
 		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expectedErr)
 	}

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -31,8 +31,6 @@ type config struct {
 
 		MaxConcurrentRPCServerRequests int64
 
-		LookupIPv6 bool
-
 		GoogleSafeBrowsing *cmd.GoogleSafeBrowsingConfig
 
 		CAAService *cmd.GRPCClientConfig
@@ -134,11 +132,9 @@ func main() {
 			scope,
 			clk,
 			dnsTries)
-		r.LookupIPv6 = c.VA.LookupIPv6
 		resolver = r
 	} else {
 		r := bdns.NewTestDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver}, scope, clk, dnsTries)
-		r.LookupIPv6 = c.VA.LookupIPv6
 		resolver = r
 	}
 

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -8,7 +8,6 @@
       "httpsPort": 5001,
       "tlsPort": 5001
     },
-    "lookupIPV6": true,
     "maxConcurrentRPCServerRequests": 16,
     "dnsTries": 3,
     "issuerDomain": "happy-hacker-ca.invalid",


### PR DESCRIPTION
The `LookupIPv6` flag has been enabled in production and isn't required anymore. This PR removes the flag entirely.

The `errA` and `errAAAA` error handling in `LookupHost` is left *as-is*,  meaning that a non-nil `errAAAA` will **not** be returned to the caller. This matches the existing behaviour, and the expectations of the `TestDNSLookupHost` unit tests.

This commit also removes the tests from `TestDNSLookupHost` that tested the `LookupIPv6 == false` behaviours since those are no longer implemented.

Resolves #2191