### PR TITLE
expiration-mailer: fix nagsAtCapacity to reset.

### DIFF
--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -435,6 +435,9 @@ func TestFindCertsAtCapacity(t *testing.T) {
 	err = testCtx.m.findExpiringCertificates()
 	test.AssertNotError(t, err, "Failed to find expiring certs")
 	test.AssertEquals(t, len(testCtx.mc.Messages), 0)
+
+	// The "48h0m0s" nag group should now be reporting that it isn't at capacity
+	test.AssertEquals(t, countGroupsAtCapacity("48h0m0s", testCtx.m.stats.nagsAtCapacity), 0)
 }
 
 func TestCertIsRenewed(t *testing.T) {


### PR DESCRIPTION
When a nag group hits capacity we set the `nagsAtCapacity` gauge to 1. This gauge also needs to be reset to 0 when the nag group is no longer at capacity.

Resolves https://github.com/letsencrypt/boulder/issues/4562