### PR TITLE
SA: fix dangling getAllOrderAuthorizationStatuses tx.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1745,7 +1745,7 @@ func (ssa *SQLStorageAuthority) getAllOrderAuthorizationStatuses(
 			orderID,
 		)
 		if err != nil {
-			return nil, err
+			return nil, Rollback(tx, err)
 		}
 		allAuthzValidity = append(allAuthzValidity, validityInfo...)
 	}


### PR DESCRIPTION
In the case where the DB `Select()` returns a non-nil `err` result the SA's `getAllOrderAuthorizationStatuses` function needs to ensure it rolls back the transaction it opened or it will be leaked.