### PR TITLE
Return proto from ca.IssueCertificateFromPrecertificate

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -870,7 +870,7 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 		OrderID:        new(int64),
 	})
 	test.AssertNotError(t, err, "Failed to issue cert from precert")
-	parsedCert, err := x509.ParseCertificate(cert.DER)
+	parsedCert, err := x509.ParseCertificate(cert.Der)
 	test.AssertNotError(t, err, "Failed to parse cert")
 
 	// Check for SCT list extension
@@ -1111,7 +1111,7 @@ func TestOrphanQueue(t *testing.T) {
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, k.Public(), k)
 	test.AssertNotError(t, err, "Failed to generate test cert")
-	_, err = ca.storeCertificate(
+	err = ca.storeCertificate(
 		context.Background(),
 		1,
 		1,
@@ -1152,7 +1152,7 @@ func TestOrphanQueue(t *testing.T) {
 	// add cert to queue, and recreate queue to make sure it still has the cert
 	qsa.fail = true
 	qsa.duplicate = false
-	_, err = ca.storeCertificate(
+	err = ca.storeCertificate(
 		context.Background(),
 		1,
 		1,

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -97,7 +97,7 @@ type CertificateAuthority interface {
 	IssuePrecertificate(ctx context.Context, issueReq *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error)
 
 	// [RegistrationAuthority]
-	IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (Certificate, error)
+	IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error)
 
 	GenerateOCSP(ctx context.Context, ocspReq *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error)
 }

--- a/grpc/ca-wrappers.go
+++ b/grpc/ca-wrappers.go
@@ -27,12 +27,8 @@ func (cac CertificateAuthorityClientWrapper) IssuePrecertificate(ctx context.Con
 	return cac.inner.IssuePrecertificate(ctx, issueReq)
 }
 
-func (cac CertificateAuthorityClientWrapper) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
-	res, err := cac.inner.IssueCertificateForPrecertificate(ctx, req)
-	if err != nil {
-		return core.Certificate{}, err
-	}
-	return PBToCert(res)
+func (cac CertificateAuthorityClientWrapper) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
+	return cac.inner.IssueCertificateForPrecertificate(ctx, req)
 }
 
 func (cac CertificateAuthorityClientWrapper) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
@@ -65,11 +61,7 @@ func (cas *CertificateAuthorityServerWrapper) IssuePrecertificate(ctx context.Co
 }
 
 func (cas *CertificateAuthorityServerWrapper) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
-	cert, err := cas.inner.IssueCertificateForPrecertificate(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return CertToPB(cert), nil
+	return cas.inner.IssueCertificateForPrecertificate(ctx, req)
 }
 
 func (cas *CertificateAuthorityServerWrapper) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {

--- a/mocks/ca.go
+++ b/mocks/ca.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
-	"github.com/letsencrypt/boulder/core"
+	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/revocation"
 )
 
@@ -15,21 +15,6 @@ import (
 // IssueCertificate.
 type MockCA struct {
 	PEM []byte
-}
-
-// IssueCertificate is a mock
-func (ca *MockCA) IssueCertificate(ctx context.Context, _ *capb.IssueCertificateRequest) (core.Certificate, error) {
-	if ca.PEM == nil {
-		return core.Certificate{}, fmt.Errorf("MockCA's PEM field must be set before calling IssueCertificate")
-	}
-	block, _ := pem.Decode(ca.PEM)
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return core.Certificate{}, err
-	}
-	return core.Certificate{
-		DER: cert.Raw,
-	}, nil
 }
 
 // IssuePrecertificate is a mock
@@ -48,8 +33,17 @@ func (ca *MockCA) IssuePrecertificate(ctx context.Context, _ *capb.IssueCertific
 }
 
 // IssueCertificateForPrecertificate is a mock
-func (ca *MockCA) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
-	return core.Certificate{DER: req.DER}, nil
+func (ca *MockCA) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
+	var mockInt = int64(1)
+	var mockString = "mock"
+	return &corepb.Certificate{
+		Der:            req.DER,
+		RegistrationID: &mockInt,
+		Serial:         &mockString,
+		Digest:         &mockString,
+		Issued:         &mockInt,
+		Expires:        &mockInt,
+	}, nil
 }
 
 // GenerateOCSP is a mock

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1225,7 +1225,7 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 		return emptyCert, wrapError(err, "issuing certificate for precertificate")
 	}
 
-	parsedCertificate, err := x509.ParseCertificate([]byte(cert.DER))
+	parsedCertificate, err := x509.ParseCertificate([]byte(cert.Der))
 	if err != nil {
 		// berrors.InternalServerError because the certificate from the CA should be
 		// parseable.
@@ -1233,7 +1233,7 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	}
 
 	// Asynchronously submit the final certificate to any configured logs
-	go ra.ctpolicy.SubmitFinalCert(cert.DER, parsedCertificate.NotAfter)
+	go ra.ctpolicy.SubmitFinalCert(cert.Der, parsedCertificate.NotAfter)
 
 	err = ra.MatchesCSR(parsedCertificate, csr)
 	if err != nil {
@@ -1246,7 +1246,11 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	logEvent.NotAfter = parsedCertificate.NotAfter
 
 	ra.newCertCounter.Inc()
-	return cert, nil
+	res, err := bgrpc.PBToCert(cert)
+	if err != nil {
+		return emptyCert, nil
+	}
+	return res, nil
 }
 
 func (ra *RegistrationAuthorityImpl) getSCTs(ctx context.Context, cert []byte, expiration time.Time) (core.SCTDERs, error) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3524,8 +3524,8 @@ func (ca *mockCAFailCertForPrecert) IssuePrecertificate(_ context.Context, _ *ca
 
 func (ca *mockCAFailCertForPrecert) IssueCertificateForPrecertificate(
 	_ context.Context,
-	_ *capb.IssueCertificateForPrecertificateRequest) (core.Certificate, error) {
-	return core.Certificate{}, ca.err
+	_ *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
+	return &corepb.Certificate{}, ca.err
 }
 
 // TestIssueCertificateInnerErrs tests that errors from the CA caught during


### PR DESCRIPTION
This is the only method on the ca which uses a non-proto
type as its request or response value. Changing this to
use a proto removes the last logic from the wrappers,
allowing them to be removed in a future CL. It also makes
the interface more uniform and easier to reason about.

Issue: #4940 