### PR TITLE
Sync config-next with config where possible.

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/letsencrypt/boulder/bdns"
@@ -130,15 +129,11 @@ func main() {
 		for _, rva := range c.VA.RemoteVAs {
 			vaConn, err := bgrpc.ClientSetup(&rva, tlsConfig, clientMetrics, clk)
 			cmd.FailOnError(err, "Unable to create remote VA client")
-			addr := rva.ServerAddress
-			if addr == "" {
-				addr = strings.Join(rva.ServerAddresses, ",")
-			}
 			remotes = append(
 				remotes,
 				va.RemoteVA{
 					ValidationAuthority: bgrpc.NewValidationAuthorityGRPCClient(vaConn),
-					Addresses:           addr,
+					Addresses:           rva.ServerAddress,
 				},
 			)
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -259,11 +259,8 @@ func (d *ConfigDuration) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 // GRPCClientConfig contains the information needed to talk to the gRPC service
 type GRPCClientConfig struct {
-	// NOTE: this field is deprecated in favor of ServerAddress, as we only ever
-	// expect a single address
-	ServerAddresses []string
-	ServerAddress   string
-	Timeout         ConfigDuration
+	ServerAddress string
+	Timeout       ConfigDuration
 }
 
 // GRPCServerConfig contains the information needed to run a gRPC service

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -19,12 +19,7 @@ import (
 // It dials the remote service and returns a grpc.ClientConn if successful.
 func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientMetrics, clk clock.Clock) (*grpc.ClientConn, error) {
 	if c.ServerAddress == "" {
-		if len(c.ServerAddresses) == 0 {
-			return nil, errors.New("Both ServerAddress and ServerAddresses are empty")
-		} else if len(c.ServerAddresses) != 1 {
-			return nil, errors.New("If ServerAddress is empty ServerAddresses can only contain one address")
-		}
-		c.ServerAddress = c.ServerAddresses[0]
+		return nil, errors.New("ServerAddress is empty")
 	}
 	if tlsConfig == nil {
 		return nil, errNilTLS

--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -8,11 +8,11 @@
       "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra.boulder:9094"],
+      "serverAddress": "ra.boulder:9094",
       "timeout": "15s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     }
   },

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -11,7 +11,7 @@
       "keyFile": "test/grpc-creds/ca.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "grpcCA": {
@@ -130,6 +130,7 @@
       }
     },
     "maxConcurrentRPCServerRequests": 100000,
+    "orphanQueueDir": "/tmp/orphaned-certificates-a",
     "features": {
         "RPCHeadroom": true,
         "WildcardDomains": true
@@ -140,7 +141,8 @@
     "challenges": {
       "http-01": true,
       "tls-sni-01": true,
-      "dns-01": true
+      "dns-01": true,
+      "tls-alpn-01": true
     }
   },
 

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -11,7 +11,7 @@
       "keyFile": "test/grpc-creds/ca.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "grpcCA": {

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -9,7 +9,8 @@
     "challenges": {
       "http-01": true,
       "tls-sni-01": true,
-      "dns-01": true
+      "dns-01": true,
+      "tls-alpn-01": true
     }
   },
 

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -18,7 +18,7 @@
       "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -5,8 +5,10 @@
     "path": "/",
     "listenAddress": "0.0.0.0:4002",
     "maxAge": "10s",
+    "timeout": "4.9s",
     "shutdownStopTimeout": "10s",
-    "debugAddr": ":8005"
+    "debugAddr": ":8005",
+    "requiredSerialPrefixes": ["ff"]
   },
 
   "syslog": {

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -28,11 +28,11 @@
       "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "ocspGeneratorService": {
-      "serverAddresses": ["ca.boulder:9096"],
+      "serverAddress": "ca.boulder:9096",
       "timeout": "15s"
     },
     "features": {

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -12,7 +12,7 @@
   },
 
   "saService": {
-    "serverAddresses": ["sa.boulder:9095"],
+    "serverAddress": "sa.boulder:9095",
     "timeout": "15s"
   }
 }

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -1,5 +1,6 @@
 {
   "publisher": {
+    "blockProfileRate": 1000000000,
     "maxConcurrentRPCServerRequests": 100000,
     "submissionTimeout": "5s",
     "debugAddr": ":8009",
@@ -17,7 +18,8 @@
       "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
     },
     "features": {
-      "RPCHeadroom": true
+      "RPCHeadroom": true,
+      "ProbeCTLogs": true
     }
   },
 

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -3,11 +3,6 @@
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 100000,
     "maxContactsPerRegistration": 100,
-    "dnsTries": 3,
-    "dnsResolvers": [
-      "127.0.0.1:8053",
-      "127.0.0.1:8054"
-    ],
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.json",
     "maxNames": 100,
