### PR TITLE
Only send cache purge request if generated OCSP has 'revoked' status

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -349,12 +349,6 @@ func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.Ce
 	status.OCSPLastUpdated = updater.clk.Now()
 	status.OCSPResponse = ocspResponse
 
-	// Purge OCSP response from CDN, gated on client having been initialized
-	// and status being 'revoked'
-	if updater.ccu != nil && status.Status == core.OCSPStatusRevoked {
-		go updater.sendPurge(cert.DER)
-	}
-
 	return &status, nil
 }
 

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -350,7 +350,8 @@ func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.Ce
 	status.OCSPResponse = ocspResponse
 
 	// Purge OCSP response from CDN, gated on client having been initialized
-	if updater.ccu != nil {
+	// and status being 'revoked'
+	if updater.ccu != nil && status.Status == core.OCSPStatusRevoked {
 		go updater.sendPurge(cert.DER)
 	}
 


### PR DESCRIPTION
Gates sending the purge request on the OCSP status being `revoked`.

Fixes #2485