### PR TITLE
Fix newOrder ready status regression, restore ready status.

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -36,6 +36,7 @@ const (
 	StatusUnknown     = AcmeStatus("unknown")     // Unknown status; the default
 	StatusPending     = AcmeStatus("pending")     // In process; client has next action
 	StatusProcessing  = AcmeStatus("processing")  // In process; server has next action
+	StatusReady       = AcmeStatus("ready")       // Order is ready for finalization
 	StatusValid       = AcmeStatus("valid")       // Object is valid
 	StatusInvalid     = AcmeStatus("invalid")     // Validation failed
 	StatusRevoked     = AcmeStatus("revoked")     // Object no longer valid

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedUseAIAIssuerURLReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcards"
+const _FeatureFlag_name = "unusedUseAIAIssuerURLReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatus"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 21, 38, 60, 69, 88, 103, 124, 147, 158, 176, 185, 204, 215, 235, 262}
+var _FeatureFlag_index = [...]uint16{0, 6, 21, 38, 60, 69, 88, 103, 124, 147, 158, 176, 185, 204, 215, 235, 262, 278}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -36,6 +36,8 @@ const (
 	EnforceV2ContentType
 	// Reject new-orders that contain a hostname redundant with a wildcard.
 	EnforceOverlappingWildcards
+	// Set orders to status "ready" when they are awaiting finalization
+	OrderReadyStatus
 )
 
 // List of features and their default value, protected by fMu
@@ -56,6 +58,7 @@ var features = map[FeatureFlag]bool{
 	EnforceV2ContentType:        false,
 	ForceConsistentStatus:       false,
 	EnforceOverlappingWildcards: false,
+	OrderReadyStatus:            false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -527,6 +527,11 @@ func (sa *StorageAuthority) GetOrder(_ context.Context, req *sapb.OrderRequest) 
 		validOrder.Expires = &exp
 	}
 
+	if *req.Id == 8 {
+		ready := string(core.StatusReady)
+		validOrder.Status = &ready
+	}
+
 	return validOrder, nil
 }
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1460,6 +1460,9 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *corepb.Order)
 	// Update the request with the created timestamp from the model
 	createdTS := order.Created.UnixNano()
 	req.Created = &createdTS
+	// A new order is never processing because it can't have been finalized yet
+	processingStatus := false
+	req.BeganProcessing = &processingStatus
 
 	// If the OrderReadyStatus feature is enabled we need to calculate the order
 	// status before returning it. Since it may have reused all valid
@@ -1478,9 +1481,6 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *corepb.Order)
 		pendingStatus := string(core.StatusPending)
 		req.Status = &pendingStatus
 	}
-	// A new order is never processing because it can't have been finalized yet
-	processingStatus := false
-	req.BeganProcessing = &processingStatus
 	// Return the new order
 	return req, nil
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -29,7 +29,7 @@
       "RPCHeadroom": true,
       "WildcardDomains": true,
       "AllowRenewalFirstRL": true,
-      "OrderReadyStatus": true
+      "OrderReadyStatus": false
     }
   },
 

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -28,7 +28,8 @@
     "features": {
       "RPCHeadroom": true,
       "WildcardDomains": true,
-      "AllowRenewalFirstRL": true
+      "AllowRenewalFirstRL": true,
+      "OrderReadyStatus": true
     }
   },
 

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -35,8 +35,8 @@
       "http://127.0.0.1:4000/acme/issuer-cert": [ "test/test-ca2.pem" ]
     },
     "features": {
-      "RPCHeadroom": true,
-      "EnforceV2ContentType": true
+      "EnforceV2ContentType": true,
+      "RPCHeadroom": true
     }
   },
 

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -115,6 +115,16 @@ def test_bad_overlap_wildcard():
     chisel2.expect_problem("urn:ietf:params:acme:error:malformed",
         lambda: chisel2.auth_and_issue(["*.example.com", "www.example.com"]))
 
