### PR TITLE
Don't overwrite files during ceremonies.

### DIFF
--- a/cmd/ceremony/file.go
+++ b/cmd/ceremony/file.go
@@ -3,7 +3,7 @@ package main
 import "os"
 
 // writeFile creates a file at the given filename and writes the provided bytes
-// to it.  // Errors if the file already exists.
+// to it. Errors if the file already exists.
 func writeFile(filename string, bytes []byte) error {
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {

--- a/cmd/ceremony/file.go
+++ b/cmd/ceremony/file.go
@@ -1,0 +1,14 @@
+package main
+
+import "os"
+
+// writeFile creates a file at the given filename and writes the provided bytes
+// to it.  // Errors if the file already exists.
+func writeFile(filename string, bytes []byte) error {
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(bytes)
+	return err
+}

--- a/cmd/ceremony/file_test.go
+++ b/cmd/ceremony/file_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestWriteFileSuccess(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = writeFile(dir+"/example", []byte("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWriteFileFail(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = writeFile(dir+"/example", []byte("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = writeFile(dir+"/example", []byte("hi"))
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+}

--- a/cmd/ceremony/key.go
+++ b/cmd/ceremony/key.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"log"
 
 	"github.com/letsencrypt/boulder/pkcs11helpers"
@@ -79,7 +78,7 @@ func generateKey(session *pkcs11helpers.Session, label string, outputPath string
 
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
 	log.Printf("Public key PEM:\n%s\n", pemBytes)
-	if err := ioutil.WriteFile(outputPath, pemBytes, 0644); err != nil {
+	if err := writeFile(outputPath, pemBytes); err != nil {
 		return nil, fmt.Errorf("Failed to write public key to %q: %s", outputPath, err)
 	}
 	log.Printf("Public key written to %q\n", outputPath)

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -1,6 +1,50 @@
 package main
 
-import "testing"
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestCheckOutputFileSucceeds(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = checkOutputFile(dir+"/example", "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckOutputFileEmpty(t *testing.T) {
+	err := checkOutputFile("", "foo")
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if err.Error() != "outputs.foo is required" {
+		t.Fatalf("wrong error: %s", err)
+	}
+}
+
+func TestCheckOutputFileExists(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := dir + "/example"
+	err = writeFile(filename, []byte("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = checkOutputFile(filename, "foo")
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("wrong error: %s", err)
+	}
+}
 
 func TestKeyGenConfigValidate(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
At validation time, verify that output paths don't already exist.
When writing files, use O_CREAT and O_EXCL to prevent overwriting.