### PR TITLE
Add verifyPOST and NewReg tests when GetRegByKey fails

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -463,16 +463,20 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		return
 	}
 
-	if existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, key); err == nil {
+	existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, key)
+	if err == nil {
 		response.Header().Set("Location",
 			wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
 		// TODO(#595): check for missing account err
 		wfe.sendError(response, logEvent, probs.Conflict("Account key is already in use"), err)
 		return
+	} else if !berrors.Is(err, berrors.NotFound) {
+		wfe.sendError(response, logEvent, probs.ServerInternal("failed check for existing account"), nil)
+		return
 	}
 
 	var init core.Registration
-	err := json.Unmarshal(body, &init)
+	err = json.Unmarshal(body, &init)
 	if err != nil {
 		wfe.sendError(response, logEvent, probs.Malformed("Error unmarshaling JSON"), err)
 		return

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2187,3 +2187,50 @@ func TestRevokeCertificateWithAuthz(t *testing.T) {
 	test.AssertEquals(t, responseWriter.Code, 200)
 	test.AssertEquals(t, responseWriter.Body.String(), "")
 }
+
+type mockSAGetRegByKeyFails struct {
+	core.StorageGetter
+}
+
+func (sa *mockSAGetRegByKeyFails) GetRegistrationByKey(ctx context.Context, jwk *jose.JSONWebKey) (core.Registration, error) {
+	return core.Registration{}, fmt.Errorf("whoops")
+}
+
+// When SA.GetRegistrationByKey errors (e.g. gRPC timeout), NewAccount should
+// return internal server errors.
+func TestNewAccountWhenGetRegByKeyFails(t *testing.T) {
+	wfe, fc := setupWFE(t)
+	wfe.SA = &mockSAGetRegByKeyFails{mocks.NewStorageAuthority(fc)}
+	payload := `{"contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`
+	responseWriter := httptest.NewRecorder()
+	request := signAndPost(t, "/new-account", "http://localhost/new-account", payload, 1, wfe.nonceService)
+	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
+	var prob probs.ProblemDetails
+	err := json.Unmarshal(responseWriter.Body.Bytes(), &prob)
+	test.AssertNotError(t, err, "unmarshalling response")
+	if prob.Type != probs.V2ErrorNS+probs.ServerInternalProblem {
+		t.Errorf("Wrong type for returned problem: %#v", prob.Type)
+	}
+}
+
+type mockSAGetRegByKeyNotFound struct {
+	core.StorageGetter
+}
+
+func (sa *mockSAGetRegByKeyNotFound) GetRegistrationByKey(ctx context.Context, jwk *jose.JSONWebKey) (core.Registration, error) {
+	return core.Registration{}, berrors.NotFoundError("not found")
+}
+
+// When SA.GetRegistrationByKey returns NotFound, NewAccount should
+// succeed.
+func TestNewAccountWhenGetRegByKeyNotFound(t *testing.T) {
+	wfe, fc := setupWFE(t)
+	wfe.SA = &mockSAGetRegByKeyNotFound{mocks.NewStorageAuthority(fc)}
+	payload := `{"contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`
+	responseWriter := httptest.NewRecorder()
+	request := signAndPost(t, "/new-account", "http://localhost/new-account", payload, 1, wfe.nonceService)
+	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
+	if responseWriter.Code != http.StatusCreated {
+		t.Errorf("Bad response to NewRegistration: %d, %s", responseWriter.Code, responseWriter.Body)
+	}
+}


### PR DESCRIPTION
I thought there was a bug in NewRegistration when GetRegByKey returns an error, so I wrote a unittest... and discovered it works correctly. Oh well, now we have more tests!