### PR TITLE
Fixes master's unit tests, test failure.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -78,7 +78,7 @@ function run_unit_tests() {
     # Run the full suite of tests once with the -race flag. Since this isn't
     # running tests individually we can't collect coverage information.
     echo "running test suite with race detection"
-    go test -race -p 1 ${TESTPATHS} || FAILURE=1
+    run go test -race -p 1 ${TESTPATHS}
   else
     # When running locally, we skip the -race flag for speedier test runs. We
     # also pass -p 1 to require the tests to run serially instead of in
@@ -99,7 +99,7 @@ function run_test_coverage() {
   echo "running test suite with coverage enabled and without race detection"
   for path in ${TESTPATHS}; do
     dir=$(basename $path)
-    go test -cover -coverprofile=${dir}.coverprofile ${path} || FAILURE=1
+    run go test -cover -coverprofile=${dir}.coverprofile ${path}
   done
 
   # Gather all the coverprofiles

--- a/test.sh
+++ b/test.sh
@@ -78,7 +78,7 @@ function run_unit_tests() {
     # Run the full suite of tests once with the -race flag. Since this isn't
     # running tests individually we can't collect coverage information.
     echo "running test suite with race detection"
-    go test -race -p 1 ${TESTPATHS}
+    go test -race -p 1 ${TESTPATHS} || FAILURE=1
   else
     # When running locally, we skip the -race flag for speedier test runs. We
     # also pass -p 1 to require the tests to run serially instead of in

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -1343,7 +1343,7 @@ func TestFallbackTLS(t *testing.T) {
 	// validation to fail since there is no IPv4 address/listener to fall back to.
 	host = "ipv6.localhost"
 	ident = core.AcmeIdentifier{Type: core.IdentifierDNS, Value: host}
-	va.stats = metrics.NewStatsdScope(mocks.NewStatter(), "VA")
+	va.stats = metrics.NewNoopScope()
 	records, prob = va.validateChallenge(ctx, ident, chall)
 
 	// The validation is expected to fail since there is no IPv4 to fall back to


### PR DESCRIPTION
This PR addresses two problems with master:
1. Merging #2752 broke master because the `va/va_test.go` test had a `metrics.NewStatsdScope` sneak in from another PR. This PR replaces it with a call to `metrics.NewNoopScope`.
2. #2721 accidentally removed a `|| FAILURE=1` component from the `go test` invocation used during CI. This caused issue #2760 where a failed unit test won't fail the build. This PR adds the `FAILURE` clause and resolves #2760 

