### PR TITLE
WFE2 unit test cleanup (part 1)

### DIFF
--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -81,6 +81,18 @@ func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
 	}
 }
 
+// AssertUnmarshaledEquals unmarshals two JSON strings (one and two) to
+// a map[string]interface{} and then uses reflect.DeepEqual to check they are
+// the same
+func AssertUnmarshaledEquals(t *testing.T, one, two string) {
+	var oneMap, twoMap map[string]interface{}
+	err := json.Unmarshal([]byte(one), &oneMap)
+	AssertNotError(t, err, "Could not unmarshal 1st argument")
+	err = json.Unmarshal([]byte(two), &twoMap)
+	AssertNotError(t, err, "Could not unmarshal 2nd argument")
+	AssertDeepEquals(t, oneMap, twoMap)
+}
+
 // AssertNotEquals uses the equality operator to measure that one and two
 // are different
 func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -339,7 +339,7 @@ func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *requestEvent, r
 	if request.Method != "GET" {
 		logEvent.AddError("Bad method")
 		response.Header().Set("Allow", "GET")
-		response.WriteHeader(http.StatusMethodNotAllowed)
+		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
 		return
 	}
 


### PR DESCRIPTION
This is the first half of a clean-up of the WFE2 unit tests that were copied over from the original WFE implementation.

I will file a follow-up pt2 PR for `TestChallenge`, `TestAuthorization`, and `TestGetCert` which I think are the remaining tests that could use a :bathtub:.

The one non-test commit changed the WFE2 index to return a problem when the method is unsupported similar to the other API endpoints. This _might_ be inappropriate since normally the index returns XHTML and not JSON. It made testing easier but I'm open to switching back to returning a `""` body and special casing the index test.

_Note to reviewers: The main diff is hidden by GH by default and needs to be expanded_.

Updates https://github.com/letsencrypt/boulder/issues/2928