### PR TITLE
Revert "Temporarily allow fetching of expired authzs. #3778"

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -479,6 +479,25 @@ def test_certificates_per_name():
     chisel.expect_problem("urn:acme:error:rateLimited",
         lambda: auth_and_issue([random_domain() + ".lim.it"]))
 
+def test_expired_authzs_404():
+    # TODO(@4a6f656c): This test is rather broken, since it cannot distinguish
+    # between a 404 due to an expired authz and a 404 due to a non-existant authz.
+    # Further verification is necessary in order to ensure that the 404 is actually
+    # due to an expiration. For now, the new authzs at least provide a form of
+    # canary to detect authz purges.
+    if len(old_authzs) == 0 or len(new_authzs) == 0:
+        raise Exception("Old authzs not prepared for test_expired_authzs_404")
+    for a in new_authzs:
+        response = requests.get(a.uri)
+        if response.status_code != 200:
+            raise Exception("Unexpected response for valid authz: ",
+                response.status_code)
+    for a in old_authzs:
+        response = requests.get(a.uri)
+        if response.status_code != 404:
+            raise Exception("Unexpected response for expired authz: ",
+                response.status_code)
+
 def test_oversized_csr():
     # Number of names is chosen to be one greater than the configured RA/CA maxNames
     numNames = 101

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1237,6 +1237,12 @@ func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.Req
 	logEvent.Extra["Identifier"] = authz.Identifier
 	logEvent.Extra["AuthorizationStatus"] = authz.Status
 
+	// After expiring, authorizations are inaccessible
+	if authz.Expires == nil || authz.Expires.Before(wfe.clk.Now()) {
+		wfe.sendError(response, logEvent, probs.NotFound("Expired authorization"), nil)
+		return
+	}
+
 	if wfe.AllowAuthzDeactivation && request.Method == "POST" {
 		// If the deactivation fails return early as errors and return codes
 		// have already been set. Otherwise continue so that the user gets

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1728,7 +1728,9 @@ func TestAuthorization(t *testing.T) {
 		Method: "GET",
 		URL:    mustParseURL(authzURL),
 	})
-	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
+	test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
+	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
+		`{"type":"`+probs.V1ErrorNS+`malformed","detail":"Expired authorization","status":404}`)
 	responseWriter.Body.Reset()
 
 	// Ensure that a valid authorization can't be reached with an invalid URL


### PR DESCRIPTION
This reverts commit fa8814baabab51a8aebc29da6e709228c9a0b5f5.

Resolves https://github.com/letsencrypt/boulder/issues/3781