### PR TITLE
ca: return better error on bad cert parse.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -497,6 +497,7 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *capb.
 	} else {
 		cert, err := x509.ParseCertificate(req.CertDER)
 		if err != nil {
+			err := fmt.Errorf("parsing certificate for GenerateOCSP: %w", err)
 			ca.log.AuditErr(err.Error())
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #5078 