### PR TITLE
Authenticate to DockerHub in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
   - docker-compose pull
 
 script:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - >-
     docker-compose run --use-aliases
     -e TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   # of 2021-01-20 it is a read-only user in DockerHub but is used to
   # bypass rate limits imposed by DockerHub to non-authenticated
   # non-paying users.
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true
   - >-
     docker-compose run --use-aliases
     -e TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ install:
   - docker-compose pull
 
 script:
+  # This user is stored in the TravisCI repository settings in the UI As
+  # of 2021-01-20 it is a read-only user in DockerHub but is used to
+  # bypass rate limits imposed by DockerHub to non-authenticated
+  # non-paying users.
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - >-
     docker-compose run --use-aliases


### PR DESCRIPTION
Currently we do not login to DockerHub for CI and are being rate limited
on pulls.

This adds a docker login using env variables that are setup in our Travis
repository.

The login credentials are a bot username and a purpose generated DockerHub
CLI token stored as ENV variables that are not viewable after added to the
TravisCI repository settings.

Risks and best practices for managing these secrets can be found at
https://docs.travis-ci.com/user/best-practices-security.

Fixes #5212
