### PR TITLE
Remove LookupMX from bdns.

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -148,7 +148,6 @@ type DNSClient interface {
 	LookupTXT(context.Context, string) (txts []string, authorities []string, err error)
 	LookupHost(context.Context, string) ([]net.IP, error)
 	LookupCAA(context.Context, string) ([]*dns.CAA, error)
-	LookupMX(context.Context, string) ([]string, error)
 }
 
 // DNSClientImpl represents a client that talks to an external resolver
@@ -480,26 +479,4 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 		}
 	}
 	return CAAs, nil
-}
-
-// LookupMX sends a DNS query to find a MX record associated hostname and returns the
-// record target.
-func (dnsClient *DNSClientImpl) LookupMX(ctx context.Context, hostname string) ([]string, error) {
-	dnsType := dns.TypeMX
-	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
-	if err != nil {
-		return nil, &DNSError{dnsType, hostname, err, -1}
-	}
-	if r.Rcode != dns.RcodeSuccess {
-		return nil, &DNSError{dnsType, hostname, nil, r.Rcode}
-	}
-
-	var results []string
-	for _, answer := range r.Answer {
-		if mx, ok := answer.(*dns.MX); ok {
-			results = append(results, mx.Mx)
-		}
-	}
-
-	return results, nil
 }

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/miekg/dns"
 	"golang.org/x/net/context"
@@ -65,13 +64,9 @@ func (t timeoutError) Timeout() bool {
 }
 
 // LookupHost is a mock
-//
-// Note: see comments on LookupMX regarding email.only
-//
 func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
 	if hostname == "always.invalid" ||
-		hostname == "invalid.invalid" ||
-		hostname == "email.only" {
+		hostname == "invalid.invalid" {
 		return []net.IP{}, nil
 	}
 	if hostname == "always.timeout" {
@@ -100,29 +95,5 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 
 // LookupCAA returns mock records for use in tests.
 func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, error) {
-	return nil, nil
-}
-
-// LookupMX is a mock
-//
-// Note: the email.only domain must have an MX but no A or AAAA
-// records. The mock LookupHost returns an address of 127.0.0.1 for
-// all domains except for special cases, so MX-only domains must be
-// handled in both LookupHost and LookupMX.
-//
-func (mock *MockDNSClient) LookupMX(_ context.Context, domain string) ([]string, error) {
-	switch strings.TrimRight(domain, ".") {
-	case "letsencrypt.org":
-		fallthrough
-	case "email.only":
-		fallthrough
-	case "email.com":
-		return []string{"mail.email.com"}, nil
-	case "always.error":
-		return []string{}, &DNSError{dns.TypeA, "always.error",
-			&net.OpError{Err: errors.New("always.error always errors")}, -1}
-	case "always.timeout":
-		return []string{}, &DNSError{dns.TypeA, "always.timeout", MockTimeoutError(), -1}
-	}
 	return nil, nil
 }

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -33,10 +33,6 @@ func (mock caaMockDNS) LookupHost(_ context.Context, hostname string) ([]net.IP,
 	return []net.IP{ip}, nil
 }
 
-func (mock caaMockDNS) LookupMX(_ context.Context, domain string) ([]string, error) {
-	return nil, nil
-}
-
 func (mock caaMockDNS) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, error) {
 	var results []*dns.CAA
 	var record dns.CAA


### PR DESCRIPTION
We used to use this for checking email domains on registration, but not
anymore.