### PR TITLE
ratelimit: use larger of regID/key overrides in GetThreshold.

### DIFF
--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -187,14 +187,29 @@ func (rlp *RateLimitPolicy) Enabled() bool {
 }
 
 // GetThreshold returns the threshold for this rate limit, taking into account
-// any overrides for `key`.
+// any overrides for `key` or `regID`. If both `key` and `regID` have an
+// override the largest of the two will be used.
 func (rlp *RateLimitPolicy) GetThreshold(key string, regID int64) int {
-	if override, ok := rlp.RegistrationOverrides[regID]; ok {
-		return override
+	regOverride, regOverrideExists := rlp.RegistrationOverrides[regID]
+	keyOverride, keyOverrideExists := rlp.Overrides[key]
+
+	if regOverrideExists && !keyOverrideExists {
+		// If there is a regOverride and no keyOverride use the regOverride
+		return regOverride
+	} else if !regOverrideExists && keyOverrideExists {
+		// If there is a keyOverride and no regOverride use the keyOverride
+		return keyOverride
+	} else if regOverrideExists && keyOverrideExists {
+		// If there is both a regOverride and a keyOverride use whichever is larger.
+		if regOverride > keyOverride {
+			return regOverride
+		} else {
+			return keyOverride
+		}
 	}
-	if override, ok := rlp.Overrides[key]; ok {
-		return override
-	}
+
+	// Otherwise there was no regOverride and no keyOverride, use the base
+	// Threshold
 	return rlp.Threshold
 }
 

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -32,22 +32,58 @@ func TestGetThreshold(t *testing.T) {
 		Threshold: 1,
 		Overrides: map[string]int{
 			"key": 2,
+			"baz": 99,
 		},
 		RegistrationOverrides: map[int64]int{
 			101: 3,
 		},
 	}
-	if policy.GetThreshold("foo", 11) != 1 {
-		t.Errorf("threshold should have been 1")
+
+	testCases := []struct {
+		Name     string
+		Key      string
+		RegID    int64
+		Expected int
+	}{
+
+		{
+			Name:     "No key or reg overrides",
+			Key:      "foo",
+			RegID:    11,
+			Expected: 1,
+		},
+		{
+			Name:     "Key override, no reg override",
+			Key:      "key",
+			RegID:    11,
+			Expected: 2,
+		},
+		{
+			Name:     "No key override, reg override",
+			Key:      "foo",
+			RegID:    101,
+			Expected: 3,
+		},
+		{
+			Name:     "Key override, larger reg override",
+			Key:      "foo",
+			RegID:    101,
+			Expected: 3,
+		},
+		{
+			Name:     "Key override, smaller reg override",
+			Key:      "baz",
+			RegID:    101,
+			Expected: 99,
+		},
 	}
-	if policy.GetThreshold("key", 11) != 2 {
-		t.Errorf("threshold should have been 2")
-	}
-	if policy.GetThreshold("key", 101) != 3 {
-		t.Errorf("threshold should have been 3")
-	}
-	if policy.GetThreshold("foo", 101) != 3 {
-		t.Errorf("threshold should have been 3")
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			test.AssertEquals(t,
+				policy.GetThreshold(tc.Key, tc.RegID),
+				tc.Expected)
+		})
 	}
 }
 


### PR DESCRIPTION
If there is a rate limit override for both the key being examined and the regID in use then the ratelimit `GetThreshold` function should return the larger of the two.

Resolves https://github.com/letsencrypt/boulder/issues/4072