### PR TITLE
Move timeouts into client interceptor.

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -70,7 +70,7 @@ func setupContext(c config) (core.RegistrationAuthority, blog.Logger, *gorp.DbMa
 	if c.Revoker.RAService != nil {
 		conn, err := bgrpc.ClientSetup(c.Revoker.RAService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to RA")
-		rac = bgrpc.NewRegistrationAuthorityClient(rapb.NewRegistrationAuthorityClient(conn), c.Revoker.RAService.Timeout.Duration)
+		rac = bgrpc.NewRegistrationAuthorityClient(rapb.NewRegistrationAuthorityClient(conn))
 	} else {
 		var err error
 		rac, err = rpc.NewRegistrationAuthorityClient(clientName, amqpConf, scope)
@@ -87,7 +87,7 @@ func setupContext(c config) (core.RegistrationAuthority, blog.Logger, *gorp.DbMa
 	if c.Revoker.SAService != nil {
 		conn, err := bgrpc.ClientSetup(c.Revoker.SAService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), c.Revoker.SAService.Timeout.Duration)
+		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		sac, err = rpc.NewStorageAuthorityClient(clientName, amqpConf, scope)
 		cmd.FailOnError(err, "Failed to create SA client")

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -173,7 +173,7 @@ func main() {
 	if c.CA.SAService != nil {
 		conn, err := bgrpc.ClientSetup(c.CA.SAService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		cai.SA = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), c.CA.SAService.Timeout.Duration)
+		cai.SA = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		cai.SA, err = rpc.NewStorageAuthorityClient(clientName, amqpConf, scope)
 		cmd.FailOnError(err, "Failed to create SA client")

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -78,7 +78,7 @@ func main() {
 	if c.Publisher.SAService != nil {
 		conn, err := bgrpc.ClientSetup(c.Publisher.SAService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), c.Publisher.SAService.Timeout.Duration)
+		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		sac, err = rpc.NewStorageAuthorityClient(clientName, amqpConf, scope)
 		cmd.FailOnError(err, "Unable to create SA client")

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -136,7 +136,7 @@ func main() {
 	if c.RA.CAService != nil {
 		conn, err := bgrpc.ClientSetup(c.RA.CAService, scope)
 		cmd.FailOnError(err, "Unable to create CA client")
-		cac = bgrpc.NewCertificateAuthorityClient(caPB.NewCertificateAuthorityClient(conn), c.RA.CAService.Timeout.Duration)
+		cac = bgrpc.NewCertificateAuthorityClient(caPB.NewCertificateAuthorityClient(conn))
 	} else {
 		cac, err = rpc.NewCertificateAuthorityClient(clientName, amqpConf, scope)
 		cmd.FailOnError(err, "Unable to create CA client")
@@ -146,14 +146,14 @@ func main() {
 	if c.RA.PublisherService != nil {
 		conn, err := bgrpc.ClientSetup(c.RA.PublisherService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to Publisher")
-		pubc = bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn), c.RA.PublisherService.Timeout.Duration)
+		pubc = bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn))
 	}
 
 	var sac core.StorageAuthority
 	if c.RA.SAService != nil {
 		conn, err := bgrpc.ClientSetup(c.RA.SAService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), c.RA.SAService.Timeout.Duration)
+		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		sac, err = rpc.NewStorageAuthorityClient(clientName, amqpConf, scope)
 		cmd.FailOnError(err, "Unable to create SA client")

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -69,7 +69,7 @@ func setupWFE(c config, logger blog.Logger, stats metrics.Scope) (core.Registrat
 	if c.WFE.RAService != nil {
 		conn, err := bgrpc.ClientSetup(c.WFE.RAService, stats)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to RA")
-		rac = bgrpc.NewRegistrationAuthorityClient(rapb.NewRegistrationAuthorityClient(conn), c.WFE.RAService.Timeout.Duration)
+		rac = bgrpc.NewRegistrationAuthorityClient(rapb.NewRegistrationAuthorityClient(conn))
 	} else {
 		var err error
 		rac, err = rpc.NewRegistrationAuthorityClient(clientName, amqpConf, stats)
@@ -80,7 +80,7 @@ func setupWFE(c config, logger blog.Logger, stats metrics.Scope) (core.Registrat
 	if c.WFE.SAService != nil {
 		conn, err := bgrpc.ClientSetup(c.WFE.SAService, stats)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), c.WFE.SAService.Timeout.Duration)
+		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		var err error
 		sac, err = rpc.NewStorageAuthorityClient(clientName, amqpConf, stats)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -379,7 +379,7 @@ func main() {
 	if c.Mailer.SAService != nil {
 		conn, err := bgrpc.ClientSetup(c.Mailer.SAService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), c.Mailer.SAService.Timeout.Duration)
+		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		sac, err = rpc.NewStorageAuthorityClient(clientName, c.Mailer.AMQP, scope)
 		cmd.FailOnError(err, "Failed to create SA client")

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -593,7 +593,7 @@ func setupClients(c cmd.OCSPUpdaterConfig, stats metrics.Scope) (
 	if c.CAService != nil {
 		conn, err := bgrpc.ClientSetup(c.CAService, stats)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to CA")
-		cac = bgrpc.NewCertificateAuthorityClient(capb.NewCertificateAuthorityClient(conn), c.CAService.Timeout.Duration)
+		cac = bgrpc.NewCertificateAuthorityClient(capb.NewCertificateAuthorityClient(conn))
 	} else {
 		var err error
 		cac, err = rpc.NewCertificateAuthorityClient(clientName, amqpConf, stats)
@@ -602,13 +602,13 @@ func setupClients(c cmd.OCSPUpdaterConfig, stats metrics.Scope) (
 
 	conn, err := bgrpc.ClientSetup(c.Publisher, stats)
 	cmd.FailOnError(err, "Failed to load credentials and create connection to service")
-	pubc := bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn), c.Publisher.Timeout.Duration)
+	pubc := bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn))
 
 	var sac core.StorageAuthority
 	if c.SAService != nil {
 		conn, err := bgrpc.ClientSetup(c.SAService, stats)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), c.SAService.Timeout.Duration)
+		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		sac, err = rpc.NewStorageAuthorityClient(clientName, amqpConf, stats)
 		cmd.FailOnError(err, "Unable to create SA client")

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -126,7 +126,7 @@ func setup(configFile string) (metrics.Scope, blog.Logger, core.StorageAuthority
 	if conf.SAService != nil {
 		conn, err := bgrpc.ClientSetup(conf.SAService, scope)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn), conf.SAService.Timeout.Duration)
+		sac = bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 	} else {
 		sac, err = rpc.NewStorageAuthorityClient("orphan-finder", &conf.AMQP, scope)
 		cmd.FailOnError(err, "Failed to create SA client")

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -38,7 +38,7 @@ func ClientSetup(c *cmd.GRPCClientConfig, stats metrics.Scope) (*grpc.ClientConn
 	if err != nil {
 		return nil, err
 	}
-	ci := clientInterceptor{stats.NewScope("gRPCClient"), clock.Default()}
+	ci := clientInterceptor{stats.NewScope("gRPCClient"), clock.Default(), c.Timeout.Duration}
 	creds := bcreds.NewClientCredentials(rootCAs, []tls.Certificate{clientCert})
 	return grpc.Dial(
 		"", // Since our staticResolver provides addresses we don't need to pass an address here

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -64,7 +64,7 @@ func TestClientInterceptor(t *testing.T) {
 	defer ctrl.Finish()
 	statter := metrics.NewMockStatter(ctrl)
 	stats := metrics.NewStatsdScope(statter, "fake", "gRPCClient")
-	ci := clientInterceptor{stats, fc}
+	ci := clientInterceptor{stats, fc, time.Second}
 
 	statter.EXPECT().Inc("fake.gRPCClient.service_test.Calls", int64(1), float32(1.0)).Return(nil)
 	statter.EXPECT().GaugeDelta("fake.gRPCClient.service_test.InProgress", int64(1), float32(1.0)).Return(nil)


### PR DESCRIPTION
Previously we had custom code in each gRPC wrapper to implement timeouts. Moving
the timeout code into the client interceptor allows us to simplify things and
reduce code duplication.

Note to reviewers: Don't forget to click "load diff" for grpc/wrappers.go.