### PR TITLE
Log fewer spurious CT submission errors.

### DIFF
--- a/canceled/canceled.go
+++ b/canceled/canceled.go
@@ -1,0 +1,16 @@
+package canceled
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// Is returns true if err is non-nil and is either context.Canceled, or has a
+// grpc code of Canceled. This is useful because cancelations propagate through
+// gRPC boundaries, and if we choose to treat in-process cancellations a certain
+// way, we usually want to treat cross-process cancellations the same way.
+func Is(err error) bool {
+	return err == context.Canceled || grpc.Code(err) == codes.Canceled
+}

--- a/canceled/canceled_test.go
+++ b/canceled/canceled_test.go
@@ -1,0 +1,22 @@
+package canceled
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func TestCanceled(t *testing.T) {
+	if !Is(context.Canceled) {
+		t.Errorf("Expected context.Canceled to be canceled, but wasn't.")
+	}
+	if !Is(grpc.Errorf(codes.Canceled, "hi")) {
+		t.Errorf("Expected gRPC cancellation to be cancelled, but wasn't.")
+	}
+	if Is(errors.New("hi")) {
+		t.Errorf("Expected random error to not be cancelled, but was.")
+	}
+}

--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -87,14 +87,14 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER) ([]core.SCT
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	for i, g := range ctp.groups {
-		go func(g []cmd.LogDescription) {
+		go func(i int, g []cmd.LogDescription) {
 			sct, err := ctp.race(subCtx, cert, g)
 			// Only one of these will be non-nil
 			if err != nil {
 				results <- result{err: fmt.Errorf("CT log group %d: %s", i, err)}
 			}
 			results <- result{sct: sct}
-		}(g)
+		}(i, g)
 	}
 
 	var ret []core.SCTDER

--- a/ctpolicy/ctpolicy_test.go
+++ b/ctpolicy/ctpolicy_test.go
@@ -44,7 +44,7 @@ func TestGetSCTs(t *testing.T) {
 		groups    [][]cmd.LogDescription
 		ctx       context.Context
 		result    []core.SCTDER
-		errRegexp regexp.Regexp
+		errRegexp *regexp.Regexp
 	}{
 		{
 			name: "basic success case",
@@ -102,8 +102,8 @@ func TestGetSCTs(t *testing.T) {
 			ret, err := ctp.GetSCTs(tc.ctx, []byte{0})
 			if tc.result != nil {
 				test.AssertDeepEquals(t, ret, tc.result)
-			} else if tc.err != nil {
-				if !tc.errRegexp.Match(err.Error()) {
+			} else if tc.errRegexp != nil {
+				if !tc.errRegexp.MatchString(err.Error()) {
 					t.Errorf("Error %q did not match expected regexp %q", err, tc.errRegexp)
 				}
 			}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
             context: .
             dockerfile: Dockerfile
         environment:
-            FAKE_DNS: 127.0.0.1
+            FAKE_DNS: 172.17.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config
+            BOULDER_CONFIG_DIR: test/config-next
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
           - /tmp:/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
             context: .
             dockerfile: Dockerfile
         environment:
-            FAKE_DNS: 172.17.0.1
+            FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config-next
+            BOULDER_CONFIG_DIR: test/config
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
           - /tmp:/tmp

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 
+	"github.com/letsencrypt/boulder/canceled"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -221,8 +222,10 @@ func (pub *Impl) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Requ
 		core.SerialToString(cert.SerialNumber),
 		ctLog)
 	if err != nil {
-		pub.log.AuditErr(
-			fmt.Sprintf("Failed to submit certificate to CT log at %s: %s", ctLog.uri, err))
+		if !canceled.Is(err) {
+			pub.log.AuditErr(
+				fmt.Sprintf("Failed to submit certificate to CT log at %s: %s", ctLog.uri, err))
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
With the CT policy changes, we cancel any outstanding requests in a
group once we've gotten a successful response from any log in that
group. That means various function calls will return early with an error
code indicating cancellation. We want to avoid logging such error codes,
because they were not really errors, they were intentional.

This change introduces a small utility package called "canceled", which
checks for both context.Canceled and the gRPC return code indicating
cancelled.