### PR TITLE
Switch to udp for internal DNS.

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 
+	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/metrics"
 )
 
@@ -190,7 +191,10 @@ func NewDNSClientImpl(
 
 	// Set timeout for underlying net.Conn
 	dnsClient.ReadTimeout = readTimeout
-	dnsClient.Net = "udp"
+	dnsClient.Net = "tcp"
+	if features.Enabled(features.UDPDNS) {
+		dnsClient.Net = "udp"
+	}
 
 	queryTime := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -190,7 +190,7 @@ func NewDNSClientImpl(
 
 	// Set timeout for underlying net.Conn
 	dnsClient.ReadTimeout = readTimeout
-	dnsClient.Net = "tcp"
+	dnsClient.Net = "udp"
 
 	queryTime := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -194,13 +194,13 @@ func serveLoopResolver(stopChan chan bool) {
 	go func() {
 		err := tcpServer.ListenAndServe()
 		if err != nil {
-			log.Fatal(err)
+			fmt.Println(err)
 		}
 	}()
 	go func() {
 		err := udpServer.ListenAndServe()
 		if err != nil {
-			log.Fatal(err)
+			fmt.Println(err)
 		}
 	}()
 	go func() {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -178,7 +178,12 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 func serveLoopResolver(stopChan chan bool) {
 	dns.HandleFunc(".", mockDNSQuery)
-	server := &dns.Server{Addr: dnsLoopbackAddr, Net: "tcp", ReadTimeout: time.Second, WriteTimeout: time.Second}
+	server := &dns.Server{
+		Addr:         dnsLoopbackAddr,
+		Net:          "udp",
+		ReadTimeout:  time.Second,
+		WriteTimeout: time.Second,
+	}
 	go func() {
 		err := server.ListenAndServe()
 		if err != nil {
@@ -206,7 +211,7 @@ func pollServer() {
 			fmt.Fprintln(os.Stderr, "Timeout reached while testing for the dns server to come up")
 			os.Exit(1)
 		case <-ticker.C:
-			conn, _ := dns.DialTimeout("tcp", dnsLoopbackAddr, backoff)
+			conn, _ := dns.DialTimeout("udp", dnsLoopbackAddr, backoff)
 			if conn != nil {
 				_ = conn.Close()
 				return

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -205,7 +205,11 @@ func serveLoopResolver(stopChan chan bool) {
 	}()
 	go func() {
 		<-stopChan
-		err := server.Shutdown()
+		err := tcpServer.Shutdown()
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = udpServer.Shutdown()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAALegacyCAA"
+const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAALegacyCAAUDPDNS"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231, 240}
+var _FeatureFlag_index = [...]uint8{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231, 240, 246}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -28,6 +28,7 @@ const (
 	AllowRenewalFirstRL
 	RecheckCAA
 	LegacyCAA
+	UDPDNS
 )
 
 // List of features and their default value, protected by fMu
@@ -47,6 +48,7 @@ var features = map[FeatureFlag]bool{
 	AllowRenewalFirstRL:      false,
 	RecheckCAA:               false,
 	LegacyCAA:                false,
+	UDPDNS:                   false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -42,6 +42,7 @@
       ]
     },
     "features": {
+      "UDPDNS": true,
       "AllowKeyRollover": true,
       "AllowTLS02Challenges": true,
       "CountCertificatesExact": true,

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -28,6 +28,7 @@
       "ServerURL": "http://boulder:6000"
     },
     "features": {
+      "UDPDNS": true,
       "LegacyCAA": true,
       "IPv6First": true
     },

--- a/test/dns-test-srv/main.go
+++ b/test/dns-test-srv/main.go
@@ -149,7 +149,7 @@ func (ts *testSrv) serveTestResolver() {
 	dns.HandleFunc(".", ts.dnsHandler)
 	dnsServer := &dns.Server{
 		Addr:         "0.0.0.0:8053",
-		Net:          "tcp",
+		Net:          "udp",
 		ReadTimeout:  time.Second,
 		WriteTimeout: time.Second,
 	}


### PR DESCRIPTION
We used to use TCP because we would request DNSSEC records from Unbound, and
they would always cause truncated records when present. Now that we no longer
request those (#2718), we can use UDP. This is better because the TCP serving
paths in Unbound are likely less thoroughly tested, and not optimized for high
load. In particular this may resolve some availability problems we've seen
recently when trying to upgrade to a more recent Unbound.

Note that this only affects the Boulder->Unbound path. The Unbound->upstream
path is already UDP by default (with TCP fallback for truncated ANSWERs).

Fixes #1775