### PR TITLE
Add CheckForACMEV1Authz flag.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -38,11 +38,12 @@ func _() {
 	_ = x[PrecertificateRevocation-27]
 	_ = x[StripDefaultSchemePort-28]
 	_ = x[GetAuthorizationsPerf-29]
+	_ = x[CheckForACMEV1Authz-30]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRANewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitFasterGetOrderForNamesCAAValidationMethodsCAAAccountURIHeadNonceStatusOKEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETAllowV1RegistrationParallelCheckFailedValidationDeleteUnusedChallengesV1DisableNewValidationsPrecertificateOCSPPrecertificateRevocationStripDefaultSchemePortGetAuthorizationsPerf"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRANewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitFasterGetOrderForNamesCAAValidationMethodsCAAAccountURIHeadNonceStatusOKEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETAllowV1RegistrationParallelCheckFailedValidationDeleteUnusedChallengesV1DisableNewValidationsPrecertificateOCSPPrecertificateRevocationStripDefaultSchemePortGetAuthorizationsPerfCheckForACMEV1Authz"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 178, 197, 216, 238, 258, 271, 288, 302, 320, 339, 356, 374, 393, 422, 444, 467, 485, 509, 531, 552}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 178, 197, 216, 238, 258, 271, 288, 302, 320, 339, 356, 374, 393, 422, 444, 467, 485, 509, 531, 552, 571}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -73,7 +73,8 @@ const (
 	GetAuthorizationsPerf
 	// Run a (potentially expensive) check during pending
 	// authorization reuse to make sure ACMEv1 authzs can't be reused
-	// in ACMEv2 orders.
+	// in ACMEv2 orders. Note: This flag should only be set to false when
+	// GetAuthorizationsPerf is true.
 	CheckForACMEV1Authz
 )
 

--- a/features/features.go
+++ b/features/features.go
@@ -71,6 +71,10 @@ const (
 	// GetAuthorizationsPerf enables a more performant GetAuthorizations2 query
 	// at the SA.
 	GetAuthorizationsPerf
+	// Run a (potentially expensive) check during pending
+	// authorization reuse to make sure ACMEv1 authzs can't be reused
+	// in ACMEv2 orders.
+	CheckForACMEV1Authz
 )
 
 // List of features and their default value, protected by fMu
@@ -105,6 +109,7 @@ var features = map[FeatureFlag]bool{
 	PrecertificateRevocation:      false,
 	StripDefaultSchemePort:        false,
 	GetAuthorizationsPerf:         false,
+	CheckForACMEV1Authz:           true,
 }
 
 var fMu = new(sync.RWMutex)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1477,7 +1477,7 @@ func (ssa *SQLStorageAuthority) GetAuthorizations2(ctx context.Context, req *sap
 	authz2IDMap := map[int64]bool{}
 	// Once the old authorization storage format fallback is removed we don't need
 	// this length check as if there are none returned we can just return immediately.
-	if features.Enabled(features.GetAuthorizationsPerf) && len(authzModels) > 0 {
+	if features.Enabled(features.CheckForACMEV1Authz) && features.Enabled(features.GetAuthorizationsPerf) && len(authzModels) > 0 {
 		// Previously we used a JOIN on the orderToAuthz2 table in order to make sure
 		// we only returned authorizations created using the ACME v2 API. Each time an
 		// order is created a pivot row (order ID + authz ID) is added to the
@@ -1512,7 +1512,7 @@ func (ssa *SQLStorageAuthority) GetAuthorizations2(ctx context.Context, req *sap
 
 	authzModelMap := make(map[string]authz2Model)
 	for _, am := range authzModels {
-		if _, present := authz2IDMap[am.ID]; features.Enabled(features.GetAuthorizationsPerf) && !present {
+		if _, present := authz2IDMap[am.ID]; features.Enabled(features.CheckForACMEV1Authz) && features.Enabled(features.GetAuthorizationsPerf) && !present {
 			continue
 		}
 		if existing, present := authzModelMap[am.IdentifierValue]; !present ||

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -24,6 +24,7 @@
       ]
     },
     "features": {
+      "CheckForACMEV1Authz": false,
       "DeleteUnusedChallenges": true,
       "FasterGetOrderForNames": true
     }


### PR DESCRIPTION
This flag defaults to true (our current behavior). If we disable it, it
removes the check in GetAuthorizations2 that ensures we don't reuse
ACMEv1 authorizations in an ACMEv2 order. That check can be an expensive
database query in certain situations, so we may want to disable it
temporarily while we implement a faster query.

Before this flag is set to false, GetAuthorizationsPerf must be set to true.