### PR TITLE
Add explicit forbidden names validation to cert-checker

### DIFF
--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -4,7 +4,8 @@
     "maxDBConns": 10,
     "features": {
       "IDNASupport": true
-    }
+    },
+    "hostnamePolicyFile": "test/hostname-policy.json"
   },
 
   "pa": {

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -1,7 +1,8 @@
 {
   "certChecker": {
     "dbConnectFile": "test/secrets/cert_checker_dburl",
-    "maxDBConns": 10
+    "maxDBConns": 10,
+    "hostnamePolicyFile": "test/hostname-policy.json"
   },
 
   "pa": {

--- a/test/hostname-policy.json
+++ b/test/hostname-policy.json
@@ -1,4 +1,8 @@
 {
+  "ExactBlacklist": [
+    "highrisk.le-test.hoffman-andrews.com",
+    "exactblacklist.letsencrypt.org"
+  ],
   "Blacklist": [
     "in-addr.arpa",
     "example",


### PR DESCRIPTION
In https://groups.google.com/forum/#!topic/mozilla.dev.security.policy/_pSjsrZrTWY, we had a problem with the policy authority configuration, but `cert-checker` didn't alert about it because it uses the same policy configuration.

This PR adds support for an explicit list of regular expressions used to match forbidden names. The regular expressions are applied after the PA has done its usual validation process in order to act as a defense-in-depth mechanism for cases (`.mil`, `.local`, etc) that we know we never want to support, even if the PA thinks they are valid (e.g. due to a policy configuration malfunction). 

Initially the forbidden name regexps are:
```
`^\s*$`,
`\.mil$`,
`\.local$`,
`^localhost$`,
`\.localhost$`,
```

Additionally, the existing `cert-checker.json` config in both `test/config/` and `test/config-next/` was missing the `hostnamePolicyFile` entry required for operation of `cert-checker`. This PR adds a `hostnamePolicyFile` entry pointing at the existing `test/hostname-policy.json` file. The cert checker can now be used in the dev env with `cert-checker -config test/config/cert-checker.json` without error.

Resolves https://github.com/letsencrypt/boulder/issues/2366