### PR TITLE
Factor out JSON writing in WFE

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -193,6 +193,26 @@ func marshalIndent(v interface{}) ([]byte, error) {
 	return json.MarshalIndent(v, "", "  ")
 }
 
+func (wfe *WebFrontEndImpl) writeJsonResponse(response http.ResponseWriter, logEvent *requestEvent, status int, v interface{}) error {
+	jsonReply, err := marshalIndent(v)
+	if err != nil {
+		return err
+	}
+
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(status)
+
+	_, err = response.Write(jsonReply)
+	if err != nil {
+		// Don't worry about returning this error because the caller will
+		// never handle it.
+		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
+		logEvent.AddError(err.Error())
+	}
+
+	return nil
+}
+
 func (wfe *WebFrontEndImpl) relativeEndpoint(request *http.Request, endpoint string) string {
 	var result string
 	proto := "http"

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -196,12 +196,11 @@ func marshalIndent(v interface{}) ([]byte, error) {
 func (wfe *WebFrontEndImpl) writeJsonResponse(response http.ResponseWriter, logEvent *requestEvent, status int, v interface{}) error {
 	jsonReply, err := marshalIndent(v)
 	if err != nil {
-		return err
+		return err // All callers are responsible for handling this error
 	}
 
 	response.Header().Set("Content-Type", "application/json")
 	response.WriteHeader(status)
-
 	_, err = response.Write(jsonReply)
 	if err != nil {
 		// Don't worry about returning this error because the caller will
@@ -209,7 +208,6 @@ func (wfe *WebFrontEndImpl) writeJsonResponse(response http.ResponseWriter, logE
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 		logEvent.AddError(err.Error())
 	}
-
 	return nil
 }
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -621,7 +621,14 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 	// Use an explicitly typed variable. Otherwise `go vet' incorrectly complains
 	// that reg.ID is a string being passed to %d.
 	regURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, reg.ID))
-	responseBody, err := marshalIndent(reg)
+
+	response.Header().Add("Location", regURL)
+	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newAuthzPath), "next"))
+	if len(wfe.SubscriberAgreementURL) > 0 {
+		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
+	}
+
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusCreated, reg)
 	if err != nil {
 		// ServerInternal because we just created this registration, and it
 		// should be OK.
@@ -629,16 +636,6 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshaling registration"), err)
 		return
 	}
-
-	response.Header().Add("Location", regURL)
-	response.Header().Set("Content-Type", "application/json")
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newAuthzPath), "next"))
-	if len(wfe.SubscriberAgreementURL) > 0 {
-		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
-	}
-
-	response.WriteHeader(http.StatusCreated)
-	response.Write(responseBody)
 }
 
 // NewAuthorization is used by clients to submit a new ID Authorization
@@ -678,20 +675,15 @@ func (wfe *WebFrontEndImpl) NewAuthorization(ctx context.Context, logEvent *requ
 	// Make a URL for this authz, then blow away the ID and RegID before serializing
 	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
 	wfe.prepAuthorizationForDisplay(request, &authz)
-	responseBody, err := marshalIndent(authz)
+
+	response.Header().Add("Location", authzURL)
+	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newCertPath), "next"))
+
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusCreated, authz)
 	if err != nil {
 		// ServerInternal because we generated the authz, it should be OK
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshaling authz"), err)
 		return
-	}
-
-	response.Header().Add("Location", authzURL)
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newCertPath), "next"))
-	response.Header().Set("Content-Type", "application/json")
-	response.WriteHeader(http.StatusCreated)
-	if _, err = response.Write(responseBody); err != nil {
-		logEvent.AddError(err.Error())
-		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 	}
 }
 
@@ -1005,23 +997,16 @@ func (wfe *WebFrontEndImpl) getChallenge(
 
 	wfe.prepChallengeForDisplay(request, authz, challenge)
 
-	jsonReply, err := marshalIndent(challenge)
+	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
+	response.Header().Add("Location", challenge.URI)
+	response.Header().Add("Link", link(authzURL, "up"))
+
+	err := wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, challenge)
 	if err != nil {
 		// InternalServerError because this is a failure to decode data passed in
 		// by the caller, which got it from the DB.
 		logEvent.AddError("unable to marshal challenge: %s", err)
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal challenge"), err)
-		return
-	}
-
-	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
-	response.Header().Add("Location", challenge.URI)
-	response.Header().Set("Content-Type", "application/json")
-	response.Header().Add("Link", link(authzURL, "up"))
-	response.WriteHeader(http.StatusAccepted)
-	if _, err := response.Write(jsonReply); err != nil {
-		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
-		logEvent.AddError(err.Error())
 		return
 	}
 }
