### PR TITLE
Factor out common PKCS11 config types.

### DIFF
--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -65,6 +65,19 @@ type PKCS11KeyGenConfig struct {
 	StoreLabel string `yaml:"store-key-with-label"`
 }
 
+func (pkgc PKCS11KeyGenConfig) validate() error {
+	if pkgc.Module == "" {
+		return errors.New("pkcs11.module is required")
+	}
+	if pkgc.StoreLabel == "" {
+		return errors.New("pkcs11.store-key-with-label is required")
+	}
+	// key-slot is allowed to be 0 (which is a valid slot).
+	// PIN is allowed to be "", which will commonly happen when
+	// PIN entry is done via PED.
+	return nil
+}
+
 type rootConfig struct {
 	CeremonyType string             `yaml:"ceremony-type"`
 	PKCS11       PKCS11KeyGenConfig `yaml:"pkcs11"`
@@ -77,13 +90,8 @@ type rootConfig struct {
 }
 
 func (rc rootConfig) validate() error {
-	// PKCS11 fields
-	if rc.PKCS11.Module == "" {
-		return errors.New("pkcs11.module is required")
-	}
-	// key-slot cannot be tested because 0 is a valid slot
-	if rc.PKCS11.StoreLabel == "" {
-		return errors.New("pkcs11.store-key-with-label is required")
+	if err := rc.PKCS11.validate(); err != nil {
+		return err
 	}
 
 	// Key gen fields
@@ -115,6 +123,20 @@ type PKCS11SigningConfig struct {
 	SigningKeyID string `yaml:"signing-key-id"`
 }
 
+func (psc PKCS11SigningConfig) validate() error {
+	if psc.Module == "" {
+		return errors.New("pkcs11.module is required")
+	}
+	if psc.SigningLabel == "" {
+		return errors.New("pkcs11.signing-key-label is required")
+	}
+	if psc.SigningKeyID == "" {
+		return errors.New("pkcs11.signing-key-id is required")
+	}
+	// key-slot is allowed to be 0 (which is a valid slot).
+	return nil
+}
+
 type intermediateConfig struct {
 	CeremonyType string              `yaml:"ceremony-type"`
 	PKCS11       PKCS11SigningConfig `yaml:"pkcs11"`
@@ -129,16 +151,8 @@ type intermediateConfig struct {
 }
 
 func (ic intermediateConfig) validate(ct certType) error {
-	// PKCS11 fields
-	if ic.PKCS11.Module == "" {
-		return errors.New("pkcs11.module is required")
-	}
-	// key-slot cannot be tested because 0 is a valid slot
-	if ic.PKCS11.SigningLabel == "" {
-		return errors.New("pkcs11.signing-key-label is required")
-	}
-	if ic.PKCS11.SigningKeyID == "" {
-		return errors.New("pkcs11.signing-key-id is required")
+	if err := ic.PKCS11.validate(); err != nil {
+		return err
 	}
 
 	// Input fields
@@ -172,13 +186,8 @@ type keyConfig struct {
 }
 
 func (kc keyConfig) validate() error {
-	// PKCS11 fields
-	if kc.PKCS11.Module == "" {
-		return errors.New("pkcs11.module is required")
-	}
-	// key-slot cannot be tested because 0 is a valid slot
-	if kc.PKCS11.StoreLabel == "" {
-		return errors.New("pkcs11.store-key-with-label is required")
+	if err := kc.PKCS11.validate(); err != nil {
+		return err
 	}
 
 	// Key gen fields
@@ -213,16 +222,8 @@ type ocspRespConfig struct {
 }
 
 func (orc ocspRespConfig) validate() error {
-	// PKCS11 fields
-	if orc.PKCS11.Module == "" {
-		return errors.New("pkcs11.module is required")
-	}
-	// key-slot cannot be tested because 0 is a valid slot
-	if orc.PKCS11.SigningLabel == "" {
-		return errors.New("pkcs11.signing-key-label is required")
-	}
-	if orc.PKCS11.SigningKeyID == "" {
-		return errors.New("pkcs11.signing-key-id is required")
+	if err := orc.PKCS11.validate(); err != nil {
+		return err
 	}
 
 	// Input fields
@@ -275,16 +276,8 @@ type crlConfig struct {
 }
 
 func (cc crlConfig) validate() error {
-	// PKCS11 fields
-	if cc.PKCS11.Module == "" {
-		return errors.New("pkcs11.module is required")
-	}
-	// key-slot cannot be tested because 0 is a valid slot
-	if cc.PKCS11.SigningLabel == "" {
-		return errors.New("pkcs11.signing-key-label is required")
-	}
-	if cc.PKCS11.SigningKeyID == "" {
-		return errors.New("pkcs11.signing-key-id is required")
+	if err := cc.PKCS11.validate(); err != nil {
+		return err
 	}
 
 	// Input fields

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -58,16 +58,18 @@ func (kgc keyGenConfig) validate() error {
 	return nil
 }
 
+type PKCS11KeyGenConfig struct {
+	Module     string `yaml:"module"`
+	PIN        string `yaml:"pin"`
+	StoreSlot  uint   `yaml:"store-key-in-slot"`
+	StoreLabel string `yaml:"store-key-with-label"`
+}
+
 type rootConfig struct {
-	CeremonyType string `yaml:"ceremony-type"`
-	PKCS11       struct {
-		Module     string `yaml:"module"`
-		PIN        string `yaml:"pin"`
-		StoreSlot  uint   `yaml:"store-key-in-slot"`
-		StoreLabel string `yaml:"store-key-with-label"`
-	} `yaml:"pkcs11"`
-	Key     keyGenConfig `yaml:"key"`
-	Outputs struct {
+	CeremonyType string             `yaml:"ceremony-type"`
+	PKCS11       PKCS11KeyGenConfig `yaml:"pkcs11"`
+	Key          keyGenConfig       `yaml:"key"`
+	Outputs      struct {
 		PublicKeyPath   string `yaml:"public-key-path"`
 		CertificatePath string `yaml:"certificate-path"`
 	} `yaml:"outputs"`
@@ -105,16 +107,18 @@ func (rc rootConfig) validate() error {
 	return nil
 }
 
+type PKCS11SigningConfig struct {
+	Module       string `yaml:"module"`
+	PIN          string `yaml:"pin"`
+	SigningSlot  uint   `yaml:"signing-key-slot"`
+	SigningLabel string `yaml:"signing-key-label"`
+	SigningKeyID string `yaml:"signing-key-id"`
+}
+
 type intermediateConfig struct {
-	CeremonyType string `yaml:"ceremony-type"`
-	PKCS11       struct {
-		Module       string `yaml:"module"`
-		PIN          string `yaml:"pin"`
-		SigningSlot  uint   `yaml:"signing-key-slot"`
-		SigningLabel string `yaml:"signing-key-label"`
-		SigningKeyID string `yaml:"signing-key-id"`
-	} `yaml:"pkcs11"`
-	Inputs struct {
+	CeremonyType string              `yaml:"ceremony-type"`
+	PKCS11       PKCS11SigningConfig `yaml:"pkcs11"`
+	Inputs       struct {
 		PublicKeyPath         string `yaml:"public-key-path"`
 		IssuerCertificatePath string `yaml:"issuer-certificate-path"`
 	} `yaml:"inputs"`
@@ -159,15 +163,10 @@ func (ic intermediateConfig) validate(ct certType) error {
 }
 
 type keyConfig struct {
-	CeremonyType string `yaml:"ceremony-type"`
-	PKCS11       struct {
-		Module     string `yaml:"module"`
-		PIN        string `yaml:"pin"`
-		StoreSlot  uint   `yaml:"store-key-in-slot"`
-		StoreLabel string `yaml:"store-key-with-label"`
-	} `yaml:"pkcs11"`
-	Key     keyGenConfig `yaml:"key"`
-	Outputs struct {
+	CeremonyType string             `yaml:"ceremony-type"`
+	PKCS11       PKCS11KeyGenConfig `yaml:"pkcs11"`
+	Key          keyGenConfig       `yaml:"key"`
+	Outputs      struct {
 		PublicKeyPath string `yaml:"public-key-path"`
 	} `yaml:"outputs"`
 }
@@ -196,15 +195,9 @@ func (kc keyConfig) validate() error {
 }
 
 type ocspRespConfig struct {
-	CeremonyType string `yaml:"ceremony-type"`
-	PKCS11       struct {
-		Module       string `yaml:"module"`
-		PIN          string `yaml:"pin"`
-		SigningSlot  uint   `yaml:"signing-key-slot"`
-		SigningLabel string `yaml:"signing-key-label"`
-		SigningKeyID string `yaml:"signing-key-id"`
-	} `yaml:"pkcs11"`
-	Inputs struct {
+	CeremonyType string              `yaml:"ceremony-type"`
+	PKCS11       PKCS11SigningConfig `yaml:"pkcs11"`
+	Inputs       struct {
 		CertificatePath                string `yaml:"certificate-path"`
 		IssuerCertificatePath          string `yaml:"issuer-certificate-path"`
 		DelegatedIssuerCertificatePath string `yaml:"delegated-issuer-certificate-path"`
@@ -261,15 +254,9 @@ func (orc ocspRespConfig) validate() error {
 }
 
 type crlConfig struct {
-	CeremonyType string `yaml:"ceremony-type"`
-	PKCS11       struct {
-		Module       string `yaml:"module"`
-		PIN          string `yaml:"pin"`
-		SigningSlot  uint   `yaml:"signing-key-slot"`
-		SigningLabel string `yaml:"signing-key-label"`
-		SigningKeyID string `yaml:"signing-key-id"`
-	} `yaml:"pkcs11"`
-	Inputs struct {
+	CeremonyType string              `yaml:"ceremony-type"`
+	PKCS11       PKCS11SigningConfig `yaml:"pkcs11"`
+	Inputs       struct {
 		IssuerCertificatePath string `yaml:"issuer-certificate-path"`
 	} `yaml:"inputs"`
 	Outputs struct {

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -95,12 +95,7 @@ func TestRootConfigValidate(t *testing.T) {
 		{
 			name: "no pkcs11.store-key-with-label",
 			config: rootConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module: "module",
 				},
 			},
@@ -109,12 +104,7 @@ func TestRootConfigValidate(t *testing.T) {
 		{
 			name: "bad key fields",
 			config: rootConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -124,12 +114,7 @@ func TestRootConfigValidate(t *testing.T) {
 		{
 			name: "no outputs.public-key-path",
 			config: rootConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -143,12 +128,7 @@ func TestRootConfigValidate(t *testing.T) {
 		{
 			name: "no outputs.certificate-path",
 			config: rootConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -168,12 +148,7 @@ func TestRootConfigValidate(t *testing.T) {
 		{
 			name: "bad certificate-profile",
 			config: rootConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -194,12 +169,7 @@ func TestRootConfigValidate(t *testing.T) {
 		{
 			name: "good config",
 			config: rootConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -251,13 +221,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 		{
 			name: "no pkcs11.signing-key-label",
 			config: intermediateConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module: "module",
 				},
 			},
@@ -266,13 +230,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 		{
 			name: "no pkcs11.key-id",
 			config: intermediateConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 				},
@@ -282,13 +240,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 		{
 			name: "no inputs.public-key-path",
 			config: intermediateConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -299,13 +251,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 		{
 			name: "no inputs.issuer-certificate-path",
 			config: intermediateConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -322,13 +268,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 		{
 			name: "no outputs.certificate-path",
 			config: intermediateConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -346,13 +286,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 		{
 			name: "bad certificate-profile",
 			config: intermediateConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -375,13 +309,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 		{
 			name: "good config",
 			config: intermediateConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -438,12 +366,7 @@ func TestKeyConfigValidate(t *testing.T) {
 		{
 			name: "no pkcs11.store-key-with-label",
 			config: keyConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module: "module",
 				},
 			},
@@ -452,12 +375,7 @@ func TestKeyConfigValidate(t *testing.T) {
 		{
 			name: "bad key fields",
 			config: keyConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -467,12 +385,7 @@ func TestKeyConfigValidate(t *testing.T) {
 		{
 			name: "no outputs.public-key-path",
 			config: keyConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -486,12 +399,7 @@ func TestKeyConfigValidate(t *testing.T) {
 		{
 			name: "good config",
 			config: keyConfig{
-				PKCS11: struct {
-					Module     string `yaml:"module"`
-					PIN        string `yaml:"pin"`
-					StoreSlot  uint   `yaml:"store-key-in-slot"`
-					StoreLabel string `yaml:"store-key-with-label"`
-				}{
+				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
 					StoreLabel: "label",
 				},
@@ -533,13 +441,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no pkcs11.signing-key-label",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module: "module",
 				},
 			},
@@ -548,13 +450,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no pkcs11.key-id",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 				},
@@ -564,13 +460,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no inputs.certificate-path",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -581,13 +471,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no inputs.issuer-certificate-path",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -605,13 +489,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no outputs.response-path",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -630,13 +508,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no ocsp-profile.this-update",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -660,13 +532,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no ocsp-profile.next-update",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -697,13 +563,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "no ocsp-profile.status",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -735,13 +595,7 @@ func TestOCSPRespConfig(t *testing.T) {
 		{
 			name: "good config",
 			config: ocspRespConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -797,13 +651,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no pkcs11.signing-key-label",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module: "module",
 				},
 			},
@@ -812,13 +660,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no pkcs11.key-id",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 				},
@@ -828,13 +670,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no inputs.issuer-certificate-path",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -845,13 +681,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no outputs.crl-path",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -867,13 +697,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no crl-profile.this-update",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -894,13 +718,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no crl-profile.next-update",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -933,13 +751,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no crl-profile.number",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -973,13 +785,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no crl-profile.revoked-certificates.certificate-path",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -1019,13 +825,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no crl-profile.revoked-certificates.revocation-date",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -1067,13 +867,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "no revocation reason",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",
@@ -1116,13 +910,7 @@ func TestCRLConfig(t *testing.T) {
 		{
 			name: "good",
 			config: crlConfig{
-				PKCS11: struct {
-					Module       string `yaml:"module"`
-					PIN          string `yaml:"pin"`
-					SigningSlot  uint   `yaml:"signing-key-slot"`
-					SigningLabel string `yaml:"signing-key-label"`
-					SigningKeyID string `yaml:"signing-key-id"`
-				}{
+				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
 					SigningLabel: "label",
 					SigningKeyID: "id",


### PR DESCRIPTION
Our PKCS11 config sections fall into two categories:
 - Those used for generating keys, where the HSM is both an input and an
   output, storing the resulting key in a specified slot.
 - Those used for signing certs, where the HSM is an input.

This creates dedicated config structs for these two, reducing
duplication in defining overall config structs. This also makes
defining test cases involving these config structs much more concise.

Fixes #4915 