### PR TITLE
load-generator: send correct ACMEv2 Content-Type on POST

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -532,7 +532,7 @@ def main():
         run_loadtest=False, test_case_filter="")
     args = parser.parse_args()
 
-    if not (args.run_all or args.run_certbot or args.run_chisel or args.custom is not None):
+    if not (args.run_all or args.run_certbot or args.run_chisel or args.run_loadtest or args.custom is not None):
         raise Exception("must run at least one of the letsencrypt or chisel tests with --all, --certbot, --chisel, or --custom")
 
     now = datetime.datetime.utcnow()

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -526,6 +526,7 @@ func (s *State) post(endpoint string, payload []byte, ns *nonceSource) (*http.Re
 	}
 	req.Header.Add("X-Real-IP", s.realIP)
 	req.Header.Add("User-Agent", userAgent)
+	req.Header.Add("Content-Type", "application/jose+json")
 	atomic.AddInt64(&s.postTotal, 1)
 	resp, err := s.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
### load generator: send correct ACMEv2 Content-Type on POST.

This PR updates the Boulder `load-generator` to send the correct ACMEv2 `Content-Type` header when POSTing the ACME server. This is required for ACMEv2 and without it all POST requests to the WFE2 running a `test/config-next` configuration result in malformed 400 errors. While only required by ACMEv2 this commit sends it for ACMEv1 requests as well. No harm no foul.

### integration tests: allow running *just* the load generator.

Prior to this PR an omission in an `if` statement in `integration-test.py` meant that you couldn't invoke `test/integration-test.py` with just the `--load` argument to only run the load generator. This commit updates the `if` to allow this use case.


