### PR TITLE
Remove explicit `boulder-tools` docker pull cmd.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ env:
 install:
   - ./test/travis-before-install.sh
   - docker-compose pull
-  - docker pull letsencrypt/boulder-tools:2017-02-07
   - docker-compose build
 
 script:


### PR DESCRIPTION
Per @jsha's comment in https://github.com/letsencrypt/boulder/issues/2567 it should be possible
to remove the explicit `docker pull letsencrypt/boulder-tools` since the `docker-compose pull` that precedes it will take care of it.