### PR TITLE
Policy based issuance for wildcard identifiers (Round two)

### DIFF
--- a/core/challenges.go
+++ b/core/challenges.go
@@ -27,8 +27,3 @@ func TLSSNIChallenge02() Challenge {
 func DNSChallenge01() Challenge {
 	return newChallenge(ChallengeTypeDNS01)
 }
-
-// DNSChallenge01Wildcard constructs a random dns-01-wildcard challenge.
-func DNSChallenge01Wildcard() Challenge {
-	return newChallenge(ChallengeTypeDNS01Wildcard)
-}

--- a/core/challenges.go
+++ b/core/challenges.go
@@ -27,3 +27,8 @@ func TLSSNIChallenge02() Challenge {
 func DNSChallenge01() Challenge {
 	return newChallenge(ChallengeTypeDNS01)
 }
+
+// DNSChallenge01Wildcard constructs a random dns-01-wildcard challenge.
+func DNSChallenge01Wildcard() Challenge {
+	return newChallenge(ChallengeTypeDNS01Wildcard)
+}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -106,7 +106,8 @@ type CertificateAuthority interface {
 // PolicyAuthority defines the public interface for the Boulder PA
 type PolicyAuthority interface {
 	WillingToIssue(domain AcmeIdentifier) error
-	ChallengesFor(domain AcmeIdentifier) (challenges []Challenge, validCombinations [][]int)
+	WillingToIssueWildcard(domain AcmeIdentifier) error
+	ChallengesFor(domain AcmeIdentifier) (challenges []Challenge, validCombinations [][]int, err error)
 }
 
 // StorageGetter are the Boulder SA's read-only methods

--- a/core/objects.go
+++ b/core/objects.go
@@ -72,11 +72,6 @@ const (
 	ChallengeTypeTLSSNI01 = "tls-sni-01"
 	ChallengeTypeTLSSNI02 = "tls-sni-02"
 	ChallengeTypeDNS01    = "dns-01"
-	// We define a special variant of the "dns-01" challenge type to indicate that
-	// the authorization/challenge are for a wildcard domain. This information is
-	// used to determine how CAA should be handled. The WFE will translate
-	// a "dns-01-wildcard" challenge into "dns-01" for presentation to the user.
-	ChallengeTypeDNS01Wildcard = "dns-01-wildcard"
 )
 
 // ValidChallenge tests whether the provided string names a known challenge
@@ -88,8 +83,6 @@ func ValidChallenge(name string) bool {
 		fallthrough
 	case ChallengeTypeDNS01:
 		return true
-	case ChallengeTypeDNS01Wildcard:
-		return features.Enabled(features.WildcardDomains)
 	case ChallengeTypeTLSSNI02:
 		return features.Enabled(features.AllowTLS02Challenges)
 
@@ -110,9 +103,8 @@ const DNSPrefix = "_acme-challenge"
 // addresses, etc.), but currently we only support
 // domain names.
 type AcmeIdentifier struct {
-	Type     IdentifierType `json:"type"`  // The type of identifier being encoded
-	Value    string         `json:"value"` // The identifier itself
-	Wildcard bool           `json:"-"`     // Is the value of the identifier the base domain of a wildcard?
+	Type  IdentifierType `json:"type"`  // The type of identifier being encoded
+	Value string         `json:"value"` // The identifier itself
 }
 
 // CertificateRequest is just a CSR

--- a/core/objects.go
+++ b/core/objects.go
@@ -383,7 +383,7 @@ type Authorization struct {
 
 	// Wildcard is a Boulder-specific Authorization field that indicates the
 	// authorization was created as a result of an order containing a name with
-	// a `*.`wildcard prefix. This will help users understand that an
+	// a `*.`wildcard prefix. This will help convey to users that an
 	// Authorization with the identifier `example.com` and one DNS-01 challenge
 	// corrsponds to a name `*.example.com` from an associated order.
 	Wildcard bool `json:"wildcard,omitempty" db:"-"`

--- a/core/objects.go
+++ b/core/objects.go
@@ -72,6 +72,11 @@ const (
 	ChallengeTypeTLSSNI01 = "tls-sni-01"
 	ChallengeTypeTLSSNI02 = "tls-sni-02"
 	ChallengeTypeDNS01    = "dns-01"
+	// We define a special variant of the "dns-01" challenge type to indicate that
+	// the authorization/challenge are for a wildcard domain. This information is
+	// used to determine how CAA should be handled. The WFE will translate
+	// a "dns-01-wildcard" challenge into "dns-01" for presentation to the user.
+	ChallengeTypeDNS01Wildcard = "dns-01-wildcard"
 )
 
 // ValidChallenge tests whether the provided string names a known challenge
@@ -83,6 +88,8 @@ func ValidChallenge(name string) bool {
 		fallthrough
 	case ChallengeTypeDNS01:
 		return true
+	case ChallengeTypeDNS01Wildcard:
+		return features.Enabled(features.WildcardDomains)
 	case ChallengeTypeTLSSNI02:
 		return features.Enabled(features.AllowTLS02Challenges)
 
@@ -103,8 +110,9 @@ const DNSPrefix = "_acme-challenge"
 // addresses, etc.), but currently we only support
 // domain names.
 type AcmeIdentifier struct {
-	Type  IdentifierType `json:"type"`  // The type of identifier being encoded
-	Value string         `json:"value"` // The identifier itself
+	Type     IdentifierType `json:"type"`  // The type of identifier being encoded
+	Value    string         `json:"value"` // The identifier itself
+	Wildcard bool           `json:"-"`     // Is the value of the identifier the base domain of a wildcard?
 }
 
 // CertificateRequest is just a CSR

--- a/core/objects.go
+++ b/core/objects.go
@@ -385,7 +385,7 @@ type Authorization struct {
 	// authorization was created as a result of an order containing a name with
 	// a `*.`wildcard prefix. This will help convey to users that an
 	// Authorization with the identifier `example.com` and one DNS-01 challenge
-	// corrsponds to a name `*.example.com` from an associated order.
+	// corresponds to a name `*.example.com` from an associated order.
 	Wildcard bool `json:"wildcard,omitempty" db:"-"`
 }
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -380,6 +380,13 @@ type Authorization struct {
 	// The server may suggest combinations of challenges if it
 	// requires more than one challenge to be completed.
 	Combinations [][]int `json:"combinations,omitempty" db:"combinations"`
+
+	// Wildcard is a Boulder-specific Authorization field that indicates the
+	// authorization was created as a result of an order containing a name with
+	// a `*.`wildcard prefix. This will help users understand that an
+	// Authorization with the identifier `example.com` and one DNS-01 challenge
+	// corrsponds to a name `*.example.com` from an associated order.
+	Wildcard bool `json:"wildcard,omitempty" db:"-"`
 }
 
 // FindChallenge will look for the given challenge inside this authorization. If

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -23,7 +23,7 @@ var testingPolicy = &goodkey.KeyPolicy{
 
 type mockPA struct{}
 
-func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, combinations [][]int) {
+func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, combinations [][]int, err error) {
 	return
 }
 
@@ -31,6 +31,10 @@ func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
 	if id.Value == "bad-name.com" || id.Value == "other-bad-name.com" {
 		return errors.New("")
 	}
+	return nil
+}
+
+func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
 	return nil
 }
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "fmt"
 
-const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAALegacyCAAUDPDNSROCACheck"
+const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAALegacyCAAUDPDNSROCACheckWildcardDomains"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231, 240, 246, 255}
+var _FeatureFlag_index = [...]uint16{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231, 240, 246, 255, 270}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -29,6 +29,8 @@ const (
 	LegacyCAA
 	UDPDNS
 	ROCACheck
+	// Allow issuance of wildcard domains for ACMEv2
+	WildcardDomains
 )
 
 // List of features and their default value, protected by fMu
@@ -50,6 +52,7 @@ var features = map[FeatureFlag]bool{
 	LegacyCAA:                false,
 	UDPDNS:                   false,
 	ROCACheck:                false,
+	WildcardDomains:          false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/mocks/ca.go
+++ b/mocks/ca.go
@@ -26,7 +26,6 @@ func (ca *MockCA) IssueCertificate(ctx context.Context, _ *caPB.IssueCertificate
 	block, _ := pem.Decode(ca.PEM)
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		fmt.Printf("Ok?\n")
 		return core.Certificate{}, err
 	}
 	return core.Certificate{

--- a/mocks/ca.go
+++ b/mocks/ca.go
@@ -26,6 +26,7 @@ func (ca *MockCA) IssueCertificate(ctx context.Context, _ *caPB.IssueCertificate
 	block, _ := pem.Decode(ca.PEM)
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
+		fmt.Printf("Ok?\n")
 		return core.Certificate{}, err
 	}
 	return core.Certificate{

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -283,12 +283,13 @@ func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error
 		if icannTLDLabels[0] == "*" {
 			return errICANNTLDWildcard
 		}
-		// Update the identifier to refer to the base domain before we fall through
-		// to WillingToIssue
-		ident.Value = baseDomain
+		// Check that the PA is willing to issue for the base domain
+		return pa.WillingToIssue(core.AcmeIdentifier{
+			Type:  core.IdentifierDNS,
+			Value: baseDomain,
+		})
 	}
 
-	// Fall through to the usual issuance policy
 	return pa.WillingToIssue(ident)
 }
 

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -333,13 +333,11 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.C
 		// We must have the DNS-01 challenge type enabled to create challenges for
 		// a wildcard identifier per LE policy. We also must have the pseudo-type
 		// DNS-01-Wildcard challenge type available.
-		requiredChallengeTypes := []string{core.ChallengeTypeDNS01, core.ChallengeTypeDNS01Wildcard}
-		for _, chalType := range requiredChallengeTypes {
-			if !pa.enabledChallenges[chalType] {
-				return nil, nil, fmt.Errorf(
-					"Challenges requested for wildcard identifier but required challenge "+
-						"type %q is not enabled", chalType)
-			}
+		if !pa.enabledChallenges[core.ChallengeTypeDNS01] ||
+			!pa.enabledChallenges[core.ChallengeTypeDNS01Wildcard] {
+			return nil, nil, fmt.Errorf(
+				"Challenges requested for wildcard identifier but DNS-01 or " +
+					"DNS-01-Wildcard challenge types are not enabled")
 		}
 		// Only provide a DNS-01-Wildcard challenge
 		challenges = []core.Challenge{core.DNSChallenge01Wildcard()}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -279,8 +279,7 @@ func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error
 		}
 		// Names must have a non-wildcard label immediately adjacent to the ICANN
 		// TLD. No `*.com`!
-		icannTLDLabels := strings.Split(rawDomain, "."+icannTLD)
-		if icannTLDLabels[0] == "*" {
+		if baseDomain == icannTLD {
 			return errICANNTLDWildcard
 		}
 		// Check that the PA is willing to issue for the base domain

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -129,6 +129,9 @@ var (
 	errLabelTooLong        = berrors.MalformedError("DNS label is too long")
 	errMalformedIDN        = berrors.MalformedError("DNS label contains malformed punycode")
 	errInvalidRLDH         = berrors.RejectedIdentifierError("DNS name contains a R-LDH label")
+	errTooManyWildcards    = berrors.MalformedError("DNS name had more than one wildcard")
+	errMalformedWildcard   = berrors.MalformedError("DNS name had a malformed wildcard label")
+	errICANNTLDWildcard    = berrors.MalformedError("DNS name was a wildcard for an ICANN TLD")
 )
 
 // WillingToIssue determines whether the CA is willing to issue for the provided
@@ -150,7 +153,8 @@ var (
 //  * MUST NOT be a label-wise suffix match for a name on the black list,
 //    where comparison is case-independent (normalized to lower case)
 //
-// If WillingToIssue returns an error, it will be of type MalformedRequestError.
+// If WillingToIssue returns an error, it will be of type MalformedRequestError
+// or RejectedIdentifierError
 func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 	if id.Type != core.IdentifierDNS {
 		return errInvalidIdentifier
@@ -236,6 +240,58 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 	return nil
 }
 
+// WillingToIssueWildcard is an extension of WillingToIssue that accepts DNS
+// identifiers for well formed wildcard domains. It enforces that:
+// * The identifer is a DNS type identifier
+// * There is at most one `*` wildcard character
+// * That the wildcard character is the leftmost label
+// * That the wildcard label is not immediate adjacent to a top level ICANN TLD
+//
+// If all of the above is true then the base domain (e.g. without the *.) is run
+// through WillingToIssue to catch other illegal things (blocked hosts, etc).
+func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error {
+	// We're only willing to process DNS identifiers
+	if ident.Type != core.IdentifierDNS {
+		return errInvalidIdentifier
+	}
+	rawDomain := ident.Value
+
+	// If there is more than one wildcard in the domain the ident is invalid
+	if strings.Count(rawDomain, "*") > 1 {
+		return errTooManyWildcards
+	}
+
+	// If there is exactly one wildcard in the domain we need to do some special
+	// processing to ensure that it is a well formed wildcard request and to
+	// translate the identifer to its base domain for use with WillingToIssue
+	if strings.Count(rawDomain, "*") == 1 {
+		// If the rawDomain has a wildcard character, but it isn't the first most
+		// label of the domain name then the wildcard domain is malformed
+		if !strings.HasPrefix(rawDomain, "*.") {
+			return errMalformedWildcard
+		}
+		// The base domain is the wildcard request with the `*.` prefix removed
+		baseDomain := strings.TrimPrefix(rawDomain, "*.")
+		// Names must end in an ICANN TLD, but they must not be equal to an ICANN TLD.
+		icannTLD, err := extractDomainIANASuffix(baseDomain)
+		if err != nil {
+			return errNonPublic
+		}
+		// Names must have a non-wildcard label immediately adjacent to the ICANN
+		// TLD. No `*.com`!
+		icannTLDLabels := strings.Split(rawDomain, "."+icannTLD)
+		if icannTLDLabels[0] == "*" {
+			return errICANNTLDWildcard
+		}
+		// Update the identifier to refer to the base domain before we fall through
+		// to WillingToIssue
+		ident.Value = baseDomain
+	}
+
+	// Fall through to the usual issuance policy
+	return pa.WillingToIssue(ident)
+}
+
 func (pa *AuthorityImpl) checkHostLists(domain string) error {
 	pa.blacklistMu.RLock()
 	defer pa.blacklistMu.RUnlock()
@@ -260,25 +316,49 @@ func (pa *AuthorityImpl) checkHostLists(domain string) error {
 
 // ChallengesFor makes a decision of what challenges, and combinations, are
 // acceptable for the given identifier.
-//
-// Note: Current implementation is static, but future versions may not be.
-func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.Challenge, [][]int) {
+func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.Challenge, [][]int, error) {
 	challenges := []core.Challenge{}
 
-	if pa.enabledChallenges[core.ChallengeTypeHTTP01] {
-		challenges = append(challenges, core.HTTPChallenge01())
-	}
+	// If the identifier is a base domain corresponding to a wildcard we only
+	// provide a DNS-01-Wildcard challenge as a matter of CA policy. We don't use
+	// a DNS-01 challenge here because without some hint the VA won't know how to
+	// check CAA for this authorization without knowing if it was a DNS challenge
+	// created for a wildcard name or not
+	//
+	// NOTE(@cpu): We don't check the WildcardDomains feature flag here since
+	// `identifier.Wildcard` is a new field only set when the feature flag was
+	// enabled.
+	if identifier.Wildcard {
+		// We must have the DNS-01 challenge type enabled to create challenges for
+		// a wildcard identifier per LE policy. We also must have the pseudo-type
+		// DNS-01-Wildcard challenge type available.
+		requiredChallengeTypes := []string{core.ChallengeTypeDNS01, core.ChallengeTypeDNS01Wildcard}
+		for _, chalType := range requiredChallengeTypes {
+			if !pa.enabledChallenges[chalType] {
+				return nil, nil, fmt.Errorf(
+					"Challenges requested for wildcard identifier but required challenge "+
+						"type %q is not enabled", chalType)
+			}
+		}
+		// Only provide a DNS-01-Wildcard challenge
+		challenges = []core.Challenge{core.DNSChallenge01Wildcard()}
+	} else {
+		// Otherwise we collect up challenges based on what is enabled.
+		if pa.enabledChallenges[core.ChallengeTypeHTTP01] {
+			challenges = append(challenges, core.HTTPChallenge01())
+		}
 
-	if pa.enabledChallenges[core.ChallengeTypeTLSSNI01] {
-		challenges = append(challenges, core.TLSSNIChallenge01())
-	}
+		if pa.enabledChallenges[core.ChallengeTypeTLSSNI01] {
+			challenges = append(challenges, core.TLSSNIChallenge01())
+		}
 
-	if features.Enabled(features.AllowTLS02Challenges) && pa.enabledChallenges[core.ChallengeTypeTLSSNI02] {
-		challenges = append(challenges, core.TLSSNIChallenge02())
-	}
+		if features.Enabled(features.AllowTLS02Challenges) && pa.enabledChallenges[core.ChallengeTypeTLSSNI02] {
+			challenges = append(challenges, core.TLSSNIChallenge02())
+		}
 
-	if pa.enabledChallenges[core.ChallengeTypeDNS01] {
-		challenges = append(challenges, core.DNSChallenge01())
+		if pa.enabledChallenges[core.ChallengeTypeDNS01] {
+			challenges = append(challenges, core.DNSChallenge01())
+		}
 	}
 
 	// We shuffle the challenges and combinations to prevent ACME clients from
@@ -298,7 +378,7 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.C
 		shuffledCombos[i] = combinations[comboIdx]
 	}
 
-	return shuffled, shuffledCombos
+	return shuffled, shuffledCombos, nil
 }
 
 // ExtractDomainIANASuffix returns the public suffix of the domain using only the "ICANN"

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -330,7 +330,7 @@ func TestChallengesForWildcard(t *testing.T) {
 	test.AssertError(t, err, "ChallengesFor did not error for a wildcard ident "+
 		"when DNS-01 was disabled")
 	test.AssertEquals(t, err.Error(), "Challenges requested for wildcard "+
-		"identifier but required challenge type \"dns-01\" is not enabled")
+		"identifier but DNS-01 or DNS-01-Wildcard challenge types are not enabled")
 
 	// Try again with DNS-01 enabled but DNS-01-Wildcard disabled
 	enabledChallenges[core.ChallengeTypeDNS01] = true
@@ -339,7 +339,7 @@ func TestChallengesForWildcard(t *testing.T) {
 	test.AssertError(t, err, "ChallengesFor did not error for a wildcard ident "+
 		"when DNS-01-Wildcard was disabled")
 	test.AssertEquals(t, err.Error(), "Challenges requested for wildcard "+
-		"identifier but required challenge type \"dns-01-wildcard\" is not enabled")
+		"identifier but DNS-01 or DNS-01-Wildcard challenge types are not enabled")
 
 	// Try again with DNS-01 and DNS-01-Wildcard enabled. It should not error and
 	// should return only one DNS-01-Wildcard type challenge

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -198,6 +198,80 @@ func TestWillingToIssue(t *testing.T) {
 	}
 }
 
+func TestWillingToIssueWildcard(t *testing.T) {
+	bannedDomains := []string{
+		`zombo.gov.us`,
+	}
+	pa := paImpl(t)
+
+	bannedBytes, err := json.Marshal(blacklistJSON{
+		Blacklist: bannedDomains,
+	})
+	test.AssertNotError(t, err, "Couldn't serialize banned list")
+	f, _ := ioutil.TempFile("", "test-wildcard-banlist.txt")
+	defer os.Remove(f.Name())
+	err = ioutil.WriteFile(f.Name(), bannedBytes, 0640)
+	test.AssertNotError(t, err, "Couldn't write serialized banned list to file")
+	err = pa.SetHostnamePolicyFile(f.Name())
+	test.AssertNotError(t, err, "Couldn't load policy contents from file")
+
+	makeDNSIdent := func(domain string) core.AcmeIdentifier {
+		return core.AcmeIdentifier{
+			Type:  core.IdentifierDNS,
+			Value: domain,
+		}
+	}
+
+	testCases := []struct {
+		Name        string
+		Ident       core.AcmeIdentifier
+		ExpectedErr error
+	}{
+		{
+			Name:        "Non-DNS identifier",
+			Ident:       core.AcmeIdentifier{Type: "nickname", Value: "cpu"},
+			ExpectedErr: errInvalidIdentifier,
+		},
+		{
+			Name:        "Too many wildcards",
+			Ident:       makeDNSIdent("ok.*.whatever.*.example.com"),
+			ExpectedErr: errTooManyWildcards,
+		},
+		{
+			Name:        "Misplaced wildcard",
+			Ident:       makeDNSIdent("ok.*.whatever.example.com"),
+			ExpectedErr: errMalformedWildcard,
+		},
+		{
+			Name:        "Missing ICANN TLD",
+			Ident:       makeDNSIdent("*.ok.madeup"),
+			ExpectedErr: errNonPublic,
+		},
+		{
+			Name:        "Wildcard for ICANN TLD",
+			Ident:       makeDNSIdent("*.com"),
+			ExpectedErr: errICANNTLDWildcard,
+		},
+		{
+			Name:        "Forbidden base domain",
+			Ident:       makeDNSIdent("*.zombo.gov.us"),
+			ExpectedErr: errBlacklisted,
+		},
+		{
+			Name:        "Valid wildcard domain",
+			Ident:       makeDNSIdent("*.everything.is.possible.at.zombo.com"),
+			ExpectedErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := pa.WillingToIssueWildcard(tc.Ident)
+			test.AssertEquals(t, result, tc.ExpectedErr)
+		})
+	}
+}
+
 var accountKeyJSON = `{
   "kty":"RSA",
   "n":"yNWVhtYEKJR21y9xsHV-PD_bYwbXSeNuFal46xYxVfRL5mqha7vttvjB_vc7Xg2RvgCxHPCqoxgMPTzHrZT75LjCwIW2K_klBYN8oYvTwwmeSkAz6ut7ZxPv-nZaT5TJhGk0NT2kh_zSpdriEJ_3vW-mqxYbbBmpvHqsa1_zx9fSuHYctAZJWzxzUZXykbWMWQZpEiE0J4ajj51fInEzVn7VxV-mzfMyboQjujPh7aNJxAWSq4oQEJJDgWwSh9leyoJoPpONHxh5nEE5AjE01FkGICSxjpZsF-w8hOTI3XXohUdu29Se26k2B0PolDSuj0GIQU6-W9TdLXSjBb2SpQ",
@@ -207,7 +281,8 @@ var accountKeyJSON = `{
 func TestChallengesFor(t *testing.T) {
 	pa := paImpl(t)
 
-	challenges, combinations := pa.ChallengesFor(core.AcmeIdentifier{})
+	challenges, combinations, err := pa.ChallengesFor(core.AcmeIdentifier{})
+	test.AssertNotError(t, err, "ChallengesFor failed")
 
 	test.Assert(t, len(challenges) == len(enabledChallenges), "Wrong number of challenges returned")
 	test.Assert(t, len(combinations) == len(enabledChallenges), "Wrong number of combinations returned")
@@ -223,6 +298,59 @@ func TestChallengesFor(t *testing.T) {
 	}
 	test.AssertEquals(t, len(seenChalls), len(enabledChallenges))
 	test.AssertDeepEquals(t, expectedCombos, combinations)
+}
+
+func TestChallengesForWildcard(t *testing.T) {
+	// wildcardIdent is an identifier thats been translated into a base domain for
+	// the purpose of authenticating a widlcard request.
+	wildcardIdent := core.AcmeIdentifier{
+		Type:     core.IdentifierDNS,
+		Value:    "zombo.com",
+		Wildcard: true,
+	}
+
+	mustConstructPA := func(t *testing.T, enabledChallenges map[string]bool) *AuthorityImpl {
+		pa, err := New(enabledChallenges)
+		if err != nil {
+			t.Fatalf("Couldn't create policy implementation: %s", err)
+		}
+		return pa
+	}
+
+	// First try to get a challenge for the wildcard ident without the
+	// DNS-01 challenge type enabled. This should produce an error
+	var enabledChallenges = map[string]bool{
+		core.ChallengeTypeHTTP01:        true,
+		core.ChallengeTypeTLSSNI01:      true,
+		core.ChallengeTypeDNS01:         false,
+		core.ChallengeTypeDNS01Wildcard: false,
+	}
+	pa := mustConstructPA(t, enabledChallenges)
+	_, _, err := pa.ChallengesFor(wildcardIdent)
+	test.AssertError(t, err, "ChallengesFor did not error for a wildcard ident "+
+		"when DNS-01 was disabled")
+	test.AssertEquals(t, err.Error(), "Challenges requested for wildcard "+
+		"identifier but required challenge type \"dns-01\" is not enabled")
+
+	// Try again with DNS-01 enabled but DNS-01-Wildcard disabled
+	enabledChallenges[core.ChallengeTypeDNS01] = true
+	pa = mustConstructPA(t, enabledChallenges)
+	_, _, err = pa.ChallengesFor(wildcardIdent)
+	test.AssertError(t, err, "ChallengesFor did not error for a wildcard ident "+
+		"when DNS-01-Wildcard was disabled")
+	test.AssertEquals(t, err.Error(), "Challenges requested for wildcard "+
+		"identifier but required challenge type \"dns-01-wildcard\" is not enabled")
+
+	// Try again with DNS-01 and DNS-01-Wildcard enabled. It should not error and
+	// should return only one DNS-01-Wildcard type challenge
+	enabledChallenges[core.ChallengeTypeDNS01Wildcard] = true
+	pa = mustConstructPA(t, enabledChallenges)
+	challenges, combinations, err := pa.ChallengesFor(wildcardIdent)
+	test.AssertNotError(t, err, "ChallengesFor errored for a wildcard ident "+
+		"unexpectedly")
+	test.AssertEquals(t, len(combinations), 1)
+	test.AssertEquals(t, len(challenges), 1)
+	test.AssertEquals(t, challenges[0].Type, core.ChallengeTypeDNS01Wildcard)
 }
 
 func TestExtractDomainIANASuffix_Valid(t *testing.T) {

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -302,7 +302,7 @@ func TestChallengesFor(t *testing.T) {
 
 func TestChallengesForWildcard(t *testing.T) {
 	// wildcardIdent is an identifier thats been translated into a base domain for
-	// the purpose of authenticating a widlcard request.
+	// the purpose of authenticating a wildcard request.
 	wildcardIdent := core.AcmeIdentifier{
 		Type:     core.IdentifierDNS,
 		Value:    "zombo.com",

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1354,13 +1354,7 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(ctx context.Context, ba
 
 	vaCtx := context.Background()
 	go func() {
-		domain := authz.Identifier.Value
-		// If the identifier is a wildcard domain we need to validate the base
-		// domain by removing the "*." wildcard prefix.
-		if strings.HasPrefix(domain, "*.") {
-			domain = strings.TrimPrefix(domain, "*.")
-		}
-		records, err := ra.VA.PerformValidation(vaCtx, domain, authz.Challenges[challengeIndex], authz)
+		records, err := ra.VA.PerformValidation(vaCtx, authz.Identifier.Value, authz.Challenges[challengeIndex], authz)
 		var prob *probs.ProblemDetails
 		if p, ok := err.(*probs.ProblemDetails); ok {
 			prob = p

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -643,6 +643,8 @@ func (ra *RegistrationAuthorityImpl) checkOrderAuthorizations(
 	if err != nil {
 		return err
 	}
+	// Ensure the names from the CSR are free of duplicates & lowercased.
+	names = core.UniqueLowerNames(names)
 	// Check the authorizations to ensure validity for the names required.
 	return ra.checkAuthorizationsCAA(ctx, names, authzs, acctIDInt, ra.clk.Now())
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -900,12 +900,6 @@ func (ra *RegistrationAuthorityImpl) issueCertificate(
 		return emptyCert, berrors.MalformedError(err.Error())
 	}
 
-	if len(csr.DNSNames) == 0 {
-		err = berrors.UnauthorizedError("CSR has no names in it")
-		logEvent.Error = err.Error()
-		return emptyCert, err
-	}
-
 	logEvent.CommonName = csr.Subject.CommonName
 	logEvent.Names = csr.DNSNames
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -646,9 +646,9 @@ func (ra *RegistrationAuthorityImpl) checkOrderAuthorizations(
 	}
 
 	// Check each of the identifiers in the order against the authzs we got back
-	var identifierValues []string
-	for _, ident := range identifiers {
-		identifierValues = append(identifierValues, ident.Value)
+	identifierValues := make([]string, len(identifiers))
+	for i, ident := range identifiers {
+		identifierValues[i] = ident.Value
 		// If an authz exists for an identifier, and the identifier is a wildcard we
 		// have to make sure the authorization has the correct DNS-01-Wildcard
 		// challenge result.

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -720,7 +720,7 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizationsCAA(
 	if len(badNames) > 0 {
 		return berrors.UnauthorizedError(
 			"authorizations for these names not found or expired: %s",
-			strings.Join(badNames, ", "),
+			strings.Join(core.UniqueLowerNames(badNames), ", "),
 		)
 	}
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2191,7 +2191,7 @@ func TestNewOrderWildcard(t *testing.T) {
 	// The authz should be the same ID as the previous order's authz. We already
 	// checked that order.Authorizations[0] only has a DNS-01-Wildcard challenge
 	// above so we don't need to recheck that here.
-	test.AssertNotEquals(t, dupeOrder.Authorizations[0], order.Authorizations[0])
+	test.AssertEquals(t, dupeOrder.Authorizations[0], order.Authorizations[0])
 }
 
 func TestFinalizeOrder(t *testing.T) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"net"
 	"net/url"
 	"os"
@@ -271,7 +272,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 
 	AuthzInitial.RegistrationID = Registration.ID
 
-	challenges, combinations := pa.ChallengesFor(AuthzInitial.Identifier)
+	challenges, combinations, _ := pa.ChallengesFor(AuthzInitial.Identifier)
 	AuthzInitial.Challenges = challenges
 	AuthzInitial.Combinations = combinations
 
@@ -2006,6 +2007,193 @@ func TestNewOrder(t *testing.T) {
 	test.AssertEquals(t, err.Error(), "DNS name does not have enough labels")
 }
 
+func TestNewOrderWildcard(t *testing.T) {
+	// Only run under test/config-next config where 20170731115209_AddOrders.sql
+	// has been applied
+	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
+		return
+	}
+
+	_, _, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+	ra.orderLifetime = time.Hour
+	id := int64(1)
+
+	orderNames := []string{"example.com", "*.welcome.zombo.com"}
+	wildcardOrderRequest := &rapb.NewOrderRequest{
+		RegistrationID: &id,
+		Names:          orderNames,
+	}
+
+	// First test that with WildcardDomains feature disabled wildcard orders are
+	// rejected as expected
+	_ = features.Set(map[string]bool{"WildcardDomains": false})
+
+	_, err := ra.NewOrder(context.Background(), wildcardOrderRequest)
+	test.AssertError(t, err, "NewOrder with wildcard names did not error with "+
+		"WildcardDomains feature disabled")
+	test.AssertEquals(t, err.Error(), "Invalid character in DNS name")
+
+	// Now test with WildcardDomains feature enabled
+	features.Reset()
+	_ = features.Set(map[string]bool{"WildcardDomains": true})
+	defer features.Reset()
+
+	// Also ensure that the required challenge types are enabled. The ra_test
+	// global `SupportedChallenges` used by `initAuthorities` does not include
+	// DNS-01 or DNS-01-Wildcard
+	supportedChallenges := map[string]bool{
+		core.ChallengeTypeHTTP01:        true,
+		core.ChallengeTypeTLSSNI01:      true,
+		core.ChallengeTypeDNS01:         true,
+		core.ChallengeTypeDNS01Wildcard: true,
+	}
+	pa, err := policy.New(supportedChallenges)
+	test.AssertNotError(t, err, "Couldn't create PA")
+	err = pa.SetHostnamePolicyFile("../test/hostname-policy.json")
+	test.AssertNotError(t, err, "Couldn't set hostname policy")
+	ra.PA = pa
+
+	order, err := ra.NewOrder(context.Background(), wildcardOrderRequest)
+	test.AssertNotError(t, err, "NewOrder failed for a wildcard order request "+
+		"with WildcardDomains enabled")
+
+	// We expect the order to be pending
+	test.AssertEquals(t, *order.Status, string(core.StatusPending))
+	// We expect the order to have two names
+	test.AssertEquals(t, len(order.Names), 2)
+	// We expect the order to have the names we requested
+	test.AssertDeepEquals(t,
+		core.UniqueLowerNames(order.Names),
+		core.UniqueLowerNames(orderNames))
+	// We expect the order to have two authorizations
+	test.AssertEquals(t, len(order.Authorizations), 2)
+
+	// Check each of the authz IDs in the order
+	for _, authzID := range order.Authorizations {
+		// We should be able to retreive the authz from the db without error
+		authz, err := ra.SA.GetAuthorization(ctx, authzID)
+		test.AssertNotError(t, err, "Could not fetch authorization from database")
+
+		// We expect the authz is in Pending status
+		test.AssertEquals(t, authz.Status, core.StatusPending)
+
+		name := authz.Identifier.Value
+		switch name {
+		case "welcome.zombo.com":
+			// If the authz is for welcome.zombo.com, we expect that it only has the DNS-01-Wildcard challenge type
+			test.AssertEquals(t, len(authz.Challenges), 1)
+			test.AssertEquals(t, authz.Challenges[0].Status, core.StatusPending)
+			test.AssertEquals(t, authz.Challenges[0].Type, core.ChallengeTypeDNS01Wildcard)
+		case "example.com":
+			// If the authz is for example.com, we expect it has normal challenges
+			test.AssertEquals(t, len(authz.Challenges), 3)
+		default:
+			t.Fatalf("Received an authorization for a name not requested: %q", name)
+		}
+	}
+
+	// An order for a base domain and a wildcard for the same base domain should
+	// return just 1 DNS-01-Wildcard authz
+	orderNames = []string{"zombo.com", "*.zombo.com"}
+	wildcardOrderRequest = &rapb.NewOrderRequest{
+		RegistrationID: &id,
+		Names:          orderNames,
+	}
+	order, err = ra.NewOrder(context.Background(), wildcardOrderRequest)
+	test.AssertNotError(t, err, "NewOrder failed for a wildcard order request "+
+		"with WildcardDomains enabled")
+
+	// We expect the order to be pending
+	test.AssertEquals(t, *order.Status, string(core.StatusPending))
+	// We expect the order to have two names
+	test.AssertEquals(t, len(order.Names), 2)
+	// We expect the order to have the names we requested
+	test.AssertDeepEquals(t,
+		core.UniqueLowerNames(order.Names),
+		core.UniqueLowerNames(orderNames))
+	// We expect the order to have one authorization
+	test.AssertEquals(t, len(order.Authorizations), 1)
+	// We expect the authorization is available
+	authz, err := ra.SA.GetAuthorization(ctx, order.Authorizations[0])
+	test.AssertNotError(t, err, "Could not fetch authorization from database")
+	// We expect the authz is in Pending status
+	test.AssertEquals(t, authz.Status, core.StatusPending)
+	// We expect the authz is for the identifier "zombo.com"
+	test.AssertEquals(t, authz.Identifier.Value, "zombo.com")
+	// We expect that the auth has only a pending DNS-01-Wildcard challenge
+	test.AssertEquals(t, len(authz.Challenges), 1)
+	test.AssertEquals(t, authz.Challenges[0].Status, core.StatusPending)
+	test.AssertEquals(t, authz.Challenges[0].Type, core.ChallengeTypeDNS01Wildcard)
+
+	// Make an order for a single domain, no wildcards. This will create a new
+	// pending authz for the domain
+	normalOrderReq := &rapb.NewOrderRequest{
+		RegistrationID: &id,
+		Names:          []string{"everything.is.possible.zombo.com"},
+	}
+	normalOrder, err := ra.NewOrder(context.Background(), normalOrderReq)
+	test.AssertNotError(t, err, "NewOrder failed for a normal non-wildcard order")
+
+	// There should be one authz
+	test.AssertEquals(t, len(normalOrder.Authorizations), 1)
+	// We expect the order is in Pending status
+	test.AssertEquals(t, *order.Status, string(core.StatusPending))
+	// We expect the authorization is available
+	authz, err = ra.SA.GetAuthorization(ctx, normalOrder.Authorizations[0])
+	test.AssertNotError(t, err, "Could not fetch authorization from database")
+	// We expect the authz is in Pending status
+	test.AssertEquals(t, authz.Status, core.StatusPending)
+	// We expect the authz is for the identifier the correct domain
+	test.AssertEquals(t, authz.Identifier.Value, "everything.is.possible.zombo.com")
+	// We expect the authz has the normal # of challenges
+	test.AssertEquals(t, len(authz.Challenges), 3)
+
+	// Now submit an order request for a wildcard of the domain we just created an
+	// order for. We should **NOT** reuse the authorization from the previous
+	// order since we now require a DNS-01-Wildcard challenge.
+	orderNames = []string{"*.everything.is.possible.zombo.com"}
+	wildcardOrderRequest = &rapb.NewOrderRequest{
+		RegistrationID: &id,
+		Names:          orderNames,
+	}
+	order, err = ra.NewOrder(context.Background(), wildcardOrderRequest)
+	test.AssertNotError(t, err, "NewOrder failed for a wildcard order request "+
+		"with WildcardDomains enabled")
+	// We expect the order is in Pending status
+	test.AssertEquals(t, *order.Status, string(core.StatusPending))
+	// There should be one authz
+	test.AssertEquals(t, len(order.Authorizations), 1)
+	// The authz should be a different ID than the previous authz
+	test.AssertNotEquals(t, order.Authorizations[0], normalOrder.Authorizations[0])
+	// We expect the authorization is available
+	authz, err = ra.SA.GetAuthorization(ctx, order.Authorizations[0])
+	test.AssertNotError(t, err, "Could not fetch authorization from database")
+	// We expect the authz is in Pending status
+	test.AssertEquals(t, authz.Status, core.StatusPending)
+	// We expect the authz is for the identifier the correct domain
+	test.AssertEquals(t, authz.Identifier.Value, "everything.is.possible.zombo.com")
+	// We expect the authz has only one challenge
+	test.AssertEquals(t, len(authz.Challenges), 1)
+	// We expect the one challenge is pending
+	test.AssertEquals(t, authz.Challenges[0].Status, core.StatusPending)
+	// We expect that the one challenge is a DNS01 type challenge
+	test.AssertEquals(t, authz.Challenges[0].Type, core.ChallengeTypeDNS01Wildcard)
+
+	// Submit an identical wildcard order request
+	dupeOrder, err := ra.NewOrder(context.Background(), wildcardOrderRequest)
+	test.AssertNotError(t, err, "NewOrder failed for a wildcard order request "+
+		"with WildcardDomains enabled")
+	// We expect the order is in Pending status
+	test.AssertEquals(t, *dupeOrder.Status, string(core.StatusPending))
+	// There should be one authz
+	test.AssertEquals(t, len(dupeOrder.Authorizations), 1)
+	// The authz should be the same ID as the previous order's authz. We already
+	// checked that order.Authorizations[0] only has a DNS-01-Wildcard challenge
+	// above so we don't need to recheck that here.
+	test.AssertNotEquals(t, dupeOrder.Authorizations[0], order.Authorizations[0])
+}
+
 func TestFinalizeOrder(t *testing.T) {
 	// Only run under test/config-next config where 20170731115209_AddOrders.sql
 	// has been applied
@@ -2242,6 +2430,193 @@ func TestFinalizeOrder(t *testing.T) {
 				test.AssertNotError(t, err, "Error getting order to check serial")
 				test.AssertNotEquals(t, *updatedOrder.CertificateSerial, "")
 				test.AssertEquals(t, *updatedOrder.Status, "valid")
+			}
+		})
+	}
+}
+
+func TestFinalizeOrderWildcard(t *testing.T) {
+	// Only run under test/config-next config where 20170731115209_AddOrders.sql
+	// has been applied
+	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
+		return
+	}
+
+	_, sa, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+
+	// Pick an expiry in the future
+	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
+
+	// Enable wildcard domains
+	_ = features.Set(map[string]bool{"WildcardDomains": true})
+	defer features.Reset()
+
+	// Also ensure that the required challenge types are enabled. The ra_test
+	// global `SupportedChallenges` used by `initAuthorities` does not include
+	// DNS-01 or DNS-01-Wildcard
+	supportedChallenges := map[string]bool{
+		core.ChallengeTypeHTTP01:        true,
+		core.ChallengeTypeTLSSNI01:      true,
+		core.ChallengeTypeDNS01:         true,
+		core.ChallengeTypeDNS01Wildcard: true,
+	}
+	pa, err := policy.New(supportedChallenges)
+	test.AssertNotError(t, err, "Couldn't create PA")
+	err = pa.SetHostnamePolicyFile("../test/hostname-policy.json")
+	test.AssertNotError(t, err, "Couldn't set hostname policy")
+	ra.PA = pa
+
+	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	test.AssertNotError(t, err, "Error creating test RSA key")
+	wildcardCSR, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		PublicKey:          testKey.PublicKey,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+		DNSNames:           []string{"*.zombo.com"},
+	}, testKey)
+	test.AssertNotError(t, err, "Error creating CSR with wildcard DNS name")
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1337),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, 1),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"*.zombo.com"},
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, testKey.Public(), testKey)
+	test.AssertNotError(t, err, "Error creating test certificate")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	// Set up a mock CA capable of giving back a cert for the wildcardCSR above
+	ca := &mocks.MockCA{
+		PEM: certPEM,
+	}
+	ra.CA = ca
+
+	// Create a new order for a wildcard domain
+	orderNames := []string{"*.zombo.com"}
+	wildcardOrderRequest := &rapb.NewOrderRequest{
+		RegistrationID: &Registration.ID,
+		Names:          orderNames,
+	}
+	order, err := ra.NewOrder(context.Background(), wildcardOrderRequest)
+	test.AssertNotError(t, err, "NewOrder failed for wildcard domain order")
+
+	// Create one standard finalized authorization for Registration.ID for zombo.com
+	finalAuthz := AuthzInitial
+	finalAuthz.Identifier = core.AcmeIdentifier{Type: "dns", Value: "zombo.com"}
+	finalAuthz.Status = "valid"
+	finalAuthz.Expires = &exp
+	finalAuthz.Challenges[0].Status = "valid"
+	finalAuthz.RegistrationID = Registration.ID
+	finalAuthz, err = sa.NewPendingAuthorization(ctx, finalAuthz)
+	test.AssertNotError(t, err, "Could not store test pending authorization")
+	err = sa.FinalizeAuthorization(ctx, finalAuthz)
+	test.AssertNotError(t, err, "Could not finalize test pending authorization")
+
+	// Finalizing the order should *not* work since the existing validated authz
+	// is not a special DNS-01-Wildcard challenge authz
+	finalizeReq := &rapb.FinalizeOrderRequest{
+		Order: order,
+		Csr:   wildcardCSR,
+	}
+	_, err = ra.FinalizeOrder(context.Background(), finalizeReq)
+	test.AssertError(t, err, "FinalizeOrder did not fail for unauthorized "+
+		"wildcard order")
+	test.AssertEquals(t, err.Error(), "authorizations for these names not "+
+		"found or expired: zombo.com")
+
+	// Creating another order for the wildcard name
+	validOrder, err := ra.NewOrder(context.Background(), wildcardOrderRequest)
+	test.AssertNotError(t, err, "NewOrder failed for wildcard domain order")
+	// We expect it has 1 authorization
+	test.AssertEquals(t, len(validOrder.Authorizations), 1)
+	// We expect to be able to get the authorization by ID
+	authz, err := sa.GetAuthorization(ctx, validOrder.Authorizations[0])
+	test.AssertNotError(t, err, "GetAuthorization failed for order authz ID")
+
+	// Finalize the authorization with the challenge validated
+	authz.Status = "valid"
+	authz.Challenges[0].Status = "valid"
+	err = sa.FinalizeAuthorization(ctx, authz)
+	test.AssertNotError(t, err, "Could not finalize order's pending authorization")
+
+	// Now it should be possible to finalize the order
+	finalizeReq = &rapb.FinalizeOrderRequest{
+		Order: validOrder,
+		Csr:   wildcardCSR,
+	}
+	_, err = ra.FinalizeOrder(context.Background(), finalizeReq)
+	test.AssertNotError(t, err, "FinalizeOrder failed for authorized "+
+		"wildcard order")
+}
+
+func TestIdentifiersForOrder(t *testing.T) {
+	makeDNSIdent := func(domain string, wildcard bool) core.AcmeIdentifier {
+		return core.AcmeIdentifier{
+			Type:     core.IdentifierDNS,
+			Value:    domain,
+			Wildcard: wildcard,
+		}
+	}
+
+	testCases := []struct {
+		Name                string
+		InputNames          []string
+		ExpectedIdentifiers []core.AcmeIdentifier
+	}{
+		{
+			Name:                "No names as input",
+			InputNames:          []string{},
+			ExpectedIdentifiers: []core.AcmeIdentifier{},
+		},
+		{
+			Name:       "Names without any wildcards",
+			InputNames: []string{"zombo.com", "zombo.org", "zombo.gov.uk"},
+			ExpectedIdentifiers: []core.AcmeIdentifier{
+				makeDNSIdent("zombo.com", false),
+				makeDNSIdent("zombo.org", false),
+				makeDNSIdent("zombo.gov.uk", false),
+			},
+		},
+		{
+			Name:       "Names with a wildcard",
+			InputNames: []string{"zombo.com", "*.zombo.org", "zombo.gov.uk"},
+			ExpectedIdentifiers: []core.AcmeIdentifier{
+				makeDNSIdent("zombo.com", false),
+				// NOTE(@cpu): We expect that *.zombo.org will result in an identifier
+				// for "zombo.org" with Wildcard: true
+				makeDNSIdent("zombo.org", true),
+				makeDNSIdent("zombo.gov.uk", false),
+			},
+		},
+		{
+			Name:       "Names with a wildcard overlapping a duplicated base domain",
+			InputNames: []string{"zombo.com", "*.zombo.com", "zombo.com"},
+			ExpectedIdentifiers: []core.AcmeIdentifier{
+				// NOTE(@cpu): There should be only *one* identifier for the base
+				// "zombo.com" domain, and it should have the wildcard flag set
+				makeDNSIdent("zombo.com", true),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			results := identifiersForOrder(tc.InputNames)
+			test.AssertEquals(t, len(tc.ExpectedIdentifiers), len(results))
+			for i, ident := range results {
+				expectedIdent := tc.ExpectedIdentifiers[i]
+				test.AssertEquals(t, ident.Type, expectedIdent.Type)
+				test.AssertEquals(t, ident.Value, expectedIdent.Value)
+				test.AssertEquals(t, ident.Wildcard, expectedIdent.Wildcard)
 			}
 		})
 	}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2559,6 +2559,12 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 }
 
 func TestIdentifiersForOrder(t *testing.T) {
+	// Only run under test/config-next config where 20170731115209_AddOrders.sql
+	// has been applied
+	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
+		return
+	}
+
 	makeDNSIdent := func(domain string, wildcard bool) core.AcmeIdentifier {
 		return core.AcmeIdentifier{
 			Type:     core.IdentifierDNS,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1577,15 +1577,14 @@ func (ssa *SQLStorageAuthority) GetAuthorizations(ctx context.Context, req *sapb
 		if err != nil {
 			return nil, err
 		}
-		var challs []core.Challenge
-		for _, c := range challObjs {
+		authz.Challenges = make([]core.Challenge, len(challObjs))
+		for i, c := range challObjs {
 			chall, err := modelToChallenge(&c)
 			if err != nil {
 				return nil, err
 			}
-			challs = append(challs, chall)
+			authz.Challenges[i] = chall
 		}
-		authz.Challenges = challs
 	}
 	return authzMapToPB(authzMap)
 }

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1555,6 +1555,28 @@ func (ssa *SQLStorageAuthority) GetAuthorizations(ctx context.Context, req *sapb
 	for name, a := range pendingAuthz {
 		authzMap[name] = a
 	}
+
+	// Fetch each of the authorizations' associated challenges
+	for _, authz := range authzMap {
+		var challObjs []challModel
+		_, err = ssa.dbMap.Select(
+			&challObjs,
+			getChallengesQuery,
+			map[string]interface{}{"authID": authz.ID},
+		)
+		if err != nil {
+			return nil, err
+		}
+		var challs []core.Challenge
+		for _, c := range challObjs {
+			chall, err := modelToChallenge(&c)
+			if err != nil {
+				return nil, err
+			}
+			challs = append(challs, chall)
+		}
+		authz.Challenges = challs
+	}
 	return authzMapToPB(authzMap)
 }
 

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -131,6 +131,7 @@
     },
     "maxConcurrentRPCServerRequests": 100000,
     "features": {
+        "WildcardDomains": true,
         "AllowTLS02Challenges": true,
         "GenerateOCSPEarly": true
     }

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -42,6 +42,7 @@
       ]
     },
     "features": {
+      "WildcardDomains": true,
       "ROCACheck": true,
       "UDPDNS": true,
       "AllowKeyRollover": true,
@@ -56,7 +57,8 @@
     "challenges": {
       "http-01": true,
       "tls-sni-01": true,
-      "dns-01": true
+      "dns-01": true,
+      "dns-01-wildcard": true
     }
   },
 

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -57,8 +57,7 @@
     "challenges": {
       "http-01": true,
       "tls-sni-01": true,
-      "dns-01": true,
-      "dns-01-wildcard": true
+      "dns-01": true
     }
   },
 

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -26,6 +26,7 @@
       ]
     },
     "features": {
+      "WildcardDomains": true,
       "AllowAccountDeactivation": true,
       "AllowRenewalFirstRL": true
     }

--- a/va/caa.go
+++ b/va/caa.go
@@ -35,6 +35,10 @@ func (va *ValidationAuthorityImpl) IsCAAValid(
 	return &vapb.IsCAAValidResponse{}, nil
 }
 
+// TODO(@cpu): `checkCAA` needs to be updated to accept an authorization instead
+// of a challenge. Subsequently we should also update the function to check CAA
+// IssueWild if the authorization's identifier's value has a `*.` prefix (See
+// #3211)
 func (va *ValidationAuthorityImpl) checkCAA(ctx context.Context, identifier core.AcmeIdentifier) *probs.ProblemDetails {
 	present, valid, err := va.checkCAARecords(ctx, identifier)
 	if err != nil {

--- a/va/va.go
+++ b/va/va.go
@@ -796,6 +796,8 @@ func (va *ValidationAuthorityImpl) validateChallenge(ctx context.Context, identi
 		return va.validateTLSSNI01(ctx, identifier, challenge)
 	case core.ChallengeTypeTLSSNI02:
 		return va.validateTLSSNI02(ctx, identifier, challenge)
+	case core.ChallengeTypeDNS01Wildcard:
+		fallthrough
 	case core.ChallengeTypeDNS01:
 		return va.validateDNS01(ctx, identifier, challenge)
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -796,8 +796,6 @@ func (va *ValidationAuthorityImpl) validateChallenge(ctx context.Context, identi
 		return va.validateTLSSNI01(ctx, identifier, challenge)
 	case core.ChallengeTypeTLSSNI02:
 		return va.validateTLSSNI02(ctx, identifier, challenge)
-	case core.ChallengeTypeDNS01Wildcard:
-		fallthrough
 	case core.ChallengeTypeDNS01:
 		return va.validateDNS01(ctx, identifier, challenge)
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -873,6 +873,12 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 	}
 	vStart := va.clk.Now()
 
+	// If the identifier is a wildcard domain we need to validate the base
+	// domain by removing the "*." wildcard prefix.
+	if strings.HasPrefix(domain, "*.") {
+		domain = strings.TrimPrefix(domain, "*.")
+	}
+
 	var remoteError chan *probs.ProblemDetails
 	if len(va.remoteVAs) > 0 {
 		remoteError = make(chan *probs.ProblemDetails, 1)

--- a/va/va.go
+++ b/va/va.go
@@ -766,6 +766,10 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier
 	return nil, probs.Unauthorized("Correct value not found for DNS challenge")
 }
 
+// TODO(@cpu): `validateChallengeAndCAA` needs to be updated to accept an
+// authorization instead of a challenge. Subsequently we should also update the
+// function to check CAA IssueWild if the authorization's identifier's value has
+// a `*.` prefix (See #3211)
 func (va *ValidationAuthorityImpl) validateChallengeAndCAA(ctx context.Context, identifier core.AcmeIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
 	ch := make(chan *probs.ProblemDetails, 1)
 	go func() {

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -268,11 +268,15 @@ func (ra *MockRegistrationAuthority) FinalizeOrder(ctx context.Context, _ *rapb.
 
 type mockPA struct{}
 
-func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, combinations [][]int) {
+func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, combinations [][]int, err error) {
 	return
 }
 
 func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
+	return nil
+}
+
+func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
 	return nil
 }
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -844,8 +844,9 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 		challenge.Error.Type = probs.V2ErrorNS + challenge.Error.Type
 	}
 
-	// DNS-01-Wildcard challenge types are used internally to hint that an
-	// authorization is for a wildcard domain's base domain. Before presenting
+	// DNS-01-Wildcard challenge types are used internally to indicate that an
+	// authorization is for a wildcard domain's base domain. This is required for
+	// proper handling of CAA "issueWild" checking. Before presenting
 	// a DNS-01-Wildcard challenge to the user, pretend its a normal DNS-01 type
 	// challenge.
 	if challenge.Type == core.ChallengeTypeDNS01Wildcard {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -843,6 +843,14 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 	if challenge.Error != nil && !strings.HasPrefix(string(challenge.Error.Type), probs.V1ErrorNS) {
 		challenge.Error.Type = probs.V2ErrorNS + challenge.Error.Type
 	}
+
+	// DNS-01-Wildcard challenge types are used internally to hint that an
+	// authorization is for a wildcard domain's base domain. Before presenting
+	// a DNS-01-Wildcard challenge to the user, pretend its a normal DNS-01 type
+	// challenge.
+	if challenge.Type == core.ChallengeTypeDNS01Wildcard {
+		challenge.Type = core.ChallengeTypeDNS01
+	}
 }
 
 // prepAuthorizationForDisplay takes a core.Authorization and prepares it for

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -862,6 +862,9 @@ func (wfe *WebFrontEndImpl) prepAuthorizationForDisplay(request *http.Request, a
 	// of the protocol.
 	if strings.HasPrefix(authz.Identifier.Value, "*.") {
 		authz.Identifier.Value = strings.TrimPrefix(authz.Identifier.Value, "*.")
+		// Mark that the authorization corresponds to a wildcard request since we've
+		// now removed the wildcard prefix from the identifier.
+		authz.Wildcard = true
 	}
 }
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2418,4 +2418,6 @@ func TestPrepAuthzForDisplayWildcard(t *testing.T) {
 
 	// The authz should not have a wildcard prefix in the identifier value
 	test.AssertEquals(t, strings.HasPrefix(authz.Identifier.Value, "*."), false)
+	// The authz should be marked as corresponding to a wildcard name
+	test.AssertEquals(t, authz.Wildcard, true)
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2395,3 +2395,27 @@ func TestNewAccountWhenGetRegByKeyNotFound(t *testing.T) {
 		t.Errorf("Bad response to NewRegistration: %d, %s", responseWriter.Code, responseWriter.Body)
 	}
 }
+
+func TestPrepAuthzForDisplayWildcard(t *testing.T) {
+	wfe, _ := setupWFE(t)
+
+	// Make an authz for a wildcard identifier
+	authz := &core.Authorization{
+		ID:             "12345",
+		Status:         core.StatusPending,
+		RegistrationID: 1,
+		Identifier:     core.AcmeIdentifier{Type: "dns", Value: "*.example.com"},
+		Challenges: []core.Challenge{
+			{
+				ID:   12345,
+				Type: "dns",
+			},
+		},
+	}
+
+	// Prep the wildcard authz for display
+	wfe.prepAuthorizationForDisplay(&http.Request{Host: "localhost"}, authz)
+
+	// The authz should not have a wildcard prefix in the identifier value
+	test.AssertEquals(t, strings.HasPrefix(authz.Identifier.Value, "*."), false)
+}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -277,11 +277,15 @@ func (ra *MockRegistrationAuthority) FinalizeOrder(ctx context.Context, req *rap
 
 type mockPA struct{}
 
-func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, combinations [][]int) {
+func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, combinations [][]int, err error) {
 	return
 }
 
 func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
+	return nil
+}
+
+func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR implements issuance for wildcard names in the V2 order flow. By policy, pending authorizations for wildcard names only receive a DNS-01 challenge for the base domain. We do not re-use authorizations for the base domain that do not come from a previous wildcard issuance (e.g. a normal authorization for `example.com` turned valid by way of a DNS-01 challenge will **not** be reused for a `*.example.com` order). 

The wildcard prefix is stripped off of the authorization identifier value in two places:
1. When presenting the authorization to the user - ACME forbids having a wildcard character in an authorization identifier.
2. When performing validation - We validate the base domain name without the `*.` prefix.

This PR is largely a rewrite/extension of https://github.com/letsencrypt/boulder/pull/3231. Instead of using a pseudo-challenge-type (DNS-01-Wildcard) to indicate an authorization & identifier correspond to the base name of a wildcard order name we instead allow the identifier to take the wildcard order name with the `*.` prefix. 
