### PR TITLE
Remove references to authzv2 from WFE.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -46,17 +46,17 @@ const (
 	newRegPath    = "/acme/new-reg"
 	regPath       = "/acme/reg/"
 	newAuthzPath  = "/acme/new-authz"
-	// For user-facing URLs we use a "v3" suffix to avoid potential confusiong
+	// When we moved to authzv2, we used a "-v3" suffix to avoid confusion
 	// regarding ACMEv2.
-	authzv2Path     = "/acme/authz-v3/"
-	challengev2Path = "/acme/chall-v3/"
-	newCertPath     = "/acme/new-cert"
-	certPath        = "/acme/cert/"
-	revokeCertPath  = "/acme/revoke-cert"
-	termsPath       = "/terms"
-	issuerPath      = "/acme/issuer-cert"
-	buildIDPath     = "/build"
-	rolloverPath    = "/acme/key-change"
+	authzPath      = "/acme/authz-v3/"
+	challengePath  = "/acme/chall-v3/"
+	newCertPath    = "/acme/new-cert"
+	certPath       = "/acme/cert/"
+	revokeCertPath = "/acme/revoke-cert"
+	termsPath      = "/terms"
+	issuerPath     = "/acme/issuer-cert"
+	buildIDPath    = "/build"
+	rolloverPath   = "/acme/key-change"
 
 	maxRequestSize = 50000
 )
@@ -321,8 +321,8 @@ func (wfe *WebFrontEndImpl) Handler(stats prometheus.Registerer) http.Handler {
 	wfe.HandleFunc(m, newAuthzPath, wfe.NewAuthorization, "POST")
 	wfe.HandleFunc(m, newCertPath, wfe.NewCertificate, "POST")
 	wfe.HandleFunc(m, regPath, wfe.Registration, "POST")
-	wfe.HandleFunc(m, authzv2Path, wfe.AuthorizationV2, "GET", "POST")
-	wfe.HandleFunc(m, challengev2Path, wfe.ChallengeV2, "GET", "POST")
+	wfe.HandleFunc(m, authzPath, wfe.Authorization, "GET", "POST")
+	wfe.HandleFunc(m, challengePath, wfe.Challenge, "GET", "POST")
 	wfe.HandleFunc(m, certPath, wfe.Certificate, "GET")
 	wfe.HandleFunc(m, revokeCertPath, wfe.RevokeCertificate, "POST")
 	wfe.HandleFunc(m, termsPath, wfe.Terms, "GET")
@@ -1025,10 +1025,9 @@ func (wfe *WebFrontEndImpl) NewCertificate(ctx context.Context, logEvent *web.Re
 	}
 }
 
