### PR TITLE
Add checkocsp and ocsp_forever.

### DIFF
--- a/test/ocsp/README.md
+++ b/test/ocsp/README.md
@@ -1,0 +1,10 @@
+This directory contains two utilities for checking ocsp.
+
+"checkocsp" is a command-line tool to check the OCSP response for a certificate
+or a list of certificates.
+
+"ocsp_forever" is a similar tool that runs as a daemon and continually checks
+OCSP for a list of certificates, and exports Prometheus stats.
+
+Both of these are useful for monitoring a Boulder instance. "checkocsp" is also
+useful for debugging.

--- a/test/ocsp/checkocsp/checkocsp.go
+++ b/test/ocsp/checkocsp/checkocsp.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/letsencrypt/boulder/test/ocsp/helper"
+)
+
+func main() {
+	flag.Parse()
+	var errors bool
+	for _, f := range flag.Args() {
+		_, err := helper.Req(f)
+		if err != nil {
+			log.Printf("error for %s: %s\n", f, err)
+			errors = true
+		}
+	}
+	if errors {
+		os.Exit(1)
+	}
+}

--- a/test/ocsp/checkocsp/checkocsp.go
+++ b/test/ocsp/checkocsp/checkocsp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 
@@ -9,8 +10,23 @@ import (
 )
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `
+OCSP-checking tool. Provide a list of certificate filenames in PEM format, and
+this tool will check OCSP for each certificate based on the AIA field in the
+certificates. It will return an error if the OCSP server fails to respond for
+any request, if any response is invalid or has a bad signature, or if any
+response is too stale.
+
+`)
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 	var errors bool
+	if len(flag.Args()) == 0 {
+		flag.Usage()
+		os.Exit(0)
+	}
 	for _, f := range flag.Args() {
 		_, err := helper.Req(f)
 		if err != nil {

--- a/test/ocsp/checkocsp/checkocsp.go
+++ b/test/ocsp/checkocsp/checkocsp.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `
-OCSP-checking tool. Provide a list of certificate filenames in PEM format, and
+OCSP-checking tool. Provide a list of filenames for certificates in PEM format, and
 this tool will check OCSP for each certificate based on the AIA field in the
 certificates. It will return an error if the OCSP server fails to respond for
 any request, if any response is invalid or has a bad signature, or if any

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -21,6 +21,7 @@ var method = flag.String("method", "GET", "Method to use for fetching OCSP")
 var urlOverride = flag.String("url", "", "URL of OCSP responder to override")
 var tooSoon = flag.Int("too-soon", 76, "If NextUpdate is fewer than this many hours in future, warn.")
 var ignoreExpiredCerts = flag.Bool("ignore-expired-certs", false, "If a cert is expired, don't bother requesting OCSP.")
+var expectStatus = flag.Int("expect-status", 0, "Expect response to have this numeric status (0=good, 1=revoked)")
 
 func getIssuer(cert *x509.Certificate) (*x509.Certificate, error) {
 	if len(cert.IssuingCertificateURL) == 0 {
@@ -164,9 +165,12 @@ func Req(fileName string) (*ocsp.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing response: %s", err)
 	}
+	if resp.Status != *expectStatus {
+		return nil, fmt.Errorf("wrong CertStatus %d, expected %d", resp.Status, *expectStatus)
+	}
 	fmt.Printf("\n")
 	fmt.Printf("Good response:\n")
-	fmt.Printf("  Status %d\n", resp.Status)
+	fmt.Printf("  CertStatus %d\n", resp.Status)
 	fmt.Printf("  SerialNumber %036x\n", resp.SerialNumber)
 	fmt.Printf("  ProducedAt %s\n", resp.ProducedAt)
 	fmt.Printf("  ThisUpdate %s\n", resp.ThisUpdate)

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -28,10 +28,10 @@ func getIssuer(cert *x509.Certificate) (*x509.Certificate, error) {
 	}
 	issuerURL := cert.IssuingCertificateURL[0]
 	resp, err := http.Get(issuerURL)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -1,0 +1,183 @@
+package helper
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ocsp"
+)
+
+var method = flag.String("method", "GET", "Method to use for fetching OCSP")
+var urlOverride = flag.String("url", "", "URL of OCSP responder to override")
+var tooSoon = flag.Int("too-soon", 76, "If NextUpdate is fewer than this many hours in future, warn.")
+var ignoreExpiredCerts = flag.Bool("ignore-expired-certs", false, "If a cert is expired, don't bother requesting OCSP.")
+
+func getIssuer(cert *x509.Certificate) (*x509.Certificate, error) {
+	if len(cert.IssuingCertificateURL) == 0 {
+		return nil, fmt.Errorf("No AIA information available, can't get issuer")
+	}
+	issuerURL := cert.IssuingCertificateURL[0]
+	resp, err := http.Get(issuerURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var issuer *x509.Certificate
+	if strings.Join(resp.Header["Content-Type"], "") == "application/x-pkcs7-mime" {
+		issuer, err = parseCMS(body)
+	} else {
+		issuer, err = parse(body)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("from %s: %s", issuerURL, err)
+	}
+	return issuer, nil
+}
+
+func parse(body []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(body)
+	var der []byte
+	if block == nil {
+		der = body
+	} else {
+		der = block.Bytes
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+// parseCMS parses certificates from CMS messages of type SignedData.
+func parseCMS(body []byte) (*x509.Certificate, error) {
+	type signedData struct {
+		Version          int
+		Digests          asn1.RawValue
+		EncapContentInfo asn1.RawValue
+		Certificates     asn1.RawValue
+	}
+	type cms struct {
+		ContentType asn1.ObjectIdentifier
+		SignedData  signedData `asn1:"explicit,tag:0"`
+	}
+	var msg cms
+	_, err := asn1.Unmarshal(body, &msg)
+	cert, err := x509.ParseCertificate(msg.SignedData.Certificates.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CMS: %s", err)
+	}
+	return cert, nil
+}
+
+func Req(fileName string) (*ocsp.Response, error) {
+	tooSoonDuration := time.Duration(*tooSoon) * time.Hour
+	contents, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := parse(contents)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate: %s", err)
+	}
+	if time.Now().After(cert.NotAfter) {
+		if *ignoreExpiredCerts {
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("certificate expired %s ago: %s",
+				time.Now().Sub(cert.NotAfter), cert.NotAfter)
+		}
+	}
+	issuer, err := getIssuer(cert)
+	if err != nil {
+		return nil, fmt.Errorf("getting issuer: %s", err)
+	}
+	req, err := ocsp.CreateRequest(cert, issuer, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating OCSP request: %s", err)
+	}
+	if len(cert.OCSPServer) == 0 {
+		return nil, fmt.Errorf("no ocsp servers in cert")
+	}
+	encodedReq := base64.StdEncoding.EncodeToString(req)
+	var httpResp *http.Response
+	ocspServer := cert.OCSPServer[0]
+	ocspURL, err := url.Parse(ocspServer)
+	if *urlOverride != "" {
+		ocspServer = *urlOverride
+	}
+	if err != nil {
+		return nil, fmt.Errorf("parsing URL: %s", err)
+	}
+	http.DefaultClient.Timeout = 5 * time.Second
+	if *method == "GET" {
+		ocspURL.Path = encodedReq
+		fmt.Printf("Fetching %s\n", ocspURL.String())
+		var err error
+		httpResp, err = http.Get(ocspURL.String())
+		if err != nil {
+			return nil, fmt.Errorf("fetching: %s", err)
+		}
+	} else if *method == "POST" {
+		fmt.Printf("POSTing request, reproduce with: curl -i --data-binary @- %s < <(base64 -d <<<%s)\n",
+			ocspServer, encodedReq)
+		var err error
+		httpResp, err = http.Post(ocspServer, "application/ocsp-request", bytes.NewBuffer(req))
+		if err != nil {
+			return nil, fmt.Errorf("fetching: %s", err)
+		}
+	} else {
+		return nil, fmt.Errorf("invalid method %s, expected GET or POST", *method)
+	}
+	fmt.Printf("HTTP %d\n", httpResp.StatusCode)
+	for k, v := range httpResp.Header {
+		for _, vv := range v {
+			fmt.Printf("%s: %s\n", k, vv)
+		}
+	}
+	if httpResp.StatusCode != 200 {
+		return nil, fmt.Errorf("http status code %d", httpResp.StatusCode)
+	}
+	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(respBytes) == 0 {
+		return nil, fmt.Errorf("empty reponse body")
+	}
+	fmt.Printf("\nDecoding body: %s\n", base64.StdEncoding.EncodeToString(respBytes))
+	resp, err := ocsp.ParseResponseForCert(respBytes, cert, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("parsing response: %s", err)
+	}
+	fmt.Printf("\n")
+	fmt.Printf("Good response:\n")
+	fmt.Printf("  Status %d\n", resp.Status)
+	fmt.Printf("  SerialNumber %036x\n", resp.SerialNumber)
+	fmt.Printf("  ProducedAt %s\n", resp.ProducedAt)
+	fmt.Printf("  ThisUpdate %s\n", resp.ThisUpdate)
+	fmt.Printf("  NextUpdate %s\n", resp.NextUpdate)
+	fmt.Printf("  RevokedAt %s\n", resp.RevokedAt)
+	fmt.Printf("  RevocationReason %d\n", resp.RevocationReason)
+	fmt.Printf("  SignatureAlgorithm %s\n", resp.SignatureAlgorithm)
+	fmt.Printf("  Extensions %#v\n", resp.Extensions)
+	timeTilExpiry := resp.NextUpdate.Sub(time.Now())
+	if timeTilExpiry < tooSoonDuration {
+		return nil, fmt.Errorf("NextUpdate is too soon: %s", timeTilExpiry)
+	}
+	return resp, nil
+}

--- a/test/ocsp/ocsp_forever/main.go
+++ b/test/ocsp/ocsp_forever/main.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/jsha/go/ocsp/helper"
+	"github.com/letsencrypt/boulder/test/ocsp/helper"
 	prom "github.com/prometheus/client_golang/prometheus"
 	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/test/ocsp/ocsp_forever/main.go
+++ b/test/ocsp/ocsp_forever/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jsha/go/ocsp/helper"
+	prom "github.com/prometheus/client_golang/prometheus"
+	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var listenAddress = flag.String("listen", ":8080", "Port to listen on")
+var interval = flag.String("interval", "1m", "Time to sleep between fetches")
+
+var (
+	response_count = prom.NewCounterVec(prom.CounterOpts{
+		Name: "responses",
+		Help: "completed responses",
+	}, nil)
+	errors_count = prom.NewCounterVec(prom.CounterOpts{
+		Name: "errors",
+		Help: "errored responses",
+	}, nil)
+	request_time_seconds_hist = prom.NewHistogram(prom.HistogramOpts{
+		Name: "request_time_seconds",
+		Help: "time a request takes",
+	})
+	request_time_seconds_summary = prom.NewSummary(prom.SummaryOpts{
+		Name: "request_time_seconds_summary",
+		Help: "time a request takes",
+	})
+	response_age_seconds = prom.NewHistogram(prom.HistogramOpts{
+		Name: "response_age_seconds",
+		Help: "how old OCSP responses were",
+		Buckets: []float64{24 * time.Hour.Seconds(), 48 * time.Hour.Seconds(),
+			72 * time.Hour.Seconds(), 96 * time.Hour.Seconds(), 120 * time.Hour.Seconds()},
+	})
+	response_age_seconds_summary = prom.NewSummary(prom.SummaryOpts{
+		Name:       "response_age_seconds_summary",
+		Help:       "how old OCSP responses were",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, 1: 0.0001},
+	})
+)
+
+func init() {
+	prom.MustRegister(response_count)
+	prom.MustRegister(request_time_seconds_hist)
+	prom.MustRegister(request_time_seconds_summary)
+	prom.MustRegister(response_age_seconds)
+	prom.MustRegister(response_age_seconds_summary)
+}
+
+func do(f string) {
+	start := time.Now()
+	resp, err := helper.Req(f)
+	if err != nil {
+		errors_count.With(prom.Labels{}).Inc()
+		fmt.Fprintf(os.Stderr, "error for %s: %s\n", f, err)
+	}
+	latency := time.Since(start)
+	request_time_seconds_hist.Observe(latency.Seconds())
+	response_count.With(prom.Labels{}).Inc()
+	request_time_seconds_summary.Observe(latency.Seconds())
+	if resp != nil {
+		response_age_seconds.Observe(time.Since(resp.ThisUpdate).Seconds())
+		response_age_seconds_summary.Observe(time.Since(resp.ThisUpdate).Seconds())
+	}
+}
+
+func main() {
+	flag.Parse()
+	sleepTime, err := time.ParseDuration(*interval)
+	if err != nil {
+		log.Fatal(err)
+	}
+	http.Handle("/metrics", promhttp.Handler())
+	go http.ListenAndServe(*listenAddress, nil)
+	for {
+		for _, pattern := range flag.Args() {
+			files, err := filepath.Glob(pattern)
+			if err != nil {
+				log.Fatal(err)
+			}
+			for _, f := range files {
+				do(f)
+				time.Sleep(sleepTime)
+			}
+		}
+	}
+}


### PR DESCRIPTION
These are monitoring tools, originally from
https://github.com/jsha/go/tree/master/ocsp. We'd like to formalize their role
in monitoring Boulder, so I'm adding them to the Boulder repo and getting them
reviewed.