### PR TITLE
docker network friendly test setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ to match how the VA operates in production and staging environments. If you use
 a host-based firewall (e.g. `ufw` or `iptables`) make sure you allow connections
 from the Docker instance to your host on the required ports.
 
+If you intend to use an ACME client in a docker container and want to connect
+to the Boulder instance started by `docker-compose`, you may attach your
+ACME client container to the `boulder_default` network that `docker-compose` creates
+and tell Boulder to use the DNS resolver provided by Docker and not the
+fake one. For that change `dnsResolver` in `test/config/va.json` and
+`test/config/ra.json` to point to `127.0.0.11:53`. Then after
+`docker-compose up` you can use `http://boulder:4000/directory` in your
+clients to connect to Boulder as long as they are attached to
+`boulder_default` network. Alternatively you can change
+`docker-compose.yml` to attach the Boulder container to the docker network
+where your containers run.
+
+If you only connect to the Boulder instance from other Docker containers
+and not from the host or external IP addresses, you may also drop all
+`ports` lines from `docker-compose.yml`. This prevents the Boulder container from being accessible from external network interfaces.
+
 If a base image changes (i.e. `letsencrypt/boulder-tools`) you will need to rebuild
 images for both the boulder and bhsm containers and re-create them. The quickest way
 to do this is with this command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
           - /tmp:/tmp
-        network_mode: bridge
         extra_hosts:
           - le.wtf:127.0.0.1
           - boulder:127.0.0.1
@@ -37,9 +36,9 @@ services:
           - 8055:8055 # dns-test-srv updates
           - 9380:9380 # mail-test-srv
           - 9381:9381 # mail-test-srv
-        links:
-          - bhsm:boulder-hsm
-          - bmysql:boulder-mysql
+        depends_on:
+          - bhsm
+          - bmysql
     bhsm:
         # To minimize the fetching of various layers this should match
         # the FROM image and tag in boulder/Dockerfile
@@ -47,24 +46,28 @@ services:
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
-        expose:
-          - 5657
-        network_mode: bridge
+        # Allow other containers to use the name `boulder-hsm` to connect
+        networks:
+            default:
+                aliases:
+                  - boulder-hsm
     bmysql:
         image: mariadb:10.1
-        network_mode: bridge
         environment:
             MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         command: mysqld --bind-address=0.0.0.0
         logging:
             driver: none
+        networks:
+            default:
+                aliases:
+                  - boulder-mysql
     prom:
         image: prom/prometheus:v1.8.2
-        network_mode: bridge
         ports:
           - 9090:9090
         volumes:
-          - $PWD/test/prometheus/:/promconf/
+          - ./test/prometheus/:/promconf/
         command: -config.file /promconf/prometheus.yml
-        links:
+        depends_on:
           - boulder

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -28,6 +28,13 @@ EOF
 # make sure we can reach the mysqldb
 wait_tcp_port boulder-mysql 3306
 
+# Ensure that boulder-mysql is in /etc/hosts not to depend on Docker DNS
+# proxy to resolve the name when running tests.
+if ! egrep -q '\<boulder-mysql\>' /etc/hosts; then
+    ip_host="$(getent hosts boulder-mysql)"
+    printf '%s\n' "$ip_host" >> /etc/hosts
+fi
+
 # create the database
 MYSQL_CONTAINER=1 $DIR/create_db.sh
 


### PR DESCRIPTION
Change docker-compose.yml to use the network stack of bhsm container
for all services. This way Boulder can use 127.0.0.1 to always reach the
utility services independent of the networking setup.

Document how to change docker-compose.yml and test/config farther to
expose Boulder to clients running in other docker containers.