### PR TITLE
Delete unused challenges

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -32,11 +32,12 @@ func _() {
 	_ = x[FasterGetOrderForNames-21]
 	_ = x[AllowV1Registration-22]
 	_ = x[ParallelCheckFailedValidation-23]
+	_ = x[DeleteUnusedChallenges-24]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETFasterGetOrderForNamesAllowV1RegistrationParallelCheckFailedValidation"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRACAAValidationMethodsCAAAccountURIHeadNonceStatusOKNewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETFasterGetOrderForNamesAllowV1RegistrationParallelCheckFailedValidationDeleteUnusedChallenges"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 266, 280, 298, 317, 334, 352, 374, 393, 422}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 176, 189, 206, 228, 247, 266, 280, 298, 317, 334, 352, 374, 393, 422, 444}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -63,6 +63,8 @@ const (
 	AllowV1Registration
 	// Check the failed validation limit in parallel during NewOrder
 	ParallelCheckFailedValidation
+	// Upon authorization validation, delete the challenges that weren't used.
+	DeleteUnusedChallenges
 )
 
 // List of features and their default value, protected by fMu
@@ -91,6 +93,7 @@ var features = map[FeatureFlag]bool{
 	FasterGetOrderForNames:        false,
 	AllowV1Registration:           true,
 	ParallelCheckFailedValidation: false,
+	DeleteUnusedChallenges:        false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -24,6 +24,7 @@
       ]
     },
     "features": {
+      "DeleteUnusedChallenges": true,
       "FasterGetOrderForNames": true
     }
   },

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -24,6 +24,7 @@
       ]
     },
     "features": {
+      "DeleteUnusedChallenges": true
     }
   },
 

--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -22,7 +22,7 @@ GRANT SELECT,INSERT,UPDATE ON certificateStatus TO 'sa'@'localhost';
 GRANT SELECT,INSERT ON issuedNames TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON certificatesPerName TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON registrations TO 'sa'@'localhost';
-GRANT SELECT,INSERT,UPDATE ON challenges TO 'sa'@'localhost';
+GRANT SELECT,INSERT,UPDATE,DELETE ON challenges TO 'sa'@'localhost';
 GRANT SELECT,INSERT on fqdnSets TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON orders TO 'sa'@'localhost';
 GRANT SELECT,INSERT ON orderToAuthz TO 'sa'@'localhost';

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -984,13 +984,12 @@ def test_delete_unused_challenges():
     for a in order.authorizations:
         if len(a.body.challenges) != 1:
             raise Exception("too many challenges (%d) left after validation", len(a.body.challenges))
-        if not isinstance(a.body.challenges[0], challenges.DNS01):
+        if not isinstance(a.body.challenges[0].chall, challenges.DNS01):
             raise Exception("wrong challenge type left after validation")
 
     # intentionally fail a challenge
-    if client is None:
-        client = chisel2.make_client()
-    csr_pem = chisel2.make_csr(domains)
+    client = chisel2.make_client()
+    csr_pem = chisel2.make_csr([random_domain()])
     order = client.new_order(csr_pem)
     c = get_chall(a, chall_type)
     client.answer_challenge(c, c.response(client.net.key))
@@ -1002,7 +1001,7 @@ def test_delete_unused_challenges():
         if len(a.body.challenges) != 1:
             raise Exception("too many challenges (%d) left after failed validation",
                 len(a.body.challenges))
-        if not isinstance(a.body.challenges[0], challenges.DNS01):
+        if not isinstance(a.body.challenges[0].chall, challenges.DNS01):
             raise Exception("wrong challenge type left after validation")
 
 def run(cmd, **kwargs):


### PR DESCRIPTION
For authzv1, this actually executes a SQL DELETE for the unused challenges
when an authorization is updated upon validation.

For authzv2, this doesn't perform a delete, but changes the authorizations that
are returned so they don't include unused challenges.

In order to test the flag for both authz storage models, I set the feature flag in
both config/ and config-next/.

Fixes #4352