### PR TITLE
Remove unused error types

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -419,7 +419,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificate(ctx context.Context, issueR
 
 func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, issueReq *caPB.IssueCertificateRequest) (*caPB.IssuePrecertificateResponse, error) {
 	if !ca.enablePrecertificateFlow {
-		return nil, berrors.NotSupportedError("Precertificate flow is disabled")
+		return nil, berrors.InternalServerError("Precertificate flow is disabled")
 	}
 
 	if issueReq.RegistrationID == nil {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -89,21 +89,6 @@ func TestCertificateRequest(t *testing.T) {
 
 // util.go
 
-func TestErrors(t *testing.T) {
-	testMessage := "test"
-	errors := []error{
-		MalformedRequestError(testMessage),
-		UnauthorizedError(testMessage),
-		NotFoundError(testMessage),
-	}
-
-	for i, err := range errors {
-		if msg := err.Error(); msg != testMessage {
-			t.Errorf("Error %d returned unexpected message %v", i, msg)
-		}
-	}
-}
-
 func TestRandomString(t *testing.T) {
 	byteLength := 256
 	b64 := RandomString(byteLength)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -92,7 +92,6 @@ func TestCertificateRequest(t *testing.T) {
 func TestErrors(t *testing.T) {
 	testMessage := "test"
 	errors := []error{
-		NotSupportedError(testMessage),
 		MalformedRequestError(testMessage),
 		UnauthorizedError(testMessage),
 		NotFoundError(testMessage),

--- a/core/util.go
+++ b/core/util.go
@@ -79,9 +79,6 @@ type RateLimitedError string
 // limit
 type TooManyRPCRequestsError string
 
-// BadNonceError indicates an empty of invalid nonce was provided
-type BadNonceError string
-
 func (e InternalServerError) Error() string     { return string(e) }
 func (e NotSupportedError) Error() string       { return string(e) }
 func (e MalformedRequestError) Error() string   { return string(e) }
@@ -91,7 +88,6 @@ func (e LengthRequiredError) Error() string     { return string(e) }
 func (e NoSuchRegistrationError) Error() string { return string(e) }
 func (e RateLimitedError) Error() string        { return string(e) }
 func (e TooManyRPCRequestsError) Error() string { return string(e) }
-func (e BadNonceError) Error() string           { return string(e) }
 
 // Random stuff
 

--- a/core/util.go
+++ b/core/util.go
@@ -54,9 +54,6 @@ func init() {
 // constraints have been violated.
 type InternalServerError string
 
-// NotSupportedError indicates a method is not yet supported
-type NotSupportedError string
-
 // MalformedRequestError indicates the user data was improper
 type MalformedRequestError string
 
@@ -80,7 +77,6 @@ type RateLimitedError string
 type TooManyRPCRequestsError string
 
 func (e InternalServerError) Error() string     { return string(e) }
-func (e NotSupportedError) Error() string       { return string(e) }
 func (e MalformedRequestError) Error() string   { return string(e) }
 func (e UnauthorizedError) Error() string       { return string(e) }
 func (e NotFoundError) Error() string           { return string(e) }

--- a/core/util.go
+++ b/core/util.go
@@ -44,47 +44,6 @@ func init() {
 	expvar.NewString("BuildTime").Set(BuildTime)
 }
 
-// Errors
-
-// InternalServerError indicates that something has gone wrong unrelated to the
-// user's input, and will be considered by the Load Balancer as an indication
-// that this Boulder instance may be malfunctioning. Minimally, returning this
-// will cause an error page to be generated at the CDN/LB for the client.
-// Consequently, you should only use this error when Boulder's internal
-// constraints have been violated.
-type InternalServerError string
-
-// MalformedRequestError indicates the user data was improper
-type MalformedRequestError string
-
-// UnauthorizedError indicates the user did not satisfactorily prove identity
-type UnauthorizedError string
-
-// NotFoundError indicates the destination was unknown. Whoa oh oh ohhh.
-type NotFoundError string
-
-// LengthRequiredError indicates a POST was sent with no Content-Length.
-type LengthRequiredError string
-
-// NoSuchRegistrationError indicates that a registration could not be found.
-type NoSuchRegistrationError string
-
-// RateLimitedError indicates the user has hit a rate limit
-type RateLimitedError string
-
-// TooManyRPCRequestsError indicates an RPC server has hit it's concurrent request
-// limit
-type TooManyRPCRequestsError string
-
-func (e InternalServerError) Error() string     { return string(e) }
-func (e MalformedRequestError) Error() string   { return string(e) }
-func (e UnauthorizedError) Error() string       { return string(e) }
-func (e NotFoundError) Error() string           { return string(e) }
-func (e LengthRequiredError) Error() string     { return string(e) }
-func (e NoSuchRegistrationError) Error() string { return string(e) }
-func (e RateLimitedError) Error() string        { return string(e) }
-func (e TooManyRPCRequestsError) Error() string { return string(e) }
-
 // Random stuff
 
 type randSource interface {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,7 +7,7 @@ type ErrorType int
 
 const (
 	InternalServer ErrorType = iota
-	NotSupported
+	_
 	Malformed
 	Unauthorized
 	NotFound
@@ -46,10 +46,6 @@ func Is(err error, errType ErrorType) bool {
 
 func InternalServerError(msg string, args ...interface{}) error {
 	return New(InternalServer, msg, args...)
-}
-
-func NotSupportedError(msg string, args ...interface{}) error {
-	return New(NotSupported, msg, args...)
 }
 
 func MalformedError(msg string, args ...interface{}) error {

--- a/grpc/bcodes.go
+++ b/grpc/bcodes.go
@@ -26,6 +26,7 @@ const (
 	_
 	RateLimitedError
 	_
+	_
 	InternalServerError
 	ProblemDetails
 )

--- a/grpc/bcodes.go
+++ b/grpc/bcodes.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/probs"
 )
@@ -24,9 +23,9 @@ const (
 	_
 	UnauthorizedError
 	NotFoundError
-	LengthRequiredError
+	__
 	RateLimitedError
-	NoSuchRegistrationError
+	___
 	InternalServerError
 	ProblemDetails
 )
@@ -38,20 +37,6 @@ var (
 
 func errorToCode(err error) codes.Code {
 	switch err.(type) {
-	case core.MalformedRequestError:
-		return MalformedRequestError
-	case core.UnauthorizedError:
-		return UnauthorizedError
-	case core.NotFoundError:
-		return NotFoundError
-	case core.LengthRequiredError:
-		return LengthRequiredError
-	case core.RateLimitedError:
-		return RateLimitedError
-	case core.NoSuchRegistrationError:
-		return NoSuchRegistrationError
-	case core.InternalServerError:
-		return InternalServerError
 	case *probs.ProblemDetails:
 		return ProblemDetails
 	default:
@@ -126,20 +111,6 @@ func unwrapError(err error, md metadata.MD) error {
 	code := grpc.Code(err)
 	errBody := grpc.ErrorDesc(err)
 	switch code {
-	case InternalServerError:
-		return core.InternalServerError(errBody)
-	case MalformedRequestError:
-		return core.MalformedRequestError(errBody)
-	case UnauthorizedError:
-		return core.UnauthorizedError(errBody)
-	case NotFoundError:
-		return core.NotFoundError(errBody)
-	case NoSuchRegistrationError:
-		return core.NoSuchRegistrationError(errBody)
-	case RateLimitedError:
-		return core.RateLimitedError(errBody)
-	case LengthRequiredError:
-		return core.LengthRequiredError(errBody)
 	case ProblemDetails:
 		pd := probs.ProblemDetails{}
 		if json.Unmarshal([]byte(errBody), &pd) != nil {

--- a/grpc/bcodes.go
+++ b/grpc/bcodes.go
@@ -21,12 +21,11 @@ import (
 // TODO(#2507): Deprecated, remove once boulder/errors code is deployed
 const (
 	MalformedRequestError = iota + 100
-	NotSupportedError
+	_
 	UnauthorizedError
 	NotFoundError
 	LengthRequiredError
 	RateLimitedError
-	BadNonceError
 	NoSuchRegistrationError
 	InternalServerError
 	ProblemDetails
@@ -41,8 +40,6 @@ func errorToCode(err error) codes.Code {
 	switch err.(type) {
 	case core.MalformedRequestError:
 		return MalformedRequestError
-	case core.NotSupportedError:
-		return NotSupportedError
 	case core.UnauthorizedError:
 		return UnauthorizedError
 	case core.NotFoundError:
@@ -51,8 +48,6 @@ func errorToCode(err error) codes.Code {
 		return LengthRequiredError
 	case core.RateLimitedError:
 		return RateLimitedError
-	case core.BadNonceError:
-		return BadNonceError
 	case core.NoSuchRegistrationError:
 		return NoSuchRegistrationError
 	case core.InternalServerError:
@@ -133,8 +128,6 @@ func unwrapError(err error, md metadata.MD) error {
 	switch code {
 	case InternalServerError:
 		return core.InternalServerError(errBody)
-	case NotSupportedError:
-		return core.NotSupportedError(errBody)
 	case MalformedRequestError:
 		return core.MalformedRequestError(errBody)
 	case UnauthorizedError:
@@ -147,8 +140,6 @@ func unwrapError(err error, md metadata.MD) error {
 		return core.RateLimitedError(errBody)
 	case LengthRequiredError:
 		return core.LengthRequiredError(errBody)
-	case BadNonceError:
-		return core.BadNonceError(errBody)
 	case ProblemDetails:
 		pd := probs.ProblemDetails{}
 		if json.Unmarshal([]byte(errBody), &pd) != nil {

--- a/grpc/bcodes.go
+++ b/grpc/bcodes.go
@@ -23,9 +23,9 @@ const (
 	_
 	UnauthorizedError
 	NotFoundError
-	__
+	_
 	RateLimitedError
-	___
+	_
 	InternalServerError
 	ProblemDetails
 )

--- a/grpc/bcodes_test.go
+++ b/grpc/bcodes_test.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -16,13 +15,6 @@ func TestErrors(t *testing.T) {
 		err          error
 		expectedCode codes.Code
 	}{
-		{core.MalformedRequestError("test 1"), MalformedRequestError},
-		{core.UnauthorizedError("test 3"), UnauthorizedError},
-		{core.NotFoundError("test 4"), NotFoundError},
-		{core.LengthRequiredError("test 5"), LengthRequiredError},
-		{core.RateLimitedError("test 7"), RateLimitedError},
-		{core.NoSuchRegistrationError("test 9"), NoSuchRegistrationError},
-		{core.InternalServerError("test 10"), InternalServerError},
 		{&probs.ProblemDetails{Type: probs.ConnectionProblem, Detail: "testing..."}, ProblemDetails},
 	}
 

--- a/grpc/bcodes_test.go
+++ b/grpc/bcodes_test.go
@@ -17,12 +17,10 @@ func TestErrors(t *testing.T) {
 		expectedCode codes.Code
 	}{
 		{core.MalformedRequestError("test 1"), MalformedRequestError},
-		{core.NotSupportedError("test 2"), NotSupportedError},
 		{core.UnauthorizedError("test 3"), UnauthorizedError},
 		{core.NotFoundError("test 4"), NotFoundError},
 		{core.LengthRequiredError("test 5"), LengthRequiredError},
 		{core.RateLimitedError("test 7"), RateLimitedError},
-		{core.BadNonceError("test 8"), BadNonceError},
 		{core.NoSuchRegistrationError("test 9"), NoSuchRegistrationError},
 		{core.InternalServerError("test 10"), InternalServerError},
 		{&probs.ProblemDetails{Type: probs.ConnectionProblem, Detail: "testing..."}, ProblemDetails},

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	testproto "github.com/letsencrypt/boulder/grpc/test_proto"
 	"github.com/letsencrypt/boulder/probs"
@@ -44,7 +43,6 @@ func TestErrorWrapping(t *testing.T) {
 	client := testproto.NewChillerClient(conn)
 
 	for _, tc := range []error{
-		core.MalformedRequestError("yup"),
 		&probs.ProblemDetails{Type: probs.MalformedProblem, Detail: "yup"},
 		berrors.MalformedError("yup"),
 	} {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -464,7 +464,7 @@ func (ra *RegistrationAuthorityImpl) checkInvalidAuthorizationLimit(ctx context.
 	noKey := ""
 	if *count.Count >= int64(limit.GetThreshold(noKey, regID)) {
 		ra.log.Info(fmt.Sprintf("Rate limit exceeded, InvalidAuthorizationsByRegID, regID: %d", regID))
-		return berrors.RateLimitedError("Too many invalid authorizations recently.")
+		return berrors.RateLimitError("Too many invalid authorizations recently.")
 	}
 	return nil
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -464,7 +464,7 @@ func (ra *RegistrationAuthorityImpl) checkInvalidAuthorizationLimit(ctx context.
 	noKey := ""
 	if *count.Count >= int64(limit.GetThreshold(noKey, regID)) {
 		ra.log.Info(fmt.Sprintf("Rate limit exceeded, InvalidAuthorizationsByRegID, regID: %d", regID))
-		return core.RateLimitedError("Too many invalid authorizations recently.")
+		return berrors.RateLimitedError("Too many invalid authorizations recently.")
 	}
 	return nil
 }

--- a/wfe/probs.go
+++ b/wfe/probs.go
@@ -11,14 +11,6 @@ import (
 
 func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs.ProblemDetails {
 	switch err.Type {
-	case berrors.NotSupported:
-		return &probs.ProblemDetails{
-			Type:       probs.ServerInternalProblem,
-			Detail:     fmt.Sprintf("%s :: %s", msg, err),
-			HTTPStatus: http.StatusNotImplemented,
-		}
-	case berrors.ConnectionFailure:
-		return probs.ConnectionFailure(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.Malformed:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.Unauthorized:

--- a/wfe/probs.go
+++ b/wfe/probs.go
@@ -17,6 +17,8 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 			Detail:     fmt.Sprintf("%s :: %s", msg, err),
 			HTTPStatus: http.StatusNotImplemented,
 		}
+	case berrors.ConnectionFailure:
+		return probs.ConnectionFailure(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.Malformed:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.Unauthorized:
@@ -54,12 +56,6 @@ func problemDetailsForError(err error, msg string) *probs.ProblemDetails {
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case core.MalformedRequestError:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
-	case core.NotSupportedError:
-		return &probs.ProblemDetails{
-			Type:       probs.ServerInternalProblem,
-			Detail:     fmt.Sprintf("%s :: %s", msg, err),
-			HTTPStatus: http.StatusNotImplemented,
-		}
 	case core.UnauthorizedError:
 		return probs.Unauthorized(fmt.Sprintf("%s :: %s", msg, err))
 	case core.NotFoundError:
@@ -70,8 +66,6 @@ func problemDetailsForError(err error, msg string) *probs.ProblemDetails {
 		return prob
 	case core.RateLimitedError:
 		return probs.RateLimited(fmt.Sprintf("%s :: %s", msg, err))
-	case core.BadNonceError:
-		return probs.BadNonce(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe/probs.go
+++ b/wfe/probs.go
@@ -2,9 +2,7 @@ package wfe
 
 import (
 	"fmt"
-	"net/http"
 
-	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/probs"
 )
@@ -46,18 +44,6 @@ func problemDetailsForError(err error, msg string) *probs.ProblemDetails {
 		return problemDetailsForBoulderError(e, msg)
 	case signatureValidationError:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
-	case core.MalformedRequestError:
-		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
-	case core.UnauthorizedError:
-		return probs.Unauthorized(fmt.Sprintf("%s :: %s", msg, err))
-	case core.NotFoundError:
-		return probs.NotFound(fmt.Sprintf("%s :: %s", msg, err))
-	case core.LengthRequiredError:
-		prob := probs.Malformed("missing Content-Length header")
-		prob.HTTPStatus = http.StatusLengthRequired
-		return prob
-	case core.RateLimitedError:
-		return probs.RateLimited(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe/probs_test.go
+++ b/wfe/probs_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
@@ -27,17 +26,7 @@ func TestProblemDetailsFromError(t *testing.T) {
 		problem    probs.ProblemType
 		detail     string
 	}{
-		// boulder/core error types:
-		//   Internal server errors expect just the `errMsg` in detail.
-		{core.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
-		//   Other errors expect the full detail message
-		{core.MalformedRequestError(detailMsg), 400, probs.MalformedProblem, fullDetail},
-		{core.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
-		{core.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},
 		{signatureValidationError(detailMsg), 400, probs.MalformedProblem, fullDetail},
-		{core.RateLimitedError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
-		//    The content length error has its own specific detail message
-		{core.LengthRequiredError(detailMsg), 411, probs.MalformedProblem, "missing Content-Length header"},
 		// boulder/errors error types
 		//   Internal server errors expect just the `errMsg` in detail.
 		{berrors.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},

--- a/wfe/probs_test.go
+++ b/wfe/probs_test.go
@@ -31,26 +31,24 @@ func TestProblemDetailsFromError(t *testing.T) {
 		//   Internal server errors expect just the `errMsg` in detail.
 		{core.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
 		//   Other errors expect the full detail message
-		{core.NotSupportedError(detailMsg), 501, probs.ServerInternalProblem, fullDetail},
 		{core.MalformedRequestError(detailMsg), 400, probs.MalformedProblem, fullDetail},
 		{core.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
 		{core.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},
 		{signatureValidationError(detailMsg), 400, probs.MalformedProblem, fullDetail},
 		{core.RateLimitedError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
-		{core.BadNonceError(detailMsg), 400, probs.BadNonceProblem, fullDetail},
 		//    The content length error has its own specific detail message
 		{core.LengthRequiredError(detailMsg), 411, probs.MalformedProblem, "missing Content-Length header"},
 		// boulder/errors error types
 		//   Internal server errors expect just the `errMsg` in detail.
 		{berrors.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
 		//   Other errors expect the full detail message
-		{berrors.NotSupportedError(detailMsg), 501, probs.ServerInternalProblem, fullDetail},
 		{berrors.MalformedError(detailMsg), 400, probs.MalformedProblem, fullDetail},
 		{berrors.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
 		{berrors.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},
 		{berrors.RateLimitError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
 		{berrors.InvalidEmailError(detailMsg), 400, probs.InvalidEmailProblem, fullDetail},
 		{berrors.RejectedIdentifierError(detailMsg), 400, probs.RejectedIdentifierProblem, fullDetail},
+		{berrors.ConnectionFailureError(detailMsg), 400, probs.ConnectionProblem, fullDetail},
 	}
 	for _, c := range testCases {
 		p := problemDetailsForError(c.err, errMsg)

--- a/wfe/probs_test.go
+++ b/wfe/probs_test.go
@@ -48,7 +48,6 @@ func TestProblemDetailsFromError(t *testing.T) {
 		{berrors.RateLimitError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
 		{berrors.InvalidEmailError(detailMsg), 400, probs.InvalidEmailProblem, fullDetail},
 		{berrors.RejectedIdentifierError(detailMsg), 400, probs.RejectedIdentifierProblem, fullDetail},
-		{berrors.ConnectionFailureError(detailMsg), 400, probs.ConnectionProblem, fullDetail},
 	}
 	for _, c := range testCases {
 		p := problemDetailsForError(c.err, errMsg)

--- a/wfe2/probs.go
+++ b/wfe2/probs.go
@@ -52,12 +52,6 @@ func problemDetailsForError(err error, msg string) *probs.ProblemDetails {
 		return problemDetailsForBoulderError(e, msg)
 	case core.MalformedRequestError:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
-	case core.NotSupportedError:
-		return &probs.ProblemDetails{
-			Type:       probs.ServerInternalProblem,
-			Detail:     fmt.Sprintf("%s :: %s", msg, err),
-			HTTPStatus: http.StatusNotImplemented,
-		}
 	case core.UnauthorizedError:
 		return probs.Unauthorized(fmt.Sprintf("%s :: %s", msg, err))
 	case core.NotFoundError:
@@ -68,8 +62,6 @@ func problemDetailsForError(err error, msg string) *probs.ProblemDetails {
 		return prob
 	case core.RateLimitedError:
 		return probs.RateLimited(fmt.Sprintf("%s :: %s", msg, err))
-	case core.BadNonceError:
-		return probs.BadNonce(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe2/probs.go
+++ b/wfe2/probs.go
@@ -11,12 +11,6 @@ import (
 
 func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs.ProblemDetails {
 	switch err.Type {
-	case berrors.NotSupported:
-		return &probs.ProblemDetails{
-			Type:       probs.ServerInternalProblem,
-			Detail:     fmt.Sprintf("%s :: %s", msg, err),
-			HTTPStatus: http.StatusNotImplemented,
-		}
 	case berrors.Malformed:
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.Unauthorized:

--- a/wfe2/probs.go
+++ b/wfe2/probs.go
@@ -2,9 +2,7 @@ package wfe2
 
 import (
 	"fmt"
-	"net/http"
 
-	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/probs"
 )
@@ -44,18 +42,6 @@ func problemDetailsForError(err error, msg string) *probs.ProblemDetails {
 		return e
 	case *berrors.BoulderError:
 		return problemDetailsForBoulderError(e, msg)
-	case core.MalformedRequestError:
-		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
-	case core.UnauthorizedError:
-		return probs.Unauthorized(fmt.Sprintf("%s :: %s", msg, err))
-	case core.NotFoundError:
-		return probs.NotFound(fmt.Sprintf("%s :: %s", msg, err))
-	case core.LengthRequiredError:
-		prob := probs.Malformed("missing Content-Length header")
-		prob.HTTPStatus = http.StatusLengthRequired
-		return prob
-	case core.RateLimitedError:
-		return probs.RateLimited(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe2/probs_test.go
+++ b/wfe2/probs_test.go
@@ -31,19 +31,16 @@ func TestProblemDetailsFromError(t *testing.T) {
 		//   Internal server errors expect just the `errMsg` in detail.
 		{core.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
 		//   Other errors expect the full detail message
-		{core.NotSupportedError(detailMsg), 501, probs.ServerInternalProblem, fullDetail},
 		{core.MalformedRequestError(detailMsg), 400, probs.MalformedProblem, fullDetail},
 		{core.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
 		{core.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},
 		{core.RateLimitedError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
-		{core.BadNonceError(detailMsg), 400, probs.BadNonceProblem, fullDetail},
 		//    The content length error has its own specific detail message
 		{core.LengthRequiredError(detailMsg), 411, probs.MalformedProblem, "missing Content-Length header"},
 		// boulder/errors error types
 		//   Internal server errors expect just the `errMsg` in detail.
 		{berrors.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
 		//   Other errors expect the full detail message
-		{berrors.NotSupportedError(detailMsg), 501, probs.ServerInternalProblem, fullDetail},
 		{berrors.MalformedError(detailMsg), 400, probs.MalformedProblem, fullDetail},
 		{berrors.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
 		{berrors.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},

--- a/wfe2/probs_test.go
+++ b/wfe2/probs_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
@@ -27,16 +26,6 @@ func TestProblemDetailsFromError(t *testing.T) {
 		problem    probs.ProblemType
 		detail     string
 	}{
-		// boulder/core error types:
-		//   Internal server errors expect just the `errMsg` in detail.
-		{core.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},
-		//   Other errors expect the full detail message
-		{core.MalformedRequestError(detailMsg), 400, probs.MalformedProblem, fullDetail},
-		{core.UnauthorizedError(detailMsg), 403, probs.UnauthorizedProblem, fullDetail},
-		{core.NotFoundError(detailMsg), 404, probs.MalformedProblem, fullDetail},
-		{core.RateLimitedError(detailMsg), 429, probs.RateLimitedProblem, fullDetail},
-		//    The content length error has its own specific detail message
-		{core.LengthRequiredError(detailMsg), 411, probs.MalformedProblem, "missing Content-Length header"},
 		// boulder/errors error types
 		//   Internal server errors expect just the `errMsg` in detail.
 		{berrors.InternalServerError(detailMsg), 500, probs.ServerInternalProblem, errMsg},


### PR DESCRIPTION
- Remove all of the errors under `core`. Their purpose is now served by `errors`, and they were almost entirely unused. The remaining uses were switched to `errors`.
- Remove `errors.NotSupportedError`. It was used in only one place (`ca.go`), and that usage is more appropriately a `ServerInternal` error.