### PR TITLE
Add CAAIdentities and Website to /directory "meta".

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -43,6 +43,14 @@ type config struct {
 		SAService *cmd.GRPCClientConfig
 
 		Features map[string]bool
+
+		// DirectoryCAAIdentity is used for the /directory response's "meta"
+		// element's "caaIdentities" field. It should match the VA's "issuerDomain"
+		// configuration value (this value is the one used to enforce CAA)
+		DirectoryCAAIdentity string
+		// DirectoryWebsite is used for the /directory response's "meta" element's
+		// "website" field.
+		DirectoryWebsite string
 	}
 
 	SubscriberAgreementURL string
@@ -107,6 +115,8 @@ func main() {
 	wfe.AllowOrigins = c.WFE.AllowOrigins
 	wfe.AcceptRevocationReason = c.WFE.AcceptRevocationReason
 	wfe.AllowAuthzDeactivation = c.WFE.AllowAuthzDeactivation
+	wfe.DirectoryCAAIdentity = c.WFE.DirectoryCAAIdentity
+	wfe.DirectoryWebsite = c.WFE.DirectoryWebsite
 
 	wfe.IssuerCert, err = cmd.LoadCert(c.Common.IssuerCert)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -52,6 +52,14 @@ type config struct {
 		CertificateChains map[string][]string
 
 		Features map[string]bool
+
+		// DirectoryCAAIdentity is used for the /directory response's "meta"
+		// element's "caaIdentities" field. It should match the VA's "issuerDomain"
+		// configuration value (this value is the one used to enforce CAA)
+		DirectoryCAAIdentity string
+		// DirectoryWebsite is used for the /directory response's "meta" element's
+		// "website" field.
+		DirectoryWebsite string
 	}
 
 	SubscriberAgreementURL string

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -15,6 +15,8 @@
     "acceptRevocationReason": true,
     "allowAuthzDeactivation": true,
     "debugAddr": ":8000",
+    "directoryCAAIdentity": "happy-hacker-ca.invalid",
+    "directoryWebsite": "https://github.com/letsencrypt/boulder",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/wfe.boulder/cert.pem",

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -15,6 +15,8 @@
     "acceptRevocationReason": true,
     "allowAuthzDeactivation": true,
     "debugAddr": ":8013",
+    "directoryCAAIdentity": "happy-hacker-ca.invalid",
+    "directoryWebsite": "https://github.com/letsencrypt/boulder",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/wfe.boulder/cert.pem",

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -100,6 +100,9 @@ func AssertUnmarshaledEquals(t *testing.T, got, expected string) {
 	AssertNotError(t, err, "Could not unmarshal 'got'")
 	err = json.Unmarshal([]byte(expected), &expectedMap)
 	AssertNotError(t, err, "Could not unmarshal 'expected'")
+	if len(gotMap) != len(expectedMap) {
+		t.Errorf("Expected had %d keys, got had %d", len(gotMap), len(expectedMap))
+	}
 	for k, v := range expectedMap {
 		if !reflect.DeepEqual(v, gotMap[k]) {
 			t.Errorf("Field %q: Expected \"%v\", got \"%v\"", k, v, gotMap[k])

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -75,6 +75,15 @@ type WebFrontEndImpl struct {
 	// URL to the current subscriber agreement (should contain some version identifier)
 	SubscriberAgreementURL string
 
+	// DirectoryCAAIdentity is used for the /directory response's "meta"
+	// element's "caaIdentities" field. It should match the VA's issuerDomain
+	// field value.
+	DirectoryCAAIdentity string
+
+	// DirectoryWebsite is used for the /directory response's "meta" element's
+	// "website" field.
+	DirectoryWebsite string
+
 	// Register of anti-replay nonces
 	nonceService *nonce.NonceService
 
@@ -351,14 +360,28 @@ func (wfe *WebFrontEndImpl) Directory(ctx context.Context, logEvent *web.Request
 		// expected set of keys. This ensures that we can properly extend the directory when we
 		// need to add a new endpoint or meta element.
 		directoryEndpoints[core.RandomString(8)] = randomDirKeyExplanationLink
-	}
-	if !clientDirChangeIntolerant {
+
 		// ACME since draft-02 describes an optional "meta" directory entry. The
 		// meta entry may optionally contain a "terms-of-service" URI for the
 		// current ToS.
-		directoryEndpoints["meta"] = map[string]string{
+		metaMap := map[string]interface{}{
 			"terms-of-service": wfe.SubscriberAgreementURL,
 		}
+		// The "meta" directory entry may also include a []string of CAA identities
+		if wfe.DirectoryCAAIdentity != "" {
+			// The specification says caaIdentities is an array of strings. In
+			// practice Boulder's VA only allows configuring ONE CAA identity. Given
+			// that constraint it doesn't make sense to allow multiple directory CAA
+			// identities so we use just the `wfe.DirectoryCAAIdentity` alone.
+			metaMap["caaIdentities"] = []string{
+				wfe.DirectoryCAAIdentity,
+			}
+		}
+		// The "meta" directory entry may also include a string with a website URL
+		if wfe.DirectoryWebsite != "" {
+			metaMap["website"] = wfe.DirectoryWebsite
+		}
+		directoryEndpoints["meta"] = metaMap
 	}
 
 	response.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This commit updates the WFE and WFE2 to have configuration support for
setting a value for the `/directory` object's "meta" field's
optional "caaIdentities" and "website" fields. The config-next wfe/wfe2
configuration are updated with values for these fields. Unit tests are
updated to check that they are sent when expected and not otherwise.

Bonus content: The `test.AssertUnmarshaledEquals` function had a bug
where it would consider two inputs equal when the # of keys differed.
This commit also fixes that bug.

There's a little bit of duplication between the WFE and WFE2 but this 
isn't a great fit for the `web` package. In both cases we need to be reading
fields from the config that are package specific. For the WFE we need to use
"terms-of-service" for one meta key, in the WFE2 "termsOfService". Putting
this work into `web` didn't really make it much cleaner so I left the duplication.

Resolves https://github.com/letsencrypt/boulder/issues/2811