### PR TITLE
Improve the `emptyDNSResponseError` message.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -167,8 +167,9 @@ func (ra *RegistrationAuthorityImpl) updateIssuedCount() error {
 
 var (
 	unparseableEmailError = berrors.InvalidEmailError("not a valid e-mail address")
-	emptyDNSResponseError = berrors.InvalidEmailError("empty DNS response")
-	multipleAddressError  = berrors.InvalidEmailError("more than one e-mail address")
+	emptyDNSResponseError = berrors.InvalidEmailError(
+		"empty DNS response validating email domain - no MX/A records")
+	multipleAddressError = berrors.InvalidEmailError("more than one e-mail address")
 )
 
 func problemIsTimeout(err error) bool {


### PR DESCRIPTION
When the RA's `validateEmail` function performs DNS lookups for the MX
and A records for the email domain it returns the
`emptyDNSResponseError` message if neither an MX or A record are found.

Prior to this PR the message only said "empty DNS response" and
didn't indicate what the DNS lookup was being used for, or which records
were empty. This PR updates the message to hopefully be less
confusing and more immediately actionable by a user.

Thanks to [jcordoba](https://community.letsencrypt.org/t/empty-dns-response/36083) for inspiring this update.