### PR TITLE
WFE2: Fix index link relation target.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -179,7 +179,7 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h web
 			//   The "index" link relation is present on all resources other than the
 			//   directory and indicates the URL of the directory.
 			if pattern != directoryPath {
-				directoryURL := web.RelativeEndpoint(request, "index")
+				directoryURL := web.RelativeEndpoint(request, directoryPath)
 				response.Header().Add("Link", link(directoryURL, "index"))
 			}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -473,7 +473,7 @@ func TestHandleFunc(t *testing.T) {
 		linkHeader := rw.Header().Get("Link")
 		if c.pattern != directoryPath {
 			// If the pattern wasn't the directory there should be a Link header for the index
-			test.AssertEquals(t, linkHeader, `<http://localhost/index>;rel="index"`)
+			test.AssertEquals(t, linkHeader, `<http://localhost/directory>;rel="index"`)
 		} else {
 			// The directory resource shouldn't get a link header
 			test.AssertEquals(t, linkHeader, "")


### PR DESCRIPTION
b8ef85352b0264ff41fd898e3126da670c08c97d had a mistake that used `/index` as the index link relation target for ACME v2 and not `/directory`.

Resolves https://github.com/letsencrypt/boulder/issues/4106