### PR TITLE
Remove GRANTS for tables that no longer exist.

### DIFF
--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -35,7 +35,6 @@ GRANT SELECT,INSERT ON certificates TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON certificateStatus TO 'sa'@'localhost';
 GRANT SELECT,INSERT ON issuedNames TO 'sa'@'localhost';
 GRANT SELECT,INSERT ON sctReceipts TO 'sa'@'localhost';
-GRANT INSERT ON ocspResponses TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON registrations TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON challenges TO 'sa'@'localhost';
 GRANT SELECT,INSERT on fqdnSets TO 'sa'@'localhost';
@@ -46,10 +45,8 @@ GRANT SELECT,INSERT,DELETE ON orderFqdnSets TO 'sa'@'localhost';
 
 -- OCSP Responder
 GRANT SELECT ON certificateStatus TO 'ocsp_resp'@'localhost';
-GRANT SELECT ON ocspResponses TO 'ocsp_resp'@'localhost';
 
 -- OCSP Generator Tool (Updater)
-GRANT INSERT ON ocspResponses TO 'ocsp_update'@'localhost';
 GRANT SELECT ON certificates TO 'ocsp_update'@'localhost';
 GRANT SELECT,UPDATE ON certificateStatus TO 'ocsp_update'@'localhost';
 GRANT SELECT ON sctReceipts TO 'ocsp_update'@'localhost';


### PR DESCRIPTION
Fixes instances of errors like:
```
ERROR 1146 (42S02) at line 38: Table 'boulder_sa_test.ocspResponses' doesn't exist
ERROR 1146 (42S02) at line 49: Table 'boulder_sa_test.ocspResponses' doesn't exist
ERROR 1146 (42S02) at line 52: Table 'boulder_sa_test.ocspResponses' doesn't exist
added users to boulder_sa_test
```