### PR TITLE
Bring test/config up to date with test/config-next

### DIFF
--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -8,11 +8,11 @@
       "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra1.boulder:9094", "ra2.boulder:9094"],
+      "serverAddresses": ["ra.boulder:9094"],
       "timeout": "15s"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     }
   },

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -11,11 +11,12 @@
       "keyFile": "test/grpc-creds/ca.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
     "grpcCA": {
       "address": ":9093",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "ra.boulder"
       ]
@@ -36,10 +37,12 @@
       "NumSessions": 2
     }],
     "expiry": "2160h",
+    "backdate": "1h",
     "lifespanOCSP": "96h",
     "maxNames": 100,
     "enableMustStaple": true,
     "hostnamePolicyFile": "test/hostname-policy.json",
+    "enablePrecertificateFlow": true,
     "cfssl": {
       "signing": {
         "profiles": {
@@ -129,7 +132,9 @@
     },
     "maxConcurrentRPCServerRequests": 100000,
     "features": {
-        "WildcardDomains": true
+        "RPCHeadroom": true,
+        "WildcardDomains": true,
+        "EmbedSCTs": true
     }
   },
 

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -18,7 +18,7 @@
       "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
     "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -6,7 +6,6 @@
     "listenAddress": "0.0.0.0:4002",
     "maxAge": "10s",
     "shutdownStopTimeout": "10s",
-    "shutdownKillTimeout": "1m",
     "debugAddr": ":8005"
   },
 

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -23,15 +23,15 @@
       "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
     },
     "publisher": {
-      "serverAddresses": ["publisher1.boulder:9091", "publisher2.boulder:9091"],
+      "serverAddresses": ["publisher.boulder:9091"],
       "timeout": "10s"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
     "ocspGeneratorService": {
-      "serverAddresses": ["ca1.boulder:9096", "ca2.boulder:9096"],
+      "serverAddresses": ["ca.boulder:9096"],
       "timeout": "15s"
     },
     "features": {

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -33,6 +33,10 @@
     "ocspGeneratorService": {
       "serverAddresses": ["ca1.boulder:9096", "ca2.boulder:9096"],
       "timeout": "15s"
+    },
+    "features": {
+      "RPCHeadroom": true,
+      "EmbedSCTs": true
     }
   },
 

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -1,4 +1,6 @@
 {
+  "backdate": "1h",
+
   "syslog": {
     "stdoutlevel": 7
   },
@@ -10,7 +12,7 @@
   },
 
   "saService": {
-    "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+    "serverAddresses": ["sa.boulder:9095"],
     "timeout": "15s"
   }
 }

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -5,6 +5,7 @@
     "debugAddr": ":8009",
     "grpc": {
       "address": ":9091",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "ra.boulder",
         "ocsp-updater.boulder"
@@ -16,8 +17,11 @@
       "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
+    },
+    "features": {
+      "RPCHeadroom": true
     }
   },
 

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -4,6 +4,10 @@
     "maxConcurrentRPCServerRequests": 100000,
     "maxContactsPerRegistration": 100,
     "dnsTries": 3,
+    "dnsResolvers": [
+      "127.0.0.1:8053",
+      "127.0.0.1:8054"
+    ],
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 100,
@@ -18,32 +22,37 @@
       "keyFile": "test/grpc-creds/ra.boulder/key.pem"
     },
     "vaService": {
-      "serverAddresses": ["va1.boulder:9092", "va2.boulder:9092"],
+      "serverAddresses": ["va.boulder:9092"],
       "timeout": "20s"
     },
     "caService": {
-      "serverAddresses": ["ca1.boulder:9093", "ca2.boulder:9093"],
+      "serverAddresses": ["ca.boulder:9093"],
       "timeout": "15s"
     },
     "publisherService": {
-      "serverAddresses": ["publisher1.boulder:9091", "publisher2.boulder:9091"],
-      "timeout": "15s"
+      "serverAddresses": ["publisher.boulder:9091"],
+      "timeout": "300s"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
     "grpc": {
       "address": ":9094",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "wfe.boulder",
         "admin-revoker.boulder"
       ]
     },
     "features": {
+      "RPCHeadroom": true,
       "WildcardDomains": true,
-      "CountCertificatesExact": true,
-      "ReusePendingAuthz": false
+      "TLSSNIRevalidation": true,
+      "ReusePendingAuthz": true,
+      "EmbedSCTs": true,
+      "EnforceOverlappingWildcards": true,
+      "VAChecksGSB": true
     },
     "CTLogGroups2": [
       {
@@ -51,11 +60,13 @@
         "logs": [
           {
             "uri": "http://boulder:4500",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q=="
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q==",
+            "submitFinalCert": true
           },
           {
             "uri": "http://boulder:4501",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA=="
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA==",
+            "submitFinalCert": true
           }
         ]
       },
@@ -64,13 +75,22 @@
         "logs": [
           {
             "uri": "http://boulder:4510",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyw1HymhJkuxSIgt3gqW3sVXqMqB3EFsXcMfPFo0vYwjNiRmCJDXKsR0Flp7MAK+wc3X/7Hpc8liUbMhPet7tEA=="
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyw1HymhJkuxSIgt3gqW3sVXqMqB3EFsXcMfPFo0vYwjNiRmCJDXKsR0Flp7MAK+wc3X/7Hpc8liUbMhPet7tEA==",
+            "submitFinalCert": true
           },
           {
             "uri": "http://boulder:4511",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg=="
+            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
+            "submitFinalCert": true
           }
         ]
+      }
+    ],
+    "InformationalCTLogs": [
+      {
+        "uri": "http://boulder:4512",
+        "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
+        "submitFinalCert": true
       }
     ]
   },
