### PR TITLE
RA: Forbid contact addresses for IANA example domains.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -195,7 +195,7 @@ func validateEmail(ctx context.Context, address string, resolver bdns.DNSClient)
 	}
 	splitEmail := strings.SplitN(email.Address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])
-	if _, present := forbiddenMailDomains[domain]; present {
+	if forbiddenMailDomains[domain] {
 		return berrors.InvalidEmailError(
 			"invalid contact domain. Contact emails @%s are forbidden",
 			domain)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -176,6 +176,18 @@ func problemIsTimeout(err error) bool {
 	return false
 }
 
+// forbiddenMailDomains is a map of domain names we do not allow after the
+// @ symbol in contact mailto addresses. These are frequently used when
+// copy-pasting example configurations and would not result in expiration
+// messages and subscriber communications reaching the user that created the
+// registration if allowed.
+var forbiddenMailDomains = map[string]bool{
+	// https://tools.ietf.org/html/rfc2606#section-3
+	"example.com": true,
+	"example.net": true,
+	"example.org": true,
+}
+
 func validateEmail(ctx context.Context, address string, resolver bdns.DNSClient) error {
 	email, err := mail.ParseAddress(address)
 	if err != nil {
@@ -183,6 +195,11 @@ func validateEmail(ctx context.Context, address string, resolver bdns.DNSClient)
 	}
 	splitEmail := strings.SplitN(email.Address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])
+	if _, present := forbiddenMailDomains[domain]; present {
+		return berrors.InvalidEmailError(
+			"invalid contact domain. Contact emails @%s are forbidden",
+			domain)
+	}
 	var resultMX []string
 	var resultA []net.IP
 	var errMX, errA error
@@ -367,18 +384,6 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, init c
 	return reg, nil
 }
 
-// forbiddenMailDomains is a map of domain names we do not allow after the
-// @ symbol in contact mailto addresses. These are frequently used when
-// copy-pasting example configurations and would not result in expiration
-// messages and subscriber communications reaching the user that created the
-// registration if allowed.
-var forbiddenMailDomains = map[string]bool{
-	// https://tools.ietf.org/html/rfc2606#section-3
-	"example.com": true,
-	"example.net": true,
-	"example.org": true,
-}
-
 func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, contacts *[]string) error {
 	if contacts == nil || len(*contacts) == 0 {
 		return nil // Nothing to validate
@@ -401,12 +406,6 @@ func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, conta
 		}
 		if parsed.Scheme != "mailto" {
 			return berrors.MalformedError("contact method %s is not supported", parsed.Scheme)
-		}
-		if addressComponents := strings.Split(contact, "@"); len(addressComponents) != 2 {
-			return berrors.MalformedError("invalid contact")
-		} else if _, present := forbiddenMailDomains[addressComponents[1]]; present {
-			return berrors.MalformedError("invalid contact domain. Contact emails @%s are forbidden",
-				addressComponents[1])
 		}
 		if !core.IsASCII(contact) {
 			return berrors.MalformedError(

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -351,6 +351,12 @@ func TestValidateContacts(t *testing.T) {
 
 	err = ra.validateContacts(context.Background(), &[]string{nonASCII})
 	test.AssertError(t, err, "Non ASCII email")
+
+	for domain, _ := range forbiddenMailDomains {
+		emails := &[]string{fmt.Sprintf("mailto:test@%s", domain)}
+		err = ra.validateContacts(context.Background(), emails)
+		test.AssertError(t, err, "Forbidden mail domain")
+	}
 }
 
 func TestValidateEmail(t *testing.T) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -351,12 +351,6 @@ func TestValidateContacts(t *testing.T) {
 
 	err = ra.validateContacts(context.Background(), &[]string{nonASCII})
 	test.AssertError(t, err, "Non ASCII email")
-
-	for domain, _ := range forbiddenMailDomains {
-		emails := &[]string{fmt.Sprintf("mailto:test@%s", domain)}
-		err = ra.validateContacts(context.Background(), emails)
-		test.AssertError(t, err, "Forbidden mail domain")
-	}
 }
 
 func TestValidateEmail(t *testing.T) {
@@ -368,7 +362,11 @@ func TestValidateEmail(t *testing.T) {
 		{"a@always.invalid", emptyDNSResponseError.Error()},
 		{"a@email.com, b@email.com", unparseableEmailError.Error()},
 		{"a@always.error", "DNS problem: networking error looking up A for always.error"},
+		{"a@example.com", "invalid contact domain. Contact emails @example.com are forbidden"},
+		{"a@example.net", "invalid contact domain. Contact emails @example.net are forbidden"},
+		{"a@example.org", "invalid contact domain. Contact emails @example.org are forbidden"},
 	}
+
 	testSuccesses := []string{
 		"a@email.com",
 		"b@email.only",

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -351,7 +351,7 @@ def test_account_update():
     Create a new ACME client/account with one contact email. Then update the
     account to a different contact emails.
     """
-    emails=("initial-email@example.com", "updated-email@example.com", "another-update@example.com")
+    emails=("initial-email@not-example.com", "updated-email@not-example.com", "another-update@not-example.com")
     client = chisel.make_client(email=emails[0])
 
     for email in emails[1:]:

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -288,7 +288,7 @@ def test_sct_embedding():
 
 def test_only_return_existing_reg():
     client = chisel2.uninitialized_client()
-    email = "test@example.com"
+    email = "test@not-example.com"
     client.new_account(messages.NewRegistration.from_data(email=email,
             terms_of_service_agreed=True))
     


### PR DESCRIPTION
We see a fair number of ACME accounts/registrations with contact
addresses for the [RFC2606 Section 3](https://tools.ietf.org/html/rfc2606#section-3) "Reserved Example Second Level
Domain Names" (`example.com`, `example.net`, `example.org`). These are
not real contact addresses and are likely the result of the user
copy-pasting example configuration. These users will miss out on
expiration emails and other subscriber communications :-(

This commit updates the RA's `validateEmail` function to reject any
contact addresses for reserved example domain names. The corresponding
unit test is updated accordingly.

Resolves https://github.com/letsencrypt/boulder/issues/3719