### PR TITLE
janitor: add more context to getWork Err log.

### DIFF
--- a/cmd/boulder-janitor/job.go
+++ b/cmd/boulder-janitor/job.go
@@ -166,7 +166,8 @@ func (j batchedDBJob) RunForever() {
 		for {
 			lastID, err := j.getWork(work, id)
 			if err != nil {
-				j.log.Err(err.Error())
+				j.log.Errf("error getting work for %q from ID %d: %v",
+					j.table, id, err.Error())
 				errStat.WithLabelValues(j.table, "getWork").Inc()
 				time.Sleep(time.Millisecond * 500)
 				continue

--- a/cmd/boulder-janitor/job.go
+++ b/cmd/boulder-janitor/job.go
@@ -166,7 +166,7 @@ func (j batchedDBJob) RunForever() {
 		for {
 			lastID, err := j.getWork(work, id)
 			if err != nil {
-				j.log.Errf("error getting work for %q from ID %d: %v",
+				j.log.Errf("error getting work for %q from ID %d: %s",
 					j.table, id, err.Error())
 				errStat.WithLabelValues(j.table, "getWork").Inc()
 				time.Sleep(time.Millisecond * 500)


### PR DESCRIPTION
This better matches what's logged when there is an error deleting a resource. Without adding this context errors from getWork aren't identifiable without cross-referencing the Prometheus stats.