### PR TITLE
WFE2: Implement draft-13 keyrollover with feature flag.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURI"
+const _FeatureFlag_name = "unusedReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRollover"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 45, 54, 73, 88, 109, 132, 143, 161, 170, 189, 200, 220, 247, 263, 283, 296}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 45, 54, 73, 88, 109, 132, 143, 161, 170, 189, 200, 220, 247, 263, 283, 296, 313}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -42,6 +42,8 @@ const (
 	CAAValidationMethods
 	// Check CAA and respect accounturi parameter.
 	CAAAccountURI
+	// Honour draft-ietf-acme-13's keyrollover
+	ACME13KeyRollover
 )
 
 // List of features and their default value, protected by fMu
@@ -64,6 +66,7 @@ var features = map[FeatureFlag]bool{
 	OrderReadyStatus:            false,
 	CAAValidationMethods:        false,
 	CAAAccountURI:               false,
+	ACME13KeyRollover:           false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -37,7 +37,8 @@
     },
     "features": {
       "EnforceV2ContentType": true,
-      "RPCHeadroom": true
+      "RPCHeadroom": true,
+      "ACME13KeyRollover": true
     }
   },
 


### PR DESCRIPTION
ACME draft-13 changed the inner JWS' body to contain the old key
that signed the outer JWS. Because this is a backwards incompatible
change with the draft-12 ACME v2 key rollover we introduce a new feature
flag `features.ACME13KeyRollover` and conditionally use the old or new
key rollover semantics based on its value.

Resolves https://github.com/letsencrypt/boulder/issues/3798