### PR TITLE
Reject revocation requests for expired certs

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -748,7 +748,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *web
 		return
 	}
 	if parsedCertificate.NotAfter.Before(wfe.clk.Now()) {
-		wfe.sendError(response, logEvent, probs.Malformed("Certificate is expired"), nil)
+		wfe.sendError(response, logEvent, probs.Unauthorized("Certificate is expired"), nil)
 		return
 	}
 	logEvent.Extra["RetrievedCertificateSerial"] = core.SerialToString(parsedCertificate.SerialNumber)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -747,6 +747,10 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *web
 		wfe.sendError(response, logEvent, probs.ServerInternal("invalid parse of stored certificate"), err)
 		return
 	}
+	if parsedCertificate.NotAfter.Before(wfe.clk.Now()) {
+		wfe.sendError(response, logEvent, probs.Malformed("Certificate is expired"), nil)
+		return
+	}
 	logEvent.Extra["RetrievedCertificateSerial"] = core.SerialToString(parsedCertificate.SerialNumber)
 	logEvent.Extra["RetrievedCertificateDNSNames"] = parsedCertificate.DNSNames
 	logEvent.Extra["RetrievedCertificateEmailAddresses"] = parsedCertificate.EmailAddresses

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1662,9 +1662,9 @@ func TestRevokeCertificateExpired(t *testing.T) {
 	result, _ := signer.Sign(revokeRequestJSON)
 	wfe.RevokeCertificate(ctx, newRequestEvent(), responseWriter,
 		makePostRequest(result.FullSerialize()))
-	test.AssertEquals(t, responseWriter.Code, 400)
+	test.AssertEquals(t, responseWriter.Code, 403)
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
-		`{"type":"`+probs.V1ErrorNS+`malformed","detail":"Certificate is expired","status":400}`)
+		`{"type":"`+probs.V1ErrorNS+`unauthorized","detail":"Certificate is expired","status":403}`)
 
 }
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jmhodges/clock"
 	"golang.org/x/net/context"
@@ -2575,6 +2576,38 @@ func TestRevokeCertificateWithAuthz(t *testing.T) {
 
 	test.AssertEquals(t, responseWriter.Code, 200)
 	test.AssertEquals(t, responseWriter.Body.String(), "")
+}
+
+func TestRevokeCertificateExpired(t *testing.T) {
+	wfe, fc := setupWFE(t)
+	responseWriter := httptest.NewRecorder()
+	test4JWK := loadKey(t, []byte(test4KeyPrivatePEM))
+
+	certPemBytes, err := ioutil.ReadFile("test/238.crt")
+	test.AssertNotError(t, err, "failed to read test/238.crt")
+	certBlock, _ := pem.Decode(certPemBytes)
+	test.AssertNotError(t, err, "failed to parse test/238.crt")
+	reason := revocation.Reason(0)
+	revokeRequest := struct {
+		CertificateDER core.JSONBuffer    `json:"certificate"`
+		Reason         *revocation.Reason `json:"reason"`
+	}{
+		CertificateDER: certBlock.Bytes,
+		Reason:         &reason,
+	}
+	revokeRequestJSON, err := json.Marshal(revokeRequest)
+	test.AssertNotError(t, err, "failed to marshal revocation request")
+
+	parsedCertificate, err := x509.ParseCertificate(certBlock.Bytes)
+	test.AssertNotError(t, err, "failed to parse test cert")
+	fc.Set(parsedCertificate.NotAfter.Add(time.Hour))
+
+	_, _, jwsBody := signRequestKeyID(t, 4, test4JWK, "http://localhost/revoke-cert", string(revokeRequestJSON), wfe.nonceService)
+	wfe.RevokeCertificate(ctx, newRequestEvent(), responseWriter,
+		makePostRequestWithPath("revoke-cert", jwsBody))
+
+	test.AssertEquals(t, responseWriter.Code, 403)
+	test.AssertEquals(t, responseWriter.Body.String(), "{\n  \"type\": \"urn:ietf:params:acme:error:unauthorized\",\n  \"detail\": \"Certificate is expired\",\n  \"status\": 403\n}")
 }
 
 type mockSAGetRegByKeyFails struct {


### PR DESCRIPTION
Went with 400 because it makes more sense to me than 409 (bad request vs. conflict).

Fixes #3894.