### PR TITLE
VA: Simplified HTTP-01 w/ IP address URLs

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -94,11 +94,6 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 			net.ParseIP("::1"),
 		}, nil
 	}
-	if hostname == "not-listening.ip" {
-		return []net.IP{
-			net.ParseIP("192.168.88.88"),
-		}, nil
-	}
 	ip := net.ParseIP("127.0.0.1")
 	return []net.IP{ip}, nil
 }

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -94,6 +94,11 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 			net.ParseIP("::1"),
 		}, nil
 	}
+	if hostname == "not-listening.ip" {
+		return []net.IP{
+			net.ParseIP("192.168.88.88"),
+		}, nil
+	}
 	ip := net.ParseIP("127.0.0.1")
 	return []net.IP{ip}, nil
 }

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogs"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogsSimplifiedVAHTTP"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 120, 141, 152, 163, 183, 210, 226, 245, 263, 283, 296, 313, 324}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 120, 141, 152, 163, 183, 210, 226, 245, 263, 283, 296, 313, 324, 340}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -38,6 +38,9 @@ const (
 	ACME13KeyRollover
 	// ProbeCTLogs enables HTTP probes to CT logs from the publisher
 	ProbeCTLogs
+	// SimplifiedVAHTTP enables the simplified VA http-01 rewrite that doesn't use
+	// a custom dialer.
+	SimplifiedVAHTTP
 )
 
 // List of features and their default value, protected by fMu
@@ -62,6 +65,7 @@ var features = map[FeatureFlag]bool{
 	CAAAccountURI:               false,
 	ACME13KeyRollover:           false,
 	ProbeCTLogs:                 false,
+	SimplifiedVAHTTP:            false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -30,7 +30,8 @@
       "RPCHeadroom": true,
       "IPv6First": true,
       "CAAValidationMethods": true,
-      "CAAAccountURI": true
+      "CAAAccountURI": true,
+      "SimplifiedVAHTTP": true
     },
     "accountURIPrefixes": [
       "http://boulder:4000/acme/reg/"
@@ -38,7 +39,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 6,
+    "stdoutlevel": 7,
     "sysloglevel": 4
   },
 

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -39,7 +39,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 7,
+    "stdoutlevel": 6,
     "sysloglevel": 4
   },
 

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -30,7 +30,8 @@
       "RPCHeadroom": true,
       "IPv6First": true,
       "CAAValidationMethods": true,
-      "CAAAccountURI": true
+      "CAAAccountURI": true,
+      "SimplifiedVAHTTP": true
     },
     "accountURIPrefixes": [
       "http://boulder:4000/acme/reg/"
@@ -38,7 +39,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 6,
+    "stdoutlevel": 7,
     "sysloglevel": 4
   },
 

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -39,7 +39,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 7,
+    "stdoutlevel": 6,
     "sysloglevel": 4
   },
 

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -36,7 +36,8 @@
       "VAChecksGSB": true,
       "IPv6First": true,
       "CAAValidationMethods": true,
-      "CAAAccountURI": true
+      "CAAAccountURI": true,
+      "SimplifiedVAHTTP": true
     },
     "remoteVAs": [
       {
@@ -54,7 +55,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 6,
+    "stdoutlevel": 7,
     "sysloglevel": 4
   },
 

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -55,7 +55,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 7,
+    "stdoutlevel": 6,
     "sysloglevel": 4
   },
 

