### PR TITLE
Improve Docker instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ recommended way to run it.
 
 Make sure you have a local copy of Boulder in your `$GOPATH`:
 
-    go get github.com/letsencrypt/boulder
+    export GOPATH=~/gopath
+    git clone https://github.com/letsencrypt/boulder/ $GOPATH/src/github.com/letsencrypt/boulder
 
 To start Boulder in a Docker container, run:
 


### PR DESCRIPTION
Previously the instructions assumed you had Go setup on your host, which
somewhat defeates the point of running Boulder inside Docker, since it requires
more initial setup. These instructions make first-time users less likely to hit
the oci runtime error described later in the README.