### PR TITLE
Fix outdated IDN comment on `pa.WillingToIssue`.

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -210,7 +210,6 @@ var (
 //  * MUST follow the DNS hostname syntax rules in RFC 1035 and RFC 2181
 //    In particular:
 //    * MUST NOT contain underscores
-//  * MUST NOT contain IDN labels (xn--)
 //  * MUST NOT match the syntax of an IP address
 //  * MUST end in a public suffix
 //  * MUST have at least one label in addition to the public suffix


### PR DESCRIPTION
Prior to this commit the comment on `pa.WillingToIssue` incorrectly
asserted that the input domain must not contain IDN labels. That's not
true anymore! :tada:

Resolves https://github.com/letsencrypt/boulder/issues/3510

Thanks to @mdebski for flagging the inaccuracy :trophy: 