### PR TITLE
[RFC] new-reg: send terms-of-service when key is in use

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -605,6 +605,9 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 	}
 
 	if existingReg, err := wfe.SA.GetRegistrationByKey(ctx, key); err == nil {
+		if len(wfe.SubscriberAgreementURL) > 0 {
+			response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
+		}
 		response.Header().Set("Location", wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, existingReg.ID)))
 		// TODO(#595): check for missing registration err
 		wfe.sendError(response, logEvent, probs.Conflict("Registration key is already in use"), err)


### PR DESCRIPTION
This pull request is a request for comments.

When a client calls `new-reg` with a key `K_reg`, but for some reason does not continue (e.g. due to connectivity issues, client crash), the client can call `new-reg` again. However, in the second call to new-reg the `terms-of-service` link is not present in the headers. As far as I can tell from the spec this means the client has to call the `reg` resource from the `Location` header with an empty object(?) to get a response with the `terms-of-service` link. Then the client can proceed with the call to `reg` with the agreement URL. I have not tested this method of retrieving the `terms-of-service` so I'm not confident even that is actually possible.

As far as I can tell it's not against the spec to send the `terms-of-service` link in the second `new-reg` call, and it wouldn't hurt. It will make it easier for clients to retrieve the ToS, and it will result in fewer roundtrips/requests.

Another option is to just *always* include the `terms-of-service` link in all `new-reg` responses, even in error responses. This should probably also be the case for the `reg` method.