### PR TITLE
cmd/caa-log-checker: -earliest and -latest

### DIFF
--- a/cmd/caa-log-checker/main_test.go
+++ b/cmd/caa-log-checker/main_test.go
@@ -130,21 +130,21 @@ random`,
 		testTime.Add(10*time.Hour).Format(time.RFC3339Nano),
 		// 6.example.com: Issue @ +1:00, CAA @ +1:01. (PASS, has CAA check within tolerance)
 		testTime.Add(time.Hour).Format(time.RFC3339Nano),
-		// 7.example.com: Issue @ +12:00 (PASS, no CAA check but issued after checkUntil)
+		// 7.example.com: Issue @ +12:00 (PASS, no CAA check but issued after latest)
 		testTime.Add(12*time.Hour).Format(time.RFC3339Nano),
-		// 8.example.com: Issue @ +11:00 (FAIL, no CAA check and on checkUntil boundary)
+		// 8.example.com: Issue @ +11:00 (FAIL, no CAA check and on latest boundary)
 		testTime.Add(11*time.Hour).Format(time.RFC3339Nano),
-		// 9.example.com: Issue @ -2:00 (PASS, no CAA check but issued before checkFrom)
+		// 9.example.com: Issue @ -2:00 (PASS, no CAA check but issued before earliest)
 		testTime.Add(-2*time.Hour).Format(time.RFC3339Nano),
-		// 10.example.com: Issue @ -1:00 (FAIL, no CAA check and issued at checkFrom boundary)
+		// 10.example.com: Issue @ -1:00 (FAIL, no CAA check and issued at earliest boundary)
 		testTime.Add(-1*time.Hour).Format(time.RFC3339Nano),
 	)
 
 	for _, testCase := range []struct {
 		name           string
 		expectedErrors string
-		checkFrom      time.Time
-		checkUntil     time.Time
+		earliest       time.Time
+		latest         time.Time
 	}{
 		{
 			"with-timespan",
@@ -176,7 +176,7 @@ random`,
 			defer os.Remove(stderr.Name())
 
 			timeTolerance := 10 * time.Minute
-			err = checkIssuances(raScanner, checkedMap, timeTolerance, testCase.checkFrom, testCase.checkUntil, stderr)
+			err = checkIssuances(raScanner, checkedMap, timeTolerance, testCase.earliest, testCase.latest, stderr)
 			test.AssertNotError(t, err, "checkIssuances failed")
 
 			stderrCont, err := ioutil.ReadFile(stderr.Name())

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -26,7 +26,7 @@ func TestCAALogChecker(t *testing.T) {
 	test.AssertEquals(t, len(result.Order.Authorizations), 1)
 
 	// Should be no specific output, since everything is good
-	cmd := exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", "/var/log/boulder-va.log", "-check-from", "19010101", "-check-until", "30000101")
+	cmd := exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", "/var/log/boulder-va.log", "-earliest", "19010101", "-latest", "30000101")
 	var stdErr bytes.Buffer
 	cmd.Stderr = &stdErr
 	out, err := cmd.Output()

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -42,7 +42,7 @@ func TestCAALogChecker(t *testing.T) {
 	tmp, err := ioutil.TempFile(os.TempDir(), "boulder-va-empty")
 	test.AssertNotError(t, err, "failed to create temporary file")
 	defer os.Remove(tmp.Name())
-	cmd = exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", tmp.Name(), "-check-from", "19010101", "-check-until", "30000101")
+	cmd = exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", tmp.Name())
 	stdErr.Reset()
 	cmd.Stderr = &stdErr
 	out, err = cmd.Output()

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -26,7 +26,7 @@ func TestCAALogChecker(t *testing.T) {
 	test.AssertEquals(t, len(result.Order.Authorizations), 1)
 
 	// Should be no specific output, since everything is good
-	cmd := exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", "/var/log/boulder-va.log")
+	cmd := exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", "/var/log/boulder-va.log", "-check-from", "19010101", "-check-until", "30000101")
 	var stdErr bytes.Buffer
 	cmd.Stderr = &stdErr
 	out, err := cmd.Output()
@@ -42,7 +42,7 @@ func TestCAALogChecker(t *testing.T) {
 	tmp, err := ioutil.TempFile(os.TempDir(), "boulder-va-empty")
 	test.AssertNotError(t, err, "failed to create temporary file")
 	defer os.Remove(tmp.Name())
-	cmd = exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", tmp.Name())
+	cmd = exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", tmp.Name(), "-check-from", "19010101", "-check-until", "30000101")
 	stdErr.Reset()
 	cmd.Stderr = &stdErr
 	out, err = cmd.Output()


### PR DESCRIPTION
Since we now sync caaChecks logs daily instead of continuously,
caa-log-checker can no longer assume that the validation logs it is
checking cover the exact same span of time as the issuance logs. This
commit adds -earliest and -latest parameters so that the script
that drives this tool can restrict verification to a timespan where we
know the data is valid.

Also adds a -debug flag to caa-log-checker to enable debug logs. At the
moment this makes the tool write to stderr how many issuance messages
were evaluated and how many were skipped due to -earliest and
-latest parameters.