### PR TITLE
Properly abort `NewAuthorization` when SA RPC fails.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -386,6 +386,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(ctx context.Context, reque
 					fmt.Sprintf("unable to get existing authorization for auth ID: %s",
 						existingAuthz.ID))
 				ra.log.Warning(fmt.Sprintf("%s: %s", string(outErr), existingAuthz.ID))
+				return authz, outErr
 			}
 
 			// The existing authorization must not expire within the next 24 hours for

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -373,6 +373,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(ctx context.Context, reque
 				fmt.Sprintf("unable to get existing validations for regID: %d, identifier: %s",
 					regID, identifier.Value))
 			ra.log.Warning(string(outErr))
+			return authz, outErr
 		}
 
 		if existingAuthz, ok := auths[identifier.Value]; ok {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -495,8 +495,8 @@ func TestReuseAuthorization(t *testing.T) {
 
 	// Create one finalized authorization
 	finalAuthz := AuthzInitial
-	//exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	finalAuthz.Expires = nil
+	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
+	finalAuthz.Expires = &exp
 	finalAuthz.Challenges[0].Status = core.StatusValid
 	finalAuthz.RegistrationID = Registration.ID
 	finalAuthz, err := sa.NewPendingAuthorization(ctx, finalAuthz)


### PR DESCRIPTION
The RA performs an RPC to the SA's `GetValidAuthorizations` function when attempting to find existing valid authorizations to reuse. Prior to this commit, ff the RPC fails (e.g. due to a timeout) the calling code
logs the failure as a warning but fails to return the error and cease processing. This results in a nil panic when we later try to index `auths`

This commit inserts the missing `return` to ensure we don't process further, thereby resolving #2274.

A test for this fix is provided with `TestReuseAuthorizationFaultySA`. Without f52f340 applied this test recreates the panic observed in #2274 and produces:

```
go test -p 1 -v -race --test.run TestReuseAuthorizationFaultySA github.com/letsencrypt/boulder/ra
=== RUN   TestReuseAuthorizationFaultySA
--- FAIL: TestReuseAuthorizationFaultySA (0.04s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x4be2b8]

```

With f52f340 it passes. Yay!
