### PR TITLE
ceremony: add cross-certificate ceremony type.

### DIFF
--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -6,7 +6,7 @@ ceremony --config path/to/config.yml
 
 `ceremony` is a tool designed for Certificate Authority specific key and certificate ceremonies. The main design principle is that unlike most ceremony tooling there is a single user input, a configuration file, which is required to complete a root, intermediate, or key ceremony. The goal is to make ceremonies as simple as possible and allow for simple verification of a single file, instead of verification of a large number of independent commands.
 
-`ceremony` operates in one of three modes
+`ceremony` has these modes:
 * `root` - generates a signing key on HSM and creates a self-signed root certificate that uses the generated key, outputting a PEM public key, and a PEM certificate
 * `intermediate` - creates a intermediate certificate and signs it using a signing key already on a HSM, outputting a PEM certificate
 * `cross-certificate` - issues a certificate for one root, signed by another root. This is distinct from an intermediate because there is no path length constraint and there are no EKUs.

--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -9,6 +9,7 @@ ceremony --config path/to/config.yml
 `ceremony` operates in one of three modes
 * `root` - generates a signing key on HSM and creates a self-signed root certificate that uses the generated key, outputting a PEM public key, and a PEM certificate
 * `intermediate` - creates a intermediate certificate and signs it using a signing key already on a HSM, outputting a PEM certificate
+* `cross-certificate` - issues a certificate for one root, signed by another root. This is distinct from an intermediate because there is no path length constraint and there are no EKUs.
 * `ocsp-signer` - creates a delegated OCSP signing certificate and signs it using a signing key already on a HSM, outputting a PEM certificate
 * `crl-signer` - creates a delegated CRL signing certificate and signs it using a signing key already on a HSM, outputting a PEM certificate
 * `key` - generates a signing key on HSM, outputting a PEM public key
@@ -72,9 +73,9 @@ certificate-profile:
 
 This config generates a ECDSA P-384 key in the HSM with the object label `root signing key` and uses this key to sign a self-signed certificate. The public key for the key generated is written to `/home/user/root-signing-pub.pem` and the certificate is written to `/home/user/root-cert.pem`.
 
-### Intermediate ceremony
+### Intermediate or Cross-Certificate ceremony
 
-- `ceremony-type`: string describing the ceremony type, `intermediate`.
+- `ceremony-type`: string describing the ceremony type, `intermediate` or `cross-certificate`.
 - `pkcs11`: object containing PKCS#11 related fields.
     | Field | Description |
     | --- | --- |

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -271,6 +271,7 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 	}
 
 	switch ct {
+	// rootCert and crossCert do not get EKU or MaxPathZero
 	case ocspCert:
 		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageOCSPSigning}
 		// ASN.1 NULL is 0x05, 0x00
@@ -282,7 +283,6 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 	case intermediateCert:
 		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
 		cert.MaxPathLenZero = true
-		// rootCert and crossCert do not get EKU or MaxPathZero
 	}
 
 	if len(profile.Policies) > 0 {

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -663,6 +663,11 @@ func main() {
 		if err != nil {
 			log.Fatalf("root ceremony failed: %s", err)
 		}
+	case "cross-certificate":
+		err = intermediateCeremony(configBytes, crossCert)
+		if err != nil {
+			log.Fatalf("cross-certificate ceremony failed: %s", err)
+		}
 	case "intermediate":
 		err = intermediateCeremony(configBytes, intermediateCert)
 		if err != nil {


### PR DESCRIPTION
This is like an intermediate ceremony, but the EKU and path length
constraints are omitted.

Fixes #5029 