### PR TITLE
Add simple counter for signatures

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -364,6 +364,9 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, xferObj co
 
 	ocspResponse, err := issuer.ocspSigner.Sign(signRequest)
 	ca.noteSignError(err)
+	if err == nil {
+		ca.stats.Inc("Signatures.OCSP", 1)
+	}
 	return ocspResponse, err
 }
 
@@ -457,6 +460,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 		ca.log.AuditErr(fmt.Sprintf("Signing failed: serial=[%s] err=[%v]", serialHex, err))
 		return emptyCert, err
 	}
+	ca.stats.Inc("Signatures.Certificate", 1)
 
 	if len(certPEM) == 0 {
 		err = core.InternalServerError("No certificate returned by server")

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -723,6 +723,7 @@ func TestExtensions(t *testing.T) {
 	// With ca.enableMustStaple = false, should issue successfully and not add
 	// Must Staple.
 	stats.EXPECT().Inc(metricCSRExtensionTLSFeature, int64(1)).Return(nil)
+	stats.EXPECT().Inc("Signatures.Certificate", int64(1)).Return(nil)
 	noStapleCert := sign(mustStapleCSR)
 	test.AssertEquals(t, countMustStaple(t, noStapleCert), 0)
 
@@ -730,11 +731,13 @@ func TestExtensions(t *testing.T) {
 	// extension into the cert
 	ca.enableMustStaple = true
 	stats.EXPECT().Inc(metricCSRExtensionTLSFeature, int64(1)).Return(nil)
+	stats.EXPECT().Inc("Signatures.Certificate", int64(1)).Return(nil)
 	singleStapleCert := sign(mustStapleCSR)
 	test.AssertEquals(t, countMustStaple(t, singleStapleCert), 1)
 
 	// Even if there are multiple TLS Feature extensions, only one extension should be included
 	stats.EXPECT().Inc(metricCSRExtensionTLSFeature, int64(1)).Return(nil)
+	stats.EXPECT().Inc("Signatures.Certificate", int64(1)).Return(nil)
 	duplicateMustStapleCert := sign(duplicateMustStapleCSR)
 	test.AssertEquals(t, countMustStaple(t, duplicateMustStapleCert), 1)
 
@@ -750,6 +753,7 @@ func TestExtensions(t *testing.T) {
 	// Unsupported extensions should be silently ignored, having the same
 	// extensions as the TLS Feature cert above, minus the TLS Feature Extension
 	stats.EXPECT().Inc(metricCSRExtensionOther, int64(1)).Return(nil)
+	stats.EXPECT().Inc("Signatures.Certificate", int64(1)).Return(nil)
 	unsupportedExtensionCert := sign(unsupportedExtensionCSR)
 	test.AssertEquals(t, len(unsupportedExtensionCert.Extensions), len(singleStapleCert.Extensions)-1)
 }


### PR DESCRIPTION
Add a super basic counter for certificate and OCSP signatures so we have a slightly less noisy idea of our current HSM signing performance and where it is going.

Fixes #2438.