### PR TITLE
Update go-jose to 2.1.4

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/letsencrypt/boulder",
 	"GoVersion": "go1.10",
-	"GodepVersion": "v80",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
@@ -400,18 +400,18 @@
 		},
 		{
 			"ImportPath": "gopkg.in/square/go-jose.v2",
-			"Comment": "v2.1.3",
-			"Rev": "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
+			"Comment": "v2.1.4",
+			"Rev": "6ee92191fea850cdcab9a18867abf5f521cdbadb"
 		},
 		{
 			"ImportPath": "gopkg.in/square/go-jose.v2/cipher",
-			"Comment": "v2.1.3",
-			"Rev": "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
+			"Comment": "v2.1.4",
+			"Rev": "6ee92191fea850cdcab9a18867abf5f521cdbadb"
 		},
 		{
 			"ImportPath": "gopkg.in/square/go-jose.v2/json",
-			"Comment": "v2.1.3",
-			"Rev": "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
+			"Comment": "v2.1.4",
+			"Rev": "6ee92191fea850cdcab9a18867abf5f521cdbadb"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/letsencrypt/boulder",
 	"GoVersion": "go1.10",
-	"GodepVersion": "v79",
+	"GodepVersion": "v80",
 	"Packages": [
 		"./..."
 	],

--- a/vendor/gopkg.in/square/go-jose.v2/.travis.yml
+++ b/vendor/gopkg.in/square/go-jose.v2/.travis.yml
@@ -8,11 +8,12 @@ matrix:
     - go: tip
 
 go:
-- 1.5
-- 1.6
-- 1.7
-- 1.8
-- 1.9
+- '1.5.x'
+- '1.6.x'
+- '1.7.x'
+- '1.8.x'
+- '1.9.x'
+- '1.10.x'
 - tip
 
 go_import_path: gopkg.in/square/go-jose.v2

--- a/vendor/gopkg.in/square/go-jose.v2/README.md
+++ b/vendor/gopkg.in/square/go-jose.v2/README.md
@@ -84,6 +84,7 @@ standard where possible. The Godoc reference has a list of constants.
  RSASSA-PSS                 | PS256, PS384, PS512
  HMAC                       | HS256, HS384, HS512
  ECDSA                      | ES256, ES384, ES512
+ Ed25519                    | EdDSA
 
  Content encryption         | Algorithm identifier(s)
  :------------------------- | :------------------------------

--- a/vendor/gopkg.in/square/go-jose.v2/jwk.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwk.go
@@ -247,11 +247,30 @@ func (k *JSONWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 // IsPublic returns true if the JWK represents a public key (not symmetric, not private).
 func (k *JSONWebKey) IsPublic() bool {
 	switch k.Key.(type) {
-	case *ecdsa.PublicKey, *rsa.PublicKey, *ed25519.PublicKey:
+	case *ecdsa.PublicKey, *rsa.PublicKey, ed25519.PublicKey:
 		return true
 	default:
 		return false
 	}
+}
+
+// Public creates JSONWebKey with corresponding publik key if JWK represents asymmetric private key.
+func (k *JSONWebKey) Public() JSONWebKey {
+	if k.IsPublic() {
+		return *k
+	}
+	ret := *k
+	switch key := k.Key.(type) {
+	case *ecdsa.PrivateKey:
+		ret.Key = key.Public()
+	case *rsa.PrivateKey:
+		ret.Key = key.Public()
+	case ed25519.PrivateKey:
+		ret.Key = key.Public()
+	default:
+		return JSONWebKey{} // returning invalid key
+	}
+	return ret
 }
 
 // Valid checks that the key contains the expected parameters.
@@ -276,12 +295,12 @@ func (k *JSONWebKey) Valid() bool {
 		if key.N == nil || key.E == 0 || key.D == nil || len(key.Primes) < 2 {
 			return false
 		}
-	case *ed25519.PublicKey:
-		if len(*key) != 32 {
+	case ed25519.PublicKey:
+		if len(key) != 32 {
 			return false
 		}
-	case *ed25519.PrivateKey:
-		if len(*key) != 64 {
+	case ed25519.PrivateKey:
+		if len(key) != 64 {
 			return false
 		}
 	default:

--- a/vendor/gopkg.in/square/go-jose.v2/jws.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jws.go
@@ -52,8 +52,19 @@ type JSONWebSignature struct {
 
 // Signature represents a single signature over the JWS payload and protected header.
 type Signature struct {
-	// Header fields, such as the signature algorithm
+	// Merged header fields. Contains both protected and unprotected header
+	// values. Prefer using Protected and Unprotected fields instead of this.
+	// Values in this header may or may not have been signed and in general
+	// should not be trusted.
 	Header Header
+
+	// Protected header. Values in this header were signed and
+	// will be verified as part of the signature verification process.
+	Protected Header
+
+	// Unprotected header. Values in this header were not signed
+	// and in general should not be trusted.
+	Unprotected Header
 
 	// The actual signature value
 	Signature []byte
@@ -159,6 +170,20 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
 			return nil, err
 		}
 
+		if signature.header != nil {
+			signature.Unprotected, err = signature.header.sanitized()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if signature.protected != nil {
+			signature.Protected, err = signature.protected.sanitized()
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		// As per RFC 7515 Section 4.1.3, only public keys are allowed to be embedded.
 		jwk := signature.Header.JSONWebKey
 		if jwk != nil && (!jwk.Valid() || !jwk.IsPublic()) {
@@ -186,6 +211,20 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
 		obj.Signatures[i].Header, err = obj.Signatures[i].mergedHeaders().sanitized()
 		if err != nil {
 			return nil, err
+		}
+
+		if obj.Signatures[i].header != nil {
+			obj.Signatures[i].Unprotected, err = obj.Signatures[i].header.sanitized()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if obj.Signatures[i].protected != nil {
+			obj.Signatures[i].Protected, err = obj.Signatures[i].protected.sanitized()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		obj.Signatures[i].Signature = sig.Signature.bytes()


### PR DESCRIPTION
This pulls in an upstream change that allows us to reference the Protected
header separately from the unprotected one (confusingly just called Header).

```
$ go test gopkg.in/square/go-jose.v2/...
ok      gopkg.in/square/go-jose.v2      16.625s
ok      gopkg.in/square/go-jose.v2/cipher       0.004s
?       gopkg.in/square/go-jose.v2/jose-util    [no test files]
ok      gopkg.in/square/go-jose.v2/json 2.080s
?       gopkg.in/square/go-jose.v2/jwk-keygen   [no test files]
ok      gopkg.in/square/go-jose.v2/jwt  0.128s
```