### PR TITLE
Remove TESTPATHS and others from test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -19,9 +19,6 @@ HARDFAIL=${HARDFAIL:-fmt godep-restore}
 
 FAILURE=0
 
-DEFAULT_TESTPATHS=$(go list -f '{{ .ImportPath }}' ./... | grep -v /vendor/)
-TESTPATHS=${TESTPATHS:-$DEFAULT_TESTPATHS}
-
 GITHUB_SECRET_FILE="/tmp/github-secret.json"
 
 start_context() {
@@ -78,7 +75,7 @@ function run_unit_tests() {
     # Run the full suite of tests once with the -race flag. Since this isn't
     # running tests individually we can't collect coverage information.
     echo "running test suite with race detection"
-    run go test -race -p 1 ${TESTPATHS}
+    run go test -race -p 1 ./...
   else
     # When running locally, we skip the -race flag for speedier test runs. We
     # also pass -p 1 to require the tests to run serially instead of in
@@ -87,7 +84,7 @@ function run_unit_tests() {
     # spuriously because one test is modifying a table (especially
     # registrations) while another test is reading it.
     # https://github.com/letsencrypt/boulder/issues/1499
-    run go test -p 1 $GOTESTFLAGS ${TESTPATHS}
+    run go test -p 1 $GOTESTFLAGS ./...
   fi
 }
 
@@ -97,10 +94,7 @@ function run_test_coverage() {
   # -race in `run_unit_tests` and it adds substantial overhead to run every
   # test with -race independently
   echo "running test suite with coverage enabled and without race detection"
-  for path in ${TESTPATHS}; do
-    dir=$(basename $path)
-    run go test -cover -coverprofile=${dir}.coverprofile ${path}
-  done
+  run go test -cover -coverprofile=${dir}.coverprofile ./...
 
   # Gather all the coverprofiles
   run gover
@@ -116,7 +110,7 @@ function run_test_coverage() {
 #
 if [[ "$RUN" =~ "vet" ]] ; then
   start_context "vet"
-  run_and_expect_silence go vet ${TESTPATHS}
+  run_and_expect_silence go vet ./...
   end_context #vet
 fi
 
@@ -215,7 +209,7 @@ if [[ "$RUN" =~ "errcheck" ]] ; then
   start_context "errcheck"
   run_and_expect_silence errcheck \
     -ignore io:Write,os:Remove,net/http:Write \
-    $(echo ${TESTPATHS} | tr ' ' '\n' | grep -v test)
+    $(go list -f '{{ .ImportPath }}' ./... | grep -v test)
   end_context #errcheck
 fi
 
@@ -236,7 +230,7 @@ if [[ "$RUN" =~ "generate" ]] ; then
   #     github.com/letsencrypt/boulder/probs)
   go install ./probs
   go install google.golang.org/grpc/codes
-  run_and_expect_silence go generate ${TESTPATHS}
+  run_and_expect_silence go generate ./...
   # Because the `mock` package we use to generate mocks does not properly
   # support vendored dependencies[0] we are forced to sed out any references to
   # the vendor directory that sneak into generated resources.

--- a/test.sh
+++ b/test.sh
@@ -19,8 +19,6 @@ HARDFAIL=${HARDFAIL:-fmt godep-restore}
 
 FAILURE=0
 
-GITHUB_SECRET_FILE="/tmp/github-secret.json"
-
 start_context() {
   CONTEXT="$1"
   printf "[%16s] Starting\n" ${CONTEXT}
@@ -61,13 +59,6 @@ function run_and_expect_silence() {
     FAILURE=1
   fi
   rm ${result_file}
-}
-
-function die() {
-  if [ ! -z "$1" ]; then
-    echo $1 > /dev/stderr
-  fi
-  exit 1
 }
 
 function run_unit_tests() {

--- a/test.sh
+++ b/test.sh
@@ -94,7 +94,7 @@ function run_test_coverage() {
   # -race in `run_unit_tests` and it adds substantial overhead to run every
   # test with -race independently
   echo "running test suite with coverage enabled and without race detection"
-  run go test -cover -coverprofile=${dir}.coverprofile ./...
+  run go test -p 1 -cover -coverprofile=${dir}.coverprofile ./...
 
   # Gather all the coverprofiles
   run gover


### PR DESCRIPTION
Prior to Go 1.9 (https://golang.org/doc/go1.9),
various go commands would expand "./..." to include vendor directories.
We worked around this by listing "./..." then grepping out vendor. Now
that we are on Go 1.10 this is no longer necessary. Remove the TESTPATHS
hack.

We still need to exclude certain test directories when running errcheck,
so some of the "go list" logic gets moved into the errcheck stanza.

Also, as of Go 1.10, running coverage on multiple packages in one run is
supported, so replace the "for" loop in the coverage stanza with a
single command.

Also, remove GITHUB_SECRET_FILE and "die," both of which were unused.