### PR TITLE
Fix missing berrors.InvalidEmail -> probs.ProblemDetails mapping

### DIFF
--- a/wfe/probs.go
+++ b/wfe/probs.go
@@ -17,7 +17,7 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 			Detail:     fmt.Sprintf("%s :: %s", msg, err),
 			HTTPStatus: http.StatusNotImplemented,
 		}
-	case berrors.Malformed, berrors.SignatureValidation, berrors.InvalidEmail:
+	case berrors.Malformed, berrors.SignatureValidation:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.Unauthorized:
 		return probs.Unauthorized(fmt.Sprintf("%s :: %s", msg, err))
@@ -33,6 +33,8 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		return probs.RejectedIdentifier(msg)
 	case berrors.UnsupportedIdentifier:
 		return probs.UnsupportedIdentifier(msg)
+	case berrors.InvalidEmail:
+		return probs.InvalidEmail(msg)
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe/probs.go
+++ b/wfe/probs.go
@@ -17,7 +17,7 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 			Detail:     fmt.Sprintf("%s :: %s", msg, err),
 			HTTPStatus: http.StatusNotImplemented,
 		}
-	case berrors.Malformed, berrors.SignatureValidation:
+	case berrors.Malformed, berrors.SignatureValidation, berrors.InvalidEmail:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.Unauthorized:
 		return probs.Unauthorized(fmt.Sprintf("%s :: %s", msg, err))

--- a/wfe/probs_test.go
+++ b/wfe/probs_test.go
@@ -34,6 +34,7 @@ func TestProblemDetailsFromError(t *testing.T) {
 		{berrors.NotFoundError("foo"), 404, probs.MalformedProblem},
 		{berrors.SignatureValidationError("foo"), 400, probs.MalformedProblem},
 		{berrors.RateLimitError("foo"), 429, probs.RateLimitedProblem},
+		{berrors.InvalidEmailError("foo"), 400, probs.MalformedProblem},
 	}
 	for _, c := range testCases {
 		p := problemDetailsForError(c.err, "k")

--- a/wfe/probs_test.go
+++ b/wfe/probs_test.go
@@ -34,7 +34,7 @@ func TestProblemDetailsFromError(t *testing.T) {
 		{berrors.NotFoundError("foo"), 404, probs.MalformedProblem},
 		{berrors.SignatureValidationError("foo"), 400, probs.MalformedProblem},
 		{berrors.RateLimitError("foo"), 429, probs.RateLimitedProblem},
-		{berrors.InvalidEmailError("foo"), 400, probs.MalformedProblem},
+		{berrors.InvalidEmailError("foo"), 400, probs.InvalidEmailProblem},
 	}
 	for _, c := range testCases {
 		p := problemDetailsForError(c.err, "k")


### PR DESCRIPTION
Missed in #2583, causes 500 errors to be returned to the user if they provide a malformed email or if we have an issue during email domain MX/A lookups.