### PR TITLE
Add precertificates to the orphan queue.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -432,13 +432,19 @@ func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 		return nil, err
 	}
 
+	var regID int64
+	if issueReq.RegistrationID == nil {
+		return nil, fmt.Errorf("incomplete request")
+	}
+	regID = *issueReq.RegistrationID
+
 	if features.Enabled(features.PrecertificateOCSP) {
 		serialHex := core.SerialToString(serialBigInt)
 		nowNanos := ca.clk.Now().UnixNano()
 		expiresNanos := validity.NotAfter.UnixNano()
 		_, err = ca.sa.AddSerial(ctx, &sapb.AddSerialRequest{
 			Serial:  &serialHex,
-			RegID:   issueReq.RegistrationID,
+			RegID:   &regID,
 			Created: &nowNanos,
 			Expires: &expiresNanos,
 		})
@@ -462,15 +468,22 @@ func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 
 		_, err = ca.sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
 			Der:    precertDER,
-			RegID:  issueReq.RegistrationID,
+			RegID:  &regID,
 			Ocsp:   ocspResp,
 			Issued: &nowNanos,
 		})
 		if err != nil {
 			err = berrors.InternalServerError(err.Error())
-			// TODO(#4425): Extend orphanQueue support to precertificates.
 			ca.log.AuditErrf("Failed RPC to store at SA, orphaning precertificate: serial=[%s] cert=[%s] err=[%v], regID=[%d], orderID=[%d]",
 				serialHex, hex.EncodeToString(precertDER), err, issueReq.RegistrationID, issueReq.OrderID)
+			if ca.orphanQueue != nil {
+				ca.queueOrphan(&orphanedCert{
+					DER:      precertDER,
+					RegID:    regID,
+					OCSPResp: ocspResp,
+					Precert:  true,
+				})
+			}
 			return nil, err
 		}
 
@@ -708,6 +721,7 @@ func (ca *CertificateAuthorityImpl) generateOCSPAndStoreCertificate(
 				DER:      certDER,
 				OCSPResp: ocspResp,
 				RegID:    regID,
+				Precert:  false,
 			})
 		}
 		return core.Certificate{}, err
@@ -720,6 +734,7 @@ type orphanedCert struct {
 	DER      []byte
 	OCSPResp []byte
 	RegID    int64
+	Precert  bool
 }
 
 func (ca *CertificateAuthorityImpl) queueOrphan(o *orphanedCert) {
@@ -764,8 +779,18 @@ func (ca *CertificateAuthorityImpl) integrateOrphan() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse orphan: %s", err)
 	}
-	issued := cert.NotBefore.Add(-ca.backdate)
-	_, err = ca.sa.AddCertificate(context.Background(), orphan.DER, orphan.RegID, orphan.OCSPResp, &issued)
+	issued := cert.NotBefore.Add(ca.backdate)
+	if orphan.Precert {
+		issuedNanos := issued.UnixNano()
+		_, err = ca.sa.AddPrecertificate(context.Background(), &sapb.AddCertificateRequest{
+			Der:    orphan.DER,
+			RegID:  &orphan.RegID,
+			Ocsp:   orphan.OCSPResp,
+			Issued: &issuedNanos,
+		})
+	} else {
+		_, err = ca.sa.AddCertificate(context.Background(), orphan.DER, orphan.RegID, orphan.OCSPResp, &issued)
+	}
 	if err != nil && !berrors.Is(err, berrors.Duplicate) {
 		return fmt.Errorf("failed to store orphaned certificate: %s", err)
 	}

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -929,6 +929,11 @@ func (qsa *queueSA) AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (
 	return &corepb.Empty{}, nil
 }
 
