### PR TITLE
Embed detail msg for RejectedIdentifier and InvalidEmail probs.

### DIFF
--- a/wfe/probs.go
+++ b/wfe/probs.go
@@ -30,11 +30,11 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		// not include it.
 		return probs.ServerInternal(msg)
 	case berrors.RejectedIdentifier:
-		return probs.RejectedIdentifier(msg)
+		return probs.RejectedIdentifier(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.UnsupportedIdentifier:
 		return probs.UnsupportedIdentifier(msg)
 	case berrors.InvalidEmail:
-		return probs.InvalidEmail(msg)
+		return probs.InvalidEmail(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe/probs_test.go
+++ b/wfe/probs_test.go
@@ -1,6 +1,7 @@
 package wfe
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -11,38 +12,57 @@ import (
 )
 
 func TestProblemDetailsFromError(t *testing.T) {
+	// errMsg is used as the msg argument for `problemDetailsForError` and is
+	// always returned in the problem detail.
+	const errMsg = "testError"
+	// detailMsg is used as the msg argument for the individual error types and is
+	// sometimes not present in the produced problem's detail.
+	const detailMsg = "testDetail"
+	// fullDetail is what we expect the problem detail to look like when it
+	// contains both the error message and the detail message
+	fullDetail := fmt.Sprintf("%s :: %s", errMsg, detailMsg)
 	testCases := []struct {
 		err        error
 		statusCode int
 		problem    probs.ProblemType
+		detail     string
 	}{
-		// boulder/core error types
-		{core.InternalServerError("foo"), 500, probs.ServerInternalProblem},
-		{core.NotSupportedError("foo"), 501, probs.ServerInternalProblem},
-		{core.MalformedRequestError("foo"), 400, probs.MalformedProblem},
-		{core.UnauthorizedError("foo"), 403, probs.UnauthorizedProblem},
-		{core.NotFoundError("foo"), 404, probs.MalformedProblem},
-		{core.SignatureValidationError("foo"), 400, probs.MalformedProblem},
-		{core.RateLimitedError("foo"), 429, probs.RateLimitedProblem},
-		{core.LengthRequiredError("foo"), 411, probs.MalformedProblem},
-		{core.BadNonceError("foo"), 400, probs.BadNonceProblem},
+		// boulder/core error types:
+		//   Internal server errors expect just the `errMsg` in detail.
+		{core.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
+		//   Other errors expect the full detail message
+		{core.NotSupportedError(detailMsg), 501, probs.ServerInternalProblem, fullDetail},
+		{core.MalformedRequestError(detailMsg), 400, probs.MalformedProblem, fullDetail},
+		{core.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
+		{core.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},
+		{core.SignatureValidationError(detailMsg), 400, probs.MalformedProblem, fullDetail},
+		{core.RateLimitedError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
+		{core.BadNonceError(detailMsg), 400, probs.BadNonceProblem, fullDetail},
+		//    The content length error has its own specific detail message
+		{core.LengthRequiredError(detailMsg), 411, probs.MalformedProblem, "missing Content-Length header"},
 		// boulder/errors error types
-		{berrors.InternalServerError("foo"), 500, probs.ServerInternalProblem},
-		{berrors.NotSupportedError("foo"), 501, probs.ServerInternalProblem},
-		{berrors.MalformedError("foo"), 400, probs.MalformedProblem},
-		{berrors.UnauthorizedError("foo"), 403, probs.UnauthorizedProblem},
-		{berrors.NotFoundError("foo"), 404, probs.MalformedProblem},
-		{berrors.SignatureValidationError("foo"), 400, probs.MalformedProblem},
-		{berrors.RateLimitError("foo"), 429, probs.RateLimitedProblem},
-		{berrors.InvalidEmailError("foo"), 400, probs.InvalidEmailProblem},
+		//   Internal server errors expect just the `errMsg` in detail.
+		{berrors.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
+		//   Other errors expect the full detail message
+		{berrors.NotSupportedError(detailMsg), 501, probs.ServerInternalProblem, fullDetail},
+		{berrors.MalformedError(detailMsg), 400, probs.MalformedProblem, fullDetail},
+		{berrors.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
+		{berrors.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},
+		{berrors.SignatureValidationError(detailMsg), 400, probs.MalformedProblem, fullDetail},
+		{berrors.RateLimitError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
+		{berrors.InvalidEmailError(detailMsg), 400, probs.InvalidEmailProblem, fullDetail},
+		{berrors.RejectedIdentifierError(detailMsg), 400, probs.RejectedIdentifierProblem, fullDetail},
 	}
 	for _, c := range testCases {
-		p := problemDetailsForError(c.err, "k")
+		p := problemDetailsForError(c.err, errMsg)
 		if p.HTTPStatus != c.statusCode {
 			t.Errorf("Incorrect status code for %s. Expected %d, got %d", reflect.TypeOf(c.err).Name(), c.statusCode, p.HTTPStatus)
 		}
 		if probs.ProblemType(p.Type) != c.problem {
 			t.Errorf("Expected problem urn %#v, got %#v", c.problem, p.Type)
+		}
+		if p.Detail != c.detail {
+			t.Errorf("Expected detailed message %q, got %q", c.detail, p.Detail)
 		}
 	}
 


### PR DESCRIPTION
In #2583 the internal error usage was reworked. Previously the rejected
identifier and invalid email problems were constructed directly with
a meaningful detail message and then piped straight through the
`core.ProblemDetailsForError` function unaltered allowing the detail to
make it all the way through to the error returned by the WFE to the
client.

E.g.
```
{
    "type": "urn:acme:error:invalidEmail",
    "detail": "Error creating new registration :: not a valid e-mail address",
    "status": 400 
}
```
```
{
    "type": "urn:acme:error:rejectedIdentifier",
    "detail": "Error creating new authz :: Policy forbids issuing for name",
    "status": 400 
}
```

Since the refactor Boulder has not been appending the detail message for
these two problem types in `problemDetailsForBoulderError`, making the
errors harder to diagnose client-side.

E.g.
```
{
    "type": "urn:acme:error:invalidEmail",
    "detail": "Error creating new registration",
    "status": 400 
}
```
```
{
    "type": "urn:acme:error:rejectedIdentifier",
    "detail": "Error creating new authz",
    "status": 400 
}
```

This commit restores the previous behaviour by updating
`problemDetailsForBoulderError`. The `TestProblemDetailsFromError` unit
test is also updated to check that the correct amount of detail is being
embedded in the problem detail based on the error type.