### PR TITLE
VA: Fix SimplifiedVAHTTP01 redirect query param handling.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-13
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-17
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -51,7 +51,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-13
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-17
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -73,7 +73,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-13
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-17
         networks:
           - bluenet
         volumes:

--- a/test/challtestsrv.py
+++ b/test/challtestsrv.py
@@ -1,0 +1,269 @@
+import urllib2
+import json
+
+class ChallTestServer:
+    """
+    ChallTestServer is a wrapper around pebble-challtestsrv's HTTP management
+    API. If the pebble-challtestsrv process you want to interact with is using
+    a -management argument other than the default ('http://localhost:8055') you
+    can instantiate the ChallTestServer using the -management address in use. If
+    no custom address is provided the default is assumed.
+    """
+    _baseURL = "http://localhost:8055"
+
+    _paths = {
+            "set-ipv4": "/set-default-ipv4",
+            "set-ipv6": "/set-default-ipv6",
+            "del-history": "/clear-request-history",
+            "get-http-history": "/http-request-history",
+            "get-dns-history": "/dns-request-history",
+            "get-alpn-history": "/tlsalpn01-request-history",
+            "add-a": "/add-a",
+            "del-a": "/clear-a",
+            "add-aaaa": "/add-aaaa",
+            "del-aaaa": "/clear-aaaa",
+            "add-caa": "/add-caa",
+            "del-caa": "/clear-caa",
+            "add-redirect": "/add-redirect",
+            "del-redirect": "/del-redirect",
+            "add-http": "/add-http01",
+            "del-http": "/del-http01",
+            "add-txt": "/set-txt",
+            "del-txt": "/clear-txt",
+            "add-alpn": "/add-tlsalpn01",
+            "del-alpn": "/del-tlsalpn01",
+            }
+
+    def __init__(self, url=None):
+        if url is not None:
+            self._baseURL = url
+
+    def _postURL(self, url, body):
+        return urllib2.urlopen(
+                url,
+                data=json.dumps(body)).read()
+
+    def _URL(self, path):
+        urlPath = self._paths.get(path, None)
+        if urlPath is None:
+            raise Exception("No challenge test server URL path known for {0}".format(path))
+        return self._baseURL + urlPath
+
+    def _clear_request_history(self, host, typ):
+        return self._postURL(
+                self._URL("del-history"),
+                { "host": host, "type": typ })
+
+    def set_default_ipv4(self, address):
+        """
+        set_default_ipv4 sets the challenge server's default IPv4 address used
+        to respond to A queries when there are no specific mock A addresses for
+        the hostname being queried. Provide an empty string as the default
+        address to disable answering A queries except for hosts that have mock
+        A addresses added.
+        """
+        return self._postURL(
+                self._URL("set-ipv4"),
+                { "ip": address })
+
+    def set_default_ipv6(self, address):
+        """
+        set_default_ipv6 sets the challenge server's default IPv6 address used
+        to respond to AAAA queries when there are no specific mock AAAA
+        addresses for the hostname being queried. Provide an empty string as the
+        default address to disable answering AAAA queries except for hosts that
+        have mock AAAA addresses added.
+        """
+        return self._postURL(
+                self._URL("set-ipv6"),
+                { "ip": address })
+
+    def add_a_record(self, host, addresses):
+        """
+        add_a_record adds a mock A response to the challenge server's DNS
+        interface for the given host and IPv4 addresses.
+        """
+        return self._postURL(
+                self._URL("add-a"),
+                { "host": host, "addresses": addresses })
+
+    def remove_a_record(self, host):
+        """
+        remove_a_record removes a mock A response from the challenge server's DNS
+        interface for the given host.
+        """
+        return self._postURL(
+                self._URL("del-a"),
+                { "host": host })
+
+    def add_aaaa_record(self, host, addresses):
+        """
+        add_aaaa_record adds a mock AAAA response to the challenge server's DNS
+        interface for the given host and IPv6 addresses.
+        """
+        return self._postURL(
+                self._URL("add-aaaa"),
+                { "host": host, "addresses": addresses })
+
+    def remove_aaaa_record(self, host):
+        """
+        remove_aaaa_record removes mock AAAA response form the challenge server's DNS
+        interface for the given host.
+        """
+        return self._postURL(
+                self._URL("del-aaaa"),
+                { "host": host })
+
+    def add_caa_issue(self, host, value):
+        """
+        add_caa_issue adds a mock CAA response to the challenge server's DNS
+        interface. The mock CAA response will contain one policy with an "issue"
+        tag specifying the provided value.
+        """
+        return self._postURL(
+                self._URL("add-caa"),
+                {
+                    "host": host,
+                    "policies": [{ "tag": "issue", "value": value}],
+                })
+
+    def remove_caa_issue(self, host):
+        """
+        remove_caa_issue removes a mock CAA response from the challenge server's
+        DNS interface for the given host.
+        """
+        return self._postURL(
+                self._URL("del-caa"),
+                { "host": host })
+
+    def http_request_history(self, host):
+        """
+        http_request_history fetches the challenge server's HTTP request history for the given host.
+        """
+        return json.loads(self._postURL(
+                self._URL("get-http-history"),
+                { "host": host }))
+
+    def clear_http_request_history(self, host):
+        """
+        clear_http_request_history clears the challenge server's HTTP request history for the given host.
+        """
+        return self._clear_request_history(host, "http")
+
+    def add_http_redirect(self, path, targetURL):
+        """
+        add_http_redirect adds a redirect to the challenge server's HTTP
+        interfaces for HTTP requests to the given path directing the client to
+        the targetURL. Redirects are not served for HTTPS requests.
+        """
+        return self._postURL(
+                self._URL("add-redirect"),
+                { "path": path, "targetURL": targetURL })
+
+    def remove_http_redirect(self, path):
+        """
+        remove_http_redirect removes a redirect from the challenge server's HTTP
+        interfaces for the given path.
+        """
+        return self._postURL(
+                self._URL("del-redirect"),
+                { "path": path })
+
+    def add_http01_response(self, token, keyauth):
+        """
+        add_http01_response adds an ACME HTTP-01 challenge response for the
+        provided token under the /.well-known/acme-challenge/ path of the
+        chalenge test server's HTTP interfaces. The given keyauth will be
+        returned as the HTTP response body for requests to the challenge token.
+        """
+        return self._postURL(
+                self._URL("add-http"),
+                { "token": token, "content": keyauth })
+
+    def remove_http01_response(self, token):
+        """
+        remove_http01_response removes an ACME HTTP-01 challenge response for
+        the provided token from the challenge test server.
+        """
+        return self._postURL(
+                self._URL("del-http"),
+                { "token": token })
+
+    def add_dns01_response(self, host, value):
+        """
+        add_dns01_response adds an ACME DNS-01 challenge response for the
+        provided host to the challenge test server's DNS interfaces. The
+        provided value will be served for TXT queries for
+        _acme-challenge.<host>.
+        """
+        if host.endswith(".") is False:
+            host = host + "."
+        return self._postURL(
+                self._URL("add-txt"),
+                { "host": host, "value": value})
+
+    def remove_dns01_response(self, host):
+        """
+        remove_dns01_response removes an ACME DNS-01 challenge response for the
+        provided host from the challenge test server's DNS interfaces.
+        """
+        return self._postURL(
+                self._URL("del-txt"),
+                { "host": host })
+
+    def dns_request_history(self, host):
+        """
+        dns_request_history returns the history of DNS requests made to the
+        challenge test server's DNS interfaces for the given host.
+        """
+        return json.loads(self._postURL(
+                self._URL("get-dns-history"),
+                { "host": host }))
+
+    def clear_dns_request_history(self, host):
+        """
+        clear_dns_request_history clears the history of DNS requests made to the
+        challenge test server's DNS interfaces for the given host.
+        """
+        return self._clear_request_history(host, "dns")
+
+    def add_tlsalpn01_response(self, host, value):
+        """
+        add_tlsalpn01_response adds an ACME TLS-ALPN-01 challenge response
+        certificate to the challenge test server's TLS-ALPN-01 interface for the
+        given host. The provided key authorization value will be embedded in the
+        response certificate served to clients that initiate a TLS-ALPN-01
+        challenge validation with the challenge test server for the provided
+        host.
+        """
+        return self._postURL(
+                self._URL("add-alpn"),
+                { "host": host, "content": value})
+
+    def remove_tlsalpn01_response(self, host):
+        """
+        remove_tlsalpn01_response removes an ACME TLS-ALPN-01 challenge response
+        certificate from the challenge test server's TLS-ALPN-01 interface for
+        the given host.
+        """
+        return self._postURL(
+                self._URL("del-alpn"),
+                { "host": host })
+
+    def tlsalpn01_request_history(self, host):
+        """
+        tls_alpn01_request_history returns the history of TLS-ALPN-01 requests
+        made to the challenge test server's TLS-ALPN-01 interface for the given
+        host.
+        """
+        return json.loads(self._postURL(
+                self._URL("get-alpn-history"),
+                { "host": host }))
+
+    def clear_tlsalpn01_request_history(self, host):
+        """
+        clear_tlsalpn01_request_history clears the history of TLS-ALPN-01
+        requests made to the challenge test server's TLS-ALPN-01 interface for
+        the given host.
+        """
+        return self._clear_request_history(host, "tlsalpn")

