### PR TITLE
Adds unique VA DNS validation error for empty TXTs.

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -32,6 +32,10 @@ func (mock *MockDNSResolver) LookupTXT(_ context.Context, hostname string) ([]st
 		// expected token + test account jwk thumbprint
 		return []string{"LPsIwTo7o8BoG0-vjCyGQGBWSVIPxI-i_X336eUOQZo"}, nil, nil
 	}
+	// empty-txts.com always returns zero TXT records
+	if hostname == "_acme-challenge.empty-txts.com" {
+		return []string{}, nil, nil
+	}
 	return []string{"hostname"}, []string{"respect my authority!"}, nil
 }
 

--- a/va/va.go
+++ b/va/va.go
@@ -428,6 +428,13 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier
 		return nil, bdns.ProblemDetailsFromDNSError(err)
 	}
 
+	// If there weren't any TXT records return a distinct error message to allow
+	// troubleshooters to differentiate between no TXT records and
+	// invalid/incorrect TXT records.
+	if len(txts) == 0 {
+		return nil, probs.Unauthorized("No TXT records found for DNS challenge")
+	}
+
 	for _, element := range txts {
 		if subtle.ConstantTimeCompare([]byte(element), []byte(authorizedKeysDigest)) == 1 {
 			// Successful challenge validation

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -671,6 +671,18 @@ func TestPerformValidationInvalid(t *testing.T) {
 	test.AssertEquals(t, stats.TimingDurationCalls[0].Metric, "VA.Validations.dns-01.invalid")
 }
 
+func TestDNSValidationEmpty(t *testing.T) {
+	va, stats, _ := setup()
+	chalDNS := createChallenge(core.ChallengeTypeDNS01)
+	_, prob := va.PerformValidation(
+		context.Background(),
+		"empty-txts.com",
+		chalDNS,
+		core.Authorization{})
+	test.AssertEquals(t, prob.Error(), "urn:acme:error:unauthorized :: No TXT records found for DNS challenge")
+	test.AssertEquals(t, stats.TimingDurationCalls[0].Metric, "VA.Validations.dns-01.invalid")
+}
+
 func TestPerformValidationValid(t *testing.T) {
 	va, stats, _ := setup()
 	// create a challenge with well known token


### PR DESCRIPTION
Presently when the VA performs a DNS-01 challenge verification it returns the same error for the case where the remote nameserver had the **wrong** TXT value, and when the remote nameserver had an **empty** response for the TXT query. It would aid debugging if the user was told which of the two failure cases was responsible for the overall challenge failure.

This PR adds a unique error message for the empty TXT records case, and a unit test/mock to exercise the new the error message.

Resolves #2326