### PR TITLE
RA: Use t.Helper in assertAuthzEqual

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -310,6 +310,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 }
 
 func assertAuthzEqual(t *testing.T, a1, a2 core.Authorization) {
+	t.Helper()
 	test.Assert(t, a1.ID == a2.ID, "ret != DB: ID")
 	test.Assert(t, a1.Identifier == a2.Identifier, "ret != DB: Identifier")
 	test.Assert(t, a1.Status == a2.Status, "ret != DB: Status")


### PR DESCRIPTION
This ensures the `assertAuthzEqual` helper doesn't obscure the location of the test that failed.