### PR TITLE
Suppress "transport is closing" errors.

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -108,7 +108,11 @@ func (log grpcLogger) Error(args ...interface{}) {
 	log.Logger.AuditErr(fmt.Sprintln(args...))
 }
 func (log grpcLogger) Errorf(format string, args ...interface{}) {
-	log.Logger.AuditErrf(format, args...)
+	output := fmt.Sprintf(format, args...)
+	if output == `grpc: Server.processUnaryRPC failed to write status: connection error: desc = "transport is closing"` {
+		return
+	}
+	log.Logger.AuditErr(output)
 }
 func (log grpcLogger) Errorln(args ...interface{}) {
 	log.Logger.AuditErr(fmt.Sprintln(args...))


### PR DESCRIPTION
These errors show up in the Publisher at shutdown during integration
test runs, because the Publisher is trying to write responses from RPCs
that were slow due to the ct-test-srv's LatencySchedule. This
specifically happens only for the optional submission of "final"
certificates.

Fixes #4379 