### PR TITLE
CI/Devenv: restore 20s RA->VA timeout.

### DIFF
--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -19,7 +19,7 @@
     },
     "vaService": {
       "serverAddress": "va.boulder:9092",
-      "timeout": "8s"
+      "timeout": "20s"
     },
     "caService": {
       "serverAddress": "ca.boulder:9093",

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -23,7 +23,7 @@
     },
     "vaService": {
       "serverAddress": "va.boulder:9092",
-      "timeout": "8s"
+      "timeout": "20s"
     },
     "caService": {
       "serverAddress": "ca.boulder:9093",

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -315,9 +315,9 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 class SlowHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         try:
-            # Sleeptime needs to be larger than the RA->VA timeout (8s at the
+            # Sleeptime needs to be larger than the RA->VA timeout (20s at the
             # time of writing)
-            sleeptime = 12
+            sleeptime = 22
             print("SlowHTTPRequestHandler: sleeping for {0}s\n".format(sleeptime))
             time.sleep(sleeptime)
             self.send_response(200)
@@ -363,8 +363,8 @@ def test_http_challenge_timeout():
 
     delta = end - start
     # Expected duration should be the RA->VA timeout plus some padding (At
-    # present the timeout is 8s so adding 4s of padding = 12s)
-    expectedDuration = 12
+    # present the timeout is 20s so adding 2s of padding = 22s)
+    expectedDuration = 22
     if delta.total_seconds() == 0 or delta.total_seconds() > expectedDuration:
         raise Exception("expected timeout to occur in under {0} seconds. Took {1}".format(expectedDuration, delta.total_seconds()))
 


### PR DESCRIPTION
I tried dropping the RA->VA timeout to make the `test_http_challenge_timeout` integration test faster. It seems to flake in CI so I'm restoring the original 20s timeout. This makes `test_http_challenge_timeout` slower but c'est la vie.