### PR TITLE
Update boulder-tools to new version.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools:2018-02-27
+        image: letsencrypt/boulder-tools:2018-03-07
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -43,7 +43,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools:2018-02-27
+        image: letsencrypt/boulder-tools:2018-03-07
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -6,10 +6,12 @@ DATESTAMP=$(date +%Y-%m-%d)
 TAG_NAME="letsencrypt/boulder-tools:$DATESTAMP"
 
 echo "Building boulder-tools image $TAG_NAME"
-docker build . -t $TAG_NAME
+docker build . -t $TAG_NAME --no-cache
 
 echo "Image ready."
 docker login
 
 echo "Pushing $TAG_NAME to Dockerhub"
 docker push $TAG_NAME
+
+sed -i "s,image: letsencrypt/boulder-tools.*,image: $TAG_NAME," ../../docker-compose.yml


### PR DESCRIPTION
This pulls in an updated Certbot repo with a fix to content-type for the
revoke method.

Also, adds a convenience replacement in tag_and_release.sh to update
docker-compose.yml.