### PR TITLE
RA: apply certificate rate limits at NewOrder time.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -4,9 +4,9 @@ package features
 
 import "strconv"
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIProbeCTLogsSimplifiedVAHTTPHeadNonceStatusOKNewAuthorizationSchemaRevokeAtRASetIssuedNamesRenewalBit"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverAllowRenewalFirstRLTLSSNIRevalidationCAAValidationMethodsCAAAccountURIProbeCTLogsSimplifiedVAHTTPHeadNonceStatusOKNewAuthorizationSchemaRevokeAtRASetIssuedNamesRenewalBitEarlyOrderRateLimit"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 26, 43, 62, 80, 100, 113, 124, 140, 157, 179, 189, 213}
+var _FeatureFlag_index = [...]uint8{0, 6, 26, 43, 62, 80, 100, 113, 124, 140, 157, 179, 189, 213, 232}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -38,6 +38,9 @@ const (
 	// SetIssuedNamesRenewalBit enables the SA setting the renewal bit for
 	// issuedNames entries during AddCertificate.
 	SetIssuedNamesRenewalBit
+	// EarlyOrderRateLimit enables the RA applying certificate per name/per FQDN
+	// set rate limits in NewOrder in addition to FinalizeOrder.
+	EarlyOrderRateLimit
 )
 
 // List of features and their default value, protected by fMu
@@ -55,6 +58,7 @@ var features = map[FeatureFlag]bool{
 	NewAuthorizationSchema:   false,
 	RevokeAtRA:               false,
 	SetIssuedNamesRenewalBit: false,
+	EarlyOrderRateLimit:      false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -46,7 +46,8 @@
       ]
     },
     "features": {
-      "RevokeAtRA": true
+      "RevokeAtRA": true,
+      "EarlyOrderRateLimit": true
     },
     "CTLogGroups2": [
       {


### PR DESCRIPTION
If an order for a given set of names will fail finalization because of certificate rate limits (certs per domain, certs per fqdn set) there isn't any point in allowing an order for those names to be created. We can stop a lot of requests earlier by enforcing the cert rate limits at new order time as well as finalization time. A new RA `EarlyOrderRateLimit` feature flag controls whether this is done or not.

Resolves https://github.com/letsencrypt/boulder/issues/3975