### PR TITLE
Remove crufty old TODO from UpdateAuthorization.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1428,16 +1428,6 @@ func (ra *RegistrationAuthorityImpl) UpdateAuthorization(
 
 	ch := &authz.Challenges[challengeIndex]
 
-	if response.Type != "" && ch.Type != response.Type {
-		// TODO(riking): Check the rate on this, uncomment error return if negligible
-		ra.stats.Inc("StartChallengeWrongType", 1)
-		// return authz, berrors.MalformedError(
-		// 	"invalid challenge update: provided type was %s but actual type is %s",
-		// 	response.Type,
-		// 	ch.Type,
-		// )
-	}
-
 	// If TLSSNIRevalidation is enabled, find out whether this was a revalidation
 	// (previous certificate existed) or not. If it is a revalidation, we can
 	// proceed with validation even though the challenge type is currently


### PR DESCRIPTION
At one point, the POST to a challenge object was in theory updating a
resource, and might have a "Type" field. We considered adding a check
that the "Type" field matched the stored "Type" field. In ACMEv2, the POST
body is always simply `{}` so this check is irrelevant. And we're unlikely
to change the behavior in ACMEv1, so let's get rid of the counter and TODO.