### PR TITLE
Audit-log cache purges.

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -241,7 +241,7 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 		return fmt.Errorf("Unexpected HTTP status code '%d': %s", resp.StatusCode, string(body))
 	}
 
-	cpc.log.Infof("Sent successful purge request purgeID: %s, purge expected in: %ds, for URLs: %s",
+	cpc.log.AuditInfof("Sent successful purge request purgeID: %s, purge expected in: %ds, for URLs: %s",
 		purgeInfo.PurgeID, purgeInfo.EstimatedSeconds, urls)
 
 	return nil


### PR DESCRIPTION
Since these are part of our revocation lifecycle, we should keep these
logs long term.