### PR TITLE
Use max_statement_time for timeouts.

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -67,7 +67,7 @@ func NewDbMapFromConfig(config *mysql.Config, maxOpenConns int) (*gorp.DbMap, er
 	dbmap := &gorp.DbMap{Db: db, Dialect: dialect, TypeConverter: BoulderTypeConverter{}}
 
 	initTables(dbmap)
-	_, err = dbmap.Exec("SET sql_mode = 'STRICT_ALL_TABLES';")
+	_, err = dbmap.Exec("SET SESSION sql_mode = 'STRICT_ALL_TABLES';")
 	if err != nil {
 		return nil, err
 	}
@@ -79,9 +79,9 @@ func NewDbMapFromConfig(config *mysql.Config, maxOpenConns int) (*gorp.DbMap, er
 	if config.ReadTimeout != 0 {
 		// In MariaDB, max_statement_time and long_query_time are both seconds.
 		// Note: in MySQL (which we don't use), max_statement_time is millis.
-		readTimeout := float64(config.ReadTimeout) / float64(time.Second)
-		_, err := dbmap.Exec("SET max_statement_time = ?, long_query_time = ?;",
-			readTimeout*0.0001, readTimeout*0.80)
+		readTimeout := config.ReadTimeout.Seconds()
+		_, err := dbmap.Exec("SET SESSION max_statement_time = ?, long_query_time = ?;",
+			readTimeout*0.95, readTimeout*0.80)
 		if err != nil {
 			return nil, err
 		}

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -89,7 +89,8 @@ func TestTimeouts(t *testing.T) {
 
 	// We expect to get:
 	// Error 1969: Query execution was interrupted (max_statement_time exceeded)
-	if !strings.Contains(err.Error(), "Error 1967") {
+	// https://mariadb.com/kb/en/mariadb/mariadb-error-codes/
+	if !strings.Contains(err.Error(), "Error 1969") {
 		t.Fatalf("Got wrong type of error: %s", err)
 	}
 }


### PR DESCRIPTION
This means that we get a more useful log message for slow queries, and don't
need to close the MySQL connection. It also means that the query is actually
killed on the MySQL side, rather than just timing out and returning on the
client side.

We set the max_statement_time to 95% of the readTimeout.

Also set the long_query_time to 80% of the readTimeout, so that queries that are
close to timing out will be logged by MySQL's slow query logging.

Fixes #2251.