### PR TITLE
OCSP Updater "stale max age" parameter.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -225,6 +225,7 @@ type OCSPUpdaterConfig struct {
 	RevokedCertificateBatchSize int
 
 	OCSPMinTimeToExpiry ConfigDuration
+	OCSPStaleMaxAge     ConfigDuration
 	OldestIssuedSCT     ConfigDuration
 
 	AkamaiBaseURL           string

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -237,8 +237,8 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 			 FROM certificateStatus AS cs
 			 JOIN certificates AS cert
 			 ON cs.serial = cert.serial
-			 WHERE cs.ocspLastUpdated < :lastUpdate
-			 AND cs.ocspLastUpdated > :maxAge
+			 WHERE cs.ocspLastUpdated > :maxAge
+			 AND cs.ocspLastUpdated < :lastUpdate
 			 AND cert.expires > now()
 			 ORDER BY cs.ocspLastUpdated ASC
 			 LIMIT :limit`,

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -192,18 +192,28 @@ func TestGenerateAndStoreOCSPResponse(t *testing.T) {
 }
 
 func TestGenerateOCSPResponses(t *testing.T) {
-	updater, sa, _, fc, cleanUp := setup(t)
+	updater, sa, dbMap, fc, cleanUp := setup(t)
 	defer cleanUp()
 
 	reg := satest.CreateWorkingRegistration(t, sa)
-	parsedCert, err := core.LoadCert("test-cert.pem")
+	parsedCertA, err := core.LoadCert("test-cert.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
-	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
+	_, err = sa.AddCertificate(ctx, parsedCertA.Raw, reg.ID)
 	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
-	parsedCert, err = core.LoadCert("test-cert-b.pem")
+	parsedCertB, err := core.LoadCert("test-cert-b.pem")
 	test.AssertNotError(t, err, "Couldn't read test certificate")
-	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
+	_, err = sa.AddCertificate(ctx, parsedCertB.Raw, reg.ID)
 	test.AssertNotError(t, err, "Couldn't add test-cert-b.pem")
+
+	// We need to set a fake "ocspLastUpdated" value for the two certs we created
+	// in order to satisfy the "ocspStaleMaxAge" constraint.
+	fakeLastUpdate := fc.Now().Add(-time.Hour * 24 * 3)
+	_, err = dbMap.Exec(
+		"UPDATE certificateStatus SET ocspLastUpdated = ? WHERE serial IN (?, ?)",
+		fakeLastUpdate,
+		core.SerialToString(parsedCertA.SerialNumber),
+		core.SerialToString(parsedCertB.SerialNumber))
+	test.AssertNotError(t, err, "Couldn't update ocspLastUpdated")
 
 	earliest := fc.Now().Add(-time.Hour)
 	certs, err := updater.findStaleOCSPResponses(earliest, 10)
@@ -219,7 +229,7 @@ func TestGenerateOCSPResponses(t *testing.T) {
 }
 
 func TestFindStaleOCSPResponses(t *testing.T) {
-	updater, sa, _, fc, cleanUp := setup(t)
+	updater, sa, dbMap, fc, cleanUp := setup(t)
 	defer cleanUp()
 
 	reg := satest.CreateWorkingRegistration(t, sa)
@@ -227,6 +237,15 @@ func TestFindStaleOCSPResponses(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't read test certificate")
 	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID)
 	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
+
+	// We need to set a fake "ocspLastUpdated" value for the cert we created
+	// in order to satisfy the "ocspStaleMaxAge" constraint.
+	fakeLastUpdate := fc.Now().Add(-time.Hour * 24 * 3)
+	_, err = dbMap.Exec(
+		"UPDATE certificateStatus SET ocspLastUpdated = ? WHERE serial = ?",
+		fakeLastUpdate,
+		core.SerialToString(parsedCert.SerialNumber))
+	test.AssertNotError(t, err, "Couldn't update ocspLastUpdated")
 
 	earliest := fc.Now().Add(-time.Hour)
 	certs, err := updater.findStaleOCSPResponses(earliest, 10)
@@ -244,6 +263,46 @@ func TestFindStaleOCSPResponses(t *testing.T) {
 	certs, err = updater.findStaleOCSPResponses(earliest, 10)
 	test.AssertNotError(t, err, "Failed to find stale responses")
 	test.AssertEquals(t, len(certs), 0)
+}
+
+func TestFindStaleOCSPResponsesStaleMaxAge(t *testing.T) {
+	updater, sa, dbMap, fc, cleanUp := setup(t)
+	defer cleanUp()
+
+	reg := satest.CreateWorkingRegistration(t, sa)
+	parsedCertA, err := core.LoadCert("test-cert.pem")
+	test.AssertNotError(t, err, "Couldn't read test certificate")
+	_, err = sa.AddCertificate(ctx, parsedCertA.Raw, reg.ID)
+	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
+	parsedCertB, err := core.LoadCert("test-cert-b.pem")
+	test.AssertNotError(t, err, "Couldn't read test certificate")
+	_, err = sa.AddCertificate(ctx, parsedCertB.Raw, reg.ID)
+	test.AssertNotError(t, err, "Couldn't add test-cert-b.pem")
+
+	// Set a "ocspLastUpdated" value of 3 days ago for parsedCertA
+	okLastUpdated := fc.Now().Add(-time.Hour * 24 * 3)
+	_, err = dbMap.Exec(
+		"UPDATE certificateStatus SET ocspLastUpdated = ? WHERE serial = ?",
+		okLastUpdated,
+		core.SerialToString(parsedCertA.SerialNumber))
+	test.AssertNotError(t, err, "Couldn't update ocspLastUpdated for parsedCertA")
+
+	// Set a "ocspLastUpdated" value of 35 days ago for parsedCertB
+	excludedLastUpdated := fc.Now().Add(-time.Hour * 24 * 35)
+	_, err = dbMap.Exec(
+		"UPDATE certificateStatus SET ocspLastUpdated = ? WHERE serial = ?",
+		excludedLastUpdated,
+		core.SerialToString(parsedCertB.SerialNumber))
+	test.AssertNotError(t, err, "Couldn't update ocspLastUpdated for parsedCertB")
+
+	// Running `findStaleOCSPResponses should only find *ONE* of the above
+	// certificates, parsedCertA. The second should be excluded by the
+	// `ocspStaleMaxAge` cutoff.
+	earliest := fc.Now().Add(-time.Hour)
+	certs, err := updater.findStaleOCSPResponses(earliest, 10)
+	test.AssertNotError(t, err, "Couldn't find stale responses")
+	test.AssertEquals(t, len(certs), 1)
+	test.AssertEquals(t, certs[0].Serial, core.SerialToString(parsedCertA.SerialNumber))
 }
 
 func TestGetCertificatesWithMissingResponses(t *testing.T) {

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -11,6 +11,7 @@
     "missingSCTBatchSize": 5000,
     "revokedCertificateBatchSize": 1000,
     "ocspMinTimeToExpiry": "72h",
+    "ocspStaleMaxAge": "720h",
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",


### PR DESCRIPTION
This PR adds a new `OCSPStaleMaxAge` configuration parameter to the `ocsp-updater`. The default value when not provided is 30 days, and this is explicitly added to both `config/ocsp-updater.json` and `config-next/ocsp-updater.json`. 

The OCSP updater uses this new parameter in `findStaleOCSPResponses` as a lower bound on the `ocspLastUpdated` field of the certificateStatus table. This is intended to speed up the processing of this query until we can land the proper fixes that require more intensive migrations & backfilling. 

The `TestGenerateOCSPResponses` and `TestFindStaleOCSPResponses` unit tests had to be updated to explicitly set the `ocspLastUpdated` field of the certificate status rows that the tests add, because otherwise they are left at a default value of `0` and are excluded by the new `OCSPStaleMaxAge` functionality.