### PR TITLE
Use standardized error format for Publisher gRPC errs.

### DIFF
--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -86,12 +86,12 @@ func main() {
 	var grpcSrv *grpc.Server
 	if c.Publisher.GRPC != nil {
 		s, l, err := bgrpc.NewServer(c.Publisher.GRPC, scope)
-		cmd.FailOnError(err, "Failed to setup gRPC server")
+		cmd.FailOnError(err, "Unable to setup Publisher gRPC server")
 		gw := bgrpc.NewPublisherServerWrapper(pubi)
 		pubPB.RegisterPublisherServer(s, gw)
 		go func() {
 			err = s.Serve(l)
-			cmd.FailOnError(err, "gRPC service failed")
+			cmd.FailOnError(err, "Publisher gRPC service failed")
 		}()
 		grpcSrv = s
 	}


### PR DESCRIPTION
When the CA and the VA encounter an error from grpc.ServerSetup() they print a message of the form:

> "Unable to setup XXX gRPC server", where XXX is "CA", or "VA".

Prior to this commit when the publisher encounters the same error it prints:

> "Failed to setup gRPC server".

This commit updates the Publisher cmd to use the same gRPC error message format as the CA and the VA.

Fixes https://github.com/letsencrypt/boulder/issues/2377