### PR TITLE
Dev/CI: Add Go 1.10.2 to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,15 @@ matrix:
     - env: RUN="unit"
     - env: RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
     - env: RUN="coverage"
+    #
+    # Next Go version build tasks:
+    #
+    - env: GO_VERSION="1.10.2" RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
+    # Config changes that have landed in master but not yet been applied to
+    # production can be made in boulder-config-next.json.
+    - env: GO_VERSION="1.10.2" RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
+    - env: GO_VERSION="1.10.2" RUN="unit"
+    - env: GO_VERSION="1.10.2" RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
   fast_finish: true
   allow_failures:
     - env: RUN="coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - "1.10.1"
-  - "1.10.2"
+  - "1.10"
 
 go_import_path: github.com/letsencrypt/boulder
 
@@ -33,6 +32,9 @@ branches:
 
 matrix:
   include:
+    #
+    # Current Go version build tasks:
+    #
     - env: RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
@@ -40,6 +42,15 @@ matrix:
     - env: RUN="unit"
     - env: RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
     - env: RUN="coverage"
+    #
+    # Next Go version build tasks:
+    #
+    - env: GO_VERSION="1.10.2" RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
+    # Config changes that have landed in master but not yet been applied to
+    # production can be made in boulder-config-next.json.
+    - env: GO_VERSION="1.10.2" RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
+    - env: GO_VERSION="1.10.2" RUN="unit"
+    - env: GO_VERSION="1.10.2" RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
   fast_finish: true
   allow_failures:
     - env: RUN="coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - "1.10"
+  - "1.10.1"
+  - "1.10.2"
 
 go_import_path: github.com/letsencrypt/boulder
 
@@ -32,9 +33,6 @@ branches:
 
 matrix:
   include:
-    #
-    # Current Go version build tasks:
-    #
     - env: RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
@@ -42,15 +40,6 @@ matrix:
     - env: RUN="unit"
     - env: RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
     - env: RUN="coverage"
-    #
-    # Next Go version build tasks:
-    #
-    - env: GO_VERSION="1.10.2" RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
-    # Config changes that have landed in master but not yet been applied to
-    # production can be made in boulder-config-next.json.
-    - env: GO_VERSION="1.10.2" RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
-    - env: GO_VERSION="1.10.2" RUN="unit"
-    - env: GO_VERSION="1.10.2" RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
   fast_finish: true
   allow_failures:
     - env: RUN="coverage"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.1}:2018-05-04
+        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -43,7 +43,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.1}:2018-05-04
+        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-04-05
+        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.1}:2018-05-04
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -43,7 +43,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.1}:2018-05-04
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-04-05
+        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.10.1" )
+GO_VERSIONS=( "1.10.1" "1.10.2" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
This PR adds Go 1.10.2 to the build matrix along with Go 1.10.1.

After staging/prod have been updated to Go 1.10.2 we can remove Go 1.10.1.

Resolves https://github.com/letsencrypt/boulder/issues/3680