### PR TITLE
Fail `test/setup.sh` if either process waited on fails

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -25,7 +25,11 @@ go get \
  cd protobuf-2.6.1 && ./configure --prefix=$HOME && make && make install) &
 
 # Wait for all the background commands to finish.
-wait
+# capture their error codes, then if bad, exit.
+RC=0
+wait %1 || RC=$?
+wait %2 || RC=$?
+(exit $RC)
 
 # Create the database and roles
 ./test/create_db.sh

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -26,10 +26,8 @@ go get \
 
 # Wait for all the background commands to finish.
 # capture their error codes, then if bad, exit.
-RC=0
-wait %1 || RC=$?
-wait %2 || RC=$?
-(exit $RC)
+wait %1 || exit $?
+wait %2 || exit $?
 
 # Create the database and roles
 ./test/create_db.sh


### PR DESCRIPTION
A simple "wait" returns the return code of the "last process or job".

It's not 100% clear to me what that means, and probably not what we want.

e.g. if `go get` fails quickly, but the `protobuf` install succeeds, the the current code continues when it should stop and fail.