### PR TITLE
Use HandleFunc to separately process authzv2s.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -45,22 +45,24 @@ import (
 // lowercase plus hyphens. If you violate that assumption you should update
 // measured_http.
 const (
-	directoryPath  = "/directory"
-	newRegPath     = "/acme/new-reg"
-	regPath        = "/acme/reg/"
-	newAuthzPath   = "/acme/new-authz"
-	authzPath      = "/acme/authz/"
-	challengePath  = "/acme/challenge/"
-	newCertPath    = "/acme/new-cert"
-	certPath       = "/acme/cert/"
-	revokeCertPath = "/acme/revoke-cert"
-	termsPath      = "/terms"
-	issuerPath     = "/acme/issuer-cert"
-	buildIDPath    = "/build"
-	rolloverPath   = "/acme/key-change"
+	directoryPath = "/directory"
+	newRegPath    = "/acme/new-reg"
+	regPath       = "/acme/reg/"
+	newAuthzPath  = "/acme/new-authz"
+	authzPath     = "/acme/authz/"
+	// For user-facing URLs we use a "v3" suffix to avoid potential confusiong
+	// regarding ACMEv2.
+	authzv2Path     = "/acme/authz-v3/"
+	challengev2Path = "/acme/chall-v3/"
+	challengePath   = "/acme/challenge/"
+	newCertPath     = "/acme/new-cert"
+	certPath        = "/acme/cert/"
+	revokeCertPath  = "/acme/revoke-cert"
+	termsPath       = "/terms"
+	issuerPath      = "/acme/issuer-cert"
+	buildIDPath     = "/build"
+	rolloverPath    = "/acme/key-change"
 )
-
-const authz2Prefix = "v2"
 
 // WebFrontEndImpl provides all the logic for Boulder's web-facing interface,
 // i.e., ACME.  Its members configure the paths for various ACME functions,
@@ -310,7 +312,9 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, newCertPath, wfe.NewCertificate, "POST")
 	wfe.HandleFunc(m, regPath, wfe.Registration, "POST")
 	wfe.HandleFunc(m, authzPath, wfe.Authorization, "GET", "POST")
+	wfe.HandleFunc(m, authzv2Path, wfe.AuthorizationV2, "GET", "POST")
 	wfe.HandleFunc(m, challengePath, wfe.Challenge, "GET", "POST")
+	wfe.HandleFunc(m, challengev2Path, wfe.ChallengeV2, "GET", "POST")
 	wfe.HandleFunc(m, certPath, wfe.Certificate, "GET")
 	wfe.HandleFunc(m, revokeCertPath, wfe.RevokeCertificate, "POST")
 	wfe.HandleFunc(m, termsPath, wfe.Terms, "GET")
@@ -998,6 +1002,54 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 	}
 }
 
