### PR TITLE
Use fields, not globals, for stats

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -98,19 +98,6 @@ const (
 	metricCSRExtensionOther = "CSRExtensions.Other"
 )
 
-var (
-	signatureCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "signatures",
-			Help: "Number of signatures",
-		},
-		[]string{"purpose"})
-)
-
-func init() {
-	prometheus.MustRegister(signatureCount)
-}
-
 type certificateStorage interface {
 	AddCertificate(context.Context, []byte, int64, []byte) (string, error)
 }
@@ -136,6 +123,7 @@ type CertificateAuthorityImpl struct {
 	maxNames         int
 	forceCNFromSAN   bool
 	enableMustStaple bool
+	signatureCount   *prometheus.CounterVec
 }
 
 // Issuer represents a single issuer certificate, along with its key.
@@ -239,6 +227,14 @@ func NewCertificateAuthorityImpl(
 		return nil, errors.New("must specify rsaProfile and ecdsaProfile")
 	}
 
+	signatureCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signatures",
+			Help: "Number of signatures",
+		},
+		[]string{"purpose"})
+	stats.MustRegister(signatureCount)
+
 	ca = &CertificateAuthorityImpl{
 		issuers:          internalIssuers,
 		defaultIssuer:    defaultIssuer,
@@ -251,6 +247,7 @@ func NewCertificateAuthorityImpl(
 		keyPolicy:        keyPolicy,
 		forceCNFromSAN:   !config.DoNotForceCN, // Note the inversion here
 		enableMustStaple: config.EnableMustStaple,
+		signatureCount:   signatureCount,
 	}
 
 	if config.Expiry == "" {
@@ -379,7 +376,7 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, xferObj co
 	ocspResponse, err := issuer.ocspSigner.Sign(signRequest)
 	ca.noteSignError(err)
 	if err == nil {
-		signatureCount.With(prometheus.Labels{"purpose": "ocsp"}).Inc()
+		ca.signatureCount.With(prometheus.Labels{"purpose": "ocsp"}).Inc()
 	}
 	return ocspResponse, err
 }
@@ -474,7 +471,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, csr x5
 		ca.log.AuditErr(fmt.Sprintf("Signing failed: serial=[%s] err=[%v]", serialHex, err))
 		return emptyCert, err
 	}
