### PR TITLE
Optimize SA.CountPendingOrders implementation.

### DIFF
--- a/sa/_db-next/migrations/20180212101925_UpdateOrderIndexes.sql
+++ b/sa/_db-next/migrations/20180212101925_UpdateOrderIndexes.sql
@@ -1,0 +1,13 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `orders`
+  ADD INDEX `regID_error_beganProcessing_certSerial_expires`
+  (`registrationID`, `error`(1), `beganProcessing`, `certificateSerial`, `expires`);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `orders`
+  DROP INDEX `regID_error_beganProcessing_certSerial_expires`;


### PR DESCRIPTION
Since order status is now a calculated field populated based on the
individual statuses of the order's associated authorizations we can't
implement `SA.CountPendingOrders`, the function used for the
pending order rate limit, as a simple "WHERE status = 'pending'" query.

Previous to this commit we worked around this by having
`SA.CountPendingOrders` fetch all unexpired orders for
a registration, and then each of the individual authorizations for those
orders. This allowed calculating the status but was extremely costly!

This commit introduces an optimized version of
`SA.CountPendingOrders` that works only on data from the
`orders` table. Instead of counting pending orders exactly, we count
orders that we know are not valid, processing or invalid. The leftover
unexpired orders must be deactivated or pending. This overcounts by
including deactivated orders in the pending orders count but is simple
to implement and will be straightforward to make fast with additional
indexing if required.

:sparkles: **Bonus Unit Test** :sparkles: - _I realized I missed a test for
`sa.SetOrderError` so I included one in this PR along side the updated
count pending orders test._

Resolves https://github.com/letsencrypt/boulder/issues/3410