### PR TITLE
Fix IsAnyNilOrZero to correctly handle all numeric types

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -217,16 +217,14 @@ func IsAnyNilOrZero(vals ...interface{}) bool {
 		switch v := val.(type) {
 		case nil:
 			return true
-		// These are the go types which correspond to proto3's scalar fields.
-		case bool, int, int32, int64, uint, uint32, uint64, float32, float64, string:
-			if reflect.ValueOf(v).IsZero() {
-				return true
-			}
 		case []byte:
 			if len(v) == 0 {
 				return true
 			}
 		default:
+			if reflect.ValueOf(v).IsZero() {
+				return true
+			}
 		}
 	}
 	return false

--- a/core/util.go
+++ b/core/util.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	mrand "math/rand"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -217,61 +218,10 @@ func IsAnyNilOrZero(vals ...interface{}) bool {
 		case nil:
 			return true
 		// These are the go types which correspond to proto3's scalar fields.
-		case bool:
-			if v == false {
+		case bool, int, int32, int64, uint, uint32, uint64, float32, float64, string:
+			if reflect.ValueOf(v).IsZero() {
 				return true
 			}
-		case int, int32, int64, uint, uint32, uint64, float32, float64:
-			if v == 0 {
-				return true
-			}
-		case string:
-			if v == "" {
-				return true
-			}
-		// These are the go types which correspond to proto2's scalar fields.
-		// TODO(#2936): Remove these when all proto2 generated code is gone.
-		case *bool:
-			if *v == false {
-				return true
-			}
-		case *int:
-			if *v == 0 {
-				return true
-			}
-		case *int32:
-			if *v == 0 {
-				return true
-			}
-		case *int64:
-			if *v == 0 {
-				return true
-			}
-		case *uint:
-			if *v == 0 {
-				return true
-			}
-		case *uint32:
-			if *v == 0 {
-				return true
-			}
-		case *uint64:
-			if *v == 0 {
-				return true
-			}
-		case *float32:
-			if *v == 0 {
-				return true
-			}
-		case *float64:
-			if *v == 0 {
-				return true
-			}
-		case *string:
-			if *v == "" {
-				return true
-			}
-		// This is the go type which can be generated for both proto2 and proto3.
 		case []byte:
 			if len(v) == 0 {
 				return true

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -110,31 +110,18 @@ func TestKeyDigestEquals(t *testing.T) {
 func TestIsAnyNilOrZero(t *testing.T) {
 	test.Assert(t, IsAnyNilOrZero(nil), "Nil seen as non-zero")
 
-	zeroBool := false
-	nonZeroBool := true
-	test.Assert(t, IsAnyNilOrZero(zeroBool), "False bool seen as non-zero")
-	test.Assert(t, IsAnyNilOrZero(&zeroBool), "False bool seen as non-zero")
-	test.Assert(t, !IsAnyNilOrZero(nonZeroBool), "True bool seen as zero")
-	test.Assert(t, !IsAnyNilOrZero(&nonZeroBool), "True bool seen as zero")
+	test.Assert(t, IsAnyNilOrZero(false), "False bool seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(true), "True bool seen as zero")
 
-	zeroNum := 0
-	nonZeroNum := -12.345
-	test.Assert(t, IsAnyNilOrZero(zeroNum), "Zero num seen as non-zero")
-	test.Assert(t, IsAnyNilOrZero(&zeroNum), "Zero num seen as non-zero")
-	test.Assert(t, !IsAnyNilOrZero(nonZeroNum), "Non-zero num seen as zero")
-	test.Assert(t, !IsAnyNilOrZero(&nonZeroNum), "Non-zero num seen as zero")
+	test.Assert(t, IsAnyNilOrZero(0), "Zero num seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(uint32(5)), "Non-zero num seen as zero")
+	test.Assert(t, !IsAnyNilOrZero(-12.345), "Non-zero num seen as zero")
 
-	zeroStr := ""
-	nonZeroStr := "string"
-	test.Assert(t, IsAnyNilOrZero(zeroStr), "Empty string seen as non-zero")
-	test.Assert(t, IsAnyNilOrZero(&zeroStr), "Empty string seen as non-zero")
-	test.Assert(t, !IsAnyNilOrZero(nonZeroStr), "Non-empty string seen as zero")
-	test.Assert(t, !IsAnyNilOrZero(&nonZeroStr), "Non-empty string seen as zero")
+	test.Assert(t, IsAnyNilOrZero(""), "Empty string seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero("string"), "Non-empty string seen as zero")
 
-	zeroByte := []byte{}
-	nonZeroByte := []byte("byte")
-	test.Assert(t, IsAnyNilOrZero(zeroByte), "Empty byte slice seen as non-zero")
-	test.Assert(t, !IsAnyNilOrZero(nonZeroByte), "Non-empty byte slice seen as zero")
+	test.Assert(t, IsAnyNilOrZero([]byte{}), "Empty byte slice seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero([]byte("byte")), "Non-empty byte slice seen as zero")
 
 	test.Assert(t, IsAnyNilOrZero(1, ""), "Mixed values seen as non-zero")
 	test.Assert(t, IsAnyNilOrZero("", 1), "Mixed values seen as non-zero")

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -123,6 +123,14 @@ func TestIsAnyNilOrZero(t *testing.T) {
 	test.Assert(t, IsAnyNilOrZero([]byte{}), "Empty byte slice seen as non-zero")
 	test.Assert(t, !IsAnyNilOrZero([]byte("byte")), "Non-empty byte slice seen as zero")
 
+	type Foo struct {
+		foo int
+	}
+	test.Assert(t, IsAnyNilOrZero(Foo{}), "Empty struct seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(Foo{5}), "Non-empty struct seen as zero")
+	var f *Foo
+	test.Assert(t, IsAnyNilOrZero(f), "Pointer to uninitialized struct seen as non-zero")
+
 	test.Assert(t, IsAnyNilOrZero(1, ""), "Mixed values seen as non-zero")
 	test.Assert(t, IsAnyNilOrZero("", 1), "Mixed values seen as non-zero")
 }

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -799,7 +799,7 @@ func (sas StorageAuthorityServerWrapper) GetAuthorization2(ctx context.Context, 
 }
 
 func (sas StorageAuthorityServerWrapper) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*corepb.Empty, error) {
-	if core.IsAnyNilOrZero(req, req.Serial, req.Reason, req.Date, req.Response) {
+	if core.IsAnyNilOrZero(req, req.Serial, req.Date, req.Response) {
 		return nil, errIncompleteRequest
 	}
 	return &corepb.Empty{}, sas.inner.RevokeCertificate(ctx, req)

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2263,12 +2263,10 @@ func TestAddBlockedKeyUnknownSource(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
-	added := int64(0)
-	source := "heyo"
 	_, err := sa.AddBlockedKey(context.Background(), &sapb.AddBlockedKeyRequest{
 		KeyHash: []byte{1, 2, 3},
-		Added:   added,
-		Source:  source,
+		Added:   1,
+		Source:  "heyo",
 	})
 	test.AssertError(t, err, "AddBlockedKey didn't fail with unknown source")
 	test.AssertEquals(t, err.Error(), "unknown source")
@@ -2282,20 +2280,18 @@ func TestBlockedKeyRevokedBy(t *testing.T) {
 	test.AssertNotError(t, err, "failed to set features")
 	defer features.Reset()
 
-	added := int64(0)
-	source := "API"
 	_, err = sa.AddBlockedKey(context.Background(), &sapb.AddBlockedKeyRequest{
 		KeyHash: []byte{1},
-		Added:   added,
-		Source:  source,
+		Added:   1,
+		Source:  "API",
 	})
 	test.AssertNotError(t, err, "AddBlockedKey failed")
-	revoker := int64(1)
+
 	_, err = sa.AddBlockedKey(context.Background(), &sapb.AddBlockedKeyRequest{
 		KeyHash:   []byte{2},
-		Added:     added,
-		Source:    source,
-		RevokedBy: revoker,
+		Added:     1,
+		Source:    "API",
+		RevokedBy: 1,
 	})
 	test.AssertNotError(t, err, "AddBlockedKey failed")
 }


### PR DESCRIPTION
The previous implementation of `IsAnyNilOrZero` did not in fact work,
and its tests did not catch this fact. Within the numeric clause, the
compiler would only instantiate the comparison literal `0` to be one
of the eight possible types. Comparisons against any of the other
seven types would always be false, no matter what value that type
held.

The tests did not catch this because they only tested two literal
values: `0` and `-12.345`, both of which can be `float64`s.

This change updates the utility function to use the `reflect` package,
to ensure that it works correctly. It also updates the test to test
multiple different kinds of numeric values, and removes the code
for handling pointer-to- types, as all of our proto2 code has been
removed.

Finally, it updates the SA wrapper's `RevokeCertificate` method to
correctly not require that `req.Reason` be non-zero: this field can
and often is zero, as that value represents `Unspecified`.

Using the reflect package is a conscious tradeoff. It will be slower
than manually writing out every single case, but it will also be less
prone to error.

Part of #5097