### PR TITLE
Update CA RPC interface to proto3

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -102,9 +102,6 @@ var (
 	// * DNSNames = example.com, example2.com
 	ECDSACSR = mustRead("./testdata/ecdsa.der.csr")
 
-	// This is never modified, but it must be a var instead of a const so we can make references to it.
-	arbitraryRegID int64 = 1001
-
 	// OIDExtensionCTPoison is defined in RFC 6962 s3.1.
 	OIDExtensionCTPoison = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
 
@@ -124,6 +121,8 @@ var (
 		{name: "certificate-for-precertificate", issueCertificateForPrecertificate: true},
 	}
 )
+
+const arbitraryRegID int64 = 1001
 
 // CFSSL config
 const rsaProfileName = "rsaEE"
@@ -348,7 +347,7 @@ func TestIssuePrecertificate(t *testing.T) {
 				req, err := x509.ParseCertificateRequest(testCase.csr)
 				test.AssertNotError(t, err, "Certificate request failed to parse")
 
-				issueReq := &caPB.IssueCertificateRequest{Csr: testCase.csr, RegistrationID: &arbitraryRegID}
+				issueReq := &caPB.IssueCertificateRequest{Csr: testCase.csr, RegistrationID: arbitraryRegID}
 
 				var certDER []byte
 				response, err := ca.IssuePrecertificate(ctx, issueReq)
@@ -456,7 +455,7 @@ func TestMultipleIssuers(t *testing.T) {
 		nil)
 	test.AssertNotError(t, err, "Failed to remake CA")
 
-	issuedCert, err := ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID})
+	issuedCert, err := ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 
 	cert, err := x509.ParseCertificate(issuedCert.DER)
@@ -481,16 +480,15 @@ func TestOCSP(t *testing.T) {
 		nil)
 	test.AssertNotError(t, err, "Failed to create CA")
 
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID}
+	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID}
 
 	cert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue")
 	parsedCert, err := x509.ParseCertificate(cert.DER)
 	test.AssertNotError(t, err, "Failed to parse cert")
-	status := string(core.OCSPStatusGood)
 	ocspResp, err := ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
 		CertDER: cert.DER,
-		Status:  &status,
+		Status:  string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "Failed to generate OCSP")
 	parsed, err := ocsp.ParseResponse(ocspResp.Response, caCert)
@@ -502,7 +500,7 @@ func TestOCSP(t *testing.T) {
 	// Test that signatures are checked.
 	_, err = ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
 		CertDER: append(cert.DER, byte(0)),
-		Status:  &status,
+		Status:  string(core.OCSPStatusGood),
 	})
 	test.AssertError(t, err, "Generated OCSP for cert with bad signature")
 
@@ -545,7 +543,7 @@ func TestOCSP(t *testing.T) {
 	// should be signed by caCert.
 	ocspResp2, err := ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
 		CertDER: append([]byte(nil), cert.DER...),
-		Status:  &status,
+		Status:  string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "Failed to sign second OCSP response")
 	_, err = ocsp.ParseResponse(ocspResp2.Response, caCert)
@@ -555,7 +553,7 @@ func TestOCSP(t *testing.T) {
 	// and should be signed by newIssuer.
 	newCertOcspResp, err := ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
 		CertDER: newCert.DER,
-		Status:  &status,
+		Status:  string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "Failed to generate OCSP")
 	parsedNewCertOcspResp, err := ocsp.ParseResponse(newCertOcspResp.Response, newIssuerCert)
@@ -631,7 +629,7 @@ func TestInvalidCSRs(t *testing.T) {
 
 		t.Run(testCase.name, func(t *testing.T) {
 			serializedCSR := mustRead(testCase.csrPath)
-			issueReq := &caPB.IssueCertificateRequest{Csr: serializedCSR, RegistrationID: &arbitraryRegID}
+			issueReq := &caPB.IssueCertificateRequest{Csr: serializedCSR, RegistrationID: arbitraryRegID}
 			_, err = ca.IssuePrecertificate(ctx, issueReq)
 
 			test.Assert(t, berrors.Is(err, testCase.errorType), "Incorrect error type returned")
@@ -666,7 +664,7 @@ func TestRejectValidityTooLong(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to parse time")
 	testCtx.fc.Set(future)
 	// Test that the CA rejects CSRs that would expire after the intermediate cert
-	_, err = ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{Csr: NoCNCSR, RegistrationID: &arbitraryRegID})
+	_, err = ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{Csr: NoCNCSR, RegistrationID: arbitraryRegID})
 	test.AssertError(t, err, "Cannot issue a certificate that expires after the intermediate certificate")
 	test.Assert(t, berrors.Is(err, berrors.InternalServer), "Incorrect error type returned")
 }
@@ -842,7 +840,7 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to create CA")
 
 	orderID := int64(0)
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID, OrderID: &orderID}
+	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID, OrderID: orderID}
 	precert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue precert")
 	parsedPrecert, err := x509.ParseCertificate(precert.DER)
