### PR TITLE
core: split identifier types into separate package.

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -18,6 +18,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
@@ -234,7 +235,7 @@ func main() {
 			}
 			_, err = sac.RevokeAuthorizationsByDomain2(ctx, req)
 		} else {
-			ident := core.AcmeIdentifier{Value: domain, Type: core.IdentifierDNS}
+			ident := identifier.ACMEIdentifier{Value: domain, Type: identifier.DNS}
 			authsRevoked, pendingAuthsRevoked, err = sac.RevokeAuthorizationsByDomain(ctx, ident)
 			// For the legacy RevokeAuthorizationsByDomain RPC synthesize
 			// a berrors.NotFound err when there were no revocations. This makes it

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/features"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/policy"
@@ -267,7 +268,7 @@ func (c *certChecker) checkCert(cert core.Certificate) (problems []string) {
 		}
 		// Check that the PA is still willing to issue for each name in DNSNames + CommonName
 		for _, name := range append(parsedCert.DNSNames, parsedCert.Subject.CommonName) {
-			id := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: name}
+			id := identifier.ACMEIdentifier{Type: identifier.DNS, Value: name}
 			// TODO(https://github.com/letsencrypt/boulder/issues/3371): Distinguish
 			// between certificates issued by v1 and v2 API.
 			if err = c.pa.WillingToIssueWildcard(id); err != nil {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -11,6 +11,7 @@ import (
 
 	caPB "github.com/letsencrypt/boulder/ca/proto"
 	corepb "github.com/letsencrypt/boulder/core/proto"
+	"github.com/letsencrypt/boulder/identifier"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/revocation"
@@ -103,9 +104,9 @@ type CertificateAuthority interface {
 
 // PolicyAuthority defines the public interface for the Boulder PA
 type PolicyAuthority interface {
-	WillingToIssue(domain AcmeIdentifier) error
-	WillingToIssueWildcard(domain AcmeIdentifier) error
-	ChallengesFor(domain AcmeIdentifier) ([]Challenge, error)
+	WillingToIssue(domain identifier.ACMEIdentifier) error
+	WillingToIssueWildcard(domain identifier.ACMEIdentifier) error
+	ChallengesFor(domain identifier.ACMEIdentifier) ([]Challenge, error)
 	ChallengeTypeEnabled(t string) bool
 }
 
@@ -150,7 +151,7 @@ type StorageAdder interface {
 	FinalizeAuthorization(ctx context.Context, authz Authorization) error
 	MarkCertificateRevoked(ctx context.Context, serial string, reasonCode revocation.Reason) error
 	AddCertificate(ctx context.Context, der []byte, regID int64, ocsp []byte, issued *time.Time) (digest string, err error)
-	RevokeAuthorizationsByDomain(ctx context.Context, domain AcmeIdentifier) (finalized, pending int64, err error)
+	RevokeAuthorizationsByDomain(ctx context.Context, domain identifier.ACMEIdentifier) (finalized, pending int64, err error)
 	DeactivateRegistration(ctx context.Context, id int64) error
 	DeactivateAuthorization(ctx context.Context, id string) error
 	NewOrder(ctx context.Context, order *corepb.Order) (*corepb.Order, error)

--- a/core/objects.go
+++ b/core/objects.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/square/go-jose.v2"
 
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/revocation"
 )
@@ -22,9 +23,6 @@ type AcmeStatus string
 
 // AcmeResource values identify different types of ACME resources
 type AcmeResource string
-
-// IdentifierType defines the available identification mechanisms for domains
-type IdentifierType string
 
 // OCSPStatus defines the state of OCSP for a domain
 type OCSPStatus string
@@ -39,11 +37,6 @@ const (
 	StatusInvalid     = AcmeStatus("invalid")     // Validation failed
 	StatusRevoked     = AcmeStatus("revoked")     // Object no longer valid
 	StatusDeactivated = AcmeStatus("deactivated") // Object has been deactivated
-)
-
-// These types are the available identification mechanisms
-const (
-	IdentifierDNS = IdentifierType("dns")
 )
 
 // The types of ACME resources
@@ -85,16 +78,6 @@ func ValidChallenge(name string) bool {
 
 // DNSPrefix is attached to DNS names in DNS challenges
 const DNSPrefix = "_acme-challenge"
-
-// An AcmeIdentifier encodes an identifier that can
-// be validated by ACME.  The protocol allows for different
-// types of identifier to be supported (DNS names, IP
-// addresses, etc.), but currently we only support
-// domain names.
-type AcmeIdentifier struct {
-	Type  IdentifierType `json:"type"`  // The type of identifier being encoded
-	Value string         `json:"value"` // The identifier itself
-}
 
 // CertificateRequest is just a CSR
 //
@@ -361,7 +344,7 @@ type Authorization struct {
 	ID string `json:"id,omitempty" db:"id"`
 
 	// The identifier for which authorization is being given
-	Identifier AcmeIdentifier `json:"identifier,omitempty" db:"identifier"`
+	Identifier identifier.ACMEIdentifier `json:"identifier,omitempty" db:"identifier"`
 
 	// The registration ID associated with the authorization
 	RegistrationID int64 `json:"regId,omitempty" db:"registrationID"`

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/goodkey"
+	"github.com/letsencrypt/boulder/identifier"
 )
 
 // maxCNLength is the maximum length allowed for the common name as specified in RFC 5280
@@ -75,8 +76,8 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 	}
 	badNames := []string{}
 	for _, name := range csr.DNSNames {
-		ident := core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		ident := identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: name,
 		}
 		var err error

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/goodkey"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -23,15 +24,15 @@ var testingPolicy = &goodkey.KeyPolicy{
 
 type mockPA struct{}
 
-func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, err error) {
+func (pa *mockPA) ChallengesFor(identifier identifier.ACMEIdentifier) (challenges []core.Challenge, err error) {
 	return
 }
 
-func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
+func (pa *mockPA) WillingToIssue(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
-func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
+func (pa *mockPA) WillingToIssueWildcard(id identifier.ACMEIdentifier) error {
 	if id.Value == "bad-name.com" || id.Value == "other-bad-name.com" {
 		return errors.New("")
 	}

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	vapb "github.com/letsencrypt/boulder/va/proto"
@@ -388,7 +389,7 @@ func PBToAuthz(pb *corepb.Authorization) (core.Authorization, error) {
 		v2 = *pb.V2
 	}
 	authz := core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: *pb.Identifier},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: *pb.Identifier},
 		RegistrationID: *pb.RegistrationID,
 		Status:         core.AcmeStatus(*pb.Status),
 		Expires:        &expires,

--- a/grpc/pb-marshalling_test.go
+++ b/grpc/pb-marshalling_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 	vapb "github.com/letsencrypt/boulder/va/proto"
@@ -267,7 +268,7 @@ func TestRegistration(t *testing.T) {
 
 func TestAuthz(t *testing.T) {
 	exp := time.Now().AddDate(0, 0, 1).UTC()
-	identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.com"}
+	identifier := identifier.ACMEIdentifier{Type: identifier.DNS, Value: "example.com"}
 	challA := core.Challenge{
 		ID:                       10,
 		Type:                     core.ChallengeTypeDNS01,

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
@@ -423,7 +424,7 @@ func (sac StorageAuthorityClientWrapper) AddCertificate(
 	return *response.Digest, nil
 }
 
-func (sac StorageAuthorityClientWrapper) RevokeAuthorizationsByDomain(ctx context.Context, domain core.AcmeIdentifier) (int64, int64, error) {
+func (sac StorageAuthorityClientWrapper) RevokeAuthorizationsByDomain(ctx context.Context, domain identifier.ACMEIdentifier) (int64, int64, error) {
 	response, err := sac.inner.RevokeAuthorizationsByDomain(ctx, &sapb.RevokeAuthorizationsByDomainRequest{Domain: &domain.Value})
 	if err != nil {
 		return 0, 0, err
@@ -1039,7 +1040,7 @@ func (sas StorageAuthorityServerWrapper) RevokeAuthorizationsByDomain(ctx contex
 		return nil, errIncompleteRequest
 	}
 
-	finalized, pending, err := sas.inner.RevokeAuthorizationsByDomain(ctx, core.AcmeIdentifier{Value: *request.Domain, Type: core.IdentifierDNS})
+	finalized, pending, err := sas.inner.RevokeAuthorizationsByDomain(ctx, identifier.ACMEIdentifier{Value: *request.Domain, Type: identifier.DNS})
 	if err != nil {
 		return nil, err
 	}

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -1,0 +1,32 @@
+// The identifier package defines types for RFC 8555 ACME identifiers.
+package identifier
+
+// IdentifierType is a named string type for registered ACME identifier types.
+// See https://tools.ietf.org/html/rfc8555#section-9.7.7
+type IdentifierType string
+
+const (
+	// DNS is specified in RFC 8555 for DNS type identifiers.
+	DNS = IdentifierType("dns")
+)
+
+// ACMEIdentifier is a struct encoding an identifier that can be validated. The
+// protocol allows for different types of identifier to be supported (DNS
+// names, IP addresses, etc.), but currently we only support RFC 8555 DNS type
+// identifiers for domain names.
+type ACMEIdentifier struct {
+	// Type is the registered IdentifierType of the identifier.
+	Type IdentifierType `json:"type"`
+	// Value is the value of the identifier. For a DNS type identifier it is
+	// a domain name.
+	Value string `json:"value"`
+}
+
+// DNSIdentifier is a convenience function for creating an ACMEIdentifier with
+// Type DNS for a given domain name.
+func DNSIdentifier(domain string) ACMEIdentifier {
+	return ACMEIdentifier{
+		Type:  DNS,
+		Value: domain,
+	}
+}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -18,6 +18,7 @@ import (
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	"github.com/letsencrypt/boulder/revocation"
@@ -241,7 +242,7 @@ func (sa *StorageAuthority) GetAuthorization(_ context.Context, id string) (core
 		ID:             "valid",
 		Status:         core.StatusValid,
 		RegistrationID: 1,
-		Identifier:     core.AcmeIdentifier{Type: "dns", Value: "not-an-example.com"},
+		Identifier:     identifier.DNSIdentifier("not-an-example.com"),
 		Challenges: []core.Challenge{
 			{
 				ID:    23,
@@ -282,7 +283,7 @@ func (sa *StorageAuthority) GetAuthorization(_ context.Context, id string) (core
 }
 
 // RevokeAuthorizationsByDomain is a mock
-func (sa *StorageAuthority) RevokeAuthorizationsByDomain(_ context.Context, ident core.AcmeIdentifier) (int64, int64, error) {
+func (sa *StorageAuthority) RevokeAuthorizationsByDomain(_ context.Context, ident identifier.ACMEIdentifier) (int64, int64, error) {
 	return 0, 0, nil
 }
 
@@ -389,7 +390,7 @@ func (sa *StorageAuthority) GetValidAuthorizations(_ context.Context, regID int6
 					Status:         core.StatusValid,
 					RegistrationID: 1,
 					Expires:        &exp,
-					Identifier: core.AcmeIdentifier{
+					Identifier: identifier.ACMEIdentifier{
 						Type:  "dns",
 						Value: name,
 					},
@@ -605,7 +606,7 @@ func (sa *StorageAuthority) GetAuthorization2(ctx context.Context, id *sapb.Auth
 	authz := core.Authorization{
 		Status:         core.StatusValid,
 		RegistrationID: 1,
-		Identifier:     core.AcmeIdentifier{Type: "dns", Value: "not-an-example.com"},
+		Identifier:     identifier.DNSIdentifier("not-an-example.com"),
 		V2:             true,
 		Challenges: []core.Challenge{
 			{
@@ -713,7 +714,7 @@ func (sa *SAWithFailedChallenges) GetAuthorization(_ context.Context, id string)
 		ID:             "valid",
 		Status:         core.StatusValid,
 		RegistrationID: 1,
-		Identifier:     core.AcmeIdentifier{Type: "dns", Value: "not-an-example.com"},
+		Identifier:     identifier.DNSIdentifier("not-an-example.com"),
 		Challenges: []core.Challenge{
 			{
 				ID:   23,

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -17,6 +17,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/iana"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/reloader"
 	"gopkg.in/yaml.v2"
@@ -214,8 +215,8 @@ var (
 //
 // If WillingToIssue returns an error, it will be of type MalformedRequestError
 // or RejectedIdentifierError
-func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
-	if id.Type != core.IdentifierDNS {
+func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
+	if id.Type != identifier.DNS {
 		return errInvalidIdentifier
 	}
 	domain := id.Value
@@ -316,9 +317,9 @@ func (pa *AuthorityImpl) WillingToIssue(id core.AcmeIdentifier) error {
 //
 // If all of the above is true then the base domain (e.g. without the *.) is run
 // through WillingToIssue to catch other illegal things (blocked hosts, etc).
-func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error {
+func (pa *AuthorityImpl) WillingToIssueWildcard(ident identifier.ACMEIdentifier) error {
 	// We're only willing to process DNS identifiers
-	if ident.Type != core.IdentifierDNS {
+	if ident.Type != identifier.DNS {
 		return errInvalidIdentifier
 	}
 	rawDomain := ident.Value
@@ -362,8 +363,8 @@ func (pa *AuthorityImpl) WillingToIssueWildcard(ident core.AcmeIdentifier) error
 		// NOTE(@cpu): This is pretty hackish! Boulder issue #3323[0] describes
 		// a better follow-up that we should land to replace this code.
 		// [0] https://github.com/letsencrypt/boulder/issues/3323
-		return pa.WillingToIssue(core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		return pa.WillingToIssue(identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: "x." + baseDomain,
 		})
 	}
@@ -413,7 +414,7 @@ func (pa *AuthorityImpl) checkHostLists(domain string) error {
 
 // ChallengesFor makes a decision of what challenges are acceptable for
 // the given identifier.
-func (pa *AuthorityImpl) ChallengesFor(identifier core.AcmeIdentifier) ([]core.Challenge, error) {
+func (pa *AuthorityImpl) ChallengesFor(identifier identifier.ACMEIdentifier) ([]core.Challenge, error) {
 	challenges := []core.Challenge{}
 
 	// If we are using the new authorization storage schema we only use a single

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -25,6 +25,7 @@ import (
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/iana"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
@@ -1882,7 +1883,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 
 	// Validate that our policy allows issuing for each of the names in the order
 	for _, name := range order.Names {
-		id := core.AcmeIdentifier{Value: name, Type: core.IdentifierDNS}
+		id := identifier.ACMEIdentifier{Value: name, Type: identifier.DNS}
 		if err := ra.PA.WillingToIssueWildcard(id); err != nil {
 			return nil, err
 		}
@@ -2032,8 +2033,8 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		if err := ra.checkInvalidAuthorizationLimit(ctx, *order.RegistrationID, name); err != nil {
 			return nil, err
 		}
-		pb, err := ra.createPendingAuthz(ctx, *order.RegistrationID, core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		pb, err := ra.createPendingAuthz(ctx, *order.RegistrationID, identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: name,
 		}, v2)
 		if err != nil {
@@ -2107,7 +2108,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 // createPendingAuthz checks that a name is allowed for issuance and creates the
 // necessary challenges for it and puts this and all of the relevant information
 // into a corepb.Authorization for transmission to the SA to be stored
-func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg int64, identifier core.AcmeIdentifier, v2 bool) (*corepb.Authorization, error) {
+func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg int64, identifier identifier.ACMEIdentifier, v2 bool) (*corepb.Authorization, error) {
 	expires := ra.clk.Now().Add(ra.pendingAuthorizationLifetime).Truncate(time.Second).UnixNano()
 	status := string(core.StatusPending)
 	authz := &corepb.Authorization{

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 
 	"golang.org/x/net/context"
@@ -199,7 +200,7 @@ func TestAddAuthorization(t *testing.T) {
 	test.AssertMarshaledEquals(t, dbPa.ID, expectedPa.ID)
 
 	exp := time.Now().AddDate(0, 0, 1)
-	identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}
+	identifier := identifier.ACMEIdentifier{Type: identifier.DNS, Value: "wut.com"}
 	newPa := core.Authorization{ID: PA.ID, Identifier: identifier, RegistrationID: reg.ID, Status: core.StatusPending, Expires: &exp}
 
 	newPa.Status = core.StatusValid
@@ -235,7 +236,7 @@ func TestRecyclePendingEnabled(t *testing.T) {
 	expires := fc.Now()
 	authz := core.Authorization{
 		RegistrationID: reg.ID,
-		Identifier: core.AcmeIdentifier{
+		Identifier: identifier.ACMEIdentifier{
 			Type:  "dns",
 			Value: "example.letsencrypt.org",
 		},
@@ -277,7 +278,7 @@ func CreateDomainAuthWithRegID(t *testing.T, domainName string, sa *SQLStorageAu
 	authz, err := sa.NewPendingAuthorization(ctx, core.Authorization{
 		Status:         core.StatusPending,
 		Expires:        &exp,
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: domainName},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: domainName},
 		RegistrationID: regID,
 		Challenges:     []core.Challenge{{Type: "simpleHttp", Status: core.StatusValid, URI: domainName, Token: "THISWOULDNTBEAGOODTOKEN"}},
 	})
@@ -321,7 +322,7 @@ func TestGetValidAuthorizationsBasic(t *testing.T) {
 	test.AssertEquals(t, len(authzMap), 1)
 	result := authzMap["example.org"]
 	test.AssertEquals(t, result.Status, core.StatusValid)
-	test.AssertEquals(t, result.Identifier.Type, core.IdentifierDNS)
+	test.AssertEquals(t, result.Identifier.Type, identifier.DNS)
 	test.AssertEquals(t, result.Identifier.Value, "example.org")
 	test.AssertEquals(t, result.RegistrationID, reg.ID)
 }
@@ -419,7 +420,7 @@ func TestGetValidAuthorizationsDuplicate(t *testing.T) {
 	test.AssertEquals(t, len(authzMap), 1)
 	result1 := authzMap[domain]
 	test.AssertEquals(t, result1.Status, core.StatusValid)
-	test.AssertEquals(t, result1.Identifier.Type, core.IdentifierDNS)
+	test.AssertEquals(t, result1.Identifier.Type, identifier.DNS)
 	test.AssertEquals(t, result1.Identifier.Value, domain)
 	test.AssertEquals(t, result1.RegistrationID, reg.ID)
 
@@ -431,7 +432,7 @@ func TestGetValidAuthorizationsDuplicate(t *testing.T) {
 	test.AssertEquals(t, len(authzMap), 1)
 	result2 := authzMap[domain]
 	test.AssertEquals(t, result2.Status, core.StatusValid)
-	test.AssertEquals(t, result2.Identifier.Type, core.IdentifierDNS)
+	test.AssertEquals(t, result2.Identifier.Type, identifier.DNS)
 	test.AssertEquals(t, result2.Identifier.Value, domain)
 	test.AssertEquals(t, result2.RegistrationID, reg.ID)
 	// make sure we got the latest auth
@@ -806,7 +807,7 @@ func TestRevokeAuthorizationsByDomain(t *testing.T) {
 	err := sa.FinalizeAuthorization(ctx, PA2)
 	test.AssertNotError(t, err, "Failed to finalize authorization")
 
-	ident := core.AcmeIdentifier{Value: "a.com", Type: core.IdentifierDNS}
+	ident := identifier.ACMEIdentifier{Value: "a.com", Type: identifier.DNS}
 	ar, par, err := sa.RevokeAuthorizationsByDomain(ctx, ident)
 	test.AssertNotError(t, err, "Failed to revoke authorizations for a.com")
 	test.AssertEquals(t, ar, int64(1))
@@ -924,8 +925,8 @@ func TestRevokeAuthorizationsByDomain2(t *testing.T) {
 	oldPending, err := sa.NewPendingAuthorization(context.Background(), core.Authorization{
 		Status:         core.StatusPending,
 		RegistrationID: reg.ID,
-		Identifier: core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		Identifier: identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: ident,
 		},
 		Expires: &exp,
@@ -1216,7 +1217,7 @@ func TestDeactivateAuthorization(t *testing.T) {
 	test.AssertMarshaledEquals(t, dbPa.ID, expectedPa.ID)
 
 	exp := time.Now().AddDate(0, 0, 1)
-	identifier := core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "wut.com"}
+	identifier := identifier.ACMEIdentifier{Type: identifier.DNS, Value: "wut.com"}
 	newPa := core.Authorization{
 		ID:             PA.ID,
 		Identifier:     identifier,
@@ -1625,7 +1626,7 @@ func TestSetOrderProcessing(t *testing.T) {
 	// Add one pending authz
 	authzExpires := fc.Now().Add(time.Hour)
 	newAuthz := core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "example.com"},
 		RegistrationID: reg.ID,
 		Status:         core.StatusPending,
 		Expires:        &authzExpires,
@@ -1678,7 +1679,7 @@ func TestFinalizeOrder(t *testing.T) {
 	// Add one pending authz
 	authzExpires := fc.Now().Add(time.Hour)
 	newAuthz := core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "example.com"},
 		RegistrationID: reg.ID,
 		Status:         core.StatusPending,
 		Expires:        &authzExpires,
@@ -1736,7 +1737,7 @@ func TestOrder(t *testing.T) {
 
 	authzExpires := fc.Now().Add(time.Hour)
 	newAuthz := core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "example.com"},
 		RegistrationID: reg.ID,
 		Status:         core.StatusPending,
 		Expires:        &authzExpires,
@@ -1886,7 +1887,7 @@ func TestGetAuthorizations(t *testing.T) {
 	// Create an authorization template for a pending authorization with a dummy identifier
 	pa := core.Authorization{
 		RegistrationID: reg.ID,
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: identA},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: identA},
 		Status:         core.StatusPending,
 		Expires:        &exp,
 	}
@@ -2013,7 +2014,7 @@ func TestGetAuthorizations2(t *testing.T) {
 	// Create an authorization template for a pending authorization with a dummy identifier
 	pa := core.Authorization{
 		RegistrationID: reg.ID,
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: identA},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: identA},
 		Status:         core.StatusPending,
 		Expires:        &exp,
 		Challenges: []core.Challenge{
@@ -2162,7 +2163,7 @@ func TestCountOrders(t *testing.T) {
 	test.AssertEquals(t, count, 0)
 
 	// Add a pending authorization
-	authz, err := sa.NewPendingAuthorization(ctx, core.Authorization{RegistrationID: reg.ID, Identifier: core.AcmeIdentifier{Type: "dns", Value: "example.com"}, Status: core.StatusPending, Expires: &expires})
+	authz, err := sa.NewPendingAuthorization(ctx, core.Authorization{RegistrationID: reg.ID, Identifier: identifier.DNSIdentifier("example.com"), Status: core.StatusPending, Expires: &expires})
 	test.AssertNotError(t, err, "Couldn't create new pending authorization")
 
 	// Add one pending order
@@ -2207,7 +2208,7 @@ func TestGetOrderForNames(t *testing.T) {
 	// Add one pending authz for the first name for regA
 	authzExpires := fc.Now().Add(time.Hour)
 	newAuthzA := core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "example.com"},
 		RegistrationID: regA.ID,
 		Status:         core.StatusPending,
 		Expires:        &authzExpires,
@@ -2217,7 +2218,7 @@ func TestGetOrderForNames(t *testing.T) {
 
 	// Add one pending authz for the second name for regA
 	newAuthzB := core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "just.another.example.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "just.another.example.com"},
 		RegistrationID: regA.ID,
 		Status:         core.StatusPending,
 		Expires:        &authzExpires,
@@ -2298,14 +2299,14 @@ func TestGetOrderForNames(t *testing.T) {
 	// Create two valid authorizations (by first creating pending authorizations)
 	authzExpires = fc.Now().Add(time.Hour)
 	validAuthzA, err := sa.NewPendingAuthorization(ctx, core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "zombo.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "zombo.com"},
 		RegistrationID: regA.ID,
 		Status:         core.StatusPending,
 		Expires:        &authzExpires,
 	})
 	test.AssertNotError(t, err, "unexpected error creating pending authorization")
 	validAuthzB, err := sa.NewPendingAuthorization(ctx, core.Authorization{
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "welcome.to.zombo.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "welcome.to.zombo.com"},
 		RegistrationID: regA.ID,
 		Status:         core.StatusPending,
 		Expires:        &authzExpires,
@@ -2387,7 +2388,7 @@ func TestStatusForOrder(t *testing.T) {
 		RegistrationID: reg.ID,
 		Expires:        &expires,
 		Status:         core.StatusPending,
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "pending.your.order.is.up"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "pending.your.order.is.up"},
 	}
 	pendingAuthz, err := sa.NewPendingAuthorization(ctx, newAuthz)
 	test.AssertNotError(t, err, "Couldn't create new pending authorization")
@@ -2397,7 +2398,7 @@ func TestStatusForOrder(t *testing.T) {
 		RegistrationID: newAuthz.RegistrationID,
 		Expires:        &alreadyExpired,
 		Status:         newAuthz.Status,
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "expired.your.order.is.up"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "expired.your.order.is.up"},
 	}
 	expiredAuthz, err := sa.NewPendingAuthorization(ctx, newExpiredAuthz)
 	test.AssertNotError(t, err, "Couldn't create new expired pending authorization")
@@ -2561,8 +2562,8 @@ func TestGetAuthorizationsFast(t *testing.T) {
 			RegistrationID: reg.ID,
 			Expires:        &expires,
 			Status:         core.StatusPending,
-			Identifier: core.AcmeIdentifier{
-				Type:  core.IdentifierDNS,
+			Identifier: identifier.ACMEIdentifier{
+				Type:  identifier.DNS,
 				Value: s,
 			},
 		})
@@ -2613,7 +2614,7 @@ func TestUpdateChallengesPendingOnly(t *testing.T) {
 		RegistrationID: reg.ID,
 		Expires:        &expires,
 		Status:         core.StatusPending,
-		Identifier:     core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "example.com"},
+		Identifier:     identifier.ACMEIdentifier{Type: identifier.DNS, Value: "example.com"},
 		Challenges: []core.Challenge{
 			core.Challenge{
 				Type:   "http-01",
@@ -3066,15 +3067,15 @@ func TestGetPendingAuthorization2(t *testing.T) {
 		Status:         core.StatusPending,
 		Expires:        &exp,
 		RegistrationID: reg.ID,
-		Identifier: core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		Identifier: identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: ident,
 		},
 	})
 	test.AssertNotError(t, err, "sa.NewPendingAuthorization failed")
 
 	validUntil = fc.Now().UTC().UnixNano()
-	identType := string(core.IdentifierDNS)
+	identType := string(identifier.DNS)
 	dbVer, err = sa.GetPendingAuthorization2(context.Background(), &sapb.GetPendingAuthorizationRequest{
 		RegistrationID:  &reg.ID,
 		IdentifierValue: &ident,
@@ -3347,8 +3348,8 @@ func TestCountInvalidAuthorizations2(t *testing.T) {
 		RegistrationID: reg.ID,
 		Expires:        &exp,
 		Status:         core.StatusPending,
-		Identifier: core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		Identifier: identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: ident,
 		},
 	})
@@ -3386,8 +3387,8 @@ func TestGetValidAuthorizations2(t *testing.T) {
 		RegistrationID: reg.ID,
 		Expires:        &exp,
 		Status:         core.StatusPending,
-		Identifier: core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		Identifier: identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: "bbb",
 		},
 	})

--- a/sa/type-converter.go
+++ b/sa/type-converter.go
@@ -9,6 +9,7 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 )
 
 // BoulderTypeConverter is used by Gorp for storing objects in DB.
@@ -17,7 +18,7 @@ type BoulderTypeConverter struct{}
 // ToDb converts a Boulder object to one suitable for the DB representation.
 func (tc BoulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
 	switch t := val.(type) {
-	case core.AcmeIdentifier, []core.Challenge, []string, [][]int:
+	case identifier.ACMEIdentifier, []core.Challenge, []string, [][]int:
 		jsonBytes, err := json.Marshal(t)
 		if err != nil {
 			return nil, err
@@ -41,7 +42,7 @@ func (tc BoulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
 // FromDb converts a DB representation back into a Boulder object.
 func (tc BoulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, bool) {
 	switch target.(type) {
-	case *core.AcmeIdentifier, *[]core.Challenge, *[]string, *[][]int:
+	case *identifier.ACMEIdentifier, *[]core.Challenge, *[]string, *[][]int:
 		binder := func(holder, target interface{}) error {
 			s, ok := holder.(*string)
 			if !ok {

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/test"
 
 	jose "gopkg.in/square/go-jose.v2"
@@ -19,8 +20,8 @@ const JWK1JSON = `{
 func TestAcmeIdentifier(t *testing.T) {
 	tc := BoulderTypeConverter{}
 
-	ai := core.AcmeIdentifier{Type: "data1", Value: "data2"}
-	out := core.AcmeIdentifier{}
+	ai := identifier.ACMEIdentifier{Type: "data1", Value: "data2"}
+	out := identifier.ACMEIdentifier{}
 
 	marshaledI, err := tc.ToDb(ai)
 	test.AssertNotError(t, err, "Could not ToDb")
@@ -41,7 +42,7 @@ func TestAcmeIdentifier(t *testing.T) {
 func TestAcmeIdentifierBadJSON(t *testing.T) {
 	badJSON := `{`
 	tc := BoulderTypeConverter{}
-	out := core.AcmeIdentifier{}
+	out := identifier.ACMEIdentifier{}
 	scanner, _ := tc.FromDb(&out)
 	err := scanner.Binder(&badJSON, &out)
 	test.AssertError(t, err, "expected error from scanner.Binder")

--- a/test/authz-filler/main.go
+++ b/test/authz-filler/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/sa"
 )
 
@@ -77,7 +78,7 @@ func main() {
 						Expires:        &expires,
 						Combinations:   [][]int{[]int{1, 2, 3}},
 						Status:         "pending",
-						Identifier: core.AcmeIdentifier{
+						Identifier: identifier.ACMEIdentifier{
 							Type:  "dns",
 							Value: "example.com",
 						},

--- a/test/load-generator/boulder-calls.go
+++ b/test/load-generator/boulder-calls.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test/load-generator/acme"
 
@@ -47,13 +48,13 @@ type OrderJSON struct {
 	// The URL field isn't returned by the API, we populate it manually with the
 	// `Location` header.
 	URL            string
-	Status         core.AcmeStatus       `json:"status"`
-	Expires        time.Time             `json:"expires"`
-	Identifiers    []core.AcmeIdentifier `json:"identifiers"`
-	Authorizations []string              `json:"authorizations"`
-	Finalize       string                `json:"finalize"`
-	Certificate    string                `json:"certificate,omitempty"`
-	Error          *probs.ProblemDetails `json:"error,omitempty"`
+	Status         core.AcmeStatus             `json:"status"`
+	Expires        time.Time                   `json:"expires"`
+	Identifiers    []identifier.ACMEIdentifier `json:"identifiers"`
+	Authorizations []string                    `json:"authorizations"`
+	Finalize       string                      `json:"finalize"`
+	Certificate    string                      `json:"certificate,omitempty"`
+	Error          *probs.ProblemDetails       `json:"error,omitempty"`
 }
 
 // getAccount takes a randomly selected v2 account from `state.accts` and puts it
@@ -163,17 +164,17 @@ func newOrder(s *State, ctx *context) error {
 	orderSize := 1 + mrand.Intn(s.maxNamesPerCert-1)
 	// Generate that many random domain names. There may be some duplicates, we
 	// don't care. The ACME server will collapse those down for us, how handy!
-	dnsNames := []core.AcmeIdentifier{}
+	dnsNames := []identifier.ACMEIdentifier{}
 	for i := 0; i <= orderSize; i++ {
-		dnsNames = append(dnsNames, core.AcmeIdentifier{
-			Type:  core.IdentifierDNS,
+		dnsNames = append(dnsNames, identifier.ACMEIdentifier{
+			Type:  identifier.DNS,
 			Value: randDomain(s.domainBase),
 		})
 	}
 
 	// create the new order request object
 	initOrder := struct {
-		Identifiers []core.AcmeIdentifier
+		Identifiers []identifier.ACMEIdentifier
 	}{
 		Identifiers: dnsNames,
 	}

--- a/va/caa.go
+++ b/va/caa.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/features"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	vapb "github.com/letsencrypt/boulder/va/proto"
 	"github.com/miekg/dns"
@@ -21,8 +21,8 @@ type caaParams struct {
 }
 
 func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsCAAValidRequest) (*vapb.IsCAAValidResponse, error) {
-	acmeID := core.AcmeIdentifier{
-		Type:  core.IdentifierDNS,
+	acmeID := identifier.ACMEIdentifier{
+		Type:  identifier.DNS,
 		Value: *req.Domain,
 	}
 	params := &caaParams{
@@ -46,7 +46,7 @@ func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsC
 // the CAA lookup & validation fail a problem is returned.
 func (va *ValidationAuthorityImpl) checkCAA(
 	ctx context.Context,
-	identifier core.AcmeIdentifier,
+	identifier identifier.ACMEIdentifier,
 	params *caaParams) *probs.ProblemDetails {
 	present, valid, records, err := va.checkCAARecords(ctx, identifier, params)
 	if err != nil {
@@ -185,7 +185,7 @@ func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname strin
 // value (or nil).
 func (va *ValidationAuthorityImpl) checkCAARecords(
 	ctx context.Context,
-	identifier core.AcmeIdentifier,
+	identifier identifier.ACMEIdentifier,
 	params *caaParams) (bool, bool, []*dns.CAA, error) {
 	hostname := strings.ToLower(identifier.Value)
 	// If this is a wildcard name, remove the prefix

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/features"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 
@@ -184,7 +185,7 @@ func (mock caaMockDNS) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, 
 func TestCAATimeout(t *testing.T) {
 	va, _ := setup(nil, 0, "", nil)
 	va.dnsClient = caaMockDNS{}
-	err := va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "caa-timeout.com"}, nil)
+	err := va.checkCAA(ctx, identifier.DNSIdentifier("caa-timeout.com"), nil)
 	if err.Type != probs.DNSProblem {
 		t.Errorf("Expected timeout error type %s, got %s", probs.DNSProblem, err.Type)
 	}
@@ -404,7 +405,7 @@ func TestCAAChecking(t *testing.T) {
 		mockLog := va.log.(*blog.Mock)
 		mockLog.Clear()
 		t.Run(caaTest.Name, func(t *testing.T) {
-			ident := core.AcmeIdentifier{Type: "dns", Value: caaTest.Domain}
+			ident := identifier.DNSIdentifier(caaTest.Domain)
 			present, valid, _, err := va.checkCAARecords(ctx, ident, params)
 			if err != nil {
 				t.Errorf("checkCAARecords error for %s: %s", caaTest.Domain, err)
@@ -422,14 +423,14 @@ func TestCAAChecking(t *testing.T) {
 	features.Reset()
 
 	// present-dns-only.com should now be valid even with http-01
-	ident := core.AcmeIdentifier{Type: "dns", Value: "present-dns-only.com"}
+	ident := identifier.DNSIdentifier("present-dns-only.com")
 	present, valid, _, err := va.checkCAARecords(ctx, ident, params)
 	test.AssertNotError(t, err, "present-dns-only.com")
 	test.Assert(t, present, "Present should be true")
 	test.Assert(t, valid, "Valid should be true")
 
 	// present-incorrect-accounturi.com should now be also be valid
-	ident = core.AcmeIdentifier{Type: "dns", Value: "present-incorrect-accounturi.com"}
+	ident = identifier.DNSIdentifier("present-incorrect-accounturi.com")
 	present, valid, _, err = va.checkCAARecords(ctx, ident, params)
 	test.AssertNotError(t, err, "present-incorrect-accounturi.com")
 	test.Assert(t, present, "Present should be true")
@@ -541,7 +542,7 @@ func TestCAALogging(t *testing.T) {
 				accountURIID:     tc.AccountURIID,
 				validationMethod: tc.ChallengeType,
 			}
-			_ = va.checkCAA(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: tc.Domain}, params)
+			_ = va.checkCAA(ctx, identifier.ACMEIdentifier{Type: identifier.DNS, Value: tc.Domain}, params)
 
 			caaLogLines := mockLog.GetAllMatching(`Checked CAA records for`)
 			if len(caaLogLines) != 1 {

--- a/va/dns.go
+++ b/va/dns.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 )
 
@@ -43,9 +44,9 @@ func availableAddresses(allAddrs []net.IP) (v4 []net.IP, v6 []net.IP) {
 	return
 }
 
-func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier core.AcmeIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
-	if identifier.Type != core.IdentifierDNS {
-		va.log.Infof("Identifier type for DNS challenge was not DNS: %s", identifier)
+func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, ident identifier.ACMEIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
+	if ident.Type != identifier.DNS {
+		va.log.Infof("Identifier type for DNS challenge was not DNS: %s", ident)
 		return nil, probs.Malformed("Identifier type for DNS was not itself DNS")
 	}
 
@@ -55,11 +56,11 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier
 	authorizedKeysDigest := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 
 	// Look for the required record in the DNS
-	challengeSubdomain := fmt.Sprintf("%s.%s", core.DNSPrefix, identifier.Value)
+	challengeSubdomain := fmt.Sprintf("%s.%s", core.DNSPrefix, ident.Value)
 	txts, authorities, err := va.dnsClient.LookupTXT(ctx, challengeSubdomain)
 
 	if err != nil {
-		va.log.Infof("Failed to lookup TXT records for %s. err=[%#v] errStr=[%s]", identifier, err, err)
+		va.log.Infof("Failed to lookup TXT records for %s. err=[%#v] errStr=[%s]", ident, err, err)
 		return nil, probs.DNS(err.Error())
 	}
 
@@ -75,7 +76,7 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, identifier
 			// Successful challenge validation
 			return []core.ValidationRecord{{
 				Authorities: authorities,
-				Hostname:    identifier.Value,
+				Hostname:    ident.Value,
 			}}, nil
 		}
 	}

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
@@ -94,8 +95,8 @@ func TestDNSValidationFailure(t *testing.T) {
 }
 
 func TestDNSValidationInvalid(t *testing.T) {
-	var notDNS = core.AcmeIdentifier{
-		Type:  core.IdentifierType("iris"),
+	var notDNS = identifier.ACMEIdentifier{
+		Type:  identifier.IdentifierType("iris"),
 		Value: "790DB180-A274-47A4-855F-31C428CB1072",
 	}
 

--- a/va/http.go
+++ b/va/http.go
@@ -16,6 +16,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/iana"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 )
 
@@ -617,15 +618,15 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 	return body, records, nil
 }
 
-func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, identifier core.AcmeIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
-	if identifier.Type != core.IdentifierDNS {
-		va.log.Infof("Got non-DNS identifier for HTTP validation: %s", identifier)
+func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, ident identifier.ACMEIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
+	if ident.Type != identifier.DNS {
+		va.log.Infof("Got non-DNS identifier for HTTP validation: %s", ident)
 		return nil, probs.Malformed("Identifier type for HTTP validation was not DNS")
 	}
 
 	// Perform the fetch
 	path := fmt.Sprintf(".well-known/acme-challenge/%s", challenge.Token)
-	body, validationRecords, prob := va.fetchHTTP(ctx, identifier.Value, "/"+path)
+	body, validationRecords, prob := va.fetchHTTP(ctx, ident.Value, "/"+path)
 	if prob != nil {
 		return validationRecords, prob
 	}
@@ -635,7 +636,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, identifie
 	if payload != challenge.ProvidedKeyAuthorization {
 		problem := probs.Unauthorized("The key authorization file from the server did not match this challenge [%v] != [%v]",
 			challenge.ProvidedKeyAuthorization, payload)
-		va.log.Infof("%s for %s", problem.Detail, identifier)
+		va.log.Infof("%s for %s", problem.Detail, ident)
 		return validationRecords, problem
 	}
 

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 
@@ -1066,14 +1067,14 @@ func TestHTTP(t *testing.T) {
 	test.AssertEquals(t, len(matchedValidRedirect), 1)
 	test.AssertEquals(t, len(matchedMovedRedirect), 1)
 
-	ipIdentifier := core.AcmeIdentifier{Type: core.IdentifierType("ip"), Value: "127.0.0.1"}
+	ipIdentifier := identifier.ACMEIdentifier{Type: identifier.IdentifierType("ip"), Value: "127.0.0.1"}
 	_, prob = va.validateHTTP01(ctx, ipIdentifier, chall)
 	if prob == nil {
 		t.Fatalf("IdentifierType IP shouldn't have worked.")
 	}
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
 
-	_, prob = va.validateHTTP01(ctx, core.AcmeIdentifier{Type: core.IdentifierDNS, Value: "always.invalid"}, chall)
+	_, prob = va.validateHTTP01(ctx, identifier.ACMEIdentifier{Type: identifier.DNS, Value: "always.invalid"}, chall)
 	if prob == nil {
 		t.Fatalf("Domain name is invalid.")
 	}

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 )
 
@@ -54,7 +55,7 @@ func certNames(cert *x509.Certificate) []string {
 }
 
 func (va *ValidationAuthorityImpl) tryGetTLSCerts(ctx context.Context,
-	identifier core.AcmeIdentifier, challenge core.Challenge,
+	identifier identifier.ACMEIdentifier, challenge core.Challenge,
 	tlsConfig *tls.Config) ([]*x509.Certificate, *tls.ConnectionState, []core.ValidationRecord, *probs.ProblemDetails) {
 
 	allAddrs, problem := va.getAddrs(ctx, identifier.Value)
@@ -118,7 +119,7 @@ func (va *ValidationAuthorityImpl) tryGetTLSCerts(ctx context.Context,
 func (va *ValidationAuthorityImpl) getTLSCerts(
 	ctx context.Context,
 	hostPort string,
-	identifier core.AcmeIdentifier,
+	identifier identifier.ACMEIdentifier,
 	challenge core.Challenge,
 	config *tls.Config,
 ) ([]*x509.Certificate, *tls.ConnectionState, *probs.ProblemDetails) {
@@ -173,7 +174,7 @@ func (va *ValidationAuthorityImpl) tlsDial(ctx context.Context, hostPort string,
 	return conn, nil
 }
 
-func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identifier core.AcmeIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
+func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identifier identifier.ACMEIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
 	if identifier.Type != "dns" {
 		va.log.Info(fmt.Sprintf("Identifier type for TLS-ALPN-01 was not DNS: %s", identifier))
 		return nil, probs.Malformed("Identifier type for TLS-ALPN-01 was not DNS")

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -123,8 +124,8 @@ func TestTLSALPN01FailIP(t *testing.T) {
 	va, _ := setup(hs, 0, "", nil)
 
 	port := getPort(hs)
-	_, prob := va.validateTLSALPN01(ctx, core.AcmeIdentifier{
-		Type:  core.IdentifierType("ip"),
+	_, prob := va.validateTLSALPN01(ctx, identifier.ACMEIdentifier{
+		Type:  identifier.IdentifierType("ip"),
 		Value: net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
 	}, chall)
 	if prob == nil {

--- a/va/va.go
+++ b/va/va.go
@@ -23,6 +23,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
@@ -275,7 +276,7 @@ func detailedError(err error) *probs.ProblemDetails {
 // validation attempt.
 func (va *ValidationAuthorityImpl) validate(
 	ctx context.Context,
-	identifier core.AcmeIdentifier,
+	identifier identifier.ACMEIdentifier,
 	challenge core.Challenge,
 	authz core.Authorization,
 ) ([]core.ValidationRecord, *probs.ProblemDetails) {
@@ -315,7 +316,7 @@ func (va *ValidationAuthorityImpl) validate(
 	return validationRecords, nil
 }
 
-func (va *ValidationAuthorityImpl) validateChallenge(ctx context.Context, identifier core.AcmeIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
+func (va *ValidationAuthorityImpl) validateChallenge(ctx context.Context, identifier identifier.ACMEIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
 	if err := challenge.CheckConsistencyForValidation(); err != nil {
 		return nil, probs.Malformed("Challenge failed consistency check: %s", err)
 	}
@@ -557,7 +558,7 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 		go va.performRemoteValidation(ctx, domain, challenge, authz, remoteProbs)
 	}
 
-	records, prob := va.validate(ctx, core.AcmeIdentifier{Type: "dns", Value: domain}, challenge, authz)
+	records, prob := va.validate(ctx, identifier.DNSIdentifier(domain), challenge, authz)
 	challenge.ValidationRecord = records
 
 	// Check for malformed ValidationRecords

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/features"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
@@ -56,8 +57,8 @@ var TheKey = rsa.PrivateKey{
 var accountKey = &jose.JSONWebKey{Key: TheKey.Public()}
 
 // Return an ACME DNS identifier for the given hostname
-func dnsi(hostname string) core.AcmeIdentifier {
-	return core.AcmeIdentifier{Type: core.IdentifierDNS, Value: hostname}
+func dnsi(hostname string) identifier.ACMEIdentifier {
+	return identifier.ACMEIdentifier{Type: identifier.DNS, Value: hostname}
 }
 
 var ctx context.Context

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -26,6 +26,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/metrics/measured_http"
@@ -674,7 +675,7 @@ func (wfe *WebFrontEndImpl) NewAuthorization(ctx context.Context, logEvent *web.
 		wfe.sendError(response, logEvent, probs.Malformed("Error unmarshaling JSON"), err)
 		return
 	}
-	if init.Identifier.Type == core.IdentifierDNS {
+	if init.Identifier.Type == identifier.DNS {
 		logEvent.DNSName = init.Identifier.Value
 	}
 
@@ -1021,7 +1022,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 	}
 	challenge := authz.Challenges[challengeIndex]
 
-	if authz.Identifier.Type == core.IdentifierDNS {
+	if authz.Identifier.Type == identifier.DNS {
 		logEvent.DNSName = authz.Identifier.Value
 	}
 	logEvent.Status = string(authz.Status)
@@ -1355,7 +1356,7 @@ func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.Req
 		}
 	}
 
-	if authz.Identifier.Type == core.IdentifierDNS {
+	if authz.Identifier.Type == identifier.DNS {
 		logEvent.DNSName = authz.Identifier.Value
 	}
 	logEvent.Status = string(authz.Status)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -29,6 +29,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/mocks"
@@ -269,15 +270,15 @@ func (ra *MockRegistrationAuthority) FinalizeOrder(ctx context.Context, _ *rapb.
 
 type mockPA struct{}
 
-func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, err error) {
+func (pa *mockPA) ChallengesFor(identifier identifier.ACMEIdentifier) (challenges []core.Challenge, err error) {
 	return
 }
 
-func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
+func (pa *mockPA) WillingToIssue(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
-func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
+func (pa *mockPA) WillingToIssueWildcard(id identifier.ACMEIdentifier) error {
 	return nil
 }
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -31,6 +31,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/mocks"
@@ -280,15 +281,15 @@ func (ra *MockRegistrationAuthority) FinalizeOrder(ctx context.Context, req *rap
 
 type mockPA struct{}
 
-func (pa *mockPA) ChallengesFor(identifier core.AcmeIdentifier) (challenges []core.Challenge, err error) {
+func (pa *mockPA) ChallengesFor(identifier identifier.ACMEIdentifier) (challenges []core.Challenge, err error) {
 	return
 }
 
-func (pa *mockPA) WillingToIssue(id core.AcmeIdentifier) error {
+func (pa *mockPA) WillingToIssue(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
-func (pa *mockPA) WillingToIssueWildcard(id core.AcmeIdentifier) error {
+func (pa *mockPA) WillingToIssueWildcard(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
@@ -2880,7 +2881,7 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 		ID:             "12345",
 		Status:         core.StatusPending,
 		RegistrationID: 1,
-		Identifier:     core.AcmeIdentifier{Type: "dns", Value: "*.example.com"},
+		Identifier:     identifier.DNSIdentifier("*.example.com"),
 		Challenges: []core.Challenge{
 			{
 				ID:   12345,


### PR DESCRIPTION
This will allow implementing sub-problems without creating a cyclic dependency between `core` and `problems`.

The `identifier` package is somewhat small/single-purpose and in the future we may want to move more "ACME" bits beyond the `identifier` types into a dedicated package outside of `core`.

Updates https://github.com/letsencrypt/boulder/issues/4193