### PR TITLE
Detect redirect loops in VA

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -547,10 +547,10 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		// assign to the client transport in order to connect to the redirect target using
 		// the IP address we selected.
 		redirDialer, redirRecord, err := va.setupHTTPValidation(ctx, req.URL.String(), redirTarget)
+		records = append(records, redirRecord)
 		if err != nil {
 			return err
 		}
-		records = append(records, redirRecord)
 
 		va.log.Debugf("following redirect to host %q url %q", req.Host, req.URL.String())
 		// Replace the transport's DialContext with the new preresolvedDialer for

--- a/va/http.go
+++ b/va/http.go
@@ -528,6 +528,14 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 			redirQuery = req.URL.RawQuery
 		}
 
+		// Check for a redirect loop. If any URL is found twice before the
+		// redirect limit, return error.
+		for _, record := range records {
+			if req.URL.String() == record.URL {
+				return berrors.ConnectionFailureError("Redirect loop detected")
+			}
+		}
+
 		// Create a validation target for the redirect host. This will resolve IP
 		// addresses for the host explicitly.
 		redirTarget, err := va.newHTTPValidationTarget(ctx, redirHost, redirPort, redirPath, redirQuery)
@@ -539,18 +547,10 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		// assign to the client transport in order to connect to the redirect target using
 		// the IP address we selected.
 		redirDialer, redirRecord, err := va.setupHTTPValidation(ctx, req.URL.String(), redirTarget)
+		records = append(records, redirRecord)
 		if err != nil {
 			return err
 		}
-
-		// Check for a redirect loop. If any URL is found twice before the
-		// redirect limit, return error.
-		for _, record := range records {
-			if redirRecord.URL == record.URL {
-				return berrors.ConnectionFailureError("Redirect loop detected")
-			}
-		}
-		records = append(records, redirRecord)
 
 		va.log.Debugf("following redirect to host %q url %q", req.Host, req.URL.String())
 		// Replace the transport's DialContext with the new preresolvedDialer for

--- a/va/http.go
+++ b/va/http.go
@@ -547,10 +547,10 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		// assign to the client transport in order to connect to the redirect target using
 		// the IP address we selected.
 		redirDialer, redirRecord, err := va.setupHTTPValidation(ctx, req.URL.String(), redirTarget)
-		records = append(records, redirRecord)
 		if err != nil {
 			return err
 		}
+		records = append(records, redirRecord)
 
 		va.log.Debugf("following redirect to host %q url %q", req.Host, req.URL.String())
 		// Replace the transport's DialContext with the new preresolvedDialer for

--- a/va/http.go
+++ b/va/http.go
@@ -539,10 +539,19 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		// assign to the client transport in order to connect to the redirect target using
 		// the IP address we selected.
 		redirDialer, redirRecord, err := va.setupHTTPValidation(ctx, req.URL.String(), redirTarget)
-		records = append(records, redirRecord)
 		if err != nil {
 			return err
 		}
+
+		// Check for a redirect loop. If any URL is found twice before the
+		// redirect limit, return error.
+		for _, record := range records {
+			if redirRecord.URL == record.URL {
+				return berrors.ConnectionFailureError("Redirect loop detected")
+			}
+		}
+		records = append(records, redirRecord)
+
 		va.log.Debugf("following redirect to host %q url %q", req.Host, req.URL.String())
 		// Replace the transport's DialContext with the new preresolvedDialer for
 		// the redirect.

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -517,27 +517,29 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 			http.StatusMovedPermanently)
 	})
 
-	mux.HandleFunc(fmt.Sprintf("/max-redirect"), func(resp http.ResponseWriter, req *http.Request) {
-		http.Redirect(
-			resp,
-			req,
-			fmt.Sprintf("http://example.com:%d/1/max-redirect", httpPort),
-			http.StatusMovedPermanently,
-		)
-	})
+	mux.HandleFunc(fmt.Sprintf("/max-redirect"),
+		func(resp http.ResponseWriter, req *http.Request) {
+			http.Redirect(
+				resp,
+				req,
+				fmt.Sprintf("http://example.com:%d/1/max-redirect", httpPort),
+				http.StatusMovedPermanently,
+			)
+		})
 	// A path that sequentually redirects, creating an incrementing redirect
 	// that will terminate when the redirect limit is reached and ensures each
 	// URL is different than the last.
 	for i := 1; i <= maxRedirect+1; i++ {
 		s, x := strconv.Itoa(i), strconv.Itoa(i+1)
-		mux.HandleFunc(fmt.Sprintf("/%s/max-redirect", s), func(resp http.ResponseWriter, req *http.Request) {
-			http.Redirect(
-				resp,
-				req,
-				fmt.Sprintf("http://example.com:%d/%s/max-redirect", httpPort, x),
-				http.StatusMovedPermanently,
-			)
-		})
+		mux.HandleFunc(fmt.Sprintf("/%s/max-redirect", s),
+			func(resp http.ResponseWriter, req *http.Request) {
+				http.Redirect(
+					resp,
+					req,
+					fmt.Sprintf("http://example.com:%d/%s/max-redirect", httpPort, x),
+					http.StatusMovedPermanently,
+				)
+			})
 	}
 
 	// A path that always redirects to a URL with a non-HTTP/HTTPs protocol scheme
