### PR TITLE
Provide the -integration build tag even race detector is off.

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -21,7 +21,7 @@ def install(race_detection):
     # Pass empty BUILD_TIME and BUILD_ID flags to avoid constantly invalidating the
     # build cache with new BUILD_TIMEs, or invalidating it on merges with a new
     # BUILD_ID.
-    cmd = "/usr/bin/make GO_BUILD_FLAGS=''  "
+    cmd = "/usr/bin/make GO_BUILD_FLAGS='-tags \"integration\"'  "
     if race_detection:
         cmd = "/usr/bin/make GO_BUILD_FLAGS='-race -tags \"integration\"'"
 


### PR DESCRIPTION
Otherwise this leads to failures of tests that need to manipulate time,
like test_expiration_mailer.