### PR TITLE
RA: Remove vestigial DNS config/setup.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -18,7 +18,6 @@ import (
 	"github.com/weppos/publicsuffix-go/publicsuffix"
 	"golang.org/x/net/context"
 
-	"github.com/letsencrypt/boulder/bdns"
 	caPB "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
@@ -68,7 +67,6 @@ type RegistrationAuthorityImpl struct {
 	caa       caaChecker
 
 	stats     metrics.Scope
-	DNSClient bdns.DNSClient
 	clk       clock.Clock
 	log       blog.Logger
 	keyPolicy goodkey.KeyPolicy

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/bdns"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -288,7 +288,6 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 	ra.VA = va
 	ra.CA = ca
 	ra.PA = pa
-	ra.DNSClient = &bdns.MockDNSClient{}
 
 	AuthzInitial.RegistrationID = Registration.ID
 
@@ -3517,7 +3516,6 @@ func TestCTPolicyMeasurements(t *testing.T) {
 	ra.VA = va
 	ra.CA = ca
 	ra.PA = pa
-	ra.DNSClient = &bdns.MockDNSClient{}
 
 	AuthzFinal.RegistrationID = Registration.ID
 	AuthzFinal, err := ssa.NewPendingAuthorization(ctx, AuthzFinal)

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -3,11 +3,6 @@
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 100000,
     "maxContactsPerRegistration": 100,
-    "dnsTries": 3,
-    "dnsResolvers": [
-      "127.0.0.1:8053",
-      "127.0.0.1:8054"
-    ],
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 100,


### PR DESCRIPTION
In db01b0b we removed email validation from the RA. This was the only use of the `bdns` package by the RA and so we can go one step further and delete the remaining setup, configuration and `bdns` fields.

Resolves #3849 