### PR TITLE
cmd/ceremony: set id-kp-serverAuth by default on intermediates

### DIFF
--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -266,6 +266,9 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 		ocspNoCheckExt := pkix.Extension{Id: oidOCSPNoCheck, Value: []byte{5, 0}}
 		cert.ExtraExtensions = append(cert.ExtraExtensions, ocspNoCheckExt)
 		cert.IsCA = false
+	} else if ct == intermediateCert {
+		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		cert.MaxPathLenZero = true
 	}
 
 	if len(profile.Policies) > 0 {
@@ -274,10 +277,6 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 			return nil, err
 		}
 		cert.ExtraExtensions = append(cert.ExtraExtensions, policyExt)
-	}
-
-	if ct == intermediateCert {
-		cert.MaxPathLenZero = true
 	}
 
 	return cert, nil

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -142,10 +142,13 @@ func TestMakeTemplate(t *testing.T) {
 	test.AssertEquals(t, cert.IssuingCertificateURL[0], profile.IssuerURL)
 	test.AssertEquals(t, cert.KeyUsage, x509.KeyUsageDigitalSignature|x509.KeyUsageCRLSign)
 	test.AssertEquals(t, len(cert.ExtraExtensions), 1)
+	test.AssertEquals(t, len(cert.ExtKeyUsage), 0)
 
 	cert, err = makeTemplate(randReader, profile, nil, intermediateCert)
 	test.AssertNotError(t, err, "makeTemplate failed when everything worked as expected")
 	test.Assert(t, cert.MaxPathLenZero, "MaxPathLenZero not set in intermediate template")
+	test.AssertEquals(t, len(cert.ExtKeyUsage), 1)
+	test.AssertEquals(t, cert.ExtKeyUsage[0], x509.ExtKeyUsageServerAuth)
 }
 
 func TestMakeTemplateOCSP(t *testing.T) {


### PR DESCRIPTION
Always add id-kp-serverAuth to intermediate certificates.