### PR TITLE
Add check for correct time in SCTs.

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -321,7 +321,7 @@ func (pub *Impl) singleLogSubmit(
 		return nil, fmt.Errorf("SCT Timestamp was too far in the future (%s)", timestamp)
 	}
 	// For regular certificates, we could get an old SCT, but that shouldn't
-	// happen for SCTs.
+	// happen for precertificates.
 	if isPrecert && timestamp.Sub(time.Now()) < -10*time.Minute {
 		return nil, fmt.Errorf("SCT Timestamp was too far in the past (%s)", timestamp)
 	}
@@ -350,7 +350,7 @@ func sctToInternal(sct *ct.SignedCertificateTimestamp, serial string) core.Signe
 
 // CreateTestingSignedSCT is used by both the publisher tests and ct-test-serv, which is
 // why it is exported. It creates a signed SCT based on the provided chain.
-func CreateTestingSignedSCT(req []string, k *ecdsa.PrivateKey, precert bool) []byte {
+func CreateTestingSignedSCT(req []string, k *ecdsa.PrivateKey, precert bool, timestamp time.Time) []byte {
 	chain := make([]ct.ASN1Cert, len(req))
 	for i, str := range req {
 		b, err := base64.StdEncoding.DecodeString(str)
@@ -373,11 +373,11 @@ func CreateTestingSignedSCT(req []string, k *ecdsa.PrivateKey, precert bool) []b
 	// Sign the SCT
 	rawKey, _ := x509.MarshalPKIXPublicKey(&k.PublicKey)
 	logID := sha256.Sum256(rawKey)
-	timestamp := uint64(time.Now().UnixNano()) / 1e6
+	timestampMillis := uint64(timestamp.UnixNano()) / 1e6
 	serialized, _ := ct.SerializeSCTSignatureInput(ct.SignedCertificateTimestamp{
 		SCTVersion: ct.V1,
 		LogID:      ct.LogID{KeyID: logID},
-		Timestamp:  timestamp,
+		Timestamp:  timestampMillis,
 	}, ct.LogEntry{Leaf: *leaf})
 	hashed := sha256.Sum256(serialized)
 	var ecdsaSig struct {
@@ -398,7 +398,7 @@ func CreateTestingSignedSCT(req []string, k *ecdsa.PrivateKey, precert bool) []b
 	}
 	jsonSCTObj.SCTVersion = ct.V1
 	jsonSCTObj.ID = base64.StdEncoding.EncodeToString(logID[:])
-	jsonSCTObj.Timestamp = timestamp
+	jsonSCTObj.Timestamp = timestampMillis
 	ds := ct.DigitallySigned{
 		Algorithm: cttls.SignatureAndHashAlgorithm{
 			Hash:      cttls.SHA256,

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -72,7 +72,7 @@ func (is *integrationSrv) handler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(publisher.CreateTestingSignedSCT(addChainReq.Chain, is.key, precert))
+		w.Write(publisher.CreateTestingSignedSCT(addChainReq.Chain, is.key, precert, time.Now()))
 	case "/submissions":
 		if r.Method != "GET" {
 			http.NotFound(w, r)

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -490,6 +490,10 @@ def test_sct_embedding():
             raise Exception("SCT contains wrong version")
         if sct.entry_type != x509.certificate_transparency.LogEntryType.PRE_CERTIFICATE:
             raise Exception("SCT contains wrong entry type")
+        delta = sct.timestamp - datetime.datetime.now()
+        if abs(delta) > datetime.timedelta(hours=1):
+            raise Exception("Delta between SCT timestamp and now was too great "
+                "%s vs %s (%s)" % (sct.timestamp, datetime.datetime.now(), delta))
 
 def test_cert_checker():
     run("./bin/cert-checker -config %s/cert-checker.json" % default_config_dir)


### PR DESCRIPTION
In publisher and in the integration test, check that SCTs are in a
reasonable range. Also, update CreateTestingSignedSCT (used by
ct-test-srv) to produce SCTs correctly with a timetamp in Unix epoch
milliseconds.