### PR TITLE
Use standard SA methods in the expiration-mailer and refactor tests

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -302,15 +302,7 @@ func (m *mailer) findExpiringCertificates() error {
 		var certs []core.Certificate
 		for _, serial := range serials {
 			var cert core.Certificate
-			err := m.dbMap.SelectOne(&cert,
-				`SELECT
-				cert.*
-				FROM certificates AS cert
-				WHERE serial = :serial`,
-				map[string]interface{}{
-					"serial": serial,
-				},
-			)
+			cert, err := sa.SelectCertificate(m.dbMap, "WHERE serial = ?", serial)
 			if err != nil {
 				m.log.AuditErr(fmt.Sprintf("expiration-mailer: Error loading cert %q: %s", cert.Serial, err))
 				return err

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -312,12 +312,6 @@ func addExpiringCerts(t *testing.T, ctx *testCtx) []core.Certificate {
 		Expires:        rawCertA.NotAfter,
 		DER:            certDerA,
 	}
-	certStatusA := &core.CertificateStatus{
-		Serial:                serial1String,
-		LastExpirationNagSent: ctx.fc.Now().AddDate(0, 0, -3),
-		Status:                core.OCSPStatusGood,
-		NotAfter:              rawCertA.NotAfter,
-	}
 
 	// Expires in 3d, already sent 4d nag at 4.5d
 	rawCertB := x509.Certificate{
@@ -334,12 +328,6 @@ func addExpiringCerts(t *testing.T, ctx *testCtx) []core.Certificate {
 		Serial:         serial2String,
 		Expires:        rawCertB.NotAfter,
 		DER:            certDerB,
-	}
-	certStatusB := &core.CertificateStatus{
-		Serial:                serial2String,
-		LastExpirationNagSent: ctx.fc.Now().Add(-36 * time.Hour),
-		Status:                core.OCSPStatusGood,
-		NotAfter:              rawCertB.NotAfter,
 	}
 
 	// Expires in 7d and change, no nag sent at all yet
@@ -358,11 +346,6 @@ func addExpiringCerts(t *testing.T, ctx *testCtx) []core.Certificate {
 		Expires:        rawCertC.NotAfter,
 		DER:            certDerC,
 	}
-	certStatusC := &core.CertificateStatus{
-		Serial:   serial3String,
-		Status:   core.OCSPStatusGood,
-		NotAfter: rawCertC.NotAfter,
-	}
 
 	// Expires in 3d, renewed
 	rawCertD := x509.Certificate{
@@ -379,11 +362,6 @@ func addExpiringCerts(t *testing.T, ctx *testCtx) []core.Certificate {
 		Serial:         serial4String,
 		Expires:        rawCertD.NotAfter,
 		DER:            certDerD,
-	}
-	certStatusD := &core.CertificateStatus{
-		Serial:   serial4String,
-		Status:   core.OCSPStatusGood,
-		NotAfter: rawCertD.NotAfter,
 	}
 	fqdnStatusD := &core.FQDNSet{
 		SetHash: []byte("hash of D"),
@@ -407,13 +385,13 @@ func addExpiringCerts(t *testing.T, ctx *testCtx) []core.Certificate {
 	test.AssertNotError(t, err, "Couldn't add certC")
 	err = setupDBMap.Insert(certD)
 	test.AssertNotError(t, err, "Couldn't add certD")
-	err = setupDBMap.Insert(certStatusA)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, lastExpirationNagSent, status, notAfter, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?,?)", serial1String, ctx.fc.Now().AddDate(0, 0, -3), string(core.OCSPStatusGood), rawCertA.NotAfter, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "Couldn't add certStatusA")
-	err = setupDBMap.Insert(certStatusB)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, lastExpirationNagSent, status, notAfter, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?,?)", serial2String, ctx.fc.Now().Add(-36*time.Hour), string(core.OCSPStatusGood), rawCertB.NotAfter, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "Couldn't add certStatusB")
-	err = setupDBMap.Insert(certStatusC)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, status, notAfter, lastExpirationNagSent, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?,?)", serial3String, string(core.OCSPStatusGood), rawCertC.NotAfter, time.Time{}, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "Couldn't add certStatusC")
-	err = setupDBMap.Insert(certStatusD)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, status, notAfter, lastExpirationNagSent, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?,?)", serial4String, string(core.OCSPStatusGood), rawCertD.NotAfter, time.Time{}, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "Couldn't add certStatusD")
 	err = setupDBMap.Insert(fqdnStatusD)
 	test.AssertNotError(t, err, "Couldn't add fqdnStatusD")
@@ -561,10 +539,6 @@ func TestCertIsRenewed(t *testing.T) {
 			Expires:        testData.NotAfter,
 			DER:            certDer,
 		}
-		certStatus := &core.CertificateStatus{
-			Serial: testData.stringSerial,
-			Status: core.OCSPStatusGood,
-		}
 		fqdnStatus := &core.FQDNSet{
 			SetHash: testData.FQDNHash,
 			Serial:  testData.stringSerial,
@@ -574,7 +548,7 @@ func TestCertIsRenewed(t *testing.T) {
 
 		err = setupDBMap.Insert(cert)
 		test.AssertNotError(t, err, fmt.Sprintf("Couldn't add cert %s", testData.stringSerial))
-		err = setupDBMap.Insert(certStatus)
+		_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, status, lastExpirationNagSent, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?)", fmt.Sprintf("%x", testData.Serial.Bytes()), string(core.OCSPStatusGood), time.Time{}, time.Time{}, time.Time{}, 0, 0, false)
 		test.AssertNotError(t, err, fmt.Sprintf("Couldn't add certStatus %s", testData.stringSerial))
 		err = setupDBMap.Insert(fqdnStatus)
 		test.AssertNotError(t, err, fmt.Sprintf("Couldn't add fqdnStatus %s", testData.stringSerial))
@@ -629,16 +603,10 @@ func TestLifetimeOfACert(t *testing.T) {
 		DER:            certDerA,
 	}
 
-	certStatusA := &core.CertificateStatus{
-		Serial:   serial1String,
-		Status:   core.OCSPStatusGood,
-		NotAfter: rawCertA.NotAfter,
-	}
-
 	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, 0)
 	err = setupDBMap.Insert(certA)
 	test.AssertNotError(t, err, "unable to insert Certificate")
-	err = setupDBMap.Insert(certStatusA)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, status, notAfter, lastExpirationNagSent, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?,?)", serial1String, string(core.OCSPStatusGood), rawCertA.NotAfter, time.Time{}, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "unable to insert CertificateStatus")
 
 	type lifeTest struct {
@@ -735,15 +703,10 @@ func TestDontFindRevokedCert(t *testing.T) {
 		DER:            certDerA,
 	}
 
-	certStatusA := &core.CertificateStatus{
-		Serial: serial1String,
-		Status: core.OCSPStatusRevoked,
-	}
-
 	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, 0)
 	err = setupDBMap.Insert(certA)
 	test.AssertNotError(t, err, "unable to insert Certificate")
-	err = setupDBMap.Insert(certStatusA)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial,status, lastExpirationNagSent, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?)", serial1String, string(core.OCSPStatusRevoked), time.Time{}, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "unable to insert CertificateStatus")
 
 	err = testCtx.m.findExpiringCertificates()
@@ -787,12 +750,6 @@ func TestDedupOnRegistration(t *testing.T) {
 		Expires:        rawCertA.NotAfter,
 		DER:            certDerA,
 	}
-	certStatusA := &core.CertificateStatus{
-		Serial:                serial1String,
-		LastExpirationNagSent: time.Unix(0, 0),
-		Status:                core.OCSPStatusGood,
-		NotAfter:              rawCertA.NotAfter,
-	}
 
 	rawCertB := newX509Cert("happy B",
 		testCtx.fc.Now().Add(48*time.Hour),
@@ -806,21 +763,15 @@ func TestDedupOnRegistration(t *testing.T) {
 		Expires:        rawCertB.NotAfter,
 		DER:            certDerB,
 	}
-	certStatusB := &core.CertificateStatus{
-		Serial:                serial2String,
-		LastExpirationNagSent: time.Unix(0, 0),
-		Status:                core.OCSPStatusGood,
-		NotAfter:              rawCertB.NotAfter,
-	}
 
 	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, 0)
 	err = setupDBMap.Insert(certA)
 	test.AssertNotError(t, err, "Couldn't add certA")
 	err = setupDBMap.Insert(certB)
 	test.AssertNotError(t, err, "Couldn't add certB")
-	err = setupDBMap.Insert(certStatusA)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, lastExpirationNagSent, status, notAfter, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?,?)", serial1String, time.Unix(0, 0), string(core.OCSPStatusGood), rawCertA.NotAfter, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "Couldn't add certStatusA")
-	err = setupDBMap.Insert(certStatusB)
+	_, err = setupDBMap.Exec("INSERT INTO certificateStatus (serial, lastExpirationNagSent, status, notAfter, ocspLastUpdated, revokedDate, revokedReason, LockCol, subscriberApproved) VALUES (?,?,?,?,?,?,?,?,?)", serial2String, time.Unix(0, 0), string(core.OCSPStatusGood), rawCertB.NotAfter, time.Time{}, time.Time{}, 0, 0, false)
 	test.AssertNotError(t, err, "Couldn't add certStatusB")
 
 	err = testCtx.m.findExpiringCertificates()


### PR DESCRIPTION
This makes making changes to the `certificate` and `certificateStatus` tables much easier in the future.