### PR TITLE
Don't require OCSP URL for intermediates.

### DIFF
--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -102,9 +102,6 @@ func (profile *certProfile) verifyProfile(ct certType) error {
 	}
 
 	if ct == intermediateCert {
-		if profile.OCSPURL == "" {
-			return errors.New("ocsp-url is required for intermediates")
-		}
 		if profile.CRLURL == "" {
 			return errors.New("crl-url is required for intermediates")
 		}

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -244,18 +244,6 @@ func TestVerifyProfile(t *testing.T) {
 				CommonName:         "d",
 				Organization:       "e",
 				Country:            "f",
-			},
-			certType:    intermediateCert,
-			expectedErr: "ocsp-url is required for intermediates",
-		},
-		{
-			profile: certProfile{
-				NotBefore:          "a",
-				NotAfter:           "b",
-				SignatureAlgorithm: "c",
-				CommonName:         "d",
-				Organization:       "e",
-				Country:            "f",
 				OCSPURL:            "g",
 			},
 			certType:    intermediateCert,


### PR DESCRIPTION
Per ballot SC30, assuming the review period passes with no objections,
OCSP is no longer required on intermediates.