### PR TITLE
Set "Created" field for new-order.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -485,6 +485,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	if err == nil {
 		response.Header().Set("Location",
 			web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
+		logEvent.Requester = existingAcct.ID
 
 		err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, existingAcct)
 		if err != nil {
@@ -1675,6 +1676,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Error creating new order"), err)
 		return
 	}
+	logEvent.Created = fmt.Sprintf("%d", *order.Id)
 
 	orderURL := web.RelativeEndpoint(request,
 		fmt.Sprintf("%s%d/%d", orderPath, acct.ID, *order.Id))

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2072,6 +2072,17 @@ func TestNewOrder(t *testing.T) {
 			}
 		})
 	}
+
+	// Test that we log the "Created" field.
+	responseWriter.Body.Reset()
+	responseWriter.HeaderMap = http.Header{}
+	request := signAndPost(t, targetPath, signedURL, validOrderBody, 1, wfe.nonceService)
+	requestEvent := newRequestEvent()
+	wfe.NewOrder(ctx, requestEvent, responseWriter, request)
+
+	if requestEvent.Created != "1" {
+		t.Errorf("Expected to log Created field when creating Order: %#v", requestEvent)
+	}
 }
 
 func TestFinalizeOrder(t *testing.T) {


### PR DESCRIPTION
This will allow us to connect new-order requests with the order URLs
that are created as a result.

Also ensure the Requester is filled in for new-acct requests that return
an existing account (it's already filled in for new-acct requests that
create an account).