### PR TITLE
Fix ocsp/helper.

### DIFF
--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -71,6 +71,7 @@ func ConfigFromFlags() Config {
 		ignoreExpiredCerts: *ignoreExpiredCerts,
 		expectStatus:       *expectStatus,
 		expectReason:       *expectReason,
+		output:             os.Stdout,
 	}
 }
 
@@ -330,7 +331,7 @@ func parseAndPrint(respBytes []byte, cert, issuer *x509.Certificate, config Conf
 	}
 
 	pr := func(s string, v ...interface{}) {
-		fmt.Fprintf(config.output, s, v)
+		fmt.Fprintf(config.output, s, v...)
 	}
 
 	pr("\n")


### PR DESCRIPTION
In #5103 I tweaked the help to allow customizing where the output goes,
but I didn't ensure that the output field was always set. Also, I forgot
to expand the `...v` parameter when passing it to Fprintf.