### PR TITLE
VA: Promote singleDialTimeout, add preresolvedDialer timeout test.

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -25,6 +25,7 @@ type preresolvedDialer struct {
 	ip       net.IP
 	port     int
 	hostname string
+	timeout  time.Duration
 }
 
 // a dialerMismatchError is produced when a preresolvedDialer is used to dial
@@ -103,10 +104,10 @@ func (d *preresolvedDialer) DialContext(
 	// Make a new dial address using the pre-resolved IP and port.
 	targetAddr := net.JoinHostPort(d.ip.String(), strconv.Itoa(d.port))
 
-	// Create a throw-away dialer using default values and the VA
-	// singleDialTimeout
+	// Create a throw-away dialer using default values and the dialer timeout
+	// (populated from the VA singleDialTimeout).
 	throwAwayDialer := &net.Dialer{
-		Timeout: singleDialTimeout,
+		Timeout: d.timeout,
 		// Default KeepAlive - see Golang src/net/http/transport.go DefaultTransport
 		KeepAlive: 30 * time.Second,
 	}
@@ -340,6 +341,7 @@ func (va *ValidationAuthorityImpl) setupHTTPValidation(
 		ip:       targetIP,
 		port:     target.port,
 		hostname: target.host,
+		timeout:  va.singleDialTimeout,
 	}
 	return dialer, record, nil
 }

--- a/va/va.go
+++ b/va/va.go
@@ -50,12 +50,6 @@ const (
 	ACMETLS1Protocol = "acme-tls/1"
 )
 
-// singleDialTimeout specifies how long an individual `DialContext` operation may take
-// before timing out. This timeout ignores the base RPC timeout and is strictly
-// used for the DialContext operations that take place during an
-// HTTP-01/TLS-SNI-[01|02] challenge validation.
-const singleDialTimeout = time.Second * 10
-
 // NOTE: unfortunately another document claimed the OID we were using in draft-ietf-acme-tls-alpn-01
 // for their own extension and IANA chose to assign it early. Because of this we had to increment
 // the id-pe-acmeIdentifier OID. Since there are in the wild implementations that use the original
@@ -154,6 +148,7 @@ type ValidationAuthorityImpl struct {
 	remoteVAs          []RemoteVA
 	maxRemoteFailures  int
 	accountURIPrefixes []string
+	singleDialTimeout  time.Duration
 
 	metrics *vaMetrics
 }
@@ -201,6 +196,11 @@ func NewValidationAuthorityImpl(
 		remoteVAs:          remoteVAs,
 		maxRemoteFailures:  maxRemoteFailures,
 		accountURIPrefixes: accountURIPrefixes,
+		// singleDialTimeout specifies how long an individual `DialContext` operation may take
+		// before timing out. This timeout ignores the base RPC timeout and is strictly
+		// used for the DialContext operations that take place during an
+		// HTTP-01/TLS-SNI-[01|02] challenge validation.
+		singleDialTimeout: 10 * time.Second,
 	}, nil
 }
 
@@ -249,6 +249,7 @@ type http01Dialer struct {
 	port        string
 	stats       metrics.Scope
 	dialerCount int
+	timeout     time.Duration
 
 	addrInfoChan chan addrRecord
 }
@@ -260,7 +261,7 @@ type http01Dialer struct {
 func (d *http01Dialer) realDialer() *net.Dialer {
 	// Record that we created a new instance of a real net.Dialer
 	d.dialerCount++
-	return &net.Dialer{Timeout: singleDialTimeout}
+	return &net.Dialer{Timeout: d.timeout}
 }
 
 // DialContext processes the IP addresses from the inner validation record, using
@@ -348,6 +349,7 @@ func (va *ValidationAuthorityImpl) newHTTP01Dialer(host string, port int, addrs 
 		port:         strconv.Itoa(port),
 		addrs:        addrs,
 		stats:        va.stats,
+		timeout:      va.singleDialTimeout,
 		addrInfoChan: make(chan addrRecord, 1),
 	}
 }
@@ -691,7 +693,7 @@ func (va *ValidationAuthorityImpl) getTLSCerts(
 // tlsDial does the equivalent of tls.Dial, but obeying a context. Once
 // tls.DialContextWithDialer is available, switch to that.
 func (va *ValidationAuthorityImpl) tlsDial(ctx context.Context, hostPort string, config *tls.Config) (*tls.Conn, error) {
-	ctx, cancel := context.WithTimeout(ctx, singleDialTimeout)
+	ctx, cancel := context.WithTimeout(ctx, va.singleDialTimeout)
 	defer cancel()
 	dialer := &net.Dialer{}
 	netConn, err := dialer.DialContext(ctx, "tcp", hostPort)


### PR DESCRIPTION
The `singleDialTimeout` field was previously a global `const` in the `va` package. Making it a field of the VA impl (and the dialer structs) makes it easier to test that it is working as expected with a smaller
than normal value.

A new `TestPreresolvedDialerTimeout` unit test is added that tests the fix from https://github.com/letsencrypt/boulder/pull/4046

Without the fix applied:
```
=== RUN   TestPreresolvedDialerTimeout
--- FAIL: TestPreresolvedDialerTimeout (0.49s)
    http_test.go:86: fetch didn't timeout after 50ms
    FAIL
    FAIL  github.com/letsencrypt/boulder/va 0.512s
```

With the fix applied:
```
=== RUN   TestPreresolvedDialerTimeout
--- PASS: TestPreresolvedDialerTimeout (0.05s)
PASS
ok    github.com/letsencrypt/boulder/va 1.075s
```

Resolves https://github.com/letsencrypt/boulder/issues/4034