### PR TITLE
notify-mailer: improve log output

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -125,7 +125,7 @@ func (m *mailer) run() error {
 			biggestAddress = k
 		}
 	}
-	m.log.Infof("Most frequent address %q had %d associated accounts", biggestAddress, biggest)
+	m.log.Infof("Most frequent address %q had %d associated lines", biggestAddress, biggest)
 
 	err = m.mailer.Connect()
 	if err != nil {

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -102,7 +102,9 @@ func (d dryRunClient) Data() (io.WriteCloser, error) {
 }
 
 func (d dryRunClient) Write(p []byte) (n int, err error) {
-	d.log.Debugf("data: %s", string(p))
+	for _, line := range strings.Split(string(p), "\n") {
+		d.log.Debugf("data: %s", line)
+	}
 	return len(p), nil
 }
 


### PR DESCRIPTION
One of the log lines describes the most frequent address corresponding
to a number of accounts, but it actually corresponds to a number of
lines in the input CSV.

Also, now that we escape newlines in log output, the dryRunMailer's
output looks messed up. Split the message body into lines and emit one
log message per line.