### PR TITLE
Modify authorization creation to allow for new style storage schema

### DIFF
--- a/core/challenges.go
+++ b/core/challenges.go
@@ -11,22 +11,26 @@ func newChallenge(challengeType string, token string) Challenge {
 	}
 }
 
-// HTTPChallenge01 constructs a random http-01 challenge
+// HTTPChallenge01 constructs a random http-01 challenge. If token is empty a random token
+// will be generated, otherwise the provided token is used.
 func HTTPChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeHTTP01, token)
 }
 
-// TLSSNIChallenge01 constructs a random tls-sni-01 challenge
+// TLSSNIChallenge01 constructs a random tls-sni-01 challenge. If token is empty a random token
+// will be generated, otherwise the provided token is used.
 func TLSSNIChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeTLSSNI01, token)
 }
 
-// DNSChallenge01 constructs a random dns-01 challenge
+// DNSChallenge01 constructs a random dns-01 challenge. If token is empty a random token
+// will be generated, otherwise the provided token is used.
 func DNSChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeDNS01, token)
 }
 
-// TLSALPNChallenge01 constructs a random tls-alpn-01 challenge
+// TLSALPNChallenge01 constructs a random tls-alpn-01 challenge. If token is empty a random token
+// will be generated, otherwise the provided token is used.
 func TLSALPNChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeTLSALPN01, token)
 }

--- a/core/challenges.go
+++ b/core/challenges.go
@@ -1,29 +1,32 @@
 package core
 
