### PR TITLE
Update VA RPCs to proto3

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -844,9 +844,9 @@ func (ra *RegistrationAuthorityImpl) recheckCAA(ctx context.Context, authzs []*c
 			}
 
 			resp, err := ra.caa.IsCAAValid(ctx, &vapb.IsCAAValidRequest{
-				Domain:           &name,
-				ValidationMethod: &method,
-				AccountURIID:     &authz.RegistrationID,
+				Domain:           name,
+				ValidationMethod: method,
+				AccountURIID:     authz.RegistrationID,
 			})
 			if err != nil {
 				ra.log.AuditErrf("Rechecking CAA: %s", err)
@@ -1612,11 +1612,11 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 		chall, _ := bgrpc.ChallengeToPB(authz.Challenges[challIndex])
 
 		req := vapb.PerformValidationRequest{
-			Domain:    &authz.Identifier.Value,
+			Domain:    authz.Identifier.Value,
 			Challenge: chall,
 			Authz: &vapb.AuthzMeta{
-				Id:    &authz.ID,
-				RegID: &authz.RegistrationID,
+				Id:    authz.ID,
+				RegID: authz.RegistrationID,
 			},
 		}
 		res, err := ra.VA.PerformValidation(vaCtx, &req)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1800,7 +1800,7 @@ func (cr *caaRecorder) IsCAAValid(
 ) (*vapb.IsCAAValidResponse, error) {
 	cr.Lock()
 	defer cr.Unlock()
-	cr.names[*in.Domain] = true
+	cr.names[in.Domain] = true
 	return &vapb.IsCAAValidResponse{}, nil
 }
 
@@ -1919,7 +1919,7 @@ func (cf *caaFailer) IsCAAValid(
 	opts ...grpc.CallOption,
 ) (*vapb.IsCAAValidResponse, error) {
 	cvrpb := &vapb.IsCAAValidResponse{}
-	switch *in.Domain {
+	switch in.Domain {
 	case "a.com":
 		cvrpb.Problem = &corepb.ProblemDetails{
 			Detail: proto.String("CAA invalid for a.com"),

--- a/va/caa.go
+++ b/va/caa.go
@@ -16,14 +16,14 @@ import (
 )
 
 type caaParams struct {
-	accountURIID     *int64
-	validationMethod *string
+	accountURIID     int64
+	validationMethod string
 }
 
 func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsCAAValidRequest) (*vapb.IsCAAValidResponse, error) {
 	acmeID := identifier.ACMEIdentifier{
 		Type:  identifier.DNS,
-		Value: *req.Domain,
+		Value: req.Domain,
 	}
 	params := &caaParams{
 		accountURIID:     req.AccountURIID,
@@ -31,7 +31,7 @@ func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsC
 	}
 	if prob := va.checkCAA(ctx, acmeID, params); prob != nil {
 		typ := string(prob.Type)
-		detail := fmt.Sprintf("While processing CAA for %s: %s", *req.Domain, prob.Detail)
+		detail := fmt.Sprintf("While processing CAA for %s: %s", req.Domain, prob.Detail)
 		return &vapb.IsCAAValidResponse{
 			Problem: &corepb.ProblemDetails{
 				ProblemType: &typ,
@@ -59,11 +59,11 @@ func (va *ValidationAuthorityImpl) checkCAA(
 	}
 
 	accountID, challengeType := "unknown", "unknown"
-	if params.accountURIID != nil {
-		accountID = fmt.Sprintf("%d", *params.accountURIID)
+	if params.accountURIID != 0 {
+		accountID = fmt.Sprintf("%d", params.accountURIID)
 	}
-	if params.validationMethod != nil {
-		challengeType = *params.validationMethod
+	if params.validationMethod != "" {
+		challengeType = params.validationMethod
 	}
 
 	va.log.AuditInfof("Checked CAA records for %s, [Present: %t, Account ID: %s, Challenge: %s, Valid for issuance: %t] Records=%s",
@@ -265,10 +265,10 @@ func (va *ValidationAuthorityImpl) validateCAASet(caaSet *CAASet, wildcard bool,
 			// https://tools.ietf.org/html/draft-ietf-acme-caa-04
 			caaAccountURI, ok := caaParameters["accounturi"]
 			if ok {
-				if params.accountURIID == nil {
+				if params.accountURIID == 0 {
 					continue
 				}
-				if !checkAccountURI(caaAccountURI, va.accountURIPrefixes, *params.accountURIID) {
+				if !checkAccountURI(caaAccountURI, va.accountURIPrefixes, params.accountURIID) {
 					continue
 				}
 			}
@@ -279,10 +279,10 @@ func (va *ValidationAuthorityImpl) validateCAASet(caaSet *CAASet, wildcard bool,
 			// https://tools.ietf.org/html/draft-ietf-acme-caa-04
 			caaMethods, ok := caaParameters["validationmethods"]
 			if ok {
-				if params.validationMethod == nil {
+				if params.validationMethod == "" {
 					continue
 				}
-				if !containsMethod(caaMethods, *params.validationMethod) {
+				if !containsMethod(caaMethods, params.validationMethod) {
 					continue
 				}
 			}

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -392,7 +392,7 @@ func TestCAAChecking(t *testing.T) {
 
 	accountURIID := int64(123)
 	method := "http-01"
-	params := &caaParams{accountURIID: &accountURIID, validationMethod: &method}
+	params := &caaParams{accountURIID: accountURIID, validationMethod: method}
 
 	va, _ := setup(nil, 0, "", nil)
 	if err := features.Set(map[string]bool{"CAAValidationMethods": true, "CAAAccountURI": true}); err != nil {
@@ -467,68 +467,63 @@ func TestCAALogging(t *testing.T) {
 	va, _ := setup(nil, 0, "", nil)
 	va.dnsClient = caaMockDNS{}
 
-	httpChal := core.ChallengeTypeHTTP01
-	dnsChal := core.ChallengeTypeDNS01
-	acctID := int64(12345)
-
 	testCases := []struct {
 		Name            string
 		Domain          string
-		AccountURIID    *int64
-		ChallengeType   *string
+		AccountURIID    int64
+		ChallengeType   string
 		ExpectedLogline string
 	}{
 		{
 			Domain:          "reserved.com",
-			ChallengeType:   nil,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: unknown, Challenge: unknown, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "reserved.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "reserved.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &dnsChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeDNS01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: dns-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "mixedcase.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for mixedcase.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"iSsUe\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "critical.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for critical.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "present.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}]",
 		},
 		{
 			Domain:          "multi-crit-present.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for multi-crit-present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}]",
 		},
 		{
 			Domain:          "present-with-parameter.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present-with-parameter.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"  letsencrypt.org  ;foo=bar;baz=bar\"}]",
 		},
 		{
 			Domain:          "satisfiable-wildcard-override.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for satisfiable-wildcard-override.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issuewild\",\"Value\":\"letsencrypt.org\"}]",
 		},
 	}
@@ -565,7 +560,7 @@ func TestIsCAAValidErrMessage(t *testing.T) {
 	// caaMockDNS.
 	domain := "caa-timeout.com"
 	resp, err := va.IsCAAValid(ctx, &vapb.IsCAAValidRequest{
-		Domain: &domain,
+		Domain: domain,
 	})
 
 	// The lookup itself should not return an error

--- a/va/proto/va.pb.go
+++ b/va/proto/va.pb.go
@@ -36,9 +36,9 @@ type IsCAAValidRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// NOTE: Domain may be a name with a wildcard prefix (e.g. `*.example.com`)
-	Domain           *string `protobuf:"bytes,1,opt,name=domain" json:"domain,omitempty"`
-	ValidationMethod *string `protobuf:"bytes,2,opt,name=validationMethod" json:"validationMethod,omitempty"`
-	AccountURIID     *int64  `protobuf:"varint,3,opt,name=accountURIID" json:"accountURIID,omitempty"`
+	Domain           string `protobuf:"bytes,1,opt,name=domain,proto3" json:"domain,omitempty"`
+	ValidationMethod string `protobuf:"bytes,2,opt,name=validationMethod,proto3" json:"validationMethod,omitempty"`
+	AccountURIID     int64  `protobuf:"varint,3,opt,name=accountURIID,proto3" json:"accountURIID,omitempty"`
 }
 
 func (x *IsCAAValidRequest) Reset() {
@@ -74,22 +74,22 @@ func (*IsCAAValidRequest) Descriptor() ([]byte, []int) {
 }
 
 func (x *IsCAAValidRequest) GetDomain() string {
-	if x != nil && x.Domain != nil {
-		return *x.Domain
+	if x != nil {
+		return x.Domain
 	}
 	return ""
 }
 
 func (x *IsCAAValidRequest) GetValidationMethod() string {
-	if x != nil && x.ValidationMethod != nil {
-		return *x.ValidationMethod
+	if x != nil {
+		return x.ValidationMethod
 	}
 	return ""
 }
 
 func (x *IsCAAValidRequest) GetAccountURIID() int64 {
-	if x != nil && x.AccountURIID != nil {
-		return *x.AccountURIID
+	if x != nil {
+		return x.AccountURIID
 	}
 	return 0
 }
@@ -100,7 +100,7 @@ type IsCAAValidResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Problem *proto1.ProblemDetails `protobuf:"bytes,1,opt,name=problem" json:"problem,omitempty"`
+	Problem *proto1.ProblemDetails `protobuf:"bytes,1,opt,name=problem,proto3" json:"problem,omitempty"`
 }
 
 func (x *IsCAAValidResponse) Reset() {
@@ -147,9 +147,9 @@ type PerformValidationRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Domain    *string           `protobuf:"bytes,1,opt,name=domain" json:"domain,omitempty"`
-	Challenge *proto1.Challenge `protobuf:"bytes,2,opt,name=challenge" json:"challenge,omitempty"`
-	Authz     *AuthzMeta        `protobuf:"bytes,3,opt,name=authz" json:"authz,omitempty"`
+	Domain    string            `protobuf:"bytes,1,opt,name=domain,proto3" json:"domain,omitempty"`
+	Challenge *proto1.Challenge `protobuf:"bytes,2,opt,name=challenge,proto3" json:"challenge,omitempty"`
+	Authz     *AuthzMeta        `protobuf:"bytes,3,opt,name=authz,proto3" json:"authz,omitempty"`
 }
 
 func (x *PerformValidationRequest) Reset() {
@@ -185,8 +185,8 @@ func (*PerformValidationRequest) Descriptor() ([]byte, []int) {
 }
 
 func (x *PerformValidationRequest) GetDomain() string {
-	if x != nil && x.Domain != nil {
-		return *x.Domain
+	if x != nil {
+		return x.Domain
 	}
 	return ""
 }
@@ -210,8 +210,8 @@ type AuthzMeta struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id    *string `protobuf:"bytes,1,opt,name=id" json:"id,omitempty"`
-	RegID *int64  `protobuf:"varint,2,opt,name=regID" json:"regID,omitempty"`
+	Id    string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	RegID int64  `protobuf:"varint,2,opt,name=regID,proto3" json:"regID,omitempty"`
 }
 
 func (x *AuthzMeta) Reset() {
@@ -247,15 +247,15 @@ func (*AuthzMeta) Descriptor() ([]byte, []int) {
 }
 
 func (x *AuthzMeta) GetId() string {
-	if x != nil && x.Id != nil {
-		return *x.Id
+	if x != nil {
+		return x.Id
 	}
 	return ""
 }
 
 func (x *AuthzMeta) GetRegID() int64 {
-	if x != nil && x.RegID != nil {
-		return *x.RegID
+	if x != nil {
+		return x.RegID
 	}
 	return 0
 }
@@ -265,8 +265,8 @@ type ValidationResult struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Records  []*proto1.ValidationRecord `protobuf:"bytes,1,rep,name=records" json:"records,omitempty"`
-	Problems *proto1.ProblemDetails     `protobuf:"bytes,2,opt,name=problems" json:"problems,omitempty"`
+	Records  []*proto1.ValidationRecord `protobuf:"bytes,1,rep,name=records,proto3" json:"records,omitempty"`
+	Problems *proto1.ProblemDetails     `protobuf:"bytes,2,opt,name=problems,proto3" json:"problems,omitempty"`
 }
 
 func (x *ValidationResult) Reset() {
@@ -364,7 +364,7 @@ var file_va_proto_va_proto_rawDesc = []byte{
 	0x69, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x29, 0x5a, 0x27,
 	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6c, 0x65, 0x74, 0x73, 0x65,
 	0x6e, 0x63, 0x72, 0x79, 0x70, 0x74, 0x2f, 0x62, 0x6f, 0x75, 0x6c, 0x64, 0x65, 0x72, 0x2f, 0x76,
-	0x61, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x61, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (

--- a/va/proto/va.proto
+++ b/va/proto/va.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package va;
 option go_package = "github.com/letsencrypt/boulder/va/proto";
@@ -15,28 +15,28 @@ service CAA {
 
 message IsCAAValidRequest {
   // NOTE: Domain may be a name with a wildcard prefix (e.g. `*.example.com`)
-  optional string domain = 1;
-  optional string validationMethod = 2;
-  optional int64 accountURIID = 3;
+  string domain = 1;
+  string validationMethod = 2;
+  int64 accountURIID = 3;
 }
 
 // If CAA is valid for the requested domain, the problem will be empty
 message IsCAAValidResponse {
-  optional core.ProblemDetails problem = 1;
+  core.ProblemDetails problem = 1;
 }
 
 message PerformValidationRequest {
-  optional string domain = 1;
-  optional core.Challenge challenge = 2;
-  optional AuthzMeta authz = 3;
+  string domain = 1;
+  core.Challenge challenge = 2;
+  AuthzMeta authz = 3;
 }
 
 message AuthzMeta {
-  optional string id = 1;
-  optional int64 regID = 2;
+  string id = 1;
+  int64 regID = 2;
 }
 
 message ValidationResult {
   repeated core.ValidationRecord records = 1;
-  optional core.ProblemDetails problems = 2;
+  core.ProblemDetails problems = 2;
 }

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -81,10 +81,8 @@ var accountURIPrefixes = []string{"http://boulder:4000/acme/reg/"}
 
 func createValidationRequest(domain, challengeType string) *vapb.PerformValidationRequest {
 	status := string(core.StatusPending)
-	authzID := ""
-	authzRegID := int64(0)
 	return &vapb.PerformValidationRequest{
-		Domain: &domain,
+		Domain: domain,
 		Challenge: &corepb.Challenge{
 			Type:              &challengeType,
 			Status:            &status,
@@ -93,8 +91,8 @@ func createValidationRequest(domain, challengeType string) *vapb.PerformValidati
 			KeyAuthorization:  &expectedKeyAuthorization,
 		},
 		Authz: &vapb.AuthzMeta{
-			Id:    &authzID,
-			RegID: &authzRegID,
+			Id:    "",
+			RegID: 0,
 		},
 	}
 }


### PR DESCRIPTION
This updates va.proto to use proto3 syntax, and updates
all clients of the autogenerated code to use the new types.
In particular, it removes indirection from built-in types
(proto3 uses ints, rather than pointers to ints, for example).

Depends on #5003
Fixes #4956

DO NOT SUBMIT until #5003 has been deployed