### PR TITLE
sa: drop SCTReceipts table and assoc. code.

### DIFF
--- a/sa/_db-next/migrations/20190717133458_DropSCTReceipts.sql
+++ b/sa/_db-next/migrations/20190717133458_DropSCTReceipts.sql
@@ -1,0 +1,21 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+DROP TABLE `sctReceipts`;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+CREATE TABLE `sctReceipts` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `sctVersion` tinyint(1) NOT NULL,
+  `logID` varchar(255) NOT NULL,
+  `timestamp` bigint(20) NOT NULL,
+  `extensions` blob DEFAULT NULL,
+  `signature` blob DEFAULT NULL,
+  `certificateSerial` varchar(255) NOT NULL,
+  `LockCol` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `certificateSerial_logID` (`certificateSerial`,`logID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sa/database.go
+++ b/sa/database.go
@@ -130,7 +130,6 @@ func initTables(dbMap *gorp.DbMap) {
 	dbMap.AddTableWithName(core.Certificate{}, "certificates").SetKeys(false, "Serial")
 	dbMap.AddTableWithName(core.CertificateStatus{}, "certificateStatus").SetKeys(false, "Serial")
 	dbMap.AddTableWithName(core.CRL{}, "crls").SetKeys(false, "Serial")
-	dbMap.AddTableWithName(core.SignedCertificateTimestamp{}, "sctReceipts").SetKeys(true, "ID").SetVersionCol("LockCol")
 	dbMap.AddTableWithName(core.FQDNSet{}, "fqdnSets").SetKeys(true, "ID")
 	dbMap.AddTableWithName(certStatusModel{}, "certificateStatus").SetKeys(false, "Serial")
 	dbMap.AddTableWithName(orderModel{}, "orders").SetKeys(true, "ID")

--- a/sa/model.go
+++ b/sa/model.go
@@ -118,17 +118,6 @@ func selectAuthz(s dbOneSelector, q string, args ...interface{}) (*authzModel, e
 	return &model, err
 }
 
-// selectSctReceipt selects all fields of one SignedCertificateTimestamp object
-func selectSctReceipt(s dbOneSelector, q string, args ...interface{}) (core.SignedCertificateTimestamp, error) {
-	var model core.SignedCertificateTimestamp
-	err := s.SelectOne(
-		&model,
-		"SELECT id, sctVersion, logID, timestamp, extensions, signature, certificateSerial, LockCol FROM sctReceipts "+q,
-		args...,
-	)
-	return model, err
-}
-
 const certFields = "registrationID, serial, digest, der, issued, expires"
 
 // SelectCertificate selects all fields of one certificate object

--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -21,7 +21,6 @@ GRANT SELECT,INSERT ON certificates TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON certificateStatus TO 'sa'@'localhost';
 GRANT SELECT,INSERT ON issuedNames TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON certificatesPerName TO 'sa'@'localhost';
-GRANT SELECT,INSERT ON sctReceipts TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON registrations TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON challenges TO 'sa'@'localhost';
 GRANT SELECT,INSERT on fqdnSets TO 'sa'@'localhost';
@@ -38,7 +37,6 @@ GRANT SELECT ON certificateStatus TO 'ocsp_resp'@'localhost';
 -- OCSP Generator Tool (Updater)
 GRANT SELECT ON certificates TO 'ocsp_update'@'localhost';
 GRANT SELECT,UPDATE ON certificateStatus TO 'ocsp_update'@'localhost';
-GRANT SELECT ON sctReceipts TO 'ocsp_update'@'localhost';
 
 -- Revoker Tool
 GRANT SELECT ON registrations TO 'revoker'@'localhost';


### PR DESCRIPTION
The `SCTReceipts` database table and associated model linkages are legacy cruft from before Boulder implemented SCT embedding. We can safely remove all of this stuff.

Resolves https://github.com/letsencrypt/boulder/issues/4343