### PR TITLE
Fix SA wrappers for maps.

### DIFF
--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -485,7 +485,9 @@ func (sas StorageAuthorityServerWrapper) GetValidAuthorizations(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		resp.Valid = append(resp.Valid, &sapb.ValidAuthorizations_MapElement{Domain: &k, Authz: authzPB})
+		// Make a copy of k because it will be reasigned with each loop.
+		kCopy := k
+		resp.Valid = append(resp.Valid, &sapb.ValidAuthorizations_MapElement{Domain: &kCopy, Authz: authzPB})
 	}
 
 	return resp, nil
@@ -561,7 +563,9 @@ func (sas StorageAuthorityServerWrapper) CountCertificatesByNames(ctx context.Co
 	resp := &sapb.CountByNames{}
 	for k, v := range byNames {
 		castedV := int64(v)
-		resp.CountByNames = append(resp.CountByNames, &sapb.CountByNames_MapElement{Name: &k, Count: &castedV})
+		// Make a copy of k because it will be reasigned with each loop.
+		kCopy := k
+		resp.CountByNames = append(resp.CountByNames, &sapb.CountByNames_MapElement{Name: &kCopy, Count: &castedV})
 	}
 
 	return resp, nil

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -485,7 +485,7 @@ func (sas StorageAuthorityServerWrapper) GetValidAuthorizations(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		// Make a copy of k because it will be reasigned with each loop.
+		// Make a copy of k because it will be reassigned with each loop.
 		kCopy := k
 		resp.Valid = append(resp.Valid, &sapb.ValidAuthorizations_MapElement{Domain: &kCopy, Authz: authzPB})
 	}
@@ -563,7 +563,7 @@ func (sas StorageAuthorityServerWrapper) CountCertificatesByNames(ctx context.Co
 	resp := &sapb.CountByNames{}
 	for k, v := range byNames {
 		castedV := int64(v)
-		// Make a copy of k because it will be reasigned with each loop.
+		// Make a copy of k because it will be reassigned with each loop.
 		kCopy := k
 		resp.CountByNames = append(resp.CountByNames, &sapb.CountByNames_MapElement{Name: &kCopy, Count: &castedV})
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -720,7 +720,7 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 		count, ok := counts[name]
 		if !ok {
 			// Shouldn't happen, but let's be careful anyhow.
-			return errors.New("StorageAuthority failed to return a count for every name")
+			return errors.New("CountCertificatesByNames failed to return a count for every name")
 		}
 		if count >= limit.GetThreshold(name, regID) {
 			badNames = append(badNames, name)

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -5,6 +5,7 @@ import base64
 import datetime
 import json
 import os
+import random
 import re
 import shutil
 import socket
@@ -405,7 +406,8 @@ def main():
             print("\n Installing NPM modules failed")
             die(ExitStatus.Error)
         # Pick a random hostname so we don't run into certificate rate limiting.
-        domain = "www." + subprocess.check_output("openssl rand -hex 6", shell=True).strip() + "-TEST.com"
+        domain = "www.%x-TEST.com,%x-test.com" % (
+            random.randrange(2**32), random.randrange(2**32))
         challenge_types = ["http-01", "dns-01"]
 
         expected_ct_submissions = 1

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -406,7 +406,7 @@ def main():
             print("\n Installing NPM modules failed")
             die(ExitStatus.Error)
         # Pick a random hostname so we don't run into certificate rate limiting.
-        domain = "www.%x-TEST.com,%x-test.com" % (
+        domains = "www.%x-TEST.com,%x-test.com" % (
             random.randrange(2**32), random.randrange(2**32))
         challenge_types = ["http-01", "dns-01"]
 
@@ -416,7 +416,7 @@ def main():
         if int(submissionStr) > 0:
             expected_ct_submissions = int(submissionStr)+1
         for chall_type in challenge_types:
-            if run_node_test(domain, chall_type, expected_ct_submissions) != 0:
+            if run_node_test(domains, chall_type, expected_ct_submissions) != 0:
                 die(ExitStatus.NodeFailure)
             expected_ct_submissions += 1
 


### PR DESCRIPTION
We turn arrays into maps with a range command. Previously, we were taking the
address of the iteration variable in that range command, which meant incorrect
results since the iteration variable gets reassigned.

Also change the integration test to catch this error.

Fixes #2496 