### PR TITLE
Daemonize expired-authz-purger while maintaining current functionality

### DIFF
--- a/cmd/expired-authz-purger/main.go
+++ b/cmd/expired-authz-purger/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jmhodges/clock"
@@ -42,6 +43,33 @@ type expiredAuthzPurger struct {
 	batchSize int64
 }
 
+func (p *expiredAuthzPurger) getWork(work chan string, query string, initialID string, purgeBefore time.Time, batchSize int64) (string, int, error) {
+	var idBatch []string
+	_, err := p.db.Select(
+		&idBatch,
+		query,
+		map[string]interface{}{
+			"id":      initialID,
+			"expires": purgeBefore,
+			"limit":   batchSize,
+		},
+	)
+	if err != nil && err != sql.ErrNoRows {
+		return "", 0, fmt.Errorf("Getting a batch: %s", err)
+	}
+	if len(idBatch) == 0 {
+		return initialID, 0, nil
+	}
+	var count int
+	var lastID string
+	for _, v := range idBatch {
+		work <- v
+		count += 1
+		lastID = v
+	}
+	return lastID, count, nil
+}
+
 // purge looks up pending or finalized authzs (depending on the value of
 // `table`) that expire before `purgeBefore`, using `parallelism`
 // goroutines. It will delete a maximum of `max` authzs.
