### PR TITLE
Explicitly disable authz2 orders

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -22,17 +22,18 @@ func _() {
 	_ = x[CAAAccountURI-11]
 	_ = x[HeadNonceStatusOK-12]
 	_ = x[NewAuthorizationSchema-13]
-	_ = x[EarlyOrderRateLimit-14]
-	_ = x[EnforceMultiVA-15]
-	_ = x[MultiVAFullResults-16]
-	_ = x[RemoveWFE2AccountID-17]
-	_ = x[CheckRenewalFirst-18]
-	_ = x[MandatoryPOSTAsGET-19]
+	_ = x[DisableAuthz2Orders-14]
+	_ = x[EarlyOrderRateLimit-15]
+	_ = x[EnforceMultiVA-16]
+	_ = x[MultiVAFullResults-17]
+	_ = x[RemoveWFE2AccountID-18]
+	_ = x[CheckRenewalFirst-19]
+	_ = x[MandatoryPOSTAsGET-20]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGET"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGET"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 261, 279, 298, 315, 333}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 266, 280, 298, 317, 334, 352}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -33,6 +33,11 @@ const (
 	// NewAuthorizationSchema enables usage of the new authorization storage schema
 	// and associated RPCs.
 	NewAuthorizationSchema
+	// DisableAuthz2Orders prevents returning orders containing authz2 authorizations
+	// from the SA. If a order containing authz2 authorizations is queried a NotFound
+	// error will be returned. DisableAuthz2Orders should only be enabled if the authz2
+	// schema is in place.
+	DisableAuthz2Orders
 	// EarlyOrderRateLimit enables the RA applying certificate per name/per FQDN
 	// set rate limits in NewOrder in addition to FinalizeOrder.
 	EarlyOrderRateLimit
@@ -75,6 +80,7 @@ var features = map[FeatureFlag]bool{
 	FasterRateLimit:          false,
 	CheckRenewalFirst:        false,
 	MandatoryPOSTAsGET:       false,
+	DisableAuthz2Orders:      false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/features/features.go
+++ b/features/features.go
@@ -36,7 +36,8 @@ const (
 	// DisableAuthz2Orders prevents returning orders containing authz2 authorizations
 	// from the SA. If a order containing authz2 authorizations is queried a NotFound
 	// error will be returned. DisableAuthz2Orders should only be enabled if the authz2
-	// schema is in place.
+	// schema is in place. DisableAuthz2Orders should not be enabled if NewAuthorizationSchema
+	// is enabled as all new orders containing v2 authorizations will be hidden.
 	DisableAuthz2Orders
 	// EarlyOrderRateLimit enables the RA applying certificate per name/per FQDN
 	// set rate limits in NewOrder in addition to FinalizeOrder.

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1602,9 +1602,13 @@ func (ssa *SQLStorageAuthority) GetOrder(ctx context.Context, req *sapb.OrderReq
 	if req.UseV2Authorizations != nil {
 		useV2Authzs = *req.UseV2Authorizations
 	}
+	useV2Authzs = useV2Authzs || features.Enabled(features.DisableAuthz2Orders)
 	v1AuthzIDs, v2AuthzIDs, err := ssa.authzForOrder(ctx, *order.Id, useV2Authzs)
 	if err != nil {
 		return nil, err
+	}
+	if features.Enabled(features.DisableAuthz2Orders) && len(order.V2Authorizations) {
+		return nil, berrors.NotFoundError("no order found for ID %d", *req.Id)
 	}
 	order.Authorizations, order.V2Authorizations = v1AuthzIDs, v2AuthzIDs
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1603,6 +1603,10 @@ func (ssa *SQLStorageAuthority) GetOrder(ctx context.Context, req *sapb.OrderReq
 	if req.UseV2Authorizations != nil {
 		useV2Authzs = *req.UseV2Authorizations
 	}
+	// we set useV2Authzs if DisableAuthz2Orders is enabled as actually looking for v2
+	// authorizations is the only way to tell if an order contains them, otherwise
+	// we will fail due to the number of authorizations not matching the number of names
+	// in the order.
 	useV2Authzs = useV2Authzs || features.Enabled(features.DisableAuthz2Orders)
 	v1AuthzIDs, v2AuthzIDs, err := ssa.authzForOrder(ctx, *order.Id, useV2Authzs)
 	if err != nil {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -20,6 +20,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
@@ -1607,7 +1608,7 @@ func (ssa *SQLStorageAuthority) GetOrder(ctx context.Context, req *sapb.OrderReq
 	if err != nil {
 		return nil, err
 	}
-	if features.Enabled(features.DisableAuthz2Orders) && len(order.V2Authorizations) {
+	if features.Enabled(features.DisableAuthz2Orders) && len(v2AuthzIDs) > 0 {
 		return nil, berrors.NotFoundError("no order found for ID %d", *req.Id)
 	}
 	order.Authorizations, order.V2Authorizations = v1AuthzIDs, v2AuthzIDs

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -3459,7 +3459,7 @@ func TestDisableAuthz2Orders(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "GetOrder failed")
 
-	features.Set(map[string]bool{"DisableAuthz2Orders": true})
+	_ = features.Set(map[string]bool{"DisableAuthz2Orders": true})
 	useV2Authz = false
 	_, err = sa.GetOrder(context.Background(), &sapb.OrderRequest{
 		Id:                  order.Id,


### PR DESCRIPTION
Add flag to explicitly disable orders containing authz2 authorizations. After looking at a handful of much more complex solutions this feels like the best option. With `NewAuthorizationSchema` disabled and `DisableAuthz2Orders` enabled any requests for orders that include authz2 authorizations will return a 404 (where previously they would return a 500).

Fixes #4263.