### PR TITLE
Reduce akamai purger interval in integration tests

### DIFF
--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -1,7 +1,7 @@
 {
     "akamaiPurger": {
         "debugAddr": ":9666",
-        "purgeInterval": "1s",
+        "purgeInterval": "1ms",
         "baseURL": "http://localhost:6789",
         "clientToken": "its-a-token",
         "clientSecret": "its-a-secret",

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -1,7 +1,7 @@
 {
     "akamaiPurger": {
         "debugAddr": ":9666",
-        "purgeInterval": "10s",
+        "purgeInterval": "1ms",
         "baseURL": "http://localhost:6789",
         "clientToken": "its-a-token",
         "clientSecret": "its-a-secret",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -129,9 +129,9 @@ def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges")
 
 def verify_akamai_purge():
-    deadline = time.time() + 10
+    deadline = time.time() + 0.25
     while True:
-        time.sleep(0.25)
+        time.sleep(0.05)
         if time.time() > deadline:
             raise Exception("Timed out waiting for Akamai purge")
         response = requests.get("http://localhost:6789/debug/get-purges")


### PR DESCRIPTION
and reduce the verify_akamai_purge deadline/sleep to match the much smaller interval. (also apparently the config interval was 10s instead of the expected 1s, which may have been causing the pain previously)