### PR TITLE
Clean up tag_and_upload.sh.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.1}:2020-04-16
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.1}:2020-04-22
         environment:
             FAKE_DNS: 10.77.77.77
             PKCS11_PROXY_SOCKET: tcp://boulder-hsm:5657
@@ -65,7 +65,7 @@ services:
             hard: -1
     bhsm:
         # To minimize fetching this should be the same version used above
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.1}:2020-04-16
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.1}:2020-04-22
         environment:
             PKCS11_DAEMON_SOCKET: tcp://0.0.0.0:5657
         command: /usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so
@@ -92,7 +92,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.1}:2020-04-16
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.1}:2020-04-22
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -1,6 +1,5 @@
 FROM buildpack-deps:stretch-scm
-
-ENV GO_VERSION_TO_INSTALL %%GO_VERSION%%
+ARG GO_VERSION
 
 # Copied from https://github.com/docker-library/golang/blob/master/Dockerfile-debian.template
 ENV GOPATH /go
@@ -8,7 +7,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:/usr/local/protoc/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
-RUN wget -O go.tgz "https://dl.google.com/go/go${GO_VERSION_TO_INSTALL}.linux-amd64.tar.gz" && tar -C /usr/local -xzf go.tgz && rm go.tgz;
+RUN wget -O go.tgz "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" && tar -C /usr/local -xzf go.tgz && rm go.tgz;
 COPY requirements.txt /tmp/requirements.txt
 COPY boulder.rsyslog.conf /etc/rsyslog.d/
 COPY build.sh /tmp/build.sh

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,26 +12,11 @@ do
   TAG_NAME="$BASE_TAG_NAME-go$GO_VERSION:$DATESTAMP"
   echo "Building boulder-tools image $TAG_NAME"
 
-  # NOTE(@cpu): Generating DOCKERFILE's on disk with the %%GO_VERSION%%
-  # templated out by `sed` is required because only Docker v17+ supports env var
-  # interpolation in Dockerfile `FROM` directives. This version isn't commonly
-  # packaged so we rely on this technique for the time being. Similarly, it
-  # would be cleaner if we could just output the `sed` directly to the `docker
-  # build` stdin but that requires Docker 17+ too! :'(
-  DOCKERFILE="golang.$GO_VERSION.Dockerfile"
-  sed -r \
-    -e 's!%%GO_VERSION%%!'"$GO_VERSION"'!g' \
-    "Dockerfile.tmpl" > "$DOCKERFILE"
-
   # Build the docker image using the templated Dockerfile, tagging it with
   # TAG_NAME
   docker build . \
     -t $TAG_NAME \
-    --no-cache \
-    -f "$DOCKERFILE"
-
-  # Clean up the temp. Dockerfile
-  rm "$DOCKERFILE"
+    --build-arg "GO_VERSION=${GO_VERSION}"
 done
 
 # Log in once now that images are ready to upload


### PR DESCRIPTION
We used a template and sed in #3622 because common versions of Docker
didn't support build args. But now they do, so we can use the convenient
build args feature to parameterize which Go version to use.

Also, remove the --no-cache flag to docker build, which slows things
down unnecessarily.