### PR TITLE
Bump Travis to use Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.4
+  - "1.10"
 
 go_import_path: github.com/letsencrypt/boulder
 


### PR DESCRIPTION
We already updated Boulder-Tools in https://github.com/letsencrypt/boulder/commit/6b8b6a37c0d0cad5b2475290f3d3fc4215dcf0a2