### PR TITLE
Deprecate CountCertificatesExact.

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -37,7 +37,7 @@ var features = map[FeatureFlag]bool{
 	IPv6First:               false,
 	AllowRenewalFirstRL:     false,
 	WildcardDomains:         false,
-	EnforceChallengeDisable: false,
+	EnforceChallengeDisable: false, // deprecated
 	TLSSNIRevalidation:      false,
 }
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1211,21 +1211,17 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 	}
 
 	var badNames []string
-	// If the CountCertificatesExact feature is enabled then treat exact public
-	// suffic domains differently by enforcing the limit against only exact
-	// matches to the names, not matches to subdomains as well.
-	if features.Enabled(features.CountCertificatesExact) && len(exactPublicSuffixes) > 0 {
+	// Domains that are exactly equal to a public suffix are treated differently
+	// by enforcing the limit against only exact matches to the names, not
+	// matches to subdomains as well. This allows the owners of such domains to
+	// issue certificates even though issuance from their subdomains may
+	// constantly exceed the rate limit.
+	if len(exactPublicSuffixes) > 0 {
 		psNamesOutOfLimit, err := ra.enforceNameCounts(ctx, exactPublicSuffixes, limit, regID, ra.SA.CountCertificatesByExactNames)
 		if err != nil {
 			return err
 		}
 		badNames = append(badNames, psNamesOutOfLimit...)
-	} else {
-		// When the CountCertificatesExact feature is *not* enabled we maintain the
-		// historic behaviour of treating exact public suffix matches the same as
-		// any other domain for rate limiting by combining the exactPublicSuffixes
-		// with the tldNames.
-		tldNames = append(tldNames, exactPublicSuffixes...)
 	}
 
 	// If there are any tldNames, enforce the certificate count rate limit against

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -45,7 +45,6 @@
       "WildcardDomains": true,
       "TLSSNIRevalidation": true,
       "AllowTLS02Challenges": true,
-      "CountCertificatesExact": true,
       "ReusePendingAuthz": true
     },
     "CTLogGroups": [


### PR DESCRIPTION
This is now enabled in prod and we can make it the default.