### PR TITLE
CAA recheck test

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -188,7 +188,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("%s", endpoint),
+		endpoint,
 		bytes.NewBuffer(reqJSON),
 	)
 	if err != nil {

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -273,7 +274,7 @@ func (dnsClient *DNSClientImpl) exchangeOne(ctx context.Context, hostname string
 			"qtype":              qtypeStr,
 			"result":             result,
 			"authenticated_data": authenticated,
-			"retries":            fmt.Sprintf("%d", tries),
+			"retries":            strconv.Itoa(tries),
 		}).Observe(dnsClient.clk.Since(start).Seconds())
 	}()
 	for {

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/letsencrypt/boulder/bdns"
@@ -178,7 +179,7 @@ func main() {
 		groups := make([]cmd.CTGroup, len(c.RA.CTLogGroups))
 		for i, logs := range c.RA.CTLogGroups {
 			groups[i] = cmd.CTGroup{
-				Name: fmt.Sprintf("%d", i),
+				Name: strconv.Itoa(i),
 				Logs: logs,
 			}
 		}

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -2,9 +2,9 @@ package grpc
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -152,7 +152,7 @@ func TestTimeouts(t *testing.T) {
 		metrics: NewClientMetrics(metrics.NewNoopScope()),
 		clk:     clock.NewFake(),
 	}
-	conn, err := grpc.Dial(net.JoinHostPort("localhost", fmt.Sprintf("%d", port)),
+	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ci.intercept))
 	if err != nil {
@@ -169,7 +169,7 @@ func TestTimeouts(t *testing.T) {
 		{10 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc.timeout), func(t *testing.T) {
+		t.Run(tc.timeout.String(), func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
 			defer cancel()
 			var second int64 = time.Second.Nanoseconds()
@@ -215,7 +215,7 @@ func TestRequestTimeTagging(t *testing.T) {
 		metrics: NewClientMetrics(metrics.NewNoopScope()),
 		clk:     clk,
 	}
-	conn, err := grpc.Dial(net.JoinHostPort("localhost", fmt.Sprintf("%d", port)),
+	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ci.intercept))
 	if err != nil {
@@ -229,9 +229,8 @@ func TestRequestTimeTagging(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	var delayTime int64 = (time.Second * 5).Nanoseconds()
-	_, err = c.Chill(ctx, &test_proto.Time{Time: &delayTime})
-	if err != nil {
-		t.Fatal(fmt.Sprintf("Unexpected error calling Chill RPC: %s", err))
+	if _, err := c.Chill(ctx, &test_proto.Time{Time: &delayTime}); err != nil {
+		t.Fatalf("Unexpected error calling Chill RPC: %s", err)
 	}
 
 	// There should be one histogram sample in the serverInterceptor rpcLag stat
@@ -302,7 +301,7 @@ func TestInFlightRPCStat(t *testing.T) {
 		metrics: NewClientMetrics(metrics.NewNoopScope()),
 		clk:     clk,
 	}
-	conn, err := grpc.Dial(net.JoinHostPort("localhost", fmt.Sprintf("%d", port)),
+	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ci.intercept))
 	if err != nil {

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net"
 	"net/mail"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -148,7 +149,7 @@ func disconnectHandler(closeFirst int, goodbyeMsg string) connHandler {
 			// closing the connection. This is a good way to deliver a SMTP error
 			// before closing
 			if goodbyeMsg != "" {
-				_, _ = conn.Write([]byte(fmt.Sprintf("%s\r\n", goodbyeMsg)))
+				_, _ = fmt.Fprintf(conn, "%s\r\n", goodbyeMsg)
 				fmt.Printf("Wrote goodbye msg: %s\n", goodbyeMsg)
 			}
 			fmt.Printf("Cutting off client early\n")
@@ -209,7 +210,7 @@ func setup(t *testing.T) (*MailerImpl, net.Listener, func()) {
 
 	m := New(
 		"localhost",
-		fmt.Sprintf("%d", port),
+		strconv.Itoa(port),
 		"user@example.com",
 		"passwd",
 		smtpRoots,

--- a/metrics/measured_http/http.go
+++ b/metrics/measured_http/http.go
@@ -1,8 +1,8 @@
 package measured_http
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/metrics"
@@ -74,7 +74,7 @@ func (h *MeasuredHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.stat.With(prometheus.Labels{
 			"endpoint": pattern,
 			"method":   method,
-			"code":     fmt.Sprintf("%d", rwws.code),
+			"code":     strconv.Itoa(rwws.code),
 		}).Observe(h.clk.Since(begin).Seconds())
 	}()
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1085,7 +1086,7 @@ func TestNewCertificate(t *testing.T) {
 
 	// After issuance the issuanceExpvar should be the current timestamp
 	now := ra.clk.Now()
-	test.AssertEquals(t, issuanceExpvar.String(), fmt.Sprintf("%d", now.Unix()))
+	test.AssertEquals(t, issuanceExpvar.String(), strconv.FormatInt(now.Unix(), 10))
 
 	_, err = x509.ParseCertificate(cert.DER)
 	test.AssertNotError(t, err, "Failed to parse certificate")
@@ -1310,11 +1311,11 @@ type mockSAWithNameCounts struct {
 
 func (m mockSAWithNameCounts) CountCertificatesByNames(ctx context.Context, names []string, earliest, latest time.Time) (ret []*sapb.CountByNames_MapElement, err error) {
 	if latest != m.clk.Now() {
-		m.t.Error(fmt.Sprintf("incorrect latest: was %s, expected %s", latest, m.clk.Now()))
+		m.t.Errorf("incorrect latest: was %s, expected %s", latest, m.clk.Now())
 	}
 	expectedEarliest := m.clk.Now().Add(-23 * time.Hour)
 	if earliest != expectedEarliest {
-		m.t.Errorf(fmt.Sprintf("incorrect earliest: was %s, expected %s", earliest, expectedEarliest))
+		m.t.Errorf("incorrect earliest: was %s, expected %s", earliest, expectedEarliest)
 	}
 	var results []*sapb.CountByNames_MapElement
 	for _, name := range names {
@@ -1327,11 +1328,11 @@ func (m mockSAWithNameCounts) CountCertificatesByNames(ctx context.Context, name
 
 func (m mockSAWithNameCounts) CountCertificatesByExactNames(ctx context.Context, names []string, earliest, latest time.Time) (ret []*sapb.CountByNames_MapElement, err error) {
 	if latest != m.clk.Now() {
-		m.t.Error(fmt.Sprintf("incorrect latest: was %s, expected %s", latest, m.clk.Now()))
+		m.t.Errorf("incorrect latest: was %s, expected %s", latest, m.clk.Now())
 	}
 	expectedEarliest := m.clk.Now().Add(-23 * time.Hour)
 	if earliest != expectedEarliest {
-		m.t.Errorf(fmt.Sprintf("incorrect earliest: was %s, expected %s", earliest, expectedEarliest))
+		m.t.Errorf("incorrect earliest: was %s, expected %s", earliest, expectedEarliest)
 	}
 	var results []*sapb.CountByNames_MapElement
 	for _, name := range names {

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -81,7 +81,7 @@ func (is *integrationSrv) handler(w http.ResponseWriter, r *http.Request) {
 
 		submissions := atomic.LoadInt64(&is.submissions)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(fmt.Sprintf("%d", submissions)))
+		fmt.Fprintf(w, "%d", submissions)
 	default:
 		http.NotFound(w, r)
 		return

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -560,7 +560,7 @@ func TestTLSSNI01FailIP(t *testing.T) {
 	port := getPort(hs)
 	_, prob := va.validateTLSSNI01(ctx, core.AcmeIdentifier{
 		Type:  core.IdentifierType("ip"),
-		Value: net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", port)),
+		Value: net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
 	}, chall)
 	if prob == nil {
 		t.Fatalf("IdentifierType IP shouldn't have worked.")

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -316,14 +316,14 @@ func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *web.RequestEven
 
 	addNoCacheHeader(response)
 	response.Header().Set("Content-Type", "text/html")
-	response.Write([]byte(fmt.Sprintf(`<html>
+	fmt.Fprintf(response, `<html>
 		<body>
 			This is an <a href="https://github.com/ietf-wg-acme/acme/">ACME</a>
 			Certificate Authority running <a href="https://github.com/letsencrypt/boulder">Boulder</a>.
 			JSON directory is available at <a href="%s">%s</a>.
 		</body>
 	</html>
-	`, directoryPath, directoryPath)))
+	`, directoryPath, directoryPath)
 }
 
 func addNoCacheHeader(w http.ResponseWriter) {
@@ -332,7 +332,7 @@ func addNoCacheHeader(w http.ResponseWriter) {
 
 func addRequesterHeader(w http.ResponseWriter, requester int64) {
 	if requester > 0 {
-		w.Header().Set("Boulder-Requester", fmt.Sprintf("%d", requester))
+		w.Header().Set("Boulder-Requester", strconv.FormatInt(requester, 10))
 	}
 }
 
@@ -1341,8 +1341,7 @@ func (wfe *WebFrontEndImpl) Issuer(ctx context.Context, logEvent *web.RequestEve
 func (wfe *WebFrontEndImpl) BuildID(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
 	response.Header().Set("Content-Type", "text/plain")
 	response.WriteHeader(http.StatusOK)
-	detailsString := fmt.Sprintf("Boulder=(%s %s)", core.GetBuildID(), core.GetBuildTime())
-	if _, err := fmt.Fprintln(response, detailsString); err != nil {
+	if _, err := fmt.Fprintf(response, "Boulder=(%s %s)\n", core.GetBuildID(), core.GetBuildTime()); err != nil {
 		wfe.log.Warningf("Could not write response: %s", err)
 	}
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -320,7 +320,7 @@ func loadPrivateKey(t *testing.T, keyBytes []byte) interface{} {
 	}
 
 	// Nothing worked! Fail hard.
-	t.Fatal(fmt.Sprintf("Unable to decode private key PEM bytes"))
+	t.Fatal("Unable to decode private key PEM bytes")
 	// NOOP - the t.Fatal() call will abort before this return
 	return nil
 }
@@ -394,7 +394,7 @@ func makePostRequest(body string) *http.Request {
 		Method:     "POST",
 		RemoteAddr: "1.1.1.1:7882",
 		Header: map[string][]string{
-			"Content-Length": {fmt.Sprintf("%d", len(body))},
+			"Content-Length": {strconv.Itoa(len(body))},
 		},
 		Body: makeBody(body),
 	}

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -63,7 +63,7 @@ func pubKeyForKey(t *testing.T, privKey interface{}) interface{} {
 	case *ecdsa.PrivateKey:
 		return k.PublicKey
 	}
-	t.Fatal(fmt.Sprintf("Unable to get public key for private key %#v", privKey))
+	t.Fatalf("Unable to get public key for private key %#v", privKey)
 	return nil
 }
 
@@ -538,7 +538,7 @@ func TestEnforceJWSAuthType(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
 			prob := wfe.enforceJWSAuthType(tc.JWS, tc.ExpectedAuthType)
 			if tc.ExpectedResult == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil result, got %#v", prob))
+				t.Fatalf("Expected nil result, got %#v", prob)
 			} else {
 				test.AssertMarshaledEquals(t, prob, tc.ExpectedResult)
 			}
@@ -608,7 +608,7 @@ func TestValidNonce(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
 			prob := wfe.validNonce(tc.JWS)
 			if tc.ExpectedResult == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil result, got %#v", prob))
+				t.Fatalf("Expected nil result, got %#v", prob)
 			} else {
 				test.AssertMarshaledEquals(t, prob, tc.ExpectedResult)
 			}
@@ -727,7 +727,7 @@ func TestValidPOSTURL(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
 			prob := wfe.validPOSTURL(tc.Request, tc.JWS)
 			if tc.ExpectedResult == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil result, got %#v", prob))
+				t.Fatalf("Expected nil result, got %#v", prob)
 			} else {
 				test.AssertMarshaledEquals(t, prob, tc.ExpectedResult)
 			}
@@ -883,7 +883,7 @@ func TestParseJWSRequest(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
 			_, prob := wfe.parseJWSRequest(tc.Request)
 			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil problem, got %#v\n", prob))
+				t.Fatalf("Expected nil problem, got %#v\n", prob)
 			} else {
 				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
 			}
@@ -927,7 +927,7 @@ func TestExtractJWK(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			jwk, prob := wfe.extractJWK(tc.JWS)
 			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil problem, got %#v\n", prob))
+				t.Fatalf("Expected nil problem, got %#v\n", prob)
 			} else if tc.ExpectedProblem == nil {
 				test.AssertMarshaledEquals(t, jwk, tc.ExpectedKey)
 			} else {
@@ -1066,7 +1066,7 @@ func TestLookupJWK(t *testing.T) {
 			inputLogEvent := newRequestEvent()
 			jwk, acct, prob := wfe.lookupJWK(tc.JWS, context.Background(), tc.Request, inputLogEvent)
 			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil problem, got %#v\n", prob))
+				t.Fatalf("Expected nil problem, got %#v\n", prob)
 			} else if tc.ExpectedProblem == nil {
 				inThumb, _ := tc.ExpectedKey.Thumbprint(crypto.SHA256)
 				outThumb, _ := jwk.Thumbprint(crypto.SHA256)
@@ -1201,7 +1201,7 @@ func TestValidJWSForKey(t *testing.T) {
 			outPayload, prob := wfe.validJWSForKey(tc.JWS, tc.JWK, request, inputLogEvent)
 
 			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil problem, got %#v\n", prob))
+				t.Fatalf("Expected nil problem, got %#v\n", prob)
 			} else if tc.ExpectedProblem == nil {
 				test.AssertEquals(t, inputLogEvent.Payload, payload)
 				test.AssertEquals(t, string(outPayload), payload)
@@ -1295,7 +1295,7 @@ func TestValidPOSTForAccount(t *testing.T) {
 			inputLogEvent := newRequestEvent()
 			outPayload, jws, acct, prob := wfe.validPOSTForAccount(tc.Request, context.Background(), inputLogEvent)
 			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil problem, got %#v\n", prob))
+				t.Fatalf("Expected nil problem, got %#v\n", prob)
 			} else if tc.ExpectedProblem == nil {
 				test.AssertEquals(t, inputLogEvent.Payload, tc.ExpectedPayload)
 				test.AssertEquals(t, string(outPayload), tc.ExpectedPayload)
@@ -1399,7 +1399,7 @@ func TestValidSelfAuthenticatedPOST(t *testing.T) {
 			inputLogEvent := newRequestEvent()
 			outPayload, jwk, prob := wfe.validSelfAuthenticatedPOST(tc.Request, inputLogEvent)
 			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatal(fmt.Sprintf("Expected nil problem, got %#v\n", prob))
+				t.Fatalf("Expected nil problem, got %#v\n", prob)
 			} else if tc.ExpectedProblem == nil {
 				inThumb, _ := tc.ExpectedJWK.Thumbprint(crypto.SHA256)
 				outThumb, _ := jwk.Thumbprint(crypto.SHA256)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -335,14 +335,14 @@ func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *web.RequestEven
 
 	addNoCacheHeader(response)
 	response.Header().Set("Content-Type", "text/html")
-	response.Write([]byte(fmt.Sprintf(`<html>
+	fmt.Fprintf(response, `<html>
 		<body>
 			This is an <a href="https://github.com/ietf-wg-acme/acme/">ACME</a>
 			Certificate Authority running <a href="https://github.com/letsencrypt/boulder">Boulder</a>.
 			JSON directory is available at <a href="%s">%s</a>.
 		</body>
 	</html>
-	`, directoryPath, directoryPath)))
+	`, directoryPath, directoryPath)
 }
 
 func addNoCacheHeader(w http.ResponseWriter) {
@@ -351,7 +351,7 @@ func addNoCacheHeader(w http.ResponseWriter) {
 
 func addRequesterHeader(w http.ResponseWriter, requester int64) {
 	if requester > 0 {
-		w.Header().Set("Boulder-Requester", fmt.Sprintf("%d", requester))
+		w.Header().Set("Boulder-Requester", strconv.FormatInt(requester, 10))
 	}
 }
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -325,7 +325,7 @@ func loadKey(t *testing.T, keyBytes []byte) crypto.Signer {
 	}
 
 	// Nothing worked! Fail hard.
-	t.Fatal(fmt.Sprintf("Unable to decode private key PEM bytes"))
+	t.Fatalf("Unable to decode private key PEM bytes")
 	// NOOP - the t.Fatal() call will abort before this return
 	return nil
 }
@@ -346,7 +346,7 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock) {
 	test.AssertNotError(t, err, "Unable to read ../test/test-ca2.pem")
 
 	certChains := map[string][]byte{
-		"http://localhost:4000/acme/issuer-cert": []byte(fmt.Sprintf("\n%s", string(chainPEM))),
+		"http://localhost:4000/acme/issuer-cert": append([]byte{'\n'}, chainPEM...),
 	}
 
 	wfe, err := NewWebFrontEndImpl(stats, fc, testKeyPolicy, certChains, blog.NewMock())
@@ -368,7 +368,7 @@ func makePostRequestWithPath(path string, body string) *http.Request {
 		Method:     "POST",
 		RemoteAddr: "1.1.1.1:7882",
 		Header: map[string][]string{
-			"Content-Length": {fmt.Sprintf("%d", len(body))},
+			"Content-Length": {strconv.Itoa(len(body))},
 		},
 		Body: makeBody(body),
 		Host: "localhost",
@@ -764,17 +764,17 @@ func TestRelativeDirectory(t *testing.T) {
 	defer func() { core.RandReader = rand.Reader }()
 
 	expectedDirectory := func(hostname string) string {
-		var expected bytes.Buffer
+		expected := new(bytes.Buffer)
 
-		expected.WriteString("{")
-		expected.WriteString(fmt.Sprintf(`"keyChange":"%s/acme/key-change",`, hostname))
-		expected.WriteString(fmt.Sprintf(`"newNonce":"%s/acme/new-nonce",`, hostname))
-		expected.WriteString(fmt.Sprintf(`"newAccount":"%s/acme/new-acct",`, hostname))
-		expected.WriteString(fmt.Sprintf(`"newOrder":"%s/acme/new-order",`, hostname))
-		expected.WriteString(fmt.Sprintf(`"revokeCert":"%s/acme/revoke-cert",`, hostname))
-		expected.WriteString(`"AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417",`)
-		expected.WriteString(`"meta":{"termsOfService":"http://example.invalid/terms"}`)
-		expected.WriteString("}")
+		fmt.Fprintf(expected, "{")
+		fmt.Fprintf(expected, `"keyChange":"%s/acme/key-change",`, hostname)
+		fmt.Fprintf(expected, `"newNonce":"%s/acme/new-nonce",`, hostname)
+		fmt.Fprintf(expected, `"newAccount":"%s/acme/new-acct",`, hostname)
+		fmt.Fprintf(expected, `"newOrder":"%s/acme/new-order",`, hostname)
+		fmt.Fprintf(expected, `"revokeCert":"%s/acme/revoke-cert",`, hostname)
+		fmt.Fprintf(expected, `"AAAAAAAAAAA":"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417",`)
+		fmt.Fprintf(expected, `"meta":{"termsOfService":"http://example.invalid/terms"}`)
+		fmt.Fprintf(expected, "}")
 		return expected.String()
 	}
 


### PR DESCRIPTION
Remove various unnecessary uses of `fmt.Sprintf`.

- Avoid calls like `t.Error(fmt.Sprintf(...))`, where `t.Errorf` can be used directly.

- Use `strconv` when converting an integer to a string, rather than using
  `fmt.Sprintf("%d", ...)`. This is simpler and can also detect type errors at
  compile time.

- Instead of using `x.Write([]byte(fmt.Sprintf(...)))`, use `fmt.Fprintf(x, ...)`.