### PR TITLE
Update publicsuffix-go to 6787c

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -244,8 +244,8 @@
 		},
 		{
 			"ImportPath": "github.com/weppos/publicsuffix-go/publicsuffix",
-			"Comment": "v0.3.2-19-ge91dbc7",
-			"Rev": "e91dbc7c619732e815b11ec8e93a4997f8834cc2"
+			"Comment": "v0.3.2-21-g6787cd3",
+			"Rev": "6787cd3b348b18fab6371264ae5392cd8eca1723"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ocsp",

--- a/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
+++ b/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
@@ -3,10 +3,10 @@
 
 package publicsuffix
 
-const defaultListVersion = "PSL version 266972c (Tue Jul 11 17:23:19 2017)"
+const defaultListVersion = "PSL version 7daa3a2 (Wed Aug  9 09:51:45 2017)"
 
 func init() {
-	r := [8307]Rule{
+	r := [8312]Rule{
 		{1, "ac", 1, false},
 		{1, "com.ac", 2, false},
 		{1, "edu.ac", 2, false},
@@ -7853,6 +7853,7 @@ func init() {
 		{1, "freebox-os.fr", 2, true},
 		{1, "freeboxos.fr", 2, true},
 		{1, "myfusion.cloud", 2, true},
+		{2, "futurecms.at", 3, true},
 		{1, "futurehosting.at", 2, true},
 		{1, "futuremailing.at", 2, true},
 		{2, "ex.ortsinfo.at", 4, true},
@@ -8019,6 +8020,9 @@ func init() {
 		{1, "azure-mobile.net", 2, true},
 		{1, "cloudapp.net", 2, true},
 		{1, "bmoattachments.org", 2, true},
+		{1, "net.ru", 2, true},
+		{1, "org.ru", 2, true},
+		{1, "pp.ru", 2, true},
 		{1, "bitballoon.com", 2, true},
 		{1, "netlify.com", 2, true},
 		{1, "4u.com", 2, true},
@@ -8177,6 +8181,7 @@ func init() {
 		{1, "priv.at", 2, true},
 		{1, "protonet.io", 2, true},
 		{1, "chirurgiens-dentistes-en-france.fr", 2, true},
+		{1, "byen.site", 2, true},
 		{1, "qa2.com", 2, true},
 		{1, "dev-myqnapcloud.com", 2, true},
 		{1, "alpha-myqnapcloud.com", 2, true},


### PR DESCRIPTION
This commit updates the publicsuffix-go dependency to
6787cd3b348b18fab6371264ae5392cd8eca1723 the tip of master at the time
of writing.

The unit tests were verified to pass:
```
?       github.com/weppos/publicsuffix-go/cmd/load      [no test files]
ok      github.com/weppos/publicsuffix-go/net/publicsuffix      0.006s
ok      github.com/weppos/publicsuffix-go/publicsuffix  0.024s
```