### PR TITLE
Fix Coveralls branch info and update README badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,6 @@ install:
   - docker-compose pull
 
 script:
-  - docker-compose run --use-aliases -e BOULDER_CONFIG_DIR="${BOULDER_CONFIG_DIR}" -e RUN="${RUN}" -e TRAVIS="${TRAVIS}" -e TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST}" -e COVERALLS_TOKEN="${COVERALLS_TOKEN}" ${CONTAINER:-boulder} ./test.sh
+  # Export all variables with a TRAVIS prefix
+  - exported_vars=(BOULDER_CONFIG_DIR RUN "${!TRAVIS@}" COVERALLS_TOKEN)
+  - docker-compose run --use-aliases "${exported_vars[@]/#/-e}" ${CONTAINER:-boulder} ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ install:
   - docker-compose pull
 
 script:
-  # Export all variables with a TRAVIS prefix
-  - exported_vars=(BOULDER_CONFIG_DIR RUN "${!TRAVIS@}" COVERALLS_TOKEN)
-  - docker-compose run --use-aliases "${exported_vars[@]/#/-e}" ${CONTAINER:-boulder} ./test.sh
+  - >-
+    docker-compose run --use-aliases
+    -e BOULDER_CONFIG_DIR
+    -e RUN
+    -e TRAVIS_BRANCH
+    -e TRAVIS_JOB_ID
+    -e TRAVIS_PULL_REQUEST
+    -e COVERALLS_TOKEN
+    ${CONTAINER:-boulder} ./test.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Boulder - An ACME CA
 
-[![Build Status](https://travis-ci.org/letsencrypt/boulder.svg)](https://travis-ci.org/letsencrypt/boulder)
-[![Coverage Status](https://coveralls.io/repos/letsencrypt/boulder/badge.svg)](https://coveralls.io/r/letsencrypt/boulder)
+[![Build Status](https://travis-ci.com/letsencrypt/boulder.svg?branch=master)](https://travis-ci.com/letsencrypt/boulder)
+[![Coverage Status](https://coveralls.io/repos/github/letsencrypt/boulder/badge.svg?branch=master)](https://coveralls.io/github/letsencrypt/boulder?branch=master)
 
 This is an implementation of an ACME-based CA. The [ACME protocol](https://github.com/ietf-wg-acme/acme/) allows the CA to automatically verify that an applicant for a certificate actually controls an identifier, and allows domain holders to issue and revoke certificates for their domains. Boulder is the software that runs [Let's Encrypt](https://letsencrypt.org).
 

--- a/test.sh
+++ b/test.sh
@@ -61,7 +61,7 @@ function run_test_coverage() {
   # We don't use the run function here because sometimes goveralls fails to
   # contact the server and exits with non-zero status, but we don't want to
   # treat that as a failure.
-  goveralls -v -coverprofile=gover.coverprofile -service=travis-ci
+  goveralls -v -coverprofile=gover.coverprofile -service=travis-pro
 }
 
 #


### PR DESCRIPTION
goveralls was not able to detect the current branch since #4735. Instead of
figuring out which variables are needed for it to work correctly, this commit
just propagates all environment variables with the TRAVIS_ prefix. In addition, to match the migration from travis-ci.org to travis-ci.com, the service name was changed to `travis-pro`, as per the Coveralls docs: https://docs.coveralls.io/supported-ci-services

Also updates the badges in the readme file. The badge wasn't updated when we
migrated to travis-ci.com. The travis-ci.org address now just has an annoying
redirect page which requires you to click a link to go to the new page on
travis-ci.com. The new badge just takes you there directly.