### PR TITLE
Remove integrated akamai purger from ocsp-updater

### DIFF
--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/akamai"
+	akamaiProto "github.com/letsencrypt/boulder/akamai/proto"
 	caPB "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
@@ -96,10 +96,10 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *gorp.DbMap, cloc
 func TestGenerateAndStoreOCSPResponse(t *testing.T) {
 	updater, sa, _, fc, cleanUp := setup(t)
 	defer cleanUp()
-	updater.ccu = &akamai.CachePurgeClient{}
 	issuer, err := core.LoadCert("../../test/test-ca2.pem")
 	test.AssertNotError(t, err, "Couldn't read test issuer certificate")
 	updater.issuer = issuer
+	updater.purgerService = akamaiProto.NewAkamaiPurgerClient(nil)
 
 	reg := satest.CreateWorkingRegistration(t, sa)
 	parsedCert, err := core.LoadCert("test-cert.pem")

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -15,11 +15,6 @@
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
     "debugAddr": ":8006",
-    "akamaiBaseURL": "http://localhost:6789",
-    "akamaiClientToken": "its-a-token",
-    "akamaiClientSecret": "its-a-secret",
-    "akamaiAccessToken": "idk-how-this-is-different-from-client-token-but-okay",
-    "akamaiV3Network": "staging",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
@@ -31,6 +26,10 @@
     },
     "ocspGeneratorService": {
       "serverAddress": "ca.boulder:9096",
+      "timeout": "15s"
+    },
+    "akamaiPurgerService": {
+      "serverAddress": "akamai-purger.boulder:9099",
       "timeout": "15s"
     },
     "features": {

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -129,7 +129,7 @@ def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges")
 
 def verify_akamai_purge():
-    deadline = time.time() + 5
+    deadline = time.time() + 10
     while True:
         time.sleep(0.25)
         if time.time() > deadline:


### PR DESCRIPTION
Also bumps up the deadline in the integration test helper which checks for purging because using the remote service from the ocsp-updater takes a little longer. Once we remove ocsp-updater revocation support that can probably be cranked back down to a more reasonable timeframe.

Fixes #4249.