### PR TITLE
gRPC: publish RPC latency stat in server interceptor.

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -65,8 +65,10 @@ func setupContext(c config) (core.RegistrationAuthority, blog.Logger, *gorp.DbMa
 	tlsConfig, err := c.Revoker.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
+	clk := cmd.Clock()
+
 	clientMetrics := bgrpc.NewClientMetrics(metrics.NewNoopScope())
-	raConn, err := bgrpc.ClientSetup(c.Revoker.RAService, tlsConfig, clientMetrics)
+	raConn, err := bgrpc.ClientSetup(c.Revoker.RAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to RA")
 	rac := bgrpc.NewRegistrationAuthorityClient(rapb.NewRegistrationAuthorityClient(raConn))
 
@@ -75,7 +77,7 @@ func setupContext(c config) (core.RegistrationAuthority, blog.Logger, *gorp.DbMa
 	dbMap, err := sa.NewDbMap(dbURL, c.Revoker.DBConfig.MaxDBConns)
 	cmd.FailOnError(err, "Couldn't setup database connection")
 
-	saConn, err := bgrpc.ClientSetup(c.Revoker.SAService, tlsConfig, clientMetrics)
+	saConn, err := bgrpc.ClientSetup(c.Revoker.SAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(saConn))
 

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -70,8 +70,10 @@ func main() {
 	tlsConfig, err := c.Publisher.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
+	clk := cmd.Clock()
+
 	clientMetrics := bgrpc.NewClientMetrics(scope)
-	conn, err := bgrpc.ClientSetup(c.Publisher.SAService, tlsConfig, clientMetrics)
+	conn, err := bgrpc.ClientSetup(c.Publisher.SAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 
@@ -83,7 +85,7 @@ func main() {
 		sac)
 
 	serverMetrics := bgrpc.NewServerMetrics(scope)
-	grpcSrv, l, err := bgrpc.NewServer(c.Publisher.GRPC, tlsConfig, serverMetrics)
+	grpcSrv, l, err := bgrpc.NewServer(c.Publisher.GRPC, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup Publisher gRPC server")
 	gw := bgrpc.NewPublisherServerWrapper(pubi)
 	pubPB.RegisterPublisherServer(grpcSrv, gw)

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -140,26 +140,28 @@ func main() {
 	tlsConfig, err := c.RA.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
+	clk := cmd.Clock()
+
 	clientMetrics := bgrpc.NewClientMetrics(scope)
-	vaConn, err := bgrpc.ClientSetup(c.RA.VAService, tlsConfig, clientMetrics)
+	vaConn, err := bgrpc.ClientSetup(c.RA.VAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Unable to create VA client")
 	vac := bgrpc.NewValidationAuthorityGRPCClient(vaConn)
 
 	caaClient := vaPB.NewCAAClient(vaConn)
 
-	caConn, err := bgrpc.ClientSetup(c.RA.CAService, tlsConfig, clientMetrics)
+	caConn, err := bgrpc.ClientSetup(c.RA.CAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Unable to create CA client")
 	// Build a CA client that is only capable of issuing certificates, not
 	// signing OCSP. TODO(jsha): Once we've fully moved to gRPC, replace this
 	// with a plain caPB.NewCertificateAuthorityClient.
 	cac := bgrpc.NewCertificateAuthorityClient(caPB.NewCertificateAuthorityClient(caConn), nil)
 
-	raConn, err := bgrpc.ClientSetup(c.RA.PublisherService, tlsConfig, clientMetrics)
+	raConn, err := bgrpc.ClientSetup(c.RA.PublisherService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to Publisher")
 	pubc := bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(raConn))
 
 	var ctp *ctpolicy.CTPolicy
-	conn, err := bgrpc.ClientSetup(c.RA.PublisherService, tlsConfig, clientMetrics)
+	conn, err := bgrpc.ClientSetup(c.RA.PublisherService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to Publisher")
 	pubc = bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn))
 
@@ -176,7 +178,7 @@ func main() {
 		ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, c.RA.InformationalCTLogs, logger, scope)
 	}
 
-	saConn, err := bgrpc.ClientSetup(c.RA.SAService, tlsConfig, clientMetrics)
+	saConn, err := bgrpc.ClientSetup(c.RA.SAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(saConn))
 
@@ -200,7 +202,7 @@ func main() {
 	}
 
 	rai := ra.NewRegistrationAuthorityImpl(
-		cmd.Clock(),
+		clk,
 		logger,
 		scope,
 		c.RA.MaxContactsPerRegistration,
@@ -234,14 +236,14 @@ func main() {
 			raDNSTimeout,
 			c.RA.DNSResolvers,
 			scope,
-			cmd.Clock(),
+			clk,
 			dnsTries)
 	} else {
 		rai.DNSClient = bdns.NewTestDNSClientImpl(
 			raDNSTimeout,
 			c.RA.DNSResolvers,
 			scope,
-			cmd.Clock(),
+			clk,
 			dnsTries)
 	}
 
@@ -250,7 +252,7 @@ func main() {
 	rai.SA = sac
 
 	serverMetrics := bgrpc.NewServerMetrics(scope)
-	grpcSrv, listener, err := bgrpc.NewServer(c.RA.GRPC, tlsConfig, serverMetrics)
+	grpcSrv, listener, err := bgrpc.NewServer(c.RA.GRPC, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup RA gRPC server")
 	gw := bgrpc.NewRegistrationAuthorityServer(rai)
 	rapb.RegisterRegistrationAuthorityServer(grpcSrv, gw)

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -66,17 +66,19 @@ func main() {
 	}
 	go sa.ReportDbConnCount(dbMap, scope)
 
+	clk := cmd.Clock()
+
 	parallel := saConf.ParallelismPerRPC
 	if parallel < 1 {
 		parallel = 1
 	}
-	sai, err := sa.NewSQLStorageAuthority(dbMap, cmd.Clock(), logger, scope, parallel)
+	sai, err := sa.NewSQLStorageAuthority(dbMap, clk, logger, scope, parallel)
 	cmd.FailOnError(err, "Failed to create SA impl")
 
 	tls, err := c.SA.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 	serverMetrics := bgrpc.NewServerMetrics(scope)
-	grpcSrv, listener, err := bgrpc.NewServer(c.SA.GRPC, tls, serverMetrics)
+	grpcSrv, listener, err := bgrpc.NewServer(c.SA.GRPC, tls, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup SA gRPC server")
 	gw := bgrpc.NewStorageAuthorityServer(sai)
 	sapb.RegisterStorageAuthorityServer(grpcSrv, gw)

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -117,7 +117,7 @@ func main() {
 	var remotes []va.RemoteVA
 	if len(c.VA.RemoteVAs) > 0 {
 		for _, rva := range c.VA.RemoteVAs {
-			vaConn, err := bgrpc.ClientSetup(&rva, tlsConfig, clientMetrics)
+			vaConn, err := bgrpc.ClientSetup(&rva, tlsConfig, clientMetrics, clk)
 			cmd.FailOnError(err, "Unable to create remote VA client")
 			remotes = append(
 				remotes,
@@ -142,7 +142,7 @@ func main() {
 		logger)
 
 	serverMetrics := bgrpc.NewServerMetrics(scope)
-	grpcSrv, l, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, serverMetrics)
+	grpcSrv, l, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup VA gRPC server")
 	err = bgrpc.RegisterValidationAuthorityGRPCServer(grpcSrv, vai)
 	cmd.FailOnError(err, "Unable to register VA gRPC server")

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/features"
@@ -60,16 +61,16 @@ type config struct {
 	}
 }
 
-func setupWFE(c config, logger blog.Logger, stats metrics.Scope) (core.RegistrationAuthority, core.StorageAuthority) {
+func setupWFE(c config, logger blog.Logger, stats metrics.Scope, clk clock.Clock) (core.RegistrationAuthority, core.StorageAuthority) {
 	tlsConfig, err := c.WFE.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
 	clientMetrics := bgrpc.NewClientMetrics(stats)
-	raConn, err := bgrpc.ClientSetup(c.WFE.RAService, tlsConfig, clientMetrics)
+	raConn, err := bgrpc.ClientSetup(c.WFE.RAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to RA")
 	rac := bgrpc.NewRegistrationAuthorityClient(rapb.NewRegistrationAuthorityClient(raConn))
 
-	saConn, err := bgrpc.ClientSetup(c.WFE.SAService, tlsConfig, clientMetrics)
+	saConn, err := bgrpc.ClientSetup(c.WFE.SAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(saConn))
 
@@ -95,11 +96,13 @@ func main() {
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString())
 
+	clk := cmd.Clock()
+
 	kp, err := goodkey.NewKeyPolicy("") // don't load any weak keys
 	cmd.FailOnError(err, "Unable to create key policy")
-	wfe, err := wfe.NewWebFrontEndImpl(scope, cmd.Clock(), kp, logger)
+	wfe, err := wfe.NewWebFrontEndImpl(scope, clk, kp, logger)
 	cmd.FailOnError(err, "Unable to create WFE")
-	rac, sac := setupWFE(c, logger, scope)
+	rac, sac := setupWFE(c, logger, scope, clk)
 	wfe.RA = rac
 	wfe.SA = sac
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -481,8 +481,10 @@ func main() {
 	tlsConfig, err := c.Mailer.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
+	clk := cmd.Clock()
+
 	clientMetrics := bgrpc.NewClientMetrics(scope)
-	conn, err := bgrpc.ClientSetup(c.Mailer.SAService, tlsConfig, clientMetrics)
+	conn, err := bgrpc.ClientSetup(c.Mailer.SAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 
@@ -557,7 +559,7 @@ func main() {
 		emailTemplate:   tmpl,
 		nagTimes:        nags,
 		limit:           c.Mailer.CertLimit,
-		clk:             cmd.Clock(),
+		clk:             clk,
 		stats:           initStats(scope),
 	}
 

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -142,7 +142,7 @@ func setup(configFile string) (blog.Logger, core.StorageAuthority) {
 	cmd.FailOnError(err, "TLS config")
 
 	clientMetrics := bgrpc.NewClientMetrics(metrics.NewNoopScope())
-	conn, err := bgrpc.ClientSetup(conf.SAService, tlsConfig, clientMetrics)
+	conn, err := bgrpc.ClientSetup(conf.SAService, tlsConfig, clientMetrics, cmd.Clock())
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(conn))
 

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 
@@ -16,7 +17,7 @@ import (
 // a client certificate and validates the the server certificate based
 // on the provided *tls.Config.
 // It dials the remote service and returns a grpc.ClientConn if successful.
-func ClientSetup(c *cmd.GRPCClientConfig, tls *tls.Config, clientMetrics *grpc_prometheus.ClientMetrics) (*grpc.ClientConn, error) {
+func ClientSetup(c *cmd.GRPCClientConfig, tls *tls.Config, clientMetrics *grpc_prometheus.ClientMetrics, clk clock.Clock) (*grpc.ClientConn, error) {
 	if len(c.ServerAddresses) == 0 {
 		return nil, fmt.Errorf("boulder/grpc: ServerAddresses is empty")
 	}
@@ -24,7 +25,7 @@ func ClientSetup(c *cmd.GRPCClientConfig, tls *tls.Config, clientMetrics *grpc_p
 		return nil, errNilTLS
 	}
 
-	ci := clientInterceptor{c.Timeout.Duration, clientMetrics}
+	ci := clientInterceptor{c.Timeout.Duration, clientMetrics, clk}
 	creds := bcreds.NewClientCredentials(tls.RootCAs, tls.Certificates)
 	return grpc.Dial(
 		"", // Since our staticResolver provides addresses we don't need to pass an address here

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -100,7 +100,7 @@ func (si *serverInterceptor) observeLatency(clientReqTime string) error {
 	}
 	// Calculate the elapsed time since the client sent the RPC
 	reqTime := time.Unix(0, reqTimeUnixNanos)
-	elapsed := si.clk.Now().Sub(reqTime)
+	elapsed := si.clk.Since(reqTime)
 	// Publish an RPC latency observation to the histogram
 	si.metrics.rpcLag.Observe(elapsed.Seconds())
 	return nil

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -34,8 +34,8 @@ type serverInterceptor struct {
 
 func newServerInterceptor(metrics serverMetrics, clk clock.Clock) serverInterceptor {
 	return serverInterceptor{
-		serverMetrics: metrics.GRPCMetrics,
-		rpcLag:        metrics.RPCLag,
+		serverMetrics: metrics.grpcMetrics,
+		rpcLag:        metrics.rpcLag,
 		clk:           clk,
 	}
 }

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -93,13 +93,13 @@ func (si *serverInterceptor) intercept(ctx context.Context, req interface{}, inf
 // is returned if the `clientReqTime` string is not a valid timestamp.
 func (si *serverInterceptor) observeLatency(clientReqTime string) error {
 	// Convert the metadata request time into an int64
-	reqTimeUnix, err := strconv.ParseInt(clientReqTime, 10, 64)
+	reqTimeUnixNanos, err := strconv.ParseInt(clientReqTime, 10, 64)
 	if err != nil {
 		return berrors.InternalServerError("grpc metadata had illegal %s value: %q - %s",
 			clientRequestTimeKey, clientReqTime, err)
 	}
 	// Calculate the elapsed time since the client sent the RPC
-	reqTime := time.Unix(0, reqTimeUnix)
+	reqTime := time.Unix(0, reqTimeUnixNanos)
 	elapsed := si.clk.Now().Sub(reqTime)
 	// Publish an RPC latency observation to the histogram
 	si.metrics.rpcLag.Observe(elapsed.Seconds())

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -42,14 +42,10 @@ func (si *serverInterceptor) intercept(ctx context.Context, req interface{}, inf
 		return nil, berrors.InternalServerError("passed nil *grpc.UnaryServerInfo")
 	}
 
-	// Extract the grpc metadata from the context
-	md, ok := metadata.FromContext(ctx)
-	if !ok {
-		return nil, berrors.InternalServerError("passed context with no grpc metadata")
-	}
-	// If there is a `clientRequestTimeKey` field, and it has a value, then
-	// observe the RPC latency with Prometheus.
-	if len(md[clientRequestTimeKey]) > 0 {
+	// Extract the grpc metadata from the context. If the context has
+	// a `clientRequestTimeKey` field, and it has a value, then observe the RPC
+	// latency with Prometheus.
+	if md, ok := metadata.FromContext(ctx); ok && len(md[clientRequestTimeKey]) > 0 {
 		if err := si.observeLatency(md[clientRequestTimeKey][0]); err != nil {
 			return nil, err
 		}

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/grpc/test_proto"
@@ -40,20 +41,27 @@ func testInvoker(_ context.Context, method string, _, _ interface{}, _ *grpc.Cli
 }
 
 func TestServerInterceptor(t *testing.T) {
-	si := serverInterceptor{grpc_prometheus.NewServerMetrics()}
+	serverMetrics := NewServerMetrics(metrics.NewNoopScope())
+	si := newServerInterceptor(serverMetrics, clock.NewFake())
+
+	md := metadata.New(map[string]string{clientRequestTimeKey: "0"})
+	ctxWithMetadata := metadata.NewContext(context.Background(), md)
 
 	_, err := si.intercept(context.Background(), nil, nil, testHandler)
+	test.AssertError(t, err, "si.intercept didn't fail with a context missing metadata")
+
+	_, err = si.intercept(ctxWithMetadata, nil, nil, testHandler)
 	test.AssertError(t, err, "si.intercept didn't fail with a nil grpc.UnaryServerInfo")
 
-	_, err = si.intercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "-service-test"}, testHandler)
+	_, err = si.intercept(ctxWithMetadata, nil, &grpc.UnaryServerInfo{FullMethod: "-service-test"}, testHandler)
 	test.AssertNotError(t, err, "si.intercept failed with a non-nil grpc.UnaryServerInfo")
 
-	_, err = si.intercept(context.Background(), 0, &grpc.UnaryServerInfo{FullMethod: "brokeTest"}, testHandler)
+	_, err = si.intercept(ctxWithMetadata, 0, &grpc.UnaryServerInfo{FullMethod: "brokeTest"}, testHandler)
 	test.AssertError(t, err, "si.intercept didn't fail when handler returned a error")
 }
 
 func TestClientInterceptor(t *testing.T) {
-	ci := clientInterceptor{time.Second, grpc_prometheus.NewClientMetrics()}
+	ci := clientInterceptor{time.Second, grpc_prometheus.NewClientMetrics(), clock.NewFake()}
 	err := ci.intercept(context.Background(), "-service-test", nil, nil, nil, testInvoker)
 	test.AssertNotError(t, err, "ci.intercept failed with a non-nil grpc.UnaryServerInfo")
 
@@ -66,7 +74,7 @@ func TestClientInterceptor(t *testing.T) {
 // timeout is reached, i.e. that FailFast is set to false.
 // https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md
 func TestFailFastFalse(t *testing.T) {
-	ci := &clientInterceptor{100 * time.Millisecond, grpc_prometheus.NewClientMetrics()}
+	ci := &clientInterceptor{100 * time.Millisecond, grpc_prometheus.NewClientMetrics(), clock.NewFake()}
 	conn, err := grpc.Dial("localhost:19876", // random, probably unused port
 		grpc.WithInsecure(),
 		grpc.WithBalancer(grpc.RoundRobin(newStaticResolver([]string{"localhost:19000"}))),
@@ -116,7 +124,8 @@ func TestTimeouts(t *testing.T) {
 	}
 	port := lis.Addr().(*net.TCPAddr).Port
 
-	si := &serverInterceptor{NewServerMetrics(metrics.NewNoopScope())}
+	serverMetrics := NewServerMetrics(metrics.NewNoopScope())
+	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
 	test_proto.RegisterChillerServer(s, &testServer{})
 	go func() {
@@ -129,7 +138,7 @@ func TestTimeouts(t *testing.T) {
 	defer s.Stop()
 
 	// make client
-	ci := &clientInterceptor{30 * time.Second, grpc_prometheus.NewClientMetrics()}
+	ci := &clientInterceptor{30 * time.Second, grpc_prometheus.NewClientMetrics(), clock.NewFake()}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", fmt.Sprintf("%d", port)),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ci.intercept))
@@ -160,4 +169,55 @@ func TestTimeouts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequestTimeTagging(t *testing.T) {
+	clk := clock.NewFake()
+	// Listen for TCP requests on a random system assigned port number
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	// Retrieve the concrete port numberthe system assigned our listener
+	port := lis.Addr().(*net.TCPAddr).Port
+
+	// Create a new ChillerServer
+	serverMetrics := NewServerMetrics(metrics.NewNoopScope())
+	si := newServerInterceptor(serverMetrics, clk)
+	s := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
+	test_proto.RegisterChillerServer(s, &testServer{})
+	// Chill until ill
+	go func() {
+		start := time.Now()
+		if err := s.Serve(lis); err != nil &&
+			!strings.HasSuffix(err.Error(), "use of closed network connection") {
+			t.Fatalf("s.Serve: %v after %s", err, time.Since(start))
+		}
+	}()
+	defer s.Stop()
+
+	// Dial the ChillerServer
+	ci := &clientInterceptor{30 * time.Second, grpc_prometheus.NewClientMetrics(), clk}
+	conn, err := grpc.Dial(net.JoinHostPort("localhost", fmt.Sprintf("%d", port)),
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(ci.intercept))
+	if err != nil {
+		t.Fatalf("did not connect: %v", err)
+	}
+	// Create a ChillerClient with the connection to the ChillerServer
+	c := test_proto.NewChillerClient(conn)
+
+	// Make an RPC request with the ChillerClient with a timeout higher than the
+	// requested ChillerServer delay so that the RPC completes normally
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var delayTime int64 = (time.Second * 5).Nanoseconds()
+	_, err = c.Chill(ctx, &test_proto.Time{Time: &delayTime})
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Unexpected error calling Chill RPC: %s", err))
+	}
+
+	// There should be one histogram sample in the serverInterceptor rpcLag stat
+	count := test.CountHistogramSamples(si.rpcLag)
+	test.AssertEquals(t, count, 1)
 }

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -218,6 +218,6 @@ func TestRequestTimeTagging(t *testing.T) {
 	}
 
 	// There should be one histogram sample in the serverInterceptor rpcLag stat
-	count := test.CountHistogramSamples(si.rpcLag)
+	count := test.CountHistogramSamples(si.metrics.rpcLag)
 	test.AssertEquals(t, count, 1)
 }

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -57,8 +57,8 @@ func NewServer(c *cmd.GRPCServerConfig, tls *tls.Config, metrics serverMetrics, 
 // serverMetrics is a struct type used to return a few registered metrics from
 // `NewServerMetrics`
 type serverMetrics struct {
-	GRPCMetrics *grpc_prometheus.ServerMetrics
-	RPCLag      prometheus.Histogram
+	grpcMetrics *grpc_prometheus.ServerMetrics
+	rpcLag      prometheus.Histogram
 }
 
 // NewServerMetrics registers metrics with a registry. It must be called a
@@ -82,7 +82,7 @@ func NewServerMetrics(stats registry) serverMetrics {
 	stats.MustRegister(rpcLag)
 
 	return serverMetrics{
-		GRPCMetrics: grpcMetrics,
-		RPCLag:      rpcLag,
+		grpcMetrics: grpcMetrics,
+		rpcLag:      rpcLag,
 	}
 }

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -6,6 +6,8 @@ import (
 	"net"
 
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/jmhodges/clock"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 
 	"github.com/letsencrypt/boulder/cmd"
@@ -15,17 +17,13 @@ import (
 // CodedError is a alias required to appease go vet
 var CodedError = grpc.Errorf
 
-var errNilMetrics = errors.New("boulder/grpc: received nil ServerMetrics")
 var errNilTLS = errors.New("boulder/grpc: received nil tls.Config")
 
 // NewServer creates a gRPC server that uses the provided *tls.Config, and
 // verifies that clients present a certificate that (a) is signed by one of
 // the configured ClientCAs, and (b) contains at least one
 // subjectAlternativeName matching the accepted list from GRPCServerConfig.
-func NewServer(c *cmd.GRPCServerConfig, tls *tls.Config, serverMetrics *grpc_prometheus.ServerMetrics) (*grpc.Server, net.Listener, error) {
-	if serverMetrics == nil {
-		return nil, nil, errNilMetrics
-	}
+func NewServer(c *cmd.GRPCServerConfig, tls *tls.Config, metrics serverMetrics, clk clock.Clock) (*grpc.Server, net.Listener, error) {
 	if tls == nil {
 		return nil, nil, errNilTLS
 	}
@@ -48,7 +46,7 @@ func NewServer(c *cmd.GRPCServerConfig, tls *tls.Config, serverMetrics *grpc_pro
 	if maxConcurrentStreams == 0 {
 		maxConcurrentStreams = 250
 	}
-	si := &serverInterceptor{serverMetrics}
+	si := newServerInterceptor(metrics, clk)
 	return grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.UnaryInterceptor(si.intercept),
@@ -56,12 +54,35 @@ func NewServer(c *cmd.GRPCServerConfig, tls *tls.Config, serverMetrics *grpc_pro
 	), l, nil
 }
 
-// NewServerMetrics constructs a *grpc_prometheus.ServerMetrics, registered with
-// the given registry, with timing histogram enabled. It must be called a
+// serverMetrics is a struct type used to return a few registered metrics from
+// `NewServerMetrics`
+type serverMetrics struct {
+	GRPCMetrics *grpc_prometheus.ServerMetrics
+	RPCLag      prometheus.Histogram
+}
+
+// NewServerMetrics registers metrics with a registry. It must be called a
 // maximum of once per registry, or there will be conflicting names.
-func NewServerMetrics(stats registry) *grpc_prometheus.ServerMetrics {
-	metrics := grpc_prometheus.NewServerMetrics()
-	metrics.EnableHandlingTimeHistogram()
-	stats.MustRegister(metrics)
-	return metrics
+// It constructs and registers a *grpc_prometheus.ServerMetrics with timing
+// histogram enabled as well as a prometheus Histogram for RPC latency.
+func NewServerMetrics(stats registry) serverMetrics {
+	// Create the grpc prometheus server metrics instance and register it
+	grpcMetrics := grpc_prometheus.NewServerMetrics()
+	grpcMetrics.EnableHandlingTimeHistogram()
+	stats.MustRegister(grpcMetrics)
+
+	// rpcLag is a prometheus histogram tracking the difference between the time
+	// the client sent an RPC and the time the server received it. Create and
+	// register it.
+	rpcLag := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "rpcLag",
+			Help: "Delta between client RPC send time and serer RPC receipt time",
+		})
+	stats.MustRegister(rpcLag)
+
+	return serverMetrics{
+		GRPCMetrics: grpcMetrics,
+		RPCLag:      rpcLag,
+	}
 }

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -77,7 +77,7 @@ func NewServerMetrics(stats registry) serverMetrics {
 	rpcLag := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name: "rpc_lag",
-			Help: "Delta between client RPC send time and serer RPC receipt time",
+			Help: "Delta between client RPC send time and server RPC receipt time",
 		})
 	stats.MustRegister(rpcLag)
 

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -76,7 +76,7 @@ func NewServerMetrics(stats registry) serverMetrics {
 	// register it.
 	rpcLag := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "rpcLag",
+			Name: "rpc_lag",
 			Help: "Delta between client RPC send time and serer RPC receipt time",
 		})
 	stats.MustRegister(rpcLag)


### PR DESCRIPTION
We may see RPCs that are dispatched by a client but do not arrive at the server for some time afterwards. To have insight into potential request latency at this layer we want to publish the time delta between when a client sent an RPC and when the server received it.

This PR updates the gRPC client interceptor to add the current time to the gRPC request metadata context when it dispatches an RPC. The server side interceptor is updated to pull the client request time out of the gRPC request metadata. Using this timestamp it can calculate the latency and publish it as an observation on a Prometheus histogram.

Accomplishing the above required wiring a clock through to each of the client interceptors. This caused a small diff across each of the gRPC aware boulder commands.

A small unit test is included in this PR that checks that a latency stat is published to the histogram after an RPC to a test ChillerServer is made. It's difficult to do more in-depth testing because using fake clocks makes the latency 0 and using real clocks requires finding a way to queue/delay requests inside of the gRPC mechanisms not exposed to Boulder.

Updates https://github.com/letsencrypt/boulder/issues/3635 - Still TODO: Explicitly logging latency in the VA, tracking outstanding RPCs as a gauge.