### PR TITLE
Add IDN TLD support

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -225,12 +225,20 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 		}
 	}
 
+	unicodeDomain := domain
+	if features.Enabled(features.IDNASupport) {
+		var err error
+		unicodeDomain, err = idna.ToUnicode(domain)
+		if err != nil {
+			return errMalformedIDN
+		}
+	}
 	// Names must end in an ICANN TLD, but they must not be equal to an ICANN TLD.
-	icannTLD, err := extractDomainIANASuffix(domain)
+	icannTLD, err := extractDomainIANASuffix(unicodeDomain)
 	if err != nil {
 		return errNonPublic
 	}
-	if icannTLD == domain {
+	if icannTLD == unicodeDomain {
 		return errICANNTLD
 	}
 

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -164,6 +164,14 @@ func TestWillingToIssue(t *testing.T) {
 	// Valid encoding
 	err = pa.WillingToIssue(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "www.xn--mnich-kva.com"})
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed IDN")
+	// IDN public suffix
+	err = pa.WillingToIssue(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "www.example.xn--fiqs8s"})
+	test.AssertNotError(t, err, "WillingToIssue failed on a domain with a properly formed IDN public suffix")
+	// Domain is punycoded ICANN TLD
+	err = pa.WillingToIssue(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "xn--d1at.xn--90a3ac"})
+	if err != errICANNTLD {
+		t.Error("Punycoded ICANN TLD identifier was not correctly forbidden", err)
+	}
 	features.Reset()
 
 	// Test domains that are equal to public suffixes


### PR DESCRIPTION
`publicsuffix-go`'s `Find` expects suffixes to be in unicode rather than punycode, causing IDN TLDs to be rejected. Convert domains to unicode prior to checking whether the domain ends in an ICANN suffix.

Fixes #2277.
