### PR TITLE
sa: reuse "ready" orders in GetOrderForNames.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1714,7 +1714,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		return nil, err
 	}
 
-	// See if there is an existing, pending, unexpired order that can be reused
+	// See if there is an existing unexpired pending (or ready) order that can be reused
 	// for this account
 	existingOrder, err := ra.SA.GetOrderForNames(ctx, &sapb.GetOrderForNamesRequest{
 		AcctID: order.RegistrationID,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1824,9 +1824,9 @@ func (ssa *SQLStorageAuthority) GetValidOrderAuthorizations(
 	return byName, nil
 }
 
-// GetOrderForNames tries to find a **pending** order with the exact set of
-// names requested, associated with the given accountID. Only unexpired orders
-// with status pending are considered. If no order meeting these requirements is
+// GetOrderForNames tries to find a **pending** or **ready** order with the
+// exact set of names requested, associated with the given accountID. Only
+// unexpired orders are considered. If no order meeting these requirements is
 // found a nil corepb.Order pointer is returned.
 func (ssa *SQLStorageAuthority) GetOrderForNames(
 	ctx context.Context,
@@ -1858,8 +1858,9 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 	if err != nil {
 		return nil, err
 	}
-	// Only return a pending order
-	if *order.Status != string(core.StatusPending) {
+	// Only return a pending or ready order
+	if *order.Status != string(core.StatusPending) &&
+		*order.Status != string(core.StatusReady) {
 		return nil, berrors.NotFoundError("no order matching request found")
 	}
 	return order, nil


### PR DESCRIPTION
Previously only "pending" orders were returned by `sa.GetOrderForNames` for the RA to reuse in `ra.NewOrder`. When we added the "ready" status to match late RFC 8555 developments we forgot to update `GetOrderForNames` to return "ready" orders. Prior to the "ready" status existing a fully validated order would have been "pending" and reused. This branch updates the reuse logic to restore reuse of validated orders.

Resolves https://github.com/letsencrypt/boulder/issues/4117