### PR TITLE
Add dial timeout to SQL DSNs.

### DIFF
--- a/test/secrets/ocsp_responder_dburl
+++ b/test/secrets/ocsp_responder_dburl
@@ -1,1 +1,1 @@
-ocsp_resp@tcp(boulder-mysql:3306)/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms
+ocsp_resp@tcp(boulder-mysql:3306)/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms&timeout=100ms

--- a/test/secrets/ocsp_updater_dburl
+++ b/test/secrets/ocsp_updater_dburl
@@ -1,1 +1,1 @@
-mysql+tcp://ocsp_update@boulder-mysql:3306/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms
+mysql+tcp://ocsp_update@boulder-mysql:3306/boulder_sa_integration?readTimeout=800ms&writeTimeout=800ms&timeout=100ms

--- a/test/secrets/sa_dburl
+++ b/test/secrets/sa_dburl
@@ -1,1 +1,1 @@
-mysql+tcp://sa@boulder-mysql:3306/boulder_sa_integration?readTimeout=14s&writeTimeout=14s
+mysql+tcp://sa@boulder-mysql:3306/boulder_sa_integration?readTimeout=14s&writeTimeout=14s&timeout=100ms


### PR DESCRIPTION
We're planning to add dial timeouts in prod, and want to make it consistent with dev.

Read timeout has to be fairly generous because it has to be at least as high as the longest query we expect to run. Dial timeout can be much more aggressive, because in all normal cases, dial should complete very quickly. This allows us to timeout connections more quickly when the database is slow or unavailable, returning 500 immediately rather than piling up connections and eventually returning 500.

This is mainly useful for services that serve user traffic directly and have a high number of maxDBConns. It's not as important for admin tools like the cert-checker, mailer, and so on.