### PR TITLE
Use %T in GoodKey error fmt to handle nil keys

### DIFF
--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -6,7 +6,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rsa"
 	"math/big"
-	"reflect"
 	"sync"
 
 	berrors "github.com/letsencrypt/boulder/errors"
@@ -79,7 +78,7 @@ func (policy *KeyPolicy) GoodKey(key crypto.PublicKey) error {
 	case *ecdsa.PublicKey:
 		return policy.goodKeyECDSA(*t)
 	default:
-		return berrors.MalformedError("unknown key type %s", reflect.TypeOf(key))
+		return berrors.MalformedError("unknown key type %T", key)
 	}
 }
 

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -22,6 +22,12 @@ func TestUnknownKeyType(t *testing.T) {
 	test.AssertError(t, testingPolicy.GoodKey(notAKey), "Should have rejected a key of unknown type")
 }
 
+func TestNilKey(t *testing.T) {
+	e := testingPolicy.GoodKey(nil)
+	test.AssertError(t, e, "Should have rejected a nil key")
+	test.AssertNotContains(t, e.Error(), "%!")
+}
+
 func TestSmallModulus(t *testing.T) {
 	pubKey := rsa.PublicKey{
 		N: big.NewInt(0),


### PR DESCRIPTION
This is to prevent nil keys from generating format errors such as:

    unknown key type %!s(\u003cnil\u003e)

Reported @ https://community.letsencrypt.org/t/ed25519-csr-bug-or-an-unimplemented-feature/90117 . Perhaps nil keys should not even be getting this far (the fix should be somewhere earlier?).