### PR TITLE
va: exempt multi-va enforcement by domain/acct ID.

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -43,6 +43,13 @@ type config struct {
 		Features map[string]bool
 
 		AccountURIPrefixes []string
+
+		// A filename pointing to a YAML file containing MultiVAPolicy contents.
+		// This file will be set up to live-reload the contents of the policy file
+		// such that the VA can use the specified disabledDomains and
+		// disabledAccounts lists to determine whether or not to enforce multi-VA
+		// consensus for an account/domain.
+		MultiVAPolicyFile string
 	}
 
 	Syslog cmd.SyslogConfig
@@ -150,7 +157,8 @@ func main() {
 		scope,
 		clk,
 		logger,
-		c.VA.AccountURIPrefixes)
+		c.VA.AccountURIPrefixes,
+		c.VA.MultiVAPolicyFile)
 	cmd.FailOnError(err, "Unable to create VA server")
 
 	serverMetrics := bgrpc.NewServerMetrics(scope)

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -147,15 +147,16 @@ func TestLoadPolicies(t *testing.T) {
 	certsPerFQDN := policy.CertificatesPerFQDNSet()
 	test.AssertEquals(t, certsPerFQDN.Threshold, 5)
 	test.AssertDeepEquals(t, certsPerFQDN.Overrides, map[string]int{
-		"le.wtf":                10000,
-		"le1.wtf":               10000,
-		"le2.wtf":               10000,
-		"le3.wtf":               10000,
-		"le.wtf,le1.wtf":        10000,
-		"good-caa-reserved.com": 10000,
-		"nginx.wtf":             10000,
-		"ecdsa.le.wtf":          10000,
-		"must-staple.le.wtf":    10000,
+		"le.wtf":                        10000,
+		"le1.wtf":                       10000,
+		"le2.wtf":                       10000,
+		"le3.wtf":                       10000,
+		"le.wtf,le1.wtf":                10000,
+		"good-caa-reserved.com":         10000,
+		"nginx.wtf":                     10000,
+		"ecdsa.le.wtf":                  10000,
+		"must-staple.le.wtf":            10000,
+		"brokenmultiva.letsencrypt.org": 10000,
 	})
 	test.AssertEquals(t, len(certsPerFQDN.RegistrationOverrides), 0)
 

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -42,6 +42,7 @@
       }
     ],
     "maxRemoteValidationFailures": 1,
+    "multiVAPolicyFile": "test/example-multiva-policy.yaml",
     "accountURIPrefixes": [
       "http://boulder:4000/acme/reg/"
     ]

--- a/test/example-multiva-policy.yaml
+++ b/test/example-multiva-policy.yaml
@@ -1,0 +1,15 @@
+# Example Boulder Multi-VA Policy File
+#
+# The domain names and registration IDs specified in this policy file are
+# *exempt* from the normal multi-VA enforcement. When the primary VA has
+# EnforceMultiVA enabled the maxRemoteValidationFailures will not be enforced
+# when the account initiating the validation is on the disabledAccounts list, or
+# when the domain being validated is in the disabledDomains list.
+
+# List of domain names that are exempt from multi-VA.
+disabledDomains:
+  - "brokenmultiva.letsencrypt.org"
+
+# List of ACME Account/Registration IDs that are exempt from multi-VA.
+disabledAccounts:
+  - 99991337

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -49,3 +49,5 @@ certificatesPerFQDNSet:
     nginx.wtf: 10000
     ecdsa.le.wtf: 10000
     must-staple.le.wtf: 10000
+    # Used by integration tests for the multiVA policy file.
+    brokenmultiva.letsencrypt.org: 10000

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -982,31 +982,31 @@ def test_http_multiva_threshold_fail_account_disabled():
         run_query("DELETE FROM precertificates WHERE registrationID={0}".format(newID))
         run_query("DELETE FROM serials WHERE registrationID={0}".format(newID))
 
-    # Update the account ID in the database to match an ID that exists in
-    # `test/example-multi-va-policy.yaml`'s disabledAccounts list. We do this
-    # with direct DB access because the alternative is hackish rewriting of the
-    # policy YAML file at runtime (especially since the reload event can't be
-    # easily detected). This approach is _also_ hackish, but marginally less so.
-    newID=99991337
-    flip_ids(acctID, newID)
-
-    # Update the in-memory account ID for the client instance to match
-    client.net.account = RegistrationResource(
-            body=client.net.account.body,
-            uri=acctURI.replace(acctID, str(newID)),
-            terms_of_service=client.net.account.terms_of_service)
-
-    # Configure a guestlist that will fail the multiVA threshold test by
-    # only allowing the primary VA.
-    guestlist = {"boulder": 1}
-
-    # Setup for a random domain name
-    domain, cleanup = multiva_setup(client, guestlist, domain=None)
-
-    # We do not expect any errors, even though the guestlist ensured multi-va
-    # failures, because the client was set up with an account key corresponding
-    # to a multi VA policy disabledAccount ID.
     try:
