### PR TITLE
Add OCSP signer generation to ceremony tool

### DIFF
--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -127,7 +127,7 @@ certificate-profile:
 
 This config generates an intermediate certificate signed by a key in the HSM, identified by the object label `root signing key` and the object ID `ffff`. The subject key used is taken from `/home/user/intermediate-signing-pub.pem` and the issuer is `/home/user/root-cert.pem`, the resulting certificate is written to `/home/user/intermediate-cert.pem`.
 
-### OCSP Signer ceremony
+### OCSP Signing Certificate ceremony
 
 - `ceremony-type`: string describing the ceremony type, `ocsp-signer`.
 - `pkcs11`: object containing PKCS#11 related fields.
@@ -149,7 +149,7 @@ This config generates an intermediate certificate signed by a key in the HSM, id
     | `certificate-path` | Path to store signed PEM certificate. |
 - `certificate-profile`: object containing profile for certificate to generate. Fields are documented [below](#Certificate-profile-format). The key-usages, ocsp-url, and crl-url fields must not be set.
 
-When generating an OCSP signing certificate the key usages field will be set to just Digital Signature and an EKU extension will be included with the id-kp-OCSPSigning usage. Additionally a id-pkix-ocsp-nocheck extension will be included in the certificate.
+When generating an OCSP signing certificate the key usages field will be set to just Digital Signature and an EKU extension will be included with the id-kp-OCSPSigning usage. Additionally an id-pkix-ocsp-nocheck extension will be included in the certificate.
 
 Example:
 

--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -9,6 +9,7 @@ ceremony --config path/to/config.yml
 `ceremony` operates in one of three modes
 * `root` - generates a signing key on HSM and creates a self-signed root certificate that uses the generated key, outputting a PEM public key, and a PEM certificate
 * `intermediate` - creates a intermediate certificate and signs it using a signing key already on a HSM, outputting a PEM certificate
+* `ocsp-signer` - creates a delegated OCSP signing certificate and signs it using a signing key already on a HSM, outputting a PEM certificate
 * `key` - generates a signing key on HSM, outputting a PEM public key
 
 These modes are set in the `ceremony-type` field of the configuration file.
@@ -124,6 +125,56 @@ certificate-profile:
 ```
 
 This config generates an intermediate certificate signed by a key in the HSM, identified by the object label `root signing key` and the object ID `ffff`. The subject key used is taken from `/home/user/intermediate-signing-pub.pem` and the issuer is `/home/user/root-cert.pem`, the resulting certificate is written to `/home/user/intermediate-cert.pem`.
+
+### OCSP Signer ceremony
+
+- `ceremony-type`: string describing the ceremony type, `ocsp-signer`.
+- `pkcs11`: object containing PKCS#11 related fields.
+    | Field | Description |
+    | --- | --- |
+    | `module` | Path to the PKCS#11 module to use to communicate with a HSM. |
+    | `pin` | Specifies the login PIN, should only be provided if the HSM device requires one to interact with the slot. |
+    | `signing-key-slot` | Specifies which HSM object slot the signing key is in. |
+    | `signing-key-label` | Specifies the HSM object label for the signing key. |
+    | `signing-key-id` | Specifies the HSM object ID for the signing key. |
+- `inputs`: object containing paths for inputs
+    | Field | Description |
+    | --- | --- |
+    | `public-key-path` | Path to PEM subject public key for certificate. |
+    | `issuer-path` | Path to PEM issuer certificate. |
+- `outputs`: object containing paths to write outputs.
+    | Field | Description |
+    | --- | --- |
+    | `certificate-path` | Path to store signed PEM certificate. |
+- `certificate-profile`: object containing profile for certificate to generate. Fields are documented [below](#Certificate-profile-format). The key-usages, ocsp-url, and crl-url fields must not be set.
+
+When generating an OCSP signing certificate the key usages field will be set to just Digital Signature and an EKU extension will be included with the id-kp-OCSPSigning usage. Additionally a id-pkix-ocsp-nocheck extension will be included in the certificate.
+
+Example:
+
+```yaml
+ceremony-type: ocsp-signer
+pkcs11:
+    module: /usr/lib/opensc-pkcs11.so
+    signing-key-slot: 0
+    signing-key-label: intermediate signing key
+    signing-key-id: ffff
+inputs:
+    public-key-path: /home/user/ocsp-signer-signing-pub.pem
+    issuer-path: /home/user/intermediate-cert.pem
+outputs:
+    certificate-path: /home/user/ocsp-signer-cert.pem
+certificate-profile:
+    signature-algorithm: ECDSAWithSHA384
+    common-name: CA OCSP signer
+    organization: good guys
+    country: US
+    not-before: 2020-01-01 12:00:00
+    not-after: 2040-01-01 12:00:00
+    issuer-url:  http://good-guys.com/root
+```
+
+This config generates a delegated OCSP signing certificate signed by a key in the HSM, identified by the object label `intermediate signing key` and the object ID `ffff`. The subject key used is taken from `/home/user/ocsp-signer-signing-pub.pem` and the issuer is `/home/user/intermdiate-cert.pem`, the resulting certificate is written to `/home/user/ocsp-signer-cert.pem`.
 
 ### Key ceremony
 

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -77,7 +77,15 @@ var AllowedSigAlgs = map[string]x509.SignatureAlgorithm{
 	"ECDSAWithSHA512": x509.ECDSAWithSHA512,
 }
 
-func (profile *certProfile) verifyProfile(root bool, ocspSigner bool) error {
+type certType int
+
+const (
+	rootCert certType = iota
+	intermediateCert
+	ocspCert
+)
+
+func (profile *certProfile) verifyProfile(ct certType) error {
 	if profile.NotBefore == "" {
 		return errors.New("not-before is required")
 	}
@@ -97,24 +105,28 @@ func (profile *certProfile) verifyProfile(root bool, ocspSigner bool) error {
 		return errors.New("country is required")
 	}
 
-	if (!root && !ocspSigner) && profile.OCSPURL == "" {
-		return errors.New("ocsp-url is required for intermediates")
-	}
-	if (!root && !ocspSigner) && profile.CRLURL == "" {
-		return errors.New("crl-url is required for intermediates")
-	}
-	if (!root && !ocspSigner) && profile.IssuerURL == "" {
-		return errors.New("issuer-url is required for intermediates")
+	if ct == intermediateCert {
+		if profile.OCSPURL == "" {
+			return errors.New("ocsp-url is required for intermediates")
+		}
+		if profile.CRLURL == "" {
+			return errors.New("crl-url is required for intermediates")
+		}
+		if profile.IssuerURL == "" {
+			return errors.New("issuer-url is required for intermediates")
+		}
 	}
 
-	if ocspSigner && len(profile.KeyUsages) != 0 {
-		return errors.New("key-usages cannot be set for a OCSP signer")
-	}
-	if ocspSigner && profile.CRLURL != "" {
-		return errors.New("crl-url cannot be set for a OCSP signer")
-	}
-	if ocspSigner && profile.OCSPURL != "" {
-		return errors.New("ocsp-url cannot be set for a OCSP signer")
+	if ct == ocspCert {
+		if len(profile.KeyUsages) != 0 {
+			return errors.New("key-usages cannot be set for a OCSP signer")
+		}
+		if profile.CRLURL != "" {
+			return errors.New("crl-url cannot be set for a OCSP signer")
+		}
+		if profile.OCSPURL != "" {
+			return errors.New("ocsp-url cannot be set for a OCSP signer")
+		}
 	}
 	return nil
 }
@@ -177,7 +189,7 @@ func buildPolicies(policies []policyInfoConfig) (pkix.Extension, error) {
 }
 
 // makeTemplate generates the certificate template for use in x509.CreateCertificate
-func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ocspSigner bool) (*x509.Certificate, error) {
+func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct certType) (*x509.Certificate, error) {
 	dateLayout := "2006-01-02 15:04:05"
 	notBefore, err := time.Parse(dateLayout, profile.NotBefore)
 	if err != nil {
@@ -215,9 +227,6 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ocs
 	}
 
 	var ku x509.KeyUsage
-	if len(profile.KeyUsages) == 0 && !ocspSigner {
-		return nil, errors.New("key usages must be set")
-	}
 	for _, kuStr := range profile.KeyUsages {
 		kuBit, ok := stringToKeyUsage[kuStr]
 		if !ok {
@@ -225,8 +234,11 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ocs
 		}
 		ku |= kuBit
 	}
-	if ocspSigner {
+	if ct == ocspCert {
 		ku = x509.KeyUsageDigitalSignature
+	}
+	if ku == 0 {
+		return nil, errors.New("at least one key usage must be set")
 	}
 
 	cert := &x509.Certificate{
@@ -248,7 +260,7 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ocs
 		SubjectKeyId:          subjectKeyID[:],
 	}
 
-	if ocspSigner {
+	if ct == ocspCert {
 		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageOCSPSigning}
 		// ASN.1 NULL is 0x05, 0x00
 		ocspNoCheckExt := pkix.Extension{Id: oidOCSPNoCheck, Value: []byte{5, 0}}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -91,7 +91,7 @@ func (rc rootConfig) validate() error {
 	}
 
 	// Certificate profile
-	if err := rc.CertProfile.verifyProfile(true); err != nil {
+	if err := rc.CertProfile.verifyProfile(true, false); err != nil {
 		return err
 	}
 
@@ -117,7 +117,7 @@ type intermediateConfig struct {
 	CertProfile certProfile `yaml:"certificate-profile"`
 }
 
-func (ic intermediateConfig) validate() error {
+func (ic intermediateConfig) validate(ocspSigner bool) error {
 	// PKCS11 fields
 	if ic.PKCS11.Module == "" {
 		return errors.New("pkcs11.module is required")
@@ -144,7 +144,7 @@ func (ic intermediateConfig) validate() error {
 	}
 
 	// Certificate profile
-	if err := ic.CertProfile.verifyProfile(false); err != nil {
+	if err := ic.CertProfile.verifyProfile(false, ocspSigner); err != nil {
 		return err
 	}
 
@@ -228,6 +228,9 @@ func rootCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
+	if err := config.validate(); err != nil {
+		return fmt.Errorf("failed to validate config: %s", err)
+	}
 	ctx, session, err := pkcs11helpers.Initialize(config.PKCS11.Module, config.PKCS11.StoreSlot, config.PKCS11.PIN)
 	if err != nil {
 		return fmt.Errorf("failed to setup session and PKCS#11 context for slot %d: %s", config.PKCS11.StoreSlot, err)
@@ -241,7 +244,7 @@ func rootCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to retrieve signer: %s", err)
 	}
-	template, err := makeTemplate(newRandReader(ctx, session), &config.CertProfile, keyInfo.der)
+	template, err := makeTemplate(newRandReader(ctx, session), &config.CertProfile, keyInfo.der, false)
 	if err != nil {
 		return fmt.Errorf("failed to create certificate profile: %s", err)
 	}
@@ -254,12 +257,16 @@ func rootCeremony(configBytes []byte) error {
 	return nil
 }
 
-func intermediateCeremony(configBytes []byte) error {
+func intermediateCeremony(configBytes []byte, ocspSigner bool) error {
 	var config intermediateConfig
 	err := yaml.UnmarshalStrict(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
+	if err := config.validate(ocspSigner); err != nil {
+		return fmt.Errorf("failed to validate config: %s", err)
+	}
+
 	ctx, session, err := pkcs11helpers.Initialize(config.PKCS11.Module, config.PKCS11.SigningSlot, config.PKCS11.PIN)
 	if err != nil {
 		return fmt.Errorf("failed to setup session and PKCS#11 context for slot %d: %s", config.PKCS11.SigningSlot, err)
@@ -299,7 +306,8 @@ func intermediateCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse issuer certificate: %s", err)
 	}
-	template, err := makeTemplate(newRandReader(ctx, session), &config.CertProfile, pubPEM.Bytes)
+
+	template, err := makeTemplate(newRandReader(ctx, session), &config.CertProfile, pubPEM.Bytes, ocspSigner)
 	if err != nil {
 		return fmt.Errorf("failed to create certificate profile: %s", err)
 	}
@@ -318,6 +326,9 @@ func keyCeremony(configBytes []byte) error {
 	err := yaml.UnmarshalStrict(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
+	}
+	if err := config.validate(); err != nil {
+		return fmt.Errorf("failed to validate config: %s", err)
 	}
 	ctx, session, err := pkcs11helpers.Initialize(config.PKCS11.Module, config.PKCS11.StoreSlot, config.PKCS11.PIN)
 	if err != nil {
@@ -357,14 +368,21 @@ func main() {
 			log.Fatalf("root ceremony failed: %s", err)
 		}
 	case "intermediate":
-		err = intermediateCeremony(configBytes)
+		err = intermediateCeremony(configBytes, false)
 		if err != nil {
 			log.Fatalf("intermediate ceremony failed: %s", err)
+		}
+	case "ocsp-signer":
+		err = intermediateCeremony(configBytes, true)
+		if err != nil {
+			log.Fatalf("ocsp signer ceremony failed: %s", err)
 		}
 	case "key":
 		err = keyCeremony(configBytes)
 		if err != nil {
 			log.Fatalf("key ceremony failed: %s", err)
 		}
+	default:
+		log.Fatalf("unknown ceremony-type, must be one of: root, intermediate, ocsp-signer, key")
 	}
 }

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -414,7 +414,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.config.validate()
+			err := tc.config.validate(false)
 			if err != nil && err.Error() != tc.expectedError {
 				t.Fatalf("Unexpected error, wanted: %q, got: %q", tc.expectedError, err)
 			} else if err == nil && tc.expectedError != "" {

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -414,7 +414,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.config.validate(false)
+			err := tc.config.validate(intermediateCert)
 			if err != nil && err.Error() != tc.expectedError {
 				t.Fatalf("Unexpected error, wanted: %q, got: %q", tc.expectedError, err)
 			} else if err == nil && tc.expectedError != "" {


### PR DESCRIPTION
Initially this was going to just be a bool on the `intermediate` type, but there is enough different in terms of what is generated that I think it makes sense to add a completely separate type. Internally they share the same config, since basically everything else is the same (apart from a few constraints on what fields can be populated in the profile).

This additionally fixes a bug where we weren't actually validating root/intermediate/key configs.

Fixes #4741