--- a/test/challtestsrv.py
+++ b/test/challtestsrv.py
@@ -107,7 +107,7 @@ class ChallTestServer:
 
     def remove_aaaa_record(self, host):
         """
-        remove_aaaa_record removes mock AAAA response form the challenge server's DNS
+        remove_aaaa_record removes mock AAAA response from the challenge server's DNS
         interface for the given host.
         """
         return self._postURL(
@@ -173,7 +173,7 @@ class ChallTestServer:
         """
         add_http01_response adds an ACME HTTP-01 challenge response for the
         provided token under the /.well-known/acme-challenge/ path of the
-        chalenge test server's HTTP interfaces. The given keyauth will be
+        challenge test server's HTTP interfaces. The given keyauth will be
         returned as the HTTP response body for requests to the challenge token.
         """
         return self._postURL(

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -42,68 +42,8 @@ PORT = os.getenv('PORT', '5002')
 
 os.environ.setdefault('REQUESTS_CA_BUNDLE', 'test/wfe-tls/minica.pem')
 
-# URLs for management interface of challtestsrv
-CHALLSRV_MANAGE = "http://localhost:8055"
-SET_TXT = CHALLSRV_MANAGE + "/set-txt"
-CLEAR_TXT = CHALLSRV_MANAGE + "/clear-txt"
-ADD_ALPN = CHALLSRV_MANAGE + "/add-tlsalpn01"
-DEL_ALPN = CHALLSRV_MANAGE + "/del-tlsalpn01"
-ADD_HTTP01 = CHALLSRV_MANAGE + "/add-http01"
-DEL_HTTP01 = CHALLSRV_MANAGE + "/del-http01"
-ADD_REDIRECT = CHALLSRV_MANAGE + "/add-redirect"
-DEL_REDIRECT = CHALLSRV_MANAGE + "/del-redirect"
-
-def add_http_redirect(path, targetURL):
-    urllib2.urlopen(ADD_REDIRECT,
-            data=json.dumps({
-                "path": path,
-                "targetURL": targetURL,
-            })).read()
-
-def remove_http_redirect(path):
-    urllib2.urlopen(DEL_REDIRECT,
-            data=json.dumps({
-                "path": path,
-            })).read()
-
-def add_http01_response(token, keyauth):
-    urllib2.urlopen(ADD_HTTP01,
-            data=json.dumps({
-                "token": token,
-                "content": keyauth,
-            })).read()
-
-def remove_http01_response(token):
-    urllib2.urlopen(DEL_HTTP01,
-            data=json.dumps({
-                "token": token,
-                })).read()
-
-def add_dns01_response(host, value):
-    urllib2.urlopen(SET_TXT,
-        data=json.dumps({
-            "host": host+ ".",
-            "value": value,
-        })).read()
-
-def remove_dns01_response(host):
-    urllib2.urlopen(CLEAR_TXT,
-        data=json.dumps({
-            "host": host + ".",
-        })).read()
-
-def add_tlsalpn01_response(host, value):
-    urllib2.urlopen(ADD_ALPN,
-        data=json.dumps({
-            "host": host,
-            "content": value,
-        })).read()
-
-def remove_tlslpn01_response(host):
-    urllib2.urlopen(DEL_ALPN,
-        data=json.dumps({
-            "host": host,
-        })).read()
+import challtestsrv
+challSrv = challtestsrv.ChallTestServer()
 
 def uninitialized_client(key=None):
     if key is None:
@@ -186,11 +126,11 @@ def do_dns_challenges(client, authzs):
         name, value = (c.validation_domain_name(a.body.identifier.value),
             c.validation(client.net.key))
         cleanup_hosts.append(name)
-        add_dns01_response(name, value)
+        challSrv.add_dns01_response(name, value)
         client.answer_challenge(c, c.response(client.net.key))
     def cleanup():
         for host in cleanup_hosts:
-            remove_dns01_response(host)
+            challSrv.remove_dns01_response(host)
     return cleanup
 
 def do_http_challenges(client, authzs):
@@ -205,7 +145,7 @@ def do_http_challenges(client, authzs):
 
         # Add the HTTP-01 challenge response for this token/key auth to the
         # challtestsrv
-        add_http01_response(token, keyauth)
+        challSrv.add_http01_response(token, keyauth)
         cleanup_tokens.append(token)
 
         # Then proceed initiating the challenges with the ACME server
@@ -215,7 +155,7 @@ def do_http_challenges(client, authzs):
         # Cleanup requires removing each of the HTTP-01 challenge responses for
         # the tokens we added.
         for token in cleanup_tokens:
-            remove_http01_response(token)
+            challSrv.remove_http01_response(token)
     return cleanup
 
 def do_tlsalpn_challenges(client, authzs):
@@ -224,11 +164,11 @@ def do_tlsalpn_challenges(client, authzs):
         c = get_chall(a, challenges.TLSALPN01)
         name, value = (a.body.identifier.value, c.key_authorization(client.key))
         cleanup_hosts.append(name)
-        add_tlsalpn01_response(name, value)
+        challSrv.add_tlsalpn01_response(name, value)
         client.answer_challenge(c, c.response(client.key))
     def cleanup():
         for host in cleanup_hosts:
-            remove_tlsalpn01_response(host)
+            challSrv.remove_tlsalpn01_response(host)
     return cleanup
 
 def expect_problem(problem_type, func):


### PR DESCRIPTION
When the `SimplifiedVAHTTP01` feature flag is enabled we need to preserve query parameters when reconstructing a redirect URL for the resolved IP address.

To add integration testing for this condition the Boulder tools images are updated to in turn pull in an updated `pebble-challtestsrv` command that tracks request history.

A new Python wrapper for the `pebble-challtestsrv` HTTP API is added to centralize interacting with the chall test srv to add mock data and to get the history of HTTP requests that have been processed.

Resolves https://github.com/letsencrypt/boulder/issues/3968