### PR TITLE
ocsp-responder: move IssuerID check after Expires check

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -179,14 +179,14 @@ func (src *dbSource) Response(req *ocsp.Request) ([]byte, http.Header, error) {
 		src.log.AuditErrf("Looking up OCSP response: %s", err)
 		return nil, nil, err
 	}
-	if !src.filter.responseMatchesIssuer(req, certStatus) {
-		src.log.Warningf("OCSP Response not sent (issuer and serial mismatch) for CA=%s, Serial=%s", hex.EncodeToString(req.IssuerKeyHash), serialString)
-		return nil, nil, bocsp.ErrNotFound
-	}
 	if certStatus.OCSPLastUpdated.IsZero() {
 		src.log.Warningf("OCSP Response not sent (ocspLastUpdated is zero) for CA=%s, Serial=%s", hex.EncodeToString(req.IssuerKeyHash), serialString)
 		return nil, nil, bocsp.ErrNotFound
 	} else if certStatus.IsExpired {
+		src.log.Warningf("OCSP Response not sent (expired) for CA=%s, Serial=%s", hex.EncodeToString(req.IssuerKeyHash), serialString)
+		return nil, nil, bocsp.ErrNotFound
+	} else if !src.filter.responseMatchesIssuer(req, certStatus) {
+		src.log.Warningf("OCSP Response not sent (issuer and serial mismatch) for CA=%s, Serial=%s", hex.EncodeToString(req.IssuerKeyHash), serialString)
 		return nil, nil, bocsp.ErrNotFound
 	}
 	return certStatus.OCSPResponse, nil, nil


### PR DESCRIPTION
It is possible for a CertificateStatus row to have a nil IssuerID
(there was a period of time in which we didn't write IssuerIDs into
CertificateStatus rows at all) but all such rows should be old and
therefore expired.

Unfortunately, this code was checking the IssuerID before it was
checking the Expiry, and therefore was generating panics when trying
to dereference a nil pointer.

This change simply moves the IssuerID check to be after the Expires
check, so that we'll only try to dereference the IssuerID on recent
CertificateStatus rows, where it is guaranteed to be non-nil.

Fixes #5200