### PR TITLE
Remove infinite memlock rlimit from docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,13 +59,6 @@ services:
           - bmysql
         entrypoint: test/entrypoint.sh
         working_dir: /go/src/github.com/letsencrypt/boulder
-        # This works around a kernel bug that is tickled by Go 1.14:
-        # https://github.com/golang/go/issues/37436
-        # Remove once devs are on Linux 5.4.2+
-        ulimits:
-          memlock:
-            soft: -1
-            hard: -1
     bmysql:
         image: mariadb:10.3
         networks:


### PR DESCRIPTION
This was necessary to work around a poor interaction between
Go 1.4.x and unpatched linux kernels. Although we are still using
the same version of Go, and the Linux project only released the
fix in kernel 5.4.2 and later, Ubuntu has backported the fix into
Focal Fossa 20.04's 5.4.0 kernel. Therefore this workaround is
no longer needed.
https://github.com/golang/go/issues/37436#issuecomment-657436406

This also removes one need for elevated permissions, making it
easier to use docker rootless for development.