### PR TITLE
Enable blocking profiles.

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -194,6 +194,8 @@ func newScope(addr string, logger blog.Logger) metrics.Scope {
 	// These handlers are defined in runtime/pprof instead of net/http/pprof, and
 	// have to be accessed through net/http/pprof's Handler func.
 	mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	// Sample an average of one blocking event per second spent blocked (1e9 ns)
+	runtime.SetBlockProfileRate(1e9)
 	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
 	mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
 	mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))


### PR DESCRIPTION
Per https://golang.org/pkg/runtime/#SetBlockProfileRate, to use blocking
profiling we need to set a profile rate. This enables it at once per
second. This might help us debug the problem where Publisher sometimes
stalls on submitting to all logs.