### PR TITLE
Run v2 integration tests as part of v1 tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ matrix:
     - env: RUN="unit"
     - env: RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
     - env: RUN="coverage"
-    - env: RUN="acme-v2" BOULDER_CONFIG_DIR="test/config-next"
   fast_finish: true
   allow_failures:
     - env: RUN="coverage"

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ fi
 # defaults, because we don't want to run it locally (would be too disruptive to
 # GOPATH). We also omit coverage by default on local runs because it generates
 # artifacts on disk that aren't needed.
-RUN=${RUN:-vet fmt migrations unit integration acme-v2 errcheck dashlint}
+RUN=${RUN:-vet fmt migrations unit integration errcheck dashlint}
 
 # The list of segments to hard fail on, as opposed to continuing to the end of
 # the unit tests before failing.
@@ -187,12 +187,6 @@ if [[ "$RUN" =~ "integration" ]] ; then
   DIRECTORY=http://boulder:4000/directory \
     run python2 test/integration-test.py --chisel --load
   end_context #integration
-fi
-
-if [[ "$RUN" =~ "acme-v2" ]] ; then
-  source ${CERTBOT_PATH:-/certbot}/${VENV_NAME:-venv}/bin/activate
-  DIRECTORY=https://boulder:4431/directory \
-    run python2 test/integration-test-v2.py
 fi
 
 # Run godep-restore (happens only in Travis) to check that the hashes in

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -34,9 +34,9 @@ from acme import standalone
 
 logging.basicConfig()
 logger = logging.getLogger()
-logger.setLevel(int(os.getenv('LOGLEVEL', 0)))
+logger.setLevel(int(os.getenv('LOGLEVEL', 20)))
 
-DIRECTORY = os.getenv('DIRECTORY', 'http://localhost:4001/directory')
+DIRECTORY_V2 = os.getenv('DIRECTORY_V2', 'http://localhost:4001/directory')
 ACCEPTABLE_TOS = os.getenv('ACCEPTABLE_TOS',"https://boulder:4431/terms/v7")
 PORT = os.getenv('PORT', '5002')
 
@@ -51,7 +51,7 @@ def make_client(email=None):
     key = josepy.JWKRSA(key=rsa.generate_private_key(65537, 2048, default_backend()))
 
     net = acme_client.ClientNetwork(key, user_agent="Boulder integration tester")
-    directory = messages.Directory.from_json(net.get(DIRECTORY).json())
+    directory = messages.Directory.from_json(net.get(DIRECTORY_V2).json())
     client = acme_client.ClientV2(directory, net)
     tos = client.directory.meta.terms_of_service
     if tos == ACCEPTABLE_TOS:
@@ -65,7 +65,7 @@ def get_chall(authz, typ):
     for chall_body in authz.body.challenges:
         if isinstance(chall_body.chall, typ):
             return chall_body
-    raise Exception("No %s challenge found" % typ)
+    raise Exception("No %s challenge found" % typ.typ)
 
 class ValidationError(Exception):
     """An error that occurs during challenge validation."""

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -560,12 +560,9 @@ def run_loadtest():
             -results %s" % latency_data_file)
 
     latency_data_file = "%s/v2-integration-test-latency.json" % tempdir
-    subprocess.check_output(
-        "./bin/load-generator \
+    run("./bin/load-generator \
             -config test/load-generator/config/v2-integration-test-config.json\
-            -results %s" % latency_data_file,
-        shell=True,
-        stderr=subprocess.STDOUT)
+            -results %s" % latency_data_file)
 
 def run_cert_checker():
     run("./bin/cert-checker -config %s/cert-checker.json" % default_config_dir)

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -22,6 +22,7 @@ import startservers
 
 import chisel
 from chisel import auth_and_issue
+from v2_integration import *
 
 import requests
 import OpenSSL
@@ -491,9 +492,6 @@ def test_sct_embedding():
         if sct.entry_type != x509.certificate_transparency.LogEntryType.PRE_CERTIFICATE:
             raise Exception("SCT contains wrong entry type")
 
-def test_cert_checker():
-    run("./bin/cert-checker -config %s/cert-checker.json" % default_config_dir)
-
 exit_status = 1
 tempdir = tempfile.mkdtemp()
 
@@ -541,6 +539,8 @@ def main():
     if args.custom:
         run(args.custom)
 
+    run_cert_checker()
+
     if not startservers.check():
         raise Exception("startservers.check failed")
 
@@ -553,11 +553,22 @@ def run_chisel(test_case_filter):
         value()
 
 def run_loadtest():
-    # Run the load generator
-    latency_data_file = "/tmp/integration-test-latency.json"
+    """Run the load generator for v1 and v2."""
+    latency_data_file = "%s/integration-test-latency.json" % tempdir
     run("./bin/load-generator \
             -config test/load-generator/config/integration-test-config.json\
             -results %s" % latency_data_file)
+
+    latency_data_file = "%s/v2-integration-test-latency.json" % tempdir
+    subprocess.check_output(
+        "./bin/load-generator \
+            -config test/load-generator/config/v2-integration-test-config.json\
+            -results %s" % latency_data_file,
+        shell=True,
+        stderr=subprocess.STDOUT)
+
+def run_cert_checker():
+    run("./bin/cert-checker -config %s/cert-checker.json" % default_config_dir)
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
- Remove acme-v2 test phase.
- Rename integration-test-v2.py to v2_integration, so it can be imported.
- Import all symbols from v2_integration before running test_*.
- In chisel2:
  - Rename DIRECTORY so it doesn't collide.
  - Incidental logging and error fixes.
- Merge v1 and v2 load testing into a single function.
- Run cert-checker just once, after all other test cases.
- In v2_integration:
  - Remove unnecessary imports.
  - Import chisel2 methods in the chisel2 namespace so they don't
    collide with chisel methods.
  - Remove main and shutdown code.
