### PR TITLE
Fix load-generator for multi-VA

### DIFF
--- a/test/load-generator/boulder-calls.go
+++ b/test/load-generator/boulder-calls.go
@@ -233,6 +233,7 @@ func solveHTTPOne(s *State, ctx *context) error {
 	}
 	authStr := fmt.Sprintf("%s.%s", chall.Token, base64.RawURLEncoding.EncodeToString(thumbprint))
 	s.challSrv.addHTTPOneChallenge(chall.Token, authStr)
+	defer s.challSrv.deleteHTTPOneChallenge(chall.Token)
 
 	update := fmt.Sprintf(`{"resource":"challenge","keyAuthorization":"%s"}`, authStr)
 	requestPayload, err := s.signWithNonce(challengePath, false, []byte(update), ctx.reg.signer)

--- a/test/load-generator/challenge-servers.go
+++ b/test/load-generator/challenge-servers.go
@@ -82,7 +82,6 @@ func (s *challSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		token := requestPath[len(wellKnownPath):]
 		if auth, found := s.getHTTPOneChallenge(token); found {
 			fmt.Fprintf(w, "%s", auth)
-			s.deleteHTTPOneChallenge(token)
 		}
 	}
 }


### PR DESCRIPTION
Wait for the authorization state to change before deleting the HTTP-01 challenge from the challenge server.