### PR TITLE
Describe certificate revocation divergence.

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -59,6 +59,13 @@ Boulder does not implement applications, instead it implements the `new-cert` fl
 
 Boulder does not implement the `reason` field for the `revoke-cert` endpoint, `unspecified` (0) from [RFC3280 Section 5.3.1](https://tools.ietf.org/html/rfc3280#section-5.3.1) is used for all requests.
 
+## [Section 6.6.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.6)
+
+Boulder considers the following keys authorized to revoke a certificate:
+
+1. The account key that initially created the certificate being revoked
+2. The public key in the certificate being revoked
+
 ## [Section 7.3.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-7.3)
 
 Boulder implements `tls-sni-01` from [draft-ietf-acme-01 Section 7.3](https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.3) instead of the `tls-sni-02` validation method.

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -66,6 +66,10 @@ Boulder considers the following keys authorized to revoke a certificate:
 1. The account key that initially created the certificate being revoked
 2. The public key in the certificate being revoked
 
+Boulder does not allow for revocation of a certificate by an account key that is
+authorized for all DNS names in a certificate when that account did not create
+the certificate.
+
 ## [Section 7.3.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-7.3)
 
 Boulder implements `tls-sni-01` from [draft-ietf-acme-01 Section 7.3](https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.3) instead of the `tls-sni-02` validation method.


### PR DESCRIPTION
This PR adds a divergence to the acme-divergence doc for Section 6.6 "Certificate Revocation". Boulder does not currently support authorizing a revocation request using an arbitrary account key that is authorized for the same domains as in the certificate.