### PR TITLE
 CI/Dev: Update Go 1.11.3 -> 1.11.4, update challtestsrv.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11.3"
+  - "1.11.4"
   - "1.10.6"
 
 go_import_path: github.com/letsencrypt/boulder

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -223,8 +223,8 @@
 		},
 		{
 			"ImportPath": "github.com/letsencrypt/challtestsrv",
-			"Comment": "v1.0.0",
-			"Rev": "495441a8880035dedbee2b7286e805deda093260"
+			"Comment": "v1.0.2",
+			"Rev": "37390bc3ad8f92bd8a94e367ee0f07060a841c3c"
 		},
 		{
 			"ImportPath": "github.com/letsencrypt/pkcs11key",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-17
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.4}:2019-01-09
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -51,7 +51,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-17
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.4}:2019-01-09
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -73,7 +73,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.3}:2018-12-17
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.4}:2019-01-09
         networks:
           - bluenet
         volumes:

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.10.6" "1.11.3" )
+GO_VERSIONS=( "1.10.6" "1.11.4" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"

--- a/vendor/github.com/letsencrypt/challtestsrv/README.md
+++ b/vendor/github.com/letsencrypt/challtestsrv/README.md
@@ -50,6 +50,18 @@ value `"bbb"`, defer cleaning it up again:
   defer challSrv.DeleteHTTPOneChallenge("_acme-challenge.example.com.")
 ```
 
+Get the history of HTTP requests processed by the challenge server for the host
+"example.com":
+```
+requestHistory := challSrv.RequestHistory("example.com", challtestsrv.HTTPRequestEventType)
+```
+
+Clear the history of HTTP requests processed by the challenge server for the
+host "example.com":
+```
+challSrv.ClearRequestHistory("example.com", challtestsrv.HTTPRequestEventType)
+```
+
 Stop the Challenge server and subservers:
 ```
   // Shutdown the Challenge server

--- a/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
@@ -35,6 +35,10 @@ type ChallSrv struct {
 	// response data maps below.
 	challMu sync.RWMutex
 
+	// requestHistory is a map from hostname to a map of event type to a list of
+	// sequential request events
+	requestHistory map[string]map[RequestEventType][]RequestEvent
+
 	// httpOne is a map of token values to key authorizations used for HTTP-01
 	// responses.
 	httpOne map[string]string
@@ -56,7 +60,7 @@ type ChallSrv struct {
 	redirects map[string]string
 }
 
-// mockDNSData holds mock respones for DNS A, AAAA, and CAA lookups.
+// mockDNSData holds mock responses for DNS A, AAAA, and CAA lookups.
 type mockDNSData struct {
 	// The IPv4 address used for all A record responses that don't match a host in
 	// aRecords.
@@ -64,7 +68,7 @@ type mockDNSData struct {
 	// The IPv6 address used for all AAAA record responses that don't match a host
 	// in aaaaRecords.
 	defaultIPv6 string
-	// A map of host to IPv4 addressess in string form for A record responses.
+	// A map of host to IPv4 addresses in string form for A record responses.
 	aRecords map[string][]string
 	// A map of host to IPv6 addresses in string form for AAAA record responses.
 	aaaaRecords map[string][]string
@@ -120,11 +124,12 @@ func New(config Config) (*ChallSrv, error) {
 	}
 
 	challSrv := &ChallSrv{
-		log:        config.Log,
-		httpOne:    make(map[string]string),
-		dnsOne:     make(map[string][]string),
-		tlsALPNOne: make(map[string]string),
-		redirects:  make(map[string]string),
+		log:            config.Log,
+		requestHistory: make(map[string]map[RequestEventType][]RequestEvent),
+		httpOne:        make(map[string]string),
+		dnsOne:         make(map[string][]string),
+		tlsALPNOne:     make(map[string]string),
+		redirects:      make(map[string]string),
 		dnsMocks: mockDNSData{
 			defaultIPv4: defaultIPv4,
 			defaultIPv6: defaultIPv6,

--- a/vendor/github.com/letsencrypt/challtestsrv/event.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/event.go
@@ -1,0 +1,133 @@
+package challtestsrv
+
+import (
+	"net"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// RequestEventType indicates what type of event occurred.
+type RequestEventType int
+
+const (
+	// HTTP requests
+	HTTPRequestEventType RequestEventType = iota
+	// DNS requests
+	DNSRequestEventType
+	// TLS-ALPN-01 requests
+	TLSALPNRequestEventType
+)
+
+// A RequestEvent is anything that can identify its RequestEventType and a key
+// for storing the request event in the history.
+type RequestEvent interface {
+	Type() RequestEventType
+	Key() string
+}
+
+// HTTPRequestEvent corresponds to an HTTP request received by a httpOneServer.
+// It implements the RequestEvent interface.
+type HTTPRequestEvent struct {
+	// The full request URL (path and query arguments)
+	URL string
+	// The Host header from the request
+	Host string
+	// Whether the request was received over HTTPS or HTTP
+	HTTPS bool
+	// The ServerName from the ClientHello. May be empty if there was no SNI or if
+	// the request was not HTTPS
+	ServerName string
+}
+
+// HTTPRequestEvents always have type HTTPRequestEventType
+func (e HTTPRequestEvent) Type() RequestEventType {
+	return HTTPRequestEventType
+}
+
+// HTTPRequestEvents use the HTTP Host as the storage key. Any explicit port
+// will be removed.
+func (e HTTPRequestEvent) Key() string {
+	if h, _, err := net.SplitHostPort(e.Host); err == nil {
+		return h
+	}
+	return e.Host
+}
+
+// DNSRequestEvent corresponds to a DNS request received by a dnsOneServer. It
+// implements the RequestEvent interface.
+type DNSRequestEvent struct {
+	// The DNS question received.
+	Question dns.Question
+}
+
+// DNSRequestEvents always have type DNSRequestEventType
+func (e DNSRequestEvent) Type() RequestEventType {
+	return DNSRequestEventType
+}
+
+// DNSRequestEvents use the Question Name as the storage key. Any trailing `.`
+// in the question name is removed.
+func (e DNSRequestEvent) Key() string {
+	key := e.Question.Name
+	if strings.HasSuffix(key, ".") {
+		key = strings.TrimSuffix(key, ".")
+	}
+	return key
+}
+
+// TLSALPNRequestEvent corresponds to a TLS request received by
+// a tlsALPNOneServer. It implements the RequestEvent interface.
+type TLSALPNRequestEvent struct {
+	// ServerName from the TLS Client Hello.
+	ServerName string
+	// SupportedProtos from the TLS Client Hello.
+	SupportedProtos []string
+}
+
+// TLSALPNRequestEvents always have type TLSALPNRequestEventType
+func (e TLSALPNRequestEvent) Type() RequestEventType {
+	return TLSALPNRequestEventType
+}
+
+// TLSALPNRequestEvents use the SNI value as the storage key
+func (e TLSALPNRequestEvent) Key() string {
+	return e.ServerName
+}
+
+// AddRequestEvent adds a RequestEvent to the server's request history. It is
+// appeneded to a list of RequestEvents indexed by the event's Type().
+func (s *ChallSrv) AddRequestEvent(event RequestEvent) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+
+	typ := event.Type()
+	host := event.Key()
+	if s.requestHistory[host] == nil {
+		s.requestHistory[host] = make(map[RequestEventType][]RequestEvent)
+	}
+	s.requestHistory[host][typ] = append(s.requestHistory[host][typ], event)
+}
+
+// RequestHistory returns the server's request history for the given hostname
+// and event type.
+func (s *ChallSrv) RequestHistory(hostname string, typ RequestEventType) []RequestEvent {
+	s.challMu.RLock()
+	defer s.challMu.RUnlock()
+
+	if hostEvents, ok := s.requestHistory[hostname]; ok {
+		return hostEvents[typ]
+	}
+	return []RequestEvent{}
+}
+
+// ClearRequestHistory clears the server's request history for the given
+// hostname and event type.
+func (s *ChallSrv) ClearRequestHistory(hostname string, typ RequestEventType) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+
+	if hostEvents, ok := s.requestHistory[hostname]; ok {
+		hostEvents[typ] = []RequestEvent{}
+	}
+}

--- a/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
@@ -1,7 +1,7 @@
 package challtestsrv
 
 import (
-	"strings"
+	"github.com/miekg/dns"
 )
 
 // SetDefaultDNSIPv4 sets the default IPv4 address used for A query responses
@@ -43,9 +43,7 @@ func (s *ChallSrv) GetDefaultDNSIPv6() string {
 func (s *ChallSrv) AddDNSARecord(host string, addresses []string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.aRecords[host] = append(s.dnsMocks.aRecords[host], addresses...)
 }
 
@@ -54,9 +52,7 @@ func (s *ChallSrv) AddDNSARecord(host string, addresses []string) {
 func (s *ChallSrv) DeleteDNSARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.aRecords, host)
 }
 
@@ -64,9 +60,7 @@ func (s *ChallSrv) DeleteDNSARecord(host string) {
 // returned when querying for A records for the given host.
 func (s *ChallSrv) GetDNSARecord(host string) []string {
 	s.challMu.RLock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	defer s.challMu.RUnlock()
 	return s.dnsMocks.aRecords[host]
 }
@@ -76,9 +70,7 @@ func (s *ChallSrv) GetDNSARecord(host string) []string {
 func (s *ChallSrv) AddDNSAAAARecord(host string, addresses []string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.aaaaRecords[host] = append(s.dnsMocks.aaaaRecords[host], addresses...)
 }
 
@@ -87,9 +79,7 @@ func (s *ChallSrv) AddDNSAAAARecord(host string, addresses []string) {
 func (s *ChallSrv) DeleteDNSAAAARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.aaaaRecords, host)
 }
 
@@ -98,9 +88,7 @@ func (s *ChallSrv) DeleteDNSAAAARecord(host string) {
 func (s *ChallSrv) GetDNSAAAARecord(host string) []string {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	return s.dnsMocks.aaaaRecords[host]
 }
 
@@ -109,9 +97,7 @@ func (s *ChallSrv) GetDNSAAAARecord(host string) []string {
 func (s *ChallSrv) AddDNSCAARecord(host string, policies []MockCAAPolicy) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.caaRecords[host] = append(s.dnsMocks.caaRecords[host], policies...)
 }
 
@@ -120,9 +106,7 @@ func (s *ChallSrv) AddDNSCAARecord(host string, policies []MockCAAPolicy) {
 func (s *ChallSrv) DeleteDNSCAARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.caaRecords, host)
 }
 
@@ -131,8 +115,6 @@ func (s *ChallSrv) DeleteDNSCAARecord(host string) {
 func (s *ChallSrv) GetDNSCAARecord(host string) []MockCAAPolicy {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	return s.dnsMocks.caaRecords[host]
 }

--- a/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
@@ -50,6 +50,10 @@ func (s *ChallSrv) GetTLSALPNChallenge(host string) (string, bool) {
 
 func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		s.AddRequestEvent(TLSALPNRequestEvent{
+			ServerName:      hello.ServerName,
+			SupportedProtos: hello.SupportedProtos,
+		})
 		if len(hello.SupportedProtos) != 1 || hello.SupportedProtos[0] != ACMETLS1Protocol {
 			return nil, fmt.Errorf(
 				"ALPN failed, ClientHelloInfo.SupportedProtos: %s",


### PR DESCRIPTION
1. Updates both boulder tools images to use an update `pebble-challtestsrv`
2. Updates the Go 1.11.3 boulder tools image to Go 1.11.4
3. Updates the vendored `challtestsrv` dep to 1.0.2

This fixes a panic in the `challtestsrv` library and prepares us to move directly 
to 1.11.4 after we've resolved the outstanding issues keeping us on the 1.10.x 
stream in prod/staging.

There are no unit tests to run for item 3.

