### PR TITLE
Fix ocsp-updater sleep calculation

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -407,7 +407,7 @@ func (updater *OCSPUpdater) tick() {
 	if took > updater.tickWindow {
 		long = "true"
 	}
-	sleepDur := end.Sub(start.Add(updater.tickWindow))
+	sleepDur := start.Add(updater.tickWindow).Sub(end)
 	if err != nil {
 		state = "failed"
 		updater.tickFailures++

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -535,18 +535,21 @@ func TestTickSleep(t *testing.T) {
 	updater.dbMap = m
 
 	// Test when updateOCSPResponses fails the failure counter is incremented
-	// and the clock moved forward
+	// and the clock moved forward by more than updater.tickWindow
+	updater.tickFailures = 2
 	before := fc.Now()
 	updater.tick()
-	test.AssertEquals(t, updater.tickFailures, 1)
-	test.Assert(t, !fc.Now().Equal(before), "Clock didn't move forward")
+	test.AssertEquals(t, updater.tickFailures, 3)
+	took := fc.Since(before)
+	test.Assert(t, took > updater.tickWindow, "Clock didn't move forward enough")
 
 	// Test when updateOCSPResponses works the failure counter is reset to zero
-	// and the clock doesn't move
+	// and the clock only moves by updater.tickWindow
 	updater.dbMap = dbMap
 	before = fc.Now()
 	updater.tick()
 	test.AssertEquals(t, updater.tickFailures, 0)
-	test.Assert(t, fc.Now().Equal(before), "Clock moved forward")
+	took = fc.Since(before)
+	test.AssertEquals(t, took, updater.tickWindow)
 
 }


### PR DESCRIPTION
In #4659 the sleep calculation was inverted, so when we intended to sleep for 10s we tried to sleep for -10s. In situations where the ocsp-updater would typically complete work faster than the expected tick duration this could cause excessively tight looping.

Fixes #4675.