### PR TITLE
Report the correct identifier when there are suberrors

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -329,7 +329,10 @@ func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentif
 	for _, ident := range idents {
 		if err := pa.willingToIssueWildcard(ident); err != nil {
 			if firstBadIdent == nil {
-				firstBadIdent = &ident
+				// Make a copy of ident so that the pointer doesn't get
+				// overwritten when for for loop iterates
+				identCopy := ident
+				firstBadIdent = &identCopy
 			}
 			if bErr, ok := err.(*berrors.BoulderError); ok {
 				subErrors = append(subErrors, berrors.SubBoulderError{

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -325,15 +325,8 @@ func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 // to the rejected identifiers will be returned.
 func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
 	var subErrors []berrors.SubBoulderError
-	var firstBadIdent *identifier.ACMEIdentifier
 	for _, ident := range idents {
 		if err := pa.willingToIssueWildcard(ident); err != nil {
-			if firstBadIdent == nil {
-				// Make a copy of ident so that the pointer doesn't get
-				// overwritten when for for loop iterates
-				identCopy := ident
-				firstBadIdent = &identCopy
-			}
 			if bErr, ok := err.(*berrors.BoulderError); ok {
 				subErrors = append(subErrors, berrors.SubBoulderError{
 					Identifier:   ident,
@@ -361,7 +354,7 @@ func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentif
 
 		detail := fmt.Sprintf(
 			"Cannot issue for %q: %s (and %d more problems. Refer to sub-problems for more information.)",
-			firstBadIdent.Value,
+			subErrors[0].Identifier.Value,
 			subErrors[0].BoulderError.Detail,
 			len(subErrors)-1,
 		)

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -327,12 +327,14 @@ func TestWillingToIssueWildcards(t *testing.T) {
 	err = pa.SetHostnamePolicyFile(f.Name())
 	test.AssertNotError(t, err, "Couldn't load policy contents from file")
 
-	badIdentifiers := []identifier.ACMEIdentifier{
+	idents := []identifier.ACMEIdentifier{
+		identifier.DNSIdentifier("perfectly-fine.com"),
 		identifier.DNSIdentifier("letsdecrypt.org"),
 		identifier.DNSIdentifier("ok.*.this.is.a.*.weird.one.com"),
+		identifier.DNSIdentifier("also-perfectly-fine.com"),
 	}
 
-	err = pa.WillingToIssueWildcards(badIdentifiers)
+	err = pa.WillingToIssueWildcards(idents)
 	test.AssertError(t, err, "Expected err from WillingToIssueWildcards")
 
 	berr, ok := err.(*berrors.BoulderError)

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -338,7 +338,7 @@ func TestWillingToIssueWildcards(t *testing.T) {
 	berr, ok := err.(*berrors.BoulderError)
 	test.AssertEquals(t, ok, true)
 	test.AssertEquals(t, len(berr.SubErrors), 2)
-	test.AssertEquals(t, berr.Error(), "Cannot issue for \"ok.*.this.is.a.*.weird.one.com\": Policy forbids issuing for name (and 1 more problems. Refer to sub-problems for more information.)")
+	test.AssertEquals(t, berr.Error(), "Cannot issue for \"letsdecrypt.org\": Policy forbids issuing for name (and 1 more problems. Refer to sub-problems for more information.)")
 
 	subErrMap := make(map[string]berrors.SubBoulderError, len(berr.SubErrors))
 

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -961,7 +961,7 @@ def test_new_order_policy_errs():
         ok = True
         if e.typ != "urn:ietf:params:acme:error:rejectedIdentifier":
             raise(Exception('Expected rejectedIdentifier type problem, got {0}'.format(e.typ)))
-        if e.detail != 'Error creating new order :: Cannot issue for "out-addr.in-addr.arpa": Policy forbids issuing for name (and 1 more problems. Refer to sub-problems for more information.)':
+        if e.detail != 'Error creating new order :: Cannot issue for "between-addr.in-addr.arpa": Policy forbids issuing for name (and 1 more problems. Refer to sub-problems for more information.)':
             raise(Exception('Order problem detail did not match expected'))
     if not ok:
         raise Exception('Expected problem, got no error')


### PR DESCRIPTION
Turns out the test was already flagging this issue.

Fixes #4356.