### PR TITLE
Add caa-log-checker tool

### DIFF
--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -3,14 +3,12 @@ package main
 import (
 	"bufio"
 	"compress/gzip"
-	"crypto/sha256"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -73,34 +71,13 @@ func checkIssuances(scanner *bufio.Scanner, checkedMap map[string][]time.Time, s
 			}
 		}
 		if len(badNames) > 0 {
-			hash := hashNames(ie.Names)
-			fmt.Fprintf(stderr, "Issuance missing CAA checks: issued at=%s, serial=%s, requester=%d, names hash=%x, names=%s, missing checks for names=%s\n", ie.ResponseTime, ie.SerialNumber, ie.Requester, hash, ie.Names, badNames)
+			fmt.Fprintf(stderr, "Issuance missing CAA checks: issued at=%s, serial=%s, requester=%d, names=%s, missing checks for names=%s\n", ie.ResponseTime, ie.SerialNumber, ie.Requester, ie.Names, badNames)
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return err
 	}
 	return nil
-}
-
-func hashNames(names []string) []byte {
-	names = uniqueLowerNames(names)
-	hash := sha256.Sum256([]byte(strings.Join(names, ",")))
-	return hash[:]
-}
-
-func uniqueLowerNames(names []string) (unique []string) {
-	nameMap := make(map[string]int, len(names))
-	for _, name := range names {
-		nameMap[strings.ToLower(name)] = 1
-	}
-
-	unique = make([]string, 0, len(nameMap))
-	for name := range nameMap {
-		unique = append(unique, name)
-	}
-	sort.Strings(unique)
-	return
 }
 
 var vaCAALineRE = regexp.MustCompile(`Checked CAA records for ([a-z0-9-.*]+), \[Present: (true|false)`)

