### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @letsencrypt/boulder-reviewers
+* @letsencrypt/boulder-developers


### PR DESCRIPTION
To use the other team, which already has write on `letsencrypt/boulder`.