### PR TITLE
Return specific error on duplicate key usage

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -513,6 +513,11 @@ func (ssa *SQLStorageAuthority) NewRegistration(ctx context.Context, reg core.Re
 	}
 	err = ssa.dbMap.WithContext(ctx).Insert(rm)
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "Error 1062: Duplicate entry") {
+			// duplicate entry error can only happen when jwk_sha256 collides, indicate
+			// to caller that the provided key is already in use
+			return reg, berrors.DuplicateError("key is already in use for a different account")
+		}
 		return reg, err
 	}
 	return modelToRegistration(rm)
@@ -574,8 +579,16 @@ func (ssa *SQLStorageAuthority) MarkCertificateRevoked(ctx context.Context, seri
 func (ssa *SQLStorageAuthority) UpdateRegistration(ctx context.Context, reg core.Registration) error {
 	const query = "WHERE id = ?"
 	model, err := selectRegistration(ssa.dbMap.WithContext(ctx), query, reg.ID)
-	if err == sql.ErrNoRows {
-		return berrors.NotFoundError("registration with ID '%d' not found", reg.ID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return berrors.NotFoundError("registration with ID '%d' not found", reg.ID)
+		}
+		if strings.HasPrefix(err.Error(), "Error 1062: Duplicate entry") {
+			// duplicate entry error can only happen when jwk_sha256 collides, indicate
+			// to caller that the provided key is already in use
+			return berrors.DuplicateError("key is already in use for a different account")
+		}
+		return err
 	}
 
 	updatedRegModel, err := registrationToModel(&reg)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -564,12 +564,11 @@ func (wfe *WebFrontEndImpl) NewAccount(
 			if err == nil {
 				returnExistingAcct(existingAcct)
 				return
-			} else {
-				// return error even if berrors.NotFound, as the duplicate key error we got from
-				// ra.NewRegistration indicates it _does_ already exist.
-				wfe.sendError(response, logEvent, probs.ServerInternal("failed check for existing account"), err)
-				return
 			}
+			// return error even if berrors.NotFound, as the duplicate key error we got from
+			// ra.NewRegistration indicates it _does_ already exist.
+			wfe.sendError(response, logEvent, probs.ServerInternal("failed check for existing account"), err)
+			return
 		}
 		wfe.sendError(response, logEvent,
 			web.ProblemDetailsForError(err, "Error creating new account"), err)


### PR DESCRIPTION
Also fixes a minor bug where `sa.UpdateRegistration` didn't properly check a returned error. If a `errors.Duplicate` type error is returned in either `KeyRollover`/`Newaccount` in wfe2 or `NewRegistration` in wfe during the update/insert step the account info/pointer will be returned instead of an internal server error.

Fixes #3000.