### PR TITLE
Audit log account ID rather than full account.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -777,13 +777,13 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *web
 
 func (wfe *WebFrontEndImpl) logCsr(request *http.Request, cr core.CertificateRequest, registration core.Registration) {
 	var csrLog = struct {
-		ClientAddr   string
-		CSR          string
-		Registration core.Registration
+		ClientAddr string
+		CSR        string
+		Requester  int64
 	}{
-		ClientAddr:   web.GetClientAddr(request),
-		CSR:          hex.EncodeToString(cr.Bytes),
-		Registration: registration,
+		ClientAddr: web.GetClientAddr(request),
+		CSR:        hex.EncodeToString(cr.Bytes),
+		Requester:  registration.ID,
 	}
 	wfe.log.AuditObject("Certificate request", csrLog)
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -737,13 +737,13 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(
 
 func (wfe *WebFrontEndImpl) logCsr(request *http.Request, cr core.CertificateRequest, account core.Registration) {
 	var csrLog = struct {
-		ClientAddr   string
-		CSR          string
-		Registration core.Registration
+		ClientAddr string
+		CSR        string
+		Requester  int64
 	}{
-		ClientAddr:   web.GetClientAddr(request),
-		CSR:          hex.EncodeToString(cr.Bytes),
-		Registration: account,
+		ClientAddr: web.GetClientAddr(request),
+		CSR:        hex.EncodeToString(cr.Bytes),
+		Requester:  account.ID,
 	}
 	wfe.log.AuditObject("Certificate request", csrLog)
 }


### PR DESCRIPTION
Account objects contain email addresses, which the subscriber may choose to
change or delete, and which we protect under our privacy policy. Since audit
logs are retained much longer than regular logs, keeping email addresses out of
the audit logs improves the privacy properties of our email storage.