### PR TITLE
Skip parsing of certificates in OCSP Updater.

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -334,11 +334,6 @@ func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.Ce
 		return nil, err
 	}
 
-	_, err = x509.ParseCertificate(cert.DER)
-	if err != nil {
-		return nil, err
-	}
-
 	signRequest := core.OCSPSigningRequest{
 		CertDER:   cert.DER,
 		Reason:    status.RevokedReason,


### PR DESCRIPTION
The result is thrown away, so this adds a slight performance overhead for no
benefit. In theory it would catch malformed certificates in the DB, but that is
the job of cert-checker.