### PR TITLE
Limit request body size.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -57,6 +58,8 @@ const (
 	issuerPath      = "/acme/issuer-cert"
 	buildIDPath     = "/build"
 	rolloverPath    = "/acme/key-change"
+
+	maxRequestSize = 50000
 )
 
 // WebFrontEndImpl provides all the logic for Boulder's web-facing interface,
@@ -500,10 +503,14 @@ func (wfe *WebFrontEndImpl) verifyPOST(ctx context.Context, logEvent *web.Reques
 		return nil, nil, reg, probs.Malformed("No body on POST")
 	}
 
-	bodyBytes, err := ioutil.ReadAll(request.Body)
+	bodyBytes, err := ioutil.ReadAll(&io.LimitedReader{R: request.Body, N: maxRequestSize + 1})
 	if err != nil {
 		wfe.httpErrorCounter.WithLabelValues("UnableToReadReqBody").Inc()
 		return nil, nil, reg, probs.ServerInternal("unable to read request body")
+	}
+	if len(bodyBytes) > maxRequestSize {
+		wfe.httpErrorCounter.WithLabelValues("RequestBodyTooLong").Inc()
+		return nil, nil, reg, probs.Unauthorized("request body too long")
 	}
 
 	body := string(bodyBytes)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2191,6 +2191,18 @@ func TestLengthRequired(t *testing.T) {
 	test.AssertEquals(t, http.StatusLengthRequired, prob.HTTPStatus)
 }
 
+func TestRequestTooLong(t *testing.T) {
+	wfe, _ := setupWFE(t)
+	payload := fmt.Sprintf(`{"a":"%s"}`, strings.Repeat("a", 50000))
+
+	_, _, _, prob := wfe.verifyPOST(ctx, newRequestEvent(), makePostRequest(signRequest(t,
+		payload, wfe.nonceService)), false, "n/a")
+	test.Assert(t, prob != nil, "No error returned for too-long request body.")
+	test.AssertEquals(t, probs.UnauthorizedProblem, prob.Type)
+	test.AssertEquals(t, "request body too long", prob.Detail)
+	test.AssertEquals(t, http.StatusForbidden, prob.HTTPStatus)
+}
+
 type mockSAGetRegByKeyFails struct {
 	core.StorageGetter
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -2199,7 +2199,7 @@ func TestRequestTooLong(t *testing.T) {
 		payload, wfe.nonceService)), false, "n/a")
 	test.Assert(t, prob != nil, "No error returned for too-long request body.")
 	test.AssertEquals(t, probs.UnauthorizedProblem, prob.Type)
-	test.AssertEquals(t, "request body too long", prob.Detail)
+	test.AssertEquals(t, "request body too large", prob.Detail)
 	test.AssertEquals(t, http.StatusForbidden, prob.HTTPStatus)
 }
 

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -23,8 +24,12 @@ import (
 	"github.com/letsencrypt/boulder/web"
 )
 
-// POST requests with a JWS body must have the following Content-Type header
-const expectedJWSContentType = "application/jose+json"
+const (
+	// POST requests with a JWS body must have the following Content-Type header
+	expectedJWSContentType = "application/jose+json"
+
+	maxRequestSize = 50000
+)
 
 func sigAlgorithmForKey(key *jose.JSONWebKey) (jose.SignatureAlgorithm, error) {
 	switch k := key.Key.(type) {
@@ -349,10 +354,13 @@ func (wfe *WebFrontEndImpl) parseJWSRequest(request *http.Request) (*jose.JSONWe
 
 	// Read the POST request body's bytes. validPOSTRequest has already checked
 	// that the body is non-nil
-	bodyBytes, err := ioutil.ReadAll(request.Body)
+	bodyBytes, err := ioutil.ReadAll(&io.LimitedReader{R: request.Body, N: maxRequestSize + 1})
 	if err != nil {
 		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "UnableToReadReqBody"}).Inc()
 		return nil, probs.ServerInternal("unable to read request body")
+	}
+	if len(bodyBytes) > maxRequestSize {
+		return nil, probs.Unauthorized("request body too long")
 	}
 
 	jws, prob := wfe.parseJWS(bodyBytes)

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/letsencrypt/boulder/core"
@@ -880,6 +881,16 @@ func TestParseJWSRequest(t *testing.T) {
 			Name:            "Valid JWS in POST request",
 			Request:         validJWSRequest,
 			ExpectedProblem: nil,
+		},
+		{
+			Name: "POST body too long",
+			Request: makePostRequestWithPath("test-path",
+				fmt.Sprintf(`{"a":"%s"}`, strings.Repeat("a", 50000))),
+			ExpectedProblem: &probs.ProblemDetails{
+				Type:       probs.UnauthorizedProblem,
+				Detail:     "request body too long",
+				HTTPStatus: http.StatusForbidden,
+			},
 		},
 	}
 

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -883,12 +883,12 @@ func TestParseJWSRequest(t *testing.T) {
 			ExpectedProblem: nil,
 		},
 		{
-			Name: "POST body too long",
+			Name: "POST body too large",
 			Request: makePostRequestWithPath("test-path",
 				fmt.Sprintf(`{"a":"%s"}`, strings.Repeat("a", 50000))),
 			ExpectedProblem: &probs.ProblemDetails{
 				Type:       probs.UnauthorizedProblem,
-				Detail:     "request body too long",
+				Detail:     "request body too large",
 				HTTPStatus: http.StatusForbidden,
 			},
 		},


### PR DESCRIPTION
Normally we do this with a reverse proxy in front of Boulder, but it's
nice to have an additional layer of protection in case someone deploys
Boulder without a reverse proxy.

Fixes #4730.