### PR TITLE
deps: update github.com/zmap/zlint to latest.

### DIFF
--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -479,7 +479,7 @@ func TestIgnoredLint(t *testing.T) {
 	expectedProblems := []string{
 		"zlint error: e_sub_cert_aia_does_not_contain_ocsp_url",
 		"zlint info: n_subject_common_name_included",
-		"zlint info: ct_sct_policy_count_unsatisfied Certificate had 0 embedded SCTs. Browser policy may require 2 for this certificate.",
+		"zlint info: w_ct_sct_policy_count_unsatisfied Certificate had 0 embedded SCTs. Browser policy may require 2 for this certificate.",
 	}
 	sort.Strings(expectedProblems)
 
@@ -494,7 +494,7 @@ func TestIgnoredLint(t *testing.T) {
 	problems = checker.checkCert(cert, map[string]bool{
 		"e_sub_cert_aia_does_not_contain_ocsp_url": true,
 		"n_subject_common_name_included":           true,
-		"ct_sct_policy_count_unsatisfied":          true,
+		"w_ct_sct_policy_count_unsatisfied":        true,
 	})
 	test.AssertEquals(t, len(problems), 0)
 }

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/weppos/publicsuffix-go v0.5.1-0.20190725085804-8ac7722bc7d7
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e
-	github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5
+	github.com/zmap/zlint v0.0.0-20190812234238-3307e6abe190
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2
 	golang.org/x/sys v0.0.0-20190416152802-12500544f89f // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/zmap/zlint v0.0.0-20190730215301-9971d62266e7 h1:iK6SvWuIShUZhWlpL2F+
 github.com/zmap/zlint v0.0.0-20190730215301-9971d62266e7/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
 github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5 h1:dCxao24v0jzeVy0/c4qfKvcgR9yvZQ7NEcBjoTgxKRc=
 github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
+github.com/zmap/zlint v0.0.0-20190812234238-3307e6abe190 h1:6GptW5eE0D3TUxZcnJ6T/krJlGyULRQjGI1Kz0fsu6c=
+github.com/zmap/zlint v0.0.0-20190812234238-3307e6abe190/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/vendor/github.com/zmap/zlint/README.md
+++ b/vendor/github.com/zmap/zlint/README.md
@@ -12,6 +12,13 @@ Baseline Requirements
 A detailed list of BR coverage can be found here:
 https://docs.google.com/spreadsheets/d/1ywp0op9mkTaggigpdF2YMTubepowJ50KQBhc_b00e-Y.
 
+Requirements
+------------
+
+ZLint requires [Go 1.12.x or newer](https://golang.org/doc/install) be
+installed. The command line setup instructions assume the `go` command is in
+your `$PATH`.
+
 Command Line Usage
 ------------------
 
@@ -60,6 +67,17 @@ following Go conventions, e.g., `subjectCommonNameNotFromSAN`. Example:
 `./newLint.sh e_subject_common_name_not_from_san subjectCommonNameNotFromSAN`.
 This will generate a new lint in the `lints` directory with the necessary
 fields filled out.
+
+**Choosing a Lint Result Level.** When choosing what `lints.LintStatus` your new
+lint should return (e.g. `Notice`,`Warn`, `Error`, or `Fatal`) the following
+general guidance may help. `Error` should be used for clear violations of RFC/BR
+`MUST` or `MUST NOT` requirements and include strong citations. `Warn` should be
+used for violations of RFC/BR `SHOULD` or `SHOULD NOT` requirements and again
+should include strong citations. `Notice` should be used for more general "FYI"
+statements that violate non-codified community standards or for cases where
+citations are unclear. Lastly `Fatal` should be used when there is an
+unresolvable error in `zlint`, `zcrypto` or some other part of the certificate
+processing.
 
 **Scoping a Lint.** Lints are executed in three steps. First, the ZLint
 framework determines whether a certificate falls within the scope of a given

--- a/vendor/github.com/zmap/zlint/lints/lint_ct_sct_policy_count_unsatisfied.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_ct_sct_policy_count_unsatisfied.go
@@ -146,7 +146,7 @@ func appleCTPolicyExpectedSCTs(cert *x509.Certificate) int {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ct_sct_policy_count_unsatisfied",
+		Name:          "w_ct_sct_policy_count_unsatisfied",
 		Description:   "Check if certificate has enough embedded SCTs to meet Apple CT Policy",
 		Citation:      "https://support.apple.com/en-us/HT205280",
 		Source:        AppleCTPolicy,

--- a/vendor/github.com/zmap/zlint/lints/lint_ext_tor_service_descriptor_hash_invalid.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_ext_tor_service_descriptor_hash_invalid.go
@@ -200,7 +200,7 @@ func (l *torServiceDescHashInvalid) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_tor_service_descriptor_hash_invalid",
+		Name:          "e_ext_tor_service_descriptor_hash_invalid",
 		Description:   "certificates with .onion names need valid TorServiceDescriptors in extension",
 		Citation:      "BRS: Ballot 201",
 		Source:        CABFBaselineRequirements,

--- a/vendor/github.com/zmap/zlint/lints/lint_onion_subject_validity_time_too_large.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_onion_subject_validity_time_too_large.go
@@ -56,7 +56,7 @@ func (l *torValidityTooLarge) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name: "onion_subject_validity_time_too_large",
+		Name: "e_onion_subject_validity_time_too_large",
 		Description: fmt.Sprintf(
 			"certificates with .onion names can not be valid for more than %d months",
 			maxOnionValidityMonths),

--- a/vendor/github.com/zmap/zlint/lints/lint_san_dns_name_onion_not_ev_cert.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_san_dns_name_onion_not_ev_cert.go
@@ -62,7 +62,7 @@ func (l *onionNotEV) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "san_dns_name_onion_not_ev_cert",
+		Name:          "e_san_dns_name_onion_not_ev_cert",
 		Description:   "certificates with a .onion subject name must be issued in accordance with EV Guidelines",
 		Citation:      "CABF Ballot 144",
 		Source:        CABFBaselineRequirements,

--- a/vendor/github.com/zmap/zlint/lints/lint_subject_contains_malformed_arpa_ip.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_subject_contains_malformed_arpa_ip.go
@@ -129,7 +129,7 @@ func lintReversedIPAddressLabels(name string, ipv6 bool) error {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_contains_malformed_arpa_ip",
+		Name:          "w_subject_contains_malformed_arpa_ip",
 		Description:   "Checks no subject domain name contains a rDNS entry in an .arpa zone with the wrong number of labels",
 		Citation:      "BRs: 7.1.4.2.1",
 		Source:        CABFBaselineRequirements,

--- a/vendor/github.com/zmap/zlint/lints/lint_subject_contains_reserved_arpa_ip.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_subject_contains_reserved_arpa_ip.go
@@ -222,7 +222,7 @@ func lintReversedIPAddress(name string, ipv6 bool) error {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_contains_reserved_arpa_ip",
+		Name:          "e_subject_contains_reserved_arpa_ip",
 		Description:   "Checks no subject domain name contains a rDNS entry in an .arpa zone specifying a reserved IP address",
 		Citation:      "BRs: 7.1.4.2.1",
 		Source:        CABFBaselineRequirements,

--- a/vendor/github.com/zmap/zlint/lints/lint_subject_printable_string_badalpha.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_subject_printable_string_badalpha.go
@@ -1,0 +1,108 @@
+/*
+ * ZLint Copyright 2019 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package lints
+
+import (
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/util"
+)
+
+var (
+	// Per RFC 5280, Appendix B. ASN.1 Notes:
+	//   The character string type PrintableString supports a very basic Latin
+	//   character set: the lowercase letters 'a' through 'z', uppercase
+	//   letters 'A' through 'Z', the digits '0' through '9', eleven special
+	//   characters ' = ( ) + , - . / : ? and space.
+	printableStringRegex = regexp.MustCompile(`^[a-zA-Z0-9\=\(\)\+,\-.\/:\? ]+$`)
+)
+
+// validatePrintableString returns an error if the provided encoded printable
+// string doesn't adhere to the character set defined in RFC 5280.
+func validatePrintableString(rawPS []byte) error {
+	if !printableStringRegex.Match(rawPS) {
+		return errors.New("encoded PrintableString contained illegal characters")
+	}
+	return nil
+}
+
+type subjectPrintableStringBadAlpha struct {
+}
+
+func (l *subjectPrintableStringBadAlpha) Initialize() error {
+	return nil
+}
+
+// CheckApplies returns true for any certificate with a non-empty RawSubject.
+func (l *subjectPrintableStringBadAlpha) CheckApplies(c *x509.Certificate) bool {
+	return len(c.RawSubject) > 0
+}
+
+// Execute checks the certificate's RawSubject to ensure that any
+// PrintableString attribute/value pairs in the Subject match the character set
+// defined for this type in RFC 5280. An Error level LintResult is returned if any
+// of the PrintableString attributes do not match a regular expression for the
+// allowed character set.
+func (l *subjectPrintableStringBadAlpha) Execute(c *x509.Certificate) *LintResult {
+	rdnSequence := util.RawRDNSequence{}
+	rest, err := asn1.Unmarshal(c.RawSubject, &rdnSequence)
+	if err != nil {
+		return &LintResult{
+			Status:  Fatal,
+			Details: "Failed to Unmarshal RawSubject into RawRDNSequence",
+		}
+	}
+	if len(rest) > 0 {
+		return &LintResult{
+			Status:  Fatal,
+			Details: "Trailing data after RawSubject RawRDNSequence",
+		}
+	}
+
+	for _, attrTypeAndValueSet := range rdnSequence {
+		for _, attrTypeAndValue := range attrTypeAndValueSet {
+			// If the attribute type is a PrintableString the bytes of the attribute
+			// value must match the printable string alphabet.
+			if attrTypeAndValue.Value.Tag == asn1.TagPrintableString {
+				if err := validatePrintableString(attrTypeAndValue.Value.Bytes); err != nil {
+					return &LintResult{
+						Status: Error,
+						Details: fmt.Sprintf("RawSubject attr oid %s %s",
+							attrTypeAndValue.Type, err.Error()),
+					}
+				}
+			}
+		}
+	}
+
+	return &LintResult{
+		Status: Pass,
+	}
+}
+
+func init() {
+	RegisterLint(&Lint{
+		Name:          "e_subject_printable_string_badalpha",
+		Description:   "PrintableString type's alphabet only includes a-z, A-Z, 0-9, and 11 special characters",
+		Citation:      "RFC 5280: Appendix B. ASN.1 Notes",
+		Source:        RFC5280,
+		EffectiveDate: util.RFC2459Date,
+		Lint:          &subjectPrintableStringBadAlpha{},
+	})
+}

--- a/vendor/github.com/zmap/zlint/util/gtld_map.go
+++ b/vendor/github.com/zmap/zlint/util/gtld_map.go
@@ -2478,6 +2478,11 @@ var tldMap = map[string]GTLDPeriod{
 		DelegationDate: "2014-12-13",
 		RemovalDate:    "",
 	},
+	"gay": {
+		GTLD:           "gay",
+		DelegationDate: "2019-08-09",
+		RemovalDate:    "",
+	},
 	"gb": {
 		GTLD:           "gb",
 		DelegationDate: "1985-01-01",
@@ -3226,7 +3231,7 @@ var tldMap = map[string]GTLDPeriod{
 	"iselect": {
 		GTLD:           "iselect",
 		DelegationDate: "2016-01-15",
-		RemovalDate:    "",
+		RemovalDate:    "2019-08-05",
 	},
 	"ismaili": {
 		GTLD:           "ismaili",
@@ -5936,7 +5941,7 @@ var tldMap = map[string]GTLDPeriod{
 	"starhub": {
 		GTLD:           "starhub",
 		DelegationDate: "2015-06-22",
-		RemovalDate:    "",
+		RemovalDate:    "2019-08-02",
 	},
 	"statebank": {
 		GTLD:           "statebank",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/zmap/zcrypto/json
 github.com/zmap/zcrypto/util
 github.com/zmap/zcrypto/x509/ct
 github.com/zmap/zcrypto/x509/pkix
-# github.com/zmap/zlint v0.0.0-20190801162132-b126a9b258d5
+# github.com/zmap/zlint v0.0.0-20190812234238-3307e6abe190
 github.com/zmap/zlint
 github.com/zmap/zlint/lints
 github.com/zmap/zlint/util


### PR DESCRIPTION
This update adds a new lint ([`e_subject_printable_string_badalpha`](https://github.com/zmap/zlint/commit/3307e6abe1904cf6f0573d7c9fb35a800385f02c)) that specifically flags certificates like the ones that caused [a historic Let's Encrypt incident](https://groups.google.com/d/msg/mozilla.dev.security.policy/wqySoetqUFM/34W5zvENAwAJ) related to the allowed `PrintableString` character set (_long since addressed in Boulder by a Go upgrade_). It also pulls in [minor housekeeping](https://github.com/zmap/zlint/commit/13a927f87ec7ccb59edbf529ba0a64d26621c6b0) related to consistently prefixing lint names with their respective lint result level and updated gTLD map data.