@@ -1078,22 +1063,16 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	// assumption: UpdateAuthorization does not modify order of challenges
 	challenge := updatedAuthorization.Challenges[challengeIndex]
 	wfe.prepChallengeForDisplay(request, authz, &challenge)
-	jsonReply, err := marshalIndent(challenge)
+
+	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
+	response.Header().Add("Location", challenge.URI)
+	response.Header().Add("Link", link(authzURL, "up"))
+
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, challenge)
 	if err != nil {
 		// ServerInternal because we made the challenges, they should be OK
 		logEvent.AddError("failed to marshal challenge: %s", err)
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal challenge"), err)
-		return
-	}
-
-	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
-	response.Header().Add("Location", challenge.URI)
-	response.Header().Set("Content-Type", "application/json")
-	response.Header().Add("Link", link(authzURL, "up"))
-	response.WriteHeader(http.StatusAccepted)
-	if _, err = response.Write(jsonReply); err != nil {
-		logEvent.AddError(err.Error())
-		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 		return
 	}
 }
@@ -1182,20 +1161,18 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 		return
 	}
 
-	jsonReply, err := marshalIndent(updatedReg)
+	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newAuthzPath), "next"))
+	if len(wfe.SubscriberAgreementURL) > 0 {
+		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
+	}
+
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, updatedReg)
 	if err != nil {
 		// ServerInternal because we just generated the reg, it should be OK
 		logEvent.AddError("unable to marshal updated registration: %s", err)
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal registration"), err)
 		return
 	}
-	response.Header().Set("Content-Type", "application/json")
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newAuthzPath), "next"))
-	if len(wfe.SubscriberAgreementURL) > 0 {
-		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
-	}
-	response.WriteHeader(http.StatusAccepted)
-	response.Write(jsonReply)
 }
 
 func (wfe *WebFrontEndImpl) deactivateAuthorization(ctx context.Context, authz *core.Authorization, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) bool {
@@ -1273,19 +1250,14 @@ func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *request
 
 	wfe.prepAuthorizationForDisplay(request, &authz)
 
-	jsonReply, err := marshalIndent(authz)
+	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newCertPath), "next"))
+
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, authz)
 	if err != nil {
 		// InternalServerError because this is a failure to decode from our DB.
 		logEvent.AddError("Failed to JSON marshal authz: %s", err)
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to JSON marshal authz"), err)
 		return
-	}
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newCertPath), "next"))
-	response.Header().Set("Content-Type", "application/json")
-	response.WriteHeader(http.StatusOK)
-	if _, err = response.Write(jsonReply); err != nil {
-		logEvent.AddError(err.Error())
-		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
 	}
 }
 
@@ -1419,14 +1391,12 @@ func (wfe *WebFrontEndImpl) deactivateRegistration(ctx context.Context, reg core
 		return
 	}
 	reg.Status = core.StatusDeactivated
-	jsonReply, err := marshalIndent(reg)
+
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, reg)
 	if err != nil {
 		// ServerInternal because registration is from DB and should be fine
 		logEvent.AddError("unable to marshal updated registration: %s", err)
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal registration"), err)
 		return
 	}
-	response.Header().Set("Content-Type", "application/json")
-	response.WriteHeader(http.StatusOK)
-	response.Write(jsonReply)
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -206,7 +206,7 @@ func (wfe *WebFrontEndImpl) writeJsonResponse(response http.ResponseWriter, logE
 		// Don't worry about returning this error because the caller will
 		// never handle it.
 		wfe.log.Warning(fmt.Sprintf("Could not write response: %s", err))
-		logEvent.AddError(err.Error())
+		logEvent.AddError(fmt.Sprintf("failed to write response: %s", err))
 	}
 	return nil
 }


### PR DESCRIPTION
This PR, removes some duplication in the WFE in regards to writing a JSON response. 

Things to note (for reviewers):

1. All callers are now responsible for setting additional http headers. What this means is that in a few cases headers are set before `marshalIndent` is called. So, responses that err during a call to this method will have additional headers that are set. If a client is using an http header instead of a response code then it may break the client.

2. Previously, checking errors when calling `response.Write(jsonReply)` was inconsistent. Now, the check is always done.

3. In cases similar to the code block below, the return statement is no longer necessary. I left it, in case additional code was added below, and to make the diff more readable.
 ```
if err != nil {
	    logEvent.AddError("unable to marshal registration: %s", err)
	    wfe.sendError(response, logEvent, probs.ServerInternal("Error marshaling registration"), err)
	    return
}
```

Fixes #2156