### PR TITLE
Return alreadyRevoked for duplicate revocations

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1558,7 +1558,7 @@ func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb
 	if rows == 0 {
 		// InternalServerError because we expected this certificate status to exist and
 		// not be revoked.
-		return berrors.InternalServerError("no certificate with serial %s and status %s", req.Serial, string(core.OCSPStatusRevoked))
+		return berrors.InternalServerError("no certificate with serial %s and status other than %s", req.Serial, string(core.OCSPStatusRevoked))
 	}
 	return nil
 }

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1556,9 +1556,9 @@ func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb
 		return err
 	}
 	if rows == 0 {
-		// InternalServerError because we expected this certificate status to exist and
-		// not be revoked.
-		return berrors.InternalServerError("no certificate with serial %s and status other than %s", req.Serial, string(core.OCSPStatusRevoked))
+		// DuplicateError because we know this certificate exists but expected it
+		// to not be revoked.
+		return berrors.DuplicateError("no certificate with serial %s and status other than %s", req.Serial, string(core.OCSPStatusRevoked))
 	}
 	return nil
 }


### PR DESCRIPTION
If two revocation requests for the same cert arrive in rapid
succession, it is possible for one of them to complete in the
time between the other one's initial check (that the cert isn't
revoked already) and final database update. This causes
the db update to fail, and the request to end in a 500.

Other methods, such as new account registration, have a
three-step "check for duplicates, update db, if that failed
check for duplicates again" flow. This change updates the
cert revocation handlers to have a similar flow.

It returns the RFC 8555 `alreadyRevoked` from wfe2, to
match the error code returned by the initial duplicate
check. It returns the non-standardized 409 Conflict from
wfe, to match the code returned by that frontend's initial
duplicate check.

Fixes #5107