### PR TITLE
CI/Dev: Add Go 1.10.3 to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - "1.10.2"
+  - "1.10.3"
 
 go_import_path: github.com/letsencrypt/boulder
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.2}:2018-06-04
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.2}:2018-06-11
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -51,7 +51,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.2}:2018-06-04
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.2}:2018-06-11
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -73,7 +73,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.2}:2018-06-04
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.10.2}:2018-06-11
         networks:
           - bluenet
         volumes:

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.10.2" )
+GO_VERSIONS=( "1.10.2" "1.10.3" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
Resolves https://github.com/letsencrypt/boulder/issues/3747