### PR TITLE
Use a boulder error type for duplicate error

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -37,7 +37,6 @@ import (
 	"github.com/letsencrypt/boulder/goodkey"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
-	"github.com/letsencrypt/boulder/sa"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -727,7 +726,7 @@ func (ca *CertificateAuthorityImpl) integrateOrphan() error {
 	}
 	issued := cert.NotBefore.Add(-ca.backdate)
 	_, err = ca.sa.AddCertificate(context.Background(), orphan.DER, orphan.RegID, orphan.OCSPResp, &issued)
-	if err != nil && err != sa.ErrDuplicate {
+	if err != nil && !berrors.Is(err, berrors.Duplicate) {
 		return fmt.Errorf("failed to store orphaned certificate: %s", err)
 	}
 	if _, err = ca.orphanQueue.Dequeue(); err != nil {

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -38,7 +38,6 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/policy"
-	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -954,7 +953,7 @@ func (qsa *queueSA) AddCertificate(_ context.Context, _ []byte, _ int64, _ []byt
 	if qsa.fail {
 		return "", errors.New("bad")
 	} else if qsa.duplicate {
-		return "", sa.ErrDuplicate
+		return "", berrors.DuplicateError("is a dupe")
 	}
 	qsa.issued = issued
 	return "", nil

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,6 +18,7 @@ const (
 	WrongAuthorizationState
 	CAA
 	MissingSCTs
+	Duplicate
 )
 
 // BoulderError represents internal Boulder errors
@@ -92,4 +93,8 @@ func CAAError(msg string, args ...interface{}) error {
 
 func MissingSCTsError(msg string, args ...interface{}) error {
 	return New(MissingSCTs, msg, args...)
+}
+
+func DuplicateError(msg string, args ...interface{}) error {
+	return New(Duplicate, msg, args...)
 }

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -28,8 +27,6 @@ import (
 	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
-
-var ErrDuplicate = errors.New("cannot add a duplicate row")
 
 type certCountFunc func(domain string, earliest, latest time.Time) (int, error)
 type getChallengesFunc func(authID string) ([]core.Challenge, error)
@@ -937,7 +934,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(
 	err = tx.Insert(cert)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "Error 1062: Duplicate entry") {
-			err = ErrDuplicate
+			err = berrors.DuplicateError("cannot add a duplicate cert")
 		}
 		return "", Rollback(tx, err)
 	}
@@ -945,7 +942,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(
 	err = tx.Insert(certStatus)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "Error 1062: Duplicate entry") {
-			err = ErrDuplicate
+			err = berrors.DuplicateError("cannot add a duplicate cert status")
 		}
 		return "", Rollback(tx, err)
 	}


### PR DESCRIPTION
Use a boulder error type to indicate duplicate rows instead of a normal untyped error (as gRPC mangles this type of error but understands how to properly handle a boulder error).