### PR TITLE
use go_import_path setting in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.8.3
 
+go_import_path: github.com/letsencrypt/boulder
+
 addons:
   hosts:
     - le.wtf

--- a/test/travis-before-install.sh
+++ b/test/travis-before-install.sh
@@ -1,13 +1,4 @@
 #!/bin/bash
-# Boulder consists of multiple Go packages, which
-# refer to each other by their absolute GitHub path,
-# That means, by default, if someone forks the repo,
-# Travis won't pass on their own repo. To fix that,
-# we move the source directory.
-if [ ! -d $GOPATH/src/github.com/letsencrypt/boulder ] ; then
-  mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt
-  mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/letsencrypt/boulder
-fi
 
 # Travis does shallow clones, so there is no master branch present.
 # But test-no-outdated-migrations.sh needs to check diffs against master.


### PR DESCRIPTION
Travis has this setting available and so less code is needed in boulder's test
scripts.