### PR TITLE
Update `google/safebrowsing` lib to tip of master.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -148,11 +148,11 @@
 		},
 		{
 			"ImportPath": "github.com/google/safebrowsing",
-			"Rev": "a8c029efb52bae66853e05241150ab338e98fbc7"
+			"Rev": "f387afacc9e702b5ed3e90100d3375871e724c08"
 		},
 		{
 			"ImportPath": "github.com/google/safebrowsing/internal/safebrowsing_proto",
-			"Rev": "a8c029efb52bae66853e05241150ab338e98fbc7"
+			"Rev": "f387afacc9e702b5ed3e90100d3375871e724c08"
 		},
 		{
 			"ImportPath": "github.com/grpc-ecosystem/go-grpc-prometheus",


### PR DESCRIPTION
This commit updates the `github.com/google/safebrowsing` dependency to
commit f387af, the tip of master at the time of writing.

Unit tests were confirmed to pass per CONTRIBUTING.md:
```
$ go test ./...
ok    github.com/google/safebrowsing  2.500s
?     github.com/google/safebrowsing/cmd/sblookup [no test files]
?     github.com/google/safebrowsing/cmd/sbserver [no test files]
?     github.com/google/safebrowsing/cmd/sbserver/statik  [no test files]
?     github.com/google/safebrowsing/internal/safebrowsing_proto  [no test files]
```

This update includes a fix I submitted to prevent GSB lookups from failing during
the brief window between the database being marked as stale and the database
contents being refreshed.