### PR TITLE
RA: fix valid authz reuse control for V2 newOrder.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1743,6 +1743,11 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	// authorizations correspond to
 	nameToExistingAuthz := make(map[string]*corepb.Authorization, len(order.Names))
 	for _, v := range existingAuthz.Authz {
+		// Don't reuse a valid authorization if the reuseValidAuthz flag is
+		// disabled.
+		if *v.Authz.Status == string(core.StatusValid) && !ra.reuseValidAuthz {
+			continue
+		}
 		nameToExistingAuthz[*v.Domain] = v.Authz
 	}
 


### PR DESCRIPTION
Before fixing `ra.NewOrder` the `TestNewOrderAuthzReuseDisabled` test
from this branch fails as expected based on #4026:
```
=== RUN   TestNewOrderAuthzReuseDisabled
--- FAIL: TestNewOrderAuthzReuseDisabled (0.24s)
    ra_test.go:2477: "reused-valid-authz" == "reused-valid-authz"
    FAIL
    FAIL        github.com/letsencrypt/boulder/ra       0.270s
```

Afterwards it passes:
```
=== RUN   TestNewOrderAuthzReuseDisabled
--- PASS: TestNewOrderAuthzReuseDisabled (0.26s)
PASS
ok      github.com/letsencrypt/boulder/ra       1.291s
```

Resolves #4026.