### PR TITLE
RA/CA: Use `doNotForceCN: false` for `test/config`.

### DIFF
--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -40,7 +40,6 @@
     "backdate": "1h",
     "lifespanOCSP": "96h",
     "maxNames": 100,
-    "doNotForceCN": true,
     "enableMustStaple": true,
     "hostnamePolicyFile": "test/hostname-policy.json",
     "enablePrecertificateFlow": true,

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -40,6 +40,7 @@
     "backdate": "1h",
     "lifespanOCSP": "96h",
     "maxNames": 100,
+    "doNotForceCN": true,
     "enableMustStaple": true,
     "hostnamePolicyFile": "test/hostname-policy.json",
     "enablePrecertificateFlow": true,

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -11,7 +11,6 @@
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 100,
-    "doNotForceCN": true,
     "reuseValidAuthz": true,
     "authorizationLifetimeDays": 30,
     "pendingAuthorizationLifetimeDays": 7,

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -38,7 +38,7 @@
     "expiry": "2160h",
     "lifespanOCSP": "96h",
     "maxNames": 100,
-    "doNotForceCN": true,
+    "doNotForceCN": false,
     "enableMustStaple": true,
     "hostnamePolicyFile": "test/hostname-policy.json",
     "cfssl": {

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -38,7 +38,6 @@
     "expiry": "2160h",
     "lifespanOCSP": "96h",
     "maxNames": 100,
-    "doNotForceCN": false,
     "enableMustStaple": true,
     "hostnamePolicyFile": "test/hostname-policy.json",
     "cfssl": {

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -7,7 +7,6 @@
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 100,
-    "doNotForceCN": false,
     "reuseValidAuthz": true,
     "authorizationLifetimeDays": 30,
     "pendingAuthorizationLifetimeDays": 7,

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -7,7 +7,7 @@
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 100,
-    "doNotForceCN": true,
+    "doNotForceCN": false,
     "reuseValidAuthz": true,
     "authorizationLifetimeDays": 30,
     "pendingAuthorizationLifetimeDays": 7,


### PR DESCRIPTION
In staging/prod we use `doNotForceCN: false` for both the RA & CA config. Switching this to `true` is blocked on CABF work that will likely take considerable time.

In the short-term we should use `doNotForceCN: false` in `test/config` and only use `doNotForceCN: true` in `test/config-next`.