### PR TITLE
Update total issued count asynchronously.

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -197,7 +197,8 @@ func main() {
 	rai.CA = cac
 	rai.SA = sac
 
-	go rai.UpdateIssuedCountForever()
+	err = rai.UpdateIssuedCountForever()
+	cmd.FailOnError(err, "Updating total issuance count")
 
 	ras, err := rpc.NewAmqpRPCServer(amqpConf, c.RA.MaxConcurrentRPCServerRequests, scope, logger)
 	cmd.FailOnError(err, "Unable to create RA RPC server")

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -197,6 +197,8 @@ func main() {
 	rai.CA = cac
 	rai.SA = sac
 
+	go rai.UpdateIssuedCountForever()
+
 	ras, err := rpc.NewAmqpRPCServer(amqpConf, c.RA.MaxConcurrentRPCServerRequests, scope, logger)
 	cmd.FailOnError(err, "Unable to create RA RPC server")
 	err = rpc.NewRegistrationAuthorityServer(ras, rai, logger)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -725,9 +725,9 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx contex
 
 func (ra *RegistrationAuthorityImpl) checkLimits(ctx context.Context, names []string, regID int64) error {
 	totalCertLimits := ra.rlPolicies.TotalCertificates()
+	ra.tiMu.RLock()
+	defer ra.tiMu.RUnlock()
 	if totalCertLimits.Enabled() && ra.totalIssuedCount > 0 {
-		ra.tiMu.RLock()
-		defer ra.tiMu.RUnlock()
 		if ra.totalIssuedCount >= totalCertLimits.Threshold {
 			domains := strings.Join(names, ",")
 			ra.totalCertsStats.Inc("Exceeded", 1)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -740,9 +740,9 @@ func (ra *RegistrationAuthorityImpl) checkTotalCertificatesLimit() error {
 	totalCertLimits := ra.rlPolicies.TotalCertificates()
 	ra.tiMu.RLock()
 	defer ra.tiMu.RUnlock()
-	// If last update of the total issued count was more than a minute ago,
+	// If last update of the total issued count was more than five minutes ago,
 	// or not yet updated, fail.
-	if ra.clk.Now().After(ra.totalIssuedLastUpdate.Add(1*time.Minute)) ||
+	if ra.clk.Now().After(ra.totalIssuedLastUpdate.Add(5*time.Minute)) ||
 		ra.totalIssuedLastUpdate.IsZero() {
 		return core.InternalServerError(fmt.Sprintf("Total certificate count out of date: updated %s", ra.totalIssuedLastUpdate))
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -137,6 +137,8 @@ func (ra *RegistrationAuthorityImpl) updateIssuedCount() error {
 	totalCertLimit := ra.rlPolicies.TotalCertificates()
 	if totalCertLimit.Enabled() {
 		now := ra.clk.Now()
+		// We don't have a Context here, so use the background context. Note that a
+		// timeout is still imposed by our RPC layer.
 		count, err := ra.SA.CountCertificatesRange(
 			context.Background(),
 			now.Add(-totalCertLimit.Window.Duration),

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -125,7 +125,7 @@ func (ra *RegistrationAuthorityImpl) UpdateIssuedCountForever() error {
 	}
 	go func() {
 		for {
-			ra.updateIssuedCount()
+			_ = ra.updateIssuedCount()
 			time.Sleep(1 * time.Minute)
 		}
 	}()

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -131,7 +131,7 @@ var (
 	}
 	AuthzFinal = core.Authorization{}
 
-	log = blog.UseMock()
+	log = blog.Get()
 )
 
 func makeResponse(ch core.Challenge) (out core.Challenge, err error) {
@@ -830,6 +830,10 @@ func TestNewCertificate(t *testing.T) {
 		CSR: ExampleCSR,
 	}
 
+	if err := ra.updateIssuedCount(); err != nil {
+		t.Fatal("Updating issuance count:", err)
+	}
+
 	cert, err := ra.NewCertificate(ctx, certRequest, Registration.ID)
 	test.AssertNotError(t, err, "Failed to issue certificate")
 
@@ -871,6 +875,10 @@ func TestTotalCertRateLimit(t *testing.T) {
 		CSR: ExampleCSR,
 	}
 
+	if err := ra.updateIssuedCount(); err != nil {
+		t.Fatal("Updating issuance count:", err)
+	}
+
 	// TODO(jsha): Since we're using a real SA rather than a mock, we call
 	// NewCertificate twice and insert the first result into the SA. Instead we
 	// should mock out the SA and have it return the cert count that we want.
@@ -880,7 +888,9 @@ func TestTotalCertRateLimit(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to store certificate")
 
 	fc.Add(time.Hour)
-	ra.updateIssuedCount()
+	if err := ra.updateIssuedCount(); err != nil {
+		t.Fatal("Updating issuance count:", err)
+	}
 	fmt.Println(ra.rlPolicies.TotalCertificates().Threshold)
 
 	_, err = ra.NewCertificate(ctx, certRequest, Registration.ID)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -880,6 +880,8 @@ func TestTotalCertRateLimit(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to store certificate")
 
 	fc.Add(time.Hour)
+	ra.updateIssuedCount()
+	fmt.Println(ra.rlPolicies.TotalCertificates().Threshold)
 
 	_, err = ra.NewCertificate(ctx, certRequest, Registration.ID)
 	test.AssertError(t, err, "Total certificate rate limit failed")


### PR DESCRIPTION
Previously the lock on total issued count would exacerbate problems when the
count query was slow, which it often is.

Fixes https://github.com/letsencrypt/boulder/issues/1809.