### PR TITLE
Revert "Reject CAA responses containing DNAMEs (#3082)"

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -469,12 +469,12 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 	var CAAs []*dns.CAA
 	var CNAMEs []*dns.CNAME
 	for _, answer := range r.Answer {
-		if caaR, ok := answer.(*dns.CAA); ok {
-			CAAs = append(CAAs, caaR)
-		} else if _, ok := answer.(*dns.DNAME); ok {
-			return nil, nil, fmt.Errorf("Got DNAME when looking up CNAME. DNAMEs not supported.")
-		} else if cnameR, ok := answer.(*dns.CNAME); ok {
-			CNAMEs = append(CNAMEs, cnameR)
+		if answer.Header().Rrtype == dnsType {
+			if caaR, ok := answer.(*dns.CAA); ok {
+				CAAs = append(CAAs, caaR)
+			} else if cnameR, ok := answer.(*dns.CNAME); ok {
+				CNAMEs = append(CNAMEs, cnameR)
+			}
 		}
 	}
 	return CAAs, CNAMEs, nil

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -469,12 +469,10 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 	var CAAs []*dns.CAA
 	var CNAMEs []*dns.CNAME
 	for _, answer := range r.Answer {
-		if answer.Header().Rrtype == dnsType {
-			if caaR, ok := answer.(*dns.CAA); ok {
-				CAAs = append(CAAs, caaR)
-			} else if cnameR, ok := answer.(*dns.CNAME); ok {
-				CNAMEs = append(CNAMEs, cnameR)
-			}
+		if caaR, ok := answer.(*dns.CAA); ok {
+			CAAs = append(CAAs, caaR)
+		} else if cnameR, ok := answer.(*dns.CNAME); ok {
+			CNAMEs = append(CNAMEs, cnameR)
 		}
 	}
 	return CAAs, CNAMEs, nil

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -140,12 +140,6 @@ func mockDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				record.Flag = 1
 				appendAnswer(record)
 			}
-			if q.Name == "dname.example.com." {
-				appendAnswer(&dns.DNAME{
-					Hdr:    dns.RR_Header{Name: "dname.example.com.", Rrtype: dns.TypeDNAME, Class: dns.ClassINET, Ttl: 0},
-					Target: "dname.example.net.",
-				})
-			}
 		case dns.TypeTXT:
 			if q.Name == "split-txt.letsencrypt.org." {
 				record := new(dns.TXT)
@@ -428,11 +422,6 @@ func TestDNSLookupCAA(t *testing.T) {
 	caas, _, err = obj.LookupCAA(context.Background(), "cname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")
-
-	_, _, err = obj.LookupCAA(context.Background(), "dname.example.com")
-	if err == nil {
-		t.Errorf("Expected failure when returning DNAME, but got success")
-	}
 }
 
 func TestDNSTXTAuthorities(t *testing.T) {


### PR DESCRIPTION
This reverts commit 08d2018c104966c8ec358d8f27e5c8cca75919fa.

Feedback from root programs:

https://cabforum.org/pipermail/public/2017-October/012293.html
https://cabforum.org/pipermail/public/2017-October/012297.html
https://cabforum.org/pipermail/public/2017-October/012358.html
https://cabforum.org/pipermail/public/2017-October/012320.html

Resolves #3130.