### PR TITLE
bdns: replace direct type assertions with errors.As

### DIFF
--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -368,7 +368,8 @@ func TestDNSLookupHost(t *testing.T) {
 	t.Logf("%s - IP: %s, Err: %s", hostname, ip, err)
 	test.AssertError(t, err, "Should be an error")
 	expectedErr := DNSError{dns.TypeA, hostname, nil, dns.RcodeRefused}
-	if err, ok := err.(*DNSError); !ok || *err != expectedErr {
+	var dnserr *DNSError
+	if !errors.As(err, &dnserr) || *dnserr != expectedErr {
 		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expectedErr)
 	}
 }
@@ -379,13 +380,14 @@ func TestDNSNXDOMAIN(t *testing.T) {
 	hostname := "nxdomain.letsencrypt.org"
 	_, err := obj.LookupHost(context.Background(), hostname)
 	expected := DNSError{dns.TypeA, hostname, nil, dns.RcodeNameError}
-	if err, ok := err.(*DNSError); !ok || *err != expected {
+	var dnserr *DNSError
+	if !errors.As(err, &dnserr) || *dnserr != expected {
 		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expected)
 	}
 
 	_, err = obj.LookupTXT(context.Background(), hostname)
 	expected.recordType = dns.TypeTXT
-	if err, ok := err.(*DNSError); !ok || *err != expected {
+	if !errors.As(err, &dnserr) || *dnserr != expected {
 		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expected)
 	}
 }

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -369,7 +369,7 @@ func TestDNSLookupHost(t *testing.T) {
 	test.AssertError(t, err, "Should be an error")
 	expectedErr := DNSError{dns.TypeA, hostname, nil, dns.RcodeRefused}
 	var dnserr *DNSError
-	if !errors.As(err, &dnserr) || *dnserr != expectedErr {
+	if !(errors.As(err, &dnserr) && *dnserr == expectedErr) {
 		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expectedErr)
 	}
 }
@@ -381,13 +381,13 @@ func TestDNSNXDOMAIN(t *testing.T) {
 	_, err := obj.LookupHost(context.Background(), hostname)
 	expected := DNSError{dns.TypeA, hostname, nil, dns.RcodeNameError}
 	var dnserr *DNSError
-	if !errors.As(err, &dnserr) || *dnserr != expected {
+	if !(errors.As(err, &dnserr) && *dnserr == expected) {
 		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expected)
 	}
 
 	_, err = obj.LookupTXT(context.Background(), hostname)
 	expected.recordType = dns.TypeTXT
-	if !errors.As(err, &dnserr) || *dnserr != expected {
+	if !(errors.As(err, &dnserr) && *dnserr == expected) {
 		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expected)
 	}
 }


### PR DESCRIPTION
errors.As checks for a specific error in a wrapped error chain
(see https://golang.org/pkg/errors/#As) as opposed to asserting
that an error is of a specific type

Part of #5010