### PR TITLE
Split internal and public errors out in web.RequestEvent

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -16,7 +16,7 @@ type RequestEvent struct {
 	Endpoint       string    `json:",omitempty"`
 	Method         string    `json:",omitempty"`
 	InternalErrors []string  `json:",omitempty"`
-	PublicError    string    `json:",omitempty"`
+	Error          string    `json:",omitempty"`
 	Requester      int64     `json:",omitempty"`
 	Contacts       *[]string `json:",omitempty"`
 	UserAgent      string    `json:",omitempty"`

--- a/web/context.go
+++ b/web/context.go
@@ -12,21 +12,22 @@ import (
 )
 
 type RequestEvent struct {
-	RealIP    string    `json:",omitempty"`
-	Endpoint  string    `json:",omitempty"`
-	Method    string    `json:",omitempty"`
-	Errors    []string  `json:",omitempty"`
-	Requester int64     `json:",omitempty"`
-	Contacts  *[]string `json:",omitempty"`
-	UserAgent string    `json:",omitempty"`
-	Latency   float64
-	Code      int
-	Payload   string                 `json:",omitempty"`
-	Extra     map[string]interface{} `json:",omitempty"`
+	RealIP         string    `json:",omitempty"`
+	Endpoint       string    `json:",omitempty"`
+	Method         string    `json:",omitempty"`
+	InternalErrors []string  `json:",omitempty"`
+	PublicError    string    `json:",omitempty"`
+	Requester      int64     `json:",omitempty"`
+	Contacts       *[]string `json:",omitempty"`
+	UserAgent      string    `json:",omitempty"`
+	Latency        float64
+	Code           int
+	Payload        string                 `json:",omitempty"`
+	Extra          map[string]interface{} `json:",omitempty"`
 }
 
 func (e *RequestEvent) AddError(msg string, args ...interface{}) {
-	e.Errors = append(e.Errors, fmt.Sprintf(msg, args...))
+	e.InternalErrors = append(e.InternalErrors, fmt.Sprintf(msg, args...))
 }
 
 type WFEHandlerFunc func(context.Context, *RequestEvent, http.ResponseWriter, *http.Request)

--- a/web/send_error.go
+++ b/web/send_error.go
@@ -27,7 +27,7 @@ func SendError(
 	code := probs.ProblemDetailsToStatusCode(prob)
 
 	// Record details to the log event
-	logEvent.AddError(fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, prob.Detail))
+	logEvent.PublicError = fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, prob.Detail)
 	if ierr != nil {
 		logEvent.AddError(fmt.Sprintf("%#v", ierr))
 	}

--- a/web/send_error.go
+++ b/web/send_error.go
@@ -27,7 +27,7 @@ func SendError(
 	code := probs.ProblemDetailsToStatusCode(prob)
 
 	// Record details to the log event
-	logEvent.PublicError = fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, prob.Detail)
+	logEvent.Error = fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, prob.Detail)
 	if ierr != nil {
 		logEvent.AddError(fmt.Sprintf("%#v", ierr))
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -606,7 +606,12 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *web.R
 		if err == nil {
 			init.InitialIP = net.ParseIP(host)
 		} else {
-			wfe.sendError(response, logEvent, probs.ServerInternal("couldn't parse the remote (that is, the client's) address"), fmt.Errorf("Couldn't parse RemoteAddr: %s", request.RemoteAddr))
+			wfe.sendError(
+				response,
+				logEvent,
+				probs.ServerInternal("couldn't parse the remote (that is, the client's) address"),
+				fmt.Errorf("Couldn't parse RemoteAddr: %s", request.RemoteAddr),
+			)
 			return
 		}
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -606,8 +606,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(ctx context.Context, logEvent *web.R
 		if err == nil {
 			init.InitialIP = net.ParseIP(host)
 		} else {
-			logEvent.AddError("Couldn't parse RemoteAddr: %s", request.RemoteAddr)
-			wfe.sendError(response, logEvent, probs.ServerInternal("couldn't parse the remote (that is, the client's) address"), nil)
+			wfe.sendError(response, logEvent, probs.ServerInternal("couldn't parse the remote (that is, the client's) address"), fmt.Errorf("Couldn't parse RemoteAddr: %s", request.RemoteAddr))
 			return
 		}
 	}
@@ -1063,11 +1062,10 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	// Check that the registration ID matching the key used matches
 	// the registration ID on the authz object
 	if currReg.ID != authz.RegistrationID {
-		logEvent.AddError("User registration id: %d != Authorization registration id: %v", currReg.ID, authz.RegistrationID)
 		wfe.sendError(response,
 			logEvent,
 			probs.Unauthorized("User registration ID doesn't match registration ID in authorization"),
-			nil,
+			fmt.Errorf("User registration id: %d != Authorization registration id: %v", currReg.ID, authz.RegistrationID),
 		)
 		return
 	}
@@ -1287,11 +1285,11 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 	cert, err := wfe.SA.GetCertificate(ctx, serial)
 	// TODO(#991): handle db errors
 	if err != nil {
-		logEvent.AddError("unable to get certificate by serial id %#v: %s", serial, err)
+		ierr := fmt.Errorf("unable to get certificate by serial id %#v: %s", serial, err)
 		if strings.HasPrefix(err.Error(), "gorp: multiple rows returned") {
-			wfe.sendError(response, logEvent, probs.Conflict("Multiple certificates with same short serial"), err)
+			wfe.sendError(response, logEvent, probs.Conflict("Multiple certificates with same short serial"), ierr)
 		} else {
-			wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), err)
+			wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), ierr)
 		}
 		return
 	}

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -492,7 +492,12 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		if err == nil {
 			ip = net.ParseIP(host)
 		} else {
-			wfe.sendError(response, logEvent, probs.ServerInternal("couldn't parse the remote (that is, the client's) address"), fmt.Errorf("Couldn't parse RemoteAddr: %s", request.RemoteAddr))
+			wfe.sendError(
+				response,
+				logEvent,
+				probs.ServerInternal("couldn't parse the remote (that is, the client's) address"),
+				fmt.Errorf("Couldn't parse RemoteAddr: %s", request.RemoteAddr),
+			)
 			return
 		}
 	}
