### PR TITLE
Don't wrap errors we return from boulder/grpc/creds.ClientHandshake

### DIFF
--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -73,7 +73,10 @@ func (tc *clientTransportCredentials) ClientHandshake(ctx context.Context, addr 
 	case err := <-errChan:
 		if err != nil {
 			_ = rawConn.Close()
-			return nil, nil, fmt.Errorf("boulder/grpc/creds: TLS handshake failed: %s", err)
+			// directly return the error so that gRPC can use its
+			// 'isTemporary' method to check if this is a recoverable
+			// error
+			return nil, nil, err
 		}
 		return conn, nil, nil
 	}

--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -52,7 +52,7 @@ func NewClientCredentials(rootCAs *x509.CertPool, clientCerts []tls.Certificate)
 // connection and the corresponding auth information about the connection.
 // Implementations must use the provided context to implement timely cancellation.
 func (tc *clientTransportCredentials) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
-	// IMPORTANT: Don't wrap this errors returned from this method. gRPC expects to be
+	// IMPORTANT: Don't wrap the errors returned from this method. gRPC expects to be
 	// able to check err.Temporary to spot temporary errors and reconnect when they happen.
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {

--- a/grpc/creds/creds_test.go
+++ b/grpc/creds/creds_test.go
@@ -171,7 +171,7 @@ func TestClientTransportCredentials(t *testing.T) {
 	defer cancel()
 	conn, _, err = tc.ClientHandshake(ctx, "A:2020", rawConnC)
 	test.AssertError(t, err, "tc.ClientHandshake didn't timeout")
-	test.AssertEquals(t, err.Error(), "boulder/grpc/creds: context deadline exceeded")
+	test.AssertEquals(t, err.Error(), "context deadline exceeded")
 	test.Assert(t, conn == nil, "tc.ClientHandshake returned a non-nil net.Conn on failure")
 
 	stop <- struct{}{}


### PR DESCRIPTION
The gRPC client reconnect code needs to be able to [check if a error is temporary so that it can decide if it should attempt to reconnect or just fail and kill the client](https://github.com/grpc/grpc-go/blob/aefc96d792e01c7be09afa69b8c1cbfe3a21e2fc/clientconn.go#L783). By wrapping the error we were receiving in our TLS handshake code we were removing the existing `Temporary` interface on the error. This meant that if a client attempted to reconnect to a server that was in the process of being shutdown, the client would consider that server permanently dead and never retry.

Fix is simple: don't wrap errors that we pass back into the gRPC internals so that they can be properly inspected.