### PR TITLE
Add pre-issuance linting to ceremony tooling

### DIFF
--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -379,16 +379,18 @@ func signAndLintCert(tbs, issuer *x509.Certificate, subjectPubKey crypto.PublicK
 	var lintSigner crypto.Signer
 	var err error
 	switch k := realSigner.Public().(type) {
-	case rsa.PublicKey:
+	case *rsa.PublicKey:
 		lintSigner, err = rsa.GenerateKey(rand.Reader, k.Size()*8)
 		if err != nil {
 			return fmt.Errorf("failed to create fake RSA signer for linting: %w", err)
 		}
-	case ecdsa.PublicKey:
+	case *ecdsa.PublicKey:
 		lintSigner, err = ecdsa.GenerateKey(k.Curve, rand.Reader)
 		if err != nil {
 			return fmt.Errorf("failed to create fake ECDSA signer for linting: %w", err)
 		}
+	default:
+		return fmt.Errorf("can't handle real signer key of type: %T", k)
 	}
 	lintCertBytes, err := x509.CreateCertificate(rand.Reader, tbs, issuer, subjectPubKey, lintSigner)
 	if err != nil {

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -13,9 +16,13 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/letsencrypt/boulder/pkcs11helpers"
+	zlintx509 "github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v2"
+	"github.com/zmap/zlint/v2/lint"
 	"golang.org/x/crypto/ocsp"
 	"gopkg.in/yaml.v2"
 )
@@ -368,7 +375,47 @@ func openSigner(cfg PKCS11SigningConfig, issuer *x509.Certificate) (crypto.Signe
 	return signer, newRandReader(session), nil
 }
 
+func signAndLintCert(tbs, issuer *x509.Certificate, subjectPubKey crypto.PublicKey, realSigner crypto.Signer) error {
+	var lintSigner crypto.Signer
+	var err error
+	switch k := realSigner.Public().(type) {
+	case rsa.PublicKey:
+		lintSigner, err = rsa.GenerateKey(rand.Reader, k.Size()*8)
+		if err != nil {
+			return fmt.Errorf("failed to create fake RSA signer for linting: %w", err)
+		}
+	case ecdsa.PublicKey:
+		lintSigner, err = ecdsa.GenerateKey(k.Curve, rand.Reader)
+		if err != nil {
+			return fmt.Errorf("failed to create fake ECDSA signer for linting: %w", err)
+		}
+	}
+	lintCertBytes, err := x509.CreateCertificate(rand.Reader, tbs, issuer, subjectPubKey, lintSigner)
+	if err != nil {
+		return fmt.Errorf("failed to create fake certificate for linting: %w", err)
+	}
+	lintCert, err := zlintx509.ParseCertificate(lintCertBytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse fake certificate for linting: %w", err)
+	}
+	lintRes := zlint.LintCertificate(lintCert)
+	if lintRes.NoticesPresent || lintRes.WarningsPresent || lintRes.ErrorsPresent || lintRes.FatalsPresent {
+		var failedLints []string
+		for lintName, result := range lintRes.Results {
+			if result.Status > lint.Pass {
+				failedLints = append(failedLints, lintName)
+			}
+		}
+		return fmt.Errorf("failed lints: %s", strings.Join(failedLints, ", "))
+	}
+	return nil
+}
+
 func signAndWriteCert(tbs, issuer *x509.Certificate, subjectPubKey crypto.PublicKey, signer crypto.Signer, certPath string) error {
+	err := signAndLintCert(tbs, issuer, subjectPubKey, signer)
+	if err != nil {
+		return fmt.Errorf("certificate failed pre-issuance lint: %w", err)
+	}
 	// x509.CreateCertificate uses a io.Reader here for signing methods that require
 	// a source of randomness. Since PKCS#11 based signing generates needed randomness
 	// at the HSM we don't need to pass a real reader. Instead of passing a nil reader

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -236,6 +236,18 @@ func TestRootConfigValidate(t *testing.T) {
 					Organization:       "e",
 					Country:            "f",
 				},
+				SkipLints: []string{
+					"e_ext_authority_key_identifier_missing",
+					"e_ext_authority_key_identifier_no_key_identifier",
+					"e_sub_ca_aia_does_not_contain_ocsp_url",
+					"e_sub_ca_aia_missing",
+					"e_sub_ca_certificate_policies_missing",
+					"e_sub_ca_crl_distribution_points_missing",
+					"n_ca_digital_signature_not_set",
+					"n_mp_allowed_eku",
+					"n_sub_ca_eku_missing",
+					"w_sub_ca_aia_does_not_contain_issuing_ca_url",
+				},
 			},
 		},
 	}
