### PR TITLE
CA: add orphans and adopted_orphans prom. counters

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -989,6 +989,9 @@ func TestPrecertOrphanQueue(t *testing.T) {
 			strings.Join(testCtx.logger.GetAllMatching(".*"), "\n"))
 	}
 
+	orphanCount := test.CountCounterVec("type", "precert", ca.orphanCount)
+	test.AssertEquals(t, orphanCount, 1)
+
 	qsa.fail = false
 	err = ca.integrateOrphan()
 	test.AssertNotError(t, err, "integrateOrphan failed")
@@ -999,6 +1002,9 @@ func TestPrecertOrphanQueue(t *testing.T) {
 	if err != goque.ErrEmpty {
 		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)
 	}
+
+	adoptedCount := test.CountCounterVec("type", "precert", ca.adoptedOrphanCount)
+	test.AssertEquals(t, adoptedCount, 1)
 }
 
 func TestOrphanQueue(t *testing.T) {


### PR DESCRIPTION
The `orphans` Prometheus `CounterVec` is used to count orphans that couldn't be confirmed saved by the SA and were queued by the CA.

The `adopted_orphans` `CounterVec` is used to count orphans pulled from the queue by the CA and successfully integrated (adopted) through to the SA.

Both counter stats are labelled by "type", e.g. "precert" or "cert".

Resolves https://github.com/letsencrypt/boulder/issues/4555