### PR TITLE
Disallow the use of disabled challenge types

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -108,6 +108,7 @@ type PolicyAuthority interface {
 	WillingToIssue(domain AcmeIdentifier) error
 	WillingToIssueWildcard(domain AcmeIdentifier) error
 	ChallengesFor(domain AcmeIdentifier) (challenges []Challenge, validCombinations [][]int, err error)
+	ChallengeStillAllowed(authz *Authorization) bool
 }
 
 // StorageGetter are the Boulder SA's read-only methods

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -108,7 +108,7 @@ type PolicyAuthority interface {
 	WillingToIssue(domain AcmeIdentifier) error
 	WillingToIssueWildcard(domain AcmeIdentifier) error
 	ChallengesFor(domain AcmeIdentifier) (challenges []Challenge, validCombinations [][]int, err error)
-	ChallengeStillAllowed(authz *Authorization) bool
+	ChallengeTypeEnabled(t string) bool
 }
 
 // StorageGetter are the Boulder SA's read-only methods

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -37,6 +37,9 @@ func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
 func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
 	return nil
 }
+func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
+	return true
+}
 
 func TestVerifyCSR(t *testing.T) {
 	private, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -37,6 +37,7 @@ func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
 func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
 	return nil
 }
+
 func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
 	return true
 }

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -2,15 +2,15 @@
 
 package features
 
-import "strconv"
+import "fmt"
 
-const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAAUDPDNSROCACheckWildcardDomains"
+const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAAUDPDNSROCACheckWildcardDomainsEnforceChallengeDisable"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231, 237, 246, 261}
+var _FeatureFlag_index = [...]uint16{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 180, 189, 202, 221, 231, 237, 246, 261, 284}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {
-		return "FeatureFlag(" + strconv.FormatInt(int64(i), 10) + ")"
+		return fmt.Sprintf("FeatureFlag(%d)", i)
 	}
 	return _FeatureFlag_name[_FeatureFlag_index[i]:_FeatureFlag_index[i+1]]
 }

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -2,7 +2,7 @@
 
 package features
 
-import "fmt"
+import "strconv"
 
 const _FeatureFlag_name = "unusedAllowAccountDeactivationAllowKeyRolloverResubmitMissingSCTsOnlyUseAIAIssuerURLAllowTLS02ChallengesGenerateOCSPEarlyReusePendingAuthzCountCertificatesExactRandomDirectoryEntryIPv6FirstDirectoryMetaAllowRenewalFirstRLRecheckCAAUDPDNSROCACheckWildcardDomainsEnforceChallengeDisable"
 
@@ -10,7 +10,7 @@ var _FeatureFlag_index = [...]uint16{0, 6, 30, 46, 69, 84, 104, 121, 138, 160, 1
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {
-		return fmt.Sprintf("FeatureFlag(%d)", i)
+		return "FeatureFlag(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _FeatureFlag_name[_FeatureFlag_index[i]:_FeatureFlag_index[i+1]]
 }

--- a/features/features.go
+++ b/features/features.go
@@ -30,6 +30,8 @@ const (
 	ROCACheck
 	// Allow issuance of wildcard domains for ACMEv2
 	WildcardDomains
+	// Enforce prevention of use of disabled challenge types
+	EnforceChallengeDisable
 )
 
 // List of features and their default value, protected by fMu
@@ -51,6 +53,7 @@ var features = map[FeatureFlag]bool{
 	UDPDNS:                   false,
 	ROCACheck:                false,
 	WildcardDomains:          false,
+	EnforceChallengeDisable:  false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -368,6 +368,13 @@ func (sa *StorageAuthority) GetValidAuthorizations(_ context.Context, regID int6
 						Type:  "dns",
 						Value: name,
 					},
+					Challenges: []core.Challenge{
+						{
+							Status: core.StatusValid,
+							ID:     23,
+							Type:   core.ChallengeTypeDNS01,
+						},
+					},
 				}
 			}
 		}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -453,3 +453,14 @@ func extractDomainIANASuffix(name string) (string, error) {
 
 	return suffix, nil
 }
+
+// AuthzStillValid checks if the challenge type that was used in a valid authorization
+// is still enabled
+func (pa *AuthorityImpl) ChallengeStillAllowed(authz *core.Authorization) bool {
+	for _, chall := range authz.Challenges {
+		if chall.Status == core.StatusValid {
+			return pa.enabledChallenges[chall.Type]
+		}
+	}
+	return false
+}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -454,13 +454,7 @@ func extractDomainIANASuffix(name string) (string, error) {
 	return suffix, nil
 }
 
