### PR TITLE
Break dependency on Golang docker image

### DIFF
--- a/test/boulder-tools/Dockerfile.tmpl
+++ b/test/boulder-tools/Dockerfile.tmpl
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch-scm
 
-ENV GO_VERSION_TO_INSTALL 1.10.8
-#ENV GO_VERSION_TO_INSTALL %%GO_VERSION%%
+ENV GO_VERSION_TO_INSTALL %%GO_VERSION%%
 
 # Copied from https://github.com/docker-library/golang/blob/master/Dockerfile-debian.template
 ENV GOPATH /go

--- a/test/boulder-tools/Dockerfile.tmpl
+++ b/test/boulder-tools/Dockerfile.tmpl
@@ -1,4 +1,13 @@
-FROM golang:%%GO_VERSION%%
+FROM buildpack-deps:stretch-scm
+
+ENV GO_VERSION_TO_INSTALL 1.10.8
+#ENV GO_VERSION_TO_INSTALL %%GO_VERSION%%
+
+# Copied from https://github.com/docker-library/golang/blob/master/Dockerfile-debian.template
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
 
 ADD build.sh /tmp/build.sh
 RUN /tmp/build.sh

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -2,6 +2,12 @@
 
 apt-get update
 
+# Install Go.
+url="https://dl.google.com/go/go${GO_VERSION_TO_INSTALL}.linux-amd64.tar.gz"
+wget -O go.tgz "$url"; \
+tar -C /usr/local -xzf go.tgz; \
+rm go.tgz;
+
 # Job %1 - Start a background job to install system deps
 apt-get install -y --no-install-recommends \
   libltdl-dev \

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -8,7 +8,7 @@ wget -O go.tgz "$url"; \
 tar -C /usr/local -xzf go.tgz; \
 rm go.tgz;
 
-# Job %1 - Start a background job to install system deps
+# Install system deps
 apt-get install -y --no-install-recommends \
   libltdl-dev \
   mariadb-client-core-10.1 \
@@ -22,12 +22,12 @@ apt-get install -y --no-install-recommends \
   cmake \
   libssl-dev \
   libseccomp-dev \
-  opensc &
+  opensc
 
 # Override default GOBIN and GOPATH
 export GOBIN=/usr/local/bin GOPATH=/tmp/gopath
 
-# Job %2 - Install protobuf and testing/dev tools.
+# Install protobuf and testing/dev tools.
 go get \
   github.com/letsencrypt/pebble/cmd/pebble-challtestsrv \
   bitbucket.org/liamstask/goose/cmd/goose \
@@ -40,12 +40,7 @@ go get \
   github.com/modocache/gover \
   github.com/tools/godep \
   golang.org/x/tools/cover \
-  golang.org/x/tools/cmd/stringer &
-
-# Wait for all the background jobs to finish, capture their error codes, then
-# if bad, exit early rather than build an incomplete image.
-wait %1 || exit $?
-wait %2 || exit $?
+  golang.org/x/tools/cmd/stringer
 
 # grpc uses a version attestation variable of the form grpc.SupportPackageIsVersionN
 # where N is the generated code version shared between protoc-gen-go and grpc-go
@@ -85,7 +80,7 @@ gem install fpm
 
 # We can't remove libseccomp-dev as it contains a shared object that is required
 # for pkcs11-proxy to run properly
-apt-get autoremove -y build-essential cmake libssl-dev ruby-dev
+apt-get autoremove -y libssl-dev ruby-dev
 apt-get clean -y
 
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.10.6" "1.11.4" )
+GO_VERSIONS=( "1.10.8" "1.11.5" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
When a Golang security release comes out, we don't want to wait on
the upstream Docker image to update and upload before we can start
running tests on it. This changes our boulder-tools image so it
can download and install Golang itself.

Also, fix some issues in build.sh:

Unparallelize the `go get` with the `apt install`. The `go get`
pulls in `go-sqlite3`, which needs `cmake`, installed by `apt install`.
    
Also, don't remove build-essential and cmake at the end.