### PR TITLE
Add response age histogram to ocsp-responder

### DIFF
--- a/ocsp/responder_test.go
+++ b/ocsp/responder_test.go
@@ -97,6 +97,12 @@ func TestOCSP(t *testing.T) {
 			},
 			[]string{"type"},
 		),
+		responseAges: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "ocspAges-test",
+				Buckets: []float64{43200},
+			},
+		),
 		clk: clock.NewFake(),
 		log: blog.NewMock(),
 	}
@@ -122,6 +128,11 @@ func TestOCSP(t *testing.T) {
 			}
 		})
 	}
+	// Exactly two of the cases above result in an OCSP response being sent.
+	samples := test.CountHistogramSamples(responder.responseAges)
+	if samples != 2 {
+		t.Errorf("Ages histogram updated incorrect number of times: %d", samples)
+	}
 }
 
 func TestRequestTooBig(t *testing.T) {
@@ -132,6 +143,12 @@ func TestRequestTooBig(t *testing.T) {
 				Name: "ocspResponses-test",
 			},
 			[]string{"type"},
+		),
+		responseAges: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "ocspAges-test",
+				Buckets: []float64{43200},
+			},
 		),
 		clk: clock.NewFake(),
 		log: blog.NewMock(),
@@ -175,6 +192,12 @@ func TestOverrideHeaders(t *testing.T) {
 			},
 			[]string{"type"},
 		),
+		responseAges: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "ocspAges-test",
+				Buckets: []float64{43200},
+			},
+		),
 		clk: clock.NewFake(),
 		log: blog.NewMock(),
 	}
@@ -205,6 +228,12 @@ func TestCacheHeaders(t *testing.T) {
 				Name: "ocspResponses-test",
 			},
 			[]string{"type"},
+		),
+		responseAges: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "ocspAges-test",
+				Buckets: []float64{43200},
+			},
 		),
 		clk: fc,
 		log: blog.NewMock(),


### PR DESCRIPTION
There are various technical requirements on the maximum age of
an OCSP response. Although ocsp-updater has mechanisms to ensure
that all certificates have responses which are sufficiently recent,
there is the possibility of a bug which results in some OCSP
responses escaping its notice.

This change adds a histogram metric to ocsp-responder which collects
the ages (i.e. now minus the `thisUpdate` timestamp) of the OCSP
respones which it serves. The histogram has equal buckets in 12-hour
increments. During normal operation, the first 7 such buckets
(representing ages 0 to 3.5 days) should have roughly equal counts,
while the latter 7 buckets (3.5 to 7 days) should be empty.

Fixes #5080