### PR TITLE
Improvements to tests and test configs.

### DIFF
--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -3,7 +3,7 @@
     "serialPrefix": 255,
     "rsaProfile": "rsaEE",
     "ecdsaProfile": "ecdsaEE",
-    "debugAddr": "localhost:8001",
+    "debugAddr": ":8001",
     "saService": {
       "serverAddresses": ["boulder:9095"],
       "serverIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -11,7 +11,7 @@
     "nagTimes": ["24h", "72h", "168h", "336h"],
     "nagCheckInterval": "24h",
     "emailTemplate": "test/example-expiration-template",
-    "debugAddr": "localhost:8008",
+    "debugAddr": ":8008",
     "saService": {
       "serverAddresses": ["boulder:9095"],
       "serverIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -7,7 +7,7 @@
     "maxAge": "10s",
     "shutdownStopTimeout": "10s",
     "shutdownKillTimeout": "1m",
-    "debugAddr": "localhost:8005"
+    "debugAddr": ":8005"
   },
 
   "statsd": {

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -14,7 +14,7 @@
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
-    "debugAddr": "localhost:8006",
+    "debugAddr": ":8006",
     "publisher": {
       "serverAddresses": ["boulder:9091"],
       "serverIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -2,7 +2,7 @@
   "publisher": {
     "maxConcurrentRPCServerRequests": 16,
     "submissionTimeout": "5s",
-    "debugAddr": "localhost:8009",
+    "debugAddr": ":8009",
     "grpc": {
       "address": "boulder:9091",
       "clientIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -3,8 +3,8 @@
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 16,
     "maxContactsPerRegistration": 100,
-    "dnsTries": 2,
-    "debugAddr": "localhost:8002",
+    "dnsTries": 3,
+    "debugAddr": "8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 1000,
     "doNotForceCN": true,
@@ -79,7 +79,7 @@
 
   "common": {
     "dnsResolver": "127.0.0.1:8053",
-    "dnsTimeout": "5s",
+    "dnsTimeout": "1s",
     "dnsAllowLoopbackAddresses": true
   }
 }

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -4,7 +4,7 @@
     "maxConcurrentRPCServerRequests": 16,
     "maxContactsPerRegistration": 100,
     "dnsTries": 3,
-    "debugAddr": "8002",
+    "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 1000,
     "doNotForceCN": true,

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -3,7 +3,7 @@
     "dbConnectFile": "test/secrets/sa_dburl",
     "maxDBConns": 10,
     "maxConcurrentRPCServerRequests": 16,
-    "debugAddr": "localhost:8003",
+    "debugAddr": ":8003",
     "grpc": {
       "address": "boulder:9095",
       "clientIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -2,7 +2,7 @@
   "va": {
     "CAASERVFAILExceptions": "test/caa-servfail-exceptions.txt",
     "userAgent": "boulder",
-    "debugAddr": "localhost:8004",
+    "debugAddr": ":8004",
     "portConfig": {
       "httpPort": 5002,
       "httpsPort": 5001,
@@ -23,11 +23,7 @@
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
-      "serviceQueue": "VA.server",
-      "RA": {
-        "server": "RA.server",
-        "rpcTimeout": "15s"
-      }
+      "serviceQueue": "VA.server"
     }
   },
 
@@ -43,7 +39,7 @@
 
   "common": {
     "dnsResolver": "127.0.0.1:8053",
-    "dnsTimeout": "10s",
+    "dnsTimeout": "1s",
     "dnsAllowLoopbackAddresses": true
   }
 }

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -12,7 +12,7 @@
     "subscriberAgreementURL": "http://boulder:4000/terms/v1",
     "acceptRevocationReason": true,
     "allowAuthzDeactivation": true,
-    "debugAddr": "localhost:8000",
+    "debugAddr": ":8000",
     "raService": {
       "serverAddresses": ["boulder:9094"],
       "serverIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -3,7 +3,7 @@
     "serialPrefix": 255,
     "rsaProfile": "rsaEE",
     "ecdsaProfile": "ecdsaEE",
-    "debugAddr": "localhost:8001",
+    "debugAddr": ":8001",
     "Issuers": [{
       "ConfigFile": "test/test-ca.key-pkcs11.json",
       "CertFile": "test/test-ca2.pem"

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -11,7 +11,7 @@
     "nagTimes": ["24h", "72h", "168h", "336h"],
     "nagCheckInterval": "24h",
     "emailTemplate": "test/example-expiration-template",
-    "debugAddr": "localhost:8008",
+    "debugAddr": ":8008",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -7,7 +7,7 @@
     "maxAge": "10s",
     "shutdownStopTimeout": "10s",
     "shutdownKillTimeout": "1m",
-    "debugAddr": "localhost:8005"
+    "debugAddr": ":8005"
   },
 
   "statsd": {

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -14,7 +14,7 @@
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
-    "debugAddr": "localhost:8006",
+    "debugAddr": ":8006",
     "publisher": {
       "serverAddresses": ["boulder:9091"],
       "serverIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -2,7 +2,7 @@
   "publisher": {
     "maxConcurrentRPCServerRequests": 16,
     "submissionTimeout": "5s",
-    "debugAddr": "localhost:8009",
+    "debugAddr": ":8009",
     "grpc": {
       "address": "boulder:9091",
       "clientIssuerPath": "test/grpc-creds/minica.pem",

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -3,8 +3,8 @@
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 16,
     "maxContactsPerRegistration": 100,
-    "dnsTries": 2,
-    "debugAddr": "localhost:8002",
+    "dnsTries": 3,
+    "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 1000,
     "doNotForceCN": true,
@@ -56,7 +56,7 @@
 
   "common": {
     "dnsResolver": "127.0.0.1:8053",
-    "dnsTimeout": "5s",
+    "dnsTimeout": "1s",
     "dnsAllowLoopbackAddresses": true
   }
 }

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -3,7 +3,7 @@
     "dbConnectFile": "test/secrets/sa_dburl",
     "maxDBConns": 10,
     "maxConcurrentRPCServerRequests": 16,
-    "debugAddr": "localhost:8003",
+    "debugAddr": ":8003",
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -2,7 +2,7 @@
   "va": {
     "CAASERVFAILExceptions": "test/caa-servfail-exceptions.txt",
     "userAgent": "boulder",
-    "debugAddr": "localhost:8004",
+    "debugAddr": ":8004",
     "portConfig": {
       "httpPort": 5002,
       "httpsPort": 5001,
@@ -15,11 +15,7 @@
     "amqp": {
       "serverURLFile": "test/secrets/amqp_url",
       "insecure": true,
-      "serviceQueue": "VA.server",
-      "RA": {
-        "server": "RA.server",
-        "rpcTimeout": "15s"
-      }
+      "serviceQueue": "VA.server"
     }
   },
 
@@ -34,7 +30,7 @@
 
   "common": {
     "dnsResolver": "127.0.0.1:8053",
-    "dnsTimeout": "10s",
+    "dnsTimeout": "1s",
     "dnsAllowLoopbackAddresses": true
   }
 }

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -12,7 +12,7 @@
     "subscriberAgreementURL": "http://boulder:4000/terms/v1",
     "checkMalformedCSR": true,
     "allowAuthzDeactivation": true,
-    "debugAddr": "localhost:8000",
+    "debugAddr": ":8000",
     "amqp": {
       "server": "amqp://guest:guest@localhost:5673",
       "insecure": true,

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -379,7 +379,7 @@ function validateHttp01(challenge) {
     state.httpServer.listen(80)
   }
 
-  cli.spinner("Validating domain");
+  console.log("Validating domain");
   post(state.responseURL, {
     resource: "challenge",
     keyAuthorization: keyAuthorization,
@@ -404,7 +404,7 @@ function ensureValidation(err, resp, body) {
       request.get(state.authorizationURL, {}, ensureValidation);
     }, state.retryDelay);
   } else if (authz.status == "valid") {
-    cli.spinner("Validating domain ... done", true);
+    console.log("Validating domain ... done");
     console.log();
     state.validatedDomains.push(state.domain);
     state.validAuthorizationURLs.push(state.authorizationURL);
@@ -428,7 +428,7 @@ function ensureValidation(err, resp, body) {
 }
 
 function getCertificate() {
-  cli.spinner("Requesting certificate");
+  console.log("Requesting certificate");
   var csr = cryptoUtil.generateCSR(state.certPrivateKey, state.validatedDomains);
   post(state.newCertificateURL, {
     resource: "new-cert",
@@ -447,7 +447,7 @@ function downloadCertificate(err, resp, body) {
     process.exit(1);
   }
 
-  cli.spinner("Requesting certificate ... done", true);
+  console.log("Requesting certificate ... done");
   console.log();
 
   state.certificate = body;


### PR DESCRIPTION
- Remove spinner from test.js. It made Travis logs hard to read.
- Listen on all interfaces for debugAddr. This makes it possible to check
  Prometheus metrics for instances running in a Docker container.
- Standardize DNS timeouts on 1s and 3 retries across all configs. This ensures
  DNS completes within the relevant RPC timeouts.
- Remove RA service queue from VA, since VA no longer uses the callback to RA on
  completing a challenge.