### PR TITLE
Send precerts to informational logs if feature is enabled

### DIFF
--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -112,12 +112,14 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER) (core.SCTDE
 			results <- result{sct: sct}
 		}(i, g)
 	}
+	isPrecert := features.Enabled(features.EmbedSCTs)
 	for _, log := range ctp.informational {
 		go func(l cmd.LogDescription) {
 			_, _ = ctp.pub.SubmitToSingleCTWithResult(subCtx, &pubpb.Request{
 				LogURL:       &l.URI,
 				LogPublicKey: &l.Key,
 				Der:          cert,
+				Precert:      &isPrecert,
 			})
 		}(log)
 	}

--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -115,12 +115,15 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER) (core.SCTDE
 	isPrecert := features.Enabled(features.EmbedSCTs)
 	for _, log := range ctp.informational {
 		go func(l cmd.LogDescription) {
-			_, _ = ctp.pub.SubmitToSingleCTWithResult(subCtx, &pubpb.Request{
+			_, err := ctp.pub.SubmitToSingleCTWithResult(subCtx, &pubpb.Request{
 				LogURL:       &l.URI,
 				LogPublicKey: &l.Key,
 				Der:          cert,
 				Precert:      &isPrecert,
 			})
+			if err != nil {
+				ctp.log.Warning(fmt.Sprintf("ct submission to informational log %q failed: %s", l.URI, err))
+			}
 		}(log)
 	}
 


### PR DESCRIPTION
Because we don't log errors for informational logs this never got caught because we jus threw the errors away. In this change I've just fixed the problem but this suggests we might want to log errors from informational logs... thoughts?