### PR TITLE
Add WFE unit tests for RA.UpdateAuthorization/PerformValidation errs.

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -256,6 +256,11 @@ func (sa *StorageAuthority) GetAuthorization(_ context.Context, id string) (core
 		authz.Expires = &exp
 		authz.Challenges[0].URI = "http://localhost:4300/acme/challenge/valid/23"
 		return authz, nil
+	} else if id == "pending" {
+		exp := sa.clk.Now().AddDate(100, 0, 0)
+		authz.Expires = &exp
+		authz.Status = core.StatusPending
+		return authz, nil
 	} else if id == "expired" {
 		exp := sa.clk.Now().AddDate(0, -1, 0)
 		authz.Expires = &exp


### PR DESCRIPTION
Tests for https://github.com/letsencrypt/boulder/commit/77f6b1e396e7aaa0107bea9034b28f4725426c63

We already had a mock that failed `UpdateAuthorization` but we only used it with a test that aborted early because the authz being updated was already valid. I added tests and also updated this mock to fail the new `PerformValidation` equivalent. The feature flag configuring which is used is flipped during the test to ensure failures from both RPCs is handled correctly.

Before applying 77f6b1e396e7aaa0107bea9034b28f4725426c63 the new unit tests would provoke a WFE/WFE2 panic as expected:
```
=== RUN   TestUpdateChallengeRAError
--- FAIL: TestUpdateChallengeRAError (0.01s)
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range

goroutine 23 [running]:
testing.tRunner.func1(0xc000246200)
	/usr/local/go/src/testing/testing.go:792 +0x6a7
panic(0xce5d80, 0x140c0f0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/letsencrypt/boulder/wfe.(*WebFrontEndImpl).postChallenge(0xc000135d88, 0xeaf7c0, 0xc000094010, 0xeaec80, 0xc00001e5c0, 0xc000246000, 0xd9b82b, 0x5, 0xd991a6, 0x3, ...)
	/go/src/github.com/letsencrypt/boulder/wfe/wfe.go:1123 +0x117b
github.com/letsencrypt/boulder/wfe.(*WebFrontEndImpl).Challenge(0xc0000e9d88, 0xeaf7c0, 0xc000094010, 0xc0000e9cd8, 0xeaec80, 0xc00001e5c0, 0xc000246000)
	/go/src/github.com/letsencrypt/boulder/wfe/wfe.go:983 +0xac1
github.com/letsencrypt/boulder/wfe.TestUpdateChallengeRAError(0xc000246200)
	/go/src/github.com/letsencrypt/boulder/wfe/wfe_test.go:1209 +0x33c
testing.tRunner(0xc000246200, 0xde6c50)
	/usr/local/go/src/testing/testing.go:827 +0x163
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:878 +0x651
FAIL	github.com/letsencrypt/boulder/wfe	0.043s
```

After 77f6b1e396e7aaa0107bea9034b28f4725426c63 everything is :green_heart: 