### PR TITLE
Drop never-used CRLs table

### DIFF
--- a/sa/_db/migrations/20210223130000_DropTableCrls.sql
+++ b/sa/_db/migrations/20210223130000_DropTableCrls.sql
@@ -1,0 +1,16 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+DROP TABLE `crls`;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+CREATE TABLE `crls` (
+  `serial` varchar(255) NOT NULL,
+  `createdAt` datetime NOT NULL,
+  `crl` varchar(255) NOT NULL,
+  PRIMARY KEY (`serial`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+


### PR DESCRIPTION
This table was part of the initial schema, but no Boulder
code has ever written to or read from it.

Part of #5254