+        # Update the account ID in the database to match an ID that exists in
+        # `test/example-multi-va-policy.yaml`'s disabledAccounts list. We do this
+        # with direct DB access because the alternative is hackish rewriting of the
+        # policy YAML file at runtime (especially since the reload event can't be
+        # easily detected). This approach is _also_ hackish, but marginally less so.
+        newID=99991337
+        flip_ids(acctID, newID)
+
+        # Update the in-memory account ID for the client instance to match
+        client.net.account = RegistrationResource(
+                body=client.net.account.body,
+                uri=acctURI.replace(acctID, str(newID)),
+                terms_of_service=client.net.account.terms_of_service)
+
+        # Configure a guestlist that will fail the multiVA threshold test by
+        # only allowing the primary VA.
+        guestlist = {"boulder": 1}
+
+        # Setup for a random domain name
+        domain, cleanup = multiva_setup(client, guestlist, domain=None)
+
+        # We do not expect any errors, even though the guestlist ensured multi-va
+        # failures, because the client was set up with an account key corresponding
+        # to a multi VA policy disabledAccount ID.
         chisel2.auth_and_issue([domain], client=client, chall_type="http-01")
     finally:
         cleanup()

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1010,7 +1010,14 @@ def test_http_multiva_threshold_fail_account_disabled():
         chisel2.auth_and_issue([domain], client=client, chall_type="http-01")
     finally:
         cleanup()
+        # Remove certificates and related resources issued by the
+        # fixed example-multi-va-policy.yaml account ID. This avoids foreign key
+        # constraints being broken when we flip_ids next.
         remove_certs(newID)
+        # Change the account ID back to the old account ID. This will prevent
+        # duplicate key errors when the integration test is run again and tries
+        # to update a different newly created account to the fixed ID from the
+        # example-multi-va-policy.yaml file.
         flip_ids(newID, acctID)
 
 class FakeH2ServerHandler(socketserver.BaseRequestHandler):

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -23,7 +23,7 @@ from helpers import *
 
 from acme import errors as acme_errors
 
-from acme.messages import Status, CertificateRequest, Directory
+from acme.messages import Status, CertificateRequest, Directory, RegistrationResource
 from acme import crypto_util as acme_crypto_util
 from acme import client as acme_client
 from acme import messages
@@ -788,16 +788,20 @@ def wait_for_server(addr):
             pass
         time.sleep(0.5)
 
-def multiva_setup(client, guestlist):
+def multiva_setup(client, guestlist, domain=None):
     """
-    Create a testing hostname and the multiva server setup. This will block
+    Setup a testing domain and backing multiva server setup. This will block
     until the server is ready. The returned cleanup function should be used to
     stop the server. The first bounceFirst requests to the server will be sent
     to the real challtestsrv for a good answer, the rest will get a bad
-    answer.
+    answer. If no explicit testing domain is provided then one is randomly
+    chosen with random_domain().
     """
+    if domain is None:
+        hostname = random_domain()
+    else:
+        hostname = domain
 
-    hostname = random_domain()
     csr_pem = chisel2.make_csr([hostname])
     order = client.new_order(csr_pem)
     authz = order.authorizations[0]
@@ -902,6 +906,112 @@ def test_http_multiva_threshold_fail():
             raise Exception("expected unauthorized prob, found {0}".format(httpChall.error.typ))
     finally:
         cleanup()
