### PR TITLE
Increase timeouts for dns-test-srv.

### DIFF
--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -149,8 +149,8 @@ func (ts *testSrv) serveTestResolver() {
 	dnsServer := &dns.Server{
 		Addr:         "0.0.0.0:8053",
 		Net:          "tcp",
-		ReadTimeout:  time.Millisecond,
-		WriteTimeout: time.Millisecond,
+		ReadTimeout:  time.Second,
+		WriteTimeout: time.Second,
 	}
 	go func() {
 		err := dnsServer.ListenAndServe()


### PR DESCRIPTION
They used to be a millisecond, which remarkably worked most of the time.
However, some fraction of DNS requests would fail and need to be retried. Even
successful integration test runs had a number of such failures, but retries
generally saved them. However, sometimes all of the retries for a given lookup
would fail, leading to a failure of the overall lookup. This typically
manifested as an error looking up CAA, because our integration tests look up CAA
much more frequently than other record types.

This appears to fix our integration test flakiness.