### PR TITLE
Implement suberrors for policy blocked names.

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -271,7 +271,7 @@ func (c *certChecker) checkCert(cert core.Certificate) (problems []string) {
 			id := identifier.ACMEIdentifier{Type: identifier.DNS, Value: name}
 			// TODO(https://github.com/letsencrypt/boulder/issues/3371): Distinguish
 			// between certificates issued by v1 and v2 API.
-			if err = c.pa.WillingToIssueWildcard(id); err != nil {
+			if err = c.pa.WillingToIssueWildcards([]identifier.ACMEIdentifier{id}); err != nil {
 				problems = append(problems, fmt.Sprintf("Policy Authority isn't willing to issue for '%s': %s", name, err))
 			} else {
 				// For defense-in-depth, even if the PA was willing to issue for a name

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -105,7 +105,7 @@ type CertificateAuthority interface {
 // PolicyAuthority defines the public interface for the Boulder PA
 type PolicyAuthority interface {
 	WillingToIssue(domain identifier.ACMEIdentifier) error
-	WillingToIssueWildcard(domain identifier.ACMEIdentifier) error
+	WillingToIssueWildcards(identifiers []identifier.ACMEIdentifier) error
 	ChallengesFor(domain identifier.ACMEIdentifier) ([]Challenge, error)
 	ChallengeTypeEnabled(t string) bool
 }

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -74,19 +74,12 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 	if len(csr.DNSNames) > maxNames {
 		return fmt.Errorf("CSR contains more than %d DNS names", maxNames)
 	}
-	badNames := []string{}
-	for _, name := range csr.DNSNames {
-		ident := identifier.ACMEIdentifier{
-			Type:  identifier.DNS,
-			Value: name,
-		}
-		var err error
-		if err = pa.WillingToIssueWildcard(ident); err != nil {
-			badNames = append(badNames, fmt.Sprintf("%q", name))
-		}
+	idents := make([]identifier.ACMEIdentifier, len(csr.DNSNames))
+	for i, dnsName := range csr.DNSNames {
+		idents[i] = identifier.DNSIdentifier(dnsName)
 	}
-	if len(badNames) > 0 {
-		return fmt.Errorf("policy forbids issuing for: %s", strings.Join(badNames, ", "))
+	if err := pa.WillingToIssueWildcards(idents); err != nil {
+		return err
 	}
 	return nil
 }

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -32,9 +32,11 @@ func (pa *mockPA) WillingToIssue(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
-func (pa *mockPA) WillingToIssueWildcard(id identifier.ACMEIdentifier) error {
-	if id.Value == "bad-name.com" || id.Value == "other-bad-name.com" {
-		return errors.New("")
+func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
+	for _, ident := range idents {
+		if ident.Value == "bad-name.com" || ident.Value == "other-bad-name.com" {
+			return errors.New("policy forbids issuing for identifier")
+		}
 	}
 	return nil
 }
@@ -131,7 +133,7 @@ func TestVerifyCSR(t *testing.T) {
 			testingPolicy,
 			&mockPA{},
 			0,
-			errors.New("policy forbids issuing for: \"bad-name.com\", \"other-bad-name.com\""),
+			errors.New("policy forbids issuing for identifier"),
 		},
 		{
 			signedReqWithEmailAddress,

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -304,8 +304,9 @@ func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
-// WillingToIssueWildcard is an extension of WillingToIssue that accepts DNS
-// identifiers for well formed wildcard domains. It enforces that:
+// WillingToIssueWildcards is an extension of WillingToIssue that accepts DNS
+// identifiers for well formed wildcard domains. For each provided identifier
+// WillingToIssueWildcards enforces that:
 // * The identifer is a DNS type identifier
 // * There is at most one `*` wildcard character
 // * That the wildcard character is the leftmost label
@@ -317,7 +318,51 @@ func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 //
 // If all of the above is true then the base domain (e.g. without the *.) is run
 // through WillingToIssue to catch other illegal things (blocked hosts, etc).
-func (pa *AuthorityImpl) WillingToIssueWildcard(ident identifier.ACMEIdentifier) error {
+//
+// If any of the identifiers are not valid then an error with suberrors specific
+// to the rejected identifiers will be returned.
+func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
+	var subErrors []berrors.SubBoulderError
+	var firstBadIdent *identifier.ACMEIdentifier
+	for _, ident := range idents {
+		if err := pa.willingToIssueWildcard(ident); err != nil {
+			if firstBadIdent == nil {
+				firstBadIdent = &ident
+			}
+			if bErr, ok := err.(*berrors.BoulderError); ok {
+				subErrors = append(subErrors, berrors.SubBoulderError{
+					Identifier:   ident,
+					BoulderError: bErr})
+			} else {
+				subErrors = append(subErrors, berrors.SubBoulderError{
+					Identifier: ident,
+					BoulderError: &berrors.BoulderError{
+						Type:   berrors.RejectedIdentifier,
+						Detail: err.Error(),
+					}})
+			}
+		}
+	}
+	if len(subErrors) > 0 {
+		var detail string
+		if len(subErrors) == 1 {
+			detail = subErrors[0].BoulderError.Detail
+		} else {
+			detail = fmt.Sprintf("Policy forbids issuing for %q and %d more identifiers. "+
+				"Refer to sub-problems for more information",
+				firstBadIdent.Value, len(subErrors)-1)
+		}
+		return (&berrors.BoulderError{
+			Type:   berrors.RejectedIdentifier,
+			Detail: detail,
+		}).WithSubErrors(subErrors)
+	}
+	return nil
+}
+
+// willingToIssueWildcard vets a single identifier. It is used by
+// the plural WillingToIssueWildcards when evaluating a list of identifiers.
+func (pa *AuthorityImpl) willingToIssueWildcard(ident identifier.ACMEIdentifier) error {
 	// We're only willing to process DNS identifiers
 	if ident.Type != identifier.DNS {
 		return errInvalidIdentifier

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -305,8 +305,13 @@ func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 }
 
 // WillingToIssueWildcards is an extension of WillingToIssue that accepts DNS
-// identifiers for well formed wildcard domains. For each provided identifier
-// WillingToIssueWildcards enforces that:
+// identifiers for well formed wildcard domains in addition to regular
+// identifiers.
+//
+// All provided identifiers are run through WillingToIssue and any errors are
+// returned. In addition to the regular WillingToIssue checks this function
+// also checks each wildcard identifier to enforce that:
+//
 // * The identifer is a DNS type identifier
 // * There is at most one `*` wildcard character
 // * That the wildcard character is the leftmost label
@@ -315,9 +320,6 @@ func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 // * That the wildcard wouldn't cover an exact blocklist entry (e.g. an exact
 //   blocklist entry for "foo.example.com" should prevent issuance for
 //   "*.example.com")
-//
-// If all of the above is true then the base domain (e.g. without the *.) is run
-// through WillingToIssue to catch other illegal things (blocked hosts, etc).
 //
 // If any of the identifiers are not valid then an error with suberrors specific
 // to the rejected identifiers will be returned.

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2158,7 +2158,7 @@ func TestNewOrder(t *testing.T) {
 
 	_, err = ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
 		RegistrationID: &id,
-		Names:          []string{"example.com", "a"},
+		Names:          []string{"a"},
 	})
 	test.AssertError(t, err, "NewOrder with invalid names did not error")
 	test.AssertEquals(t, err.Error(), "DNS name does not have enough labels")
@@ -3179,7 +3179,7 @@ func TestFinalizeOrder(t *testing.T) {
 				},
 				Csr: policyForbidCSR,
 			},
-			ExpectedErrMsg: "policy forbids issuing for: \"example.org\"",
+			ExpectedErrMsg: "Policy forbids issuing for name",
 		},
 		{
 			Name: "Order with missing registration",

--- a/web/probs.go
+++ b/web/probs.go
@@ -6,38 +6,50 @@ import (
 )
 
 func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs.ProblemDetails {
+	var outProb *probs.ProblemDetails
+
 	switch err.Type {
 	case berrors.Malformed:
-		return probs.Malformed("%s :: %s", msg, err)
+		outProb = probs.Malformed("%s :: %s", msg, err)
 	case berrors.Unauthorized:
-		return probs.Unauthorized("%s :: %s", msg, err)
+		outProb = probs.Unauthorized("%s :: %s", msg, err)
 	case berrors.NotFound:
-		return probs.NotFound("%s :: %s", msg, err)
+		outProb = probs.NotFound("%s :: %s", msg, err)
 	case berrors.RateLimit:
-		return probs.RateLimited("%s :: %s", msg, err)
+		outProb = probs.RateLimited("%s :: %s", msg, err)
 	case berrors.InternalServer:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.
-		return probs.ServerInternal(msg)
+		outProb = probs.ServerInternal(msg)
 	case berrors.RejectedIdentifier:
-		return probs.RejectedIdentifier("%s :: %s", msg, err)
+		outProb = probs.RejectedIdentifier("%s :: %s", msg, err)
 	case berrors.InvalidEmail:
-		return probs.InvalidEmail("%s :: %s", msg, err)
+		outProb = probs.InvalidEmail("%s :: %s", msg, err)
 	case berrors.WrongAuthorizationState:
-		return probs.Malformed("%s :: %s", msg, err)
+		outProb = probs.Malformed("%s :: %s", msg, err)
 	case berrors.CAA:
-		return probs.CAA("%s :: %s", msg, err)
+		outProb = probs.CAA("%s :: %s", msg, err)
 	case berrors.MissingSCTs:
 		// MissingSCTs are an internal server error, but with a specific error
 		// message related to the SCT problem
-		return probs.ServerInternal("%s :: %s", msg, "Unable to meet CA SCT embedding requirements")
+		outProb = probs.ServerInternal("%s :: %s", msg, "Unable to meet CA SCT embedding requirements")
 	case berrors.OrderNotReady:
-		return probs.OrderNotReady("%s :: %s", msg, err)
+		outProb = probs.OrderNotReady("%s :: %s", msg, err)
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.
-		return probs.ServerInternal(msg)
+		outProb = probs.ServerInternal(msg)
 	}
+
+	if len(err.SubErrors) > 0 {
+		var subProbs []probs.SubProblemDetails
+		for _, subErr := range err.SubErrors {
+			subProbs = append(subProbs, subProblemDetailsForSubError(subErr, msg))
+		}
+		return outProb.WithSubProblems(subProbs)
+	}
+
+	return outProb
 }
 
 // problemDetailsForError turns an error into a ProblemDetails with the special
@@ -54,5 +66,14 @@ func ProblemDetailsForError(err error, msg string) *probs.ProblemDetails {
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.
 		return probs.ServerInternal(msg)
+	}
+}
+
+// subProblemDetailsForSubError converts a SubBoulderError into
+// a SubProblemDetails using problemDetailsForBoulderError.
+func subProblemDetailsForSubError(subErr berrors.SubBoulderError, msg string) probs.SubProblemDetails {
+	return probs.SubProblemDetails{
+		Identifier:     subErr.Identifier,
+		ProblemDetails: *problemDetailsForBoulderError(subErr.BoulderError, msg),
 	}
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -278,7 +278,7 @@ func (pa *mockPA) WillingToIssue(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
-func (pa *mockPA) WillingToIssueWildcard(id identifier.ACMEIdentifier) error {
+func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
 	return nil
 }
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -289,7 +289,7 @@ func (pa *mockPA) WillingToIssue(id identifier.ACMEIdentifier) error {
 	return nil
 }
 
-func (pa *mockPA) WillingToIssueWildcard(id identifier.ACMEIdentifier) error {
+func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
 	return nil
 }
 


### PR DESCRIPTION
When validating a CSR's identifiers, or a new order's identifiers there may be more than one identifier that is blocked by policy. We should return an error that has suberrors identifying each bad identifier individually in this case.

Updates https://github.com/letsencrypt/boulder/issues/4193
Resolves https://github.com/letsencrypt/boulder/issues/3727