### PR TITLE
va: quote control & non-printable chars in payload

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -635,7 +635,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, ident ide
 
 	if payload != challenge.ProvidedKeyAuthorization {
 		problem := probs.Unauthorized("The key authorization file from the server did not match this challenge [%v] != [%v]",
-			challenge.ProvidedKeyAuthorization, payload)
+			challenge.ProvidedKeyAuthorization, strings.Trim(strconv.Quote(payload), `"`))
 		va.log.Infof("%s for %s", problem.Detail, ident)
 		return validationRecords, problem
 	}


### PR DESCRIPTION
Fixes e.g. invisible BOM marker leading to confusing unauthorized
error messages.

Aligns with the other site where the payload is printed with %q.

----

e.g. https://community.letsencrypt.org/t/key-authorization-file-error-even-though-the-match/94962
https://community.letsencrypt.org/t/issues-making-certificates/89330/23


Not very elegant but Go does not seem to publicly expose an easier way to do it in one pass. I felt it better than reimplementing only half of `strconv.Quote`.