### PR TITLE
Add indexes on certificateStatus.

### DIFF
--- a/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
+++ b/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
@@ -4,9 +4,6 @@ ALTER TABLE issuedNames
        ADD COLUMN renewal TINYINT(1) NOT NULL DEFAULT 0,
        ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`);
 
--- TODO: DROP INDEX `reversedName_renewal_notBefore_Idx` once we are no longer
--- relying on it for queries.
-
 -- +goose Down
 ALTER TABLE issuedNames
        DROP COLUMN renewal,

--- a/sa/_db-next/migrations/20171107160000_AddCertificateStatusIndexes.sql
+++ b/sa/_db-next/migrations/20171107160000_AddCertificateStatusIndexes.sql
@@ -1,13 +1,13 @@
 -- +goose Up
 ALTER TABLE certificateStatus
-       ADD INDEX `isExpired_ocspLastUpdated_Idx` (`isExpired`, `ocspLastUpdated`),
-       ADD INDEX `notAfter_Idx` (`notAfter`),
+       ADD INDEX `isExpired_ocspLastUpdated_idx` (`isExpired`, `ocspLastUpdated`),
+       ADD INDEX `notAfter_idx` (`notAfter`),
        DROP INDEX `status_certificateStatus_idx`,
        DROP INDEX `ocspLastUpdated_certificateStatus_idx`;
 
 -- +goose Down
 ALTER TABLE certificateStatus
-       DROP INDEX `isExpired_ocspLastUpdated_Idx`,
-       DROP INDEX `notAfter_Idx`,
+       DROP INDEX `isExpired_ocspLastUpdated_idx`,
+       DROP INDEX `notAfter_idx`,
        ADD INDEX `ocspLastUpdated_certificateStatus_idx` (`ocspLastUpdated`),
        ADD INDEX `status_certificateStatus_idx` (`status`);

--- a/sa/_db-next/migrations/20171107160000_AddCertificateStatusIndexes.sql
+++ b/sa/_db-next/migrations/20171107160000_AddCertificateStatusIndexes.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE certificateStatus
+       ADD INDEX `isExpired_ocspLastUpdated_Idx` (`isExpired`, `ocspLastUpdated),
+       ADD INDEX `notAfter_Idx` (`notAfter`),
+       DROP INDEX `status_certificateStatus_idx`,
+       DROP INDEX `ocspLastUpdated_certificateStatus_idx`;
+
+-- +goose Down
+ALTER TABLE certificateStatus
+       DROP INDEX `isExpired_ocspLastUpdated_Idx`,
+       DROP INDEX `notAfter_Idx`,
+       ADD INDEX `ocspLastUpdated_certificateStatus_idx` (`ocspLastUpdated`),
+       ADD INDEX `status_certificateStatus_idx` (`status`);

