### PR TITLE
Call logging.basicConfig() in chisel.

### DIFF
--- a/test/chisel.py
+++ b/test/chisel.py
@@ -28,6 +28,7 @@ from acme import messages
 from acme import standalone
 
 logger = logging.getLogger()
+logging.basicConfig()
 logger.setLevel(int(os.getenv('LOGLEVEL', 20)))
 
 DIRECTORY = os.getenv('DIRECTORY', 'http://localhost:4000/directory')


### PR DESCRIPTION
Without this, chisel would fail to log even with LOGLEVEL set to 0.