### PR TITLE
Improve error messages.

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -80,11 +80,11 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 			Type:  core.IdentifierDNS,
 			Value: name,
 		}); err != nil {
-			badNames = append(badNames, name)
+			badNames = append(badNames, fmt.Sprintf("%q", name))
 		}
 	}
 	if len(badNames) > 0 {
-		return fmt.Errorf("policy forbids issuing for: %q", strings.Join(badNames, ", "))
+		return fmt.Errorf("policy forbids issuing for: %s", strings.Join(badNames, ", "))
 	}
 	return nil
 }

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -84,7 +84,7 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 		}
 	}
 	if len(badNames) > 0 {
-		return fmt.Errorf("policy forbids issuing for: %s", strings.Join(badNames, ", "))
+		return fmt.Errorf("policy forbids issuing for: %q", strings.Join(badNames, ", "))
 	}
 	return nil
 }

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -122,7 +122,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("policy forbids issuing for: bad-name.com"),
+			errors.New("policy forbids issuing for: \"bad-name.com\""),
 		},
 		{
 			signedReqWithEmailAddress,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -749,7 +749,7 @@ func (ra *RegistrationAuthorityImpl) checkLimits(ctx context.Context, names []st
 			domains := strings.Join(names, ",")
 			ra.totalCertsStats.Inc("Exceeded", 1)
 			ra.log.Info(fmt.Sprintf("Rate limit exceeded, TotalCertificates, regID: %d, domains: %s, totalIssued: %d", regID, domains, totalIssued))
-			return core.RateLimitedError("Certificate issuance limit reached")
+			return core.RateLimitedError("Global certificate issuance limit reached. Try again in an hour.")
 		}
 		ra.totalCertsStats.Inc("Pass", 1)
 	}


### PR DESCRIPTION
Quote rejected hostnames.
Include term "global" when rejecting based on global rate limit.

Fixes #2252 