### PR TITLE
sa: remove nil checks for zero-able fields.

### DIFF
--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -128,7 +128,7 @@ func (policy *KeyPolicy) GoodKey(ctx context.Context, key crypto.PublicKey) erro
 		exists, err := policy.dbCheck(ctx, &sapb.KeyBlockedRequest{KeyHash: digest[:]})
 		if err != nil {
 			return err
-		} else if *exists.Exists {
+		} else if exists.Exists != nil && *exists.Exists {
 			return badKey("public key is forbidden")
 		}
 	}

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -330,7 +330,7 @@ func registrationValid(reg *corepb.Registration) bool {
 // from `newOrderValid` it ensures the order ID, the BeganProcessing fields
 // and the Created field are not nil.
 func orderValid(order *corepb.Order) bool {
-	return order.Id != nil && order.BeganProcessing != nil && order.Created != nil && newOrderValid(order)
+	return order.Id != nil && order.Created != nil && newOrderValid(order)
 }
 
 // newOrderValid checks that a corepb.Order is valid. It allows for a nil

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -323,7 +323,7 @@ func PBToAuthz(pb *corepb.Authorization) (core.Authorization, error) {
 }
 
 func registrationValid(reg *corepb.Registration) bool {
-	return !(reg.Id == nil || reg.Key == nil || reg.Agreement == nil || reg.InitialIP == nil || reg.CreatedAt == nil || reg.Status == nil || reg.ContactsPresent == nil)
+	return !(reg.Id == nil || reg.Key == nil || reg.Agreement == nil || reg.InitialIP == nil || reg.CreatedAt == nil || reg.Status == nil)
 }
 
 // orderValid checks that a corepb.Order is valid. In addition to the checks
@@ -341,7 +341,7 @@ func orderValid(order *corepb.Order) bool {
 // `order.CertificateSerial` to be nil such that it can be used in places where
 // the order has not been finalized yet.
 func newOrderValid(order *corepb.Order) bool {
-	return !(order.RegistrationID == nil || order.Expires == nil || order.V2Authorizations == nil || order.Names == nil)
+	return !(order.RegistrationID == nil || order.Expires == nil || order.Names == nil)
 }
 
 func authorizationValid(authz *corepb.Authorization) bool {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -128,11 +128,11 @@ func (sac StorageAuthorityClientWrapper) CountRegistrationsByIP(ctx context.Cont
 		return 0, err
 	}
 
-	if response == nil || response.Count == nil {
+	if response == nil {
 		return 0, errIncompleteResponse
 	}
 
-	return int(*response.Count), nil
+	return int(responseToInt(response)), nil
 }
 
 func (sac StorageAuthorityClientWrapper) CountRegistrationsByIPRange(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error) {
@@ -150,11 +150,18 @@ func (sac StorageAuthorityClientWrapper) CountRegistrationsByIPRange(ctx context
 		return 0, err
 	}
 
-	if response == nil || response.Count == nil {
+	if response == nil {
 		return 0, errIncompleteResponse
 	}
 
-	return int(*response.Count), nil
+	return int(responseToInt(response)), nil
+}
+
+func responseToInt(resp *sapb.Count) int64 {
+	if resp.Count != nil {
+		return *resp.Count
+	}
+	return 0
 }
 
 func (sac StorageAuthorityClientWrapper) CountOrders(ctx context.Context, acctID int64, earliest, latest time.Time) (int, error) {
@@ -172,11 +179,11 @@ func (sac StorageAuthorityClientWrapper) CountOrders(ctx context.Context, acctID
 		return 0, err
 	}
 
-	if response == nil || response.Count == nil {
+	if response == nil {
 		return 0, errIncompleteResponse
 	}
 
-	return int(*response.Count), nil
+	return int(responseToInt(response)), nil
 }
 
 func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, window time.Duration, domains []string) (int64, error) {
@@ -190,11 +197,11 @@ func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, wind
 		return 0, err
 	}
 
-	if response == nil || response.Count == nil {
+	if response == nil {
 		return 0, errIncompleteResponse
 	}
 
-	return *response.Count, nil
+	return responseToInt(response), nil
 }
 
 func (sac StorageAuthorityClientWrapper) PreviousCertificateExists(
@@ -205,7 +212,7 @@ func (sac StorageAuthorityClientWrapper) PreviousCertificateExists(
 	if err != nil {
 		return nil, err
 	}
-	if exists == nil || exists.Exists == nil {
+	if exists == nil {
 		return nil, errIncompleteResponse
 	}
 	return exists, err
@@ -239,17 +246,24 @@ func (sac StorageAuthorityClientWrapper) AddSerial(
 	return empty, nil
 }
 
+func boolPointerToBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}
+
 func (sac StorageAuthorityClientWrapper) FQDNSetExists(ctx context.Context, domains []string) (bool, error) {
 	response, err := sac.inner.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: domains})
 	if err != nil {
 		return false, err
 	}
 
-	if response == nil || response.Exists == nil {
+	if response == nil {
 		return false, errIncompleteResponse
 	}
 
-	return *response.Exists, nil
+	return boolPointerToBool(response.Exists), nil
 }
 
 func (sac StorageAuthorityClientWrapper) NewRegistration(ctx context.Context, reg core.Registration) (core.Registration, error) {
@@ -434,7 +448,7 @@ func (sas StorageAuthorityClientWrapper) CountPendingAuthorizations2(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if count == nil || count.Count == nil {
+	if count == nil {
 		return nil, errIncompleteResponse
 	}
 	return count, nil
@@ -456,7 +470,7 @@ func (sas StorageAuthorityClientWrapper) CountInvalidAuthorizations2(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if count == nil || count.Count == nil {
+	if count == nil {
 		return nil, errIncompleteResponse
 	}
 	return count, nil

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -803,7 +803,7 @@ func (sas StorageAuthorityServerWrapper) GetAuthorization2(ctx context.Context, 
 }
 
 func (sas StorageAuthorityServerWrapper) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*corepb.Empty, error) {
-	if req == nil || req.Serial == nil || req.Reason == nil || req.Date == nil || req.Response == nil {
+	if req == nil || req.Serial == nil || req.Date == nil || req.Response == nil {
 		return nil, errIncompleteRequest
 	}
 	return &corepb.Empty{}, sas.inner.RevokeCertificate(ctx, req)

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -818,7 +818,7 @@ func (sas StorageAuthorityServerWrapper) NewAuthorizations2(ctx context.Context,
 }
 
 func (sas StorageAuthorityServerWrapper) GetAuthorizations2(ctx context.Context, req *sapb.GetAuthorizationsRequest) (*sapb.Authorizations, error) {
-	if req == nil || req.Domains == nil || req.RequireV2Authzs == nil || req.RegistrationID == nil || req.Now == nil {
+	if req == nil || req.Domains == nil || req.RegistrationID == nil || req.Now == nil {
 		return nil, errIncompleteRequest
 	}
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1539,6 +1539,12 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization2(ctx context.Context, req 
 // RevokeCertificate stores revocation information about a certificate. It will only store this
 // information if the certificate is not already marked as revoked.
 func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) error {
+	var reason revocation.Reason
+	if req.Reason == nil {
+		reason = revocation.Reason(0)
+	} else {
+		reason = revocation.Reason(*req.Reason)
+	}
 	revokedDate := time.Unix(0, *req.Date)
 	res, err := ssa.dbMap.Exec(
 		`UPDATE certificateStatus SET
@@ -1549,7 +1555,7 @@ func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb
 				ocspResponse = ?
 			WHERE serial = ? AND status != ?`,
 		string(core.OCSPStatusRevoked),
-		revocation.Reason(*req.Reason),
+		reason,
 		revokedDate,
 		revokedDate,
 		req.Response,


### PR DESCRIPTION
As part of the migration to proto3, any fields in requests that may be
zero should also be allowed to be nil. That's because proto3 will
represent those fields as absent when they have their zero value.

This is based on a manual review of the wrappers for the SA, plus
a pair of integration test runs. For the integration test runs I took these
steps:

1. Copy sa/proto to sa/proto2
2. Change sa/proto to use proto3 and regenerate.
3. In sa/*.go and cmd/boulder-sa/main.go, update the imports to use the
    proto2 version.
4. Split grpc/sa-wrappers.go into sa-server-wrappers.go and sa-wrappers.go
    (containing the client code)
5. In sa-server-wrappers.go, change the import to use sa/proto2.
6. In sa-server-wrappers.go, make a local copy of the core.StorageAuthority
    interface that uses the sa/proto2 types. This was necessary as
    a temporary kludge because of how the server wrapper internally
    uses the core.StorageAuthority interface.
7. Fix all the pointer-vs-value build errors in every other package.
8. Run integration tests.

I also performed those steps with proto2 and proto3 swapped, to confirm the
behavior when a proto2 client talks to a proto3 SA.

Part of #5037