### PR TITLE
Fix OCSP log queue blocking when maxLogLen = 0.

### DIFF
--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -97,12 +97,12 @@ func TestOcspNoEmptyLines(t *testing.T) {
 	test.AssertDeepEquals(t, log.GetAll(), []string{})
 }
 
-// If the maxLogLen is 0, log everything immediately.
-func TestOcspLogMaxLenZeroMeansLogImmediately(t *testing.T) {
+// If the maxLogLen is shorter than one entry, log everything immediately.
+func TestOcspLogWhenMaxLogLenIsShort(t *testing.T) {
 	t.Parallel()
 	log := blog.NewMock()
 	stats := metrics.NoopRegisterer
-	queue := newOCSPLogQueue(0, 10000*time.Millisecond, stats, log)
+	queue := newOCSPLogQueue(3, 10000*time.Millisecond, stats, log)
 	go queue.loop()
 	queue.enqueue(serial(t), time.Now(), ocsp.ResponseStatus(ocsp.Good))
 	queue.stop()

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -97,8 +97,8 @@ func TestOcspNoEmptyLines(t *testing.T) {
 	test.AssertDeepEquals(t, log.GetAll(), []string{})
 }
 
-// If the maxLogLen is 0, don't log anything.
-func TestOcspLogMaxLenZeroMeansNoLog(t *testing.T) {
+// If the maxLogLen is 0, log everything immediately.
+func TestOcspLogMaxLenZeroMeansLogImmediately(t *testing.T) {
 	t.Parallel()
 	log := blog.NewMock()
 	stats := metrics.NoopRegisterer
@@ -107,7 +107,10 @@ func TestOcspLogMaxLenZeroMeansNoLog(t *testing.T) {
 	queue.enqueue(serial(t), time.Now(), ocsp.ResponseStatus(ocsp.Good))
 	queue.stop()
 
-	test.AssertDeepEquals(t, log.GetAll(), []string{})
+	expected := []string{
+		"INFO: [AUDIT] OCSP signed: aabbccddeeffaabbccddeeff000102030405:0,",
+	}
+	test.AssertDeepEquals(t, log.GetAll(), expected)
 }
 
 // Enqueueing entries after stop causes panic.


### PR DESCRIPTION
Move responsibility for handling the default path (maxLogLen = 0)
from the ocspLogQueue component to CertificateAuthorityImpl. Now the
ocspLogQueue isn't constructed at all unless we configure it to be used.

Also, remove buffer from OCSP audit log chan. The bug this fixes was
hidden by the large buffer, and on reconsideration the large buffer was
unnecessary.

Verified that with the buffer removed, the integration test fails. Then
adding the fixes to the maxLogLen = 0 case fixes the integration test.

Fixes #5228 