### PR TITLE
RA: Update RPC interface to proto3 

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -213,9 +213,6 @@ func (bkr *badKeyRevoker) sendMessage(addr string, serials []string) error {
 	return nil
 }
 
-var keyCompromiseCode = int64(ocsp.KeyCompromise)
-var revokerName = "bad-key-revoker"
-
 // revokeCerts revokes all the certificates associated with a particular key hash and sends
 // emails to the users that issued the certificates. Emails are not sent to the user which
 // requested revocation of the original certificate which marked the key as compromised.
@@ -235,8 +232,8 @@ func (bkr *badKeyRevoker) revokeCerts(revokerEmails []string, emailToCerts map[s
 			}
 			_, err := bkr.raClient.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
 				Cert:      cert.DER,
-				Code:      &keyCompromiseCode,
-				AdminName: &revokerName,
+				Code:      int64(ocsp.KeyCompromise),
+				AdminName: "bad-key-revoker",
 			})
 			if err != nil {
 				return err

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -50,7 +50,7 @@ func (rac RegistrationAuthorityClientWrapper) NewAuthorization(ctx context.Conte
 		return core.Authorization{}, err
 	}
 
-	response, err := rac.inner.NewAuthorization(ctx, &rapb.NewAuthorizationRequest{Authz: req, RegID: &regID})
+	response, err := rac.inner.NewAuthorization(ctx, &rapb.NewAuthorizationRequest{Authz: req, RegID: regID})
 	if err != nil {
 		return core.Authorization{}, err
 	}
@@ -63,7 +63,7 @@ func (rac RegistrationAuthorityClientWrapper) NewAuthorization(ctx context.Conte
 }
 
 func (rac RegistrationAuthorityClientWrapper) NewCertificate(ctx context.Context, csr core.CertificateRequest, regID int64) (core.Certificate, error) {
-	response, err := rac.inner.NewCertificate(ctx, &rapb.NewCertificateRequest{Csr: csr.Bytes, RegID: &regID})
+	response, err := rac.inner.NewCertificate(ctx, &rapb.NewCertificateRequest{Csr: csr.Bytes, RegID: regID})
 	if err != nil {
 		return core.Certificate{}, err
 	}
@@ -109,11 +109,10 @@ func (rac RegistrationAuthorityClientWrapper) PerformValidation(
 }
 
 func (rac RegistrationAuthorityClientWrapper) RevokeCertificateWithReg(ctx context.Context, cert x509.Certificate, code revocation.Reason, regID int64) error {
-	reason := int64(code)
 	_, err := rac.inner.RevokeCertificateWithReg(ctx, &rapb.RevokeCertificateWithRegRequest{
 		Cert:  cert.Raw,
-		Code:  &reason,
-		RegID: &regID,
+		Code:  int64(code),
+		RegID: regID,
 	})
 	if err != nil {
 		return err
@@ -151,11 +150,10 @@ func (rac RegistrationAuthorityClientWrapper) DeactivateAuthorization(ctx contex
 }
 
 func (rac RegistrationAuthorityClientWrapper) AdministrativelyRevokeCertificate(ctx context.Context, cert x509.Certificate, code revocation.Reason, adminName string) error {
-	reason := int64(code)
 	_, err := rac.inner.AdministrativelyRevokeCertificate(ctx, &rapb.AdministrativelyRevokeCertificateRequest{
 		Cert:      cert.Raw,
-		Code:      &reason,
-		AdminName: &adminName,
+		Code:      int64(code),
+		AdminName: adminName,
 	})
 	if err != nil {
 		return err
@@ -211,14 +209,14 @@ func (ras *RegistrationAuthorityServerWrapper) NewRegistration(ctx context.Conte
 }
 
 func (ras *RegistrationAuthorityServerWrapper) NewAuthorization(ctx context.Context, request *rapb.NewAuthorizationRequest) (*corepb.Authorization, error) {
-	if request == nil || !authorizationValid(request.Authz) || request.RegID == nil {
+	if request == nil || !authorizationValid(request.Authz) || request.RegID == 0 {
 		return nil, errIncompleteRequest
 	}
 	authz, err := PBToAuthz(request.Authz)
 	if err != nil {
 		return nil, err
 	}
-	newAuthz, err := ras.inner.NewAuthorization(ctx, authz, *request.RegID)
+	newAuthz, err := ras.inner.NewAuthorization(ctx, authz, request.RegID)
 	if err != nil {
 		return nil, err
 	}
@@ -226,14 +224,14 @@ func (ras *RegistrationAuthorityServerWrapper) NewAuthorization(ctx context.Cont
 }
 
 func (ras *RegistrationAuthorityServerWrapper) NewCertificate(ctx context.Context, request *rapb.NewCertificateRequest) (*corepb.Certificate, error) {
-	if request == nil || request.Csr == nil || request.RegID == nil {
+	if request == nil || request.Csr == nil || request.RegID == 0 {
 		return nil, errIncompleteRequest
 	}
 	csr, err := x509.ParseCertificateRequest(request.Csr)
 	if err != nil {
 		return nil, err
 	}
-	cert, err := ras.inner.NewCertificate(ctx, core.CertificateRequest{CSR: csr, Bytes: request.Csr}, *request.RegID)
+	cert, err := ras.inner.NewCertificate(ctx, core.CertificateRequest{CSR: csr, Bytes: request.Csr}, request.RegID)
 	if err != nil {
 		return nil, err
 	}
@@ -269,20 +267,14 @@ func (ras *RegistrationAuthorityServerWrapper) PerformValidation(
 }
 
 func (ras *RegistrationAuthorityServerWrapper) RevokeCertificateWithReg(ctx context.Context, request *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
-	if request == nil || request.Cert == nil || request.RegID == nil {
+	if request == nil || request.Cert == nil || request.RegID == 0 {
 		return nil, errIncompleteRequest
-	}
-	var code revocation.Reason
-	if request.Code == nil {
-		code = revocation.Reason(0)
-	} else {
-		code = revocation.Reason(*request.Code)
 	}
 	cert, err := x509.ParseCertificate(request.Cert)
 	if err != nil {
 		return nil, err
 	}
-	err = ras.inner.RevokeCertificateWithReg(ctx, *cert, code, *request.RegID)
+	err = ras.inner.RevokeCertificateWithReg(ctx, *cert, revocation.Reason(request.Code), request.RegID)
 	if err != nil {
 		return nil, err
 	}
@@ -320,20 +312,14 @@ func (ras *RegistrationAuthorityServerWrapper) DeactivateAuthorization(ctx conte
 }
 
 func (ras *RegistrationAuthorityServerWrapper) AdministrativelyRevokeCertificate(ctx context.Context, request *rapb.AdministrativelyRevokeCertificateRequest) (*corepb.Empty, error) {
-	if request == nil || request.Cert == nil || request.AdminName == nil {
+	if request == nil || request.Cert == nil || request.AdminName == "" {
 		return nil, errIncompleteRequest
-	}
-	var code revocation.Reason
-	if request.Code == nil {
-		code = revocation.Reason(0)
-	} else {
-		code = revocation.Reason(*request.Code)
 	}
 	cert, err := x509.ParseCertificate(request.Cert)
 	if err != nil {
 		return nil, err
 	}
-	err = ras.inner.AdministrativelyRevokeCertificate(ctx, *cert, code, *request.AdminName)
+	err = ras.inner.AdministrativelyRevokeCertificate(ctx, *cert, revocation.Reason(request.Code), request.AdminName)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +327,7 @@ func (ras *RegistrationAuthorityServerWrapper) AdministrativelyRevokeCertificate
 }
 
 func (ras *RegistrationAuthorityServerWrapper) NewOrder(ctx context.Context, request *rapb.NewOrderRequest) (*corepb.Order, error) {
-	if request == nil || request.RegistrationID == nil {
+	if request == nil || request.RegistrationID == 0 {
 		return nil, errIncompleteRequest
 	}
 	return ras.inner.NewOrder(ctx, request)

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -267,7 +267,7 @@ func (ras *RegistrationAuthorityServerWrapper) PerformValidation(
 }
 
 func (ras *RegistrationAuthorityServerWrapper) RevokeCertificateWithReg(ctx context.Context, request *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
-	if request == nil || request.Cert == nil || request.RegID == 0 {
+	if request == nil || request.Cert == nil {
 		return nil, errIncompleteRequest
 	}
 	cert, err := x509.ParseCertificate(request.Cert)

--- a/ra/proto/ra.pb.go
+++ b/ra/proto/ra.pb.go
@@ -35,8 +35,8 @@ type NewAuthorizationRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Authz *proto1.Authorization `protobuf:"bytes,1,opt,name=authz" json:"authz,omitempty"`
-	RegID *int64                `protobuf:"varint,2,opt,name=regID" json:"regID,omitempty"`
+	Authz *proto1.Authorization `protobuf:"bytes,1,opt,name=authz,proto3" json:"authz,omitempty"`
+	RegID int64                 `protobuf:"varint,2,opt,name=regID,proto3" json:"regID,omitempty"`
 }
 
 func (x *NewAuthorizationRequest) Reset() {
@@ -79,8 +79,8 @@ func (x *NewAuthorizationRequest) GetAuthz() *proto1.Authorization {
 }
 
 func (x *NewAuthorizationRequest) GetRegID() int64 {
-	if x != nil && x.RegID != nil {
-		return *x.RegID
+	if x != nil {
+		return x.RegID
 	}
 	return 0
 }
@@ -90,8 +90,8 @@ type NewCertificateRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Csr   []byte `protobuf:"bytes,1,opt,name=csr" json:"csr,omitempty"`
-	RegID *int64 `protobuf:"varint,2,opt,name=regID" json:"regID,omitempty"`
+	Csr   []byte `protobuf:"bytes,1,opt,name=csr,proto3" json:"csr,omitempty"`
+	RegID int64  `protobuf:"varint,2,opt,name=regID,proto3" json:"regID,omitempty"`
 }
 
 func (x *NewCertificateRequest) Reset() {
@@ -134,8 +134,8 @@ func (x *NewCertificateRequest) GetCsr() []byte {
 }
 
 func (x *NewCertificateRequest) GetRegID() int64 {
-	if x != nil && x.RegID != nil {
-		return *x.RegID
+	if x != nil {
+		return x.RegID
 	}
 	return 0
 }
@@ -145,8 +145,8 @@ type UpdateRegistrationRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Base   *proto1.Registration `protobuf:"bytes,1,opt,name=base" json:"base,omitempty"`
-	Update *proto1.Registration `protobuf:"bytes,2,opt,name=update" json:"update,omitempty"`
+	Base   *proto1.Registration `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
+	Update *proto1.Registration `protobuf:"bytes,2,opt,name=update,proto3" json:"update,omitempty"`
 }
 
 func (x *UpdateRegistrationRequest) Reset() {
@@ -200,9 +200,9 @@ type UpdateAuthorizationRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Authz          *proto1.Authorization `protobuf:"bytes,1,opt,name=authz" json:"authz,omitempty"`
-	ChallengeIndex *int64                `protobuf:"varint,2,opt,name=challengeIndex" json:"challengeIndex,omitempty"`
-	Response       *proto1.Challenge     `protobuf:"bytes,3,opt,name=response" json:"response,omitempty"`
+	Authz          *proto1.Authorization `protobuf:"bytes,1,opt,name=authz,proto3" json:"authz,omitempty"`
+	ChallengeIndex int64                 `protobuf:"varint,2,opt,name=challengeIndex,proto3" json:"challengeIndex,omitempty"`
+	Response       *proto1.Challenge     `protobuf:"bytes,3,opt,name=response,proto3" json:"response,omitempty"`
 }
 
 func (x *UpdateAuthorizationRequest) Reset() {
@@ -245,8 +245,8 @@ func (x *UpdateAuthorizationRequest) GetAuthz() *proto1.Authorization {
 }
 
 func (x *UpdateAuthorizationRequest) GetChallengeIndex() int64 {
-	if x != nil && x.ChallengeIndex != nil {
-		return *x.ChallengeIndex
+	if x != nil {
+		return x.ChallengeIndex
 	}
 	return 0
 }
@@ -263,8 +263,8 @@ type PerformValidationRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Authz          *proto1.Authorization `protobuf:"bytes,1,opt,name=authz" json:"authz,omitempty"`
-	ChallengeIndex *int64                `protobuf:"varint,2,opt,name=challengeIndex" json:"challengeIndex,omitempty"`
+	Authz          *proto1.Authorization `protobuf:"bytes,1,opt,name=authz,proto3" json:"authz,omitempty"`
+	ChallengeIndex int64                 `protobuf:"varint,2,opt,name=challengeIndex,proto3" json:"challengeIndex,omitempty"`
 }
 
 func (x *PerformValidationRequest) Reset() {
@@ -307,8 +307,8 @@ func (x *PerformValidationRequest) GetAuthz() *proto1.Authorization {
 }
 
 func (x *PerformValidationRequest) GetChallengeIndex() int64 {
-	if x != nil && x.ChallengeIndex != nil {
-		return *x.ChallengeIndex
+	if x != nil {
+		return x.ChallengeIndex
 	}
 	return 0
 }
@@ -318,9 +318,9 @@ type RevokeCertificateWithRegRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Cert  []byte `protobuf:"bytes,1,opt,name=cert" json:"cert,omitempty"`
-	Code  *int64 `protobuf:"varint,2,opt,name=code" json:"code,omitempty"`
-	RegID *int64 `protobuf:"varint,3,opt,name=regID" json:"regID,omitempty"`
+	Cert  []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	Code  int64  `protobuf:"varint,2,opt,name=code,proto3" json:"code,omitempty"`
+	RegID int64  `protobuf:"varint,3,opt,name=regID,proto3" json:"regID,omitempty"`
 }
 
 func (x *RevokeCertificateWithRegRequest) Reset() {
@@ -363,15 +363,15 @@ func (x *RevokeCertificateWithRegRequest) GetCert() []byte {
 }
 
 func (x *RevokeCertificateWithRegRequest) GetCode() int64 {
-	if x != nil && x.Code != nil {
-		return *x.Code
+	if x != nil {
+		return x.Code
 	}
 	return 0
 }
 
 func (x *RevokeCertificateWithRegRequest) GetRegID() int64 {
-	if x != nil && x.RegID != nil {
-		return *x.RegID
+	if x != nil {
+		return x.RegID
 	}
 	return 0
 }
@@ -381,9 +381,9 @@ type AdministrativelyRevokeCertificateRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Cert      []byte  `protobuf:"bytes,1,opt,name=cert" json:"cert,omitempty"`
-	Code      *int64  `protobuf:"varint,2,opt,name=code" json:"code,omitempty"`
-	AdminName *string `protobuf:"bytes,3,opt,name=adminName" json:"adminName,omitempty"`
+	Cert      []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	Code      int64  `protobuf:"varint,2,opt,name=code,proto3" json:"code,omitempty"`
+	AdminName string `protobuf:"bytes,3,opt,name=adminName,proto3" json:"adminName,omitempty"`
 }
 
 func (x *AdministrativelyRevokeCertificateRequest) Reset() {
@@ -426,15 +426,15 @@ func (x *AdministrativelyRevokeCertificateRequest) GetCert() []byte {
 }
 
 func (x *AdministrativelyRevokeCertificateRequest) GetCode() int64 {
-	if x != nil && x.Code != nil {
-		return *x.Code
+	if x != nil {
+		return x.Code
 	}
 	return 0
 }
 
 func (x *AdministrativelyRevokeCertificateRequest) GetAdminName() string {
-	if x != nil && x.AdminName != nil {
-		return *x.AdminName
+	if x != nil {
+		return x.AdminName
 	}
 	return ""
 }
@@ -444,8 +444,8 @@ type NewOrderRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	RegistrationID *int64   `protobuf:"varint,1,opt,name=registrationID" json:"registrationID,omitempty"`
-	Names          []string `protobuf:"bytes,2,rep,name=names" json:"names,omitempty"`
+	RegistrationID int64    `protobuf:"varint,1,opt,name=registrationID,proto3" json:"registrationID,omitempty"`
+	Names          []string `protobuf:"bytes,2,rep,name=names,proto3" json:"names,omitempty"`
 }
 
 func (x *NewOrderRequest) Reset() {
@@ -481,8 +481,8 @@ func (*NewOrderRequest) Descriptor() ([]byte, []int) {
 }
 
 func (x *NewOrderRequest) GetRegistrationID() int64 {
-	if x != nil && x.RegistrationID != nil {
-		return *x.RegistrationID
+	if x != nil {
+		return x.RegistrationID
 	}
 	return 0
 }
@@ -499,8 +499,8 @@ type FinalizeOrderRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Order *proto1.Order `protobuf:"bytes,1,opt,name=order" json:"order,omitempty"`
-	Csr   []byte        `protobuf:"bytes,2,opt,name=csr" json:"csr,omitempty"`
+	Order *proto1.Order `protobuf:"bytes,1,opt,name=order,proto3" json:"order,omitempty"`
+	Csr   []byte        `protobuf:"bytes,2,opt,name=csr,proto3" json:"csr,omitempty"`
 }
 
 func (x *FinalizeOrderRequest) Reset() {
@@ -663,7 +663,7 @@ var file_ra_proto_ra_proto_rawDesc = []byte{
 	0x65, 0x2e, 0x4f, 0x72, 0x64, 0x65, 0x72, 0x22, 0x00, 0x42, 0x29, 0x5a, 0x27, 0x67, 0x69, 0x74,
 	0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6c, 0x65, 0x74, 0x73, 0x65, 0x6e, 0x63, 0x72,
 	0x79, 0x70, 0x74, 0x2f, 0x62, 0x6f, 0x75, 0x6c, 0x64, 0x65, 0x72, 0x2f, 0x72, 0x61, 0x2f, 0x70,
-	0x72, 0x6f, 0x74, 0x6f,
+	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (

--- a/ra/proto/ra.proto
+++ b/ra/proto/ra.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package ra;
 option go_package = "github.com/letsencrypt/boulder/ra/proto";
@@ -20,49 +20,49 @@ service RegistrationAuthority {
 }
 
 message NewAuthorizationRequest {
-  optional core.Authorization authz = 1;
-  optional int64 regID = 2;
+  core.Authorization authz = 1;
+  int64 regID = 2;
 }
 
 message NewCertificateRequest {
-  optional bytes csr = 1;
-  optional int64 regID = 2;
+  bytes csr = 1;
+  int64 regID = 2;
 }
 
 message UpdateRegistrationRequest {
-  optional core.Registration base = 1;
-  optional core.Registration update = 2;
+  core.Registration base = 1;
+  core.Registration update = 2;
 }
 
 message UpdateAuthorizationRequest {
-  optional core.Authorization authz = 1;
-  optional int64 challengeIndex = 2;
-  optional core.Challenge response = 3;
+  core.Authorization authz = 1;
+  int64 challengeIndex = 2;
+  core.Challenge response = 3;
 }
 
 message PerformValidationRequest {
-  optional core.Authorization authz = 1;
-  optional int64 challengeIndex = 2;
+  core.Authorization authz = 1;
+  int64 challengeIndex = 2;
 }
 
 message RevokeCertificateWithRegRequest {
-  optional bytes cert = 1;
-  optional int64 code = 2;
-  optional int64 regID = 3;
+  bytes cert = 1;
+  int64 code = 2;
+  int64 regID = 3;
 }
 
 message AdministrativelyRevokeCertificateRequest {
-  optional bytes cert = 1;
-  optional int64 code = 2;
-  optional string adminName = 3;
+  bytes cert = 1;
+  int64 code = 2;
+  string adminName = 3;
 }
 
 message NewOrderRequest {
-  optional int64 registrationID = 1;
+  int64 registrationID = 1;
   repeated string names = 2;
 }
 
 message FinalizeOrderRequest {
-  optional core.Order order = 1;
-  optional bytes csr = 2;
+  core.Order order = 1;
+  bytes csr = 2;
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1557,12 +1557,7 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 	}
 
 	authz := base
-	var challIndex int
-	if req.ChallengeIndex == nil {
-		challIndex = 0
-	} else {
-		challIndex = int(*req.ChallengeIndex)
-	}
+	challIndex := int(req.ChallengeIndex)
 	if challIndex >= len(authz.Challenges) {
 		return nil,
 			berrors.MalformedError("invalid challenge index '%d'", challIndex)
@@ -1857,7 +1852,7 @@ func (ra *RegistrationAuthorityImpl) checkOrderNames(names []string) error {
 // NewOrder creates a new order object
 func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.NewOrderRequest) (*corepb.Order, error) {
 	order := &corepb.Order{
-		RegistrationID: req.RegistrationID,
+		RegistrationID: &req.RegistrationID,
 		Names:          core.UniqueLowerNames(req.Names),
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1757,7 +1757,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertificateWithReg(ctx context.Contex
 		//   CN
 		//   DNS names
 		//   Revocation reason
-		//   Registration ID of requester
+		//   Registration ID of requester; may be 0 if request is signed with cert key
 		//   Error (if there was one)
 		ra.log.AuditInfof("%s, Request by registration ID: %d",
 			revokeEvent(state, serialString, cert.Subject.CommonName, cert.DNSNames, revocationCode),

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1198,11 +1198,10 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to serialize authz"), err)
 			return
 		}
-		challIndex := int64(challengeIndex)
 
 		authzPB, err = wfe.RA.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
-			ChallengeIndex: &challIndex})
+			ChallengeIndex: int64(challengeIndex)})
 		if err != nil {
 			wfe.sendError(
 				response,

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1243,11 +1243,10 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to serialize authz"), err)
 			return
 		}
-		challIndex := int64(challengeIndex)
 
 		authzPB, err = wfe.RA.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
-			ChallengeIndex: &challIndex,
+			ChallengeIndex: int64(challengeIndex),
 		})
 		if err != nil {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
@@ -1977,7 +1976,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	}
 
 	order, err := wfe.RA.NewOrder(ctx, &rapb.NewOrderRequest{
-		RegistrationID: &acct.ID,
+		RegistrationID: acct.ID,
 		Names:          names,
 	})
 	if err != nil {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -259,7 +259,7 @@ func (ra *MockRegistrationAuthority) NewOrder(ctx context.Context, req *rapb.New
 	status := string(core.StatusPending)
 	return &corepb.Order{
 		Id:               &one,
-		RegistrationID:   req.RegistrationID,
+		RegistrationID:   &req.RegistrationID,
 		Expires:          &zero,
 		Names:            req.Names,
 		Status:           &status,


### PR DESCRIPTION
Updates the Registration Authority to use proto3 for its
RPC methods. This turns out to be a fairly minimal change,
as many of the RA's request and response messages are
defined in core.proto, and are therefore still proto2.

Fixes #4955