### PR TITLE
Filter spurious shutdown errors.

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -184,7 +184,7 @@ func main() {
 		caWrapper := bgrpc.NewCertificateAuthorityServer(cai)
 		caPB.RegisterCertificateAuthorityServer(s, caWrapper)
 		go func() {
-			err = s.Serve(l)
+			err = cmd.FilterShutdownErrors(s.Serve(l))
 			cmd.FailOnError(err, "CA gRPC service failed")
 		}()
 		caSrv = s
@@ -196,7 +196,7 @@ func main() {
 		caWrapper := bgrpc.NewCertificateAuthorityServer(cai)
 		caPB.RegisterOCSPGeneratorServer(s, caWrapper)
 		go func() {
-			err = s.Serve(l)
+			err = cmd.FilterShutdownErrors(s.Serve(l))
 			cmd.FailOnError(err, "OCSPGenerator gRPC service failed")
 		}()
 		ocspSrv = s

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -95,7 +95,7 @@ func main() {
 		gw := bgrpc.NewPublisherServerWrapper(pubi)
 		pubPB.RegisterPublisherServer(s, gw)
 		go func() {
-			err = s.Serve(l)
+			err = cmd.FilterShutdownErrors(s.Serve(l))
 			cmd.FailOnError(err, "Publisher gRPC service failed")
 		}()
 		grpcSrv = s

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -223,7 +223,7 @@ func main() {
 		gw := bgrpc.NewRegistrationAuthorityServer(rai)
 		rapb.RegisterRegistrationAuthorityServer(grpcSrv, gw)
 		go func() {
-			err = grpcSrv.Serve(listener)
+			err = cmd.FilterShutdownErrors(grpcSrv.Serve(listener))
 			cmd.FailOnError(err, "RA gRPC service failed")
 		}()
 	}

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -68,7 +68,7 @@ func main() {
 		gw := bgrpc.NewStorageAuthorityServer(sai)
 		sapb.RegisterStorageAuthorityServer(grpcSrv, gw)
 		go func() {
-			err = grpcSrv.Serve(listener)
+			err = cmd.FilterShutdownErrors(grpcSrv.Serve(listener))
 			cmd.FailOnError(err, "SA gRPC service failed")
 		}()
 	}

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -151,7 +151,7 @@ func main() {
 	vaPB.RegisterCAAServer(grpcSrv, vai)
 	cmd.FailOnError(err, "Unable to register CAA gRPC server")
 	go func() {
-		err = grpcSrv.Serve(l)
+		err = cmd.FilterShutdownErrors(grpcSrv.Serve(l))
 		cmd.FailOnError(err, "VA gRPC service failed")
 	}()
 

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -162,14 +162,11 @@ def check():
 
 @atexit.register
 def stop():
-    # When we are about to exit, send SIGKILL to each subprocess and wait for
+    # When we are about to exit, send SIGTERM to each subprocess and wait for
     # them to nicely die. This reflects the restart process in prod and allows
     # us to exercise the graceful shutdown code paths.
-    # TODO(jsha): Switch to SIGTERM once we fix
-    # https://github.com/letsencrypt/boulder/issues/2410 and remove AMQP, to
-    # make shutdown less noisy.
     for p in processes:
         if p.poll() is None:
-            p.send_signal(signal.SIGKILL)
+            p.send_signal(signal.SIGTERM)
     for p in processes:
         p.wait()


### PR DESCRIPTION
Previously, we would produce an error an a nonzero status code on shutdown,
because gRPC's GracefulStop would cause s.Serve() to return an error. Now we
filter that specific error and treat it as success. This also allows us to kill
process with SIGTERM instead of SIGKILL in integration tests.

Fixes #2410.