### PR TITLE
Add Prometheus to docker-compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,3 +55,13 @@ brabbitmq:
     environment:
         RABBITMQ_NODE_IP_ADDRESS: "0.0.0.0"
     log_driver: none
+prom:
+    image: prom/prometheus
+    net: bridge
+    ports:
+      - 9090:9090
+    volumes:
+      - $PWD/test/prometheus/:/promconf/
+    command: -config.file /promconf/prometheus.yml
+    links:
+      - boulder

--- a/test/prometheus/prometheus.yml
+++ b/test/prometheus/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval:     1s
+
+scrape_configs:
+  - job_name: 'boulder'
+    static_configs:
+      - targets:
+        - boulder:8001
+        - boulder:8002
+        - boulder:8003
+        - boulder:8004
+        - boulder:8005
+        - boulder:8006
+        - boulder:8007
+        - boulder:8008
+        - boulder:8009
+        - boulder:8010


### PR DESCRIPTION
This makes it easier to test monitoring of local Boulder instances, and look at stats when load testing.

Note that this creates a dependency from prom -> boulder that can only be satisfied by `docker-compose up` or `docker-compose up boulder`, not by `docker-compose run --service-ports boulder` (since docker-compose doesn't see the latter as a full-fledged boulder instance).