### PR TITLE
Add instructions to fetch boulder into $GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Boulder has a Dockerfile to make it easy to install and set up all its
 dependencies. This is how the maintainers work on Boulder, and is our main
 recommended way to run it.
 
+Make sure you have a local copy of Boulder in your `$GOPATH`:
+
+    go get github.com/letsencrypt/boulder
+
 To start Boulder in a Docker container, run:
 
     docker-compose up


### PR DESCRIPTION
When cloning this repository it is not clear that you need to get boulder first. Starting directly with `docker-compose up` fails.