### PR TITLE
Use internet facing appropriate histogram buckets for DNS latencies

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -189,15 +189,17 @@ func NewDNSClientImpl(
 
 	queryTime := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "dns_query_time",
-			Help: "Time taken to perform a DNS query",
+			Name:    "dns_query_time",
+			Help:    "Time taken to perform a DNS query",
+			Buckets: metrics.InternetFacingBuckets,
 		},
 		[]string{"qtype", "result", "authenticated_data"},
 	)
 	totalLookupTime := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "dns_total_lookup_time",
-			Help: "Time taken to perform a DNS lookup, including all retried queries",
+			Name:    "dns_total_lookup_time",
+			Help:    "Time taken to perform a DNS lookup, including all retried queries",
+			Buckets: metrics.InternetFacingBuckets,
 		},
 		[]string{"qtype", "result", "authenticated_data", "retries"},
 	)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -418,7 +418,7 @@ func initStats(scope metrics.Scope) mailerStats {
 		prometheus.HistogramOpts{
 			Name:    "sendLatency",
 			Help:    "Time the mailer takes sending messages",
-			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
+			Buckets: metrics.InternetFacingBuckets,
 		})
 	scope.MustRegister(sendLatency)
 

--- a/metrics/scope.go
+++ b/metrics/scope.go
@@ -7,6 +7,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// InternetFacingBuckets are the histogram buckets that should be used when
+// measuring latencies that involve traversing the public internet.
+var InternetFacingBuckets = []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45}
+
 // Scope is a stats collector that will prefix the name the stats it
 // collects.
 type Scope interface {

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -147,7 +147,7 @@ func initMetrics(stats metrics.Scope) *pubMetrics {
 		prometheus.HistogramOpts{
 			Name:    "ct_submission_time_seconds",
 			Help:    "Time taken to submit a certificate to a CT log",
-			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
+			Buckets: metrics.InternetFacingBuckets,
 		},
 		[]string{"log", "status"},
 	)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -120,7 +120,7 @@ func NewRegistrationAuthorityImpl(
 		prometheus.HistogramOpts{
 			Name:    "ctpolicy_results",
 			Help:    "Histogram of latencies of ctpolicy.GetSCTs calls with success/failure/deadlineExceeded labels",
-			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
+			Buckets: metrics.InternetFacingBuckets,
 		},
 		[]string{"result"},
 	)

--- a/va/va.go
+++ b/va/va.go
@@ -68,7 +68,7 @@ func initMetrics(stats metrics.Scope) *vaMetrics {
 		prometheus.HistogramOpts{
 			Name:    "validation_time",
 			Help:    "Time taken to validate a challenge",
-			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
+			Buckets: metrics.InternetFacingBuckets,
 		},
 		[]string{"type", "result"})
 	stats.MustRegister(validationTime)
@@ -76,7 +76,7 @@ func initMetrics(stats metrics.Scope) *vaMetrics {
 		prometheus.HistogramOpts{
 			Name:    "remote_validation_time",
 			Help:    "Time taken to remotely validate a challenge",
-			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45},
+			Buckets: metrics.InternetFacingBuckets,
 		},
 		[]string{"type", "result"})
 	stats.MustRegister(remoteValidationTime)


### PR DESCRIPTION
Also instead of repeating the same bucket definitions everywhere just use a single top level var in the `metrics` package in order to discourage copy/pasting.

Fixes #3607.