### PR TITLE
Add authorization deactivation integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.12}:2019-04-08
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.12}:2019-07-31
         environment:
             FAKE_DNS: 10.77.77.77
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -55,7 +55,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.12}:2019-04-08
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.12}:2019-07-31
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -77,7 +77,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.12}:2019-04-08
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.12}:2019-07-31
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -50,7 +50,7 @@ go get \
 git clone https://github.com/certbot/certbot /certbot
 cd /certbot
 ./letsencrypt-auto --os-packages-only
-./tools/venv3.py
+./tools/venv.py
 cd -
 
 # Install pkcs11-proxy. Checked out commit was master HEAD at time

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -15,7 +15,7 @@ import chisel
 from chisel import auth_and_issue
 from helpers import *
 
-from acme import challenges
+from acme import challenges, messages
 
 import OpenSSL
 
@@ -611,3 +611,10 @@ def test_sct_embedding():
         if abs(delta) > datetime.timedelta(hours=1):
             raise Exception("Delta between SCT timestamp and now was too great "
                 "%s vs %s (%s)" % (sct.timestamp, datetime.datetime.now(), delta))
+
+def test_auth_deactivation():
+    client = chisel.make_client(None)
+    auth = client.request_domain_challenges(random_domain())
+    resp = client.deactivate_authorization(auth)
+    if resp.body.status is not messages.STATUS_DEACTIVATED:
+        raise Exception("unexpected authorization status")

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -618,3 +618,8 @@ def test_auth_deactivation():
     resp = client.deactivate_authorization(auth)
     if resp.body.status is not messages.STATUS_DEACTIVATED:
         raise Exception("unexpected authorization status")
+
+    _, auth = auth_and_issue([random_domain()], client=client)
+    resp = client.deactivate_authorization(auth[0])
+    if resp.body.status is not messages.STATUS_DEACTIVATED:
+        raise Exception("unexpected authorization status")

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1010,5 +1010,10 @@ def test_auth_deactivation_v2():
     if resp.body.status is not messages.STATUS_DEACTIVATED:
         raise Exception("unexpected authorization status")
 
+    order = chisel2.auth_and_issue([random_domain()], client=client)
+    resp = client.deactivate_authorization(order.authorizations[0])
+    if resp.body.status is not messages.STATUS_DEACTIVATED:
+        raise Exception("unexpected authorization status")
+
 def run(cmd, **kwargs):
     return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, **kwargs)

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1002,5 +1002,13 @@ def test_delete_unused_challenges():
     if not isinstance(a.body.challenges[0].chall, challenges.DNS01):
         raise Exception("wrong challenge type left after validation")
 
+def test_auth_deactivation_v2():
+    client = chisel2.make_client(None)
+    csr_pem = chisel2.make_csr([random_domain()])
+    order = client.new_order(csr_pem)
+    resp = client.deactivate_authorization(order.authorizations[0])
+    if resp.body.status is not messages.STATUS_DEACTIVATED:
+        raise Exception("unexpected authorization status")
+
 def run(cmd, **kwargs):
     return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, **kwargs)


### PR DESCRIPTION
Required a new boulder-tools, which also required reverting the `./tools/venv3.py` change, which never made it into an actual image as it broke a bunch of stuff (see all the python3 changes/reverts for context).

Fixes #4365.