@@ -366,6 +378,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 					CRLURL:             "h",
 					IssuerURL:          "i",
 				},
+				SkipLints: []string{},
 			},
 		},
 	}

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -1,0 +1,96 @@
+package lint
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	zlintx509 "github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v2"
+	"github.com/zmap/zlint/v2/lint"
+)
+
+// Check accomplishes the entire process of linting: it generates a throwaway
+// signing key, uses that to create a throwaway cert, and runs a default set
+// of lints (everything except for the ETSI and EV lints) against it. This is
+// the primary public interface of this package, but it can be inefficient;
+// creating a new signer and a new lint registry are expensive operations which
+// performance-sensitive clients may want to cache.
+func Check(tbs, issuer *x509.Certificate, subjectPubKey crypto.PublicKey, realSigner crypto.Signer, skipLints []string) error {
+	lintSigner, err := MakeSigner(realSigner)
+	if err != nil {
+		return err
+	}
+	lintCert, err := MakeLintCert(tbs, issuer, subjectPubKey, lintSigner)
+	if err != nil {
+		return err
+	}
+	lints, err := lint.GlobalRegistry().Filter(lint.FilterOptions{
+		ExcludeNames: skipLints,
+		ExcludeSources: []lint.LintSource{
+			lint.CABFEVGuidelines,
+			lint.EtsiEsi,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create lint registry: %w", err)
+	}
+	return LintCert(lintCert, lints)
+}
+
+// MakeSigner creates a throwaway crypto.Signer with the same key algorithm
+// as the given Signer. This is useful if you intend to lint many certs are
+// okay using the same throwaway key to sign all of them.
+func MakeSigner(realSigner crypto.Signer) (crypto.Signer, error) {
+	var lintSigner crypto.Signer
+	var err error
+	switch k := realSigner.Public().(type) {
+	case *rsa.PublicKey:
+		lintSigner, err = rsa.GenerateKey(rand.Reader, k.Size()*8)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create RSA lint signer: %w", err)
+		}
+	case *ecdsa.PublicKey:
+		lintSigner, err = ecdsa.GenerateKey(k.Curve, rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create ECDSA lint signer: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported lint signer type: %T", k)
+	}
+	return lintSigner, nil
+}
+
+// MakeLintCert creates a throwaway x509.Certificate which can be linted.
+// Only use the result from MakeSigner as the final argument.
+func MakeLintCert(tbs, issuer *x509.Certificate, subjectPubKey crypto.PublicKey, lintSigner crypto.Signer) (*zlintx509.Certificate, error) {
+	lintCertBytes, err := x509.CreateCertificate(rand.Reader, tbs, issuer, subjectPubKey, lintSigner)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lint certificate: %w", err)
+	}
+	lintCert, err := zlintx509.ParseCertificate(lintCertBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse lint certificate: %w", err)
+	}
+	return lintCert, nil
+}
+
+// LintCert runs the given set of lints across the given cert and returns
+// an error containing the names of all failed lints, or nil.
+func LintCert(lintCert *zlintx509.Certificate, lints lint.Registry) error {
+	lintRes := zlint.LintCertificateEx(lintCert, lints)
+	if lintRes.NoticesPresent || lintRes.WarningsPresent || lintRes.ErrorsPresent || lintRes.FatalsPresent {
+		var failedLints []string
+		for lintName, result := range lintRes.Results {
+			if result.Status > lint.Pass {
+				failedLints = append(failedLints, lintName)
+			}
+		}
+		return fmt.Errorf("failed lints: %s", strings.Join(failedLints, ", "))
+	}
+	return nil
+}

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1,0 +1,44 @@
+package lint
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"math/big"
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestMakeSigner_RSA(t *testing.T) {
+	rsaMod, ok := big.NewInt(0).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+	test.Assert(t, ok, "failed to set RSA mod")
+	realSigner := &rsa.PrivateKey{
+		PublicKey: rsa.PublicKey{
+			N: rsaMod,
+		},
+	}
+	lintSigner, err := MakeSigner(realSigner)
+	test.AssertNotError(t, err, "MakeSigner failed")
+	_, ok = lintSigner.(*rsa.PrivateKey)
+	test.Assert(t, ok, "lint signer is not RSA")
+}
+
+func TestMakeSigner_ECDSA(t *testing.T) {
+	realSigner := &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+		},
+	}
+	lintSigner, err := MakeSigner(realSigner)
+	test.AssertNotError(t, err, "MakeSigner failed")
+	_, ok := lintSigner.(*ecdsa.PrivateKey)
+	test.Assert(t, ok, "lint signer is not ECDSA")
+}
+
+func TestMakeSigner_Unsupported(t *testing.T) {
+	realSigner := ed25519.NewKeyFromSeed([]byte("0123456789abcdef0123456789abcdef"))
+	_, err := MakeSigner(realSigner)
+	test.AssertError(t, err, "MakeSigner shouldn't have succeeded")
+}

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -380,8 +381,9 @@ func TestNewSignerUnsupportedKeyType(t *testing.T) {
 	_, err := NewSigner(Config{
 		Profile: defaultProfileConfig(),
 		Issuer: &x509.Certificate{
-			PublicKey: &dsa.PublicKey{},
+			PublicKey: &ed25519.PublicKey{},
 		},
+		Signer: &ed25519.PrivateKey{},
 	})
 	test.AssertError(t, err, "NewSigner didn't fail")
 	test.AssertEquals(t, err.Error(), "unsupported issuer key type")
@@ -397,6 +399,11 @@ func TestNewSignerRSAKey(t *testing.T) {
 				N: mod,
 			},
 		},
