### PR TITLE
Add golang pkg cache volume to container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             BOULDER_CONFIG_DIR: test/config
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
+          - $GOPATH/pkg:/go/pkg
           - /tmp:/tmp
         network_mode: bridge
         extra_hosts:


### PR DESCRIPTION
Speeds up building boulder binaries, fixes #3582.

```
# Before
docker-compose run boulder make rpm  1.11s user 0.71s system 0% cpu 4:29.58 total
# After
docker-compose run boulder make rpm  1.03s user 0.45s system 0% cpu 3:38.93 total
```