### PR TITLE
Improve performance of GetOrderForNames.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -29,11 +29,12 @@ func _() {
 	_ = x[RemoveWFE2AccountID-18]
 	_ = x[CheckRenewalFirst-19]
 	_ = x[MandatoryPOSTAsGET-20]
+	_ = x[FasterGetOrderForNames-21]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGET"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETFasterGetOrderForNames"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 266, 280, 298, 317, 334, 352}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 266, 280, 298, 317, 334, 352, 374}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -57,6 +57,8 @@ const (
 	// MandatoryPOSTAsGET forbids legacy unauthenticated GET requests for ACME
 	// resources.
 	MandatoryPOSTAsGET
+	// Use an optimized query for GetOrderForNames.
+	FasterGetOrderForNames
 )
 
 // List of features and their default value, protected by fMu
@@ -82,6 +84,7 @@ var features = map[FeatureFlag]bool{
 	CheckRenewalFirst:        false,
 	MandatoryPOSTAsGET:       false,
 	DisableAuthz2Orders:      false,
+	FasterGetOrderForNames:   false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -24,6 +24,7 @@
       ]
     },
     "features": {
+      "FasterGetOrderForNames": true
     }
   },
 


### PR DESCRIPTION
When there are a lot of potential orders to reuse, the query could scan
unnecessary rows, sometimes leading to timeouts. The new query uses the
available index more effectively and adds a LIMIT clause.

There are no new unittest cases because I think the cases at https://github.com/letsencrypt/boulder/blob/master/sa/sa_test.go#L2046-L2086 already cover what I would want to test for this change, but I'm definitely open to ideas for additional test cases.

Fixes #4325 