### PR TITLE
RA: Log Authz ID and solved-by Chal type at Issuance

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -398,6 +398,21 @@ func (authz *Authorization) FindChallenge(challengeID int64) int {
 	return -1
 }
 
+// SolvedBy will look through the Authorizations challenges, returning a pointer
+// to the *first* challenge it finds with Status: valid, or nil if no challenge
+// is valid.
+func (authz *Authorization) SolvedBy() *Challenge {
+	if len(authz.Challenges) == 0 {
+		return nil
+	}
+	for _, chal := range authz.Challenges {
+		if chal.Status == StatusValid {
+			return &chal
+		}
+	}
+	return nil
+}
+
 // JSONBuffer fields get encoded and decoded JOSE-style, in base64url encoding
 // with stripped padding.
 type JSONBuffer []byte

--- a/core/objects.go
+++ b/core/objects.go
@@ -398,19 +398,19 @@ func (authz *Authorization) FindChallenge(challengeID int64) int {
 	return -1
 }
 
-// SolvedBy will look through the Authorizations challenges, returning a pointer
-// to the *first* challenge it finds with Status: valid, or nil if no challenge
+// SolvedBy will look through the Authorizations challenges, returning the type
+// of the *first* challenge it finds with Status: valid, or "" if no challenge
 // is valid.
-func (authz *Authorization) SolvedBy() *Challenge {
+func (authz *Authorization) SolvedBy() string {
 	if len(authz.Challenges) == 0 {
-		return nil
+		return ""
 	}
 	for _, chal := range authz.Challenges {
 		if chal.Status == StatusValid {
-			return &chal
+			return chal.Type
 		}
 	}
-	return nil
+	return ""
 }
 
 // JSONBuffer fields get encoded and decoded JOSE-style, in base64url encoding

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -101,13 +101,12 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 	testCases := []struct {
 		Name           string
 		Authz          Authorization
-		ExpectedResult *Challenge
+		ExpectedResult string
 	}{
 		// An authz with no challenges should return nil
 		{
-			Name:           "No challenges",
-			Authz:          Authorization{},
-			ExpectedResult: nil,
+			Name:  "No challenges",
+			Authz: Authorization{},
 		},
 		// An authz with all non-valid challenges should return nil
 		{
@@ -115,7 +114,6 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 			Authz: Authorization{
 				Challenges: []Challenge{HTTPChallenge01(), DNSChallenge01()},
 			},
-			ExpectedResult: nil,
 		},
 		// An authz with one valid HTTP01 challenge amongst other challenges should
 		// return the HTTP01 challenge
@@ -124,7 +122,7 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 			Authz: Authorization{
 				Challenges: []Challenge{HTTPChallenge01(), validHTTP01, DNSChallenge01()},
 			},
-			ExpectedResult: &validHTTP01,
+			ExpectedResult: "http-01",
 		},
 		// An authz with both a valid HTTP01 challenge and a valid DNS01 challenge
 		// among other challenges should return whichever valid challenge is first
@@ -134,26 +132,15 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 			Authz: Authorization{
 				Challenges: []Challenge{validDNS01, HTTPChallenge01(), validHTTP01, DNSChallenge01()},
 			},
-			ExpectedResult: &validDNS01,
+			ExpectedResult: "dns-01",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			result := tc.Authz.SolvedBy()
-			// If the expected result is nil, make sure the result was nil
-			if tc.ExpectedResult == nil {
-				test.AssertEquals(t, result, tc.ExpectedResult)
-			} else {
-				// Otherwise make sure the result wasn't nil
-				test.AssertNotNil(t, result, "Result was nil")
-				// Make sure the result was the correct challenge
-				test.AssertEquals(t, result.ID, tc.ExpectedResult.ID)
-				// Make sure the result was the correct challenge type
-				test.AssertEquals(t, result.Type, tc.ExpectedResult.Type)
-				// Make sure the result challenge was valid
-				test.AssertEquals(t, result.Status, StatusValid)
-			}
+			// Make sure the result was the correct challenge type
+			test.AssertEquals(t, result, tc.ExpectedResult)
 		})
 	}
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -268,8 +268,8 @@ func validateEmail(ctx context.Context, address string, resolver bdns.DNSClient)
 // referenced during a certificateRequestEvent. It holds both the authorization
 // ID and the challenge type that made the authorization valid.
 type certificateRequestAuthz struct {
-	ID            string `json:",omitempty"`
-	ChallengeType string `json:",omitempty"`
+	ID            string
+	ChallengeType string
 }
 
 // certificateRequestEvent is a struct for holding information that is logged as
