### PR TITLE
Improve output when Go integration tests fail.

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -32,7 +32,7 @@ def fakeclock(date):
 
 def get_future_output(cmd, date):
     return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT,
-        env={'FAKECLOCK': fakeclock(date)})
+        env={'FAKECLOCK': fakeclock(date)}).decode()
 
 def random_domain():
     """Generate a random domain for testing (to avoid rate limiting)."""

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -31,14 +31,15 @@ def fakeclock(date):
     return date.strftime("%a %b %d %H:%M:%S UTC %Y")
 
 def get_future_output(cmd, date):
-    return run(cmd, env={'FAKECLOCK': fakeclock(date)})
+    return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT,
+        env={'FAKECLOCK': fakeclock(date)})
 
 def random_domain():
     """Generate a random domain for testing (to avoid rate limiting)."""
     return "rand.%x.xyz" % random.randrange(2**32)
 
 def run(cmd, **kwargs):
-    return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, **kwargs).decode()
+    return subprocess.check_call(cmd, shell=True, stderr=subprocess.STDOUT, **kwargs)
 
 def fetch_ocsp(request_bytes, url):
     """Fetch an OCSP response using POST, GET, and GET with URL encoding.
@@ -69,9 +70,10 @@ def ocsp_verify(cert_file, issuer_file, ocsp_response):
     ocsp_resp_file = os.path.join(tempdir, "ocsp.resp")
     with open(ocsp_resp_file, "wb") as f:
         f.write(ocsp_response)
-    output = run("openssl ocsp -no_nonce -issuer %s -cert %s \
+    cmd = "openssl ocsp -no_nonce -issuer %s -cert %s \
       -verify_other %s -CAfile test/test-root.pem \
-      -respin %s" % (issuer_file, cert_file, issuer_file, ocsp_resp_file))
+      -respin %s" % (issuer_file, cert_file, issuer_file, ocsp_resp_file)
+    output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode()
     # OpenSSL doesn't always return non-zero when response verify fails, so we
     # also look for the string "Response Verify Failure"
     verify_failure = "Response Verify Failure"

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -56,10 +56,7 @@ def run_go_tests(filterPattern=None):
     if filterPattern is not None and filterPattern != "":
         cmdLine = cmdLine + ["--test.run", filterPattern]
     cmdLine = cmdLine + ["-tags", "integration", "-count=1", "-race", "./test/integration"]
-    try:
-        subprocess.check_call(cmdLine, shell=False, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as e:
-        raise(Exception("%s. Output:\n%s" % (e, e.output)))
+    subprocess.check_call(cmdLine, shell=False, stderr=subprocess.STDOUT)
 
 def run_expired_authz_purger():
     # Note: This test must be run after all other tests that depend on
@@ -410,10 +407,7 @@ def run_cert_checker():
     run("./bin/cert-checker -config %s/cert-checker.json" % config_dir)
 
 if __name__ == "__main__":
-    try:
-        main()
-    except subprocess.CalledProcessError as e:
-        raise(Exception("%s. Output:\n%s" % (e, e.output)))
+    main()
 
 @atexit.register
 def stop():


### PR DESCRIPTION
Right now we show output like:

Traceback (most recent call last):
  File "test/integration-test.py", line 60, in run_go_tests
    subprocess.check_call(cmdLine, shell=False, stderr=subprocess.STDOUT)
  File "/usr/lib/python3.5/subprocess.py", line 271, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['go', 'test', '-tags', 'integration', '-count=1', '-race', './test/integration']' returned non-zero exit status 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test/integration-test.py", line 414, in <module>
    main()
  File "test/integration-test.py", line 293, in main
    run_go_tests(args.test_case_filter)
  File "test/integration-test.py", line 62, in run_go_tests
    raise(Exception("%s. Output:\n%s" % (e, e.output)))
Exception: Command '['go', 'test', '-tags', 'integration', '-count=1', '-race', './test/integration']' returned non-zero exit status 1. Output:
None

This change removes the try / raise clauses that were causing this
double exception logging. The original purpose of these clauses was to
make sure we logged output on failure. To continue to fulfill that
purpose, I switched the `run` function to use check_call instead of
check_output. check_output captures the stdout; check_call emits it to
the caller's stdout as normal, so we still see the output.

I also changed the two cases that actually wanted to process output so
they use check_output directly.