### PR TITLE
CI: Ignore Godeps 'Comment' fields in godep-restore.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -184,7 +184,9 @@ if [[ "$RUN" =~ "godep-restore" ]] ; then
   cp Godeps/Godeps.json /tmp/Godeps.json.head
   run_and_expect_silence rm -rf Godeps/ vendor/
   run_and_expect_silence godep save ./...
-  run_and_expect_silence diff <(sed /GodepVersion/d /tmp/Godeps.json.head) <(sed /GodepVersion/d Godeps/Godeps.json)
+  run_and_expect_silence diff \
+    <(sed /GodepVersion/d;/Comment/d /tmp/Godeps.json.head) \
+    <(sed /GodepVersion/d;/Comment/d Godeps/Godeps.json)
   run_and_expect_silence git diff --exit-code -- ./vendor/
   end_context #godep-restore
 fi

--- a/test.sh
+++ b/test.sh
@@ -185,8 +185,8 @@ if [[ "$RUN" =~ "godep-restore" ]] ; then
   run_and_expect_silence rm -rf Godeps/ vendor/
   run_and_expect_silence godep save ./...
   run_and_expect_silence diff \
-    <(sed /GodepVersion/d;/Comment/d /tmp/Godeps.json.head) \
-    <(sed /GodepVersion/d;/Comment/d Godeps/Godeps.json)
+    <(sed '/GodepVersion/d;/Comment/d' /tmp/Godeps.json.head) \
+    <(sed '/GodepVersion/d;/Comment/d' Godeps/Godeps.json)
   run_and_expect_silence git diff --exit-code -- ./vendor/
   end_context #godep-restore
 fi


### PR DESCRIPTION
In preparation of `vgo` it seems many upstream projects are adding new
tags. This is causing variations in the `godep-restore` phase of CI when
the CI Godeps picks up a new `Comment` field that isn't present in the
committed JSON. This has broken master ~3 times now and so it seems
prudent to ignore the Comment field entirely for the short term. We
continue to wait for the glorious day in which we can switch to `vgo`
and never muck with `Godeps.json` again....