### PR TITLE
Properly initialize submissions_b count

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -169,7 +169,7 @@ def test_ct_submission():
     url_a = "http://boulder:4500/submissions"
     url_b = "http://boulder:4501/submissions"
     submissions_a = urllib2.urlopen(url_a).read()
-    submissions_b = urllib2.urlopen(url_a).read()
+    submissions_b = urllib2.urlopen(url_b).read()
     expected_a_submissions = int(submissions_a)+1
     expected_b_submissions = int(submissions_b)+1
     auth_and_issue([random_domain()])


### PR DESCRIPTION
The `submissions_b` count in the integration test `test_ct_submission` function was being populated initially by using `url_a` when it _should_ be initialized using `url_b` since it's the count of submissions to log b.

This resolves https://github.com/letsencrypt/boulder/issues/2723

I tested this fix with a branch that ran this test 12 times per build. Prior to this fix multiple builds out of 20 (~4-5) would fail. With this fix, all 20 passed.