### PR TITLE
Update golangci-lint to 1.39

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.16.2_2021-03-30
+          - go1.16.2_2021-04-02
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3'
 services:
   boulder:
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.15.7_2021-03-30}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.16.3_2021-04-02}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config
       GOFLAGS: -mod=vendor
     volumes:
-      - .:/go/src/github.com/letsencrypt/boulder:cached
+      - .:/boulder:cached
       - ./.gocache:/root/.cache/go-build:cached
     networks:
       bluenet:
@@ -48,7 +48,7 @@ services:
     depends_on:
       - bmysql
     entrypoint: test/entrypoint.sh
-    working_dir: &boulder_working_dir /go/src/github.com/letsencrypt/boulder
+    working_dir: &boulder_working_dir /boulder
 
   bmysql:
     image: mariadb:10.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   boulder:
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.16.3_2021-04-02}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.16.2_2021-04-02}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -31,7 +31,7 @@ unzip /tmp/protoc.zip -d /usr/local/protoc
 export GOBIN=/usr/local/bin GOCACHE=/tmp/gocache
 
 # Install golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOBIN v1.29.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOBIN v1.39.0
 
 # Install protobuf and testing/dev tools.
 # Note: The version of golang/protobuf is partially tied to the version of grpc


### PR DESCRIPTION
Also change Boulder's path within the container to /boulder. We don't have to follow the $GOPATH conventions now that we use Go modules.