### PR TITLE
Tidy up default_config_dir in integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
     #
     # Current Go version build tasks:
     #
-    - RUN="lints integration generate rpm"
+    - RUN="lints integration generate rpm" BOULDER_CONFIG_DIR="test/config"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
     - RUN="integration" BOULDER_CONFIG_DIR="test/config-next"

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -22,10 +22,10 @@ tempdir = tempfile.mkdtemp()
 def stop():
     shutil.rmtree(tempdir)
 
-default_config_dir = os.environ.get('BOULDER_CONFIG_DIR', '')
-if default_config_dir == '':
-    default_config_dir = 'test/config'
-CONFIG_NEXT = default_config_dir.startswith("test/config-next")
+config_dir = os.environ.get('BOULDER_CONFIG_DIR', '')
+if config_dir == '':
+    raise Exception("BOULDER_CONFIG_DIR was not set")
+CONFIG_NEXT = config_dir.startswith("test/config-next")
 
 def fakeclock(date):
     return date.strftime("%a %b %d %H:%M:%S UTC %Y")

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -265,7 +265,7 @@ def main():
         setup_twenty_days_ago()
         startservers.stop()
 
-    if not startservers.start(race_detection=True):
+    if not startservers.start(race_detection=True, fakeclock=None):
         raise Exception("startservers failed")
 
     if args.run_chisel:
@@ -354,7 +354,7 @@ def check_balance():
                 % address)
 
 def run_cert_checker():
-    run("./bin/cert-checker -config %s/cert-checker.json" % default_config_dir)
+    run("./bin/cert-checker -config %s/cert-checker.json" % config_dir)
 
 if __name__ == "__main__":
     try:

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -9,11 +9,7 @@ import tempfile
 import threading
 import time
 
-from helpers import waitport
-
-default_config_dir = os.environ.get('BOULDER_CONFIG_DIR', '')
-if default_config_dir == '':
-    default_config_dir = 'test/config'
+from helpers import waitport, config_dir, CONFIG_NEXT
 
 processes = []
 
@@ -43,7 +39,7 @@ def run(cmd, race_detection, fakeclock):
     p.cmd = cmd
     return p
 
-def start(race_detection, fakeclock=None, config_dir=default_config_dir):
+def start(race_detection, fakeclock):
     """Return True if everything builds and starts.
 
     Give up and return False if anything fails to build, or dies at
@@ -63,7 +59,7 @@ def start(race_detection, fakeclock=None, config_dir=default_config_dir):
     # before any services that intend to send it RPCs. On shutdown they will be
     # killed in reverse order.
     progs = []
-    if config_dir.startswith("test/config-next"):
+    if CONFIG_NEXT:
         # Run the two 'remote' VAs
         progs.extend([
             [8011, './bin/boulder-remoteva --config %s' % os.path.join(config_dir, "va-remote-a.json")],

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -406,11 +406,11 @@ def test_expiration_mailer():
 
     urllib2.urlopen("http://localhost:9381/clear", data='')
     print get_future_output('./bin/expiration-mailer --config %s/expiration-mailer.json' %
-        default_config_dir, no_reminder)
+        config_dir, no_reminder)
     print get_future_output('./bin/expiration-mailer --config %s/expiration-mailer.json' %
-        default_config_dir, first_reminder)
+        config_dir, first_reminder)
     print get_future_output('./bin/expiration-mailer --config %s/expiration-mailer.json' %
-        default_config_dir, last_reminder)
+        config_dir, last_reminder)
     resp = urllib2.urlopen("http://localhost:9381/count?to=%s" % email_addr)
     mailcount = int(resp.read())
     if mailcount != 2:
@@ -576,7 +576,7 @@ def test_admin_revoker_cert():
     # Revoke certificate by serial
     reset_akamai_purges()
     run("./bin/admin-revoker serial-revoke --config %s/admin-revoker.json %s %d" % (
-        default_config_dir, serial, 1))
+        config_dir, serial, 1))
     # Wait for OCSP response to indicate revocation took place
     ee_ocsp_url = "http://localhost:4002"
     verify_ocsp(cert_file_pem, "test/test-ca2.pem", ee_ocsp_url, "revoked")


### PR DESCRIPTION
We now expect that the config dir is always set, so we make that
explicit in the integration test and error if that's not true.

This change also renames the variable to just "config_dir", and removes
the parameter to startservers.start, which is currently never set to
anything other than its default value.

This also explicitly sets the environment variable in .travis.yml.