### PR TITLE
Deprecate GetAuthorizationsPerf flag.

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -23,27 +23,27 @@ func _() {
 	_ = x[EarlyOrderRateLimit-12]
 	_ = x[FasterGetOrderForNames-13]
 	_ = x[PrecertificateOCSP-14]
-	_ = x[CAAValidationMethods-15]
-	_ = x[CAAAccountURI-16]
-	_ = x[HeadNonceStatusOK-17]
-	_ = x[EnforceMultiVA-18]
-	_ = x[MultiVAFullResults-19]
-	_ = x[RemoveWFE2AccountID-20]
-	_ = x[CheckRenewalFirst-21]
-	_ = x[MandatoryPOSTAsGET-22]
-	_ = x[AllowV1Registration-23]
-	_ = x[ParallelCheckFailedValidation-24]
-	_ = x[DeleteUnusedChallenges-25]
-	_ = x[V1DisableNewValidations-26]
-	_ = x[PrecertificateRevocation-27]
-	_ = x[StripDefaultSchemePort-28]
-	_ = x[GetAuthorizationsPerf-29]
+	_ = x[GetAuthorizationsPerf-15]
+	_ = x[CAAValidationMethods-16]
+	_ = x[CAAAccountURI-17]
+	_ = x[HeadNonceStatusOK-18]
+	_ = x[EnforceMultiVA-19]
+	_ = x[MultiVAFullResults-20]
+	_ = x[RemoveWFE2AccountID-21]
+	_ = x[CheckRenewalFirst-22]
+	_ = x[MandatoryPOSTAsGET-23]
+	_ = x[AllowV1Registration-24]
+	_ = x[ParallelCheckFailedValidation-25]
+	_ = x[DeleteUnusedChallenges-26]
+	_ = x[V1DisableNewValidations-27]
+	_ = x[PrecertificateRevocation-28]
+	_ = x[StripDefaultSchemePort-29]
 	_ = x[StoreIssuerInfo-30]
 }
 
-const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRANewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitFasterGetOrderForNamesPrecertificateOCSPCAAValidationMethodsCAAAccountURIHeadNonceStatusOKEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETAllowV1RegistrationParallelCheckFailedValidationDeleteUnusedChallengesV1DisableNewValidationsPrecertificateRevocationStripDefaultSchemePortGetAuthorizationsPerfStoreIssuerInfo"
+const _FeatureFlag_name = "unusedPerformValidationRPCACME13KeyRolloverSimplifiedVAHTTPTLSSNIRevalidationAllowRenewalFirstRLSetIssuedNamesRenewalBitFasterRateLimitProbeCTLogsRevokeAtRANewAuthorizationSchemaDisableAuthz2OrdersEarlyOrderRateLimitFasterGetOrderForNamesPrecertificateOCSPGetAuthorizationsPerfCAAValidationMethodsCAAAccountURIHeadNonceStatusOKEnforceMultiVAMultiVAFullResultsRemoveWFE2AccountIDCheckRenewalFirstMandatoryPOSTAsGETAllowV1RegistrationParallelCheckFailedValidationDeleteUnusedChallengesV1DisableNewValidationsPrecertificateRevocationStripDefaultSchemePortStoreIssuerInfo"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 178, 197, 216, 238, 256, 276, 289, 306, 320, 338, 357, 374, 392, 411, 440, 462, 485, 509, 531, 552, 567}
+var _FeatureFlag_index = [...]uint16{0, 6, 26, 43, 59, 77, 96, 120, 135, 146, 156, 178, 197, 216, 238, 256, 277, 297, 310, 327, 341, 359, 378, 395, 413, 432, 461, 483, 506, 530, 552, 567}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -26,6 +26,7 @@ const (
 	EarlyOrderRateLimit
 	FasterGetOrderForNames
 	PrecertificateOCSP
+	GetAuthorizationsPerf
 
 	//   Currently in-use features
 	// Check CAA and respect validationmethods parameter.
@@ -65,9 +66,6 @@ const (
 	// StripDefaultSchemePort enables stripping of default scheme ports from HTTP
 	// request Host headers
 	StripDefaultSchemePort
-	// GetAuthorizationsPerf enables a more performant GetAuthorizations2 query
-	// at the SA.
-	GetAuthorizationsPerf
 	// StoreIssuerInfo enables storage of information identifying the issuer of
 	// a certificate in the certificateStatus table.
 	StoreIssuerInfo

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -26,7 +26,6 @@
     "features": {
       "DeleteUnusedChallenges": true,
       "FasterGetOrderForNames": true,
-      "GetAuthorizationsPerf": true,
       "StoreIssuerInfo": true
     }
   },


### PR DESCRIPTION
In the process I tweaked a few variable names in GetAuthorizations2 to
refer to just "authz" instead of "authz2" because it made things
clearer, particularly in the case of authz2IDMap, which is a map of
whether a given ID exists, not a map from authz's to IDs.

Fixes #4564