### PR TITLE
Deconflict netaccess and boulder containers.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
         working_dir: /go/src/github.com/letsencrypt/boulder
-        entrypoint: test/entrypoint.sh
+        entrypoint: test/entrypoint-netaccess.sh
         depends_on:
           - bmysql
 

--- a/test/entrypoint-netaccess.sh
+++ b/test/entrypoint-netaccess.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# For the boulder container, we want to run entrypoint.sh and start.py by
+# default (when no command is passed on a "docker-compose run" command line).
+# However, we want the netaccess container to run nothing by default.
+# Otherwise it would race with boulder container's entrypoint.sh to run
+# migrations, and one or the other would fail randomly. Also, it would compete
+# with the boulder container for ports. This is a variant of entrypoint.sh that
+# exists if it is not given an argument.
+if [[ "$@" = "" ]]; then
+  echo "Not needed as part of 'docker-compse up'. Exiting normally."
+  exit 0
+fi
+$(dirname "${BASH_SOURCE[0]}")/entrypoint.sh "$@"

--- a/test/entrypoint-netaccess.sh
+++ b/test/entrypoint-netaccess.sh
@@ -5,7 +5,7 @@
 # Otherwise it would race with boulder container's entrypoint.sh to run
 # migrations, and one or the other would fail randomly. Also, it would compete
 # with the boulder container for ports. This is a variant of entrypoint.sh that
-# exists if it is not given an argument.
+# exits if it is not given an argument.
 if [[ "$@" = "" ]]; then
   echo "Not needed as part of 'docker-compse up'. Exiting normally."
   exit 0


### PR DESCRIPTION
Since these two containers were using the same entrpoint.sh, they were
competing to run migrations and bind ports when run with `docker-compose
up`. Since we don't need the netaccess container when doing
`docker-compose up`, give it a separate entrypoint that exits
immediately by default, but does the normal migrations when run with
`docker-compose run`.