### PR TITLE
Reject RSA keys with non-standard exponent

### DIFF
--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -239,21 +239,14 @@ func (policy *KeyPolicy) goodKeyRSA(key *rsa.PublicKey) (err error) {
 	}
 
 	// Rather than support arbitrary exponents, which significantly increases
-	// the size of the key space we allow, we restrict E to the standard RSA
-	// exponent 65537.
+	// the size of the key space we allow, we restrict E to the defacto standard
+	// RSA exponent 65537. There is no specific standards document that specifies
+	// 65537 as the 'best' exponent, but ITU X.509 Annex C suggests there are
+	// notable merits for using it if using a fixed exponent.
 	if key.E != 65537 {
 		return berrors.MalformedError("key exponent must be 65537")
 	}
 
-	// The CA SHALL confirm that the value of the public exponent is an
-	// odd number equal to 3 or more. Additionally, the public exponent
-	// SHOULD be in the range between 2^16 + 1 and 2^256-1.
-	// NOTE: rsa.PublicKey cannot represent an exponent part greater than
-	// 2^32 - 1 or 2^64 - 1, because it stores E as an integer. So we
-	// don't need to check the upper bound.
-	if (key.E%2) == 0 || key.E < ((1<<16)+1) {
-		return berrors.MalformedError("key exponent should be odd and >2^16: %d", key.E)
-	}
 	// The modulus SHOULD also have the following characteristics: an odd
 	// number, not the power of a prime, and have no factors smaller than 752.
 	// TODO: We don't yet check for "power of a prime."

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -237,6 +237,14 @@ func (policy *KeyPolicy) goodKeyRSA(key *rsa.PublicKey) (err error) {
 	if modulusBitLen%8 != 0 {
 		return berrors.MalformedError("key length wasn't a multiple of 8: %d", modulusBitLen)
 	}
+
+	// Rather than support arbitrary exponents, which significantly increases
+	// the size of the key space we allow, we restrict E to the standard RSA
+	// exponent 65537.
+	if key.E != 65537 {
+		return berrors.MalformedError("key exponent must be 65537")
+	}
+
 	// The CA SHALL confirm that the value of the public exponent is an
 	// odd number equal to 3 or more. Additionally, the public exponent
 	// SHOULD be in the range between 2^16 + 1 and 2^256-1.

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -249,7 +249,7 @@ func (policy *KeyPolicy) goodKeyRSA(key *rsa.PublicKey) (err error) {
 	//   odd number equal to 3 or more. Additionally, the public exponent
 	//   SHOULD be in the range between 2^16 + 1 and 2^256-1.
 	//
-	// By only allowing one exponent that fits these constraints we satisfy
+	// By only allowing one exponent, which fits these constraints, we satisfy
 	// these requirements.
 	if key.E != 65537 {
 		return berrors.MalformedError("key exponent must be 65537")

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -243,6 +243,14 @@ func (policy *KeyPolicy) goodKeyRSA(key *rsa.PublicKey) (err error) {
 	// RSA exponent 65537. There is no specific standards document that specifies
 	// 65537 as the 'best' exponent, but ITU X.509 Annex C suggests there are
 	// notable merits for using it if using a fixed exponent.
+	//
+	// The CABF Baseline Requirements state:
+	//   The CA SHALL confirm that the value of the public exponent is an
+	//   odd number equal to 3 or more. Additionally, the public exponent
+	//   SHOULD be in the range between 2^16 + 1 and 2^256-1.
+	//
+	// By only allowing one exponent that fits these constraints we satisfy
+	// these requirements.
 	if key.E != 65537 {
 		return berrors.MalformedError("key exponent must be 65537")
 	}

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -74,31 +74,22 @@ func TestModulusModulo8(t *testing.T) {
 
 var mod2048 = big.NewInt(0).Sub(big.NewInt(0).Lsh(big.NewInt(1), 2048), big.NewInt(1))
 
-func TestSmallExponent(t *testing.T) {
+func TestNonStandardExp(t *testing.T) {
+	evenMod := big.NewInt(0).Add(big.NewInt(1).Lsh(big.NewInt(1), 2047), big.NewInt(2))
 	key := rsa.PublicKey{
-		N: mod2048,
-		E: 5,
+		N: evenMod,
+		E: (1 << 16),
 	}
 	err := testingPolicy.GoodKey(&key)
-	test.AssertError(t, err, "Should have rejected small exponent")
-	test.AssertEquals(t, err.Error(), "key exponent should be odd and >2^16: 5")
-}
-
-func TestEvenExponent(t *testing.T) {
-	key := rsa.PublicKey{
-		N: mod2048,
-		E: 1 << 17,
-	}
-	err := testingPolicy.GoodKey(&key)
-	test.AssertError(t, err, "Should have rejected even exponent")
-	test.AssertEquals(t, err.Error(), "key exponent should be odd and >2^16: 131072")
+	test.AssertError(t, err, "Should have rejected non-standard exponent")
+	test.AssertEquals(t, err.Error(), "key exponent must be 65537")
 }
 
 func TestEvenModulus(t *testing.T) {
 	evenMod := big.NewInt(0).Add(big.NewInt(1).Lsh(big.NewInt(1), 2047), big.NewInt(2))
 	key := rsa.PublicKey{
 		N: evenMod,
-		E: (1 << 17) + 1,
+		E: (1 << 16) + 1,
 	}
 	err := testingPolicy.GoodKey(&key)
 	test.AssertError(t, err, "Should have rejected even modulus")
@@ -108,7 +99,7 @@ func TestEvenModulus(t *testing.T) {
 func TestModulusDivisibleBySmallPrime(t *testing.T) {
 	key := rsa.PublicKey{
 		N: mod2048,
-		E: (1 << 17) + 1,
+		E: (1 << 16) + 1,
 	}
 	err := testingPolicy.GoodKey(&key)
 	test.AssertError(t, err, "Should have rejected modulus divisible by 3")


### PR DESCRIPTION
Only allow the RSA exponent 65537, which is the defacto standard (only 3 unexpired certificates issued by Let's Encrypt use a different exponent).