### PR TITLE
Remove seventy- and zero-day ago integration setup

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -32,20 +32,6 @@ from acme import challenges
 
 import requests
 
-def setup_seventy_days_ago():
-    """Do any setup that needs to happen 70 days in the past, for tests that
-       will run in the 'present'.
-    """
-    # Issue a certificate with the clock set back, and save the authzs to check
-    # later that they are expired (404).
-    _, v1_integration.old_authzs = auth_and_issue([random_domain()])
-
-def setup_zero_days_ago():
-    """Do any setup that needs to happen at the start of a test run."""
-    # Issue a certificate and save the authzs to check that they still exist
-    # at a later point.
-    _, v1_integration.new_authzs = auth_and_issue([random_domain()])
-
 def run_client_tests():
     root = os.environ.get("CERTBOT_PATH")
     assert root is not None, (
@@ -175,25 +161,15 @@ def main():
     caa_client = None
     if not args.skip_setup:
         now = datetime.datetime.utcnow()
-        seventy_days_ago = now+datetime.timedelta(days=-70)
-        if not startservers.start(race_detection=True, fakeclock=fakeclock(seventy_days_ago)):
-            raise Exception("startservers failed (mocking seventy days ago)")
-        setup_seventy_days_ago()
-        v1_integration.caa_client = caa_client = chisel.make_client()
-        startservers.stop()
-
-        now = datetime.datetime.utcnow()
         twenty_days_ago = now+datetime.timedelta(days=-20)
         if not startservers.start(race_detection=True, fakeclock=fakeclock(twenty_days_ago)):
             raise Exception("startservers failed (mocking twenty days ago)")
+        v1_integration.caa_client = caa_client = chisel.make_client()
         setup_twenty_days_ago()
         startservers.stop()
 
     if not startservers.start(race_detection=True):
         raise Exception("startservers failed")
-
-    if not args.skip_setup:
-        setup_zero_days_ago()
 
     if args.run_all or args.run_chisel:
         run_chisel(args.test_case_filter)

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -542,25 +542,6 @@ def test_certificates_per_name():
     chisel.expect_problem("urn:acme:error:rateLimited",
         lambda: auth_and_issue([random_domain() + ".lim.it"]))
 
-def test_expired_authzs_404():
-    # TODO(@4a6f656c): This test is rather broken, since it cannot distinguish
-    # between a 404 due to an expired authz and a 404 due to a non-existant authz.
-    # Further verification is necessary in order to ensure that the 404 is actually
-    # due to an expiration. For now, the new authzs at least provide a form of
-    # canary to detect authz purges.
-    if len(old_authzs) == 0 or len(new_authzs) == 0:
-        raise Exception("Old authzs not prepared for test_expired_authzs_404")
-    for a in new_authzs:
-        response = requests.get(a.uri)
-        if response.status_code != 200:
-            raise Exception("Unexpected response for valid authz: ",
-                response.status_code)
-    for a in old_authzs:
-        response = requests.get(a.uri)
-        if response.status_code != 404:
-            raise Exception("Unexpected response for expired authz: ",
-                response.status_code)
-
 def test_oversized_csr():
     # Number of names is chosen to be one greater than the configured RA/CA maxNames
     numNames = 101


### PR DESCRIPTION
These two setup phases were only used by `test_expired_authz_404`,
which is adequately covered by unittests. Since each setup and teardown
is rather time consuming, this speeds up and simplifies integration
tests.

Before: 5m10
After: 4m46