### PR TITLE
Mention the non-default challenge ports in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Alternatively, you can override the docker-compose.yml default with an environme
 
     docker-compose run -e FAKE_DNS=172.17.0.1 --service-ports boulder ./start.py
 
+Boulder's default VA configuration (`test/config/va.json`) is configured to
+connect to port 5002 to validate HTTP-01 challenges and port 5001 to validate
+TLS-SNI-01 challenges. If you want to solve challenges with a client running on
+your host you should make sure it uses these ports to respond to validation
+requests, or update the VA configuration's `portConfig` to use ports 80 and 443
+to match how the VA operates in production and staging environments.
+
 If a base image changes (i.e. `letsencrypt/boulder-tools`) you will need to rebuild
 images for both the boulder and bhsm containers and re-create them. The quickest way
 to do this is with this command:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ connect to port 5002 to validate HTTP-01 challenges and port 5001 to validate
 TLS-SNI-01 challenges. If you want to solve challenges with a client running on
 your host you should make sure it uses these ports to respond to validation
 requests, or update the VA configuration's `portConfig` to use ports 80 and 443
-to match how the VA operates in production and staging environments.
+to match how the VA operates in production and staging environments. If you use
+a host-based firewall (e.g. `ufw` or `iptables`) make sure you allow connections
+from the Docker instance to your host on the required ports.
 
 If a base image changes (i.e. `letsencrypt/boulder-tools`) you will need to rebuild
 images for both the boulder and bhsm containers and re-create them. The quickest way


### PR DESCRIPTION
By default the Boulder dev env's VA config `test/config/va.json` has
a `portConfig` that connects to port 5002 for HTTP-01 challenges and
port 5001 for TLS-SNI-01 challenges.

This can be confusing to someone that follows the FAKE_DNS guidelines
for using a client from the host machine but expects the VA to reach out
on port 80 or 443 like production/staging's VA.

This commit updates the README to include a note on the non-standard
ports and how to change them.