### PR TITLE
Remove the last mention of RabbitMQ (in start.py)

### DIFF
--- a/start.py
+++ b/start.py
@@ -2,7 +2,8 @@
 """
 Run a local instance of Boulder for testing purposes.
 
-This runs in non-monolithic mode and requires RabbitMQ on localhost.
+Boulder always runs as a collection of services. This script will
+start them all on their own ports (see test/startservers.py)
 
 Keeps servers alive until ^C. Exit non-zero if any servers fail to
 start, or die before ^C.


### PR DESCRIPTION
RabbitMQ was removed in favor of gRPC in 2016. While there have been many commits to remove the AMQP-related code, this last mention in start.py persisted.