### PR TITLE
Refactor orphan-finder for easier state

### DIFF
--- a/cmd/orphan-finder/main_test.go
+++ b/cmd/orphan-finder/main_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-var log = blog.UseMock()
-
 type mockSA struct {
 	certificates    []core.Certificate
 	precertificates []core.Certificate
@@ -102,24 +100,15 @@ func (ca *mockCA) GenerateOCSP(context.Context, *capb.GenerateOCSPRequest, ...gr
 	}, nil
 }
 
-func checkNoErrors(t *testing.T) {
-	logs := log.GetAllMatching("ERR:")
-	if len(logs) != 0 {
-		t.Errorf("Found error logs:")
-		for _, ll := range logs {
-			t.Error(ll)
-		}
-	}
-}
-
 func TestParseLine(t *testing.T) {
 	fc := clock.NewFake()
 	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
-	sa := &mockSA{}
-	ca := &mockCA{}
-
-	// Set an example backdate duration (this is normally read from config)
-	backdateDuration = time.Hour
+	opf := &orphanFinder{
+		sa:       &mockSA{},
+		ca:       &mockCA{},
+		logger:   blog.UseMock(),
+		backdate: time.Hour,
+	}
 
 	testCertDER := "3082045b30820343a003020102021300ffa0160630d618b2eb5c0510824b14274856300d06092a864886f70d01010b0500301f311d301b06035504030c146861707079206861636b65722066616b65204341301e170d3135313030333035323130305a170d3136303130313035323130305a3018311630140603550403130d6578616d706c652e636f2e626e30820122300d06092a864886f70d01010105000382010f003082010a02820101009ea3f1d21fade5596e36a6a77095a94758e4b72466b7444ada4f7c4cf6fde9b1d470b93b65c1fdd896917f248ccae49b57c80dc21c64b010699432130d059d2d8392346e8a179c7c947835549c64a7a5680c518faf0a5cbea48e684fca6304775c8fa9239c34f1d5cb2d063b098bd1c17183c7521efc884641b2f0b41402ac87c7076848d4347cef59dd5a9c174ad25467db933c95ef48c578ba762f527b21666a198fb5e1fe2d8299b4dceb1791e96ad075e3ecb057c776d764fad8f0829d43c32ddf985a3a36fade6966cec89468721a1ec47ab38eac8da4514060ded51d283a787b7c69971bda01f49f76baa41b1f9b4348aa4279e0fa55645d6616441f0d0203010001a382019530820191300e0603551d0f0101ff0404030205a0301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff04023000301d0603551d0e04160414369d0c100452b9eb3ffe7ae852e9e839a3ae5adb301f0603551d23041830168014fb784f12f96015832c9f177f3419b32e36ea4189306a06082b06010505070101045e305c302606082b06010505073001861a687474703a2f2f6c6f63616c686f73743a343030322f6f637370303206082b060105050730028626687474703a2f2f6c6f63616c686f73743a343030302f61636d652f6973737565722d6365727430180603551d110411300f820d6578616d706c652e636f2e626e30270603551d1f0420301e301ca01aa0188616687474703a2f2f6578616d706c652e636f6d2f63726c30630603551d20045c305a300a060667810c0102013000304c06032a03043045302206082b060105050702011616687474703a2f2f6578616d706c652e636f6d2f637073301f06082b0601050507020230130c11446f20576861742054686f752057696c74300d06092a864886f70d01010b05000382010100bbb4b994971cafa2e56e2258db46d88bfb361d8bfcd75521c03174e471eaa9f3ff2e719059bb57cc064079496d8550577c127baa84a18e792ddd36bf4f7b874b6d40d1d14288c15d38e4d6be25eb7805b1c3756b3735702eb4585d1886bc8af2c14086d3ce506e55184913c83aaaa8dfe6160bd035e42cda6d97697ed3ee3124c9bf9620a9fe6602191c1b746533c1d4a30023bbe902cb4aa661901177ed924eb836c94cc062dd0ce439c4ece9ee1dfe0499a42cbbcb2ea7243c59f4df4fdd7058229bacf9a640632dbd776b21633137b2df1c41f0765a66f448777aeec7ed4c0cdeb9d8a2356ff813820a287e11d52efde1aa543b4ef2ee992a7a9d5ccf7da4"
 
@@ -238,11 +227,11 @@ func TestParseLine(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			log.Clear()
-			found, added, typ := storeParsedLogLine(sa, ca, log, tc.LogLine)
+			opf.logger.(*blog.Mock).Clear()
+			found, added, typ := opf.storeLogLine(tc.LogLine)
 			test.AssertEquals(t, found, tc.ExpectFound)
 			test.AssertEquals(t, added, tc.ExpectAdded)
-			logs := log.GetAllMatching("ERR:")
+			logs := opf.logger.(*blog.Mock).GetAllMatching("ERR:")
 			if tc.ExpectNoErrors {
 				test.AssertEquals(t, len(logs), 0)
 			}
@@ -258,13 +247,13 @@ func TestParseLine(t *testing.T) {
 				var storedCert core.Certificate
 				switch typ {
 				case precertOrphan:
-					resp, err := sa.GetPrecertificate(context.Background(), &sapb.Serial{Serial: testCertSerial})
+					resp, err := opf.sa.GetPrecertificate(context.Background(), &sapb.Serial{Serial: testCertSerial})
 					test.AssertNotError(t, err, "Error getting test precert serial from SA")
 					precert, err := bgrpc.PBToCert(resp)
 					test.AssertNotError(t, err, "Error getting test precert from GetPrecertificate pb response")
 					storedCert = precert
 				case certOrphan:
-					cert, err := sa.GetCertificate(context.Background(), testCertSerial)
+					cert, err := opf.sa.GetCertificate(context.Background(), testCertSerial)
 					test.AssertNotError(t, err, "Error getting test cert serial from SA")
 					storedCert = cert
 				default:
@@ -273,7 +262,7 @@ func TestParseLine(t *testing.T) {
 				// The orphan should have been added with the correct registration ID from the log line
 				test.AssertEquals(t, storedCert.RegistrationID, int64(tc.ExpectRegID))
 				// The Issued timestamp should be the certificate's NotBefore timestamp offset by the backdateDuration
-				expectedIssued := testCert.NotBefore.Add(backdateDuration)
+				expectedIssued := testCert.NotBefore.Add(opf.backdate)
 				test.Assert(t, storedCert.Issued.Equal(expectedIssued),
 					fmt.Sprintf("stored cert issued date (%s) was not equal to expected (%s)",
 						storedCert.Issued, expectedIssued))
@@ -285,13 +274,22 @@ func TestParseLine(t *testing.T) {
 func TestNotOrphan(t *testing.T) {
 	fc := clock.NewFake()
 	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
-	sa := &mockSA{}
-	ca := &mockCA{}
+	opf := &orphanFinder{
+		sa:       &mockSA{},
+		ca:       &mockCA{},
+		logger:   blog.UseMock(),
+		backdate: time.Hour,
+	}
 
-	log.Clear()
-	found, added, typ := storeParsedLogLine(sa, ca, log, "cert=fakeout")
+	found, added, typ := opf.storeLogLine("cert=fakeout")
 	test.AssertEquals(t, found, false)
 	test.AssertEquals(t, added, false)
 	test.AssertEquals(t, typ, unknownOrphan)
-	checkNoErrors(t)
+	logs := opf.logger.(*blog.Mock).GetAllMatching("ERR:")
+	if len(logs) != 0 {
+		t.Errorf("Found error logs:")
+		for _, ll := range logs {
+			t.Error(ll)
+		}
+	}
 }

--- a/cmd/orphan-finder/main_test.go
+++ b/cmd/orphan-finder/main_test.go
@@ -287,7 +287,7 @@ func TestNotOrphan(t *testing.T) {
 	test.AssertEquals(t, typ, unknownOrphan)
 	logs := opf.logger.(*blog.Mock).GetAllMatching("ERR:")
 	if len(logs) != 0 {
-		t.Errorf("Found error logs:")
+		t.Error("Found error logs:")
 		for _, ll := range logs {
 			t.Error(ll)
 		}


### PR DESCRIPTION
Add a new `orphanFinder` struct which stores its own
CA, SA, logger, and backdate duration. Move code out
of `main` and into methods on the new struct; similarly
refactor one existing helper function to now be a method.
Update tests to instantiate an `orphanFinder`.

This makes it easier for the orphanFinder to carry state
(such as a list of valid issuers) in the future, and reduces
the amount of code in main.

Part of #5079, #5149