### PR TITLE
WFE2: Remove secondary ToS check.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1617,17 +1617,6 @@ func (wfe *WebFrontEndImpl) finalizeOrder(
 		return
 	}
 
-	// The account must have agreed to the subscriber agreement to finalize an
-	// order since it will result in the issuance of a certificate.
-	// Any version of the agreement is acceptable here. Version match is enforced in
-	// wfe.Registration when agreeing the first time. Agreement updates happen
-	// by mailing subscribers and don't require a registration update.
-	if acct.Agreement == "" {
-		wfe.sendError(response, logEvent,
-			probs.Unauthorized("Must agree to subscriber agreement before any further actions"), nil)
-		return
-	}
-
 	// If the order's status is not pending we can not finalize it and must
 	// return an error
 	if *order.Status != string(core.StatusPending) {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1934,14 +1934,6 @@ func TestFinalizeOrder(t *testing.T) {
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order found for account ID 2","status":404}`,
 		},
 		{
-			Name: "Account without Subscriber agreement",
-			// mocks/mocks.go's StorageAuthority's GetRegistration mock treats ID 6
-			// as an account without the agreement set. Order ID 6 is mocked to belong
-			// to it.
-			Request:      signAndPost(t, "6/6/finalize-order", "http://localhost/6/6/finalize-order", "{}", 6, wfe.nonceService),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `unauthorized","detail":"Must agree to subscriber agreement before any further actions","status":403}`,
-		},
-		{
 			Name:         "Order ID is invalid",
 			Request:      signAndPost(t, "1/okwhatever/finalize-order", "http://localhost/1/okwhatever/finalize-order", "{}", 1, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid order ID","status":400}`,


### PR DESCRIPTION
`terms-of-service-agreed` is checked at initial signup and doesn't need
to be rechecked. Worse, since the V2 registration only accepts a bool
the "Agreement" field is never set and checking it against != "" will
always fail for v2 accounts.

This was [already done for Pebble](https://github.com/letsencrypt/pebble/commit/6d6e811c1dc55b9e3af4ce7db94baf9ec4f8bd38) but was missed in the Boulder WFE2.