### PR TITLE
deps: update weppos/publicsuffix-go and zmap/zlint.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,9 +32,9 @@ require (
 	github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 // indirect
 	github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
-	github.com/weppos/publicsuffix-go v0.10.1-0.20190926082447-75329425f8bb
+	github.com/weppos/publicsuffix-go v0.10.1-0.20191119120252-3dd5f42d2d87
 	github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e
-	github.com/zmap/zlint v1.0.2-0.20190921214057-00156801166b
+	github.com/zmap/zlint v1.0.3-0.20191115164049-eea5fe83935a
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2
 	golang.org/x/sys v0.0.0-20190416152802-12500544f89f // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/weppos/publicsuffix-go v0.5.1-0.20190725085804-8ac7722bc7d7 h1:lUoUsi
 github.com/weppos/publicsuffix-go v0.5.1-0.20190725085804-8ac7722bc7d7/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.10.1-0.20190926082447-75329425f8bb h1:EiKPP9teaFiXHBov7yjs2s2OdtCIRPxHHmWe9D0+e88=
 github.com/weppos/publicsuffix-go v0.10.1-0.20190926082447-75329425f8bb/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
+github.com/weppos/publicsuffix-go v0.10.1-0.20191119120252-3dd5f42d2d87 h1:atBJZP3ARnSmu6xeR2b0ksATs8da4d6er1f6VnrucoY=
+github.com/weppos/publicsuffix-go v0.10.1-0.20191119120252-3dd5f42d2d87/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=
@@ -164,6 +166,8 @@ github.com/zmap/zlint v1.0.1 h1:LRjQApGB7ppkCQEsW2FVYBxz7KJWGHZZvk1OsnbLxgY=
 github.com/zmap/zlint v1.0.1/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
 github.com/zmap/zlint v1.0.2-0.20190921214057-00156801166b h1:gZluua+YxLCHC5AN3j2HnuLj0BgkxuHy9OzZC8W86fE=
 github.com/zmap/zlint v1.0.2-0.20190921214057-00156801166b/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
+github.com/zmap/zlint v1.0.3-0.20191115164049-eea5fe83935a h1:QaoQc5dqoKaxmebnB1fCIrBxHCdrIinK8SAsWC/v720=
+github.com/zmap/zlint v1.0.3-0.20191115164049-eea5fe83935a/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
+++ b/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
@@ -3,13 +3,13 @@
 
 package publicsuffix
 
-const defaultListVersion = "PSL version f42b9c (Wed Sep 25 17:05:14 2019)"
+const defaultListVersion = "PSL version 2c6878 (Fri Nov 15 23:25:27 2019)"
 
-func DefaultRules() [8796]Rule {
+func DefaultRules() [8794]Rule {
 	return r
 }
 
-var r = [8796]Rule{
+var r = [8794]Rule{
 	{1, "ac", 1, false},
 	{1, "com.ac", 2, false},
 	{1, "edu.ac", 2, false},
@@ -5449,6 +5449,9 @@ var r = [8796]Rule{
 	{1, "univ.sn", 2, false},
 	{1, "so", 1, false},
 	{1, "com.so", 2, false},
+	{1, "edu.so", 2, false},
+	{1, "gov.so", 2, false},
+	{1, "me.so", 2, false},
 	{1, "net.so", 2, false},
 	{1, "org.so", 2, false},
 	{1, "sr", 1, false},
@@ -6323,7 +6326,6 @@ var r = [8796]Rule{
 	{1, "career", 1, false},
 	{1, "careers", 1, false},
 	{1, "cars", 1, false},
-	{1, "cartier", 1, false},
 	{1, "casa", 1, false},
 	{1, "case", 1, false},
 	{1, "caseih", 1, false},
@@ -6480,7 +6482,6 @@ var r = [8796]Rule{
 	{1, "eurovision", 1, false},
 	{1, "eus", 1, false},
 	{1, "events", 1, false},
-	{1, "everbank", 1, false},
 	{1, "exchange", 1, false},
 	{1, "expert", 1, false},
 	{1, "exposed", 1, false},
@@ -6909,7 +6910,6 @@ var r = [8796]Rule{
 	{1, "photography", 1, false},
 	{1, "photos", 1, false},
 	{1, "physio", 1, false},
-	{1, "piaget", 1, false},
 	{1, "pics", 1, false},
 	{1, "pictet", 1, false},
 	{1, "pictures", 1, false},
@@ -7457,9 +7457,6 @@ var r = [8796]Rule{
 	{1, "potager.org", 2, true},
 	{1, "sweetpepper.org", 2, true},
 	{1, "myasustor.com", 2, true},
-	{1, "go-vip.co", 2, true},
-	{1, "go-vip.net", 2, true},
-	{1, "wpcomstaging.com", 2, true},
 	{1, "myfritz.net", 2, true},
 	{2, "awdev.ca", 3, true},
 	{2, "advisor.ws", 3, true},
@@ -8640,6 +8637,7 @@ var r = [8796]Rule{
 	{1, "logoip.de", 2, true},
 	{1, "logoip.com", 2, true},
 	{1, "schokokeks.net", 2, true},
+	{1, "gov.scot", 2, true},
 	{1, "scrysec.com", 2, true},
 	{1, "firewall-gateway.com", 2, true},
 	{1, "firewall-gateway.de", 2, true},

--- a/vendor/github.com/zmap/zlint/.gitignore
+++ b/vendor/github.com/zmap/zlint/.gitignore
@@ -119,3 +119,5 @@ cmd/zlint/zlint
 /zlint-gtld-update
 cmd/zlint-gtld-update/zlint-gtld-update
 
+### Integration test data ###
+data

--- a/vendor/github.com/zmap/zlint/.travis.yml
+++ b/vendor/github.com/zmap/zlint/.travis.yml
@@ -14,6 +14,12 @@ script:
   - make format-check
   # Run unit tests
   - make test
+  # Run integration tests
+  - make integration PARALLELISM=3
+
+cache:
+  directories:
+    - data
 
 notifications:
   email:

--- a/vendor/github.com/zmap/zlint/lints/lint_qcstatem_qclimitvalue_valid.go
+++ b/vendor/github.com/zmap/zlint/lints/lint_qcstatem_qclimitvalue_valid.go
@@ -25,7 +25,7 @@ import (
 type qcStatemQcLimitValueValid struct{}
 
 func (this *qcStatemQcLimitValueValid) getStatementOid() *asn1.ObjectIdentifier {
-	return &util.IdEtsiQcsQcSSCD
+	return &util.IdEtsiQcsQcLimitValue
 }
 
 func (l *qcStatemQcLimitValueValid) Initialize() error {

--- a/vendor/github.com/zmap/zlint/makefile
+++ b/vendor/github.com/zmap/zlint/makefile
@@ -1,10 +1,15 @@
 SHELL := /bin/bash
+# Number of linting Go routines to use in integration tests
+PARALLELISM := 5
+# Additional integration test flags (e.g. -force, -summary, -outputTick)
+INT_FLAGS :=
 
 CMDS = zlint zlint-gtld-update
 CMD_PREFIX = ./cmd/
 GO_ENV = GO111MODULE="on" GOFLAGS="-mod=vendor"
 BUILD = $(GO_ENV) go build
 TEST = $(GO_ENV) GORACE=halt_on_error=1 go test -race
+INT_TEST = $(GO_ENV) go test -v -tags integration -timeout 20m ./integration/... -parallelism $(PARALLELISM) $(INT_FLAGS)
 
 all: $(CMDS)
 
@@ -20,7 +25,10 @@ clean:
 test:
 	$(TEST) ./...
 
+integration:
+	$(INT_TEST)
+
 format-check:
 	diff <(find . -name '*.go' -not -path './vendor/*' -print | xargs -n1 gofmt -l) <(printf "")
 
-.PHONY: clean zlint zlint-gtld-update test format-check
+.PHONY: clean zlint zlint-gtld-update test integration format-check

--- a/vendor/github.com/zmap/zlint/util/gtld_map.go
+++ b/vendor/github.com/zmap/zlint/util/gtld_map.go
@@ -1096,7 +1096,7 @@ var tldMap = map[string]GTLDPeriod{
 	"cartier": {
 		GTLD:           "cartier",
 		DelegationDate: "2014-12-11",
-		RemovalDate:    "",
+		RemovalDate:    "2019-11-14",
 	},
 	"casa": {
 		GTLD:           "casa",
@@ -2081,7 +2081,7 @@ var tldMap = map[string]GTLDPeriod{
 	"everbank": {
 		GTLD:           "everbank",
 		DelegationDate: "2014-11-26",
-		RemovalDate:    "",
+		RemovalDate:    "2019-11-14",
 	},
 	"exchange": {
 		GTLD:           "exchange",
@@ -4896,7 +4896,7 @@ var tldMap = map[string]GTLDPeriod{
 	"piaget": {
 		GTLD:           "piaget",
 		DelegationDate: "2015-03-16",
-		RemovalDate:    "",
+		RemovalDate:    "2019-11-14",
 	},
 	"pics": {
 		GTLD:           "pics",

--- a/vendor/github.com/zmap/zlint/util/qc_stmt.go
+++ b/vendor/github.com/zmap/zlint/util/qc_stmt.go
@@ -98,14 +98,14 @@ type EtsiQcSscd struct {
 }
 
 type EtsiMonetaryValueAlph struct {
-	iso4217CurrencyCodeAlph string `asn1:"printable"`
-	amount                  int
-	exponent                int
+	Iso4217CurrencyCodeAlph string `asn1:"printable"`
+	Amount                  int
+	Exponent                int
 }
 type EtsiMonetaryValueNum struct {
-	iso4217CurrencyCodeNum int
-	amount                 int
-	exponent               int
+	Iso4217CurrencyCodeNum int
+	Amount                 int
+	Exponent               int
 }
 
 type EtsiQcLimitValue struct {
@@ -217,9 +217,9 @@ func ParseQcStatem(extVal []byte, sought asn1.ObjectIdentifier) EtsiQcStmtIf {
 				numErr = true
 			} else {
 				etsiObj.IsNum = true
-				etsiObj.Amount = numeric.amount
-				etsiObj.Exponent = numeric.exponent
-				etsiObj.CurrencyNum = numeric.iso4217CurrencyCodeNum
+				etsiObj.Amount = numeric.Amount
+				etsiObj.Exponent = numeric.Exponent
+				etsiObj.CurrencyNum = numeric.Iso4217CurrencyCodeNum
 
 			}
 			if numErr {
@@ -228,9 +228,9 @@ func ParseQcStatem(extVal []byte, sought asn1.ObjectIdentifier) EtsiQcStmtIf {
 					alphErr = true
 				} else {
 					etsiObj.IsNum = false
-					etsiObj.Amount = alphabetic.amount
-					etsiObj.Exponent = alphabetic.exponent
-					etsiObj.CurrencyAlph = alphabetic.iso4217CurrencyCodeAlph
+					etsiObj.Amount = alphabetic.Amount
+					etsiObj.Exponent = alphabetic.Exponent
+					etsiObj.CurrencyAlph = alphabetic.Iso4217CurrencyCodeAlph
 					AppendToStringSemicolonDelim(&etsiObj.errorInfo,
 						checkAsn1Reencoding(reflect.ValueOf(alphabetic).Interface(),
 							statem.Any.FullBytes, "error with ASN.1 encoding, possibly a wrong ASN.1 string type was used"))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -86,7 +86,7 @@ github.com/syndtr/goleveldb/leveldb/table
 github.com/syndtr/goleveldb/leveldb/util
 # github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
 github.com/titanous/rocacheck
-# github.com/weppos/publicsuffix-go v0.10.1-0.20190926082447-75329425f8bb
+# github.com/weppos/publicsuffix-go v0.10.1-0.20191119120252-3dd5f42d2d87
 github.com/weppos/publicsuffix-go/publicsuffix
 # github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e
 github.com/zmap/zcrypto/json
@@ -94,7 +94,7 @@ github.com/zmap/zcrypto/util
 github.com/zmap/zcrypto/x509
 github.com/zmap/zcrypto/x509/ct
 github.com/zmap/zcrypto/x509/pkix
-# github.com/zmap/zlint v1.0.2-0.20190921214057-00156801166b
+# github.com/zmap/zlint v1.0.3-0.20191115164049-eea5fe83935a
 github.com/zmap/zlint
 github.com/zmap/zlint/lints
 github.com/zmap/zlint/util


### PR DESCRIPTION
Updates `github.com/weppos/publicsuffix-go` to 3dd5f42, and `github.com/zmap/zlint` to eea5fe8. Both hashes are the tip of master at the time of writing. Primarily this was done to capture some removed gTLDs at the same time in both deps.

Unit tests are confirmed to pass:
```
~/go/src/github.com/weppos/publicsuffix-go$ git log --pretty=format:'%h' -n 1
3dd5f42

~/go/src/github.com/weppos/publicsuffix-go$ go test ./...
?   	github.com/weppos/publicsuffix-go/cmd/load	[no test files]
ok  	github.com/weppos/publicsuffix-go/net/publicsuffix	0.008s
ok  	github.com/weppos/publicsuffix-go/publicsuffix	0.005s
?   	github.com/weppos/publicsuffix-go/publicsuffix/generator	[no test files]

~/go/src/github.com/zmap/zlint$ git log --pretty=format:'%h' -n 1
eea5fe8

~/go/src/github.com/zmap/zlint$ go test ./...
ok  	github.com/zmap/zlint	0.240s
?   	github.com/zmap/zlint/cmd/zlint	[no test files]
?   	github.com/zmap/zlint/cmd/zlint-gtld-update	[no test files]
ok  	github.com/zmap/zlint/lints	0.156s
ok  	github.com/zmap/zlint/util	0.020s
```