### PR TITLE
OCSP Updater "stale max age" parameter

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -225,6 +225,7 @@ type OCSPUpdaterConfig struct {
 	RevokedCertificateBatchSize int
 
 	OCSPMinTimeToExpiry ConfigDuration
+	OCSPStaleMaxAge     ConfigDuration
 	OldestIssuedSCT     ConfigDuration
 
 	AkamaiBaseURL           string

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -52,8 +52,10 @@ type OCSPUpdater struct {
 	pubc core.Publisher
 	sac  core.StorageAuthority
 
-	// Used  to calculate how far back stale OCSP responses should be looked for
+	// Used to calculate how far back stale OCSP responses should be looked for
 	ocspMinTimeToExpiry time.Duration
+	// Used to caculate how far back in time the findStaleOCSPResponse will look
+	ocspStaleMaxAge time.Duration
 	// Used to calculate how far back missing SCT receipts should be looked for
 	oldestIssuedSCT time.Duration
 	// Number of CT logs we expect to have receipts from
@@ -89,6 +91,10 @@ func newUpdater(
 		config.MissingSCTWindow.Duration == 0 {
 		return nil, fmt.Errorf("Loop window sizes must be non-zero")
 	}
+	if config.OCSPStaleMaxAge.Duration == 0 {
+		// Default to 30 days
+		config.OCSPStaleMaxAge = cmd.ConfigDuration{Duration: time.Hour * 24 * 30}
+	}
 
 	updater := OCSPUpdater{
 		stats:               stats,
@@ -100,6 +106,7 @@ func newUpdater(
 		pubc:                pub,
 		numLogs:             numLogs,
 		ocspMinTimeToExpiry: config.OCSPMinTimeToExpiry.Duration,
+		ocspStaleMaxAge:     config.OCSPStaleMaxAge.Duration,
 		oldestIssuedSCT:     config.OldestIssuedSCT.Duration,
 	}
 
@@ -209,6 +216,8 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 	var statuses []core.CertificateStatus
 	// TODO(@cpu): Once the notafter-backfill cmd has been run & completed then
 	// the query below can be rewritten to use `AND NOT cs.isExpired`.
+	now := updater.clk.Now()
+	maxAgeCutoff := now.Add(-updater.ocspStaleMaxAge)
 	_, err := updater.dbMap.Select(
 		&statuses,
 		`SELECT
@@ -218,12 +227,14 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 			 FROM certificateStatus AS cs
 			 JOIN certificates AS cert
 			 ON cs.serial = cert.serial
-			 WHERE cs.ocspLastUpdated < :lastUpdate
+			 WHERE cs.ocspLastUpdated > :maxAge
+			 AND cs.ocspLastUpdated < :lastUpdate
 			 AND cert.expires > now()
 			 ORDER BY cs.ocspLastUpdated ASC
 			 LIMIT :limit`,
 		map[string]interface{}{
 			"lastUpdate": oldestLastUpdatedTime,
+			"maxAge":     maxAgeCutoff,
 			"limit":      batchSize,
 		},
 	)

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -11,6 +11,7 @@
     "missingSCTBatchSize": 5000,
     "revokedCertificateBatchSize": 1000,
     "ocspMinTimeToExpiry": "72h",
+    "ocspStaleMaxAge": "720h",
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",


### PR DESCRIPTION
This PR adds a new `OCSPStaleMaxAge` configuration parameter to the `ocsp-updater`. The default value when not provided is 30 days, and this is explicitly added to both `config/ocsp-updater.json` and `config-next/ocsp-updater.json`. 

The OCSP updater uses this new parameter in `findStaleOCSPResponses` as a lower bound on the `ocspLastUpdated` field of the certificateStatus table. This is intended to speed up the processing of this query until we can land the proper fixes that require more intensive migrations & backfilling. 

The `TestGenerateOCSPResponses` and `TestFindStaleOCSPResponses` unit tests had to be updated to explicitly set the `ocspLastUpdated` field of the certificate status rows that the tests add, because otherwise they are left at a default value of `0` and are excluded by the new `OCSPStaleMaxAge` functionality.