### PR TITLE
WFE2: Include invalid kid in error messages.

### DIFF
--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -389,14 +389,15 @@ func (wfe *WebFrontEndImpl) acctIDFromURL(acctURL string, request *http.Request)
 	} else if strings.HasPrefix(acctURL, wfe.LegacyKeyIDPrefix) {
 		accountIDStr = strings.TrimPrefix(acctURL, wfe.LegacyKeyIDPrefix)
 	} else {
-		return 0, probs.Malformed("KeyID header contained an invalid account URL")
+		return 0, probs.Malformed(
+			fmt.Sprintf("KeyID header contained an invalid account URL: %q", acctURL))
 	}
 
 	// Convert the raw account ID string to an int64 for use with the SA's
 	// GetRegistration RPC
 	accountID, err := strconv.ParseInt(accountIDStr, 10, 64)
 	if err != nil {
-		return 0, probs.Malformed("Malformed account ID in KeyID header URL")
+		return 0, probs.Malformed("Malformed account ID in KeyID header URL: %q", acctURL)
 	}
 	return accountID, nil
 }

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1023,7 +1023,7 @@ func TestLookupJWK(t *testing.T) {
 			Request: makePostRequestWithPath("test-path", invalidKeyIDJWSBody),
 			ExpectedProblem: &probs.ProblemDetails{
 				Type:       probs.MalformedProblem,
-				Detail:     "KeyID header contained an invalid account URL",
+				Detail:     "KeyID header contained an invalid account URL: \"https://acme-99.lettuceencrypt.org/acme/reg/1\"",
 				HTTPStatus: http.StatusBadRequest,
 			},
 			ErrorStatType: "JWSInvalidKeyID",
@@ -1034,7 +1034,7 @@ func TestLookupJWK(t *testing.T) {
 			Request: makePostRequestWithPath("test-path", nonNumericKeyIDJWSBody),
 			ExpectedProblem: &probs.ProblemDetails{
 				Type:       probs.MalformedProblem,
-				Detail:     "Malformed account ID in KeyID header URL",
+				Detail:     "Malformed account ID in KeyID header URL: \"https://acme-v00.lettuceencrypt.org/acme/reg/abcd\"",
 				HTTPStatus: http.StatusBadRequest,
 			},
 			ErrorStatType: "JWSInvalidKeyID",


### PR DESCRIPTION
This commit updates the `wfe2/verify.go` implementation of
`acctIDFromURL` to include the invalid `kid` value being rejected as
part of the rejection error message. This will hopefully help
users/client developers understand the problem faster. Unit tests are
updated accordingly.