### PR TITLE
Split grpc/util.go into client and server.

### DIFF
--- a/grpc/client.go
+++ b/grpc/client.go
@@ -6,11 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 
 	"github.com/jmhodges/clock"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 
 	"github.com/letsencrypt/boulder/cmd"
 	bcreds "github.com/letsencrypt/boulder/grpc/creds"
@@ -53,38 +51,4 @@ func ClientSetup(c *cmd.GRPCClientConfig, stats metrics.Scope) (*grpc.ClientConn
 		grpc.WithBalancer(grpc.RoundRobin(newStaticResolver(c.ServerAddresses))),
 		grpc.WithUnaryInterceptor(ci.intercept),
 	)
-}
-
-// NewServer loads various TLS certificates and creates a
-// gRPC Server that verifies the client certificate was
-// issued by the provided issuer certificate and presents a
-// a server TLS certificate.
-func NewServer(c *cmd.GRPCServerConfig, stats metrics.Scope) (*grpc.Server, net.Listener, error) {
-	if stats == nil {
-		return nil, nil, errNilScope
-	}
-	cert, err := tls.LoadX509KeyPair(c.ServerCertificatePath, c.ServerKeyPath)
-	if err != nil {
-		return nil, nil, err
-	}
-	clientIssuerBytes, err := ioutil.ReadFile(c.ClientIssuerPath)
-	if err != nil {
-		return nil, nil, err
-	}
-	clientCAs := x509.NewCertPool()
-	if ok := clientCAs.AppendCertsFromPEM(clientIssuerBytes); !ok {
-		return nil, nil, errors.New("Failed to parse client issuer certificates")
-	}
-	servConf := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    clientCAs,
-	}
-	creds := credentials.NewTLS(servConf)
-	l, err := net.Listen("tcp", c.Address)
-	if err != nil {
-		return nil, nil, err
-	}
-	si := &serverInterceptor{stats.NewScope("gRPCServer"), clock.Default()}
-	return grpc.NewServer(grpc.Creds(creds), grpc.UnaryInterceptor(si.intercept)), l, nil
 }

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -14,11 +13,6 @@ import (
 	bcreds "github.com/letsencrypt/boulder/grpc/creds"
 	"github.com/letsencrypt/boulder/metrics"
 )
-
-// CodedError is a alias required to appease go vet
-var CodedError = grpc.Errorf
-
-var errNilScope = errors.New("boulder/grpc: received nil scope")
 
 // ClientSetup loads various TLS certificates and creates a
 // gRPC TransportCredentials that presents the client certificate

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -1,0 +1,55 @@
+package grpc
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	"net"
+
+	"github.com/jmhodges/clock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/metrics"
+)
+
+// CodedError is a alias required to appease go vet
+var CodedError = grpc.Errorf
+
+var errNilScope = errors.New("boulder/grpc: received nil scope")
+
+// NewServer loads various TLS certificates and creates a
+// gRPC Server that verifies the client certificate was
+// issued by the provided issuer certificate and presents a
+// a server TLS certificate.
+func NewServer(c *cmd.GRPCServerConfig, stats metrics.Scope) (*grpc.Server, net.Listener, error) {
+	if stats == nil {
+		return nil, nil, errNilScope
+	}
+	cert, err := tls.LoadX509KeyPair(c.ServerCertificatePath, c.ServerKeyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	clientIssuerBytes, err := ioutil.ReadFile(c.ClientIssuerPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	clientCAs := x509.NewCertPool()
+	if ok := clientCAs.AppendCertsFromPEM(clientIssuerBytes); !ok {
+		return nil, nil, errors.New("Failed to parse client issuer certificates")
+	}
+	servConf := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+	}
+	creds := credentials.NewTLS(servConf)
+	l, err := net.Listen("tcp", c.Address)
+	if err != nil {
+		return nil, nil, err
+	}
+	si := &serverInterceptor{stats.NewScope("gRPCServer"), clock.Default()}
+	return grpc.NewServer(grpc.Creds(creds), grpc.UnaryInterceptor(si.intercept)), l, nil
+}


### PR DESCRIPTION
Having files or packages named util is not great, because they wind up
attracting lots of small, unrelated functionality.