### PR TITLE
Remove issuanceExpvar.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -3,7 +3,6 @@ package ra
 import (
 	"crypto/x509"
 	"encoding/json"
-	"expvar"
 	"fmt"
 	"net"
 	"net/mail"
@@ -41,12 +40,6 @@ import (
 	"golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
-
-// Note: the issuanceExpvar must be a global. If it is a member of the RA, or
-// initialized with everything else in NewRegistrationAuthority() then multiple
-// invocations of the constructor (e.g from unit tests) will panic with a "Reuse
-// of exported var name:" error from the expvar package.
-var issuanceExpvar = expvar.NewInt("lastIssuance")
 
 type caaChecker interface {
 	IsCAAValid(
@@ -126,9 +119,9 @@ func NewRegistrationAuthorityImpl(
 	stats.MustRegister(ctpolicyResults)
 
 	ra := &RegistrationAuthorityImpl{
-		stats:                        stats,
-		clk:                          clk,
-		log:                          logger,
+		stats: stats,
+		clk:   clk,
+		log:   logger,
 		authorizationLifetime:        authorizationLifetime,
 		pendingAuthorizationLifetime: pendingAuthorizationLifetime,
 		rlPolicies:                   ratelimit.New(),
@@ -985,7 +978,6 @@ func (ra *RegistrationAuthorityImpl) issueCertificate(
 		logEvent.Error = err.Error()
 		result = "error"
 	} else {
-		issuanceExpvar.Set(ra.clk.Now().Unix())
 		result = "successful"
 	}
 	logEvent.ResponseTime = ra.clk.Now()

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -17,7 +17,6 @@ import (
 	"net/url"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1099,9 +1098,6 @@ func TestNewCertificate(t *testing.T) {
 	ExampleCSR.Signature[0]--
 	test.AssertError(t, err, "Failed to check CSR signature")
 
-	// Before issuance the issuanceExpvar should be 0
-	test.AssertEquals(t, issuanceExpvar.String(), "0")
-
 	// Check that we don't fail on case mismatches
 	ExampleCSR.Subject.CommonName = "www.NOT-example.com"
 	certRequest = core.CertificateRequest{
@@ -1110,10 +1106,6 @@ func TestNewCertificate(t *testing.T) {
 
 	cert, err := ra.NewCertificate(ctx, certRequest, Registration.ID)
 	test.AssertNotError(t, err, "Failed to issue certificate")
-
-	// After issuance the issuanceExpvar should be the current timestamp
-	now := ra.clk.Now()
-	test.AssertEquals(t, issuanceExpvar.String(), strconv.FormatInt(now.Unix(), 10))
 
 	_, err = x509.ParseCertificate(cert.DER)
 	test.AssertNotError(t, err, "Failed to parse certificate")


### PR DESCRIPTION
We've replaced this functionality with Prometheus variables, and there are no longer alerts that need it.