### PR TITLE
wfe/wfe2: handle bad authz2 IDs as malformed req.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1028,7 +1028,7 @@ func (wfe *WebFrontEndImpl) ChallengeV2(
 	}
 	authorizationID, err := strconv.ParseInt(slug[0], 10, 64)
 	if err != nil {
-		notFound()
+		wfe.sendError(response, logEvent, probs.Malformed("Invalid authorization ID"), nil)
 		return
 	}
 	challengeID := slug[1]
@@ -1426,7 +1426,7 @@ func (wfe *WebFrontEndImpl) AuthorizationV2(ctx context.Context, logEvent *web.R
 	}
 	authzID, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {
-		notFound()
+		wfe.sendError(response, logEvent, probs.Malformed("Invalid authorization ID"), nil)
 		return
 	}
 	authzPB, err := wfe.SA.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: &authzID})


### PR DESCRIPTION
Prev. the WFE2 would return a 500 error in the case where an authorization ID was invalid. The WFE1 would return a 404. Returning a malformed request problem reports the true cause of the error as an invalid client request.