### PR TITLE
PA: Support YAML for hostname policy.

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -70,7 +70,7 @@ type blockedNamesPolicy struct {
 	// TODO(@cpu): Remove the JSON tag when data is updated to use the new field names
 	BlockedNames []string `json:"blacklist" yaml:"BlockedNames"`
 
-	// RevokedNames operate the same as BlockedNames but are change with more
+	// RevokedNames operate the same as BlockedNames but are changed with more
 	// frequency based on administrative blocks/revocations that are added over
 	// time above and beyond high-value domains. Managing these entries separately
 	// from BlockedNames makes it easier to vet changes accurately.

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -70,11 +70,11 @@ type blockedNamesPolicy struct {
 	// TODO(@cpu): Remove the JSON tag when data is updated to use the new field names
 	BlockedNames []string `json:"blacklist" yaml:"BlockedNames"`
 
-	// SDNNames operate the same as BlockedNames but change with greater
-	// frequency based on the Treasury department's Specially Designated Nationals
-	// list. Because of the rate of change and the importance of careful
-	// management of these names we separate them from the BlockedNames list.
-	SDNNames []string `yaml:"SDNNames"`
+	// RevokedNames operate the same as BlockedNames but are change with more
+	// frequency based on administrative blocks/revocations that are added over
+	// time above and beyond high-value domains. Managing these entries separately
+	// from BlockedNames makes it easier to vet changes accurately.
+	RevokedNames []string `yaml:"RevokedNames"`
 }
 
 // SetHostnamePolicyFile will load the given policy file, returning error if it
@@ -139,7 +139,7 @@ func (pa *AuthorityImpl) processHostnamePolicy(policy blockedNamesPolicy) error 
 	for _, v := range policy.BlockedNames {
 		nameMap[v] = true
 	}
-	for _, v := range policy.SDNNames {
+	for _, v := range policy.RevokedNames {
 		nameMap[v] = true
 	}
 	exactNameMap := make(map[string]bool)

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -60,21 +60,20 @@ type blockedNamesPolicy struct {
 	//
 	// TODO(@cpu): Remove the JSON tag when data is updated to use the new field names
 	ExactBlockedNames []string `json:"exactBlacklist" yaml:"ExactBlockedNames"`
-	// BlockedNames is like ExactBlockedNames except that issuance is blocked for
-	// subdomains as well. (e.g. BlockedNames containing `example.com` will block
-	// `www.example.com`).
+	// HighRiskBlockedNames is like ExactBlockedNames except that issuance is
+	// blocked for subdomains as well. (e.g. BlockedNames containing `example.com`
+	// will block `www.example.com`).
 	//
-	// This list typically holds high-value domain names and doesn't change with
-	// much regularity.
+	// This list typically doesn't change with much regularity.
 	//
 	// TODO(@cpu): Remove the JSON tag when data is updated to use the new field names
-	BlockedNames []string `json:"blacklist" yaml:"BlockedNames"`
+	HighRiskBlockedNames []string `json:"blacklist" yaml:"HighRiskBlockedNames"`
 
-	// RevokedNames operate the same as BlockedNames but are changed with more
+	// AdminBlockedNames operates the same as BlockedNames but is changed with more
 	// frequency based on administrative blocks/revocations that are added over
-	// time above and beyond high-value domains. Managing these entries separately
-	// from BlockedNames makes it easier to vet changes accurately.
-	RevokedNames []string `yaml:"RevokedNames"`
+	// time above and beyond the high-risk domains. Managing these entries separately
+	// from HighRiskBlockedNames makes it easier to vet changes accurately.
+	AdminBlockedNames []string `yaml:"AdminBlockedNames"`
 }
 
 // SetHostnamePolicyFile will load the given policy file, returning error if it
@@ -120,8 +119,8 @@ func (pa *AuthorityImpl) loadHostnamePolicy(unmarshal unmarshalHandler) func([]b
 		if err != nil {
 			return err
 		}
-		if len(policy.BlockedNames) == 0 {
-			return fmt.Errorf("No entries in BlockedNames.")
+		if len(policy.HighRiskBlockedNames) == 0 {
+			return fmt.Errorf("No entries in HighRiskBlockedNames.")
 		}
 		if len(policy.ExactBlockedNames) == 0 {
 			return fmt.Errorf("No entries in ExactBlockedNames.")
@@ -136,10 +135,10 @@ func (pa *AuthorityImpl) loadHostnamePolicy(unmarshal unmarshalHandler) func([]b
 // exact blocked names entries are forbidden.
 func (pa *AuthorityImpl) processHostnamePolicy(policy blockedNamesPolicy) error {
 	nameMap := make(map[string]bool)
-	for _, v := range policy.BlockedNames {
+	for _, v := range policy.HighRiskBlockedNames {
 		nameMap[v] = true
 	}
-	for _, v := range policy.RevokedNames {
+	for _, v := range policy.AdminBlockedNames {
 		nameMap[v] = true
 	}
 	exactNameMap := make(map[string]bool)

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -26,10 +26,10 @@ import (
 type AuthorityImpl struct {
 	log blog.Logger
 
-	blacklist              map[string]bool
-	exactBlacklist         map[string]bool
-	wildcardExactBlacklist map[string]bool
-	blacklistMu            sync.RWMutex
+	blocklist              map[string]bool
+	exactBlocklist         map[string]bool
+	wildcardExactBlocklist map[string]bool
+	blocklistMu            sync.RWMutex
 
 	enabledChallenges map[string]bool
 	pseudoRNG         *rand.Rand
@@ -49,9 +49,22 @@ func New(challengeTypes map[string]bool) (*AuthorityImpl, error) {
 	return &pa, nil
 }
 
-type blacklistJSON struct {
-	Blacklist      []string
-	ExactBlacklist []string
+// blockedNamesPolicy is a struct holding lists of blocked domain names. One for
+// exact blocks and one for blocks including all subdomains.
+type blockedNamesPolicy struct {
+	// ExactBlockedNames is a list of domain names. Issuance for names exactly
+	// matching an entry in the list will be forbidden. (e.g. `ExactBlockedNames`
+	// containing `www.example.com` will not block `example.com` or
+	// `mail.example.com`).
+	//
+	// TODO(@cpu): Remove the JSON tag when data is updated to use the new field names
+	ExactBlockedNames []string `json:"exactBlacklist"`
+	// BlockedNames is like ExactBlockedNames except that issuance is blocked for
+	// subdomains as well. (e.g. BlockedNames containing `example.com` will block
+	// `www.example.com`).
+	//
+	// TODO(@cpu): Remove the JSON tag when data is updated to use the new field names
+	BlockedNames []string `json:"blacklist"`
 }
 
 // SetHostnamePolicyFile will load the given policy file, returning error if it
@@ -68,27 +81,27 @@ func (pa *AuthorityImpl) hostnamePolicyLoadError(err error) {
 func (pa *AuthorityImpl) loadHostnamePolicy(b []byte) error {
 	hash := sha256.Sum256(b)
 	pa.log.Infof("loading hostname policy, sha256: %s", hex.EncodeToString(hash[:]))
-	var bl blacklistJSON
+	var bl blockedNamesPolicy
 	err := json.Unmarshal(b, &bl)
 	if err != nil {
 		return err
 	}
-	if len(bl.Blacklist) == 0 {
-		return fmt.Errorf("No entries in blacklist.")
+	if len(bl.BlockedNames) == 0 {
+		return fmt.Errorf("No entries in BlockedNames.")
 	}
 	nameMap := make(map[string]bool)
-	for _, v := range bl.Blacklist {
+	for _, v := range bl.BlockedNames {
 		nameMap[v] = true
 	}
 	exactNameMap := make(map[string]bool)
 	wildcardNameMap := make(map[string]bool)
-	for _, v := range bl.ExactBlacklist {
+	for _, v := range bl.ExactBlockedNames {
 		exactNameMap[v] = true
-		// Remove the leftmost label of the exact blacklist entry to make an exact
-		// wildcard blacklist entry that will prevent issuing a wildcard that would
-		// include the exact blacklist entry. e.g. if "highvalue.example.com" is on
-		// the exact blacklist we want "example.com" to be on the
-		// wildcardExactBlacklist so that "*.example.com" cannot be issued.
+		// Remove the leftmost label of the exact blocked names entry to make an exact
+		// wildcard block list entry that will prevent issuing a wildcard that would
+		// include the exact blocklist entry. e.g. if "highvalue.example.com" is on
+		// the exact blocklist we want "example.com" to be in the
+		// wildcardExactBlocklist so that "*.example.com" cannot be issued.
 		//
 		// First, split the domain into two parts: the first label and the rest of the domain.
 		parts := strings.SplitN(v, ".", 2)
@@ -96,17 +109,17 @@ func (pa *AuthorityImpl) loadHostnamePolicy(b []byte) error {
 		// at least be a "something." and a TLD like "com"
 		if len(parts) < 2 {
 			return fmt.Errorf(
-				"Malformed exact blacklist entry, only one label: %q", v)
+				"Malformed ExactBlockedNames entry, only one label: %q", v)
 		}
 		// Add the second part, the domain minus the first label, to the
 		// wildcardNameMap to block issuance for `*.`+parts[1]
 		wildcardNameMap[parts[1]] = true
 	}
-	pa.blacklistMu.Lock()
-	pa.blacklist = nameMap
-	pa.exactBlacklist = exactNameMap
-	pa.wildcardExactBlacklist = wildcardNameMap
-	pa.blacklistMu.Unlock()
+	pa.blocklistMu.Lock()
+	pa.blocklist = nameMap
+	pa.exactBlocklist = exactNameMap
+	pa.wildcardExactBlocklist = wildcardNameMap
+	pa.blocklistMu.Unlock()
 	return nil
 }
 
@@ -141,7 +154,7 @@ var (
 	errInvalidIdentifier    = berrors.MalformedError("Invalid identifier type")
 	errNonPublic            = berrors.MalformedError("Name does not end in a public suffix")
 	errICANNTLD             = berrors.MalformedError("Name is an ICANN TLD")
-	errBlacklisted          = berrors.RejectedIdentifierError("Policy forbids issuing for name")
+	errPolicyForbidden      = berrors.RejectedIdentifierError("Policy forbids issuing for name")
 	errInvalidDNSCharacter  = berrors.MalformedError("Invalid character in DNS name")
 	errNameTooLong          = berrors.MalformedError("DNS name too long")
 	errIPAddress            = berrors.MalformedError("Issuance for IP addresses not supported")
@@ -174,7 +187,7 @@ var (
 //  * MUST NOT match the syntax of an IP address
 //  * MUST end in a public suffix
 //  * MUST have at least one label in addition to the public suffix
-//  * MUST NOT be a label-wise suffix match for a name on the black list,
+//  * MUST NOT be a label-wise suffix match for a name on the block list,
 //    where comparison is case-independent (normalized to lower case)
 //
 // If WillingToIssue returns an error, it will be of type MalformedRequestError
@@ -260,7 +273,7 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 		return errICANNTLD
 	}
 
-	// Require no match against blacklist
+	// Require no match against hostname block lists
 	if err := pa.checkHostLists(domain); err != nil {
 		return err
 	}
@@ -275,8 +288,8 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 // * That the wildcard character is the leftmost label
 // * That the wildcard label is not immediately adjacent to a top level ICANN
 //   TLD
-// * That the wildcard wouldn't cover an exact blacklist entry (e.g. an exact
-//   blacklist entry for "foo.example.com" should prevent issuance for
+// * That the wildcard wouldn't cover an exact blocklist entry (e.g. an exact
+//   blocklist entry for "foo.example.com" should prevent issuance for
 //   "*.example.com")
 //
 // If all of the above is true then the base domain (e.g. without the *.) is run
@@ -314,13 +327,13 @@ func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error
 		if baseDomain == icannTLD {
 			return errICANNTLDWildcard
 		}
-		// The base domain can't be in the wildcard exact blacklist
+		// The base domain can't be in the wildcard exact blocklist
 		if err := pa.checkWildcardHostList(baseDomain); err != nil {
 			return err
 		}
 		// Check that the PA is willing to issue for the base domain
 		// Since the base domain without the "*." may trip the exact hostname policy
-		// blacklist when the "*." is removed we replace it with a single "x"
+		// blocklist when the "*." is removed we replace it with a single "x"
 		// character to differentiate "*.example.com" from "example.com" for the
 		// exact hostname check.
 		//
@@ -336,42 +349,42 @@ func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error
 	return pa.WillingToIssue(ident)
 }
 
-// checkWildcardHostList checks the wildcardExactBlacklist for a given domain.
+// checkWildcardHostList checks the wildcardExactBlocklist for a given domain.
 // If the domain is not present on the list nil is returned, otherwise
-// errBlacklisted is returned.
+// errPolicyForbidden is returned.
 func (pa *AuthorityImpl) checkWildcardHostList(domain string) error {
-	pa.blacklistMu.RLock()
-	defer pa.blacklistMu.RUnlock()
+	pa.blocklistMu.RLock()
+	defer pa.blocklistMu.RUnlock()
 
-	if pa.blacklist == nil {
+	if pa.blocklist == nil {
 		return fmt.Errorf("Hostname policy not yet loaded.")
 	}
 
-	if pa.wildcardExactBlacklist[domain] {
-		return errBlacklisted
+	if pa.wildcardExactBlocklist[domain] {
+		return errPolicyForbidden
 	}
 
 	return nil
 }
 
 func (pa *AuthorityImpl) checkHostLists(domain string) error {
-	pa.blacklistMu.RLock()
-	defer pa.blacklistMu.RUnlock()
+	pa.blocklistMu.RLock()
+	defer pa.blocklistMu.RUnlock()
 
-	if pa.blacklist == nil {
+	if pa.blocklist == nil {
 		return fmt.Errorf("Hostname policy not yet loaded.")
 	}
 
 	labels := strings.Split(domain, ".")
 	for i := range labels {
 		joined := strings.Join(labels[i:], ".")
-		if pa.blacklist[joined] {
-			return errBlacklisted
+		if pa.blocklist[joined] {
+			return errPolicyForbidden
 		}
 	}
 
-	if pa.exactBlacklist[domain] {
-		return errBlacklisted
+	if pa.exactBlocklist[domain] {
+		return errPolicyForbidden
 	}
 	return nil
 }
@@ -430,7 +443,7 @@ func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.C
 
 // ChallengeTypeEnabled returns whether the specified challenge type is enabled
 func (pa *AuthorityImpl) ChallengeTypeEnabled(t string) bool {
-	pa.blacklistMu.RLock()
-	defer pa.blacklistMu.RUnlock()
+	pa.blocklistMu.RLock()
+	defer pa.blocklistMu.RUnlock()
 	return pa.enabledChallenges[t]
 }

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -64,8 +64,17 @@ type blockedNamesPolicy struct {
 	// subdomains as well. (e.g. BlockedNames containing `example.com` will block
 	// `www.example.com`).
 	//
+	// This list typically holds high-value domain names and doesn't change with
+	// much regularity.
+	//
 	// TODO(@cpu): Remove the JSON tag when data is updated to use the new field names
 	BlockedNames []string `json:"blacklist" yaml:"BlockedNames"`
+
+	// SDNNames operate the same as BlockedNames but change with greater
+	// frequency based on the Treasury department's Specially Designated Nationals
+	// list. Because of the rate of change and the importance of careful
+	// management of these names we separate them from the BlockedNames list.
+	SDNNames []string `yaml:"SDNNames"`
 }
 
 // SetHostnamePolicyFile will load the given policy file, returning error if it
@@ -128,6 +137,9 @@ func (pa *AuthorityImpl) loadHostnamePolicy(unmarshal unmarshalHandler) func([]b
 func (pa *AuthorityImpl) processHostnamePolicy(policy blockedNamesPolicy) error {
 	nameMap := make(map[string]bool)
 	for _, v := range policy.BlockedNames {
+		nameMap[v] = true
+	}
+	for _, v := range policy.SDNNames {
 		nameMap[v] = true
 	}
 	exactNameMap := make(map[string]bool)

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -113,6 +113,8 @@ func TestWillingToIssue(t *testing.T) {
 		`website2.co.uk`,
 		`www.website3.com`,
 		`lots.of.labels.website4.com`,
+		`banned.in.dc.com`,
+		`bad.brains.banned.in.dc.com`,
 	}
 	blocklistContents := []string{
 		`website2.com`,
@@ -125,6 +127,9 @@ func TestWillingToIssue(t *testing.T) {
 		`www.website1.org`,
 		`highvalue.website1.org`,
 		`dl.website1.org`,
+	}
+	sdnNamesContents := []string{
+		`banned.in.dc.com`,
 	}
 
 	shouldBeAccepted := []string{
@@ -141,6 +146,7 @@ func TestWillingToIssue(t *testing.T) {
 	policy := blockedNamesPolicy{
 		BlockedNames:      blocklistContents,
 		ExactBlockedNames: exactBlocklistContents,
+		SDNNames:          sdnNamesContents,
 	}
 
 	jsonPolicyBytes, err := json.Marshal(policy)

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -128,7 +128,7 @@ func TestWillingToIssue(t *testing.T) {
 		`highvalue.website1.org`,
 		`dl.website1.org`,
 	}
-	sdnNamesContents := []string{
+	revokedNamesContents := []string{
 		`banned.in.dc.com`,
 	}
 
@@ -146,7 +146,7 @@ func TestWillingToIssue(t *testing.T) {
 	policy := blockedNamesPolicy{
 		BlockedNames:      blocklistContents,
 		ExactBlockedNames: exactBlocklistContents,
-		SDNNames:          sdnNamesContents,
+		RevokedNames:      revokedNamesContents,
 	}
 
 	jsonPolicyBytes, err := json.Marshal(policy)

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -128,7 +128,7 @@ func TestWillingToIssue(t *testing.T) {
 		`highvalue.website1.org`,
 		`dl.website1.org`,
 	}
-	revokedNamesContents := []string{
+	adminBlockedContents := []string{
 		`banned.in.dc.com`,
 	}
 
@@ -144,9 +144,9 @@ func TestWillingToIssue(t *testing.T) {
 	}
 
 	policy := blockedNamesPolicy{
-		BlockedNames:      blocklistContents,
-		ExactBlockedNames: exactBlocklistContents,
-		RevokedNames:      revokedNamesContents,
+		HighRiskBlockedNames: blocklistContents,
+		ExactBlockedNames:    exactBlocklistContents,
+		AdminBlockedNames:    adminBlockedContents,
 	}
 
 	jsonPolicyBytes, err := json.Marshal(policy)
@@ -243,8 +243,8 @@ func TestWillingToIssueWildcard(t *testing.T) {
 	pa := paImpl(t)
 
 	bannedBytes, err := json.Marshal(blockedNamesPolicy{
-		BlockedNames:      bannedDomains,
-		ExactBlockedNames: exactBannedDomains,
+		HighRiskBlockedNames: bannedDomains,
+		ExactBlockedNames:    exactBannedDomains,
 	})
 	test.AssertNotError(t, err, "Couldn't serialize banned list")
 	f, _ := ioutil.TempFile("", "test-wildcard-banlist.*.json")
@@ -409,8 +409,8 @@ func TestMalformedExactBlocklist(t *testing.T) {
 
 	// Create JSON for the exactBannedDomains
 	bannedBytes, err := json.Marshal(blockedNamesPolicy{
-		BlockedNames:      bannedDomains,
-		ExactBlockedNames: exactBannedDomains,
+		HighRiskBlockedNames: bannedDomains,
+		ExactBlockedNames:    exactBannedDomains,
 	})
 	test.AssertNotError(t, err, "Couldn't serialize banned list")
 

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -41,7 +41,7 @@
     "lifespanOCSP": "96h",
     "maxNames": 100,
     "enableMustStaple": true,
-    "hostnamePolicyFile": "test/hostname-policy.json",
+    "hostnamePolicyFile": "test/hostname-policy.yaml",
     "cfssl": {
       "signing": {
         "profiles": {

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -41,7 +41,7 @@
     "lifespanOCSP": "96h",
     "maxNames": 100,
     "enableMustStaple": true,
-    "hostnamePolicyFile": "test/hostname-policy.json",
+    "hostnamePolicyFile": "test/hostname-policy.yaml",
     "cfssl": {
       "signing": {
         "profiles": {

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -2,7 +2,7 @@
   "certChecker": {
     "dbConnectFile": "test/secrets/cert_checker_dburl",
     "maxDBConns": 10,
-    "hostnamePolicyFile": "test/hostname-policy.json"
+    "hostnamePolicyFile": "test/hostname-policy.yaml"
   },
 
   "pa": {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -4,7 +4,7 @@
     "maxConcurrentRPCServerRequests": 100000,
     "maxContactsPerRegistration": 100,
     "debugAddr": ":8002",
-    "hostnamePolicyFile": "test/hostname-policy.json",
+    "hostnamePolicyFile": "test/hostname-policy.yaml",
     "maxNames": 100,
     "reuseValidAuthz": true,
     "authorizationLifetimeDays": 30,

--- a/test/hostname-policy.yaml
+++ b/test/hostname-policy.yaml
@@ -26,7 +26,8 @@ BlockedNames:
   - "localhost"
   - "test"
 
-# SDNNames are the same as BlockedNames but change more frequently and so are
+# RevokedNames are treated the same as BlockedNames by Boulder but since they
+# change more frequently based on administrative action over time they are
 # separated into their own list.
-SDNNames:
+RevokedNames:
   - "sealand"

--- a/test/hostname-policy.yaml
+++ b/test/hostname-policy.yaml
@@ -25,3 +25,8 @@ BlockedNames:
   - "local"
   - "localhost"
   - "test"
+
+# SDNNames are the same as BlockedNames but change more frequently and so are
+# separated into their own list.
+SDNNames:
+  - "sealand"

--- a/test/hostname-policy.yaml
+++ b/test/hostname-policy.yaml
@@ -10,9 +10,9 @@ ExactBlockedNames:
   - "highrisk.le-test.hoffman-andrews.com"
   - "exactblacklist.letsencrypt.org"
 
-# BlockedNames prevent issuance for the exact names listed as well as all
-# subdomains/wildcards.
-BlockedNames:
+# HighRiskBlockedNames prevent issuance for the exact names listed as well as
+# all subdomains/wildcards.
+HighRiskBlockedNames:
   # See RFC 3152
   - "ipv6.arpa"
   # See RFC 2317
@@ -26,8 +26,8 @@ BlockedNames:
   - "localhost"
   - "test"
 
-# RevokedNames are treated the same as BlockedNames by Boulder but since they
-# change more frequently based on administrative action over time they are
-# separated into their own list.
-RevokedNames:
+# AdminBlockedNames are treated the same as HighRiskBlockedNames by Boulder but
+# since they change more frequently based on administrative action over time
+# they are separated into their own list.
+AdminBlockedNames:
   - "sealand"

--- a/test/hostname-policy.yaml
+++ b/test/hostname-policy.yaml
@@ -1,0 +1,27 @@
+#
+# Example YAML Boulder hostname policy
+#
+# This is *not* a production ready policy file and not reflective of Let's
+# Encrypt's policies! It is just an example.
+
+# ExactBlockedNames prevent issuance for the exact names listed, as well as
+# their wildcard form.
+ExactBlockedNames:
+  - "highrisk.le-test.hoffman-andrews.com"
+  - "exactblacklist.letsencrypt.org"
+
+# BlockedNames prevent issuance for the exact names listed as well as all
+# subdomains/wildcards.
+BlockedNames:
+  # See RFC 3152
+  - "ipv6.arpa"
+  # See RFC 2317
+  - "in-addr.arpa"
+  # Etc etc etc
+  - "example"
+  - "example.net"
+  - "example.org"
+  - "invalid"
+  - "local"
+  - "localhost"
+  - "test"


### PR DESCRIPTION
Our existing hostname policy configs use JSON. We would like to switch to YAML to match the rate limit policy configs and to support commenting/tagging entries in the hostname policy.

The PA is updated to support both JSON and YAML while we migrate the existing policy data to the new format. To verify there are no changes in functionality the existing unit tests were updated to test the same policy expressed in YAML and JSON form.

In integration tests the `config` tree continues to use a JSON hostname policy file to test the legacy support. In `config-next` a YAML hostname policy file is used instead.

The new YAML format allows separating out `HighRiskBlockedNames` (primarily used to meet the requirement of managing issuance for "high risk" domains per CABF BRs, mostly static) and `AdminBlockedNames` (used after administrative action is taken to block a domain. Additions are made with some frequency). Since the rate at which we change entries in these lists differs it is helpful to separate them in the policy content.