### PR TITLE
Make ra.PerformValidation resilient to va failure

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1628,11 +1628,13 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 		if err != nil {
 			prob = probs.ServerInternal("Could not communicate with VA")
 			ra.log.AuditErrf("Could not communicate with VA: %s", err)
-		} else if res.Problems != nil {
-			prob, err = bgrpc.PBToProblemDetails(res.Problems)
-			if err != nil {
-				prob = probs.ServerInternal("Could not communicate with VA")
-				ra.log.AuditErrf("Could not communicate with VA: %s", err)
+		} else {
+			if res.Problems != nil {
+				prob, err = bgrpc.PBToProblemDetails(res.Problems)
+				if err != nil {
+					prob = probs.ServerInternal("Could not communicate with VA")
+					ra.log.AuditErrf("Could not communicate with VA: %s", err)
+				}
 			}
 
 			// Save the updated records

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1622,7 +1622,9 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 		}
 		res, err := ra.VA.PerformValidation(vaCtx, &req)
 
+		challenge := &authz.Challenges[challIndex]
 		var prob *probs.ProblemDetails
+
 		if err != nil {
 			prob = probs.ServerInternal("Could not communicate with VA")
 			ra.log.AuditErrf("Could not communicate with VA: %s", err)
@@ -1632,18 +1634,17 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 				prob = probs.ServerInternal("Could not communicate with VA")
 				ra.log.AuditErrf("Could not communicate with VA: %s", err)
 			}
-		}
 
-		// Save the updated records
-		challenge := &authz.Challenges[challIndex]
-		records := make([]core.ValidationRecord, len(res.Records))
-		for i, r := range res.Records {
-			records[i], err = bgrpc.PBToValidationRecord(r)
-			if err != nil {
-				prob = probs.ServerInternal("Records for validation corrupt")
+			// Save the updated records
+			records := make([]core.ValidationRecord, len(res.Records))
+			for i, r := range res.Records {
+				records[i], err = bgrpc.PBToValidationRecord(r)
+				if err != nil {
+					prob = probs.ServerInternal("Records for validation corrupt")
+				}
 			}
+			challenge.ValidationRecord = records
 		}
-		challenge.ValidationRecord = records
 
 		if !challenge.RecordsSane() && prob == nil {
 			prob = probs.ServerInternal("Records for validation failed sanity check")


### PR DESCRIPTION
ra.PerformValidation's goroutine surfaces errors not by returning them,
but by accumulating them into the `prob`variable and saving them to
the database. This makes it possible for processing to continue even
in error cases when it should (mostly) halt. This change fixes a bug
where we would try to access a member of the result returned from
va.PerformValidation, even if that function call had returned an error.