### PR TITLE
Removes "coverage" from default RUN.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -9,8 +9,9 @@ fi
 # RUN variable with the ones you want (see .travis.yml for an example).
 # Order doesn't matter. Note: godep-restore is specifically left out of the
 # defaults, because we don't want to run it locally (would be too disruptive to
-# GOPATH).
-RUN=${RUN:-vet fmt migrations unit coverage integration errcheck}
+# GOPATH). We also omit coverage by default on local runs because it generates
+# artifacts on disk that aren't needed.
+RUN=${RUN:-vet fmt migrations unit integration errcheck}
 
 # The list of segments to hard fail on, as opposed to continuing to the end of
 # the unit tests before failing.


### PR DESCRIPTION
Having "coverage" in the default RUN is leaving ".coverprofile" files
all over the src tree. This PR removes this task from the default
RUN list for local work. It is included in travis.yml and will still run
for CI or when specified explicitly with a command line env var
  override.