### PR TITLE
Remove background subprocess for DB migrations.

### DIFF
--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -15,7 +15,6 @@ fi
 mysql $dbconn -e "SET GLOBAL binlog_format = 'MIXED';"
 
 for dbenv in $DBENVS; do
-  (
   db="boulder_sa_${dbenv}"
 
   if mysql $dbconn -e 'show databases;' | grep $db > /dev/null; then
@@ -62,8 +61,6 @@ for dbenv in $DBENVS; do
       mysql $dbconn -D $db -f < $USERS_SQL || die "unable to add users to ${db}"
   fi
   echo "added users to ${db}"
-  ) &
 done
-wait
 
 echo "created all databases"


### PR DESCRIPTION
We started running our DB migrations in the background to speed up CI. However,
the semantics of subprocesses and `wait` mean that if a migration fails, the
overall `create_db.sh` doesn't fail. That means, for instance, tests continue to
run, and it's hard to find the resulting error.

This change runs the migrations in serial again so that we can catch such errors
more easily.