### PR TITLE
Trim newlines in http.Server.ErrorLog log adapter

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -109,6 +110,13 @@ type errorWriter struct {
 }
 
 func (ew errorWriter) Write(p []byte) (n int, err error) {
+	// log.Logger will append a newline to all messages before calling
+	// Write. Our log checksum checker doesn't like newlines, because
+	// syslog will strip them out so the calculated checksums will
+	// differ. So that we don't hit this corner case for every line
+	// logged from inside net/http.Server we strip the newline before
+	// we get to the checksum generator.
+	p = bytes.TrimRight(p, "\n")
 	ew.Logger.Err(fmt.Sprintf("net/http.Server: %s", string(p)))
 	return
 }

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -258,6 +258,13 @@ type errorWriter struct {
 }
 
 func (ew errorWriter) Write(p []byte) (n int, err error) {
+	// log.Logger will append a newline to all messages before calling
+	// Write. Our log checksum checker doesn't like newlines, because
+	// syslog will strip them out so the calculated checksums will
+	// differ. So that we don't hit this corner case for every line
+	// logged from inside net/http.Server we strip the newline before
+	// we get to the checksum generator.
+	p = bytes.TrimRight(p, "\n")
 	ew.Logger.Err(fmt.Sprintf("net/http.Server: %s", string(p)))
 	return
 }


### PR DESCRIPTION
log.Logger, the wrapper type that http.Server.ErrorLog uses will append
a newline to every line before calling Write on the inner logger if the
line doesn't already contain one. This breaks our checksum generation/
verification code because syslog will strip newlines. So that we don't
generate irreproducible checksums we strip the newline that log.Logger
added.

Fixes #4812