### PR TITLE
Remove authorization combos for V2 API

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -873,6 +873,10 @@ func (wfe *WebFrontEndImpl) prepAuthorizationForDisplay(request *http.Request, a
 	authz.ID = ""
 	authz.RegistrationID = 0
 
+	// Combinations are a relic of the V1 API. Since they are tagged omitempty we
+	// can set this field to nil to avoid sending it to users of the V2 API.
+	authz.Combinations = nil
+
 	// The ACME spec forbids allowing "*" in authorization identifiers. Boulder
 	// allows this internally as a means of tracking when an authorization
 	// corresponds to a wildcard request (e.g. to handle CAA properly). We strip

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2438,7 +2438,7 @@ func TestNewAccountWhenGetRegByKeyNotFound(t *testing.T) {
 	}
 }
 
-func TestPrepAuthzForDisplayWildcard(t *testing.T) {
+func TestPrepAuthzForDisplay(t *testing.T) {
 	wfe, _ := setupWFE(t)
 
 	// Make an authz for a wildcard identifier
@@ -2453,6 +2453,7 @@ func TestPrepAuthzForDisplayWildcard(t *testing.T) {
 				Type: "dns",
 			},
 		},
+		Combinations: [][]int{{1, 2, 3}, {4}, {5, 6}},
 	}
 
 	// Prep the wildcard authz for display
@@ -2462,4 +2463,10 @@ func TestPrepAuthzForDisplayWildcard(t *testing.T) {
 	test.AssertEquals(t, strings.HasPrefix(authz.Identifier.Value, "*."), false)
 	// The authz should be marked as corresponding to a wildcard name
 	test.AssertEquals(t, authz.Wildcard, true)
+	// The authz should not have any combinations
+	// NOTE(@cpu): We don't use test.AssertNotNil here because its use of
+	// interface{} types makes a comparsion of [][]int{nil} and nil fail.
+	if authz.Combinations != nil {
+		t.Errorf("Authz had a non-nil combinations")
+	}
 }


### PR DESCRIPTION
The `combinations` field of an authorization is a relic of the V1 API
and not present in the current ACME draft specifications. This commit
updates the WFE2's `prepAuthorizationForDisplay` function to remove the
`combinations` field before returning an authorization object to be
displayed in an API response.

Resolves https://github.com/letsencrypt/boulder/issues/3275