### PR TITLE
Add Location header to WFE2 finalize response

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1664,6 +1664,10 @@ func (wfe *WebFrontEndImpl) finalizeOrder(
 		return
 	}
 
+	orderURL := wfe.relativeEndpoint(request,
+		fmt.Sprintf("%s%d/%d", orderPath, acct.ID, *updatedOrder.Id))
+	response.Header().Set("Location", orderURL)
+
 	respObj := wfe.orderToOrderJSON(request, updatedOrder)
 	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, respObj)
 	if err != nil {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1858,9 +1858,10 @@ func TestFinalizeOrder(t *testing.T) {
 	egUrl := mustParseURL("1/1/finalize-order")
 
 	testCases := []struct {
-		Name         string
-		Request      *http.Request
-		ExpectedBody string
+		Name            string
+		Request         *http.Request
+		ExpectedHeaders map[string]string
+		ExpectedBody    string
 	}{
 		{
 			Name: "POST, but no body",
@@ -1938,8 +1939,9 @@ func TestFinalizeOrder(t *testing.T) {
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Error parsing certificate request: asn1: structure error: tags don't match (16 vs {class:0 tag:0 length:16 isCompound:false}) {optional:false explicit:false application:false defaultValue:\u003cnil\u003e tag:\u003cnil\u003e stringType:0 timeType:0 set:false omitEmpty:false} certificateRequest @2","status":400}`,
 		},
 		{
-			Name:    "Good CSR",
-			Request: signAndPost(t, "1/4/finalize-order", "http://localhost/1/4/finalize-order", goodCertCSRPayload, 1, wfe.nonceService),
+			Name:            "Good CSR",
+			Request:         signAndPost(t, "1/4/finalize-order", "http://localhost/1/4/finalize-order", goodCertCSRPayload, 1, wfe.nonceService),
+			ExpectedHeaders: map[string]string{"Location": "http://localhost/acme/order/1/4"},
 			ExpectedBody: `
 {
   "status": "processing",
@@ -1960,6 +1962,9 @@ func TestFinalizeOrder(t *testing.T) {
 			responseWriter.Body.Reset()
 			responseWriter.HeaderMap = http.Header{}
 			wfe.Order(ctx, newRequestEvent(), responseWriter, tc.Request)
+			for k, v := range tc.ExpectedHeaders {
+				test.AssertEquals(t, responseWriter.Header().Get(k), v)
+			}
 			test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), tc.ExpectedBody)
 		})
 	}


### PR DESCRIPTION
According to the spec, the Location header should point at the order.