### PR TITLE
Rename DNSResolver -> DNSClient

### DIFF
--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -225,7 +225,7 @@ func newTestStats() metrics.Scope {
 var testStats = newTestStats()
 
 func TestDNSNoServers(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Hour, []string{}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Hour, []string{}, testStats, clock.NewFake(), 1)
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -233,7 +233,7 @@ func TestDNSNoServers(t *testing.T) {
 }
 
 func TestDNSOneServer(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -241,7 +241,7 @@ func TestDNSOneServer(t *testing.T) {
 }
 
 func TestDNSDuplicateServers(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr, dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr, dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -249,7 +249,7 @@ func TestDNSDuplicateServers(t *testing.T) {
 }
 
 func TestDNSLookupsNoServer(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{}, testStats, clock.NewFake(), 1)
 
 	_, _, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 	test.AssertError(t, err, "No servers")
@@ -262,7 +262,7 @@ func TestDNSLookupsNoServer(t *testing.T) {
 }
 
 func TestDNSServFail(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 	bad := "servfail.com"
 
 	_, _, err := obj.LookupTXT(context.Background(), bad)
@@ -290,7 +290,7 @@ func TestDNSServFail(t *testing.T) {
 }
 
 func TestDNSLookupTXT(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	a, _, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 	t.Logf("A: %v", a)
@@ -304,7 +304,7 @@ func TestDNSLookupTXT(t *testing.T) {
 }
 
 func TestDNSLookupHost(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	ip, err := obj.LookupHost(context.Background(), "servfail.com")
 	t.Logf("servfail.com - IP: %s, Err: %s", ip, err)
@@ -371,7 +371,7 @@ func TestDNSLookupHost(t *testing.T) {
 }
 
 func TestDNSNXDOMAIN(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	hostname := "nxdomain.letsencrypt.org"
 	_, err := obj.LookupHost(context.Background(), hostname)
@@ -388,7 +388,7 @@ func TestDNSNXDOMAIN(t *testing.T) {
 }
 
 func TestDNSLookupCAA(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	caas, err := obj.LookupCAA(context.Background(), "bracewel.net")
 	test.AssertNotError(t, err, "CAA lookup failed")
@@ -404,7 +404,7 @@ func TestDNSLookupCAA(t *testing.T) {
 }
 
 func TestDNSTXTAuthorities(t *testing.T) {
-	obj := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
 	_, auths, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 
@@ -582,7 +582,7 @@ func TestRetry(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		dr := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), tc.maxTries)
+		dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), tc.maxTries)
 
 		dr.dnsClient = tc.te
 		_, _, err := dr.LookupTXT(context.Background(), "example.com")
@@ -600,7 +600,7 @@ func TestRetry(t *testing.T) {
 		}
 	}
 
-	dr := NewTestDNSResolverImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 3)
+	dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 3)
 	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -11,12 +11,12 @@ import (
 	"golang.org/x/net/context"
 )
 
-// MockDNSResolver is a mock
-type MockDNSResolver struct {
+// MockDNSClient is a mock
+type MockDNSClient struct {
 }
 
 // LookupTXT is a mock
-func (mock *MockDNSResolver) LookupTXT(_ context.Context, hostname string) ([]string, []string, error) {
+func (mock *MockDNSClient) LookupTXT(_ context.Context, hostname string) ([]string, []string, error) {
 	if hostname == "_acme-challenge.servfail.com" {
 		return nil, nil, fmt.Errorf("SERVFAIL")
 	}
@@ -59,7 +59,7 @@ func (t timeoutError) Timeout() bool {
 //
 // Note: see comments on LookupMX regarding email.only
 //
-func (mock *MockDNSResolver) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
+func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
 	if hostname == "always.invalid" ||
 		hostname == "invalid.invalid" ||
 		hostname == "email.only" {
@@ -90,7 +90,7 @@ func (mock *MockDNSResolver) LookupHost(_ context.Context, hostname string) ([]n
 }
 
 // LookupCAA returns mock records for use in tests.
-func (mock *MockDNSResolver) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, error) {
+func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, error) {
 	var results []*dns.CAA
 	var record dns.CAA
 	switch strings.TrimRight(domain, ".") {
@@ -158,7 +158,7 @@ func (mock *MockDNSResolver) LookupCAA(_ context.Context, domain string) ([]*dns
 // all domains except for special cases, so MX-only domains must be
 // handled in both LookupHost and LookupMX.
 //
-func (mock *MockDNSResolver) LookupMX(_ context.Context, domain string) ([]string, error) {
+func (mock *MockDNSClient) LookupMX(_ context.Context, domain string) ([]string, error) {
 	switch strings.TrimRight(domain, ".") {
 	case "letsencrypt.org":
 		fallthrough

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -186,7 +186,7 @@ func main() {
 		dnsTries = 1
 	}
 	if !c.Common.DNSAllowLoopbackAddresses {
-		rai.DNSResolver = bdns.NewDNSResolverImpl(
+		rai.DNSClient = bdns.NewDNSClientImpl(
 			raDNSTimeout,
 			[]string{c.Common.DNSResolver},
 			nil,
@@ -194,7 +194,7 @@ func main() {
 			clock.Default(),
 			dnsTries)
 	} else {
-		rai.DNSResolver = bdns.NewTestDNSResolverImpl(
+		rai.DNSClient = bdns.NewTestDNSClientImpl(
 			raDNSTimeout,
 			[]string{c.Common.DNSResolver},
 			scope,

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -108,9 +108,9 @@ func main() {
 	clk := clock.Default()
 	caaSERVFAILExceptions, err := bdns.ReadHostList(c.VA.CAASERVFAILExceptions)
 	cmd.FailOnError(err, "Couldn't read CAASERVFAILExceptions file")
-	var resolver bdns.DNSResolver
+	var resolver bdns.DNSClient
 	if !c.Common.DNSAllowLoopbackAddresses {
-		r := bdns.NewDNSResolverImpl(
+		r := bdns.NewDNSClientImpl(
 			dnsTimeout,
 			[]string{c.Common.DNSResolver},
 			caaSERVFAILExceptions,
@@ -119,7 +119,7 @@ func main() {
 			dnsTries)
 		resolver = r
 	} else {
-		r := bdns.NewTestDNSResolverImpl(dnsTimeout, []string{c.Common.DNSResolver}, scope, clk, dnsTries)
+		r := bdns.NewTestDNSClientImpl(dnsTimeout, []string{c.Common.DNSResolver}, scope, clk, dnsTries)
 		resolver = r
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -51,11 +51,11 @@ type RegistrationAuthorityImpl struct {
 	PA        core.PolicyAuthority
 	publisher core.Publisher
 
-	stats       metrics.Scope
-	DNSResolver bdns.DNSResolver
-	clk         clock.Clock
-	log         blog.Logger
-	keyPolicy   goodkey.KeyPolicy
+	stats     metrics.Scope
+	DNSClient bdns.DNSClient
+	clk       clock.Clock
+	log       blog.Logger
+	keyPolicy goodkey.KeyPolicy
 	// How long before a newly created authorization expires.
 	authorizationLifetime        time.Duration
 	pendingAuthorizationLifetime time.Duration
@@ -180,7 +180,7 @@ func problemIsTimeout(err error) bool {
 	return false
 }
 
-func validateEmail(ctx context.Context, address string, resolver bdns.DNSResolver) error {
+func validateEmail(ctx context.Context, address string, resolver bdns.DNSClient) error {
 	emails, err := mail.ParseAddressList(address)
 	if err != nil {
 		return unparseableEmailError
@@ -382,7 +382,7 @@ func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, conta
 
 		start := ra.clk.Now()
 		ra.stats.Inc("ValidateEmail.Calls", 1)
-		err = validateEmail(ctx, parsed.Opaque, ra.DNSResolver)
+		err = validateEmail(ctx, parsed.Opaque, ra.DNSClient)
 		ra.stats.TimingDuration("ValidateEmail.Latency", ra.clk.Now().Sub(start))
 		if err != nil {
 			ra.stats.Inc("ValidateEmail.Errors", 1)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -262,7 +262,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	ra.VA = va
 	ra.CA = ca
 	ra.PA = pa
-	ra.DNSResolver = &bdns.MockDNSResolver{}
+	ra.DNSClient = &bdns.MockDNSClient{}
 
 	AuthzInitial.RegistrationID = Registration.ID
 
@@ -347,7 +347,7 @@ func TestValidateEmail(t *testing.T) {
 	}
 
 	for _, tc := range testFailures {
-		err := validateEmail(context.Background(), tc.input, &bdns.MockDNSResolver{})
+		err := validateEmail(context.Background(), tc.input, &bdns.MockDNSClient{})
 		if !berrors.Is(err, berrors.InvalidEmail) {
 			t.Errorf("validateEmail(%q): got error %#v, expected type berrors.InvalidEmail", tc.input, err)
 		}
@@ -359,7 +359,7 @@ func TestValidateEmail(t *testing.T) {
 	}
 
 	for _, addr := range testSuccesses {
-		if err := validateEmail(context.Background(), addr, &bdns.MockDNSResolver{}); err != nil {
+		if err := validateEmail(context.Background(), addr, &bdns.MockDNSClient{}); err != nil {
 			t.Errorf("validateEmail(%q): expected success, but it failed: %#v",
 				addr, err)
 		}

--- a/va/va.go
+++ b/va/va.go
@@ -92,7 +92,7 @@ func initMetrics(stats metrics.Scope) *vaMetrics {
 // ValidationAuthorityImpl represents a VA
 type ValidationAuthorityImpl struct {
 	log               blog.Logger
-	dnsResolver       bdns.DNSResolver
+	dnsClient         bdns.DNSClient
 	issuerDomain      string
 	safeBrowsing      SafeBrowsing
 	httpPort          int
@@ -111,7 +111,7 @@ type ValidationAuthorityImpl struct {
 func NewValidationAuthorityImpl(
 	pc *cmd.PortConfig,
 	sbc SafeBrowsing,
-	resolver bdns.DNSResolver,
+	resolver bdns.DNSClient,
 	remoteVAs []RemoteVA,
 	maxRemoteFailures int,
 	userAgent string,
@@ -123,7 +123,7 @@ func NewValidationAuthorityImpl(
 
 	return &ValidationAuthorityImpl{
 		log:               logger,
-		dnsResolver:       resolver,
+		dnsClient:         resolver,
 		issuerDomain:      issuerDomain,
 		safeBrowsing:      sbc,
 		httpPort:          pc.HTTPPort,
@@ -155,7 +155,7 @@ type verificationRequestEvent struct {
 // resolved. This is the same choice made by the Go internal resolution library
 // used by net/http.
 func (va ValidationAuthorityImpl) getAddr(ctx context.Context, hostname string) (net.IP, []net.IP, *probs.ProblemDetails) {
-	addrs, err := va.dnsResolver.LookupHost(ctx, hostname)
+	addrs, err := va.dnsClient.LookupHost(ctx, hostname)
 	if err != nil {
 		va.log.Debug(fmt.Sprintf("%s DNS failure: %s", hostname, err))
 		problem := probs.ConnectionFailure(err.Error())
@@ -726,7 +726,7 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier
 
 	// Look for the required record in the DNS
 	challengeSubdomain := fmt.Sprintf("%s.%s", core.DNSPrefix, identifier.Value)
-	txts, authorities, err := va.dnsResolver.LookupTXT(ctx, challengeSubdomain)
+	txts, authorities, err := va.dnsClient.LookupTXT(ctx, challengeSubdomain)
 
 	if err != nil {
 		va.log.Info(fmt.Sprintf("Failed to lookup txt records for %s. err=[%#v] errStr=[%s]", identifier, err, err))
@@ -1027,7 +1027,7 @@ func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname strin
 	// the RPC call.
 	//
 	// We depend on our resolver to snap CNAME and DNAME records.
-	results := va.parallelCAALookup(ctx, hostname, va.dnsResolver.LookupCAA)
+	results := va.parallelCAALookup(ctx, hostname, va.dnsClient.LookupCAA)
 	return parseResults(results)
 }
 

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -984,7 +984,7 @@ func TestDNSValidationServFail(t *testing.T) {
 
 func TestDNSValidationNoServer(t *testing.T) {
 	va, _ := setup(nil, 0)
-	va.dnsResolver = bdns.NewTestDNSResolverImpl(
+	va.dnsClient = bdns.NewTestDNSClientImpl(
 		time.Second*5,
 		nil,
 		metrics.NewNoopScope(),
@@ -1078,7 +1078,7 @@ func setup(srv *httptest.Server, maxRemoteFailures int) (*ValidationAuthorityImp
 		// Use the test server's port as both the HTTPPort and the TLSPort for the VA
 		&portConfig,
 		nil,
-		&bdns.MockDNSResolver{},
+		&bdns.MockDNSClient{},
 		nil,
 		maxRemoteFailures,
 		"user agent 1.0",


### PR DESCRIPTION
Fixes #639.

This resolves something that has bugged me for two+ years, our `DNSResolverImpl` is not a DNS resolver, it is a DNS client. This change just makes that obvious.