### PR TITLE
RA: forbid finalizing pending orders.

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -19,6 +19,7 @@ const (
 	CAA
 	MissingSCTs
 	Duplicate
+	OrderNotReady
 )
 
 // BoulderError represents internal Boulder errors
@@ -97,4 +98,8 @@ func MissingSCTsError(msg string, args ...interface{}) error {
 
 func DuplicateError(msg string, args ...interface{}) error {
 	return New(Duplicate, msg, args...)
+}
+
+func OrderNotReadyError(msg string, args ...interface{}) error {
+	return New(OrderNotReady, msg, args...)
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -834,13 +834,7 @@ func (ra *RegistrationAuthorityImpl) failOrder(
 func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rapb.FinalizeOrderRequest) (*corepb.Order, error) {
 	order := req.Order
 
-	// Prior to ACME draft-10 the "ready" status did not exist and orders in
-	// a pending status with valid authzs were finalizable. We accept both states
-	// here for deployability ease. In the future we will only allow ready orders
-	// to be finalized.
-	// TODO(@cpu): Forbid finalizing "Pending" orders
-	if *order.Status != string(core.StatusPending) &&
-		*order.Status != string(core.StatusReady) {
+	if *order.Status != string(core.StatusReady) {
 		return nil, berrors.MalformedError(
 			"Order's status (%q) is not acceptable for finalization",
 			*order.Status)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -835,7 +835,7 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 	order := req.Order
 
 	if *order.Status != string(core.StatusReady) {
-		return nil, berrors.MalformedError(
+		return nil, berrors.OrderNotReadyError(
 			"Order's status (%q) is not acceptable for finalization",
 			*order.Status)
 	}

--- a/web/probs.go
+++ b/web/probs.go
@@ -31,6 +31,8 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		// MissingSCTs are an internal server error, but with a specific error
 		// message related to the SCT problem
 		return probs.ServerInternal("%s :: %s", msg, "Unable to meet CA SCT embedding requirements")
+	case berrors.OrderNotReady:
+		return probs.OrderNotReady("%s :: %s", msg, err)
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.


### PR DESCRIPTION
This cleanup was already done [on the WFE2 side](https://github.com/letsencrypt/boulder/commit/c105cfa5de012eb3ce24740f72af165aef18f37f#diff-ca032e0cdaf034fa3ef3736b81b24dc2) but I missed doing it it in the RA.