### PR TITLE
va: fix flaky test_http2_http01_challenge int. test.

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -55,7 +55,13 @@ var (
 	// http.Client.Do() will return a url.Error err that wraps
 	// a errors.ErrorString instance. There isn't much else to do with one of
 	// those except match the encoded byte string with a regex. :-X
-	h2SettingsFrameErrRegex = regexp.MustCompile(`net\/http\: HTTP\/1\.x transport connection broken: malformed HTTP response \"\\x00\\x00\\x[a-f0-9]{2}\\x04\\x00\\x00\\x00\\x00\\x00.*"`)
+	//
+	// NOTE(@cpu): The first component of this regex is optional to avoid an
+	// integration test flake. In some (fairly rare) conditions the malformed
+	// response error will be returned simply as a http.badStringError without
+	// the broken transport prefix. Most of the time the error is returned with
+	// a transport connection error prefix.
+	h2SettingsFrameErrRegex = regexp.MustCompile(`(?:net\/http\: HTTP\/1\.x transport connection broken: )?malformed HTTP response \"\\x00\\x00\\x[a-f0-9]{2}\\x04\\x00\\x00\\x00\\x00\\x00.*"`)
 )
 
 // RemoteVA wraps the core.ValidationAuthority interface and adds a field containing the addresses


### PR DESCRIPTION
In some rare conditions the malformed HTTP response error message that we match in the VA for HTTP-01 connections to HTTP/2 servers will be returned as a raw `http.badStringError` that doesn't have a transport connection broken prefix. In these cases the existing `test_http2_http01_challenge` integration tests fails because the `h2SettingsFrameErrRegex` doesn't match the returned error.

To accommodate this we make the `h2SettingsFrameErrRegex` optionally match the transport connection broken prefix.

Resolves https://github.com/letsencrypt/boulder/issues/4205