### PR TITLE
Gates usage of the prefixdb behind "UsePrefixDB" feature.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedIDNASupportAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyGoogleSafeBrowsingV4UseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarly"
+const _FeatureFlag_name = "unusedIDNASupportAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyGoogleSafeBrowsingV4UseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyUsePrefixDB"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 100, 115, 135, 152}
+var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 100, 115, 135, 152, 163}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -20,6 +20,7 @@ const (
 	UseAIAIssuerURL
 	AllowTLS02Challenges
 	GenerateOCSPEarly
+	UsePrefixDB
 )
 
 // List of features and their default value, protected by fMu
@@ -33,6 +34,7 @@ var features = map[FeatureFlag]bool{
 	UseAIAIssuerURL:          false,
 	AllowTLS02Challenges:     false,
 	GenerateOCSPEarly:        false,
+	UsePrefixDB:              false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/sa/database.go
+++ b/sa/database.go
@@ -88,7 +88,12 @@ func NewDbMapFromConfig(config *mysql.Config, maxOpenConns int) (*gorp.DbMap, er
 		return nil, err
 	}
 	driverName := fmt.Sprintf("mysql-%d", driverNum)
-	sql.Register(driverName, prefixdb.New(prefix, mysql.MySQLDriver{}))
+
+	if features.Enabled(features.UsePrefixDB) {
+		sql.Register(driverName, prefixdb.New(prefix, mysql.MySQLDriver{}))
+	} else {
+		sql.Register(driverName, mysql.MySQLDriver{})
+	}
 
 	db, err := sqlOpen(driverName, config.FormatDSN())
 	if err != nil {

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -81,7 +81,7 @@ func TestStrictness(t *testing.T) {
 	// With the UsePrefixDB feature enabled the STRICT_ALL_TABLES option should be
 	// specified, and so we expect to see an error about the very large
 	// registration ID value instead of a foreign key error.
-	features.Set(map[string]bool{"UsePrefixDB": true})
+	_ = features.Set(map[string]bool{"UsePrefixDB": true})
 	defer features.Reset()
 
 	dbMap, err = NewDbMap(vars.DBConnSA, 1)
@@ -116,7 +116,7 @@ func TestTimeouts(t *testing.T) {
 		t.Fatalf("Got wrong type of error when not using prefix DB: %s", err)
 	}
 
-	features.Set(map[string]bool{"UsePrefixDB": true})
+	_ = features.Set(map[string]bool{"UsePrefixDB": true})
 	defer features.Reset()
 
 	// Now test with the UsePrefixDB feature enabled. The readTimeout

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
 )
@@ -62,7 +63,28 @@ func TestNewDbMap(t *testing.T) {
 }
 
 func TestStrictness(t *testing.T) {
+
+	// Without the UsePrefixDB feature enabled the STRICT_ALL_TABLES option will
+	// not be speficied, and so we expect to see an error about the registration
+	// ID provided violating a foreign key constraint
 	dbMap, err := NewDbMap(vars.DBConnSA, 1)
+	_, err = dbMap.Exec(`insert into authz set
+		id="hi", identifier="foo", status="pending", combinations="combos",
+		registrationID=999999999999999999999999999;`)
+	if err == nil {
+		t.Fatal("Expected error when providing unsatisfied foreign key, got none.")
+	}
+	if !strings.Contains(err.Error(), "Cannot add or update a child row: a foreign key constraint fails") {
+		t.Fatalf("Got wrong type of error: %s", err)
+	}
+
+	// With the UsePrefixDB feature enabled the STRICT_ALL_TABLES option should be
+	// specified, and so we expect to see an error about the very large
+	// registration ID value instead of a foreign key error.
+	features.Set(map[string]bool{"UsePrefixDB": true})
+	defer features.Reset()
+
+	dbMap, err = NewDbMap(vars.DBConnSA, 1)
 	_, err = dbMap.Exec(`insert into authz set
 		id="hi", identifier="foo", status="pending", combinations="combos",
 		registrationID=999999999999999999999999999;`)
@@ -75,6 +97,8 @@ func TestStrictness(t *testing.T) {
 }
 
 func TestTimeouts(t *testing.T) {
+	// First test without the UsePrefixDB feature enabled. The readTimeout
+	// provided will not be prefixed onto the DB connection.
 	dbMap, err := NewDbMap(vars.DBConnSA+"?readTimeout=1s", 1)
 	if err != nil {
 		t.Fatal("Error setting up DB:", err)
@@ -87,10 +111,29 @@ func TestTimeouts(t *testing.T) {
 		t.Fatal("Expected error when running slow query, got none.")
 	}
 
+	// Without the timeout being respected a bad connection error occurs
+	if !strings.Contains(err.Error(), "driver: bad connection") {
+		t.Fatalf("Got wrong type of error when not using prefix DB: %s", err)
+	}
+
+	features.Set(map[string]bool{"UsePrefixDB": true})
+	defer features.Reset()
+
+	// Now test with the UsePrefixDB feature enabled. The readTimeout
+	// provided should affect the created DB connection as intended.
+	dbMap, err = NewDbMap(vars.DBConnSA+"?readTimeout=1s", 1)
+	if err != nil {
+		t.Fatal("Error setting up DB:", err)
+	}
+	_, err = dbMap.Exec(`SELECT 1 FROM (SELECT SLEEP(5)) as subselect;`)
+	if err == nil {
+		t.Fatal("Expected error when running slow query, got none.")
+	}
+
 	// We expect to get:
 	// Error 1969: Query execution was interrupted (max_statement_time exceeded)
 	// https://mariadb.com/kb/en/mariadb/mariadb-error-codes/
 	if !strings.Contains(err.Error(), "Error 1969") {
-		t.Fatalf("Got wrong type of error: %s", err)
+		t.Fatalf("Got wrong type of error using prefix DB: %s", err)
 	}
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -24,7 +24,8 @@
       ]
     },
     "features": {
-      "AllowAccountDeactivation": true
+      "AllowAccountDeactivation": true,
+      "UsePrefixDB": true
     }
   },
 


### PR DESCRIPTION
This commit adds a new "UsePrefixDB" feature flag. This flag controls
whether the SA constructs a prefixdb wrapper or uses the base MySQL
driver directly. The unit tests that test the prefix behaviour of the SA
are updated to test according to the feature state.

Resolves https://github.com/letsencrypt/boulder/issues/2705