### PR TITLE
CA: Don't add cert DER to audit log for OCSP failures.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -493,8 +493,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 		})
 		if err != nil {
 			err = berrors.InternalServerError(err.Error())
-			ca.log.AuditInfo(fmt.Sprintf("OCSP Signing failure: serial=[%s] pem=[%s] err=[%s]",
-				serialHex, hex.EncodeToString(certDER), err))
+			ca.log.AuditInfo(fmt.Sprintf("OCSP Signing failure: serial=[%s] err=[%s]", serialHex, err))
 			// Ignore errors here to avoid orphaning the certificate. The
 			// ocsp-updater will look for certs with a zero ocspLastUpdated
 			// and generate the initial response in this case.


### PR DESCRIPTION
First, commit c0ad8d90403cb8a965254ade56c902f4810fec94 (PR #2658)
had a minor bug: It didn't update the "pem=" in the audit log
message to "cert=" to be consistent with the rest of the code.

But, more importantly, we don't need to include the cert DER in the
audit log at this point because we've already logged the DER and its
serial number prior to this. Thus, at this point logging the serial
number is good enough.