### PR TITLE
Update to go1.15.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: focal
 os: linux
 
 go:
-  - "1.15.5"
+  - "1.15.7"
 
 go_import_path: github.com/letsencrypt/boulder
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: focal
 os: linux
 
 go:
+  - "1.15.5"
   - "1.15.7"
 
 go_import_path: github.com/letsencrypt/boulder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.5}:2020-11-20
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.7}:2021-01-19
         environment:
             - FAKE_DNS=10.77.77.77
             - BOULDER_CONFIG_DIR=test/config
@@ -76,7 +76,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.5}:2020-11-20
+        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.7}:2021-01-19
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.15.5" )
+GO_VERSIONS=( "1.15.7" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.15.7" )
+GO_VERSIONS=( "1.15.5" "1.15.7" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
Go version 1.15.7 is a security release.

Fixes: #5237