### PR TITLE
Add CAA-specific error.

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -84,3 +84,4 @@ func WrongAuthorizationStateError(msg string, args ...interface{}) error {
 
 func CAAError(msg string, args ...interface{}) error {
 	return New(CAA, msg, args...)
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,6 +15,7 @@ const (
 	RejectedIdentifier
 	InvalidEmail
 	ConnectionFailure
+	CAA
 )
 
 // BoulderError represents internal Boulder errors
@@ -74,4 +75,8 @@ func InvalidEmailError(msg string, args ...interface{}) error {
 
 func ConnectionFailureError(msg string, args ...interface{}) error {
 	return New(ConnectionFailure, msg, args...)
+}
+
+func CAAError(msg string, args ...interface{}) error {
+	return New(CAA, msg, args...)
 }

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -18,6 +18,7 @@ const (
 	InvalidEmailProblem        = ProblemType("invalidEmail")
 	RejectedIdentifierProblem  = ProblemType("rejectedIdentifier")
 	AccountDoesNotExistProblem = ProblemType("accountDoesNotExist")
+	CAAProblem                 = ProblemType("caa")
 
 	V1ErrorNS = "urn:acme:error:"
 	V2ErrorNS = "urn:ietf:params:acme:error:"
@@ -64,7 +65,9 @@ func ProblemDetailsToStatusCode(prob *ProblemDetails) int {
 		return http.StatusBadRequest
 	case ServerInternalProblem:
 		return http.StatusInternalServerError
-	case UnauthorizedProblem:
+	case
+		UnauthorizedProblem,
+		CAAProblem:
 		return http.StatusForbidden
 	case RateLimitedProblem:
 		return statusTooManyRequests
@@ -220,5 +223,14 @@ func AccountDoesNotExist(detail string) *ProblemDetails {
 		Type:       AccountDoesNotExistProblem,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// CAA returns a ProblemDetails representing a CAAProblem
+func CAA(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       CAAProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusForbidden,
 	}
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -742,7 +742,7 @@ func (ra *RegistrationAuthorityImpl) recheckCAA(ctx context.Context, names []str
 			}
 			message = message + pd.Detail
 		}
-		return berrors.UnauthorizedError(message)
+		return berrors.CAAError(message)
 	}
 	return nil
 }

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1790,8 +1790,8 @@ func TestRecheckCAAFail(t *testing.T) {
 	err := ra.recheckCAA(context.Background(), names)
 	if err == nil {
 		t.Errorf("expected err, got nil")
-	} else if err.(*berrors.BoulderError).Type != berrors.Unauthorized {
-		t.Errorf("expected Unauthorized, got %v", err.(*berrors.BoulderError).Type)
+	} else if err.(*berrors.BoulderError).Type != berrors.CAA {
+		t.Errorf("expected CAA error, got %v", err.(*berrors.BoulderError).Type)
 	} else if !strings.Contains(err.Error(), "error rechecking CAA for a.com") {
 		t.Errorf("expected error to contain error for a.com, got %q", err)
 	} else if !strings.Contains(err.Error(), "error rechecking CAA for c.com") {

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -237,7 +237,7 @@ def test_caa():
     """Request issuance for two CAA domains, one where we are permitted and one where we are not."""
     auth_and_issue(["good-caa-reserved.com"])
 
-    chisel.expect_problem("urn:acme:error:connection",
+    chisel.expect_problem("urn:acme:error:caa",
         lambda: auth_and_issue(["bad-caa-reserved.com"]))
 
 def run(cmd, **kwargs):

--- a/va/caa.go
+++ b/va/caa.go
@@ -46,7 +46,7 @@ func (va *ValidationAuthorityImpl) checkCAA(ctx context.Context, identifier core
 		valid,
 	))
 	if !valid {
-		return probs.ConnectionFailure(fmt.Sprintf("CAA record for %s prevents issuance", identifier.Value))
+		return probs.CAA(fmt.Sprintf("CAA record for %s prevents issuance", identifier.Value))
 	}
 	return nil
 }

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -97,7 +97,7 @@ func TestCAAFailure(t *testing.T) {
 	va, _ := setup(hs, 0)
 
 	_, prob := va.validateChallengeAndCAA(ctx, dnsi("reserved.com"), chall)
-	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
+	test.AssertEquals(t, prob.Type, probs.CAAProblem)
 }
 
 func TestParseResults(t *testing.T) {

--- a/wfe/probs.go
+++ b/wfe/probs.go
@@ -25,6 +25,8 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		return probs.RejectedIdentifier(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.InvalidEmail:
 		return probs.InvalidEmail(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.CAA:
+		return probs.CAA(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe2/probs.go
+++ b/wfe2/probs.go
@@ -25,6 +25,8 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		return probs.RejectedIdentifier(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.InvalidEmail:
 		return probs.InvalidEmail(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.CAA:
+		return probs.CAA(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.


### PR DESCRIPTION
Previously, CAA problems were lumped in under "ConnectionProblem" or
"Unauthorized". This should make things clearer and easier to differentiate.

Fixes #3043 