### PR TITLE
Doc "Boulder divergences from ACME": ACME v2 is in production

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -10,6 +10,7 @@ Presently the following protocol features are not implemented:
 
 - Pre-authorization. This is an optional feature and we have no plans to implement it. V2 clients should use order based issuance without pre-authorization.
 - The “orders” field on account objects. We intend to support this non-essential feature in the near future. Please follow Boulder Issue [#3335](https://github.com/letsencrypt/boulder/issues/3335).
+- The “ready” state on order objects is not implemented. Orders remain “pending” when associated authorizations are all valid and finalization may occur. Client developers should check the authorization statuses to determine if the order is ready. Please follow Boulder Issue [#3530](https://github.com/letsencrypt/boulder/issues/3530).
 
 **ACME v1 divergences from [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).**
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -4,7 +4,7 @@ While Boulder attempts to implement the ACME specification as strictly as possib
 
 Since Boulder evolved alongside the ACME specification there is not one exact ACME draft number that can be referenced in isolation to understand the protocol Boulder speaks. This document exists to detail differences between what Boulder does and the most-recently published ACME draft. Since ACME is not yet finalized it will be updated as new numbered drafts are published.
 
-**ACME v2 divergences from [`draft-ietf-acme-acme-10`](https://tools.ietf.org/html/draft-ietf-acme-acme-10).**
+**ACME v2 divergences from [`draft-ietf-acme-acme-12`](https://tools.ietf.org/html/draft-ietf-acme-acme-12).**
 
 Presently the following protocol features are not implemented:
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -9,8 +9,8 @@ Since Boulder evolved alongside the ACME specification there is not one exact AC
 Presently the following protocol features are not implemented:
 
 - Pre-authorization. This is an optional feature and we have no plans to implement it. V2 clients should use order based issuance without pre-authorization.
-- The “orders” field on account objects. We intend to support this non-essential feature in the near future. Please follow Boulder Issue [#3335](https://github.com/letsencrypt/boulder/issues/3335).
-- The “ready” state on order objects is not implemented. Orders remain “pending” when associated authorizations are all valid and finalization may occur. Client developers should check the authorization statuses to determine if the order is ready. Please follow Boulder Issue [#3530](https://github.com/letsencrypt/boulder/issues/3530).
+- The `orders` field on account objects. We intend to support this non-essential feature in the near future. Please follow Boulder Issue [#3335](https://github.com/letsencrypt/boulder/issues/3335).
+- The `ready` state on order objects is not implemented. Orders remain `pending` when associated authorizations are all valid and finalization may occur. Client developers should check the authorization statuses to determine if the order is ready. Please follow Boulder Issue [#3530](https://github.com/letsencrypt/boulder/issues/3530).
 
 **ACME v1 divergences from [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).**
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -10,7 +10,6 @@ Presently the following protocol features are not implemented:
 
 - Pre-authorization. This is an optional feature and we have no plans to implement it. V2 clients should use order based issuance without pre-authorization.
 - The “orders” field on account objects. We intend to support this non-essential feature in the near future. Please follow Boulder Issue [#3335](https://github.com/letsencrypt/boulder/issues/3335).
-- The “ready” state on order objects is not implemented. Orders remain “pending” when associated authorizations are all valid and finalization may occur. Client developers should check the authorization statuses to determine if the order is ready. Please follow Boulder Issue [#3530](https://github.com/letsencrypt/boulder/issues/3530).
 
 **ACME v1 divergences from [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).**
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -4,9 +4,15 @@ While Boulder attempts to implement the ACME specification as strictly as possib
 
 Since Boulder evolved alongside the ACME specification there is not one exact ACME draft number that can be referenced in isolation to understand the protocol Boulder speaks. This document exists to detail differences between what Boulder does and the most-recently published ACME draft. Since ACME is not yet finalized it will be updated as new numbered drafts are published.
 
-We refer to what Boulder presently implements as "ACME v1" and we are [actively working on "ACME v2"](https://letsencrypt.org/2017/06/14/acme-v2-api.html), a second API endpoint with less divergences that is based on what will become the final ACME RFC.
+**ACME v2 divergences from [`draft-ietf-acme-acme-10`](https://tools.ietf.org/html/draft-ietf-acme-acme-10).**
 
-**Current draft: [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).**
+Presently the following protocol features are not implemented:
+
+- Pre-authorization. This is an optional feature and we have no plans to implement it. V2 clients should use order based issuance without pre-authorization.
+- The “orders” field on account objects. We intend to support this non-essential feature in the near future. Please follow Boulder Issue [#3335](https://github.com/letsencrypt/boulder/issues/3335).
+- The “ready” state on order objects is not implemented. Orders remain “pending” when associated authorizations are all valid and finalization may occur. Client developers should check the authorization statuses to determine if the order is ready. Please follow Boulder Issue [#3530](https://github.com/letsencrypt/boulder/issues/3530).
+
+**ACME v1 divergences from [`draft-ietf-acme-acme-07`](https://tools.ietf.org/html/draft-ietf-acme-acme-07).**
 
 ## [Section 6](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-6)
 


### PR DESCRIPTION
Probably more details should be added, but I think it can be merged before that.

I used https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578 and the fact that #3530 is closed.