### PR TITLE
wfe2: set web.RequestEvent.Method for POST-as-GET.

### DIFF
--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -600,6 +600,10 @@ func (wfe *WebFrontEndImpl) validPOSTAsGETForAccount(
 	if string(body) != "" {
 		return nil, probs.Malformed("POST-as-GET requests must have an empty payload")
 	}
+	// To make log analysis easier we choose to elevate the pseudo ACME HTTP
+	// method "POST-as-GET" to the logEvent's Method, replacing the
+	// http.MethodPost value.
+	logEvent.Method = "POST-as-GET"
 	return reg, prob
 }
 


### PR DESCRIPTION
To make log analysis easier we choose to elevate the pseudo ACME HTTP method "POST-as-GET" to the `web.RequestEvent.Method` after processing a valid POST-as-GET request, replacing the "POST" method value that will have been set by the outermost handler.

I thought about writing an integration test but I don't think we have any structure in place to assert values are present in WFE2 log output during the integration phase. If there's a convenient way to do so I'm happy to learn about it.

Resolves https://github.com/letsencrypt/boulder/issues/4389