### PR TITLE
Use "account" not "registration" throughout WFE2.

### DIFF
--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -375,7 +375,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 
 	header := jws.Signatures[0].Header
 	accountURL := header.KeyID
-	prefix := wfe.relativeEndpoint(request, regPath)
+	prefix := wfe.relativeEndpoint(request, acctPath)
 	accountIDStr := strings.TrimPrefix(accountURL, prefix)
 	// Convert the account ID string to an int64 for use with the SA's
 	// GetRegistration RPC

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -133,7 +133,7 @@ func signRequestKeyID(
 	jwk := &jose.JSONWebKey{
 		Key:       privateKey,
 		Algorithm: keyAlgForKey(t, privateKey),
-		KeyID:     fmt.Sprintf("http://localhost/acme/reg/%d", keyID),
+		KeyID:     fmt.Sprintf("http://localhost/acme/acct/%d", keyID),
 	}
 
 	signerKey := jose.SigningKey{
@@ -994,7 +994,7 @@ func TestLookupJWK(t *testing.T) {
 			Request: makePostRequestWithPath("test-path", errorIDJWSBody),
 			ExpectedProblem: &probs.ProblemDetails{
 				Type:       probs.ServerInternalProblem,
-				Detail:     "Error retreiving account \"http://localhost/acme/reg/100\"",
+				Detail:     "Error retreiving account \"http://localhost/acme/acct/100\"",
 				HTTPStatus: http.StatusInternalServerError,
 			},
 			ErrorStatType: "JWSKeyIDLookupFailed",
@@ -1005,7 +1005,7 @@ func TestLookupJWK(t *testing.T) {
 			Request: makePostRequestWithPath("test-path", missingIDJWSBody),
 			ExpectedProblem: &probs.ProblemDetails{
 				Type:       probs.AccountDoesNotExistProblem,
-				Detail:     "Account \"http://localhost/acme/reg/102\" not found",
+				Detail:     "Account \"http://localhost/acme/acct/102\" not found",
 				HTTPStatus: http.StatusBadRequest,
 			},
 			ErrorStatType: "JWSKeyIDNotFound",
@@ -1234,7 +1234,7 @@ func TestValidPOSTForAccount(t *testing.T) {
 			Request: makePostRequestWithPath("test", missingJWSBody),
 			ExpectedProblem: &probs.ProblemDetails{
 				Type:       probs.AccountDoesNotExistProblem,
-				Detail:     "Account \"http://localhost/acme/reg/102\" not found",
+				Detail:     "Account \"http://localhost/acme/acct/102\" not found",
 				HTTPStatus: http.StatusBadRequest,
 			},
 			ErrorStatType: "JWSKeyIDNotFound",

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -35,8 +35,8 @@ import (
 // measured_http.
 const (
 	directoryPath  = "/directory"
-	newRegPath     = "/acme/new-reg"
-	regPath        = "/acme/reg/"
+	newAcctPath    = "/acme/new-acct"
+	acctPath       = "/acme/acct/"
 	authzPath      = "/acme/authz/"
 	challengePath  = "/acme/challenge/"
 	certPath       = "/acme/cert/"
@@ -298,8 +298,8 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	m := http.NewServeMux()
 	wfe.HandleFunc(m, directoryPath, wfe.Directory, "GET")
-	wfe.HandleFunc(m, newRegPath, wfe.NewRegistration, "POST")
-	wfe.HandleFunc(m, regPath, wfe.Registration, "POST")
+	wfe.HandleFunc(m, newAcctPath, wfe.NewAccount, "POST")
+	wfe.HandleFunc(m, acctPath, wfe.Account, "POST")
 	wfe.HandleFunc(m, authzPath, wfe.Authorization, "GET", "POST")
 	wfe.HandleFunc(m, challengePath, wfe.Challenge, "GET", "POST")
 	wfe.HandleFunc(m, certPath, wfe.Certificate, "GET")
@@ -368,7 +368,7 @@ func addRequesterHeader(w http.ResponseWriter, requester int64) {
 // using the `request.Host` of the HTTP request.
 func (wfe *WebFrontEndImpl) Directory(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
 	directoryEndpoints := map[string]interface{}{
-		"new-reg":     newRegPath,
+		"new-account": newAcctPath,
 		"revoke-cert": revokeCertPath,
 	}
 
@@ -440,10 +440,14 @@ func link(url, relation string) string {
 	return fmt.Sprintf("<%s>;rel=\"%s\"", url, relation)
 }
 
-// NewRegistration is used by clients to submit a new registration/account
-func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
+// NewAccount is used by clients to submit a new account
+func (wfe *WebFrontEndImpl) NewAccount(
+	ctx context.Context,
+	logEvent *requestEvent,
+	response http.ResponseWriter,
+	request *http.Request) {
 
-	// NewRegistration uses `validSelfAuthenticatedPOST` instead of
+	// NewAccount uses `validSelfAuthenticatedPOST` instead of
 	// `validPOSTforAccount` because there is no account to authenticate against
 	// until after it is created!
 	body, key, prob := wfe.validSelfAuthenticatedPOST(request, logEvent)
@@ -453,10 +457,11 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 		return
 	}
 
-	if existingReg, err := wfe.SA.GetRegistrationByKey(ctx, key); err == nil {
-		response.Header().Set("Location", wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, existingReg.ID)))
-		// TODO(#595): check for missing registration err
-		wfe.sendError(response, logEvent, probs.Conflict("Registration key is already in use"), err)
+	if existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, key); err == nil {
+		response.Header().Set("Location",
+			wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
+		// TODO(#595): check for missing account err
+		wfe.sendError(response, logEvent, probs.Conflict("Account key is already in use"), err)
 		return
 	}
 
@@ -484,37 +489,36 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *reque
 		}
 	}
 
-	reg, err := wfe.RA.NewRegistration(ctx, init)
+	acct, err := wfe.RA.NewRegistration(ctx, init)
 	if err != nil {
-		logEvent.AddError("unable to create new registration: %s", err)
-		wfe.sendError(response, logEvent, problemDetailsForError(err, "Error creating new registration"), err)
+		logEvent.AddError("unable to create new account: %s", err)
+		wfe.sendError(response, logEvent,
+			problemDetailsForError(err, "Error creating new account"), err)
 		return
 	}
-	logEvent.Requester = reg.ID
-	addRequesterHeader(response, reg.ID)
-	logEvent.Contacts = reg.Contact
+	logEvent.Requester = acct.ID
+	addRequesterHeader(response, acct.ID)
+	logEvent.Contacts = acct.Contact
 
-	// Use an explicitly typed variable. Otherwise `go vet' incorrectly complains
-	// that reg.ID is a string being passed to %d.
-	regURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, reg.ID))
+	acctURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, acct.ID))
 
-	response.Header().Add("Location", regURL)
+	response.Header().Add("Location", acctURL)
 	if len(wfe.SubscriberAgreementURL) > 0 {
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
 	}
 
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusCreated, reg)
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusCreated, acct)
 	if err != nil {
-		// ServerInternal because we just created this registration, and it
+		// ServerInternal because we just created this account, and it
 		// should be OK.
-		logEvent.AddError("unable to marshal registration: %s", err)
-		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshaling registration"), err)
+		logEvent.AddError("unable to marshal account: %s", err)
+		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshaling account"), err)
 		return
 	}
 }
 
