### PR TITLE
Update publicsuffix-go to `fb1fc94`

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -250,8 +250,8 @@
 		},
 		{
 			"ImportPath": "github.com/weppos/publicsuffix-go/publicsuffix",
-			"Comment": "v0.3.2-3-gc12e7e9",
-			"Rev": "c12e7e9661316d45fdcc942bdafe63242b087cfc"
+			"Comment": "v0.3.2-5-gfb1fc94",
+			"Rev": "fb1fc944c9808ebf8f4d9950ee32345f41538b4c"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ocsp",

--- a/vendor/github.com/weppos/publicsuffix-go/publicsuffix/publicsuffix.go
+++ b/vendor/github.com/weppos/publicsuffix-go/publicsuffix/publicsuffix.go
@@ -262,7 +262,7 @@ func NewRule(content string) (*Rule, error) {
 func NewRuleUnicode(content string) (*Rule, error) {
 	var err error
 
-	content, err = idna.ToASCII(content)
+	content, err = ToASCII(content)
 	if err != nil {
 		return nil, err
 	}
@@ -492,6 +492,42 @@ func decompose(r *Rule, name string) (tld, sld, trd string) {
 	}
 
 	return
+}
+
+// ToASCII is a wrapper for idna.ToASCII.
+//
+// This wrapper exists because idna.ToASCII backward-compatibility was broken twice in few months
+// and I can't call this package directly anymore. The wrapper performs some terrible-but-necessary
+// before-after replacements to make sure an already ASCII input always results in the same output
+// even if passed through ToASCII.
+//
+// See golang/net@67957fd0b1, golang/net@f2499483f9, golang/net@78ebe5c8b6,
+// and weppos/publicsuffix-go#66.
+func ToASCII(s string) (string, error) {
+	// .example.com should be .example.com
+	// ..example.com should be ..example.com
+	if strings.HasPrefix(s, ".") {
+		dotIndex := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == '.' {
+				dotIndex = i
+			} else {
+				break
+			}
+		}
+		out, err := idna.ToASCII(s[dotIndex+1:])
+		out = s[:dotIndex+1] + out
+		return out, err
+	}
+
+	return idna.ToASCII(s)
+}
+
+// ToUnicode is a wrapper for idna.ToUnicode.
+//
+// See ToASCII for more details about why this wrapper exists.
+func ToUnicode(s string) (string, error) {
+	return idna.ToUnicode(s)
 }
 
 // CookieJarList implements the cookiejar.PublicSuffixList interface.

--- a/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
+++ b/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
@@ -3,10 +3,10 @@
 
 package publicsuffix
 
-const defaultListVersion = "PSL version 03089bf (Fri Mar  3 16:01:32 2017)"
+const defaultListVersion = "PSL version 6efe629 (Fri Mar 31 19:05:40 2017)"
 
 func init() {
-	r := [8107]Rule{
+	r := [8108]Rule{
 		{1, "ac", 1, false},
 		{1, "com.ac", 2, false},
 		{1, "edu.ac", 2, false},
@@ -7726,14 +7726,15 @@ func init() {
 		{1, "vladikavkaz.su", 2, true},
 		{1, "vladimir.su", 2, true},
 		{1, "vologda.su", 2, true},
+		{1, "fastlylb.net", 2, true},
+		{1, "map.fastlylb.net", 3, true},
+		{1, "freetls.fastly.net", 3, true},
 		{1, "map.fastly.net", 3, true},
 		{1, "a.prod.fastly.net", 4, true},
 		{1, "global.prod.fastly.net", 4, true},
 		{1, "a.ssl.fastly.net", 4, true},
 		{1, "b.ssl.fastly.net", 4, true},
 		{1, "global.ssl.fastly.net", 4, true},
-		{1, "fastlylb.net", 2, true},
-		{1, "map.fastlylb.net", 3, true},
 		{1, "fhapp.xyz", 2, true},
 		{1, "firebaseapp.com", 2, true},
 		{1, "flynnhub.com", 2, true},


### PR DESCRIPTION
This PR updates the `publicsuffix-go` dependency to https://github.com/weppos/publicsuffix-go/commit/fb1fc944c9808ebf8f4d9950ee32345f41538b4c, the
latest autopull and the HEAD of master at the time of writing.

Per CONTRIBUTING.md the tests were verified to pass:
```
?       github.com/weppos/publicsuffix-go/cmd/load      [no test files]
ok      github.com/weppos/publicsuffix-go/net/publicsuffix      0.007s
ok      github.com/weppos/publicsuffix-go/publicsuffix  0.027s

```