### PR TITLE
Return a no-store Cache-Control header for newNonce

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -525,7 +525,7 @@ func (wfe *WebFrontEndImpl) Nonce(
 	// The ACME specification says the server MUST include a Cache-Control header
 	// field with the "no-store" directive in responses for the newNonce resource,
 	// in order to prevent caching of this resource.
-	response.Header().Set("Cache-Control", "private, max-age=0, no-store")
+	response.Header().Set("Cache-Control", "no-store")
 }
 
 // sendError wraps web.SendError

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -515,12 +515,17 @@ func (wfe *WebFrontEndImpl) Nonce(
 	}
 
 	statusCode := http.StatusNoContent
-	// The ACME specification says GET requets should receive http.StatusNoContent
+	// The ACME specification says GET requests should receive http.StatusNoContent
 	// and HEAD/POST-as-GET requests should receive http.StatusOK.
 	if request.Method != "GET" {
 		statusCode = http.StatusOK
 	}
 	response.WriteHeader(statusCode)
+
+	// The ACME specification says the server MUST include a Cache-Control header
+	// field with the "no-store" directive in responses for the newNonce resource,
+	// in order to prevent caching of this resource.
+	response.Header().Set("Cache-Control", "private, max-age=0, no-store")
 }
 
 // sendError wraps web.SendError

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -905,6 +905,11 @@ func TestNonceEndpoint(t *testing.T) {
 			// And the response should contain a valid nonce in the Replay-Nonce header
 			nonce := responseWriter.Header().Get("Replay-Nonce")
 			test.AssertEquals(t, wfe.nonceService.Valid(nonce), true)
+			// The server MUST include a Cache-Control header field with the "no-store"
+			// directive in responses for the newNonce resource, in order to prevent
+			// caching of this resource.
+			cacheControl := responseWriter.Header().Get("Cache-Control")
+			test.AssertEquals(t, cacheControl, "private, max-age=0, no-store")
 		})
 	}
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -909,7 +909,7 @@ func TestNonceEndpoint(t *testing.T) {
 			// directive in responses for the newNonce resource, in order to prevent
 			// caching of this resource.
 			cacheControl := responseWriter.Header().Get("Cache-Control")
-			test.AssertEquals(t, cacheControl, "private, max-age=0, no-store")
+			test.AssertEquals(t, cacheControl, "no-store")
 		})
 	}
 }


### PR DESCRIPTION
fixes #4727 

The [spec specifies](https://tools.ietf.org/html/rfc8555#section-7.2) that a `no-store` Cache-Control header is required in response to getting a new nonce. This PR makes that change specifically but does not modify other uses of the `no-cache` directive. If the other endpoints would also benefit from `private` and/or `no-store` I'm happy to make that change as well.

