### PR TITLE
Clean up .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
 
 install:
   - ./test/travis-before-install.sh
-  - $HOME/bin/docker-compose pull
+  - docker-compose pull
 
 script:
   - docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" ${CONTAINER:-boulder} ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ go:
 
 go_import_path: github.com/letsencrypt/boulder
 
-addons:
-  hosts:
-    - le.wtf
-    - boulder
-    - boulder-mysql
-
 sudo: required
 
 services:
@@ -19,20 +13,15 @@ services:
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-`. You should not push branches beginning with `test-` to the
 # letsencrypt repository, but this is a convenient way to push branches to your
-# own fork of the repostiroy to ensure Travis passes before submitting a PR.
+# own fork of the repository to ensure Travis passes before submitting a PR.
 # For instance, you might run:
 # git push myremote branchname:test-branchname
 branches:
   only:
     - master
-    - staging
-    - release
     - /^test-.*$/
 
 env:
-    #
-    # Current Go version build tasks:
-    #
     - RUN="lints integration generate rpm" BOULDER_CONFIG_DIR="test/config"
     # Config changes that have landed in master but not yet been applied to
     # production can be made in boulder-config-next.json.
@@ -51,10 +40,9 @@ matrix:
   allow_failures:
     - env: RUN="coverage" CONTAINER="netaccess"
 
-
 install:
   - ./test/travis-before-install.sh
   - $HOME/bin/docker-compose pull
 
 script:
-  - $HOME/bin/docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" ${CONTAINER:-boulder} ./test.sh
+  - docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" ${CONTAINER:-boulder} ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ install:
   - $HOME/bin/docker-compose pull
 
 script:
-  - docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_COMMIT="${TRAVIS_COMMIT}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" ${CONTAINER:-boulder} ./test.sh
+  - docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" ${CONTAINER:-boulder} ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,17 +51,6 @@ matrix:
   allow_failures:
     - env: RUN="coverage" CONTAINER="netaccess"
 
-# We require a newer version of docker-compose than is installed by way of the
-# "services: docker" directive. Per the travis docs[0] this is best remedied
-# with the following `before_install` commands.
-# [0]: https://docs.travis-ci.com/user/docker/#Using-Docker-Compose
-before_install:
-  # We install `docker-compose` to $HOME/bin to avoid needing root perms.
-  # Afterwards where required we refer to the `docker-compose` binary by
-  # absolute path.
-  - curl -L https://github.com/docker/compose/releases/download/1.20.1/docker-compose-$(uname -s)-$(uname -m) > $HOME/bin/docker-compose
-  - chmod +x $HOME/bin/docker-compose
-
 install:
   - ./test/travis-before-install.sh
   - $HOME/bin/docker-compose pull

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ matrix:
   allow_failures:
     - env: RUN="coverage" CONTAINER="netaccess"
 
+
 install:
   - ./test/travis-before-install.sh
   - $HOME/bin/docker-compose pull


### PR DESCRIPTION
We have a comment in .travis.yml indicating that Travis' version of docker-compose is too old for us, but that's no longer true, so we can simplify things and speed up by using the stock installed one.

The list of custom hostnames in .travis.yml that all point to localhost are no longer used. Instead we use a custom DNS server within our docker-compose setup. So this PR removes those hostnames.

Remove staging and release as special branches to have tests run. We no longer use branches as part of our release process.