### PR TITLE
ocsp-updater: fix generateResponse for precerts w/o certs

### DIFF
--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 	"time"
 

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -406,6 +406,12 @@ func TestLoopTickBackoff(t *testing.T) {
 }
 
 func TestGenerateOCSPResponsePrecert(t *testing.T) {
+	// The schema required to insert a precertificate is only available in
+	// config-next at the time of writing.
+	if !strings.HasSuffix(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
+		return
+	}
+
 	updater, sa, dbMap, fc, cleanUp := setup(t)
 	defer cleanUp()
 

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -451,7 +451,7 @@ func TestGenerateOCSPResponsePrecert(t *testing.T) {
 
 	// Disable PrecertificateOCSP.
 	err = features.Set(map[string]bool{"PrecertificateOCSP": false})
-	test.AssertNotError(t, err, "setting PrecerticiateOCSP feature to off")
+	test.AssertNotError(t, err, "setting PrecertificateOCSP feature to off")
 
 	// Directly call generateResponse with the result, when the PrecertificateOCSP
 	// feature flag is disabled we expect this to error because no matching
@@ -462,7 +462,7 @@ func TestGenerateOCSPResponsePrecert(t *testing.T) {
 
 	// Now enable PrecertificateOCSP.
 	err = features.Set(map[string]bool{"PrecertificateOCSP": true})
-	test.AssertNotError(t, err, "setting PrecerticiateOCSP feature to off")
+	test.AssertNotError(t, err, "setting PrecertificateOCSP feature to off")
 
 	// Directly call generateResponse again with the same result. It should not
 	// error and should instead update the precertificate's OCSP status even

--- a/sa/model.go
+++ b/sa/model.go
@@ -134,9 +134,9 @@ func SelectCertificate(s dbOneSelector, q string, args ...interface{}) (core.Cer
 
 const precertFields = "registrationID, serial, der, issued, expires"
 
-// selectPrecertificate selects all fields of one precertificate object
+// SelectPrecertificate selects all fields of one precertificate object
 // identified by serial.
-func selectPrecertificate(s dbOneSelector, serial string) (core.Certificate, error) {
+func SelectPrecertificate(s dbOneSelector, serial string) (core.Certificate, error) {
 	var model precertificateModel
 	err := s.SelectOne(
 		&model,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -472,7 +472,7 @@ func (ssa *SQLStorageAuthority) GetPrecertificate(ctx context.Context, reqSerial
 		return nil,
 			fmt.Errorf("Invalid precertificate serial %q", *reqSerial.Serial)
 	}
-	cert, err := selectPrecertificate(ssa.dbMap.WithContext(ctx), *reqSerial.Serial)
+	cert, err := SelectPrecertificate(ssa.dbMap.WithContext(ctx), *reqSerial.Serial)
 	if err == sql.ErrNoRows {
 		return nil,
 			berrors.NotFoundError("precertificate with serial %q not found", *reqSerial.Serial)

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -27,6 +27,7 @@
       "timeout": "15s"
     },
     "features": {
+      "PrecertificateOCSP": true
     }
   },
 


### PR DESCRIPTION
Since 9906c9321776bf37c206fc47707cd3acc6919378 when `features.PrecertificateOCSP` is enabled it is possible for there to be `certificateStatus` rows that correspond to `precertificates` that do not have a matching final `certificates` row. This happens in the case where we began serving OCSP for a precert and weren't able to issue a final certificate.

Prior to the fix in this branch when the `ocsp-updater` would find stale OCSP responses by querying the `certificateStatus` table it would error in `generateResponse` when it couldn't find a matching `certificates` row. This branch updates the logic so that when `features.PrecertificateOCSP` is enabled it will also try finding the ocsp update DER from the `precertificates` table when there is no matching serial in the `certificates` table.