### PR TITLE
wfe2: fix typo in err msg

### DIFF
--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -455,7 +455,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDLookupFailed"}).Inc()
 		// Add an error to the log event with the internal error message
 		logEvent.AddError(fmt.Sprintf("Error calling SA.GetRegistration: %s", err.Error()))
-		return nil, nil, probs.ServerInternal("Error retreiving account %q", accountURL)
+		return nil, nil, probs.ServerInternal("Error retrieving account %q", accountURL)
 	}
 
 	// Verify the account is not deactivated

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1043,7 +1043,7 @@ func TestLookupJWK(t *testing.T) {
 			Request: makePostRequestWithPath("test-path", errorIDJWSBody),
 			ExpectedProblem: &probs.ProblemDetails{
 				Type:       probs.ServerInternalProblem,
-				Detail:     "Error retreiving account \"http://localhost/acme/acct/100\"",
+				Detail:     "Error retrieving account \"http://localhost/acme/acct/100\"",
 				HTTPStatus: http.StatusInternalServerError,
 			},
 			ErrorStatType: "JWSKeyIDLookupFailed",


### PR DESCRIPTION
Credit to @schoen for [flagging this](https://community.letsencrypt.org/t/the-request-message-was-malformed-error-creating-new-order-dns-name-had-a-malformed-wildcard-label/93115/4).