### PR TITLE
Implement key rollover

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -56,6 +56,7 @@ const (
 	ResourceRegistration = AcmeResource("reg")
 	ResourceChallenge    = AcmeResource("challenge")
 	ResourceAuthz        = AcmeResource("authz")
+	ResourceKeyChange    = AcmeResource("key-change")
 )
 
 // These status are the states of OCSP

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -20,7 +20,7 @@ Boulder does not implement the `caa` and `dnssec` errors.
 
 ## [Section 6.1.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.1)
 
-Boulder does not implement the `new-application` or `key-change` resources. Instead of `new-application` Boulder implements the `new-cert` resource that is defined in [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5).
+Boulder does not implement the `new-application` resource. Instead of `new-application` Boulder implements the `new-cert` resource that is defined in [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5).
 
 ## [Section 6.1.1.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.1.1)
 
@@ -45,7 +45,7 @@ Boulder does not allow `tel` URIs in the registrations `contact` list.
 
 ## [Section 6.2.1.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.2.1)
 
-Boulder does not implement key roll-over.
+Boulder implements draft-03 style key roll-over with a few divergences. Since Boulder doesn't currently use the registration URL to identify users we do not check for that field in the JWS protected header. Boulder also requires the outer JWS payload contains the `"resource": "key-change"` field.
 
 ## [Section 6.3.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.3)
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -45,7 +45,7 @@ Boulder does not allow `tel` URIs in the registrations `contact` list.
 
 ## [Section 6.2.1.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.2.1)
 
-Boulder implements draft-03 style key roll-over with a few divergences. Since Boulder doesn't currently use the registration URL to identify users we do not check for that field in the JWS protected header. Boulder also requires the outer JWS payload contains the `"resource": "key-change"` field.
+Boulder implements draft-03 style key roll-over with a few divergences. Since Boulder doesn't currently use the registration URL to identify users we do not check for that field in the JWS protected headers but do check for it in the inner payload. Boulder also requires the outer JWS payload contains the `"resource": "key-change"` field.
 
 ## [Section 6.3.](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.3)
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedIDNASupportAllowAccountDeactivationCertStatusOptimizationsMigrated"
+const _FeatureFlag_name = "unusedIDNASupportAllowAccountDeactivationCertStatusOptimizationsMigratedAllowKeyRollover"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 72}
+var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 72, 88}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -15,6 +15,7 @@ const (
 	IDNASupport
 	AllowAccountDeactivation
 	CertStatusOptimizationsMigrated
+	AllowKeyRollover
 )
 
 // List of features and their default value, protected by fMu
@@ -23,6 +24,7 @@ var features = map[FeatureFlag]bool{
 	IDNASupport:                     false,
 	AllowAccountDeactivation:        false,
 	CertStatusOptimizationsMigrated: false,
+	AllowKeyRollover:                false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -774,7 +774,9 @@ func (ra *RegistrationAuthorityImpl) checkLimits(ctx context.Context, names []st
 	return nil
 }
 
-// UpdateRegistration updates an existing Registration with new values.
+// UpdateRegistration updates an existing Registration with new values. Caller
+// is responsible for making sure that update.Key is only different from base.Key
+// if it is being called from the WFE key change endpoint.
 func (ra *RegistrationAuthorityImpl) UpdateRegistration(ctx context.Context, base core.Registration, update core.Registration) (core.Registration, error) {
 	if changed := mergeUpdate(&base, update); !changed {
 		// If merging the update didn't actually change the base then our work is

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -43,7 +43,8 @@
       }
     },
     "features": {
-        "IDNASupport": true
+      "IDNASupport": true,
+      "AllowKeyRollover": true,
     }
   },
 

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -44,7 +44,7 @@
     },
     "features": {
       "IDNASupport": true,
-      "AllowKeyRollover": true,
+      "AllowKeyRollover": true
     }
   },
 

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -27,7 +27,8 @@
       }
     },
     "features": {
-      "AllowAccountDeactivation": true
+      "AllowAccountDeactivation": true,
+      "AllowKeyRollover": true,
     }
   },
 

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -28,7 +28,7 @@
     },
     "features": {
       "AllowAccountDeactivation": true,
-      "AllowKeyRollover": true,
+      "AllowKeyRollover": true
     }
   },
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -179,7 +179,7 @@ def run_node_test(domain, chall_type, expected_ct_submissions, run_next):
         node test.js --email %s --domains %s \
           --certKey %s --cert %s --challType %s %s && \
         openssl x509 -in %s -out %s -inform der -outform pem
-        ''' % (email_addr, domain, key_file, cert_file, chall_type, cert_file, cert_file_pem, run_next),
+        ''' % (email_addr, domain, key_file, cert_file, chall_type, run_next, cert_file, cert_file_pem),
         shell=True, cwd=JS_DIR).wait() != 0:
         print("\nIssuing failed")
         return ISSUANCE_FAILED

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -328,8 +328,6 @@ def main():
                         help="run the certbot integration tests")
     parser.add_argument('--node', dest="run_node", action="store_true",
                         help="run the node client's integration tests")
-    parser.add_argument('--next-tests', dest="run_next_tests", action="store_true",
-                        help="run the integration tests that require using the test/config-next configuration files")
     # allow any ACME client to run custom command for integration
     # testing (without having to implement its own busy-wait loop)
     parser.add_argument('--custom', metavar="CMD", help="run custom command")
@@ -359,7 +357,7 @@ def main():
         if int(submissionStr) > 0:
             expected_ct_submissions = int(submissionStr)+1
         next_tests = ""
-        if args.run_next_tests:
+        if os.environ.get("BOULDER_CONFIG_DIR", "") == "test/config-next":
             next_tests = "--next-tests"
         for chall_type in challenge_types:
             if run_node_test(domain, chall_type, expected_ct_submissions, next_tests) != 0:

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -169,7 +169,7 @@ def verify_ct_submission(expectedSubmissions, url):
         die(ExitStatus.CTFailure)
     return 0
 
