### PR TITLE
WFE2: Wire missed config elements to WFE object.

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -219,6 +219,8 @@ func main() {
 	wfe.AllowOrigins = c.WFE.AllowOrigins
 	wfe.AcceptRevocationReason = c.WFE.AcceptRevocationReason
 	wfe.AllowAuthzDeactivation = c.WFE.AllowAuthzDeactivation
+	wfe.DirectoryCAAIdentity = c.WFE.DirectoryCAAIdentity
+	wfe.DirectoryWebsite = c.WFE.DirectoryWebsite
 
 	wfe.IssuerCert, err = cmd.LoadCert(c.Common.IssuerCert)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't read issuer cert [%s]", c.Common.IssuerCert))


### PR DESCRIPTION
This commit addresses two config elements that were defined but not wired through to the WFE implementation object. Prior to this commit the `c.WFE.DirectoryCAAIdentity` and `c.WFE.DirectoryWebsite` configuration values were read and unmarshaled from config but not passed to the WFE. After this commit these two config options will be picked up by the WFE impl.

Resolves https://github.com/letsencrypt/boulder/issues/3602