### PR TITLE
tests: allow skipping load testing during int. tests.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -94,7 +94,7 @@ fi
 #
 if [[ "$RUN" =~ "integration" ]] ; then
   args=("--chisel")
-  if [[ "${INT_SKIP_LOAD}:-}" == "" ]]; then
+  if [[ "${INT_SKIP_LOAD:-}" == "" ]]; then
     args+=("--load")
   fi
   if [[ "${INT_FILTER:-}" != "" ]]; then

--- a/test.sh
+++ b/test.sh
@@ -94,7 +94,9 @@ fi
 #
 if [[ "$RUN" =~ "integration" ]] ; then
   args=("--chisel")
-  args+=("--load")
+  if [[ "${INT_SKIP_LOAD}:-}" == "" ]]; then
+    args+=("--load")
+  fi
   if [[ "${INT_FILTER:-}" != "" ]]; then
     args+=("--filter" "${INT_FILTER}")
   fi

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -198,6 +198,7 @@ def main():
     if not (args.run_all or args.run_certbot or args.run_chisel or args.run_loadtest or args.custom is not None):
         raise Exception("must run at least one of the letsencrypt or chisel tests with --all, --certbot, --chisel, --load or --custom")
 
+    caa_client = None
     if not args.skip_setup:
         now = datetime.datetime.utcnow()
         seventy_days_ago = now+datetime.timedelta(days=-70)


### PR DESCRIPTION
Adds plumbing in `test.sh` to modify whether the `--load` argument is provided to `test/integration-test.py`. Use `-e INT_SKIP_LOAD=true` with `docker-compose run ... ./test.sh` to skip load generation.