@@ -302,7 +302,7 @@ type certificateRequestEvent struct {
 	// Authorizations is a map of identifier names to certificateRequestAuthz
 	// objects. It can be used to understand how the names in a certificate
 	// request were authorized.
-	Authorizations map[string]certificateRequestAuthz `json:",omitempty"`
+	Authorizations map[string]certificateRequestAuthz
 }
 
 // noRegistrationID is used for the regID parameter to GetThreshold when no

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -264,19 +264,45 @@ func validateEmail(ctx context.Context, address string, resolver bdns.DNSClient)
 	return emptyDNSResponseError
 }
 
+// certificateRequestAuthz is a struct for holding information about a valid
+// referenced during a certificateRequestEvent. It holds both the authorization
+// ID and the challenge type that made the authorization valid.
+type certificateRequestAuthz struct {
+	ID            string `json:",omitempty"`
+	ChallengeType string `json:",omitempty"`
+}
+
+// certificateRequestEvent is a struct for holding information that is logged as
+// JSON to the audit log as the result of an issuance event.
 type certificateRequestEvent struct {
-	ID             string    `json:",omitempty"`
-	Requester      int64     `json:",omitempty"`
-	OrderID        int64     `json:",omitempty"`
-	SerialNumber   string    `json:",omitempty"`
-	VerifiedFields []string  `json:",omitempty"`
-	CommonName     string    `json:",omitempty"`
-	Names          []string  `json:",omitempty"`
-	NotBefore      time.Time `json:",omitempty"`
-	NotAfter       time.Time `json:",omitempty"`
-	RequestTime    time.Time `json:",omitempty"`
-	ResponseTime   time.Time `json:",omitempty"`
-	Error          string    `json:",omitempty"`
+	ID string `json:",omitempty"`
+	// Requester is the associated account ID
+	Requester int64 `json:",omitempty"`
+	// OrderID is the associated order ID (may be empty for an ACME v1 issuance)
+	OrderID int64 `json:",omitempty"`
+	// SerialNumber is the string representation of the issued certificate's
+	// serial number
+	SerialNumber string `json:",omitempty"`
+	// VerifiedFields are required by the baseline requirements and are always
+	// a static value for Boulder.
+	VerifiedFields []string `json:",omitempty"`
+	// CommonName is the subject common name from the issued cert
+	CommonName string `json:",omitempty"`
+	// Names are the DNS SAN entries from the issued cert
+	Names []string `json:",omitempty"`
+	// NotBefore is the starting timestamp of the issued cert's validity period
+	NotBefore time.Time `json:",omitempty"`
+	// NotAfter is the ending timestamp of the issued cert's validity period
+	NotAfter time.Time `json:",omitempty"`
+	// RequestTime and ResponseTime are for tracking elapsed time during issuance
+	RequestTime  time.Time `json:",omitempty"`
+	ResponseTime time.Time `json:",omitempty"`
+	// Error contains any encountered errors
+	Error string `json:",omitempty"`
+	// Authorizations is a map of identifier names to certificateRequestAuthz
+	// objects. It can be used to understand how the names in a certificate
+	// request were authorized.
+	Authorizations map[string]certificateRequestAuthz `json:",omitempty"`
 }
 
 // noRegistrationID is used for the regID parameter to GetThreshold when no

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -265,8 +265,10 @@ func validateEmail(ctx context.Context, address string, resolver bdns.DNSClient)
 }
 
 // certificateRequestAuthz is a struct for holding information about a valid
