### PR TITLE
Add parallelism to SA CountCertificatesByNames.

### DIFF
--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -20,6 +20,9 @@ type config struct {
 		cmd.DBConfig
 
 		Features map[string]bool
+
+		// Max simultaneous SQL queries caused by a single RPC.
+		ParallelismPerRPC int
 	}
 
 	Syslog cmd.SyslogConfig
@@ -54,7 +57,11 @@ func main() {
 
 	go sa.ReportDbConnCount(dbMap, scope)
 
-	sai, err := sa.NewSQLStorageAuthority(dbMap, cmd.Clock(), logger, scope)
+	parallel := saConf.ParallelismPerRPC
+	if parallel == 0 {
+		parallel = 1
+	}
+	sai, err := sa.NewSQLStorageAuthority(dbMap, cmd.Clock(), logger, scope, parallel)
 	cmd.FailOnError(err, "Failed to create SA impl")
 
 	var grpcSrv *grpc.Server

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -58,7 +58,7 @@ func main() {
 	go sa.ReportDbConnCount(dbMap, scope)
 
 	parallel := saConf.ParallelismPerRPC
-	if parallel == 0 {
+	if parallel < 1 {
 		parallel = 1
 	}
 	sai, err := sa.NewSQLStorageAuthority(dbMap, cmd.Clock(), logger, scope, parallel)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -183,7 +183,7 @@ func TestGetAndProcessCerts(t *testing.T) {
 	fc := clock.NewFake()
 
 	checker := newChecker(saDbMap, fc, pa, expectedValidityPeriod)
-	sa, err := sa.NewSQLStorageAuthority(saDbMap, fc, blog.NewMock(), metrics.NewNoopScope())
+	sa, err := sa.NewSQLStorageAuthority(saDbMap, fc, blog.NewMock(), metrics.NewNoopScope(), 1)
 	test.AssertNotError(t, err, "Couldn't create SA to insert certificates")
 	saCleanUp := test.ResetSATestDatabase(t)
 	defer func() {

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -812,7 +812,7 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 		t.Fatalf("Couldn't connect the database: %s", err)
 	}
 	fc := newFakeClock(t)
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope())
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope(), 1)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
 	}

--- a/cmd/expired-authz-purger/main_test.go
+++ b/cmd/expired-authz-purger/main_test.go
@@ -24,7 +24,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	log := blog.UseMock()
 	fc := clock.NewFake()
 	fc.Add(time.Hour)
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope())
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope(), 1)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
 	}

--- a/cmd/id-exporter/main_test.go
+++ b/cmd/id-exporter/main_test.go
@@ -379,7 +379,7 @@ func setup(t *testing.T) testCtx {
 	cleanUp := test.ResetSATestDatabase(t)
 
 	fc := newFakeClock(t)
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope())
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope(), 1)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
 	}

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -130,7 +130,7 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *gorp.DbMap, cloc
 	fc := clock.NewFake()
 	fc.Add(1 * time.Hour)
 
-	sa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope())
+	sa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope(), 1)
 	test.AssertNotError(t, err, "Failed to create SA")
 
 	cleanUp := test.ResetSATestDatabase(t)

