### PR TITLE
log: Remove trailing newlines and escape internal newlines.

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -138,7 +138,7 @@ type logWriter struct {
 }
 
 func (lw logWriter) Write(p []byte) (n int, err error) {
-	lw.Logger.Info(string(p))
+	lw.Logger.Info(strings.Trim(string(p), "\n"))
 	return
 }
 

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -138,6 +138,7 @@ type logWriter struct {
 }
 
 func (lw logWriter) Write(p []byte) (n int, err error) {
+	// Lines received by logWriter will always have a trailing newline.
 	lw.Logger.Info(strings.Trim(string(p), "\n"))
 	return
 }

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -194,3 +194,12 @@ func TestReadConfigFile(t *testing.T) {
 	test.AssertNotError(t, err, "ReadConfigFile(../test/config/notify-mailer.json) errored")
 	test.AssertEquals(t, c.NotifyMailer.SMTPConfig.Server, "localhost")
 }
+
+func TestLogWriter(t *testing.T) {
+	mock := blog.UseMock()
+	lw := logWriter{mock}
+	lw.Write([]byte("hi\n"))
+	lines := mock.GetAllMatching(".*")
+	test.AssertEquals(t, len(lines), 1)
+	test.AssertEquals(t, lines[0], "INFO: hi")
+}

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -198,7 +198,7 @@ func TestReadConfigFile(t *testing.T) {
 func TestLogWriter(t *testing.T) {
 	mock := blog.UseMock()
 	lw := logWriter{mock}
-	_ = lw.Write([]byte("hi\n"))
+	_, _ = lw.Write([]byte("hi\n"))
 	lines := mock.GetAllMatching(".*")
 	test.AssertEquals(t, len(lines), 1)
 	test.AssertEquals(t, lines[0], "INFO: hi")

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -198,7 +198,7 @@ func TestReadConfigFile(t *testing.T) {
 func TestLogWriter(t *testing.T) {
 	mock := blog.UseMock()
 	lw := logWriter{mock}
-	lw.Write([]byte("hi\n"))
+	_ = lw.Write([]byte("hi\n"))
 	lines := mock.GetAllMatching(".*")
 	test.AssertEquals(t, len(lines), 1)
 	test.AssertEquals(t, lines[0], "INFO: hi")

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"log/syslog"
@@ -339,4 +340,12 @@ func TestStdoutFailure(t *testing.T) {
 
 	// Try to audit log something
 	log.AuditInfo("This should cause a panic, stdout is closed!")
+}
+
+func TestLogAtLevelRemovesNewlines(t *testing.T) {
+	var buf bytes.Buffer
+	w := &bothWriter{nil, 6, 0, clock.New(), &buf}
+	w.logAtLevel(6, "foo\nbar")
+
+	test.Assert(t, strings.Contains(buf.String(), "foo\\nbar"), "failed to escape newline")
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -342,7 +342,7 @@ func TestStdoutFailure(t *testing.T) {
 	log.AuditInfo("This should cause a panic, stdout is closed!")
 }
 
-func TestLogAtLevelRemovesNewlines(t *testing.T) {
+func TestLogAtLevelEscapesNewlines(t *testing.T) {
 	var buf bytes.Buffer
 	w := &bothWriter{nil, 6, 0, clock.New(), &buf}
 	w.logAtLevel(6, "foo\nbar")


### PR DESCRIPTION
Fixes #4914.