### PR TITLE
Convert the probs functions to be formatters.

### DIFF
--- a/probs/probs.go
+++ b/probs/probs.go
@@ -79,73 +79,70 @@ func ProblemDetailsToStatusCode(prob *ProblemDetails) int {
 
 // BadNonce returns a ProblemDetails with a BadNonceProblem and a 400 Bad
 // Request status code.
-func BadNonce(detail string) *ProblemDetails {
+func BadNonce(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       BadNonceProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // RejectedIdentifier returns a ProblemDetails with a RejectedIdentifierProblem and a 400 Bad
 // Request status code.
-func RejectedIdentifier(detail string) *ProblemDetails {
+func RejectedIdentifier(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       RejectedIdentifierProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // Conflict returns a ProblemDetails with a MalformedProblem and a 409 Conflict
 // status code.
-func Conflict(detail string) *ProblemDetails {
+func Conflict(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       MalformedProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusConflict,
 	}
 }
 
 // Malformed returns a ProblemDetails with a MalformedProblem and a 400 Bad
 // Request status code.
-func Malformed(detail string, args ...interface{}) *ProblemDetails {
-	if len(args) > 0 {
-		detail = fmt.Sprintf(detail, args...)
-	}
+func Malformed(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       MalformedProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // NotFound returns a ProblemDetails with a MalformedProblem and a 404 Not Found
 // status code.
-func NotFound(detail string) *ProblemDetails {
+func NotFound(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       MalformedProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusNotFound,
 	}
 }
 
 // ServerInternal returns a ProblemDetails with a ServerInternalProblem and a
 // 500 Internal Server Failure status code.
-func ServerInternal(detail string) *ProblemDetails {
+func ServerInternal(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       ServerInternalProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusInternalServerError,
 	}
 }
 
 // Unauthorized returns a ProblemDetails with an UnauthorizedProblem and a 403
 // Forbidden status code.
-func Unauthorized(detail string) *ProblemDetails {
+func Unauthorized(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       UnauthorizedProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusForbidden,
 	}
 }
@@ -172,85 +169,85 @@ func ContentLengthRequired() *ProblemDetails {
 
 // InvalidContentType returns a ProblemDetails suitable for a missing
 // ContentType header, or an incorrect ContentType header
-func InvalidContentType(detail string) *ProblemDetails {
+func InvalidContentType(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       MalformedProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusUnsupportedMediaType,
 	}
 }
 
 // InvalidEmail returns a ProblemDetails representing an invalid email address
 // error
-func InvalidEmail(detail string) *ProblemDetails {
+func InvalidEmail(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       InvalidEmailProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // ConnectionFailure returns a ProblemDetails representing a ConnectionProblem
 // error
-func ConnectionFailure(detail string) *ProblemDetails {
+func ConnectionFailure(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       ConnectionProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // UnknownHost returns a ProblemDetails representing an UnknownHostProblem error
-func UnknownHost(detail string) *ProblemDetails {
+func UnknownHost(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       UnknownHostProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // RateLimited returns a ProblemDetails representing a RateLimitedProblem error
-func RateLimited(detail string) *ProblemDetails {
+func RateLimited(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       RateLimitedProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: statusTooManyRequests,
 	}
 }
 
 // TLSError returns a ProblemDetails representing a TLSProblem error
-func TLSError(detail string) *ProblemDetails {
+func TLSError(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       TLSProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // AccountDoesNotExist returns a ProblemDetails representing an
 // AccountDoesNotExistProblem error
-func AccountDoesNotExist(detail string) *ProblemDetails {
+func AccountDoesNotExist(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       AccountDoesNotExistProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
 // CAA returns a ProblemDetails representing a CAAProblem
-func CAA(detail string) *ProblemDetails {
+func CAA(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       CAAProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusForbidden,
 	}
 }
 
 // DNS returns a ProblemDetails representing a DNSProblem
-func DNS(detail string) *ProblemDetails {
+func DNS(detail string, a ...interface{}) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       DNSProblem,
-		Detail:     detail,
+		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
 	}
 }

--- a/va/caa.go
+++ b/va/caa.go
@@ -42,12 +42,12 @@ func (va *ValidationAuthorityImpl) checkCAA(
 	identifier core.AcmeIdentifier) *probs.ProblemDetails {
 	present, valid, err := va.checkCAARecords(ctx, identifier)
 	if err != nil {
-		return probs.DNS(err.Error())
+		return probs.DNS("%v", err)
 	}
 	va.log.AuditInfof("Checked CAA records for %s, [Present: %t, Valid for issuance: %t]",
 		identifier.Value, present, valid)
 	if !valid {
-		return probs.CAA(fmt.Sprintf("CAA record for %s prevents issuance", identifier.Value))
+		return probs.CAA("CAA record for %s prevents issuance", identifier.Value)
 	}
 	return nil
 }

--- a/web/probs.go
+++ b/web/probs.go
@@ -1,8 +1,6 @@
 package web
 
 import (
-	"fmt"
-
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/probs"
 )
@@ -10,29 +8,29 @@ import (
 func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs.ProblemDetails {
 	switch err.Type {
 	case berrors.Malformed:
-		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.Malformed("%s :: %s", msg, err)
 	case berrors.Unauthorized:
-		return probs.Unauthorized(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.Unauthorized("%s :: %s", msg, err)
 	case berrors.NotFound:
-		return probs.NotFound(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.NotFound("%s :: %s", msg, err)
 	case berrors.RateLimit:
-		return probs.RateLimited(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.RateLimited("%s :: %s", msg, err)
 	case berrors.InternalServer:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.
 		return probs.ServerInternal(msg)
 	case berrors.RejectedIdentifier:
-		return probs.RejectedIdentifier(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.RejectedIdentifier("%s :: %s", msg, err)
 	case berrors.InvalidEmail:
-		return probs.InvalidEmail(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.InvalidEmail("%s :: %s", msg, err)
 	case berrors.WrongAuthorizationState:
-		return probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.Malformed("%s :: %s", msg, err)
 	case berrors.CAA:
-		return probs.CAA(fmt.Sprintf("%s :: %s", msg, err))
+		return probs.CAA("%s :: %s", msg, err)
 	case berrors.MissingSCTs:
 		// MissingSCTs are an internal server error, but with a specific error
 		// message related to the SCT problem
-		return probs.ServerInternal(fmt.Sprintf("%s :: %s", msg, "Unable to meet CA SCT embedding requirements"))
+		return probs.ServerInternal("%s :: %s", msg, "Unable to meet CA SCT embedding requirements")
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -509,7 +509,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *web.Reques
 
 	// Only check for validity if we are actually checking the registration
 	if regCheck && reg.Status != core.StatusValid {
-		return nil, nil, reg, probs.Unauthorized(fmt.Sprintf("Registration is not valid, has status '%s'", reg.Status))
+		return nil, nil, reg, probs.Unauthorized("Registration is not valid, has status '%s'", reg.Status)
 	}
 
 	if statName, err := checkAlgorithm(key, parsedJws); err != nil {
@@ -536,7 +536,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *web.Reques
 		return nil, nil, reg, probs.BadNonce("JWS has no anti-replay nonce")
 	} else if !wfe.nonceService.Valid(nonce) {
 		wfe.stats.Inc("Errors.JWSInvalidNonce", 1)
-		return nil, nil, reg, probs.BadNonce(fmt.Sprintf("JWS has invalid anti-replay nonce %s", nonce))
+		return nil, nil, reg, probs.BadNonce("JWS has invalid anti-replay nonce %s", nonce)
 	}
 
 	// Check that the "resource" field is present and has the correct value
@@ -1164,8 +1164,8 @@ func (wfe *WebFrontEndImpl) Registration(ctx context.Context, logEvent *web.Requ
 	// extraneous requests to the RA we have to add this bypass.
 	if len(update.Agreement) > 0 && update.Agreement != currReg.Agreement &&
 		update.Agreement != wfe.SubscriberAgreementURL {
-		msg := fmt.Sprintf("Provided agreement URL [%s] does not match current agreement URL [%s]", update.Agreement, wfe.SubscriberAgreementURL)
-		wfe.sendError(response, logEvent, probs.Malformed(msg), nil)
+		problem := probs.Malformed("Provided agreement URL [%s] does not match current agreement URL [%s]", update.Agreement, wfe.SubscriberAgreementURL)
+		wfe.sendError(response, logEvent, problem, nil)
 		return
 	}
 

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -100,8 +100,7 @@ func checkJWSAuthType(jws *jose.JSONWebSignature) (jwsAuthType, *probs.ProblemDe
 	header := jws.Signatures[0].Header
 	// There must not be a Key ID *and* an embedded JWK
 	if header.KeyID != "" && header.JSONWebKey != nil {
-		return invalidAuthType, probs.Malformed(
-			"jwk and kid header fields are mutually exclusive")
+		return invalidAuthType, probs.Malformed("jwk and kid header fields are mutually exclusive")
 	} else if header.KeyID != "" {
 		return embeddedKeyID, nil
 	} else if header.JSONWebKey != nil {
@@ -151,15 +150,13 @@ func (wfe *WebFrontEndImpl) validPOSTRequest(request *http.Request) *probs.Probl
 		// JSON serialization.
 		if _, present := request.Header["Content-Type"]; !present {
 			wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "NoContentType"}).Inc()
-			return probs.InvalidContentType(fmt.Sprintf(
-				"No Content-Type header on POST. "+
-					"Content-Type must be %q", expectedJWSContentType))
+			return probs.InvalidContentType("No Content-Type header on POST. Content-Type must be %q",
+				expectedJWSContentType)
 		}
 		if contentType := request.Header.Get("Content-Type"); contentType != expectedJWSContentType {
 			wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "WrongContentType"}).Inc()
-			return probs.InvalidContentType(fmt.Sprintf(
-				"Invalid Content-Type header on POST. "+
-					"Content-Type must be %q", expectedJWSContentType))
+			return probs.InvalidContentType("Invalid Content-Type header on POST. Content-Type must be %q",
+				expectedJWSContentType)
 		}
 	}
 
@@ -193,7 +190,7 @@ func (wfe *WebFrontEndImpl) validNonce(jws *jose.JSONWebSignature) *probs.Proble
 		return probs.BadNonce("JWS has no anti-replay nonce")
 	} else if !wfe.nonceService.Valid(nonce) {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSInvalidNonce"}).Inc()
-		return probs.BadNonce(fmt.Sprintf("JWS has an invalid anti-replay nonce: %q", nonce))
+		return probs.BadNonce("JWS has an invalid anti-replay nonce: %q", nonce)
 	}
 	return nil
 }
@@ -230,9 +227,8 @@ func (wfe *WebFrontEndImpl) validPOSTURL(
 	// header
 	if expectedURL.String() != headerURL {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSMismatchedURL"}).Inc()
-		return probs.Malformed(fmt.Sprintf(
-			"JWS header parameter 'url' incorrect. Expected %q got %q",
-			expectedURL.String(), headerURL))
+		return probs.Malformed("JWS header parameter 'url' incorrect. Expected %q got %q",
+			expectedURL.String(), headerURL)
 	}
 	return nil
 }
@@ -262,9 +258,8 @@ func (wfe *WebFrontEndImpl) matchJWSURLs(outer, inner *jose.JSONWebSignature) *p
 	// Verify that the outer URL matches the inner URL
 	if outerURL != innerURL {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverMismatchedURLs"}).Inc()
-		return probs.Malformed(fmt.Sprintf(
-			"Outer JWS 'url' value %q does not match inner JWS 'url' value %q",
-			outerURL, innerURL))
+		return probs.Malformed("Outer JWS 'url' value %q does not match inner JWS 'url' value %q",
+			outerURL, innerURL)
 	}
 
 	return nil
@@ -295,7 +290,7 @@ func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*jose.JSONWebSignature, *prob
 	if unprotected.Header != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSUnprotectedHeaders"}).Inc()
 		return nil, probs.Malformed(
-			"JWS \"header\" field not allowed. All headers must be in \"protected\" field")
+			`JWS "header" field not allowed. All headers must be in "protected" field`)
 	}
 
 	// ACME v2 never uses the "signatures" array of JSON serialized JWS, just the
@@ -303,7 +298,7 @@ func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*jose.JSONWebSignature, *prob
 	if len(unprotected.Signatures) > 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSMultiSig"}).Inc()
 		return nil, probs.Malformed(
-			"JWS \"signatures\" field not allowed. Only the \"signature\" field should contain a signature")
+			`JWS "signatures" field not allowed. Only the "signature" field should contain a signature`)
 	}
 
 	// Parse the JWS using go-jose and enforce that the expected one non-empty
@@ -402,7 +397,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 	accountID, err := strconv.ParseInt(accountIDStr, 10, 64)
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSInvalidKeyID"}).Inc()
-		return nil, nil, probs.Malformed(fmt.Sprintf("Malformed account ID in KeyID header"))
+		return nil, nil, probs.Malformed("Malformed account ID in KeyID header")
 	}
 
 	// Try to find the account for this account ID
@@ -411,8 +406,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 		// If the account isn't found, return a suitable problem
 		if berrors.Is(err, berrors.NotFound) {
 			wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDNotFound"}).Inc()
-			return nil, nil, probs.AccountDoesNotExist(fmt.Sprintf(
-				"Account %q not found", accountURL))
+			return nil, nil, probs.AccountDoesNotExist("Account %q not found", accountURL)
 		}
 
 		// If there was an error and it isn't a "Not Found" error, return
@@ -420,15 +414,13 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDLookupFailed"}).Inc()
 		// Add an error to the log event with the internal error message
 		logEvent.AddError(fmt.Sprintf("Error calling SA.GetRegistration: %s", err.Error()))
-		return nil, nil, probs.ServerInternal(fmt.Sprintf(
-			"Error retreiving account %q", accountURL))
+		return nil, nil, probs.ServerInternal("Error retreiving account %q", accountURL)
 	}
 
 	// Verify the account is not deactivated
 	if account.Status != core.StatusValid {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDAccountInvalid"}).Inc()
-		return nil, nil, probs.Unauthorized(
-			fmt.Sprintf("Account is not valid, has status %q", account.Status))
+		return nil, nil, probs.Unauthorized("Account is not valid, has status %q", account.Status)
 	}
 
 	// Update the logEvent with the account information and return the JWK

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1599,15 +1599,15 @@ func (wfe *WebFrontEndImpl) GetOrder(ctx context.Context, logEvent *web.RequestE
 	order, err := wfe.SA.GetOrder(ctx, &sapb.OrderRequest{Id: &orderID})
 	if err != nil {
 		if berrors.Is(err, berrors.NotFound) {
-			wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("No order for ID %d", orderID)), err)
+			wfe.sendError(response, logEvent, probs.NotFound("No order for ID %d", orderID), err)
 			return
 		}
-		wfe.sendError(response, logEvent, probs.ServerInternal(fmt.Sprintf("Failed to retrieve order for ID %d", orderID)), err)
+		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to retrieve order for ID %d", orderID), err)
 		return
 	}
 
 	if *order.RegistrationID != acctID {
-		wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("No order found for account ID %d", acctID)), nil)
+		wfe.sendError(response, logEvent, probs.NotFound("No order found for account ID %d", acctID), nil)
 		return
 	}
 
@@ -1653,22 +1653,22 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	order, err := wfe.SA.GetOrder(ctx, &sapb.OrderRequest{Id: &orderID})
 	if err != nil {
 		if berrors.Is(err, berrors.NotFound) {
-			wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("No order for ID %d", orderID)), err)
+			wfe.sendError(response, logEvent, probs.NotFound("No order for ID %d", orderID), err)
 			return
 		}
-		wfe.sendError(response, logEvent, probs.ServerInternal(fmt.Sprintf("Failed to retrieve order for ID %d", orderID)), err)
+		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to retrieve order for ID %d", orderID), err)
 		return
 	}
 
 	if *order.RegistrationID != acctID {
-		wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("No order found for account ID %d", acctID)), nil)
+		wfe.sendError(response, logEvent, probs.NotFound("No order found for account ID %d", acctID), nil)
 		return
 	}
 
 	// If the authenticated account ID doesn't match the order's registration ID
 	// pretend it doesn't exist and abort.
 	if acct.ID != *order.RegistrationID {
-		wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("No order found for account ID %d", acct.ID)), nil)
+		wfe.sendError(response, logEvent, probs.NotFound("No order found for account ID %d", acct.ID), nil)
 		return
 	}
 
@@ -1691,7 +1691,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	// If the order is expired we can not finalize it and must return an error
 	orderExpiry := time.Unix(*order.Expires, 0)
 	if orderExpiry.Before(wfe.clk.Now()) {
-		wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("Order %d is expired", *order.Id)), nil)
+		wfe.sendError(response, logEvent, probs.NotFound("Order %d is expired", *order.Id), nil)
 		return
 	}
 


### PR DESCRIPTION
Many of the probs.XYZ calls are of the form probs.XYZ(fmt.Sprintf(...)).
Convert these functions to take a format string and optional arguments,
following the same pattern used in the errors package. Convert the
various call sites to remove the now redundant fmt.Sprintf calls.