### PR TITLE
Fix statsd->prometheus bridge.

### DIFF
--- a/metrics/auto.go
+++ b/metrics/auto.go
@@ -57,7 +57,7 @@ func (ap *autoProm) get(name string, make maker) prometheus.Collector {
 func newAutoProm(registerer prometheus.Registerer) *autoProm {
 	return &autoProm{
 		metrics:    make(map[string]prometheus.Collector),
-		Registerer: prometheus.NewRegistry(),
+		Registerer: registerer,
 	}
 }
 

--- a/metrics/auto_test.go
+++ b/metrics/auto_test.go
@@ -53,15 +53,16 @@ func TestAutoRegisterer(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	ap := newAutoRegisterer(registry)
 	gauge := ap.autoGauge("ima_stat")
+	expected := "Desc{fqName: \"ima_stat\", help: \"auto\", constLabels: {}, variableLabels: []}"
 	if gauge == nil {
 		t.Fatal("gauge was nil")
 	}
-	expected := "Desc{fqName: \"ima_stat\", help: \"auto\", constLabels: {}, variableLabels: []}"
 	gaugeDesc := gauge.Desc().String()
 	if gaugeDesc != expected {
 		t.Errorf("gauge description: got %q, expected %q", gaugeDesc, expected)
 	}
-	counter := ap.autoCounter("ima_stat")
+	counter := ap.autoCounter("ima_counter")
+	expected = "Desc{fqName: \"ima_counter\", help: \"auto\", constLabels: {}, variableLabels: []}"
 	if counter == nil {
 		t.Fatal("counter was nil")
 	}
@@ -69,7 +70,8 @@ func TestAutoRegisterer(t *testing.T) {
 	if counterDesc != expected {
 		t.Errorf("counter description: got %q, expected %q", counterDesc, expected)
 	}
-	summary := ap.autoSummary("ima_stat")
+	summary := ap.autoSummary("ima_summary")
+	expected = "Desc{fqName: \"ima_summary\", help: \"auto\", constLabels: {}, variableLabels: []}"
 	if summary == nil {
 		t.Fatal("summary was nil")
 	}

--- a/metrics/scope.go
+++ b/metrics/scope.go
@@ -23,7 +23,7 @@ type Scope interface {
 // promScope is a Scope that sends data to Prometheus
 type promScope struct {
 	*autoRegisterer
-	prefix     string
+	prefix     []string
 	registerer prometheus.Registerer
 }
 
@@ -32,8 +32,9 @@ var _ Scope = &promScope{}
 // NewPromScope returns a Scope that sends data to Prometheus
 func NewPromScope(registerer prometheus.Registerer, scopes ...string) Scope {
 	return &promScope{
-		prefix:         strings.Join(scopes, ".") + ".",
+		prefix:         scopes,
 		autoRegisterer: newAutoRegisterer(registerer),
+		registerer:     registerer,
 	}
 }
 
@@ -45,43 +46,51 @@ func NewNoopScope() Scope {
 // NewScope generates a new Scope prefixed by this Scope's prefix plus the
 // prefixes given joined by periods
 func (s *promScope) NewScope(scopes ...string) Scope {
-	scope := strings.Join(scopes, ".")
-	return NewPromScope(s.registerer, s.prefix+scope)
+	return NewPromScope(s.registerer, append(s.prefix, scopes...)...)
 }
 
 // Inc increments the given stat and adds the Scope's prefix to the name
 func (s *promScope) Inc(stat string, value int64) error {
-	s.autoCounter(s.prefix + stat).Add(float64(value))
+	s.autoCounter(s.statName(stat)).Add(float64(value))
 	return nil
 }
 
 // Gauge sends a gauge stat and adds the Scope's prefix to the name
 func (s *promScope) Gauge(stat string, value int64) error {
-	s.autoGauge(s.prefix + stat).Set(float64(value))
+	s.autoGauge(s.statName(stat)).Set(float64(value))
 	return nil
 }
 
 // GaugeDelta sends the change in a gauge stat and adds the Scope's prefix to the name
 func (s *promScope) GaugeDelta(stat string, value int64) error {
-	s.autoGauge(s.prefix + stat).Add(float64(value))
+	s.autoGauge(s.statName(stat)).Add(float64(value))
 	return nil
 }
 
 // Timing sends a latency stat and adds the Scope's prefix to the name
 func (s *promScope) Timing(stat string, delta int64) error {
-	s.autoSummary(s.prefix + stat + "_seconds").Observe(float64(delta))
+	s.autoSummary(s.statName(stat) + "_seconds").Observe(float64(delta))
 	return nil
 }
 
 // TimingDuration sends a latency stat as a time.Duration and adds the Scope's
 // prefix to the name
 func (s *promScope) TimingDuration(stat string, delta time.Duration) error {
-	s.autoSummary(s.prefix + stat + "_seconds").Observe(delta.Seconds())
+	s.autoSummary(s.statName(stat) + "_seconds").Observe(delta.Seconds())
 	return nil
 }
 
 // SetInt sets a stat's integer value and adds the Scope's prefix to the name
 func (s *promScope) SetInt(stat string, value int64) error {
-	s.autoGauge(s.prefix + stat).Set(float64(value))
+	s.autoGauge(s.statName(stat)).Set(float64(value))
 	return nil
+}
+
+// statName construct a name for a stat based on the prefix of this scope, plus
+// the provided string.
+func (s *promScope) statName(stat string) string {
+	if len(s.prefix) > 0 {
+		return strings.Join(s.prefix, "_") + "_" + stat
+	}
+	return stat
 }


### PR DESCRIPTION
In #2752, I accidentally introduced a change that would use a NewRegistry for
each NewPromScope, ignoring the Registry that was passed as an argument. Because
this registry was not attached to any HTTP server, the results would not get
exported. This fixes that, so the Registry passed into NewPromScope is
respected.

In the process, I noticed that stats were getting prefixed by a spurious "_". I
fixed that by turning prefix into a slice of strings, and combining them with "_"
only if it the slice is non-empty.

Fixes #2824.