@@ -866,8 +864,8 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 	cert, err := ca.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           sctBytes,
-		RegistrationID: &arbitraryRegID,
-		OrderID:        new(int64),
+		RegistrationID: arbitraryRegID,
+		OrderID:        0,
 	})
 	test.AssertNotError(t, err, "Failed to issue cert from precert")
 	parsedCert, err := x509.ParseCertificate(cert.DER)
@@ -929,14 +927,14 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 	}
 
 	orderID := int64(0)
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID, OrderID: &orderID}
+	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID, OrderID: orderID}
 	precert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue precert")
 	_, err = ca.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           sctBytes,
-		RegistrationID: &arbitraryRegID,
-		OrderID:        new(int64),
+		RegistrationID: arbitraryRegID,
+		OrderID:        0,
 	})
 	if err == nil {
 		t.Error("Expected error issuing duplicate serial but got none.")
@@ -963,8 +961,8 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 	_, err = errorca.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           sctBytes,
-		RegistrationID: &arbitraryRegID,
-		OrderID:        new(int64),
+		RegistrationID: arbitraryRegID,
+		OrderID:        0,
 	})
 	if err == nil {
 		t.Fatal("Expected error issuing duplicate serial but got none.")
@@ -1038,10 +1036,9 @@ func TestPrecertOrphanQueue(t *testing.T) {
 		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)
 	}
 
-	var one int64 = 1
 	_, err = ca.IssuePrecertificate(context.Background(), &caPB.IssueCertificateRequest{
-		RegistrationID: &one,
-		OrderID:        &one,
+		RegistrationID: int64(1),
+		OrderID:        int64(1),
 		Csr:            CNandSANCSR,
 	})
 	test.AssertError(t, err, "Expected IssuePrecertificate to fail with `failSA`")
@@ -1229,7 +1226,7 @@ func TestIssuePrecertificateLinting(t *testing.T) {
 	// Attempt to issue a pre-certificate
 	_, err = ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{
 		Csr:            CNandSANCSR,
-		RegistrationID: &arbitraryRegID,
+		RegistrationID: arbitraryRegID,
 	})
 	// It should error
 	test.AssertError(t, err, "expected err from IssuePrecertificate with linttrapSigner")
@@ -1262,32 +1259,28 @@ func TestGenerateOCSPWithIssuerID(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to create CA")
 
 	// GenerateOCSP with feature enabled + req contains bad IssuerID
-	issuerID := int64(666)
-	serial := "DEADDEADDEADDEADDEADDEADDEADDEADDEAD"
-	status := string(core.OCSPStatusGood)
 	_, err = ca.GenerateOCSP(context.Background(), &caPB.GenerateOCSPRequest{
-		IssuerID: &issuerID,
-		Serial:   &serial,
-		Status:   &status,
+		IssuerID: int64(666),
+		Serial:   "DEADDEADDEADDEADDEADDEADDEADDEADDEAD",
+		Status:   string(core.OCSPStatusGood),
 	})
 	test.AssertError(t, err, "GenerateOCSP didn't fail with invalid IssuerID")
 
 	// GenerateOCSP with feature enabled + req contains good IssuerID
-	issuerID = idForIssuer(ca.defaultIssuer.cert)
 	_, err = ca.GenerateOCSP(context.Background(), &caPB.GenerateOCSPRequest{
-		IssuerID: &issuerID,
-		Serial:   &serial,
-		Status:   &status,
+		IssuerID: idForIssuer(ca.defaultIssuer.cert),
+		Serial:   "DEADDEADDEADDEADDEADDEADDEADDEADDEAD",
+		Status:   string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "GenerateOCSP failed")
 
 	// GenerateOCSP with feature enabled + req doesn't contain IssuerID
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID}
+	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID}
 	cert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue")
 	_, err = ca.GenerateOCSP(context.Background(), &caPB.GenerateOCSPRequest{
 		CertDER: cert.DER,
-		Status:  &status,
+		Status:  string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "GenerateOCSP failed")
 }

