### PR TITLE
Bump Go version and push new Docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.1
+  - 1.9.4
 
 go_import_path: github.com/letsencrypt/boulder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # To minimize the fetching of various layers this image and tag should
 # be used as the base of the bhsm container in boulder/docker-compose.yml
-FROM letsencrypt/boulder-tools:2017-12-18
+FROM letsencrypt/boulder-tools:2018-02-15
 
 # Boulder exposes its web application at port TCP 4000 and 4001
 EXPOSE 4000 4001 4002 4003 4430 4431 8053 8055

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     bhsm:
         # To minimize the fetching of various layers this should match
         # the FROM image and tag in boulder/Dockerfile
-        image: letsencrypt/boulder-tools:2017-12-18
+        image: letsencrypt/boulder-tools:2018-02-15
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.1
+FROM golang:1.9.4
 
 ADD build.sh /tmp/build.sh
 RUN /tmp/build.sh

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -72,7 +72,7 @@ gem install fpm
 apt-get autoremove -y build-essential cmake libssl-dev ruby-dev
 apt-get clean -y
 
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 # Save mock/mockgen/model because it will be needed later during `go generate`.
 GOPATH=/alt-gopath go get github.com/golang/mock/mockgen/model
+
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Also, move the installation of `mock/model` above the removal of junk
directories; otherwise we get a "getcwd: no such file or directory"
error.