### PR TITLE
Check email address validity in notify-mailer.

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -23,6 +23,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	bmail "github.com/letsencrypt/boulder/mail"
 	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
 )
 
@@ -145,6 +146,10 @@ func (m *mailer) run() error {
 			m.log.Debugf("skipping %q: out of target range")
 			continue
 		}
+		if err := policy.ValidEmail(address); err != nil {
+			m.log.Infof("skipping %q: %s", address, err)
+			continue
+		}
 		recipients := addressesToRecipients[address]
 		m.printStatus(address, i+1, numAddresses, startTime)
 		var mailBody bytes.Buffer
@@ -162,7 +167,8 @@ func (m *mailer) run() error {
 				m.log.Errf("address %q was rejected by server: %s", address, err)
 				continue
 			default:
-				return err
+				return fmt.Errorf("sending mail %d of %d to %q: %s",
+					i, len(sortedAddresses), address, err)
 			}
 		}
 		sent++

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -176,31 +176,31 @@ func TestMailIntervals(t *testing.T) {
 		subject:       testSubject,
 		destinations:  []recipient{{id: 1}, {id: 2}, {id: 3}, {id: 4}},
 		emailTemplate: tmpl,
-		targetRange:   interval{start: "test-example-updated@example.com", end: "\xFF"},
+		targetRange:   interval{start: "test-example-updated@letsencrypt.org", end: "\xFF"},
 		sleepInterval: 0,
 		clk:           newFakeClock(t),
 	}
 
 	// Run the mailer. Two messages should have been produced, one to
-	// test-example-updated@example.com (beginning of the range),
-	// and one to test-test-test@example.com.
+	// test-example-updated@letsencrypt.org (beginning of the range),
+	// and one to test-test-test@letsencrypt.org.
 	mc.Clear()
 	err = m.run()
 	test.AssertNotError(t, err, "run() produced an error")
 	test.AssertEquals(t, len(mc.Messages), 2)
 	test.AssertEquals(t, mocks.MailerMessage{
-		To:      "test-example-updated@example.com",
+		To:      "test-example-updated@letsencrypt.org",
 		Subject: testSubject,
 		Body:    "an email body",
 	}, mc.Messages[0])
 	test.AssertEquals(t, mocks.MailerMessage{
-		To:      "test-test-test@example.com",
+		To:      "test-test-test@letsencrypt.org",
 		Subject: testSubject,
 		Body:    "an email body",
 	}, mc.Messages[1])
 
 	// Create a mailer with a checkpoint interval ending before
