### PR TITLE
Improve test-tools.

### DIFF
--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -673,19 +673,25 @@ func TestLoopTickBackoff(t *testing.T) {
 		tickFunc:             func(context.Context, int) error { return errors.New("baddie") },
 	}
 
+	assertBetween := func(a, b, c int64) {
+		t.Helper()
+		if a < b || a > c {
+			t.Fatalf("%d is not between %d and %d", a, b, c)
+		}
+	}
 	start := l.clk.Now()
 	l.tick()
 	// Expected to sleep for 1m
 	backoff := float64(60000000000)
 	maxJittered := backoff * 1.2
-	test.AssertBetween(t, l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
+	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
 
 	start = l.clk.Now()
 	l.tick()
 	// Expected to sleep for 1m30s
 	backoff = 90000000000
 	maxJittered = backoff * 1.2
-	test.AssertBetween(t, l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
+	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
 
 	l.failures = 6
 	start = l.clk.Now()
@@ -693,7 +699,7 @@ func TestLoopTickBackoff(t *testing.T) {
 	// Expected to sleep for 11m23.4375s, should be truncated to 10m
 	backoff = 600000000000
 	maxJittered = backoff * 1.2
-	test.AssertBetween(t, l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
+	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
 
 	l.tickFunc = func(context.Context, int) error { return nil }
 	start = l.clk.Now()

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -18,7 +18,9 @@ func TestNewToken(t *testing.T) {
 	token := NewToken()
 	fmt.Println(token)
 	tokenLength := int(math.Ceil(32 * 8 / 6.0)) // 32 bytes, b64 encoded
-	test.AssertIntEquals(t, len(token), tokenLength)
+	if len(token) != tokenLength {
+		t.Fatalf("Expected token of length %d, got %d", tokenLength, len(token))
+	}
 	collider := map[string]bool{}
 	// Test for very blatant RNG failures:
 	// Try 2^20 birthdays in a 2^72 search space...
@@ -43,7 +45,9 @@ func TestSerialUtils(t *testing.T) {
 
 	serialNum, err := StringToSerial("00000000000000000000016345785d8a0000")
 	test.AssertNotError(t, err, "Couldn't convert serial number to *big.Int")
-	test.AssertBigIntEquals(t, serialNum, big.NewInt(100000000000000000))
+	if serialNum.Cmp(big.NewInt(100000000000000000)) != 0 {
+		t.Fatalf("Incorrect conversion, got %d", serialNum)
+	}
 
 	badSerial, err := StringToSerial("doop!!!!000")
 	test.AssertEquals(t, fmt.Sprintf("%v", err), "Invalid serial number")

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"reflect"
 	"runtime"
 	"strings"
@@ -32,43 +31,49 @@ func caller() string {
 
 // Assert a boolean
 func Assert(t *testing.T, result bool, message string) {
+	t.Helper()
 	if !result {
-		fatalf(t, "%s %s", caller(), message)
+		t.Fatal(message)
 	}
 }
 
 // AssertNotNil checks an object to be non-nil
 func AssertNotNil(t *testing.T, obj interface{}, message string) {
+	t.Helper()
 	if obj == nil {
-		fatalf(t, "%s %s", caller(), message)
+		t.Fatal(message)
 	}
 }
 
 // AssertNotError checks that err is nil
 func AssertNotError(t *testing.T, err error, message string) {
+	t.Helper()
 	if err != nil {
-		fatalf(t, "%s %s: %s", caller(), message, err)
+		t.Fatalf("%s: %s", message, err)
 	}
 }
 
 // AssertError checks that err is non-nil
 func AssertError(t *testing.T, err error, message string) {
+	t.Helper()
 	if err == nil {
-		fatalf(t, "%s %s: expected error but received none", caller(), message)
+		t.Fatalf("%s: expected error but received none", message)
 	}
 }
 
 // AssertEquals uses the equality operator (==) to measure one and two
 func AssertEquals(t *testing.T, one interface{}, two interface{}) {
+	t.Helper()
 	if one != two {
-		fatalf(t, "%s %#v != %#v", caller(), one, two)
+		t.Fatalf("%#v != %#v", one, two)
 	}
 }
 
 // AssertDeepEquals uses the reflect.DeepEqual method to measure one and two
 func AssertDeepEquals(t *testing.T, one interface{}, two interface{}) {
+	t.Helper()
 	if !reflect.DeepEqual(one, two) {
-		fatalf(t, "%s [%+v] !(deep)= [%+v]", caller(), one, two)
+		t.Fatalf("[%+v] !(deep)= [%+v]", one, two)
 	}
 }
 
@@ -81,79 +86,59 @@ func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
 	AssertNotError(t, err, "Could not marshal 2nd argument")
 
 	if !bytes.Equal(oneJSON, twoJSON) {
-		fatalf(t, "%s [%s] !(json)= [%s]", caller(), oneJSON, twoJSON)
+		t.Fatalf("[%s] !(json)= [%s]", oneJSON, twoJSON)
 	}
 }
 
-// AssertUnmarshaledEquals unmarshals two JSON strings (one and two) to
+// AssertUnmarshaledEquals unmarshals two JSON strings (got and expected) to
 // a map[string]interface{} and then uses reflect.DeepEqual to check they are
 // the same
-func AssertUnmarshaledEquals(t *testing.T, one, two string) {
-	var oneMap, twoMap map[string]interface{}
-	err := json.Unmarshal([]byte(one), &oneMap)
-	AssertNotError(t, err, "Could not unmarshal 1st argument")
-	err = json.Unmarshal([]byte(two), &twoMap)
-	AssertNotError(t, err, "Could not unmarshal 2nd argument")
-	AssertDeepEquals(t, oneMap, twoMap)
+func AssertUnmarshaledEquals(t *testing.T, got, expected string) {
+	t.Helper()
+	var gotMap, expectedMap map[string]interface{}
+	err := json.Unmarshal([]byte(got), &gotMap)
+	AssertNotError(t, err, "Could not unmarshal 'got'")
+	err = json.Unmarshal([]byte(expected), &expectedMap)
+	AssertNotError(t, err, "Could not unmarshal 'expected'")
+	for k, v := range expectedMap {
+		if !reflect.DeepEqual(v, gotMap[k]) {
+			t.Errorf("Field %q: Expected \"%v\", got \"%v\"", k, v, gotMap[k])
+		}
+	}
 }
 
 // AssertNotEquals uses the equality operator to measure that one and two
 // are different
 func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {
+	t.Helper()
 	if one == two {
-		fatalf(t, "%s %#v == %#v", caller(), one, two)
+		t.Fatalf("%#v == %#v", one, two)
 	}
 }
 
 // AssertByteEquals uses bytes.Equal to measure one and two for equality.
 func AssertByteEquals(t *testing.T, one []byte, two []byte) {
+	t.Helper()
 	if !bytes.Equal(one, two) {
-		fatalf(t, "%s Byte [%s] != [%s]",
-			caller(),
+		t.Fatalf("Byte [%s] != [%s]",
 			base64.StdEncoding.EncodeToString(one),
 			base64.StdEncoding.EncodeToString(two))
 	}
 }
 
-// AssertIntEquals uses the equality operator to measure one and two.
-func AssertIntEquals(t *testing.T, one int, two int) {
-	if one != two {
-		fatalf(t, "%s Int [%d] != [%d]", caller(), one, two)
-	}
-}
-
-// AssertBigIntEquals uses the big.Int.cmp() method to measure whether
-// one and two are equal
-func AssertBigIntEquals(t *testing.T, one *big.Int, two *big.Int) {
-	if one.Cmp(two) != 0 {
-		fatalf(t, "%s Int [%d] != [%d]", caller(), one, two)
-	}
-}
-
 // AssertContains determines whether needle can be found in haystack
 func AssertContains(t *testing.T, haystack string, needle string) {
+	t.Helper()
 	if !strings.Contains(haystack, needle) {
-		fatalf(t, "%s String [%s] does not contain [%s]", caller(), haystack, needle)
+		t.Fatalf("String [%s] does not contain [%s]", haystack, needle)
 	}
 }
 
 // AssertNotContains determines if needle is not found in haystack
 func AssertNotContains(t *testing.T, haystack string, needle string) {
+	t.Helper()
 	if strings.Contains(haystack, needle) {
-		fatalf(t, "%s String [%s] contains [%s]", caller(), haystack, needle)
-	}
-}
-
-// AssertSeverity determines if a string matches the Severity formatting
-func AssertSeverity(t *testing.T, data string, severity int) {
-	expected := fmt.Sprintf("\"severity\":%d", severity)
-	AssertContains(t, data, expected)
-}
-
-// AssertBetween determines if a is between b and c
-func AssertBetween(t *testing.T, a, b, c int64) {
-	if a < b || a > c {
-		fatalf(t, "%d is not between %d and %d", a, b, c)
+		t.Fatalf("String [%s] contains [%s]", haystack, needle)
 	}
 }
 


### PR DESCRIPTION
Use t.Helper and t.Fatalf instead of our own versions.

Remove some unused or single-user helpers.

Make the output of AssetUnmarshaledEquals clearer by showing one line per field.

Fix an instance in log_test.go where the helpers were called with a nil `t *testing.T`, which now causes a panic.