### PR TITLE
Fix ocsp-updater backoff jitter test.

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -654,9 +654,7 @@ func (l *looper) tick() {
 		l.stats.Inc("LongTicks", 1)
 	}
 
-	// After we have all the stats stuff out of the way let's check if the tick
-	// function failed, if the reason is the HSM is dead increase the length of
-	// sleepDur using the exponentially increasing duration returned by core.RetryBackoff.
+	// On success, sleep till it's time for the next tick. On failure, backoff.
 	sleepDur := expectedTickEnd.Sub(tickEnd)
 	if err != nil {
 		l.stats.Inc("FailedTicks", 1)

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -683,23 +683,20 @@ func TestLoopTickBackoff(t *testing.T) {
 	l.tick()
 	// Expected to sleep for 1m
 	backoff := float64(60000000000)
-	maxJittered := backoff * 1.2
-	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
+	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff*0.8), int64(backoff*1.2))
 
 	start = l.clk.Now()
 	l.tick()
 	// Expected to sleep for 1m30s
 	backoff = 90000000000
-	maxJittered = backoff * 1.2
-	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
+	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff*0.8), int64(backoff*1.2))
 
 	l.failures = 6
 	start = l.clk.Now()
 	l.tick()
 	// Expected to sleep for 11m23.4375s, should be truncated to 10m
 	backoff = 600000000000
-	maxJittered = backoff * 1.2
-	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff), int64(maxJittered))
+	assertBetween(l.clk.Now().Sub(start).Nanoseconds(), int64(backoff*0.8), int64(backoff*1.2))
 
 	l.tickFunc = func(context.Context, int) error { return nil }
 	start = l.clk.Now()

--- a/core/util.go
+++ b/core/util.go
@@ -268,7 +268,8 @@ const retryJitter = 0.2
 // RetryBackoff calculates a backoff time based on number of retries, will always
 // add jitter so requests that start in unison won't fall into lockstep. Because of
 // this the returned duration can always be larger than the maximum by a factor of
-// retryJitter. Adapted from https://github.com/grpc/grpc-go/blob/master/rpc_util.go#L311
+// retryJitter. Adapted from
+// https://github.com/grpc/grpc-go/blob/v1.11.3/backoff.go#L77-L96
 func RetryBackoff(retries int, base, max time.Duration, factor float64) time.Duration {
 	if retries == 0 {
 		return 0


### PR DESCRIPTION
Previously this test assumed jitter could only be positive, but it can
be negative too. This fixes the expected bounds.