### PR TITLE
Make expiration mailer log standard startup format.

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -353,7 +353,7 @@ func main() {
 	stats, logger := cmd.StatsAndLogging(c.Statsd, c.Syslog)
 	scope := metrics.NewStatsdScope(stats, "Expiration")
 	defer logger.AuditPanic()
-	logger.Info(clientName)
+	logger.Info(cmd.VersionString(clientName))
 
 	if *certLimit > 0 {
 		c.Mailer.CertLimit = *certLimit


### PR DESCRIPTION
Previously it was just logging its name, not its version.