### PR TITLE
test: don't eat go test stdout, support filter.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -105,7 +105,7 @@ if [[ "$RUN" =~ "integration" ]] ; then
 
   source ${CERTBOT_PATH:-/certbot}/${VENV_NAME:-venv}/bin/activate
   DIRECTORY=http://boulder:4000/directory \
-    python2 test/integration-test.py --chisel "${args[@]}"
+    python2 test/integration-test.py --chisel --gotest "${args[@]}"
 fi
 
 # Test that just ./start.py works, which is a proxy for testing that

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -45,12 +45,11 @@ def run_go_tests(filterPattern=None):
     return zero or an exception will be raised. If the filterPattern is provided
     it is used as the value of the `--test.run` argument to the go test command.
     """
-    cmdLine = "go test"
+    cmdLine = [ "go", "test", ]
     if filterPattern is not None and filterPattern != "":
-        cmdLine = "{0} --test.run {1}".format(cmdLine, filterPattern)
-    cmdLine = "{0} -tags integration -count=1 ./test/integration".format(cmdLine)
-    cmd = shlex.split(cmdLine)
-    return subprocess.check_call(cmd, shell=False, stderr=subprocess.STDOUT)
+        cmdLine = cmdLine + ["--test.run", filterPattern]
+    cmdLine = cmdLine + ["-tags", "integration", "-count=1", "./test/integration"]
+    return subprocess.check_call(cmdLine, shell=False, stderr=subprocess.STDOUT)
 
 def run_expired_authz_purger():
     # Note: This test must be run after all other tests that depend on

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -45,8 +45,8 @@ def run_go_tests(filterPattern=None):
     return zero or an exception will be raised. If the filterPattern is provided
     it is used as the value of the `--test.run` argument to the go test command.
     """
-    cmdLine = "go test -v"
-    if filterPattern is not None:
+    cmdLine = "go test"
+    if filterPattern is not None and filterPattern != "":
         cmdLine = "{0} --test.run {1}".format(cmdLine, filterPattern)
     cmdLine = "{0} -tags integration -count=1 ./test/integration".format(cmdLine)
     cmd = shlex.split(cmdLine)

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -17,6 +17,7 @@ import random
 import re
 import requests
 import subprocess
+import shlex
 import signal
 import time
 
@@ -38,8 +39,18 @@ def run_client_tests():
     cmd = os.path.join(root, 'tests', 'boulder-integration.sh')
     run(cmd, cwd=root)
 
-def run_go_tests():
-    run("go test -tags integration -count=1 ./test/integration")
+def run_go_tests(filterPattern=None):
+    """
+    run_go_tests launches the Go integration tests. The go test command must
+    return zero or an exception will be raised. If the filterPattern is provided
+    it is used as the value of the `--test.run` argument to the go test command.
+    """
+    cmdLine = "go test -v"
+    if filterPattern is not None:
+        cmdLine = "{0} --test.run {1}".format(cmdLine, filterPattern)
+    cmdLine = "{0} -tags integration -count=1 ./test/integration".format(cmdLine)
+    cmd = shlex.split(cmdLine)
+    return subprocess.check_call(cmd, shell=False, stderr=subprocess.STDOUT)
 
 def run_expired_authz_purger():
     # Note: This test must be run after all other tests that depend on
@@ -222,6 +233,8 @@ def main():
                         help="run the certbot integration tests")
     parser.add_argument('--chisel', dest="run_chisel", action="store_true",
                         help="run integration tests using chisel")
+    parser.add_argument('--gotest', dest="run_go", action="store_true",
+                        help="run Go integration tests")
     parser.add_argument('--filter', dest="test_case_filter", action="store",
                         help="Regex filter for test cases")
     # allow any ACME client to run custom command for integration
@@ -259,7 +272,8 @@ def main():
     if args.run_certbot:
         run_client_tests()
 
-    run_go_tests()
+    if args.run_go:
+        run_go_tests(args.test_case_filter)
 
     if args.custom:
         run(args.custom)


### PR DESCRIPTION
* Use `check_call` instead of `check_output`, we don't care about capturing the output and instead want it to go to stdout so test failures can be debugged.

* Don't use `shell=True`, it isn't needed here.

* Pipe through the test case filter so that it can be used with `--test.run` to limit the Go integration tests run.