### PR TITLE
Accept large responses from the resolver.

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -254,6 +254,10 @@ func (dnsClient *DNSClientImpl) exchangeOne(ctx context.Context, hostname string
 	// metrics about the percentage of responses that are secured with
 	// DNSSEC.
 	m.AuthenticatedData = true
+	// Tell the resolver that we're willing to receive responses up to 4096 bytes.
+	// This happens sometimes when there are a very large number of CAA records
+	// present.
+	m.SetEdns0(4096, false)
 
 	if len(dnsClient.servers) < 1 {
 		return nil, fmt.Errorf("Not configured with at least one DNS Server")


### PR DESCRIPTION
This fixes some use cases where a domain being validated has a very
large number of CAA records.

Fixes #3451 