### PR TITLE
Add a missing "2" to commit id.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -87,7 +87,7 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Comment": "v0.4-8-g3043356",
+			"Comment": "v0.4-8-g30433562",
 			"Rev": "30433562cfbf487fe1df7cd26c7bab168d2f14d0"
 		},
 		{


### PR DESCRIPTION
Our CI tests that `godep restore; godep save ./...` reproduces the exact Godeps.json that's committed. For some reason, after #3206 and #3207 were merged recently, CI started failing with a diff suggesting that it wanted this extra digit on the commit id for one of our dependencies. This is mysterious because:

 - All other commit ids are 7 digits, this one with the "2" added is 8 digits (there are no commits with the same 7-digit prefix in gogo/protobuf)
 - When running the same commands locally, I get a Godeps.json that contains the 7 digit commit id.

To fix our build, I manually edited in the extra digit. This appears to make tests pass.