### PR TITLE
Delete unused WFE/WFE2 cache configuration params.

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -32,10 +32,6 @@ type config struct {
 
 		AllowOrigins []string
 
-		CertNoCacheExpirationWindow cmd.ConfigDuration
-		IndexCacheDuration          cmd.ConfigDuration
-		IssuerCacheDuration         cmd.ConfigDuration
-
 		ShutdownStopTimeout cmd.ConfigDuration
 
 		SubscriberAgreementURL string

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -32,7 +32,6 @@ type config struct {
 
 		AllowOrigins []string
 
-		CertCacheDuration           cmd.ConfigDuration
 		CertNoCacheExpirationWindow cmd.ConfigDuration
 		IndexCacheDuration          cmd.ConfigDuration
 		IssuerCacheDuration         cmd.ConfigDuration
@@ -119,11 +118,6 @@ func main() {
 	wfe.AllowOrigins = c.WFE.AllowOrigins
 	wfe.AcceptRevocationReason = c.WFE.AcceptRevocationReason
 	wfe.AllowAuthzDeactivation = c.WFE.AllowAuthzDeactivation
-
-	wfe.CertCacheDuration = c.WFE.CertCacheDuration.Duration
-	wfe.CertNoCacheExpirationWindow = c.WFE.CertNoCacheExpirationWindow.Duration
-	wfe.IndexCacheDuration = c.WFE.IndexCacheDuration.Duration
-	wfe.IssuerCacheDuration = c.WFE.IssuerCacheDuration.Duration
 
 	wfe.IssuerCert, err = cmd.LoadCert(c.Common.IssuerCert)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -32,10 +32,6 @@ type config struct {
 
 		AllowOrigins []string
 
-		CertNoCacheExpirationWindow cmd.ConfigDuration
-		IndexCacheDuration          cmd.ConfigDuration
-		IssuerCacheDuration         cmd.ConfigDuration
-
 		ShutdownStopTimeout cmd.ConfigDuration
 
 		SubscriberAgreementURL string

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -32,7 +32,6 @@ type config struct {
 
 		AllowOrigins []string
 
-		CertCacheDuration           cmd.ConfigDuration
 		CertNoCacheExpirationWindow cmd.ConfigDuration
 		IndexCacheDuration          cmd.ConfigDuration
 		IssuerCacheDuration         cmd.ConfigDuration
@@ -118,11 +117,6 @@ func main() {
 	wfe.AllowOrigins = c.WFE.AllowOrigins
 	wfe.AcceptRevocationReason = c.WFE.AcceptRevocationReason
 	wfe.AllowAuthzDeactivation = c.WFE.AllowAuthzDeactivation
-
-	wfe.CertCacheDuration = c.WFE.CertCacheDuration.Duration
-	wfe.CertNoCacheExpirationWindow = c.WFE.CertNoCacheExpirationWindow.Duration
-	wfe.IndexCacheDuration = c.WFE.IndexCacheDuration.Duration
-	wfe.IssuerCacheDuration = c.WFE.IssuerCacheDuration.Duration
 
 	wfe.IssuerCert, err = cmd.LoadCert(c.Common.IssuerCert)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -81,12 +81,6 @@ type WebFrontEndImpl struct {
 	// Key policy.
 	keyPolicy goodkey.KeyPolicy
 
-	// Cache settings
-	CertCacheDuration           time.Duration
-	CertNoCacheExpirationWindow time.Duration
-	IndexCacheDuration          time.Duration
-	IssuerCacheDuration         time.Duration
-
 	// CORS settings
 	AllowOrigins []string
 

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -682,7 +682,6 @@ func TestPOST404(t *testing.T) {
 
 func TestIndex(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.IndexCacheDuration = time.Second * 10
 
 	responseWriter := httptest.NewRecorder()
 
@@ -1894,7 +1893,6 @@ func TestTermsRedirect(t *testing.T) {
 
 func TestIssuer(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.IssuerCacheDuration = time.Second * 10
 	wfe.IssuerCert = []byte{0, 0, 1}
 
 	responseWriter := httptest.NewRecorder()
@@ -1911,9 +1909,6 @@ func TestGetCertificate(t *testing.T) {
 	defer features.Reset()
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
-
-	wfe.CertCacheDuration = time.Second * 10
-	wfe.CertNoCacheExpirationWindow = time.Hour * 24 * 7
 
 	certPemBytes, _ := ioutil.ReadFile("test/178.crt")
 	certBlock, _ := pem.Decode(certPemBytes)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -85,12 +85,6 @@ type WebFrontEndImpl struct {
 	// Key policy.
 	keyPolicy goodkey.KeyPolicy
 
-	// Cache settings
-	CertCacheDuration           time.Duration
-	CertNoCacheExpirationWindow time.Duration
-	IndexCacheDuration          time.Duration
-	IssuerCacheDuration         time.Duration
-
 	// CORS settings
 	AllowOrigins []string
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jmhodges/clock"
 	"golang.org/x/net/context"
@@ -615,7 +614,6 @@ func TestPOST404(t *testing.T) {
 
 func TestIndex(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.IndexCacheDuration = time.Second * 10
 
 	responseWriter := httptest.NewRecorder()
 
@@ -1446,7 +1444,6 @@ func TestAccount(t *testing.T) {
 
 func TestIssuer(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.IssuerCacheDuration = time.Second * 10
 	wfe.IssuerCert = []byte{0, 0, 1}
 
 	responseWriter := httptest.NewRecorder()
@@ -1461,9 +1458,6 @@ func TestIssuer(t *testing.T) {
 func TestGetCertificate(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
-
-	wfe.CertCacheDuration = time.Second * 10
-	wfe.CertNoCacheExpirationWindow = time.Hour * 24 * 7
 
 	certPemBytes, _ := ioutil.ReadFile("test/178.crt")
 	pkixContent := "application/pem-certificate-chain"


### PR DESCRIPTION
This commit removes `CertCacheDuration`, `CertNoCacheExpirationWindow`,
`IndexCacheDuration` and `IssuerCacheDuration`. These were read from
config values that weren't set in config/config-next into WFE struct
fields that were never referenced in any code.