### PR TITLE
Removes `ProblemDetailsForError` from `verifyPOST`.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -482,7 +482,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *requestEve
 			return nil, nil, reg, probs.Unauthorized(unknownKey)
 		}
 
-		return nil, nil, reg, core.ProblemDetailsForError(err, "")
+		return nil, nil, reg, probs.ServerInternal("Failed to get registration by key")
 	} else {
 		// If the lookup was successful, use that key.
 		key = reg.Key


### PR DESCRIPTION
Prior to this PR, when there was an err from `wfe.SA.GetRegistrationByKey`, and that error wasn't an instance of `core.NoSuchRegistrationError`, `verifyPOST` converted the error into a problem by sending it through `core.ProblemDetailsForError(err, "")`.

In this case, this isn't an appropriate strategy. The only possible errors that can be sent through this function will not match any of the `case` statements in `core.ProblemDetailsForError` and will be returned by the `default` case:

```
default:
  // Internal server error messages may include sensitive data, so we do
  // not include it.
  return probs.ServerInternal(msg)
```

Since `verifyPOST` calls this function with `msg = ""`, `ProblemDetailsForError` will return an empty `ServerInternalProblem`. When the caller of `verifyPOST` gives the returned serv internal problem to `sendError` it will produce: `"Internal error -  - %!s(<nil>)"` because the problem's detail is "" and the error code given to `sendError` is nil.

Since having examined the code paths in `verifyPOST` before `core.ProblemDetailsForError` won't ever match anything but the default case producing a blank message it seems the proper fix here is to not use `ProblemDetailsForError` at all and instead directly instantiate a `ServerInternalProblem` with a suitable message. This will fix the empty audit log line and make debugging clearer.

Fixes https://github.com/letsencrypt/boulder/issues/2430