### PR TITLE
CA: add "issuer" label to signatureCount metric

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -195,7 +195,7 @@ func NewCertificateAuthorityImpl(
 			Name: "signatures",
 			Help: "Number of signatures",
 		},
-		[]string{"purpose"})
+		[]string{"purpose", "issuer"})
 	stats.MustRegister(signatureCount)
 
 	orphanCount := prometheus.NewCounterVec(
@@ -331,7 +331,7 @@ func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *capb.
 	ocspResponse, err := ocsp.CreateResponse(issuer.cert.Certificate, issuer.cert.Certificate, tbsResponse, issuer.ocspSigner)
 	ca.noteSignError(err)
 	if err == nil {
-		ca.signatureCount.With(prometheus.Labels{"purpose": "ocsp"}).Inc()
+		ca.signatureCount.With(prometheus.Labels{"purpose": "ocsp", "issuer": issuer.boulderIssuer.Name()}).Inc()
 	}
 	return &capb.OCSPResponse{Response: ocspResponse}, err
 }
@@ -475,7 +475,7 @@ func (ca *CertificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	ca.signatureCount.WithLabelValues(string(certType)).Inc()
+	ca.signatureCount.With(prometheus.Labels{"purpose": string(certType), "issuer": issuer.boulderIssuer.Name()}).Inc()
 	ca.log.AuditInfof("Signing success: serial=[%s] names=[%s] csr=[%s] certificate=[%s]",
 		serialHex, strings.Join(precert.DNSNames, ", "), hex.EncodeToString(req.DER),
 		hex.EncodeToString(certDER))
@@ -588,7 +588,7 @@ func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		ca.log.AuditErrf("Signing failed: serial=[%s] err=[%v]", serialHex, err)
 		return nil, nil, err
 	}
