### PR TITLE
Require OCSPURL and CRLURL in CertProfile only for intermediates.

### DIFF
--- a/cmd/gen-ca/main.go
+++ b/cmd/gen-ca/main.go
@@ -241,11 +241,11 @@ func verifyProfile(profile CertProfile, root bool) error {
 	if profile.Country == "" {
 		return errors.New("Country in profile is required")
 	}
-	if profile.OCSPURL == "" {
-		return errors.New("OCSPURL in profile is required")
+	if !root && profile.OCSPURL == "" {
+		return errors.New("OCSPURL in profile is required for intermediates")
 	}
-	if profile.CRLURL == "" {
-		return errors.New("CRLURL in profile is required")
+	if !root && profile.CRLURL == "" {
+		return errors.New("CRLURL in profile is required for intermediates")
 	}
 	if !root && profile.IssuerURL == "" {
 		return errors.New("IssuerURL in profile is required for intermediates")

--- a/cmd/gen-ca/main_test.go
+++ b/cmd/gen-ca/main_test.go
@@ -345,7 +345,7 @@ func TestVerifyProfile(t *testing.T) {
 				Country:            "f",
 			},
 			root:        false,
-			expectedErr: "OCSPURL in profile is required",
+			expectedErr: "OCSPURL in profile is required for intermediates",
 		},
 		{
 			profile: CertProfile{
@@ -358,7 +358,7 @@ func TestVerifyProfile(t *testing.T) {
 				OCSPURL:            "g",
 			},
 			root:        false,
-			expectedErr: "CRLURL in profile is required",
+			expectedErr: "CRLURL in profile is required for intermediates",
 		},
 		{
 			profile: CertProfile{
@@ -382,8 +382,6 @@ func TestVerifyProfile(t *testing.T) {
 				CommonName:         "d",
 				Organization:       "e",
 				Country:            "f",
-				OCSPURL:            "g",
-				CRLURL:             "h",
 			},
 			root: true,
 		},


### PR DESCRIPTION
Fixes issue #3770. 