### PR TITLE
Introduce new core.AcmeChallenge type

### DIFF
--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -33,7 +33,7 @@ var pa *policy.AuthorityImpl
 
 func init() {
 	var err error
-	pa, err = policy.New(map[string]bool{})
+	pa, err = policy.New(map[core.AcmeChallenge]bool{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -75,13 +75,7 @@ type SMTPConfig struct {
 // it should offer.
 type PAConfig struct {
 	DBConfig
-	Challenges map[string]bool
-}
-
-// HostnamePolicyConfig specifies a file from which to load a policy regarding
-// what hostnames to issue for.
-type HostnamePolicyConfig struct {
-	HostnamePolicyFile string
+	Challenges map[core.AcmeChallenge]bool
 }
 
 // CheckChallenges checks whether the list of challenges in the PA config
@@ -90,12 +84,18 @@ func (pc PAConfig) CheckChallenges() error {
 	if len(pc.Challenges) == 0 {
 		return errors.New("empty challenges map in the Policy Authority config is not allowed")
 	}
-	for name := range pc.Challenges {
-		if !core.ValidChallenge(name) {
-			return fmt.Errorf("Invalid challenge in PA config: %s", name)
+	for c := range pc.Challenges {
+		if !c.IsValid() {
+			return fmt.Errorf("Invalid challenge in PA config: %s", c)
 		}
 	}
 	return nil
+}
+
+// HostnamePolicyConfig specifies a file from which to load a policy regarding
+// what hostnames to issue for.
+type HostnamePolicyConfig struct {
+	HostnamePolicyFile string
 }
 
 // TLSConfig represents certificates and a key for authenticated TLS.

--- a/core/challenges.go
+++ b/core/challenges.go
@@ -1,6 +1,6 @@
 package core
 
-func newChallenge(challengeType string, token string) Challenge {
+func newChallenge(challengeType AcmeChallenge, token string) Challenge {
 	return Challenge{
 		Type:   challengeType,
 		Status: StatusPending,

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -34,10 +34,10 @@ func TestChallenges(t *testing.T) {
 	tlsalpn01 := TLSALPNChallenge01(token)
 	test.AssertNotError(t, tlsalpn01.CheckConsistencyForClientOffer(), "CheckConsistencyForClientOffer returned an error")
 
-	test.Assert(t, ValidChallenge(ChallengeTypeHTTP01), "Refused valid challenge")
-	test.Assert(t, ValidChallenge(ChallengeTypeDNS01), "Refused valid challenge")
-	test.Assert(t, ValidChallenge(ChallengeTypeTLSALPN01), "Refused valid challenge")
-	test.Assert(t, !ValidChallenge("nonsense-71"), "Accepted invalid challenge")
+	test.Assert(t, ChallengeTypeHTTP01.IsValid(), "Refused valid challenge")
+	test.Assert(t, ChallengeTypeDNS01.IsValid(), "Refused valid challenge")
+	test.Assert(t, ChallengeTypeTLSALPN01.IsValid(), "Refused valid challenge")
+	test.Assert(t, !AcmeChallenge("nonsense-71").IsValid(), "Accepted invalid challenge")
 }
 
 // objects.go

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -112,7 +112,7 @@ type PolicyAuthority interface {
 	WillingToIssue(domain identifier.ACMEIdentifier) error
 	WillingToIssueWildcards(identifiers []identifier.ACMEIdentifier) error
 	ChallengesFor(domain identifier.ACMEIdentifier) ([]Challenge, error)
-	ChallengeTypeEnabled(t string) bool
+	ChallengeTypeEnabled(t AcmeChallenge) bool
 }
 
 // StorageGetter are the Boulder SA's read-only methods

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -43,7 +43,7 @@ func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) er
 	return nil
 }
 
-func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
+func (pa *mockPA) ChallengeTypeEnabled(t core.AcmeChallenge) bool {
 	return true
 }
 

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -59,6 +59,7 @@ func PBToProblemDetails(in *corepb.ProblemDetails) (*probs.ProblemDetails, error
 }
 
 func ChallengeToPB(challenge core.Challenge) (*corepb.Challenge, error) {
+	ctype := string(challenge.Type)
 	st := string(challenge.Status)
 	prob, err := ProblemDetailsToPB(challenge.Error)
 	if err != nil {
@@ -72,7 +73,7 @@ func ChallengeToPB(challenge core.Challenge) (*corepb.Challenge, error) {
 		}
 	}
 	return &corepb.Challenge{
-		Type:              &challenge.Type,
+		Type:              &ctype,
 		Status:            &st,
 		Token:             &challenge.Token,
 		KeyAuthorization:  &challenge.ProvidedKeyAuthorization,
@@ -103,7 +104,7 @@ func PBToChallenge(in *corepb.Challenge) (challenge core.Challenge, err error) {
 		return core.Challenge{}, err
 	}
 	ch := core.Challenge{
-		Type:             *in.Type,
+		Type:             core.AcmeChallenge(*in.Type),
 		Status:           core.AcmeStatus(*in.Status),
 		Token:            *in.Token,
 		Error:            prob,

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -32,13 +32,13 @@ type AuthorityImpl struct {
 	wildcardExactBlocklist map[string]bool
 	blocklistMu            sync.RWMutex
 
-	enabledChallenges map[string]bool
+	enabledChallenges map[core.AcmeChallenge]bool
 	pseudoRNG         *rand.Rand
 	rngMu             sync.Mutex
 }
 
 // New constructs a Policy Authority.
-func New(challengeTypes map[string]bool) (*AuthorityImpl, error) {
+func New(challengeTypes map[core.AcmeChallenge]bool) (*AuthorityImpl, error) {
 
 	pa := AuthorityImpl{
 		log:               blog.Get(),
@@ -576,7 +576,7 @@ func (pa *AuthorityImpl) ChallengesFor(identifier identifier.ACMEIdentifier) ([]
 }
 
 // ChallengeTypeEnabled returns whether the specified challenge type is enabled
-func (pa *AuthorityImpl) ChallengeTypeEnabled(t string) bool {
+func (pa *AuthorityImpl) ChallengeTypeEnabled(t core.AcmeChallenge) bool {
 	pa.blocklistMu.RLock()
 	defer pa.blocklistMu.RUnlock()
 	return pa.enabledChallenges[t]

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var enabledChallenges = map[string]bool{
+var enabledChallenges = map[core.AcmeChallenge]bool{
 	core.ChallengeTypeHTTP01: true,
 	core.ChallengeTypeDNS01:  true,
 }
@@ -370,7 +370,7 @@ func TestChallengesFor(t *testing.T) {
 
 	test.Assert(t, len(challenges) == len(enabledChallenges), "Wrong number of challenges returned")
 
-	seenChalls := make(map[string]bool)
+	seenChalls := make(map[core.AcmeChallenge]bool)
 	for _, challenge := range challenges {
 		test.Assert(t, !seenChalls[challenge.Type], "should not already have seen this type")
 		seenChalls[challenge.Type] = true
@@ -388,7 +388,7 @@ func TestChallengesForWildcard(t *testing.T) {
 		Value: "*.zombo.com",
 	}
 
-	mustConstructPA := func(t *testing.T, enabledChallenges map[string]bool) *AuthorityImpl {
+	mustConstructPA := func(t *testing.T, enabledChallenges map[core.AcmeChallenge]bool) *AuthorityImpl {
 		pa, err := New(enabledChallenges)
 		test.AssertNotError(t, err, "Couldn't create policy implementation")
 		return pa
@@ -396,7 +396,7 @@ func TestChallengesForWildcard(t *testing.T) {
 
 	// First try to get a challenge for the wildcard ident without the
 	// DNS-01 challenge type enabled. This should produce an error
-	var enabledChallenges = map[string]bool{
+	var enabledChallenges = map[core.AcmeChallenge]bool{
 		core.ChallengeTypeHTTP01: true,
 		core.ChallengeTypeDNS01:  false,
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -215,7 +215,7 @@ func (ra *RegistrationAuthorityImpl) rateLimitPoliciesLoadError(err error) {
 // some common analysis easier.
 type certificateRequestAuthz struct {
 	ID            string
-	ChallengeType string
+	ChallengeType core.AcmeChallenge
 }
 
 // certificateRequestEvent is a struct for holding information that is logged as
@@ -829,7 +829,7 @@ func (ra *RegistrationAuthorityImpl) recheckCAA(ctx context.Context, authzs []*c
 			var method string
 			for _, challenge := range authz.Challenges {
 				if challenge.Status == core.StatusValid {
-					method = challenge.Type
+					method = string(challenge.Type)
 					break
 				}
 			}
@@ -1162,16 +1162,16 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	// of each of the valid authorizations we used for this issuance.
 	logEventAuthzs := make(map[string]certificateRequestAuthz, len(names))
 	for name, authz := range authzs {
-		var solvedByChallengeType string
 		// If the authz has no solved by challenge type there has been an internal
 		// consistency violation worth logging a warning about. In this case the
 		// solvedByChallengeType will be logged as the empty string.
-		if solvedByChallengeType = authz.SolvedBy(); solvedByChallengeType == "" {
-			ra.log.Warningf("Authz %q has status %q but empty SolvedBy()", authz.ID, authz.Status)
+		solvedByChallengeType, err := authz.SolvedBy()
+		if err != nil || solvedByChallengeType == nil {
+			ra.log.Warningf("Authz %q has status %q but empty SolvedBy(): %s", authz.ID, authz.Status, err)
 		}
 		logEventAuthzs[name] = certificateRequestAuthz{
 			ID:            authz.ID,
-			ChallengeType: solvedByChallengeType,
+			ChallengeType: *solvedByChallengeType,
 		}
 	}
 	logEvent.Authorizations = logEventAuthzs
@@ -1508,6 +1508,7 @@ func (ra *RegistrationAuthorityImpl) recordValidation(ctx context.Context, authI
 		return err
 	}
 	status := string(challenge.Status)
+	ctype := string(challenge.Type)
 	var expires int64
 	if challenge.Status == core.StatusInvalid {
 		expires = authExpires.UnixNano()
@@ -1522,7 +1523,7 @@ func (ra *RegistrationAuthorityImpl) recordValidation(ctx context.Context, authI
 		Id:                &authzID,
 		Status:            &status,
 		Expires:           &expires,
-		Attempted:         &challenge.Type,
+		Attempted:         &ctype,
 		ValidationRecords: vr.Records,
 		ValidationError:   vr.Problems,
 	})
@@ -1940,7 +1941,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		// that doesn't meet this criteria from SA.GetAuthorizations but we verify
 		// again to be safe.
 		if strings.HasPrefix(name, "*.") &&
-			len(authz.Challenges) == 1 && *authz.Challenges[0].Type == core.ChallengeTypeDNS01 {
+			len(authz.Challenges) == 1 && core.AcmeChallenge(*authz.Challenges[0].Type) == core.ChallengeTypeDNS01 {
 			authzID, err := strconv.ParseInt(*authz.Id, 10, 64)
 			if err != nil {
 				return nil, err

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -977,7 +977,7 @@ func TestPerformValidationSuccess(t *testing.T) {
 	}
 
 	// Verify that the VA got the request, and it's the same as the others
-	test.AssertEquals(t, authz.Challenges[challIdx].Type, *vaRequest.Challenge.Type)
+	test.AssertEquals(t, string(authz.Challenges[challIdx].Type), *vaRequest.Challenge.Type)
 	test.AssertEquals(t, authz.Challenges[challIdx].Token, *vaRequest.Challenge.Token)
 
 	// Sleep so the RA has a chance to write to the SA

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -112,7 +112,7 @@ func getAuthorization(t *testing.T, id string, sa *sa.SQLStorageAuthority) core.
 	return dbAuthz
 }
 
-func challTypeIndex(t *testing.T, challenges []core.Challenge, typ string) int64 {
+func challTypeIndex(t *testing.T, challenges []core.Challenge, typ core.AcmeChallenge) int64 {
 	t.Helper()
 	var challIdx int64
 	var set bool
@@ -297,7 +297,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, *sa.SQLStorageAut
 
 	va := &DummyValidationAuthority{request: make(chan *vapb.PerformValidationRequest, 1)}
 
-	pa, err := policy.New(map[string]bool{
+	pa, err := policy.New(map[core.AcmeChallenge]bool{
 		core.ChallengeTypeHTTP01: true,
 		core.ChallengeTypeDNS01:  true,
 	})
@@ -2270,7 +2270,7 @@ func TestNewOrderReuseInvalidAuthz(t *testing.T) {
 	test.AssertEquals(t, numAuthorizations(order), 1)
 
 	status := string(core.StatusInvalid)
-	attempted := core.ChallengeTypeDNS01
+	attempted := string(core.ChallengeTypeDNS01)
 	err = ra.SA.FinalizeAuthorization2(ctx, &sapb.FinalizeAuthorizationRequest{
 		Id:        &order.V2Authorizations[0],
 		Status:    &status,
@@ -3177,7 +3177,7 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 
 	// Finalize the authorization with the challenge validated
 	status := string(core.StatusValid)
-	attempted := core.ChallengeTypeDNS01
+	attempted := string(core.ChallengeTypeDNS01)
 	expInt := ra.clk.Now().Add(time.Hour * 24 * 7).UnixNano()
 	err = sa.FinalizeAuthorization2(ctx, &sapb.FinalizeAuthorizationRequest{
 		Id:        &validOrder.V2Authorizations[0],
@@ -3370,7 +3370,7 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 		// The authz entry should have the correct authz ID
 		test.AssertEquals(t, authzEntry.ID, fmt.Sprintf("%d", authzIDs[i]))
 		// The authz entry should have the correct challenge type
-		test.AssertEquals(t, authzEntry.ChallengeType, chalTypes[i])
+		test.AssertEquals(t, string(authzEntry.ChallengeType), chalTypes[i])
 	}
 }
 
@@ -3407,7 +3407,7 @@ func TestUpdateMissingAuthorization(t *testing.T) {
 func TestValidChallengeStillGood(t *testing.T) {
 	_, _, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
-	pa, err := policy.New(map[string]bool{
+	pa, err := policy.New(map[core.AcmeChallenge]bool{
 		core.ChallengeTypeHTTP01: true,
 	})
 	test.AssertNotError(t, err, "Couldn't create PA")
@@ -3421,7 +3421,7 @@ func TestValidChallengeStillGood(t *testing.T) {
 func TestPerformValidationBadChallengeType(t *testing.T) {
 	_, _, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
-	pa, err := policy.New(map[string]bool{})
+	pa, err := policy.New(map[core.AcmeChallenge]bool{})
 	test.AssertNotError(t, err, "Couldn't create PA")
 	ra.PA = pa
 
@@ -3603,11 +3603,12 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 		// Finalize the authz
 		status := "valid"
 		expInt := exp.UnixNano()
+		attempted := string(httpChal.Type)
 		err = sa.FinalizeAuthorization2(ctx, &sapb.FinalizeAuthorizationRequest{
 			Id:        &ids.Ids[0],
 			Status:    &status,
 			Expires:   &expInt,
-			Attempted: &httpChal.Type,
+			Attempted: &attempted,
 		})
 		test.AssertNotError(t, err, "sa.FinalizeAuthorization2 failed")
 		return ids.Ids[0]

--- a/sa/model.go
+++ b/sa/model.go
@@ -173,12 +173,12 @@ type challModel struct {
 	ID              int64  `db:"id"`
 	AuthorizationID string `db:"authorizationID"`
 
-	Type             string          `db:"type"`
-	Status           core.AcmeStatus `db:"status"`
-	Error            []byte          `db:"error"`
-	Token            string          `db:"token"`
-	KeyAuthorization string          `db:"keyAuthorization"`
-	ValidationRecord []byte          `db:"validationRecord"`
+	Type             core.AcmeChallenge `db:"type"`
+	Status           core.AcmeStatus    `db:"status"`
+	Error            []byte             `db:"error"`
+	Token            string             `db:"token"`
+	KeyAuthorization string             `db:"keyAuthorization"`
+	ValidationRecord []byte             `db:"validationRecord"`
 
 	// TODO(#1818): Remove, this field is unused, but is kept temporarily to avoid a database migration.
 	Validated bool `db:"validated"`

--- a/test/load-generator/acme/challenge.go
+++ b/test/load-generator/acme/challenge.go
@@ -29,7 +29,7 @@ const (
 // NewChallengeStrategy returns the ChallengeStrategy for the given
 // ChallengeStrategyName, or an error if it is unknown.
 func NewChallengeStrategy(rawName string) (ChallengeStrategy, error) {
-	var preferredType string
+	var preferredType core.AcmeChallenge
 	switch name := strings.ToUpper(rawName); name {
 	case RandomChallengeStrategy:
 		return &randomChallengeStrategy{}, nil
@@ -74,7 +74,7 @@ func (strategy randomChallengeStrategy) PickChallenge(authz *core.Authorization)
 // always returns the authorization's challenge with type matching the
 // preferredType.
 type preferredTypeChallengeStrategy struct {
-	preferredType string
+	preferredType core.AcmeChallenge
 }
 
 // PickChallenge for a preferredTypeChallengeStrategy returns the authorization

--- a/va/caa.go
+++ b/va/caa.go
@@ -58,16 +58,16 @@ func (va *ValidationAuthorityImpl) checkCAA(
 		return probs.CAA(fmt.Sprintf("CAA records for %s were malformed", identifier.Value))
 	}
 
-	accountID, challengeType := "unknown", "unknown"
-	if params.accountURIID != nil {
+	accountID, validationMethod := "unknown", "unknown"
+	if params.accountURIID != nil && *params.accountURIID != 0 {
 		accountID = fmt.Sprintf("%d", *params.accountURIID)
 	}
-	if params.validationMethod != nil {
-		challengeType = *params.validationMethod
+	if params.validationMethod != nil && *params.validationMethod != "" {
+		validationMethod = *params.validationMethod
 	}
 
 	va.log.AuditInfof("Checked CAA records for %s, [Present: %t, Account ID: %s, Challenge: %s, Valid for issuance: %t] Records=%s",
-		identifier.Value, present, accountID, challengeType, valid, recordsStr)
+		identifier.Value, present, accountID, validationMethod, valid, recordsStr)
 	if !valid {
 		return probs.CAA(fmt.Sprintf("CAA record for %s prevents issuance", identifier.Value))
 	}

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -467,68 +467,63 @@ func TestCAALogging(t *testing.T) {
 	va, _ := setup(nil, 0, "", nil)
 	va.dnsClient = caaMockDNS{}
 
-	httpChal := core.ChallengeTypeHTTP01
-	dnsChal := core.ChallengeTypeDNS01
-	acctID := int64(12345)
-
 	testCases := []struct {
 		Name            string
 		Domain          string
-		AccountURIID    *int64
-		ChallengeType   *string
+		AccountURIID    int64
+		ChallengeType   core.AcmeChallenge
 		ExpectedLogline string
 	}{
 		{
 			Domain:          "reserved.com",
-			ChallengeType:   nil,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: unknown, Challenge: unknown, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "reserved.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "reserved.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &dnsChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeDNS01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: dns-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "mixedcase.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for mixedcase.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"iSsUe\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "critical.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for critical.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"}]",
 		},
 		{
 			Domain:          "present.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}]",
 		},
 		{
 			Domain:          "multi-crit-present.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for multi-crit-present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}]",
 		},
 		{
 			Domain:          "present-with-parameter.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present-with-parameter.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"  letsencrypt.org  ;foo=bar;baz=bar\"}]",
 		},
 		{
 			Domain:          "satisfiable-wildcard-override.com",
-			AccountURIID:    &acctID,
-			ChallengeType:   &httpChal,
+			AccountURIID:    12345,
+			ChallengeType:   core.ChallengeTypeHTTP01,
 			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for satisfiable-wildcard-override.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issuewild\",\"Value\":\"letsencrypt.org\"}]",
 		},
 	}
@@ -538,9 +533,10 @@ func TestCAALogging(t *testing.T) {
 			mockLog := va.log.(*blog.Mock)
 			mockLog.Clear()
 
+			validationMethod := string(tc.ChallengeType)
 			params := &caaParams{
-				accountURIID:     tc.AccountURIID,
-				validationMethod: tc.ChallengeType,
+				accountURIID:     &tc.AccountURIID,
+				validationMethod: &validationMethod,
 			}
 			_ = va.checkCAA(ctx, identifier.ACMEIdentifier{Type: identifier.DNS, Value: tc.Domain}, params)
 

--- a/va/va.go
+++ b/va/va.go
@@ -330,9 +330,10 @@ func (va *ValidationAuthorityImpl) validate(
 	// `baseIdentifier`
 	ch := make(chan *probs.ProblemDetails, 1)
 	go func() {
+		validationMethod := string(challenge.Type)
 		params := &caaParams{
 			accountURIID:     &regid,
-			validationMethod: &challenge.Type,
+			validationMethod: &validationMethod,
 		}
 		ch <- va.checkCAA(ctx, identifier, params)
 	}()

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -79,14 +79,15 @@ func TestMain(m *testing.M) {
 
 var accountURIPrefixes = []string{"http://boulder:4000/acme/reg/"}
 
-func createValidationRequest(domain, challengeType string) *vapb.PerformValidationRequest {
+func createValidationRequest(domain, challengeType core.AcmeChallenge) *vapb.PerformValidationRequest {
+	ctype := string(challengeType)
 	status := string(core.StatusPending)
 	authzID := ""
 	authzRegID := int64(0)
 	return &vapb.PerformValidationRequest{
 		Domain: &domain,
 		Challenge: &corepb.Challenge{
-			Type:              &challengeType,
+			Type:              &ctype,
 			Status:            &status,
 			Token:             &expectedToken,
 			Validationrecords: nil,

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -79,7 +79,7 @@ func TestMain(m *testing.M) {
 
 var accountURIPrefixes = []string{"http://boulder:4000/acme/reg/"}
 
-func createValidationRequest(domain, challengeType core.AcmeChallenge) *vapb.PerformValidationRequest {
+func createValidationRequest(domain string, challengeType core.AcmeChallenge) *vapb.PerformValidationRequest {
 	ctype := string(challengeType)
 	status := string(core.StatusPending)
 	authzID := ""
@@ -100,9 +100,8 @@ func createValidationRequest(domain, challengeType core.AcmeChallenge) *vapb.Per
 	}
 }
 
-func createChallenge(challengeType string) core.Challenge {
+func createChallenge(challengeType core.AcmeChallenge) core.Challenge {
 	return core.Challenge{
-		// challengeType is a core.ChallengeType* (string constant, not a type).
 		Type:                     challengeType,
 		Status:                   core.StatusPending,
 		Token:                    expectedToken,

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1084,7 +1084,7 @@ func (wfe *WebFrontEndImpl) ChallengeV2(
 		wfe.getChallenge(ctx, response, request, authz, &challenge, logEvent)
 
 	case "POST":
-		logEvent.ChallengeType = challenge.Type
+		logEvent.ChallengeType = string(challenge.Type)
 		wfe.postChallenge(ctx, response, request, authz, challengeIndex, logEvent)
 	}
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -267,7 +267,7 @@ func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) er
 	return nil
 }
 
-func (pa *mockPA) ChallengeTypeEnabled(t string) bool {
+func (pa *mockPA) ChallengeTypeEnabled(t core.AcmeChallenge) bool {
 	return true
 }
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1083,7 +1083,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 		wfe.getChallenge(ctx, response, request, authz, &challenge, logEvent)
 
 	case "POST":
-		logEvent.ChallengeType = challenge.Type
+		logEvent.ChallengeType = string(challenge.Type)
 		wfe.postChallenge(ctx, response, request, authz, challengeIndex, logEvent)
 	}
 }


### PR DESCRIPTION
ACME Challenges are well-known strings ("http-01", "dns-01", and
"tlsalpn-01") identifying which kind of challenge should be used
to verify control of a domain. Because they are well-known and
only certain values are valid, it is better to represent them as
something more akin to an enum than as bare strings. This also
improves our ability to ensure that an AcmeChallenge is not
accidentally used as some other kind of string in a different
context. This change also brings them closer in line with the
existing core.AcmeResource and core.OCSPStatus string enums.

Fixes #5009