### PR TITLE
Add stat for how often DNS responses are signed

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -273,6 +273,9 @@ func (dnsResolver *DNSResolverImpl) exchangeOne(ctx context.Context, hostname st
 				}
 			} else {
 				msgStats.Inc("Successes", 1)
+				if r.m.AuthenticatedData {
+					msgStats.Inc("Authenticated", 1)
+				}
 			}
 			return r.m, r.err
 		}


### PR DESCRIPTION
I'm interested in seeing both how often DNS responses we see are signed (mainly for CAA, but also interested in other query types). This change adds a new counter, `Authenticated`, that can be compared against the `Successes` counter to find the percentage of signed responses we see. The counter is incremented if the `msg.AuthenticatedData` bit is set by the upstream resolver.