### PR TITLE
Fix a bad error return in RA

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -359,9 +359,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, init c
 	// Store the authorization object, then return it
 	reg, err := ra.SA.NewRegistration(ctx, reg)
 	if err != nil {
-		// berrors.InternalServerError since the user-data was validated before being
-		// passed to the SA.
-		err = berrors.InternalServerError(err.Error())
+		return core.Registration{}, err
 	}
 
 	ra.stats.Inc("NewRegistrations", 1)


### PR DESCRIPTION
RA.NewRegistration checked for an error return from
SA.NewRegistration, but failed to properly propagate
the error. It was just setting the `err` variable and falling
through to the successful return case. This fixes that
issue and adds a unittest.