### PR TITLE
Add script for tagging boulder-tools images.

### DIFF
--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+DATESTAMP=$(date +%Y-%m-%d)
+TAG_NAME="letsencrypt/boulder-tools:$DATESTAMP"
+
+echo "Building boulder-tools image $TAG_NAME"
+docker build . -t $TAG_NAME
+
+echo "Image ready."
+docker login
+
+echo "Pushing $TAG_NAME to Dockerhub"
+docker push $TAG_NAME


### PR DESCRIPTION
This PR adds a small script, `test/boulder-tools/tag_and_upload.sh`, that:

1) Builds the boulder-tools image with the correct tag
2) Prompts you to log in to dockerhub
3) Pushes the boulder-tools image

This means I won't have to remember how to do this next time we need to
bump our Go version :-)