### PR TITLE
grpc wrapper removal: Turn ra.NewRegistration into passthrough

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -56,7 +56,7 @@ type WebFrontEnd interface {
 // RegistrationAuthority defines the public interface for the Boulder RA
 type RegistrationAuthority interface {
 	// [WebFrontEnd]
-	NewRegistration(ctx context.Context, reg Registration) (Registration, error)
+	NewRegistration(ctx context.Context, reg *corepb.Registration) (*corepb.Registration, error)
 
 	// [WebFrontEnd]
 	NewAuthorization(ctx context.Context, authz Authorization, regID int64) (Authorization, error)

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -212,7 +212,7 @@ func pbToValidationResult(in *vapb.ValidationResult) ([]core.ValidationRecord, *
 	return recordAry, prob, nil
 }
 
-func registrationToPB(reg core.Registration) (*corepb.Registration, error) {
+func RegistrationToPB(reg core.Registration) (*corepb.Registration, error) {
 	keyBytes, err := reg.Key.MarshalJSON()
 	if err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func registrationToPB(reg core.Registration) (*corepb.Registration, error) {
 	}, nil
 }
 
-func pbToRegistration(pb *corepb.Registration) (core.Registration, error) {
+func PbToRegistration(pb *corepb.Registration) (core.Registration, error) {
 	var key jose.JSONWebKey
 	err := key.UnmarshalJSON(pb.Key)
 	if err != nil {

--- a/grpc/pb-marshalling_test.go
+++ b/grpc/pb-marshalling_test.go
@@ -168,26 +168,26 @@ func TestRegistration(t *testing.T) {
 		CreatedAt: time.Now().Round(0),
 		Status:    core.StatusValid,
 	}
-	pbReg, err := registrationToPB(inReg)
+	pbReg, err := RegistrationToPB(inReg)
 	test.AssertNotError(t, err, "registrationToPB failed")
-	outReg, err := pbToRegistration(pbReg)
-	test.AssertNotError(t, err, "pbToRegistration failed")
+	outReg, err := PbToRegistration(pbReg)
+	test.AssertNotError(t, err, "PbToRegistration failed")
 	test.AssertDeepEquals(t, inReg, outReg)
 
 	inReg.Contact = nil
-	pbReg, err = registrationToPB(inReg)
+	pbReg, err = RegistrationToPB(inReg)
 	test.AssertNotError(t, err, "registrationToPB failed")
 	pbReg.Contact = []string{}
-	outReg, err = pbToRegistration(pbReg)
-	test.AssertNotError(t, err, "pbToRegistration failed")
+	outReg, err = PbToRegistration(pbReg)
+	test.AssertNotError(t, err, "PbToRegistration failed")
 	test.AssertDeepEquals(t, inReg, outReg)
 
 	var empty []string
 	inReg.Contact = &empty
-	pbReg, err = registrationToPB(inReg)
+	pbReg, err = RegistrationToPB(inReg)
 	test.AssertNotError(t, err, "registrationToPB failed")
-	outReg, err = pbToRegistration(pbReg)
-	test.AssertNotError(t, err, "pbToRegistration failed")
+	outReg, err = PbToRegistration(pbReg)
+	test.AssertNotError(t, err, "PbToRegistration failed")
 	test.Assert(t, *outReg.Contact != nil, "Empty slice was converted to a nil slice")
 }
 

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -25,23 +25,8 @@ func NewRegistrationAuthorityClient(inner rapb.RegistrationAuthorityClient) *Reg
 	return &RegistrationAuthorityClientWrapper{inner}
 }
 
-func (rac RegistrationAuthorityClientWrapper) NewRegistration(ctx context.Context, reg core.Registration) (core.Registration, error) {
-	req, err := registrationToPB(reg)
-	if err != nil {
-		return core.Registration{}, err
-	}
-
-	response, err := rac.inner.NewRegistration(ctx, req)
-	if err != nil {
-		return core.Registration{}, err
-	}
-
-	if response == nil || !registrationValid(response) {
-		return core.Registration{}, errIncompleteResponse
-	}
-
-	r, err := pbToRegistration(response)
-	return r, err
+func (rac RegistrationAuthorityClientWrapper) NewRegistration(ctx context.Context, request *corepb.Registration) (*corepb.Registration, error) {
+	return rac.inner.NewRegistration(ctx, request)
 }
 
 func (rac RegistrationAuthorityClientWrapper) NewAuthorization(ctx context.Context, authz core.Authorization, regID int64) (core.Authorization, error) {
@@ -72,11 +57,11 @@ func (rac RegistrationAuthorityClientWrapper) NewCertificate(ctx context.Context
 }
 
 func (rac RegistrationAuthorityClientWrapper) UpdateRegistration(ctx context.Context, base, updates core.Registration) (core.Registration, error) {
-	basePB, err := registrationToPB(base)
+	basePB, err := RegistrationToPB(base)
 	if err != nil {
 		return core.Registration{}, err
 	}
-	updatePB, err := registrationToPB(updates)
+	updatePB, err := RegistrationToPB(updates)
 	if err != nil {
 		return core.Registration{}, err
 	}
@@ -90,7 +75,7 @@ func (rac RegistrationAuthorityClientWrapper) UpdateRegistration(ctx context.Con
 		return core.Registration{}, errIncompleteResponse
 	}
 
-	return pbToRegistration(response)
+	return PbToRegistration(response)
 }
 
 func (rac RegistrationAuthorityClientWrapper) PerformValidation(
@@ -122,7 +107,7 @@ func (rac RegistrationAuthorityClientWrapper) RevokeCertificateWithReg(ctx conte
 }
 
 func (rac RegistrationAuthorityClientWrapper) DeactivateRegistration(ctx context.Context, reg core.Registration) error {
-	regPB, err := registrationToPB(reg)
+	regPB, err := RegistrationToPB(reg)
 	if err != nil {
 		return err
 	}
@@ -195,18 +180,7 @@ func NewRegistrationAuthorityServer(inner core.RegistrationAuthority) *Registrat
 }
 
 func (ras *RegistrationAuthorityServerWrapper) NewRegistration(ctx context.Context, request *corepb.Registration) (*corepb.Registration, error) {
-	if request == nil || !newRegistrationValid(request) {
-		return nil, errIncompleteRequest
-	}
-	reg, err := pbToRegistration(request)
-	if err != nil {
-		return nil, err
-	}
-	newReg, err := ras.inner.NewRegistration(ctx, reg)
-	if err != nil {
-		return nil, err
-	}
-	return registrationToPB(newReg)
+	return ras.inner.NewRegistration(ctx, request)
 }
 
 func (ras *RegistrationAuthorityServerWrapper) NewAuthorization(ctx context.Context, request *rapb.NewAuthorizationRequest) (*corepb.Authorization, error) {
@@ -246,11 +220,11 @@ func (ras *RegistrationAuthorityServerWrapper) UpdateRegistration(ctx context.Co
 	if request == nil || !registrationValid(request.Base) {
 		return nil, errIncompleteRequest
 	}
-	base, err := pbToRegistration(request.Base)
+	base, err := PbToRegistration(request.Base)
 	if err != nil {
 		return nil, err
 	}
-	update, err := pbToRegistration(request.Update)
+	update, err := PbToRegistration(request.Update)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +232,7 @@ func (ras *RegistrationAuthorityServerWrapper) UpdateRegistration(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	return registrationToPB(newReg)
+	return RegistrationToPB(newReg)
 }
 
 func (ras *RegistrationAuthorityServerWrapper) PerformValidation(
@@ -289,7 +263,7 @@ func (ras *RegistrationAuthorityServerWrapper) DeactivateRegistration(ctx contex
 	if request == nil || !registrationValid(request) {
 		return nil, errIncompleteRequest
 	}
-	reg, err := pbToRegistration(request)
+	reg, err := PbToRegistration(request)
 	if err != nil {
 		return nil, err
 	}

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -37,7 +37,7 @@ func (sac StorageAuthorityClientWrapper) GetRegistration(ctx context.Context, re
 		return core.Registration{}, errIncompleteResponse
 	}
 
-	return pbToRegistration(response)
+	return PbToRegistration(response)
 }
 
 func (sac StorageAuthorityClientWrapper) GetRegistrationByKey(ctx context.Context, key *jose.JSONWebKey) (core.Registration, error) {
@@ -55,7 +55,7 @@ func (sac StorageAuthorityClientWrapper) GetRegistrationByKey(ctx context.Contex
 		return core.Registration{}, errIncompleteResponse
 	}
 
-	return pbToRegistration(response)
+	return PbToRegistration(response)
 }
 
 func (sac StorageAuthorityClientWrapper) GetCertificate(ctx context.Context, serial string) (core.Certificate, error) {
@@ -253,7 +253,7 @@ func (sac StorageAuthorityClientWrapper) FQDNSetExists(ctx context.Context, doma
 }
 
 func (sac StorageAuthorityClientWrapper) NewRegistration(ctx context.Context, reg core.Registration) (core.Registration, error) {
-	regPB, err := registrationToPB(reg)
+	regPB, err := RegistrationToPB(reg)
 	if err != nil {
 		return core.Registration{}, err
 	}
@@ -267,11 +267,11 @@ func (sac StorageAuthorityClientWrapper) NewRegistration(ctx context.Context, re
 		return core.Registration{}, errIncompleteResponse
 	}
 
-	return pbToRegistration(response)
+	return PbToRegistration(response)
 }
 
 func (sac StorageAuthorityClientWrapper) UpdateRegistration(ctx context.Context, reg core.Registration) error {
-	regPB, err := registrationToPB(reg)
+	regPB, err := RegistrationToPB(reg)
 	if err != nil {
 		return err
 	}
@@ -516,7 +516,7 @@ func (sas StorageAuthorityServerWrapper) GetRegistration(ctx context.Context, re
 		return nil, err
 	}
 
-	return registrationToPB(reg)
+	return RegistrationToPB(reg)
 }
 
 func (sas StorageAuthorityServerWrapper) GetRegistrationByKey(ctx context.Context, request *sapb.JSONWebKey) (*corepb.Registration, error) {
@@ -535,7 +535,7 @@ func (sas StorageAuthorityServerWrapper) GetRegistrationByKey(ctx context.Contex
 		return nil, err
 	}
 
-	return registrationToPB(reg)
+	return RegistrationToPB(reg)
 }
 
 func (sas StorageAuthorityServerWrapper) GetCertificate(ctx context.Context, request *sapb.Serial) (*corepb.Certificate, error) {
@@ -678,7 +678,7 @@ func (sas StorageAuthorityServerWrapper) NewRegistration(ctx context.Context, re
 		return nil, errIncompleteRequest
 	}
 
-	reg, err := pbToRegistration(request)
+	reg, err := PbToRegistration(request)
 	if err != nil {
 		return nil, err
 	}
@@ -688,7 +688,7 @@ func (sas StorageAuthorityServerWrapper) NewRegistration(ctx context.Context, re
 		return nil, err
 	}
 
-	return registrationToPB(newReg)
+	return RegistrationToPB(newReg)
 }
 
 func (sas StorageAuthorityServerWrapper) UpdateRegistration(ctx context.Context, request *corepb.Registration) (*corepb.Empty, error) {
@@ -696,7 +696,7 @@ func (sas StorageAuthorityServerWrapper) UpdateRegistration(ctx context.Context,
 		return nil, errIncompleteRequest
 	}
 
-	reg, err := pbToRegistration(request)
+	reg, err := PbToRegistration(request)
 	if err != nil {
 		return nil, err
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -348,7 +348,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, reques
 	var key jose.JSONWebKey
 	err := key.UnmarshalJSON(request.Key)
 	if err != nil {
-		berrors.InternalServerError("failed to unmarshal account key: %s", err.Error())
+		return &corepb.Registration{}, berrors.InternalServerError("failed to unmarshal account key: %s", err.Error())
 	}
 	// Check if account key is acceptable for use
 	if err := ra.keyPolicy.GoodKey(ctx, key.Key); err != nil {
@@ -359,7 +359,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, reques
 	var ipAddr net.IP
 	err = ipAddr.UnmarshalText(request.InitialIP)
 	if err != nil {
-		berrors.InternalServerError("failed to unmarshal ip address: %s", err.Error())
+		return &corepb.Registration{}, berrors.InternalServerError("failed to unmarshal ip address: %s", err.Error())
 	}
 
 	if err := ra.checkRegistrationLimits(ctx, ipAddr); err != nil {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -346,8 +346,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, reques
 
 	// Convert key bytes to key
 	var key jose.JSONWebKey
-	err := key.UnmarshalJSON(request.Key)
-	if err != nil {
+	if err := key.UnmarshalJSON(request.Key); err != nil {
 		return &corepb.Registration{}, berrors.InternalServerError("failed to unmarshal account key: %s", err.Error())
 	}
 	// Check if account key is acceptable for use
@@ -357,8 +356,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, reques
 
 	// Convert IP from bytes
 	var ipAddr net.IP
-	err = ipAddr.UnmarshalText(request.InitialIP)
-	if err != nil {
+	if err := ipAddr.UnmarshalText(request.InitialIP); err != nil {
 		return &corepb.Registration{}, berrors.InternalServerError("failed to unmarshal ip address: %s", err.Error())
 	}
 

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -200,7 +200,7 @@ type MockRegistrationAuthority struct {
 	lastRevocationReason revocation.Reason
 }
 
-func (ra *MockRegistrationAuthority) NewRegistration(ctx context.Context, reg core.Registration) (core.Registration, error) {
+func (ra *MockRegistrationAuthority) NewRegistration(ctx context.Context, reg *corepb.Registration) (*corepb.Registration, error) {
 	return reg, nil
 }
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -643,9 +643,10 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		return
 	}
 	var contacts []string
-	contactsPresent := accountCreateRequest.Contact != nil
+	var contactsPresent bool
 	if accountCreateRequest.Contact != nil {
-		contacts = *accountCreateRequest.Contact
+	        contactsPresent = true
+ 		contacts = *accountCreateRequest.Contact
 	}
 
 	// Create corepb.Registration from provided account information

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -645,8 +645,8 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	var contacts []string
 	var contactsPresent bool
 	if accountCreateRequest.Contact != nil {
-	        contactsPresent = true
- 		contacts = *accountCreateRequest.Contact
+		contactsPresent = true
+		contacts = *accountCreateRequest.Contact
 	}
 
 	// Create corepb.Registration from provided account information

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -629,12 +629,36 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		return
 	}
 
-	acct, err := wfe.RA.NewRegistration(ctx, core.Registration{
-		Contact:   accountCreateRequest.Contact,
-		Agreement: wfe.SubscriberAgreementURL,
-		Key:       key,
-		InitialIP: ip,
-	})
+	// Prepare account information to create corepb.Registration
+	keyBytes, err := key.MarshalJSON()
+	if err != nil {
+		wfe.sendError(response, logEvent,
+			web.ProblemDetailsForError(err, "Error creating new account"), err)
+		return
+	}
+	ipBytes, err := ip.MarshalText()
+	if err != nil {
+		wfe.sendError(response, logEvent,
+			web.ProblemDetailsForError(err, "Error creating new account"), err)
+		return
+	}
+	var contacts []string
+	contactsPresent := accountCreateRequest.Contact != nil
+	if accountCreateRequest.Contact != nil {
+		contacts = *accountCreateRequest.Contact
+	}
+
+	// Create corepb.Registration from provided account information
+	reg := corepb.Registration{
+		Contact:         contacts,
+		ContactsPresent: contactsPresent,
+		Agreement:       wfe.SubscriberAgreementURL,
+		Key:             keyBytes,
+		InitialIP:       ipBytes,
+	}
+
+	// Send the registration to the RA via grpc
+	acctPB, err := wfe.RA.NewRegistration(ctx, &reg)
 	if err != nil {
 		if errors.Is(err, berrors.Duplicate) {
 			existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, key)
@@ -647,6 +671,23 @@ func (wfe *WebFrontEndImpl) NewAccount(
 			wfe.sendError(response, logEvent, probs.ServerInternal("failed check for existing account"), err)
 			return
 		}
+		wfe.sendError(response, logEvent,
+			web.ProblemDetailsForError(err, "Error creating new account"), err)
+		return
+	}
+
+	// TODO Andrew: Is this tested?
+	registrationValid := func(reg *corepb.Registration) bool {
+		return !(len(reg.Key) == 0 || len(reg.InitialIP) == 0) && reg.Id != 0
+	}
+
+	if acctPB == nil || !registrationValid(acctPB) {
+		wfe.sendError(response, logEvent,
+			web.ProblemDetailsForError(err, "Error creating new account"), err)
+		return
+	}
+	acct, err := bgrpc.PbToRegistration(acctPB)
+	if err != nil {
 		wfe.sendError(response, logEvent,
 			web.ProblemDetailsForError(err, "Error creating new account"), err)
 		return

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -677,7 +677,6 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		return
 	}
 
-	// TODO Andrew: Is this tested?
 	registrationValid := func(reg *corepb.Registration) bool {
 		return !(len(reg.Key) == 0 || len(reg.InitialIP) == 0) && reg.Id != 0
 	}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -208,8 +208,9 @@ type MockRegistrationAuthority struct {
 	lastRevocationReason revocation.Reason
 }
 
-func (ra *MockRegistrationAuthority) NewRegistration(ctx context.Context, acct core.Registration) (core.Registration, error) {
-	acct.ID = 1
+func (ra *MockRegistrationAuthority) NewRegistration(ctx context.Context, acct *corepb.Registration) (*corepb.Registration, error) {
+	acct.Id = 1
+	acct.CreatedAt = time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano()
 	return acct, nil
 }
 
@@ -1539,7 +1540,7 @@ func TestNewAccountNoID(t *testing.T) {
 			"mailto:person@mail.com"
 		],
 		"initialIp": "1.1.1.1",
-		"createdAt": "0001-01-01T00:00:00Z",
+		"createdAt": "2021-01-01T00:00:00Z",
 		"status": ""
 	}`)
 }


### PR DESCRIPTION
Turn ra.NewRegistration into passthrough
    
Fixes #5343