### PR TITLE
Don't activate virtual environment

### DIFF
--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -56,7 +56,6 @@ if [[ $# -eq 0 ]]; then
     # the activate script touches PS1, which is undefined, so we have to relax
     # the "fail on undefined" setting here.
     set +u
-    source ${CERTBOT_PATH:-/certbot}/${VENV_NAME:-venv3}/bin/activate
     exec python3 ./start.py
 fi
 


### PR DESCRIPTION
With the change in https://github.com/letsencrypt/boulder/pull/4732, I think this line should be removed because a virtual environment is no longer created in the boulder-tools image.

Certbot's tests using boulder were broken, but this change seems to have fixed it.