### PR TITLE
Implement legacy form of CAA

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -147,7 +147,7 @@ var (
 type DNSClient interface {
 	LookupTXT(context.Context, string) (txts []string, authorities []string, err error)
 	LookupHost(context.Context, string) ([]net.IP, error)
-	LookupCAA(context.Context, string) ([]*dns.CAA, error)
+	LookupCAA(context.Context, string) ([]*dns.CAA, []*dns.CNAME, error)
 	LookupMX(context.Context, string) ([]string, error)
 }
 
@@ -432,11 +432,11 @@ func (dnsClient *DNSClientImpl) LookupHost(ctx context.Context, hostname string)
 
 // LookupCAA sends a DNS query to find all CAA records associated with
 // the provided hostname.
-func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, error) {
+func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, []*dns.CNAME, error) {
 	dnsType := dns.TypeCAA
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
 	if err != nil {
-		return nil, &DNSError{dnsType, hostname, err, -1}
+		return nil, nil, &DNSError{dnsType, hostname, err, -1}
 	}
 
 	// If the resolver returns SERVFAIL for a certain list of FQDNs, return an
@@ -445,24 +445,27 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 	// That is since fixed, but we have a handful of other domains that still return
 	// SERVFAIL, but will need certificate renewals. After a suitable notice
 	// period we will remove these exceptions.
-	var CAAs []*dns.CAA
 	if r.Rcode == dns.RcodeServerFailure {
 		if dnsClient.caaSERVFAILExceptions == nil ||
 			dnsClient.caaSERVFAILExceptions[hostname] {
-			return nil, nil
+			return nil, nil, nil
 		} else {
-			return nil, &DNSError{dnsType, hostname, nil, r.Rcode}
+			return nil, nil, &DNSError{dnsType, hostname, nil, r.Rcode}
 		}
 	}
 
+	var CAAs []*dns.CAA
+	var CNAMEs []*dns.CNAME
 	for _, answer := range r.Answer {
 		if answer.Header().Rrtype == dnsType {
 			if caaR, ok := answer.(*dns.CAA); ok {
 				CAAs = append(CAAs, caaR)
+			} else if cnameR, ok := answer.(*dns.CNAME); ok {
+				CNAMEs = append(CNAMEs, cnameR)
 			}
 		}
 	}
-	return CAAs, nil
+	return CAAs, CNAMEs, nil
 }
 
 // LookupMX sends a DNS query to find a MX record associated hostname and returns the

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -431,7 +431,8 @@ func (dnsClient *DNSClientImpl) LookupHost(ctx context.Context, hostname string)
 }
 
 // LookupCAA sends a DNS query to find all CAA records associated with
