### PR TITLE
Handle `sql.ErrNoRows` for GetAuthorization correctly.

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,7 +1,6 @@
 package mocks
 
 import (
-	"database/sql"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -232,7 +231,7 @@ func (sa *StorageAuthority) GetAuthorization(_ context.Context, id string) (core
 		return core.Authorization{}, fmt.Errorf("Unspecified database error")
 	}
 
-	return core.Authorization{}, sql.ErrNoRows
+	return core.Authorization{}, berrors.NotFoundError("no authorization found with id %q", id)
 }
 
 // RevokeAuthorizationsByDomain is a mock

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -183,8 +183,9 @@ func (ssa *SQLStorageAuthority) GetAuthorization(ctx context.Context, id string)
 		if err != nil && err != sql.ErrNoRows {
 			return authz, Rollback(tx, err)
 		} else if err == sql.ErrNoRows {
-			rollbackErr := tx.Rollback()
-			if rollbackErr != nil {
+			// Since we have not done any work at this point we can commit the
+			// transaction instead of rolling it back
+			if rollbackErr := tx.Commit(); rollbackErr != nil {
 				return authz, rollbackErr
 			}
 			return authz, err

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1326,5 +1326,5 @@ func TestGetAuthorizationNoRows(t *testing.T) {
 	// An empty authz ID should result in `sql.ErrNoRows`
 	_, err := sa.GetAuthorization(ctx, "")
 	test.AssertError(t, err, "Didn't get an error looking up empty authz ID")
-	test.AssertEquals(t, err, sql.ErrNoRows)
+	test.Assert(t, berrors.Is(err, berrors.NotFound), "GetAuthorization did not return a berrors.NotFound error")
 }

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1316,3 +1316,15 @@ func TestNewOrder(t *testing.T) {
 	test.AssertEquals(t, len(authzIDs), 3)
 	test.AssertDeepEquals(t, authzIDs, []string{"a", "b", "c"})
 }
+
+// TestGetAuthorizationNoRows ensures that the GetAuthorization function returns
+// the correct error when there are no results for the provided ID.
+func TestGetAuthorizationNoRows(t *testing.T) {
+	sa, _, cleanUp := initSA(t)
+	defer cleanUp()
+
+	// An empty authz ID should result in `sql.ErrNoRows`
+	_, err := sa.GetAuthorization(ctx, "")
+	test.AssertError(t, err, "Didn't get an error looking up empty authz ID")
+	test.AssertEquals(t, err, sql.ErrNoRows)
+}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -3,7 +3,6 @@ package wfe
 import (
 	"bytes"
 	"crypto/x509"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1040,7 +1039,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 
 	authz, err := wfe.SA.GetAuthorization(ctx, authorizationID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if berrors.Is(err, berrors.NotFound) {
 			notFound()
 		} else {
 			wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2,7 +2,6 @@ package wfe2
 
 import (
 	"crypto/x509"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -20,6 +19,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/core"
+	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/goodkey"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -586,7 +586,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 
 	authz, err := wfe.SA.GetAuthorization(ctx, authorizationID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if berrors.Is(err, berrors.NotFound) {
 			notFound()
 		} else {
 			wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)


### PR DESCRIPTION
Prior to this commit if the `sa.GetAuthorization` found no pending authz
rows **and** no authz rows for a given authz ID then `sql.ErrNoRows` 
was returned to callers.

This commit changes the SA's `GetAuthorization` function to transform
 `sql.ErrNoRows` into `berrors.NotFound` error. The wfe (and wfe2) are
updated to check for the `GetAuthorization` error being a `berrors.NotFound`
instance and now handle this correctly with a missing response instead of
a server internal error.

Resolves https://github.com/letsencrypt/boulder/issues/3023