### PR TITLE
notify-mailer: warn for bad rcpt, don't exit.

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -137,7 +137,13 @@ func (m *mailer) run() error {
 		}
 		err := m.mailer.SendMail([]string{dest}, m.subject, m.emailTemplate)
 		if err != nil {
-			return err
+			switch err.(type) {
+			case bmail.InvalidRcptError:
+				m.log.Errf("address %q was rejected by server: %s", dest, err)
+				continue
+			default:
+				return err
+			}
 		}
 		m.clk.Sleep(m.sleepInterval)
 	}


### PR DESCRIPTION
Resolves https://github.com/letsencrypt/boulder/issues/4019

I can't find RFC verse and chapter for "401 4.1.3" errors, but [IANA's registry of SMTP enhanced status codes](https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml) does show an entry matching `x.1.3`:
```
X.1.3 | Bad destination mailbox address syntax | 501 | The destination address was syntactically invalid. This can apply to any field in the address. This code is only useful for permanent failures. | [RFC3463] (Standards Track) | G. Vaudreuil | IESG
```
However that entry from IANA says the "associated basic code" is 501, not 401.

Since we wrote this tool to talk to exactly one SMTP server in the world and it definitely is returning "401 4.1.3" in some cases I think its reasonable to handle as I've done in this PR. Alternative suggestions welcome.

