### PR TITLE
Update prometheus client_golang dep to 0.8.0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -163,13 +163,13 @@
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",
-			"Comment": "0.7.0-129-g3fb8ace",
-			"Rev": "3fb8ace93bc4ccddea55af62320c2fd109252880"
+			"Comment": "v0.8.0",
+			"Rev": "c5b7fccd204277076155f10851dad72b76a49317"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus/promhttp",
-			"Comment": "0.7.0-129-g3fb8ace",
-			"Rev": "3fb8ace93bc4ccddea55af62320c2fd109252880"
+			"Comment": "v0.8.0",
+			"Rev": "c5b7fccd204277076155f10851dad72b76a49317"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_model/go",

--- a/vendor/github.com/prometheus/client_golang/AUTHORS.md
+++ b/vendor/github.com/prometheus/client_golang/AUTHORS.md
@@ -1,0 +1,18 @@
+The Prometheus project was started by Matt T. Proud (emeritus) and
+Julius Volz in 2012.
+
+Maintainers of this repository:
+
+* Björn Rabenstein <beorn@soundcloud.com>
+
+The following individuals have contributed code to this repository
+(listed in alphabetical order):
+
+* Bernerd Schaefer <bj.schaefer@gmail.com>
+* Björn Rabenstein <beorn@soundcloud.com>
+* Daniel Bornkessel <daniel@soundcloud.com>
+* Jeff Younker <jeff@drinktomi.com>
+* Julius Volz <julius.volz@gmail.com>
+* Matt T. Proud <matt.proud@gmail.com>
+* Tobias Schmidt <ts@soundcloud.com>
+

