### PR TITLE
RA,CA: Refuse to start with MaxNames == 0.

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -120,7 +120,7 @@ func main() {
 	cmd.FailOnError(err, "Failed to set feature flags")
 
 	if c.CA.MaxNames == 0 {
-		cmd.FailOnError(fmt.Errorf("MaxNames must not be 0"), "Error in CA config")
+		cmd.Fail(fmt.Sprintf("Error in CA config: MaxNames must not be 0"))
 	}
 
 	scope, logger := cmd.StatsAndLogging(c.Syslog, c.CA.DebugAddr)

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -119,6 +119,10 @@ func main() {
 	err = features.Set(c.CA.Features)
 	cmd.FailOnError(err, "Failed to set feature flags")
 
+	if c.CA.MaxNames == 0 {
+		cmd.FailOnError(fmt.Errorf("MaxNames must not be 0"), "Error in CA config")
+	}
+
 	scope, logger := cmd.StatsAndLogging(c.Syslog, c.CA.DebugAddr)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString())

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -195,6 +195,10 @@ func main() {
 	kp, err := goodkey.NewKeyPolicy(c.RA.WeakKeyFile)
 	cmd.FailOnError(err, "Unable to create key policy")
 
+	if c.RA.MaxNames == 0 {
+		cmd.FailOnError(fmt.Errorf("MaxNames must not be 0"), "Error in RA config")
+	}
+
 	rai := ra.NewRegistrationAuthorityImpl(
 		cmd.Clock(),
 		logger,

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -196,7 +196,7 @@ func main() {
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	if c.RA.MaxNames == 0 {
-		cmd.FailOnError(fmt.Errorf("MaxNames must not be 0"), "Error in RA config")
+		cmd.Fail(fmt.Sprintf("Error in RA config: MaxNames must not be 0"))
 	}
 
 	rai := ra.NewRegistrationAuthorityImpl(

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -190,13 +190,20 @@ func newScope(addr string, logger blog.Logger) metrics.Scope {
 	return metrics.NewPromScope(registry)
 }
 
-// FailOnError exits and prints an error message if we encountered a problem
+// Fail exits and prints an error message to stderr and the logger audit log.
+func Fail(msg string) {
+	logger := blog.Get()
+	logger.AuditErr(msg)
+	fmt.Fprintf(os.Stderr, msg)
+	os.Exit(1)
+}
+
+// FailOnError exits and prints an error message, but only if we encountered
+// a problem and err != nil
 func FailOnError(err error, msg string) {
 	if err != nil {
-		logger := blog.Get()
-		logger.AuditErr(fmt.Sprintf("%s: %s", msg, err))
-		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
-		os.Exit(1)
+		msg := fmt.Sprintf("%s: %s", msg, err)
+		Fail(msg)
 	}
 }
 

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -71,7 +71,7 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 	if len(csr.Subject.CommonName) > maxCNLength {
 		return fmt.Errorf("CN was longer than %d bytes", maxCNLength)
 	}
-	if maxNames > 0 && len(csr.DNSNames) > maxNames {
+	if len(csr.DNSNames) > maxNames {
 		return fmt.Errorf("CSR contains more than %d DNS names", maxNames)
 	}
 	badNames := []string{}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -280,7 +280,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
 		stats,
-		1, testKeyPolicy, 0, true, false, 300*24*time.Hour, 7*24*time.Hour, nil, noopCAA{}, 0, ctp)
+		1, testKeyPolicy, 100, true, false, 300*24*time.Hour, 7*24*time.Hour, nil, noopCAA{}, 0, ctp)
 	ra.SA = ssa
 	ra.VA = va
 	ra.CA = ca

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -915,7 +915,7 @@ func TestIssueCertificate(t *testing.T) {
 		stats,
 		0,
 		testKeyPolicy,
-		0,
+		100,
 		true,
 		false,
 		300*24*time.Hour,


### PR DESCRIPTION
This commit updates the `boulder-ra` and `boulder-ca` commands to refuse
to start if their configured `MaxNames` is 0 (the default value). This
should always be set to a positive number.

This commit also updates `csr/csr.go` to always apply the max names
check since it will never be 0 after the change above.

Related to https://github.com/letsencrypt/boulder/issues/3632