### PR TITLE
Fix unsafe rand.Rand usage in policy/pa.go

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -299,6 +299,7 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.C
 	combinations := make([][]int, len(challenges))
 
 	pa.rngMu.Lock()
+	defer pa.rngMu.Unlock()
 	for i, challIdx := range pa.pseudoRNG.Perm(len(challenges)) {
 		shuffled[i] = challenges[challIdx]
 		combinations[i] = []int{i}
@@ -308,7 +309,6 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.C
 	for i, comboIdx := range pa.pseudoRNG.Perm(len(combinations)) {
 		shuffledCombos[i] = combinations[comboIdx]
 	}
-	pa.rngMu.Unlock()
 
 	return shuffled, shuffledCombos
 }

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -31,6 +31,7 @@ type AuthorityImpl struct {
 
 	enabledChallenges map[string]bool
 	pseudoRNG         *rand.Rand
+	rngMu             sync.Mutex
 }
 
 // New constructs a Policy Authority.
@@ -297,6 +298,7 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.C
 	shuffled := make([]core.Challenge, len(challenges))
 	combinations := make([][]int, len(challenges))
 
+	pa.rngMu.Lock()
 	for i, challIdx := range pa.pseudoRNG.Perm(len(challenges)) {
 		shuffled[i] = challenges[challIdx]
 		combinations[i] = []int{i}
@@ -306,6 +308,7 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.C
 	for i, comboIdx := range pa.pseudoRNG.Perm(len(combinations)) {
 		shuffledCombos[i] = combinations[comboIdx]
 	}
+	pa.rngMu.Unlock()
 
 	return shuffled, shuffledCombos
 }


### PR DESCRIPTION
After looking at this and thinking about it a bit more it doesn't really make sense to remove either usage of shuffling for the challenges or combinations. If we shuffle one but not the other we don't really get the behavior we want for either the v1 or v2 API (if the v2 API actually ends up using this and not it's own implementation) especially since there are people still developing new clients against the v1 API that we'd prefer aren't broken in the case we have to introduce another challenge for security reasons.

Instead I've just gone with the easy fix of implementing a lock around the usage. Another option would be to just create a new source each time and seed it using `rand.Int63` but I doubt that would be much faster than the latency the lock contention will introduce.

Fixes #2890.