### PR TITLE
expiration-mailer daemon mode

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -395,6 +395,7 @@ func main() {
 	certLimit := flag.Int("cert_limit", 0, "Count of certificates to process per expiration period")
 	reconnBase := flag.Duration("reconnectBase", 1*time.Second, "Base sleep duration between reconnect attempts")
 	reconnMax := flag.Duration("reconnectMax", 5*60*time.Second, "Max sleep duration between reconnect attempts after exponential backoff")
+	daemon := flag.Bool("daemon", false, "Run in daemon mode")
 
 	flag.Parse()
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -519,7 +519,7 @@ func main() {
 			os.Exit(1)
 		}
 		t := time.NewTicker(c.Mailer.RunPeriod)
-		for range t.c {
+		for range t.C {
 			err = m.findExpiringCertificates()
 			cmd.FailOnError(err, "expiration-mailer has failed")
 		}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -377,7 +377,7 @@ type config struct {
 		// Path to a text/template email template
 		EmailTemplate string
 
-		RunPeriod time.Duration
+		RunPeriod cmd.ConfigDuration
 
 		TLS       cmd.TLSConfig
 		SAService *cmd.GRPCClientConfig
@@ -514,11 +514,11 @@ func main() {
 	go cmd.DebugServer(c.Mailer.DebugAddr)
 
 	if *daemon {
-		if c.Mailer.RunPeriod == 0 {
+		if c.Mailer.RunPeriod.Duration == 0 {
 			fmt.Fprintln(os.Stderr, "mailer.runPeriod is not set")
 			os.Exit(1)
 		}
-		t := time.NewTicker(c.Mailer.RunPeriod)
+		t := time.NewTicker(c.Mailer.RunPeriod.Duration)
 		for range t.C {
 			err = m.findExpiringCertificates()
 			cmd.FailOnError(err, "expiration-mailer has failed")

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -377,7 +377,7 @@ type config struct {
 		// Path to a text/template email template
 		EmailTemplate string
 
-		RunPeriod cmd.ConfigDuration
+		Frequency cmd.ConfigDuration
 
 		TLS       cmd.TLSConfig
 		SAService *cmd.GRPCClientConfig
@@ -514,11 +514,11 @@ func main() {
 	go cmd.DebugServer(c.Mailer.DebugAddr)
 
 	if *daemon {
-		if c.Mailer.RunPeriod.Duration == 0 {
+		if c.Mailer.Frequency.Duration == 0 {
 			fmt.Fprintln(os.Stderr, "mailer.runPeriod is not set")
 			os.Exit(1)
 		}
-		t := time.NewTicker(c.Mailer.RunPeriod.Duration)
+		t := time.NewTicker(c.Mailer.Frequency.Duration)
 		for range t.C {
 			err = m.findExpiringCertificates()
 			cmd.FailOnError(err, "expiration-mailer has failed")

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -20,7 +20,8 @@
     "saService": {
       "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
-    }
+    },
+    "runPeriod": "1h",
   },
 
   "statsd": {

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -21,7 +21,7 @@
       "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
-    "runPeriod": "1h",
+    "runPeriod": "1h"
   },
 
   "statsd": {

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -21,7 +21,7 @@
       "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
-    "runPeriod": "1h"
+    "frequency": "1h"
   },
 
   "statsd": {


### PR DESCRIPTION
Adds a daemon mode to `expiration-mailer` that is triggered by using the flag `--daemon` in order to follow deployability guidelines. If the `--daemon` flag is used the `mailer.runPeriod` config field is checked for a tick duration, if the value is `0` it exits.

Super lightweight implementation, OCSP-Updater has some custom ticker code which we use to do fancy things when the method being invoked in the loop takes longer expected, but that isn't necessary here.

Fixes #2617.