+// ChallengeV2 handles POST requests to challenge URLs belonging to
+// authzv2-style authorizations.  Such requests are clients'
+// responses to the server's challenges.
+func (wfe *WebFrontEndImpl) ChallengeV2(
+	ctx context.Context,
+	logEvent *web.RequestEvent,
+	response http.ResponseWriter,
+	request *http.Request) {
+	notFound := func() {
+		wfe.sendError(response, logEvent, probs.NotFound("No such challenge"), nil)
+	}
+	if !features.Enabled(features.NewAuthorizationSchema) {
+		notFound()
+		return
+	}
+	slug := strings.Split(request.URL.Path, "/")
+	if len(slug) != 2 {
+		notFound()
+		return
+	}
+	authorizationID, err := strconv.ParseInt(slug[0], 10, 64)
+	if err != nil {
+		notFound()
+		return
+	}
+	challengeID := slug[1]
+	authzPB, err := wfe.SA.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: &authorizationID})
+	if err != nil {
+		if berrors.Is(err, berrors.NotFound) {
+			notFound()
+		} else {
+			wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
+		}
+		return
+	}
+	authz, err := bgrpc.PBToAuthz(authzPB)
+	if err != nil {
+		wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
+		return
+	}
+	challengeIndex := authz.FindChallengeByStringID(challengeID)
+	if challengeIndex == -1 {
+		notFound()
+		return
+	}
+	wfe.challengeCommon(ctx, logEvent, response, request, authz, challengeIndex)
+}
+
 // Challenge handles POST requests to challenge URLs.  Such requests are clients'
 // responses to the server's challenges.
 func (wfe *WebFrontEndImpl) Challenge(
@@ -1010,92 +1062,60 @@ func (wfe *WebFrontEndImpl) Challenge(
 		wfe.sendError(response, logEvent, probs.NotFound("No such challenge"), nil)
 	}
 
-	// Challenge URIs are of the form /acme/challenge/<auth id>/<challenge id>
-	// or /acme/challenge/v2/<auth id>/<challenge id> depending on the authorization
-	// version. Here we parse out the authorization and challenge IDs and retrieve
+	// Here we parse out the authorization and challenge IDs and retrieve
 	// the authorization.
 	slug := strings.Split(request.URL.Path, "/")
-	if len(slug) != 2 && len(slug) != 3 {
+	if len(slug) != 2 {
 		notFound()
 		return
 	}
-	var authorizationID string
-	var challengeID interface{}
-	var err error
-	var v2 bool
-	if len(slug) == 3 {
-		if !features.Enabled(features.NewAuthorizationSchema) || slug[0] != authz2Prefix {
-			notFound()
-			return
-		}
-		v2 = true
-		authorizationID, challengeID = slug[1], slug[2]
-	} else {
-		authorizationID = slug[0]
-		challengeID, err = strconv.ParseInt(slug[1], 10, 64)
-		if err != nil {
-			notFound()
-			return
-		}
+	var authorizationID string = slug[0]
+	challengeID, err := strconv.ParseInt(slug[1], 10, 64)
+	if err != nil {
+		notFound()
+		return
 	}
 
-	var authz core.Authorization
-	if v2 {
-		id, err := strconv.ParseInt(authorizationID, 10, 64)
-		if err != nil {
+	authz, err := wfe.SA.GetAuthorization(ctx, authorizationID)
+	if err != nil {
+		if berrors.Is(err, berrors.NotFound) {
 			notFound()
-			return
-		}
-		authzPB, err := wfe.SA.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: &id})
-		if err != nil {
-			if berrors.Is(err, berrors.NotFound) {
-				notFound()
-			} else {
-				wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
-			}
-			return
-		}
-		authz, err = bgrpc.PBToAuthz(authzPB)
-		if err != nil {
+		} else {
 			wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
-			return
 		}
-	} else {
-		authz, err = wfe.SA.GetAuthorization(ctx, authorizationID)
-		if err != nil {
-			if berrors.Is(err, berrors.NotFound) {
-				notFound()
-			} else {
-				wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
-			}
-			return
-		}
-	}
-
-	// After expiring, challenges are inaccessible
-	if authz.Expires == nil || authz.Expires.Before(wfe.clk.Now()) {
-		wfe.sendError(response, logEvent, probs.NotFound("Expired authorization"), nil)
 		return
 	}
 
 	// Check that the requested challenge exists within the authorization
-	var challengeIndex int
-	if authz.V2 {
-		challengeIndex = authz.FindChallengeByStringID(challengeID.(string))
-	} else {
-		challengeIndex = authz.FindChallenge(challengeID.(int64))
-	}
+	challengeIndex := authz.FindChallenge(challengeID)
 	if challengeIndex == -1 {
 		notFound()
 		return
 	}
-	challenge := authz.Challenges[challengeIndex]
+
+	wfe.challengeCommon(ctx, logEvent, response, request, authz, challengeIndex)
+}
+
+// challengeCommon handles logic that is common to both Challenge and
+// ChallengeV2.
+func (wfe *WebFrontEndImpl) challengeCommon(
+	ctx context.Context,
+	logEvent *web.RequestEvent,
+	response http.ResponseWriter,
+	request *http.Request,
+	authz core.Authorization,
+	challengeIndex int) {
+	if authz.Expires == nil || authz.Expires.Before(wfe.clk.Now()) {
+		wfe.sendError(response, logEvent, probs.NotFound("Expired authorization"), nil)
+		return
+	}
 
 	if authz.Identifier.Type == identifier.DNS {
 		logEvent.DNSName = authz.Identifier.Value
 	}
 	logEvent.Status = string(authz.Status)
 
+	challenge := authz.Challenges[challengeIndex]
 	switch request.Method {
 	case "GET", "HEAD":
 		wfe.getChallenge(ctx, response, request, authz, &challenge, logEvent)
@@ -1111,7 +1131,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz core.Authorization, challenge *core.Challenge) {
 	// Update the challenge URI to be relative to the HTTP request Host
 	if authz.V2 {
-		challenge.URI = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%s/%s", challengePath, authz2Prefix, authz.ID, challenge.StringID()))
+		challenge.URI = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%s", challengev2Path, authz.ID, challenge.StringID()))
 	} else {
 		challenge.URI = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%d", challengePath, authz.ID, challenge.ID))
 	}
@@ -1386,45 +1406,48 @@ func (wfe *WebFrontEndImpl) deactivateAuthorization(ctx context.Context, authz *
 	return true
 }
 
-// Authorization is used by clients to submit an update to one of their
-// authorizations.
-func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+// AuthorizationV2 is used by clients to submit an update to an authzv2-style
+// authorization.
+func (wfe *WebFrontEndImpl) AuthorizationV2(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
 	// Requests to this handler should have a path that leads to a known authz
 	id := request.URL.Path
 	var authz core.Authorization
 	var err error
-	if features.Enabled(features.NewAuthorizationSchema) && strings.HasPrefix(id, authz2Prefix) {
-		authzID, err := strconv.ParseInt(strings.TrimPrefix(id, authz2Prefix+"/"), 10, 64)
-		if err != nil {
+	if !features.Enabled(features.NewAuthorizationSchema) {
+		wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
+		return
+	}
+	authzID, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
+		return
+	}
+	authzPB, err := wfe.SA.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: &authzID})
+	if err != nil {
+		if berrors.Is(err, berrors.NotFound) {
 			wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
-			return
-		}
-		authzPB, err := wfe.SA.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: &authzID})
-		if err != nil {
-			if berrors.Is(err, berrors.NotFound) {
-				wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
-			} else {
-				wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
-			}
-			return
-		}
-		authz, err = bgrpc.PBToAuthz(authzPB)
-		if err != nil {
+		} else {
 			wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
-			return
 		}
-	} else {
-		authz, err = wfe.SA.GetAuthorization(ctx, id)
-		if err != nil {
-			if berrors.Is(err, berrors.NotFound) {
-				wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
-			} else {
-				wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
-			}
-			return
-		}
+		return
+	}
+	authz, err = bgrpc.PBToAuthz(authzPB)
+	if err != nil {
+		wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
+		return
 	}
 
+	wfe.authorizationCommon(ctx, logEvent, response, request, authz)
+}
+
+// authorizationCommon handles logic that is common to both AuthorizationV2 and
+// Authorization.
+func (wfe *WebFrontEndImpl) authorizationCommon(
+	ctx context.Context,
+	logEvent *web.RequestEvent,
+	response http.ResponseWriter,
+	request *http.Request,
+	authz core.Authorization) {
 	if authz.Identifier.Type == identifier.DNS {
 		logEvent.DNSName = authz.Identifier.Value
 	}
@@ -1449,12 +1472,32 @@ func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.Req
 
 	response.Header().Add("Link", link(web.RelativeEndpoint(request, newCertPath), "next"))
 
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, authz)
+	err := wfe.writeJsonResponse(response, logEvent, http.StatusOK, authz)
 	if err != nil {
 		// InternalServerError because this is a failure to decode from our DB.
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to JSON marshal authz"), err)
 		return
 	}
+}
+
+// Authorization is used by clients to submit an update to one of their
+// authorizations.
+func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	// Requests to this handler should have a path that leads to a known authz
+	id := request.URL.Path
+	var authz core.Authorization
+	var err error
+	authz, err = wfe.SA.GetAuthorization(ctx, id)
+	if err != nil {
+		if berrors.Is(err, berrors.NotFound) {
+			wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
+		} else {
+			wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)
+		}
+		return
+	}
+
+	wfe.authorizationCommon(ctx, logEvent, response, request, authz)
 }
 
 var allHex = regexp.MustCompile("^[0-9a-f]+$")
