### PR TITLE
SA: migrate `fqdnSets.id`, `issuedNames.id` to BIGINT.

### DIFF
--- a/sa/_db-next/migrations/20191118124728_FixFQDNSetsAndIssuedNamesID.sql
+++ b/sa/_db-next/migrations/20191118124728_FixFQDNSetsAndIssuedNamesID.sql
@@ -1,0 +1,12 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `fqdnSets` MODIFY `id` BIGINT(20) NOT NULL AUTO_INCREMENT;
+ALTER TABLE `issuedNames` MODIFY `id` BIGINT(20) NOT NULL AUTO_INCREMENT;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `fqdnSets` MODIFY `id` INT(11) NOT NULL AUTO_INCREMENT;
+ALTER TABLE `issuedNames` MODIFY `id` INT(11) NOT NULL AUTO_INCREMENT;


### PR DESCRIPTION
Based on the volume of data Boulder supports we use `BIGINT(20)` for database ID fields throughout all of our tables except for two that were missed: `fqdnSets` and `issuedNames`. Prior to this migration being applied both were using `INT(11)`, allowing only values up to 2,147,483,647. After the migration is applied the `BIGINT(20)` type allows values up to 2^63-1.