### PR TITLE
wfe: Return after sending errors

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -833,12 +833,14 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *web
 	if err != nil {
 		if berrors.Is(err, berrors.NotFound) {
 			wfe.sendError(response, logEvent, probs.NotFound("No such certificate"), err)
+			return
 		}
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to retrieve certificate"), err)
 		return
 	}
 	if !bytes.Equal(cert.DER, revokeRequest.CertificateDER) {
 		wfe.sendError(response, logEvent, probs.NotFound("No such certificate"), err)
+		return
 	}
 	parsedCertificate, err := x509.ParseCertificate(cert.DER)
 	if err != nil {


### PR DESCRIPTION
Because these `wfe.sendError()` calls were not followed
by `return`s, the wfe was sending both them and the
next error encountered. In some cases, this could result
in the wrong HTTP response code being set, as that is
determined by the last error sent.

Issue #4950