### PR TITLE
Do not return deactivated accounts in NewAccount

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -490,6 +490,14 @@ func (wfe *WebFrontEndImpl) NewAccount(
 
 	existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, key)
 	if err == nil {
+		if existingAcct.Status == core.StatusDeactivated {
+			// If there is an existing, but deactivated account, then return an unauthorized
+			// problem informing the user that this account was deactivated
+			wfe.sendError(response, logEvent, probs.Unauthorized(
+				"An account with the provided public key exists but is deactivated"), nil)
+			return
+		}
+
 		response.Header().Set("Location",
 			web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.ID)))
 		logEvent.Requester = existingAcct.ID


### PR DESCRIPTION
As discussed in issue #3971, this PR implements the correct behavior by returning unauthorized problem for newAccount/newReg POSTs for deactivated accounts.

This PR was inspired by the work @felixfontein did on https://github.com/letsencrypt/pebble/pull/180.