### PR TITLE
Check for CKA_LABEL in NewSigner.

### DIFF
--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -35,9 +36,9 @@ func genKey(path string, inSlot string) error {
 	if err != nil {
 		return err
 	}
-	_, err = exec.Command("bin/ceremony", "-config", tmpPath).CombinedOutput()
+	output, err := exec.Command("bin/ceremony", "-config", tmpPath).CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("error running ceremony for %s: %s:\n%s", tmpPath, err, string(output))
 	}
 	return nil
 }

--- a/test/cert-ceremonies/root-ceremony-rsa.yaml
+++ b/test/cert-ceremonies/root-ceremony-rsa.yaml
@@ -23,7 +23,6 @@ certificate-profile:
 skip-lints:
    - e_ext_authority_key_identifier_missing
    - e_ext_authority_key_identifier_no_key_identifier
-   - e_sub_ca_aia_does_not_contain_ocsp_url
    - e_sub_ca_aia_missing
    - e_sub_ca_certificate_policies_missing
    - e_sub_ca_crl_distribution_points_missing


### PR DESCRIPTION
In #4992, we refactored NewSigner to look keys up by public key *and by
label*. However, we didn't correctly incorporate the label check into
the new code. This fixes that and adds a test.