-def run_node_test(domain, chall_type, expected_ct_submissions, run_next):
+def run_node_test(domain, chall_type, expected_ct_submissions):
     email_addr = "js.integration.test@letsencrypt.org"
     cert_file = os.path.join(tempdir, "cert.der")
     cert_file_pem = os.path.join(tempdir, "cert.pem")
@@ -177,9 +177,9 @@ def run_node_test(domain, chall_type, expected_ct_submissions, run_next):
     # Issue the certificate and transform it from DER-encoded to PEM-encoded.
     if subprocess.Popen('''
         node test.js --email %s --domains %s \
-          --certKey %s --cert %s --challType %s %s && \
+          --certKey %s --cert %s --challType %s && \
         openssl x509 -in %s -out %s -inform der -outform pem
-        ''' % (email_addr, domain, key_file, cert_file, chall_type, run_next, cert_file, cert_file_pem),
+        ''' % (email_addr, domain, key_file, cert_file, chall_type, cert_file, cert_file_pem),
         shell=True, cwd=JS_DIR).wait() != 0:
         print("\nIssuing failed")
         return ISSUANCE_FAILED
@@ -331,7 +331,7 @@ def main():
     # allow any ACME client to run custom command for integration
     # testing (without having to implement its own busy-wait loop)
     parser.add_argument('--custom', metavar="CMD", help="run custom command")
-    parser.set_defaults(run_all=False, run_certbot=False, run_node=False, run_next_tests=False)
+    parser.set_defaults(run_all=False, run_certbot=False, run_node=False)
     args = parser.parse_args()
 
     if not (args.run_all or args.run_certbot or args.run_node or args.custom is not None):
@@ -356,19 +356,16 @@ def main():
         submissionStr = resp.read()
         if int(submissionStr) > 0:
             expected_ct_submissions = int(submissionStr)+1
-        next_tests = ""
-        if os.environ.get("BOULDER_CONFIG_DIR", "") == "test/config-next":
-            next_tests = "--next-tests"
         for chall_type in challenge_types:
-            if run_node_test(domain, chall_type, expected_ct_submissions, next_tests) != 0:
+            if run_node_test(domain, chall_type, expected_ct_submissions) != 0:
                 die(ExitStatus.NodeFailure)
             expected_ct_submissions += 1
 
-        if run_node_test("good-caa-reserved.com", challenge_types[0], expected_ct_submissions, next_tests) != 0:
+        if run_node_test("good-caa-reserved.com", challenge_types[0], expected_ct_submissions) != 0:
             print("\nDidn't issue certificate for domain with good CAA records")
             die(ExitStatus.NodeFailure)
 
-        if run_node_test("bad-caa-reserved.com", challenge_types[0], expected_ct_submissions, next_tests) != ISSUANCE_FAILED:
+        if run_node_test("bad-caa-reserved.com", challenge_types[0], expected_ct_submissions) != ISSUANCE_FAILED:
             print("\nIssused certificate for domain with bad CAA records")
             die(ExitStatus.NodeFailure)
 

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -230,7 +230,7 @@ function rotateAccountKey() {
                 console.log(body);
                 console.log("error: " + err);
                 console.log("POST to /acme/key-change failed, aborting.");
-            process.exit(1)
+                process.exit(1)
             }
 
             getChallenges({domain: state.domains.pop()});

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -21,7 +21,7 @@ var util = require("./acme-util");
 var Acme = require("./acme");
 
 var cliOptions = cli.parse({
-  // To test against the demo instance, pass --directory "https://www.letsencrypt-demo.org/acme/directory"
+  // To test against the demo instance, pass --directory "https://acme-staging.api.letsencrypt.org/acme/directory"
   // To get a cert from the demo instance, you must be publicly reachable on
   // port 443 under the DNS name you are trying to get, and run test.js as root.
   directory:  ["directory", "Directory URL", "string", "http://localhost:4000/directory"],

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -3,9 +3,8 @@
 // npm install
 // js test.js
 //
-// To test against a live or demo Boulder, edit this file to change
-// newRegistrationURL, then run:
-// sudo js test.js.
+// To test against a live or demo Boulder, pass the argument
+// --directory with the URL of the directory endpoint.
 
 "use strict";
 
@@ -22,10 +21,10 @@ var util = require("./acme-util");
 var Acme = require("./acme");
 
 var cliOptions = cli.parse({
-  // To test against the demo instance, pass --newReg "https://www.letsencrypt-demo.org/acme/new-reg"
+  // To test against the demo instance, pass --directory "https://www.letsencrypt-demo.org/acme/directory"
   // To get a cert from the demo instance, you must be publicly reachable on
   // port 443 under the DNS name you are trying to get, and run test.js as root.
-  newReg:  ["new-reg", "New Registration URL", "string", "http://localhost:4000/acme/new-reg"],
+  directory:  ["directory", "Directory URL", "string", "http://localhost:4000/directory"],
   certKeyFile:  ["certKey", "File for cert key (created if not exists)", "path", "cert-key.pem"],
   certFile:  ["cert", "Path to output certificate (DER format)", "path", "cert.pem"],
   email:  ["email", "Email address", "string", null],
@@ -38,8 +37,10 @@ var state = {
   certPrivateKey: null,
   accountKeyPair: null,
 
-  newRegistrationURL: cliOptions.newReg,
+  directoryURL: cliOptions.directory,
+  newRegistrationURL: "",
   registrationURL: "",
+  keyChangeURL: "",
 
   domains: cliOptions.domains && cliOptions.domains.replace(/\s/g, "").split(/[^\w.-]+/),
   validatedDomains: [],
@@ -99,6 +100,10 @@ page.
 
 main
   |
+makeKeyPair
+  |
+populateURLs
+  |
 register
   |
 getTerms
@@ -140,8 +145,28 @@ function makeKeyPair() {
     state.certPrivateKey = cryptoUtil.importPemPrivateKey(fs.readFileSync(state.keyFile));
 
     console.log();
-    makeAccountKeyPair("account-key.pem", register)
+    makeAccountKeyPair("account-key.pem", populateURLs)
   });
+}
+
+function populateURLs() {
+    request(state.directoryURL, function (err, resp, body) {
+        if (err || resp.statusCode != 200) {
+            console.log(body);
+            console.log("Failed to retrieve directory, failing.");
+            process.exit(1);
+        }
+        var directory = JSON.parse(body);
+        if (directory['new-reg'] == "" || state.nextTests && directory['key-change'] == "") {
+            console.log(body);
+            console.log("Incomplete directory returned, failing.");
+            process.exit(1);
+        }
+        state.newRegistrationURL = directory['new-reg'];
+        state.keyChangeURL = directory['key-change'];
+
+        register();
+    });
 }
 
 function makeAccountKeyPair(keyName, callback) {
@@ -224,12 +249,12 @@ function rotateAccountKey() {
         }, null, 2)
         var signed = cryptoUtil.generateSignature(state.acme.privateKey, new Buffer(payload), oldAcme.nonces.shift());
         signed.resource = "key-change"
-        oldAcme.post("http://boulder:4000/acme/key-change", signed, function(err, resp, body) {
+        oldAcme.post(state.keyChangeURL, signed, function(err, resp, body) {
             if (err || Math.floor(resp.statusCode / 100) != 2) {
                 console.log(body);
                 console.log("error: " + err);
                 console.log("POST to /acme/key-change failed, aborting.");
-            process.exit(1)
+                process.exit(1)
             }
 
             getChallenges({domain: state.domains.pop()});

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -246,6 +246,7 @@ function rotateAccountKey() {
         var payload = JSON.stringify({
             oldKey: oldAcme.privateKey.publicKey,
             newKey: state.acme.privateKey.publicKey,
+            account: state.registrationURL,
         }, null, 2)
         var signed = cryptoUtil.generateSignature(state.acme.privateKey, new Buffer(payload), oldAcme.nonces.shift());
         signed.resource = "key-change"

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -244,11 +244,10 @@ function rotateAccountKey() {
     var oldAcme = state.acme;
     makeAccountKeyPair("new-account-key.pem", function() {
         var payload = JSON.stringify({
-            oldKey: oldAcme.privateKey.publicKey,
             newKey: state.acme.privateKey.publicKey,
             account: state.registrationURL,
         }, null, 2)
-        var signed = cryptoUtil.generateSignature(state.acme.privateKey, new Buffer(payload), oldAcme.nonces.shift());
+        var signed = cryptoUtil.generateSignature(state.acme.privateKey, new Buffer(payload), null);
         signed.resource = "key-change"
         oldAcme.post(state.keyChangeURL, signed, function(err, resp, body) {
             if (err || Math.floor(resp.statusCode / 100) != 2) {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1432,13 +1432,20 @@ func (wfe *WebFrontEndImpl) KeyRollover(ctx context.Context, logEvent *requestEv
 		return
 	}
 	var rolloverRequest struct {
-		OldKey jose.JsonWebKey
-		NewKey jose.JsonWebKey
+		OldKey  jose.JsonWebKey
+		NewKey  jose.JsonWebKey
+		Account string
 	}
 	err = json.Unmarshal(payload, &rolloverRequest)
 	if err != nil {
 		logEvent.AddError("unable to JSON parse resource from JWS payload: %s", err)
 		wfe.sendError(response, logEvent, probs.Malformed("Request payload did not parse as JSON"), nil)
+		return
+	}
+
+	if wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, reg.ID)) != rolloverRequest.Account {
+		logEvent.AddError("incorrect account URL provided")
+		wfe.sendError(response, logEvent, probs.Malformed("Incorrect account URL provided in payload"), nil)
 		return
 	}
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1087,8 +1087,6 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	}
 }
 
-var emptyKey jose.JsonWebKey
-
 // Registration is used by a client to submit an update to their registration.
 func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
 
@@ -1164,7 +1162,7 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 	// the key of the updated registration object is going to be the same as the
 	// key of the current one, so we set it here. This ensures we can cleanly
 	// serialize the update as JSON to send via AMQP to the RA.
-	if features.Enabled(features.AllowKeyRollover) && update.Key != emptyKey && update.Key != currReg.Key {
+	if features.Enabled(features.AllowKeyRollover) && update.Key.Key != nil && update.Key.Key != currReg.Key.Key {
 		msg := "Key can only be changed using the /acme/key-change endpoint"
 		logEvent.AddError(msg)
 		wfe.sendError(response, logEvent, probs.Malformed(msg), nil)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -355,25 +355,30 @@ const (
 	unknownKey = "No registration exists matching provided key"
 )
 
-func extractJWSKey(body string) (*jose.JsonWebKey, *jose.JsonWebSignature, error) {
+func (wfe *WebFrontEndImpl) extractJWSKey(body string) (*jose.JsonWebKey, *jose.JsonWebSignature, error) {
 	parsedJws, err := jose.ParseSigned(body)
 	if err != nil {
+		wfe.stats.Inc("Errors.UnableToParseJWS", 1)
 		return nil, nil, errors.New("Parse error reading JWS")
 	}
 
 	if len(parsedJws.Signatures) > 1 {
+		wfe.stats.Inc("Errors.TooManyJWSSignaturesInPOST", 1)
 		return nil, nil, errors.New("Too many signatures in POST body")
 	}
 	if len(parsedJws.Signatures) == 0 {
+		wfe.stats.Inc("Errors.JWSNotSignedInPOST", 1)
 		return nil, nil, errors.New("POST JWS not signed")
 	}
 
 	key := parsedJws.Signatures[0].Header.JsonWebKey
 	if key == nil {
+		wfe.stats.Inc("Errors.NoJWKInJWSSignatureHeader", 1)
 		return nil, nil, errors.New("No JWK in JWS header")
 	}
 
 	if !key.Valid() {
+		wfe.stats.Inc("Errors.InvalidJWK", 1)
 		return nil, nil, errors.New("Invalid JWK in JWS header")
 	}
 
@@ -426,7 +431,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *requestEve
 	// RA.  However the WFE is the RA's only view of the outside world
 	// *anyway*, so it could always lie about what key was used by faking
 	// the signature itself.
-	submittedKey, parsedJws, err := extractJWSKey(body)
+	submittedKey, parsedJws, err := wfe.extractJWSKey(body)
 	if err != nil {
 		logEvent.AddError(err.Error())
 		return nil, nil, reg, probs.Malformed(err.Error())
@@ -1413,7 +1418,7 @@ func (wfe *WebFrontEndImpl) KeyRollover(ctx context.Context, logEvent *requestEv
 	}
 
 	// Parse as JWS
-	newKey, parsedJWS, err := extractJWSKey(string(body))
+	newKey, parsedJWS, err := wfe.extractJWSKey(string(body))
 	if err != nil {
 		logEvent.AddError(err.Error())
 		wfe.sendError(response, logEvent, probs.Malformed(err.Error()), err)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1410,19 +1410,13 @@ func (wfe *WebFrontEndImpl) setCORSHeaders(response http.ResponseWriter, request
 }
 
 func publicKeysEqual(a, b interface{}) (bool, error) {
-	var err error
-	aBytes, bBytes := []byte{}, []byte{}
-	for _, side := range []struct {
-		key   interface{}
-		bytes *[]byte
-	}{
-		{a, &aBytes},
-		{b, &bBytes},
-	} {
-		*side.bytes, err = x509.MarshalPKIXPublicKey(side.key)
-		if err != nil {
-			return false, err
-		}
+	aBytes, err := x509.MarshalPKIXPublicKey(a)
+	if err != nil {
+		return false, err
+	}
+	bBytes, err := x509.MarshalPKIXPublicKey(b)
+	if err != nil {
+		return false, err
 	}
 	return bytes.Compare(aBytes, bBytes) == 0, nil
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1166,10 +1166,11 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 		return
 	}
 
-	// Registration objects contain a JWK object, which must be non-nil. We know
-	// the key of the updated registration object is going to be the same as the
-	// key of the current one, so we set it here. This ensures we can cleanly
-	// serialize the update as JSON to send via AMQP to the RA.
+	// Registration objects contain a JWK object which are merged in UpdateRegistration
+	// if it is different from the existing registration key. Since this isn't how you
+	// update the key we just copy the existing one into the update object here. This
+	// ensures the key isn't changed and that we can cleanly serialize the update as
+	// JSON to send via RPC to the RA.
 	update.Key = currReg.Key
 
 	updatedReg, err := wfe.RA.UpdateRegistration(ctx, currReg, update)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -332,7 +332,10 @@ func (wfe *WebFrontEndImpl) Directory(ctx context.Context, logEvent *requestEven
 		"new-cert":    newCertPath,
 		"revoke-cert": revokeCertPath,
 	}
-	if features.Enabled(features.AllowKeyRollover) {
+	if features.Enabled(features.AllowKeyRollover) && !strings.HasPrefix(request.UserAgent(), "LetsEncryptPythonClient") {
+		// Versions of Certbot pre-0.6.0 (named LetsEncryptPythonClient at the time) break when they
+		// encounter a directory containing elements they don't expect so we gate adding the key-change
+		// field on a User-Agent header that doesn't start with 'LetsEncryptPythonClient'
 		directoryEndpoints["key-change"] = rolloverPath
 	}
 

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1980,7 +1980,7 @@ func TestKeyRollover(t *testing.T) {
 		  "status": 400
 		}`)
 
-	inner, err := signer.Sign([]byte(`{"account":"http://localhost/acme/reg/1"}`))
+	inner, err := signer.Sign([]byte(`{}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr := inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
@@ -1992,43 +1992,11 @@ func TestKeyRollover(t *testing.T) {
 		responseWriter.Body.String(),
 		`{
 		  "type": "urn:acme:error:malformed",
-		  "detail": "Request payload contained malformed old JWK",
-		  "status": 400
-		}`)
-
-	inner, err = signer.Sign([]byte(`{"oldKey":{"e": "AQAB","kty": "RSA","n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_pSUHWXNmS9R4NZ3t2fQAzPeW7jOfF0LKuJRGkekx6tXP1uSnNibgpJULNc4208dgBaCHo3mvaE2HV2GmVl1yxwWX5QZZkGQGjNDZYnjFfa2DKVvFs0QbAk21ROm594kAxlRlMMrvqlf24Eq4ERO0ptzpZgm_3j_e4hGRD39gJS7kAzK-j2cacFQ5Qi2Y6wZI2p-FCq_wiYsfEAIkATPBiLKl_6d_Jfcvs_impcXQ"}}`))
-	test.AssertNotError(t, err, "Unable to sign")
-	innerStr = inner.FullSerialize()
-	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
-	outer = signRequest(t, innerStr, wfe.nonceService)
-
-	responseWriter.Body.Reset()
-	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
-	assertJSONEquals(t,
-		responseWriter.Body.String(),
-		`{
-		  "type": "urn:acme:error:malformed",
 		  "detail": "Incorrect account URL provided in payload",
 		  "status": 400
 		}`)
 
-	inner, err = signer.Sign([]byte(`{"oldKey":{"e": "AQAB","kty": "RSA","n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_pSUHWXNmS9R4NZ3t2fQAzPeW7jOfF0LKuJRGkekx6tXP1uSnNibgpJULNc4208dgBaCHo3mvaE2HV2GmVl1yxwWX5QZZkGQGjNDZYnjFfa2DKVvFs0QbAk21ROm594kAxlRlMMrvqlf24Eq4ERO0ptzpZgm_3j_e4hGRD39gJS7kAzK-j2cacFQ5Qi2Y6wZI2p-FCq_wiYsfEAIkATPBiLKl_6d_Jfcvs_impcXQ"},"account":"http://localhost/acme/reg/1"}`))
-	test.AssertNotError(t, err, "Unable to sign")
-	innerStr = inner.FullSerialize()
-	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
-	outer = signRequest(t, innerStr, wfe.nonceService)
-
-	responseWriter.Body.Reset()
-	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
-	assertJSONEquals(t,
-		responseWriter.Body.String(),
-		`{
-		  "type": "urn:acme:error:malformed",
-		  "detail": "Old JWK in inner payload doesn't match current JWK",
-		  "status": 400
-		}`)
-
-	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
+	inner, err = signer.Sign([]byte(`{"account":"http://localhost/acme/reg/1"}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr = inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
@@ -2044,7 +2012,7 @@ func TestKeyRollover(t *testing.T) {
 		  "status": 400
 		}`)
 
-	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
+	inner, err = signer.Sign([]byte(`{"newKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr = inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
@@ -2060,7 +2028,7 @@ func TestKeyRollover(t *testing.T) {
 		  "status": 400
 		}`)
 
-	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"uTQER6vUA1RDixS8xsfCRiKUNGRzzyIK0MhbS2biClShbb0hSx2mPP7gBvis2lizZ9r-y9hL57kNQoYCKndOBg0FYsHzrQ3O9AcoV1z2Mq-XhHZbFrVYaXI0M3oY9BJCWog0dyi3XC0x8AxC1npd1U61cToHx-3uSvgZOuQA5ffEn5L38Dz1Ti7OV3E4XahnRJvejadUmTkki7phLBUXm5MnnyFm0CPpf6ApV7zhLjN5W-nV0WL17o7v8aDgV_t9nIdi1Y26c3PlCEtiVHZcebDH5F1Deta3oLLg9-g6rWnTqPbY3knffhp4m0scLD6e33k8MtzxDX_D7vHsg0_X1w","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
+	inner, err = signer.Sign([]byte(`{"newKey":{"kty":"RSA","n":"uTQER6vUA1RDixS8xsfCRiKUNGRzzyIK0MhbS2biClShbb0hSx2mPP7gBvis2lizZ9r-y9hL57kNQoYCKndOBg0FYsHzrQ3O9AcoV1z2Mq-XhHZbFrVYaXI0M3oY9BJCWog0dyi3XC0x8AxC1npd1U61cToHx-3uSvgZOuQA5ffEn5L38Dz1Ti7OV3E4XahnRJvejadUmTkki7phLBUXm5MnnyFm0CPpf6ApV7zhLjN5W-nV0WL17o7v8aDgV_t9nIdi1Y26c3PlCEtiVHZcebDH5F1Deta3oLLg9-g6rWnTqPbY3knffhp4m0scLD6e33k8MtzxDX_D7vHsg0_X1w","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr = inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1557,23 +1557,6 @@ func TestRegistration(t *testing.T) {
 	test.AssertEquals(t, contains(links, "<http://localhost/acme/new-authz>;rel=\"next\""), true)
 	test.AssertEquals(t, contains(links, "<http://example.invalid/new-terms>;rel=\"terms-of-service\""), true)
 	responseWriter.Body.Reset()
-
-	// Test POST valid JSON with correct registration key
-	result, err = signer.Sign([]byte(`{"resource":"reg","agreement":"` + agreementURL + `","key":{"kty": "RSA","n": "yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e": "AQAB"}}`))
-	test.AssertNotError(t, err, "Couldn't sign")
-	wfe.Registration(ctx, newRequestEvent(), responseWriter,
-		makePostRequestWithPath("1", result.FullSerialize()))
-	test.AssertNotContains(t, responseWriter.Body.String(), "urn:acme:error")
-	responseWriter.Body.Reset()
-
-	// Test POST valid JSON with wrong registration key
-	result, err = signer.Sign([]byte(`{"resource":"reg","agreement":"` + agreementURL + `","key":{"kty": "RSA","n": "yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e": "AQAC"}}`))
-	test.AssertNotError(t, err, "Couldn't sign")
-	wfe.Registration(ctx, newRequestEvent(), responseWriter,
-		makePostRequestWithPath("1", result.FullSerialize()))
-	test.AssertContains(t, responseWriter.Body.String(), "urn:acme:error:malformed")
-	test.AssertContains(t, responseWriter.Body.String(), "Key can only be changed using the /acme/key-change endpoint")
-	responseWriter.Body.Reset()
 }
 
 func TestTermsRedirect(t *testing.T) {

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1453,6 +1453,8 @@ func contains(s []string, e string) bool {
 }
 
 func TestRegistration(t *testing.T) {
+	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
+	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	mux, err := wfe.Handler()
 	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
@@ -1554,6 +1556,23 @@ func TestRegistration(t *testing.T) {
 	links = responseWriter.Header()["Link"]
 	test.AssertEquals(t, contains(links, "<http://localhost/acme/new-authz>;rel=\"next\""), true)
 	test.AssertEquals(t, contains(links, "<http://example.invalid/new-terms>;rel=\"terms-of-service\""), true)
+	responseWriter.Body.Reset()
+
+	// Test POST valid JSON with correct registration key
+	result, err = signer.Sign([]byte(`{"resource":"reg","agreement":"` + agreementURL + `","key":{"kty": "RSA","n": "yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e": "AQAB"}}`))
+	test.AssertNotError(t, err, "Couldn't sign")
+	wfe.Registration(ctx, newRequestEvent(), responseWriter,
+		makePostRequestWithPath("1", result.FullSerialize()))
+	test.AssertNotContains(t, responseWriter.Body.String(), "urn:acme:error")
+	responseWriter.Body.Reset()
+
+	// Test POST valid JSON with wrong registration key
+	result, err = signer.Sign([]byte(`{"resource":"reg","agreement":"` + agreementURL + `","key":{"kty": "RSA","n": "yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e": "AQAC"}}`))
+	test.AssertNotError(t, err, "Couldn't sign")
+	wfe.Registration(ctx, newRequestEvent(), responseWriter,
+		makePostRequestWithPath("1", result.FullSerialize()))
+	test.AssertContains(t, responseWriter.Body.String(), "urn:acme:error:malformed")
+	test.AssertContains(t, responseWriter.Body.String(), "Key can only be changed using the /acme/key-change endpoint")
 	responseWriter.Body.Reset()
 }
 

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -594,6 +594,21 @@ func TestDirectory(t *testing.T) {
 	test.AssertEquals(t, responseWriter.Header().Get("Content-Type"), "application/json")
 	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
 	assertJSONEquals(t, responseWriter.Body.String(), `{"key-change":"http://localhost:4300/acme/key-change","new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`)
+
+	responseWriter.Body.Reset()
+	url, _ = url.Parse("/directory")
+	headers := map[string][]string{
+		"User-Agent": {"LetsEncryptPythonClient"},
+	}
+	mux.ServeHTTP(responseWriter, &http.Request{
+		Method: "GET",
+		URL:    url,
+		Host:   "127.0.0.1:4300",
+		Header: headers,
+	})
+	test.AssertEquals(t, responseWriter.Header().Get("Content-Type"), "application/json")
+	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
+	assertJSONEquals(t, responseWriter.Body.String(), `{"new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`)
 }
 
 func TestRelativeDirectory(t *testing.T) {

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -552,7 +552,7 @@ func TestDirectory(t *testing.T) {
 	})
 	test.AssertEquals(t, responseWriter.Header().Get("Content-Type"), "application/json")
 	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
-	assertJSONEquals(t, responseWriter.Body.String(), `{"new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`)
+	assertJSONEquals(t, responseWriter.Body.String(), `{"key-change":"http://localhost:4300/acme/key-change","new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`)
 }
 
 func TestRelativeDirectory(t *testing.T) {
@@ -566,15 +566,15 @@ func TestRelativeDirectory(t *testing.T) {
 		result      string
 	}{
 		// Test '' (No host header) with no proto header
-		{"", "", `{"new-authz":"http://localhost/acme/new-authz","new-cert":"http://localhost/acme/new-cert","new-reg":"http://localhost/acme/new-reg","revoke-cert":"http://localhost/acme/revoke-cert"}`},
+		{"", "", `{"key-change":"http://localhost/acme/key-change","new-authz":"http://localhost/acme/new-authz","new-cert":"http://localhost/acme/new-cert","new-reg":"http://localhost/acme/new-reg","revoke-cert":"http://localhost/acme/revoke-cert"}`},
 		// Test localhost:4300 with no proto header
-		{"localhost:4300", "", `{"new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`},
+		{"localhost:4300", "", `{"key-change":"http://localhost:4300/acme/key-change","new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`},
 		// Test 127.0.0.1:4300 with no proto header
-		{"127.0.0.1:4300", "", `{"new-authz":"http://127.0.0.1:4300/acme/new-authz","new-cert":"http://127.0.0.1:4300/acme/new-cert","new-reg":"http://127.0.0.1:4300/acme/new-reg","revoke-cert":"http://127.0.0.1:4300/acme/revoke-cert"}`},
+		{"127.0.0.1:4300", "", `{"key-change":"http://127.0.0.1:4300/acme/key-change","new-authz":"http://127.0.0.1:4300/acme/new-authz","new-cert":"http://127.0.0.1:4300/acme/new-cert","new-reg":"http://127.0.0.1:4300/acme/new-reg","revoke-cert":"http://127.0.0.1:4300/acme/revoke-cert"}`},
 		// Test localhost:4300 with HTTP proto header
-		{"localhost:4300", "http", `{"new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`},
+		{"localhost:4300", "http", `{"key-change":"http://localhost:4300/acme/key-change","new-authz":"http://localhost:4300/acme/new-authz","new-cert":"http://localhost:4300/acme/new-cert","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert"}`},
 		// Test localhost:4300 with HTTPS proto header
-		{"localhost:4300", "https", `{"new-authz":"https://localhost:4300/acme/new-authz","new-cert":"https://localhost:4300/acme/new-cert","new-reg":"https://localhost:4300/acme/new-reg","revoke-cert":"https://localhost:4300/acme/revoke-cert"}`},
+		{"localhost:4300", "https", `{"key-change":"https://localhost:4300/acme/key-change","new-authz":"https://localhost:4300/acme/new-authz","new-cert":"https://localhost:4300/acme/new-cert","new-reg":"https://localhost:4300/acme/new-reg","revoke-cert":"https://localhost:4300/acme/revoke-cert"}`},
 	}
 
 	for _, tt := range dirTests {

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -190,6 +190,9 @@ func (ra *MockRegistrationAuthority) NewCertificate(ctx context.Context, req cor
 }
 
 func (ra *MockRegistrationAuthority) UpdateRegistration(ctx context.Context, reg core.Registration, updated core.Registration) (core.Registration, error) {
+	if reg.Key != updated.Key {
+		reg.Key = updated.Key
+	}
 	return reg, nil
 }
 
@@ -573,6 +576,8 @@ func TestDirectory(t *testing.T) {
 	// This tests to ensure the `Host` in the following `http.Request` is not
 	// used.by setting `BaseURL` using `localhost`, sending `127.0.0.1` in the Host,
 	// and expecting `localhost` in the JSON result.
+	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
+	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	wfe.BaseURL = "http://localhost:4300"
 	mux, err := wfe.Handler()
@@ -592,6 +597,8 @@ func TestDirectory(t *testing.T) {
 }
 
 func TestRelativeDirectory(t *testing.T) {
+	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
+	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	mux, err := wfe.Handler()
 	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
@@ -1930,5 +1937,119 @@ func TestDeactivateRegistration(t *testing.T) {
 		  "type": "urn:acme:error:unauthorized",
 		  "detail": "Registration is not valid, has status 'deactivated'",
 		  "status": 403
+		}`)
+}
+
+func TestKeyRollover(t *testing.T) {
+	responseWriter := httptest.NewRecorder()
+	wfe, _ := setupWFE(t)
+	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
+	defer features.Reset()
+
+	key, err := jose.LoadPrivateKey([]byte(test3KeyPrivatePEM))
+	test.AssertNotError(t, err, "Failed to load key")
+	rsaKey, ok := key.(*rsa.PrivateKey)
+	test.Assert(t, ok, "Couldn't load RSA key")
+	signer, err := jose.NewSigner("RS256", rsaKey)
+	test.AssertNotError(t, err, "Failed to make signer")
+	signer.SetNonceSource(wfe.nonceService)
+
+	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", "{}"))
+	assertJSONEquals(t,
+		responseWriter.Body.String(),
+		`{
+		  "type": "urn:acme:error:malformed",
+		  "detail": "Parse error reading JWS",
+		  "status": 400
+		}`)
+
+	inner, err := signer.Sign([]byte(`{}`))
+	test.AssertNotError(t, err, "Unable to sign")
+	innerStr := inner.FullSerialize()
+	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
+	outer := signRequest(t, innerStr, wfe.nonceService)
+
+	responseWriter.Body.Reset()
+	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
+	assertJSONEquals(t,
+		responseWriter.Body.String(),
+		`{
+		  "type": "urn:acme:error:malformed",
+		  "detail": "Request payload contained malformed old JWK",
+		  "status": 400
+		}`)
+
+	inner, err = signer.Sign([]byte(`{"oldKey":{"e": "AQAB","kty": "RSA","n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_pSUHWXNmS9R4NZ3t2fQAzPeW7jOfF0LKuJRGkekx6tXP1uSnNibgpJULNc4208dgBaCHo3mvaE2HV2GmVl1yxwWX5QZZkGQGjNDZYnjFfa2DKVvFs0QbAk21ROm594kAxlRlMMrvqlf24Eq4ERO0ptzpZgm_3j_e4hGRD39gJS7kAzK-j2cacFQ5Qi2Y6wZI2p-FCq_wiYsfEAIkATPBiLKl_6d_Jfcvs_impcXQ"}}`))
+	test.AssertNotError(t, err, "Unable to sign")
+	innerStr = inner.FullSerialize()
+	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
+	outer = signRequest(t, innerStr, wfe.nonceService)
+
+	responseWriter.Body.Reset()
+	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
+	assertJSONEquals(t,
+		responseWriter.Body.String(),
+		`{
+		  "type": "urn:acme:error:malformed",
+		  "detail": "Old JWK in inner payload doesn't match current JWK",
+		  "status": 400
+		}`)
+
+	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"}}`))
+	test.AssertNotError(t, err, "Unable to sign")
+	innerStr = inner.FullSerialize()
+	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
+	outer = signRequest(t, innerStr, wfe.nonceService)
+
+	responseWriter.Body.Reset()
+	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
+	assertJSONEquals(t,
+		responseWriter.Body.String(),
+		`{
+		  "type": "urn:acme:error:malformed",
+		  "detail": "Request payload contained malformed new JWK",
+		  "status": 400
+		}`)
+
+	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"}}`))
+	test.AssertNotError(t, err, "Unable to sign")
+	innerStr = inner.FullSerialize()
+	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
+	outer = signRequest(t, innerStr, wfe.nonceService)
+
+	responseWriter.Body.Reset()
+	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
+	assertJSONEquals(t,
+		responseWriter.Body.String(),
+		`{
+		  "type": "urn:acme:error:malformed",
+		  "detail": "New JWK in inner payload doesn't match signing JWK",
+		  "status": 400
+		}`)
+
+	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"uTQER6vUA1RDixS8xsfCRiKUNGRzzyIK0MhbS2biClShbb0hSx2mPP7gBvis2lizZ9r-y9hL57kNQoYCKndOBg0FYsHzrQ3O9AcoV1z2Mq-XhHZbFrVYaXI0M3oY9BJCWog0dyi3XC0x8AxC1npd1U61cToHx-3uSvgZOuQA5ffEn5L38Dz1Ti7OV3E4XahnRJvejadUmTkki7phLBUXm5MnnyFm0CPpf6ApV7zhLjN5W-nV0WL17o7v8aDgV_t9nIdi1Y26c3PlCEtiVHZcebDH5F1Deta3oLLg9-g6rWnTqPbY3knffhp4m0scLD6e33k8MtzxDX_D7vHsg0_X1w","e":"AQAB"}}`))
+	test.AssertNotError(t, err, "Unable to sign")
+	innerStr = inner.FullSerialize()
+	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
+	outer = signRequest(t, innerStr, wfe.nonceService)
+
+	responseWriter.Body.Reset()
+	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
+	assertJSONEquals(t,
+		responseWriter.Body.String(),
+		`{
+		  "id": 1,
+		  "key": {
+		    "kty": "RSA",
+		    "n": "uTQER6vUA1RDixS8xsfCRiKUNGRzzyIK0MhbS2biClShbb0hSx2mPP7gBvis2lizZ9r-y9hL57kNQoYCKndOBg0FYsHzrQ3O9AcoV1z2Mq-XhHZbFrVYaXI0M3oY9BJCWog0dyi3XC0x8AxC1npd1U61cToHx-3uSvgZOuQA5ffEn5L38Dz1Ti7OV3E4XahnRJvejadUmTkki7phLBUXm5MnnyFm0CPpf6ApV7zhLjN5W-nV0WL17o7v8aDgV_t9nIdi1Y26c3PlCEtiVHZcebDH5F1Deta3oLLg9-g6rWnTqPbY3knffhp4m0scLD6e33k8MtzxDX_D7vHsg0_X1w",
+		    "e": "AQAB"
+		  },
+		  "contact": [
+		    "mailto:person@mail.com"
+		  ],
+		  "agreement": "http://example.invalid/terms",
+		  "initialIp": "",
+		  "createdAt": "0001-01-01T00:00:00Z",
+		  "Status": "valid"
 		}`)
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1980,7 +1980,7 @@ func TestKeyRollover(t *testing.T) {
 		  "status": 400
 		}`)
 
-	inner, err := signer.Sign([]byte(`{}`))
+	inner, err := signer.Sign([]byte(`{"account":"http://localhost/acme/reg/1"}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr := inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
@@ -2008,11 +2008,27 @@ func TestKeyRollover(t *testing.T) {
 		responseWriter.Body.String(),
 		`{
 		  "type": "urn:acme:error:malformed",
+		  "detail": "Incorrect account URL provided in payload",
+		  "status": 400
+		}`)
+
+	inner, err = signer.Sign([]byte(`{"oldKey":{"e": "AQAB","kty": "RSA","n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_pSUHWXNmS9R4NZ3t2fQAzPeW7jOfF0LKuJRGkekx6tXP1uSnNibgpJULNc4208dgBaCHo3mvaE2HV2GmVl1yxwWX5QZZkGQGjNDZYnjFfa2DKVvFs0QbAk21ROm594kAxlRlMMrvqlf24Eq4ERO0ptzpZgm_3j_e4hGRD39gJS7kAzK-j2cacFQ5Qi2Y6wZI2p-FCq_wiYsfEAIkATPBiLKl_6d_Jfcvs_impcXQ"},"account":"http://localhost/acme/reg/1"}`))
+	test.AssertNotError(t, err, "Unable to sign")
+	innerStr = inner.FullSerialize()
+	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
+	outer = signRequest(t, innerStr, wfe.nonceService)
+
+	responseWriter.Body.Reset()
+	wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
+	assertJSONEquals(t,
+		responseWriter.Body.String(),
+		`{
+		  "type": "urn:acme:error:malformed",
 		  "detail": "Old JWK in inner payload doesn't match current JWK",
 		  "status": 400
 		}`)
 
-	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"}}`))
+	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr = inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
@@ -2028,7 +2044,7 @@ func TestKeyRollover(t *testing.T) {
 		  "status": 400
 		}`)
 
-	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"}}`))
+	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr = inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful
@@ -2044,7 +2060,7 @@ func TestKeyRollover(t *testing.T) {
 		  "status": 400
 		}`)
 
-	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"uTQER6vUA1RDixS8xsfCRiKUNGRzzyIK0MhbS2biClShbb0hSx2mPP7gBvis2lizZ9r-y9hL57kNQoYCKndOBg0FYsHzrQ3O9AcoV1z2Mq-XhHZbFrVYaXI0M3oY9BJCWog0dyi3XC0x8AxC1npd1U61cToHx-3uSvgZOuQA5ffEn5L38Dz1Ti7OV3E4XahnRJvejadUmTkki7phLBUXm5MnnyFm0CPpf6ApV7zhLjN5W-nV0WL17o7v8aDgV_t9nIdi1Y26c3PlCEtiVHZcebDH5F1Deta3oLLg9-g6rWnTqPbY3knffhp4m0scLD6e33k8MtzxDX_D7vHsg0_X1w","e":"AQAB"}}`))
+	inner, err = signer.Sign([]byte(`{"oldKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"newKey":{"kty":"RSA","n":"uTQER6vUA1RDixS8xsfCRiKUNGRzzyIK0MhbS2biClShbb0hSx2mPP7gBvis2lizZ9r-y9hL57kNQoYCKndOBg0FYsHzrQ3O9AcoV1z2Mq-XhHZbFrVYaXI0M3oY9BJCWog0dyi3XC0x8AxC1npd1U61cToHx-3uSvgZOuQA5ffEn5L38Dz1Ti7OV3E4XahnRJvejadUmTkki7phLBUXm5MnnyFm0CPpf6ApV7zhLjN5W-nV0WL17o7v8aDgV_t9nIdi1Y26c3PlCEtiVHZcebDH5F1Deta3oLLg9-g6rWnTqPbY3knffhp4m0scLD6e33k8MtzxDX_D7vHsg0_X1w","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`))
 	test.AssertNotError(t, err, "Unable to sign")
 	innerStr = inner.FullSerialize()
 	innerStr = innerStr[:len(innerStr)-1] + `,"resource":"key-change"}` // awful

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2023,7 +2023,7 @@ func TestKeyRollover(t *testing.T) {
 		responseWriter.Body.String(),
 		`{
 		  "type": "urn:acme:error:malformed",
-		  "detail": "New JWK in inner payload doesn't match signing JWK",
+		  "detail": "New JWK in inner payload doesn't match key used to sign inner JWS",
 		  "status": 400
 		}`)
 


### PR DESCRIPTION
Fixes #503.

Functionality is gated by the feature flag `AllowKeyRollover`. Since this functionality is only specified in ACME draft-03 and we mostly implement the draft-02 style this takes some liberties in the implementation. The `key-change` resource is used to side-step draft-03 `url` requirement.

ACME divergence documentation still needs to be updated. 