### PR TITLE
Update default value of ocspchecker -expectStatus

### DIFF
--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -23,7 +23,7 @@ var (
 	hostOverride       = flag.String("host", "", "Host header to override in HTTP request")
 	tooSoon            = flag.Int("too-soon", 76, "If NextUpdate is fewer than this many hours in future, warn.")
 	ignoreExpiredCerts = flag.Bool("ignore-expired-certs", false, "If a cert is expired, don't bother requesting OCSP.")
-	expectStatus       = flag.Int("expect-status", 0, "Expect response to have this numeric status (0=Good, 1=Revoked, 2=Unknown); or -1 for no enforcement.")
+	expectStatus       = flag.Int("expect-status", -1, "Expect response to have this numeric status (0=Good, 1=Revoked, 2=Unknown); or -1 for no enforcement.")
 	expectReason       = flag.Int("expect-reason", -1, "Expect response to have this numeric revocation reason (0=Unspecified, 1=KeyCompromise, etc); or -1 for no enforcement.")
 )
 


### PR DESCRIPTION
This changes the default behavior of the `-expectStatus` flag of
the ocspchecker and ocsp_forever binaries (as well as any other
consumer of the ocsp/helper.go library).

Previously, the flag had a default value of 0, meaning that all
OCSP responses were expected to have a status of "Good" (i.e. not
"Revoked"); having any other status is an error which would cause
the tool to print different information and have a non-zero exit code.

This flag now has a default value of -1, meaning that no enforcement
of the OCSP status should happen. All OCSP responses, whether Good,
Revoked, or otherwise, will simply be logged for informational
purposes and the tool will exit successfully.

This is a backwards-incompatible change, and users which rely on
the default behavior of this flag should update themselves.