-	// "test-example-updated@example.com"
+	// "test-example-updated@letsencrypt.org"
 	m = &mailer{
 		log:           blog.UseMock(),
 		mailer:        mc,
@@ -208,24 +208,24 @@ func TestMailIntervals(t *testing.T) {
 		subject:       testSubject,
 		destinations:  []recipient{{id: 1}, {id: 2}, {id: 3}, {id: 4}},
 		emailTemplate: tmpl,
-		targetRange:   interval{end: "test-example-updated@example.com"},
+		targetRange:   interval{end: "test-example-updated@letsencrypt.org"},
 		sleepInterval: 0,
 		clk:           newFakeClock(t),
 	}
 
 	// Run the mailer. Two messages should have been produced, one to
-	// example@example.com (ID 1), one to example-example-example@example.com (ID 2)
+	// example@letsencrypt.org (ID 1), one to example-example-example@example.com (ID 2)
 	mc.Clear()
 	err = m.run()
 	test.AssertNotError(t, err, "run() produced an error")
 	test.AssertEquals(t, len(mc.Messages), 2)
 	test.AssertEquals(t, mocks.MailerMessage{
-		To:      "example-example-example@example.com",
+		To:      "example-example-example@letsencrypt.org",
 		Subject: testSubject,
 		Body:    "an email body",
 	}, mc.Messages[0])
 	test.AssertEquals(t, mocks.MailerMessage{
-		To:      "example@example.com",
+		To:      "example@letsencrypt.org",
 		Subject: testSubject,
 		Body:    "an email body",
 	}, mc.Messages[1])
@@ -256,7 +256,7 @@ func TestMessageContentStatic(t *testing.T) {
 	test.AssertNotError(t, err, "error calling mailer run()")
 	test.AssertEquals(t, len(mc.Messages), 1)
 	test.AssertEquals(t, mocks.MailerMessage{
-		To:      "example@example.com",
+		To:      "example@letsencrypt.org",
 		Subject: testSubject,
 		Body:    "an email body",
 	}, mc.Messages[0])
@@ -293,7 +293,7 @@ func TestMessageContentInterpolated(t *testing.T) {
 	test.AssertNotError(t, err, "error calling mailer run()")
 	test.AssertEquals(t, len(mc.Messages), 1)
 	test.AssertEquals(t, mocks.MailerMessage{
-		To:      "example@example.com",
+		To:      "example@letsencrypt.org",
 		Subject: "Test Subject",
 		Body:    "issued by eyeballing it",
 	}, mc.Messages[0])
@@ -351,7 +351,7 @@ func TestMessageContentInterpolatedMultiple(t *testing.T) {
 	test.AssertNotError(t, err, "error calling mailer run()")
 	test.AssertEquals(t, len(mc.Messages), 1)
 	test.AssertEquals(t, mocks.MailerMessage{
-		To:      "gotta.lotta.accounts@example.net",
+		To:      "gotta.lotta.accounts@letsencrypt.org",
 		Subject: "Test Subject",
 		Body: `issued for:
 blog.example.com
@@ -374,27 +374,27 @@ func (bs mockEmailResolver) SelectOne(output interface{}, _ string, args ...inte
 	dbList := []contactJSON{
 		{
 			ID:      1,
-			Contact: []byte(`["mailto:example@example.com"]`),
+			Contact: []byte(`["mailto:example@letsencrypt.org"]`),
 		},
 		{
 			ID:      2,
-			Contact: []byte(`["mailto:test-example-updated@example.com"]`),
+			Contact: []byte(`["mailto:test-example-updated@letsencrypt.org"]`),
 		},
 		{
 			ID:      3,
-			Contact: []byte(`["mailto:test-test-test@example.com"]`),
+			Contact: []byte(`["mailto:test-test-test@letsencrypt.org"]`),
 		},
 		{
 			ID:      4,
-			Contact: []byte(`["mailto:example-example-example@example.com"]`),
+			Contact: []byte(`["mailto:example-example-example@letsencrypt.org"]`),
 		},
 		{
 			ID:      5,
-			Contact: []byte(`["mailto:youve.got.mail@example.com"]`),
+			Contact: []byte(`["mailto:youve.got.mail@letsencrypt.org"]`),
 		},
 		{
 			ID:      6,
-			Contact: []byte(`["mailto:mail@example.com"]`),
+			Contact: []byte(`["mailto:mail@letsencrypt.org"]`),
 		},
 		{
 			ID:      7,
@@ -402,23 +402,23 @@ func (bs mockEmailResolver) SelectOne(output interface{}, _ string, args ...inte
 		},
 		{
 			ID:      200,
-			Contact: []byte(`["mailto:gotta.lotta.accounts@example.net"]`),
+			Contact: []byte(`["mailto:gotta.lotta.accounts@letsencrypt.org"]`),
 		},
 		{
 			ID:      201,
-			Contact: []byte(`["mailto:gotta.lotta.accounts@example.net"]`),
+			Contact: []byte(`["mailto:gotta.lotta.accounts@letsencrypt.org"]`),
 		},
 		{
 			ID:      202,
-			Contact: []byte(`["mailto:gotta.lotta.accounts@example.net"]`),
+			Contact: []byte(`["mailto:gotta.lotta.accounts@letsencrypt.org"]`),
 		},
 		{
 			ID:      203,
-			Contact: []byte(`["mailto:gotta.lotta.accounts@example.net"]`),
+			Contact: []byte(`["mailto:gotta.lotta.accounts@letsencrypt.org"]`),
 		},
 		{
 			ID:      204,
-			Contact: []byte(`["mailto:gotta.lotta.accounts@example.net"]`),
+			Contact: []byte(`["mailto:gotta.lotta.accounts@letsencrypt.org"]`),
 		},
 	}
 
@@ -519,10 +519,10 @@ func TestResolveEmails(t *testing.T) {
 	test.AssertNotError(t, err, "failed to resolveEmailAddresses")
 
 	expected := []string{
-		"example@example.com",
-		"test-example-updated@example.com",
-		"test-test-test@example.com",
-		"gotta.lotta.accounts@example.net",
+		"example@letsencrypt.org",
+		"test-example-updated@letsencrypt.org",
+		"test-test-test@letsencrypt.org",
+		"gotta.lotta.accounts@letsencrypt.org",
 	}
 
 	test.AssertEquals(t, len(addressesToRecipients), len(expected))

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -108,7 +108,6 @@ type PolicyAuthority interface {
 	WillingToIssueWildcards(identifiers []identifier.ACMEIdentifier) error
 	ChallengesFor(domain identifier.ACMEIdentifier) ([]Challenge, error)
 	ChallengeTypeEnabled(t string) bool
-	ValidDomain(domain string) error
 }
 
 // StorageGetter are the Boulder SA's read-only methods

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -47,10 +47,6 @@ func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
 	return true
 }
 
-func (pa *mockPA) ValidDomain(_ string) error {
-	return nil
-}
-
 func TestVerifyCSR(t *testing.T) {
 	private, err := rsa.GenerateKey(rand.Reader, 2048)
 	test.AssertNotError(t, err, "error generating test key")

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -305,11 +305,14 @@ var forbiddenMailDomains = map[string]bool{
 	"example.org": true,
 }
 
+// ValidEmail returns an error if the input doesn't parse as an email address,
+// the domain isn't a valid hostname in Preferred Name Syntax, or its on the
+// list of domains forbidden for mail (because they are often used in examples).
 func ValidEmail(address string) error {
 	email, err := mail.ParseAddress(address)
 	if err != nil {
 		if len(address) > 254 {
-			address = address[:254]
+			address = address[:254] + "..."
 		}
 		return berrors.InvalidEmailError("%q is not a valid e-mail address", address)
 	}

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -451,3 +451,17 @@ func TestMalformedExactBlocklist(t *testing.T) {
 	test.AssertError(t, err, "Loaded invalid exact blocklist content without error")
 	test.AssertEquals(t, err.Error(), "Malformed ExactBlockedNames entry, only one label: \"com\"")
 }
+
+func TestValidEmailError(t *testing.T) {
+	err := ValidEmail("(๑•́ ω •̀๑)")
+	test.AssertEquals(t, err.Error(), "\"(๑•́ ω •̀๑)\" is not a valid e-mail address")
+
+	err = ValidEmail("john.smith@gmail.com #replace with real email")
+	test.AssertEquals(t, err.Error(), "\"john.smith@gmail.com #replace with real email\" is not a valid e-mail address")
+
+	err = ValidEmail("example@example.com")
+	test.AssertEquals(t, err.Error(), "invalid contact domain. Contact emails @example.com are forbidden")
+
+	err = ValidEmail("example@-foobar.com")
+	test.AssertEquals(t, err.Error(), "contact email \"example@-foobar.com\" has invalid domain : Domain name contains an invalid character")
+}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3680,13 +3680,6 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 	}
 }
 
-func TestValidateEmailError(t *testing.T) {
-	_, _, ra, _, cleanUp := initAuthorities(t)
-	defer cleanUp()
-	err := ra.validateEmail("(๑•́ ω •̀๑)")
-	test.AssertEquals(t, err.Error(), "\"(๑•́ ω •̀๑)\" is not a valid e-mail address")
-}
-
 type mockSAPreviousValidations struct {
 	mocks.StorageAuthority
 	existsDomain string

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -272,10 +272,6 @@ func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
 	return true
 }
 
-func (pa *mockPA) ValidDomain(_ string) error {
-	return nil
-}
-
 func makeBody(s string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(s))
 }


### PR DESCRIPTION
This required a refactoring: Move validateEmail from the RA to ValidEmail
in the `policy` package. I also moved `ValidDomain` from a method on
PolicyAuthority to a standalone function so that ValidEmail can call it.

notify-mailer will now log invalid addresses and skip them without
attempting to send mail. Since @example.com addresses are invalid,
I updated the notify-mailer test, which used a lot of such addresses.

Also, now when notify-mailer receives an unrecoverable error sending
mail, it logs the email address and what offset within the list it was.