### PR TITLE
Re-apply #4279 with requests fix

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -6,9 +6,11 @@ import time
 import re
 import random
 import requests
+import socket
 import tempfile
 import shutil
 import atexit
+import errno
 import subprocess
 
 import challtestsrv
@@ -126,3 +128,21 @@ def setup_twenty_days_ago():
     """
     for f in twenty_days_ago_functions:
         f()
+
+def waitport(port, prog, perTickCheck=None):
+    """Wait until a port on localhost is open."""
+    for _ in range(1000):
+        try:
+            time.sleep(0.1)
+            if perTickCheck is not None and not perTickCheck():
+                return false
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect(('localhost', port))
+            s.close()
+            return True
+        except socket.error as e:
+            if e.errno == errno.ECONNREFUSED:
+                print "Waiting for debug port %d (%s)" % (port, prog)
+            else:
+                raise
+    raise Exception("timed out waiting for debug port %d (%s)" % (port, prog))

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -5,7 +5,7 @@ import urllib2
 import time
 import re
 import random
-import requests
+import json
 import socket
 import tempfile
 import shutil
@@ -99,7 +99,7 @@ def verify_ocsp(cert_file, issuer_file, url, status):
         raise Exception("OCSP response wasn't '%s'" % status)
 
 def reset_akamai_purges():
-    requests.post("http://localhost:6789/debug/reset-purges")
+    urllib2.urlopen("http://localhost:6789/debug/reset-purges", "{}")
 
 def verify_akamai_purge():
     deadline = time.time() + 10
@@ -107,8 +107,8 @@ def verify_akamai_purge():
         time.sleep(0.25)
         if time.time() > deadline:
             raise Exception("Timed out waiting for Akamai purge")
-        response = requests.get("http://localhost:6789/debug/get-purges")
-        purgeData = response.json()
+        response = urllib2.urlopen("http://localhost:6789/debug/get-purges")
+        purgeData = json.load(response)
         if len(purgeData["V3"]) is not 1:
             continue
         break

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -63,50 +63,6 @@ def make_ocsp_req(cert_file, issuer_file):
         ocsp_req = f.read()
     return ocsp_req
 
-def fetch_until(cert_file, issuer_file, url, initial, final):
-    """Fetch OCSP for cert_file until OCSP status goes from initial to final.
-
-    Initial and final are treated as regular expressions. Any OCSP response
-    whose OpenSSL OCSP verify output doesn't match either initial or final is
-    a fatal error.
-
-    If OCSP responses by the three methods (POST, GET, URL-encoded GET) differ
-    from each other, that is a fatal error.
-
-    If we loop for more than five seconds, that is a fatal error.
-
-    Returns nothing on success.
-    """
-    ocsp_request = make_ocsp_req(cert_file, issuer_file)
-    timeout = time.time() + 5
-    while True:
-        time.sleep(0.25)
-        if time.time() > timeout:
-            raise Exception("Timed out waiting for OCSP to go from '%s' to '%s'" % (
-                initial, final))
-        responses = fetch_ocsp(ocsp_request, url)
-        # This variable will be true at the end of the loop if all the responses
-        # matched the final state.
-        all_final = True
-        for resp in responses:
-            verify_output = ocsp_verify(cert_file, issuer_file, resp)
-            if re.search(initial, verify_output):
-                all_final = False
-                break
-            elif re.search(final, verify_output):
-                continue
-            else:
-                print verify_output
-                raise Exception("OCSP response didn't match '%s' or '%s'" %(
-                    initial, final))
-        if all_final:
-            # Check that all responses were equal to each other.
-            for resp in responses:
-                if resp != responses[0]:
-                    raise Exception("OCSP responses differed: %s vs %s" %(
-                        base64.b64encode(responses[0]), base64.b64encode(resp)))
-            return
-
 def ocsp_verify(cert_file, issuer_file, ocsp_response):
     ocsp_resp_file = os.path.join(tempdir, "ocsp.resp")
     with open(ocsp_resp_file, "w") as f:
@@ -122,8 +78,23 @@ def ocsp_verify(cert_file, issuer_file, ocsp_response):
         raise Exception("OCSP verify failure")
     return output
 
-def wait_for_ocsp_good(cert_file, issuer_file, url):
-    fetch_until(cert_file, issuer_file, url, " unauthorized", ": good")
+def verify_ocsp(cert_file, issuer_file, url, status):
+    ocsp_request = make_ocsp_req(cert_file, issuer_file)
+    responses = fetch_ocsp(ocsp_request, url)
+
+    # Verify all responses are the same
+    for resp in responses:
+        if resp != responses[0]:
+            raise Exception("OCSP responses differed: %s vs %s" %(
+                base64.b64encode(responses[0]), base64.b64encode(resp)))
+
+    # Check response is for the correct certificate and is correct
+    # status
+    resp = responses[0]
+    verify_output = ocsp_verify(cert_file, issuer_file, resp)
+    if not re.search("%s: %s" % (cert_file, status), verify_output):
+        print verify_output
+        raise Exception("OCSP response wasn't '%s'" % status)
 
 def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges")
@@ -140,23 +111,6 @@ def verify_akamai_purge():
             continue
         break
     reset_akamai_purges()
-
-def verify_revocation(cert_file, issuer_file, url):
-    ocsp_request = make_ocsp_req(cert_file, issuer_file)
-    responses = fetch_ocsp(ocsp_request, url)
-
-    # Verify all responses are the same
-    for resp in responses:
-        if resp != responses[0]:
-            raise Exception("OCSP responses differed: %s vs %s" %(
-                base64.b64encode(responses[0]), base64.b64encode(resp)))
-
-    # Check response is for the correct certificate and is revoked
-    resp = responses[0]
-    verify_output = ocsp_verify(cert_file, issuer_file, resp)
-    if not re.search(": revoked", verify_output):
-        print verify_output
-        raise Exception("OCSP response wasn't 'revoked'")
 
 twenty_days_ago_functions = [ ]
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -18,6 +18,7 @@ import re
 import requests
 import subprocess
 import signal
+import time
 
 import startservers
 
@@ -116,6 +117,7 @@ def test_single_ocsp():
 
     p = subprocess.Popen(
         './bin/ocsp-responder --config test/issuer-ocsp-responder.json', shell=True)
+    waitport(4003, './bin/ocsp-responder --config test/issuer-ocsp-responder.json')
 
     # Verify that the static OCSP responder, which answers with a
     # pre-signed, long-lived response for the CA cert, works.

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -119,7 +119,7 @@ def test_single_ocsp():
 
     # Verify that the static OCSP responder, which answers with a
     # pre-signed, long-lived response for the CA cert, works.
-    wait_for_ocsp_good("test/test-ca2.pem", "test/test-root.pem", "http://localhost:4003")
+    verify_ocsp("test/test-ca2.pem", "test/test-root.pem", "http://localhost:4003", "good")
 
     p.send_signal(signal.SIGTERM)
     p.wait()

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -363,7 +363,7 @@ def test_ocsp():
 
     # As OCSP-Updater is generating responses independently of the CA we sit in a loop
     # checking OCSP until we either see a good response or we timeout (5s).
-    wait_for_ocsp_good(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url)
+    verify_ocsp(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url, "good")
 
 def test_ct_submission():
     hostname = random_domain()
@@ -421,7 +421,7 @@ def test_revoke_by_account():
         f.write(OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, cert.body.wrapped).decode())
     ee_ocsp_url = "http://localhost:4002"
-    verify_revocation(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url)
+    verify_ocsp(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url, "revoked")
     verify_akamai_purge()
     return 0
 
@@ -582,7 +582,7 @@ def test_admin_revoker_cert():
         default_config_dir, serial, 1))
     # Wait for OCSP response to indicate revocation took place
     ee_ocsp_url = "http://localhost:4002"
-    verify_revocation(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url)
+    verify_ocsp(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url, "revoked")
     verify_akamai_purge()
 
 def test_admin_revoker_authz():

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -524,7 +524,7 @@ def test_revoke_by_issuer():
         f.write(OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, cert).decode())
     ee_ocsp_url = "http://localhost:4002"
-    verify_revocation(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url)
+    verify_ocsp(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url, "revoked")
     verify_akamai_purge()
 
 def test_revoke_by_authz():
@@ -544,7 +544,7 @@ def test_revoke_by_authz():
         f.write(OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, cert).decode())
     ee_ocsp_url = "http://localhost:4002"
-    verify_revocation(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url)
+    verify_ocsp(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url, "revoked")
     verify_akamai_purge()
 
 def test_revoke_by_privkey():
@@ -577,7 +577,7 @@ def test_revoke_by_privkey():
         f.write(OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, cert).decode())
     ee_ocsp_url = "http://localhost:4002"
-    verify_revocation(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url)
+    verify_ocsp(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url, "revoked")
     verify_akamai_purge()
 
 def test_sct_embedding():


### PR DESCRIPTION
Move from using `requests` to `urllib2` in `helpers.py`. Verified this works with `docker-compose up`. In the future we really should be installing our own python dependencies in the boulder-tools image rather than relying on getting them by using the certbot virtualenv.