### PR TITLE
Implement suberrors & subproblems

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,10 @@
 package errors
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/letsencrypt/boulder/identifier"
+)
 
 // ErrorType provides a coarse category for BoulderErrors
 type ErrorType int
@@ -24,12 +28,30 @@ const (
 
 // BoulderError represents internal Boulder errors
 type BoulderError struct {
-	Type   ErrorType
-	Detail string
+	Type      ErrorType
+	Detail    string
+	SubErrors []SubBoulderError
+}
+
+// SubBoulderError represents sub-errors specific to an identifier that are
+// related to a top-level internal Boulder error.
+type SubBoulderError struct {
+	*BoulderError
+	Identifier identifier.ACMEIdentifier
 }
 
 func (be *BoulderError) Error() string {
 	return be.Detail
+}
+
+// WithSubErrors returns a new BoulderError instance created by adding the
+// provided subErrs to the existing BoulderError.
+func (be *BoulderError) WithSubErrors(subErrs []SubBoulderError) *BoulderError {
+	return &BoulderError{
+		Type:      be.Type,
+		Detail:    be.Detail,
+		SubErrors: append(be.SubErrors, subErrs...),
+	}
 }
 
 // New is a convenience function for creating a new BoulderError

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,50 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/letsencrypt/boulder/identifier"
+	"github.com/letsencrypt/boulder/test"
+)
+
+// TestWithSubErrors tests that a boulder error can be created by adding
+// suberrors to an existing top level boulder error
+func TestWithSubErrors(t *testing.T) {
+	topErr := &BoulderError{
+		Type:   RateLimit,
+		Detail: "don't you think you have enough certificates already?",
+	}
+
+	subErrs := []SubBoulderError{
+		SubBoulderError{
+			Identifier: identifier.DNSIdentifier("example.com"),
+			BoulderError: &BoulderError{
+				Type:   RateLimit,
+				Detail: "everyone uses this example domain",
+			},
+		},
+		SubBoulderError{
+			Identifier: identifier.DNSIdentifier("what about example.com"),
+			BoulderError: &BoulderError{
+				Type:   RateLimit,
+				Detail: "try a real identifier value next time",
+			},
+		},
+	}
+
+	outResult := topErr.WithSubErrors(subErrs)
+	// The outResult should be a new, distinct error
+	test.AssertNotEquals(t, topErr, outResult)
+	// The outResult error should have the correct sub errors
+	test.AssertDeepEquals(t, outResult.SubErrors, subErrs)
+	// Adding another suberr shouldn't squash the original sub errors
+	anotherSubErr := SubBoulderError{
+		Identifier: identifier.DNSIdentifier("another ident"),
+		BoulderError: &BoulderError{
+			Type:   RateLimit,
+			Detail: "another rate limit err",
+		},
+	}
+	outResult = outResult.WithSubErrors([]SubBoulderError{anotherSubErr})
+	test.AssertDeepEquals(t, outResult.SubErrors, append(subErrs, anotherSubErr))
+}

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -42,7 +42,7 @@ type ProblemDetails struct {
 	// HTTPStatus is the HTTP status code the ProblemDetails should probably be sent
 	// as.
 	HTTPStatus int `json:"status,omitempty"`
-	// SubProblems are optional additional per-identifier problems See
+	// SubProblems are optional additional per-identifier problems. See
 	// RFC 8555 Section 6.7.1: https://tools.ietf.org/html/rfc8555#section-6.7.1
 	SubProblems []SubProblemDetails `json:"subproblems,omitempty"`
 }


### PR DESCRIPTION
Updates https://github.com/letsencrypt/boulder/issues/4193

Updating relevant Boulder locations to use `WithSubErrors` and `WithSubProblems` will be done in a separate follow-up PR.