+		Signer: &rsa.PrivateKey{
+			PublicKey: rsa.PublicKey{
+				N: mod,
+			},
+		},
 	})
 	test.AssertNotError(t, err, "NewSigner failed")
 	_, ok = signer.lintKey.(*rsa.PrivateKey)
@@ -408,6 +415,11 @@ func TestNewSignerECDSAKey(t *testing.T) {
 		Profile: defaultProfileConfig(),
 		Issuer: &x509.Certificate{
 			PublicKey: &ecdsa.PublicKey{
+				Curve: elliptic.P256(),
+			},
+		},
+		Signer: &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{
 				Curve: elliptic.P256(),
 			},
 		},
@@ -651,5 +663,5 @@ func TestIssueBadLint(t *testing.T) {
 		NotAfter:  fc.Now().Add(time.Hour),
 	})
 	test.AssertError(t, err, "Issue didn't fail")
-	test.AssertEquals(t, err.Error(), "tbsCertificate linting failed: w_ct_sct_policy_count_unsatisfied")
+	test.AssertEquals(t, err.Error(), "tbsCertificate linting failed: failed lints: w_ct_sct_policy_count_unsatisfied")
 }

--- a/test/cert-ceremonies/root-ceremony-rsa.yaml
+++ b/test/cert-ceremonies/root-ceremony-rsa.yaml
@@ -20,3 +20,14 @@ certificate-profile:
     key-usages:
         - Cert Sign
         - CRL Sign
+skip-lints:
+   - e_ext_authority_key_identifier_missing
+   - e_ext_authority_key_identifier_no_key_identifier
+   - e_sub_ca_aia_does_not_contain_ocsp_url
+   - e_sub_ca_aia_missing
+   - e_sub_ca_certificate_policies_missing
+   - e_sub_ca_crl_distribution_points_missing
+   - n_ca_digital_signature_not_set
+   - n_mp_allowed_eku
+   - n_sub_ca_eku_missing
+   - w_sub_ca_aia_does_not_contain_issuing_ca_url

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -148,8 +148,12 @@ challSrvProcess = None
 def setupHierarchy():
     e = os.environ.copy()
     e.setdefault("GOBIN", "%s/bin" % os.getcwd())
-    subprocess.check_call(["go", "install", "./cmd/ceremony"], env=e)
-    subprocess.check_call(["go", "run", "test/cert-ceremonies/generate.go"], env=e)
+    try:
+        subprocess.check_output(["go", "install", "./cmd/ceremony"], env=e)
+        subprocess.check_output(["go", "run", "test/cert-ceremonies/generate.go"], env=e)
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        raise
 
 
 def install(race_detection):


### PR DESCRIPTION
When issuing a new root or intermediate cert, we should take every
precaution possible to ensure that these certs are well-formed.

This change introduces a new step prior to issuing and writing a new CA
cert. We generate a new disposable private key based on the type of the
key being used in the real ceremony, then use this key to sign a fake
certificate for the sole purpose of linting. We then pass this through
the full suite of zlint's checks before proceeding with the acutal
issuance.

Fixes #5051