### PR TITLE
Empty gRPC whitelist fix

### DIFF
--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -141,7 +141,7 @@ func (tc *serverTransportCredentials) validateClient(peerState tls.ConnectionSta
 	 * once we have deployed & updated all gRPC configurations to have an accepted
 	 * SAN list configured
 	 */
-	if tc.acceptedSANs == nil {
+	if len(tc.acceptedSANs) == 0 {
 		return nil
 	}
 

--- a/grpc/creds/creds_test.go
+++ b/grpc/creds/creds_test.go
@@ -31,9 +31,16 @@ func TestServerTransportCredentials(t *testing.T) {
 	_, err = NewServerCredentials(nil, acceptedSANs)
 	test.AssertEquals(t, err, NilServerConfigErr)
 
-	// A creds with a nil acceptedSANs list should consider any peer valid
-	bcreds := &serverTransportCredentials{servTLSConfig, nil}
+	// A creds with a empty acceptedSANs list should consider any peer valid
+	wrappedCreds, err := NewServerCredentials(servTLSConfig, nil)
+	test.AssertNotError(t, err, "NewServerCredentials failed with nil acceptedSANs")
+	bcreds := wrappedCreds.(*serverTransportCredentials)
 	emptyState := tls.ConnectionState{}
+	err = bcreds.validateClient(emptyState)
+	test.AssertNotError(t, err, "validateClient() errored for emptyState")
+	wrappedCreds, err = NewServerCredentials(servTLSConfig, map[string]struct{}{})
+	test.AssertNotError(t, err, "NewServerCredentials failed with empty acceptedSANs")
+	bcreds = wrappedCreds.(*serverTransportCredentials)
 	err = bcreds.validateClient(emptyState)
 	test.AssertNotError(t, err, "validateClient() errored for emptyState")
 

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -46,12 +46,9 @@ func NewServer(c *cmd.GRPCServerConfig, stats metrics.Scope) (*grpc.Server, net.
 		ClientCAs:    clientCAs,
 	}
 
-	var acceptedSANs map[string]struct{}
-	if len(c.ClientNames) > 0 {
-		acceptedSANs = make(map[string]struct{})
-		for _, name := range c.ClientNames {
-			acceptedSANs[name] = struct{}{}
-		}
+	acceptedSANs := make(map[string]struct{})
+	for _, name := range c.ClientNames {
+		acceptedSANs[name] = struct{}{}
 	}
 
 	creds, err := bcreds.NewServerCredentials(servTLSConfig, acceptedSANs)

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -46,9 +46,12 @@ func NewServer(c *cmd.GRPCServerConfig, stats metrics.Scope) (*grpc.Server, net.
 		ClientCAs:    clientCAs,
 	}
 
-	acceptedSANs := make(map[string]struct{})
-	for _, name := range c.ClientNames {
-		acceptedSANs[name] = struct{}{}
+	var acceptedSANs map[string]struct{}
+	if len(c.ClientNames) > 0 {
+		acceptedSANs = make(map[string]struct{})
+		for _, name := range c.ClientNames {
+			acceptedSANs[name] = struct{}{}
+		}
 	}
 
 	creds, err := bcreds.NewServerCredentials(servTLSConfig, acceptedSANs)


### PR DESCRIPTION
`grpc/creds:serverTransportCredentials.validateClient` is meant to ignore the check if the `acceptedSANs` map it is constructed with is `nil`. This never happens as the map is constructed using `make(map[string]struct{})` meaning it can never be `nil`.

Instead start with a `nil` map and only populate it if we have `ClientNames` to whitelist.

Fixes #2375.