--- a/sa/_db-next/migrations/20171107160000_AddCertificateStatusIndexes.sql
+++ b/sa/_db-next/migrations/20171107160000_AddCertificateStatusIndexes.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 ALTER TABLE certificateStatus
-       ADD INDEX `isExpired_ocspLastUpdated_Idx` (`isExpired`, `ocspLastUpdated),
+       ADD INDEX `isExpired_ocspLastUpdated_Idx` (`isExpired`, `ocspLastUpdated`),
        ADD INDEX `notAfter_Idx` (`notAfter`),
        DROP INDEX `status_certificateStatus_idx`,
        DROP INDEX `ocspLastUpdated_certificateStatus_idx`;


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/issues/1864 we discussed possible
optimizations to how expiration-mailer and ocsp-updater query the
certificateStatus table. In https://github.com/letsencrypt/boulder/pull/2177 we
added the `notAfter` and `isExpired` fields for more efficient querying.
However, we forgot to add indexes on these fields. This change adds new indexes
and drops the old indexes, and should result in much more efficient querying in
those two components.

Also, remove a comment that `goose` couldn't understand.

Running EXPLAINs to show the difference:

For expiration-mailer, before:
```
MariaDB [boulder_sa_integration]> EXPLAIN SELECT  cs.serial  FROM certificateStatus AS cs  WHERE cs.notAfter > DATE_ADD(NOW(), INTERVAL 21 DAY)  AND cs.notAfter < DATE_ADD(NOW(), INTERVAL 10 DAY)  AND cs.status != "revoked"  AND COALESCE(TIMESTAMPDIFF(SECOND, cs.lastExpirationNagSent, cs.notAfter) > 10 * 86400, 1)  ORDER BY cs.notAfter ASC  LIMIT 100000;
+------+-------------+-------+------+------------------------------+------+---------+------+------+-----------------------------+
| id   | select_type | table | type | possible_keys                | key  | key_len | ref  | rows | Extra                       |
+------+-------------+-------+------+------------------------------+------+---------+------+------+-----------------------------+
|    1 | SIMPLE      | cs    | ALL  | status_certificateStatus_idx | NULL | NULL    | NULL |  486 | Using where; Using filesort |
+------+-------------+-------+------+------------------------------+------+---------+------+------+-----------------------------+
1 row in set (0.00 sec)
```

For expiration-mailer, after:

```
MariaDB [boulder_sa_integration]> EXPLAIN SELECT  cs.serial  FROM certificateStatus AS cs  WHERE cs.notAfter < DATE_ADD(NOW(), INTERVAL 21 DAY)  AND cs.notAfter < DATE_ADD(NOW(), INTERVAL 10 DAY)  AND cs.status != "revoked"  AND COALESCE(TIMESTAMPDIFF(SECOND, cs.lastExpirationNagSent, cs.notAfter) > 10 * 86400, 1)  ORDER BY cs.notAfter ASC  LIMIT 100000;
+------+-------------+-------+-------+---------------+--------------+---------+------+------+------------------------------------+
| id   | select_type | table | type  | possible_keys | key          | key_len | ref  | rows | Extra                              |
+------+-------------+-------+-------+---------------+--------------+---------+------+------+------------------------------------+
|    1 | SIMPLE      | cs    | range | notAfter_idx  | notAfter_idx | 6       | NULL |    1 | Using index condition; Using where |
+------+-------------+-------+-------+---------------+--------------+---------+------+------+------------------------------------+
```

For ocsp-updater, before:

```
MariaDB [boulder_sa_integration]> EXPLAIN SELECT    cs.serial,    cs.status,    cs.revokedDate,    cs.notAfter    FROM certificateStatus AS cs    WHERE cs.ocspLastUpdated > DATE_SUB(NOW(), INTERVAL 10 DAY)    AND cs.ocspLastUpdated < DATE_SUB(NOW(), INTERVAL 3 DAY)    AND NOT cs.isExpired    ORDER BY cs.ocspLastUpdated ASC    LIMIT 100000;
+------+-------------+-------+-------+---------------------------------------+---------------------------------------+---------+------+------+------------------------------------+
| id   | select_type | table | type  | possible_keys                         | key                                   | key_len | ref  | rows | Extra                              |
+------+-------------+-------+-------+---------------------------------------+---------------------------------------+---------+------+------+------------------------------------+
|    1 | SIMPLE      | cs    | range | ocspLastUpdated_certificateStatus_idx | ocspLastUpdated_certificateStatus_idx | 5       | NULL |    1 | Using index condition; Using where |
+------+-------------+-------+-------+---------------------------------------+---------------------------------------+---------+------+------+------------------------------------+
1 row in set (0.00 sec)
```

For ocsp-updater, after:
```
MariaDB [boulder_sa_integration]> EXPLAIN SELECT    cs.serial,    cs.status,    cs.revokedDate,    cs.notAfter    FROM certificateStatus AS cs    WHERE cs.ocspLastUpdated > DATE_SUB(NOW(), INTERVAL 10 DAY)    AND cs.ocspLastUpdated < DATE_SUB(NOW(), INTERVAL 3 DAY)    AND NOT cs.isExpired    ORDER BY cs.ocspLastUpdated ASC    LIMIT 100000;
+------+-------------+-------+-------+-------------------------------+-------------------------------+---------+------+------+-----------------------+
| id   | select_type | table | type  | possible_keys                 | key                           | key_len | ref  | rows | Extra                 |
+------+-------------+-------+-------+-------------------------------+-------------------------------+---------+------+------+-----------------------+
|    1 | SIMPLE      | cs    | range | isExpired_ocspLastUpdated_idx | isExpired_ocspLastUpdated_idx | 7       | NULL |    1 | Using index condition |
+------+-------------+-------+-------+-------------------------------+-------------------------------+---------+------+------+-----------------------+
1 row in set (0.00 sec)
```