### PR TITLE
Revert "Update google/certificate-transparency dependency. (#2242)"

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -108,23 +108,23 @@
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",
-			"Rev": "10e14470ce93d5dfe6eff6b85d3e7a06ef2f4809"
+			"Rev": "0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go/asn1",
-			"Rev": "10e14470ce93d5dfe6eff6b85d3e7a06ef2f4809"
+			"Rev": "0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go/client",
-			"Rev": "10e14470ce93d5dfe6eff6b85d3e7a06ef2f4809"
+			"Rev": "0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go/x509",
-			"Rev": "10e14470ce93d5dfe6eff6b85d3e7a06ef2f4809"
+			"Rev": "0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go/x509/pkix",
-			"Rev": "10e14470ce93d5dfe6eff6b85d3e7a06ef2f4809"
+			"Rev": "0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341"
 		},
 		{
 			"ImportPath": "github.com/jmhodges/clock",

--- a/vendor/github.com/google/certificate-transparency/go/serialization.go
+++ b/vendor/github.com/google/certificate-transparency/go/serialization.go
@@ -6,11 +6,9 @@ import (
 	"crypto"
 	"encoding/asn1"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 )
 
 // Variable size structure prefix-header byte lengths
@@ -20,7 +18,6 @@ const (
 	ExtensionsLengthBytes       = 2
 	CertificateChainLengthBytes = 3
 	SignatureLengthBytes        = 2
-	JSONLengthBytes             = 3
 )
 
 // Max lengths
@@ -147,49 +144,10 @@ func ReadTimestampedEntryInto(r io.Reader, t *TimestampedEntry) error {
 		if t.PrecertEntry.TBSCertificate, err = readVarBytes(r, PreCertificateLengthBytes); err != nil {
 			return err
 		}
-	case XJSONLogEntryType:
-		if t.JSONData, err = readVarBytes(r, JSONLengthBytes); err != nil {
-			return err
-		}
 	default:
 		return fmt.Errorf("unknown EntryType: %d", t.EntryType)
 	}
 	t.Extensions, err = readVarBytes(r, ExtensionsLengthBytes)
-	return nil
-}
-
-// SerializeTimestampedEntry writes timestamped entry to Writer.
-// In case of error, w may contain garbage.
-func SerializeTimestampedEntry(w io.Writer, t *TimestampedEntry) error {
-	if err := binary.Write(w, binary.BigEndian, t.Timestamp); err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.BigEndian, t.EntryType); err != nil {
-		return err
-	}
-	switch t.EntryType {
-	case X509LogEntryType:
-		if err := writeVarBytes(w, t.X509Entry, CertificateLengthBytes); err != nil {
-			return err
-		}
-	case PrecertLogEntryType:
-		if err := binary.Write(w, binary.BigEndian, t.PrecertEntry.IssuerKeyHash); err != nil {
-			return err
-		}
-		if err := writeVarBytes(w, t.PrecertEntry.TBSCertificate, PreCertificateLengthBytes); err != nil {
-			return err
-		}
-	case XJSONLogEntryType:
-		// TODO: Pending google/certificate-transparency#1243, replace
-		// with ObjectHash once supported by CT server.
-		//jsonhash := objecthash.CommonJSONHash(string(t.JSONData))
-		if err := writeVarBytes(w, []byte(t.JSONData), JSONLengthBytes); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unknown EntryType: %d", t.EntryType)
-	}
-	writeVarBytes(w, t.Extensions, ExtensionsLengthBytes)
 	return nil
 }
 
@@ -341,29 +299,6 @@ func serializeV1CertSCTSignatureInput(timestamp uint64, cert ASN1Cert, ext CTExt
 	return buf.Bytes(), nil
 }
 
