### PR TITLE
gRPC: allow nil ValidationRecords in FinalizeAuthz2

### DIFF
--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -1209,7 +1209,7 @@ func (sas StorageAuthorityServerWrapper) GetAuthorizations2(ctx context.Context,
 }
 
 func (sas StorageAuthorityServerWrapper) FinalizeAuthorization2(ctx context.Context, req *sapb.FinalizeAuthorizationRequest) (*corepb.Empty, error) {
-	if req == nil || req.ValidationRecords == nil || req.Status == nil || req.Attempted == nil || req.Expires == nil || req.Id == nil {
+	if req == nil || req.Status == nil || req.Attempted == nil || req.Expires == nil || req.Id == nil {
 		return nil, errIncompleteRequest
 	}
 


### PR DESCRIPTION
The SA `FinalizeAuthorization2` RPC is used with `FinalizeAuthorizationRequest` objects that may have a nil `ValidationRecords` field (notably for DNS-01 challenges that failed). The RPC wrapper should not reject such messages as incomplete.

We don't typically unit test gRPC wrappers, and adding an integration test for this will likely conflict with https://github.com/letsencrypt/boulder/issues/4241 so I tested this fix manually using Certbot and a local Boulder instance configured with the authz2 feature flag.

Before applying the fix, failing a DNS-01 challenge left the authorization stuck in pending state and Certbot would poll until it gave up. On the server-side a 500 error matching what we observed in staging is logged:
> boulder-ra [AUDIT] Could not record updated validation: err=[rpc error: code = Unknown desc = Incomplete gRPC request message] regID=[xxx] authzID=[xxxx]

After applying the fix failing a DNS-01 challenge caused the associated authorization to be marked invalid immediately. No 500 errors are logged.

Resolves https://github.com/letsencrypt/boulder/issues/4269