### PR TITLE
Make datetime consistent for authz expiration

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1895,7 +1895,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 // necessary challenges for it and puts this and all of the relevant information
 // into a corepb.Authorization for transmission to the SA to be stored
 func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg int64, identifier core.AcmeIdentifier) (*corepb.Authorization, error) {
-	expires := ra.clk.Now().Add(ra.pendingAuthorizationLifetime).UnixNano()
+	expires := ra.clk.Now().Add(ra.pendingAuthorizationLifetime).Unix() * 1e9
 	status := string(core.StatusPending)
 	authz := &corepb.Authorization{
 		Identifier:     &identifier.Value,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1895,7 +1895,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 // necessary challenges for it and puts this and all of the relevant information
 // into a corepb.Authorization for transmission to the SA to be stored
 func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg int64, identifier core.AcmeIdentifier) (*corepb.Authorization, error) {
-	expires := ra.clk.Now().Add(ra.pendingAuthorizationLifetime).Unix() * 1e9
+	expires := ra.clk.Now().Add(ra.pendingAuthorizationLifetime).Truncate(time.Second).UnixNano()
 	status := string(core.StatusPending)
 	authz := &corepb.Authorization{
 		Identifier:     &identifier.Value,


### PR DESCRIPTION
So I took a quick stab at one possible solution for the authz expiration variance discussed over at https://community.letsencrypt.org/t/inconsistent-datetime-format-in-some-responses/61452

Golang's nanosecond precision results in newly created pending authz having one expires datetime, but subsequent requests have a different expires datetime due to database storage throwing away fractional second information.
```
  "expires": "2018-04-14T04:43:00.105818284Z",
...
  "expires": "2018-04-14T04:43:00Z",
```
I am not a Go expert so there might be some more widely accepted approach to accomplishing the same thing, please let me know if you would prefer a different solution.