### PR TITLE
Makefile: remove clean/install/archive targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,24 +42,6 @@ build_cmds: | $(OBJDIR)
 	GOBIN=$(OBJDIR) go install $(GO_BUILD_FLAGS) ./...
 	cp $(OBJDIR)/boulder-va $(OBJDIR)/boulder-remoteva
 
-clean:
-	rm -f $(OBJDIR)/*
-	rmdir $(OBJDIR)
-
-# Install to a destination directory. Defaults to /usr/local/, but you can
-# override it with the DESTDIR variable. Example:
-#
-# DESTDIR=~/bin make install
-install:
-	@mkdir -p $(DESTDIR)
-	$(foreach var,$(OBJECTS), install -m 0755 $(OBJDIR)/$(var) $(DESTDIR)/;)
-
-# Produce a tarball of the current commit; you can set the destination in the
-# ARCHIVEDIR variable.
-archive:
-	git archive --output=$(ARCHIVEDIR)/boulder-$(COMMIT_ID).tar.gz \
-		--prefix=boulder-$(COMMIT_ID)/ $(COMMIT_ID)
-
 # Building an RPM requires `fpm` from https://github.com/jordansissel/fpm
 # which you can install with `gem install fpm`.
 # It is recommended that maintainers use environment overrides to specify


### PR DESCRIPTION
These `make` targets are either bit-rotten or Let's Encrypt doesn't use them. Removing the targets leaves the Makefile with two jobs: building the project and building an RPM.

I considered replacing these last two aspects of the Makefile with a straight `bash` script but found it wasn't really a useful change. The remaining `Makefile` is small and handles setting all of our build-time variables well enough. I don't think my idea of replacing it makes sense. In a perfect world the RPM generation wouldn't live in this repo but I don't have the energy to tilt at that windmill.

Resolves https://github.com/letsencrypt/boulder/issues/3494