### PR TITLE
SA: use err with more context for bad JSON unmarshals.

### DIFF
--- a/sa/type-converter.go
+++ b/sa/type-converter.go
@@ -48,7 +48,13 @@ func (tc BoulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, b
 				return errors.New("FromDb: Unable to convert *string")
 			}
 			b := []byte(*s)
-			return json.Unmarshal(b, target)
+			if err := json.Unmarshal(b, target); err != nil {
+				return badJSONError(
+					fmt.Sprintf("binder failed to unmarshal %T", target),
+					b,
+					err)
+			}
+			return nil
 		}
 		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
 	case *jose.JSONWebKey:
@@ -65,7 +71,13 @@ func (tc BoulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, b
 			if !ok {
 				return fmt.Errorf("FromDb: Unable to convert %T to *jose.JSONWebKey", target)
 			}
-			return k.UnmarshalJSON(b)
+			if err := k.UnmarshalJSON(b); err != nil {
+				return badJSONError(
+					"binder failed to unmarshal JWK",
+					b,
+					err)
+			}
+			return nil
 		}
 		return gorp.CustomScanner{Holder: new(string), Target: target, Binder: binder}, true
 	case *core.AcmeStatus:

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -38,6 +38,18 @@ func TestAcmeIdentifier(t *testing.T) {
 	test.AssertMarshaledEquals(t, ai, out)
 }
 
+func TestAcmeIdentifierBadJSON(t *testing.T) {
+	badJSON := `{`
+	tc := BoulderTypeConverter{}
+	out := core.AcmeIdentifier{}
+	scanner, ok := tc.FromDb(&out)
+	err := scanner.Binder(&badJSON, &out)
+	test.AssertError(t, err, "expected error from scanner.Binder")
+	badJSONErr, ok := err.(errBadJSON)
+	test.AssertEquals(t, ok, true)
+	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
+}
+
 func TestJSONWebKey(t *testing.T) {
 	tc := BoulderTypeConverter{}
 
@@ -61,6 +73,18 @@ func TestJSONWebKey(t *testing.T) {
 	err = scanner.Binder(&marshaled, &out)
 	test.AssertNotError(t, err, "failed to scanner.Binder")
 	test.AssertMarshaledEquals(t, jwk, out)
+}
+
+func TestJSONWebKeyBadJSON(t *testing.T) {
+	badJSON := `{`
+	tc := BoulderTypeConverter{}
+	out := jose.JSONWebKey{}
+	scanner, ok := tc.FromDb(&out)
+	err := scanner.Binder(&badJSON, &out)
+	test.AssertError(t, err, "expected error from scanner.Binder")
+	badJSONErr, ok := err.(errBadJSON)
+	test.AssertEquals(t, ok, true)
+	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
 }
 
 func TestAcmeStatus(t *testing.T) {

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -42,7 +42,7 @@ func TestAcmeIdentifierBadJSON(t *testing.T) {
 	badJSON := `{`
 	tc := BoulderTypeConverter{}
 	out := core.AcmeIdentifier{}
-	scanner, ok := tc.FromDb(&out)
+	scanner, _ := tc.FromDb(&out)
 	err := scanner.Binder(&badJSON, &out)
 	test.AssertError(t, err, "expected error from scanner.Binder")
 	badJSONErr, ok := err.(errBadJSON)
@@ -79,7 +79,7 @@ func TestJSONWebKeyBadJSON(t *testing.T) {
 	badJSON := `{`
 	tc := BoulderTypeConverter{}
 	out := jose.JSONWebKey{}
-	scanner, ok := tc.FromDb(&out)
+	scanner, _ := tc.FromDb(&out)
 	err := scanner.Binder(&badJSON, &out)
 	test.AssertError(t, err, "expected error from scanner.Binder")
 	badJSONErr, ok := err.(errBadJSON)


### PR DESCRIPTION
There are several places where the SA unmarshals JSON content to transform a model type to its standard type. If one of these unmarshals fail it is hard to track down the problem without knowing more context like what was being unmarshaled and what the raw data looked like.

Previously truncated JSON in model data produced an error with a generic message like: "Unexpected end of JSON input". In this branch the error messages contain much more context, e.g.
> failed to unmarshal authz2 model's validation record: error unmarshaling JSON "{": unexpected end of JSON input

or

> binder failed to unmarshal *core.AcmeIdentifier: error unmarshaling JSON "{": unexpected end of JSON input

Resolves https://github.com/letsencrypt/boulder/issues/4186