### PR TITLE
Remove BaseURL from WFE config.

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -22,7 +22,6 @@ import (
 type config struct {
 	WFE struct {
 		cmd.ServiceConfig
-		BaseURL          string
 		ListenAddress    string
 		TLSListenAddress string
 
@@ -51,7 +50,6 @@ type config struct {
 	Syslog cmd.SyslogConfig
 
 	Common struct {
-		BaseURL    string
 		IssuerCert string
 	}
 }
@@ -114,9 +112,6 @@ func main() {
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))
 
 	logger.Info(fmt.Sprintf("WFE using key policy: %#v", kp))
-
-	// Set up paths
-	wfe.BaseURL = c.Common.BaseURL
 
 	logger.Info(fmt.Sprintf("Server running, listening on %s...\n", c.WFE.ListenAddress))
 	handler := wfe.Handler()

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -26,7 +26,6 @@ import (
 type config struct {
 	WFE struct {
 		cmd.ServiceConfig
-		BaseURL          string
 		ListenAddress    string
 		TLSListenAddress string
 
@@ -60,7 +59,6 @@ type config struct {
 	Syslog cmd.SyslogConfig
 
 	Common struct {
-		BaseURL    string
 		IssuerCert string
 	}
 }
@@ -216,9 +214,6 @@ func main() {
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))
 
 	logger.Info(fmt.Sprintf("WFE using key policy: %#v", kp))
-
-	// Set up paths
-	wfe.BaseURL = c.Common.BaseURL
 
 	logger.Info(fmt.Sprintf("Server running, listening on %s...\n", c.WFE.ListenAddress))
 	handler := wfe.Handler()

--- a/web/relative.go
+++ b/web/relative.go
@@ -1,0 +1,36 @@
+package web
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// RelativeEndpoint takes a path component of URL and constructs a new URL using
+// the host and port from the request combined the provided path.
+func RelativeEndpoint(request *http.Request, endpoint string) string {
+	var result string
+	proto := "http"
+	host := request.Host
+
+	// If the request was received via TLS, use `https://` for the protocol
+	if request.TLS != nil {
+		proto = "https"
+	}
+
+	// Allow upstream proxies  to specify the forwarded protocol. Allow this value
+	// to override our own guess.
+	if specifiedProto := request.Header.Get("X-Forwarded-Proto"); specifiedProto != "" {
+		proto = specifiedProto
+	}
+
+	// Default to "localhost" when no request.Host is provided. Otherwise requests
+	// with an empty `Host` produce results like `http:///acme/new-authz`
+	if request.Host == "" {
+		host = "localhost"
+	}
+
+	resultUrl := url.URL{Scheme: proto, Host: host, Path: endpoint}
+	result = resultUrl.String()
+
+	return result
+}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -227,38 +227,6 @@ func (wfe *WebFrontEndImpl) writeJsonResponse(response http.ResponseWriter, logE
 	return nil
 }
 
-func (wfe *WebFrontEndImpl) relativeEndpoint(request *http.Request, endpoint string) string {
-	var result string
-	proto := "http"
-	host := request.Host
-
-	// If the request was received via TLS, use `https://` for the protocol
-	if request.TLS != nil {
-		proto = "https"
-	}
-
-	// Allow upstream proxies  to specify the forwarded protocol. Allow this value
-	// to override our own guess.
-	if specifiedProto := request.Header.Get("X-Forwarded-Proto"); specifiedProto != "" {
-		proto = specifiedProto
-	}
-
-	// Default to "localhost" when no request.Host is provided. Otherwise requests
-	// with an empty `Host` produce results like `http:///acme/new-authz`
-	if request.Host == "" {
-		host = "localhost"
-	}
-
-	if wfe.BaseURL != "" {
-		result = fmt.Sprintf("%s%s", wfe.BaseURL, endpoint)
-	} else {
-		resultUrl := url.URL{Scheme: proto, Host: host, Path: endpoint}
-		result = resultUrl.String()
-	}
-
-	return result
-}
-
 const randomDirKeyExplanationLink = "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417"
 
 func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory map[string]interface{}) ([]byte, error) {
@@ -266,10 +234,8 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 	// relative-ized result
 	relativeDir := make(map[string]interface{}, len(directory))
 
-	// Copy each entry of the provided directory into the new relative map. If
-	// `wfe.BaseURL` != "", use the old behaviour and prefix each endpoint with
-	// the `BaseURL`. Otherwise, prefix each endpoint using the request protocol
-	// & host.
+	// Copy each entry of the provided directory into the new relative map,
+	// prefixing it with the request protocol and host.
 	for k, v := range directory {
 		if v == randomDirKeyExplanationLink {
 			relativeDir[k] = v
@@ -278,7 +244,7 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 		switch v := v.(type) {
 		case string:
 			// Only relative-ize top level string values, e.g. not the "meta" element
-			relativeDir[k] = wfe.relativeEndpoint(request, v)
+			relativeDir[k] = web.RelativeEndpoint(request, v)
 		default:
 			// If it isn't a string, put it into the results unmodified
 			relativeDir[k] = v
@@ -593,7 +559,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *web.R
 	}
 
 	if existingReg, err := wfe.SA.GetRegistrationByKey(ctx, key); err == nil {
-		response.Header().Set("Location", wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, existingReg.ID)))
+		response.Header().Set("Location", web.RelativeEndpoint(request, fmt.Sprintf("%s%d", regPath, existingReg.ID)))
 		// TODO(#595): check for missing registration err
 		wfe.sendError(response, logEvent, probs.Conflict("Registration key is already in use"), err)
 		return
@@ -634,10 +600,10 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *web.R
 
 	// Use an explicitly typed variable. Otherwise `go vet' incorrectly complains
 	// that reg.ID is a string being passed to %d.
-	regURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, reg.ID))
+	regURL := web.RelativeEndpoint(request, fmt.Sprintf("%s%d", regPath, reg.ID))
 
 	response.Header().Add("Location", regURL)
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newAuthzPath), "next"))
+	response.Header().Add("Link", link(web.RelativeEndpoint(request, newAuthzPath), "next"))
 	if len(wfe.SubscriberAgreementURL) > 0 {
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
 	}
