### PR TITLE
Increase VA SingleDialTimeout to 10s.

### DIFF
--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -20,7 +20,7 @@
     },
     "vaService": {
       "serverAddresses": ["va.boulder:19092"],
-      "timeout": "15s"
+      "timeout": "20s"
     },
     "caService": {
       "serverAddresses": ["ca.boulder:19093"],

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -22,7 +22,7 @@
     },
     "raService": {
       "serverAddresses": ["ra.boulder:19094"],
-      "timeout": "15s"
+      "timeout": "20s"
     },
     "saService": {
       "serverAddresses": ["sa.boulder:19095"],

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -19,7 +19,7 @@
     },
     "vaService": {
       "serverAddresses": ["va.boulder:19092"],
-      "timeout": "15s"
+      "timeout": "20s"
     },
     "caService": {
       "serverAddresses": ["ca.boulder:19093"],

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -23,7 +23,7 @@
     },
     "raService": {
       "serverAddresses": ["ra.boulder:19094"],
-      "timeout": "15s"
+      "timeout": "20s"
     },
     "saService": {
       "serverAddresses": ["sa.boulder:19095"],

--- a/va/va.go
+++ b/va/va.go
@@ -47,7 +47,7 @@ const (
 // before timing out. This timeout ignores the base RPC timeout and is strictly
 // used for the Dial operations that take place during an
 // HTTP-01/TLS-SNI-[01|02] challenge validation.
-var singleDialTimeout = time.Second * 5
+var singleDialTimeout = time.Second * 10
 
 // RemoteVA wraps the core.ValidationAuthority interface and adds a field containing the addresses
 // of the remote gRPC server since the interface (and the underlying gRPC client) doesn't

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -340,9 +340,10 @@ func TestHTTPTimeout(t *testing.T) {
 	started := time.Now()
 	_, prob := va.validateHTTP01(ctx, dnsi("localhost"), chall)
 	took := time.Since(started)
-	// Check that the HTTP connection times out after 5 seconds and doesn't block for 10 seconds
-	test.Assert(t, (took > (time.Second * 5)), "HTTP timed out before 5 seconds")
-	test.Assert(t, (took < (time.Second * 10)), "HTTP connection didn't timeout after 5 seconds")
+	// Check that the HTTP connection does't return before a timeout, and times
+	// out after 10 seconds
+	test.Assert(t, (took > (time.Second * 10)), "HTTP timed out before 10 seconds")
+	test.Assert(t, (took < (time.Second * 20)), "HTTP connection didn't timeout after 10 seconds")
 	if prob == nil {
 		t.Fatalf("Connection should've timed out")
 	}
@@ -517,9 +518,10 @@ func TestTLSSNI01(t *testing.T) {
 		t.Fatalf("Validation should've failed")
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
-	// Check that the TLS connection times out after 5 seconds and doesn't block for 10 seconds
-	test.Assert(t, (took > (time.Second * 5)), "TLS returned before 5 seconds")
-	test.Assert(t, (took < (time.Second * 10)), "TLS connection didn't timeout after 5 seconds")
+	// Check that the TLS connection doesn't return before a timeout, and times
+	// out after 10 seconds
+	test.Assert(t, (took > (time.Second * 10)), "TLS connection returned before 10 seconds")
+	test.Assert(t, (took < (time.Second * 20)), "TLS connection didn't timeout after 10 seconds")
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
 
 	// Take down validation server and check that validation fails.
@@ -589,9 +591,10 @@ func TestTLSSNI02(t *testing.T) {
 		t.Fatalf("Validation should have failed")
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
-	// Check that the TLS connection times out after 5 seconds and doesn't block for 10 seconds
-	test.Assert(t, (took > (time.Second * 5)), "TLS returned before 5 seconds")
-	test.Assert(t, (took < (time.Second * 10)), "TLS connection didn't timeout after 5 seconds")
+	// Check that the TLS connection doesn't return before a timeout, and times
+	// out after 10 seconds
+	test.Assert(t, (took > (time.Second * 10)), "TLS connection returned before 10 seconds")
+	test.Assert(t, (took < (time.Second * 20)), "TLS connection didn't timeout after 10 seconds")
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
 
 	// Take down validation server and check that validation fails.

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -341,9 +341,14 @@ func TestHTTPTimeout(t *testing.T) {
 	_, prob := va.validateHTTP01(ctx, dnsi("localhost"), chall)
 	took := time.Since(started)
 	// Check that the HTTP connection does't return before a timeout, and times
-	// out after 10 seconds
-	test.Assert(t, (took > (time.Second * 10)), "HTTP timed out before 10 seconds")
-	test.Assert(t, (took < (time.Second * 20)), "HTTP connection didn't timeout after 10 seconds")
+	// out after the expected time
+	test.Assert(t,
+		(took > (time.Second * singleDialTimeout)),
+		fmt.Sprintf("HTTP timed out before %d seconds", singleDialTimeout))
+	test.Assert(t,
+		(took < (time.Second * (singleDialTimeout * 2))),
+		fmt.Sprintf("HTTP connection didn't timeout after %d seconds",
+			singleDialTimeout))
 	if prob == nil {
 		t.Fatalf("Connection should've timed out")
 	}
@@ -519,9 +524,14 @@ func TestTLSSNI01(t *testing.T) {
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
 	// Check that the TLS connection doesn't return before a timeout, and times
-	// out after 10 seconds
-	test.Assert(t, (took > (time.Second * 10)), "TLS connection returned before 10 seconds")
-	test.Assert(t, (took < (time.Second * 20)), "TLS connection didn't timeout after 10 seconds")
+	// out after the expected time
+	test.Assert(t,
+		(took > (time.Second * singleDialTimeout)),
+		fmt.Sprintf("TLS connection returned before %d seconds", singleDialTimeout))
+	test.Assert(t,
+		(took < (time.Second * (2 * singleDialTimeout))),
+		fmt.Sprintf("TLS connection didn't timeout after %d seconds",
+			singleDialTimeout))
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
 
 	// Take down validation server and check that validation fails.
@@ -592,9 +602,14 @@ func TestTLSSNI02(t *testing.T) {
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
 	// Check that the TLS connection doesn't return before a timeout, and times
-	// out after 10 seconds
-	test.Assert(t, (took > (time.Second * 10)), "TLS connection returned before 10 seconds")
-	test.Assert(t, (took < (time.Second * 20)), "TLS connection didn't timeout after 10 seconds")
+	// out after the expected time
+	test.Assert(t,
+		(took > (time.Second * singleDialTimeout)),
+		fmt.Sprintf("TLS connection returned before %d seconds", singleDialTimeout))
+	test.Assert(t,
+		(took < (time.Second * (2 * singleDialTimeout))),
+		fmt.Sprintf("TLS connection didn't timeout after %d seconds",
+			singleDialTimeout))
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost \[using 127.0.0.1\]: \[127.0.0.1\]`)), 1)
 
 	// Take down validation server and check that validation fails.


### PR DESCRIPTION
This PR changes the VA's `singleDialTimeout` value from `5 * time.Second` to `10 * time.Second`. This will give slower servers a better chance to respond, especially for the multi-VA case where `n` requests arrive ~simultaneously.

This PR also bumps the RA->VA timeout by 5s and the WFE->RA timeout by 5s to accommodate the increased dial timeout. I put this in a separate commit in case we'd rather deal with this separately.