### PR TITLE
Format top-level markdown docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,4 @@
 # Contributor Code of Conduct
 
-The contributor code of conduct is available for reference [on the community forum](https://community.letsencrypt.org/guidelines).
+The contributor code of conduct is available for reference [on the community
+forum](https://community.letsencrypt.org/guidelines).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,75 @@
-Thanks for helping us build Boulder! This page contains requirements and guidelines for Boulder contributions.
+Thanks for helping us build Boulder! This page contains requirements and
+guidelines for Boulder contributions.
 
 # Patch Requirements
+
 * All new functionality and fixed bugs must be accompanied by tests.
 * All patches must meet the deployability requirements listed below.
-* We prefer pull requests from external forks be created with the ["Allow edits from maintainers"](https://github.com/blog/2247-improving-collaboration-with-forks) checkbox selected.
+* We prefer pull requests from external forks be created with the ["Allow edits
+  from
+  maintainers"](https://github.com/blog/2247-improving-collaboration-with-forks)
+  checkbox selected.
 
 # Review Requirements
+
 * All pull requests must receive at least one approval through the GitHub UI.
 * We indicate review approval through GitHub's code review facility.
-* New commits pushed to a branch invalidate previous reviews. In other words, a reviewer must give positive reviews of a branch after its most recent pushed commit.
+* New commits pushed to a branch invalidate previous reviews. In other words, a
+  reviewer must give positive reviews of a branch after its most recent pushed
+  commit.
 * You cannot review your own code.
-* If a branch contains commits from multiple authors, it needs a reviewer who is not an author of commits on that branch.
-* If a branch contains updates to files in the vendor/ directory, the author is responsible for running tests in all updated dependencies, and commenting in the review thread that they have done so. Reviewers must not approve reviews that have changes in vendor/ but lack a comment about tests.
-* Review changes to or addition of tests just as rigorously as you review code changes. Consider: Do tests actually test what they mean to test? Is this the best way to test the functionality in question? Do the tests cover all the functionality in the patch, including error cases?
-* Are there new RPCs or config fields? Make sure the patch meets the Deployability rules below.
+* If a branch contains commits from multiple authors, it needs a reviewer who
+  is not an author of commits on that branch.
+* If a branch contains updates to files in the vendor/ directory, the author is
+  responsible for running tests in all updated dependencies, and commenting in
+  the review thread that they have done so. Reviewers must not approve reviews
+  that have changes in vendor/ but lack a comment about tests.
+* Review changes to or addition of tests just as rigorously as you review code
+  changes. Consider: Do tests actually test what they mean to test? Is this the
+  best way to test the functionality in question? Do the tests cover all the
+  functionality in the patch, including error cases?
+* Are there new RPCs or config fields? Make sure the patch meets the
+  Deployability rules below.
 
 # Patch Guidelines
-* Please include helpful comments. No need to gratuitously comment clear code, but make sure it's clear why things are being done.
-* Include information in your pull request about what you're trying to accomplish with your patch.
-* Avoid named return values. See [#3017](https://github.com/letsencrypt/boulder/pull/3017) for an example of a subtle problem they can cause.
-* Do not include `XXX`s or naked `TODO`s. Use the formats:
-```
-// TODO(<email-address>): Hoverboard + Time-machine unsupported until upstream patch.
-// TODO(#<num>): Pending hoverboard/time-machine interface.
-// TODO(@githubusername): Enable hoverboard kickflips once interface is stable.
-```
+
+* Please include helpful comments. No need to gratuitously comment clear code,
+  but make sure it's clear why things are being done. Include information in
+  your pull request about what you're trying to accomplish with your patch.
+* Avoid named return values. See
+  [#3017](https://github.com/letsencrypt/boulder/pull/3017) for an example of a
+* subtle problem they can cause. Do not include `XXX`s or naked `TODO`s. Use
+  the formats:
+
+  ```go
+  // TODO(<email-address>): Hoverboard + Time-machine unsupported until upstream patch.
+  // TODO(#<num>): Pending hoverboard/time-machine interface.
+  // TODO(@githubusername): Enable hoverboard kickflips once interface is stable.
+  ```
 
 # Squash merging
 
-Once a pull request is approved and the tests are passing, the author or any other committer can merge it. We always use [squash merges](https://github.com/blog/2141-squash-your-commits) via GitHub's web interface. That means that during the course of your review you should generally not squash or amend commits, or force push. Even if the changes in each commit are small, keeping them separate makes it easier for us to review incremental changes to a pull request. Rest assured that those tiny changes will get squashed into a nice meaningful-size commit when we merge.
+Once a pull request is approved and the tests are passing, the author or any
+other committer can merge it. We always use [squash
+merges](https://github.com/blog/2141-squash-your-commits) via GitHub's web
+interface. That means that during the course of your review you should
+generally not squash or amend commits, or force push. Even if the changes in
+each commit are small, keeping them separate makes it easier for us to review
+incremental changes to a pull request. Rest assured that those tiny changes
+will get squashed into a nice meaningful-size commit when we merge.
 
-If the Travis tests are failing on your branch, you should look at the logs to figure out why. Sometimes (though rarely) they fail spuriously, in which case you can post a comment requesting that a project owner kick the build.
+If the Travis tests are failing on your branch, you should look at the logs
+to figure out why. Sometimes (though rarely) they fail spuriously, in which
+case you can post a comment requesting that a project owner kick the build.
 
 # Error handling
 
 All errors must be addressed in some way: That may be simply by returning an
 error up the stack, or by handling it in some intelligent way where it is
-generated, or by explicitly ignoring it and assigning to `_`. We use the `errcheck`
-tool in our integration tests to make sure all errors are addressed. Note that
-ignoring errors, even in tests, should be rare, since they may generate
-hard-to-debug problems.
+generated, or by explicitly ignoring it and assigning to `_`. We use the
+`errcheck` tool in our integration tests to make sure all errors are
+addressed. Note that ignoring errors, even in tests, should be rare, since
+they may generate hard-to-debug problems.
 
 We define two special types of error. `BoulderError`, defined in
 errors/errors.go, is used specifically when an typed error needs to be passed
@@ -69,23 +99,44 @@ not necessary to separately call `.AddError`.
 
 # Deployability
 
-We want to ensure that a new Boulder revision can be deployed to the currently running Boulder production instance without requiring config changes first. We also want to ensure that during a deploy, services can be restarted in any order. That means two things:
+We want to ensure that a new Boulder revision can be deployed to the
+currently running Boulder production instance without requiring config
+changes first. We also want to ensure that during a deploy, services can be
+restarted in any order. That means two things:
 
 ## Good zero values for config fields
 
-Any newly added config field must have a usable [zero value](https://tour.golang.org/basics/12). That is to say, if a config field is absent, Boulder shouldn't crash or misbehave. If that config file names a file to be read, Boulder should be able to proceed without that file being read.
+Any newly added config field must have a usable [zero
+value](https://tour.golang.org/basics/12). That is to say, if a config field
+is absent, Boulder shouldn't crash or misbehave. If that config file names a
+file to be read, Boulder should be able to proceed without that file being
+read.
 
-Note that there are some config fields that we want to be a hard requirement. To handle such a field, first add it as optional, then file an issue to make it required after the next deploy is complete.
+Note that there are some config fields that we want to be a hard requirement.
+To handle such a field, first add it as optional, then file an issue to make
+it required after the next deploy is complete.
 
-In general, we would like our deploy process to be: deploy new code + old config; then immediately after deploy the same code + new config. This makes deploys cheaper so we can do them more often, and allows us to more readily separate deploy-triggered problems from config-triggered problems.
+In general, we would like our deploy process to be: deploy new code + old
+config; then immediately after deploy the same code + new config. This makes
+deploys cheaper so we can do them more often, and allows us to more readily
+separate deploy-triggered problems from config-triggered problems.
 
 ## Flag-gating features
 
-When adding significant new features or replacing existing RPCs the `boulder/features` package should be used to gate its usage. To add a flag a new `const FeatureFlag` should be added and its default value specified in `features.features` in `features/features.go`. In order to test if the flag is enabled elsewhere in the codebase you can use `features.Enabled(features.ExampleFeatureName)` which returns a `bool` indicating if the flag is enabled or not.
+When adding significant new features or replacing existing RPCs the
+`boulder/features` package should be used to gate its usage. To add a flag a
+new `const FeatureFlag` should be added and its default value specified in
+`features.features` in `features/features.go`. In order to test if the flag
+is enabled elsewhere in the codebase you can use
+`features.Enabled(features.ExampleFeatureName)` which returns a `bool`
+indicating if the flag is enabled or not.
 
-Each service should include a `map[string]bool` named `Features` in its configuration object at the top level and call `features.Set` with that map immediately after parsing the configuration. For example to enable `UseNewMetrics` and disable `AccountRevocation` you would add this object:
+Each service should include a `map[string]bool` named `Features` in its
+configuration object at the top level and call `features.Set` with that map
+immediately after parsing the configuration. For example to enable
+`UseNewMetrics` and disable `AccountRevocation` you would add this object:
 
-```
+```json
 {
     ...
     "features": {
@@ -95,56 +146,67 @@ Each service should include a `map[string]bool` named `Features` in its configur
 }
 ```
 
-Feature flags are meant to be used temporarily and should not be used for permanent boolean configuration options. Once a feature has been enabled in both staging and production the flag should be removed making the previously gated functionality the default in future deployments.
+Feature flags are meant to be used temporarily and should not be used for
+permanent boolean configuration options. Once a feature has been enabled in
+both staging and production the flag should be removed making the previously
+gated functionality the default in future deployments.
 
 ### Gating RPCs
 
-When you add a new RPC to a Boulder service (e.g. `SA.GetFoo()`), all components that call that RPC should gate those calls using a feature flag. Since the feature's zero value is false, a deploy with the existing config will not call `SA.GetFoo()`. Then, once the deploy is complete and we know that all SA instances support the `GetFoo()` RPC, we do a followup config deploy that sets the default value to true, and finally remove the flag entirely once we are confident the functionality it gates behaves correctly.
+When you add a new RPC to a Boulder service (e.g. `SA.GetFoo()`), all
+components that call that RPC should gate those calls using a feature flag.
+Since the feature's zero value is false, a deploy with the existing config
+will not call `SA.GetFoo()`. Then, once the deploy is complete and we know
+that all SA instances support the `GetFoo()` RPC, we do a followup config
+deploy that sets the default value to true, and finally remove the flag
+entirely once we are confident the functionality it gates behaves correctly.
 
 ### Gating migrations
 
 We use [database migrations](https://en.wikipedia.org/wiki/Schema_migration)
-to modify the existing schema. These migrations will be run on live
-data while Boulder is still running, so we need Boulder code at any given commit to
-be capable of running without depending on any changes in schemas that have not
-yet been applied.
+to modify the existing schema. These migrations will be run on live data
+while Boulder is still running, so we need Boulder code at any given commit
+to be capable of running without depending on any changes in schemas that
+have not yet been applied.
 
 For instance, if we're adding a new column to an existing table, Boulder should
 run correctly in three states:
- 1. Migration not yet applied.
- 2. Migration applied, flag not yet flipped.
- 3. Migration applied, flag flipped.
+
+1. Migration not yet applied.
+2. Migration applied, flag not yet flipped.
+3. Migration applied, flag flipped.
 
 Specifically, that means that all of our `SELECT` statements should enumerate
 columns to select, and not use `*`. Also, generally speaking, we will need a
-separate model `struct` for serializing and deserializing data before and after the
-migration. This is because the ORM package we use,
+separate model `struct` for serializing and deserializing data before and
+after the migration. This is because the ORM package we use,
 [`gorp`](https://github.com/go-gorp/gorp), expects every field in a struct to
 map to a column in the table. If we add a new field to a model struct and
 Boulder attempts to write that struct to a table that doesn't yet have the
-corresponding column (case 1), gorp will fail with
-`Insert failed table posts has no column named Foo`.
-There are examples of such models in sa/model.go, along with code to
-turn a model into a `struct` used internally. 
+corresponding column (case 1), gorp will fail with `Insert failed table posts
+has no column named Foo`. There are examples of such models in sa/model.go,
+along with code to turn a model into a `struct` used internally.
 
 An example of a flag-gated migration, adding a new `IsWizard` field to Person
 controlled by a `AllowWizards` feature flag:
 
-```
+```go
 # features/features.go:
 
 const (
-	unused FeatureFlag = iota // unused is used for testing
-	AllowWizards // Added!
+  unused FeatureFlag = iota // unused is used for testing
+  AllowWizards // Added!
 )
 
 ...
 
 var features = map[FeatureFlag]bool{
-	unused: false,
-	AllowWizards: false, // Added!
+  unused: false,
+  AllowWizards: false, // Added!
 }
+```
 
+```go
 # sa/sa.go:
 
 struct Person {
@@ -203,7 +265,7 @@ any given time, otherwise Gorp will error.  Depending on your table you may also
 need to add `SetKeys` and `SetVersionCol` entries for your versioned models.
 Example:
 
-```
+```go
 func initTables(dbMap *gorp.DbMap) {
  // < unrelated lines snipped for brevity >
 
@@ -219,9 +281,10 @@ You can then add a migration with:
 
 `$ goose -path ./sa/_db/ create AddWizards sql`
 
-Finally, edit the resulting file (`sa/_db/migrations/20160915101011_AddWizards.sql`) to define your migration:
+Finally, edit the resulting file
+(`sa/_db/migrations/20160915101011_AddWizards.sql`) to define your migration:
 
-```
+```mysql
 -- +goose Up
 ALTER TABLE people ADD isWizard BOOLEAN SET DEFAULT false;
 
@@ -260,7 +323,11 @@ To add a dependency, add the import statement to your .go file, then run
 `go build` on it. This will automatically add the dependency to go.mod. Next,
 run `go mod vendor` to save a copy in the vendor folder.
 
-When vendorizing dependencies, it's important to make sure tests pass on the version you are vendorizing. Currently we enforce this by requiring that pull requests containing a dependency update include a comment indicating that you ran the tests and that they succeeded, preferably with the command line you run them with.
+When vendorizing dependencies, it's important to make sure tests pass on the
+version you are vendorizing. Currently we enforce this by requiring that pull
+requests containing a dependency update include a comment indicating that you
+ran the tests and that they succeeded, preferably with the command line you
+run them with.
 
 ## Updating Dependencies
 
@@ -288,19 +355,22 @@ repository for a refactoring to reduce the number of transitive dependencies.
 
 The [Boulder development
 environment](https://github.com/letsencrypt/boulder/blob/master/README.md#setting-up-boulder)
-does not use the Go version installed on the host machine, and instead uses a Go
-environment baked into a "boulder-tools" Docker image. We build a separate
+does not use the Go version installed on the host machine, and instead uses a
+Go environment baked into a "boulder-tools" Docker image. We build a separate
 boulder-tools container for each supported Go version. Please see [the
-Boulder-tools README](https://github.com/letsencrypt/boulder/blob/master/test/boulder-tools/README.md)
+Boulder-tools
+README](https://github.com/letsencrypt/boulder/blob/master/test/boulder-tools/README.md)
 for more information on upgrading Go versions.
 
 # ACME Protocol Divergences
 
 While Boulder attempts to implement the ACME specification as strictly as
 possible there are places at which we will diverge from the letter of the
-specification for various reasons. We detail these divergences (for both the V1
-and V2 API) in the [ACME divergences doc](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md).
+specification for various reasons. We detail these divergences (for both the
+V1 and V2 API) in the [ACME divergences
+doc](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md).
 
 ## Problems or questions?
 
-The best place to ask dev related questions is on the [Community Forums](https://community.letsencrypt.org/).
+The best place to ask dev related questions is on the [Community
+Forums](https://community.letsencrypt.org/).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 [![Build Status](https://travis-ci.com/letsencrypt/boulder.svg?branch=master)](https://travis-ci.com/letsencrypt/boulder)
 [![Coverage Status](https://coveralls.io/repos/github/letsencrypt/boulder/badge.svg?branch=master)](https://coveralls.io/github/letsencrypt/boulder?branch=master)
 
-This is an implementation of an ACME-based CA. The [ACME protocol](https://github.com/ietf-wg-acme/acme/) allows the CA to automatically verify that an applicant for a certificate actually controls an identifier, and allows domain holders to issue and revoke certificates for their domains. Boulder is the software that runs [Let's Encrypt](https://letsencrypt.org).
+This is an implementation of an ACME-based CA. The [ACME
+protocol](https://github.com/ietf-wg-acme/acme/) allows the CA to
+automatically verify that an applicant for a certificate actually controls an
+identifier, and allows domain holders to issue and revoke certificates for
+their domains. Boulder is the software that runs [Let's
+Encrypt](https://letsencrypt.org).
 
 ## Contents
 
@@ -29,9 +34,16 @@ Boulder is divided into the following main components:
 7. OCSP Updater
 8. OCSP Responder
 
-This component model lets us separate the function of the CA by security context.  The Web Front End, Validation Authority, OCSP Responder and Publisher need access to the Internet, which puts them at greater risk of compromise.  The Registration Authority can live without Internet connectivity, but still needs to talk to the Web Front End and Validation Authority.  The Certificate Authority need only receive instructions from the Registration Authority. All components talk to the SA for storage, so most lines indicating SA RPCs are not shown here.
+This component model lets us separate the function of the CA by security
+context. The Web Front End, Validation Authority, OCSP Responder and
+Publisher need access to the Internet, which puts them at greater risk of
+compromise. The Registration Authority can live without Internet
+connectivity, but still needs to talk to the Web Front End and Validation
+Authority. The Certificate Authority need only receive instructions from the
+Registration Authority. All components talk to the SA for storage, so most
+lines indicating SA RPCs are not shown here.
 
-```
+```text
                              +--------- OCSP Updater
                              |               |
                              v               |
@@ -46,77 +58,154 @@ Subscriber server <- VA <----+               |
 
 ```
 
-Internally, the logic of the system is based around five types of objects: accounts, authorizations, challenges, orders (for ACME v2) and certificates, mapping directly to the resources of the same name in ACME.
+Internally, the logic of the system is based around five types of objects:
+accounts, authorizations, challenges, orders (for ACME v2) and certificates,
+mapping directly to the resources of the same name in ACME.
 
-We run two Web Front Ends, one for each ACME API version. Only the front end components differentiate between API version. Requests from ACME clients result in new objects and changes to objects.  The Storage Authority maintains persistent copies of the current set of objects.
+We run two Web Front Ends, one for each ACME API version. Only the front end
+components differentiate between API version. Requests from ACME clients
+result in new objects and changes to objects. The Storage Authority maintains
+persistent copies of the current set of objects.
 
-Objects are also passed from one component to another on change events.  For example, when a client provides a successful response to a validation challenge, it results in a change to the corresponding validation object.  The Validation Authority forwards the new validation object to the Storage Authority for storage, and to the Registration Authority for any updates to a related Authorization object.
+Objects are also passed from one component to another on change events. For
+example, when a client provides a successful response to a validation
+challenge, it results in a change to the corresponding validation object. The
+Validation Authority forwards the new validation object to the Storage
+Authority for storage, and to the Registration Authority for any updates to a
+related Authorization object.
 
-Boulder uses gRPC for inter-component communication.  For components that you want to be remote, it is necessary to instantiate a "client" and "server" for that component.  The client implements the component's Go interface, while the server has the actual logic for the component. A high level overview for this communication model can be found in the [gRPC documentation](http://www.grpc.io/docs/).
+Boulder uses gRPC for inter-component communication. For components that you
+want to be remote, it is necessary to instantiate a "client" and "server" for
+that component. The client implements the component's Go interface, while the
+server has the actual logic for the component. A high level overview for this
+communication model can be found in the [gRPC
+documentation](http://www.grpc.io/docs/).
 
-The full details of how the various ACME operations happen in Boulder are laid out in [DESIGN.md](https://github.com/letsencrypt/boulder/blob/master/docs/DESIGN.md).
+The full details of how the various ACME operations happen in Boulder are
+laid out in
+[DESIGN.md](https://github.com/letsencrypt/boulder/blob/master/docs/DESIGN.md).
 
 ## Setting up Boulder
 
 ### Development
 
-Boulder has a Dockerfile and uses Docker Compose to make it easy to install and set up all its dependencies. This is how the maintainers work on Boulder, and is our main recommended way to run it for development/experimentation. It is not suitable for use as a production environment.
+Boulder has a Dockerfile and uses Docker Compose to make it easy to install
+and set up all its dependencies. This is how the maintainers work on Boulder,
+and is our main recommended way to run it for development/experimentation. It
+is not suitable for use as a production environment.
 
-While we aim to make Boulder easy to setup ACME client developers may find [Pebble](https://github.com/letsencrypt/pebble), a miniature version of Boulder, to be better suited for continuous integration and quick experimentation.
+While we aim to make Boulder easy to setup ACME client developers may find
+[Pebble](https://github.com/letsencrypt/pebble), a miniature version of
+Boulder, to be better suited for continuous integration and quick
+experimentation.
 
-We recommend setting git's [fsckObjects setting](https://groups.google.com/forum/#!topic/binary-transparency/f-BI4o8HZW0/discussion) before getting a copy of Boulder to have better integrity guarantees for updates.
+We recommend setting git's [fsckObjects
+setting](https://groups.google.com/forum/#!topic/binary-transparency/f-BI4o8HZW0/discussion)
+before getting a copy of Boulder to have better integrity guarantees for
+updates.
 
-Make sure you have a local copy of Boulder in your [`$GOPATH`](https://golang.org/doc/code.html#GOPATH), and that you are in that directory:
+Make sure you have a local copy of Boulder in your
+[`$GOPATH`](https://golang.org/doc/code.html#GOPATH), and that you are in
+that directory:
 
-    export GOPATH=~/gopath
-    git clone https://github.com/letsencrypt/boulder/ $GOPATH/src/github.com/letsencrypt/boulder
-    cd $GOPATH/src/github.com/letsencrypt/boulder
+```shell
+export GOPATH=~/gopath
+git clone https://github.com/letsencrypt/boulder/ $GOPATH/src/github.com/letsencrypt/boulder
+cd $GOPATH/src/github.com/letsencrypt/boulder
+```
 
-Additionally, make sure you have Docker Engine 1.13.0+ and Docker Compose 1.10.0+ installed. If you do not, you can follow Docker's [installation instructions](https://docs.docker.com/compose/install/).
+Additionally, make sure you have Docker Engine 1.13.0+ and Docker Compose
+1.10.0+ installed. If you do not, you can follow Docker's [installation
+instructions](https://docs.docker.com/compose/install/).
 
-We recommend having **at least 2GB of RAM** available on your Docker host. In practice using less RAM may result in the MariaDB container failing in non-obvious ways.
+We recommend having **at least 2GB of RAM** available on your Docker host. In
+practice using less RAM may result in the MariaDB container failing in
+non-obvious ways.
 
 To start Boulder in a Docker container, run:
 
-    docker-compose up
+```shell
+docker-compose up
+```
 
 To run tests:
 
-    docker-compose run --use-aliases boulder ./test.sh
+```shell
+docker-compose run --use-aliases boulder ./test.sh
+```
 
 To run a specific unittest:
 
-    docker-compose run --use-aliases boulder go test ./ra
+```shell
+docker-compose run --use-aliases boulder go test ./ra
+```
 
-The configuration in docker-compose.yml mounts your `$GOPATH` on top of its own `$GOPATH` so you can edit code on your host and it will be immediately reflected inside the Docker containers run with docker-compose.
+The configuration in docker-compose.yml mounts your `$GOPATH` on top of its
+own `$GOPATH` so you can edit code on your host and it will be immediately
+reflected inside the Docker containers run with docker-compose.
 
-If docker-compose fails with an error message like "Cannot start service boulder: oci runtime error: no such file or directory" or "Cannot create container for service boulder" you should double check that your `$GOPATH` exists and doesn't contain any characters other than letters, numbers, `-` and `_`, and that it doesn't contain any dangling symlinks.
+If docker-compose fails with an error message like "Cannot start service
+boulder: oci runtime error: no such file or directory" or "Cannot create
+container for service boulder" you should double check that your `$GOPATH`
+exists and doesn't contain any characters other than letters, numbers, `-`
+and `_`, and that it doesn't contain any dangling symlinks.
 
-If you have problems with Docker, you may want to try [removing all containers and volumes](https://www.digitalocean.com/community/tutorials/how-to-remove-docker-images-containers-and-volumes).
+If you have problems with Docker, you may want to try [removing all
+containers and
+volumes](https://www.digitalocean.com/community/tutorials/how-to-remove-docker-images-containers-and-volumes).
 
-By default, Boulder uses a fake DNS resolver that resolves all hostnames to 127.0.0.1. This is suitable for running integration tests inside the Docker container. If you want Boulder to be able to communicate with a client running on your host instead, you should find your host's Docker IP with:
+By default, Boulder uses a fake DNS resolver that resolves all hostnames to
+127.0.0.1. This is suitable for running integration tests inside the Docker
+container. If you want Boulder to be able to communicate with a client
+running on your host instead, you should find your host's Docker IP with:
 
-    ifconfig docker0 | grep "inet addr:" | cut -d: -f2 | awk '{ print $1}'
+```shell
+ifconfig docker0 | grep "inet addr:" | cut -d: -f2 | awk '{ print $1}'
+```
 
-And edit docker-compose.yml to change the `FAKE_DNS` environment variable to match. This will cause Boulder's stubbed-out DNS resolver (`sd-test-srv`) to respond to all A queries with the address in `FAKE_DNS`.
+And edit docker-compose.yml to change the `FAKE_DNS` environment variable to
+match. This will cause Boulder's stubbed-out DNS resolver (`sd-test-srv`) to
+respond to all A queries with the address in `FAKE_DNS`.
 
-Alternatively, you can override the docker-compose.yml default with an environmental variable using -e (replace 172.17.0.1 with the host IPv4 address found in the command above)
+Alternatively, you can override the docker-compose.yml default with an
+environmental variable using -e (replace 172.17.0.1 with the host IPv4
+address found in the command above)
 
-    docker-compose run --use-aliases -e FAKE_DNS=172.17.0.1 --service-ports boulder ./start.py
+```shell
+docker-compose run --use-aliases -e FAKE_DNS=172.17.0.1 --service-ports boulder ./start.py
+```
 
-Boulder's default VA configuration (`test/config/va.json`) is configured to connect to port 5002 to validate HTTP-01 challenges and port 5001 to validate TLS-ALPN-01 challenges. If you want to solve challenges with a client running on your host you should make sure it uses these ports to respond to validation requests, or update the VA configuration's `portConfig` to use ports 80 and 443 to match how the VA operates in production and staging environments. If you use a host-based firewall (e.g. `ufw` or `iptables`) make sure you allow connections from the Docker instance to your host on the required ports.
-
+Boulder's default VA configuration (`test/config/va.json`) is configured to
+connect to port 5002 to validate HTTP-01 challenges and port 5001 to validate
+TLS-ALPN-01 challenges. If you want to solve challenges with a client running
+on your host you should make sure it uses these ports to respond to
+validation requests, or update the VA configuration's `portConfig` to use
+ports 80 and 443 to match how the VA operates in production and staging
+environments. If you use a host-based firewall (e.g. `ufw` or `iptables`)
+make sure you allow connections from the Docker instance to your host on the
+required ports.
 
 ### Working with Certbot
 
-Check out the Certbot client from https://github.com/certbot/certbot and follow their setup instructions. Once you've got the client set up, you'll probably want to run it against your local Boulder. There are a number of command line flags that are necessary to run the client against a local Boulder, and without root access. The simplest way to run the client locally is to use a convenient alias for certbot (`certbot_test`) with a custom `SERVER` environment variable:
+Check out the Certbot client from https://github.com/certbot/certbot and
+follow their setup instructions. Once you've got the client set up, you'll
+probably want to run it against your local Boulder. There are a number of
+command line flags that are necessary to run the client against a local
+Boulder, and without root access. The simplest way to run the client locally
+is to use a convenient alias for certbot (`certbot_test`) with a custom
+`SERVER` environment variable:
 
-    SERVER=http://localhost:4001/directory certbot_test certonly --standalone -d test.example.com
+```shell
+SERVER=http://localhost:4001/directory certbot_test certonly --standalone -d test.example.com
+```
 
-Your local Boulder instance uses a fake DNS resolver that returns 127.0.0.1 for any query, so you can use any value for the -d flag. To return an answer other than `127.0.0.1` change the Boulder `FAKE_DNS` environment variable to another IP address.
+Your local Boulder instance uses a fake DNS resolver that returns 127.0.0.1
+for any query, so you can use any value for the -d flag. To return an answer
+other than `127.0.0.1` change the Boulder `FAKE_DNS` environment variable to
+another IP address.
 
-To use the legacy ACME v1 API over change `SERVER` to `http://localhost:4000/directory`.
-
+To use the legacy ACME v1 API over change `SERVER` to
+`http://localhost:4000/directory`.
 
 ### Working with another ACME Client
 
@@ -129,11 +218,22 @@ the following URLs:
 * ACME v1, HTTPS: `https://localhost:4430/directory`
 * ACME v2, HTTPS: `https://localhost:4431/directory`
 
-To access the HTTPS versions of the endpoints you will need to configure your ACME client software to use a CA truststore that contains the `test/wfe-tls/minica.pem` CA certificate. See [`test/PKI.md`](https://github.com/letsencrypt/boulder/blob/master/test/PKI.md) for more information.
+To access the HTTPS versions of the endpoints you will need to configure your
+ACME client software to use a CA truststore that contains the
+`test/wfe-tls/minica.pem` CA certificate. See
+[`test/PKI.md`](https://github.com/letsencrypt/boulder/blob/master/test/PKI.md)
+for more information.
 
-Your local Boulder instance uses a fake DNS resolver that returns 127.0.0.1 for any query, allowing you to issue certificates for any domain as if it resolved to your localhost. To return an answer other than `127.0.0.1` change the Boulder `FAKE_DNS` environment variable to another IP address.
+Your local Boulder instance uses a fake DNS resolver that returns 127.0.0.1
+for any query, allowing you to issue certificates for any domain as if it
+resolved to your localhost. To return an answer other than `127.0.0.1` change
+the Boulder `FAKE_DNS` environment variable to another IP address.
 
-Most often you will want to configure `FAKE_DNS` to point to your host machine where you run an ACME client. Remember to also configure the ACME client to use ports 5002 and 5001 instead of 80 and 443 for HTTP-01 and TLS-ALPN-01 challenge servers (or customize the Boulder VA configuration to match your port choices).
+Most often you will want to configure `FAKE_DNS` to point to your host
+machine where you run an ACME client. Remember to also configure the ACME
+client to use ports 5002 and 5001 instead of 80 and 443 for HTTP-01 and
+TLS-ALPN-01 challenge servers (or customize the Boulder VA configuration to
+match your port choices).
 
 ### Production
 
@@ -148,7 +248,8 @@ other than Boulder.
 We offer a brief [deployment and implementation
 guide](https://github.com/letsencrypt/boulder/wiki/Deployment-&-Implementation-Guide)
 that describes some of the required work and security considerations involved in
-using Boulder in a production environment. As-is the docker based Boulder development environment is **not suitable for
+using Boulder in a production environment. As-is the docker based Boulder
+development environment is **not suitable for
 production usage**. It uses private key material that is publicly available,
 exposes debug ports and is brittle to component failure.
 
@@ -168,4 +269,7 @@ and various other tips related to working on the codebase.
 
 ## License
 
-This project is licensed under the Mozilla Public License 2.0, the full text of which can be found in the [LICENSE.txt](https://github.com/letsencrypt/boulder/blob/master/LICENSE.txt) file.
+This project is licensed under the Mozilla Public License 2.0, the full text
+of which can be found in the
+[LICENSE.txt](https://github.com/letsencrypt/boulder/blob/master/LICENSE.txt)
+file.


### PR DESCRIPTION
This change brings the three top-level markdown documents (README,
CONTRIBUTING, and CODE_OF_CONDUCT) in line with standard markdown
formatting and styling, as informed by
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md

Primarily, it:
* Hard-wraps long lines to be 80 characters or less, except for
  long URLs and code blocks;
* Uniformly wraps all code blocks in triple-backticks, and supplies
  language information for syntax highlighting; and
* Makes a few other small tweaks.