### PR TITLE
tests: fix TestPrecertificateRevocation integration test

### DIFF
--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -133,8 +133,8 @@ func (is *integrationSrv) addChainOrPre(w http.ResponseWriter, r *http.Request, 
 	is.Lock()
 	for _, h := range cert.DNSNames {
 		if is.rejectHosts[h] {
-			is.Unlock()
 			is.rejected = append(is.rejected, addChainReq.Chain[0])
+			is.Unlock()
 			w.WriteHeader(400)
 			return
 		}

--- a/test/integration/common_mock.go
+++ b/test/integration/common_mock.go
@@ -13,10 +13,12 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 )
 
+var ctSrvPorts = []int{4500, 4501, 4510, 4511}
+
 // ctAddRejectHost adds a domain to all of the CT test server's reject-host
 // lists. If this fails the test is aborted with a fatal error.
 func ctAddRejectHost(domain string) error {
-	for _, port := range []int{4500, 4501, 4510, 4511} {
+	for _, port := range ctSrvPorts {
 		url := fmt.Sprintf("http://boulder:%d/add-reject-host", port)
 		body := []byte(fmt.Sprintf(`{"host": %q}`, domain))
 		resp, err := http.Post(url, "", bytes.NewBuffer(body))


### PR DESCRIPTION
Spamming runs of the `TestPrecertificateRevocation` integration test from 1cd9733c244514a76572e9014e0e7fbb41a8827a found two ways it would flake on rare occasion:

1. A [data race in the `ct-test-srv`](https://gist.github.com/cpu/761c176cb72e0eaa52656d3322423202) would kill the test log process and the integration test would be unable to reach the mock API. This causes the test failure flagged in #4460. The root cause is addressed in 9ece20d by refactoring the `ct-test-srv`'s `addChainOrPre` function to use a separate function for checking/extending the rejected list with the correct locking in place.

2. Occasionally the integration test wasn't able to find a matching precert in the very first configured ct-test-srv. This produces a test failure like:
```
--- FAIL: TestPrecertificateRevocation (4.95s)
    --- FAIL: TestPrecertificateRevocation/revocation_by_certificate_key (1.27s)
        revocation_test.go:110: finding rejected precertificate: no matching ct-test-srv rejection found
FAIL
FAIL	github.com/letsencrypt/boulder/test/integration	4.961s
FAIL
```

I believe this is addressed by 8eaa38b9b37909d785f571bd2515da6262cc392f which changes the integration test logic to check all of the configured `ct-test-srv` instances for a matching precert instead of just the first.

Resolves https://github.com/letsencrypt/boulder/issues/4460