### PR TITLE
Add GitHub actions workflow for Boulder CI tests

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
-      fail-fast: true
+      fail-fast: false
       # Test matrix.
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.15.7_a1df5bd3
+          - go1.15.7_2021-02-25
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -34,7 +34,8 @@ jobs:
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags
-          - "docker-compose run --use-aliases boulder ./test.sh --lints --integration --generate --rpm"
+          - "docker-compose run --use-aliases boulder ./test.sh --lints --generate --rpm"
+          - "docker-compose run --use-aliases boulder ./test.sh --integration"
           # Config changes that have landed in main but not yet been applied to
           # production can be made in boulder-config-next.json.
           - "docker-compose run --use-aliases boulder ./test.sh --integration --config-next"

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -16,7 +16,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   #  Boulder_ci_tests job. This looks like a single job, but the matrix
-  #  items will mulitiply it. For example every entry in the
+  #  items will mulitply it. For example every entry in the
   #  BOULDER_TOOLS_TAG list will run with every test. If there were two
   #  tags and 5 tests there would be 10 jobs run.
   boulder_ci_tests:
@@ -28,7 +28,7 @@ jobs:
       fail-fast: true
       # Test matrix.
       matrix:
-        # Add additional docker image tags here and all tests will be ran with the additional image.
+        # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
           - go1.15.7_a1df5bd3
         # Tests command definitions. Use the entire docker-compose command you want to run.
@@ -56,7 +56,7 @@ jobs:
 
     # Sequence of tasks that will be executed as part of the job.
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
       - name: Docker Login

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -1,0 +1,99 @@
+# Boulder CI test suite workflow
+
+name: Boulder CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  #  Boulder_ci_tests job. This looks like a single job, but the matrix
+  #  items will mulitiply it. For example every entry in the
+  #  BOULDER_TOOLS_TAG list will run with every test. If there were two
+  #  tags and 5 tests there would be 10 jobs run.
+  boulder_ci_tests:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+    strategy:
+      # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
+      fail-fast: true
+      # Test matrix.
+      matrix:
+        # Add additional docker image tags here and all tests will be ran with the additional image.
+        BOULDER_TOOLS_TAG:
+          - go1.15.7_a1df5bd3
+        # Tests command definitions. Use the entire docker-compose command you want to run.
+        tests:
+          # Run ./test.sh --help for a description of each of the flags
+          - "docker-compose run --use-aliases boulder ./test.sh --lints --integration --generate --rpm"
+          # Config changes that have landed in main but not yet been applied to
+          # production can be made in boulder-config-next.json.
+          - "docker-compose run --use-aliases boulder ./test.sh --integration --config-next"
+          - "docker-compose run --use-aliases boulder ./test.sh --unit --enable-race-detection"
+          - "docker-compose run --use-aliases boulder ./test.sh --unit --enable-race-detection --config-next"
+          - "docker-compose run --use-aliases boulder ./test.sh --start-py"
+          # gomod-vendor runs with a separate network access definition
+          # because it needs to fetch packages from GitHub et. al., which
+          # is incompatible with the DNS server override in the boulder
+          # container (used for service discovery).
+          - "docker-compose run --use-aliases netaccess ./test.sh --gomod-vendor"
+
+    # This sets the docker image tag for the boulder-tools repository to
+    # use in tests. It will be set appropriately for each tag in the list
+    # defined in the matrix.
+    env:
+      BOULDER_TOOLS_TAG: ${{ matrix.BOULDER_TOOLS_TAG }}
+
+    # Sequence of tasks that will be executed as part of the job.
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Docker Login
+        # You may pin to the exact commit or the version.
+        # uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+        uses: docker/login-action@v1.8.0
+        with:
+          # Username used to log against the Docker registry
+          username: ${{ secrets.DOCKER_USERNAME}}
+          # Password or personal access token used to log against the Docker registry
+          password: ${{ secrets.DOCKER_PASSWORD}}
+          # Log out from the Docker registry at the end of a job
+          logout: true
+        continue-on-error: true
+
+      # Print the env variable being used to pull the docker image. For
+      # informational use.
+      - name: Print BOULDER_TOOLS_TAG
+        run: echo "Using BOULDER_TOOLS_TAG ${BOULDER_TOOLS_TAG}"
+
+      # Pre-pull the docker containers before running the tests.
+      - name: docker-compose pull
+        run: docker-compose pull
+      
+      # Run the test matrix. This will run
+      - name: "Run Test: ${{ matrix.tests }}"
+        run: ${{ matrix.tests }}
+
+  # This is a utility build job to detect if the status of any of the
+  # above jobs have failed and fail if so. It is needed so there can be
+  # one static job name that can be used to determine success of the job
+  # in GitHub branch protection.
+  boulder_ci_test_matrix_status:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Boulder CI Test Matrix
+    needs: boulder_ci_tests
+    steps:
+      - name: Check boulder ci test matrix status
+        if: ${{ needs.boulder_ci_tests.result != 'success' }}
+        run: exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.7}:2021-02-17
+        image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.15.7_a1df5bd3}
         environment:
             - FAKE_DNS=10.77.77.77
             - BOULDER_CONFIG_DIR=test/config
