### PR TITLE
Allow `validateEmail` to timeout w/o error.

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -56,11 +56,9 @@ func (t timeoutError) Timeout() bool {
 // Note: see comments on LookupMX regarding email.only
 //
 func (mock *MockDNSResolver) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
-	if hostname == "always.invalid" || hostname == "invalid.invalid" {
-		return []net.IP{}, &DNSError{dns.TypeA, "always.invalid",
-			&net.OpError{Err: errors.New("invalid host error")}, -1}
-	}
-	if hostname == "email.only" {
+	if hostname == "always.invalid" ||
+		hostname == "invalid.invalid" ||
+		hostname == "email.only" {
 		return []net.IP{}, nil
 	}
 	if hostname == "always.timeout" {

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -150,6 +150,11 @@ func (mock *MockDNSResolver) LookupMX(_ context.Context, domain string) ([]strin
 		fallthrough
 	case "email.com":
 		return []string{"mail.email.com"}, nil
+	case "always.error":
+		return []string{}, &DNSError{dns.TypeA, "always.error",
+			&net.OpError{Err: errors.New("always.error always errors")}, -1}
+	case "always.timeout":
+		return []string{}, &DNSError{dns.TypeA, "always.timeout", MockTimeoutError(), -1}
 	}
 	return nil, nil
 }

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -56,9 +56,11 @@ func (t timeoutError) Timeout() bool {
 // Note: see comments on LookupMX regarding email.only
 //
 func (mock *MockDNSResolver) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
-	if hostname == "always.invalid" ||
-		hostname == "invalid.invalid" ||
-		hostname == "email.only" {
+	if hostname == "always.invalid" || hostname == "invalid.invalid" {
+		return []net.IP{}, &DNSError{dns.TypeA, "always.invalid",
+			&net.OpError{Err: errors.New("invalid host error")}, -1}
+	}
+	if hostname == "email.only" {
 		return []net.IP{}, nil
 	}
 	if hostname == "always.timeout" {

--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -27,6 +27,8 @@ func (d DNSError) Error() string {
 			} else {
 				detail = detailDNSNetFailure
 			}
+			// Note: we check d.underlying here even though `Timeout()` does this because the call to `netErr.Timeout()` above only
+			// happens for `*net.OpError` underlying types!
 		} else if d.underlying == context.Canceled || d.underlying == context.DeadlineExceeded {
 			detail = detailDNSTimeout
 		} else {
@@ -41,10 +43,13 @@ func (d DNSError) Error() string {
 		dns.TypeToString[d.recordType], d.hostname)
 }
 
-// Timeout returns true if the underlying error was a timeout
+// Timeout returns true if the underlying error was a timeout from the network
+// or the context the request was made under
 func (d DNSError) Timeout() bool {
 	if netErr, ok := d.underlying.(*net.OpError); ok {
 		return netErr.Timeout()
+	} else if d.underlying == context.Canceled || d.underlying == context.DeadlineExceeded {
+		return true
 	}
 	return false
 }

--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -44,7 +44,7 @@ func (d DNSError) Error() string {
 }
 
 // Timeout returns true if the underlying error was a timeout from the network
-// or the context the request was made under
+// or the context the request was made under timed out
 func (d DNSError) Timeout() bool {
 	if netErr, ok := d.underlying.(*net.OpError); ok {
 		return netErr.Timeout()

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -324,7 +324,7 @@ func TestValidateEmail(t *testing.T) {
 		{"an email`", unparseableEmailDetail},
 		{"a@always.invalid", emptyDNSResponseDetail},
 		{"a@email.com, b@email.com", multipleAddressDetail},
-		{"a@always.error", "DNS problem: networking error looking up A for always.error"},
+		{"a@always.error", "server failure at resolver"},
 	}
 	testSuccesses := []string{
 		"a@email.com",

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -11,6 +11,7 @@
     "reuseValidAuthz": true,
     "authorizationLifetimeDays": 300,
     "pendingAuthorizationLifetimeDays": 7,
+    "emailValidationTimeout": "8s",
     "vaService": {
       "serverAddresses": ["boulder:9092"],
       "serverIssuerPath": "test/grpc-creds/ca.pem",

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -667,7 +667,8 @@ func TestIssueCertificate(t *testing.T) {
 		true,
 		false,
 		300*24*time.Hour,
-		7*24*time.Hour)
+		7*24*time.Hour,
+		10*time.Second)
 	ra.SA = mocks.NewStorageAuthority(fc)
 	ra.CA = &mocks.MockCA{
 		PEM: mockCertPEM,


### PR DESCRIPTION
This PR reworks the `validateEmail()` function from the RA to perform the MX and A/AAAA lookups to validate an email address asynchronously with a proper timeout. The timeout used is configurable to allow setting it lower than the overall WFE->RA timeout. This enables us to treat the validation of an email address as best-effort during registration and to tighten the overall WFE->RA timeouts.

* The default value for `EmailValidationTimeout` when not provided via a config file (e.g. when using `test/config` vs `test/config-next`) is 8 seconds. This fits within the 10s that the WFE->RA requests are allowed to take.
* `bdns/problem.go` - `DNSError.Timeout()` was changed to also include context cancellation and timeout as DNS timeouts. This matches what `DNSError.Error()` was doing to set the error message and supports external callers to `Timeout` not duplicating the work.
* `bdns/mocks.go` - the `LookupMX` mock was changed to support `always.error` and `always.timeout` in a manner similar to the `LookupHost` mock. Otherwise the `TestValidateEmail` unit test for the RA would fail when the MX lookup completed before the Host lookup because the error wouldn't be correct (empty DNS records vs a timeout or network error). 

Resolves https://github.com/letsencrypt/boulder/issues/2260.