### PR TITLE
Add error checking in load-generator and ocsp_forever

### DIFF
--- a/test/load-generator/boulder-calls.go
+++ b/test/load-generator/boulder-calls.go
@@ -337,7 +337,7 @@ func completeAuthorization(authz *core.Authorization, s *State, ctx *context) er
 
 	// Poll the authorization waiting for the challenge response to be recorded in
 	// a change of state. The polling may sleep and retry a few times if required
-	pollAuthorization(authz, s, ctx)
+	err = pollAuthorization(authz, s, ctx)
 	if err != nil {
 		return err
 	}

--- a/test/ocsp/ocsp_forever/main.go
+++ b/test/ocsp/ocsp_forever/main.go
@@ -79,7 +79,12 @@ func main() {
 		log.Fatal(err)
 	}
 	http.Handle("/metrics", promhttp.Handler())
-	go http.ListenAndServe(*listenAddress, nil)
+	go func() {
+		err = http.ListenAndServe(*listenAddress, nil)
+		if err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
 	for {
 		for _, pattern := range flag.Args() {
 			// Note: re-glob this pattern on each run, in case new certificates have


### PR DESCRIPTION
Found by golangci-lint's errcheck invocation.