### PR TITLE
Return full CAA RR response from bdns to va

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -484,7 +484,7 @@ func (dnsClient *DNSClientImpl) LookupHost(ctx context.Context, hostname string)
 }
 
 // LookupCAA sends a DNS query to find all CAA records associated with
-// the provided hostname and the complete dig-style RR `response` this
+// the provided hostname and the complete dig-style RR `response`. This
 // response is quite verbose, however it's only populated when the CAA
 // response is non-empty.
 func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, string, error) {

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -484,7 +484,9 @@ func (dnsClient *DNSClientImpl) LookupHost(ctx context.Context, hostname string)
 }
 
 // LookupCAA sends a DNS query to find all CAA records associated with
-// the provided hostname.
+// the provided hostname and the complete dig-style RR `response` this
+// response is quite verbose, however it's only populated when the CAA
+// response is non-empty.
 func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, string, error) {
 	dnsType := dns.TypeCAA
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
@@ -502,7 +504,7 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 			CAAs = append(CAAs, caaR)
 		}
 	}
-	response := "CAA query response was empty"
+	var response string
 	if len(CAAs) > 0 {
 		response = r.String()
 	}

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -487,14 +487,13 @@ func (dnsClient *DNSClientImpl) LookupHost(ctx context.Context, hostname string)
 // the provided hostname.
 func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, string, error) {
 	dnsType := dns.TypeCAA
-	var response string
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
 	if err != nil {
-		return nil, response, &DNSError{dnsType, hostname, err, -1}
+		return nil, "", &DNSError{dnsType, hostname, err, -1}
 	}
 
 	if r.Rcode == dns.RcodeServerFailure {
-		return nil, response, &DNSError{dnsType, hostname, nil, r.Rcode}
+		return nil, "", &DNSError{dnsType, hostname, nil, r.Rcode}
 	}
 
 	var CAAs []*dns.CAA
@@ -503,10 +502,9 @@ func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) 
 			CAAs = append(CAAs, caaR)
 		}
 	}
+	response := "CAA query response was empty"
 	if len(CAAs) > 0 {
 		response = r.String()
-	} else {
-		response = "CAA query response was empty"
 	}
 	return CAAs, response, nil
 }

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -392,7 +392,7 @@ func TestDNSLookupCAA(t *testing.T) {
 	caas, resp, err := obj.LookupCAA(context.Background(), "bracewel.net")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should have CAA records")
-	expectedResp := `;; opcode: QUERY, status: NOERROR,
+	expectedResp := `;; opcode: QUERY, status: NOERROR, id: XXXX
 ;; flags: qr rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
 
 ;; QUESTION SECTION:
@@ -401,18 +401,18 @@ func TestDNSLookupCAA(t *testing.T) {
 ;; ANSWER SECTION:
 bracewel.net.	0	IN	CAA	1 issue "letsencrypt.org"
 `
-	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, ""), expectedResp)
+	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, " id: XXXX"), expectedResp)
 
 	caas, resp, err = obj.LookupCAA(context.Background(), "nonexistent.letsencrypt.org")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) == 0, "Shouldn't have CAA records")
 	expectedResp = "CAA query response was empty"
-	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, ""), expectedResp)
+	test.AssertEquals(t, resp, expectedResp)
 
 	caas, resp, err = obj.LookupCAA(context.Background(), "cname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")
-	expectedResp = `;; opcode: QUERY, status: NOERROR,
+	expectedResp = `;; opcode: QUERY, status: NOERROR, id: XXXX
 ;; flags: qr rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
 
 ;; QUESTION SECTION:
@@ -421,7 +421,7 @@ bracewel.net.	0	IN	CAA	1 issue "letsencrypt.org"
 ;; ANSWER SECTION:
 caa.example.com.	0	IN	CAA	1 issue "letsencrypt.org"
 `
-	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, ""), expectedResp)
+	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, " id: XXXX"), expectedResp)
 }
 
 func TestIsPrivateIP(t *testing.T) {

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -406,7 +406,7 @@ bracewel.net.	0	IN	CAA	1 issue "letsencrypt.org"
 	caas, resp, err = obj.LookupCAA(context.Background(), "nonexistent.letsencrypt.org")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) == 0, "Shouldn't have CAA records")
