### PR TITLE
Disable new signer in config-next

### DIFF
--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -37,43 +37,106 @@
       "CertFile": "/tmp/intermediate-cert-rsa-b.pem",
       "NumSessions": 2
     }],
-    "SignerProfile": {
-      "allowRSAKeys": true,
-      "allowECDSAKeys": true,
-      "allowMustStaple": true,
-      "allowCTPoison": true,
-      "allowSCTList": true,
-      "allowCommonName": true,
-      "issuerURL": "http://127.0.0.1:4000/acme/issuer-cert",
-      "ocspURL": "http://127.0.0.1:4002/",
-      "crlURL": "http://example.com/crl",
-      "policies": [
-        {
-          "oid": "2.23.140.1.2.1"
-        },
-        {
-          "oid": "1.2.3.4",
-          "qualifiers": [
-            {
-              "type": "id-qt-cps",
-              "value": "http://example.com/cps"
-            }
-          ]
-        }
-      ],
-      "maxValidityPeriod": "2160h",
-      "maxValidityBackdate": "1h5m"
-    },
     "expiry": "2160h",
     "backdate": "1h",
     "lifespanOCSP": "96h",
     "maxNames": 100,
     "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "ignoredLints": ["n_subject_common_name_included"],
+    "cfssl": {
+      "signing": {
+        "profiles": {
+          "rsaEE": {
+            "usages": [
+              "digital signature",
+              "key encipherment",
+              "server auth",
+              "client auth"
+            ],
+            "backdate": "1h",
+            "ca_constraint": { "is_ca": false },
+            "issuer_urls": [
+              "http://boulder:4430/acme/issuer-cert"
+            ],
+            "ocsp_url": "http://127.0.0.1:4002/",
+            "crl_url": "http://example.com/crl",
+            "policies": [
+              {
+                "ID": "2.23.140.1.2.1"
+              },
+              {
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                } ]
+              }
+            ],
+            "expiry": "2160h",
+            "CSRWhitelist": {
+              "PublicKeyAlgorithm": true,
+              "PublicKey": true,
+              "SignatureAlgorithm": true
+            },
+            "ClientProvidesSerialNumbers": true,
+            "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
+            "lint_error_level": "pass",
+            "ignored_lints": [
+              "n_subject_common_name_included"
+            ]
+          },
+          "ecdsaEE": {
+            "usages": [
+              "digital signature",
+              "server auth",
+              "client auth"
+            ],
+            "backdate": "1h",
+            "is_ca": false,
+            "issuer_urls": [
+              "http://127.0.0.1:4000/acme/issuer-cert"
+            ],
+            "ocsp_url": "http://127.0.0.1:4002/",
+            "crl_url": "http://example.com/crl",
+            "policies": [
+              {
+                "ID": "2.23.140.1.2.1"
+              },
+              {
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                }, {
+                  "type": "id-qt-unotice",
+                  "value": "Do What Thou Wilt"
+                } ]
+              }
+            ],
+            "expiry": "2160h",
+            "CSRWhitelist": {
+              "PublicKeyAlgorithm": true,
+              "PublicKey": true,
+              "SignatureAlgorithm": true
+            },
+            "ClientProvidesSerialNumbers": true,
+            "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
+            "lint_error_level": "pass",
+            "ignored_lints": [
+              "n_subject_common_name_included"
+            ]
+          }
+        },
+        "default": {
+          "usages": [
+            "digital signature"
+          ],
+          "expiry": "8760h"
+        }
+      }
+    },
     "orphanQueueDir": "/tmp/orphaned-certificates-a",
     "features": {
-      "StoreIssuerInfo": true,
-      "NonCFSSLSigner": true
+      "StoreIssuerInfo": true
     }
   },
 

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -37,43 +37,106 @@
       "CertFile": "/tmp/intermediate-cert-rsa-b.pem",
       "NumSessions": 2
     }],
