### PR TITLE
Rename "authz2" types to just "authz"

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -136,7 +136,7 @@ func initTables(dbMap *gorp.DbMap) {
 	dbMap.AddTableWithName(requestedNameModel{}, "requestedNames").SetKeys(false, "OrderID")
 	dbMap.AddTableWithName(orderFQDNSet{}, "orderFqdnSets").SetKeys(true, "ID")
 	dbMap.AddTableWithName(authzModel{}, "authz2").SetKeys(true, "ID")
-	dbMap.AddTableWithName(orderToAuthz2Model{}, "orderToAuthz2").SetKeys(false, "OrderID", "AuthzID")
+	dbMap.AddTableWithName(orderToAuthzModel{}, "orderToAuthz2").SetKeys(false, "OrderID", "AuthzID")
 	dbMap.AddTableWithName(recordedSerialModel{}, "serials").SetKeys(true, "ID")
 	dbMap.AddTableWithName(precertificateModel{}, "precertificates").SetKeys(true, "ID")
 }

--- a/sa/model.go
+++ b/sa/model.go
@@ -351,11 +351,6 @@ type requestedNameModel struct {
 
 type orderToAuthzModel struct {
 	OrderID int64
-	AuthzID string
-}
-
-type orderToAuthz2Model struct {
-	OrderID int64
 	AuthzID int64
 }
 
@@ -449,7 +444,7 @@ func statusUint(status core.AcmeStatus) uint8 {
 	return statusToUint[string(status)]
 }
 
-const authz2Fields = "id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, token, validationError, validationRecord"
+const authzFields = "id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, token, validationError, validationRecord"
 
 type authzModel struct {
 	ID               int64     `db:"id"`

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -903,7 +903,7 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *corepb.Order)
 		}
 
 		for _, id := range req.V2Authorizations {
-			otoa := &orderToAuthz2Model{
+			otoa := &orderToAuthzModel{
 				OrderID: order.ID,
 				AuthzID: id,
 			}
@@ -1443,7 +1443,7 @@ func (ssa *SQLStorageAuthority) GetAuthorizations2(ctx context.Context, req *sap
 			expires > ? AND
 			identifierType = ? AND
 			identifierValue IN (%s)`,
-		authz2Fields,
+		authzFields,
 		strings.Join(qmarks, ","),
 	)
 	_, err := ssa.dbMap.Select(
@@ -1624,7 +1624,7 @@ func (ssa *SQLStorageAuthority) GetPendingAuthorization2(ctx context.Context, re
 			identifierType = :dnsType AND
 			identifierValue = :ident
 			ORDER BY expires ASC
-			LIMIT 1 `, authz2Fields),
+			LIMIT 1 `, authzFields),
 		map[string]interface{}{
 			"regID":      *req.RegistrationID,
 			"status":     statusUint(core.StatusPending),
@@ -1676,7 +1676,7 @@ func (ssa *SQLStorageAuthority) GetValidOrderAuthorizations2(ctx context.Context
 			authz2.expires > :expires AND
 			authz2.status = :status AND
 			orderToAuthz2.orderID = :orderID`,
-			authz2Fields,
+			authzFields,
 		),
 		map[string]interface{}{
 			"regID":   *req.AcctID,
@@ -1758,7 +1758,7 @@ func (ssa *SQLStorageAuthority) GetValidAuthorizations2(ctx context.Context, req
 			expires > ? AND
 			identifierType = ? AND
 			identifierValue IN (%s)`,
-			authz2Fields,
+			authzFields,
 			strings.Join(qmarks, ","),
 		),
 		params...,

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1140,17 +1140,17 @@ func TestGetAuthorizations2(t *testing.T) {
 
 	// Associate authorizations with an order so that GetAuthorizations2 thinks
 	// they are WFE2 authorizations.
-	err := sa.dbMap.Insert(&orderToAuthz2Model{
+	err := sa.dbMap.Insert(&orderToAuthzModel{
 		OrderID: 1,
 		AuthzID: authzIDA,
 	})
 	test.AssertNotError(t, err, "sa.dbMap.Insert failed")
-	err = sa.dbMap.Insert(&orderToAuthz2Model{
+	err = sa.dbMap.Insert(&orderToAuthzModel{
 		OrderID: 1,
 		AuthzID: authzIDB,
 	})
 	test.AssertNotError(t, err, "sa.dbMap.Insert failed")
-	err = sa.dbMap.Insert(&orderToAuthz2Model{
+	err = sa.dbMap.Insert(&orderToAuthzModel{
 		OrderID: 1,
 		AuthzID: authzIDC,
 	})


### PR DESCRIPTION
This cleans up after the authzv2 migration and makes names a little
easier to read, since there is no longer a v1/v2 distinction. This
leaves the names of tables the same since they would require a migration
to change.