### PR TITLE
Logs failed SA.UpdatePendingAuthorization.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -963,11 +963,11 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 
 	// Store the updated version
 	if err = ra.SA.UpdatePendingAuthorization(ctx, authz); err != nil {
-		//Previously this was a MalformedREquestError alongside a comment explaning
-		//that this condition could only happen if the client corrupts the challenge
-		//data. In practice this isn't true, and this condition is better reflected
-		//as an internal server error caused by the SA being unable to process the
-		//RPC call, potentially due to an ongoing outage
+		// Previously this was a MalformedREquestError alongside a comment explaning
+		// that this condition could only happen if the client corrupts the challenge
+		// data. In practice this isn't true, and this condition is better reflected
+		// as an internal server error caused by the SA being unable to process the
+		// RPC call, potentially due to an ongoing outage
 		ra.log.Warning(fmt.Sprintf(
 			"Error calling ra.SA.UpdatePendingAuthorization: %q\n", err.Error()))
 		err = core.InternalServerError("Could not update pending authorization")

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -963,13 +963,8 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 
 	// Store the updated version
 	if err = ra.SA.UpdatePendingAuthorization(ctx, authz); err != nil {
-		// Previously this was a MalformedREquestError alongside a comment explaning
-		// that this condition could only happen if the client corrupts the challenge
-		// data. In practice this isn't true, and this condition is better reflected
-		// as an internal server error caused by the SA being unable to process the
-		// RPC call, potentially due to an ongoing outage
 		ra.log.Warning(fmt.Sprintf(
-			"Error calling ra.SA.UpdatePendingAuthorization: %q\n", err.Error()))
+			"Error calling ra.SA.UpdatePendingAuthorization: %s\n", err.Error()))
 		err = core.InternalServerError("Could not update pending authorization")
 		return
 	}


### PR DESCRIPTION
This commit resolves #2303 by updating the comment, and returned error type produced when the RA calls `SA.UpdatePendingAuthorization` and it fails.

Previously this produced a `MalformedRequestError` that was described as only happening when the client corrupted the challenge data.

Now this is returned as more descriptive `ServerInternalError` and the underlying error from the SA is logged as a warning for further debugging.