### PR TITLE
Fix FasterGetOrderForNames and add tests.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -29,11 +29,12 @@ func _() {
 	_ = x[RemoveWFE2AccountID-18]
 	_ = x[CheckRenewalFirst-19]
 	_ = x[MandatoryPOSTAsGET-20]
+	_ = x[FasterGetOrderForNames-21]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGET"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETFasterGetOrderForNames"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 266, 280, 298, 317, 334, 352}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 266, 280, 298, 317, 334, 352, 374}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -57,6 +57,8 @@ const (
 	// MandatoryPOSTAsGET forbids legacy unauthenticated GET requests for ACME
 	// resources.
 	MandatoryPOSTAsGET
+	// Use an optimized query for GetOrderForNames.
+	FasterGetOrderForNames
 )
 
 // List of features and their default value, protected by fMu
@@ -82,6 +84,7 @@ var features = map[FeatureFlag]bool{
 	CheckRenewalFirst:        false,
 	MandatoryPOSTAsGET:       false,
 	DisableAuthz2Orders:      false,
+	FasterGetOrderForNames:   false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1852,7 +1852,6 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 	if err == sql.ErrNoRows {
 		return nil, berrors.NotFoundError("no order matching request found")
 	} else if err != nil {
-		// An unexpected error occurred
 		return nil, err
 	}
 
@@ -1861,7 +1860,7 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 	}
 
 	// Get the order
-	order, err := ssa.GetOrder(ctx, &sapb.OrderRequest{Id: &orderID, UseV2Authorizations: req.UseV2Authorizations})
+	order, err := ssa.GetOrder(ctx, &sapb.OrderRequest{Id: &result.orderID, UseV2Authorizations: req.UseV2Authorizations})
 	if err != nil {
 		return nil, err
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1856,6 +1856,10 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 		return nil, err
 	}
 
+	if result.RegistrationID != *req.AcctID {
+		return nil, berrors.NotFoundError("no order matching request found")
+	}
+
 	// Get the order
 	order, err := ssa.GetOrder(ctx, &sapb.OrderRequest{Id: &orderID, UseV2Authorizations: req.UseV2Authorizations})
 	if err != nil {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1812,17 +1812,43 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 	// Hash the names requested for lookup in the orderFqdnSets table
 	fqdnHash := hashNames(req.Names)
 
-	var orderID int64
-	err := ssa.dbMap.WithContext(ctx).SelectOne(&orderID, `
-	SELECT orderID
-	FROM orderFqdnSets
-	WHERE setHash = ?
-	AND registrationID = ?
-	AND expires > ?`,
-		fqdnHash, *req.AcctID, ssa.clk.Now())
+	// Find a possibly-suitable order. We don't include the account ID or order
+	// status in this query because there's no index that includes those, so
+	// including them could require the DB to scan extra rows.
+	// Instead, we select one unexpired order that matches the fqdnSet. If
+	// that order doesn't match the account ID or status we need, just return
+	// nothing. We use `ORDER BY expires ASC` because the index on
+	// (setHash, expires) is in ASC order. DESC would be slightly nicer from a
+	// user experience perspective but would be slow when there are many entries
+	// to sort.
+	// This approach works fine because in most cases there's only one account
+	// issuing for a given name. If there are other accounts issuing for the same
+	// name, it just means order reuse happens less often.
+	var result struct {
+		OrderID        int64
+		RegistrationID int64
+	}
+	var err error
+	if features.Enabled(features.FasterGetOrderForNames) {
+		err = ssa.dbMap.WithContext(ctx).SelectOne(&result, `
+					SELECT orderID, registrationID
+					FROM orderFqdnSets
+					WHERE setHash = ?
+					AND expires > ?
+					ORDER BY expires DESC
+					LIMIT 1`,
+			fqdnHash, ssa.clk.Now())
+	} else {
+		err = ssa.dbMap.WithContext(ctx).SelectOne(&result, `
+					SELECT orderID, registrationID
+					FROM orderFqdnSets
+					WHERE setHash = ?
+					AND registrationID = ?
+					AND expires > ?
+					LIMIT 1`,
+			fqdnHash, *req.AcctID, ssa.clk.Now())
+	}
 
-	// There isn't an unexpired order for the provided AcctID that has the
-	// fqdnHash requested.
 	if err == sql.ErrNoRows {
 		return nil, berrors.NotFoundError("no order matching request found")
 	} else if err != nil {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1860,7 +1860,7 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 	}
 
 	// Get the order
-	order, err := ssa.GetOrder(ctx, &sapb.OrderRequest{Id: &result.orderID, UseV2Authorizations: req.UseV2Authorizations})
+	order, err := ssa.GetOrder(ctx, &sapb.OrderRequest{Id: &result.OrderID, UseV2Authorizations: req.UseV2Authorizations})
 	if err != nil {
 		return nil, err
 	}

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -24,6 +24,7 @@
       ]
     },
     "features": {
+      "FasterGetOrderForNames": true
     }
   },
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -41,6 +41,7 @@ def run_client_tests():
     run(cmd, cwd=root)
 
 def run_expired_authz_purger():
+    return
     # Note: This test must be run after all other tests that depend on
     # authorizations added to the database during setup
     # (e.g. test_expired_authzs_404).

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -41,7 +41,6 @@ def run_client_tests():
     run(cmd, cwd=root)
 
 def run_expired_authz_purger():
-    return
     # Note: This test must be run after all other tests that depend on
     # authorizations added to the database during setup
     # (e.g. test_expired_authzs_404).


### PR DESCRIPTION
This rolls forward #4326 after it was reverted in #4328.

Resolves https://github.com/letsencrypt/boulder/issues/4329

The older query didn't have a `LIMIT 1` so it was returning multiple results, but gorp's `SelectOne` was okay with multiple results when the selection was going into an `int64`. When I changed this to a `struct` in #4326, gorp started producing errors.

For this bug to manifest, an account needs to create an order, then fail validation, twice in a row for a given domain name, then create an order once more for the same domain name - that third request will fail because there are multiple orders in the orderFqdnSets table for that domain.

Note that the bug condition doesn't happen when an account does three successful issuances in a row, because finalizing an order (that is, issuing a certificate for it) deletes the row in orderFqdnSets. Failing an authorization does not delete the row in orderFqdnSets. I believe this was an intentional design decision because an authorization can participate in many orders, and those orders can have many other authorizations, so computing the updated state of all those orders would be expensive (remember, order state is not persisted in the DB but is calculated dynamically based on the authorizations it contains).

This wasn't detected in integration tests because we don't have any tests that fail validation for the same domain multiple times. I filed an issue for an integration test that would have incidentally caught this: https://github.com/letsencrypt/boulder/issues/4332. There's also a more specific test case in #4331.