### PR TITLE
Add better error message for timeouts.

### DIFF
--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	berrors "github.com/letsencrypt/boulder/errors"
 )
@@ -177,9 +179,28 @@ func (ci *clientInterceptor) intercept(
 	// And defer decrementing it when we're done
 	defer ci.metrics.inFlightRPCs.With(labels).Dec()
 	// Handle the RPC
+	begin := time.Now()
 	err := ci.metrics.grpcMetrics.UnaryClientInterceptor()(localCtx, fullMethod, req, reply, cc, invoker, opts...)
 	if err != nil {
 		err = unwrapError(err, respMD)
 	}
+	if status.Code(err) == codes.DeadlineExceeded {
+		return deadlineDetails{
+			service: service,
+			method:  method,
+			latency: time.Since(begin),
+		}
+	}
 	return err
+}
+
+type deadlineDetails struct {
+	service string
+	method  string
+	latency time.Duration
+}
+
+func (dd deadlineDetails) Error() string {
+	return fmt.Sprintf("%s.%s timed out after %d ms",
+		dd.service, dd.method, int64(dd.latency/time.Millisecond))
 }

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -162,8 +162,8 @@ func TestTimeouts(t *testing.T) {
 		expectedErrorPrefix string
 	}{
 		{250 * time.Millisecond, "rpc error: code = Unknown desc = rpc error: code = DeadlineExceeded desc = the chiller overslept"},
-		{100 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
-		{10 * time.Millisecond, "rpc error: code = DeadlineExceeded desc = not enough time left on clock: "},
+		{100 * time.Millisecond, "Chiller.Chill timed out after 0 ms"},
+		{10 * time.Millisecond, "Chiller.Chill timed out after 0 ms"},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.timeout.String(), func(t *testing.T) {


### PR DESCRIPTION
Right now we sometimes get errors like:

rpc error: code = Unknown desc = rpc error:
  code = DeadlineExceeded desc = context deadline exceeded

For instance, when an SA call times out, and the RA returns that
timed-out error to the WFE. These are kind of confusing because they
have two layers of nested gRPC error, and they don't provide additional
information about which SA call timed out.

This change replaces DeadlineExceeded errors with our own error type
that includes the service and the method that were called, as well as
the amount of time it took (which helps understand if timeouts are
happening because earlier calls ate up time towards the deadline).

When the RA->SA NewOrder call times out, and the RA returns that error to WFE:

"InternalErrors":["rpc error: code = Unknown desc =
  sa.StorageAuthority.NewOrder timed out after 14954 ms"]

When the WFE->RA NewOrder call times out:

"InternalErrors":["ra.RegistrationAuthority.NewOrder timed out after 15000 ms"]

Note that this change only handles timeouts at one level deep, which I
think is sufficient for our needs.

Fixes #4321 