### PR TITLE
Standardize all proto import names

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/crypto/ocsp"
 
 	ca_config "github.com/letsencrypt/boulder/ca/config"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	csrlib "github.com/letsencrypt/boulder/csr"
@@ -429,7 +429,7 @@ var ocspStatusToCode = map[string]int{
 }
 
 // GenerateOCSP produces a new OCSP response and returns it
-func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *caPB.GenerateOCSPRequest) (*caPB.OCSPResponse, error) {
+func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	var issuer *internalIssuer
 	var serial *big.Int
 	// Once the feature is enabled we need to support both RPCs that include
@@ -486,10 +486,10 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *caPB.
 	if err == nil {
 		ca.signatureCount.With(prometheus.Labels{"purpose": "ocsp"}).Inc()
 	}
-	return &caPB.OCSPResponse{Response: ocspResponse}, err
+	return &capb.OCSPResponse{Response: ocspResponse}, err
 }
 
-func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, issueReq *caPB.IssueCertificateRequest) (*caPB.IssuePrecertificateResponse, error) {
+func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, issueReq *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
 	serialBigInt, validity, err := ca.generateSerialNumberAndValidity()
 	if err != nil {
 		return nil, err
@@ -516,7 +516,7 @@ func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 	}
 
 	status := string(core.OCSPStatusGood)
-	ocspResp, err := ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
+	ocspResp, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		CertDER: precertDER,
 		Status:  &status,
 	})
@@ -557,7 +557,7 @@ func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 		return nil, err
 	}
 
-	return &caPB.IssuePrecertificateResponse{
+	return &capb.IssuePrecertificateResponse{
 		DER: precertDER,
 	}, nil
 }
@@ -584,7 +584,7 @@ func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 // final certificate, but this is just a belt-and-suspenders measure, since
 // there could be race conditions where two goroutines are issuing for the same
 // serial number at the same time.
-func (ca *CertificateAuthorityImpl) IssueCertificateForPrecertificate(ctx context.Context, req *caPB.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
+func (ca *CertificateAuthorityImpl) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
 	emptyCert := core.Certificate{}
 	precert, err := x509.ParseCertificate(req.DER)
 	if err != nil {
@@ -654,7 +654,7 @@ func (ca *CertificateAuthorityImpl) generateSerialNumberAndValidity() (*big.Int,
 	return serialBigInt, validity, nil
 }
 
-func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *caPB.IssueCertificateRequest, serialBigInt *big.Int, validity validity) ([]byte, error) {
+func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, serialBigInt *big.Int, validity validity) ([]byte, error) {
 	csr, err := x509.ParseCertificateRequest(issueReq.Csr)
 	if err != nil {
 		return nil, err

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/crypto/ocsp"
 
 	ca_config "github.com/letsencrypt/boulder/ca/config"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
@@ -348,7 +348,7 @@ func TestIssuePrecertificate(t *testing.T) {
 				req, err := x509.ParseCertificateRequest(testCase.csr)
 				test.AssertNotError(t, err, "Certificate request failed to parse")
 
-				issueReq := &caPB.IssueCertificateRequest{Csr: testCase.csr, RegistrationID: &arbitraryRegID}
+				issueReq := &capb.IssueCertificateRequest{Csr: testCase.csr, RegistrationID: &arbitraryRegID}
 
 				var certDER []byte
 				response, err := ca.IssuePrecertificate(ctx, issueReq)
@@ -456,7 +456,7 @@ func TestMultipleIssuers(t *testing.T) {
 		nil)
 	test.AssertNotError(t, err, "Failed to remake CA")
 
-	issuedCert, err := ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID})
+	issuedCert, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 
 	cert, err := x509.ParseCertificate(issuedCert.DER)
@@ -481,14 +481,14 @@ func TestOCSP(t *testing.T) {
 		nil)
 	test.AssertNotError(t, err, "Failed to create CA")
 
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID}
+	issueReq := capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID}
 
 	cert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue")
 	parsedCert, err := x509.ParseCertificate(cert.DER)
 	test.AssertNotError(t, err, "Failed to parse cert")
 	status := string(core.OCSPStatusGood)