-// referenced during a certificateRequestEvent. It holds both the authorization
-// ID and the challenge type that made the authorization valid.
+// authz referenced during a certificateRequestEvent. It holds both the
+// authorization ID and the challenge type that made the authorization valid. We
+// specifically include the challenge type that solved the authorization to make
+// some common analysis easier.
 type certificateRequestAuthz struct {
 	ID            string
 	ChallengeType string

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1093,15 +1093,15 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	// of each of the valid authorizations we used for this issuance.
 	logEventAuthzs := make(map[string]certificateRequestAuthz, len(names))
 	for name, authz := range authzs {
-		var solvedByChallenge *core.Challenge
-		// If the authz has no solved by challenge there has been an internal
+		var solvedByChallengeType string
+		// If the authz has no solved by challenge type there has been an internal
 		// consistency violation worth raising an internal server error about.
-		if solvedByChallenge = authz.SolvedBy(); solvedByChallenge == nil {
-			return emptyCert, berrors.InternalServerError("Authz %q has status %q but nil SolvedBy()", authz.ID, authz.Status)
+		if solvedByChallengeType = authz.SolvedBy(); solvedByChallengeType == "" {
+			return emptyCert, berrors.InternalServerError("Authz %q has status %q but empty SolvedBy()", authz.ID, authz.Status)
 		}
 		logEventAuthzs[name] = certificateRequestAuthz{
 			ID:            authz.ID,
-			ChallengeType: solvedByChallenge.Type,
+			ChallengeType: solvedByChallengeType,
 		}
 	}
 	logEvent.Authorizations = logEventAuthzs

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1095,9 +1095,11 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	for name, authz := range authzs {
 		var solvedByChallengeType string
 		// If the authz has no solved by challenge type there has been an internal
-		// consistency violation worth raising an internal server error about.
+		// consistency violation worth logging a warning about. In this case the
+		// solvedByChallengeType will be logged as the emtpy string.
 		if solvedByChallengeType = authz.SolvedBy(); solvedByChallengeType == "" {
-			return emptyCert, berrors.InternalServerError("Authz %q has status %q but empty SolvedBy()", authz.ID, authz.Status)
+			ra.log.Warning(fmt.Sprintf(
+				"Authz %q has status %q but empty SolvedBy()", authz.ID, authz.Status))
 		}
 		logEventAuthzs[name] = certificateRequestAuthz{
 			ID:            authz.ID,

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1976,7 +1976,7 @@ func TestRecheckCAADates(t *testing.T) {
 	// NOTE: The names provided here correspond to authorizations in the
 	// `mockSAWithRecentAndOlder`
 	names := []string{"recent.com", "older.com", "older2.com", "wildcard.com", "*.wildcard.com"}
-	err := ra.checkAuthorizations(context.Background(), names, 999)
+	_, err := ra.checkAuthorizations(context.Background(), names, 999)
 	// We expect that there is no error rechecking authorizations for these names
 	if err != nil {
 		t.Errorf("expected nil err, got %s", err)
@@ -3210,20 +3210,23 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 			Type:  "dns",
 			Value: domain,
 		}
-		// Create pending challenges mapped by their type
-		chals := map[string]core.Challenge{
-			"http-01":    core.HTTPChallenge01(),
-			"dns-01":     core.DNSChallenge01(),
-			"tls-sni-01": core.TLSSNIChallenge01(),
-		}
-		var chal core.Challenge
-		var validChallengeType bool
-		// Ensure the chalType is one we have in the chals map
-		if chal, validChallengeType = chals[chalType]; !validChallengeType {
+		// Create challenges
+		httpChal := core.HTTPChallenge01()
+		dnsChal := core.DNSChallenge01()
+		tlsChal := core.TLSSNIChallenge01()
+		// Set the selected challenge to valid
+		switch chalType {
+		case "http-01":
+			httpChal.Status = core.StatusValid
+		case "dns-01":
+			dnsChal.Status = core.StatusValid
+		case "tls-sni-01":
+			tlsChal.Status = core.StatusValid
+		default:
 			t.Fatalf("Invalid challenge type used with authzForChalType: %q", chalType)
 		}
-		// Set the selected challenge type to valid
-		chal.Status = "valid"
+		// Set the template's challenges
+		template.Challenges = []core.Challenge{httpChal, dnsChal, tlsChal}
 		// Set the overall authz to valid
 		template.Status = "valid"
 		template.Expires = &exp

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3196,6 +3196,167 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 		"wildcard order")
 }
 
+func TestIssueCertificateAuditLog(t *testing.T) {
+	_, sa, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+
+	// Set up order and authz expiries
+	ra.orderLifetime = 24 * time.Hour
+	exp := ra.clk.Now().Add(24 * time.Hour)
+
+	authzForChalType := func(domain, chalType string) core.Authorization {
+		template := AuthzInitial
+		template.Identifier = core.AcmeIdentifier{
+			Type:  "dns",
+			Value: domain,
+		}
+		// Create pending challenges mapped by their type
+		chals := map[string]core.Challenge{
+			"http-01":    core.HTTPChallenge01(),
+			"dns-01":     core.DNSChallenge01(),
+			"tls-sni-01": core.TLSSNIChallenge01(),
+		}
+		var chal core.Challenge
+		var validChallengeType bool
+		// Ensure the chalType is one we have in the chals map
+		if chal, validChallengeType = chals[chalType]; !validChallengeType {
+			t.Fatalf("Invalid challenge type used with authzForChalType: %q", chalType)
+		}
+		// Set the selected challenge type to valid
+		chal.Status = "valid"
+		// Set the overall authz to valid
+		template.Status = "valid"
+		template.Expires = &exp
+		template.RegistrationID = Registration.ID
+		// Create the pending authz
+		authz, err := sa.NewPendingAuthorization(ctx, template)
+		if err != nil {
+			t.Fatalf("Could not create test pending authorization")
+		}
+		// Finalize the authz
+		err = sa.FinalizeAuthorization(ctx, authz)
+		if err != nil {
+			t.Fatalf("Could not finalize test pending authorization")
+		}
+		return authz
+	}
+
+	// Make some valid authorizations for some names using different challenge types
+	names := []string{"not-example.com", "www.not-example.com", "still.not-example.com", "definitely.not-example.com"}
+	chalTypes := []string{"http-01", "dns-01", "tls-sni-01", "dns-01"}
+	var authzs []core.Authorization
+	var authzIDs []string
+	for i, name := range names {
+		authzs = append(authzs, authzForChalType(name, chalTypes[i]))
+		authzIDs = append(authzIDs, authzs[i].ID)
+	}
+
+	// Create a pending order for all of the names
+	expUnix := exp.Unix()
+	pendingStatus := "pending"
+	order, err := sa.NewOrder(context.Background(), &corepb.Order{
+		RegistrationID: &Registration.ID,
+		Expires:        &expUnix,
+		Names:          names,
+		Authorizations: authzIDs,
+		Status:         &pendingStatus,
+	})
+	test.AssertNotError(t, err, "Could not add test order with finalized authz IDs")
+
+	// Generate a CSR covering the order names with a random RSA key
+	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	test.AssertNotError(t, err, "error generating test key")
+	csr, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		PublicKey:          testKey.PublicKey,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+		Subject:            pkix.Name{CommonName: "not-example.com"},
+		DNSNames:           names,
+	}, testKey)
+	test.AssertNotError(t, err, "Could not create test order CSR")
+
+	// Create a mock certificate for the fake CA to return
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(12),
+		Subject: pkix.Name{
+			CommonName: "not-example.com",
+		},
+		DNSNames:              names,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, 1),
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, testKey.Public(), testKey)
+	test.AssertNotError(t, err, "Failed to create mock cert for test CA")
+
+	// Set up the RA's CA with a mock that returns the cert from above
+	ra.CA = &mocks.MockCA{
+		PEM: pem.EncodeToMemory(&pem.Block{
+			Bytes: cert,
+		}),
+	}
+
+	// The mock cert needs to be parsed to get its notbefore/notafter dates
+	parsedCerts, err := x509.ParseCertificates(cert)
+	test.AssertNotError(t, err, "Failed to parse mock cert DER bytes")
+	test.AssertEquals(t, len(parsedCerts), 1)
+	parsedCert := parsedCerts[0]
+
+	// Cast the RA's mock log so we can ensure its cleared and can access the
+	// matched log lines
+	mockLog := ra.log.(*blog.Mock)
+	mockLog.Clear()
+
+	// Finalize the order with the CSR
+	_, err = ra.FinalizeOrder(context.Background(), &rapb.FinalizeOrderRequest{
+		Order: order,
+		Csr:   csr})
+	test.AssertNotError(t, err, "Error finalizing test order")
+
+	// Get the logged lines from the audit logger
+	loglines := mockLog.GetAllMatching("Certificate request - successful JSON=")
+
+	// There should be exactly 1 matching log line
+	test.AssertEquals(t, len(loglines), 1)
+	// Strip away the stuff before 'JSON='
+	jsonContent := strings.TrimPrefix(loglines[0], "INFO: [AUDIT] Certificate request - successful JSON=")
+
+	// Unmarshal the JSON into a certificate request event object
+	var event certificateRequestEvent
+	err = json.Unmarshal([]byte(jsonContent), &event)
+	// The JSON should unmarshal without error
+	test.AssertNotError(t, err, "Error unmarshalling logged JSON issuance event")
+	// The event should have no error
+	test.AssertEquals(t, event.Error, "")
+	// The event requester should be the expected reg ID
+	test.AssertEquals(t, event.Requester, Registration.ID)
+	// The event order ID should be the expected order ID
+	test.AssertEquals(t, event.OrderID, *order.Id)
+	// The event serial number should be the expected serial number
+	test.AssertEquals(t, event.SerialNumber, core.SerialToString(template.SerialNumber))
+	// The event verified fields should be the expected value
+	test.AssertDeepEquals(t, event.VerifiedFields, []string{"subject.commonName", "subjectAltName"})
+	// The event CommonName should match the expected common name
+	test.AssertEquals(t, event.CommonName, "not-example.com")
+	// The event names should match the order names
+	test.AssertDeepEquals(t, core.UniqueLowerNames(event.Names), core.UniqueLowerNames(order.Names))
+	// The event's NotBefore and NotAfter should match the cert's
+	test.AssertEquals(t, event.NotBefore, parsedCert.NotBefore)
+	test.AssertEquals(t, event.NotAfter, parsedCert.NotAfter)
+
+	// There should be one event Authorization entry for each name
+	test.AssertEquals(t, len(event.Authorizations), len(names))
+
+	// Check the authz entry for each name
+	for i, name := range names {
+		authzEntry := event.Authorizations[name]
+		// The authz entry should have the correct authz ID
+		test.AssertEquals(t, authzEntry.ID, authzIDs[i])
+		// The authz entry should have the correct challenge type
+		test.AssertEquals(t, authzEntry.ChallengeType, chalTypes[i])
+	}
+}
+
 // TestUpdateMissingAuthorization tests the race condition where a challenge is
 // updated to valid concurrently with another attempt to have the challenge
 // updated. Previously this would return a `berrors.InternalServer` error when


