### PR TITLE
policy: replacing error assertions with errors.As

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -392,7 +393,8 @@ func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentif
 	var subErrors []berrors.SubBoulderError
 	for _, ident := range idents {
 		if err := pa.willingToIssueWildcard(ident); err != nil {
-			if bErr, ok := err.(*berrors.BoulderError); ok {
+			var bErr *berrors.BoulderError
+			if errors.As(err, &bErr) {
 				subErrors = append(subErrors, berrors.SubBoulderError{
 					Identifier:   ident,
 					BoulderError: bErr})


### PR DESCRIPTION
errors.As checks for a specific error in a wrapped error chain
(see https://golang.org/pkg/errors/#As) as opposed to asserting
that an error is of a specific type.

Part of #5010