### PR TITLE
Failed status get should return internal error.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -859,7 +859,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *web
 	certStatus, err := wfe.SA.GetCertificateStatus(ctx, serial)
 	if err != nil {
 		// TODO(#991): handle db errors
-		wfe.sendError(response, logEvent, probs.NotFound("Certificate status not yet available"), err)
+		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to get certificate status"), err)
 		return
 	}
 	logEvent.Extra["CertificateStatus"] = certStatus.Status

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -806,7 +806,7 @@ func (wfe *WebFrontEndImpl) processRevocation(
 	// already revoked
 	certStatus, err := wfe.SA.GetCertificateStatus(ctx, serial)
 	if err != nil {
-		return probs.NotFound("Certificate status not yet available")
+		return probs.ServerInternal("Failed to get certificate status")
 	}
 	logEvent.Extra["CertificateStatus"] = certStatus.Status
 


### PR DESCRIPTION
Previously this was a NotFound error, but since we now update the
certificateStatus table synchronously on issuance and revocation, we
expect to always get a successful response; if we get an error, that's
a ServerInternal error.