### PR TITLE
Use format strings properly for ProblemDetails

### DIFF
--- a/va/dns.go
+++ b/va/dns.go
@@ -61,7 +61,7 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, ident iden
 	challengeSubdomain := fmt.Sprintf("%s.%s", core.DNSPrefix, ident.Value)
 	txts, err := va.dnsClient.LookupTXT(ctx, challengeSubdomain)
 	if err != nil {
-		return nil, probs.DNS(err.Error())
+		return nil, probs.DNS("%s", err)
 	}
 
 	// If there weren't any TXT records return a distinct error message to allow

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -578,7 +578,8 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 	// A path that returns a body containing printf formatting verbs
 	mux.HandleFunc("/printf-verbs", func(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusOK)
-		fmt.Fprint(resp, "%"+"2F.well-known%"+"2F"+tooLargeBuf.String())
+		resp.Write([]byte("%2F.well-known%2F"))
+		resp.Write(tooLargeBuf.Bytes())
 	})
 
 	return server

--- a/va/va.go
+++ b/va/va.go
@@ -297,13 +297,13 @@ func detailedError(err error) *probs.ProblemDetails {
 		return probs.ConnectionFailure("Timeout after connect (your server may be slow or overloaded)")
 	}
 	if berrors.Is(err, berrors.ConnectionFailure) {
-		return probs.ConnectionFailure(err.Error())
+		return probs.ConnectionFailure("%s", err)
 	}
 	if berrors.Is(err, berrors.Unauthorized) {
-		return probs.Unauthorized(err.Error())
+		return probs.Unauthorized("%s", err)
 	}
 	if berrors.Is(err, berrors.DNS) {
-		return probs.DNS(err.Error())
+		return probs.DNS("%s", err)
 	}
 
 	if h2SettingsFrameErrRegex.MatchString(err.Error()) {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -516,7 +516,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *web.Reques
 	// the signature itself.
 	submittedKey, parsedJws, err := wfe.extractJWSKey(body)
 	if err != nil {
-		return nil, nil, reg, probs.Malformed(err.Error())
+		return nil, nil, reg, probs.Malformed("%s", err)
 	}
 
 	var key *jose.JSONWebKey
@@ -530,7 +530,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *web.Reques
 		// to check its quality before doing the verify.
 		if err = wfe.keyPolicy.GoodKey(ctx, submittedKey.Key); err != nil {
 			wfe.joseErrorCounter.WithLabelValues("JWKRejectedByGoodKey").Inc()
-			return nil, nil, reg, probs.Malformed(err.Error())
+			return nil, nil, reg, probs.Malformed("%s", err)
 		}
 		key = submittedKey
 	} else if err != nil {
@@ -557,7 +557,7 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *web.Reques
 
 	if statName, err := checkAlgorithm(key, parsedJws); err != nil {
 		wfe.joseErrorCounter.WithLabelValues(statName).Inc()
-		return nil, nil, reg, probs.Malformed(err.Error())
+		return nil, nil, reg, probs.Malformed("%s", err)
 	}
 
 	payload, err := parsedJws.Verify(key)
@@ -1541,7 +1541,7 @@ func (wfe *WebFrontEndImpl) KeyRollover(ctx context.Context, logEvent *web.Reque
 	// Parse as JWS
 	newKey, parsedJWS, err := wfe.extractJWSKey(string(body))
 	if err != nil {
-		wfe.sendError(response, logEvent, probs.Malformed(err.Error()), err)
+		wfe.sendError(response, logEvent, probs.Malformed("%s", err), err)
 		return
 	}
 	payload, err := parsedJWS.Verify(newKey)

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -628,7 +628,7 @@ func (wfe *WebFrontEndImpl) validSelfAuthenticatedJWS(
 	// If the key doesn't meet the GoodKey policy return a problem immediately
 	if err := wfe.keyPolicy.GoodKey(ctx, pubKey.Key); err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWKRejectedByGoodKey"}).Inc()
-		return nil, nil, probs.BadPublicKey(err.Error())
+		return nil, nil, probs.BadPublicKey("%s", err)
 	}
 
 	// Verify the JWS with the embedded JWK
@@ -704,12 +704,12 @@ func (wfe *WebFrontEndImpl) validKeyRollover(
 	// If the key doesn't meet the GoodKey policy return a problem immediately
 	if err := wfe.keyPolicy.GoodKey(ctx, jwk.Key); err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverJWKRejectedByGoodKey"}).Inc()
-		return nil, probs.BadPublicKey(err.Error())
+		return nil, probs.BadPublicKey("%s", err)
 	}
 
 	// Check that the public key and JWS algorithms match expected
 	if err := checkAlgorithm(jwk, innerJWS); err != nil {
-		return nil, probs.Malformed(err.Error())
+		return nil, probs.Malformed("%s", err)
 	}
 
 	// Verify the inner JWS signature with the public key from the embedded JWK.
@@ -747,7 +747,7 @@ func (wfe *WebFrontEndImpl) validKeyRollover(
 	// We must validate that the inner JWS' rollover request specifies the correct
 	// oldKey.
 	if keysEqual, err := core.PublicKeysEqual(req.OldKey.Key, oldKey.Key); err != nil {
-		return nil, probs.Malformed("Unable to compare new and old keys: %s", err.Error())
+		return nil, probs.Malformed("Unable to compare new and old keys: %s", err)
 	} else if !keysEqual {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverWrongOldKey"}).Inc()
 		return nil, probs.Malformed("Inner JWS does not contain old key field matching current account key")

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1461,7 +1461,7 @@ func (wfe *WebFrontEndImpl) Authorization(
 		wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
 		return
 	} else if berrors.Is(err, berrors.Malformed) {
-		wfe.sendError(response, logEvent, probs.Malformed(err.Error()), nil)
+		wfe.sendError(response, logEvent, probs.Malformed("%s", err), nil)
 		return
 	} else if err != nil {
 		wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), err)


### PR DESCRIPTION
Our `probs.*` methods act like Sprintf, taking a format and a variable list of args. However, some call sites were creating ProblemDetails with just an error string. If the error string contained formatting directives, this could result in incorrect output.

Replaces all calls of that type with a Sprintf-style invocation.

Fixes #4783 

Thanks to @alexzorin!