### PR TITLE
Intercept stdlib logger (try 2).

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -8,6 +8,7 @@ import (
 	"expvar"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"log/syslog"
 	"net/http"
 	"net/http/pprof"
@@ -131,6 +132,15 @@ func (log promLogger) Println(args ...interface{}) {
 	log.AuditErr(fmt.Sprint(args...))
 }
 
+type logWriter struct {
+	blog.Logger
+}
+
+func (lw logWriter) Write(p []byte) (n int, err error) {
+	lw.Logger.Info(string(p))
+	return
+}
+
 // StatsAndLogging constructs a prometheus registerer and an AuditLogger based
 // on its config parameters, and return them both. It also spawns off an HTTP
 // server on the provided port to report the stats and provide pprof profiling
@@ -169,6 +179,7 @@ func NewLogger(logConf SyslogConfig) blog.Logger {
 	cfsslLog.SetLogger(cfsslLogger{logger})
 	_ = mysql.SetLogger(mysqlLogger{logger})
 	grpclog.SetLoggerV2(grpcLogger{logger})
+	log.SetOutput(logWriter{logger})
 	return logger
 }
 

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/letsencrypt/boulder/core"
@@ -118,6 +120,21 @@ func TestCfsslLogger(t *testing.T) {
 		test.AssertEquals(t, logged[0], tc.expected)
 		test.AssertEquals(t, logged[1], tc.expected)
 		log.Clear()
+	}
+}
+
+func TestCaptureStdlibLog(t *testing.T) {
+	logger := blog.UseMock()
+	oldDest := log.Writer()
+	defer func() {
+		log.SetOutput(oldDest)
+	}()
+	log.SetOutput(logWriter{logger})
+	log.Print("thisisatest")
+	results := logger.GetAllMatching("thisisatest")
+	if len(results) != 1 {
+		t.Fatalf("Expected logger to receive 'thisisatest', got: %s",
+			strings.Join(logger.GetAllMatching(".*"), "\n"))
 	}
 }
 


### PR DESCRIPTION
This builds on #4665 and #4781. The problem we had previously was that
we were relying on a goroutine to consume bytes from a pipe in a
non-blocking manner, which meant that log.Fatal would cause us to exit
before writing out the data.

This version implements an io.Writer so we can make sure the log line
gets written in a blocking manner.