### PR TITLE
Remove UseAIAIssuerURL feature flag and code.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedUseAIAIssuerURLReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURI"
+const _FeatureFlag_name = "unusedReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURI"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 21, 38, 60, 69, 88, 103, 124, 147, 158, 176, 185, 204, 215, 235, 262, 278, 298, 311}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 45, 54, 73, 88, 109, 132, 143, 161, 170, 189, 200, 220, 247, 263, 283, 296}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -11,7 +11,6 @@ type FeatureFlag int
 
 const (
 	unused FeatureFlag = iota // unused is used for testing
-	UseAIAIssuerURL
 	// For new-authz requests, if there is no valid authz, but there is a pending
 	// authz, return that instead of creating a new one.
 	ReusePendingAuthz
@@ -48,7 +47,6 @@ const (
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
 	unused:                      false,
-	UseAIAIssuerURL:             false,
 	ReusePendingAuthz:           false,
 	CountCertificatesExact:      false,
 	IPv6First:                   false, // deprecated

--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -31,8 +31,7 @@
       "timeout": "15s"
     },
     "features": {
-      "RPCHeadroom": true,
-      "UseAIAIssuerURL": true
+      "RPCHeadroom": true
     }
   },
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -185,9 +185,9 @@ def test_issuer():
     """
     certr, authzs = auth_and_issue([random_domain()])
     cert = urllib2.urlopen(certr.uri).read()
-    # The chain URI uses HTTPS when UseAIAIssuerURL is set, so include the root
-    # certificate for the WFE's PKI. Note: We use the requests library here so
-    # we honor the REQUESTS_CA_BUNDLE passed by test.sh.
+    # In the future the chain URI will use HTTPS so include the root certificate
+    # for the WFE's PKI. Note: We use the requests library here so we honor the
+    # REQUESTS_CA_BUNDLE passed by test.sh.
     chain = requests.get(certr.cert_chain_uri).content
     parsed_chain = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_ASN1, chain)
     parsed_cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_ASN1, cert)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -904,15 +904,8 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 
 	// TODO Content negotiation
 	response.Header().Add("Location", certURL)
-	if features.Enabled(features.UseAIAIssuerURL) {
-		if err = wfe.addIssuingCertificateURLs(response, parsedCertificate.IssuingCertificateURL); err != nil {
-			wfe.sendError(response, logEvent, probs.ServerInternal("unable to parse IssuingCertificateURL"), err)
-			return
-		}
-	} else {
-		relativeIssuerPath := web.RelativeEndpoint(request, issuerPath)
-		response.Header().Add("Link", link(relativeIssuerPath, "up"))
-	}
+	relativeIssuerPath := web.RelativeEndpoint(request, issuerPath)
+	response.Header().Add("Link", link(relativeIssuerPath, "up"))
 	response.Header().Set("Content-Type", "application/pkix-cert")
 	response.WriteHeader(http.StatusCreated)
 	if _, err = response.Write(cert.DER); err != nil {
@@ -1294,20 +1287,8 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 
 	// TODO Content negotiation
 	response.Header().Set("Content-Type", "application/pkix-cert")
-	if features.Enabled(features.UseAIAIssuerURL) {
-		parsedCertificate, err := x509.ParseCertificate([]byte(cert.DER))
-		if err != nil {
-			wfe.sendError(response, logEvent, probs.ServerInternal("Unable to parse certificate"), err)
-			return
-		}
-		if err = wfe.addIssuingCertificateURLs(response, parsedCertificate.IssuingCertificateURL); err != nil {
-			wfe.sendError(response, logEvent, probs.ServerInternal("unable to parse IssuingCertificateURL"), err)
-			return
-		}
-	} else {
-		relativeIssuerPath := web.RelativeEndpoint(request, issuerPath)
-		response.Header().Add("Link", link(relativeIssuerPath, "up"))
-	}
+	relativeIssuerPath := web.RelativeEndpoint(request, issuerPath)
+	response.Header().Add("Link", link(relativeIssuerPath, "up"))
 	response.WriteHeader(http.StatusOK)
 	if _, err = response.Write(cert.DER); err != nil {
 		wfe.log.Warningf("Could not write response: %s", err)


### PR DESCRIPTION
We aren't going to deploy this as-is and its causing integration test
problems for downstream clients.

Resolves https://github.com/letsencrypt/boulder/issues/3783