### PR TITLE
Use latest Certbot in boulder-tools.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # To minimize the fetching of various layers this image and tag should
 # be used as the base of the bhsm container in boulder/docker-compose.yml
-FROM letsencrypt/boulder-tools:2016-11-02
+FROM letsencrypt/boulder-tools:2017-02-07
 
 # Boulder exposes its web application at port TCP 4000
 EXPOSE 4000 4002 4003 8053 8055

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ boulder:
 bhsm:
     # To minimize the fetching of various layers this should match
     # the FROM image and tag in boulder/Dockerfile
-    image: letsencrypt/boulder-tools:2016-11-02
+    image: letsencrypt/boulder-tools:2017-02-07
     environment:
         PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
     command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm.so

--- a/test.sh
+++ b/test.sh
@@ -174,23 +174,7 @@ if [[ "$RUN" =~ "integration" ]] ; then
   # Set context to integration, and force a pending state
   start_context "integration"
 
-  if [ -z "$CERTBOT_PATH" ]; then
-    export CERTBOT_PATH=$(mktemp -d -t cbpXXXX)
-    echo "------------------------------------------------"
-    echo "--- Checking out letsencrypt client is slow. ---"
-    echo "--- Recommend setting \$CERTBOT_PATH to  ---"
-    echo "--- client repo with initialized virtualenv  ---"
-    echo "------------------------------------------------"
-    # Note: We check out the tag for the release that matches the
-    # Debian-packaged Certbot version in the current letsencrypt/boulder-tools
-    # Docker image.
-    run git clone -b v0.8.1 --depth=1 https://www.github.com/certbot/certbot.git $CERTBOT_PATH || exit 1
-  fi
-
-  if ! type certbot >/dev/null 2>/dev/null; then
-    source ${CERTBOT_PATH}/${VENV_NAME:-venv}/bin/activate
-  fi
-
+  source ${CERTBOT_PATH:-/certbot}/${VENV_NAME:-venv}/bin/activate
   run python test/integration-test.py --chisel
   end_context #integration
 fi

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -2,21 +2,10 @@
 
 # Boulder deps
 apt-get update
-apt-get install -y --no-install-recommends apt-transport-https ca-certificates
-
-curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-cat >/etc/apt/sources.list.d/bouldertools.list <<EOAPT
-deb https://deb.nodesource.com/node_4.x trusty main
-deb-src https://deb.nodesource.com/node_4.x trusty main
-deb http://ftp.debian.org/debian jessie-backports main
-EOAPT
-apt-get update
-apt-get install -y --no-install-recommends  -t jessie-backports certbot python-certbot python-certbot-apache python-cffi
 
 apt-get install -y --no-install-recommends \
   libltdl-dev \
   mariadb-client-core-10.0 \
-  nodejs \
   rpm \
   ruby \
   ruby-dev \
@@ -30,7 +19,8 @@ apt-get install -y --no-install-recommends \
   opensc &
 
 # Install port forwarder, database migration tool, and testing tools.
-GOBIN=/usr/local/bin GOPATH=/tmp/gopath go get \
+export GOBIN=/usr/local/bin GOPATH=/tmp/gopath
+go get \
   github.com/jsha/listenbuddy \
   bitbucket.org/liamstask/goose/cmd/goose \
   github.com/golang/lint/golint \
@@ -46,13 +36,28 @@ GOBIN=/usr/local/bin GOPATH=/tmp/gopath go get \
 
 wait
 
+# protoc-gen-go outputs a line that says:
+# const _ = grpc.SupportPackageIsVersion4
+# so it will fail to compile with a different version of the grpc package.
+# Since we currently have version 3 of the grpc package vendored, we have to
+# build a specific version of protoc-gen-go.
+cd $GOPATH/src/github.com/golang/protobuf/protoc-gen-go
+git checkout a66a4fa9a8dd2304462f7aad7161e8bf53eee461
+go install ./
+
+git clone https://github.com/certbot/certbot /certbot
+cd /certbot
+./letsencrypt-auto --os-packages-only
+./tools/venv.sh
+cd -
+
 # Install pkcs11-proxy. Checked out commit was master HEAD at time
 # of writing
-git clone https://github.com/SUNET/pkcs11-proxy && \
-  cd pkcs11-proxy && \
+git clone https://github.com/SUNET/pkcs11-proxy /tmp/pkcs11-proxy && \
+  cd /tmp/pkcs11-proxy && \
   git checkout 944684f78bca0c8da6cabe3fa273fed3db44a890 && \
   cmake . && make && make install && \
-  cd -
+  cd - && rm -r /tmp/pkcs11-proxy
 
 # Setup SoftHSM
 echo "0:/var/lib/softhsm/slot0.db" > /etc/softhsm/softhsm.conf
@@ -64,7 +69,7 @@ gem install fpm
 
 # We can't remove libseccomp-dev as it contains a shared object that is required
 # for pkcs11-proxy to run properly
-apt-get autoremove -y build-essential cmake libssl-dev
+apt-get autoremove -y build-essential cmake libssl-dev ruby-dev
 apt-get clean -y
 
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This allows us to iterate more easily against the current acme module.

Also, remove nodejs from boulder-tools, clean up a few packages that weren't
previously cleaned up, and install a specific version of protoc-gen-go to match
our vendored grpc.