### PR TITLE
 Quieter wfe

### DIFF
--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -36,7 +36,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 5,
+    "stdoutlevel": 4,
     "sysloglevel": 4
   },
 

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -43,7 +43,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 5,
+    "stdoutlevel": 4,
     "sysloglevel": 4
   },
 

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -36,7 +36,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 5,
+    "stdoutlevel": 4,
     "sysloglevel": 4
   },
 

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -41,7 +41,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 5,
+    "stdoutlevel": 4,
     "sysloglevel": 4
   },
 


### PR DESCRIPTION
Our Travis output is quite verbose with the WFE output, and it's very
rare that we have to reference it. I'd like to remove the INFO-level
logs (i.e. the logs of every request) so that it's easier to see real
errors, and faster to scroll to the bottom of logs of failed runs.