### PR TITLE
Limit number of authzs purged at once.

### DIFF
--- a/cmd/expired-authz-purger/config.json
+++ b/cmd/expired-authz-purger/config.json
@@ -7,6 +7,7 @@
         "maxDBConns": 10,
         "gracePeriod": "168h",
         "batchSize": 1000,
+        "maxAuthzs": 10000,
         "parallelism": 20
     }
 }

--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -62,9 +62,9 @@ func (p *expiredAuthzPurger) purge(table string, yes bool, purgeBefore time.Time
 		var query string
 		switch table {
 		case "pendingAuthorizations":
-			query = "SELECT id FROM pendingAuthorizations WHERE expires <= ? LIMIT ? OFFSET ?"
+			query = "SELECT id FROM pendingAuthorizations WHERE expires <= ? ORDER BY id LIMIT ? OFFSET ?"
 		case "authz":
-			query = "SELECT id FROM authz WHERE expires <= ? LIMIT ? OFFSET ?"
+			query = "SELECT id FROM authz WHERE expires <= ? ORDER BY id LIMIT ? OFFSET ?"
 		}
 		_, err := p.db.Select(
 			&idBatch,

--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -47,8 +47,8 @@ type expiredAuthzPurger struct {
 
 // purge looks up pending or finalized authzs (depending on the value of
 // `table`) that expire before `purgeBefore`. If `yes` is true, or if a user at
-// the terminal types "y", it will then delete those authzs, using `parallel`
-// goroutines.
+// the terminal types "y", it will then delete those authzs, using `parallelism`
+// goroutines. It will delete a maximum of `max` authzs.
 // Neither table has an index on `expires` by itself, so we just iterate through
 // the table with LIMIT and OFFSET using the default ordering. Note that this
 // becomes expensive once the earliest set of authzs has been purged, since the

--- a/cmd/expired-authz-purger/main_test.go
+++ b/cmd/expired-authz-purger/main_test.go
@@ -33,7 +33,7 @@ func TestPurgeAuthzs(t *testing.T) {
 
 	p := expiredAuthzPurger{log, fc, dbMap, 1}
 
-	err = p.purgeAuthzs(time.Time{}, true, 10)
+	err = p.purgeAuthzs(time.Time{}, true, 10, 100)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 
 	old, new := fc.Now().Add(-time.Hour), fc.Now().Add(time.Hour)
@@ -58,7 +58,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "NewPendingAuthorization failed")
 
-	err = p.purgeAuthzs(fc.Now(), true, 10)
+	err = p.purgeAuthzs(fc.Now(), true, 10, 100)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err := dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
@@ -67,7 +67,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
 	test.AssertEquals(t, count, int64(1))
 
-	err = p.purgeAuthzs(fc.Now().Add(time.Hour), true, 10)
+	err = p.purgeAuthzs(fc.Now().Add(time.Hour), true, 10, 100)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err = dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")

--- a/test/authz-filler/config.json
+++ b/test/authz-filler/config.json
@@ -1,6 +1,6 @@
 {
   "Filler": {
     "Parallelism": 20,
-    "DBConnect": "mysql+tcp://sa@boulder-mysql:3306/boulder_sa_integration?readTimeout=14s&writeTimeout=14s&timeout=100ms"
+    "dbConnectFile": "test/secrets/sa_dburl",
   }
 }

--- a/test/authz-filler/config.json
+++ b/test/authz-filler/config.json
@@ -1,0 +1,6 @@
+{
+  "Filler": {
+    "Parallelism": 20,
+    "DBConnect": "mysql+tcp://sa@boulder-mysql:3306/boulder_sa_integration?readTimeout=14s&writeTimeout=14s&timeout=100ms"
+  }
+}

--- a/test/authz-filler/main.go
+++ b/test/authz-filler/main.go
@@ -1,0 +1,92 @@
+// A quick way to fill up a database with a large number of authz objects, in
+// order to manually test the performance of the expired-authz-purger.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/sa"
+)
+
+type fillerConfig struct {
+	Filler struct {
+		cmd.DBConfig
+		Parallelism uint
+	}
+}
+
+type model struct {
+	core.Authorization
+
+	LockCol int
+}
+
+func main() {
+	configPath := flag.String("config", "config.json", "Path to Boulder configuration file")
+	flag.Parse()
+
+	configJSON, err := ioutil.ReadFile(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read config file '%s': %s\n", *configPath, err)
+		os.Exit(1)
+	}
+
+	var config fillerConfig
+	err = json.Unmarshal(configJSON, &config)
+	cmd.FailOnError(err, "Failed to parse config")
+
+	// Configure DB
+	dbURL, err := config.Filler.DBConfig.URL()
+	cmd.FailOnError(err, "Couldn't load DB URL")
+	dbMap, err := sa.NewDbMap(dbURL, 1000)
+	cmd.FailOnError(err, "Could not connect to database")
+
+	dbMap.AddTableWithName(model{}, "pendingAuthorizations").SetKeys(false, "ID")
+	span := 24 * time.Hour * 365
+	start := time.Now().Add(-span)
+	increment := time.Hour
+
+	work := make(chan time.Time, 1000)
+	go func() {
+		for i := 0; i < int(span)/int(increment); i++ {
+			expires := start.Add(time.Duration(i) * increment)
+			for j := 0; j < 30000; j++ {
+				work <- expires
+			}
+		}
+	}()
+
+	for i := 0; i < int(config.Filler.Parallelism); i++ {
+		go func() {
+			for expires := range work {
+				err = dbMap.Insert(&model{
+					core.Authorization{
+						ID:             core.NewToken(),
+						RegistrationID: 1,
+						Expires:        &expires,
+						Combinations:   [][]int{[]int{1, 2, 3}},
+						Status:         "pending",
+						Identifier: core.AcmeIdentifier{
+							Type:  "dns",
+							Value: "example.com",
+						},
+					},
+					0,
+				})
+				if err != nil {
+					log.Print(err)
+				}
+			}
+		}()
+	}
+
+	select {}
+}


### PR DESCRIPTION
Previously the expired-authz-purger would try to load the ids for all relevant
authzs into memory before doing any work. On a very large table, this would mean
running out of memory. This setting allows limiting how much work will be done
in one chunk.

Also add periodic logging of deletion count.

Fixes #3147.