### PR TITLE
Switch to syntax = "proto3" for publisher.

### DIFF
--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -99,10 +99,10 @@ func (ctp *CTPolicy) race(ctx context.Context, cert core.CertDER, group ctconfig
 				return
 			}
 			sct, err := ctp.pub.SubmitToSingleCTWithResult(ctx, &pubpb.Request{
-				LogURL:       &uri,
-				LogPublicKey: &key,
+				LogURL:       uri,
+				LogPublicKey: key,
 				Der:          cert,
-				Precert:      &isPrecert,
+				Precert:      isPrecert,
 			})
 			if err != nil {
 				// Only log the error if it is not a result of the context being canceled
@@ -166,10 +166,10 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER, expiration 
 				return
 			}
 			_, err = ctp.pub.SubmitToSingleCTWithResult(context.Background(), &pubpb.Request{
-				LogURL:       &uri,
-				LogPublicKey: &key,
+				LogURL:       uri,
+				LogPublicKey: key,
 				Der:          cert,
-				Precert:      &isPrecert,
+				Precert:      isPrecert,
 			})
 			if err != nil {
 				ctp.log.Warningf("ct submission to informational log %q failed: %s", uri, err)
@@ -194,7 +194,6 @@ func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER, expiration 
 // SubmitFinalCert submits finalized certificates created from precertificates
 // to any configured logs
 func (ctp *CTPolicy) SubmitFinalCert(cert []byte, expiration time.Time) {
-	falseVar := false
 	for _, log := range ctp.finalLogs {
 		go func(l ctconfig.LogDescription) {
 			uri, key, err := l.Info(expiration)
@@ -203,11 +202,11 @@ func (ctp *CTPolicy) SubmitFinalCert(cert []byte, expiration time.Time) {
 				return
 			}
 			_, err = ctp.pub.SubmitToSingleCTWithResult(context.Background(), &pubpb.Request{
-				LogURL:       &uri,
-				LogPublicKey: &key,
+				LogURL:       uri,
+				LogPublicKey: key,
 				Der:          cert,
-				Precert:      &falseVar,
-				StoreSCT:     &falseVar,
+				Precert:      false,
+				StoreSCT:     false,
 			})
 			if err != nil {
 				ctp.log.Warningf("ct submission of final cert to log %q failed: %s", uri, err)

--- a/ctpolicy/ctpolicy_test.go
+++ b/ctpolicy/ctpolicy_test.go
@@ -140,7 +140,7 @@ type failOne struct {
 }
 
 func (mp *failOne) SubmitToSingleCTWithResult(_ context.Context, req *pubpb.Request) (*pubpb.Result, error) {
-	if *req.LogURL == mp.badURL {
+	if req.LogURL == mp.badURL {
 		return nil, errors.New("BAD")
 	}
 	return &pubpb.Result{Sct: []byte{0}}, nil

--- a/grpc/publisher-wrappers.go
+++ b/grpc/publisher-wrappers.go
@@ -48,8 +48,5 @@ func NewPublisherServerWrapper(inner *publisher.Impl) *PublisherServerWrapper {
 
 // SubmitToSingleCTWithResult is a wrapper
 func (pub *PublisherServerWrapper) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Request) (*pubpb.Result, error) {
-	if req == nil || req.Der == nil || req.LogURL == nil || req.LogPublicKey == nil {
-		return nil, errIncompleteRequest
-	}
 	return pub.inner.SubmitToSingleCTWithResult(ctx, req)
 }

--- a/publisher/proto/publisher.pb.go
+++ b/publisher/proto/publisher.pb.go
@@ -34,11 +34,11 @@ type Request struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Der          []byte  `protobuf:"bytes,1,opt,name=der" json:"der,omitempty"`
-	LogURL       *string `protobuf:"bytes,2,opt,name=LogURL" json:"LogURL,omitempty"`
-	LogPublicKey *string `protobuf:"bytes,3,opt,name=LogPublicKey" json:"LogPublicKey,omitempty"`
-	Precert      *bool   `protobuf:"varint,4,opt,name=precert" json:"precert,omitempty"`
-	StoreSCT     *bool   `protobuf:"varint,5,opt,name=storeSCT" json:"storeSCT,omitempty"`
+	Der          []byte `protobuf:"bytes,1,opt,name=der,proto3" json:"der,omitempty"`
+	LogURL       string `protobuf:"bytes,2,opt,name=LogURL,proto3" json:"LogURL,omitempty"`
+	LogPublicKey string `protobuf:"bytes,3,opt,name=LogPublicKey,proto3" json:"LogPublicKey,omitempty"`
+	Precert      bool   `protobuf:"varint,4,opt,name=precert,proto3" json:"precert,omitempty"`
+	StoreSCT     bool   `protobuf:"varint,5,opt,name=storeSCT,proto3" json:"storeSCT,omitempty"`
 }
 
 func (x *Request) Reset() {
@@ -81,29 +81,29 @@ func (x *Request) GetDer() []byte {
 }
 
 func (x *Request) GetLogURL() string {
-	if x != nil && x.LogURL != nil {
-		return *x.LogURL
+	if x != nil {
+		return x.LogURL
 	}
 	return ""
 }
 
 func (x *Request) GetLogPublicKey() string {
-	if x != nil && x.LogPublicKey != nil {
-		return *x.LogPublicKey
+	if x != nil {
+		return x.LogPublicKey
 	}
 	return ""
 }
 
 func (x *Request) GetPrecert() bool {
-	if x != nil && x.Precert != nil {
-		return *x.Precert
+	if x != nil {
+		return x.Precert
 	}
 	return false
 }
 
 func (x *Request) GetStoreSCT() bool {
-	if x != nil && x.StoreSCT != nil {
-		return *x.StoreSCT
+	if x != nil {
+		return x.StoreSCT
 	}
 	return false
 }
@@ -113,7 +113,7 @@ type Result struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Sct []byte `protobuf:"bytes,1,opt,name=sct" json:"sct,omitempty"`
+	Sct []byte `protobuf:"bytes,1,opt,name=sct,proto3" json:"sct,omitempty"`
 }
 
 func (x *Result) Reset() {
@@ -174,7 +174,8 @@ var file_publisher_proto_rawDesc = []byte{
 	0x62, 0x6d, 0x69, 0x74, 0x54, 0x6f, 0x53, 0x69, 0x6e, 0x67, 0x6c, 0x65, 0x43, 0x54, 0x57, 0x69,
 	0x74, 0x68, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x12, 0x08, 0x2e, 0x52, 0x65, 0x71, 0x75, 0x65,
 	0x73, 0x74, 0x1a, 0x07, 0x2e, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x22, 0x00, 0x42, 0x0d, 0x5a,
-	0x0b, 0x2e, 0x3b, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x73, 0x68, 0x65, 0x72,
+	0x0b, 0x2e, 0x3b, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x73, 0x68, 0x65, 0x72, 0x62, 0x06, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (

--- a/publisher/proto/publisher.proto
+++ b/publisher/proto/publisher.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 option go_package = ".;publisher";
 
 service Publisher {
@@ -6,13 +6,13 @@ service Publisher {
 }
 
 message Request {
-        optional bytes der = 1;
-        optional string LogURL = 2;
-        optional string LogPublicKey = 3;
-        optional bool precert = 4;
-        optional bool storeSCT = 5;
+        bytes der = 1;
+        string LogURL = 2;
+        string LogPublicKey = 3;
+        bool precert = 4;
+        bool storeSCT = 5;
 }
 
 message Result {
-        optional bytes sct = 1;
+        bytes sct = 1;
 }

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -235,16 +235,13 @@ func (pub *Impl) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Requ
 	// Add a log URL/pubkey to the cache, if already present the
 	// existing *Log will be returned, otherwise one will be constructed, added
 	// and returned.
-	ctLog, err := pub.ctLogsCache.AddLog(*req.LogURL, *req.LogPublicKey, pub.userAgent, pub.log)
+	ctLog, err := pub.ctLogsCache.AddLog(req.LogURL, req.LogPublicKey, pub.userAgent, pub.log)
 	if err != nil {
 		pub.log.AuditErrf("Making Log: %s", err)
 		return nil, err
 	}
 
-	isPrecert := false
-	if req.Precert != nil {
-		isPrecert = *req.Precert
-	}
+	isPrecert := req.Precert
 
 	sct, err := pub.singleLogSubmit(
 		ctx,

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -265,12 +265,11 @@ func TestTimestampVerificationFuture(t *testing.T) {
 	testLog := addLog(t, pub, port, &k.PublicKey)
 
 	// Precert
-	trueBool := true
 	issuerBundle, precert, err := makePrecert(k)
 	test.AssertNotError(t, err, "Failed to create test leaf")
 	pub.issuerBundle = issuerBundle
 
-	_, err = pub.SubmitToSingleCTWithResult(ctx, &pubpb.Request{LogURL: &testLog.uri, LogPublicKey: &testLog.logID, Der: precert, Precert: &trueBool})
+	_, err = pub.SubmitToSingleCTWithResult(ctx, &pubpb.Request{LogURL: testLog.uri, LogPublicKey: testLog.logID, Der: precert, Precert: true})
 	if err == nil {
 		t.Fatal("Expected error for lying log server, got none")
 	}
@@ -289,12 +288,11 @@ func TestTimestampVerificationPast(t *testing.T) {
 	testLog := addLog(t, pub, port, &k.PublicKey)
 
 	// Precert
-	trueBool := true
 	issuerBundle, precert, err := makePrecert(k)
 	test.AssertNotError(t, err, "Failed to create test leaf")
 	pub.issuerBundle = issuerBundle
 
-	_, err = pub.SubmitToSingleCTWithResult(ctx, &pubpb.Request{LogURL: &testLog.uri, LogPublicKey: &testLog.logID, Der: precert, Precert: &trueBool})
+	_, err = pub.SubmitToSingleCTWithResult(ctx, &pubpb.Request{LogURL: testLog.uri, LogPublicKey: testLog.logID, Der: precert, Precert: true})
 	if err == nil {
 		t.Fatal("Expected error for lying log server, got none")
 	}
@@ -366,8 +364,8 @@ func TestLogErrorBody(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to marshal key")
 	pkB64 := base64.StdEncoding.EncodeToString(pkDER)
 	_, err = pub.SubmitToSingleCTWithResult(context.Background(), &pubpb.Request{
-		LogURL:       &logURI,
-		LogPublicKey: &pkB64,
+		LogURL:       logURI,
+		LogPublicKey: pkB64,
 		Der:          leaf.Raw,
 	})
 	test.AssertError(t, err, "SubmitToSingleCTWithResult didn't fail")
@@ -387,8 +385,8 @@ func TestHTTPStatusMetric(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to marshal key")
 	pkB64 := base64.StdEncoding.EncodeToString(pkDER)
 	_, err = pub.SubmitToSingleCTWithResult(context.Background(), &pubpb.Request{
-		LogURL:       &logURI,
-		LogPublicKey: &pkB64,
+		LogURL:       logURI,
+		LogPublicKey: pkB64,
 		Der:          leaf.Raw,
 	})
 	test.AssertError(t, err, "SubmitToSingleCTWithResult didn't fail")
@@ -409,8 +407,8 @@ func TestHTTPStatusMetric(t *testing.T) {
 	logURI = fmt.Sprintf("http://localhost:%d", port)
 
 	_, err = pub.SubmitToSingleCTWithResult(context.Background(), &pubpb.Request{
-		LogURL:       &logURI,
-		LogPublicKey: &pkB64,
+		LogURL:       logURI,
+		LogPublicKey: pkB64,
 		Der:          leaf.Raw,
 	})
 	test.AssertNotError(t, err, "SubmitToSingleCTWithResult failed")


### PR DESCRIPTION
And make corresponding changes to call sites and wrappers.

Note that proto2 vs proto3 is distinction in the syntax of the .proto files
and doesn't change the wire format, so this meets the deployability
guidelines.