### PR TITLE
CA: Use a fresh CA object in each Invalid CSR subtest.

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -498,20 +498,20 @@ func TestInvalidCSRs(t *testing.T) {
 		{"RejectWrongSignature", "./testdata/invalid_signature.der.csr", "Issued a certificate based on a CSR with an invalid signature."},
 	}
 
-	testCtx := setup(t)
-	sa := &mockSA{}
-	ca, err := NewCertificateAuthorityImpl(
-		testCtx.caConfig,
-		sa,
-		testCtx.pa,
-		testCtx.fc,
-		testCtx.stats,
-		testCtx.issuers,
-		testCtx.keyPolicy,
-		testCtx.logger)
-	test.AssertNotError(t, err, "Failed to create CA")
-
 	for _, testCase := range testCases {
+		testCtx := setup(t)
+		sa := &mockSA{}
+		ca, err := NewCertificateAuthorityImpl(
+			testCtx.caConfig,
+			sa,
+			testCtx.pa,
+			testCtx.fc,
+			testCtx.stats,
+			testCtx.issuers,
+			testCtx.keyPolicy,
+			testCtx.logger)
+		test.AssertNotError(t, err, "Failed to create CA")
+
 		t.Run(testCase.name, func(t *testing.T) {
 			serializedCSR := mustRead(testCase.csrPath)
 			_, err = ca.IssueCertificate(ctx, &caPB.IssueCertificateRequest{Csr: serializedCSR, RegistrationID: &arbitraryRegID})


### PR DESCRIPTION
Limit the interference between these subtests by giving each subtest its own CA
object, as is done for the other issuance tests.