### PR TITLE
Use error wrapping for berrors and tests

### DIFF
--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -367,11 +367,8 @@ func TestDNSLookupHost(t *testing.T) {
 	ip, err = obj.LookupHost(context.Background(), hostname)
 	t.Logf("%s - IP: %s, Err: %s", hostname, ip, err)
 	test.AssertError(t, err, "Should be an error")
-	expectedErr := DNSError{dns.TypeA, hostname, nil, dns.RcodeRefused}
-	var dnserr *DNSError
-	if !(errors.As(err, &dnserr) && *dnserr == expectedErr) {
-		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expectedErr)
-	}
+	expectedErr := &DNSError{dns.TypeA, hostname, nil, dns.RcodeRefused}
+	test.AssertDeepEquals(t, err, expectedErr)
 }
 
 func TestDNSNXDOMAIN(t *testing.T) {
@@ -379,17 +376,12 @@ func TestDNSNXDOMAIN(t *testing.T) {
 
 	hostname := "nxdomain.letsencrypt.org"
 	_, err := obj.LookupHost(context.Background(), hostname)
-	expected := DNSError{dns.TypeA, hostname, nil, dns.RcodeNameError}
-	var dnserr *DNSError
-	if !(errors.As(err, &dnserr) && *dnserr == expected) {
-		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expected)
-	}
+	expected := &DNSError{dns.TypeA, hostname, nil, dns.RcodeNameError}
+	test.AssertDeepEquals(t, err, expected)
 
 	_, err = obj.LookupTXT(context.Background(), hostname)
 	expected.recordType = dns.TypeTXT
-	if !(errors.As(err, &dnserr) && *dnserr == expected) {
-		t.Errorf("Looking up %s, got %#v, expected %#v", hostname, err, expected)
-	}
+	test.AssertDeepEquals(t, err, expected)
 }
 
 func TestDNSLookupCAA(t *testing.T) {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -642,7 +642,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 		err = berrors.InternalServerError("issuance of duplicate final certificate requested: %s", serialHex)
 		ca.log.AuditErr(err.Error())
 		return nil, err
-	} else if !berrors.Is(err, berrors.NotFound) {
+	} else if !errors.Is(err, berrors.NotFound) {
 		return nil, fmt.Errorf("error checking for duplicate issuance of %s: %s", serialHex, err)
 	}
 	var scts []ct.SignedCertificateTimestamp
@@ -960,12 +960,12 @@ func (ca *CertificateAuthorityImpl) integrateOrphan() error {
 			Issued:   issuedNanos,
 			IssuerID: orphan.IssuerID,
 		})
