### PR TITLE
publisher: remove HTTP GET log probing.

### DIFF
--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"os"
 	"runtime"
-	"time"
 
 	ct "github.com/google/certificate-transparency-go"
 
@@ -90,20 +89,6 @@ func main() {
 	cmd.FailOnError(err, "Unable to setup Publisher gRPC server")
 	gw := bgrpc.NewPublisherServerWrapper(pubi)
 	pubPB.RegisterPublisherServer(grpcSrv, gw)
-
-	// Collect HTTP GET debug data every second from each log which
-	// we are requesting SCTs from. This will allow us to verify during
-	// CT outages we've seen in the past if the issue is with the CT
-	// client itself or something in the larger publisher/golang http
-	// library.
-	if features.Enabled(features.ProbeCTLogs) {
-		go func() {
-			t := time.NewTicker(time.Second)
-			for range t.C {
-				go pubi.ProbeLogs()
-			}
-		}()
-	}
 
 	go cmd.CatchSignals(logger, grpcSrv.GracefulStop)
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -16,9 +16,9 @@ func _() {
 	_ = x[AllowRenewalFirstRL-5]
 	_ = x[SetIssuedNamesRenewalBit-6]
 	_ = x[FasterRateLimit-7]
-	_ = x[CAAValidationMethods-8]
-	_ = x[CAAAccountURI-9]
-	_ = x[ProbeCTLogs-10]
+	_ = x[ProbeCTLogs-8]
+	_ = x[CAAValidationMethods-9]
+	_ = x[CAAAccountURI-10]
 	_ = x[HeadNonceStatusOK-11]
 	_ = x[NewAuthorizationSchema-12]
 	_ = x[RevokeAtRA-13]
@@ -29,9 +29,9 @@ func _() {
 	_ = x[CheckRenewalFirst-18]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitCAAValidationMethodsCAAAccountURIProbeCTLogsHeadNonceStatusOKNewAuthorizationSchemaRevokeAtRAEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirst"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsCAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaRevokeAtRAEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirst"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 155, 168, 179, 196, 218, 228, 247, 261, 279, 298, 315}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 166, 179, 196, 218, 228, 247, 261, 279, 298, 315}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -19,14 +19,13 @@ const (
 	AllowRenewalFirstRL
 	SetIssuedNamesRenewalBit
 	FasterRateLimit
+	ProbeCTLogs
 
 	//   Currently in-use features
 	// Check CAA and respect validationmethods parameter.
 	CAAValidationMethods
 	// Check CAA and respect accounturi parameter.
 	CAAAccountURI
-	// ProbeCTLogs enables HTTP probes to CT logs from the publisher
-	ProbeCTLogs
 	// HEAD requests to the WFE2 new-nonce endpoint should return HTTP StatusOK
 	// instead of HTTP StatusNoContent.
 	HeadNonceStatusOK

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 
 	blog "github.com/letsencrypt/boulder/log"
@@ -432,46 +431,4 @@ func TestLogErrorBody(t *testing.T) {
 	})
 	test.AssertError(t, err, "SubmitToSingleCTWithResult didn't fail")
 	test.AssertEquals(t, len(log.GetAllMatching("well this isn't good now is it")), 1)
-}
-
-func TestProbeLogs(t *testing.T) {
-	pub, _, k := setup(t)
-
-	srvA := logSrv(k)
-	defer srvA.Close()
-	portA, err := getPort(srvA.URL)
-	test.AssertNotError(t, err, "Failed to get test server port")
-	srvB := errorBodyLogSrv()
-	defer srvB.Close()
-	portB, err := getPort(srvB.URL)
-	test.AssertNotError(t, err, "Failed to get test server port")
-
-	addLog := func(uri string) {
-		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		test.AssertNotError(t, err, "ecdsa.GenerateKey() failed for k")
-		der, err := x509.MarshalPKIXPublicKey(&k.PublicKey)
-		test.AssertNotError(t, err, "x509.MarshalPKIXPublicKey(der) failed")
-		kb64 := base64.StdEncoding.EncodeToString(der)
-		_, err = pub.ctLogsCache.AddLog(uri, kb64, pub.log)
-		test.AssertNotError(t, err, "Failed to add log to logCache")
-	}
-
-	addLog(fmt.Sprintf("http://localhost:%d", portA))
-	addLog(fmt.Sprintf("http://localhost:%d", portB))
-	addLog("http://blackhole:9999")
-
-	pub.ProbeLogs()
-
-	test.AssertEquals(t, test.CountHistogramSamples(pub.metrics.probeLatency.With(prometheus.Labels{
-		"log":    fmt.Sprintf("http://localhost:%d", portA),
-		"status": "200 OK",
-	})), 1)
-	test.AssertEquals(t, test.CountHistogramSamples(pub.metrics.probeLatency.With(prometheus.Labels{
-		"log":    fmt.Sprintf("http://localhost:%d", portB),
-		"status": "400 Bad Request",
-	})), 1)
-	test.AssertEquals(t, test.CountHistogramSamples(pub.metrics.probeLatency.With(prometheus.Labels{
-		"log":    "http://blackhole:9999",
-		"status": "error",
-	})), 1)
 }

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -18,7 +18,6 @@
       "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
     },
     "features": {
-      "ProbeCTLogs": true
     }
   },
 


### PR DESCRIPTION
We adding this diagnostic probing while debugging an issue that has since been resolved.

Resolves https://github.com/letsencrypt/boulder/issues/4209