+// TestPrecertOrphanQueue tests that IssuePrecertificate writes precertificates
+// to the orphan queue if storage fails, and that `integrateOrphan` later
+// successfully writes those precertificates to the database. To do this, it
+// uses the `queueSA` mock, which allows us to flip on and off a "fail" bit that
+// decides whether it errors in response to storage requests.
 func TestPrecertOrphanQueue(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "orphan-queue-tmp")
 	defer os.Remove(tmpDir)

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -202,6 +203,7 @@ func init() {
 }
 
 func setup(t *testing.T) *testCtx {
+	features.Reset()
 	fc := clock.NewFake()
 	fc.Add(1 * time.Hour)
 
@@ -898,7 +900,8 @@ type queueSA struct {
 	fail      bool
 	duplicate bool
 
-	issued *time.Time
+	issued        *time.Time
+	issuedPrecert *time.Time
 }
 
 func (qsa *queueSA) AddCertificate(_ context.Context, _ []byte, _ int64, _ []byte, issued *time.Time) (string, error) {
@@ -912,11 +915,68 @@ func (qsa *queueSA) AddCertificate(_ context.Context, _ []byte, _ int64, _ []byt
 }
 
 func (qsa *queueSA) AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*corepb.Empty, error) {
-	return &corepb.Empty{}, nil
+	if qsa.fail {
+		return nil, errors.New("bad")
+	} else if qsa.duplicate {
+		return nil, berrors.DuplicateError("is a dupe")
+	}
+	issued := time.Unix(0, *req.Issued)
+	qsa.issuedPrecert = &issued
+	return nil, nil
 }
 
 func (qsa *queueSA) AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*corepb.Empty, error) {
 	return &corepb.Empty{}, nil
+}
+
+func TestPrecertOrphanQueue(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "orphan-queue-tmp")
+	defer os.Remove(tmpDir)
+	test.AssertNotError(t, err, "Failed to create temp directory")
+	orphanQueue, err := goque.OpenQueue(tmpDir)
+	test.AssertNotError(t, err, "Failed to open orphaned certificate queue")
+
+	qsa := &queueSA{fail: true}
+	testCtx := setup(t)
+	fakeNow := time.Date(2019, 9, 20, 0, 0, 0, 0, time.UTC)
+	testCtx.fc.Set(fakeNow)
+	ca, err := NewCertificateAuthorityImpl(
+		testCtx.caConfig,
+		qsa,
+		testCtx.pa,
+		testCtx.fc,
+		testCtx.stats,
+		testCtx.issuers,
+		testCtx.keyPolicy,
+		testCtx.logger,
+		orphanQueue)
+	test.AssertNotError(t, err, "Failed to create CA")
+
+	_ = features.Set(map[string]bool{"PrecertificateOCSP": true})
+
+	err = ca.integrateOrphan()
+	if err != goque.ErrEmpty {
+		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)
+	}
+
+	var one int64 = 1
+	_, err = ca.IssuePrecertificate(context.Background(), &caPB.IssueCertificateRequest{
+		RegistrationID: &one,
+		OrderID:        &one,
+		Csr:            CNandSANCSR,
+	})
+	test.AssertError(t, err, "Expected IssuePrecertificate to fail with `failSA`")
+
+	qsa.fail = false
+	err = ca.integrateOrphan()
+	test.AssertNotError(t, err, "integrateOrphan failed")
+	if !qsa.issuedPrecert.Equal(fakeNow) {
+		t.Errorf("expected issued time to be %s, got %s", fakeNow, *qsa.issued)
+	}
+	err = ca.integrateOrphan()
+	if err != goque.ErrEmpty {
+		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)
+	}
 }
 
 func TestOrphanQueue(t *testing.T) {
@@ -928,6 +988,11 @@ func TestOrphanQueue(t *testing.T) {
 
 	qsa := &queueSA{fail: true}
 	testCtx := setup(t)
+	fakeNow, err := time.Parse("Mon Jan 2 15:04:05 2006", "Mon Jan 2 15:04:05 2006")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCtx.fc.Set(fakeNow)
 	ca, err := NewCertificateAuthorityImpl(
 		testCtx.caConfig,
 		qsa,
@@ -951,7 +1016,7 @@ func TestOrphanQueue(t *testing.T) {
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		DNSNames:     []string{"test.invalid"},
-		NotBefore:    time.Time{}.Add(time.Hour * 24),
+		NotBefore:    fakeNow.Add(-time.Hour),
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, k.Public(), k)
 	test.AssertNotError(t, err, "Failed to generate test cert")
@@ -967,7 +1032,9 @@ func TestOrphanQueue(t *testing.T) {
 	qsa.fail = false
 	err = ca.integrateOrphan()
 	test.AssertNotError(t, err, "integrateOrphan failed")
-	test.AssertEquals(t, *qsa.issued, time.Time{}.Add(time.Hour*24).Add(-time.Hour))
+	if !qsa.issued.Equal(fakeNow) {
+		t.Errorf("expected issued time to be %s, got %s", fakeNow, *qsa.issued)
+	}
 	err = ca.integrateOrphan()
 	if err != goque.ErrEmpty {
 		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)
@@ -983,7 +1050,9 @@ func TestOrphanQueue(t *testing.T) {
 	qsa.duplicate = true
 	err = ca.integrateOrphan()
 	test.AssertNotError(t, err, "integrateOrphan failed with duplicate cert")
-	test.AssertEquals(t, *qsa.issued, time.Time{}.Add(time.Hour*24).Add(-time.Hour))
+	if !qsa.issued.Equal(fakeNow) {
+		t.Errorf("expected issued time to be %s, got %s", fakeNow, *qsa.issued)
+	}
 	err = ca.integrateOrphan()
 	if err != goque.ErrEmpty {
 		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)
@@ -1010,7 +1079,9 @@ func TestOrphanQueue(t *testing.T) {
 	qsa.fail = false
 	err = ca.integrateOrphan()
 	test.AssertNotError(t, err, "integrateOrphan failed")
-	test.AssertEquals(t, *qsa.issued, time.Time{}.Add(time.Hour*24).Add(-time.Hour))
+	if !qsa.issued.Equal(fakeNow) {
+		t.Errorf("expected issued time to be %s, got %s", fakeNow, *qsa.issued)
+	}
 	err = ca.integrateOrphan()
 	if err != goque.ErrEmpty {
 		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)


### PR DESCRIPTION
Also, fix a bug in the issued time that gets assigned to inserted
entries, and fix the unittests correspondingly.