### PR TITLE
Consistently used stdlib context package

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -1,6 +1,7 @@
 package bdns
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net"
@@ -12,7 +13,6 @@ import (
 	"github.com/jmhodges/clock"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/metrics"
 )

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -212,7 +212,8 @@ func serveLoopResolver(stopChan chan bool) {
 
 func pollServer() {
 	backoff := time.Duration(200 * time.Millisecond)
-	ctx, _ := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
+	defer cancel()
 	ticker := time.NewTicker(backoff)
 
 	for {
@@ -631,7 +632,8 @@ func TestRetry(t *testing.T) {
 	}
 
 	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
-	ctx, _ = context.WithTimeout(context.Background(), -10*time.Hour)
+	ctx, cancel = context.WithTimeout(context.Background(), -10*time.Hour)
+	defer cancel()
 	_, _, err = dr.LookupTXT(ctx, "example.com")
 	if err == nil ||
 		err.Error() != "DNS problem: query timed out looking up TXT for example.com" {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -1,6 +1,7 @@
 package bdns
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -10,8 +11,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/metrics"

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -1,13 +1,13 @@
 package bdns
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"os"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // MockDNSClient is a mock

--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -1,11 +1,11 @@
 package bdns
 
 import (
+	"context"
 	"fmt"
 	"net"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // DNSError wraps a DNS error with various relevant information

--- a/bdns/problem_test.go
+++ b/bdns/problem_test.go
@@ -1,12 +1,12 @@
 package bdns
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestDNSError(t *testing.T) {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -27,7 +28,6 @@ import (
 	cttls "github.com/google/certificate-transparency-go/tls"
 	"github.com/jmhodges/clock"
 	"github.com/miekg/pkcs11"
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/ca/config"
 	caPB "github.com/letsencrypt/boulder/ca/proto"

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -26,7 +27,6 @@ import (
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/ocsp"
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/ca/config"
 	caPB "github.com/letsencrypt/boulder/ca/proto"

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/x509"
 	"database/sql"
 	"flag"
@@ -10,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 
-	"golang.org/x/net/context"
 	"gopkg.in/go-gorp/gorp.v2"
 
 	"github.com/letsencrypt/boulder/cmd"

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -15,7 +16,6 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"errors"
 	"flag"
@@ -15,8 +16,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/jmhodges/clock"
 	"gopkg.in/go-gorp/gorp.v2"

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -15,14 +16,7 @@ import (
 	"text/template"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/jmhodges/clock"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_model/go"
-	"gopkg.in/go-gorp/gorp.v2"
-	"gopkg.in/square/go-jose.v2"
-
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	blog "github.com/letsencrypt/boulder/log"
@@ -32,6 +26,10 @@ import (
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_model/go"
+	"gopkg.in/go-gorp/gorp.v2"
+	"gopkg.in/square/go-jose.v2"
 )
 
 func bigIntFromB64(b64 string) *big.Int {

--- a/cmd/expired-authz-purger/main_test.go
+++ b/cmd/expired-authz-purger/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -15,7 +16,6 @@ import (
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
-	"golang.org/x/net/context"
 )
 
 func TestPurgeAuthzs(t *testing.T) {

--- a/cmd/id-exporter/main_test.go
+++ b/cmd/id-exporter/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -14,8 +15,6 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/core"

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
@@ -22,7 +23,6 @@ import (
 	"github.com/letsencrypt/boulder/sa"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"golang.org/x/crypto/ocsp"
-	"golang.org/x/net/context"
 )
 
 /*

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -18,7 +19,6 @@ import (
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
-	"golang.org/x/net/context"
 	"gopkg.in/go-gorp/gorp.v2"
 )
 

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -12,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"

--- a/cmd/orphan-finder/main_test.go
+++ b/cmd/orphan-finder/main_test.go
@@ -1,16 +1,14 @@
 package main
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/jmhodges/clock"
-
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	blog "github.com/letsencrypt/boulder/log"

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -1,12 +1,12 @@
 package core
 
 import (
+	"context"
 	"crypto/x509"
 	"net"
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
 	jose "gopkg.in/square/go-jose.v2"
 
 	caPB "github.com/letsencrypt/boulder/ca/proto"

--- a/core/va.go
+++ b/core/va.go
@@ -1,6 +1,6 @@
 package core
 
-import "golang.org/x/net/context"
+import "context"
 
 // ValidationAuthority defines the public interface for the Boulder VA
 type ValidationAuthority interface {

--- a/grpc/ca-wrappers.go
+++ b/grpc/ca-wrappers.go
@@ -7,10 +7,10 @@
 package grpc
 
 import (
+	"context"
 	"errors"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	caPB "github.com/letsencrypt/boulder/ca/proto"

--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -1,13 +1,13 @@
 package creds
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
 )
 

--- a/grpc/errors.go
+++ b/grpc/errors.go
@@ -1,10 +1,10 @@
 package grpc
 
 import (
+	"context"
 	"errors"
 	"strconv"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -1,12 +1,12 @@
 package grpc
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/jmhodges/clock"

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -1,13 +1,13 @@
 package grpc
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/grpc/publisher-wrappers.go
+++ b/grpc/publisher-wrappers.go
@@ -7,7 +7,7 @@
 package grpc
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/letsencrypt/boulder/publisher"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -7,9 +7,8 @@
 package grpc
 
 import (
+	"context"
 	"crypto/x509"
-
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -7,10 +7,10 @@
 package grpc
 
 import (
+	"context"
 	"net"
 	"time"
 
-	"golang.org/x/net/context"
 	"gopkg.in/square/go-jose.v2"
 
 	"github.com/letsencrypt/boulder/core"

--- a/grpc/va-wrappers.go
+++ b/grpc/va-wrappers.go
@@ -7,7 +7,8 @@
 package grpc
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	ggrpc "google.golang.org/grpc"
 
 	"github.com/letsencrypt/boulder/core"

--- a/mocks/ca.go
+++ b/mocks/ca.go
@@ -1,11 +1,10 @@
 package mocks
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	caPB "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	"golang.org/x/net/context"
 	"gopkg.in/square/go-jose.v2"
 
 	"github.com/letsencrypt/boulder/core"

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -1,6 +1,7 @@
 package publisher
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha256"
@@ -22,7 +23,6 @@ import (
 	"github.com/google/certificate-transparency-go/tls"
 	cttls "github.com/google/certificate-transparency-go/tls"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/canceled"
 	"github.com/letsencrypt/boulder/core"

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -1,6 +1,7 @@
 package publisher
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
-	"golang.org/x/net/context"
 
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1,6 +1,7 @@
 package ra
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -38,7 +39,6 @@ import (
 	"github.com/letsencrypt/boulder/web"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
-	"golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1,6 +1,7 @@
 package ra
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -55,7 +56,6 @@ import (
 	vaPB "github.com/letsencrypt/boulder/va/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	jose "gopkg.in/square/go-jose.v2"
 )

--- a/sa/rate_limits.go
+++ b/sa/rate_limits.go
@@ -1,12 +1,12 @@
 package sa
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 	"time"
 
 	"github.com/weppos/publicsuffix-go/publicsuffix"
-	"golang.org/x/net/context"
 )
 
 // baseDomain returns the eTLD+1 of a domain name for the purpose of rate

--- a/sa/rate_limits_test.go
+++ b/sa/rate_limits_test.go
@@ -1,11 +1,10 @@
 package sa
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestFasterRateLimit(t *testing.T) {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"context"
 
 	"github.com/jmhodges/clock"
-	"golang.org/x/net/context"
 	"gopkg.in/go-gorp/gorp.v2"
 	jose "gopkg.in/square/go-jose.v2"
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1,6 +1,7 @@
 package sa
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"database/sql"
@@ -11,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"context"
 
 	"github.com/jmhodges/clock"
 	"gopkg.in/go-gorp/gorp.v2"

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2,6 +2,7 @@ package sa
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -18,27 +19,23 @@ import (
 	"testing"
 	"time"
 
-	"github.com/letsencrypt/boulder/identifier"
-	"github.com/letsencrypt/boulder/probs"
-
-	"golang.org/x/net/context"
-
 	"github.com/jmhodges/clock"
-	gorp "gopkg.in/go-gorp/gorp.v2"
-	jose "gopkg.in/square/go-jose.v2"
-
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
+	gorp "gopkg.in/go-gorp/gorp.v2"
+	jose "gopkg.in/square/go-jose.v2"
 )
 
 var log = blog.UseMock()

--- a/sa/satest/satest.go
+++ b/sa/satest/satest.go
@@ -1,12 +1,11 @@
 package satest
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/core"
 	jose "gopkg.in/square/go-jose.v2"

--- a/va/caa.go
+++ b/va/caa.go
@@ -1,6 +1,7 @@
 package va
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/letsencrypt/boulder/probs"
 	vapb "github.com/letsencrypt/boulder/va/proto"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type caaParams struct {

--- a/va/va.go
+++ b/va/va.go
@@ -2,6 +2,7 @@ package va
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -28,7 +29,6 @@ import (
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -1,6 +1,7 @@
 package va
 
 import (
+	"context"
 	"crypto/rsa"
 	"encoding/base64"
 	"errors"
@@ -27,7 +28,6 @@ import (
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 	"gopkg.in/square/go-jose.v2"
 )
 

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -63,8 +63,12 @@ func dnsi(hostname string) identifier.ACMEIdentifier {
 
 var ctx context.Context
 
-func init() {
-	ctx, _ = context.WithTimeout(context.Background(), 10*time.Minute)
+func TestMain(m *testing.M) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Minute)
+	ret := m.Run()
+	cancel()
+	os.Exit(ret)
 }
 
 var accountURIPrefixes = []string{"http://boulder:4000/acme/reg/"}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,11 +108,11 @@ golang.org/x/crypto/cryptobyte
 golang.org/x/crypto/cryptobyte/asn1
 golang.org/x/crypto/pkcs12/internal/rc2
 # golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2
-golang.org/x/net/context
 golang.org/x/net/idna
 golang.org/x/net/trace
 golang.org/x/net/ipv4
 golang.org/x/net/ipv6
+golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/internal/timeseries
 golang.org/x/net/http2

--- a/web/context.go
+++ b/web/context.go
@@ -1,13 +1,12 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	blog "github.com/letsencrypt/boulder/log"
 )

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -2,6 +2,7 @@ package wfe
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -18,7 +19,6 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 	jose "gopkg.in/square/go-jose.v2"
 
 	"github.com/letsencrypt/boulder/core"

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2,6 +2,7 @@ package wfe
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
@@ -19,8 +20,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"gopkg.in/square/go-jose.v2"
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/core"
@@ -41,8 +40,8 @@ import (
 	"github.com/letsencrypt/boulder/test"
 	vaPB "github.com/letsencrypt/boulder/va/proto"
 	"github.com/letsencrypt/boulder/web"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"gopkg.in/square/go-jose.v2"
 )
 
 const (

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1,6 +1,7 @@
 package wfe2
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -8,8 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/mocks"

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2,6 +2,7 @@ package wfe2
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -33,7 +34,6 @@ import (
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/web"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 	jose "gopkg.in/square/go-jose.v2"
 )
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2,6 +2,7 @@ package wfe2
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	"golang.org/x/net/context"
 	"gopkg.in/square/go-jose.v2"
 
 	"github.com/letsencrypt/boulder/core"


### PR DESCRIPTION
No idea why this works now when @cpu's original attempt didn't, ¯\\\_(ツ)_/¯.

Fixes #2335.