### PR TITLE
Upgrade docker-compose version number

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
     boulder:
         build:


### PR DESCRIPTION
Upgrades the docker-compose file version per https://docs.docker.com/compose/compose-file/compose-versioning/

Based on the changes from the provided link, `sudo docker-compose up` still works. Boulder doesn't use any of the deprecated docker-compose features.