### PR TITLE
Add a deadline to TLS handshake.

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -665,18 +665,13 @@ func tlsDial(ctx context.Context, hostPort string, config *tls.Config) (*tls.Con
 	if err != nil {
 		return nil, err
 	}
+	if deadline, ok := ctx.Deadline(); ok {
+		netConn.SetDeadline(deadline)
+	}
 	conn := tls.Client(netConn, config)
-	errChan := make(chan error)
-	go func() {
-		errChan <- conn.Handshake()
-	}()
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errChan:
-		if err != nil {
-			return nil, err
-		}
+	err = conn.Handshake()
+	if err != nil {
+		return nil, err
 	}
 	return conn, nil
 }

--- a/va/va.go
+++ b/va/va.go
@@ -666,7 +666,7 @@ func tlsDial(ctx context.Context, hostPort string, config *tls.Config) (*tls.Con
 		return nil, err
 	}
 	if deadline, ok := ctx.Deadline(); ok {
-		netConn.SetDeadline(deadline)
+		_ = netConn.SetDeadline(deadline)
 	}
 	conn := tls.Client(netConn, config)
 	err = conn.Handshake()

--- a/va/va.go
+++ b/va/va.go
@@ -631,7 +631,7 @@ func (va *ValidationAuthorityImpl) getTLSCerts(
 	va.log.Info(fmt.Sprintf("%s [%s] Attempting to validate for %s %s", challenge.Type, identifier, hostPort, config.ServerName))
 	// We expect a self-signed challenge certificate, do not verify it here.
 	config.InsecureSkipVerify = true
-	conn, err := tlsDial(ctx, hostPort, config)
+	conn, err := va.tlsDial(ctx, hostPort, config)
 
 	if err != nil {
 		va.log.Infof("%s connection failure for %s. err=[%#v] errStr=[%s]", challenge.Type, identifier, err, err)
@@ -657,7 +657,7 @@ func (va *ValidationAuthorityImpl) getTLSCerts(
 
 // tlsDial does the equivalent of tls.Dial, but obeying a context. Once
 // tls.DialContextWithDialer is available, switch to that.
-func tlsDial(ctx context.Context, hostPort string, config *tls.Config) (*tls.Conn, error) {
+func (va *ValidationAuthorityImpl) tlsDial(ctx context.Context, hostPort string, config *tls.Config) (*tls.Conn, error) {
 	ctx, cancel := context.WithTimeout(ctx, singleDialTimeout)
 	defer cancel()
 	dialer := &net.Dialer{}
@@ -665,9 +665,12 @@ func tlsDial(ctx context.Context, hostPort string, config *tls.Config) (*tls.Con
 	if err != nil {
 		return nil, err
 	}
-	if deadline, ok := ctx.Deadline(); ok {
-		_ = netConn.SetDeadline(deadline)
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		va.log.AuditErr("tlsDial was called without a deadline")
+		return nil, fmt.Errorf("tlsDial was called without a deadline")
 	}
+	_ = netConn.SetDeadline(deadline)
 	conn := tls.Client(netConn, config)
 	err = conn.Handshake()
 	if err != nil {

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -675,35 +674,6 @@ func TestTLSSNI01TimeoutAfterConnect(t *testing.T) {
 	expected := "Timeout during read (your server may be slow or overloaded)"
 	if prob.Detail != expected {
 		t.Errorf("Wrong error detail. Expected %q, got %q", expected, prob.Detail)
-	}
-}
-
-// Note: This test is potentially flaky, if some other concurrent test spawns
-// over a hundred goroutines concurrently with it.
-func TestTLSSNI01TimeoutNoLeak(t *testing.T) {
-	chall := createChallenge(core.ChallengeTypeTLSSNI01)
-	hs := slowTLSSrv()
-	va, _ := setup(hs, 0)
-
-	numGoroutinesBefore := runtime.NumGoroutine()
-	for i := 0; i < 200; i++ {
-		timeout := 10 * time.Millisecond
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		_, prob := va.validateTLSSNI01(ctx, dnsi("slow.server"), chall)
-		if prob == nil {
-			t.Fatalf("Validation should've failed")
-		}
-		if prob.Error() != "connection :: Timeout during read (your server may be slow or overloaded)" {
-			t.Errorf("Wrong error for TLS handshake timeout: %s", prob)
-		}
-	}
-	numGoroutinesAfter := runtime.NumGoroutine()
-
-	delta := numGoroutinesAfter - numGoroutinesBefore
-
-	if delta > 100 {
-		t.Fatalf("The number of goroutines increased by %d after running 1000 timed-out validations.", delta)
 	}
 }
 

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -671,7 +671,7 @@ func TestTLSSNI01TimeoutAfterConnect(t *testing.T) {
 		t.Fatalf("Connection should've timed out")
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
-	expected := "Timeout after connect (your server may be slow or overloaded)"
+	expected := "Timeout during read (your server may be slow or overloaded)"
 	if prob.Detail != expected {
 		t.Errorf("Wrong error detail. Expected %q, got %q", expected, prob.Detail)
 	}

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -679,18 +679,15 @@ func TestTLSSNI01TimeoutAfterConnect(t *testing.T) {
 }
 
 // Note: This test is potentially flaky, if some other concurrent test spawns
-// over a hundred goroutines concurrently with it. It may also potentially flake
-// if we don't reliably timeout in the correct place (i.e. we may get timeout
-// during connect instead).
+// over a hundred goroutines concurrently with it.
 func TestTLSSNI01TimeoutNoLeak(t *testing.T) {
 	chall := createChallenge(core.ChallengeTypeTLSSNI01)
 	hs := slowTLSSrv()
 	va, _ := setup(hs, 0)
 
 	numGoroutinesBefore := runtime.NumGoroutine()
-	numAttempts := 200
-	for i := 0; i < numAttempts; i++ {
-		timeout := 20 * time.Millisecond
+	for i := 0; i < 200; i++ {
+		timeout := 10 * time.Millisecond
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		_, prob := va.validateTLSSNI01(ctx, dnsi("slow.server"), chall)
@@ -705,8 +702,8 @@ func TestTLSSNI01TimeoutNoLeak(t *testing.T) {
 
 	delta := numGoroutinesAfter - numGoroutinesBefore
 
-	if delta > numAttempts/2 {
-		t.Fatalf("The number of goroutines increased by %d after running %d timed-out validations.", delta, numAttempts)
+	if delta > 100 {
+		t.Fatalf("The number of goroutines increased by %d after running 1000 timed-out validations.", delta)
 	}
 }
 


### PR DESCRIPTION
Previously, if a TLS handshake timed out, we would block forever in
`conn.Handshake()`, leaking both a TCP connection and a goroutine.
This sets a deadline on the underlying TCP connection, ensuring that
`conn.Handshake()` eventually times out.

Fixes #3915