### PR TITLE
Use RawURLEncoding for authz2 challenge IDs

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -328,7 +328,7 @@ func (ch Challenge) StringID() string {
 	h := fnv.New128a()
 	h.Write([]byte(ch.Token))
 	h.Write([]byte(ch.Type))
-	return base64.URLEncoding.EncodeToString(h.Sum(nil)[0:4])
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil)[0:4])
 }
 
 // Authorization represents the authorization of an account key holder

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -150,9 +150,9 @@ func TestChallengeStringID(t *testing.T) {
 		Token: "asd",
 		Type:  ChallengeTypeDNS01,
 	}
-	test.AssertEquals(t, ch.StringID(), "iFVMwA==")
+	test.AssertEquals(t, ch.StringID(), "iFVMwA")
 	ch.Type = ChallengeTypeHTTP01
-	test.AssertEquals(t, ch.StringID(), "0Gexug==")
+	test.AssertEquals(t, ch.StringID(), "0Gexug")
 }
 
 func TestFindChallengeByType(t *testing.T) {

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1118,11 +1118,11 @@ func TestGetChallengeV2UpRel(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	_ = features.Set(map[string]bool{"NewAuthorizationSchema": true})
 
-	challengeURL := "http://localhost/acme/challenge/v2/1/-ZfxEw=="
+	challengeURL := "http://localhost/acme/challenge/v2/1/-ZfxEw"
 	resp := httptest.NewRecorder()
 
 	req, err := http.NewRequest("GET", challengeURL, nil)
-	req.URL.Path = "v2/1/-ZfxEw=="
+	req.URL.Path = "v2/1/-ZfxEw"
 	test.AssertNotError(t, err, "Could not make NewRequest")
 
 	wfe.Challenge(ctx, newRequestEvent(), resp, req)
@@ -1886,7 +1886,7 @@ func TestAuthorization(t *testing.T) {
 			{
 				"type": "dns",
 				"token":"token",
-				"uri": "http://localhost/acme/challenge/v2/1/-ZfxEw=="
+				"uri": "http://localhost/acme/challenge/v2/1/-ZfxEw"
 			}
 		]
 	}`)
@@ -2588,7 +2588,7 @@ func TestPrepChallengeForDisplay(t *testing.T) {
 	_ = features.Set(map[string]bool{"NewAuthorizationSchema": true})
 	authz.V2 = true
 	wfe.prepChallengeForDisplay(req, authz, chall)
-	test.AssertEquals(t, chall.URI, "http://example.com/acme/challenge/v2/eyup/iFVMwA==")
+	test.AssertEquals(t, chall.URI, "http://example.com/acme/challenge/v2/eyup/iFVMwA")
 }
 
 // noSCTMockRA is a mock RA that always returns a `berrors.MissingSCTsError` from `NewCertificate`
@@ -2671,9 +2671,9 @@ func TestChallengeNewIDScheme(t *testing.T) {
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/valid/23"}`,
 		},
 		{
-			path:     "v2/1/-ZfxEw==",
-			location: "http://localhost/acme/challenge/v2/1/-ZfxEw==",
-			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/v2/1/-ZfxEw=="}`,
+			path:     "v2/1/-ZfxEw",
+			location: "http://localhost/acme/challenge/v2/1/-ZfxEw",
+			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/v2/1/-ZfxEw"}`,
 		},
 	} {
 		resp := httptest.NewRecorder()
@@ -2703,9 +2703,9 @@ func TestChallengeNewIDScheme(t *testing.T) {
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/valid/23"}`,
 		},
 		{
-			path:     "v2/1/-ZfxEw==",
-			location: "http://localhost/acme/challenge/v2/1/-ZfxEw==",
-			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/v2/1/-ZfxEw=="}`,
+			path:     "v2/1/-ZfxEw",
+			location: "http://localhost/acme/challenge/v2/1/-ZfxEw",
+			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/v2/1/-ZfxEw"}`,
 		},
 	} {
 		resp := httptest.NewRecorder()

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1557,7 +1557,7 @@ func TestGetAuthorization(t *testing.T) {
 			{
 				"type": "dns",
 				"token":"token",
-				"url": "http://localhost/acme/challenge/v2/1/-ZfxEw=="
+				"url": "http://localhost/acme/challenge/v2/1/-ZfxEw"
 			}
 		]
 	}`)
@@ -1580,7 +1580,7 @@ func TestGetAuthorization(t *testing.T) {
 			{
 				"type": "dns",
 				"token":"token",
-				"url": "http://localhost/acme/challenge/v2/1/-ZfxEw=="
+				"url": "http://localhost/acme/challenge/v2/1/-ZfxEw"
 			}
 		]
 	}`)
