### PR TITLE
Remove checks for deployed features

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -270,11 +270,7 @@ func (c *certChecker) checkCert(cert core.Certificate) (problems []string) {
 			id := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: name}
 			// TODO(https://github.com/letsencrypt/boulder/issues/3371): Distinguish
 			// between certificates issued by v1 and v2 API.
-			checkFunc := c.pa.WillingToIssue
-			if features.Enabled(features.WildcardDomains) {
-				checkFunc = c.pa.WillingToIssueWildcard
-			}
-			if err = checkFunc(id); err != nil {
+			if err = c.pa.WillingToIssueWildcard(id); err != nil {
 				problems = append(problems, fmt.Sprintf("Policy Authority isn't willing to issue for '%s': %s", name, err))
 			} else {
 				// For defense-in-depth, even if the PA was willing to issue for a name

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/policy"
@@ -85,9 +84,6 @@ func TestCheckWildcardCert(t *testing.T) {
 	defer func() {
 		saCleanup()
 	}()
-
-	_ = features.Set(map[string]bool{"WildcardDomains": true})
-	defer features.Reset()
 
 	testKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	fc := clock.NewFake()
@@ -172,8 +168,6 @@ func TestCheckCert(t *testing.T) {
 			longName,
 			"example-a.com",
 			"foodnotbombs.mil",
-			// `*.foodnotbombs.mil` should be flagged because the wildcard issuance feature is disabled
-			"*.foodnotbombs.mil",
 			// `dev-myqnapcloud.com` is included because it is an exact private
 			// entry on the public suffix list
 			"dev-myqnapcloud.com",
@@ -203,16 +197,15 @@ func TestCheckCert(t *testing.T) {
 	problems := checker.checkCert(cert)
 
 	problemsMap := map[string]int{
-		"Stored digest doesn't match certificate digest":                                                 1,
-		"Stored serial doesn't match certificate serial":                                                 1,
-		"Stored expiration doesn't match certificate NotAfter":                                           1,
-		"Certificate doesn't have basic constraints set":                                                 1,
-		"Certificate has a validity period longer than 2160h0m0s":                                        1,
-		"Stored issuance date is outside of 6 hour window of certificate NotBefore":                      1,
-		"Certificate has incorrect key usage extensions":                                                 1,
-		"Certificate has common name >64 characters long (65)":                                           1,
-		"Policy Authority isn't willing to issue for '*.foodnotbombs.mil': Wildcard names not supported": 1,
-		"Certificate contains an unexpected extension: 1.3.3.7":                                          1,
+		"Stored digest doesn't match certificate digest":                            1,
+		"Stored serial doesn't match certificate serial":                            1,
+		"Stored expiration doesn't match certificate NotAfter":                      1,
+		"Certificate doesn't have basic constraints set":                            1,
+		"Certificate has a validity period longer than 2160h0m0s":                   1,
+		"Stored issuance date is outside of 6 hour window of certificate NotBefore": 1,
+		"Certificate has incorrect key usage extensions":                            1,
+		"Certificate has common name >64 characters long (65)":                      1,
+		"Certificate contains an unexpected extension: 1.3.3.7":                     1,
 	}
 	for _, p := range problems {
 		_, ok := problemsMap[p]

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 )
 
@@ -81,14 +80,7 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 			Value: name,
 		}
 		var err error
-		// If wildcard names are enabled then use WillingToIssueWildcard
-		if features.Enabled(features.WildcardDomains) {
-			err = pa.WillingToIssueWildcard(ident)
-		} else {
-			// Otherwise use WillingToIssue
-			err = pa.WillingToIssue(ident)
-		}
-		if err != nil {
+		if err = pa.WillingToIssueWildcard(ident); err != nil {
 			badNames = append(badNames, fmt.Sprintf("%q", name))
 		}
 	}

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -28,13 +28,13 @@ func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier, registrationID i
 }
 
 func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
-	if id.Value == "bad-name.com" || id.Value == "other-bad-name.com" {
-		return errors.New("")
-	}
 	return nil
 }
 
 func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
+	if id.Value == "bad-name.com" || id.Value == "other-bad-name.com" {
+		return errors.New("")
+	}
 	return nil
 }
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBTLSSNIRevalidationEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeTLSSNIRevalidationEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 200, 220, 247, 263, 283, 296, 313, 324}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 202, 220, 247, 263, 283, 296, 313, 324}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsTLSSNIRevalidationOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 202, 229, 247, 263, 283, 296, 313, 324}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 202, 229, 245, 263, 283, 296, 313, 324}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 202, 229, 245, 263, 283, 296, 313, 324}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 120, 141, 152, 163, 183, 210, 226, 245, 263, 283, 296, 313, 324}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeTLSSNIRevalidationEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsTLSSNIRevalidationOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 202, 220, 247, 263, 283, 296, 313, 324}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 202, 229, 247, 263, 283, 296, 313, 324}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomTLSSNIRevalidationVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBTLSSNIRevalidationEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 189, 200, 220, 247, 263, 283, 296, 313, 324}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 182, 200, 220, 247, 263, 283, 296, 313, 324}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCountCertificatesExactIPv6FirstAllowRenewalFirstRLWildcardDomainsForceConsistentStatusEnforceChallengeDisableRPCHeadroomTLSSNIRevalidationEmbedSCTsCancelCTSubmissionsVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsAllowRenewalFirstRLWildcardDomainsForceConsistentStatusRPCHeadroomTLSSNIRevalidationVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 45, 54, 73, 88, 109, 132, 143, 161, 170, 189, 200, 220, 247, 263, 283, 296, 313, 324}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 124, 139, 160, 171, 189, 200, 220, 247, 263, 283, 296, 313, 324}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -18,7 +18,6 @@ const (
 	IPv6First
 	EnforceChallengeDisable
 	EmbedSCTs
-	AllowRenewalFirstRL
 	WildcardDomains
 	ForceConsistentStatus
 	RPCHeadroom
@@ -28,6 +27,7 @@ const (
 	OrderReadyStatus
 
 	//   Currently in-use features
+	AllowRenewalFirstRL
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
 	// Check CAA and respect validationmethods parameter.
@@ -45,14 +45,14 @@ var features = map[FeatureFlag]bool{
 	unused:                      false,
 	ReusePendingAuthz:           false,
 	CountCertificatesExact:      false,
-	IPv6First:                   false, // deprecated
+	IPv6First:                   false,
 	AllowRenewalFirstRL:         false,
 	WildcardDomains:             false,
-	EnforceChallengeDisable:     false, // deprecated
+	EnforceChallengeDisable:     false,
 	RPCHeadroom:                 false,
 	TLSSNIRevalidation:          false,
-	EmbedSCTs:                   false, // deprecated
-	CancelCTSubmissions:         true,  // deprecated
+	EmbedSCTs:                   false,
+	CancelCTSubmissions:         true,
 	VAChecksGSB:                 false,
 	EnforceV2ContentType:        false,
 	ForceConsistentStatus:       false,

--- a/features/features.go
+++ b/features/features.go
@@ -20,10 +20,9 @@ const (
 	EmbedSCTs               // can be deleted?
 	AllowRenewalFirstRL     // can be deleted?
 	WildcardDomains         // can be deleted?
+	ForceConsistentStatus   // can be deleted?
 
 	//   Currently in-use features
-	// Copy authz status to challenge status
-	ForceConsistentStatus
 	// Ensure there is headroom in RPC timeouts to return an error to the client
 	RPCHeadroom
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance

--- a/features/features.go
+++ b/features/features.go
@@ -25,12 +25,11 @@ const (
 	VAChecksGSB
 	EnforceV2ContentType
 	EnforceOverlappingWildcards
+	OrderReadyStatus
 
 	//   Currently in-use features
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
-	// Set orders to status "ready" when they are awaiting finalization
-	OrderReadyStatus
 	// Check CAA and respect validationmethods parameter.
 	CAAValidationMethods
 	// Check CAA and respect accounturi parameter.

--- a/features/features.go
+++ b/features/features.go
@@ -24,12 +24,11 @@ const (
 	RPCHeadroom
 	VAChecksGSB
 	EnforceV2ContentType
+	EnforceOverlappingWildcards
 
 	//   Currently in-use features
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
-	// Reject new-orders that contain a hostname redundant with a wildcard.
-	EnforceOverlappingWildcards
 	// Set orders to status "ready" when they are awaiting finalization
 	OrderReadyStatus
 	// Check CAA and respect validationmethods parameter.

--- a/features/features.go
+++ b/features/features.go
@@ -13,25 +13,21 @@ const (
 	unused FeatureFlag = iota // unused is used for testing
 	//   Deprecated features, these can be removed once stripped from production configs
 	ReusePendingAuthz
-	CancelCTSubmissions
+	CancelCTSubmissions     // can be deleted?
+	CountCertificatesExact  // can be deleted?
+	IPv6First               // can be deleted?
+	EnforceChallengeDisable // can be deleted?
+	EmbedSCTs               // can be deleted?
+	AllowRenewalFirstRL     // can be deleted?
+	WildcardDomains         // can be deleted?
 
 	//   Currently in-use features
-	// For new-authz requests, if there is no valid authz, but there is a pending
-	// authz, return that instead of creating a new one.
-	CountCertificatesExact
-	IPv6First
-	AllowRenewalFirstRL
-	// Allow issuance of wildcard domains for ACMEv2
-	WildcardDomains
 	// Copy authz status to challenge status
 	ForceConsistentStatus
-	// Enforce prevention of use of disabled challenge types
-	EnforceChallengeDisable
 	// Ensure there is headroom in RPC timeouts to return an error to the client
 	RPCHeadroom
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
-	EmbedSCTs
 	VAChecksGSB
 	// Return errors to ACMEv2 clients that do not send the correct JWS
 	// Content-Type header

--- a/features/features.go
+++ b/features/features.go
@@ -11,9 +11,13 @@ type FeatureFlag int
 
 const (
 	unused FeatureFlag = iota // unused is used for testing
+	//   Deprecated features, these can be removed once stripped from production configs
+	ReusePendingAuthz
+	CancelCTSubmissions
+
+	//   Currently in-use features
 	// For new-authz requests, if there is no valid authz, but there is a pending
 	// authz, return that instead of creating a new one.
-	ReusePendingAuthz
 	CountCertificatesExact
 	IPv6First
 	AllowRenewalFirstRL
@@ -28,8 +32,6 @@ const (
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
 	EmbedSCTs
-	// CancelCTSubmissions is deprecated
-	CancelCTSubmissions
 	VAChecksGSB
 	// Return errors to ACMEv2 clients that do not send the correct JWS
 	// Content-Type header

--- a/features/features.go
+++ b/features/features.go
@@ -22,11 +22,11 @@ const (
 	WildcardDomains
 	ForceConsistentStatus
 	RPCHeadroom
+	VAChecksGSB
 
 	//   Currently in-use features
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
-	VAChecksGSB
 	// Return errors to ACMEv2 clients that do not send the correct JWS
 	// Content-Type header
 	EnforceV2ContentType

--- a/features/features.go
+++ b/features/features.go
@@ -23,13 +23,11 @@ const (
 	ForceConsistentStatus
 	RPCHeadroom
 	VAChecksGSB
+	EnforceV2ContentType
 
 	//   Currently in-use features
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
-	// Return errors to ACMEv2 clients that do not send the correct JWS
-	// Content-Type header
-	EnforceV2ContentType
 	// Reject new-orders that contain a hostname redundant with a wildcard.
 	EnforceOverlappingWildcards
 	// Set orders to status "ready" when they are awaiting finalization

--- a/features/features.go
+++ b/features/features.go
@@ -13,18 +13,17 @@ const (
 	unused FeatureFlag = iota // unused is used for testing
 	//   Deprecated features, these can be removed once stripped from production configs
 	ReusePendingAuthz
-	CancelCTSubmissions     // can be deleted?
-	CountCertificatesExact  // can be deleted?
-	IPv6First               // can be deleted?
-	EnforceChallengeDisable // can be deleted?
-	EmbedSCTs               // can be deleted?
-	AllowRenewalFirstRL     // can be deleted?
-	WildcardDomains         // can be deleted?
-	ForceConsistentStatus   // can be deleted?
+	CancelCTSubmissions
+	CountCertificatesExact
+	IPv6First
+	EnforceChallengeDisable
+	EmbedSCTs
+	AllowRenewalFirstRL
+	WildcardDomains
+	ForceConsistentStatus
+	RPCHeadroom
 
 	//   Currently in-use features
-	// Ensure there is headroom in RPC timeouts to return an error to the client
-	RPCHeadroom
 	// Allow TLS-SNI in new-authz that are revalidating for previous issuance
 	TLSSNIRevalidation
 	VAChecksGSB

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/grpc/test_proto"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
@@ -124,8 +123,6 @@ func (s *testServer) Chill(ctx context.Context, in *test_proto.Time) (*test_prot
 }
 
 func TestTimeouts(t *testing.T) {
-	_ = features.Set(map[string]bool{"RPCHeadroom": true})
-	defer features.Reset()
 	// start server
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -364,7 +364,7 @@ func (sa *StorageAuthority) PreviousCertificateExists(
 }
 
 func (sa *StorageAuthority) GetPendingAuthorization(ctx context.Context, req *sapb.GetPendingAuthorizationRequest) (*core.Authorization, error) {
-	return nil, fmt.Errorf("GetPendingAuthorization not implemented")
+	return nil, berrors.NotFoundError("no pending authorization found")
 }
 
 // GetValidAuthorizations is a mock

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -364,7 +364,7 @@ func (sa *StorageAuthority) PreviousCertificateExists(
 }
 
 func (sa *StorageAuthority) GetPendingAuthorization(ctx context.Context, req *sapb.GetPendingAuthorizationRequest) (*core.Authorization, error) {
-	return nil, berrors.NotFoundError("no pending authorization found")
+	return nil, nil
 }
 
 // GetValidAuthorizations is a mock

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1707,10 +1707,8 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		}
 	}
 
-	if features.Enabled(features.EnforceOverlappingWildcards) {
-		if err := wildcardOverlap(order.Names); err != nil {
-			return nil, err
-		}
+	if err := wildcardOverlap(order.Names); err != nil {
+		return nil, err
 	}
 
 	// See if there is an existing, pending, unexpired order that can be reused
@@ -1834,7 +1832,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		// An authz without an expiry is an unexpected internal server event
 		if authz.Expires == nil {
 			return nil, berrors.InternalServerError(
-				"SA.GetAuthorizations returned an authz (%d) with nil expiry",
+				"SA.GetAuthorizations returned an authz (%s) with nil expiry",
 				*authz.Id)
 		}
 		// If the reused authorization expires before the minExpiry, it's expiry

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -833,8 +833,7 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 	// a pending status with valid authzs were finalizable. We accept both states
 	// here for deployability ease. In the future we will only allow ready orders
 	// to be finalized.
-	// TODO(@cpu): Forbid finalizing "Pending" orders once
-	// `features.Enabled(features.OrderReadyStatus)` is deployed
+	// TODO(@cpu): Forbid finalizing "Pending" orders
 	if *order.Status != string(core.StatusPending) &&
 		*order.Status != string(core.StatusReady) {
 		return nil, berrors.MalformedError(

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1702,11 +1702,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	// Validate that our policy allows issuing for each of the names in the order
 	for _, name := range order.Names {
 		id := core.AcmeIdentifier{Value: name, Type: core.IdentifierDNS}
-		if features.Enabled(features.WildcardDomains) {
-			if err := ra.PA.WillingToIssueWildcard(id); err != nil {
-				return nil, err
-			}
-		} else if err := ra.PA.WillingToIssue(id); err != nil {
+		if err := ra.PA.WillingToIssueWildcard(id); err != nil {
 			return nil, err
 		}
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -526,25 +526,23 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(ctx context.Context, reque
 			}
 		}
 	}
-	if features.Enabled(features.ReusePendingAuthz) {
-		nowishNano := ra.clk.Now().Add(time.Hour).UnixNano()
-		identifierTypeString := string(identifier.Type)
-		pendingAuth, err := ra.SA.GetPendingAuthorization(ctx, &sapb.GetPendingAuthorizationRequest{
-			RegistrationID:  &regID,
-			IdentifierType:  &identifierTypeString,
-			IdentifierValue: &identifier.Value,
-			ValidUntil:      &nowishNano,
-		})
-		if err != nil && !berrors.Is(err, berrors.NotFound) {
-			return core.Authorization{}, berrors.InternalServerError(
-				"unable to get pending authorization for regID: %d, identifier: %s: %s",
-				regID,
-				identifier.Value,
-				err)
-		} else if err == nil {
-			return *pendingAuth, nil
-		}
-		// Fall through to normal creation flow.
+
+	nowishNano := ra.clk.Now().Add(time.Hour).UnixNano()
+	identifierTypeString := string(identifier.Type)
+	pendingAuth, err := ra.SA.GetPendingAuthorization(ctx, &sapb.GetPendingAuthorizationRequest{
+		RegistrationID:  &regID,
+		IdentifierType:  &identifierTypeString,
+		IdentifierValue: &identifier.Value,
+		ValidUntil:      &nowishNano,
+	})
+	if err != nil && !berrors.Is(err, berrors.NotFound) {
+		return core.Authorization{}, berrors.InternalServerError(
+			"unable to get pending authorization for regID: %d, identifier: %s: %s",
+			regID,
+			identifier.Value,
+			err)
+	} else if err == nil {
+		return *pendingAuth, nil
 	}
 
 	authzPB, err := ra.createPendingAuthz(ctx, regID, identifier)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1886,19 +1886,17 @@ func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg
 		Expires:        &expires,
 	}
 
-	if identifier.Type == core.IdentifierDNS && !features.Enabled(features.VAChecksGSB) {
-		isSafeResp, err := ra.VA.IsSafeDomain(ctx, &vaPB.IsSafeDomainRequest{Domain: &identifier.Value})
-		if err != nil {
-			outErr := berrors.InternalServerError("unable to determine if domain was safe")
-			ra.log.Warningf("%s: %s", outErr, err)
-			return nil, outErr
-		}
-		if !isSafeResp.GetIsSafe() {
-			return nil, berrors.UnauthorizedError(
-				"%q was considered an unsafe domain by a third-party API",
-				identifier.Value,
-			)
-		}
+	isSafeResp, err := ra.VA.IsSafeDomain(ctx, &vaPB.IsSafeDomainRequest{Domain: &identifier.Value})
+	if err != nil {
+		outErr := berrors.InternalServerError("unable to determine if domain was safe")
+		ra.log.Warningf("%s: %s", outErr, err)
+		return nil, outErr
+	}
+	if !isSafeResp.GetIsSafe() {
+		return nil, berrors.UnauthorizedError(
+			"%q was considered an unsafe domain by a third-party API",
+			identifier.Value,
+		)
 	}
 
 	// If TLSSNIRevalidation is enabled, find out whether this was a revalidation

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1883,19 +1883,6 @@ func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg
 		Expires:        &expires,
 	}
 
-	isSafeResp, err := ra.VA.IsSafeDomain(ctx, &vaPB.IsSafeDomainRequest{Domain: &identifier.Value})
-	if err != nil {
-		outErr := berrors.InternalServerError("unable to determine if domain was safe")
-		ra.log.Warningf("%s: %s", outErr, err)
-		return nil, outErr
-	}
-	if !isSafeResp.GetIsSafe() {
-		return nil, berrors.UnauthorizedError(
-			"%q was considered an unsafe domain by a third-party API",
-			identifier.Value,
-		)
-	}
-
 	// If TLSSNIRevalidation is enabled, find out whether this was a revalidation
 	// (previous certificate existed) or not. If it is a revalidation, we'll tell
 	// the PA about that so it can include the TLS-SNI-01 challenge.

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3522,8 +3522,6 @@ func TestCTPolicyMeasurements(t *testing.T) {
 }
 
 func TestWildcardOverlap(t *testing.T) {
-	_ = features.Set(map[string]bool{"EnforceOverlappingWildcards": true})
-	defer features.Reset()
 	err := wildcardOverlap([]string{
 		"*.example.com",
 		"*.example.net",

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2748,8 +2748,6 @@ func TestFinalizeOrder(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "Could not add test order with finalized authz IDs")
 
-	// Enable the order ready status temporarily
-	_ = features.Set(map[string]bool{"OrderReadyStatus": true})
 	// Create an order with valid authzs, it should end up status ready in the
 	// resulting returned order
 	modernFinalOrder, err := sa.NewOrder(context.Background(), &corepb.Order{
@@ -2761,8 +2759,6 @@ func TestFinalizeOrder(t *testing.T) {
 		BeganProcessing: &processingStatus,
 	})
 	test.AssertNotError(t, err, "Could not add test order with finalized authz IDs, ready status")
-	// Disable the order ready status again
-	_ = features.Set(map[string]bool{"OrderReadyStatus": false})
 
 	// Swallowing errors here because the CSRPEM is hardcoded test data expected
 	// to parse in all instance
@@ -3259,6 +3255,8 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 	mockLog.Clear()
 
 	// Finalize the order with the CSR
+	status := string(core.StatusReady)
+	order.Status = &status
 	_, err = ra.FinalizeOrder(context.Background(), &rapb.FinalizeOrderRequest{
 		Order: order,
 		Csr:   csr})

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3361,6 +3361,10 @@ func (ms *mockSAPreexistingCertificate) PreviousCertificateExists(ctx context.Co
 	return &sapb.Exists{Exists: &f}, nil
 }
 
+func (ms *mockSAPreexistingCertificate) GetPendingAuthorization(ctx context.Context, req *sapb.GetPendingAuthorizationRequest) (*core.Authorization, error) {
+	return nil, berrors.NotFoundError("no pending authorization found")
+}
+
 // With TLS-SNI-01 disabled, an account that previously issued a certificate for
 // example.com should still be able to get a new authorization.
 func TestNewAuthzTLSSNIRevalidation(t *testing.T) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3406,7 +3406,6 @@ func TestNewAuthzTLSSNIRevalidation(t *testing.T) {
 		return foundTLSSNI
 	}
 	if !hasTLSSNI(authz.Challenges) {
-		fmt.Println(authz.Challenges)
 		t.Errorf("TLS-SNI challenge was not created during revalidation.")
 	}
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -664,9 +664,6 @@ func TestReusePendingAuthorization(t *testing.T) {
 	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	_ = features.Set(map[string]bool{"ReusePendingAuthz": true})
-	defer features.Reset()
-
 	// Create one pending authorization
 	firstAuthz, err := ra.NewAuthorization(ctx, AuthzInitial, Registration.ID)
 	test.AssertNotError(t, err, "Could not store test pending authorization")

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -477,9 +477,8 @@ func (ssa *SQLStorageAuthority) countCertificatesByExactName(domain string, earl
 // countCertificates returns, for a single domain, the count of
 // non-renewal certificate issuances in the given time range for that domain using the
 // provided query, assumed to be either `countCertificatesExactSelect` or
-// `countCertificatesSelect`. If the `AllowRenewalFirstRL` feature flag is set,
-// renewals of certificates issued within the same window are considered "free"
-// and are not counted.
+// `countCertificatesSelect`. Renewals of certificates issued within the same window
+// are considered "free" and are not counted.
 func (ssa *SQLStorageAuthority) countCertificates(domain string, earliest, latest time.Time, query string) (int, error) {
 	var serials []string
 	_, err := ssa.dbMap.Select(
@@ -496,40 +495,27 @@ func (ssa *SQLStorageAuthority) countCertificates(domain string, earliest, lates
 		return 0, err
 	}
 
-	// If the `AllowRenewalFirstRL` feature flag is enabled then do the work
-	// required to discount renewals
-	if features.Enabled(features.AllowRenewalFirstRL) {
-		// If there are no serials found, short circuit since there isn't subsequent
-		// work to do
-		if len(serials) == 0 {
-			return 0, nil
-		}
-
-		// Find all FQDN Set Hashes with the serials from the issuedNames table that
-		// were visible within our search window
-		fqdnSets, err := ssa.getFQDNSetsBySerials(serials)
-		if err != nil {
-			return 0, err
-		}
-
-		// Using those FQDN Set Hashes, we can then find all of the non-renewal
-		// issuances with a second query against the fqdnSets table using the set
-		// hashes we know about
-		nonRenewalIssuances, err := ssa.getNewIssuancesByFQDNSet(fqdnSets, earliest)
-		if err != nil {
-			return 0, err
-		}
-		return nonRenewalIssuances, nil
-	} else {
-		// Otherwise, use the preexisting behaviour and deduplicate by serials
-		// returning a count of unique serials qignoring any potential renewals
-		serialMap := make(map[string]struct{}, len(serials))
-		for _, s := range serials {
-			serialMap[s] = struct{}{}
-		}
-
-		return len(serialMap), nil
+	// If there are no serials found, short circuit since there isn't subsequent
+	// work to do
+	if len(serials) == 0 {
+		return 0, nil
 	}
+
+	// Find all FQDN Set Hashes with the serials from the issuedNames table that
+	// were visible within our search window
+	fqdnSets, err := ssa.getFQDNSetsBySerials(serials)
+	if err != nil {
+		return 0, err
+	}
+
+	// Using those FQDN Set Hashes, we can then find all of the non-renewal
+	// issuances with a second query against the fqdnSets table using the set
+	// hashes we know about
+	nonRenewalIssuances, err := ssa.getNewIssuancesByFQDNSet(fqdnSets, earliest)
+	if err != nil {
+		return 0, err
+	}
+	return nonRenewalIssuances, nil
 }
 
 // GetCertificate takes a serial number and returns the corresponding
@@ -2048,16 +2034,13 @@ func (ssa *SQLStorageAuthority) GetAuthorizations(
 		authzMap[name] = a
 	}
 
-	// WildcardDomain issuance requires that the authorizations returned by this
+	// Wildcard domain issuance requires that the authorizations returned by this
 	// RPC also include populated challenges such that the caller can know if the
 	// challenges meet the wildcard issuance policy (e.g. only 1 DNS-01
-	// challenge). We use a feature flag check here in case this causes
-	// performance regressions.
-	if features.Enabled(features.WildcardDomains) {
-		// Fetch each of the authorizations' associated challenges
-		for _, authz := range authzMap {
-			authz.Challenges, err = ssa.getChallenges(authz.ID)
-		}
+	// challenge).
+	// Fetch each of the authorizations' associated challenges
+	for _, authz := range authzMap {
+		authz.Challenges, err = ssa.getChallenges(authz.ID)
 	}
 	return authzMapToPB(authzMap)
 }

--- a/va/va.go
+++ b/va/va.go
@@ -912,8 +912,12 @@ func (va *ValidationAuthorityImpl) validate(
 		ch <- va.checkCAA(ctx, identifier, params)
 	}()
 	go func() {
-		ch <- probs.Unauthorized("%q was considered an unsafe domain by a third-party API",
-			baseIdentifier.Value)
+		if !va.isSafeDomain(ctx, baseIdentifier.Value) {
+			ch <- probs.Unauthorized("%q was considered an unsafe domain by a third-party API",
+				baseIdentifier.Value)
+		} else {
+			ch <- nil
+		}
 	}()
 
 	// TODO(#1292): send into another goroutine

--- a/va/va.go
+++ b/va/va.go
@@ -912,12 +912,8 @@ func (va *ValidationAuthorityImpl) validate(
 		ch <- va.checkCAA(ctx, identifier, params)
 	}()
 	go func() {
-		if features.Enabled(features.VAChecksGSB) && !va.isSafeDomain(ctx, baseIdentifier.Value) {
-			ch <- probs.Unauthorized("%q was considered an unsafe domain by a third-party API",
-				baseIdentifier.Value)
-		} else {
-			ch <- nil
-		}
+		ch <- probs.Unauthorized("%q was considered an unsafe domain by a third-party API",
+			baseIdentifier.Value)
 	}()
 
 	// TODO(#1292): send into another goroutine

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/metrics/mock_metrics"
@@ -910,9 +909,6 @@ func TestGSBAtValidation(t *testing.T) {
 	defer hs.Close()
 
 	va, _ := setup(hs, 0)
-
-	_ = features.Set(map[string]bool{"VAChecksGSB": true})
-	defer features.Reset()
 
 	ctrl := gomock.NewController(t)
 	sbc := NewMockSafeBrowsing(ctrl)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -995,7 +994,7 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 
 	// If the authz has been marked invalid, consider all challenges on that authz
 	// to be invalid as well.
-	if features.Enabled(features.ForceConsistentStatus) && authz.Status == core.StatusInvalid {
+	if authz.Status == core.StatusInvalid {
 		challenge.Status = authz.Status
 	}
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -26,7 +26,6 @@ import (
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/ctpolicy"
 	berrors "github.com/letsencrypt/boulder/errors"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -2450,7 +2449,6 @@ func TestKeyRollover(t *testing.T) {
 }
 
 func TestPrepChallengeForDisplay(t *testing.T) {
-	_ = features.Set(map[string]bool{"ForceConsistentStatus": true})
 	req := &http.Request{
 		Host: "example.com",
 	}

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -145,19 +145,17 @@ func (wfe *WebFrontEndImpl) validPOSTRequest(request *http.Request) *probs.Probl
 		return probs.ContentLengthRequired()
 	}
 
-	if features.Enabled(features.EnforceV2ContentType) {
-		// Per 6.2 ALL POSTs should have the correct JWS Content-Type for flattened
-		// JSON serialization.
-		if _, present := request.Header["Content-Type"]; !present {
-			wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "NoContentType"}).Inc()
-			return probs.InvalidContentType("No Content-Type header on POST. Content-Type must be %q",
-				expectedJWSContentType)
-		}
-		if contentType := request.Header.Get("Content-Type"); contentType != expectedJWSContentType {
-			wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "WrongContentType"}).Inc()
-			return probs.InvalidContentType("Invalid Content-Type header on POST. Content-Type must be %q",
-				expectedJWSContentType)
-		}
+	// Per 6.2 ALL POSTs should have the correct JWS Content-Type for flattened
+	// JSON serialization.
+	if _, present := request.Header["Content-Type"]; !present {
+		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "NoContentType"}).Inc()
+		return probs.InvalidContentType("No Content-Type header on POST. Content-Type must be %q",
+			expectedJWSContentType)
+	}
+	if contentType := request.Header.Get("Content-Type"); contentType != expectedJWSContentType {
+		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "WrongContentType"}).Inc()
+		return probs.InvalidContentType("Invalid Content-Type header on POST. Content-Type must be %q",
+			expectedJWSContentType)
 	}
 
 	// Per 6.4.1 "Replay-Nonce" clients should not send a Replay-Nonce header in

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -24,7 +24,6 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
@@ -882,7 +881,7 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 
 	// If the authz has been marked invalid, consider all challenges on that authz
 	// to be invalid as well.
-	if features.Enabled(features.ForceConsistentStatus) && authz.Status == core.StatusInvalid {
+	if authz.Status == core.StatusInvalid {
 		challenge.Status = authz.Status
 	}
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1691,8 +1691,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	// a pending status with valid authzs were finalizable. We accept both states
 	// here for deployability ease. In the future we will only allow ready orders
 	// to be finalized.
-	// TODO(@cpu): Forbid finalizing "Pending" orders once
-	// `features.Enabled(features.OrderReadyStatus)` is deployed
+	// TODO(@cpu): Forbid finalizing "Pending" orders
 	if *order.Status != string(core.StatusPending) &&
 		*order.Status != string(core.StatusReady) {
 		wfe.sendError(response, logEvent,

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -370,6 +370,7 @@ func makePostRequestWithPath(path string, body string) *http.Request {
 		RemoteAddr: "1.1.1.1:7882",
 		Header: map[string][]string{
 			"Content-Length": {strconv.Itoa(len(body))},
+			"Content-Type":   []string{expectedJWSContentType},
 		},
 		Body: makeBody(body),
 		Host: "localhost",
@@ -1250,6 +1251,7 @@ func TestNewAccount(t *testing.T) {
 				URL:    mustParseURL(newAcctPath),
 				Header: map[string][]string{
 					"Content-Length": {"0"},
+					"Content-Type":   []string{expectedJWSContentType},
 				},
 			},
 			`{"type":"` + probs.V2ErrorNS + `malformed","detail":"No body on POST","status":400}`,
@@ -1845,6 +1847,7 @@ func TestNewOrder(t *testing.T) {
 				Method: "POST",
 				Header: map[string][]string{
 					"Content-Length": {"0"},
+					"Content-Type":   []string{expectedJWSContentType},
 				},
 			},
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No body on POST","status":400}`,
@@ -1939,6 +1942,7 @@ func TestFinalizeOrder(t *testing.T) {
 				Method:     "POST",
 				Header: map[string][]string{
 					"Content-Length": {"0"},
+					"Content-Type":   []string{expectedJWSContentType},
 				},
 			},
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No body on POST","status":400}`,


### PR DESCRIPTION
Removes the checks for a handful of deployed feature flags in preparation for removing the flags entirely. Also moves all of the currently deprecated flags to a separate section of the flags list so they can be more easily removed once purged from production configs.

Fixes #3880.