### PR TITLE
Return correct response to existing newAccount reqs.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -497,8 +497,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	if err == nil {
 		response.Header().Set("Location",
 			wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
-		// TODO(#595): check for missing account err
-		wfe.sendError(response, logEvent, probs.Conflict("Account key is already in use"), err)
+		response.WriteHeader(http.StatusOK)
 		return
 	} else if !berrors.Is(err, berrors.NotFound) {
 		wfe.sendError(response, logEvent, probs.ServerInternal("failed check for existing account"), nil)

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1131,9 +1131,8 @@ func TestNewECDSAAccount(t *testing.T) {
 	// POST, Valid JSON, Key already in use
 	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
 	responseBody = responseWriter.Body.String()
-	test.AssertUnmarshaledEquals(t, responseBody, `{"type":"`+probs.V2ErrorNS+`malformed","detail":"Account key is already in use","status":409}`)
 	test.AssertEquals(t, responseWriter.Header().Get("Location"), "http://localhost/acme/acct/3")
-	test.AssertEquals(t, responseWriter.Code, 409)
+	test.AssertEquals(t, responseWriter.Code, 200)
 }
 
 // Test that the WFE handling of the "empty update" POST is correct. The ACME
@@ -1276,13 +1275,10 @@ func TestNewAccount(t *testing.T) {
 	request = makePostRequestWithPath(path, body)
 
 	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
-	test.AssertUnmarshaledEquals(t,
-		responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`malformed","detail":"Account key is already in use","status":409}`)
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Location"),
 		"http://localhost/acme/acct/1")
-	test.AssertEquals(t, responseWriter.Code, 409)
+	test.AssertEquals(t, responseWriter.Code, 200)
 }
 
 func TestGetAuthorization(t *testing.T) {


### PR DESCRIPTION
Prior to this commit the WFE2 returned a HTTP 409 status with
a malformed problem body when a newAccount request arrived signed with
the same key as is used with an existing account. Per draft-09 this
should be a HTTP 200 OK response. This is what Pebble implements as
well.

This commit updates the WFE2 and tests to match draft-09 behaviour in
this regard.

An outdated TODO is also removed. The case where an error other 
than `berrors.NotFound` is returned is handled correctly.

Resolves https://github.com/letsencrypt/boulder/issues/3327