### PR TITLE
cert-checker: treat info/warning lint results as errs.

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -220,16 +220,14 @@ func (c *certChecker) checkCert(cert core.Certificate, ignoredLints map[string]b
 		// Run zlint checks
 		results := zlint.LintCertificate(parsedCert)
 		for name, res := range results.Results {
-			if ignoredLints[name] {
+			if ignoredLints[name] || res.Status <= lints.Pass {
 				continue
 			}
-			if res.Status >= lints.Error {
-				prob := fmt.Sprintf("zlint %s: %s", res.Status, name)
-				if res.Details != "" {
-					prob = fmt.Sprintf("%s %s", prob, res.Details)
-				}
-				problems = append(problems, prob)
+			prob := fmt.Sprintf("zlint %s: %s", res.Status, name)
+			if res.Details != "" {
+				prob = fmt.Sprintf("%s %s", prob, res.Details)
 			}
+			problems = append(problems, prob)
 		}
 		// Check stored serial is correct
 		storedSerial, err := core.StringToSerial(cert.Serial)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -478,10 +478,9 @@ func TestIgnoredLint(t *testing.T) {
 	// missing OCSP url in the template.
 	expectedProblems := []string{
 		"zlint error: e_sub_cert_aia_does_not_contain_ocsp_url",
-		// TODO(@cpu): After Issue #4273 is unblocked these warn/info results should be expected
-		// "zlint warn: w_serial_number_low_entropy",
-		// "zlint info: n_subject_common_name_included",
-		// "zlint info: ct_sct_policy_count_unsatisfied Certificate had 0 embedded SCTs. Browser policy may require 2 for this certificate.",
+		"zlint warn: w_serial_number_low_entropy",
+		"zlint info: n_subject_common_name_included",
+		"zlint info: ct_sct_policy_count_unsatisfied Certificate had 0 embedded SCTs. Browser policy may require 2 for this certificate.",
 	}
 	sort.Strings(expectedProblems)
 
@@ -495,11 +494,9 @@ func TestIgnoredLint(t *testing.T) {
 	// lints. This should return no problems.
 	problems = checker.checkCert(cert, map[string]bool{
 		"e_sub_cert_aia_does_not_contain_ocsp_url": true,
-		// TODO(@cpu): After Issue #4273 is unblocked these info/warn lints should
-		// be ignored in the test.
-		// "w_serial_number_low_entropy":     true,
-		// "n_subject_common_name_included":  true,
-		// "ct_sct_policy_count_unsatisfied": true,
+		"w_serial_number_low_entropy":              true,
+		"n_subject_common_name_included":           true,
+		"ct_sct_policy_count_unsatisfied":          true,
 	})
 	test.AssertEquals(t, len(problems), 0)
 }


### PR DESCRIPTION
Resolves https://github.com/letsencrypt/boulder/issues/4273