### PR TITLE
deps: update publicsuffix-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
-	github.com/weppos/publicsuffix-go v0.13.1-0.20201231103007-cb9948bdd70d
+	github.com/weppos/publicsuffix-go v0.13.1-0.20210123135404-5fd73613514e
 	github.com/zmap/zcrypto v0.0.0-20200513165325-16679db567ff
 	github.com/zmap/zlint/v2 v2.2.1
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/weppos/publicsuffix-go v0.13.1-0.20200721065424-2c0d957a7459 h1:HSg0s
 github.com/weppos/publicsuffix-go v0.13.1-0.20200721065424-2c0d957a7459/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
 github.com/weppos/publicsuffix-go v0.13.1-0.20201231103007-cb9948bdd70d h1:IQSbczOwgHe9b66yjFunc52erpWWpMrboQHUbwEoxB4=
 github.com/weppos/publicsuffix-go v0.13.1-0.20201231103007-cb9948bdd70d/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
+github.com/weppos/publicsuffix-go v0.13.1-0.20210123135404-5fd73613514e h1:X8mSlwys/CsazsP+x4De5k6JaltoDTpx72EV7KdEtNk=
+github.com/weppos/publicsuffix-go v0.13.1-0.20210123135404-5fd73613514e/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=

--- a/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
+++ b/vendor/github.com/weppos/publicsuffix-go/publicsuffix/rules.go
@@ -3,13 +3,13 @@
 
 package publicsuffix
 
-const defaultListVersion = "PSL version 6b67c6 (Wed Dec 23 23:20:29 2020)"
+const defaultListVersion = "PSL version f2cce8 (Thu Jan 21 11:57:05 2021)"
 
-func DefaultRules() [9105]Rule {
+func DefaultRules() [9117]Rule {
 	return r
 }
 
-var r = [9105]Rule{
+var r = [9117]Rule{
 	{1, "ac", 1, false},
 	{1, "com.ac", 2, false},
 	{1, "edu.ac", 2, false},
@@ -6141,7 +6141,13 @@ var r = [9105]Rule{
 	{1, "xn--j1amh", 1, false},
 	{1, "xn--mgb2ddes", 1, false},
 	{1, "xxx", 1, false},
-	{2, "ye", 2, false},
+	{1, "ye", 1, false},
+	{1, "com.ye", 2, false},
+	{1, "edu.ye", 2, false},
+	{1, "gov.ye", 2, false},
+	{1, "net.ye", 2, false},
+	{1, "mil.ye", 2, false},
+	{1, "org.ye", 2, false},
 	{1, "ac.za", 2, false},
 	{1, "agric.za", 2, false},
 	{1, "alt.za", 2, false},
@@ -8138,6 +8144,7 @@ var r = [9105]Rule{
 	{1, "filegear-jp.me", 2, true},
 	{1, "filegear-sg.me", 2, true},
 	{1, "firebaseapp.com", 2, true},
+	{1, "fireweb.app", 2, true},
 	{1, "flap.id", 2, true},
 	{1, "fly.dev", 2, true},
 	{1, "edgeapp.net", 2, true},
@@ -8151,6 +8158,7 @@ var r = [9105]Rule{
 	{1, "freebox-os.fr", 2, true},
 	{1, "freeboxos.fr", 2, true},
 	{1, "freedesktop.org", 2, true},
+	{1, "freemyip.com", 2, true},
 	{1, "wien.funkfeuer.at", 3, true},
 	{2, "futurecms.at", 3, true},
 	{2, "ex.futurecms.at", 4, true},
@@ -8167,6 +8175,7 @@ var r = [9105]Rule{
 	{1, "gentlentapis.com", 2, true},
 	{1, "lab.ms", 2, true},
 	{1, "cdn-edges.net", 2, true},
+	{1, "ghost.io", 2, true},
 	{1, "github.io", 2, true},
 	{1, "githubusercontent.com", 2, true},
 	{1, "gitlab.io", 2, true},
@@ -8567,8 +8576,11 @@ var r = [9105]Rule{
 	{1, "pp.ru", 2, true},
 	{1, "hostedpi.com", 2, true},
 	{1, "customer.mythic-beasts.com", 3, true},
+	{1, "caracal.mythic-beasts.com", 3, true},
+	{1, "fentiger.mythic-beasts.com", 3, true},
 	{1, "lynx.mythic-beasts.com", 3, true},
 	{1, "ocelot.mythic-beasts.com", 3, true},
+	{1, "oncilla.mythic-beasts.com", 3, true},
 	{1, "onza.mythic-beasts.com", 3, true},
 	{1, "sphinx.mythic-beasts.com", 3, true},
 	{1, "vs.mythic-beasts.com", 3, true},
@@ -8880,6 +8892,7 @@ var r = [9105]Rule{
 	{1, "pp.ua", 2, true},
 	{1, "shiftedit.io", 2, true},
 	{1, "myshopblocks.com", 2, true},
+	{1, "myshopify.com", 2, true},
 	{1, "shopitsite.com", 2, true},
 	{1, "shopware.store", 2, true},
 	{1, "mo-siemens.io", 2, true},
@@ -8893,6 +8906,7 @@ var r = [9105]Rule{
 	{1, "alpha.bounty-full.com", 3, true},
 	{1, "beta.bounty-full.com", 3, true},
 	{1, "small-web.org", 2, true},
+	{1, "try-snowplow.com", 2, true},
 	{1, "stackhero-network.com", 2, true},
 	{1, "static.land", 2, true},
 	{1, "dev.static.land", 3, true},
@@ -8908,8 +8922,6 @@ var r = [9105]Rule{
 	{1, "soc.srcf.net", 3, true},
 	{1, "user.srcf.net", 3, true},
 	{1, "temp-dns.com", 2, true},
-	{1, "applicationcloud.io", 2, true},
-	{1, "scapp.io", 2, true},
 	{2, "s5y.io", 3, true},
 	{2, "sensiosite.cloud", 3, true},
 	{1, "syncloud.it", 2, true},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -93,7 +93,7 @@ github.com/syndtr/goleveldb/leveldb/table
 github.com/syndtr/goleveldb/leveldb/util
 # github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
 github.com/titanous/rocacheck
-# github.com/weppos/publicsuffix-go v0.13.1-0.20201231103007-cb9948bdd70d
+# github.com/weppos/publicsuffix-go v0.13.1-0.20210123135404-5fd73613514e
 github.com/weppos/publicsuffix-go/publicsuffix
 # github.com/zmap/zcrypto v0.0.0-20200513165325-16679db567ff
 github.com/zmap/zcrypto/json


### PR DESCRIPTION
This brings in 1 new commit, adding 15 suffixes and removing 3.

https://github.com/weppos/publicsuffix-go/compare/cb9948bdd70d..5fd73613514e

--

This was requested [here](https://community.letsencrypt.org/t/cannot-issue-for-riyadh-ye-domain-name-is-an-icann-tld/143499/1).