### PR TITLE
Implement alreadyRevoked error type for WFE2

### DIFF
--- a/probs/probs.go
+++ b/probs/probs.go
@@ -20,6 +20,7 @@ const (
 	AccountDoesNotExistProblem = ProblemType("accountDoesNotExist")
 	CAAProblem                 = ProblemType("caa")
 	DNSProblem                 = ProblemType("dns")
+	AlreadyRevokedProblem      = ProblemType("alreadyRevoked")
 
 	V1ErrorNS = "urn:acme:error:"
 	V2ErrorNS = "urn:ietf:params:acme:error:"
@@ -104,6 +105,16 @@ func Conflict(detail string, a ...interface{}) *ProblemDetails {
 		Type:       MalformedProblem,
 		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusConflict,
+	}
+}
+
+// AlreadyRevoked returns a ProblemDetails with a AlreadyRevokedProblem and a 400 Bad
+// Request status code.
+func AlreadyRevoked(detail string, a ...interface{}) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       AlreadyRevokedProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusBadRequest,
 	}
 }
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -634,7 +634,7 @@ func (wfe *WebFrontEndImpl) processRevocation(
 	logEvent.Extra["CertificateStatus"] = certStatus.Status
 
 	if certStatus.Status == core.OCSPStatusRevoked {
-		return probs.Conflict("Certificate already revoked")
+		return probs.AlreadyRevoked("Certificate already revoked")
 	}
 
 	// Validate that the requester is authenticated to revoke the given certificate

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2513,9 +2513,9 @@ func TestRevokeCertificateAlreadyRevoked(t *testing.T) {
 	wfe.RevokeCertificate(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath("revoke-cert", jwsBody))
 
-	test.AssertEquals(t, responseWriter.Code, 409)
+	test.AssertEquals(t, responseWriter.Code, 400)
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`malformed","detail":"Certificate already revoked","status":409}`)
+		`{"type":"`+probs.V2ErrorNS+`alreadyRevoked","detail":"Certificate already revoked","status":400}`)
 }
 
 func TestRevokeCertificateWithAuthz(t *testing.T) {


### PR DESCRIPTION
Implements support for draft-14's [alreadyRevoked](https://tools.ietf.org/html/draft-ietf-acme-acme-14#page-15) error. Fixes #3820.