### PR TITLE
Add test for re-signed OCSP revocation reasons

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -82,7 +82,7 @@ def ocsp_verify(cert_file, issuer_file, ocsp_response):
         raise(Exception("OCSP verify failure"))
     return output
 
-def verify_ocsp(cert_file, issuer_file, url, status):
+def verify_ocsp(cert_file, issuer_file, url, status="revoked"):
     ocsp_request = make_ocsp_req(cert_file, issuer_file)
     responses = fetch_ocsp(ocsp_request, url)
 
@@ -96,9 +96,11 @@ def verify_ocsp(cert_file, issuer_file, url, status):
     # status
     resp = responses[0]
     verify_output = ocsp_verify(cert_file, issuer_file, resp)
-    if not re.search("%s: %s" % (cert_file, status), verify_output):
-        print(verify_output)
-        raise(Exception("OCSP response wasn't '%s'" % status))
+    if status is not None:
+        if not re.search("%s: %s" % (cert_file, status), verify_output):
+            print(verify_output)
+            raise(Exception("OCSP response wasn't '%s'" % status))
+    return verify_output
 
 def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges", data="{}")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -99,6 +99,7 @@ def verify_ocsp(cert_file, issuer_file, url, status):
     if not re.search("%s: %s" % (cert_file, status), verify_output):
         print(verify_output)
         raise(Exception("OCSP response wasn't '%s'" % status))
+    return verify_output
 
 def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges", data="{}")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -99,7 +99,6 @@ def verify_ocsp(cert_file, issuer_file, url, status):
     if not re.search("%s: %s" % (cert_file, status), verify_output):
         print(verify_output)
         raise(Exception("OCSP response wasn't '%s'" % status))
-    return verify_output
 
 def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges", data="{}")

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1663,27 +1663,11 @@ def test_auth_deactivation():
         raise Exception("unexpected authorization status")
 
 def get_ocsp_response_and_reason(cert_file, issuer_file, url):
-    """Returns the ocsp response bytes and revocation reason."""
-    ocsp_request = make_ocsp_req(cert_file, issuer_file)
-    responses = fetch_ocsp(ocsp_request, url)
-
-    # Verify all responses are the same
-    for resp in responses:
-        if resp != responses[0]:
-            raise(Exception("OCSP responses differed: %s vs %s" %(
-                base64.b64encode(responses[0]), base64.b64encode(resp))))
-    ocsp_response = responses[0]
-
-    ocsp_resp_file = os.path.join(tempdir, "ocsp.resp")
-    with open(ocsp_resp_file, "wb") as f:
-        f.write(ocsp_response)
-
-    cmd = "openssl ocsp -no_nonce -issuer %s -cert %s -respin %s" % (
-        issuer_file, cert_file, ocsp_resp_file)
-    output = subprocess.check_output(cmd, shell=True).decode()
+    """Returns the ocsp response output and revocation reason."""
+    output = verify_ocsp(cert_file, issuer_file, url, None)
     m = re.search('Reason: (\w+)', output)
     reason = m.group(1) if m is not None else ""
-    return bytearray(ocsp_response), reason
+    return output, reason
 
 ocsp_resigning_setup_data = {}
 @register_twenty_days_ago


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1648840, it was seen
that Let's Encrypt's OCSP responder was generating OCSP responses with
an empty revocationReason field, but only for responses which had been
re-signed (i.e. it was correctly providing a revocationReason for the
first few days after a revocation).

This test issues and then revokes a cert, then jumps 20 days forward
to force the ocsp-updater to re-sign the ocsp response. It then checks
that the new response still has the correct revocation reason.

Fixes #4907