### PR TITLE
Adds "meta" entry w/ ToS to /directory.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedIDNASupportAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyGoogleSafeBrowsingV4UseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyCountCertificatesExactRandomDirectoryEntryIPv6First"
+const _FeatureFlag_name = "unusedIDNASupportAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyGoogleSafeBrowsingV4UseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMeta"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 100, 115, 135, 152, 174, 194, 203}
+var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 100, 115, 135, 152, 174, 194, 203, 216}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -23,6 +23,7 @@ const (
 	CountCertificatesExact
 	RandomDirectoryEntry
 	IPv6First
+	DirectoryMeta
 )
 
 // List of features and their default value, protected by fMu
@@ -39,6 +40,7 @@ var features = map[FeatureFlag]bool{
 	CountCertificatesExact:   false,
 	RandomDirectoryEntry:     false,
 	IPv6First:                false,
+	DirectoryMeta:            false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -33,7 +33,8 @@
       "AllowAccountDeactivation": true,
       "AllowKeyRollover": true,
       "UseAIAIssuerURL": true,
-      "RandomDirectoryEntry": true
+      "RandomDirectoryEntry": true,
+      "DirectoryMeta": true
     }
   },
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -277,10 +277,10 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 		if features.Enabled(features.RandomDirectoryEntry) && v == randomDirKeyExplanationLink {
 			continue
 		}
-		switch v.(type) {
+		switch v := v.(type) {
 		case string:
 			// Only relative-ize top level string values, e.g. not the "meta" element
-			relativeDir[k] = wfe.relativeEndpoint(request, v.(string))
+			relativeDir[k] = wfe.relativeEndpoint(request, v)
 		default:
 			// If it isn't a string, put it into the results unmodified
 			relativeDir[k] = v


### PR DESCRIPTION
This PR adds the acme draft-02+ optional "meta" element for the
/directory response. Presently we only include the optional
"terms-of-service" URL. Whether the meta entry is included is controlled
by two factors:

  1. The state of the "DirectoryMeta" feature flag, which defaults to
     off
  2. Whether the client advertises the UA we know to be intolerant of
     new directory entries.

The TestDirectory unit test is updated to test both states of the flag
and the UA detection.

Resolves https://github.com/letsencrypt/boulder/issues/1077