### PR TITLE
Remove certDER OCSP generation code path from CA

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -269,49 +269,19 @@ var ocspStatusToCode = map[string]int{
 // GenerateOCSP produces a new OCSP response and returns it
 func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	// req.Status, req.Reason, and req.RevokedAt are often 0, for non-revoked certs.
-	// Either CertDER or both (Serial and IssuerID) must be non-zero.
-	if core.IsAnyNilOrZero(req, req.CertDER) && core.IsAnyNilOrZero(req, req.Serial, req.IssuerID) {
+	if core.IsAnyNilOrZero(req, req.Serial, req.IssuerID) {
 		return nil, berrors.InternalServerError("Incomplete generate OCSP request")
 	}
 
-	var issuer *internalIssuer
-	var serial *big.Int
-	// Once the feature is enabled we need to support both RPCs that include
-	// IssuerID and those that don't as we still need to be able to update rows
-	// that didn't have an IssuerID set when they were created. Once this feature
-	// has been enabled for a full OCSP lifetime cycle we can remove this
-	// functionality.
-	if features.Enabled(features.StoreIssuerInfo) && req.IssuerID != 0 {
-		serialInt, err := core.StringToSerial(req.Serial)
-		if err != nil {
-			return nil, err
-		}
-		serial = serialInt
-		var ok bool
-		issuer, ok = ca.issuers.byID[issuance.IssuerID(req.IssuerID)]
-		if !ok {
-			return nil, fmt.Errorf("This CA doesn't have an issuer cert with ID %d", req.IssuerID)
-		}
-	} else {
-		cert, err := x509.ParseCertificate(req.CertDER)
-		if err != nil {
-			err := fmt.Errorf("parsing certificate for GenerateOCSP: %w", err)
-			ca.log.AuditErr(err.Error())
-			return nil, err
-		}
-
-		serial = cert.SerialNumber
-		cn := cert.Issuer.CommonName
-		issuer = ca.issuers.byName[cn]
-		if issuer == nil {
-			return nil, fmt.Errorf("This CA doesn't have an issuer cert with CommonName %q", cn)
-		}
-		err = cert.CheckSignatureFrom(issuer.cert.Certificate)
-		if err != nil {
-			return nil, fmt.Errorf("GenerateOCSP was asked to sign OCSP for cert "+
-				"%s from %q, but the cert's signature was not valid: %s.",
-				core.SerialToString(cert.SerialNumber), cn, err)
-		}
+	serialInt, err := core.StringToSerial(req.Serial)
+	if err != nil {
+		return nil, err
+	}
+	serial := serialInt
+	var ok bool
+	issuer, ok := ca.issuers.byID[issuance.IssuerID(req.IssuerID)]
+	if !ok {
+		return nil, fmt.Errorf("This CA doesn't have an issuer cert with ID %d", req.IssuerID)
 	}
 
 	now := ca.clk.Now().Truncate(time.Hour)
@@ -367,18 +337,18 @@ func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 	if err != nil {
 		return nil, err
 	}
+	issuerID := issuer.cert.ID()
 
 	ocspResp, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
-		CertDER: precertDER,
-		Status:  string(core.OCSPStatusGood),
+		Serial:   serialHex,
+		IssuerID: int64(issuerID),
+		Status:   string(core.OCSPStatusGood),
 	})
 	if err != nil {
 		err = berrors.InternalServerError(err.Error())
 		ca.log.AuditInfof("OCSP Signing failure: serial=[%s] err=[%s]", serialHex, err)
 		return nil, err
 	}
-
-	issuerID := issuer.cert.ID()
 
 	req := &sapb.AddCertificateRequest{
 		Der:      precertDER,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -477,6 +477,7 @@ func TestECDSAAllowList(t *testing.T) {
 
 func TestOCSP(t *testing.T) {
 	testCtx := setup(t)
+	_ = features.Set(map[string]bool{"NonCFSSLSigner": true})
 	sa := &mockSA{}
 	ca, err := NewCertificateAuthorityImpl(
 		sa,
@@ -498,13 +499,15 @@ func TestOCSP(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to create CA")
 
 	// Issue a certificate from the RSA issuer caCert, then check OCSP comes from the same issuer.
+	rsaIssuerID := ca.issuers.byAlg[x509.RSA].cert.ID()
 	rsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	rsaCert, err := x509.ParseCertificate(rsaCertPB.DER)
 	test.AssertNotError(t, err, "Failed to parse rsaCert")
 	rsaOCSPPB, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
-		CertDER: rsaCertPB.DER,
-		Status:  string(core.OCSPStatusGood),
+		Serial:   core.SerialToString(rsaCert.SerialNumber),
+		IssuerID: int64(rsaIssuerID),
+		Status:   string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "Failed to generate OCSP")
 	rsaOCSP, err := ocsp.ParseResponse(rsaOCSPPB.Response, caCert.Certificate)
@@ -514,13 +517,15 @@ func TestOCSP(t *testing.T) {
 	test.AssertEquals(t, rsaOCSP.SerialNumber.Cmp(rsaCert.SerialNumber), 0)
 
 	// Issue a certificate from the ECDSA issuer caCert2, then check OCSP comes from the same issuer.
+	ecdsaIssuerID := ca.issuers.byAlg[x509.ECDSA].cert.ID()
 	ecdsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	ecdsaCert, err := x509.ParseCertificate(ecdsaCertPB.DER)
 	test.AssertNotError(t, err, "Failed to parse ecdsaCert")
 	ecdsaOCSPPB, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
-		CertDER: ecdsaCertPB.DER,
-		Status:  string(core.OCSPStatusGood),
+		Serial:   core.SerialToString(ecdsaCert.SerialNumber),
+		IssuerID: int64(ecdsaIssuerID),
+		Status:   string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "Failed to generate OCSP")
 	ecdsaOCSP, err := ocsp.ParseResponse(ecdsaOCSPPB.Response, caCert2.Certificate)
@@ -529,12 +534,29 @@ func TestOCSP(t *testing.T) {
 	test.AssertEquals(t, ecdsaOCSP.RevocationReason, 0)
 	test.AssertEquals(t, ecdsaOCSP.SerialNumber.Cmp(ecdsaCert.SerialNumber), 0)
 
-	// Test that signatures are checked.
-	_, err = ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
-		CertDER: append(rsaCertPB.DER, byte(0)),
-		Status:  string(core.OCSPStatusGood),
+	// GenerateOCSP with a bad IssuerID should fail.
+	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
+		Serial:   core.SerialToString(rsaCert.SerialNumber),
+		IssuerID: int64(666),
+		Status:   string(core.OCSPStatusGood),
 	})
-	test.AssertError(t, err, "Generated OCSP for cert with bad signature")
+	test.AssertError(t, err, "GenerateOCSP didn't fail with invalid IssuerID")
+
+	// GenerateOCSP with a bad Serial should fail.
+	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
+		Serial:   "BADDECAF",
+		IssuerID: int64(rsaIssuerID),
+		Status:   string(core.OCSPStatusGood),
+	})
+	test.AssertError(t, err, "GenerateOCSP didn't fail with invalid Serial")
+
+	// GenerateOCSP with a valid-but-nonexistent Serial should fail.
+	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
+		Serial:   "03DEADBEEFBADDECAFFADEFACECAFE30",
+		IssuerID: int64(rsaIssuerID),
+		Status:   string(core.OCSPStatusGood),
+	})
+	test.AssertNotError(t, err, "GenerateOCSP failed with fake-but-valid Serial")
 }
 
 func TestInvalidCSRs(t *testing.T) {
@@ -1124,55 +1146,4 @@ func TestOrphanQueue(t *testing.T) {
 	if err != goque.ErrEmpty {
 		t.Fatalf("Unexpected error, wanted %q, got %q", goque.ErrEmpty, err)
 	}
-}
-
-func TestGenerateOCSPWithIssuerID(t *testing.T) {
-	testCtx := setup(t)
-	sa := &mockSA{}
-	_ = features.Set(map[string]bool{"StoreIssuerInfo": true})
-	ca, err := NewCertificateAuthorityImpl(
-		sa,
-		testCtx.pa,
-		testCtx.boulderIssuers,
-		nil,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
-		testCtx.serialPrefix,
-		testCtx.maxNames,
-		testCtx.ocspLifetime,
-		testCtx.keyPolicy,
-		nil,
-		0,
-		time.Second,
-		testCtx.logger,
-		testCtx.stats,
-		testCtx.fc)
-	test.AssertNotError(t, err, "Failed to create CA")
-
-	// GenerateOCSP with feature enabled + req contains bad IssuerID
-	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
-		IssuerID: int64(666),
-		Serial:   "DEADDEADDEADDEADDEADDEADDEADDEADDEAD",
-		Status:   string(core.OCSPStatusGood),
-	})
-	test.AssertError(t, err, "GenerateOCSP didn't fail with invalid IssuerID")
-
-	// GenerateOCSP with feature enabled + req contains good IssuerID
-	rsaIssuer := ca.issuers.byAlg[x509.RSA]
-	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
-		IssuerID: int64(rsaIssuer.cert.ID()),
-		Serial:   "DEADDEADDEADDEADDEADDEADDEADDEADDEAD",
-		Status:   string(core.OCSPStatusGood),
-	})
-	test.AssertNotError(t, err, "GenerateOCSP failed")
-
-	// GenerateOCSP with feature enabled + req doesn't contain IssuerID
-	issueReq := capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID}
-	cert, err := ca.IssuePrecertificate(ctx, &issueReq)
-	test.AssertNotError(t, err, "Failed to issue")
-	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
-		CertDER: cert.DER,
-		Status:  string(core.OCSPStatusGood),
-	})
-	test.AssertNotError(t, err, "GenerateOCSP failed")
 }

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -550,6 +550,7 @@ func TestOCSP(t *testing.T) {
 	test.AssertError(t, err, "GenerateOCSP didn't fail with invalid Serial")
 
 	// GenerateOCSP with the old certDER codepath should fail.
+	// TODO(#5079): Remove this test when the proto drops this field entirely.
 	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
 		CertDER: rsaCertPB.DER,
 		Status:  string(core.OCSPStatusGood),

--- a/ca/proto/ca.pb.go
+++ b/ca/proto/ca.pb.go
@@ -216,6 +216,7 @@ type GenerateOCSPRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// TODO(#5079): Remove certDER field.
 	CertDER   []byte `protobuf:"bytes,1,opt,name=certDER,proto3" json:"certDER,omitempty"`
 	Status    string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	Reason    int32  `protobuf:"varint,3,opt,name=reason,proto3" json:"reason,omitempty"`

--- a/ca/proto/ca.proto
+++ b/ca/proto/ca.proto
@@ -40,6 +40,7 @@ message IssueCertificateForPrecertificateRequest {
 
 // Exactly one of certDER or [serial and issuerID] must be set.
 message GenerateOCSPRequest {
+  // TODO(#5079): Remove certDER field.
   bytes certDER = 1;
   string status = 2;
   int32 reason = 3;

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -1,5 +1,11 @@
 {
   "backdate": "1h",
+  "issuerCerts": [
+    "/tmp/intermediate-cert-rsa-a.pem",
+    "/tmp/intermediate-cert-rsa-b.pem",
+    "/tmp/intermediate-cert-ecdsa-a.pem"
+  ],
+
 
   "syslog": {
     "stdoutlevel": 7,


### PR DESCRIPTION
Only process OCSP generation requests which are identified
by the certificate's serial number and the ID (not NameID,
unfortunately) of its issuer. Delete the code path which handled
OCSP generation for requests identified by the full DER of
the certificate in question.

Update existing tests to use serial+id to request OCSP, and
move test cases from the old `TestGenerateOCSPWithIssuerID`
into the default test method.

Part of #5079