### PR TITLE
Update acme divergences documentation

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -28,9 +28,8 @@ support this non-essential feature in the future. Please follow Boulder Issue
 
 ## [Section 7.4](https://tools.ietf.org/html/rfc8555#section-7.4)
 
-Boulder does not respect the `notBefore` and `notAfter` fields of a `newOrder`
-request paylod. Boulder always issues certificates with validity starting at or
-near the time of issuance, and validity ending after 90 days.
+Boulder does not accept the optional `notBefore` and `notAfter` fields of a
+`newOrder` request paylod.
 
 ## [Section 7.4.1](https://tools.ietf.org/html/rfc8555#section-7.4.1)
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -2,12 +2,13 @@
 
 While Boulder attempts to implement the ACME specification ([RFC 8555]) as strictly as possible there are places at which we will diverge from the letter of the specification for various reasons. This document describes the difference between RFC 8555 and Boulder's implementation of ACME, informally called ACMEv2 and available at https://acme-v02.api.letsencrypt.org/directory. Boulder's implementation of ACMEv1 differs substantially from the final RFC. Documentation for Boulder's ACMEv1 support is available in [acme-divergences-v1.md](acme-divergences-v1.md).
 
-Presently the following protocol features are not implemented:
+Presently, Boulder diverges from the RFC 8555 ACME spec in the following ways:
 
-- Pre-authorization. This is an optional feature and we have no plans to implement it. V2 clients should use order based issuance without pre-authorization.
-- The `orders` field on account objects. We intend to support this non-essential feature in the future. Please follow Boulder Issue [#3335](https://github.com/letsencrypt/boulder/issues/3335).
+## [Section 6.3](https://tools.ietf.org/html/rfc8555#section-6.3)
 
-POST-as-GET: We support POST-as-GET but do not yet mandate it. We [plan to mandate](https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380) POST-as-GET for all ACMEv2 requests in late 2019.
+We support POST-as-GET but do not yet mandate it. We
+[plan to mandate](https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380)
+POST-as-GET for all ACMEv2 requests in November 2020.
 
 ## [Section 6.6](https://tools.ietf.org/html/rfc8555#section-6.6)
 
@@ -15,11 +16,28 @@ Boulder does not provide a `Retry-After` header when a user hits a rate-limit, n
 
 ## [Section 6.7](https://tools.ietf.org/html/rfc8555#section-6.7)
 
-Boulder uses `invalidEmail` in place of the error `invalidContact` defined in [draft-ietf-acme-01 Section 5.4](https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-5.4).
+Boulder uses `invalidEmail` in place of the error `invalidContact`.
 
 Boulder does not implement the `unsupportedContact` and `dnssec` errors.
 
-## [Section 7.4.2](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-7.4.2)
+## [Section 7.1.2](https://tools.ietf.org/html/rfc8555#section-7.1.2)
+
+Boulder does not supply the `orders` field on account objects. We intend to
+support this non-essential feature in the future. Please follow Boulder Issue
+[#3335](https://github.com/letsencrypt/boulder/issues/3335).
+
+## [Section 7.4](https://tools.ietf.org/html/rfc8555#section-7.4)
+
+Boulder does not respect the `notBefore` and `notAfter` fields of a `newOrder`
+request paylod. Boulder always issues certificates with validity starting at or
+near the time of issuance, and validity ending after 90 days.
+
+## [Section 7.4.1](https://tools.ietf.org/html/rfc8555#section-7.4.1)
+
+Pre-authorization is an optional feature and we have no plans to implement it.
+V2 clients should use order based issuance without pre-authorization.
+
+## [Section 7.4.2](https://tools.ietf.org/html/rfc8555#section-7.4.2)
 
 Boulder does not process `Accept` headers for `Content-Type` negotiation when retrieving certificates.
 


### PR DESCRIPTION
We do not respect the notBefore and notAfter fields of a newOrder
request; we always issue with a validity interval determined by
Boulder. This is an important divergence from spec, and should be
noted.

In addition, this change reorganizes the document to have all changes
noted under their respective section headings, updates estimated
resolution dates on long-standing divergences, and updates all URLs
to reference the final RFC 8555 instead of various drafts.