### PR TITLE
WFE2: Don't allow finalizing pending orders, impl BadOrderState err type

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -515,10 +515,10 @@ func (sa *StorageAuthority) GetOrder(_ context.Context, req *sapb.OrderRequest) 
 		validOrder.RegistrationID = &six
 	}
 
-	// Order ID 7 is expired
+	// Order ID 7 is ready, but expired
 	if *req.Id == 7 {
-		pending := string(core.StatusPending)
-		validOrder.Status = &pending
+		ready := string(core.StatusReady)
+		validOrder.Status = &ready
 		exp = sa.clk.Now().AddDate(-30, 0, 0).Unix()
 		validOrder.Expires = &exp
 	}

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -21,6 +21,7 @@ const (
 	CAAProblem                 = ProblemType("caa")
 	DNSProblem                 = ProblemType("dns")
 	AlreadyRevokedProblem      = ProblemType("alreadyRevoked")
+	OrderNotReadyProblem       = ProblemType("orderNotReady")
 
 	V1ErrorNS = "urn:acme:error:"
 	V2ErrorNS = "urn:ietf:params:acme:error:"
@@ -260,5 +261,14 @@ func DNS(detail string, a ...interface{}) *ProblemDetails {
 		Type:       DNSProblem,
 		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// OrderNotReady returns a ProblemDetails representing a OrderNotReadyProblem
+func OrderNotReady(detail string, a ...interface{}) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       OrderNotReadyProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusForbidden,
 	}
 }

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -440,27 +440,9 @@ def test_order_finalize_early():
 
     deadline = datetime.datetime.now() + datetime.timedelta(seconds=5)
 
-    # Finalizing an order early should generate an unauthorized error and we
-    # should check that the order is invalidated.
-    chisel2.expect_problem("urn:ietf:params:acme:error:unauthorized",
+    # Finalizing an order early should generate an orderNotReady error.
+    chisel2.expect_problem("urn:ietf:params:acme:error:orderNotReady",
         lambda: client.finalize_order(order, deadline))
-
-    # Poll for a fixed amount of time checking for the order to become invalid
-    # from the early finalization attempt initiated above failing
-    while datetime.datetime.now() < deadline:
-        time.sleep(1)
-        updatedOrder = requests.get(order.uri).json()
-        if updatedOrder['status'] == "invalid":
-            break
-
-    # If the loop ended and the status isn't invalid then we reached the
-    # deadline waiting for the order to become invalid, fail the test
-    if updatedOrder['status'] != "invalid":
-        raise Exception("timed out waiting for order %s to become invalid" % order.uri)
-
-    # The order should have an error with the expected type
-    if updatedOrder['error']['type'] != 'urn:ietf:params:acme:error:unauthorized':
-        raise Exception("order %s has incorrect error field type: \"%s\"" % (order.uri, updatedOrder['error']['type']))
 
 def test_revoke_by_issuer():
     client = chisel2.make_client(None)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1805,13 +1805,8 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 		return
 	}
 
