### PR TITLE
Stop logging request-id

### DIFF
--- a/wfe/context.go
+++ b/wfe/context.go
@@ -8,12 +8,10 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 )
 
 type requestEvent struct {
-	ID            string    `json:",omitempty"`
 	RealIP        string    `json:",omitempty"`
 	Endpoint      string    `json:",omitempty"`
 	Method        string    `json:",omitempty"`
@@ -51,13 +49,11 @@ type topHandler struct {
 
 func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logEvent := &requestEvent{
-		ID:        core.NewToken(),
 		RealIP:    r.Header.Get("X-Real-IP"),
 		Method:    r.Method,
 		UserAgent: r.Header.Get("User-Agent"),
 		Extra:     make(map[string]interface{}, 0),
 	}
-	w.Header().Set("Boulder-Request-ID", logEvent.ID)
 	defer th.logEvent(logEvent)
 
 	th.wfe.ServeHTTP(logEvent, w, r)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2099,20 +2099,6 @@ func TestVerifyPOSTInvalidJWK(t *testing.T) {
 	test.AssertEquals(t, http.StatusBadRequest, prob.HTTPStatus)
 }
 
-func TestHeaderBoulderRequestId(t *testing.T) {
-	wfe, _ := setupWFE(t)
-	mux := wfe.Handler()
-	responseWriter := httptest.NewRecorder()
-
-	mux.ServeHTTP(responseWriter, &http.Request{
-		Method: "GET",
-		URL:    mustParseURL(directoryPath),
-	})
-
-	requestID := responseWriter.Header().Get("Boulder-Request-ID")
-	test.Assert(t, len(requestID) > 0, "Boulder-Request-ID header is empty")
-}
-
 func TestHeaderBoulderRequester(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()

--- a/wfe2/context.go
+++ b/wfe2/context.go
@@ -8,12 +8,10 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 )
 
 type requestEvent struct {
-	ID            string    `json:",omitempty"`
 	RealIP        string    `json:",omitempty"`
 	Endpoint      string    `json:",omitempty"`
 	Method        string    `json:",omitempty"`
@@ -51,13 +49,11 @@ type topHandler struct {
 
 func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logEvent := &requestEvent{
-		ID:        core.NewToken(),
 		RealIP:    r.Header.Get("X-Real-IP"),
 		Method:    r.Method,
 		UserAgent: r.Header.Get("User-Agent"),
 		Extra:     make(map[string]interface{}, 0),
 	}
-	w.Header().Set("Boulder-Request-ID", logEvent.ID)
 	defer th.logEvent(logEvent)
 
 	th.wfe.ServeHTTP(logEvent, w, r)

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1567,20 +1567,6 @@ func newRequestEvent() *requestEvent {
 	return &requestEvent{Extra: make(map[string]interface{})}
 }
 
-func TestHeaderBoulderRequestId(t *testing.T) {
-	wfe, _ := setupWFE(t)
-	mux := wfe.Handler()
-	responseWriter := httptest.NewRecorder()
-
-	mux.ServeHTTP(responseWriter, &http.Request{
-		Method: "GET",
-		URL:    mustParseURL(directoryPath),
-	})
-
-	requestID := responseWriter.Header().Get("Boulder-Request-ID")
-	test.Assert(t, len(requestID) > 0, "Boulder-Request-ID header is empty")
-}
-
 func TestHeaderBoulderRequester(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()


### PR DESCRIPTION
We originally planned to use this to match up logs across multiple systems, but we don't currently use it, and it chews up a lot of space in our logs. We can add it back in later if/when we want to start doing that correlation.