### PR TITLE
Retiring feature flags

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -621,17 +621,10 @@ func (updater *OCSPUpdater) missingReceiptsTick(ctx context.Context, batchSize i
 			continue
 		}
 
-		// If the feature flag is enabled, only send the certificate to the missing
-		// logs using the `SubmitToSingleCT` endpoint that was added for this
-		// purpose
-		if features.Enabled(features.ResubmitMissingSCTsOnly) {
-			for _, log := range missingLogs {
-				_ = updater.pubc.SubmitToSingleCT(ctx, log.uri, log.key, cert.DER)
-			}
-		} else {
-			// Otherwise, use the classic behaviour and submit the certificate to
-			// every log to get SCTS using the pre-existing `SubmitToCT` endpoint
-			_ = updater.pubc.SubmitToCT(ctx, cert.DER)
+		// Only send the certificate to the missing logs using
+		// the `SubmitToSingleCT` endpoint that was added for this purpose
+		for _, log := range missingLogs {
+			_ = updater.pubc.SubmitToSingleCT(ctx, log.uri, log.key, cert.DER)
 		}
 	}
 	return nil

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -471,8 +471,9 @@ func TestMissingReceiptsTick(t *testing.T) {
 	err = updater.missingReceiptsTick(ctx, 5)
 	test.AssertNotError(t, err, "Failed to run missingReceiptsTick")
 
-	// We have three logs configured from setup, and with the
-	// ResubmitMissingSCTsOnly feature flag disabled we expect that we submitted
+	// TODO: This test shouldn't be here anymore, as ResubmitMissingSCTsOnly is gone. Not sure how to proceed.
+	// We have three logs configured from setup, but with the
+	// ResubmitMissingSCTsOnly feature flag abled we expect that we submitted
 	// to all three logs.
 	logIDs, err := updater.getSubmittedReceipts("00")
 	test.AssertNotError(t, err, "Couldn't get submitted receipts for serial 00")
@@ -510,10 +511,6 @@ func TestMissingOnlyReceiptsTick(t *testing.T) {
 	serials, err := updater.getSerialsIssuedSince(fc.Now().Add(-2*time.Hour), 1)
 	test.AssertNotError(t, err, "Failed to retrieve serials")
 	test.AssertEquals(t, len(serials), 1)
-
-	// Enable the ResubmitMissingSCTsOnly feature flag for this test run
-	_ = features.Set(map[string]bool{"ResubmitMissingSCTsOnly": true})
-	defer features.Reset()
 
 	// Use a mock publisher so we can EXPECT specific calls
 	ctrl := gomock.NewController(t)

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,7 +4,7 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedRetiredFlagxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
+const _FeatureFlag_name = "unusedRetiredFlagxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyzzzzzzzzzzzzzzzzzzzOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
 
 var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 95, 115, 132, 149, 171, 191, 200, 213, 232}
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,7 +4,7 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedRetiredFlagAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
+const _FeatureFlag_name = "unusedRetiredFlagxxxxxxxxxxxxxxxxxxxxxxxxAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
 
 var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 95, 115, 132, 149, 171, 191, 200, 213, 232}
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,7 +4,7 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedRetiredFlagxxxxxxxxxxxxxxxxxxxxxxxxAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
+const _FeatureFlag_name = "unusedRetiredFlagxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
 
 var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 95, 115, 132, 149, 171, 191, 200, 213, 232}
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,7 +4,7 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedIDNASupportAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
+const _FeatureFlag_name = "unusedRetiredFlagAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRL"
 
 var _FeatureFlag_index = [...]uint8{0, 6, 17, 41, 57, 80, 95, 115, 132, 149, 171, 191, 200, 213, 232}
 

