### PR TITLE
Add newline when printing to STDERR

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -146,7 +146,7 @@ func (w *bothWriter) logAtLevel(level syslog.Priority, msg string) {
 	}
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to write to syslog: %s (%s)", msg, err)
+		fmt.Fprintf(os.Stderr, "Failed to write to syslog: %s (%s)\n", msg, err)
 	}
 
 	var reset string


### PR DESCRIPTION
In `log/log.go` when we fail to write to syslog we log the message to STDERR but without a newline. This causes all of the STDERR logs (when we reconnect to syslog) to be delivered where they go to be on a single line which causes some debugging pain.