### PR TITLE
Move CAConfig out of cmd.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -26,8 +26,8 @@ import (
 	"github.com/miekg/pkcs11"
 	"golang.org/x/net/context"
 
+	"github.com/letsencrypt/boulder/ca/config"
 	caPB "github.com/letsencrypt/boulder/ca/proto"
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	corePB "github.com/letsencrypt/boulder/core/proto"
 	csrlib "github.com/letsencrypt/boulder/csr"
@@ -180,7 +180,7 @@ func makeInternalIssuers(
 // from a single issuer (the first first in the issuers slice), and can sign OCSP
 // for any of the issuer certificates provided.
 func NewCertificateAuthorityImpl(
-	config cmd.CAConfig,
+	config ca_config.CAConfig,
 	sa certificateStorage,
 	pa core.PolicyAuthority,
 	clk clock.Clock,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/crypto/ocsp"
 	"golang.org/x/net/context"
 
+	"github.com/letsencrypt/boulder/ca/config"
 	caPB "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
@@ -148,7 +149,7 @@ func mustRead(path string) []byte {
 }
 
 type testCtx struct {
-	caConfig  cmd.CAConfig
+	caConfig  ca_config.CAConfig
 	pa        core.PolicyAuthority
 	issuers   []Issuer
 	keyPolicy goodkey.KeyPolicy
@@ -197,7 +198,7 @@ func setup(t *testing.T) *testCtx {
 	}
 
 	// Create a CA
-	caConfig := cmd.CAConfig{
+	caConfig := ca_config.CAConfig{
 		RSAProfile:   rsaProfileName,
 		ECDSAProfile: ecdsaProfileName,
 		SerialPrefix: 17,

--- a/ca/config/config.go
+++ b/ca/config/config.go
@@ -1,0 +1,77 @@
+package ca_config
+
+import (
+	cfsslConfig "github.com/cloudflare/cfssl/config"
+	"github.com/letsencrypt/pkcs11key"
+
+	"github.com/letsencrypt/boulder/cmd"
+)
+
+// CAConfig structs have configuration information for the certificate
+// authority, including database parameters as well as controls for
+// issued certificates.
+type CAConfig struct {
+	cmd.ServiceConfig
+	cmd.DBConfig
+	cmd.HostnamePolicyConfig
+
+	GRPCCA            *cmd.GRPCServerConfig
+	GRPCOCSPGenerator *cmd.GRPCServerConfig
+
+	RSAProfile   string
+	ECDSAProfile string
+	TestMode     bool
+	SerialPrefix int
+	// TODO(jsha): Remove Key field once we've migrated to Issuers
+	Key *IssuerConfig
+	// Issuers contains configuration information for each issuer cert and key
+	// this CA knows about. The first in the list is used as the default.
+	Issuers []IssuerConfig
+	// LifespanOCSP is how long OCSP responses are valid for; It should be longer
+	// than the minTimeToExpiry field for the OCSP Updater.
+	LifespanOCSP cmd.ConfigDuration
+	// How long issued certificates are valid for, should match expiry field
+	// in cfssl config.
+	Expiry string
+	// How far back certificates should be backdated, should match backdate
+	// field in cfssl config.
+	Backdate cmd.ConfigDuration
+	// The maximum number of subjectAltNames in a single certificate
+	MaxNames int
+	CFSSL    cfsslConfig.Config
+
+	// DoNotForceCN is a temporary config setting. It controls whether
+	// to add a certificate's serial to its Subject, and whether to
+	// not pull a SAN entry to be the CN if no CN was given in a CSR.
+	DoNotForceCN bool
+
+	// EnableMustStaple governs whether the Must Staple extension in CSRs
+	// triggers issuance of certificates with Must Staple.
+	EnableMustStaple bool
+
+	// EnablePrecertificateFlow governs whether precertificate-based issuance
+	// is enabled.
+	EnablePrecertificateFlow bool
+
+	// WeakKeyFile is the path to a JSON file containing truncated RSA modulus
+	// hashes of known easily enumerable keys.
+	WeakKeyFile string
+
+	SAService *cmd.GRPCClientConfig
+
+	Features map[string]bool
+}
+
+// IssuerConfig contains info about an issuer: private key and issuer cert.
+// It should contain either a File path to a PEM-format private key,
+// or a PKCS11Config defining how to load a module for an HSM.
+type IssuerConfig struct {
+	// A file from which a pkcs11key.Config will be read and parsed, if present
+	ConfigFile string
+	File       string
+	PKCS11     *pkcs11key.Config
+	CertFile   string
+	// Number of sessions to open with the HSM. For maximum performance,
+	// this should be equal to the number of cores in the HSM. Defaults to 1.
+	NumSessions int
+}

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/letsencrypt/boulder/ca"
+	"github.com/letsencrypt/boulder/ca/config"
 	caPB "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
@@ -26,7 +27,7 @@ import (
 )
 
 type config struct {
-	CA cmd.CAConfig
+	CA ca_config.CAConfig
 
 	PA cmd.PAConfig
 
@@ -60,7 +61,7 @@ func loadIssuers(c config) ([]ca.Issuer, error) {
 	return issuers, nil
 }
 
-func loadIssuer(issuerConfig cmd.IssuerConfig) (crypto.Signer, *x509.Certificate, error) {
+func loadIssuer(issuerConfig ca_config.IssuerConfig) (crypto.Signer, *x509.Certificate, error) {
 	cert, err := core.LoadCert(issuerConfig.CertFile)
 	if err != nil {
 		return nil, nil, err
@@ -77,7 +78,7 @@ func loadIssuer(issuerConfig cmd.IssuerConfig) (crypto.Signer, *x509.Certificate
 	return signer, cert, err
 }
 
-func loadSigner(issuerConfig cmd.IssuerConfig) (crypto.Signer, error) {
+func loadSigner(issuerConfig ca_config.IssuerConfig) (crypto.Signer, error) {
 	if issuerConfig.File != "" {
 		keyBytes, err := ioutil.ReadFile(issuerConfig.File)
 		if err != nil {

--- a/cmd/boulder-ca/main_test.go
+++ b/cmd/boulder-ca/main_test.go
@@ -3,11 +3,11 @@ package main
 import (
 	"testing"
 
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/ca/config"
 )
 
 func TestLoadIssuerSuccess(t *testing.T) {
-	signer, cert, err := loadIssuer(cmd.IssuerConfig{
+	signer, cert, err := loadIssuer(ca_config.IssuerConfig{
 		File:     "../../test/test-ca.key",
 		CertFile: "../../test/test-ca2.pem",
 	})
@@ -23,7 +23,7 @@ func TestLoadIssuerSuccess(t *testing.T) {
 }
 
 func TestLoadIssuerBadKey(t *testing.T) {
-	_, _, err := loadIssuer(cmd.IssuerConfig{
+	_, _, err := loadIssuer(ca_config.IssuerConfig{
 		File:     "/dev/null",
 		CertFile: "../../test/test-ca2.pem",
 	})
@@ -33,7 +33,7 @@ func TestLoadIssuerBadKey(t *testing.T) {
 }
 
 func TestLoadIssuerBadCert(t *testing.T) {
-	_, _, err := loadIssuer(cmd.IssuerConfig{
+	_, _, err := loadIssuer(ca_config.IssuerConfig{
 		File:     "../../test/test-ca.key",
 		CertFile: "/dev/null",
 	})

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,9 +10,6 @@ import (
 	"strings"
 	"time"
 
-	cfsslConfig "github.com/cloudflare/cfssl/config"
-	"github.com/letsencrypt/pkcs11key"
-
 	"github.com/letsencrypt/boulder/core"
 )
 
@@ -73,61 +70,6 @@ type SMTPConfig struct {
 	Username string
 }
 
-// CAConfig structs have configuration information for the certificate
-// authority, including database parameters as well as controls for
-// issued certificates.
-type CAConfig struct {
-	ServiceConfig
-	DBConfig
-	HostnamePolicyConfig
-
-	GRPCCA            *GRPCServerConfig
-	GRPCOCSPGenerator *GRPCServerConfig
-
-	RSAProfile   string
-	ECDSAProfile string
-	TestMode     bool
-	SerialPrefix int
-	// TODO(jsha): Remove Key field once we've migrated to Issuers
-	Key *IssuerConfig
-	// Issuers contains configuration information for each issuer cert and key
-	// this CA knows about. The first in the list is used as the default.
-	Issuers []IssuerConfig
-	// LifespanOCSP is how long OCSP responses are valid for; It should be longer
-	// than the minTimeToExpiry field for the OCSP Updater.
-	LifespanOCSP ConfigDuration
-	// How long issued certificates are valid for, should match expiry field
-	// in cfssl config.
-	Expiry string
-	// How far back certificates should be backdated, should match backdate
-	// field in cfssl config.
-	Backdate ConfigDuration
-	// The maximum number of subjectAltNames in a single certificate
-	MaxNames int
-	CFSSL    cfsslConfig.Config
-
-	// DoNotForceCN is a temporary config setting. It controls whether
-	// to add a certificate's serial to its Subject, and whether to
-	// not pull a SAN entry to be the CN if no CN was given in a CSR.
-	DoNotForceCN bool
-
-	// EnableMustStaple governs whether the Must Staple extension in CSRs
-	// triggers issuance of certificates with Must Staple.
-	EnableMustStaple bool
-
-	// EnablePrecertificateFlow governs whether precertificate-based issuance
-	// is enabled.
-	EnablePrecertificateFlow bool
-
-	// WeakKeyFile is the path to a JSON file containing truncated RSA modulus
-	// hashes of known easily enumerable keys.
-	WeakKeyFile string
-
-	SAService *GRPCClientConfig
-
-	Features map[string]bool
-}
-
 // PAConfig specifies how a policy authority should connect to its
 // database, what policies it should enforce, and what challenges
 // it should offer.
@@ -155,20 +97,6 @@ func (pc PAConfig) CheckChallenges() error {
 		}
 	}
 	return nil
-}
-
-// IssuerConfig contains info about an issuer: private key and issuer cert.
-// It should contain either a File path to a PEM-format private key,
-// or a PKCS11Config defining how to load a module for an HSM.
-type IssuerConfig struct {
-	// A file from which a pkcs11key.Config will be read and parsed, if present
-	ConfigFile string
-	File       string
-	PKCS11     *pkcs11key.Config
-	CertFile   string
-	// Number of sessions to open with the HSM. For maximum performance,
-	// this should be equal to the number of cores in the HSM. Defaults to 1.
-	NumSessions int
 }
 
 // TLSConfig represents certificates and a key for authenticated TLS.


### PR DESCRIPTION
We removed most of the component-specific configs out of cmd a long time ago. We
left CAConfig in, because it is used directly in the NewCertificateAuthority
constructor. That means that moving CAConfig into cmd/boulder-ca would have
resulted in a circular dependency.

Eventually we probably want to decompose CAConfig so it's a set of arguments to
NewCertificateAuthority, but as a short term improvement, move the config into
its own package to break the dependency. This has the advantage of removing a
couple of big dependencies from cmd.