### PR TITLE
Add Retry-After header for authz/challenge poll

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedUseAIAIssuerURLAllowTLS02ChallengesReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsEnforceChallengeDisableTLSSNIRevalidationCancelCTSubmissions"
+const _FeatureFlag_name = "unusedUseAIAIssuerURLAllowTLS02ChallengesReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsEnforceChallengeDisableTLSSNIRevalidationCancelCTSubmissionsRetryAfter"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 21, 41, 58, 80, 89, 108, 123, 146, 164, 183}
+var _FeatureFlag_index = [...]uint8{0, 6, 21, 41, 58, 80, 89, 108, 123, 146, 164, 183, 193}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -26,6 +26,7 @@ const (
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
 	CancelCTSubmissions
+	RetryAfter
 )
 
 // List of features and their default value, protected by fMu
@@ -41,6 +42,7 @@ var features = map[FeatureFlag]bool{
 	EnforceChallengeDisable: false, // deprecated
 	TLSSNIRevalidation:      false,
 	CancelCTSubmissions:     true,
+	RetryAfter:              false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -938,6 +938,9 @@ func (wfe *WebFrontEndImpl) Challenge(
 	logEvent *web.RequestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
+	if features.Enabled(features.RetryAfter) {
+		response.Header().Set("Retry-After", "3")
+	}
 
 	notFound := func() {
 		wfe.sendError(response, logEvent, probs.NotFound("No such challenge"), nil)
@@ -1243,6 +1246,9 @@ func (wfe *WebFrontEndImpl) deactivateAuthorization(ctx context.Context, authz *
 // Authorization is used by clients to submit an update to one of their
 // authorizations.
 func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	if features.Enabled(features.RetryAfter) {
+		response.Header().Set("Retry-After", "3")
+	}
 	// Requests to this handler should have a path that leads to a known authz
 	id := request.URL.Path
 	authz, err := wfe.SA.GetAuthorization(ctx, id)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -25,6 +25,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
@@ -780,6 +781,9 @@ func (wfe *WebFrontEndImpl) Challenge(
 	logEvent *web.RequestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
+	if features.Enabled(features.RetryAfter) {
+		response.Header().Set("Retry-After", "3")
+	}
 
 	notFound := func() {
 		wfe.sendError(response, logEvent, probs.NotFound("No such challenge"), nil)
@@ -1115,6 +1119,9 @@ func (wfe *WebFrontEndImpl) deactivateAuthorization(
 // Authorization is used by clients to submit an update to one of their
 // authorizations.
 func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	if features.Enabled(features.RetryAfter) {
+		response.Header().Set("Retry-After", "3")
+	}
 	// Requests to this handler should have a path that leads to a known authz
 	id := request.URL.Path
 	authz, err := wfe.SA.GetAuthorization(ctx, id)


### PR DESCRIPTION
Some clients exhibit excessive retry patterns on authz and/or challenge polling,
but obey the Retry-After header. This change starts setting Retry-After to a
default value of 3 seconds, gated by a feature flag in case some clients break
badly in the presence of Retry-After (which we've never sent before).
If successful, this may reduce the amount of polling we receive from
misconfigured clients. We may then choose to refine the behavior further, for
instance by setting Retry-After to longer intervals based on the age or status
of the authorization. For instance, valid / invalid authorizations could have a
very large Retry-After, since they are expected to never change.