### PR TITLE
WFE2 Chain File Loading Improvements

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -67,7 +67,8 @@ type config struct {
 // validates that the PEM is well-formed with no leftover bytes, and contains
 // only a well-formed X509 certificate. If the cert file meets these
 // requirements the PEM bytes from the file are returned, otherwise an error is
-// returned.
+// returned. If the PEM contents of a certFile do not have a trailing newline
+// one is added.
 func loadCertificateFile(aiaIssuerURL, certFile string) ([]byte, error) {
 	pemBytes, err := ioutil.ReadFile(certFile)
 	if err != nil {
@@ -114,7 +115,10 @@ func loadCertificateFile(aiaIssuerURL, certFile string) ([]byte, error) {
 				"input (%d bytes)",
 			aiaIssuerURL, certFile, len(rest))
 	}
-
+	// If the PEM contents don't end in a \n, add it.
+	if pemBytes[len(pemBytes)-1] != '\n' {
+		pemBytes = append(pemBytes, '\n')
+	}
 	return pemBytes, nil
 }
 

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -76,6 +76,12 @@ func loadCertificateFile(aiaIssuerURL, certFile string) ([]byte, error) {
 				"invalid chain file: %q - error reading contents: %s",
 			aiaIssuerURL, certFile, err)
 	}
+	if bytes.Contains(pemBytes, []byte("\r\n")) {
+		return nil, fmt.Errorf(
+			"CertificateChain entry for AIA issuer url %q has an "+
+				"invalid chain file: %q - contents had CRLF line endings",
+			aiaIssuerURL, certFile)
+	}
 	// Try to decode the contents as PEM
 	certBlock, rest := pem.Decode(pemBytes)
 	if certBlock == nil {


### PR DESCRIPTION
## Reject WFE2 certificate chain PEM files with CRLF endings.

0f82ffa updates the `boulder-wfe2` command's processing of
certificate chains such that it will reject chain files that contain PEM
encoding with Windows CRLF line endings. Boulder is a UNIX service and
throughout we assume UNIX newlines. CRLF endings in a certificate chain
input file is an error that should be resolved by the operator prior to
startup.

## Add trailing newline to PEM chainfiles automatically.

If a PEM encoded chain file doesn't end with a trailing `\n` the WFE2
should add it.  528c413 updates the chain file loading to handle this
and adds a corresponding unit test.

Resolves https://github.com/letsencrypt/boulder/issues/3557 and https://github.com/letsencrypt/boulder/issues/3560