--- a/vendor/github.com/prometheus/client_golang/prometheus/counter.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/counter.go
@@ -30,6 +30,15 @@ type Counter interface {
 	Metric
 	Collector
 
+	// Set is used to set the Counter to an arbitrary value. It is only used
+	// if you have to transfer a value from an external counter into this
+	// Prometheus metric. Do not use it for regular handling of a
+	// Prometheus counter (as it can be used to break the contract of
+	// monotonically increasing values).
+	//
+	// Deprecated: Use NewConstMetric to create a counter for an external
+	// value. A Counter should never be set.
+	Set(float64)
 	// Inc increments the counter by 1.
 	Inc()
 	// Add adds the given value to the counter. It panics if the value is <

--- a/vendor/github.com/prometheus/client_golang/prometheus/desc.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/desc.go
@@ -78,7 +78,7 @@ type Desc struct {
 	// Help string. Each Desc with the same fqName must have the same
 	// dimHash.
 	dimHash uint64
-	// err is an error that occurred during construction. It is reported on
+	// err is an error that occured during construction. It is reported on
 	// registration time.
 	err error
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/http.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/http.go
@@ -62,7 +62,7 @@ func giveBuf(buf *bytes.Buffer) {
 //
 // Deprecated: Please note the issues described in the doc comment of
 // InstrumentHandler. You might want to consider using promhttp.Handler instead
-// (which is not instrumented).
+// (which is non instrumented).
 func Handler() http.Handler {
 	return InstrumentHandler("prometheus", UninstrumentedHandler())
 }
@@ -245,52 +245,34 @@ func InstrumentHandlerFuncWithOpts(opts SummaryOpts, handlerFunc func(http.Respo
 		},
 		instLabels,
 	)
-	if err := Register(reqCnt); err != nil {
-		if are, ok := err.(AlreadyRegisteredError); ok {
-			reqCnt = are.ExistingCollector.(*CounterVec)
-		} else {
-			panic(err)
-		}
-	}
 
 	opts.Name = "request_duration_microseconds"
 	opts.Help = "The HTTP request latencies in microseconds."
 	reqDur := NewSummary(opts)
-	if err := Register(reqDur); err != nil {
-		if are, ok := err.(AlreadyRegisteredError); ok {
-			reqDur = are.ExistingCollector.(Summary)
-		} else {
-			panic(err)
-		}
-	}
 
 	opts.Name = "request_size_bytes"
 	opts.Help = "The HTTP request sizes in bytes."
 	reqSz := NewSummary(opts)
-	if err := Register(reqSz); err != nil {
-		if are, ok := err.(AlreadyRegisteredError); ok {
-			reqSz = are.ExistingCollector.(Summary)
-		} else {
-			panic(err)
-		}
-	}
 
 	opts.Name = "response_size_bytes"
 	opts.Help = "The HTTP response sizes in bytes."
 	resSz := NewSummary(opts)
-	if err := Register(resSz); err != nil {
-		if are, ok := err.(AlreadyRegisteredError); ok {
-			resSz = are.ExistingCollector.(Summary)
-		} else {
-			panic(err)
-		}
-	}
+
+	regReqCnt := MustRegisterOrGet(reqCnt).(*CounterVec)
+	regReqDur := MustRegisterOrGet(reqDur).(Summary)
+	regReqSz := MustRegisterOrGet(reqSz).(Summary)
+	regResSz := MustRegisterOrGet(resSz).(Summary)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		now := time.Now()
 
 		delegate := &responseWriterDelegator{ResponseWriter: w}
-		out := computeApproximateRequestSize(r)
+		out := make(chan int)
+		urlLen := 0
+		if r.URL != nil {
+			urlLen = len(r.URL.String())
+		}
+		go computeApproximateRequestSize(r, out, urlLen)
 
 		_, cn := w.(http.CloseNotifier)
 		_, fl := w.(http.Flusher)
@@ -308,44 +290,30 @@ func InstrumentHandlerFuncWithOpts(opts SummaryOpts, handlerFunc func(http.Respo
 
 		method := sanitizeMethod(r.Method)
 		code := sanitizeCode(delegate.status)
-		reqCnt.WithLabelValues(method, code).Inc()
-		reqDur.Observe(elapsed)
-		resSz.Observe(float64(delegate.written))
-		reqSz.Observe(float64(<-out))
+		regReqCnt.WithLabelValues(method, code).Inc()
+		regReqDur.Observe(elapsed)
+		regResSz.Observe(float64(delegate.written))
+		regReqSz.Observe(float64(<-out))
 	})
 }
 
-func computeApproximateRequestSize(r *http.Request) <-chan int {
-	// Get URL length in current go routine for avoiding a race condition.
-	// HandlerFunc that runs in parallel may modify the URL.
-	s := 0
-	if r.URL != nil {
-		s += len(r.URL.String())
+func computeApproximateRequestSize(r *http.Request, out chan int, s int) {
+	s += len(r.Method)
+	s += len(r.Proto)
+	for name, values := range r.Header {
+		s += len(name)
+		for _, value := range values {
+			s += len(value)
+		}
 	}
+	s += len(r.Host)
 
-	out := make(chan int, 1)
+	// N.B. r.Form and r.MultipartForm are assumed to be included in r.URL.
 
-	go func() {
-		s += len(r.Method)
-		s += len(r.Proto)
-		for name, values := range r.Header {
-			s += len(name)
-			for _, value := range values {
-				s += len(value)
-			}
-		}
-		s += len(r.Host)
-
-		// N.B. r.Form and r.MultipartForm are assumed to be included in r.URL.
-
-		if r.ContentLength != -1 {
-			s += int(r.ContentLength)
-		}
-		out <- s
-		close(out)
-	}()
-
-	return out
+	if r.ContentLength != -1 {
+		s += int(r.ContentLength)
+	}
+	out <- s
 }
 
 type responseWriterDelegator struct {

--- a/vendor/github.com/prometheus/client_golang/prometheus/process_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/process_collector.go
@@ -19,10 +19,10 @@ type processCollector struct {
 	pid             int
 	collectFn       func(chan<- Metric)
 	pidFn           func() (int, error)
-	cpuTotal        *Desc
-	openFDs, maxFDs *Desc
-	vsize, rss      *Desc
-	startTime       *Desc
+	cpuTotal        Counter
+	openFDs, maxFDs Gauge
+	vsize, rss      Gauge
+	startTime       Gauge
 }
 
 // NewProcessCollector returns a collector which exports the current state of
@@ -48,36 +48,36 @@ func NewProcessCollectorPIDFn(
 		pidFn:     pidFn,
 		collectFn: func(chan<- Metric) {},
 
-		cpuTotal: NewDesc(
-			namespace+"_process_cpu_seconds_total",
-			"Total user and system CPU time spent in seconds.",
-			nil, nil,
-		),
-		openFDs: NewDesc(
-			namespace+"_process_open_fds",
-			"Number of open file descriptors.",
-			nil, nil,
-		),
-		maxFDs: NewDesc(
-			namespace+"_process_max_fds",
-			"Maximum number of open file descriptors.",
-			nil, nil,
-		),
-		vsize: NewDesc(
-			namespace+"_process_virtual_memory_bytes",
-			"Virtual memory size in bytes.",
-			nil, nil,
-		),
-		rss: NewDesc(
-			namespace+"_process_resident_memory_bytes",
-			"Resident memory size in bytes.",
-			nil, nil,
-		),
-		startTime: NewDesc(
-			namespace+"_process_start_time_seconds",
-			"Start time of the process since unix epoch in seconds.",
-			nil, nil,
-		),
+		cpuTotal: NewCounter(CounterOpts{
+			Namespace: namespace,
+			Name:      "process_cpu_seconds_total",
+			Help:      "Total user and system CPU time spent in seconds.",
+		}),
+		openFDs: NewGauge(GaugeOpts{
+			Namespace: namespace,
+			Name:      "process_open_fds",
+			Help:      "Number of open file descriptors.",
+		}),
+		maxFDs: NewGauge(GaugeOpts{
+			Namespace: namespace,
+			Name:      "process_max_fds",
+			Help:      "Maximum number of open file descriptors.",
+		}),
+		vsize: NewGauge(GaugeOpts{
+			Namespace: namespace,
+			Name:      "process_virtual_memory_bytes",
+			Help:      "Virtual memory size in bytes.",
+		}),
+		rss: NewGauge(GaugeOpts{
+			Namespace: namespace,
+			Name:      "process_resident_memory_bytes",
+			Help:      "Resident memory size in bytes.",
+		}),
+		startTime: NewGauge(GaugeOpts{
+			Namespace: namespace,
+			Name:      "process_start_time_seconds",
+			Help:      "Start time of the process since unix epoch in seconds.",
+		}),
 	}
 
 	// Set up process metric collection if supported by the runtime.
@@ -90,12 +90,12 @@ func NewProcessCollectorPIDFn(
 
 // Describe returns all descriptions of the collector.
 func (c *processCollector) Describe(ch chan<- *Desc) {
-	ch <- c.cpuTotal
-	ch <- c.openFDs
-	ch <- c.maxFDs
-	ch <- c.vsize
-	ch <- c.rss
-	ch <- c.startTime
+	ch <- c.cpuTotal.Desc()
+	ch <- c.openFDs.Desc()
+	ch <- c.maxFDs.Desc()
+	ch <- c.vsize.Desc()
+	ch <- c.rss.Desc()
+	ch <- c.startTime.Desc()
 }
 
 // Collect returns the current state of all metrics of the collector.
@@ -117,19 +117,26 @@ func (c *processCollector) processCollect(ch chan<- Metric) {
 	}
 
 	if stat, err := p.NewStat(); err == nil {
-		ch <- MustNewConstMetric(c.cpuTotal, CounterValue, stat.CPUTime())
-		ch <- MustNewConstMetric(c.vsize, GaugeValue, float64(stat.VirtualMemory()))
-		ch <- MustNewConstMetric(c.rss, GaugeValue, float64(stat.ResidentMemory()))
+		c.cpuTotal.Set(stat.CPUTime())
+		ch <- c.cpuTotal
+		c.vsize.Set(float64(stat.VirtualMemory()))
+		ch <- c.vsize
+		c.rss.Set(float64(stat.ResidentMemory()))
+		ch <- c.rss
+
 		if startTime, err := stat.StartTime(); err == nil {
-			ch <- MustNewConstMetric(c.startTime, GaugeValue, startTime)
+			c.startTime.Set(startTime)
+			ch <- c.startTime
 		}
 	}
 
 	if fds, err := p.FileDescriptorsLen(); err == nil {
-		ch <- MustNewConstMetric(c.openFDs, GaugeValue, float64(fds))
+		c.openFDs.Set(float64(fds))
+		ch <- c.openFDs
 	}
 
 	if limits, err := p.NewLimits(); err == nil {
-		ch <- MustNewConstMetric(c.maxFDs, GaugeValue, float64(limits.OpenFiles))
+		c.maxFDs.Set(float64(limits.OpenFiles))
+		ch <- c.maxFDs
 	}
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -152,6 +152,38 @@ func MustRegister(cs ...Collector) {
 	DefaultRegisterer.MustRegister(cs...)
 }
 
+// RegisterOrGet registers the provided Collector with the DefaultRegisterer and
+// returns the Collector, unless an equal Collector was registered before, in
+// which case that Collector is returned.
+//
+// Deprecated: RegisterOrGet is merely a convenience function for the
+// implementation as described in the documentation for
+// AlreadyRegisteredError. As the use case is relatively rare, this function
+// will be removed in a future version of this package to clean up the
+// namespace.
+func RegisterOrGet(c Collector) (Collector, error) {
+	if err := Register(c); err != nil {
+		if are, ok := err.(AlreadyRegisteredError); ok {
+			return are.ExistingCollector, nil
+		}
+		return nil, err
+	}
+	return c, nil
+}
+
+// MustRegisterOrGet behaves like RegisterOrGet but panics instead of returning
+// an error.
+//
+// Deprecated: This is deprecated for the same reason RegisterOrGet is. See
+// there for details.
+func MustRegisterOrGet(c Collector) Collector {
+	c, err := RegisterOrGet(c)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
 // Unregister removes the registration of the provided Collector from the
 // DefaultRegisterer.
 //
@@ -167,6 +199,25 @@ type GathererFunc func() ([]*dto.MetricFamily, error)
 // Gather implements Gatherer.
 func (gf GathererFunc) Gather() ([]*dto.MetricFamily, error) {
 	return gf()
+}
+
+// SetMetricFamilyInjectionHook replaces the DefaultGatherer with one that
+// gathers from the previous DefaultGatherers but then merges the MetricFamily
+// protobufs returned from the provided hook function with the MetricFamily
+// protobufs returned from the original DefaultGatherer.
+//
+// Deprecated: This function manipulates the DefaultGatherer variable. Consider
+// the implications, i.e. don't do this concurrently with any uses of the
+// DefaultGatherer. In the rare cases where you need to inject MetricFamily
+// protobufs directly, it is recommended to use a custom Registry and combine it
+// with a custom Gatherer using the Gatherers type (see
+// there). SetMetricFamilyInjectionHook only exists for compatibility reasons
+// with previous versions of this package.
+func SetMetricFamilyInjectionHook(hook func() []*dto.MetricFamily) {
+	DefaultGatherer = Gatherers{
+		DefaultGatherer,
+		GathererFunc(func() ([]*dto.MetricFamily, error) { return hook(), nil }),
+	}
 }
 
 // AlreadyRegisteredError is returned by the Register method if the Collector to
@@ -396,7 +447,7 @@ func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 
 	// Drain metricChan in case of premature return.
 	defer func() {
-		for range metricChan {
+		for _ = range metricChan {
 		}
 	}()
 
@@ -632,7 +683,7 @@ func (s metricSorter) Less(i, j int) bool {
 	return s[i].GetTimestampMs() < s[j].GetTimestampMs()
 }
 
-// normalizeMetricFamilies returns a MetricFamily slice with empty
+// normalizeMetricFamilies returns a MetricFamily slice whith empty
 // MetricFamilies pruned and the remaining MetricFamilies sorted by name within
 // the slice, with the contained Metrics sorted within each MetricFamily.
 func normalizeMetricFamilies(metricFamiliesByName map[string]*dto.MetricFamily) []*dto.MetricFamily {


### PR DESCRIPTION
This PR updates the `github.com/prometheus/client_golang` dependency to the v0.8.0 release tag.

For future note, `godep update github.com/prometheus/client_golang/prometheus/promhttp` doesn't work correctly for this package due to the nesting structure (See https://github.com/tools/godep/issues/164). This can be worked around by using `godep update github.com/prometheus/client_golang/...` instead ¯\\\_(ツ)\_/¯

Per `CONTRIBUTING.md` I verified the unit tests pass:

```
daniel@XXXXXX:~/go/src/github.com/prometheus/client_golang$ git show -s
commit c5b7fccd204277076155f10851dad72b76a49317
Merge: a4d14b3 1b26087
Author: Björn Rabenstein <bjoern@rabenste.in>
Date:   Wed Aug 17 17:48:24 2016 +0200

    Merge pull request #226 from prometheus/beorn7/alloc
    
    Bring back zero-alloc label-value access for metric vecs
daniel@XXXXXX:~/go/src/github.com/prometheus/client_golang$ go test ./...
ok  	github.com/prometheus/client_golang/api/prometheus	0.003s
?   	github.com/prometheus/client_golang/examples/random	[no test files]
?   	github.com/prometheus/client_golang/examples/simple	[no test files]
ok  	github.com/prometheus/client_golang/prometheus	28.661s
ok  	github.com/prometheus/client_golang/prometheus/promhttp	0.013s
ok  	github.com/prometheus/client_golang/prometheus/push	0.007s
```