### PR TITLE
Remove SA connection from ocsp-updater.

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -20,7 +20,6 @@ import (
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/sa"
-	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -43,7 +42,6 @@ type OCSPUpdater struct {
 	dbMap ocspDB
 
 	ogc capb.OCSPGeneratorClient
-	sac core.StorageAuthority
 
 	tickWindow    time.Duration
 	batchSize     int
@@ -73,7 +71,6 @@ func newUpdater(
 	clk clock.Clock,
 	dbMap ocspDB,
 	ogc capb.OCSPGeneratorClient,
-	sac core.StorageAuthority,
 	apc akamaipb.AkamaiPurgerClient,
 	config OCSPUpdaterConfig,
 	issuerPath string,
@@ -116,7 +113,6 @@ func newUpdater(
 		dbMap:                        dbMap,
 		ogc:                          ogc,
 		log:                          log,
-		sac:                          sac,
 		ocspMinTimeToExpiry:          config.OCSPMinTimeToExpiry.Duration,
 		parallelGenerateOCSPRequests: config.ParallelGenerateOCSPRequests,
 		purgerService:                apc,
@@ -349,7 +345,6 @@ type OCSPUpdaterConfig struct {
 
 func setupClients(c OCSPUpdaterConfig, stats prometheus.Registerer, clk clock.Clock) (
 	capb.OCSPGeneratorClient,
-	core.StorageAuthority,
 	akamaipb.AkamaiPurgerClient,
 ) {
 	var tls *tls.Config
@@ -363,10 +358,6 @@ func setupClients(c OCSPUpdaterConfig, stats prometheus.Registerer, clk clock.Cl
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to CA")
 	ogc := bgrpc.NewOCSPGeneratorClient(capb.NewOCSPGeneratorClient(caConn))
 
-	saConn, err := bgrpc.ClientSetup(c.SAService, tls, clientMetrics, clk)
-	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
-	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(saConn))
-
 	var apc akamaipb.AkamaiPurgerClient
 	if c.AkamaiPurgerService != nil {
 		apcConn, err := bgrpc.ClientSetup(c.AkamaiPurgerService, tls, clientMetrics, clk)
@@ -374,7 +365,7 @@ func setupClients(c OCSPUpdaterConfig, stats prometheus.Registerer, clk clock.Cl
 		apc = akamaipb.NewAkamaiPurgerClient(apcConn)
 	}
 
-	return ogc, sac, apc
+	return ogc, apc
 }
 
 func (updater *OCSPUpdater) tick() {
@@ -433,14 +424,13 @@ func main() {
 	sa.InitDBMetrics(dbMap, stats)
 
 	clk := cmd.Clock()
-	ogc, sac, apc := setupClients(conf, stats, clk)
+	ogc, apc := setupClients(conf, stats, clk)
 
 	updater, err := newUpdater(
 		stats,
 		clk,
 		dbMap,
 		ogc,
-		sac,
 		apc,
 		// Necessary evil for now
 		conf,

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -62,7 +62,6 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *db.WrappedMap, c
 		fc,
 		dbMap,
 		&mockOCSP{},
-		sa,
 		nil,
 		OCSPUpdaterConfig{
 			OldOCSPBatchSize:         1,

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -17,10 +17,6 @@
       "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
       "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
     },
-    "saService": {
-      "serverAddress": "sa.boulder:9095",
-      "timeout": "15s"
-    },
     "ocspGeneratorService": {
       "serverAddress": "ca.boulder:9096",
       "timeout": "15s"

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -16,7 +16,6 @@
         "admin-revoker.boulder",
         "ca.boulder",
         "expiration-mailer.boulder",
-        "ocsp-updater.boulder",
         "orphan-finder.boulder",
         "ra.boulder",
         "sa.boulder",


### PR DESCRIPTION
The ocsp-updater no longer makes RPCs to the SA, but accesses the DB
directly (sometimes with help from SA functions to keep the DB
consistent).

This removes the SA connection config from config-next/. We'll remove
from config/ once the corresponding config has been removed from prod.