### PR TITLE
Use relative paths in Go integration tests.

### DIFF
--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -6,9 +6,9 @@
   },
 
   "tls": {
-    "caCertFile": "../../test/grpc-creds/minica.pem",
-    "certFile": "../../test/grpc-creds/orphan-finder.boulder/cert.pem",
-    "keyFile": "../../test/grpc-creds/orphan-finder.boulder/key.pem"
+    "caCertFile": "test/grpc-creds/minica.pem",
+    "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
+    "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
   },
 
   "ocspGeneratorService": {

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -6,9 +6,9 @@
   },
 
   "tls": {
-    "caCertFile": "../../test/grpc-creds/minica.pem",
-    "certFile": "../../test/grpc-creds/orphan-finder.boulder/cert.pem",
-    "keyFile": "../../test/grpc-creds/orphan-finder.boulder/key.pem"
+    "caCertFile": "test/grpc-creds/minica.pem",
+    "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
+    "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
   },
 
   "ocspGeneratorService": {

--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/eggsampler/acme/v2"
 )
 
+func init() {
+	// Go tests get run in the directory their source code lives in. For these
+	// test cases, that would be "test/integration." However, it's easier to
+	// reference test data and config files for integration tests relative to the
+	// root of the Boulder repo, so we run all of these tests from there instead.
+	os.Chdir("../../")
+}
+
 var (
 	OIDExtensionCTPoison = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
 )

--- a/test/integration/orphan_finder_test.go
+++ b/test/integration/orphan_finder_test.go
@@ -39,8 +39,8 @@ func TestOrphanFinder(t *testing.T) {
 	io.WriteString(f, fmt.Sprintf(template, precert.SerialNumber.Bytes(),
 		precert.Raw, cert.SerialNumber.Bytes(), cert.Raw))
 	f.Close()
-	cmd := exec.Command("../../bin/orphan-finder", "parse-ca-log",
-		"--config", "../../"+os.Getenv("BOULDER_CONFIG_DIR")+"/orphan-finder.json",
+	cmd := exec.Command("./bin/orphan-finder", "parse-ca-log",
+		"--config", "./"+os.Getenv("BOULDER_CONFIG_DIR")+"/orphan-finder.json",
 		"--log-file", f.Name())
 	out, err := cmd.Output()
 	if err != nil {
@@ -70,7 +70,7 @@ func makeFakeCert(precert bool) (*x509.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	issuerKeyBytes, err := ioutil.ReadFile("../test-ca.key")
+	issuerKeyBytes, err := ioutil.ReadFile("test/test-ca.key")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes it simpler to specify paths to testdata and config files.

Fixes #4508