### PR TITLE
Setup issuance hierarchy in startservers.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - RUN="integration" BOULDER_CONFIG_DIR="test/config-next"
     - RUN="unit"
     - RUN="unit-next" BOULDER_CONFIG_DIR="test/config-next"
-    - RUN="start"
+    - RUN="start" BOULDER_CONFIG_DIR="test/config"
     # gomod-vendor runs with a separate container because it needs to fetch
     # packages from GitHub et. al., which is incompatible with the DNS server
     # override in the boulder container (used for service discovery).

--- a/start.py
+++ b/start.py
@@ -16,6 +16,9 @@ import time
 sys.path.append('./test')
 import startservers
 
+# Setup issuance hierarchy
+startservers.setupHierarchy()
+
 if not startservers.start(race_detection=False, fakeclock=None):
     sys.exit(1)
 try:

--- a/test.sh
+++ b/test.sh
@@ -107,7 +107,7 @@ fi
 # Test that just ./start.py works, which is a proxy for testing that
 # `docker-compose up` works, since that just runs start.py (via entrypoint.sh).
 if [[ "$RUN" =~ "start" ]] ; then
-  ./start.py &
+  python3 start.py &
   for I in $(seq 1 100); do
     sleep 1
     curl http://localhost:4000/directory && break

--- a/test.sh
+++ b/test.sh
@@ -101,12 +101,6 @@ if [[ "$RUN" =~ "integration" ]] ; then
     args+=("--filter" "${INT_FILTER}")
   fi
 
-  # We want to setup our 'HSM' before we get into the python part
-  # of the integration tests. To do this we need to build the ceremony
-  # binary, which is typically done in test/startservers.py.
-  GOBIN=$(pwd)/bin go install ./cmd/ceremony
-  go run test/cert-ceremonies/generate.go
-
   python3 test/integration-test.py --chisel --gotest "${args[@]}"
 fi
 
@@ -120,6 +114,7 @@ if [[ "$RUN" =~ "start" ]] ; then
   done
   if [[ $I = 100 ]]; then
     echo "Boulder did not come up after ./start.py."
+    exit 1
   fi
 fi
 

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -261,6 +261,9 @@ def main():
     if not (args.run_certbot or args.run_chisel or args.custom  or args.run_go is not None):
         raise(Exception("must run at least one of the letsencrypt or chisel tests with --certbot, --chisel, --gotest, or --custom"))
 
+    # Setup issuance hierarchy
+    startservers.setupHierarchy()
+
     if not args.test_case_filter:
         now = datetime.datetime.utcnow()
 

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -17,6 +17,13 @@ processes = []
 # to run the load-generator).
 challSrvProcess = None
 
+def setupHierarchy():
+    e = os.environ.copy()
+    e.setdefault("GOBIN", "%s/bin" % os.getcwd())
+    subprocess.call("go install ./cmd/ceremony", shell=True, env=e)
+    subprocess.call("go run test/cert-ceremonies/generate.go", shell=True, env=e)
+
+
 def install(race_detection):
     # Pass empty BUILD_TIME and BUILD_ID flags to avoid constantly invalidating the
     # build cache with new BUILD_TIMEs, or invalidating it on merges with a new


### PR DESCRIPTION
Once we de-dupe startservers.install calls we may want to move
setupHierarchy there, but for now we need to call it from
integration-test.py and start.py.

Fixes #4842