### PR TITLE
Return descriptive error when SCT policy can't be met.

### DIFF
--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/letsencrypt/boulder/canceled"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
@@ -107,7 +108,7 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER) (core.SCTDE
 			sct, err := ctp.race(subCtx, cert, g)
 			// Only one of these will be non-nil
 			if err != nil {
-				results <- result{err: fmt.Errorf("CT log group %q: %s", g.Name, err)}
+				results <- result{err: berrors.MissingSCTsError("CT log group %q: %s", g.Name, err)}
 			}
 			results <- result{sct: sct}
 		}(i, g)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,6 +17,7 @@ const (
 	ConnectionFailure
 	WrongAuthorizationState
 	CAA
+	MissingSCTs
 )
 
 // BoulderError represents internal Boulder errors
@@ -87,4 +88,8 @@ func WrongAuthorizationStateError(msg string, args ...interface{}) error {
 
 func CAAError(msg string, args ...interface{}) error {
 	return New(CAA, msg, args...)
+}
+
+func MissingSCTsError(msg string, args ...interface{}) error {
+	return New(MissingSCTs, msg, args...)
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1124,6 +1124,9 @@ func (ra *RegistrationAuthorityImpl) getSCTs(ctx context.Context, cert []byte) (
 		state := "failure"
 		if err == context.DeadlineExceeded {
 			state = "deadlineExceeded"
+			// Convert the error to a missingSCTsError to communicate the timeout,
+			// otherwise it will be a generic serverInternalError
+			err = berrors.MissingSCTsError(err.Error())
 		}
 		ra.log.Warning(fmt.Sprintf("ctpolicy.GetSCTs failed: %s", err))
 		ra.ctpolicyResults.With(prometheus.Labels{"result": state}).Observe(took.Seconds())

--- a/web/probs.go
+++ b/web/probs.go
@@ -29,6 +29,10 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.CAA:
 		return probs.CAA(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.MissingSCTs:
+		// MissingSCTs are an internal server error, but with a specific error
+		// message related to the SCT problem
+		return probs.ServerInternal(fmt.Sprintf("%s :: %s", msg, "Unable to meet CA SCT embedding requirements"))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.


### PR DESCRIPTION
This commit updates CTPolicy & the RA to return a distinct error when
the RA is unable to fetch the required SCTs for a certificate when
processing an issuance. This error type is plumbed up to the WFE/WFE2
where the `web/probs.go` code converts it into a server internal error
with a suitable user facing error.

Resolves https://github.com/letsencrypt/boulder/issues/3546