### PR TITLE
Handful of revocation pkg cleanups

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -21,9 +21,9 @@ import (
 	"github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/mail"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
-	"github.com/letsencrypt/boulder/revocation"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/crypto/ocsp"
 
 	"google.golang.org/grpc"
 )
@@ -192,7 +192,7 @@ func (bkr *badKeyRevoker) sendMessage(addr string, serials []string) error {
 	return nil
 }
 
-var keyCompromiseCode = int64(revocation.KeyCompromise)
+var keyCompromiseCode = int64(ocsp.KeyCompromise)
 var revokerName = "bad-key-revoker"
 
 // revokeCerts revokes all the certificates associated with a particular key hash and sends

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/google/certificate-transparency-go v1.0.22-0.20181127102053-c25855a82
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -223,6 +224,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=

--- a/go.sum
+++ b/go.sum
@@ -87,7 +87,6 @@ github.com/google/certificate-transparency-go v1.0.22-0.20181127102053-c25855a82
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -224,7 +223,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -39,6 +39,7 @@ import (
 	"github.com/letsencrypt/boulder/web"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
+	"golang.org/x/crypto/ocsp"
 	grpc "google.golang.org/grpc"
 )
 
@@ -1713,7 +1714,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, cert
 	if err != nil {
 		return err
 	}
