### PR TITLE
Add lower, faster duplicate certificate rate limit

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1385,10 +1385,11 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx contex
 		return fmt.Errorf("checking duplicate certificate limit for %q: %s", names, err)
 	}
 	names = core.UniqueLowerNames(names)
-	if int(count) >= limit.GetThreshold(strings.Join(names, ","), regID) {
+	threshold := limit.GetThreshold(strings.Join(names, ","), regID)
+	if int(count) >= threshold {
 		return berrors.RateLimitError(
-			"too many certificates already issued for exact set of domains: %s",
-			strings.Join(names, ","),
+			"too many certificates (%d) already issued for this exact set of domains in the last %s: %s",
+			threshold, limit.Window.Duration, strings.Join(names, ","),
 		)
 	}
 	return nil

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1388,8 +1388,8 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx contex
 	threshold := limit.GetThreshold(strings.Join(names, ","), regID)
 	if int(count) >= threshold {
 		return berrors.RateLimitError(
-			"too many certificates (%d) already issued for this exact set of domains in the last %s: %s",
-			threshold, limit.Window.Duration, strings.Join(names, ","),
+			"too many certificates (%d) already issued for this exact set of domains in the last %.0f hours: %s",
+			threshold, limit.Window.Duration.Hours(), strings.Join(names, ","),
 		)
 	}
 	return nil

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1403,6 +1403,14 @@ func (ra *RegistrationAuthorityImpl) checkLimits(ctx context.Context, names []st
 		}
 	}
 
