### PR TITLE
Fixes unkeyed fields `go vet` warnings.

### DIFF
--- a/cdr/resolver_test.go
+++ b/cdr/resolver_test.go
@@ -24,8 +24,8 @@ var log = blog.UseMock()
 
 func TestParseAnswer(t *testing.T) {
 	as := []core.GPDNSAnswer{
-		{"a", 257, 10, "0 issue \"ca.com\""},
-		{"b", 1, 10, "1.1.1.1"},
+		{Name: "a", Type: 257, TTL: 10, Data: "0 issue \"ca.com\""},
+		{Name: "b", Type: 1, TTL: 10, Data: "1.1.1.1"},
 	}
 
 	r, err := parseAnswer(as)

--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -188,7 +188,7 @@ func (tc *serverTransportCredentials) ServerHandshake(rawConn net.Conn) (net.Con
 		return nil, nil, err
 	}
 
-	return conn, credentials.TLSInfo{conn.ConnectionState()}, nil
+	return conn, credentials.TLSInfo{State: conn.ConnectionState()}, nil
 }
 
 // ClientHandshake is not implemented for a `serverTransportCredentials`, use

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -458,7 +458,7 @@ func GPDNSHandler(w http.ResponseWriter, r *http.Request) {
 		resp := core.GPDNSResponse{
 			Status: dns.RcodeSuccess,
 			Answer: []core.GPDNSAnswer{
-				{r.URL.Query().Get("name"), 257, 10, "0 issue \"ca.com\""},
+				{Name: r.URL.Query().Get("name"), Type: 257, TTL: 10, Data: "0 issue \"ca.com\""},
 			},
 		}
 		data, err := json.Marshal(resp)
@@ -478,7 +478,7 @@ func GPDNSHandler(w http.ResponseWriter, r *http.Request) {
 		resp := core.GPDNSResponse{
 			Status: dns.RcodeSuccess,
 			Answer: []core.GPDNSAnswer{
-				{r.URL.Query().Get("name"), 257, 10, strconv.Itoa(mrand.Int())},
+				{Name: r.URL.Query().Get("name"), Type: 257, TTL: 10, Data: strconv.Itoa(mrand.Int())},
 			},
 		}
 		data, err := json.Marshal(resp)


### PR DESCRIPTION
Fixes three files that were throwing "composite literal uses unkeyed fields" errors under an updated go vet.