### PR TITLE
Don't 500 on missing pendingAuthz

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2007,11 +2007,11 @@ func TestNewOrder(t *testing.T) {
 }
 
 // TestUpdateMissingAuthorization tests the race condition where a challenge is
-// updated to valid concurrent to another attempt to have the challenge updated.
-// Previously this would return a `berrors.InternalServer` error when the row
-// was found missing from `pendingAuthorizations` by the 2nd update since the
-// 1st had already deleted it. We accept this may happen and now test for
-// a `berrors.NotFound` error return.
+// updated to valid concurrently with another attempt to have the challenge
+// updated. Previously this would return a `berrors.InternalServer` error when
+// the row was found missing from `pendingAuthorizations` by the 2nd update
+// since the 1st had already deleted it. We accept this may happen and now test
+// for a `berrors.NotFound` error return.
 //
 // See https://github.com/letsencrypt/boulder/issues/3201
 func TestUpdateMissingAuthorization(t *testing.T) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2006,6 +2006,42 @@ func TestNewOrder(t *testing.T) {
 	test.AssertDeepEquals(t, existing, order.Authorizations)
 }
 
+// TestUpdateMissingAuthorization tests the race condition where a challenge is
+// updated to valid concurrent to another attempt to have the challenge updated.
+// Previously this would return a `berrors.InternalServer` error when the row
+// was found missing from `pendingAuthorizations` by the 2nd update since the
+// 1st had already deleted it. We accept this may happen and now test for
+// a `berrors.NotFound` error return.
+//
+// See https://github.com/letsencrypt/boulder/issues/3201
+func TestUpdateMissingAuthorization(t *testing.T) {
+	_, _, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+	ctx := context.Background()
+
+	authz, err := ra.NewAuthorization(ctx, AuthzRequest, Registration.ID)
+	test.AssertNotError(t, err, "NewAuthorization failed")
+
+	// Twiddle the authz to pretend its been validated by the VA
+	authz.Status = "valid"
+	authz.Challenges[0].Status = "valid"
+
+	// Call onValidationUpdate once to finalize the new authz state with the SA.
+	// It should not error
+	err = ra.onValidationUpdate(ctx, authz)
+	test.AssertNotError(t, err, "Initial onValidationUpdate for Authz failed")
+
+	// Call onValidationUpdate again to simulate another validation attempt
+	// finishing. It should error since the pendingAuthorization row has been
+	// removed by the first finalization update.
+	err = ra.onValidationUpdate(ctx, authz)
+	test.AssertError(t, err, "Second onValidationUpdate didn't fail")
+	// It should *not* be an internal server error
+	test.AssertEquals(t, berrors.Is(err, berrors.InternalServer), false)
+	// It *should* be a NotFound error
+	test.AssertEquals(t, berrors.Is(err, berrors.NotFound), true)
+}
+
 var CAkeyPEM = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIJKQIBAAKCAgEAqmM0dEf/J9MCk2ItzevL0dKJ84lVUtf/vQ7AXFi492vFXc3b

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -806,7 +806,9 @@ func (ssa *SQLStorageAuthority) UpdatePendingAuthorization(ctx context.Context, 
 	return tx.Commit()
 }
 
-// FinalizeAuthorization converts a Pending Authorization to a final one
+// FinalizeAuthorization converts a Pending Authorization to a final one. If the
+// Authorization is not found a berrors.NotFound result is returned. If the
+// Authorization is not valid a berrors.InternalServer error is returned.
 func (ssa *SQLStorageAuthority) FinalizeAuthorization(ctx context.Context, authz core.Authorization) error {
 	tx, err := ssa.dbMap.Begin()
 	if err != nil {
@@ -815,7 +817,7 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization(ctx context.Context, authz
 
 	// Check that a pending authz exists
 	if !existingPending(tx, authz.ID) {
-		err = berrors.InternalServerError("authorization with ID %q not found", authz.ID)
+		err = berrors.NotFoundError("authorization with ID %q not found", authz.ID)
 		return Rollback(tx, err)
 	}
 	if statusIsPending(authz.Status) {
@@ -826,7 +828,7 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization(ctx context.Context, authz
 	auth := &authzModel{authz}
 	pa, err := selectPendingAuthz(tx, "WHERE id = ?", authz.ID)
 	if err == sql.ErrNoRows {
-		return Rollback(tx, berrors.InternalServerError("authorization with ID %q not found", authz.ID))
+		return Rollback(tx, berrors.NotFoundError("authorization with ID %q not found", authz.ID))
 	}
 	if err != nil {
 		return Rollback(tx, err)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -780,13 +780,13 @@ func (ssa *SQLStorageAuthority) UpdatePendingAuthorization(ctx context.Context, 
 	}
 
 	if !existingPending(tx, authz.ID) {
-		err = berrors.InternalServerError("authorization with ID '%d' not found", authz.ID)
+		err = berrors.NotFoundError("authorization with ID '%d' not found", authz.ID)
 		return Rollback(tx, err)
 	}
 
 	pa, err := selectPendingAuthz(tx, "WHERE id = ?", authz.ID)
 	if err == sql.ErrNoRows {
-		err = berrors.InternalServerError("authorization with ID '%d' not found", authz.ID)
+		err = berrors.NotFoundError("authorization with ID '%d' not found", authz.ID)
 		return Rollback(tx, err)
 	}
 	if err != nil {
@@ -795,11 +795,19 @@ func (ssa *SQLStorageAuthority) UpdatePendingAuthorization(ctx context.Context, 
 	pa.Authorization = authz
 	_, err = tx.Update(pa)
 	if err != nil {
+		switch err.(type) {
+		case gorp.OptimisticLockError:
+			err = berrors.WrongAuthorizationStateError("authorization with ID '%d' concurrently updated")
+		}
 		return Rollback(tx, err)
 	}
 
 	err = updateChallenges(authz.ID, authz.Challenges, tx)
 	if err != nil {
+		switch err.(type) {
+		case gorp.OptimisticLockError:
+			err = berrors.WrongAuthorizationStateError("authorization with ID '%d' concurrently updated")
+		}
 		return Rollback(tx, err)
 	}
 


### PR DESCRIPTION
As described in #3201  a concurrent challenge POST would result in 500 errors if the pending authz row was deleted by a promotion to the authz table underneath another request. 

This PR adjusts the SA & RA so that if a pending authz is promoted to a final authz between updates a not found error will be returned instead of a server internal error.

Update: Removed mentions of the additional lockcol problem. The root cause of this is still TBD so we've split #3201 / this PR to only address the missing pending authz.

Resolves https://github.com/letsencrypt/boulder/issues/3201