### PR TITLE
Log when incorporating an orphaned certificate.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -965,7 +965,7 @@ func (ca *CertificateAuthorityImpl) integrateOrphan() error {
 	if _, err = ca.orphanQueue.Dequeue(); err != nil {
 		return fmt.Errorf("failed to dequeue integrated orphaned certificate: %s", err)
 	}
-	ca.log.AuditErrf("Incorporated orphaned certificate: serial=[%s] cert=[%s] regID=[%d]",
+	ca.log.AuditInfof("Incorporated orphaned certificate: serial=[%s] cert=[%s] regID=[%d]",
 		core.SerialToString(cert.SerialNumber), hex.EncodeToString(orphan.DER), orphan.RegID)
 	typ := "cert"
 	if orphan.Precert {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -965,6 +965,8 @@ func (ca *CertificateAuthorityImpl) integrateOrphan() error {
 	if _, err = ca.orphanQueue.Dequeue(); err != nil {
 		return fmt.Errorf("failed to dequeue integrated orphaned certificate: %s", err)
 	}
+	ca.log.AuditErrf("Incorporated orphaned certificate: serial=[%s] cert=[%s] regID=[%d]",
+		core.SerialToString(cert.SerialNumber), hex.EncodeToString(orphan.DER), orphan.RegID)
 	typ := "cert"
 	if orphan.Precert {
 		typ = "precert"


### PR DESCRIPTION
This gives a little clearer lifecycle of the certificate's processing,
and makes it clear when it should be available in the DB.