### PR TITLE
Log RSA key sizes in WFE/WFE2 and add feature to restrict them

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -28,11 +28,12 @@ func _() {
 	_ = x[StoreKeyHashes-17]
 	_ = x[BlockedKeyTable-18]
 	_ = x[StoreRevokerInfo-19]
+	_ = x[RestrictRSAKeySizes-20]
 }
 
-const _FeatureFlag_name = "unusedWriteIssuedNamesPrecertHeadNonceStatusOKRemoveWFE2AccountIDCheckRenewalFirstParallelCheckFailedValidationDeleteUnusedChallengesCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationV1DisableNewValidationsPrecertificateRevocationStripDefaultSchemePortStoreIssuerInfoStoreKeyHashesBlockedKeyTableStoreRevokerInfo"
+const _FeatureFlag_name = "unusedWriteIssuedNamesPrecertHeadNonceStatusOKRemoveWFE2AccountIDCheckRenewalFirstParallelCheckFailedValidationDeleteUnusedChallengesCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationV1DisableNewValidationsPrecertificateRevocationStripDefaultSchemePortStoreIssuerInfoStoreKeyHashesBlockedKeyTableStoreRevokerInfoRestrictRSAKeySizes"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 29, 46, 65, 82, 111, 133, 153, 166, 180, 198, 216, 235, 258, 282, 304, 319, 333, 348, 364}
+var _FeatureFlag_index = [...]uint16{0, 6, 29, 46, 65, 82, 111, 133, 153, 166, 180, 198, 216, 235, 258, 282, 304, 319, 333, 348, 364, 383}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -56,6 +56,9 @@ const (
 	// was checked for extant unrevoked certificates in the blockedKeys table. It should
 	// only be enabled if BlockedKeyTable is also enabled.
 	StoreRevokerInfo
+	// RestrictRSAKeySizes enables restriction of acceptable RSA public key moduli to
+	// the common sizes (2048, 3072, and 4096 bits).
+	RestrictRSAKeySizes
 )
 
 // List of features and their default value, protected by fMu
