### PR TITLE
Don't echo command from run_and_expect_silence.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -60,7 +60,6 @@ function run_and_expect_silence() {
 
   # Fail if result_file is nonempty.
   if [ -s ${result_file} ]; then
-    echo "[!] FAILURE: $@"
     FAILURE=1
   fi
   rm ${result_file}


### PR DESCRIPTION
Some commands, like our errcheck command, are very long. When we echo these both
before and after running them, it can obscure what is often a single-line
failure message. Removing the echo after failure makes it easier to spot the
real failure message.