### PR TITLE
tests: initialize caa_client var before ref.

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -198,6 +198,7 @@ def main():
     if not (args.run_all or args.run_certbot or args.run_chisel or args.run_loadtest or args.custom is not None):
         raise Exception("must run at least one of the letsencrypt or chisel tests with --all, --certbot, --chisel, --load or --custom")
 
+    caa_client = None
     if not args.skip_setup:
         now = datetime.datetime.utcnow()
         seventy_days_ago = now+datetime.timedelta(days=-70)


### PR DESCRIPTION
Without this change running a single integration tests with `INT_SKIP_SETUP` like so:

```
  docker-compose run --use-aliases -e INT_FILTER="test_http_multiva_threshold_pass" -e INT_SKIP_SETUP=true -e RUN="integration" boulder ./test.sh;
```

Produces an error like:

```
+ python2 test/integration-test.py --chisel --load --filter test_http_multiva_threshold_pass --skip-setup
Traceback (most recent call last):
  File "test/integration-test.py", line 309, in <module>
    main()
  File "test/integration-test.py", line 217, in main
    caa_account_uri = caa_client.account.uri if caa_client is not None else None
UnboundLocalError: local variable 'caa_client' referenced before assignment
```