### PR TITLE
Enforce NFKC instead of NFC (#2968)

### DIFF
--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -91,7 +91,7 @@ func TestWillingToIssue(t *testing.T) {
 		{`example.internal`, errNonPublic},
 		// All-numeric final label not okay.
 		{`www.zombo.163`, errNonPublic},
-		{`xn--109-3veba6djs1bfxlfmx6c9g.xn--f1awi.xn--p1ai`, errMalformedIDN}, // Not in Unicode NFC
+		{`xn--109-3veba6djs1bfxlfmx6c9g.xn--f1awi.xn--p1ai`, errMalformedIDN}, // Not in Unicode NFKC
 	}
 
 	shouldBeTLDError := []string{


### PR DESCRIPTION
RFC 5280 incorporates RFC 3490 by reference. RFC 3490 requires using the KC normalization form, which therefore is required by the BRs. There was some confusion in #2964 as RFC 3490 was obsoleted by RFC 5890 but since the BRs simply reference RFC 5280 this doesn't matter. This PR fixes the confusion.