### PR TITLE
Fix gen-ca output

### DIFF
--- a/cmd/gen-ca/main.go
+++ b/cmd/gen-ca/main.go
@@ -265,6 +265,19 @@ func makeTemplate(ctx pkcs11helpers.PKCtx, profile *CertProfile, pubKey []byte, 
 		return nil, err
 	}
 
+	var ocspServer []string
+	if profile.OCSPURL != "" {
+		ocspServer = []string{profile.OCSPURL}
+	}
+	var crlDistributionPoints []string
+	if profile.CRLURL != "" {
+		crlDistributionPoints = []string{profile.CRLURL}
+	}
+	var issuingCertificateURL []string
+	if profile.IssuerURL != "" {
+		issuingCertificateURL = []string{profile.IssuerURL}
+	}
+
 	var policyOIDs []asn1.ObjectIdentifier
 	for _, oidStr := range profile.PolicyOIDs {
 		oid, err := parseOID(oidStr)
@@ -298,9 +311,9 @@ func makeTemplate(ctx pkcs11helpers.PKCtx, profile *CertProfile, pubKey []byte, 
 		},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
-		OCSPServer:            []string{profile.OCSPURL},
-		CRLDistributionPoints: []string{profile.CRLURL},
-		IssuingCertificateURL: []string{profile.IssuerURL},
+		OCSPServer:            ocspServer,
+		CRLDistributionPoints: crlDistributionPoints,
+		IssuingCertificateURL: issuingCertificateURL,
 		PolicyIdentifiers:     policyOIDs,
 		KeyUsage:              x509.KeyUsageCertSign & x509.KeyUsageCRLSign,
 		SubjectKeyId:          subjectKeyID[:],

--- a/cmd/gen-ca/main.go
+++ b/cmd/gen-ca/main.go
@@ -315,7 +315,7 @@ func makeTemplate(ctx pkcs11helpers.PKCtx, profile *CertProfile, pubKey []byte, 
 		CRLDistributionPoints: crlDistributionPoints,
 		IssuingCertificateURL: issuingCertificateURL,
 		PolicyIdentifiers:     policyOIDs,
-		KeyUsage:              x509.KeyUsageCertSign & x509.KeyUsageCRLSign,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		SubjectKeyId:          subjectKeyID[:],
 	}
 


### PR DESCRIPTION
Fix: When any of OCSPURL, CRLURL or IssuerURL in the CertProfile are empty, the relevant fields are encoded in ASN.1 as empty arrays. 
Fix: KeyUsage is a bitmask requiring bitwise OR. 