+def test_duplicate_orders():
+    """
+    Test that the same client issuing for the same domain names twice in a row
+    works without error.
+    """
+    client = chisel2.make_client(None)
+    domains = [ random_domain() ]
+    chisel2.auth_and_issue(domains, client=client)
+    chisel2.auth_and_issue(domains, client=client)
+
 def test_order_reuse_failed_authz():
     """
     Test that creating an order for a domain name, failing an authorization in

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -185,8 +185,8 @@ def test_order_finalize_early():
 
     deadline = datetime.datetime.now() + datetime.timedelta(seconds=5)
 
-    # Finalize the order without doing anything with the authorizations. YOLO
-    # We expect this to generate an unauthorized error.
+    # Finalizing an order early should generate an unauthorized error and we
+    # should check that the order is invalidated.
     chisel2.expect_problem("urn:ietf:params:acme:error:unauthorized",
         lambda: client.finalize_order(order, deadline))
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1955,7 +1955,7 @@ func TestFinalizeOrder(t *testing.T) {
 			Name: "Order is already finalized",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 1 as an Order with a Serial
 			Request:      signAndPost(t, "1/1", "http://localhost/1/1", goodCertCSRPayload, 1, wfe.nonceService),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order's status (\"valid\") was not pending","status":400}`,
+			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order's status (\"valid\") is not acceptable for finalization","status":400}`,
 		},
 		{
 			Name: "Order is expired",
@@ -1969,7 +1969,7 @@ func TestFinalizeOrder(t *testing.T) {
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Error parsing certificate request: asn1: structure error: tags don't match (16 vs {class:0 tag:0 length:16 isCompound:false}) {optional:false explicit:false application:false defaultValue:\u003cnil\u003e tag:\u003cnil\u003e stringType:0 timeType:0 set:false omitEmpty:false} certificateRequest @2","status":400}`,
 		},
 		{
-			Name:            "Good CSR",
+			Name:            "Good CSR, Pending Order",
 			Request:         signAndPost(t, "1/4", "http://localhost/1/4", goodCertCSRPayload, 1, wfe.nonceService),
 			ExpectedHeaders: map[string]string{"Location": "http://localhost/acme/order/1/4"},
 			ExpectedBody: `
@@ -1983,6 +1983,23 @@ func TestFinalizeOrder(t *testing.T) {
     "http://localhost/acme/authz/hello"
   ],
   "finalize": "http://localhost/acme/finalize/1/4"
+}`,
+		},
+		{
+			Name:            "Good CSR, Ready Order",
+			Request:         signAndPost(t, "1/8", "http://localhost/1/8", goodCertCSRPayload, 1, wfe.nonceService),
+			ExpectedHeaders: map[string]string{"Location": "http://localhost/acme/order/1/8"},
+			ExpectedBody: `
+{
+  "status": "processing",
+  "expires": "1970-01-01T00:00:00.9466848Z",
+  "identifiers": [
+    {"type":"dns","value":"example.com"}
+  ],
+  "authorizations": [
+    "http://localhost/acme/authz/hello"
+  ],
+  "finalize": "http://localhost/acme/finalize/1/8"
 }`,
 		},
 	}


### PR DESCRIPTION
In #3614 we adjusted the `SA.NewOrder` function to conditionally call `ssa.statusForOrder` on the new order when `features.OrderReadyStatus` was enabled. Unfortunately this call to `ssa.statusForOrder` happened *before* the `req.BeganProcessing` field was initialized with a pointer to a `false` bool. The `ssa.statusForOrder` function (correctly) assumes that `req.BeganProcessing == nil` is illegal and doesn't correspond to a known status. This results in `NewOrder` requests returning a 500 error
of the form: 
> Internal error - Error creating new order - Order XXX is in an invalid state. No state known for this order's authorizations

Our integration tests missed this because we didn't have a test case that issued for a set of names with one account, and then issued again for the same set of names with the same account.

This PR fixes the original bug by moving the `BeganProcessing` initialization before the call to `statusForOrder`. This PR also adds an integration test to catch this sort of bug again in the future.
Prior to the SA fix this test failed with the 500 server internal error observed by the Certbot team. With the SA fix in place the test passes again.

Finally, this PR disables the `OrderReadyStatus` feature flag in `test/config-next/sa.json`. Certbot's ACME implementation breaks when this flag is enabled (See https://github.com/certbot/certbot/issues/5856). Since Certbot runs integration tests against Boulder with config-next we should be courteous and leave this flag disabled until we are closer to being able to turn it on for staging/prod.

_**Note to reviewers**: It might be easiest to look at 758ebc3 to evaluate the bug fix. You may want to check out the branch at this commit and run the integration tests to assure yourself that it was the correct fix before the flag is disabled in 14689d8. The bulk of this diff is ac6672b which restores already reviewed code from 3614_