@@ -732,10 +734,10 @@ func TestFetchHTTP(t *testing.T) {
 	// We need to know the randomly assigned HTTP port for testcases as well
 	httpPort := getPort(testSrv)
 
-	// For the looped test case we expect one validation record per until
-	// boulder detects that a url has been used twice indicating a redirect
-	// loop. Because it is hitting the /loop endpoint it will encounter this
-	// scenario after the base url and fail on the second time hitting the
+	// For the looped test case we expect one validation record per redirect
+	// until boulder detects that a url has been used twice indicating a
+	// redirect loop. Because it is hitting the /loop endpoint it will encounter
+	// this scenario after the base url and fail on the second time hitting the
 	// redirect with a port definition. On i=0 it will encounter the first
 	// redirect to the url with a port definition and on i=1 it will encounter
 	// the second redirect to the url with the port and get an expected error.

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -734,7 +734,7 @@ func TestFetchHTTP(t *testing.T) {
 	// redirect to the url with a port definition and on i=1 it will encounter
 	// the second redirect to the url with the port and get an expected error.
 	expectedLoopRecords := []core.ValidationRecord{}
-	for i := 0; i <= 1; i++ {
+	for i := 0; i < 2; i++ {
 		// The first request will not have a port # in the URL.
 		url := "http://example.com/loop"
 		if i != 0 {

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -521,13 +521,14 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 	// that will terminate when the redirect limit is reached and ensures each
 	// URL is different than the last.
 	for i := 0; i <= maxRedirect+1; i++ {
-		s, x := strconv.Itoa(i), strconv.Itoa(i+1)
-		mux.HandleFunc(fmt.Sprintf("/max-redirect/%s", s),
+		// Need to re-scope i so it iterates properly in the function
+		i := i
+		mux.HandleFunc(fmt.Sprintf("/max-redirect/%d", i),
 			func(resp http.ResponseWriter, req *http.Request) {
 				http.Redirect(
 					resp,
 					req,
-					fmt.Sprintf("http://example.com:%d/max-redirect/%s", httpPort, x),
+					fmt.Sprintf("http://example.com:%d/max-redirect/%d", httpPort, i+1),
 					http.StatusMovedPermanently,
 				)
 			})

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -508,7 +508,7 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 	})
 
 	// A path that always redirects to itself, creating a loop that will terminate
-	// after maxRedirect.
+	// when detected.
 	mux.HandleFunc("/loop", func(resp http.ResponseWriter, req *http.Request) {
 		http.Redirect(
 			resp,
@@ -516,6 +516,29 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 			fmt.Sprintf("http://example.com:%d/loop", httpPort),
 			http.StatusMovedPermanently)
 	})
+
+	mux.HandleFunc(fmt.Sprintf("/max-redirect"), func(resp http.ResponseWriter, req *http.Request) {
+		http.Redirect(
+			resp,
+			req,
+			fmt.Sprintf("http://example.com:%d/1/max-redirect", httpPort),
+			http.StatusMovedPermanently,
+		)
+	})
+	// A path that sequentually redirects, creating an incrementing redirect
+	// that will terminate when the redirect limit is reached and ensures each
+	// URL is different than the last.
+	for i := 1; i <= maxRedirect+1; i++ {
+		s, x := strconv.Itoa(i), strconv.Itoa(i+1)
+		mux.HandleFunc(fmt.Sprintf("/%s/max-redirect", s), func(resp http.ResponseWriter, req *http.Request) {
+			http.Redirect(
+				resp,
+				req,
+				fmt.Sprintf("http://example.com:%d/%s/max-redirect", httpPort, x),
+				http.StatusMovedPermanently,
+			)
+		})
+	}
 
 	// A path that always redirects to a URL with a non-HTTP/HTTPs protocol scheme
 	mux.HandleFunc("/redir-bad-proto", func(resp http.ResponseWriter, req *http.Request) {
@@ -709,17 +732,41 @@ func TestFetchHTTP(t *testing.T) {
 	// We need to know the randomly assigned HTTP port for testcases as well
 	httpPort := getPort(testSrv)
 
-	// For the looped test case we expect one validation record per redirect up to
-	// maxRedirect (inclusive). There is also +1 record for the base lookup,
-	// giving a termination criteria of > maxRedirect+1
+	// For the looped test case we expect one validation record per until
+	// boulder detects that a url has been used twice indicating a redirect
+	// loop. Because it is hitting the /loop endpoint it will encounter this
+	// scenario after the base url and fail on the second time hitting the
+	// redirect with a port definition. On i=0 it will encounter the first
+	// redirect to the url with a port definition and on i=1 it will encounter
+	// the second redirect to the url with the port and get an expected error.
 	expectedLoopRecords := []core.ValidationRecord{}
-	for i := 0; i <= maxRedirect+1; i++ {
+	for i := 0; i <= 1; i++ {
 		// The first request will not have a port # in the URL.
 		url := "http://example.com/loop"
 		if i != 0 {
 			url = fmt.Sprintf("http://example.com:%d/loop", httpPort)
 		}
 		expectedLoopRecords = append(expectedLoopRecords,
+			core.ValidationRecord{
+				Hostname:          "example.com",
+				Port:              strconv.Itoa(httpPort),
+				URL:               url,
+				AddressesResolved: []net.IP{net.ParseIP("127.0.0.1")},
+				AddressUsed:       net.ParseIP("127.0.0.1"),
+			})
+	}
+
+	// For the too many redirect test case we expect one validation record per
+	// redirect up to maxRedirect (inclusive). There is also +1 record for the
+	// base lookup, giving a termination criteria of > maxRedirect+1
+	expectedTooManyRedirRecords := []core.ValidationRecord{}
+	for i := 0; i <= maxRedirect+1; i++ {
+		// The first request will not have a port # in the URL.
+		url := "http://example.com/max-redirect"
+		if i != 0 {
+			url = fmt.Sprintf("http://example.com:%d/%d/max-redirect", httpPort, i)
+		}
+		expectedTooManyRedirRecords = append(expectedTooManyRedirRecords,
 			core.ValidationRecord{
 				Hostname:          "example.com",
 				Port:              strconv.Itoa(httpPort),
@@ -774,8 +821,16 @@ func TestFetchHTTP(t *testing.T) {
 			Host: "example.com",
 			Path: "/loop",
 			ExpectedProblem: probs.ConnectionFailure(fmt.Sprintf(
-				"Fetching http://example.com:%d/loop: Too many redirects", httpPort)),
+				"Fetching http://example.com:%d/loop: Redirect loop detected", httpPort)),
 			ExpectedRecords: expectedLoopRecords,
+		},
+		{
+			Name: "Too many redirects",
+			Host: "example.com",
+			Path: "/max-redirect",
+			ExpectedProblem: probs.ConnectionFailure(fmt.Sprintf(
+				"Fetching http://example.com:%d/12/max-redirect: Too many redirects", httpPort)),
+			ExpectedRecords: expectedTooManyRedirRecords,
 		},
 		{
 			Name: "Redirect to bad protocol",

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -517,7 +517,7 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 			http.StatusMovedPermanently)
 	})
 
-	// A path that sequentually redirects, creating an incrementing redirect
+	// A path that sequentially redirects, creating an incrementing redirect
 	// that will terminate when the redirect limit is reached and ensures each
 	// URL is different than the last.
 	for i := 0; i <= maxRedirect+1; i++ {
@@ -755,7 +755,7 @@ func TestFetchHTTP(t *testing.T) {
 	// base lookup, giving a termination criteria of > maxRedirect+1
 	expectedTooManyRedirRecords := []core.ValidationRecord{}
 	for i := 0; i <= maxRedirect+1; i++ {
-		//The first request will not have a port # in the URL.
+		// The first request will not have a port # in the URL.
 		url := "http://example.com/max-redirect/0"
 		if i != 0 {
 			url = fmt.Sprintf("http://example.com:%d/max-redirect/%d", httpPort, i)


### PR DESCRIPTION
Currently the VA checks to see how many redirects have been followed and
bails out if greater than maxRedirect (10), but it does not check to see
if any redirect url has been followed twice which would mean a broken
infinite redirect loop. Storing the validation records for these is
relatively expensive because we store a record for each hop in the
redirect.

This change checks the previous redirect records to see if the URL has
been used before and error if it has. This will catch a redirect loop
earlier than the maxRedirect value in most cases.

Fixes #5224