### PR TITLE
Add exception for grpc timeouts in WFE.

### DIFF
--- a/web/send_error.go
+++ b/web/send_error.go
@@ -41,7 +41,7 @@ func SendError(
 	// since we don't need to keep those long-term. Note that they are still
 	// included in the request logs.
 	deadlineExceeded := ierr == context.DeadlineExceeded || grpc.Code(ierr) == codes.DeadlineExceeded
-	if prob.Type == probs.ServerInternalProblem && deadlineExceeded {
+	if prob.Type == probs.ServerInternalProblem && !deadlineExceeded {
 		if ierr != nil {
 			log.AuditErrf("Internal error - %s - %s", prob.Detail, ierr)
 		} else {

--- a/web/send_error.go
+++ b/web/send_error.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/probs"
 )
@@ -37,7 +40,8 @@ func SendError(
 	// auditable events. Also, skip the audit log for deadline exceeded errors
 	// since we don't need to keep those long-term. Note that they are still
 	// included in the request logs.
-	if prob.Type == probs.ServerInternalProblem && ierr != context.DeadlineExceeded {
+	deadlineExceeded := ierr == context.DeadlineExceeded || grpc.Code(ierr) == codes.DeadlineExceeded
+	if prob.Type == probs.ServerInternalProblem && deadlineExceeded {
 		if ierr != nil {
 			log.AuditErrf("Internal error - %s - %s", prob.Detail, ierr)
 		} else {


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/pull/3985/files we added an
exception where deadline exceeded errors in WFE wouldn't cause audit
logs, but we forgot to include gRPC responses where the code was
DeadlineExceeded.