### PR TITLE
Enforce type equality in test.AssertEquals

### DIFF
--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -64,6 +64,9 @@ func AssertError(t *testing.T, err error, message string) {
 // AssertEquals uses the equality operator (==) to measure one and two
 func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 	t.Helper()
+	if reflect.TypeOf(one) != reflect.TypeOf(two) {
+		t.Fatalf("cannot test equality of different types: %T != %T", one, two)
+	}
 	if one != two {
 		t.Fatalf("%#v != %#v", one, two)
 	}


### PR DESCRIPTION
Because it's annoying when you get `0 != 0`.