### PR TITLE
Fix up stats after #3167

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -133,9 +133,10 @@ func main() {
 	wfe.BaseURL = c.Common.BaseURL
 
 	logger.Info(fmt.Sprintf("Server running, listening on %s...\n", c.WFE.ListenAddress))
+	handler := wfe.Handler()
 	srv := &http.Server{
 		Addr:    c.WFE.ListenAddress,
-		Handler: wfe.Handler(),
+		Handler: handler,
 	}
 
 	go func() {
@@ -149,7 +150,7 @@ func main() {
 	if c.WFE.TLSListenAddress != "" {
 		tlsSrv = &http.Server{
 			Addr:    c.WFE.TLSListenAddress,
-			Handler: wfe.Handler(),
+			Handler: handler,
 		}
 		go func() {
 			err := tlsSrv.ListenAndServeTLS(c.WFE.ServerCertificatePath, c.WFE.ServerKeyPath)

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -133,9 +133,10 @@ func main() {
 	wfe.BaseURL = c.Common.BaseURL
 
 	logger.Info(fmt.Sprintf("Server running, listening on %s...\n", c.WFE.ListenAddress))
+	handler := wfe.Handler()
 	srv := &http.Server{
 		Addr:    c.WFE.ListenAddress,
-		Handler: wfe.Handler(),
+		Handler: handler,
 	}
 
 	go func() {
@@ -149,7 +150,7 @@ func main() {
 	if c.WFE.TLSListenAddress != "" {
 		tlsSrv = &http.Server{
 			Addr:    c.WFE.TLSListenAddress,
-			Handler: wfe.Handler(),
+			Handler: handler,
 		}
 		go func() {
 			err := tlsSrv.ListenAndServeTLS(c.WFE.ServerCertificatePath, c.WFE.ServerKeyPath)

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -253,5 +253,5 @@ func mux(scope metrics.Scope, responderPath string, source cfocsp.Source) http.H
 		}
 		stripPrefix.ServeHTTP(w, r)
 	})
-	return measured_http.New(&ocspMux{h}, cmd.Clock())
+	return measured_http.New(&ocspMux{h}, cmd.Clock(), scope)
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -153,7 +153,7 @@ func NewLogger(logConf SyslogConfig) blog.Logger {
 func newScope(addr string, logger blog.Logger) metrics.Scope {
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(prometheus.NewGoCollector())
-	registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), "boulder"))
+	registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
 
 	mux := http.NewServeMux()
 	// Register each of the available pprof handlers. These are all registered on

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -417,6 +417,17 @@ def test_admin_revoker_authz():
     if data['status'] != "revoked":
         raise Exception("Authorization wasn't revoked")
 
+def test_stats():
+    def expect_stat(port, stat):
+        url = "http://localhost:%d/metrics" % port
+        response = requests.get(url)
+        if not stat in response.content:
+            print(response.content)
+            raise Exception("%s not present in %s" % (stat, url))
+    expect_stat(8000, "\nresponse_time_count{")
+    expect_stat(8000, "\ngo_goroutines ")
+    expect_stat(8001, "\ngo_goroutines ")
+
 exit_status = 1
 tempdir = tempfile.mkdtemp()
 
@@ -483,6 +494,7 @@ def run_chisel():
     test_renewal_exemption()
     test_expired_authzs_404()
     test_account_update()
+    test_stats()
 
 if __name__ == "__main__":
     try:

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -323,7 +323,7 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	// meaning we can wind up returning 405 when we mean to return 404. See
 	// https://github.com/letsencrypt/boulder/issues/717
 	m.Handle("/", web.NewTopHandler(wfe.log, web.WFEHandlerFunc(wfe.Index)))
-	return measured_http.New(m, wfe.clk)
+	return measured_http.New(m, wfe.clk, wfe.stats)
 }
 
 // Method implementations


### PR DESCRIPTION
There were two bugs in #3167:
   - All process-level stats got prefixed with "boulder", which broke dashboards.
   - All `request_time` stats got dropped, because measured_http was using the prometheus DefaultRegisterer.

To fix, this PR plumbs through a scope object to measured_http, and uses an empty prefix when calling NewProcessCollector().
