### PR TITLE
RA: Remove nil checks for zero-able fields

### DIFF
--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -323,14 +323,13 @@ func PBToAuthz(pb *corepb.Authorization) (core.Authorization, error) {
 }
 
 func registrationValid(reg *corepb.Registration) bool {
-	return !(reg.Id == nil || reg.Key == nil || reg.Agreement == nil || reg.InitialIP == nil || reg.CreatedAt == nil || reg.Status == nil || reg.ContactsPresent == nil)
+	return !(reg.Id == nil || reg.Key == nil || reg.InitialIP == nil || reg.CreatedAt == nil)
 }
 
 // orderValid checks that a corepb.Order is valid. In addition to the checks
-// from `newOrderValid` it ensures the order ID, the BeganProcessing fields
-// and the Created field are not nil.
+// from `newOrderValid` it ensures the order ID and the Created field are not nil.
 func orderValid(order *corepb.Order) bool {
-	return order.Id != nil && order.BeganProcessing != nil && order.Created != nil && newOrderValid(order)
+	return order.Id != nil && order.Created != nil && newOrderValid(order)
 }
 
 // newOrderValid checks that a corepb.Order is valid. It allows for a nil

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -272,11 +272,17 @@ func (ras *RegistrationAuthorityServerWrapper) RevokeCertificateWithReg(ctx cont
 	if request == nil || request.Cert == nil || request.RegID == nil {
 		return nil, errIncompleteRequest
 	}
+	var code revocation.Reason
+	if request.Code == nil {
+		code = revocation.Reason(0)
+	} else {
+		code = revocation.Reason(*request.Code)
+	}
 	cert, err := x509.ParseCertificate(request.Cert)
 	if err != nil {
 		return nil, err
 	}
-	err = ras.inner.RevokeCertificateWithReg(ctx, *cert, revocation.Reason(*request.Code), *request.RegID)
+	err = ras.inner.RevokeCertificateWithReg(ctx, *cert, code, *request.RegID)
 	if err != nil {
 		return nil, err
 	}
@@ -317,11 +323,17 @@ func (ras *RegistrationAuthorityServerWrapper) AdministrativelyRevokeCertificate
 	if request == nil || request.Cert == nil || request.AdminName == nil {
 		return nil, errIncompleteRequest
 	}
+	var code revocation.Reason
+	if request.Code == nil {
+		code = revocation.Reason(0)
+	} else {
+		code = revocation.Reason(*request.Code)
+	}
 	cert, err := x509.ParseCertificate(request.Cert)
 	if err != nil {
 		return nil, err
 	}
-	err = ras.inner.AdministrativelyRevokeCertificate(ctx, *cert, revocation.Reason(*request.Code), *request.AdminName)
+	err = ras.inner.AdministrativelyRevokeCertificate(ctx, *cert, code, *request.AdminName)
 	if err != nil {
 		return nil, err
 	}

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -262,14 +262,14 @@ func (ras *RegistrationAuthorityServerWrapper) UpdateRegistration(ctx context.Co
 func (ras *RegistrationAuthorityServerWrapper) PerformValidation(
 	ctx context.Context,
 	request *rapb.PerformValidationRequest) (*corepb.Authorization, error) {
-	if request == nil || !authorizationValid(request.Authz) || request.ChallengeIndex == nil {
+	if request == nil || !authorizationValid(request.Authz) {
 		return nil, errIncompleteRequest
 	}
 	return ras.inner.PerformValidation(ctx, request)
 }
 
 func (ras *RegistrationAuthorityServerWrapper) RevokeCertificateWithReg(ctx context.Context, request *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
-	if request == nil || request.Cert == nil || request.Code == nil || request.RegID == nil {
+	if request == nil || request.Cert == nil || request.RegID == nil {
 		return nil, errIncompleteRequest
 	}
 	cert, err := x509.ParseCertificate(request.Cert)
@@ -314,7 +314,7 @@ func (ras *RegistrationAuthorityServerWrapper) DeactivateAuthorization(ctx conte
 }
 
 func (ras *RegistrationAuthorityServerWrapper) AdministrativelyRevokeCertificate(ctx context.Context, request *rapb.AdministrativelyRevokeCertificateRequest) (*corepb.Empty, error) {
-	if request == nil || request.Cert == nil || request.Code == nil || request.AdminName == nil {
+	if request == nil || request.Cert == nil || request.AdminName == nil {
 		return nil, errIncompleteRequest
 	}
 	cert, err := x509.ParseCertificate(request.Cert)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1550,7 +1550,12 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 	}
 
 	authz := base
-	challIndex := int(*req.ChallengeIndex)
+	var challIndex int
+	if req.ChallengeIndex == nil {
+		challIndex = 0
+	} else {
+		challIndex = int(*req.ChallengeIndex)
+	}
 	if challIndex >= len(authz.Challenges) {
 		return nil,
 			berrors.MalformedError("invalid challenge index '%d'", challIndex)


### PR DESCRIPTION
Any field which can be zero must be allowed to be nil,
so that a proto2 server receiving requests from a proto3
client is willing to process messages with zero-value fields
encoded as missing.

Part of #4955