### PR TITLE
Update README for RAM requirement, add `cd` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,20 @@ Boulder has a Dockerfile to make it easy to install and set up all its
 dependencies. This is how the maintainers work on Boulder, and is our main
 recommended way to run it.
 
-Make sure you have a local copy of Boulder in your `$GOPATH`:
+Make sure you have a local copy of Boulder in your `$GOPATH`, and that you are
+in that directory:
 
     export GOPATH=~/gopath
     git clone https://github.com/letsencrypt/boulder/ $GOPATH/src/github.com/letsencrypt/boulder
+    cd $GOPATH/src/github.com/letsencrypt/boulder
 
 Additionally, make sure you have Docker Engine 1.10.0+ and Docker Compose
 1.6.0+ installed. If you do not, you can follow Docker's [installation
 instructions](https://docs.docker.com/compose/install/).
+
+We recommend having **at least 2GB of RAM** available on your Docker host. In
+practice using less RAM may result in the MariaDB container failing in
+non-obvious ways.
 
 To start Boulder in a Docker container, run:
 


### PR DESCRIPTION
From... ahem... some frustrating debugging I determined that the Boulder
docker environment fails in strange & mysterious ways if you do not have
sufficient RAM. This commit adds this fact to the README to save future
souls my torment.

This commit also adds a `cd` to the intial `git clone` instructions to
ensure the user is in the correct directory to run `docker-compose up`
from.