### PR TITLE
ctpolicy: Add informational logs and don't cancel remaining submissions

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -80,7 +80,14 @@ type config struct {
 		// in a group and the first SCT returned will be used. This allows
 		// us to comply with Chrome CT policy which requires one SCT from a
 		// Google log and one SCT from any other log included in their policy.
-		CTLogGroups [][]cmd.LogDescription
+		// NOTE: CTLogGroups is depreciated in favor of CTLogGroups2.
+		CTLogGroups  [][]cmd.LogDescription
+		CTLogGroups2 []cmd.CTGroup
+		// InformationalCTLogs are a set of CT logs we will always submit to
+		// but won't ever use the SCTs from. This may be because we want to
+		// test them or because they are not yet approved by a browser/root
+		// program but we still want our certs to end up there.
+		InformationalCTLogs []cmd.LogDescription
 
 		Features map[string]bool
 	}
@@ -162,7 +169,16 @@ func main() {
 		pubc = bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn))
 
 		if c.RA.CTLogGroups != nil {
-			ctp = ctpolicy.New(pubc, c.RA.CTLogGroups, logger)
+			groups := make([]cmd.CTGroup, len(c.RA.CTLogGroups))
+			for i, logs := range c.RA.CTLogGroups {
+				groups[i] = cmd.CTGroup{
+					Name: fmt.Sprintf("%d", i),
+					Logs: l,
+				}
+			}
+			ctp = ctpolicy.New(pubc, groups, logger)
+		} else if c.RA.CTLogGroups2 != nil {
+			ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, logger)
 		}
 	}
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -173,12 +173,12 @@ func main() {
 			for i, logs := range c.RA.CTLogGroups {
 				groups[i] = cmd.CTGroup{
 					Name: fmt.Sprintf("%d", i),
-					Logs: l,
+					Logs: logs,
 				}
 			}
-			ctp = ctpolicy.New(pubc, groups, logger)
+			ctp = ctpolicy.New(pubc, groups, nil, logger)
 		} else if c.RA.CTLogGroups2 != nil {
-			ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, logger)
+			ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, nil, logger)
 		}
 	}
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -178,7 +178,7 @@ func main() {
 			}
 			ctp = ctpolicy.New(pubc, groups, nil, logger)
 		} else if c.RA.CTLogGroups2 != nil {
-			ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, nil, logger)
+			ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, c.RA.InformationalCTLogs, logger)
 		}
 	}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -291,3 +291,8 @@ type CAADistributedResolverConfig struct {
 	MaxFailures int
 	Proxies     []string
 }
+
+type CTGroup struct {
+	Name string
+	Logs []LogDescription
+}