-func serializeV1JSONSCTSignatureInput(timestamp uint64, j []byte) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := binary.Write(&buf, binary.BigEndian, V1); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, CertificateTimestampSignatureType); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, timestamp); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, XJSONLogEntryType); err != nil {
-		return nil, err
-	}
-	if err := writeVarBytes(&buf, j, JSONLengthBytes); err != nil {
-		return nil, err
-	}
-	if err := writeVarBytes(&buf, nil, ExtensionsLengthBytes); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
 func serializeV1PrecertSCTSignatureInput(timestamp uint64, issuerKeyHash [issuerKeyHashLength]byte, tbs []byte, ext CTExtensions) ([]byte, error) {
 	if err := checkCertificateFormat(tbs); err != nil {
 		return nil, err
@@ -410,8 +345,6 @@ func serializeV1SCTSignatureInput(sct SignedCertificateTimestamp, entry LogEntry
 		return serializeV1PrecertSCTSignatureInput(sct.Timestamp, entry.Leaf.TimestampedEntry.PrecertEntry.IssuerKeyHash,
 			entry.Leaf.TimestampedEntry.PrecertEntry.TBSCertificate,
 			entry.Leaf.TimestampedEntry.Extensions)
-	case XJSONLogEntryType:
-		return serializeV1JSONSCTSignatureInput(sct.Timestamp, entry.Leaf.TimestampedEntry.JSONData)
 	default:
 		return nil, fmt.Errorf("unknown TimestampedEntryLeafType %s", entry.Leaf.TimestampedEntry.EntryType)
 	}
@@ -526,7 +459,6 @@ func deserializeSCTV1(r io.Reader, sct *SignedCertificateTimestamp) error {
 	return nil
 }
 
-// DeserializeSCT reads an SCT from Reader.
 func DeserializeSCT(r io.Reader) (*SignedCertificateTimestamp, error) {
 	var sct SignedCertificateTimestamp
 	if err := binary.Read(r, binary.BigEndian, &sct.SCTVersion); err != nil {
@@ -628,64 +560,4 @@ func SerializeSCTList(scts []SignedCertificateTimestamp) ([]byte, error) {
 		}
 	}
 	return asn1.Marshal(buf.Bytes()) // transform to Octet String
-}
-
-// SerializeMerkleTreeLeaf writes MerkleTreeLeaf to Writer.
-// In case of error, w may contain garbage.
-func SerializeMerkleTreeLeaf(w io.Writer, m *MerkleTreeLeaf) error {
-	if m.Version != V1 {
-		return fmt.Errorf("unknown Version %d", m.Version)
-	}
-	if err := binary.Write(w, binary.BigEndian, m.Version); err != nil {
-		return err
-	}
-	if m.LeafType != TimestampedEntryLeafType {
-		return fmt.Errorf("unknown LeafType %d", m.LeafType)
-	}
-	if err := binary.Write(w, binary.BigEndian, m.LeafType); err != nil {
-		return err
-	}
-	if err := SerializeTimestampedEntry(w, &m.TimestampedEntry); err != nil {
-		return err
-	}
-	return nil
-}
-
-// CreateX509MerkleTreeLeaf generates a MerkleTreeLeaf for an X509 cert
-func CreateX509MerkleTreeLeaf(cert ASN1Cert, timestamp uint64) *MerkleTreeLeaf {
-	return &MerkleTreeLeaf{
-		Version:  V1,
-		LeafType: TimestampedEntryLeafType,
-		TimestampedEntry: TimestampedEntry{
-			Timestamp: timestamp,
-			EntryType: X509LogEntryType,
-			X509Entry: cert,
-		},
-	}
-}
-
-// CreateJSONMerkleTreeLeaf creates the merkle tree leaf for json data.
-func CreateJSONMerkleTreeLeaf(data interface{}, timestamp uint64) *MerkleTreeLeaf {
-	jsonData, err := json.Marshal(AddJSONRequest{Data: data})
-	if err != nil {
-		return nil
-	}
-	// Match the JSON serialization implemented by json-c
-	jsonStr := strings.Replace(string(jsonData), ":", ": ", -1)
-	jsonStr = strings.Replace(jsonStr, ",", ", ", -1)
-	jsonStr = strings.Replace(jsonStr, "{", "{ ", -1)
-	jsonStr = strings.Replace(jsonStr, "}", " }", -1)
-	jsonStr = strings.Replace(jsonStr, "/", `\/`, -1)
-	// TODO: Pending google/certificate-transparency#1243, replace with
-	// ObjectHash once supported by CT server.
-
-	return &MerkleTreeLeaf{
-		Version:  V1,
-		LeafType: TimestampedEntryLeafType,
-		TimestampedEntry: TimestampedEntry{
-			Timestamp: timestamp,
-			EntryType: XJSONLogEntryType,
-			JSONData:  []byte(jsonStr),
-		},
-	}
 }

--- a/vendor/github.com/google/certificate-transparency/go/types.go
+++ b/vendor/github.com/google/certificate-transparency/go/types.go
@@ -28,8 +28,6 @@ func (e LogEntryType) String() string {
 		return "X509LogEntryType"
 	case PrecertLogEntryType:
 		return "PrecertLogEntryType"
-	case XJSONLogEntryType:
-		return "XJSONLogEntryType"
 	}
 	panic(fmt.Sprintf("No string defined for LogEntryType constant value %d", e))
 }
@@ -38,7 +36,6 @@ func (e LogEntryType) String() string {
 const (
 	X509LogEntryType    LogEntryType = 0
 	PrecertLogEntryType LogEntryType = 1
-	XJSONLogEntryType   LogEntryType = 0x8000 // Experimental.  Don't rely on this!
 )
 
 // MerkleLeafType represents the MerkleLeafType enum from section 3.4 of the
@@ -241,7 +238,6 @@ type LogEntry struct {
 	Leaf     MerkleTreeLeaf
 	X509Cert *x509.Certificate
 	Precert  *Precertificate
-	JSONData []byte
 	Chain    []ASN1Cert
 }
 
@@ -317,7 +313,6 @@ type TimestampedEntry struct {
 	Timestamp    uint64
 	EntryType    LogEntryType
 	X509Entry    ASN1Cert
-	JSONData     []byte
 	PrecertEntry PreCert
 	Extensions   CTExtensions
 }
@@ -365,10 +360,4 @@ func (e sctError) Error() string {
 	default:
 		return "unknown error"
 	}
-}
-
-// AddJSONRequest represents the JSON request body sent ot the add-json CT
-// method.
-type AddJSONRequest struct {
-	Data interface{} `json:"data"`
 }


### PR DESCRIPTION
This reverts commit 277cdf1638ebb30a812d7c0de9bcff8f8cfbfeee.

This causes breakage on Go 1.5, which we are still running in prod.