### PR TITLE
Add wildcard exact blacklist to PA.

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -320,6 +320,10 @@ func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error
 		// blacklist when the "*." is removed we replace it with a single "x"
 		// character to differentiate "*.example.com" from "example.com" for the
 		// exact hostname check.
+		//
+		// NOTE(@cpu): This is pretty hackish! Boulder issue #3323[0] describes
+		// a better follow-up that we should land to replace this code.
+		// [0] https://github.com/letsencrypt/boulder/issues/3323
 		return pa.WillingToIssue(core.AcmeIdentifier{
 			Type:  core.IdentifierDNS,
 			Value: "x." + baseDomain,

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -316,9 +316,13 @@ func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error
 			return err
 		}
 		// Check that the PA is willing to issue for the base domain
+		// Since the base domain without the "*." may trip the exact hostname policy
+		// blacklist when the "*." is removed we replace it with a single "x"
+		// character to differentiate "*.example.com" from "example.com" for the
+		// exact hostname check.
 		return pa.WillingToIssue(core.AcmeIdentifier{
 			Type:  core.IdentifierDNS,
-			Value: baseDomain,
+			Value: "x." + baseDomain,
 		})
 	}
 

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -263,12 +263,6 @@ func TestWillingToIssueWildcard(t *testing.T) {
 			Ident:       makeDNSIdent("*.zombo.gov.us"),
 			ExpectedErr: errBlacklisted,
 		},
-		// We should not allow getting a wildcard for an exact blacklist domain.
-		{
-			Name:        "Wildcard for ExactBlacklist domain",
-			Ident:       makeDNSIdent("*.highvalue.letsdecrypt.org"),
-			ExpectedErr: errBlacklisted,
-		},
 		// We should not allow getting a wildcard for that would cover an exact
 		// blocklist domain
 		{
@@ -281,6 +275,13 @@ func TestWillingToIssueWildcard(t *testing.T) {
 		{
 			Name:        "Wildcard for non-matching subdomain of ExactBlacklist domain",
 			Ident:       makeDNSIdent("*.lowvalue.letsdecrypt.org"),
+			ExpectedErr: nil,
+		},
+		// We should allow getting a wildcard for an exact blacklist domain since it
+		// only covers subdomains, not the exact name.
+		{
+			Name:        "Wildcard for ExactBlacklist domain",
+			Ident:       makeDNSIdent("*.highvalue.letsdecrypt.org"),
 			ExpectedErr: nil,
 		},
 		{

--- a/test/integration-test-v2.py
+++ b/test/integration-test-v2.py
@@ -32,6 +32,7 @@ def main():
     # issue (#3312)
     #test_wildcardmultidomain()
     #test_overlapping_wildcard()
+    test_wildcard_exactblacklist()
 
     if not startservers.check():
         raise Exception("startservers.check failed")
@@ -69,6 +70,19 @@ def test_overlapping_wildcard():
         order = client.poll_order_and_request_issuance(order)
     finally:
         cleanup()
+
+def test_wildcard_exactblacklist():
+    """
+    Test issuance for a wildcard that would cover an exact blacklist entry. It
+    should fail with a policy error.
+    """
+
+    # We include "highrisk.le-test.hoffman-andrews.com" in `test/hostname-policy.json`
+    # Issuing for "*.le-test.hoffman-andrews.com" should be blocked
+    domain = "*.le-test.hoffman-andrews.com"
+    # We expect this to produce a policy problem
+    chisel2.expect_problem("urn:ietf:params:acme:error:rejectedIdentifier",
+        lambda: auth_and_issue([domain], chall_type="dns-01"))
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
This commit adds a new `wildcardExactBlacklist` map to the PA's
`AuthorityImpl` that is used by `WillingToIssueWildcard` to decide if
a wildcard issuance would cover a high value domain.

This prevents getting a wildcard for `"*.example.com"` if
`"highvalue.example.com"` is on the exact blacklist since it would
circumvent the intention of the exact blacklist by minting a certificate
that could be used for `"highvalue.example.com"`.

Resolves https://github.com/letsencrypt/boulder/issues/3239