### PR TITLE
Simplify test for CRL signer.

### DIFF
--- a/cmd/ceremony/crl_test.go
+++ b/cmd/ceremony/crl_test.go
@@ -74,7 +74,7 @@ func TestGenerateCRL(t *testing.T) {
 	test.AssertNotError(t, err, "failed to parse test cert")
 
 	signer := emptySigner{}
-	// TODO: Validate output.
+	// TODO(#4988): Validate output.
 	_, err = generateCRL(signer, cert, time.Time{}.Add(time.Hour), time.Time{}.Add(time.Hour*2), 1, nil)
 	test.AssertNotError(t, err, "generateCRL failed with valid profile")
 }

--- a/cmd/ceremony/crl_test.go
+++ b/cmd/ceremony/crl_test.go
@@ -1,18 +1,19 @@
 package main
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"io"
 	"math/big"
 	"testing"
 	"time"
 
-	"github.com/letsencrypt/boulder/pkcs11helpers"
 	"github.com/letsencrypt/boulder/test"
-	"github.com/miekg/pkcs11"
 )
 
 func TestGenerateCRLTimeBounds(t *testing.T) {
@@ -44,6 +45,16 @@ func TestGenerateCRLLength(t *testing.T) {
 	test.AssertEquals(t, err.Error(), "nextUpdate must be less than 12 months after thisUpdate")
 }
 
+type emptySigner struct{}
+
+func (p emptySigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return nil, nil
+}
+
+func (p emptySigner) Public() crypto.PublicKey {
+	return &rsa.PublicKey{N: big.NewInt(1), E: 1}
+}
+
 func TestGenerateCRL(t *testing.T) {
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	test.AssertNotError(t, err, "failed to generate test key")
@@ -62,32 +73,8 @@ func TestGenerateCRL(t *testing.T) {
 	cert, err := x509.ParseCertificate(certBytes)
 	test.AssertNotError(t, err, "failed to parse test cert")
 
-	ctx := pkcs11helpers.MockCtx{}
-	ctx.SignInitFunc = func(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle) error {
-		return nil
-	}
-	ctx.SignFunc = func(_ pkcs11.SessionHandle, digest []byte) ([]byte, error) {
-		r, s, err := ecdsa.Sign(rand.Reader, k, digest[:])
-		if err != nil {
-			return nil, err
-		}
-		rBytes := r.Bytes()
-		sBytes := s.Bytes()
-		// http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/os/pkcs11-curr-v2.40-os.html
-		// Section 2.3.1: EC Signatures
-		// "If r and s have different octet length, the shorter of both must be padded with
-		// leading zero octets such that both have the same octet length."
-		switch {
-		case len(rBytes) < len(sBytes):
-			padding := make([]byte, len(sBytes)-len(rBytes))
-			rBytes = append(padding, rBytes...)
-		case len(rBytes) > len(sBytes):
-			padding := make([]byte, len(rBytes)-len(sBytes))
-			sBytes = append(padding, sBytes...)
-		}
-		return append(rBytes, sBytes...), nil
-	}
-
-	_, err = generateCRL(&x509Signer{ctx: ctx, keyType: pkcs11helpers.ECDSAKey, pub: k.Public()}, cert, time.Time{}.Add(time.Hour), time.Time{}.Add(time.Hour*2), 1, nil)
+	signer := emptySigner{}
+	// TODO: Validate output.
+	_, err = generateCRL(signer, cert, time.Time{}.Add(time.Hour), time.Time{}.Add(time.Hour*2), 1, nil)
 	test.AssertNotError(t, err, "generateCRL failed with valid profile")
 }


### PR DESCRIPTION
This mocks out the signer type rather than mocking out the pkcs11
object, making the test less dependent on the internals of our
pkcs11helpers package.

Part of refactorings related to #4918.