### PR TITLE
integration: Fail tests on unindexed queries.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
         # because that seems to trigger based on the optimizer's choice to not
         # use an index for certain queries, particularly when tables are still
         # small.
-        command: mysqld --bind-address=0.0.0.0 --slow-query-log --log-output=TABLE --log-queries-not-using-indexes=OFF
+        command: mysqld --bind-address=0.0.0.0 --slow-query-log --log-output=TABLE --log-queries-not-using-indexes=ON
         logging:
             driver: none
     netaccess:

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -315,9 +315,31 @@ def check_slow_queries():
     """Checks that we haven't run any slow queries during the integration test.
 
     This depends on flags set on mysqld in docker-compose.yml.
+
+    We skip the boulder_sa_test database because we manually run a bunch of
+    non-indexed queries in unittests. We skip actions by the setup and root
+    users because they're known to be non-indexed. Similarly we skip the
+    cert_checker, mailer, and janitor's work because they are known to be
+    slow (though we should eventually improve these).
+    The SELECT ... IN () on the authz2 table shows up in the slow query log
+    a lot. Presumably when there are a lot of entries in the IN() argument
+    and the table is small, it's not efficient to use the index. But we
+    should dig into this more.
     """
-    output = run("mysql -h boulder-mysql -D boulder_sa_integration -e " +
-        "'select * from mysql.slow_log where user_host not like \"test_setup%\" \G'")
+    query = """
+        SELECT * FROM mysql.slow_log
+            WHERE db != 'boulder_sa_test'
+            AND user_host NOT LIKE "test_setup%"
+            AND user_host NOT LIKE "root%"
+            AND user_host NOT LIKE "cert_checker%"
+            AND user_host NOT LIKE "mailer%"
+            AND user_host NOT LIKE "janitor%"
+            AND sql_text NOT LIKE 'SELECT status, expires FROM authz2 WHERE id IN %'
+        \G
+    """
+    output = subprocess.check_output(
+      ["mysql", "-h", "boulder-mysql", "-e", query],
+      stderr=subprocess.STDOUT)
     if len(output) > 0:
         print(output)
         raise Exception("Found slow queries in the slow query log")


### PR DESCRIPTION
Also incidentally remove the database flag from the mysql invocation
since it was unnecessary.

Fixes #4406