### PR TITLE
log: panic if bothWriter write to stdout errs.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -175,12 +175,14 @@ func (w *bothWriter) logAtLevel(level syslog.Priority, msg string) {
 	}
 
 	if int(level) <= w.stdoutLevel {
-		fmt.Printf("%s%s %s %s%s\n",
+		if _, err := fmt.Printf("%s%s %s %s%s\n",
 			prefix,
 			w.clk.Now().Format("150405"),
 			path.Base(os.Args[0]),
 			msg,
-			reset)
+			reset); err != nil {
+			panic(fmt.Sprintf("failed to write to stdout: %v\n", err))
+		}
 	}
 }
 


### PR DESCRIPTION
If we can't write to stdout we prefer to panic immediately rather than potentially lose logs we capture from redirecting stdout as a syslog backup.

A unit test is included to verify the panic behaviour. Prior to the `log` diff in this branch the test failed because the non-nil `err` result from `fmt.Printf` was being [thrown away](https://github.com/letsencrypt/boulder/blob/7b513de6a5976fc0a975abe7c0a9bee6774edffc/log/log.go#L178-L183):
```
=== RUN   TestStdoutFailure
=== PAUSE TestStdoutFailure
=== CONT  TestStdoutFailure
FAIL	github.com/letsencrypt/boulder/log	0.011s
FAIL
```

After the `log` package diff in this branch is applied the test passes.

I additionally tested this end-to-end by redirecting stdout to a full filesystem volume mounted into the Boulder docker image. It provoked the expected panic when a component tried to write to stdout and the filesystem was full.