### PR TITLE
Fix SAN to CN promotion

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -33,12 +33,13 @@ var goodSignatureAlgorithms = map[x509.SignatureAlgorithm]bool{
 }
 
 var (
-	invalidPubKey       = errors.New("invalid public key in CSR")
-	unsupportedSigAlg   = errors.New("signature algorithm not supported")
-	invalidSig          = errors.New("invalid signature on CSR")
-	invalidEmailPresent = errors.New("CSR contains one or more email address fields")
-	invalidIPPresent    = errors.New("CSR contains one or more IP address fields")
-	invalidNoDNS        = errors.New("at least one DNS name is required")
+	invalidPubKey        = errors.New("invalid public key in CSR")
+	unsupportedSigAlg    = errors.New("signature algorithm not supported")
+	invalidSig           = errors.New("invalid signature on CSR")
+	invalidEmailPresent  = errors.New("CSR contains one or more email address fields")
+	invalidIPPresent     = errors.New("CSR contains one or more IP address fields")
+	invalidNoDNS         = errors.New("at least one DNS name is required")
+	invalidAllSANTooLong = errors.New("CSR doesn't contain a SAN short enough to fit in CN")
 )
 
 // VerifyCSR checks the validity of a x509.CertificateRequest. Before doing checks it normalizes
@@ -67,6 +68,9 @@ func VerifyCSR(csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.Ke
 	}
 	if len(csr.DNSNames) == 0 && csr.Subject.CommonName == "" {
 		return invalidNoDNS
+	}
+	if forceCNFromSAN && csr.Subject.CommonName == "" {
+		return invalidAllSANTooLong
 	}
 	if len(csr.Subject.CommonName) > maxCNLength {
 		return fmt.Errorf("CN was longer than %d bytes", maxCNLength)

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -70,6 +70,9 @@ func TestVerifyCSR(t *testing.T) {
 	signedReqWithIPAddress := new(x509.CertificateRequest)
 	*signedReqWithIPAddress = *signedReq
 	signedReqWithIPAddress.IPAddresses = []net.IP{net.IPv4(1, 2, 3, 4)}
+	signedReqWithAllLongSANs := new(x509.CertificateRequest)
+	*signedReqWithAllLongSANs = *signedReq
+	signedReqWithAllLongSANs.DNSNames = []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com"}
 
 	cases := []struct {
 		csr           *x509.CertificateRequest
@@ -151,10 +154,18 @@ func TestVerifyCSR(t *testing.T) {
 			0,
 			invalidIPPresent,
 		},
+		{
+			signedReqWithAllLongSANs,
+			100,
+			testingPolicy,
+			&mockPA{},
+			0,
+			invalidAllSANTooLong,
+		},
 	}
 
 	for _, c := range cases {
-		err := VerifyCSR(c.csr, c.maxNames, c.keyPolicy, c.pa, false, c.regID)
+		err := VerifyCSR(c.csr, c.maxNames, c.keyPolicy, c.pa, true, c.regID)
 		test.AssertDeepEquals(t, c.expectedError, err)
 	}
 }


### PR DESCRIPTION
Before #4275 if a CSR only contained SANs longer than the max CN limit it would set the CN to one anyway and would cause the 'CN too long' check to get triggered. After #4275 if all of the SANs were too long the CN wouldn't get set and we didn't have a check for `forceCNFromSAN && cn == ""` which would allow empty CNs despite `forceCNFromSAN` being set. This adds that check and a test for the corner case.