### PR TITLE
Refactoring tls.Config mutation out of grpc

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -138,6 +138,11 @@ func (t *TLSConfig) Load() (*tls.Config, error) {
 		ClientCAs:    rootCAs,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{cert},
+		// Set the only acceptable TLS version to 1.2 and the only acceptable cipher suite
+		// to ECDHE-RSA-CHACHA20-POLY1305.
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS12,
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
 	}, nil
 }
 

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -32,11 +32,6 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientM
 		return nil, errNilTLS
 	}
 
-	// Set the only acceptable TLS version to 1.2 and the only acceptable cipher suite
-	// to ECDHE-RSA-CHACHA20-POLY1305.
-	tlsConfig.MinVersion, tlsConfig.MaxVersion = tls.VersionTLS12, tls.VersionTLS12
-	tlsConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305}
-
 	ci := clientInterceptor{c.Timeout.Duration, metrics, clk}
 	host, _, err := net.SplitHostPort(c.ServerAddress)
 	if err != nil {

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -31,11 +31,6 @@ func NewServer(c *cmd.GRPCServerConfig, tlsConfig *tls.Config, metrics serverMet
 		acceptedSANs[name] = struct{}{}
 	}
 
-	// Set the only acceptable TLS version to 1.2 and the only acceptable cipher suite
-	// to ECDHE-RSA-CHACHA20-POLY1305.
-	tlsConfig.MinVersion, tlsConfig.MaxVersion = tls.VersionTLS12, tls.VersionTLS12
-	tlsConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305}
-
 	creds, err := bcreds.NewServerCredentials(tlsConfig, acceptedSANs)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
In all boulder services, we construct a single tls.Config object
and then pass it into multiple gRPC setup methods. In all boulder
services but one, we pass the object into multiple clients, and
just one server. In general, this is safe, because all of the client
setup happens on the main thread, and the server setup similarly
happens on the main thread before spinning off the gRPC server
goroutine.

In the CA, we do the above and pass the tlsConfig object into two
gRPC server setup functions. Thus the first server goroutine races
with the setup of the second server.

This change removes the post-hoc assignment of MinVersion,
MaxVersion, and CipherSuites of the tls.Config object passed
to grpc.ClientSetup and grpc.NewServer. And adds those same
values to the cmd.TLSConfig.Load, the method responsible for
constructing the tls.Config object before it's passed to
grpc.ClientSetup and grpc.NewServer.

Part of #5159