### PR TITLE
Replace clock.Default() with clock.New()

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -119,7 +119,7 @@ func NewCachePurgeClient(
 		retries:      retries,
 		retryBackoff: retryBackoff,
 		log:          log,
-		clk:          clock.Default(),
+		clk:          clock.New(),
 		purgeLatency: purgeLatency,
 		purges:       purges,
 	}, nil

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -53,7 +53,7 @@ func BenchmarkCheckCert(b *testing.B) {
 		test.ResetSATestDatabase(b)()
 	}()
 
-	checker := newChecker(saDbMap, clock.Default(), pa, expectedValidityPeriod)
+	checker := newChecker(saDbMap, clock.New(), pa, expectedValidityPeriod)
 	testKey, _ := rsa.GenerateKey(rand.Reader, 1024)
 	expiry := time.Now().AddDate(0, 0, 1)
 	serial := big.NewInt(1337)

--- a/cmd/clock_generic.go
+++ b/cmd/clock_generic.go
@@ -4,11 +4,11 @@ package cmd
 
 import "github.com/jmhodges/clock"
 
-// Clock functions similarly to clock.Default(), but the returned value can be
+// Clock functions similarly to clock.New(), but the returned value can be
 // changed using the FAKECLOCK environment variable if the 'integration' build
 // flag is set.
 //
 // This function returns the default Clock.
 func Clock() clock.Clock {
-	return clock.Default()
+	return clock.New()
 }

--- a/log/log.go
+++ b/log/log.go
@@ -60,7 +60,7 @@ func New(log *syslog.Writer, stdoutLogLevel int, syslogLogLevel int) (Logger, er
 		return nil, errors.New("Attempted to use a nil System Logger.")
 	}
 	return &impl{
-		&bothWriter{log, stdoutLogLevel, syslogLogLevel, clock.Default()},
+		&bothWriter{log, stdoutLogLevel, syslogLogLevel, clock.New()},
 	}, nil
 }
 

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -141,7 +141,7 @@ func New(
 		},
 		log:              logger,
 		from:             from,
-		clk:              clock.Default(),
+		clk:              clock.New(),
 		csprgSource:      realSource{},
 		reconnectBase:    reconnectBase,
 		reconnectMax:     reconnectMax,
@@ -155,7 +155,7 @@ func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
 	return &MailerImpl{
 		dialer:      dryRunClient{logger},
 		from:        from,
-		clk:         clock.Default(),
+		clk:         clock.New(),
 		csprgSource: realSource{},
 		sendMailAttempts: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "send_mail_attempts",

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -157,7 +157,7 @@ func TestDNSValidationNoServer(t *testing.T) {
 		time.Second*5,
 		nil,
 		metrics.NoopRegisterer,
-		clock.Default(),
+		clock.New(),
 		1,
 		log)
 

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -204,7 +204,7 @@ func setup(
 		userAgent,
 		"letsencrypt.org",
 		metrics.NoopRegisterer,
-		clock.Default(),
+		clock.New(),
 		logger,
 		accountURIPrefixes,
 		"")


### PR DESCRIPTION
clock.Default is deprecated:
https://godoc.org/github.com/jmhodges/clock#Default

partial staticcheck cleanup: responseWriter.Body.Bytes()