### PR TITLE
Handle "too many objects" in pkcs11helper.

### DIFF
--- a/pkcs11helpers/helpers.go
+++ b/pkcs11helpers/helpers.go
@@ -182,6 +182,8 @@ func Sign(ctx PKCtx, session pkcs11.SessionHandle, object pkcs11.ObjectHandle, k
 	return signature, nil
 }
 
+var ErrNoObject = errors.New("no objects found matching provided template")
+
 // FindObject looks up a PKCS#11 object handle based on the provided template.
 // In the case where zero or more than one objects are found to match the
 // template an error is returned.
@@ -189,18 +191,18 @@ func FindObject(ctx PKCtx, session pkcs11.SessionHandle, tmpl []*pkcs11.Attribut
 	if err := ctx.FindObjectsInit(session, tmpl); err != nil {
 		return 0, err
 	}
-	handles, more, err := ctx.FindObjects(session, 1)
+	handles, _, err := ctx.FindObjects(session, 10)
 	if err != nil {
 		return 0, err
 	}
-	if len(handles) == 0 {
-		return 0, errors.New("no objects found matching provided template")
-	}
-	if more {
-		return 0, errors.New("more than one object matches provided template")
-	}
 	if err := ctx.FindObjectsFinal(session); err != nil {
 		return 0, err
+	}
+	if len(handles) == 0 {
+		return 0, ErrNoObject
+	}
+	if len(handles) > 1 {
+		return 0, fmt.Errorf("too many objects (%d) that match the provided template", len(handles))
 	}
 	return handles[0], nil
 }

--- a/pkcs11helpers/helpers.go
+++ b/pkcs11helpers/helpers.go
@@ -191,7 +191,7 @@ func FindObject(ctx PKCtx, session pkcs11.SessionHandle, tmpl []*pkcs11.Attribut
 	if err := ctx.FindObjectsInit(session, tmpl); err != nil {
 		return 0, err
 	}
-	handles, _, err := ctx.FindObjects(session, 10)
+	handles, _, err := ctx.FindObjects(session, 2)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Previously we were relying on a "more" boolean returned from
FindObjects. But according to
https://pkg.go.dev/github.com/miekg/pkcs11?tab=doc#Ctx.FindObjects,

> The returned boolean value is deprecated and should be ignored.

Instead, we ask for more objects than we need and error if we get more
than 1.

Add a test, and in the process split up the relevant test  into
multiple smaller test cases.

This also adds a named error for the "no objects" case, which I plan to
use in the ceremony tools to check that a slot is empty before generating
a key into it.