### PR TITLE
Clarify ACME divergences doc

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -2,9 +2,11 @@
 
 While Boulder attempts to implement the ACME specification as strictly as possible there are places at which we will diverge from the letter of the specification for various reasons.
 
-This document details these differences, since ACME is not yet finalized it will be updated as numbered drafts are published.
+Boulder evolved alongside the ACME specification and so there is not one exact draft number that can be referenced. Instead this document details these differences between what Boulder does and the most-recently published ACME draft. Since ACME is not yet finalized it will be updated as numbered drafts are published.
 
-Current draft: [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).
+We refer to what Boulder presently implements as "ACME v1" and we are [actively working on "ACME v2"](https://letsencrypt.org/2017/06/14/acme-v2-api.html), an implementation with less divergences based on what will become the final ACME RFC.
+
+**Current draft: [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).**
 
 ## [Section 6](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-6)
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -36,7 +36,7 @@ Boulder does not implement the `caa` and `dnssec` errors.
 
 ## [Section 7.1](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-7.1)
 
-Boulder does not implement the `new-order` resource. Instead of `new-order` Boulder implements the `new-cert` resource that is defined in [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5).
+Boulder does not implement the `new-order` resource (previously referred to as `new-application`). Instead of `new-order` Boulder implements the `new-cert` resource that is defined in [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5).
 
 Boulder also doesn't implement the `new-nonce` endpoint.
 
@@ -56,7 +56,7 @@ Boulder does not implement the `terms-of-service-agreed` or `orders` fields in t
 
 ## [Section 7.1.3](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-7.1.3)
 
-Boulder does not implement orders, instead it implements the `new-cert` flow from [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5). Instead of authorizations in the order response, Boulder currently uses authorizations that are created using the `new-authz` flow from [draft-ietf-acme-02 Section 6.4](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.4).
+Boulder does not implement orders (previously called `applications`), instead it implements the `new-cert` flow from [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5). Instead of authorizations in the order response, Boulder currently uses authorizations that are created using the `new-authz` flow from [draft-ietf-acme-02 Section 6.4](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.4).
 
 ## [Section 7.1.4](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-7.1.4)
 
@@ -86,7 +86,7 @@ Boulder implements draft-05 style key roll-over with a few divergences. Since Bo
 
 ## [Section 7.4](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-7.4)
 
-Boulder does not implement orders, instead it implements the `new-cert` flow from [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5). Instead of authorizations in the order response, Boulder currently uses authorizations that are created using the `new-authz` flow from [draft-ietf-acme-02 Section 6.4](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.4). Certificates are not proactively issued, a user must request issuance via the `new-cert` endpoint instead of assuming a certificate will be created once all required authorizations are validated.
+Boulder does not implement orders (previously called `applications`), instead it implements the `new-cert` flow from [draft-ietf-acme-02 Section 6.5](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.5). Instead of authorizations in the order response, Boulder currently uses authorizations that are created using the `new-authz` flow from [draft-ietf-acme-02 Section 6.4](https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.4). Certificates are not proactively issued, a user must request issuance via the `new-cert` endpoint instead of assuming a certificate will be created once all required authorizations are validated.
 
 ## [Section 7.4.2](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-7.4.2)
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -2,7 +2,7 @@
 
 While Boulder attempts to implement the ACME specification as strictly as possible there are places at which we will diverge from the letter of the specification for various reasons.
 
-Since Boulder evolved alongside the ACME specification there is not one exact ACME draft number that can be referenced in isolation to understand Boulder. This document exists to detail differences between what Boulder does and the most-recently published ACME draft. Since ACME is not yet finalized it will be updated as new numbered drafts are published.
+Since Boulder evolved alongside the ACME specification there is not one exact ACME draft number that can be referenced in isolation to understand the protocol Boulder speaks. This document exists to detail differences between what Boulder does and the most-recently published ACME draft. Since ACME is not yet finalized it will be updated as new numbered drafts are published.
 
 We refer to what Boulder presently implements as "ACME v1" and we are [actively working on "ACME v2"](https://letsencrypt.org/2017/06/14/acme-v2-api.html), a second API endpoint with less divergences that is based on what will become the final ACME RFC.
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -2,9 +2,9 @@
 
 While Boulder attempts to implement the ACME specification as strictly as possible there are places at which we will diverge from the letter of the specification for various reasons.
 
-Boulder evolved alongside the ACME specification and so there is not one exact draft number that can be referenced. Instead this document details these differences between what Boulder does and the most-recently published ACME draft. Since ACME is not yet finalized it will be updated as numbered drafts are published.
+Since Boulder evolved alongside the ACME specification there is not one exact ACME draft number that can be referenced in isolation to understand Boulder. This document exists to detail differences between what Boulder does and the most-recently published ACME draft. Since ACME is not yet finalized it will be updated as new numbered drafts are published.
 
-We refer to what Boulder presently implements as "ACME v1" and we are [actively working on "ACME v2"](https://letsencrypt.org/2017/06/14/acme-v2-api.html), an implementation with less divergences based on what will become the final ACME RFC.
+We refer to what Boulder presently implements as "ACME v1" and we are [actively working on "ACME v2"](https://letsencrypt.org/2017/06/14/acme-v2-api.html), a second API endpoint with less divergences that is based on what will become the final ACME RFC.
 
 **Current draft: [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).**
 


### PR DESCRIPTION
A frequent point of confusion is which ACME draft Boulder implements. Often people imagine (sensibly!) that there is one draft they can reference to understand Boulder.

This commit updates the divergences doc to clarify that it should be used to compare Boulder to whatever the most current ACME draft is and that Boulder doesn't implement a specific draft. This commit also adds a reference to what ACME v1 is and a link to the ACME v2 blog post.

Small references are also added to the "applications" concept from prev. drafts. Otherwise folks that land on older ACME drafts may wonder why the divergences doc doesn't mention "applications", a concept that was renamed to "orders" in subsequent drafts. We do document divergences for "orders" and attention should be directed there.