### PR TITLE
VA: CAA tag identifiers are case insensitive. (#3722)

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -84,7 +84,7 @@ func newCAASet(CAAs []*dns.CAA) *CAASet {
 	var filtered CAASet
 
 	for _, caaRecord := range CAAs {
-		switch caaRecord.Tag {
+		switch strings.ToLower(caaRecord.Tag) {
 		case "issue":
 			filtered.Issue = append(filtered.Issue, caaRecord)
 		case "issuewild":

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -44,6 +44,10 @@ func (mock caaMockDNS) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, 
 		record.Tag = "issue"
 		record.Value = "ca.com"
 		results = append(results, &record)
+	case "mixedcase.com":
+		record.Tag = "iSsUe"
+		record.Value = "ca.com"
+		results = append(results, &record)
 	case "critical.com":
 		record.Flag = 1
 		record.Tag = "issue"
@@ -154,6 +158,12 @@ func TestCAAChecking(t *testing.T) {
 		{
 			Name:    "Bad (Reserved)",
 			Domain:  "reserved.com",
+			Present: true,
+			Valid:   false,
+		},
+		{
+			Name:    "Bad (Reserved, Mixed case Issue)",
+			Domain:  "mixedcase.com",
 			Present: true,
 			Valid:   false,
 		},


### PR DESCRIPTION
Per RFC 6844 Section 5.1 the matching of CAA tag identifiers (e.g.
"Issue") is case insensitive. This commit updates the CAA tag processing
to be case insensitive as required by the RFC.

To exercise the fix this commit adds a test case to the `caaMockDNS`
`LookupCAA` implementation for a hostname (`mixedcase.com`) that has
a CAA record with a mixed case `Issue` tag. Prior to the fix from this
branch being included in `va/caa.go` the test fails:
```
    --- FAIL: TestCAAChecking/Bad_(Reserved,_Mixed_case_Issue) (0.00s)
          caa_test.go:292: checkCAARecords validity mismatch for
          mixedcase.com: got true expected false
```

With the fix applied, the test passes.