### PR TITLE
Fix example goose migration path.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ You can then add a migration with:
 
 `$ goose -path ./sa/_db/ create AddWizards sql`
 
-Finally, edit the resulting file (`sa/_db/20160915101011_AddWizards.sql`) to define your migration:
+Finally, edit the resulting file (`sa/_db/migrations/20160915101011_AddWizards.sql`) to define your migration:
 
 ```
 -- +goose Up

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ You can then add a migration with:
 
 `$ goose -path ./sa/_db/ create AddWizards sql`
 
-Finally, edit the resulting file (`sa/_db/20160915101011_WizardMigrations.sql`) to define your migration:
+Finally, edit the resulting file (`sa/_db/20160915101011_AddWizards.sql`) to define your migration:
 
 ```
 -- +goose Up


### PR DESCRIPTION
The contrib guide to migrations creates a migration with `goose create
AddWizards sql` but references it later as
`sa/_db/20160915101011_WizardMigrations.sql`. This commit fixes the
reference to use the correct `AddWizards.sql` filename suffix.