### PR TITLE
Adds divergences for URL & existing reg status code.

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -6,6 +6,10 @@ This document details these differences, since ACME is not yet finalized it will
 
 Current draft: [`draft-ietf-acme-acme-04`](https://tools.ietf.org/html/draft-ietf-acme-acme-04).
 
+## [Section 5.4.1](https://tools.ietf.org/html/draft-ietf-acme-acme-04#section-5.4.1)
+
+Boulder does not use the `url` field from the JWS protected resource. Instead Boulder will validate the `resource` field from the JWS protected header matches the resource being requested.
+
 ## [Section 5.6.](https://tools.ietf.org/html/draft-ietf-acme-acme-04#section-5.6)
 
 Boulder does not provide a `Retry-After` header when a user hits a rate-limit, nor does it provide `Link` headers to further documentation on rate-limiting.
@@ -45,6 +49,8 @@ Boulder doesn't implement the `new-nonce` endpoint, instead it responds to `HEAD
 ## [Section 6.3.](https://tools.ietf.org/html/draft-ietf-acme-acme-04#section-6.3)
 
 Boulder only allows `mailto` URIs in the registrations `contact` list.
+
+Boulder uses a HTTP status code 409 (Conflict) response when providing the Content-Location header to an already existing registration.
 
 ## [Section 6.3.2.](https://tools.ietf.org/html/draft-ietf-acme-acme-04#section-6.3.2)
 


### PR DESCRIPTION
Issue #2365 reported two places where we had divergences from ACME-04 in Boulder's implementation that were not reflected in the divergences doc. This PR documents:

1. That Boulder checks the `resource` field from the protected JWS header instead of the `url` field as described in Section 5.4.1
2. That Boulder uses a response with HTTP status code 409 (Conflict) when returning a Location header for an existing reg while Section 6.3 describes using HTTP status code 200 for this purpose.

This resolves #2365.