### PR TITLE
Update v1 WFE to advertise new issuer api endpoint

### DIFF
--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -1023,7 +1023,7 @@ func TestIssueCertificate(t *testing.T) {
 		"http://localhost/acme/cert/0000ff0000000000000e4b4f67d86e818c46")
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Link"),
-		`<http://localhost/acme/issuer-cert>;rel="up"`)
+		`<http://localhost/acme/issuer/>;rel="up"`)
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Content-Type"),
 		"application/pkix-cert")
@@ -1041,7 +1041,7 @@ func TestIssueCertificate(t *testing.T) {
 		}`, wfe.nonceService)))
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Link"),
-		`<http://localhost/acme/issuer-cert>;rel="up"`)
+		`<http://localhost/acme/issuer/>;rel="up"`)
 
 	mockLog.Clear()
 	responseWriter.Body.Reset()
@@ -2166,7 +2166,7 @@ func TestGetCertificate(t *testing.T) {
 	test.Assert(t, bytes.Compare(responseWriter.Body.Bytes(), certBlock.Bytes) == 0, "Certificates don't match")
 	test.AssertEquals(
 		t, responseWriter.Header().Get("Link"),
-		`<http://localhost/acme/issuer-cert>;rel="up"`)
+		`<http://localhost/acme/issuer/>;rel="up"`)
 
 	// Unused serial, no cache
 	mockLog.Clear()


### PR DESCRIPTION
In the future, we would like to change the way the `Issuer` handler
works, so that it can supply different issuer certificates (e.g. one
for RSA and one for ECDSA) depending on the contents of the
request.

This change prepares for that goal in two ways:

First, it changes the path at which we advertise issuer certificates
should be retrieved by our `<link rel="up">` links. This will allow us
to see if there are any clients which ignore those links and instead
hard-code the path to the issuer cert.

Second, it begins to supply issuer certs at a path which mirrors the
existing `/cert/` path. This will allow us to more easily serve multiple
issuer certs, determined by a trailing path component which identifies
the desired issuer, much as the `/cert/` endpoint identifies the desired
cert via its serial number.

Part of #5164