### PR TITLE
Truncate order expiry values before storage

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2024,8 +2024,9 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		prometheus.Labels{"type": "requested"},
 	).Observe(float64(len(order.Names)))
 
-	// Set the order's expiry to the minimum expiry
-	order.Expires = minExpiry.UnixNano()
+	// Set the order's expiry to the minimum expiry. The db doesn't store
+	// sub-second values, so truncate here.
+	order.Expires = minExpiry.Truncate(time.Second).UnixNano()
 	storedOrder, err := ra.SA.NewOrder(ctx, order)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The database stores order expiry values as type DATETIME, which only
supports values with second-level accuracy. (Contrast with type
DATETIME(6), which allows microsecond accuracy.) But the order object
being written to the database does not have its expiry value rewritten
by the insert process. This leads to Boulder returning different
values for `expires` depending on whether the order was created fresh
(nanosecond accuracy) or retrieved from the db (second accuracy).

There appears to be only one codepath which suffers from this
discrepancy. Although Authorization objects also have an `expires`
field, they are never returned to the client immediately upon creation;
they are first exposed to the user as URLs within an Order object, and
so are always retrieved from the database.

Fixes #5166