### PR TITLE
CI/Dev: restore allowOrigins wfe/wfe2 config.

### DIFF
--- a/test/config-next/wfe.json
+++ b/test/config-next/wfe.json
@@ -4,6 +4,7 @@
     "TLSListenAddress": "0.0.0.0:4430",
     "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
     "serverKeyPath": "test/wfe-tls/boulder/key.pem",
+    "allowOrigins": ["*"],
     "shutdownStopTimeout": "10s",
     "subscriberAgreementURL": "http://boulder:4000/terms/v1",
     "debugAddr": ":8000",

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -4,6 +4,7 @@
     "TLSListenAddress": "0.0.0.0:4431",
     "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
     "serverKeyPath": "test/wfe-tls/boulder/key.pem",
+    "allowOrigins": ["*"],
     "shutdownStopTimeout": "10s",
     "subscriberAgreementURL": "https://boulder:4431/terms/v7",
     "debugAddr": ":8013",

--- a/test/config/wfe.json
+++ b/test/config/wfe.json
@@ -4,6 +4,7 @@
     "TLSListenAddress": "0.0.0.0:4430",
     "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
     "serverKeyPath": "test/wfe-tls/boulder/key.pem",
+    "allowOrigins": ["*"],
     "shutdownStopTimeout": "10s",
     "subscriberAgreementURL": "http://boulder:4000/terms/v1",
     "debugAddr": ":8000",

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -4,6 +4,7 @@
     "TLSListenAddress": "0.0.0.0:4431",
     "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
     "serverKeyPath": "test/wfe-tls/boulder/key.pem",
+    "allowOrigins": ["*"],
     "shutdownStopTimeout": "10s",
     "subscriberAgreementURL": "https://boulder:4431/terms/v7",
     "debugAddr": ":8013",

--- a/test/integration/wfe_test.go
+++ b/test/integration/wfe_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration
 
 import (

--- a/test/integration/wfe_test.go
+++ b/test/integration/wfe_test.go
@@ -1,0 +1,29 @@
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+// TestWFECORS is a small integration test that checks that the
+// Access-Control-Allow-Origin header is returned for a GET request to the
+// directory endpoint that has an Origin request header of "*".
+func TestWFECORS(t *testing.T) {
+	// Construct a GET request with an Origin header to sollicit an
+	// Access-Control-Allow-Origin response header.
+	getReq, _ := http.NewRequest("GET", "http://boulder:4001/directory", nil)
+	getReq.Header.Set("Origin", "*")
+
+	// Performing the GET should return status 200.
+	client := &http.Client{}
+	resp, err := client.Do(getReq)
+	test.AssertNotError(t, err, "GET directory")
+	test.AssertEquals(t, resp.StatusCode, http.StatusOK)
+
+	// We expect that the response has the correct Access-Control-Allow-Origin
+	// header.
+	corsAllowOrigin := resp.Header.Get("Access-Control-Allow-Origin")
+	test.AssertEquals(t, corsAllowOrigin, "*")
+}


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/commit/67ec373a96856036d870580d4c5c367f23b44242 we removed "unused" WFE and WFE2 config elements. Unfortunately I missed that one of these elements, `allowOrigins`, **is** used and without this config in place CORS is broken.

We have unit tests for the CORS headers but we did not have any end-to-end integration tests that would catch a problem with the WFE/WFE2 missing the `allowOrigins` config element.

This PR restores the `allowOrigins` config value across the WFE/WFE2 configs and also adds a very small integration test. That test only checks one CORS header and only for the HTTP ACMEv2 endpoint but I think it's sufficient for the moment (and definitely better than nothing).

Prior to fixing the config elements the integration test fails as expected:
```
--- FAIL: TestWFECORS (0.00s)
    wfe_test.go:28: "" != "*"
FAIL
FAIL	github.com/letsencrypt/boulder/test/integration	0.014s
FAIL
```