### PR TITLE
Update CONTRIBUTING.md for ACMEv2 plan.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@ Thanks for helping us build Boulder! This page contains requirements and guideli
 
 # Patch Requirements
 * All new functionality and fixed bugs must be accompanied by tests.
-* Boulder currently implements the ACME-01 draft as defined by [acme-spec](https://tools.ietf.org/html/draft-ietf-acme-acme-01). If a spec change is required for Boulder functionality, you should propose it on the ACME mailing list (acme@ietf.org), possibly accompanied by a pull request on the [spec repo](https://github.com/ietf-wg-acme/acme/).
 * All patches must meet the deployability requirements listed below.
 * We prefer pull requests from external forks be created with the ["Allow edits from maintainers"](https://github.com/blog/2247-improving-collaboration-with-forks) checkbox selected.
+* Boulder currently implements something we internally refer to as "ACME v1". It is largely the same as the IETF ACME protocol's current most draft ([ACME draft-06](https://tools.ietf.org/html/draft-ietf-acme-acme-06)). The [acme-divergences](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) document outlines the places where Boulder differs from the IETF drafts. Our [plans for an "ACME v2" endpoint](https://letsencrypt.org/2017/06/14/acme-v2-api.html) describe how we will resolve the divergences when ACME leaves draft status. If a protocol spec change is required for Boulder functionality, you should propose it on the ACME mailing list (acme@ietf.org), possibly accompanied by a pull request on the [spec repo](https://github.com/ietf-wg-acme/acme/).
 
 # Review Requirements
 * All pull requests must receive at least one positive review. Contributors are


### PR DESCRIPTION
Prior to this PR we referenced ACME draft-01, which is quite out of date. This PR updates the draft, describes our divergences document, and links to the "ACME v2" plan. I moved the bulletpoint about this lower than the others in "Patch Requirements" since the need for protocol changes are quite rare at this point.