### PR TITLE
Update github.com/cloudflare/cfssl

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,82 +12,82 @@
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/auth",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/certdb",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/certdb/dbconf",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/certdb/sql",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/config",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs7",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/csr",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/errors",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers/derhelpers",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/info",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/log",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp/config",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer/local",
-			"Comment": "1.3.1-12-g8d76cdf7",
+			"Comment": "1.3.1-12-g8d76cdf",
 			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,83 +12,83 @@
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/auth",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/certdb",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/certdb/dbconf",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/certdb/sql",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/config",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/crypto/pkcs7",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/csr",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/errors",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/helpers/derhelpers",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/info",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/log",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/ocsp/config",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/cloudflare/cfssl/signer/local",
-			"Comment": "1.3.1-8-g74f2ddc",
-			"Rev": "74f2ddc212e277519d83f942a8efd3bb9e243f16"
+			"Comment": "1.3.1-12-g8d76cdf7",
+			"Rev": "8d76cdf742f917ba01551bf7ca41f8a7f82da15a"
 		},
 		{
 			"ImportPath": "github.com/go-sql-driver/mysql",

--- a/vendor/github.com/cloudflare/cfssl/signer/local/local.go
+++ b/vendor/github.com/cloudflare/cfssl/signer/local/local.go
@@ -457,6 +457,11 @@ func (s *Signer) SignFromPrecert(precert *x509.Certificate, scts []ct.SignedCert
 	if err != nil {
 		return nil, err
 	}
+	// Serialize again as an octet string before embedding
+	serializedList, err = asn1.Marshal(serializedList)
+	if err != nil {
+		return nil, cferr.Wrap(cferr.CTError, cferr.Unknown, err)
+	}
 	sctExt := pkix.Extension{Id: signer.SCTListOID, Critical: false, Value: serializedList}
 
 	// Create the new tbsCert from precert. Do explicit copies of any slices so that we don't


### PR DESCRIPTION
Pulls in SCT list serialization fix, unblocks #3521.

```
ok  	github.com/cloudflare/cfssl/api/client	1.137s	coverage: 52.2% of statements
ok  	github.com/cloudflare/cfssl/api/crl	1.110s	coverage: 75.0% of statements
ok  	github.com/cloudflare/cfssl/api/gencrl	1.062s	coverage: 72.5% of statements
ok  	github.com/cloudflare/cfssl/api/generator	1.304s	coverage: 33.3% of statements
ok  	github.com/cloudflare/cfssl/api/info	1.133s	coverage: 84.1% of statements
ok  	github.com/cloudflare/cfssl/api/initca	1.068s	coverage: 90.5% of statements
ok  	github.com/cloudflare/cfssl/api/ocsp	1.152s	coverage: 93.8% of statements
ok  	github.com/cloudflare/cfssl/api/revoke	2.574s	coverage: 75.0% of statements
ok  	github.com/cloudflare/cfssl/api/scan	2.885s	coverage: 62.1% of statements
ok  	github.com/cloudflare/cfssl/api/sign	3.188s	coverage: 83.3% of statements
ok  	github.com/cloudflare/cfssl/api/signhandler	1.179s	coverage: 26.3% of statements
ok  	github.com/cloudflare/cfssl/auth	1.012s	coverage: 68.2% of statements
ok  	github.com/cloudflare/cfssl/bundler	15.700s	coverage: 84.5% of statements
ok  	github.com/cloudflare/cfssl/certdb/dbconf	1.016s	coverage: 84.2% of statements
ok  	github.com/cloudflare/cfssl/certdb/ocspstapling	1.415s	coverage: 69.2% of statements
ok  	github.com/cloudflare/cfssl/certdb/sql	1.248s	coverage: 70.5% of statements
ok  	github.com/cloudflare/cfssl/cli	1.013s	coverage: 61.9% of statements
ok  	github.com/cloudflare/cfssl/cli/bundle	1.012s	coverage: 0.0% of statements [no tests to run]
ok  	github.com/cloudflare/cfssl/cli/crl	1.091s	coverage: 57.8% of statements
ok  	github.com/cloudflare/cfssl/cli/gencert	11.960s	coverage: 83.6% of statements
ok  	github.com/cloudflare/cfssl/cli/gencrl	1.089s	coverage: 73.3% of statements
ok  	github.com/cloudflare/cfssl/cli/gencsr	1.064s	coverage: 70.3% of statements
ok  	github.com/cloudflare/cfssl/cli/genkey	6.415s	coverage: 70.0% of statements
ok  	github.com/cloudflare/cfssl/cli/ocsprefresh	1.060s	coverage: 64.3% of statements
ok  	github.com/cloudflare/cfssl/cli/revoke	1.033s	coverage: 88.2% of statements
ok  	github.com/cloudflare/cfssl/cli/scan	1.013s	coverage: 36.0% of statements
ok  	github.com/cloudflare/cfssl/cli/selfsign	2.029s	coverage: 73.2% of statements
ok  	github.com/cloudflare/cfssl/cli/serve	1.073s	coverage: 39.0% of statements
ok  	github.com/cloudflare/cfssl/cli/sign	1.054s	coverage: 54.8% of statements
ok  	github.com/cloudflare/cfssl/cli/version	1.012s	coverage: 100.0% of statements
ok  	github.com/cloudflare/cfssl/cmd/cfssl	1.036s	coverage: 0.0% of statements [no tests to run]
ok  	github.com/cloudflare/cfssl/cmd/cfssljson	1.018s	coverage: 3.4% of statements
ok  	github.com/cloudflare/cfssl/cmd/mkbundle	1.012s	coverage: 0.0% of statements [no tests to run]
ok  	github.com/cloudflare/cfssl/config	1.029s	coverage: 67.7% of statements
ok  	github.com/cloudflare/cfssl/crl	1.056s	coverage: 68.3% of statements
ok  	github.com/cloudflare/cfssl/csr	31.882s	coverage: 89.6% of statements
ok  	github.com/cloudflare/cfssl/errors	1.016s	coverage: 79.6% of statements
ok  	github.com/cloudflare/cfssl/helpers	1.251s	coverage: 82.8% of statements
ok  	github.com/cloudflare/cfssl/helpers/testsuite	6.974s	coverage: 65.8% of statements
ok  	github.com/cloudflare/cfssl/initca	207.580s	coverage: 73.2% of statements
ok  	github.com/cloudflare/cfssl/log	1.010s	coverage: 59.3% of statements
ok  	github.com/cloudflare/cfssl/multiroot/config	1.161s	coverage: 77.4% of statements
ok  	github.com/cloudflare/cfssl/ocsp	1.230s	coverage: 77.4% of statements
ok  	github.com/cloudflare/cfssl/revoke	1.336s	coverage: 77.9% of statements
ok  	github.com/cloudflare/cfssl/scan	1.016s	coverage: 1.1% of statements
ok  	github.com/cloudflare/cfssl/selfsign	1.059s	coverage: 70.0% of statements
ok  	github.com/cloudflare/cfssl/signer	1.014s	coverage: 19.4% of statements
ok  	github.com/cloudflare/cfssl/signer/local	3.355s	coverage: 77.9% of statements
ok  	github.com/cloudflare/cfssl/signer/remote	2.371s	coverage: 70.0% of statements
ok  	github.com/cloudflare/cfssl/signer/universal	2.163s	coverage: 67.7% of statements
ok  	github.com/cloudflare/cfssl/transport	1.012s
ok  	github.com/cloudflare/cfssl/transport/ca/localca	1.043s	coverage: 94.9% of statements
ok  	github.com/cloudflare/cfssl/transport/core	1.030s	coverage: 90.9% of statements
ok  	github.com/cloudflare/cfssl/transport/kp	1.032s	coverage: 37.1% of statements
ok  	github.com/cloudflare/cfssl/ubiquity	1.034s	coverage: 88.3% of statements
ok  	github.com/cloudflare/cfssl/whitelist	2.879s	coverage: 100.0% of statements
```