@@ -1176,7 +1181,12 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 	// Certificate paths consist of the CertBase path, plus exactly sixteen hex
 	// digits.
 	if !core.ValidSerial(serial) {
-		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), fmt.Errorf("certificate serial provided was not valid: %s", serial))
+		wfe.sendError(
+			response,
+			logEvent,
+			probs.NotFound("Certificate not found"),
+			fmt.Errorf("certificate serial provided was not valid: %s", serial),
+		)
 		return
 	}
 	logEvent.Extra["RequestedSerial"] = serial

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -328,9 +329,8 @@ func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *web.RequestEven
 	}
 
 	if request.Method != "GET" {
-		logEvent.AddError("Bad method")
 		response.Header().Set("Allow", "GET")
-		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
+		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), errors.New("Bad method"))
 		return
 	}
 
@@ -492,8 +492,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		if err == nil {
 			ip = net.ParseIP(host)
 		} else {
-			logEvent.AddError("Couldn't parse RemoteAddr: %s", request.RemoteAddr)
-			wfe.sendError(response, logEvent, probs.ServerInternal("couldn't parse the remote (that is, the client's) address"), nil)
+			wfe.sendError(response, logEvent, probs.ServerInternal("couldn't parse the remote (that is, the client's) address"), fmt.Errorf("Couldn't parse RemoteAddr: %s", request.RemoteAddr))
 			return
 		}
 	}
@@ -1177,8 +1176,7 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 	// Certificate paths consist of the CertBase path, plus exactly sixteen hex
 	// digits.
 	if !core.ValidSerial(serial) {
-		logEvent.AddError("certificate serial provided was not valid: %s", serial)
-		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
+		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), fmt.Errorf("certificate serial provided was not valid: %s", serial))
 		return
 	}
 	logEvent.Extra["RequestedSerial"] = serial
@@ -1186,11 +1184,11 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 	cert, err := wfe.SA.GetCertificate(ctx, serial)
 	// TODO(#991): handle db errors
 	if err != nil {
-		logEvent.AddError("unable to get certificate by serial id %#v: %s", serial, err)
+		ierr := fmt.Errorf("unable to get certificate by serial id %#v: %s", serial, err)
 		if strings.HasPrefix(err.Error(), "gorp: multiple rows returned") {
-			wfe.sendError(response, logEvent, probs.Conflict("Multiple certificates with same short serial"), err)
+			wfe.sendError(response, logEvent, probs.Conflict("Multiple certificates with same short serial"), ierr)
 		} else {
-			wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), err)
+			wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), ierr)
 		}
 		return
 	}


### PR DESCRIPTION
Splits out the old `Errors` slice into a `PublicError` string and a `InternalErrors` slice. Also removes a number of occurrences of calling `logEvent.AddError` then immediately calling `wfe.sendError` with either the same internal error which caused the same error to be logged twice or no error which is slightly redundant as `wfe.sendError` calls `logEvent.AddError` internally.

Fixes #3664.