### PR TITLE
Move CN to SAN in v2 API

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -876,6 +876,10 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 
 // NewCertificate requests the issuance of a certificate.
 func (ra *RegistrationAuthorityImpl) NewCertificate(ctx context.Context, req core.CertificateRequest, regID int64) (core.Certificate, error) {
+	// Verify the CSR
+	if err := csrlib.VerifyCSR(req.CSR, ra.maxNames, &ra.keyPolicy, ra.PA, ra.forceCNFromSAN, regID); err != nil {
+		return core.Certificate{}, berrors.MalformedError(err.Error())
+	}
 	// NewCertificate provides an order ID of 0, indicating this is a classic ACME
 	// v1 issuance request from the new certificate endpoint that is not
 	// associated with an ACME v2 order.
@@ -930,12 +934,7 @@ func (ra *RegistrationAuthorityImpl) issueCertificate(
 		return emptyCert, err
 	}
 
-	// Verify the CSR
 	csr := req.CSR
-	if err := csrlib.VerifyCSR(csr, ra.maxNames, &ra.keyPolicy, ra.PA, ra.forceCNFromSAN, int64(acctID)); err != nil {
-		return emptyCert, berrors.MalformedError(err.Error())
-	}
-
 	logEvent.CommonName = csr.Subject.CommonName
 	logEvent.Names = csr.DNSNames
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -815,6 +815,10 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 		return nil, err
 	}
 
+	if err := csrlib.VerifyCSR(csrOb, ra.maxNames, &ra.keyPolicy, ra.PA, ra.forceCNFromSAN, *req.Order.RegistrationID); err != nil {
+		return nil, berrors.MalformedError(err.Error())
+	}
+
 	// Dedupe, lowercase and sort both the names from the CSR and the names in the
 	// order.
 	csrNames := core.UniqueLowerNames(csrOb.DNSNames)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -2727,6 +2728,87 @@ func TestFinalizeOrder(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFinalizeOrderWithMixedSANAndCN(t *testing.T) {
+	_, sa, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+	ra.orderLifetime = time.Hour
+
+	// Pick an expiry in the future
+	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
+
+	// Create one finalized authorization for Registration.ID for not-example.com
+	var err error
+	finalAuthz := AuthzInitial
+	finalAuthz.Identifier = core.AcmeIdentifier{Type: "dns", Value: "not-example.com"}
+	finalAuthz.Status = "valid"
+	finalAuthz.Expires = &exp
+	finalAuthz.Challenges[0].Status = "valid"
+	finalAuthz.RegistrationID = Registration.ID
+	finalAuthz, err = sa.NewPendingAuthorization(ctx, finalAuthz)
+	test.AssertNotError(t, err, "Could not store test pending authorization")
+	err = sa.FinalizeAuthorization(ctx, finalAuthz)
+	test.AssertNotError(t, err, "Could not finalize test pending authorization")
+
+	// Create one finalized authorization for Registration.ID for www.not-example.org
+	finalAuthzB := AuthzInitial
+	finalAuthzB.Identifier = core.AcmeIdentifier{Type: "dns", Value: "www.not-example.com"}
+	finalAuthzB.Status = "valid"
+	finalAuthzB.Expires = &exp
+	finalAuthzB.Challenges[0].Status = "valid"
+	finalAuthzB.RegistrationID = Registration.ID
+	finalAuthzB, err = sa.NewPendingAuthorization(ctx, finalAuthzB)
+	test.AssertNotError(t, err, "Could not store 2nd test pending authorization")
+	err = sa.FinalizeAuthorization(ctx, finalAuthzB)
+	test.AssertNotError(t, err, "Could not finalize 2nd test pending authorization")
+
+	// Create a new order to finalize with names in SAN and CN
+	expUnix := exp.Unix()
+	pendingStatus := "pending"
+	mixedOrder, err := sa.NewOrder(context.Background(), &corepb.Order{
+		RegistrationID: &Registration.ID,
+		Expires:        &expUnix,
+		Names:          []string{"not-example.com", "www.not-example.com"},
+		Authorizations: []string{finalAuthz.ID, finalAuthzB.ID},
+		Status:         &pendingStatus,
+	})
+	test.AssertNotError(t, err, "Could not add test order with finalized authz IDs")
+	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	test.AssertNotError(t, err, "error generating test key")
+	mixedCSR, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		PublicKey:          testKey.PublicKey,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+		Subject:            pkix.Name{CommonName: "not-example.com"},
+		DNSNames:           []string{"www.not-example.com"},
+	}, testKey)
+	test.AssertNotError(t, err, "Could not create mixed CSR")
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(12),
+		DNSNames:              []string{"www.not-example.com", "not-example.com"},
+		NotBefore:             time.Now(),
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, testKey.Public(), testKey)
+	test.AssertNotError(t, err, "Failed to create mixed cert")
+
+	ra.CA = &mocks.MockCA{
+		PEM: pem.EncodeToMemory(&pem.Block{
+			Bytes: cert,
+		}),
+	}
+
+	_, result := ra.FinalizeOrder(context.Background(), &rapb.FinalizeOrderRequest{Order: mixedOrder, Csr: mixedCSR})
+	test.AssertNotError(t, result, fmt.Sprintf("FinalizeOrder result was %#v, expected nil", result))
+	// Check that the order now has a serial for the issued certificate
+	updatedOrder, err := sa.GetOrder(
+		context.Background(),
+		&sapb.OrderRequest{Id: mixedOrder.Id})
+	test.AssertNotError(t, err, "Error getting order to check serial")
+	test.AssertNotEquals(t, *updatedOrder.CertificateSerial, "")
+	test.AssertEquals(t, *updatedOrder.Status, "valid")
 }
 
 func TestFinalizeOrderWildcard(t *testing.T) {


### PR DESCRIPTION
Fixes #3368.

Basically just adds a `csr.VerifyCSR` call in `ra.FinalizeOrder` that mirrors what we have in `ra.NewCertificate`, this moves the CN to SAN as expected if included.