### PR TITLE
wfe2: Return Status 200 for HEAD to new-nonce endpoint.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogsSimplifiedVAHTTPPerformValidationRPC"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogsSimplifiedVAHTTPPerformValidationRPCHeadNonceStatusOK"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 120, 141, 152, 163, 183, 210, 226, 245, 263, 283, 296, 313, 324, 340, 360}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 120, 141, 152, 163, 183, 210, 226, 245, 263, 283, 296, 313, 324, 340, 360, 377}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -44,6 +44,9 @@ const (
 	// PerformValidationRPC enables the WFE/WFE2 to use the RA's PerformValidation
 	// RPC instead of the deprecated UpdateAuthorization RPC.
 	PerformValidationRPC
+	// HEAD requests to the WFE2 new-nonce endpoint should return HTTP StatusOK
+	// instead of HTTP StatusNoContent.
+	HeadNonceStatusOK
 )
 
 // List of features and their default value, protected by fMu
@@ -70,6 +73,7 @@ var features = map[FeatureFlag]bool{
 	ProbeCTLogs:                 false,
 	SimplifiedVAHTTP:            false,
 	PerformValidationRPC:        false,
+	HeadNonceStatusOK:           false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -39,7 +39,8 @@
       "EnforceV2ContentType": true,
       "RPCHeadroom": true,
       "ACME13KeyRollover": true,
-      "PerformValidationRPC": true
+      "PerformValidationRPC": true,
+      "HeadNonceStatusOK": true
     }
   },
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -424,14 +424,20 @@ func (wfe *WebFrontEndImpl) Directory(
 }
 
 // Nonce is an endpoint for getting a fresh nonce with an HTTP GET or HEAD
-// request. This endpoint only returns a no content header - the `HandleFunc`
+// request. This endpoint only returns a status code header - the `HandleFunc`
 // wrapper ensures that a nonce is written in the correct response header.
 func (wfe *WebFrontEndImpl) Nonce(
 	ctx context.Context,
 	logEvent *web.RequestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
-	response.WriteHeader(http.StatusNoContent)
+	statusCode := http.StatusOK
+	// The ACME specification says GET requets should receive http.StatusNoContent
+	// and HEAD requests should receive http.StatusOK.
+	if request.Method == "GET" {
+		statusCode = http.StatusNoContent
+	}
+	response.WriteHeader(statusCode)
 }
 
 // sendError wraps web.SendError

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -431,11 +431,13 @@ func (wfe *WebFrontEndImpl) Nonce(
 	logEvent *web.RequestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
-	statusCode := http.StatusOK
+	statusCode := http.StatusNoContent
 	// The ACME specification says GET requets should receive http.StatusNoContent
-	// and HEAD requests should receive http.StatusOK.
-	if request.Method == "GET" {
-		statusCode = http.StatusNoContent
+	// and HEAD requests should receive http.StatusOK. We gate this with the
+	// HeadNonceStatusOK feature flag because it may break clients that are
+	// programmed to expect StatusOK.
+	if features.Enabled(features.HeadNonceStatusOK) && request.Method == "HEAD" {
+		statusCode = http.StatusOK
 	}
 	response.WriteHeader(statusCode)
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -825,46 +825,56 @@ func TestRelativeDirectory(t *testing.T) {
 	}
 }
 
-// TestNonceEndpointGET tests GET requests to the WFE2's new-nonce endpoint
+// TestNonceEndpoint tests requests to the WFE2's new-nonce endpoint
 func TestNonceEndpointGET(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 
-	responseWriter := httptest.NewRecorder()
+	testCases := []struct {
+		Name              string
+		Method            string
+		ExpectedStatus    int
+		HeadNonceStatusOK bool
+	}{
+		{
+			Name:           "GET new-nonce request",
+			Method:         "GET",
+			ExpectedStatus: http.StatusNoContent,
+		},
+		{
+			Name:           "HEAD new-nonce request (legacy)",
+			Method:         "HEAD",
+			ExpectedStatus: http.StatusNoContent,
+		},
+		{
+			Name:              "HEAD new-nonce request (feature flag)",
+			Method:            "HEAD",
+			ExpectedStatus:    http.StatusOK,
+			HeadNonceStatusOK: true,
+		},
+	}
 
-	mux.ServeHTTP(responseWriter, &http.Request{
-		Method: "GET",
-		URL:    mustParseURL(newNoncePath),
-	})
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if tc.HeadNonceStatusOK {
+				if err := features.Set(map[string]bool{"HeadNonceStatusOK": true}); err != nil {
+					t.Fatalf("Failed to enable HeadNonceStatusOK feature: %v", err)
+				}
+				defer features.Reset()
+			}
 
-	// Sending a GET request to the nonce endpoint should produce a HTTP response
-	// with the correct status code. Unlike HEAD requests we expect GET requests
-	// to receive status 204 in response.
-	test.AssertEquals(t, responseWriter.Code, http.StatusNoContent)
-	// And the response should contain a valid nonce in the Replay-Nonce header
-	nonce := responseWriter.Header().Get("Replay-Nonce")
-	test.AssertEquals(t, wfe.nonceService.Valid(nonce), true)
-}
-
-// TestNonceEndpointHEAD tests HEAD requests to the WFE2's new-nonce endpoint
-func TestNonceEndpointHEAD(t *testing.T) {
-	wfe, _ := setupWFE(t)
-	mux := wfe.Handler()
-
-	responseWriter := httptest.NewRecorder()
-
-	mux.ServeHTTP(responseWriter, &http.Request{
-		Method: "HEAD",
-		URL:    mustParseURL(newNoncePath),
-	})
-
-	// Sending a HEAD request to the nonce endpoint should produce a HTTP response
-	// with the correct status code. Unlike GET requests we expect HEAD requests
-	// to receive status 200 in response.
-	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
-	// And the response should contain a valid nonce in the Replay-Nonce header
-	nonce := responseWriter.Header().Get("Replay-Nonce")
-	test.AssertEquals(t, wfe.nonceService.Valid(nonce), true)
+			responseWriter := httptest.NewRecorder()
+			mux.ServeHTTP(responseWriter, &http.Request{
+				Method: tc.Method,
+				URL:    mustParseURL(newNoncePath),
+			})
+			// The response should have the expected HTTP status code
+			test.AssertEquals(t, responseWriter.Code, tc.ExpectedStatus)
+			// And the response should contain a valid nonce in the Replay-Nonce header
+			nonce := responseWriter.Header().Get("Replay-Nonce")
+			test.AssertEquals(t, wfe.nonceService.Valid(nonce), true)
+		})
+	}
 }
 
 func TestHTTPMethods(t *testing.T) {


### PR DESCRIPTION
Previously we mistakenly returned status 204 (no content) for all
requests to new-nonce, including HEAD. This status should only be used
for GET requests.

Resolves https://github.com/letsencrypt/boulder/issues/3989