### PR TITLE
Update publicsuffix-go to cbbcd04

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -259,8 +259,8 @@
 		},
 		{
 			"ImportPath": "github.com/weppos/publicsuffix-go/publicsuffix",
-			"Comment": "v0.4.0-17-gb8c0530",
-			"Rev": "b8c0530c1a2815258b75b8a6da052e7789ab9b99"
+			"Comment": "v0.4.0-20-gcbbcd04",
+			"Rev": "cbbcd048f995c801105a0083cb157c4fec9ea89c"
 		},
 		{
 			"ImportPath": "github.com/zmap/zcrypto/json",

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -104,7 +104,7 @@ func TestWillingToIssue(t *testing.T) {
 
 	shouldBeTLDError := []string{
 		`co.uk`,
-		`foo.bn`,
+		`foo.bd`,
 	}
 
 	shouldBeBlacklisted := []string{

--- a/vendor/github.com/weppos/publicsuffix-go/publicsuffix/publicsuffix.go
+++ b/vendor/github.com/weppos/publicsuffix-go/publicsuffix/publicsuffix.go
@@ -1,3 +1,5 @@
+//go:generate go run ../cmd/gen/gen.go
+
 // Package publicsuffix provides a domain name parser
 // based on data from the public suffix list http://publicsuffix.org/.
 // A public suffix is one under which Internet users can directly register names.

--- a/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
+++ b/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
@@ -3,10 +3,10 @@
 
 package publicsuffix
 
-const defaultListVersion = "PSL version 267707 (Thu Jul 19 16:32:46 2018)"
+const defaultListVersion = "PSL version f8ccab (Wed Aug  8 09:06:53 2018)"
 
 func init() {
-	r := [8615]Rule{
+	r := [8618]Rule{
 		{1, "ac", 1, false},
 		{1, "com.ac", 2, false},
 		{1, "edu.ac", 2, false},
@@ -302,7 +302,12 @@ func init() {
 		{1, "gov.bm", 2, false},
 		{1, "net.bm", 2, false},
 		{1, "org.bm", 2, false},
-		{2, "bn", 2, false},
+		{1, "bn", 1, false},
+		{1, "com.bn", 2, false},
+		{1, "edu.bn", 2, false},
+		{1, "gov.bn", 2, false},
+		{1, "net.bn", 2, false},
+		{1, "org.bn", 2, false},
 		{1, "bo", 1, false},
 		{1, "com.bo", 2, false},
 		{1, "edu.bo", 2, false},
@@ -7321,7 +7326,6 @@ func init() {
 		{1, "xn--w4rs40l", 1, false},
 		{1, "xn--xhq521b", 1, false},
 		{1, "xn--zfr164b", 1, false},
-		{1, "xperia", 1, false},
 		{1, "xyz", 1, false},
 		{1, "yachts", 1, false},
 		{1, "yahoo", 1, false},
@@ -8516,7 +8520,6 @@ func init() {
 		{2, "stolos.io", 3, true},
 		{1, "spacekit.io", 2, true},
 		{1, "customer.speedpartner.de", 3, true},
-		{1, "stackspace.space", 2, true},
 		{1, "storj.farm", 2, true},
 		{1, "utwente.io", 2, true},
 		{1, "temp-dns.com", 2, true},


### PR DESCRIPTION
The previous update was just [9 days ago](https://github.com/letsencrypt/boulder/pull/3808). However, since we merged some changes into the PSL that are related to IANA TLDs I though about providing an immediate patch.

Tests are passing:

```
➜  ~ cd ~/go/src/github.com/weppos/publicsuffix-go
➜  publicsuffix-go git:(master) GOCACHE=off  go test ./...
?   	github.com/weppos/publicsuffix-go/cmd/load	[no test files]
ok  	github.com/weppos/publicsuffix-go/net/publicsuffix	0.021s
ok  	github.com/weppos/publicsuffix-go/publicsuffix	0.034s
```