### PR TITLE
Add -expect-reason flag to checkocsp

### DIFF
--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -39,7 +39,8 @@ func TestPrecertificateOCSP(t *testing.T) {
 		t.Fatalf("couldn't find rejected precert for %q", domain)
 	}
 
-	_, err = ocsp_helper.ReqDER(cert.Raw, ocsp.Good)
+	ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
+	_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 	if err != nil {
 		t.Errorf("requesting OCSP for rejected precertificate: %s", err)
 	}

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -123,7 +123,7 @@ func TestPrecertificateRevocation(t *testing.T) {
 
 			// To start with the precertificate should have a Good OCSP response.
 			ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
-			_, err = ocsp_helper.ReqDER(cert.Raw, oscpConfig)
+			_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 			test.AssertNotError(t, err, "requesting OCSP for precert")
 
 			// Revoke the precertificate using the specified key and client
@@ -136,7 +136,7 @@ func TestPrecertificateRevocation(t *testing.T) {
 
 			// Check the OCSP response for the precertificate again. It should now be
 			// revoked.
-			ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked)
+			ocspConfig = ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked)
 			_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 			test.AssertNotError(t, err, "requesting OCSP for revoked precert")
 		})

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -122,7 +122,8 @@ func TestPrecertificateRevocation(t *testing.T) {
 			}
 
 			// To start with the precertificate should have a Good OCSP response.
-			_, err = ocsp_helper.ReqDER(cert.Raw, ocsp.Good)
+			ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
+			_, err = ocsp_helper.ReqDER(cert.Raw, oscpConfig)
 			test.AssertNotError(t, err, "requesting OCSP for precert")
 
 			// Revoke the precertificate using the specified key and client
@@ -135,7 +136,8 @@ func TestPrecertificateRevocation(t *testing.T) {
 
 			// Check the OCSP response for the precertificate again. It should now be
 			// revoked.
-			_, err = ocsp_helper.ReqDER(cert.Raw, ocsp.Revoked)
+			ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked)
+			_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 			test.AssertNotError(t, err, "requesting OCSP for revoked precert")
 		})
 	}
@@ -173,7 +175,8 @@ func TestRevokeWithKeyCompromise(t *testing.T) {
 	test.AssertEquals(t, err.Error(), `acme: error code 400 "urn:ietf:params:acme:error:badPublicKey": public key is forbidden`)
 
 	// Check the OCSP response. It should be revoked with reason = 1 (keyCompromise)
-	response, err := ocsp_helper.ReqDER(cert.Raw, ocsp.Revoked)
+	ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked)
+	response, err := ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 	test.AssertNotError(t, err, "requesting OCSP for revoked cert")
 	test.AssertEquals(t, response.RevocationReason, 1)
 }
@@ -218,12 +221,13 @@ func TestBadKeyRevoker(t *testing.T) {
 		ocsp.KeyCompromise,
 	)
 	test.AssertNotError(t, err, "failed to revoke certificate")
