### PR TITLE
Fix parity of RevokeCertificate error message

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1558,7 +1558,7 @@ func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb
 	if rows == 0 {
 		// InternalServerError because we expected this certificate status to exist and
 		// not be revoked.
-		return berrors.InternalServerError("no certificate with serial %s and status %s", req.Serial, string(core.OCSPStatusRevoked))
+		return berrors.InternalServerError("no certificate with serial %s and status other than %s", req.Serial, string(core.OCSPStatusRevoked))
 	}
 	return nil
 }


### PR DESCRIPTION
The query executed by the `RevokeCertificate` method searches for
(and updates) a row with the given serial and with revocation status
not equal to `core.OCSPStatusRevoked`. The log line, however, says
that it failed to find any row with status revoked.

This log line is misleading, and should be clarified.

Part of #5107