### PR TITLE
Remove OCSPStaleMaxAge config value and handling

### DIFF
--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -8,7 +8,6 @@
     "missingSCTBatchSize": 5000,
     "parallelGenerateOCSPRequests": 10,
     "ocspMinTimeToExpiry": "72h",
-    "ocspStaleMaxAge": "5040h",
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -8,7 +8,6 @@
     "missingSCTBatchSize": 5000,
     "parallelGenerateOCSPRequests": 10,
     "ocspMinTimeToExpiry": "72h",
-    "ocspStaleMaxAge": "5040h",
     "oldestIssuedSCT": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",


### PR DESCRIPTION
The OCSPStaleMaxAge config value was added in #2419 as part of an
effort to ensure that ocsp-updater's queries of the certificateStatus
table were efficient. It was never intended as a long-term fix:
in #2431 and #2432 the query was updated to index on the much more
efficient isExpired and notAfter columns if a feature flag was set,
and in #2561 that code path was made the default and the flag removed.

However, the `WHERE ocspLastUpdate > ocspStaleMaxAge` clause has
remained in the query. This is redundant, as the ocspStaleMaxAge has
always been set to 5040 hours, or 210 days, significantly longer than
the 90-day expiration of Let's Encrypt certs.

This change removes that clause from the query, and removes the config
scaffolding around it. In addition, it updates the tests to remove
workarounds necessitated by this column, and simplifies and documents
them for future readers.

Fixes #4884