### PR TITLE
Disable ReusePendingAuthz and tls-sni in config.

### DIFF
--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -140,7 +140,7 @@
   "pa": {
     "challenges": {
       "http-01": true,
-      "tls-sni-01": true,
+      "tls-sni-01": false,
       "dns-01": true
     }
   },

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -55,7 +55,7 @@
   "pa": {
     "challenges": {
       "http-01": true,
-      "tls-sni-01": true,
+      "tls-sni-01": false,
       "dns-01": true
     },
     "challengesWhitelistFile": "test/challenges-whitelist.json"

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -137,7 +137,7 @@
   "pa": {
     "challenges": {
       "http-01": true,
-      "tls-sni-01": true,
+      "tls-sni-01": false,
       "dns-01": true
     }
   },

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -44,14 +44,14 @@
       "AllowKeyRollover": true,
       "CountCertificatesExact": true,
       "RecheckCAA": true,
-      "ReusePendingAuthz": true
+      "ReusePendingAuthz": false
     }
   },
 
   "pa": {
     "challenges": {
       "http-01": true,
-      "tls-sni-01": true,
+      "tls-sni-01": false,
       "dns-01": true
     }
   },


### PR DESCRIPTION
This bring test/config closer to what's currently deployed in production.
config-next still has ReusePendingAuthz enabled, since we expect to re-enable
it.