### PR TITLE
Remove common config from publisher

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -247,37 +247,6 @@ func UniqueLowerNames(names []string) (unique []string) {
 	return
 }
 
-// LoadCertBundle loads a PEM bundle of certificates from disk
-func LoadCertBundle(filename string) ([]*x509.Certificate, error) {
-	bundleBytes, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	var bundle []*x509.Certificate
-	var block *pem.Block
-	rest := bundleBytes
-	for {
-		block, rest = pem.Decode(rest)
-		if block == nil {
-			break
-		}
-		if block.Type != "CERTIFICATE" {
-			return nil, fmt.Errorf("Block has invalid type: %s", block.Type)
-		}
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		bundle = append(bundle, cert)
-	}
-
-	if len(bundle) == 0 {
-		return nil, fmt.Errorf("Bundle doesn't contain any certificates")
-	}
-
-	return bundle, nil
-}
-
 // LoadCert loads a PEM certificate specified by filename or returns an error
 func LoadCert(filename string) (*x509.Certificate, error) {
 	certPEM, err := ioutil.ReadFile(filename)

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -405,15 +405,3 @@ func GetCTBundleForChain(chain []*issuance.Certificate) []ct.ASN1Cert {
 	}
 	return ctBundle
 }
-
-// GetCTBundleForCerts takes a slice of *x509.Certificate(s)
-// representing a certificate chain and returns a slice of
-// ct.ANS1Cert(s) in the same order
-// TODO(5269): Remove this after all configs have migrated to `Chains`.
-func GetCTBundleForCerts(chain []*x509.Certificate) []ct.ASN1Cert {
-	var ctBundle []ct.ASN1Cert
-	for _, cert := range chain {
-		ctBundle = append(ctBundle, ct.ASN1Cert{Data: cert.Raw})
-	}
-	return ctBundle
-}

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -140,21 +140,11 @@ func setup(t *testing.T) (*Impl, *x509.Certificate, *ecdsa.PrivateKey) {
 	})
 	test.AssertNotError(t, err, "failed to load chain3.")
 
-	// Load our fourth chain using core.LoadCertBundle
-	// TODO(5269): Remove this after all configs have migrated to
-	// `Chains`.
-	chain4, err := core.LoadCertBundle("test/testIntermediate.pem")
-	test.AssertNotError(t, err, "failed to load chain4.")
-	chain4Issuer := issuance.Certificate{Certificate: chain4[0]}
-
 	// Create an example issuerNameID to CT bundle mapping
 	issuerBundles := map[issuance.IssuerNameID][]ct.ASN1Cert{
 		chain1[0].NameID(): GetCTBundleForChain(chain1),
 		chain2[0].NameID(): GetCTBundleForChain(chain2),
 		chain3[0].NameID(): GetCTBundleForChain(chain3),
-		// TODO(5269): Remove this after all configs have migrated to
-		// `Chains`.
-		chain4Issuer.NameID(): GetCTBundleForCerts(chain4),
 	}
 	pub := New(
 		issuerBundles,
@@ -404,29 +394,6 @@ func Test_GetCTBundleForChain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bundle := GetCTBundleForChain(tt.args.chain)
-			test.AssertDeepEquals(t, bundle, tt.want)
-		})
-	}
-}
-
-// TODO(5269): Remove this after all configs have migrated to `Chains`.
-func Test_GetCTBundleForBundle(t *testing.T) {
-	bundle, err := core.LoadCertBundle("test/testIntermediate.pem")
-	want := []ct.ASN1Cert{{Data: bundle[0].Raw}}
-	test.AssertNotError(t, err, "Unable to read test/testIntermediate.pem")
-	type args struct {
-		chain []*x509.Certificate
-	}
-	tests := []struct {
-		name string
-		args args
-		want []ct.ASN1Cert
-	}{
-		{"Create a ct bundle with a single intermediate", args{bundle}, want},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bundle := GetCTBundleForCerts(tt.args.chain)
 			test.AssertDeepEquals(t, bundle, tt.want)
 		})
 	}

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -2,23 +2,6 @@
   "publisher": {
     "userAgent": "boulder/1.0",
     "blockProfileRate": 1000000000,
-    "debugAddr": ":8009",
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9091",
-      "clientNames": [
-        "health-checker.boulder",
-        "ocsp-updater.boulder",
-        "ra.boulder"
-      ]
-    },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
-    },
-    "features": {
-    },
     "chains": [
       [
         "/tmp/intermediate-cert-rsa-a.pem",
@@ -36,7 +19,24 @@
         "/tmp/intermediate-cert-ecdsa-b.pem",
         "/tmp/root-cert-ecdsa.pem"
       ]
-    ]
+    ],
+    "debugAddr": ":8009",
+    "grpc": {
+      "maxConnectionAge": "30s",
+      "address": ":9091",
+      "clientNames": [
+        "health-checker.boulder",
+        "ocsp-updater.boulder",
+        "ra.boulder"
+      ]
+    },
+    "tls": {
+      "caCertFile": "test/grpc-creds/minica.pem",
+      "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
+      "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
+    },
+    "features": {
+    }
   },
 
   "syslog": {

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -2,6 +2,24 @@
   "publisher": {
     "userAgent": "boulder/1.0",
     "blockProfileRate": 1000000000,
+    "chains": [
+      [
+        "/tmp/intermediate-cert-rsa-a.pem",
+        "/tmp/root-cert-rsa.pem"
+      ],
+      [
+        "/tmp/intermediate-cert-rsa-b.pem",
+        "/tmp/root-cert-rsa.pem"
+      ],
+      [
+        "/tmp/intermediate-cert-ecdsa-a.pem",
+        "/tmp/root-cert-ecdsa.pem"
+      ],
+      [
+        "/tmp/intermediate-cert-ecdsa-b.pem",
+        "/tmp/root-cert-ecdsa.pem"
+      ]
+    ],
     "debugAddr": ":8009",
     "grpc": {
       "address": ":9091",

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -41,11 +41,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 6
-  },
-
-  "common": {
-    "ct": {
-      "intermediateBundleFilename": "/tmp/intermediate-cert-rsa-a.pem"
-    }
   }
 }


### PR DESCRIPTION
The old `config.Common.CT.IntermediateBundleFilename` format is no
longer used in any production configs, and can be removed safely.

Part of #5162
Part of #5242
Fixes #5269