### PR TITLE
Allow `validateEmail` to timeout w/o error.

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -150,6 +150,11 @@ func (mock *MockDNSResolver) LookupMX(_ context.Context, domain string) ([]strin
 		fallthrough
 	case "email.com":
 		return []string{"mail.email.com"}, nil
+	case "always.error":
+		return []string{}, &DNSError{dns.TypeA, "always.error",
+			&net.OpError{Err: errors.New("always.error always errors")}, -1}
+	case "always.timeout":
+		return []string{}, &DNSError{dns.TypeA, "always.timeout", MockTimeoutError(), -1}
 	}
 	return nil, nil
 }

--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -27,6 +27,8 @@ func (d DNSError) Error() string {
 			} else {
 				detail = detailDNSNetFailure
 			}
+			// Note: we check d.underlying here even though `Timeout()` does this because the call to `netErr.Timeout()` above only
+			// happens for `*net.OpError` underlying types!
 		} else if d.underlying == context.Canceled || d.underlying == context.DeadlineExceeded {
 			detail = detailDNSTimeout
 		} else {
@@ -45,6 +47,8 @@ func (d DNSError) Error() string {
 func (d DNSError) Timeout() bool {
 	if netErr, ok := d.underlying.(*net.OpError); ok {
 		return netErr.Timeout()
+	} else if d.underlying == context.Canceled || d.underlying == context.DeadlineExceeded {
+		return true
 	}
 	return false
 }

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -321,12 +321,15 @@ func TestValidateEmail(t *testing.T) {
 		{"an email`", unparseableEmailDetail},
 		{"a@always.invalid", emptyDNSResponseDetail},
 		{"a@email.com, b@email.com", multipleAddressDetail},
-		{"a@always.timeout", "DNS problem: query timed out looking up A for always.timeout"},
 		{"a@always.error", "DNS problem: networking error looking up A for always.error"},
 	}
 	testSuccesses := []string{
 		"a@email.com",
 		"b@email.only",
+		// A timeout during email validation is treated as a success. We treat email
+		// validation during registration as a best-effort. See
+		// https://github.com/letsencrypt/boulder/issues/2260 for more
+		"a@always.timeout",
 	}
 
 	for _, tc := range testFailures {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -3,7 +3,7 @@
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 16,
     "maxContactsPerRegistration": 100,
-    "dnsTries": 3,
+    "dnsTries": 2,
     "debugAddr": "localhost:8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 1000,
@@ -67,7 +67,7 @@
 
   "common": {
     "dnsResolver": "127.0.0.1:8053",
-    "dnsTimeout": "10s",
+    "dnsTimeout": "5s",
     "dnsAllowLoopbackAddresses": true
   }
 }

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -3,7 +3,7 @@
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 16,
     "maxContactsPerRegistration": 100,
-    "dnsTries": 3,
+    "dnsTries": 2,
     "debugAddr": "localhost:8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 1000,
@@ -56,7 +56,7 @@
 
   "common": {
     "dnsResolver": "127.0.0.1:8053",
-    "dnsTimeout": "10s",
+    "dnsTimeout": "5s",
     "dnsAllowLoopbackAddresses": true
   }
 }


### PR DESCRIPTION
This PR reworks the `validateEmail()` function from the RA to allow timeouts during DNS validation of MX/A/AAAA records for an email to be non-fatal and match our intention to verify emails best-effort.

Notes:
* `bdns/problem.go` - `DNSError.Timeout()` was changed to also include context cancellation and timeout as DNS timeouts. This matches what `DNSError.Error()` was doing to set the error message and supports external callers to `Timeout` not duplicating the work.

* `bdns/mocks.go` - the `LookupMX` mock was changed to support   `always.error` and `always.timeout` in a manner similar to the `LookupHost` mock. Otherwise the `TestValidateEmail` unit test for the RA would fail when the MX lookup completed before the Host lookup because the error  wouldn't be correct (empty DNS records vs a timeout or network error).

* `test/config/ra.json`, `test/config-next/ra.json` - the `dnsTries` and `dnsTimeout` values were updated such that `dnsTries * dnsTimeout` was <= the WFE->RA RPC timeout (currently 15s in the test configs). This allows the dns lookups to all timeout without the overall RPC timing out.

Resolves https://github.com/letsencrypt/boulder/issues/2260.