### PR TITLE
VA: Replace invalid UTF-8 in cert contents, proactively marshal.

### DIFF
--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -199,7 +199,7 @@ func pbToValidationRecord(in *corepb.ValidationRecord) (record core.ValidationRe
 	}, nil
 }
 
-func validationResultToPB(records []core.ValidationRecord, prob *probs.ProblemDetails) (*vapb.ValidationResult, error) {
+func ValidationResultToPB(records []core.ValidationRecord, prob *probs.ProblemDetails) (*vapb.ValidationResult, error) {
 	recordAry := make([]*corepb.ValidationRecord, len(records))
 	var err error
 	for i, v := range records {

--- a/grpc/pb-marshalling_test.go
+++ b/grpc/pb-marshalling_test.go
@@ -187,8 +187,8 @@ func TestValidationResult(t *testing.T) {
 	result := []core.ValidationRecord{vrA, vrB}
 	prob := &probs.ProblemDetails{Type: probs.TLSProblem, Detail: "asd", HTTPStatus: 200}
 
-	pb, err := validationResultToPB(result, prob)
-	test.AssertNotError(t, err, "validationResultToPB failed")
+	pb, err := ValidationResultToPB(result, prob)
+	test.AssertNotError(t, err, "ValidationResultToPB failed")
 	test.Assert(t, pb != nil, "Returned vapb.ValidationResult is nil")
 
 	reconResult, reconProb, err := pbToValidationResult(pb)

--- a/grpc/va-wrappers.go
+++ b/grpc/va-wrappers.go
@@ -35,7 +35,7 @@ func (s *ValidationAuthorityGRPCServer) PerformValidation(ctx context.Context, i
 	if !ok && err != nil {
 		return nil, err
 	}
-	return validationResultToPB(records, prob)
+	return ValidationResultToPB(records, prob)
 }
 
 func (s *ValidationAuthorityGRPCServer) IsSafeDomain(ctx context.Context, in *vaPB.IsSafeDomainRequest) (*vaPB.IsDomainSafe, error) {

--- a/va/va.go
+++ b/va/va.go
@@ -1147,12 +1147,9 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 	va.log.Infof("Validations: %+v", authz)
 
 	// Try to marshal the validation results and prob (if any) to protocol
-	// buffers. We do this later in the VA wrapper but we also want to try this
-	// proactively in the VA such that we can log anytime there is a failure to
-	// marshal. This is typically the result of invalid UTF-8 in user supplied
-	// data that we intended to escape with `replaceInvalidUTF8` but may have
-	// missed. In such a case logging explicitly at this layer in addition to
-	// erroring at the RPC layer is preferred.
+	// buffers. We log at this layer instead of leaving it up to gRPC because gRPC
+	// doesn't log the actual contents that failed to marshal, making it hard to
+	// figure out what's broken.
 	if _, err := bgrpc.ValidationResultToPB(records, prob); err != nil {
 		va.log.Errf(
 			"failed to marshal records %#v and prob %#v to protocol buffer: %v",

--- a/va/va.go
+++ b/va/va.go
@@ -1154,9 +1154,9 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 	// missed. In such a case logging explicitly at this layer in addition to
 	// erroring at the RPC layer is preferred.
 	if _, err := bgrpc.ValidationResultToPB(records, prob); err != nil {
-		va.log.AuditErr(fmt.Sprintf(
+		va.log.Errf(
 			"failed to marshal records %#v and prob %#v to protocol buffer: %v",
-			records, prob, err))
+			records, prob, err)
 	}
 
 	if prob == nil {

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -629,6 +629,32 @@ func TestTLSSNI01Invalid(t *testing.T) {
 	}
 }
 
+// TestTLSSNI01BadUTFSrv tests that validating TLS-SNI-01 against
+// a host that returns a certificate with a SAN/CN that contains invalid UTF-8
+// will result in a problem with the invalid UTF-8 replaced.
+func TestTLSSNI01BadUTFSrv(t *testing.T) {
+	chall := createChallenge(core.ChallengeTypeTLSSNI01)
+	hs := tlssniSrvWithNames(t, chall, "localhost", "\xf0\x28\x8c\xbc")
+	port := getPort(hs)
+	va, _ := setup(hs, 0)
+
+	// Construct the zName so we know what to expect in the error message
+	h := sha256.Sum256([]byte(chall.ProvidedKeyAuthorization))
+	z := hex.EncodeToString(h[:])
+	zName := fmt.Sprintf("%s.%s.acme.invalid", z[:32], z[32:])
+
+	_, prob := va.validateTLSSNI01(ctx, dnsi("localhost"), chall)
+	if prob == nil {
+		t.Fatalf("TLS-SNI-01 validation should have failed.")
+	}
+	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)
+	test.AssertEquals(t, prob.Detail, fmt.Sprintf(
+		"Incorrect validation certificate for tls-sni-01 challenge. "+
+			"Requested %s from 127.0.0.1:%d. Received 1 certificate(s), "+
+			`first certificate had names "localhost, %s"`,
+		zName, port, "\ufffd(\ufffd\ufffd"))
+}
+
 func slowTLSSrv() *httptest.Server {
 	server := httptest.NewUnstartedServer(http.DefaultServeMux)
 	server.TLS = &tls.Config{
@@ -837,11 +863,13 @@ func TestCertNames(t *testing.T) {
 		"hello.world", "goodbye.world",
 		"bonjour.le.monde", "au.revoir.le.monde",
 		"bonjour.le.monde", "au.revoir.le.monde",
+		"f\xffoo", "f\xffoo",
 	}
-	// We expect only unique names, in sorted order
+	// We expect only unique names, in sorted order and with any invalid utf-8
+	// replaced.
 	expected := []string{
 		"au.revoir.le.monde", "bonjour.le.monde",
-		"goodbye.world", "hello.world",
+		"f\ufffdoo", "goodbye.world", "hello.world",
 	}
 	template := &x509.Certificate{
 		SerialNumber:          big.NewInt(1337),
@@ -1021,7 +1049,7 @@ func TestValidateTLSALPN01BadChallenge(t *testing.T) {
 }
 
 func TestValidateTLSALPN01BrokenSrv(t *testing.T) {
-	chall := createChallenge(core.ChallengeTypeTLSSNI01)
+	chall := createChallenge(core.ChallengeTypeTLSALPN01)
 	hs := brokenTLSSrv()
 
 	va, _ := setup(hs, 0)
@@ -1034,7 +1062,7 @@ func TestValidateTLSALPN01BrokenSrv(t *testing.T) {
 }
 
 func TestValidateTLSALPN01UnawareSrv(t *testing.T) {
-	chall := createChallenge(core.ChallengeTypeTLSSNI01)
+	chall := createChallenge(core.ChallengeTypeTLSALPN01)
 	hs := tlssniSrvWithNames(t, chall, "localhost")
 
 	va, _ := setup(hs, 0)
@@ -1044,6 +1072,27 @@ func TestValidateTLSALPN01UnawareSrv(t *testing.T) {
 		t.Fatalf("TLS ALPN validation should have failed.")
 	}
 	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)
+}
+
+// TestValidateTLSALPN01BadUTFSrv tests that validating TLS-ALPN-01 against
+// a host that returns a certificate with a SAN/CN that contains invalid UTF-8
+// will result in a problem with the invalid UTF-8 replaced.
+func TestValidateTLSALPN01BadUTFSrv(t *testing.T) {
+	chall := createChallenge(core.ChallengeTypeTLSALPN01)
+	hs := tlsalpn01Srv(t, chall, IdPeAcmeIdentifier, "localhost", "\xf0\x28\x8c\xbc")
+	port := getPort(hs)
+	va, _ := setup(hs, 0)
+
+	_, prob := va.validateTLSALPN01(ctx, dnsi("localhost"), chall)
+	if prob == nil {
+		t.Fatalf("TLS ALPN validation should have failed.")
+	}
+	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)
+	test.AssertEquals(t, prob.Detail, fmt.Sprintf(
+		"Incorrect validation certificate for tls-alpn-01 challenge. "+
+			"Requested localhost from 127.0.0.1:%d. Received 1 certificate(s), "+
+			`first certificate had names "localhost, %s"`,
+		port, "\ufffd(\ufffd\ufffd"))
 }
 
 func TestPerformValidationInvalid(t *testing.T) {


### PR DESCRIPTION
Marshaling invalid UTF-8 strings to protocol buffers causes an error. This can happen in VA `PerformValidation` RPC responses if remote servers return invalid UTF-8 in some ACME challenge contexts. We previously fixed this for HTTP-01 and DNS-01 but missed a case where TLS-ALPN-01/TLS-SNI-01 challenge response certificate content was included in error messages without replacing invalid UTF-8. That's now fixed & unit tests are added.

To aid in diagnosing any future instances the VA is also updated to proactively attempt to marshal its `PerformValidation` results before handing off to the RPC wrappers that will do the same. This way if we detect an error in marshaling the VA can audit log the escaped content for investigation purposes.

Hopefully with these two efforts combined we can avoid any future VA RPC errors from UTF-8 encoding.

Resolves https://github.com/letsencrypt/boulder/issues/3838