### PR TITLE
Fix ORDER BY to match comment.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1835,7 +1835,7 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 					FROM orderFqdnSets
 					WHERE setHash = ?
 					AND expires > ?
-					ORDER BY expires DESC
+					ORDER BY expires ASC
 					LIMIT 1`,
 			fqdnHash, ssa.clk.Now())
 	} else {


### PR DESCRIPTION
In #4331 I introduced this new more efficient query for
GetOrderForNames, and commented about why we needed an ORDER BY... ASC
to efficiently use the index. However, the actually query did not match
the comment, and it used DESC. This fixes the query.

To demonstrate that the index is actually used with the ASC version,
here's the EXPLAIN output after filling up the table with a bunch of
failed orders:
```
MariaDB [boulder_sa_integration]> explain select orderID, registrationID FROM orderFqdnSets
    -> WHERE setHash = UNHEX('B60FE34E4A6735D5A575D81C97F4DFED2102DC179B34252E4AA18F6E2A375C98')
    -> AND expires > NOW() ORDER BY EXPIRES ASC LIMIT 1 \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: orderFqdnSets
         type: range
possible_keys: setHash_expires_idx
          key: setHash_expires_idx
      key_len: 37
          ref: NULL
         rows: 1500
        Extra: Using index condition
1 row in set (0.000 sec)

MariaDB [boulder_sa_integration]> explain select orderID, registrationID FROM orderFqdnSets
    -> WHERE setHash = UNHEX('B60FE34E4A6735D5A575D81C97F4DFED2102DC179B34252E4AA18F6E2A375C98')
    -> AND expires > NOW() ORDER BY EXPIRES DESC LIMIT 1 \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: orderFqdnSets
         type: range
possible_keys: setHash_expires_idx
          key: setHash_expires_idx
      key_len: 37
          ref: NULL
         rows: 1500
        Extra: Using where
1 row in set (0.000 sec)
```