### PR TITLE
Fix wait_tcp_port in test/entrypoint.sh 

### DIFF
--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -14,14 +14,15 @@ wait_tcp_port() {
     local host="$1" port="$2"
 
     # see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
-    for n in `seq 1 30` ; do
+    local max_tries="120"
+    for n in `seq 1 $max_tries` ; do
       if exec 6<>/dev/tcp/$host/$port; then
         break
       else
         echo "$(date) - still trying to connect to $host:$port"
         sleep 1
       fi
-      if [ "$n" -eq "30" ]; then
+      if [ "$n" -eq "$max_tries" ]; then
         echo "unable to connect"
         exit 1
       fi

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -21,6 +21,10 @@ wait_tcp_port() {
         echo "$(date) - still trying to connect to $host:$port"
         sleep 1
       fi
+      if [ "$n" -eq "30" ]; then
+        echo "unable to connect"
+        exit 1
+      fi
     done
     exec 6>&-
     echo "Connected to $host:$port"


### PR DESCRIPTION
When we moved from using `while ! ...` to `for n in seq ...` an exit condition wasn't added when we exited the loop because we hit the max seq. This just adds a check for that case and exits with 1 if we hit it. Also increase the timeout from 30s to 2m.

Fixes #3762.