### PR TITLE
Updates `clock` to v1.1.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -132,7 +132,7 @@
 		},
 		{
 			"ImportPath": "github.com/jmhodges/clock",
-			"Comment": "v1.0-4-g880ee4c",
+			"Comment": "v1.1",
 			"Rev": "880ee4c335489bc78d01e4d0a254ae880734bc15"
 		},
 		{


### PR DESCRIPTION
This PR updates the `github.com/jmhodges/clock` dependency to the 1.1 release instead of a development commit ahead of the 1.0 release.

There's no update to the `vendor/` directory as the 1.1 release is the same development commit we had checked out, there is no content change to the vendored code.

Per `CONTRIBUTING.md` I verified the unit tests pass:
```
daniel@XXXXXX:~/go/src/github.com/jmhodges/clock$ git show -s
commit 880ee4c335489bc78d01e4d0a254ae880734bc15
Author: Roland Bracewell Shoemaker <rolandshoemaker@gmail.com>
Date:   Mon Apr 18 12:11:01 2016 -0700

    Add Since (#5)
daniel@XXXXXX:~/go/src/github.com/jmhodges/clock$ go test ./...
ok  	github.com/jmhodges/clock	0.001s
```

![fresh clocks](https://media.giphy.com/media/iwJMmqOiqzss0/giphy.gif)