### PR TITLE
RA: Don't lose CA error types when prefixing err msg.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1122,15 +1122,26 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 		OrderID:        &orderIDInt,
 	}
 
+	// wrapError adds a prefix to an error. If the error is a boulder error then
+	// the problem detail is updated with the prefix. Otherwise a new error is
+	// returned with the message prefixed using `fmt.Errorf`
+	wrapError := func(e error, prefix string) error {
+		if berr, ok := e.(*berrors.BoulderError); ok {
+			berr.Detail = fmt.Sprintf("%s: %s", prefix, berr.Detail)
+			return berr
+		}
+		return fmt.Errorf("%s: %s", prefix, e)
+	}
+
 	var cert core.Certificate
 	if features.Enabled(features.EmbedSCTs) {
 		precert, err := ra.CA.IssuePrecertificate(ctx, issueReq)
 		if err != nil {
-			return emptyCert, fmt.Errorf("issuing precert: %s", err)
+			return emptyCert, wrapError(err, "issuing precert")
 		}
 		scts, err := ra.getSCTs(ctx, precert.DER)
 		if err != nil {
-			return emptyCert, fmt.Errorf("getting SCTs: %s", err)
+			return emptyCert, wrapError(err, "getting SCTs")
 		}
 		cert, err = ra.CA.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
 			DER:            precert.DER,
@@ -1139,12 +1150,12 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 			OrderID:        &orderIDInt,
 		})
 		if err != nil {
-			return emptyCert, fmt.Errorf("issuing cert for precert: %s", err)
+			return emptyCert, wrapError(err, "issuing cert for precert")
 		}
 	} else {
 		cert, err = ra.CA.IssueCertificate(ctx, issueReq)
 		if err != nil {
-			return emptyCert, fmt.Errorf("issuing cert: %s", err)
+			return emptyCert, wrapError(err, "issuing cert")
 		}
 
 		_, _ = ra.getSCTs(ctx, cert.DER)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1137,7 +1137,7 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	if features.Enabled(features.EmbedSCTs) {
 		precert, err := ra.CA.IssuePrecertificate(ctx, issueReq)
 		if err != nil {
-			return emptyCert, wrapError(err, "issuing precert")
+			return emptyCert, wrapError(err, "issuing precertificate")
 		}
 		scts, err := ra.getSCTs(ctx, precert.DER)
 		if err != nil {
@@ -1150,12 +1150,12 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 			OrderID:        &orderIDInt,
 		})
 		if err != nil {
-			return emptyCert, wrapError(err, "issuing cert for precert")
+			return emptyCert, wrapError(err, "issuing certificate for precertificate")
 		}
 	} else {
 		cert, err = ra.CA.IssueCertificate(ctx, issueReq)
 		if err != nil {
-			return emptyCert, wrapError(err, "issuing cert")
+			return emptyCert, wrapError(err, "issuing certificate")
 		}
 
 		_, _ = ra.getSCTs(ctx, cert.DER)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3752,7 +3752,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 				err: fmt.Errorf("bad bad not good"),
 			},
 			Features:    map[string]bool{"EmbedSCTs": true},
-			ExpectedErr: fmt.Errorf("issuing precert: bad bad not good"),
+			ExpectedErr: fmt.Errorf("issuing precertificate: bad bad not good"),
 		},
 		{
 			Name: "malformed problem during IssuePrecertificate",
@@ -3761,7 +3761,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 			},
 			Features: map[string]bool{"EmbedSCTs": true},
 			ExpectedProb: &berrors.BoulderError{
-				Detail: "issuing precert: detected 1x whack attack",
+				Detail: "issuing precertificate: detected 1x whack attack",
 				Type:   berrors.Malformed,
 			},
 		},
@@ -3771,7 +3771,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 				err: fmt.Errorf("aaaaaaaaaaaaaaaaaaaa!!"),
 			},
 			Features:    map[string]bool{"EmbedSCTs": true},
-			ExpectedErr: fmt.Errorf("issuing cert for precert: aaaaaaaaaaaaaaaaaaaa!!"),
+			ExpectedErr: fmt.Errorf("issuing certificate for precertificate: aaaaaaaaaaaaaaaaaaaa!!"),
 		},
 		{
 			Name: "malformed problem during IssueCertificateForPrecertificate",
@@ -3780,7 +3780,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 			},
 			Features: map[string]bool{"EmbedSCTs": true},
 			ExpectedProb: &berrors.BoulderError{
-				Detail: "issuing cert for precert: provided DER is DERanged",
+				Detail: "issuing certificate for precertificate: provided DER is DERanged",
 				Type:   berrors.Malformed,
 			},
 		},
@@ -3790,7 +3790,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 				err: fmt.Errorf("CA is out of certificates, try again later"),
 			},
 			Features:    map[string]bool{"EmbedSCTs": false},
