### PR TITLE
Log less on polling endpoints.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -956,8 +956,6 @@ func (wfe *WebFrontEndImpl) Challenge(
 		notFound()
 		return
 	}
-	logEvent.Extra["AuthorizationID"] = authorizationID
-	logEvent.Extra["ChallengeID"] = challengeID
 
 	authz, err := wfe.SA.GetAuthorization(ctx, authorizationID)
 	if err != nil {
@@ -984,10 +982,8 @@ func (wfe *WebFrontEndImpl) Challenge(
 	challenge := authz.Challenges[challengeIndex]
 
 	logEvent.Extra["ChallengeType"] = challenge.Type
-	logEvent.Extra["AuthorizationRegistrationID"] = authz.RegistrationID
-	logEvent.Extra["AuthorizationIdentifier"] = authz.Identifier
+	logEvent.Extra["Identifier"] = authz.Identifier
 	logEvent.Extra["AuthorizationStatus"] = authz.Status
-	logEvent.Extra["AuthorizationExpires"] = authz.Expires
 
 	switch request.Method {
 	case "GET", "HEAD":
@@ -1252,11 +1248,8 @@ func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.Req
 		wfe.sendError(response, logEvent, probs.NotFound("Unable to find authorization"), err)
 		return
 	}
-	logEvent.Extra["AuthorizationID"] = authz.ID
-	logEvent.Extra["AuthorizationRegistrationID"] = authz.RegistrationID
-	logEvent.Extra["AuthorizationIdentifier"] = authz.Identifier
+	logEvent.Extra["Identifier"] = authz.Identifier
 	logEvent.Extra["AuthorizationStatus"] = authz.Status
-	logEvent.Extra["AuthorizationExpires"] = authz.Expires
 
 	// After expiring, authorizations are inaccessible
 	if authz.Expires == nil || authz.Expires.Before(wfe.clk.Now()) {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -798,8 +798,6 @@ func (wfe *WebFrontEndImpl) Challenge(
 		notFound()
 		return
 	}
-	logEvent.Extra["AuthorizationID"] = authorizationID
-	logEvent.Extra["ChallengeID"] = challengeID
 
 	authz, err := wfe.SA.GetAuthorization(ctx, authorizationID)
 	if err != nil {
@@ -826,10 +824,8 @@ func (wfe *WebFrontEndImpl) Challenge(
 	challenge := authz.Challenges[challengeIndex]
 
 	logEvent.Extra["ChallengeType"] = challenge.Type
-	logEvent.Extra["AuthorizationRegistrationID"] = authz.RegistrationID
-	logEvent.Extra["AuthorizationIdentifier"] = authz.Identifier
+	logEvent.Extra["Identifier"] = authz.Identifier
 	logEvent.Extra["AuthorizationStatus"] = authz.Status
-	logEvent.Extra["AuthorizationExpires"] = authz.Expires
 
 	switch request.Method {
 	case "GET", "HEAD":
@@ -1123,11 +1119,8 @@ func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.Req
 		wfe.sendError(response, logEvent, probs.NotFound("Unable to find authorization"), err)
 		return
 	}
-	logEvent.Extra["AuthorizationID"] = authz.ID
-	logEvent.Extra["AuthorizationRegistrationID"] = authz.RegistrationID
-	logEvent.Extra["AuthorizationIdentifier"] = authz.Identifier
+	logEvent.Extra["Identifier"] = authz.Identifier
 	logEvent.Extra["AuthorizationStatus"] = authz.Status
-	logEvent.Extra["AuthorizationExpires"] = authz.Expires
 
 	// After expiring, authorizations are inaccessible
 	if authz.Expires == nil || authz.Expires.Before(wfe.clk.Now()) {


### PR DESCRIPTION
This removes some fields from "Extra" that are logged on every poll event and
aren't necessary. For instance, authorizationID and challengeID can easily be
derived from the endpoint, and AuthorizationRequesterID is a duplicate of
Requester.