### PR TITLE
Updates pkcs11key dep to v1.0.0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -142,7 +142,8 @@
 		},
 		{
 			"ImportPath": "github.com/letsencrypt/pkcs11key",
-			"Rev": "bda7cf218ae2225f745ead23f9b65901dfebbf45"
+			"Comment": "v1.0.0",
+			"Rev": "c47dab18ddd8c4d4267661870d3ba331cddc57c9"
 		},
 		{
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",

--- a/vendor/github.com/letsencrypt/pkcs11key/README.md
+++ b/vendor/github.com/letsencrypt/pkcs11key/README.md
@@ -1,0 +1,12 @@
+PKCS11Key
+========
+
+The pkcs11key package implements a crypto.Signer interface for a PKCS#11 private key.
+
+[![Build Status](https://travis-ci.org/letsencrypt/pkcs11key.svg)](https://travis-ci.org/letsencrypt/pkcs11key)
+
+## License summary
+Some of this code is Copyright (c) 2014 CloudFlare Inc., some is Copyright (c)
+2015 Internet Security Research Group.
+
+The code is licensed under the BSD 2-clause license. See the LICENSE file for more details.

--- a/vendor/github.com/letsencrypt/pkcs11key/key.go
+++ b/vendor/github.com/letsencrypt/pkcs11key/key.go
@@ -133,7 +133,7 @@ func initialize(modulePath string) (ctx, error) {
 
 	newModule := pkcs11.New(modulePath)
 	if newModule == nil {
-		return nil, fmt.Errorf("unable to load PKCS#11 module")
+		return nil, fmt.Errorf("unable to load PKCS#11 module from %q", modulePath)
 	}
 
 	err := newModule.Initialize()


### PR DESCRIPTION
This PR updates the `github.com/letsencrypt/pkcs11key` dependency to v1.0.0.

Per `CONTRIBUTING.md` I checked the unit tests pass:
```
daniel@XXXXX:~/go/src/github.com/letsencrypt/pkcs11key$ git show -s
commit c47dab18ddd8c4d4267661870d3ba331cddc57c9
Author: Jacob Hoffman-Andrews <github@hoffman-andrews.com>
Date:   Fri Sep 9 15:23:00 2016 -0400

    Echo path when failing to load module. (#6)

daniel@XXXXX:~/go/src/github.com/letsencrypt/pkcs11key$ go test ./...
ok  	github.com/letsencrypt/pkcs11key	0.002s
ok  	github.com/letsencrypt/pkcs11key/uri	0.002s
```