### PR TITLE
CI: remove Go 1.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - "1.11.5"
   - "1.12"
 
 go_import_path: github.com/letsencrypt/boulder

--- a/test.sh
+++ b/test.sh
@@ -111,11 +111,6 @@ fi
 if [[ "$RUN" =~ "fmt" ]] ; then
   start_context "fmt"
   check_gofmt() {
-    # NOTE(@jsha): Go 1.11.5's gofmt and Go 1.12's gofmt don't agree. Let's
-    # temporarily ignore the gofmt check when not using Go 1.12
-    if [ "$TRAVIS_GO_VERSION" != "1.12" ]; then
-      return 0
-    fi
     unformatted=$(find . -name "*.go" -not -path "./vendor/*" -print | xargs -n1 gofmt -l)
     if [ "x${unformatted}" == "x" ] ; then
       return 0


### PR DESCRIPTION
We're officially on 1.12 in prod/staging and can deprecate the 1.11.x builds/tests in CI.