-func (wfe *WebFrontEndImpl) regHoldsAuthorizations(ctx context.Context, regID int64, names []string) (bool, error) {
-	authz, err := wfe.SA.GetValidAuthorizations(ctx, regID, names, wfe.clk.Now())
+func (wfe *WebFrontEndImpl) acctHoldsAuthorizations(ctx context.Context, acctID int64, names []string) (bool, error) {
+	authz, err := wfe.SA.GetValidAuthorizations(ctx, acctID, names, wfe.clk.Now())
 	if err != nil {
 		return false, err
 	}
@@ -539,7 +543,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *req
 	return
 }
 
-func (wfe *WebFrontEndImpl) logCsr(request *http.Request, cr core.CertificateRequest, registration core.Registration) {
+func (wfe *WebFrontEndImpl) logCsr(request *http.Request, cr core.CertificateRequest, account core.Registration) {
 	var csrLog = struct {
 		ClientAddr   string
 		CSR          string
@@ -547,7 +551,7 @@ func (wfe *WebFrontEndImpl) logCsr(request *http.Request, cr core.CertificateReq
 	}{
 		ClientAddr:   getClientAddr(request),
 		CSR:          hex.EncodeToString(cr.Bytes),
-		Registration: registration,
+		Registration: account,
 	}
 	wfe.log.AuditObject("Certificate request", csrLog)
 }
@@ -672,7 +676,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	authz core.Authorization,
 	challengeIndex int,
 	logEvent *requestEvent) {
-	body, _, currReg, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
+	body, _, currAcct, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
 	addRequesterHeader(response, logEvent.Requester)
 	if prob != nil {
 		// validPOSTForAccount handles its own setting of logEvent.Errors
@@ -680,20 +684,21 @@ func (wfe *WebFrontEndImpl) postChallenge(
 		return
 	}
 	// Any version of the agreement is acceptable here. Version match is enforced in
-	// wfe.Registration when agreeing the first time. Agreement updates happen
-	// by mailing subscribers and don't require a registration update.
-	if currReg.Agreement == "" {
-		wfe.sendError(response, logEvent, probs.Unauthorized("Registration didn't agree to subscriber agreement before any further actions"), nil)
+	// wfe.Account when agreeing the first time. Agreement updates happen
+	// by mailing subscribers and don't require an account update.
+	if currAcct.Agreement == "" {
+		wfe.sendError(response, logEvent,
+			probs.Unauthorized("Account must agree to subscriber agreement before any further actions"), nil)
 		return
 	}
 
-	// Check that the registration ID matching the key used matches
-	// the registration ID on the authz object
-	if currReg.ID != authz.RegistrationID {
-		logEvent.AddError("User registration id: %d != Authorization registration id: %v", currReg.ID, authz.RegistrationID)
+	// Check that the account ID matching the key used matches
+	// the account ID on the authz object
+	if currAcct.ID != authz.RegistrationID {
+		logEvent.AddError("User account id: %d != Authorization account id: %v", currAcct.ID, authz.RegistrationID)
 		wfe.sendError(response,
 			logEvent,
-			probs.Unauthorized("User registration ID doesn't match registration ID in authorization"),
+			probs.Unauthorized("User account ID doesn't match account ID in authorization"),
 			nil,
 		)
 		return
@@ -731,13 +736,13 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	}
 }
 
-// Registration is used by a client to submit an update to their registration.
-func (wfe *WebFrontEndImpl) Registration(
+// Account is used by a client to submit an update to their account.
+func (wfe *WebFrontEndImpl) Account(
 	ctx context.Context,
 	logEvent *requestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
-	body, _, currReg, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
+	body, _, currAcct, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
 	addRequesterHeader(response, logEvent.Requester)
 	if prob != nil {
 		// validPOSTForAccount handles its own setting of logEvent.Errors
@@ -746,33 +751,34 @@ func (wfe *WebFrontEndImpl) Registration(
 	}
 
 	// Requests to this handler should have a path that leads to a known
-	// registration
+	// account
 	idStr := request.URL.Path
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		logEvent.AddError("registration ID must be an integer, was %#v", idStr)
-		wfe.sendError(response, logEvent, probs.Malformed("Registration ID must be an integer"), err)
+		logEvent.AddError("account ID must be an integer, was %#v", idStr)
+		wfe.sendError(response, logEvent, probs.Malformed("Account ID must be an integer"), err)
 		return
 	} else if id <= 0 {
-		msg := fmt.Sprintf("Registration ID must be a positive non-zero integer, was %d", id)
+		msg := fmt.Sprintf("Account ID must be a positive non-zero integer, was %d", id)
 		logEvent.AddError(msg)
 		wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
 		return
-	} else if id != currReg.ID {
-		logEvent.AddError("Request signing key did not match registration key: %d != %d", id, currReg.ID)
-		wfe.sendError(response, logEvent, probs.Unauthorized("Request signing key did not match registration key"), nil)
+	} else if id != currAcct.ID {
+		logEvent.AddError("Request signing key did not match account key: %d != %d", id, currAcct.ID)
+		wfe.sendError(response, logEvent,
+			probs.Unauthorized("Request signing key did not match account key"), nil)
 		return
 	}
 
 	var update core.Registration
 	err = json.Unmarshal(body, &update)
 	if err != nil {
-		logEvent.AddError("unable to JSON parse registration: %s", err)
-		wfe.sendError(response, logEvent, probs.Malformed("Error unmarshaling registration"), err)
+		logEvent.AddError("unable to JSON parse account: %s", err)
+		wfe.sendError(response, logEvent, probs.Malformed("Error unmarshaling account"), err)
 		return
 	}
 
-	// People *will* POST their full registrations to this endpoint, including
+	// People *will* POST their full accounts to this endpoint, including
 	// the 'valid' status, to avoid always failing out when that happens only
 	// attempt to deactivate if the provided status is different from their current
 	// status.
@@ -780,42 +786,44 @@ func (wfe *WebFrontEndImpl) Registration(
 	// If a user tries to send both a deactivation request and an update to their
 	// contacts or subscriber agreement URL the deactivation will take place and
 	// return before an update would be performed.
-	if update.Status != "" && update.Status != currReg.Status {
+	if update.Status != "" && update.Status != currAcct.Status {
 		if update.Status != core.StatusDeactivated {
 			wfe.sendError(response, logEvent, probs.Malformed("Invalid value provided for status field"), nil)
 			return
 		}
-		wfe.deactivateRegistration(ctx, *currReg, response, request, logEvent)
+		wfe.deactivateAccount(ctx, *currAcct, response, request, logEvent)
 		return
 	}
 
-	// If a user POSTs their registration object including a previously valid
+	// If a user POSTs their account object including a previously valid
 	// agreement URL but that URL has since changed we will fail out here
 	// since the update agreement URL doesn't match the current URL. To fix that we
 	// only fail if the sent URL doesn't match the currently valid agreement URL
-	// and it doesn't match the URL currently stored in the registration
+	// and it doesn't match the URL currently stored in the account
 	// in the database. The RA understands the user isn't actually trying to
 	// update the agreement but since we do an early check here in order to prevent
 	// extraneous requests to the RA we have to add this bypass.
-	if len(update.Agreement) > 0 && update.Agreement != currReg.Agreement &&
+	if len(update.Agreement) > 0 && update.Agreement != currAcct.Agreement &&
 		update.Agreement != wfe.SubscriberAgreementURL {
-		msg := fmt.Sprintf("Provided agreement URL [%s] does not match current agreement URL [%s]", update.Agreement, wfe.SubscriberAgreementURL)
+		msg := fmt.Sprintf("Provided agreement URL [%s] does not match current agreement URL [%s]",
+			update.Agreement, wfe.SubscriberAgreementURL)
 		logEvent.AddError(msg)
 		wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
 		return
 	}
 
-	// Registration objects contain a JWK object which are merged in UpdateRegistration
-	// if it is different from the existing registration key. Since this isn't how you
+	// Account objects contain a JWK object which are merged in UpdateRegistration
+	// if it is different from the existing account key. Since this isn't how you
 	// update the key we just copy the existing one into the update object here. This
 	// ensures the key isn't changed and that we can cleanly serialize the update as
 	// JSON to send via RPC to the RA.
-	update.Key = currReg.Key
+	update.Key = currAcct.Key
 
-	updatedReg, err := wfe.RA.UpdateRegistration(ctx, *currReg, update)
+	updatedAcct, err := wfe.RA.UpdateRegistration(ctx, *currAcct, update)
 	if err != nil {
-		logEvent.AddError("unable to update registration: %s", err)
-		wfe.sendError(response, logEvent, problemDetailsForError(err, "Unable to update registration"), err)
+		logEvent.AddError("unable to update account: %s", err)
+		wfe.sendError(response, logEvent,
+			problemDetailsForError(err, "Unable to update account"), err)
 		return
 	}
 
@@ -823,11 +831,12 @@ func (wfe *WebFrontEndImpl) Registration(
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
 	}
 
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, updatedReg)
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, updatedAcct)
 	if err != nil {
-		// ServerInternal because we just generated the reg, it should be OK
-		logEvent.AddError("unable to marshal updated registration: %s", err)
-		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal registration"), err)
+		// ServerInternal because we just generated the account, it should be OK
+		logEvent.AddError("unable to marshal updated account: %s", err)
+		wfe.sendError(response, logEvent,
+			probs.ServerInternal("Failed to marshal account"), err)
 		return
 	}
 }
@@ -838,15 +847,16 @@ func (wfe *WebFrontEndImpl) deactivateAuthorization(
 	logEvent *requestEvent,
 	response http.ResponseWriter,
 	request *http.Request) bool {
-	body, _, reg, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
+	body, _, acct, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
 	addRequesterHeader(response, logEvent.Requester)
 	if prob != nil {
 		wfe.sendError(response, logEvent, prob, nil)
 		return false
 	}
-	if reg.ID != authz.RegistrationID {
-		logEvent.AddError("registration ID doesn't match ID for authorization")
-		wfe.sendError(response, logEvent, probs.Unauthorized("Registration ID doesn't match ID for authorization"), nil)
+	if acct.ID != authz.RegistrationID {
+		logEvent.AddError("account ID doesn't match ID for authorization")
+		wfe.sendError(response, logEvent,
+			probs.Unauthorized("Account ID doesn't match ID for authorization"), nil)
 		return false
 	}
 	var req struct {
@@ -1097,7 +1107,7 @@ func (wfe *WebFrontEndImpl) KeyRollover(
 
 	// Check that the new key isn't the same as the old key. This would fail as
 	// part of the subsequent `wfe.SA.GetRegistrationByKey` check since the new key
-	// will find the old registration if its equal to the old registration key. We
+	// will find the old account if its equal to the old account key. We
 	// check new key against old key explicitly to save an RPC round trip and a DB
 	// query for this easy rejection case
 	keysEqual, err := core.PublicKeysEqual(newKey.Key, acct.Key.Key)
@@ -1115,8 +1125,10 @@ func (wfe *WebFrontEndImpl) KeyRollover(
 
 	// Check that the new key isn't already being used for an existing account
 	if existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, &newKey); err != nil {
-		response.Header().Set("Location", wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, existingAcct.ID)))
-		wfe.sendError(response, logEvent, probs.Conflict("New key is already in use for a different account"), err)
+		response.Header().Set("Location",
+			wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
+		wfe.sendError(response, logEvent,
+			probs.Conflict("New key is already in use for a different account"), err)
 		return
 	}
 
@@ -1135,20 +1147,27 @@ func (wfe *WebFrontEndImpl) KeyRollover(
 	}
 }
 
-func (wfe *WebFrontEndImpl) deactivateRegistration(ctx context.Context, reg core.Registration, response http.ResponseWriter, request *http.Request, logEvent *requestEvent) {
-	err := wfe.RA.DeactivateRegistration(ctx, reg)
+func (wfe *WebFrontEndImpl) deactivateAccount(
+	ctx context.Context,
+	acct core.Registration,
+	response http.ResponseWriter,
+	request *http.Request,
+	logEvent *requestEvent) {
+	err := wfe.RA.DeactivateRegistration(ctx, acct)
 	if err != nil {
-		logEvent.AddError("unable to deactivate registration", err)
-		wfe.sendError(response, logEvent, problemDetailsForError(err, "Error deactivating registration"), err)
+		logEvent.AddError("unable to deactivate account", err)
+		wfe.sendError(response, logEvent,
+			problemDetailsForError(err, "Error deactivating account"), err)
 		return
 	}
-	reg.Status = core.StatusDeactivated
+	acct.Status = core.StatusDeactivated
 
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, reg)
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, acct)
 	if err != nil {
-		// ServerInternal because registration is from DB and should be fine
-		logEvent.AddError("unable to marshal updated registration: %s", err)
-		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal registration"), err)
+		// ServerInternal because account is from DB and should be fine
+		logEvent.AddError("unable to marshal updated account: %s", err)
+		wfe.sendError(response, logEvent,
+			probs.ServerInternal("Failed to marshal account"), err)
 		return
 	}
 }
@@ -1176,8 +1195,12 @@ type orderJSON struct {
 }
 
 // NewOrder is used by clients to create a new order object from a CSR
-func (wfe *WebFrontEndImpl) NewOrder(ctx context.Context, logEvent *requestEvent, response http.ResponseWriter, request *http.Request) {
-	body, _, reg, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
+func (wfe *WebFrontEndImpl) NewOrder(
+	ctx context.Context,
+	logEvent *requestEvent,
+	response http.ResponseWriter,
+	request *http.Request) {
+	body, _, acct, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
 	addRequesterHeader(response, logEvent.Requester)
 	if prob != nil {
 		// validPOSTForAccount handles its own setting of logEvent.Errors
@@ -1221,7 +1244,7 @@ func (wfe *WebFrontEndImpl) NewOrder(ctx context.Context, logEvent *requestEvent
 	}
 
 	order, err := wfe.RA.NewOrder(ctx, &rapb.NewOrderRequest{
-		RegistrationID: &reg.ID,
+		RegistrationID: &acct.ID,
 		Csr:            rawCSR.CSR,
 	})
 	if err != nil {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -206,26 +206,26 @@ type MockRegistrationAuthority struct {
 	lastRevocationReason revocation.Reason
 }
 
-func (ra *MockRegistrationAuthority) NewRegistration(ctx context.Context, reg core.Registration) (core.Registration, error) {
-	return reg, nil
+func (ra *MockRegistrationAuthority) NewRegistration(ctx context.Context, acct core.Registration) (core.Registration, error) {
+	return acct, nil
 }
 
-func (ra *MockRegistrationAuthority) NewAuthorization(ctx context.Context, authz core.Authorization, regID int64) (core.Authorization, error) {
-	authz.RegistrationID = regID
+func (ra *MockRegistrationAuthority) NewAuthorization(ctx context.Context, authz core.Authorization, acctID int64) (core.Authorization, error) {
+	authz.RegistrationID = acctID
 	authz.ID = "bkrPh2u0JUf18-rVBZtOOWWb3GuIiliypL-hBM9Ak1Q"
 	return authz, nil
 }
 
-func (ra *MockRegistrationAuthority) NewCertificate(ctx context.Context, req core.CertificateRequest, regID int64) (core.Certificate, error) {
+func (ra *MockRegistrationAuthority) NewCertificate(ctx context.Context, req core.CertificateRequest, acctID int64) (core.Certificate, error) {
 	return core.Certificate{}, nil
 }
 
-func (ra *MockRegistrationAuthority) UpdateRegistration(ctx context.Context, reg core.Registration, updated core.Registration) (core.Registration, error) {
-	keysMatch, _ := core.PublicKeysEqual(reg.Key.Key, updated.Key.Key)
+func (ra *MockRegistrationAuthority) UpdateRegistration(ctx context.Context, acct core.Registration, updated core.Registration) (core.Registration, error) {
+	keysMatch, _ := core.PublicKeysEqual(acct.Key.Key, updated.Key.Key)
 	if !keysMatch {
-		reg.Key = updated.Key
+		acct.Key = updated.Key
 	}
-	return reg, nil
+	return acct, nil
 }
 
 func (ra *MockRegistrationAuthority) UpdateAuthorization(ctx context.Context, authz core.Authorization, foo int, challenge core.Challenge) (core.Authorization, error) {
@@ -660,7 +660,7 @@ func TestDirectory(t *testing.T) {
   "meta": {
     "terms-of-service": "http://example.invalid/terms"
   },
-  "new-reg": "http://localhost:4300/acme/new-reg",
+  "new-account": "http://localhost:4300/acme/new-acct",
   "revoke-cert": "http://localhost:4300/acme/revoke-cert",
   "AAAAAAAAAAA": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417"
 }`
@@ -699,15 +699,15 @@ func TestRelativeDirectory(t *testing.T) {
 		result      string
 	}{
 		// Test '' (No host header) with no proto header
-		{"", "", `{"key-change":"http://localhost/acme/key-change","new-reg":"http://localhost/acme/new-reg","revoke-cert":"http://localhost/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
+		{"", "", `{"key-change":"http://localhost/acme/key-change","new-account":"http://localhost/acme/new-acct","revoke-cert":"http://localhost/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
 		// Test localhost:4300 with no proto header
-		{"localhost:4300", "", `{"key-change":"http://localhost:4300/acme/key-change","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
+		{"localhost:4300", "", `{"key-change":"http://localhost:4300/acme/key-change","new-account":"http://localhost:4300/acme/new-acct","revoke-cert":"http://localhost:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
 		// Test 127.0.0.1:4300 with no proto header
-		{"127.0.0.1:4300", "", `{"key-change":"http://127.0.0.1:4300/acme/key-change","new-reg":"http://127.0.0.1:4300/acme/new-reg","revoke-cert":"http://127.0.0.1:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
+		{"127.0.0.1:4300", "", `{"key-change":"http://127.0.0.1:4300/acme/key-change","new-account":"http://127.0.0.1:4300/acme/new-acct","revoke-cert":"http://127.0.0.1:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
 		// Test localhost:4300 with HTTP proto header
-		{"localhost:4300", "http", `{"key-change":"http://localhost:4300/acme/key-change","new-reg":"http://localhost:4300/acme/new-reg","revoke-cert":"http://localhost:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
+		{"localhost:4300", "http", `{"key-change":"http://localhost:4300/acme/key-change","new-account":"http://localhost:4300/acme/new-acct","revoke-cert":"http://localhost:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
 		// Test localhost:4300 with HTTPS proto header
-		{"localhost:4300", "https", `{"key-change":"https://localhost:4300/acme/key-change","new-reg":"https://localhost:4300/acme/new-reg","revoke-cert":"https://localhost:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
+		{"localhost:4300", "https", `{"key-change":"https://localhost:4300/acme/key-change","new-account":"https://localhost:4300/acme/new-acct","revoke-cert":"https://localhost:4300/acme/revoke-cert","AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417","meta":{"terms-of-service": "http://example.invalid/terms"}}`},
 	}
 
 	for _, tt := range dirTests {
@@ -758,18 +758,13 @@ func TestHTTPMethods(t *testing.T) {
 			Allowed: getOnly,
 		},
 		{
-			Name:    "NewReg path should be POST only",
-			Path:    newRegPath,
+			Name:    "NewAcct path should be POST only",
+			Path:    newAcctPath,
 			Allowed: postOnly,
 		},
 		{
-			Name:    "NewReg path should be POST only",
-			Path:    newRegPath,
-			Allowed: postOnly,
-		},
-		{
-			Name:    "Reg path should be POST only",
-			Path:    regPath,
+			Name:    "Acct path should be POST only",
+			Path:    acctPath,
 			Allowed: postOnly,
 		},
 		{
@@ -988,12 +983,12 @@ func TestBadNonce(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	result, err := signer.Sign([]byte(`{"contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`))
 	test.AssertNotError(t, err, "Failed to sign body")
-	wfe.NewRegistration(ctx, newRequestEvent(), responseWriter,
+	wfe.NewAccount(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath("nonce", result.FullSerialize()))
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"urn:acme:error:badNonce","detail":"JWS has no anti-replay nonce","status":400}`)
 }
 
-func TestNewECDSARegistration(t *testing.T) {
+func TestNewECDSAAccount(t *testing.T) {
 	wfe, _ := setupWFE(t)
 
 	// E1 always exists; E2 never exists
@@ -1001,25 +996,25 @@ func TestNewECDSARegistration(t *testing.T) {
 	_, ok := key.(*ecdsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load ECDSA key")
 
-	payload := `{"resource":"new-reg","contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`
-	path := "new-reg"
-	signedURL := fmt.Sprintf("http://localhost/%s", path)
+	payload := `{"contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`
+	path := newAcctPath
+	signedURL := fmt.Sprintf("http://localhost%s", path)
 	_, _, body := signRequestEmbed(t, key, signedURL, payload, wfe.nonceService)
 	request := makePostRequestWithPath(path, body)
 
 	responseWriter := httptest.NewRecorder()
-	wfe.NewRegistration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
 
-	var reg core.Registration
+	var acct core.Registration
 	responseBody := responseWriter.Body.String()
-	err := json.Unmarshal([]byte(responseBody), &reg)
-	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")
-	test.Assert(t, len(*reg.Contact) >= 1, "No contact field in registration")
-	test.AssertEquals(t, (*reg.Contact)[0], "mailto:person@mail.com")
-	test.AssertEquals(t, reg.Agreement, "http://example.invalid/terms")
-	test.AssertEquals(t, reg.InitialIP.String(), "1.1.1.1")
+	err := json.Unmarshal([]byte(responseBody), &acct)
+	test.AssertNotError(t, err, "Couldn't unmarshal returned account object")
+	test.Assert(t, len(*acct.Contact) >= 1, "No contact field in account")
+	test.AssertEquals(t, (*acct.Contact)[0], "mailto:person@mail.com")
+	test.AssertEquals(t, acct.Agreement, "http://example.invalid/terms")
+	test.AssertEquals(t, acct.InitialIP.String(), "1.1.1.1")
 
-	test.AssertEquals(t, responseWriter.Header().Get("Location"), "http://localhost/acme/reg/0")
+	test.AssertEquals(t, responseWriter.Header().Get("Location"), "http://localhost/acme/acct/0")
 
 	key = loadKey(t, []byte(testE1KeyPrivatePEM))
 	_, ok = key.(*ecdsa.PrivateKey)
@@ -1031,23 +1026,23 @@ func TestNewECDSARegistration(t *testing.T) {
 	// Reset the body and status code
 	responseWriter = httptest.NewRecorder()
 	// POST, Valid JSON, Key already in use
-	wfe.NewRegistration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
 	responseBody = responseWriter.Body.String()
-	test.AssertUnmarshaledEquals(t, responseBody, `{"type":"urn:acme:error:malformed","detail":"Registration key is already in use","status":409}`)
-	test.AssertEquals(t, responseWriter.Header().Get("Location"), "http://localhost/acme/reg/3")
+	test.AssertUnmarshaledEquals(t, responseBody, `{"type":"urn:acme:error:malformed","detail":"Account key is already in use","status":409}`)
+	test.AssertEquals(t, responseWriter.Header().Get("Location"), "http://localhost/acme/acct/3")
 	test.AssertEquals(t, responseWriter.Code, 409)
 }
 
 // Test that the WFE handling of the "empty update" POST is correct. The ACME
 // spec describes how when clients wish to query the server for information
-// about a registration an empty registration update should be sent, and
-// a populated reg object will be returned.
-func TestEmptyRegistration(t *testing.T) {
+// about an account an empty account update should be sent, and
+// a populated acct object will be returned.
+func TestEmptyAccount(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	responseWriter := httptest.NewRecorder()
 
 	// Test Key 1 is mocked in the mock StorageAuthority used in setupWFE to
-	// return a populated registration for GetRegistrationByKey when test key 1 is
+	// return a populated account for GetRegistrationByKey when test key 1 is
 	// used.
 	key := loadKey(t, []byte(test1KeyPrivatePEM))
 	_, ok := key.(*rsa.PrivateKey)
@@ -1059,8 +1054,8 @@ func TestEmptyRegistration(t *testing.T) {
 	_, _, body := signRequestKeyID(t, 1, key, signedURL, payload, wfe.nonceService)
 	request := makePostRequestWithPath(path, body)
 
-	// Send a registration update with the trivial body
-	wfe.Registration(
+	// Send an account update with the trivial body
+	wfe.Account(
 		ctx,
 		newRequestEvent(),
 		responseWriter,
@@ -1070,44 +1065,44 @@ func TestEmptyRegistration(t *testing.T) {
 	// There should be no error
 	test.AssertNotContains(t, responseBody, "urn:acme:error")
 
-	// We should get back a populated Registration
-	var reg core.Registration
-	err := json.Unmarshal([]byte(responseBody), &reg)
-	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")
-	test.Assert(t, len(*reg.Contact) >= 1, "No contact field in registration")
-	test.AssertEquals(t, (*reg.Contact)[0], "mailto:person@mail.com")
-	test.AssertEquals(t, reg.Agreement, "http://example.invalid/terms")
+	// We should get back a populated Account
+	var acct core.Registration
+	err := json.Unmarshal([]byte(responseBody), &acct)
+	test.AssertNotError(t, err, "Couldn't unmarshal returned account object")
+	test.Assert(t, len(*acct.Contact) >= 1, "No contact field in account")
+	test.AssertEquals(t, (*acct.Contact)[0], "mailto:person@mail.com")
+	test.AssertEquals(t, acct.Agreement, "http://example.invalid/terms")
 	responseWriter.Body.Reset()
 }
 
-func TestNewRegistration(t *testing.T) {
+func TestNewAccount(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 	key := loadKey(t, []byte(test2KeyPrivatePEM))
 	_, ok := key.(*rsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load test2 key")
 
-	path := newRegPath
-	signedURL := fmt.Sprintf("http://localhost%s", newRegPath)
+	path := newAcctPath
+	signedURL := fmt.Sprintf("http://localhost%s", path)
 
-	wrongAgreementReg := `{"contact":["mailto:person@mail.com"],"agreement":"https://letsencrypt.org/im-bad"}`
-	// A reg with the wrong agreement URL
-	_, _, wrongAgreementBody := signRequestEmbed(t, key, signedURL, wrongAgreementReg, wfe.nonceService)
+	wrongAgreementAcct := `{"contact":["mailto:person@mail.com"],"agreement":"https://letsencrypt.org/im-bad"}`
+	// An acct with the wrong agreement URL
+	_, _, wrongAgreementBody := signRequestEmbed(t, key, signedURL, wrongAgreementAcct, wfe.nonceService)
 
 	// A non-JSON payload
 	_, _, fooBody := signRequestEmbed(t, key, signedURL, `foo`, wfe.nonceService)
 
-	type newRegErrorTest struct {
+	type newAcctErrorTest struct {
 		r        *http.Request
 		respBody string
 	}
 
-	regErrTests := []newRegErrorTest{
+	acctErrTests := []newAcctErrorTest{
 		// POST, but no body.
 		{
 			&http.Request{
 				Method: "POST",
-				URL:    mustParseURL(newRegPath),
+				URL:    mustParseURL(newAcctPath),
 				Header: map[string][]string{
 					"Content-Length": {"0"},
 				},
@@ -1117,29 +1112,29 @@ func TestNewRegistration(t *testing.T) {
 
 		// POST, but body that isn't valid JWS
 		{
-			makePostRequestWithPath(newRegPath, "hi"),
+			makePostRequestWithPath(newAcctPath, "hi"),
 			`{"type":"urn:acme:error:malformed","detail":"Parse error reading JWS","status":400}`,
 		},
 
 		// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 		{
-			makePostRequestWithPath(newRegPath, fooBody),
+			makePostRequestWithPath(newAcctPath, fooBody),
 			`{"type":"urn:acme:error:malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 
 		// Same signed body, but payload modified by one byte, breaking signature.
 		// should fail JWS verification.
 		{
-			makePostRequestWithPath(newRegPath,
+			makePostRequestWithPath(newAcctPath,
 				`{"payload":"Zm9x","protected":"eyJhbGciOiJSUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoicW5BUkxyVDdYejRnUmNLeUxkeWRtQ3ItZXk5T3VQSW1YNFg0MHRoazNvbjI2RmtNem5SM2ZSanM2NmVMSzdtbVBjQlo2dU9Kc2VVUlU2d0FhWk5tZW1vWXgxZE12cXZXV0l5aVFsZUhTRDdROHZCcmhSNnVJb080akF6SlpSLUNoelp1U0R0N2lITi0zeFVWc3B1NVhHd1hVX01WSlpzaFR3cDRUYUZ4NWVsSElUX09iblR2VE9VM1hoaXNoMDdBYmdaS21Xc1ZiWGg1cy1DcklpY1U0T2V4SlBndW5XWl9ZSkp1ZU9LbVR2bkxsVFY0TXpLUjJvWmxCS1oyN1MwLVNmZFZfUUR4X3lkbGU1b01BeUtWdGxBVjM1Y3lQTUlzWU53Z1VHQkNkWV8yVXppNWVYMGxUYzdNUFJ3ejZxUjFraXAtaTU5VmNHY1VRZ3FIVjZGeXF3IiwiZSI6IkFRQUIifSwia2lkIjoiIiwibm9uY2UiOiJyNHpuenZQQUVwMDlDN1JwZUtYVHhvNkx3SGwxZVBVdmpGeXhOSE1hQnVvIiwidXJsIjoiaHR0cDovL2xvY2FsaG9zdC9hY21lL25ldy1yZWcifQ","signature":"jcTdxSygm_cvD7KbXqsxgnoPApCTSkV4jolToSOd2ciRkg5W7Yl0ZKEEKwOc-dYIbQiwGiDzisyPCicwWsOUA1WSqHylKvZ3nxSMc6KtwJCW2DaOqcf0EEjy5VjiZJUrOt2c-r6b07tbn8sfOJKwlF2lsOeGi4s-rtvvkeQpAU-AWauzl9G4bv2nDUeCviAZjHx_PoUC-f9GmZhYrbDzAvXZ859ktM6RmMeD0OqPN7bhAeju2j9Gl0lnryZMtq2m0J2m1ucenQBL1g4ZkP1JiJvzd2cAz5G7Ftl2YeJJyWhqNd3qq0GVOt1P11s8PTGNaSoM0iR9QfUxT9A6jxARtg"}`),
 			`{"type":"urn:acme:error:malformed","detail":"JWS verification error","status":400}`,
 		},
 		{
-			makePostRequestWithPath(newRegPath, wrongAgreementBody),
+			makePostRequestWithPath(newAcctPath, wrongAgreementBody),
 			`{"type":"urn:acme:error:malformed","detail":"Provided agreement URL [https://letsencrypt.org/im-bad] does not match current agreement URL [` + agreementURL + `]","status":400}`,
 		},
 	}
-	for _, rt := range regErrTests {
+	for _, rt := range acctErrTests {
 		responseWriter := httptest.NewRecorder()
 		mux.ServeHTTP(responseWriter, rt.r)
 		test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), rt.respBody)
@@ -1151,20 +1146,20 @@ func TestNewRegistration(t *testing.T) {
 	_, _, body := signRequestEmbed(t, key, signedURL, payload, wfe.nonceService)
 	request := makePostRequestWithPath(path, body)
 
-	wfe.NewRegistration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
 
-	var reg core.Registration
+	var acct core.Registration
 	responseBody := responseWriter.Body.String()
-	err := json.Unmarshal([]byte(responseBody), &reg)
-	test.AssertNotError(t, err, "Couldn't unmarshal returned registration object")
-	test.Assert(t, len(*reg.Contact) >= 1, "No contact field in registration")
-	test.AssertEquals(t, (*reg.Contact)[0], "mailto:person@mail.com")
-	test.AssertEquals(t, reg.Agreement, "http://example.invalid/terms")
-	test.AssertEquals(t, reg.InitialIP.String(), "1.1.1.1")
+	err := json.Unmarshal([]byte(responseBody), &acct)
+	test.AssertNotError(t, err, "Couldn't unmarshal returned account object")
+	test.Assert(t, len(*acct.Contact) >= 1, "No contact field in account")
+	test.AssertEquals(t, (*acct.Contact)[0], "mailto:person@mail.com")
+	test.AssertEquals(t, acct.Agreement, "http://example.invalid/terms")
+	test.AssertEquals(t, acct.InitialIP.String(), "1.1.1.1")
 
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Location"),
-		"http://localhost/acme/reg/0")
+		"http://localhost/acme/acct/0")
 	links := responseWriter.Header()["Link"]
 	test.AssertEquals(t, contains(links, "<"+agreementURL+">;rel=\"terms-of-service\""), true)
 
@@ -1179,13 +1174,13 @@ func TestNewRegistration(t *testing.T) {
 	_, _, body = signRequestEmbed(t, key, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
 
-	wfe.NewRegistration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:acme:error:malformed","detail":"Registration key is already in use","status":409}`)
+		`{"type":"urn:acme:error:malformed","detail":"Account key is already in use","status":409}`)
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Location"),
-		"http://localhost/acme/reg/1")
+		"http://localhost/acme/acct/1")
 	test.AssertEquals(t, responseWriter.Code, 409)
 }
 
@@ -1247,7 +1242,7 @@ func contains(s []string, e string) bool {
 	return false
 }
 
-func TestRegistration(t *testing.T) {
+func TestAccount(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 	responseWriter := httptest.NewRecorder()
@@ -1255,7 +1250,7 @@ func TestRegistration(t *testing.T) {
 	// Test GET proper entry returns 405
 	mux.ServeHTTP(responseWriter, &http.Request{
 		Method: "GET",
-		URL:    mustParseURL(regPath),
+		URL:    mustParseURL(acctPath),
 	})
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
@@ -1263,7 +1258,7 @@ func TestRegistration(t *testing.T) {
 	responseWriter.Body.Reset()
 
 	// Test POST invalid JSON
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("2", "invalid"))
+	wfe.Account(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("2", "invalid"))
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{"type":"urn:acme:error:malformed","detail":"Parse error reading JWS","status":400}`)
@@ -1273,68 +1268,68 @@ func TestRegistration(t *testing.T) {
 	_, ok := key.(*rsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load RSA key")
 
-	signedURL := fmt.Sprintf("http://localhost%s%d", regPath, 102)
-	path := fmt.Sprintf("%s%d", regPath, 102)
-	payload := `{"resource":"reg","agreement":"` + agreementURL + `"}`
-	// ID 102 is used by the mock for missing reg
+	signedURL := fmt.Sprintf("http://localhost%s%d", acctPath, 102)
+	path := fmt.Sprintf("%s%d", acctPath, 102)
+	payload := `{"agreement":"` + agreementURL + `"}`
+	// ID 102 is used by the mock for missing acct
 	_, _, body := signRequestKeyID(t, 102, nil, signedURL, payload, wfe.nonceService)
 	request := makePostRequestWithPath(path, body)
 
 	// Test POST valid JSON but key is not registered
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"urn:ietf:params:acme:error:accountDoesNotExist","detail":"Account \"http://localhost/acme/reg/102\" not found","status":400}`)
+		`{"type":"urn:ietf:params:acme:error:accountDoesNotExist","detail":"Account \"http://localhost/acme/acct/102\" not found","status":400}`)
 	responseWriter.Body.Reset()
 
 	key = loadKey(t, []byte(test1KeyPrivatePEM))
 	_, ok = key.(*rsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load RSA key")
 
-	// Test POST valid JSON with registration up in the mock (with incorrect agreement URL)
+	// Test POST valid JSON with account up in the mock (with incorrect agreement URL)
 	payload = `{"agreement":"https://letsencrypt.org/im-bad"}`
 	path = "1"
 	signedURL = "http://localhost/1"
 	_, _, body = signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
 
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{"type":"urn:acme:error:malformed","detail":"Provided agreement URL [https://letsencrypt.org/im-bad] does not match current agreement URL [`+agreementURL+`]","status":400}`)
 	responseWriter.Body.Reset()
 
-	// Test POST valid JSON with registration up in the mock (with correct agreement URL)
-	payload = `{"resource":"reg","agreement":"` + agreementURL + `"}`
+	// Test POST valid JSON with account up in the mock (with correct agreement URL)
+	payload = `{"agreement":"` + agreementURL + `"}`
 	_, _, body = signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
 
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertNotContains(t, responseWriter.Body.String(), "urn:acme:error")
 	links := responseWriter.Header()["Link"]
 	test.AssertEquals(t, contains(links, "<"+agreementURL+">;rel=\"terms-of-service\""), true)
 	responseWriter.Body.Reset()
 
-	// Test POST valid JSON with garbage in URL but valid registration ID
-	payload = `{"resource":"reg","agreement":"` + agreementURL + `"}`
+	// Test POST valid JSON with garbage in URL but valid account ID
+	payload = `{"agreement":"` + agreementURL + `"}`
 	signedURL = "http://localhost/a/bunch/of/garbage/1"
 	_, _, body = signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath("/a/bunch/of/garbage/1", body)
 
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertContains(t, responseWriter.Body.String(), "400")
 	test.AssertContains(t, responseWriter.Body.String(), "urn:acme:error:malformed")
 	responseWriter.Body.Reset()
 
-	// Test POST valid JSON with registration up in the mock (with old agreement URL)
+	// Test POST valid JSON with account up in the mock (with old agreement URL)
 	responseWriter.HeaderMap = http.Header{}
 	wfe.SubscriberAgreementURL = "http://example.invalid/new-terms"
-	payload = `{"resource":"reg","agreement":"` + agreementURL + `"}`
+	payload = `{"agreement":"` + agreementURL + `"}`
 	signedURL = "http://localhost/1"
 	_, _, body = signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
 
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertNotContains(t, responseWriter.Body.String(), "urn:acme:error")
 	links = responseWriter.Header()["Link"]
 	test.AssertEquals(t, contains(links, "<http://example.invalid/new-terms>;rel=\"terms-of-service\""), true)
@@ -1530,7 +1525,7 @@ func TestHeaderBoulderRequester(t *testing.T) {
 	test.Assert(t, ok, "Failed to load test 1 RSA key")
 
 	payload := `{"agreement":"` + agreementURL + `"}`
-	path := fmt.Sprintf("%s%d", regPath, 1)
+	path := fmt.Sprintf("%s%d", acctPath, 1)
 	signedURL := fmt.Sprintf("http://localhost%s", path)
 	_, _, body := signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request := makePostRequestWithPath(path, body)
@@ -1588,7 +1583,7 @@ func TestDeactivateAuthorization(t *testing.T) {
 		}`)
 }
 
-func TestDeactivateRegistration(t *testing.T) {
+func TestDeactivateAccount(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
 
@@ -1599,7 +1594,7 @@ func TestDeactivateRegistration(t *testing.T) {
 	_, _, body := signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request := makePostRequestWithPath(path, body)
 
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{"type": "urn:acme:error:malformed","detail": "Invalid value provided for status field","status": 400}`)
@@ -1609,7 +1604,7 @@ func TestDeactivateRegistration(t *testing.T) {
 	_, _, body = signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
 
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{
@@ -1632,7 +1627,7 @@ func TestDeactivateRegistration(t *testing.T) {
 	payload = `{"status":"deactivated", "contact":[]}`
 	_, _, body = signRequestKeyID(t, 1, nil, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{
@@ -1662,7 +1657,7 @@ func TestDeactivateRegistration(t *testing.T) {
 	_, _, body = signRequestKeyID(t, 3, key, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
 
-	wfe.Registration(ctx, newRequestEvent(), responseWriter, request)
+	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
@@ -1787,7 +1782,7 @@ func TestKeyRollover(t *testing.T) {
 			Payload: `{"newKey":` + string(newJWKJSON) + `}`,
 			ExpectedResponse: `{
 		     "type": "urn:acme:error:malformed",
-		     "detail": "Inner key rollover request specified Account \"\", but outer JWS has Key ID \"http://localhost/acme/reg/1\"",
+		     "detail": "Inner key rollover request specified Account \"\", but outer JWS has Key ID \"http://localhost/acme/acct/1\"",
 		     "status": 400
 		   }`,
 			NewKey:        newKey,
@@ -1795,7 +1790,7 @@ func TestKeyRollover(t *testing.T) {
 		},
 		{
 			Name:    "Missing new key from inner payload",
-			Payload: `{"account":"http://localhost/acme/reg/1"}`,
+			Payload: `{"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
 		     "type": "urn:acme:error:malformed",
 		     "detail": "Inner JWS does not verify with specified new key",
@@ -1805,7 +1800,7 @@ func TestKeyRollover(t *testing.T) {
 		},
 		{
 			Name:    "New key is the same as the old key",
-			Payload: `{"newKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"account":"http://localhost/acme/reg/1"}`,
+			Payload: `{"newKey":{"kty":"RSA","n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ","e":"AQAB"},"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
 		     "type": "urn:acme:error:malformed",
 		     "detail": "New key specified by rollover request is the same as the old key",
@@ -1815,7 +1810,7 @@ func TestKeyRollover(t *testing.T) {
 		},
 		{
 			Name:    "Inner JWS signed by the wrong key",
-			Payload: `{"newKey":` + string(newJWKJSON) + `,"account":"http://localhost/acme/reg/1"}`,
+			Payload: `{"newKey":` + string(newJWKJSON) + `,"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
 		     "type": "urn:acme:error:malformed",
 		     "detail": "Inner JWS does not verify with specified new key",
@@ -1825,7 +1820,7 @@ func TestKeyRollover(t *testing.T) {
 		},
 		{
 			Name:    "Valid key rollover request",
-			Payload: `{"newKey":` + string(newJWKJSON) + `,"account":"http://localhost/acme/reg/1"}`,
+			Payload: `{"newKey":` + string(newJWKJSON) + `,"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
 		     "id": 1,
 		     "key": ` + string(newJWKJSON) + `,


### PR DESCRIPTION
The ACME specification no longer describes "registrations" since this is
a fairly overloaded term. Instead the term used is "account". This
commit updates the WFE2 & tests throughout to replace occurrences of
"reg" and "registration" to use "acct" and "account".

NOTE: This change is strictly limited to the wfe2 package. E.g. the
RA/SA and many core objects still refer to registrations.

Resolves https://github.com/letsencrypt/boulder/issues/2986