### PR TITLE
Test rate limit config: increase order rate limit

### DIFF
--- a/test/rate-limit-policies-b.yml
+++ b/test/rate-limit-policies-b.yml
@@ -35,8 +35,8 @@ pendingAuthorizationsPerAccount:
   window: 168h # 1 week, should match pending authorization lifetime.
   threshold: 999
 newOrdersPerAccount:
-  window: 5m
-  threshold: 999
+  window: 3h
+  threshold: 9999
 certificatesPerFQDNSet:
   window: 24h
   threshold: 99999

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -37,8 +37,8 @@ invalidAuthorizationsPerAccount:
   window: 5m
   threshold: 3
 newOrdersPerAccount:
-  window: 5m
-  threshold: 3
+  window: 3h
+  threshold: 1500
 certificatesPerFQDNSet:
   window: 24h
   threshold: 5


### PR DESCRIPTION
3 orders every 5m is way too low for a default test rate limit.