### PR TITLE
Log the Origin header.

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -23,13 +23,15 @@ type RequestEvent struct {
 	Latency   float64 `json:"-"`
 	RealIP    string  `json:"-"`
 
-	Slug           string                 `json:",omitempty"`
-	InternalErrors []string               `json:",omitempty"`
-	Error          string                 `json:",omitempty"`
-	Contacts       []string               `json:",omitempty"`
-	UserAgent      string                 `json:"ua,omitempty"`
-	Payload        string                 `json:",omitempty"`
-	Extra          map[string]interface{} `json:",omitempty"`
+	Slug           string   `json:",omitempty"`
+	InternalErrors []string `json:",omitempty"`
+	Error          string   `json:",omitempty"`
+	Contacts       []string `json:",omitempty"`
+	UserAgent      string   `json:"ua,omitempty"`
+	// Origin is sent by the browser from XHR-based clients.
+	Origin  string                 `json:",omitempty"`
+	Payload string                 `json:",omitempty"`
+	Extra   map[string]interface{} `json:",omitempty"`
 
 	// For endpoints that create objects, the ID of the newly created object.
 	Created string `json:",omitempty"`
@@ -95,6 +97,7 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RealIP:    realIP,
 		Method:    r.Method,
 		UserAgent: r.Header.Get("User-Agent"),
+		Origin:    r.Header.Get("Origin"),
 		Extra:     make(map[string]interface{}, 0),
 	}
 

--- a/web/context_test.go
+++ b/web/context_test.go
@@ -54,3 +54,19 @@ func TestStatusCodeLogging(t *testing.T) {
 			expected, strings.Join(mockLog.GetAllMatching(".*"), "\n"))
 	}
 }
+
+func TestOrigin(t *testing.T) {
+	mockLog := blog.UseMock()
+	th := NewTopHandler(mockLog, myHandler{})
+	req, err := http.NewRequest("GET", "/thisisignored", &bytes.Reader{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Origin", "https://example.com")
+	th.ServeHTTP(httptest.NewRecorder(), req)
+	expected := `INFO: GET /endpoint 0 201 0 0.0.0.0 JSON={.*"Origin":"https://example.com"}`
+	if 1 != len(mockLog.GetAllMatching(expected)) {
+		t.Errorf("Expected exactly one log line matching %q. Got \n%s",
+			expected, strings.Join(mockLog.GetAllMatching(".*"), "\n"))
+	}
+}


### PR DESCRIPTION
XHR requests from web-based ACME clients provide the User-Agent
of the browser that initiated the request, but the hostname of the site
that originated the request is sent in the Origin header. This will let
us better analyze web-based ACME traffic.

Fixes #4370 