### PR TITLE
Block keys using hex(sha256(spki)).

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -87,17 +87,17 @@ func Fingerprint256(data []byte) string {
 	return base64.RawURLEncoding.EncodeToString(d.Sum(nil))
 }
 
-// KeyDigest produces a padded, standard Base64-encoded SHA256 digest of a
+// KeyDigestB64 produces a padded, standard Base64-encoded SHA256 digest of a
 // provided public key.
-func KeyDigest(key crypto.PublicKey) (string, error) {
+func KeyDigestB64(key crypto.PublicKey) (string, error) {
 	switch t := key.(type) {
 	case *jose.JSONWebKey:
 		if t == nil {
 			return "", fmt.Errorf("Cannot compute digest of nil key")
 		}
-		return KeyDigest(t.Key)
+		return KeyDigestB64(t.Key)
 	case jose.JSONWebKey:
-		return KeyDigest(t.Key)
+		return KeyDigestB64(t.Key)
 	default:
 		keyDER, err := x509.MarshalPKIXPublicKey(key)
 		if err != nil {
@@ -112,8 +112,8 @@ func KeyDigest(key crypto.PublicKey) (string, error) {
 
 // KeyDigestEquals determines whether two public keys have the same digest.
 func KeyDigestEquals(j, k crypto.PublicKey) bool {
-	digestJ, errJ := KeyDigest(j)
-	digestK, errK := KeyDigest(k)
+	digestJ, errJ := KeyDigestB64(j)
+	digestK, errK := KeyDigestB64(k)
 	// Keys that don't have a valid digest (due to marshalling problems)
 	// are never equal. So, e.g. nil keys are not equal.
 	if errJ != nil || errK != nil {

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -78,15 +78,15 @@ func TestKeyDigest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	digest, err := KeyDigest(jwk)
+	digest, err := KeyDigestB64(jwk)
 	test.Assert(t, err == nil && digest == JWK1Digest, "Failed to digest JWK by value")
-	digest, err = KeyDigest(&jwk)
+	digest, err = KeyDigestB64(&jwk)
 	test.Assert(t, err == nil && digest == JWK1Digest, "Failed to digest JWK by reference")
-	digest, err = KeyDigest(jwk.Key)
+	digest, err = KeyDigestB64(jwk.Key)
 	test.Assert(t, err == nil && digest == JWK1Digest, "Failed to digest bare key")
 
 	// Test with unknown key type
-	_, err = KeyDigest(struct{}{})
+	_, err = KeyDigestB64(struct{}{})
 	test.Assert(t, err != nil, "Should have rejected unknown key type")
 }
 

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -2,6 +2,9 @@ package goodkey
 
 import (
 	"crypto"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"io/ioutil"
 
@@ -10,18 +13,22 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// blockedKeys is a type for maintaining a map of Base64 encoded SHA256 hashes
+type keyHash [32]byte
+
+// blockedKeys is a type for maintaining a map of SHA256 hashes
 // of SubjectPublicKeyInfo's that should be considered blocked.
 // blockedKeys are created by using loadBlockedKeysList.
-type blockedKeys map[string]bool
+type blockedKeys map[keyHash]bool
+
+var ErrWrongDecodedSize = errors.New("not enough bytes decoded for sha256 hash")
 
 // blocked checks if the given public key is considered administratively
-// blocked based on a Base64 encoded SHA256 hash of the SubjectPublicKeyInfo.
+// blocked based on a SHA256 hash of the SubjectPublicKeyInfo.
 // Important: blocked should not be called except on a blockedKeys instance
 // returned from loadBlockedKeysList.
 // function should not be used until after `loadBlockedKeysList` has returned.
 func (b blockedKeys) blocked(key crypto.PublicKey) (bool, error) {
-	hash, err := core.KeyDigest(key)
+	b64Hash, err := core.KeyDigest(key)
 	if err != nil {
 		// the bool result should be ignored when err is != nil but to be on the
 		// paranoid side return true anyway so that a key we can't compute the
@@ -29,11 +36,19 @@ func (b blockedKeys) blocked(key crypto.PublicKey) (bool, error) {
 		// err result.
 		return true, err
 	}
+	var hash keyHash
+	n, err := base64.StdEncoding.Decode(hash[:], []byte(b64Hash))
+	if err != nil {
+		return true, err
+	}
+	if n != sha256.Size {
+		return true, ErrWrongDecodedSize
+	}
 	return b[hash], nil
 }
 
 // loadBlockedKeysList creates a blockedKeys object that can be used to check if
-// a key is blocked. It creates a lookup map from a list of Base64 encoded
+// a key is blocked. It creates a lookup map from a list of
 // SHA256 hashes of SubjectPublicKeyInfo's in the input YAML file
 // with the expected format:
 //
@@ -52,18 +67,38 @@ func loadBlockedKeysList(filename string) (*blockedKeys, error) {
 	}
 
 	var list struct {
-		BlockedHashes []string `yaml:"blocked"`
+		BlockedHashes    []string `yaml:"blocked"`
+		BlockedHashesHex []string `yaml:"blockedHashesHex"`
 	}
 	if err := yaml.Unmarshal(yamlBytes, &list); err != nil {
 		return nil, err
 	}
 
-	if len(list.BlockedHashes) == 0 {
+	if len(list.BlockedHashes) == 0 && len(list.BlockedHashesHex) == 0 {
 		return nil, errors.New("no blocked hashes in YAML")
 	}
 
-	blockedKeys := make(blockedKeys, len(list.BlockedHashes))
-	for _, hash := range list.BlockedHashes {
+	blockedKeys := make(blockedKeys, len(list.BlockedHashes)+len(list.BlockedHashesHex))
+	for _, b64Hash := range list.BlockedHashes {
+		var hash keyHash
+		n, err := base64.StdEncoding.Decode(hash[:], []byte(b64Hash))
+		if err != nil {
+			return nil, err
+		}
+		if n != sha256.Size {
+			return nil, ErrWrongDecodedSize
+		}
+		blockedKeys[hash] = true
+	}
+	for _, hexHash := range list.BlockedHashesHex {
+		var hash keyHash
+		n, err := hex.Decode(hash[:], []byte(hexHash))
+		if err != nil {
+			return nil, err
+		}
+		if n != sha256.Size {
+			return nil, ErrWrongDecodedSize
+		}
 		blockedKeys[hash] = true
 	}
 	return &blockedKeys, nil

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -28,7 +28,7 @@ var ErrWrongDecodedSize = errors.New("not enough bytes decoded for sha256 hash")
 // returned from loadBlockedKeysList.
 // function should not be used until after `loadBlockedKeysList` has returned.
 func (b blockedKeys) blocked(key crypto.PublicKey) (bool, error) {
-	b64Hash, err := core.KeyDigest(key)
+	b64Hash, err := core.KeyDigestB64(key)
 	if err != nil {
 		// the bool result should be ignored when err is != nil but to be on the
 		// paranoid side return true anyway so that a key we can't compute the

--- a/goodkey/blocked_test.go
+++ b/goodkey/blocked_test.go
@@ -16,7 +16,8 @@ import (
 func TestBlockedKeys(t *testing.T) {
 	// Start with an empty list
 	var inList struct {
-		BlockedHashes []string `yaml:"blocked"`
+		BlockedHashes    []string `yaml:"blocked"`
+		BlockedHashesHex []string `yaml:"blockedHashesHex"`
 	}
 
 	yamlList, err := yaml.Marshal(&inList)
@@ -56,7 +57,9 @@ func TestBlockedKeys(t *testing.T) {
 	// public keys in the test certs/JWKs
 	inList.BlockedHashes = []string{
 		"cuwGhNNI6nfob5aqY90e7BleU6l7rfxku4X3UTJ3Z7M=",
-		"Qebc1V3SkX3izkYRGNJilm9Bcuvf0oox4U2Rn+b4JOE=",
+	}
+	inList.BlockedHashesHex = []string{
+		"41e6dcd55dd2917de2ce461118d262966f4172ebdfd28a31e14d919fe6f824e1",
 	}
 
 	yamlList, err = yaml.Marshal(&inList)

--- a/sa/model.go
+++ b/sa/model.go
@@ -190,7 +190,7 @@ func registrationToModel(r *core.Registration) (*regModel, error) {
 		return nil, err
 	}
 
-	sha, err := core.KeyDigest(r.Key)
+	sha, err := core.KeyDigestB64(r.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -114,7 +114,7 @@ func (ssa *SQLStorageAuthority) GetRegistrationByKey(ctx context.Context, key *j
 	if key == nil {
 		return core.Registration{}, fmt.Errorf("key argument to GetRegistrationByKey must not be nil")
 	}
-	sha, err := core.KeyDigest(key.Key)
+	sha, err := core.KeyDigestB64(key.Key)
 	if err != nil {
 		return core.Registration{}, err
 	}

--- a/test/block-a-key/main.go
+++ b/test/block-a-key/main.go
@@ -100,7 +100,7 @@ func main() {
 		log.Fatalf("error loading public key: %v", err)
 	}
 
-	spkiHash, err := core.KeyDigest(key)
+	spkiHash, err := core.KeyDigestB64(key)
 	if err != nil {
 		log.Fatalf("error computing spki hash: %v", err)
 	}

--- a/test/block-a-key/main_test.go
+++ b/test/block-a-key/main_test.go
@@ -51,7 +51,7 @@ func TestKeyBlocking(t *testing.T) {
 				key, err = keyFromCert(tc.certPath)
 			}
 			test.AssertNotError(t, err, "error getting key from input file")
-			spkiHash, err := core.KeyDigest(key)
+			spkiHash, err := core.KeyDigestB64(key)
 			test.AssertNotError(t, err, "error computing spki hash")
 			test.AssertEquals(t, spkiHash, tc.expected)
 		})

--- a/test/example-blocked-keys.yaml
+++ b/test/example-blocked-keys.yaml
@@ -26,3 +26,7 @@ blocked:
   - cuwGhNNI6nfob5aqY90e7BleU6l7rfxku4X3UTJ3Z7M=
   # test/block-a-key/test/test.rsa.jwk.json
   - Qebc1V3SkX3izkYRGNJilm9Bcuvf0oox4U2Rn+b4JOE=
+blockedHashesHex:
+  - 41e6dcd55dd2917de2ce461118d262966f4172ebdfd28a31e14d919fe6f824e1
+
+  


### PR DESCRIPTION
In addition to base64(sha256(spki)).

As part of that, change KeyDigest to return [32]byte, and add KeyDigestB64 which provides the base64-encoded output that KeyDigest used to provide. Also update all call sites.