### PR TITLE
Adds warning about unsub link

### DIFF
--- a/data/production-email.template
+++ b/data/production-email.template
@@ -17,7 +17,8 @@ this certificate with a newer one that covers more or fewer names than
 the list above, you may be able to ignore this message.
 
 If you want to stop receiving all email from this address, click
-|UNSUB:https://mandrillapp.com/unsub|
+|UNSUB:https://mandrillapp.com/unsub| (Warning: this is a one-click action
+that cannot be undone)
 
 Regards,
 The Let's Encrypt Team

--- a/data/staging-email.template
+++ b/data/staging-email.template
@@ -20,7 +20,8 @@ For details about when we send these emails, please visit
 https://letsencrypt.org/docs/expiration-emails/.
 
 If you want to stop receiving all email from this address, click
-|UNSUB:https://mandrillapp.com/unsub|
+|UNSUB:https://mandrillapp.com/unsub| (Warning: this is a one-click action
+that cannot be undone)
 
 Regards,
 The Let's Encrypt Team


### PR DESCRIPTION
We received some [community forum feedback](https://community.letsencrypt.org/t/certificate-expiration-notice-e-mail-unsubscribe-links-could-use-more-clairity/) that the certificate expiration email's unsubscribe link didn't provide enough context to know what would happen if you clicked it. Combined with https://github.com/letsencrypt/boulder/issues/1396 I agree that we should make it clear that there won't be a subsequent confirmation of intent if you click unsubscribe *and* you can't resubscribe yourself.

_Note: there is an outstanding operations ticket to switch to using the Boulder `data/` templates in staging/production. Until that happens this PR won't take effect post-merge/deployment._