### PR TITLE
Fix Finalize/DeactivateAuthorization DB deadlock

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1372,17 +1372,17 @@ func (ssa *SQLStorageAuthority) DeactivateAuthorization(ctx context.Context, id 
 		if authz.Status != core.StatusPending {
 			return Rollback(tx, berrors.WrongAuthorizationStateError("authorization not pending"))
 		}
+		authz.Status = core.StatusDeactivated
+		err = txWithCtx.Insert(&authzModel{authz.Authorization})
+		if err != nil {
+			return Rollback(tx, err)
+		}
 		result, err := txWithCtx.Delete(authzObj)
 		if err != nil {
 			return Rollback(tx, err)
 		}
 		if result != 1 {
 			return Rollback(tx, berrors.InternalServerError("wrong number of rows deleted: expected 1, got %d", result))
-		}
-		authz.Status = core.StatusDeactivated
-		err = txWithCtx.Insert(&authzModel{authz.Authorization})
-		if err != nil {
-			return Rollback(tx, err)
 		}
 	} else {
 		_, err = txWithCtx.Exec(


### PR DESCRIPTION
FinalizeAuthorization deleted from pendingAuthorizations and then added
to authz. DeactivateAuthorization did it in opposite order. This tweaks
them so they always do the insert / delete in the same order as each
other, to avoid deadlocks.

Fixes #4141 

I think it's probably not possible to meaningfully unit or integration test for this
but I'm open to suggestions.