### PR TITLE
Fix data race when MatchesCSR fails

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -847,11 +847,11 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(ctx context.Context, req cor
 	}
 
 	if ra.publisher != nil {
-		go func() {
+		go func(der []byte) {
 			// Since we don't want this method to be canceled if the parent context
 			// expires, pass a background context to it and run it in a goroutine.
-			_ = ra.publisher.SubmitToCT(context.Background(), cert.DER)
-		}()
+			_ = ra.publisher.SubmitToCT(context.Background(), der)
+		}(cert.DER)
 	}
 
 	parsedCertificate, err := x509.ParseCertificate([]byte(cert.DER))


### PR DESCRIPTION
I can reliably reproduce a data race by doing the following things:

- Changing cmd/boulder-ra/main.go to use a `cmd.Clock()` so I can fake dates in the future
- Editing docker-compose.yml to set a FAKECLOCK in the future
- Editing start.py to set race_detection=True
- docker-compose up
- certbot_test certonly --standalone -d nuzbar.com

The race detector output is below. However, I'm confused about the output; it claims that there's a write on a line that only has a `return` statement on it. I poked at the code a little bit, and this diff appears to solve it: forcing a copy of `cert.DER` before forking off a goroutine. However, I'm confused about why this would be an issue. My understanding of how Go handles function-scoped variables is that they'll be retains as long as they need to be based on reference counting. What are your thoughts? I'd like to understand this better!

```
WARNING: DATA RACE
Write at 0x00c4201e05d8 by goroutine 133:
  github.com/letsencrypt/boulder/ra.(*RegistrationAuthorityImpl).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/ra/ra.go:872 +0x16b2
  github.com/letsencrypt/boulder/grpc.(*RegistrationAuthorityServerWrapper).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/grpc/ra-wrappers.go:243 +0x263
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler.func1()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:445 +0xa1
  github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus.UnaryServerInterceptor()
      /go/src/github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server.go:29 +0xc9
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).intercept()
      /go/src/github.com/letsencrypt/boulder/grpc/interceptors.go:23 +0x9a
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).(github.com/letsencrypt/boulder/grpc.intercept)-fm()
      /go/src/github.com/letsencrypt/boulder/grpc/server.go:51 +0x99
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:447 +0x1fb
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:748 +0xf67
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).handleStream()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:942 +0x122a
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:507 +0xb6

Previous read at 0x00c4201e05d8 by goroutine 121:
  github.com/letsencrypt/boulder/ra.(*RegistrationAuthorityImpl).NewCertificate.func2()
      /go/src/github.com/letsencrypt/boulder/ra/ra.go:856 +0x9e

Goroutine 133 (running) created at:
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:508 +0xb8
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport/http2_server.go:306 +0x1362
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport/http2_server.go:370 +0xacd
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:515 +0x1e7
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveHTTP2Transport()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:496 +0x628
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).handleRawConn()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:466 +0x5f3

Goroutine 121 (running) created at:
  github.com/letsencrypt/boulder/ra.(*RegistrationAuthorityImpl).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/ra/ra.go:857 +0x1a4c
  github.com/letsencrypt/boulder/grpc.(*RegistrationAuthorityServerWrapper).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/grpc/ra-wrappers.go:243 +0x263
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler.func1()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:445 +0xa1
  github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus.UnaryServerInterceptor()
      /go/src/github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server.go:29 +0xc9
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).intercept()
      /go/src/github.com/letsencrypt/boulder/grpc/interceptors.go:23 +0x9a
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).(github.com/letsencrypt/boulder/grpc.intercept)-fm()
      /go/src/github.com/letsencrypt/boulder/grpc/server.go:51 +0x99
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:447 +0x1fb
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:748 +0xf67
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).handleStream()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:942 +0x122a
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:507 +0xWARNING: DATA RACE
Write at 0x00c4201e05d8 by goroutine 133:
  github.com/letsencrypt/boulder/ra.(*RegistrationAuthorityImpl).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/ra/ra.go:872 +0x16b2
  github.com/letsencrypt/boulder/grpc.(*RegistrationAuthorityServerWrapper).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/grpc/ra-wrappers.go:243 +0x263
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler.func1()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:445 +0xa1
  github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus.UnaryServerInterceptor()
      /go/src/github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server.go:29 +0xc9
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).intercept()
      /go/src/github.com/letsencrypt/boulder/grpc/interceptors.go:23 +0x9a
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).(github.com/letsencrypt/boulder/grpc.intercept)-fm()
      /go/src/github.com/letsencrypt/boulder/grpc/server.go:51 +0x99
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:447 +0x1fb
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:748 +0xf67
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).handleStream()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:942 +0x122a
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:507 +0xb6

Previous read at 0x00c4201e05d8 by goroutine 121:
  github.com/letsencrypt/boulder/ra.(*RegistrationAuthorityImpl).NewCertificate.func2()
      /go/src/github.com/letsencrypt/boulder/ra/ra.go:856 +0x9e

Goroutine 133 (running) created at:
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:508 +0xb8
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport/http2_server.go:306 +0x1362
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/transport/http2_server.go:370 +0xacd
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:515 +0x1e7
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveHTTP2Transport()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:496 +0x628
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).handleRawConn()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:466 +0x5f3

Goroutine 121 (running) created at:
  github.com/letsencrypt/boulder/ra.(*RegistrationAuthorityImpl).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/ra/ra.go:857 +0x1a4c
  github.com/letsencrypt/boulder/grpc.(*RegistrationAuthorityServerWrapper).NewCertificate()
      /go/src/github.com/letsencrypt/boulder/grpc/ra-wrappers.go:243 +0x263
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler.func1()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:445 +0xa1
  github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus.UnaryServerInterceptor()
      /go/src/github.com/letsencrypt/boulder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server.go:29 +0xc9
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).intercept()
      /go/src/github.com/letsencrypt/boulder/grpc/interceptors.go:23 +0x9a
  github.com/letsencrypt/boulder/grpc.(*serverInterceptor).(github.com/letsencrypt/boulder/grpc.intercept)-fm()
      /go/src/github.com/letsencrypt/boulder/grpc/server.go:51 +0x99
  github.com/letsencrypt/boulder/ra/proto._RegistrationAuthority_NewCertificate_Handler()
      /go/src/github.com/letsencrypt/boulder/ra/proto/ra.pb.go:447 +0x1fb
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:748 +0xf67
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).handleStream()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:942 +0x122a
  github.com/letsencrypt/boulder/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /go/src/github.com/letsencrypt/boulder/vendor/google.golang.org/grpc/server.go:507 +0xb6
```