### PR TITLE
Remove EnforceChallengeDisable

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1861,12 +1861,10 @@ func (ssa *SQLStorageAuthority) GetValidOrderAuthorizations(
 		}
 		existing, present := byName[auth.Identifier.Value]
 		if !present || auth.Expires.After(*existing.Expires) {
-			if features.Enabled(features.EnforceChallengeDisable) {
-				// Retrieve challenges for the authz
-				auth.Challenges, err = ssa.getChallenges(auth.ID)
-				if err != nil {
-					return nil, err
-				}
+			// Retrieve challenges for the authz
+			auth.Challenges, err = ssa.getChallenges(auth.ID)
+			if err != nil {
+				return nil, err
 			}
 
 			byName[auth.Identifier.Value] = auth
@@ -1977,12 +1975,10 @@ func (ssa *SQLStorageAuthority) getAuthorizations(
 		}
 		existing, present := byName[auth.Identifier.Value]
 		if !present || auth.Expires.After(*existing.Expires) {
-			if features.Enabled(features.EnforceChallengeDisable) {
-				// Retrieve challenges for the authz
-				auth.Challenges, err = ssa.getChallenges(auth.ID)
-				if err != nil {
-					return nil, err
-				}
+			// Retrieve challenges for the authz
+			auth.Challenges, err = ssa.getChallenges(auth.ID)
+			if err != nil {
+				return nil, err
 			}
 
 			byName[auth.Identifier.Value] = auth

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -46,8 +46,7 @@
       "TLSSNIRevalidation": true,
       "AllowTLS02Challenges": true,
       "CountCertificatesExact": true,
-      "ReusePendingAuthz": true,
-      "EnforceChallengeDisable": true
+      "ReusePendingAuthz": true
     },
     "CTLogGroups": [
 

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -27,8 +27,7 @@
     },
     "features": {
       "WildcardDomains": true,
-      "AllowRenewalFirstRL": true,
-      "EnforceChallengeDisable": true
+      "AllowRenewalFirstRL": true
     }
   },
 

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -42,8 +42,7 @@
     },
     "features": {
       "CountCertificatesExact": true,
-      "ReusePendingAuthz": false,
-      "EnforceChallengeDisable": true
+      "ReusePendingAuthz": false
     }
   },
 

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -25,7 +25,6 @@
       ]
     },
     "features": {
-      "EnforceChallengeDisable": true
     }
   },
 


### PR DESCRIPTION
Removes usage of the `EnforceChallengeDisable` feature, the feature itself is not removed as it is still configured in staging/production, once that is fixed I'll submit another PR removing the actual flag.

This keeps the behavior that when authorizations are removed from the SA they have their challenges populated, because that seems to make the most sense to me? It also retains TLS re-validation.

Fixes #3441.