### PR TITLE
fix volume definitions for selinux compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
             BOULDER_CONFIG_DIR: test/config
         volumes:
-            - .:/go/src/github.com/letsencrypt/boulder:z
-            - ./.gocache:/root/.cache/go-build:z
+          - .:/go/src/github.com/letsencrypt/boulder:z
+          - ./.gocache:/root/.cache/go-build:z
         networks:
           bluenet:
             ipv4_address: 10.77.77.77

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
             BOULDER_CONFIG_DIR: test/config
         volumes:
-          - .:/go/src/github.com/letsencrypt/boulder
-          - ./.gocache:/root/.cache/go-build
+            - .:/go/src/github.com/letsencrypt/boulder:z
+            - ./.gocache:/root/.cache/go-build:z
         networks:
           bluenet:
             ipv4_address: 10.77.77.77
@@ -77,7 +77,7 @@ services:
         networks:
           - bluenet
         volumes:
-          - .:/go/src/github.com/letsencrypt/boulder
+          - .:/go/src/github.com/letsencrypt/boulder:z
         working_dir: /go/src/github.com/letsencrypt/boulder
         entrypoint: test/entrypoint-netaccess.sh
         depends_on:


### PR DESCRIPTION
Adds :z to volumes so that they will function properly on a system with selinux set to enforcing. 

See issue https://github.com/letsencrypt/boulder/issues/4165