### PR TITLE
test: set golangci-lint timeout to 9m.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -68,7 +68,9 @@ function run_test_coverage() {
 # Run various linters.
 #
 if [[ "$RUN" =~ "lints" ]] ; then
-  golangci-lint run ./...
+  # golangci-lint is sometimes slow. Travis will kill our job if it goes 10m
+  # without emitting logs, so set the timeout to 9m.
+  golangci-lint run --timeout 9m ./...
   run_and_expect_silence ./test/test-no-outdated-migrations.sh
   python test/grafana/lint.py
   # Check for common spelling errors using codespell.


### PR DESCRIPTION
This is an increase from the default of 1m.