### PR TITLE
CA: Sync fake clock's time with system time in issuance tests.

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -374,6 +374,13 @@ func TestIssueCertificate(t *testing.T) {
 
 func issueCertificateSubTestDefaultSetup(t *testing.T) (*CertificateAuthorityImpl, *mockSA) {
 	testCtx := setup(t)
+
+	// Although the CA generally uses its own clock (ca.clk) to generate
+	// timestamps, the notBefore date is set based on the current system time.
+	// That's wrong, but work around it for now by syncing the fake clock with
+	// the system clock.
+	testCtx.fc.Set(clock.New().Now())
+
 	sa := &mockSA{}
 	ca, err := NewCertificateAuthorityImpl(
 		testCtx.caConfig,


### PR DESCRIPTION
The notBefore date in certificates is set based on the current system time,
not based on ca.clk. Work around that problem in the issuance tests by
syncing the test ca.clk with the system time. This doesn't affect any
current tests but is required for upcoming tests to work correctly.