### PR TITLE
Filter invalid UTF-8 from error responses.

### DIFF
--- a/va/utf8filter.go
+++ b/va/utf8filter.go
@@ -1,13 +1,16 @@
 package va
 
+import "strings"
+
 // replaceInvalidUTF8 replaces all invalid UTF-8 encodings with
 // Unicode REPLACEMENT CHARACTER.
 func replaceInvalidUTF8(input []byte) string {
-	var ret string
+	var b strings.Builder
+
 	// Ranging over a string in Go produces runes. When the range keyword
 	// encounters an invalid UTF-8 encoding, it returns REPLACEMENT CHARACTER.
 	for _, v := range string(input) {
-		ret = ret + string(v)
+		b.WriteRune(v)
 	}
-	return ret
+	return b.String()
 }

--- a/va/utf8filter.go
+++ b/va/utf8filter.go
@@ -1,0 +1,13 @@
+package va
+
+// replaceInvalidUTF8 replaces all invalid UTF-8 encodings with
+// Unicode REPLACEMENT CHARACTER.
+func replaceInvalidUTF8(input []byte) string {
+	var ret string
+	// Ranging over a string in Go produces runes. When the range keyword
+	// encounters an invalid UTF-8 encoding, it returns REPLACEMENT CHARACTER.
+	for _, v := range string(input) {
+		ret = ret + string(v)
+	}
+	return ret
+}

--- a/va/utf8filter_test.go
+++ b/va/utf8filter_test.go
@@ -1,0 +1,12 @@
+package va
+
+import "testing"
+
+func TestReplaceInvalidUTF8(t *testing.T) {
+	input := "f\xffoo"
+	expected := "f\ufffdoo"
+	result := replaceInvalidUTF8([]byte(input))
+	if result != expected {
+		t.Errorf("replaceInvalidUTF8(%q): got %q, expected %q", input, result, expected)
+	}
+}


### PR DESCRIPTION
For HTTP-01 challenges that return incorrect responses, the
VA tries to put the first little bit of the HTTP response in the problem
detail.

However, VA needs to be able to serialize the problem detail as a
protobuf to send it to the RA, and protobufs require string types to be
UTF-8. Filter out any invalid UTF-8 sequences and replace them with
REPLACEMENT CHARACTER.

Fixes #3838 (probably)