### PR TITLE
Use pkcs11key.NewPool in CA.

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -116,7 +116,11 @@ func loadSigner(issuerConfig cmd.IssuerConfig) (crypto.Signer, error) {
 		pkcs11Config.PrivateKeyLabel == "" {
 		return nil, fmt.Errorf("Missing a field in pkcs11Config %#v", pkcs11Config)
 	}
-	return pkcs11key.New(pkcs11Config.Module,
+	numSessions := issuerConfig.NumSessions
+	if numSessions <= 0 {
+		numSessions = 1
+	}
+	return pkcs11key.NewPool(numSessions, pkcs11Config.Module,
 		pkcs11Config.TokenLabel, pkcs11Config.PIN, pkcs11Config.PrivateKeyLabel)
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -189,6 +189,9 @@ type IssuerConfig struct {
 	File       string
 	PKCS11     *pkcs11key.Config
 	CertFile   string
+	// Number of sessions to open with the HSM. For maximum performance,
+	// this should be equal to the number of cores in the HSM. Defaults to 1.
+	NumSessions int
 }
 
 // TLSConfig reprents certificates and a key for authenticated TLS.

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -12,10 +12,12 @@
     },
     "Issuers": [{
       "ConfigFile": "test/test-ca.key-pkcs11.json",
-      "CertFile": "test/test-ca2.pem"
+      "CertFile": "test/test-ca2.pem",
+      "NumSessions": 10
     }, {
       "ConfigFile": "test/test-ca.key-pkcs11.json",
-      "CertFile": "test/test-ca.pem"
+      "CertFile": "test/test-ca.pem",
+      "NumSessions": 10
     }],
     "expiry": "2160h",
     "lifespanOCSP": "96h",


### PR DESCRIPTION
Right now, we only get single-threaded performance from our HSM, even though it
has multiple cores. We can use the pkcs11key's NewPool function to create a pool
of PKCS#11 sessions, allowing us to take advantage of the HSM's full
performance.