-	ca.signatureCount.WithLabelValues(string(precertType)).Inc()
+	ca.signatureCount.With(prometheus.Labels{"purpose": string(precertType), "issuer": issuer.boulderIssuer.Name()}).Inc()
 
 	ca.log.AuditInfof("Signing success: serial=[%s] names=[%s] csr=[%s] precertificate=[%s]",
 		serialHex, strings.Join(csr.DNSNames, ", "), hex.EncodeToString(csr.Raw),

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -608,7 +608,7 @@ func TestInvalidCSRs(t *testing.T) {
 			_, err = ca.IssuePrecertificate(ctx, issueReq)
 
 			test.AssertErrorIs(t, err, testCase.errorType)
-			test.AssertEquals(t, signatureCountByPurpose("cert", ca.signatureCount), 0)
+			test.AssertMetricWithLabelsEquals(t, ca.signatureCount, prometheus.Labels{"purpose": "cert"}, 0)
 
 			test.AssertError(t, err, testCase.errorMessage)
 			if testCase.check != nil {
@@ -679,12 +679,12 @@ func countMustStaple(t *testing.T, cert *x509.Certificate) (count int) {
 }
 
 func issueCertificateSubTestMustStaple(t *testing.T, i *TestCertificateIssuance) {
-	test.AssertEquals(t, signatureCountByPurpose("precertificate", i.ca.signatureCount), 1)
+	test.AssertMetricWithLabelsEquals(t, i.ca.signatureCount, prometheus.Labels{"purpose": "precertificate"}, 1)
 	test.AssertEquals(t, countMustStaple(t, i.cert), 1)
 }
 
 func issueCertificateSubTestUnknownExtension(t *testing.T, i *TestCertificateIssuance) {
-	test.AssertEquals(t, signatureCountByPurpose("precertificate", i.ca.signatureCount), 1)
+	test.AssertMetricWithLabelsEquals(t, i.ca.signatureCount, prometheus.Labels{"purpose": "precertificate"}, 1)
 
 	// NOTE: The hard-coded value here will have to change over time as Boulder
 	// adds new (unrequested) extensions to certificates.
@@ -693,7 +693,7 @@ func issueCertificateSubTestUnknownExtension(t *testing.T, i *TestCertificateIss
 }
 
 func issueCertificateSubTestCTPoisonExtension(t *testing.T, i *TestCertificateIssuance) {
-	test.AssertEquals(t, signatureCountByPurpose("precertificate", i.ca.signatureCount), 1)
+	test.AssertMetricWithLabelsEquals(t, i.ca.signatureCount, prometheus.Labels{"purpose": "precertificate"}, 1)
 }
 
 func findExtension(extensions []pkix.Extension, id asn1.ObjectIdentifier) *pkix.Extension {
@@ -703,10 +703,6 @@ func findExtension(extensions []pkix.Extension, id asn1.ObjectIdentifier) *pkix.
 		}
 	}
 	return nil
-}
-
-func signatureCountByPurpose(signatureType string, signatureCount *prometheus.CounterVec) int {
-	return test.CountCounterVec("purpose", signatureType, signatureCount)
 }
 
 func makeSCTs() ([][]byte, error) {

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -163,7 +163,7 @@ func AssertNotContains(t *testing.T, haystack string, needle string) {
 // metrics in the vector prior to comparison; this is so that users can easily
 // make assertions about one of many field dimensions (e.g. for a CounterVec with
 // fields "host" and "valid", being able to assert that two "valid": "true"
-// incremets occurred, without caring which host did each increment). To make
+// increments occurred, without caring which host did each increment). To make
 // assertions about subsets of a vector's metrics, use the MetricVec's .CurryWith
 // or .GetMetricWith methods. Only works for integer metrics (Counters and Gauges),
 // does not work for Histograms.

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -159,22 +159,21 @@ func AssertNotContains(t *testing.T, haystack string, needle string) {
 
 // AssertMetricEquals determines whether the value held by a prometheus Collector
 // (e.g. Gauge, Counter, CounterVec, etc) is equal to the expected integer.
-// In the case of vector collectors, it collects and sums the values from all
-// metrics in the vector prior to comparison; this is so that users can easily
-// make assertions about one of many field dimensions (e.g. for a CounterVec with
-// fields "host" and "valid", being able to assert that two "valid": "true"
-// increments occurred, without caring which host did each increment). To make
-// assertions about subsets of a vector's metrics, use the MetricVec's .CurryWith
-// or .GetMetricWith methods. Only works for integer metrics (Counters and Gauges),
-// does not work for Histograms.
-func AssertMetricWithLabelsEquals(t *testing.T, c prometheus.Collector, l prometheus.Labels, expected int) {
+// In order to make useful assertions about just a subset of labels (e.g. for a
+// CounterVec with fields "host" and "valid", being able to assert that two
+// "valid": "true" increments occurred, without caring which host was tagged in
+// each), takes a set of labels and ignores any metrics which have different
+// label values.
+// Only works for simple metrics (Counters and Gauges), or for the *count*
+// (not value) of data points in a Histogram.
+func AssertMetricWithLabelsEquals(t *testing.T, c prometheus.Collector, l prometheus.Labels, expected float64) {
 	ch := make(chan prometheus.Metric)
 	done := make(chan struct{})
 	go func() {
 		c.Collect(ch)
 		close(done)
 	}()
-	var total int
+	var total float64
 	timeout := time.After(time.Second)
 loop:
 	for {
@@ -188,15 +187,18 @@ loop:
 			var iom io_prometheus_client.Metric
 			_ = m.Write(&iom)
 			for _, lp := range iom.Label {
+				// If any of the labels on this metric have the same name as but
+				// different value than a label in `l`, skip this metric.
 				val, ok := l[lp.GetName()]
 				if ok && lp.GetValue() != val {
 					break metric
 				}
 			}
-			// Exactly one of the Counter or Gauge values will be populated by the
-			// .Write() operation, so just add both because the other will be 0.
-			total += int(iom.Counter.GetValue())
-			total += int(iom.Gauge.GetValue())
+			// Exactly one of the Counter, Gauge, or Histogram values will be set by
+			// the .Write() operation, so add them all because the others will be 0.
+			total += iom.Counter.GetValue()
+			total += iom.Gauge.GetValue()
+			total += float64(iom.Histogram.GetSampleCount())
 		}
 	}
 	AssertEquals(t, total, expected)

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -157,6 +157,51 @@ func AssertNotContains(t *testing.T, haystack string, needle string) {
 	}
 }
 
+// AssertMetricEquals determines whether the value held by a prometheus Collector
+// (e.g. Gauge, Counter, CounterVec, etc) is equal to the expected integer.
+// In the case of vector collectors, it collects and sums the values from all
+// metrics in the vector prior to comparison; this is so that users can easily
+// make assertions about one of many field dimensions (e.g. for a CounterVec with
+// fields "host" and "valid", being able to assert that two "valid": "true"
+// incremets occurred, without caring which host did each increment). To make
+// assertions about subsets of a vector's metrics, use the MetricVec's .CurryWith
+// or .GetMetricWith methods. Only works for integer metrics (Counters and Gauges),
+// does not work for Histograms.
+func AssertMetricWithLabelsEquals(t *testing.T, c prometheus.Collector, l prometheus.Labels, expected int) {
+	ch := make(chan prometheus.Metric)
+	done := make(chan struct{})
+	go func() {
+		c.Collect(ch)
+		close(done)
+	}()
+	var total int
+	timeout := time.After(time.Second)
+loop:
+	for {
+	metric:
+		select {
+		case <-timeout:
+			t.Fatal("timed out collecting metrics")
+		case <-done:
+			break loop
+		case m := <-ch:
+			var iom io_prometheus_client.Metric
+			_ = m.Write(&iom)
+			for _, lp := range iom.Label {
+				val, ok := l[lp.GetName()]
+				if ok && lp.GetValue() != val {
+					break metric
+				}
+			}
+			// Exactly one of the Counter or Gauge values will be populated by the
+			// .Write() operation, so just add both because the other will be 0.
+			total += int(iom.Counter.GetValue())
+			total += int(iom.Gauge.GetValue())
+		}
+	}
+	AssertEquals(t, total, expected)
+}
+
 // CountCounterVec returns the count by label and value of a prometheus metric
 func CountCounterVec(labelName string, value string, counterVec *prometheus.CounterVec) int {
 	return CountCounter(counterVec.With(prometheus.Labels{labelName: value}))


### PR DESCRIPTION
Add a new label, "issuer", to the `signatureCount` prometheus metric
which is exported by the CA. This allows us to separately monitor
signatures by the R3 and E1 intermediates, for all three kinds of
issuance we perform: precertificate, certificate, and ocsp. Add the
appropriate label value when incrementing this metric.

Also add a new `AssertMetricWithLabelsEquals` method to our test
helpers. This allows us to make assertions about the total value of
all metrics with a particular subset of labels set, rather than only
being able to make assertions about metrics which are parameterized by
only a single label. A follow-up change will migrate our usages of
CountCounterVec, CountCounter, and GaugeValueWithLabels to use this new
helper instead.

Fixes #5354