### PR TITLE
Switch DNS metrics from statsd to prometheus

### DIFF
--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -10,6 +10,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_model/go"
 )
 
 func fatalf(t *testing.T, format string, args ...interface{}) {
@@ -151,4 +154,14 @@ func AssertBetween(t *testing.T, a, b, c int64) {
 	if a < b || a > c {
 		fatalf(t, "%d is not between %d and %d", a, b, c)
 	}
+}
+
+// CountCounter returns the count by label and value of a prometheus metric
+func CountCounter(labelName string, value string, counter *prometheus.CounterVec) int {
+	ch := make(chan prometheus.Metric, 10)
+	counter.With(prometheus.Labels{labelName: value}).Collect(ch)
+	m := <-ch
+	var iom io_prometheus_client.Metric
+	_ = m.Write(&iom)
+	return int(iom.Counter.GetValue())
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_model/go"
 	"golang.org/x/net/context"
 	"gopkg.in/square/go-jose.v2"
 
@@ -1012,7 +1010,7 @@ func TestIssueCertificate(t *testing.T) {
 		`{"type":"urn:acme:error:malformed","detail":"CSR generated using a pre-1.0.2 OpenSSL with a client that doesn't properly specify the CSR version. See https://community.letsencrypt.org/t/openssl-bug-information/19591","status":400}`)
 
 	// Test the CSR signature type counter works
-	test.AssertEquals(t, count("type", "SHA256-RSA", wfe.csrSignatureAlgs), 4)
+	test.AssertEquals(t, test.CountCounter("type", "SHA256-RSA", wfe.csrSignatureAlgs), 4)
 }
 
 func TestGetChallenge(t *testing.T) {
@@ -2246,13 +2244,4 @@ func TestKeyRollover(t *testing.T) {
 		wfe.KeyRollover(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("", outer))
 		assertJSONEquals(t, responseWriter.Body.String(), testCase.expectedResponse)
 	}
-}
-
-func count(key string, value string, counter *prometheus.CounterVec) int {
-	ch := make(chan prometheus.Metric, 10)
-	counter.With(prometheus.Labels{key: value}).Collect(ch)
-	m := <-ch
-	var iom io_prometheus_client.Metric
-	_ = m.Write(&iom)
-	return int(iom.Counter.GetValue())
 }


### PR DESCRIPTION
Makes the DNS stats code much nicer if I don't say so myself. Should make investigating DNS problems much easier now as well.

Fixes #2956.