### PR TITLE
Include the domain name in problems from IsCAAValid.

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -25,7 +25,7 @@ func (va *ValidationAuthorityImpl) IsCAAValid(
 
 	if prob != nil {
 		typ := string(prob.Type)
-		detail := fmt.Sprintf("%s : %s", *req.Domain, prob.Detail)
+		detail := fmt.Sprintf("While processing CAA for %s : %s", *req.Domain, prob.Detail)
 		return &vapb.IsCAAValidResponse{
 			Problem: &corepb.ProblemDetails{
 				ProblemType: &typ,

--- a/va/caa.go
+++ b/va/caa.go
@@ -25,7 +25,7 @@ func (va *ValidationAuthorityImpl) IsCAAValid(
 
 	if prob != nil {
 		typ := string(prob.Type)
-		detail := fmt.Sprintf("While processing CAA for %s : %s", *req.Domain, prob.Detail)
+		detail := fmt.Sprintf("While processing CAA for %s: %s", *req.Domain, prob.Detail)
 		return &vapb.IsCAAValidResponse{
 			Problem: &corepb.ProblemDetails{
 				ProblemType: &typ,

--- a/va/caa.go
+++ b/va/caa.go
@@ -25,10 +25,11 @@ func (va *ValidationAuthorityImpl) IsCAAValid(
 
 	if prob != nil {
 		typ := string(prob.Type)
+		detail := fmt.Sprintf("%s : %s", *req.Domain, prob.Detail)
 		return &vapb.IsCAAValidResponse{
 			Problem: &corepb.ProblemDetails{
 				ProblemType: &typ,
-				Detail:      &prob.Detail,
+				Detail:      &detail,
 			},
 		}, nil
 	}

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
+
+	vapb "github.com/letsencrypt/boulder/va/proto"
 )
 
 // caaMockDNS implements the `dns.DNSClient` interface with a set of useful test
@@ -299,6 +301,29 @@ func TestCAAChecking(t *testing.T) {
 	if err == nil {
 		t.Errorf("Should have returned error on CAA lookup, but did not: %s", "servfail.present.com")
 	}
+}
+
+// TestIsCAAValidErrMessage tests that an error result from `va.IsCAAValid`
+// includes the domain name that was being checked in the failure detail.
+func TestIsCAAValidErrMessage(t *testing.T) {
+	va, _ := setup(nil, 0)
+	va.dnsClient = caaMockDNS{}
+
+	// Call IsCAAValid with a domain we know fails with a generic error from the
+	// caaMockDNS.
+	domain := "caa-timeout.com"
+	resp, err := va.IsCAAValid(ctx, &vapb.IsCAAValidRequest{
+		Domain: &domain,
+	})
+
+	// The lookup itself should not return an error
+	test.AssertNotError(t, err, "Unexpected error calling IsCAAValidRequest")
+	// The result should not be nil
+	test.AssertNotNil(t, resp, "Response to IsCAAValidRequest was nil")
+	// The result's Problem should not be nil
+	test.AssertNotNil(t, resp.Problem, "Response Problem was nil")
+	// The result's Problem should be an error message that includes the domain.
+	test.AssertEquals(t, *resp.Problem.Detail, fmt.Sprintf("%s : error", domain))
 }
 
 func TestCAAFailure(t *testing.T) {

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -323,7 +323,7 @@ func TestIsCAAValidErrMessage(t *testing.T) {
 	// The result's Problem should not be nil
 	test.AssertNotNil(t, resp.Problem, "Response Problem was nil")
 	// The result's Problem should be an error message that includes the domain.
-	test.AssertEquals(t, *resp.Problem.Detail, fmt.Sprintf("%s : error", domain))
+	test.AssertEquals(t, *resp.Problem.Detail, fmt.Sprintf("While processing CAA for %s : error", domain))
 }
 
 func TestCAAFailure(t *testing.T) {

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -323,7 +323,7 @@ func TestIsCAAValidErrMessage(t *testing.T) {
 	// The result's Problem should not be nil
 	test.AssertNotNil(t, resp.Problem, "Response Problem was nil")
 	// The result's Problem should be an error message that includes the domain.
-	test.AssertEquals(t, *resp.Problem.Detail, fmt.Sprintf("While processing CAA for %s : error", domain))
+	test.AssertEquals(t, *resp.Problem.Detail, fmt.Sprintf("While processing CAA for %s: error", domain))
 }
 
 func TestCAAFailure(t *testing.T) {


### PR DESCRIPTION
For certificates with many domains it can be difficult to associate
a given CAA error with the specific domain that caused it. To make this
easier this commit explicitly prefixes all of the problems that can be
returned from `va.IsCAAValid` with the domain name in question.

A small unit test is included to check a CAA problem's detail message is
suitably prefixed with the affected domain.

Resolves https://github.com/letsencrypt/boulder/issues/3094