### PR TITLE
Wrap getAllOrderAuthorizationStatuses table selects in transaction

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1890,8 +1890,6 @@ func (ssa *SQLStorageAuthority) getAllOrderAuthorizationStatuses(
 		allAuthzValidity = append(allAuthzValidity, validityInfo...)
 	}
 	return allAuthzValidity, tx.Commit()
-
-	return allAuthzValidity, nil
 }
 
 // GetValidOrderAuthorizations is used to find the valid, unexpired authorizations

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1868,9 +1868,13 @@ func (ssa *SQLStorageAuthority) getAllOrderAuthorizationStatuses(
 		allAuthzValidity = append(allAuthzValidity, validityInfo...)
 	}
 
+	tx, err := ssa.dbMap.Begin()
+	if err != nil {
+		return nil, err
+	}
 	for _, table := range authorizationTables {
 		var validityInfo []authzValidity
-		_, err := ssa.dbMap.WithContext(ctx).Select(
+		_, err := tx.WithContext(ctx).Select(
 			&validityInfo,
 			fmt.Sprintf(`SELECT status, expires from %s AS authz
 		INNER JOIN orderToAuthz
@@ -1885,6 +1889,7 @@ func (ssa *SQLStorageAuthority) getAllOrderAuthorizationStatuses(
 		}
 		allAuthzValidity = append(allAuthzValidity, validityInfo...)
 	}
+	return allAuthzValidity, tx.Commit()
 
 	return allAuthzValidity, nil
 }

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -3445,26 +3445,3 @@ func TestGetValidAuthorizations2(t *testing.T) {
 	test.AssertEquals(t, *authzs.Authz[1].Domain, "bbb")
 	test.AssertEquals(t, *authzs.Authz[1].Authz.Id, oldPA.ID)
 }
-
-func TestBrokenStuff(t *testing.T) {
-	sa, fc, cleanUp := initSA(t)
-	defer cleanUp()
-
-	reg := satest.CreateWorkingRegistration(t, sa)
-	authz, err := sa.NewPendingAuthorization(context.Background(), core.Authorization{
-		RegistrationID: reg.ID,
-		Identifier:     identifier.DNSIdentifier("example.com"),
-		Expires:        fc.Now().Add(time.Hour * 10),
-	})
-	test.AssertNotError(t, err, "new pending fail")
-	expires := fc.Now().Add(time.Hour * 10).UnixNano()
-	_, err = sa.NewOrder(context.Background(), &corepb.Order{
-		RegistrationID: &reg.ID,
-		Expires:        &expires,
-		Authorizations: []string{
-			authz.ID,
-		},
-		Names: []string{"example.com"},
-	})
-	test.AssertNotError(t, err, "new order fail")
-}


### PR DESCRIPTION
Wrapping the two table queries in a single transaction causes blocking behavior that prevents the existing race. I thought about including the test case I used to verify this change but it was pretty hacky (and it only caught the race about 1/5 times).

Fixes #4265.