### PR TITLE
Add initial boulder-janitor daemon for tidying certificate resources.

### DIFF
--- a/cmd/boulder-janitor/certs.go
+++ b/cmd/boulder-janitor/certs.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/jmhodges/clock"
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+// newCertificatesJob returns a batchedDBJob configured to delete expired rows
+// from the certificates table.
+func newCertificatesJob(
+	db janitorDB,
+	log blog.Logger,
+	clk clock.Clock,
+	config Config) *batchedDBJob {
+	purgeBefore := clk.Now().Add(-config.Janitor.Certificates.GracePeriod.Duration)
+	workQuery := `
+		 SELECT id FROM certificates
+		 WHERE
+		   id > :startID AND
+		   expires <= :cutoff
+		 ORDER by id
+		 LIMIT :limit`
+	return &batchedDBJob{
+		db:          db,
+		log:         log,
+		purgeBefore: purgeBefore,
+		batchSize:   config.Janitor.Certificates.BatchSize,
+		maxDPS:      config.Janitor.Certificates.MaxDPS,
+		parallelism: config.Janitor.Certificates.Parallelism,
+		table:       "certificates",
+		workQuery:   workQuery,
+	}
+}

--- a/cmd/boulder-janitor/certsPerName.go
+++ b/cmd/boulder-janitor/certsPerName.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/jmhodges/clock"
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+// newCertificatesPerNameJob returns a batchedDBJob configured to delete expired
+// rows from the certificatesPerName table.
+func newCertificatesPerNameJob(
+	db janitorDB,
+	log blog.Logger,
+	clk clock.Clock,
+	config Config) *batchedDBJob {
+	purgeBefore := clk.Now().Add(-config.Janitor.CertificatesPerName.GracePeriod.Duration)
+	workQuery := `SELECT id FROM certificatesPerName
+		 WHERE
+		   id > :startID AND
+		   time <= :cutoff
+		 ORDER by id
+		 LIMIT :limit`
+	log.Debugf("Creating Certificates job from config: %#v\n", config.Janitor.CertificatesPerName)
+	return &batchedDBJob{
+		db:          db,
+		log:         log,
+		purgeBefore: purgeBefore,
+		batchSize:   config.Janitor.CertificatesPerName.BatchSize,
+		maxDPS:      config.Janitor.CertificatesPerName.MaxDPS,
+		parallelism: config.Janitor.CertificatesPerName.Parallelism,
+		table:       "certificatesPerName",
+		workQuery:   workQuery,
+	}
+}

--- a/cmd/boulder-janitor/certstatus.go
+++ b/cmd/boulder-janitor/certstatus.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/jmhodges/clock"
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+// newCertificateStatusJob returns a batchedDBJob configured to delete expired
+// rows from the certificateStatus table.
+func newCertificateStatusJob(
+	db janitorDB,
+	log blog.Logger,
+	clk clock.Clock,
+	config Config) *batchedDBJob {
+	purgeBefore := clk.Now().Add(-config.Janitor.CertificateStatus.GracePeriod.Duration)
+	workQuery := `SELECT id FROM certificateStatus
+		 WHERE
+		   id > :startID AND
+		   notAfter <= :cutoff
+		 ORDER by id
+		 LIMIT :limit`
+	log.Debugf("Creating CertificateStatus job from config: %#v\n", config.Janitor.CertificateStatus)
+	j := &batchedDBJob{
+		db:          db,
+		log:         log,
+		purgeBefore: purgeBefore,
+		batchSize:   config.Janitor.CertificateStatus.BatchSize,
+		maxDPS:      config.Janitor.CertificateStatus.MaxDPS,
+		parallelism: config.Janitor.CertificateStatus.Parallelism,
+		table:       "certificateStatus",
+		workQuery:   workQuery,
+	}
+	return j
+}

