### PR TITLE
Remove /issuer-cert endpoint from v2 API

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
-	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
 	noncepb "github.com/letsencrypt/boulder/nonce/proto"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
@@ -107,10 +106,6 @@ type config struct {
 	}
 
 	Syslog cmd.SyslogConfig
-
-	Common struct {
-		IssuerCert string
-	}
 }
 
 // loadCertificateFile loads a PEM certificate from the certFile provided. It
@@ -346,10 +341,6 @@ func main() {
 	wfe.DirectoryCAAIdentity = c.WFE.DirectoryCAAIdentity
 	wfe.DirectoryWebsite = c.WFE.DirectoryWebsite
 	wfe.LegacyKeyIDPrefix = c.WFE.LegacyKeyIDPrefix
-
-	issuerCert, err := core.LoadCert(c.Common.IssuerCert)
-	cmd.FailOnError(err, fmt.Sprintf("Couldn't load issuer cert [%s]", c.Common.IssuerCert))
-	wfe.IssuerCert = &issuance.Certificate{Certificate: issuerCert}
 
 	logger.Infof("WFE using key policy: %#v", kp)
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/identifier"
-	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/mocks"
@@ -912,7 +911,6 @@ func TestNonceEndpoint(t *testing.T) {
 
 func TestHTTPMethods(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.IssuerCert = &issuance.Certificate{Certificate: &x509.Certificate{}}
 	mux := wfe.Handler(metrics.NoopRegisterer)
 
 	// NOTE: Boulder's muxer treats HEAD as implicitly allowed if GET is specified
@@ -968,11 +966,6 @@ func TestHTTPMethods(t *testing.T) {
 			Name:    "RevokeCert path should be POST only",
 			Path:    revokeCertPath,
 			Allowed: postOnly,
-		},
-		{
-			Name:    "Issuer path should be GET only",
-			Path:    issuerPath,
-			Allowed: getOnly,
 		},
 		{
 			Name:    "Build ID path should be GET only",
@@ -1742,20 +1735,6 @@ func TestAccount(t *testing.T) {
 		"detail": "Request signing key did not match account key",
 		"status": 403
 	}`)
-}
-
-func TestIssuer(t *testing.T) {
-	wfe, _ := setupWFE(t)
-	wfe.IssuerCert = &issuance.Certificate{Certificate: &x509.Certificate{}}
-	wfe.IssuerCert.Raw = []byte{0, 0, 1}
-
-	responseWriter := httptest.NewRecorder()
-
-	wfe.Issuer(ctx, newRequestEvent(), responseWriter, &http.Request{
-		Method: "GET",
-	})
-	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
-	test.Assert(t, bytes.Compare(responseWriter.Body.Bytes(), wfe.IssuerCert.Raw) == 0, "Incorrect bytes returned")
 }
 
 func TestGetCertificate(t *testing.T) {


### PR DESCRIPTION
The /issuer-cert endpoint was a holdover from the v1 API, where
it is a critical part of the issuance flow. In the v2 issuance
flow, the issuer certificate is provided directly in the response
for the certificate itself. Thus, this endpoint is redundant.

Stats show that it receives approximately zero traffic (less than
one request per week, all of which are now coming from wget or
browser useragents). It also complicates the refactoring necessary
for the v2 API to support multiple issuers.

As such, it is a safe and easy decision to remove it.

Fixes #5196