--- a/cmd/weak-key-search/main_test.go
+++ b/cmd/weak-key-search/main_test.go
@@ -31,7 +31,7 @@ func TestSearch(t *testing.T) {
 	test.AssertNotError(t, err, "sa.NewDbMap failed")
 	fc := clock.NewFake()
 	log := blog.UseMock()
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope())
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope(), 1)
 	test.AssertNotError(t, err, "sa.NewSQLStorageAuthority failed")
 	defer test.ResetSATestDatabase(t)
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -226,7 +226,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope())
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope(), 1)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -366,7 +366,8 @@ func (ssa *SQLStorageAuthority) CountCertificatesByNames(ctx context.Context, do
 				currentCount, err := ssa.countCertificatesByName(domain, earliest, latest)
 				if err != nil {
 					results <- result{err: err}
-					continue
+					// Skip any further work in this goroutine.
+					return
 				}
 				results <- result{
 					count:  currentCount,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jmhodges/clock"
@@ -33,6 +34,11 @@ type SQLStorageAuthority struct {
 	clk   clock.Clock
 	log   blog.Logger
 	scope metrics.Scope
+
+	// For RPCs that generate multiple, parallelizable SQL queries, this is the
+	// max parallelism they will use (to avoid consuming too many MariaDB
+	// threads).
+	parallelismPerRPC int
 }
 
 func digest256(data []byte) []byte {
@@ -69,14 +75,16 @@ func NewSQLStorageAuthority(
 	clk clock.Clock,
 	logger blog.Logger,
 	scope metrics.Scope,
+	parallelismPerRPC int,
 ) (*SQLStorageAuthority, error) {
 	SetSQLDebug(dbMap, logger)
 
 	ssa := &SQLStorageAuthority{
-		dbMap: dbMap,
-		clk:   clk,
-		log:   logger,
-		scope: scope,
+		dbMap:             dbMap,
+		clk:               clk,
+		log:               logger,
+		scope:             scope,
+		parallelismPerRPC: parallelismPerRPC,
 	}
 
 	return ssa, nil
@@ -333,14 +341,47 @@ func (t TooManyCertificatesError) Error() string {
 // certificates than that matching one of the provided domain names, it will return
 // TooManyCertificatesError.
 func (ssa *SQLStorageAuthority) CountCertificatesByNames(ctx context.Context, domains []string, earliest, latest time.Time) ([]*sapb.CountByNames_MapElement, error) {
-	var ret []*sapb.CountByNames_MapElement
+	work := make(chan string, len(domains))
+	type result struct {
+		err    error
+		count  int
+		domain string
+	}
+	results := make(chan result, len(domains))
 	for _, domain := range domains {
-		currentCount, err := ssa.countCertificatesByName(domain, earliest, latest)
-		if err != nil {
-			return ret, err
+		work <- domain
+	}
+	close(work)
+	var wg sync.WaitGroup
+	// We may perform up to 100 queries, depending on what's on the certificate
+	// request. Parallelize them so we don't hit our timeout, but limit the
+	// parallelism so we don't consume too many threads on the database.
+	for i := 0; i < ssa.parallelismPerRPC; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for domain := range work {
+				currentCount, err := ssa.countCertificatesByName(domain, earliest, latest)
+				if err != nil {
+					results <- result{err: err}
+					continue
+				}
+				results <- result{
+					count:  currentCount,
+					domain: domain,
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+	var ret []*sapb.CountByNames_MapElement
+	for r := range results {
+		if r.err != nil {
+			return nil, r.err
 		}
-		name := string(domain)
-		pbCount := int64(currentCount)
+		name := string(r.domain)
+		pbCount := int64(r.count)
 		ret = append(ret, &sapb.CountByNames_MapElement{
 			Name:  &name,
 			Count: &pbCount,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -369,6 +369,7 @@ func (ssa *SQLStorageAuthority) CountCertificatesByNames(ctx context.Context, do
 				case <-ctx.Done():
 					results <- result{err: ctx.Err()}
 					return
+				default:
 				}
 				currentCount, err := ssa.countCertificatesByName(domain, earliest, latest)
 				if err != nil {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -49,7 +49,7 @@ func initSA(t *testing.T) (*SQLStorageAuthority, clock.FakeClock, func()) {
 	fc := clock.NewFake()
 	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
 
-	sa, err := NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope())
+	sa, err := NewSQLStorageAuthority(dbMap, fc, log, metrics.NewNoopScope(), 1)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -552,9 +552,20 @@ func TestAddCertificate(t *testing.T) {
 	)
 }
 
+type slowCountSA struct {
+	*SQLStorageAuthority
+}
+
+func (s slowCountSA) countCertificatesByName(domain string, earliest, latest time.Time) (int, error) {
+	time.Sleep(100 * time.Millisecond)
+	return s.SQLStorageAuthority.countCertificatesByName(domain, earliest, latest)
+}
+
 func TestCountCertificatesByNames(t *testing.T) {
-	sa, clk, cleanUp := initSA(t)
+	ssa, clk, cleanUp := initSA(t)
 	defer cleanUp()
+
+	sa := slowCountSA{ssa}
 	// Test cert generated locally by Boulder / CFSSL, names [example.com,
 	// www.example.com, admin.example.com]
 	certDER, err := ioutil.ReadFile("test-cert.der")
@@ -623,6 +634,18 @@ func TestCountCertificatesByNames(t *testing.T) {
 		expectedCount := int64(expected[domain])
 		test.AssertEquals(t, actualCount, expectedCount)
 	}
+
+	begin := time.Now()
+	_, err = sa.CountCertificatesByNames(ctx, []string{
+		"example.com", "foo.com", "example.co.bn", "1.co", "2.co", "3.co", "4.co", "5.co", "6.co", "8.co", "9.co",
+		"10.co", "11.co",
+	}, yesterday, now.Add(10000*time.Hour))
+	test.AssertNotError(t, err, "Counting many certs")
+	elapsed := time.Since(begin)
+	if elapsed > time.Second {
+		t.Errorf("CountCertificatesByNames too slow; not parallelizing effectively.")
+	}
+
 }
 
 const (


### PR DESCRIPTION
Since we can make up to 100 SQL queries from this method (based on the 100-SAN
limit), sometimes it is too slow and we get a timeout for large certificates. By
running some of those queries in parallel, we can speed things up and stop
getting timeouts.

Note: This PR doesn't currently have tests. I couldn't think of a good way to test
that queries were run in parallel. I tried creating a `slowSA` struct that embeds
a `SQLStorageAuthority` and overrides `countCertificatesByName` to contain a
sleep, but of course `SQLStorageAuthority.CountCertificatesByNames` doesn't
call the parent's `countCertificatesByName` (because it's embedding, not
inheritance). I'm happy to take suggestions about how to effectively test this.