### PR TITLE
Accept application/pkcs7-mime to parse certificate.

### DIFF
--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -41,7 +41,8 @@ func getIssuer(cert *x509.Certificate) (*x509.Certificate, error) {
 		return nil, err
 	}
 	var issuer *x509.Certificate
-	if resp.Header.Get("Content-Type") == "application/x-pkcs7-mime" {
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "application/x-pkcs7-mime" || contentType == "application/pkcs7-mime" {
 		issuer, err = parseCMS(body)
 	} else {
 		issuer, err = parse(body)


### PR DESCRIPTION
When downloading a pkcs7 file to parse for issuer, some servers
appear to deliver application/pkcs7-mime Content-Type and others
application/x-pkcs7-mime. This patch changes the conditional
to look for both to invoke parseCMS().