### PR TITLE
Log simpler format of WFE errors.

### DIFF
--- a/web/send_error.go
+++ b/web/send_error.go
@@ -29,7 +29,7 @@ func SendError(
 	// Record details to the log event
 	logEvent.Error = fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, prob.Detail)
 	if ierr != nil {
-		logEvent.AddError(fmt.Sprintf("%#v", ierr))
+		logEvent.AddError(fmt.Sprintf("%s", ierr))
 	}
 
 	// Only audit log internal errors so users cannot purposefully cause


### PR DESCRIPTION
In #3452 we refactored error logging a little bit. In the process we
added a %#v format for internal errors. In theory this would help us
debug strange error cases better. In practice the additional type
information is almost always "&errors.BoulderError{" or
"&status.statusError{". The latter includes confusing protobuf-internal
fields like XXX_unrecognized:[]uint8(nil).

Switching to %s should simplify the logged error and make it easier to
get to the core of what's wrong.