### PR TITLE
Updates CFSSL dep to c9a961e.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,73 +12,73 @@
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/auth",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/certdb",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/config",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs7",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/csr",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/errors",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers/derhelpers",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/info",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/log",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp/config",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer/local",
-			"Comment": "1.2.0-168-g37c1a76",
-			"Rev": "37c1a7625a837fe8c27437b63e3cbb14f7419e82"
+			"Comment": "1.2.0-169-gc9a961e",
+			"Rev": "c9a961ed337dbde794abb97a2a302320a99869da"
 		},
 		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",

--- a/vendor/github.com/cloudflare/cfssl/ocsp/responder.go
+++ b/vendor/github.com/cloudflare/cfssl/ocsp/responder.go
@@ -198,6 +198,13 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 				base64RequestBytes[i] = '+'
 			}
 		}
+		// In certain situations a UA may construct a request that has a double
+		// slash between the host name and the base64 request body due to naively
+		// constructing the request URL. In that case strip the leading slash
+		// so that we can still decode the request.
+		if len(base64RequestBytes) > 0 && base64RequestBytes[0] == '/' {
+			base64RequestBytes = base64RequestBytes[1:]
+		}
 		requestBody, err = base64.StdEncoding.DecodeString(string(base64RequestBytes))
 		if err != nil {
 			log.Infof("Error decoding base64 from URL: %s", string(base64RequestBytes))


### PR DESCRIPTION
Per review policy, running tests in updated dependencies yields:

```
$ go test ./vendor/github.com/cloudflare/cfssl/ocsp/
?       github.com/letsencrypt/boulder/vendor/github.com/cloudflare/cfssl/ocsp  [no test files]
```