### PR TITLE
gRPC: support wrap/unwrap of berrors with suberrors.

### DIFF
--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmhodges/clock"
 	berrors "github.com/letsencrypt/boulder/errors"
 	testproto "github.com/letsencrypt/boulder/grpc/test_proto"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -51,4 +52,46 @@ func TestErrorWrapping(t *testing.T) {
 
 	test.AssertEquals(t, wrapError(nil, nil), nil)
 	test.AssertEquals(t, unwrapError(nil, nil), nil)
+}
+
+// TestSubErrorWrapping tests that a boulder error with suberrors can be
+// correctly wrapped and unwrapped across the RPC layer.
+func TestSubErrorWrapping(t *testing.T) {
+	serverMetrics := NewServerMetrics(metrics.NewNoopScope())
+	si := newServerInterceptor(serverMetrics, clock.NewFake())
+	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NewNoopScope()), clock.NewFake()}
+	srv := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
+	es := &errorServer{}
+	testproto.RegisterChillerServer(srv, es)
+	lis, err := net.Listen("tcp", "127.0.0.1:")
+	test.AssertNotError(t, err, "Failed to create listener")
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	conn, err := grpc.Dial(
+		lis.Addr().String(),
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(ci.intercept),
+	)
+	test.AssertNotError(t, err, "Failed to dial grpc test server")
+	client := testproto.NewChillerClient(conn)
+
+	subErrors := []berrors.SubBoulderError{
+		{
+			Identifier: identifier.DNSIdentifier("chillserver.com"),
+			BoulderError: &berrors.BoulderError{
+				Type:   berrors.RejectedIdentifier,
+				Detail: "2 ill 2 chill",
+			},
+		},
+	}
+
+	es.err = (&berrors.BoulderError{
+		Type:   berrors.Malformed,
+		Detail: "malformed chill req",
+	}).WithSubErrors(subErrors)
+
+	_, err = client.Chill(context.Background(), &testproto.Time{})
+	test.Assert(t, err != nil, fmt.Sprintf("nil error returned, expected: %s", err))
+	test.AssertDeepEquals(t, err, es.err)
 }


### PR DESCRIPTION
If a boulder error type with suberrors is being wrapped then we must marshal the suberrors as JSON and include this data in the RPC metadata trailer that also carries the berror type. When unwrapping metadata with JSON suberrors they should be unmarshalled into the returned berror's suberrors.

Resolves https://github.com/letsencrypt/boulder/issues/4276