### PR TITLE
Godeps: Try to appease CI by mimicking comment diff.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -252,7 +252,7 @@
 		},
 		{
 			"ImportPath": "github.com/go-sql-driver/mysql",
-			"Comment": "v1.3-28-g3955978",
+			"Comment": "v1.3.0-28-g3955978",
 			"Rev": "3955978caca48c1658a4bb7a9c6a0f084e326af3"
 		},
 		{


### PR DESCRIPTION
Prior to this PR the builds of master are failing in Travis with an error during the `godep-restore` phase of our CI:

```
[   godep-restore] Starting
godep restore
rm -rf Godeps/ vendor/
godep save ./...
diff /dev/fd/63 /dev/fd/62
254c254
<                       "Comment": "v1.3-28-g3955978",
---
>                       "Comment": "v1.3.0-28-g3955978",
>                       git diff --exit-code -- ./vendor/
>
```

~This seems to be a mysterious difference in the "Comment" field of the `github.com/go-sql-driver/mysql` dependency. This dep hasn't changed versions so given the general level of frustration involved with debugging Godep it seems like the easiest path forward is to mimick the diff.~ The root cause here is the upstream `github.com/go-sql-driver/mysql` project adding a new tag for the 3955978caca48c1658a4bb7a9c6a0f084e326af3 commit. The new tag is named to match semvar requirements and Godeps in CI is preferring that tag. Updating the file to point to this new tag is a sensible fix from our side.

This commit updates the "Comment" filed to match what CI expects.