-	expectedResp = "CAA query response was empty"
+	expectedResp = ""
 	test.AssertEquals(t, resp, expectedResp)
 
 	caas, resp, err = obj.LookupCAA(context.Background(), "cname.example.com")

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -273,7 +274,7 @@ func TestDNSLookupsNoServer(t *testing.T) {
 	_, err = obj.LookupHost(context.Background(), "letsencrypt.org")
 	test.AssertError(t, err, "No servers")
 
-	_, err = obj.LookupCAA(context.Background(), "letsencrypt.org")
+	_, _, err = obj.LookupCAA(context.Background(), "letsencrypt.org")
 	test.AssertError(t, err, "No servers")
 }
 
@@ -287,7 +288,7 @@ func TestDNSServFail(t *testing.T) {
 	_, err = obj.LookupHost(context.Background(), bad)
 	test.AssertError(t, err, "LookupHost didn't return an error")
 
-	emptyCaa, err := obj.LookupCAA(context.Background(), bad)
+	emptyCaa, _, err := obj.LookupCAA(context.Background(), bad)
 	test.Assert(t, len(emptyCaa) == 0, "Query returned non-empty list of CAA records")
 	test.AssertError(t, err, "LookupCAA should have returned an error")
 }
@@ -386,18 +387,41 @@ func TestDNSNXDOMAIN(t *testing.T) {
 
 func TestDNSLookupCAA(t *testing.T) {
 	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	removeIDExp := regexp.MustCompile(" id: [[:digit:]]+")
 
-	caas, err := obj.LookupCAA(context.Background(), "bracewel.net")
+	caas, resp, err := obj.LookupCAA(context.Background(), "bracewel.net")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should have CAA records")
+	expectedResp := `;; opcode: QUERY, status: NOERROR,
+;; flags: qr rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
 
-	caas, err = obj.LookupCAA(context.Background(), "nonexistent.letsencrypt.org")
+;; QUESTION SECTION:
+;bracewel.net.	IN	 CAA
+
+;; ANSWER SECTION:
+bracewel.net.	0	IN	CAA	1 issue "letsencrypt.org"
+`
+	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, ""), expectedResp)
+
+	caas, resp, err = obj.LookupCAA(context.Background(), "nonexistent.letsencrypt.org")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) == 0, "Shouldn't have CAA records")
+	expectedResp = "CAA query response was empty"
+	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, ""), expectedResp)
 
-	caas, err = obj.LookupCAA(context.Background(), "cname.example.com")
+	caas, resp, err = obj.LookupCAA(context.Background(), "cname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")
+	expectedResp = `;; opcode: QUERY, status: NOERROR,
+;; flags: qr rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;cname.example.com.	IN	 CAA
+
+;; ANSWER SECTION:
+caa.example.com.	0	IN	CAA	1 issue "letsencrypt.org"
+`
+	test.AssertEquals(t, removeIDExp.ReplaceAllString(resp, ""), expectedResp)
 }
 
 func TestIsPrivateIP(t *testing.T) {

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -119,6 +119,6 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 }
 
 // LookupCAA returns mock records for use in tests.
-func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, error) {
-	return nil, nil
+func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, string, error) {
+	return nil, "", nil
 }

