### PR TITLE
Remove unused revokeAuthorizations functions.

### DIFF
--- a/sa/authz.go
+++ b/sa/authz.go
@@ -36,31 +36,3 @@ func getAuthorizationIDsByDomain(db dbSelector, tableName string, ident string, 
 	}
 	return allIDs, nil
 }
-
-func revokeAuthorizations(db dbExecer, tableName string, authIDs []string) (int64, error) {
-	stmtArgs := []interface{}{string(core.StatusRevoked)}
-	qmarks := []string{}
-	for _, id := range authIDs {
-		stmtArgs = append(stmtArgs, id)
-		qmarks = append(qmarks, "?")
-	}
-	idStmt := fmt.Sprintf("(%s)", strings.Join(qmarks, ", "))
-	result, err := db.Exec(
-		fmt.Sprintf(
-			`UPDATE %s
-       SET status = ?
-       WHERE id IN %s`,
-			tableName,
-			idStmt,
-		),
-		stmtArgs...,
-	)
-	if err != nil {
-		return 0, err
-	}
-	batchSize, err := result.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-	return batchSize, nil
-}

--- a/sa/authz.go
+++ b/sa/authz.go
@@ -2,7 +2,6 @@ package sa
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/letsencrypt/boulder/core"

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -706,20 +706,6 @@ func (ssa *SQLStorageAuthority) getAuthorizationIDsByDomain2(ctx context.Context
 	return ids, nil
 }
 
-func (ssa *SQLStorageAuthority) revokeAuthorizations2(ctx context.Context, ids []int64) error {
-	qmarks := []string{}
-	params := []interface{}{statusUint(core.StatusRevoked)}
-	for _, id := range ids {
-		qmarks = append(qmarks, "?")
-		params = append(params, id)
-	}
-	_, err := ssa.dbMap.Exec(
-		fmt.Sprintf(`UPDATE authz2 SET status = ? WHERE id IN (%s)`, strings.Join(qmarks, ",")),
-		params...,
-	)
-	return err
-}
-
 // AddCertificate stores an issued certificate and returns the digest as
 // a string, or an error if any occurred.
 func (ssa *SQLStorageAuthority) AddCertificate(


### PR DESCRIPTION
Instead of these, we use the policy blocklist.

Fixes #4350.