### PR TITLE
Fix flakiness in VA test.

### DIFF
--- a/va/va_test.go
+++ b/va/va_test.go
@@ -869,7 +869,7 @@ func TestPerformValidationInvalid(t *testing.T) {
 	mockScope := mock_metrics.NewMockScope(ctrl)
 	va.stats = mockScope
 	mockScope.EXPECT().TimingDuration("Validations.dns-01.invalid", gomock.Any()).Return(nil)
-	mockScope.EXPECT().Inc(gomock.Any(), gomock.Any()).Return(nil)
+	mockScope.EXPECT().Inc(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	chalDNS := createChallenge(core.ChallengeTypeDNS01)
 	_, prob := va.PerformValidation(context.Background(), "foo.com", chalDNS, core.Authorization{})
@@ -903,7 +903,7 @@ func TestPerformValidationValid(t *testing.T) {
 	mockScope := mock_metrics.NewMockScope(ctrl)
 	va.stats = mockScope
 	mockScope.EXPECT().TimingDuration("Validations.dns-01.valid", gomock.Any()).Return(nil)
-	mockScope.EXPECT().Inc(gomock.Any(), gomock.Any()).Return(nil)
+	mockScope.EXPECT().Inc(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// create a challenge with well known token
 	chalDNS := core.DNSChallenge01()


### PR DESCRIPTION
When the VA validates a domain, it runs both CAA check and validation check in
parallel. If the validation check returns a failed result before the CAA check is done,
the VA returns immediately. However, the CAA check increments a stat. So there's
a flaky condition where, depending on the timing, that stat increment may or may
not get called on the MockScope. Add `.AnyTimes()` to our mock statements to
indicate we don't care whether Inc gets called.

/cc @briansmith 