### PR TITLE
va: don't wrap up http-01 DNS problem types.

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -213,9 +213,9 @@ func (va *ValidationAuthorityImpl) newHTTPValidationTarget(
 	// Resolve IP addresses for the hostname
 	addrs, err := va.getAddrs(ctx, host)
 	if err != nil {
-		// Convert the error into a ConnectionFailureError so it is presented to the
-		// end user in a problem after being fed through detailedError.
-		return nil, berrors.ConnectionFailureError(err.Error())
+		// va.getAddrs will only ever return a *probs.DNS or *probs.UnknownHost
+		// error. It is safe to pass through unchanged.
+		return nil, err
 	}
 
 	target := &httpValidationTarget{

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -127,7 +127,7 @@ func TestHTTPValidationTarget(t *testing.T) {
 		{
 			Name:          "No IPs for host",
 			Host:          "always.invalid",
-			ExpectedError: berrors.ConnectionFailureError("unknownHost :: No valid IP addresses found for always.invalid"),
+			ExpectedError: probs.UnknownHost("No valid IP addresses found for always.invalid"),
 		},
 		{
 			Name:        "Only IPv4 addrs for host",


### PR DESCRIPTION
When `va.newHTTPValidationTarget` gets an error from `va.getAddrs` it does not need to wrap the error in a `berrors.ConnectionFailureError`. The `getAddrs` function will only ever return a `probs.DNS` or a `probs.UnknownHost` type error result and the va `detailedError` function can handle these fine as-is. This is the approach taken by the TLS-ALPN-01 validation code already.

This change prevents HTTP-01 challenge failures related to DNS being reported as connection type problems. In turn this makes analysis of problem types easier. 

e.g. before:
```
{
  "type"   : "connection",
  "detail" : "unknownHost :: No valid IP addresses found for example.com",
  "status" : 400
}
```

after:
```
{
  "type"   : "unknownHost",
  "detail" : "No valid IP addresses found for example.com",
  "status" : 400
}
```