### PR TITLE
Use IssuerNameID to get issuer from precertificate

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -109,7 +109,7 @@ const (
 	certType    = certificateType("certificate")
 )
 
-// Three maps of keys to internalIssuers. Lookup by PublicKeyAlgorithm is
+// Four maps of keys to internalIssuers. Lookup by PublicKeyAlgorithm is
 // useful for determining which issuer to use to sign a given (pre)cert, based
 // on its PublicKeyAlgorithm. Lookup by CommonName is useful for determining
 // which issuer to use to sign an OCSP response, based on the cert's

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -115,11 +115,13 @@ const (
 // which issuer to use to sign an OCSP response, based on the cert's
 // Issuer CN. Lookup by ID is useful for the same functionality, in cases
 // where features.StoreIssuerInfo is true and the OCSP request is identified
-// by Serial and IssuerID rather than by the full cert.
+// by Serial and IssuerID rather than by the full cert. Lookup by NameID is
+// useful as a easier-to-compute replacement for both byName and byID lookups.
 type issuerMaps struct {
-	byAlg  map[x509.PublicKeyAlgorithm]*internalIssuer
-	byName map[string]*internalIssuer
-	byID   map[issuance.IssuerID]*internalIssuer
+	byAlg    map[x509.PublicKeyAlgorithm]*internalIssuer
+	byName   map[string]*internalIssuer
+	byID     map[issuance.IssuerID]*internalIssuer
+	byNameID map[issuance.IssuerNameID]*internalIssuer
 }
 
 // CertificateAuthorityImpl represents a CA that signs certificates, CRLs, and
@@ -175,6 +177,7 @@ func makeInternalIssuers(issuers []*issuance.Issuer, lifespanOCSP time.Duration)
 	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*internalIssuer, 2)
 	issuersByName := make(map[string]*internalIssuer, len(issuers))
 	issuersByID := make(map[issuance.IssuerID]*internalIssuer, len(issuers))
+	issuersByNameID := make(map[issuance.IssuerNameID]*internalIssuer, len(issuers))
 	for _, issuer := range issuers {
 		ii := &internalIssuer{
 			cert:          issuer.Cert,
@@ -192,8 +195,9 @@ func makeInternalIssuers(issuers []*issuance.Issuer, lifespanOCSP time.Duration)
 		}
 		issuersByName[issuer.Name()] = ii
 		issuersByID[issuer.ID()] = ii
+		issuersByNameID[issuer.Cert.NameID()] = ii
 	}
-	return issuerMaps{issuersByAlg, issuersByName, issuersByID}, nil
+	return issuerMaps{issuersByAlg, issuersByName, issuersByID, issuersByNameID}, nil
 }
 
 func makeCFSSLInternalIssuers(issuers []Issuer, policy *cfsslConfig.Signing, lifespanOCSP time.Duration) (issuerMaps, error) {
@@ -203,6 +207,7 @@ func makeCFSSLInternalIssuers(issuers []Issuer, policy *cfsslConfig.Signing, lif
 	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*internalIssuer, len(issuers))
 	issuersByName := make(map[string]*internalIssuer, len(issuers))
 	issuersByID := make(map[issuance.IssuerID]*internalIssuer, len(issuers))
+	issuersByNameID := make(map[issuance.IssuerNameID]*internalIssuer, len(issuers))
 	for idx, iss := range issuers {
 		if iss.Cert == nil || iss.Signer == nil {
 			return issuerMaps{}, errors.New("Issuer with nil cert or signer specified.")
@@ -235,8 +240,9 @@ func makeCFSSLInternalIssuers(issuers []Issuer, policy *cfsslConfig.Signing, lif
 		}
 		issuersByName[cn] = ii
 		issuersByID[iss.Cert.ID()] = ii
+		issuersByNameID[iss.Cert.NameID()] = ii
 	}
-	return issuerMaps{issuersByAlg, issuersByName, issuersByID}, nil
+	return issuerMaps{issuersByAlg, issuersByName, issuersByID, issuersByNameID}, nil
 }
 
 // NewCertificateAuthorityImpl creates a CA instance that can sign certificates
@@ -655,9 +661,9 @@ func (ca *CertificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 		scts = append(scts, sct)
 	}
 
-	issuer, ok := ca.issuers.byAlg[precert.PublicKeyAlgorithm]
+	issuer, ok := ca.issuers.byNameID[issuance.GetIssuerNameID(precert)]
 	if !ok {
-		return nil, berrors.InternalServerError("no issuer found for public key algorithm %s", precert.PublicKeyAlgorithm)
+		return nil, berrors.InternalServerError("no issuer found for Issuer Name %s", precert.Issuer)
 	}
 
 	var certDER []byte


### PR DESCRIPTION
Today, when issuing a certificate based on a precertificate, we choose
the issuer based on algorithm: we find the precert's algorithm, look
it up in our table mapping algs to issuers, and then issue the final
cert from that issuer.

It is therefore hypothetically possible for the precertificate and
final certificate to be issued from different issuers, if the mapping
of algs to issuers were updated between precert and final cert issuance.
We don't expect this to be possible given Boulder's architecture, but
it could become possible given sufficient refactoring.

This change updates the lookup method to be based on the IssuerNameID,
which is a truncated hash computed across the whole Name field of the
issuer certificate (or equivalently across the Issuer field of the
issued precertificate). This ensures that final issuance will fail,
rather than have different issuers for the precert and final cert.

Part of #5216