### PR TITLE
Godeps: Fix golang_protobuf_extensions comment.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -366,7 +366,7 @@
 		},
 		{
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
-			"Comment": "v1.0.0-2-gc12348c",
+			"Comment": "v1.0.1",
 			"Rev": "c12348ce28de40eed0136aa2b644d0ee0650e56c"
 		},
 		{


### PR DESCRIPTION
The "v1.0.0-2-gc12348c" tag referenced in the Godeps.json comment for the "github.com/matttproud/golang_protobuf_extensions/pbutil" import doesn't seem to exist in the upstream repo anymore.

The "v1.0.1" comment being flagged as a diff in Godeps restore during CI _does_ exist and it points to the same commit (c12348ce28de40eed0136aa2b644d0ee0650e56c) we are using.

This commit fixes the comment to match upstream & expected. This fixes master's build.

(Note this is very similar to https://github.com/letsencrypt/boulder/commit/e65286659e9dd7a62a0038197c90ead88ded7eb2 ugh Godeps....)