### PR TITLE
Enable WFE2 "EnforceV2ContentType" flag in config-next.

### DIFF
--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -32,7 +32,9 @@
       "http://boulder:4430/acme/issuer-cert": [ "test/test-ca2.pem" ],
       "http://127.0.0.1:4000/acme/issuer-cert": [ "test/test-ca2.pem" ]
     },
-    "features": {}
+    "features": {
+      "EnforceV2ContentType": true
+    }
   },
 
   "syslog": {


### PR DESCRIPTION
We shipped this feature flag disabled because at the time Certbot's acme
module had a bug with revocation that sent the wrong content-type. That
has been fixed upstream and the current boulder-tools image has the fix.
We should be able to turn this flag on now for config-next without
breaking tests.