### PR TITLE
Local DB migration improvements (`-next` directory, auto-migrate)

### DIFF
--- a/sa/_db-next/dbconf.yml
+++ b/sa/_db-next/dbconf.yml
@@ -1,0 +1,10 @@
+test:
+  driver: mysql
+  open: root@tcp(boulder-mysql:3306)/boulder_sa_test
+integration:
+  driver: mysql
+  open: root@tcp(boulder-mysql:3306)/boulder_sa_integration
+# what goose uses by default, even during migration creation
+development:
+  driver: mysql
+  open: root@tcp(boulder-mysql:3306)/boulder_sa_integration


### PR DESCRIPTION
This PR makes two improvements to how we handle migrations locally:

1)  Prior to this PR an optimization was present in `test/create_db.sh` that would `exit 0` if the `boulder_sa_integration` database existed. This early exit meant that after the first invocation of `create_db.sh` no further `goose` migrations would be applied unless the operator dropped their databases or edited the script.

This PR reworks the existing DB optimization so that it only skips the `CREATE DATABASE` statements and allows `goose` to try and apply migrations. This doesn't result in significantly longer start up times because Goose is smart enough to know when no migrations are required and outputs something similar to:
  `goose: no migrations to run. current version: 20160602142227`

This should address #2174.

2) This PR also implements a separate `sa/_db-next/` directory for "pending" migrations. This is meant to follow the "test/config" vs "test/config-next" approach to managing changes that are developed but not yet activated in production.

Migrations that are to-be-performed by Ops should be created in the `sa/_db-next` directory first. Once they have been performed by ops in staging/prod and the config flag gate for the migration (see CONTRIBUTING.md) has been set to true, the migration can be moved from `_db-next` to `_db`.

By default all pending migrations from the `-next` directory are applied in the local dev env. If you **do not** wish these migrations to be applied then set the `APPLY_NEXT_MIGRATIONS` env var to false. E.g.:  
   `docker-compose run -eAPPLY_NEXT_MIGRATIONS=false boulder`

This should address #2195 
