### PR TITLE
Python upgrade os upgrades and travis config cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
-language: go
-dist: xenial
+dist: focal
 os: linux
-
-go:
-  - "1.15"
-  - "1.15.5"
 
 go_import_path: github.com/letsencrypt/boulder
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,12 @@ jobs:
   allow_failures:
     - env: TESTFLAGS="--coverage" CONTAINER="netaccess"
 
+before_install: docker-compose pull
+
 install: skip
 
 script:
   - >-
-    docker-compose pull &&
     docker-compose run --use-aliases
     -e TRAVIS_BRANCH
     -e TRAVIS_JOB_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 dist: focal
 os: linux
+language: go
 
 go:
-  - "1.15"
+  - "1.15.5"
 
 services:
   - docker
@@ -38,11 +39,11 @@ jobs:
   allow_failures:
     - env: TESTFLAGS="--coverage" CONTAINER="netaccess"
 
-install:
-  - docker-compose pull
+install: skip
 
 script:
   - >-
+    docker-compose pull &&
     docker-compose run --use-aliases
     -e TRAVIS_BRANCH
     -e TRAVIS_JOB_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 dist: focal
 os: linux
 
-go_import_path: github.com/letsencrypt/boulder
+go:
+  - "1.15"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+language: go
 dist: focal
 os: linux
-language: go
 
 go:
   - "1.15.5"
+
+go_import_path: github.com/letsencrypt/boulder
 
 services:
   - docker
@@ -39,9 +41,8 @@ jobs:
   allow_failures:
     - env: TESTFLAGS="--coverage" CONTAINER="netaccess"
 
-before_install: docker-compose pull
-
-install: skip
+install:
+  - docker-compose pull
 
 script:
   - >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.5}:2020-11-12
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.5}:2020-11-20
         environment:
             - FAKE_DNS=10.77.77.77
             - BOULDER_CONFIG_DIR=test/config
@@ -76,7 +76,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.5}:2020-11-12
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.5}:2020-11-20
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/start.py
+++ b/start.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python2.7 -u
 """
 Run a local instance of Boulder for testing purposes.
 

--- a/start.py
+++ b/start.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S python3 -u
 """
 Run a local instance of Boulder for testing purposes.
 

--- a/test.sh
+++ b/test.sh
@@ -235,7 +235,7 @@ if [[ "${RUN[@]}" =~ lints ]] ; then
   # without emitting logs, so set the timeout to 9m.
   golangci-lint run --timeout 9m ./...
   run_and_expect_silence ./test/test-no-outdated-migrations.sh
-  python test/grafana/lint.py
+  python3 test/grafana/lint.py
   # Check for common spelling errors using codespell.
   # Update .codespell.ignore.txt if you find false positives (NOTE: ignored
   # words should be all lowercase).

--- a/test.sh
+++ b/test.sh
@@ -214,7 +214,6 @@ print_heading "Settings:"
 trap "print_outcome" EXIT
 
 settings="$(cat -- <<-EOM
-    TRAVIS_GO_VERSION:  ${TRAVIS_GO_VERSION-not specified}
     RUN:                ${RUN[@]}
     BOULDER_CONFIG_DIR: $BOULDER_CONFIG_DIR
     UNIT_PACKAGES:      ${UNIT_PACKAGES[@]}

--- a/test.sh
+++ b/test.sh
@@ -214,6 +214,7 @@ print_heading "Settings:"
 trap "print_outcome" EXIT
 
 settings="$(cat -- <<-EOM
+    TRAVIS_GO_VERSION:  ${TRAVIS_GO_VERSION-not specified}
     RUN:                ${RUN[@]}
     BOULDER_CONFIG_DIR: $BOULDER_CONFIG_DIR
     UNIT_PACKAGES:      ${UNIT_PACKAGES[@]}

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:stretch-scm
+FROM buildpack-deps:buster-scm
 ARG GO_VERSION
 
 # Copied from https://github.com/docker-library/golang/blob/master/Dockerfile-debian.template

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -4,7 +4,7 @@ apt-get update
 
 # Install system deps
 apt-get install -y --no-install-recommends \
-  mariadb-client-core-10.1 \
+  mariadb-client-core-10.3 \
   rpm \
   ruby \
   ruby-dev \

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.15" "1.15.5" )
+GO_VERSIONS=( "1.15.5" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"

--- a/test/grafana/lint.py
+++ b/test/grafana/lint.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # Check dashboard JSON files for common errors, like forgetting to templatize a
 # datasource.
 import json


### PR DESCRIPTION
Modified the Dockerfile to build using Debian Buster, an upgrade from
Debian Stretch. The default Python 3 version for Stretch is 3.5.x which
is soon to de deprecated by Python-cryptography a dependency we rely on
for our integration test suite. The default Python 3 version for Debian
Buster is 3.7.x

In the .travis.yml file we are instructing travis to provision Xenial
instances and install two versions of Go. This change bumps Xenial
(16.04) -> Focal (20.04) and removes the installation of the two Go
versions; all of our testing happens inside of a docker container so
having Go installed on the Docker parent isn't necessary.

In the docker-compose.yml file we configure which docker image to pull
from Dockerhub, I've updated these to reflect the Debian Buster images
already built and pushed.

Modified build.sh to install mariadb-client-core 10.3, there is no 10.1
install candidate for Debian Buster and release notes for 10.2 and 10.3
indicate that these were both security releases.

Modified test.sh to use python3 instead of system python (usually 2.7)
for test/grafana/lints.py

Fixes #5180