### PR TITLE
Use primary key as cursor in cert-checker rather than serial

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -136,27 +136,41 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 		return err
 	}
 
+	var initialID int
+	err = c.dbMap.SelectOne(
+		&initialID,
+		"SELECT id FROM certificates WHERE issued >= :issued AND expires >= :now LIMIT 1",
+		args,
+	)
+	if err != nil {
+		return err
+	}
+	if initialID > 0 {
+		// decrement the initial ID so that we select below as we aren't using >=
+		initialID -= 1
+	}
+
 	// Retrieve certs in batches of 1000 (the size of the certificate channel)
 	// so that we don't eat unnecessary amounts of memory and avoid the 16MB MySQL
 	// packet limit.
 	args["limit"] = batchSize
-	args["lastSerial"] = ""
+	args["id"] = initialID
 	for offset := 0; offset < count; {
 		certs, err := sa.SelectCertificates(
 			c.dbMap,
-			"WHERE issued >= :issued AND expires >= :now AND serial > :lastSerial ORDER BY serial LIMIT :limit",
+			"WHERE id > :id AND expires >= :now ORDER BY id LIMIT :limit",
 			args,
 		)
 		if err != nil {
 			return err
 		}
 		for _, cert := range certs {
-			c.certs <- cert
+			c.certs <- cert.Certificate
 		}
 		if len(certs) == 0 {
 			break
 		}
-		args["lastSerial"] = certs[len(certs)-1].Serial
+		args["id"] = certs[len(certs)-1].ID
 		offset += len(certs)
 	}
 

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -144,7 +144,7 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 	for offset := 0; offset < count; {
 		certs, err := sa.SelectCertificates(
 			c.dbMap,
-			"WHERE issued >= :issued AND expires >= :now AND serial > :lastSerial LIMIT :limit",
+			"WHERE issued >= :issued AND expires >= :now AND serial > :lastSerial ORDER BY serial LIMIT :limit",
 			args,
 		)
 		if err != nil {

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -315,8 +315,8 @@ func (db mismatchedCountDB) SelectOne(output interface{}, _ string, _ ...interfa
 // a dastardly switch-a-roo here and return an empty set
 func (db mismatchedCountDB) Select(output interface{}, _ string, _ ...interface{}) ([]interface{}, error) {
 	// But actually return nothing
-	outputPtr, _ := output.(*[]core.Certificate)
-	*outputPtr = []core.Certificate{}
+	outputPtr, _ := output.(*[]sa.CertWithID)
+	*outputPtr = []sa.CertWithID{}
 	return nil, nil
 }
 

--- a/sa/model.go
+++ b/sa/model.go
@@ -142,12 +142,17 @@ func SelectCertificate(s dbOneSelector, q string, args ...interface{}) (core.Cer
 	return model, err
 }
 
+type CertWithID struct {
+	ID int64
+	core.Certificate
+}
+
 // SelectCertificates selects all fields of multiple certificate objects
-func SelectCertificates(s dbSelector, q string, args map[string]interface{}) ([]core.Certificate, error) {
-	var models []core.Certificate
+func SelectCertificates(s dbSelector, q string, args map[string]interface{}) ([]CertWithID, error) {
+	var models []CertWithID
 	_, err := s.Select(
 		&models,
-		"SELECT "+certFields+" FROM certificates "+q, args)
+		"SELECT id, "+certFields+" FROM certificates "+q, args)
 	return models, err
 }
 


### PR DESCRIPTION
`cert-checker` assumes an undefined behavior of MySQL which is only sometimes true, which means sometimes we select fewer certificates than we actually expect to. Instead of adding an explicit ORDER BY we simply switch to cursoring using the primary key, which gets us overall much more efficient usage of indexes.

Fixes #4315.