### PR TITLE
CA: Set IssuerID when integrating orphaned certs

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1131,6 +1131,7 @@ func TestOrphanQueue(t *testing.T) {
 		1,
 		tmpl.SerialNumber,
 		certDER,
+		1,
 	)
 	test.AssertError(t, err, "storeCertificate didn't fail when AddCertificate failed")
 
@@ -1172,6 +1173,7 @@ func TestOrphanQueue(t *testing.T) {
 		1,
 		tmpl.SerialNumber,
 		certDER,
+		1,
 	)
 	test.AssertError(t, err, "storeCertificate didn't fail when AddCertificate failed")
 	err = orphanQueue.Close()


### PR DESCRIPTION
There are two code paths which end up calling the SA's AddPrecertificate
RPC: one "normal" path from inside the CA's IssuePrecertificate
method, and one "exceptional" path from inside the orphan-integration
path which only gets executed if the initial attempt to store the cert
failed for some reason.

The first of these paths always sets the IssuerID in the RPC's
AddCertificateRequest. The latter of these paths never does.
Historically, this has been fine, as the SA has stored NULL in the
certificateStatus table when given a nil IssuerID, which matches the
behavior prior to the StoreIssuerInfo flag (when the IssuerID was
always nil, and cert status was tracked by full cert DER instead).

However, with the switch to proto3, the SA now interprets a nil
IssuerID as a 0, and stores that value in the table instead. The
ocsp-updater code which consumes rows of the certificateStatus table
is not able to properly handle IssuerIDs of 0, leading to fun times.

This change ensures that the orphan handling code also sets the
IssuerID when asking the SA to create a new certificateStatus row,
so we should stop producing new rows with a 0 IssuerID.