### PR TITLE
Quick fix for flaky integration tests.

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -46,9 +46,9 @@ def start(race_detection):
     global processes
     forward()
     progs = [
+        'boulder-sa --config %s' % os.path.join(default_config_dir, "sa.json"),
         'boulder-wfe --config %s' % os.path.join(default_config_dir, "wfe.json"),
         'boulder-ra --config %s' % os.path.join(default_config_dir, "ra.json"),
-        'boulder-sa --config %s' % os.path.join(default_config_dir, "sa.json"),
         'boulder-ca --config %s' % os.path.join(default_config_dir, "ca.json"),
         'boulder-va --config %s' % os.path.join(default_config_dir, "va.json"),
         'boulder-publisher --config %s' % os.path.join(default_config_dir, "publisher.json"),


### PR DESCRIPTION
Until recently, no RPCs would be performed during integration tests until all
servers were up and running. In https://github.com/letsencrypt/boulder/pull/2246
we added code so that RA now calls SA.CountCertificatesRange immediately on
startup. This should be fine - the message should be queued by AMQP and get
handled when SA starts up, typically is less than 3 seconds. However, this
caused a flaky test failure in CI. It's possible in some of these cases that SA
is actually taking 3 seconds to start, or it's possible that there is a bug that
depends on start order.

This change moves the SA to start earlier, which seems to reduce flakiness but
is not a real fix to the problem.