### PR TITLE
CI/Dev: enable TLS 1.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,9 @@ services:
         environment:
             FAKE_DNS: 10.77.77.77
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config
+            BOULDER_CONFIG_DIR: test/config-next
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"
-            # TODO(@cpu): Remove this when we are ready to enable TLS 1.3
-            GODEBUG: "tls13=0"
         volumes:
           - .:/go/src/github.com/letsencrypt/boulder
           - ./.gocache:/root/.cache/go-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         environment:
             FAKE_DNS: 10.77.77.77
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config-next
+            BOULDER_CONFIG_DIR: test/config
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"
         volumes:

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -525,11 +525,12 @@ func TestTLSALPN01TLS13(t *testing.T) {
 	va, _ := setup(hs, 0, "", nil)
 
 	_, prob := va.validateChallenge(ctx, dnsi("localhost"), chall)
-	// TODO(@cpu): This should be changed to test there was no problem and that
-	// the correct stat counter was incremented once TLS 1.3 support is enabled.
-	if prob == nil {
-		t.Fatal("expected problem validating TLS-ALPN-01 challenge against a TLS 1.3 only server, got nil")
+	// Validation should not fail
+	if prob != nil {
+		t.Errorf("Validation failed: %v", prob)
 	}
-	test.AssertEquals(t, prob.Type, probs.TLSProblem)
-	test.AssertEquals(t, prob.Detail, "remote error: tls: protocol version not supported")
+	// The correct TLS-ALPN-01 OID counter should have been incremented
+	test.AssertEquals(t, test.CountCounterVec(
+		"oid", IdPeAcmeIdentifier.String(), va.metrics.tlsALPNOIDCounter),
+		1)
 }


### PR DESCRIPTION
Also update the VA's TLS-ALPN-01 TLS 1.3 unit test to not expect a failure.

We plan to enable TLS 1.3 for Boulder in the staging environment alongside the next release.

Follow-up to https://github.com/letsencrypt/boulder/pull/4435