### PR TITLE
Fix duplicate cert limit off-by-one.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1004,7 +1004,7 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx contex
 		return err
 	}
 	names = core.UniqueLowerNames(names)
-	if int(count) > limit.GetThreshold(strings.Join(names, ","), regID) {
+	if int(count) >= limit.GetThreshold(strings.Join(names, ","), regID) {
 		return berrors.RateLimitError(
 			"too many certificates already issued for exact set of domains: %s",
 			strings.Join(names, ","),


### PR DESCRIPTION
The RA's `checkCertificatesPerFQDNSetLimit` function was using `>` where
it should have been using `>=` when evaluating a FQDNSet count against
the rate limit threshold. This resulted in an off by one error where we
allowed 1 more duplicate certificate than intended. Thanks to @mnordhoff 
for reporting in #3106! :clap: 

This commit fixes the off-by-one error and adds a short unit test. The
unit test failed the
`TestCheckExactCertificateLimit/FQDN_set_issuances_equal_to_limit`
subtest before the fix was applied and passes afterwards.

Resolves https://github.com/letsencrypt/boulder/issues/3106