### PR TITLE
Re-vendor golang.org/x/crypto/...

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -254,23 +254,23 @@
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ed25519",
-			"Rev": "7c6cc321c680f03b9ef0764448e780704f486b51"
+			"Rev": "650f4a345ab4e5b245a3034b110ebc7299e68186"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ed25519/internal/edwards25519",
-			"Rev": "7c6cc321c680f03b9ef0764448e780704f486b51"
+			"Rev": "650f4a345ab4e5b245a3034b110ebc7299e68186"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ocsp",
-			"Rev": "7c6cc321c680f03b9ef0764448e780704f486b51"
+			"Rev": "650f4a345ab4e5b245a3034b110ebc7299e68186"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/pkcs12",
-			"Rev": "7c6cc321c680f03b9ef0764448e780704f486b51"
+			"Rev": "650f4a345ab4e5b245a3034b110ebc7299e68186"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/pkcs12/internal/rc2",
-			"Rev": "7c6cc321c680f03b9ef0764448e780704f486b51"
+			"Rev": "650f4a345ab4e5b245a3034b110ebc7299e68186"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/vendor/golang.org/x/crypto/AUTHORS
+++ b/vendor/golang.org/x/crypto/AUTHORS
@@ -1,3 +1,3 @@
 # This source code refers to The Go Authors for copyright purposes.
 # The master list of authors is in the main Go distribution,
-# visible at http://tip.golang.org/AUTHORS.
+# visible at https://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/crypto/CONTRIBUTORS
+++ b/vendor/golang.org/x/crypto/CONTRIBUTORS
@@ -1,3 +1,3 @@
 # This source code was written by the Go contributors.
 # The master list of contributors is in the main Go distribution,
-# visible at http://tip.golang.org/CONTRIBUTORS.
+# visible at https://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/crypto/ed25519/ed25519.go
+++ b/vendor/golang.org/x/crypto/ed25519/ed25519.go
@@ -3,20 +3,20 @@
 // license that can be found in the LICENSE file.
 
 // Package ed25519 implements the Ed25519 signature algorithm. See
-// http://ed25519.cr.yp.to/.
+// https://ed25519.cr.yp.to/.
 //
 // These functions are also compatible with the “Ed25519” function defined in
