### PR TITLE
Switch recheckCAA error to Unauthorized.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -742,7 +742,7 @@ func (ra *RegistrationAuthorityImpl) recheckCAA(ctx context.Context, names []str
 			}
 			message = message + pd.Detail
 		}
-		return berrors.ConnectionFailureError(message)
+		return berrors.UnauthorizedError(message)
 	}
 	return nil
 }

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1808,6 +1808,8 @@ func TestRecheckCAAFail(t *testing.T) {
 	err := ra.recheckCAA(context.Background(), names)
 	if err == nil {
 		t.Errorf("expected err, got nil")
+	} else if err.(*berrors.BoulderError).Type != berrors.Unauthorized {
+		t.Errorf("expected Unauthorized, got %v", err.(*berrors.BoulderError).Type)
 	} else if !strings.Contains(err.Error(), "error rechecking CAA for a.com") {
 		t.Errorf("expected error to contain error for a.com, got %q", err)
 	} else if !strings.Contains(err.Error(), "error rechecking CAA for c.com") {


### PR DESCRIPTION
ConnectionFailure is only used during validation, and so isn't handled by WFE's
problemDetailsFromBoulderError. This led to returning ServerInternal instead of
the intended error code, and hiding the error detail. Unauthorized is probably
a better error type for now anyhow, but long-term we should switch to a specific
CAA error type.

This PR will allow clients to see the detailed list of problem domains when
new-cert returns an error due to CAA rechecking.