### PR TITLE
Return 500s from ocsp-responder.

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -90,11 +90,12 @@ func (src *DBSource) Response(req *ocsp.Request) ([]byte, http.Header, error) {
 		"SELECT ocspResponse, ocspLastUpdated FROM certificateStatus WHERE serial = :serial",
 		map[string]interface{}{"serial": serialString},
 	)
-	if err != nil && err != sql.ErrNoRows {
-		src.log.AuditErr(fmt.Sprintf("Failed to retrieve response from certificateStatus table: %s", err))
+	if err == sql.ErrNoRows {
+		return nil, nil, cfocsp.ErrNotFound
 	}
 	if err != nil {
-		return nil, nil, cfocsp.ErrNotFound
+		src.log.AuditErr(fmt.Sprintf("Looking up OCSP response: %s", err))
+		return nil, nil, err
 	}
 	if response.OCSPLastUpdated.IsZero() {
 		src.log.Debug(fmt.Sprintf("OCSP Response not sent (ocspLastUpdated is zero) for CA=%s, Serial=%s", hex.EncodeToString(src.caKeyHash), serialString))

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -134,9 +134,9 @@ func TestErrorLog(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to parse OCSP request")
 
 	_, _, err = src.Response(ocspReq)
-	test.AssertEquals(t, err, cfocsp.ErrNotFound)
+	test.AssertEquals(t, err.Error(), "Failure!")
 
-	test.AssertEquals(t, len(mockLog.GetAllMatching("Failed to retrieve response from certificateStatus table")), 1)
+	test.AssertEquals(t, len(mockLog.GetAllMatching("Looking up OCSP response")), 1)
 }
 
 func mustRead(path string) []byte {


### PR DESCRIPTION
Previously, all errors were treated as Not Found, but we actually want
to treat database errors differently; for instance, by not caching them,
and by setting tighter alerting thresholds for them.

Fixes #3419.