### PR TITLE
do not count renewals as issuances

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1208,6 +1208,8 @@ func (ssa *SQLStorageAuthority) getNewIssuancesByFQDNSet(fqdnSets []setHash, ear
 			continue
 		}
 
+		processedSetHashes[key] = true
+
 		// If the issued date is before our earliest cutoff then skip it
 		if result.Issued.Before(earliest) {
 			continue
@@ -1215,7 +1217,6 @@ func (ssa *SQLStorageAuthority) getNewIssuancesByFQDNSet(fqdnSets []setHash, ear
 
 		// Otherwise note the issuance and mark the set hash as processed
 		issuanceCount++
-		processedSetHashes[key] = true
 	}
 
 	// Return the count of how many non-renewal issuances there were


### PR DESCRIPTION
Currently a renewal is only counted as renewal if the previous issuance happened after "earliest". fixes #2922