-	signatureCount.With(prometheus.Labels{"purpose": "cert"}).Inc()
+	ca.signatureCount.With(prometheus.Labels{"purpose": "cert"}).Inc()
 
 	if len(certPEM) == 0 {
 		err = berrors.InternalServerError("no certificate returned by server")

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -687,6 +687,8 @@ func TestExtensions(t *testing.T) {
 	defer ctrl.Finish()
 	stats := mock_metrics.NewMockScope(ctrl)
 
+	stats.EXPECT().MustRegister(gomock.Any()).AnyTimes()
+
 	ca, err := NewCertificateAuthorityImpl(
 		testCtx.caConfig,
 		testCtx.fc,

--- a/metrics/mock_metrics/mock_scope.go
+++ b/metrics/mock_metrics/mock_scope.go
@@ -6,6 +6,7 @@ package mock_metrics
 import (
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/letsencrypt/boulder/metrics"
+	prometheus "github.com/prometheus/client_golang/prometheus"
 	time "time"
 )
 
@@ -58,6 +59,18 @@ func (_m *MockScope) Inc(_param0 string, _param1 int64) error {
 
 func (_mr *_MockScopeRecorder) Inc(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Inc", arg0, arg1)
+}
+
+func (_m *MockScope) MustRegister(_param0 ...prometheus.Collector) {
+	_s := []interface{}{}
+	for _, _x := range _param0 {
+		_s = append(_s, _x)
+	}
+	_m.ctrl.Call(_m, "MustRegister", _s...)
+}
+
+func (_mr *_MockScopeRecorder) MustRegister(arg0 ...interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MustRegister", arg0...)
 }
 
 func (_m *MockScope) NewScope(_param0 ...string) metrics.Scope {

--- a/metrics/scope.go
+++ b/metrics/scope.go
@@ -34,6 +34,7 @@ var _ Scope = &promScope{}
 // NewPromScope returns a Scope that sends data to Prometheus
 func NewPromScope(registerer prometheus.Registerer, scopes ...string) Scope {
 	return &promScope{
+		Registerer:     registerer,
 		prefix:         strings.Join(scopes, ".") + ".",
 		autoRegisterer: newAutoRegisterer(registerer),
 	}

--- a/metrics/scope.go
+++ b/metrics/scope.go
@@ -40,11 +40,6 @@ func NewPromScope(registerer prometheus.Registerer, scopes ...string) Scope {
 	}
 }
 
-// NewNoopScope returns a Scope that won't collect anything
-func NewNoopScope() Scope {
-	return NewPromScope(prometheus.NewRegistry())
-}
-
 // NewScope generates a new Scope prefixed by this Scope's prefix plus the
 // prefixes given joined by periods
 func (s *promScope) NewScope(scopes ...string) Scope {
@@ -87,4 +82,34 @@ func (s *promScope) TimingDuration(stat string, delta time.Duration) error {
 func (s *promScope) SetInt(stat string, value int64) error {
 	s.autoGauge(s.prefix + stat).Set(float64(value))
 	return nil
+}
+
+type noopScope struct{}
+
+// NewNoopScope returns a Scope that won't collect anything
+func NewNoopScope() Scope {
+	return noopScope{}
+}
+func (ns noopScope) NewScope(scopes ...string) Scope {
+	return ns
+}
+func (_ noopScope) Inc(stat string, value int64) error {
+	return nil
+}
+func (_ noopScope) Gauge(stat string, value int64) error {
+	return nil
+}
+func (_ noopScope) GaugeDelta(stat string, value int64) error {
+	return nil
+}
+func (_ noopScope) Timing(stat string, delta int64) error {
+	return nil
+}
+func (_ noopScope) TimingDuration(stat string, delta time.Duration) error {
+	return nil
+}
+func (_ noopScope) SetInt(stat string, value int64) error {
+	return nil
+}
+func (_ noopScope) MustRegister(...prometheus.Collector) {
 }

--- a/metrics/scope.go
+++ b/metrics/scope.go
@@ -18,13 +18,15 @@ type Scope interface {
 	Timing(stat string, delta int64) error
 	TimingDuration(stat string, delta time.Duration) error
 	SetInt(stat string, value int64) error
+
+	MustRegister(...prometheus.Collector)
 }
 
 // promScope is a Scope that sends data to Prometheus
 type promScope struct {
+	prometheus.Registerer
 	*autoRegisterer
-	prefix     string
-	registerer prometheus.Registerer
+	prefix string
 }
 
 var _ Scope = &promScope{}
@@ -46,7 +48,7 @@ func NewNoopScope() Scope {
 // prefixes given joined by periods
 func (s *promScope) NewScope(scopes ...string) Scope {
 	scope := strings.Join(scopes, ".")
-	return NewPromScope(s.registerer, s.prefix+scope)
+	return NewPromScope(s.Registerer, s.prefix+scope)
 }
 
 // Inc increments the given stat and adds the Scope's prefix to the name


### PR DESCRIPTION
Following up on #2752, we don't need to use global vars for our Prometheus stats. We already have a custom registry plumbed through using `Scope` objects. In this PR, expose the MustRegister method of that registry through the Scope interface, and move existing global vars to be fields of objects. This should improve testability somewhat.

Note that this has a bit of an unfortunate side effect: two instances of the same stats-using class (e.g. VA) can't use the same Scope object, because their MustRegister calls will conflict. In practice this is fine since we never instantiate duplicates of the the classes that use stats, but it's something we should keep an eye on.

Updates #2733