### PR TITLE
Include domain name in email subj

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -113,7 +113,6 @@ func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
 			subject += fmt.Sprintf(" (and %d more)", len(domains)-1)
 		}
 	}
-	m.log.Debug(fmt.Sprintf("Message subject %q", subject))
 
 	email := emailContent{
 		ExpirationDate:   expDate.UTC().Format(time.RFC822Z),

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -98,8 +98,23 @@ func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
 	}
 	domains = core.UniqueLowerNames(domains)
 	sort.Strings(domains)
-
 	m.log.Debug(fmt.Sprintf("Sending mail for %s (%s)", strings.Join(domains, ", "), strings.Join(serials, ", ")))
+
+	var subject string
+	if m.subject != "" {
+		// If there is a subject from the configuration file, we should use it as-is
+		// to preserve the "classic" behaviour before we added a domain name.
+		subject = m.subject
+	} else {
+		// Otherwise, when no subject is configured we should make one using the
+		// domain names in the expiring certificate
+		subject = fmt.Sprintf("Certificate expiration notice for domain %q", domains[0])
+		if len(domains) > 1 {
+			subject += fmt.Sprintf(" (and %d more)", len(domains)-1)
+		}
+	}
+	fmt.Printf("Subject: %s\n", subject)
+	m.log.Debug(fmt.Sprintf("Message subject %q", subject))
 
 	email := emailContent{
 		ExpirationDate:   expDate.UTC().Format(time.RFC822Z),
@@ -113,7 +128,7 @@ func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
 		return err
 	}
 	startSending := m.clk.Now()
-	err = m.mailer.SendMail(emails, m.subject, msgBuf.String())
+	err = m.mailer.SendMail(emails, subject, msgBuf.String())
 	if err != nil {
 		return err
 	}
@@ -455,13 +470,9 @@ func main() {
 	// Make sure durations are sorted in increasing order
 	sort.Sort(nags)
 
-	subject := "Certificate expiration notice"
-	if c.Mailer.Subject != "" {
-		subject = c.Mailer.Subject
-	}
 	m := mailer{
 		stats:         scope,
-		subject:       subject,
+		subject:       c.Mailer.Subject,
 		log:           logger,
 		dbMap:         dbMap,
 		rs:            sac,

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -113,7 +113,6 @@ func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
 			subject += fmt.Sprintf(" (and %d more)", len(domains)-1)
 		}
 	}
-	fmt.Printf("Subject: %s\n", subject)
 	m.log.Debug(fmt.Sprintf("Message subject %q", subject))
 
 	email := emailContent{

--- a/cmd/expiration-mailer/send_test.go
+++ b/cmd/expiration-mailer/send_test.go
@@ -45,7 +45,7 @@ func TestSendEarliestCertInfo(t *testing.T) {
 	}
 	domains := "example-a.com\nexample-b.com\nshared-example.com"
 	expected := mocks.MailerMessage{
-		Subject: "",
+		Subject: "Certificate expiration notice for domain \"example-a.com\" (and 2 more)",
 		Body: fmt.Sprintf(`hi, cert for DNS names %s is going to expire in 2 days (%s)`,
 			domains,
 			rawCertB.NotAfter.Format(time.RFC822Z)),


### PR DESCRIPTION
This PR modifies the `expiration-mailer` utility to change the subject used in the reminder emails to include a domain name from the expiring certificate.

Previously unless otherwise specified using the `Mailer.Subject` configuration parameter all reminder emails were sent with the subject `Certificate expiration notice`. Both the `test/config/` and `test/config-next` expiration mailer configurations do not override the subject and were using the default.

With this PR, if no `Mailer.Subject` configuration parameter is provided then reminder emails are sent with the subject `Certificate expiration notice for domain "foo.bar.com"` in the case of only one domain in the expiring certificate, and `Certificate expiration for domain "foo.bar.com" (and $(n-1) more)` for the case where there are n > 1 domains (e.g. "(and 1 more)", "(and 2 more)" ...). I explicitly left support for the `Mailer.Subject` override to allow legacy configurations to function.

I didn't explicitly add a new unit test for this behaviour because the existing unit tests were exercising both the "configuration override" portion of the subject behaviour, and matching the new expected subject. It would be entirely duplicated code to write a separate test for the subject template.

Resolves #2411