### PR TITLE
Set timeout for GSB requests.

### DIFF
--- a/cmd/boulder-va/gsb.go
+++ b/cmd/boulder-va/gsb.go
@@ -112,10 +112,11 @@ func newGoogleSafeBrowsingV4(gsb *cmd.GoogleSafeBrowsingConfig, logger blog.Logg
 
 	dbFile := filepath.Join(gsb.DataDir, v4DbFilename)
 	sb, err := safebrowsingv4.NewSafeBrowser(safebrowsingv4.Config{
-		APIKey:    gsb.APIKey,
-		DBPath:    dbFile,
-		ServerURL: gsb.ServerURL,
-		Logger:    gsbLogAdapter{logger},
+		APIKey:         gsb.APIKey,
+		DBPath:         dbFile,
+		ServerURL:      gsb.ServerURL,
+		Logger:         gsbLogAdapter{logger},
+		RequestTimeout: 5 * time.Second,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Safebrowsing defaults to a one minute timeout for its requests. Set a much lower
one so that we don't timeout new-authzs when communicating with safebrowsing is
slow.