### PR TITLE
Fix latency logging.

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -1093,7 +1092,7 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 	logEvent.Challenge = challenge
 
 	validationLatency := time.Since(vStart)
-	logEvent.ValidationLatency = math.Floor(1000*float64(validationLatency)/float64(time.Second)) / 1000
+	logEvent.ValidationLatency = validationLatency.Round(time.Millisecond).Seconds()
 
 	va.metrics.validationTime.With(prometheus.Labels{
 		"type":        string(challenge.Type),

--- a/va/va.go
+++ b/va/va.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -194,8 +195,8 @@ type verificationRequestEvent struct {
 	Hostname          string                  `json:",omitempty"`
 	ValidationRecords []core.ValidationRecord `json:",omitempty"`
 	Challenge         core.Challenge          `json:",omitempty"`
-	ValidationLatency time.Duration           `json:",omitempty"`
-	Error             string                  `json:",omitempty"`
+	ValidationLatency float64
+	Error             string `json:",omitempty"`
 }
 
 // getAddr will query for all A/AAAA records associated with hostname and return
@@ -1092,7 +1093,7 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 	logEvent.Challenge = challenge
 
 	validationLatency := time.Since(vStart)
-	logEvent.ValidationLatency = validationLatency
+	logEvent.ValidationLatency = math.Floor(1000*float64(validationLatency)/float64(time.Second)) / 1000
 
 	va.metrics.validationTime.With(prometheus.Labels{
 		"type":        string(challenge.Type),

--- a/web/context.go
+++ b/web/context.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"time"
 
@@ -79,7 +80,7 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rwws := &responseWriterWithStatus{w, 0}
 	defer func() {
 		logEvent.Code = rwws.code
-		logEvent.Latency = float64(time.Since(begin)) / float64(time.Second)
+		logEvent.Latency = math.Floor(1000*float64(time.Since(begin))/float64(time.Second)) / 1000
 		th.logEvent(logEvent)
 	}()
 	th.wfe.ServeHTTP(logEvent, rwws, r)

--- a/web/context.go
+++ b/web/context.go
@@ -3,7 +3,6 @@ package web
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"time"
 
@@ -80,7 +79,7 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rwws := &responseWriterWithStatus{w, 0}
 	defer func() {
 		logEvent.Code = rwws.code
-		logEvent.Latency = math.Floor(1000*float64(time.Since(begin))/float64(time.Second)) / 1000
+		logEvent.Latency = time.Since(begin).Round(time.Millisecond).Seconds()
 		th.logEvent(logEvent)
 	}()
 	th.wfe.ServeHTTP(logEvent, rwws, r)

--- a/web/context_test.go
+++ b/web/context_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/test"
@@ -13,6 +14,7 @@ import (
 type myHandler struct{}
 
 func (m myHandler) ServeHTTP(e *RequestEvent, w http.ResponseWriter, r *http.Request) {
+	time.Sleep(10 * time.Millisecond)
 	w.WriteHeader(201)
 	_, _ = w.Write([]byte("hi"))
 }

--- a/web/context_test.go
+++ b/web/context_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/test"
@@ -14,7 +13,6 @@ import (
 type myHandler struct{}
 
 func (m myHandler) ServeHTTP(e *RequestEvent, w http.ResponseWriter, r *http.Request) {
-	time.Sleep(10 * time.Millisecond)
 	w.WriteHeader(201)
 	_, _ = w.Write([]byte("hi"))
 }
@@ -28,5 +26,5 @@ func TestLogCode(t *testing.T) {
 	}
 	th.ServeHTTP(httptest.NewRecorder(), req)
 	test.AssertEquals(t, 1, len(mockLog.GetAllMatching(`"Code":201`)))
-	test.AssertEquals(t, 1, len(mockLog.GetAllMatching(`"Latency":0\.`)))
+	test.AssertEquals(t, 1, len(mockLog.GetAllMatching(`"Latency":0`)))
 }


### PR DESCRIPTION
In the VA, we were rendering a Duration to JSON, which gave an integer
number of nanoseconds rather than a float64 of seconds. Also, in both VA
and WFE we were rendering way more precision than we needed. Millisecond
precision is enough, and since we log latency for every WFE response,
the extra bytes are worth saving.