### PR TITLE
va: Send extValue in TLSALPN unauthorized response

### DIFF
--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -234,7 +234,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 			}
 			if subtle.ConstantTimeCompare(h[:], extValue) != 1 {
 				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"Invalid acmeValidationV1 extension value: %s for this challenge but got %s",
+					"Expected acmeValidationV1 extension value %s for this challenge but got %s",
 					core.ChallengeTypeTLSALPN01, hex.EncodeToString(h[:]), hex.EncodeToString(extValue))
 				return validationRecords, probs.Unauthorized(errText)
 			}

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -222,19 +222,20 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 			}
 			if !ext.Critical {
 				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"acmeValidationV1 extension not critical.", core.ChallengeTypeTLSALPN01)
+					"acmeValidationV1 extension not critical", core.ChallengeTypeTLSALPN01)
 				return validationRecords, probs.Unauthorized(errText)
 			}
 			var extValue []byte
 			rest, err := asn1.Unmarshal(ext.Value, &extValue)
 			if err != nil || len(rest) > 0 {
 				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"Malformed acmeValidationV1 extension value.", core.ChallengeTypeTLSALPN01)
+					"Malformed acmeValidationV1 extension value", core.ChallengeTypeTLSALPN01)
 				return validationRecords, probs.Unauthorized(errText)
 			}
 			if subtle.ConstantTimeCompare(h[:], extValue) != 1 {
 				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"Invalid acmeValidationV1 extension value.", core.ChallengeTypeTLSALPN01)
+					"Invalid acmeValidationV1 extension value: %s for this challenge but got %s",
+					core.ChallengeTypeTLSALPN01, hex.EncodeToString(h[:]), hex.EncodeToString(extValue))
 				return validationRecords, probs.Unauthorized(errText)
 			}
 			return validationRecords, nil

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -227,7 +227,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 			}
 			var extValue []byte
 			rest, err := asn1.Unmarshal(ext.Value, &extValue)
-			if err != nil || len(rest) > 0 {
+			if err != nil || len(rest) > 0 || len(h) != len(extValue) {
 				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
 					"Malformed acmeValidationV1 extension value", core.ChallengeTypeTLSALPN01)
 				return validationRecords, probs.Unauthorized(errText)


### PR DESCRIPTION
Brings it to be more in line with the responses from the other two challenges and will hopefully make the challenge a lot easier to debug (like in the recent community thread).

I hope the length is okay:

```json
"error": {
  "type": "urn:ietf:params:acme:error:unauthorized",
  "detail": "Incorrect validation certificate for tls-alpn-01 challenge. Expected acmeValidationV1 extension value 836bf5358f8a32826c61faeff2e0225b00756f935b00ed3002cabb9d536b9f53 for this challenge but got 8539b12e31c306b81a0aedab4128722c6ad71f71f46316a3c71612f47df0e532",
  "status": 403
},
```