### PR TITLE
web: replacing error assertions with errors.As

### DIFF
--- a/web/probs.go
+++ b/web/probs.go
@@ -64,12 +64,12 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 // error is of an type unknown to ProblemDetailsForError, it will return a
 // ServerInternal ProblemDetails.
 func ProblemDetailsForError(err error, msg string) *probs.ProblemDetails {
-	var problemDetailsErr *probs.ProblemDetails
-	var boulderErr *berrors.BoulderError
-	if errors.As(err, &problemDetailsErr) {
-		return problemDetailsErr
-	} else if errors.As(err, &boulderErr) {
-		return problemDetailsForBoulderError(boulderErr, msg)
+	var probsProblemDetails *probs.ProblemDetails
+	var berrorsBoulderError *berrors.BoulderError
+	if errors.As(err, &probsProblemDetails) {
+		return probsProblemDetails
+	} else if errors.As(err, &berrorsBoulderError) {
+		return problemDetailsForBoulderError(berrorsBoulderError, msg)
 	} else {
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/web/probs.go
+++ b/web/probs.go
@@ -59,7 +59,7 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 	return outProb
 }
 
-// ProblemDetailsForError turns an error into a ProblemDetails with the special
+// problemDetailsForError turns an error into a ProblemDetails with the special
 // case of returning the same error back if its already a ProblemDetails. If the
 // error is of an type unknown to ProblemDetailsForError, it will return a
 // ServerInternal ProblemDetails.


### PR DESCRIPTION
errors.As checks for a specific error in a wrapped error chain
(see https://golang.org/pkg/errors/#As) as opposed to asserting
that an error is of a specific type.

Part of #5010