### PR TITLE
Re-added COPY of the source into the boulder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN adduser --disabled-password --gecos "" --home /go/src/github.com/letsencrypt
 RUN chown -R buser /go/
 
 WORKDIR /go/src/github.com/letsencrypt/boulder
+COPY . ./
 
 RUN mkdir bin
 


### PR DESCRIPTION
I re-added the `COPY . ./` line to the boulder image, as in our company, we use boulder in our applications for integration tests of our let's encrypt tooling. We currently build the image from our branch in our CI and push it to our private repo, from where the respective applications pull the image.

In those applications, we don't have access to the source of boulder, which therefore can't be mounted into the image. So the files need already be in the image.

This change does not hinder the mounting of the 'local' source into the Docker image for development purposes but it would help people in a way such that they don't have to checkout the whole repository, but can rely just on the boulder docker image to run a fully working boulder instance.