### PR TITLE
Fix issuerCert in test configs.

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -32,23 +32,9 @@ type config struct {
 	PA cmd.PAConfig
 
 	Syslog cmd.SyslogConfig
-
-	Common struct {
-		// Path to a PEM-encoded copy of the issuer certificate.
-		IssuerCert string
-	}
 }
 
 func loadIssuers(c config) ([]ca.Issuer, error) {
-	if c.CA.Key != nil {
-		issuerConfig := *c.CA.Key
-		issuerConfig.CertFile = c.Common.IssuerCert
-		priv, cert, err := loadIssuer(issuerConfig)
-		return []ca.Issuer{{
-			Signer: priv,
-			Cert:   cert,
-		}}, err
-	}
 	var issuers []ca.Issuer
 	for _, issuerConfig := range c.CA.Issuers {
 		priv, cert, err := loadIssuer(issuerConfig)

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -148,9 +148,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 4
-  },
-
-  "common": {
-    "issuerCert": "test/test-ca.pem"
   }
 }

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -15,6 +15,6 @@
  },
 
   "common": {
-    "issuerCert": "test/test-ca.pem"
+    "issuerCert": "test/test-ca2.pem"
   }
 }

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -42,7 +42,7 @@
   },
 
   "common": {
-    "issuerCert": "test/test-ca.pem",
+    "issuerCert": "test/test-ca2.pem",
     "ct": {
       "logs": [
         {

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -40,9 +40,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 4
-  },
-
-  "common": {
-    "issuerCert": "test/test-ca.pem"
   }
 }

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -43,6 +43,6 @@
   },
 
   "common": {
-    "issuerCert": "test/test-ca.pem"
+    "issuerCert": "test/test-ca2.pem"
   }
 }

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -145,9 +145,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 4
-  },
-
-  "common": {
-    "issuerCert": "test/test-ca.pem"
   }
 }

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -16,6 +16,6 @@
  },
 
   "common": {
-    "issuerCert": "test/test-ca.pem"
+    "issuerCert": "test/test-ca2.pem"
   }
 }

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -42,7 +42,7 @@
   },
 
   "common": {
-    "issuerCert": "test/test-ca.pem",
+    "issuerCert": "test/test-ca2.pem",
     "ct": {
       "logs": [
         {

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -43,6 +43,6 @@
   },
 
   "common": {
-    "issuerCert": "test/test-ca.pem"
+    "issuerCert": "test/test-ca2.pem"
   }
 }

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -43,6 +43,6 @@
   },
 
   "common": {
-    "issuerCert": "test/test-ca.pem"
+    "issuerCert": "test/test-ca2.pem"
   }
 }


### PR DESCRIPTION
Previously, there was a disagreement between WFE and CA as to what the correct
issuer certificate was. Consolidate on test-ca2.pem (h2ppy h2cker fake CA).
    
Also, the CA configs contained an outdated entry for "IssuerCert", which was not
being used: The CA configs now use an "Issuers" array to allow signing by
multiple issuer certificates at once (for instance when rolling intermediates).
Removed this outdated entry, and the config code for CA to load it. I've
confirmed these changes match what is currently in production.

Added an integration test to check for this problem in the future.

Fixes #3309, thanks to @icing for bringing the issue to our attention!