-	if features.Enabled(features.BlockedKeyTable) && reason == revocation.KeyCompromise {
+	if features.Enabled(features.BlockedKeyTable) && reason == ocsp.KeyCompromise {
 		digest, err := core.KeyDigest(cert.PublicKey)
 		if err != nil {
 			return err

--- a/revocation/reasons.go
+++ b/revocation/reasons.go
@@ -4,58 +4,45 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"golang.org/x/crypto/ocsp"
 )
 
 // Reason is used to specify a certificate revocation reason
 type Reason int
 
-const (
-	// Definitions for these codes can be found in Section 8.5.3.1 of ITU-T X.509
-	// http://www.itu.int/rec/T-REC-X.509-201210-I/en
-	Unspecified          = 0
-	KeyCompromise        = 1
-	CACompromise         = 2
-	AffiliationChanged   = 3
-	Superseded           = 4
-	CessationOfOperation = 5
-	CertificateHold      = 6
-	// 7 is unused
-	RemoveFromCRL      = 8
-	PrivilegeWithdrawn = 9
-	AACompromise       = 10
-)
-
-// RevocationReasons provides a map from reason code to string explaining the
-// code
+// ReasonToString provides a map from reason code to string
 var ReasonToString = map[Reason]string{
-	Unspecified:          "unspecified",
-	KeyCompromise:        "keyCompromise",
-	CACompromise:         "cACompromise",
-	AffiliationChanged:   "affiliationChanged",
-	Superseded:           "superseded",
-	CessationOfOperation: "cessationOfOperation",
-	CertificateHold:      "certificateHold",
+	ocsp.Unspecified:          "unspecified",
+	ocsp.KeyCompromise:        "keyCompromise",
+	ocsp.CACompromise:         "cACompromise",
+	ocsp.AffiliationChanged:   "affiliationChanged",
+	ocsp.Superseded:           "superseded",
+	ocsp.CessationOfOperation: "cessationOfOperation",
+	ocsp.CertificateHold:      "certificateHold",
 	// 7 is unused
-	RemoveFromCRL:      "removeFromCRL",
-	PrivilegeWithdrawn: "privilegeWithdrawn",
-	AACompromise:       "aAcompromise",
+	ocsp.RemoveFromCRL:      "removeFromCRL",
+	ocsp.PrivilegeWithdrawn: "privilegeWithdrawn",
+	ocsp.AACompromise:       "aAcompromise",
 }
 
 // UserAllowedReasons contains the subset of Reasons which users are
 // allowed to use
 var UserAllowedReasons = map[Reason]struct{}{
-	Unspecified:          {}, // unspecified
-	KeyCompromise:        {}, // keyCompromise
-	AffiliationChanged:   {}, // affiliationChanged
-	Superseded:           {}, // superseded
-	CessationOfOperation: {}, // cessationOfOperation
+	ocsp.Unspecified:          {}, // unspecified
+	ocsp.KeyCompromise:        {}, // keyCompromise
+	ocsp.AffiliationChanged:   {}, // affiliationChanged
+	ocsp.Superseded:           {}, // superseded
+	ocsp.CessationOfOperation: {}, // cessationOfOperation
 }
 
-// UserAllowedReasonsMessage creates a string describing a list of user allowed
+// UserAllowedReasonsMessage contains a string describing a list of user allowed
 // revocation reasons. This is useful when a revocation is rejected because it
 // is not a valid user supplied reason and the allowed values must be
-// communicated.
-func UserAllowedReasonsMessage() string {
+// communicated. This variable is populated during package initialization.
+var UserAllowedReasonsMessage = ""
+
+func init() {
 	// Build a slice of ints from the allowed reason codes.
 	// We want a slice because iterating `UserAllowedReasons` will change order
 	// and make the message unpredictable and cumbersome for unit testing.
@@ -71,5 +58,5 @@ func UserAllowedReasonsMessage() string {
 		reasonStrings = append(reasonStrings, fmt.Sprintf("%s (%d)",
 			ReasonToString[Reason(reason)], reason))
 	}
-	return strings.Join(reasonStrings, ", ")
+	UserAllowedReasonsMessage = strings.Join(reasonStrings, ", ")
 }

--- a/test/load-generator/boulder-calls.go
+++ b/test/load-generator/boulder-calls.go
@@ -23,8 +23,8 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
-	"github.com/letsencrypt/boulder/revocation"
 	"github.com/letsencrypt/boulder/test/load-generator/acme"
+	"golang.org/x/crypto/ocsp"
 	"gopkg.in/square/go-jose.v2"
 )
 
@@ -619,7 +619,7 @@ func revokeCertificate(s *State, ctx *context) error {
 		Reason      int
 	}{
 		Certificate: base64.URLEncoding.EncodeToString(pemBlock.Bytes),
-		Reason:      revocation.Unspecified,
+		Reason:      ocsp.Unspecified,
 	}
 
 	revokeJSON, err := json.Marshal(revokeObj)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -877,7 +877,15 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *web
 	reason := revocation.Reason(0)
 	if revokeRequest.Reason != nil {
 		if _, present := revocation.UserAllowedReasons[*revokeRequest.Reason]; !present {
-			wfe.sendError(response, logEvent, probs.Malformed("unsupported revocation reason code provided"), nil)
+			reasonStr, ok := revocation.ReasonToString[revocation.Reason(*revokeRequest.Reason)]
+			if !ok {
+				reasonStr = "unknown"
+			}
+			wfe.sendError(response, logEvent, probs.Malformed(
+				"unsupported revocation reason code provided: %s (%d). Supported reasons: %s",
+				reasonStr,
+				*revokeRequest.Reason,
+				revocation.UserAllowedReasonsMessage), nil)
 			return
 		}
 		reason = *revokeRequest.Reason

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1615,7 +1615,7 @@ func TestRevokeCertificateReasons(t *testing.T) {
 	wfe.RevokeCertificate(ctx, newRequestEvent(), responseWriter,
 		makePostRequest(result.FullSerialize()))
 	test.AssertEquals(t, responseWriter.Code, 400)
-	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.V1ErrorNS+`malformed","detail":"unsupported revocation reason code provided","status":400}`)
+	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.V1ErrorNS+`malformed","detail":"unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), affiliationChanged (3), superseded (4), cessationOfOperation (5)","status":400}`)
 
 	responseWriter = httptest.NewRecorder()
 	unsupported = revocation.Reason(100)
@@ -1626,7 +1626,7 @@ func TestRevokeCertificateReasons(t *testing.T) {
 	wfe.RevokeCertificate(ctx, newRequestEvent(), responseWriter,
 		makePostRequest(result.FullSerialize()))
 	test.AssertEquals(t, responseWriter.Code, 400)
-	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.V1ErrorNS+`malformed","detail":"unsupported revocation reason code provided","status":400}`)
+	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.V1ErrorNS+`malformed","detail":"unsupported revocation reason code provided: unknown (100). Supported reasons: unspecified (0), keyCompromise (1), affiliationChanged (3), superseded (4), cessationOfOperation (5)","status":400}`)
 }
 
 // Valid revocation request for existing, non-revoked cert, signed with account

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -827,7 +827,7 @@ func (wfe *WebFrontEndImpl) processRevocation(
 				"unsupported revocation reason code provided: %s (%d). Supported reasons: %s",
 				reasonStr,
 				*revokeRequest.Reason,
-				revocation.UserAllowedReasonsMessage())
+				revocation.UserAllowedReasonsMessage)
 		}
 		reason = *revokeRequest.Reason
 	}


### PR DESCRIPTION
When we originally added this package (4 years ago) x/crypto/ocsp didn't
have its own list of revocation reasons, so we added our own. Now it does
have its own list, so just use that list instead of duplicating code for
no real reason.

Also we build a list of the revocation reasons we support so that we can
tell users when they try to use an unsupported one. Instead of building
this string every time, just build it once it during package initialization.

Finally return the same error message in wfe that we use in wfe2 when a
user requests an unsupported reason.