### PR DESCRIPTION
This PR updates the RA such that `certificateRequestEvent` objects created during issuance and written to the audit log as JSON also include a new `Authorizations` field. This field is a map of the form `map[string]certificateRequestAuthz` and can be used to map from an identifier name appearing in the associated certificate to a `certificateRequestAuthz` object. Each of the `certificateRequestAuthz` objects holds an authorization ID and the type of challenge that made the authorization valid. 

Example Audit log output (with the JSON pulled out and pretty-printed):
```
{
 "ID":"0BjPk94KlxExRRIQ3kslRVSJ68KMaTh416chRvq0wyA",
 "Requester":666,
  "SerialNumber":"ff699d91cab5bc84f1bc97fc71e4e27abc1a",
  "VerifiedFields":["subject.commonName","subjectAltName"],
  "CommonName":"rand.44634cbf.xyz",
  "Names":["rand.44634cbf.xyz"],
  "NotBefore":"2018-03-28T19:50:07Z",
  "NotAfter":"2018-06-26T19:50:07Z",
  "RequestTime":"2018-03-28T20:50:07.234038859Z",
  "ResponseTime":"2018-03-28T20:50:07.278848954Z",
  "Authorizations":  {
    "rand.44634cbf.xyz" : {
      "ID":"jGt37Rnvfr0nhZn-wLkxrQxc2HBfV4t6TSraRiGnNBM",
      "ChallengeType":"http-01"
    }
  }
}
```



Resolves https://github.com/letsencrypt/boulder/issues/3253