### PR TITLE
Increase default MaxIdleConns.

### DIFF
--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -55,6 +55,7 @@ func main() {
 	dbMap, err := sa.NewDbMap(dbURL, saConf.DBConfig.MaxDBConns)
 	cmd.FailOnError(err, "Couldn't connect to SA database")
 
+	dbMap.Db.SetMaxIdleConns(saConf.DBConfig.MaxIdleDBConns)
 	go sa.ReportDbConnCount(dbMap, scope)
 
 	parallel := saConf.ParallelismPerRPC

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -55,7 +55,9 @@ func main() {
 	dbMap, err := sa.NewDbMap(dbURL, saConf.DBConfig.MaxDBConns)
 	cmd.FailOnError(err, "Couldn't connect to SA database")
 
-	dbMap.Db.SetMaxIdleConns(saConf.DBConfig.MaxIdleDBConns)
+	if saConf.DBConfig.MaxIdleDBConns != 0 {
+		dbMap.Db.SetMaxIdleConns(saConf.DBConfig.MaxIdleDBConns)
+	}
 	go sa.ReportDbConnCount(dbMap, scope)
 
 	parallel := saConf.ParallelismPerRPC

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,8 +51,9 @@ type ServiceConfig struct {
 type DBConfig struct {
 	DBConnect string
 	// A file containing a connect URL for the DB.
-	DBConnectFile string
-	MaxDBConns    int
+	DBConnectFile  string
+	MaxDBConns     int
+	MaxIdleDBConns int
 }
 
 // URL returns the DBConnect URL represented by this DBConfig object, either

--- a/sa/database.go
+++ b/sa/database.go
@@ -61,8 +61,6 @@ func NewDbMapFromConfig(config *mysql.Config, maxOpenConns int) (*gorp.DbMap, er
 		return nil, err
 	}
 	setMaxOpenConns(db, maxOpenConns)
-	// Set a nonzero idle connection limit so we get better connection reuse.
-	db.SetMaxIdleConns(20)
 
 	dialect := gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8"}
 	dbmap := &gorp.DbMap{Db: db, Dialect: dialect, TypeConverter: BoulderTypeConverter{}}

--- a/sa/database.go
+++ b/sa/database.go
@@ -61,6 +61,8 @@ func NewDbMapFromConfig(config *mysql.Config, maxOpenConns int) (*gorp.DbMap, er
 		return nil, err
 	}
 	setMaxOpenConns(db, maxOpenConns)
+	// Set a nonzero idle connection limit so we get better connection reuse.
+	db.SetMaxIdleConns(20)
 
 	dialect := gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8"}
 	dbmap := &gorp.DbMap{Db: db, Dialect: dialect, TypeConverter: BoulderTypeConverter{}}

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -2,6 +2,7 @@
   "sa": {
     "dbConnectFile": "test/secrets/sa_dburl",
     "maxDBConns": 100,
+    "maxIdleDBConns": 10,
     "maxConcurrentRPCServerRequests": 100000,
     "ParallelismPerRPC": 20,
     "debugAddr": ":8003",


### PR DESCRIPTION
Go's default is 2: https://golang.org/src/database/sql/sql.go#L686.
Graphs show we are opening 100-200 fresh connections per second on the SA.
Changing this default should reduce that a lot, which should reduce load on both
the SA and MariaDB. This should also improve latency, since every new TCP
connection adds a little bit of latency.