### PR TITLE
RA: Use suberrors when rechecking CAA.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -905,7 +905,7 @@ func (ra *RegistrationAuthorityImpl) recheckCAA(ctx context.Context, authzs []*c
 			if firstBadIdent == nil {
 				firstBadIdent = &authz.Identifier
 			}
-			if bErr, ok := err.(*berrors.BoulderError); ok && berrors.Is(bErr, berrors.CAA) {
+			if bErr, _ := err.(*berrors.BoulderError); berrors.Is(err, berrors.CAA) {
 				subErrors = append(subErrors, berrors.SubBoulderError{
 					Identifier:   authz.Identifier,
 					BoulderError: bErr})

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -897,16 +897,35 @@ func (ra *RegistrationAuthorityImpl) recheckCAA(ctx context.Context, authzs []*c
 			ch <- err
 		}(authz)
 	}
-	var caaFailures []string
-	for _ = range authzs {
-		if err := <-ch; berrors.Is(err, berrors.CAA) {
-			caaFailures = append(caaFailures, err.Error())
-		} else if err != nil {
-			return err
+	var subErrors []berrors.SubBoulderError
+	var firstBadIdent *identifier.ACMEIdentifier
+	for _, authz := range authzs {
+		err := <-ch
+		if err != nil {
+			if firstBadIdent == nil {
+				firstBadIdent = &authz.Identifier
+			}
+			if bErr, ok := err.(*berrors.BoulderError); ok && berrors.Is(bErr, berrors.CAA) {
+				subErrors = append(subErrors, berrors.SubBoulderError{
+					Identifier:   authz.Identifier,
+					BoulderError: bErr})
+			} else {
+				return err
+			}
 		}
 	}
-	if len(caaFailures) > 0 {
-		return berrors.CAAError("Rechecking CAA: %v", strings.Join(caaFailures, ", "))
+	if len(subErrors) > 0 {
+		var detail string
+		if len(subErrors) == 1 {
+			detail = fmt.Sprintf("Rechecking CAA for %q: %s", firstBadIdent.Value, subErrors[0].BoulderError.Detail)
+		} else {
+			detail = fmt.Sprintf("Rechecking CAA for %q and %d more identifiers failed. "+
+				"Refer to sub-problems for more information", firstBadIdent.Value, len(subErrors)-1)
+		}
+		return (&berrors.BoulderError{
+			Type:   berrors.CAA,
+			Detail: detail,
+		}).WithSubErrors(subErrors)
 	}
 	return nil
 }


### PR DESCRIPTION
When Boulder's RA rechecks CAA for a set of authorization identifiers it should use suberrors to make it easy to identify which of a possible 100 identifiers had a CAA issue at order finalization time.

Updates https://github.com/letsencrypt/boulder/issues/4193 
Resolves https://github.com/letsencrypt/boulder/issues/4235

