### PR TITLE
ca: replacing error assertions with errors.As

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -829,7 +829,8 @@ func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		if err != nil {
 			// If the Signing error was a pre-issuance lint error then marshal the
 			// linting errors to include in the audit err msg.
-			if lErr, ok := err.(*local.LintError); ok {
+			var lErr *local.LintError
+			if errors.As(err, &lErr) {
 				// NOTE(@cpu): We throw away the JSON marshal error here. If marshaling
 				// fails for some reason it's acceptable to log an empty string for the
 				// JSON component.


### PR DESCRIPTION
errors.As checks for a specific error in a wrapped error chain
(see https://golang.org/pkg/errors/#As) as opposed to asserting
that an error is of a specific type.

Part of #5010