### PR TITLE
Remove redundant semicolon

### DIFF
--- a/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
+++ b/sa/_db-next/migrations/20171015225800_AddRenewalBit.sql
@@ -8,4 +8,3 @@ ALTER TABLE issuedNames
 ALTER TABLE issuedNames
        DROP COLUMN renewal,
        DROP INDEX `reversedName_renewal_notBefore_Idx`;
-;


### PR DESCRIPTION
The redundant semicolon breaks the goose down
function for this migration. This patch removes it.