### PR TITLE
Refactor test_caa and twenty-days-ago setup

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -11,6 +11,9 @@ import shutil
 import atexit
 import subprocess
 
+import challtestsrv
+
+challSrv = challtestsrv.ChallTestServer()
 tempdir = tempfile.mkdtemp()
 
 @atexit.register
@@ -161,3 +164,18 @@ def verify_revocation(cert_file, issuer_file, url):
     if not re.search(": revoked", verify_output):
         print verify_output
         raise Exception("OCSP response wasn't 'revoked'")
+
+twenty_days_ago_functions = [ ]
+
+def register_twenty_days_ago(f):
+    """Register a function to be run during "setup_twenty_days_ago." This allows
+       test cases to define their own custom setup.
+    """
+    twenty_days_ago_functions.append(f)
+
+def setup_twenty_days_ago():
+    """Do any setup that needs to happen 20 day in the past, for tests that
+       will run in the 'present'.
+    """
+    for f in twenty_days_ago_functions:
+        f()

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -32,13 +32,11 @@ def install(race_detection):
 
     return subprocess.call(cmd, shell=True) == 0
 
-def run(cmd, race_detection, fakeclock, account_uri):
+def run(cmd, race_detection, fakeclock):
     e = os.environ.copy()
     e.setdefault("GORACE", "halt_on_error=1")
     if fakeclock:
         e.setdefault("FAKECLOCK", fakeclock)
-    if account_uri:
-        e.setdefault("ACCOUNT_URI", account_uri)
     # Note: Must use exec here so that killing this process kills the command.
     cmd = """exec %s""" % cmd
     p = subprocess.Popen(cmd, shell=True, env=e)
@@ -64,7 +62,7 @@ def waitport(port, prog):
                 raise
     raise Exception("timed out waiting for debug port %d (%s)" % (port, prog))
 
-def start(race_detection, fakeclock=None, account_uri=None):
+def start(race_detection, fakeclock=None):
     """Return True if everything builds and starts.
 
     Give up and return False if anything fails to build, or dies at
@@ -114,7 +112,7 @@ def start(race_detection, fakeclock=None, account_uri=None):
     for (port, prog) in progs:
         try:
             global processes
-            processes.append(run(prog, race_detection, fakeclock, account_uri))
+            processes.append(run(prog, race_detection, fakeclock))
             if not waitport(port, prog):
                 return False
         except Exception as e:
@@ -160,13 +158,9 @@ def startChallSrv():
     # which is used is controlled by mock DNS data added by the relevant
     # integration tests.
     prog = 'pebble-challtestsrv --defaultIPv4 %s --defaultIPv6 "" --dns01 :8053,:8054 --management :8055 --http01 10.77.77.77:5002 -https01 10.77.77.77:5001 --tlsalpn01 10.88.88.88:5001' % os.environ.get("FAKE_DNS")
-    try:
-        challSrvProcess = run(prog, False, None, None)
-        # Wait for the pebble-challtestsrv management port.
-        if not waitport(8055, prog):
-            return False
-    except Exception as e:
-        print(e)
+    challSrvProcess = run(prog, False, None)
+    # Wait for the pebble-challtestsrv management port.
+    if not waitport(8055, prog):
         return False
 
 def stopChallSrv():

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -471,7 +471,7 @@ def test_caa():
     # now be denied due to CAA.
     chisel.expect_problem("urn:acme:error:caa", lambda: chisel.issue(caa_client, caa_authzs))
 
-    challSrv.add_caa_issue({"domain": "bad-caa-reserved.com", "value": badCAA})
+    challSrv.add_caa_issue("bad-caa-reserved.com", badCAA)
     chisel.expect_problem("urn:acme:error:caa",
         lambda: auth_and_issue(["bad-caa-reserved.com"]))
 


### PR DESCRIPTION
As part of #4241, I need to introduce some twenty-days-ago setup. So I refactored the
only current instance (`test_caa`) to use a style where setup functions can be registered right
next to the test cases they affect. The `@register_twenty_days_ago` is Python for
"call `register_twenty_days_ago` with the thing on the next line as an argument."

I also cleaned up a bunch of related stuff:
 - Removed the `ACCOUNT_URI` environment variable and associated function params.
   This was introduced in in #3736 to pass a URI to `challtestsrv` before we refactored for
   more dynamic updates. It's not used any more.
 - Removed a `try` / `except` from `startChallSrv` that needlessly hid errors.
 - Move setting of DNS fixtures for `caa_test` into the test case itself.