### PR TITLE
goodkey: early rejection of unsupported key types

### DIFF
--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -96,7 +96,7 @@ func (policy *KeyPolicy) GoodKey(ctx context.Context, key crypto.PublicKey) erro
 	case *rsa.PublicKey, *ecdsa.PublicKey:
 		break
 	default:
-		return berrors.MalformedError("unknown key type %T", t)
+		return berrors.MalformedError("unsupported key type %T", t)
 	}
 	// If there is a blocked list configured then check if the public key is one
 	// that has been administratively blocked.
@@ -126,7 +126,7 @@ func (policy *KeyPolicy) GoodKey(ctx context.Context, key crypto.PublicKey) erro
 	case *ecdsa.PublicKey:
 		return policy.goodKeyECDSA(t)
 	default:
-		return berrors.MalformedError("unknown key type %T", key)
+		return berrors.MalformedError("unsupported key type %T", key)
 	}
 }
 

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -26,6 +26,13 @@ func TestUnknownKeyType(t *testing.T) {
 	err := testingPolicy.GoodKey(context.Background(), notAKey)
 	test.AssertError(t, err, "Should have rejected a key of unknown type")
 	test.AssertEquals(t, err.Error(), "unknown key type struct {}")
+
+	// Check for early rejection and that no error is seen from blockedKeys.blocked.
+	testingPolicyWithBlockedKeys := *testingPolicy
+	testingPolicyWithBlockedKeys.blockedList = &blockedKeys{}
+	err = testingPolicyWithBlockedKeys.GoodKey(context.Background(), notAKey)
+	test.AssertError(t, err, "Should have rejected a key of unknown type")
+	test.AssertEquals(t, err.Error(), "unknown key type struct {}")
 }
 
 func TestNilKey(t *testing.T) {

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -25,20 +25,20 @@ func TestUnknownKeyType(t *testing.T) {
 	notAKey := struct{}{}
 	err := testingPolicy.GoodKey(context.Background(), notAKey)
 	test.AssertError(t, err, "Should have rejected a key of unknown type")
-	test.AssertEquals(t, err.Error(), "unknown key type struct {}")
+	test.AssertEquals(t, err.Error(), "unsupported key type struct {}")
 
 	// Check for early rejection and that no error is seen from blockedKeys.blocked.
 	testingPolicyWithBlockedKeys := *testingPolicy
 	testingPolicyWithBlockedKeys.blockedList = &blockedKeys{}
 	err = testingPolicyWithBlockedKeys.GoodKey(context.Background(), notAKey)
 	test.AssertError(t, err, "Should have rejected a key of unknown type")
-	test.AssertEquals(t, err.Error(), "unknown key type struct {}")
+	test.AssertEquals(t, err.Error(), "unsupported key type struct {}")
 }
 
 func TestNilKey(t *testing.T) {
 	err := testingPolicy.GoodKey(context.Background(), nil)
 	test.AssertError(t, err, "Should have rejected a nil key")
-	test.AssertEquals(t, err.Error(), "unknown key type <nil>")
+	test.AssertEquals(t, err.Error(), "unsupported key type <nil>")
 }
 
 func TestSmallModulus(t *testing.T) {


### PR DESCRIPTION
This prevents a confusing error being emitted by blockedKeys.blocked.

Fixes #4728