-// the provided hostname.
+// the provided hostname. It also returns all CNAMEs that were part of the
+// response, for using in CAA tree climbing.
 func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, []*dns.CNAME, error) {
 	dnsType := dns.TypeCAA
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -257,7 +257,7 @@ func TestDNSLookupsNoServer(t *testing.T) {
 	_, err = obj.LookupHost(context.Background(), "letsencrypt.org")
 	test.AssertError(t, err, "No servers")
 
-	_, err = obj.LookupCAA(context.Background(), "letsencrypt.org")
+	_, _, err = obj.LookupCAA(context.Background(), "letsencrypt.org")
 	test.AssertError(t, err, "No servers")
 }
 
@@ -273,18 +273,18 @@ func TestDNSServFail(t *testing.T) {
 
 	// CAA lookup ignores validation failures from the resolver for now
 	// and returns an empty list of CAA records.
-	emptyCaa, err := obj.LookupCAA(context.Background(), bad)
+	emptyCaa, _, err := obj.LookupCAA(context.Background(), bad)
 	test.Assert(t, len(emptyCaa) == 0, "Query returned non-empty list of CAA records")
 	test.AssertNotError(t, err, "LookupCAA returned an error")
 
 	// When we turn on enforceCAASERVFAIL, such lookups should fail.
 	obj.caaSERVFAILExceptions = map[string]bool{"servfailexception.example.com": true}
-	emptyCaa, err = obj.LookupCAA(context.Background(), bad)
+	emptyCaa, _, err = obj.LookupCAA(context.Background(), bad)
 	test.Assert(t, len(emptyCaa) == 0, "Query returned non-empty list of CAA records")
 	test.AssertError(t, err, "LookupCAA should have returned an error")
 
 	// Unless they are on the exception list
-	emptyCaa, err = obj.LookupCAA(context.Background(), "servfailexception.example.com")
+	emptyCaa, _, err = obj.LookupCAA(context.Background(), "servfailexception.example.com")
 	test.Assert(t, len(emptyCaa) == 0, "Query returned non-empty list of CAA records")
 	test.AssertNotError(t, err, "LookupCAA for servfail exception returned an error")
 }
@@ -390,15 +390,15 @@ func TestDNSNXDOMAIN(t *testing.T) {
 func TestDNSLookupCAA(t *testing.T) {
 	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
 
-	caas, err := obj.LookupCAA(context.Background(), "bracewel.net")
+	caas, _, err := obj.LookupCAA(context.Background(), "bracewel.net")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should have CAA records")
 
-	caas, err = obj.LookupCAA(context.Background(), "nonexistent.letsencrypt.org")
+	caas, _, err = obj.LookupCAA(context.Background(), "nonexistent.letsencrypt.org")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) == 0, "Shouldn't have CAA records")
 
-	caas, err = obj.LookupCAA(context.Background(), "cname.example.com")
+	caas, _, err = obj.LookupCAA(context.Background(), "cname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")
 }

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -101,6 +101,11 @@ func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.C
 		cnameRecord.Hdr = dns.RR_Header{Name: "cname-to-reserved.com"}
 		cnameRecord.Target = "reserved.com"
 		return nil, []*dns.CNAME{cnameRecord}, nil
+	case "cname-to-child-of-reserved.com":
+		cnameRecord := new(dns.CNAME)
+		cnameRecord.Hdr = dns.RR_Header{Name: "cname-to-reserved.com"}
+		cnameRecord.Target = "www.reserved.com"
+		return nil, []*dns.CNAME{cnameRecord}, nil
 	case "reserved.com":
 		record.Tag = "issue"
 		record.Value = "ca.com"

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -96,6 +96,11 @@ func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.C
 	switch strings.TrimRight(domain, ".") {
 	case "caa-timeout.com":
 		return nil, nil, &DNSError{dns.TypeCAA, "always.timeout", MockTimeoutError(), -1}
+	case "deep-cname.not-present.com":
+		cnameRecord := new(dns.CNAME)
+		cnameRecord.Hdr = dns.RR_Header{Name: domain}
+		cnameRecord.Target = "target.not-present.com"
+		return nil, []*dns.CNAME{cnameRecord}, nil
 	case "deep-cname.present-with-parameter.com":
 		cnameRecord := new(dns.CNAME)
 		cnameRecord.Hdr = dns.RR_Header{Name: domain}

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -105,7 +105,21 @@ func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.C
 		cnameRecord := new(dns.CNAME)
 		cnameRecord.Hdr = dns.RR_Header{Name: domain}
 		cnameRecord.Target = "cname-to-reserved.com"
-		return nil, []*dns.CNAME{cnameRecord}, nil
+		return []*dns.CAA{
+				&dns.CAA{
+					Tag:   "issue",
+					Value: "ca.com",
+				},
+			}, []*dns.CNAME{
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: domain},
+					Target: "cname-to-reserved.com",
+				},
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: "cname-to-reserved.com"},
+					Target: "reserved.com",
+				},
+			}, nil
 	case "blog.cname-to-subdomain.com":
 		cnameRecord := new(dns.CNAME)
 		cnameRecord.Hdr = dns.RR_Header{Name: domain}
@@ -115,7 +129,17 @@ func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.C
 		cnameRecord := new(dns.CNAME)
 		cnameRecord.Hdr = dns.RR_Header{Name: domain}
 		cnameRecord.Target = "reserved.com"
