### PR TITLE
Fix mailer error bug

### DIFF
--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -340,33 +340,29 @@ func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
 			// After reconnecting, loop around and try `sendOne` again.
 			m.stats.Inc("SendMail.Reconnects", 1)
 			continue
-		} else if err != nil {
-			if protoErr, ok := err.(*textproto.Error); ok {
-				/*
-				 *  If the error is an instance of `textproto.Error` with a SMTP error code,
-				 *  and that error code is 421 then treat this as a reconnect-able event.
-				 *
-				 *  The SMTP RFC defines this error code as:
-				 *   421 <domain> Service not available, closing transmission channel
-				 *   (This may be a reply to any command if the service knows it
-				 *   must shut down)
-				 *
-				 * In practice we see this code being used by our production SMTP server
-				 * when the connection has gone idle for too long. For more information
-				 * see issue #2249[0].
-				 *
-				 * [0] - https://github.com/letsencrypt/boulder/issues/2249
-				 */
-				if protoErr.Code == 421 {
-					m.stats.Inc("SendMail.Errors.SMTP.421", 1)
-					m.reconnect()
-					m.stats.Inc("SendMail.Reconnects", 1)
-				} else if _, ok := recoverableErrorCodes[protoErr.Code]; ok {
-					m.stats.Inc(fmt.Sprintf("SendMail.Errors.SMTP.%d", protoErr.Code), 1)
-					return RecoverableSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
-				}
-			}
-
+		} else if protoErr, ok := err.(*textproto.Error); ok && protoErr.Code == 421 {
+			/*
+			 *  If the error is an instance of `textproto.Error` with a SMTP error code,
+			 *  and that error code is 421 then treat this as a reconnect-able event.
+			 *
+			 *  The SMTP RFC defines this error code as:
+			 *   421 <domain> Service not available, closing transmission channel
+			 *   (This may be a reply to any command if the service knows it
+			 *   must shut down)
+			 *
+			 * In practice we see this code being used by our production SMTP server
+			 * when the connection has gone idle for too long. For more information
+			 * see issue #2249[0].
+			 *
+			 * [0] - https://github.com/letsencrypt/boulder/issues/2249
+			 */
+			m.stats.Inc("SendMail.Errors.SMTP.421", 1)
+			m.reconnect()
+			m.stats.Inc("SendMail.Reconnects", 1)
+		} else if protoErr, ok := err.(*textproto.Error); ok && recoverableErrorCodes[protoErr.Code] {
+			m.stats.Inc(fmt.Sprintf("SendMail.Errors.SMTP.%d", protoErr.Code), 1)
+			return RecoverableSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
+		} else {
 			// If it wasn't an EOF error or a recoverable SMTP error it is unexpected and we
 			// return from SendMail() with the error
 			m.stats.Inc("SendMail.Errors", 1)

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net"
 	"net/mail"
+	"net/textproto"
 	"strconv"
 	"strings"
 	"testing"
@@ -336,4 +337,98 @@ func TestReconnectSMTP421(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected SendMail() to not fail. Got err: %s", err)
 	}
+}
+
+func TestOtherError(t *testing.T) {
+	m, l, cleanUp := setup(t)
+	defer cleanUp()
+	const messages = 3
+
+	go listenForever(l, t, func(_ int, t *testing.T, conn net.Conn) {
+		defer func() {
+			err := conn.Close()
+			if err != nil {
+				t.Errorf("conn.Close: %s", err)
+			}
+		}()
+		authenticateClient(t, conn)
+
+		buf := bufio.NewReader(conn)
+		if err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME"); err != nil {
+			return
+		}
+
+		_, _ = conn.Write([]byte("250 Sure. Go on. \r\n"))
+
+		if err := expect(t, buf, "RCPT TO:<hi@bye.com>"); err != nil {
+			return
+		}
+
+		_, _ = conn.Write([]byte("999 1.1.1 This would probably be bad?\r\n"))
+
+		if err := expect(t, buf, "RSET"); err != nil {
+			return
+		}
+
+		_, _ = conn.Write([]byte("250 Ok yr rset now\r\n"))
+	})
+
+	err := m.Connect()
+	if err != nil {
+		t.Errorf("Failed to connect: %s", err)
+	}
+
+	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	// We expect there to be an error
+	if err == nil {
+		t.Errorf("Expected SendMail() to return an error, got nil")
+	}
+	expected := "999 1.1.1 This would probably be bad?"
+	if rcptErr, ok := err.(*textproto.Error); !ok {
+		t.Errorf("Expected SendMail() to return an textproto.Error, got a %T error: %v", err, err)
+	} else if rcptErr.Error() != expected {
+		t.Errorf("SendMail() returned textproto.Error with wrong message. Got %q, expected %q\n",
+			rcptErr.Error(), expected)
+	}
+
+	m, l, cleanUp = setup(t)
+	defer cleanUp()
+
+	go listenForever(l, t, func(_ int, t *testing.T, conn net.Conn) {
+		defer func() {
+			err := conn.Close()
+			if err != nil {
+				t.Errorf("conn.Close: %s", err)
+			}
+		}()
+		authenticateClient(t, conn)
+
+		buf := bufio.NewReader(conn)
+		if err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME"); err != nil {
+			return
+		}
+
+		_, _ = conn.Write([]byte("250 Sure. Go on. \r\n"))
+
+		if err := expect(t, buf, "RCPT TO:<hi@bye.com>"); err != nil {
+			return
+		}
+
+		_, _ = conn.Write([]byte("999 1.1.1 This would probably be bad?\r\n"))
+
+		if err := expect(t, buf, "RSET"); err != nil {
+			return
+		}
+
+		_, _ = conn.Write([]byte("nop\r\n"))
+	})
+	err = m.Connect()
+	if err != nil {
+		t.Errorf("Failed to connect: %s", err)
+	}
+
+	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	// We expect there to be an error
+	test.AssertError(t, err, "SendMail didn't fail as expected")
+	test.AssertEquals(t, err.Error(), "999 1.1.1 This would probably be bad? (also, on sending RSET: short response: nop)")
 }


### PR DESCRIPTION
This fixes two bugs:
1. `resetAndError` would be called on every error, including `io.EOF`, which is returned when the connection is terminated. Calling `m.client.Reset()` after a `io.EOF` will result in another error, causing us to wrap the `io.EOF` with a `errors.errorString`. This broke a check in `sendMail` that was used to cause a reconnect.
2. There was a error type cast that assumed the type without checking it, which could result in a panic when an error of the unexpected type was returned. 