### PR TITLE
Removes AQMP publishing support from ocsp-updater.

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -589,15 +589,9 @@ func setupClients(c cmd.OCSPUpdaterConfig, stats metrics.Scope) (
 	cac, err := rpc.NewCertificateAuthorityClient(clientName, amqpConf, stats)
 	cmd.FailOnError(err, "Unable to create CA client")
 
-	var pubc core.Publisher
-	if c.Publisher != nil {
-		conn, err := bgrpc.ClientSetup(c.Publisher, stats)
-		cmd.FailOnError(err, "Failed to load credentials and create connection to service")
-		pubc = bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn), c.Publisher.Timeout.Duration)
-	} else {
-		pubc, err = rpc.NewPublisherClient(clientName, amqpConf, stats)
-		cmd.FailOnError(err, "Unable to create Publisher client")
-	}
+	conn, err := bgrpc.ClientSetup(c.Publisher, stats)
+	cmd.FailOnError(err, "Failed to load credentials and create connection to service")
+	pubc := bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn), c.Publisher.Timeout.Duration)
 	sac, err := rpc.NewStorageAuthorityClient(clientName, amqpConf, stats)
 	cmd.FailOnError(err, "Unable to create SA client")
 	return cac, pubc, sac

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -15,6 +15,13 @@
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
     "debugAddr": "localhost:8006",
+    "publisher": {
+      "serverAddresses": ["boulder:9091"],
+      "serverIssuerPath": "test/grpc-creds/minica.pem",
+      "clientCertificatePath": "test/grpc-creds/boulder-client/cert.pem",
+      "clientKeyPath": "test/grpc-creds/boulder-client/key.pem",
+      "timeout": "10s"
+    },
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
@@ -24,10 +31,6 @@
       },
       "CA": {
         "server": "CA.server",
-        "rpcTimeout": "15s"
-      },
-      "Publisher": {
-        "server": "Publisher.server",
         "rpcTimeout": "15s"
       }
     }

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -3,6 +3,15 @@
     "maxConcurrentRPCServerRequests": 16,
     "submissionTimeout": "5s",
     "debugAddr": "localhost:8009",
+    "grpc": {
+      "address": "boulder:9091",
+      "clientIssuerPath": "test/grpc-creds/minica.pem",
+      "serverCertificatePath": "test/grpc-creds/boulder-server/cert.pem",
+      "serverKeyPath": "test/grpc-creds/boulder-server/key.pem",
+      "clientNames": [
+        "boulder-client"
+      ]
+    },
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,


### PR DESCRIPTION
The ocsp-updater has been switched over to the `config-next/` usage of gRPC for submitting to the publisher service. This commit removes the legacy AQMP support for such.

This does not remove the `rpc/rpc-wrappers.go` implementation of `NewPublisherClient` at this point because it appears `boulder-ca` may still be using it.