### PR TITLE
bdns: friendly error text for NXDOMAIN, SERVFAIL

### DIFF
--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -39,7 +39,9 @@ func (d DNSError) Error() string {
 		}
 	} else if d.rCode != dns.RcodeSuccess {
 		detail = dns.RcodeToString[d.rCode]
-		additional = " - " + rcodeExplanations[d.rCode]
+		if explanation, ok := rcodeExplanations[d.rCode]; ok {
+			additional = " - " + explanation
+		}
 	} else {
 		detail = detailServerFailure
 	}

--- a/bdns/problem_test.go
+++ b/bdns/problem_test.go
@@ -22,13 +22,16 @@ func TestDNSError(t *testing.T) {
 			"DNS problem: networking error looking up MX for hostname",
 		}, {
 			&DNSError{dns.TypeTXT, "hostname", nil, dns.RcodeNameError},
-			"DNS problem: NXDOMAIN looking up TXT for hostname",
+			"DNS problem: NXDOMAIN looking up TXT for hostname - check that a DNS record exists for this domain",
 		}, {
 			&DNSError{dns.TypeTXT, "hostname", context.DeadlineExceeded, -1},
 			"DNS problem: query timed out looking up TXT for hostname",
 		}, {
 			&DNSError{dns.TypeTXT, "hostname", context.Canceled, -1},
 			"DNS problem: query timed out looking up TXT for hostname",
+		}, {
+			&DNSError{dns.TypeCAA, "hostname", nil, dns.RcodeServerFailure},
+			"DNS problem: SERVFAIL looking up CAA for hostname - the domain's nameservers may be malfunctioning",
 		},
 	}
 	for _, tc := range testCases {

--- a/bdns/problem_test.go
+++ b/bdns/problem_test.go
@@ -32,6 +32,9 @@ func TestDNSError(t *testing.T) {
 		}, {
 			&DNSError{dns.TypeCAA, "hostname", nil, dns.RcodeServerFailure},
 			"DNS problem: SERVFAIL looking up CAA for hostname - the domain's nameservers may be malfunctioning",
+		}, {
+			&DNSError{dns.TypeA, "hostname", nil, dns.RcodeFormatError},
+			"DNS problem: FORMERR looking up A for hostname",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Providing additional explanatory text in the error message may help
guide users who are unfamiliar with DNS error codes.

----

Before:

>DNS problem: NXDOMAIN looking up TXT for hostname

After:

>DNS problem: NXDOMAIN looking up TXT for hostname - check that a DNS record exists for this domain
