### PR TITLE
Use Docker Compose version 2 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Make sure you have a local copy of Boulder in your `$GOPATH`:
     export GOPATH=~/gopath
     git clone https://github.com/letsencrypt/boulder/ $GOPATH/src/github.com/letsencrypt/boulder
 
+Additionally, make sure you have Docker Engine 1.10.0+ and Docker Compose
+1.6.0+ installed. If you do not, you can follow Docker's [installation
+instructions]((https://docs.docker.com/compose/install/).
+
 To start Boulder in a Docker container, run:
 
     docker-compose up

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Make sure you have a local copy of Boulder in your `$GOPATH`:
 
 Additionally, make sure you have Docker Engine 1.10.0+ and Docker Compose
 1.6.0+ installed. If you do not, you can follow Docker's [installation
-instructions]((https://docs.docker.com/compose/install/).
+instructions](https://docs.docker.com/compose/install/).
 
 To start Boulder in a Docker container, run:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm.so
         expose:
           - 5657
+        network_mode: bridge
     bmysql:
         image: mariadb:10.1
         network_mode: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '2'
 services:
     boulder:
-        build: .
-        dockerfile: Dockerfile
+        build:
+            context: .
+            dockerfile: Dockerfile
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,64 +1,65 @@
 version: '2'
-boulder:
-    build: .
-    dockerfile: Dockerfile
-    environment:
-        FAKE_DNS: 127.0.0.1
-        PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-        BOULDER_CONFIG_DIR: test/config
-    volumes:
-      - .:/go/src/github.com/letsencrypt/boulder
-      - /tmp:/tmp
-    net: bridge
-    extra_hosts:
-      - le.wtf:127.0.0.1
-      - boulder:127.0.0.1
-    ports:
-      - 4000:4000 # ACME
-      - 4002:4002 # OCSP
-      - 4003:4003 # OCSP
-      - 4430:4430 # ACME via HTTPS
-      - 4500:4500 # ct-test-srv
-      - 6000:6000 # gsb-test-srv
-      - 8000:8000 # debug ports
-      - 8001:8001
-      - 8002:8002
-      - 8003:8003
-      - 8004:8004
-      - 8005:8005
-      - 8006:8006
-      - 8008:8008
-      - 8009:8009
-      - 8010:8010
-      - 8055:8055 # dns-test-srv updates
-      - 9380:9380 # mail-test-srv
-      - 9381:9381 # mail-test-srv
-    links:
-      - bhsm:boulder-hsm
-      - bmysql:boulder-mysql
-bhsm:
-    # To minimize the fetching of various layers this should match
-    # the FROM image and tag in boulder/Dockerfile
-    image: letsencrypt/boulder-tools:2017-05-25
-    environment:
-        PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
-    command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm.so
-    expose:
-      - 5657
-bmysql:
-    image: mariadb:10.1
-    net: bridge
-    environment:
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    command: mysqld --bind-address=0.0.0.0
-    log_driver: none
-prom:
-    image: prom/prometheus
-    net: bridge
-    ports:
-      - 9090:9090
-    volumes:
-      - $PWD/test/prometheus/:/promconf/
-    command: -config.file /promconf/prometheus.yml
-    links:
-      - boulder
+services:
+    boulder:
+        build: .
+        dockerfile: Dockerfile
+        environment:
+            FAKE_DNS: 127.0.0.1
+            PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
+            BOULDER_CONFIG_DIR: test/config
+        volumes:
+          - .:/go/src/github.com/letsencrypt/boulder
+          - /tmp:/tmp
+        net: bridge
+        extra_hosts:
+          - le.wtf:127.0.0.1
+          - boulder:127.0.0.1
+        ports:
+          - 4000:4000 # ACME
+          - 4002:4002 # OCSP
+          - 4003:4003 # OCSP
+          - 4430:4430 # ACME via HTTPS
+          - 4500:4500 # ct-test-srv
+          - 6000:6000 # gsb-test-srv
+          - 8000:8000 # debug ports
+          - 8001:8001
+          - 8002:8002
+          - 8003:8003
+          - 8004:8004
+          - 8005:8005
+          - 8006:8006
+          - 8008:8008
+          - 8009:8009
+          - 8010:8010
+          - 8055:8055 # dns-test-srv updates
+          - 9380:9380 # mail-test-srv
+          - 9381:9381 # mail-test-srv
+        links:
+          - bhsm:boulder-hsm
+          - bmysql:boulder-mysql
+    bhsm:
+        # To minimize the fetching of various layers this should match
+        # the FROM image and tag in boulder/Dockerfile
+        image: letsencrypt/boulder-tools:2017-05-25
+        environment:
+            PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
+        command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm.so
+        expose:
+          - 5657
+    bmysql:
+        image: mariadb:10.1
+        net: bridge
+        environment:
+            MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        command: mysqld --bind-address=0.0.0.0
+        log_driver: none
+    prom:
+        image: prom/prometheus
+        net: bridge
+        ports:
+          - 9090:9090
+        volumes:
+          - $PWD/test/prometheus/:/promconf/
+        command: -config.file /promconf/prometheus.yml
+        links:
+          - boulder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '2'
 boulder:
     build: .
     dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
           - /tmp:/tmp
-        net: bridge
+        network_mode: bridge
         extra_hosts:
           - le.wtf:127.0.0.1
           - boulder:127.0.0.1
@@ -49,7 +49,7 @@ services:
           - 5657
     bmysql:
         image: mariadb:10.1
-        net: bridge
+        network_mode: bridge
         environment:
             MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         command: mysqld --bind-address=0.0.0.0
@@ -57,7 +57,7 @@ services:
             driver: none
     prom:
         image: prom/prometheus
-        net: bridge
+        network_mode: bridge
         ports:
           - 9090:9090
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,8 @@ services:
         environment:
             MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         command: mysqld --bind-address=0.0.0.0
-        log_driver: none
+        logging:
+            driver: none
     prom:
         image: prom/prometheus
         net: bridge


### PR DESCRIPTION
After talking to @jsha, this updates Boulder's `docker-compose.yml` to version 2. I'm currently working on moving some Certbot tests from EC2 to Docker and this allows me to take advantage of networking features like [embedded DNS](https://docs.docker.com/engine/userguide/networking/configure-dns/) which is used by default in newer versions of Docker Compose.

This shouldn't change any behavior of the file. One notable thing is I had to add `network_mode: bridge` to the `bhsm` service. I don't believe this is a change in behavior though since `bhsm` was included in the `links` section for `boulder`. For example, when using the file in `master`, I see this:
```
$ sudo docker network inspect bridge
[
    {
        "Name": "bridge",
        "Id": "c736e49cb6042ca5c0b303704176742842a9a80f37aed84de06e46928a0462f2",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": [
                {
                    "Subnet": "172.17.0.0/16",
                    "Gateway": "172.17.0.1"
                }
            ]
        },
        "Internal": false,
        "Containers": {
            "5bcb2b178af390117a67cbde8a11610e8ccd5f61c747c10f99e67e4a18ba413b": {
                "Name": "boulder_bhsm_1",
                "EndpointID": "ee06921451ff80df907276d95897cadf6c2653f9d71358c174d636e5027d5ff5",
                "MacAddress": "02:42:ac:11:00:02",
                "IPv4Address": "172.17.0.2/16",
                "IPv6Address": ""
            },
            "73dafc2a041d4e4a72b3a13813e71d6aa5b00510c9a51c759b7430d6cea2762a": {
                "Name": "boulder_boulder_1",
                "EndpointID": "b1db4a6ead9173b0adc2baa6269c74681f214583e3c57879fa6ef69fd5610243",
                "MacAddress": "02:42:ac:11:00:04",
                "IPv4Address": "172.17.0.4/16",
                "IPv6Address": ""
            },
            "90eb008f0dc03b130e852a305ec9471b22694b52e6ffbf561efb3c172cabc43e": {
                "Name": "boulder_bmysql_1",
                "EndpointID": "fbca935d27e46b8ad44ea637ed04f959f14ceec6d5d618de59154718af7b7a73",
                "MacAddress": "02:42:ac:11:00:03",
                "IPv4Address": "172.17.0.3/16",
                "IPv6Address": ""
            }
        },
        "Options": {
            "com.docker.network.bridge.default_bridge": "true",
            "com.docker.network.bridge.enable_icc": "true",
            "com.docker.network.bridge.enable_ip_masquerade": "true",
            "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
            "com.docker.network.bridge.name": "docker0",
            "com.docker.network.driver.mtu": "1500"
        },
        "Labels": {}
    }
]
```
One additional thing that'd make my life easier which I didn't include in this PR is to stop using the default `bridge` network entirely and just use the default network created by Docker Compose. The reason for this is while I can [override values using additional Docker Compose files](https://docs.docker.com/compose/extends/), doing so seems to break all the links specified in the base file. Using the default network allows me to build off this file without doing surgery with something like `sed` or reconfiguring `links` which are much more fragile to future changes to this file.