### PR TITLE
Set docker volumes to cache consistency mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
             # non-ASCII to stdout.
             PYTHONIOENCODING: "utf-8"
         volumes:
-          - .:/go/src/github.com/letsencrypt/boulder
-          - ./.gocache:/root/.cache/go-build
+          - .:/go/src/github.com/letsencrypt/boulder:cached
+          - ./.gocache:/root/.cache/go-build:cached
         networks:
           bluenet:
             ipv4_address: 10.77.77.77


### PR DESCRIPTION
(Only applies to OS X)

boulder is, typically, not a long lived docker container, and we don't
really care about synchronous consistency between the host fs and
container fs. `cached` provides the best performance for read-heavy
workloads, which is what is typically slowest on container startup
(at least from my experience).

This change provides a 30-40% speedup on OS X.