### PR TITLE
Deflake GetValidAuthorizations2 unittest.

### DIFF
--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2121,12 +2121,15 @@ func TestGetValidOrderAuthorizations2(t *testing.T) {
 	test.AssertNotError(t, err, "sa.GetValidOrderAuthorizations failed")
 	test.AssertNotNil(t, authzMap, "sa.GetValidOrderAuthorizations result was nil")
 	test.AssertEquals(t, len(authzMap.Authz), 2)
-	test.AssertEquals(t, *authzMap.Authz[0].Authz.Identifier, "a.example.com")
-	test.AssertEquals(t, *authzMap.Authz[1].Authz.Identifier, "b.example.com")
-	test.AssertEquals(t, *authzMap.Authz[0].Authz.Expires, expires.UnixNano())
-	test.AssertEquals(t, *authzMap.Authz[1].Authz.Expires, expires.UnixNano())
-	test.AssertEquals(t, *authzMap.Authz[0].Authz.Id, fmt.Sprintf("%d", authzIDA))
-	test.AssertEquals(t, *authzMap.Authz[1].Authz.Id, fmt.Sprintf("%d", authzIDB))
+
+	namesToCheck := map[string]int64{"a.example.com": authzIDA, "b.example.com": authzIDB}
+	for _, a := range authzMap.Authz {
+		if fmt.Sprintf("%d", namesToCheck[*a.Authz.Identifier]) != *a.Authz.Id {
+			t.Fatalf("incorrect identifier %q with id %d", *a.Authz.Identifier, a.Authz.Id)
+		}
+		test.AssertEquals(t, *a.Authz.Expires, expires.UnixNano())
+		delete(namesToCheck, *a.Authz.Identifier)
+	}
 
 	// Getting the order authorizations for an order that doesn't exist should return nothing
 	missingID := int64(0xC0FFEEEEEEE)

--- a/test/load-generator/acme/directory_test.go
+++ b/test/load-generator/acme/directory_test.go
@@ -105,6 +105,8 @@ func newMockDirectoryServer() *mockDirectoryServer {
 // TestNew tests that creating a new Client and populating the endpoint map
 // works correctly.
 func TestNew(t *testing.T) {
+	unreachableDirectoryURL := "http://localhost:1987"
+
 	srv := newMockDirectoryServer()
 	srv.Start()
 	defer srv.Close()
@@ -151,14 +153,11 @@ func TestNew(t *testing.T) {
 			DirectoryURL:  "http://" + string([]byte{0x1, 0x7F}),
 			ExpectedError: ErrInvalidDirectoryURL.Error(),
 		},
-		/* This test case depends on an error message that changed in Go 1.14. We
-		   can uncomment it once we've moved fully to Go 1.14.
 		{
 			Name:          "unreachable directory URL",
-			DirectoryURL:  "http://localhost:1987",
+			DirectoryURL:  unreachableDirectoryURL,
 			ExpectedError: "Get http://localhost:1987: dial tcp 127.0.0.1:1987: connect: connection refused",
 		},
-		*/
 		{
 			Name:          "wrong directory HTTP status code",
 			DirectoryURL:  wrongStatusCodeURL,

--- a/test/load-generator/acme/directory_test.go
+++ b/test/load-generator/acme/directory_test.go
@@ -105,8 +105,6 @@ func newMockDirectoryServer() *mockDirectoryServer {
 // TestNew tests that creating a new Client and populating the endpoint map
 // works correctly.
 func TestNew(t *testing.T) {
-	unreachableDirectoryURL := "http://localhost:1987"
-
 	srv := newMockDirectoryServer()
 	srv.Start()
 	defer srv.Close()
@@ -153,11 +151,14 @@ func TestNew(t *testing.T) {
 			DirectoryURL:  "http://" + string([]byte{0x1, 0x7F}),
 			ExpectedError: ErrInvalidDirectoryURL.Error(),
 		},
+		/* This test case depends on an error message that changed in Go 1.14. We
+		   can uncomment it once we've moved fully to Go 1.14.
 		{
 			Name:          "unreachable directory URL",
-			DirectoryURL:  unreachableDirectoryURL,
+			DirectoryURL:  "http://localhost:1987",
 			ExpectedError: "Get http://localhost:1987: dial tcp 127.0.0.1:1987: connect: connection refused",
 		},
+		*/
 		{
 			Name:          "wrong directory HTTP status code",
 			DirectoryURL:  wrongStatusCodeURL,


### PR DESCRIPTION
The test would sometimes fail based on randomized ordering of map
elements.