### PR TITLE
Go Report Card low hanging fruit

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -391,7 +391,7 @@ func TestOCSP(t *testing.T) {
 	test.AssertEquals(t, parsed.SerialNumber.Cmp(parsedCert.SerialNumber), 0)
 
 	// Test that signatures are checked.
-	ocspResp, err = ca.GenerateOCSP(ctx, core.OCSPSigningRequest{
+	_, err = ca.GenerateOCSP(ctx, core.OCSPSigningRequest{
 		CertDER: append(cert.DER, byte(0)),
 		Status:  string(core.OCSPStatusGood),
 	})

--- a/cdr/resolver.go
+++ b/cdr/resolver.go
@@ -145,7 +145,7 @@ func (cdr *CAADistributedResolver) queryCAA(ctx context.Context, url string, ic 
 		if respObj.Comment != "" {
 			return nil, fmt.Errorf("Query failed with %s: %s", dns.RcodeToString[respObj.Status], respObj.Comment)
 		}
-		return nil, fmt.Errorf("Query failed wtih %s", dns.RcodeToString[respObj.Status])
+		return nil, fmt.Errorf("Query failed with %s", dns.RcodeToString[respObj.Status])
 	}
 
 	return parseAnswer(respObj.Answer)

--- a/cmd/contact-exporter/main.go
+++ b/cmd/contact-exporter/main.go
@@ -62,10 +62,10 @@ func writeContacts(contactsList []contact, outfile string) error {
 
 	if outfile != "" {
 		return ioutil.WriteFile(outfile, data, 0644)
-	} else {
-		fmt.Printf("%s", data)
-		return nil
 	}
+
+	fmt.Printf("%s", data)
+	return nil
 }
 
 const usageIntro = `

--- a/cmd/contact-exporter/main_test.go
+++ b/cmd/contact-exporter/main_test.go
@@ -83,13 +83,13 @@ func TestFindContacts(t *testing.T) {
 
 func exampleContacts() []contact {
 	return []contact{
-		contact{
+		{
 			ID: 1,
 		},
-		contact{
+		{
 			ID: 2,
 		},
-		contact{
+		{
 			ID: 3,
 		},
 	}

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -304,27 +304,27 @@ type mockEmailResolver struct{}
 func (bs mockEmailResolver) SelectOne(output interface{}, _ string, args ...interface{}) error {
 	// The "db" is just a list in memory
 	db := []contactJSON{
-		contactJSON{
+		{
 			ID:      1,
 			Contact: []byte(`["mailto:example@example.com"]`),
 		},
-		contactJSON{
+		{
 			ID:      2,
 			Contact: []byte(`["mailto:test-example-updated@example.com"]`),
 		},
-		contactJSON{
+		{
 			ID:      3,
 			Contact: []byte(`["mailto:test-test-test@example.com"]`),
 		},
-		contactJSON{
+		{
 			ID:      4,
 			Contact: []byte(`["mailto:example-example-example@example.com"]`),
 		},
-		contactJSON{
+		{
 			ID:      5,
 			Contact: []byte(`["mailto:youve.got.mail@example.com"]`),
 		},
-		contactJSON{
+		{
 			ID:      6,
 			Contact: []byte(`["mailto:mail@example.com"]`),
 		},
@@ -367,18 +367,18 @@ func TestResolveEmails(t *testing.T) {
 	// more test cases here you must also add the corresponding DB result in the
 	// mock.
 	regs := []regID{
-		regID{
+		{
 			ID: 1,
 		},
-		regID{
+		{
 			ID: 2,
 		},
-		regID{
+		{
 			ID: 3,
 		},
 		// This registration ID deliberately doesn't exist in the mock data to make
 		// sure this case is handled gracefully
-		regID{
+		{
 			ID: 999,
 		},
 	}

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -91,6 +91,7 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *gorp.DbMap, cloc
 		"",
 		blog.NewMock(),
 	)
+	test.AssertNotError(t, err, "Failed to create newUpdater")
 
 	return updater, sa, dbMap, fc, cleanUp
 }

--- a/core/objects.go
+++ b/core/objects.go
@@ -466,7 +466,7 @@ type CertificateStatus struct {
 
 	// For performance reasons[0] we duplicate the `Expires` field of the
 	// `Certificates` object/table in `CertificateStatus` to avoid a costly `JOIN`
-	// later on just to retreive this `Time` value. This helps both the OCSP
+	// later on just to retrieve this `Time` value. This helps both the OCSP
 	// updater and the expiration-mailer stay performant.
 	//
 	// Similarly, we add an explicit `IsExpired` boolean to `CertificateStatus`

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -84,7 +84,7 @@ func TestKeyDigest(t *testing.T) {
 	test.Assert(t, err == nil && digest == JWK1Digest, "Failed to digest bare key")
 
 	// Test with unknown key type
-	digest, err = KeyDigest(struct{}{})
+	_, err = KeyDigest(struct{}{})
 	test.Assert(t, err != nil, "Should have rejected unknown key type")
 }
 

--- a/features/features.go
+++ b/features/features.go
@@ -81,7 +81,7 @@ func Enabled(n FeatureFlag) bool {
 	defer fMu.RUnlock()
 	v, present := features[n]
 	if !present {
-		panic(fmt.Sprintf("feature '%s' doesn't exist", n))
+		panic(fmt.Sprintf("feature '%s' doesn't exist", n.String()))
 	}
 	return v
 }

--- a/grpc/creds/creds_test.go
+++ b/grpc/creds/creds_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestServerTransportCredentials(t *testing.T) {
 	acceptedSANs := map[string]struct{}{
-		"boulder-client": struct{}{},
+		"boulder-client": {},
 	}
 	goodCert, err := core.LoadCert("../../test/grpc-creds/boulder-client/cert.pem")
 	test.AssertNotError(t, err, "core.LoadCert('../../grpc-creds/boulder-client/cert.pem') failed")
@@ -62,7 +62,7 @@ func TestServerTransportCredentials(t *testing.T) {
 	// that has a leaf certificate containing an IP address SAN present in the
 	// accepted list.
 	acceptedIPSans := map[string]struct{}{
-		"127.0.0.1": struct{}{},
+		"127.0.0.1": {},
 	}
 	bcreds = &serverTransportCredentials{servTLSConfig, acceptedIPSans}
 	err = bcreds.validateClient(rightState)

--- a/prefixdb/db.go
+++ b/prefixdb/db.go
@@ -1,4 +1,4 @@
-package prefixedDatabase
+package prefixdb
 
 import "database/sql/driver"
 

--- a/prefixdb/db_test.go
+++ b/prefixdb/db_test.go
@@ -1,4 +1,4 @@
-package prefixedDatabase
+package prefixdb
 
 import (
 	"database/sql"

--- a/prefixedDatabase/db.go
+++ b/prefixedDatabase/db.go
@@ -1,4 +1,4 @@
-package prefixed_db
+package prefixedDatabase
 
 import "database/sql/driver"
 

--- a/prefixedDatabase/db_test.go
+++ b/prefixedDatabase/db_test.go
@@ -1,4 +1,4 @@
-package prefixed_db
+package prefixedDatabase
 
 import (
 	"database/sql"

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1345,7 +1345,7 @@ func TestDeactivateAuthorization(t *testing.T) {
 	err = ra.DeactivateAuthorization(ctx, authz)
 	test.AssertNotError(t, err, "Could not deactivate authorization")
 	deact, err := sa.GetAuthorization(ctx, authz.ID)
-	test.AssertNotError(t, err, "Could not get deactivated authorization wtih ID "+authz.ID)
+	test.AssertNotError(t, err, "Could not get deactivated authorization with ID "+authz.ID)
 	test.AssertEquals(t, deact.Status, core.StatusDeactivated)
 }
 

--- a/revocation/reasons.go
+++ b/revocation/reasons.go
@@ -38,9 +38,9 @@ var ReasonToString = map[Reason]string{
 // UserAllowedReasons contains the subset of Reasons which users are
 // allowed to use
 var UserAllowedReasons = map[Reason]struct{}{
-	Unspecified:          struct{}{}, // unspecified
-	KeyCompromise:        struct{}{}, // keyCompromise
-	AffiliationChanged:   struct{}{}, // affiliationChanged
-	Superseded:           struct{}{}, // superseded
-	CessationOfOperation: struct{}{}, // cessationOfOperation
+	Unspecified:          {}, // unspecified
+	KeyCompromise:        {}, // keyCompromise
+	AffiliationChanged:   {}, // affiliationChanged
+	Superseded:           {}, // superseded
+	CessationOfOperation: {}, // cessationOfOperation
 }

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -437,7 +437,7 @@ func (rpc *AmqpRPCServer) Start(c *cmd.AMQPConfig) error {
 				rpc.mu.RUnlock()
 				rpc.log.Info(" [!] Got channel close, but no signal to shut down. Continuing.")
 			}
-		case _ = <-rpc.connection.closeChannel():
+		case <-rpc.connection.closeChannel():
 			rpc.log.Info(fmt.Sprintf(" [!] Server channel closed: %s", rpc.serverQueue))
 			rpc.connection.reconnect(c, rpc.log)
 		}

--- a/rpc/amqp-rpc.go
+++ b/rpc/amqp-rpc.go
@@ -437,7 +437,7 @@ func (rpc *AmqpRPCServer) Start(c *cmd.AMQPConfig) error {
 				rpc.mu.RUnlock()
 				rpc.log.Info(" [!] Got channel close, but no signal to shut down. Continuing.")
 			}
-		case err = <-rpc.connection.closeChannel():
+		case _ = <-rpc.connection.closeChannel():
 			rpc.log.Info(fmt.Sprintf(" [!] Server channel closed: %s", rpc.serverQueue))
 			rpc.connection.reconnect(c, rpc.log)
 		}

--- a/sa/database.go
+++ b/sa/database.go
@@ -17,7 +17,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
-	"github.com/letsencrypt/boulder/prefixed_db"
+	"github.com/letsencrypt/boulder/prefixedDatabase"
 )
 
 // NewDbMap creates the root gorp mapping object. Create one of these for each
@@ -88,7 +88,7 @@ func NewDbMapFromConfig(config *mysql.Config, maxOpenConns int) (*gorp.DbMap, er
 		return nil, err
 	}
 	driverName := fmt.Sprintf("mysql-%d", driverNum)
-	sql.Register(driverName, prefixed_db.New(prefix, mysql.MySQLDriver{}))
+	sql.Register(driverName, prefixedDatabase.New(prefix, mysql.MySQLDriver{}))
 
 	db, err := sqlOpen(driverName, config.FormatDSN())
 	if err != nil {

--- a/sa/database.go
+++ b/sa/database.go
@@ -17,7 +17,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
-	"github.com/letsencrypt/boulder/prefixedDatabase"
+	"github.com/letsencrypt/boulder/prefixdb"
 )
 
 // NewDbMap creates the root gorp mapping object. Create one of these for each
@@ -88,7 +88,7 @@ func NewDbMapFromConfig(config *mysql.Config, maxOpenConns int) (*gorp.DbMap, er
 		return nil, err
 	}
 	driverName := fmt.Sprintf("mysql-%d", driverNum)
-	sql.Register(driverName, prefixedDatabase.New(prefix, mysql.MySQLDriver{}))
+	sql.Register(driverName, prefixdb.New(prefix, mysql.MySQLDriver{}))
 
 	db, err := sqlOpen(driverName, config.FormatDSN())
 	if err != nil {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -661,7 +661,7 @@ func (ssa *SQLStorageAuthority) NewPendingAuthorization(ctx context.Context, aut
 	err = tx.Commit()
 	output = pendingAuthz.Authorization
 	output.Challenges = authz.Challenges
-	return output, nil
+	return output, err
 }
 
 // UpdatePendingAuthorization updates a Pending Authorization

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -788,7 +788,7 @@ func (ssa *SQLStorageAuthority) RevokeAuthorizationsByDomain(ctx context.Context
 }
 
 // AddCertificate stores an issued certificate and returns the digest as
-// a string, or an error if any occured.
+// a string, or an error if any occurred.
 func (ssa *SQLStorageAuthority) AddCertificate(ctx context.Context, certDER []byte, regID int64) (string, error) {
 	parsedCertificate, err := x509.ParseCertificate(certDER)
 	if err != nil {

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -34,6 +34,7 @@ func TestAcmeIdentifier(t *testing.T) {
 
 	marshaled := marshaledI.(string)
 	err = scanner.Binder(&marshaled, &out)
+	test.AssertNotError(t, err, "failed to scanner.Binder")
 	test.AssertMarshaledEquals(t, ai, out)
 }
 
@@ -58,6 +59,7 @@ func TestJsonWebKey(t *testing.T) {
 
 	marshaled := marshaledI.(string)
 	err = scanner.Binder(&marshaled, &out)
+	test.AssertNotError(t, err, "failed to scanner.Binder")
 	test.AssertMarshaledEquals(t, jwk, out)
 }
 
@@ -79,6 +81,7 @@ func TestAcmeStatus(t *testing.T) {
 
 	marshaled := marshaledI.(string)
 	err = scanner.Binder(&marshaled, &out)
+	test.AssertNotError(t, err, "failed to scanner.Binder")
 	test.AssertMarshaledEquals(t, as, out)
 }
 
@@ -100,6 +103,7 @@ func TestOCSPStatus(t *testing.T) {
 
 	marshaled := marshaledI.(string)
 	err = scanner.Binder(&marshaled, &out)
+	test.AssertNotError(t, err, "failed to scanner.Binder")
 	test.AssertMarshaledEquals(t, os, out)
 }
 
@@ -119,5 +123,6 @@ func TestStringSlice(t *testing.T) {
 
 	marshaled := marshaledI.(string)
 	err = scanner.Binder(&marshaled, &out)
+	test.AssertNotError(t, err, "failed to scanner.Binder")
 	test.AssertMarshaledEquals(t, au, out)
 }

--- a/test/mail-test-srv/http_test.go
+++ b/test/mail-test-srv/http_test.go
@@ -23,7 +23,7 @@ func reqAndRecorder(t testing.TB, method, relativeUrl string, body io.Reader) (*
 func TestHTTPClear(t *testing.T) {
 	srv := mailSrv{}
 	w, r := reqAndRecorder(t, "POST", "/clear", nil)
-	srv.allReceivedMail = []rcvdMail{rcvdMail{}}
+	srv.allReceivedMail = []rcvdMail{{}}
 	srv.httpClear(w, r)
 	if w.Code != 200 {
 		t.Errorf("expected 200, got %d", w.Code)
@@ -33,7 +33,7 @@ func TestHTTPClear(t *testing.T) {
 	}
 
 	w, r = reqAndRecorder(t, "GET", "/clear", nil)
-	srv.allReceivedMail = []rcvdMail{rcvdMail{}}
+	srv.allReceivedMail = []rcvdMail{{}}
 	srv.httpClear(w, r)
 	if w.Code != 405 {
 		t.Errorf("expected 405, got %d", w.Code)
@@ -46,11 +46,11 @@ func TestHTTPClear(t *testing.T) {
 func TestHTTPCount(t *testing.T) {
 	srv := mailSrv{}
 	srv.allReceivedMail = []rcvdMail{
-		rcvdMail{From: "a", To: "b"},
-		rcvdMail{From: "a", To: "b"},
-		rcvdMail{From: "a", To: "c"},
-		rcvdMail{From: "c", To: "a"},
-		rcvdMail{From: "c", To: "b"},
+		{From: "a", To: "b"},
+		{From: "a", To: "b"},
+		{From: "a", To: "c"},
+		{From: "c", To: "a"},
+		{From: "c", To: "b"},
 	}
 
 	tests := []struct {

--- a/va/va.go
+++ b/va/va.go
@@ -563,9 +563,9 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 		// interface value. See, e.g.
 		// https://stackoverflow.com/questions/29138591/hiding-nil-values-understanding-why-golang-fails-here
 		return records, nil
-	} else {
-		return records, prob
 	}
+
+	return records, prob
 }
 
 // CAASet consists of filtered CAA records

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -897,12 +897,12 @@ func TestParseResults(t *testing.T) {
 	test.Assert(t, s == nil, "set is not nil")
 	test.Assert(t, err == nil, "error is not nil")
 	test.AssertNotError(t, err, "no error should be returned")
-	r = []caaResult{{nil, errors.New("")}, {[]*dns.CAA{&dns.CAA{Value: "test"}}, nil}}
+	r = []caaResult{{nil, errors.New("")}, {[]*dns.CAA{{Value: "test"}}, nil}}
 	s, err = parseResults(r)
 	test.Assert(t, s == nil, "set is not nil")
 	test.AssertEquals(t, err.Error(), "")
 	expected := dns.CAA{Value: "other-test"}
-	r = []caaResult{{[]*dns.CAA{&expected}, nil}, {[]*dns.CAA{&dns.CAA{Value: "test"}}, nil}}
+	r = []caaResult{{[]*dns.CAA{&expected}, nil}, {[]*dns.CAA{{Value: "test"}}, nil}}
 	s, err = parseResults(r)
 	test.AssertEquals(t, len(s.Unknown), 1)
 	test.Assert(t, s.Unknown[0] == &expected, "Incorrect record returned")

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -986,6 +986,7 @@ func TestNewECDSARegistration(t *testing.T) {
 	responseWriter = httptest.NewRecorder()
 	// POST, Valid JSON, Key already in use
 	result, err = signer.Sign([]byte(`{"resource":"new-reg","contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`))
+	test.AssertNotError(t, err, "Failed to signer.Sign")
 
 	wfe.NewRegistration(ctx, newRequestEvent(), responseWriter, makePostRequest(result.FullSerialize()))
 	assertJSONEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:malformed","detail":"Registration key is already in use","status":409}`)
@@ -1156,6 +1157,7 @@ func TestNewRegistration(t *testing.T) {
 	responseWriter = httptest.NewRecorder()
 	// POST, Valid JSON, Key already in use
 	result, err = signer.Sign([]byte(`{"resource":"new-reg","contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`))
+	test.AssertNotError(t, err, "Failed to signer.Sign")
 
 	wfe.NewRegistration(ctx, newRequestEvent(), responseWriter,
 		makePostRequest(result.FullSerialize()))
@@ -1878,6 +1880,7 @@ func TestHeaderBoulderRequester(t *testing.T) {
 	// requests that do call sendError() also should have the requester header
 	signer.SetNonceSource(wfe.nonceService)
 	result, err = signer.Sign([]byte(`{"resource":"reg","agreement":"https://letsencrypt.org/im-bad"}`))
+	test.AssertNotError(t, err, "Failed to signer.Sign")
 	request = makePostRequestWithPath(regPath+"1", result.FullSerialize())
 	mux.ServeHTTP(responseWriter, request)
 	test.AssertEquals(t, responseWriter.Header().Get("Boulder-Requester"), "1")


### PR DESCRIPTION
I found this neat [Go Report Card](https://goreportcard.com) tool last night and plugged Boulder in.

We [get an A+](https://goreportcard.com/report/github.com/letsencrypt/boulder) currently! :tada: :apple: :school: 

There was still a handful of low hanging fruit findings we could fix, so I started this PR. Mostly spell check fixes, some `gofmt` collapsing, and a handful of unused errors.

Still left to do: The majority of the `go lint` findings. Specifically, lots of comments on exported fields/functions need to be written. There are also a couple packages with `-` or `_` in the name left to be renamed. I can take a crack at this after I finish my real work for the day :blush: 