### PR TITLE
RA: reject Contacts that marshal too long for DB.

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -418,6 +418,19 @@ func TestValidateContacts(t *testing.T) {
 
 	err = ra.validateContacts(context.Background(), &[]string{"mailto:admin@[1.2.3.4]"})
 	test.AssertError(t, err, "Forbidden email")
+
+	// The registrations.contact field is VARCHAR(191). 175 'a' characters plus
+	// the prefix "mailto:" and the suffix "@a.com" makes exactly 191 bytes of
+	// encoded JSON. The correct size to hit our maximum DB field length.
+	var longStringBuf strings.Builder
+	longStringBuf.WriteString("mailto:")
+	for i := 0; i < 175; i++ {
+		longStringBuf.WriteRune('a')
+	}
+	longStringBuf.WriteString("@a.com")
+
+	err = ra.validateContacts(context.Background(), &[]string{longStringBuf.String()})
+	test.AssertError(t, err, "Too long contacts")
 }
 
 func TestNewRegistration(t *testing.T) {


### PR DESCRIPTION
In the deep dark history of Boulder we ended up jamming contacts into a VARCHAR db field as JSON. Because of that choice we need to make sure that when contacts are marshalled the resulting bytes will fit into the column or a 500 will be returned to the user when the SA RPC fails.

One day we should fix this properly and not return a hacky error message that's hard for users to understand. Unfortunately that will likely require a migration or a new DB table. In the shorter term this hack will prevent 500s which is a clear improvement.