### PR TITLE
CA: Orphan certificate during issuance if it can't be parsed.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -477,6 +477,16 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 	}
 	certDER := block.Bytes
 
+	_, err = x509.ParseCertificate(certDER)
+	if err != nil {
+		err = berrors.InternalServerError("failed to parse certificate: %s", err)
+		ca.log.AuditErr(fmt.Sprintf(
+			"Parsing certificate failed, orphaning certificate: serial=[%s] err=[%v]",
+			serialHex,
+			err))
+		return emptyCert, err
+	}
+
 	cert := core.Certificate{
 		DER: certDER,
 	}


### PR DESCRIPTION
It is better to orphan a malformed certificate than store it in the
database where it could somehow be retrieved. Such a malformed
certificate would already have been incorporated into the audit log
at the point we orphan it, so there is a record of it. In particular
there is no point in sending a malformed certificate to CT logs.

For further motivation, it is expected that we'll soon need to
use the parsed certificate later in the function.