### PR TITLE
CA config: use same hostname in ECDSA/RSA issuer_urls.

### DIFF
--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -55,7 +55,7 @@
             "backdate": "1h",
             "ca_constraint": { "is_ca": false },
             "issuer_urls": [
-              "http://boulder:4430/acme/issuer-cert"
+              "http://127.0.0.1:4430/acme/issuer-cert"
             ],
             "ocsp_url": "http://127.0.0.1:4002/",
             "crl_url": "http://example.com/crl",

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -55,7 +55,7 @@
             "backdate": "1h",
             "ca_constraint": { "is_ca": false },
             "issuer_urls": [
-              "http://boulder:4430/acme/issuer-cert"
+              "http://127.0.0.1:4430/acme/issuer-cert"
             ],
             "ocsp_url": "http://127.0.0.1:4002/",
             "crl_url": "http://example.com/crl",


### PR DESCRIPTION
This commit changes the `issuer_urls` setting of the RSA certificate
profile in both `test/config/ca.json` and `test/config-next/ca.json` to
use `127.0.0.1` as the hostname. This brings the ECDSA and RSA profiles in
sync w.r.t issuer URL hostname.

Resolves https://github.com/letsencrypt/boulder/issues/3783