### PR TITLE
config: replacing error assertions with errors.As

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -171,7 +171,8 @@ func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
 	s := ""
 	err := json.Unmarshal(b, &s)
 	if err != nil {
-		if _, ok := err.(*json.UnmarshalTypeError); ok {
+		var jsonUnmarshalTypeErr *json.UnmarshalTypeError
+		if errors.As(err, &jsonUnmarshalTypeErr) {
 			return ErrDurationMustBeString
 		}
 		return err


### PR DESCRIPTION
errors.As checks for a specific error in a wrapped error chain
(see https://golang.org/pkg/errors/#As) as opposed to asserting
that an error is of a specific type.

Part of #5010