### PR TITLE
akamai-purger: empty queue on shutdown

### DIFF
--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -153,8 +153,7 @@ func main() {
 		if ap.len() > 0 {
 			queueLen := ap.len()
 			logger.Info(fmt.Sprintf("Shutting down; purging %d queue entries before exit.", queueLen))
-			err = ap.purge()
-			if err != nil {
+			if err := ap.purge(); err != nil {
 				logger.Err(fmt.Sprintf("Shutting down; failed to purge %d queue entries before exit: %s",
 					queueLen, err))
 				os.Exit(1)

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -150,13 +150,11 @@ func main() {
 		// As we may have missed a tick by calling ticker.Stop() and
 		// writing to the stop channel call ap.purge one last time just
 		// in case there is anything that still needs to be purged.
-		if ap.len() > 0 {
-			queueLen := ap.len()
+		if queueLen := ap.len(); queueLen > 0 {
 			logger.Info(fmt.Sprintf("Shutting down; purging %d queue entries before exit.", queueLen))
 			if err := ap.purge(); err != nil {
-				logger.Err(fmt.Sprintf("Shutting down; failed to purge %d queue entries before exit: %s",
+				cmd.Fail(fmt.Sprintf("Shutting down; failed to purge %d queue entries before exit: %s",
 					queueLen, err))
-				os.Exit(1)
 			} else {
 				logger.Info(fmt.Sprintf("Shutting down; finished purging %d queue entries.", queueLen))
 			}

--- a/test/integration/akamai_purger_drain_queue_test.go
+++ b/test/integration/akamai_purger_drain_queue_test.go
@@ -1,0 +1,127 @@
+// +build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
+	"github.com/letsencrypt/boulder/cmd"
+	bcreds "github.com/letsencrypt/boulder/grpc/creds"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+func setup() (*exec.Cmd, *bytes.Buffer, akamaipb.AkamaiPurgerClient, error) {
+	purgerCmd := exec.Command("./bin/akamai-purger", "--config", "test/integration/testdata/akamai-purger-queue-drain-config.json")
+	var outputBuffer bytes.Buffer
+	purgerCmd.Stdout = &outputBuffer
+	purgerCmd.Stderr = &outputBuffer
+	purgerCmd.Start()
+
+	// If we error, we need to kill the process we started or the test command
+	// will never exit.
+	sigterm := func() {
+		purgerCmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	s := func(input string) *string {
+		return &input
+	}
+	tlsConfig, err := (&cmd.TLSConfig{
+		CACertFile: s("test/grpc-creds/minica.pem"),
+		CertFile:   s("test/grpc-creds/ra.boulder/cert.pem"),
+		KeyFile:    s("test/grpc-creds/ra.boulder/key.pem"),
+	}).Load()
+	if err != nil {
+		sigterm()
+		return nil, nil, nil, err
+	}
+	creds := bcreds.NewClientCredentials(tlsConfig.RootCAs, tlsConfig.Certificates, "akamai-purger.boulder")
+	conn, err := grpc.Dial(
+		"dns:///akamai-purger.boulder:9199",
+		grpc.WithTransportCredentials(creds),
+	)
+	if err != nil {
+		sigterm()
+		return nil, nil, nil, err
+	}
+	for i := 0; ; i++ {
+		if conn.GetState() == connectivity.Ready {
+			break
+		}
+		if i > 10 {
+			sigterm()
+			return nil, nil, nil, err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	purgerClient := akamaipb.NewAkamaiPurgerClient(conn)
+	return purgerCmd, &outputBuffer, purgerClient, nil
+}
+
+func TestAkamaiPurgerDrainQueueFails(t *testing.T) {
+	purgerCmd, outputBuffer, purgerClient, err := setup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = purgerClient.Purge(context.Background(), &akamaipb.PurgeRequest{
+		Urls: []string{"http://example.com/"},
+	})
+	if err != nil {
+		// Don't use t.Fatal here because we need to get as far as the SIGTERM or
+		// we'll hang on exit.
+		t.Error(err)
+	}
+
+	purgerCmd.Process.Signal(syscall.SIGTERM)
+	err = purgerCmd.Wait()
+	if err == nil {
+		t.Error("expected error shutting down akamai-purger that could not reach backend")
+	}
+	expectedOutput := "failed to purge 1 queue entries before exit: All attempts to submit purge request failed"
+	if !strings.Contains(outputBuffer.String(), expectedOutput) {
+		t.Errorf("akamai-purger stdout did not contain expected %q. Output was:\n%s", expectedOutput, outputBuffer.String())
+	}
+}
+
+func TestAkamaiPurgerDrainQueueSucceeds(t *testing.T) {
+	purgerCmd, outputBuffer, purgerClient, err := setup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		_, err := purgerClient.Purge(context.Background(), &akamaipb.PurgeRequest{
+			Urls: []string{"http://example.com/"},
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	time.Sleep(200 * time.Millisecond)
+	purgerCmd.Process.Signal(syscall.SIGTERM)
+
+	akamaiTestSrvCmd := exec.Command("./bin/akamai-test-srv", "--listen", "localhost:6889",
+		"--secret", "its-a-secret")
+	akamaiTestSrvCmd.Stdout = os.Stdout
+	akamaiTestSrvCmd.Stderr = os.Stderr
+	akamaiTestSrvCmd.Start()
+
+	err = purgerCmd.Wait()
+	if err != nil {
+		t.Errorf("unexpected error shutting down akamai-purger: %s", err)
+	}
+	expectedOutput := "Shutting down; finished purging 10 queue entries."
+	if !strings.Contains(outputBuffer.String(), expectedOutput) {
+		t.Errorf("akamai-purger stdout did not contain expected %q. Output was:\n%s", expectedOutput, outputBuffer.String())
+	}
+	akamaiTestSrvCmd.Process.Signal(syscall.SIGTERM)
+	_ = akamaiTestSrvCmd.Wait()
+}

--- a/test/integration/akamai_purger_drain_queue_test.go
+++ b/test/integration/akamai_purger_drain_queue_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -57,9 +58,9 @@ func setup() (*exec.Cmd, *bytes.Buffer, akamaipb.AkamaiPurgerClient, error) {
 		if conn.GetState() == connectivity.Ready {
 			break
 		}
-		if i > 10 {
+		if i > 40 {
 			sigterm()
-			return nil, nil, nil, err
+			return nil, nil, nil, fmt.Errorf("timed out waiting for akamai-purger to come up")
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -116,7 +117,7 @@ func TestAkamaiPurgerDrainQueueSucceeds(t *testing.T) {
 
 	err = purgerCmd.Wait()
 	if err != nil {
-		t.Errorf("unexpected error shutting down akamai-purger: %s", err)
+		t.Errorf("unexpected error shutting down akamai-purger: %s. Output was:\n%s", err, outputBuffer.String())
 	}
 	expectedOutput := "Shutting down; finished purging 10 queue entries."
 	if !strings.Contains(outputBuffer.String(), expectedOutput) {

--- a/test/integration/testdata/akamai-purger-queue-drain-config.json
+++ b/test/integration/testdata/akamai-purger-queue-drain-config.json
@@ -1,0 +1,31 @@
+{
+    "akamaiPurger": {
+        "debugAddr": ":9766",
+        "purgeInterval": "1000ms",
+        "purgeRetries": 10,
+        "purgeRetryBackoff": "50ms",
+        "baseURL": "http://localhost:6889",
+        "clientToken": "its-a-token",
+        "clientSecret": "its-a-secret",
+        "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
+        "v3Network": "staging",
+        "tls": {
+          "caCertfile": "test/grpc-creds/minica.pem",
+          "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
+          "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
+        },
+        "grpc": {
+          "address": ":9199",
+          "clientNames": [
+            "ra.boulder"
+          ]
+        }
+    },
+    "syslog": {
+      "stdoutlevel": 6,
+      "sysloglevel": 6
+    },
+    "common": {
+      "issuerCert": "/tmp/intermediate-cert-rsa-a.pem"
+    }
+}


### PR DESCRIPTION
This fixes two issues:
 - It expands the handler for CatchSignals wait on `stopped` so we don't
   hit CatchSignals' os.Exit(0) until we're really done.
 - It adds a select{} after the gRPC server exits, so we don't fall out
   the bottom of the program before the purges are done.

This also adds logging about the final purge before exiting, how many
URLs were involved, and whether it succeeded or failed.

Add an integration test to verify this property. To avoid messy timing
issues trying to use the main instance of akamai-purger started by the
integration test, and to allow testing of multiple shutdown cases, this
test starts its own copies of akamai-purger and akamai-test-srv, with
its own config specifying alternate ports and retry intervals.

Fixes #4886.