### PR TITLE
Drop unused index from issuedNames table

### DIFF
--- a/sa/_db-next/migrations/20210216114200_IssuedNamesDropIndex.sql
+++ b/sa/_db-next/migrations/20210216114200_IssuedNamesDropIndex.sql
@@ -1,0 +1,10 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE issuedNames DROP INDEX `reversedName_renewal_notBefore_Idx`;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE issuedNames ADD INDEX `reversedName_renewal_notBefore_Idx` (`reversedName`,`renewal`,`notBefore`);


### PR DESCRIPTION
Drop the reversedName_renewal_notBefore_Idx from the issuedNames table.
This index was added to facilitate rate limit queries, but we now use
the certificatesPerName table for rate limits instead.

Keep the reversedName_notBefore_Idx in place, as it is still useful for
gathering stats on how many hostnames have active certificates.

Fixes #3180