### PR TITLE
Fixes Mandrill UNSUB merge tag

### DIFF
--- a/data/production-email.template
+++ b/data/production-email.template
@@ -17,8 +17,8 @@ this certificate with a newer one that covers more or fewer names than
 the list above, you may be able to ignore this message.
 
 If you want to stop receiving all email from this address, click
-|UNSUB:https://mandrillapp.com/unsub| (Warning: this is a one-click action
-that cannot be undone)
+*|UNSUB:https://mandrillapp.com/unsub|*
+(Warning: this is a one-click action that cannot be undone)
 
 Regards,
 The Let's Encrypt Team

--- a/data/staging-email.template
+++ b/data/staging-email.template
@@ -20,8 +20,8 @@ For details about when we send these emails, please visit
 https://letsencrypt.org/docs/expiration-emails/.
 
 If you want to stop receiving all email from this address, click
-|UNSUB:https://mandrillapp.com/unsub| (Warning: this is a one-click action
-that cannot be undone)
+*|UNSUB:https://mandrillapp.com/unsub|*
+(Warning: this is a one-click action that cannot be undone)
 
 Regards,
 The Let's Encrypt Team


### PR DESCRIPTION
Per [the documentation](https://mandrill.zendesk.com/hc/en-us/articles/205583017-Can-I-add-an-automatic-unsubscribe-link-to-Mandrill-emails-) we should be using `*|UNSUB:url|*` not `|UNSUB:url|`. I also confirmed that the template that predates the Boulder `data/` version used `*|UNSUB:https://mandrillapp.com/unsub|*`.

I also moved the "WARNING" onto the preceding line. The unsubscribe URL is quite long and gnarly once its been filed in and the warning could be missed in a MUA that doesn't wrap lines well.

This resolves https://github.com/letsencrypt/boulder/issues/2523