### PR TITLE
Don't print %!s(nil) when ierr is nil.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -602,7 +602,11 @@ func (wfe *WebFrontEndImpl) sendError(response http.ResponseWriter, logEvent *re
 	// Only audit log internal errors so users cannot purposefully cause
 	// auditable events.
 	if prob.Type == probs.ServerInternalProblem {
-		wfe.log.AuditErr(fmt.Sprintf("Internal error - %s - %s", prob.Detail, ierr))
+		if ierr != nil {
+			wfe.log.AuditErr(fmt.Sprintf("Internal error - %s - %s", prob.Detail, ierr))
+		} else {
+			wfe.log.AuditErr(fmt.Sprintf("Internal error - %s", prob.Detail))
+		}
 	}
 
 	problemDoc, err := marshalIndent(prob)


### PR DESCRIPTION
Sometimes sendError gets a nil argument for ierr (internal error). When this
happens we print a line like:

[AUDIT] Internal error - Failed to get registration by key - %!s(<nil>)

This is fine but distracting, since it looks like a logging bug.
Instead, print a shorter message with just the external-facing problem.