--- a/features/features.go
+++ b/features/features.go
@@ -12,7 +12,6 @@ type FeatureFlag int
 
 const (
 	unused FeatureFlag = iota // unused is used for testing
-	IDNASupport
 	AllowAccountDeactivation
 	AllowKeyRollover
 	ResubmitMissingSCTsOnly
@@ -31,8 +30,7 @@ const (
 
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
-	unused:                   false,
-	IDNASupport:              false,
+	unused: false,
 	AllowAccountDeactivation: false,
 	AllowKeyRollover:         false,
 	ResubmitMissingSCTsOnly:  false,

--- a/features/features.go
+++ b/features/features.go
@@ -12,7 +12,6 @@ type FeatureFlag int
 
 const (
 	unused FeatureFlag = iota // unused is used for testing
-	AllowAccountDeactivation
 	AllowKeyRollover
 	ResubmitMissingSCTsOnly
 	UseAIAIssuerURL
@@ -30,19 +29,18 @@ const (
 
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
-	unused: false,
-	AllowAccountDeactivation: false,
-	AllowKeyRollover:         false,
-	ResubmitMissingSCTsOnly:  false,
-	UseAIAIssuerURL:          false,
-	AllowTLS02Challenges:     false,
-	GenerateOCSPEarly:        false,
-	ReusePendingAuthz:        false,
-	CountCertificatesExact:   false,
-	RandomDirectoryEntry:     false,
-	IPv6First:                false,
-	DirectoryMeta:            false,
-	AllowRenewalFirstRL:      false,
+	unused:                  false,
+	AllowKeyRollover:        false,
+	ResubmitMissingSCTsOnly: false,
+	UseAIAIssuerURL:         false,
+	AllowTLS02Challenges:    false,
+	GenerateOCSPEarly:       false,
+	ReusePendingAuthz:       false,
+	CountCertificatesExact:  false,
+	RandomDirectoryEntry:    false,
+	IPv6First:               false,
+	DirectoryMeta:           false,
+	AllowRenewalFirstRL:     false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/features/features.go
+++ b/features/features.go
@@ -12,7 +12,6 @@ type FeatureFlag int
 
 const (
 	unused FeatureFlag = iota // unused is used for testing
-	AllowKeyRollover
 	ResubmitMissingSCTsOnly
 	UseAIAIssuerURL
 	AllowTLS02Challenges
@@ -30,7 +29,6 @@ const (
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
 	unused:                  false,
-	AllowKeyRollover:        false,
 	ResubmitMissingSCTsOnly: false,
 	UseAIAIssuerURL:         false,
 	AllowTLS02Challenges:    false,

--- a/features/features.go
+++ b/features/features.go
@@ -12,7 +12,6 @@ type FeatureFlag int
 
 const (
 	unused FeatureFlag = iota // unused is used for testing
-	ResubmitMissingSCTsOnly
 	UseAIAIssuerURL
 	AllowTLS02Challenges
 	GenerateOCSPEarly
@@ -28,17 +27,16 @@ const (
 
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
-	unused:                  false,
-	ResubmitMissingSCTsOnly: false,
-	UseAIAIssuerURL:         false,
-	AllowTLS02Challenges:    false,
-	GenerateOCSPEarly:       false,
-	ReusePendingAuthz:       false,
-	CountCertificatesExact:  false,
-	RandomDirectoryEntry:    false,
-	IPv6First:               false,
-	DirectoryMeta:           false,
-	AllowRenewalFirstRL:     false,
+	unused:                 false,
+	UseAIAIssuerURL:        false,
+	AllowTLS02Challenges:   false,
+	GenerateOCSPEarly:      false,
+	ReusePendingAuthz:      false,
+	CountCertificatesExact: false,
+	RandomDirectoryEntry:   false,
+	IPv6First:              false,
+	DirectoryMeta:          false,
+	AllowRenewalFirstRL:    false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -139,9 +139,7 @@ var (
 	errTooFewLabels        = berrors.MalformedError("DNS name does not have enough labels")
 	errLabelTooShort       = berrors.MalformedError("DNS label is too short")
 	errLabelTooLong        = berrors.MalformedError("DNS label is too long")
-	// TODO(@cpu): Delete `errIDNNotSupported` when IDNASupport feature flag is removed.
-	errIDNNotSupported = berrors.MalformedError("Internationalized domain names (starting with xn--) not yet supported")
-	errMalformedIDN    = berrors.MalformedError("DNS label contains malformed punycode")
+	errMalformedIDN        = berrors.MalformedError("DNS label contains malformed punycode")
 )
 
 // WillingToIssue determines whether the CA is willing to issue for the provided
@@ -216,17 +214,13 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 		}
 
 		if punycodeRegexp.MatchString(label) {
-			if features.Enabled(features.IDNASupport) {
-				// We don't care about script usage, if a name is resolvable it was
-				// registered with a higher power and they should be enforcing their
-				// own policy. As long as it was properly encoded that is enough
-				// for us.
-				_, err := idna.ToUnicode(label)
-				if err != nil {
-					return errMalformedIDN
-				}
-			} else {
-				return errIDNNotSupported
+			// We don't care about script usage, if a name is resolvable it was
+			// registered with a higher power and they should be enforcing their
+			// own policy. As long as it was properly encoded that is enough
+			// for us.
+			_, err := idna.ToUnicode(label)
+			if err != nil {
+				return errMalformedIDN
 			}
 		}
 	}

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -159,9 +159,6 @@ func TestWillingToIssue(t *testing.T) {
 	}
 
 	// Test IDNs
-	err = pa.WillingToIssue(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "www.xn--mnich-kva.com"})
-	test.AssertError(t, err, "WillingToIssue didn't fail on a IDN with features.IDNASupport disabled")
-	_ = features.Set(map[string]bool{"IDNASupport": true})
 	// Invalid encoding
 	err = pa.WillingToIssue(core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "www.xn--m.com"})
 	test.AssertError(t, err, "WillingToIssue didn't fail on a malformed IDN")

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1079,7 +1079,7 @@ func mergeUpdate(r *core.Registration, input core.Registration) bool {
 		changed = true
 	}
 
-	if features.Enabled(features.AllowKeyRollover) && input.Key != nil {
+	if input.Key != nil {
 		sameKey, _ := core.PublicKeysEqual(r.Key.Key, input.Key.Key)
 		if !sameKey {
 			r.Key = input.Key

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1662,7 +1662,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 }
 
 func TestDeactivateRegistration(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 	_, _, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1656,7 +1656,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 }
 
 func TestDeactivateRegistration(t *testing.T) {
-	defer features.Reset()
 	_, _, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1398,12 +1398,6 @@ func TestRegistrationKeyUpdate(t *testing.T) {
 
 	rA, rB := core.Registration{Key: &jose.JSONWebKey{Key: oldKey}}, core.Registration{}
 	changed := mergeUpdate(&rA, rB)
-	if changed {
-		t.Fatal("mergeUpdate changed the key with features.AllowKeyRollover disabled and empty update")
-	}
-
-	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
-	defer features.Reset()
 
 	changed = mergeUpdate(&rA, rB)
 	if changed {

--- a/sa/database.go
+++ b/sa/database.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/go-gorp/gorp.v2"
 
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 )
@@ -179,11 +178,8 @@ func ReportDbConnCount(dbMap *gorp.DbMap, statter metrics.Scope) {
 // https://godoc.org/github.com/coopernurse/gorp#DbMap.Insert
 func initTables(dbMap *gorp.DbMap) {
 	var regTable *gorp.TableMap
-	if features.Enabled(features.AllowAccountDeactivation) {
-		regTable = dbMap.AddTableWithName(regModelv2{}, "registrations").SetKeys(true, "ID")
-	} else {
-		regTable = dbMap.AddTableWithName(regModelv1{}, "registrations").SetKeys(true, "ID")
-	}
+	regTable = dbMap.AddTableWithName(regModelv2{}, "registrations").SetKeys(true, "ID")
+
 	regTable.SetVersionCol("LockCol")
 	regTable.ColMap("Key").SetNotNull(true)
 	regTable.ColMap("KeySHA256").SetNotNull(true).SetUnique(true)

--- a/sa/model.go
+++ b/sa/model.go
@@ -10,7 +10,6 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/revocation"
 )
@@ -241,23 +240,17 @@ func registrationToModel(r *core.Registration) (interface{}, error) {
 		InitialIP: []byte(r.InitialIP.To16()),
 		CreatedAt: r.CreatedAt,
 	}
-	if features.Enabled(features.AllowAccountDeactivation) {
-		return &regModelv2{
-			regModelv1: rm,
-			Status:     string(r.Status),
-		}, nil
-	}
-	return &rm, nil
+	return &regModelv2{
+		regModelv1: rm,
+		Status:     string(r.Status),
+	}, nil
 }
 
 func modelToRegistration(ri interface{}) (core.Registration, error) {
 	var rm *regModelv1
-	if features.Enabled(features.AllowAccountDeactivation) {
-		r2 := ri.(*regModelv2)
-		rm = &r2.regModelv1
-	} else {
-		rm = ri.(*regModelv1)
-	}
+	r2 := ri.(*regModelv2)
+	rm = &r2.regModelv1
+
 	k := &jose.JSONWebKey{}
 	err := json.Unmarshal(rm.Key, k)
 	if err != nil {
@@ -281,10 +274,9 @@ func modelToRegistration(ri interface{}) (core.Registration, error) {
 		InitialIP: net.IP(rm.InitialIP),
 		CreatedAt: rm.CreatedAt,
 	}
-	if features.Enabled(features.AllowAccountDeactivation) {
-		r2 := ri.(*regModelv2)
-		r.Status = core.AcmeStatus(r2.Status)
-	}
+	r2 = ri.(*regModelv2)
+	r.Status = core.AcmeStatus(r2.Status)
+
 	return r, nil
 }
 

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -2,12 +2,9 @@ package sa
 
 import (
 	"testing"
-
-	"github.com/letsencrypt/boulder/features"
 )
 
 func TestModelToRegistrationNilContact(t *testing.T) {
-	defer features.Reset()
 	reg, err := modelToRegistration(&regModelv2{
 		regModelv1: regModelv1{
 			Key:     []byte(`{"kty":"RSA","n":"AQAB","e":"AQAB"}`),
@@ -25,7 +22,6 @@ func TestModelToRegistrationNilContact(t *testing.T) {
 }
 
 func TestModelToRegistrationNonNilContact(t *testing.T) {
-	defer features.Reset()
 	reg, err := modelToRegistration(&regModelv2{
 		regModelv1: regModelv1{
 			Key:     []byte(`{"kty":"RSA","n":"AQAB","e":"AQAB"}`),

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestModelToRegistrationNilContact(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 	reg, err := modelToRegistration(&regModelv2{
 		regModelv1: regModelv1{
@@ -26,7 +25,6 @@ func TestModelToRegistrationNilContact(t *testing.T) {
 }
 
 func TestModelToRegistrationNonNilContact(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 	reg, err := modelToRegistration(&regModelv2{
 		regModelv1: regModelv1{

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -124,11 +124,9 @@ func (ssa *SQLStorageAuthority) GetRegistration(ctx context.Context, id int64) (
 	const query = "WHERE id = ?"
 	var model interface{}
 	var err error
-	if features.Enabled(features.AllowAccountDeactivation) {
-		model, err = selectRegistrationv2(ssa.dbMap, query, id)
-	} else {
-		model, err = selectRegistration(ssa.dbMap, query, id)
-	}
+
+	model, err = selectRegistrationv2(ssa.dbMap, query, id)
+
 	if err == sql.ErrNoRows {
 		return core.Registration{}, berrors.NotFoundError("registration with ID '%d' not found", id)
 	}
@@ -150,11 +148,9 @@ func (ssa *SQLStorageAuthority) GetRegistrationByKey(ctx context.Context, key *j
 	if err != nil {
 		return core.Registration{}, err
 	}
-	if features.Enabled(features.AllowAccountDeactivation) {
-		model, err = selectRegistrationv2(ssa.dbMap, query, sha)
-	} else {
-		model, err = selectRegistration(ssa.dbMap, query, sha)
-	}
+
+	model, err = selectRegistrationv2(ssa.dbMap, query, sha)
+
 	if err == sql.ErrNoRows {
 		return core.Registration{}, berrors.NotFoundError("no registrations with public key sha256 %q", sha)
 	}
@@ -628,11 +624,9 @@ func (ssa *SQLStorageAuthority) UpdateRegistration(ctx context.Context, reg core
 	const query = "WHERE id = ?"
 	var model interface{}
 	var err error
-	if features.Enabled(features.AllowAccountDeactivation) {
-		model, err = selectRegistrationv2(ssa.dbMap, query, reg.ID)
-	} else {
-		model, err = selectRegistration(ssa.dbMap, query, reg.ID)
-	}
+
+	model, err = selectRegistrationv2(ssa.dbMap, query, reg.ID)
+
 	if err == sql.ErrNoRows {
 		return berrors.NotFoundError("registration with ID '%d' not found", reg.ID)
 	}
@@ -646,17 +640,10 @@ func (ssa *SQLStorageAuthority) UpdateRegistration(ctx context.Context, reg core
 	// version we need to cast both the updated and existing model to their proper types
 	// so that we can copy over the LockCol from one to the other. Once we have copied
 	// that field we reassign to the interface so gorp can properly update it.
-	if features.Enabled(features.AllowAccountDeactivation) {
-		erm := model.(*regModelv2)
-		urm := updatedRegModel.(*regModelv2)
-		urm.LockCol = erm.LockCol
-		updatedRegModel = urm
-	} else {
-		erm := model.(*regModelv1)
-		urm := updatedRegModel.(*regModelv1)
-		urm.LockCol = erm.LockCol
-		updatedRegModel = urm
-	}
+	erm := model.(*regModelv2)
+	urm := updatedRegModel.(*regModelv2)
+	urm.LockCol = erm.LockCol
+	updatedRegModel = urm
 
 	n, err := ssa.dbMap.Update(updatedRegModel)
 	if err != nil {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1059,7 +1059,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 }
 
 func TestDeactivateAccount(t *testing.T) {
-	defer features.Reset()
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1059,7 +1059,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 }
 
 func TestDeactivateAccount(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -130,7 +130,6 @@
     },
     "maxConcurrentRPCServerRequests": 100000,
     "features": {
-        "IDNASupport": true,
         "AllowTLS02Challenges": true,
         "GenerateOCSPEarly": true
     }

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -3,7 +3,6 @@
     "dbConnectFile": "test/secrets/cert_checker_dburl",
     "maxDBConns": 10,
     "features": {
-      "IDNASupport": true,
       "AllowTLS02Challenges": true
     },
     "hostnamePolicyFile": "test/hostname-policy.json"

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -34,9 +34,7 @@
       "serverAddresses": ["ca.boulder:19096"],
       "timeout": "15s"
     },
-    "features": {
-      "ResubmitMissingSCTsOnly": true
-    }
+    "features": {}
   },
 
   "syslog": {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -41,7 +41,6 @@
       ]
     },
     "features": {
-      "AllowKeyRollover": true,
       "AllowTLS02Challenges": true,
       "CountCertificatesExact": true,
       "ReusePendingAuthz": true

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -41,7 +41,6 @@
       ]
     },
     "features": {
-      "IDNASupport": true,
       "AllowKeyRollover": true,
       "AllowTLS02Challenges": true,
       "CountCertificatesExact": true,

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -24,7 +24,6 @@
       ]
     },
     "features": {
-      "AllowAccountDeactivation": true,
       "AllowRenewalFirstRL": true
     }
   },

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -30,7 +30,6 @@
       "timeout": "15s"
     },
     "features": {
-      "AllowKeyRollover": true,
       "UseAIAIssuerURL": true,
       "RandomDirectoryEntry": true,
       "DirectoryMeta": true

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -30,7 +30,6 @@
       "timeout": "15s"
     },
     "features": {
-      "AllowAccountDeactivation": true,
       "AllowKeyRollover": true,
       "UseAIAIssuerURL": true,
       "RandomDirectoryEntry": true,

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -30,7 +30,6 @@
       "timeout": "15s"
     },
     "features": {
-      "AllowKeyRollover": true,
       "UseAIAIssuerURL": true,
       "RandomDirectoryEntry": true,
       "DirectoryMeta": true

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -30,7 +30,6 @@
       "timeout": "15s"
     },
     "features": {
-      "AllowAccountDeactivation": true,
       "AllowKeyRollover": true,
       "UseAIAIssuerURL": true,
       "RandomDirectoryEntry": true,

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -183,9 +183,6 @@ def test_ct_submission():
     if (int(submissions_a) < expected_a_submissions or
         int(submissions_a) > 2 * expected_a_submissions):
         raise Exception("Expected %d CT submissions to boulder:4500, found %s" % (expected_a_submissions, submissions_a))
-    # Only test when ResubmitMissingSCTsOnly is enabled
-    if not default_config_dir.startswith("test/config-next"):
-        return
     for _ in range(0, 10):
         submissions_a = urllib2.urlopen(url_a).read()
         submissions_b = urllib2.urlopen(url_b).read()

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -313,9 +313,7 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, termsPath, wfe.Terms, "GET")
 	wfe.HandleFunc(m, issuerPath, wfe.Issuer, "GET")
 	wfe.HandleFunc(m, buildIDPath, wfe.BuildID, "GET")
-	if features.Enabled(features.AllowKeyRollover) {
-		wfe.HandleFunc(m, rolloverPath, wfe.KeyRollover, "POST")
-	}
+	wfe.HandleFunc(m, rolloverPath, wfe.KeyRollover, "POST")
 	// We don't use our special HandleFunc for "/" because it matches everything,
 	// meaning we can wind up returning 405 when we mean to return 404. See
 	// https://github.com/letsencrypt/boulder/issues/717
@@ -385,7 +383,7 @@ func (wfe *WebFrontEndImpl) Directory(ctx context.Context, logEvent *requestEven
 	// encounter a directory containing elements they don't expect so we gate
 	// adding new directory fields for clients matching this UA.
 	clientDirChangeIntolerant := strings.HasPrefix(request.UserAgent(), "LetsEncryptPythonClient")
-	if features.Enabled(features.AllowKeyRollover) && !clientDirChangeIntolerant {
+	if !clientDirChangeIntolerant {
 		directoryEndpoints["key-change"] = rolloverPath
 	}
 	if features.Enabled(features.RandomDirectoryEntry) && !clientDirChangeIntolerant {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -533,7 +533,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *requestEve
 	}
 
 	// Only check for validity if we are actually checking the registration
-	if regCheck && features.Enabled(features.AllowAccountDeactivation) && reg.Status != core.StatusValid {
+	if regCheck && reg.Status != core.StatusValid {
 		return nil, nil, reg, probs.Unauthorized(fmt.Sprintf("Registration is not valid, has status '%s'", reg.Status))
 	}
 
@@ -1219,7 +1219,7 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 	// If a user tries to send both a deactivation request and an update to their
 	// contacts or subscriber agreement URL the deactivation will take place and
 	// return before an update would be performed.
-	if features.Enabled(features.AllowAccountDeactivation) && (update.Status != "" && update.Status != currReg.Status) {
+	if update.Status != "" && update.Status != currReg.Status {
 		if update.Status != core.StatusDeactivated {
 			wfe.sendError(response, logEvent, probs.Malformed("Invalid value provided for status field"), nil)
 			return

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2073,7 +2073,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 func TestDeactivateRegistration(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	defer features.Reset()
 
 	responseWriter.Body.Reset()
 	wfe.Registration(ctx, newRequestEvent(), responseWriter,
@@ -2149,7 +2148,6 @@ func TestDeactivateRegistration(t *testing.T) {
 func TestKeyRollover(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	defer features.Reset()
 
 	key := loadPrivateKey(t, []byte(test3KeyPrivatePEM))
 	rsaKey, ok := key.(*rsa.PrivateKey)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2079,7 +2079,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 func TestDeactivateRegistration(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 
 	responseWriter.Body.Reset()
@@ -2156,7 +2155,6 @@ func TestDeactivateRegistration(t *testing.T) {
 func TestKeyRollover(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 
 	key := loadPrivateKey(t, []byte(test3KeyPrivatePEM))

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -671,8 +671,6 @@ func TestDirectory(t *testing.T) {
 	// This tests to ensure the `Host` in the following `http.Request` is not
 	// used.by setting `BaseURL` using `localhost`, sending `127.0.0.1` in the Host,
 	// and expecting `localhost` in the JSON result.
-	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
-	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	wfe.BaseURL = "http://localhost:4300"
 	mux := wfe.Handler()
@@ -780,8 +778,6 @@ func TestRandomDirectoryKey(t *testing.T) {
 }
 
 func TestRelativeDirectory(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
-	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 
@@ -1652,8 +1648,6 @@ func contains(s []string, e string) bool {
 }
 
 func TestRegistration(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
-	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 	responseWriter := httptest.NewRecorder()

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/probs"
 
 	"gopkg.in/square/go-jose.v2"
@@ -192,7 +191,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *requestEve
 	}
 
 	// Only check for validity if we are actually checking the registration
-	if regCheck && features.Enabled(features.AllowAccountDeactivation) && reg.Status != core.StatusValid {
+	if regCheck && reg.Status != core.StatusValid {
 		return nil, nil, reg, probs.Unauthorized(fmt.Sprintf("Registration is not valid, has status '%s'", reg.Status))
 	}
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1034,7 +1034,7 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *requestE
 	// If a user tries to send both a deactivation request and an update to their
 	// contacts or subscriber agreement URL the deactivation will take place and
 	// return before an update would be performed.
-	if features.Enabled(features.AllowAccountDeactivation) && (update.Status != "" && update.Status != currReg.Status) {
+	if update.Status != "" && update.Status != currReg.Status {
 		if update.Status != core.StatusDeactivated {
 			wfe.sendError(response, logEvent, probs.Malformed("Invalid value provided for status field"), nil)
 			return

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -303,9 +303,7 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, termsPath, wfe.Terms, "GET")
 	wfe.HandleFunc(m, issuerPath, wfe.Issuer, "GET")
 	wfe.HandleFunc(m, buildIDPath, wfe.BuildID, "GET")
-	if features.Enabled(features.AllowKeyRollover) {
-		wfe.HandleFunc(m, rolloverPath, wfe.KeyRollover, "POST")
-	}
+	wfe.HandleFunc(m, rolloverPath, wfe.KeyRollover, "POST")
 	// We don't use our special HandleFunc for "/" because it matches everything,
 	// meaning we can wind up returning 405 when we mean to return 404. See
 	// https://github.com/letsencrypt/boulder/issues/717
@@ -375,7 +373,7 @@ func (wfe *WebFrontEndImpl) Directory(ctx context.Context, logEvent *requestEven
 	// encounter a directory containing elements they don't expect so we gate
 	// adding new directory fields for clients matching this UA.
 	clientDirChangeIntolerant := strings.HasPrefix(request.UserAgent(), "LetsEncryptPythonClient")
-	if features.Enabled(features.AllowKeyRollover) && !clientDirChangeIntolerant {
+	if !clientDirChangeIntolerant {
 		directoryEndpoints["key-change"] = rolloverPath
 	}
 	if features.Enabled(features.RandomDirectoryEntry) && !clientDirChangeIntolerant {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -649,8 +649,6 @@ func TestDirectory(t *testing.T) {
 	// This tests to ensure the `Host` in the following `http.Request` is not
 	// used.by setting `BaseURL` using `localhost`, sending `127.0.0.1` in the Host,
 	// and expecting `localhost` in the JSON result.
-	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
-	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	wfe.BaseURL = "http://localhost:4300"
 	mux := wfe.Handler()
@@ -758,8 +756,6 @@ func TestRandomDirectoryKey(t *testing.T) {
 }
 
 func TestRelativeDirectory(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
-	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 
@@ -1715,8 +1711,6 @@ func contains(s []string, e string) bool {
 }
 
 func TestRegistration(t *testing.T) {
-	_ = features.Set(map[string]bool{"AllowKeyRollover": true})
-	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 	responseWriter := httptest.NewRecorder()

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2163,7 +2163,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 func TestDeactivateRegistration(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 
 	responseWriter.Body.Reset()
@@ -2247,7 +2246,6 @@ func TestDeactivateRegistration(t *testing.T) {
 func TestKeyRollover(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	_ = features.Set(map[string]bool{"AllowAccountDeactivation": true})
 	defer features.Reset()
 
 	key := loadPrivateKey(t, []byte(test3KeyPrivatePEM))

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2157,7 +2157,6 @@ func TestDeactivateAuthorization(t *testing.T) {
 func TestDeactivateRegistration(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	defer features.Reset()
 
 	responseWriter.Body.Reset()
 	wfe.Registration(ctx, newRequestEvent(), responseWriter,
@@ -2240,7 +2239,6 @@ func TestDeactivateRegistration(t *testing.T) {
 func TestKeyRollover(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
-	defer features.Reset()
 
 	key := loadPrivateKey(t, []byte(test3KeyPrivatePEM))
 	rsaKey, ok := key.(*rsa.PrivateKey)


### PR DESCRIPTION
Addresses https://github.com/letsencrypt/boulder/issues/2692 https://github.com/letsencrypt/boulder/issues/2736 https://github.com/letsencrypt/boulder/issues/2735 though I haven't been able to figure out one set of tests that looks like we may be able to remove it.

You can see it here: https://github.com/rabdill/boulder/blob/22f079db42b220f5cc497533f2ba0d65d4102002/cmd/ocsp-updater/main_test.go#L474-L483