### PR TITLE
Add gosec linter to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,24 +15,20 @@ issues:
   exclude-rules:
     - linters:
       - gosec
-        # TODO: Identify, fix, and remove violations of each of these rules
-        # (sorted in order of decreasing frequency in our codebase).
-        # G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
-        # G304 (CWE-22) : Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
-        # G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
-        # G401 (CWE-326): Use of weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
-        # G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
-        # G505 (CWE-327): Blocklisted import crypto/sha1: weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
-        # G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
-        # G402 (CWE-295): TLS MinVersion too low. (Confidence: HIGH, Severity: HIGH)
-        # G402 (CWE-295): TLS InsecureSkipVerify set true. (Confidence: HIGH, Severity: HIGH)
-        # G204 (CWE-78) : Subprocess launched with variable (Confidence: HIGH, Severity: MEDIUM)
-        # G402 (CWE-295): TLS MaxVersion too low. (Confidence: HIGH, Severity: HIGH)
-        # G501 (CWE-327): Blocklisted import crypto/md5: weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
-        # G403 (CWE-310): RSA keys should be at least 2048 bits (Confidence: HIGH, Severity: MEDIUM)
-        # G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
-        # G107 (CWE-88) : Potential HTTP request made with variable url (Confidence: MEDIUM, Severity: MEDIUM)
-      text: "(G104|G304|G404|G401|G306|G505|G601|G402|G204|G501|F403|G307|G107)"
+      # TODO: Identify, fix, and remove violations of each of these rules
+      # G101: Potential hardcoded credentials
+      # G102: Binds to all network interfaces
+      # G107: Potential HTTP request made with variable url
+      # G201: SQL string formatting
+      # G202: SQL string concatenation
+      # G306: Expect WriteFile permissions to be 0600 or less
+      # G401: Use of weak cryptographic primitive
+      # G402: TLS InsecureSkipVerify set true.
+      # G403: RSA keys should be at least 2048 bits
+      # G501: Blacklisted import `crypto/md5`: weak cryptographic primitive
+      # G505: Blacklisted import `crypto/sha1`: weak cryptographic primitive
+      # G601: Implicit memory aliasing in for loop.
+      text: "G(101|102|107|201|202|306|401|402|403|501|505|601)"
     - linters:
       - staticcheck
       text: "(SA1019|ST1005|ST1013|SA6003|SA5011|S1029|SA2002):"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,11 @@
 linters:
   disable-all: true
   enable:
-    - govet
-    - gofmt
-    - ineffassign
     - errcheck
+    - gofmt
+    - gosec
+    - govet
+    - ineffassign
     - misspell
     - staticcheck
 linters-settings:
@@ -12,6 +13,26 @@ linters-settings:
     ignore: fmt:[FS]?[Pp]rint*,io:Write,os:Remove,net/http:Write,github.com/miekg/dns:WriteMsg,net:Write,encoding/binary:Write
 issues:
   exclude-rules:
+    - linters:
+      - gosec
+        # TODO: Identify, fix, and remove violations of each of these rules
+        # (sorted in order of decreasing frequency in our codebase).
+        # G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
+        # G304 (CWE-22) : Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
+        # G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
+        # G401 (CWE-326): Use of weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
+        # G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
+        # G505 (CWE-327): Blocklisted import crypto/sha1: weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
+        # G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
+        # G402 (CWE-295): TLS MinVersion too low. (Confidence: HIGH, Severity: HIGH)
+        # G402 (CWE-295): TLS InsecureSkipVerify set true. (Confidence: HIGH, Severity: HIGH)
+        # G204 (CWE-78) : Subprocess launched with variable (Confidence: HIGH, Severity: MEDIUM)
+        # G402 (CWE-295): TLS MaxVersion too low. (Confidence: HIGH, Severity: HIGH)
+        # G501 (CWE-327): Blocklisted import crypto/md5: weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
+        # G403 (CWE-310): RSA keys should be at least 2048 bits (Confidence: HIGH, Severity: MEDIUM)
+        # G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
+        # G107 (CWE-88) : Potential HTTP request made with variable url (Confidence: MEDIUM, Severity: MEDIUM)
+      text: "(G104|G304|G404|G401|G306|G505|G601|G402|G204|G501|F403|G307|G107)"
     - linters:
       - staticcheck
       text: "(SA1019|ST1005|ST1013|SA6003|SA5011|S1029|SA2002):"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-14
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-28
         environment:
             - FAKE_DNS=10.77.77.77
             - BOULDER_CONFIG_DIR=test/config
@@ -76,7 +76,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-14
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-28
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -30,7 +30,7 @@ unzip /tmp/protoc.zip -d /usr/local/protoc
 export GOBIN=/usr/local/bin GOCACHE=/tmp/gocache
 
 # Install golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOBIN v1.24.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOBIN v1.29.0
 
 # Install protobuf and testing/dev tools.
 # Note: The version of golang/protobuf is partially tied to the version of grpc


### PR DESCRIPTION
This enables the gosec linter. It also disables a number of
warnings which it emits on the current codebase. Some of these
(e.g. G104: Errors unhandled) we expect to leave disabled
permanently; others (e.g. G601: Implicit memory aliasing in for loop)
we expect to fix and then enable to prevent regressions.

Part of #4948