### PR TITLE
Pin version of Prometheus to 1.8.2 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         logging:
             driver: none
     prom:
-        image: prom/prometheus
+        image: prom/prometheus:v1.8.2
         network_mode: bridge
         ports:
           - 9090:9090


### PR DESCRIPTION
Pin version of Prometheus to 1.8.2 because Prometheus folks has just released v2 and switched the :latest tag to that.

Using Prometheus v2 produces an error:
>  prometheus: error: unknown short flag '-c'