### PR TITLE
Update OCSP load testing doc.

### DIFF
--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -15,54 +15,39 @@ Check that the port is open:
     local-machine$ nc -zv remote-machine 5657
     Connection to remote-machine 5657 port [tcp/*] succeeded!
 
-Set up a handy alias:
+Edit docker-compose.yml to change these in the "boulder" section's "env":
 
-    local-machine$ alias drun="docker-compose run -e PKCS11_PROXY_SOCKET=tcp://remote-machine:5657 -e FAKE_DNS=172.17.0.1 --service-ports"
+    PKCS11_PROXY_SOCKET: tcp://remote-machine:5657
+    FAKE_DNS: 172.17.0.1
 
 Run the pkcs11key benchmark to check raw signing speed at various settings for SESSIONS:
 
-    local-machine$ drun -e SESSIONS=4 -e MODULE=/usr/local/lib/libpkcs11-proxy.so --entrypoint /go/src/github.com/letsencrypt/pkcs11key/test.sh boulder
+    local-machine$ docker-compose run -e SESSIONS=4 -e MODULE=/usr/local/lib/libpkcs11-proxy.so --entrypoint /go/src/github.com/letsencrypt/pkcs11key/test.sh boulder
 
 Initialize the tokens for use by Boulder:
 
-    local-machine$ drun --entrypoint "softhsm --module /usr/local/lib/libpkcs11-proxy.so --init-token --pin 5678 --so-pin 1234 --slot 0 --label intermediate" boulder
-    local-machine$ drun --entrypoint "softhsm --module /usr/local/lib/libpkcs11-proxy.so --init-token --pin 5678 --so-pin 1234 --slot 1 --label root" boulder
+    local-machine$ docker-compose run --entrypoint "softhsm --module /usr/local/lib/libpkcs11-proxy.so --init-token --pin 5678 --so-pin 1234 --slot 0 --label intermediate" boulder
+    local-machine$ docker-compose run --entrypoint "softhsm --module /usr/local/lib/libpkcs11-proxy.so --init-token --pin 5678 --so-pin 1234 --slot 1 --label root" boulder
+
+Configure Boulder to always consider all OCSP responses instantly stale, so it
+will sign new ones as fast as it can. Edit "ocspMinTimeToExpiry" in
+test/config/ocsp-updater.json (or test/config-next/ocsp-updater.json):
+
+    "ocspMinTimeToExpiry": "0h",
 
 Run a local Boulder instance:
 
-    local-machine$ drun boulder ./start.py
+    local-machine$ docker-compose up
 
-Issue a bunch of certificates with test.js, ideally more than a hundred. Note:
-you may already have more than a hundred certificates already issued in your
-local database. If so, no need to do more.
+Issue a bunch of certificates with test.js, ideally a few thousand
+(corresponding to the default batch size of 5000 in ocsp-updater.json, to make
+sure each batch is maxed out):
 
-Using a MySQL client, artificially make all the OCSP responses go stale (9 days
-is chosen to be between ocspStaleMaxAge and ocspMinTimeToExpiry in
-test/config/ocsp-updater.json):
+    while true; do nodejs test.js --domains $(openssl rand -hex 4).com  ; done
 
-    local-machine$ docker-compose run boulder mysql -h boulder-mysql -u root -D boulder_sa_integration
-    MariaDB [boulder_sa_integration]> update certificateStatus set ocspLastUpdated = DATE_SUB(NOW(), INTERVAL 9 DAY);
-    Query OK, 641 rows affected (0.02 sec)
-    Rows matched: 641  Changed: 641  Warnings: 0
+Use the local Prometheus instance to graph the number of complete gRPC calls:
 
-Then, query the ocspLastUpdated field, grouping by second. You should see the
-numbers updating over the next few seconds. The count per second gives you a
-rough idea of how quickly ocsp-updater was able to refresh the results.
-
-    MariaDB [boulder_sa_integration]> select count(*), ocspLastUpdated from certificateStatus group by ocspLastUpdated;
-    +----------+---------------------+
-    | count(*) | ocspLastUpdated     |
-    +----------+---------------------+
-    |      271 | 2016-12-21 07:00:22 |
-    |       19 | 2016-12-30 07:00:22 |
-    |       75 | 2016-12-30 07:00:23 |
-    |       88 | 2016-12-30 07:00:24 |
-    |       88 | 2016-12-30 07:00:25 |
-    |       86 | 2016-12-30 07:00:26 |
-    |       15 | 2016-12-30 07:00:27 |
-    +----------+---------------------+
-
-For instance, this represents a peak speed of about 88 signatures per second.
+http://localhost:9090/graph?g0.range_input=5m&g0.expr=irate(grpc_client_handled_total%7Bgrpc_method%3D%22GenerateOCSP%22%7D%5B1m%5D)&g0.tab=0
 
 If you vary the NumSessions config value in test/config/ca.json, you should see
 the signing speed vary linearly, up to the number of cores in the remote

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -43,7 +43,7 @@ Issue a bunch of certificates with test.js, ideally a few thousand
 (corresponding to the default batch size of 5000 in ocsp-updater.json, to make
 sure each batch is maxed out):
 
-    while true; do nodejs test.js --domains $(openssl rand -hex 4).com  ; done
+    local-machine$ while true; do nodejs test.js --domains $(openssl rand -hex 4).com  ; done
 
 Use the local Prometheus instance to graph the number of complete gRPC calls:
 


### PR DESCRIPTION
Prefer up over start to allow prometheus container to find boulder.
Use ocspMinTimeToExpiry: 0h trick instead of updating DB manually.

Offer command to fill DB.

Offer Prometheus link to throughput graph.