### PR TITLE
Populate mailer counter when creating dryRun client

### DIFF
--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -157,6 +157,10 @@ func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
 		from:        from,
 		clk:         clock.Default(),
 		csprgSource: realSource{},
+		sendMailAttempts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "send_mail_attempts",
+			Help: "A counter of send mail attempts labelled by result",
+		}, []string{"result", "error"}),
 	}
 }
 


### PR DESCRIPTION
If a `dryRunClient` is used it will cause panics when `SendMail` is called because the constructor doesn't populate the prometheus counter. This fix populates the counter.