### PR TITLE
RA: Don't extend valid authorization time by pending expiry.

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1540,7 +1540,7 @@ func (ra *RegistrationAuthorityImpl) recordValidation(ctx context.Context, authI
 	if challenge.Status == core.StatusInvalid {
 		expires = authExpires.UnixNano()
 	} else {
-		expires = authExpires.Add(ra.authorizationLifetime).UnixNano()
+		expires = ra.clk.Now().Add(ra.authorizationLifetime).UnixNano()
 	}
 	vr, err := bgrpc.ValidationResultToPB(challenge.ValidationRecord, challenge.Error)
 	if err != nil {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -977,6 +977,11 @@ func TestPerformValidationSuccess(t *testing.T) {
 	test.Assert(t, len(vaAuthz.Challenges) > 0, "Authz passed to VA has no challenges")
 	challIdx = challTypeIndex(t, dbAuthz.Challenges, core.ChallengeTypeDNS01)
 	test.Assert(t, dbAuthz.Challenges[challIdx].Status == core.StatusValid, "challenge was not marked as valid")
+
+	// The DB authz's expiry should be equal to the current time plus the
+	// configured authorization lifetime
+	expectedExpires := ra.clk.Now().Add(ra.authorizationLifetime)
+	test.AssertEquals(t, *dbAuthz.Expires, expectedExpires)
 }
 
 func TestCertificateKeyNotEqualAccountKey(t *testing.T) {

--- a/test/integration/authz_test.go
+++ b/test/integration/authz_test.go
@@ -1,0 +1,51 @@
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+const (
+	// validAuthorizationLifetime is the expected valid authorization lifetime. It
+	// should match the value in the RA config's "authorizationLifetimeDays"
+	// configuration field.
+	validAuthorizationLifetime = 30
+)
+
+// TestValidAuthzExpires checks that a valid authorization has the expected
+// expires time.
+func TestValidAuthzExpires(t *testing.T) {
+	t.Parallel()
+	os.Setenv("DIRECTORY", "http://boulder:4001/directory")
+	c, err := makeClient()
+	test.AssertNotError(t, err, "makeClient failed")
+
+	// Issue for a random domain
+	domains := []string{random_domain()}
+	result, err := authAndIssue(c, nil, domains)
+	// There should be no error
+	test.AssertNotError(t, err, "authAndIssue failed")
+	// The order should be valid
+	test.AssertEquals(t, result.Order.Status, "valid")
+	// There should be one authorization URL
+	test.AssertEquals(t, len(result.Order.Authorizations), 1)
+
+	// Fetching the authz by URL shouldn't fail
+	authzURL := result.Order.Authorizations[0]
+	authzOb, err := c.FetchAuthorization(c.Account, authzURL)
+	test.AssertNotError(t, err, "FetchAuthorization failed")
+
+	// The authz should be valid and for the correct identifier
+	test.AssertEquals(t, authzOb.Status, "valid")
+	test.AssertEquals(t, authzOb.Identifier.Value, domains[0])
+
+	// The authz should have the expected expiry date
+	expectedExpires := time.Now().AddDate(0, 0, validAuthorizationLifetime).Round(time.Minute)
+	actualExpires := authzOb.Expires.Round(time.Minute)
+	test.AssertEquals(t, expectedExpires.Equal(actualExpires), true)
+}


### PR DESCRIPTION
The RA should set the expiry of valid authorizations based only on the current time and the configured `authorizationLifetime`. It should not extend the pending authorization's lifetime by the `authorizationLifetime`.

Resolves https://github.com/letsencrypt/boulder/issues/4617

I didn't gate this with a feature flag. If we think this needs an API announcement and gradual rollout (_I don't personally think this change deserves that_) then I think we should change the RA config's `authorizationLifetimeDays` value to 37 days instead of adding a feature flag that we'll have to clean up after the flag date. We can change it back to 30 after the flag date.