### PR TITLE
Fix the `config/publisher.json` clientNames list.

### DIFF
--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -9,7 +9,8 @@
       "serverCertificatePath": "test/grpc-creds/publisher.boulder/cert.pem",
       "serverKeyPath": "test/grpc-creds/publisher.boulder/key.pem",
       "clientNames": [
-        "boulder-client"
+        "ra.boulder",
+        "ocsp-updater.boulder"
       ]
     },
     "amqp": {


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/pull/2453 we created individual client certificates for each gRPC client. The "clientNames" list in `config-next/publisher.json` was updated for the new
component-specific SANs but we neglected to updated `config/publisher.json`. This caused the `ocsp-updater` (which uses gRPC in the base `config/` to talk to the `publisher`) to fail.

This PR updates `config/publisher.json` to have the same clientNames as `config-next/publisher.json` and resolves #2465