### PR TITLE
Reject CAA responses containing DNAMEs

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -467,14 +467,8 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 	for _, answer := range r.Answer {
 		if caaR, ok := answer.(*dns.CAA); ok {
 			CAAs = append(CAAs, caaR)
-		} else if dnameR, ok := answer.(*dns.DNAME); ok {
-			// Note: The legacy CAA spec erroneously treats DNAMEs as equivalent to
-			// CNAMEs. DNAMEs are extremely rare, but to be strict, we'll copy them
-			// into the CNAME list.
-			CNAMEs = append(CNAMEs, &dns.CNAME{
-				Hdr:    dnameR.Hdr,
-				Target: dnameR.Target,
-			})
+		} else if _, ok := answer.(*dns.DNAME); ok {
+			return nil, nil, fmt.Errorf("Got DNAME when looking up CNAME. DNAMEs not supported.")
 		} else if cnameR, ok := answer.(*dns.CNAME); ok {
 			CNAMEs = append(CNAMEs, cnameR)
 		}

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -410,7 +410,7 @@ func TestDNSLookupCAA(t *testing.T) {
 
 	_, cnames, err := obj.LookupCAA(context.Background(), "dname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
-	test.Assert(t, len(cnames) > 0, "Should treate DNAME as CNAME")
+	test.Assert(t, len(cnames) > 0, "Should treat DNAME as CNAME")
 }
 
 func TestDNSTXTAuthorities(t *testing.T) {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -139,6 +139,12 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				record.Flag = 1
 				appendAnswer(record)
 			}
+			if q.Name == "dname.example.com." {
+				appendAnswer(&dns.DNAME{
+					Hdr:    dns.RR_Header{Name: "dname.example.com.", Rrtype: dns.TypeDNAME, Class: dns.ClassINET, Ttl: 0},
+					Target: "dname.example.net.",
+				})
+			}
 		case dns.TypeTXT:
 			if q.Name == "split-txt.letsencrypt.org." {
 				record := new(dns.TXT)
@@ -401,6 +407,10 @@ func TestDNSLookupCAA(t *testing.T) {
 	caas, _, err = obj.LookupCAA(context.Background(), "cname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")
+
+	_, cnames, err := obj.LookupCAA(context.Background(), "dname.example.com")
+	test.AssertNotError(t, err, "CAA lookup failed")
+	test.Assert(t, len(cnames) > 0, "Should treate DNAME as CNAME")
 }
 
 func TestDNSTXTAuthorities(t *testing.T) {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -408,9 +408,10 @@ func TestDNSLookupCAA(t *testing.T) {
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")
 
-	_, cnames, err := obj.LookupCAA(context.Background(), "dname.example.com")
-	test.AssertNotError(t, err, "CAA lookup failed")
-	test.Assert(t, len(cnames) > 0, "Should treat DNAME as CNAME")
+	_, _, err = obj.LookupCAA(context.Background(), "dname.example.com")
+	if err == nil {
+		t.Errorf("Expected failure when returning DNAME, but got success")
+	}
 }
 
 func TestDNSTXTAuthorities(t *testing.T) {


### PR DESCRIPTION
Since the legacy CAA spec does the wrong thing with DNAMEs (treating them as
CNAMEs), and it's hard to reconcile this approach with CNAME handling, and
DNAMEs are extremely rare, reject outright any CAA responses containing DNAMEs.

Also, in the process, fix a bug in the previous LegacyCAA implementation.
Because the processing of records in LookupCAA was gated by `if
answer.Header().RRType == dnsType`, non-CAA responses were filtered out. This
wasn't caught by previous testing, because it was unittesting that mocked out
bdns.