### PR TITLE
Add logging of OCSP generation events

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -258,6 +258,8 @@ func NewCertificateAuthorityImpl(
 	ocspLifetime time.Duration,
 	keyPolicy goodkey.KeyPolicy,
 	orphanQueue *goque.Queue,
+	ocspLogMaxLength int,
+	ocspLogPeriod time.Duration,
 	logger blog.Logger,
 	stats prometheus.Registerer,
 	clk clock.Clock,
@@ -352,7 +354,7 @@ func NewCertificateAuthorityImpl(
 	}, []string{"type"})
 	stats.MustRegister(signErrorCounter)
 
-	ocspLogQueue := newOCSPLogQueue(4000, 500*time.Millisecond, stats, logger)
+	ocspLogQueue := newOCSPLogQueue(ocspLogMaxLength, ocspLogPeriod, stats, logger)
 
 	ca = &CertificateAuthorityImpl{
 		sa:                 sa,

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -352,6 +352,8 @@ func NewCertificateAuthorityImpl(
 	}, []string{"type"})
 	stats.MustRegister(signErrorCounter)
 
+	ocspLogQueue := newOCSPLogQueue(4000, 500*time.Millisecond, stats, logger)
+
 	ca = &CertificateAuthorityImpl{
 		sa:                 sa,
 		pa:                 pa,
@@ -365,7 +367,7 @@ func NewCertificateAuthorityImpl(
 		ocspLifetime:       ocspLifetime,
 		keyPolicy:          keyPolicy,
 		orphanQueue:        orphanQueue,
-		ocspLogQueue:       newOCSPLogQueue(stats, logger),
+		ocspLogQueue:       ocspLogQueue,
 		log:                logger,
 		signatureCount:     signatureCount,
 		csrExtensionCount:  csrExtensionCount,
@@ -930,10 +932,18 @@ func (ca *CertificateAuthorityImpl) OrphanIntegrationLoop() {
 	}
 }
 
-/// LogOCSPLoop collects OCSP generation log events into bundles, and logs
-/// them periodically.
+// LogOCSPLoop collects OCSP generation log events into bundles, and logs
+// them periodically.
 func (ca *CertificateAuthorityImpl) LogOCSPLoop() {
 	ca.ocspLogQueue.loop()
+}
+
+// Stop asks this CertificateAuthorityImpl to shut down. It must be called
+// after the corresponding RPC service is shut down and there are no longer
+// any inflight RPCs. It will attempt to drain any logging queues (which may
+// block), and will return only when done.
+func (ca *CertificateAuthorityImpl) Stop() {
+	ca.ocspLogQueue.stop()
 }
 
 // integrateOrpan removes an orphan from the queue and adds it to the database. The

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -328,6 +328,8 @@ func TestFailNoSerialPrefix(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -438,6 +440,8 @@ func issueCertificateSubTestSetup(t *testing.T, boulderIssuer bool) (*Certificat
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -500,6 +504,8 @@ func TestMultipleIssuers(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -533,6 +539,8 @@ func TestOCSP(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -592,6 +600,8 @@ func TestOCSP(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -697,6 +707,8 @@ func TestInvalidCSRs(t *testing.T) {
 			testCtx.ocspLifetime,
 			testCtx.keyPolicy,
 			nil,
+			0,
+			time.Second,
 			testCtx.logger,
 			testCtx.stats,
 			testCtx.fc)
@@ -736,6 +748,8 @@ func TestRejectValidityTooLong(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -795,6 +809,8 @@ func TestSingleAIAEnforcement(t *testing.T) {
 		time.Second,
 		goodkey.KeyPolicy{},
 		nil,
+		0,
+		time.Second,
 		&blog.Mock{},
 		metrics.NoopRegisterer,
 		clock.New(),
@@ -911,6 +927,8 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 			testCtx.ocspLifetime,
 			testCtx.keyPolicy,
 			nil,
+			0,
+			time.Second,
 			testCtx.logger,
 			testCtx.stats,
 			testCtx.fc)
@@ -1001,6 +1019,8 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -1045,6 +1065,8 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -1126,6 +1148,8 @@ func TestPrecertOrphanQueue(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		orphanQueue,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -1196,6 +1220,8 @@ func TestOrphanQueue(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		orphanQueue,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -1316,6 +1342,8 @@ func TestIssuePrecertificateLinting(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)
@@ -1380,6 +1408,8 @@ func TestGenerateOCSPWithIssuerID(t *testing.T) {
 		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
+		0,
+		time.Second,
 		testCtx.logger,
 		testCtx.stats,
 		testCtx.fc)

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -1,0 +1,68 @@
+package ca
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/crypto/ocsp"
+
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+type ocspLogQueue struct {
+	queue  chan ocspLog
+	depth  prometheus.Gauge
+	logger blog.Logger
+}
+
+type ocspLog struct {
+	serial []byte
+	time   time.Time
+	status ocsp.ResponseStatus
+}
+
+func newOCSPLogQueue(stats prometheus.Registerer, logger blog.Logger) *ocspLogQueue {
+	depth := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "ocsp_log_queue_depth",
+			Help: "Number of OCSP generation log entries waiting to be written",
+		})
+	stats.MustRegister(depth)
+	return &ocspLogQueue{
+		queue:  make(chan ocspLog, 10000),
+		depth:  depth,
+		logger: logger,
+	}
+}
+
+func (olq *ocspLogQueue) enqueue(serial []byte, time time.Time, status ocsp.ResponseStatus) {
+	olq.queue <- ocspLog{
+		serial: serial,
+		time:   time,
+		status: ocsp.ResponseStatus(status),
+	}
+}
+
+// loop consumes events from the queue channel, batches them up, and
+// logs them in batches of 100, or every 500 milliseconds, whichever comes first.
+func (olq *ocspLogQueue) loop() error {
+	for {
+		var builder strings.Builder
+		deadline := time.After(500 * time.Millisecond)
+	inner:
+		for i := 0; i < 100; i++ {
+			olq.depth.Set(float64(len(olq.queue)))
+			select {
+			case ol := <-olq.queue:
+				fmt.Fprintf(&builder, "%x:%d,", ol.serial, ol.status)
+			case <-deadline:
+				break inner
+			}
+		}
+		if builder.Len() > 0 {
+			olq.logger.AuditInfof("OCSP updates: %s", builder.String())
+		}
+	}
+}

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -72,7 +72,7 @@ func (olq *ocspLogQueue) enqueue(serial []byte, time time.Time, status ocsp.Resp
 	olq.queue <- ocspLog{
 		serial: append([]byte{}, serial...),
 		time:   time,
-		status: ocsp.ResponseStatus(status),
+		status: status,
 	}
 }
 

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -3,6 +3,7 @@ package ca
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -11,8 +12,22 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
+// ocspLogQueue accumulates OCSP logging events and writes several of them
+// in a single log line. This reduces the number of log lines and bytes,
+// which would otherwise be quite high. As of Jan 2021 we do approximately
+// 550 rps of OCSP generation events. We can turn that into about 5.5 rps
+// of log lines if we accumulate 100 entries per line, which amounts to about
+// 3900 bytes per log line.
+// Summary of log line usage:
+// serial in hex: 36 bytes, separator characters: 2 bytes, status: 1 byte
 type ocspLogQueue struct {
+	// Maximum length, in bytes, of a single log line.
+	maxLogLen int
+	// Maximum amount of time between OCSP logging events.
+	period time.Duration
 	queue  chan ocspLog
+	// This allows the stop() function to block until we've drained the queue.
+	wg     sync.WaitGroup
 	depth  prometheus.Gauge
 	logger blog.Logger
 }
@@ -23,7 +38,12 @@ type ocspLog struct {
 	status ocsp.ResponseStatus
 }
 
-func newOCSPLogQueue(stats prometheus.Registerer, logger blog.Logger) *ocspLogQueue {
+func newOCSPLogQueue(
+	maxLogLen int,
+	period time.Duration,
+	stats prometheus.Registerer,
+	logger blog.Logger,
+) *ocspLogQueue {
 	depth := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "ocsp_log_queue_depth",
@@ -31,9 +51,12 @@ func newOCSPLogQueue(stats prometheus.Registerer, logger blog.Logger) *ocspLogQu
 		})
 	stats.MustRegister(depth)
 	return &ocspLogQueue{
-		queue:  make(chan ocspLog, 10000),
-		depth:  depth,
-		logger: logger,
+		maxLogLen: maxLogLen,
+		period:    period,
+		queue:     make(chan ocspLog, 1000),
+		wg:        sync.WaitGroup{},
+		depth:     depth,
+		logger:    logger,
 	}
 }
 
@@ -47,22 +70,43 @@ func (olq *ocspLogQueue) enqueue(serial []byte, time time.Time, status ocsp.Resp
 
 // loop consumes events from the queue channel, batches them up, and
 // logs them in batches of 100, or every 500 milliseconds, whichever comes first.
-func (olq *ocspLogQueue) loop() error {
-	for {
+func (olq *ocspLogQueue) loop() {
+	olq.wg.Add(1)
+	defer olq.wg.Done()
+	done := false
+	for !done {
 		var builder strings.Builder
 		deadline := time.After(500 * time.Millisecond)
 	inner:
-		for i := 0; i < 100; i++ {
+		// To ensure we don't go over the max log line length,
+		// use a safety margin greater than the expected length of
+		// each entry.
+		for builder.Len() < olq.maxLogLen-50 {
 			olq.depth.Set(float64(len(olq.queue)))
 			select {
-			case ol := <-olq.queue:
-				fmt.Fprintf(&builder, "%x:%d,", ol.serial, ol.status)
+			case ol, ok := <-olq.queue:
+				if !ok {
+					// Channel was closed, finish.
+					done = true
+					break inner
+				} else {
+					fmt.Fprintf(&builder, "%x:%d,", ol.serial, ol.status)
+				}
 			case <-deadline:
 				break inner
 			}
 		}
 		if builder.Len() > 0 {
-			olq.logger.AuditInfof("OCSP updates: %s", builder.String())
+			olq.logger.AuditInfof("OCSP signed: %s", builder.String())
 		}
 	}
+}
+
+// stop the loop, and wait for it to finish. This must be called only after
+// it's guaranteed that nothing will call enqueue again (for instance, after
+// the OCSPGenerator and CertificateAuthority services are shut down with
+// no RPCs in flight). Otherwise, enqueue will panic.
+func (olq *ocspLogQueue) stop() {
+	close(olq.queue)
+	olq.wg.Wait()
 }

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -1,0 +1,92 @@
+package ca
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/test"
+	"golang.org/x/crypto/ocsp"
+)
+
+// Set up an ocspLogQueue with a very long period and a large maxLen,
+// to ensure any buffered entries get flushed on `.stop()`.
+func TestOcspLogFlushOnExit(t *testing.T) {
+	t.Parallel()
+	log := blog.NewMock()
+	stats := metrics.NoopRegisterer
+	queue := newOCSPLogQueue(4000, 10000*time.Millisecond, stats, log)
+	serial, err := hex.DecodeString("aabbccddeeffaabbccddeeff000102030405")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go queue.loop()
+	queue.enqueue(serial, time.Now(), ocsp.ResponseStatus(ocsp.Good))
+	queue.stop()
+
+	expected := []string{
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,",
+	}
+	test.AssertDeepEquals(t, log.GetAll(), expected)
+}
+
+// Ensure log lines are sent when they exceed maxLen.
+func TestOcspFlushOnLength(t *testing.T) {
+	t.Parallel()
+	log := blog.NewMock()
+	stats := metrics.NoopRegisterer
+	queue := newOCSPLogQueue(100, 100*time.Millisecond, stats, log)
+	serial, err := hex.DecodeString("aabbccddeeffaabbccddeeff000102030405")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go queue.loop()
+	for i := 0; i < 5; i++ {
+		queue.enqueue(serial, time.Now(), ocsp.ResponseStatus(ocsp.Good))
+	}
+	queue.stop()
+
+	expected := []string{
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,aabbccddeeffaabbccddeeff000102030405:0,",
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,aabbccddeeffaabbccddeeff000102030405:0,",
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,",
+	}
+	test.AssertDeepEquals(t, log.GetAll(), expected)
+}
+
+// Ensure log lines are sent after a timeout.
+func TestOcspFlushOnTimeout(t *testing.T) {
+	t.Parallel()
+	log := blog.NewMock()
+	stats := metrics.NoopRegisterer
+	queue := newOCSPLogQueue(90000, 10*time.Millisecond, stats, log)
+	serial, err := hex.DecodeString("aabbccddeeffaabbccddeeff000102030405")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go queue.loop()
+	for i := 0; i < 3; i++ {
+		queue.enqueue(serial, time.Now(), ocsp.ResponseStatus(ocsp.Good))
+		queue.enqueue(serial, time.Now(), ocsp.ResponseStatus(ocsp.Good))
+		// This gets a little tricky: Each iteration of the `select` in
+		// queue.loop() is a race between the channel that receives log
+		// events and the `<-clk.After(n)` timer. Even if we used
+		// a fake clock, our loop here would often win that race, producing
+		// inconsistent logging results. For instance, it would be entirely
+		// possible for all of these `enqueues` to win the race, putting
+		// all log entries on one line.
+		// To avoid that, sleep using the wall clock for 50ms.
+		time.Sleep(50 * time.Millisecond)
+	}
+	queue.stop()
+
+	expected := []string{
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,aabbccddeeffaabbccddeeff000102030405:0,",
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,aabbccddeeffaabbccddeeff000102030405:0,",
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,aabbccddeeffaabbccddeeff000102030405:0,",
+	}
+	test.AssertDeepEquals(t, log.GetAll(), expected)
+}

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -88,6 +88,20 @@ func TestOcspFlushOnTimeout(t *testing.T) {
 	test.AssertDeepEquals(t, log.GetAll(), expected)
 }
 
+// If the deadline passes and nothing has been logged, we should not log a blank line.
+func TestOcspNoEmptyLines(t *testing.T) {
+	t.Parallel()
+	log := blog.NewMock()
+	stats := metrics.NoopRegisterer
+	queue := newOCSPLogQueue(90000, 10*time.Millisecond, stats, log)
+
+	go queue.loop()
+	time.Sleep(50 * time.Millisecond)
+	queue.stop()
+
+	test.AssertDeepEquals(t, log.GetAll(), []string{})
+}
+
 func TestOcspLogMaxLenZeroMeansNoLog(t *testing.T) {
 	t.Parallel()
 	log := blog.NewMock()
@@ -100,7 +114,7 @@ func TestOcspLogMaxLenZeroMeansNoLog(t *testing.T) {
 	test.AssertDeepEquals(t, log.GetAll(), []string{})
 }
 
-func TestOcspLogPanicsOnEnqueuAfterStop(t *testing.T) {
+func TestOcspLogPanicsOnEnqueueAfterStop(t *testing.T) {
 	t.Parallel()
 
 	log := blog.NewMock()

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -310,6 +310,7 @@ func main() {
 	if orphanQueue != nil {
 		go cai.OrphanIntegrationLoop()
 	}
+	go cai.LogOCSPLoop()
 
 	serverMetrics := bgrpc.NewServerMetrics(scope)
 

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -89,6 +89,20 @@ type config struct {
 		// is not used.
 		OrphanQueueDir string
 
+		// Maximum length (in bytes) of a line accumulating OCSP audit log entries.
+		// Recommended to be around 4000. If this is 0, do not perform OCSP audit
+		// logging.
+		OCSPLogMaxLength int
+
+		// Maximum period (in Go duration format) to wait to accumulate a max-length
+		// OCSP audit log line. We will emit a log line at least once per period,
+		// if there is anything to be logged. Keeping this low minimizes the risk
+		// of losing logs during a catastrophic failure. Making it too high
+		// means logging more often than necessary, which is inefficient in terms
+		// of bytes and log system resources.
+		// Recommended to be around 500ms.
+		OCSPLogPeriod cmd.ConfigDuration
+
 		Features map[string]bool
 	}
 
@@ -302,6 +316,8 @@ func main() {
 		c.CA.LifespanOCSP.Duration,
 		kp,
 		orphanQueue,
+		c.CA.OCSPLogMaxLength,
+		c.CA.OCSPLogPeriod.Duration,
 		logger,
 		scope,
 		clk)

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -340,6 +340,7 @@ func main() {
 		ocspHealth.Shutdown()
 		caSrv.GracefulStop()
 		ocspSrv.GracefulStop()
+		cai.Stop()
 	})
 
 	select {}

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -85,6 +85,8 @@
     "weakKeyFile": "test/example-weak-keys.json",
     "blockedKeyFile": "test/example-blocked-keys.yaml",
     "orphanQueueDir": "/tmp/orphaned-certificates-a",
+    "ocspLogMaxLength": 4000,
+    "ocspLogPeriod": "500ms",
     "features": {
       "NonCFSSLSigner": true,
       "StoreIssuerInfo": true

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -85,6 +85,8 @@
     "weakKeyFile": "test/example-weak-keys.json",
     "blockedKeyFile": "test/example-blocked-keys.yaml",
     "orphanQueueDir": "/tmp/orphaned-certificates-b",
+    "ocspLogMaxLength": 4000,
+    "ocspLogPeriod": "500ms",
     "features": {
       "NonCFSSLSigner": true,
       "StoreIssuerInfo": true


### PR DESCRIPTION
This adds a new component to the CA, `ocspLogQueue`, which batches up OCSP generation events for audit logging. It will log accumulated events when it reaches a certain line length, or when a maximum amount of times has passed.