### PR TITLE
Don't return "Agreement" in V2 account objects.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -513,6 +513,14 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	addRequesterHeader(response, acct.ID)
 	logEvent.Contacts = acct.Contact
 
+	// We populate the account Agreement field when creating a new response to
+	// track which terms-of-service URL was in effect when an account with
+	// "termsOfServiceAgreed":"true" is created. That said, we don't want to send
+	// this value back to a V2 client. The "Agreement" field of an
+	// account/registration is a V1 notion so we strip it here in the WFE2 before
+	// returning the account.
+	acct.Agreement = ""
+
 	acctURL := web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, acct.ID))
 
 	response.Header().Add("Location", acctURL)
@@ -1064,6 +1072,14 @@ func (wfe *WebFrontEndImpl) Account(
 	if len(wfe.SubscriberAgreementURL) > 0 {
 		response.Header().Add("Link", link(wfe.SubscriberAgreementURL, "terms-of-service"))
 	}
+
+	// We populate the account Agreement field when creating a new response to
+	// track which terms-of-service URL was in effect when an account with
+	// "termsOfServiceAgreed":"true" is created. That said, we don't want to send
+	// this value back to a V2 client. The "Agreement" field of an
+	// account/registration is a V1 notion so we strip it here in the WFE2 before
+	// returning the account.
+	updatedAcct.Agreement = ""
 
 	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, updatedAcct)
 	if err != nil {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1156,7 +1156,7 @@ func TestNewECDSAAccount(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't unmarshal returned account object")
 	test.Assert(t, len(*acct.Contact) >= 1, "No contact field in account")
 	test.AssertEquals(t, (*acct.Contact)[0], "mailto:person@mail.com")
-	test.AssertEquals(t, acct.Agreement, "http://example.invalid/terms")
+	test.AssertEquals(t, acct.Agreement, "")
 	test.AssertEquals(t, acct.InitialIP.String(), "1.1.1.1")
 
 	test.AssertEquals(t, responseWriter.Header().Get("Location"), "http://localhost/acme/acct/0")
@@ -1215,7 +1215,7 @@ func TestEmptyAccount(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't unmarshal returned account object")
 	test.Assert(t, len(*acct.Contact) >= 1, "No contact field in account")
 	test.AssertEquals(t, (*acct.Contact)[0], "mailto:person@mail.com")
-	test.AssertEquals(t, acct.Agreement, "http://example.invalid/terms")
+	test.AssertEquals(t, acct.Agreement, "")
 	responseWriter.Body.Reset()
 }
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1298,29 +1298,32 @@ func TestNewAccount(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't unmarshal returned account object")
 	test.Assert(t, len(*acct.Contact) >= 1, "No contact field in account")
 	test.AssertEquals(t, (*acct.Contact)[0], "mailto:person@mail.com")
-	test.AssertEquals(t, acct.Agreement, "http://example.invalid/terms")
 	test.AssertEquals(t, acct.InitialIP.String(), "1.1.1.1")
+	// Agreement is an ACMEv1 field and should not be present
+	test.AssertEquals(t, acct.Agreement, "")
 
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Location"),
 		"http://localhost/acme/acct/0")
 
+	// Load an existing key
 	key = loadKey(t, []byte(test1KeyPrivatePEM))
 	_, ok = key.(*rsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load test1 key")
 
 	// Reset the body and status code
 	responseWriter = httptest.NewRecorder()
-
 	// POST, Valid JSON, Key already in use
 	_, _, body = signRequestEmbed(t, key, signedURL, payload, wfe.nonceService)
 	request = makePostRequestWithPath(path, body)
-
+	// POST the NewAccount request
 	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, request)
+	// We expect a Location header and a 200 response with an empty body
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Location"),
 		"http://localhost/acme/acct/1")
 	test.AssertEquals(t, responseWriter.Code, 200)
+	test.AssertEquals(t, responseWriter.Body.String(), "")
 }
 
 func TestGetAuthorization(t *testing.T) {


### PR DESCRIPTION
This commit updates the WFE2 to remove the "Agreement" value on V2 account objects before returning them to the user. This field is not defined in the V2 specification and we should not be returning it.

The V2 `TermsOfServiceAgreed` field is marked optional, and for Let's Encrypt purposes it doesn't make much sense to write it in returned Account objects because the value will necessarily be true 100% of the time. We never create an account unless the request has `TermsOfServiceAgreed: true`.

Resolves https://github.com/letsencrypt/boulder/issues/3590