-    "SignerProfile": {
-      "allowRSAKeys": true,
-      "allowECDSAKeys": true,
-      "allowMustStaple": true,
-      "allowCTPoison": true,
-      "allowSCTList": true,
-      "allowCommonName": true,
-      "issuerURL": "http://127.0.0.1:4000/acme/issuer-cert",
-      "ocspURL": "http://127.0.0.1:4002/",
-      "crlURL": "http://example.com/crl",
-      "policies": [
-        {
-          "oid": "2.23.140.1.2.1"
-        },
-        {
-          "oid": "1.2.3.4",
-          "qualifiers": [
-            {
-              "type": "id-qt-cps",
-              "value": "http://example.com/cps"
-            }
-          ]
-        }
-      ],
-      "maxValidityPeriod": "2160h",
-      "maxValidityBackdate": "1h5m"
-    },
     "expiry": "2160h",
     "backdate": "1h",
     "lifespanOCSP": "96h",
     "maxNames": 100,
     "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "ignoredLints": ["n_subject_common_name_included"],
+    "cfssl": {
+      "signing": {
+        "profiles": {
+          "rsaEE": {
+            "usages": [
+              "digital signature",
+              "key encipherment",
+              "server auth",
+              "client auth"
+            ],
+            "backdate": "1h",
+            "ca_constraint": { "is_ca": false },
+            "issuer_urls": [
+              "http://boulder:4430/acme/issuer-cert"
+            ],
+            "ocsp_url": "http://127.0.0.1:4002/",
+            "crl_url": "http://example.com/crl",
+            "policies": [
+              {
+                "ID": "2.23.140.1.2.1"
+              },
+              {
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                } ]
+              }
+            ],
+            "expiry": "2160h",
+            "CSRWhitelist": {
+              "PublicKeyAlgorithm": true,
+              "PublicKey": true,
+              "SignatureAlgorithm": true
+            },
+            "ClientProvidesSerialNumbers": true,
+            "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
+            "lint_error_level": "pass",
+            "ignored_lints": [
+              "n_subject_common_name_included"
+            ]
+          },
+          "ecdsaEE": {
+            "usages": [
+              "digital signature",
+              "server auth",
+              "client auth"
+            ],
+            "backdate": "1h",
+            "is_ca": false,
+            "issuer_urls": [
+              "http://127.0.0.1:4000/acme/issuer-cert"
+            ],
+            "ocsp_url": "http://127.0.0.1:4002/",
+            "crl_url": "http://example.com/crl",
+            "policies": [
+              {
+                "ID": "2.23.140.1.2.1"
+              },
+              {
+                "ID": "1.2.3.4",
+                "Qualifiers": [ {
+                  "type": "id-qt-cps",
+                  "value": "http://example.com/cps"
+                }, {
+                  "type": "id-qt-unotice",
+                  "value": "Do What Thou Wilt"
+                } ]
+              }
+            ],
+            "expiry": "2160h",
+            "CSRWhitelist": {
+              "PublicKeyAlgorithm": true,
+              "PublicKey": true,
+              "SignatureAlgorithm": true
+            },
+            "ClientProvidesSerialNumbers": true,
+            "allowed_extensions": [ "1.3.6.1.5.5.7.1.24" ],
+            "lint_error_level": "pass",
+            "ignored_lints": [
+              "n_subject_common_name_included"
+            ]
+          }
+        },
+        "default": {
+          "usages": [
+            "digital signature"
+          ],
+          "expiry": "8760h"
+        }
+      }
+    },
     "orphanQueueDir": "/tmp/orphaned-certificates-b",
     "features": {
-      "StoreIssuerInfo": true,
-      "NonCFSSLSigner": true
+      "StoreIssuerInfo": true
     }
   },
 


### PR DESCRIPTION
This appears to be causing timeouts when communicating with the ca
in the integration tests. Disabling the config so that we can
ensure everything is working for this week's release.

This is a partial (config-only) revert of #5007