### PR TITLE
Fix akamai cache purger bugs

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -205,7 +205,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 	if err != nil {
 		return err
 	}
-	if purgeInfo.HTTPStatus != 201 || resp.StatusCode != 201 {
+	if purgeInfo.HTTPStatus != http.StatusCreated || resp.StatusCode != http.StatusCreated {
 		if purgeInfo.HTTPStatus == http.StatusForbidden {
 			return errFatal(fmt.Sprintf("Unauthorized to purge URLs %q", urls))
 		}

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -209,7 +209,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 		if purgeInfo.HTTPStatus == http.StatusForbidden {
 			return errFatal(fmt.Sprintf("Unauthorized to purge URLs %q", urls))
 		}
-		return fmt.Errorf("Unexpected HTTP status code: %s", string(body))
+		return fmt.Errorf("Unexpected HTTP status code '%d': %s", resp.StatusCode, string(body))
 	}
 
 	cpc.log.Info(fmt.Sprintf(

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -92,6 +92,7 @@ func (as *akamaiServer) akamaiHandler(w http.ResponseWriter, r *http.Request) {
 	for _, testURL := range req.Objects {
 		if !strings.HasPrefix(testURL, "http://") {
 			resp.HTTPStatus = http.StatusForbidden
+			break
 		}
 	}
 

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -108,11 +109,13 @@ func TestPurge(t *testing.T) {
 	log := blog.NewMock()
 
 	as := akamaiServer{responseCode: http.StatusCreated}
-	http.HandleFunc("/", as.akamaiHandler)
-	go http.ListenAndServe(":9999", nil)
+	m := http.NewServeMux()
+	server := httptest.NewUnstartedServer(m)
+	m.HandleFunc("/", as.akamaiHandler)
+	server.Start()
 
 	client, err := NewCachePurgeClient(
-		"http://localhost:9999",
+		server.URL,
 		"token",
 		"secret",
 		"accessToken",

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
+	"strings"
 	"time"
 
 	"github.com/jmhodges/clock"
@@ -218,9 +218,12 @@ func (updater *OCSPUpdater) sendPurge(der []byte) {
 	// do GET)
 	urls := []string{}
 	for _, ocspServer := range cert.OCSPServer {
+		if !strings.HasSuffix(ocspServer, "/") {
+			ocspServer += "/"
+		}
 		urls = append(
 			urls,
-			path.Join(ocspServer, url.QueryEscape(base64.StdEncoding.EncodeToString(req))),
+			fmt.Sprintf("%s%s", ocspServer, url.QueryEscape(base64.StdEncoding.EncodeToString(req))),
 		)
 	}
 


### PR DESCRIPTION
Fixes two bugs in the Akamai cache purging library and one in the `ocsp-updater` and adds some tests to the Akamai library.

* The first was that the backoff logic was broken, the backoff was calculated but discarded as it was assumed the sleep happened inside `core.RetryBackoff` instead of it returning the amount of time to backoff.
* The second was that the internal HTTP client would only log errors if they were fatal which was superfluous as the caller would also log the fatal errors and masked what the actual issue was during retries.
* The last in `ocsp-updater` was that `path.Join` was used to create a URL which is not an intended use of the method as it attempts to clean paths. This meant that the scheme prefix `http://` would be 'cleaned' to `http:/`, since Akamai has no idea what the malformed URLs referred to it would return 403 Forbidden which we could consider a temporary error and retry until failure.