### PR TITLE
wfe: reject empty identifiers in new-authz and new-order

### DIFF
--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1809,6 +1809,23 @@ func TestNewAuthorizationEmptyType(t *testing.T) {
 		`{"type":"`+probs.V1ErrorNS+`malformed","detail":"Invalid new-authorization request: missing fields","status":400}`)
 }
 
+func TestNewAuthorizationNonDNS(t *testing.T) {
+	responseWriter := httptest.NewRecorder()
+	wfe, _ := setupWFE(t)
+
+	wfe.NewAuthorization(ctx, newRequestEvent(), responseWriter,
+		makePostRequest(signRequest(t, `{
+		  "resource":"new-authz",
+			"identifier": {
+				"Type": "shibboleth",
+				"Value": "example.com"
+			}
+		}`, wfe.nonceService)))
+	test.AssertUnmarshaledEquals(t,
+		responseWriter.Body.String(),
+		`{"type":"`+probs.V1ErrorNS+`malformed","detail":"Invalid new-authorization request: wrong identifier type","status":400}`)
+}
+
 func TestAuthorization(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler(metrics.NoopRegisterer)

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1775,6 +1775,40 @@ func TestAuthorization500(t *testing.T) {
 
 }
 
+func TestNewAuthorizationEmptyDomain(t *testing.T) {
+	responseWriter := httptest.NewRecorder()
+	wfe, _ := setupWFE(t)
+
+	wfe.NewAuthorization(ctx, newRequestEvent(), responseWriter,
+		makePostRequest(signRequest(t, `{
+		  "resource":"new-authz",
+			"identifier": {
+				"Type": "dns",
+				"Value": ""
+			}
+		}`, wfe.nonceService)))
+	test.AssertUnmarshaledEquals(t,
+		responseWriter.Body.String(),
+		`{"type":"`+probs.V1ErrorNS+`malformed","detail":"Invalid new-authorization request: missing fields","status":400}`)
+}
+
+func TestNewAuthorizationEmptyType(t *testing.T) {
+	responseWriter := httptest.NewRecorder()
+	wfe, _ := setupWFE(t)
+
+	wfe.NewAuthorization(ctx, newRequestEvent(), responseWriter,
+		makePostRequest(signRequest(t, `{
+		  "resource":"new-authz",
+			"identifier": {
+				"Type": "",
+				"Value": "example.com"
+			}
+		}`, wfe.nonceService)))
+	test.AssertUnmarshaledEquals(t,
+		responseWriter.Body.String(),
+		`{"type":"`+probs.V1ErrorNS+`malformed","detail":"Invalid new-authorization request: missing fields","status":400}`)
+}
+
 func TestAuthorization(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	mux := wfe.Handler(metrics.NoopRegisterer)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1971,7 +1971,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 			return
 		}
 		if ident.Value == "" {
-			wfe.sendError(response, logEvent, probs.Malformed("NewOrder request included invalid empty domain name"), nil)
+			wfe.sendError(response, logEvent, probs.Malformed("NewOrder request included empty domain name"), nil)
 			return
 		}
 		names[i] = ident.Value

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1970,6 +1970,10 @@ func (wfe *WebFrontEndImpl) NewOrder(
 				nil)
 			return
 		}
+		if ident.Value == "" {
+			wfe.sendError(response, logEvent, probs.Malformed("NewOrder request included invalid empty domain name"), nil)
+			return
+		}
 		names[i] = ident.Value
 	}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2233,6 +2233,11 @@ func TestNewOrder(t *testing.T) {
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 		{
+			Name:         "POST, empty domain name identifier",
+			Request:      signAndPost(t, targetPath, signedURL, `{"identifiers":[{"type":"dns","value":""}]}`, 1, wfe.nonceService),
+			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request included empty domain name","status":400}`,
+		},
+		{
 			Name:         "POST, no identifiers in payload",
 			Request:      signAndPost(t, targetPath, signedURL, "{}", 1, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request did not specify any identifiers","status":400}`,


### PR DESCRIPTION
Currently these are rejected at the RA. It's nicer to reject them one step earlier.

Fixes #5081