### PR TITLE
CA: Consistently use hex.EncodeToString(certDER) in audit log.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -502,7 +502,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 		if err != nil {
 			err = berrors.InternalServerError(err.Error())
 			ca.log.AuditInfo(fmt.Sprintf("OCSP Signing failure: serial=[%s] pem=[%s] err=[%s]",
-				serialHex, certPEM, err))
+				serialHex, hex.EncodeToString(certDER), err))
 			// Ignore errors here to avoid orphaning the certificate. The
 			// ocsp-updater will look for certs with a zero ocspLastUpdated
 			// and generate the initial response in this case.


### PR DESCRIPTION
`certPEM` should only be used when it cannot be decoded. Otherwise
`hex.EncodeToString(certDER)` should be used, as is done everywhere
else.