### PR TITLE
Bug Fixes

### DIFF
--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -142,7 +142,6 @@ func main() {
 			Logger:    tailLogger{logger},
 		})
 		cmd.FailOnError(err, "failed to tail file")
-		defer t.Cleanup()
 
 		go func() {
 			for line := range t.Lines {
@@ -172,6 +171,7 @@ func main() {
 			// "reopen" code path for files that are removed and then recreated.
 			// These errors are harmless so we ignore them to allow clean shutdown.
 			_ = t.Stop()
+			t.Cleanup()
 		}
 	})
 }

--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -81,10 +81,11 @@ func delHTTP01Response(token string) error {
 	if err != nil {
 		return fmt.Errorf("deleting http-01 response: %s", err)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("deleting http-01 response: status %d", resp.StatusCode)
 	}
-	resp.Body.Close()
 	return nil
 }
 
@@ -126,11 +127,12 @@ func authAndIssue(c *client, csrKey *ecdsa.PrivateKey, domains []string) (*issua
 		if err != nil {
 			return nil, fmt.Errorf("adding HTTP-01 response: %s", err)
 		}
-		defer delHTTP01Response(chal.Token)
 		chal, err = c.Client.UpdateChallenge(c.Account, chal)
 		if err != nil {
+			delHTTP01Response(chal.Token)
 			return nil, fmt.Errorf("updating challenge: %s", err)
 		}
+		delHTTP01Response(chal.Token)
 	}
 
 	csr, err := makeCSR(csrKey, domains)


### PR DESCRIPTION
Patches:

- Make sure all log tailing types call `Cleanup`
- Make sure the `http.Response` body is closed in all cases
- Make sure that the challenge token is always deleted