### PR TITLE
web: strip :443/:80 unconditionally w/ features.StripDefaultSchemePort

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -114,9 +114,13 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// is sent to the /directory endpoint we don't reply with directory URLs that
 		// also contain these ports, which would then in turn end up being sent in the JWS
 		// signature 'url' header, which we don't support.
-		if r.TLS != nil && strings.HasSuffix(r.Host, ":443") {
+		//
+		// We unconditionally strip :443 even when r.TLS is nil because the WFE/WFE2
+		// may be deployed HTTP-only behind another service that terminates HTTPS on
+		// its behalf.
+		if strings.HasSuffix(r.Host, ":443") {
 			r.Host = strings.TrimSuffix(r.Host, ":443")
-		} else if r.TLS == nil && strings.HasSuffix(r.Host, ":80") {
+		} else if strings.HasSuffix(r.Host, ":80") {
 			r.Host = strings.TrimSuffix(r.Host, ":80")
 		}
 	}

--- a/web/context_test.go
+++ b/web/context_test.go
@@ -107,6 +107,12 @@ func TestHostHeaderRewrite(t *testing.T) {
 	req.TLS = &tls.ConnectionState{}
 	th.ServeHTTP(httptest.NewRecorder(), req)
 
+	req, err = http.NewRequest("GET", "/", &bytes.Reader{})
+	test.AssertNotError(t, err, "http.NewRequest failed")
+	req.Host = "localhost:443"
+	req.TLS = nil
+	th.ServeHTTP(httptest.NewRecorder(), req)
+
 	hhh.f = func(_ *RequestEvent, _ http.ResponseWriter, r *http.Request) {
 		t.Helper()
 		test.AssertEquals(t, r.Host, "localhost:123")


### PR DESCRIPTION
Only removing :443 when the http.Request.TLS is not nil breaks when Boulder's WFE/WFE2 are running HTTP behind a separate ingress proxy that terminates HTTPS on its behalf.

Follow-up to https://github.com/letsencrypt/boulder/pull/4448