--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/letsencrypt/boulder/cmd"
+)
+
+func openFile(path string) (*bufio.Scanner, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	var reader io.Reader
+	reader = f
+	if strings.HasSuffix(path, ".gz") {
+		reader, err = gzip.NewReader(f)
+		if err != nil {
+			return nil, err
+		}
+	}
+	scanner := bufio.NewScanner(reader)
+	return scanner, nil
+}
+
+type issuanceEvent struct {
+	SerialNumber string
+	Names        []string
+	ResponseTime time.Time
+	Requester    int64
+}
+
+var raIssuanceLineRE = regexp.MustCompile(`Certificate request - successful JSON=(.*)`)
+
+func checkIssuances(scanner *bufio.Scanner, checkedMap map[string][]time.Time, stderr *os.File) error {
+	lNum := 0
+	for scanner.Scan() {
+		lNum++
+		line := scanner.Text()
+		matches := raIssuanceLineRE.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+		if len(matches) != 2 {
+			return fmt.Errorf("line %d: unexpected number of regex matches", lNum)
+		}
+		var ie issuanceEvent
+		err := json.Unmarshal([]byte(matches[1]), &ie)
+		if err != nil {
+			return fmt.Errorf("line %d: failed to unmarshal JSON: %s", lNum, err)
+		}
+		var badNames []string
+		for _, name := range ie.Names {
+			nameOk := false
+			for _, t := range checkedMap[name] {
+				if t.Before(ie.ResponseTime) && t.After(ie.ResponseTime.Add(-8*time.Hour)) {
+					nameOk = true
+				}
+			}
+			if !nameOk {
+				badNames = append(badNames, name)
+			}
+		}
+		if len(badNames) > 0 {
+			hash := hashNames(ie.Names)
+			fmt.Fprintf(stderr, "Issuance missing CAA checks: issued at=%s, serial=%s, requester=%d, names hash=%x, names=%s, missing checks for names=%s\n", ie.ResponseTime, ie.SerialNumber, ie.Requester, hash, ie.Names, badNames)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func hashNames(names []string) []byte {
+	names = uniqueLowerNames(names)
+	hash := sha256.Sum256([]byte(strings.Join(names, ",")))
+	return hash[:]
+}
+
+func uniqueLowerNames(names []string) (unique []string) {
+	nameMap := make(map[string]int, len(names))
+	for _, name := range names {
+		nameMap[strings.ToLower(name)] = 1
+	}
+
+	unique = make([]string, 0, len(nameMap))
+	for name := range nameMap {
+		unique = append(unique, name)
+	}
+	sort.Strings(unique)
+	return
+}
+
+var vaCAALineRE = regexp.MustCompile(`Checked CAA records for ([a-z0-9-.*]+), \[Present: (true|false)`)
+
+func processVALog(checkedMap map[string][]time.Time, scanner *bufio.Scanner) error {
+	lNum := 0
+	for scanner.Scan() {
+		lNum++
+		line := scanner.Text()
+		matches := vaCAALineRE.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+		if len(matches) != 3 {
+			return fmt.Errorf("line %d: unexpected number of regex matches", lNum)
+		}
+		domain := matches[1]
+		labels := strings.Split(domain, ".")
+		present := matches[2]
+
+		datestampText := line[0:32]
+		datestamp, err := time.Parse(time.RFC3339, datestampText)
+		if err != nil {
+			return fmt.Errorf("line %d: failed processing timestamp: %s", lNum, err)
+		}
+
+		checkedMap[domain] = append(checkedMap[domain], datestamp)
+		// If we checked x.y.z, and the result was Present: false, that means we
+		// also checked y.z and z, and found no records there.
+		// We'll add y.z to the map, but not z (to save memory space, since we don't issue
+		// for z).
+		if present == "false" {
+			for i := 1; i < len(labels)-1; i++ {
+				parent := strings.Join(labels[i:], ".")
+				checkedMap[parent] = append(checkedMap[parent], datestamp)
+			}
+		}
+	}
+	return scanner.Err()
+}
+
+func loadMap(paths []string) (map[string][]time.Time, error) {
+	var checkedMap = make(map[string][]time.Time)
+
+	for _, path := range paths {
+		scanner, err := openFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open %q: %s", path, err)
+		}
+		if err = processVALog(checkedMap, scanner); err != nil {
+			return nil, fmt.Errorf("failed to process %q: %s", path, err)
+		}
+	}
+
+	return checkedMap, nil
+}
+
+func main() {
+	raLog := flag.String("ra-log", "", "Path to a single boulder-ra log file")
+	vaLogs := flag.String("va-logs", "", "List of paths to boulder-va logs, separated by commas")
+	flag.Parse()
+
+	// Build a map from hostnames to a list of times those hostnames were checked
+	// for CAA.
+	checkedMap, err := loadMap(strings.Split(*vaLogs, ","))
+	cmd.FailOnError(err, "failed while loading VA logs")
+
+	raScanner, err := openFile(*raLog)
+	cmd.FailOnError(err, fmt.Sprintf("failed to open %q", *raLog))
+
+	err = checkIssuances(raScanner, checkedMap, os.Stderr)
+	cmd.FailOnError(err, "failed while processing RA log")
+}

--- a/cmd/caa-log-checker/main_test.go
+++ b/cmd/caa-log-checker/main_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestOpenFile(t *testing.T) {
+	tmpPlain, err := ioutil.TempFile(os.TempDir(), "plain")
+	test.AssertNotError(t, err, "failed to create temporary file")
+	defer os.Remove(tmpPlain.Name())
+	tmpPlain.Write([]byte("test-1\ntest-2"))
+	tmpPlain.Close()
+
+	tmpGzip, err := ioutil.TempFile(os.TempDir(), "gzip-*.gz")
+	test.AssertNotError(t, err, "failed to create temporary file")
+	defer os.Remove(tmpGzip.Name())
+	gzipWriter := gzip.NewWriter(tmpGzip)
+	gzipWriter.Write([]byte("test-1\ntest-2"))
+	gzipWriter.Flush()
+	gzipWriter.Close()
+	tmpGzip.Close()
+
+	checkFile := func(path string) {
+		t.Helper()
+		scanner, err := openFile(path)
+		test.AssertNotError(t, err, fmt.Sprintf("failed to open %q", path))
+		var lines []string
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+		test.AssertNotError(t, scanner.Err(), fmt.Sprintf("failed to read from %q", path))
+	}
+
+	checkFile(tmpPlain.Name())
+	checkFile(tmpGzip.Name())
+}
+
+func TestLoadMap(t *testing.T) {
+	testTime := time.Time{}.Add(time.Hour).Add(time.Nanosecond * 123456000)
+	testTime = testTime.In(time.FixedZone("UTC-8", -8*60*60))
+
+	tmpA, err := ioutil.TempFile(os.TempDir(), "va-a")
+	test.AssertNotError(t, err, "failed to create temporary file")
+	defer os.Remove(tmpA.Name())
+	formattedTime := testTime.Format(time.RFC3339Nano)
+	tmpA.Write([]byte(fmt.Sprintf(`random
+%s Checked CAA records for example.com, [Present: true, asd
+random
+%s Checked CAA records for beep.boop.com, [Present: false, asd`, formattedTime, formattedTime)))
+	tmpA.Close()
+	tmpB, err := ioutil.TempFile(os.TempDir(), "va-b")
+	test.AssertNotError(t, err, "failed to create temporary file")
+	defer os.Remove(tmpB.Name())
+	formattedTime = testTime.Add(time.Hour).Format(time.RFC3339Nano)
+	tmpB.Write([]byte(fmt.Sprintf(`random
+%s Checked CAA records for example.com, [Present: true, asd
+random
+%s Checked CAA records for beep.boop.com, [Present: false, asd`, formattedTime, formattedTime)))
+	tmpB.Close()
+
+	m, err := loadMap([]string{tmpA.Name(), tmpB.Name()})
+	test.AssertNotError(t, err, "fail to load log files")
+	test.AssertEquals(t, len(m), 3)
+	test.Assert(t, m["example.com"][0].Equal(testTime), "wrong time")
+	test.Assert(t, m["example.com"][1].Equal(testTime.Add(time.Hour)), "wrong time")
+	test.Assert(t, m["beep.boop.com"][0].Equal(testTime), "wrong time")
+	test.Assert(t, m["beep.boop.com"][1].Equal(testTime.Add(time.Hour)), "wrong time")
+	test.Assert(t, m["boop.com"][0].Equal(testTime), "wrong time")
+	test.Assert(t, m["boop.com"][1].Equal(testTime.Add(time.Hour)), "wrong time")
+}
+
+func TestCheckIssuances(t *testing.T) {
+	checkedMap := map[string][]time.Time{
+		"example.com": []time.Time{
+			time.Time{}.Add(time.Hour),
+			time.Time{}.Add(3 * time.Hour),
+		},
+		"2.example.com": []time.Time{
+			time.Time{}.Add(time.Hour),
+		},
+		"4.example.com": []time.Time{
+			time.Time{}.Add(time.Hour),
+		},
+	}
+
+	raBuf := bytes.NewBuffer([]byte(fmt.Sprintf(`random
+Certificate request - successful JSON={"SerialNumber": "1", "Names":["example.com"], "ResponseTime":"%s", "Requester":0}
+random
+Certificate request - successful JSON={"SerialNumber": "2", "Names":["2.example.com", "3.example.com"], "ResponseTime":"%s", "Requester":0}
+Certificate request - successful JSON={"SerialNumber": "3", "Names":["4.example.com"], "ResponseTime":"%s", "Requester":0}
+random`,
+		time.Time{}.Add(time.Hour*2).Format(time.RFC3339Nano),
+		time.Time{}.Add(time.Hour*2).Format(time.RFC3339Nano),
+		time.Time{}.Format(time.RFC3339Nano),
+	)))
+	raScanner := bufio.NewScanner(raBuf)
+
+	stderr, err := ioutil.TempFile(os.TempDir(), "stderr")
+	test.AssertNotError(t, err, "failed creating temporary file")
+	defer os.Remove(stderr.Name())
+
+	err = checkIssuances(raScanner, checkedMap, stderr)
+	test.AssertNotError(t, err, "checkIssuances failed")
+
+	stderrCont, err := ioutil.ReadFile(stderr.Name())
+	test.AssertNotError(t, err, "failed to read temporary file")
+	test.AssertEquals(t, string(stderrCont), `Issuance missing CAA checks: issued at=0001-01-01 02:00:00 +0000 UTC, serial=2, requester=0, names hash=87424e6a210a7f067af05576e64957de28ea88be7edfeccc90865ceb27e938b1, names=[2.example.com 3.example.com], missing checks for names=[3.example.com]
+Issuance missing CAA checks: issued at=0001-01-01 00:00:00 +0000 UTC, serial=3, requester=0, names hash=2811971efc0a8db4f95c268ca75a949d4d1c6fefd70e09be5da42e4eeee1f3b5, names=[4.example.com], missing checks for names=[4.example.com]
+`)
+}

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -1,0 +1,53 @@
+// +build integration
+
+package integration
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestCAALogChecker(t *testing.T) {
+	t.Parallel()
+
+	os.Setenv("DIRECTORY", "http://boulder:4001/directory")
+	c, err := makeClient()
+	test.AssertNotError(t, err, "makeClient failed")
+
+	domains := []string{random_domain()}
+	result, err := authAndIssue(c, nil, domains)
+	test.AssertNotError(t, err, "authAndIssue failed")
+	test.AssertEquals(t, result.Order.Status, "valid")
+	test.AssertEquals(t, len(result.Order.Authorizations), 1)
+
+	// Should be no specific output, since everything is good
+	cmd := exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", "/var/log/boulder-va.log")
+	var stdErr bytes.Buffer
+	cmd.Stderr = &stdErr
+	out, err := cmd.Output()
+	test.AssertNotError(t, err, "caa-log-checker failed")
+	test.AssertEquals(t, string(out), "")
+	test.AssertEquals(t, stdErr.String(), "")
+
+	// Should be output, issuances in boulder-ra.log won't match an empty
+	// va log. Because we can't control what happens before this test
+	// we don't know how many issuances there have been. We just
+	// test for caa-log-checker outputting _something_ since any
+	// output, with a 0 exit code, indicates it's found bad issuances.
+	tmp, err := ioutil.TempFile(os.TempDir(), "boulder-va-empty")
+	test.AssertNotError(t, err, "failed to create temporary file")
+	defer os.Remove(tmp.Name())
+	cmd = exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", tmp.Name())
+	stdErr.Reset()
+	cmd.Stderr = &stdErr
+	out, err = cmd.Output()
+	test.AssertNotError(t, err, "caa-log-checker failed")
+
+	test.AssertEquals(t, string(out), "")
+	test.AssertNotEquals(t, stdErr.String(), "")
+}


### PR DESCRIPTION
Adds a productionized version of our internal tooling to the tree. The major differences are: it doesn't skip certs with only one name, it doesn't read in all the va logs in parallel, it only supports reading one ra log at a time, and it adds unit tests.

Probably it should include a integration test, but that requires capturing logs on the docker container, which I don't think we currently do? Probably would make for a good follow-up issue.

Fixes #4698.