### PR TITLE
Accept empty pin and generate a key ID in cmd/gen-key

### DIFF
--- a/cmd/gen-key/main.go
+++ b/cmd/gen-key/main.go
@@ -82,7 +82,7 @@ func main() {
 	module := flag.String("module", "", "PKCS#11 module to use")
 	keyType := flag.String("type", "", "Type of key to generate (RSA or ECDSA)")
 	slot := flag.Uint("slot", 0, "Slot to generate key in")
-	pin := flag.String("pin", "", "PIN for slot")
+	pin := flag.String("pin", "", "PIN for slot if not using PED to login")
 	label := flag.String("label", "", "Key label")
 	rsaModLen := flag.Uint("modulus-bits", 0, "Size of RSA modulus in bits. Only used if --type=RSA")
 	rsaExp := flag.Uint("public-exponent", 65537, "Public RSA exponent. Only used if --type=RSA")
@@ -98,9 +98,6 @@ func main() {
 	}
 	if *keyType != "RSA" && *keyType != "ECDSA" {
 		log.Fatal("--type may only be RSA or ECDSA")
-	}
-	if *pin == "" {
-		log.Fatal("--pin is required")
 	}
 	if *label == "" {
 		log.Fatal("--label is required")

--- a/cmd/gen-key/rsa.go
+++ b/cmd/gen-key/rsa.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"errors"
@@ -16,7 +17,7 @@ import (
 // device and specifies which mechanism should be used. modulusLen specifies the
 // length of the modulus to be generated on the device in bits and exponent
 // specifies the public exponent that should be used.
-func rsaArgs(label string, modulusLen, exponent uint) generateArgs {
+func rsaArgs(label string, modulusLen, exponent uint, keyID []byte) generateArgs {
 	// Encode as unpadded big endian encoded byte slice
 	expSlice := big.NewInt(int64(exponent)).Bytes()
 	log.Printf("\tEncoded public exponent (%d) as: %0X\n", exponent, expSlice)
@@ -25,6 +26,7 @@ func rsaArgs(label string, modulusLen, exponent uint) generateArgs {
 			pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS_KEY_PAIR_GEN, nil),
 		},
 		publicAttrs: []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_ID, keyID),
 			pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
 			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
 			// Allow the key to verify signatures
@@ -35,6 +37,7 @@ func rsaArgs(label string, modulusLen, exponent uint) generateArgs {
 			pkcs11.NewAttribute(pkcs11.CKA_PUBLIC_EXPONENT, expSlice),
 		},
 		privateAttrs: []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_ID, keyID),
 			pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
 			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
 			// Prevent attributes being retrieved
@@ -130,8 +133,13 @@ func rsaVerify(ctx PKCtx, session pkcs11.SessionHandle, object pkcs11.ObjectHand
 // specified by modulusLen and with the exponent specified by pubExponent.
 // It returns the public part of the generated key pair as a rsa.PublicKey.
 func rsaGenerate(ctx PKCtx, session pkcs11.SessionHandle, label string, modulusLen, pubExponent uint) (*rsa.PublicKey, error) {
-	log.Printf("Generating RSA key with %d bit modulus and public exponent %d\n", modulusLen, pubExponent)
-	args := rsaArgs(label, modulusLen, pubExponent)
+	keyID := make([]byte, 4)
+	_, err := rand.Read(keyID)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Generating RSA key with %d bit modulus and public exponent %d and ID %x\n", modulusLen, pubExponent, keyID)
+	args := rsaArgs(label, modulusLen, pubExponent, keyID)
 	pub, priv, err := ctx.GenerateKeyPair(session, args.mechanism, args.publicAttrs, args.privateAttrs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Two fixes that I found while doing work on the gen-cert tool and setting up the HSM again
* Accept an empty PIN argument, this allows purely using the PED for login if not using challenge mode
* Generate 4 byte key ID for public/private key pairs during key gen, the HSM doesn't generate this field itself and `letsencrypt/pkcs11key` relies on this attribute to function