### PR TITLE
Removes `err` return from `wfe.Handler()`.

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -118,8 +118,7 @@ func main() {
 
 	// Set up paths
 	wfe.BaseURL = c.Common.BaseURL
-	h, err := wfe.Handler()
-	cmd.FailOnError(err, "Problem setting up HTTP handlers")
+	h := wfe.Handler()
 
 	httpMonitor := metrics.NewHTTPMonitor(scope, h)
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -275,7 +275,7 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 
 // Handler returns an http.Handler that uses various functions for
 // various ACME-specified paths.
-func (wfe *WebFrontEndImpl) Handler() (http.Handler, error) {
+func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	m := http.NewServeMux()
 	wfe.HandleFunc(m, directoryPath, wfe.Directory, "GET")
 	wfe.HandleFunc(m, newRegPath, wfe.NewRegistration, "POST")
@@ -300,7 +300,7 @@ func (wfe *WebFrontEndImpl) Handler() (http.Handler, error) {
 		clk: clock.Default(),
 		wfe: wfeHandlerFunc(wfe.Index),
 	})
-	return m, nil
+	return m
 }
 
 // Method implementations

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -611,8 +611,7 @@ func TestDirectory(t *testing.T) {
 	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	wfe.BaseURL = "http://localhost:4300"
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 
 	responseWriter := httptest.NewRecorder()
 
@@ -646,8 +645,7 @@ func TestRelativeDirectory(t *testing.T) {
 	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
 	defer features.Reset()
 	wfe, _ := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 
 	dirTests := []struct {
 		host        string
@@ -692,8 +690,7 @@ func TestRelativeDirectory(t *testing.T) {
 //  - RA returns with a failure
 func TestIssueCertificate(t *testing.T) {
 	wfe, fc := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 	mockLog := wfe.log.(*blog.Mock)
 
 	// The mock CA we use always returns the same test certificate, with a Not
@@ -1004,8 +1001,6 @@ func TestNewECDSARegistration(t *testing.T) {
 // a populated reg object will be returned.
 func TestEmptyRegistration(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	_, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
 	responseWriter := httptest.NewRecorder()
 
 	// Test Key 1 is mocked in the mock StorageAuthority used in setupWFE to
@@ -1045,9 +1040,7 @@ func TestEmptyRegistration(t *testing.T) {
 
 func TestNewRegistration(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
-
+	mux := wfe.Handler()
 	key, err := jose.LoadPrivateKey([]byte(test2KeyPrivatePEM))
 	test.AssertNotError(t, err, "Failed to load key")
 	rsaKey, ok := key.(*rsa.PrivateKey)
@@ -1417,8 +1410,7 @@ func TestRevokeCertificateWithAuthz(t *testing.T) {
 
 func TestAuthorization(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 
 	responseWriter := httptest.NewRecorder()
 
@@ -1524,8 +1516,7 @@ func TestRegistration(t *testing.T) {
 	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
 	defer features.Reset()
 	wfe, _ := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 	responseWriter := httptest.NewRecorder()
 
 	// Test invalid method
@@ -1658,8 +1649,7 @@ func TestIssuer(t *testing.T) {
 
 func TestGetCertificate(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 
 	wfe.CertCacheDuration = time.Second * 10
 	wfe.CertNoCacheExpirationWindow = time.Hour * 24 * 7
@@ -1819,7 +1809,7 @@ func TestGetCertificateHEADHasCorrectBodyLength(t *testing.T) {
 	mockLog := wfe.log.(*blog.Mock)
 	mockLog.Clear()
 
-	mux, _ := wfe.Handler()
+	mux := wfe.Handler()
 	s := httptest.NewServer(mux)
 	// TODO(#1989): Close s
 	req, _ := http.NewRequest("HEAD", s.URL+"/acme/cert/0000000000000000000000000000000000b2", nil)
@@ -1855,8 +1845,7 @@ func TestVerifyPOSTInvalidJWK(t *testing.T) {
 
 func TestHeaderBoulderRequestId(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 	responseWriter := httptest.NewRecorder()
 
 	mux.ServeHTTP(responseWriter, &http.Request{
@@ -1870,8 +1859,7 @@ func TestHeaderBoulderRequestId(t *testing.T) {
 
 func TestHeaderBoulderRequester(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	mux, err := wfe.Handler()
-	test.AssertNotError(t, err, "Problem setting up HTTP handlers")
+	mux := wfe.Handler()
 	responseWriter := httptest.NewRecorder()
 
 	// create a signed request

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1479,7 +1479,7 @@ func TestAuthorization(t *testing.T) {
 	assertJSONEquals(t, responseWriter.Body.String(), `{"identifier":{"type":"dns","value":"test.com"}}`)
 
 	var authz core.Authorization
-	err = json.Unmarshal([]byte(responseWriter.Body.String()), &authz)
+	err := json.Unmarshal([]byte(responseWriter.Body.String()), &authz)
 	test.AssertNotError(t, err, "Couldn't unmarshal returned authorization object")
 
 	// Expired authorizations should be inaccessible


### PR DESCRIPTION
There was no possibility for a non-nil `error` to be returned from `wfe.Handler()`. This commit removes the `error` return and updates all of the callers.