+
+def test_http_multiva_threshold_fail_domain_disabled():
+    # Only the config-next config dir has remote VAs and a multi VA policy file
+    # configured at the time of writing.
+    if not CONFIG_NEXT:
+        return
+
+    client = chisel2.make_client()
+
+    # Configure a guestlist that will fail the multiVA threshold test by
+    # only allowing the primary VA.
+    guestlist = {"boulder": 1}
+
+    # Explicitly use a domain name that exists in
+    # `test/example-multiva-policy.yaml`'s disabledDomains list
+    domain = "brokenmultiva.letsencrypt.org"
+
+    _, cleanup = multiva_setup(client, guestlist, domain)
+
+    # We do not expect any errors, even though the guestlist ensured multi-va
+    # failures, because the domain was in the multi VA policy disabledDomains
+    # list.
+    try:
+        chisel2.auth_and_issue([domain], client=client, chall_type="http-01")
+    finally:
+        cleanup()
+
+def test_http_multiva_threshold_fail_account_disabled():
+    # Only the config-next config dir has remote VAs and a multi VA policy file
+    # configured at the time of writing.
+    if not CONFIG_NEXT:
+        return
+
+    # Create an ACME account
+    client = chisel2.make_client()
+
+    # Find the numeric ID it was assigned by the ACME server
+    acctURI = client.net.account.uri
+    if len(acctURI.split("/")) < 1:
+        raise Exception("invalid account URI for newly registered account: {0}".format(acctURI))
+    acctID = acctURI.split("/")[-1:][0]
+
+    def run_query(query):
+        command=["mysql",
+            "-h", "bmysql",
+            "-u", "root",
+            "--password=",
+            "-e", query,
+            "boulder_sa_integration",
+            ]
+        subprocess.check_call(command, shell=False, stderr=subprocess.STDOUT)
+
+    def flip_ids(oldID, newID):
+        """
+        flip_ids changes a registrations ID from one value to another. Note that
+        in order for this to succeed all other tables with foreign key
+        constraints on the registration.ID field must be adjusted or otherwise
+        dealt with.
+        """
+        run_query("UPDATE registrations SET id={0} WHERE id={1}".format(newID, oldID))
+
+    def remove_certs(newID):
+        """
+        remove_certs deletes rows created while the account registration ID was changed.
+        We need to delete these rows so that the original account registration
+        ID can be restored without violating the foreign key constraints on the
+        certs, precerts and serials tables. Updating the registrationID of these
+        rows first is difficult because the new value (the original ID) doesn't
+        exist in the registrations table yet. The best solution would be doing
+        all of this in one transaction but we're already deep in hacky
+        integration test yak shaving at this point...
+        """
+        run_query("DELETE FROM certificates WHERE registrationID={0}".format(newID))
+        run_query("DELETE FROM precertificates WHERE registrationID={0}".format(newID))
+        run_query("DELETE FROM serials WHERE registrationID={0}".format(newID))
+
+    # Update the account ID in the database to match an ID that exists in
+    # `test/example-multi-va-policy.yaml`'s disabledAccounts list. We do this
+    # with direct DB access because the alternative is hackish rewriting of the
+    # policy YAML file at runtime (especially since the reload event can't be
+    # easily detected). This approach is _also_ hackish, but marginally less so.
+    newID=99991337
+    flip_ids(acctID, newID)
+
+    # Update the in-memory account ID for the client instance to match
+    client.net.account = RegistrationResource(
+            body=client.net.account.body,
+            uri=acctURI.replace(acctID, str(newID)),
+            terms_of_service=client.net.account.terms_of_service)
+
+    # Configure a guestlist that will fail the multiVA threshold test by
+    # only allowing the primary VA.
+    guestlist = {"boulder": 1}
+
+    # Setup for a random domain name
+    domain, cleanup = multiva_setup(client, guestlist, domain=None)
+
+    # We do not expect any errors, even though the guestlist ensured multi-va
+    # failures, because the client was set up with an account key corresponding
+    # to a multi VA policy disabledAccount ID.
+    try:
+        chisel2.auth_and_issue([domain], client=client, chall_type="http-01")
+    finally:
+        cleanup()
+        remove_certs(newID)
+        flip_ids(newID, acctID)
 
 class FakeH2ServerHandler(socketserver.BaseRequestHandler):
     """

--- a/va/policy.go
+++ b/va/policy.go
@@ -1,0 +1,95 @@
+package va
+
+import (
+	"errors"
+	"sync"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// MultiVAPolicy is a structure containing a map of disabled account IDs and
+// domains that should not have multi-VA enforcement applied. It is safe to use
+// concurrently and is designed to be live-updated with the reloader package.
+type MultiVAPolicy struct {
+	disabledDomains  map[string]bool
+	disabledAccounts map[int64]bool
+	sync.RWMutex
+}
+
+var (
+	// errEmptyMultiVAPolicy is returned from LoadPolicy when the new policy
+	// content is empty or doesn't specify at least one domain or account ID.
+	errEmptyMultiVAPolicy = errors.New(
+		"MultiVAPolicy must include at least one disabledDomain or disabledAccount")
+)
+
+// EnabledDomain returns true if the given domain has multi-VA enabled by
+// policy or false otherwise. It is safe to call concurrently.
+func (p *MultiVAPolicy) EnabledDomain(domain string) bool {
+	// If the policy is nil then multi VA is enabled for all domains.
+	if p == nil {
+		return true
+	}
+	p.RLock()
+	defer p.RUnlock()
+	return !p.disabledDomains[domain]
+}
+
+// EnabledAccount returns true if the given account ID has multi-VA enabled by
+// policy or false otherwise. It is safe to call concurrently.
+func (p *MultiVAPolicy) EnabledAccount(acctID int64) bool {
+	// If the policy is nil then multi VA is enabled for all accounts.
+	if p == nil {
+		return true
+	}
+	p.RLock()
+	defer p.RUnlock()
+	return !p.disabledAccounts[acctID]
+}
+
+// LoadPolicy loads the given yamlBytes into the multi VA policy. The new policy
+// must specify at least one domain or account ID or an error is returned. The
+// new policy contents will completely replace the old contents. It is safe to
+// call concurrently and is designed to work with the reloader package as
+// a dataCallback.
+func (p *MultiVAPolicy) LoadPolicy(yamlBytes []byte) error {
+	if len(yamlBytes) == 0 {
+		return errEmptyMultiVAPolicy
+	}
+
+	// Unmarshal the YAML into a throw-away struct containing lists of domain
+	// names and IDs.
+	var policyObject struct {
+		DisabledDomains  []string `yaml:"disabledDomains"`
+		DisabledAccounts []int64  `yaml:"disabledAccounts"`
+	}
+	if err := yaml.Unmarshal(yamlBytes, &policyObject); err != nil {
+		return err
+	}
+
+	// If there isn't content in one of the lists return an error. This will help
+	// catch YAML mistakes that would otherwise result in empty policy going
+	// undetected.
+	if len(policyObject.DisabledDomains) == 0 && len(policyObject.DisabledAccounts) == 0 {
+		return errEmptyMultiVAPolicy
+	}
+
+	// Create a lookup map for the disabled domains.
+	disabledDomainsMap := make(map[string]bool, len(policyObject.DisabledDomains))
+	for _, d := range policyObject.DisabledDomains {
+		disabledDomainsMap[d] = true
+	}
+	// Create a lookup map for the disabled accounts.
+	disabledAccountsMap := make(map[int64]bool, len(policyObject.DisabledAccounts))
+	for _, acct := range policyObject.DisabledAccounts {
+		disabledAccountsMap[acct] = true
+	}
+
+	// Finally lock the real policy object and update its maps with the maps
+	// created from the new YAML content.
+	p.Lock()
+	defer p.Unlock()
+	p.disabledDomains = disabledDomainsMap
+	p.disabledAccounts = disabledAccountsMap
+	return nil
+}

--- a/va/policy_test.go
+++ b/va/policy_test.go
@@ -1,0 +1,73 @@
+package va
+
+import (
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+// TestLoadPolicy tests that the MultiVAPolicy load works as expected.
+func TestLoadPolicy(t *testing.T) {
+	testCases := []struct {
+		name             string
+		yamlBytes        []byte
+		expectedErr      error
+		expectedDomains  []string
+		expectedAccounts []int64
+	}{
+		{
+			name:        "nil yaml bytes",
+			yamlBytes:   nil,
+			expectedErr: errEmptyMultiVAPolicy,
+		},
+		{
+			name:        "empty yaml bytes",
+			yamlBytes:   []byte{},
+			expectedErr: errEmptyMultiVAPolicy,
+		},
+		{
+			name: "empty policy",
+			yamlBytes: []byte(`
+# No domains
+disabledDomains:
+# No accounts
+disabledAccounts:
+`),
+			expectedErr: errEmptyMultiVAPolicy,
+		},
+		{
+			name: "valid policy",
+			yamlBytes: []byte(`
+# Some example disabled domains
+disabledDomains:
+  - example.com
+  - lettucedecrypt.org
+
+# An example disabled account ID
+disabledAccounts:
+  - 123456
+`),
+			expectedDomains:  []string{"example.com", "lettucedecrypt.org"},
+			expectedAccounts: []int64{123456},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var policy MultiVAPolicy
+			err := policy.LoadPolicy(tc.yamlBytes)
+			if err != nil && tc.expectedErr != nil {
+				test.AssertEquals(t, err, tc.expectedErr)
+			} else if err != nil && tc.expectedErr == nil {
+				t.Fatalf("unexpected error: %v\n", err)
+			} else if err == nil {
+				for _, d := range tc.expectedDomains {
+					test.AssertEquals(t, policy.EnabledDomain(d), false)
+				}
+				for _, acctID := range tc.expectedAccounts {
+					test.AssertEquals(t, policy.EnabledAccount(acctID), false)
+				}
+			}
+		})
+	}
+}

--- a/va/va.go
+++ b/va/va.go
@@ -28,6 +28,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
+	"github.com/letsencrypt/boulder/reloader"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -157,6 +158,7 @@ type ValidationAuthorityImpl struct {
 	clk                clock.Clock
 	remoteVAs          []RemoteVA
 	maxRemoteFailures  int
+	multiVAPolicy      *MultiVAPolicy
 	accountURIPrefixes []string
 	singleDialTimeout  time.Duration
 
@@ -175,6 +177,7 @@ func NewValidationAuthorityImpl(
 	clk clock.Clock,
 	logger blog.Logger,
 	accountURIPrefixes []string,
+	multiVAPolicyFile string,
 ) (*ValidationAuthorityImpl, error) {
 	if pc.HTTPPort == 0 {
 		pc.HTTPPort = 80
@@ -190,7 +193,7 @@ func NewValidationAuthorityImpl(
 		return nil, errors.New("no account URI prefixes configured")
 	}
 
-	return &ValidationAuthorityImpl{
+	va := &ValidationAuthorityImpl{
 		log:                logger,
 		dnsClient:          resolver,
 		issuerDomain:       issuerDomain,
@@ -209,7 +212,26 @@ func NewValidationAuthorityImpl(
 		// used for the DialContext operations that take place during an
 		// HTTP-01 challenge validation.
 		singleDialTimeout: 10 * time.Second,
-	}, nil
+	}
+
+	// if a multiVAPolicyFile was specified then set up a live reloader and
+	// a MultiVAPolicy instance for the VA to refer to.
+	if multiVAPolicyFile != "" {
+		policy := new(MultiVAPolicy)
+		va.multiVAPolicy = policy
+		_, err := reloader.New(multiVAPolicyFile, policy.LoadPolicy, va.multiVAPolicyLoadError)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return va, nil
+}
+
+// multiVAPolicyError is a small error handler called by the reloader package
+// when the multiVAPolicy file can't be loaded.
+func (va *ValidationAuthorityImpl) multiVAPolicyLoadError(err error) {
+	va.log.AuditErrf("error live-loading mutli VA policy file: %v", err)
 }
 
 // Used for audit logging
@@ -610,7 +632,15 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, domain
 			challenge.Status = core.StatusValid
 		} else if features.Enabled(features.EnforceMultiVA) {
 			remoteProb := va.processRemoteResults(domain, string(challenge.Type), prob, remoteResults, len(va.remoteVAs))
-			if remoteProb != nil {
+
+			// We consider the multi VA result skippable even though we are enforcing
+			// multi VA if the domain or the account has multi-VA disabled by policy.
+			skippable := !va.multiVAPolicy.EnabledDomain(domain) ||
+				!va.multiVAPolicy.EnabledAccount(authz.RegistrationID)
+
+			// If the remote result was a non-nil problem and the domain/acct aren't
+			// skippable then fail the validation
+			if remoteProb != nil && !skippable {
 				prob = remoteProb
 				challenge.Status = core.StatusInvalid
 				challenge.Error = remoteProb


### PR DESCRIPTION
In order to move multi perspective validation forward we need to support policy in Boulder configuration that can relax multi-va requirements temporarily.

A similar mechanism was used in support of the gradual deprecation of the TLS-SNI-01 challenge type and with the introduction of CAA enforcement and has shown to be a helpful tool to have available when introducing changes that are expected to break sites.

When the VA "multiVAPolicyFile" is specified it is assumed to be a YAML file containing two lists:

1. disabledNames - a list of domain names that are exempt from multi VA enforcement.
2. disabledAccounts - a list of account IDs that are exempt from multi VA enforcement.

When a hostname or account ID is added to the policy we'll begin communication with the related ACME account contact to establish that this is a temporary measure and the root problem will need to be addressed before an eventual cut-off date.

Resolves https://github.com/letsencrypt/boulder/issues/4455