### PR TITLE
Move gRPC error wrapping/unwrapping into the interceptors

### DIFF
--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/letsencrypt/boulder/metrics"
-
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/jmhodges/clock"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
+	"github.com/letsencrypt/boulder/metrics"
 )
 
 // serverInterceptor is a gRPC interceptor that adds statsd and Prometheus
@@ -47,6 +47,7 @@ func (si *serverInterceptor) intercept(ctx context.Context, req interface{}, inf
 	methodScope.GaugeDelta("InProgress", -1)
 	if err != nil {
 		methodScope.Inc("Failed", 1)
+		err = wrapError(err)
 	}
 	return resp, err
 }
@@ -88,6 +89,7 @@ func (ci *clientInterceptor) intercept(
 	methodScope.GaugeDelta("InProgress", -1)
 	if err != nil {
 		methodScope.Inc("Failed", 1)
+		err = unwrapError(err)
 	}
 	return err
 }

--- a/grpc/publisher-wrappers.go
+++ b/grpc/publisher-wrappers.go
@@ -41,7 +41,7 @@ func (pc *PublisherClientWrapper) SubmitToSingleCT(ctx context.Context, logURL, 
 			LogURL:       &logURL,
 			LogPublicKey: &logPublicKey,
 			Der:          der})
-	return unwrapError(err)
+	return err
 }
 
 // PublisherServerWrapper is a wrapper required to bridge the differences between the
