### PR TITLE
Log the endpoint we are serving

### DIFF
--- a/wfe/context.go
+++ b/wfe/context.go
@@ -62,9 +62,6 @@ func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Extra:       make(map[string]interface{}, 0),
 	}
 	w.Header().Set("Boulder-Request-ID", logEvent.ID)
-	if r.URL != nil {
-		logEvent.Endpoint = r.URL.String()
-	}
 	defer th.logEvent(logEvent)
 
 	th.wfe.ServeHTTP(logEvent, w, r)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -153,6 +154,11 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h wfe
 				logEvent.ResponseNonce = nonce
 			} else {
 				logEvent.AddError("unable to make nonce: %s", err)
+			}
+
+			logEvent.Endpoint = pattern
+			if request.URL != nil {
+				logEvent.Endpoint = path.Join(logEvent.Endpoint, request.URL.Path)
 			}
 
 			switch request.Method {


### PR DESCRIPTION
We use `http.StripPrefix` so handlers don't have to deal with stripping the boring part of URLs that they don't need (#1881). This caused either an empty string or only the ID from the path to be logged as the `endpoint` which was not useful for debugging. By doing the logging in the constructor instead we still have access to the prefix part of the path and can use it to reconstruct the full path.

Fixes #2328.