-			ExpectedErr: fmt.Errorf("issuing cert: CA is out of certificates, try again later"),
+			ExpectedErr: fmt.Errorf("issuing certificate: CA is out of certificates, try again later"),
 		},
 		{
 			Name: "malformed problem during IssueCertificate",
@@ -3799,7 +3799,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 			},
 			Features: map[string]bool{"EmbedSCTs": false},
 			ExpectedProb: &berrors.BoulderError{
-				Detail: "issuing cert: CSR had a jillion and one names",
+				Detail: "issuing certificate: CSR had a jillion and one names",
 				Type:   berrors.Malformed,
 			},
 		},

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/bdns"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
@@ -3623,7 +3623,7 @@ type mockCAFailPrecert struct {
 
 func (ca *mockCAFailPrecert) IssuePrecertificate(
 	_ context.Context,
-	_ *caPB.IssueCertificateRequest) (*caPB.IssuePrecertificateResponse, error) {
+	_ *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
 	return nil, ca.err
 }
 
@@ -3635,15 +3635,15 @@ type mockCAFailCertForPrecert struct {
 }
 
 // IssuePrecertificate needs to be mocked for mockCAFailCertForPrecert's `IssueCertificateForPrecertificate` to get called.
-func (ca *mockCAFailCertForPrecert) IssuePrecertificate(_ context.Context, _ *caPB.IssueCertificateRequest) (*caPB.IssuePrecertificateResponse, error) {
-	return &caPB.IssuePrecertificateResponse{
+func (ca *mockCAFailCertForPrecert) IssuePrecertificate(_ context.Context, _ *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
+	return &capb.IssuePrecertificateResponse{
 		DER: []byte{},
 	}, nil
 }
 
 func (ca *mockCAFailCertForPrecert) IssueCertificateForPrecertificate(
 	_ context.Context,
-	_ *caPB.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
+	_ *capb.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
 	return core.Certificate{}, ca.err
 }
 
@@ -3655,7 +3655,7 @@ type mockCAFailIssueCert struct {
 
 func (ca *mockCAFailIssueCert) IssueCertificate(
 	_ context.Context,
-	_ *caPB.IssueCertificateRequest) (core.Certificate, error) {
+	_ *capb.IssueCertificateRequest) (core.Certificate, error) {
 	return core.Certificate{}, ca.err
 }
 

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -109,7 +109,7 @@ func TestLoadPolicies(t *testing.T) {
 
 	// Test that the PendingAuthorizationsPerAccount section parsed correctly
 	pendingAuthsPerAcct := policy.PendingAuthorizationsPerAccount()
-	test.AssertEquals(t, pendingAuthsPerAcct.Threshold, 20)
+	test.AssertEquals(t, pendingAuthsPerAcct.Threshold, 150)
 	test.AssertEquals(t, len(pendingAuthsPerAcct.Overrides), 0)
 	test.AssertEquals(t, len(pendingAuthsPerAcct.RegistrationOverrides), 0)
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -423,6 +423,17 @@ def test_expired_authzs_404():
             raise Exception("Unexpected response for expired authz: ",
                 response.status_code)
 
+def test_oversized_csr():
+    # Number of names is chosen to be one greater than the configured RA/CA maxNames
+    numNames = 101
+    # Generate numNames subdomains of a random domain
+    base_domain = random_domain()
+    domains = [ "{0}.{1}".format(str(n),base_domain) for n in range(numNames) ]
+    # We expect issuing for these domains to produce a malformed error because
+    # there are too many names in the request.
+    chisel.expect_problem("urn:acme:error:malformed",
+            lambda: auth_and_issue(domains))
+
 default_config_dir = os.environ.get('BOULDER_CONFIG_DIR', '')
 if default_config_dir == '':
     default_config_dir = 'test/config'

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -32,7 +32,7 @@ registrationsPerIPRange:
     127.0.0.1: 1000000
 pendingAuthorizationsPerAccount:
   window: 168h # 1 week, should match pending authorization lifetime.
-  threshold: 20
+  threshold: 150
 invalidAuthorizationsPerAccount:
   window: 5m
   threshold: 3


### PR DESCRIPTION
Previously we [updated the RA's `issueCertificateInner` function to prefix errors](https://github.com/letsencrypt/boulder/commit/c7e5fc1d41c25481be935d5daef745e575df7855) returned from the CA with meaningful information about which CA RPC caused the failure. Unfortunately by using `fmt.Errorf` to do this we're discarding the underlying error type. This can cause unexpected server internal errors downstream if (for e.g.) the CA rejects a CSR with a malformed error (see https://github.com/letsencrypt/boulder/issues/3632).

This PR updates the `issueCertificateInner` error message prefixing to maintain the error type if the underlying error is a `berrors.BoulderError`. A RA unit test with several mock CAs is added to test the prefixing occurs as expected without loss of error type.

This PR also adds an integration test that ensures we reject a CSR with >100 names with a  malformed error. This is not strictly related to this PR but since I wrote it while debugging the root issue I thought I'd include it. To allow this test to pass the `pendingAuthorizationsPerAccount` in `test/rate-limit-policies.yml` and associated tests had to be adjusted.

Resolves https://github.com/letsencrypt/boulder/issues/3632