### PR TITLE
Update histogram buckets for latencies that measure things over the internet

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -417,8 +417,9 @@ func initStats(scope metrics.Scope) mailerStats {
 
 	sendLatency := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "sendLatency",
-			Help: "Time the mailer takes sending messages",
+			Name:    "sendLatency",
+			Help:    "Time the mailer takes sending messages",
+			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
 		})
 	scope.MustRegister(sendLatency)
 

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -135,8 +135,9 @@ type pubMetrics struct {
 func initMetrics(stats metrics.Scope) *pubMetrics {
 	submissionLatency := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "ct_submission_time_seconds",
-			Help: "Time taken to submit a certificate to a CT log",
+			Name:    "ct_submission_time_seconds",
+			Help:    "Time taken to submit a certificate to a CT log",
+			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
 		},
 		[]string{"log", "status"},
 	)

--- a/va/va.go
+++ b/va/va.go
@@ -66,15 +66,17 @@ type vaMetrics struct {
 func initMetrics(stats metrics.Scope) *vaMetrics {
 	validationTime := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "validation_time",
-			Help: "Time taken to validate a challenge",
+			Name:    "validation_time",
+			Help:    "Time taken to validate a challenge",
+			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
 		},
 		[]string{"type", "result"})
 	stats.MustRegister(validationTime)
 	remoteValidationTime := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "remote_validation_time",
-			Help: "Time taken to remotely validate a challenge",
+			Name:    "remote_validation_time",
+			Help:    "Time taken to remotely validate a challenge",
+			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
 		},
 		[]string{"type", "result"})
 	stats.MustRegister(remoteValidationTime)


### PR DESCRIPTION
Updates the buckets for histograms in the publisher, va, and expiration-mailer which are used to measure the latency of operations that go over the internet and therefore are liable to take a lot longer than the default buckets can measure. Uses a standard set of buckets for all three instead of attempting to tune for each one.

Fixes #3217.