### PR TITLE
Fixes RPC bug for CountCertificatesExact feature flag.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -824,13 +824,15 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 		tldNames = append(tldNames, exactPublicSuffixes...)
 	}
 
-	// Enforce the certificate count rate limit against the tldNames as well as
-	// any subdomains.
-	namesOutOfLimit, err := ra.enforceNameCounts(ctx, tldNames, limit, regID, ra.SA.CountCertificatesByNames)
-	if err != nil {
-		return err
+	// If there are any tldNames, enforce the certificate count rate limit against
+	// them and any subdomains.
+	if len(tldNames) > 0 {
+		namesOutOfLimit, err := ra.enforceNameCounts(ctx, tldNames, limit, regID, ra.SA.CountCertificatesByNames)
+		if err != nil {
+			return err
+		}
+		badNames = append(badNames, namesOutOfLimit...)
 	}
-	badNames = append(badNames, namesOutOfLimit...)
 
 	if len(badNames) > 0 {
 		// check if there is already a existing certificate for

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1513,6 +1513,9 @@ func TestPSLMatchIssuance(t *testing.T) {
 	mockSA := &mockSAOnlyExact{}
 	ra.SA = mockSA
 
+	_ = features.Set(map[string]bool{"CountCertificatesExact": false})
+	defer features.Reset()
+
 	// Without CountCertificatesExact enabled we expect the rate limit check to
 	// fail since it will use the in-exact SA method that the mock always fails
 	err = ra.checkCertificatesPerNameLimit(ctx, []string{"dedyn.io"}, certsPerNamePolicy, 99)
@@ -1520,7 +1523,6 @@ func TestPSLMatchIssuance(t *testing.T) {
 
 	// Enable the CountCertificatesExact feature flag
 	_ = features.Set(map[string]bool{"CountCertificatesExact": true})
-	defer features.Reset()
 
 	// With CountCertificatesExact enabled we expect the limit check to pass when
 	// names only includes exact PSL matches and the RA will use the SA's exact

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -311,13 +311,6 @@ def test_expired_authz_purger():
     expect(now, 0, "authz")
     expect(after_grace_period, 1, "authz")
 
-def test_psl_issue():
-    # Test that issuing for an exact public suffix domain works without error.
-    # We use "dedyn.io" here because it is a domain in the private portion of
-    # the public suffix list and we don't presently have the ability to mock
-    # test PSL entries easily.
-    auth_and_issue(["dedyn.io"])
-
 def test_certificates_per_name():
     chisel.expect_problem("urn:acme:error:rateLimited",
         lambda: auth_and_issue(["lim.it"]))
@@ -413,7 +406,6 @@ def run_chisel():
     test_caa()
     test_admin_revoker_cert()
     test_admin_revoker_authz()
-    test_psl_issue()
     test_certificates_per_name()
     test_ocsp()
     test_single_ocsp()

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -311,6 +311,13 @@ def test_expired_authz_purger():
     expect(now, 0, "authz")
     expect(after_grace_period, 1, "authz")
 
+def test_psl_issue():
+    # Test that issuing for an exact public suffix domain works without error.
+    # We use "dedyn.io" here because it is a domain in the private portion of
+    # the public suffix list and we don't presently have the ability to mock
+    # test PSL entries easily.
+    auth_and_issue(["dedyn.io"])
+
 def test_certificates_per_name():
     chisel.expect_problem("urn:acme:error:rateLimited",
         lambda: auth_and_issue(["lim.it"]))
@@ -406,6 +413,7 @@ def run_chisel():
     test_caa()
     test_admin_revoker_cert()
     test_admin_revoker_authz()
+    test_psl_issue()
     test_certificates_per_name()
     test_ocsp()
     test_single_ocsp()


### PR DESCRIPTION
With the `CountCertificatesExact` feature flag enabled if the RA's
`checkCertificatesPerNameLimit` was called with `names` only containing
domains exactly matching a public suffix entry then the legacy
`ra.enforceNameCounts` function will be called with an empty `tldNames`
argument. This in turn will cause the RA->SA RPC to fail with an
"incomplete gRPC request message error".

This commit fixes this bug by only calling `ra.enforceNameCounts` when
`len(tldNames) > 0`.

Resolves https://github.com/letsencrypt/boulder/issues/2758