### PR TITLE
Allow probs.ProblemDetails to be passed across gRPC layer

### DIFF
--- a/grpc/bcodes.go
+++ b/grpc/bcodes.go
@@ -69,7 +69,7 @@ func wrapError(err error) error {
 		pd := err.(*probs.ProblemDetails)
 		bodyBytes, jsonErr := json.Marshal(pd)
 		if jsonErr != nil {
-			return err // fail open
+			return err
 		}
 		body = string(bodyBytes)
 	} else {
@@ -104,9 +104,8 @@ func unwrapError(err error) error {
 		return core.BadNonceError(errBody)
 	case ProblemDetails:
 		pd := probs.ProblemDetails{}
-		jsonErr := json.Unmarshal([]byte(errBody), &pd)
-		if jsonErr != nil {
-			return err // fail open
+		if json.Unmarshal([]byte(errBody), &pd) != nil {
+			return err
 		}
 		return &pd
 	default:

--- a/grpc/bcodes.go
+++ b/grpc/bcodes.go
@@ -69,6 +69,8 @@ func wrapError(err error) error {
 		pd := err.(*probs.ProblemDetails)
 		bodyBytes, jsonErr := json.Marshal(pd)
 		if jsonErr != nil {
+			// Since gRPC will wrap this itself using grpc.Errorf(codes.Unknown, ...)
+			// we just pass the original error back to the caller
 			return err
 		}
 		body = string(bodyBytes)

--- a/grpc/bcodes_test.go
+++ b/grpc/bcodes_test.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -25,11 +26,12 @@ func TestErrors(t *testing.T) {
 		{core.BadNonceError("test 8"), BadNonceError},
 		{core.NoSuchRegistrationError("test 9"), NoSuchRegistrationError},
 		{core.InternalServerError("test 10"), InternalServerError},
+		{&probs.ProblemDetails{Type: probs.ConnectionProblem, Detail: "testing..."}, ProblemDetails},
 	}
 
 	for _, tc := range testcases {
 		wrappedErr := wrapError(tc.err)
 		test.AssertEquals(t, grpc.Code(wrappedErr), tc.expectedCode)
-		test.AssertEquals(t, tc.err, unwrapError(wrappedErr))
+		test.AssertDeepEquals(t, tc.err, unwrapError(wrappedErr))
 	}
 }

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -1,0 +1,57 @@
+package grpc
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"github.com/letsencrypt/boulder/core"
+	testproto "github.com/letsencrypt/boulder/grpc/test_proto"
+	"github.com/letsencrypt/boulder/probs"
+	"github.com/letsencrypt/boulder/test"
+)
+
+type errorServer struct{}
+
+func (s *errorServer) Chill(ctx context.Context, in *testproto.Time) (*testproto.Time, error) {
+	var err error
+	switch *in.Time {
+	case 0:
+		err = core.MalformedRequestError("yup")
+	case 1:
+		err = &probs.ProblemDetails{Type: probs.MalformedProblem, Detail: "yup"}
+		// case 2:
+		//	err = berrors.New(berrors.Malformed, "yup")
+	}
+	return nil, wrapError(err)
+}
+
+func TestErrorWrapping(t *testing.T) {
+	srv := grpc.NewServer()
+	testproto.RegisterChillerServer(srv, &errorServer{})
+	lis, err := net.Listen("tcp", ":19876")
+	test.AssertNotError(t, err, "Failed to listen on localhost:19876")
+	go srv.Serve(lis)
+
+	conn, err := grpc.Dial(
+		"localhost:19876",
+		grpc.WithInsecure(),
+	)
+	test.AssertNotError(t, err, "Failed to dial grpc test server")
+	client := testproto.NewChillerClient(conn)
+
+	for _, tc := range []struct {
+		code     int64
+		expected error
+	}{
+		{0, core.MalformedRequestError("yup")},
+		{1, &probs.ProblemDetails{Type: probs.MalformedProblem, Detail: "yup"}},
+	} {
+		_, err := client.Chill(context.Background(), &testproto.Time{Time: &tc.code})
+		test.Assert(t, err != nil, fmt.Sprintf("nil error returned, expected: %s", err))
+		test.AssertDeepEquals(t, unwrapError(err), tc.expected)
+	}
+}

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -34,7 +34,7 @@ func TestErrorWrapping(t *testing.T) {
 	testproto.RegisterChillerServer(srv, &errorServer{})
 	lis, err := net.Listen("tcp", ":19876")
 	test.AssertNotError(t, err, "Failed to listen on localhost:19876")
-	go srv.Serve(lis)
+	go func() { _ = srv.Serve(lis) }()
 
 	conn, err := grpc.Dial(
 		"localhost:19876",

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -23,8 +23,6 @@ func (s *errorServer) Chill(ctx context.Context, in *testproto.Time) (*testproto
 		err = core.MalformedRequestError("yup")
 	case 1:
 		err = &probs.ProblemDetails{Type: probs.MalformedProblem, Detail: "yup"}
-		// case 2:
-		//	err = berrors.New(berrors.Malformed, "yup")
 	}
 	return nil, wrapError(err)
 }
@@ -32,12 +30,12 @@ func (s *errorServer) Chill(ctx context.Context, in *testproto.Time) (*testproto
 func TestErrorWrapping(t *testing.T) {
 	srv := grpc.NewServer()
 	testproto.RegisterChillerServer(srv, &errorServer{})
-	lis, err := net.Listen("tcp", ":19876")
-	test.AssertNotError(t, err, "Failed to listen on localhost:19876")
+	lis, err := net.Listen("tcp", ":")
+	test.AssertNotError(t, err, "Failed to create listener")
 	go func() { _ = srv.Serve(lis) }()
 
 	conn, err := grpc.Dial(
-		"localhost:19876",
+		lis.Addr().String(),
 		grpc.WithInsecure(),
 	)
 	test.AssertNotError(t, err, "Failed to dial grpc test server")


### PR DESCRIPTION
Currently services will pass both `core.XXXError` and `probs.XXX` type errors across the gRPC layer. In the future (#2505) we intend to stop passing `probs.XXX` type errors across this layer but for now we need to support them until that change is landed. This patch takes the easiest path to allow this by encoding the `probs.ProblemDetails` to JSON and storing it in the gRPC error body so that it can be passed around.

Fixes #2497.