### PR TITLE
Dockerfile/docker-compose.yml cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,12 @@ EXPOSE 4000 4002 4003 4430 8053 8055
 
 ENV PATH /usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 ENV GOPATH /go
-ENV GO15VENDOREXPERIMENT=1
 
 RUN adduser --disabled-password --gecos "" --home /go/src/github.com/letsencrypt/boulder -q buser
 RUN chown -R buser /go/
 
 WORKDIR /go/src/github.com/letsencrypt/boulder
 
-# Copy in the Boulder sources
-COPY . .
 RUN mkdir bin
 
 RUN chown -R buser /go/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ boulder:
         PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
         BOULDER_CONFIG_DIR: test/config
     volumes:
-      - $GOPATH:/go/
+      - .:/go/src/github.com/letsencrypt/boulder
       - /tmp:/tmp
     net: bridge
     extra_hosts:


### PR DESCRIPTION
Removes the reliance on `$GOPATH` being set in order to use `docker-compose`. Also removes a few unnecessary commands from the `Dockerfile` that were no longer doing anything. If you get weird errors along the lines of `oci runtime error: cannot chdir to ...` you will need to `docker-compose rm; docker-compose build; docker-compose up` to fix them.

Fixes #2660.