### PR TITLE
Run golang integration tests in parallel and run the race detector

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -48,7 +48,7 @@ def run_go_tests(filterPattern=None):
     cmdLine = [ "go", "test", ]
     if filterPattern is not None and filterPattern != "":
         cmdLine = cmdLine + ["--test.run", filterPattern]
-    cmdLine = cmdLine + ["-tags", "integration", "-count=1", "./test/integration"]
+    cmdLine = cmdLine + ["-tags", "integration", "-count=1", "-race", "./test/integration"]
     return subprocess.check_call(cmdLine, shell=False, stderr=subprocess.STDOUT)
 
 def run_expired_authz_purger():

--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestPrecertificateOCSP(t *testing.T) {
+	t.Parallel()
 	// This test is gated on the PrecertificateOCSP feature flag.
 	if !strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
 		return

--- a/test/integration/orphan_finder_test.go
+++ b/test/integration/orphan_finder_test.go
@@ -27,6 +27,7 @@ var template = `[AUDIT] Failed RPC to store at SA, orphaning precertificate: ser
 // be run after other tests so the account ID 1 exists (since the inserted
 // certificates will be associated with that account).
 func TestOrphanFinder(t *testing.T) {
+	t.Parallel()
 	precert, err := makeFakeCert(true)
 	if err != nil {
 		log.Fatal(err)

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -32,6 +32,7 @@ func isPrecert(cert *x509.Certificate) bool {
 // certificate can be revoked using all of the available RFC 8555 revocation
 // authentication mechansims.
 func TestPrecertificateRevocation(t *testing.T) {
+	t.Parallel()
 	// This test is gated on the PrecertificateRevocation feature flag.
 	if !strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
 		return


### PR DESCRIPTION
Somewhat annoyingly requires explicitly marking each test as being able to run in parallel, so that'll need to be remembered whenever we add a new test. One possible other solution would be to make each test its own package, which would make running them in parallel the default (as golang will run tests for different binaries/packages in parallel unless you tell it not to).

Fixes #4437.