### PR TITLE
Adds "SelectFoo" functions for each DB type.

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -80,8 +80,7 @@ func revokeBySerial(ctx context.Context, serial string, reasonCode revocation.Re
 		panic(fmt.Sprintf("Invalid reason code: %d", reasonCode))
 	}
 
-	var certObj core.Certificate
-	err = tx.SelectOne(&certObj, fmt.Sprintf("SELECT %s FROM certificates WHERE serial = ?", sa.CertificateFields), serial)
+	certObj, err := sa.SelectCertificate(tx.SelectOne, "WHERE serial = ?", serial)
 	if err == sql.ErrNoRows {
 		return core.NotFoundError(fmt.Sprintf("No certificate found for %s", serial))
 	}

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -80,7 +80,7 @@ func revokeBySerial(ctx context.Context, serial string, reasonCode revocation.Re
 		panic(fmt.Sprintf("Invalid reason code: %d", reasonCode))
 	}
 
-	certObj, err := sa.SelectCertificate(tx.SelectOne, "WHERE serial = ?", serial)
+	certObj, err := sa.SelectCertificate(tx, "WHERE serial = ?", serial)
 	if err == sql.ErrNoRows {
 		return core.NotFoundError(fmt.Sprintf("No certificate found for %s", serial))
 	}

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -117,7 +117,7 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 	args["lastSerial"] = ""
 	for offset := 0; offset < count; {
 		certs, err := sa.SelectCertificates(
-			c.dbMap.Select,
+			c.dbMap,
 			"WHERE issued >= :issued AND expires >= :now AND serial > :lastSerial LIMIT :limit",
 			args,
 		)

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -116,10 +116,9 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 	args["limit"] = batchSize
 	args["lastSerial"] = ""
 	for offset := 0; offset < count; {
-		var certs []core.Certificate
-		_, err = c.dbMap.Select(
-			&certs,
-			fmt.Sprintf("SELECT %s FROM certificates WHERE issued >= :issued AND expires >= :now AND serial > :lastSerial LIMIT :limit", sa.CertificateFields),
+		certs, err := sa.SelectCertificates(
+			c.dbMap.Select,
+			"WHERE issued >= :issued AND expires >= :now AND serial > :lastSerial LIMIT :limit",
 			args,
 		)
 		if err != nil {

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -237,13 +237,13 @@ func (updater *OCSPUpdater) getCertificatesWithMissingResponses(batchSize int) (
 	var err error
 	if features.Enabled(features.CertStatusOptimizationsMigrated) {
 		statuses, err = sa.SelectCertificateStatusesv2(
-			updater.dbMap.Select,
+			updater.dbMap,
 			query,
 			batchSize,
 		)
 	} else {
 		statuses, err = sa.SelectCertificateStatuses(
-			updater.dbMap.Select,
+			updater.dbMap,
 			query,
 			batchSize,
 		)
@@ -261,7 +261,7 @@ type responseMeta struct {
 
 func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.CertificateStatus) (*core.CertificateStatus, error) {
 	cert, err := sa.SelectCertificate(
-		updater.dbMap.SelectOne,
+		updater.dbMap,
 		"WHERE serial = ?",
 		status.Serial,
 	)
@@ -366,14 +366,14 @@ func (updater *OCSPUpdater) findRevokedCertificatesToUpdate(batchSize int) ([]co
 	var err error
 	if features.Enabled(features.CertStatusOptimizationsMigrated) {
 		statuses, err = sa.SelectCertificateStatusesv2(
-			updater.dbMap.Select,
+			updater.dbMap,
 			query,
 			string(core.OCSPStatusRevoked),
 			batchSize,
 		)
 	} else {
 		statuses, err = sa.SelectCertificateStatuses(
-			updater.dbMap.Select,
+			updater.dbMap,
 			query,
 			string(core.OCSPStatusRevoked),
 			batchSize,

--- a/sa/authz.go
+++ b/sa/authz.go
@@ -70,7 +70,7 @@ func getAuthz(tx *gorp.Transaction, id string) (core.Authorization, string, erro
 	// First try to find a row from the `pendingAuthorizations` table with
 	// a `pendingauthzModel{}`.
 	pa, err := SelectPendingAuthz(
-		tx.SelectOne,
+		tx,
 		query,
 		id)
 	// If there was an error other than "no rows", abort
@@ -87,7 +87,7 @@ func getAuthz(tx *gorp.Transaction, id string) (core.Authorization, string, erro
 		// table using a `authzModel` since there wasn't a `pendingAuthorization`
 		// row
 		fa, err := SelectAuthz(
-			tx.SelectOne,
+			tx,
 			query,
 			id)
 		// If there *still* was no rows, we're out of options. Nothing found

--- a/sa/authz.go
+++ b/sa/authz.go
@@ -69,7 +69,7 @@ func getAuthz(tx *gorp.Transaction, id string) (core.Authorization, string, erro
 
 	// First try to find a row from the `pendingAuthorizations` table with
 	// a `pendingauthzModel{}`.
-	pa, err := SelectPendingAuthz(
+	pa, err := selectPendingAuthz(
 		tx,
 		query,
 		id)
@@ -86,7 +86,7 @@ func getAuthz(tx *gorp.Transaction, id string) (core.Authorization, string, erro
 		// But if the err was ErrNoRows, then we need to try looking in the `authz`
 		// table using a `authzModel` since there wasn't a `pendingAuthorization`
 		// row
-		fa, err := SelectAuthz(
+		fa, err := selectAuthz(
 			tx,
 			query,
 			id)

--- a/sa/model.go
+++ b/sa/model.go
@@ -28,8 +28,8 @@ type dbSelector interface {
 const regFields = "id, jwk, jwk_sha256, contact, agreement, initialIP, createdAt, LockCol"
 const regFieldsv2 = regFields + ", status"
 
-// Select all fields of one registration model
-func SelectRegistration(s dbOneSelector, q string, args ...interface{}) (*regModelv1, error) {
+// selectRegistration selects all fields of one registration model
+func selectRegistration(s dbOneSelector, q string, args ...interface{}) (*regModelv1, error) {
 	var model regModelv1
 	err := s.SelectOne(
 		&model,
@@ -39,8 +39,8 @@ func SelectRegistration(s dbOneSelector, q string, args ...interface{}) (*regMod
 	return &model, err
 }
 
-// Select all fields (including v2 migrated fields) of one registration model
-func SelectRegistrationv2(s dbOneSelector, q string, args ...interface{}) (*regModelv2, error) {
+// selectRegistrationv2 selects all fields (including v2 migrated fields) of one registration model
+func selectRegistrationv2(s dbOneSelector, q string, args ...interface{}) (*regModelv2, error) {
 	var model regModelv2
 	err := s.SelectOne(
 		&model,
@@ -48,8 +48,8 @@ func SelectRegistrationv2(s dbOneSelector, q string, args ...interface{}) (*regM
 	return &model, err
 }
 
-// Select all fields of one pending authorization model
-func SelectPendingAuthz(s dbOneSelector, q string, args ...interface{}) (*pendingauthzModel, error) {
+// selectPendingAuthz selects all fields of one pending authorization model
+func selectPendingAuthz(s dbOneSelector, q string, args ...interface{}) (*pendingauthzModel, error) {
 	var model pendingauthzModel
 	err := s.SelectOne(
 		&model,
@@ -61,8 +61,8 @@ func SelectPendingAuthz(s dbOneSelector, q string, args ...interface{}) (*pendin
 
 const authzFields = "id, identifier, registrationID, status, expires, combinations"
 
-// Select all fields of one authorization model
-func SelectAuthz(s dbOneSelector, q string, args ...interface{}) (*authzModel, error) {
+// selectAuthz selects all fields of one authorization model
+func selectAuthz(s dbOneSelector, q string, args ...interface{}) (*authzModel, error) {
 	var model authzModel
 	err := s.SelectOne(
 		&model,
@@ -72,8 +72,8 @@ func SelectAuthz(s dbOneSelector, q string, args ...interface{}) (*authzModel, e
 	return &model, err
 }
 
-// Select all fields of multiple authorization objects
-func SelectAuthzs(s dbSelector, q string, args ...interface{}) ([]*core.Authorization, error) {
+// selectAuthzs selects all fields of multiple authorization objects
+func selectAuthzs(s dbSelector, q string, args ...interface{}) ([]*core.Authorization, error) {
 	var models []*core.Authorization
 	_, err := s.Select(
 		&models,
@@ -83,8 +83,8 @@ func SelectAuthzs(s dbSelector, q string, args ...interface{}) ([]*core.Authoriz
 	return models, err
 }
 
-// Select all fields of one SignedCertificateTimestamp object
-func SelectSctReceipt(s dbOneSelector, q string, args ...interface{}) (core.SignedCertificateTimestamp, error) {
+// selectSctReceipt selects all fields of one SignedCertificateTimestamp object
+func selectSctReceipt(s dbOneSelector, q string, args ...interface{}) (core.SignedCertificateTimestamp, error) {
 	var model core.SignedCertificateTimestamp
 	err := s.SelectOne(
 		&model,
@@ -96,7 +96,7 @@ func SelectSctReceipt(s dbOneSelector, q string, args ...interface{}) (core.Sign
 
 const certFields = "registrationID, serial, digest, der, issued, expires"
 
-// Select all fields of one certificate object
+// SelectCertificate selects all fields of one certificate object
 func SelectCertificate(s dbOneSelector, q string, args ...interface{}) (core.Certificate, error) {
 	var model core.Certificate
 	err := s.SelectOne(
@@ -107,7 +107,7 @@ func SelectCertificate(s dbOneSelector, q string, args ...interface{}) (core.Cer
 	return model, err
 }
 
-// Select all fields of multiple certificate objects
+// SelectCertificates selects all fields of multiple certificate objects
 func SelectCertificates(s dbSelector, q string, args map[string]interface{}) ([]core.Certificate, error) {
 	var models []core.Certificate
 	_, err := s.Select(
@@ -119,7 +119,7 @@ func SelectCertificates(s dbSelector, q string, args map[string]interface{}) ([]
 const certStatusFields = "serial, subscriberApproved, status, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, ocspResponse, LockCol"
 const certStatusFieldsv2 = certStatusFields + ", notAfter, isExpired"
 
-// Select all fields of one certificate status model
+// SelectCertificateStatus selects all fields of one certificate status model
 func SelectCertificateStatus(s dbOneSelector, q string, args ...interface{}) (certStatusModelv1, error) {
 	var model certStatusModelv1
 	err := s.SelectOne(
@@ -130,7 +130,7 @@ func SelectCertificateStatus(s dbOneSelector, q string, args ...interface{}) (ce
 	return model, err
 }
 
-// Select all fields (including the v2 migrated fields) of one certificate status model
+// SelectCertificateStatusv2 selects all fields (including the v2 migrated fields) of one certificate status model
 func SelectCertificateStatusv2(s dbOneSelector, q string, args ...interface{}) (certStatusModelv2, error) {
 	var model certStatusModelv2
 	err := s.SelectOne(
@@ -141,7 +141,7 @@ func SelectCertificateStatusv2(s dbOneSelector, q string, args ...interface{}) (
 	return model, err
 }
 
-// Select all fields of multiple certificate status objects
+// SelectCertificateStatuses selects all fields of multiple certificate status objects
 func SelectCertificateStatuses(s dbSelector, q string, args ...interface{}) ([]core.CertificateStatus, error) {
 	var models []core.CertificateStatus
 	_, err := s.Select(
@@ -152,7 +152,7 @@ func SelectCertificateStatuses(s dbSelector, q string, args ...interface{}) ([]c
 	return models, err
 }
 
-// Select all fields (including the v2 migrated fields) of multiple certificate status objects
+// SelectCertificateStatusesv2 selects all fields (including the v2 migrated fields) of multiple certificate status objects
 func SelectCertificateStatusesv2(s dbSelector, q string, args ...interface{}) ([]core.CertificateStatus, error) {
 	var models []core.CertificateStatus
 	_, err := s.Select(

--- a/sa/model.go
+++ b/sa/model.go
@@ -28,6 +28,7 @@ type dbSelector interface {
 const regFields = "id, jwk, jwk_sha256, contact, agreement, initialIP, createdAt, LockCol"
 const regFieldsv2 = regFields + ", status"
 
+// Select all fields of one registration model
 func SelectRegistration(s dbOneSelector, q string, args ...interface{}) (*regModelv1, error) {
 	var model regModelv1
 	err := s.SelectOne(
@@ -38,6 +39,7 @@ func SelectRegistration(s dbOneSelector, q string, args ...interface{}) (*regMod
 	return &model, err
 }
 
+// Select all fields (including v2 migrated fields) of one registration model
 func SelectRegistrationv2(s dbOneSelector, q string, args ...interface{}) (*regModelv2, error) {
 	var model regModelv2
 	err := s.SelectOne(
@@ -46,6 +48,7 @@ func SelectRegistrationv2(s dbOneSelector, q string, args ...interface{}) (*regM
 	return &model, err
 }
 
+// Select all fields of one pending authorization model
 func SelectPendingAuthz(s dbOneSelector, q string, args ...interface{}) (*pendingauthzModel, error) {
 	var model pendingauthzModel
 	err := s.SelectOne(
@@ -58,6 +61,7 @@ func SelectPendingAuthz(s dbOneSelector, q string, args ...interface{}) (*pendin
 
 const authzFields = "id, identifier, registrationID, status, expires, combinations"
 
+// Select all fields of one authorization model
 func SelectAuthz(s dbOneSelector, q string, args ...interface{}) (*authzModel, error) {
 	var model authzModel
 	err := s.SelectOne(
@@ -68,6 +72,7 @@ func SelectAuthz(s dbOneSelector, q string, args ...interface{}) (*authzModel, e
 	return &model, err
 }
 
+// Select all fields of multiple authorization objects
 func SelectAuthzs(s dbSelector, q string, args ...interface{}) ([]*core.Authorization, error) {
 	var models []*core.Authorization
 	_, err := s.Select(
@@ -78,6 +83,7 @@ func SelectAuthzs(s dbSelector, q string, args ...interface{}) ([]*core.Authoriz
 	return models, err
 }
 
+// Select all fields of one SignedCertificateTimestamp object
 func SelectSctReceipt(s dbOneSelector, q string, args ...interface{}) (core.SignedCertificateTimestamp, error) {
 	var model core.SignedCertificateTimestamp
 	err := s.SelectOne(
@@ -90,6 +96,7 @@ func SelectSctReceipt(s dbOneSelector, q string, args ...interface{}) (core.Sign
 
 const certFields = "registrationID, serial, digest, der, issued, expires"
 
+// Select all fields of one certificate object
 func SelectCertificate(s dbOneSelector, q string, args ...interface{}) (core.Certificate, error) {
 	var model core.Certificate
 	err := s.SelectOne(
@@ -100,6 +107,7 @@ func SelectCertificate(s dbOneSelector, q string, args ...interface{}) (core.Cer
 	return model, err
 }
 
+// Select all fields of multiple certificate objects
 func SelectCertificates(s dbSelector, q string, args map[string]interface{}) ([]core.Certificate, error) {
 	var models []core.Certificate
 	_, err := s.Select(
@@ -111,6 +119,7 @@ func SelectCertificates(s dbSelector, q string, args map[string]interface{}) ([]
 const certStatusFields = "serial, subscriberApproved, status, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, ocspResponse, LockCol"
 const certStatusFieldsv2 = certStatusFields + ", notAfter, isExpired"
 
+// Select all fields of one certificate status model
 func SelectCertificateStatus(s dbOneSelector, q string, args ...interface{}) (certStatusModelv1, error) {
 	var model certStatusModelv1
 	err := s.SelectOne(
@@ -121,6 +130,7 @@ func SelectCertificateStatus(s dbOneSelector, q string, args ...interface{}) (ce
 	return model, err
 }
 
+// Select all fields (including the v2 migrated fields) of one certificate status model
 func SelectCertificateStatusv2(s dbOneSelector, q string, args ...interface{}) (certStatusModelv2, error) {
 	var model certStatusModelv2
 	err := s.SelectOne(
@@ -131,6 +141,7 @@ func SelectCertificateStatusv2(s dbOneSelector, q string, args ...interface{}) (
 	return model, err
 }
 
+// Select all fields of multiple certificate status objects
 func SelectCertificateStatuses(s dbSelector, q string, args ...interface{}) ([]core.CertificateStatus, error) {
 	var models []core.CertificateStatus
 	_, err := s.Select(
@@ -141,6 +152,7 @@ func SelectCertificateStatuses(s dbSelector, q string, args ...interface{}) ([]c
 	return models, err
 }
 
+// Select all fields (including the v2 migrated fields) of multiple certificate status objects
 func SelectCertificateStatusesv2(s dbSelector, q string, args ...interface{}) ([]core.CertificateStatus, error) {
 	var models []core.CertificateStatus
 	_, err := s.Select(

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -100,9 +100,9 @@ func (ssa *SQLStorageAuthority) GetRegistration(ctx context.Context, id int64) (
 	var model interface{}
 	var err error
 	if features.Enabled(features.AllowAccountDeactivation) {
-		model, err = SelectRegistrationv2(ssa.dbMap, query, id)
+		model, err = selectRegistrationv2(ssa.dbMap, query, id)
 	} else {
-		model, err = SelectRegistration(ssa.dbMap, query, id)
+		model, err = selectRegistration(ssa.dbMap, query, id)
 	}
 	if err == sql.ErrNoRows {
 		return core.Registration{}, core.NoSuchRegistrationError(
@@ -125,9 +125,9 @@ func (ssa *SQLStorageAuthority) GetRegistrationByKey(ctx context.Context, key jo
 		return core.Registration{}, err
 	}
 	if features.Enabled(features.AllowAccountDeactivation) {
-		model, err = SelectRegistrationv2(ssa.dbMap, query, sha)
+		model, err = selectRegistrationv2(ssa.dbMap, query, sha)
 	} else {
-		model, err = SelectRegistration(ssa.dbMap, query, sha)
+		model, err = selectRegistration(ssa.dbMap, query, sha)
 	}
 	if err == sql.ErrNoRows {
 		msg := fmt.Sprintf("No registrations with public key sha256 %s", sha)
@@ -176,7 +176,7 @@ func (ssa *SQLStorageAuthority) GetValidAuthorizations(ctx context.Context, regi
 		qmarks[i] = "?"
 	}
 
-	auths, err := SelectAuthzs(ssa.dbMap,
+	auths, err := selectAuthzs(ssa.dbMap,
 		"WHERE registrationID = ? "+
 			"AND expires > ? "+
 			"AND identifier IN ("+strings.Join(qmarks, ",")+") "+
@@ -506,9 +506,9 @@ func (ssa *SQLStorageAuthority) UpdateRegistration(ctx context.Context, reg core
 	var model interface{}
 	var err error
 	if features.Enabled(features.AllowAccountDeactivation) {
-		model, err = SelectRegistrationv2(ssa.dbMap, query, reg.ID)
+		model, err = selectRegistrationv2(ssa.dbMap, query, reg.ID)
 	} else {
-		model, err = SelectRegistration(ssa.dbMap, query, reg.ID)
+		model, err = selectRegistration(ssa.dbMap, query, reg.ID)
 	}
 	if err == sql.ErrNoRows {
 		msg := fmt.Sprintf("No registrations with ID %d", reg.ID)
@@ -932,7 +932,7 @@ func (e ErrNoReceipt) Error() string {
 // GetSCTReceipt gets a specific SCT receipt for a given certificate serial and
 // CT log ID
 func (ssa *SQLStorageAuthority) GetSCTReceipt(ctx context.Context, serial string, logID string) (receipt core.SignedCertificateTimestamp, err error) {
-	receipt, err = SelectSctReceipt(ssa.dbMap, "WHERE certificateSerial = ? AND logID = ?", serial, logID)
+	receipt, err = selectSctReceipt(ssa.dbMap, "WHERE certificateSerial = ? AND logID = ?", serial, logID)
 	if err == sql.ErrNoRows {
 		err = ErrNoReceipt(err.Error())
 		return

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -47,30 +47,6 @@ type authzModel struct {
 	core.Authorization
 }
 
-// We need two certStatus model structs, one for when boulder does *not* have
-// the 20160817143417_CertStatusOptimizations.sql migration applied
-// (certStatusModelv1) and one for when it does (certStatusModelv2)
-//
-// TODO(@cpu): Collapse into one struct once the migration has been applied
-//             & feature flag set.
-type certStatusModelv1 struct {
-	Serial                string            `db:"serial"`
-	SubscriberApproved    bool              `db:"subscriberApproved"`
-	Status                core.OCSPStatus   `db:"status"`
-	OCSPLastUpdated       time.Time         `db:"ocspLastUpdated"`
-	RevokedDate           time.Time         `db:"revokedDate"`
-	RevokedReason         revocation.Reason `db:"revokedReason"`
-	LastExpirationNagSent time.Time         `db:"lastExpirationNagSent"`
-	OCSPResponse          []byte            `db:"ocspResponse"`
-	LockCol               int64             `json:"-"`
-}
-
-type certStatusModelv2 struct {
-	certStatusModelv1
-	NotAfter  time.Time `db:"notAfter"`
-	IsExpired bool      `db:"isExpired"`
-}
-
 // NewSQLStorageAuthority provides persistence using a SQL backend for
 // Boulder. It will modify the given gorp.DbMap by adding relevant tables.
 func NewSQLStorageAuthority(dbMap *gorp.DbMap, clk clock.Clock, logger blog.Logger) (*SQLStorageAuthority, error) {
@@ -136,20 +112,14 @@ func updateChallenges(authID string, challenges []core.Challenge, tx *gorp.Trans
 
 // GetRegistration obtains a Registration by ID
 func (ssa *SQLStorageAuthority) GetRegistration(ctx context.Context, id int64) (core.Registration, error) {
-	var reg interface{}
-	var fields string
+	const query = "WHERE id = ?"
+	var model interface{}
+	var err error
 	if features.Enabled(features.AllowAccountDeactivation) {
-		reg = &regModelv2{}
-		fields = regV2Fields
+		model, err = SelectRegistrationv2(ssa.dbMap.SelectOne, query, id)
 	} else {
-		reg = &regModelv1{}
-		fields = regV1Fields
+		model, err = SelectRegistration(ssa.dbMap.SelectOne, query, id)
 	}
-	err := ssa.dbMap.SelectOne(
-		reg,
-		fmt.Sprintf("SELECT %s FROM registrations WHERE id = ?", fields),
-		id,
-	)
 	if err == sql.ErrNoRows {
 		return core.Registration{}, core.NoSuchRegistrationError(
 			fmt.Sprintf("No registrations with ID %d", id),
@@ -158,30 +128,23 @@ func (ssa *SQLStorageAuthority) GetRegistration(ctx context.Context, id int64) (
 	if err != nil {
 		return core.Registration{}, err
 	}
-	return modelToRegistration(reg)
+	return modelToRegistration(model)
 }
 
 // GetRegistrationByKey obtains a Registration by JWK
 func (ssa *SQLStorageAuthority) GetRegistrationByKey(ctx context.Context, key jose.JsonWebKey) (core.Registration, error) {
-	var reg interface{}
-	var fields string
-	if features.Enabled(features.AllowAccountDeactivation) {
-		reg = &regModelv2{}
-		fields = regV2Fields
-	} else {
-		reg = &regModelv1{}
-		fields = regV1Fields
-	}
+	const query = "WHERE jwk_sha256 = ?"
+	var model interface{}
+	var err error
 	sha, err := core.KeyDigest(key.Key)
 	if err != nil {
 		return core.Registration{}, err
 	}
-	err = ssa.dbMap.SelectOne(
-		reg,
-		fmt.Sprintf("SELECT %s FROM registrations WHERE jwk_sha256 = :key", fields),
-		map[string]interface{}{"key": sha},
-	)
-
+	if features.Enabled(features.AllowAccountDeactivation) {
+		model, err = SelectRegistrationv2(ssa.dbMap.SelectOne, query, sha)
+	} else {
+		model, err = SelectRegistration(ssa.dbMap.SelectOne, query, sha)
+	}
 	if err == sql.ErrNoRows {
 		msg := fmt.Sprintf("No registrations with public key sha256 %s", sha)
 		return core.Registration{}, core.NoSuchRegistrationError(msg)
@@ -190,7 +153,7 @@ func (ssa *SQLStorageAuthority) GetRegistrationByKey(ctx context.Context, key jo
 		return core.Registration{}, err
 	}
 
-	return modelToRegistration(reg)
+	return modelToRegistration(model)
 }
 
 // GetAuthorization obtains an Authorization by ID
@@ -200,15 +163,15 @@ func (ssa *SQLStorageAuthority) GetAuthorization(ctx context.Context, id string)
 		return
 	}
 
-	var pa pendingauthzModel
-	err = tx.SelectOne(&pa, fmt.Sprintf("SELECT %s FROM pendingAuthorizations WHERE id = ?", pendingAuthzFields), id)
+	const authzQuery = "WHERE id = ?"
+	pa, err := SelectPendingAuthz(tx.SelectOne, authzQuery, id)
 	if err != nil && err != sql.ErrNoRows {
 		err = Rollback(tx, err)
 		return
 	}
 	if err == sql.ErrNoRows {
-		var fa authzModel
-		err = tx.SelectOne(&fa, fmt.Sprintf("SELECT %s FROM authz WHERE id = ?", authzFields), id)
+		var fa *authzModel
+		fa, err = SelectAuthz(tx.SelectOne, authzQuery, id)
 		if err == sql.ErrNoRows {
 			err = fmt.Errorf("No pendingAuthorization or authz with ID %s", id)
 			err = Rollback(tx, err)
@@ -267,18 +230,12 @@ func (ssa *SQLStorageAuthority) GetValidAuthorizations(ctx context.Context, regi
 		qmarks[i] = "?"
 	}
 
-	var auths []*core.Authorization
-	_, err = ssa.dbMap.Select(
-		&auths,
-		fmt.Sprintf(`
-		SELECT %s FROM authz
-		WHERE registrationID = ?
-		AND expires > ?
-		AND identifier IN (`+strings.Join(qmarks, ",")+`)
-		AND status = 'valid'
-		`, authzFields),
-		append([]interface{}{registrationID, now}, params...)...,
-	)
+	auths, err := SelectAuthzs(ssa.dbMap.Select,
+		"WHERE registrationID = ? "+
+			"AND expires > ? "+
+			"AND identifier IN ("+strings.Join(qmarks, ",")+") "+
+			"AND status = 'valid'",
+		append([]interface{}{registrationID, now}, params...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -451,8 +408,7 @@ func (ssa *SQLStorageAuthority) GetCertificate(ctx context.Context, serial strin
 		return core.Certificate{}, err
 	}
 
-	var cert core.Certificate
-	err := ssa.dbMap.SelectOne(&cert, fmt.Sprintf("SELECT %s FROM certificates WHERE serial = ?", CertificateFields), serial)
+	cert, err := SelectCertificate(ssa.dbMap.SelectOne, "WHERE serial = ?", serial)
 	if err == sql.ErrNoRows {
 		return core.Certificate{}, core.NotFoundError(fmt.Sprintf("No certificate found for %s", serial))
 	}
@@ -552,20 +508,14 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(ctx context.Context, seri
 		return err
 	}
 
+	const statusQuery = "WHERE serial = ?"
 	var statusObj interface{}
-	var fields string
 
 	if features.Enabled(features.CertStatusOptimizationsMigrated) {
-		statusObj = &certStatusModelv2{}
-		fields = CertificateStatusFieldsv2
+		statusObj, err = SelectCertificateStatusv2(tx.SelectOne, statusQuery, serial)
 	} else {
-		statusObj = &certStatusModelv1{}
-		fields = CertificateStatusFields
+		statusObj, err = SelectCertificateStatus(tx.SelectOne, statusQuery, serial)
 	}
-	err = tx.SelectOne(
-		statusObj,
-		fmt.Sprintf("SELECT %s FROM certificateStatus WHERE serial = ?", fields),
-		serial)
 	if err == sql.ErrNoRows {
 		err = fmt.Errorf("No certificate with serial %s", serial)
 		err = Rollback(tx, err)
@@ -576,22 +526,21 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(ctx context.Context, seri
 		return err
 	}
 
+	var n int64
 	now := ssa.clk.Now()
 	if features.Enabled(features.CertStatusOptimizationsMigrated) {
-		status := statusObj.(*certStatusModelv2)
+		status := statusObj.(certStatusModelv2)
 		status.Status = core.OCSPStatusRevoked
 		status.RevokedDate = now
 		status.RevokedReason = reasonCode
-		statusObj = status
+		n, err = tx.Update(&status)
 	} else {
-		status := statusObj.(*certStatusModelv1)
+		status := statusObj.(certStatusModelv1)
 		status.Status = core.OCSPStatusRevoked
 		status.RevokedDate = now
 		status.RevokedReason = reasonCode
-		statusObj = status
+		n, err = tx.Update(&status)
 	}
-
-	n, err := tx.Update(statusObj)
 	if err != nil {
 		err = Rollback(tx, err)
 		return err
@@ -607,16 +556,14 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(ctx context.Context, seri
 
 // UpdateRegistration stores an updated Registration
 func (ssa *SQLStorageAuthority) UpdateRegistration(ctx context.Context, reg core.Registration) error {
-	var regType interface{}
-	var fields string
+	const query = "WHERE id = ?"
+	var model interface{}
+	var err error
 	if features.Enabled(features.AllowAccountDeactivation) {
-		regType = &regModelv2{}
-		fields = regV2Fields
+		model, err = SelectRegistrationv2(ssa.dbMap.SelectOne, query, reg.ID)
 	} else {
-		regType = &regModelv1{}
-		fields = regV1Fields
+		model, err = SelectRegistration(ssa.dbMap.SelectOne, query, reg.ID)
 	}
-	err := ssa.dbMap.SelectOne(regType, fmt.Sprintf("SELECT %s FROM registrations WHERE id = ?", fields), reg.ID)
 	if err == sql.ErrNoRows {
 		msg := fmt.Sprintf("No registrations with ID %d", reg.ID)
 		return core.NoSuchRegistrationError(msg)
@@ -632,12 +579,12 @@ func (ssa *SQLStorageAuthority) UpdateRegistration(ctx context.Context, reg core
 	// so that we can copy over the LockCol from one to the other. Once we have copied
 	// that field we reassign to the interface so gorp can properly update it.
 	if features.Enabled(features.AllowAccountDeactivation) {
-		erm := regType.(*regModelv2)
+		erm := model.(*regModelv2)
 		urm := updatedRegModel.(*regModelv2)
 		urm.LockCol = erm.LockCol
 		updatedRegModel = urm
 	} else {
-		erm := regType.(*regModelv1)
+		erm := model.(*regModelv1)
 		urm := updatedRegModel.(*regModelv1)
 		urm.LockCol = erm.LockCol
 		updatedRegModel = urm
@@ -731,8 +678,7 @@ func (ssa *SQLStorageAuthority) UpdatePendingAuthorization(ctx context.Context, 
 		return
 	}
 
-	var pa pendingauthzModel
-	err = tx.SelectOne(&pa, fmt.Sprintf("SELECT %s FROM pendingAuthorizations WHERE id = ?", pendingAuthzFields), authz.ID)
+	pa, err := SelectPendingAuthz(tx.SelectOne, "WHERE id = ?", authz.ID)
 	if err == sql.ErrNoRows {
 		return Rollback(tx, fmt.Errorf("No pending authorization with ID %s", authz.ID))
 	}
@@ -740,7 +686,7 @@ func (ssa *SQLStorageAuthority) UpdatePendingAuthorization(ctx context.Context, 
 		return Rollback(tx, err)
 	}
 	pa.Authorization = authz
-	_, err = tx.Update(&pa)
+	_, err = tx.Update(pa)
 	if err != nil {
 		err = Rollback(tx, err)
 		return
@@ -776,8 +722,7 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization(ctx context.Context, authz
 	}
 
 	auth := &authzModel{authz}
-	var pa pendingauthzModel
-	err = tx.SelectOne(&pa, fmt.Sprintf("SELECT %s FROM pendingAuthorizations WHERE id = ?", pendingAuthzFields), authz.ID)
+	pa, err := SelectPendingAuthz(tx.SelectOne, "WHERE id = ?", authz.ID)
 	if err == sql.ErrNoRows {
 		return Rollback(tx, fmt.Errorf("No pending authorization with ID %s", authz.ID))
 	}
@@ -791,7 +736,7 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization(ctx context.Context, authz
 		return
 	}
 
-	_, err = tx.Delete(&pa)
+	_, err = tx.Delete(pa)
 	if err != nil {
 		err = Rollback(tx, err)
 		return
@@ -970,20 +915,11 @@ func (e ErrNoReceipt) Error() string {
 // GetSCTReceipt gets a specific SCT receipt for a given certificate serial and
 // CT log ID
 func (ssa *SQLStorageAuthority) GetSCTReceipt(ctx context.Context, serial string, logID string) (receipt core.SignedCertificateTimestamp, err error) {
-	err = ssa.dbMap.SelectOne(
-		&receipt,
-		fmt.Sprintf("SELECT %s FROM sctReceipts WHERE certificateSerial = :serial AND logID = :logID", sctFields),
-		map[string]interface{}{
-			"serial": serial,
-			"logID":  logID,
-		},
-	)
-
+	receipt, err = SelectSctReceipt(ssa.dbMap.SelectOne, "WHERE certificateSerial = ? AND logID = ?", serial, logID)
 	if err == sql.ErrNoRows {
 		err = ErrNoReceipt(err.Error())
 		return
 	}
-
 	return
 }
 


### PR DESCRIPTION
In #2178 we moved to explicit `SELECT` statements using a set of `const` fields for each type to support db migrations and forward compatibility.

This commit removes the temptation to interpolate queries by providing convenience `Select` functions for each type allowing the caller to provide the WHERE clause and arguments.

Resolves #2214.