### PR TITLE
WFE2: Implement badRevocationReason problem type.

### DIFF
--- a/probs/probs.go
+++ b/probs/probs.go
@@ -26,6 +26,7 @@ const (
 	OrderNotReadyProblem         = ProblemType("orderNotReady")
 	BadSignatureAlgorithmProblem = ProblemType("badSignatureAlgorithm")
 	BadPublicKeyProblem          = ProblemType("badPublicKey")
+	BadRevocationReasonProblem   = ProblemType("badRevocationReason")
 
 	V1ErrorNS = "urn:acme:error:"
 	V2ErrorNS = "urn:ietf:params:acme:error:"
@@ -318,5 +319,15 @@ func OrderNotReady(detail string, a ...interface{}) *ProblemDetails {
 		Type:       OrderNotReadyProblem,
 		Detail:     fmt.Sprintf(detail, a...),
 		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+// BadRevocationReason returns a ProblemDetails representing
+// a BadRevocationReasonProblem
+func BadRevocationReason(detail string, a ...interface{}) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       BadRevocationReasonProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusBadRequest,
 	}
 }

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -93,7 +93,8 @@ func ProblemDetailsToStatusCode(prob *ProblemDetails) int {
 		BadNonceProblem,
 		InvalidEmailProblem,
 		RejectedIdentifierProblem,
-		AccountDoesNotExistProblem:
+		AccountDoesNotExistProblem,
+		BadRevocationReasonProblem:
 		return http.StatusBadRequest
 	case ServerInternalProblem:
 		return http.StatusInternalServerError

--- a/probs/probs_test.go
+++ b/probs/probs_test.go
@@ -36,6 +36,7 @@ func TestProblemDetailsToStatusCode(t *testing.T) {
 		{&ProblemDetails{Type: "foo", HTTPStatus: 200}, 200},
 		{&ProblemDetails{Type: ConnectionProblem, HTTPStatus: 200}, 200},
 		{&ProblemDetails{Type: AccountDoesNotExistProblem}, http.StatusBadRequest},
+		{&ProblemDetails{Type: BadRevocationReasonProblem}, http.StatusBadRequest},
 	}
 
 	for _, c := range testCases {
@@ -64,6 +65,7 @@ func TestProblemDetailsConvenience(t *testing.T) {
 		{TLSError("TLS error detail"), TLSProblem, http.StatusBadRequest, "TLS error detail"},
 		{RejectedIdentifier("rejected identifier detail"), RejectedIdentifierProblem, http.StatusBadRequest, "rejected identifier detail"},
 		{AccountDoesNotExist("no account detail"), AccountDoesNotExistProblem, http.StatusBadRequest, "no account detail"},
+		{BadRevocationReason("only reason xxx is supported"), BadRevocationReasonProblem, http.StatusBadRequest, "only reason xxx is supported"},
 	}
 
 	for _, c := range testCases {

--- a/revocation/reasons.go
+++ b/revocation/reasons.go
@@ -1,5 +1,10 @@
 package revocation
 
+import (
+	"sort"
+	"strings"
+)
+
 // Reason is used to specify a certificate revocation reason
 type Reason int
 
@@ -43,4 +48,32 @@ var UserAllowedReasons = map[Reason]struct{}{
 	AffiliationChanged:   {}, // affiliationChanged
 	Superseded:           {}, // superseded
 	CessationOfOperation: {}, // cessationOfOperation
+}
+
+// UserAllowedReasonsMessage creates a string describing a list of user allowed
+// revocation reasons. This is useful when a revocation is rejected because it
+// is not a valid user supplied reason and the allowed values must be
+// communicated.
+func UserAllowedReasonsMessage() string {
+	// Build a slice of ints from the allowed reason codes.
+	// We want a slice because iterating `UserAllowedReasons` will change order
+	// and make the message unpredictable and cumbersome for unit testing.
+	// We use []ints instead of []Reason to use `sort.Ints` without fuss.
+	var allowed []int
+	for reason, _ := range UserAllowedReasons {
+		allowed = append(allowed, int(reason))
+	}
+	sort.Ints(allowed)
+
+	// Find the string representation of each allowed reason code and build
+	// a message to return in `buf`.
+	var buf strings.Builder
+	for i, reason := range allowed {
+		buf.WriteString(ReasonToString[Reason(reason)])
+		if i != len(UserAllowedReasons)-1 {
+			buf.WriteString(", ")
+		}
+	}
+
+	return buf.String()
 }

--- a/revocation/reasons.go
+++ b/revocation/reasons.go
@@ -1,6 +1,7 @@
 package revocation
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -70,6 +71,7 @@ func UserAllowedReasonsMessage() string {
 	var buf strings.Builder
 	for i, reason := range allowed {
 		buf.WriteString(ReasonToString[Reason(reason)])
+		buf.WriteString(fmt.Sprintf(" (%d)", reason))
 		if i != len(UserAllowedReasons)-1 {
 			buf.WriteString(", ")
 		}

--- a/revocation/reasons.go
+++ b/revocation/reasons.go
@@ -66,16 +66,10 @@ func UserAllowedReasonsMessage() string {
 	}
 	sort.Ints(allowed)
 
-	// Find the string representation of each allowed reason code and build
-	// a message to return in `buf`.
-	var buf strings.Builder
-	for i, reason := range allowed {
-		buf.WriteString(ReasonToString[Reason(reason)])
-		buf.WriteString(fmt.Sprintf(" (%d)", reason))
-		if i != len(UserAllowedReasons)-1 {
-			buf.WriteString(", ")
-		}
+	var reasonStrings []string
+	for _, reason := range allowed {
+		reasonStrings = append(reasonStrings, fmt.Sprintf("%s (%d)",
+			ReasonToString[Reason(reason)], reason))
 	}
-
-	return buf.String()
+	return strings.Join(reasonStrings, ", ")
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -749,8 +749,14 @@ func (wfe *WebFrontEndImpl) processRevocation(
 	reason := revocation.Reason(0)
 	if revokeRequest.Reason != nil && wfe.AcceptRevocationReason {
 		if _, present := revocation.UserAllowedReasons[*revokeRequest.Reason]; !present {
+			reasonStr, ok := revocation.ReasonToString[revocation.Reason(*revokeRequest.Reason)]
+			if !ok {
+				reasonStr = "unknown"
+			}
 			return probs.BadRevocationReason(
-				"unsupported revocation reason code provided. Supported reasons: %s",
+				"unsupported revocation reason code provided: %s (%d). Supported reasons: %s",
+				reasonStr,
+				*revokeRequest.Reason,
 				revocation.UserAllowedReasonsMessage())
 		}
 		reason = *revokeRequest.Reason

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -749,7 +749,9 @@ func (wfe *WebFrontEndImpl) processRevocation(
 	reason := revocation.Reason(0)
 	if revokeRequest.Reason != nil && wfe.AcceptRevocationReason {
 		if _, present := revocation.UserAllowedReasons[*revokeRequest.Reason]; !present {
-			return probs.Malformed("unsupported revocation reason code provided")
+			return probs.BadRevocationReason(
+				"unsupported revocation reason code provided. Supported reasons: %s",
+				revocation.UserAllowedReasonsMessage())
 		}
 		reason = *revokeRequest.Reason
 	}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2631,13 +2631,13 @@ func TestRevokeCertificateReasons(t *testing.T) {
 			Name:             "Unsupported reason",
 			Reason:           &reason2,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided. Supported reasons: unspecified, keyCompromise, affiliationChanged, superseded, cessationOfOperation","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), affiliationChanged (3), superseded (4), cessationOfOperation (5)","status":400}`,
 		},
 		{
 			Name:             "Non-existent reason",
 			Reason:           &reason100,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided. Supported reasons: unspecified, keyCompromise, affiliationChanged, superseded, cessationOfOperation","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: unknown (100). Supported reasons: unspecified (0), keyCompromise (1), affiliationChanged (3), superseded (4), cessationOfOperation (5)","status":400}`,
 		},
 	}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2631,13 +2631,13 @@ func TestRevokeCertificateReasons(t *testing.T) {
 			Name:             "Unsupported reason",
 			Reason:           &reason2,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `malformed","detail":"unsupported revocation reason code provided","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided. Supported reasons: unspecified, keyCompromise, affiliationChanged, superseded, cessationOfOperation","status":400}`,
 		},
 		{
 			Name:             "Non-existent reason",
 			Reason:           &reason100,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `malformed","detail":"unsupported revocation reason code provided","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided. Supported reasons: unspecified, keyCompromise, affiliationChanged, superseded, cessationOfOperation","status":400}`,
 		},
 	}
 


### PR DESCRIPTION
Previously we were [returning a Malformed problem type](https://github.com/letsencrypt/boulder/blob/4ca01b5de3db5574e82683094a718961f53e7d67/wfe2/wfe.go#L751-L753) when rejecting a revocation request for containing an invalid revocation reason code.  [RFC 8555 Section 7.6 mandates the use of the `badRevocationReason` problem type for this](https://tools.ietf.org/html/rfc8555#section-7.6) and encourages including the allowed reasons in the problem detail:

> The server MAY disallow a subset of reasonCodes from being used by the user.  If a request contains a disallowed reasonCode, then the server MUST reject it with the error type "urn:ietf:params:acme:error:badRevocationReason".  The problem document detail SHOULD indicate which reasonCodes are allowed.

Prev response:
```
{
  "type": "urn:ietf:params:acme:error:malformed",
  "detail":  "unsupported revocation reason code provided",
  "status": 400
}
```

Updated response:
```
{
  "type": "urn:ietf:params:acme:error:badRevocationReason",
  "detail": "unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), affiliationChanged (3), superseded (4), cessationOfOperation (5)",
  "status": 400
}
```

Resolves https://github.com/letsencrypt/boulder/issues/4250