### PR TITLE
Remove export of feature flags.

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -3,7 +3,6 @@
 package features
 
 import (
-	"expvar"
 	"fmt"
 	"sync"
 )
@@ -64,13 +63,6 @@ func init() {
 	}
 }
 
-// expvar.Set requires a type that satisfies the expvar.Var interface,
-// since neither string nor bool implement this interface we require
-// a basic shim.
-type boolVar bool
-
-func (b boolVar) String() string { return fmt.Sprintf("%t", b) }
-
 // Set accepts a list of features and whether they should
 // be enabled or disabled, it will return a error if passed
 // a feature name that it doesn't know
@@ -85,16 +77,6 @@ func Set(featureSet map[string]bool) error {
 		features[f] = v
 	}
 	return nil
-}
-
-// Export populates a expvar.Map with the state of all
-// of the features.
-func Export(m *expvar.Map) {
-	fMu.RLock()
-	defer fMu.RUnlock()
-	for f, v := range features {
-		m.Set(f.String(), boolVar(v))
-	}
 }
 
 // Enabled returns true if the feature is enabled or false

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -1,7 +1,6 @@
 package features
 
 import (
-	"expvar"
 	"testing"
 
 	"github.com/letsencrypt/boulder/test"
@@ -30,14 +29,4 @@ func TestFeatures(t *testing.T) {
 	}()
 	features = map[FeatureFlag]bool{}
 	Enabled(unused)
-}
-
-func TestExport(t *testing.T) {
-	features = map[FeatureFlag]bool{
-		unused: false,
-	}
-	m := expvar.NewMap("testing")
-	Export(m)
-	v := m.Get("unused")
-	test.AssertEquals(t, v.String(), "false")
 }


### PR DESCRIPTION
In #3167 I removed the code that would use this, but forgot to remove the
exporting code. This follows up on that. We don't currently use this for
monitoring, and it's easier to get the current flags from a config file.