### PR TITLE
deps: update github.com/zmap/zlint to latest.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/weppos/publicsuffix-go v0.5.1-0.20190725085804-8ac7722bc7d7
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e
-	github.com/zmap/zlint v0.0.0-20190730215301-9971d62266e7
+	github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2
 	golang.org/x/sys v0.0.0-20190416152802-12500544f89f // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/zmap/zlint v0.0.0-20190730153040-757a6bf54dd7 h1:mvNjPKT3lstwA+1K5S/2
 github.com/zmap/zlint v0.0.0-20190730153040-757a6bf54dd7/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
 github.com/zmap/zlint v0.0.0-20190730215301-9971d62266e7 h1:iK6SvWuIShUZhWlpL2F+nlm8RX7M9h+ZT3MkjCKi4zs=
 github.com/zmap/zlint v0.0.0-20190730215301-9971d62266e7/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
+github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5 h1:dCxao24v0jzeVy0/c4qfKvcgR9yvZQ7NEcBjoTgxKRc=
+github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -79,7 +79,6 @@
             "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
             "lint_error_level": "pass",
             "ignored_lints": [
-              "ct_sct_policy_count_unsatisfied",
               "n_subject_common_name_included"
             ]
           },
@@ -121,7 +120,6 @@
             "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
             "lint_error_level": "pass",
             "ignored_lints": [
-              "ct_sct_policy_count_unsatisfied",
               "n_subject_common_name_included"
             ]
           }

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -80,7 +80,6 @@
             "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
             "lint_error_level": "pass",
             "ignored_lints": [
-              "ct_sct_policy_count_unsatisfied",
               "n_subject_common_name_included"
             ]
           },
@@ -122,7 +121,6 @@
             "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
             "lint_error_level": "pass",
             "ignored_lints": [
-              "ct_sct_policy_count_unsatisfied",
               "n_subject_common_name_included"
             ]
           }

--- a/vendor/github.com/zmap/zlint/lints/lint_ct_sct_policy_count_unsatisfied.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_ct_sct_policy_count_unsatisfied.go
@@ -30,9 +30,11 @@ func (l *sctPolicyCount) Initialize() error {
 	return nil
 }
 
-// CheckApplies returns true for any subscriber certificates.
+// CheckApplies returns true for any subscriber certificates that are not
+// precertificates (e.g. that do not have the CT poison extension defined in RFC
+// 6962.
 func (l *sctPolicyCount) CheckApplies(c *x509.Certificate) bool {
-	return util.IsSubscriberCert(c)
+	return util.IsSubscriberCert(c) && !util.IsExtInCert(c, util.CtPoisonOID)
 }
 
 // Execute checks if the provided certificate has embedded SCTs from

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/zmap/zcrypto/json
 github.com/zmap/zcrypto/util
 github.com/zmap/zcrypto/x509/ct
 github.com/zmap/zcrypto/x509/pkix
-# github.com/zmap/zlint v0.0.0-20190730215301-9971d62266e7
+# github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5
 github.com/zmap/zlint
 github.com/zmap/zlint/lints
 github.com/zmap/zlint/util


### PR DESCRIPTION
* Update the `github.com/zmap/zlint` dependency to [b126a9b](https://github.com/zmap/zlint/commit/b126a9b258d55b1b9621e9a16525567317d86b6e), the tip of master at the time of writing. This captures [a small fix](https://github.com/zmap/zlint/pull/299) to the `ct_sct_policy_count_unsatisfied` lint that ensures it isn't run for precertificates.
* With that fix in place we no longer have to ignore the `ct_sct_policy_count_unsatisfied` lint in the config-next CA configs that enable preissuance linting.