### PR TITLE
Basic CT rate-limiting logic

### DIFF
--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	ct "github.com/google/certificate-transparency/go"
 
@@ -57,7 +58,7 @@ func main() {
 
 	logs := make([]*publisher.Log, len(c.Common.CT.Logs))
 	for i, ld := range c.Common.CT.Logs {
-		logs[i], err = publisher.NewLog(ld.URI, ld.Key)
+		logs[i], err = publisher.NewLog(ld.URI, ld.Key, ld.MaxSPS)
 		cmd.FailOnError(err, "Unable to parse CT log description")
 	}
 
@@ -83,6 +84,12 @@ func main() {
 		logger,
 		scope,
 		sa)
+	go func() {
+		for {
+			time.Sleep(time.Second)
+			pubi.ClearSubmissions()
+		}
+	}()
 
 	go cmd.ProfileCmd(scope)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -307,8 +307,9 @@ func (d *ConfigDuration) UnmarshalYAML(unmarshal func(interface{}) error) error 
 // LogDescription contains the information needed to submit certificates
 // to a CT log and verify returned receipts
 type LogDescription struct {
-	URI string
-	Key string
+	URI    string
+	Key    string
+	MaxSPS int64
 }
 
 // GRPCClientConfig contains the information needed to talk to the gRPC service

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -35,7 +35,8 @@
       "logs": [
         {
           "uri": "http://127.0.0.1:4500",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q=="
+          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q==",
+          "maxSPS": 50
         }
       ],
       "intermediateBundleFilename": "test/test-ca2.pem"


### PR DESCRIPTION
Fixes #2268.

Instead of blocking until the rate resets just skip the submission so that it later gets picked up by the missing receipt logic in OCSP-Updater. This is so that we don't amass a huge number of pending SubmitCT goroutines in the publisher while waiting for the rate to go down. 
