### PR TITLE
Shorten final certificate issuance log line.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -605,7 +605,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 		return emptyCert, err
 	}
 	certDER := block.Bytes
-	ca.log.AuditInfof("Signing success: serial=[%s] names=[%s] precertificate=[%s] certificate=[%s]",
+	ca.log.AuditInfof("Signing success: serial=[%s] names=[%s] certificate=[%s]",
 		serialHex, strings.Join(precert.DNSNames, ", "), hex.EncodeToString(req.DER),
 		hex.EncodeToString(certDER))
 	return ca.storeCertificate(ctx, *req.RegistrationID, *req.OrderID, precert.SerialNumber, certDER)


### PR DESCRIPTION
Previously, we logged both the precertificate and the final certificate
when the final certificate was signed. However, we already log the
precertificate body at precertificate issuance time, and we can conect
the two log lines by serial, so this was making the final certificate
log line unnecessarily long.