### PR TITLE
Move docker login before docker pull.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,15 +41,15 @@ jobs:
   allow_failures:
     - env: TESTFLAGS="--coverage" CONTAINER="netaccess"
 
-install:
-  - docker-compose pull
-
-script:
+before_script:
   # This user is stored in the TravisCI repository settings in the UI As
   # of 2021-01-20 it is a read-only user in DockerHub but is used to
   # bypass rate limits imposed by DockerHub to non-authenticated
   # non-paying users.
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true
+  - docker-compose pull
+
+script:
   - >-
     docker-compose run --use-aliases
     -e TRAVIS_BRANCH


### PR DESCRIPTION
Ensure docker login happens before the docker-compose pull. Change install
section to a more appropriate before_script section for the docker login
and pull.

Fix #5282