### PR TITLE
Fix nil panic in mailer logger setup when DB conn fails.

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -474,8 +474,8 @@ func main() {
 	dbURL, err := c.Mailer.DBConfig.URL()
 	cmd.FailOnError(err, "Couldn't load DB URL")
 	dbMap, err := sa.NewDbMap(dbURL, c.Mailer.DBConfig.MaxDBConns)
-	sa.SetSQLDebug(dbMap, logger)
 	cmd.FailOnError(err, "Could not connect to database")
+	sa.SetSQLDebug(dbMap, logger)
 	go sa.ReportDbConnCount(dbMap, scope)
 
 	tlsConfig, err := c.Mailer.TLS.Load()


### PR DESCRIPTION
Prior to this commit, if the expiration-mailer database configuration is invalid, or the database is unreachable, `cmd/expiration-mailer/main.go`'s `main()` function tries to call `sa.SetSQLDebug(dbMap, logger)` before erroring from the DB initialization failure. This causes a nil panic.

This commit changes the order of two lines such that `sa.SetSQLDebug` is only called when there was no db setup error.

Thanks to @pgporada for flagging.