### PR TITLE
Mount $GOCACHE as a volume.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,7 @@ services:
             BOULDER_CONFIG_DIR: test/config
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
-          - $GOPATH/pkg:/go/pkg
-          - /tmp:/tmp
+          - ./.gocache:/root/.cache/go-build
         network_mode: bridge
         extra_hosts:
           - le.wtf:127.0.0.1


### PR DESCRIPTION
In #3584 we mounted the package path in an attempt to speed things up,
but that wasn't actually effective. The latest Go has a $GOCACHE which
defaults to $HOME/.cache/go-build, and stores cached build artifacts.
This change mounts that path to a hidden directory on the host. It also
removes the volume mounts for /tmp/ and $GOPATH/pkg, which weren't doing
anything.

I've verified this speeds up the startup for RUN=integration on my
machine from several seconds to roughly zero seconds on repeated runs.