### PR TITLE
CI: remove Go 1.12.8 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - "1.12.8"
   - "1.13"
 
 go_import_path: github.com/letsencrypt/boulder

--- a/test.sh
+++ b/test.sh
@@ -124,12 +124,8 @@ fi
 # Run go mod vendor (happens only in Travis) to check that the versions in
 # vendor/ really exist in the remote repo and match what we have.
 if [[ "$RUN" =~ "gomod-vendor" ]] ; then
-  # NOTE(@cpu): Go 1.13 and 1.12.x handle vendoring differently. Only test on Go
-  # 1.13. This check can be deleted after we remove Go 1.12.x support.
-  if [ "$TRAVIS_GO_VERSION" == "1.13" ]; then
-    go mod vendor
-    git diff --exit-code
-  fi
+  go mod vendor
+  git diff --exit-code
 fi
 
 # Run generate to make sure all our generated code can be re-generated with


### PR DESCRIPTION
We've switched Boulder in staging/prod to builds generated with Go 1.13.