### PR TITLE
Upgrade go-jose to v2.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,6 @@ require (
 	google.golang.org/genproto v0.0.0-20190415143225-d1146b9035b9 // indirect
 	google.golang.org/grpc v1.20.0
 	gopkg.in/go-gorp/gorp.v2 v2.0.1-0.20180410155428-6032c66e0f5f
-	gopkg.in/square/go-jose.v2 v2.4.0
+	gopkg.in/square/go-jose.v2 v2.4.1
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ gopkg.in/go-gorp/gorp.v2 v2.0.1-0.20180410155428-6032c66e0f5f h1:OuFU7cfzlNAFNOX
 gopkg.in/go-gorp/gorp.v2 v2.0.1-0.20180410155428-6032c66e0f5f/go.mod h1:eJwu1bWCXesk9aw26U78PFtctx3Y8haXGmL7x3VJlrw=
 gopkg.in/square/go-jose.v2 v2.4.0 h1:0kXPskUMGAXXWJlP05ktEMOV0vmzFQUWw6d+aZJQU8A=
 gopkg.in/square/go-jose.v2 v2.4.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.4.1 h1:H0TmLt7/KmzlrDOpa1F+zr0Tk90PbJYBfsVUmRLrf9Y=
+gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/gopkg.in/square/go-jose.v2/encoding.go
+++ b/vendor/gopkg.in/square/go-jose.v2/encoding.go
@@ -23,12 +23,11 @@ import (
 	"encoding/binary"
 	"io"
 	"math/big"
-	"regexp"
+	"strings"
+	"unicode"
 
 	"gopkg.in/square/go-jose.v2/json"
 )
-
-var stripWhitespaceRegex = regexp.MustCompile("\\s")
 
 // Helper function to serialize known-good objects.
 // Precondition: value is not a nil pointer.
@@ -56,7 +55,14 @@ func mustSerializeJSON(value interface{}) []byte {
 
 // Strip all newlines and whitespace
 func stripWhitespace(data string) string {
-	return stripWhitespaceRegex.ReplaceAllString(data, "")
+	buf := strings.Builder{}
+	buf.Grow(len(data))
+	for _, r := range data {
+		if !unicode.IsSpace(r) {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
 }
 
 // Perform compression based on algorithm

--- a/vendor/gopkg.in/square/go-jose.v2/jws.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jws.go
@@ -102,14 +102,14 @@ func (sig Signature) mergedHeaders() rawHeader {
 }
 
 // Compute data to be signed
-func (obj JSONWebSignature) computeAuthData(payload []byte, signature *Signature) []byte {
+func (obj JSONWebSignature) computeAuthData(payload []byte, signature *Signature) ([]byte, error) {
 	var authData bytes.Buffer
 
 	protectedHeader := new(rawHeader)
 
 	if signature.original != nil && signature.original.Protected != nil {
 		if err := json.Unmarshal(signature.original.Protected.bytes(), protectedHeader); err != nil {
-			panic(err)
+			return nil, err
 		}
 		authData.WriteString(signature.original.Protected.base64())
 	} else if signature.protected != nil {
@@ -134,7 +134,7 @@ func (obj JSONWebSignature) computeAuthData(payload []byte, signature *Signature
 		authData.Write(payload)
 	}
 
-	return authData.Bytes()
+	return authData.Bytes(), nil
 }
 
 // parseSignedFull parses a message in full format.

--- a/vendor/gopkg.in/square/go-jose.v2/signing.go
+++ b/vendor/gopkg.in/square/go-jose.v2/signing.go
@@ -370,7 +370,11 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 		}
 	}
 
-	input := obj.computeAuthData(payload, &signature)
+	input, err := obj.computeAuthData(payload, &signature)
+	if err != nil {
+		return ErrCryptoFailure
+	}
+
 	alg := headers.getSignatureAlgorithm()
 	err = verifier.verifyPayload(input, signature.Signature, alg)
 	if err == nil {
@@ -421,7 +425,11 @@ outer:
 			}
 		}
 
-		input := obj.computeAuthData(payload, &signature)
+		input, err := obj.computeAuthData(payload, &signature)
+		if err != nil {
+			continue
+		}
+
 		alg := headers.getSignatureAlgorithm()
 		err = verifier.verifyPayload(input, signature.Signature, alg)
 		if err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ google.golang.org/grpc/tap
 gopkg.in/fsnotify.v1
 # gopkg.in/go-gorp/gorp.v2 v2.0.1-0.20180410155428-6032c66e0f5f
 gopkg.in/go-gorp/gorp.v2
-# gopkg.in/square/go-jose.v2 v2.4.0
+# gopkg.in/square/go-jose.v2 v2.4.1
 gopkg.in/square/go-jose.v2
 gopkg.in/square/go-jose.v2/cipher
 gopkg.in/square/go-jose.v2/json


### PR DESCRIPTION
Incorporates https://github.com/square/go-jose/pull/282.

$ go test gopkg.in/square/go-jose.v2
go: finding gopkg.in/square/go-jose.v2 v2.4.1
ok      gopkg.in/square/go-jose.v2      46.790s