### PR TITLE
RA: implement stricter contact email validation.

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -108,6 +108,7 @@ type PolicyAuthority interface {
 	WillingToIssueWildcards(identifiers []identifier.ACMEIdentifier) error
 	ChallengesFor(domain identifier.ACMEIdentifier) ([]Challenge, error)
 	ChallengeTypeEnabled(t string) bool
+	ValidDomain(domain string) error
 }
 
 // StorageGetter are the Boulder SA's read-only methods

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -46,6 +46,10 @@ func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
 	return true
 }
 
+func (pa *mockPA) ValidDomain(_ string) error {
+	return nil
+}
+
 func TestVerifyCSR(t *testing.T) {
 	private, err := rsa.GenerateKey(rand.Reader, 2048)
 	test.AssertNotError(t, err, "error generating test key")

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3708,7 +3708,9 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 }
 
 func TestValidateEmailError(t *testing.T) {
-	err := validateEmail("(๑•́ ω •̀๑)")
+	_, _, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+	err := ra.validateEmail("(๑•́ ω •̀๑)")
 	test.AssertEquals(t, err.Error(), "\"(๑•́ ω •̀๑)\" is not a valid e-mail address")
 }
 

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -2,7 +2,7 @@
   "ra": {
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 100000,
-    "maxContactsPerRegistration": 100,
+    "maxContactsPerRegistration": 3,
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.yaml",
     "maxNames": 100,

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -2,7 +2,7 @@
   "ra": {
     "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
     "maxConcurrentRPCServerRequests": 100000,
-    "maxContactsPerRegistration": 100,
+    "maxContactsPerRegistration": 3,
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.yaml",
     "maxNames": 100,

--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -41,7 +41,7 @@ type client struct {
 	acme.Client
 }
 
-func makeClient() (*client, error) {
+func makeClient(contacts ...string) (*client, error) {
 	c, err := acme.NewClient(os.Getenv("DIRECTORY"))
 	if err != nil {
 		return nil, fmt.Errorf("Error connecting to acme directory: %v", err)
@@ -50,9 +50,9 @@ func makeClient() (*client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating private key: %v", err)
 	}
-	account, err := c.NewAccount(privKey, false, true, "mailto:example@letsencrypt.org")
+	account, err := c.NewAccount(privKey, false, true, contacts...)
 	if err != nil {
-		return nil, fmt.Errorf("error creating new account: %v", err)
+		return nil, err
 	}
 	return &client{account, c}, nil
 }

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/eggsampler/acme/v3"
@@ -31,5 +32,131 @@ func TestTooBigOrderError(t *testing.T) {
 	} else {
 		test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:malformed")
 		test.AssertEquals(t, prob.Detail, "Error creating new order :: Order cannot contain more than 100 DNS names")
+	}
+}
+
+// TestAccountEmailError tests that registering a new account, or updating an
+// account, with invalid contact information produces the expected problem
+// result to ACME clients.
+func TestAccountEmailError(t *testing.T) {
+	t.Parallel()
+	os.Setenv("DIRECTORY", "http://boulder:4001/directory")
+
+	/*
+		  // TODO(@cpu): Uncomment this when the too-long test case is re-added.
+			var longStringBuf strings.Builder
+			for i := 0; i < 254; i++ {
+				longStringBuf.WriteRune('a')
+			}
+	*/
+
+	createErrorPrefix := "Error creating new account :: "
+	updateErrorPrefix := "Unable to update account :: "
+
+	testCases := []struct {
+		name               string
+		contacts           []string
+		expectedProbType   string
+		expectedProbDetail string
+	}{
+		{
+			name:               "empty contact",
+			contacts:           []string{"mailto:valid@valid.com", ""},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: `empty contact`,
+		},
+		{
+			name:               "empty proto",
+			contacts:           []string{"mailto:valid@valid.com", " "},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: `contact method "" is not supported`,
+		},
+		{
+			name:               "empty mailto",
+			contacts:           []string{"mailto:valid@valid.com", "mailto:"},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: `"" is not a valid e-mail address`,
+		},
+		{
+			name:               "non-ascii mailto",
+			contacts:           []string{"mailto:valid@valid.com", "mailto:cpu@l̴etsencrypt.org"},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: `contact email ["mailto:cpu@l̴etsencrypt.org"] contains non-ASCII characters`,
+		},
+		{
+			name:               "too many contacts",
+			contacts:           []string{"a", "b", "c", "d"},
+			expectedProbType:   "urn:ietf:params:acme:error:malformed",
+			expectedProbDetail: `too many contacts provided: 4 > 3`,
+		},
+		{
+			name:               "invalid contact",
+			contacts:           []string{"mailto:valid@valid.com", "mailto:a@"},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: `"a@" is not a valid e-mail address`,
+		},
+		{
+			name:               "forbidden contact domain",
+			contacts:           []string{"mailto:valid@valid.com", "mailto:a@example.com"},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: "invalid contact domain. Contact emails @example.com are forbidden",
+		},
+		{
+			name:               "contact domain invalid TLD",
+			contacts:           []string{"mailto:valid@valid.com", "mailto:a@example.cpu"},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: `contact email "a@example.cpu" has invalid domain : Domain name does not end with a valid public suffix (TLD)`,
+		},
+		{
+			name:               "contact domain invalid",
+			contacts:           []string{"mailto:valid@valid.com", "mailto:a@example./.com"},
+			expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+			expectedProbDetail: "contact email \"a@example./.com\" has invalid domain : Domain name contains an invalid character",
+		},
+		/*
+			// NOTE(@cpu): Disabled for now - causes serverInternal err when SA saves
+			// contacts.
+			{
+				name: "too long contact",
+				contacts: []string{
+					fmt.Sprintf("mailto:%s@a.com", longStringBuf.String()),
+				},
+				expectedProbType:   "urn:ietf:params:acme:error:invalidEmail",
+				expectedProbDetail: "??????",
+			},
+		*/
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// First try registering a new account and ensuring the expected problem occurs
+			if _, err := makeClient(tc.contacts...); err != nil {
+				if prob, ok := err.(acme.Problem); !ok {
+					t.Fatalf("expected acme.Problem error got %#v", err)
+				} else {
+					test.AssertEquals(t, prob.Type, tc.expectedProbType)
+					test.AssertEquals(t, prob.Detail, createErrorPrefix+tc.expectedProbDetail)
+				}
+			} else if err == nil {
+				t.Errorf("expected %s type problem for %q, got nil",
+					tc.expectedProbType, strings.Join(tc.contacts, ","))
+			}
+
+			// Next try making a client with a good contact and updating with the test
+			// case contact info. The same problem should occur.
+			c, err := makeClient("mailto:valid@valid.com")
+			test.AssertNotError(t, err, "failed to create account with valid contact")
+			if _, err := c.UpdateAccount(c.Account, tc.contacts...); err != nil {
+				if prob, ok := err.(acme.Problem); !ok {
+					t.Fatalf("expected acme.Problem error after updating account got %#v", err)
+				} else {
+					test.AssertEquals(t, prob.Type, tc.expectedProbType)
+					test.AssertEquals(t, prob.Detail, updateErrorPrefix+tc.expectedProbDetail)
+				}
+			} else if err == nil {
+				t.Errorf("expected %s type problem after updating account to %q, got nil",
+					tc.expectedProbType, strings.Join(tc.contacts, ","))
+			}
+		})
 	}
 }

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -40,7 +40,7 @@ func TestPrecertificateRevocation(t *testing.T) {
 
 	// Create a base account to use for revocation tests.
 	os.Setenv("DIRECTORY", "http://boulder:4001/directory")
-	c, err := makeClient()
+	c, err := makeClient("mailto:example@letsencrypt.org")
 	test.AssertNotError(t, err, "creating acme client")
 
 	// Create a specific key for CSRs so that it is possible to test revocation

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -286,6 +286,10 @@ func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
 	return true
 }
 
+func (pa *mockPA) ValidDomain(_ string) error {
+	return nil
+}
+
 func makeBody(s string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(s))
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -295,6 +295,10 @@ func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) er
 	return nil
 }
 
+func (pa *mockPA) ValidDomaiN(_ string) error {
+	return nil
+}
+
 func makeBody(s string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(s))
 }


### PR DESCRIPTION
Prev. we weren't checking the domain portion of an email contact address very strictly in the RA. This updates the PA to export a function that can be used to validate the domain the same way we validate domain portions of DNS type identifiers for issuance.

This also changes the RA to use the `invalidEmail` error type in more places.

A new Go integration test is added that checks these errors end-to-end for both account creation and account update.

Resolves https://github.com/letsencrypt/boulder/issues/4561