### PR TITLE
Remove SCT.LockCol

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -556,8 +556,6 @@ type SignedCertificateTimestamp struct {
 
 	// The serial of the certificate this SCT is for
 	CertificateSerial string `db:"certificateSerial"`
-
-	LockCol int64
 }
 
 // FQDNSet contains the SHA256 hash of the lowercased, comma joined dNSNames


### PR DESCRIPTION
This struct member is never referenced anywhere.