### PR TITLE
admin-revoker: use WithTransaction

### DIFF
--- a/db/rollback.go
+++ b/db/rollback.go
@@ -21,10 +21,10 @@ func (re *RollbackError) Error() string {
 	return fmt.Sprintf("%s (also, while rolling back: %s)", re.Err, re.RollbackErr)
 }
 
-// Rollback rolls back the provided transaction. If the rollback fails for any
+// rollback rolls back the provided transaction. If the rollback fails for any
 // reason a `RollbackError` error is returned wrapping the original error. If no
 // rollback error occurs then the original error is returned.
-func Rollback(tx *gorp.Transaction, err error) error {
+func rollback(tx *gorp.Transaction, err error) error {
 	if txErr := tx.Rollback(); txErr != nil {
 		return &RollbackError{
 			Err:         err,

--- a/db/rollback_test.go
+++ b/db/rollback_test.go
@@ -30,11 +30,11 @@ func TestRollback(t *testing.T) {
 	dbMap := &gorp.DbMap{Db: dbConn, Dialect: dialect, TypeConverter: nil}
 
 	tx, _ := dbMap.Begin()
-	// Commit the transaction so that a subsequent Rollback will always fail.
+	// Commit the transaction so that a subsequent rollback will always fail.
 	_ = tx.Commit()
 
 	innerErr := berrors.NotFoundError("Gone, gone, gone")
-	result := Rollback(tx, innerErr)
+	result := rollback(tx, innerErr)
 
 	// Since the tx.Rollback will fail we expect the result to be a wrapped error
 	test.AssertNotEquals(t, result, innerErr)
@@ -47,7 +47,7 @@ func TestRollback(t *testing.T) {
 	// Create a new transaction and don't commit it this time. The rollback should
 	// succeed.
 	tx, _ = dbMap.Begin()
-	result = Rollback(tx, innerErr)
+	result = rollback(tx, innerErr)
 
 	// We expect that the err is returned unwrapped.
 	test.AssertEquals(t, result, innerErr)

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -17,7 +17,7 @@ func WithTransaction(ctx context.Context, dbMap DatabaseMap, f txFunc) (interfac
 	txWithCtx := tx.WithContext(ctx)
 	result, err := f(txWithCtx)
 	if err != nil {
-		return nil, Rollback(tx, err)
+		return nil, rollback(tx, err)
 	}
 	err = tx.Commit()
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         environment:
             FAKE_DNS: 10.77.77.77
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config
+            BOULDER_CONFIG_DIR: test/config-next
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         environment:
             FAKE_DNS: 10.77.77.77
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
-            BOULDER_CONFIG_DIR: test/config-next
+            BOULDER_CONFIG_DIR: test/config
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"
         volumes:


### PR DESCRIPTION
This is a small clean-up I spotted while migrating the `WithTransaction` wrapper out of the `sa` package into `db` during https://github.com/letsencrypt/boulder/pull/4544.

The `admin-revoker` util. was using bare transactions with the `db.Rollback` (prev `sa.Rollback`) helper function instead of the newly exported `db.WithTransaction` wrapper. The latter is safer so we should use it here too.

After this change all of the external consumers of the `Rollback` function have been switched to using `WithTransaction` so we can unexport `Rollback`.