### PR TITLE
Remove logging of Request/ResponseNonce.

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -11,18 +11,16 @@ import (
 )
 
 type RequestEvent struct {
-	RealIP        string    `json:",omitempty"`
-	Endpoint      string    `json:",omitempty"`
-	Method        string    `json:",omitempty"`
-	Errors        []string  `json:",omitempty"`
-	Requester     int64     `json:",omitempty"`
-	Contacts      *[]string `json:",omitempty"`
-	RequestNonce  string    `json:",omitempty"`
-	ResponseNonce string    `json:",omitempty"`
-	UserAgent     string    `json:",omitempty"`
-	Code          int
-	Payload       string                 `json:",omitempty"`
-	Extra         map[string]interface{} `json:",omitempty"`
+	RealIP    string    `json:",omitempty"`
+	Endpoint  string    `json:",omitempty"`
+	Method    string    `json:",omitempty"`
+	Errors    []string  `json:",omitempty"`
+	Requester int64     `json:",omitempty"`
+	Contacts  *[]string `json:",omitempty"`
+	UserAgent string    `json:",omitempty"`
+	Code      int
+	Payload   string                 `json:",omitempty"`
+	Extra     map[string]interface{} `json:",omitempty"`
 }
 
 func (e *RequestEvent) AddError(msg string, args ...interface{}) {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -160,7 +160,6 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h web
 			nonce, err := wfe.nonceService.Nonce()
 			if err == nil {
 				response.Header().Set("Replay-Nonce", nonce)
-				logEvent.ResponseNonce = nonce
 			} else {
 				logEvent.AddError("unable to make nonce: %s", err)
 			}
@@ -544,7 +543,6 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *web.Reques
 
 	// Check that the request has a known anti-replay nonce
 	nonce := parsedJws.Signatures[0].Header.Nonce
-	logEvent.RequestNonce = nonce
 	if len(nonce) == 0 {
 		wfe.stats.Inc("Errors.JWSMissingNonce", 1)
 		return nil, nil, reg, probs.BadNonce("JWS has no anti-replay nonce")

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -575,7 +575,7 @@ func TestValidNonce(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
-			prob := wfe.validNonce(tc.JWS, newRequestEvent())
+			prob := wfe.validNonce(tc.JWS)
 			if tc.ExpectedResult == nil && prob != nil {
 				t.Fatal(fmt.Sprintf("Expected nil result, got %#v", prob))
 			} else {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -161,7 +161,6 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h web
 				nonce, err := wfe.nonceService.Nonce()
 				if err == nil {
 					response.Header().Set("Replay-Nonce", nonce)
-					logEvent.ResponseNonce = nonce
 				} else {
 					logEvent.AddError("unable to make nonce: %s", err)
 				}


### PR DESCRIPTION
These take up a lot of space in the logs, and we almost never reference
them.