### PR TITLE
Restore expvar handler.

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"expvar"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -169,6 +170,7 @@ func newScope(addr string, logger blog.Logger) metrics.Scope {
 	reg("profile")
 	reg("threadcreate")
 	reg("trace")
+	mux.Handle("/debug/vars", expvar.Handler())
 	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{
 		ErrorLog: promLogger{logger},
 	}))


### PR DESCRIPTION
In #3167 I removed expvar, thinking it was unused, but it turns out the RA
exports the last issuance time, and core/util.go has a function to export
BuildID, both of which are used in monitoring. This wasn't caught at compile
time because the global expvar package was happy to register the exports even
though there was no handler to serve them.