### PR TITLE
Max TestValidAuthzExpires non-flaky.

### DIFF
--- a/test/integration/authz_test.go
+++ b/test/integration/authz_test.go
@@ -48,7 +48,7 @@ func TestValidAuthzExpires(t *testing.T) {
 	expectedExpiresMin := time.Now().AddDate(0, 0, validAuthorizationLifetime).Add(-time.Minute)
 	expectedExpiresMax := expectedExpiresMin.Add(2 * time.Minute)
 	actualExpires := authzOb.Expires
-	if !actualExpires.Before(expectedExpiresMin) || actualExpires.After(expectedExpiresMax) {
+	if actualExpires.Before(expectedExpiresMin) || actualExpires.After(expectedExpiresMax) {
 		t.Errorf("Wrong expiry. Got %s, expected it to be between %s and %s",
 			actualExpires, expectedExpiresMin, expectedExpiresMax)
 	}

--- a/test/integration/authz_test.go
+++ b/test/integration/authz_test.go
@@ -44,10 +44,12 @@ func TestValidAuthzExpires(t *testing.T) {
 	test.AssertEquals(t, authzOb.Status, "valid")
 	test.AssertEquals(t, authzOb.Identifier.Value, domains[0])
 
-	// The authz should have the expected expiry date
-	expectedExpires := time.Now().AddDate(0, 0, validAuthorizationLifetime).Round(time.Minute)
-	actualExpires := authzOb.Expires.Round(time.Minute)
-	if !expectedExpires.Equal(actualExpires) {
-		t.Errorf("Wrong expiry. Got %q, expected %q", actualExpires, expectedExpires)
+	// The authz should have the expected expiry date, plus or minus a minute
+	expectedExpiresMin := time.Now().AddDate(0, 0, validAuthorizationLifetime).Add(-time.Minute)
+	expectedExpiresMax := expectedExpiresMin.Add(2 * time.Minute)
+	actualExpires := authzOb.Expires
+	if !actualExpires.Before(expectedExpiresMin) || actualExpires.After(expectedExpiresMax) {
+		t.Errorf("Wrong expiry. Got %s, expected it to be between %s and %s",
+			actualExpires, expectedExpiresMin, expectedExpiresMax)
 	}
 }


### PR DESCRIPTION
Previously, the test called `.Round(time.Minute)` on the expected
and actual expiration times, intending to perform an "approximately
equal" function.

However, when the expected and actual times differed by a second, but
they happened to fall on opposite sides of a rounding interval (i.e. 30
seconds into a minute), they would be rounded in opposite directions,
resulting in a conclusion that they were not equal.

This change instead defines an acceptable range of plus or minus a
minute for the expiration time, and checks that the actual expiration
time is in that interval.