-	// Prior to ACME draft-10 the "ready" status did not exist and orders in
-	// a pending status with valid authzs were finalizable. We accept both states
-	// here for deployability ease. In the future we will only allow ready orders
-	// to be finalized.
-	// TODO(@cpu): Forbid finalizing "Pending" orders
-	if *order.Status != string(core.StatusPending) &&
-		*order.Status != string(core.StatusReady) {
+	// Only ready orders can be finalized.
+	if *order.Status != string(core.StatusReady) {
 		wfe.sendError(response, logEvent,
 			probs.Malformed(
 				"Order's status (%q) is not acceptable for finalization",

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1808,7 +1808,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	// Only ready orders can be finalized.
 	if *order.Status != string(core.StatusReady) {
 		wfe.sendError(response, logEvent,
-			probs.Malformed(
+			probs.OrderNotReady(
 				"Order's status (%q) is not acceptable for finalization",
 				*order.Status),
 			nil)

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2165,7 +2165,7 @@ func TestFinalizeOrder(t *testing.T) {
 			Name: "Order is already finalized",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 1 as an Order with a Serial
 			Request:      signAndPost(t, "1/1", "http://localhost/1/1", goodCertCSRPayload, 1, wfe.nonceService),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order's status (\"valid\") is not acceptable for finalization","status":400}`,
+			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `orderNotReady","detail":"Order's status (\"valid\") is not acceptable for finalization","status":403}`,
 		},
 		{
 			Name: "Order is expired",
@@ -2176,7 +2176,7 @@ func TestFinalizeOrder(t *testing.T) {
 		{
 			Name:         "Good CSR, Pending Order",
 			Request:      signAndPost(t, "1/4", "http://localhost/1/4", goodCertCSRPayload, 1, wfe.nonceService),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order's status (\"pending\") is not acceptable for finalization","status":400}`,
+			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `orderNotReady","detail":"Order's status (\"pending\") is not acceptable for finalization","status":403}`,
 		},
 		{
 			Name:            "Good CSR, Ready Order",

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2174,21 +2174,9 @@ func TestFinalizeOrder(t *testing.T) {
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order 7 is expired","status":404}`,
 		},
 		{
-			Name:            "Good CSR, Pending Order",
-			Request:         signAndPost(t, "1/4", "http://localhost/1/4", goodCertCSRPayload, 1, wfe.nonceService),
-			ExpectedHeaders: map[string]string{"Location": "http://localhost/acme/order/1/4"},
-			ExpectedBody: `
-{
-  "status": "processing",
-  "expires": "1970-01-01T00:00:00.9466848Z",
-  "identifiers": [
-    {"type":"dns","value":"example.com"}
-  ],
-  "authorizations": [
-    "http://localhost/acme/authz/hello"
-  ],
-  "finalize": "http://localhost/acme/finalize/1/4"
-}`,
+			Name:         "Good CSR, Pending Order",
+			Request:      signAndPost(t, "1/4", "http://localhost/1/4", goodCertCSRPayload, 1, wfe.nonceService),
+			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order's status (\"pending\") is not acceptable for finalization","status":400}`,
 		},
 		{
 			Name:            "Good CSR, Ready Order",
@@ -2229,7 +2217,7 @@ func TestFinalizeOrder(t *testing.T) {
 	// to match the whole response body because the "detail" of a bad CSR problem
 	// contains a verbose Go error message that can change between versions (e.g.
 	// Go 1.10.4 to 1.11 changed the expected format)
-	badCSRReq := signAndPost(t, "1/4", "http://localhost/1/4", `{"CSR": "ABCD"}`, 1, wfe.nonceService)
+	badCSRReq := signAndPost(t, "1/8", "http://localhost/1/8", `{"CSR": "ABCD"}`, 1, wfe.nonceService)
 	responseWriter.Body.Reset()
 	responseWriter.HeaderMap = http.Header{}
 	wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, badCSRReq)
@@ -2819,7 +2807,7 @@ func TestFinalizeSCTError(t *testing.T) {
 	}`
 
 	// Create a finalization request with the above payload
-	request := signAndPost(t, "1/4", "http://localhost/1/4", goodCertCSRPayload, 1, wfe.nonceService)
+	request := signAndPost(t, "1/8", "http://localhost/1/8", goodCertCSRPayload, 1, wfe.nonceService)
 
 	// POST the finalize order request.
 	wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, request)


### PR DESCRIPTION
We've been using the newer "ready" order status for longer than the lifetime of any previously "pending" orders. I believe this means we can drop the legacy allowance for finalizing pending orders and enforce finalization only occur for "ready" orders without any feature flags. This is implemented in c85d4b0.

There is a new error type added in the draft spec (`orderNotReady`) that should be returned to clients that finalize an order in state other than "ready". This is implemented in 6008202. 

Resolves https://github.com/letsencrypt/boulder/issues/4073