### PR TITLE
Copy boulder-va to boulder-remoteva.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ $(CMD_BINS): build_cmds
 
 build_cmds: | $(OBJDIR)
 	GOBIN=$(OBJDIR) go install $(GO_BUILD_FLAGS) ./...
+	cp $(OBJDIR)/boulder-va $(OBJDIR)/boulder-remoteva
 
 clean:
 	rm -f $(OBJDIR)/*

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -77,8 +77,8 @@ def start(race_detection, fakeclock=None, account_uri=None):
     if default_config_dir.startswith("test/config-next"):
         # Run the two 'remote' VAs
         progs.extend([
-            [8011, './bin/boulder-va --config %s' % os.path.join(default_config_dir, "va-remote-a.json")],
-            [8012, './bin/boulder-va --config %s' % os.path.join(default_config_dir, "va-remote-b.json")],
+            [8011, './bin/boulder-remoteva --config %s' % os.path.join(default_config_dir, "va-remote-a.json")],
+            [8012, './bin/boulder-remoteva --config %s' % os.path.join(default_config_dir, "va-remote-b.json")],
         ])
     progs.extend([
         [53, './bin/sd-test-srv --listen :53'], # Service discovery DNS server


### PR DESCRIPTION
This will make it easier to distinguish in logs.

Fixes #4124 