### PR TITLE
Return more detailed error for connection reset in va

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -704,6 +704,9 @@ func detailedError(err error) *probs.ProblemDetails {
 		} else if syscallErr, ok := netErr.Err.(*os.SyscallError); ok &&
 			syscallErr.Err == syscall.ECONNREFUSED {
 			return probs.ConnectionFailure("Connection refused")
+		} else if syscallErr, ok := netErr.Err.(*os.SyscallError); ok &&
+			syscallErr.Err == syscall.ECONNRESET {
+			return probs.ConnectionFailure("Connection reset by peer")
 		}
 	}
 	if err, ok := err.(net.Error); ok && err.Timeout() {

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -1526,17 +1526,37 @@ func TestPerformRemoteValidation(t *testing.T) {
 }
 
 func TestDetailedError(t *testing.T) {
-	err := &net.OpError{
-		Op:  "dial",
-		Net: "tcp",
-		Err: &os.SyscallError{
-			Syscall: "getsockopt",
-			Err:     syscall.ECONNREFUSED,
+	cases := []struct {
+		err      error
+		expected string
+	}{
+		{
+			&net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{
+					Syscall: "getsockopt",
+					Err:     syscall.ECONNREFUSED,
+				},
+			},
+			"Connection refused",
+		},
+		{
+			&net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{
+					Syscall: "getsockopt",
+					Err:     syscall.ECONNRESET,
+				},
+			},
+			"Connection reset by peer",
 		},
 	}
-	expected := "Connection refused"
-	actual := detailedError(err).Detail
-	if actual != expected {
-		t.Errorf("Wrong detail for connection refused. Got %q, expected %q", actual, expected)
+	for _, tc := range cases {
+		actual := detailedError(tc.err).Detail
+		if actual != tc.expected {
+			t.Errorf("Wrong detail for %v. Got %q, expected %q", tc.err, actual, tc.expected)
+		}
 	}
 }


### PR DESCRIPTION
If we hit a `syscall.ECONNRESET` error return a more useful error than `Error getting validation data`, updates the `TestDetailedError` test to cover this case.

Fixes #2851.