-		if err != nil && !berrors.Is(err, berrors.Duplicate) {
+		if err != nil && !errors.Is(err, berrors.Duplicate) {
 			return fmt.Errorf("failed to store orphaned precertificate: %s", err)
 		}
 	} else {
 		_, err = ca.sa.AddCertificate(context.Background(), orphan.DER, orphan.RegID, nil, &issued)
-		if err != nil && !berrors.Is(err, berrors.Duplicate) {
+		if err != nil && !errors.Is(err, berrors.Duplicate) {
 			return fmt.Errorf("failed to store orphaned certificate: %s", err)
 		}
 	}

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -707,7 +707,7 @@ func TestInvalidCSRs(t *testing.T) {
 			issueReq := &capb.IssueCertificateRequest{Csr: serializedCSR, RegistrationID: arbitraryRegID}
 			_, err = ca.IssuePrecertificate(ctx, issueReq)
 
-			test.Assert(t, berrors.Is(err, testCase.errorType), "Incorrect error type returned")
+			test.AssertErrorIs(t, err, testCase.errorType)
 			test.AssertEquals(t, signatureCountByPurpose("cert", ca.signatureCount), 0)
 
 			test.AssertError(t, err, testCase.errorMessage)
@@ -749,7 +749,7 @@ func TestRejectValidityTooLong(t *testing.T) {
 	// Test that the CA rejects CSRs that would expire after the intermediate cert
 	_, err = ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
 	test.AssertError(t, err, "Cannot issue a certificate that expires after the intermediate certificate")
-	test.Assert(t, berrors.Is(err, berrors.InternalServer), "Incorrect error type returned")
+	test.AssertErrorIs(t, err, berrors.InternalServer)
 }
 
 func TestSingleAIAEnforcement(t *testing.T) {
@@ -1351,7 +1351,7 @@ func TestIssuePrecertificateLinting(t *testing.T) {
 	test.AssertError(t, err, "expected err from IssuePrecertificate with linttrapSigner")
 	// The local.LintError should have been converted to an internal server error
 	// berror with the correct message.
-	test.Assert(t, berrors.Is(err, berrors.InternalServer), "Incorrect error type returned")
+	test.AssertErrorIs(t, err, berrors.InternalServer)
 	test.AssertEquals(t, err.Error(), "failed to sign certificate: pre-issuance linting found 2 error results")
 
 	// We also expect that an AUDIT level error is logged that includes the expect

--- a/cmd/boulder-janitor/orders_test.go
+++ b/cmd/boulder-janitor/orders_test.go
@@ -95,7 +95,7 @@ func TestDeleteOrder(t *testing.T) {
 	// The order should be gone
 	_, err = ssa.GetOrder(ctx, &sapb.OrderRequest{Id: testOrder.Id})
 	test.AssertError(t, err, "found order after deleting it")
-	test.AssertEquals(t, berrors.Is(err, berrors.NotFound), true)
+	test.AssertErrorIs(t, err, berrors.NotFound)
 
 	// The orderToAuthz2 rows should be gone
 	var authzIDs []int64

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -153,7 +153,7 @@ func checkDER(sai certificateStorage, der []byte) (*x509.Certificate, orphanType
 	if err == nil {
 		return nil, orphanTyp, errAlreadyExists
 	}
-	if berrors.Is(err, berrors.NotFound) {
+	if errors.Is(err, berrors.NotFound) {
 		return orphan, orphanTyp, nil
 	}
 	return nil, orphanTyp, fmt.Errorf("Existing %s lookup failed: %s", orphanTyp, err)

--- a/ctpolicy/ctpolicy_test.go
+++ b/ctpolicy/ctpolicy_test.go
@@ -126,7 +126,7 @@ func TestGetSCTs(t *testing.T) {
 					t.Errorf("Error %q did not match expected regexp %q", err, tc.errRegexp)
 				}
 				if tc.berrorType != nil {
-					test.AssertEquals(t, berrors.Is(err, *tc.berrorType), true)
+					test.AssertErrorIs(t, err, *tc.berrorType)
 				}
 			}
 		})

--- a/db/map_test.go
+++ b/db/map_test.go
@@ -246,9 +246,7 @@ func testDbMap(t *testing.T) *WrappedMap {
 func TestWrappedMap(t *testing.T) {
 	mustDbErr := func(err error) ErrDatabaseOp {
 		var dbOpErr ErrDatabaseOp
-		if !errors.As(err, &dbOpErr) {
-			t.Fatalf("expected a ErrDatabaseOp, got %T: %v", err, err)
-		}
+		test.AssertErrorWraps(t, err, &dbOpErr)
 		return dbOpErr
 	}
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -30,6 +30,10 @@ const (
 	BadCSR
 )
 
+func (ErrorType) Error() string {
+	return "urn:ietf:params:acme:error"
+}
+
 // BoulderError represents internal Boulder errors
 type BoulderError struct {
 	Type      ErrorType
@@ -46,6 +50,10 @@ type SubBoulderError struct {
 
 func (be *BoulderError) Error() string {
 	return be.Detail
+}
+
+func (be *BoulderError) Unwrap() error {
+	return be.Type
 }
 
 // WithSubErrors returns a new BoulderError instance created by adding the
@@ -67,9 +75,9 @@ func New(errType ErrorType, msg string, args ...interface{}) error {
 }
 
 // Is is a convenience function for testing the internal type of an BoulderError
+// FIXME: delete this and replace calls with errors.Is when I'm sure this works.
 func Is(err error, errType ErrorType) bool {
-	var bErr *BoulderError
-	return errors.As(err, &bErr) && bErr.Type == errType
+	return errors.Is(err, errType)
 }
 
 func InternalServerError(msg string, args ...interface{}) error {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,13 +1,15 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/letsencrypt/boulder/identifier"
 )
 
-// ErrorType provides a coarse category for BoulderErrors
+// ErrorType provides a coarse category for BoulderErrors.
+// Objects of type ErrorType should never be directly returned by other
+// functions; instead use the methods below to create an appropriate
+// BoulderError wrapping one of these types.
 type ErrorType int
 
 const (
@@ -72,12 +74,6 @@ func New(errType ErrorType, msg string, args ...interface{}) error {
 		Type:   errType,
 		Detail: fmt.Sprintf(msg, args...),
 	}
-}
-
-// Is is a convenience function for testing the internal type of an BoulderError
-// FIXME: delete this and replace calls with errors.Is when I'm sure this works.
-func Is(err error, errType ErrorType) bool {
-	return errors.Is(err, errType)
 }
 
 func InternalServerError(msg string, args ...interface{}) error {

--- a/goodkey/blocked_test.go
+++ b/goodkey/blocked_test.go
@@ -3,7 +3,6 @@ package goodkey
 import (
 	"context"
 	"crypto"
-	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -98,6 +97,6 @@ func TestBlockedKeys(t *testing.T) {
 	for _, k := range blockedKeys {
 		err := testingPolicy.GoodKey(context.Background(), k)
 		test.AssertError(t, err, "test key was not blocked by key policy with block list")
-		test.Assert(t, errors.Is(err, ErrBadKey), "err was not goodkey.ErrBadKey")
+		test.AssertErrorIs(t, err, ErrBadKey)
 	}
 }

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"errors"
 	"fmt"
 	"math/big"
 	"testing"
@@ -285,7 +284,7 @@ func TestDBBlocklistReject(t *testing.T) {
 	test.AssertNotError(t, err, "ecdsa.GenerateKey failed")
 	err = policy.GoodKey(context.Background(), k.Public())
 	test.AssertError(t, err, "GoodKey didn't fail with a blocked key")
-	test.Assert(t, errors.Is(err, ErrBadKey), "returned error is wrong type")
+	test.AssertErrorIs(t, err, ErrBadKey)
 	test.AssertEquals(t, err.Error(), "public key is forbidden")
 }
 

--- a/grpc/creds/creds_test.go
+++ b/grpc/creds/creds_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"math/big"
 	"net"
 	"net/http/httptest"
@@ -58,9 +57,7 @@ func TestServerTransportCredentials(t *testing.T) {
 	}
 	err = bcreds.validateClient(wrongState)
 	var errSANNotAccepted ErrSANNotAccepted
-	if !errors.As(err, &errSANNotAccepted) {
-		t.Errorf("Expected error of type ErrSANNotAccepted, got %T: %s", err, err)
-	}
+	test.AssertErrorWraps(t, err, &errSANNotAccepted)
 
 	// A creds should accept peers that have a leaf certificate with a SAN
 	// that is on the accepted list
@@ -197,6 +194,5 @@ func TestClientReset(t *testing.T) {
 	_, _, err := tc.ClientHandshake(context.Background(), "T:1010", &brokenConn{})
 	test.AssertError(t, err, "ClientHandshake succeeded with brokenConn")
 	var netErr net.Error
-	ok := errors.As(err, &netErr)
-	test.Assert(t, ok, "returned error doesn't have a Temporary method")
+	test.AssertErrorWraps(t, err, &netErr)
 }

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -304,12 +303,8 @@ func TestBadEmailError(t *testing.T) {
 	}
 	expected := "401: 4.1.3 Bad recipient address syntax"
 	var rcptErr RecoverableSMTPError
-	if !errors.As(err, &rcptErr) {
-		t.Errorf("Expected SendMail() to return an RecoverableSMTPError, got a %T error: %v", err, err)
-	} else if rcptErr.Message != expected {
-		t.Errorf("SendMail() returned RecoverableSMTPError with wrong message. Got %q, expected %q\n",
-			rcptErr.Message, expected)
-	}
+	test.AssertErrorWraps(t, err, &rcptErr)
+	test.AssertEquals(t, rcptErr.Message, expected)
 }
 
 func TestReconnectSMTP421(t *testing.T) {
@@ -383,12 +378,8 @@ func TestOtherError(t *testing.T) {
 	}
 	expected := "999 1.1.1 This would probably be bad?"
 	var rcptErr *textproto.Error
-	if !errors.As(err, &rcptErr) {
-		t.Errorf("Expected SendMail() to return an textproto.Error, got a %T error: %v", err, err)
-	} else if rcptErr.Error() != expected {
-		t.Errorf("SendMail() returned textproto.Error with wrong message. Got %q, expected %q\n",
-			rcptErr.Error(), expected)
-	}
+	test.AssertErrorWraps(t, err, &rcptErr)
+	test.AssertEquals(t, rcptErr.Error(), expected)
 
 	m, l, cleanUp = setup(t)
 	defer cleanUp()

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -331,7 +330,7 @@ func TestWillingToIssueWildcards(t *testing.T) {
 	test.AssertError(t, err, "Expected err from WillingToIssueWildcards")
 
 	var berr *berrors.BoulderError
-	test.AssertEquals(t, errors.As(err, &berr), true)
+	test.AssertErrorWraps(t, err, &berr)
 	test.AssertEquals(t, len(berr.SubErrors), 2)
 	test.AssertEquals(t, berr.Error(), "Cannot issue for \"letsdecrypt.org\": The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy (and 1 more problems. Refer to sub-problems for more information.)")
 
@@ -356,7 +355,7 @@ func TestWillingToIssueWildcards(t *testing.T) {
 	// It should error
 	test.AssertError(t, err, "Expected err from WillingToIssueWildcards")
 
-	test.AssertEquals(t, errors.As(err, &berr), true)
+	test.AssertErrorWraps(t, err, &berr)
 	// There should be *no* suberrors because there was only one error overall.
 	test.AssertEquals(t, len(berr.SubErrors), 0)
 	test.AssertEquals(t, berr.Error(), "Cannot issue for \"letsdecrypt.org\": The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy")

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -581,7 +581,7 @@ func (ra *RegistrationAuthorityImpl) NewAuthorization(ctx context.Context, reque
 		ValidUntil:      ra.clk.Now().Add(time.Hour).UnixNano(),
 	}
 	pendingPB, err := ra.SA.GetPendingAuthorization2(ctx, req)
-	if err != nil && !berrors.Is(err, berrors.NotFound) {
+	if err != nil && !errors.Is(err, berrors.NotFound) {
 		return core.Authorization{}, berrors.InternalServerError(
 			"unable to get pending authorization for regID: %d, identifier: %s: %s",
 			regID,
@@ -1856,7 +1856,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	})
 	// If there was an error and it wasn't an acceptable "NotFound" error, return
 	// immediately
-	if err != nil && !berrors.Is(err, berrors.NotFound) {
+	if err != nil && !errors.Is(err, berrors.NotFound) {
 		return nil, err
 	}
 	// If there was an order, return it

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -1,7 +1,6 @@
 package sa
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/letsencrypt/boulder/grpc"
@@ -37,7 +36,7 @@ func TestModelToRegistrationBadJSON(t *testing.T) {
 	})
 	test.AssertError(t, err, "expected error from truncated reg model key")
 	var badJSONErr errBadJSON
-	test.AssertEquals(t, errors.As(err, &badJSONErr), true)
+	test.AssertErrorWraps(t, err, &badJSONErr)
 	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
 }
 
@@ -172,7 +171,7 @@ func TestModelToChallengeBadJSON(t *testing.T) {
 			_, err := modelToChallenge(tc.Model)
 			test.AssertError(t, err, "expected error from modelToChallenge")
 			var badJSONErr errBadJSON
-			test.AssertEquals(t, errors.As(err, &badJSONErr), true)
+			test.AssertErrorWraps(t, err, &badJSONErr)
 			test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
 		})
 	}
@@ -187,7 +186,7 @@ func TestModelToOrderBadJSON(t *testing.T) {
 	})
 	test.AssertError(t, err, "expected error from modelToOrder")
 	var badJSONErr errBadJSON
-	test.AssertEquals(t, errors.As(err, &badJSONErr), true)
+	test.AssertErrorWraps(t, err, &badJSONErr)
 	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
 }
 
@@ -219,7 +218,7 @@ func TestPopulateAttemptedFieldsBadJSON(t *testing.T) {
 			err := populateAttemptedFields(*tc.Model, &corepb.Challenge{})
 			test.AssertError(t, err, "expected error from populateAttemptedFields")
 			var badJSONErr errBadJSON
-			test.AssertEquals(t, errors.As(err, &badJSONErr), true)
+			test.AssertErrorWraps(t, err, &badJSONErr)
 			test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
 		})
 	}

--- a/sa/precertificates_test.go
+++ b/sa/precertificates_test.go
@@ -93,12 +93,8 @@ func TestAddPrecertificate(t *testing.T) {
 			Issued:   issuedTime.UnixNano(),
 			IssuerID: 1,
 		})
-		if err == nil {
-			t.Fatalf("Expected error inserting duplicate precertificate, got none")
-		}
-		if !berrors.Is(err, berrors.Duplicate) {
-			t.Fatalf("Expected berrors.Duplicate inserting duplicate precertificate, got %#v", err)
-		}
+		test.AssertError(t, err, "Expected error inserting duplicate precertificate")
+		test.AssertErrorIs(t, err, berrors.Duplicate)
 	}
 
 	addPrecert(true)

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -988,9 +987,7 @@ func TestSetOrderProcessing(t *testing.T) {
 	// Try to set the same order to be processing again. We should get an error.
 	err = sa.SetOrderProcessing(context.Background(), order)
 	test.AssertError(t, err, "Set the same order processing twice. This should have been an error.")
-	if !errors.Is(err, berrors.OrderNotReady) {
-		t.Errorf("Wrong error when setting an order to processing twice. Expected OrderNotReady, got %#v", err)
-	}
+	test.AssertErrorIs(t, err, berrors.OrderNotReady)
 }
 
 func TestFinalizeOrder(t *testing.T) {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -171,20 +171,14 @@ func TestNoSuchRegistrationErrors(t *testing.T) {
 	defer cleanUp()
 
 	_, err := sa.GetRegistration(ctx, 100)
-	if !berrors.Is(err, berrors.NotFound) {
-		t.Errorf("GetRegistration: expected a berrors.NotFound type error, got %T type error (%s)", err, err)
-	}
+	test.AssertErrorIs(t, err, berrors.NotFound)
 
 	jwk := satest.GoodJWK()
 	_, err = sa.GetRegistrationByKey(ctx, jwk)
-	if !berrors.Is(err, berrors.NotFound) {
-		t.Errorf("GetRegistrationByKey: expected a berrors.NotFound type error, got %T type error (%s)", err, err)
-	}
+	test.AssertErrorIs(t, err, berrors.NotFound)
 
 	err = sa.UpdateRegistration(ctx, core.Registration{ID: 100, Key: jwk})
-	if !berrors.Is(err, berrors.NotFound) {
-		t.Errorf("UpdateRegistration: expected a berrors.NotFound type error, got %T type error (%v)", err, err)
-	}
+	test.AssertErrorIs(t, err, berrors.NotFound)
 }
 
 func TestAddCertificate(t *testing.T) {
@@ -1108,7 +1102,7 @@ func TestGetAuthorizationNoRows(t *testing.T) {
 	id := int64(123)
 	_, err := sa.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: id})
 	test.AssertError(t, err, "Didn't get an error looking up non-existent authz ID")
-	test.Assert(t, berrors.Is(err, berrors.NotFound), "GetAuthorization did not return a berrors.NotFound error")
+	test.AssertErrorIs(t, err, berrors.NotFound)
 }
 
 func TestGetAuthorizations2(t *testing.T) {
@@ -1290,7 +1284,7 @@ func TestGetOrderForNames(t *testing.T) {
 	// We expect the result to return an error
 	test.AssertError(t, err, "sa.GetOrderForNames did not return an error for an empty result")
 	// The error should be a notfound error
-	test.AssertEquals(t, berrors.Is(err, berrors.NotFound), true)
+	test.AssertErrorIs(t, err, berrors.NotFound)
 	// The result should be nil
 	test.Assert(t, result == nil, "sa.GetOrderForNames for non-existent order returned non-nil result")
 
@@ -1327,7 +1321,7 @@ func TestGetOrderForNames(t *testing.T) {
 	// It should error
 	test.AssertError(t, err, "sa.GetOrderForNames did not return an error for an empty result")
 	// The error should be a notfound error
-	test.AssertEquals(t, berrors.Is(err, berrors.NotFound), true)
+	test.AssertErrorIs(t, err, berrors.NotFound)
 	// The result should be nil
 	test.Assert(t, result == nil, "sa.GetOrderForNames for diff AcctID returned non-nil result")
 
@@ -1343,7 +1337,7 @@ func TestGetOrderForNames(t *testing.T) {
 	// It should error since there is no result
 	test.AssertError(t, err, "sa.GetOrderForNames did not return an error for an empty result")
 	// The error should be a notfound error
-	test.AssertEquals(t, berrors.Is(err, berrors.NotFound), true)
+	test.AssertErrorIs(t, err, berrors.NotFound)
 	// The result should be nil because the initial order expired & we don't want
 	// to return expired orders
 	test.Assert(t, result == nil, "sa.GetOrderForNames returned non-nil result for expired order case")
@@ -1396,7 +1390,7 @@ func TestGetOrderForNames(t *testing.T) {
 	// It should error since a valid order should not be reused.
 	test.AssertError(t, err, "sa.GetOrderForNames did not return an error for an empty result")
 	// The error should be a notfound error
-	test.AssertEquals(t, berrors.Is(err, berrors.NotFound), true)
+	test.AssertErrorIs(t, err, berrors.NotFound)
 	// The result should be nil because the one matching order has been finalized
 	// already
 	test.Assert(t, result == nil, "sa.GetOrderForNames returned non-nil result for finalized order case")
@@ -2204,7 +2198,7 @@ func TestGetOrderExpired(t *testing.T) {
 		Id: order.Id,
 	})
 	test.AssertError(t, err, "GetOrder didn't fail for an expired order")
-	test.Assert(t, berrors.Is(err, berrors.NotFound), "GetOrder error wasn't of type NotFound")
+	test.AssertErrorIs(t, err, berrors.NotFound)
 }
 
 func TestBlockedKey(t *testing.T) {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -993,7 +994,7 @@ func TestSetOrderProcessing(t *testing.T) {
 	// Try to set the same order to be processing again. We should get an error.
 	err = sa.SetOrderProcessing(context.Background(), order)
 	test.AssertError(t, err, "Set the same order processing twice. This should have been an error.")
-	if !berrors.Is(err, berrors.OrderNotReady) {
+	if !errors.Is(err, berrors.OrderNotReady) {
 		t.Errorf("Wrong error when setting an order to processing twice. Expected OrderNotReady, got %#v", err)
 	}
 }

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -2,7 +2,6 @@ package sa
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/letsencrypt/boulder/core"
@@ -48,7 +47,7 @@ func TestAcmeIdentifierBadJSON(t *testing.T) {
 	err := scanner.Binder(&badJSON, &out)
 	test.AssertError(t, err, "expected error from scanner.Binder")
 	var badJSONErr errBadJSON
-	test.AssertEquals(t, errors.As(err, &badJSONErr), true)
+	test.AssertErrorWraps(t, err, &badJSONErr)
 	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
 }
 
@@ -85,7 +84,7 @@ func TestJSONWebKeyBadJSON(t *testing.T) {
 	err := scanner.Binder(&badJSON, &out)
 	test.AssertError(t, err, "expected error from scanner.Binder")
 	var badJSONErr errBadJSON
-	test.AssertEquals(t, errors.As(err, &badJSONErr), true)
+	test.AssertErrorWraps(t, err, &badJSONErr)
 	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
 }
 

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -29,12 +28,9 @@ func TestTooBigOrderError(t *testing.T) {
 	test.AssertError(t, err, "authAndIssue failed")
 
 	var prob acme.Problem
-	if !errors.As(err, &prob) {
-		t.Fatalf("expected problem result, got %#v\n", err)
-	} else {
-		test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:malformed")
-		test.AssertEquals(t, prob.Detail, "Error creating new order :: Order cannot contain more than 100 DNS names")
-	}
+	test.AssertErrorWraps(t, err, &prob)
+	test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:malformed")
+	test.AssertEquals(t, prob.Detail, "Error creating new order :: Order cannot contain more than 100 DNS names")
 }
 
 // TestAccountEmailError tests that registering a new account, or updating an
@@ -132,12 +128,9 @@ func TestAccountEmailError(t *testing.T) {
 			// First try registering a new account and ensuring the expected problem occurs
 			var prob acme.Problem
 			if _, err := makeClient(tc.contacts...); err != nil {
-				if !errors.As(err, &prob) {
-					t.Fatalf("expected acme.Problem error got %#v", err)
-				} else {
-					test.AssertEquals(t, prob.Type, tc.expectedProbType)
-					test.AssertEquals(t, prob.Detail, createErrorPrefix+tc.expectedProbDetail)
-				}
+				test.AssertErrorWraps(t, err, &prob)
+				test.AssertEquals(t, prob.Type, tc.expectedProbType)
+				test.AssertEquals(t, prob.Detail, createErrorPrefix+tc.expectedProbDetail)
 			} else if err == nil {
 				t.Errorf("expected %s type problem for %q, got nil",
 					tc.expectedProbType, strings.Join(tc.contacts, ","))
@@ -148,12 +141,9 @@ func TestAccountEmailError(t *testing.T) {
 			c, err := makeClient("mailto:valid@valid.com")
 			test.AssertNotError(t, err, "failed to create account with valid contact")
 			if _, err := c.UpdateAccount(c.Account, tc.contacts...); err != nil {
-				if !errors.As(err, &prob) {
-					t.Fatalf("expected acme.Problem error after updating account got %#v", err)
-				} else {
-					test.AssertEquals(t, prob.Type, tc.expectedProbType)
-					test.AssertEquals(t, prob.Detail, updateErrorPrefix+tc.expectedProbDetail)
-				}
+				test.AssertErrorWraps(t, err, &prob)
+				test.AssertEquals(t, prob.Type, tc.expectedProbType)
+				test.AssertEquals(t, prob.Detail, updateErrorPrefix+tc.expectedProbDetail)
 			} else if err == nil {
 				t.Errorf("expected %s type problem after updating account to %q, got nil",
 					tc.expectedProbType, strings.Join(tc.contacts, ","))

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -48,6 +49,23 @@ func AssertError(t *testing.T, err error, message string) {
 	t.Helper()
 	if err == nil {
 		t.Fatalf("%s: expected error but received none", message)
+	}
+}
+
+// AssertErrorWraps checks that err can be unwrapped into the given target.
+// NOTE: Has the side effect of actually performing that unwrapping.
+func AssertErrorWraps(t *testing.T, err error, target interface{}) {
+	t.Helper()
+	if !errors.As(err, target) {
+		t.Fatalf("error does not wrap an error of the expected type: %q !> %+T", err.Error(), target)
+	}
+}
+
+// AssertErrorIs checks that err wraps the given error
+func AssertErrorIs(t *testing.T, err error, target error) {
+	t.Helper()
+	if !errors.Is(err, target) {
+		t.Fatalf("error does not wrap expected error: %q !> %q", err.Error(), target.Error())
 	}
 }
 

--- a/va/va.go
+++ b/va/va.go
@@ -293,13 +293,13 @@ func detailedError(err error) *probs.ProblemDetails {
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return probs.ConnectionFailure("Timeout after connect (your server may be slow or overloaded)")
 	}
-	if berrors.Is(err, berrors.ConnectionFailure) {
+	if errors.Is(err, berrors.ConnectionFailure) {
 		return probs.ConnectionFailure(err.Error())
 	}
-	if berrors.Is(err, berrors.Unauthorized) {
+	if errors.Is(err, berrors.Unauthorized) {
 		return probs.Unauthorized(err.Error())
 	}
-	if berrors.Is(err, berrors.DNS) {
+	if errors.Is(err, berrors.DNS) {
 		return probs.DNS(err.Error())
 	}
 

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -458,7 +458,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 	account, err := wfe.SA.GetRegistration(ctx, accountID)
 	if err != nil {
 		// If the account isn't found, return a suitable problem
-		if berrors.Is(err, berrors.NotFound) {
+		if errors.Is(err, berrors.NotFound) {
 			wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDNotFound"}).Inc()
 			return nil, nil, probs.AccountDoesNotExist(fmt.Sprintf(
 				"Account %q not found", accountURL))


### PR DESCRIPTION
This change adds two new test assertion helpers, `AssertErrorIs`
and `AssertErrorWraps`. The former is a wrapper around `errors.Is`,
and asserts that the error's wrapping chain contains a specific (i.e.
singleton) error. The latter is a wrapper around `errors.As`, and
asserts that the error's wrapping chain contains any error which is
of the given type; it also has the same unwrapping side effect as
`errors.As`, which can be useful for further assertions about the
contents of the error.

It also makes two small changes to our `berrors` package, namely
making `berrors.ErrorType` itself an error rather than just an int,
and giving `berrors.BoulderError` an `Unwrap()` method which
exposes that inner `ErrorType`. This allows us to use the two new
helpers above to make assertions about berrors, rather than
having to hand-roll equality assertions about their types.

Finally, it takes advantage of the two changes above to greatly
simplify many of the assertions in our tests, removing conditional
checks and replacing them with simple assertions.