### PR TITLE
Migrate WFE2 to use Prometheus stats.

### DIFF
--- a/wfe2/stats.go
+++ b/wfe2/stats.go
@@ -1,0 +1,38 @@
+package wfe2
+
+import (
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type wfe2Stats struct {
+	// httpErrorCount counts client errors at the HTTP level
+	// e.g. failure to provide a Content-Length header, no POST body, etc
+	httpErrorCount *prometheus.CounterVec
+	// joseErrorCount counts client errors at the JOSE level
+	// e.g. bad JWS, broken JWS signature, invalid JWK, etc
+	joseErrorCount *prometheus.CounterVec
+}
+
+func initStats(scope metrics.Scope) wfe2Stats {
+	httpErrorCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "httpErrors",
+			Help: "client request errors at the HTTP level",
+		},
+		[]string{"type"})
+	scope.MustRegister(httpErrorCount)
+
+	joseErrorCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "joseErrors",
+			Help: "client request errors at the JOSE level",
+		},
+		[]string{"type"})
+	scope.MustRegister(joseErrorCount)
+
+	return wfe2Stats{
+		httpErrorCount: httpErrorCount,
+		joseErrorCount: joseErrorCount,
+	}
+}


### PR DESCRIPTION
Per #3001 we should not be adding new StatsD code for metrics anymore.
This commit updates all of the WFE2 to use 1st class Prometheus stats.
Unit tests are updated accordingly.

I have broken the error stats into two counts:

1. httpErrorCount for all of the http layer client request errors (e.g.
   no POST body, no content-length)
2. joseErrorCount, for all of the JOSE layer client request errors (e.g.
   malformed JWS, broken signature, invalid JWK)

This commit also removes the stubbed out `TestValidKeyRollover` function
from `wfe2/verify_test.go`. This was committed accidentally and the same
functionality is covered by the `wfe2/wfe_test.go` `TestKeyRollover`
function.

Updates #3001 