@@ -1670,7 +1713,7 @@ func (wfe *WebFrontEndImpl) addIssuingCertificateURLs(response http.ResponseWrit
 
 func urlForAuthz(authz core.Authorization, request *http.Request) string {
 	if authz.V2 {
-		return web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%s", authzPath, authz2Prefix, authz.ID))
+		return web.RelativeEndpoint(request, authzv2Path+string(authz.ID))
 	}
 	return web.RelativeEndpoint(request, authzPath+string(authz.ID))
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1118,20 +1118,20 @@ func TestGetChallengeV2UpRel(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	_ = features.Set(map[string]bool{"NewAuthorizationSchema": true})
 
-	challengeURL := "http://localhost/acme/challenge/v2/1/-ZfxEw"
+	challengeURL := "http://localhost/acme/chall-v3/1/-ZfxEw"
 	resp := httptest.NewRecorder()
 
 	req, err := http.NewRequest("GET", challengeURL, nil)
-	req.URL.Path = "v2/1/-ZfxEw"
+	req.URL.Path = "1/-ZfxEw"
 	test.AssertNotError(t, err, "Could not make NewRequest")
 
-	wfe.Challenge(ctx, newRequestEvent(), resp, req)
+	wfe.ChallengeV2(ctx, newRequestEvent(), resp, req)
 	test.AssertEquals(t,
 		resp.Code,
 		http.StatusAccepted)
 	test.AssertEquals(t,
 		resp.Header().Get("Link"),
-		`<http://localhost/acme/authz/v2/1>;rel="up"`)
+		`<http://localhost/acme/authz-v3/1>;rel="up"`)
 }
 
 func TestChallenge(t *testing.T) {

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2670,26 +2670,26 @@ func TestChallengeNewIDScheme(t *testing.T) {
 		path     string
 		location string
 		expected string
-		f        func(context.Context, *web.RequestEvent, http.ResponseWriter, *http.Request)
+		handler  func(context.Context, *web.RequestEvent, http.ResponseWriter, *http.Request)
 	}{
 		{
 			path:     "valid/23",
 			location: "http://localhost/acme/challenge/valid/23",
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/valid/23"}`,
-			f:        wfe.Challenge,
+			handler:  wfe.Challenge,
 		},
 		{
 			path:     "1/-ZfxEw",
 			location: "http://localhost/acme/chall-v3/1/-ZfxEw",
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/chall-v3/1/-ZfxEw"}`,
-			f:        wfe.ChallengeV2,
+			handler:  wfe.ChallengeV2,
 		},
 	} {
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", tc.path, nil)
 		test.AssertNotError(t, err, "http.NewRequest failed")
 
-		tc.f(context.Background(), newRequestEvent(), resp, req)
+		tc.handler(context.Background(), newRequestEvent(), resp, req)
 		test.AssertEquals(t,
 			resp.Code,
 			http.StatusAccepted)
@@ -2705,23 +2705,23 @@ func TestChallengeNewIDScheme(t *testing.T) {
 		path     string
 		location string
 		expected string
-		f        func(context.Context, *web.RequestEvent, http.ResponseWriter, *http.Request)
+		handler  func(context.Context, *web.RequestEvent, http.ResponseWriter, *http.Request)
 	}{
 		{
 			path:     "valid/23",
 			location: "http://localhost/acme/challenge/valid/23",
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/valid/23"}`,
-			f:        wfe.Challenge,
+			handler:  wfe.Challenge,
 		},
 		{
 			path:     "1/-ZfxEw",
 			location: "http://localhost/acme/chall-v3/1/-ZfxEw",
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/chall-v3/1/-ZfxEw"}`,
-			f:        wfe.ChallengeV2,
+			handler:  wfe.ChallengeV2,
 		},
 	} {
 		resp := httptest.NewRecorder()
-		tc.f(ctx, newRequestEvent(), resp, makePostRequestWithPath(
+		tc.handler(ctx, newRequestEvent(), resp, makePostRequestWithPath(
 			tc.path, signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 		test.AssertEquals(t,
 			resp.Code,

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1774,8 +1774,6 @@ func TestAuthorization(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler()
 
-	_ = features.Set(map[string]bool{"NewAuthorizationSchema": true})
-
 	responseWriter := httptest.NewRecorder()
 
 	// GET instead of POST should be rejected
@@ -1865,11 +1863,19 @@ func TestAuthorization(t *testing.T) {
 	})
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
 		`{"type":"`+probs.V1ErrorNS+`malformed","detail":"No such authorization","status":404}`)
+}
+
+func TestAuthorizationV2(t *testing.T) {
+	wfe, _ := setupWFE(t)
+
+	_ = features.Set(map[string]bool{"NewAuthorizationSchema": true})
+
+	responseWriter := httptest.NewRecorder()
 
 	// Test retrieving a v2 style authorization
 	responseWriter = httptest.NewRecorder()
-	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
-		URL:    mustParseURL("v2/1"),
+	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+		URL:    mustParseURL("1"),
 		Method: "GET",
 	})
 	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
@@ -1886,7 +1892,7 @@ func TestAuthorization(t *testing.T) {
 			{
 				"type": "dns",
 				"token":"token",
-				"uri": "http://localhost/acme/challenge/v2/1/-ZfxEw"
+				"uri": "http://localhost/acme/chall-v3/1/-ZfxEw"
 			}
 		]
 	}`)
@@ -2588,7 +2594,7 @@ func TestPrepChallengeForDisplay(t *testing.T) {
 	_ = features.Set(map[string]bool{"NewAuthorizationSchema": true})
 	authz.V2 = true
 	wfe.prepChallengeForDisplay(req, authz, chall)
-	test.AssertEquals(t, chall.URI, "http://example.com/acme/challenge/v2/eyup/iFVMwA")
+	test.AssertEquals(t, chall.URI, "http://example.com/acme/chall-v3/eyup/iFVMwA")
 }
 
 // noSCTMockRA is a mock RA that always returns a `berrors.MissingSCTsError` from `NewCertificate`
@@ -2664,23 +2670,26 @@ func TestChallengeNewIDScheme(t *testing.T) {
 		path     string
 		location string
 		expected string
+		f        func(context.Context, *web.RequestEvent, http.ResponseWriter, *http.Request)
 	}{
 		{
 			path:     "valid/23",
 			location: "http://localhost/acme/challenge/valid/23",
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/valid/23"}`,
+			f:        wfe.Challenge,
 		},
 		{
-			path:     "v2/1/-ZfxEw",
-			location: "http://localhost/acme/challenge/v2/1/-ZfxEw",
-			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/v2/1/-ZfxEw"}`,
+			path:     "1/-ZfxEw",
+			location: "http://localhost/acme/chall-v3/1/-ZfxEw",
+			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/chall-v3/1/-ZfxEw"}`,
+			f:        wfe.ChallengeV2,
 		},
 	} {
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", tc.path, nil)
 		test.AssertNotError(t, err, "http.NewRequest failed")
 
-		wfe.Challenge(context.Background(), newRequestEvent(), resp, req)
+		tc.f(context.Background(), newRequestEvent(), resp, req)
 		test.AssertEquals(t,
 			resp.Code,
 			http.StatusAccepted)
@@ -2696,20 +2705,23 @@ func TestChallengeNewIDScheme(t *testing.T) {
 		path     string
 		location string
 		expected string
+		f        func(context.Context, *web.RequestEvent, http.ResponseWriter, *http.Request)
 	}{
 		{
 			path:     "valid/23",
 			location: "http://localhost/acme/challenge/valid/23",
 			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/valid/23"}`,
+			f:        wfe.Challenge,
 		},
 		{
-			path:     "v2/1/-ZfxEw",
-			location: "http://localhost/acme/challenge/v2/1/-ZfxEw",
-			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/challenge/v2/1/-ZfxEw"}`,
+			path:     "1/-ZfxEw",
+			location: "http://localhost/acme/chall-v3/1/-ZfxEw",
+			expected: `{"type":"dns","token":"token","uri":"http://localhost/acme/chall-v3/1/-ZfxEw"}`,
+			f:        wfe.ChallengeV2,
 		},
 	} {
 		resp := httptest.NewRecorder()
-		wfe.Challenge(ctx, newRequestEvent(), resp, makePostRequestWithPath(
+		tc.f(ctx, newRequestEvent(), resp, makePostRequestWithPath(
 			tc.path, signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 		test.AssertEquals(t,
 			resp.Code,


### PR DESCRIPTION
Previously we made v2 authz handling part of regular authz handling, and
just tried to strip the v2/ prefix. This led to a bug: #4327, where
authzv1s that had an id randomly start with "v2" would 404 because they
were treated as authzv2's.

This change moves authz2's and related challenges onto their own prefix,
and uses HandleFunc to dispatch them appropriately. To reduce code
duplication, I factored out the code that was common to v1 and v2 into
new Common functions.

I also changed the path names to contain "v3" instead of "v2" to avoid
potential confusion.

Note: This only applies to `wfe` so far. I'd like to do a round of review to make sure I'm on the right track before applying these refactorings to `wfe2`.