### PR TITLE
Restore BlockedKeyTable to map of flag values.

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -84,6 +84,7 @@ var features = map[FeatureFlag]bool{
 	StoreRevokerInfo:              false,
 	RestrictRSAKeySizes:           false,
 	FasterNewOrdersRateLimit:      false,
+	BlockedKeyTable:               false,
 }
 
 var fMu = new(sync.RWMutex)


### PR DESCRIPTION
Without this, loading a config that has the BlockedKeyTable feature flag
will error out.