### PR TITLE
Only count pending authorizations in CountPendingAuthorizations

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -885,9 +885,9 @@ func (ssa *SQLStorageAuthority) CountCertificatesRange(ctx context.Context, star
 func (ssa *SQLStorageAuthority) CountPendingAuthorizations(ctx context.Context, regID int64) (count int, err error) {
 	err = ssa.dbMap.SelectOne(&count,
 		`SELECT count(1) FROM pendingAuthorizations
-     WHERE registrationID = :regID AND
-     expires > :now AND
-     status = :pending`,
+		WHERE registrationID = :regID AND
+		expires > :now AND
+		status = :pending`,
 		map[string]interface{}{
 			"regID":   regID,
 			"now":     ssa.clk.Now(),

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -885,11 +885,13 @@ func (ssa *SQLStorageAuthority) CountCertificatesRange(ctx context.Context, star
 func (ssa *SQLStorageAuthority) CountPendingAuthorizations(ctx context.Context, regID int64) (count int, err error) {
 	err = ssa.dbMap.SelectOne(&count,
 		`SELECT count(1) FROM pendingAuthorizations
-		 WHERE registrationID = :regID AND
-				expires > :now`,
+     WHERE registrationID = :regID AND
+     expires > :now AND
+     status = :pending`,
 		map[string]interface{}{
-			"regID": regID,
-			"now":   ssa.clk.Now(),
+			"regID":   regID,
+			"now":     ssa.clk.Now(),
+			"pending": string(core.StatusPending),
 		})
 	return
 }

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -152,6 +152,13 @@ func TestCountPendingAuthorizations(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't create new pending authorization")
 	count, err := sa.CountPendingAuthorizations(ctx, reg.ID)
 	test.AssertNotError(t, err, "Couldn't count pending authorizations")
+	test.AssertEquals(t, count, 0)
+
+	pendingAuthz.Status = core.StatusPending
+	pendingAuthz, err = sa.NewPendingAuthorization(ctx, pendingAuthz)
+	test.AssertNotError(t, err, "Couldn't create new pending authorization")
+	count, err = sa.CountPendingAuthorizations(ctx, reg.ID)
+	test.AssertNotError(t, err, "Couldn't count pending authorizations")
 	test.AssertEquals(t, count, 1)
 
 	fc.Add(2 * time.Hour)


### PR DESCRIPTION
`CountPendingAuthorizations` wasn't updated when we added authorization deactivation which means deactivated authorizations count towards the pending authorization limit. This PR adds a `AND status = 'pending'` clause to the existing SQL query.

Currently there is no index on the `status` column but as we are already filtering using the `registrationID, expires` index this doesn't have a significant impact on the query performance.

Fixes #2309.