### PR TITLE
sa: wrap transactions in a function for commits/rollbacks

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -241,7 +241,10 @@ func (ssa *SQLStorageAuthority) GetAuthorization(ctx context.Context, id string)
 	if overallError != nil {
 		return core.Authorization{}, overallError
 	}
-	return authz.(core.Authorization), nil
+	if authz, ok := authz.(core.Authorization); ok {
+		return authz, nil
+	}
+	return core.Authorization{}, fmt.Errorf("shouldn't happen: casting error in GetAuthorization")
 }
 
 // GetValidAuthorizations returns the latest authorization object for all
@@ -581,7 +584,10 @@ func (ssa *SQLStorageAuthority) NewPendingAuthorization(ctx context.Context, aut
 	if overallError != nil {
 		return core.Authorization{}, overallError
 	}
-	return output.(core.Authorization), nil
+	if output, ok := output.(core.Authorization); ok {
+		return output, nil
+	}
+	return core.Authorization{}, fmt.Errorf("shouldn't happen: casting error in NewPendingAuthorization")
 }
 
 // GetPendingAuthorization returns the most recent Pending authorization

--- a/sa/transaction.go
+++ b/sa/transaction.go
@@ -14,22 +14,26 @@ type transaction interface {
 	Update(...interface{}) (int64, error)
 }
 
-type txFunc func(transaction) error
+// txFunc represents a function that does work in the context of a transaction.
+type txFunc func(transaction) (interface{}, error)
 
 // withTransaction runs the given function in a transaction, rolling back if it
 // returns an error and committing if not. The provided context is also attached
-// to the transaction. Because `f` only accepts a transaction as an argument, it
-// is expected that it will be a closure, with additional inputs and outputs
-// coming from the outer function.
-func withTransaction(ctx context.Context, dbMap *gorp.DbMap, f txFunc) error {
+// to the transaction. withTransaction also passes through a value returned by
+// `f`, if there is no error.
+func withTransaction(ctx context.Context, dbMap *gorp.DbMap, f txFunc) (interface{}, error) {
 	tx, err := dbMap.Begin()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	txWithCtx := tx.WithContext(ctx)
-	err = f(txWithCtx)
+	result, err := f(txWithCtx)
 	if err != nil {
-		return Rollback(tx, err)
+		return nil, Rollback(tx, err)
 	}
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/sa/transaction.go
+++ b/sa/transaction.go
@@ -1,0 +1,35 @@
+package sa
+
+import (
+	"golang.org/x/net/context"
+	"gopkg.in/go-gorp/gorp.v2"
+)
+
+type transaction interface {
+	dbOneSelector
+	dbInserter
+	dbSelectExecer
+	Delete(...interface{}) (int64, error)
+	Get(interface{}, ...interface{}) (interface{}, error)
+	Update(...interface{}) (int64, error)
+}
+
+type txFunc func(transaction) error
+
+// withTransaction runs the given function in a transaction, rolling back if it
+// returns an error and committing if not. The provided context is also attached
+// to the transaction. Because `f` only accepts a transaction as an argument, it
+// is expected that it will be a closure, with additional inputs and outputs
+// coming from the outer function.
+func withTransaction(ctx context.Context, dbMap *gorp.DbMap, f txFunc) error {
+	tx, err := dbMap.Begin()
+	if err != nil {
+		return err
+	}
+	txWithCtx := tx.WithContext(ctx)
+	err = f(txWithCtx)
+	if err != nil {
+		return Rollback(tx, err)
+	}
+	return tx.Commit()
+}

--- a/sa/transaction.go
+++ b/sa/transaction.go
@@ -1,7 +1,7 @@
 package sa
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"gopkg.in/go-gorp/gorp.v2"
 )
 


### PR DESCRIPTION
In the current SA code, we need to remember to call `Rollback` on any error.
If we don't, we'll leave dangling transactions, which are hard to spot but eventually
clog up the database and cause availability problems.

This change attempts to deal with rollbacks more rigorously, by implementing a
`withTransaction` function that takes a closure as input. `withTransaction` opens
a transaction, applies a `context.Context` to it, and then runs the closure. If the
closure returns an error, `withTransaction` rolls back and return the error; otherwise
it commits and returns nil.

One of the quirks of this implementation is that it relies on the closure modifying
variables from its parent scope in order to return values. An alternate implementation
could define the return value of the closure as `interface{}, nil`, and have the calling
function do a type assertion. I'm seeking feedback on that; not sure yet which is cleaner.

This is a subset of the functions that need this treatment. I've got more coming, but
some of the changes break tests so I'm checking into why.

Updates #4337

Reminder to reviewers: Append `?w=1` to the diff URL in order to ignore whitespace.