### PR TITLE
Purge everything that would be expired in a year at start of eap test

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -295,7 +295,7 @@ def test_expired_authz_purger():
     now = datetime.datetime.utcnow()
 
     # Run the purger once to clear out any backlog so we have a clean slate.
-    expect(now, None, "")
+    expect(now+datetime.timedelta(days=+365), None, "")
 
     # Make an authz, but don't attempt its challenges.
     chisel.make_client().request_domain_challenges("eap-test.com")


### PR DESCRIPTION
Instead of running it at the current time to clean out left over cruft run it with a FAKECLOCK of +1 year so that we catch everything that could get in the way.