### PR TITLE
WFE2: Always send Link header for directory URL.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -175,6 +175,13 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h web
 					logEvent.AddError("unable to make nonce: %s", err)
 				}
 			}
+			// Per section 7.1 "Resources":
+			//   The "index" link relation is present on all resources other than the
+			//   directory and indicates the URL of the directory.
+			if pattern != directoryPath {
+				directoryURL := web.RelativeEndpoint(request, "index")
+				response.Header().Add("Link", link(directoryURL, "index"))
+			}
 
 			logEvent.Endpoint = pattern
 			if request.URL != nil {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -448,6 +448,7 @@ func TestHandleFunc(t *testing.T) {
 		{[]string{"GET"}, "POST", false, false, "/test"},
 		{[]string{"GET"}, "OPTIONS", false, true, "/test"},
 		{[]string{"GET"}, "MAKE-COFFEE", false, false, "/test"}, // 405, or 418?
+		{[]string{"GET"}, "GET", true, true, directoryPath},
 	} {
 		runWrappedHandler(&http.Request{Method: c.reqMethod}, c.pattern, c.allowed...)
 		test.AssertEquals(t, stubCalled, c.shouldCallStub)
@@ -468,6 +469,14 @@ func TestHandleFunc(t *testing.T) {
 			test.AssertNotEquals(t, nonce, lastNonce)
 			test.AssertNotEquals(t, nonce, "")
 			lastNonce = nonce
+		}
+		linkHeader := rw.Header().Get("Link")
+		if c.pattern != directoryPath {
+			// If the pattern wasn't the directory there should be a Link header for the index
+			test.AssertEquals(t, linkHeader, `<http://localhost/index>;rel="index"`)
+		} else {
+			// The directory resource shouldn't get a link header
+			test.AssertEquals(t, linkHeader, "")
 		}
 	}
 


### PR DESCRIPTION
All HTTP responses for requests to resources (other than the directory resource) should get a `Link` header with the `"index"` relation that points to the ACME directory URL. See
https://tools.ietf.org/html/draft-ietf-acme-acme-18#section-7.1