### PR TITLE
Remove Common.DNSResolver from VA config

### DIFF
--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -12,6 +12,8 @@
       "127.0.0.1:8053",
       "127.0.0.1:8054"
     ],
+    "dnsTimeout": "1s",
+    "dnsAllowLoopbackAddresses": true,
     "issuerDomain": "happy-hacker-ca.invalid",
     "tls": {
       "caCertfile": "test/grpc-creds/minica.pem",
@@ -39,10 +41,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 4
-  },
-
-  "common": {
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true
   }
 }

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -12,6 +12,8 @@
       "127.0.0.1:8053",
       "127.0.0.1:8054"
     ],
+    "dnsTimeout": "1s",
+    "dnsAllowLoopbackAddresses": true,
     "issuerDomain": "happy-hacker-ca.invalid",
     "tls": {
       "caCertfile": "test/grpc-creds/minica.pem",
@@ -39,10 +41,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 4
-  },
-
-  "common": {
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true
   }
 }

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -12,6 +12,8 @@
       "127.0.0.1:8053",
       "127.0.0.1:8054"
     ],
+    "dnsTimeout": "1s",
+    "dnsAllowLoopbackAddresses": true,
     "issuerDomain": "happy-hacker-ca.invalid",
     "tls": {
       "caCertfile": "test/grpc-creds/minica.pem",
@@ -52,10 +54,5 @@
   "syslog": {
     "stdoutlevel": 6,
     "sysloglevel": 6
-  },
-
-  "common": {
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true
   }
 }


### PR DESCRIPTION
This field is not used by any production configs, so we can safely
remove it.

Also, add config fields for DNSTimeout and DNSAllowLoopbackAddress
outside of the Common sub-struct, to allow for its removal later.

Part of #5242