-	_, err = ocsp_helper.ReqDER(badCert.certs[0].Raw, ocsp.Revoked)
+	ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked)
+	_, err = ocsp_helper.ReqDER(badCert.certs[0].Raw, ocspConfig)
 	test.AssertNotError(t, err, "ReqDER failed")
 
 	for _, cert := range certs {
 		for i := 0; i < 5; i++ {
-			_, err = ocsp_helper.ReqDER(cert.Raw, ocsp.Revoked)
+			_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 			if err == nil {
 				break
 			}

--- a/test/ocsp/checkocsp/checkocsp.go
+++ b/test/ocsp/checkocsp/checkocsp.go
@@ -30,7 +30,7 @@ stale.
 		os.Exit(0)
 	}
 	for _, f := range flag.Args() {
-		_, err := helper.Req(f)
+		_, err := helper.Req(f, helper.ConfigFromFlags())
 		if err != nil {
 			log.Printf("error for %s: %s\n", f, err)
 			errors = true

--- a/test/ocsp/checkocsp/checkocsp.go
+++ b/test/ocsp/checkocsp/checkocsp.go
@@ -12,11 +12,13 @@ import (
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `
-OCSP-checking tool. Provide a list of filenames for certificates in PEM format, and
-this tool will check OCSP for each certificate based on the AIA field in the
-certificates. It will return an error if the OCSP server fails to respond for
-any request, if any response is invalid or has a bad signature, or if any
-response is too stale.
+checkocsp [OPTION]... FILE [FILE]...
+
+OCSP-checking tool. Provide a list of filenames for certificates in PEM format,
+and this tool will check OCSP for each certificate based on its AIA field.
+It will return an error if the OCSP server fails to respond for any request,
+if any response is invalid or has a bad signature, or if any response is too
+stale.
 
 `)
 		flag.PrintDefaults()

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -250,10 +250,8 @@ func parseAndPrint(respBytes []byte, cert, issuer *x509.Certificate, expectStatu
 	if resp.Status != expectStatus {
 		return nil, fmt.Errorf("wrong CertStatus %d, expected %d", resp.Status, expectStatus)
 	}
-	if isFlagSet("expect-reason") {
-		if resp.RevocationReason != *expectReason {
-			return nil, fmt.Errorf("wrong RevocationReason %d, expected %d", resp.RevocationReason, *expectReason)
-		}
+	if resp.RevocationReason != *expectReason && isFlagSet("expect-reason") {
+		return nil, fmt.Errorf("wrong RevocationReason %d, expected %d", resp.RevocationReason, *expectReason)
 	}
 	timeTilExpiry := time.Until(resp.NextUpdate)
 	tooSoonDuration := time.Duration(*tooSoon) * time.Hour

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -51,23 +51,23 @@ var DefaultConfig = Config{
 	expectReason:       *expectReason,
 }
 
-var configFromFlagsMemo sync.Once
+var parseFlagsOnce sync.Once
 
 // ConfigFromFlags returns a Config whose values are populated from
 // any command line flags passed by the user, or default values if not passed.
 func ConfigFromFlags() Config {
-	return configFromFlagsMemo.Do(func() {
+	parseFlagsOnce.Do(func() {
 		flag.Parse()
-		return Config{
-			method:             *method,
-			urlOverride:        *urlOverride,
-			hostOverride:       *hostOverride,
-			tooSoon:            *tooSoon,
-			ignoreExpiredCerts: *ignoreExpiredCerts,
-			expectStatus:       *expectStatus,
-			expectReason:       *expectReason,
-		}
 	})
+	return Config{
+		method:             *method,
+		urlOverride:        *urlOverride,
+		hostOverride:       *hostOverride,
+		tooSoon:            *tooSoon,
+		ignoreExpiredCerts: *ignoreExpiredCerts,
+		expectStatus:       *expectStatus,
+		expectReason:       *expectReason,
+	}
 }
 
 // WithExpectStatus returns a new Config with the given expectStatus,

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -58,6 +58,15 @@ var isConfigPopulated bool = false
 func ConfigFromFlags() Config {
 	if !isConfigPopulated {
 		flag.Parse()
+		configFromFlags = Config{
+			method:             *method,
+			urlOverride:        *urlOverride,
+			hostOverride:       *hostOverride,
+			tooSoon:            *tooSoon,
+			ignoreExpiredCerts: *ignoreExpiredCerts,
+			expectStatus:       *expectStatus,
+			expectReason:       *expectReason,
+		}
 		isConfigPopulated = true
 	}
 	ret := configFromFlags

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -48,7 +48,12 @@ func init() {
 	flag.BoolVar(&DefaultConfig.ignoreExpiredCerts, "ignore-expired-certs", false, "If a cert is expired, don't bother requesting OCSP.")
 	flag.IntVar(&DefaultConfig.expectStatus, "expect-status", -1, "Expect response to have this numeric status (0=Good, 1=Revoked, 2=Unknown)")
 	flag.IntVar(&DefaultConfig.expectReason, "expect-reason", -1, "Expect response to have this numeric revocation reason (0=Unspecified, 1=KeyCompromise, etc.)")
-	flag.Parse()
+	// Note that this init() does *not* call flag.Parse(). If a binary imports
+	// multiple libraries which all declare flags, all of those declarations
+	// need to happen before any flags are parsed (or else early parses will
+	// fail to recognize supplied flags that haven't been declared yet). Make
+	// sure your top-level main package parses flags when all libraries have
+	// been loaded.
 }
 
 func getIssuer(cert *x509.Certificate) (*x509.Certificate, error) {

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -22,7 +22,7 @@ var hostOverride = flag.String("host", "", "Host header to override in HTTP requ
 var tooSoon = flag.Int("too-soon", 76, "If NextUpdate is fewer than this many hours in future, warn.")
 var ignoreExpiredCerts = flag.Bool("ignore-expired-certs", false, "If a cert is expired, don't bother requesting OCSP.")
 var expectStatus = flag.Int("expect-status", ocsp.Good, "Expect response to have this numeric status (0=Good, 1=Revoked, 2=Unknown)")
-var expectReason = flag.Int("expect-reason", ocsp.KeyCompromise, "Expect response to have this numeric revocation reason (0=Unspecified, 1=KeyCompromise, etc.)")
+var expectReason = flag.Int("expect-reason", ocsp.Unspecified, "Expect response to have this numeric revocation reason (0=Unspecified, 1=KeyCompromise, etc.)")
 
 // isFlagSet determines if the named flag has been set on the command line.
 // This is especially useful for flags whose values are builtin types and for

--- a/test/ocsp/ocsp_forever/main.go
+++ b/test/ocsp/ocsp_forever/main.go
@@ -57,7 +57,7 @@ func init() {
 
 func do(f string) {
 	start := time.Now()
-	resp, err := helper.Req(f)
+	resp, err := helper.Req(f, helper.ConfigFromFlags())
 	latency := time.Since(start)
 	if err != nil {
 		errors_count.With(prom.Labels{}).Inc()


### PR DESCRIPTION
Adds a new -expect-reason flag to the checkocsp binary to allow for
verifying the revocation reason of the certificate(s) in question.
This flag has a default value of -1, meaning that no particular
revocation reason will be expected or enforced.

Also updates the -expect-status flag to have the same default (-1) and
behavior, so that when the tool is run interactively it can simply
print the revocation status of each certificate.

Finally, refactors the way the ocsp/helper library declares flags and
accesses their values. This unifies the interface and makes it easy to
extend to allow tests to modify parameters other than expectStatus when
desired.

Fixes #4885