--- a/cmd/boulder-janitor/certstatus.go
+++ b/cmd/boulder-janitor/certstatus.go
@@ -20,7 +20,7 @@ func newCertificateStatusJob(
 		 ORDER by id
 		 LIMIT :limit`
 	log.Debugf("Creating CertificateStatus job from config: %#v\n", config.Janitor.CertificateStatus)
-	j := &batchedDBJob{
+	return &batchedDBJob{
 		db:          db,
 		log:         log,
 		purgeBefore: purgeBefore,
@@ -30,5 +30,4 @@ func newCertificateStatusJob(
 		table:       "certificateStatus",
 		workQuery:   workQuery,
 	}
-	return j
 }

--- a/cmd/boulder-janitor/config.go
+++ b/cmd/boulder-janitor/config.go
@@ -72,14 +72,11 @@ type Config struct {
 // Valid checks that each of the cleanup job configurations are valid or returns
 // an error.
 func (c Config) Valid() error {
-	if err := c.Janitor.Certificates.Valid(); err != nil {
-		return err
-	}
-	if err := c.Janitor.CertificateStatus.Valid(); err != nil {
-		return err
-	}
-	if err := c.Janitor.CertificatesPerName.Valid(); err != nil {
-		return err
+	jobConfigs := []CleanupConfig{c.Janitor.Certificates, c.Janitor.CertificateStatus, c.Janitor.CertificatesPerName}
+	for _, cc := range jobConfigs {
+		if err := cc.Valid(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/boulder-janitor/config.go
+++ b/cmd/boulder-janitor/config.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/letsencrypt/boulder/cmd"
+)
+
+// CleanupConfig describes common configuration parameters shared by all cleanup
+// jobs.
+type CleanupConfig struct {
+	// Enabled controls whether the janitor will run this cleanup job.
+	Enabled bool
+	// GracePeriod controls when a resource is old enough to be cleaned up.
+	GracePeriod cmd.ConfigDuration
+	// BatchSize controls how many rows of the resource will be read from the DB
+	// per-query.
+	BatchSize int64
+	// Parallelism controls how many independent go routines will run Delete
+	// statements for old resources being cleaned up.
+	Parallelism int
+	// MaxDPS controls the maximum number of deletes which will be performed
+	// per second in total for the resource's table across all of the parallel go
+	// routines for this resource. This can be used to reduce the replication lag
+	// caused by creating a very large numbers of delete statements.
+	MaxDPS int
+}
+
+var (
+	errInvalidGracePeriod   = errors.New("grace period must be > 0")
+	errInvalidParallelism   = errors.New("parallelism must be > 0")
+	errInvalidNegativeValue = errors.New("no numeric configuration values should be negative")
+)
+
+// Valid checks the cleanup config is valid or returns an error.
+func (c CleanupConfig) Valid() error {
+	if c.GracePeriod.Duration <= 0 {
+		return errInvalidGracePeriod
+	}
+	if c.Parallelism <= 0 {
+		return errInvalidParallelism
+	}
+	if c.BatchSize < 0 || c.MaxDPS < 0 {
+		return errInvalidNegativeValue
+	}
+	return nil
+}
+
+// Config describes the overall Janitor configuration.
+type Config struct {
+	Janitor struct {
+		// Syslog holds common syslog configuration.
+		Syslog cmd.SyslogConfig
+		// DebugAddr controls the bind address for prometheus metrics, etc.
+		DebugAddr string
+		// Features holds potential Feature flags.
+		Features map[string]bool
+		// Common database connection configuration.
+		cmd.DBConfig
+
+		// Certificates describes a cleanup job for the certificates table.
+		Certificates struct {
+			CleanupConfig
+		}
+
+		// CertificateStatus describes a cleanup job for the certificateStatus table.
+		CertificateStatus struct {
+			CleanupConfig
+		}
+
+		// CertificatesPerName describes a cleanup job for the certificatesPerName table.
+		CertificatesPerName struct {
+			CleanupConfig
+		}
+	}
+}
+
+// Valid checks that each of the cleanup job configurations are valid or returns
+// an error.
+func (c Config) Valid() error {
+	if err := c.Janitor.Certificates.Valid(); err != nil {
+		return err
+	}
+	if err := c.Janitor.CertificateStatus.Valid(); err != nil {
+		return err
+	}
+	if err := c.Janitor.CertificatesPerName.Valid(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/boulder-janitor/config.go
+++ b/cmd/boulder-janitor/config.go
@@ -30,6 +30,7 @@ var (
 	errInvalidGracePeriod   = errors.New("grace period must be > 0")
 	errInvalidParallelism   = errors.New("parallelism must be > 0")
 	errInvalidNegativeValue = errors.New("neither BatchSize or MaxDPS may be negative")
+	errEmptyMetricsAddr     = errors.New("metricsAddr must not be empty")
 )
 
 // Valid checks the cleanup config is valid or returns an error.
@@ -72,6 +73,9 @@ type Config struct {
 // Valid checks that each of the cleanup job configurations are valid or returns
 // an error.
 func (c Config) Valid() error {
+	if c.Janitor.DebugAddr == "" {
+		return errEmptyMetricsAddr
+	}
 	jobConfigs := []CleanupConfig{c.Janitor.Certificates, c.Janitor.CertificateStatus, c.Janitor.CertificatesPerName}
 	for _, cc := range jobConfigs {
 		if err := cc.Valid(); err != nil {

--- a/cmd/boulder-janitor/config.go
+++ b/cmd/boulder-janitor/config.go
@@ -59,19 +59,13 @@ type Config struct {
 		cmd.DBConfig
 
 		// Certificates describes a cleanup job for the certificates table.
-		Certificates struct {
-			CleanupConfig
-		}
+		Certificates CleanupConfig
 
 		// CertificateStatus describes a cleanup job for the certificateStatus table.
-		CertificateStatus struct {
-			CleanupConfig
-		}
+		CertificateStatus CleanupConfig
 
 		// CertificatesPerName describes a cleanup job for the certificatesPerName table.
-		CertificatesPerName struct {
-			CleanupConfig
-		}
+		CertificatesPerName CleanupConfig
 	}
 }
 

--- a/cmd/boulder-janitor/config.go
+++ b/cmd/boulder-janitor/config.go
@@ -29,7 +29,7 @@ type CleanupConfig struct {
 var (
 	errInvalidGracePeriod   = errors.New("grace period must be > 0")
 	errInvalidParallelism   = errors.New("parallelism must be > 0")
-	errInvalidNegativeValue = errors.New("no numeric configuration values should be negative")
+	errInvalidNegativeValue = errors.New("neither BatchSize or MaxDPS may be negative")
 )
 
 // Valid checks the cleanup config is valid or returns an error.

--- a/cmd/boulder-janitor/config_test.go
+++ b/cmd/boulder-janitor/config_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestValidCleanupConfig(t *testing.T) {
+	testCases := []struct {
+		name        string
+		config      CleanupConfig
+		expectedErr error
+	}{
+		{
+			name: "invalid grace period",
+			config: CleanupConfig{
+				GracePeriod: cmd.ConfigDuration{Duration: time.Hour * -1},
+			},
+			expectedErr: errInvalidGracePeriod,
+		},
+		{
+			name: "invalid parallelism",
+			config: CleanupConfig{
+				GracePeriod: cmd.ConfigDuration{Duration: time.Hour},
+				Parallelism: 0,
+			},
+			expectedErr: errInvalidParallelism,
+		},
+		{
+			name: "invalid batch sizse",
+			config: CleanupConfig{
+				GracePeriod: cmd.ConfigDuration{Duration: time.Hour},
+				Parallelism: 1,
+				BatchSize:   -1,
+			},
+			expectedErr: errInvalidNegativeValue,
+		},
+		{
+			name: "invalid max DPS",
+			config: CleanupConfig{
+				GracePeriod: cmd.ConfigDuration{Duration: time.Hour},
+				Parallelism: 1,
+				BatchSize:   1,
+				MaxDPS:      -1,
+			},
+			expectedErr: errInvalidNegativeValue,
+		},
+		{
+			name: "valid",
+			config: CleanupConfig{
+				GracePeriod: cmd.ConfigDuration{Duration: time.Hour},
+				Parallelism: 1,
+				BatchSize:   1,
+				MaxDPS:      1,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.config.Valid()
+			test.AssertEquals(t, actual, tc.expectedErr)
+		})
+	}
+}

--- a/cmd/boulder-janitor/janitor.go
+++ b/cmd/boulder-janitor/janitor.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"sync"
+
+	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/features"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/sa"
+)
+
+// janitorDB is an interface describing the two functions of a sql.DB that the
+// janitor uses. It allows easy mocking of the DB for unit tests.
+type janitorDB interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Select(i interface{}, query string, args ...interface{}) ([]interface{}, error)
+}
+
+var (
+	// errNoJobsConfigured is returned from New() when there are no jobs enabled
+	// in the provided Config.
+	errNoJobsConfigured = errors.New("no jobs enabled in configuration")
+)
+
+// janitor is a struct for a long-running cleanup daemon tasked with multiple
+// cleanup jobs.
+type janitor struct {
+	log  blog.Logger
+	clk  clock.Clock
+	db   janitorDB
+	jobs []*batchedDBJob
+}
+
+// New creates a janitor instance from the provided configuration or errors. The
+// janitor will not be running until its Run() function is invoked.
+func New(clk clock.Clock, config Config) (*janitor, error) {
+	if err := config.Valid(); err != nil {
+		return nil, err
+	}
+
+	// Setup logging and stats
+	var logger blog.Logger
+	if config.Janitor.DebugAddr != "" {
+		var scope metrics.Scope
+		scope, logger = cmd.StatsAndLogging(config.Janitor.Syslog, config.Janitor.DebugAddr)
+		scope.MustRegister(deletedStat)
+	} else {
+		logger = cmd.NewLogger(config.Janitor.Syslog)
+	}
+	defer logger.AuditPanic()
+	logger.Info(cmd.VersionString())
+
+	// Create DB Map
+	dbURL, err := config.Janitor.DBConfig.URL()
+	if err != nil {
+		return nil, err
+	}
+	dbMap, err := sa.NewDbMap(dbURL, config.Janitor.DBConfig.MaxDBConns)
+	if err != nil {
+		return nil, err
+	}
+	sa.SetSQLDebug(dbMap, logger)
+
+	// Enable configured feature flags
+	err = features.Set(config.Janitor.Features)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct configured jobs
+	jobs, err := newJobs(dbMap, logger, clk, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &janitor{
+		log:  logger,
+		clk:  clk,
+		db:   dbMap,
+		jobs: jobs,
+	}, nil
+}
+
+// newJobs constructs a list of batchedDBJobs based on the provided config. If
+// no jobs are enabled in the config then errNoJobsConfigured is returned.
+func newJobs(
+	dbMap janitorDB,
+	logger blog.Logger,
+	clk clock.Clock,
+	config Config) ([]*batchedDBJob, error) {
+	var jobs []*batchedDBJob
+	if config.Janitor.CertificateStatus.Enabled {
+		jobs = append(jobs, newCertificateStatusJob(dbMap, logger, clk, config))
+	}
+	if config.Janitor.Certificates.Enabled {
+		jobs = append(jobs, newCertificatesJob(dbMap, logger, clk, config))
+	}
+	if config.Janitor.CertificatesPerName.Enabled {
+		jobs = append(jobs, newCertificatesPerNameJob(dbMap, logger, clk, config))
+	}
+	if len(jobs) == 0 {
+		return nil, errNoJobsConfigured
+	}
+	return jobs, nil
+}
+
+// Run starts the janitor daemon. Each configured job will start running in
+// dedicated go routines. The janitor will block on the completion of these
+// jobs (presently forever).
+func (j *janitor) Run() error {
+	// Run each job and wait for all of them to complete
+	wg := new(sync.WaitGroup)
+	for _, job := range j.jobs {
+		wg.Add(1)
+		go job.RunForever()
+	}
+	wg.Wait()
+	return nil
+}

--- a/cmd/boulder-janitor/janitor.go
+++ b/cmd/boulder-janitor/janitor.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"errors"
-	"sync"
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/cmd"
@@ -104,11 +103,11 @@ func newJobs(
 // dedicated go routines. The janitor will block on the completion of these
 // jobs (presently forever).
 func (j *janitor) Run() {
-	// Run each job and wait for all of them to complete
-	wg := new(sync.WaitGroup)
+	waitChan := make(chan bool)
+	// Run each job
 	for _, job := range j.jobs {
-		wg.Add(1)
 		go job.RunForever()
 	}
-	wg.Wait()
+	// Wait forever
+	<-waitChan
 }

--- a/cmd/boulder-janitor/janitor.go
+++ b/cmd/boulder-janitor/janitor.go
@@ -111,7 +111,7 @@ func newJobs(
 // Run starts the janitor daemon. Each configured job will start running in
 // dedicated go routines. The janitor will block on the completion of these
 // jobs (presently forever).
-func (j *janitor) Run() error {
+func (j *janitor) Run() {
 	// Run each job and wait for all of them to complete
 	wg := new(sync.WaitGroup)
 	for _, job := range j.jobs {
@@ -119,5 +119,4 @@ func (j *janitor) Run() error {
 		go job.RunForever()
 	}
 	wg.Wait()
-	return nil
 }

--- a/cmd/boulder-janitor/janitor.go
+++ b/cmd/boulder-janitor/janitor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
-	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/sa"
 )
 
@@ -48,14 +47,8 @@ func New(clk clock.Clock, config Config) (*janitor, error) {
 	}
 
 	// Setup logging and stats
-	var logger blog.Logger
-	if config.Janitor.DebugAddr != "" {
-		var scope metrics.Scope
-		scope, logger = cmd.StatsAndLogging(config.Janitor.Syslog, config.Janitor.DebugAddr)
-		scope.MustRegister(deletedStat)
-	} else {
-		logger = cmd.NewLogger(config.Janitor.Syslog)
-	}
+	scope, logger := cmd.StatsAndLogging(config.Janitor.Syslog, config.Janitor.DebugAddr)
+	scope.MustRegister(deletedStat)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString())
 

--- a/cmd/boulder-janitor/janitor.go
+++ b/cmd/boulder-janitor/janitor.go
@@ -42,6 +42,11 @@ func New(clk clock.Clock, config Config) (*janitor, error) {
 		return nil, err
 	}
 
+	// Enable configured feature flags
+	if err := features.Set(config.Janitor.Features); err != nil {
+		return nil, err
+	}
+
 	// Setup logging and stats
 	var logger blog.Logger
 	if config.Janitor.DebugAddr != "" {
@@ -64,12 +69,6 @@ func New(clk clock.Clock, config Config) (*janitor, error) {
 		return nil, err
 	}
 	sa.SetSQLDebug(dbMap, logger)
-
-	// Enable configured feature flags
-	err = features.Set(config.Janitor.Features)
-	if err != nil {
-		return nil, err
-	}
 
 	// Construct configured jobs
 	jobs, err := newJobs(dbMap, logger, clk, config)

--- a/cmd/boulder-janitor/janitor_test.go
+++ b/cmd/boulder-janitor/janitor_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jmhodges/clock"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestNewJobs(t *testing.T) {
+	onlyCertStatusConfig := `{
+	"janitor": {
+		"certificates": {
+			"enabled": false
+		},
+		"certificateStatus": {
+			"enabled": true,
+			"gracePeriod": "1h"
+		},
+		"certificatesPerName": {
+			"enabled": false
+		}
+	}
+}`
+	allConfig := `{
+	"janitor": {
+		"certificates": {
+			"enabled": true,
+			"gracePeriod": "1h"
+		},
+		"certificateStatus": {
+			"enabled": true,
+			"gracePeriod": "1h"
+		},
+		"certificatesPerName": {
+			"enabled": true,
+			"gracePeriod": "1h"
+		}
+	}
+}`
+	testCases := []struct {
+		name              string
+		config            string
+		expectedTableJobs []string
+		expectedError     error
+	}{
+		{
+			name:          "no jobs enabled",
+			config:        `{}`,
+			expectedError: errNoJobsConfigured,
+		},
+		{
+			name:              "only certificate status enabled",
+			config:            onlyCertStatusConfig,
+			expectedTableJobs: []string{"certificateStatus"},
+		},
+		{
+			name:              "only certificates enabled",
+			config:            allConfig,
+			expectedTableJobs: []string{"certificates", "certificateStatus", "certificatesPerName"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var config Config
+			err := json.Unmarshal([]byte(tc.config), &config)
+			test.AssertNotError(t, err, "error unmarshaling tc Config")
+
+			jobs, err := newJobs(nil, blog.UseMock(), clock.NewFake(), config)
+			test.AssertEquals(t, err, tc.expectedError)
+
+			var tableMap map[string]bool
+			if err != nil {
+				for _, j := range jobs {
+					tableMap[j.table] = true
+				}
+				for _, expected := range tc.expectedTableJobs {
+					if _, present := tableMap[expected]; !present {
+						t.Errorf("expected batchedDBJob with table %q to be present", expected)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/boulder-janitor/job.go
+++ b/cmd/boulder-janitor/job.go
@@ -59,7 +59,7 @@ type batchedDBJob struct {
 // getWork reads work into the provided work channel starting at the startID by
 // using the batchedDBJob's configured work query, purgeBefore, and batchSize.
 // If there is no error the last primary key ID written to the work channel will
-// be returned, otherwise an error result are returned.
+// be returned, otherwise an error result is returned.
 func (j batchedDBJob) getWork(work chan<- int64, startID int64) (int64, error) {
 	var idBatch []int64
 	_, err := j.db.Select(

--- a/cmd/boulder-janitor/job.go
+++ b/cmd/boulder-janitor/job.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// errStat is a prometheus counter vector tracking the number of errors
-	// experienced by the janitor during operation sliced by a tabel label anda
+	// experienced by the janitor during operation sliced by a tabel label and a
 	// type label. Examples of possible type labels include "getWork" and
 	// "deleteResource".
 	errStat = prometheus.NewCounterVec(

--- a/cmd/boulder-janitor/job.go
+++ b/cmd/boulder-janitor/job.go
@@ -121,7 +121,7 @@ func (j batchedDBJob) cleanResource(work <-chan int64) {
 					<-ticker.C
 				}
 				if err := j.deleteResource(id); err != nil {
-					j.log.AuditErrf(
+					j.log.Errf(
 						"error deleting ID %d from table %q: %s",
 						id, j.table, err)
 					errStat.WithLabelValues(j.table, "deleteResource").Inc()
@@ -163,7 +163,7 @@ func (j batchedDBJob) RunForever() {
 		for {
 			lastID, err := j.getWork(work, id)
 			if err != nil {
-				j.log.AuditErr(err.Error())
+				j.log.Err(err.Error())
 				errStat.WithLabelValues(j.table, "getWork").Inc()
 				time.Sleep(time.Millisecond * 500)
 				continue

--- a/cmd/boulder-janitor/job.go
+++ b/cmd/boulder-janitor/job.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// deletedStat is a prometheus counter vector tracking the number of rows
+	// deleted by the janitor, sliced by a table label.
+	deletedStat = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "janitor_deletions",
+			Help: "Number of deletions by table the boulder-janitor has performed.",
+		},
+		[]string{"table"})
+	// workStat is a prometheus gauge vector tracking the number of rows found
+	// during a batchedJob's getWork stage and queued into the work channel sliced
+	// by a table label.
+	workStat = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "janitor_workbatch",
+			Help: "Number of items of work by table the boulder-janitor queued for deletion.",
+		},
+		[]string{"table"})
+)
+
+// batchedDBJob is a struct abstracting the common properties of a long running
+// cleanup job based on cursoring across a database table's auto incrementing
+// primary key.
+type batchedDBJob struct {
+	db  janitorDB
+	log blog.Logger
+	// table is the name of the table that this job cleans up.
+	table string
+	// purgeBefore indicates the cut-off for the the resoruce being cleaned up by
+	// the job. Rows that older than now - purgeBefore are deleted.
+	purgeBefore time.Time
+	// batchSize indicates how many database rows of work should be returned per query.
+	batchSize int64
+	// maxDPS optionally indicates a maximum rate of deletes to run per second.
+	maxDPS int
+	// parallelism controls how many independent go routines will be performing
+	// cleanup deletes.
+	parallelism int
+	// workQuery is the parameterized SQL query that is used to find more work. It will be provided three parameters:
+	//   * :startID - the primary key value to start the work query from.
+	//   * :cutoff  - the purgeBefore date used to control which rows are old enough to be deleted.
+	//   * :limit   - the batchSize value. Only this many rows should be returned by the query.
+	workQuery string
+}
+
+// getWork reads work into the provided work channel starting at the startID by
+// using the batchedDBJob's configured work query, purgeBefore, and batchSize.
+// If there is no error the last primary key ID written to the work channel will
+// be returned, otherwise an error result are returned.
+func (j batchedDBJob) getWork(work chan<- int64, startID int64) (int64, error) {
+	var idBatch []int64
+	_, err := j.db.Select(
+		&idBatch,
+		j.workQuery,
+		map[string]interface{}{
+			"startID": startID,
+			"cutoff":  j.purgeBefore,
+			"limit":   j.batchSize,
+		},
+	)
+	if err != nil && err != sql.ErrNoRows {
+		return 0, err
+	}
+	rowsFound := len(idBatch)
+	workStat.WithLabelValues(j.table).Set(float64(rowsFound))
+	if rowsFound == 0 {
+		return startID, nil
+	}
+	var lastID int64
+	for _, v := range idBatch {
+		work <- v
+		lastID = v
+	}
+	return lastID, nil
+}
+
+// cleanResource uses the configured level of parallelism to run go routines
+// that read ID values from the work channel and delete the corresponding table
+// rows. If the batchedDBJob configures a maxDPS rate then it will be enforced by
+// synchronizing the delete operations on a ticker based on the maxDPS.
+// cleanResource will block until all of the worker go routines complete.
+func (j batchedDBJob) cleanResource(work <-chan int64) {
+	wg := new(sync.WaitGroup)
+	deleted := int64(0)
+
+	var ticker *time.Ticker
+	if j.maxDPS > 0 {
+		ticker = time.NewTicker(
+			time.Duration(float64(time.Second) / float64(j.maxDPS)))
+	}
+
+	for i := 0; i < j.parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for id := range work {
+				if ticker != nil {
+					<-ticker.C
+				}
+				if err := j.deleteResource(id); err != nil {
+					j.log.AuditErrf(
+						"error deleting ID %d from table %q: %s",
+						id, j.table, err)
+				}
+				_ = atomic.AddInt64(&deleted, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	j.log.Infof(
+		"deleted a total of %d rows from table %q",
+		deleted, j.table)
+}
+
+// deleteResource peforms a delete of the given ID from the batchedDBJob's
+// table or returns an error.
+func (j batchedDBJob) deleteResource(id int64) error {
+	// NOTE(@cpu): We throw away the sql.Result here without checking the rows
+	// affected because the query is always specific to the ID auto-increment
+	// primary key. If there are multiple rows with the same primary key MariaDB
+	// has failed us deeply.
+	query := fmt.Sprintf(`DELETE FROM %s WHERE id = ?`, j.table)
+	if _, err := j.db.Exec(query, id); err != nil {
+		return err
+	}
+	j.log.Debugf("deleted ID %d in table %q", id, j.table)
+	deletedStat.WithLabelValues(j.table).Inc()
+	return nil
+}
+
+// RunForever starts a go routine that will run forever getting work with
+// getWork and deleting rows with cleanResource.
+func (j batchedDBJob) RunForever() {
+	var id int64
+	work := make(chan int64)
+
+	go func() {
+		for {
+			lastID, err := j.getWork(work, id)
+			if err != nil {
+				j.log.AuditErr(err.Error())
+				time.Sleep(time.Millisecond * 500)
+				continue
+			} else if lastID == id {
+				j.log.Debugf(
+					"made no new progress on table %q. Sleeping for a minute",
+					j.table)
+				time.Sleep(time.Minute)
+			}
+			id = lastID
+		}
+	}()
+
+	j.cleanResource(work)
+}

--- a/cmd/boulder-janitor/job.go
+++ b/cmd/boulder-janitor/job.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// errStat is a prometheus counter vector tracking the number of errors
-	// experienced by the janitor during operation sliced by a tabel label and a
+	// experienced by the janitor during operation sliced by a table label and a
 	// type label. Examples of possible type labels include "getWork" and
 	// "deleteResource".
 	errStat = prometheus.NewCounterVec(

--- a/cmd/boulder-janitor/job_test.go
+++ b/cmd/boulder-janitor/job_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/test"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func setup() (*blog.Mock, clock.Clock) {
+	return blog.UseMock(), clock.NewFake()
+}
+
+type mockDB struct {
+	t               *testing.T
+	expectedQuery   string
+	expectedArgMap  map[string]interface{}
+	selectResult    []int64
+	expectedExecArg int64
+	execResult      sql.Result
+	errResult       error
+}
+
+func (m mockDB) Exec(query string, args ...interface{}) (sql.Result, error) {
+	test.AssertEquals(m.t, query, m.expectedQuery)
+
+	if len(args) < 1 {
+		m.t.Fatal("Exec() had no args")
+	} else if idArg, ok := args[0].(int64); !ok {
+		m.t.Fatalf("Select()'s args[0] was %T not int64", args[0])
+	} else {
+		test.AssertEquals(m.t, idArg, m.expectedExecArg)
+	}
+
+	return m.execResult, m.errResult
+}
+
+func (m mockDB) Select(result interface{}, query string, args ...interface{}) ([]interface{}, error) {
+	test.AssertEquals(m.t, query, m.expectedQuery)
+
+	if len(args) < 1 {
+		m.t.Fatal("Select() had no args")
+	} else if argMap, ok := args[0].(map[string]interface{}); !ok {
+		m.t.Fatalf("Select()'s args[0] was %T not map[string]interface{}", args[0])
+	} else {
+		test.AssertDeepEquals(m.t, argMap, m.expectedArgMap)
+	}
+
+	if idResults, ok := result.(*[]int64); !ok {
+		m.t.Fatalf("Select()'s result target pointer was %T not []int64", result)
+	} else {
+		for _, id := range m.selectResult {
+			*idResults = append(*idResults, id)
+		}
+	}
+
+	return nil, m.errResult
+}
+
+func TestGetWork(t *testing.T) {
+	log, clk := setup()
+	startID := int64(10)
+	table := "certificates"
+	purgeBefore := clk.Now().Add(-time.Hour)
+	batchSize := int64(20)
+	workQuery := `SELECT id FROM certificates WHERE id > :startID AND time <= :cutoff ORDER by id LIMIT :limit`
+	mockIDs := []int64{
+		1,
+		2,
+		3,
+		10,
+		90,
+	}
+
+	testDB := &mockDB{
+		t:             t,
+		expectedQuery: workQuery,
+		expectedArgMap: map[string]interface{}{
+			"startID": startID,
+			"cutoff":  purgeBefore,
+			"limit":   batchSize,
+		},
+	}
+
+	workChan := make(chan int64)
+
+	job := &batchedDBJob{
+		db:          testDB,
+		log:         log,
+		table:       table,
+		purgeBefore: purgeBefore,
+		batchSize:   batchSize,
+		workQuery:   workQuery,
+	}
+
+	// Mock Select() to return a non-nil error result
+	testDB.errResult = errors.New("database is on vacation")
+	_, err := job.getWork(workChan, startID)
+	// We expect to get back an error
+	test.AssertError(t, err, "no error returned from getWork with bad DB")
+
+	// Mock Select() to return good results and a nil error
+	testDB.errResult = nil
+	testDB.selectResult = mockIDs
+
+	// Start a go routine to read the work channel results
+	go func() {
+		// We should be able to read one item per mockID and it should match the expected ID
+		for i := 0; i < len(mockIDs); i++ {
+			got := <-workChan
+			test.AssertEquals(t, got, mockIDs[i])
+		}
+	}()
+
+	// We expect to get back no error and the correct lastID
+	lastID, err := job.getWork(workChan, startID)
+	test.AssertEquals(t, lastID, mockIDs[len(mockIDs)-1])
+
+	// We expect the work gauge for this table has been updated
+	workCount, err := test.GaugeValueWithLabels(workStat, prometheus.Labels{"table": table})
+	test.AssertNotError(t, err, "unexpected error from GaugeValueWithLabels")
+	test.AssertEquals(t, workCount, len(mockIDs))
+}
+
+func TestDeleteResource(t *testing.T) {
+	log, _ := setup()
+	table := "certificates"
+
+	testID := int64(1)
+
+	testDB := &mockDB{
+		t:               t,
+		expectedQuery:   "DELETE FROM certificates WHERE id = ?",
+		expectedExecArg: testID,
+	}
+
+	job := &batchedDBJob{
+		db:    testDB,
+		log:   log,
+		table: table,
+	}
+
+	// Mock Exec() to return a non-nil error result
+	testDB.errResult = errors.New("database is on vacation")
+	err := job.deleteResource(testID)
+	// We expect an err result back
+	test.AssertError(t, err, "no error returned from deleteResource with bad DB")
+	// We expect no deletes to have been tracked in the deletedStat
+	test.AssertEquals(t, test.CountCounterVec("table", "certificates", deletedStat), 0)
+
+	// With the mock error removed we expect no error returned from deleteResource
+	testDB.errResult = nil
+	err = job.deleteResource(testID)
+	// We expect a delete to have been tracked in the deletedStat
+	test.AssertEquals(t, test.CountCounterVec("table", "certificates", deletedStat), 1)
+}
+
+type slowDB struct{}
+
+func (db slowDB) Exec(_ string, _ ...interface{}) (sql.Result, error) {
+	time.Sleep(time.Second)
+	return nil, nil
+}
+
+func (db slowDB) Select(result interface{}, _ string, _ ...interface{}) ([]interface{}, error) {
+	return nil, nil
+}
+
+func TestCleanResource(t *testing.T) {
+	log, _ := setup()
+
+	// Use a DB that always sleeps for 1 second for each Exec()'d delete.
+	db := slowDB{}
+
+	job := batchedDBJob{
+		db:    db,
+		log:   log,
+		table: "example",
+		// Start with a parallelism of 1
+		parallelism: 1,
+	}
+
+	busyWork := func() <-chan int64 {
+		work := make(chan int64, 2)
+		work <- 1
+		work <- 2
+		close(work)
+		return work
+	}
+
+	// Create some work without blocking the test go routine
+	work := busyWork()
+
+	// Run cleanResource and track the elapsed time
+	start := time.Now()
+	job.cleanResource(work)
+	elapsed := time.Since(start)
+
+	// With a parallelism of 1 and a sleep of 1 second per delete it should take
+	// more than 1 second to delete both IDs in the work channel
+	test.Assert(t,
+		elapsed >= time.Second,
+		fmt.Sprintf("expected parallelism of 1 to take longer than 1 second to delete two rows, took %s", elapsed))
+
+	// Both rows should have been deleted
+	expectedLog := `deleted a total of 2 rows from table "example"`
+	matches := log.GetAllMatching(expectedLog)
+	test.AssertEquals(t, len(matches), 1)
+
+	// Increase the parallelism
+	job.parallelism = 2
+	// Recreate the work channel
+	work = busyWork()
+	// Clear the log
+	log.Clear()
+
+	// Run cleanResource again and track the elapsed time
+	start = time.Now()
+	job.cleanResource(work)
+	elapsed = time.Since(start)
+
+	// With a parallelism of 2 and a sleep of 1 second per delete it should take
+	// less than 1 second to delete both IDs in the work channel
+	test.Assert(t,
+		elapsed <= time.Second+(time.Millisecond*500),
+		fmt.Sprintf("expected parallelism of 2 to take less than 1 second to delete two rows, took %s", elapsed))
+
+	// Both rows should have been deleted
+	matches = log.GetAllMatching(expectedLog)
+	test.AssertEquals(t, len(matches), 1)
+
+	// Introduce a low max DPS to the job
+	job.maxDPS = 1
+	// Recreate the work channel
+	work = busyWork()
+	// Clear the log
+	log.Clear()
+
+	// Run cleanResource again and track the elapsed time
+	start = time.Now()
+	job.cleanResource(work)
+	elapsed = time.Since(start)
+
+	// With the maxDPS of 1 the parallelism of 2 should be limited such that it
+	// will take more than 1 second to delete both IDs in the work channel once
+	// again.
+	test.Assert(t,
+		elapsed >= time.Second,
+		fmt.Sprintf("expected parallelism of 2 with max DPS 1 to take longer than 1 second to delete two rows, took %s", elapsed))
+
+	// Both rows should have been deleted
+	matches = log.GetAllMatching(expectedLog)
+	test.AssertEquals(t, len(matches), 1)
+}

--- a/cmd/boulder-janitor/job_test.go
+++ b/cmd/boulder-janitor/job_test.go
@@ -120,6 +120,7 @@ func TestGetWork(t *testing.T) {
 
 	// We expect to get back no error and the correct lastID
 	lastID, err := job.getWork(workChan, startID)
+	test.AssertNotError(t, err, "unexpected error from getWork")
 	test.AssertEquals(t, lastID, mockIDs[len(mockIDs)-1])
 
 	// We expect the work gauge for this table has been updated
@@ -157,6 +158,7 @@ func TestDeleteResource(t *testing.T) {
 	// With the mock error removed we expect no error returned from deleteResource
 	testDB.errResult = nil
 	err = job.deleteResource(testID)
+	test.AssertNotError(t, err, "unexpected error from deleteResource")
 	// We expect a delete to have been tracked in the deletedStat
 	test.AssertEquals(t, test.CountCounterVec("table", "certificates", deletedStat), 1)
 }

--- a/cmd/boulder-janitor/main.go
+++ b/cmd/boulder-janitor/main.go
@@ -22,6 +22,5 @@ func main() {
 	j, err := New(cmd.Clock(), config)
 	cmd.FailOnError(err, "Failed to build janitor with config")
 
-	err = j.Run()
-	cmd.FailOnError(err, "Failed to run janitor")
+	j.Run()
 }

--- a/cmd/boulder-janitor/main.go
+++ b/cmd/boulder-janitor/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+
+	"github.com/letsencrypt/boulder/cmd"
+)
+
+func main() {
+	configPath := flag.String("config", "config.json", "Path to boulder-janitor configuration file")
+	flag.Parse()
+
+	configJSON, err := ioutil.ReadFile(*configPath)
+	cmd.FailOnError(err, "Failed to read config file")
+
+	var config Config
+	err = json.Unmarshal(configJSON, &config)
+	cmd.FailOnError(err, "Failed to parse JSON config")
+
+	j, err := New(cmd.Clock(), config)
+	cmd.FailOnError(err, "Failed to build janitor with config")
+
+	err = j.Run()
+	cmd.FailOnError(err, "Failed to run janitor")
+}

--- a/cmd/boulder-janitor/main_test.go
+++ b/cmd/boulder-janitor/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/boulder-janitor/main_test.go
+++ b/cmd/boulder-janitor/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/test/config-next/janitor.json
+++ b/test/config-next/janitor.json
@@ -1,0 +1,31 @@
+{
+  "janitor": {
+    "syslog": {
+      "stdoutLevel": 7
+    },
+    "dbConnectFile": "test/secrets/janitor_dburl",
+    "maxDBConns": 10,
+    "debugAddr": ":8014",
+    "certificates": {
+        "enabled": true,
+        "gracePeriod": "1h",
+        "batchSize": 10,
+        "parallelism": 2,
+        "maxDPS": 1
+    },
+    "certificateStatus": {
+        "enabled": true,
+        "gracePeriod": "1h",
+        "batchSize": 10,
+        "parallelism": 2,
+        "maxDPS": 1
+    },
+    "certificatesPerName": {
+        "enabled": true,
+        "gracePeriod": "1h",
+        "batchSize": 10,
+        "parallelism": 2,
+        "maxDPS": 1
+    }
+  }
+}

--- a/test/sa_db_users.sql
+++ b/test/sa_db_users.sql
@@ -12,6 +12,7 @@ CREATE USER IF NOT EXISTS 'cert_checker'@'localhost';
 CREATE USER IF NOT EXISTS 'ocsp_update'@'localhost';
 CREATE USER IF NOT EXISTS 'test_setup'@'localhost';
 CREATE USER IF NOT EXISTS 'purger'@'localhost';
+CREATE USER IF NOT EXISTS 'janitor'@'localhost';
 
 -- Storage Authority
 GRANT SELECT,INSERT,UPDATE ON authz TO 'sa'@'localhost';
@@ -56,6 +57,12 @@ GRANT SELECT,DELETE ON pendingAuthorizations TO 'purger'@'localhost';
 GRANT SELECT,DELETE ON authz TO 'purger'@'localhost';
 GRANT SELECT,DELETE ON challenges TO 'purger'@'localhost';
 GRANT SELECT,DELETE ON authz2 TO 'purger'@'localhost';
+
+-- Janitor
+GRANT SELECT,DELETE ON certificates TO 'janitor'@'localhost';
+GRANT SELECT,DELETE ON certificateStatus TO 'janitor'@'localhost';
+GRANT SELECT,DELETE ON certificatesPerName TO 'janitor'@'localhost';
+GRANT SELECT,DELETE ON sctReceipts TO 'janitor'@'localhost';
 
 -- Test setup and teardown
 GRANT ALL PRIVILEGES ON * to 'test_setup'@'localhost';

--- a/test/secrets/janitor_dburl
+++ b/test/secrets/janitor_dburl
@@ -1,0 +1,1 @@
+janitor@tcp(boulder-mysql:3306)/boulder_sa_integration


### PR DESCRIPTION
A new `boulder-janitor` command is added that provides a long-running daemon that cleans up rows associated with expired resources based on cursoring by an auto-incrementing primary key. 

At present the janitor cleans rows from the following tables:

* `certificates`
* `certificateStatus`
* `certificatesPerName`

Adding cleanup of tables associated with Order resources is the next step.

Three prometheus stats are exported:

1. `janitor_deletions` - `CounterVec` for the number of deletions by table the boulder-janitor has performed.
2. `janitor_workbatch` - `GaugeVec` for the number of items of work by table the boulder-janitor queued for deletion.
3. `janitor_errors` - `CounterVec` for the number of errors by table and error type the boulder-janitor has experienced.

Integration tests are a WIP. I'm putting this up for review without them since its a fairly large diff already. I think we should block actual deployment of the tool on integration tests landing. If folks would rather delay merging this until the integration tests are ready I'm also open to that.

Updates https://github.com/letsencrypt/boulder/issues/4181