@@ -68,6 +68,6 @@ func (pub *PublisherServerWrapper) SubmitToSingleCT(ctx context.Context, request
 	if request == nil || request.Der == nil || request.LogURL == nil || request.LogPublicKey == nil {
 		return nil, errors.New("incomplete SubmitToSingleCT gRPC message")
 	}
-	err := wrapError(pub.inner.SubmitToSingleCT(ctx, *request.LogURL, *request.LogPublicKey, request.Der))
+	err := pub.inner.SubmitToSingleCT(ctx, *request.LogURL, *request.LogPublicKey, request.Der)
 	return &pubPB.Empty{}, err
 }

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -34,7 +34,7 @@ func (rac RegistrationAuthorityClientWrapper) NewRegistration(ctx context.Contex
 
 	response, err := rac.inner.NewRegistration(ctx, req)
 	if err != nil {
-		return core.Registration{}, unwrapError(err)
+		return core.Registration{}, err
 	}
 
 	if response == nil || !registrationValid(response) {
@@ -53,7 +53,7 @@ func (rac RegistrationAuthorityClientWrapper) NewAuthorization(ctx context.Conte
 
 	response, err := rac.inner.NewAuthorization(ctx, &rapb.NewAuthorizationRequest{Authz: req, RegID: &regID})
 	if err != nil {
-		return core.Authorization{}, unwrapError(err)
+		return core.Authorization{}, err
 	}
 
 	if response == nil || !authorizationValid(response) {
@@ -66,7 +66,7 @@ func (rac RegistrationAuthorityClientWrapper) NewAuthorization(ctx context.Conte
 func (rac RegistrationAuthorityClientWrapper) NewCertificate(ctx context.Context, csr core.CertificateRequest, regID int64) (core.Certificate, error) {
 	response, err := rac.inner.NewCertificate(ctx, &rapb.NewCertificateRequest{Csr: csr.Bytes, RegID: &regID})
 	if err != nil {
-		return core.Certificate{}, unwrapError(err)
+		return core.Certificate{}, err
 	}
 
 	if response == nil || !certificateValid(response) {
@@ -88,7 +88,7 @@ func (rac RegistrationAuthorityClientWrapper) UpdateRegistration(ctx context.Con
 
 	response, err := rac.inner.UpdateRegistration(ctx, &rapb.UpdateRegistrationRequest{Base: basePB, Update: updatePB})
 	if err != nil {
-		return core.Registration{}, unwrapError(err)
+		return core.Registration{}, err
 	}
 
 	if response == nil || !registrationValid(response) {
@@ -116,7 +116,7 @@ func (rac RegistrationAuthorityClientWrapper) UpdateAuthorization(ctx context.Co
 		Response:       challPB,
 	})
 	if err != nil {
-		return core.Authorization{}, unwrapError(err)
+		return core.Authorization{}, err
 	}
 
 	if response == nil || !authorizationValid(response) {
@@ -134,7 +134,7 @@ func (rac RegistrationAuthorityClientWrapper) RevokeCertificateWithReg(ctx conte
 		RegID: &regID,
 	})
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -148,7 +148,7 @@ func (rac RegistrationAuthorityClientWrapper) DeactivateRegistration(ctx context
 
 	_, err = rac.inner.DeactivateRegistration(ctx, regPB)
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -162,7 +162,7 @@ func (rac RegistrationAuthorityClientWrapper) DeactivateAuthorization(ctx contex
 
 	_, err = rac.inner.DeactivateAuthorization(ctx, authzPB)
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -176,7 +176,7 @@ func (rac RegistrationAuthorityClientWrapper) AdministrativelyRevokeCertificate(
 		AdminName: &adminName,
 	})
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -201,7 +201,7 @@ func (ras *RegistrationAuthorityServerWrapper) NewRegistration(ctx context.Conte
 	}
 	newReg, err := ras.inner.NewRegistration(ctx, reg)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return registrationToPB(newReg)
 }
@@ -216,7 +216,7 @@ func (ras *RegistrationAuthorityServerWrapper) NewAuthorization(ctx context.Cont
 	}
 	newAuthz, err := ras.inner.NewAuthorization(ctx, authz, *request.RegID)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return authzToPB(newAuthz)
 }
@@ -231,7 +231,7 @@ func (ras *RegistrationAuthorityServerWrapper) NewCertificate(ctx context.Contex
 	}
 	cert, err := ras.inner.NewCertificate(ctx, core.CertificateRequest{CSR: csr, Bytes: request.Csr}, *request.RegID)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return certToPB(cert), nil
 }
@@ -250,7 +250,7 @@ func (ras *RegistrationAuthorityServerWrapper) UpdateRegistration(ctx context.Co
 	}
 	newReg, err := ras.inner.UpdateRegistration(ctx, base, update)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return registrationToPB(newReg)
 }
@@ -269,7 +269,7 @@ func (ras *RegistrationAuthorityServerWrapper) UpdateAuthorization(ctx context.C
 	}
 	newAuthz, err := ras.inner.UpdateAuthorization(ctx, authz, int(*request.ChallengeIndex), chall)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return authzToPB(newAuthz)
 }
@@ -284,7 +284,7 @@ func (ras *RegistrationAuthorityServerWrapper) RevokeCertificateWithReg(ctx cont
 	}
 	err = ras.inner.RevokeCertificateWithReg(ctx, *cert, revocation.Reason(*request.Code), *request.RegID)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return &corepb.Empty{}, nil
 }
@@ -299,7 +299,7 @@ func (ras *RegistrationAuthorityServerWrapper) DeactivateRegistration(ctx contex
 	}
 	err = ras.inner.DeactivateRegistration(ctx, reg)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return &corepb.Empty{}, nil
 }
@@ -314,7 +314,7 @@ func (ras *RegistrationAuthorityServerWrapper) DeactivateAuthorization(ctx conte
 	}
 	err = ras.inner.DeactivateAuthorization(ctx, authz)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return &corepb.Empty{}, nil
 }
@@ -329,7 +329,7 @@ func (ras *RegistrationAuthorityServerWrapper) AdministrativelyRevokeCertificate
 	}
 	err = ras.inner.AdministrativelyRevokeCertificate(ctx, *cert, revocation.Reason(*request.Code), *request.AdminName)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 	return &corepb.Empty{}, nil
 }

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -32,7 +32,7 @@ func NewStorageAuthorityClient(inner sapb.StorageAuthorityClient) *StorageAuthor
 func (sac StorageAuthorityClientWrapper) GetRegistration(ctx context.Context, regID int64) (core.Registration, error) {
 	response, err := sac.inner.GetRegistration(ctx, &sapb.RegistrationID{Id: &regID})
 	if err != nil {
-		return core.Registration{}, unwrapError(err)
+		return core.Registration{}, err
 	}
 
 	if response == nil || !registrationValid(response) {
@@ -50,7 +50,7 @@ func (sac StorageAuthorityClientWrapper) GetRegistrationByKey(ctx context.Contex
 
 	response, err := sac.inner.GetRegistrationByKey(ctx, &sapb.JsonWebKey{Jwk: keyBytes})
 	if err != nil {
-		return core.Registration{}, unwrapError(err)
+		return core.Registration{}, err
 	}
 
 	if response == nil || !registrationValid(response) {
@@ -63,7 +63,7 @@ func (sac StorageAuthorityClientWrapper) GetRegistrationByKey(ctx context.Contex
 func (sac StorageAuthorityClientWrapper) GetAuthorization(ctx context.Context, authID string) (core.Authorization, error) {
 	response, err := sac.inner.GetAuthorization(ctx, &sapb.AuthorizationID{Id: &authID})
 	if err != nil {
-		return core.Authorization{}, unwrapError(err)
+		return core.Authorization{}, err
 	}
 
 	if response == nil || !authorizationValid(response) {
@@ -82,7 +82,7 @@ func (sac StorageAuthorityClientWrapper) GetValidAuthorizations(ctx context.Cont
 		Now:            &nowUnix,
 	})
 	if err != nil {
-		return nil, unwrapError(err)
+		return nil, err
 	}
 
 	if response == nil {
@@ -106,7 +106,7 @@ func (sac StorageAuthorityClientWrapper) GetValidAuthorizations(ctx context.Cont
 func (sac StorageAuthorityClientWrapper) GetCertificate(ctx context.Context, serial string) (core.Certificate, error) {
 	response, err := sac.inner.GetCertificate(ctx, &sapb.Serial{Serial: &serial})
 	if err != nil {
-		return core.Certificate{}, unwrapError(err)
+		return core.Certificate{}, err
 	}
 
 	if response == nil || !certificateValid(response) {
@@ -119,7 +119,7 @@ func (sac StorageAuthorityClientWrapper) GetCertificate(ctx context.Context, ser
 func (sac StorageAuthorityClientWrapper) GetCertificateStatus(ctx context.Context, serial string) (core.CertificateStatus, error) {
 	response, err := sac.inner.GetCertificateStatus(ctx, &sapb.Serial{Serial: &serial})
 	if err != nil {
-		return core.CertificateStatus{}, unwrapError(err)
+		return core.CertificateStatus{}, err
 	}
 
 	if response == nil || response.Serial == nil || response.SubscriberApproved == nil || response.Status == nil || response.OcspLastUpdated == nil || response.RevokedDate == nil || response.RevokedReason == nil || response.LastExpirationNagSent == nil || response.OcspResponse == nil || response.NotAfter == nil || response.IsExpired == nil {
@@ -149,7 +149,7 @@ func (sac StorageAuthorityClientWrapper) CountCertificatesRange(ctx context.Cont
 		Latest:   &latestNano,
 	})
 	if err != nil {
-		return 0, unwrapError(err)
+		return 0, err
 	}
 
 	if response == nil || response.Count == nil {
@@ -171,7 +171,7 @@ func (sac StorageAuthorityClientWrapper) CountCertificatesByNames(ctx context.Co
 		},
 	})
 	if err != nil {
-		return nil, unwrapError(err)
+		return nil, err
 	}
 
 	if response == nil || response.CountByNames == nil {
@@ -201,7 +201,7 @@ func (sac StorageAuthorityClientWrapper) CountRegistrationsByIP(ctx context.Cont
 		Ip: ip,
 	})
 	if err != nil {
-		return 0, unwrapError(err)
+		return 0, err
 	}
 
 	if response == nil || response.Count == nil {
@@ -214,7 +214,7 @@ func (sac StorageAuthorityClientWrapper) CountRegistrationsByIP(ctx context.Cont
 func (sac StorageAuthorityClientWrapper) CountPendingAuthorizations(ctx context.Context, regID int64) (int, error) {
 	response, err := sac.inner.CountPendingAuthorizations(ctx, &sapb.RegistrationID{Id: &regID})
 	if err != nil {
-		return 0, unwrapError(err)
+		return 0, err
 	}
 
 	if response == nil || response.Count == nil {
@@ -231,7 +231,7 @@ func (sac StorageAuthorityClientWrapper) CountInvalidAuthorizations(ctx context.
 func (sac StorageAuthorityClientWrapper) GetSCTReceipt(ctx context.Context, serial, logID string) (core.SignedCertificateTimestamp, error) {
 	response, err := sac.inner.GetSCTReceipt(ctx, &sapb.GetSCTReceiptRequest{Serial: &serial, LogID: &logID})
 	if err != nil {
-		return core.SignedCertificateTimestamp{}, unwrapError(err)
+		return core.SignedCertificateTimestamp{}, err
 	}
 
 	if response == nil || !sctValid(response) {
@@ -249,7 +249,7 @@ func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, wind
 		Domains: domains,
 	})
 	if err != nil {
-		return 0, unwrapError(err)
+		return 0, err
 	}
 
 	if response == nil || response.Count == nil {
@@ -262,7 +262,7 @@ func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, wind
 func (sac StorageAuthorityClientWrapper) FQDNSetExists(ctx context.Context, domains []string) (bool, error) {
 	response, err := sac.inner.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: domains})
 	if err != nil {
-		return false, unwrapError(err)
+		return false, err
 	}
 
 	if response == nil || response.Exists == nil {
@@ -280,7 +280,7 @@ func (sac StorageAuthorityClientWrapper) NewRegistration(ctx context.Context, re
 
 	response, err := sac.inner.NewRegistration(ctx, regPB)
 	if err != nil {
-		return core.Registration{}, unwrapError(err)
+		return core.Registration{}, err
 	}
 
 	if response == nil || !registrationValid(response) {
@@ -298,7 +298,7 @@ func (sac StorageAuthorityClientWrapper) UpdateRegistration(ctx context.Context,
 
 	_, err = sac.inner.UpdateRegistration(ctx, regPB)
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -312,7 +312,7 @@ func (sac StorageAuthorityClientWrapper) NewPendingAuthorization(ctx context.Con
 
 	response, err := sac.inner.NewPendingAuthorization(ctx, authPB)
 	if err != nil {
-		return core.Authorization{}, unwrapError(err)
+		return core.Authorization{}, err
 	}
 
 	if response == nil || !authorizationValid(response) {
@@ -330,7 +330,7 @@ func (sac StorageAuthorityClientWrapper) UpdatePendingAuthorization(ctx context.
 
 	_, err = sac.inner.UpdatePendingAuthorization(ctx, authPB)
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -344,7 +344,7 @@ func (sac StorageAuthorityClientWrapper) FinalizeAuthorization(ctx context.Conte
 
 	_, err = sac.inner.FinalizeAuthorization(ctx, authPB)
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -358,7 +358,7 @@ func (sac StorageAuthorityClientWrapper) MarkCertificateRevoked(ctx context.Cont
 		Code:   &reason,
 	})
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -370,7 +370,7 @@ func (sac StorageAuthorityClientWrapper) AddCertificate(ctx context.Context, der
 		RegID: &regID,
 	})
 	if err != nil {
-		return "", unwrapError(err)
+		return "", err
 	}
 
 	if response == nil || response.Digest == nil {
@@ -383,7 +383,7 @@ func (sac StorageAuthorityClientWrapper) AddCertificate(ctx context.Context, der
 func (sac StorageAuthorityClientWrapper) AddSCTReceipt(ctx context.Context, sct core.SignedCertificateTimestamp) error {
 	_, err := sac.inner.AddSCTReceipt(ctx, sctToPB(sct))
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -392,7 +392,7 @@ func (sac StorageAuthorityClientWrapper) AddSCTReceipt(ctx context.Context, sct 
 func (sac StorageAuthorityClientWrapper) RevokeAuthorizationsByDomain(ctx context.Context, domain core.AcmeIdentifier) (int64, int64, error) {
 	response, err := sac.inner.RevokeAuthorizationsByDomain(ctx, &sapb.RevokeAuthorizationsByDomainRequest{Domain: &domain.Value})
 	if err != nil {
-		return 0, 0, unwrapError(err)
+		return 0, 0, err
 	}
 
 	if response == nil || response.Finalized == nil || response.Pending == nil {
@@ -405,7 +405,7 @@ func (sac StorageAuthorityClientWrapper) RevokeAuthorizationsByDomain(ctx contex
 func (sac StorageAuthorityClientWrapper) DeactivateRegistration(ctx context.Context, id int64) error {
 	_, err := sac.inner.DeactivateRegistration(ctx, &sapb.RegistrationID{Id: &id})
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -414,7 +414,7 @@ func (sac StorageAuthorityClientWrapper) DeactivateRegistration(ctx context.Cont
 func (sac StorageAuthorityClientWrapper) DeactivateAuthorization(ctx context.Context, id string) error {
 	_, err := sac.inner.DeactivateAuthorization(ctx, &sapb.AuthorizationID{Id: &id})
 	if err != nil {
-		return unwrapError(err)
+		return err
 	}
 
 	return nil
@@ -436,7 +436,7 @@ func (sas StorageAuthorityServerWrapper) GetRegistration(ctx context.Context, re
 
 	reg, err := sas.inner.GetRegistration(ctx, *request.Id)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return registrationToPB(reg)
@@ -455,7 +455,7 @@ func (sas StorageAuthorityServerWrapper) GetRegistrationByKey(ctx context.Contex
 
 	reg, err := sas.inner.GetRegistrationByKey(ctx, &jwk)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return registrationToPB(reg)
@@ -468,7 +468,7 @@ func (sas StorageAuthorityServerWrapper) GetAuthorization(ctx context.Context, r
 
 	authz, err := sas.inner.GetAuthorization(ctx, *request.Id)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return authzToPB(authz)
@@ -481,7 +481,7 @@ func (sas StorageAuthorityServerWrapper) GetValidAuthorizations(ctx context.Cont
 
 	valid, err := sas.inner.GetValidAuthorizations(ctx, *request.RegistrationID, request.Domains, time.Unix(0, *request.Now))
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	resp := &sapb.ValidAuthorizations{}
@@ -505,7 +505,7 @@ func (sas StorageAuthorityServerWrapper) GetCertificate(ctx context.Context, req
 
 	cert, err := sas.inner.GetCertificate(ctx, *request.Serial)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return certToPB(cert), nil
@@ -518,7 +518,7 @@ func (sas StorageAuthorityServerWrapper) GetCertificateStatus(ctx context.Contex
 
 	certStatus, err := sas.inner.GetCertificateStatus(ctx, *request.Serial)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	ocspLastUpdatedNano := certStatus.OCSPLastUpdated.UnixNano()
@@ -549,7 +549,7 @@ func (sas StorageAuthorityServerWrapper) CountCertificatesRange(ctx context.Cont
 
 	count, err := sas.inner.CountCertificatesRange(ctx, time.Unix(0, *request.Earliest), time.Unix(0, *request.Latest))
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &sapb.Count{Count: &count}, nil
@@ -562,7 +562,7 @@ func (sas StorageAuthorityServerWrapper) CountCertificatesByNames(ctx context.Co
 
 	byNames, err := sas.inner.CountCertificatesByNames(ctx, request.Names, time.Unix(0, *request.Range.Earliest), time.Unix(0, *request.Range.Latest))
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	resp := &sapb.CountByNames{}
@@ -583,7 +583,7 @@ func (sas StorageAuthorityServerWrapper) CountRegistrationsByIP(ctx context.Cont
 
 	count, err := sas.inner.CountRegistrationsByIP(ctx, net.IP(request.Ip), time.Unix(0, *request.Range.Earliest), time.Unix(0, *request.Range.Latest))
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	castedCount := int64(count)
@@ -597,7 +597,7 @@ func (sas StorageAuthorityServerWrapper) CountPendingAuthorizations(ctx context.
 
 	count, err := sas.inner.CountPendingAuthorizations(ctx, *request.Id)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	castedCount := int64(count)
@@ -615,7 +615,7 @@ func (sas StorageAuthorityServerWrapper) GetSCTReceipt(ctx context.Context, requ
 
 	sct, err := sas.inner.GetSCTReceipt(ctx, *request.Serial, *request.LogID)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return sctToPB(sct), nil
@@ -630,7 +630,7 @@ func (sas StorageAuthorityServerWrapper) CountFQDNSets(ctx context.Context, requ
 
 	count, err := sas.inner.CountFQDNSets(ctx, window, request.Domains)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	castedCount := int64(count)
@@ -644,7 +644,7 @@ func (sas StorageAuthorityServerWrapper) FQDNSetExists(ctx context.Context, requ
 
 	exists, err := sas.inner.FQDNSetExists(ctx, request.Domains)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &sapb.Exists{Exists: &exists}, nil
@@ -662,7 +662,7 @@ func (sas StorageAuthorityServerWrapper) NewRegistration(ctx context.Context, re
 
 	newReg, err := sas.inner.NewRegistration(ctx, reg)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return registrationToPB(newReg)
@@ -680,7 +680,7 @@ func (sas StorageAuthorityServerWrapper) UpdateRegistration(ctx context.Context,
 
 	err = sas.inner.UpdateRegistration(ctx, reg)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &corepb.Empty{}, nil
@@ -698,7 +698,7 @@ func (sas StorageAuthorityServerWrapper) NewPendingAuthorization(ctx context.Con
 
 	newAuthz, err := sas.inner.NewPendingAuthorization(ctx, authz)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return authzToPB(newAuthz)
@@ -716,7 +716,7 @@ func (sas StorageAuthorityServerWrapper) UpdatePendingAuthorization(ctx context.
 
 	err = sas.inner.UpdatePendingAuthorization(ctx, authz)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &corepb.Empty{}, nil
@@ -734,7 +734,7 @@ func (sas StorageAuthorityServerWrapper) FinalizeAuthorization(ctx context.Conte
 
 	err = sas.inner.FinalizeAuthorization(ctx, authz)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &corepb.Empty{}, nil
@@ -747,7 +747,7 @@ func (sas StorageAuthorityServerWrapper) MarkCertificateRevoked(ctx context.Cont
 
 	err := sas.inner.MarkCertificateRevoked(ctx, *request.Serial, revocation.Reason(*request.Code))
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &corepb.Empty{}, nil
@@ -760,7 +760,7 @@ func (sas StorageAuthorityServerWrapper) AddCertificate(ctx context.Context, req
 
 	digest, err := sas.inner.AddCertificate(ctx, request.Der, *request.RegID)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &sapb.AddCertificateResponse{Digest: &digest}, nil
@@ -773,7 +773,7 @@ func (sas StorageAuthorityServerWrapper) AddSCTReceipt(ctx context.Context, requ
 
 	err := sas.inner.AddSCTReceipt(ctx, pbToSCT(request))
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &corepb.Empty{}, nil
@@ -786,7 +786,7 @@ func (sas StorageAuthorityServerWrapper) RevokeAuthorizationsByDomain(ctx contex
 
 	finalized, pending, err := sas.inner.RevokeAuthorizationsByDomain(ctx, core.AcmeIdentifier{Value: *request.Domain, Type: core.IdentifierDNS})
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &sapb.RevokeAuthorizationsByDomainResponse{Finalized: &finalized, Pending: &pending}, nil
@@ -799,7 +799,7 @@ func (sas StorageAuthorityServerWrapper) DeactivateRegistration(ctx context.Cont
 
 	err := sas.inner.DeactivateRegistration(ctx, *request.Id)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &corepb.Empty{}, nil
@@ -812,7 +812,7 @@ func (sas StorageAuthorityServerWrapper) DeactivateAuthorization(ctx context.Con
 
 	err := sas.inner.DeactivateAuthorization(ctx, *request.Id)
 	if err != nil {
-		return nil, wrapError(err)
+		return nil, err
 	}
 
 	return &corepb.Empty{}, nil


### PR DESCRIPTION
Instead of using `unwrapError/wrapError` in each of the wrapper functions do it in the server/client interceptors instead. This means we now consistently do error unwrapping/wrapping.

Fixes #2509.