### PR TITLE
Drop the token unique index from Authz2

### DIFF
--- a/sa/_db/migrations/20210113201944_DropUniqueTokenIndexAuthz2Table.sql
+++ b/sa/_db/migrations/20210113201944_DropUniqueTokenIndexAuthz2Table.sql
@@ -1,0 +1,10 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE authz2 DROP INDEX token, ALGORITHM=NOCOPY, LOCK=NONE;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE authz2_new ADD UNIQUE INDEX token (token), ALGORITHM=NOCOPY;


### PR DESCRIPTION
The unique index `token` is unnecessary for Boulder's security guarantees, and it is an impediment to the more subtle table management mechanisms like innodb partitioning.

Uses ALGORITHM=NOCOPY and LOCK=NONE, which require MariaDB 10.3.7. [0]

[0] https://mariadb.com/kb/en/mariadb-1037-release-notes/