### PR TITLE
CI/Dev: Remove boulder-tools Certbot version pin.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.5}:2019-01-23
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.5}:2019-02-11
         environment:
             FAKE_DNS: 127.0.0.1
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -51,7 +51,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.5}:2019-01-23
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.5}:2019-02-11
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -73,7 +73,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.5}:2019-01-23
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.11.5}:2019-02-11
         networks:
           - bluenet
         volumes:

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -54,12 +54,8 @@ go install ./
 
 git clone https://github.com/certbot/certbot /certbot
 cd /certbot
-# Checkout a specific commit of Certbot prior to PR 6144[0] landing. This is
-# required for the config-next integration tests for TLS-ALPN-01 to function.
-# [0] - https://github.com/certbot/certbot/pull/6144
-git checkout 87e1912bf91cf91e8ff1d3e4d5928353ae1a294c
 ./letsencrypt-auto --os-packages-only
-./tools/venv.sh
+./tools/venv.py
 cd -
 
 # Install pkcs11-proxy. Checked out commit was master HEAD at time


### PR DESCRIPTION
The upstream Certbot project acme module supports initiating TLS-ALPN-01 challenges again since https://github.com/certbot/certbot/commit/30803f30ba63742cf98f4c6fbfcf890317d558ae and so we can remove the version pin we had in place. This lets us keep the Certbot version we're testing with in-sync with master at the time of building the tools image again.

Resolves https://github.com/letsencrypt/boulder/issues/4033