### PR TITLE
Add "During secondary validation:" error prefix.

### DIFF
--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -887,25 +887,29 @@ def test_http_multiva_threshold_fail():
 
     hostname, cleanup = multiva_setup(client, guestlist)
 
+    failed_authzrs = []
     try:
         chisel2.auth_and_issue([hostname], client=client, chall_type="http-01")
     except acme_errors.ValidationError as e:
         # NOTE(@cpu): Chisel2's expect_problem doesn't work in this case so this
         # test needs to unpack an `acme_errors.ValidationError` on its own. It
         # might be possible to clean this up in the future.
-        if len(e.failed_authzrs) != 1:
-            raise(Exception("expected one failed authz, found {0}".format(len(e.failed_authzrs))))
-        challs = e.failed_authzrs[0].body.challenges
-        httpChall = None
-        for chall_body in challs:
-            if isinstance(chall_body.chall, challenges.HTTP01):
-                httpChall = chall_body
-        if httpChall is None:
-            raise(Exception("no HTTP-01 challenge in failed authz"))
-        if httpChall.error.typ != "urn:ietf:params:acme:error:unauthorized":
-            raise(Exception("expected unauthorized prob, found {0}".format(httpChall.error.typ)))
+        failed_authzrs = e.failed_authzrs
     finally:
         cleanup()
+    if len(failed_authzrs) != 1:
+        raise(Exception("expected one failed authz, found {0}".format(len(failed_authzrs))))
+    challs = failed_authzrs[0].body.challenges
+    httpChall = None
+    for chall_body in challs:
+        if isinstance(chall_body.chall, challenges.HTTP01):
+            httpChall = chall_body
+    if httpChall is None:
+        raise(Exception("no HTTP-01 challenge in failed authz"))
+    if httpChall.error.typ != "urn:ietf:params:acme:error:unauthorized":
+        raise(Exception("expected unauthorized prob, found {0}".format(httpChall.error.typ)))
+    if not httpChall.error.detail.startswith("During secondary validation: "):
+        raise(Exception("expected 'During secondary validation' problem detail, found {0}".format(httpChall.error.detail)))
 
 def test_http_multiva_threshold_fail_domain_disabled():
     # Only the config-next config dir has remote VAs and a multi VA policy file

--- a/va/va.go
+++ b/va/va.go
@@ -502,7 +502,9 @@ func (va *ValidationAuthorityImpl) processRemoteResults(
 				state = "success"
 				return nil
 			} else if bad > va.maxRemoteFailures {
-				return result.Problem
+				modifiedProblem := *result.Problem
+				modifiedProblem.Detail = "During secondary validation: " + firstProb.Detail
+				return &modifiedProblem
 			}
 		}
 
@@ -528,7 +530,9 @@ func (va *ValidationAuthorityImpl) processRemoteResults(
 		state = "success"
 		return nil
 	} else if bad > va.maxRemoteFailures {
-		return firstProb
+		modifiedProblem := *firstProb
+		modifiedProblem.Detail = "During secondary validation: " + firstProb.Detail
+		return &modifiedProblem
 	}
 
 	// This condition should not occur - it indicates the good/bad counts didn't

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -329,8 +329,6 @@ func TestMultiVA(t *testing.T) {
 		`The key authorization file from the server did not match this challenge %q != "???"`,
 		expectedKeyAuthorization)
 
-	internalErr := probs.ServerInternal("Remote PerformValidation RPC failed")
-
 	expectedInternalErrLine := fmt.Sprintf(
 		`ERR: \[AUDIT\] Remote VA "broken".PerformValidation failed: %s`,
 		brokenRemoteVAError.Error())
@@ -382,7 +380,7 @@ func TestMultiVA(t *testing.T) {
 			},
 			AllowedUAs:   allowedUAs,
 			Features:     enforceMultiVA,
-			ExpectedProb: internalErr,
+			ExpectedProb: probs.ServerInternal("During secondary validation: Remote PerformValidation RPC failed"),
 			// The real failure cause should be logged
 			ExpectedLog: expectedInternalErrLine,
 		},
@@ -410,11 +408,13 @@ func TestMultiVA(t *testing.T) {
 		{
 			// With only one working remote VA there should be a validation failure
 			// when enforcing multi VA.
-			Name:         "Local VA and one remote VA OK, enforce multi VA",
-			RemoteVAs:    remoteVAs,
-			AllowedUAs:   map[string]bool{localUA: true, remoteUA2: true},
-			Features:     enforceMultiVA,
-			ExpectedProb: unauthorized,
+			Name:       "Local VA and one remote VA OK, enforce multi VA",
+			RemoteVAs:  remoteVAs,
+			AllowedUAs: map[string]bool{localUA: true, remoteUA2: true},
+			Features:   enforceMultiVA,
+			ExpectedProb: probs.Unauthorized(
+				`During secondary validation: The key authorization file from the server did not match this challenge %q != "???"`,
+				expectedKeyAuthorization),
 		},
 		{
 			// With one remote VA cancelled there should not be a validation failure
@@ -442,7 +442,7 @@ func TestMultiVA(t *testing.T) {
 			// With the local and remote VAs seeing diff problems and the full results
 			// feature flag on but multi VA enforcement off we expect
 			// no problem.
-			Name:       "Local and remove VA differential, full results, no enforce multi VA",
+			Name:       "Local and remote VA differential, full results, no enforce multi VA",
 			RemoteVAs:  remoteVAs,
 			AllowedUAs: map[string]bool{localUA: true},
 			Features:   noEnforceMultiVAFullResults,
@@ -450,11 +450,13 @@ func TestMultiVA(t *testing.T) {
 		{
 			// With the local and remote VAs seeing diff problems and the full results
 			// feature flag on and multi VA enforcement on we expect a problem.
-			Name:         "Local and remove VA differential, full results, enforce multi VA",
-			RemoteVAs:    remoteVAs,
-			AllowedUAs:   map[string]bool{localUA: true},
-			Features:     enforceMultiVAFullResults,
-			ExpectedProb: unauthorized,
+			Name:       "Local and remote VA differential, full results, enforce multi VA",
+			RemoteVAs:  remoteVAs,
+			AllowedUAs: map[string]bool{localUA: true},
+			Features:   enforceMultiVAFullResults,
+			ExpectedProb: probs.Unauthorized(
+				`During secondary validation: The key authorization file from the server did not match this challenge %q != "???"`,
+				expectedKeyAuthorization),
 		},
 	}
 


### PR DESCRIPTION
This should make it easier to distinguish errors that are triggered by
remote failures rather than local ones.

Fixes #4669 