### PR TITLE
core: Remove nil checks for core proto types.

### DIFF
--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -194,7 +194,7 @@ func NewRegistrationAuthorityServer(inner core.RegistrationAuthority) *Registrat
 }
 
 func (ras *RegistrationAuthorityServerWrapper) NewRegistration(ctx context.Context, request *corepb.Registration) (*corepb.Registration, error) {
-	if request == nil || !registrationValid(request) {
+	if request == nil || !newRegistrationValid(request) {
 		return nil, errIncompleteRequest
 	}
 	reg, err := pbToRegistration(request)
@@ -209,7 +209,7 @@ func (ras *RegistrationAuthorityServerWrapper) NewRegistration(ctx context.Conte
 }
 
 func (ras *RegistrationAuthorityServerWrapper) NewAuthorization(ctx context.Context, request *rapb.NewAuthorizationRequest) (*corepb.Authorization, error) {
-	if request == nil || !authorizationValid(request.Authz) || request.RegID == 0 {
+	if request == nil || request.Authz == nil || request.Authz.Identifier == nil || *request.Authz.Identifier == "" || request.RegID == 0 {
 		return nil, errIncompleteRequest
 	}
 	authz, err := PBToAuthz(request.Authz)
@@ -239,7 +239,7 @@ func (ras *RegistrationAuthorityServerWrapper) NewCertificate(ctx context.Contex
 }
 
 func (ras *RegistrationAuthorityServerWrapper) UpdateRegistration(ctx context.Context, request *rapb.UpdateRegistrationRequest) (*corepb.Registration, error) {
-	if request == nil || !registrationValid(request.Base) || !registrationValid(request.Update) {
+	if request == nil || !registrationValid(request.Base) {
 		return nil, errIncompleteRequest
 	}
 	base, err := pbToRegistration(request.Base)

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -667,7 +667,7 @@ func (sac StorageAuthorityServerWrapper) PreviousCertificateExists(
 }
 
 func (sas StorageAuthorityServerWrapper) NewRegistration(ctx context.Context, request *corepb.Registration) (*corepb.Registration, error) {
-	if request == nil || !registrationValid(request) {
+	if request == nil || !newRegistrationValid(request) {
 		return nil, errIncompleteRequest
 	}
 


### PR DESCRIPTION
In preparation for moving to proto3 for the core/proto types
(Registration, Order, Authorization, Challenge, etc), this removes
checks that will fail when a proto2 client or server receives a message
from a proto3 client or server. Since proto3 encodes fields that have
their zero value as being absent (i.e. nil, in Go), we treat nil the
same as having a zero value.

In the process this change introduces additional checks, verifying
certain fields which should never have a zero value.

This involves factoring out registrationValid into registrationValid and
newRegistrationValid, since new registration requests lack some fields that
already-created registrations should always have.

Similarly, UpdateRegistration is changed to not verify that
`request.Update` is valid, since an update to registration object is not
a complete registration object - it may only update one field.

Part of #5050 