### PR TITLE
Add a renewal bit to issuedNames.

### DIFF
--- a/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
+++ b/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
@@ -2,13 +2,14 @@
 -- +goose Up
 ALTER TABLE issuedNames
        ADD COLUMN renewal TINYINT(1) NOT NULL DEFAULT 0,
-       ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`),
-       DROP INDEX `reversedName_notBefore_Idx`
+       ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`);
 ;
+
+-- TODO: DROP INDEX `reversedName_renewal_notBefore_Idx` once we are no longer
+-- relying on it for queries.
 
 -- +goose Down
 ALTER TABLE issuedNames
        DROP COLUMN renewal,
-       ADD INDEX `reversedName_notBefore_Idx` (`reversedName`,`notBefore`),
-       DROP INDEX `reversedName_renewal_notBefore_Idx`
+       DROP INDEX `reversedName_renewal_notBefore_Idx`;
 ;

--- a/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
+++ b/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
@@ -1,0 +1,14 @@
+
+-- +goose Up
+ALTER TABLE issuedNames
+       ADD COLUMN renewal TINYINT(1) NOT NULL DEFAULT 0,
+       ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`),
+       DROP INDEX `reversedName_notBefore_Idx`
+;
+
+-- +goose Down
+ALTER TABLE issuedNames
+       DROP COLUMN renewal,
+       ADD INDEX `reversedName_notBefore_Idx` (`reversedName`,`notBefore`),
+       DROP INDEX `reversedName_renewal_notBefore_Idx`
+;

--- a/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
+++ b/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
@@ -5,6 +5,9 @@ ALTER TABLE issuedNames
        ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`);
 ;
 
+-- TODO: DROP INDEX `reversedName_renewal_notBefore_Idx` once we are no longer
+-- relying on it for queries.
+
 -- +goose Down
 ALTER TABLE issuedNames
        DROP COLUMN renewal,

--- a/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
+++ b/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
@@ -3,7 +3,6 @@
 ALTER TABLE issuedNames
        ADD COLUMN renewal TINYINT(1) NOT NULL DEFAULT 0,
        ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`);
-;
 
 -- TODO: DROP INDEX `reversedName_renewal_notBefore_Idx` once we are no longer
 -- relying on it for queries.

--- a/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
+++ b/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
@@ -5,9 +5,6 @@ ALTER TABLE issuedNames
        ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`);
 ;
 
--- TODO: DROP INDEX `reversedName_renewal_notBefore_Idx` once we are no longer
--- relying on it for queries.
-
 -- +goose Down
 ALTER TABLE issuedNames
        DROP COLUMN renewal,


### PR DESCRIPTION
This is only the migration, so far. Rather than doing the feature-switch dance,
we can wait for this migration to be applied, and then commit the code to start
setting it, with a feature switch to start checking it, which can be turned on
once we've been setting the bit in production for a week.

Having this as an indexed bit on issuedNames allows us to cheaply exclude
renewals from our rate limit queries, so we can avoid the ordering dependency
for renewals vs new issuances on the same domain.

Fixes #3161