### PR TITLE
integration tests: verify load-generator req success.

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -576,11 +576,27 @@ def run_loadtest():
     run("./bin/load-generator \
             -config test/load-generator/config/integration-test-config.json\
             -results %s" % latency_data_file)
+    check_loadoutput(latency_data_file)
 
     latency_data_file = "%s/v2-integration-test-latency.json" % tempdir
     run("./bin/load-generator \
             -config test/load-generator/config/v2-integration-test-config.json\
             -results %s" % latency_data_file)
+    check_loadoutput(latency_data_file)
+
+def check_loadoutput(statefile):
+    """
+    check_loadoutput checks that a JSON load generator latency state file
+    contains only "good" request results and not any errors. If there are any
+    bad request results an exception is raised.
+    """
+    with open(statefile) as f:
+        data_lines = f.readlines()
+
+    for line in data_lines:
+        datapoint = json.loads(line)
+        if datapoint['type'] != 'good':
+            raise Exception("Load generator had a failed request: %s", line)
 
 def run_cert_checker():
     run("./bin/cert-checker -config %s/cert-checker.json" % default_config_dir)

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -532,7 +532,7 @@ def main():
         run_loadtest=False, test_case_filter="")
     args = parser.parse_args()
 
-    if not (args.run_all or args.run_certbot or args.run_chisel or args.custom is not None):
+    if not (args.run_all or args.run_certbot or args.run_chisel or args.run_loadtest or args.custom is not None):
         raise Exception("must run at least one of the letsencrypt or chisel tests with --all, --certbot, --chisel, or --custom")
 
     now = datetime.datetime.utcnow()

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -526,6 +526,7 @@ func (s *State) post(endpoint string, payload []byte, ns *nonceSource) (*http.Re
 	}
 	req.Header.Add("X-Real-IP", s.realIP)
 	req.Header.Add("User-Agent", userAgent)
+	req.Header.Add("Content-Type", "application/jose+json")
 	atomic.AddInt64(&s.postTotal, 1)
 	resp, err := s.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
**Note to reviewers**: This PR builds on https://github.com/letsencrypt/boulder/pull/3667 and that should be reviewed/merged first. The only new code in this PR is in 07fa04b.

Prior to this PR we ran the load generator in integration tests against both the V1 and the V2 API for a short duration. This helps prevent bitrot in the load-generator from catching us unaware. At the time of landing this code we also tried to verify that none of the load-generator requests failed. This was found to be flaky/unreliable and removed to make forward progress.

This PR re-adds the check that all of the load-generator requests were successful. We've made some nice performance/reliability improvements lately and I think we can now expect that the load-generator will produce no errors. This will help catch regressions in the load-generator that do not result in a non-zero exit code but still indicate a problem that should be addressed (e.g. https://github.com/letsencrypt/boulder/pull/3667) 