### PR TITLE
Promote authzv2 to test/config now that it's live

### DIFF
--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -14,6 +14,9 @@
     "saService": {
       "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
+    },
+    "features": {
+      "NewAuthorizationSchema": true
     }
   },
 

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -45,6 +45,7 @@
       ]
     },
     "features": {
+      "NewAuthorizationSchema": true,
       "EarlyOrderRateLimit": true
     },
     "CTLogGroups2": [

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -24,7 +24,6 @@
       ]
     },
     "features": {
-      "DisableAuthz2Orders": true,
       "DeleteUnusedChallenges": true
     }
   },

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -31,6 +31,7 @@
       "timeout": "15s"
     },
     "features": {
+      "NewAuthorizationSchema": true
     }
   },
 

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -37,6 +37,7 @@
     },
     "features": {
       "HeadNonceStatusOK": true,
+      "NewAuthorizationSchema": true,
       "RemoveWFE2AccountID": true
     }
   },

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -44,20 +44,13 @@ def run_expired_authz_purger():
     # (e.g. test_expired_authzs_404).
 
     def expect(target_time, num, table):
-        if CONFIG_NEXT:
-            tool = "expired-authz-purger2"
-            out = get_future_output("./bin/expired-authz-purger2 --single-run --config cmd/expired-authz-purger2/config.json", target_time)
-        else:
-            tool = "expired-authz-purger"
-            out = get_future_output("./bin/expired-authz-purger --config cmd/expired-authz-purger/config.json", target_time)
+        tool = "expired-authz-purger2"
+        out = get_future_output("./bin/expired-authz-purger2 --single-run --config cmd/expired-authz-purger2/config.json", target_time)
         if 'via FAKECLOCK' not in out:
             raise Exception("%s was not built with `integration` build tag" % (tool))
         if num is None:
             return
-        if CONFIG_NEXT:
-            expected_output = 'deleted %d expired authorizations' % (num)
-        else:
-            expected_output = 'Deleted a total of %d expired authorizations from %s' % (num, table)
+        expected_output = 'deleted %d expired authorizations' % (num)
         if expected_output not in out:
             raise Exception("%s did not print '%s'.  Output:\n%s" % (
                   tool, expected_output, out))

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -239,24 +239,17 @@ def main():
         raise Exception("must run at least one of the letsencrypt or chisel tests with --certbot, --chisel, or --custom")
 
     if not args.test_case_filter:
-        # In CONFIG_NEXT mode, use the basic, non-next config for setup.
-        # This lets us test the transition to authz2.
-        config = default_config_dir
-        if CONFIG_NEXT:
-            config = "test/config"
-        else:
-            config = "test/config-next"
         now = datetime.datetime.utcnow()
 
         six_months_ago = now+datetime.timedelta(days=-30*6)
-        if not startservers.start(race_detection=True, fakeclock=fakeclock(six_months_ago), config_dir=config):
+        if not startservers.start(race_detection=True, fakeclock=fakeclock(six_months_ago)):
             raise Exception("startservers failed (mocking six months ago)")
         v1_integration.caa_client = caa_client = chisel.make_client()
         setup_six_months_ago()
         startservers.stop()
 
         twenty_days_ago = now+datetime.timedelta(days=-20)
-        if not startservers.start(race_detection=True, fakeclock=fakeclock(twenty_days_ago), config_dir=config):
+        if not startservers.start(race_detection=True, fakeclock=fakeclock(twenty_days_ago)):
             raise Exception("startservers failed (mocking twenty days ago)")
         setup_twenty_days_ago()
         startservers.stop()

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -449,13 +449,6 @@ def test_recheck_caa():
        was good. We'll set a new CAA record forbidding issuance; the CAA should
        recheck CAA and reject the request.
     """
-    # TODO(jsha): We can't do this test in non-CONFIG_NEXT mode
-    # because of authzv2. We do the twenty_days setup in CONFIG_NEXT
-    # mode (creating an authzv2), then restart Boulder with the authzv2
-    # flag disabled, which causes the authz to 404. Remove this check once
-    # authzv2 is live.
-    if not CONFIG_NEXT:
-        return
     if len(caa_recheck_authzs) == 0:
         raise Exception("CAA authzs not prepared for test_caa")
     domains = []


### PR DESCRIPTION
This also removes some awkward dancing we did in integration_test.py to
run setup_twenty_days_ago under the opposite config of whatever we were
about to run tests under.

Reverts most of #4288 and #4290.