### PR TITLE
cmd/caa-log-checker: Add -time-tolerance flag

### DIFF
--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -92,15 +92,13 @@ func checkIssuances(scanner *bufio.Scanner, checkedMap map[string][]time.Time, t
 				validEnd := ie.issuanceTime
 				if t.After(validStart) && t.Before(validEnd.Add(timeTolerance)) {
 					nameOk = true
-				} else {
-					// If the check didn't pass, calculate how much tolerance we'd need for it to
-					// pass, to make it easier to diagnose log timestamp desync.
-					if !t.Before(validEnd) {
-						timeError := t.Sub(validEnd)
-						// ...however only if its <1h, otherwise it's probably not a match
-						if timeError < timeTolerance+time.Hour {
-							minTimeError = math.Min(minTimeError, float64(timeError)/float64(time.Second))
-						}
+				} else if t.After(validStart) {
+					// If the check didn't pass and the check is in the future, calculate how much tolerance
+					// we'd need for it to pass, to make it easier to diagnose log timestamp desync.
+					timeError := t.Sub(validEnd)
+					// ...however only if its <1h, otherwise it's probably not a match
+					if timeError < timeTolerance+time.Hour {
+						minTimeError = math.Min(minTimeError, float64(timeError)/float64(time.Second))
 					}
 				}
 			}

--- a/cmd/caa-log-checker/main_test.go
+++ b/cmd/caa-log-checker/main_test.go
@@ -140,7 +140,7 @@ random`,
 	stderrCont, err := ioutil.ReadFile(stderr.Name())
 	test.AssertNotError(t, err, "failed to read temporary file")
 	test.AssertEquals(t, string(stderrCont),
-		"Issuance missing CAA checks: issued at=0000-12-31 19:00:00.123456 -0800 -0800, serial=2, requester=0, names=[2.example.com 3.example.com], missing checks for names=[3.example.com], timeError=NaN\n"+
-			"Issuance missing CAA checks: issued at=0000-12-31 17:30:00.123456 -0800 -0800, serial=3, requester=0, names=[4.example.com], missing checks for names=[4.example.com], timeError=1800.000\n"+
-			"Issuance missing CAA checks: issued at=0001-01-01 03:00:00.123456 -0800 -0800, serial=4, requester=0, names=[5.example.com], missing checks for names=[5.example.com], timeError=NaN\n")
+		"Issuance missing CAA checks: issued at=0000-12-31 19:00:00.123456 -0800 -0800, serial=2, requester=0, names=[2.example.com 3.example.com], missing checks for names=[3.example.com], timeError=[+Inf]\n"+
+			"Issuance missing CAA checks: issued at=0000-12-31 17:30:00.123456 -0800 -0800, serial=3, requester=0, names=[4.example.com], missing checks for names=[4.example.com], timeError=[1800.000]\n"+
+			"Issuance missing CAA checks: issued at=0001-01-01 03:00:00.123456 -0800 -0800, serial=4, requester=0, names=[5.example.com], missing checks for names=[5.example.com], timeError=[+Inf]\n")
 }


### PR DESCRIPTION
This flag adds a tolerance window after the issuance time, where CAA checks will still be considered applicable, even though they appear to have happened after issuance.

This happens usually when a CAA check happens during issuance (because no cached one exists). There is no guarantee that logs from different hosts will follow a strict causal ordering (due clock desync or buffering in the log system), and so sometimes the CAA check log line will have a timestamp ordered after the issuance line.