### PR TITLE
Add cumulative nanoseconds for nonce scan.

### DIFF
--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -129,7 +129,7 @@ func (ns *NonceService) minUsed() int64 {
 	}
 	latency := time.Since(s)
 	ns.stats.TimingDuration("LinearScan.Latency", latency)
-	ns.stats.Inc("LinearScan.Cumulative.Ns", int64(latency/time.Nanosecond))
+	ns.stats.Inc("LinearScan.Cumulative.Ns", int64(latency))
 	return min
 }
 

--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -127,7 +127,9 @@ func (ns *NonceService) minUsed() int64 {
 			min = t
 		}
 	}
-	ns.stats.TimingDuration("LinearScan.Latency", time.Since(s))
+	latency := time.Since(s)
+	ns.stats.TimingDuration("LinearScan.Latency", latency)
+	ns.stats.Inc("LinearScan.Cumulative.Ns", int64(latency/time.Nanosecond))
 	return min
 }
 


### PR DESCRIPTION
This will make it easier to calculate what fraction of the time we
expect to block on this.