### PR TITLE
Remove "Terminated request" / "Successful request"

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -64,17 +64,12 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (th *TopHandler) logEvent(logEvent *RequestEvent) {
 	var msg string
-	if len(logEvent.Errors) != 0 {
-		msg = "Terminated request"
-	} else {
-		msg = "Successful request"
-	}
 	jsonEvent, err := json.Marshal(logEvent)
 	if err != nil {
-		th.log.AuditErr(fmt.Sprintf("%s - failed to marshal logEvent - %s", msg, err))
+		th.log.AuditErr(fmt.Sprintf("failed to marshal logEvent - %s - %#v", msg, err))
 		return
 	}
-	th.log.Info(fmt.Sprintf("%s JSON=%s", msg, jsonEvent))
+	th.log.Info(fmt.Sprintf("JSON=%s", jsonEvent))
 }
 
 // Comma-separated list of HTTP clients involved in making this

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1942,9 +1942,11 @@ func TestGetCertificate(t *testing.T) {
 		t, responseWriter.Header().Get("Link"),
 		`<https://localhost:4000/acme/issuer-cert>;rel="up"`)
 
-	reqlogs := mockLog.GetAllMatching(`Successful request`)
-	test.AssertEquals(t, len(reqlogs), 1)
-	test.AssertContains(t, reqlogs[0], `INFO: `)
+	reqlogs := mockLog.GetAllMatching(`INFO: JSON=.*"Code":200.*`)
+	if len(reqlogs) != 1 {
+		t.Errorf("Didn't find info logs with code 200. Instead got:\n%s\n",
+			strings.Join(mockLog.GetAllMatching(`.*`), "\n"))
+	}
 
 	// Unused serial, no cache
 	mockLog.Clear()
@@ -1957,9 +1959,11 @@ func TestGetCertificate(t *testing.T) {
 	test.AssertEquals(t, responseWriter.Header().Get("Cache-Control"), "public, max-age=0, no-cache")
 	assertJSONEquals(t, responseWriter.Body.String(), `{"type":"`+probs.V1ErrorNS+`malformed","detail":"Certificate not found","status":404}`)
 
-	reqlogs = mockLog.GetAllMatching(`Terminated request`)
-	test.AssertEquals(t, len(reqlogs), 1)
-	test.AssertContains(t, reqlogs[0], `INFO: `)
+	reqlogs = mockLog.GetAllMatching(`INFO: JSON=.*"Code":404.*`)
+	if len(reqlogs) != 1 {
+		t.Errorf("Didn't find info logs with code 404. Instead got:\n%s\n",
+			strings.Join(mockLog.GetAllMatching(`.*`), "\n"))
+	}
 
 	// Invalid serial, no cache
 	responseWriter = httptest.NewRecorder()

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1549,18 +1549,22 @@ func TestGetCertificate(t *testing.T) {
 				test.Assert(t, bytes.Compare(bodyBytes, tc.ExpectedCert) == 0, "Certificates don't match")
 
 				// Successful requests should be logged as such
-				reqlogs := mockLog.GetAllMatching(`Successful request`)
-				test.AssertEquals(t, len(reqlogs), 1)
-				test.AssertContains(t, reqlogs[0], `INFO: `)
+				reqlogs := mockLog.GetAllMatching(`INFO: JSON=.*"Code":200.*`)
+				if len(reqlogs) != 1 {
+					t.Errorf("Didn't find info logs with code 200. Instead got:\n%s\n",
+						strings.Join(mockLog.GetAllMatching(`.*`), "\n"))
+				}
 			} else {
 				// Otherwise if the expectation wasn't a certificate, check that the body matches the expected
 				body := responseWriter.Body.String()
 				test.AssertUnmarshaledEquals(t, body, tc.ExpectedBody)
 
 				// Unsuccessful requests should be logged as such
-				reqlogs := mockLog.GetAllMatching(`Terminated request`)
-				test.AssertEquals(t, len(reqlogs), 1)
-				test.AssertContains(t, reqlogs[0], `INFO: `)
+				reqlogs := mockLog.GetAllMatching(`INFO: JSON=.*"Code":404.*`)
+				if len(reqlogs) != 1 {
+					t.Errorf("Didn't find info logs with code 404. Instead got:\n%s\n",
+						strings.Join(mockLog.GetAllMatching(`.*`), "\n"))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The WFE logs these with every request, but with #3483,
they aren't necessary; everything other than 2xx is a failed request.