### PR TITLE
Implements client whitelisting for gRPC.

### DIFF
--- a/cmd/caa-checker/test-config.yml
+++ b/cmd/caa-checker/test-config.yml
@@ -11,3 +11,5 @@ grpc:
   server-certificate-path: test/grpc-creds/server.pem
   server-key-path: test/grpc-creds/key.pem
   client-issuer-path: test/grpc-creds/ca.pem
+  client-whitelist:
+    - boulder

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -325,10 +325,11 @@ type GRPCClientConfig struct {
 
 // GRPCServerConfig contains the information needed to run a gRPC service
 type GRPCServerConfig struct {
-	Address               string `json:"address" yaml:"address"`
-	ServerCertificatePath string `json:"serverCertificatePath" yaml:"server-certificate-path"`
-	ServerKeyPath         string `json:"serverKeyPath" yaml:"server-key-path"`
-	ClientIssuerPath      string `json:"clientIssuerPath" yaml:"client-issuer-path"`
+	Address               string   `json:"address" yaml:"address"`
+	ServerCertificatePath string   `json:"serverCertificatePath" yaml:"server-certificate-path"`
+	ServerKeyPath         string   `json:"serverKeyPath" yaml:"server-key-path"`
+	ClientIssuerPath      string   `json:"clientIssuerPath" yaml:"client-issuer-path"`
+	ClientWhitelist       []string `json:"clientWhitelist" yaml:"client-whitelist"`
 }
 
 // PortConfig specifies what ports the VA should call to on the remote

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -38,7 +38,7 @@ func ClientSetup(c *cmd.GRPCClientConfig, stats metrics.Scope) (*grpc.ClientConn
 	if err != nil {
 		return nil, err
 	}
-	ci := clientInterceptor{stats.NewScope("gRPCClient"), clock.Default()}
+	ci := clientStatsInterceptor{stats.NewScope("gRPCClient"), clock.Default()}
 	return grpc.Dial(
 		"", // Since our staticResolver provides addresses we don't need to pass an address here
 		grpc.WithTransportCredentials(bcreds.New(rootCAs, []tls.Certificate{clientCert})),

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/letsencrypt/boulder/metrics"
@@ -9,12 +10,9 @@ import (
 	"github.com/jmhodges/clock"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 )
-
-type serverInterceptor struct {
-	stats metrics.Scope
-	clk   clock.Clock
-}
 
 func cleanMethod(m string, trimService bool) string {
 	m = strings.TrimLeft(m, "-")
@@ -28,11 +26,108 @@ func cleanMethod(m string, trimService bool) string {
 	return strings.Replace(m, "-", "_", -1)
 }
 
-func (si *serverInterceptor) intercept(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+/*
+ * serverWhiteListInterceptor implements the UnaryServerInterceptor interface to
+ * validate a peer's TLS client certificate's subject common name against
+ * a whitelist. Peers without a valid certificate with the correct name are
+ * rejected. The whitelist interceptor allows chaining one additional "next"
+ * interceptor to be called after the whitelist processing.
+ */
+type serverWhitelistInterceptor struct {
+	stats     metrics.Scope
+	whitelist map[string]struct{}
+	next      grpc.UnaryServerInterceptor
+}
+
+func (si *serverWhitelistInterceptor) intercept(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (interface{}, error) {
+	var ok bool
+
 	if info == nil {
 		si.stats.Inc("NoInfo", 1)
 		return nil, errors.New("passed nil *grpc.UnaryServerInfo")
 	}
+
+	// First we need to find the Peer for this context
+	var p *peer.Peer
+	if p, ok = peer.FromContext(ctx); !ok {
+		si.stats.Inc("NoPeer", 1)
+		return nil, errors.New("passed context without *grpc.Peer")
+	}
+
+	// Next we need to make sure that the peer's auth info is a TLS auth info.
+	var tlsInfo credentials.TLSInfo
+	if tlsInfo, ok = p.AuthInfo.(credentials.TLSInfo); !ok {
+		si.stats.Inc("NoPeerTLSInfo", 1)
+		return nil, errors.New("peer did not have credentials.TLSInfo as AuthInfo")
+	}
+
+	// The peer must have at least one verified chain built from its
+	// PeerCertificates.
+	chains := tlsInfo.State.VerifiedChains
+	if len(chains) < 1 {
+		si.stats.Inc("NoPeerVerifiedChains", 1)
+		return nil, errors.New("peer tlsInfo.State had zero VerifiedChains")
+	}
+
+	/*
+	 * For each of the peer's verified chains we can look at the chain's leaf
+	 * certificate and check whether the subject common name is in the whitelist.
+	 * At least one chain must have a leaf certificate with a subject CN that
+	 * matches the whitelist
+	 *
+	 * Its important we process `VerifiedChains` instead of processing
+	 * PeerCertificates to ensure that we match the subject CN of the
+	 * leaf certificate that the upper layers of the gRPC credentials code
+	 * verified. To do otherwise would allow an attacker to include a whitelisted
+	 * certificate in PeerCertificates that matched the whitelist but wasn't used
+	 * in the chain the server validated.
+	 */
+	var whitelisted bool
+	for _, chain := range chains {
+		leafSubjectCN := chain[0].Subject.CommonName
+		if _, ok = si.whitelist[leafSubjectCN]; ok {
+			whitelisted = true
+		}
+	}
+
+	// If none of the chains had a leaf certificate that matched the whitelist, we
+	// reject the peer
+	if !whitelisted {
+		si.stats.Inc("PeerRejectedByWhitelist", 1)
+		return nil, fmt.Errorf(
+			"peer's verified TLS chains did not include a leaf certificate with whitelisted subject CN")
+	}
+
+	// If there is a next UnaryServerInterceptor, invoke it and return
+	// This is a little bit clunky - in the future we may want to replace this
+	// with a general chaining mechanism ala go-grpc-middleware
+	if si.next != nil {
+		return si.next(ctx, req, info, handler)
+	} else {
+		// Otherwise, invoke the handler and return
+		return handler(ctx, req)
+	}
+}
+
+type serverStatsInterceptor struct {
+	stats metrics.Scope
+	clk   clock.Clock
+}
+
+func (si *serverStatsInterceptor) intercept(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (interface{}, error) {
+	if info == nil {
+		si.stats.Inc("NoInfo", 1)
+		return nil, errors.New("passed nil *grpc.UnaryServerInfo")
+	}
+
 	s := si.clk.Now()
 	methodScope := si.stats.NewScope(cleanMethod(info.FullMethod, true))
 	methodScope.Inc("Calls", 1)
@@ -46,14 +141,20 @@ func (si *serverInterceptor) intercept(ctx context.Context, req interface{}, inf
 	return resp, err
 }
 
-type clientInterceptor struct {
+type clientStatsInterceptor struct {
 	stats metrics.Scope
 	clk   clock.Clock
 }
 
 // intercept fulfils the grpc.UnaryClientInterceptor interface, it should be noted that while this API
 // is currently experimental the metrics it reports should be kept as stable as can be, *within reason*.
-func (ci *clientInterceptor) intercept(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func (ci *clientStatsInterceptor) intercept(
+	ctx context.Context,
+	method string,
+	req, reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption) error {
 	s := ci.clk.Now()
 	methodScope := ci.stats.NewScope(cleanMethod(method, false))
 	methodScope.Inc("Calls", 1)

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -1,6 +1,8 @@
 package grpc
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"testing"
 	"time"
@@ -9,7 +11,10 @@ import (
 	"github.com/jmhodges/clock"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 
+	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -32,12 +37,116 @@ func testInvoker(_ context.Context, method string, _, _ interface{}, _ *grpc.Cli
 	return nil
 }
 
-func TestServerInterceptor(t *testing.T) {
+type mockInfo struct{}
+
+func (m mockInfo) AuthType() string {
+	return "MockInfo"
+}
+
+func TestServerWhitelistInterceptor(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	statter := metrics.NewMockStatter(ctrl)
 	stats := metrics.NewStatsdScope(statter, "fake", "gRPCServer")
-	si := serverInterceptor{stats, fc}
+
+	whitelist := map[string]struct{}{
+		"boulder": struct{}{},
+	}
+
+	si := serverWhitelistInterceptor{stats, whitelist, nil}
+
+	// A nil grpc.UnaryServerInfo should produce an increment on
+	// `fake.gRPCServer.NoInfo` and an error
+	statter.EXPECT().Inc("fake.gRPCServer.NoInfo", int64(1), float32(1.0)).Return(nil)
+	_, err := si.intercept(context.Background(), nil, nil, testHandler)
+	test.AssertError(t, err,
+		"serverWhitelistInterceptor.intercept didn't fail with a nil grpc.UnaryServerInfo")
+
+	unaryServInfo := &grpc.UnaryServerInfo{FullMethod: "-service-test"}
+
+	// A nil peer in the provided context should produce an increment on
+	// `fake.gRPCServer.NoPeer` and an error
+	statter.EXPECT().Inc("fake.gRPCServer.NoPeer", int64(1), float32(1.0)).Return(nil)
+	_, err = si.intercept(context.Background(), nil, unaryServInfo, testHandler)
+	test.AssertEquals(t, err.Error(), "passed context without *grpc.Peer")
+
+	// A peer with a AuthInfo that isn't a credentials.TLSInfo should increment
+	// the `fake.gRPCServer.NoPeerTLSInfo` stat and produce an error
+	p := peer.Peer{
+		AuthInfo: mockInfo{},
+	}
+	ctx := peer.NewContext(context.Background(), &p)
+	statter.EXPECT().Inc("fake.gRPCServer.NoPeerTLSInfo", int64(1), float32(1.0)).Return(nil)
+	_, err = si.intercept(ctx, nil, unaryServInfo, testHandler)
+	test.AssertEquals(t, err.Error(), "peer did not have credentials.TLSInfo "+
+		"as AuthInfo")
+
+	// A peer with a TLSInfo that has a TLS state without any verified peer
+	// certificates should increment the `fake.gRCPServer.NoPeerVerifiedChains`
+	// stat and produce an error
+	emptyTLSAuthInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{},
+	}
+	p.AuthInfo = emptyTLSAuthInfo
+	statter.EXPECT().Inc("fake.gRPCServer.NoPeerVerifiedChains", int64(1), float32(1.0)).Return(nil)
+	_, err = si.intercept(ctx, nil, unaryServInfo, testHandler)
+	test.AssertEquals(t, err.Error(), "peer tlsInfo.State had zero VerifiedChains")
+
+	// A peer presenting a chain that has a leaf certificate with a subject CN
+	// that isn't on the whitelist should increment the
+	// `fake.gRPCServer.PeerRejectedByWhitelist` stat and produce an error
+	wrongCert, err := core.LoadCert("../test/test-root.pem")
+	test.AssertNotError(t, err, "LoadCert failed for test/test-root.pem")
+	wrongTLSAuthInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			VerifiedChains: [][]*x509.Certificate{[]*x509.Certificate{wrongCert}},
+		},
+	}
+	p.AuthInfo = wrongTLSAuthInfo
+	statter.EXPECT().Inc("fake.gRPCServer.PeerRejectedByWhitelist", int64(1), float32(1.0)).Return(nil)
+	_, err = si.intercept(ctx, nil, unaryServInfo, testHandler)
+	test.AssertEquals(t, err.Error(),
+		"peer's verified TLS chains did not include a leaf certificate with "+
+			"whitelisted subject CN")
+
+	// A peer presenting a chain with a leaf certificate that has a subject CN
+	// matching an entry on the whitelist should produce no errors and increment
+	// none of the error stats.
+	validCert, err := core.LoadCert("../test/grpc-creds/client.pem")
+	test.AssertNotError(t, err, "LoadCert failed for test/grpc-creds/client.pem")
+	validTLSAuthInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			VerifiedChains: [][]*x509.Certificate{[]*x509.Certificate{validCert}},
+		},
+	}
+	p.AuthInfo = validTLSAuthInfo
+	_, err = si.intercept(ctx, nil, unaryServInfo, testHandler)
+	test.AssertNotError(t, err,
+		"serverWhitelistInterceptor.intercept failed with a valid peer leaf subject CN")
+
+	// A peer presenting one verified chain that matches, and one or more verified
+	// chains that don't match should produce no errors and increment none of the
+	// error stats.
+	twoChainzAuthInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			VerifiedChains: [][]*x509.Certificate{
+				[]*x509.Certificate{wrongCert},
+				[]*x509.Certificate{validCert},
+			},
+		},
+	}
+	p.AuthInfo = twoChainzAuthInfo
+	_, err = si.intercept(ctx, nil, unaryServInfo, testHandler)
+	test.AssertNotError(t, err,
+		"serverWhitelistInterceptor.intercept failed with a valid peer leaf subject CN")
+}
+
+func TestServerStatsInterceptor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	statter := metrics.NewMockStatter(ctrl)
+	stats := metrics.NewStatsdScope(statter, "fake", "gRPCServer")
+	si := serverStatsInterceptor{stats, fc}
 
 	statter.EXPECT().Inc("fake.gRPCServer.NoInfo", int64(1), float32(1.0)).Return(nil)
 	_, err := si.intercept(context.Background(), nil, nil, testHandler)
@@ -59,12 +168,12 @@ func TestServerInterceptor(t *testing.T) {
 	test.AssertError(t, err, "si.intercept didn't fail when handler returned a error")
 }
 
-func TestClientInterceptor(t *testing.T) {
+func TestClientStatsInterceptor(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	statter := metrics.NewMockStatter(ctrl)
 	stats := metrics.NewStatsdScope(statter, "fake", "gRPCClient")
-	ci := clientInterceptor{stats, fc}
+	ci := clientStatsInterceptor{stats, fc}
 
 	statter.EXPECT().Inc("fake.gRPCClient.service_test.Calls", int64(1), float32(1.0)).Return(nil)
 	statter.EXPECT().GaugeDelta("fake.gRPCClient.service_test.InProgress", int64(1), float32(1.0)).Return(nil)

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -8,7 +8,10 @@
       "address": "boulder:9093",
       "clientIssuerPath": "test/grpc-creds/ca.pem",
       "serverCertificatePath": "test/grpc-creds/server.pem",
-      "serverKeyPath": "test/grpc-creds/key.pem"
+      "serverKeyPath": "test/grpc-creds/key.pem",
+      "clientWhitelist": [
+        "boulder"
+      ]
     },
     "Issuers": [{
       "ConfigFile": "test/test-ca.key-pkcs11.json",

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -7,7 +7,10 @@
       "address": "boulder:9091",
       "clientIssuerPath": "test/grpc-creds/ca.pem",
       "serverCertificatePath": "test/grpc-creds/server.pem",
-      "serverKeyPath": "test/grpc-creds/key.pem"
+      "serverKeyPath": "test/grpc-creds/key.pem",
+      "clientWhitelist": [
+        "boulder"
+      ]
     },
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -27,7 +27,10 @@
       "address": "boulder:9092",
       "serverCertificatePath": "test/grpc-creds/server.pem",
       "serverKeyPath": "test/grpc-creds/key.pem",
-      "clientIssuerPath": "test/grpc-creds/ca.pem"
+      "clientIssuerPath": "test/grpc-creds/ca.pem",
+      "clientWhitelist": [
+        "boulder"
+      ]
     },
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",


### PR DESCRIPTION
As described in #2282, our gRPC code uses mutual TLS to authenticate both clients and servers. However, currently our gRPC servers will accept any client certificate signed by the internal CA we use to authenticate connections. Instead, we would like each server to have a list of which clients it will accept. This will improve security by preventing the compromise of one client private key being used to access endpoints unrelated to its intended scope/purpose.

This PR implements a whitelist based on the client certificate's subject common name. Enforcement is handled by the grpc `serverWhitelistInterceptor`. Care is taken to use the `VerifiedChains` attribute of the client TLSState instead of the `PeerCertificates` attribute to prevent tricky clients from providing a whitelist matching cert in a chain separate from the one that was verified by the server.

The existing `serverInterceptor` and `clientInterceptor`'s were renamed to `serverStatsInterceptor` and `clientStatsInterceptor` now that we have more than one interceptor on the server side. The new `serverWhitelistInterceptor` provides the ability to chain one follow-on interceptor, so we plug the  `serverStatsInterceptor` in there. In the future we may want to generalize this into generic interceptor chaining support ala how some 3rd party grpc middleware does it.

An example client whitelist is added to each of the existing gRPC endpoints in `config-next/` to whitelist the subject common name of the test RPC certificate (`test/grpc-creds/client.pem`), "boulder".

Resolves #2282