### PR TITLE
Add random subdomain for rate limit test.

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -405,7 +405,7 @@ def test_renewal_exemption():
 
 def test_certificates_per_name():
     chisel.expect_problem("urn:acme:error:rateLimited",
-        lambda: auth_and_issue(["lim.it"]))
+        lambda: auth_and_issue([random_domain() + ".lim.it"]))
 
 def test_expired_authzs_404():
     if len(old_authzs) == 0:


### PR DESCRIPTION
The test for the certificates_per_name rate limit uses an exact domain
name that has an override in the rate limit config file to have a limit
of 0. This works correctly most of the time. However, if that mechanism
fails once (due to some bug), future runs of the integation test will
continue to fail, because there will now be an issued certificate for
"lim.it" in the DB, and subsequent attempts will be considered renewals.

This change adds a random subdomain to the test, so that it's not
eligible for the renewal exemption.