### PR TITLE
gitignore: ignore .gocache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 _obj
 _test
 bin
+.gocache
 
 # Architecture specific extensions/prefixes
 *.[568vq]


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/commit/f932fdab10dfe8b5ba70d06927edbae52b629ade we added a volume mount for the container's Go cache to `./.gocache` in the project root. This commit adds the `.gocache` folder that is created to the project `.gitignore` since we don't ever want to check it into source control.