-// ChallengeV2 handles POST requests to challenge URLs belonging to
-// authzv2-style authorizations.  Such requests are clients'
-// responses to the server's challenges.
-func (wfe *WebFrontEndImpl) ChallengeV2(
+// Challenge handles POST requests to challenge URLs.
+// Such requests are clients' responses to the server's challenges.
+func (wfe *WebFrontEndImpl) Challenge(
 	ctx context.Context,
 	logEvent *web.RequestEvent,
 	response http.ResponseWriter,
@@ -1092,7 +1091,7 @@ func (wfe *WebFrontEndImpl) ChallengeV2(
 // the client by filling in its URI field and clearing its ID field.
 func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz core.Authorization, challenge *core.Challenge) {
 	// Update the challenge URI to be relative to the HTTP request Host
-	challenge.URI = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%s", challengev2Path, authz.ID, challenge.StringID()))
+	challenge.URI = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%s", challengePath, authz.ID, challenge.StringID()))
 
 	// Historically the Type field of a problem was always prefixed with a static
 	// error namespace. To support the V2 API and migrating to the correct IETF
@@ -1360,9 +1359,8 @@ func (wfe *WebFrontEndImpl) deactivateAuthorization(ctx context.Context, authz *
 	return true
 }
 
-// AuthorizationV2 is used by clients to submit an update to an authzv2-style
-// authorization.
-func (wfe *WebFrontEndImpl) AuthorizationV2(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+// Authorization is used by clients to submit an update to an authorization.
+func (wfe *WebFrontEndImpl) Authorization(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
 	// Requests to this handler should have a path that leads to a known authz
 	id := request.URL.Path
 	var authz core.Authorization
@@ -1390,17 +1388,6 @@ func (wfe *WebFrontEndImpl) AuthorizationV2(ctx context.Context, logEvent *web.R
 		return
 	}
 
-	wfe.authorizationCommon(ctx, logEvent, response, request, authz)
-}
-
-// authorizationCommon handles logic that is common to both AuthorizationV2 and
-// Authorization.
-func (wfe *WebFrontEndImpl) authorizationCommon(
-	ctx context.Context,
-	logEvent *web.RequestEvent,
-	response http.ResponseWriter,
-	request *http.Request,
-	authz core.Authorization) {
 	if authz.Identifier.Type == identifier.DNS {
 		logEvent.DNSName = authz.Identifier.Value
 	}
@@ -1425,7 +1412,7 @@ func (wfe *WebFrontEndImpl) authorizationCommon(
 
 	response.Header().Add("Link", link(web.RelativeEndpoint(request, newCertPath), "next"))
 
-	err := wfe.writeJsonResponse(response, logEvent, http.StatusOK, authz)
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, authz)
 	if err != nil {
 		// InternalServerError because this is a failure to decode from our DB.
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to JSON marshal authz"), err)
@@ -1628,5 +1615,5 @@ func (wfe *WebFrontEndImpl) deactivateRegistration(ctx context.Context, reg core
 }
 
 func urlForAuthz(authz core.Authorization, request *http.Request) string {
-	return web.RelativeEndpoint(request, authzv2Path+string(authz.ID))
+	return web.RelativeEndpoint(request, authzPath+string(authz.ID))
 }

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1069,7 +1069,7 @@ func TestGetChallenge(t *testing.T) {
 		req.URL.Path = "1/-ZfxEw"
 		test.AssertNotError(t, err, "Could not make NewRequest")
 
-		wfe.ChallengeV2(ctx, newRequestEvent(), resp, req)
+		wfe.Challenge(ctx, newRequestEvent(), resp, req)
 		test.AssertEquals(t,
 			resp.Code,
 			http.StatusAccepted)
@@ -1103,7 +1103,7 @@ func TestGetChallengeV2UpRel(t *testing.T) {
 	req.URL.Path = "1/-ZfxEw"
 	test.AssertNotError(t, err, "Could not make NewRequest")
 
-	wfe.ChallengeV2(ctx, newRequestEvent(), resp, req)
+	wfe.Challenge(ctx, newRequestEvent(), resp, req)
 	test.AssertEquals(t,
 		resp.Code,
 		http.StatusAccepted)
@@ -1128,7 +1128,7 @@ func TestChallenge(t *testing.T) {
 
 	challengeURL := "http://localhost/acme/chall-v3/1/-ZfxEw"
 	path := "1/-ZfxEw"
-	wfe.ChallengeV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Challenge(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath(path,
 			signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 
@@ -1146,7 +1146,7 @@ func TestChallenge(t *testing.T) {
 	// Expired challenges should be inaccessible
 	challengeURL = "3/-ZfxEw"
 	responseWriter = httptest.NewRecorder()
-	wfe.ChallengeV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Challenge(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath(challengeURL,
 			signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 	test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
@@ -1156,7 +1156,7 @@ func TestChallenge(t *testing.T) {
 	// Challenge Not found
 	challengeURL = ""
 	responseWriter = httptest.NewRecorder()
-	wfe.ChallengeV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Challenge(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath(challengeURL,
 			signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 	test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
@@ -1166,7 +1166,7 @@ func TestChallenge(t *testing.T) {
 	// Unspecified database error
 	errorURL := "4/-ZfxEw"
 	responseWriter = httptest.NewRecorder()
-	wfe.ChallengeV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Challenge(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath(errorURL,
 			signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 	test.AssertEquals(t, responseWriter.Code, http.StatusInternalServerError)
@@ -1194,7 +1194,7 @@ func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 
 	path := "1/-ZfxEw"
-	wfe.ChallengeV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Challenge(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath(path,
 			signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 
@@ -1217,7 +1217,7 @@ func TestUpdateChallengeRAError(t *testing.T) {
 	// Update a pending challenge
 	path := "2/-ZfxEw"
 	responseWriter := httptest.NewRecorder()
-	wfe.ChallengeV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Challenge(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath(path,
 			signRequest(t, `{"resource":"challenge"}`, wfe.nonceService)))
 
@@ -1759,9 +1759,9 @@ func TestAuthorization500(t *testing.T) {
 
 	responseWriter := httptest.NewRecorder()
 
-	authzURL := mustParseURL(authzv2Path)
+	authzURL := mustParseURL(authzPath)
 	authzURL.Path = "4"
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		Method: "GET",
 		URL:    authzURL,
 	})
@@ -1851,7 +1851,7 @@ func TestAuthorization(t *testing.T) {
 	// Expired authorizations should be inaccessible
 	authzURL := "3"
 	responseWriter = httptest.NewRecorder()
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		Method: "GET",
 		URL:    mustParseURL(authzURL),
 	})
@@ -1861,7 +1861,7 @@ func TestAuthorization(t *testing.T) {
 	responseWriter.Body.Reset()
 
 	// Ensure that a valid authorization can't be reached with an invalid URL
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		URL:    mustParseURL("7"),
 		Method: "GET",
 	})
@@ -1874,7 +1874,7 @@ func TestAuthorizationV2(t *testing.T) {
 
 	// Test retrieving a v2 style authorization
 	responseWriter := httptest.NewRecorder()
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		URL:    mustParseURL("1"),
 		Method: "GET",
 	})
@@ -1900,7 +1900,7 @@ func TestAuthorizationV2(t *testing.T) {
 	// Test that getting a v2 authorization with an invalid ID results in the
 	// expected not found status.
 	responseWriter = httptest.NewRecorder()
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		URL:    mustParseURL("1junkjunkjunk"),
 		Method: "GET",
 	})
@@ -1925,7 +1925,7 @@ func TestAuthorizationChallengeNamespace(t *testing.T) {
 	// that has an error with the type already prefixed by the v1 error NS
 	authzURL := "55"
 	responseWriter := httptest.NewRecorder()
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		Method: "GET",
 		URL:    mustParseURL(authzURL),
 	})
@@ -1941,7 +1941,7 @@ func TestAuthorizationChallengeNamespace(t *testing.T) {
 	// that has an error with the type not prefixed by an error namespace.
 	authzURL = "56"
 	responseWriter = httptest.NewRecorder()
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter, &http.Request{
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		Method: "GET",
 		URL:    mustParseURL(authzURL),
 	})
@@ -2421,14 +2421,14 @@ func TestDeactivateAuthorization(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 
 	responseWriter.Body.Reset()
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath("1", signRequest(t, `{"resource":"authz","status":""}`, wfe.nonceService)))
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{"type": "`+probs.V1ErrorNS+`malformed","detail": "Invalid status value","status": 400}`)
 
 	responseWriter.Body.Reset()
-	wfe.AuthorizationV2(ctx, newRequestEvent(), responseWriter,
+	wfe.Authorization(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath("1", signRequest(t, `{"resource":"authz","status":"deactivated"}`, wfe.nonceService)))
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -951,13 +951,13 @@ func TestHTTPMethods(t *testing.T) {
 		// TODO(@cpu): Remove GET authz support, support only POST-as-GET
 		{
 			Name:    "Authz path should be GET or POST only",
-			Path:    authzv2Path,
+			Path:    authzPath,
 			Allowed: getOrPost,
 		},
 		// TODO(@cpu): Remove GET challenge support, support only POST-as-GET
 		{
 			Name:    "Challenge path should be GET or POST only",
-			Path:    challengev2Path,
+			Path:    challengePath,
 			Allowed: getOrPost,
 		},
 		// TODO(@cpu): Remove GET certificate support, support only POST-as-GET
@@ -3260,7 +3260,7 @@ func TestGETAPIAuthz(t *testing.T) {
 	tooFreshErr := `{"type":"` + probs.V2ErrorNS + `unauthorized","detail":"Authorization is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`
 	for _, tc := range testCases {
 		responseWriter := httptest.NewRecorder()
-		req, logEvent := makeGet(tc.path, getAuthzv2Path)
+		req, logEvent := makeGet(tc.path, getAuthzPath)
 		wfe.Authorization(context.Background(), logEvent, responseWriter, req)
 
 		if responseWriter.Code == http.StatusOK && tc.expectTooFreshErr {
@@ -3299,7 +3299,7 @@ func TestGETAPIChallenge(t *testing.T) {
 	tooFreshErr := `{"type":"` + probs.V2ErrorNS + `unauthorized","detail":"Authorization is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`
 	for _, tc := range testCases {
 		responseWriter := httptest.NewRecorder()
-		req, logEvent := makeGet(tc.path, getAuthzv2Path)
+		req, logEvent := makeGet(tc.path, getAuthzPath)
 		wfe.Challenge(context.Background(), logEvent, responseWriter, req)
 
 		if responseWriter.Code == http.StatusOK && tc.expectTooFreshErr {


### PR DESCRIPTION
We've now made the migration; no need to keep these vestiges around.