-func newChallenge(challengeType string) Challenge {
+func newChallenge(challengeType string, token string) Challenge {
+	if token == "" {
+		token = NewToken()
+	}
 	return Challenge{
 		Type:   challengeType,
 		Status: StatusPending,
-		Token:  NewToken(),
+		Token:  token,
 	}
 }
 
 // HTTPChallenge01 constructs a random http-01 challenge
-func HTTPChallenge01() Challenge {
-	return newChallenge(ChallengeTypeHTTP01)
+func HTTPChallenge01(token string) Challenge {
+	return newChallenge(ChallengeTypeHTTP01, token)
 }
 
 // TLSSNIChallenge01 constructs a random tls-sni-01 challenge
-func TLSSNIChallenge01() Challenge {
-	return newChallenge(ChallengeTypeTLSSNI01)
+func TLSSNIChallenge01(token string) Challenge {
+	return newChallenge(ChallengeTypeTLSSNI01, token)
 }
 
 // DNSChallenge01 constructs a random dns-01 challenge
-func DNSChallenge01() Challenge {
-	return newChallenge(ChallengeTypeDNS01)
+func DNSChallenge01(token string) Challenge {
+	return newChallenge(ChallengeTypeDNS01, token)
 }
 
 // TLSALPNChallenge01 constructs a random tls-alpn-01 challenge
-func TLSALPNChallenge01() Challenge {
-	return newChallenge(ChallengeTypeTLSALPN01)
+func TLSALPNChallenge01(token string) Challenge {
+	return newChallenge(ChallengeTypeTLSALPN01, token)
 }

--- a/core/challenges_test.go
+++ b/core/challenges_test.go
@@ -1,0 +1,14 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestNewChallenge(t *testing.T) {
+	challenge := newChallenge(ChallengeTypeDNS01, "")
+	test.Assert(t, challenge.Token != "", "token is not set")
+	challenge = newChallenge(ChallengeTypeDNS01, "asd")
+	test.Assert(t, challenge.Token == "asd", "token is not set")
+}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -24,16 +24,16 @@ func TestChallenges(t *testing.T) {
 		t.Errorf("Error unmarshaling JWK: %v", err)
 	}
 
-	http01 := HTTPChallenge01()
+	http01 := HTTPChallenge01("")
 	test.AssertNotError(t, http01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
-	tlssni01 := TLSSNIChallenge01()
+	tlssni01 := TLSSNIChallenge01("")
 	test.AssertNotError(t, tlssni01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
-	dns01 := DNSChallenge01()
+	dns01 := DNSChallenge01("")
 	test.AssertNotError(t, dns01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
-	tlsalpn01 := TLSALPNChallenge01()
+	tlsalpn01 := TLSALPNChallenge01("")
 	test.AssertNotError(t, tlsalpn01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
 	test.Assert(t, ValidChallenge(ChallengeTypeHTTP01), "Refused valid challenge")

--- a/core/objects.go
+++ b/core/objects.go
@@ -378,7 +378,7 @@ type Authorization struct {
 	// final authorizations, they describe the evidence that
 	// the server used in support of granting the authorization.
 	//
-	// There should only ever be on challenge of each type in this
+	// There should only ever be one challenge of each type in this
 	// slice and the order of these challenges may not be predictable.
 	Challenges []Challenge `json:"challenges,omitempty" db:"-"`
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -215,6 +215,11 @@ func looksLikeKeyAuthorization(str string) error {
 // challenge, we just throw all the elements into one bucket,
 // together with the common metadata elements.
 type Challenge struct {
+	// ID was previously used to uniquely identify a challenge in the database and
+	// by users in the WFE. The ID is only populated when a challenge is added to
+	// the database. When features.NewAuthorizationSchema is enabled it is no
+	// longer populated at all and must not be relied upon in order to uniquely
+	// identify a challenge when transiting the RPC or storage layers.
 	ID int64 `json:"id,omitempty"`
 
 	// The type of challenge
@@ -372,6 +377,9 @@ type Authorization struct {
 	// in process, these are challenges to be fulfilled; for
 	// final authorizations, they describe the evidence that
 	// the server used in support of granting the authorization.
+	//
+	// There should only ever be on challenge of each type in this
+	// slice and the order of these challenges may not be predictable.
 	Challenges []Challenge `json:"challenges,omitempty" db:"-"`
 
 	// The server may suggest combinations of challenges if it

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -94,9 +94,9 @@ func TestJSONBufferUnmarshal(t *testing.T) {
 }
 
 func TestAuthorizationSolvedBy(t *testing.T) {
-	validHTTP01 := HTTPChallenge01()
+	validHTTP01 := HTTPChallenge01("")
 	validHTTP01.Status = StatusValid
-	validDNS01 := DNSChallenge01()
+	validDNS01 := DNSChallenge01("")
 	validDNS01.Status = StatusValid
 	testCases := []struct {
 		Name           string
@@ -112,7 +112,7 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 		{
 			Name: "All non-valid challenges",
 			Authz: Authorization{
-				Challenges: []Challenge{HTTPChallenge01(), DNSChallenge01()},
+				Challenges: []Challenge{HTTPChallenge01(""), DNSChallenge01("")},
 			},
 		},
 		// An authz with one valid HTTP01 challenge amongst other challenges should
@@ -120,7 +120,7 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 		{
 			Name: "Valid HTTP01 challenge",
 			Authz: Authorization{
-				Challenges: []Challenge{HTTPChallenge01(), validHTTP01, DNSChallenge01()},
+				Challenges: []Challenge{HTTPChallenge01(""), validHTTP01, DNSChallenge01("")},
 			},
 			ExpectedResult: "http-01",
 		},
@@ -130,7 +130,7 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 		{
 			Name: "Valid HTTP01 and DNS01 challenge",
 			Authz: Authorization{
-				Challenges: []Challenge{validDNS01, HTTPChallenge01(), validHTTP01, DNSChallenge01()},
+				Challenges: []Challenge{validDNS01, HTTPChallenge01(""), validHTTP01, DNSChallenge01("")},
 			},
 			ExpectedResult: "dns-01",
 		},

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusPerformValidationRPCAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogsSimplifiedVAHTTPHeadNonceStatusOK"
+const _FeatureFlag_name = "unusedReusePendingAuthzCancelCTSubmissionsCountCertificatesExactIPv6FirstEnforceChallengeDisableEmbedSCTsWildcardDomainsForceConsistentStatusRPCHeadroomVAChecksGSBEnforceV2ContentTypeEnforceOverlappingWildcardsOrderReadyStatusPerformValidationRPCAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIACME13KeyRolloverProbeCTLogsSimplifiedVAHTTPHeadNonceStatusOKNewAuthorizationSchema"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 120, 141, 152, 163, 183, 210, 226, 246, 265, 283, 303, 316, 333, 344, 360, 377}
+var _FeatureFlag_index = [...]uint16{0, 6, 23, 42, 64, 73, 96, 105, 120, 141, 152, 163, 183, 210, 226, 246, 265, 283, 303, 316, 333, 344, 360, 377, 399}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -45,6 +45,8 @@ const (
 	// HEAD requests to the WFE2 new-nonce endpoint should return HTTP StatusOK
 	// instead of HTTP StatusNoContent.
 	HeadNonceStatusOK
+	// NewAuthorizationSchema enables usage of the new authorization storage schema
+	NewAuthorizationSchema
 )
 
 // List of features and their default value, protected by fMu
@@ -72,6 +74,7 @@ var features = map[FeatureFlag]bool{
 	SimplifiedVAHTTP:            false,
 	PerformValidationRPC:        false,
 	HeadNonceStatusOK:           false,
+	NewAuthorizationSchema:      false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -469,12 +469,6 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier, regID int
 	pa.rngMu.Lock()
 	defer pa.rngMu.Unlock()
 	for i, challIdx := range pa.pseudoRNG.Perm(len(challenges)) {
-		// If we are using the new authorization storage schema we need to give
-		// each challenge a sequential ID. This order is determined by the order
-		// they are added to the challenge slice above.
-		if features.Enabled(features.NewAuthorizationSchema) {
-			challenges[i].ID = int64(i)
-		}
 		shuffled[i] = challenges[challIdx]
 		combinations[i] = []int{i}
 	}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -420,6 +420,13 @@ func (pa *AuthorityImpl) checkHostLists(domain string) error {
 func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier, regID int64, revalidation bool) ([]core.Challenge, [][]int, error) {
 	challenges := []core.Challenge{}
 
+	// If we are using the new authorization storage schema we only use a single
+	// token for all challenges rather than a unique token per challenge.
+	var token string
+	if features.Enabled(features.NewAuthorizationSchema) {
+		token = core.NewToken()
+	}
+
 	// If the identifier is for a DNS wildcard name we only
 	// provide a DNS-01 challenge as a matter of CA policy.
 	if strings.HasPrefix(identifier.Value, "*.") {
@@ -431,26 +438,26 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier, regID int
 					"challenge type is not enabled")
 		}
 		// Only provide a DNS-01-Wildcard challenge
-		challenges = []core.Challenge{core.DNSChallenge01()}
+		challenges = []core.Challenge{core.DNSChallenge01(token)}
 	} else {
 		// Otherwise we collect up challenges based on what is enabled.
 		if pa.ChallengeTypeEnabled(core.ChallengeTypeHTTP01, regID) {
-			challenges = append(challenges, core.HTTPChallenge01())
+			challenges = append(challenges, core.HTTPChallenge01(token))
 		}
 
 		// Add a TLS-SNI challenge, if either (a) the challenge is enabled, or (b)
 		// the TLSSNIRevalidation feature flag is on and this is a revalidation.
 		if pa.ChallengeTypeEnabled(core.ChallengeTypeTLSSNI01, regID) ||
 			(features.Enabled(features.TLSSNIRevalidation) && revalidation) {
-			challenges = append(challenges, core.TLSSNIChallenge01())
+			challenges = append(challenges, core.TLSSNIChallenge01(token))
 		}
 
 		if pa.ChallengeTypeEnabled(core.ChallengeTypeTLSALPN01, regID) {
-			challenges = append(challenges, core.TLSALPNChallenge01())
+			challenges = append(challenges, core.TLSALPNChallenge01(token))
 		}
 
 		if pa.ChallengeTypeEnabled(core.ChallengeTypeDNS01, regID) {
-			challenges = append(challenges, core.DNSChallenge01())
+			challenges = append(challenges, core.DNSChallenge01(token))
 		}
 	}
 
@@ -462,6 +469,12 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier, regID int
 	pa.rngMu.Lock()
 	defer pa.rngMu.Unlock()
 	for i, challIdx := range pa.pseudoRNG.Perm(len(challenges)) {
+		// If we are using the new authorization storage schema we need to give
+		// each challenge a sequential ID. This order is determined by the order
+		// they are added to the challenge slice above.
+		if features.Enabled(features.NewAuthorizationSchema) {
+			challenges[i].ID = int64(i)
+		}
 		shuffled[i] = challenges[challIdx]
 		combinations[i] = []int{i}
 	}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3193,9 +3193,9 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 			Value: domain,
 		}
 		// Create challenges
-		httpChal := core.HTTPChallenge01()
-		dnsChal := core.DNSChallenge01()
-		tlsChal := core.TLSSNIChallenge01()
+		httpChal := core.HTTPChallenge01("")
+		dnsChal := core.DNSChallenge01("")
+		tlsChal := core.TLSSNIChallenge01("")
 		// Set the selected challenge to valid
 		switch chalType {
 		case "http-01":
@@ -3687,7 +3687,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 			Value: domain,
 		}
 		// Create one valid HTTP challenge
-		httpChal := core.HTTPChallenge01()
+		httpChal := core.HTTPChallenge01("")
 		httpChal.Status = core.StatusValid
 		// Set the template's challenges
 		template.Challenges = []core.Challenge{httpChal}

--- a/sa/model.go
+++ b/sa/model.go
@@ -404,15 +404,15 @@ func modelToOrder(om *orderModel) (*corepb.Order, error) {
 var challTypeToUint = map[string]uint{
 	"http-01":     0,
 	"tls-sni-01":  1,
-	"tls-alpn-01": 2,
-	"dns-01":      3,
+	"dns-01":      2,
+	"tls-alpn-01": 3,
 }
 
 var uintToChallType = map[uint]string{
 	0: "http-01",
 	1: "tls-sni-01",
-	2: "tls-alpn-01",
-	3: "dns-01",
+	2: "dns-01",
+	3: "tls-alpn-01",
 }
 
 var identifierTypeToUint = map[string]uint{

--- a/sa/model.go
+++ b/sa/model.go
@@ -408,12 +408,6 @@ var challTypeToUint = map[string]uint{
 	"dns-01":      3,
 }
 
-// uintToChallType is used to map bit position in the challenges bitmap
-// to challenge type. *WARNING* it is important that the order of this map
-// (and the map above) matches the order in which challenges are added to
-// the challenge slice in policy/pa.go:ChallengesFor. This is necessary
-// so that we have a consistent ID for each challenge when we pass between
-// the storage layer boundary.
 var uintToChallType = map[uint]string{
 	0: "http-01",
 	1: "tls-sni-01",
@@ -607,16 +601,12 @@ func modelToAuthzPB(am *authz2Model) (*corepb.Authorization, error) {
 	// to core.StatusValid or core.StatusInvalid depending on if there is anything
 	// in ValidationError and populate the ValidationRecord and ValidationError
 	// fields.
-	challenges := int64(0)
 	for pos := uint(0); pos < 8; pos++ {
 		if (am.Challenges>>pos)&1 == 1 {
 			challType := uintToChallType[pos]
 			status := string(core.StatusPending)
-			id := challenges
-			challenges++
 			token := base64.StdEncoding.EncodeToString(am.Token)
 			challenge := &corepb.Challenge{
-				Id:     &id,
 				Type:   &challType,
 				Status: &status,
 				Token:  &token,

--- a/sa/model.go
+++ b/sa/model.go
@@ -404,15 +404,21 @@ func modelToOrder(om *orderModel) (*corepb.Order, error) {
 var challTypeToUint = map[string]uint{
 	"http-01":     0,
 	"tls-sni-01":  1,
-	"dns-01":      2,
-	"tls-alpn-01": 3,
+	"tls-alpn-01": 2,
+	"dns-01":      3,
 }
 
+// uintToChallType is used to map bit position in the challenges bitmap
+// to challenge type. *WARNING* it is important that the order of this map
+// (and the map above) matches the order in which challenges are added to
+// the challenge slice in policy/pa.go:ChallengesFor. This is necessary
+// so that we have a consistent ID for each challenge when we pass between
+// the storage layer boundary.
 var uintToChallType = map[uint]string{
 	0: "http-01",
 	1: "tls-sni-01",
-	2: "dns-01",
-	3: "tls-alpn-01",
+	2: "tls-alpn-01",
+	3: "dns-01",
 }
 
 var identifierTypeToUint = map[string]uint{

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -49,12 +49,10 @@ func TestV2AuthzModel(t *testing.T) {
 	reg := int64(1)
 	status := string(core.StatusValid)
 	expires := int64(1234)
-	challID := int64(0)
 	challType := string(core.ChallengeTypeHTTP01)
 	token := "MTIz"
 	hostname := "hostname"
 	port := "port"
-	challID2 := int64(1)
 	challType2 := string(core.ChallengeTypeDNS01)
 	statusPending := string(core.StatusPending)
 	url := "url"
@@ -66,7 +64,6 @@ func TestV2AuthzModel(t *testing.T) {
 		Expires:        &expires,
 		Challenges: []*corepb.Challenge{
 			&corepb.Challenge{
-				Id:     &challID,
 				Type:   &challType,
 				Status: &status,
 				Token:  &token,
@@ -82,7 +79,6 @@ func TestV2AuthzModel(t *testing.T) {
 				},
 			},
 			&corepb.Challenge{
-				Id:     &challID2,
 				Type:   &challType2,
 				Status: &statusPending,
 				Token:  &token,

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -271,7 +271,7 @@ func tlsalpn01Srv(t *testing.T, chall core.Challenge, oid asn1.ObjectIdentifier,
 }
 
 func TestHTTPBadPort(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, expectedToken)
 
 	hs := httpSrv(t, chall.Token)
@@ -296,7 +296,7 @@ func TestHTTPBadPort(t *testing.T) {
 }
 
 func TestHTTP(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, expectedToken)
 
 	// NOTE: We do not attempt to shut down the server. The problem is that the
@@ -371,7 +371,7 @@ func TestHTTP(t *testing.T) {
 }
 
 func TestHTTPTimeout(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, expectedToken)
 
 	hs := httpSrv(t, chall.Token)
@@ -437,7 +437,7 @@ func TestHTTPDialTimeout(t *testing.T) {
 	// that, just retry until we get something other than "Network unreachable".
 	var prob *probs.ProblemDetails
 	for i := 0; i < 20; i++ {
-		_, prob = va.validateHTTP01(ctx, dnsi("unroutable.invalid"), core.HTTPChallenge01())
+		_, prob = va.validateHTTP01(ctx, dnsi("unroutable.invalid"), core.HTTPChallenge01(""))
 		if prob != nil && strings.Contains(prob.Detail, "Network unreachable") {
 			continue
 		} else {
@@ -466,7 +466,7 @@ func TestHTTPDialTimeout(t *testing.T) {
 }
 
 func TestHTTPRedirectLookup(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, expectedToken)
 
 	hs := httpSrv(t, expectedToken)
@@ -529,7 +529,7 @@ func TestHTTPRedirectLookup(t *testing.T) {
 }
 
 func TestHTTPRedirectLoop(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, "looper")
 
 	hs := httpSrv(t, expectedToken)
@@ -543,7 +543,7 @@ func TestHTTPRedirectLoop(t *testing.T) {
 }
 
 func TestHTTPRedirectUserAgent(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, expectedToken)
 
 	hs := httpSrv(t, expectedToken)
@@ -916,7 +916,7 @@ func TestSNIErrInvalidChain(t *testing.T) {
 }
 
 func TestValidateHTTP(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, core.NewToken())
 
 	hs := httpSrv(t, chall.Token)
@@ -929,7 +929,7 @@ func TestValidateHTTP(t *testing.T) {
 }
 
 func TestGSBAtValidation(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, core.NewToken())
 
 	hs := httpSrv(t, chall.Token)
@@ -1182,7 +1182,7 @@ func TestPerformValidationValid(t *testing.T) {
 	va, mockLog := setup(nil, 0)
 
 	// create a challenge with well known token
-	chalDNS := core.DNSChallenge01()
+	chalDNS := core.DNSChallenge01("")
 	chalDNS.Token = expectedToken
 	chalDNS.ProvidedKeyAuthorization = expectedKeyAuthorization
 	_, prob := va.PerformValidation(context.Background(), "good-dns01.com", chalDNS, core.Authorization{})
@@ -1211,7 +1211,7 @@ func TestPerformValidationWildcard(t *testing.T) {
 	va, mockLog := setup(nil, 0)
 
 	// create a challenge with well known token
-	chalDNS := core.DNSChallenge01()
+	chalDNS := core.DNSChallenge01("")
 	chalDNS.Token = expectedToken
 	chalDNS.ProvidedKeyAuthorization = expectedKeyAuthorization
 	// perform a validation for a wildcard name
@@ -1258,7 +1258,7 @@ func TestDNSValidationInvalid(t *testing.T) {
 		Value: "790DB180-A274-47A4-855F-31C428CB1072",
 	}
 
-	chalDNS := core.DNSChallenge01()
+	chalDNS := core.DNSChallenge01("")
 	chalDNS.ProvidedKeyAuthorization = expectedKeyAuthorization
 
 	va, _ := setup(nil, 0)
@@ -1271,13 +1271,13 @@ func TestDNSValidationInvalid(t *testing.T) {
 func TestDNSValidationNotSane(t *testing.T) {
 	va, _ := setup(nil, 0)
 
-	chal0 := core.DNSChallenge01()
+	chal0 := core.DNSChallenge01("")
 	chal0.Token = ""
 
-	chal1 := core.DNSChallenge01()
+	chal1 := core.DNSChallenge01("")
 	chal1.Token = "yfCBb-bRTLz8Wd1C0lTUQK3qlKj3-t2tYGwx5Hj7r_"
 
-	chal2 := core.DNSChallenge01()
+	chal2 := core.DNSChallenge01("")
 	chal2.ProvidedKeyAuthorization = "a"
 
 	var authz = core.Authorization{
@@ -1329,7 +1329,7 @@ func TestDNSValidationOK(t *testing.T) {
 	va, _ := setup(nil, 0)
 
 	// create a challenge with well known token
-	chalDNS := core.DNSChallenge01()
+	chalDNS := core.DNSChallenge01("")
 	chalDNS.Token = expectedToken
 	chalDNS.ProvidedKeyAuthorization = expectedKeyAuthorization
 
@@ -1342,7 +1342,7 @@ func TestDNSValidationNoAuthorityOK(t *testing.T) {
 	va, _ := setup(nil, 0)
 
 	// create a challenge with well known token
-	chalDNS := core.DNSChallenge01()
+	chalDNS := core.DNSChallenge01("")
 	chalDNS.Token = expectedToken
 
 	chalDNS.ProvidedKeyAuthorization = expectedKeyAuthorization
@@ -1353,7 +1353,7 @@ func TestDNSValidationNoAuthorityOK(t *testing.T) {
 }
 
 func TestLimitedReader(t *testing.T) {
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, core.NewToken())
 
 	hs := httpSrv(t, "012345\xff67890123456789012345678901234567890123456789012345678901234567890123456789")
@@ -1481,7 +1481,7 @@ func TestAvailableAddresses(t *testing.T) {
 // subsequent IPv4 request get a new dialer each.
 func TestHTTP01DialerFallback(t *testing.T) {
 	// Create a new challenge to use for the httpSrv
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, core.NewToken())
 
 	// Create an IPv4 test server
@@ -1518,7 +1518,7 @@ func TestHTTP01DialerFallback(t *testing.T) {
 
 func TestFallbackDialer(t *testing.T) {
 	// Create a new challenge to use for the httpSrv
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, core.NewToken())
 
 	// Create an IPv4 test server
@@ -1656,7 +1656,7 @@ func (v cancelledVA) IsSafeDomain(_ context.Context, _ *vaPB.IsSafeDomainRequest
 
 func TestPerformRemoteValidation(t *testing.T) {
 	// Create a new challenge to use for the httpSrv
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, core.NewToken())
 
 	// Create an IPv4 test server
@@ -1846,7 +1846,7 @@ func (b *brokenRemoteVA) IsSafeDomain(
 
 func TestPerformRemoteValidationFailure(t *testing.T) {
 	// Create a new challenge to use for the httpSrv
-	chall := core.HTTPChallenge01()
+	chall := core.HTTPChallenge01("")
 	setChallengeToken(&chall, core.NewToken())
 
 	// Create an IPv4 test server


### PR DESCRIPTION
Adds a feature which gates creation of authorizations following the style required for the new schema (and which can be used for gating the reset of our new schema code later down the road).

There was an internal discussion about an issue this creates regarding a predictable ordering of challenges within a challenge due to sequential challenge IDs which will always be static for each challenge type. It was suggested we could add some kind of obfuscation to the challenge ID when presented to the user to prevent this. This hasn't been done in this PR as it would only be focused in the WFE and would be better suited as its own changeset.

Fixes #3981.