### PR TITLE
SA: Move GetPrecertificate next to AddPrecertificate.

### DIFF
--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -13,6 +13,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
+	bgrpc "github.com/letsencrypt/boulder/grpc"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
 

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -2,7 +2,9 @@ package sa
 
 import (
 	"crypto/x509"
+	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -465,25 +465,6 @@ func (ssa *SQLStorageAuthority) GetCertificate(ctx context.Context, serial strin
 	return cert, err
 }
 
-// GetPrecertificate takes a serial number and returns the corresponding
-// precertificate, or error if it does not exist.
-func (ssa *SQLStorageAuthority) GetPrecertificate(ctx context.Context, reqSerial *sapb.Serial) (*corepb.Certificate, error) {
-	if !core.ValidSerial(*reqSerial.Serial) {
-		return nil,
-			fmt.Errorf("Invalid precertificate serial %q", *reqSerial.Serial)
-	}
-	cert, err := SelectPrecertificate(ssa.dbMap.WithContext(ctx), *reqSerial.Serial)
-	if err == sql.ErrNoRows {
-		return nil,
-			berrors.NotFoundError("precertificate with serial %q not found", *reqSerial.Serial)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return bgrpc.CertToPB(cert), nil
-}
-
 // GetCertificateStatus takes a hexadecimal string representing the full 128-bit serial
 // number of a certificate and returns data about that certificate's current
 // validity.


### PR DESCRIPTION
We have a nice `sa/precertificates.go` file that holds `AddPrecertificate` (and other precert functions). Let's put `GetPrecertificate` there too instead of in the more generic `sa/sa.go`.