### PR TITLE
Add gRPC MaxConnectionAge config.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -269,7 +269,7 @@ type GRPCServerConfig struct {
 	// (SANs). The server will reject clients that do not present a certificate
 	// with a SAN present on the `ClientNames` list.
 	ClientNames []string `json:"clientNames"`
-	// How long a connection may live before the server sends a GoAway to the
+	// MaxConnectionAge specifies how long a connection may live before the server sends a GoAway to the
 	// client. Because gRPC connections re-resolve DNS after a connection close,
 	// this controls how long it takes before a client learns about changes to its
 	// backends.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -269,6 +269,12 @@ type GRPCServerConfig struct {
 	// (SANs). The server will reject clients that do not present a certificate
 	// with a SAN present on the `ClientNames` list.
 	ClientNames []string `json:"clientNames"`
+	// How long a connection may live before the server sends a GoAway to the
+	// client. Because gRPC connections re-resolve DNS after a connection close,
+	// this controls how long it takes before a client learns about changes to its
+	// backends.
+	// https://pkg.go.dev/google.golang.org/grpc/keepalive#ServerParameters
+	MaxConnectionAge ConfigDuration
 }
 
 // PortConfig specifies what ports the VA should call to on the remote

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -14,6 +14,7 @@
     },
     "grpc": {
       "address": ":9099",
+      "maxConnectionAge": "30s",
       "clientNames": [
         "health-checker.boulder",
         "ra.boulder"

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -8,6 +8,7 @@
     },
     "hostnamePolicyFile": "test/hostname-policy.yaml",
     "grpcCA": {
+      "maxConnectionAge": "30s",
       "address": ":9093",
       "clientNames": [
         "health-checker.boulder",
@@ -15,6 +16,7 @@
       ]
     },
     "grpcOCSPGenerator": {
+      "maxConnectionAge": "30s",
       "address": ":9096",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -8,6 +8,7 @@
     },
     "hostnamePolicyFile": "test/hostname-policy.yaml",
     "grpcCA": {
+      "maxConnectionAge": "30s",
       "address": ":9093",
       "clientNames": [
         "health-checker.boulder",
@@ -15,6 +16,7 @@
       ]
     },
     "grpcOCSPGenerator": {
+      "maxConnectionAge": "30s",
       "address": ":9096",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config-next/nonce.json
+++ b/test/config-next/nonce.json
@@ -8,6 +8,7 @@
         },
         "debugAddr": ":8111",
         "grpc": {
+            "maxConnectionAge": "30s",
             "address": ":9101",
             "clientNames": [
                 "health-checker.boulder",

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -4,6 +4,7 @@
     "blockProfileRate": 1000000000,
     "debugAddr": ":8009",
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9091",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -42,6 +42,7 @@
       "timeout": "15s"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9094",
       "clientNames": [
         "admin-revoker.boulder",

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -12,6 +12,7 @@
       "keyFile": "test/grpc-creds/sa.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9095",
       "clientNames": [
         "admin-revoker.boulder",

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -19,6 +19,7 @@
       "keyFile": "test/grpc-creds/va.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9097",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -19,6 +19,7 @@
       "keyFile": "test/grpc-creds/va.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9098",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -19,6 +19,7 @@
       "keyFile": "test/grpc-creds/va.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9092",
       "clientNames": [
         "health-checker.boulder",


### PR DESCRIPTION
This allows servers to tell clients to go away after some period of time, which triggers the clients to re-resolve DNS.

Per https://github.com/grpc/grpc/issues/12295, this is the preferred way to do this.

Related: #5307.