### PR TITLE
Remove unused WFE2 feature flags.

### DIFF
--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -28,13 +28,7 @@
       "serverAddresses": ["sa.boulder:19095"],
       "timeout": "15s"
     },
-    "features": {
-      "AllowAccountDeactivation": true,
-      "AllowKeyRollover": true,
-      "UseAIAIssuerURL": true,
-      "RandomDirectoryEntry": true,
-      "DirectoryMeta": true
-    }
+    "features": {}
   },
 
   "syslog": {

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -29,12 +29,7 @@
       "serverAddresses": ["sa.boulder:19095"],
       "timeout": "15s"
     },
-    "features": {
-      "AllowAccountDeactivation": true,
-      "AllowKeyRollover": true,
-      "RandomDirectoryEntry": true,
-      "DirectoryMeta": true
-    }
+    "features": {}
   },
 
   "syslog": {


### PR DESCRIPTION
The WFE2 doesn't check any of the feature flags that are configured in
the `test/config/wfe2.json` and `test/config-next/wfe2.json` config
files - we default to acting as if all new features are enabled for the
V2 work. This commit removes the flags from the config to avoid
confusion or expectations that changing the config will disable the
features.