### PR TITLE
boulder-janitor: Calculate purge window on query instead of on startup

### DIFF
--- a/cmd/boulder-janitor/certs.go
+++ b/cmd/boulder-janitor/certs.go
@@ -12,7 +12,7 @@ func newCertificatesJob(
 	log blog.Logger,
 	clk clock.Clock,
 	config Config) *batchedDBJob {
-	purgeBefore := clk.Now().Add(-config.Janitor.Certificates.GracePeriod.Duration)
+	purgeBefore := config.Janitor.Certificates.GracePeriod.Duration
 	workQuery := `
 		 SELECT id FROM certificates
 		 WHERE
@@ -23,6 +23,7 @@ func newCertificatesJob(
 	return &batchedDBJob{
 		db:          db,
 		log:         log,
+		clk:         clk,
 		purgeBefore: purgeBefore,
 		workSleep:   config.Janitor.Certificates.WorkSleep.Duration,
 		batchSize:   config.Janitor.Certificates.BatchSize,

--- a/cmd/boulder-janitor/certsPerName.go
+++ b/cmd/boulder-janitor/certsPerName.go
@@ -12,7 +12,7 @@ func newCertificatesPerNameJob(
 	log blog.Logger,
 	clk clock.Clock,
 	config Config) *batchedDBJob {
-	purgeBefore := clk.Now().Add(-config.Janitor.CertificatesPerName.GracePeriod.Duration)
+	purgeBefore := config.Janitor.CertificatesPerName.GracePeriod.Duration
 	workQuery := `SELECT id FROM certificatesPerName
 		 WHERE
 		   id > :startID AND
@@ -22,6 +22,7 @@ func newCertificatesPerNameJob(
 	return &batchedDBJob{
 		db:          db,
 		log:         log,
+		clk:         clk,
 		purgeBefore: purgeBefore,
 		workSleep:   config.Janitor.CertificatesPerName.WorkSleep.Duration,
 		batchSize:   config.Janitor.CertificatesPerName.BatchSize,

--- a/cmd/boulder-janitor/certstatus.go
+++ b/cmd/boulder-janitor/certstatus.go
@@ -12,7 +12,7 @@ func newCertificateStatusJob(
 	log blog.Logger,
 	clk clock.Clock,
 	config Config) *batchedDBJob {
-	purgeBefore := clk.Now().Add(-config.Janitor.CertificateStatus.GracePeriod.Duration)
+	purgeBefore := config.Janitor.CertificateStatus.GracePeriod.Duration
 	workQuery := `SELECT id FROM certificateStatus
 		 WHERE
 		   id > :startID AND
@@ -22,6 +22,7 @@ func newCertificateStatusJob(
 	return &batchedDBJob{
 		db:          db,
 		log:         log,
+		clk:         clk,
 		purgeBefore: purgeBefore,
 		workSleep:   config.Janitor.CertificateStatus.WorkSleep.Duration,
 		batchSize:   config.Janitor.CertificateStatus.BatchSize,

--- a/cmd/boulder-janitor/job_test.go
+++ b/cmd/boulder-janitor/job_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func setup() (*blog.Mock, clock.Clock) {
+func setup() (*blog.Mock, clock.FakeClock) {
 	return blog.UseMock(), clock.NewFake()
 }
 
@@ -67,6 +67,7 @@ func TestGetWork(t *testing.T) {
 	log, clk := setup()
 	startID := int64(10)
 	table := "certificates"
+	clk.Add(time.Hour * 5)
 	purgeBefore := clk.Now().Add(-time.Hour)
 	batchSize := int64(20)
 	workQuery := `SELECT id FROM certificates WHERE id > :startID AND time <= :cutoff ORDER by id LIMIT :limit`
@@ -93,8 +94,9 @@ func TestGetWork(t *testing.T) {
 	job := &batchedDBJob{
 		db:          testDB,
 		log:         log,
+		clk:         clk,
 		table:       table,
-		purgeBefore: purgeBefore,
+		purgeBefore: time.Hour,
 		batchSize:   batchSize,
 		workQuery:   workQuery,
 	}


### PR DESCRIPTION
Doesn't add a new test as the old test tests what we want to test already (test).

Fixes #4430.