### PR TITLE
Fix bug in how bad-key-revoker resolves contacts

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -283,7 +283,7 @@ func (bkr *badKeyRevoker) invoke() (bool, error) {
 	// extant certificates, still add them to ids so that we can resolve their
 	// email and avoid sending emails later. If RevokedBy == 0 it was a row
 	// inserted by admin-revoker with a dummy ID, since there won't be a registration
-	// to look up, don't both adding it to ids.
+	// to look up, don't bother adding it to ids.
 	if _, present := ownedBy[unchecked.RevokedBy]; !present && unchecked.RevokedBy != 0 {
 		ids = append(ids, unchecked.RevokedBy)
 	}

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -153,6 +153,9 @@ func (bkr *badKeyRevoker) resolveContacts(ids []int64) (map[int64][]string, erro
 		}
 		err := bkr.dbMap.SelectOne(&emails, "SELECT contact FROM registrations WHERE id = ?", id)
 		if err != nil {
+			if db.IsNoRows(err) {
+				continue
+			}
 			return nil, err
 		}
 		if len(emails.Contact) != 0 {

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -281,8 +281,10 @@ func (bkr *badKeyRevoker) invoke() (bool, error) {
 	}
 	// if the account that revoked the original certificate isn't an owner of any
 	// extant certificates, still add them to ids so that we can resolve their
-	// email and avoid sending emails later.
-	if _, present := ownedBy[unchecked.RevokedBy]; !present {
+	// email and avoid sending emails later. If RevokedBy == 0 it was a row
+	// inserted by admin-revoker with a dummy ID, since there won't be a registration
+	// to look up, don't both adding it to ids.
+	if _, present := ownedBy[unchecked.RevokedBy]; !present && unchecked.RevokedBy != 0 {
 		ids = append(ids, unchecked.RevokedBy)
 	}
 	// get contact addresses for the list of IDs

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -182,7 +182,7 @@ func TestResolveContacts(t *testing.T) {
 	regIDC := insertRegistration(t, dbMap, "example.com")
 	regIDD := insertRegistration(t, dbMap, "example-2.com")
 
-	idToEmail, err := bkr.resolveContacts([]int64{regIDA, regIDB, regIDC, regIDD})
+	idToEmail, err := bkr.resolveContacts([]int64{0, regIDA, regIDB, regIDC, regIDD})
 	test.AssertNotError(t, err, "resolveContacts failed")
 	test.AssertDeepEquals(t, idToEmail, map[int64][]string{
 		regIDA: {""},


### PR DESCRIPTION
admin-revoker uses a dummy registration ID (0) when adding rows to the blockedKeys table. resolveContacts in bad-key-revoker fails if it cannot lookup a registration. Don't bother adding the id to the list of ids to resolve, and add a catch for non-existent registration IDs to resolveContacts.