### PR TITLE
Remove deprecated HeaderMap reference.

### DIFF
--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1039,7 +1039,6 @@ func TestIssueCertificate(t *testing.T) {
 	test.AssertContains(t, reqlogs[0], `"CommonName":"not-an-example.com",`)
 
 	mockLog.Clear()
-	responseWriter.HeaderMap = http.Header{}
 	wfe.NewCertificate(ctx, newRequestEvent(), responseWriter,
 		makePostRequest(signRequest(t, `{
 			"resource":"new-cert",
@@ -2060,7 +2059,6 @@ func TestRegistration(t *testing.T) {
 	responseWriter.Body.Reset()
 
 	// Test POST valid JSON with registration up in the mock (with old agreement URL)
-	responseWriter.HeaderMap = http.Header{}
 	wfe.SubscriberAgreementURL = "http://example.invalid/new-terms"
 	result, err = signer.Sign([]byte(`{"resource":"reg","agreement":"` + agreementURL + `"}`))
 	test.AssertNotError(t, err, "Couldn't sign")

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2262,7 +2262,6 @@ func TestNewOrder(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			responseWriter.Body.Reset()
-			responseWriter.HeaderMap = http.Header{}
 
 			wfe.NewOrder(ctx, newRequestEvent(), responseWriter, tc.Request)
 			test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), tc.ExpectedBody)
@@ -2276,7 +2275,6 @@ func TestNewOrder(t *testing.T) {
 
 	// Test that we log the "Created" field.
 	responseWriter.Body.Reset()
-	responseWriter.HeaderMap = http.Header{}
 	request := signAndPost(t, targetPath, signedURL, validOrderBody, 1, wfe.nonceService)
 	requestEvent := newRequestEvent()
 	wfe.NewOrder(ctx, requestEvent, responseWriter, request)
@@ -2401,7 +2399,6 @@ func TestFinalizeOrder(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			responseWriter.Body.Reset()
-			responseWriter.HeaderMap = http.Header{}
 			wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, tc.Request)
 			for k, v := range tc.ExpectedHeaders {
 				got := responseWriter.Header().Get(k)
@@ -2420,7 +2417,6 @@ func TestFinalizeOrder(t *testing.T) {
 	// Go 1.10.4 to 1.11 changed the expected format)
 	badCSRReq := signAndPost(t, "1/8", "http://localhost/1/8", `{"CSR": "ABCD"}`, 1, wfe.nonceService)
 	responseWriter.Body.Reset()
-	responseWriter.HeaderMap = http.Header{}
 	wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, badCSRReq)
 	responseBody := responseWriter.Body.String()
 	test.AssertContains(t, responseBody, "Error parsing certificate request")


### PR DESCRIPTION
ResponseRecorder's HeaderMap field is deprecated:
https://godoc.org/net/http/httptest#ResponseRecorder

partial staticcheck cleanup: https://staticcheck.io/docs/checks#SA1019