@@ -76,7 +76,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools-go${TRAVIS_GO_VERSION:-1.15.7}:2021-02-17
+        image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.15.7_a1df5bd3}
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     boulder:
         # To minimize fetching this should be the same version used below
-        image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.15.7_a1df5bd3}
+        image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.15.7_2021-02-25}
         environment:
             - FAKE_DNS=10.77.77.77
             - BOULDER_CONFIG_DIR=test/config
@@ -76,7 +76,7 @@ services:
         logging:
             driver: none
     netaccess:
-        image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.15.7_a1df5bd3}
+        image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.15.7_2021-02-25}
         environment:
             GO111MODULE: "on"
             GOFLAGS: "-mod=vendor"

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -2,14 +2,15 @@
 
 cd $(dirname $0)
 
-DATESTAMP=$(date +%Y-%m-%d)
-BASE_TAG_NAME="letsencrypt/boulder-tools"
-GO_VERSIONS=( "1.15.7" )
+DOCKER_REPO="letsencrypt/boulder-tools"
+GIT_HASH="$(git rev-parse --short HEAD)"
+
+GO_VERSIONS=( "1.15.7" "1.16" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"
 do
-  TAG_NAME="$BASE_TAG_NAME-go$GO_VERSION:$DATESTAMP"
+  TAG_NAME="$DOCKER_REPO:go${GO_VERSION}_${GIT_HASH}"
   echo "Building boulder-tools image $TAG_NAME"
 
   # Build the docker image using the templated Dockerfile, tagging it with
@@ -26,9 +27,9 @@ docker login
 # Upload a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"
 do
-  TAG_NAME="$BASE_TAG_NAME-go$GO_VERSION:$DATESTAMP"
-  echo "Pushing $TAG_NAME to Dockerhub"
-  docker push $TAG_NAME
+  TAG_NAME="$DOCKER_REPO:go${GO_VERSION}_${GIT_HASH}"
+  echo "Pushing ${TAG_NAME} to Dockerhub"
+  docker push ${TAG_NAME}
 done
 
 # TODO(@cpu): Figure out a `sed` for updating the date in `docker-compose.yml`'s

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -5,7 +5,7 @@ cd $(dirname $0)
 DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
 
-GO_VERSIONS=( "1.15.7" "1.16" )
+GO_VERSIONS=( "1.15.7" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -2,15 +2,15 @@
 
 cd $(dirname $0)
 
+DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
-GIT_HASH="$(git rev-parse --short HEAD)"
 
 GO_VERSIONS=( "1.15.7" "1.16" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"
 do
-  TAG_NAME="$DOCKER_REPO:go${GO_VERSION}_${GIT_HASH}"
+  TAG_NAME="$DOCKER_REPO:go${GO_VERSION}_${DATESTAMP}"
   echo "Building boulder-tools image $TAG_NAME"
 
   # Build the docker image using the templated Dockerfile, tagging it with
@@ -27,7 +27,7 @@ docker login
 # Upload a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"
 do
-  TAG_NAME="$DOCKER_REPO:go${GO_VERSION}_${GIT_HASH}"
+  TAG_NAME="$DOCKER_REPO:go${GO_VERSION}_${DATESTAMP}"
   echo "Pushing ${TAG_NAME} to Dockerhub"
   docker push ${TAG_NAME}
 done


### PR DESCRIPTION
- Add GitHub actions workflow for Boulder CI tests in parity with Travis
  CI except the coverage test.
- Change boulder-tools docker image to push to a static docker repo
  instead of creating a new one each time. Use docker version tags and git
  hash to identify go versions in the repo.
- Change docker-compose to pull from the static boulder-tools repo. This
  breaks using the TRAVIS_GO_VERSION env variable to pull the docker image, but
  the default will still work with intent of decommissioning Travis-CI for
  GitHub CI.

Fix: #5289 