### PR TITLE
tests: fix TestPrecertificateOCSP flake.

### DIFF
--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"encoding/base64"
 	"os"
 	"strings"
 	"testing"
@@ -37,18 +36,15 @@ func TestPrecertificateOCSP(t *testing.T) {
 		t.Fatal("expected error issuing for domain rejected by CT servers; got none")
 	}
 
-	rejections, err := ctGetRejections(4500)
-	if err != nil {
-		t.Fatalf("getting ct-test-srv rejections: %s", err)
+	// Try to find a precertificate matching the domain from one of the
+	// configured ct-test-srv instances.
+	cert, err := ctFindRejection([]string{domain})
+	if err != nil || cert == nil {
+		t.Fatalf("couldn't find rejected precert for %q", domain)
 	}
-	for _, r := range rejections {
-		rejectedCertBytes, err := base64.StdEncoding.DecodeString(r)
-		if err != nil {
-			t.Fatalf("decoding rejected cert: %s", err)
-		}
-		_, err = ocsp_helper.ReqDER(rejectedCertBytes, ocsp.Good)
-		if err != nil {
-			t.Errorf("requesting OCSP for rejected precertificate: %s", err)
-		}
+
+	_, err = ocsp_helper.ReqDER(cert.Raw, ocsp.Good)
+	if err != nil {
+		t.Errorf("requesting OCSP for rejected precertificate: %s", err)
 	}
 }

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -107,19 +107,9 @@ func TestPrecertificateRevocation(t *testing.T) {
 
 			// Try to find a precertificate matching the domain from one of the
 			// configured ct-test-srv instances.
-			var cert *x509.Certificate
-			for _, port := range ctSrvPorts {
-				cert, err = ctFindRejection(port, []string{tc.domain})
-				if err != nil {
-					continue
-				} else if err == nil {
-					break
-				}
-			}
-			// At least one of the logs should have given us back a matching
-			// precertificate to use for revocation.
-			if cert == nil {
-				t.Fatal("precert was missing poison extension")
+			cert, err := ctFindRejection([]string{tc.domain})
+			if err != nil || cert == nil {
+				t.Fatalf("couldn't find rejected precert for %q", tc.domain)
 			}
 
 			// To be confident that we're testing the right thing also verify that the


### PR DESCRIPTION
Since 6f71c0c switched the Go integration tests to run in parallel the `TestPrecertificateOCSP` test has been flaky. To fix the flake the test needs to be changed to be resilient to precertificates other than the one it is expecting being returned by the ct-test-srv since other tests are also concurrently using it.