### PR TITLE
Remove nearly-unused WrongAuthorizationState error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -22,6 +22,7 @@ const (
 	RejectedIdentifier
 	InvalidEmail
 	ConnectionFailure
+	_ // Reserved, previously WrongAuthorizationState
 	CAA
 	MissingSCTs
 	Duplicate

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -22,7 +22,6 @@ const (
 	RejectedIdentifier
 	InvalidEmail
 	ConnectionFailure
-	WrongAuthorizationState
 	CAA
 	MissingSCTs
 	Duplicate
@@ -109,10 +108,6 @@ func InvalidEmailError(msg string, args ...interface{}) error {
 
 func ConnectionFailureError(msg string, args ...interface{}) error {
 	return New(ConnectionFailure, msg, args...)
-}
-
-func WrongAuthorizationStateError(msg string, args ...interface{}) error {
-	return New(WrongAuthorizationState, msg, args...)
 }
 
 func CAAError(msg string, args ...interface{}) error {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1532,17 +1532,16 @@ func (ra *RegistrationAuthorityImpl) recordValidation(ctx context.Context, authI
 func (ra *RegistrationAuthorityImpl) PerformValidation(
 	ctx context.Context,
 	req *rapb.PerformValidationRequest) (*corepb.Authorization, error) {
-	base, err := bgrpc.PBToAuthz(req.Authz)
+	authz, err := bgrpc.PBToAuthz(req.Authz)
 	if err != nil {
 		return nil, err
 	}
 
 	// Refuse to update expired authorizations
-	if base.Expires == nil || base.Expires.Before(ra.clk.Now()) {
+	if authz.Expires == nil || authz.Expires.Before(ra.clk.Now()) {
 		return nil, berrors.MalformedError("expired authorization")
 	}
 
-	authz := base
 	challIndex := int(req.ChallengeIndex)
 	if challIndex >= len(authz.Challenges) {
 		return nil,
@@ -1566,7 +1565,7 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 	}
 
 	if authz.Status != core.StatusPending {
-		return nil, berrors.WrongAuthorizationStateError("authorization must be pending")
+		return nil, berrors.MalformedError("authorization must be pending")
 	}
 
 	// Look up the account key for this authorization

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -920,7 +920,7 @@ func TestPerformValidationAlreadyValid(t *testing.T) {
 		Authz:          authzPB,
 		ChallengeIndex: int64(ResponseIndex),
 	})
-	test.AssertErrorIs(t, err, berrors.WrongAuthorizationState)
+	test.AssertErrorIs(t, err, berrors.Malformed)
 }
 
 func TestPerformValidationSuccess(t *testing.T) {

--- a/web/probs.go
+++ b/web/probs.go
@@ -28,8 +28,6 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		outProb = probs.RejectedIdentifier(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.InvalidEmail:
 		outProb = probs.InvalidEmail(fmt.Sprintf("%s :: %s", msg, err))
-	case berrors.WrongAuthorizationState:
-		outProb = probs.Malformed(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.CAA:
 		outProb = probs.CAA(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.MissingSCTs:


### PR DESCRIPTION
This error class is only used in one instance, and when returned to
the user it is transformed into a `probs.Malformed` anyway. It does
more harm than good to keep this one-off BoulderError around, as
it introduces confusion about what sorts of errors we expose to the
client.

Fixes #5167