### PR TITLE
Revert "Increase default MaxIdleConns. (#3164)"

### DIFF
--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -70,9 +70,6 @@ func main() {
 	scope.MustRegister(dbConnStat)
 	dbConnStat.Set(float64(saConf.DBConfig.MaxDBConns))
 
-	if saConf.DBConfig.MaxIdleDBConns != 0 {
-		dbMap.Db.SetMaxIdleConns(saConf.DBConfig.MaxIdleDBConns)
-	}
 	go sa.ReportDbConnCount(dbMap, scope)
 
 	clk := cmd.Clock()

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -48,9 +48,8 @@ type ServiceConfig struct {
 type DBConfig struct {
 	DBConnect string
 	// A file containing a connect URL for the DB.
-	DBConnectFile  string
-	MaxDBConns     int
-	MaxIdleDBConns int
+	DBConnectFile string
+	MaxDBConns    int
 }
 
 // URL returns the DBConnect URL represented by this DBConfig object, either

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -2,7 +2,6 @@
   "sa": {
     "dbConnectFile": "test/secrets/sa_dburl",
     "maxDBConns": 100,
-    "maxIdleDBConns": 10,
     "maxConcurrentRPCServerRequests": 100000,
     "ParallelismPerRPC": 20,
     "debugAddr": ":8003",


### PR DESCRIPTION
This reverts commit 600640294d0dd6446ef646f4dba3b72d86726bc0,
removing the maxIdleDBConns config setting.

Fixes #4005 