### PR TITLE
v2 API gRPC wrapper bugfixes

### DIFF
--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -414,9 +414,9 @@ func orderValid(order *corepb.Order) bool {
 
 // newOrderValid checks that a corepb.Order is valid. It allows for a nil
 // `order.Id` because the order has not been assigned an ID yet when it is being
-// created initlaly.. It also allow `order.CertificateStatus` to be nil such
+// created initlaly.. It also allow `order.CertificateSerial` to be nil such
 // that it can be used in places where the order has not been finalized yet.
-// Callers must additionally ensure the `CertificateStatus` field is non-nil if
+// Callers must additionally ensure the `CertificateSerial` field is non-nil if
 // they intend to use it.
 func newOrderValid(order *corepb.Order) bool {
 	return !(order.RegistrationID == nil || order.Expires == nil || order.Authorizations == nil || order.Status == nil || order.Names == nil)

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -409,7 +409,7 @@ func registrationValid(reg *corepb.Registration) bool {
 // orderValid checks that a corepb.Order is valid. In addition to the checks
 // from `newOrderValid` it ensures the order ID is not nil.
 func orderValid(order *corepb.Order) bool {
-	return orderId != nil && newOrderValid(order)
+	return order.Id != nil && newOrderValid(order)
 }
 
 // newOrderValid checks that a corepb.Order is valid. It allows for a nil

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -414,7 +414,7 @@ func orderValid(order *corepb.Order) bool {
 
 // newOrderValid checks that a corepb.Order is valid. It allows for a nil
 // `order.Id` because the order has not been assigned an ID yet when it is being
-// created initlaly.. It also allow `order.CertificateSerial` to be nil such
+// created initially. It also allows `order.CertificateSerial` to be nil such
 // that it can be used in places where the order has not been finalized yet.
 // Callers must additionally ensure the `CertificateSerial` field is non-nil if
 // they intend to use it.

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -409,7 +409,7 @@ func registrationValid(reg *corepb.Registration) bool {
 // orderValid checks that a corepb.Order is valid. In addition to the checks
 // from `newOrderValid` it ensures the order ID is not nil.
 func orderValid(order *corepb.Order) bool {
-	return !(order.Id == nil || !newOrderValid(order))
+	return orderId != nil && newOrderValid(order)
 }
 
 // newOrderValid checks that a corepb.Order is valid. It allows for a nil

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -406,12 +406,20 @@ func registrationValid(reg *corepb.Registration) bool {
 	return !(reg.Id == nil || reg.Key == nil || reg.Agreement == nil || reg.InitialIP == nil || reg.CreatedAt == nil || reg.Status == nil || reg.ContactsPresent == nil)
 }
 
-// orderValid checks that a corepb.Order is valid. It allows
-// `order.CertificateStatus` to be nil such that it can be used in places where
-// the order has not been finalized yet. Callers must additionally ensure the
-// `CertificateStatus` field is non-nil if they intend to use it.
+// orderValid checks that a corepb.Order is valid. In addition to the checks
+// from `newOrderValid` it ensures the order ID is not nil.
 func orderValid(order *corepb.Order) bool {
-	return !(order.Id == nil || order.RegistrationID == nil || order.Expires == nil || order.Authorizations == nil || order.Status == nil || order.Names == nil)
+	return !(order.Id == nil || !newOrderValid(order))
+}
+
+// newOrderValid checks that a corepb.Order is valid. It allows for a nil
+// `order.Id` because the order has not been assigned an ID yet when it is being
+// created initlaly.. It also allow `order.CertificateStatus` to be nil such
+// that it can be used in places where the order has not been finalized yet.
+// Callers must additionally ensure the `CertificateStatus` field is non-nil if
+// they intend to use it.
+func newOrderValid(order *corepb.Order) bool {
+	return !(order.RegistrationID == nil || order.Expires == nil || order.Authorizations == nil || order.Status == nil || order.Names == nil)
 }
 
 func authorizationValid(authz *corepb.Authorization) bool {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -1094,7 +1094,7 @@ func (sas StorageAuthorityServerWrapper) GetAuthorizations(ctx context.Context, 
 }
 
 func (sas StorageAuthorityServerWrapper) AddPendingAuthorizations(ctx context.Context, request *sapb.AddPendingAuthorizationsRequest) (*sapb.AuthorizationIDs, error) {
-	if request == nil || request.Authz != nil {
+	if request == nil || request.Authz == nil {
 		return nil, errIncompleteRequest
 	}
 

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -546,7 +546,7 @@ func (sas StorageAuthorityClientWrapper) GetAuthorizations(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil || resp.Authz == nil {
+	if resp == nil {
 		return nil, errIncompleteResponse
 	}
 	for _, element := range resp.Authz {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -510,7 +510,7 @@ func (sas StorageAuthorityClientWrapper) GetOrder(ctx context.Context, request *
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil || resp.Id == nil || resp.RegistrationID == nil || resp.Expires == nil || resp.Authorizations == nil || resp.Status == nil || resp.Error == nil || resp.CertificateSerial == nil || resp.Names == nil {
+	if resp == nil || !orderValid(resp) {
 		return nil, errIncompleteResponse
 	}
 	return resp, nil

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -1020,7 +1020,7 @@ func (sas StorageAuthorityServerWrapper) DeactivateAuthorization(ctx context.Con
 }
 
 func (sas StorageAuthorityServerWrapper) NewOrder(ctx context.Context, request *corepb.Order) (*corepb.Order, error) {
-	if request == nil || !orderValid(request) {
+	if request == nil || !newOrderValid(request) {
 		return nil, errIncompleteRequest
 	}
 

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -523,10 +523,17 @@ func (sas StorageAuthorityClientWrapper) GetOrderAuthorizations(
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil || resp.Authz == nil {
+	if resp == nil {
 		return nil, errIncompleteResponse
 	}
 
+	// If there were no authorizations, return nil
+	if resp.Authz == nil {
+		return nil, nil
+	}
+
+	// Otherwise check the authorizations are valid and convert them from protobuf
+	// form before returning a map of results to the caller
 	auths := make(map[string]*core.Authorization, len(resp.Authz))
 	for _, element := range resp.Authz {
 		if element == nil || element.Domain == nil || !authorizationValid(element.Authz) {


### PR DESCRIPTION
### Allow nil `Authz` slice in `GetAuthorizations` response.
The `StorageAuthorityClientWrapper` was enforcing that the response to
a `GetAuthorizations` request did not have `resp.Authz == nil`. This
meant that the RA's `NewOrder` function failed when creating an order
for names that had no existing authorizations to reuse.

This commit updates the wrapper to allow `resp.Authz` to be nil - this
is a valid case when there are no authorizations found.

### Fix SA server wrapper `AddPendingAuthorizations` logic.
Prior to this commit the `StorageAuthorityServerWrapper`'s
`AddPendingAuthorizations` function had an error in the boolean logic
for determining if a request was incomplete. It was rejecting any
requests that had a non-nil `Authz`. This commit fixes the logic so that
it rejects requests that have a **nil** `Authz`.

### Add `newOrderValid` for new-order rpc wrappers.
This commit updates the `StorageAuthorityServerWrapper`'s `NewOrder`
function to use a new pb-marshalling utility function `newOrderValid` to
determine if the provided order is valid or not. Previous to this commit
the `NewOrder` server wrapper used `orderValid` which rejected orders
that had a nil `Id`. This is incorrect because **all** orders provided
to `NewOrder` have a nil id! They haven't been added yet :-)

### Fix SA server wrapper `GetOrder` incomplete response check.
Prior to this commit the `StorageAuthorityClientWrapper`'s `GetOrder`
function was validating that the returned order had a non-nil
`CertificateSerial`. This isn't correct - you can GET an order that
hasn't been finalized with a certificate and it should work. This commit
updates the `GetOrder` function to use the utility `orderValid` function
that allows for a nil `CertificateSerial` but enforces all other fields
are populated as expected.

### Allow nil Authz in `GetOrderAuthorizations` response.
This commit fixes the `StorageAuthorityClientWrapper`'s
`GetOrderAuthorizations` function to not consider a response with a nil
`Authz` array incomplete. This condition happens under normal
circumstances when an attempt to finalize an order is made for an order
that has completed no authorizations.
