### PR TITLE
Split out config structs from cmd package.

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/ctpolicy"
+	"github.com/letsencrypt/boulder/ctpolicy/ctconfig"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
@@ -70,12 +71,12 @@ type config struct {
 		// in a group and the first SCT returned will be used. This allows
 		// us to comply with Chrome CT policy which requires one SCT from a
 		// Google log and one SCT from any other log included in their policy.
-		CTLogGroups2 []cmd.CTGroup
+		CTLogGroups2 []ctconfig.CTGroup
 		// InformationalCTLogs are a set of CT logs we will always submit to
 		// but won't ever use the SCTs from. This may be because we want to
 		// test them or because they are not yet approved by a browser/root
 		// program but we still want our certs to end up there.
-		InformationalCTLogs []cmd.LogDescription
+		InformationalCTLogs []ctconfig.LogDescription
 
 		// IssuerCertPath is the path to the intermediate used to issue certificates.
 		// It is required if the RevokeAtRA feature is enabled and is used to

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -23,7 +23,13 @@ type config struct {
 
 		PortConfig cmd.PortConfig
 
-		CAADistributedResolver *cmd.CAADistributedResolverConfig
+		// CAADistributedResolverConfig specifies the HTTP client setup and interfaces
+		// needed to resolve CAA addresses over multiple paths
+		CAADistributedResolver struct {
+			Timeout     cmd.ConfigDuration
+			MaxFailures int
+			Proxies     []string
+		}
 
 		// The number of times to try a DNS query (that has a temporary error)
 		// before giving up. May be short-circuited by deadlines. A zero value

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -319,8 +319,6 @@ type config struct {
 
 	PA cmd.PAConfig
 
-	Statsd cmd.StatsdConfig
-
 	Syslog cmd.SyslogConfig
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -148,50 +148,10 @@ type RPCServerConfig struct {
 	RPCTimeout ConfigDuration
 }
 
-// OCSPUpdaterConfig provides the various window tick times and batch sizes needed
-// for the OCSP (and SCT) updater
-type OCSPUpdaterConfig struct {
-	ServiceConfig
-	DBConfig
-
-	OldOCSPWindow            ConfigDuration
-	RevokedCertificateWindow ConfigDuration
-
-	OldOCSPBatchSize            int
-	RevokedCertificateBatchSize int
-
-	OCSPMinTimeToExpiry          ConfigDuration
-	OCSPStaleMaxAge              ConfigDuration
-	ParallelGenerateOCSPRequests int
-
-	AkamaiBaseURL           string
-	AkamaiClientToken       string
-	AkamaiClientSecret      string
-	AkamaiAccessToken       string
-	AkamaiV3Network         string
-	AkamaiPurgeRetries      int
-	AkamaiPurgeRetryBackoff ConfigDuration
-
-	SignFailureBackoffFactor float64
-	SignFailureBackoffMax    ConfigDuration
-
-	SAService            *GRPCClientConfig
-	OCSPGeneratorService *GRPCClientConfig
-	AkamaiPurgerService  *GRPCClientConfig
-
-	Features map[string]bool
-}
-
 // SyslogConfig defines the config for syslogging.
 type SyslogConfig struct {
 	StdoutLevel int
 	SyslogLevel int
-}
-
-// StatsdConfig defines the config for Statsd.
-type StatsdConfig struct {
-	Server string
-	Prefix string
 }
 
 // ConfigDuration is just an alias for time.Duration that allows
@@ -269,93 +229,4 @@ type PortConfig struct {
 	HTTPPort  int
 	HTTPSPort int
 	TLSPort   int
-}
-
-// CAADistributedResolverConfig specifies the HTTP client setup and interfaces
-// needed to resolve CAA addresses over multiple paths
-type CAADistributedResolverConfig struct {
-	Timeout     ConfigDuration
-	MaxFailures int
-	Proxies     []string
-}
-
-// LogShard describes a single shard of a temporally sharded
-// CT log
-type LogShard struct {
-	URI         string
-	Key         string
-	WindowStart time.Time
-	WindowEnd   time.Time
-}
-
-// TemporalSet contains a set of temporal shards of a single log
-type TemporalSet struct {
-	Name   string
-	Shards []LogShard
-}
-
-// Setup initializes the TemporalSet by parsing the start and end dates
-// and verifying WindowEnd > WindowStart
-func (ts *TemporalSet) Setup() error {
-	if ts.Name == "" {
-		return errors.New("Name cannot be empty")
-	}
-	if len(ts.Shards) == 0 {
-		return errors.New("temporal set contains no shards")
-	}
-	for i := range ts.Shards {
-		if ts.Shards[i].WindowEnd.Before(ts.Shards[i].WindowStart) ||
-			ts.Shards[i].WindowEnd.Equal(ts.Shards[i].WindowStart) {
-			return errors.New("WindowStart must be before WindowEnd")
-		}
-	}
-	return nil
-}
-
-// pick chooses the correct shard from a TemporalSet to use for the given
-// expiration time. In the case where two shards have overlapping windows
-// the earlier of the two shards will be chosen.
-func (ts *TemporalSet) pick(exp time.Time) (*LogShard, error) {
-	for _, shard := range ts.Shards {
-		if exp.Before(shard.WindowStart) {
-			continue
-		}
-		if !exp.Before(shard.WindowEnd) {
-			continue
-		}
-		return &shard, nil
-	}
-	return nil, fmt.Errorf("no valid shard available for temporal set %q for expiration date %q", ts.Name, exp)
-}
-
-// LogDescription contains the information needed to submit certificates
-// to a CT log and verify returned receipts. If TemporalSet is non-nil then
-// URI and Key should be empty.
-type LogDescription struct {
-	URI             string
-	Key             string
-	SubmitFinalCert bool
-
-	*TemporalSet
-}
-
-// Info returns the URI and key of the log, either from a plain log description
-// or from the earliest valid shard from a temporal log set
-func (ld LogDescription) Info(exp time.Time) (string, string, error) {
-	if ld.TemporalSet == nil {
-		return ld.URI, ld.Key, nil
-	}
-	shard, err := ld.TemporalSet.pick(exp)
-	if err != nil {
-		return "", "", err
-	}
-	return shard.URI, shard.Key, nil
-}
-
-type CTGroup struct {
-	Name string
-	Logs []LogDescription
-	// How long to wait for one log to accept a certificate before moving on to
-	// the next.
-	Stagger ConfigDuration
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -4,9 +4,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -99,111 +97,4 @@ func TestTLSConfigLoad(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestTemporalSetup(t *testing.T) {
-	for _, tc := range []struct {
-		ts  TemporalSet
-		err string
-	}{
-		{
-			ts:  TemporalSet{},
-			err: "Name cannot be empty",
-		},
-		{
-			ts: TemporalSet{
-				Name: "temporal set",
-			},
-			err: "temporal set contains no shards",
-		},
-		{
-			ts: TemporalSet{
-				Name: "temporal set",
-				Shards: []LogShard{
-					{
-						WindowStart: time.Time{},
-						WindowEnd:   time.Time{},
-					},
-				},
-			},
-			err: "WindowStart must be before WindowEnd",
-		},
-		{
-			ts: TemporalSet{
-				Name: "temporal set",
-				Shards: []LogShard{
-					{
-						WindowStart: time.Time{}.Add(time.Hour),
-						WindowEnd:   time.Time{},
-					},
-				},
-			},
-			err: "WindowStart must be before WindowEnd",
-		},
-		{
-			ts: TemporalSet{
-				Name: "temporal set",
-				Shards: []LogShard{
-					{
-						WindowStart: time.Time{},
-						WindowEnd:   time.Time{}.Add(time.Hour),
-					},
-				},
-			},
-			err: "",
-		},
-	} {
-		err := tc.ts.Setup()
-		if err != nil && tc.err != err.Error() {
-			t.Errorf("got error %q, wanted %q", err, tc.err)
-		} else if err == nil && tc.err != "" {
-			t.Errorf("unexpected error %q", err)
-		}
-	}
-}
-
-func TestLogInfo(t *testing.T) {
-	ld := LogDescription{
-		URI: "basic-uri",
-		Key: "basic-key",
-	}
-	uri, key, err := ld.Info(time.Time{})
-	test.AssertNotError(t, err, "Info failed")
-	test.AssertEquals(t, uri, ld.URI)
-	test.AssertEquals(t, key, ld.Key)
-
-	fc := clock.NewFake()
-	ld.TemporalSet = &TemporalSet{}
-	_, _, err = ld.Info(fc.Now())
-	test.AssertError(t, err, "Info should fail with a TemporalSet with no viable shards")
-	ld.TemporalSet.Shards = []LogShard{{WindowStart: fc.Now().Add(time.Hour), WindowEnd: fc.Now().Add(time.Hour * 2)}}
-	_, _, err = ld.Info(fc.Now())
-	test.AssertError(t, err, "Info should fail with a TemporalSet with no viable shards")
-
-	fc.Add(time.Hour * 4)
-	now := fc.Now()
-	ld.TemporalSet.Shards = []LogShard{
-		{
-			WindowStart: now.Add(time.Hour * -4),
-			WindowEnd:   now.Add(time.Hour * -2),
-			URI:         "a",
-			Key:         "a",
-		},
-		{
-			WindowStart: now.Add(time.Hour * -2),
-			WindowEnd:   now.Add(time.Hour * 2),
-			URI:         "b",
-			Key:         "b",
-		},
-		{
-			WindowStart: now.Add(time.Hour * 2),
-			WindowEnd:   now.Add(time.Hour * 4),
-			URI:         "c",
-			Key:         "c",
-		},
-	}
-	uri, key, err = ld.Info(now)
-	test.AssertNotError(t, err, "Info failed")
-	test.AssertEquals(t, uri, "b")
-	test.AssertEquals(t, key, "b")
 }

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -70,7 +70,7 @@ func newUpdater(
 	ca core.CertificateAuthority,
 	sac core.StorageAuthority,
 	apc akamaipb.AkamaiPurgerClient,
-	config cmd.OCSPUpdaterConfig,
+	config OCSPUpdaterConfig,
 	issuerPath string,
 	log blog.Logger,
 ) (*OCSPUpdater, error) {
@@ -495,9 +495,7 @@ func (l *looper) loop() error {
 }
 
 type config struct {
-	OCSPUpdater cmd.OCSPUpdaterConfig
-
-	Statsd cmd.StatsdConfig
+	OCSPUpdater OCSPUpdaterConfig
 
 	Syslog cmd.SyslogConfig
 
@@ -506,7 +504,41 @@ type config struct {
 	}
 }
 
-func setupClients(c cmd.OCSPUpdaterConfig, stats metrics.Scope, clk clock.Clock) (
+// OCSPUpdaterConfig provides the various window tick times and batch sizes needed
+// for the OCSP (and SCT) updater
+type OCSPUpdaterConfig struct {
+	cmd.ServiceConfig
+	cmd.DBConfig
+
+	OldOCSPWindow            cmd.ConfigDuration
+	RevokedCertificateWindow cmd.ConfigDuration
+
+	OldOCSPBatchSize            int
+	RevokedCertificateBatchSize int
+
+	OCSPMinTimeToExpiry          cmd.ConfigDuration
+	OCSPStaleMaxAge              cmd.ConfigDuration
+	ParallelGenerateOCSPRequests int
+
+	AkamaiBaseURL           string
+	AkamaiClientToken       string
+	AkamaiClientSecret      string
+	AkamaiAccessToken       string
+	AkamaiV3Network         string
+	AkamaiPurgeRetries      int
+	AkamaiPurgeRetryBackoff cmd.ConfigDuration
+
+	SignFailureBackoffFactor float64
+	SignFailureBackoffMax    cmd.ConfigDuration
+
+	SAService            *cmd.GRPCClientConfig
+	OCSPGeneratorService *cmd.GRPCClientConfig
+	AkamaiPurgerService  *cmd.GRPCClientConfig
+
+	Features map[string]bool
+}
+
+func setupClients(c OCSPUpdaterConfig, stats metrics.Scope, clk clock.Clock) (
 	core.CertificateAuthority,
 	core.StorageAuthority,
 	akamaipb.AkamaiPurgerClient,

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -79,7 +79,7 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *gorp.DbMap, cloc
 		&mockCA{},
 		sa,
 		nil,
-		cmd.OCSPUpdaterConfig{
+		OCSPUpdaterConfig{
 			OldOCSPBatchSize:            1,
 			RevokedCertificateBatchSize: 1,
 			OldOCSPWindow:               cmd.ConfigDuration{Duration: time.Second},

--- a/ctpolicy/ctconfig/ctconfig.go
+++ b/ctpolicy/ctconfig/ctconfig.go
@@ -1,0 +1,90 @@
+package ctconfig
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/letsencrypt/boulder/cmd"
+)
+
+// LogShard describes a single shard of a temporally sharded
+// CT log
+type LogShard struct {
+	URI         string
+	Key         string
+	WindowStart time.Time
+	WindowEnd   time.Time
+}
+
+// TemporalSet contains a set of temporal shards of a single log
+type TemporalSet struct {
+	Name   string
+	Shards []LogShard
+}
+
+// Setup initializes the TemporalSet by parsing the start and end dates
+// and verifying WindowEnd > WindowStart
+func (ts *TemporalSet) Setup() error {
+	if ts.Name == "" {
+		return errors.New("Name cannot be empty")
+	}
+	if len(ts.Shards) == 0 {
+		return errors.New("temporal set contains no shards")
+	}
+	for i := range ts.Shards {
+		if ts.Shards[i].WindowEnd.Before(ts.Shards[i].WindowStart) ||
+			ts.Shards[i].WindowEnd.Equal(ts.Shards[i].WindowStart) {
+			return errors.New("WindowStart must be before WindowEnd")
+		}
+	}
+	return nil
+}
+
+// pick chooses the correct shard from a TemporalSet to use for the given
+// expiration time. In the case where two shards have overlapping windows
+// the earlier of the two shards will be chosen.
+func (ts *TemporalSet) pick(exp time.Time) (*LogShard, error) {
+	for _, shard := range ts.Shards {
+		if exp.Before(shard.WindowStart) {
+			continue
+		}
+		if !exp.Before(shard.WindowEnd) {
+			continue
+		}
+		return &shard, nil
+	}
+	return nil, fmt.Errorf("no valid shard available for temporal set %q for expiration date %q", ts.Name, exp)
+}
+
+// LogDescription contains the information needed to submit certificates
+// to a CT log and verify returned receipts. If TemporalSet is non-nil then
+// URI and Key should be empty.
+type LogDescription struct {
+	URI             string
+	Key             string
+	SubmitFinalCert bool
+
+	*TemporalSet
+}
+
+// Info returns the URI and key of the log, either from a plain log description
+// or from the earliest valid shard from a temporal log set
+func (ld LogDescription) Info(exp time.Time) (string, string, error) {
+	if ld.TemporalSet == nil {
+		return ld.URI, ld.Key, nil
+	}
+	shard, err := ld.TemporalSet.pick(exp)
+	if err != nil {
+		return "", "", err
+	}
+	return shard.URI, shard.Key, nil
+}
+
+type CTGroup struct {
+	Name string
+	Logs []LogDescription
+	// How long to wait for one log to accept a certificate before moving on to
+	// the next.
+	Stagger cmd.ConfigDuration
+}

--- a/ctpolicy/ctconfig/ctconfig_test.go
+++ b/ctpolicy/ctconfig/ctconfig_test.go
@@ -1,0 +1,116 @@
+package ctconfig
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestTemporalSetup(t *testing.T) {
+	for _, tc := range []struct {
+		ts  TemporalSet
+		err string
+	}{
+		{
+			ts:  TemporalSet{},
+			err: "Name cannot be empty",
+		},
+		{
+			ts: TemporalSet{
+				Name: "temporal set",
+			},
+			err: "temporal set contains no shards",
+		},
+		{
+			ts: TemporalSet{
+				Name: "temporal set",
+				Shards: []LogShard{
+					{
+						WindowStart: time.Time{},
+						WindowEnd:   time.Time{},
+					},
+				},
+			},
+			err: "WindowStart must be before WindowEnd",
+		},
+		{
+			ts: TemporalSet{
+				Name: "temporal set",
+				Shards: []LogShard{
+					{
+						WindowStart: time.Time{}.Add(time.Hour),
+						WindowEnd:   time.Time{},
+					},
+				},
+			},
+			err: "WindowStart must be before WindowEnd",
+		},
+		{
+			ts: TemporalSet{
+				Name: "temporal set",
+				Shards: []LogShard{
+					{
+						WindowStart: time.Time{},
+						WindowEnd:   time.Time{}.Add(time.Hour),
+					},
+				},
+			},
+			err: "",
+		},
+	} {
+		err := tc.ts.Setup()
+		if err != nil && tc.err != err.Error() {
+			t.Errorf("got error %q, wanted %q", err, tc.err)
+		} else if err == nil && tc.err != "" {
+			t.Errorf("unexpected error %q", err)
+		}
+	}
+}
+
+func TestLogInfo(t *testing.T) {
+	ld := LogDescription{
+		URI: "basic-uri",
+		Key: "basic-key",
+	}
+	uri, key, err := ld.Info(time.Time{})
+	test.AssertNotError(t, err, "Info failed")
+	test.AssertEquals(t, uri, ld.URI)
+	test.AssertEquals(t, key, ld.Key)
+
+	fc := clock.NewFake()
+	ld.TemporalSet = &TemporalSet{}
+	_, _, err = ld.Info(fc.Now())
+	test.AssertError(t, err, "Info should fail with a TemporalSet with no viable shards")
+	ld.TemporalSet.Shards = []LogShard{{WindowStart: fc.Now().Add(time.Hour), WindowEnd: fc.Now().Add(time.Hour * 2)}}
+	_, _, err = ld.Info(fc.Now())
+	test.AssertError(t, err, "Info should fail with a TemporalSet with no viable shards")
+
+	fc.Add(time.Hour * 4)
+	now := fc.Now()
+	ld.TemporalSet.Shards = []LogShard{
+		{
+			WindowStart: now.Add(time.Hour * -4),
+			WindowEnd:   now.Add(time.Hour * -2),
+			URI:         "a",
+			Key:         "a",
+		},
+		{
+			WindowStart: now.Add(time.Hour * -2),
+			WindowEnd:   now.Add(time.Hour * 2),
+			URI:         "b",
+			Key:         "b",
+		},
+		{
+			WindowStart: now.Add(time.Hour * 2),
+			WindowEnd:   now.Add(time.Hour * 4),
+			URI:         "c",
+			Key:         "c",
+		},
+	}
+	uri, key, err = ld.Info(now)
+	test.AssertNotError(t, err, "Info failed")
+	test.AssertEquals(t, uri, "b")
+	test.AssertEquals(t, key, "b")
+}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/ctpolicy"
+	"github.com/letsencrypt/boulder/ctpolicy/ctconfig"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
@@ -3489,7 +3490,7 @@ func TestCTPolicyMeasurements(t *testing.T) {
 		PEM: eeCertPEM,
 	}
 
-	ctp := ctpolicy.New(&timeoutPub{}, []cmd.CTGroup{{}}, nil, log, metrics.NewNoopScope())
+	ctp := ctpolicy.New(&timeoutPub{}, []ctconfig.CTGroup{{}}, nil, log, metrics.NewNoopScope())
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
 		stats,


### PR DESCRIPTION
This follows up on some refactoring we had done previously but not
completed. This removes various binary-specific config structs from the
common cmd package, and moves them into their appropriate packages. In
the case of CT configs, they had to be moved into their own package to
avoid a dependency loop between RA and ctpolicy.