### PR TITLE
Report canceled remote validations as problems

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -388,8 +388,9 @@ func (va *ValidationAuthorityImpl) performRemoteValidation(
 			if err != nil && canceled.Is(err) {
 				// If the non-nil err was a canceled error, ignore it. That's fine: it
 				// just means we cancelled the remote VA request before it was
-				// finished because we didn't care about its result.
-				va.log.Infof("Remote VA %q.PerformValidation canceled: %s", rva.Address, err)
+				// finished because we didn't care about its result. Don't log to avoid
+				// spamming the logs.
+				result.Problem = probs.ServerInternal("Remote PerformValidation RPC canceled")
 			} else if err != nil {
 				// This is a real error, not just a problem with the validation.
 				va.log.Errf("Remote VA %q.PerformValidation failed: %s", rva.Address, err)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -453,26 +453,26 @@ func TestMultiVA(t *testing.T) {
 				expectedKeyAuthorization)),
 		},
 		{
-			// With one remote VA cancelled there should not be a validation failure
-			// when enforcing multi VA.
+			// When enforcing multi-VA, any cancellations are a problem.
 			Name: "Local VA and one remote VA OK, one cancelled VA, enforce multi VA",
 			RemoteVAs: []RemoteVA{
 				{remoteVA1, remoteUA1},
 				{cancelledVA{}, remoteUA2},
 			},
-			AllowedUAs: allowedUAs,
-			Features:   enforceMultiVA,
+			AllowedUAs:   allowedUAs,
+			Features:     enforceMultiVA,
+			ExpectedProb: probs.ServerInternal("During secondary validation: Remote PerformValidation RPC canceled"),
 		},
 		{
-			// With two remote VAs cancelled there should not be a validation failure
-			// when enforcing multi VA
-			Name: "Local VA and one remote VA OK, one cancelled VA, enforce multi VA",
+			// When enforcing multi-VA, any cancellations are a problem.
+			Name: "Local VA OK, two cancelled remote VAs, enforce multi VA",
 			RemoteVAs: []RemoteVA{
 				{cancelledVA{}, remoteUA1},
 				{cancelledVA{}, remoteUA2},
 			},
-			AllowedUAs: allowedUAs,
-			Features:   enforceMultiVA,
+			AllowedUAs:   allowedUAs,
+			Features:     enforceMultiVA,
+			ExpectedProb: probs.ServerInternal("During secondary validation: Remote PerformValidation RPC canceled"),
 		},
 		{
 			// With the local and remote VAs seeing diff problems and the full results


### PR DESCRIPTION
Previously, canceled remote validations were simply noted and then
dropped on the floor. This should be safe, as they're theoretically
only canceled when the parent span (i.e. the local PerformValidation
RPC) ends. But for the sake of defense-in-depth, it seems better to
correctly mark canceled remote validations as having Problems, so
that their results cannot be accidentally used anywhere.

This results in a test behavior change: if EnforceMultiVA is on, and
some RPCs are canceled, this now results in validation failure. This
should not have any production impact, because remote validations
should only be canceled when the parent RPC early-exits, but that only
happens when EnforceMultiVA is not enabled. These tests now test a
case where the other remote validations were canceled for some other
reason, which should result in validation failure.

Depends on #5003