### PR TITLE
Rename several items in bdns

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -390,10 +390,10 @@ func (dnsClient *impl) LookupTXT(ctx context.Context, hostname string) ([]string
 	dnsType := dns.TypeTXT
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
 	if err != nil {
-		return nil, &DNSError{dnsType, hostname, err, -1}
+		return nil, &Error{dnsType, hostname, err, -1}
 	}
 	if r.Rcode != dns.RcodeSuccess {
-		return nil, &DNSError{dnsType, hostname, nil, r.Rcode}
+		return nil, &Error{dnsType, hostname, nil, r.Rcode}
 	}
 
 	for _, answer := range r.Answer {
@@ -428,10 +428,10 @@ func isPrivateV6(ip net.IP) bool {
 func (dnsClient *impl) lookupIP(ctx context.Context, hostname string, ipType uint16) ([]dns.RR, error) {
 	resp, err := dnsClient.exchangeOne(ctx, hostname, ipType)
 	if err != nil {
-		return nil, &DNSError{ipType, hostname, err, -1}
+		return nil, &Error{ipType, hostname, err, -1}
 	}
 	if resp.Rcode != dns.RcodeSuccess {
-		return nil, &DNSError{ipType, hostname, nil, resp.Rcode}
+		return nil, &Error{ipType, hostname, nil, resp.Rcode}
 	}
 	return resp.Answer, nil
 }
@@ -491,11 +491,11 @@ func (dnsClient *impl) LookupCAA(ctx context.Context, hostname string) ([]*dns.C
 	dnsType := dns.TypeCAA
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
 	if err != nil {
-		return nil, "", &DNSError{dnsType, hostname, err, -1}
+		return nil, "", &Error{dnsType, hostname, err, -1}
 	}
 
 	if r.Rcode == dns.RcodeServerFailure {
-		return nil, "", &DNSError{dnsType, hostname, nil, r.Rcode}
+		return nil, "", &Error{dnsType, hostname, nil, r.Rcode}
 	}
 
 	var CAAs []*dns.CAA

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -146,15 +146,15 @@ var (
 	}
 )
 
-// DNSClient queries for DNS records
-type DNSClient interface {
+// Client queries for DNS records
+type Client interface {
 	LookupTXT(context.Context, string) (txts []string, err error)
 	LookupHost(context.Context, string) ([]net.IP, error)
 	LookupCAA(context.Context, string) ([]*dns.CAA, string, error)
 }
 
-// DNSClientImpl represents a client that talks to an external resolver
-type DNSClientImpl struct {
+// ClientImpl represents a client that talks to an external resolver
+type ClientImpl struct {
 	dnsClient                exchanger
 	servers                  []string
 	allowRestrictedAddresses bool
@@ -168,22 +168,22 @@ type DNSClientImpl struct {
 	idMismatchCounter *prometheus.CounterVec
 }
 
-var _ DNSClient = &DNSClientImpl{}
+var _ Client = &ClientImpl{}
 
 type exchanger interface {
 	Exchange(m *dns.Msg, a string) (*dns.Msg, time.Duration, error)
 }
 
-// NewDNSClientImpl constructs a new DNS resolver object that utilizes the
+// New constructs a new DNS resolver object that utilizes the
 // provided list of DNS servers for resolution.
-func NewDNSClientImpl(
+func New(
 	readTimeout time.Duration,
 	servers []string,
 	stats prometheus.Registerer,
 	clk clock.Clock,
 	maxTries int,
 	log blog.Logger,
-) *DNSClientImpl {
+) *ClientImpl {
 	dnsClient := new(dns.Client)
 
 	// Set timeout for underlying net.Conn
@@ -222,7 +222,7 @@ func NewDNSClientImpl(
 	)
 	stats.MustRegister(queryTime, totalLookupTime, timeoutCounter, idMismatchCounter)
 
-	return &DNSClientImpl{
+	return &ClientImpl{
 		dnsClient:                dnsClient,
 		servers:                  servers,
 		allowRestrictedAddresses: false,
@@ -236,17 +236,17 @@ func NewDNSClientImpl(
 	}
 }
 
-// NewTestDNSClientImpl constructs a new DNS resolver object that utilizes the
+// NewTest constructs a new DNS resolver object that utilizes the
 // provided list of DNS servers for resolution and will allow loopback addresses.
 // This constructor should *only* be called from tests (unit or integration).
-func NewTestDNSClientImpl(
+func NewTest(
 	readTimeout time.Duration,
 	servers []string,
 	stats prometheus.Registerer,
 	clk clock.Clock,
 	maxTries int,
-	log blog.Logger) *DNSClientImpl {
-	resolver := NewDNSClientImpl(readTimeout, servers, stats, clk, maxTries, log)
+	log blog.Logger) *ClientImpl {
+	resolver := New(readTimeout, servers, stats, clk, maxTries, log)
 	resolver.allowRestrictedAddresses = true
 	return resolver
 }
@@ -255,7 +255,7 @@ func NewTestDNSClientImpl(
 // out of the server list, returning the response, time, and error (if any).
 // We assume that the upstream resolver requests and validates DNSSEC records
 // itself.
-func (dnsClient *DNSClientImpl) exchangeOne(ctx context.Context, hostname string, qtype uint16) (resp *dns.Msg, err error) {
+func (dnsClient *ClientImpl) exchangeOne(ctx context.Context, hostname string, qtype uint16) (resp *dns.Msg, err error) {
 	m := new(dns.Msg)
 	// Set question type
 	m.SetQuestion(dns.Fqdn(hostname), qtype)
@@ -385,7 +385,7 @@ type dnsResp struct {
 // LookupTXT sends a DNS query to find all TXT records associated with
 // the provided hostname which it returns along with the returned
 // DNS authority section.
-func (dnsClient *DNSClientImpl) LookupTXT(ctx context.Context, hostname string) ([]string, error) {
+func (dnsClient *ClientImpl) LookupTXT(ctx context.Context, hostname string) ([]string, error) {
 	var txt []string
 	dnsType := dns.TypeTXT
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
@@ -425,7 +425,7 @@ func isPrivateV6(ip net.IP) bool {
 	return false
 }
 
-func (dnsClient *DNSClientImpl) lookupIP(ctx context.Context, hostname string, ipType uint16) ([]dns.RR, error) {
+func (dnsClient *ClientImpl) lookupIP(ctx context.Context, hostname string, ipType uint16) ([]dns.RR, error) {
 	resp, err := dnsClient.exchangeOne(ctx, hostname, ipType)
 	if err != nil {
 		return nil, &DNSError{ipType, hostname, err, -1}
@@ -442,7 +442,7 @@ func (dnsClient *DNSClientImpl) lookupIP(ctx context.Context, hostname string, i
 // requests in the case of temporary network errors. It can return net package,
 // context.Canceled, and context.DeadlineExceeded errors, all wrapped in the
 // DNSError type.
-func (dnsClient *DNSClientImpl) LookupHost(ctx context.Context, hostname string) ([]net.IP, error) {
+func (dnsClient *ClientImpl) LookupHost(ctx context.Context, hostname string) ([]net.IP, error) {
 	var recordsA, recordsAAAA []dns.RR
 	var errA, errAAAA error
 	var wg sync.WaitGroup
@@ -487,7 +487,7 @@ func (dnsClient *DNSClientImpl) LookupHost(ctx context.Context, hostname string)
 // the provided hostname and the complete dig-style RR `response`. This
 // response is quite verbose, however it's only populated when the CAA
 // response is non-empty.
-func (dnsClient *DNSClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, string, error) {
+func (dnsClient *ClientImpl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, string, error) {
 	dnsType := dns.TypeCAA
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
 	if err != nil {

--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -183,7 +183,7 @@ func New(
 	clk clock.Clock,
 	maxTries int,
 	log blog.Logger,
-) *impl {
+) Client {
 	dnsClient := new(dns.Client)
 
 	// Set timeout for underlying net.Conn
@@ -245,9 +245,9 @@ func NewTest(
 	stats prometheus.Registerer,
 	clk clock.Clock,
 	maxTries int,
-	log blog.Logger) *impl {
+	log blog.Logger) Client {
 	resolver := New(readTimeout, servers, stats, clk, maxTries, log)
-	resolver.allowRestrictedAddresses = true
+	resolver.(*impl).allowRestrictedAddresses = true
 	return resolver
 }
 

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -242,7 +242,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestDNSNoServers(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Hour, []string{}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Hour, []string{}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -250,7 +250,7 @@ func TestDNSNoServers(t *testing.T) {
 }
 
 func TestDNSOneServer(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -258,7 +258,7 @@ func TestDNSOneServer(t *testing.T) {
 }
 
 func TestDNSDuplicateServers(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr, dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{dnsLoopbackAddr, dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 
@@ -266,7 +266,7 @@ func TestDNSDuplicateServers(t *testing.T) {
 }
 
 func TestDNSLookupsNoServer(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
 	_, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 	test.AssertError(t, err, "No servers")
@@ -279,7 +279,7 @@ func TestDNSLookupsNoServer(t *testing.T) {
 }
 
 func TestDNSServFail(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 	bad := "servfail.com"
 
 	_, err := obj.LookupTXT(context.Background(), bad)
@@ -294,7 +294,7 @@ func TestDNSServFail(t *testing.T) {
 }
 
 func TestDNSLookupTXT(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
 	a, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 	t.Logf("A: %v", a)
@@ -308,7 +308,7 @@ func TestDNSLookupTXT(t *testing.T) {
 }
 
 func TestDNSLookupHost(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
 	ip, err := obj.LookupHost(context.Background(), "servfail.com")
 	t.Logf("servfail.com - IP: %s, Err: %s", ip, err)
@@ -373,7 +373,7 @@ func TestDNSLookupHost(t *testing.T) {
 }
 
 func TestDNSNXDOMAIN(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
 	hostname := "nxdomain.letsencrypt.org"
 	_, err := obj.LookupHost(context.Background(), hostname)
@@ -386,7 +386,7 @@ func TestDNSNXDOMAIN(t *testing.T) {
 }
 
 func TestDNSLookupCAA(t *testing.T) {
-	obj := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
+	obj := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 	removeIDExp := regexp.MustCompile(" id: [[:digit:]]+")
 
 	caas, resp, err := obj.LookupCAA(context.Background(), "bracewel.net")
@@ -596,7 +596,7 @@ func TestRetry(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), tc.maxTries, blog.UseMock())
+		dr := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), tc.maxTries, blog.UseMock())
 		dr.dnsClient = tc.te
 		_, err := dr.LookupTXT(context.Background(), "example.com")
 		if err == errTooManyRequests {
@@ -623,7 +623,7 @@ func TestRetry(t *testing.T) {
 		}
 	}
 
-	dr := NewTestDNSClientImpl(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 3, blog.UseMock())
+	dr := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 3, blog.UseMock())
 	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -716,7 +716,7 @@ func TestRotateServerOnErr(t *testing.T) {
 	// number of dnsServers to ensure we always get around to trying the one
 	// working server
 	maxTries := 5
-	client := NewTestDNSClientImpl(time.Second*10, dnsServers, metrics.NoopRegisterer, clock.NewFake(), maxTries, blog.UseMock())
+	client := NewTest(time.Second*10, dnsServers, metrics.NoopRegisterer, clock.NewFake(), maxTries, blog.UseMock())
 
 	// Configure a mock exchanger that will always return a retryable error for
 	// the A and B servers. This will force the C server to do all the work once

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -596,7 +596,8 @@ func TestRetry(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		dr := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), tc.maxTries, blog.UseMock())
+		testClient := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), tc.maxTries, blog.UseMock())
+		dr := testClient.(*impl)
 		dr.dnsClient = tc.te
 		_, err := dr.LookupTXT(context.Background(), "example.com")
 		if err == errTooManyRequests {
@@ -623,7 +624,8 @@ func TestRetry(t *testing.T) {
 		}
 	}
 
-	dr := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 3, blog.UseMock())
+	testClient := NewTest(time.Second*10, []string{dnsLoopbackAddr}, metrics.NoopRegisterer, clock.NewFake(), 3, blog.UseMock())
+	dr := testClient.(*impl)
 	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -725,7 +727,7 @@ func TestRotateServerOnErr(t *testing.T) {
 		brokenAddresses: map[string]bool{"a": true, "b": true},
 		lookups:         make(map[string]int),
 	}
-	client.dnsClient = mock
+	client.(*impl).dnsClient = mock
 
 	// Perform a bunch of lookups. We choose the initial server randomly. Any time
 	// A or B is chosen there should be an error and a retry using the next server

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -368,7 +368,7 @@ func TestDNSLookupHost(t *testing.T) {
 	ip, err = obj.LookupHost(context.Background(), hostname)
 	t.Logf("%s - IP: %s, Err: %s", hostname, ip, err)
 	test.AssertError(t, err, "Should be an error")
-	expectedErr := &DNSError{dns.TypeA, hostname, nil, dns.RcodeRefused}
+	expectedErr := &Error{dns.TypeA, hostname, nil, dns.RcodeRefused}
 	test.AssertDeepEquals(t, err, expectedErr)
 }
 
@@ -377,7 +377,7 @@ func TestDNSNXDOMAIN(t *testing.T) {
 
 	hostname := "nxdomain.letsencrypt.org"
 	_, err := obj.LookupHost(context.Background(), hostname)
-	expected := &DNSError{dns.TypeA, hostname, nil, dns.RcodeNameError}
+	expected := &Error{dns.TypeA, hostname, nil, dns.RcodeNameError}
 	test.AssertDeepEquals(t, err, expected)
 
 	_, err = obj.LookupTXT(context.Background(), hostname)

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -73,7 +73,7 @@ func (mock *MockClient) LookupHost(_ context.Context, hostname string) ([]net.IP
 		return []net.IP{}, nil
 	}
 	if hostname == "always.timeout" {
-		return []net.IP{}, &DNSError{dns.TypeA, "always.timeout", makeTimeoutError(), -1}
+		return []net.IP{}, &Error{dns.TypeA, "always.timeout", makeTimeoutError(), -1}
 	}
 	if hostname == "always.error" {
 		err := &net.OpError{
@@ -86,7 +86,7 @@ func (mock *MockClient) LookupHost(_ context.Context, hostname string) ([]net.IP
 		m.AuthenticatedData = true
 		m.SetEdns0(4096, false)
 		logDNSError(mock.Log, "mock.server", hostname, m, nil, err)
-		return []net.IP{}, &DNSError{dns.TypeA, hostname, err, -1}
+		return []net.IP{}, &Error{dns.TypeA, hostname, err, -1}
 	}
 	if hostname == "id.mismatch" {
 		err := dns.ErrId
@@ -100,7 +100,7 @@ func (mock *MockClient) LookupHost(_ context.Context, hostname string) ([]net.IP
 		record.A = net.ParseIP("127.0.0.1")
 		r.Answer = append(r.Answer, record)
 		logDNSError(mock.Log, "mock.server", hostname, m, r, err)
-		return []net.IP{}, &DNSError{dns.TypeA, hostname, err, -1}
+		return []net.IP{}, &Error{dns.TypeA, hostname, err, -1}
 	}
 	// dual-homed host with an IPv6 and an IPv4 address
 	if hostname == "ipv4.and.ipv6.localhost" {

--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -12,13 +12,13 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-// MockDNSClient is a mock
-type MockDNSClient struct {
+// MockClient is a mock
+type MockClient struct {
 	Log blog.Logger
 }
 
 // LookupTXT is a mock
-func (mock *MockDNSClient) LookupTXT(_ context.Context, hostname string) ([]string, error) {
+func (mock *MockClient) LookupTXT(_ context.Context, hostname string) ([]string, error) {
 	if hostname == "_acme-challenge.servfail.com" {
 		return nil, fmt.Errorf("SERVFAIL")
 	}
@@ -50,8 +50,8 @@ func (mock *MockDNSClient) LookupTXT(_ context.Context, hostname string) ([]stri
 	return []string{"hostname"}, nil
 }
 
-// MockTimeoutError returns a a net.OpError for which Timeout() returns true.
-func MockTimeoutError() *net.OpError {
+// makeTimeoutError returns a a net.OpError for which Timeout() returns true.
+func makeTimeoutError() *net.OpError {
 	return &net.OpError{
 		Err: os.NewSyscallError("ugh timeout", timeoutError{}),
 	}
@@ -67,13 +67,13 @@ func (t timeoutError) Timeout() bool {
 }
 
 // LookupHost is a mock
-func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
+func (mock *MockClient) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
 	if hostname == "always.invalid" ||
 		hostname == "invalid.invalid" {
 		return []net.IP{}, nil
 	}
 	if hostname == "always.timeout" {
-		return []net.IP{}, &DNSError{dns.TypeA, "always.timeout", MockTimeoutError(), -1}
+		return []net.IP{}, &DNSError{dns.TypeA, "always.timeout", makeTimeoutError(), -1}
 	}
 	if hostname == "always.error" {
 		err := &net.OpError{
@@ -119,6 +119,6 @@ func (mock *MockDNSClient) LookupHost(_ context.Context, hostname string) ([]net
 }
 
 // LookupCAA returns mock records for use in tests.
-func (mock *MockDNSClient) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, string, error) {
+func (mock *MockClient) LookupCAA(_ context.Context, domain string) ([]*dns.CAA, string, error) {
 	return nil, "", nil
 }

--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -8,8 +8,8 @@ import (
 	"github.com/miekg/dns"
 )
 
-// DNSError wraps a DNS error with various relevant information
-type DNSError struct {
+// Error wraps a DNS error with various relevant information
+type Error struct {
 	recordType uint16
 	hostname   string
 	// Exactly one of rCode or underlying should be set.
@@ -17,11 +17,11 @@ type DNSError struct {
 	rCode      int
 }
 
-func (d DNSError) Underlying() error {
+func (d Error) Underlying() error {
 	return d.underlying
 }
 
-func (d DNSError) Error() string {
+func (d Error) Error() string {
 	var detail, additional string
 	if d.underlying != nil {
 		if netErr, ok := d.underlying.(*net.OpError); ok {
@@ -50,7 +50,7 @@ func (d DNSError) Error() string {
 }
 
 // Timeout returns true if the underlying error was a timeout
-func (d DNSError) Timeout() bool {
+func (d Error) Timeout() bool {
 	if netErr, ok := d.underlying.(*net.OpError); ok {
 		return netErr.Timeout()
 	} else if d.underlying == context.Canceled || d.underlying == context.DeadlineExceeded {

--- a/bdns/problem_test.go
+++ b/bdns/problem_test.go
@@ -9,31 +9,31 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestDNSError(t *testing.T) {
+func TestError(t *testing.T) {
 	testCases := []struct {
 		err      error
 		expected string
 	}{
 		{
-			&DNSError{dns.TypeA, "hostname", makeTimeoutError(), -1},
+			&Error{dns.TypeA, "hostname", makeTimeoutError(), -1},
 			"DNS problem: query timed out looking up A for hostname",
 		}, {
-			&DNSError{dns.TypeMX, "hostname", &net.OpError{Err: errors.New("some net error")}, -1},
+			&Error{dns.TypeMX, "hostname", &net.OpError{Err: errors.New("some net error")}, -1},
 			"DNS problem: networking error looking up MX for hostname",
 		}, {
-			&DNSError{dns.TypeTXT, "hostname", nil, dns.RcodeNameError},
+			&Error{dns.TypeTXT, "hostname", nil, dns.RcodeNameError},
 			"DNS problem: NXDOMAIN looking up TXT for hostname - check that a DNS record exists for this domain",
 		}, {
-			&DNSError{dns.TypeTXT, "hostname", context.DeadlineExceeded, -1},
+			&Error{dns.TypeTXT, "hostname", context.DeadlineExceeded, -1},
 			"DNS problem: query timed out looking up TXT for hostname",
 		}, {
-			&DNSError{dns.TypeTXT, "hostname", context.Canceled, -1},
+			&Error{dns.TypeTXT, "hostname", context.Canceled, -1},
 			"DNS problem: query timed out looking up TXT for hostname",
 		}, {
-			&DNSError{dns.TypeCAA, "hostname", nil, dns.RcodeServerFailure},
+			&Error{dns.TypeCAA, "hostname", nil, dns.RcodeServerFailure},
 			"DNS problem: SERVFAIL looking up CAA for hostname - the domain's nameservers may be malfunctioning",
 		}, {
-			&DNSError{dns.TypeA, "hostname", nil, dns.RcodeFormatError},
+			&Error{dns.TypeA, "hostname", nil, dns.RcodeFormatError},
 			"DNS problem: FORMERR looking up A for hostname",
 		},
 	}

--- a/bdns/problem_test.go
+++ b/bdns/problem_test.go
@@ -15,7 +15,7 @@ func TestDNSError(t *testing.T) {
 		expected string
 	}{
 		{
-			&DNSError{dns.TypeA, "hostname", MockTimeoutError(), -1},
+			&DNSError{dns.TypeA, "hostname", makeTimeoutError(), -1},
 			"DNS problem: query timed out looking up A for hostname",
 		}, {
 			&DNSError{dns.TypeMX, "hostname", &net.OpError{Err: errors.New("some net error")}, -1},

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -107,12 +107,12 @@ func main() {
 		dnsTries = 1
 	}
 	clk := cmd.Clock()
-	var resolver bdns.DNSClient
+	var resolver bdns.Client
 	if len(c.Common.DNSResolver) != 0 {
 		c.VA.DNSResolvers = append(c.VA.DNSResolvers, c.Common.DNSResolver)
 	}
 	if !c.Common.DNSAllowLoopbackAddresses {
-		r := bdns.NewDNSClientImpl(
+		r := bdns.New(
 			dnsTimeout,
 			c.VA.DNSResolvers,
 			scope,
@@ -121,7 +121,7 @@ func main() {
 			logger)
 		resolver = r
 	} else {
-		r := bdns.NewTestDNSClientImpl(
+		r := bdns.NewTest(
 			dnsTimeout,
 			c.VA.DNSResolvers,
 			scope,

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -139,7 +139,7 @@ func TestDNSValidationServFail(t *testing.T) {
 
 func TestDNSValidationNoServer(t *testing.T) {
 	va, log := setup(nil, 0, "", nil)
-	va.dnsClient = bdns.NewTestDNSClientImpl(
+	va.dnsClient = bdns.NewTest(
 		time.Second*5,
 		nil,
 		metrics.NoopRegisterer,

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -70,7 +70,7 @@ func TestPreresolvedDialerTimeout(t *testing.T) {
 
 	started := time.Now()
 
-	va.dnsClient = dnsMockReturnsUnroutable{&bdns.MockDNSClient{}}
+	va.dnsClient = dnsMockReturnsUnroutable{&bdns.MockClient{}}
 	// NOTE(@jsha): The only method I've found so far to trigger a connect timeout
 	// is to connect to an unrouteable IP address. This usually generates
 	// a connection timeout, but will rarely return "Network unreachable" instead.
@@ -1299,7 +1299,7 @@ func TestHTTPTimeout(t *testing.T) {
 // unroutable address for LookupHost. This is useful in testing connect
 // timeouts.
 type dnsMockReturnsUnroutable struct {
-	*bdns.MockDNSClient
+	*bdns.MockClient
 }
 
 func (mock dnsMockReturnsUnroutable) LookupHost(_ context.Context, hostname string) ([]net.IP, error) {
@@ -1317,7 +1317,7 @@ func TestHTTPDialTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	va.dnsClient = dnsMockReturnsUnroutable{&bdns.MockDNSClient{}}
+	va.dnsClient = dnsMockReturnsUnroutable{&bdns.MockClient{}}
 	// The only method I've found so far to trigger a connect timeout is to
 	// connect to an unrouteable IP address. This usually generates a connection
 	// timeout, but will rarely return "Network unreachable" instead. If we get

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -207,7 +207,7 @@ func TestTLSALPN01DialTimeout(t *testing.T) {
 	chall := tlsalpnChallenge()
 	hs := slowTLSSrv()
 	va, _ := setup(hs, 0, "", nil)
-	va.dnsClient = dnsMockReturnsUnroutable{&bdns.MockDNSClient{}}
+	va.dnsClient = dnsMockReturnsUnroutable{&bdns.MockClient{}}
 	started := time.Now()
 
 	timeout := 50 * time.Millisecond

--- a/va/va.go
+++ b/va/va.go
@@ -172,7 +172,7 @@ func initMetrics(stats prometheus.Registerer) *vaMetrics {
 // ValidationAuthorityImpl represents a VA
 type ValidationAuthorityImpl struct {
 	log                blog.Logger
-	dnsClient          bdns.DNSClient
+	dnsClient          bdns.Client
 	issuerDomain       string
 	httpPort           int
 	httpsPort          int
@@ -190,7 +190,7 @@ type ValidationAuthorityImpl struct {
 // NewValidationAuthorityImpl constructs a new VA
 func NewValidationAuthorityImpl(
 	pc *cmd.PortConfig,
-	resolver bdns.DNSClient,
+	resolver bdns.Client,
 	remoteVAs []RemoteVA,
 	maxRemoteFailures int,
 	userAgent string,

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -134,7 +134,7 @@ func setup(srv *httptest.Server, maxRemoteFailures int, userAgent string, remote
 	va, err := NewValidationAuthorityImpl(
 		// Use the test server's port as both the HTTPPort and the TLSPort for the VA
 		&portConfig,
-		&bdns.MockDNSClient{Log: logger},
+		&bdns.MockClient{Log: logger},
 		nil,
 		maxRemoteFailures,
 		userAgent,


### PR DESCRIPTION
[Go style says](https://blog.golang.org/package-names):

> Avoid stutter. Since client code uses the package name as a prefix when referring to the package contents, the names for those contents need not repeat the package name. The HTTP server provided by the http package is called Server, not HTTPServer. Client code refers to this type as http.Server, so there is no ambiguity.

Rename DNSClient, DNSClientImpl, NewDNSClientImpl, NewTestDNSClientImpl, DNSError, and MockDNSClient to follow those guidelines.

Unexport DNSClientImpl and MockTimeoutError (was only used internally).

Make New and NewTest return the Client interface rather than a concrete `impl` type.