--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -45,7 +45,7 @@ func (ctp *CTPolicy) race(ctx context.Context, cert core.CertDER, group cmd.CTGr
 	results := make(chan result, len(group.Logs))
 	var subCtx context.Context
 	var cancel func()
-	if !features.Enabled(features.DontCancelCTSubmissions) {
+	if features.Enabled(features.CancelCTSubmissions) {
 		subCtx, cancel = context.WithCancel(ctx)
 	} else {
 		subCtx, cancel = ctx, func() {}
@@ -94,7 +94,7 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER) ([]core.SCT
 	results := make(chan result, len(ctp.groups))
 	var subCtx context.Context
 	var cancel func()
-	if !features.Enabled(features.DontCancelCTSubmissions) {
+	if features.Enabled(features.CancelCTSubmissions) {
 		subCtx, cancel = context.WithCancel(ctx)
 	} else {
 		subCtx, cancel = ctx, func() {}

--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/letsencrypt/boulder/canceled"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 )
@@ -15,17 +16,19 @@ import (
 // CTPolicy is used to hold information about SCTs required from various
 // groupings
 type CTPolicy struct {
-	pub    core.Publisher
-	groups [][]cmd.LogDescription
-	log    blog.Logger
+	pub           core.Publisher
+	groups        []cmd.CTGroup
+	informational []cmd.LogDescription
+	log           blog.Logger
 }
 
 // New creates a new CTPolicy struct
-func New(pub core.Publisher, groups [][]cmd.LogDescription, log blog.Logger) *CTPolicy {
+func New(pub core.Publisher, groups []cmd.CTGroup, informational []cmd.LogDescription, log blog.Logger) *CTPolicy {
 	return &CTPolicy{
-		pub:    pub,
-		groups: groups,
-		log:    log,
+		pub:           pub,
+		groups:        groups,
+		informational: informational,
+		log:           log,
 	}
 }
 
@@ -38,11 +41,17 @@ type result struct {
 // once it has the first SCT it cancels all of the other submissions and returns.
 // It allows up to len(group)-1 of the submissions to fail as we only care about
 // getting a single SCT.
-func (ctp *CTPolicy) race(ctx context.Context, cert core.CertDER, group []cmd.LogDescription) (core.SCTDER, error) {
-	results := make(chan result, len(group))
-	subCtx, cancel := context.WithCancel(ctx)
+func (ctp *CTPolicy) race(ctx context.Context, cert core.CertDER, group cmd.CTGroup) (core.SCTDER, error) {
+	results := make(chan result, len(group.Logs))
+	var subCtx context.Context
+	var cancel func()
+	if !features.Enabled(features.DontCancelCTSubmissions) {
+		subCtx, cancel = context.WithCancel(ctx)
+	} else {
+		subCtx, cancel = ctx, func() {}
+	}
 	defer cancel()
-	for _, l := range group {
+	for _, l := range group.Logs {
 		go func(l cmd.LogDescription) {
 			sct, err := ctp.pub.SubmitToSingleCTWithResult(subCtx, &pubpb.Request{
 				LogURL:       &l.URI,
@@ -61,15 +70,14 @@ func (ctp *CTPolicy) race(ctx context.Context, cert core.CertDER, group []cmd.Lo
 		}(l)
 	}
 
-	for i := 0; i < len(group); i++ {
+	for i := 0; i < len(group.Logs); i++ {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case res := <-results:
 			if res.sct != nil {
-				// Return the very first SCT we get back and cancel any other
-				// in progress work.
-				cancel()
+				// Return the very first SCT we get back. Returning triggers
+				// the defer'd context cancellation method.
 				return res.sct, nil
 			}
 			// We will continue waiting for an SCT until we've seen the same number
@@ -84,17 +92,32 @@ func (ctp *CTPolicy) race(ctx context.Context, cert core.CertDER, group []cmd.Lo
 // the set of SCTs to the caller.
 func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER) ([]core.SCTDER, error) {
 	results := make(chan result, len(ctp.groups))
-	subCtx, cancel := context.WithCancel(ctx)
+	var subCtx context.Context
+	var cancel func()
+	if !features.Enabled(features.DontCancelCTSubmissions) {
+		subCtx, cancel = context.WithCancel(ctx)
+	} else {
+		subCtx, cancel = ctx, func() {}
+	}
 	defer cancel()
 	for i, g := range ctp.groups {
-		go func(i int, g []cmd.LogDescription) {
+		go func(i int, g cmd.CTGroup) {
 			sct, err := ctp.race(subCtx, cert, g)
 			// Only one of these will be non-nil
 			if err != nil {
-				results <- result{err: fmt.Errorf("CT log group %d: %s", i, err)}
+				results <- result{err: fmt.Errorf("CT log group %q: %s", g.Name, err)}
 			}
 			results <- result{sct: sct}
 		}(i, g)
+	}
+	for _, log := range ctp.informational {
+		go func(l cmd.LogDescription) {
+			_, _ = ctp.pub.SubmitToSingleCTWithResult(subCtx, &pubpb.Request{
+				LogURL:       &l.URI,
+				LogPublicKey: &l.Key,
+				Der:          cert,
+			})
+		}(log)
 	}
 
 	var ret []core.SCTDER
@@ -103,7 +126,7 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER) ([]core.SCT
 		// If any one group fails to get a SCT then we fail out immediately
 		// cancel any other in progress work as we can't continue
 		if res.err != nil {
-			cancel()
+			// Returning triggers the defer'd context cancellation method
 			return nil, res.err
 		}
 		ret = append(ret, res.sct)

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedUseAIAIssuerURLAllowTLS02ChallengesReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsEnforceChallengeDisableTLSSNIRevalidation"
+const _FeatureFlag_name = "unusedUseAIAIssuerURLAllowTLS02ChallengesReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsEnforceChallengeDisableTLSSNIRevalidationDontCancelCTSubmissions"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 21, 41, 58, 80, 89, 108, 123, 146, 164}
+var _FeatureFlag_index = [...]uint8{0, 6, 21, 41, 58, 80, 89, 108, 123, 146, 164, 187}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedUseAIAIssuerURLAllowTLS02ChallengesReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsEnforceChallengeDisableTLSSNIRevalidationDontCancelCTSubmissions"
+const _FeatureFlag_name = "unusedUseAIAIssuerURLAllowTLS02ChallengesReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsEnforceChallengeDisableTLSSNIRevalidationCancelCTSubmissions"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 21, 41, 58, 80, 89, 108, 123, 146, 164, 187}
+var _FeatureFlag_index = [...]uint8{0, 6, 21, 41, 58, 80, 89, 108, 123, 146, 164, 183}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -25,6 +25,7 @@ const (
 	EnforceChallengeDisable
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
+	DontCancelCTSubmissions
 )
 
 // List of features and their default value, protected by fMu
@@ -39,6 +40,7 @@ var features = map[FeatureFlag]bool{
 	WildcardDomains:         false,
 	EnforceChallengeDisable: false, // deprecated
 	TLSSNIRevalidation:      false,
+	DontCancelCTSubmissions: false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/features/features.go
+++ b/features/features.go
@@ -25,7 +25,7 @@ const (
 	EnforceChallengeDisable
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
-	DontCancelCTSubmissions
+	CancelCTSubmissions
 )
 
 // List of features and their default value, protected by fMu
@@ -40,7 +40,7 @@ var features = map[FeatureFlag]bool{
 	WildcardDomains:         false,
 	EnforceChallengeDisable: false, // deprecated
 	TLSSNIRevalidation:      false,
-	DontCancelCTSubmissions: false,
+	CancelCTSubmissions:     true,
 }
 
 var fMu = new(sync.RWMutex)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3301,7 +3301,7 @@ func TestCTPolicyMeasurements(t *testing.T) {
 		PEM: eeCertPEM,
 	}
 
-	ctp := ctpolicy.New(&timeoutPub{}, [][]cmd.LogDescription{{}}, log)
+	ctp := ctpolicy.New(&timeoutPub{}, []cmd.CTGroup{{}}, nil, log)
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
 		stats,

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -45,7 +45,8 @@
       "WildcardDomains": true,
       "TLSSNIRevalidation": true,
       "AllowTLS02Challenges": true,
-      "ReusePendingAuthz": true
+      "ReusePendingAuthz": true,
+      "CancelCTSubmissions": false
     },
     "CTLogGroups2": [
       {
@@ -73,6 +74,12 @@
             "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg=="
           }
         ]
+      }
+    ],
+    "InformationalCTLogs": [
+      {
+        "uri": "http://boulder:4512",
+        "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg=="
       }
     ]
   },

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -47,31 +47,33 @@
       "AllowTLS02Challenges": true,
       "ReusePendingAuthz": true
     },
-    "CTLogGroups": [
-
-      [
-        {
-          "uri": "http://boulder:4500",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q=="
-        },
-        {
-          "uri": "http://boulder:4501",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA=="
-        }
-      ],
-
-
-      [
-        {
-          "uri": "http://boulder:4510",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyw1HymhJkuxSIgt3gqW3sVXqMqB3EFsXcMfPFo0vYwjNiRmCJDXKsR0Flp7MAK+wc3X/7Hpc8liUbMhPet7tEA=="
-        },
-        {
-          "uri": "http://boulder:4511",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg=="
-        }
-      ]
-
+    "CTLogGroups2": [
+      {
+        "name": "a",
+        "logs": [
+          {
+            "uri": "http://boulder:4500",
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q=="
+          },
+          {
+            "uri": "http://boulder:4501",
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA=="
+          }
+        ]
+      },
+      {
+        "name": "b",
+        "logs": [
+          {
+            "uri": "http://boulder:4510",
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyw1HymhJkuxSIgt3gqW3sVXqMqB3EFsXcMfPFo0vYwjNiRmCJDXKsR0Flp7MAK+wc3X/7Hpc8liUbMhPet7tEA=="
+          },
+          {
+            "uri": "http://boulder:4511",
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg=="
+          }
+        ]
+      }
     ]
   },
 

--- a/test/ct-test-srv/ct-test-srv.json
+++ b/test/ct-test-srv/ct-test-srv.json
@@ -51,17 +51,14 @@
       "Addr": ":4511",
       "PrivKey": "MHcCAQEEINwaal89BqkwvQ6r3uOj7R5VEjJi5iSDbAhlYyDhZv/joAoGCCqGSM49AwEHoUQDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
       "LatencySchedule": [
-        0.7,
-        0.3,
-        2,
-        0.0,
-        0.0,
-        20,
-        0.2,
-        0.3,
-        0.2,
-        70,
-        0.1
+        100
+      ]
+    },
+    {
+      "Addr": ":4512",
+      "PrivKey": "MHcCAQEEINwaal89BqkwvQ6r3uOj7R5VEjJi5iSDbAhlYyDhZv/joAoGCCqGSM49AwEHoUQDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
+      "LatencySchedule": [
+        100
       ]
     }
   ]


### PR DESCRIPTION
Add a set of logs which will be submitted to but not relied on for their SCTs,
this allows us to test submissions to a particular log or submit to a log which
is not yet approved by a browser/root program.

Also add a feature which stops cancellations of remaining submissions when racing
to get a SCT from a group of logs.

Fixes #3464 and fixes #3465.