@@ -51,7 +79,7 @@ type expiredAuthzPurger struct {
 // database will have to scan through many rows before it finds some that meet
 // the expiration criteria. When we move to better authz storage (#2620), we
 // will get an appropriate index that will make this cheaper.
-func (p *expiredAuthzPurger) purge(table string, purgeBefore time.Time, parallelism int, max int) error {
+func (p *expiredAuthzPurger) purge(table string, purgeBefore time.Time, parallelism int, max int, daemon bool) error {
 	var query string
 	switch table {
 	case "pendingAuthorizations":
@@ -60,44 +88,38 @@ func (p *expiredAuthzPurger) purge(table string, purgeBefore time.Time, parallel
 		query = "SELECT id FROM authz WHERE id >= :id AND expires <= :expires ORDER BY id LIMIT :limit"
 	}
 
-	done := make(chan int)
 	work := make(chan string)
 	go func() {
 		// id starts as "", which is smaller than all other ids.
 		var id string
 		var count int
-		for count < max {
-			var idBatch []string
-			_, err := p.db.Select(
-				&idBatch,
-				query,
-				map[string]interface{}{
-					"id":      id,
-					"expires": purgeBefore,
-					"limit":   p.batchSize,
-				},
-			)
-			if err != nil && err != sql.ErrNoRows {
-				p.log.AuditErrf("Getting a batch: %s", err)
-				time.Sleep(10)
+
+		var working func() bool
+		if daemon {
+			working = func() bool { return true }
+		} else {
+			working = func() bool { return count < max }
+		}
+
+		for working() {
+			lastID, added, err := p.getWork(work, query, id, purgeBefore, p.batchSize)
+			if err != nil {
+				p.log.AuditErr(err.Error())
+				time.Sleep(time.Millisecond * 500)
 				continue
-			}
-			for _, v := range idBatch {
-				work <- v
-				count += 1
-				// Start the next query at the highest id we saw in this batch.
-				id = v
-			}
-			p.log.Infof("Deleted %d authzs from %s so far", count, table)
-			if len(idBatch) < int(p.batchSize) {
+			} else if daemon && lastID == id {
+				time.Sleep(time.Minute)
+			} else if !daemon && added < int(p.batchSize) {
 				break
 			}
+			count += added
+			id = lastID
 		}
 		close(work)
-		done <- count
 	}()
 
 	wg := new(sync.WaitGroup)
+	deleted := int64(0)
 	for i := 0; i < parallelism; i++ {
 		wg.Add(1)
 		go func() {
@@ -107,14 +129,13 @@ func (p *expiredAuthzPurger) purge(table string, purgeBefore time.Time, parallel
 				if err != nil {
 					p.log.AuditErrf("Deleting %s: %s", id, err)
 				}
+				atomic.AddInt64(&deleted, 1)
 			}
 		}()
 	}
 
-	count := <-done
 	wg.Wait()
-
-	p.log.Infof("Deleted a total of %d expired authorizations from %s", count, table)
+	p.log.Infof("Deleted a total of %d expired authorizations from %s", deleted, table)
 	return nil
 }
 
@@ -140,11 +161,11 @@ func deleteAuthorization(db *gorp.DbMap, table, id string) error {
 	return nil
 }
 
-func (p *expiredAuthzPurger) purgeAuthzs(purgeBefore time.Time, parallelism int, max int) error {
+func (p *expiredAuthzPurger) purgeAuthzs(purgeBefore time.Time, parallelism int, max int, daemon bool) error {
 	// Purge authz first because it tends to be bigger and in more need of
 	// purging.
 	for _, table := range []string{"authz", "pendingAuthorizations"} {
-		err := p.purge(table, purgeBefore, parallelism, max)
+		err := p.purge(table, purgeBefore, parallelism, max, daemon)
 		if err != nil {
 			return err
 		}
@@ -153,6 +174,7 @@ func (p *expiredAuthzPurger) purgeAuthzs(purgeBefore time.Time, parallelism int,
 }
 
 func main() {
+	daemon := flag.Bool("daemon", false, "Runs the expired-authz-purger in daemon mode")
 	configPath := flag.String("config", "config.json", "Path to Boulder configuration file")
 	flag.Parse()
 
@@ -198,6 +220,6 @@ func main() {
 	purgeBefore := purger.clk.Now().Add(-config.ExpiredAuthzPurger.GracePeriod.Duration)
 	logger.Info("Beginning purge")
 	err = purger.purgeAuthzs(purgeBefore, int(config.ExpiredAuthzPurger.Parallelism),
-		int(config.ExpiredAuthzPurger.MaxAuthzs))
+		int(config.ExpiredAuthzPurger.MaxAuthzs), *daemon)
 	cmd.FailOnError(err, "Failed to purge authorizations")
 }

--- a/cmd/expired-authz-purger/main_test.go
+++ b/cmd/expired-authz-purger/main_test.go
@@ -33,7 +33,7 @@ func TestPurgeAuthzs(t *testing.T) {
 
 	p := expiredAuthzPurger{log, fc, dbMap, 1}
 
-	err = p.purgeAuthzs(time.Time{}, 10, 100)
+	err = p.purgeAuthzs(time.Time{}, 10, 100, false)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 
 	old, new := fc.Now().Add(-time.Hour), fc.Now().Add(time.Hour)
@@ -58,7 +58,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "NewPendingAuthorization failed")
 
-	err = p.purgeAuthzs(fc.Now(), 10, 100)
+	err = p.purgeAuthzs(fc.Now(), 10, 100, false)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err := dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
@@ -67,7 +67,7 @@ func TestPurgeAuthzs(t *testing.T) {
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")
 	test.AssertEquals(t, count, int64(1))
 
-	err = p.purgeAuthzs(fc.Now().Add(time.Hour), 10, 100)
+	err = p.purgeAuthzs(fc.Now().Add(time.Hour), 10, 100, false)
 	test.AssertNotError(t, err, "purgeAuthzs failed")
 	count, err = dbMap.SelectInt("SELECT COUNT(1) FROM pendingAuthorizations")
 	test.AssertNotError(t, err, "dbMap.SelectInt failed")


### PR DESCRIPTION
Allows the expired-authz-purger to be run in a daemon mode, by passing the `-daemon` flag on start up while still allowing it to run as it does now for deployment purposes. Checkpointing the last ID seen between invocations of the binary is left for a follow-up change as I'd like to get the major structural changes looked at alone first.

Integrating this mode in our integration tests is a slightly complicated affair and I've held off on attempting it for now since we handle it slightly differently from our other services. Would be interested if anyone has strong opinions about how to go about this.

Updates #3840.