### PR TITLE
Remove references to test-ca.pem.

### DIFF
--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -145,7 +145,7 @@ func TestLoadCert(t *testing.T) {
 			"open ../does/not/exist: no such file or directory",
 		},
 		{
-			"../test/test-ca.key",
+			"./testdata/key.pem",
 			"Invalid certificate value returned",
 		},
 	}
@@ -156,8 +156,8 @@ func TestLoadCert(t *testing.T) {
 		test.AssertEquals(t, err.Error(), tc.expectedErr)
 	}
 
-	bytes, err := LoadCert("../test/test-ca.pem")
-	test.AssertNotError(t, err, "LoadCert(../test/test-ca.pem) errored")
+	bytes, err := LoadCert("./testdata/cert.pem")
+	test.AssertNotError(t, err, "LoadCert(\"./testdata/cert.pem\") errored")
 	test.AssertNotEquals(t, len(bytes), 0)
 }
 

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -115,8 +115,6 @@ CspkK71IGqM9UwwMtCZBp0fK/Xv9o1d85paXcJ/aH8zg6EK4UkuXDFnLsg1LrIru
 OY8B7wwvZTLzU6WWs781TJXx2CE04PneeeArLpVLkiGIWjk=
 -----END CERTIFICATE-----`
 
-const issuerPath = "../test/test-ca.pem"
-
 var log = blog.UseMock()
 var ctx = context.Background()
 


### PR DESCRIPTION
shell_test.go and publisher_test.go had unnecessary references to
../test/test-ca.pem. This change makes them a little more self-contained.

Note: ca/ca_test.go still depends on test-ca.pem, but removing the dependency
turns out to be a little more complicated due to hardcoded expectations in some
of the test cases.