### PR TITLE
Fix some misspellings.

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -167,7 +167,7 @@ func main() {
 
 	// Boulder's components assume that there will always be CT logs configured.
 	// Issuing a certificate without SCTs embedded is a miss-issuance event in the
-	// enviromnent Boulder is built for. Exit early if there is no CTLogGroups2
+	// environment Boulder is built for. Exit early if there is no CTLogGroups2
 	// configured.
 	if len(c.RA.CTLogGroups2) == 0 {
 		cmd.Fail("CTLogGroups2 must not be empty")

--- a/cmd/key-hash-backfill/main.go
+++ b/cmd/key-hash-backfill/main.go
@@ -106,7 +106,7 @@ func main() {
 		Syslog cmd.SyslogConfig
 	}
 	configFile := flag.String("config", "", "File containing a JSON config.")
-	initialID := flag.Int("intial-id", 0, "Initial certificate ID to start from")
+	initialID := flag.Int("initial-id", 0, "Initial certificate ID to start from")
 	batchSize := flag.Int("batch-size", 1000, "Number of certificates to fetch per batch")
 	flag.Parse()
 

--- a/test/load-generator/acme/challenge.go
+++ b/test/load-generator/acme/challenge.go
@@ -60,7 +60,7 @@ type randomChallengeStrategy struct {
 
 // PickChallenge for a randomChallengeStrategy returns a random challenge from
 // the authorization.
-func (strat randomChallengeStrategy) PickChallenge(authz *core.Authorization) (*core.Challenge, error) {
+func (strategy randomChallengeStrategy) PickChallenge(authz *core.Authorization) (*core.Challenge, error) {
 	if authz == nil {
 		return nil, ErrPickChallengeNilAuthz
 	}
@@ -80,7 +80,7 @@ type preferredTypeChallengeStrategy struct {
 // PickChallenge for a preferredTypeChallengeStrategy returns the authorization
 // challenge that has Type equal the preferredType. An error is returned if the
 // challenge doesn't have an authorization matching the preferredType.
-func (strat preferredTypeChallengeStrategy) PickChallenge(authz *core.Authorization) (*core.Challenge, error) {
+func (strategy preferredTypeChallengeStrategy) PickChallenge(authz *core.Authorization) (*core.Challenge, error) {
 	if authz == nil {
 		return nil, ErrPickChallengeNilAuthz
 	}
@@ -88,11 +88,11 @@ func (strat preferredTypeChallengeStrategy) PickChallenge(authz *core.Authorizat
 		return nil, ErrPickChallengeAuthzMissingChallenges
 	}
 	for _, chall := range authz.Challenges {
-		if chall.Type == strat.preferredType {
+		if chall.Type == strategy.preferredType {
 			return &chall, nil
 		}
 	}
 	return nil, fmt.Errorf("authorization (ID %q) had no %q type challenge",
 		authz.ID,
-		strat.preferredType)
+		strategy.preferredType)
 }

--- a/test/load-generator/acme/challenge_test.go
+++ b/test/load-generator/acme/challenge_test.go
@@ -49,13 +49,13 @@ func TestNewChallengeStrategy(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			strat, err := NewChallengeStrategy(tc.InputName)
+			strategy, err := NewChallengeStrategy(tc.InputName)
 			if err == nil && tc.ExpectedError != "" {
 				t.Errorf("Expected %q got no error\n", tc.ExpectedError)
 			} else if err != nil {
 				test.AssertEquals(t, err.Error(), tc.ExpectedError)
 			} else if err == nil && tc.ExpectedError == "" {
-				test.AssertEquals(t, fmt.Sprintf("%T", strat), tc.ExpectedStratType)
+				test.AssertEquals(t, fmt.Sprintf("%T", strategy), tc.ExpectedStratType)
 			}
 		})
 	}
@@ -123,9 +123,9 @@ func TestPickChallenge(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			strat, err := NewChallengeStrategy(tc.StratName)
+			strategy, err := NewChallengeStrategy(tc.StratName)
 			test.AssertNotError(t, err, "Failed to create challenge strategy")
-			chall, err := strat.PickChallenge(tc.InputAuthz)
+			chall, err := strategy.PickChallenge(tc.InputAuthz)
 			if err == nil && tc.ExpectedError != "" {
 				t.Errorf("Expected %q got no error\n", tc.ExpectedError)
 			} else if err != nil {


### PR DESCRIPTION
Found by golangci-lint's `misspell` linter.

`strat` was a false positive vs `start` but I figured it's easier to
just change the name.