-// https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05.
+// RFC 8032.
 package ed25519
 
 // This code is a port of the public domain, “ref10” implementation of ed25519
 // from SUPERCOP.
 
 import (
+	"bytes"
 	"crypto"
 	cryptorand "crypto/rand"
 	"crypto/sha512"
-	"crypto/subtle"
 	"errors"
 	"io"
 	"strconv"
@@ -177,5 +177,5 @@ func Verify(publicKey PublicKey, message, sig []byte) bool {
 
 	var checkR [32]byte
 	R.ToBytes(&checkR)
-	return subtle.ConstantTimeCompare(sig[:32], checkR[:]) == 1
+	return bytes.Equal(sig[:32], checkR[:])
 }

--- a/vendor/golang.org/x/crypto/ocsp/ocsp.go
+++ b/vendor/golang.org/x/crypto/ocsp/ocsp.go
@@ -295,17 +295,17 @@ const (
 
 // The enumerated reasons for revoking a certificate.  See RFC 5280.
 const (
-	Unspecified          = iota
-	KeyCompromise        = iota
-	CACompromise         = iota
-	AffiliationChanged   = iota
-	Superseded           = iota
-	CessationOfOperation = iota
-	CertificateHold      = iota
-	_                    = iota
-	RemoveFromCRL        = iota
-	PrivilegeWithdrawn   = iota
-	AACompromise         = iota
+	Unspecified          = 0
+	KeyCompromise        = 1
+	CACompromise         = 2
+	AffiliationChanged   = 3
+	Superseded           = 4
+	CessationOfOperation = 5
+	CertificateHold      = 6
+
+	RemoveFromCRL      = 8
+	PrivilegeWithdrawn = 9
+	AACompromise       = 10
 )
 
 // Request represents an OCSP request. See RFC 6960.
@@ -450,8 +450,8 @@ func ParseRequest(bytes []byte) (*Request, error) {
 // then the signature over the response is checked. If issuer is not nil then
 // it will be used to validate the signature or embedded certificate.
 //
-// Invalid signatures or parse failures will result in a ParseError. Error
-// responses will result in a ResponseError.
+// Invalid responses and parse failures will result in a ParseError.
+// Error responses will result in a ResponseError.
 func ParseResponse(bytes []byte, issuer *x509.Certificate) (*Response, error) {
 	return ParseResponseForCert(bytes, nil, issuer)
 }
@@ -462,8 +462,8 @@ func ParseResponse(bytes []byte, issuer *x509.Certificate) (*Response, error) {
 // issuer is not nil then it will be used to validate the signature or embedded
 // certificate.
 //
-// Invalid signatures or parse failures will result in a ParseError. Error
-// responses will result in a ResponseError.
+// Invalid responses and parse failures will result in a ParseError.
+// Error responses will result in a ResponseError.
 func ParseResponseForCert(bytes []byte, cert, issuer *x509.Certificate) (*Response, error) {
 	var resp responseASN1
 	rest, err := asn1.Unmarshal(bytes, &resp)
@@ -496,10 +496,32 @@ func ParseResponseForCert(bytes []byte, cert, issuer *x509.Certificate) (*Respon
 		return nil, ParseError("OCSP response contains bad number of responses")
 	}
 
+	var singleResp singleResponse
+	if cert == nil {
+		singleResp = basicResp.TBSResponseData.Responses[0]
+	} else {
+		match := false
+		for _, resp := range basicResp.TBSResponseData.Responses {
+			if cert.SerialNumber.Cmp(resp.CertID.SerialNumber) == 0 {
+				singleResp = resp
+				match = true
+				break
+			}
+		}
+		if !match {
+			return nil, ParseError("no response matching the supplied certificate")
+		}
+	}
+
 	ret := &Response{
 		TBSResponseData:    basicResp.TBSResponseData.Raw,
 		Signature:          basicResp.Signature.RightAlign(),
 		SignatureAlgorithm: getSignatureAlgorithmFromOID(basicResp.SignatureAlgorithm.Algorithm),
+		Extensions:         singleResp.SingleExtensions,
+		SerialNumber:       singleResp.CertID.SerialNumber,
+		ProducedAt:         basicResp.TBSResponseData.ProducedAt,
+		ThisUpdate:         singleResp.ThisUpdate,
+		NextUpdate:         singleResp.NextUpdate,
 	}
 
 	// Handle the ResponderID CHOICE tag. ResponderID can be flattened into
@@ -542,25 +564,14 @@ func ParseResponseForCert(bytes []byte, cert, issuer *x509.Certificate) (*Respon
 		}
 	}
 
-	var r singleResponse
-	for _, resp := range basicResp.TBSResponseData.Responses {
-		if cert == nil || cert.SerialNumber.Cmp(resp.CertID.SerialNumber) == 0 {
-			r = resp
-			break
-		}
-	}
-
-	for _, ext := range r.SingleExtensions {
+	for _, ext := range singleResp.SingleExtensions {
 		if ext.Critical {
 			return nil, ParseError("unsupported critical extension")
 		}
 	}
-	ret.Extensions = r.SingleExtensions
-
-	ret.SerialNumber = r.CertID.SerialNumber
 
 	for h, oid := range hashOIDs {
-		if r.CertID.HashAlgorithm.Algorithm.Equal(oid) {
+		if singleResp.CertID.HashAlgorithm.Algorithm.Equal(oid) {
 			ret.IssuerHash = h
 			break
 		}
@@ -570,19 +581,15 @@ func ParseResponseForCert(bytes []byte, cert, issuer *x509.Certificate) (*Respon
 	}
 
 	switch {
-	case bool(r.Good):
+	case bool(singleResp.Good):
 		ret.Status = Good
-	case bool(r.Unknown):
+	case bool(singleResp.Unknown):
 		ret.Status = Unknown
 	default:
 		ret.Status = Revoked
-		ret.RevokedAt = r.Revoked.RevocationTime
-		ret.RevocationReason = int(r.Revoked.Reason)
+		ret.RevokedAt = singleResp.Revoked.RevocationTime
+		ret.RevocationReason = int(singleResp.Revoked.Reason)
 	}
-
-	ret.ProducedAt = basicResp.TBSResponseData.ProducedAt
-	ret.ThisUpdate = r.ThisUpdate
-	ret.NextUpdate = r.NextUpdate
 
 	return ret, nil
 }
@@ -652,7 +659,7 @@ func CreateRequest(cert, issuer *x509.Certificate, opts *RequestOptions) ([]byte
 //
 // The issuer cert is used to puplate the IssuerNameHash and IssuerKeyHash fields.
 //
-// The template is used to populate the SerialNumber, RevocationStatus, RevokedAt,
+// The template is used to populate the SerialNumber, Status, RevokedAt,
 // RevocationReason, ThisUpdate, and NextUpdate fields.
 //
 // If template.IssuerHash is not set, SHA1 will be used.
@@ -753,7 +760,7 @@ func CreateResponse(issuer, responderCert *x509.Certificate, template Response, 
 	}
 	if template.Certificate != nil {
 		response.Certificates = []asn1.RawValue{
-			asn1.RawValue{FullBytes: template.Certificate.Raw},
+			{FullBytes: template.Certificate.Raw},
 		}
 	}
 	responseDER, err := asn1.Marshal(response)

--- a/vendor/golang.org/x/crypto/pkcs12/bmp-string.go
+++ b/vendor/golang.org/x/crypto/pkcs12/bmp-string.go
@@ -13,7 +13,7 @@ import (
 func bmpString(s string) ([]byte, error) {
 	// References:
 	// https://tools.ietf.org/html/rfc7292#appendix-B.1
-	// http://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane
+	// https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane
 	//  - non-BMP characters are encoded in UTF 16 by using a surrogate pair of 16-bit codes
 	//	  EncodeRune returns 0xfffd if the rune does not need special encoding
 	//  - the above RFC provides the info that BMPStrings are NULL terminated.

--- a/vendor/golang.org/x/crypto/pkcs12/crypto.go
+++ b/vendor/golang.org/x/crypto/pkcs12/crypto.go
@@ -124,7 +124,7 @@ func pbDecrypt(info decryptable, password []byte) (decrypted []byte, err error) 
 	return
 }
 
-// decryptable abstracts a object that contains ciphertext.
+// decryptable abstracts an object that contains ciphertext.
 type decryptable interface {
 	Algorithm() pkix.AlgorithmIdentifier
 	Data() []byte

--- a/vendor/golang.org/x/crypto/pkcs12/internal/rc2/rc2.go
+++ b/vendor/golang.org/x/crypto/pkcs12/internal/rc2/rc2.go
@@ -122,7 +122,6 @@ func (c *rc2Cipher) Encrypt(dst, src []byte) {
 	r3 = r3 + c.k[r2&63]
 
 	for j <= 40 {
-
 		// mix r0
 		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
 		r0 = rotl16(r0, 1)
@@ -151,7 +150,6 @@ func (c *rc2Cipher) Encrypt(dst, src []byte) {
 	r3 = r3 + c.k[r2&63]
 
 	for j <= 60 {
-
 		// mix r0
 		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
 		r0 = rotl16(r0, 1)
@@ -244,7 +242,6 @@ func (c *rc2Cipher) Decrypt(dst, src []byte) {
 	r0 = r0 - c.k[r3&63]
 
 	for j >= 0 {
-
 		// unmix r3
 		r3 = rotl16(r3, 16-5)
 		r3 = r3 - c.k[j] - (r2 & r1) - ((^r2) & r0)

--- a/vendor/golang.org/x/crypto/pkcs12/pkcs12.go
+++ b/vendor/golang.org/x/crypto/pkcs12/pkcs12.go
@@ -109,6 +109,10 @@ func ToPEM(pfxData []byte, password string) ([]*pem.Block, error) {
 
 	bags, encodedPassword, err := getSafeContents(pfxData, encodedPassword)
 
+	if err != nil {
+		return nil, err
+	}
+
 	blocks := make([]*pem.Block, 0, len(bags))
 	for _, bag := range bags {
 		block, err := convertBag(&bag, encodedPassword)


### PR DESCRIPTION
In #3454, I tried to update certificate-transparency-go, but that pulled in a bunch of extra package updates, making for a complicated PR. This PR breaks out one of the packages that needed update, to allow us to bring things up to date in a simpler, more piecemeal fashion.

```
$ go test golang.org/x/crypto/...
ok      golang.org/x/crypto/acme        2.564s
ok      golang.org/x/crypto/acme/autocert       0.634s
ok      golang.org/x/crypto/argon2      0.118s
ok      golang.org/x/crypto/bcrypt      2.282s
ok      golang.org/x/crypto/blake2b     0.103s
ok      golang.org/x/crypto/blake2s     0.072s
ok      golang.org/x/crypto/blowfish    0.006s
ok      golang.org/x/crypto/bn256       0.462s
2ok     golang.org/x/crypto/cast5       4.288s
ok      golang.org/x/crypto/chacha20poly1305    0.037s
ok      golang.org/x/crypto/cryptobyte  0.012s
?       golang.org/x/crypto/cryptobyte/asn1     [no test files]
ok      golang.org/x/crypto/curve25519  0.029s
ok      golang.org/x/crypto/ed25519     0.082s
?       golang.org/x/crypto/ed25519/internal/edwards25519       [no test files]
ok      golang.org/x/crypto/hkdf        0.003s
ok      golang.org/x/crypto/internal/chacha20   0.002s
ok      golang.org/x/crypto/md4 0.002s
ok      golang.org/x/crypto/nacl/auth   1.473s
ok      golang.org/x/crypto/nacl/box    0.007s
ok      golang.org/x/crypto/nacl/secretbox      0.004s
ok      golang.org/x/crypto/ocsp        0.034s
ok      golang.org/x/crypto/openpgp     7.275s
ok      golang.org/x/crypto/openpgp/armor       0.015s
ok      golang.org/x/crypto/openpgp/clearsign   0.028s
ok      golang.org/x/crypto/openpgp/elgamal     0.015s
?       golang.org/x/crypto/openpgp/errors      [no test files]
ok      golang.org/x/crypto/openpgp/packet      0.170s
ok      golang.org/x/crypto/openpgp/s2k 9.401s
ok      golang.org/x/crypto/otr 0.321s
ok      golang.org/x/crypto/pbkdf2      0.046s
ok      golang.org/x/crypto/pkcs12      0.065s
ok      golang.org/x/crypto/pkcs12/internal/rc2 0.014s
ok      golang.org/x/crypto/poly1305    0.023s
ok      golang.org/x/crypto/ripemd160   0.061s
ok      golang.org/x/crypto/salsa20     0.029s
ok      golang.org/x/crypto/salsa20/salsa       0.043s
ok      golang.org/x/crypto/scrypt      0.815s
ok      golang.org/x/crypto/sha3        0.263s
ok      golang.org/x/crypto/ssh 1.175s
ok      golang.org/x/crypto/ssh/agent   0.827s
ok      golang.org/x/crypto/ssh/knownhosts      0.038s
ok      golang.org/x/crypto/ssh/terminal        0.029s
ok      golang.org/x/crypto/ssh/test    0.148s
ok      golang.org/x/crypto/tea 0.012s
ok      golang.org/x/crypto/twofish     0.013s
ok      golang.org/x/crypto/xtea        0.002s
ok      golang.org/x/crypto/xts 0.016s
```