### PR TITLE
Remove newCertificate loop from ocsp-updater.

### DIFF
--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -2,11 +2,9 @@
   "ocspUpdater": {
     "dbConnectFile": "test/secrets/ocsp_updater_dburl",
     "maxDBConns": 10,
-    "newCertificateWindow": "1s",
     "oldOCSPWindow": "2s",
     "missingSCTWindow": "1s",
     "revokedCertificateWindow": "1s",
-    "newCertificateBatchSize": 1000,
     "oldOCSPBatchSize": 5000,
     "missingSCTBatchSize": 5000,
     "parallelGenerateOCSPRequests": 10,


### PR DESCRIPTION
Since https://github.com/letsencrypt/boulder/pull/2633 we generate OCSP
at first issuance, so we no longer need this loop to check for new
certificates that need OCSP status generated. Since the associate SQL
query is slow, we should just turn it off.

This is the first step before configuring it off in prod, then deleting
the code and deleting the settings from config.