### PR TITLE
Remove dead code from ocsp-updater

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"database/sql"
 	"errors"
 	"flag"
@@ -12,7 +10,6 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
@@ -57,10 +54,6 @@ type OCSPUpdater struct {
 	// these requests in parallel allows us to get higher total throughput.
 	parallelGenerateOCSPRequests int
 
-	purgerService akamaipb.AkamaiPurgerClient
-	// issuer is used to generate OCSP request URLs to purge
-	issuer *x509.Certificate
-
 	genStoreHistogram prometheus.Histogram
 	generatedCounter  *prometheus.CounterVec
 	storedCounter     *prometheus.CounterVec
@@ -71,9 +64,7 @@ func newUpdater(
 	clk clock.Clock,
 	dbMap ocspDB,
 	ogc capb.OCSPGeneratorClient,
-	apc akamaipb.AkamaiPurgerClient,
 	config OCSPUpdaterConfig,
-	issuerPath string,
 	log blog.Logger,
 ) (*OCSPUpdater, error) {
 	if config.OldOCSPBatchSize == 0 {
@@ -115,7 +106,6 @@ func newUpdater(
 		log:                          log,
 		ocspMinTimeToExpiry:          config.OCSPMinTimeToExpiry.Duration,
 		parallelGenerateOCSPRequests: config.ParallelGenerateOCSPRequests,
-		purgerService:                apc,
 		genStoreHistogram:            genStoreHistogram,
 		generatedCounter:             generatedCounter,
 		storedCounter:                storedCounter,
@@ -124,14 +114,6 @@ func newUpdater(
 		batchSize:                    config.OldOCSPBatchSize,
 		maxBackoff:                   config.SignFailureBackoffMax.Duration,
 		backoffFactor:                config.SignFailureBackoffFactor,
-	}
-
-	if updater.purgerService != nil {
-		issuer, err := core.LoadCert(issuerPath)
-		if err != nil {
-			return nil, err
-		}
-		updater.issuer = issuer
 	}
 
 	return &updater, nil
@@ -277,10 +259,6 @@ type config struct {
 	OCSPUpdater OCSPUpdaterConfig
 
 	Syslog cmd.SyslogConfig
-
-	Common struct {
-		IssuerCert string
-	}
 }
 
 // OCSPUpdaterConfig provides the various window tick times and batch sizes needed
@@ -295,47 +273,12 @@ type OCSPUpdaterConfig struct {
 	OCSPMinTimeToExpiry          cmd.ConfigDuration
 	ParallelGenerateOCSPRequests int
 
-	AkamaiBaseURL           string
-	AkamaiClientToken       string
-	AkamaiClientSecret      string
-	AkamaiAccessToken       string
-	AkamaiV3Network         string
-	AkamaiPurgeRetries      int
-	AkamaiPurgeRetryBackoff cmd.ConfigDuration
-
 	SignFailureBackoffFactor float64
 	SignFailureBackoffMax    cmd.ConfigDuration
 
-	SAService            *cmd.GRPCClientConfig
 	OCSPGeneratorService *cmd.GRPCClientConfig
-	AkamaiPurgerService  *cmd.GRPCClientConfig
 
 	Features map[string]bool
-}
-
-func setupClients(c OCSPUpdaterConfig, stats prometheus.Registerer, clk clock.Clock) (
-	capb.OCSPGeneratorClient,
-	akamaipb.AkamaiPurgerClient,
-) {
-	var tls *tls.Config
-	var err error
-	if c.TLS.CertFile != nil {
-		tls, err = c.TLS.Load()
-		cmd.FailOnError(err, "TLS config")
-	}
-	clientMetrics := bgrpc.NewClientMetrics(stats)
-	caConn, err := bgrpc.ClientSetup(c.OCSPGeneratorService, tls, clientMetrics, clk)
-	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to CA")
-	ogc := bgrpc.NewOCSPGeneratorClient(capb.NewOCSPGeneratorClient(caConn))
-
-	var apc akamaipb.AkamaiPurgerClient
-	if c.AkamaiPurgerService != nil {
-		apcConn, err := bgrpc.ClientSetup(c.AkamaiPurgerService, tls, clientMetrics, clk)
-		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to Akamai Purger service")
-		apc = akamaipb.NewAkamaiPurgerClient(apcConn)
-	}
-
-	return ogc, apc
 }
 
 func (updater *OCSPUpdater) tick() {
@@ -394,17 +337,21 @@ func main() {
 	sa.InitDBMetrics(dbMap, stats)
 
 	clk := cmd.Clock()
-	ogc, apc := setupClients(conf, stats, clk)
+
+	tlsConfig, err := c.OCSPUpdater.TLS.Load()
+	cmd.FailOnError(err, "TLS config")
+	clientMetrics := bgrpc.NewClientMetrics(stats)
+	caConn, err := bgrpc.ClientSetup(c.OCSPUpdater.OCSPGeneratorService, tlsConfig, clientMetrics, clk)
+	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to CA")
+	ogc := bgrpc.NewOCSPGeneratorClient(capb.NewOCSPGeneratorClient(caConn))
 
 	updater, err := newUpdater(
 		stats,
 		clk,
 		dbMap,
 		ogc,
-		apc,
 		// Necessary evil for now
 		conf,
-		c.Common.IssuerCert,
 		logger,
 	)
 	cmd.FailOnError(err, "Failed to create updater")

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
-	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
@@ -60,7 +59,6 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *db.WrappedMap, c
 		fc,
 		dbMap,
 		&mockOCSP{},
-		nil,
 		OCSPUpdaterConfig{
 			OldOCSPBatchSize:         1,
 			OldOCSPWindow:            cmd.ConfigDuration{Duration: time.Second},
@@ -69,7 +67,6 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *db.WrappedMap, c
 				Duration: time.Minute,
 			},
 		},
-		"",
 		blog.NewMock(),
 	)
 	test.AssertNotError(t, err, "Failed to create newUpdater")
@@ -84,10 +81,6 @@ func nowNano(fc clock.Clock) int64 {
 func TestGenerateAndStoreOCSPResponse(t *testing.T) {
 	updater, sa, _, fc, cleanUp := setup(t)
 	defer cleanUp()
-	issuer, err := core.LoadCert("../../test/test-ca2.pem")
-	test.AssertNotError(t, err, "Couldn't read test issuer certificate")
-	updater.issuer = issuer
-	updater.purgerService = akamaipb.NewAkamaiPurgerClient(nil)
 
 	reg := satest.CreateWorkingRegistration(t, sa)
 	parsedCert, err := core.LoadCert("test-cert.pem")

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -26,9 +26,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 6
-  },
-
-  "common": {
-    "issuerCert": "/tmp/intermediate-cert-rsa-a.pem"
   }
 }

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -14,10 +14,6 @@
       "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
       "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
     },
-    "saService": {
-      "serverAddress": "sa.boulder:9095",
-      "timeout": "15s"
-    },
     "ocspGeneratorService": {
       "serverAddress": "ca.boulder:9096",
       "timeout": "15s"
@@ -30,9 +26,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 6
-  },
-
-  "common": {
-    "issuerCert": "/tmp/intermediate-cert-rsa-a.pem"
   }
 }


### PR DESCRIPTION
The akamai purger is now a standalone service, and the ocsp-updater does
not talk to it directly. All of the code in the ocsp-updater related to
the akami purger is gated behind tests that the corresponding config
values are not nil, and the resulting objects are never used by the
service's business logic.

Now that all of the corresponding config stanzas have been removed
from our production configs, we can remove them from the config
struct definitions as well.

DO NOT SUBMIT until IN-5635 is resolved