### PR TITLE
In tag_and_upload, ensure correct directory.

### DIFF
--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+cd $(dirname $0)
+
 DATESTAMP=$(date +%Y-%m-%d)
 TAG_NAME="letsencrypt/boulder-tools:$DATESTAMP"
 


### PR DESCRIPTION
This avoids accidentally building the Boulder Dockerfile instead of the
boulder-tools one.