### PR TITLE
Randomize order of CT logs when submitting precerts

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -171,9 +171,9 @@ func main() {
 				Logs: logs,
 			}
 		}
-		ctp = ctpolicy.New(pubc, groups, nil, logger)
+		ctp = ctpolicy.New(pubc, groups, nil, logger, scope)
 	} else if c.RA.CTLogGroups2 != nil {
-		ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, c.RA.InformationalCTLogs, logger)
+		ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, c.RA.InformationalCTLogs, logger, scope)
 	}
 
 	saConn, err := bgrpc.ClientSetup(c.RA.SAService, tlsConfig, clientMetrics)

--- a/ctpolicy/ctpolicy_test.go
+++ b/ctpolicy/ctpolicy_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/metrics"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type mockPub struct {
@@ -120,7 +122,7 @@ func TestGetSCTs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctp := New(tc.mock, tc.groups, nil, blog.NewMock())
+			ctp := New(tc.mock, tc.groups, nil, blog.NewMock(), metrics.NewNoopScope())
 			ret, err := ctp.GetSCTs(tc.ctx, []byte{0})
 			if tc.result != nil {
 				test.AssertDeepEquals(t, ret, tc.result)
@@ -134,4 +136,40 @@ func TestGetSCTs(t *testing.T) {
 			}
 		})
 	}
+}
+
+type failOne struct {
+	mockPub
+
+	badURL string
+}
+
+func (mp *failOne) SubmitToSingleCTWithResult(_ context.Context, req *pubpb.Request) (*pubpb.Result, error) {
+	if *req.LogURL == mp.badURL {
+		return nil, errors.New("BAD")
+	}
+	return &pubpb.Result{Sct: []byte{0}}, nil
+}
+
+func TestGetSCTsMetrics(t *testing.T) {
+	ctp := New(&failOne{badURL: "abc"}, []cmd.CTGroup{
+		{
+			Name: "a",
+			Logs: []cmd.LogDescription{
+				{URI: "abc", Key: "def"},
+				{URI: "ghi", Key: "jkl"},
+			},
+		},
+		{
+			Name: "b",
+			Logs: []cmd.LogDescription{
+				{URI: "abc", Key: "def"},
+				{URI: "ghi", Key: "jkl"},
+			},
+		},
+	}, nil, blog.NewMock(), metrics.NewNoopScope())
+	_, err := ctp.GetSCTs(context.Background(), []byte{0})
+	test.AssertNotError(t, err, "GetSCTs failed")
+	test.AssertEquals(t, test.CountCounter(ctp.winnerCounter.With(prometheus.Labels{"log": "ghi", "group": "a"})), 1)
+	test.AssertEquals(t, test.CountCounter(ctp.winnerCounter.With(prometheus.Labels{"log": "ghi", "group": "b"})), 1)
 }

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -276,7 +276,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 		Status:    core.StatusValid,
 	})
 
-	ctp := ctpolicy.New(&mocks.Publisher{}, nil, nil, log)
+	ctp := ctpolicy.New(&mocks.Publisher{}, nil, nil, log, metrics.NewNoopScope())
 
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
@@ -3508,7 +3508,7 @@ func TestCTPolicyMeasurements(t *testing.T) {
 		PEM: eeCertPEM,
 	}
 
-	ctp := ctpolicy.New(&timeoutPub{}, []cmd.CTGroup{{}}, nil, log)
+	ctp := ctpolicy.New(&timeoutPub{}, []cmd.CTGroup{{}}, nil, log, metrics.NewNoopScope())
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
 		stats,

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -908,7 +908,7 @@ func TestIssueCertificate(t *testing.T) {
 	// authorized, etc.
 	stats := metrics.NewNoopScope()
 
-	ctp := ctpolicy.New(&mocks.Publisher{}, nil, nil, wfe.log)
+	ctp := ctpolicy.New(&mocks.Publisher{}, nil, nil, wfe.log, metrics.NewNoopScope())
 	ra := ra.NewRegistrationAuthorityImpl(
 		fc,
 		wfe.log,


### PR DESCRIPTION
So we maximize the chances we actually exercise all of the logs in a group and not just the first in the list.