--- a/va/http.go
+++ b/va/http.go
@@ -340,9 +340,8 @@ func (va *ValidationAuthorityImpl) fetchHTTPSimple(
 
 // fallbackErr returns true only for net.OpError instances where the op is equal
 // to "dial", or url.Error instances wrapping such an error. fallbackErr returns
-// false for all other errors. By policy we're only interested in retrying
-// requests that were made to an IPv6 address that generated a network error
-// during dials.
+// false for all other errors. By policy, only dial errors (not read or write
+// errors) are eligble for fallback from an IPv6 to an IPv4 address.
 func fallbackErr(err error) bool {
 	// Err shouldn't ever be nil if we're considering it for fallback
 	if err == nil {

--- a/va/http.go
+++ b/va/http.go
@@ -110,7 +110,7 @@ type httpValidationTarget struct {
 	// the IP addresses that will be drawn from by calls to nextIP() to set curIP
 	next []net.IP
 	// the current IP address being used for validation (if any)
-	cur *net.IP
+	cur net.IP
 }
 
 // nextIP changes the cur IP by removing the first entry from the next slice and
@@ -123,18 +123,15 @@ func (vt *httpValidationTarget) nextIP() error {
 			"host %q has no IP addresses remaining to use",
 			vt.host)
 	}
-	oldIP := vt.cur
-	if oldIP != nil {
-		vt.tried = append(vt.tried, *oldIP)
-	}
-	vt.cur = &vt.next[0]
+	vt.tried = append(vt.tried, vt.cur)
+	vt.cur = vt.next[0]
 	vt.next = vt.next[1:]
 	return nil
 }
 
 // ip returns the current *net.IP for the validation target. It may return nil
 // if all possible IPs have been expended by calls to nextIP.
-func (vt *httpValidationTarget) ip() *net.IP {
+func (vt *httpValidationTarget) ip() net.IP {
 	return vt.cur
 }
 
@@ -282,8 +279,8 @@ func (va *ValidationAuthorityImpl) setupHTTPValidation(
 			"host %q has no IP addresses remaining to use",
 			target.host)
 	}
-	record.AddressUsed = *targetIP
-	url := httpValidationURL(*targetIP, target.path, target.port)
+	record.AddressUsed = targetIP
+	url := httpValidationURL(targetIP, target.path, target.port)
 	record.URL = url.String()
 
 	// If there's no provided HTTP request to mutate (e.g. a redirect request

--- a/va/http.go
+++ b/va/http.go
@@ -79,10 +79,10 @@ type httpValidationTarget struct {
 	next []net.IP
 }
 
-// IP hands out one of the next IP addresses for the validation target. The list
+// ip hands out one of the next IP addresses for the validation target. The list
 // of tried IP addresses is updated to include the IP that is returned to the
 // caller. If there are no next IP addresses an error is returned.
-func (vt *httpValidationTarget) IP() (*net.IP, error) {
+func (vt *httpValidationTarget) ip() (*net.IP, error) {
 	if len(vt.next) == 0 {
 		return nil, fmt.Errorf("host %q has no IP addresses remaining to use", vt.host)
 	}
@@ -227,7 +227,7 @@ func (va *ValidationAuthorityImpl) setupHTTPValidation(
 	}
 
 	// Build a URL with the target's IP address and port
-	targetIP, err := target.IP()
+	targetIP, err := target.ip()
 	if err != nil {
 		return nil, record, err
 	}

--- a/va/http.go
+++ b/va/http.go
@@ -111,9 +111,11 @@ type httpValidationTarget struct {
 	next []net.IP
 }
 
-// ip hands out one of the next IP addresses for the validation target. The list
-// of tried IP addresses is updated to include the IP that is returned to the
-// caller. If there are no next IP addresses an error is returned.
+// ip hands out one of the next IP addresses for the validation target and
+// mutates the internal state of the validation target to track ips used. The
+// list of tried IP addresses is updated to include the IP that is returned to
+// the caller. The returned IP is also removed from the next slice. If there are
+// no next IP addresses an error is returned.
 func (vt *httpValidationTarget) ip() (*net.IP, error) {
 	if len(vt.next) == 0 {
 		return nil, fmt.Errorf("host %q has no IP addresses remaining to use", vt.host)

--- a/va/http.go
+++ b/va/http.go
@@ -351,23 +351,16 @@ func fallbackErr(err error) bool {
 		return false
 	}
 
-	// if the error is a URL error, unwrap it and see if the inner err is
-	// a fallback error
-	if urlErr, ok := err.(*url.Error); ok {
-		return fallbackErr(urlErr.Err)
-	}
-
-	// Network operation errors should provoke a fallback
-	if _, ok := err.(*net.OpError); ok {
+	switch err := err.(type) {
+	case *url.Error:
+		return fallbackErr(err.Err)
+	case *net.OpError:
 		return true
-	}
-
-	// Generic network errors (timeouts, etc) should also provoke a fallback
-	if _, ok := err.(net.Error); ok {
+	case net.Error:
 		return true
+	default:
+		return false
 	}
-
-	return false
 }
 
 // processHTTPValidation performs an HTTP validation for the given host, port

--- a/va/http.go
+++ b/va/http.go
@@ -1,0 +1,424 @@
+package va
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/letsencrypt/boulder/core"
+	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/probs"
+)
+
+func newHTTPClient() http.Client {
+	// Construct a one-off HTTP client with a custom transport.
+	return http.Client{
+		Transport: &http.Transport{
+			// We are talking to a client that does not yet have a certificate,
+			// so we accept a temporary, invalid one.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			// We don't expect to make multiple requests to a client, so close
+			// connection immediately.
+			DisableKeepAlives: true,
+			// We don't want idle connections, but 0 means "unlimited," so we pick 1.
+			MaxIdleConns:        1,
+			IdleConnTimeout:     time.Second,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
+}
+
+// httpValidationURL constructs a URL for the given IP address, path and port
+// combination. The port is omittied from the URL if it is the default HTTP
+// port. It is only used for constructing initial HTTP-01 validation requests
+// and so does not need to support constructing a URL with an HTTPS scheme.
+func httpValidationURL(validationIP net.IP, path string, port int) *url.URL {
+	urlHost := validationIP.String()
+
+	// If the port is something other than the conventional HTTP port, put it in
+	// the URL.
+	if port != 80 {
+		urlHost = net.JoinHostPort(validationIP.String(), strconv.Itoa(port))
+	} else if validationIP.To4() == nil {
+		// if the validation IP is an IPv6 address, and we aren't using
+		// `net.JoinHostPort` then we have to manually surround the IPv6 address
+		// with square brackets to make a valid IPv6 URL (e.g "http://[::1]/foo" not
+		// "http://::1/foo")
+		urlHost = fmt.Sprintf("[%s]", urlHost)
+	}
+
+	return &url.URL{
+		Scheme: "http",
+		Host:   urlHost,
+		Path:   path,
+	}
+}
+
+// httpValidationTarget bundles all of the information needed to make an HTTP-01
+// validation request against a target.
+type httpValidationTarget struct {
+	// the hostname being validated
+	host string
+	// the port for the validation request
+	port int
+	// the path for the validation request
+	path string
+	// all of the IP addresses available for the host
+	available []net.IP
+	// the IP addresses that were tried for validation so far (e.g. returned by
+	// calls to the IP function)
+	tried []net.IP
+	// the IP addresses that will be returned by calls to the IP function.
+	next []net.IP
+}
+
+// IP hands out one of the next IP addresses for the validation target. The list
+// of tried IP addresses is updated to include the IP that is returned to the
+// caller. If there are no next IP addresses an error is returned.
+func (vt *httpValidationTarget) IP() (*net.IP, error) {
+	if len(vt.next) == 0 {
+		return nil, fmt.Errorf("host %q has no IP addresses remaining to use", vt.host)
+	}
+	curIP := vt.next[0]
+	vt.next = vt.next[1:]
+	vt.tried = append(vt.tried, curIP)
+	return &curIP, nil
+}
+
+// newHTTPValidationTarget creates a httpValidationTarget for the given host,
+// port, and path. This involves querying DNS for the IP addresses for the host.
+// An error is returned if there are no usable IP addresses or if the DNS
+// lookups fail.
+func (va *ValidationAuthorityImpl) newHTTPValidationTarget(
+	ctx context.Context,
+	host string,
+	port int,
+	path string) (*httpValidationTarget, error) {
+	// Resolve IP addresses for the hostname
+	addrs, err := va.getAddrs(ctx, host)
+	if err != nil {
+		// Convert the error into a ConnectionFailureError so it is presented to the
+		// end user in a problem after being fed through detailedError.
+		return nil, berrors.ConnectionFailureError(err.Error())
+	}
+
+	target := &httpValidationTarget{
+		host:      host,
+		port:      port,
+		path:      path,
+		available: addrs,
+	}
+
+	// Separate the addresses into the available v4 and v6 addresses
+	v4Addrs, v6Addrs := availableAddresses(addrs)
+	hasV6Addrs := len(v6Addrs) > 0
+	hasV4Addrs := len(v4Addrs) > 0
+
+	if !hasV6Addrs && !hasV4Addrs {
+		// If there are no v6 addrs and no v4addrs there was a bug with getAddrs or
+		// availableAddresses and we need to return an error.
+		return nil, fmt.Errorf("host %q has no IPv4 or IPv6 addresses", host)
+	} else if !hasV6Addrs && hasV4Addrs {
+		// If there are no v6 addrs and there are v4 addrs then use the first v4
+		// address. There's no fallback address.
+		target.next = []net.IP{v4Addrs[0]}
+	} else if hasV6Addrs && hasV4Addrs {
+		// If there are both v6 addrs and v4 addrs then use the first v6 address and
+		// fallback with the first v4 address.
+		target.next = []net.IP{v6Addrs[0], v4Addrs[0]}
+	} else if hasV6Addrs && !hasV4Addrs {
+		// If there are just v6 addrs then use the first v6 address. There's no
+		// fallback address.
+		target.next = []net.IP{v6Addrs[0]}
+	}
+	return target, nil
+}
+
+// extractRequestTarget extracts the hostname and port specified in the provided
+// HTTP redirect request. If the request's URL's protocol schema is not HTTP or
+// HTTPS an error is returned. If an explicit port is specified in the request's
+// URL and it isn't the VA's HTTP or HTTPS port, an error is returned. If the
+// request's URL's Host is a bare IPv4 or IPv6 address and not a domain name an
+// error is returned.
+func (va *ValidationAuthorityImpl) extractRequestTarget(req *http.Request) (string, int, error) {
+	// A nil request is certainly not a valid redirect and has no port to extract.
+	if req == nil {
+		return "", 0, fmt.Errorf("redirect HTTP request was nil")
+	}
+
+	reqScheme := req.URL.Scheme
+
+	// The redirect request must use HTTP or HTTPs protocol schemes regardless of the port..
+	if reqScheme != "http" && reqScheme != "https" {
+		return "", 0, berrors.ConnectionFailureError(
+			"Invalid protocol scheme in redirect target. "+
+				`Only "http" and "https" protocol schemes are supported, not %q`, reqScheme)
+	}
+
+	// Try and split an explicit port number from the request URL host. If there is
+	// one we need to make sure its a valid port. If there isn't one we need to
+	// pick the port based on the reqScheme default port.
+	reqHost := req.URL.Host
+	reqPort := 0
+	if h, p, err := net.SplitHostPort(reqHost); err == nil {
+		reqHost = h
+		reqPort, err = strconv.Atoi(p)
+		if err != nil {
+			return "", 0, err
+		}
+
+		// The explicit port must match the VA's configured HTTP or HTTPS port.
+		if reqPort != va.httpPort && reqPort != va.httpsPort {
+			return "", 0, berrors.ConnectionFailureError(
+				"Invalid port in redirect target. Only ports %d and %d are supported, not %d",
+				va.httpPort, va.httpsPort, reqPort)
+		}
+	} else if reqScheme == "http" {
+		reqPort = va.httpPort
+	} else if reqScheme == "https" {
+		reqPort = va.httpsPort
+	} else {
+		// This shouldn't happen but defensively return an internal server error in
+		// case it does.
+		return "", 0, fmt.Errorf("unable to determine redirect HTTP request port")
+	}
+
+	// Check that the request host isn't a bare IP address. We only follow
+	// redirects to hostnames.
+	if net.ParseIP(reqHost) != nil {
+		return "", 0, berrors.ConnectionFailureError(
+			"Invalid host in redirect target %q. "+
+				"Only domain names are supported, not IP addresses", reqHost)
+	}
+
+	return reqHost, reqPort, nil
+}
+
+// setupHTTPValidation can be used in two ways:
+// 1) To create and setup the initial validation request for a target by
+//    providing a nil req.
+// 2) To mutate an existing HTTP request to use a URL/Host based on resolved IP
+//    addresses.
+// The second is helpful when processing redirect requests.
+func (va *ValidationAuthorityImpl) setupHTTPValidation(
+	ctx context.Context,
+	req *http.Request,
+	target *httpValidationTarget) (*http.Request, core.ValidationRecord, error) {
+	if target == nil {
+		// This is the only case where returning an empty validation record makes
+		// sense - we can't construct a better one, something has gone quite wrong.
+		return nil,
+			core.ValidationRecord{},
+			fmt.Errorf("httpValidationTarget can not be nil")
+	}
+
+	// Construct a base validation record with the target's information.
+	record := core.ValidationRecord{
+		Hostname:          target.host,
+		Port:              strconv.Itoa(target.port),
+		AddressesResolved: target.available,
+	}
+
+	// Build a URL with the target's IP address and port
+	targetIP, err := target.IP()
+	if err != nil {
+		return nil, record, err
+	}
+	record.AddressUsed = *targetIP
+	url := httpValidationURL(*targetIP, target.path, target.port)
+	record.URL = url.String()
+
+	// If there's no provided HTTP request to mutate (e.g. a redirect request
+	// we're following as part of a validation) then construct a new initial HTTP
+	// GET request for the validation.
+	if req == nil {
+		req, err = http.NewRequest("GET", url.String(), nil)
+		if err != nil {
+			return nil, record, err
+		}
+		// Immediately reconstruct the request using the validation context
+		req = req.WithContext(ctx)
+		if va.userAgent != "" {
+			req.Header.Set("User-Agent", va.userAgent)
+		}
+		// Some of our users use mod_security. Mod_security sees a lack of Accept
+		// headers as bot behavior and rejects requests. While this is a bug in
+		// mod_security's rules (given that the HTTP specs disagree with that
+		// requirement), we add the Accept header now in order to fix our
+		// mod_security users' mysterious breakages. See
+		// <https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/265> and
+		// <https://github.com/letsencrypt/boulder/issues/1019>. This was done
+		// because it's a one-line fix with no downside. We're not likely to want to
+		// do many more things to satisfy misunderstandings around HTTP.
+		req.Header.Set("Accept", "*/*")
+	}
+
+	// Override the request's target URL and Host
+	req.URL = url
+	req.Host = target.host
+	return req, record, nil
+}
+
+// fetchHTTPSimple invokes processHTTPValidation and if an error result is
+// returned, converts it to a problem. Otherwise the results from
+// processHTTPValidation are returned.
+func (va *ValidationAuthorityImpl) fetchHTTPSimple(
+	ctx context.Context,
+	host string,
+	path string) ([]byte, []core.ValidationRecord, *probs.ProblemDetails) {
+	body, records, err := va.processHTTPValidation(ctx, host, path)
+	if err != nil {
+		// Use detailedError to convert the error into a problem
+		return body, records, detailedError(err)
+	}
+	return body, records, nil
+}
+
+// processHTTPValidation performs an HTTP validation for the given host, port
+// and path. If successful the body of the HTTP response is returned along with
+// the validation records created during the validation. If not successful
+// a non-nil error and potentially some ValidationRecords are returned.
+func (va *ValidationAuthorityImpl) processHTTPValidation(
+	ctx context.Context,
+	host string,
+	path string) ([]byte, []core.ValidationRecord, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		// Shouldn't happen: All requests should have a deadline by this point.
+		deadline = time.Now().Add(100 * time.Second)
+	} else {
+		// Set the context deadline slightly shorter than the HTTP deadline, so we
+		// get a useful error rather than a generic "deadline exceeded" error. This
+		// lets us give a more specific error to the subscriber.
+		deadline = deadline.Add(-10 * time.Millisecond)
+	}
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	// Create a target for the host, port and path
+	target, err := va.newHTTPValidationTarget(ctx, host, va.httpPort, path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Set up the initial validation request and a base validation record
+	initialReq, baseRecord, err := va.setupHTTPValidation(ctx, nil, target)
+	if err != nil {
+		return nil, []core.ValidationRecord{}, err
+	}
+
+	va.log.AuditInfof("Attempting to validate HTTP-01 for %q with GET to %q",
+		initialReq.Host, initialReq.URL.String())
+
+	// Create a closure around records & numRedirects we can use with a HTTP
+	// client to process redirects per our own policy (e.g. resolving IP
+	// addresses explicitly, not following redirects to ports != [80,443], etc)
+	records := []core.ValidationRecord{baseRecord}
+	numRedirects := 0
+	processRedirect := func(req *http.Request, via []*http.Request) error {
+		va.log.Infof("processing a HTTP redirect from the server to %q\n", req.URL.String())
+		// Only process up to maxRedirect redirects
+		if numRedirects > maxRedirect {
+			return berrors.ConnectionFailureError("Too many redirects")
+		}
+		numRedirects++
+		va.metrics.http01Redirects.Inc()
+
+		// Extract the redirect target's host and port. This will return an error if
+		// the redirect request scheme, host or port is not acceptable.
+		redirHost, redirPort, err := va.extractRequestTarget(req)
+		if err != nil {
+			return err
+		}
+
+		redirPath := req.URL.Path
+		// Setup a validation target for the redirect host. This will resolve IP
+		// addresses for the host explicitly.
+		redirTarget, err := va.newHTTPValidationTarget(ctx, redirHost, redirPort, redirPath)
+		if err != nil {
+			return err
+		}
+
+		// Mutate the existing redirect request to use a URL and Host based on the
+		// explicitly resolved target IPs. This will also give us a validationRecord
+		// for the redirect which we should append to the records.
+		_, redirRecord, err := va.setupHTTPValidation(ctx, req, redirTarget)
+		records = append(records, redirRecord)
+		if err != nil {
+			return err
+		}
+		va.log.Infof("following redirect to host %q url %q\n", req.Host, req.URL.String())
+		return nil
+	}
+
+	// Create a new HTTP client and check HTTP redirects it encounters with
+	// processRedirect
+	client := newHTTPClient()
+	client.CheckRedirect = processRedirect
+
+	// Make the initial validation request. This may result in redirects being
+	// followed.
+	httpResponse, err := client.Do(initialReq)
+	// If there was an error we may need to try a fallback.
+	if err != nil {
+		// Calling To4 on an IPv6 address returns nil and can be used to
+		// differentiate IPv6/IPv4 net.IP instances
+		triedIPv6 := baseRecord.AddressUsed.To4() == nil
+		if !triedIPv6 {
+			// If the base validation record indicates we used an IPv4 address then we
+			// don't have anything to fallback to, return the error immediately.
+			return nil, records, err
+		} else if triedIPv6 && len(target.next) == 0 {
+			// If we did try IPv6 but there isn't another address to try, return the
+			// error immediately.
+			return nil, records, err
+		}
+
+		// Otherwise we tried IPv6 first and it failed, but we have another address
+		// to fallback to, so setup another validation to retry ithe target and
+		// append the retry record.
+		retryReq, retryRecord, err := va.setupHTTPValidation(ctx, nil, target)
+		records = append(records, retryRecord)
+		if err != nil {
+			return nil, records, err
+		}
+		va.metrics.http01Fallbacks.Inc()
+
+		// Perform the retry
+		httpResponse, err = client.Do(retryReq)
+		// If the retry still failed there isn't anything more to do, return the
+		// error immediately.
+		if err != nil {
+			return nil, records, err
+		}
+	}
+
+	// At this point we've made a successful request (be it from a retry or
+	// otherwise) and can read and process the response body.
+	body, err := ioutil.ReadAll(&io.LimitedReader{R: httpResponse.Body, N: maxResponseSize})
+	closeErr := httpResponse.Body.Close()
+	if err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return nil, records, berrors.UnauthorizedError("Error reading HTTP response body: %v", err)
+	}
+	// io.LimitedReader will silently truncate a Reader so if the
+	// resulting payload is the same size as maxResponseSize fail
+	if len(body) >= maxResponseSize {
+		return nil, records, berrors.UnauthorizedError("Invalid response from %s [%s]: %q",
+			records[len(records)-1].URL, records[len(records)-1].AddressUsed, body)
+	}
+	if httpResponse.StatusCode != 200 {
+		return nil, records, berrors.UnauthorizedError("Invalid response from %s [%s]: %d",
+			records[len(records)-1].URL, records[len(records)-1].AddressUsed, httpResponse.StatusCode)
+	}
+	return body, records, nil
+}

--- a/va/http.go
+++ b/va/http.go
@@ -36,7 +36,7 @@ func newHTTPClient() http.Client {
 }
 
 // httpValidationURL constructs a URL for the given IP address, path and port
-// combination. The port is omittied from the URL if it is the default HTTP
+// combination. The port is omitted from the URL if it is the default HTTP
 // port. It is only used for constructing initial HTTP-01 validation requests
 // and so does not need to support constructing a URL with an HTTPS scheme.
 func httpValidationURL(validationIP net.IP, path string, port int) *url.URL {

--- a/va/http.go
+++ b/va/http.go
@@ -46,11 +46,13 @@ func httpValidationURL(validationIP net.IP, path string, port int) *url.URL {
 	// the URL.
 	if port != 80 {
 		urlHost = net.JoinHostPort(validationIP.String(), strconv.Itoa(port))
-	} else if validationIP.To4() == nil {
-		// if the validation IP is an IPv6 address, and we aren't using
-		// `net.JoinHostPort` then we have to manually surround the IPv6 address
-		// with square brackets to make a valid IPv6 URL (e.g "http://[::1]/foo" not
-		// "http://::1/foo")
+	}
+
+	// if the validation IP is an IPv6 address, and we aren't using
+	// `net.JoinHostPort` then we have to manually surround the IPv6 address
+	// with square brackets to make a valid IPv6 URL (e.g "http://[::1]/foo" not
+	// "http://::1/foo")
+	if port == 80 && validationIP.To4() == nil {
 		urlHost = fmt.Sprintf("[%s]", urlHost)
 	}
 

--- a/va/http.go
+++ b/va/http.go
@@ -401,7 +401,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		}
 
 		// Otherwise we tried IPv6 first and it failed, but we have another address
-		// to fallback to, so setup another validation to retry ithe target and
+		// to fallback to, so setup another validation to retry the target and
 		// append the retry record.
 		retryReq, retryRecord, err := va.setupHTTPValidation(ctx, nil, target)
 		records = append(records, retryRecord)

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -20,7 +20,10 @@ import (
 )
 
 func TestNewHTTPClient(t *testing.T) {
-	client := newHTTPClient()
+	dummyRedirHandler := func(_ *http.Request, _ []*http.Request) error {
+		return nil
+	}
+	client := newHTTPClient(dummyRedirHandler)
 
 	// The client should have a HTTP Transport
 	rawTransport := client.Transport

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -152,12 +152,14 @@ func TestHTTPValidationTarget(t *testing.T) {
 				// Calling ip() on the target should give the expected IPs in the right
 				// order.
 				for i, expectedIP := range tc.ExpectedIPs {
-					gotIP, err := target.ip()
-					if err != nil {
-						t.Errorf("Expected IP %d to be %s got err: %v", i, expectedIP, err)
+					gotIP := target.ip()
+					if gotIP == nil {
+						t.Errorf("Expected IP %d to be %s got nil", i, expectedIP)
 					} else {
 						test.AssertEquals(t, gotIP.String(), expectedIP)
 					}
+					// Advance to the next IP
+					_ = target.nextIP()
 				}
 			}
 		})

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -146,10 +146,10 @@ func TestHTTPValidationTarget(t *testing.T) {
 				test.AssertNotEquals(t, target.host, "")
 				test.AssertNotEquals(t, target.port, 0)
 				test.AssertNotEquals(t, target.path, "")
-				// Calling IP() on the target should give the expected IPs in the right
+				// Calling ip() on the target should give the expected IPs in the right
 				// order.
 				for i, expectedIP := range tc.ExpectedIPs {
-					gotIP, err := target.IP()
+					gotIP, err := target.ip()
 					if err != nil {
 						t.Errorf("Expected IP %d to be %s got err: %v", i, expectedIP, err)
 					} else {

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -477,7 +477,12 @@ func TestFallbackErr(t *testing.T) {
 	untypedErr := errors.New("the least interesting kind of error")
 	berr := berrors.InternalServerError("code violet: class neptune")
 	netOpErr := &net.OpError{
+		Op:  "siphon",
 		Err: fmt.Errorf("port was clogged. please empty packets"),
+	}
+	netDialOpErr := &net.OpError{
+		Op:  "dial",
+		Err: fmt.Errorf("your call is important to us - please stay on the line"),
 	}
 	netErr := &testNetErr{}
 
@@ -499,14 +504,17 @@ func TestFallbackErr(t *testing.T) {
 			Err:  berr,
 		},
 		{
-			Name:           "A net.OpError instance",
-			Err:            netOpErr,
+			Name: "A non-dial net.OpError instance",
+			Err:  netOpErr,
+		},
+		{
+			Name:           "A dial net.OpError instance",
+			Err:            netDialOpErr,
 			ExpectFallback: true,
 		},
 		{
-			Name:           "A net.Error instance",
-			Err:            netErr,
-			ExpectFallback: true,
+			Name: "A generic net.Error instance",
+			Err:  netErr,
 		},
 		{
 			Name: "A URL error wrapping a standard error",
@@ -529,18 +537,23 @@ func TestFallbackErr(t *testing.T) {
 			},
 		},
 		{
-			Name: "A URL error wrapping a net OpError",
+			Name: "A URL error wrapping a non-dial net OpError",
 			Err: &url.Error{
 				Err: netOpErr,
+			},
+		},
+		{
+			Name: "A URL error wrapping a dial net.OpError",
+			Err: &url.Error{
+				Err: netDialOpErr,
 			},
 			ExpectFallback: true,
 		},
 		{
-			Name: "A URL error wrapping a net Error",
+			Name: "A URL error wrapping a generic net Error",
 			Err: &url.Error{
 				Err: netErr,
 			},
-			ExpectFallback: true,
 		},
 	}
 

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -1,0 +1,696 @@
+package va
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/letsencrypt/boulder/core"
+	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/probs"
+	"github.com/letsencrypt/boulder/test"
+
+	"testing"
+)
+
+func TestNewHTTPClient(t *testing.T) {
+	client := newHTTPClient()
+
+	// The client should have a HTTP Transport
+	rawTransport := client.Transport
+	if httpTrans, ok := rawTransport.(*http.Transport); !ok {
+		t.Fatalf(
+			"newHTTPClient returned a client with a Transport of the wrong type: "+
+				"%t not http.Transport",
+			rawTransport)
+	} else {
+		// The HTTP Transport should have a TLS config that skips verifying
+		// certificates.
+		test.AssertEquals(t, httpTrans.TLSClientConfig.InsecureSkipVerify, true)
+		// Keep alives should be disabled
+		test.AssertEquals(t, httpTrans.DisableKeepAlives, true)
+		test.AssertEquals(t, httpTrans.MaxIdleConns, 1)
+		test.AssertEquals(t, httpTrans.IdleConnTimeout.String(), "1s")
+		test.AssertEquals(t, httpTrans.TLSHandshakeTimeout.String(), "10s")
+	}
+}
+
+func TestHTTPValidationURL(t *testing.T) {
+	egPath := "/.well-known/.less-known/.obscure"
+	testCases := []struct {
+		Name        string
+		IP          string
+		Path        string
+		Port        int
+		ExpectedURL string
+	}{
+		{
+			Name:        "IPv4 Standard port",
+			IP:          "10.10.10.10",
+			Path:        egPath,
+			Port:        80,
+			ExpectedURL: fmt.Sprintf("http://10.10.10.10%s", egPath),
+		},
+		{
+			Name:        "IPv4 Non-standard port",
+			IP:          "15.15.15.15",
+			Path:        egPath,
+			Port:        8080,
+			ExpectedURL: fmt.Sprintf("http://15.15.15.15:8080%s", egPath),
+		},
+		{
+			Name:        "IPv6 Standard port",
+			IP:          "::1",
+			Path:        egPath,
+			Port:        80,
+			ExpectedURL: fmt.Sprintf("http://[::1]%s", egPath),
+		},
+		{
+			Name:        "IPv6 Non-standard port",
+			IP:          "::1",
+			Path:        egPath,
+			Port:        8080,
+			ExpectedURL: fmt.Sprintf("http://[::1]:8080%s", egPath),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ipAddr := net.ParseIP(tc.IP)
+			if ipAddr == nil {
+				t.Fatalf("Failed to parse test case %q IP %q", tc.Name, tc.IP)
+			}
+			url := httpValidationURL(ipAddr, tc.Path, tc.Port)
+			test.AssertEquals(t, url.String(), tc.ExpectedURL)
+		})
+	}
+}
+
+func TestHTTPValidationTarget(t *testing.T) {
+	// NOTE(@cpu): See `bdns/mocks.go` and the mock `LookupHost` function for the
+	// hostnames used in this test.
+	testCases := []struct {
+		Name          string
+		Host          string
+		ExpectedError error
+		ExpectedIPs   []string
+	}{
+		{
+			Name:          "No IPs for host",
+			Host:          "always.invalid",
+			ExpectedError: berrors.ConnectionFailureError("unknownHost :: No valid IP addresses found for always.invalid"),
+		},
+		{
+			Name:        "Only IPv4 addrs for host",
+			Host:        "some.example.com",
+			ExpectedIPs: []string{"127.0.0.1"},
+		},
+		{
+			Name:        "Only IPv6 addrs for host",
+			Host:        "ipv6.localhost",
+			ExpectedIPs: []string{"::1"},
+		},
+		{
+			Name: "Both IPv6 and IPv4 addrs for host",
+			Host: "ipv4.and.ipv6.localhost",
+			// In this case we expect 1 IPv6 address first, and then 1 IPv4 address
+			ExpectedIPs: []string{"::1", "127.0.0.1"},
+		},
+	}
+
+	const (
+		examplePort = 1234
+		examplePath = "/.well-known/path/i/took"
+	)
+
+	va, _ := setup(nil, 0)
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			target, err := va.newHTTPValidationTarget(
+				context.Background(),
+				tc.Host,
+				examplePort,
+				examplePath)
+			if err != nil && tc.ExpectedError == nil {
+				t.Fatalf("Unexpected error from NewHTTPValidationTarget: %v", err)
+			} else if err != nil && tc.ExpectedError != nil {
+				test.AssertMarshaledEquals(t, err, tc.ExpectedError)
+			} else if err == nil {
+				// The target should be populated.
+				test.AssertNotEquals(t, target.host, "")
+				test.AssertNotEquals(t, target.port, 0)
+				test.AssertNotEquals(t, target.path, "")
+				// Calling IP() on the target should give the expected IPs in the right
+				// order.
+				for i, expectedIP := range tc.ExpectedIPs {
+					gotIP, err := target.IP()
+					if err != nil {
+						t.Errorf("Expected IP %d to be %s got err: %v", i, expectedIP, err)
+					} else {
+						test.AssertEquals(t, gotIP.String(), expectedIP)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExtractRequestTarget(t *testing.T) {
+	mustURL := func(t *testing.T, rawURL string) *url.URL {
+		urlOb, err := url.Parse(rawURL)
+		if err != nil {
+			t.Fatalf("Unable to parse raw URL %q: %v", rawURL, err)
+			return nil
+		}
+		return urlOb
+	}
+
+	testCases := []struct {
+		Name          string
+		Req           *http.Request
+		ExpectedError error
+		ExpectedHost  string
+		ExpectedPort  int
+	}{
+		{
+			Name:          "nil input req",
+			ExpectedError: fmt.Errorf("redirect HTTP request was nil"),
+		},
+		{
+			Name: "invalid protocal scheme",
+			Req: &http.Request{
+				URL: mustURL(t, "gopher://letsencrypt.org"),
+			},
+			ExpectedError: fmt.Errorf("Invalid protocol scheme in redirect target. " +
+				`Only "http" and "https" protocol schemes are supported, ` +
+				`not "gopher"`),
+		},
+		{
+			Name: "invalid explicit port",
+			Req: &http.Request{
+				URL: mustURL(t, "https://weird.port.letsencrypt.org:9999"),
+			},
+			ExpectedError: fmt.Errorf("Invalid port in redirect target. Only ports 80 " +
+				"and 443 are supported, not 9999"),
+		},
+		{
+			Name: "bare IP",
+			Req: &http.Request{
+				URL: mustURL(t, "https://10.10.10.10"),
+			},
+			ExpectedError: fmt.Errorf(`Invalid host in redirect target "10.10.10.10". ` +
+				"Only domain names are supported, not IP addresses"),
+		},
+		{
+			Name: "valid HTTP redirect, explicit port",
+			Req: &http.Request{
+				URL: mustURL(t, "http://cpu.letsencrypt.org:80"),
+			},
+			ExpectedHost: "cpu.letsencrypt.org",
+			ExpectedPort: 80,
+		},
+		{
+			Name: "valid HTTP redirect, implicit port",
+			Req: &http.Request{
+				URL: mustURL(t, "http://cpu.letsencrypt.org"),
+			},
+			ExpectedHost: "cpu.letsencrypt.org",
+			ExpectedPort: 80,
+		},
+		{
+			Name: "valid HTTPS redirect, explicit port",
+			Req: &http.Request{
+				URL: mustURL(t, "https://cpu.letsencrypt.org:443/hello.world"),
+			},
+			ExpectedHost: "cpu.letsencrypt.org",
+			ExpectedPort: 443,
+		},
+		{
+			Name: "valid HTTPS redirect, implicit port",
+			Req: &http.Request{
+				URL: mustURL(t, "https://cpu.letsencrypt.org/hello.world"),
+			},
+			ExpectedHost: "cpu.letsencrypt.org",
+			ExpectedPort: 443,
+		},
+	}
+
+	va, _ := setup(nil, 0)
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			host, port, err := va.extractRequestTarget(tc.Req)
+			if err != nil && tc.ExpectedError == nil {
+				t.Errorf("Expected nil err got %v", err)
+			} else if err != nil && tc.ExpectedError != nil {
+				test.AssertEquals(t, err.Error(), tc.ExpectedError.Error())
+			} else if err == nil && tc.ExpectedError != nil {
+				t.Errorf("Expected err %v, got nil", tc.ExpectedError)
+			} else {
+				test.AssertEquals(t, host, tc.ExpectedHost)
+				test.AssertEquals(t, port, tc.ExpectedPort)
+			}
+		})
+	}
+}
+
+func TestSetupHTTPValidation(t *testing.T) {
+	va, _ := setup(nil, 0)
+
+	mustTarget := func(t *testing.T, host string, port int, path string) *httpValidationTarget {
+		target, err := va.newHTTPValidationTarget(
+			context.Background(),
+			host,
+			port,
+			path)
+		if err != nil {
+			t.Fatalf("Failed to construct httpValidationTarget for %q", host)
+			return nil
+		}
+		return target
+	}
+
+	inputURL, err := url.Parse("http://ipv4.and.ipv6.localhost/yellow/brick/road")
+	if err != nil {
+		t.Fatalf("Failed to construct test inputURL")
+	}
+
+	testCases := []struct {
+		Name                string
+		InputReq            *http.Request
+		InputTarget         *httpValidationTarget
+		ExpectedRequestHost string
+		ExpectedRequestURL  string
+		ExpectedRecord      core.ValidationRecord
+		ExpectedError       error
+	}{
+		{
+			Name:          "nil target",
+			ExpectedError: fmt.Errorf("httpValidationTarget can not be nil"),
+		},
+		{
+			Name: "target with no IPs",
+			InputTarget: &httpValidationTarget{
+				host: "foobar",
+				port: va.httpPort,
+				path: "idk",
+			},
+			// With a broken target no URL is added to the validation record because
+			// there was no IP to construct it with.
+			ExpectedRecord: core.ValidationRecord{
+				Hostname: "foobar",
+				Port:     strconv.Itoa(va.httpPort),
+			},
+			ExpectedError: fmt.Errorf(`host "foobar" has no IP addresses remaining to use`),
+		},
+		{
+			Name:                "nil input req",
+			InputTarget:         mustTarget(t, "example.com", 9999, "/.well-known/stuff"),
+			ExpectedRequestHost: "example.com",
+			ExpectedRequestURL:  "http://127.0.0.1:9999/.well-known/stuff",
+			ExpectedRecord: core.ValidationRecord{
+				Hostname:          "example.com",
+				Port:              "9999",
+				URL:               "http://127.0.0.1:9999/.well-known/stuff",
+				AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+				AddressUsed:       net.ParseIP("127.0.0.1"),
+			},
+		},
+		{
+			Name:        "non-nil input req",
+			InputTarget: mustTarget(t, "ipv4.and.ipv6.localhost", 808, "/yellow/brick/road"),
+			InputReq: &http.Request{
+				URL: inputURL,
+			},
+			ExpectedRequestHost: "ipv4.and.ipv6.localhost",
+			ExpectedRequestURL:  "http://[::1]:808/yellow/brick/road",
+			ExpectedRecord: core.ValidationRecord{
+				Hostname:          "ipv4.and.ipv6.localhost",
+				Port:              "808",
+				URL:               "http://[::1]:808/yellow/brick/road",
+				AddressesResolved: []net.IP{net.ParseIP("::1"), net.ParseIP("127.0.0.1")},
+				AddressUsed:       net.ParseIP("::1"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			outReq, outRecord, err := va.setupHTTPValidation(
+				context.Background(),
+				tc.InputReq,
+				tc.InputTarget)
+
+			if err != nil && tc.ExpectedError == nil {
+				t.Errorf("Expected nil error, got %v", err)
+			} else if err == nil && tc.ExpectedError != nil {
+				t.Errorf("Expected %v error, got nil", tc.ExpectedError)
+			} else if err != nil && tc.ExpectedError != nil {
+				test.AssertEquals(t, err.Error(), tc.ExpectedError.Error())
+			} else {
+				test.AssertEquals(t, outReq.Host, tc.ExpectedRequestHost)
+				test.AssertEquals(t, outReq.URL.String(), tc.ExpectedRequestURL)
+			}
+			// In all cases we expect there to have been a validation record
+			test.AssertMarshaledEquals(t, outRecord, tc.ExpectedRecord)
+			// If the input request was nil then check that the constructed outReq has
+			// the right UA and Accept header values.
+			if tc.InputReq == nil && err == nil {
+				test.AssertEquals(t, outReq.Header.Get("User-Agent"), va.userAgent)
+				test.AssertEquals(t, outReq.Header.Get("Accept"), "*/*")
+			} else if tc.InputReq != nil && err == nil {
+				// Otherwise if there was an input req make sure its URL and Host were
+				// mutated as expected.
+				test.AssertEquals(t, tc.InputReq.Host, tc.ExpectedRequestHost)
+				test.AssertEquals(t, tc.InputReq.URL.String(), tc.ExpectedRequestURL)
+			}
+		})
+	}
+}
+
+// A more concise version of httpSrv() that supports http.go tests
+func httpTestSrv(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+	server := httptest.NewUnstartedServer(mux)
+
+	server.Start()
+	httpPort := getPort(server)
+
+	// A path that always returns an OK response
+	mux.HandleFunc("/ok", func(resp http.ResponseWriter, req *http.Request) {
+		resp.WriteHeader(http.StatusOK)
+		fmt.Fprint(resp, "ok")
+	})
+
+	// A path that always times out by sleeping longer than the validation context
+	// allows
+	mux.HandleFunc("/timeout", func(resp http.ResponseWriter, req *http.Request) {
+		time.Sleep(time.Second)
+		resp.WriteHeader(http.StatusOK)
+		fmt.Fprint(resp, "sorry, I'm a slow server")
+	})
+
+	// A path that always redirects to itself, creating a loop that will terminate
+	// after maxRedirect.
+	mux.HandleFunc("/loop", func(resp http.ResponseWriter, req *http.Request) {
+		http.Redirect(
+			resp,
+			req,
+			fmt.Sprintf("http://example.com:%d/loop", httpPort),
+			301)
+	})
+
+	// A path that always redirects to a URL with a non-HTTP/HTTPs protocol scheme
+	mux.HandleFunc("/redir-bad-proto", func(resp http.ResponseWriter, req *http.Request) {
+		http.Redirect(
+			resp,
+			req,
+			"gopher://example.com",
+			301,
+		)
+	})
+
+	// A path that always redirects to a URL with a port other than the configured
+	// HTTP/HTTPS port
+	mux.HandleFunc("/redir-bad-port", func(resp http.ResponseWriter, req *http.Request) {
+		http.Redirect(
+			resp,
+			req,
+			"https://example.com:1987",
+			301,
+		)
+	})
+
+	// A path that always redirects to a URL with a bare IP address
+	mux.HandleFunc("/redir-bad-host", func(resp http.ResponseWriter, req *http.Request) {
+		http.Redirect(
+			resp,
+			req,
+			"https://127.0.0.1",
+			301,
+		)
+	})
+
+	mux.HandleFunc("/bad-status-code", func(resp http.ResponseWriter, req *http.Request) {
+		resp.WriteHeader(http.StatusGone)
+		fmt.Fprint(resp, "sorry, I'm gone")
+	})
+
+	tooLargeBuf := bytes.NewBuffer([]byte{})
+	for i := 0; i < maxResponseSize+10; i++ {
+		tooLargeBuf.WriteByte(byte(97))
+	}
+	mux.HandleFunc("/resp-too-big", func(resp http.ResponseWriter, req *http.Request) {
+		resp.WriteHeader(http.StatusOK)
+		fmt.Fprint(resp, tooLargeBuf)
+	})
+
+	return server
+}
+
+func TestFetchHTTPSimple(t *testing.T) {
+	// Create a test server
+	testSrv := httpTestSrv(t)
+	defer testSrv.Close()
+
+	// Setup a VA. By providing the testSrv to setup the VA will use the testSrv's
+	// randomly assigned port as its HTTP port.
+	va, _ := setup(testSrv, 0)
+
+	// We need to know the randomly assigned HTTP port for testcases as well
+	httpPort := getPort(testSrv)
+
+	// For the looped test case we expect one validation record per redirect up to
+	// maxRedirect (inclusive). There is also +1 record for the base lookup,
+	// giving a termination criteria of > maxRedirect+1
+	expectedLoopRecords := []core.ValidationRecord{}
+	for i := 0; i <= maxRedirect+1; i++ {
+		expectedLoopRecords = append(expectedLoopRecords,
+			core.ValidationRecord{
+				Hostname:          "example.com",
+				Port:              strconv.Itoa(httpPort),
+				URL:               fmt.Sprintf("http://127.0.0.1:%d/loop", httpPort),
+				AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+				AddressUsed:       net.ParseIP("127.0.0.1"),
+			})
+	}
+
+	expectedTruncatedResp := bytes.NewBuffer([]byte{})
+	for i := 0; i < maxResponseSize; i++ {
+		expectedTruncatedResp.WriteByte(byte(97))
+	}
+
+	testCases := []struct {
+		Name            string
+		Host            string
+		Path            string
+		ExpectedBody    string
+		ExpectedRecords []core.ValidationRecord
+		ExpectedProblem *probs.ProblemDetails
+	}{
+		{
+			Name: "No IPs for host",
+			Host: "always.invalid",
+			Path: "/.well-known/whatever",
+			ExpectedProblem: probs.ConnectionFailure(
+				"unknownHost :: No valid IP addresses found for always.invalid"),
+			// There are no validation records in this case because the base record
+			// is only constructed once a URL is made.
+			ExpectedRecords: nil,
+		},
+		{
+			Name: "Timeout for host",
+			Host: "example.com",
+			Path: "/timeout",
+			ExpectedProblem: probs.ConnectionFailure(
+				"Fetching http://127.0.0.1:%d/timeout: "+
+					"Timeout after connect (your server may be slow or overloaded)", httpPort),
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/timeout", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name: "Redirect loop",
+			Host: "example.com",
+			Path: "/loop",
+			ExpectedProblem: probs.ConnectionFailure(
+				"Fetching http://example.com:%d/loop: Too many redirects", httpPort),
+			ExpectedRecords: expectedLoopRecords,
+		},
+		{
+			Name: "Redirect to bad protocol",
+			Host: "example.com",
+			Path: "/redir-bad-proto",
+			ExpectedProblem: probs.ConnectionFailure(
+				"Fetching gopher://example.com: Invalid protocol scheme in " +
+					`redirect target. Only "http" and "https" protocol schemes ` +
+					`are supported, not "gopher"`),
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/redir-bad-proto", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name: "Redirect to bad port",
+			Host: "example.com",
+			Path: "/redir-bad-port",
+			ExpectedProblem: probs.ConnectionFailure(
+				"Fetching https://example.com:1987: Invalid port in redirect target. "+
+					"Only ports %d and 443 are supported, not 1987", httpPort),
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/redir-bad-port", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name: "Redirect to bad host (bare IP address)",
+			Host: "example.com",
+			Path: "/redir-bad-host",
+			ExpectedProblem: probs.ConnectionFailure(
+				"Fetching https://127.0.0.1: Invalid host in redirect target " +
+					`"127.0.0.1". Only domain names are supported, not IP addresses`),
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/redir-bad-host", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name: "Wrong HTTP status code",
+			Host: "example.com",
+			Path: "/bad-status-code",
+			ExpectedProblem: probs.Unauthorized(
+				"Invalid response from http://127.0.0.1:%d/bad-status-code "+
+					"[127.0.0.1]: 410",
+				httpPort,
+			),
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/bad-status-code", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name: "Response too large",
+			Host: "example.com",
+			Path: "/resp-too-big",
+			ExpectedProblem: probs.Unauthorized(
+				"Invalid response from http://127.0.0.1:%d/resp-too-big "+
+					"[127.0.0.1]: %q", httpPort, expectedTruncatedResp.String(),
+			),
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/resp-too-big", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name: "Broken IPv6 only",
+			Host: "ipv6.localhost",
+			Path: "/ok",
+			ExpectedProblem: probs.ConnectionFailure(
+				"Fetching http://[::1]:%d/ok: Error getting validation data", httpPort,
+			),
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "ipv6.localhost",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://[::1]:%d/ok", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("::1")},
+					AddressUsed:       net.ParseIP("::1"),
+				},
+			},
+		},
+		{
+			Name:         "Dual homed w/ broken IPv6, working IPv4",
+			Host:         "ipv4.and.ipv6.localhost",
+			Path:         "/ok",
+			ExpectedBody: "ok",
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "ipv4.and.ipv6.localhost",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://[::1]:%d/ok", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("::1"), net.ParseIP("127.0.0.1")},
+					// The first validation record should have used the IPv6 addr
+					AddressUsed: net.ParseIP("::1"),
+				},
+				core.ValidationRecord{
+					Hostname:          "ipv4.and.ipv6.localhost",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/ok", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("::1"), net.ParseIP("127.0.0.1")},
+					// The second validation record should have used the IPv4 addr as a fallback
+					AddressUsed: net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name:         "Working IPv4 only",
+			Host:         "example.com",
+			Path:         "/ok",
+			ExpectedBody: "ok",
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               fmt.Sprintf("http://127.0.0.1:%d/ok", httpPort),
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+			defer cancel()
+			body, records, prob := va.fetchHTTPSimple(ctx, tc.Host, tc.Path)
+			if prob != nil && tc.ExpectedProblem == nil {
+				t.Errorf("expected nil prob, got %#v\n", prob)
+			} else if prob == nil && tc.ExpectedProblem != nil {
+				t.Errorf("expected %#v prob, got nil", tc.ExpectedProblem)
+			} else if prob != nil && tc.ExpectedProblem != nil {
+				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
+			} else {
+				test.AssertEquals(t, string(body), tc.ExpectedBody)
+			}
+			// in all cases we expect validation records to be present and matching expected
+			test.AssertMarshaledEquals(t, records, tc.ExpectedRecords)
+		})
+	}
+}


### PR DESCRIPTION
Continued bugs from the custom dialer approach used by the VA for HTTP-01 (most recently https://github.com/letsencrypt/boulder/issues/3889) motivated a rewrite.

Instead of using a custom dialer to be able to control DNS resolution for HTTP validation requests we can construct URLs for the IP addresses we resolve and overload the Host header. This avoids having to do address resolution within the dialer and eliminates the complexity of the dialer `addrInfoChan`. The only thing left for our custom dialer now is to shave some time off of the provided context to help us discern timeouts before/after connect.

The existing IP preference & fallback behaviour is preserved: e.g. if a host has both IPv6 and IPv4 addresses we connect to the first IPv6 address. If there is a network error connecting to that address (e.g. an error during "dial"), we try once more with the first IPv4 address. No other retries are done. Matching existing behaviour no fallback is done for HTTP level failures on an IPv6 address (e.g. mismatched webroots, redirect loops, etc). A new Prometheus counter "http01_fallbacks" is used to keep track of the number of fallbacks performed.

As a result of moving the layer at which the retry happens a fallback like described above will now produce two validation records: one for the initial IPv6 connection, and one for the IPv4 connection. Neither will have the "addressesTried" field populated, just "addressesResolved" and "addressUsed". Previously with the dialer doing the retry we would have created just one validation record with an IPv4 "addressUsed" field and both an IPv6 and IPv4 address in the "addressesTried" field.

Because this is a big diff for a key part of the VA the new code is gated by the `SimplifiedVAHTTP` feature flag.