### PR TITLE
orphan-finder: Rename CAService in config.

### DIFF
--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -39,10 +39,10 @@ command descriptions:
 `
 
 type config struct {
-	TLS       cmd.TLSConfig
-	SAService *cmd.GRPCClientConfig
-	CAService *cmd.GRPCClientConfig
-	Syslog    cmd.SyslogConfig
+	TLS                  cmd.TLSConfig
+	SAService            *cmd.GRPCClientConfig
+	OCSPGeneratorService *cmd.GRPCClientConfig
+	Syslog               cmd.SyslogConfig
 	// Backdate specifies how to adjust a certificate's NotBefore date to get back
 	// to the original issued date. It should match the value used in
 	// `test/config/ca.json` for the CA "backdate" value.
@@ -164,7 +164,7 @@ func setup(configFile string) (blog.Logger, core.StorageAuthority, core.Certific
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(saConn))
 
-	caConn, err := bgrpc.ClientSetup(conf.CAService, tlsConfig, clientMetrics, cmd.Clock())
+	caConn, err := bgrpc.ClientSetup(conf.OCSPGeneratorService, tlsConfig, clientMetrics, cmd.Clock())
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to CA")
 	cac := bgrpc.NewCertificateAuthorityClient(nil, capb.NewCertificateAuthorityClient(caConn))
 


### PR DESCRIPTION
OCSPGeneratorService matches the semantics better, and is what
ocsp-updater uses. It also matches what's in the config-next.

This wasn't caught by integration tests because we don't currently
run orphan-finder in the integration tests. We don't have a good way
to induce failures in the SA on demand.