@@ -684,11 +650,11 @@ func (wfe *WebFrontEndImpl) NewAuthorization(ctx context.Context, logEvent *web.
 	logEvent.Extra["AuthzID"] = authz.ID
 
 	// Make a URL for this authz, then blow away the ID and RegID before serializing
-	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
+	authzURL := web.RelativeEndpoint(request, authzPath+string(authz.ID))
 	wfe.prepAuthorizationForDisplay(request, &authz)
 
 	response.Header().Add("Location", authzURL)
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newCertPath), "next"))
+	response.Header().Add("Link", link(web.RelativeEndpoint(request, newCertPath), "next"))
 
 	err = wfe.writeJsonResponse(response, logEvent, http.StatusCreated, authz)
 	if err != nil {
@@ -910,7 +876,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 		return
 	}
 	serial := parsedCertificate.SerialNumber
-	certURL := wfe.relativeEndpoint(request, certPath+core.SerialToString(serial))
+	certURL := web.RelativeEndpoint(request, certPath+core.SerialToString(serial))
 
 	// TODO Content negotiation
 	response.Header().Add("Location", certURL)
@@ -920,7 +886,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 			return
 		}
 	} else {
-		relativeIssuerPath := wfe.relativeEndpoint(request, issuerPath)
+		relativeIssuerPath := web.RelativeEndpoint(request, issuerPath)
 		response.Header().Add("Link", link(relativeIssuerPath, "up"))
 	}
 	response.Header().Set("Content-Type", "application/pkix-cert")
@@ -998,7 +964,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 // the client by filling in its URI field and clearing its ID field.
 func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz core.Authorization, challenge *core.Challenge) {
 	// Update the challenge URI to be relative to the HTTP request Host
-	challenge.URI = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s/%d", challengePath, authz.ID, challenge.ID))
+	challenge.URI = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%d", challengePath, authz.ID, challenge.ID))
 	// Ensure the challenge ID isn't written. 0 is considered "empty" for the purpose of the JSON omitempty tag.
 	challenge.ID = 0
 
@@ -1033,7 +999,7 @@ func (wfe *WebFrontEndImpl) getChallenge(
 
 	wfe.prepChallengeForDisplay(request, authz, challenge)
 
-	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
+	authzURL := web.RelativeEndpoint(request, authzPath+string(authz.ID))
 	response.Header().Add("Location", challenge.URI)
 	response.Header().Add("Link", link(authzURL, "up"))
 
@@ -1097,7 +1063,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	challenge := updatedAuthorization.Challenges[challengeIndex]
 	wfe.prepChallengeForDisplay(request, authz, &challenge)
 
-	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
+	authzURL := web.RelativeEndpoint(request, authzPath+string(authz.ID))
 	response.Header().Add("Location", challenge.URI)
 	response.Header().Add("Link", link(authzURL, "up"))
 
@@ -1188,7 +1154,7 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *web.Requ
 		return
 	}
 
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newAuthzPath), "next"))
+	response.Header().Add("Link", link(web.RelativeEndpoint(request, newAuthzPath), "next"))
 	if len(wfe.SubscriberAgreementURL) > 0 {
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
 	}