-		return nil, []*dns.CNAME{cnameRecord}, nil
+		return []*dns.CAA{
+				&dns.CAA{
+					Tag:   "issue",
+					Value: "ca.com",
+				},
+			}, []*dns.CNAME{
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: domain},
+					Target: "reserved.com",
+				},
+			}, nil
 	case "cname-to-child-of-reserved.com":
 		cnameRecord := new(dns.CNAME)
 		cnameRecord.Hdr = dns.RR_Header{Name: domain}

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -96,19 +96,24 @@ func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.C
 	switch strings.TrimRight(domain, ".") {
 	case "caa-timeout.com":
 		return nil, nil, &DNSError{dns.TypeCAA, "always.timeout", MockTimeoutError(), -1}
+	case "deep-cname.present-with-parameter.com":
+		cnameRecord := new(dns.CNAME)
+		cnameRecord.Hdr = dns.RR_Header{Name: domain}
+		cnameRecord.Target = "cname-to-reserved.com"
+		return nil, []*dns.CNAME{cnameRecord}, nil
 	case "blog.cname-to-subdomain.com":
 		cnameRecord := new(dns.CNAME)
-		cnameRecord.Hdr = dns.RR_Header{Name: "blog.cname-to-subdomain.com"}
+		cnameRecord.Hdr = dns.RR_Header{Name: domain}
 		cnameRecord.Target = "www.blog.cname-to-subdomain.com"
 		return nil, []*dns.CNAME{cnameRecord}, nil
 	case "cname-to-reserved.com":
 		cnameRecord := new(dns.CNAME)
-		cnameRecord.Hdr = dns.RR_Header{Name: "cname-to-reserved.com"}
+		cnameRecord.Hdr = dns.RR_Header{Name: domain}
 		cnameRecord.Target = "reserved.com"
 		return nil, []*dns.CNAME{cnameRecord}, nil
 	case "cname-to-child-of-reserved.com":
 		cnameRecord := new(dns.CNAME)
-		cnameRecord.Hdr = dns.RR_Header{Name: "cname-to-reserved.com"}
+		cnameRecord.Hdr = dns.RR_Header{Name: domain}
 		cnameRecord.Target = "www.reserved.com"
 		return nil, []*dns.CNAME{cnameRecord}, nil
 	case "reserved.com":

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -96,6 +96,11 @@ func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.C
 	switch strings.TrimRight(domain, ".") {
 	case "caa-timeout.com":
 		return nil, nil, &DNSError{dns.TypeCAA, "always.timeout", MockTimeoutError(), -1}
+	case "blog.cname-to-subdomain.com":
+		cnameRecord := new(dns.CNAME)
+		cnameRecord.Hdr = dns.RR_Header{Name: "blog.cname-to-subdomain.com"}
+		cnameRecord.Target = "www.blog.cname-to-subdomain.com"
+		return nil, []*dns.CNAME{cnameRecord}, nil
 	case "cname-to-reserved.com":
 		cnameRecord := new(dns.CNAME)
 		cnameRecord.Hdr = dns.RR_Header{Name: "cname-to-reserved.com"}

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAA"
+const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAALegacyCAA"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231}
+var _FeatureFlag_index = [...]uint8{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231, 240}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -27,6 +27,7 @@ const (
 	DirectoryMeta
 	AllowRenewalFirstRL
 	RecheckCAA
+	LegacyCAA
 )
 
 // List of features and their default value, protected by fMu
@@ -45,6 +46,7 @@ var features = map[FeatureFlag]bool{
 	DirectoryMeta:            false,
 	AllowRenewalFirstRL:      false,
 	RecheckCAA:               false,
+	LegacyCAA:                false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -28,6 +28,7 @@
       "ServerURL": "http://boulder:6000"
     },
     "features": {
+      "LegacyCAA": true,
       "IPv6First": true
     },
     "remoteVAs": [

--- a/va/caa.go
+++ b/va/caa.go
@@ -117,9 +117,11 @@ func parseResults(results []caaResult) (*CAASet, error) {
 	return nil, nil
 }
 
+// withParents returns a list containing the input fqdn, and all parent domains
+// in order.
 func withParents(fqdn string) []string {
 	var result []string
-	labels := strings.Split(fqdn, ".")
+	labels := strings.Split(strings.TrimRight(fqdn, "."), ".")
 	for i := 0; i < len(labels); i++ {
 		result = append(result, strings.Join(labels[i:], "."))
 	}

--- a/va/caa.go
+++ b/va/caa.go
@@ -138,7 +138,13 @@ func parent(fqdn string) string {
 	}
 }
 
-// Implement pre-erratum 5065 style tree-climbing CAA.
+// Implement pre-erratum 5065 style tree-climbing CAA. Note: a strict
+// interpretation of pre-5065 indicates a linear lookup path - if there is any
+// CNAME at all, that precludes further tree-climbing on the original FQDN. This
+// is clearly wrong. We implement a hybrid approach that is strictly more
+// conservative: We always do full tree-climbing on the original FQDN (by virtue
+// of parallelCAALookup. When the LegacyCAA flag is enabled, we also
+// do linear tree climbing on single-level aliases.
 func (va *ValidationAuthorityImpl) treeClimbingLookupCAA(ctx context.Context, fqdn string) ([]*dns.CAA, []*dns.CNAME, error) {
 	target := fqdn
 	// Limit CNAME chasing to break CNAME loops

--- a/va/caa.go
+++ b/va/caa.go
@@ -142,11 +142,11 @@ func (va *ValidationAuthorityImpl) treeClimbingLookupCAA(ctx context.Context, fq
 	return va.treeClimbingLookupCAAWithCount(ctx, fqdn, &maxAttempts)
 }
 
-func (va *ValidationAuthorityImpl) treeClimbingLookupCAAWithCount(ctx context.Context, fqdn string, maxAttempts *int) ([]*dns.CAA, error) {
-	if *maxAttempts < 1 {
+func (va *ValidationAuthorityImpl) treeClimbingLookupCAAWithCount(ctx context.Context, fqdn string, attemptsRemaining *int) ([]*dns.CAA, error) {
+	if *attemptsRemaining < 1 {
 		return nil, fmt.Errorf("too many CNAMEs when looking up CAA")
 	}
-	*maxAttempts--
+	*attemptsRemaining--
 	caas, cnames, err := va.dnsClient.LookupCAA(ctx, fqdn)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (va *ValidationAuthorityImpl) treeClimbingLookupCAAWithCount(ctx context.Co
 			// list.
 			newTargets := parentDomains(cnames[i].Target)
 			for _, newTarget := range newTargets {
-				caas, err := va.treeClimbingLookupCAAWithCount(ctx, newTarget, maxAttempts)
+				caas, err := va.treeClimbingLookupCAAWithCount(ctx, newTarget, attemptsRemaining)
 				if len(caas) != 0 || err != nil {
 					return caas, err
 				}

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -23,6 +23,9 @@ func TestTreeClimbNotPresent(t *testing.T) {
 }
 
 func TestDeepTreeClimb(t *testing.T) {
+	// The ultimate target of the CNAME has a CAA record preventing issuance, but
+	// the parent of the FQDN has a CAA record permitting. The target of the CNAME
+	// takes precedence.
 	target := "deep-cname.present-with-parameter.com"
 	_ = features.Set(map[string]bool{"LegacyCAA": true})
 	va, _ := setup(nil, 0)
@@ -47,8 +50,8 @@ func TestTreeClimbingLookupCAALimitHit(t *testing.T) {
 	_ = features.Set(map[string]bool{"LegacyCAA": true})
 	va, _ := setup(nil, 0)
 	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: target})
-	if prob != nil {
-		t.Fatalf("Expected success for %q, got %s", target, prob)
+	if prob == nil {
+		t.Fatalf("Expected failure for %q, got success", target)
 	}
 }
 
@@ -58,7 +61,7 @@ func TestCNAMEToReserved(t *testing.T) {
 	va, _ := setup(nil, 0)
 	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: target})
 	if prob == nil {
-		t.Fatalf("Expected error for cname-to-reserved.com, got none")
+		t.Fatalf("Expected error for cname-to-reserved.com, got success")
 	}
 	if prob.Type != probs.ConnectionProblem {
 		t.Errorf("Expected timeout error type %s, got %s", probs.ConnectionProblem, prob.Type)

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -12,22 +12,13 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestFindAlias(t *testing.T) {
-	var cnames []*dns.CNAME
-	alias := findAlias("foo.com", cnames)
-	if alias != "" {
-		t.Errorf("Got alias and didn't expect one: %q", alias)
-	}
-	cnames = append(cnames, &dns.CNAME{
-		Hdr:    dns.RR_Header{Name: "quux.com"},
-		Target: "szyzygy.com",
-	}, &dns.CNAME{
-		Hdr:    dns.RR_Header{Name: "bar.com"},
-		Target: "quux.com",
-	})
-	alias2 := findAlias("bar.com", cnames)
-	if alias2 != "quux.com" {
-		t.Errorf("Got alias of %q, expected %q", alias2, "quux.com")
+func TestDeepTreeClimb(t *testing.T) {
+	target := "deep-cname.present-with-parameter.com"
+	_ = features.Set(map[string]bool{"LegacyCAA": true})
+	va, _ := setup(nil, 0)
+	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: target})
+	if prob == nil {
+		t.Fatalf("Expected error for %q, got none", target)
 	}
 }
 

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
+func TestTreeClimbNotPresent(t *testing.T) {
+	target := "deep-cname.not-present.com"
+	_ = features.Set(map[string]bool{"LegacyCAA": true})
+	va, _ := setup(nil, 0)
+	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: target})
+	if prob != nil {
+		t.Fatalf("Expected success for %q, got %s", target, prob)
+	}
+}
+
 func TestDeepTreeClimb(t *testing.T) {
 	target := "deep-cname.present-with-parameter.com"
 	_ = features.Set(map[string]bool{"LegacyCAA": true})

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
+func TestParentDomains(t *testing.T) {
+	pd := parentDomains("")
+	if len(pd) != 0 {
+		t.Errorf("Incorrect result from parentDomains(%q): %s", "", pd)
+	}
+	pd = parentDomains("com")
+	if len(pd) != 0 {
+		t.Errorf("Incorrect result from parentDomains(%q): %s", "com", pd)
+	}
+	pd = parentDomains("blog.example.com")
+	if len(pd) != 2 || pd[0] != "example.com" || pd[1] != "com" {
+		t.Errorf("Incorrect result from parentDomains(%q): %s", "blog.example.com", pd)
+	}
+}
+
 func TestTreeClimbNotPresent(t *testing.T) {
 	target := "deep-cname.not-present.com"
 	_ = features.Set(map[string]bool{"LegacyCAA": true})

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -32,18 +32,30 @@ func TestFindAlias(t *testing.T) {
 }
 
 func TestTreeClimbingLookupCAASimpleSuccess(t *testing.T) {
+	target := "www.present-with-parameter.com"
+	_ = features.Set(map[string]bool{"LegacyCAA": true})
+	va, _ := setup(nil, 0)
+	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: target})
+	if prob != nil {
+		t.Fatalf("Expected success for %q, got %s", target, prob)
+	}
 }
 
 func TestTreeClimbingLookupCAALimitHit(t *testing.T) {
+	target := "blog.cname-to-subdomain.com"
+	_ = features.Set(map[string]bool{"LegacyCAA": true})
+	va, _ := setup(nil, 0)
+	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: target})
+	if prob != nil {
+		t.Fatalf("Expected success for %q, got %s", target, prob)
+	}
 }
 
 func TestCNAMEToReserved(t *testing.T) {
-	err := features.Set(map[string]bool{"LegacyCAA": true})
-	if err != nil {
-		t.Fatal("Failed to set feature:", err)
-	}
+	target := "cname-to-reserved.com"
+	_ = features.Set(map[string]bool{"LegacyCAA": true})
 	va, _ := setup(nil, 0)
-	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "cname-to-reserved.com"})
+	prob := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: target})
 	if prob == nil {
 		t.Fatalf("Expected error for cname-to-reserved.com, got none")
 	}


### PR DESCRIPTION
This implements the pre-erratum 5065 version of CAA, behind a feature flag.

This involved refactoring DNSClient.LookupCAA to return a list of CNAMEs in addition to the CAA records, and adding an alternate `lookuper` that does tree-climbing on single-depth aliases.