### PR TITLE
Address #4476 issues

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -670,7 +670,9 @@ func modelToAuthzPB(am *authz2Model) (*corepb.Authorization, error) {
 	expires := am.Expires.UTC().UnixNano()
 	id := fmt.Sprintf("%d", am.ID)
 	status := uintToStatus[am.Status]
+	v2 := true
 	pb := &corepb.Authorization{
+		V2:             &v2,
 		Id:             &id,
 		Status:         &status,
 		Identifier:     &am.IdentifierValue,

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1470,6 +1470,11 @@ func (ssa *SQLStorageAuthority) GetOrder(ctx context.Context, req *sapb.OrderReq
 	if err != nil {
 		return nil, err
 	}
+	orderExp := time.Unix(0, *order.Expires)
+	if orderExp.Before(ssa.clk.Now()) {
+		return nil, berrors.NotFoundError("no order found for ID %d", *req.Id)
+	}
+
 	v1AuthzIDs, v2AuthzIDs, err := ssa.authzForOrder(ctx, *order.Id)
 	if err != nil {
 		return nil, err

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2741,7 +2741,7 @@ func TestNewAuthorizations2(t *testing.T) {
 	tokenA := "YXNkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	v2 := true
 	apbA := &corepb.Authorization{
-		V2: &v2,
+		V2:             &v2,
 		Identifier:     &ident,
 		RegistrationID: &reg.ID,
 		Status:         &pending,
@@ -2756,7 +2756,7 @@ func TestNewAuthorizations2(t *testing.T) {
 	}
 	tokenB := "ZmdoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	apbB := &corepb.Authorization{
-		V2: &v2,
+		V2:             &v2,
 		Identifier:     &ident,
 		RegistrationID: &reg.ID,
 		Status:         &pending,


### PR DESCRIPTION
Addresses two issues introduced in #4476:
* Keep setting the V2 field in `modelToAuthzPB` so RPCs returned from new components to old don't cause panics
* Don't return expired orders from the SA, so that users requesting old orders that contain old style authorizations don't cause breakage in the RA