### PR TITLE
VA: Log observed CAA records.

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -40,12 +40,23 @@ func (va *ValidationAuthorityImpl) IsCAAValid(
 func (va *ValidationAuthorityImpl) checkCAA(
 	ctx context.Context,
 	identifier core.AcmeIdentifier) *probs.ProblemDetails {
-	present, valid, err := va.checkCAARecords(ctx, identifier)
+	present, valid, records, err := va.checkCAARecords(ctx, identifier)
 	if err != nil {
 		return probs.DNS("%v", err)
 	}
-	va.log.AuditInfof("Checked CAA records for %s, [Present: %t, Valid for issuance: %t]",
-		identifier.Value, present, valid)
+
+	// Build a string with the DNS presentation format of each *dns.CAA record we
+	// checked (if any) separated by commas to be included in the audit log line
+	var recordsStr strings.Builder
+	for i, rec := range records {
+		fmt.Fprintf(&recordsStr, "%q", rec.String())
+		if i != len(records)-1 {
+			fmt.Fprintf(&recordsStr, ",")
+		}
+	}
+
+	va.log.AuditInfof("Checked CAA records for %s, [Present: %t, Valid for issuance: %t] Records=[%s]",
+		identifier.Value, present, valid, recordsStr.String())
 	if !valid {
 		return probs.CAA("CAA record for %s prevents issuance", identifier.Value)
 	}
@@ -104,17 +115,17 @@ type caaResult struct {
 	err     error
 }
 
-func parseResults(results []caaResult) (*CAASet, error) {
+func parseResults(results []caaResult) (*CAASet, []*dns.CAA, error) {
 	// Return first result
 	for _, res := range results {
 		if res.err != nil {
-			return nil, res.err
+			return nil, nil, res.err
 		}
 		if len(res.records) > 0 {
-			return newCAASet(res.records), nil
+			return newCAASet(res.records), res.records, nil
 		}
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (va *ValidationAuthorityImpl) parallelCAALookup(ctx context.Context, name string) []caaResult {
@@ -135,7 +146,7 @@ func (va *ValidationAuthorityImpl) parallelCAALookup(ctx context.Context, name s
 	return results
 }
 
-func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname string) (*CAASet, error) {
+func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname string) (*CAASet, []*dns.CAA, error) {
 	hostname = strings.TrimRight(hostname, ".")
 
 	// See RFC 6844 "Certification Authority Processing" for pseudocode, as
@@ -155,13 +166,15 @@ func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname strin
 // validates them. If the identifier argument's value has a wildcard prefix then
 // the prefix is stripped and validation will be performed against the base
 // domain, honouring any issueWild CAA records encountered as apppropriate.
-// checkCAARecords returns three values: the first is a bool indicating whether
-// CAA records were present. The second is a bool indicating whether issuance
-// for the identifier is valid. Any errors encountered are returned as the third
-// return value (or nil).
+// checkCAARecords returns four values: the first is a bool indicating whether
+// CAA records were present after filtering for known/supported CAA tags. The
+// second is a bool indicating whether issuance for the identifier is valid. The
+// unmodified *dns.CAA records that were processed/filtered are returned as the
+// third argument. Any  errors encountered are returned as the fourth return
+// value (or nil).
 func (va *ValidationAuthorityImpl) checkCAARecords(
 	ctx context.Context,
-	identifier core.AcmeIdentifier) (present, valid bool, err error) {
+	identifier core.AcmeIdentifier) (bool, bool, []*dns.CAA, error) {
 	hostname := strings.ToLower(identifier.Value)
 	// If this is a wildcard name, remove the prefix
 	var wildcard bool
@@ -169,12 +182,12 @@ func (va *ValidationAuthorityImpl) checkCAARecords(
 		hostname = strings.TrimPrefix(identifier.Value, `*.`)
 		wildcard = true
 	}
-	caaSet, err := va.getCAASet(ctx, hostname)
+	caaSet, records, err := va.getCAASet(ctx, hostname)
 	if err != nil {
-		return false, false, err
+		return false, false, nil, err
 	}
-	present, valid = va.validateCAASet(caaSet, wildcard)
-	return present, valid, nil
+	present, valid := va.validateCAASet(caaSet, wildcard)
+	return present, valid, records, nil
 }
 
 // validateCAASet checks a provided *CAASet. When the wildcard argument is true

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -329,31 +329,31 @@ func TestCAALogging(t *testing.T) {
 	}{
 		{
 			Domain:          "reserved.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Valid for issuance: false] Records=[\"\\t0\\tCLASS0\\tNone\\t0 issue \\\"ca.com\\\"\"]",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "mixedcase.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for mixedcase.com, [Present: true, Valid for issuance: false] Records=[\"\\t0\\tCLASS0\\tNone\\t0 iSsUe \\\"ca.com\\\"\"]",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for mixedcase.com, [Present: true, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"iSsUe\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "critical.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for critical.com, [Present: true, Valid for issuance: false] Records=[\"\\t0\\tCLASS0\\tNone\\t1 issue \\\"ca.com\\\"\"]",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for critical.com, [Present: true, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "present.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present.com, [Present: true, Valid for issuance: true] Records=[\"\\t0\\tCLASS0\\tNone\\t0 issue \\\"letsencrypt.org\\\"\"]",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present.com, [Present: true, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}]",
 		},
 		{
 			Domain:          "multi-crit-present.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for multi-crit-present.com, [Present: true, Valid for issuance: true] Records=[\"\\t0\\tCLASS0\\tNone\\t1 issue \\\"ca.com\\\"\",\"\\t0\\tCLASS0\\tNone\\t1 issue \\\"letsencrypt.org\\\"\"]",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for multi-crit-present.com, [Present: true, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}]",
 		},
 		{
 			Domain:          "present-with-parameter.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present-with-parameter.com, [Present: true, Valid for issuance: true] Records=[\"\\t0\\tCLASS0\\tNone\\t0 issue \\\"  letsencrypt.org  ;foo=bar;baz=bar\\\"\"]",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present-with-parameter.com, [Present: true, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"  letsencrypt.org  ;foo=bar;baz=bar\"}]",
 		},
 		{
 			Domain:          "satisfiable-wildcard-override.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for satisfiable-wildcard-override.com, [Present: true, Valid for issuance: false] Records=[\"\\t0\\tCLASS0\\tNone\\t0 issue \\\"ca.com\\\"\",\"\\t0\\tCLASS0\\tNone\\t0 issuewild \\\"letsencrypt.org\\\"\"]",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for satisfiable-wildcard-override.com, [Present: true, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issuewild\",\"Value\":\"letsencrypt.org\"}]",
 		},
 	}
 


### PR DESCRIPTION
This is a quick first pass at audit logging the `*dns.CAA` records in JSON format from within the VA's `IsCAAValid` function. This will provide more information for post-hoc analysis of CAA decisions.