### PR TITLE
Set the Certificate Content-Type before writing headers.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1207,8 +1207,8 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 		return
 	}
 
-	response.WriteHeader(http.StatusOK)
 	response.Header().Set("Content-Type", "application/pem-certificate-chain")
+	response.WriteHeader(http.StatusOK)
 
 	pem := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",


### PR DESCRIPTION
Prior to this commit we called `response.WriteHeader(http.StatusOK)` in
the wfe2's `Certificate` handler before
`response.Header().Set("Content-Type", "...")`, which meant that the
response was served with a Content-Type of `application/json` instead of
the intended `application/pem-certificate-chain`. This commit changes
the order so the correct Content-Type header is written in the response.

Thanks to @shred & his ACME4J integration test suite for catching this
one!