### PR TITLE
orphan-finder: adopt orphan precerts.

### DIFF
--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -17,6 +19,7 @@ import (
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
@@ -52,11 +55,39 @@ type config struct {
 
 type certificateStorage interface {
 	AddCertificate(context.Context, []byte, int64, []byte, *time.Time) (string, error)
+	AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*corepb.Empty, error)
 	GetCertificate(ctx context.Context, serial string) (core.Certificate, error)
+	GetPrecertificate(ctx context.Context, reqSerial *sapb.Serial) (*corepb.Certificate, error)
 }
 
 type ocspGenerator interface {
 	GenerateOCSP(context.Context, core.OCSPSigningRequest) ([]byte, error)
+}
+
+// orphanType is a numeric identifier for the type of orphan being processed.
+type orphanType int
+
+const (
+	// unknownOrphan indicates an orphan of an unknown type
+	unknownOrphan orphanType = iota
+	// certOrphan indicates an orphaned final certificate type
+	certOrphan
+	// precertOrphan indicates an orphaned precertificate type
+	precertOrphan
+)
+
+// String returns a human representation of the orphanType and the expected
+// label in the orphaning message for that type, or "unknown" if it isn't
+// a known orphan type.
+func (t orphanType) String() string {
+	switch t {
+	case certOrphan:
+		return "certificate"
+	case precertOrphan:
+		return "precertificate"
+	default:
+		return "unknown"
+	}
 }
 
 var (
@@ -67,83 +98,142 @@ var (
 
 var backdateDuration time.Duration
 
-func checkDER(sai certificateStorage, der []byte) (*x509.Certificate, error) {
-	ctx := context.Background()
-	cert, err := x509.ParseCertificate(der)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to parse DER: %s", err)
+// orphanTypeForCert returns precertOrphan if the certificate has the RFC 6962
+// CT poison extension, or certOrphan if it does not. If the certificate is nil
+// unknownOrphan is returned.
+func orphanTypeForCert(cert *x509.Certificate) orphanType {
+	if cert == nil {
+		return unknownOrphan
 	}
-	_, err = sai.GetCertificate(ctx, core.SerialToString(cert.SerialNumber))
+	// RFC 6962 Section 3.1 - https://tools.ietf.org/html/rfc6962#section-3.1
+	poisonExt := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(poisonExt) {
+			return precertOrphan
+		}
+	}
+	return certOrphan
+}
+
+// checkDER parses the provided DER bytes and uses the resulting certificate's
+// serial to check if there is an existing precertificate or certificate for the
+// provided DER. If there is a matching precert/cert serial then
+// errAlreadyExists and the orphanType are returned. If there is no matching
+// precert/cert serial then the parsed certificate and orphanType are returned.
+func checkDER(sai certificateStorage, der []byte) (*x509.Certificate, orphanType, error) {
+	ctx := context.Background()
+	orphan, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, unknownOrphan, fmt.Errorf("Failed to parse orphan DER: %s", err)
+	}
+	orphanSerial := core.SerialToString(orphan.SerialNumber)
+	orphanTyp := orphanTypeForCert(orphan)
+
+	switch orphanTyp {
+	case certOrphan:
+		_, err = sai.GetCertificate(ctx, orphanSerial)
+	case precertOrphan:
+		_, err = sai.GetPrecertificate(ctx, &sapb.Serial{Serial: &orphanSerial})
+	default:
+		err = errors.New("unknown orphan type")
+	}
 	if err == nil {
-		return nil, errAlreadyExists
+		return nil, orphanTyp, errAlreadyExists
 	}
 	if berrors.Is(err, berrors.NotFound) {
-		return cert, nil
+		return orphan, orphanTyp, nil
 	}
-	return nil, fmt.Errorf("Existing certificate lookup failed: %s", err)
+	return nil, orphanTyp, fmt.Errorf("Existing %s lookup failed: %s", orphanTyp, err)
 }
 
 // storeParsedLogLine attempts to parse one log line according to the format used when
-// orphaning certificates. It returns two booleans: The first is true if the
-// line was a match, and the second is true if the certificate was successfully
-// added to the DB. As part of adding a certificate to the DB, it requests a
-// fresh OCSP response from the CA to store alongside the certificate.
-func storeParsedLogLine(sa certificateStorage, ca ocspGenerator, logger blog.Logger, line string) (found bool, added bool) {
+// orphaning certificates and precertificates. It returns two booleans and the
+// orphanType: The first boolean is true if the line was a match, and the second
+// is true if the orphan was successfully added to the DB. As part of adding an
+// orphan to the DB, it requests a fresh OCSP response from the CA to store
+// alongside the precertificate/certificate.
+func storeParsedLogLine(sa certificateStorage, ca ocspGenerator, logger blog.Logger, line string) (found bool, added bool, typ orphanType) {
 	ctx := context.Background()
-	if !strings.Contains(line, "cert=") || !strings.Contains(line, "orphaning certificate") {
-		return false, false
+
+	// The log line should contain a label indicating it is a cert or a precert
+	// orphan. We will determine which it is in checkDER based on the DER instead
+	// of the log line label.
+	if !strings.Contains(line, fmt.Sprintf("orphaning %s", certOrphan)) &&
+		!strings.Contains(line, fmt.Sprintf("orphaning %s", precertOrphan)) {
+		return false, false, unknownOrphan
 	}
+	// The log line should also contain certificate DER
+	if !strings.Contains(line, "cert=") {
+		return false, false, unknownOrphan
+	}
+	// Extract and decode the orphan DER
 	derStr := derOrphan.FindStringSubmatch(line)
 	if len(derStr) <= 1 {
 		logger.AuditErrf("Didn't match regex for cert: %s", line)
-		return true, false
+		return true, false, unknownOrphan
 	}
 	der, err := hex.DecodeString(derStr[1])
 	if err != nil {
 		logger.AuditErrf("Couldn't decode hex: %s, [%s]", err, line)
-		return true, false
+		return true, false, unknownOrphan
 	}
-	cert, err := checkDER(sa, der)
+	// Parse the DER, determine the orphan type, and ensure it doesn't already
+	// exist in the DB
+	cert, typ, err := checkDER(sa, der)
 	if err != nil {
 		logFunc := logger.Errf
 		if err == errAlreadyExists {
 			logFunc = logger.Infof
 		}
 		logFunc("%s, [%s]", err, line)
-		return true, false
+		return true, false, typ
 	}
 	// extract the regID
 	regStr := regOrphan.FindStringSubmatch(line)
 	if len(regStr) <= 1 {
 		logger.AuditErrf("regID variable is empty, [%s]", line)
-		return true, false
+		return true, false, typ
 	}
 	regID, err := strconv.Atoi(regStr[1])
 	if err != nil {
 		logger.AuditErrf("Couldn't parse regID: %s, [%s]", err, line)
-		return true, false
+		return true, false, typ
 	}
-	// OCSP-Updater will do the first response generation for this cert so pass an
-	// empty OCSP response. We use `cert.NotBefore` as the issued date to avoid
-	// the SA tagging this certificate with an issued date of the current time
-	// when we know it was an orphan issued in the past. Because certificates are
-	// backdated we need to add the backdate duration to find the true issued
-	// time.
-	issuedDate := cert.NotBefore.Add(backdateDuration)
+	// generate a fresh OCSP response
 	ocspResponse, err := ca.GenerateOCSP(ctx, core.OCSPSigningRequest{
 		CertDER: der,
 		Status:  string(core.OCSPStatusGood),
 	})
 	if err != nil {
 		logger.AuditErrf("Couldn't generate OCSP: %s, [%s]", err, line)
-		return true, false
+		return true, false, typ
 	}
-	_, err = sa.AddCertificate(ctx, der, int64(regID), ocspResponse, &issuedDate)
+	// We use `cert.NotBefore` as the issued date to avoid the SA tagging this
+	// certificate with an issued date of the current time when we know it was an
+	// orphan issued in the past. Because certificates are backdated we need to
+	// add the backdate duration to find the true issued time.
+	issuedDate := cert.NotBefore.Add(backdateDuration)
+	switch typ {
+	case certOrphan:
+		_, err = sa.AddCertificate(ctx, der, int64(regID), ocspResponse, &issuedDate)
+	case precertOrphan:
+		reg64 := int64(regID)
+		issued := issuedDate.UnixNano()
+		_, err = sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
+			Der:    der,
+			RegID:  &reg64,
+			Ocsp:   ocspResponse,
+			Issued: &issued,
+		})
+	default:
+		// Shouldn't happen but be defensive anyway
+		err = errors.New("unknown orphan type")
+	}
 	if err != nil {
 		logger.AuditErrf("Failed to store certificate: %s, [%s]", err, line)
-		return true, false
+		return true, false, typ
 	}
-	return true, true
+	return true, true, typ
 }
 
 func setup(configFile string) (blog.Logger, core.StorageAuthority, core.CertificateAuthority) {
@@ -207,18 +297,30 @@ func main() {
 		logData, err := ioutil.ReadFile(*logPath)
 		cmd.FailOnError(err, "Failed to read log file")
 
-		orphansFound := int64(0)
-		orphansAdded := int64(0)
+		var certOrphansFound, certOrphansAdded, precertOrphansFound, precertOrphansAdded int64
 		for _, line := range strings.Split(string(logData), "\n") {
-			found, added := storeParsedLogLine(sa, ca, logger, line)
+			found, added, typ := storeParsedLogLine(sa, ca, logger, line)
+			var foundStat, addStat *int64
+			switch typ {
+			case certOrphan:
+				foundStat = &certOrphansFound
+				addStat = &certOrphansAdded
+			case precertOrphan:
+				foundStat = &precertOrphansFound
+				addStat = &precertOrphansAdded
+			default:
+				logger.Errf("Found orphan type %s", typ)
+				continue
+			}
 			if found {
-				orphansFound++
+				*foundStat++
 				if added {
-					orphansAdded++
+					*addStat++
 				}
 			}
 		}
-		logger.Infof("Found %d orphans and added %d to the database\n", orphansFound, orphansAdded)
+		logger.Infof("Found %d certificate orphans and added %d to the database\n", certOrphansFound, certOrphansAdded)
+		logger.Infof("Found %d precertificate orphans and added %d to the database\n", precertOrphansFound, precertOrphansAdded)
 
 	case "parse-der":
 		ctx := context.Background()
@@ -228,7 +330,7 @@ func main() {
 		}
 		der, err := ioutil.ReadFile(*derPath)
 		cmd.FailOnError(err, "Failed to read DER file")
-		cert, err := checkDER(sa, der)
+		cert, typ, err := checkDER(sa, der)
 		cmd.FailOnError(err, "Pre-AddCertificate checks failed")
 		// Because certificates are backdated we need to add the backdate duration
 		// to find the true issued time.
@@ -238,7 +340,22 @@ func main() {
 			Status:  string(core.OCSPStatusGood),
 		})
 		cmd.FailOnError(err, "Generating OCSP")
-		_, err = sa.AddCertificate(ctx, der, int64(*regID), ocspResponse, &issuedDate)
+
+		switch typ {
+		case certOrphan:
+			_, err = sa.AddCertificate(ctx, der, int64(*regID), ocspResponse, &issuedDate)
+		case precertOrphan:
+			reg64 := int64(*regID)
+			issued := issuedDate.UnixNano()
+			_, err = sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
+				Der:    der,
+				RegID:  &reg64,
+				Ocsp:   ocspResponse,
+				Issued: &issued,
+			})
+		default:
+			err = errors.New("unknown orphan type")
+		}
 		cmd.FailOnError(err, "Failed to add certificate to database")
 
 	default:

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -194,7 +194,7 @@ func storeParsedLogLine(sa certificateStorage, ca ocspGenerator, logger blog.Log
 		logger.AuditErrf("regID variable is empty, [%s]", line)
 		return true, false, typ
 	}
-	regID, err := strconv.Atoi(regStr[1])
+	regID, err := strconv.ParseInt(regStr[1], 10, 64)
 	if err != nil {
 		logger.AuditErrf("Couldn't parse regID: %s, [%s]", err, line)
 		return true, false, typ
@@ -215,13 +215,12 @@ func storeParsedLogLine(sa certificateStorage, ca ocspGenerator, logger blog.Log
 	issuedDate := cert.NotBefore.Add(backdateDuration)
 	switch typ {
 	case certOrphan:
-		_, err = sa.AddCertificate(ctx, der, int64(regID), ocspResponse, &issuedDate)
+		_, err = sa.AddCertificate(ctx, der, regID, ocspResponse, &issuedDate)
 	case precertOrphan:
-		reg64 := int64(regID)
 		issued := issuedDate.UnixNano()
 		_, err = sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
 			Der:    der,
-			RegID:  &reg64,
+			RegID:  &regID,
 			Ocsp:   ocspResponse,
 			Issued: &issued,
 		})

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -273,7 +273,7 @@ func main() {
 	configFile := flagSet.String("config", "", "File path to the configuration file for this service")
 	logPath := flagSet.String("log-file", "", "Path to boulder-ca log file to parse")
 	derPath := flagSet.String("der-file", "", "Path to DER certificate file")
-	regID := flagSet.Int("regID", 0, "Registration ID of user who requested the certificate")
+	regID := flagSet.Int64("regID", 0, "Registration ID of user who requested the certificate")
 	err := flagSet.Parse(os.Args[2:])
 	cmd.FailOnError(err, "Error parsing flagset")
 
@@ -343,13 +343,12 @@ func main() {
 
 		switch typ {
 		case certOrphan:
-			_, err = sa.AddCertificate(ctx, der, int64(*regID), ocspResponse, &issuedDate)
+			_, err = sa.AddCertificate(ctx, der, *regID, ocspResponse, &issuedDate)
 		case precertOrphan:
-			reg64 := int64(*regID)
 			issued := issuedDate.UnixNano()
 			_, err = sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
 				Der:    der,
-				RegID:  &reg64,
+				RegID:  regID,
 				Ocsp:   ocspResponse,
 				Issued: &issued,
 			})

--- a/cmd/orphan-finder/main_test.go
+++ b/cmd/orphan-finder/main_test.go
@@ -10,36 +10,82 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/core"
+	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
+	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
+	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
 )
 
 var log = blog.UseMock()
 
 type mockSA struct {
-	certificate core.Certificate
-	clk         clock.FakeClock
+	certificates    []core.Certificate
+	precertificates []core.Certificate
+	clk             clock.FakeClock
 }
 
 func (m *mockSA) AddCertificate(ctx context.Context, der []byte, regID int64, _ []byte, issued *time.Time) (string, error) {
-	m.certificate.DER = der
-	m.certificate.RegistrationID = regID
-
-	if issued == nil {
-		m.certificate.Issued = m.clk.Now()
-	} else {
-		m.certificate.Issued = *issued
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		return "", err
 	}
-
+	cert := core.Certificate{
+		DER:            der,
+		RegistrationID: regID,
+		Serial:         core.SerialToString(parsed.SerialNumber),
+	}
+	if issued == nil {
+		cert.Issued = m.clk.Now()
+	} else {
+		cert.Issued = *issued
+	}
+	m.certificates = append(m.certificates, cert)
 	return "", nil
 }
 
 func (m *mockSA) GetCertificate(ctx context.Context, s string) (core.Certificate, error) {
-	if m.certificate.DER != nil {
-		return m.certificate, nil
+	if len(m.certificates) == 0 {
+		return core.Certificate{}, berrors.NotFoundError("no certs stored")
 	}
-	return core.Certificate{}, berrors.NotFoundError("no cert stored")
+	for _, cert := range m.certificates {
+		if cert.Serial == s {
+			return cert, nil
+		}
+	}
+	return core.Certificate{}, berrors.NotFoundError("no cert stored for requested serial")
+}
+
+func (m *mockSA) AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*corepb.Empty, error) {
+	parsed, err := x509.ParseCertificate(req.Der)
+	if err != nil {
+		return nil, err
+	}
+	precert := core.Certificate{
+		DER:            req.Der,
+		RegistrationID: *req.RegID,
+		Serial:         core.SerialToString(parsed.SerialNumber),
+	}
+	if req.Issued == nil {
+		precert.Issued = m.clk.Now()
+	} else {
+		precert.Issued = time.Unix(0, *req.Issued)
+	}
+	m.precertificates = append(m.precertificates, precert)
+	return &corepb.Empty{}, nil
+}
+
+func (m *mockSA) GetPrecertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
+	if len(m.precertificates) == 0 {
+		return nil, berrors.NotFoundError("no precerts stored")
+	}
+	for _, precert := range m.precertificates {
+		if precert.Serial == *req.Serial {
+			return bgrpc.CertToPB(precert), nil
+		}
+	}
+	return nil, berrors.NotFoundError("no precert stored for requested serial")
 }
 
 type mockCA struct{}
@@ -69,12 +115,24 @@ func TestParseLine(t *testing.T) {
 
 	testCertDER := "3082045b30820343a003020102021300ffa0160630d618b2eb5c0510824b14274856300d06092a864886f70d01010b0500301f311d301b06035504030c146861707079206861636b65722066616b65204341301e170d3135313030333035323130305a170d3136303130313035323130305a3018311630140603550403130d6578616d706c652e636f2e626e30820122300d06092a864886f70d01010105000382010f003082010a02820101009ea3f1d21fade5596e36a6a77095a94758e4b72466b7444ada4f7c4cf6fde9b1d470b93b65c1fdd896917f248ccae49b57c80dc21c64b010699432130d059d2d8392346e8a179c7c947835549c64a7a5680c518faf0a5cbea48e684fca6304775c8fa9239c34f1d5cb2d063b098bd1c17183c7521efc884641b2f0b41402ac87c7076848d4347cef59dd5a9c174ad25467db933c95ef48c578ba762f527b21666a198fb5e1fe2d8299b4dceb1791e96ad075e3ecb057c776d764fad8f0829d43c32ddf985a3a36fade6966cec89468721a1ec47ab38eac8da4514060ded51d283a787b7c69971bda01f49f76baa41b1f9b4348aa4279e0fa55645d6616441f0d0203010001a382019530820191300e0603551d0f0101ff0404030205a0301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff04023000301d0603551d0e04160414369d0c100452b9eb3ffe7ae852e9e839a3ae5adb301f0603551d23041830168014fb784f12f96015832c9f177f3419b32e36ea4189306a06082b06010505070101045e305c302606082b06010505073001861a687474703a2f2f6c6f63616c686f73743a343030322f6f637370303206082b060105050730028626687474703a2f2f6c6f63616c686f73743a343030302f61636d652f6973737565722d6365727430180603551d110411300f820d6578616d706c652e636f2e626e30270603551d1f0420301e301ca01aa0188616687474703a2f2f6578616d706c652e636f6d2f63726c30630603551d20045c305a300a060667810c0102013000304c06032a03043045302206082b060105050702011616687474703a2f2f6578616d706c652e636f6d2f637073301f06082b0601050507020230130c11446f20576861742054686f752057696c74300d06092a864886f70d01010b05000382010100bbb4b994971cafa2e56e2258db46d88bfb361d8bfcd75521c03174e471eaa9f3ff2e719059bb57cc064079496d8550577c127baa84a18e792ddd36bf4f7b874b6d40d1d14288c15d38e4d6be25eb7805b1c3756b3735702eb4585d1886bc8af2c14086d3ce506e55184913c83aaaa8dfe6160bd035e42cda6d97697ed3ee3124c9bf9620a9fe6602191c1b746533c1d4a30023bbe902cb4aa661901177ed924eb836c94cc062dd0ce439c4ece9ee1dfe0499a42cbbcb2ea7243c59f4df4fdd7058229bacf9a640632dbd776b21633137b2df1c41f0765a66f448777aeec7ed4c0cdeb9d8a2356ff813820a287e11d52efde1aa543b4ef2ee992a7a9d5ccf7da4"
 
+	testPreCertDER := "308204553082033da003020102021203e1dea6f3349009a90e0306dbb39c3e7ca2300d06092a864886f70d01010b0500304a310b300906035504061302555331163014060355040a130d4c6574277320456e6372797074312330210603550403131a4c6574277320456e637279707420417574686f72697479205833301e170d3139313031363132353431375a170d3230303131343132353431375a30133111300f060355040313086a756e74732e696f30820122300d06092a864886f70d01010105000382010f003082010a0282010100c91926403839aadbf2a73af4f85e3884df553880c7e9d11943121b941f284a2c805b6329a93d7fb2357c1298d811cfce61faa863c334149f948ff52a55a516e56b2d31d137b1d0319f2aabdea0e9d5e8630b54d7e53597e094c323e24a7ec1ab0db5d85651a641ec3fd7841fe5cbc675315c49b714238ead757e55409fd68c4b48d42f14c2124d381800fd2ec417ed7f363b00ab23aaddaf9113d5cf889bbf391431bffb91d425d11a1e79318b7007b8e75cc56633662c3d6c58175b5cab6225aa495361b1124642f19584820d215f23f46bd9fafa3341a0f7f387bf7cdecbccd7fcbcb3e917becb41562771e579884a0d8a1b170536f82ba90b398e9a6932150203010001a382016a30820166300e0603551d0f0101ff0404030205a0301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff04023000301d0603551d0e041604144d14d73117ca7f5a27394ed590b0d037eb5888a2301f0603551d23041830168014a84a6a63047dddbae6d139b7a64565eff3a8eca1306f06082b0601050507010104633061302e06082b060105050730018622687474703a2f2f6f6373702e696e742d78332e6c657473656e63727970742e6f7267302f06082b060105050730028623687474703a2f2f636572742e696e742d78332e6c657473656e63727970742e6f72672f30130603551d11040c300a82086a756e74732e696f304c0603551d20044530433008060667810c0102013037060b2b0601040182df130101013028302606082b06010505070201161a687474703a2f2f6370732e6c657473656e63727970742e6f72673013060a2b06010401d6790204030101ff04020500300d06092a864886f70d01010b0500038201010035f9d6620874966f2aa400f069c5f601dc11083f5859a15d20e9b1d2f9d87d3756a71a03cee0ab2a69b5173a4395b698163ba60394167c9eb4b66d20d9b3a76bf94995288e8d15c70bee969f77a71147718803e73df0a7832c1fcae1e3138601ebc61725bc7505c6d1e5b0eaf7797e09161d71e37d76370dc489312b1bf0600d1c952f846edb810c284c0d831f27481a8f2220ad178c87d8c4688023fa3798293dc9fdffa9e5b885a8107d8a2480226cd5f9121d6d7ea83b10292371ad6757e7729b27136a064f2901822b4f0ea52f8149a17860e37d3dc925488b1ba4aa26ef51e60de024e67e3d5e04ac97d8bd79a003e668ea2e1bd1c0b9d77c7cf7bfdc32"
+
+	logLine := func(typ orphanType, der, regID, orderID string) string {
+		return fmt.Sprintf(
+			"0000-00-00T00:00:00+00:00 hostname boulder-ca[pid]: "+
+				"[AUDIT] Failed RPC to store at SA, orphaning %s: "+
+				"cert=[%s] err=[context deadline exceeded], regID=[%s], orderID=[%s]",
+			typ, der, regID, orderID)
+	}
+
 	testCases := []struct {
 		Name           string
 		LogLine        string
 		ExpectFound    bool
 		ExpectAdded    bool
 		ExpectNoErrors bool
+		ExpectAddedDER string
+		ExpectRegID    int
 	}{
 		{
 			Name:           "Empty line",
@@ -85,62 +143,121 @@ func TestParseLine(t *testing.T) {
 		},
 		{
 			Name:           "Empty cert in line",
-			LogLine:        "0000-00-00T00:00:00+00:00 hostname boulder-ca[pid]: [AUDIT] Failed RPC to store at SA, orphaning certificate: cert=[] err=[context deadline exceeded], regID=[1337], orderID=[0]",
+			LogLine:        logLine(certOrphan, "", "1337", "0"),
 			ExpectFound:    true,
 			ExpectAdded:    false,
 			ExpectNoErrors: false,
 		},
 		{
 			Name:           "Invalid cert in line",
-			LogLine:        "0000-00-00T00:00:00+00:00 hostname boulder-ca[pid]: [AUDIT] Failed RPC to store at SA, orphaning certificate: cert=[deadbeef] err=[context deadline exceeded], regID=[], orderID=[]",
+			LogLine:        logLine(certOrphan, "deadbeef", "", ""),
 			ExpectFound:    true,
 			ExpectAdded:    false,
 			ExpectNoErrors: false,
 		},
 		{
 			Name:           "Valid cert in line",
-			LogLine:        fmt.Sprintf("0000-00-00T00:00:00+00:00 hostname boulder-ca[pid]: [AUDIT] Failed RPC to store at SA, orphaning certificate: cert=[%s] err=[context deadline exceeded], regID=[1001], orderID=[0]", testCertDER),
+			LogLine:        logLine(certOrphan, testCertDER, "1001", "0"),
 			ExpectFound:    true,
 			ExpectAdded:    true,
+			ExpectAddedDER: testCertDER,
+			ExpectRegID:    1001,
 			ExpectNoErrors: true,
 		},
 		{
 			Name:        "Already inserted cert in line",
-			LogLine:     fmt.Sprintf("0000-00-00T00:00:00+00:00 hostname boulder-ca[pid]: [AUDIT] Failed RPC to store at SA, orphaning certificate: cert=[%s] err=[context deadline exceeded], regID=[1001], orderID=[0]", testCertDER),
+			LogLine:     logLine(certOrphan, testCertDER, "1001", "0"),
 			ExpectFound: true,
 			// ExpectAdded is false because we have already added this cert in the
 			// previous "Valid cert in line" test case.
 			ExpectAdded:    false,
 			ExpectNoErrors: true,
 		},
+		{
+			Name:           "Empty precert in line",
+			LogLine:        logLine(precertOrphan, "", "1337", "0"),
+			ExpectFound:    true,
+			ExpectAdded:    false,
+			ExpectNoErrors: false,
+		},
+		{
+			Name:           "Invalid precert in line",
+			LogLine:        logLine(precertOrphan, "deadbeef", "", ""),
+			ExpectFound:    true,
+			ExpectAdded:    false,
+			ExpectNoErrors: false,
+		},
+		{
+			Name:           "Valid precert in line",
+			LogLine:        logLine(precertOrphan, testPreCertDER, "9999", "0"),
+			ExpectFound:    true,
+			ExpectAdded:    true,
+			ExpectAddedDER: testPreCertDER,
+			ExpectRegID:    9999,
+			ExpectNoErrors: true,
+		},
+		{
+			Name:        "Already inserted precert in line",
+			LogLine:     logLine(precertOrphan, testPreCertDER, "1001", "0"),
+			ExpectFound: true,
+			// ExpectAdded is false because we have already added this cert in the
+			// previous "Valid cert in line" test case.
+			ExpectAdded:    false,
+			ExpectNoErrors: true,
+		},
+		{
+			Name:           "Unknown orphan type",
+			LogLine:        logLine(unknownOrphan, testPreCertDER, "1001", "0"),
+			ExpectFound:    false,
+			ExpectAdded:    false,
+			ExpectNoErrors: false,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			log.Clear()
-			found, added := storeParsedLogLine(sa, ca, log, tc.LogLine)
+			found, added, typ := storeParsedLogLine(sa, ca, log, tc.LogLine)
 			test.AssertEquals(t, found, tc.ExpectFound)
 			test.AssertEquals(t, added, tc.ExpectAdded)
 			logs := log.GetAllMatching("ERR:")
 			if tc.ExpectNoErrors {
 				test.AssertEquals(t, len(logs), 0)
 			}
+
+			if tc.ExpectAdded {
+				// Decode the precert/cert DER we expect the testcase added to get the
+				// certificate serial
+				der, _ := hex.DecodeString(tc.ExpectAddedDER)
+				testCert, _ := x509.ParseCertificate(der)
+				testCertSerial := core.SerialToString(testCert.SerialNumber)
+
+				// Fetch the precert/cert using the correct mock SA function
+				var storedCert core.Certificate
+				switch typ {
+				case precertOrphan:
+					resp, err := sa.GetPrecertificate(context.Background(), &sapb.Serial{Serial: &testCertSerial})
+					test.AssertNotError(t, err, "Error getting test precert serial from SA")
+					precert, err := bgrpc.PBToCert(resp)
+					test.AssertNotError(t, err, "Error getting test precert from GetPrecertificate pb response")
+					storedCert = precert
+				case certOrphan:
+					cert, err := sa.GetCertificate(context.Background(), testCertSerial)
+					test.AssertNotError(t, err, "Error getting test cert serial from SA")
+					storedCert = cert
+				default:
+					t.Fatalf("unknown orphan type returned: %s", typ)
+				}
+				// The orphan should have been added with the correct registration ID from the log line
+				test.AssertEquals(t, storedCert.RegistrationID, int64(tc.ExpectRegID))
+				// The Issued timestamp should be the certificate's NotBefore timestamp offset by the backdateDuration
+				expectedIssued := testCert.NotBefore.Add(backdateDuration)
+				test.Assert(t, storedCert.Issued.Equal(expectedIssued),
+					fmt.Sprintf("stored cert issued date (%s) was not equal to expected (%s)",
+						storedCert.Issued, expectedIssued))
+			}
 		})
 	}
-
-	// Decode the test cert DER we added above to get the certificate serial
-	der, _ := hex.DecodeString(testCertDER)
-	testCert, _ := x509.ParseCertificate(der)
-	testCertSerial := core.SerialToString(testCert.SerialNumber)
-
-	// Fetch the certificate from the mock SA
-	cert, err := sa.GetCertificate(context.Background(), testCertSerial)
-	// It should not error
-	test.AssertNotError(t, err, "Error getting test certificate from SA")
-	// The orphan cert should have been added with the correct registration ID from the log line
-	test.AssertEquals(t, cert.RegistrationID, int64(1001))
-	// The Issued timestamp should be the certificate's NotBefore timestamp offset by the backdateDuration
-	test.AssertEquals(t, cert.Issued, testCert.NotBefore.Add(backdateDuration))
 }
 
 func TestNotOrphan(t *testing.T) {
@@ -150,8 +267,9 @@ func TestNotOrphan(t *testing.T) {
 	ca := &mockCA{}
 
 	log.Clear()
-	found, added := storeParsedLogLine(sa, ca, log, "cert=fakeout")
+	found, added, typ := storeParsedLogLine(sa, ca, log, "cert=fakeout")
 	test.AssertEquals(t, found, false)
 	test.AssertEquals(t, added, false)
+	test.AssertEquals(t, typ, unknownOrphan)
 	checkNoErrors(t)
 }


### PR DESCRIPTION
Since 9906c93 the CA has logged orphan log lines for precertificates as well as certificates. The orphan-finder needs to handle them similar to final certificates.

Resolves https://github.com/letsencrypt/boulder/issues/4479