### PR TITLE
Move CA RPC non-nil checks out of wrappers

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -208,6 +208,32 @@ func GetBuildHost() (retID string) {
 	return
 }
 
+// IsAnyNilOrZero returns whether any of the supplied values are nil, or (if not)
+// if any of them it its type's zero-value. This is useful for validating that
+// all required fields on a proto message are present.
+func IsAnyNilOrZero(vals ...interface{}) bool {
+	for _, val := range vals {
+		switch v := val.(type) {
+		case nil:
+			return true
+		case int32, int64, uint32, uint64, float32, float64:
+			if v == 0 {
+				return true
+			}
+		case string:
+			if v == "" {
+				return true
+			}
+		case bool:
+			if v == false {
+				return true
+			}
+		default:
+		}
+	}
+	return false
+}
+
 // UniqueLowerNames returns the set of all unique names in the input after all
 // of them are lowercased. The returned names will be in their lowercased form
 // and sorted alphabetically.

--- a/core/util.go
+++ b/core/util.go
@@ -209,14 +209,19 @@ func GetBuildHost() (retID string) {
 }
 
 // IsAnyNilOrZero returns whether any of the supplied values are nil, or (if not)
-// if any of them it its type's zero-value. This is useful for validating that
+// if any of them is its type's zero-value. This is useful for validating that
 // all required fields on a proto message are present.
 func IsAnyNilOrZero(vals ...interface{}) bool {
 	for _, val := range vals {
 		switch v := val.(type) {
 		case nil:
 			return true
-		case int32, int64, uint32, uint64, float32, float64:
+		// These are the go types which correspond to proto3's scalar fields.
+		case bool:
+			if v == false {
+				return true
+			}
+		case int, int32, int64, uint, uint32, uint64, float32, float64:
 			if v == 0 {
 				return true
 			}
@@ -224,8 +229,51 @@ func IsAnyNilOrZero(vals ...interface{}) bool {
 			if v == "" {
 				return true
 			}
-		case bool:
-			if v == false {
+		// These are the go types which correspond to proto2's scalar fields.
+		// TODO(#2936): Remove these when all proto2 generated code is gone.
+		case *bool:
+			if *v == false {
+				return true
+			}
+		case *int:
+			if *v == 0 {
+				return true
+			}
+		case *int32:
+			if *v == 0 {
+				return true
+			}
+		case *int64:
+			if *v == 0 {
+				return true
+			}
+		case *uint:
+			if *v == 0 {
+				return true
+			}
+		case *uint32:
+			if *v == 0 {
+				return true
+			}
+		case *uint64:
+			if *v == 0 {
+				return true
+			}
+		case *float32:
+			if *v == 0 {
+				return true
+			}
+		case *float64:
+			if *v == 0 {
+				return true
+			}
+		case *string:
+			if *v == "" {
+				return true
+			}
+		// This is the go type which can be generated for both proto2 and proto3.
+		case []byte:
+			if len(v) == 0 {
 				return true
 			}
 		default:

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -107,6 +107,39 @@ func TestKeyDigestEquals(t *testing.T) {
 	test.Assert(t, !KeyDigestEquals(struct{}{}, struct{}{}), "Unknown key types should not match anything")
 }
 
+func TestIsAnyNilOrZero(t *testing.T) {
+	test.Assert(t, IsAnyNilOrZero(nil), "Nil seen as non-zero")
+
+	zeroBool := false
+	nonZeroBool := true
+	test.Assert(t, IsAnyNilOrZero(zeroBool), "False bool seen as non-zero")
+	test.Assert(t, IsAnyNilOrZero(&zeroBool), "False bool seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(nonZeroBool), "True bool seen as zero")
+	test.Assert(t, !IsAnyNilOrZero(&nonZeroBool), "True bool seen as zero")
+
+	zeroNum := 0
+	nonZeroNum := -12.345
+	test.Assert(t, IsAnyNilOrZero(zeroNum), "Zero num seen as non-zero")
+	test.Assert(t, IsAnyNilOrZero(&zeroNum), "Zero num seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(nonZeroNum), "Non-zero num seen as zero")
+	test.Assert(t, !IsAnyNilOrZero(&nonZeroNum), "Non-zero num seen as zero")
+
+	zeroStr := ""
+	nonZeroStr := "string"
+	test.Assert(t, IsAnyNilOrZero(zeroStr), "Empty string seen as non-zero")
+	test.Assert(t, IsAnyNilOrZero(&zeroStr), "Empty string seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(nonZeroStr), "Non-empty string seen as zero")
+	test.Assert(t, !IsAnyNilOrZero(&nonZeroStr), "Non-empty string seen as zero")
+
+	zeroByte := []byte{}
+	nonZeroByte := []byte("byte")
+	test.Assert(t, IsAnyNilOrZero(zeroByte), "Empty byte slice seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(nonZeroByte), "Non-empty byte slice seen as zero")
+
+	test.Assert(t, IsAnyNilOrZero(1, ""), "Mixed values seen as non-zero")
+	test.Assert(t, IsAnyNilOrZero("", 1), "Mixed values seen as non-zero")
+}
+
 func TestUniqueLowerNames(t *testing.T) {
 	u := UniqueLowerNames([]string{"foobar.com", "fooBAR.com", "baz.com", "foobar.com", "bar.com", "bar.com", "a.com"})
 	sort.Strings(u)

--- a/grpc/ca-wrappers.go
+++ b/grpc/ca-wrappers.go
@@ -82,16 +82,10 @@ func NewCertificateAuthorityServer(inner core.CertificateAuthority) *Certificate
 }
 
 func (cas *CertificateAuthorityServerWrapper) IssuePrecertificate(ctx context.Context, request *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
-	if request == nil || request.Csr == nil || request.OrderID == nil || request.RegistrationID == nil {
-		return nil, errIncompleteRequest
-	}
 	return cas.inner.IssuePrecertificate(ctx, request)
 }
 
 func (cas *CertificateAuthorityServerWrapper) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
-	if req == nil || req.DER == nil || req.OrderID == nil || req.RegistrationID == nil || req.SCTs == nil {
-		return nil, errIncompleteRequest
-	}
 	cert, err := cas.inner.IssueCertificateForPrecertificate(ctx, req)
 	if err != nil {
 		return nil, err
@@ -100,8 +94,5 @@ func (cas *CertificateAuthorityServerWrapper) IssueCertificateForPrecertificate(
 }
 
 func (cas *CertificateAuthorityServerWrapper) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
-	if (req.CertDER == nil && (req.Serial == nil || req.IssuerID == nil)) || req.Status == nil || req.Reason == nil || req.RevokedAt == nil {
-		return nil, errIncompleteRequest
-	}
 	return cas.inner.GenerateOCSP(ctx, req)
 }

--- a/grpc/ca-wrappers.go
+++ b/grpc/ca-wrappers.go
@@ -24,14 +24,7 @@ func NewCertificateAuthorityClient(inner capb.CertificateAuthorityClient) *Certi
 }
 
 func (cac CertificateAuthorityClientWrapper) IssuePrecertificate(ctx context.Context, issueReq *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
-	resp, err := cac.inner.IssuePrecertificate(ctx, issueReq)
-	if err != nil {
-		return nil, err
-	}
-	if resp == nil || resp.DER == nil {
-		return nil, errIncompleteResponse
-	}
-	return resp, nil
+	return cac.inner.IssuePrecertificate(ctx, issueReq)
 }
 
 func (cac CertificateAuthorityClientWrapper) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
@@ -43,14 +36,7 @@ func (cac CertificateAuthorityClientWrapper) IssueCertificateForPrecertificate(c
 }
 
 func (cac CertificateAuthorityClientWrapper) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
-	res, err := cac.inner.GenerateOCSP(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if res == nil || res.Response == nil {
-		return nil, errIncompleteResponse
-	}
-	return res, nil
+	return cac.inner.GenerateOCSP(ctx, req)
 }
 
 type OCSPGeneratorClientWrapper struct {
@@ -62,14 +48,7 @@ func NewOCSPGeneratorClient(inner capb.OCSPGeneratorClient) *OCSPGeneratorClient
 }
 
 func (ogc OCSPGeneratorClientWrapper) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest, _ ...grpc.CallOption) (*capb.OCSPResponse, error) {
-	res, err := ogc.inner.GenerateOCSP(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if res == nil || res.Response == nil {
-		return nil, errIncompleteResponse
-	}
-	return res, nil
+	return ogc.inner.GenerateOCSP(ctx, req)
 }
 
 // CertificateAuthorityServerWrapper is the gRPC version of a core.CertificateAuthority server


### PR DESCRIPTION
Introduces a new generic helper utility to check that
fields of proto messages are non-nil and non-zero.

Uses this helper to simplify the ca RPC wrapper
methods, moving their completeness checks into
the underlying method handler. Also annotates the
completeness checks to justify which fields are or
are not being checked for future readers. Finally,
removes the similar non-nil checks from the client
wrappers, where they provide no marginal value.

Follow-up changes will do the same for other RPC
services, migrate said services to proto3, and change
the `IssueCertificateForPrecertificate` method to return
a `corepb.Certificate` instead of a `core.Certificate`, like
the other methods on the ca service.

Issues: #4955