### PR TITLE
Cleanup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: RUN="coverage"
+  # Only do a coverage run for the current go version
   exclude:
-    # only do coverage for the current go version
     - go: "1.10.2"
     - env: RUN="coverage"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - "1.10"
+  - "1.10.2"
 
 go_import_path: github.com/letsencrypt/boulder
 
@@ -30,8 +31,7 @@ branches:
     - release
     - /^test-.*$/
 
-matrix:
-  include:
+env:
     #
     # Current Go version build tasks:
     #
@@ -42,17 +42,14 @@ matrix:
     - env: RUN="unit"
     - env: RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
     - env: RUN="coverage"
-    #
-    # Next Go version build tasks:
-    #
-    - env: GO_VERSION="1.10.2" RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
-    # Config changes that have landed in master but not yet been applied to
-    # production can be made in boulder-config-next.json.
-    - env: GO_VERSION="1.10.2" RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
-    - env: GO_VERSION="1.10.2" RUN="unit"
-    - env: GO_VERSION="1.10.2" RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
+
+matrix:
   fast_finish: true
   allow_failures:
+    - env: RUN="coverage"
+  exclude:
+    # only do coverage for the current go version
+    - go: "1.10.2"
     - env: RUN="coverage"
 
 # We require a newer version of docker-compose than is installed by way of the

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - "1.10"
-  - 1.10.2
+  - "1.10.2"
 
 go_import_path: github.com/letsencrypt/boulder
 
@@ -35,13 +35,13 @@ env:
     #
     # Current Go version build tasks:
     #
-    - env: RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
+    - RUN="vet fmt migrations integration godep-restore errcheck generate dashlint rpm"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
-    - env: RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
-    - env: RUN="unit"
-    - env: RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
-    - env: RUN="coverage"
+    - RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
+    - RUN="unit"
+    - RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
+    - RUN="coverage"
 
 matrix:
   fast_finish: true
@@ -49,7 +49,7 @@ matrix:
     - env: RUN="coverage"
   # Only do a coverage run for the current go version
   exclude:
-    - go: 1.10.2
+    - go: "1.10.2"
       env: RUN="coverage"
 
 # We require a newer version of docker-compose than is installed by way of the

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
   # Only do a coverage run for the current go version
   exclude:
     - go: "1.10.2"
-    - env: RUN="coverage"
+      env: RUN="coverage"
 
 # We require a newer version of docker-compose than is installed by way of the
 # "services: docker" directive. Per the travis docs[0] this is best remedied

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10"
+  - "1.10.1"
   - "1.10.2"
 
 go_import_path: github.com/letsencrypt/boulder

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - "1.10"
-  - "1.10.2"
+  - 1.10.2
 
 go_import_path: github.com/letsencrypt/boulder
 
@@ -49,7 +49,7 @@ matrix:
     - env: RUN="coverage"
   # Only do a coverage run for the current go version
   exclude:
-    - go: "1.10.2"
+    - go: 1.10.2
       env: RUN="coverage"
 
 # We require a newer version of docker-compose than is installed by way of the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.1}:2018-05-04
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -43,7 +43,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${GO_VERSION:-1.10.1}:2018-05-04
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.1}:2018-05-04
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so

--- a/test/boulder-tools/README.md
+++ b/test/boulder-tools/README.md
@@ -15,8 +15,7 @@ When a new Go version is available we perform serveral steps to integrate it to 
 1. We add it to the `GO_VERSIONS` array in `tag_and_upload.sh`.
 2. We run the `tag_and_upload.sh` script to build, tag, and upload
    a `boulder-tools` image for each of the `GO_VERSIONS`
-3. We update `.travis.yml`, duplicating the existing build tasks, adding new
-   `GO_VERSION=` `ENV` entries for the new Go version.
+3. We update `.travis.yml`, adding the new Go version to the `go` section.
 
 After some time when we have spot checked the new Go release and coordinated
 a staging/prod environment upgrade with the operations team we can remove the


### PR DESCRIPTION
Our `.travis.yml` does some weird things that are a bit non-standard. This change brings it into line with the [general Travis conventions](https://docs.travis-ci.com/user/customizing-the-build).