### PR TITLE
Sign OCSP in parallel for better performance.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -224,9 +224,10 @@ type OCSPUpdaterConfig struct {
 	MissingSCTBatchSize         int
 	RevokedCertificateBatchSize int
 
-	OCSPMinTimeToExpiry ConfigDuration
-	OCSPStaleMaxAge     ConfigDuration
-	OldestIssuedSCT     ConfigDuration
+	OCSPMinTimeToExpiry          ConfigDuration
+	OCSPStaleMaxAge              ConfigDuration
+	OldestIssuedSCT              ConfigDuration
+	ParallelGenerateOCSPRequests int
 
 	AkamaiBaseURL           string
 	AkamaiClientToken       string

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -760,7 +760,6 @@ func main() {
 	dbURL, err := conf.DBConfig.URL()
 	cmd.FailOnError(err, "Couldn't load DB URL")
 	dbMap, err := sa.NewDbMap(dbURL, conf.DBConfig.MaxDBConns)
-	sa.SetSQLDebug(dbMap, auditlogger)
 	cmd.FailOnError(err, "Could not connect to database")
 	go sa.ReportDbConnCount(dbMap, scope)
 

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -220,7 +220,7 @@ func TestGenerateOCSPResponses(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't find stale responses")
 	test.AssertEquals(t, len(certs), 2)
 
-	err = updater.generateOCSPResponses(ctx, certs)
+	err = updater.generateOCSPResponses(ctx, certs, metrics.NewNoopScope())
 	test.AssertNotError(t, err, "Couldn't generate OCSP responses")
 
 	certs, err = updater.findStaleOCSPResponses(earliest, 10)

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -30,7 +30,9 @@ import (
 
 var ctx = context.Background()
 
-type mockCA struct{}
+type mockCA struct {
+	sleepTime time.Duration
+}
 
 func (ca *mockCA) IssueCertificate(_ context.Context, csr x509.CertificateRequest, regID int64) (core.Certificate, error) {
 	return core.Certificate{}, nil
@@ -38,6 +40,7 @@ func (ca *mockCA) IssueCertificate(_ context.Context, csr x509.CertificateReques
 
 func (ca *mockCA) GenerateOCSP(_ context.Context, xferObj core.OCSPSigningRequest) (ocsp []byte, err error) {
 	ocsp = []byte{1, 2, 3}
+	time.Sleep(ca.sleepTime)
 	return
 }
 
@@ -220,8 +223,20 @@ func TestGenerateOCSPResponses(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't find stale responses")
 	test.AssertEquals(t, len(certs), 2)
 
+	// Hacky test of parallelism: Make each request to the CA take 1 second, and
+	// produce 2 requests to the CA. If the pair of requests complete in about a
+	// second, they were made in parallel.
+	// Note that this test also tests the basic functionality of
+	// generateOCSPResponses.
+	start := time.Now()
+	updater.cac = &mockCA{time.Second}
+	updater.parallelGenerateOCSPRequests = 10
 	err = updater.generateOCSPResponses(ctx, certs, metrics.NewNoopScope())
 	test.AssertNotError(t, err, "Couldn't generate OCSP responses")
+	elapsed := time.Since(start)
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("generateOCSPResponses took too long, expected it to make calls in parallel.")
+	}
 
 	certs, err = updater.findStaleOCSPResponses(earliest, 10)
 	test.AssertNotError(t, err, "Failed to find stale responses")

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -9,6 +9,7 @@
     "newCertificateBatchSize": 1000,
     "oldOCSPBatchSize": 5000,
     "missingSCTBatchSize": 5000,
+    "parallelGenerateOCSPRequests": 10,
     "revokedCertificateBatchSize": 1000,
     "ocspMinTimeToExpiry": "72h",
     "ocspStaleMaxAge": "720h",

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -8,6 +8,7 @@
     "revokedCertificateWindow": "1s",
     "newCertificateBatchSize": 1000,
     "oldOCSPBatchSize": 5000,
+    "parallelGenerateOCSPRequests": 10,
     "missingSCTBatchSize": 5000,
     "revokedCertificateBatchSize": 1000,
     "ocspMinTimeToExpiry": "72h",

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -43,7 +43,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 7
+    "stdoutlevel": 6
   },
 
   "common": {

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -43,7 +43,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 6
+    "stdoutlevel": 7
   },
 
   "common": {


### PR DESCRIPTION
Previously all OCSP signing and storage would be serial, which meant it was hard
to exercise the full capacity of our HSM. In this change, we run a limited
number of update and store requests in parallel.

This change also changes stats generation in generateOCSPResponses so we can
tell the difference between stats produced by new OCSP requests vs existing ones,
and adds a new stat that records how long the SQL query in findStaleOCSPResponses
takes.