### PR TITLE
Capitalize X509 in CRL PEM output.

### DIFF
--- a/cmd/ceremony/crl.go
+++ b/cmd/ceremony/crl.go
@@ -45,5 +45,5 @@ func generateCRL(signer crypto.Signer, issuer *x509.Certificate, thisUpdate, nex
 		return nil, err
 	}
 
-	return pem.EncodeToMemory(&pem.Block{Type: "x509 CRL", Bytes: crlBytes}), nil
+	return pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: crlBytes}), nil
 }


### PR DESCRIPTION
`openssl crl` rejects "x509" but accepts "X509", at least as of version
1.1.1f.