+	fqdnFastLimits := ra.rlPolicies.CertificatesPerFQDNSetFast()
+	if fqdnFastLimits.Enabled() {
+		err := ra.checkCertificatesPerFQDNSetLimit(ctx, names, fqdnFastLimits, regID)
+		if err != nil {
+			return err
+		}
+	}
+
 	fqdnLimits := ra.rlPolicies.CertificatesPerFQDNSet()
 	if fqdnLimits.Enabled() {
 		err := ra.checkCertificatesPerFQDNSetLimit(ctx, names, fqdnLimits, regID)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -223,6 +223,7 @@ type dummyRateLimitConfig struct {
 	NewOrdersPerAccountPolicy             ratelimit.RateLimitPolicy
 	InvalidAuthorizationsPerAccountPolicy ratelimit.RateLimitPolicy
 	CertificatesPerFQDNSetPolicy          ratelimit.RateLimitPolicy
+	CertificatesPerFQDNSetFastPolicy      ratelimit.RateLimitPolicy
 }
 
 func (r *dummyRateLimitConfig) TotalCertificates() ratelimit.RateLimitPolicy {
@@ -259,6 +260,10 @@ func (r *dummyRateLimitConfig) InvalidAuthorizationsPerAccount() ratelimit.RateL
 
 func (r *dummyRateLimitConfig) CertificatesPerFQDNSet() ratelimit.RateLimitPolicy {
 	return r.CertificatesPerFQDNSetPolicy
+}
+
+func (r *dummyRateLimitConfig) CertificatesPerFQDNSetFast() ratelimit.RateLimitPolicy {
+	return r.CertificatesPerFQDNSetFastPolicy
 }
 
 func (r *dummyRateLimitConfig) LoadPolicies(contents []byte) error {
@@ -1336,8 +1341,10 @@ func TestRateLimitLiveReload(t *testing.T) {
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le.wtf"], 10000)
 	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP().Overrides["127.0.0.1"], 1000000)
 	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount().Threshold, 150)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, 6)
 	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Overrides["le.wtf"], 10000)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, 5)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSetFast().Threshold, 2)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSetFast().Overrides["le.wtf"], 100)
 
 	// Write a different  policy YAML to the monitored file, expect a reload.
 	// Sleep a few milliseconds before writing so the timestamp isn't identical to

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1513,12 +1513,12 @@ func TestCheckExactCertificateLimit(t *testing.T) {
 		{
 			Name:        "FQDN set issuances equal to limit",
 			Domain:      "equal.example.com",
-			ExpectedErr: fmt.Errorf("too many certificates (3) already issued for this exact set of domains in the last 23h0m0s: equal.example.com: see https://letsencrypt.org/docs/rate-limits/"),
+			ExpectedErr: fmt.Errorf("too many certificates (3) already issued for this exact set of domains in the last 23 hours: equal.example.com: see https://letsencrypt.org/docs/rate-limits/"),
 		},
 		{
 			Name:        "FQDN set issuances above limit",
 			Domain:      "over.example.com",
-			ExpectedErr: fmt.Errorf("too many certificates (3) already issued for this exact set of domains in the last 23h0m0s: over.example.com: see https://letsencrypt.org/docs/rate-limits/"),
+			ExpectedErr: fmt.Errorf("too many certificates (3) already issued for this exact set of domains in the last 23 hours: over.example.com: see https://letsencrypt.org/docs/rate-limits/"),
 		},
 	}
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1513,12 +1513,12 @@ func TestCheckExactCertificateLimit(t *testing.T) {
 		{
 			Name:        "FQDN set issuances equal to limit",
 			Domain:      "equal.example.com",
-			ExpectedErr: fmt.Errorf("too many certificates already issued for exact set of domains: equal.example.com: see https://letsencrypt.org/docs/rate-limits/"),
+			ExpectedErr: fmt.Errorf("too many certificates (3) already issued for this exact set of domains in the last 23h0m0s: equal.example.com: see https://letsencrypt.org/docs/rate-limits/"),
 		},
 		{
 			Name:        "FQDN set issuances above limit",
 			Domain:      "over.example.com",
-			ExpectedErr: fmt.Errorf("too many certificates already issued for exact set of domains: over.example.com: see https://letsencrypt.org/docs/rate-limits/"),
+			ExpectedErr: fmt.Errorf("too many certificates (3) already issued for this exact set of domains in the last 23h0m0s: over.example.com: see https://letsencrypt.org/docs/rate-limits/"),
 		},
 	}
 

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -145,7 +145,7 @@ func TestLoadPolicies(t *testing.T) {
 
 	// Test that the CertificatesPerFQDN section parsed correctly
 	certsPerFQDN := policy.CertificatesPerFQDNSet()
-	test.AssertEquals(t, certsPerFQDN.Threshold, 5)
+	test.AssertEquals(t, certsPerFQDN.Threshold, 6)
 	test.AssertDeepEquals(t, certsPerFQDN.Overrides, map[string]int{
 		"le.wtf":                10000,
 		"le1.wtf":               10000,
@@ -158,6 +158,12 @@ func TestLoadPolicies(t *testing.T) {
 		"must-staple.le.wtf":    10000,
 	})
 	test.AssertEquals(t, len(certsPerFQDN.RegistrationOverrides), 0)
+	certsPerFQDNFast := policy.CertificatesPerFQDNSetFast()
+	test.AssertEquals(t, certsPerFQDNFast.Threshold, 2)
+	test.AssertDeepEquals(t, certsPerFQDNFast.Overrides, map[string]int{
+		"le.wtf": 100,
+	})
+	test.AssertEquals(t, len(certsPerFQDNFast.RegistrationOverrides), 0)
 
 	// Test that loading invalid YAML generates an error
 	err = policy.LoadPolicies([]byte("err"))

--- a/test/integration/ratelimit_test.go
+++ b/test/integration/ratelimit_test.go
@@ -1,0 +1,25 @@
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestDuplicateFQDNRateLimit(t *testing.T) {
+	t.Parallel()
+	domain := random_domain()
+	os.Setenv("DIRECTORY", "http://boulder:4001/directory")
+
+	_, err := authAndIssue(nil, nil, []string{domain})
+	test.AssertNotError(t, err, "Failed to issue first certificate")
+
+	_, err = authAndIssue(nil, nil, []string{domain})
+	test.AssertNotError(t, err, "Failed to issue second certificate")
+
+	_, err = authAndIssue(nil, nil, []string{domain})
+	test.AssertError(t, err, "Somehow managed to issue third certificate")
+}

--- a/test/rate-limit-policies-b.yml
+++ b/test/rate-limit-policies-b.yml
@@ -35,7 +35,7 @@ newOrdersPerAccount:
   window: 3h
   threshold: 9999
 certificatesPerFQDNSet:
-  window: 24h
+  window: 168h
   threshold: 99999
   overrides:
     le.wtf: 9999
@@ -47,3 +47,8 @@ certificatesPerFQDNSet:
     nginx.wtf: 9999
     ecdsa.le.wtf: 9999
     must-staple.le.wtf: 9999
+certificatesPerFQDNSetFast:
+  window: 1h
+  threshold: 20
+  overrides:
+    le.wtf: 9

--- a/test/rate-limit-policies-b.yml
+++ b/test/rate-limit-policies-b.yml
@@ -48,7 +48,7 @@ certificatesPerFQDNSet:
     ecdsa.le.wtf: 9999
     must-staple.le.wtf: 9999
 certificatesPerFQDNSetFast:
-  window: 1h
+  window: 2h
   threshold: 20
   overrides:
     le.wtf: 9

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -50,7 +50,7 @@ certificatesPerFQDNSet:
     ecdsa.le.wtf: 10000
     must-staple.le.wtf: 10000
 certificatesPerFQDNSetFast:
-  window: 1h
+  window: 2h
   threshold: 2
   overrides:
     le.wtf: 100

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -37,8 +37,8 @@ newOrdersPerAccount:
   window: 3h
   threshold: 1500
 certificatesPerFQDNSet:
-  window: 24h
-  threshold: 5
+  window: 168h
+  threshold: 6
   overrides:
     le.wtf: 10000
     le1.wtf: 10000
@@ -49,3 +49,8 @@ certificatesPerFQDNSet:
     nginx.wtf: 10000
     ecdsa.le.wtf: 10000
     must-staple.le.wtf: 10000
+certificatesPerFQDNSetFast:
+  window: 1h
+  threshold: 2
+  overrides:
+    le.wtf: 100

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -531,11 +531,11 @@ def test_account_update():
 
 def test_renewal_exemption():
     """
-    Under a single domain, issue one certificate, then two renewals of that
-    certificate, then one more different certificate (with a different
-    subdomain). Since the certificatesPerName rate limit in testing is 2 per 90
-    days, and the renewals should be discounted under the renewal exemption,
-    each of these issuances should succeed. Then do one last issuance that we
+    Under a single domain, issue two certificates for different subdomains of
+    the same name, then renewals of each of them. Since the certificatesPerName
+    rate limit in testing is 2 per 90 days, and the renewals should not be
+    counted under the renewal exemption, each of these issuances should succeed.
+    Then do one last issuance (for a third subdomain of the same name) that we
     expect to be rate limited, just to check that the rate limit is actually 2,
     and we are testing what we think we are testing. See
     https://letsencrypt.org/docs/rate-limits/ for more details.
@@ -545,9 +545,9 @@ def test_renewal_exemption():
     auth_and_issue(["www." + base_domain])
     # First Renewal
     auth_and_issue(["www." + base_domain])
-    # Second Renewal
-    auth_and_issue(["www." + base_domain])
     # Issuance of a different cert
+    auth_and_issue(["blog." + base_domain])
+    # Renew that one
     auth_and_issue(["blog." + base_domain])
     # Final, failed issuance, for another different cert
     chisel.expect_problem("urn:acme:error:rateLimited",

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1424,11 +1424,11 @@ def test_account_update():
 
 def test_renewal_exemption():
     """
-    Under a single domain, issue one certificate, then two renewals of that
-    certificate, then one more different certificate (with a different
-    subdomain). Since the certificatesPerName rate limit in testing is 2 per 90
-    days, and the renewals should be discounted under the renewal exemption,
-    each of these issuances should succeed. Then do one last issuance that we
+    Under a single domain, issue two certificates for different subdomains of
+    the same name, then renewals of each of them. Since the certificatesPerName
+    rate limit in testing is 2 per 90 days, and the renewals should not be
+    counted under the renewal exemption, each of these issuances should succeed.
+    Then do one last issuance (for a third subdomain of the same name) that we
     expect to be rate limited, just to check that the rate limit is actually 2,
     and we are testing what we think we are testing. See
     https://letsencrypt.org/docs/rate-limits/ for more details.
@@ -1438,9 +1438,9 @@ def test_renewal_exemption():
     chisel2.auth_and_issue(["www." + base_domain])
     # First Renewal
     chisel2.auth_and_issue(["www." + base_domain])
-    # Second Renewal
-    chisel2.auth_and_issue(["www." + base_domain])
     # Issuance of a different cert
+    chisel2.auth_and_issue(["blog." + base_domain])
+    # Renew that one
     chisel2.auth_and_issue(["blog." + base_domain])
     # Final, failed issuance, for another different cert
     chisel2.expect_problem("urn:ietf:params:acme:error:rateLimited",


### PR DESCRIPTION
Add a new rate limit, identical in implementation to the current
`CertificatesPerFQDNSet` limit, intended to always have both a lower
window and a lower threshold. This allows us to block runaway clients
quickly, and give their owners the ability to fix and try again quickly
(on the order of hours instead of days).

Configure the integration tests to set this new limit at 2 certs per 2
hours. Also increase the existing limit from 5 to 6 certs in 7 days, to
allow clients to hit the first limit three times before being fully
blocked for the week. Also add a new integration test to verify this
behavior.

Note that the new ratelimit must have a window greater than the
configured certificate backdate (currently 1 hour) in order to be
useful.

Fixes #5210