@@ -2920,7 +2920,7 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	authz.V2 = true
 	wfe.prepAuthorizationForDisplay(&http.Request{Host: "localhost"}, authz)
 	chal = authz.Challenges[0]
-	test.AssertEquals(t, chal.URL, "http://localhost/acme/challenge/v2/12345/po1V2w==")
+	test.AssertEquals(t, chal.URL, "http://localhost/acme/challenge/v2/12345/po1V2w")
 	test.AssertEquals(t, chal.URI, "")
 }
 
@@ -2978,9 +2978,9 @@ func TestChallengeNewIDScheme(t *testing.T) {
 			expected: `{"type":"dns","token":"token","url":"http://localhost/acme/challenge/valid/23"}`,
 		},
 		{
-			path:     "v2/1/-ZfxEw==",
-			location: "http://localhost/acme/challenge/v2/1/-ZfxEw==",
-			expected: `{"type":"dns","token":"token","url":"http://localhost/acme/challenge/v2/1/-ZfxEw=="}`,
+			path:     "v2/1/-ZfxEw",
+			location: "http://localhost/acme/challenge/v2/1/-ZfxEw",
+			expected: `{"type":"dns","token":"token","url":"http://localhost/acme/challenge/v2/1/-ZfxEw"}`,
 		},
 	} {
 		resp := httptest.NewRecorder()
@@ -3010,9 +3010,9 @@ func TestChallengeNewIDScheme(t *testing.T) {
 			expected: `{"type":"dns","token":"token","url":"http://localhost/acme/challenge/valid/23"}`,
 		},
 		{
-			path:     "v2/1/-ZfxEw==",
-			location: "http://localhost/acme/challenge/v2/1/-ZfxEw==",
-			expected: `{"type":"dns","token":"token","url":"http://localhost/acme/challenge/v2/1/-ZfxEw=="}`,
+			path:     "v2/1/-ZfxEw",
+			location: "http://localhost/acme/challenge/v2/1/-ZfxEw",
+			expected: `{"type":"dns","token":"token","url":"http://localhost/acme/challenge/v2/1/-ZfxEw"}`,
 		},
 	} {
 		resp := httptest.NewRecorder()
@@ -3123,11 +3123,11 @@ func TestGetChallengeV2UpRel(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	_ = features.Set(map[string]bool{"NewAuthorizationSchema": true})
 
-	challengeURL := "http://localhost/acme/challenge/v2/1/-ZfxEw=="
+	challengeURL := "http://localhost/acme/challenge/v2/1/-ZfxEw"
 	resp := httptest.NewRecorder()
 
 	req, err := http.NewRequest("GET", challengeURL, nil)
-	req.URL.Path = "v2/1/-ZfxEw=="
+	req.URL.Path = "v2/1/-ZfxEw"
 	test.AssertNotError(t, err, "Could not make NewRequest")
 
 	wfe.Challenge(ctx, newRequestEvent(), resp, req)


### PR DESCRIPTION
Safe to deploy without consideration for supporting the old style as the feature is currently disabled.

Fixes #4267.