@@ -1268,7 +1234,7 @@ func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.Req
 
 	wfe.prepAuthorizationForDisplay(request, &authz)
 
-	response.Header().Add("Link", link(wfe.relativeEndpoint(request, newCertPath), "next"))
+	response.Header().Add("Link", link(web.RelativeEndpoint(request, newCertPath), "next"))
 
 	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, authz)
 	if err != nil {
@@ -1318,7 +1284,7 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 			return
 		}
 	} else {
-		relativeIssuerPath := wfe.relativeEndpoint(request, issuerPath)
+		relativeIssuerPath := web.RelativeEndpoint(request, issuerPath)
 		response.Header().Add("Link", link(relativeIssuerPath, "up"))
 	}
 	response.WriteHeader(http.StatusOK)
@@ -1441,7 +1407,7 @@ func (wfe *WebFrontEndImpl) KeyRollover(ctx context.Context, logEvent *web.Reque
 		return
 	}
 
-	if wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", regPath, reg.ID)) != rolloverRequest.Account {
+	if web.RelativeEndpoint(request, fmt.Sprintf("%s%d", regPath, reg.ID)) != rolloverRequest.Account {
 		wfe.sendError(response, logEvent, probs.Malformed("Incorrect account URL provided in payload"), nil)
 		return
 	}

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -451,14 +450,8 @@ func replaceRandomKey(b []byte) []byte {
 }
 
 func assertJSONEquals(t *testing.T, got, expected string) {
-	var gotMap, expectedMap map[string]interface{}
-	err := json.Unmarshal([]byte(got), &gotMap)
-	test.AssertNotError(t, err, "failed to parse received JSON")
-	err = json.Unmarshal([]byte(expected), &expectedMap)
-	test.AssertNotError(t, err, "failed to parse expected JSON")
-	if !reflect.DeepEqual(gotMap, expectedMap) {
-		t.Fatalf("JSON response differed from expected:\n Got: %s, Expected: %s", got, expected)
-	}
+	t.Helper()
+	test.AssertUnmarshaledEquals(t, got, expected)
 }
 
 func TestHandleFunc(t *testing.T) {
@@ -708,12 +701,7 @@ func TestIndex(t *testing.T) {
 }
 
 func TestDirectory(t *testing.T) {
-	// Note: using `wfe.BaseURL` to test the non-relative /directory behaviour
-	// This tests to ensure the `Host` in the following `http.Request` is not
-	// used.by setting `BaseURL` using `localhost`, sending `127.0.0.1` in the Host,
-	// and expecting `localhost` in the JSON result.
 	wfe, _ := setupWFE(t)
-	wfe.BaseURL = "http://localhost:4300"
 	mux := wfe.Handler()
 
 	responseWriter := httptest.NewRecorder()
@@ -722,7 +710,7 @@ func TestDirectory(t *testing.T) {
 	mux.ServeHTTP(responseWriter, &http.Request{
 		Method: "GET",
 		URL:    url,
-		Host:   "127.0.0.1:4300",
+		Host:   "localhost:4300",
 	})
 	test.AssertEquals(t, responseWriter.Header().Get("Content-Type"), "application/json")
 	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
@@ -734,7 +722,7 @@ func TestDirectory(t *testing.T) {
 	mux.ServeHTTP(responseWriter, &http.Request{
 		Method: "GET",
 		URL:    url,
-		Host:   "127.0.0.1:4300",
+		Host:   "localhost:4300",
 	})
 	test.AssertEquals(t, responseWriter.Header().Get("Content-Type"), "application/json")
 	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
@@ -750,7 +738,7 @@ func TestDirectory(t *testing.T) {
 	mux.ServeHTTP(responseWriter, &http.Request{
 		Method: "GET",
 		URL:    url,
-		Host:   "127.0.0.1:4300",
+		Host:   "localhost:4300",
 		Header: headers,
 	})
 	test.AssertEquals(t, responseWriter.Header().Get("Content-Type"), "application/json")
@@ -760,7 +748,6 @@ func TestDirectory(t *testing.T) {
 
 func TestRandomDirectoryKey(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.BaseURL = "http://localhost:4300"
 
 	responseWriter := httptest.NewRecorder()
 	url, _ := url.Parse("/directory")

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -374,7 +374,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 
 	header := jws.Signatures[0].Header
 	accountURL := header.KeyID
-	prefix := wfe.relativeEndpoint(request, acctPath)
+	prefix := web.RelativeEndpoint(request, acctPath)
 	accountIDStr := strings.TrimPrefix(accountURL, prefix)
 	// Convert the account ID string to an int64 for use with the SA's
 	// GetRegistration RPC

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"path"
 	"regexp"
 	"strconv"
@@ -70,9 +69,6 @@ type WebFrontEndImpl struct {
 	clk   clock.Clock
 	stats wfe2Stats
 	scope metrics.Scope
-
-	// URL configuration parameters
-	BaseURL string
 
 	// Issuer certificate (DER) for /acme/issuer-cert
 	IssuerCert []byte
@@ -249,27 +245,6 @@ func requestProto(request *http.Request) string {
 	return proto
 }
 
-func (wfe *WebFrontEndImpl) relativeEndpoint(request *http.Request, endpoint string) string {
-	var result string
-	host := request.Host
-	proto := requestProto(request)
-
-	// Default to "localhost" when no request.Host is provided. Otherwise requests
-	// with an empty `Host` produce results like `http:///acme/new-authz`
-	if request.Host == "" {
-		host = "localhost"
-	}
-
-	if wfe.BaseURL != "" {
-		result = fmt.Sprintf("%s%s", wfe.BaseURL, endpoint)
-	} else {
-		resultUrl := url.URL{Scheme: proto, Host: host, Path: endpoint}
-		result = resultUrl.String()
-	}
-
-	return result
-}
-
 const randomDirKeyExplanationLink = "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417"
 
 func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory map[string]interface{}) ([]byte, error) {
@@ -277,10 +252,8 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 	// relative-ized result
 	relativeDir := make(map[string]interface{}, len(directory))
 
-	// Copy each entry of the provided directory into the new relative map. If
-	// `wfe.BaseURL` != "", use the old behaviour and prefix each endpoint with
-	// the `BaseURL`. Otherwise, prefix each endpoint using the request protocol
-	// & host.
+	// Copy each entry of the provided directory into the new relative map,
+	// prefixing it with the request protocol and host.
 	for k, v := range directory {
 		if v == randomDirKeyExplanationLink {
 			relativeDir[k] = v
@@ -289,7 +262,7 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 		switch v := v.(type) {
 		case string:
 			// Only relative-ize top level string values, e.g. not the "meta" element
-			relativeDir[k] = wfe.relativeEndpoint(request, v)
+			relativeDir[k] = web.RelativeEndpoint(request, v)
 		default:
 			// If it isn't a string, put it into the results unmodified
 			relativeDir[k] = v
@@ -466,7 +439,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, key)
 	if err == nil {
 		response.Header().Set("Location",
-			wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
+			web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
 		response.WriteHeader(http.StatusOK)
 		return
 	} else if !berrors.Is(err, berrors.NotFound) {
@@ -515,7 +488,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	addRequesterHeader(response, acct.ID)
 	logEvent.Contacts = acct.Contact
 
-	acctURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, acct.ID))
+	acctURL := web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, acct.ID))
 
 	response.Header().Add("Location", acctURL)
 	if len(wfe.SubscriberAgreementURL) > 0 {
@@ -841,7 +814,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 // the client by filling in its URL field and clearing its ID and URI fields.
 func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz core.Authorization, challenge *core.Challenge) {
 	// Update the challenge URL to be relative to the HTTP request Host
-	challenge.URL = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s/%d", challengePath, authz.ID, challenge.ID))
+	challenge.URL = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%d", challengePath, authz.ID, challenge.ID))
 	// Ensure the challenge URI and challenge ID aren't written by setting them to
 	// values that the JSON omitempty tag considers empty
 	challenge.URI = ""
@@ -897,7 +870,7 @@ func (wfe *WebFrontEndImpl) getChallenge(
 
 	wfe.prepChallengeForDisplay(request, authz, challenge)
 
-	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
+	authzURL := web.RelativeEndpoint(request, authzPath+string(authz.ID))
 	response.Header().Add("Location", challenge.URL)
 	response.Header().Add("Link", link(authzURL, "up"))
 
@@ -960,7 +933,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	challenge := updatedAuthorization.Challenges[challengeIndex]
 	wfe.prepChallengeForDisplay(request, authz, &challenge)
 
-	authzURL := wfe.relativeEndpoint(request, authzPath+string(authz.ID))
+	authzURL := web.RelativeEndpoint(request, authzPath+string(authz.ID))
 	response.Header().Add("Location", challenge.URL)
 	response.Header().Add("Link", link(authzURL, "up"))
 
@@ -1379,7 +1352,7 @@ func (wfe *WebFrontEndImpl) KeyRollover(
 	// Check that the new key isn't already being used for an existing account
 	if existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, &newKey); err == nil {
 		response.Header().Set("Location",
-			wfe.relativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
+			web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
 		wfe.sendError(response, logEvent,
 			probs.Conflict("New key is already in use for a different account"), err)
 		return
@@ -1444,7 +1417,7 @@ func (wfe *WebFrontEndImpl) orderToOrderJSON(request *http.Request, order *corep
 	for i, name := range order.Names {
 		idents[i] = core.AcmeIdentifier{Type: core.IdentifierDNS, Value: name}
 	}
-	finalizeURL := wfe.relativeEndpoint(request,
+	finalizeURL := web.RelativeEndpoint(request,
 		fmt.Sprintf("%s%d/%d", finalizeOrderPath, *order.RegistrationID, *order.Id))
 	respObj := orderJSON{
 		Status:         core.AcmeStatus(*order.Status),
@@ -1464,10 +1437,10 @@ func (wfe *WebFrontEndImpl) orderToOrderJSON(request *http.Request, order *corep
 		respObj.Error.Type = probs.V2ErrorNS + respObj.Error.Type
 	}
 	for i, authzID := range order.Authorizations {
-		respObj.Authorizations[i] = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", authzPath, authzID))
+		respObj.Authorizations[i] = web.RelativeEndpoint(request, fmt.Sprintf("%s%s", authzPath, authzID))
 	}
 	if respObj.Status == core.StatusValid {
-		certURL := wfe.relativeEndpoint(request,
+		certURL := web.RelativeEndpoint(request,
 			fmt.Sprintf("%s%s", certPath, *order.CertificateSerial))
 		respObj.Certificate = certURL
 	}
@@ -1535,7 +1508,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		return
 	}
 
-	orderURL := wfe.relativeEndpoint(request,
+	orderURL := web.RelativeEndpoint(request,
 		fmt.Sprintf("%s%d/%d", orderPath, acct.ID, *order.Id))
 	response.Header().Set("Location", orderURL)
 
@@ -1693,7 +1666,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 		return
 	}
 
-	orderURL := wfe.relativeEndpoint(request,
+	orderURL := web.RelativeEndpoint(request,
 		fmt.Sprintf("%s%d/%d", orderPath, acct.ID, *updatedOrder.Id))
 	response.Header().Set("Location", orderURL)
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -676,13 +676,7 @@ func (fr fakeRand) Read(p []byte) (int, error) {
 }
 
 func TestDirectory(t *testing.T) {
-	// Note: `TestDirectory` sets the `wfe.BaseURL` specifically to test the
-	// that it overrides the relative /directory behaviour.
-	// This ensures the `Host` value of `127.0.0.1` in the following
-	// `http.Request` is not used in the response URLs that are tested against
-	// `http://localhost:4300`
 	wfe, _ := setupWFE(t)
-	wfe.BaseURL = "http://localhost:4300"
 	mux := wfe.Handler()
 	core.RandReader = fakeRand{}
 	defer func() { core.RandReader = rand.Reader }()
@@ -706,7 +700,7 @@ func TestDirectory(t *testing.T) {
 	req := &http.Request{
 		Method: "GET",
 		URL:    url,
-		Host:   "127.0.0.1:4300",
+		Host:   "localhost:4300",
 	}
 	// Serve the /directory response for this request into a recorder
 	responseWriter := httptest.NewRecorder()


### PR DESCRIPTION
For a long time now the WFE has generated URLs based on the incoming
request rather than a hardcoded BaseURL. BaseURL is no longer set in the
prod configs.

This also allows factoring out relativeEndpoint into the web package.