### PR TITLE
publisher: disable HTTP/2 support.

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/base64"
@@ -19,7 +20,6 @@ import (
 	"github.com/google/certificate-transparency-go"
 	ctClient "github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/jsonclient"
-	"github.com/google/certificate-transparency-go/tls"
 	cttls "github.com/google/certificate-transparency-go/tls"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
@@ -131,6 +131,18 @@ func NewLog(uri, b64PK string, logger blog.Logger) (*Log, error) {
 			MaxIdleConns:        http.DefaultTransport.(*http.Transport).MaxIdleConns,
 			IdleConnTimeout:     http.DefaultTransport.(*http.Transport).IdleConnTimeout,
 			TLSHandshakeTimeout: http.DefaultTransport.(*http.Transport).TLSHandshakeTimeout,
+			// In Boulder Issue 3821[0] we found that HTTP/2 support was causing hard
+			// to diagnose intermittent freezes in CT submission. Disabling HTTP/2 with
+			// an environment variable resolved the freezes but is not a stable fix.
+			//
+			// Per the Go `http` package docs we can make this change persistent by
+			// changing the `http.Transport` config:
+			//   "Programs that must disable HTTP/2 can do so by setting
+			//   Transport.TLSNextProto (for clients) or Server.TLSNextProto (for
+			//   servers) to a non-nil, empty map"
+			//
+			// [0]: https://github.com/letsencrypt/boulder/issues/3821
+			TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{},
 		},
 	}
 	client, err := ctClient.New(url.String(), httpClient, opts)
@@ -266,7 +278,7 @@ func (pub *Impl) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Requ
 		return nil, err
 	}
 
-	sctBytes, err := tls.Marshal(*sct)
+	sctBytes, err := cttls.Marshal(*sct)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/issues/3821 we found that HTTP/2 support was causing hard to diagnose intermittent freezes in CT submission. Disabling HTTP/2 with an environment variable resolved the freezes but is not a stable fix.

Per the Go `http` package docs we can make this change persistent by changing the `http.Transport` config:

> "Programs that must disable HTTP/2 can do so by setting Transport.TLSNextProto (for clients) or Server.TLSNextProto (for servers) to a non-nil, empty map"

Resolves https://github.com/letsencrypt/boulder/issues/4236