### PR TITLE
Make "Working with a client:" its own section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Run tests:
     ./test.sh
 
 Working with a client:
+----------------------
 
 Check out the Certbot client from https://github.com/certbot/certbot and follow the setup instructions there. Once you've got the client set up, you'll probably want to run it against your local Boulder. There are a number of command line flags that are necessary to run the client against a local Boulder, and without root access. The simplest way to run the client locally is to source a file that provides an alias for certbot (`certbot_test`) that has all those flags:
 


### PR DESCRIPTION
This seemed like it wasn't part of the "Slow start" section, and is very helpful in its own right.