### PR TITLE
Use challtestsrv for solving TLS-ALPN-01 in integration tests

### DIFF
--- a/test/challtestsrv/cmd/challtestsrv/tlsalpnone.go
+++ b/test/challtestsrv/cmd/challtestsrv/tlsalpnone.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+// addTLSALPN01 handles an HTTP POST request to add a new TLS-ALPN-01 challenge
+// response for a given host.
+func (srv *managementServer) addTLSALPN01(w http.ResponseWriter, r *http.Request) {
+	// Read the request body
+	msg, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Unmarshal the request body JSON as a request object
+	var request struct {
+		Host    string
+		Content string
+	}
+	err = json.Unmarshal(msg, &request)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// If the request has an empty host or content it's a bad request
+	if request.Host == "" || request.Content == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Add the TLS-ALPN-01 challenge to the challenge server
+	srv.challSrv.AddTLSALPNChallenge(request.Host, request.Content)
+	srv.log.Printf("Added TLS-ALPN-01 challenge for host %q - key auth %q\n",
+		request.Host, request.Content)
+	w.WriteHeader(http.StatusOK)
+}
+
+// delTLSALPN01 handles an HTTP POST request to delete an existing TLS-ALPN-01
+// challenge response for a given host.
+func (srv *managementServer) delTLSALPN01(w http.ResponseWriter, r *http.Request) {
+	// Read the request body
+	msg, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Unmarshal the request body JSON as a request object
+	var request struct {
+		Host string
+	}
+	err = json.Unmarshal(msg, &request)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// If the request has an empty host it's a bad request
+	if request.Host == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Delete the TLS-ALPN-01 challenge for the given host from the challenge server
+	srv.challSrv.DeleteTLSALPNChallenge(request.Host)
+	srv.log.Printf("Removed TLS-ALPN-01 challenge for host %q\n", request.Host)
+	w.WriteHeader(http.StatusOK)
+}

--- a/test/challtestsrv/tlsalpnone.go
+++ b/test/challtestsrv/tlsalpnone.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -60,8 +61,9 @@ func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientH
 			return nil, fmt.Errorf("failed marshalling hash OCTET STRING: %s", err)
 		}
 		certTmpl := x509.Certificate{
-			DNSNames: []string{hello.ServerName},
-			Extensions: []pkix.Extension{
+			SerialNumber: big.NewInt(1729),
+			DNSNames:     []string{hello.ServerName},
+			ExtraExtensions: []pkix.Extension{
 				{
 					Id:       va.IdPeAcmeIdentifierV1,
 					Critical: true,

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -92,7 +92,7 @@ def start(race_detection, fakeclock=None, account_uri=None):
         # The gsb-test-srv needs to be started before the VA or its intial DB
         # update will fail and all subsequent lookups will be invalid
         [6000, 'gsb-test-srv -apikey my-voice-is-my-passport'],
-        [8053, 'challtestsrv --dns01 :8053,:8054 --management :8055 --http01 ""'],
+        [8053, 'challtestsrv --dns01 :8053,:8054 --management :8055 --http01 "" --tlsalpn01 :5001'],
         [8004, 'boulder-va --config %s --addr va1.boulder:9092 --debug-addr :8004' % os.path.join(default_config_dir, "va.json")],
         [8104, 'boulder-va --config %s --addr va2.boulder:9092 --debug-addr :8104' % os.path.join(default_config_dir, "va.json")],
         [8001, 'boulder-ca --config %s --ca-addr ca1.boulder:9093 --ocsp-addr ca1.boulder:9096 --debug-addr :8001' % os.path.join(default_config_dir, "ca.json")],

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -41,6 +41,11 @@ def test_wildcardmultidomain():
 def test_http_challenge():
     chisel2.auth_and_issue([random_domain(), random_domain()], chall_type="http-01")
 
+def test_tls_alpn_challenge():
+    if not default_config_dir.startswith("test/config-next"):
+        return
+    chisel2.auth_and_issue([random_domain(), random_domain()], chall_type="tls-alpn-01")
+
 def test_overlapping_wildcard():
     """
     Test issuance for a random domain and a wildcard version of the same domain


### PR DESCRIPTION
Also in the process fix some errors I made in the original challtestsrv TLS-ALPN-01 implementation.

Fixes #3780.