@@ -80,6 +83,7 @@ var features = map[FeatureFlag]bool{
 	StoreKeyHashes:                false,
 	BlockedKeyTable:               false,
 	StoreRevokerInfo:              false,
+	RestrictRSAKeySizes:           false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -49,7 +49,7 @@
     "features": {
       "BlockedKeyTable": true,
       "StoreRevokerInfo": true,
-      "RestrictRSAKeySizes": true,
+      "RestrictRSAKeySizes": true
     },
     "CTLogGroups2": [
       {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -48,7 +48,8 @@
     },
     "features": {
       "BlockedKeyTable": true,
-      "StoreRevokerInfo": true
+      "StoreRevokerInfo": true,
+      "RestrictRSAKeySizes": true,
     },
     "CTLogGroups2": [
       {

--- a/web/context.go
+++ b/web/context.go
@@ -2,6 +2,9 @@ package web
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -161,4 +164,14 @@ func GetClientAddr(r *http.Request) string {
 		return xff + "," + r.RemoteAddr
 	}
 	return r.RemoteAddr
+}
+
+func KeyTypeToString(pub crypto.PublicKey) string {
+	switch pk := pub.(type) {
+	case *rsa.PublicKey:
+		return fmt.Sprintf("RSA %d", pk.N.BitLen())
+	case *ecdsa.PublicKey:
+		return fmt.Sprintf("ECDSA %s", pk.Params().Name)
+	}
+	return "unknown"
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -3,6 +3,7 @@ package wfe
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -974,6 +975,9 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 	logEvent.Extra["CSRDNSNames"] = certificateRequest.CSR.DNSNames
 	logEvent.Extra["CSREmailAddresses"] = certificateRequest.CSR.EmailAddresses
 	logEvent.Extra["CSRIPAddresses"] = certificateRequest.CSR.IPAddresses
+	if rsaPub, ok := certificateRequest.CSR.PublicKey.(*rsa.PublicKey); ok {
+		logEvent.Extra["CSRPublicRSAModSize"] = rsaPub.N.BitLen()
+	}
 
 	// Inc CSR signature algorithm counter
 	wfe.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -974,7 +974,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 	logEvent.Extra["CSRDNSNames"] = certificateRequest.CSR.DNSNames
 	logEvent.Extra["CSREmailAddresses"] = certificateRequest.CSR.EmailAddresses
 	logEvent.Extra["CSRIPAddresses"] = certificateRequest.CSR.IPAddresses
-	logEvent.Extra["CSRPublicKeyType"] = web.KeyTypeToString(certificateRequest.CSR.PublicKey)
+	logEvent.Extra["KeyType"] = web.KeyTypeToString(certificateRequest.CSR.PublicKey)
 
 	// Inc CSR signature algorithm counter
 	wfe.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -3,7 +3,6 @@ package wfe
 import (
 	"bytes"
 	"context"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -975,9 +974,7 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 	logEvent.Extra["CSRDNSNames"] = certificateRequest.CSR.DNSNames
 	logEvent.Extra["CSREmailAddresses"] = certificateRequest.CSR.EmailAddresses
 	logEvent.Extra["CSRIPAddresses"] = certificateRequest.CSR.IPAddresses
-	if rsaPub, ok := certificateRequest.CSR.PublicKey.(*rsa.PublicKey); ok {
-		logEvent.Extra["CSRPublicRSAModSize"] = rsaPub.N.BitLen()
-	}
+	logEvent.Extra["CSRPublicKeyType"] = web.KeyTypeToString(certificateRequest.CSR.PublicKey)
 
 	// Inc CSR signature algorithm counter
 	wfe.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -3,7 +3,6 @@ package wfe2
 import (
 	"bytes"
 	"context"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -2161,9 +2160,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	logEvent.Extra["CSRDNSNames"] = certificateRequest.CSR.DNSNames
 	logEvent.Extra["CSREmailAddresses"] = certificateRequest.CSR.EmailAddresses
 	logEvent.Extra["CSRIPAddresses"] = certificateRequest.CSR.IPAddresses
-	if rsaPub, ok := certificateRequest.CSR.PublicKey.(*rsa.PublicKey); ok {
-		logEvent.Extra["CSRPublicRSAModSize"] = rsaPub.N.BitLen()
-	}
+	logEvent.Extra["CSRPublicKeyType"] = web.KeyTypeToString(certificateRequest.CSR.PublicKey)
 
 	// Inc CSR signature algorithm counter
 	wfe.stats.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -3,6 +3,7 @@ package wfe2
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -2160,6 +2161,9 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	logEvent.Extra["CSRDNSNames"] = certificateRequest.CSR.DNSNames
 	logEvent.Extra["CSREmailAddresses"] = certificateRequest.CSR.EmailAddresses
 	logEvent.Extra["CSRIPAddresses"] = certificateRequest.CSR.IPAddresses
+	if rsaPub, ok := certificateRequest.CSR.PublicKey.(*rsa.PublicKey); ok {
+		logEvent.Extra["CSRPublicRSAModSize"] = rsaPub.N.BitLen()
+	}
 
 	// Inc CSR signature algorithm counter
 	wfe.stats.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2160,7 +2160,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	logEvent.Extra["CSRDNSNames"] = certificateRequest.CSR.DNSNames
 	logEvent.Extra["CSREmailAddresses"] = certificateRequest.CSR.EmailAddresses
 	logEvent.Extra["CSRIPAddresses"] = certificateRequest.CSR.IPAddresses
-	logEvent.Extra["CSRPublicKeyType"] = web.KeyTypeToString(certificateRequest.CSR.PublicKey)
+	logEvent.Extra["KeyType"] = web.KeyTypeToString(certificateRequest.CSR.PublicKey)
 
 	// Inc CSR signature algorithm counter
 	wfe.stats.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()


### PR DESCRIPTION
Currently 99.99% of RSA keys we see in certificates at Let's Encrypt are either 2048, 3072, or 4096 bits, but we support every 8 bit increment between 2048 and 4096. Supporting these uncommon key sizes opens us up to having to block much larger ranges of keys when dealing with something like the Debian weak keys incident. Instead we should just reduce the set of key sizes we support down to what people actually use.

Fixes #4835.