### PR TITLE
bdns: move logDNSError to exchangeOne, log ErrId specially.

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -505,8 +505,8 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 }
 
 // logDNSError logs the provided err result from making a query for hostname to
-// the chosenServer. If the err is a `dns.ErrId` instance then the raw Base64
-// URL encoded bytes of the query (and if not-nil, the response) in wire format
+// the chosenServer. If the err is a `dns.ErrId` instance then the Base64
+// encoded bytes of the query (and if not-nil, the response) in wire format
 // is logged as well. This function is called from exchangeOne only for the case
 // where an error occurs querying a hostname that indicates a problem between
 // the VA and the chosenServer.
@@ -531,7 +531,7 @@ func logDNSError(
 			logger.Errf("logDNSError failed to pack msg: %v\n", err)
 			return
 		}
-		encodedMsg := base64.RawURLEncoding.EncodeToString(packedMsgBytes)
+		encodedMsg := base64.StdEncoding.EncodeToString(packedMsgBytes)
 
 		var encodedResp string
 		if resp != nil {
@@ -540,7 +540,7 @@ func logDNSError(
 				logger.Errf("logDNSError failed to pack resp: %v\n", err)
 				return
 			}
-			encodedResp = base64.RawURLEncoding.EncodeToString(packedRespBytes)
+			encodedResp = base64.StdEncoding.EncodeToString(packedRespBytes)
 		}
 
 		logger.Errf(

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -507,9 +507,10 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 // logDNSError logs the provided err result from making a query for hostname to
 // the chosenServer. If the err is a `dns.ErrId` instance then the Base64
 // encoded bytes of the query (and if not-nil, the response) in wire format
-// is logged as well. This function is called from exchangeOne only for the case
-// where an error occurs querying a hostname that indicates a problem between
-// the VA and the chosenServer.
+// is logged as well. This won't capture the query ID (this is internal to
+// miekg/dns) but it provides additonal information to help debug. This function
+// is called from exchangeOne only for the case where an error occurs querying
+// a hostname that indicates a problem between the VA and the chosenServer.
 func logDNSError(
 	logger blog.Logger,
 	chosenServer string,

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -299,7 +299,7 @@ func (dnsClient *DNSClientImpl) exchangeOne(ctx context.Context, hostname string
 				authenticated = fmt.Sprintf("%t", rsp.AuthenticatedData)
 			}
 			if err != nil {
-				dnsClient.logDNSError(hostname, m, rsp, err)
+				logDNSError(dnsClient.log, hostname, m, rsp, err)
 			}
 			dnsClient.queryTime.With(prometheus.Labels{
 				"qtype":              qtypeStr,
@@ -495,13 +495,6 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 // This function is called from exchangeOne only for the case where an error
 // occurs querying a hostname that indicates a problem between the VA and the
 // resolver.
-func (dnsClient *DNSClientImpl) logDNSError(hostname string, msg, resp *dns.Msg, err error) {
-	// We use a stand-alone function for this to make it easy to share the
-	// implementation between the DNSClientImpl and MockDNSClient
-	logDNSError(dnsClient.log, hostname, msg, resp, err)
-}
-
-// log a DNS level error with the given logger. See DNSClientImpl.logDNSError.
 func logDNSError(logger blog.Logger, hostname string, msg, resp *dns.Msg, underlying error) {
 	// We don't expect logDNSError to be called with a nil msg or err but
 	// if it happens return early. We allow resp to be nil.
@@ -539,7 +532,7 @@ func logDNSError(logger blog.Logger, hostname string, msg, resp *dns.Msg, underl
 			encodedResp)
 	} else {
 		// Otherwise log a general DNS error
-		logger.Errf("logDNSerror queryType=[%s] hostname=[%s] err=[%s]",
+		logger.Errf("logDNSError queryType=[%s] hostname=[%s] err=[%s]",
 			hostname,
 			queryType,
 			underlying)

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -182,7 +182,6 @@ func NewDNSClientImpl(
 	log blog.Logger,
 ) *DNSClientImpl {
 	stats = stats.NewScope("DNS")
-	// TODO(jmhodges): make constructor use an Option func pattern
 	dnsClient := new(dns.Client)
 
 	// Set timeout for underlying net.Conn

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -491,7 +491,10 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 
 // logDNSError logs the provided err result from making a query for hostname. If
 // the err is a `dns.ErrId` instance then the raw Base64 URL encoded bytes of
-// the query (and if not-nil) the response in wire format is logged as well.
+// the query (and if not-nil, the response) in wire format is logged as well.
+// This function is called from exchangeOne only for the case where an error
+// occurs querying a hostname that indicates a problem between the VA and the
+// resolver.
 func (dnsClient *DNSClientImpl) logDNSError(hostname string, msg, resp *dns.Msg, err error) {
 	// We use a stand-alone function for this to make it easy to share the
 	// implementation between the DNSClientImpl and MockDNSClient

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -14,6 +14,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 
+	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 )
 
@@ -157,6 +158,7 @@ type DNSClientImpl struct {
 	allowRestrictedAddresses bool
 	maxTries                 int
 	clk                      clock.Clock
+	log                      blog.Logger
 
 	queryTime       *prometheus.HistogramVec
 	totalLookupTime *prometheus.HistogramVec
@@ -177,6 +179,7 @@ func NewDNSClientImpl(
 	stats metrics.Scope,
 	clk clock.Clock,
 	maxTries int,
+	log blog.Logger,
 ) *DNSClientImpl {
 	stats = stats.NewScope("DNS")
 	// TODO(jmhodges): make constructor use an Option func pattern
@@ -220,14 +223,21 @@ func NewDNSClientImpl(
 		queryTime:                queryTime,
 		totalLookupTime:          totalLookupTime,
 		timeoutCounter:           timeoutCounter,
+		log:                      log,
 	}
 }
 
 // NewTestDNSClientImpl constructs a new DNS resolver object that utilizes the
 // provided list of DNS servers for resolution and will allow loopback addresses.
 // This constructor should *only* be called from tests (unit or integration).
-func NewTestDNSClientImpl(readTimeout time.Duration, servers []string, stats metrics.Scope, clk clock.Clock, maxTries int) *DNSClientImpl {
-	resolver := NewDNSClientImpl(readTimeout, servers, stats, clk, maxTries)
+func NewTestDNSClientImpl(
+	readTimeout time.Duration,
+	servers []string,
+	stats metrics.Scope,
+	clk clock.Clock,
+	maxTries int,
+	log blog.Logger) *DNSClientImpl {
+	resolver := NewDNSClientImpl(readTimeout, servers, stats, clk, maxTries, log)
 	resolver.allowRestrictedAddresses = true
 	return resolver
 }

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -507,10 +507,9 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 // logDNSError logs the provided err result from making a query for hostname to
 // the chosenServer. If the err is a `dns.ErrId` instance then the Base64
 // encoded bytes of the query (and if not-nil, the response) in wire format
-// is logged as well. This won't capture the query ID (this is internal to
-// miekg/dns) but it provides additonal information to help debug. This function
-// is called from exchangeOne only for the case where an error occurs querying
-// a hostname that indicates a problem between the VA and the chosenServer.
+// is logged as well. This function is called from exchangeOne only for the case
+// where an error occurs querying a hostname that indicates a problem between
+// the VA and the chosenServer.
 func logDNSError(
 	logger blog.Logger,
 	chosenServer string,

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -535,6 +535,7 @@ func logDNSError(
 		encodedMsg := base64.StdEncoding.EncodeToString(packedMsgBytes)
 
 		var encodedResp string
+		var respQname string
 		if resp != nil {
 			packedRespBytes, err := resp.Pack()
 			if err != nil {
@@ -542,12 +543,16 @@ func logDNSError(
 				return
 			}
 			encodedResp = base64.StdEncoding.EncodeToString(packedRespBytes)
+			if len(resp.Answer) > 0 && resp.Answer[0].Header() != nil {
+				respQname = resp.Answer[0].Header().Name
+			}
 		}
 
 		logger.Errf(
-			"logDNSError ID mismatch chosenServer=[%s] hostname=[%s] queryType=[%s] err=[%s] msg=[%s] resp=[%s]",
+			"logDNSError ID mismatch chosenServer=[%s] hostname=[%s] respHostname=[%s] queryType=[%s] err=[%s] msg=[%s] resp=[%s]",
 			chosenServer,
 			hostname,
+			respQname,
 			queryType,
 			underlying,
 			encodedMsg,

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
+	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/miekg/dns"
@@ -247,7 +248,7 @@ func newTestStats() metrics.Scope {
 var testStats = newTestStats()
 
 func TestDNSNoServers(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Hour, []string{}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Hour, []string{}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -255,7 +256,7 @@ func TestDNSNoServers(t *testing.T) {
 }
 
 func TestDNSOneServer(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -263,7 +264,7 @@ func TestDNSOneServer(t *testing.T) {
 }
 
 func TestDNSDuplicateServers(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr, dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr, dnsLoopbackAddr}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -271,7 +272,7 @@ func TestDNSDuplicateServers(t *testing.T) {
 }
 
 func TestDNSLookupsNoServer(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 	test.AssertError(t, err, "No servers")
@@ -284,7 +285,7 @@ func TestDNSLookupsNoServer(t *testing.T) {
 }
 
 func TestDNSServFail(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1, blog.UseMock())
 	bad := "servfail.com"
 
 	_, err := obj.LookupTXT(context.Background(), bad)
@@ -299,7 +300,7 @@ func TestDNSServFail(t *testing.T) {
 }
 
 func TestDNSLookupTXT(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	a, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 	t.Logf("A: %v", a)
@@ -313,7 +314,7 @@ func TestDNSLookupTXT(t *testing.T) {
 }
 
 func TestDNSLookupHost(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	ip, err := obj.LookupHost(context.Background(), "servfail.com")
 	t.Logf("servfail.com - IP: %s, Err: %s", ip, err)
@@ -380,7 +381,7 @@ func TestDNSLookupHost(t *testing.T) {
 }
 
 func TestDNSNXDOMAIN(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	hostname := "nxdomain.letsencrypt.org"
 	_, err := obj.LookupHost(context.Background(), hostname)
@@ -397,7 +398,7 @@ func TestDNSNXDOMAIN(t *testing.T) {
 }
 
 func TestDNSLookupCAA(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1)
+	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 1, blog.UseMock())
 
 	caas, err := obj.LookupCAA(context.Background(), "bracewel.net")
 	test.AssertNotError(t, err, "CAA lookup failed")
@@ -584,7 +585,7 @@ func TestRetry(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), tc.maxTries)
+		dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), tc.maxTries, blog.UseMock())
 		dr.dnsClient = tc.te
 		_, err := dr.LookupTXT(context.Background(), "example.com")
 		if err == errTooManyRequests {
@@ -611,7 +612,7 @@ func TestRetry(t *testing.T) {
 		}
 	}
 
-	dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 3)
+	dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, testStats, clock.NewFake(), 3, blog.UseMock())
 	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -704,7 +705,7 @@ func TestRotateServerOnErr(t *testing.T) {
 	// number of dnsServers to ensure we always get around to trying the one
 	// working server
 	maxTries := 5
-	client := NewTestDNSClientImpl(time.Second*10, dnsServers, testStats, clock.NewFake(), maxTries)
+	client := NewTestDNSClientImpl(time.Second*10, dnsServers, testStats, clock.NewFake(), maxTries, blog.UseMock())
 
 	// Configure a mock exchanger that will always return a retryable error for
 	// the A and B servers. This will force the C server to do all the work once

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -85,7 +85,7 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 		m.SetQuestion(dns.Fqdn(hostname), dns.TypeA)
 		m.AuthenticatedData = true
 		m.SetEdns0(4096, false)
-		logDNSError(mock.Log, hostname, m, nil, err)
+		logDNSError(mock.Log, "mock.server", hostname, m, nil, err)
 		return []net.IP{}, &DNSError{dns.TypeA, hostname, err, -1}
 	}
 	if hostname == "id.mismatch" {
@@ -99,7 +99,7 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 		record.Hdr = dns.RR_Header{Name: dns.Fqdn(hostname), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0}
 		record.A = net.ParseIP("127.0.0.1")
 		r.Answer = append(r.Answer, record)
-		logDNSError(mock.Log, hostname, m, r, err)
+		logDNSError(mock.Log, "mock.server", hostname, m, r, err)
 		return []net.IP{}, &DNSError{dns.TypeA, hostname, err, -1}
 	}
 	// dual-homed host with an IPv6 and an IPv4 address

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -121,10 +121,17 @@ func main() {
 			c.VA.DNSResolvers,
 			scope,
 			clk,
-			dnsTries)
+			dnsTries,
+			logger)
 		resolver = r
 	} else {
-		r := bdns.NewTestDNSClientImpl(dnsTimeout, c.VA.DNSResolvers, scope, clk, dnsTries)
+		r := bdns.NewTestDNSClientImpl(
+			dnsTimeout,
+			c.VA.DNSResolvers,
+			scope,
+			clk,
+			dnsTries,
+			logger)
 		resolver = r
 	}
 

--- a/va/caa.go
+++ b/va/caa.go
@@ -149,9 +149,6 @@ func (va *ValidationAuthorityImpl) parallelCAALookup(ctx context.Context, name s
 		wg.Add(1)
 		go func(name string, r *caaResult) {
 			r.records, r.err = va.dnsClient.LookupCAA(ctx, name)
-			if r.err != nil {
-				va.logDNSError(name, r.err)
-			}
 			wg.Done()
 		}(strings.Join(labels[i:], "."), &results[i])
 	}

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -152,13 +152,14 @@ func TestDNSValidationServFail(t *testing.T) {
 }
 
 func TestDNSValidationNoServer(t *testing.T) {
-	va, _ := setup(nil, 0, "", nil)
+	va, log := setup(nil, 0, "", nil)
 	va.dnsClient = bdns.NewTestDNSClientImpl(
 		time.Second*5,
 		nil,
 		metrics.NewNoopScope(),
 		clock.Default(),
-		1)
+		1,
+		log)
 
 	chalDNS := createChallenge(core.ChallengeTypeDNS01)
 

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -3,6 +3,7 @@ package va
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	mrand "math/rand"
@@ -22,6 +23,7 @@ import (
 	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/miekg/dns"
 
 	"testing"
 )
@@ -320,6 +322,46 @@ func TestHTTPValidationDNSError(t *testing.T) {
 		t.Errorf("Didn't see expected DNS error logged. Instead, got:\n%s",
 			strings.Join(mockLog.GetAllMatching(`.*`), "\n"))
 	}
+}
+
+// TestHTTPValidationDNSIdMismatchError tests that performing an HTTP-01
+// challenge with a domain name that always returns a DNS ID mismatch error from
+// the mock resolver results in valid query/response data being logged in
+// a format we can decode successfully.
+func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
+	va, mockLog := setup(nil, 0, "", nil)
+
+	_, _, prob := va.fetchHTTP(ctx, "id.mismatch", "/.well-known/acme-challenge/whatever")
+	test.AssertError(t, prob, "Expected validation fetch to fail")
+	matchingLines := mockLog.GetAllMatching(`logDNSError ID mismatch`)
+	if len(matchingLines) != 1 {
+		t.Errorf("Didn't see expected DNS error logged. Instead, got:\n%s",
+			strings.Join(mockLog.GetAllMatching(`.*`), "\n"))
+	}
+	expectedRegex := regexp.MustCompile(
+		`ERR: \[AUDIT\] logDNSError ID mismatch ` +
+			`hostname=\[id\.mismatch\] ` +
+			`err\=\[dns: id mismatch\] ` +
+			`msg=\[([A-Za-z0-9+_]+)\] ` +
+			`resp=\[([A-Za-z0-9+_]+)\]`,
+	)
+
+	matches := expectedRegex.FindAllStringSubmatch(matchingLines[0], -1)
+	test.AssertEquals(t, len(matches), 1)
+	submatches := matches[0]
+	test.AssertEquals(t, len(submatches), 3)
+
+	msgBytes, err := base64.RawURLEncoding.DecodeString(submatches[1])
+	test.AssertNotError(t, err, "bad base64 encoded query msg")
+	msg := new(dns.Msg)
+	err = msg.Unpack(msgBytes)
+	test.AssertNotError(t, err, "bad packed query msg")
+
+	respBytes, err := base64.RawURLEncoding.DecodeString(submatches[2])
+	test.AssertNotError(t, err, "bad base64 encoded resp msg")
+	resp := new(dns.Msg)
+	err = resp.Unpack(respBytes)
+	test.AssertNotError(t, err, "bad packed response msg")
 }
 
 func TestSetupHTTPValidation(t *testing.T) {

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -341,6 +341,7 @@ func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 	expectedRegex := regexp.MustCompile(
 		`ERR: \[AUDIT\] logDNSError ID mismatch ` +
 			`hostname=\[id\.mismatch\] ` +
+			`queryType=\[A\] ` +
 			`err\=\[dns: id mismatch\] ` +
 			`msg=\[([A-Za-z0-9+_]+)\] ` +
 			`resp=\[([A-Za-z0-9+_]+)\]`,

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -340,6 +340,7 @@ func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 	}
 	expectedRegex := regexp.MustCompile(
 		`ERR: \[AUDIT\] logDNSError ID mismatch ` +
+			`chosenServer=\[mock.server\] ` +
 			`hostname=\[id\.mismatch\] ` +
 			`queryType=\[A\] ` +
 			`err\=\[dns: id mismatch\] ` +

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -342,6 +342,7 @@ func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 		`ERR: \[AUDIT\] logDNSError ID mismatch ` +
 			`chosenServer=\[mock.server\] ` +
 			`hostname=\[id\.mismatch\] ` +
+			`respHostname=\[id\.mismatch\.\] ` +
 			`queryType=\[A\] ` +
 			`err\=\[dns: id mismatch\] ` +
 			`msg=\[([A-Za-z0-9+=/\=]+)\] ` +

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -344,8 +344,8 @@ func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 			`hostname=\[id\.mismatch\] ` +
 			`queryType=\[A\] ` +
 			`err\=\[dns: id mismatch\] ` +
-			`msg=\[([A-Za-z0-9+_]+)\] ` +
-			`resp=\[([A-Za-z0-9+_]+)\]`,
+			`msg=\[([A-Za-z0-9+=/\=]+)\] ` +
+			`resp=\[([A-Za-z0-9+=/\=]+)\]`,
 	)
 
 	matches := expectedRegex.FindAllStringSubmatch(matchingLines[0], -1)
@@ -353,13 +353,13 @@ func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 	submatches := matches[0]
 	test.AssertEquals(t, len(submatches), 3)
 
-	msgBytes, err := base64.RawURLEncoding.DecodeString(submatches[1])
+	msgBytes, err := base64.StdEncoding.DecodeString(submatches[1])
 	test.AssertNotError(t, err, "bad base64 encoded query msg")
 	msg := new(dns.Msg)
 	err = msg.Unpack(msgBytes)
 	test.AssertNotError(t, err, "bad packed query msg")
 
-	respBytes, err := base64.RawURLEncoding.DecodeString(submatches[2])
+	respBytes, err := base64.StdEncoding.DecodeString(submatches[2])
 	test.AssertNotError(t, err, "bad base64 encoded resp msg")
 	resp := new(dns.Msg)
 	err = resp.Unpack(respBytes)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -198,7 +198,7 @@ func setup(
 	va, err := NewValidationAuthorityImpl(
 		// Use the test server's port as both the HTTPPort and the TLSPort for the VA
 		&portConfig,
-		&bdns.MockDNSClient{},
+		&bdns.MockDNSClient{logger},
 		nil,
 		maxRemoteFailures,
 		userAgent,

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -198,7 +198,7 @@ func setup(
 	va, err := NewValidationAuthorityImpl(
 		// Use the test server's port as both the HTTPPort and the TLSPort for the VA
 		&portConfig,
-		&bdns.MockDNSClient{logger},
+		&bdns.MockDNSClient{Log: logger},
 		nil,
 		maxRemoteFailures,
 		userAgent,


### PR DESCRIPTION
We've found we need the context offered from logging the error closer to when it happens in the `bdns` package rather than in the `va`. Adopting the function requires adapting it slightly. Specifically in the new location we know it won't be called with any timeout results, with a non-dns error, or with a nil underlying error.

Having the logging done in `bdns` (and specifically from `exchangeOne`) also lets us log the wire format of the query and response when we get a `dns.ErrId` error indicating a query/response ID mismatch. A small unit test is included that ensures the logging happens as expected.

Resolves https://github.com/letsencrypt/boulder/issues/4532