--- a/ca/proto/ca.pb.go
+++ b/ca/proto/ca.pb.go
@@ -35,9 +35,9 @@ type IssueCertificateRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Csr            []byte `protobuf:"bytes,1,opt,name=csr" json:"csr,omitempty"`
-	RegistrationID *int64 `protobuf:"varint,2,opt,name=registrationID" json:"registrationID,omitempty"`
-	OrderID        *int64 `protobuf:"varint,3,opt,name=orderID" json:"orderID,omitempty"`
+	Csr            []byte `protobuf:"bytes,1,opt,name=csr,proto3" json:"csr,omitempty"`
+	RegistrationID int64  `protobuf:"varint,2,opt,name=registrationID,proto3" json:"registrationID,omitempty"`
+	OrderID        int64  `protobuf:"varint,3,opt,name=orderID,proto3" json:"orderID,omitempty"`
 }
 
 func (x *IssueCertificateRequest) Reset() {
@@ -80,15 +80,15 @@ func (x *IssueCertificateRequest) GetCsr() []byte {
 }
 
 func (x *IssueCertificateRequest) GetRegistrationID() int64 {
-	if x != nil && x.RegistrationID != nil {
-		return *x.RegistrationID
+	if x != nil {
+		return x.RegistrationID
 	}
 	return 0
 }
 
 func (x *IssueCertificateRequest) GetOrderID() int64 {
-	if x != nil && x.OrderID != nil {
-		return *x.OrderID
+	if x != nil {
+		return x.OrderID
 	}
 	return 0
 }
@@ -98,7 +98,7 @@ type IssuePrecertificateResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	DER []byte `protobuf:"bytes,1,opt,name=DER" json:"DER,omitempty"`
+	DER []byte `protobuf:"bytes,1,opt,name=DER,proto3" json:"DER,omitempty"`
 }
 
 func (x *IssuePrecertificateResponse) Reset() {
@@ -145,10 +145,10 @@ type IssueCertificateForPrecertificateRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	DER            []byte   `protobuf:"bytes,1,opt,name=DER" json:"DER,omitempty"`
-	SCTs           [][]byte `protobuf:"bytes,2,rep,name=SCTs" json:"SCTs,omitempty"`
-	RegistrationID *int64   `protobuf:"varint,3,opt,name=registrationID" json:"registrationID,omitempty"`
-	OrderID        *int64   `protobuf:"varint,4,opt,name=orderID" json:"orderID,omitempty"`
+	DER            []byte   `protobuf:"bytes,1,opt,name=DER,proto3" json:"DER,omitempty"`
+	SCTs           [][]byte `protobuf:"bytes,2,rep,name=SCTs,proto3" json:"SCTs,omitempty"`
+	RegistrationID int64    `protobuf:"varint,3,opt,name=registrationID,proto3" json:"registrationID,omitempty"`
+	OrderID        int64    `protobuf:"varint,4,opt,name=orderID,proto3" json:"orderID,omitempty"`
 }
 
 func (x *IssueCertificateForPrecertificateRequest) Reset() {
@@ -198,15 +198,15 @@ func (x *IssueCertificateForPrecertificateRequest) GetSCTs() [][]byte {
 }
 
 func (x *IssueCertificateForPrecertificateRequest) GetRegistrationID() int64 {
-	if x != nil && x.RegistrationID != nil {
-		return *x.RegistrationID
+	if x != nil {
+		return x.RegistrationID
 	}
 	return 0
 }
 
 func (x *IssueCertificateForPrecertificateRequest) GetOrderID() int64 {
-	if x != nil && x.OrderID != nil {
-		return *x.OrderID
+	if x != nil {
+		return x.OrderID
 	}
 	return 0
 }
@@ -217,12 +217,12 @@ type GenerateOCSPRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	CertDER   []byte  `protobuf:"bytes,1,opt,name=certDER" json:"certDER,omitempty"`
-	Status    *string `protobuf:"bytes,2,opt,name=status" json:"status,omitempty"`
-	Reason    *int32  `protobuf:"varint,3,opt,name=reason" json:"reason,omitempty"`
-	RevokedAt *int64  `protobuf:"varint,4,opt,name=revokedAt" json:"revokedAt,omitempty"`
-	Serial    *string `protobuf:"bytes,5,opt,name=serial" json:"serial,omitempty"`
-	IssuerID  *int64  `protobuf:"varint,6,opt,name=issuerID" json:"issuerID,omitempty"`
+	CertDER   []byte `protobuf:"bytes,1,opt,name=certDER,proto3" json:"certDER,omitempty"`
+	Status    string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	Reason    int32  `protobuf:"varint,3,opt,name=reason,proto3" json:"reason,omitempty"`
+	RevokedAt int64  `protobuf:"varint,4,opt,name=revokedAt,proto3" json:"revokedAt,omitempty"`
+	Serial    string `protobuf:"bytes,5,opt,name=serial,proto3" json:"serial,omitempty"`
+	IssuerID  int64  `protobuf:"varint,6,opt,name=issuerID,proto3" json:"issuerID,omitempty"`
 }
 
 func (x *GenerateOCSPRequest) Reset() {
@@ -265,36 +265,36 @@ func (x *GenerateOCSPRequest) GetCertDER() []byte {
 }
 
 func (x *GenerateOCSPRequest) GetStatus() string {
-	if x != nil && x.Status != nil {
-		return *x.Status
+	if x != nil {
+		return x.Status
 	}
 	return ""
 }
 
 func (x *GenerateOCSPRequest) GetReason() int32 {
-	if x != nil && x.Reason != nil {
-		return *x.Reason
+	if x != nil {
+		return x.Reason
 	}
 	return 0
 }
 
 func (x *GenerateOCSPRequest) GetRevokedAt() int64 {
-	if x != nil && x.RevokedAt != nil {
-		return *x.RevokedAt
+	if x != nil {
+		return x.RevokedAt
 	}
 	return 0
 }
 
 func (x *GenerateOCSPRequest) GetSerial() string {
-	if x != nil && x.Serial != nil {
-		return *x.Serial
+	if x != nil {
+		return x.Serial
 	}
 	return ""
 }
 
 func (x *GenerateOCSPRequest) GetIssuerID() int64 {
-	if x != nil && x.IssuerID != nil {
-		return *x.IssuerID
+	if x != nil {
+		return x.IssuerID
 	}
 	return 0
 }
@@ -304,7 +304,7 @@ type OCSPResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Response []byte `protobuf:"bytes,1,opt,name=response" json:"response,omitempty"`
+	Response []byte `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
 }
 
 func (x *OCSPResponse) Reset() {
@@ -410,7 +410,7 @@ var file_ca_proto_ca_proto_rawDesc = []byte{
 	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x29, 0x5a, 0x27, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
 	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6c, 0x65, 0x74, 0x73, 0x65, 0x6e, 0x63, 0x72, 0x79, 0x70, 0x74,
 	0x2f, 0x62, 0x6f, 0x75, 0x6c, 0x64, 0x65, 0x72, 0x2f, 0x63, 0x61, 0x2f, 0x70, 0x72, 0x6f, 0x74,
-	0x6f,
+	0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (

--- a/ca/proto/ca.proto
+++ b/ca/proto/ca.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package ca;
 option go_package = "github.com/letsencrypt/boulder/ca/proto";
@@ -21,32 +21,32 @@ service OCSPGenerator {
 }
 
 message IssueCertificateRequest {
-  optional bytes csr = 1;
-  optional int64 registrationID = 2;
-  optional int64 orderID = 3;
+  bytes csr = 1;
+  int64 registrationID = 2;
+  int64 orderID = 3;
 }
 
 message IssuePrecertificateResponse {
-  optional bytes DER = 1;
+  bytes DER = 1;
 }
 
 message IssueCertificateForPrecertificateRequest {
-  optional bytes DER = 1;
+  bytes DER = 1;
   repeated bytes SCTs = 2;
-  optional int64 registrationID = 3;
-  optional int64 orderID = 4;
+  int64 registrationID = 3;
+  int64 orderID = 4;
 }
 
 // Exactly one of certDER or [serial and issuerID] must be set.
 message GenerateOCSPRequest {
-  optional bytes certDER = 1;
-  optional string status = 2;
-  optional int32 reason = 3;
-  optional int64 revokedAt = 4;
-  optional string serial = 5;
-  optional int64 issuerID = 6;
+  bytes certDER = 1;
+  string status = 2;
+  int32 reason = 3;
+  int64 revokedAt = 4;
+  string serial = 5;
+  int64 issuerID = 6;
 }
 
 message OCSPResponse {
-  optional bytes response = 1;
+  bytes response = 1;
 }

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -178,17 +178,14 @@ func getCertDER(selector ocspDB, serial string) ([]byte, error) {
 }
 
 func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.CertificateStatus) (*core.CertificateStatus, error) {
-	reason := int32(status.RevokedReason)
-	statusStr := string(status.Status)
-	revokedAt := status.RevokedDate.UnixNano()
 	ocspReq := capb.GenerateOCSPRequest{
-		Reason:    &reason,
-		Status:    &statusStr,
-		RevokedAt: &revokedAt,
+		Reason:    int32(status.RevokedReason),
+		Status:    string(status.Status),
+		RevokedAt: status.RevokedDate.UnixNano(),
 	}
 	if status.IssuerID != nil {
-		ocspReq.Serial = &status.Serial
-		ocspReq.IssuerID = status.IssuerID
+		ocspReq.Serial = status.Serial
+		ocspReq.IssuerID = *status.IssuerID
 	} else {
 		certDER, err := getCertDER(updater.dbMap, status.Serial)
 		if err != nil {

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -416,7 +416,7 @@ type mockOCSPRecordIssuer struct {
 }
 
 func (ca *mockOCSPRecordIssuer) GenerateOCSP(_ context.Context, req *caPB.GenerateOCSPRequest, _ ...grpc.CallOption) (*caPB.OCSPResponse, error) {
-	ca.gotIssuer = req.IssuerID != nil && req.Serial != nil
+	ca.gotIssuer = req.IssuerID != 0 && req.Serial != ""
 	return &caPB.OCSPResponse{Response: []byte{1, 2, 3}}, nil
 }
 

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -234,14 +234,11 @@ func storeParsedLogLine(sa certificateStorage, ca ocspGenerator, logger blog.Log
 
 func generateOCSP(ctx context.Context, ca ocspGenerator, certDER []byte) ([]byte, error) {
 	// generate a fresh OCSP response
-	statusGood := string(core.OCSPStatusGood)
-	zeroInt32 := int32(0)
-	zeroInt64 := int64(0)
 	ocspResponse, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		CertDER:   certDER,
-		Status:    &statusGood,
-		Reason:    &zeroInt32,
-		RevokedAt: &zeroInt64,
+		Status:    string(core.OCSPStatusGood),
+		Reason:    int32(0),
+		RevokedAt: int64(0),
 	})
 	if err != nil {
 		return nil, err

--- a/grpc/ca-wrappers.go
+++ b/grpc/ca-wrappers.go
@@ -82,14 +82,14 @@ func NewCertificateAuthorityServer(inner core.CertificateAuthority) *Certificate
 }
 
 func (cas *CertificateAuthorityServerWrapper) IssuePrecertificate(ctx context.Context, request *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
-	if request == nil || request.Csr == nil || request.OrderID == nil || request.RegistrationID == nil {
+	if request == nil || request.Csr == nil || request.OrderID == 0 || request.RegistrationID == 0 {
 		return nil, errIncompleteRequest
 	}
 	return cas.inner.IssuePrecertificate(ctx, request)
 }
 
 func (cas *CertificateAuthorityServerWrapper) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
-	if req == nil || req.DER == nil || req.OrderID == nil || req.RegistrationID == nil || req.SCTs == nil {
+	if req == nil || req.DER == nil || req.OrderID == 0 || req.RegistrationID == 0 || req.SCTs == nil {
 		return nil, errIncompleteRequest
 	}
 	cert, err := cas.inner.IssueCertificateForPrecertificate(ctx, req)
@@ -100,7 +100,7 @@ func (cas *CertificateAuthorityServerWrapper) IssueCertificateForPrecertificate(
 }
 
 func (cas *CertificateAuthorityServerWrapper) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
-	if (req.CertDER == nil && (req.Serial == nil || req.IssuerID == nil)) || req.Status == nil || req.Reason == nil || req.RevokedAt == nil {
+	if (req.CertDER == nil && (req.Serial == "" || req.IssuerID == 0)) || req.Status == "" || req.Reason == 0 || req.RevokedAt == 0 {
 		return nil, errIncompleteRequest
 	}
 	return cas.inner.GenerateOCSP(ctx, req)

--- a/grpc/ca-wrappers.go
+++ b/grpc/ca-wrappers.go
@@ -82,14 +82,14 @@ func NewCertificateAuthorityServer(inner core.CertificateAuthority) *Certificate
 }
 
 func (cas *CertificateAuthorityServerWrapper) IssuePrecertificate(ctx context.Context, request *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
-	if request == nil || request.Csr == nil || request.OrderID == 0 || request.RegistrationID == 0 {
+	if request == nil || request.Csr == nil {
 		return nil, errIncompleteRequest
 	}
 	return cas.inner.IssuePrecertificate(ctx, request)
 }
 
 func (cas *CertificateAuthorityServerWrapper) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
-	if req == nil || req.DER == nil || req.OrderID == 0 || req.RegistrationID == 0 || req.SCTs == nil {
+	if req == nil || req.DER == nil || req.SCTs == nil {
 		return nil, errIncompleteRequest
 	}
 	cert, err := cas.inner.IssueCertificateForPrecertificate(ctx, req)
@@ -100,7 +100,7 @@ func (cas *CertificateAuthorityServerWrapper) IssueCertificateForPrecertificate(
 }
 
 func (cas *CertificateAuthorityServerWrapper) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
-	if (req.CertDER == nil && (req.Serial == "" || req.IssuerID == 0)) || req.Status == "" || req.Reason == 0 || req.RevokedAt == 0 {
+	if req.CertDER == nil && (req.Serial == "" || req.IssuerID == 0) {
 		return nil, errIncompleteRequest
 	}
 	return cas.inner.GenerateOCSP(ctx, req)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1180,8 +1180,8 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	orderIDInt := int64(oID)
 	issueReq := &caPB.IssueCertificateRequest{
 		Csr:            csr.Raw,
-		RegistrationID: &acctIDInt,
-		OrderID:        &orderIDInt,
+		RegistrationID: acctIDInt,
+		OrderID:        orderIDInt,
 	}
 
 	// wrapError adds a prefix to an error. If the error is a boulder error then
@@ -1210,8 +1210,8 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	cert, err := ra.CA.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           scts,
-		RegistrationID: &acctIDInt,
-		OrderID:        &orderIDInt,
+		RegistrationID: acctIDInt,
+		OrderID:        orderIDInt,
 	})
 	if err != nil {
 		return emptyCert, wrapError(err, "issuing certificate for precertificate")
@@ -1651,14 +1651,13 @@ func revokeEvent(state, serial, cn string, names []string, revocationCode revoca
 // revokeCertificate generates a revoked OCSP response for the given certificate, stores
 // the revocation information, and purges OCSP request URLs from Akamai.
 func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, cert x509.Certificate, code revocation.Reason, revokedBy int64, source string, comment string) error {
-	status := string(core.OCSPStatusRevoked)
 	reason := int32(code)
 	revokedAt := ra.clk.Now().UnixNano()
 	ocspResponse, err := ra.CA.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
 		CertDER:   cert.Raw,
-		Status:    &status,
-		Reason:    &reason,
-		RevokedAt: &revokedAt,
+		Status:    string(core.OCSPStatusRevoked),
+		Reason:    reason,
+		RevokedAt: revokedAt,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This updates the ca.proto to use proto3 syntax, and updates
all clients of the autogenerated code to use the new types. In
particular, it removes indirection from built-in types (proto3
uses ints, rather than pointers to ints, for example).

It also updates a few instances where tests were being
conducted to see if various object fields were nil to instead
check for those fields' new zero-value.

Fixes #4940