### PR TITLE
Don't re-parse cert in GeneratePurgeURLs

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -357,13 +357,11 @@ func generateOCSPCacheKeys(req []byte, ocspServer string) []string {
 	}
 }
 
-// GeneratePurgeURLs ...
-func GeneratePurgeURLs(der []byte, issuer *x509.Certificate) ([]string, error) {
-	cert, err := x509.ParseCertificate(der)
-	if err != nil {
-		return nil, err
-	}
-
+// GeneratePurgeURLs generates akamai URLs that can be POSTed to in order to
+// purge akamai's cache of the corresponding OCSP responses. The URLs encode
+// the contents of the OCSP request, so this method constructs a full OCSP
+// request.
+func GeneratePurgeURLs(cert, issuer *x509.Certificate) ([]string, error) {
 	req, err := ocsp.CreateRequest(cert, issuer, nil)
 	if err != nil {
 		return nil, err

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1711,7 +1711,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, cert
 			return err
 		}
 	}
-	purgeURLs, err := akamai.GeneratePurgeURLs(cert.Raw, ra.issuer.Certificate)
+	purgeURLs, err := akamai.GeneratePurgeURLs(&cert, ra.issuer.Certificate)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The only caller of this function is the RA's `revokeCertificate`
method, which already has the hydrated `x509.Certificate`
version of the cert. There's no need to pass the raw version
and re-parse the DER again, just pass a reference to the
existing cert.