### PR TITLE
Increase the MySQL container `max_connections`.

### DIFF
--- a/test/create_db.sh
+++ b/test/create_db.sh
@@ -14,6 +14,11 @@ fi
 # to the format we use in production, MIXED.
 mysql $dbconn -e "SET GLOBAL binlog_format = 'MIXED';"
 
+# MariaDB sets the default @@max_connections value to 100. The SA alone is
+# configured to use up to 100 connections. We increase the max connections here
+# to give headroom for other components (ocsp-updater for example).
+mysql $dbconn -e "SET GLOBAL max_connections = 500;"
+
 for dbenv in $DBENVS; do
   db="boulder_sa_${dbenv}"
 


### PR DESCRIPTION
By default the MariaDB/MySQL container starts with a global max
connections limit of 100. The SA is configured in `test/config` and
`test/config-next` to use 100 connections. This doesn't leave any
overhead for `ocsp-updater` connections and can be reached under load
pretty easily.

This commit adjusts the global max connections setting from
`test/create_db.sh`, setting it to a more generous `500` instead of the
default `100`.