### PR TITLE
ocsp-responder: check reqSerialPrefixes correctly.

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -81,7 +81,9 @@ func (src *DBSource) Response(req *ocsp.Request) ([]byte, http.Header, error) {
 	if len(src.reqSerialPrefixes) > 0 {
 		match := false
 		for _, prefix := range src.reqSerialPrefixes {
-			match = strings.HasPrefix(serialString, prefix)
+			if match = strings.HasPrefix(serialString, prefix); match {
+				break
+			}
 		}
 		if !match {
 			return nil, nil, cfocsp.ErrNotFound

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -165,7 +165,7 @@ func TestRequiredSerialPrefix(t *testing.T) {
 
 	fmt.Println(core.SerialToString(ocspReq.SerialNumber))
 
-	src, err = makeDBSource(mockSelector{}, "./testdata/test-ca.der.pem", []string{"00"}, mockLog)
+	src, err = makeDBSource(mockSelector{}, "./testdata/test-ca.der.pem", []string{"00", "nope"}, mockLog)
 	test.AssertNotError(t, err, "failed to create DBSource")
 	_, _, err = src.Response(ocspReq)
 	test.AssertNotError(t, err, "src.Response failed with acceptable prefix")


### PR DESCRIPTION
A match of an OCSP request's serial number to *any* of the configured `reqSerialPrefixes` entries is sufficient for the request to be valid, not just the last `reqSerialPrefixes` entry.

Resolves https://github.com/letsencrypt/boulder/issues/3829