### PR TITLE
Give more detailed validation errors in VA

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -13,7 +13,6 @@ import (
 
 // MockDNSClient is a mock
 type MockDNSClient struct {
-	DefaultIP string
 }
 
 // LookupTXT is a mock
@@ -95,11 +94,8 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 			net.ParseIP("::1"),
 		}, nil
 	}
-	if mock.DefaultIP == "" {
-		return []net.IP{net.ParseIP("127.0.0.1")}, nil
-	} else {
-		return []net.IP{net.ParseIP(mock.DefaultIP)}, nil
-	}
+	ip := net.ParseIP("127.0.0.1")
+	return []net.IP{ip}, nil
 }
 
 // LookupCAA returns mock records for use in tests.

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -13,6 +13,7 @@ import (
 
 // MockDNSClient is a mock
 type MockDNSClient struct {
+	DefaultIP string
 }
 
 // LookupTXT is a mock
@@ -94,8 +95,11 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 			net.ParseIP("::1"),
 		}, nil
 	}
-	ip := net.ParseIP("127.0.0.1")
-	return []net.IP{ip}, nil
+	if mock.DefaultIP == "" {
+		return []net.IP{net.ParseIP("127.0.0.1")}, nil
+	} else {
+		return []net.IP{net.ParseIP(mock.DefaultIP)}, nil
+	}
 }
 
 // LookupCAA returns mock records for use in tests.

