### PR TITLE
Add some timing histogram stats

### DIFF
--- a/grpc/client.go
+++ b/grpc/client.go
@@ -28,7 +28,7 @@ func ClientSetup(c *cmd.GRPCClientConfig, tls *tls.Config, stats metrics.Scope) 
 		return nil, errNilTLS
 	}
 
-	grpc_prometheus.EnableHandlingTimeHistogram()
+	grpc_prometheus.EnableClientHandlingTimeHistogram()
 
 	ci := clientInterceptor{stats.NewScope("gRPCClient"), clock.Default(), c.Timeout.Duration}
 	creds := bcreds.NewClientCredentials(tls.RootCAs, tls.Certificates)


### PR DESCRIPTION
Previously our gRPC client code called the wrong function, enabling server-side instead of client-side histograms.

Also, add a timing stat for the generate / store combination in OCSP Updater.