### PR TITLE
Use mockable clock in CA's OCSP signer.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -412,16 +412,7 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, xferObj co
 			core.SerialToString(cert.SerialNumber), cn, err)
 	}
 
-	// We use time.Now() rather than ca.clk.Now() here as we use openssl
-	// to verify the validity of the OCSP responses we generate during testing
-	// and openssl doesn't understand our concept of fake time so it thinks
-	// our responses are expired when we are doing things with our fake clock
-	// time set in the past. Since we don't rely on fake clock time for any
-	// OCSP unit tests always using the real time doesn't cause any problems.
-	// Currently the only integration test case that triggers this is
-	// ocsp_exp_unauth_setup, but any other integration test introduced that
-	// sets the fake clock into the past and verifies OCSP will also do so.
-	now := time.Now().Truncate(time.Hour)
+	now := ca.clk.Now().Truncate(time.Hour)
 	tbsResponse := ocsp.Response{
 		Status:       ocspStatusToCode[xferObj.Status],
 		SerialNumber: cert.SerialNumber,

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1173,7 +1173,7 @@ def test_auth_deactivation_v2():
         raise Exception("unexpected authorization status")
 
 
-def check_ocsp_successful(cert_file, issuer_file, url):
+def check_ocsp_basic_oid(cert_file, issuer_file, url):
     """
     This function checks if an OCSP response was successful, but doesn't verify
     the signature or timestamp. This is useful when simulating the past, so we
@@ -1207,7 +1207,7 @@ def ocsp_exp_unauth_setup():
     # Since we're pretending to be in the past, we'll get an expired OCSP
     # response. Just check that it exists; don't do the full verification (which
     # would fail).
-    check_ocsp_successful(cert_file_pem, "test/test-ca2.pem", "http://localhost:4002")
+    check_ocsp_basic_oid(cert_file_pem, "test/test-ca2.pem", "http://localhost:4002")
     global expired_cert_name
     expired_cert_name = cert_file_pem
 


### PR DESCRIPTION
This brings OCSP signing into alignment with the other components of the
CA in that they use ca.clk, which can be mocked out in unittests.

This tweaks test_ocsp_exp_unauth to be compatible with the change.

Fixes #4441.