### PR TITLE
Ensure consistent ordering from getFQDNSetsBySerials.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1114,8 +1114,7 @@ func (ssa *SQLStorageAuthority) getFQDNSetsBySerials(serials []string) ([]setHas
 		qmarks[i] = "?"
 	}
 	query := "SELECT setHash FROM fqdnSets " +
-		"WHERE serial IN (" + strings.Join(qmarks, ",") + ") " +
-		"ORDER BY setHash ASC"
+		"WHERE serial IN (" + strings.Join(qmarks, ",") + ")"
 	_, err := ssa.dbMap.Select(
 		&fqdnSets,
 		query,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1114,7 +1114,8 @@ func (ssa *SQLStorageAuthority) getFQDNSetsBySerials(serials []string) ([]setHas
 		qmarks[i] = "?"
 	}
 	query := "SELECT setHash FROM fqdnSets " +
-		"WHERE serial IN (" + strings.Join(qmarks, ",") + ")"
+		"WHERE serial IN (" + strings.Join(qmarks, ",") + ") " +
+		"ORDER BY setHash ASC"
 	_, err := ssa.dbMap.Select(
 		&fqdnSets,
 		query,


### PR DESCRIPTION
Fixes flaky `getFQDNSetsBySerials` unit test.