### PR TITLE
Clarify public key blocklist documentation.

### DIFF
--- a/ca/config/config.go
+++ b/ca/config/config.go
@@ -47,7 +47,7 @@ type CAConfig struct {
 	WeakKeyFile string
 
 	// BlockedKeyFile is the path to a YAML file containing Base64 encoded
-	// SHA256 hashes of DER encoded PKIX public keys that should be considered
+	// SHA256 hashes of SubjectPublicKeyInfo's that should be considered
 	// administratively blocked.
 	BlockedKeyFile string
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -65,7 +65,7 @@ type config struct {
 		WeakKeyFile string
 
 		// BlockedKeyFile is the path to a YAML file containing Base64 encoded
-		// SHA256 hashes of DER encoded PKIX public keys that should be considered
+		// SHA256 hashes of SubjectPublicKeyInfo's that should be considered
 		// administratively blocked.
 		BlockedKeyFile string
 

--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -61,7 +61,7 @@ type config struct {
 		DirectoryWebsite string
 
 		// BlockedKeyFile is the path to a YAML file containing Base64 encoded
-		// SHA256 hashes of DER encoded PKIX public keys that should be considered
+		// SHA256 hashes of SubjectPublicKeyInfo's that should be considered
 		// administratively blocked.
 		BlockedKeyFile string
 	}

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -79,7 +79,7 @@ type config struct {
 		LegacyKeyIDPrefix string
 
 		// BlockedKeyFile is the path to a YAML file containing Base64 encoded
-		// SHA256 hashes of DER encoded PKIX public keys that should be considered
+		// SHA256 hashes of SubjectPublicKeyInfo's that should be considered
 		// administratively blocked.
 		BlockedKeyFile string
 	}

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -11,13 +11,13 @@ import (
 )
 
 // blockedKeys is a type for maintaining a map of Base64 encoded SHA256 hashes
-// of DER encoded PKIX public keys that should be considered blocked.
+// of SubjectPublicKeyInfo's that should be considered blocked.
 // blockedKeys are created by using loadBlockedKeysList.
 type blockedKeys map[string]bool
 
 // blocked checks if the given public key is considered administratively
-// blocked based on a Base64 encoded SHA256 hash of the DER encoded PKIX public
-// key. Important: blocked should not be called except on a blockedKeys instance
+// blocked based on a Base64 encoded SHA256 hash of the SubjectPublicKeyInfo.
+// Important: blocked should not be called except on a blockedKeys instance
 // returned from loadBlockedKeysList.
 // function should not be used until after `loadBlockedKeysList` has returned.
 func (b blockedKeys) blocked(key crypto.PublicKey) (bool, error) {
@@ -34,7 +34,7 @@ func (b blockedKeys) blocked(key crypto.PublicKey) (bool, error) {
 
 // loadBlockedKeysList creates a blockedKeys object that can be used to check if
 // a key is blocked. It creates a lookup map from a list of Base64 encoded
-// SHA256 digest of a DER encoded PKIX public key hashes in the input YAML file
+// SHA256 hashes of SubjectPublicKeyInfo's in the input YAML file
 // with the expected format:
 //
 // ```

--- a/test/block-a-key/main.go
+++ b/test/block-a-key/main.go
@@ -14,12 +14,16 @@ import (
 )
 
 const usageHelp = `
-block-a-key is utility tool for generating a Base64 encoded SHA256 digest of
-a certificate or JWK public key in DER encoded PKIX subject public key form.
+block-a-key is utility tool for generating a SHA256 hash of the SubjectPublicKeyInfo
+from a certificate or a synthetic SubjectPublicKeyInfo generated from a JWK public key.
+It outputs the Base64 encoding of that hash.
 
 The produced encoded digest can be used with Boulder's key blocklist to block
 any ACME account creation or certificate requests that use the same public
 key.
+
+If you already have an SPKI hash, and it's a SHA256 hash, you can add it directly
+to the key blocklist. If it's in hex form you'll need to convert it to base64 first.
 
 installation:
   go install github.com/letsencrypt/boulder/test/block-a-key/...

--- a/test/example-blocked-keys.yaml
+++ b/test/example-blocked-keys.yaml
@@ -1,8 +1,7 @@
 #
 # List of blocked keys
 #
-# Each blocked entry is a Base64 encoded SHA256 digest of a public key encoded
-# in DER form as a PKIX public key.
+# Each blocked entry is a Base64 encoded SHA256 hash of a SubjectPublicKeyInfo.
 #
 # Use the test/block-a-key utility to generate new additions.
 #


### PR DESCRIPTION
Previously, we referred to "DER encoded PKIX public keys", but PKIX (RFC 5280)
doesn't define a standalone "public key" type. Instead, it defines
SubjectPublicKeyInfo, containing an algorithm and a BIT STRING. As a
result, SPKI and SPKI hash are more commonly used terms, and we're more
likely to get reports based on those. We should mirror that terminology
in our documentation.