### PR TITLE
orphan-finder: fix OCSP service config field

### DIFF
--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -42,10 +42,10 @@ command descriptions:
 `
 
 type config struct {
-	TLS       cmd.TLSConfig
-	SAService *cmd.GRPCClientConfig
-	CAService *cmd.GRPCClientConfig
-	Syslog    cmd.SyslogConfig
+	TLS                  cmd.TLSConfig
+	SAService            *cmd.GRPCClientConfig
+	OCSPGeneratorService *cmd.GRPCClientConfig
+	Syslog               cmd.SyslogConfig
 	// Backdate specifies how to adjust a certificate's NotBefore date to get back
 	// to the original issued date. It should match the value used in
 	// `test/config/ca.json` for the CA "backdate" value.
@@ -253,8 +253,8 @@ func setup(configFile string) (blog.Logger, core.StorageAuthority, core.Certific
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(saConn))
 
-	caConn, err := bgrpc.ClientSetup(conf.CAService, tlsConfig, clientMetrics, cmd.Clock())
-	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to CA")
+	caConn, err := bgrpc.ClientSetup(conf.OCSPGeneratorService, tlsConfig, clientMetrics, cmd.Clock())
+	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to OCSPGeneratorService")
 	cac := bgrpc.NewCertificateAuthorityClient(nil, capb.NewCertificateAuthorityClient(caConn))
 
 	backdateDuration = conf.Backdate.Duration


### PR DESCRIPTION
In d3b9107 the orphan-finder gained the ability to generate OCSP responses. To support this the `config-next/orphan-finder.json` config file was updated with an `ocspGeneratorService` key.

This update changes the orphan-finder's `config` struct to match the JSON key in-use. Prior to this change the struct field was expecting to be matched to a `caService` key in the JSON config.