### PR TITLE
Set pebble-challtestsrv IP from FAKE_DNS at startup.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.2}:2018-12-11
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.2}:2018-12-13
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -51,7 +51,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.2}:2018-12-11
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.2}:2018-12-13
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -73,7 +73,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.2}:2018-12-11
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.2}:2018-12-13
         networks:
           - bluenet
         volumes:

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -669,21 +669,6 @@ def setup_mock_dns(caa_account_uri=None):
     if caa_account_uri is None:
       caa_account_uri = os.environ.get("ACCOUNT_URI")
 
-    # Set the default IPv4 address for A queries to the FAKE_DNS env var value.
-    fakeDNS = os.environ.get("FAKE_DNS")
-    default_ipv4_url = "{0}/set-default-ipv4".format(challsrv_url_base)
-    urllib2.urlopen(default_ipv4_url,
-            data=json.dumps({
-                "ip": fakeDNS,
-            })).read()
-    # Disable the default IPv6 address so there are no AAAA records. Docker
-    # makes IPv6 annoying.
-    default_ipv6_url = "{0}/set-default-ipv6".format(challsrv_url_base)
-    urllib2.urlopen(default_ipv6_url,
-            data=json.dumps({
-                "ip": "",
-            })).read()
-
     goodCAA = "happy-hacker-ca.invalid"
     badCAA = "sad-hacker-ca.invalid"
 

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -70,6 +70,7 @@ def start(race_detection, fakeclock=None, account_uri=None):
     signal.signal(signal.SIGINT, lambda _, __: stop())
     if not install(race_detection):
         return False
+
     # Processes are in order of dependency: Each process should be started
     # before any services that intend to send it RPCs. On shutdown they will be
     # killed in reverse order.
@@ -97,7 +98,7 @@ def start(race_detection, fakeclock=None, account_uri=None):
         # interface and TLS-ALPN-01 responses on 5001 for another interface. The
         # choice of which is used is controlled by mock DNS data added by the
         # relevant integration tests.
-        [8053, 'pebble-challtestsrv --dns01 :8053,:8054 --management :8055 --http01 :5002 -https01 10.77.77.77:5001 --tlsalpn01 10.88.88.88:5001'],
+        [8053, 'pebble-challtestsrv --defaultIPv4 %s --defaultIPv6 "" --dns01 :8053,:8054 --management :8055 --http01 :5002 -https01 10.77.77.77:5001 --tlsalpn01 10.88.88.88:5001' % os.environ.get("FAKE_DNS")],
         [8004, './bin/boulder-va --config %s --addr va1.boulder:9092 --debug-addr :8004' % os.path.join(default_config_dir, "va.json")],
         [8104, './bin/boulder-va --config %s --addr va2.boulder:9092 --debug-addr :8104' % os.path.join(default_config_dir, "va.json")],
         [8001, './bin/boulder-ca --config %s --ca-addr ca1.boulder:9093 --ocsp-addr ca1.boulder:9096 --debug-addr :8001' % os.path.join(default_config_dir, "ca-a.json")],

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -70,7 +70,6 @@ def start(race_detection, fakeclock=None, account_uri=None):
     signal.signal(signal.SIGINT, lambda _, __: stop())
     if not install(race_detection):
         return False
-
     # Processes are in order of dependency: Each process should be started
     # before any services that intend to send it RPCs. On shutdown they will be
     # killed in reverse order.


### PR DESCRIPTION
`pebble-challtestsrv` added a `-defaultIPv4` arg we can use to simplify
the integration tests and fix FAKE_DNS usage outside of integration
tests.

A new boulder-tools image with an updated `pebble-challtestsrv` is used
and `test/startservers.py` is changed to populate `-defaultIPv4` via the
`FAKE_DNS` env var.

Resolves https://github.com/letsencrypt/boulder/issues/3983