### PR TITLE
Default to DNS challenge in chisel and chisel2.

### DIFF
--- a/test/chisel.py
+++ b/test/chisel.py
@@ -190,7 +190,7 @@ def do_http_challenges(client, authzs):
         thread.join()
     return cleanup
 
-def auth_and_issue(domains, chall_type="http-01", email=None, cert_output=None, client=None):
+def auth_and_issue(domains, chall_type="dns-01", email=None, cert_output=None, client=None):
     """Make authzs for each of the given domains, set up a server to answer the
        challenges in those authzs, tell the ACME server to validate the challenges,
        then poll for the authzs to be ready and issue a cert."""

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -93,7 +93,7 @@ def http_01_answer(client, chall_body):
           chall=chall_body.chall, response=response,
           validation=validation)
 
-def auth_and_issue(domains, chall_type="http-01", email=None, cert_output=None, client=None):
+def auth_and_issue(domains, chall_type="dns-01", email=None, cert_output=None, client=None):
     """Make authzs for each of the given domains, set up a server to answer the
        challenges in those authzs, tell the ACME server to validate the challenges,
        then poll for the authzs to be ready and issue a cert."""

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -148,6 +148,9 @@ def test_multidomain():
 def test_dns_challenge():
     auth_and_issue([random_domain(), random_domain()], chall_type="dns-01")
 
+def test_http_challenge():
+    auth_and_issue([random_domain(), random_domain()], chall_type="http-01")
+
 def test_issuer():
     """
     Issue a certificate, fetch its chain, and verify the chain and

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -38,6 +38,9 @@ def test_wildcardmultidomain():
     """
     chisel2.auth_and_issue([random_domain(), "*."+random_domain()], chall_type="dns-01")
 
+def test_http_challenge():
+    chisel2.auth_and_issue([random_domain(), random_domain()], chall_type="http-01")
+
 def test_overlapping_wildcard():
     """
     Test issuance for a random domain and a wildcard version of the same domain


### PR DESCRIPTION
This allows these tools to easily be run in command line mode from
the host machine against a Boulder running inside `docker-compose up`
without modifying the FAKE_DNS field in docker-compose.yml. This
allows for easier testing of various conditions.