### PR TITLE
SA: separate out RL update transaction in AddCertificate.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -106,7 +106,7 @@ func NewSQLStorageAuthority(
 	SetSQLDebug(dbMap, logger)
 
 	rateLimitWriteErrors := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "rateLimitWriteErrors",
+		Name: "rate_limit_write_errors",
 		Help: "number of failed ratelimit update transactions during AddCertificate",
 	})
 	scope.MustRegister(rateLimitWriteErrors)

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1696,6 +1696,37 @@ func TestAddCertificateRenewalBit(t *testing.T) {
 	}
 }
 
+func TestAddCertificateBadRatelimitUpdate(t *testing.T) {
+	sa, _, cleanUp := initSA(t)
+	defer cleanUp()
+
+	reg := satest.CreateWorkingRegistration(t, sa)
+	issued := sa.clk.Now()
+	serial, cert := test.ThrowAwayCert(t, 1)
+
+	// Manually add an fqdn set for the certificate serial. This will cause the
+	// real fqdn set update in AddCertificate to fail due to the duplicate serial.
+	err := addFQDNSet(
+		sa.dbMap,
+		cert.DNSNames,
+		serial,
+		cert.NotBefore,
+		cert.NotAfter)
+	test.AssertNotError(t, err, "Couldn't manually add fqdnSet")
+
+	// Add the test certificate, it shouldn't error even though part of the rate
+	// limit updates failed.
+	_, err = sa.AddCertificate(ctx, cert.Raw, reg.ID, nil, &issued)
+	test.AssertNotError(t, err, "Couldn't add testCert")
+
+	// The rate limit transaction failure stat should have been incremented
+	test.AssertEquals(t, test.CountCounter(sa.failedAddCertRLTransactions), 1)
+
+	// The rate limit transaction failure should have been audit logged
+	logLines := log.GetAllMatching(`\[AUDIT\] failed AddCertificate ratelimit update transaction: Error 1062: Duplicate entry '.*' for key 'serial'`)
+	test.AssertEquals(t, len(logLines), 1)
+}
+
 func TestCountCertificatesRenewalBit(t *testing.T) {
 	sa, fc, cleanUp := initSA(t)
 	defer cleanUp()

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1720,7 +1720,7 @@ func TestAddCertificateBadRatelimitUpdate(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't add testCert")
 
 	// The rate limit transaction failure stat should have been incremented
-	test.AssertEquals(t, test.CountCounter(sa.failedAddCertRLTransactions), 1)
+	test.AssertEquals(t, test.CountCounter(sa.rateLimitWriteErrors), 1)
 
 	// The rate limit transaction failure should have been audit logged
 	logLines := log.GetAllMatching(`\[AUDIT\] failed AddCertificate ratelimit update transaction: Error 1062: Duplicate entry '.*' for key 'serial'`)


### PR DESCRIPTION
The `AddCertificate` processing related to updating the `fqdnSets` and `certificatesPerNames` tables can be done in a separate transaction from the inserts to `issuedNames` and `certificates`.

This has the advantage of letting the overall `AddCertificate` request succeed when the primary transaction succeeds but the rate limit update transaction fails. We are OK with slightly incorrect rate limit results if it means more `AddCertificate` requests succeed and there are fewer orphaned final certificates.

To maintain visibility we audit log when the rate limit transaction fails and also increment a new `failedAddCertRLTransactions` prometheus counter.

Resolves https://github.com/letsencrypt/boulder/issues/4566