### PR TITLE
Revert "Logic error.  Always-zero-value-variable used. (#3126)"

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -465,6 +465,7 @@ func (ssa *SQLStorageAuthority) countCertificatesByExactName(domain string, earl
 // certificates than that matching one of the provided domain names, it will return
 // TooManyCertificatesError.
 func (ssa *SQLStorageAuthority) countCertificates(domain string, earliest, latest time.Time, query string) (int, error) {
+	var count int64
 	const max = 10000
 	var serials []string
 	_, err := ssa.dbMap.Select(
@@ -480,7 +481,7 @@ func (ssa *SQLStorageAuthority) countCertificates(domain string, earliest, lates
 		return 0, nil
 	} else if err != nil {
 		return 0, err
-	} else if len(serials) > max {
+	} else if count > max {
 		return max, TooManyCertificatesError(fmt.Sprintf("More than %d issuedName entries for %s.", max, domain))
 	}
 


### PR DESCRIPTION
This reverts commit 887d75f1e0019694ec7aab9d9a60f9da69f013db.

Part of #3214.