### PR TITLE
Allow configuring gRPC's MaxConcurrentStreams

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -281,6 +281,12 @@ type GRPCServerConfig struct {
 	// (SANs). The server will reject clients that do not present a certificate
 	// with a SAN present on the `ClientNames` list.
 	ClientNames []string `json:"clientNames"`
+	// gRPC multiplexes RPCs across HTTP/2 streams in a single TCP connection.
+	// HTTP/2 servers are allowed to set a limit on the number of streams a client
+	// will create. In Go by default that limit is 250. We can override that for
+	// our servers with this config value. In practice this is a limit on how many
+	// concurrent requests we can handle.
+	MaxConcurrentStreams int
 }
 
 // PortConfig specifies what ports the VA should call to on the remote

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -52,7 +52,7 @@ func NewServer(c *cmd.GRPCServerConfig, tls *tls.Config, serverMetrics *grpc_pro
 	return grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.UnaryInterceptor(si.intercept),
-		grpc.MaxConcurrentStreams(maxConcurrentStreams),
+		grpc.MaxConcurrentStreams(uint32(maxConcurrentStreams)),
 	), l, nil
 }
 

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -44,8 +44,16 @@ func NewServer(c *cmd.GRPCServerConfig, tls *tls.Config, serverMetrics *grpc_pro
 		return nil, nil, err
 	}
 
+	maxConcurrentStreams := c.MaxConcurrentStreams
+	if maxConcurrentStreams == 0 {
+		maxConcurrentStreams = 250
+	}
 	si := &serverInterceptor{serverMetrics}
-	return grpc.NewServer(grpc.Creds(creds), grpc.UnaryInterceptor(si.intercept)), l, nil
+	return grpc.NewServer(
+		grpc.Creds(creds),
+		grpc.UnaryInterceptor(si.intercept),
+		grpc.MaxConcurrentStreams(maxConcurrentStreams),
+	), l, nil
 }
 
 // NewServerMetrics constructs a *grpc_prometheus.ServerMetrics, registered with

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -16,6 +16,7 @@
     },
     "grpcCA": {
       "address": ":9093",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "ra.boulder"
       ]

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -5,6 +5,7 @@
     "debugAddr": ":8009",
     "grpc": {
       "address": ":9091",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "ra.boulder",
         "ocsp-updater.boulder"

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -40,6 +40,7 @@
     },
     "grpc": {
       "address": ":9094",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "wfe.boulder",
         "admin-revoker.boulder"

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -13,6 +13,7 @@
     },
     "grpc": {
       "address": ":9095",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "admin-revoker.boulder",
         "ca.boulder",

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -17,6 +17,7 @@
     },
     "grpc": {
       "address": ":9097",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "va.boulder"
       ]

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -17,6 +17,7 @@
     },
     "grpc": {
       "address": ":9098",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "va.boulder"
       ]

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -21,6 +21,7 @@
     },
     "grpc": {
       "address": ":9092",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "ra.boulder"
       ]


### PR DESCRIPTION
During periods of peak load, some RPCs are significantly delayed (on the order of seconds) by client-side blocking. HTTP/2 clients have to obey a "max concurrent streams" setting sent by the server. In Go's HTTP/2 implementation, this value [defaults to 250](https://github.com/golang/net/blob/master/http2/server.go#L56), so the gRPC default is also 250. So whenever there are more than 250 requests in progress at a time, additional requests will be delayed until there is a slot available.

During this peak load, we aren't hitting limits on CPU or memory, so we should increase the max concurrent streams limit to take better advantage of our available resources. This PR adds a config field to do that.

Fixes #3641.