### PR TITLE
Revert "Set timeout for GSB requests. (#3136)"

### DIFF
--- a/cmd/boulder-va/gsb.go
+++ b/cmd/boulder-va/gsb.go
@@ -112,11 +112,10 @@ func newGoogleSafeBrowsingV4(gsb *cmd.GoogleSafeBrowsingConfig, logger blog.Logg
 
 	dbFile := filepath.Join(gsb.DataDir, v4DbFilename)
 	sb, err := safebrowsingv4.NewSafeBrowser(safebrowsingv4.Config{
-		APIKey:         gsb.APIKey,
-		DBPath:         dbFile,
-		ServerURL:      gsb.ServerURL,
-		Logger:         gsbLogAdapter{logger},
-		RequestTimeout: 5 * time.Second,
+		APIKey:    gsb.APIKey,
+		DBPath:    dbFile,
+		ServerURL: gsb.ServerURL,
+		Logger:    gsbLogAdapter{logger},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit 78f454bdfd6b04f30ad4ddd94d39c8d0b86ef398.

There's a newer context-based was to set timeouts in this library, which avoids setting such a short timeout on the database update call, which might timeout more often.