### PR TITLE
CA: Small cleanups to issuer loading

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -35,9 +35,9 @@ type config struct {
 	Syslog cmd.SyslogConfig
 }
 
-func loadCFSSLIssuers(c config) ([]ca.Issuer, error) {
+func loadCFSSLIssuers(configs []ca_config.IssuerConfig) ([]ca.Issuer, error) {
 	var issuers []ca.Issuer
-	for _, issuerConfig := range c.CA.Issuers {
+	for _, issuerConfig := range configs {
 		priv, cert, err := loadIssuer(issuerConfig)
 		cmd.FailOnError(err, "Couldn't load private key")
 		issuers = append(issuers, ca.Issuer{
@@ -177,7 +177,7 @@ func main() {
 		boulderIssuerConfigs, err = loadBoulderIssuers(c.CA.Issuers, c.CA.SignerProfile, c.CA.IgnoredLints)
 		cmd.FailOnError(err, "Couldn't load issuers")
 	} else {
-		cfsslIssuers, err = loadCFSSLIssuers(c)
+		cfsslIssuers, err = loadCFSSLIssuers(c.CA.Issuers)
 		cmd.FailOnError(err, "Couldn't load issuers")
 	}
 

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -28,14 +28,14 @@
         "orphan-finder.boulder"
       ]
     },
-    "Issuers": [{
-      "ConfigFile": "test/test-ca.key-pkcs11.json",
-      "CertFile": "/tmp/intermediate-cert-rsa-a.pem",
-      "NumSessions": 2
+    "issuers": [{
+      "configFile": "test/test-ca.key-pkcs11.json",
+      "certFile": "/tmp/intermediate-cert-rsa-a.pem",
+      "numSessions": 2
     },{
-      "ConfigFile": "test/test-ca.key-pkcs11.json",
-      "CertFile": "/tmp/intermediate-cert-rsa-b.pem",
-      "NumSessions": 2
+      "configFile": "test/test-ca.key-pkcs11.json",
+      "certFile": "/tmp/intermediate-cert-rsa-b.pem",
+      "numSessions": 2
     }],
     "expiry": "2160h",
     "backdate": "1h",

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -28,14 +28,14 @@
         "orphan-finder.boulder"
       ]
     },
-    "Issuers": [{
-      "ConfigFile": "test/test-ca.key-pkcs11.json",
-      "CertFile": "/tmp/intermediate-cert-rsa-a.pem",
-      "NumSessions": 2
+    "issuers": [{
+      "configFile": "test/test-ca.key-pkcs11.json",
+      "certFile": "/tmp/intermediate-cert-rsa-a.pem",
+      "numSessions": 2
     },{
-      "ConfigFile": "test/test-ca.key-pkcs11.json",
-      "CertFile": "/tmp/intermediate-cert-rsa-b.pem",
-      "NumSessions": 2
+      "configFile": "test/test-ca.key-pkcs11.json",
+      "certFile": "/tmp/intermediate-cert-rsa-b.pem",
+      "numSessions": 2
     }],
     "expiry": "2160h",
     "backdate": "1h",


### PR DESCRIPTION
This just changes the `loadCFSSLIssuers` signature to more closely match
the `loadBoulderIssuers` signature (it didn't need access to the whole config
object), and standardize our json on lowercase string keys.