### PR TITLE
Remove Go 1.10 from test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - "1.11.5"
-  - "1.10.8"
 
 go_import_path: github.com/letsencrypt/boulder
 

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.10.8" "1.11.5" )
+GO_VERSIONS=( "1.11.5" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
We're now running 1.11 in prod.