### PR TITLE
Hotfix: Allow authz creation in absence of GSB response. (#2972)

### DIFF
--- a/va/gsb_test.go
+++ b/va/gsb_test.go
@@ -58,13 +58,15 @@ func TestIsSafeDomain(t *testing.T) {
 		t.Errorf("bad.com: want false, got %t", resp.GetIsSafe())
 	}
 
+	// If there is an error looking up a domain (e.g. because of a GSB outage),
+	// then we expect the VA to allow the authz to be created without error.
 	domain = "errorful.com"
 	resp, err = va.IsSafeDomain(ctx, &vaPB.IsSafeDomainRequest{Domain: &domain})
-	if err == nil {
-		t.Errorf("errorful.com: want error, got none")
+	if err != nil {
+		t.Errorf("errorful.com: want no error, got %v", resp)
 	}
-	if resp != nil {
-		t.Errorf("errorful.com: want resp == nil, got %v", resp)
+	if !resp.GetIsSafe() {
+		t.Errorf("errorful.com: want true, got %t", resp.GetIsSafe())
 	}
 }
 


### PR DESCRIPTION
This commit updates the VA's `IsSafeDomain` RPC to treat errors from the
Google Safe Browsing client as a positive response. Subsequently the VA
will only block authz creation in the case that the GSB API returns
a true negative (e.g. confirms an unsafe domain). If the database is in
an inconsistent state due to an API outage we will allow the authz to be
created.