### PR TITLE
Log authz ID when ra.onValidationUpdate fails.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1061,7 +1061,9 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 
 		err = ra.onValidationUpdate(vaCtx, authz)
 		if err != nil {
-			ra.log.AuditErr(fmt.Sprintf("Could not record updated validation: err=[%s] regID=[%d]", err, authz.RegistrationID))
+			ra.log.AuditErr(fmt.Sprintf(
+				"Could not record updated validation: err=[%s] regID=[%d] authzID=[%s]",
+				err, authz.RegistrationID, authz.ID))
 		}
 	}()
 	ra.stats.Inc("UpdatedPendingAuthorizations", 1)


### PR DESCRIPTION
0e112ae updates `ra/ra.go` such that when `onValidationUpdate` returns a non-nil error the `AuditErr` message includes the affected authorization ID in addition to the registration ID.

Resolves #2661.