### PR TITLE
Refactor IsSane and IsSane* to return useful errors.

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -26,24 +26,16 @@ func TestChallenges(t *testing.T) {
 	}
 
 	http01 := HTTPChallenge01()
-	if !http01.IsSane(false) {
-		t.Errorf("New http-01 challenge is not sane: %v", http01)
-	}
+	test.AssertNotError(t, http01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
 	tlssni01 := TLSSNIChallenge01()
-	if !tlssni01.IsSane(false) {
-		t.Errorf("New tls-sni-01 challenge is not sane: %v", tlssni01)
-	}
+	test.AssertNotError(t, tlssni01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
 	tlssni02 := TLSSNIChallenge02()
-	if !tlssni02.IsSane(false) {
-		t.Errorf("New tls-sni-02 challenge is not sane: %v", tlssni02)
-	}
+	test.AssertNotError(t, tlssni02.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
 	dns01 := DNSChallenge01()
-	if !dns01.IsSane(false) {
-		t.Errorf("New dns-01 challenge is not sane: %v", dns01)
-	}
+	test.AssertNotError(t, dns01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
 	test.Assert(t, ValidChallenge(ChallengeTypeHTTP01), "Refused valid challenge")
 	test.Assert(t, ValidChallenge(ChallengeTypeTLSSNI01), "Refused valid challenge")

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -63,24 +63,24 @@ func TestChallengeSanityCheck(t *testing.T) {
 			Type:   challengeType,
 			Status: StatusInvalid,
 		}
-		test.Assert(t, !chall.IsSaneForClientOffer(), "IsSane should be false")
+		test.AssertError(t, chall.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer didn't return an error")
 
 		chall.Status = StatusPending
-		test.Assert(t, !chall.IsSaneForClientOffer(), "IsSane should be false")
+		test.AssertError(t, chall.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer didn't return an error")
 
 		chall.Token = "KQqLsiS5j0CONR_eUXTUSUDNVaHODtc-0pD6ACif7U4"
-		test.Assert(t, chall.IsSaneForClientOffer(), "IsSane should be true")
+		test.AssertNotError(t, chall.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
 		chall.ProvidedKeyAuthorization = chall.Token + ".AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-		test.Assert(t, chall.IsSaneForValidation(), "IsSane should be true")
+		test.AssertNotError(t, chall.CheckConsistencyForValidation(), "CheckConsistencyForValidation returned an error")
 
 		chall.ProvidedKeyAuthorization = "aaaa.aaaa"
-		test.Assert(t, !chall.IsSaneForValidation(), "IsSane should be false")
+		test.AssertError(t, chall.CheckConsistencyForValidation(), "CheckConsistencyForValidation didn't return an error")
 	}
 
 	chall := Challenge{Type: "bogus", Status: StatusPending}
-	test.Assert(t, !chall.IsSane(false), "IsSane should be false")
-	test.Assert(t, !chall.IsSane(true), "IsSane should be false")
+	test.AssertError(t, chall.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer didn't return an error")
+	test.AssertError(t, chall.CheckConsistencyForValidation(), "CheckConsistencyForValidation didn't return an error")
 }
 
 func TestJSONBufferUnmarshal(t *testing.T) {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -496,7 +496,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(ctx context.Context, reque
 
 	// Check each challenge for sanity.
 	for _, challenge := range authz.Challenges {
-		if !challenge.IsSaneForClientOffer() {
+		if err := challenge.CheckConsistencyForClientOffer(); err != nil {
 			// berrors.InternalServerError because we generated these challenges, they should
 			// be OK.
 			err = berrors.InternalServerError("challenge didn't pass sanity check: %+v", challenge)
@@ -1011,8 +1011,8 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 	ch.ProvidedKeyAuthorization = response.ProvidedKeyAuthorization
 
 	// Double check before sending to VA
-	if !ch.IsSaneForValidation() {
-		err = berrors.MalformedError("response does not complete challenge")
+	if cErr := ch.CheckConsistencyForValidation(); cErr != nil {
+		err = berrors.MalformedError(cErr.Error())
 		return
 	}
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -491,8 +491,8 @@ func TestNewAuthorization(t *testing.T) {
 	test.Assert(t, len(authz.Challenges) == len(SupportedChallenges), "Incorrect number of challenges returned")
 	test.Assert(t, SupportedChallenges[authz.Challenges[0].Type], fmt.Sprintf("Unsupported challenge: %s", authz.Challenges[0].Type))
 	test.Assert(t, SupportedChallenges[authz.Challenges[1].Type], fmt.Sprintf("Unsupported challenge: %s", authz.Challenges[1].Type))
-	test.Assert(t, authz.Challenges[0].IsSane(false), "Challenge 0 is not sane")
-	test.Assert(t, authz.Challenges[1].IsSane(false), "Challenge 1 is not sane")
+	test.AssertNotError(t, authz.Challenges[0].CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer for Challenge 0 returned an error")
+	test.AssertNotError(t, authz.Challenges[1].CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer for Challenge 1 returned an error")
 
 	t.Log("DONE TestNewAuthorization")
 }

--- a/va/va.go
+++ b/va/va.go
@@ -642,8 +642,8 @@ func (va *ValidationAuthorityImpl) validateChallengeAndCAA(ctx context.Context, 
 }
 
 func (va *ValidationAuthorityImpl) validateChallenge(ctx context.Context, identifier core.AcmeIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
-	if !challenge.IsSaneForValidation() {
-		return nil, probs.Malformed("Challenge failed sanity check.")
+	if err := challenge.CheckConsistencyForValidation(); err != nil {
+		return nil, probs.Malformed("Challenge failed consistency check: %s", err)
 	}
 	switch challenge.Type {
 	case core.ChallengeTypeHTTP01:

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -942,7 +942,7 @@ func TestDNSValidationNotSane(t *testing.T) {
 			t.Errorf("Got wrong error type for %d: expected %s, got %s",
 				i, prob.Type, probs.MalformedProblem)
 		}
-		if !strings.Contains(prob.Error(), "Challenge failed sanity check.") {
+		if !strings.Contains(prob.Error(), "Challenge failed consistency check:") {
 			t.Errorf("Got wrong error: %s", prob.Error())
 		}
 	}


### PR DESCRIPTION
This change changes the returning values from boolean to error.

It makes `checkConsistency` an internal function and removes the
optional argument in favor of making checks explicit where they are
used.

It also renames those functions to CheckConsistency* to not
give the impression of still returning boolean values.

I'd really appreciate suggestion for better error messages.

Fixes #1037.

Signed-off-by: David Calavera <david.calavera@gmail.com>