### PR TITLE
travis: remove stale rabbitmq hosts addon.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
     - le.wtf
     - boulder
     - boulder-mysql
-    - boulder-rabbitmq
 
 sudo: required
 


### PR DESCRIPTION
We've long since killed off RabbitMQ usage in Boulder. :rabbit: :no_entry_sign: 