### PR TITLE
Add stagger to CT log submissions.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -309,4 +309,7 @@ type CAADistributedResolverConfig struct {
 type CTGroup struct {
 	Name string
 	Logs []LogDescription
+	// How long to wait for one log to accept a certificate before moving on to
+	// the next.
+	Stagger ConfigDuration
 }

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -56,6 +56,7 @@
     "CTLogGroups2": [
       {
         "name": "a",
+        "stagger": "500ms",
         "logs": [
           {
             "uri": "http://boulder:4500",
@@ -71,6 +72,7 @@
       },
       {
         "name": "b",
+        "stagger": "500ms",
         "logs": [
           {
             "uri": "http://boulder:4510",


### PR DESCRIPTION
This allows each log a chance to respond before we move onto the next,
spreading our load more evenly across the logs in a log group.