### PR TITLE
Enable exportloopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,11 @@
 linters:
   disable-all: true
   enable:
-    - govet
-    - gofmt
-    - ineffassign
     - errcheck
+    - exportloopref
+    - gofmt
+    - govet
+    - ineffassign
     - misspell
     - staticcheck
 linters-settings:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-14
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-28
         environment:
             - FAKE_DNS=10.77.77.77
             - BOULDER_CONFIG_DIR=test/config
@@ -76,7 +76,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-14
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-28
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
-github.com/weppos/publicsuffix-go v0.13.1-0.20200526195454-983d101becd6 h1:ZRXyUEzq0HIULzh5VO/7Igju+LG0hGc8u1FX5SWdTcg=
-github.com/weppos/publicsuffix-go v0.13.1-0.20200526195454-983d101becd6/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
 github.com/weppos/publicsuffix-go v0.13.1-0.20200721065424-2c0d957a7459 h1:HSg0sbamo0i1wQa89tIuoUekIeonTumvEOuhlMwNnIU=
 github.com/weppos/publicsuffix-go v0.13.1-0.20200721065424-2c0d957a7459/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -30,7 +30,7 @@ unzip /tmp/protoc.zip -d /usr/local/protoc
 export GOBIN=/usr/local/bin GOCACHE=/tmp/gocache
 
 # Install golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOBIN v1.24.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOBIN v1.29.0
 
 # Install protobuf and testing/dev tools.
 # Note: The version of golang/protobuf is partially tied to the version of grpc


### PR DESCRIPTION
The golangci-lint metapackage includes exportloopref at v0.1.17,
the latest tagged release of exportloopref. Enabling it in our
config should be all that is necessary to start benefitting from
it.

At this time, exportloopref does not detect cases where a reference
to a loop var is passed to a function. I'm investigating contributing
that support upstream (and then bumping the version bundled with
golangci-lint).

Fixes #4948