### PR TITLE
`certificateStatus` table optimizations (Part Four)

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
 	bmail "github.com/letsencrypt/boulder/mail"
@@ -244,8 +245,9 @@ func (m *mailer) findExpiringCertificates() error {
 		// in a slightly more efficient way by looking at `cs.NotAfter` instead of
 		// `cert.expires` in the WHERE clause.
 		var certs []core.Certificate
+		var err error
 		if features.Enabled(features.CertStatusOptimizationsMigrated) {
-			_, err := m.dbMap.Select(
+			_, err = m.dbMap.Select(
 				&certs,
 				`SELECT cert.* FROM certificates AS cert
 				 JOIN certificateStatus AS cs
@@ -264,7 +266,7 @@ func (m *mailer) findExpiringCertificates() error {
 				},
 			)
 		} else {
-			_, err := m.dbMap.Select(
+			_, err = m.dbMap.Select(
 				&certs,
 				`SELECT cert.* FROM certificates AS cert
 						 JOIN certificateStatus AS cs

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -239,25 +239,50 @@ func (m *mailer) findExpiringCertificates() error {
 
 		m.log.Info(fmt.Sprintf("expiration-mailer: Searching for certificates that expire between %s and %s and had last nag >%s before expiry",
 			left.UTC(), right.UTC(), expiresIn))
+
+		// If CertStatusOptimizationsMigrated is enabled then we can do this query
+		// in a slightly more efficient way by looking at `cs.NotAfter` instead of
+		// `cert.expires` in the WHERE clause.
 		var certs []core.Certificate
-		_, err := m.dbMap.Select(
-			&certs,
-			`SELECT cert.* FROM certificates AS cert
-			 JOIN certificateStatus AS cs
-			 ON cs.serial = cert.serial
-			 AND cert.expires > :cutoffA
-			 AND cert.expires <= :cutoffB
-			 AND cs.status != "revoked"
-			 AND COALESCE(TIMESTAMPDIFF(SECOND, cs.lastExpirationNagSent, cert.expires) > :nagCutoff, 1)
-			 ORDER BY cert.expires ASC
-			 LIMIT :limit`,
-			map[string]interface{}{
-				"cutoffA":   left,
-				"cutoffB":   right,
-				"nagCutoff": expiresIn.Seconds(),
-				"limit":     m.limit,
-			},
-		)
+		if features.Enabled(features.CertStatusOptimizationsMigrated) {
+			_, err := m.dbMap.Select(
+				&certs,
+				`SELECT cert.* FROM certificates AS cert
+				 JOIN certificateStatus AS cs
+				 ON cs.serial = cert.serial
+				 AND cs.notAfter > :cutoffA
+				 AND cs.notAfter <= :cutoffB
+				 AND cs.status != "revoked"
+				 AND COALESCE(TIMESTAMPDIFF(SECOND, cs.lastExpirationNagSent, cert.expires) > :nagCutoff, 1)
+				 ORDER BY cert.expires ASC
+				 LIMIT :limit`,
+				map[string]interface{}{
+					"cutoffA":   left,
+					"cutoffB":   right,
+					"nagCutoff": expiresIn.Seconds(),
+					"limit":     m.limit,
+				},
+			)
+		} else {
+			_, err := m.dbMap.Select(
+				&certs,
+				`SELECT cert.* FROM certificates AS cert
+						 JOIN certificateStatus AS cs
+						 ON cs.serial = cert.serial
+						 AND cert.expires > :cutoffA
+						 AND cert.expires <= :cutoffB
+						 AND cs.status != "revoked"
+						 AND COALESCE(TIMESTAMPDIFF(SECOND, cs.lastExpirationNagSent, cert.expires) > :nagCutoff, 1)
+						 ORDER BY cert.expires ASC
+						 LIMIT :limit`,
+				map[string]interface{}{
+					"cutoffA":   left,
+					"cutoffB":   right,
+					"nagCutoff": expiresIn.Seconds(),
+					"limit":     m.limit,
+				},
+			)
+		}
 		if err != nil {
 			m.log.AuditErr(fmt.Sprintf("expiration-mailer: Error loading certificates: %s", err))
 			return err // fatal

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -18,6 +18,9 @@
       "clientCertificatePath": "test/grpc-creds/boulder-client/cert.pem",
       "clientKeyPath": "test/grpc-creds/boulder-client/key.pem",
       "timeout": "15s"
+    },
+    "features": {
+      "CertStatusOptimizationsMigrated": true
     }
   },
 


### PR DESCRIPTION
Similar to #2431 the expiration-mailer's `findExpiringCertificates()` query can be optimized slightly by using `certificateStatus.NotAfter` in place of `certificate.expires` in the `WHERE` clause of its query when the `CertStatusOptimizationsMigrated` feature is enabled.

Resolves https://github.com/letsencrypt/boulder/issues/2425