### PR TITLE
Fetch only the challenges needed in getAuthz.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1956,8 +1956,7 @@ func (ssa *SQLStorageAuthority) getAuthorizations(
 
 	for _, auth := range byName {
 		// Retrieve challenges for the authz
-		auth.Challenges, err = ssa.getChallenges(auth.ID)
-		if err != nil {
+		if auth.Challenges, err = ssa.getChallenges(auth.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -29,6 +29,7 @@ import (
 )
 
 type certCountFunc func(domain string, earliest, latest time.Time) (int, error)
+type getChallengesFunc func(authID string) ([]core.Challenge, error)
 
 // SQLStorageAuthority defines a Storage Authority
 type SQLStorageAuthority struct {
@@ -42,9 +43,10 @@ type SQLStorageAuthority struct {
 	// threads).
 	parallelismPerRPC int
 
-	// We use a function type here so we can mock out this internal function in
+	// We use function types here so we can mock out this internal function in
 	// unittests.
 	countCertificatesByName certCountFunc
+	getChallenges           getChallengesFunc
 }
 
 func digest256(data []byte) []byte {
@@ -106,6 +108,7 @@ func NewSQLStorageAuthority(
 	}
 
 	ssa.countCertificatesByName = ssa.countCertificatesByNameImpl
+	ssa.getChallenges = ssa.getChallengesImpl
 
 	return ssa, nil
 }
@@ -1947,13 +1950,15 @@ func (ssa *SQLStorageAuthority) getAuthorizations(
 		}
 		existing, present := byName[auth.Identifier.Value]
 		if !present || auth.Expires.After(*existing.Expires) {
-			// Retrieve challenges for the authz
-			auth.Challenges, err = ssa.getChallenges(auth.ID)
-			if err != nil {
-				return nil, err
-			}
-
 			byName[auth.Identifier.Value] = auth
+		}
+	}
+
+	for _, auth := range byName {
+		// Retrieve challenges for the authz
+		auth.Challenges, err = ssa.getChallenges(auth.ID)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -2062,7 +2067,7 @@ func (ssa *SQLStorageAuthority) AddPendingAuthorizations(ctx context.Context, re
 	return &sapb.AuthorizationIDs{Ids: ids}, nil
 }
 
-func (ssa *SQLStorageAuthority) getChallenges(authID string) ([]core.Challenge, error) {
+func (ssa *SQLStorageAuthority) getChallengesImpl(authID string) ([]core.Challenge, error) {
 	var challObjs []challModel
 	_, err := ssa.dbMap.Select(
 		&challObjs,


### PR DESCRIPTION
In getAuthorizations, we had a single loop to both select the freshest authz and
fetch challenges corresponding to authzs. This meant that in some cases, we
would fetch challenges only to throw them away. Since each challenge fetch is a
DB round trip, this would cause extreme slowness when called for domains that
have a large number of authorizations.

This change splits that into two loops: One to select the freshest authzs, and
another to fetch challenges for those authzs.