-// AuthzStillValid checks if the challenge type that was used in a valid authorization
-// is still enabled
-func (pa *AuthorityImpl) ChallengeStillAllowed(authz *core.Authorization) bool {
-	for _, chall := range authz.Challenges {
-		if chall.Status == core.StatusValid {
-			return pa.enabledChallenges[chall.Type]
-		}
-	}
-	return false
+// ChallengeTypeEnabled returns whether the specified challenge type is enabled
+func (pa *AuthorityImpl) ChallengeTypeEnabled(t string) bool {
+	return pa.enabledChallenges[t]
 }

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -461,13 +461,3 @@ func TestMalformedExactBlacklist(t *testing.T) {
 	test.AssertError(t, err, "Loaded invalid exact blacklist content without error")
 	test.AssertEquals(t, err.Error(), "Malformed exact blacklist entry, only one label: \"com\"")
 }
-
-func TestChallengeStillAllowed(t *testing.T) {
-	pa := paImpl(t)
-	pa.enabledChallenges[core.ChallengeTypeHTTP01] = false
-	test.Assert(t, !pa.ChallengeStillAllowed(&core.Authorization{}), "pa.ChallengeStillAllowed didn't fail with empty authorization")
-	test.Assert(t, !pa.ChallengeStillAllowed(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusPending}}}), "pa.ChallengeStillAllowed didn't fail with no valid challenges")
-	test.Assert(t, !pa.ChallengeStillAllowed(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeHTTP01}}}), "pa.ChallengeStillAllowed didn't fail with disabled challenge")
-
-	test.Assert(t, pa.ChallengeStillAllowed(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeTLSSNI01}}}), "pa.ChallengeStillAllowed failed with enabled challenge")
-}

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -461,3 +461,13 @@ func TestMalformedExactBlacklist(t *testing.T) {
 	test.AssertError(t, err, "Loaded invalid exact blacklist content without error")
 	test.AssertEquals(t, err.Error(), "Malformed exact blacklist entry, only one label: \"com\"")
 }
+
+func TestChallengeStillAllowed(t *testing.T) {
+	pa := paImpl(t)
+	pa.enabledChallenges[core.ChallengeTypeHTTP01] = false
+	test.Assert(t, !pa.ChallengeStillAllowed(&core.Authorization{}), "pa.ChallengeStillAllowed didn't fail with empty authorization")
+	test.Assert(t, !pa.ChallengeStillAllowed(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusPending}}}), "pa.ChallengeStillAllowed didn't fail with no valid challenges")
+	test.Assert(t, !pa.ChallengeStillAllowed(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeHTTP01}}}), "pa.ChallengeStillAllowed didn't fail with disabled challenge")
+
+	test.Assert(t, pa.ChallengeStillAllowed(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeTLSSNI01}}}), "pa.ChallengeStillAllowed failed with enabled challenge")
+}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -721,6 +721,9 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizationsCAA(
 			// Ensure that CAA is rechecked for this name
 			recheckNames = append(recheckNames, name)
 		}
