### PR TITLE
akamai: replacing error assertions with errors.As

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -257,7 +257,7 @@ func (cpc *CachePurgeClient) purgeBatch(urls []string) error {
 			var errorFatal errFatal
 			if errors.As(err, &errorFatal) {
 				cpc.purges.WithLabelValues("fatal failure").Inc()
-				return errorFatal
+				return err
 			}
 			cpc.log.AuditErrf("Akamai cache purge failed, retrying: %s", err)
 			cpc.purges.WithLabelValues("retryable failure").Inc()

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -61,9 +61,9 @@ type CachePurgeClient struct {
 
 // errFatal is used by CachePurgeClient.purge to indicate that it failed for a
 // reason that cannot be remediated by retrying a purge request
-type errFatal string
+type errFatal struct{ msg string }
 
-func (e errFatal) Error() string { return string(e) }
+func (e *errFatal) Error() string { return e.msg }
 
 var (
 	// ErrAllRetriesFailed lets the caller of Purge to know if all the purge submission
@@ -183,7 +183,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 
 	reqJSON, err := json.Marshal(purgeReq)
 	if err != nil {
-		return errFatal(err.Error())
+		return &errFatal{err.Error()}
 	}
 	req, err := http.NewRequest(
 		"POST",
@@ -191,7 +191,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 		bytes.NewBuffer(reqJSON),
 	)
 	if err != nil {
-		return errFatal(err.Error())
+		return &errFatal{err.Error()}
 	}
 
 	// Create authorization header for request
@@ -201,7 +201,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 		core.RandomString(16),
 	)
 	if err != nil {
-		return errFatal(err.Error())
+		return &errFatal{err.Error()}
 	}
 	req.Header.Set("Authorization", authHeader)
 	req.Header.Set("Content-Type", "application/json")
@@ -236,7 +236,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 	}
 	if purgeInfo.HTTPStatus != http.StatusCreated || resp.StatusCode != http.StatusCreated {
 		if purgeInfo.HTTPStatus == http.StatusForbidden {
-			return errFatal(fmt.Sprintf("Unauthorized to purge URLs %q", urls))
+			return &errFatal{fmt.Sprintf("Unauthorized to purge URLs %q", urls)}
 		}
 		return fmt.Errorf("Unexpected HTTP status code '%d': %s", resp.StatusCode, string(body))
 	}
@@ -254,9 +254,10 @@ func (cpc *CachePurgeClient) purgeBatch(urls []string) error {
 
 		err := cpc.purge(urls)
 		if err != nil {
-			if _, ok := err.(errFatal); ok {
+			var errorFatal *errFatal
+			if errors.As(err, &errorFatal) {
 				cpc.purges.WithLabelValues("fatal failure").Inc()
-				return err
+				return errorFatal
 			}
 			cpc.log.AuditErrf("Akamai cache purge failed, retrying: %s", err)
 			cpc.purges.WithLabelValues("retryable failure").Inc()

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -66,7 +66,7 @@ func (ap *akamaiPurger) purge() error {
 		ap.mu.Lock()
 		ap.toPurge = append(urls, ap.toPurge...)
 		ap.mu.Unlock()
-		ap.log.Errf("Failed to purge %d URLs: %s", len(urls), err)
+		ap.log.Errf("Failed to purge %d URLs: %v", len(urls), err)
 		return err
 	}
 	return nil

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -66,7 +66,7 @@ func (ap *akamaiPurger) purge() error {
 		ap.mu.Lock()
 		ap.toPurge = append(urls, ap.toPurge...)
 		ap.mu.Unlock()
-		ap.log.Errf("Failed to purge %d URLs: %v", len(urls), err)
+		ap.log.Errf("Failed to purge %d URLs: %s", len(urls), err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
errors.As checks for a specific error in a wrapped error chain
(see https://golang.org/pkg/errors/#As) as opposed to asserting
that an error is of a specific type.

Part of #5010