### PR TITLE
Remove boulder-tools checkout of mockgen/model.

### DIFF
--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -72,7 +72,4 @@ gem install fpm
 apt-get autoremove -y build-essential cmake libssl-dev ruby-dev
 apt-get clean -y
 
-# Save mock/mockgen/model because it will be needed later during `go generate`.
-GOPATH=/alt-gopath go get github.com/golang/mock/mockgen/model
-
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This was added in the theory that it would stop some errors running
`docker compose go generate ./...` but in tests today, that command
succeeds right now even after removing this from the build steps and
rebuilding. This is not surprising, because as Roland pointed out, the
/alt-gopath/ path was never actually referenced anywhere.