### PR TITLE
Include a CRC32-IEEE checksum in log lines

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"hash/crc32"
 	"sync"
 
 	"github.com/jmhodges/clock"
@@ -125,6 +126,9 @@ func (w *bothWriter) logAtLevel(level syslog.Priority, msg string) {
 
 	const red = "\033[31m\033[1m"
 	const yellow = "\033[33m"
+
+	crc := crc32.ChecksumIEEE([]byte(msg))
+	msg = fmt.Sprintf("%x %s", crc, msg)
 
 	switch syslogAllowed := int(level) <= w.syslogLevel; level {
 	case syslog.LOG_ERR:

--- a/log/log.go
+++ b/log/log.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"log/syslog"
 	"os"
 	"path"
 	"runtime"
 	"strings"
-	"hash/crc32"
 	"sync"
 
 	"github.com/jmhodges/clock"

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -106,8 +106,8 @@ func ExampleLogger() {
 	impl.AuditErr("Error Audit")
 	impl.Warning("Warning Audit")
 	// Output:
-	// [31m[1mE000000 log.test [AUDIT] Error Audit[0m
-	// [33mW000000 log.test Warning Audit[0m
+	// [31m[1mE000000 log.test 80b817e3 [AUDIT] Error Audit[0m
+	// [33mW000000 log.test 48fd5d76 Warning Audit[0m
 }
 
 func TestSyslogMethods(t *testing.T) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -106,8 +106,8 @@ func ExampleLogger() {
 	impl.AuditErr("Error Audit")
 	impl.Warning("Warning Audit")
 	// Output:
-	// [31m[1mE000000 log.test 80b817e3 [AUDIT] Error Audit[0m
-	// [33mW000000 log.test 48fd5d76 Warning Audit[0m
+	// [31m[1mE000000 log.test 46_ghQg [AUDIT] Error Audit[0m
+	// [33mW000000 log.test 9rr1xwQ Warning Audit[0m
 }
 
 func TestSyslogMethods(t *testing.T) {


### PR DESCRIPTION
Adds a CRC32-IEEE checksum to our log lines. At most this adds 8 bytes per line, and at least adds 2 bytes. Given this a relatively minor change I haven't bothered flagging it, although if we have anything in place that assumes the current structure of log lines we may want to add a flag in order to prevent immediate breakage before things can be altered.

Fixes #4474.