### PR TITLE
Switch from enforcing Unicode NFKC -> NFC

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -280,7 +280,7 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 			if err != nil {
 				return errMalformedIDN
 			}
-			if !norm.NFKC.IsNormalString(ulabel) {
+			if !norm.NFC.IsNormalString(ulabel) {
 				return errMalformedIDN
 			}
 		} else if idnReservedRegexp.MatchString(label) {

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -98,7 +98,7 @@ func TestWillingToIssue(t *testing.T) {
 		{`example.internal`, errNonPublic},
 		// All-numeric final label not okay.
 		{`www.zombo.163`, errNonPublic},
-		{`xn--109-3veba6djs1bfxlfmx6c9g.xn--f1awi.xn--p1ai`, errMalformedIDN}, // Not in Unicode NFKC
+		{`xn--109-3veba6djs1bfxlfmx6c9g.xn--f1awi.xn--p1ai`, errMalformedIDN}, // Not in Unicode NFC
 		{`bq--abwhky3f6fxq.jakacomo.com`, errInvalidRLDH},
 	}
 


### PR DESCRIPTION
In order to comply with the RFC 8399 update of RFC 5280.