### PR TITLE
Use 2-space indents in all proto files

### DIFF
--- a/akamai/proto/akamai.proto
+++ b/akamai/proto/akamai.proto
@@ -6,9 +6,9 @@ option go_package = "github.com/letsencrypt/boulder/akamai/proto";
 import "core/proto/core.proto";
 
 service AkamaiPurger {
-    rpc Purge(PurgeRequest) returns (core.Empty) {}
+  rpc Purge(PurgeRequest) returns (core.Empty) {}
 }
 
 message PurgeRequest {
-    repeated string urls = 1;
+  repeated string urls = 1;
 }

--- a/core/proto/core.proto
+++ b/core/proto/core.proto
@@ -4,34 +4,34 @@ package core;
 option go_package = "github.com/letsencrypt/boulder/core/proto";
 
 message Challenge {
-	optional int64 id = 1;
-	optional string type = 2;
-	optional string status = 6;
-	optional string uri = 9;
-	optional string token = 3;
-	optional string keyAuthorization = 5;
-	repeated ValidationRecord validationrecords = 10;
-	optional ProblemDetails error = 7;
+  optional int64 id = 1;
+  optional string type = 2;
+  optional string status = 6;
+  optional string uri = 9;
+  optional string token = 3;
+  optional string keyAuthorization = 5;
+  repeated ValidationRecord validationrecords = 10;
+  optional ProblemDetails error = 7;
 }
 
 message ValidationRecord {
-        optional string hostname = 1;
-        optional string port = 2;
-        repeated bytes addressesResolved = 3; // net.IP.MarshalText()
-        optional bytes addressUsed = 4; // net.IP.MarshalText()
+  optional string hostname = 1;
+  optional string port = 2;
+  repeated bytes addressesResolved = 3; // net.IP.MarshalText()
+  optional bytes addressUsed = 4; // net.IP.MarshalText()
 
-        repeated string authorities = 5;
-        optional string url = 6;
-        // A list of addresses tried before the address used (see
-        // core/objects.go and the comment on the ValidationRecord structure
-        // definition for more information.
-        repeated bytes addressesTried = 7; // net.IP.MarshalText()
+  repeated string authorities = 5;
+  optional string url = 6;
+  // A list of addresses tried before the address used (see
+  // core/objects.go and the comment on the ValidationRecord structure
+  // definition for more information.
+  repeated bytes addressesTried = 7; // net.IP.MarshalText()
 }
 
 message ProblemDetails {
-	optional string problemType = 1;
-	optional string detail = 2;
-	optional int32 httpStatus = 3;
+  optional string problemType = 1;
+  optional string detail = 2;
+  optional int32 httpStatus = 3;
 }
 
 message Certificate {
@@ -44,52 +44,52 @@ message Certificate {
 }
 
 message CertificateStatus {
-        optional string serial = 1;
-        reserved 2; // previously subscriberApproved
-        optional string status = 3;
-        optional int64 ocspLastUpdated = 4;
-        optional int64 revokedDate = 5;
-        optional int64 revokedReason = 6;
-        optional int64 lastExpirationNagSent = 7;
-        optional bytes ocspResponse = 8;
-        optional int64 notAfter = 9;
-        optional bool isExpired = 10;
+  optional string serial = 1;
+  reserved 2; // previously subscriberApproved
+  optional string status = 3;
+  optional int64 ocspLastUpdated = 4;
+  optional int64 revokedDate = 5;
+  optional int64 revokedReason = 6;
+  optional int64 lastExpirationNagSent = 7;
+  optional bytes ocspResponse = 8;
+  optional int64 notAfter = 9;
+  optional bool isExpired = 10;
 }
 
 message Registration {
-        optional int64 id = 1;
-        optional bytes key = 2;
-        repeated string contact = 3;
-        optional bool contactsPresent = 4;
-        optional string agreement = 5;
-        optional bytes initialIP = 6;
-        optional int64 createdAt = 7; // Unix timestamp (nanoseconds)
-        optional string status = 8;
+  optional int64 id = 1;
+  optional bytes key = 2;
+  repeated string contact = 3;
+  optional bool contactsPresent = 4;
+  optional string agreement = 5;
+  optional bytes initialIP = 6;
+  optional int64 createdAt = 7; // Unix timestamp (nanoseconds)
+  optional string status = 8;
 }
 
 message Authorization {
-        optional string id = 1;
-        optional string identifier = 2;
-        optional int64 registrationID = 3;
-        optional string status = 4;
-        optional int64 expires = 5; // Unix timestamp (nanoseconds)
-        repeated core.Challenge challenges = 6;
-        reserved 7; // previously combinations
-        reserved 8; // previously v2
+  optional string id = 1;
+  optional string identifier = 2;
+  optional int64 registrationID = 3;
+  optional string status = 4;
+  optional int64 expires = 5; // Unix timestamp (nanoseconds)
+  repeated core.Challenge challenges = 6;
+  reserved 7; // previously combinations
+  reserved 8; // previously v2
 }
 
 message Order {
-        optional int64 id = 1;
-        optional int64 registrationID = 2;
-        optional int64 expires = 3;
-        optional ProblemDetails error = 4;
-        optional string certificateSerial = 5;
-        reserved 6; // previously authorizations, deprecated in favor of v2Authorizations
-        optional string status = 7;
-        repeated string names = 8;
-        optional bool beganProcessing = 9;
-        optional int64 created = 10;
-        repeated int64 v2Authorizations = 11;
+  optional int64 id = 1;
+  optional int64 registrationID = 2;
+  optional int64 expires = 3;
+  optional ProblemDetails error = 4;
+  optional string certificateSerial = 5;
+  reserved 6; // previously authorizations, deprecated in favor of v2Authorizations
+  optional string status = 7;
+  repeated string names = 8;
+  optional bool beganProcessing = 9;
+  optional int64 created = 10;
+  repeated int64 v2Authorizations = 11;
 }
 
 message Empty {}

--- a/nonce/proto/nonce.proto
+++ b/nonce/proto/nonce.proto
@@ -6,14 +6,14 @@ option go_package = "github.com/letsencrypt/boulder/nonce/proto";
 import "core/proto/core.proto";
 
 service NonceService {
-	rpc Nonce(core.Empty) returns (NonceMessage) {}
-	rpc Redeem(NonceMessage) returns (ValidMessage) {}
+  rpc Nonce(core.Empty) returns (NonceMessage) {}
+  rpc Redeem(NonceMessage) returns (ValidMessage) {}
 }
 
 message NonceMessage {
-	string nonce = 1;
+  string nonce = 1;
 }
 
 message ValidMessage {
-    bool valid = 1;
+  bool valid = 1;
 }

--- a/publisher/proto/publisher.proto
+++ b/publisher/proto/publisher.proto
@@ -2,17 +2,17 @@ syntax = "proto3";
 option go_package = ".;publisher";
 
 service Publisher {
-        rpc SubmitToSingleCTWithResult(Request) returns (Result) {}
+  rpc SubmitToSingleCTWithResult(Request) returns (Result) {}
 }
 
 message Request {
-        bytes der = 1;
-        string LogURL = 2;
-        string LogPublicKey = 3;
-        bool precert = 4;
-        bool storeSCT = 5;
+  bytes der = 1;
+  string LogURL = 2;
+  string LogPublicKey = 3;
+  bool precert = 4;
+  bool storeSCT = 5;
 }
 
 message Result {
-        bytes sct = 1;
+  bytes sct = 1;
 }

--- a/ra/proto/ra.proto
+++ b/ra/proto/ra.proto
@@ -6,63 +6,63 @@ option go_package = "github.com/letsencrypt/boulder/ra/proto";
 import "core/proto/core.proto";
 
 service RegistrationAuthority {
-        rpc NewRegistration(core.Registration) returns (core.Registration) {}
-        rpc NewAuthorization(NewAuthorizationRequest) returns (core.Authorization) {}
-        rpc NewCertificate(NewCertificateRequest) returns (core.Certificate) {}
-        rpc UpdateRegistration(UpdateRegistrationRequest) returns (core.Registration) {}
-        rpc PerformValidation(PerformValidationRequest) returns (core.Authorization) {}
-        rpc RevokeCertificateWithReg(RevokeCertificateWithRegRequest) returns (core.Empty) {}
-        rpc DeactivateRegistration(core.Registration) returns (core.Empty) {}
-        rpc DeactivateAuthorization(core.Authorization) returns (core.Empty) {}
-        rpc AdministrativelyRevokeCertificate(AdministrativelyRevokeCertificateRequest) returns (core.Empty) {}
-        rpc NewOrder(NewOrderRequest) returns (core.Order) {}
-        rpc FinalizeOrder(FinalizeOrderRequest) returns (core.Order) {}
+  rpc NewRegistration(core.Registration) returns (core.Registration) {}
+  rpc NewAuthorization(NewAuthorizationRequest) returns (core.Authorization) {}
+  rpc NewCertificate(NewCertificateRequest) returns (core.Certificate) {}
+  rpc UpdateRegistration(UpdateRegistrationRequest) returns (core.Registration) {}
+  rpc PerformValidation(PerformValidationRequest) returns (core.Authorization) {}
+  rpc RevokeCertificateWithReg(RevokeCertificateWithRegRequest) returns (core.Empty) {}
+  rpc DeactivateRegistration(core.Registration) returns (core.Empty) {}
+  rpc DeactivateAuthorization(core.Authorization) returns (core.Empty) {}
+  rpc AdministrativelyRevokeCertificate(AdministrativelyRevokeCertificateRequest) returns (core.Empty) {}
+  rpc NewOrder(NewOrderRequest) returns (core.Order) {}
+  rpc FinalizeOrder(FinalizeOrderRequest) returns (core.Order) {}
 }
 
 message NewAuthorizationRequest {
-        optional core.Authorization authz = 1;
-        optional int64 regID = 2;
+  optional core.Authorization authz = 1;
+  optional int64 regID = 2;
 }
 
 message NewCertificateRequest {
-        optional bytes csr = 1;
-        optional int64 regID = 2;
+  optional bytes csr = 1;
+  optional int64 regID = 2;
 }
 
 message UpdateRegistrationRequest {
-        optional core.Registration base = 1;
-        optional core.Registration update = 2;
+  optional core.Registration base = 1;
+  optional core.Registration update = 2;
 }
 
 message UpdateAuthorizationRequest {
-        optional core.Authorization authz = 1;
-        optional int64 challengeIndex = 2;
-        optional core.Challenge response = 3;
+  optional core.Authorization authz = 1;
+  optional int64 challengeIndex = 2;
+  optional core.Challenge response = 3;
 }
 
 message PerformValidationRequest {
-        optional core.Authorization authz = 1;
-        optional int64 challengeIndex = 2;
+  optional core.Authorization authz = 1;
+  optional int64 challengeIndex = 2;
 }
 
 message RevokeCertificateWithRegRequest {
-        optional bytes cert = 1;
-        optional int64 code = 2;
-        optional int64 regID = 3;
+  optional bytes cert = 1;
+  optional int64 code = 2;
+  optional int64 regID = 3;
 }
 
 message AdministrativelyRevokeCertificateRequest {
-        optional bytes cert = 1;
-        optional int64 code = 2;
-        optional string adminName = 3;
+  optional bytes cert = 1;
+  optional int64 code = 2;
+  optional string adminName = 3;
 }
 
 message NewOrderRequest {
-        optional int64 registrationID = 1;
-        repeated string names = 2;
+  optional int64 registrationID = 1;
+  repeated string names = 2;
 }
 
 message FinalizeOrderRequest {
-        optional core.Order order = 1;
-        optional bytes csr = 2;
+  optional core.Order order = 1;
+  optional bytes csr = 2;
 }

--- a/sa/proto/sa.proto
+++ b/sa/proto/sa.proto
@@ -6,239 +6,239 @@ option go_package = "github.com/letsencrypt/boulder/sa/proto";
 import "core/proto/core.proto";
 
 service StorageAuthority {
-        // Getters
-        rpc GetRegistration(RegistrationID) returns (core.Registration) {}
-        rpc GetRegistrationByKey(JSONWebKey) returns (core.Registration) {}
-        rpc GetCertificate(Serial) returns (core.Certificate) {}
-        rpc GetPrecertificate(Serial) returns (core.Certificate) {}
-        rpc GetCertificateStatus(Serial) returns (core.CertificateStatus) {}
-        rpc CountCertificatesByNames(CountCertificatesByNamesRequest) returns (CountByNames) {}
-        rpc CountRegistrationsByIP(CountRegistrationsByIPRequest) returns (Count) {}
-        rpc CountRegistrationsByIPRange(CountRegistrationsByIPRequest) returns (Count) {}
-        rpc CountOrders(CountOrdersRequest) returns (Count) {}
-        // Return a count of authorizations with status "invalid" that belong to
-        // a given registration ID and expire in the given time range.
-        rpc CountFQDNSets(CountFQDNSetsRequest) returns (Count) {}
-        rpc FQDNSetExists(FQDNSetExistsRequest) returns (Exists) {}
-        rpc PreviousCertificateExists(PreviousCertificateExistsRequest) returns (Exists) {}
-        rpc GetAuthorization2(AuthorizationID2) returns (core.Authorization) {}
-        rpc GetAuthorizations2(GetAuthorizationsRequest) returns (Authorizations) {}
-        rpc GetPendingAuthorization2(GetPendingAuthorizationRequest) returns (core.Authorization) {}
-        rpc CountPendingAuthorizations2(RegistrationID) returns (Count) {}
-        rpc GetValidOrderAuthorizations2(GetValidOrderAuthorizationsRequest) returns (Authorizations) {}
-        rpc CountInvalidAuthorizations2(CountInvalidAuthorizationsRequest) returns (Count) {}
-        rpc GetValidAuthorizations2(GetValidAuthorizationsRequest) returns (Authorizations) {}
-        rpc KeyBlocked(KeyBlockedRequest) returns (Exists) {}
-        // Adders
-        rpc NewRegistration(core.Registration) returns (core.Registration) {}
-        rpc UpdateRegistration(core.Registration) returns (core.Empty) {}
-        rpc AddCertificate(AddCertificateRequest) returns (AddCertificateResponse) {}
-        rpc AddPrecertificate(AddCertificateRequest) returns (core.Empty) {}
-        rpc AddSerial(AddSerialRequest) returns (core.Empty) {}
-        rpc DeactivateRegistration(RegistrationID) returns (core.Empty) {}
-        rpc NewOrder(core.Order) returns (core.Order) {}
-        rpc SetOrderProcessing(core.Order) returns (core.Empty) {}
-        rpc SetOrderError(core.Order) returns (core.Empty) {}
-        rpc FinalizeOrder(core.Order) returns (core.Empty) {}
-        rpc GetOrder(OrderRequest) returns (core.Order) {}
-        rpc GetOrderForNames(GetOrderForNamesRequest) returns (core.Order) {}
-        rpc RevokeCertificate(RevokeCertificateRequest) returns (core.Empty) {}
-        rpc NewAuthorizations2(AddPendingAuthorizationsRequest) returns (Authorization2IDs) {}
-        rpc FinalizeAuthorization2(FinalizeAuthorizationRequest) returns (core.Empty) {}
-        rpc DeactivateAuthorization2(AuthorizationID2) returns (core.Empty) {}
-        rpc AddBlockedKey(AddBlockedKeyRequest) returns (core.Empty) {}
+  // Getters
+  rpc GetRegistration(RegistrationID) returns (core.Registration) {}
+  rpc GetRegistrationByKey(JSONWebKey) returns (core.Registration) {}
+  rpc GetCertificate(Serial) returns (core.Certificate) {}
+  rpc GetPrecertificate(Serial) returns (core.Certificate) {}
+  rpc GetCertificateStatus(Serial) returns (core.CertificateStatus) {}
+  rpc CountCertificatesByNames(CountCertificatesByNamesRequest) returns (CountByNames) {}
+  rpc CountRegistrationsByIP(CountRegistrationsByIPRequest) returns (Count) {}
+  rpc CountRegistrationsByIPRange(CountRegistrationsByIPRequest) returns (Count) {}
+  rpc CountOrders(CountOrdersRequest) returns (Count) {}
+  // Return a count of authorizations with status "invalid" that belong to
+  // a given registration ID and expire in the given time range.
+  rpc CountFQDNSets(CountFQDNSetsRequest) returns (Count) {}
+  rpc FQDNSetExists(FQDNSetExistsRequest) returns (Exists) {}
+  rpc PreviousCertificateExists(PreviousCertificateExistsRequest) returns (Exists) {}
+  rpc GetAuthorization2(AuthorizationID2) returns (core.Authorization) {}
+  rpc GetAuthorizations2(GetAuthorizationsRequest) returns (Authorizations) {}
+  rpc GetPendingAuthorization2(GetPendingAuthorizationRequest) returns (core.Authorization) {}
+  rpc CountPendingAuthorizations2(RegistrationID) returns (Count) {}
+  rpc GetValidOrderAuthorizations2(GetValidOrderAuthorizationsRequest) returns (Authorizations) {}
+  rpc CountInvalidAuthorizations2(CountInvalidAuthorizationsRequest) returns (Count) {}
+  rpc GetValidAuthorizations2(GetValidAuthorizationsRequest) returns (Authorizations) {}
+  rpc KeyBlocked(KeyBlockedRequest) returns (Exists) {}
+  // Adders
+  rpc NewRegistration(core.Registration) returns (core.Registration) {}
+  rpc UpdateRegistration(core.Registration) returns (core.Empty) {}
+  rpc AddCertificate(AddCertificateRequest) returns (AddCertificateResponse) {}
+  rpc AddPrecertificate(AddCertificateRequest) returns (core.Empty) {}
+  rpc AddSerial(AddSerialRequest) returns (core.Empty) {}
+  rpc DeactivateRegistration(RegistrationID) returns (core.Empty) {}
+  rpc NewOrder(core.Order) returns (core.Order) {}
+  rpc SetOrderProcessing(core.Order) returns (core.Empty) {}
+  rpc SetOrderError(core.Order) returns (core.Empty) {}
+  rpc FinalizeOrder(core.Order) returns (core.Empty) {}
+  rpc GetOrder(OrderRequest) returns (core.Order) {}
+  rpc GetOrderForNames(GetOrderForNamesRequest) returns (core.Order) {}
+  rpc RevokeCertificate(RevokeCertificateRequest) returns (core.Empty) {}
+  rpc NewAuthorizations2(AddPendingAuthorizationsRequest) returns (Authorization2IDs) {}
+  rpc FinalizeAuthorization2(FinalizeAuthorizationRequest) returns (core.Empty) {}
+  rpc DeactivateAuthorization2(AuthorizationID2) returns (core.Empty) {}
+  rpc AddBlockedKey(AddBlockedKeyRequest) returns (core.Empty) {}
 }
 
 message RegistrationID {
-        optional int64 id = 1;
+  optional int64 id = 1;
 }
 
 message JSONWebKey {
-        optional bytes jwk = 1; 
+  optional bytes jwk = 1; 
 }
 
 message AuthorizationID {
-        optional string id = 1;
+  optional string id = 1;
 }
 
 message GetPendingAuthorizationRequest {
-        optional int64 registrationID = 1;
-        optional string identifierType = 2;
-        optional string identifierValue = 3;
-        // Result must be valid until at least this Unix timestamp (nanos)
-        optional int64 validUntil = 4;
+  optional int64 registrationID = 1;
+  optional string identifierType = 2;
+  optional string identifierValue = 3;
+  // Result must be valid until at least this Unix timestamp (nanos)
+  optional int64 validUntil = 4;
 }
 
 message GetValidAuthorizationsRequest {
-        optional int64 registrationID = 1;
-        repeated string domains = 2;
-        optional int64 now = 3; // Unix timestamp (nanoseconds)
+  optional int64 registrationID = 1;
+  repeated string domains = 2;
+  optional int64 now = 3; // Unix timestamp (nanoseconds)
 }
 
 message ValidAuthorizations {
-        message MapElement {
-                optional string domain = 1;
-                optional core.Authorization authz = 2;
-        }
-        repeated MapElement valid = 1;
+  message MapElement {
+          optional string domain = 1;
+          optional core.Authorization authz = 2;
+  }
+  repeated MapElement valid = 1;
 }
 
 message Serial {
-        optional string serial = 1;
+  optional string serial = 1;
 }
 
 message Range {
-        optional int64 earliest = 1; // Unix timestamp (nanoseconds)
-        optional int64 latest = 2;   // Unix timestamp (nanoseconds)
+  optional int64 earliest = 1; // Unix timestamp (nanoseconds)
+  optional int64 latest = 2;   // Unix timestamp (nanoseconds)
 }
 
 message Count {
-        optional int64 count = 1;
+  optional int64 count = 1;
 }
 
 message CountCertificatesByNamesRequest {
-        optional Range range = 1;
-        repeated string names = 2;
+  optional Range range = 1;
+  repeated string names = 2;
 }
 
 message CountByNames {
-        message MapElement {
-                optional string name = 1;
-                optional int64 count = 2;
-        }
-        repeated MapElement countByNames = 1;
+  message MapElement {
+          optional string name = 1;
+          optional int64 count = 2;
+  }
+  repeated MapElement countByNames = 1;
 }
 
 message CountRegistrationsByIPRequest {
-        optional bytes ip = 1;
-        optional Range range = 2;
+  optional bytes ip = 1;
+  optional Range range = 2;
 }
 
 message CountInvalidAuthorizationsRequest {
-        optional int64 registrationID = 1;
-        optional string hostname = 2;
-        // Count authorizations that expire in this range.
-        optional Range range = 3;
+  optional int64 registrationID = 1;
+  optional string hostname = 2;
+  // Count authorizations that expire in this range.
+  optional Range range = 3;
 }
 
 message CountOrdersRequest {
-        optional int64 accountID = 1;
-        optional Range range = 2;
+  optional int64 accountID = 1;
+  optional Range range = 2;
 }
 
 message CountFQDNSetsRequest {
-        optional int64 window = 1;
-        repeated string domains = 2;
+  optional int64 window = 1;
+  repeated string domains = 2;
 }
 
 message FQDNSetExistsRequest {
-        repeated string domains = 1;
+  repeated string domains = 1;
 }
 
 message PreviousCertificateExistsRequest {
-        optional string domain = 1;
-        optional int64 regID = 2;
+  optional string domain = 1;
+  optional int64 regID = 2;
 }
 
 message Exists {
-        optional bool exists = 1;
+  optional bool exists = 1;
 }
 
 message AddSerialRequest {
-        optional int64 regID = 1;
-        optional string serial = 2;
-        optional int64 created = 3; // Unix timestamp (nanoseconds)
-        optional int64 expires = 4; // Unix timestamp (nanoseconds)
+  optional int64 regID = 1;
+  optional string serial = 2;
+  optional int64 created = 3; // Unix timestamp (nanoseconds)
+  optional int64 expires = 4; // Unix timestamp (nanoseconds)
 }
 
 message AddCertificateRequest {
-        optional bytes der = 1;
-        optional int64 regID = 2;
-        // A signed OCSP response for the certificate contained in "der".
-        // Note: The certificate status in the OCSP response is assumed to be 0 (good).
-        optional bytes ocsp = 3;
-        // An optional issued time. When not present the SA defaults to using
-        // the current time. The orphan-finder uses this parameter to add
-        // certificates with the correct historic issued date
-        optional int64 issued = 4;
-        optional int64 issuerID = 5;
+  optional bytes der = 1;
+  optional int64 regID = 2;
+  // A signed OCSP response for the certificate contained in "der".
+  // Note: The certificate status in the OCSP response is assumed to be 0 (good).
+  optional bytes ocsp = 3;
+  // An optional issued time. When not present the SA defaults to using
+  // the current time. The orphan-finder uses this parameter to add
+  // certificates with the correct historic issued date
+  optional int64 issued = 4;
+  optional int64 issuerID = 5;
 }
 
 message AddCertificateResponse {
-        optional string digest = 1;
+  optional string digest = 1;
 }
 
 message OrderRequest {
-        optional int64 id = 1;
-        optional bool useV2Authorizations = 2;
+  optional int64 id = 1;
+  optional bool useV2Authorizations = 2;
 }
 
 message GetValidOrderAuthorizationsRequest {
-        optional int64 id = 1;
-        optional int64 acctID = 2;
+  optional int64 id = 1;
+  optional int64 acctID = 2;
 }
 
 message GetOrderForNamesRequest {
-        optional int64 acctID = 1;
-        repeated string names = 2;
-        optional bool useV2Authorizations = 3;
+  optional int64 acctID = 1;
+  repeated string names = 2;
+  optional bool useV2Authorizations = 3;
 }
 
 message GetAuthorizationsRequest {
-        optional int64 registrationID = 1;
-        repeated string domains = 2;
-        optional int64 now = 3; // Unix timestamp (nanoseconds)
-        optional bool requireV2Authzs = 4; // Do not include legacy V1 authzs
+  optional int64 registrationID = 1;
+  repeated string domains = 2;
+  optional int64 now = 3; // Unix timestamp (nanoseconds)
+  optional bool requireV2Authzs = 4; // Do not include legacy V1 authzs
 }
 
 message Authorizations {
-        message MapElement {
-                optional string domain = 1;
-                optional core.Authorization authz = 2;
-        }
-        repeated MapElement authz = 1;
+  message MapElement {
+          optional string domain = 1;
+          optional core.Authorization authz = 2;
+  }
+  repeated MapElement authz = 1;
 }
 
 message AddPendingAuthorizationsRequest {
-        repeated core.Authorization authz = 1;
+  repeated core.Authorization authz = 1;
 }
 
 message AuthorizationIDs {
-        repeated string ids = 1;
+  repeated string ids = 1;
 }
 
 message AuthorizationID2 {
-        optional int64 id = 1;
+  optional int64 id = 1;
 }
 
 message Authorization2IDs {
-        repeated int64 ids = 1;
+  repeated int64 ids = 1;
 }
 
 message RevokeCertificateRequest {
-        optional string serial = 1;
-        optional int64 reason = 2;
-        optional int64 date = 3; // Unix timestamp (nanoseconds)
-        optional bytes response = 4;
+  optional string serial = 1;
+  optional int64 reason = 2;
+  optional int64 date = 3; // Unix timestamp (nanoseconds)
+  optional bytes response = 4;
 }
 
 message FinalizeAuthorizationRequest {
-        optional int64 id = 1;
-        optional string status = 2;
-        optional int64 expires = 3; // Unix timestamp (nanoseconds)
-        optional string attempted = 4;
-        repeated core.ValidationRecord validationRecords = 5;
-        optional core.ProblemDetails validationError = 6;
+  optional int64 id = 1;
+  optional string status = 2;
+  optional int64 expires = 3; // Unix timestamp (nanoseconds)
+  optional string attempted = 4;
+  repeated core.ValidationRecord validationRecords = 5;
+  optional core.ProblemDetails validationError = 6;
 }
 
 message AddBlockedKeyRequest {
-        optional bytes keyHash = 1;
-        optional int64 added = 2; // Unix timestamp (nanoseconds)
-        optional string source = 3;
-        optional string comment = 4;
-        optional int64 revokedBy = 5;
+  optional bytes keyHash = 1;
+  optional int64 added = 2; // Unix timestamp (nanoseconds)
+  optional string source = 3;
+  optional string comment = 4;
+  optional int64 revokedBy = 5;
 }
 
 message KeyBlockedRequest {
-        optional bytes keyHash = 1;
+  optional bytes keyHash = 1;
 }

--- a/va/proto/va.proto
+++ b/va/proto/va.proto
@@ -6,37 +6,37 @@ option go_package = "github.com/letsencrypt/boulder/va/proto";
 import "core/proto/core.proto";
 
 service VA {
-	rpc PerformValidation(PerformValidationRequest) returns (ValidationResult) {}
+  rpc PerformValidation(PerformValidationRequest) returns (ValidationResult) {}
 }
 
 service CAA {
-	rpc IsCAAValid(IsCAAValidRequest) returns (IsCAAValidResponse) {}
+  rpc IsCAAValid(IsCAAValidRequest) returns (IsCAAValidResponse) {}
 }
 
 message IsCAAValidRequest {
-	// NOTE: Domain may be a name with a wildcard prefix (e.g. `*.example.com`)
-	optional string domain = 1;
-	optional string validationMethod = 2;
-	optional int64 accountURIID = 3;
+  // NOTE: Domain may be a name with a wildcard prefix (e.g. `*.example.com`)
+  optional string domain = 1;
+  optional string validationMethod = 2;
+  optional int64 accountURIID = 3;
 }
 
 // If CAA is valid for the requested domain, the problem will be empty
 message IsCAAValidResponse {
-	optional core.ProblemDetails problem = 1;
+  optional core.ProblemDetails problem = 1;
 }
 
 message PerformValidationRequest {
-	optional string domain = 1;
-	optional core.Challenge challenge = 2;
-	optional AuthzMeta authz = 3;
+  optional string domain = 1;
+  optional core.Challenge challenge = 2;
+  optional AuthzMeta authz = 3;
 }
 
 message AuthzMeta {
-	optional string id = 1;
-	optional int64 regID = 2;
+  optional string id = 1;
+  optional int64 regID = 2;
 }
 
 message ValidationResult {
-	repeated core.ValidationRecord records = 1;
-	optional core.ProblemDetails problems = 2;
+  repeated core.ValidationRecord records = 1;
+  optional core.ProblemDetails problems = 2;
 }


### PR DESCRIPTION
Our proto files have had a variety of indentation styles: 2 spaces,
4 spaces, 8 spaces, and tabs; sometimes mixed within the same
file. The proto3 style guide[1] says to use 2-space indents,
so this change standardizes on that.

[1] https://developers.google.com/protocol-buffers/docs/style