### PR TITLE
Remove /go/bin from PATH in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM letsencrypt/boulder-tools:2016-11-02
 # Boulder exposes its web application at port TCP 4000
 EXPOSE 4000 4002 4003 8053 8055
 
-ENV PATH /go/bin:/usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
+ENV PATH /usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/:/go/bin
 ENV GOPATH /go
 ENV GO15VENDOREXPERIMENT=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM letsencrypt/boulder-tools:2016-11-02
 # Boulder exposes its web application at port TCP 4000
 EXPOSE 4000 4002 4003 8053 8055
 
-ENV PATH /usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/:/go/bin
+ENV PATH /usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 ENV GOPATH /go
 ENV GO15VENDOREXPERIMENT=1
 


### PR DESCRIPTION
We don't write any built binaries there during the test process (Boulder binaries go in boulder/bin), so including it in that path has no effect, at least on Travis.

For local builds, because GOPATH gets mounted as a volume at /go/, including /go/bin in PATH means that a `docker run` command locally can wind up running a local copy of some key binary that is different than the one that gets run in Travis. For instance, this happens when the host's version of protoc-gen-go differs from the version in the image, producing diffs when Travis runs the "generate" phase of test.sh.