### PR TITLE
Fixes Section 6.3 and Section 5.4.1 divergences.

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -8,7 +8,7 @@ Current draft: [`draft-ietf-acme-acme-04`](https://tools.ietf.org/html/draft-iet
 
 ## [Section 5.4.1](https://tools.ietf.org/html/draft-ietf-acme-acme-04#section-5.4.1)
 
-Boulder does not use the `url` field from the JWS protected resource. Instead Boulder will validate the `resource` field from the JWS protected header matches the resource being requested.
+Boulder does not use the `url` field from the JWS protected resource. Instead Boulder will validate the `resource` field from the JWS payload matches the resource being requested. Boulder implements the resource types described in [draft-ietf-acme-02 Section 6.1](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.1) plus the additional "KeyChange" resource. Boulder verifies the `resource` field contains the `/directory` URI for the requested resource.
 
 ## [Section 5.6.](https://tools.ietf.org/html/draft-ietf-acme-acme-04#section-5.6)
 
@@ -50,7 +50,7 @@ Boulder doesn't implement the `new-nonce` endpoint, instead it responds to `HEAD
 
 Boulder only allows `mailto` URIs in the registrations `contact` list.
 
-Boulder uses a HTTP status code 409 (Conflict) response when providing the Content-Location header to an already existing registration.
+Boulder uses a HTTP status code 409 (Conflict) response for an already existing registration instead of 200 (OK). Boulder returns the URI of the already existing registration in a `Location` header field instead of a `Content-Location` header field.
 
 ## [Section 6.3.2.](https://tools.ietf.org/html/draft-ietf-acme-acme-04#section-6.3.2)
 


### PR DESCRIPTION
As pointed out by @webczat (Thanks again!), my last update to `acme-divergences.md` https://github.com/letsencrypt/boulder/pull/2402 was still a little bit off-the-mark accuracy wise.

This PR resolves the problems (fingers crossed! :crossed_flags:) that remained with the documentation of the Section 6.3 "URL field" divergence and the Section 5.4.1 "existing registration" divergence.

Resolves https://github.com/letsencrypt/boulder/issues/2414