### PR TITLE
Add x509.ExtKeyUsageClientAuth to intermediate certificate.

### DIFF
--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -282,7 +282,7 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 		cert.ExtraExtensions = append(cert.ExtraExtensions, ocspNoCheckExt)
 		cert.IsCA = false
 	} else if ct == intermediateCert {
-		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
 		cert.MaxPathLenZero = true
 	}
 

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -151,8 +151,9 @@ func TestMakeTemplate(t *testing.T) {
 	cert, err = makeTemplate(randReader, profile, pubKey, intermediateCert)
 	test.AssertNotError(t, err, "makeTemplate failed when everything worked as expected")
 	test.Assert(t, cert.MaxPathLenZero, "MaxPathLenZero not set in intermediate template")
-	test.AssertEquals(t, len(cert.ExtKeyUsage), 1)
-	test.AssertEquals(t, cert.ExtKeyUsage[0], x509.ExtKeyUsageServerAuth)
+	test.AssertEquals(t, len(cert.ExtKeyUsage), 2)
+	test.AssertEquals(t, cert.ExtKeyUsage[0], x509.ExtKeyUsageClientAuth)
+	test.AssertEquals(t, cert.ExtKeyUsage[1], x509.ExtKeyUsageServerAuth)
 }
 
 func TestMakeTemplateOCSP(t *testing.T) {


### PR DESCRIPTION
Fixes #4843
(This is the hard-coded option)