### PR TITLE
Remove references to buser in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,6 @@ EXPOSE 4000 4001 4002 4003 4430 4431 8053 8055
 ENV PATH /usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 ENV GOPATH /go
 
-RUN adduser --disabled-password --gecos "" --home /go/src/github.com/letsencrypt/boulder -q buser
-RUN chown -R buser /go/
-
 WORKDIR /go/src/github.com/letsencrypt/boulder
-
-RUN mkdir bin
-
-RUN chown -R buser /go/
 
 ENTRYPOINT [ "./test/entrypoint.sh" ]

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -47,8 +47,4 @@ if [[ $# -eq 0 ]]; then
     exec ./start.py
 fi
 
-# TODO(jsha): Change to an unprivileged user before running commands. Currently,
-# running as an unprivileged user causes the certbot integration test to fail
-# during the test of the manual plugin. There's a call to killpg in there that
-# kills the whole test, but only when run under `su buser -c "..."`
 exec $@


### PR DESCRIPTION
We originally planned to run as a non-root user in our Docker setup. We haven't
done that yet, so let's clean up the detritus until we do.