### PR TITLE
Improve error message for IPv6 failure with no IPv4 fallback.

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -216,7 +216,7 @@ func (d *dialer) Dial(_, _ string) (net.Conn, error) {
 	// error - there's nothing left to try
 	if len(v4) == 0 && len(d.record.AddressesTried) > 0 {
 		return nil,
-			fmt.Errorf("Unable to contact %q at %q, no additional IPv4 addresses to try as fallback",
+			fmt.Errorf("Unable to contact %q at %q, no IPv4 addresses to try as fallback",
 				d.record.Hostname, d.record.AddressesTried[0])
 	} else if len(v4) == 0 && len(d.record.AddressesTried) == 0 {
 		// It shouldn't be possible that there are no IPv4 addresses and no previous
@@ -480,7 +480,7 @@ func (va *ValidationAuthorityImpl) tryGetTLSSNICerts(ctx context.Context, identi
 	// an error - there's nothing left to try
 	if len(v4) == 0 && len(thisRecord.AddressesTried) > 0 {
 		return nil, validationRecords, probs.Malformed(
-			fmt.Sprintf("Unable to contact %q at %q, no additional IPv4 addresses to try as fallback",
+			fmt.Sprintf("Unable to contact %q at %q, no IPv4 addresses to try as fallback",
 				thisRecord.Hostname, thisRecord.AddressesTried[0]))
 	} else if len(v4) == 0 && len(thisRecord.AddressesTried) == 0 {
 		// It shouldn't be possible that there are no IPv4 addresses and no previous

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -1306,7 +1306,7 @@ func TestFallbackTLS(t *testing.T) {
 	test.Assert(t, prob != nil, "validation succeeded with broken IPv6 and no IPv4 fallback")
 	// We expect that the problem has the correct error message about nothing to fallback to
 	test.AssertEquals(t, prob.Detail,
-		"Unable to contact \"ipv6.localhost\" at \"::1\", no additional IPv4 addresses to try as fallback")
+		"Unable to contact \"ipv6.localhost\" at \"::1\", no IPv4 addresses to try as fallback")
 	// We expect one validation record to be present
 	test.AssertEquals(t, len(records), 1)
 	// We expect that the address eventually used was the IPv6 localhost address

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -1304,8 +1304,9 @@ func TestFallbackTLS(t *testing.T) {
 	// and a broken IPv6
 	records, prob = va.validateChallenge(ctx, ident, chall)
 	test.Assert(t, prob != nil, "validation succeeded with broken IPv6 and no IPv4 fallback")
-	// We expect that the problem has the correct error message about working IPs
-	test.AssertEquals(t, prob.Detail, "no working IP addresses found for \"ipv6.localhost\"")
+	// We expect that the problem has the correct error message about nothing to fallback to
+	test.AssertEquals(t, prob.Detail,
+		"Unable to contact \"ipv6.localhost\" at \"::1\", no additional IPv4 addresses to try as fallback")
 	// We expect one validation record to be present
 	test.AssertEquals(t, len(records), 1)
 	// We expect that the address eventually used was the IPv6 localhost address


### PR DESCRIPTION
This PR improves the rather vague error message that was previously returned if an IPv6 challenge validation failed when IPv6First was enabled and there were no IPv4 addresses left to try as a fallback.

Resolves #2821