### PR TITLE
docs: remove stale multi-va feat. flag info

### DIFF
--- a/docs/multi-va.md
+++ b/docs/multi-va.md
@@ -38,14 +38,13 @@ and
 as their config files.
 
 There are two feature flags that control whether multi-VA takes effect:
-MultiVAFullResults and EnforceMultiVA. If MultiVAFullResults is enabled (the
-current setting in prod and staging), then each primary validation will also
-send out remote validation requests, and wait for all the results to come in, so
-we can log the results for analysis. If EnforceMultiVA is enabled, we require
-that almost all remote validation requests succeed. The primary VA's
-"maxRemoteValidationFailures" config field specifies how many remote VAs can
-fail before the primary VA considers overall validation a failure. It should be
-strictly less than the number of remote VAs.
+MultiVAFullResults and EnforceMultiVA. If MultiVAFullResults is enabled
+then each primary validation will also send out remote validation requests, and
+wait for all the results to come in, so we can log the results for analysis. If
+EnforceMultiVA is enabled, we require that almost all remote validation requests
+succeed. The primary VA's "maxRemoteValidationFailures" config field specifies
+how many remote VAs can fail before the primary VA considers overall validation
+a failure. It should be strictly less than the number of remote VAs.
 
 Validation is also controlled by the "multiVAPolicyFile" config field on the
 primary VA. This specifies a file that can contain temporary overrides for


### PR DESCRIPTION
It's not true anymore that `MultiVAFullResults` is enabled in both prod and staging. Rather than update for the current state (`MultiVAFullResults` in prod only) I think the information should be removed. One day we'll disable `MultiVAFullResults` in prod too, and then probably deprecate the feature flag and associated code entirely.
