### PR TITLE
cmd/ceremony: set max path len to 0 for intermediates

### DIFF
--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -276,6 +276,10 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 		cert.ExtraExtensions = append(cert.ExtraExtensions, policyExt)
 	}
 
+	if ct == intermediateCert {
+		cert.MaxPathLenZero = true
+	}
+
 	return cert, nil
 }
 

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -142,6 +142,10 @@ func TestMakeTemplate(t *testing.T) {
 	test.AssertEquals(t, cert.IssuingCertificateURL[0], profile.IssuerURL)
 	test.AssertEquals(t, cert.KeyUsage, x509.KeyUsageDigitalSignature|x509.KeyUsageCRLSign)
 	test.AssertEquals(t, len(cert.ExtraExtensions), 1)
+
+	cert, err = makeTemplate(randReader, profile, nil, intermediateCert)
+	test.AssertNotError(t, err, "makeTemplate failed when everything worked as expected")
+	test.Assert(t, cert.MaxPathLenZero, "MaxPathLenZero not set in intermediate template")
 }
 
 func TestMakeTemplateOCSP(t *testing.T) {


### PR DESCRIPTION
Fixes #4743