### PR TITLE
Make ocspchecker resilient to multiple errors

### DIFF
--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -311,8 +311,8 @@ func parseAndPrint(respBytes []byte, cert, issuer *x509.Certificate, config Conf
 		errs = append(errs, fmt.Errorf("checking signature on delegated signer: %s", err))
 	}
 
-	fmt.Printf("\n")
-	fmt.Printf("Response:\n")
+	fmt.Print("\n")
+	fmt.Print("Response:\n")
 	fmt.Printf("  CertStatus %d\n", resp.Status)
 	fmt.Printf("  SerialNumber %036x\n", resp.SerialNumber)
 	fmt.Printf("  ProducedAt %s\n", resp.ProducedAt)
@@ -323,9 +323,9 @@ func parseAndPrint(respBytes []byte, cert, issuer *x509.Certificate, config Conf
 	fmt.Printf("  SignatureAlgorithm %s\n", resp.SignatureAlgorithm)
 	fmt.Printf("  Extensions %#v\n", resp.Extensions)
 	if resp.Certificate == nil {
-		fmt.Printf("  Certificate: nil\n")
+		fmt.Print("  Certificate: nil\n")
 	} else {
-		fmt.Printf("  Certificate:\n")
+		fmt.Print("  Certificate:\n")
 		fmt.Printf("    Subject: %s\n", resp.Certificate.Subject)
 		fmt.Printf("    Issuer: %s\n", resp.Certificate.Issuer)
 		fmt.Printf("    NotBefore: %s\n", resp.Certificate.NotBefore)
@@ -333,7 +333,7 @@ func parseAndPrint(respBytes []byte, cert, issuer *x509.Certificate, config Conf
 	}
 
 	if len(errs) > 0 {
-		fmt.Printf("Errors:\n")
+		fmt.Print("Errors:\n")
 		err := errs[0]
 		fmt.Printf("  %v\n", err.Error())
 		for _, e := range errs[1:] {
@@ -342,6 +342,6 @@ func parseAndPrint(respBytes []byte, cert, issuer *x509.Certificate, config Conf
 		}
 		return nil, err
 	}
-	fmt.Printf("No errors found.\n")
+	fmt.Print("No errors found.\n")
 	return resp, nil
 }

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -332,15 +332,12 @@ func parseAndPrint(respBytes []byte, cert, issuer *x509.Certificate, config Conf
 		fmt.Printf("    NotAfter: %s\n", resp.Certificate.NotAfter)
 	}
 
-	if errs != nil {
+	if len(errs) > 0 {
 		fmt.Printf("Errors:\n")
-		var err error
-		for _, e := range errs {
-			if err == nil {
-				err = e
-			} else {
-				err = fmt.Errorf("%w; %v", err, e)
-			}
+		err := errs[0]
+		fmt.Printf("  %v\n", err.Error())
+		for _, e := range errs[1:] {
+			err = fmt.Errorf("%w; %v", err, e)
 			fmt.Printf("  %v\n", e.Error())
 		}
 		return nil, err


### PR DESCRIPTION
Previously, if ocspchecker encountered a cert whose OCSP response
it didn't like, it would print the first reason it didn't like it and then
move on to the next cert provided on the command line. This
behavior both obscures the cert in question (by not printing
details of its OCSP response) and the error in question (by only
printing the first encountered error, instead of all errors).

This change causes ocspchecker to both print the details of the
OCSP response whether it likes the response or not, and to
accumulate all errors it encounters while validating that response.

This should increase interactive usability, as requested in #4901.