### PR TITLE
cmd/ceremony: support qualified CPS policies

### DIFF
--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -117,6 +117,13 @@ certificate-profile:
     policy-oids:
         - 1.2.3
         - 5.4.3.2.1
+    cps-policies:
+        - oid: 4.5.6
+          values: http://example.com/cps
+        - oid: 7.8.9
+          values:
+            - http://example.com/another-cps
+            - http://example.com/a-third-cps
     key-usages:
         - Digital Signature
         - Cert Sign
@@ -178,5 +185,6 @@ The certificate profile defines a restricted set of fields that are used to gene
 | `ocsp-url` | Specifies the AIA OCSP responder URL |
 | `crl-url` | Specifies the cRLDistributionPoints URL |
 | `issuer-url` | Specifies the AIA caIssuer URL |
-| `policy-oids` | Specifies the contents of the certificatePolicies extension |
+| `policy-oids` | Specifies bare OIDs to add to the certificatePolicies extension |
+| `cps-policies` | Specifies id-qt-cps policies to add to the certificatePolicies extension. Should contain a list of qualified policies with the fields `oid`, containing the policy OID, and `values`, containing a list of string qualifiers. |
 | `key-usages` | Specifies list of key usage bits should be set, list can contain `Digital Signature`, `CRL Sign`, and `Cert Sign` |

--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -114,16 +114,10 @@ certificate-profile:
     ocsp-url: http://good-guys.com/ocsp
     crl-url:  http://good-guys.com/crl
     issuer-url:  http://good-guys.com/root
-    policy-oids:
-        - 1.2.3
-        - 5.4.3.2.1
-    cps-policies:
+    policies:
+        - oid: 1.2.3
         - oid: 4.5.6
-          values: http://example.com/cps
-        - oid: 7.8.9
-          values:
-            - http://example.com/another-cps
-            - http://example.com/a-third-cps
+          cps-uri: "http://example.com/cps"
     key-usages:
         - Digital Signature
         - Cert Sign
@@ -185,6 +179,5 @@ The certificate profile defines a restricted set of fields that are used to gene
 | `ocsp-url` | Specifies the AIA OCSP responder URL |
 | `crl-url` | Specifies the cRLDistributionPoints URL |
 | `issuer-url` | Specifies the AIA caIssuer URL |
-| `policy-oids` | Specifies bare OIDs to add to the certificatePolicies extension |
-| `cps-policies` | Specifies id-qt-cps policies to add to the certificatePolicies extension. Should contain a list of qualified policies with the fields `oid`, containing the policy OID, and `values`, containing a list of string qualifiers. |
+| `policies` | Specifies contents of a certificatePolicies extension. Should contain a list of policies with the fields `oid`, indicating the policy OID, and a `cps-uri` field, containing the CPS URI to use, if the policy should contain a id-qt-cps qualifier. Only single CPS values are supported. |
 | `key-usages` | Specifies list of key usage bits should be set, list can contain `Digital Signature`, `CRL Sign`, and `Cert Sign` |

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -19,6 +19,11 @@ import (
 	"github.com/miekg/pkcs11"
 )
 