@@ -90,7 +110,6 @@
   },
 
   "common": {
-    "dnsResolver": "127.0.0.1:8053",
     "dnsTimeout": "1s",
     "dnsAllowLoopbackAddresses": true
   }

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -1,7 +1,7 @@
 {
   "sa": {
     "dbConnectFile": "test/secrets/sa_dburl",
-    "maxDBConns": 10,
+    "maxDBConns": 100,
     "maxConcurrentRPCServerRequests": 100000,
     "ParallelismPerRPC": 20,
     "debugAddr": ":8003",
@@ -12,6 +12,7 @@
     },
     "grpc": {
       "address": ":9095",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "admin-revoker.boulder",
         "ca.boulder",
@@ -25,6 +26,7 @@
       ]
     },
     "features": {
+      "RPCHeadroom": true,
       "WildcardDomains": true
     }
   },

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -9,6 +9,10 @@
     },
     "maxConcurrentRPCServerRequests": 100000,
     "dnsTries": 3,
+    "dnsResolvers": [
+      "127.0.0.1:8053",
+      "127.0.0.1:8054"
+    ],
     "issuerDomain": "happy-hacker-ca.invalid",
     "tls": {
       "caCertfile": "test/grpc-creds/minica.pem",
@@ -17,6 +21,7 @@
     },
     "grpc": {
       "address": ":9092",
+      "maxConcurrentStreams": 2000,
       "clientNames": [
         "ra.boulder"
       ]
@@ -27,7 +32,9 @@
       "ServerURL": "http://va1.boulder:6000"
     },
     "features": {
-      "IPv6First": true
+      "RPCHeadroom": true,
+      "VAChecksGSB": true,
+      "IPv6First": true,
     }
   },
 
@@ -37,7 +44,6 @@
   },
 
   "common": {
-    "dnsResolver": "127.0.0.1:8053",
     "dnsTimeout": "1s",
     "dnsAllowLoopbackAddresses": true
   }

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -34,7 +34,7 @@
     "features": {
       "RPCHeadroom": true,
       "VAChecksGSB": true,
-      "IPv6First": true,
+      "IPv6First": true
     }
   },
 

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -11,25 +11,27 @@
     "indexCacheDuration": "24h",
     "issuerCacheDuration": "48h",
     "shutdownStopTimeout": "10s",
-    "shutdownKillTimeout": "1m",
     "subscriberAgreementURL": "http://boulder:4000/terms/v1",
     "acceptRevocationReason": true,
     "allowAuthzDeactivation": true,
     "debugAddr": ":8000",
+    "directoryCAAIdentity": "happy-hacker-ca.invalid",
+    "directoryWebsite": "https://github.com/letsencrypt/boulder",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
       "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra1.boulder:9094", "ra2.boulder:9094"],
+      "serverAddresses": ["ra.boulder:9094"],
       "timeout": "20s"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
     "features": {
+      "RPCHeadroom": true
     }
   },
 

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -23,18 +23,21 @@
       "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra1.boulder:9094", "ra2.boulder:9094"],
+      "serverAddresses": ["ra.boulder:9094"],
       "timeout": "15s"
     },
     "saService": {
-      "serverAddresses": ["sa1.boulder:9095", "sa2.boulder:9095"],
+      "serverAddresses": ["sa.boulder:9095"],
       "timeout": "15s"
     },
     "certificateChains": {
       "http://boulder:4430/acme/issuer-cert": [ "test/test-ca2.pem" ],
       "http://127.0.0.1:4000/acme/issuer-cert": [ "test/test-ca2.pem" ]
     },
-    "features": {}
+    "features": {
+      "EnforceV2ContentType": true,
+      "RPCHeadroom": true
+    }
   },
 
   "syslog": {


### PR DESCRIPTION
Notably, enable the precertificate flow, RPCHeadroom, and multi-IP hostnames.
Lots of other changes and feature flags too.