### PR TITLE
Deprecate EarlyOrderRateLimit and FasterGetOrder

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -20,16 +20,16 @@ func _() {
 	_ = x[RevokeAtRA-9]
 	_ = x[NewAuthorizationSchema-10]
 	_ = x[DisableAuthz2Orders-11]
-	_ = x[CAAValidationMethods-12]
-	_ = x[CAAAccountURI-13]
-	_ = x[HeadNonceStatusOK-14]
-	_ = x[EarlyOrderRateLimit-15]
-	_ = x[EnforceMultiVA-16]
-	_ = x[MultiVAFullResults-17]
-	_ = x[RemoveWFE2AccountID-18]
-	_ = x[CheckRenewalFirst-19]
-	_ = x[MandatoryPOSTAsGET-20]
-	_ = x[FasterGetOrderForNames-21]
+	_ = x[EarlyOrderRateLimit-12]
+	_ = x[FasterGetOrderForNames-13]
+	_ = x[CAAValidationMethods-14]
+	_ = x[CAAAccountURI-15]
+	_ = x[HeadNonceStatusOK-16]
+	_ = x[EnforceMultiVA-17]
+	_ = x[MultiVAFullResults-18]
+	_ = x[RemoveWFE2AccountID-19]
+	_ = x[CheckRenewalFirst-20]
+	_ = x[MandatoryPOSTAsGET-21]
 	_ = x[AllowV1Registration-22]
 	_ = x[ParallelCheckFailedValidation-23]
 	_ = x[DeleteUnusedChallenges-24]
@@ -39,9 +39,9 @@ func _() {
 	_ = x[StripDefaultSchemePort-28]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRANewAuthorizationSchemaDisableAuthz2OrdersCAAValidationMethodsCAAAccountURIHeadNonceStatusOKEarlyOrderRateLimitEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETFasterGetOrderForNamesAllowV1RegistrationParallelCheckFailedValidationDeleteUnusedChallengesV1DisableNewValidationsPrecertificateOCSPPrecertificateRevocationStripDefaultSchemePort"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRANewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitFasterGetOrderForNamesCAAValidationMethodsCAAAccountURIHeadNonceStatusOKEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETAllowV1RegistrationParallelCheckFailedValidationDeleteUnusedChallengesV1DisableNewValidationsPrecertificateOCSPPrecertificateRevocationStripDefaultSchemePort"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 178, 197, 217, 230, 247, 266, 280, 298, 317, 334, 352, 374, 393, 422, 444, 467, 485, 509, 531}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 178, 197, 216, 238, 258, 271, 288, 302, 320, 339, 356, 374, 393, 422, 444, 467, 485, 509, 531}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -23,6 +23,8 @@ const (
 	RevokeAtRA
 	NewAuthorizationSchema
 	DisableAuthz2Orders
+	EarlyOrderRateLimit
+	FasterGetOrderForNames
 
 	//   Currently in-use features
 	// Check CAA and respect validationmethods parameter.
@@ -32,9 +34,6 @@ const (
 	// HEAD requests to the WFE2 new-nonce endpoint should return HTTP StatusOK
 	// instead of HTTP StatusNoContent.
 	HeadNonceStatusOK
-	// EarlyOrderRateLimit enables the RA applying certificate per name/per FQDN
-	// set rate limits in NewOrder in addition to FinalizeOrder.
-	EarlyOrderRateLimit
 	// EnforceMultiVA causes the VA to block on remote VA PerformValidation
 	// requests in order to make a valid/invalid decision with the results.
 	EnforceMultiVA
@@ -50,8 +49,6 @@ const (
 	// MandatoryPOSTAsGET forbids legacy unauthenticated GET requests for ACME
 	// resources.
 	MandatoryPOSTAsGET
-	// Use an optimized query for GetOrderForNames.
-	FasterGetOrderForNames
 	// Allow creation of new registrations in ACMEv1.
 	AllowV1Registration
 	// Check the failed validation limit in parallel during NewOrder

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1042,6 +1042,10 @@ func (ra *RegistrationAuthorityImpl) NewCertificate(ctx context.Context, req cor
 	if err := csrlib.VerifyCSR(req.CSR, ra.maxNames, &ra.keyPolicy, ra.PA, ra.forceCNFromSAN, regID); err != nil {
 		return core.Certificate{}, berrors.MalformedError(err.Error())
 	}
+	if err := ra.checkLimits(ctx, req.CSR.DNSNames, regID); err != nil {
+		return core.Certificate{}, err
+	}
+
 	// NewCertificate provides an order ID of 0, indicating this is a classic ACME
 	// v1 issuance request from the new certificate endpoint that is not
 	// associated with an ACME v2 order.
@@ -1116,14 +1120,6 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 
 	if core.KeyDigestEquals(csr.PublicKey, account.Key) {
 		return emptyCert, berrors.MalformedError("certificate public key must be different than account key")
-	}
-
-	// Check rate limits before checking authorizations. If someone is unable to
-	// issue a cert due to rate limiting, we don't want to tell them to go get the
-	// necessary authorizations, only to later fail the rate limit check.
-	err = ra.checkLimits(ctx, names, account.ID)
-	if err != nil {
-		return emptyCert, err
 	}
 
 	var authzs map[string]*core.Authorization
@@ -1393,6 +1389,11 @@ func (ra *RegistrationAuthorityImpl) checkLimits(ctx context.Context, names []st
 		if err != nil {
 			return err
 		}
+	}
+
+	// Check if there is rate limit space for a new order within the current window
+	if err := ra.checkNewOrdersPerAccountLimit(ctx, regID); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1823,21 +1824,11 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	if existingOrder != nil {
 		return existingOrder, nil
 	}
-	// Otherwise we were unable to find an order to reuse, continue creating a new
-	// order
-
-	// Check if there is rate limit space for a new order within the current window
-	if err := ra.checkNewOrdersPerAccountLimit(ctx, *order.RegistrationID); err != nil {
+	// Check if there is rate limit space for issuing a certificate for the new
+	// order's names. If there isn't then it doesn't make sense to allow creating
+	// an order - it will just fail when finalization checks the same limits.
+	if err := ra.checkLimits(ctx, order.Names, *order.RegistrationID); err != nil {
 		return nil, err
-	}
-
-	if features.Enabled(features.EarlyOrderRateLimit) {
-		// Check if there is rate limit space for issuing a certificate for the new
-		// order's names. If there isn't then it doesn't make sense to allow creating
-		// an order - it will just fail when finalization checks the same limits.
-		if err := ra.checkLimits(ctx, order.Names, *order.RegistrationID); err != nil {
-			return nil, err
-		}
 	}
 
 	// An order's lifetime is effectively bound by the shortest remaining lifetime

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1120,9 +1120,8 @@ func TestNewOrderRateLimiting(t *testing.T) {
 	test.AssertNotError(t, err, "NewOrder for orderTwo failed after advancing clock")
 }
 
-// TestEarlyOrderRateLimiting tests that the EarlyOrderRateLimiting flag results
-// in NewOrder applying the certificates per name/per FQDN rate limits against
-// the order names.
+// TestEarlyOrderRateLimiting tests that NewOrder applies the certificates per
+// name/per FQDN rate limits against the order names.
 func TestEarlyOrderRateLimiting(t *testing.T) {
 	_, _, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
@@ -1150,10 +1149,6 @@ func TestEarlyOrderRateLimiting(t *testing.T) {
 		},
 	}
 
-	// Start with the feature flag enabled.
-	err := features.Set(map[string]bool{"EarlyOrderRateLimit": true})
-	test.AssertNotError(t, err, "Failed to set EarlyOrderRateLimit feature flag")
-
 	// Request an order for the test domain
 	newOrder := &rapb.NewOrderRequest{
 		RegistrationID: &Registration.ID,
@@ -1162,7 +1157,7 @@ func TestEarlyOrderRateLimiting(t *testing.T) {
 
 	// With the feature flag enabled the NewOrder request should fail because of
 	// the CertificatesPerNamePolicy.
-	_, err = ra.NewOrder(ctx, newOrder)
+	_, err := ra.NewOrder(ctx, newOrder)
 	test.AssertError(t, err, "NewOrder did not apply cert rate limits with feature flag enabled")
 
 	// The err should be the expected rate limit error
@@ -1171,15 +1166,6 @@ func TestEarlyOrderRateLimiting(t *testing.T) {
 	test.Assert(t,
 		strings.HasPrefix(err.Error(), expectedErrPrefix),
 		fmt.Sprintf("expected error to have prefix %q got %q", expectedErrPrefix, err))
-
-	// Disable EarlyOrderRateLimit.
-	_ = features.Set(map[string]bool{"EarlyOrderRateLimit": false})
-
-	// The same NewOrder request should now succeed because EarlyOrderRateLimit
-	// isn't enabled and the CertificatesPerNamePolicy won't be enforced until
-	// finalization time.
-	_, err = ra.NewOrder(ctx, newOrder)
-	test.AssertNotError(t, err, "NewOrder applied cert rate limits with feature flag disabled")
 }
 
 func TestAuthzFailedRateLimiting(t *testing.T) {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1784,25 +1784,14 @@ func (ssa *SQLStorageAuthority) GetOrderForNames(
 		RegistrationID int64
 	}
 	var err error
-	if features.Enabled(features.FasterGetOrderForNames) {
-		err = ssa.dbMap.WithContext(ctx).SelectOne(&result, `
+	err = ssa.dbMap.WithContext(ctx).SelectOne(&result, `
 					SELECT orderID, registrationID
 					FROM orderFqdnSets
 					WHERE setHash = ?
 					AND expires > ?
 					ORDER BY expires ASC
 					LIMIT 1`,
-			fqdnHash, ssa.clk.Now())
-	} else {
-		err = ssa.dbMap.WithContext(ctx).SelectOne(&result, `
-					SELECT orderID, registrationID
-					FROM orderFqdnSets
-					WHERE setHash = ?
-					AND registrationID = ?
-					AND expires > ?
-					LIMIT 1`,
-			fqdnHash, *req.AcctID, ssa.clk.Now())
-	}
+		fqdnHash, ssa.clk.Now())
 
 	if err == sql.ErrNoRows {
 		return nil, berrors.NotFoundError("no order matching request found")


### PR DESCRIPTION
This also moves a redundant `checkLimits` call that was happening both
for FinalizeOrder and NewCertificate. There's no need to call it for FinalizeOrder
because we're now checking limits in NewOrder.

Also, this moves the NewOrdersPerAccount limit into checkLimits. Notably, this
changes the order of checks somewhat, so it happens after the certificates
per domain limit and the certificates per FQDN limit. I think this is probably
safe enough without a feature flag, but if folks feel nervous about it, I can keep
the order exactly the same and then do some order-changing in a later PR
behind a flag.