+		if authz != nil && !ra.PA.ChallengeStillAllowed(authz) {
+			return berrors.UnauthorizedError("challenge used to validate authorization with ID %q no longer allowed", authz.ID)
+		}
 	}
 
 	if err := ra.recheckCAA(ctx, recheckNames); err != nil {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1762,10 +1762,8 @@ func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg
 func (ra *RegistrationAuthorityImpl) authzValidChallengeEnabled(authz *core.Authorization) bool {
 	for _, chall := range authz.Challenges {
 		if chall.Status == core.StatusValid {
-			fmt.Println("TYPE", chall.Type)
 			return ra.PA.ChallengeTypeEnabled(chall.Type)
 		}
 	}
-	fmt.Println("NO TYPE", authz)
 	return false
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -532,7 +532,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(ctx context.Context, reque
 				ra.log.Warning(fmt.Sprintf("%s: %s", outErr.Error(), existingAuthz.ID))
 				return core.Authorization{}, outErr
 			}
-			if !features.Enabled(features.EnforceChallengeDisable) || ra.validChallengeStillGood(&populatedAuthz) {
+			if !features.Enabled(features.EnforceChallengeDisable) || ra.authzValidChallengeEnabled(&populatedAuthz) {
 				// The existing authorization must not expire within the next 24 hours for
 				// it to be OK for reuse
 				reuseCutOff := ra.clk.Now().Add(time.Hour * 24)
@@ -722,8 +722,8 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizationsCAA(
 			// Ensure that CAA is rechecked for this name
 			recheckNames = append(recheckNames, name)
 		}
-		if authz != nil && features.Enabled(features.EnforceChallengeDisable) && !ra.validChallengeStillGood(authz) {
-			return berrors.UnauthorizedError("challenge used to validate authorization with ID %q no longer allowed", authz.ID)
+		if authz != nil && features.Enabled(features.EnforceChallengeDisable) && !ra.authzValidChallengeEnabled(authz) {
+			return berrors.UnauthorizedError("challenge used to validate authorization with ID %q forbidden by policy", authz.ID)
 		}
 	}
 
@@ -1757,9 +1757,9 @@ func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg
 	return authz, nil
 }
 
-// validChallengeStillGood checks whether the valid challenge in an authorization uses a type
+// authzValidChallengeEnabled checks whether the valid challenge in an authorization uses a type
 // which is still enabled
-func (ra *RegistrationAuthorityImpl) validChallengeStillGood(authz *core.Authorization) bool {
+func (ra *RegistrationAuthorityImpl) authzValidChallengeEnabled(authz *core.Authorization) bool {
 	for _, chall := range authz.Challenges {
 		if chall.Status == core.StatusValid {
 			fmt.Println("TYPE", chall.Type)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -71,6 +71,7 @@ var (
 	SupportedChallenges = map[string]bool{
 		core.ChallengeTypeHTTP01:   true,
 		core.ChallengeTypeTLSSNI01: true,
+		core.ChallengeTypeDNS01:    true,
 	}
 
 	// These values we simulate from the client
@@ -622,6 +623,7 @@ func TestReuseValidAuthorization(t *testing.T) {
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
 	finalAuthz.Expires = &exp
 	finalAuthz.Challenges[0].Status = "valid"
+	finalAuthz.Challenges[0].Type = core.ChallengeTypeHTTP01
 	finalAuthz.RegistrationID = Registration.ID
 	finalAuthz, err := sa.NewPendingAuthorization(ctx, finalAuthz)
 	test.AssertNotError(t, err, "Could not store test pending authorization")
@@ -668,6 +670,21 @@ func TestReuseValidAuthorization(t *testing.T) {
 	test.AssertNotError(t, err, "UpdateAuthorization on secondAuthz sni failed")
 	test.AssertEquals(t, finalAuthz.ID, secondAuthz.ID)
 	test.AssertEquals(t, secondAuthz.Status, core.StatusValid)
+
+	// Test that a valid authorization that used a challenge which has been disabled
+	// is not reused
+	pa, err := policy.New(map[string]bool{
+		core.ChallengeTypeHTTP01:   false,
+		core.ChallengeTypeTLSSNI01: true,
+		core.ChallengeTypeDNS01:    true,
+	})
+	test.AssertNotError(t, err, "Couldn't create PA")
+	err = pa.SetHostnamePolicyFile("../test/hostname-policy.json")
+	test.AssertNotError(t, err, "Couldn't set hostname policy")
+	ra.PA = pa
+	newAuthz, err := ra.NewAuthorization(ctx, AuthzRequest, Registration.ID)
+	test.AssertNotError(t, err, "NewAuthorization for secondAuthz failed")
+	test.Assert(t, finalAuthz.ID != newAuthz.ID, "NewAuthorization reused a valid authz with a disabled challenge type")
 }
 
 func TestReusePendingAuthorization(t *testing.T) {
@@ -902,7 +919,7 @@ func TestUpdateAuthorizationAlreadyValid(t *testing.T) {
 
 	response, err := makeResponse(finalAuthz.Challenges[ResponseIndex])
 	test.AssertNotError(t, err, "Unable to construct response to challenge")
-	finalAuthz.Challenges[ResponseIndex].Type = core.ChallengeTypeDNS01
+	finalAuthz.Challenges[ResponseIndex].Type = core.ChallengeTypeHTTP01
 	finalAuthz.Challenges[ResponseIndex].Status = core.StatusPending
 	va.RecordsReturn = []core.ValidationRecord{
 		{Hostname: "example.com"}}
@@ -2907,6 +2924,33 @@ func TestDisabledChallengeValidAuthz(t *testing.T) {
 		fc.Now(),
 	)
 	test.AssertNotError(t, err, "RA prevented use of an authorization which used an enabled challenge type")
+}
+
+func TestValidChallengeStillGood(t *testing.T) {
+	_, _, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+	pa, err := policy.New(map[string]bool{
+		core.ChallengeTypeTLSSNI01: true,
+	})
+	test.AssertNotError(t, err, "Couldn't create PA")
+	ra.PA = pa
+
+	test.Assert(t, !ra.validChallengeStillGood(&core.Authorization{}), "ra.validChallengeStillGood didn't fail with empty authorization")
+	test.Assert(t, !ra.validChallengeStillGood(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusPending}}}), "ra.validChallengeStillGood didn't fail with no valid challenges")
+	test.Assert(t, !ra.validChallengeStillGood(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeHTTP01}}}), "ra.validChallengeStillGood didn't fail with disabled challenge")
+
+	test.Assert(t, ra.validChallengeStillGood(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeTLSSNI01}}}), "ra.validChallengeStillGood failed with enabled challenge")
+}
+
+func TestUpdateAuthorizationBadChallengeType(t *testing.T) {
+	_, _, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+	pa, err := policy.New(map[string]bool{})
+	test.AssertNotError(t, err, "Couldn't create PA")
+	ra.PA = pa
+
+	_, err = ra.UpdateAuthorization(context.Background(), core.Authorization{}, 0, core.Challenge{})
+	test.AssertError(t, err, "ra.UpdateAuthorization allowed a update to a authorization")
 }
 
 var CAkeyPEM = `

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2914,7 +2914,7 @@ func TestDisabledChallengeValidAuthz(t *testing.T) {
 		0,
 		fc.Now(),
 	)
-	test.AssertError(t, err, "RA didn't prevent use of an authorization which used an disabled challenge type")
+	test.AssertError(t, err, "RA didn't prevent use of an authorization which used a disabled challenge type")
 
 	err = ra.checkAuthorizationsCAA(
 		context.Background(),
@@ -2942,11 +2942,11 @@ func TestValidChallengeStillGood(t *testing.T) {
 
 	_ = features.Set(map[string]bool{"EnforceChallengeDisable": true})
 
-	test.Assert(t, !ra.validChallengeStillGood(&core.Authorization{}), "ra.validChallengeStillGood didn't fail with empty authorization")
-	test.Assert(t, !ra.validChallengeStillGood(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusPending}}}), "ra.validChallengeStillGood didn't fail with no valid challenges")
-	test.Assert(t, !ra.validChallengeStillGood(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeHTTP01}}}), "ra.validChallengeStillGood didn't fail with disabled challenge")
+	test.Assert(t, !ra.authzValidChallengeEnabled(&core.Authorization{}), "ra.authzValidChallengeEnabled didn't fail with empty authorization")
+	test.Assert(t, !ra.authzValidChallengeEnabled(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusPending}}}), "ra.authzValidChallengeEnabled didn't fail with no valid challenges")
+	test.Assert(t, !ra.authzValidChallengeEnabled(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeHTTP01}}}), "ra.authzValidChallengeEnabled didn't fail with disabled challenge")
 
-	test.Assert(t, ra.validChallengeStillGood(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeTLSSNI01}}}), "ra.validChallengeStillGood failed with enabled challenge")
+	test.Assert(t, ra.authzValidChallengeEnabled(&core.Authorization{Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeTLSSNI01}}}), "ra.authzValidChallengeEnabled failed with enabled challenge")
 }
 
 func TestUpdateAuthorizationBadChallengeType(t *testing.T) {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1545,6 +1545,27 @@ func (ssa *SQLStorageAuthority) GetOrderAuthorizations(
 		}
 		existing, present := byName[auth.Identifier.Value]
 		if !present || auth.Expires.After(*existing.Expires) {
+
+			// Retrieve challenges for the authzvar challObjs []challModel
+			var challObjs []challModel
+			_, err = ssa.dbMap.Select(
+				&challObjs,
+				getChallengesQuery,
+				map[string]interface{}{"authID": auth.ID},
+			)
+			if err != nil {
+				return nil, err
+			}
+			var challs []core.Challenge
+			for _, c := range challObjs {
+				chall, err := modelToChallenge(&c)
+				if err != nil {
+					return nil, err
+				}
+				challs = append(challs, chall)
+			}
+			auth.Challenges = challs
+
 			byName[auth.Identifier.Value] = auth
 		}
 	}
@@ -1622,31 +1643,31 @@ func (ssa *SQLStorageAuthority) getAuthorizations(ctx context.Context, table str
 			continue
 		}
 
-		// Retrieve challenges for the authzvar challObjs []challModel
-		var challObjs []challModel
-		_, err = ssa.dbMap.Select(
-			&challObjs,
-			getChallengesQuery,
-			map[string]interface{}{"authID": auth.ID},
-		)
-		if err != nil {
-			return nil, err
-		}
-		var challs []core.Challenge
-		for _, c := range challObjs {
-			chall, err := modelToChallenge(&c)
-			if err != nil {
-				return nil, err
-			}
-			challs = append(challs, chall)
-		}
-		auth.Challenges = challs
-
 		if auth.Identifier.Type != core.IdentifierDNS {
 			return nil, fmt.Errorf("unknown identifier type: %q on authz id %q", auth.Identifier.Type, auth.ID)
 		}
 		existing, present := byName[auth.Identifier.Value]
 		if !present || auth.Expires.After(*existing.Expires) {
+			// Retrieve challenges for the authzvar challObjs []challModel
+			var challObjs []challModel
+			_, err = ssa.dbMap.Select(
+				&challObjs,
+				getChallengesQuery,
+				map[string]interface{}{"authID": auth.ID},
+			)
+			if err != nil {
+				return nil, err
+			}
+			var challs []core.Challenge
+			for _, c := range challObjs {
+				chall, err := modelToChallenge(&c)
+				if err != nil {
+					return nil, err
+				}
+				challs = append(challs, chall)
+			}
+			auth.Challenges = challs
+
 			byName[auth.Identifier.Value] = auth
 		}
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1531,10 +1531,12 @@ func (ssa *SQLStorageAuthority) GetOrderAuthorizations(
 		}
 		existing, present := byName[auth.Identifier.Value]
 		if !present || auth.Expires.After(*existing.Expires) {
-			// Retrieve challenges for the authz
-			auth.Challenges, err = ssa.getChallenges(auth.ID)
-			if err != nil {
-				return nil, err
+			if features.Enabled(features.EnforceChallengeDisable) {
+				// Retrieve challenges for the authz
+				auth.Challenges, err = ssa.getChallenges(auth.ID)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			byName[auth.Identifier.Value] = auth
@@ -1619,8 +1621,13 @@ func (ssa *SQLStorageAuthority) getAuthorizations(ctx context.Context, table str
 		}
 		existing, present := byName[auth.Identifier.Value]
 		if !present || auth.Expires.After(*existing.Expires) {
-			// Retrieve challenges for the authz
-			auth.Challenges, err = ssa.getChallenges(auth.ID)
+			if features.Enabled(features.EnforceChallengeDisable) {
+				// Retrieve challenges for the authz
+				auth.Challenges, err = ssa.getChallenges(auth.ID)
+				if err != nil {
+					return nil, err
+				}
+			}
 
 			byName[auth.Identifier.Value] = auth
 		}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1621,6 +1621,27 @@ func (ssa *SQLStorageAuthority) getAuthorizations(ctx context.Context, table str
 		if auth.Expires == nil {
 			continue
 		}
+
+		// Retrieve challenges for the authzvar challObjs []challModel
+		var challObjs []challModel
+		_, err = ssa.dbMap.Select(
+			&challObjs,
+			getChallengesQuery,
+			map[string]interface{}{"authID": auth.ID},
+		)
+		if err != nil {
+			return nil, err
+		}
+		var challs []core.Challenge
+		for _, c := range challObjs {
+			chall, err := modelToChallenge(&c)
+			if err != nil {
+				return nil, err
+			}
+			challs = append(challs, chall)
+		}
+		auth.Challenges = challs
+
 		if auth.Identifier.Type != core.IdentifierDNS {
 			return nil, fmt.Errorf("unknown identifier type: %q on authz id %q", auth.Identifier.Type, auth.ID)
 		}

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -47,7 +47,8 @@
       "AllowTLS02Challenges": true,
       "CountCertificatesExact": true,
       "RecheckCAA": true,
-      "ReusePendingAuthz": true
+      "ReusePendingAuthz": true,
+      "EnforceChallengeDisable": true
     }
   },
 

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -28,7 +28,8 @@
     "features": {
       "WildcardDomains": true,
       "AllowAccountDeactivation": true,
-      "AllowRenewalFirstRL": true
+      "AllowRenewalFirstRL": true,
+      "EnforceChallengeDisable": true
     }
   },
 

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -280,6 +280,10 @@ func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
 	return nil
 }
 
+func (pa *mockPA) ChallengeTypeEnabled(string) bool {
+	return true
+}
+
 func makeBody(s string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(s))
 }


### PR DESCRIPTION
This patch does three things:
* Prevent the use of a authorization for issuance that was validated using a disabled challenge type
* Don't reuse a authorization that was validated using a disabled challenge type
* Don't allow validation using a disabled validation type

And adds tests for all three cases.