### PR TITLE
Allow generating a key in a non-empty slot.

### DIFF
--- a/cmd/ceremony/key.go
+++ b/cmd/ceremony/key.go
@@ -50,13 +50,9 @@ type keyInfo struct {
 }
 
 func generateKey(session *pkcs11helpers.Session, label string, outputPath string, config keyGenConfig) (*keyInfo, error) {
-	_, err := session.FindObject([]*pkcs11.Attribute{})
-	if err != pkcs11helpers.ErrNoObject {
-		return nil, fmt.Errorf("expected no objects in slot for key storage. got error: %s", err)
-	}
-
 	var pubKey crypto.PublicKey
 	var keyID []byte
+	var err error
 	switch config.Type {
 	case "rsa":
 		pubKey, keyID, err = rsaGenerate(session, label, config.RSAModLength, rsaExp)

--- a/cmd/ceremony/key.go
+++ b/cmd/ceremony/key.go
@@ -50,9 +50,11 @@ type keyInfo struct {
 }
 
 func generateKey(session *pkcs11helpers.Session, label string, outputPath string, config keyGenConfig) (*keyInfo, error) {
-	_, err := session.FindObject([]*pkcs11.Attribute{})
+	_, err := session.FindObject([]*pkcs11.Attribute{
+		&pkcs11.Attribute{Type: pkcs11.CKA_LABEL, Value: []byte(label)},
+	})
 	if err != pkcs11helpers.ErrNoObject {
-		return nil, fmt.Errorf("expected no objects in slot for key storage. got error: %s", err)
+		return nil, fmt.Errorf("expected no preexisting objects with label %q in slot for key storage. got error: %s", label, err)
 	}
 
 	var pubKey crypto.PublicKey

--- a/cmd/ceremony/key.go
+++ b/cmd/ceremony/key.go
@@ -50,9 +50,13 @@ type keyInfo struct {
 }
 
 func generateKey(session *pkcs11helpers.Session, label string, outputPath string, config keyGenConfig) (*keyInfo, error) {
+	_, err := session.FindObject([]*pkcs11.Attribute{})
+	if err != pkcs11helpers.ErrNoObject {
+		return nil, fmt.Errorf("expected no objects in slot for key storage. got error: %s", err)
+	}
+
 	var pubKey crypto.PublicKey
 	var keyID []byte
-	var err error
 	switch config.Type {
 	case "rsa":
 		pubKey, keyID, err = rsaGenerate(session, label, config.RSAModLength, rsaExp)

--- a/cmd/ceremony/key.go
+++ b/cmd/ceremony/key.go
@@ -51,7 +51,7 @@ type keyInfo struct {
 
 func generateKey(session *pkcs11helpers.Session, label string, outputPath string, config keyGenConfig) (*keyInfo, error) {
 	_, err := session.FindObject([]*pkcs11.Attribute{
-		&pkcs11.Attribute{Type: pkcs11.CKA_LABEL, Value: []byte(label)},
+		{Type: pkcs11.CKA_LABEL, Value: []byte(label)},
 	})
 	if err != pkcs11helpers.ErrNoObject {
 		return nil, fmt.Errorf("expected no preexisting objects with label %q in slot for key storage. got error: %s", label, err)

--- a/cmd/ceremony/key_test.go
+++ b/cmd/ceremony/key_test.go
@@ -12,7 +12,6 @@ import (
 	"math/big"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/letsencrypt/boulder/pkcs11helpers"
@@ -106,23 +105,4 @@ func TestGenerateKeyEC(t *testing.T) {
 	diskKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	test.AssertNotError(t, err, "Failed to parse disk key")
 	test.AssertDeepEquals(t, diskKey, keyInfo.key)
-}
-
-func TestGenerateKeySlotHasSomething(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "ceremony-testing-slot-has-something")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
-	defer os.RemoveAll(tmp)
-
-	ctx := setupCtx()
-	ctx.FindObjectsFunc = func(pkcs11.SessionHandle, int) ([]pkcs11.ObjectHandle, bool, error) {
-		return []pkcs11.ObjectHandle{1}, false, nil
-	}
-	keyPath := path.Join(tmp, "should-not-exist.pem")
-	s := &pkcs11helpers.Session{Module: &ctx, Session: 0}
-	_, err = generateKey(s, "", keyPath, keyGenConfig{
-		Type:       "ecdsa",
-		ECDSACurve: "P-256",
-	})
-	test.AssertError(t, err, "expected failure for a slot with an object already in it")
-	test.Assert(t, strings.HasPrefix(err.Error(), "expected no objects"), "wrong error")
 }

--- a/cmd/ceremony/key_test.go
+++ b/cmd/ceremony/key_test.go
@@ -76,14 +76,11 @@ func TestGenerateKeyRSA(t *testing.T) {
 	test.AssertDeepEquals(t, diskKey, keyInfo.key)
 }
 
-func TestGenerateKeyEC(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "ceremony-testing-ec")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
-	defer os.RemoveAll(tmp)
-
-	ctx := setupCtx()
+func setECGenerateFuncs(ctx *pkcs11helpers.MockCtx) {
 	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	test.AssertNotError(t, err, "Failed to generate a ECDSA test key")
+	if err != nil {
+		panic(err)
+	}
 	ctx.GetAttributeValueFunc = func(pkcs11.SessionHandle, pkcs11.ObjectHandle, []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
 		return []*pkcs11.Attribute{
 			pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, []byte{6, 8, 42, 134, 72, 206, 61, 3, 1, 7}),
@@ -93,6 +90,15 @@ func TestGenerateKeyEC(t *testing.T) {
 	ctx.SignFunc = func(_ pkcs11.SessionHandle, msg []byte) ([]byte, error) {
 		return ecPKCS11Sign(ecPriv, msg)
 	}
+}
+
+func TestGenerateKeyEC(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "ceremony-testing-ec")
+	test.AssertNotError(t, err, "Failed to create temporary directory")
+	defer os.RemoveAll(tmp)
+
+	ctx := setupCtx()
+	setECGenerateFuncs(&ctx)
 	keyPath := path.Join(tmp, "test-ecdsa-key.pem")
 	s := &pkcs11helpers.Session{Module: &ctx, Session: 0}
 	keyInfo, err := generateKey(s, "", keyPath, keyGenConfig{
@@ -108,13 +114,7 @@ func TestGenerateKeyEC(t *testing.T) {
 	test.AssertDeepEquals(t, diskKey, keyInfo.key)
 }
 
-func TestGenerateKeySlotHasSomethingWithLabel(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "ceremony-testing-slot-has-something")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
-	defer os.RemoveAll(tmp)
-
-	ctx := setupCtx()
-	label := "someLabel"
+func setFindObjectsFuncs(label string, ctx *pkcs11helpers.MockCtx) {
 	var objectsFound []pkcs11.ObjectHandle
 	ctx.FindObjectsInitFunc = func(_ pkcs11.SessionHandle, template []*pkcs11.Attribute) error {
 		for _, attr := range template {
@@ -127,6 +127,20 @@ func TestGenerateKeySlotHasSomethingWithLabel(t *testing.T) {
 	ctx.FindObjectsFunc = func(pkcs11.SessionHandle, int) ([]pkcs11.ObjectHandle, bool, error) {
 		return objectsFound, false, nil
 	}
+	ctx.FindObjectsFinalFunc = func(pkcs11.SessionHandle) error {
+		objectsFound = nil
+		return nil
+	}
+}
+
+func TestGenerateKeySlotHasSomethingWithLabel(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "ceremony-testing-slot-has-something")
+	test.AssertNotError(t, err, "Failed to create temporary directory")
+	defer os.RemoveAll(tmp)
+
+	ctx := setupCtx()
+	label := "someLabel"
+	setFindObjectsFuncs(label, &ctx)
 	keyPath := path.Join(tmp, "should-not-exist.pem")
 	s := &pkcs11helpers.Session{Module: &ctx, Session: 0}
 	_, err = generateKey(s, label, keyPath, keyGenConfig{
@@ -135,4 +149,21 @@ func TestGenerateKeySlotHasSomethingWithLabel(t *testing.T) {
 	})
 	test.AssertError(t, err, "expected failure for a slot with an object already in it")
 	test.Assert(t, strings.HasPrefix(err.Error(), "expected no preexisting objects with label"), "wrong error")
+}
+
+func TestGenerateKeySlotHasSomethingWithDifferentLabel(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "ceremony-testing-slot-has-something")
+	test.AssertNotError(t, err, "Failed to create temporary directory")
+	defer os.RemoveAll(tmp)
+
+	ctx := setupCtx()
+	setECGenerateFuncs(&ctx)
+	setFindObjectsFuncs("someLabel", &ctx)
+	keyPath := path.Join(tmp, "should-not-exist.pem")
+	s := &pkcs11helpers.Session{Module: &ctx, Session: 0}
+	_, err = generateKey(s, "someOtherLabel", keyPath, keyGenConfig{
+		Type:       "ecdsa",
+		ECDSACurve: "P-256",
+	})
+	test.AssertNotError(t, err, "expected success even though there was an object with a different label")
 }

--- a/cmd/ceremony/key_test.go
+++ b/cmd/ceremony/key_test.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/letsencrypt/boulder/pkcs11helpers"
@@ -105,4 +106,23 @@ func TestGenerateKeyEC(t *testing.T) {
 	diskKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	test.AssertNotError(t, err, "Failed to parse disk key")
 	test.AssertDeepEquals(t, diskKey, keyInfo.key)
+}
+
+func TestGenerateKeySlotHasSomething(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "ceremony-testing-slot-has-something")
+	test.AssertNotError(t, err, "Failed to create temporary directory")
+	defer os.RemoveAll(tmp)
+
+	ctx := setupCtx()
+	ctx.FindObjectsFunc = func(pkcs11.SessionHandle, int) ([]pkcs11.ObjectHandle, bool, error) {
+		return []pkcs11.ObjectHandle{1}, false, nil
+	}
+	keyPath := path.Join(tmp, "should-not-exist.pem")
+	s := &pkcs11helpers.Session{Module: &ctx, Session: 0}
+	_, err = generateKey(s, "", keyPath, keyGenConfig{
+		Type:       "ecdsa",
+		ECDSACurve: "P-256",
+	})
+	test.AssertError(t, err, "expected failure for a slot with an object already in it")
+	test.Assert(t, strings.HasPrefix(err.Error(), "expected no objects"), "wrong error")
 }


### PR DESCRIPTION
Partial revert of #4981 / 62eae60. Some HSMs have a small number
of slots and require storing multiple keys per slot (differentiated
by keyID, which we now look up based on the public key per #4992).

So now we just require that there is nothing else with the same label.