### PR TITLE
SA: statusForOrder shouldn't fetch authzs for expired orders.

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2790,7 +2790,7 @@ func TestFinalizeOrder(t *testing.T) {
 
 	// Create a new order referencing both of the above finalized authzs
 	pendingStatus := "pending"
-	expUnix := exp.Unix()
+	expUnix := exp.UnixNano()
 	finalOrder, err := sa.NewOrder(context.Background(), &corepb.Order{
 		RegistrationID: &Registration.ID,
 		Expires:        &expUnix,
@@ -3037,7 +3037,7 @@ func TestFinalizeOrderWithMixedSANAndCN(t *testing.T) {
 	test.AssertNotError(t, err, "Could not finalize 2nd test pending authorization")
 
 	// Create a new order to finalize with names in SAN and CN
-	expUnix := exp.Unix()
+	expUnix := exp.UnixNano()
 	pendingStatus := "pending"
 	mixedOrder, err := sa.NewOrder(context.Background(), &corepb.Order{
 		RegistrationID: &Registration.ID,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1632,6 +1632,18 @@ func (ssa *SQLStorageAuthority) statusForOrder(ctx context.Context, order *corep
 		return string(core.StatusInvalid), nil
 	}
 
+	// If the order is expired the status is invalid and we don't need to get
+	// order authorizations. Its important to exit early in this case because an
+	// order that references an expired authorization will be itself have been
+	// expired (because we match the order expiry to the associated authz expiries
+	// in ra.NewOrder), and expired authorizations may be purged from the DB.
+	// Because of this purging fetching the authz's for an expired order may
+	// return less authz objects than expected, triggering a 500 error response.
+	orderExpiry := time.Unix(0, *order.Expires)
+	if orderExpiry.Before(ssa.clk.Now()) {
+		return string(core.StatusInvalid), nil
+	}
+
 	// Get the full Authorization objects for the order
 	authzs, err := ssa.getAllOrderAuthorizations(ctx, *order.Id, *order.RegistrationID)
 	// If there was an error getting the authorizations, return it immediately

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1638,7 +1638,7 @@ func (ssa *SQLStorageAuthority) statusForOrder(ctx context.Context, order *corep
 	// expired (because we match the order expiry to the associated authz expiries
 	// in ra.NewOrder), and expired authorizations may be purged from the DB.
 	// Because of this purging fetching the authz's for an expired order may
-	// return less authz objects than expected, triggering a 500 error response.
+	// return fewer authz objects than expected, triggering a 500 error response.
 	orderExpiry := time.Unix(0, *order.Expires)
 	if orderExpiry.Before(ssa.clk.Now()) {
 		return string(core.StatusInvalid), nil

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1325,10 +1325,10 @@ func TestSetOrderProcessing(t *testing.T) {
 	err = sa.FinalizeAuthorization(ctx, authz)
 	test.AssertNotError(t, err, "Couldn't finalize pending authz to valid")
 
-	i := int64(1337)
+	orderExpiry := sa.clk.Now().Add(365 * 24 * time.Hour).UnixNano()
 	order := &corepb.Order{
 		RegistrationID: &reg.ID,
-		Expires:        &i,
+		Expires:        &orderExpiry,
 		Names:          []string{"example.com"},
 		Authorizations: []string{authz.ID},
 	}
@@ -1378,10 +1378,10 @@ func TestFinalizeOrder(t *testing.T) {
 	err = sa.FinalizeAuthorization(ctx, authz)
 	test.AssertNotError(t, err, "Couldn't finalize pending authorization")
 
-	i := int64(1337)
+	orderExpiry := sa.clk.Now().Add(365 * 24 * time.Hour).UnixNano()
 	order := &corepb.Order{
 		RegistrationID: &reg.ID,
-		Expires:        &i,
+		Expires:        &orderExpiry,
 		Names:          []string{"example.com"},
 		Authorizations: []string{authz.ID},
 	}


### PR DESCRIPTION
If an order is expired the status is invalid and we don't need to get any of the order's authorizations. Its important to exit early in this case because expired authorizations may be purged from the DB. Fetching the authz's for an expired order may return less authz objects than expected, triggering a 500 error response.

Resolves https://github.com/letsencrypt/boulder/issues/3839