### PR TITLE
Increase maximum labels from 10 to 14

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -92,7 +92,7 @@ func (pa *AuthorityImpl) loadHostnamePolicy(b []byte) error {
 }
 
 const (
-	maxLabels = 10
+	maxLabels = 14
 
 	// RFC 1034 says DNS labels have a max of 63 octets, and names have a max of 255
 	// octets: https://tools.ietf.org/html/rfc1035#page-10

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -43,7 +43,7 @@ func TestWillingToIssue(t *testing.T) {
 		{`[2001:db8:85a3:8d3:1319:8a2e:370:7348]`, errInvalidDNSCharacter}, // unexpected IPv6 variants
 		{`[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443`, errInvalidDNSCharacter},
 		{`2001:db8::/32`, errInvalidDNSCharacter},
-		{`a.b.c.d.e.f.g.h.i.j.k`, errTooManyLabels}, // Too many labels (>10)
+		{`a.b.c.d.e.f.g.h.i.j.k.l.m.n.o`, errTooManyLabels}, // Too many labels (>14)
 
 		{`www.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.com`, errNameTooLong}, // Too long (>255 characters)
 
@@ -122,6 +122,7 @@ func TestWillingToIssue(t *testing.T) {
 		"8675309.com",
 		"web5ite2.com",
 		"www.web-site2.com",
+		"0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
 	}
 
 	pa := paImpl(t)


### PR DESCRIPTION
This is required to be able to get a certificate for an IPv6 reverse
DNS entry at the /48 level, e.g. 0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.

(Fixes https://community.letsencrypt.org/t/dns-name-has-too-many-labels-error/21577)
