### PR TITLE
Rework CAA value parameter parsing to match RFC 6644bis draft.

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -317,23 +317,53 @@ func checkAccountURI(accountURI string, accountURIPrefixes []string, accountID i
 	return false
 }
 
-// Given a CAA record, assume that the Value is in the issue/issuewild format,
-// that is, a domain name with zero or more additional key-value parameters.
-// Returns the domain name, which may be "" (unsatisfiable), and a tag-value map of parameters.
+// extractIssuerDomainAndParameters extracts the domain and parameters (if any)
+// from a issue/issuewild CAA record. This follows sections 5.2 and 5.3 of the
+// RFC 6844bis draft (https://tools.ietf.org/html/draft-ietf-lamps-rfc6844bis-00),
+// where all components are semi-colon separated. The domain name (which may be
+// an empty string in the unsatisfiable case) and a tag-value map of parameters
+// are returned.
 func extractIssuerDomainAndParameters(caa *dns.CAA) (domain string, parameters map[string]string) {
 	isIssueSpace := func(r rune) bool {
 		return r == '\t' || r == ' '
 	}
 
-	v := strings.SplitN(caa.Value, ";", 2)
-	domain = strings.TrimFunc(v[0], isIssueSpace)
-	parameters = make(map[string]string)
+	// Semi-colons (ASCII 0x3B) are prohibited from being specified in the
+	// parameter tag or value, hence we can simply split on semi-colons.
+	parts := strings.Split(caa.Value, ";")
+	domain = strings.TrimFunc(parts[0], isIssueSpace)
 
-	if len(v) == 2 {
-		for _, s := range strings.FieldsFunc(v[1], isIssueSpace) {
-			if kv := strings.SplitN(s, "=", 2); len(kv) == 2 {
-				parameters[kv[0]] = kv[1]
+	parameters = make(map[string]string)
+	for _, parameter := range parts[1:] {
+		valid := true
+
+		// A parameter tag cannot include equal signs (ASCII 0x3D),
+		// however they are permitted in the value.
+		tv := strings.SplitN(parameter, "=", 2)
+		if len(tv) != 2 {
+			// TODO(4a6f656c): Should we be silently ignoring incorrectly
+			// formatted parameters?
+			continue
+		}
+
+		tag := strings.TrimFunc(tv[0], isIssueSpace)
+		for _, r := range []rune(tag) {
+			// ASCII alpha/digits.
+			if r < 0x30 || r > 0x39 && r < 0x41 || r > 0x5a && r < 0x61 || r > 0x7a {
+				valid = false
 			}
+		}
+
+		value := strings.TrimFunc(tv[1], isIssueSpace)
+		for _, r := range []rune(value) {
+			// ASCII without whitespace/semi-colons.
+			if r < 0x21 || r > 0x3a && r < 0x3c || r > 0x7e {
+				valid = false
+			}
+		}
+
+		if valid {
+			parameters[tag] = value
 		}
 	}
 

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -814,16 +814,18 @@ func TestExtractIssuerDomainAndParameters(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		caa := &dns.CAA{Value: test.value}
-		gotDomain, gotParameters, gotValid := extractIssuerDomainAndParameters(caa)
-		if got, want := gotValid, test.wantValid; got != want {
-			t.Errorf("CAA value %q - got valid %v, want %v", test.value, got, want)
-		}
-		if got, want := gotDomain, test.wantDomain; got != want {
-			t.Errorf("CAA value %q - got domain %q, want %q", test.value, got, want)
-		}
-		if got, want := gotParameters, test.wantParameters; !reflect.DeepEqual(got, want) {
-			t.Errorf("CAA value %q - got parameters %v, want %v", test.value, got, want)
-		}
+		t.Run("", func(t *testing.T) {
+			caa := &dns.CAA{Value: test.value}
+			gotDomain, gotParameters, gotValid := extractIssuerDomainAndParameters(caa)
+			if got, want := gotValid, test.wantValid; got != want {
+				t.Errorf("CAA value %q - got valid %v, want %v", test.value, got, want)
+			}
+			if got, want := gotDomain, test.wantDomain; got != want {
+				t.Errorf("CAA value %q - got domain %q, want %q", test.value, got, want)
+			}
+			if got, want := gotParameters, test.wantParameters; !reflect.DeepEqual(got, want) {
+				t.Errorf("CAA value %q - got parameters %v, want %v", test.value, got, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This switches from whitespace to semi-colon separated tag/value parameters,
while implementing stricter checks on valid tag and value values (to match
the RFC). Test coverage is added for CAA value parameter parsing, along with
some additional tests for CAA records with multiple parameter values.

Fixes issue #3795.