### PR TITLE
`certificateStatus` table optimizations (Part Three)

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -540,7 +540,7 @@ func (updater *OCSPUpdater) oldOCSPResponsesTick(ctx context.Context, batchSize 
 	// certificates we come across
 	if features.Enabled(features.CertStatusOptimizationsMigrated) {
 		for _, s := range statuses {
-			if !s.IsExpired && s.NotAfter.Before(tickStart) {
+			if !s.IsExpired && tickStart.After(s.NotAfter) {
 				err := updater.markExpired(s)
 				if err != nil {
 					return err

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -526,14 +526,15 @@ func (updater *OCSPUpdater) generateOCSPResponses(ctx context.Context, statuses 
 // oldOCSPResponsesTick looks for certificates with stale OCSP responses and
 // generates/stores new ones
 func (updater *OCSPUpdater) oldOCSPResponsesTick(ctx context.Context, batchSize int) error {
-	tickStart := time.Now()
+	tickStart := updater.clk.Now()
 	statuses, err := updater.findStaleOCSPResponses(tickStart.Add(-updater.ocspMinTimeToExpiry), batchSize)
 	if err != nil {
 		updater.stats.Inc("Errors.FindStaleResponses", 1)
 		updater.log.AuditErr(fmt.Sprintf("Failed to find stale OCSP responses: %s", err))
 		return err
 	}
-	updater.stats.TimingDuration("oldOCSPResponsesTick.QueryTime", time.Since(tickStart))
+	tickEnd := updater.clk.Now()
+	updater.stats.TimingDuration("oldOCSPResponsesTick.QueryTime", tickEnd.Sub(tickStart))
 
 	// If the CertStatusOptimizationsMigrated flag is set then we need to
 	// opportunistically update the certificateStatus `isExpired` column for expired

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -39,7 +39,8 @@
       "timeout": "15s"
     },
     "features": {
-      "ResubmitMissingSCTsOnly": true
+      "ResubmitMissingSCTsOnly": true,
+      "CertStatusOptimizationsMigrated": true
     }
   },
 


### PR DESCRIPTION
Following on to https://github.com/letsencrypt/boulder/pull/2177 and https://github.com/letsencrypt/boulder/issues/2227 this PR adds code to the `ocsp-updater` that takes advantage of the migrations & backfill from the previous optimization PRs.

This has the primary effect of removing the `JOIN` on the `certificates` table in the `findStaleOCSPResponses` query. We expect this to be a big win in terms of query performance.

The `ocsp-updater` is also updated to opportunistically fill in the newly added `isExpired` field of the `CertificateStatus` table as it encounters rows that aren't marked as expired but correspond to an expired certificate.

Resolves https://github.com/letsencrypt/boulder/issues/2238 and #2239