### PR TITLE
Remove netaccess container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,13 @@ env:
     # godep-restore runs with a separate container because it needs to fetch
     # packages from GitHub et. al., which is incompatible with the DNS server
     # override in the boulder container (used for service discovery).
-    - RUN="godep-restore" CONTAINER="netaccess"
-    - RUN="coverage" CONTAINER="netaccess"
+    - RUN="godep-restore"
+    - RUN="coverage"
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: RUN="coverage" CONTAINER="netaccess"
+    - env: RUN="coverage"
 
 # We require a newer version of docker-compose than is installed by way of the
 # "services: docker" directive. Per the travis docs[0] this is best remedied
@@ -67,4 +67,4 @@ install:
   - $HOME/bin/docker-compose pull
 
 script:
-  - $HOME/bin/docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" ${CONTAINER:-boulder} ./test.sh
+  - $HOME/bin/docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" boulder ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,12 @@ env:
     #
     # Current Go version build tasks:
     #
-    - RUN="vet fmt migrations integration errcheck generate dashlint rpm"
+    - RUN="vet fmt migrations integration errcheck generate dashlint rpm godep-restore"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
     - RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
     - RUN="unit"
     - RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
-    # godep-restore runs with a separate container because it needs to fetch
-    # packages from GitHub et. al., which is incompatible with the DNS server
-    # override in the boulder container (used for service discovery).
-    - RUN="godep-restore"
     - RUN="coverage"
 
 matrix:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,16 +72,6 @@ services:
         command: mysqld --bind-address=0.0.0.0
         logging:
             driver: none
-    netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.2}:2018-05-04
-        networks:
-          - bluenet
-        volumes:
-          - .:/go/src/github.com/letsencrypt/boulder
-        working_dir: /go/src/github.com/letsencrypt/boulder
-        entrypoint: test/entrypoint.sh
-        depends_on:
-          - bmysql
 
 networks:
   bluenet:

--- a/test/sd-test-srv/main.go
+++ b/test/sd-test-srv/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// proxyQuery takes an A query for a domain and proxies it to Cloudflare DNS.
+// proxyQuery takes a query for a domain and proxies it to Cloudflare DNS.
 // This allows us to shim in sd-test-srv for our container without blocking
 // lookups to github.com and coveralls.io, which are used in our `godep-restore`
 // and `coverage` test phases respectively.
@@ -40,16 +40,16 @@ func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 		w.WriteMsg(m)
 		return
 	}
-	if r.Question[0].Qtype != dns.TypeA {
-		m.Rcode = dns.RcodeServerFailure
-		w.WriteMsg(m)
-		return
-	}
 	if !strings.HasSuffix(r.Question[0].Name, ".boulder.") {
 		proxyQuery(w, r)
 		return
 	}
 
+	if r.Question[0].Qtype != dns.TypeA {
+		m.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return
+	}
 	hdr := dns.RR_Header{
 		Name:   r.Question[0].Name,
 		Rrtype: dns.TypeA,


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/pull/3687, we introduced a special DNS server for the Boulder container that could act as our service discover by serving multiple results for some A queries. That necessitated splitting out some tests into a `netaccess` container that could look up real DNS names.

This turned out to be a problem for integrators who run boulder with `docker-compose up -d` as recommended in our README. The migrations get run in both the `netaccess` container and the `boulder` container, and they race, resulting in one or the other container failing.

This change removes the notion of a `netaccess` container and instead allows sd-test-srv to proxy queries it can't answer to Cloudflare's DNS.