### PR TITLE
cert-ceremonies: Only run once.

### DIFF
--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -75,9 +76,14 @@ func genCert(path string) error {
 func main() {
 	// If one of the output files already exists, assume this ran once
 	// already for the container and don't re-run.
-	if _, err := os.Stat("/tmp/root-signing-pub-rsa.pem"); err == nil {
+	outputFile := "/tmp/root-signing-pub-rsa.pem"
+	if _, err := os.Stat(outputFile); err == nil {
 		fmt.Println("skipping certificate generation: already exists")
 		return
+	} else if os.IsNotExist(err) {
+		// Good to continue
+	} else {
+		log.Fatal("statting %q: %s", outputFile, err)
 	}
 	// Create a SoftHSM slot for the root signing key
 	rootKeySlot, err := createSlot("root signing key (rsa)")

--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -73,6 +73,12 @@ func genCert(path string) error {
 }
 
 func main() {
+	// If one of the output files already exists, assume this ran once
+	// already for the container and don't re-run.
+	if _, err := os.Stat("/tmp/root-signing-pub-rsa.pem"); err == nil {
+		fmt.Println("skipping certificate generation: already exists")
+		return
+	}
 	// Create a SoftHSM slot for the root signing key
 	rootKeySlot, err := createSlot("root signing key (rsa)")
 	cmd.FailOnError(err, "failed creating softhsm2 slot for root key")

--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -77,13 +77,13 @@ func main() {
 	// If one of the output files already exists, assume this ran once
 	// already for the container and don't re-run.
 	outputFile := "/tmp/root-signing-pub-rsa.pem"
-	if _, err := os.Stat(outputFile); err == nil {
+	if loc, err := os.Stat(outputFile); err == nil && loc.Mode().IsRegular() {
 		fmt.Println("skipping certificate generation: already exists")
 		return
-	} else if os.IsNotExist(err) {
-		// Good to continue
-	} else {
-		log.Fatal("statting %q: %s", outputFile, err)
+	} else if err == nil && !loc.Mode().IsRegular() {
+		log.Fatalf("statting %q: not a regular file", outputFile)
+	} else if err != nil && !os.IsNotExist(err) {
+		log.Fatalf("statting %q: %s", outputFile, err)
 	}
 	// Create a SoftHSM slot for the root signing key
 	rootKeySlot, err := createSlot("root signing key (rsa)")


### PR DESCRIPTION
This allows running `docker-compose up` multiple times for manually
testing things that are useful across multiple runs.