### PR TITLE
Disallow issuance of names containing R-LDH labels

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -104,6 +104,7 @@ const (
 
 var dnsLabelRegexp = regexp.MustCompile("^[a-z0-9][a-z0-9-]{0,62}$")
 var punycodeRegexp = regexp.MustCompile("^xn--")
+var idnReservedRegexp = regexp.MustCompile("^[a-z0-9]{2}--")
 
 func isDNSCharacter(ch byte) bool {
 	return ('a' <= ch && ch <= 'z') ||
@@ -141,6 +142,7 @@ var (
 	errLabelTooShort       = berrors.MalformedError("DNS label is too short")
 	errLabelTooLong        = berrors.MalformedError("DNS label is too long")
 	errMalformedIDN        = berrors.MalformedError("DNS label contains malformed punycode")
+	errInvalidRLDH         = berrors.RejectedIdentifierError("DNS name contains is a R-LDH label")
 )
 
 // WillingToIssue determines whether the CA is willing to issue for the provided
@@ -226,6 +228,8 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 			if !norm.NFKC.IsNormalString(ulabel) {
 				return errMalformedIDN
 			}
+		} else if idnReservedRegexp.MatchString(label) {
+			return errInvalidRLDH
 		}
 	}
 

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -142,7 +142,7 @@ var (
 	errLabelTooShort       = berrors.MalformedError("DNS label is too short")
 	errLabelTooLong        = berrors.MalformedError("DNS label is too long")
 	errMalformedIDN        = berrors.MalformedError("DNS label contains malformed punycode")
-	errInvalidRLDH         = berrors.RejectedIdentifierError("DNS name contains is a R-LDH label")
+	errInvalidRLDH         = berrors.RejectedIdentifierError("DNS name contains a R-LDH label")
 )
 
 // WillingToIssue determines whether the CA is willing to issue for the provided

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -92,6 +92,7 @@ func TestWillingToIssue(t *testing.T) {
 		// All-numeric final label not okay.
 		{`www.zombo.163`, errNonPublic},
 		{`xn--109-3veba6djs1bfxlfmx6c9g.xn--f1awi.xn--p1ai`, errMalformedIDN}, // Not in Unicode NFKC
+		{`bq--abwhky3f6fxq.jakacomo.com`, errInvalidRLDH},
 	}
 
 	shouldBeTLDError := []string{


### PR DESCRIPTION
This is required by RFC 5890, which is not explicitly required by the BRs _at the moment_ but prepares us for a world where RFC 5280 or the BRs are updated to refer to the most recent IDNA RFC (and is general best practice).

Fixes #2885.