### PR TITLE
Handle Challenge "Errors" field for V2 API.

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -230,8 +230,9 @@ type Challenge struct {
 	// Contains the error that occurred during challenge validation, if any
 	Error *probs.ProblemDetails `json:"error,omitempty"`
 
-	// For the V2 API the "error" field is deprecated in favour of "errors".
-	Errors *probs.ProblemDetails `json:"errors,omitempty"`
+	// For the V2 API the "error" field is deprecated in favour of "errors", an
+	// array of problems.
+	Errors []*probs.ProblemDetails `json:"errors,omitempty"`
 
 	// A URI to which a response can be POSTed
 	URI string `json:"uri,omitempty"`

--- a/core/objects.go
+++ b/core/objects.go
@@ -230,6 +230,9 @@ type Challenge struct {
 	// Contains the error that occurred during challenge validation, if any
 	Error *probs.ProblemDetails `json:"error,omitempty"`
 
+	// For the V2 API the "error" field is deprecated in favour of "errors".
+	Errors *probs.ProblemDetails `json:"errors,omitempty"`
+
 	// A URI to which a response can be POSTed
 	URI string `json:"uri,omitempty"`
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -884,7 +884,7 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 	// ACME v2 uses an "Errors" field not "Error". Adjust accordingly before
 	// returning the challenge for display.
 	if challenge.Error != nil {
-		challenge.Errors = challenge.Error
+		challenge.Errors = []*probs.ProblemDetails{challenge.Error}
 		challenge.Error = nil
 	}
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -880,6 +880,13 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 	if challenge.Error != nil && !strings.HasPrefix(string(challenge.Error.Type), probs.V1ErrorNS) {
 		challenge.Error.Type = probs.V2ErrorNS + challenge.Error.Type
 	}
+
+	// ACME v2 uses an "Errors" field not "Error". Adjust accordingly before
+	// returning the challenge for display.
+	if challenge.Error != nil {
+		challenge.Errors = challenge.Error
+		challenge.Error = nil
+	}
 }
 
 // prepAuthorizationForDisplay takes a core.Authorization and prepares it for

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1322,7 +1322,8 @@ func TestAuthorizationChallengeNamespace(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't unmarshal returned authorization object")
 	test.AssertEquals(t, len(authz.Challenges), 1)
 	// The Challenge Errors Type should have its prefix unmodified
-	test.AssertEquals(t, string(authz.Challenges[0].Errors.Type), probs.V1ErrorNS+"things:are:whack")
+	test.AssertEquals(t, len(authz.Challenges[0].Errors), 1)
+	test.AssertEquals(t, string(authz.Challenges[0].Errors[0].Type), probs.V1ErrorNS+"things:are:whack")
 
 	// For "failed" the SA mock returns an authorization with a failed challenge
 	// that has an error with the type not prefixed by an error namespace.
@@ -1337,7 +1338,8 @@ func TestAuthorizationChallengeNamespace(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't unmarshal returned authorization object")
 	test.AssertEquals(t, len(authz.Challenges), 1)
 	// The Challenge Errors Type should have had the probs.V2ErrorNS prefix added
-	test.AssertEquals(t, string(authz.Challenges[0].Errors.Type), probs.V2ErrorNS+"things:are:whack")
+	test.AssertEquals(t, len(authz.Challenges[0].Errors), 1)
+	test.AssertEquals(t, string(authz.Challenges[0].Errors[0].Type), probs.V2ErrorNS+"things:are:whack")
 	responseWriter.Body.Reset()
 }
 
@@ -2456,8 +2458,9 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	test.AssertEquals(t, chal.URI, "")
 	// We also expect the authz challenge has its "Errors" field set and the
 	// "Error" field emptied.
-	test.AssertEquals(t, chal.Errors.Detail, "Whoops")
-	test.AssertEquals(t, string(chal.Errors.Type), "urn:ietf:params:acme:error:malformed")
+	test.AssertEquals(t, len(chal.Errors), 1)
+	test.AssertEquals(t, chal.Errors[0].Detail, "Whoops")
+	test.AssertEquals(t, string(chal.Errors[0].Type), "urn:ietf:params:acme:error:malformed")
 	if chal.Error != nil {
 		t.Errorf("Authz had a non-nil legacy 'error' field")
 	}


### PR DESCRIPTION
In ACME v1 challenges have an "error" field for a singular problem. In v2 
challenges have an "errors" field, an array of problems. This commit
updates the `core/objects.go` `Challenge` type to have both fields. 
We set the V2 "errors" field with the contents of the V1 "error" field before
clearing it in the V2 "prepChallengeForDisplay" function similar to how "uri" 
vs "url" is handled. Note this means presently we'll only ever return 1 problem
for a challenge - it might be sensible to revisit returning multiple challenge
errors at a time for V2 when we implement #3247

Resolves https://github.com/letsencrypt/boulder/issues/3339
  