### PR TITLE
Remove travis-before-install.sh.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ before_install:
   - chmod +x $HOME/bin/docker-compose
 
 install:
-  - ./test/travis-before-install.sh
   - $HOME/bin/docker-compose pull
 
 script:

--- a/test/travis-before-install.sh
+++ b/test/travis-before-install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Travis does shallow clones, so there is no master branch present.
-# But test-no-outdated-migrations.sh needs to check diffs against master.
-# Fetch just the master branch from origin.
-( git fetch origin master
-git branch master FETCH_HEAD ) &


### PR DESCRIPTION
The comment in that script, that the master branch isn't present in
Travis builds, is no longer accurate. So we don't need this workaround
anymore.