### PR TITLE
ra: forbid mailto contacts that contain hfields

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -358,6 +358,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, init c
 // * A list containing an empty contact
 // * A list containing a contact that does not parse as a URL
 // * A list containing a contact that has a URL scheme other than mailto
+// * A list containing a mailto contact that contains hfields
 // * A list containing a contact that has non-ascii characters
 // * A list containing a contact that doesn't pass `validateEmail`
 func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, contacts *[]string) error {
@@ -382,6 +383,9 @@ func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, conta
 		}
 		if parsed.Scheme != "mailto" {
 			return berrors.InvalidEmailError("contact method %q is not supported", parsed.Scheme)
+		}
+		if parsed.RawQuery != "" {
+			return berrors.InvalidEmailError("contact email [%q] contains hfields", contact)
 		}
 		if !core.IsASCII(contact) {
 			return berrors.InvalidEmailError(

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -419,6 +419,9 @@ func TestValidateContacts(t *testing.T) {
 	err = ra.validateContacts(context.Background(), &[]string{"mailto:admin@[1.2.3.4]"})
 	test.AssertError(t, err, "Forbidden email")
 
+	err = ra.validateContacts(context.Background(), &[]string{"mailto:admin@a.com?no-reminder-emails"})
+	test.AssertError(t, err, "No hfields in email")
+
 	// The registrations.contact field is VARCHAR(191). 175 'a' characters plus
 	// the prefix "mailto:" and the suffix "@a.com" makes exactly 191 bytes of
 	// encoded JSON. The correct size to hit our maximum DB field length.


### PR DESCRIPTION
https://tools.ietf.org/html/rfc8555#section-7.3

   Clients MUST NOT
   provide a "mailto" URL in the "contact" field that contains "hfields"
   [RFC6068] or more than one "addr-spec" in the "to" component.  If a
   server encounters a "mailto" contact URL that does not meet these
   criteria, then it SHOULD reject it as invalid.

--

While trying to find a way to smuggle in a "I'd like to register my email address but please don't send me reminder emails" hint to Boulder, I discovered that Boulder is failing to forbid hfields. FWIW I failed to find a way, can't use RFC5322 comments either :cry:.