### PR TITLE
ocsp-updater: exploit isExpired index for revoked query.

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -336,7 +336,7 @@ func (updater *OCSPUpdater) markExpired(status core.CertificateStatus) error {
 }
 
 func (updater *OCSPUpdater) findRevokedCertificatesToUpdate(batchSize int) ([]core.CertificateStatus, error) {
-	const query = "WHERE status = ? AND ocspLastUpdated <= revokedDate LIMIT ?"
+	const query = "WHERE NOT isExpired AND status = ? AND ocspLastUpdated <= revokedDate LIMIT ?"
 	statuses, err := sa.SelectCertificateStatuses(
 		updater.dbMap,
 		query,


### PR DESCRIPTION
Before modifying the `findRevokedCertificatesToUpdate` query to include `NOT
isExpired` the query shows no `possible_keys` in `EXPLAIN` output.

```
MariaDB [boulder_sa_integration]> explain SELECT serial, status, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, ocspResponse, notAfter, isExpired FROM certificateStatus WHERE status = 'revoked' AND ocspLastUpdated <= revokedDate LIMIT 1000;
+------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
| id   | select_type | table             | type | possible_keys | key  | key_len | ref  | rows | Extra       |
+------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
|    1 | SIMPLE      | certificateStatus | ALL  | NULL          | NULL | NULL    | NULL |  208 | Using where |
+------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
1 row in set (0.01 sec)
```

Afterwards we see `isExpired_ocspLastUpdated_idx` is considered:

```
MariaDB [boulder_sa_integration]> explain SELECT serial, status, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, ocspResponse, notAfter, isExpired FROM certificateStatus WHERE NOT isExpired AND status = 'revoked' AND ocspLastUpdated <= revokedDate LIMIT 1000;
+------+-------------+-------------------+------+-------------------------------+------+---------+------+------+-------------+
| id   | select_type | table             | type | possible_keys                 | key  | key_len | ref  | rows | Extra       |
+------+-------------+-------------------+------+-------------------------------+------+---------+------+------+-------------+
|    1 | SIMPLE      | certificateStatus | ALL  | isExpired_ocspLastUpdated_idx | NULL | NULL    | NULL |  208 | Using where |
+------+-------------+-------------------+------+-------------------------------+------+---------+------+------+-------------+
1 row in set (0.00 sec)

MariaDB [boulder_sa_integration]>
```

Resolves https://github.com/letsencrypt/boulder/issues/4010