### PR TITLE
Reduce load testing request rate in Travis.

### DIFF
--- a/test/load-generator/config/integration-test-config.json
+++ b/test/load-generator/config/integration-test-config.json
@@ -6,7 +6,7 @@
             "solveHTTPOne",
             "newCertificate"
         ],
-        "rate": 5,
+        "rate": 1,
         "runtime": "10s",
         "rateDelta": "5/1m"
     },

--- a/test/load-generator/config/v2-integration-test-config.json
+++ b/test/load-generator/config/v2-integration-test-config.json
@@ -6,7 +6,7 @@
             "fulfillOrder",
             "finalizeOrder"
         ],
-        "rate": 5,
+        "rate": 1,
         "runtime": "10s",
         "rateDelta": "5/1m"
     },


### PR DESCRIPTION
This may reduce the amount of logs we output, getting us below the level
that gets our jobs killed.