### PR TITLE
ca: remove SerialExists check in GenerateOCSP

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -101,7 +101,6 @@ type certificateStorage interface {
 	GetCertificate(context.Context, string) (core.Certificate, error)
 	AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*corepb.Empty, error)
 	AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*corepb.Empty, error)
-	SerialExists(ctx context.Context, req *sapb.Serial) (*sapb.Exists, error)
 }
 
 type certificateType string

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -449,13 +449,6 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *caPB.
 		if !ok {
 			return nil, fmt.Errorf("This CA doesn't have an issuer cert with ID %d", *req.IssuerID)
 		}
-		exists, err := ca.sa.SerialExists(ctx, &sapb.Serial{Serial: req.Serial})
-		if err != nil {
-			return nil, err
-		}
-		if !*exists.Exists {
-			return nil, fmt.Errorf("GenerateOCSP was asked to sign OCSP for certification with unknown serial %q", *req.Serial)
-		}
 	} else {
 		cert, err := x509.ParseCertificate(req.CertDER)
 		if err != nil {

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -166,11 +166,6 @@ func (m *mockSA) AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*co
 	return &corepb.Empty{}, nil
 }
 
-func (m *mockSA) SerialExists(ctx context.Context, req *sapb.Serial) (*sapb.Exists, error) {
-	e := true
-	return &sapb.Exists{Exists: &e}, nil
-}
-
 func (m *mockSA) GetCertificate(ctx context.Context, serial string) (core.Certificate, error) {
 	return core.Certificate{}, berrors.NotFoundError("cannot find the cert")
 }


### PR DESCRIPTION
When StoreIssuerInfo is enabled the CA loses its ability to verify that the certificate we are requesting an OCSP response for is real directly (previously we sent the cert DER and checked the signature on it). In order to prevent the ocsp-updater from sending a request for a serial that doesn't exist we added a check that the serial we were being asked to generate a response for did actually exist. This introduced a significant amount of database pressure as it requires a DB query for every single OCSP response we generate. It also provides a minimal level of security, we already trust the ocsp-updater and creating a response for a certificate that doesn't exist doesn't actually accomplish much (if the ocsp-updater was compromised the more realistic attack would be asking to generate a good response for a revoked certificate).

This change removes the check that the serial exists from the CA.

Fixes #4935.