### PR TITLE
Shrink byte size of WFE request logs.

### DIFF
--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -36,7 +36,7 @@
   },
 
   "syslog": {
-    "stdoutlevel": 4,
+    "stdoutlevel": 6,
     "sysloglevel": 4
   },
 

--- a/web/context.go
+++ b/web/context.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -12,19 +13,33 @@ import (
 )
 
 type RequestEvent struct {
-	RealIP         string    `json:",omitempty"`
-	Endpoint       string    `json:",omitempty"`
-	Slug           string    `json:",omitempty"`
-	Method         string    `json:",omitempty"`
-	InternalErrors []string  `json:",omitempty"`
-	Error          string    `json:",omitempty"`
-	Requester      int64     `json:",omitempty"`
-	Contacts       *[]string `json:",omitempty"`
-	UserAgent      string    `json:",omitempty"`
-	Latency        float64
-	Code           int
+	// These fields are not rendered in JSON; instead, they are rendered
+	// whitespace-separated ahead of the JSON. This saves bytes in the logs since
+	// we don't have to include field names, quotes, or commas -- all of these
+	// fields are known to not include whitespace.
+	Method    string  `json:"-,omitempty"`
+	Endpoint  string  `json:"-,omitempty"`
+	Requester int64   `json:"-,omitempty"`
+	Code      int     `json:"-,omitempty"`
+	Latency   float64 `json:"-,omitempty"`
+	RealIP    string  `json:"-,omitempty"`
+
+	Slug           string                 `json:",omitempty"`
+	InternalErrors []string               `json:",omitempty"`
+	Error          string                 `json:",omitempty"`
+	Contacts       *[]string              `json:",omitempty"`
+	UserAgent      string                 `json:"ua,omitempty"`
 	Payload        string                 `json:",omitempty"`
 	Extra          map[string]interface{} `json:",omitempty"`
+
+	// For challenge and authorization GETs and POSTs:
+	// the status of the authorization at the time the request began.
+	Status string `json:",omitempty"`
+	// The DNS name, if applicable
+	DNSName string `json:",omitempty"`
+
+	// For challenge POSTs, the challenge type.
+	ChallengeType string `json:",omitempty"`
 }
 
 func (e *RequestEvent) AddError(msg string, args ...interface{}) {
@@ -68,8 +83,14 @@ func (r *responseWriterWithStatus) WriteHeader(code int) {
 }
 
 func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check that this header is well-formed, since we assume it is when logging.
+	realIP := r.Header.Get("X-Real-IP")
+	if net.ParseIP(realIP) == nil {
+		realIP = "0.0.0.0"
+	}
+
 	logEvent := &RequestEvent{
-		RealIP:    r.Header.Get("X-Real-IP"),
+		RealIP:    realIP,
 		Method:    r.Method,
 		UserAgent: r.Header.Get("User-Agent"),
 		Extra:     make(map[string]interface{}, 0),
@@ -79,7 +100,7 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rwws := &responseWriterWithStatus{w, 0}
 	defer func() {
 		logEvent.Code = rwws.code
-		logEvent.Latency = time.Since(begin).Round(time.Millisecond).Seconds()
+		logEvent.Latency = time.Since(begin).Seconds()
 		th.logEvent(logEvent)
 	}()
 	th.wfe.ServeHTTP(logEvent, rwws, r)
@@ -92,7 +113,9 @@ func (th *TopHandler) logEvent(logEvent *RequestEvent) {
 		th.log.AuditErrf("failed to marshal logEvent - %s - %#v", msg, err)
 		return
 	}
-	th.log.Infof("JSON=%s", jsonEvent)
+	th.log.Infof("%s %s %d %d %d %s JSON=%s",
+		logEvent.Method, logEvent.Endpoint, logEvent.Requester, logEvent.Code,
+		int(logEvent.Latency*1000), logEvent.RealIP, jsonEvent)
 }
 
 // Comma-separated list of HTTP clients involved in making this


### PR DESCRIPTION
Note: This does not yet pass tests. Posting for feedback on the general approach while I fix tests.

- Log the simple, non-whitespace-containing fields as positional
parameters to avoid the JSON overhead for them.
- Log latency in milliseconds rather than seconds (saves "0.").
- Hoist some fields from the "Extra" sub-object and give
  them shorter names. This saves the bytes for rendering the "Extra"
  field plus the bytes for the longer names.

Example output from integration tests:

Before (1687 bytes):

I205230 boulder-wfe JSON={"Endpoint":"/directory","Method":"GET","UserAgent":"Boulder integration tester","Latency":0.001,"Code":0}
I205230 boulder-wfe JSON={"Endpoint":"/acme/new-reg","Method":"HEAD","Error":"405 :: malformed :: Method not allowed","UserAgent":"Boulder integration tester","Latency":0,"Code":405}
I205230 boulder-wfe JSON={"Endpoint":"/acme/new-reg","Method":"POST","Requester":611,"Contacts":[],"UserAgent":"Boulder integration tester","Latency":0.025,"Code":201,"Payload":"{\n  \"resource\": \"new-reg\"\n}"}
I205230 boulder-wfe JSON={"Endpoint":"/acme/reg/","Slug":"611","Method":"POST","Requester":611,"Contacts":[],"UserAgent":"Boulder integration tester","Latency":0.021,"Code":202,"Payload":"{\n  \"status\": \"valid\", \n  \"resource\": \"reg\", \n  \"agreement\": \"http://boulder:4000/terms/v1\", \n  \"key\": {\n    \"e\": \"AQAB\", \n    \"kty\": \"RSA\", \n    \"n\": \"r1zCJC8Muw5K8ti-pjojivHxyNxOZye-N5aX_i7kBiHrAOp9qxgQUHUyU3COCjFPrSzScTpKoIyCwdL7x-1mPX3pby7CzGugtY9da_LZkDmsDE8LIuQkZ_wRLyh1103OQZEd71AlddMx1iwLLVl4UTICoJFUfYvXHvkqmsE5xhBPJhl-SdSrJM6F7Kn7k0WycA5ig_QPbjVbzJlQq-C65iGDJtc_LvY0FFF4exThZM7xsvucJywJMHCEWZUktm9YB-CBNA1gVbL52u22jQpX-MN52UVdqSh9ZipoJLtxKjZx31DHB_bcdgtJ8YGIE4lY_ZAax1Ut-a5WTJvVq2Hk8w\"\n  }\n}"}
I205230 boulder-wfe JSON={"Endpoint":"/acme/new-authz","Method":"POST","Requester":611,"Contacts":[],"UserAgent":"Boulder integration tester","Latency":0.031,"Code":201,"Payload":"{\n  \"identifier\": {\n    \"type\": \"dns\", \n    \"value\": \"rand.18fe4d73.xyz\"\n  }, \n  \"resource\": \"new-authz\"\n}","Extra":{"AuthzID":"PgF1JQ3TK6c1FR0wVdm_mYows_xWSsyYgyezSvSNI-0","Identifier":{"type":"dns","value":"rand.18fe4d73.xyz"}}}

After (1406 bytes):

I210117 boulder-wfe GET /directory 0 0 0 0.0.0.0 JSON={"ua":"Boulder integration tester"}
I210117 boulder-wfe HEAD /acme/new-reg 0 405 0 0.0.0.0 JSON={"Error":"405 :: malformed :: Method not allowed","ua":"Boulder integration tester"}
I210117 boulder-wfe POST /acme/new-reg 676 201 23 0.0.0.0 JSON={"Contacts":[],"ua":"Boulder integration tester","Payload":"{\n  \"resource\": \"new-reg\"\n}"}
I210117 boulder-wfe POST /acme/reg/ 676 202 23 0.0.0.0 JSON={"Slug":"676","Contacts":[],"ua":"Boulder integration tester","Payload":"{\n  \"status\": \"valid\", \n  \"resource\": \"reg\", \n  \"agreement\": \"http://boulder:4000/terms/v1\", \n  \"key\": {\n    \"e\": \"AQAB\", \n    \"kty\": \"RSA\", \n    \"n\": \"zXSFAzdzwwFGjNysmG0YE7MxAwQ8JkkvLQ7Qs7xB1h5kFM_F-W2jxYEmrRTrA0ylfuzb4RQMBrsLfv0XV8rsDIuP_t92ADBjfd25ajuuia9EGrhpHitFimEUlZjsqGQp8F49xLhDMAqm1SLBY_k1pY8TKSLHeyOyLYIKLaL3Ra9yZ63qB65oGuNhXroKqqx7nUjyZtqtUV5NUPvPgvhJgXgYKMjck3jXWgr4ZGqYyJQqNqydYSk3uJGfruChakZThwl3vbH8aUPaeoXcvPA8KaQl56JUf7jAVY3n9qKKb5mgT96vDKWUpJaI5YE1rMZIJfkaFK-ZZIhFeeKCSsSJlQ\"\n  }\n}"}
I210117 boulder-wfe POST /acme/new-authz 676 201 35 0.0.0.0 JSON={"Contacts":[],"ua":"Boulder integration tester","Payload":"{\n  \"identifier\": {\n    \"type\": \"dns\", \n    \"value\": \"rand.14ebdfd1.xyz\"\n  }, \n  \"resource\": \"new-authz\"\n}","Created":"Z-soxIEhsGlMK3GYyDqYrSlxDFEeH6q3mrd6aoi2iIs","DNSName":"rand.14ebdfd1.xyz"}