+type cpsPolicy struct {
+	OID    string
+	Values []string
+}
+
 // certProfile contains the information required to generate a certificate
 type certProfile struct {
 	// SignatureAlgorithm should contain one of the allowed signature algorithms
@@ -54,8 +59,15 @@ type certProfile struct {
 
 	// PolicyOIDs should contain any OIDs to be inserted in a certificate
 	// policies extension. These should be formatted in the standard OID
-	// string format (i.e. "1.2.3")
+	// string format (i.e. "1.2.3"). This should only be used for policies
+	// which don't need any policyQualifiers.
 	PolicyOIDs []string `yaml:"policy-oids"`
+
+	// CPSPolicies should contain any PolicyInformation extensions with
+	// id-qt-cps type policyQualifiers to be inserted into the certificate.
+	// The OIDs should be formatted in the standard OID string format
+	// (i.e. "1.2.3")
+	CPSPolicies []cpsPolicy `yaml:"cps-policies`
 
 	// KeyUsages should contain the set of key usage bits to set
 	KeyUsages []string `yaml:"key-usages"`
@@ -120,6 +132,21 @@ var stringToKeyUsage = map[string]x509.KeyUsage{
 	"Cert Sign":         x509.KeyUsageCertSign,
 }
 
+type policyQualifier struct {
+	Id    asn1.ObjectIdentifier
+	Value string `asn1:"tag:optional,ia5"`
+}
+
+type policyInformation struct {
+	Policy     asn1.ObjectIdentifier
+	Qualifiers []policyQualifier `asn1:"tag:optional,omitempty"`
+}
+
+var (
+	oidExtensionCertificatePolicies = asn1.ObjectIdentifier{2, 5, 29, 32}
+	oidCPSQualifier                 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
+)
+
 // makeTemplate generates the certificate template for use in x509.CreateCertificate
 func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte) (*x509.Certificate, error) {
 	dateLayout := "2006-01-02 15:04:05"
@@ -143,15 +170,6 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte) (*x
 	var issuingCertificateURL []string
 	if profile.IssuerURL != "" {
 		issuingCertificateURL = []string{profile.IssuerURL}
-	}
-
-	var policyOIDs []asn1.ObjectIdentifier
-	for _, oidStr := range profile.PolicyOIDs {
-		oid, err := parseOID(oidStr)
-		if err != nil {
-			return nil, err
-		}
-		policyOIDs = append(policyOIDs, oid)
 	}
 
 	sigAlg, ok := AllowedSigAlgs[profile.SignatureAlgorithm]
@@ -194,9 +212,39 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte) (*x
 		OCSPServer:            ocspServer,
 		CRLDistributionPoints: crlDistributionPoints,
 		IssuingCertificateURL: issuingCertificateURL,
-		PolicyIdentifiers:     policyOIDs,
 		KeyUsage:              ku,
 		SubjectKeyId:          subjectKeyID[:],
+	}
+
+	if len(profile.PolicyOIDs) > 0 || len(profile.CPSPolicies) > 0 {
+		policyExt := pkix.Extension{Id: oidExtensionCertificatePolicies}
+		var policies []policyInformation
+		for _, oidStr := range profile.PolicyOIDs {
+			oid, err := parseOID(oidStr)
+			if err != nil {
+				return nil, err
+			}
+			policies = append(policies, policyInformation{Policy: oid})
+		}
+		for _, p := range profile.CPSPolicies {
+			oid, err := parseOID(p.OID)
+			if err != nil {
+				return nil, err
+			}
+			if len(p.Values) == 0 {
+				return nil, errors.New("cps-policies.values cannot be empty")
+			}
+			qualifiers := make([]policyQualifier, len(p.Values))
+			for i, q := range p.Values {
+				qualifiers[i] = policyQualifier{Id: oidCPSQualifier, Value: q}
+			}
+			policies = append(policies, policyInformation{Policy: oid, Qualifiers: qualifiers})
+		}
+		policyExt.Value, err = asn1.Marshal(policies)
+		if err != nil {
+			return nil, err
+		}
+		cert.ExtraExtensions = append(cert.ExtraExtensions, policyExt)
 	}
 
 	return cert, nil

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -67,7 +67,7 @@ type certProfile struct {
 	// id-qt-cps type policyQualifiers to be inserted into the certificate.
 	// The OIDs should be formatted in the standard OID string format
 	// (i.e. "1.2.3")
-	CPSPolicies []cpsPolicy `yaml:"cps-policies`
+	CPSPolicies []cpsPolicy `yaml:"cps-policies"`
 
 	// KeyUsages should contain the set of key usage bits to set
 	KeyUsages []string `yaml:"key-usages"`

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -151,7 +151,7 @@ func buildPolicies(policies []policyInfoConfig) (pkix.Extension, error) {
 		}
 		pi := policyInformation{Policy: oid}
 		if p.CPSURI != "" {
-			pi.Qualifiers = []policyQualifier{policyQualifier{Id: oidCPSQualifier, Value: p.CPSURI}}
+			pi.Qualifiers = []policyQualifier{{Id: oidCPSQualifier, Value: p.CPSURI}}
 		}
 		policyInfo = append(policyInfo, pi)
 	}

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -58,9 +58,9 @@ type certProfile struct {
 	IssuerURL string `yaml:"issuer-url"`
 
 	// PolicyOIDs should contain any OIDs to be inserted in a certificate
-	// policies extension. These should be formatted in the standard OID
-	// string format (i.e. "1.2.3"). This should only be used for policies
-	// which don't need any policyQualifiers.
+	// policies extension. If the CPSURI field of a policyInfoConfig element
+	// is set it will result in a policyInformation structure containing a
+	// single id-qt-cps type qualifier indicating the CPS URI.
 	Policies []policyInfoConfig `yaml:"policies"`
 
 	// KeyUsages should contain the set of key usage bits to set

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -116,20 +116,11 @@ func TestMakeTemplate(t *testing.T) {
 	test.AssertError(t, err, "makeTemplate didn't fail with invalid key usages")
 
 	profile.KeyUsages = []string{"Digital Signature", "CRL Sign"}
-	profile.PolicyOIDs = []string{""}
+	profile.Policies = []policyInfoConfig{{}}
 	_, err = makeTemplate(randReader, profile, nil)
 	test.AssertError(t, err, "makeTemplate didn't fail with invalid policy OID")
 
-	profile.PolicyOIDs = []string{"1.2.3"}
-	profile.CPSPolicies = []cpsPolicy{{OID: ""}}
-	_, err = makeTemplate(randReader, profile, nil)
-	test.AssertError(t, err, "makeTemplate didn't fail with invalid CPS policy OID")
-
-	profile.CPSPolicies = []cpsPolicy{{OID: "1.2.3"}}
-	_, err = makeTemplate(randReader, profile, nil)
-	test.AssertError(t, err, "makeTemplate didn't fail with invalid CPS policy values")
-
-	profile.CPSPolicies = []cpsPolicy{{OID: "1.2.3", Values: []string{"hello"}}}
+	profile.Policies = []policyInfoConfig{{OID: "1.2.3"}, {OID: "1.2.3.4", CPSURI: "hello"}}
 	profile.CommonName = "common name"
 	profile.Organization = "organization"
 	profile.Country = "country"


### PR DESCRIPTION
Adds support for qualified CPS policies to root/intermediate generation.
This changes the existing policy-oids fields to a policies field which covers both bare policies and id-qt-cps qualified policies.

Fixes #4724

Example cert created with a CPS policy: 
```
$ openssl x509 -in test.pem -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            9d:bf:ee:a2:89:c7:76:8b:98:63:1c:fa:95:77:9f:7c
    Signature Algorithm: ecdsa-with-SHA256
        Issuer: C=country, O=organization, CN=common name
        Validity
            Not Before: May 18 11:31:00 2018 GMT
            Not After : May 18 11:31:00 2018 GMT
        Subject: C=country, O=organization, CN=common name
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub: 
                    04:6b:b0:ed:74:22:15:30:7b:52:a3:b5:ee:a3:9e:
                    5a:fc:c2:b7:16:25:80:06:73:b6:67:d1:ab:71:0b:
                    52:07:c6:a0:5c:be:86:a2:1b:fd:41:fb:ec:62:b8:
                    7b:e6:e7:e9:5e:58:7f:c0:2d:dd:32:f8:13:e2:e5:
                    6c:49:8a:8b:cb
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, CRL Sign
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Key Identifier: 
                E3:B0:C4:42:98:FC:1C:14:9A:FB:F4:C8:99:6F:B9:24:27:AE:41:E4:64:9B:93:4C:A4:95:99:1B:78:52:B8:55
            Authority Information Access: 
                OCSP - URI:ocsp
                CA Issuers - URI:issuer

            X509v3 CRL Distribution Points: 

                Full Name:
                  URI:crl

            X509v3 Certificate Policies: 
                Policy: 1.2.3
                Policy: 1.2.3
                  CPS: hello

    Signature Algorithm: ecdsa-with-SHA256
         30:46:02:21:00:89:08:fc:4c:d6:b3:6f:ef:04:3b:5d:c3:ea:
         4a:ea:79:ed:95:be:c2:02:3e:e0:35:3a:bd:ef:5f:9d:52:40:
         84:02:21:00:df:5f:42:2b:39:c5:a5:46:19:6e:51:d6:85:bf:
         18:a3:fd:1b:1e:15:5a:f4:18:12:41:86:7b:11:9c:2b:5e:b5
```