### PR TITLE
WFE2: Add unit tests for draft-12/draft-13 intercompat.

### DIFF
--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2128,6 +2128,22 @@ func TestKeyRollover(t *testing.T) {
 			NewKey: newKeyPriv,
 		},
 		{
+			Name:    "Valid key rollover request, added ACME13KeyRollover compat",
+			Payload: `{"newKey":` + string(newJWKJSON) + `, "oldKey":` + test1KeyPublicJSON + `, "account":"http://localhost/acme/acct/1"}`,
+			ExpectedResponse: `{
+		     "id": 1,
+		     "key": ` + string(newJWKJSON) + `,
+		     "contact": [
+		       "mailto:person@mail.com"
+		     ],
+		     "agreement": "http://example.invalid/terms",
+		     "initialIp": "",
+		     "createdAt": "0001-01-01T00:00:00Z",
+		     "status": "valid"
+		   }`,
+			NewKey: newKeyPriv,
+		},
+		{
 			Name:              "ACME13KeyRollover, legacy rollover request",
 			ACME13KeyRollover: true,
 			Payload:           `{"newKey":` + string(newJWKJSON) + `,"account":"http://localhost/acme/acct/1"}`,
@@ -2178,6 +2194,23 @@ func TestKeyRollover(t *testing.T) {
 			Name:              "ACME13KeyRollover, Valid key rollover request",
 			ACME13KeyRollover: true,
 			Payload:           `{"oldKey":` + test1KeyPublicJSON + `,"account":"http://localhost/acme/acct/1"}`,
+			ExpectedResponse: `{
+		     "id": 1,
+		     "key": ` + string(newJWKJSON) + `,
+		     "contact": [
+		       "mailto:person@mail.com"
+		     ],
+		     "agreement": "http://example.invalid/terms",
+		     "initialIp": "",
+		     "createdAt": "0001-01-01T00:00:00Z",
+		     "status": "valid"
+		   }`,
+			NewKey: newKeyPriv,
+		},
+		{
+			Name:              "ACME13KeyRollover, Valid key rollover request, legacy compat",
+			ACME13KeyRollover: true,
+			Payload:           `{"oldKey":` + test1KeyPublicJSON + `, "newKey":` + string(newJWKJSON) + `, "account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
 		     "id": 1,
 		     "key": ` + string(newJWKJSON) + `,


### PR DESCRIPTION
The implementation of the `features.ACME13KeyRollover` flag was written
with the intent to allow client developers to send both the `"newKey"`
and `"oldKey"` and be interoperable between both feature flag states.  We
ignore the `"oldKey"` in the legacy case and ignore `"newKey"` in the 
draft-13. We should have an explicit unit test for this to be sure it works as
intended and I missed that in my initial PR :blush: 