### PR TITLE
sa: return corepb.Empty{} not nil.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -908,7 +908,7 @@ func (ssa *SQLStorageAuthority) RevokeAuthorizationsByDomain2(ctx context.Contex
 			return nil, err
 		}
 	}
-	return nil, nil
+	return &corepb.Empty{}, nil
 }
 
 // AddCertificate stores an issued certificate and returns the digest as
@@ -1458,7 +1458,7 @@ func (ssa *SQLStorageAuthority) DeactivateAuthorization2(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	return nil, nil
+	return &corepb.Empty{}, nil
 }
 
 // NewOrder adds a new v2 style order to the database


### PR DESCRIPTION
The new `RevokeAuthorizationsByDomain2` and `DeactivateAuthorization2` SA RPCs are declared to return `*corepb.Empty, error` but were implemented to `return nil, nil` for the success case. This causes a gRPC unmarshal error: 

```
E151233 boulder-sa [AUDIT] grpc: server failed to encode response:  rpc error: code = Internal desc = grpc: error while marshaling: proto: Marshal called with nil
```

Both RPCs should `return &corepb.Empty{}, nil` for success to avoid this.