### PR TITLE
Handle unprintable characters in HTTP responses.

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -634,7 +634,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, ident ide
 	payload := strings.TrimRight(string(body), whitespaceCutset)
 
 	if payload != challenge.ProvidedKeyAuthorization {
-		problem := probs.Unauthorized("The key authorization file from the server did not match this challenge [%v] != [%v]",
+		problem := probs.Unauthorized("The key authorization file from the server did not match this challenge %q != %q",
 			challenge.ProvidedKeyAuthorization, payload)
 		va.log.Infof("%s for %s", problem.Detail, ident)
 		return validationRecords, problem

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -325,7 +325,7 @@ func TestMultiVA(t *testing.T) {
 	}
 
 	unauthorized := probs.Unauthorized(
-		"The key authorization file from the server did not match this challenge [%s] != [???]",
+		`The key authorization file from the server did not match this challenge %q != "???"`,
 		expectedKeyAuthorization)
 
 	internalErr := probs.ServerInternal("Remote PerformValidation RPC failed")


### PR DESCRIPTION
Fixes #4244. Thanks to @alexzorin for spotting the issue and suggesting a fix!