### PR TITLE
Remove unnecessary transaction.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1717,13 +1717,9 @@ func (ssa *SQLStorageAuthority) getAllOrderAuthorizationStatuses(
 		allAuthzValidity = append(allAuthzValidity, validityInfo...)
 	}
 
-	tx, err := ssa.dbMap.Begin()
-	if err != nil {
-		return nil, err
-	}
 	for _, table := range authorizationTables {
 		var validityInfo []authzValidity
-		_, err := tx.WithContext(ctx).Select(
+		_, err := ssa.dbMap.WithContext(ctx).Select(
 			&validityInfo,
 			fmt.Sprintf(`SELECT status, expires from %s AS authz
 		INNER JOIN orderToAuthz
@@ -1734,11 +1730,11 @@ func (ssa *SQLStorageAuthority) getAllOrderAuthorizationStatuses(
 			orderID,
 		)
 		if err != nil {
-			return nil, Rollback(tx, err)
+			return nil, err
 		}
 		allAuthzValidity = append(allAuthzValidity, validityInfo...)
 	}
-	return allAuthzValidity, tx.Commit()
+	return allAuthzValidity, nil
 }
 
 // GetValidOrderAuthorizations is used to find the valid, unexpired authorizations


### PR DESCRIPTION
In getAllOrderAuthorizationStatuses, we were using a transaction for a series of SELECTs.
Since these SELECTs don't need to be strongly consistent with each other, that creates
needless locking and round trips.