### PR TITLE
More small WFE2 fixes

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -231,7 +231,10 @@ type Challenge struct {
 	Error *probs.ProblemDetails `json:"error,omitempty"`
 
 	// A URI to which a response can be POSTed
-	URI string `json:"uri"`
+	URI string `json:"uri,omitempty"`
+
+	// For the V2 API the "URI" field is deprecated in favour of URL.
+	URL string `json:"url,omitempty"`
 
 	// Used by http-01, tls-sni-01, and dns-01 challenges
 	Token string `json:"token,omitempty"` // Used by http-00, tls-sni-00, and dns-00 challenges

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -924,7 +924,7 @@ func (wfe *WebFrontEndImpl) getChallenge(
 	response.Header().Add("Location", challenge.URI)
 	response.Header().Add("Link", link(authzURL, "up"))
 
-	err := wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, challenge)
+	err := wfe.writeJsonResponse(response, logEvent, http.StatusOK, challenge)
 	if err != nil {
 		// InternalServerError because this is a failure to decode data passed in
 		// by the caller, which got it from the DB.
@@ -988,7 +988,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	response.Header().Add("Location", challenge.URI)
 	response.Header().Add("Link", link(authzURL, "up"))
 
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, challenge)
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, challenge)
 	if err != nil {
 		// ServerInternal because we made the challenges, they should be OK
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal challenge"), err)
@@ -1085,7 +1085,7 @@ func (wfe *WebFrontEndImpl) Account(
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
 	}
 
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, updatedAcct)
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, updatedAcct)
 	if err != nil {
 		// ServerInternal because we just generated the account, it should be OK
 		wfe.sendError(response, logEvent,

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -810,7 +810,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 		wfe.sendError(response, logEvent, probs.NotFound("No such challenge"), nil)
 	}
 
-	// Challenge URIs are of the form /acme/challenge/<auth id>/<challenge id>.
+	// Challenge URLs are of the form /acme/challenge/<auth id>/<challenge id>.
 	// Here we parse out the id components.
 	slug := strings.Split(request.URL.Path, "/")
 	if len(slug) != 2 {
@@ -866,11 +866,13 @@ func (wfe *WebFrontEndImpl) Challenge(
 }
 
 // prepChallengeForDisplay takes a core.Challenge and prepares it for display to
-// the client by filling in its URI field and clearing its ID field.
+// the client by filling in its URL field and clearing its ID and URI fields.
 func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz core.Authorization, challenge *core.Challenge) {
-	// Update the challenge URI to be relative to the HTTP request Host
-	challenge.URI = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s/%d", challengePath, authz.ID, challenge.ID))
-	// Ensure the challenge ID isn't written. 0 is considered "empty" for the purpose of the JSON omitempty tag.
+	// Update the challenge URL to be relative to the HTTP request Host
+	challenge.URL = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s/%d", challengePath, authz.ID, challenge.ID))
+	// Ensure the challenge URI and challenge ID aren't written by setting them to
+	// values that the JSON omitempty tag considers empty
+	challenge.URI = ""
 	challenge.ID = 0
 
 	// Historically the Type field of a problem was always prefixed with a static
@@ -921,7 +923,7 @@ func (wfe *WebFrontEndImpl) getChallenge(
 	wfe.prepChallengeForDisplay(request, authz, challenge)
 
 	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
-	response.Header().Add("Location", challenge.URI)
+	response.Header().Add("Location", challenge.URL)
 	response.Header().Add("Link", link(authzURL, "up"))
 
 	err := wfe.writeJsonResponse(response, logEvent, http.StatusOK, challenge)
@@ -985,7 +987,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	wfe.prepChallengeForDisplay(request, authz, &challenge)
 
 	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
-	response.Header().Add("Location", challenge.URI)
+	response.Header().Add("Location", challenge.URL)
 	response.Header().Add("Link", link(authzURL, "up"))
 
 	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, challenge)

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -947,7 +947,7 @@ func TestGetChallenge(t *testing.T) {
 		wfe.Challenge(ctx, newRequestEvent(), resp, req)
 		test.AssertEquals(t,
 			resp.Code,
-			http.StatusAccepted)
+			http.StatusOK)
 		test.AssertEquals(t,
 			resp.Header().Get("Location"),
 			challengeURL)
@@ -983,7 +983,7 @@ func TestChallenge(t *testing.T) {
 		{
 			Name:           "Valid challenge",
 			Path:           "valid/23",
-			ExpectedStatus: http.StatusAccepted,
+			ExpectedStatus: http.StatusOK,
 			ExpectedHeaders: map[string]string{
 				"Location": "http://localhost/acme/challenge/valid/23",
 				"Link":     `<http://localhost/acme/authz/valid>;rel="up"`,

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -963,7 +963,7 @@ func TestGetChallenge(t *testing.T) {
 		if method == "GET" {
 			test.AssertUnmarshaledEquals(
 				t, resp.Body.String(),
-				`{"type":"dns","uri":"http://localhost/acme/challenge/valid/23"}`)
+				`{"type":"dns","url":"http://localhost/acme/challenge/valid/23"}`)
 		}
 	}
 }
@@ -988,7 +988,7 @@ func TestChallenge(t *testing.T) {
 				"Location": "http://localhost/acme/challenge/valid/23",
 				"Link":     `<http://localhost/acme/authz/valid>;rel="up"`,
 			},
-			ExpectedBody: `{"type":"dns","uri":"http://localhost/acme/challenge/valid/23"}`,
+			ExpectedBody: `{"type":"dns","url":"http://localhost/acme/challenge/valid/23"}`,
 		},
 		{
 			Name:           "Expired challenge",
@@ -1677,7 +1677,7 @@ func TestDeactivateAuthorization(t *testing.T) {
 		  "challenges": [
 		    {
 		      "type": "dns",
-		      "uri": "http://localhost/acme/challenge/valid/23"
+		      "url": "http://localhost/acme/challenge/valid/23"
 		    }
 		  ]
 		}`)
@@ -2472,4 +2472,9 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	if authz.Combinations != nil {
 		t.Errorf("Authz had a non-nil combinations")
 	}
+
+	// We expect the authz challenge has its URL set and the URI emptied.
+	chal := authz.Challenges[0]
+	test.AssertEquals(t, chal.URL, "http://localhost/acme/challenge/12345/12345")
+	test.AssertEquals(t, chal.URI, "")
 }


### PR DESCRIPTION
* Fixes two places WFE2 returned `http.StatusAccepted` when it should return `http.StatusOK`
* Removes the legacy challenge "URI" field in place of "URL"