-	ocspResp, err := ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
+	ocspResp, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		CertDER: cert.DER,
 		Status:  &status,
 	})
@@ -500,7 +500,7 @@ func TestOCSP(t *testing.T) {
 	test.AssertEquals(t, parsed.SerialNumber.Cmp(parsedCert.SerialNumber), 0)
 
 	// Test that signatures are checked.
-	_, err = ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
+	_, err = ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		CertDER: append(cert.DER, byte(0)),
 		Status:  &status,
 	})
@@ -543,7 +543,7 @@ func TestOCSP(t *testing.T) {
 
 	// ocspResp2 is a second OCSP response for `cert` (issued by caCert), and
 	// should be signed by caCert.
-	ocspResp2, err := ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
+	ocspResp2, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		CertDER: append([]byte(nil), cert.DER...),
 		Status:  &status,
 	})
@@ -553,7 +553,7 @@ func TestOCSP(t *testing.T) {
 
 	// newCertOcspResp is an OCSP response for `newCert` (issued by newIssuer),
 	// and should be signed by newIssuer.
-	newCertOcspResp, err := ca.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
+	newCertOcspResp, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		CertDER: newCert.DER,
 		Status:  &status,
 	})
@@ -631,7 +631,7 @@ func TestInvalidCSRs(t *testing.T) {
 
 		t.Run(testCase.name, func(t *testing.T) {
 			serializedCSR := mustRead(testCase.csrPath)
-			issueReq := &caPB.IssueCertificateRequest{Csr: serializedCSR, RegistrationID: &arbitraryRegID}
+			issueReq := &capb.IssueCertificateRequest{Csr: serializedCSR, RegistrationID: &arbitraryRegID}
 			_, err = ca.IssuePrecertificate(ctx, issueReq)
 
 			test.Assert(t, berrors.Is(err, testCase.errorType), "Incorrect error type returned")
@@ -666,7 +666,7 @@ func TestRejectValidityTooLong(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to parse time")
 	testCtx.fc.Set(future)
 	// Test that the CA rejects CSRs that would expire after the intermediate cert
-	_, err = ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{Csr: NoCNCSR, RegistrationID: &arbitraryRegID})
+	_, err = ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: NoCNCSR, RegistrationID: &arbitraryRegID})
 	test.AssertError(t, err, "Cannot issue a certificate that expires after the intermediate certificate")
 	test.Assert(t, berrors.Is(err, berrors.InternalServer), "Incorrect error type returned")
 }
@@ -842,7 +842,7 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to create CA")
 
 	orderID := int64(0)
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID, OrderID: &orderID}
+	issueReq := capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID, OrderID: &orderID}
 	precert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue precert")
 	parsedPrecert, err := x509.ParseCertificate(precert.DER)
@@ -863,7 +863,7 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 	}
 
 	test.AssertNotError(t, err, "Failed to marshal SCT")
-	cert, err := ca.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
+	cert, err := ca.IssueCertificateForPrecertificate(ctx, &capb.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           sctBytes,
 		RegistrationID: &arbitraryRegID,
@@ -929,10 +929,10 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 	}
 
 	orderID := int64(0)
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID, OrderID: &orderID}
+	issueReq := capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID, OrderID: &orderID}
 	precert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue precert")
-	_, err = ca.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
+	_, err = ca.IssueCertificateForPrecertificate(ctx, &capb.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           sctBytes,
 		RegistrationID: &arbitraryRegID,
@@ -960,7 +960,7 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		nil)
 	test.AssertNotError(t, err, "Failed to create CA")
 
