### PR TITLE
Fix config-next features location and registration status validity check

### DIFF
--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -8,6 +8,9 @@
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
       "serviceQueue": "SA.server"
+    },
+    "features": {
+      "AllowAccountDeactivation": true
     }
   },
 
@@ -19,9 +22,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 4
-  },
-
-  "features": {
-    "AllowAccountDeactivation": true
   }
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -10,12 +10,9 @@
       "serviceQueue": "SA.server"
     },
     "features": {
-      "AllowAccountDeactivation": true
+      "AllowAccountDeactivation": true,
+      "CertStatusOptimizationsMigrated": true
     }
-  },
-
-  "features": {
-    "CertStatusOptimizationsMigrated": true
   },
 
   "statsd": {

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -25,6 +25,9 @@
         "server": "SA.server",
         "rpcTimeout": "15s"
       }
+    },
+    "features": {
+      "AllowAccountDeactivation": true
     }
   },
 
@@ -41,9 +44,5 @@
   "common": {
     "issuerCert": "test/test-ca.pem",
     "dnsResolver": "127.0.0.1:8053"
-  },
-
-  "features": {
-    "AllowAccountDeactivation": true
   }
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1125,7 +1125,7 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 	// If a user tries to send both a deactivation request and an update to their
 	// contacts or subscriber agreement URL the deactivation will take place and
 	// return before an update would be performed.
-	if features.Enabled(features.AllowAccountDeactivation) && (update.Status != currReg.Status) {
+	if features.Enabled(features.AllowAccountDeactivation) && (update.Status != "" && update.Status != currReg.Status) {
 		if update.Status != core.StatusDeactivated {
 			wfe.sendError(response, logEvent, probs.Malformed("Invalid value provided for status field"), nil)
 			return

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -452,7 +452,8 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *requestEve
 		logEvent.Contacts = reg.Contact
 	}
 
-	if features.Enabled(features.AllowAccountDeactivation) && reg.Status != core.StatusValid {
+	// Only check for validity if we are actually checking the registration
+	if regCheck && features.Enabled(features.AllowAccountDeactivation) && reg.Status != core.StatusValid {
 		return nil, nil, reg, probs.Unauthorized(fmt.Sprintf("Registration is not valid, has status '%s'", reg.Status))
 	}
 


### PR DESCRIPTION
#2199 put the `features` JSON field in the wrong place for `sa.json` and `wfe.json`. This meant the integration tests never ran the code which in turn meant I missed a bug where we checked the validity of registrations when they were being created which didn't really make sense.

This moves the `features` fields to the right place and only tests the registration validity in `verifyPOST` when `regCheck` is true (i.e. when we actually care about checking the validity of the registration otherwise).