### PR TITLE
Treat duplicate finalize as OrderNotReady.

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -975,7 +975,7 @@ func (ssa *SQLStorageAuthority) SetOrderProcessing(ctx context.Context, req *cor
 
 		n, err := result.RowsAffected()
 		if err != nil || n == 0 {
-			return nil, berrors.InternalServerError("no order updated to beganProcessing status")
+			return nil, berrors.OrderNotReadyError("Order was already processing. This may indicate your client submitted the same order multiple times, possibly due to a client bug.")
 		}
 
 		return nil, nil

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -992,6 +992,15 @@ func TestSetOrderProcessing(t *testing.T) {
 	test.AssertNotError(t, err, "GetOrder failed")
 	test.AssertEquals(t, *updatedOrder.Status, string(core.StatusProcessing))
 	test.AssertEquals(t, *updatedOrder.BeganProcessing, true)
+
+	// Try to set the same order to be processing again. We should get an error.
+	err = sa.SetOrderProcessing(context.Background(), order)
+	if err == nil {
+		t.Errorf("Set the same order processing twice. This should have been an error.")
+	}
+	if !berrors.Is(err, berrors.OrderNotReady) {
+		t.Errorf("Wrong error when setting an order to processing twice. Expected OrderNotReady, got %#v", err)
+	}
 }
 
 func TestFinalizeOrder(t *testing.T) {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -995,9 +995,7 @@ func TestSetOrderProcessing(t *testing.T) {
 
 	// Try to set the same order to be processing again. We should get an error.
 	err = sa.SetOrderProcessing(context.Background(), order)
-	if err == nil {
-		test.AssertError(t, err, "Set the same order processing twice. This should have been an error.")
-	}
+	test.AssertError(t, err, "Set the same order processing twice. This should have been an error.")
 	if !berrors.Is(err, berrors.OrderNotReady) {
 		t.Errorf("Wrong error when setting an order to processing twice. Expected OrderNotReady, got %#v", err)
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -996,7 +996,7 @@ func TestSetOrderProcessing(t *testing.T) {
 	// Try to set the same order to be processing again. We should get an error.
 	err = sa.SetOrderProcessing(context.Background(), order)
 	if err == nil {
-		t.Errorf("Set the same order processing twice. This should have been an error.")
+		test.AssertError(t, err, "Set the same order processing twice. This should have been an error.")
 	}
 	if !berrors.Is(err, berrors.OrderNotReady) {
 		t.Errorf("Wrong error when setting an order to processing twice. Expected OrderNotReady, got %#v", err)


### PR DESCRIPTION
This turns what would otherwise be a 500 error into a 4xx error.

Fixes #4672 