### PR TITLE
Add parallelism to expired-authz-purger.

### DIFF
--- a/cmd/expired-authz-purger/config.json
+++ b/cmd/expired-authz-purger/config.json
@@ -6,6 +6,7 @@
         "dbConnectFile": "test/secrets/purger_dburl",
         "maxDBConns": 10,
         "gracePeriod": "168h",
-        "batchSize": 1000
+        "batchSize": 1000,
+        "parallelism": 20
     }
 }

--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -195,7 +195,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Grace period is 0, refusing to purge all pending authorizations")
 		os.Exit(1)
 	}
-	if config.ExpiredAuthzPurger.Parallelism == 0 {
+	if config.ExpiredAuthzPurger.Parallelism < 1 {
 		fmt.Fprintln(os.Stderr, "Parallelism field in config must be set to non-zero")
 		os.Exit(1)
 	}

--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -195,7 +195,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Grace period is 0, refusing to purge all pending authorizations")
 		os.Exit(1)
 	}
-	if config.ExpiredAuthzPurger.Parallelism < 1 {
+	if config.ExpiredAuthzPurger.Parallelism == 0 {
 		fmt.Fprintln(os.Stderr, "Parallelism field in config must be set to non-zero")
 		os.Exit(1)
 	}

--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -200,6 +200,6 @@ func main() {
 		os.Exit(1)
 	}
 	purgeBefore := purger.clk.Now().Add(-config.ExpiredAuthzPurger.GracePeriod.Duration)
-	err = purger.purgeAuthzs(purgeBefore, *yes, config.ExpiredAuthzPurger.Parallelism)
+	err = purger.purgeAuthzs(purgeBefore, *yes, int(config.ExpiredAuthzPurger.Parallelism))
 	cmd.FailOnError(err, "Failed to purge authorizations")
 }

--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -30,7 +30,7 @@ type eapConfig struct {
 
 		GracePeriod cmd.ConfigDuration
 		BatchSize   int
-		Parallelism int
+		Parallelism uint
 
 		Features map[string]bool
 	}

--- a/cmd/expired-authz-purger/main_test.go
+++ b/cmd/expired-authz-purger/main_test.go
@@ -34,7 +34,7 @@ func TestPurgeAuthzs(t *testing.T) {
 
 	p := expiredAuthzPurger{stats, log, fc, dbMap, 1}
 
-	err = p.purgeAuthzs(time.Time{}, true)
+	err = p.purgeAuthzs(time.Time{}, true, 10)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 
 	old, new := fc.Now().Add(-time.Hour), fc.Now().Add(time.Hour)
@@ -59,7 +59,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "NewPendingAuthorization failed")
 
-	err = p.purgeAuthzs(fc.Now(), true)
+	err = p.purgeAuthzs(fc.Now(), true, 10)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err := dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
@@ -68,7 +68,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
 	test.AssertEquals(t, count, int64(1))
 
-	err = p.purgeAuthzs(fc.Now().Add(time.Hour), true)
+	err = p.purgeAuthzs(fc.Now().Add(time.Hour), true, 10)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err = dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")


### PR DESCRIPTION
Fixes #2933

The parallelism code will get executed as part of the existing integration test, with the modified config file.