### PR TITLE
CA: Verify digitalSignature and certSign key usages

### DIFF
--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -353,6 +353,16 @@ func NewIssuer(cert *x509.Certificate, signer crypto.Signer, profile *Profile, l
 	default:
 		return nil, errors.New("unsupported issuer key type")
 	}
+
+	if profile.useForRSALeaves || profile.useForECDSALeaves {
+		if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+			return nil, errors.New("end-entity signing cert does not have keyUsage certSign")
+		}
+	}
+	if cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+		return nil, errors.New("end-entity ocsp signing cert does not have keyUsage digitalSignature")
+	}
+
 	i := &Issuer{
 		Cert:    cert,
 		Signer:  signer,

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -359,6 +359,7 @@ func NewIssuer(cert *x509.Certificate, signer crypto.Signer, profile *Profile, l
 			return nil, errors.New("end-entity signing cert does not have keyUsage certSign")
 		}
 	}
+	// TODO(#5086): Only do this check for ocsp-issuing issuers.
 	if cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
 		return nil, errors.New("end-entity ocsp signing cert does not have keyUsage digitalSignature")
 	}


### PR DESCRIPTION
When the CA loads new issuers (both their certificates and their
private keys), it performs a variety of sanity checks, such as
ensuring that the profile's signature algorithm matches the key
type.

With this change, we also check that the issuer's certificate has
the appropriate key usage bits set:
`certSign`, if it is going to be issuing end-entity certs; and
`digitalSignature`, because it will be signing OCSP responses for
previously-issued certificates.

Fixes #5068