### PR TITLE
Remove unused OCSP Updater Publisher config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -186,7 +186,6 @@ type OCSPUpdaterConfig struct {
 	SignFailureBackoffFactor float64
 	SignFailureBackoffMax    ConfigDuration
 
-	Publisher            *GRPCClientConfig
 	SAService            *GRPCClientConfig
 	OCSPGeneratorService *GRPCClientConfig
 


### PR DESCRIPTION
Since https://github.com/letsencrypt/boulder/commit/3e61513364c8b7add5376aa2160549ed4057bdfd#diff-fd09431b6c4f935692859733688d597f this field of the `OCSPUpdaterConfig` struct has been unused.