### PR TITLE
Verify SSL by default in chisel.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -184,7 +184,7 @@ if [[ "$RUN" =~ "integration" ]] ; then
   start_context "integration"
 
   source ${CERTBOT_PATH:-/certbot}/${VENV_NAME:-venv}/bin/activate
-  REQUESTS_CA_BUNDLE=test/wfe-tls/minica.pem DIRECTORY=http://boulder:4000/directory \
+  DIRECTORY=http://boulder:4000/directory \
     run python2 test/integration-test.py --chisel
   end_context #integration
 fi
@@ -198,7 +198,7 @@ if [[ "$RUN" =~ "acme-v2" ]] ; then
   git clone $CERTBOT_REPO $CERTBOT_DIR
   (cd $CERTBOT_DIR ; git checkout acme-v2-integration; ./tools/venv.sh)
   source $CERTBOT_DIR/venv/bin/activate
-  REQUESTS_CA_BUNDLE=test/wfe-tls/minica.pem DIRECTORY=https://boulder:4431/directory \
+  DIRECTORY=https://boulder:4431/directory \
     run python2 test/integration-test-v2.py
 fi
 

--- a/test/chisel.py
+++ b/test/chisel.py
@@ -37,12 +37,13 @@ DIRECTORY = os.getenv('DIRECTORY', 'http://localhost:4000/directory')
 SET_TXT = "http://localhost:8055/set-txt"
 CLEAR_TXT = "http://localhost:8055/clear-txt"
 
+os.environ.setdefault('REQUESTS_CA_BUNDLE', 'test/wfe-tls/minica.pem')
+
 def make_client(email=None):
     """Build an acme.Client and register a new account with a random key."""
     key = josepy.JWKRSA(key=rsa.generate_private_key(65537, 2048, default_backend()))
 
-    net = acme_client.ClientNetwork(key, verify_ssl=False,
-                                    user_agent="Boulder integration tester")
+    net = acme_client.ClientNetwork(key, user_agent="Boulder integration tester")
 
     client = acme_client.Client(DIRECTORY, key=key, net=net)
     account = client.register(messages.NewRegistration.from_data(email=email))

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -40,6 +40,8 @@ DIRECTORY = os.getenv('DIRECTORY', 'http://localhost:4001/directory')
 ACCEPTABLE_TOS = os.getenv('ACCEPTABLE_TOS',"https://boulder:4431/terms/v7")
 PORT = os.getenv('PORT', '5002')
 
+os.environ.setdefault('REQUESTS_CA_BUNDLE', 'test/wfe-tls/minica.pem')
+
 # URLs to control dns-test-srv
 SET_TXT = "http://localhost:8055/set-txt"
 CLEAR_TXT = "http://localhost:8055/clear-txt"


### PR DESCRIPTION
chisel had verify_ssl=False. Remove that, and set a sensible default
for REQUESTS_CA_BUNDLE to make it easier to run chisel on the command
line. Port the REQUESTS_CA_BUNDLE change into chisel2 as well.