--- a/va/caa.go
+++ b/va/caa.go
@@ -2,7 +2,6 @@ package va
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -46,14 +45,9 @@ func (va *ValidationAuthorityImpl) checkCAA(
 	ctx context.Context,
 	identifier identifier.ACMEIdentifier,
 	params *caaParams) *probs.ProblemDetails {
-	present, valid, records, response, err := va.checkCAARecords(ctx, identifier, params)
+	present, valid, response, err := va.checkCAARecords(ctx, identifier, params)
 	if err != nil {
 		return probs.DNS(err.Error())
-	}
-
-	recordsStr, err := json.Marshal(&records)
-	if err != nil {
-		return probs.CAA(fmt.Sprintf("CAA records for %s were malformed", identifier.Value))
 	}
 
 	accountID, validationMethod := "unknown", "unknown"
@@ -64,8 +58,8 @@ func (va *ValidationAuthorityImpl) checkCAA(
 		validationMethod = params.validationMethod
 	}
 
-	va.log.AuditInfof("Checked CAA records for %s, [Present: %t, Account ID: %s, Challenge: %s, Valid for issuance: %t] Records=%s Response=%q",
-		identifier.Value, present, accountID, validationMethod, valid, recordsStr, response)
+	va.log.AuditInfof("Checked CAA records for %s, [Present: %t, Account ID: %s, Challenge: %s, Valid for issuance: %t] Response=%q",
+		identifier.Value, present, accountID, validationMethod, valid, response)
 	if !valid {
 		return probs.CAA(fmt.Sprintf("CAA record for %s prevents issuance", identifier.Value))
 	}
@@ -125,17 +119,17 @@ type caaResult struct {
 	err      error
 }
 
-func parseResults(results []caaResult) (*CAASet, []*dns.CAA, string, error) {
+func parseResults(results []caaResult) (*CAASet, string, error) {
 	// Return first result
 	for _, res := range results {
 		if res.err != nil {
-			return nil, nil, "", res.err
+			return nil, "", res.err
 		}
 		if len(res.records) > 0 {
-			return newCAASet(res.records), res.records, res.response, nil
+			return newCAASet(res.records), res.response, nil
 		}
 	}
-	return nil, nil, "", nil
+	return nil, "", nil
 }
 
 func (va *ValidationAuthorityImpl) parallelCAALookup(ctx context.Context, name string) []caaResult {
@@ -156,7 +150,7 @@ func (va *ValidationAuthorityImpl) parallelCAALookup(ctx context.Context, name s
 	return results
 }
 
-func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname string) (*CAASet, []*dns.CAA, string, error) {
+func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname string) (*CAASet, string, error) {
 	hostname = strings.TrimRight(hostname, ".")
 
 	// See RFC 6844 "Certification Authority Processing" for pseudocode, as
@@ -185,7 +179,7 @@ func (va *ValidationAuthorityImpl) getCAASet(ctx context.Context, hostname strin
 func (va *ValidationAuthorityImpl) checkCAARecords(
 	ctx context.Context,
 	identifier identifier.ACMEIdentifier,
-	params *caaParams) (bool, bool, []*dns.CAA, string, error) {
+	params *caaParams) (bool, bool, string, error) {
 	hostname := strings.ToLower(identifier.Value)
 	// If this is a wildcard name, remove the prefix
 	var wildcard bool
@@ -193,12 +187,12 @@ func (va *ValidationAuthorityImpl) checkCAARecords(
 		hostname = strings.TrimPrefix(identifier.Value, `*.`)
 		wildcard = true
 	}
-	caaSet, records, response, err := va.getCAASet(ctx, hostname)
+	caaSet, response, err := va.getCAASet(ctx, hostname)
 	if err != nil {
-		return false, false, nil, "", err
+		return false, false, "", err
 	}
 	present, valid := va.validateCAASet(caaSet, wildcard, params)
-	return present, valid, records, response, nil
+	return present, valid, response, nil
 }
 
 func containsMethod(commaSeparatedMethods, method string) bool {

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -603,6 +603,7 @@ func TestParseResults(t *testing.T) {
 	}
 	s, response, err = parseResults(r)
 	test.Assert(t, s == nil, "set is not nil")
+	test.AssertEquals(t, response, "")
 	// A slice of caaResults containing an error followed by a CAA
 	// record should return the error
 	r = []caaResult{
@@ -617,16 +618,17 @@ func TestParseResults(t *testing.T) {
 	//  records should return the first CAA record
 	expected := dns.CAA{Value: "foo"}
 	r = []caaResult{
-		{[]*dns.CAA{&expected}, "", nil},
+		{[]*dns.CAA{&expected}, "foo", nil},
 		{nil, "", errors.New("")},
 		{[]*dns.CAA{{Value: "test"}}, "", nil},
 	}
 	s, response, err = parseResults(r)
 	test.AssertEquals(t, len(s.Unknown), 1)
 	test.Assert(t, s.Unknown[0] == &expected, "Incorrect record returned")
+	test.AssertEquals(t, response, "foo")
 	test.AssertNotError(t, err, "no error should be returned")
 	// A slice of caaResults containing multiple CAA records should
-	// return the first
+	// return the first non-empty CAA record
 	r = []caaResult{
 		{[]*dns.CAA{}, "", nil},
 		{[]*dns.CAA{&expected}, "foo", nil},
@@ -635,6 +637,7 @@ func TestParseResults(t *testing.T) {
 	s, response, err = parseResults(r)
 	test.AssertEquals(t, len(s.Unknown), 1)
 	test.Assert(t, s.Unknown[0] == &expected, "Incorrect record returned")
+	test.AssertEquals(t, response, "foo")
 	test.AssertNotError(t, err, "no error should be returned")
 }
 

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -406,7 +406,7 @@ func TestCAAChecking(t *testing.T) {
 		mockLog.Clear()
 		t.Run(caaTest.Name, func(t *testing.T) {
 			ident := identifier.DNSIdentifier(caaTest.Domain)
-			present, valid, _, _, err := va.checkCAARecords(ctx, ident, params)
+			present, valid, _, err := va.checkCAARecords(ctx, ident, params)
 			if err != nil {
 				t.Errorf("checkCAARecords error for %s: %s", caaTest.Domain, err)
 			}
@@ -424,41 +424,41 @@ func TestCAAChecking(t *testing.T) {
 
 	// present-dns-only.com should now be valid even with http-01
 	ident := identifier.DNSIdentifier("present-dns-only.com")
-	present, valid, _, _, err := va.checkCAARecords(ctx, ident, params)
+	present, valid, _, err := va.checkCAARecords(ctx, ident, params)
 	test.AssertNotError(t, err, "present-dns-only.com")
 	test.Assert(t, present, "Present should be true")
 	test.Assert(t, valid, "Valid should be true")
 
 	// present-incorrect-accounturi.com should now be also be valid
 	ident = identifier.DNSIdentifier("present-incorrect-accounturi.com")
-	present, valid, _, _, err = va.checkCAARecords(ctx, ident, params)
+	present, valid, _, err = va.checkCAARecords(ctx, ident, params)
 	test.AssertNotError(t, err, "present-incorrect-accounturi.com")
 	test.Assert(t, present, "Present should be true")
 	test.Assert(t, valid, "Valid should be true")
 
 	// nil params should be valid, too
-	present, valid, _, _, err = va.checkCAARecords(ctx, ident, nil)
+	present, valid, _, err = va.checkCAARecords(ctx, ident, nil)
 	test.AssertNotError(t, err, "present-dns-only.com")
 	test.Assert(t, present, "Present should be true")
 	test.Assert(t, valid, "Valid should be true")
 
 	ident.Value = "servfail.com"
-	present, valid, _, _, err = va.checkCAARecords(ctx, ident, nil)
+	present, valid, _, err = va.checkCAARecords(ctx, ident, nil)
 	test.AssertError(t, err, "servfail.com")
 	test.Assert(t, !present, "Present should be false")
 	test.Assert(t, !valid, "Valid should be false")
 
-	if _, _, _, _, err := va.checkCAARecords(ctx, ident, nil); err == nil {
+	if _, _, _, err := va.checkCAARecords(ctx, ident, nil); err == nil {
 		t.Errorf("Should have returned error on CAA lookup, but did not: %s", ident.Value)
 	}
 
 	ident.Value = "servfail.present.com"
-	present, valid, _, _, err = va.checkCAARecords(ctx, ident, nil)
+	present, valid, _, err = va.checkCAARecords(ctx, ident, nil)
 	test.AssertError(t, err, "servfail.present.com")
 	test.Assert(t, !present, "Present should be false")
 	test.Assert(t, !valid, "Valid should be false")
 
-	if _, _, _, _, err := va.checkCAARecords(ctx, ident, nil); err == nil {
+	if _, _, _, err := va.checkCAARecords(ctx, ident, nil); err == nil {
 		t.Errorf("Should have returned error on CAA lookup, but did not: %s", ident.Value)
 	}
 }
@@ -476,55 +476,55 @@ func TestCAALogging(t *testing.T) {
 	}{
 		{
 			Domain:          "reserved.com",
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: unknown, Challenge: unknown, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: unknown, Challenge: unknown, Valid for issuance: false] Response=\"\"",
 		},
 		{
 			Domain:          "reserved.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeHTTP01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Response=\"\"",
 		},
 		{
 			Domain:          "reserved.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeDNS01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: dns-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for reserved.com, [Present: true, Account ID: 12345, Challenge: dns-01, Valid for issuance: false] Response=\"\"",
 		},
 		{
 			Domain:          "mixedcase.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeHTTP01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for mixedcase.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"iSsUe\",\"Value\":\"ca.com\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for mixedcase.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Response=\"\"",
 		},
 		{
 			Domain:          "critical.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeHTTP01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for critical.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for critical.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Response=\"\"",
 		},
 		{
 			Domain:          "present.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeHTTP01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Response=\"\"",
 		},
 		{
 			Domain:          "multi-crit-present.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeHTTP01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for multi-crit-present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":1,\"Tag\":\"issue\",\"Value\":\"letsencrypt.org\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for multi-crit-present.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Response=\"\"",
 		},
 		{
 			Domain:          "present-with-parameter.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeHTTP01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present-with-parameter.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"  letsencrypt.org  ;foo=bar;baz=bar\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for present-with-parameter.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: true] Response=\"\"",
 		},
 		{
 			Domain:          "satisfiable-wildcard-override.com",
 			AccountURIID:    12345,
 			ChallengeType:   core.ChallengeTypeHTTP01,
-			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for satisfiable-wildcard-override.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Records=[{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issue\",\"Value\":\"ca.com\"},{\"Hdr\":{\"Name\":\"\",\"Rrtype\":0,\"Class\":0,\"Ttl\":0,\"Rdlength\":0},\"Flag\":0,\"Tag\":\"issuewild\",\"Value\":\"letsencrypt.org\"}] Response=\"\"",
+			ExpectedLogline: "INFO: [AUDIT] Checked CAA records for satisfiable-wildcard-override.com, [Present: true, Account ID: 12345, Challenge: http-01, Valid for issuance: false] Response=\"\"",
 		},
 	}
 
@@ -589,27 +589,53 @@ func TestCAAFailure(t *testing.T) {
 }
 
 func TestParseResults(t *testing.T) {
+	// An empty slice of caaResults should return nil, "", nil
 	r := []caaResult{}
-	s, records, _, err := parseResults(r)
+	s, response, err := parseResults(r)
 	test.Assert(t, s == nil, "set is not nil")
 	test.Assert(t, err == nil, "error is not nil")
-	test.Assert(t, records == nil, "records is not nil")
-	test.AssertNotError(t, err, "no error should be returned")
-	r = []caaResult{{nil, "", errors.New("")}, {[]*dns.CAA{{Value: "test"}}, "", nil}}
-	s, records, _, err = parseResults(r)
+	test.Assert(t, response == "", "records is not nil")
+	// A slice of empty caaResults should return nil, "", nil
+	r = []caaResult{
+		{[]*dns.CAA{}, "", nil},
+		{[]*dns.CAA{}, "", nil},
+		{[]*dns.CAA{}, "", nil},
+	}
+	s, response, err = parseResults(r)
+	test.Assert(t, s == nil, "set is not nil")
+	// A slice of caaResults containing an error followed by a CAA
+	// record should return the error
+	r = []caaResult{
+		{nil, "", errors.New("")},
+		{[]*dns.CAA{{Value: "test"}}, "", nil},
+	}
+	s, response, err = parseResults(r)
 	test.Assert(t, s == nil, "set is not nil")
 	test.AssertEquals(t, err.Error(), "")
-	expected := dns.CAA{Value: "other-test"}
-	test.AssertEquals(t, len(records), 0)
-	r = []caaResult{{[]*dns.CAA{&expected}, "", nil}, {[]*dns.CAA{{Value: "test"}}, "", nil}}
-	s, records, _, err = parseResults(r)
+	test.AssertEquals(t, response, "")
+	//  A slice of caaResults containing an error sandwiched between CAA
+	//  records should return the first CAA record
+	expected := dns.CAA{Value: "foo"}
+	r = []caaResult{
+		{[]*dns.CAA{&expected}, "", nil},
+		{nil, "", errors.New("")},
+		{[]*dns.CAA{{Value: "test"}}, "", nil},
+	}
+	s, response, err = parseResults(r)
 	test.AssertEquals(t, len(s.Unknown), 1)
 	test.Assert(t, s.Unknown[0] == &expected, "Incorrect record returned")
 	test.AssertNotError(t, err, "no error should be returned")
-	test.AssertEquals(t, len(records), len(r[0].records))
-	for i, rec := range records {
-		test.AssertEquals(t, rec.String(), r[0].records[i].String())
+	// A slice of caaResults containing multiple CAA records should
+	// return the first
+	r = []caaResult{
+		{[]*dns.CAA{}, "", nil},
+		{[]*dns.CAA{&expected}, "foo", nil},
+		{[]*dns.CAA{{Value: "bar"}}, "bar", nil},
 	}
+	s, response, err = parseResults(r)
+	test.AssertEquals(t, len(s.Unknown), 1)
+	test.Assert(t, s.Unknown[0] == &expected, "Incorrect record returned")
+	test.AssertNotError(t, err, "no error should be returned")
 }
 
 func TestCheckAccountURI(t *testing.T) {

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -603,6 +603,7 @@ func TestParseResults(t *testing.T) {
 	}
 	s, response, err = parseResults(r)
 	test.Assert(t, s == nil, "set is not nil")
+	test.Assert(t, err == nil, "error is not nil")
 	test.AssertEquals(t, response, "")
 	// A slice of caaResults containing an error followed by a CAA
 	// record should return the error
@@ -626,7 +627,7 @@ func TestParseResults(t *testing.T) {
 	test.AssertEquals(t, len(s.Unknown), 1)
 	test.Assert(t, s.Unknown[0] == &expected, "Incorrect record returned")
 	test.AssertEquals(t, response, "foo")
-	test.AssertNotError(t, err, "no error should be returned")
+	test.Assert(t, err == nil, "error is not nil")
 	// A slice of caaResults containing multiple CAA records should
 	// return the first non-empty CAA record
 	r = []caaResult{


### PR DESCRIPTION
When the VA encounters CAA records, it logs the contents of those
records. When those records were the result of following a chain of
CNAMEs, the CNAMEs are included as part of the response from our
recursive resolver. However, the current flow for logging the responses
logs only the CAA records, not the CNAMEs.

This change returns the complete dig-style RR response from bdns to the
va where the response of the authoritative CAA RR is string-quoted and
logged.

This dig-style RR response is quite verbose, however it is only ever
returned from bdns.LookupCAA when a CAA response is non-empty. If the CAA
response is empty only an empty string is returned.

Fixes #5082