### PR TITLE
Update to go1.15rc2 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 os: linux
 
 go:
-  - "1.15rc1"
+  - "1.15rc2"
   - "1.14.5"
 
 go_import_path: github.com/letsencrypt/boulder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-29
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-08-07
         environment:
             - FAKE_DNS=10.77.77.77
             - BOULDER_CONFIG_DIR=test/config
@@ -76,7 +76,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-07-29
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.14.5}:2020-08-07
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.15rc1" "1.14.5" )
+GO_VERSIONS=( "1.15rc2" "1.14.5" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
Go 1.15rc2 was released today. The diff from rc1 only includes one
change to the crypto/ package, but worth upgrading just to be ready
for the official 1.15 stable release.