-	_, err = errorca.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
+	_, err = errorca.IssueCertificateForPrecertificate(ctx, &capb.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           sctBytes,
 		RegistrationID: &arbitraryRegID,
@@ -1039,7 +1039,7 @@ func TestPrecertOrphanQueue(t *testing.T) {
 	}
 
 	var one int64 = 1
-	_, err = ca.IssuePrecertificate(context.Background(), &caPB.IssueCertificateRequest{
+	_, err = ca.IssuePrecertificate(context.Background(), &capb.IssueCertificateRequest{
 		RegistrationID: &one,
 		OrderID:        &one,
 		Csr:            CNandSANCSR,
@@ -1227,7 +1227,7 @@ func TestIssuePrecertificateLinting(t *testing.T) {
 	testCtx.logger.Clear()
 
 	// Attempt to issue a pre-certificate
-	_, err = ca.IssuePrecertificate(ctx, &caPB.IssueCertificateRequest{
+	_, err = ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{
 		Csr:            CNandSANCSR,
 		RegistrationID: &arbitraryRegID,
 	})
@@ -1265,7 +1265,7 @@ func TestGenerateOCSPWithIssuerID(t *testing.T) {
 	issuerID := int64(666)
 	serial := "DEADDEADDEADDEADDEADDEADDEADDEADDEAD"
 	status := string(core.OCSPStatusGood)
-	_, err = ca.GenerateOCSP(context.Background(), &caPB.GenerateOCSPRequest{
+	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
 		IssuerID: &issuerID,
 		Serial:   &serial,
 		Status:   &status,
@@ -1274,7 +1274,7 @@ func TestGenerateOCSPWithIssuerID(t *testing.T) {
 
 	// GenerateOCSP with feature enabled + req contains good IssuerID
 	issuerID = idForIssuer(ca.defaultIssuer.cert)
-	_, err = ca.GenerateOCSP(context.Background(), &caPB.GenerateOCSPRequest{
+	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
 		IssuerID: &issuerID,
 		Serial:   &serial,
 		Status:   &status,
@@ -1282,10 +1282,10 @@ func TestGenerateOCSPWithIssuerID(t *testing.T) {
 	test.AssertNotError(t, err, "GenerateOCSP failed")
 
 	// GenerateOCSP with feature enabled + req doesn't contain IssuerID
-	issueReq := caPB.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID}
+	issueReq := capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: &arbitraryRegID}
 	cert, err := ca.IssuePrecertificate(ctx, &issueReq)
 	test.AssertNotError(t, err, "Failed to issue")
-	_, err = ca.GenerateOCSP(context.Background(), &caPB.GenerateOCSPRequest{
+	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
 		CertDER: cert.DER,
 		Status:  &status,
 	})

--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/goodkey"
 	blog "github.com/letsencrypt/boulder/log"
@@ -31,8 +31,8 @@ type mockCA struct {
 	mocks.MockCA
 }
 
-func (ca *mockCA) GenerateOCSP(ctx context.Context, req *caPB.GenerateOCSPRequest) (*caPB.OCSPResponse, error) {
-	return &caPB.OCSPResponse{}, nil
+func (ca *mockCA) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
+	return &capb.OCSPResponse{}, nil
 }
 
 func TestRevokeBatch(t *testing.T) {

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/letsencrypt/boulder/ca"
 	ca_config "github.com/letsencrypt/boulder/ca/config"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/features"
@@ -195,7 +195,7 @@ func main() {
 	caSrv, caListener, err := bgrpc.NewServer(c.CA.GRPCCA, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup CA gRPC server")
 	caWrapper := bgrpc.NewCertificateAuthorityServer(cai)
-	caPB.RegisterCertificateAuthorityServer(caSrv, caWrapper)
+	capb.RegisterCertificateAuthorityServer(caSrv, caWrapper)
 	go func() {
 		cmd.FailOnError(cmd.FilterShutdownErrors(caSrv.Serve(caListener)), "CA gRPC service failed")
 	}()
@@ -203,7 +203,7 @@ func main() {
 	ocspSrv, ocspListener, err := bgrpc.NewServer(c.CA.GRPCOCSPGenerator, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup CA gRPC server")
 	ocspWrapper := bgrpc.NewCertificateAuthorityServer(cai)
-	caPB.RegisterOCSPGeneratorServer(ocspSrv, ocspWrapper)
+	capb.RegisterOCSPGeneratorServer(ocspSrv, ocspWrapper)
 	go func() {
 		cmd.FailOnError(cmd.FilterShutdownErrors(ocspSrv.Serve(ocspListener)),
 			"OCSPGenerator gRPC service failed")

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/publisher"
-	pubPB "github.com/letsencrypt/boulder/publisher/proto"
+	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 )
 
 type config struct {
@@ -93,7 +93,7 @@ func main() {
 	grpcSrv, l, err := bgrpc.NewServer(c.Publisher.GRPC, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup Publisher gRPC server")
 	gw := bgrpc.NewPublisherServerWrapper(pubi)
-	pubPB.RegisterPublisherServer(grpcSrv, gw)
+	pubpb.RegisterPublisherServer(grpcSrv, gw)
 
 	go cmd.CatchSignals(logger, grpcSrv.GracefulStop)
 

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/ctpolicy"
@@ -17,11 +17,11 @@ import (
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/policy"
-	pubPB "github.com/letsencrypt/boulder/publisher/proto"
+	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	"github.com/letsencrypt/boulder/ra"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
-	vaPB "github.com/letsencrypt/boulder/va/proto"
+	vapb "github.com/letsencrypt/boulder/va/proto"
 )
 
 type config struct {
@@ -145,16 +145,16 @@ func main() {
 	cmd.FailOnError(err, "Unable to create VA client")
 	vac := bgrpc.NewValidationAuthorityGRPCClient(vaConn)
 
-	caaClient := vaPB.NewCAAClient(vaConn)
+	caaClient := vapb.NewCAAClient(vaConn)
 
 	caConn, err := bgrpc.ClientSetup(c.RA.CAService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Unable to create CA client")
-	cac := bgrpc.NewCertificateAuthorityClient(caPB.NewCertificateAuthorityClient(caConn))
+	cac := bgrpc.NewCertificateAuthorityClient(capb.NewCertificateAuthorityClient(caConn))
 
 	var ctp *ctpolicy.CTPolicy
 	conn, err := bgrpc.ClientSetup(c.RA.PublisherService, tlsConfig, clientMetrics, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to Publisher")
-	pubc := bgrpc.NewPublisherClientWrapper(pubPB.NewPublisherClient(conn))
+	pubc := bgrpc.NewPublisherClientWrapper(pubpb.NewPublisherClient(conn))
 
 	var apc akamaipb.AkamaiPurgerClient
 	var issuerCert *x509.Certificate

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/va"
-	vaPB "github.com/letsencrypt/boulder/va/proto"
+	vapb "github.com/letsencrypt/boulder/va/proto"
 )
 
 type config struct {
@@ -165,7 +165,7 @@ func main() {
 	cmd.FailOnError(err, "Unable to setup VA gRPC server")
 	err = bgrpc.RegisterValidationAuthorityGRPCServer(grpcSrv, vai)
 	cmd.FailOnError(err, "Unable to register VA gRPC server")
-	vaPB.RegisterCAAServer(grpcSrv, vai)
+	vapb.RegisterCAAServer(grpcSrv, vai)
 	cmd.FailOnError(err, "Unable to register CAA gRPC server")
 
 	go cmd.CatchSignals(logger, grpcSrv.GracefulStop)

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	akamaiProto "github.com/letsencrypt/boulder/akamai/proto"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/db"
@@ -35,9 +35,9 @@ type mockOCSP struct {
 	sleepTime time.Duration
 }
 
-func (ca *mockOCSP) GenerateOCSP(_ context.Context, req *caPB.GenerateOCSPRequest, _ ...grpc.CallOption) (*caPB.OCSPResponse, error) {
+func (ca *mockOCSP) GenerateOCSP(_ context.Context, req *capb.GenerateOCSPRequest, _ ...grpc.CallOption) (*capb.OCSPResponse, error) {
 	time.Sleep(ca.sleepTime)
-	return &caPB.OCSPResponse{Response: []byte{1, 2, 3}}, nil
+	return &capb.OCSPResponse{Response: []byte{1, 2, 3}}, nil
 }
 
 var log = blog.UseMock()
@@ -83,7 +83,7 @@ func TestGenerateAndStoreOCSPResponse(t *testing.T) {
 	issuer, err := core.LoadCert("../../test/test-ca2.pem")
 	test.AssertNotError(t, err, "Couldn't read test issuer certificate")
 	updater.issuer = issuer
-	updater.purgerService = akamaiProto.NewAkamaiPurgerClient(nil)
+	updater.purgerService = akamaipb.NewAkamaiPurgerClient(nil)
 
 	reg := satest.CreateWorkingRegistration(t, sa)
 	parsedCert, err := core.LoadCert("test-cert.pem")
@@ -415,9 +415,9 @@ type mockOCSPRecordIssuer struct {
 	gotIssuer bool
 }
 
-func (ca *mockOCSPRecordIssuer) GenerateOCSP(_ context.Context, req *caPB.GenerateOCSPRequest, _ ...grpc.CallOption) (*caPB.OCSPResponse, error) {
+func (ca *mockOCSPRecordIssuer) GenerateOCSP(_ context.Context, req *capb.GenerateOCSPRequest, _ ...grpc.CallOption) (*capb.OCSPResponse, error) {
 	ca.gotIssuer = req.IssuerID != nil && req.Serial != nil
-	return &caPB.OCSPResponse{Response: []byte{1, 2, 3}}, nil
+	return &capb.OCSPResponse{Response: []byte{1, 2, 3}}, nil
 }
 
 func TestIssuerInfo(t *testing.T) {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -9,7 +9,7 @@ import (
 
 	jose "gopkg.in/square/go-jose.v2"
 
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/identifier"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
@@ -94,12 +94,12 @@ type RegistrationAuthority interface {
 // CertificateAuthority defines the public interface for the Boulder CA
 type CertificateAuthority interface {
 	// [RegistrationAuthority]
-	IssuePrecertificate(ctx context.Context, issueReq *caPB.IssueCertificateRequest) (*caPB.IssuePrecertificateResponse, error)
+	IssuePrecertificate(ctx context.Context, issueReq *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error)
 
 	// [RegistrationAuthority]
-	IssueCertificateForPrecertificate(ctx context.Context, req *caPB.IssueCertificateForPrecertificateRequest) (Certificate, error)
+	IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (Certificate, error)
 
-	GenerateOCSP(ctx context.Context, ocspReq *caPB.GenerateOCSPRequest) (*caPB.OCSPResponse, error)
+	GenerateOCSP(ctx context.Context, ocspReq *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error)
 }
 
 // PolicyAuthority defines the public interface for the Boulder PA

--- a/grpc/va-wrappers.go
+++ b/grpc/va-wrappers.go
@@ -13,14 +13,14 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/probs"
-	vaPB "github.com/letsencrypt/boulder/va/proto"
+	vapb "github.com/letsencrypt/boulder/va/proto"
 )
 
 type ValidationAuthorityGRPCServer struct {
 	impl core.ValidationAuthority
 }
 
-func (s *ValidationAuthorityGRPCServer) PerformValidation(ctx context.Context, in *vaPB.PerformValidationRequest) (*vaPB.ValidationResult, error) {
+func (s *ValidationAuthorityGRPCServer) PerformValidation(ctx context.Context, in *vapb.PerformValidationRequest) (*vapb.ValidationResult, error) {
 	domain, challenge, authz, err := performValidationReqToArgs(in)
 	if err != nil {
 		return nil, err
@@ -41,16 +41,16 @@ func (s *ValidationAuthorityGRPCServer) PerformValidation(ctx context.Context, i
 
 func RegisterValidationAuthorityGRPCServer(s *ggrpc.Server, impl core.ValidationAuthority) error {
 	rpcSrv := &ValidationAuthorityGRPCServer{impl}
-	vaPB.RegisterVAServer(s, rpcSrv)
+	vapb.RegisterVAServer(s, rpcSrv)
 	return nil
 }
 
 type ValidationAuthorityGRPCClient struct {
-	gc vaPB.VAClient
+	gc vapb.VAClient
 }
 
 func NewValidationAuthorityGRPCClient(cc *ggrpc.ClientConn) core.ValidationAuthority {
-	return &ValidationAuthorityGRPCClient{vaPB.NewVAClient(cc)}
+	return &ValidationAuthorityGRPCClient{vapb.NewVAClient(cc)}
 }
 
 // PerformValidation has the VA revalidate the specified challenge and returns

--- a/mocks/ca.go
+++ b/mocks/ca.go
@@ -6,7 +6,7 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/revocation"
 )
@@ -18,7 +18,7 @@ type MockCA struct {
 }
 
 // IssueCertificate is a mock
-func (ca *MockCA) IssueCertificate(ctx context.Context, _ *caPB.IssueCertificateRequest) (core.Certificate, error) {
+func (ca *MockCA) IssueCertificate(ctx context.Context, _ *capb.IssueCertificateRequest) (core.Certificate, error) {
 	if ca.PEM == nil {
 		return core.Certificate{}, fmt.Errorf("MockCA's PEM field must be set before calling IssueCertificate")
 	}
@@ -33,7 +33,7 @@ func (ca *MockCA) IssueCertificate(ctx context.Context, _ *caPB.IssueCertificate
 }
 
 // IssuePrecertificate is a mock
-func (ca *MockCA) IssuePrecertificate(ctx context.Context, _ *caPB.IssueCertificateRequest) (*caPB.IssuePrecertificateResponse, error) {
+func (ca *MockCA) IssuePrecertificate(ctx context.Context, _ *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
 	if ca.PEM == nil {
 		return nil, fmt.Errorf("MockCA's PEM field must be set before calling IssueCertificate")
 	}
@@ -42,18 +42,18 @@ func (ca *MockCA) IssuePrecertificate(ctx context.Context, _ *caPB.IssueCertific
 	if err != nil {
 		return nil, err
 	}
-	return &caPB.IssuePrecertificateResponse{
+	return &capb.IssuePrecertificateResponse{
 		DER: cert.Raw,
 	}, nil
 }
 
 // IssueCertificateForPrecertificate is a mock
-func (ca *MockCA) IssueCertificateForPrecertificate(ctx context.Context, req *caPB.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
+func (ca *MockCA) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
 	return core.Certificate{DER: req.DER}, nil
 }
 
 // GenerateOCSP is a mock
-func (ca *MockCA) GenerateOCSP(ctx context.Context, req *caPB.GenerateOCSPRequest) (*caPB.OCSPResponse, error) {
+func (ca *MockCA) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	return nil, nil
 }
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/akamai"
 	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
-	caPB "github.com/letsencrypt/boulder/ca/proto"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	csrlib "github.com/letsencrypt/boulder/csr"
@@ -35,7 +35,7 @@ import (
 	"github.com/letsencrypt/boulder/reloader"
 	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
-	vaPB "github.com/letsencrypt/boulder/va/proto"
+	vapb "github.com/letsencrypt/boulder/va/proto"
 	"github.com/letsencrypt/boulder/web"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
@@ -46,9 +46,9 @@ import (
 type caaChecker interface {
 	IsCAAValid(
 		ctx context.Context,
-		in *vaPB.IsCAAValidRequest,
+		in *vapb.IsCAAValidRequest,
 		opts ...grpc.CallOption,
-	) (*vaPB.IsCAAValidResponse, error)
+	) (*vapb.IsCAAValidResponse, error)
 }
 
 // RegistrationAuthorityImpl defines an RA.
@@ -847,7 +847,7 @@ func (ra *RegistrationAuthorityImpl) recheckCAA(ctx context.Context, authzs []*c
 				return
 			}
 
-			resp, err := ra.caa.IsCAAValid(ctx, &vaPB.IsCAAValidRequest{
+			resp, err := ra.caa.IsCAAValid(ctx, &vapb.IsCAAValidRequest{
 				Domain:           &name,
 				ValidationMethod: &method,
 				AccountURIID:     &authz.RegistrationID,
@@ -1186,7 +1186,7 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	// Create the certificate and log the result
 	acctIDInt := int64(acctID)
 	orderIDInt := int64(oID)
-	issueReq := &caPB.IssueCertificateRequest{
+	issueReq := &capb.IssueCertificateRequest{
 		Csr:            csr.Raw,
 		RegistrationID: &acctIDInt,
 		OrderID:        &orderIDInt,
@@ -1215,7 +1215,7 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	if err != nil {
 		return emptyCert, wrapError(err, "getting SCTs")
 	}
-	cert, err := ra.CA.IssueCertificateForPrecertificate(ctx, &caPB.IssueCertificateForPrecertificateRequest{
+	cert, err := ra.CA.IssueCertificateForPrecertificate(ctx, &capb.IssueCertificateForPrecertificateRequest{
 		DER:            precert.DER,
 		SCTs:           scts,
 		RegistrationID: &acctIDInt,
@@ -1662,7 +1662,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, cert
 	status := string(core.OCSPStatusRevoked)
 	reason := int32(code)
 	revokedAt := ra.clk.Now().UnixNano()
-	ocspResponse, err := ra.CA.GenerateOCSP(ctx, &caPB.GenerateOCSPRequest{
+	ocspResponse, err := ra.CA.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		CertDER:   cert.Raw,
 		Status:    &status,
 		Reason:    &reason,

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -53,7 +53,7 @@ import (
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
-	vaPB "github.com/letsencrypt/boulder/va/proto"
+	vapb "github.com/letsencrypt/boulder/va/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
 	"golang.org/x/crypto/ocsp"
@@ -1760,10 +1760,10 @@ type noopCAA struct{}
 
 func (cr noopCAA) IsCAAValid(
 	ctx context.Context,
-	in *vaPB.IsCAAValidRequest,
+	in *vapb.IsCAAValidRequest,
 	opts ...grpc.CallOption,
-) (*vaPB.IsCAAValidResponse, error) {
-	return &vaPB.IsCAAValidResponse{}, nil
+) (*vapb.IsCAAValidResponse, error) {
+	return &vapb.IsCAAValidResponse{}, nil
 }
 
 // caaRecorder implements caaChecker, always returning nil, but recording the
@@ -1775,13 +1775,13 @@ type caaRecorder struct {
 
 func (cr *caaRecorder) IsCAAValid(
 	ctx context.Context,
-	in *vaPB.IsCAAValidRequest,
+	in *vapb.IsCAAValidRequest,
 	opts ...grpc.CallOption,
-) (*vaPB.IsCAAValidResponse, error) {
+) (*vapb.IsCAAValidResponse, error) {
 	cr.Lock()
 	defer cr.Unlock()
 	cr.names[*in.Domain] = true
-	return &vaPB.IsCAAValidResponse{}, nil
+	return &vapb.IsCAAValidResponse{}, nil
 }
 
 // A mock SA that returns special authzs for testing rechecking of CAA (in
@@ -1895,10 +1895,10 @@ type caaFailer struct{}
 
 func (cf *caaFailer) IsCAAValid(
 	ctx context.Context,
-	in *vaPB.IsCAAValidRequest,
+	in *vapb.IsCAAValidRequest,
 	opts ...grpc.CallOption,
-) (*vaPB.IsCAAValidResponse, error) {
-	cvrpb := &vaPB.IsCAAValidResponse{}
+) (*vapb.IsCAAValidResponse, error) {
+	cvrpb := &vapb.IsCAAValidResponse{}
 	switch *in.Domain {
 	case "a.com":
 		cvrpb.Problem = &corepb.ProblemDetails{

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -38,7 +38,7 @@ import (
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/revocation"
 	"github.com/letsencrypt/boulder/test"
-	vaPB "github.com/letsencrypt/boulder/va/proto"
+	vapb "github.com/letsencrypt/boulder/va/proto"
 	"github.com/letsencrypt/boulder/web"
 	"google.golang.org/grpc"
 	"gopkg.in/square/go-jose.v2"
@@ -823,10 +823,10 @@ type noopCAA struct{}
 
 func (cr noopCAA) IsCAAValid(
 	ctx context.Context,
-	in *vaPB.IsCAAValidRequest,
+	in *vapb.IsCAAValidRequest,
 	opts ...grpc.CallOption,
-) (*vaPB.IsCAAValidResponse, error) {
-	return &vaPB.IsCAAValidResponse{}, nil
+) (*vapb.IsCAAValidResponse, error) {
+	return &vapb.IsCAAValidResponse{}, nil
 }
 
 func TestRelativeDirectory(t *testing.T) {


### PR DESCRIPTION
We previously used mixed case names for proto imports
(e.g. both `caPB` and `rapb`), sometimes in the same file.
This change standardizes on the all-lowercase spelling,
which was predominant throughout the codebase.