### PR TITLE
Stop running tests on go1.15.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: focal
 os: linux
 
 go:
-  - "1.15.5"
   - "1.15.7"
 
 go_import_path: github.com/letsencrypt/boulder

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.15.5" "1.15.7" )
+GO_VERSIONS=( "1.15.7" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
The go 1.15.7 security release is running everywhere, so we no
longer need to run tests on this older version.

Fixes #5237