### PR TITLE
Restore missing errcheck

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1116,6 +1116,10 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			returnAuthz = updatedAuthz
 		} else {
 			returnAuthz, err = wfe.RA.UpdateAuthorization(ctx, authz, challengeIndex, challengeUpdate)
+			if err != nil {
+				wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
+				return
+			}
 		}
 	}
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1031,6 +1031,10 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			returnAuthz = updatedAuthz
 		} else {
 			returnAuthz, err = wfe.RA.UpdateAuthorization(ctx, authz, challengeIndex, core.Challenge{})
+			if err != nil {
+				wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
https://github.com/letsencrypt/boulder/commit/8f5de538c17832fede713a131c099cedf550cb8c introduced a regression where an err from the legacy `ra.UpdateAuthorization` RPC wouldn't be caught.