### PR TITLE
Return error from `sendHTTPRequest` immediately.

### DIFF
--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -122,6 +122,9 @@ func Req(fileName string) (*ocsp.Response, error) {
 	http.DefaultClient.Timeout = 5 * time.Second
 
 	httpResp, err := sendHTTPRequest(req, ocspURL)
+	if err != nil {
+		return nil, err
+	}
 	fmt.Printf("HTTP %d\n", httpResp.StatusCode)
 	for k, v := range httpResp.Header {
 		for _, vv := range v {


### PR DESCRIPTION
Prior to this commit the `httpResp` result of `sendHTTPRequest` was
examined even in the case where `sendHTTPRequest` returns a non-nil
error. This can cause a nil panic since the `httpResp` may be `nil` when
the error is not. This commit returns an error from `Req()` immediately
when `sendHTTPRequest` returns one.