### PR TITLE
RA: Remove email DNS validations.

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -330,6 +330,8 @@ func TestValidateContacts(t *testing.T) {
 	otherValidEmail := "mailto:other-admin@email.com"
 	malformedEmail := "mailto:admin.com"
 	nonASCII := "mailto:señor@email.com"
+	unparseable := "mailto:a@email.com, b@email.com"
+	forbidden := "mailto:a@example.org"
 
 	err := ra.validateContacts(context.Background(), &[]string{})
 	test.AssertNotError(t, err, "No Contacts")
@@ -351,49 +353,12 @@ func TestValidateContacts(t *testing.T) {
 
 	err = ra.validateContacts(context.Background(), &[]string{nonASCII})
 	test.AssertError(t, err, "Non ASCII email")
-}
 
-func TestValidateEmail(t *testing.T) {
-	testFailures := []struct {
-		input    string
-		expected string
-	}{
-		{"an email`", unparseableEmailError.Error()},
-		{"a@always.invalid", emptyDNSResponseError.Error()},
-		{"a@email.com, b@email.com", unparseableEmailError.Error()},
-		{"a@always.error", "DNS problem: networking error looking up A for always.error"},
-		{"a@example.com", "invalid contact domain. Contact emails @example.com are forbidden"},
-		{"a@example.net", "invalid contact domain. Contact emails @example.net are forbidden"},
-		{"a@example.org", "invalid contact domain. Contact emails @example.org are forbidden"},
-	}
+	err = ra.validateContacts(context.Background(), &[]string{unparseable})
+	test.AssertError(t, err, "Unparseable email")
 
-	testSuccesses := []string{
-		"a@email.com",
-		"b@email.only",
-		// A timeout during email validation is treated as a success. We treat email
-		// validation during registration as a best-effort. See
-		// https://github.com/letsencrypt/boulder/issues/2260 for more
-		"a@always.timeout",
-	}
-
-	for _, tc := range testFailures {
-		err := validateEmail(context.Background(), tc.input, &bdns.MockDNSClient{})
-		if !berrors.Is(err, berrors.InvalidEmail) {
-			t.Errorf("validateEmail(%q): got error %#v, expected type berrors.InvalidEmail", tc.input, err)
-		}
-
-		if err.Error() != tc.expected {
-			t.Errorf("validateEmail(%q): got %#v, expected %#v",
-				tc.input, err.Error(), tc.expected)
-		}
-	}
-
-	for _, addr := range testSuccesses {
-		if err := validateEmail(context.Background(), addr, &bdns.MockDNSClient{}); err != nil {
-			t.Errorf("validateEmail(%q): expected success, but it failed: %#v",
-				addr, err)
-		}
-	}
+	err = ra.validateContacts(context.Background(), &[]string{forbidden})
+	test.AssertError(t, err, "Forbidden email")
 }
 
 func TestNewRegistration(t *testing.T) {

--- a/test/challtestsrv/dnsone.go
+++ b/test/challtestsrv/dnsone.go
@@ -64,18 +64,6 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 			record.A = net.ParseIP(fakeDNS)
 
 			m.Answer = append(m.Answer, record)
-		case dns.TypeMX:
-			record := new(dns.MX)
-			record.Hdr = dns.RR_Header{
-				Name:   q.Name,
-				Rrtype: dns.TypeMX,
-				Class:  dns.ClassINET,
-				Ttl:    0,
-			}
-			record.Mx = "mail." + q.Name
-			record.Preference = 10
-
-			m.Answer = append(m.Answer, record)
 		case dns.TypeTXT:
 			values := s.GetDNSOneChallenge(q.Name)
 			if values == nil {


### PR DESCRIPTION
Performing DNS lookups to check the A/AAAA/MX records of a provided contact e-mail address adds variability to the RA's NewRegistration/UpdateRegistration functions and requires that the RA be able to reach out to the EFN. Since this is simply a convenience to prevent some classes of registration errors we can remove it to improve performance and to tighten up our security posture slightly.

Resolves https://github.com/letsencrypt/boulder/issues/3849