### PR TITLE
boulder-janitor: Calculate expiry cutoff in code rather than the database

### DIFF
--- a/cmd/boulder-janitor/certs.go
+++ b/cmd/boulder-janitor/certs.go
@@ -14,10 +14,9 @@ func newCertificatesJob(
 	config Config) *batchedDBJob {
 	purgeBefore := config.Janitor.Certificates.GracePeriod.Duration
 	workQuery := `
-		 SELECT id FROM certificates
+		 SELECT id, expires FROM certificates
 		 WHERE
-		   id > :startID AND
-		   expires <= :cutoff
+		   id > :startID
 		 LIMIT :limit`
 	log.Debugf("Creating Certificates job from config: %#v\n", config.Janitor.Certificates)
 	return &batchedDBJob{

--- a/cmd/boulder-janitor/certsPerName.go
+++ b/cmd/boulder-janitor/certsPerName.go
@@ -13,6 +13,10 @@ func newCertificatesPerNameJob(
 	clk clock.Clock,
 	config Config) *batchedDBJob {
 	purgeBefore := config.Janitor.CertificatesPerName.GracePeriod.Duration
+	// Technically the `time` column in certificatesPerName is not an expiry, it is
+	// the time at which it was inserted into the table, but we use it as the cutoff
+	// for deletions here as we only care about data in this table for 7 days after
+	// it was inserted.
 	workQuery := `SELECT id, time AS expires FROM certificatesPerName
 		 WHERE
 		   id > :startID

--- a/cmd/boulder-janitor/certsPerName.go
+++ b/cmd/boulder-janitor/certsPerName.go
@@ -13,10 +13,9 @@ func newCertificatesPerNameJob(
 	clk clock.Clock,
 	config Config) *batchedDBJob {
 	purgeBefore := config.Janitor.CertificatesPerName.GracePeriod.Duration
-	workQuery := `SELECT id FROM certificatesPerName
+	workQuery := `SELECT id, time AS expires FROM certificatesPerName
 		 WHERE
-		   id > :startID AND
-		   time <= :cutoff
+		   id > :startID
 		 LIMIT :limit`
 	log.Debugf("Creating CertificatesPerName job from config: %#v\n", config.Janitor.CertificatesPerName)
 	return &batchedDBJob{

--- a/cmd/boulder-janitor/certstatus.go
+++ b/cmd/boulder-janitor/certstatus.go
@@ -13,10 +13,9 @@ func newCertificateStatusJob(
 	clk clock.Clock,
 	config Config) *batchedDBJob {
 	purgeBefore := config.Janitor.CertificateStatus.GracePeriod.Duration
-	workQuery := `SELECT id FROM certificateStatus
+	workQuery := `SELECT id, notAfter AS expires FROM certificateStatus
 		 WHERE
-		   id > :startID AND
-		   notAfter <= :cutoff
+		   id > :startID
 		 LIMIT :limit`
 	log.Debugf("Creating CertificateStatus job from config: %#v\n", config.Janitor.CertificateStatus)
 	return &batchedDBJob{

--- a/cmd/boulder-janitor/janitor_test.go
+++ b/cmd/boulder-janitor/janitor_test.go
@@ -36,7 +36,7 @@ func TestNewJobs(t *testing.T) {
 		},
 		"certificatesPerName": {
 			"enabled": true,
-			"gracePeriod": "1h"
+			"gracePeriod": "169h"
 		}
 	}
 }`

--- a/test/config-next/janitor.json
+++ b/test/config-next/janitor.json
@@ -24,7 +24,7 @@
     },
     "certificatesPerName": {
         "enabled": true,
-        "gracePeriod": "1h",
+        "gracePeriod": "169h",
         "batchSize": 100,
         "workSleep": "500ms",
         "parallelism": 2,

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -130,6 +130,10 @@ def run_janitor():
         certStatusWorkbatch = get_stat_line(8014, statline("workbatch", "certificateStatus"))
         certsWorkBatch = get_stat_line(8014, statline("workbatch", "certificates"))
         certsPerNameWorkBatch = get_stat_line(8014, statline("workbatch", "certificatesPerName"))
+        if not certStatusWorkbatch or not certsWorkBatch or not certsPerNameWorkBatch:
+            print("not done after check {0}. Sleeping".format(i))
+            time.sleep(2)
+            continue
 
         allReady = True
         for line in [certStatusWorkbatch, certsWorkBatch, certsPerNameWorkBatch]:


### PR DESCRIPTION
Fixes #4431.