### PR TITLE
CI: Add codespell to detect common typos.

### DIFF
--- a/.codespell.ignore.txt
+++ b/.codespell.ignore.txt
@@ -1,0 +1,10 @@
+geting
+keypair
+vas
+strat
+hist
+dur
+uint
+iff
+cas
+te

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.13.2}:2019-11-18
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.13.2}:2020-01-07
         environment:
             FAKE_DNS: 10.77.77.77
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -58,7 +58,7 @@ services:
         working_dir: /go/src/github.com/letsencrypt/boulder
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.13.2}:2019-11-18
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.13.2}:2020-01-07
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -85,7 +85,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.13.2}:2019-11-18
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.13.2}:2020-01-07
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/test.sh
+++ b/test.sh
@@ -79,6 +79,13 @@ if [[ "$RUN" =~ "lints" ]] ; then
   run_and_expect_silence errcheck \
     -ignore fmt:Fprintf,fmt:Fprintln,fmt:Fprint,io:Write,os:Remove,net/http:Write \
     $(go list -f '{{ .ImportPath }}' ./... | grep -v test)
+
+  # Check for common spelling errors using codespell.
+  # Update .codespell.ignore.txt if you find false positives (NOTE: ignored
+  # words should be all lowercase).
+  run_and_expect_silence codespell \
+    --ignore-words=.codespell.ignore.txt \
+    --skip=.git,.gocache,go.sum,go.mod,vendor,bin,*.pyc,*.pem,*.der,*.resp,*.req,*.csr,.codespell.ignore.txt
 fi
 
 #

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -25,6 +25,7 @@ apt-get install -y --no-install-recommends \
   unzip \
   python3-dev \
   python3-venv \
+  python3-pip \
   gcc \
   libaugeas0 \
   libssl-dev \
@@ -52,6 +53,9 @@ go get \
   golang.org/x/tools/cover \
   golang.org/x/tools/cmd/stringer \
   github.com/gordonklaus/ineffassign
+
+# Install codespell for linting common spelling errors
+pip3 install codespell
 
 git clone https://github.com/certbot/certbot /certbot
 cd /certbot


### PR DESCRIPTION
The `codespell` tool will be run during the "lints" phase of `test.sh`. See `.codespell.ignore.txt for ignored words. Note that these ignored words should be listed one per-line, in **lowercase** form.

The boulder-tools `build.sh` script is updated to include `codespell` in the tools image. I built and pushed new images with this script that are ref'd by `docker-compose.yml`.

Resolves https://github.com/letsencrypt/boulder/issues/4635