### PR TITLE
Make restarting boulder in docker nicer.

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python2.7 -u
 """
 Run a local instance of Boulder for testing purposes.
 
@@ -8,6 +8,7 @@ Keeps servers alive until ^C. Exit non-zero if any servers fail to
 start, or die before ^C.
 """
 
+import errno
 import os
 import sys
 import time
@@ -25,3 +26,8 @@ try:
     sys.exit(1)
 except KeyboardInterrupt:
     print "\nstopping servers."
+except OSError, v:
+    # Ignore EINTR, which happens when we get SIGTERM or SIGINT (i.e. when
+    # someone hits Ctrl-C after running docker-compose up or start.py.
+    if v.errno != errno.EINTR:
+        raise

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -5,6 +5,7 @@ set -e -u
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # start rsyslog
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 wait_tcp_port() {

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -4,7 +4,9 @@ set -e -u
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# start rsyslog
+# Start rsyslog. Note: Sometimes for unknown reasons /var/run/rsyslogd.pid is
+# already present, which prevents the whole container from starting. We remove
+# it just in case it's there.
 rm -f /var/run/rsyslogd.pid
 service rsyslog start
 

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -44,6 +44,7 @@ def start(race_detection):
     up explicitly by calling stop(), or automatically atexit.
     """
     signal.signal(signal.SIGTERM, lambda _, __: stop())
+    signal.signal(signal.SIGINT, lambda _, __: stop())
     global processes
     forward()
     progs = [
@@ -134,6 +135,11 @@ def check():
 
 @atexit.register
 def stop():
+    # When we are about to exit, send SIGTERM to each subprocess and wait for
+    # them to nicely die. This reflects the restart process in prod and allows
+    # us to exercise the graceful shutdown code paths.
     for p in processes:
         if p.poll() is None:
             p.send_signal(signal.SIGTERM)
+    for p in processes:
+        p.wait()

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -136,4 +136,4 @@ def check():
 def stop():
     for p in processes:
         if p.poll() is None:
-            p.kill()
+            p.send_signal(signal.SIGTERM)

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -43,6 +43,7 @@ def start(race_detection):
     startup. Anything that did start before this point can be cleaned
     up explicitly by calling stop(), or automatically atexit.
     """
+    signal.signal(signal.SIGTERM, lambda _, __: stop())
     global processes
     forward()
     progs = [


### PR DESCRIPTION
- Handle SIGTERM and SIGINT in startservers.py.
- Forcibly remove rsyslog pid to avoid error.
- Use unbuffered mode for Python so the print statements (like "all servers running") get printed right away rather than at shutdown.
- Squelch an unnecessary OSError about interrupting the wait() call.