@@ -22,19 +17,19 @@
       "keyFile": "test/grpc-creds/ra.boulder/key.pem"
     },
     "vaService": {
-      "serverAddresses": ["va.boulder:9092"],
+      "serverAddress": "va.boulder:9092",
       "timeout": "20s"
     },
     "caService": {
-      "serverAddresses": ["ca.boulder:9093"],
+      "serverAddress": "ca.boulder:9093",
       "timeout": "15s"
     },
     "publisherService": {
-      "serverAddresses": ["publisher.boulder:9091"],
+      "serverAddress": "publisher.boulder:9091",
       "timeout": "300s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "grpc": {
@@ -56,6 +51,7 @@
     "CTLogGroups2": [
       {
         "name": "a",
+        "stagger": "500ms",
         "logs": [
           {
             "uri": "http://boulder:4500",
@@ -71,6 +67,7 @@
       },
       {
         "name": "b",
+        "stagger": "500ms",
         "logs": [
           {
             "uri": "http://boulder:4510",
@@ -78,8 +75,27 @@
             "submitFinalCert": true
           },
           {
-            "uri": "http://boulder:4511",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
+            "name": "temporal test set",
+            "shards": [
+              {
+                "uri": "http://boulder:4511",
+                "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
+                "windowStart": "2006-01-02T15:04:05Z",
+                "windowEnd": "2017-01-02T15:04:05Z"
+              },
+              {
+                "uri": "http://boulder:4511",
+                "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
+                "windowStart": "2017-01-02T15:04:05Z",
+                "windowEnd": "2022-01-02T15:04:05Z"
+              },
+              {
+                "uri": "http://boulder:4511",
+                "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
+                "windowStart": "2022-01-02T15:04:05Z",
+                "windowEnd": "2050-01-02T15:04:05Z"
+              }
+            ],
             "submitFinalCert": true
           }
         ]
@@ -98,7 +114,8 @@
     "challenges": {
       "http-01": true,
       "tls-sni-01": true,
-      "dns-01": true
+      "dns-01": true,
+      "tls-alpn-01": true
     },
     "challengesWhitelistFile": "test/challenges-whitelist.json"
   },

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -2,6 +2,7 @@
   "sa": {
     "dbConnectFile": "test/secrets/sa_dburl",
     "maxDBConns": 100,
+    "maxIdleDBConns": 10,
     "maxConcurrentRPCServerRequests": 100000,
     "ParallelismPerRPC": 20,
     "debugAddr": ":8003",
@@ -26,7 +27,9 @@
     },
     "features": {
       "RPCHeadroom": true,
-      "WildcardDomains": true
+      "WildcardDomains": true,
+      "AllowRenewalFirstRL": true,
+      "OrderReadyStatus": true
     }
   },
 

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -23,11 +23,11 @@
       "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra.boulder:9094"],
+      "serverAddress": "ra.boulder:9094",
       "timeout": "20s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "features": {

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -17,17 +17,18 @@
     "debugAddr": ":8013",
     "directoryCAAIdentity": "happy-hacker-ca.invalid",
     "directoryWebsite": "https://github.com/letsencrypt/boulder",
+    "legacyKeyIDPrefix": "http://boulder:4000/reg/",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
       "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra.boulder:9094"],
+      "serverAddress": "ra.boulder:9094",
       "timeout": "15s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "certificateChains": {
@@ -36,7 +37,8 @@
     },
     "features": {
       "EnforceV2ContentType": true,
-      "RPCHeadroom": true
+      "RPCHeadroom": true,
+      "ACME13KeyRollover": true
     }
   },
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -311,11 +311,6 @@ def test_http_challenge_https_redirect():
         raise Exception("Expected all redirected requests to have ServerName {0} got \"{1}\"".format(d, r['ServerName']))
 
 def test_tls_alpn_challenge():
-    # TODO(@mdebski): Once the tls-alpn-01 challenge is enabled in pa.challenges
-    # by default, delete this early return.
-    if not default_config_dir.startswith("test/config-next"):
-        return
-
     # Pick two random domains
     domains = [random_domain(), random_domain()]
 
@@ -608,12 +603,6 @@ def test_renewal_exemption():
     and we are testing what we think we are testing. See
     https://letsencrypt.org/docs/rate-limits/ for more details.
     """
-
-    # TODO(@cpu): Once the `AllowRenewalFirstRL` feature flag is enabled by
-    # default, delete this early return.
-    if not default_config_dir.startswith("test/config-next"):
-        return
-
     base_domain = random_domain()
     # First issuance
     auth_and_issue(["www." + base_domain])
@@ -709,8 +698,6 @@ def test_stats():
     expect_stat(8001, "\ngo_goroutines ")
 
 def test_sct_embedding():
-    if not os.environ.get('BOULDER_CONFIG_DIR', '').startswith("test/config-next"):
-        return
     certr, authzs = auth_and_issue([random_domain()])
     certBytes = urllib2.urlopen(certr.uri).read()
     cert = x509.load_der_x509_certificate(certBytes, default_backend())


### PR DESCRIPTION
- Remove deprecated `ServerAddresses`  field.
- Enable TLS-ALPN-01 through-out `config/` (RA, cert-checker, CA)
- CA: Enable orphan cert queue.
- OCSP Responder: add timeout and `requiredSerialPrefixes`.
- Publisher: Set a `blockProfileRate` and enable `ProbeCTLogs` feature flag.
- RA: Add `stagger` to log groups, add a temporal test set.
- SA: Set a `maxIdleDBConns` and enable `OrderReadyStatus` and `AllowRenewalFirstRL` feature flags.
- WFE2: Set a `legacyKeyIDPrefix` and enable `ACME13KeyRollover` feature flag

<s>The `OrderReadyStatus` feature flag can be deleted outright, it isn't used anywhere (configs or code) - I didn't do it in this PR to avoid a conflict with #3999</s> (Nevermind! @rolandshoemaker got it in https://github.com/letsencrypt/boulder/pull/4001 :tada:)
