### PR TITLE
Revert BOULDER_CONFIG_DIR to test/config.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ boulder:
     environment:
         FAKE_DNS: 127.0.0.1
         PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-        BOULDER_CONFIG_DIR: test/config-next
+        BOULDER_CONFIG_DIR: test/config
     volumes:
       - $GOPATH:/go/
       - /tmp:/tmp

--- a/test/chisel.py
+++ b/test/chisel.py
@@ -167,6 +167,7 @@ def auth_and_issue(domains, chall_type="http-01", email=None, cert_output=None, 
 
     try:
         cert_resource = issue(client, authzs, cert_output)
+        client.fetch_chain(cert_resource)
         return cert_resource
     finally:
         cleanup()


### PR DESCRIPTION
This was accidentally changed in
https://github.com/letsencrypt/boulder/pull/2634/, and broke Certbot's tests.

This also includes an update to chisel that fetches the certificate chain, which
would have caught this error.

Fixes #2643 