### PR TITLE
va: case-insensitivity of suffixes in http redirs

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -510,6 +510,10 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		numRedirects++
 		va.metrics.http01Redirects.Inc()
 
+		// Lowercase the redirect host immediately, as the dialer and redirect
+		// validation expect it to have been lowercased already.
+		req.URL.Host = strings.ToLower(req.URL.Host)
+
 		// Extract the redirect target's host and port. This will return an error if
 		// the redirect request scheme, host or port is not acceptable.
 		redirHost, redirPort, err := va.extractRequestTarget(req)

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -497,6 +497,15 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 		fmt.Fprint(resp, tooLargeBuf)
 	})
 
+	// A path that redirects to an uppercase public suffix (#4215)
+	mux.HandleFunc("/redir-uppercase-publicsuffix", func(resp http.ResponseWriter, req *http.Request) {
+		http.Redirect(
+			resp,
+			req,
+			"http://example.COM/ok",
+			301)
+	})
+
 	return server
 }
 
@@ -822,6 +831,28 @@ func TestFetchHTTP(t *testing.T) {
 			Path:         "/ok",
 			ExpectedBody: "ok",
 			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               "http://example.com/ok",
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+		{
+			Name:         "Redirect to uppercase Public Suffix",
+			Host:         "example.com",
+			Path:         "/redir-uppercase-publicsuffix",
+			ExpectedBody: "ok",
+			ExpectedRecords: []core.ValidationRecord{
+				core.ValidationRecord{
+					Hostname:          "example.com",
+					Port:              strconv.Itoa(httpPort),
+					URL:               "http://example.com/redir-uppercase-publicsuffix",
+					AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+					AddressUsed:       net.ParseIP("127.0.0.1"),
+				},
 				core.ValidationRecord{
 					Hostname:          "example.com",
 					Port:              strconv.Itoa(httpPort),


### PR DESCRIPTION
#4215 

An URI host is [supposed to be case-insensitive](https://tools.ietf.org/html/rfc3986#section-3.2.2) but I've read that some webservers do not exactly conform to that, e.g. case-sensitive cache keys. Hopefully it does not create new problems.