### PR TITLE
Config: serverAddresses -> serverAddress.

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/letsencrypt/boulder/bdns"
@@ -130,15 +129,11 @@ func main() {
 		for _, rva := range c.VA.RemoteVAs {
 			vaConn, err := bgrpc.ClientSetup(&rva, tlsConfig, clientMetrics, clk)
 			cmd.FailOnError(err, "Unable to create remote VA client")
-			addr := rva.ServerAddress
-			if addr == "" {
-				addr = strings.Join(rva.ServerAddresses, ",")
-			}
 			remotes = append(
 				remotes,
 				va.RemoteVA{
 					ValidationAuthority: bgrpc.NewValidationAuthorityGRPCClient(vaConn),
-					Addresses:           addr,
+					Addresses:           rva.ServerAddress,
 				},
 			)
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -253,11 +253,8 @@ func (d *ConfigDuration) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 // GRPCClientConfig contains the information needed to talk to the gRPC service
 type GRPCClientConfig struct {
-	// NOTE: this field is deprecated in favor of ServerAddress, as we only ever
-	// expect a single address
-	ServerAddresses []string
-	ServerAddress   string
-	Timeout         ConfigDuration
+	ServerAddress string
+	Timeout       ConfigDuration
 }
 
 // GRPCServerConfig contains the information needed to run a gRPC service

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -19,12 +19,7 @@ import (
 // It dials the remote service and returns a grpc.ClientConn if successful.
 func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientMetrics, clk clock.Clock) (*grpc.ClientConn, error) {
 	if c.ServerAddress == "" {
-		if len(c.ServerAddresses) == 0 {
-			return nil, errors.New("Both ServerAddress and ServerAddresses are empty")
-		} else if len(c.ServerAddresses) != 1 {
-			return nil, errors.New("If ServerAddress is empty ServerAddresses can only contain one address")
-		}
-		c.ServerAddress = c.ServerAddresses[0]
+		return nil, errors.New("ServerAddress must not be empty")
 	}
 	if tlsConfig == nil {
 		return nil, errNilTLS

--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -8,11 +8,11 @@
       "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra.boulder:9094"],
+      "serverAddress": "ra.boulder:9094",
       "timeout": "15s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     }
   },

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -11,7 +11,7 @@
       "keyFile": "test/grpc-creds/ca.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "grpcCA": {

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -11,7 +11,7 @@
       "keyFile": "test/grpc-creds/ca.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "grpcCA": {

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -18,7 +18,7 @@
       "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -26,11 +26,11 @@
       "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "ocspGeneratorService": {
-      "serverAddresses": ["ca.boulder:9096"],
+      "serverAddress": "ca.boulder:9096",
       "timeout": "15s"
     },
     "features": {

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -12,7 +12,7 @@
   },
 
   "saService": {
-    "serverAddresses": ["sa.boulder:9095"],
+    "serverAddress": "sa.boulder:9095",
     "timeout": "15s"
   }
 }

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -22,19 +22,19 @@
       "keyFile": "test/grpc-creds/ra.boulder/key.pem"
     },
     "vaService": {
-      "serverAddresses": ["va.boulder:9092"],
+      "serverAddress": "va.boulder:9092",
       "timeout": "20s"
     },
     "caService": {
-      "serverAddresses": ["ca.boulder:9093"],
+      "serverAddress": "ca.boulder:9093",
       "timeout": "15s"
     },
     "publisherService": {
-      "serverAddresses": ["publisher.boulder:9091"],
+      "serverAddress": "publisher.boulder:9091",
       "timeout": "300s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "grpc": {

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -23,11 +23,11 @@
       "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra.boulder:9094"],
+      "serverAddress": "ra.boulder:9094",
       "timeout": "20s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "features": {

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -23,11 +23,11 @@
       "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
     },
     "raService": {
-      "serverAddresses": ["ra.boulder:9094"],
+      "serverAddress": "ra.boulder:9094",
       "timeout": "15s"
     },
     "saService": {
-      "serverAddresses": ["sa.boulder:9095"],
+      "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
     "certificateChains": {


### PR DESCRIPTION
The plural `serverAddresses` field in gRPC config has been deprecated for a bit now. We've removed the last usages of it in our staging/prod environments and can clear out the related code. Moving forward we only support a singular `serverAddress` and rely on DNS to direct to multiple instances of a given server.