### PR TITLE
Fix HTTP-01 IPv6 to IPv4 fallback with fresh dialer per conn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,20 @@ Boulder has a Dockerfile to make it easy to install and set up all its
 dependencies. This is how the maintainers work on Boulder, and is our main
 recommended way to run it.
 
-Make sure you have a local copy of Boulder in your `$GOPATH`:
+Make sure you have a local copy of Boulder in your `$GOPATH`, and that you are
+in that directory:
 
     export GOPATH=~/gopath
     git clone https://github.com/letsencrypt/boulder/ $GOPATH/src/github.com/letsencrypt/boulder
+    cd $GOPATH/src/github.com/letsencrypt/boulder
 
 Additionally, make sure you have Docker Engine 1.10.0+ and Docker Compose
 1.6.0+ installed. If you do not, you can follow Docker's [installation
 instructions](https://docs.docker.com/compose/install/).
+
+We recommend having **at least 2GB of RAM** available on your Docker host. In
+practice using less RAM may result in the MariaDB container failing in
+non-obvious ways.
 
 To start Boulder in a Docker container, run:
 

--- a/va/va.go
+++ b/va/va.go
@@ -173,20 +173,32 @@ func (va ValidationAuthorityImpl) getAddr(ctx context.Context, hostname string) 
 	return addr, addrs, nil
 }
 
+// http01Dialer is a struct that exists to provide a dialer like object with
+// a `Dial` method that can be given to an http.Transport for HTTP-01
+// validation. The primary purpose of the http01Dialer's Dial method is to
+// circumvent traditional DNS lookup and to use the IP addresses provided in the
+// inner `record` member populated by the `resolveAndConstructDialer` function.
 type http01Dialer struct {
 	record      core.ValidationRecord
 	stats       metrics.Scope
 	dialerCount int
 }
 
-func (d *http01Dialer) newDialer() net.Dialer {
-	// Record that we created a new dialer
+// realDialer is used to create a true `net.Dialer` that can be used once an IP
+// address to connect to is determined. It increments the `dialerCount` integer
+// to track how many "fresh" dialer instances have been created during a `Dial`.
+func (d *http01Dialer) realDialer() *net.Dialer {
+	// Record that we created a new instance of a real net.Dialer
 	d.dialerCount++
-	return net.Dialer{Timeout: validationTimeout}
+	return &net.Dialer{Timeout: validationTimeout}
 }
 
+// Dial processes the IP addresses from the inner validation record, using
+// `realDialer` to make connections as required. If `features.IPv6First` is
+// enabled then for dual-homed hosts an initial IPv6 connection will be made
+// followed by a IPv4 connection if there is a failure with the IPv6 connection.
 func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
-	realDialer := d.newDialer()
+	var realDialer *net.Dialer
 
 	// Split the available addresses into v4 and v6 addresses
 	v4, v6 := availableAddresses(d.record)
@@ -201,6 +213,7 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 		}
 		address := net.JoinHostPort(addresses[0].String(), d.record.Port)
 		d.record.AddressUsed = addresses[0]
+		realDialer = d.realDialer()
 		return realDialer.Dial("tcp", address)
 	}
 
@@ -209,6 +222,7 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 	if features.Enabled(features.IPv6First) && len(v6) > 0 {
 		address := net.JoinHostPort(v6[0].String(), d.record.Port)
 		d.record.AddressUsed = v6[0]
+		realDialer = d.realDialer()
 		conn, err := realDialer.Dial("tcp", address)
 
 		// If there is no error, return immediately
@@ -219,7 +233,7 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 		// Otherwise, we note that we tried an address and fall back to trying IPv4
 		d.record.AddressesTried = append(d.record.AddressesTried, d.record.AddressUsed)
 		// Reconstruct the underlying dialer to get a new timeout for the second request
-		realDialer = d.newDialer()
+		realDialer = d.realDialer()
 		d.stats.Inc("IPv4Fallback", 1)
 	}
 

--- a/va/va.go
+++ b/va/va.go
@@ -233,8 +233,6 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 
 		// Otherwise, we note that we tried an address and fall back to trying IPv4
 		d.record.AddressesTried = append(d.record.AddressesTried, d.record.AddressUsed)
-		// Reconstruct the underlying dialer to get a new timeout for the second request
-		realDialer = d.realDialer()
 		d.stats.Inc("IPv4Fallback", 1)
 	}
 

--- a/va/va.go
+++ b/va/va.go
@@ -186,7 +186,8 @@ type http01Dialer struct {
 
 // realDialer is used to create a true `net.Dialer` that can be used once an IP
 // address to connect to is determined. It increments the `dialerCount` integer
-// to track how many "fresh" dialer instances have been created during a `Dial`.
+// to track how many "fresh" dialer instances have been created during a `Dial`
+// for testing purposes.
 func (d *http01Dialer) realDialer() *net.Dialer {
 	// Record that we created a new instance of a real net.Dialer
 	d.dialerCount++

--- a/va/va.go
+++ b/va/va.go
@@ -254,6 +254,7 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 	// talking to the first IPv6 address, try the first IPv4 address
 	address := net.JoinHostPort(v4[0].String(), d.record.Port)
 	d.record.AddressUsed = v4[0]
+	realDialer = d.realDialer()
 	return realDialer.Dial("tcp", address)
 }
 

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -1211,7 +1211,8 @@ func TestHTTP01DialerFallback(t *testing.T) {
 	// Create a test VA
 	va, _ := setup(hs, 0)
 
-	// Create a test dialer for the dual homed host
+	// Create a test dialer for the dual homed host. There is only an IPv4 httpSrv
+	// so the IPv6 address returned in the AAAA record will always fail.
 	d, _ := va.resolveAndConstructDialer(context.Background(), "ipv4.and.ipv6.localhost", va.httpPort)
 
 	// Try to dial the dialer


### PR DESCRIPTION
The implementation of the dialer used by the HTTP01 challenge, constructed with `resolveAndConstructDialer`, used the same wrapped `net.Dialer` for both the initial IPv6 connection, and any subsequent IPv4 fallback connections. This caused the IPv4 fallback to never succeed for cases where the initial IPv6 connection expended the `validationTimeout`.

This commit updates the http01Dialer (newly renamed from `dialer` since it is in fact specific to HTTP01 challenges) to use a fresh dialer for each connection. To facilitate testing the http01Dialer maintains
a count of how many dialer instances it has constructed. We use this in a unit test to ensure the correct behaviour without a great deal of new mocking/interfaces.

Resolves #2770 