### PR TITLE
Improve nesting of RPC deadlines

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedUseAIAIssuerURLReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcards"
+const _FeatureFlag_name = "unusedUseAIAIssuerURLReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcards"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 21, 38, 60, 69, 88, 103, 124, 147, 165, 174, 193, 204, 224, 251}
+var _FeatureFlag_index = [...]uint16{0, 6, 21, 38, 60, 69, 88, 103, 124, 147, 158, 176, 185, 204, 215, 235, 262}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -24,6 +24,8 @@ const (
 	ForceConsistentStatus
 	// Enforce prevention of use of disabled challenge types
 	EnforceChallengeDisable
+	// Ensure there is headroom in RPC timeouts to return an error to the client
+	RPCHeadroom
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
 	EmbedSCTs
@@ -46,6 +48,7 @@ var features = map[FeatureFlag]bool{
 	AllowRenewalFirstRL:         false,
 	WildcardDomains:             false,
 	EnforceChallengeDisable:     false, // deprecated
+	RPCHeadroom:                 true,
 	TLSSNIRevalidation:          false,
 	EmbedSCTs:                   false,
 	CancelCTSubmissions:         true,

--- a/features/features.go
+++ b/features/features.go
@@ -48,7 +48,7 @@ var features = map[FeatureFlag]bool{
 	AllowRenewalFirstRL:         false,
 	WildcardDomains:             false,
 	EnforceChallengeDisable:     false, // deprecated
-	RPCHeadroom:                 true,
+	RPCHeadroom:                 false,
 	TLSSNIRevalidation:          false,
 	EmbedSCTs:                   false,
 	CancelCTSubmissions:         true,

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -29,7 +29,7 @@ func (si *serverInterceptor) intercept(ctx context.Context, req interface{}, inf
 	}
 
 	if features.Enabled(features.RPCHeadroom) {
-		// Shave 20 milliseconds off the deadline to ensure that the RPC server times
+		// Shave 20 milliseconds off the deadline to ensure that if the RPC server times
 		// out any sub-calls it makes (like DNS lookups, or onwards RPCs), it has a
 		// chance to report that timeout to the client. This allows for more specific
 		// errors, e.g "the VA timed out looking up CAA for example.com" (when called

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -108,6 +108,7 @@ func (s *testServer) Chill(ctx context.Context, in *test_proto.Time) (*test_prot
 
 func TestTimeouts(t *testing.T) {
 	_ = features.Set(map[string]bool{"RPCHeadroom": true})
+	defer features.Reset()
 	// start server
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -142,8 +142,8 @@ func TestTimeouts(t *testing.T) {
 		expectedErrorPrefix string
 	}{
 		{250 * time.Millisecond, "rpc error: code = Unknown desc = rpc error: code = DeadlineExceeded desc = the chiller overslept"},
-		{150 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
-		{50 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
+		{100 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
+		{10 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s", tc.timeout), func(t *testing.T) {

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
+	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/grpc/test_proto"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
@@ -106,6 +107,7 @@ func (s *testServer) Chill(ctx context.Context, in *test_proto.Time) (*test_prot
 }
 
 func TestTimeouts(t *testing.T) {
+	_ = features.Set(map[string]bool{"RPCHeadroom": true})
 	// start server
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -2,6 +2,10 @@ package grpc
 
 import (
 	"errors"
+	"fmt"
+	"log"
+	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,8 +13,10 @@ import (
 	"github.com/jmhodges/clock"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	"github.com/letsencrypt/boulder/grpc/test_proto"
+	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -54,17 +60,6 @@ func TestClientInterceptor(t *testing.T) {
 	test.AssertError(t, err, "ci.intercept didn't fail when handler returned a error")
 }
 
-// testServer is used to implement InterceptorTest
-type testServer struct{}
-
-// Chill implements InterceptorTest.Chill
-func (s *testServer) Chill(ctx context.Context, in *test_proto.Time) (*test_proto.Time, error) {
-	start := time.Now()
-	time.Sleep(time.Duration(*in.Time) * time.Nanosecond)
-	spent := int64(time.Since(start) / time.Nanosecond)
-	return &test_proto.Time{Time: &spent}, nil
-}
-
 // TestFailFastFalse sends a gRPC request to a backend that is
 // unavailable, and ensures that the request doesn't error out until the
 // timeout is reached, i.e. that FailFast is set to false.
@@ -90,4 +85,76 @@ func TestFailFastFalse(t *testing.T) {
 		t.Errorf("Chill failed fast, when FailFast should be disabled.")
 	}
 	_ = conn.Close()
+}
+
+// testServer is used to implement TestTimeouts, and will attempt to sleep for
+// the given amount of time (unless it hits a timeout or cancel).
+type testServer struct{}
+
+// Chill implements ChillerServer.Chill
+func (s *testServer) Chill(ctx context.Context, in *test_proto.Time) (*test_proto.Time, error) {
+	start := time.Now()
+	// Sleep for either the requested amount of time, or the context times out or
+	// is canceled.
+	select {
+	case <-time.After(time.Duration(*in.Time) * time.Nanosecond):
+		spent := int64(time.Since(start) / time.Nanosecond)
+		return &test_proto.Time{Time: &spent}, nil
+	case <-ctx.Done():
+		return nil, grpc.Errorf(codes.DeadlineExceeded, "the chiller overslept")
+	}
+}
+
+func TestTimeouts(t *testing.T) {
+	// start server
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+
+	si := &serverInterceptor{NewServerMetrics(metrics.NewNoopScope())}
+	s := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
+	test_proto.RegisterChillerServer(s, &testServer{})
+	go func() {
+		start := time.Now()
+		if err := s.Serve(lis); err != nil &&
+			!strings.HasSuffix(err.Error(), "use of closed network connection") {
+			t.Fatalf("s.Serve: %v after %s", err, time.Since(start))
+		}
+	}()
+	defer s.Stop()
+
+	// make client
+	ci := &clientInterceptor{30 * time.Second, grpc_prometheus.NewClientMetrics()}
+	conn, err := grpc.Dial(net.JoinHostPort("localhost", fmt.Sprintf("%d", port)),
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(ci.intercept))
+	if err != nil {
+		t.Fatalf("did not connect: %v", err)
+	}
+	c := test_proto.NewChillerClient(conn)
+
+	testCases := []struct {
+		timeout             time.Duration
+		expectedErrorPrefix string
+	}{
+		{250 * time.Millisecond, "rpc error: code = Unknown desc = rpc error: code = DeadlineExceeded desc = the chiller overslept"},
+		{150 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
+		{50 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s", tc.timeout), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+			defer cancel()
+			var second int64 = time.Second.Nanoseconds()
+			_, err := c.Chill(ctx, &test_proto.Time{Time: &second})
+			if err == nil {
+				t.Fatal("Got no error, expected a timeout")
+			}
+			if !strings.HasPrefix(err.Error(), tc.expectedErrorPrefix) {
+				t.Errorf("Wrong error. Got %s, expected %s", err.Error(), tc.expectedErrorPrefix)
+			}
+		})
+	}
 }

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -131,6 +131,7 @@
     },
     "maxConcurrentRPCServerRequests": 100000,
     "features": {
+        "RPCHeadroom": true,
         "WildcardDomains": true,
         "EmbedSCTs": true
     }

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -35,6 +35,7 @@
       "timeout": "15s"
     },
     "features": {
+      "RPCHeadroom": true,
       "EmbedSCTs": true
     }
   },

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -18,6 +18,9 @@
     "saService": {
       "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
+    },
+    "features": {
+      "RPCHeadroom": true,
     }
   },
 

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -20,7 +20,7 @@
       "timeout": "15s"
     },
     "features": {
-      "RPCHeadroom": true,
+      "RPCHeadroom": true
     }
   },
 

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -46,6 +46,7 @@
       ]
     },
     "features": {
+      "RPCHeadroom": true,
       "WildcardDomains": true,
       "TLSSNIRevalidation": true,
       "ReusePendingAuthz": true,

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -26,6 +26,7 @@
       ]
     },
     "features": {
+      "RPCHeadroom": true,
       "WildcardDomains": true,
       "AllowRenewalFirstRL": true
     }

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -22,6 +22,7 @@
       ]
     },
     "features": {
+      "RPCHeadroom": true,
       "IPv6First": true
     }
   },

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -22,6 +22,7 @@
       ]
     },
     "features": {
+      "RPCHeadroom": true,
       "IPv6First": true
     }
   },

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -31,6 +31,7 @@
       "ServerURL": "http://boulder:6000"
     },
     "features": {
+      "RPCHeadroom": true,
       "VAChecksGSB": true,
       "IPv6First": true
     },

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -31,6 +31,7 @@
       "timeout": "15s"
     },
     "features": {
+      "RPCHeadroom": true,
       "UseAIAIssuerURL": true
     }
   },

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -35,6 +35,7 @@
       "http://127.0.0.1:4000/acme/issuer-cert": [ "test/test-ca2.pem" ]
     },
     "features": {
+      "RPCHeadroom": true,
       "EnforceV2ContentType": true
     }
   },


### PR DESCRIPTION
gRPC passes deadline information through the RPC boundary, but client and server have the same deadline. Ideally we'd like the server to have a slightly tighter deadline than the client, so if one of the server's onward RPCs or other network calls times out, the server can pass back more detailed information to the client, rather than the client timing out the server and losing the opportunity to log more detailed information about which component caused the timeout.

In this change, I subtract 100ms from the deadline on the server side of our interceptors, using our existing serverInterceptor. I also check that there is at least 100ms remaining in which to do useful work, so the server doesn't begin a potentially expensive task only to abort it.

Fixes #3608.