### PR TITLE
Fix AddPrecertificate bug

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -847,11 +847,14 @@ func (ca *CertificateAuthorityImpl) integrateOrphan() error {
 			Ocsp:   orphan.OCSPResp,
 			Issued: &issuedNanos,
 		})
+		if err != nil && !berrors.Is(err, berrors.Duplicate) {
+			return fmt.Errorf("failed to store orphaned precertificate: %s", err)
+		}
 	} else {
 		_, err = ca.sa.AddCertificate(context.Background(), orphan.DER, orphan.RegID, nil, &issued)
-	}
-	if err != nil && !berrors.Is(err, berrors.Duplicate) {
-		return fmt.Errorf("failed to store orphaned certificate: %s", err)
+		if err != nil && !berrors.Is(err, berrors.Duplicate) {
+			return fmt.Errorf("failed to store orphaned certificate: %s", err)
+		}
 	}
 	if _, err = ca.orphanQueue.Dequeue(); err != nil {
 		return fmt.Errorf("failed to dequeue integrated orphaned certificate: %s", err)

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -95,7 +95,7 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 			args = append(args, req.IssuerID)
 		}
 
-		_, err = ssa.dbMap.WithContext(ctx).Exec(fmt.Sprintf(
+		_, err = txWithCtx.WithContext(ctx).Exec(fmt.Sprintf(
 			"INSERT INTO certificateStatus (%s) VALUES (%s)",
 			csFields,
 			strings.Join(qmarks, ","),

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -101,6 +101,9 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 			strings.Join(qmarks, ","),
 		), args...)
 		if err != nil {
+			if db.IsDuplicate(err) {
+				return nil, berrors.DuplicateError("cannot add a duplicate precertificate")
+			}
 			return nil, err
 		}
 

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -95,7 +95,7 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 			args = append(args, req.IssuerID)
 		}
 
-		_, err = txWithCtx.WithContext(ctx).Exec(fmt.Sprintf(
+		_, err = txWithCtx.Exec(fmt.Sprintf(
 			"INSERT INTO certificateStatus (%s) VALUES (%s)",
 			csFields,
 			strings.Join(qmarks, ","),

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -101,9 +101,6 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 			strings.Join(qmarks, ","),
 		), args...)
 		if err != nil {
-			if db.IsDuplicate(err) {
-				return nil, berrors.DuplicateError("cannot add a duplicate certificate status")
-			}
 			return nil, err
 		}
 

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -102,7 +102,7 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 		), args...)
 		if err != nil {
 			if db.IsDuplicate(err) {
-				return nil, berrors.DuplicateError("cannot add a duplicate precertificate")
+				return nil, berrors.DuplicateError("cannot add a duplicate certificate status")
 			}
 			return nil, err
 		}

--- a/sa/precertificates_test.go
+++ b/sa/precertificates_test.go
@@ -2,14 +2,12 @@ package sa
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/db"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
@@ -117,44 +115,4 @@ func TestAddPrecertificate(t *testing.T) {
 	err := features.Set(map[string]bool{"WriteIssuedNamesPrecert": true})
 	test.AssertNotError(t, err, "failed to set WriteIssuedNamesPrecert feature flag")
 	addPrecert(true)
-}
-
-func TestAddPrecertificateStatusDupe(t *testing.T) {
-	sa, clk, cleanUp := initSA(t)
-	defer cleanUp()
-
-	reg := satest.CreateWorkingRegistration(t, sa)
-	serial, testCert := test.ThrowAwayCert(t, 1)
-
-	args := []interface{}{
-		serial,
-		string(core.OCSPStatusGood),
-		clk.Now(),
-		time.Time{},
-		0,
-		time.Time{},
-		[]byte{},
-		time.Time{},
-		false,
-	}
-	qmarks := []string{}
-	for range args {
-		qmarks = append(qmarks, "?")
-	}
-	_, err := sa.dbMap.Exec(fmt.Sprintf(
-		"INSERT INTO certificateStatus (%s) VALUES (%s)",
-		certStatusFields, strings.Join(qmarks, ",")),
-		args...,
-	)
-	test.AssertNotError(t, err, "certStatus insert failed")
-
-	issued := clk.Now().UnixNano()
-	_, err = sa.AddPrecertificate(context.Background(), &sapb.AddCertificateRequest{
-		Der:    testCert.Raw,
-		RegID:  &reg.ID,
-		Ocsp:   []byte{},
-		Issued: &issued,
-	})
-	test.AssertError(t, err, "AddPrecertificate didn't fail with duplicate certificate status")
-	test.Assert(t, berrors.Is(err, berrors.Duplicate), "AddPrecertificate didn't return a berrors.Duplicate type error")
 }


### PR DESCRIPTION
Fixes an issue introduced in #4573 that could cause the CA orphan queue to spin endlessly.

The bug introduced in #4573 was that while the precertificate insertion and other operations were using a transaction in AddPrecertificate, the certificate status insertion wasn't. This meant that if the certificate status call succeeded but one of the preceding operations didn't, all of the other insertions would be rolled back, but the certificate status insertion wouldn't. This would cause a scenario where a certificate status row existed for a precertificate that didn't have a matching row in the precertificates table. Any preceding call to AddPrecertificate would then fail on the certificate status insertion, as there was already an existing duplicate row, which would prevent any of the other insertions in the transactions from being applied.

This change also refactors the duplicate error check in ca/ca.go as it is unclear from the error message it causes which of the two RPCs (AddPrecertificate or AddCertificate) failed.