### PR TITLE
Speed up expired authz purger

### DIFF
--- a/cmd/expired-authz-purger/config.json
+++ b/cmd/expired-authz-purger/config.json
@@ -1,7 +1,7 @@
 {
     "expiredAuthzPurger": {
         "syslog": {
-          "stdoutLevel": 6
+          "stdoutLevel": 7
         },
         "dbConnectFile": "test/secrets/purger_dburl",
         "maxDBConns": 10,

--- a/cmd/expired-authz-purger/config.json
+++ b/cmd/expired-authz-purger/config.json
@@ -1,7 +1,7 @@
 {
     "expiredAuthzPurger": {
         "syslog": {
-          "stdoutLevel": 7
+          "stdoutLevel": 6
         },
         "dbConnectFile": "test/secrets/purger_dburl",
         "maxDBConns": 10,

--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -141,6 +141,8 @@ func deleteAuthorization(db *gorp.DbMap, table, id string) error {
 }
 
 func (p *expiredAuthzPurger) purgeAuthzs(purgeBefore time.Time, parallelism int, max int) error {
+	// Purge authz first because it tends to be bigger and in more need of
+	// purging.
 	for _, table := range []string{"authz", "pendingAuthorizations"} {
 		err := p.purge(table, purgeBefore, parallelism, max)
 		if err != nil {

--- a/cmd/expired-authz-purger/main_test.go
+++ b/cmd/expired-authz-purger/main_test.go
@@ -33,7 +33,7 @@ func TestPurgeAuthzs(t *testing.T) {
 
 	p := expiredAuthzPurger{log, fc, dbMap, 1}
 
-	err = p.purgeAuthzs(time.Time{}, true, 10, 100)
+	err = p.purgeAuthzs(time.Time{}, 10, 100)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 
 	old, new := fc.Now().Add(-time.Hour), fc.Now().Add(time.Hour)
@@ -58,7 +58,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "NewPendingAuthorization failed")
 
-	err = p.purgeAuthzs(fc.Now(), true, 10, 100)
+	err = p.purgeAuthzs(fc.Now(), 10, 100)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err := dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
@@ -67,7 +67,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
 	test.AssertEquals(t, count, int64(1))
 
-	err = p.purgeAuthzs(fc.Now().Add(time.Hour), true, 10, 100)
+	err = p.purgeAuthzs(fc.Now().Add(time.Hour), 10, 100)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err = dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -315,7 +315,7 @@ def get_future_output(cmd, date):
 
 def test_expired_authz_purger():
     def expect(target_time, num, table):
-        out = get_future_output("./bin/expired-authz-purger --config cmd/expired-authz-purger/config.json --yes", target_time)
+        out = get_future_output("./bin/expired-authz-purger --config cmd/expired-authz-purger/config.json", target_time)
         if 'via FAKECLOCK' not in out:
             raise Exception("expired-authz-purger was not built with `integration` build tag")
         if num is None:


### PR DESCRIPTION
Now, rather than LIMIT / OFFSET, this uses the highest id from the last batch in each new batch's query. This makes efficient use of the index, and means the database does not have to scan over a large number of non-expired rows before starting to find any expired rows.

This also changes the structure of the purge function to continually push ids for deletion onto a channel, to be processed by goroutines consuming that channel.

Also, remove the --yes flag and prompting.