### PR TITLE
ocsp-updater looper simplification

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -113,7 +113,7 @@ func newUpdater(
 	stats.MustRegister(storedCounter)
 	tickHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "ocsp_updater_ticks",
-		Help: "A histogram of ocsp-updater tick latencies labelled by result",
+		Help: "A histogram of ocsp-updater tick latencies labelled by result and whether the tick was considered longer than expected",
 	}, []string{"result", "long"})
 	stats.MustRegister(tickHistogram)
 
@@ -417,7 +417,6 @@ func (updater *OCSPUpdater) tick() {
 			updater.maxBackoff,
 			updater.backoffFactor,
 		)
-		fmt.Println(sleepDur)
 	} else if updater.tickFailures > 0 {
 		updater.tickFailures = 0
 	}

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -325,7 +325,7 @@ type OCSPUpdaterConfig struct {
 	cmd.ServiceConfig
 	cmd.DBConfig
 
-	OldOCSPWindow cmd.ConfigDuration
+	OldOCSPWindow    cmd.ConfigDuration
 	OldOCSPBatchSize int
 
 	OCSPMinTimeToExpiry          cmd.ConfigDuration

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/square/go-jose.v2"
 
@@ -124,4 +125,29 @@ func TestValidSerial(t *testing.T) {
 	test.AssertEquals(t, isValidSerial, true)
 	isValidSerial = ValidSerial(length36)
 	test.AssertEquals(t, isValidSerial, true)
+}
+
+func TestRetryBackoff(t *testing.T) {
+	assertBetween := func(a, b, c float64) {
+		t.Helper()
+		if a < b || a > a {
+			t.Fatalf("%f is not between %f and %f", a, b, c)
+		}
+	}
+
+	factor := 1.5
+	base := time.Minute
+	max := 10 * time.Minute
+
+	expected := base
+	backoff := RetryBackoff(1, base, max, factor)
+	assertBetween(float64(backoff), float64(expected)*0.8, float64(expected)*1.2)
+	expected = time.Second * 90
+	backoff = RetryBackoff(2, base, max, factor)
+	assertBetween(float64(backoff), float64(expected)*0.8, float64(expected)*1.2)
+	expected = time.Minute * 10
+	// should be truncated
+	backoff = RetryBackoff(7, base, max, factor)
+	assertBetween(float64(backoff), float64(expected)*0.8, float64(expected)*1.2)
+
 }


### PR DESCRIPTION
Replaces a `cmd/ocsp-updater` test  of `core.RetryBackoff` with a `core` one, which is more appropriate in my view, since that is all that it is really testing.

Fixes #4596.