--- a/va/va.go
+++ b/va/va.go
@@ -125,6 +125,15 @@ func NewValidationAuthorityImpl(
 	clk clock.Clock,
 	logger blog.Logger,
 ) *ValidationAuthorityImpl {
+	if pc.HTTPPort == 0 {
+		pc.HTTPPort = 80
+	}
+	if pc.HTTPSPort == 0 {
+		pc.HTTPSPort = 443
+	}
+	if pc.TLSPort == 0 {
+		pc.TLSPort = 443
+	}
 
 	return &ValidationAuthorityImpl{
 		log:               logger,

--- a/va/va.go
+++ b/va/va.go
@@ -664,6 +664,9 @@ func detailedError(err error) *probs.ProblemDetails {
 			syscallErr.Err == syscall.ECONNREFUSED {
 			return probs.ConnectionFailure("Connection refused")
 		} else if syscallErr, ok := netErr.Err.(*os.SyscallError); ok &&
+			syscallErr.Err == syscall.ENETUNREACH {
+			return probs.ConnectionFailure("Network unreachable")
+		} else if syscallErr, ok := netErr.Err.(*os.SyscallError); ok &&
 			syscallErr.Err == syscall.ECONNRESET {
 			return probs.ConnectionFailure("Connection reset by peer")
 		} else if netErr.Timeout() && netErr.Op == "dial" {

--- a/va/va.go
+++ b/va/va.go
@@ -43,9 +43,9 @@ const (
 	maxResponseSize = 128
 )
 
-// singleDialTimeout specifies how long an individual `Dial` operation may take
+// singleDialTimeout specifies how long an individual `DialContext` operation may take
 // before timing out. This timeout ignores the base RPC timeout and is strictly
-// used for the Dial operations that take place during an
+// used for the DialContext operations that take place during an
 // HTTP-01/TLS-SNI-[01|02] challenge validation.
 var singleDialTimeout = time.Second * 10
 
@@ -179,8 +179,8 @@ func (va ValidationAuthorityImpl) getAddr(ctx context.Context, hostname string) 
 }
 
 // http01Dialer is a struct that exists to provide a dialer like object with
-// a `Dial` method that can be given to an http.Transport for HTTP-01
-// validation. The primary purpose of the http01Dialer's Dial method is to
+// a `DialContext` method that can be given to an http.Transport for HTTP-01
+// validation. The primary purpose of the http01Dialer's DialContext method is to
 // circumvent traditional DNS lookup and to use the IP addresses provided in the
 // inner `record` member populated by the `resolveAndConstructDialer` function.
 type http01Dialer struct {
@@ -191,19 +191,32 @@ type http01Dialer struct {
 
 // realDialer is used to create a true `net.Dialer` that can be used once an IP
 // address to connect to is determined. It increments the `dialerCount` integer
-// to track how many "fresh" dialer instances have been created during a `Dial`
-// for testing purposes.
+// to track how many "fresh" dialer instances have been created during a
+// `DialContext` for testing purposes.
 func (d *http01Dialer) realDialer() *net.Dialer {
 	// Record that we created a new instance of a real net.Dialer
 	d.dialerCount++
 	return &net.Dialer{Timeout: singleDialTimeout}
 }
 
-// Dial processes the IP addresses from the inner validation record, using
+// DialContext processes the IP addresses from the inner validation record, using
 // `realDialer` to make connections as required. If `features.IPv6First` is
 // enabled then for dual-homed hosts an initial IPv6 connection will be made
 // followed by a IPv4 connection if there is a failure with the IPv6 connection.
-func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
+func (d *http01Dialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		// Shouldn't happen: All requests should have a deadline by this point.
+		deadline = time.Now().Add(100 * time.Second)
+	} else {
+		// Set the context deadline slightly shorter than the HTTP deadline, so we
+		// get the dial error rather than a generic "deadline exceeded" error. This
+		// lets us give a more specific error to the subscriber.
+		deadline = deadline.Add(-10 * time.Millisecond)
+	}
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
 	var realDialer *net.Dialer
 
 	// Split the available addresses into v4 and v6 addresses
@@ -220,7 +233,7 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 		address := net.JoinHostPort(addresses[0].String(), d.record.Port)
 		d.record.AddressUsed = addresses[0]
 		realDialer = d.realDialer()
-		return realDialer.Dial("tcp", address)
+		return realDialer.DialContext(ctx, "tcp", address)
 	}
 
 	// If the IPv6 first feature is enabled and there is at least one IPv6 address
@@ -229,7 +242,7 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 		address := net.JoinHostPort(v6[0].String(), d.record.Port)
 		d.record.AddressUsed = v6[0]
 		realDialer = d.realDialer()
-		conn, err := realDialer.Dial("tcp", address)
+		conn, err := realDialer.DialContext(ctx, "tcp", address)
 
 		// If there is no error, return immediately
 		if err == nil {
@@ -258,7 +271,8 @@ func (d *http01Dialer) Dial(_, _ string) (net.Conn, error) {
 	address := net.JoinHostPort(v4[0].String(), d.record.Port)
 	d.record.AddressUsed = v4[0]
 	realDialer = d.realDialer()
-	return realDialer.Dial("tcp", address)
+	conn, err := realDialer.DialContext(ctx, "tcp", address)
+	return conn, err
 }
 
 // availableAddresses takes a ValidationRecord and splits the AddressesResolved
@@ -326,6 +340,7 @@ func (va *ValidationAuthorityImpl) fetchHTTP(ctx context.Context, identifier cor
 		return nil, nil, probs.Malformed("URL provided for HTTP was invalid")
 	}
 
+	httpRequest = httpRequest.WithContext(ctx)
 	if va.userAgent != "" {
 		httpRequest.Header["User-Agent"] = []string{va.userAgent}
 	}
@@ -333,7 +348,7 @@ func (va *ValidationAuthorityImpl) fetchHTTP(ctx context.Context, identifier cor
 	dialer, prob := va.resolveAndConstructDialer(ctx, host, port)
 	dialer.record.URL = url.String()
 	// Start with an empty validation record list - we will add a record after
-	// each dialer.Dial()
+	// each dialer.DialContext()
 	var validationRecords []core.ValidationRecord
 	if prob != nil {
 		return nil, []core.ValidationRecord{dialer.record}, prob
@@ -346,9 +361,9 @@ func (va *ValidationAuthorityImpl) fetchHTTP(ctx context.Context, identifier cor
 		// We don't expect to make multiple requests to a client, so close
 		// connection immediately.
 		DisableKeepAlives: true,
-		// Intercept Dial in order to connect to the IP address we
+		// Intercept DialContext in order to connect to the IP address we
 		// select.
-		Dial: dialer.Dial,
+		DialContext: dialer.DialContext,
 	}
 
 	// Some of our users use mod_security. Mod_security sees a lack of Accept
@@ -402,7 +417,7 @@ func (va *ValidationAuthorityImpl) fetchHTTP(ctx context.Context, identifier cor
 		if err != nil {
 			return err
 		}
-		tr.Dial = dialer.Dial
+		tr.DialContext = dialer.DialContext
 		va.log.Debug(fmt.Sprintf("%s [%s] redirect from %q to %q [%s]", challenge.Type, identifier, via[len(via)-1].URL.String(), req.URL.String(), dialer.record.AddressUsed))
 		return nil
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -271,8 +271,7 @@ func (d *http01Dialer) DialContext(ctx context.Context, _, _ string) (net.Conn, 
 	address := net.JoinHostPort(v4[0].String(), d.record.Port)
 	d.record.AddressUsed = v4[0]
 	realDialer = d.realDialer()
-	conn, err := realDialer.DialContext(ctx, "tcp", address)
-	return conn, err
+	return realDialer.DialContext(ctx, "tcp", address)
 }
 
 // availableAddresses takes a ValidationRecord and splits the AddressesResolved

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -414,7 +414,7 @@ func TestHTTPDialTimeout(t *testing.T) {
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
 	expectMatch := regexp.MustCompile(
-		"Fetching http://unroutable.invalid:\\d+/.well-known/acme-challenge/.*: Timeout during connect")
+		"Fetching http://unroutable.invalid/.well-known/acme-challenge/.*: Timeout during connect")
 	if !expectMatch.MatchString(prob.Detail) {
 		t.Errorf("Problem details incorrect. Got %q, expected to match %q",
 			prob.Detail, expectMatch)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -601,7 +601,11 @@ func TestTLSSNI01TimeoutAfterConnect(t *testing.T) {
 	// Set a short dial timeout so this test can happen quickly. Note: It would be
 	// better to override this with a context, but that doesn't work right now:
 	// https://github.com/letsencrypt/boulder/issues/3628
+	oldSingleDialTimeout := singleDialTimeout
 	singleDialTimeout = 50 * time.Millisecond
+	defer func() {
+		singleDialTimeout = oldSingleDialTimeout
+	}()
 	chall := createChallenge(core.ChallengeTypeTLSSNI01)
 	hs := slowTLSSrv()
 	va, _ := setup(hs, 0)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -340,7 +340,7 @@ func TestHTTPTimeout(t *testing.T) {
 	started := time.Now()
 	_, prob := va.validateHTTP01(ctx, dnsi("localhost"), chall)
 	took := time.Since(started)
-	// Check that the HTTP connection does't return before a timeout, and times
+	// Check that the HTTP connection doesn't return before a timeout, and times
 	// out after the expected time
 	test.Assert(t,
 		(took > (time.Second * singleDialTimeout)),
@@ -354,7 +354,7 @@ func TestHTTPTimeout(t *testing.T) {
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
 	expectMatch := regexp.MustCompile(
-		"Fetching http://localhost:\\d+/.well-known/acme-challenge/wait-long: Timeout")
+		"Fetching http://localhost:\\d+/.well-known/acme-challenge/wait-long: Timeout after connect")
 	if !expectMatch.MatchString(prob.Detail) {
 		t.Errorf("Problem details incorrect. Got %q, expected to match %q",
 			prob.Detail, expectMatch)


### PR DESCRIPTION
In particular, differentiate timeouts during connect (which are usually a firewall problem) from timeouts after connect (which are usually a software problem). In the process, refactor the tests and add testing for specific problem detail messages.

This also switches over the HTTP challenge's dialer to use DialContext, and to shave a little bit of headroom off of the context deadline, so that the dial can report its timeout before the overall context expires, which would lead to an overly generic "deadline exceeded" error, which would then get translated (incorrectly) into a "timeout after connect."

There is an additional error case, `Timeout during %s (your server may be slow or overloaded)`, (where `%s` can be `read` or `write`) which doesn't have any unittests. I believe it may not be possible to trigger this, since `read` and `write` timeouts get subsumed by the HTTP or TLS library, but it's worth having as a fallback case. We'll see if it shows up in the logs.

Among the test refactorings, I shortened the timeout on the TLS timeout test to 50ms. Previously this was the long pole making the whole test take 10s. Now it takes ~500 ms overall.

I recommend starting review at https://github.com/letsencrypt/boulder/compare/detailed-va-errors?expand=1#diff-4c51d1d7ca3ec3022d14b42809af0d7eR671 (the changes to `detailedError`), then reviewing the `Dial` -> `DialContext` changes, then the tests.