### PR TITLE
Add a decode() to check_output for slow queries.

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -339,7 +339,7 @@ def check_slow_queries():
     """
     output = subprocess.check_output(
       ["mysql", "-h", "boulder-mysql", "-e", query],
-      stderr=subprocess.STDOUT)
+      stderr=subprocess.STDOUT).decode()
     if len(output) > 0:
         print(output)
         raise Exception("Found slow queries in the slow query log")

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1285,6 +1285,3 @@ def test_blocked_key_cert():
 
     if testPass is False:
         raise(Exception("expected cert creation to fail with Error when using blocked key"))
-
-def run(cmd, **kwargs):
-    return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, **kwargs)


### PR DESCRIPTION
In Python3, the output of subprocess.check_output is of type bytes.
That means calling print() on the output will print \n instead of an
actual newline. This PR adds decoding to the output of mysql in the slow
query test, bringing it into line with other check_output calls.

This also removes a redundant "def run" that is shadowed by the
definition in helpers.py (and was also missing a decode() call).