### PR TITLE
No new certificates tick

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -156,19 +156,14 @@ type OCSPUpdaterConfig struct {
 	ServiceConfig
 	DBConfig
 
-	NewCertificateWindow     ConfigDuration
 	OldOCSPWindow            ConfigDuration
-	MissingSCTWindow         ConfigDuration
 	RevokedCertificateWindow ConfigDuration
 
-	NewCertificateBatchSize     int
 	OldOCSPBatchSize            int
-	MissingSCTBatchSize         int
 	RevokedCertificateBatchSize int
 
 	OCSPMinTimeToExpiry          ConfigDuration
 	OCSPStaleMaxAge              ConfigDuration
-	OldestIssuedSCT              ConfigDuration
 	ParallelGenerateOCSPRequests int
 
 	AkamaiBaseURL           string

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -236,19 +236,6 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 	return statuses, err
 }
 
-func (updater *OCSPUpdater) getCertificatesWithMissingResponses(batchSize int) ([]core.CertificateStatus, error) {
-	const query = "WHERE ocspLastUpdated = 0 LIMIT ?"
-	statuses, err := sa.SelectCertificateStatuses(
-		updater.dbMap,
-		query,
-		batchSize,
-	)
-	if err == sql.ErrNoRows {
-		return statuses, nil
-	}
-	return statuses, err
-}
-
 type responseMeta struct {
 	*core.OCSPResponse
 	*core.CertificateStatus

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -263,22 +263,6 @@ func TestFindStaleOCSPResponsesStaleMaxAge(t *testing.T) {
 	test.AssertEquals(t, certs[0].Serial, core.SerialToString(parsedCertA.SerialNumber))
 }
 
-func TestGetCertificatesWithMissingResponses(t *testing.T) {
-	updater, sa, _, fc, cleanUp := setup(t)
-	defer cleanUp()
-
-	reg := satest.CreateWorkingRegistration(t, sa)
-	cert, err := core.LoadCert("test-cert.pem")
-	test.AssertNotError(t, err, "Couldn't read test certificate")
-	issued := fc.Now()
-	_, err = sa.AddCertificate(ctx, cert.Raw, reg.ID, nil, &issued)
-	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
-
-	statuses, err := updater.getCertificatesWithMissingResponses(10)
-	test.AssertNotError(t, err, "Couldn't get status")
-	test.AssertEquals(t, len(statuses), 1)
-}
-
 func TestFindRevokedCertificatesToUpdate(t *testing.T) {
 	updater, sa, _, fc, cleanUp := setup(t)
 	defer cleanUp()

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -80,13 +80,9 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *gorp.DbMap, cloc
 		&mockCA{},
 		sa,
 		cmd.OCSPUpdaterConfig{
-			NewCertificateBatchSize:     1,
 			OldOCSPBatchSize:            1,
-			MissingSCTBatchSize:         1,
 			RevokedCertificateBatchSize: 1,
-			NewCertificateWindow:        cmd.ConfigDuration{Duration: time.Second},
 			OldOCSPWindow:               cmd.ConfigDuration{Duration: time.Second},
-			MissingSCTWindow:            cmd.ConfigDuration{Duration: time.Second},
 			RevokedCertificateWindow:    cmd.ConfigDuration{Duration: time.Second},
 		},
 		"",
@@ -304,26 +300,6 @@ func TestFindRevokedCertificatesToUpdate(t *testing.T) {
 	statuses, err = updater.findRevokedCertificatesToUpdate(10)
 	test.AssertNotError(t, err, "Failed to find revoked certificates")
 	test.AssertEquals(t, len(statuses), 1)
-}
-
-func TestNewCertificateTick(t *testing.T) {
-	updater, sa, _, fc, cleanUp := setup(t)
-	defer cleanUp()
-
-	reg := satest.CreateWorkingRegistration(t, sa)
-	parsedCert, err := core.LoadCert("test-cert.pem")
-	test.AssertNotError(t, err, "Couldn't read test certificate")
-	issued := fc.Now()
-	_, err = sa.AddCertificate(ctx, parsedCert.Raw, reg.ID, nil, &issued)
-	test.AssertNotError(t, err, "Couldn't add test-cert.pem")
-
-	prev := fc.Now().Add(-time.Hour)
-	err = updater.newCertificateTick(ctx, 10)
-	test.AssertNotError(t, err, "Couldn't run newCertificateTick")
-
-	certs, err := updater.findStaleOCSPResponses(prev, 10)
-	test.AssertNotError(t, err, "Failed to find stale responses")
-	test.AssertEquals(t, len(certs), 0)
 }
 
 func TestOldOCSPResponsesTick(t *testing.T) {

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -2,11 +2,9 @@
   "ocspUpdater": {
     "dbConnectFile": "test/secrets/ocsp_updater_dburl",
     "maxDBConns": 10,
-    "newCertificateWindow": "1s",
     "oldOCSPWindow": "2s",
     "missingSCTWindow": "1s",
     "revokedCertificateWindow": "1s",
-    "newCertificateBatchSize": 1000,
     "oldOCSPBatchSize": 5000,
     "missingSCTBatchSize": 5000,
     "parallelGenerateOCSPRequests": 10,

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -2,11 +2,9 @@
   "ocspUpdater": {
     "dbConnectFile": "test/secrets/ocsp_updater_dburl",
     "maxDBConns": 10,
-    "newCertificateWindow": "1s",
     "oldOCSPWindow": "2s",
     "missingSCTWindow": "1s",
     "revokedCertificateWindow": "1s",
-    "newCertificateBatchSize": 1000,
     "oldOCSPBatchSize": 5000,
     "missingSCTBatchSize": 5000,
     "parallelGenerateOCSPRequests": 10,


### PR DESCRIPTION
Since #2633 we generate OCSP at first issuance, so we no longer need 
this loop to check for new certificates that need OCSP status generated.
Since the associate SQL query is slow, we should just turn it off.

Also remove the configuration fields for the MissingSCTTick. The code
for that was already deleted.