### PR TITLE
Remove unnecessary CONVERT in JOIN

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -2203,7 +2203,7 @@ func (ssa *SQLStorageAuthority) GetAuthorizations2(ctx context.Context, req *sap
 	query := fmt.Sprintf(
 		`SELECT %s FROM authz2
 		JOIN orderToAuthz2
-		ON CONVERT(id, CHAR) = authzID
+		ON id = authzID
 		WHERE registrationID = ? AND
 		expires > ? AND
 		status IN (?,?) AND

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -2203,7 +2203,7 @@ func (ssa *SQLStorageAuthority) GetAuthorizations2(ctx context.Context, req *sap
 	query := fmt.Sprintf(
 		`SELECT %s FROM authz2
 		JOIN orderToAuthz2
-		ON id = CONVERT(authzID, INTEGER)
+		ON CONVERT(id, CHAR) = authzID
 		WHERE registrationID = ? AND
 		expires > ? AND
 		status IN (?,?) AND


### PR DESCRIPTION
Converting the int ID to a string seems to convince the optimizer to use the proper index as shown below:

```
# BEFORE
mysql> EXPLAIN SELECT id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, token, validationError, validationRecord FROM authz2 JOIN orderToAuthz2 ON id = CONVERT(authzID, INTEGER) WHERE registrationID = 2 AND expires > '2019-06-26 18:18:38.60921' AND status IN (1,0) AND identifierValue IN ('5f4cf51338f0-11141.foo.tld','c21e15ddae90-11141.foo.tld')\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: orderToAuthz2
         type: index
possible_keys: NULL
          key: PRIMARY
      key_len: 16
          ref: NULL
         rows: 1
        Extra: Using index
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: authz2
         type: eq_ref
possible_keys: PRIMARY,regID_expires_idx,regID_identifier_status_expires_idx,expires_idx
          key: PRIMARY
      key_len: 8
          ref: func
         rows: 1
        Extra: Using where
2 rows in set (0.00 sec)

# AFTER
mysql> EXPLAIN SELECT id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, token, validationError, validationRecord FROM authz2 JOIN orderToAuthz2 ON CONVERT(id, CHAR) = authzID WHERE registrationID = 2 AND expires > '2019-06-26 18:18:38.60921' AND status IN (1,0) AND identifierValue IN ('5f4cf51338f0-11141.foo.tld','c21e15ddae90-11141.foo.tld')\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: authz2
         type: ref
possible_keys: regID_expires_idx,regID_identifier_status_expires_idx,expires_idx
          key: regID_identifier_status_expires_idx
      key_len: 8
          ref: const
         rows: 1
        Extra: Using index condition
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: orderToAuthz2
         type: ref
possible_keys: authzID
          key: authzID
      key_len: 8
          ref: func
         rows: 1
        Extra: Using where; Using index
2 rows in set (0.00 sec)
```

Fixes (probably) #4282.