### PR TITLE
Check authorization status at the WFE/2 instead of RA

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1078,7 +1078,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	// increment a stat for this case and return early.
 	var returnAuthz core.Authorization
 	if authz.Status == core.StatusValid {
-		// ra.stats.Inc("ReusedValidAuthzChallenge", 1)
+		wfe.stats.Inc("ReusedValidAuthzChallengeWFE", 1)
 		returnAuthz = authz
 	} else {
 		var challengeUpdate core.Challenge

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1072,28 +1072,39 @@ func (wfe *WebFrontEndImpl) postChallenge(
 		return
 	}
 
-	var challengeUpdate core.Challenge
-	if err := json.Unmarshal(body, &challengeUpdate); err != nil {
-		wfe.sendError(response, logEvent, probs.Malformed("Error unmarshaling challenge response"), err)
-		return
-	}
+	// We can expect some clients to try and update a challenge for an authorization
+	// that is already valid. In this case we don't need to process the challenge
+	// update. It wouldn't be helpful, the overall authorization is already good! We
+	// increment a stat for this case and return early.
+	var returnAuthz core.Authorization
+	if authz.Status == core.StatusValid {
+		// ra.stats.Inc("ReusedValidAuthzChallenge", 1)
+		returnAuthz = authz
+	} else {
+		var challengeUpdate core.Challenge
+		if err := json.Unmarshal(body, &challengeUpdate); err != nil {
+			wfe.sendError(response, logEvent, probs.Malformed("Error unmarshaling challenge response"), err)
+			return
+		}
 
-	// Ask the RA to update this authorization
-	updatedAuthorization, err := wfe.RA.UpdateAuthorization(ctx, authz, challengeIndex, challengeUpdate)
-	if err != nil {
-		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
-		return
+		// Ask the RA to update this authorization
+		var err error
+		returnAuthz, err = wfe.RA.UpdateAuthorization(ctx, authz, challengeIndex, challengeUpdate)
+		if err != nil {
+			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
+			return
+		}
 	}
 
 	// assumption: UpdateAuthorization does not modify order of challenges
-	challenge := updatedAuthorization.Challenges[challengeIndex]
+	challenge := returnAuthz.Challenges[challengeIndex]
 	wfe.prepChallengeForDisplay(request, authz, &challenge)
 
 	authzURL := web.RelativeEndpoint(request, authzPath+string(authz.ID))
 	response.Header().Add("Location", challenge.URI)
 	response.Header().Add("Link", link(authzURL, "up"))
 
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, challenge)
+	err := wfe.writeJsonResponse(response, logEvent, http.StatusAccepted, challenge)
 	if err != nil {
 		// ServerInternal because we made the challenges, they should be OK
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to marshal challenge"), err)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1168,11 +1168,11 @@ func TestChallenge(t *testing.T) {
 }
 
 // MockRAUpdateAuthorizationError is a mock RA that just returns an error on UpdateAuthorization
-type MockRAStrictUpdateAuthz struct {
+type MockRAUpdateAuthorizationError struct {
 	MockRegistrationAuthority
 }
 
-func (ra *MockRAStrictUpdateAuthz) UpdateAuthorization(_ context.Context, authz core.Authorization, _ int, _ core.Challenge) (core.Authorization, error) {
+func (ra *MockRAUpdateAuthorizationError) UpdateAuthorization(_ context.Context, authz core.Authorization, _ int, _ core.Challenge) (core.Authorization, error) {
 	return core.Authorization{}, errors.New("broken on purpose")
 }
 
@@ -1181,7 +1181,7 @@ func (ra *MockRAStrictUpdateAuthz) UpdateAuthorization(_ context.Context, authz 
 // the RA.
 func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.RA = &MockRAStrictUpdateAuthz{}
+	wfe.RA = &MockRAUpdateAuthorizationError{}
 	responseWriter := httptest.NewRecorder()
 
 	path := "valid/23"
@@ -1190,7 +1190,6 @@ func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 			signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 
 	body := responseWriter.Body.String()
-	fmt.Println(body)
 	test.AssertUnmarshaledEquals(t, body, `{
 		"type": "dns",
 		"uri": "http://localhost/acme/challenge/valid/23"

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -988,7 +988,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	// increment a stat for this case and return early.
 	var returnAuthz core.Authorization
 	if authz.Status == core.StatusValid {
-		// ra.stats.Inc("ReusedValidAuthzChallenge", 1)
+		wfe.scope.Inc("ReusedValidAuthzChallengeWFE", 1)
 		returnAuthz = authz
 	} else {
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1099,11 +1099,11 @@ func TestChallenge(t *testing.T) {
 }
 
 // MockRAUpdateAuthorizationError is a mock RA that just returns an error on UpdateAuthorization
-type MockRAStrictUpdateAuthz struct {
+type MockRAUpdateAuthorizationError struct {
 	MockRegistrationAuthority
 }
 
-func (ra *MockRAStrictUpdateAuthz) UpdateAuthorization(_ context.Context, authz core.Authorization, _ int, _ core.Challenge) (core.Authorization, error) {
+func (ra *MockRAUpdateAuthorizationError) UpdateAuthorization(_ context.Context, authz core.Authorization, _ int, _ core.Challenge) (core.Authorization, error) {
 	return core.Authorization{}, errors.New("broken on purpose")
 }
 
@@ -1112,7 +1112,7 @@ func (ra *MockRAStrictUpdateAuthz) UpdateAuthorization(_ context.Context, authz 
 // the RA.
 func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.RA = &MockRAStrictUpdateAuthz{}
+	wfe.RA = &MockRAUpdateAuthorizationError{}
 	responseWriter := httptest.NewRecorder()
 
 	signedURL := "http://localhost/valid/23"
@@ -1121,7 +1121,6 @@ func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 	wfe.Challenge(ctx, newRequestEvent(), responseWriter, request)
 
 	body := responseWriter.Body.String()
-	fmt.Println(body)
 	test.AssertUnmarshaledEquals(t, body, `{
 		"type": "dns",
 		"url": "http://localhost/acme/challenge/valid/23"

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1097,23 +1098,18 @@ func TestChallenge(t *testing.T) {
 	}
 }
 
-// MockRAStrictUpdateAuthz is a mock RA that enforces authz status in `UpdateAuthorization`
+// MockRAUpdateAuthorizationError is a mock RA that just returns an error on UpdateAuthorization
 type MockRAStrictUpdateAuthz struct {
 	MockRegistrationAuthority
 }
 
-// UpdateAuthorization for a MockRAStrictUpdateAuthz returns a
-// berrors.WrongAuthorizationStateError when told to update a non-pending authz. It
-// returns the authz unchanged for all other cases.
 func (ra *MockRAStrictUpdateAuthz) UpdateAuthorization(_ context.Context, authz core.Authorization, _ int, _ core.Challenge) (core.Authorization, error) {
-	if authz.Status != core.StatusPending {
-		return core.Authorization{}, berrors.WrongAuthorizationStateError("authorization is not pending")
-	}
-	return authz, nil
+	return core.Authorization{}, errors.New("broken on purpose")
 }
 
 // TestUpdateChallengeFinalizedAuthz tests that POSTing a challenge associated
-// with an already valid authorization returns the expected Malformed problem.
+// with an already valid authorization just returns the challenge without calling
+// the RA.
 func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	wfe.RA = &MockRAStrictUpdateAuthz{}
@@ -1125,11 +1121,11 @@ func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 	wfe.Challenge(ctx, newRequestEvent(), responseWriter, request)
 
 	body := responseWriter.Body.String()
+	fmt.Println(body)
 	test.AssertUnmarshaledEquals(t, body, `{
-  "type": "`+probs.V2ErrorNS+`malformed",
-  "detail": "Unable to update challenge :: authorization is not pending",
-  "status": 400
-}`)
+		"type": "dns",
+		"url": "http://localhost/acme/challenge/valid/23"
+	  }`)
 }
 
 func TestBadNonce(t *testing.T) {


### PR DESCRIPTION
Required a rewrite of two tests that assumed behavior of the RA which was incorrect. This leaves the existing RA check in place for deployability reasons, once merged I'll file a ticket to remove it after the next release is cut.

Fixes #3934.