### PR TITLE
Size V2 newOrder requests from load-generator randomly.

### DIFF
--- a/test/load-generator/config/v2-example-config.json
+++ b/test/load-generator/config/v2-example-config.json
@@ -17,6 +17,7 @@
     "certKeySize": 2048,
     "regEmail": "loadtesting@letsencrypt.org",
     "maxRegs": 20,
+    "maxNamesPerCert": 20,
     "dontSaveState": true,
     "results": "v2-example-latency.json"
 }

--- a/test/load-generator/config/v2-integration-test-config.json
+++ b/test/load-generator/config/v2-integration-test-config.json
@@ -17,5 +17,6 @@
     "certKeySize": 2048,
     "regEmail": "loadtesting@letsencrypt.org",
     "maxRegs": 20,
+    "maxNamesPerCert": 20,
     "dontSaveState": true
 }

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -340,7 +340,15 @@ func (s *State) Restore(filename string) error {
 }
 
 // New returns a pointer to a new State struct or an error
-func New(apiBase string, keySize int, domainBase string, realIP string, maxRegs int, latencyPath string, userEmail string, operations []string) (*State, error) {
+func New(
+	apiBase string,
+	keySize int,
+	domainBase string,
+	realIP string,
+	maxRegs, maxNamesPerCert int,
+	latencyPath string,
+	userEmail string,
+	operations []string) (*State, error) {
 	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
@@ -365,16 +373,17 @@ func New(apiBase string, keySize int, domainBase string, realIP string, maxRegs 
 		return nil, err
 	}
 	s := &State{
-		client:      client,
-		apiBase:     apiBase,
-		certKey:     certKey,
-		domainBase:  domainBase,
-		callLatency: latencyFile,
-		wg:          new(sync.WaitGroup),
-		realIP:      realIP,
-		maxRegs:     maxRegs,
-		email:       userEmail,
-		respCodes:   make(map[int]*respCode),
+		client:          client,
+		apiBase:         apiBase,
+		certKey:         certKey,
+		domainBase:      domainBase,
+		callLatency:     latencyFile,
+		wg:              new(sync.WaitGroup),
+		realIP:          realIP,
+		maxRegs:         maxRegs,
+		maxNamesPerCert: maxNamesPerCert,
+		email:           userEmail,
+		respCodes:       make(map[int]*respCode),
 	}
 
 	// convert operations strings to methods


### PR DESCRIPTION
Prior to this commit all of the `newOrder` requests generated by the
load generator had 1 DNS type identifier. In this commit the
`maxNamesPerCert` parameter that was present in the codebase is fixed
(it was never wired through to config before) and used to size the
orders randomly. Each order will have between 1 and `maxNamesPerCert`
identifiers.

For integration testing we set this at 20. 100 would be more realistic
but we'll start small for now.