### PR TITLE
Clean up akamai purger configs

### DIFF
--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -1,33 +1,28 @@
 {
-    "akamaiPurger": {
-        "debugAddr": ":9666",
-        "purgeInterval": "1ms",
-        "baseURL": "http://localhost:6789",
-        "clientToken": "its-a-token",
-        "clientSecret": "its-a-secret",
-        "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
-        "v3Network": "staging",
-        "tls": {
-          "caCertfile": "test/grpc-creds/minica.pem",
-          "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
-          "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
-        },
-        "grpc": {
-          "address": ":9099",
-          "clientNames": [
-            "health-checker.boulder",
-            "ra.boulder"
-          ]
-        }
+  "akamaiPurger": {
+    "debugAddr": ":9666",
+    "purgeInterval": "1ms",
+    "baseURL": "http://localhost:6789",
+    "clientToken": "its-a-token",
+    "clientSecret": "its-a-secret",
+    "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
+    "v3Network": "staging",
+    "tls": {
+      "caCertfile": "test/grpc-creds/minica.pem",
+      "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
+      "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
     },
-  
-    "syslog": {
-      "stdoutlevel": 6,
-      "sysloglevel": 6
-    },
-  
-    "common": {
-      "issuerCert": "/tmp/intermediate-cert-rsa-a.pem"
+    "grpc": {
+      "address": ":9099",
+      "clientNames": [
+        "health-checker.boulder",
+        "ra.boulder"
+      ]
     }
+  },
+
+  "syslog": {
+    "stdoutlevel": 6,
+    "sysloglevel": 6
   }
-  
+}

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -1,33 +1,28 @@
 {
-    "akamaiPurger": {
-        "debugAddr": ":9666",
-        "purgeInterval": "1ms",
-        "baseURL": "http://localhost:6789",
-        "clientToken": "its-a-token",
-        "clientSecret": "its-a-secret",
-        "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
-        "v3Network": "staging",
-        "tls": {
-          "caCertfile": "test/grpc-creds/minica.pem",
-          "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
-          "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
-        },
-        "grpc": {
-          "address": ":9099",
-          "clientNames": [
-            "health-checker.boulder",
-            "ra.boulder"
-          ]
-        }
+  "akamaiPurger": {
+    "debugAddr": ":9666",
+    "purgeInterval": "1ms",
+    "baseURL": "http://localhost:6789",
+    "clientToken": "its-a-token",
+    "clientSecret": "its-a-secret",
+    "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
+    "v3Network": "staging",
+    "tls": {
+      "caCertfile": "test/grpc-creds/minica.pem",
+      "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
+      "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
     },
-  
-    "syslog": {
-      "stdoutlevel": 6,
-      "sysloglevel": 6
-    },
-  
-    "common": {
-      "issuerCert": "/tmp/intermediate-cert-rsa-a.pem"
+    "grpc": {
+      "address": ":9099",
+      "clientNames": [
+        "health-checker.boulder",
+        "ra.boulder"
+      ]
     }
+  },
+
+  "syslog": {
+    "stdoutlevel": 6,
+    "sysloglevel": 6
   }
-  
+}


### PR DESCRIPTION
These configs contained a `common.issuerCert` field which is not
read or used by the akamai-purger service. This change removes
is for clarity.

In addition, these files had irregular indentation. This change cleans
them up to use two-space indents throughout.