### PR TITLE
Improve bad-key-revoker log output.

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -92,6 +92,11 @@ type unrevokedCertificate struct {
 	IsExpired      bool
 }
 
+func (uc unrevokedCertificate) String() string {
+	return fmt.Sprintf("id=%d serial=%s regID=%d status=%s, expired=%t",
+		uc.ID, uc.Serial, uc.RegistrationID, uc.Status, uc.IsExpired)
+}
+
 // findUnrevoked looks for all unexpired, currently valid certificates which have a specific SPKI hash,
 // by looking first at the keyHashToSerial table and then the certificateStatus and certificates tables.
 // If the number of certificates it finds is larger than bkr.maxRevocations it'll error out.
@@ -317,7 +322,7 @@ func (bkr *badKeyRevoker) invoke() (bool, error) {
 	}
 
 	revokerEmails := idToEmails[unchecked.RevokedBy]
-	bkr.logger.AuditInfo(fmt.Sprintf("revoking certs. revoked emails=%v, emailsToCerts=%v",
+	bkr.logger.AuditInfo(fmt.Sprintf("revoking certs. revoked emails=%v, emailsToCerts=%s",
 		revokerEmails, emailsToCerts))
 
 	// revoke each certificate and send emails to their owners

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -93,7 +93,7 @@ type unrevokedCertificate struct {
 }
 
 func (uc unrevokedCertificate) String() string {
-	return fmt.Sprintf("id=%d serial=%s regID=%d status=%s, expired=%t",
+	return fmt.Sprintf("id=%d serial=%s regID=%d status=%s expired=%t",
 		uc.ID, uc.Serial, uc.RegistrationID, uc.Status, uc.IsExpired)
 }
 


### PR DESCRIPTION
Previously this was logging a map of emails to unrevokedCertificates.
Since unrevokedCertificates includes DER, which is a []byte, this was
getting printed as a series of decimal numbers, one for each byte.

This adds a Stringer implementation for unrevokedCertificates that
omits the DER.

Fixes #4921.