### PR TITLE
WFE2: Add feature flag for Mandatory POST-As-GET.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -27,11 +27,12 @@ func _() {
 	_ = x[MultiVAFullResults-16]
 	_ = x[RemoveWFE2AccountID-17]
 	_ = x[CheckRenewalFirst-18]
+	_ = x[MandatoryPOSTAsGET-19]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsCAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaRevokeAtRAEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirst"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsCAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaRevokeAtRAEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGET"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 166, 179, 196, 218, 228, 247, 261, 279, 298, 315}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 166, 179, 196, 218, 228, 247, 261, 279, 298, 315, 333}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -49,6 +49,9 @@ const (
 	// CheckRenewalFirst will check whether an issuance is a renewal before
 	// checking the "certificates per name" rate limit.
 	CheckRenewalFirst
+	// MandatoryPOSTAsGET forbids legacy unauthenticated GET requests for ACME
+	// resources.
+	MandatoryPOSTAsGET
 )
 
 // List of features and their default value, protected by fMu
@@ -72,6 +75,7 @@ var features = map[FeatureFlag]bool{
 	RemoveWFE2AccountID:      false,
 	FasterRateLimit:          false,
 	CheckRenewalFirst:        false,
+	MandatoryPOSTAsGET:       false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -42,7 +42,8 @@
     "features": {
       "HeadNonceStatusOK": true,
       "NewAuthorizationSchema": true,
-      "RemoveWFE2AccountID": true
+      "RemoveWFE2AccountID": true,
+      "MandatoryPOSTAsGET": true
     }
   },
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -905,6 +905,11 @@ func (wfe *WebFrontEndImpl) Challenge(
 	response http.ResponseWriter,
 	request *http.Request) {
 
+	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost {
+		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
+		return
+	}
+
 	notFound := func() {
 		wfe.sendError(response, logEvent, probs.NotFound("No such challenge"), nil)
 	}
@@ -1342,6 +1347,11 @@ func (wfe *WebFrontEndImpl) deactivateAuthorization(
 // Authorization is used by clients to submit an update to one of their
 // authorizations.
 func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost {
+		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
+		return
+	}
+
 	var requestAccount *core.Registration
 	var requestBody []byte
 	// If the request is a POST it is either:
@@ -1440,6 +1450,11 @@ var allHex = regexp.MustCompile("^[0-9a-f]+$")
 // Certificate is used by clients to request a copy of their current certificate, or to
 // request a reissuance of the certificate.
 func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost {
+		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
+		return
+	}
+
 	var requesterAccount *core.Registration
 	// Any POSTs to the Certificate endpoint should be POST-as-GET requests. There are
 	// no POSTs with a body allowed for this endpoint.
@@ -1860,10 +1875,15 @@ func (wfe *WebFrontEndImpl) NewOrder(
 
 // GetOrder is used to retrieve a existing order object
 func (wfe *WebFrontEndImpl) GetOrder(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost {
+		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
+		return
+	}
+
 	var requesterAccount *core.Registration
 	// Any POSTs to the Order endpoint should be POST-as-GET requests. There are
 	// no POSTs with a body allowed for this endpoint.
-	if request.Method == "POST" {
+	if request.Method == http.MethodPost {
 		acct, prob := wfe.validPOSTAsGETForAccount(request, ctx, logEvent)
 		if prob != nil {
 			wfe.sendError(response, logEvent, prob, nil)

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3053,3 +3053,63 @@ func TestOrderToOrderJSONV2Authorizations(t *testing.T) {
 		"http://localhost/acme/authz/v2/2",
 	})
 }
+
+// TestMandatoryPOSTAsGET tests that the MandatoryPOSTAsGET feature flag
+// correctly causes unauthenticated GET requests to ACME resources to be
+// forbidden.
+func TestMandatoryPOSTAsGET(t *testing.T) {
+	wfe, _ := setupWFE(t)
+
+	features.Set(map[string]bool{"MandatoryPOSTAsGET": true})
+	defer features.Reset()
+
+	// CheckProblem matches a HTTP response body to a Method Not Allowed problem.
+	checkProblem := func(actual []byte) {
+		var prob probs.ProblemDetails
+		err := json.Unmarshal(actual, &prob)
+		test.AssertNotError(t, err, "error unmarshaling HTTP response body as problem")
+		test.AssertEquals(t, string(prob.Type), "urn:ietf:params:acme:error:malformed")
+		test.AssertEquals(t, prob.Detail, "Method not allowed")
+		test.AssertEquals(t, prob.HTTPStatus, http.StatusMethodNotAllowed)
+	}
+
+	testCases := []struct {
+		name    string
+		path    string
+		handler web.WFEHandlerFunc
+	}{
+		{
+			// GET requests to a mocked order path should return an error
+			name:    "GET Order",
+			path:    "1/1",
+			handler: wfe.GetOrder,
+		},
+		{
+			// GET requests to a mocked authorization path should return an error
+			name:    "GET Authz",
+			path:    "v2/1",
+			handler: wfe.Authorization,
+		},
+		{
+			// GET requests to a mocked challenge path should return an error
+			name:    "GET Chall",
+			path:    "valid/23",
+			handler: wfe.Challenge,
+		},
+		{
+			// GET requests to a mocked certificate serial path should return an error
+			name:    "GET Cert",
+			path:    "acme/cert/0000000000000000000000000000000000b2",
+			handler: wfe.Certificate,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			responseWriter := httptest.NewRecorder()
+			req := &http.Request{URL: &url.URL{Path: tc.path}, Method: "GET"}
+			tc.handler(ctx, newRequestEvent(), responseWriter, req)
+			checkProblem(responseWriter.Body.Bytes())
+		})
+	}
+}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3060,7 +3060,7 @@ func TestOrderToOrderJSONV2Authorizations(t *testing.T) {
 func TestMandatoryPOSTAsGET(t *testing.T) {
 	wfe, _ := setupWFE(t)
 
-	features.Set(map[string]bool{"MandatoryPOSTAsGET": true})
+	_ = features.Set(map[string]bool{"MandatoryPOSTAsGET": true})
 	defer features.Reset()
 
 	// CheckProblem matches a HTTP response body to a Method Not Allowed problem.


### PR DESCRIPTION
In [November 2019](https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380) we will be removing support for legacy pre RFC-8555 unauthenticated GET requests for accessing ACME resources. A new `MandatoryPOSTAsGET` feature flag is added to the WFE2 to allow
enforcing this change. Once this feature flag has been activated in Nov we can remove both it and the WFE2 code supporting GET requests.

Resolves https://github.com/letsencrypt/boulder/issues/4246