### PR TITLE
Reject IPAddresses and EmailAddresses earlier.

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -51,10 +51,10 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 		return errors.New("invalid signature on CSR")
 	}
 	if len(csr.EmailAddresses) > 0 {
-		return errors.New("CSR contains one or more emailAddress fields")
+		return errors.New("CSR contains one or more email address fields")
 	}
 	if len(csr.IPAddresses) > 0 {
-		return errors.New("CSR contains one or more iPAddress fields")
+		return errors.New("CSR contains one or more IP address fields")
 	}
 	if len(csr.DNSNames) == 0 && csr.Subject.CommonName == "" {
 		return errors.New("at least one DNS name is required")

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -50,6 +50,12 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 	if err := csr.CheckSignature(); err != nil {
 		return errors.New("invalid signature on CSR")
 	}
+	if len(csr.EmailAddresses) > 0 {
+		return errors.New("CSR contains one or more emailAddress fields")
+	}
+	if len(csr.IPAddresses) > 0 {
+		return errors.New("CSR contains one or more iPAddress fields")
+	}
 	if len(csr.DNSNames) == 0 && csr.Subject.CommonName == "" {
 		return errors.New("at least one DNS name is required")
 	}

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -30,6 +30,15 @@ var badSignatureAlgorithms = map[x509.SignatureAlgorithm]bool{
 	x509.ECDSAWithSHA1:             true,
 }
 
+var (
+	invalidPubKey       = errors.New("invalid public key in CSR")
+	unsupportedSigAlg   = errors.New("signature algorithm not supported")
+	invalidSig          = errors.New("invalid signature on CSR")
+	invalidEmailPresent = errors.New("CSR contains one or more email address fields")
+	invalidIPPresent    = errors.New("CSR contains one or more IP address fields")
+	invalidNoDNS        = errors.New("at least one DNS name is required")
+)
+
 // VerifyCSR checks the validity of a x509.CertificateRequest. Before doing checks it normalizes
 // the CSR which lowers the case of DNS names and subject CN, and if forceCNFromSAN is true it
 // will hoist a DNS name into the CN if it is empty.
@@ -37,7 +46,7 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 	normalizeCSR(csr, forceCNFromSAN)
 	key, ok := csr.PublicKey.(crypto.PublicKey)
 	if !ok {
-		return errors.New("invalid public key in CSR")
+		return invalidPubKey
 	}
 	if err := keyPolicy.GoodKey(key); err != nil {
 		return fmt.Errorf("invalid public key in CSR: %s", err)
@@ -45,19 +54,19 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 	if badSignatureAlgorithms[csr.SignatureAlgorithm] {
 		// go1.6 provides a stringer for x509.SignatureAlgorithm but 1.5.x
 		// does not
-		return errors.New("signature algorithm not supported")
+		return unsupportedSigAlg
 	}
 	if err := csr.CheckSignature(); err != nil {
-		return errors.New("invalid signature on CSR")
+		return invalidSig
 	}
 	if len(csr.EmailAddresses) > 0 {
-		return errors.New("CSR contains one or more email address fields")
+		return invalidEmailPresent
 	}
 	if len(csr.IPAddresses) > 0 {
-		return errors.New("CSR contains one or more IP address fields")
+		return invalidIPPresent
 	}
 	if len(csr.DNSNames) == 0 && csr.Subject.CommonName == "" {
-		return errors.New("at least one DNS name is required")
+		return invalidNoDNS
 	}
 	if len(csr.Subject.CommonName) > maxCNLength {
 		return fmt.Errorf("CN was longer than %d bytes", maxCNLength)

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -74,7 +74,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("invalid public key in CSR"),
+			invalidPubKey,
 		},
 		{
 			&x509.CertificateRequest{PublicKey: private.PublicKey},
@@ -82,7 +82,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("signature algorithm not supported"),
+			unsupportedSigAlg,
 		},
 		{
 			brokenSignedReq,
@@ -90,7 +90,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("invalid signature on CSR"),
+			invalidSig,
 		},
 		{
 			signedReq,
@@ -98,7 +98,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("at least one DNS name is required"),
+			invalidNoDNS,
 		},
 		{
 			signedReqWithLongCN,
@@ -130,7 +130,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("CSR contains one or more email address fields"),
+			invalidEmailPresent,
 		},
 		{
 			signedReqWithIPAddress,
@@ -138,7 +138,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("CSR contains one or more IP address fields"),
+			invalidIPPresent,
 		},
 	}
 

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
+	"net"
 	"strings"
 	"testing"
 
@@ -52,6 +53,12 @@ func TestVerifyCSR(t *testing.T) {
 	signedReqWithBadName := new(x509.CertificateRequest)
 	*signedReqWithBadName = *signedReq
 	signedReqWithBadName.DNSNames = []string{"bad-name.com"}
+	signedReqWithEmailAddress := new(x509.CertificateRequest)
+	*signedReqWithEmailAddress = *signedReq
+	signedReqWithEmailAddress.EmailAddresses = []string{"foo@bar.com"}
+	signedReqWithIPAddress := new(x509.CertificateRequest)
+	*signedReqWithIPAddress = *signedReq
+	signedReqWithIPAddress.IPAddresses = []net.IP{net.IPv4(1, 2, 3, 4)}
 
 	cases := []struct {
 		csr           *x509.CertificateRequest
@@ -116,6 +123,22 @@ func TestVerifyCSR(t *testing.T) {
 			&mockPA{},
 			0,
 			errors.New("policy forbids issuing for: bad-name.com"),
+		},
+		{
+			signedReqWithEmailAddress,
+			1,
+			testingPolicy,
+			&mockPA{},
+			0,
+			errors.New("CSR contains one or more emailAddress fields"),
+		},
+		{
+			signedReqWithIPAddress,
+			1,
+			testingPolicy,
+			&mockPA{},
+			0,
+			errors.New("CSR contains one or more iPAddress fields"),
 		},
 	}
 

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -130,7 +130,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("CSR contains one or more emailAddress fields"),
+			errors.New("CSR contains one or more email address fields"),
 		},
 		{
 			signedReqWithIPAddress,
@@ -138,7 +138,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("CSR contains one or more iPAddress fields"),
+			errors.New("CSR contains one or more IP address fields"),
 		},
 	}
 


### PR DESCRIPTION
Previously, if we received a CSR with IPAddress or EmailAddress SANs, we would
ignore those fields, issuing only for the DNSNames in the CSR. However, we would
later check in MatchesCSR that the CSR's IPAddresses and EmailAddresses matches
those in the issued certificate. This check would fail, serving a 500 to the end
user.

Instead, we now reject the CSR earlier in the process, and send a
meaningful error message.

Fixes https://github.com/letsencrypt/boulder/issues/2203