### PR TITLE
integration: use 2048-bit intermediate.

### DIFF
--- a/test/cert-ceremonies/intermediate-key-ceremony-rsa.yaml
+++ b/test/cert-ceremonies/intermediate-key-ceremony-rsa.yaml
@@ -6,6 +6,6 @@ pkcs11:
     store-key-with-label: intermediate signing key (rsa)
 key:
     type: rsa
-    rsa-mod-length: 4096
+    rsa-mod-length: 2048
 outputs:
     public-key-path: /tmp/intermediate-signing-pub-rsa.pem


### PR DESCRIPTION
Since we generate an intermediate on each integration test run, this
speeds things up by a few seconds. It also makes generation of our
linting keys on CA startup faster.