### PR TITLE
Overlapping wildcard errors are 400, not 500.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config
+            BOULDER_CONFIG_DIR: test/config-next
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
           - /tmp:/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config-next
+            BOULDER_CONFIG_DIR: test/config
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
           - /tmp:/tmp

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedUseAIAIssuerURLReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentType"
+const _FeatureFlag_name = "unusedUseAIAIssuerURLReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcards"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 21, 38, 60, 69, 88, 103, 124, 147, 165, 174, 193, 204, 224}
+var _FeatureFlag_index = [...]uint8{0, 6, 21, 38, 60, 69, 88, 103, 124, 147, 165, 174, 193, 204, 224, 251}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -32,24 +32,27 @@ const (
 	// Return errors to ACMEv2 clients that do not send the correct JWS
 	// Content-Type header
 	EnforceV2ContentType
+	// Reject new-orders that contain a hostname redundant with a wildcard.
+	EnforceOverlappingWildcards
 )
 
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
-	unused:                  false,
-	UseAIAIssuerURL:         false,
-	ReusePendingAuthz:       false,
-	CountCertificatesExact:  false,
-	IPv6First:               false,
-	AllowRenewalFirstRL:     false,
-	WildcardDomains:         false,
-	EnforceChallengeDisable: false, // deprecated
-	TLSSNIRevalidation:      false,
-	EmbedSCTs:               false,
-	CancelCTSubmissions:     true,
-	VAChecksGSB:             false,
-	EnforceV2ContentType:    false,
-	ForceConsistentStatus:   false,
+	unused:                      false,
+	UseAIAIssuerURL:             false,
+	ReusePendingAuthz:           false,
+	CountCertificatesExact:      false,
+	IPv6First:                   false,
+	AllowRenewalFirstRL:         false,
+	WildcardDomains:             false,
+	EnforceChallengeDisable:     false, // deprecated
+	TLSSNIRevalidation:          false,
+	EmbedSCTs:                   false,
+	CancelCTSubmissions:         true,
+	VAChecksGSB:                 false,
+	EnforceV2ContentType:        false,
+	ForceConsistentStatus:       false,
+	EnforceOverlappingWildcards: false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1949,7 +1949,8 @@ func wildcardOverlap(dnsNames []string) error {
 		labels := strings.Split(name, ".")
 		labels[0] = "*"
 		if nameMap[strings.Join(labels, ".")] {
-			return fmt.Errorf("Domain name %q is redundant with a wildcard domain in the same request. Remove one or the other from the certificate request.", name)
+			return berrors.MalformedError(
+				"Domain name %q is redundant with a wildcard domain in the same request. Remove one or the other from the certificate request.", name)
 		}
 	}
 	return nil

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1728,8 +1728,10 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		}
 	}
 
-	if err := wildcardOverlap(order.Names); err != nil {
-		return nil, err
+	if features.Enabled(features.EnforceOverlappingWildcards) {
+		if err := wildcardOverlap(order.Names); err != nil {
+			return nil, err
+		}
 	}
 
 	// See if there is an existing, pending, unexpired order that can be reused

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3348,6 +3348,7 @@ func TestCTPolicyMeasurements(t *testing.T) {
 }
 
 func TestWildcardOverlap(t *testing.T) {
+	_ = features.Set(map[string]bool{"EnforceOverlappingWildcards": true})
 	err := wildcardOverlap([]string{
 		"*.example.com",
 		"*.example.net",

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3363,6 +3363,13 @@ func TestWildcardOverlap(t *testing.T) {
 	if err == nil {
 		t.Errorf("Got no error, expected one")
 	}
+	berr, ok := err.(*berrors.BoulderError)
+	if !ok {
+		t.Errorf("Error was wrong type: %T", err)
+	}
+	if berr.Type != berrors.Malformed {
+		t.Errorf("Error was wrong BoulderError type: %d", berr.Type)
+	}
 	err = wildcardOverlap([]string{
 		"*.foo.example.com",
 		"*.example.net",

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3349,6 +3349,7 @@ func TestCTPolicyMeasurements(t *testing.T) {
 
 func TestWildcardOverlap(t *testing.T) {
 	_ = features.Set(map[string]bool{"EnforceOverlappingWildcards": true})
+	defer features.Reset()
 	err := wildcardOverlap([]string{
 		"*.example.com",
 		"*.example.net",

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -47,6 +47,7 @@
       "ReusePendingAuthz": true,
       "CancelCTSubmissions": false,
       "EmbedSCTs": true,
+      "EnforceOverlappingWildcards": true,
       "VAChecksGSB": true
     },
     "CTLogGroups2": [

--- a/test/integration-test-v2.py
+++ b/test/integration-test-v2.py
@@ -54,7 +54,7 @@ def main():
     test_revoke_by_authz()
     test_revoke_by_privkey()
     test_order_finalize_early()
-    test_overlap_wildcard()
+    test_bad_overlap_wildcard()
 
     test_loadgeneration()
 

--- a/test/integration-test-v2.py
+++ b/test/integration-test-v2.py
@@ -54,6 +54,7 @@ def main():
     test_revoke_by_authz()
     test_revoke_by_privkey()
     test_order_finalize_early()
+    test_overlap_wildcard()
 
     test_loadgeneration()
 
@@ -139,6 +140,10 @@ def test_wildcard_authz_reuse():
         if authz.body.status != Status("pending"):
             raise Exception("order for %s included a non-pending authorization (status: %s) from a previous HTTP-01 order" %
                     ((domains), str(authz.body.status)))
+
+def test_overlap_wildcard():
+    chisel2.expect_problem("urn:acme:error:malformed",
+        lambda: auth_and_issue(["*.example.com", "www.example.com"]))
 
 def test_order_reuse_failed_authz():
     """

--- a/test/integration-test-v2.py
+++ b/test/integration-test-v2.py
@@ -141,8 +141,8 @@ def test_wildcard_authz_reuse():
             raise Exception("order for %s included a non-pending authorization (status: %s) from a previous HTTP-01 order" %
                     ((domains), str(authz.body.status)))
 
-def test_overlap_wildcard():
-    chisel2.expect_problem("urn:acme:error:malformed",
+def test_bad_overlap_wildcard():
+    chisel2.expect_problem("urn:ietf:params:acme:error:malformed",
         lambda: auth_and_issue(["*.example.com", "www.example.com"]))
 
 def test_order_reuse_failed_authz():


### PR DESCRIPTION
Return a malformed error for these requests. Also add an integration test.

Fixes #3558 