### PR TITLE
mailer: replacing error assertions with errors.As

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -158,18 +159,17 @@ func (m *mailer) run() error {
 			return err
 		}
 		if mailBody.Len() == 0 {
-			return fmt.Errorf("email body was empty after interpolation.")
+			return fmt.Errorf("email body was empty after interpolation")
 		}
 		err := m.mailer.SendMail([]string{address}, m.subject, mailBody.String())
 		if err != nil {
-			switch err.(type) {
-			case bmail.RecoverableSMTPError:
+			var recoverableSMTPErr *bmail.RecoverableSMTPError
+			if errors.As(err, &recoverableSMTPErr) {
 				m.log.Errf("address %q was rejected by server: %s", address, err)
 				continue
-			default:
-				return fmt.Errorf("sending mail %d of %d to %q: %s",
-					i, len(sortedAddresses), address, err)
 			}
+			return fmt.Errorf("sending mail %d of %d to %q: %s",
+				i, len(sortedAddresses), address, err)
 		}
 		sent++
 		m.clk.Sleep(m.sleepInterval)

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -159,11 +159,11 @@ func (m *mailer) run() error {
 			return err
 		}
 		if mailBody.Len() == 0 {
-			return fmt.Errorf("email body was empty after interpolation")
+			return fmt.Errorf("email body was empty after interpolation.")
 		}
 		err := m.mailer.SendMail([]string{address}, m.subject, mailBody.String())
 		if err != nil {
-			var recoverableSMTPErr *bmail.RecoverableSMTPError
+			var recoverableSMTPErr bmail.RecoverableSMTPError
 			if errors.As(err, &recoverableSMTPErr) {
 				m.log.Errf("address %q was rejected by server: %s", address, err)
 				continue

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -151,7 +151,7 @@ func New(
 	}
 }
 
-// NewDryRun constructs a Mailer suitable for doing a dry run. It simply logs each
+// New constructs a Mailer suitable for doing a dry run. It simply logs each
 // command that would have been run, at debug level.
 func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
 	return &MailerImpl{
@@ -313,7 +313,7 @@ type RecoverableSMTPError struct {
 	Message string
 }
 
-func (e *RecoverableSMTPError) Error() string {
+func (e RecoverableSMTPError) Error() string {
 	return e.Message
 }
 
@@ -369,7 +369,7 @@ func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
 			m.reconnect()
 		} else if errors.As(err, &protoErr) && recoverableErrorCodes[protoErr.Code] {
 			m.sendMailAttempts.WithLabelValues("failure", fmt.Sprintf("SMTP %d", protoErr.Code)).Inc()
-			return &RecoverableSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
+			return RecoverableSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
 		} else {
 			// If it wasn't an EOF error or a recoverable SMTP error it is unexpected and we
 			// return from SendMail() with the error

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -151,7 +151,7 @@ func New(
 	}
 }
 
-// New constructs a Mailer suitable for doing a dry run. It simply logs each
+// NewDryRun constructs a Mailer suitable for doing a dry run. It simply logs each
 // command that would have been run, at debug level.
 func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
 	return &MailerImpl{
@@ -313,7 +313,7 @@ type RecoverableSMTPError struct {
 	Message string
 }
 
-func (e RecoverableSMTPError) Error() string {
+func (e *RecoverableSMTPError) Error() string {
 	return e.Message
 }
 
@@ -336,6 +336,7 @@ var recoverableErrorCodes = map[int]bool{
 // SendMail sends an email to the provided list of recipients. The email body
 // is simple text.
 func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
+	var protoErr *textproto.Error
 	for {
 		err := m.sendOne(to, subject, msg)
 		if err == nil {
@@ -348,7 +349,7 @@ func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
 			m.reconnect()
 			// After reconnecting, loop around and try `sendOne` again.
 			continue
-		} else if protoErr, ok := err.(*textproto.Error); ok && protoErr.Code == 421 {
+		} else if errors.As(err, &protoErr) && protoErr.Code == 421 {
 			m.sendMailAttempts.WithLabelValues("failure", "SMTP 421").Inc()
 			/*
 			 *  If the error is an instance of `textproto.Error` with a SMTP error code,
@@ -366,9 +367,9 @@ func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
 			 * [0] - https://github.com/letsencrypt/boulder/issues/2249
 			 */
 			m.reconnect()
-		} else if protoErr, ok := err.(*textproto.Error); ok && recoverableErrorCodes[protoErr.Code] {
+		} else if errors.As(err, &protoErr) && recoverableErrorCodes[protoErr.Code] {
 			m.sendMailAttempts.WithLabelValues("failure", fmt.Sprintf("SMTP %d", protoErr.Code)).Inc()
-			return RecoverableSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
+			return &RecoverableSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
 		} else {
 			// If it wasn't an EOF error or a recoverable SMTP error it is unexpected and we
 			// return from SendMail() with the error

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -303,7 +303,7 @@ func TestBadEmailError(t *testing.T) {
 		t.Errorf("Expected SendMail() to return an RecoverableSMTPError, got nil")
 	}
 	expected := "401: 4.1.3 Bad recipient address syntax"
-	var rcptErr *RecoverableSMTPError
+	var rcptErr RecoverableSMTPError
 	if !errors.As(err, &rcptErr) {
 		t.Errorf("Expected SendMail() to return an RecoverableSMTPError, got a %T error: %v", err, err)
 	} else if rcptErr.Message != expected {

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -302,7 +303,8 @@ func TestBadEmailError(t *testing.T) {
 		t.Errorf("Expected SendMail() to return an RecoverableSMTPError, got nil")
 	}
 	expected := "401: 4.1.3 Bad recipient address syntax"
-	if rcptErr, ok := err.(RecoverableSMTPError); !ok {
+	var rcptErr *RecoverableSMTPError
+	if !errors.As(err, &rcptErr) {
 		t.Errorf("Expected SendMail() to return an RecoverableSMTPError, got a %T error: %v", err, err)
 	} else if rcptErr.Message != expected {
 		t.Errorf("SendMail() returned RecoverableSMTPError with wrong message. Got %q, expected %q\n",
@@ -380,7 +382,8 @@ func TestOtherError(t *testing.T) {
 		t.Errorf("Expected SendMail() to return an error, got nil")
 	}
 	expected := "999 1.1.1 This would probably be bad?"
-	if rcptErr, ok := err.(*textproto.Error); !ok {
+	var rcptErr *textproto.Error
+	if !errors.As(err, &rcptErr) {
 		t.Errorf("Expected SendMail() to return an textproto.Error, got a %T error: %v", err, err)
 	} else if rcptErr.Error() != expected {
 		t.Errorf("SendMail() returned textproto.Error with wrong message. Got %q, expected %q\n",


### PR DESCRIPTION
errors.As checks for a specific error in a wrapped error chain
(see https://golang.org/pkg/errors/#As) as opposed to asserting
that an error is of a specific type.

Part of #5010