### PR TITLE
Move OCSP gRPC service to separate file and struct

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -63,8 +63,8 @@ type issuerMaps struct {
 	byNameID map[issuance.IssuerNameID]*issuance.Issuer
 }
 
-// certificateAuthorityImpl represents a CA that signs certificates, CRLs, and
-// OCSP responses.
+// certificateAuthorityImpl represents a CA that signs certificates.
+// It can sign OCSP responses as well, but only via delegation to an ocspImpl.
 type certificateAuthorityImpl struct {
 	capb.UnimplementedCertificateAuthorityServer
 	capb.UnimplementedOCSPGeneratorServer
@@ -176,6 +176,7 @@ func NewCertificateAuthorityImpl(
 	ca = &certificateAuthorityImpl{
 		sa:                 sa,
 		pa:                 pa,
+		ocsp:               ocsp,
 		issuers:            issuers,
 		ecdsaAllowedRegIDs: ecdsaAllowedRegIDsMap,
 		validityPeriod:     certExpiry,
@@ -183,6 +184,7 @@ func NewCertificateAuthorityImpl(
 		prefix:             serialPrefix,
 		maxNames:           maxNames,
 		keyPolicy:          keyPolicy,
+		orphanQueue:        orphanQueue,
 		log:                logger,
 		signatureCount:     signatureCount,
 		csrExtensionCount:  csrExtensionCount,

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -70,7 +70,7 @@ type certificateAuthorityImpl struct {
 	capb.UnimplementedOCSPGeneratorServer
 	sa                 certificateStorage
 	pa                 core.PolicyAuthority
-	ocsp               capb.OCSPGeneratorServer
+	ocsp               *ocspImpl
 	issuers            issuerMaps
 	ecdsaAllowedRegIDs map[int64]bool
 	prefix             int // Prepended to the serial number
@@ -105,12 +105,12 @@ func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
 }
 
 // NewCertificateAuthorityImpl creates a CA instance that can sign certificates
-// from a single issuer (the first first in the issuers slice), and can sign OCSP
-// for any of the issuer certificates provided.
+// from any number of issuance.Issuers according to their profiles, and can sign
+// OCSP (via delegation to an ocspImpl and its issuers).
 func NewCertificateAuthorityImpl(
 	sa certificateStorage,
 	pa core.PolicyAuthority,
-	ocsp capb.OCSPGeneratorServer,
+	ocsp *ocspImpl,
 	boulderIssuers []*issuance.Issuer,
 	ecdsaAllowedRegIDs []int64,
 	certExpiry time.Duration,

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -2,7 +2,6 @@ package ca
 
 import (
 	"context"
-	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/hex"
@@ -55,23 +54,19 @@ const (
 	certType    = certificateType("certificate")
 )
 
-// Four maps of keys to internalIssuers. Lookup by PublicKeyAlgorithm is
-// useful for determining which issuer to use to sign a given (pre)cert, based
-// on its PublicKeyAlgorithm. Lookup by ID and by NameID is useful for looking
-// up the appropriate issuer to use for OCSP, where byID uses the value currently
-// stored in the certStatus database table, and byNameID is an easier-to-compute
-// replacement.
+// Two maps of keys to Issuers. Lookup by PublicKeyAlgorithm is useful for
+// determining which issuer to use to sign a given (pre)cert, based on its
+// PublicKeyAlgorithm. Lookup by NameID is useful for looking up the appropriate
+// issuer based on the issuer of a given (pre)certificate.
 type issuerMaps struct {
-	byAlg    map[x509.PublicKeyAlgorithm]*internalIssuer
-	byID     map[issuance.IssuerID]*internalIssuer
-	byNameID map[issuance.IssuerNameID]*internalIssuer
+	byAlg    map[x509.PublicKeyAlgorithm]*issuance.Issuer
+	byNameID map[issuance.IssuerNameID]*issuance.Issuer
 }
 
-// CertificateAuthorityImpl represents a CA that signs certificates, CRLs, and
+// certificateAuthorityImpl represents a CA that signs certificates, CRLs, and
 // OCSP responses.
-type CertificateAuthorityImpl struct {
+type certificateAuthorityImpl struct {
 	capb.UnimplementedCertificateAuthorityServer
-	capb.UnimplementedOCSPGeneratorServer
 	sa                 certificateStorage
 	pa                 core.PolicyAuthority
 	issuers            issuerMaps
@@ -80,10 +75,8 @@ type CertificateAuthorityImpl struct {
 	validityPeriod     time.Duration
 	backdate           time.Duration
 	maxNames           int
-	ocspLifetime       time.Duration
 	keyPolicy          goodkey.KeyPolicy
 	orphanQueue        *goque.Queue
-	ocspLogQueue       *ocspLogQueue
 	clk                clock.Clock
 	log                blog.Logger
 	signatureCount     *prometheus.CounterVec
@@ -93,42 +86,20 @@ type CertificateAuthorityImpl struct {
 	signErrorCounter   *prometheus.CounterVec
 }
 
-// Issuer represents a single issuer certificate, along with its key.
-type Issuer struct {
-	Signer crypto.Signer
-	Cert   *issuance.Certificate
-}
-
-// internalIssuer represents the fully initialized internal state for a single
-// issuer, including the OCSP signer object.
-// TODO(#5086): Remove the ocsp-specific pieces of this as we factor OCSP out.
-type internalIssuer struct {
-	cert          *issuance.Certificate
-	ocspSigner    crypto.Signer
-	boulderIssuer *issuance.Issuer
-}
-
-func makeInternalIssuers(issuers []*issuance.Issuer, lifespanOCSP time.Duration) (issuerMaps, error) {
-	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*internalIssuer, 2)
-	issuersByID := make(map[issuance.IssuerID]*internalIssuer, len(issuers))
-	issuersByNameID := make(map[issuance.IssuerNameID]*internalIssuer, len(issuers))
+func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
+	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*issuance.Issuer, 2)
+	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Issuer, len(issuers))
 	for _, issuer := range issuers {
-		ii := &internalIssuer{
-			cert:          issuer.Cert,
-			ocspSigner:    issuer.Signer,
-			boulderIssuer: issuer,
-		}
 		for _, alg := range issuer.Algs() {
 			// TODO(#5259): Enforce that there is only one issuer for each algorithm,
 			// instead of taking the first issuer for each algorithm type.
 			if issuersByAlg[alg] == nil {
-				issuersByAlg[alg] = ii
+				issuersByAlg[alg] = issuer
 			}
 		}
-		issuersByID[issuer.ID()] = ii
-		issuersByNameID[issuer.Cert.NameID()] = ii
+		issuersByNameID[issuer.Cert.NameID()] = issuer
 	}
-	return issuerMaps{issuersByAlg, issuersByID, issuersByNameID}, nil
+	return issuerMaps{issuersByAlg, issuersByNameID}, nil
 }
 
 // NewCertificateAuthorityImpl creates a CA instance that can sign certificates
@@ -143,16 +114,13 @@ func NewCertificateAuthorityImpl(
 	certBackdate time.Duration,
 	serialPrefix int,
 	maxNames int,
-	ocspLifetime time.Duration,
 	keyPolicy goodkey.KeyPolicy,
 	orphanQueue *goque.Queue,
-	ocspLogMaxLength int,
-	ocspLogPeriod time.Duration,
 	logger blog.Logger,
 	stats prometheus.Registerer,
 	clk clock.Clock,
-) (*CertificateAuthorityImpl, error) {
-	var ca *CertificateAuthorityImpl
+) (*certificateAuthorityImpl, error) {
+	var ca *certificateAuthorityImpl
 	var err error
 
 	// TODO(briansmith): Make the backdate setting mandatory after the
@@ -166,7 +134,7 @@ func NewCertificateAuthorityImpl(
 		err = errors.New("Must have a positive non-zero serial prefix less than 256 for CA.")
 		return nil, err
 	}
-	issuers, err := makeInternalIssuers(boulderIssuers, ocspLifetime)
+	issuers, err := makeIssuerMaps(boulderIssuers)
 	if err != nil {
 		return nil, err
 	}
@@ -214,12 +182,7 @@ func NewCertificateAuthorityImpl(
 	}, []string{"type"})
 	stats.MustRegister(signErrorCounter)
 
-	var ocspLogQueue *ocspLogQueue
-	if ocspLogMaxLength > 0 {
-		ocspLogQueue = newOCSPLogQueue(ocspLogMaxLength, ocspLogPeriod, stats, logger)
-	}
-
-	ca = &CertificateAuthorityImpl{
+	ca = &certificateAuthorityImpl{
 		sa:                 sa,
 		pa:                 pa,
 		issuers:            issuers,
@@ -228,10 +191,7 @@ func NewCertificateAuthorityImpl(
 		backdate:           certBackdate,
 		prefix:             serialPrefix,
 		maxNames:           maxNames,
-		ocspLifetime:       ocspLifetime,
 		keyPolicy:          keyPolicy,
-		orphanQueue:        orphanQueue,
-		ocspLogQueue:       ocspLogQueue,
 		log:                logger,
 		signatureCount:     signatureCount,
 		csrExtensionCount:  csrExtensionCount,
@@ -245,7 +205,7 @@ func NewCertificateAuthorityImpl(
 }
 
 // noteSignError is called after operations that may cause a PKCS11 signing error.
-func (ca *CertificateAuthorityImpl) noteSignError(err error) {
+func (ca *certificateAuthorityImpl) noteSignError(err error) {
 	var pkcs11Error *pkcs11.Error
 	if errors.As(err, &pkcs11Error) {
 		ca.signErrorCounter.WithLabelValues("HSM").Inc()
@@ -258,49 +218,7 @@ var ocspStatusToCode = map[string]int{
 	"unknown": ocsp.Unknown,
 }
 
-// GenerateOCSP produces a new OCSP response and returns it
-func (ca *CertificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
-	// req.Status, req.Reason, and req.RevokedAt are often 0, for non-revoked certs.
-	if core.IsAnyNilOrZero(req, req.Serial, req.IssuerID) {
-		return nil, berrors.InternalServerError("Incomplete generate OCSP request")
-	}
-
-	serialInt, err := core.StringToSerial(req.Serial)
-	if err != nil {
-		return nil, err
-	}
-	serial := serialInt
-	var ok bool
-	issuer, ok := ca.issuers.byID[issuance.IssuerID(req.IssuerID)]
-	if !ok {
-		return nil, fmt.Errorf("This CA doesn't have an issuer cert with ID %d", req.IssuerID)
-	}
-
-	now := ca.clk.Now().Truncate(time.Hour)
-	tbsResponse := ocsp.Response{
-		Status:       ocspStatusToCode[req.Status],
-		SerialNumber: serial,
-		ThisUpdate:   now,
-		NextUpdate:   now.Add(ca.ocspLifetime),
-	}
-	if tbsResponse.Status == ocsp.Revoked {
-		tbsResponse.RevokedAt = time.Unix(0, req.RevokedAt)
-		tbsResponse.RevocationReason = int(req.Reason)
-	}
-
-	if ca.ocspLogQueue != nil {
-		ca.ocspLogQueue.enqueue(serial.Bytes(), now, ocsp.ResponseStatus(tbsResponse.Status))
-	}
-
-	ocspResponse, err := ocsp.CreateResponse(issuer.cert.Certificate, issuer.cert.Certificate, tbsResponse, issuer.ocspSigner)
-	ca.noteSignError(err)
-	if err == nil {
-		ca.signatureCount.With(prometheus.Labels{"purpose": "ocsp", "issuer": issuer.boulderIssuer.Name()}).Inc()
-	}
-	return &capb.OCSPResponse{Response: ocspResponse}, err
-}
-
-func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, issueReq *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
+func (ca *certificateAuthorityImpl) IssuePrecertificate(ctx context.Context, issueReq *capb.IssueCertificateRequest) (*capb.IssuePrecertificateResponse, error) {
 	// issueReq.orderID may be zero, for ACMEv1 requests.
 	if core.IsAnyNilOrZero(issueReq, issueReq.Csr, issueReq.RegistrationID) {
 		return nil, berrors.InternalServerError("Incomplete issue certificate request")
@@ -397,7 +315,7 @@ func (ca *CertificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 // final certificate, but this is just a belt-and-suspenders measure, since
 // there could be race conditions where two goroutines are issuing for the same
 // serial number at the same time.
-func (ca *CertificateAuthorityImpl) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
+func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx context.Context, req *capb.IssueCertificateForPrecertificateRequest) (*corepb.Certificate, error) {
 	// issueReq.orderID may be zero, for ACMEv1 requests.
 	if core.IsAnyNilOrZero(req, req.DER, req.SCTs, req.RegistrationID) {
 		return nil, berrors.InternalServerError("Incomplete cert for precertificate request")
@@ -462,7 +380,7 @@ type validity struct {
 	NotAfter  time.Time
 }
 
-func (ca *CertificateAuthorityImpl) generateSerialNumberAndValidity() (*big.Int, validity, error) {
+func (ca *certificateAuthorityImpl) generateSerialNumberAndValidity() (*big.Int, validity, error) {
 	// We want 136 bits of random number, plus an 8-bit instance id prefix.
 	const randBits = 136
 	serialBytes := make([]byte, randBits/8+1)
@@ -485,7 +403,7 @@ func (ca *CertificateAuthorityImpl) generateSerialNumberAndValidity() (*big.Int,
 	return serialBigInt, validity, nil
 }
 
-func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, serialBigInt *big.Int, validity validity) ([]byte, *internalIssuer, error) {
+func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, serialBigInt *big.Int, validity validity) ([]byte, *issuance.Issuer, error) {
 	csr, err := x509.ParseCertificateRequest(issueReq.Csr)
 	if err != nil {
 		return nil, nil, err
@@ -505,7 +423,7 @@ func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		return nil, nil, err
 	}
 
-	var issuer *internalIssuer
+	var issuer *issuance.Issuer
 	var ok bool
 	if issueReq.IssuerNameID == 0 {
 		// Use the issuer which corresponds to the algorithm of the public key
@@ -526,7 +444,7 @@ func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		}
 	}
 
-	if issuer.cert.NotAfter.Before(validity.NotAfter) {
+	if issuer.Cert.NotAfter.Before(validity.NotAfter) {
 		err = berrors.InternalServerError("cannot issue a certificate that expires after the issuer certificate")
 		ca.log.AuditErr(err.Error())
 		return nil, nil, err
@@ -536,7 +454,7 @@ func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 
 	ca.log.AuditInfof("Signing: serial=[%s] names=[%s] csr=[%s]",
 		serialHex, strings.Join(csr.DNSNames, ", "), hex.EncodeToString(csr.Raw))
-	certDER, err := issuer.boulderIssuer.Issue(&issuance.IssuanceRequest{
+	certDER, err := issuer.Issue(&issuance.IssuanceRequest{
 		PublicKey:         csr.PublicKey,
 		Serial:            serialBigInt.Bytes(),
 		CommonName:        csr.Subject.CommonName,
@@ -552,7 +470,7 @@ func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		ca.log.AuditErrf("Signing failed: serial=[%s] err=[%v]", serialHex, err)
 		return nil, nil, err
 	}
-	ca.signatureCount.With(prometheus.Labels{"purpose": string(precertType), "issuer": issuer.boulderIssuer.Name()}).Inc()
+	ca.signatureCount.With(prometheus.Labels{"purpose": string(precertType), "issuer": issuer.Name()}).Inc()
 
 	ca.log.AuditInfof("Signing success: serial=[%s] names=[%s] csr=[%s] precertificate=[%s]",
 		serialHex, strings.Join(csr.DNSNames, ", "), hex.EncodeToString(csr.Raw),
@@ -561,7 +479,7 @@ func (ca *CertificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 	return certDER, issuer, nil
 }
 
-func (ca *CertificateAuthorityImpl) storeCertificate(
+func (ca *certificateAuthorityImpl) storeCertificate(
 	ctx context.Context,
 	regID int64,
 	orderID int64,
@@ -598,7 +516,7 @@ type orphanedCert struct {
 	IssuerID int64
 }
 
-func (ca *CertificateAuthorityImpl) queueOrphan(o *orphanedCert) {
+func (ca *certificateAuthorityImpl) queueOrphan(o *orphanedCert) {
 	if _, err := ca.orphanQueue.EnqueueObject(o); err != nil {
 		ca.log.AuditErrf("failed to queue orphan for integration: %s", err)
 	}
@@ -607,7 +525,7 @@ func (ca *CertificateAuthorityImpl) queueOrphan(o *orphanedCert) {
 // OrphanIntegrationLoop runs a loop executing integrateOrphans and then waiting a minute.
 // It is split out into a separate function called directly by boulder-ca in order to make
 // testing the orphan queue functionality somewhat more simple.
-func (ca *CertificateAuthorityImpl) OrphanIntegrationLoop() {
+func (ca *certificateAuthorityImpl) OrphanIntegrationLoop() {
 	for {
 		if err := ca.integrateOrphan(); err != nil {
 			if err == goque.ErrEmpty {
@@ -620,30 +538,12 @@ func (ca *CertificateAuthorityImpl) OrphanIntegrationLoop() {
 	}
 }
 
-// LogOCSPLoop collects OCSP generation log events into bundles, and logs
-// them periodically.
-func (ca *CertificateAuthorityImpl) LogOCSPLoop() {
-	if ca.ocspLogQueue != nil {
-		ca.ocspLogQueue.loop()
-	}
-}
-
-// Stop asks this CertificateAuthorityImpl to shut down. It must be called
-// after the corresponding RPC service is shut down and there are no longer
-// any inflight RPCs. It will attempt to drain any logging queues (which may
-// block), and will return only when done.
-func (ca *CertificateAuthorityImpl) Stop() {
-	if ca.ocspLogQueue != nil {
-		ca.ocspLogQueue.stop()
-	}
-}
-
 // integrateOrpan removes an orphan from the queue and adds it to the database. The
 // item isn't dequeued until it is actually added to the database to prevent items from
 // being lost if the CA is restarted between the item being dequeued and being added to
 // the database. It calculates the issuance time by subtracting the backdate period from
 // the notBefore time.
-func (ca *CertificateAuthorityImpl) integrateOrphan() error {
+func (ca *certificateAuthorityImpl) integrateOrphan() error {
 	item, err := ca.orphanQueue.Peek()
 	if err != nil {
 		if err == goque.ErrEmpty {

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -281,7 +281,7 @@ func TestFailNoSerialPrefix(t *testing.T) {
 }
 
 type TestCertificateIssuance struct {
-	ca      *CertificateAuthorityImpl
+	ca      *certificateAuthorityImpl
 	sa      *mockSA
 	req     *x509.CertificateRequest
 	mode    IssuanceMode
@@ -356,7 +356,7 @@ func TestIssuePrecertificate(t *testing.T) {
 	}
 }
 
-func issueCertificateSubTestSetup(t *testing.T) (*CertificateAuthorityImpl, *mockSA) {
+func issueCertificateSubTestSetup(t *testing.T) (*certificateAuthorityImpl, *mockSA) {
 	testCtx := setup(t)
 	sa := &mockSA{}
 	ca, err := NewCertificateAuthorityImpl(
@@ -562,7 +562,7 @@ func TestInvalidCSRs(t *testing.T) {
 	testCases := []struct {
 		name         string
 		csrPath      string
-		check        func(t *testing.T, ca *CertificateAuthorityImpl, sa *mockSA)
+		check        func(t *testing.T, ca *certificateAuthorityImpl, sa *mockSA)
 		errorMessage string
 		errorType    berrors.ErrorType
 	}{

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -24,7 +24,6 @@ import (
 	ctx509 "github.com/google/certificate-transparency-go/x509"
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/crypto/ocsp"
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
@@ -131,15 +130,17 @@ func mustRead(path string) []byte {
 
 type testCtx struct {
 	pa             core.PolicyAuthority
+	ocsp           *ocspImpl
 	certExpiry     time.Duration
 	certBackdate   time.Duration
 	serialPrefix   int
 	maxNames       int
-	ocspLifetime   time.Duration
 	boulderIssuers []*issuance.Issuer
 	keyPolicy      goodkey.KeyPolicy
 	fc             clock.FakeClock
 	stats          prometheus.Registerer
+	signatureCount *prometheus.CounterVec
+	signErrorCount *prometheus.CounterVec
 	logger         *blog.Mock
 }
 
@@ -241,18 +242,44 @@ func setup(t *testing.T) *testCtx {
 		AllowECDSANISTP256: true,
 		AllowECDSANISTP384: true,
 	}
+	signatureCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signatures",
+			Help: "Number of signatures",
+		},
+		[]string{"purpose", "issuer"})
+	signErrorCount := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "signature_errors",
+		Help: "A counter of signature errors labelled by error type",
+	}, []string{"type"})
+
+	ocsp, err := NewOCSPImpl(
+		&mockSA{},
+		boulderIssuers,
+		time.Hour,
+		0,
+		time.Second,
+		blog.NewMock(),
+		metrics.NoopRegisterer,
+		signatureCount,
+		signErrorCount,
+		fc,
+	)
+	test.AssertNotError(t, err, "Failed to create ocsp impl")
 
 	return &testCtx{
 		pa:             pa,
+		ocsp:           ocsp,
 		certExpiry:     8760 * time.Hour,
 		certBackdate:   time.Hour,
 		serialPrefix:   17,
 		maxNames:       2,
-		ocspLifetime:   time.Hour,
 		boulderIssuers: boulderIssuers,
 		keyPolicy:      keyPolicy,
 		fc:             fc,
 		stats:          metrics.NoopRegisterer,
+		signatureCount: signatureCount,
+		signErrorCount: signErrorCount,
 		logger:         blog.NewMock(),
 	}
 }
@@ -265,17 +292,17 @@ func TestFailNoSerialPrefix(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		0,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		nil,
+		nil,
 		testCtx.fc)
 	test.AssertError(t, err, "CA should have failed with no SerialPrefix")
 }
@@ -362,19 +389,19 @@ func issueCertificateSubTestSetup(t *testing.T) (*certificateAuthorityImpl, *moc
 	ca, err := NewCertificateAuthorityImpl(
 		sa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 
@@ -410,19 +437,19 @@ func TestMultipleIssuers(t *testing.T) {
 	ca, err := NewCertificateAuthorityImpl(
 		sa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to remake CA")
 
@@ -475,89 +502,6 @@ func TestECDSAAllowList(t *testing.T) {
 	test.AssertByteEquals(t, cert.RawIssuer, caCert2.RawSubject)
 }
 
-func TestOCSP(t *testing.T) {
-	testCtx := setup(t)
-	sa := &mockSA{}
-	ca, err := NewCertificateAuthorityImpl(
-		sa,
-		testCtx.pa,
-		testCtx.boulderIssuers,
-		nil,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
-		testCtx.serialPrefix,
-		testCtx.maxNames,
-		testCtx.ocspLifetime,
-		testCtx.keyPolicy,
-		nil,
-		0,
-		time.Second,
-		testCtx.logger,
-		testCtx.stats,
-		testCtx.fc)
-	test.AssertNotError(t, err, "Failed to create CA")
-
-	// Issue a certificate from the RSA issuer caCert, then check OCSP comes from the same issuer.
-	rsaIssuerID := ca.issuers.byAlg[x509.RSA].cert.ID()
-	rsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
-	test.AssertNotError(t, err, "Failed to issue certificate")
-	rsaCert, err := x509.ParseCertificate(rsaCertPB.DER)
-	test.AssertNotError(t, err, "Failed to parse rsaCert")
-	rsaOCSPPB, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
-		Serial:   core.SerialToString(rsaCert.SerialNumber),
-		IssuerID: int64(rsaIssuerID),
-		Status:   string(core.OCSPStatusGood),
-	})
-	test.AssertNotError(t, err, "Failed to generate OCSP")
-	rsaOCSP, err := ocsp.ParseResponse(rsaOCSPPB.Response, caCert.Certificate)
-	test.AssertNotError(t, err, "Failed to parse / validate OCSP for rsaCert")
-	test.AssertEquals(t, rsaOCSP.Status, 0)
-	test.AssertEquals(t, rsaOCSP.RevocationReason, 0)
-	test.AssertEquals(t, rsaOCSP.SerialNumber.Cmp(rsaCert.SerialNumber), 0)
-
-	// Issue a certificate from the ECDSA issuer caCert2, then check OCSP comes from the same issuer.
-	ecdsaIssuerID := ca.issuers.byAlg[x509.ECDSA].cert.ID()
-	ecdsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID})
-	test.AssertNotError(t, err, "Failed to issue certificate")
-	ecdsaCert, err := x509.ParseCertificate(ecdsaCertPB.DER)
-	test.AssertNotError(t, err, "Failed to parse ecdsaCert")
-	ecdsaOCSPPB, err := ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
-		Serial:   core.SerialToString(ecdsaCert.SerialNumber),
-		IssuerID: int64(ecdsaIssuerID),
-		Status:   string(core.OCSPStatusGood),
-	})
-	test.AssertNotError(t, err, "Failed to generate OCSP")
-	ecdsaOCSP, err := ocsp.ParseResponse(ecdsaOCSPPB.Response, caCert2.Certificate)
-	test.AssertNotError(t, err, "Failed to parse / validate OCSP for ecdsaCert")
-	test.AssertEquals(t, ecdsaOCSP.Status, 0)
-	test.AssertEquals(t, ecdsaOCSP.RevocationReason, 0)
-	test.AssertEquals(t, ecdsaOCSP.SerialNumber.Cmp(ecdsaCert.SerialNumber), 0)
-
-	// GenerateOCSP with a bad IssuerID should fail.
-	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
-		Serial:   core.SerialToString(rsaCert.SerialNumber),
-		IssuerID: int64(666),
-		Status:   string(core.OCSPStatusGood),
-	})
-	test.AssertError(t, err, "GenerateOCSP didn't fail with invalid IssuerID")
-
-	// GenerateOCSP with a bad Serial should fail.
-	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
-		Serial:   "BADDECAF",
-		IssuerID: int64(rsaIssuerID),
-		Status:   string(core.OCSPStatusGood),
-	})
-	test.AssertError(t, err, "GenerateOCSP didn't fail with invalid Serial")
-
-	// GenerateOCSP with a valid-but-nonexistent Serial should *not* fail.
-	_, err = ca.GenerateOCSP(context.Background(), &capb.GenerateOCSPRequest{
-		Serial:   "03DEADBEEFBADDECAFFADEFACECAFE30",
-		IssuerID: int64(rsaIssuerID),
-		Status:   string(core.OCSPStatusGood),
-	})
-	test.AssertNotError(t, err, "GenerateOCSP failed with fake-but-valid Serial")
-}
-
 func TestInvalidCSRs(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -607,19 +551,19 @@ func TestInvalidCSRs(t *testing.T) {
 		ca, err := NewCertificateAuthorityImpl(
 			sa,
 			testCtx.pa,
+			testCtx.ocsp,
 			testCtx.boulderIssuers,
 			nil,
 			testCtx.certExpiry,
 			testCtx.certBackdate,
 			testCtx.serialPrefix,
 			testCtx.maxNames,
-			testCtx.ocspLifetime,
 			testCtx.keyPolicy,
 			nil,
-			0,
-			time.Second,
 			testCtx.logger,
 			testCtx.stats,
+			testCtx.signatureCount,
+			testCtx.signErrorCount,
 			testCtx.fc)
 		test.AssertNotError(t, err, "Failed to create CA")
 
@@ -645,19 +589,19 @@ func TestRejectValidityTooLong(t *testing.T) {
 	ca, err := NewCertificateAuthorityImpl(
 		sa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		nil,
+		nil,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 
@@ -747,19 +691,19 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 	ca, err := NewCertificateAuthorityImpl(
 		sa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 
@@ -854,19 +798,19 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 	ca, err := NewCertificateAuthorityImpl(
 		sa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 
@@ -897,19 +841,19 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 	errorca, err := NewCertificateAuthorityImpl(
 		errorsa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		nil,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 
@@ -977,19 +921,19 @@ func TestPrecertOrphanQueue(t *testing.T) {
 	ca, err := NewCertificateAuthorityImpl(
 		qsa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		orphanQueue,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 
@@ -1046,19 +990,19 @@ func TestOrphanQueue(t *testing.T) {
 	ca, err := NewCertificateAuthorityImpl(
 		qsa,
 		testCtx.pa,
+		testCtx.ocsp,
 		testCtx.boulderIssuers,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
-		testCtx.ocspLifetime,
 		testCtx.keyPolicy,
 		orphanQueue,
-		0,
-		time.Second,
 		testCtx.logger,
 		testCtx.stats,
+		nil,
+		nil,
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -1,7 +1,5 @@
 package ca
 
-// TODO(##5226): Move the GenerateOCSP service into this file too.
-
 import (
 	"context"
 	"errors"

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -3,6 +3,7 @@ package ca
 // TODO(##5226): Move the GenerateOCSP service into this file too.
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -12,8 +13,117 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/ocsp"
 
+	capb "github.com/letsencrypt/boulder/ca/proto"
+	"github.com/letsencrypt/boulder/core"
+	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
 )
+
+// ocspImpl provides a backing implementation for the OCSP gRPC service.
+type ocspImpl struct {
+	capb.UnimplementedOCSPGeneratorServer
+	sa certificateStorage
+	// TODO(#5152): Replace IssuerID with IssuerNameID.
+	issuers      map[issuance.IssuerID]*issuance.Issuer
+	ocspLifetime time.Duration
+	ocspLogQueue *ocspLogQueue
+	log          blog.Logger
+	clk          clock.Clock
+}
+
+func NewOCSPImpl(
+	sa certificateStorage,
+	issuers []*issuance.Issuer,
+	ocspLifetime time.Duration,
+	ocspLogMaxLength int,
+	ocspLogPeriod time.Duration,
+	logger blog.Logger,
+	stats prometheus.Registerer,
+	clk clock.Clock,
+) (*ocspImpl, error) {
+	issuersByID := make(map[issuance.IssuerID]*issuance.Issuer, len(issuers))
+	for _, issuer := range issuers {
+		issuersByID[issuer.ID()] = issuer
+	}
+
+	var ocspLogQueue *ocspLogQueue
+	if ocspLogMaxLength > 0 {
+		ocspLogQueue = newOCSPLogQueue(ocspLogMaxLength, ocspLogPeriod, stats, logger)
+	}
+
+	oi := &ocspImpl{
+		sa:           sa,
+		issuers:      issuersByID,
+		ocspLifetime: ocspLifetime,
+		ocspLogQueue: ocspLogQueue,
+		log:          logger,
+		clk:          clk,
+	}
+	return oi, nil
+}
+
+// LogOCSPLoop collects OCSP generation log events into bundles, and logs
+// them periodically.
+func (oi *ocspImpl) LogOCSPLoop() {
+	if oi.ocspLogQueue != nil {
+		oi.ocspLogQueue.loop()
+	}
+}
+
+// Stop asks this ocspImpl to shut down. It must be called after the
+// corresponding RPC service is shut down and there are no longer any inflight
+// RPCs. It will attempt to drain any logging queues (which may block), and will
+// return only when done.
+func (oi *ocspImpl) Stop() {
+	if oi.ocspLogQueue != nil {
+		oi.ocspLogQueue.stop()
+	}
+}
+
+// GenerateOCSP produces a new OCSP response and returns it
+func (oi *ocspImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
+	// req.Status, req.Reason, and req.RevokedAt are often 0, for non-revoked certs.
+	if core.IsAnyNilOrZero(req, req.Serial, req.IssuerID) {
+		return nil, berrors.InternalServerError("Incomplete generate OCSP request")
+	}
+
+	serialInt, err := core.StringToSerial(req.Serial)
+	if err != nil {
+		return nil, err
+	}
+	serial := serialInt
+
+	// TODO(#5152): Replace IssuerID with IssuerNameID.
+	var ok bool
+	issuer, ok := oi.issuers[issuance.IssuerID(req.IssuerID)]
+	if !ok {
+		return nil, fmt.Errorf("This CA doesn't have an issuer cert with ID %d", req.IssuerID)
+	}
+
+	now := oi.clk.Now().Truncate(time.Hour)
+	tbsResponse := ocsp.Response{
+		Status:       ocspStatusToCode[req.Status],
+		SerialNumber: serial,
+		ThisUpdate:   now,
+		NextUpdate:   now.Add(oi.ocspLifetime),
+	}
+	if tbsResponse.Status == ocsp.Revoked {
+		tbsResponse.RevokedAt = time.Unix(0, req.RevokedAt)
+		tbsResponse.RevocationReason = int(req.Reason)
+	}
+
+	if oi.ocspLogQueue != nil {
+		oi.ocspLogQueue.enqueue(serial.Bytes(), now, ocsp.ResponseStatus(tbsResponse.Status))
+	}
+
+	ocspResponse, err := ocsp.CreateResponse(issuer.Cert.Certificate, issuer.Cert.Certificate, tbsResponse, issuer.Signer)
+	oi.noteSignError(err)
+	if err == nil {
+		oi.signatureCount.With(prometheus.Labels{"purpose": "ocsp", "issuer": issuer.Name()}).Inc()
+	}
+	return &capb.OCSPResponse{Response: ocspResponse}, err
+}
 
 // ocspLogQueue accumulates OCSP logging events and writes several of them
 // in a single log line. This reduces the number of log lines and bytes,

--- a/ca/proto/ca.pb.go
+++ b/ca/proto/ca.pb.go
@@ -220,7 +220,8 @@ type GenerateOCSPRequest struct {
 	Reason    int32  `protobuf:"varint,3,opt,name=reason,proto3" json:"reason,omitempty"`
 	RevokedAt int64  `protobuf:"varint,4,opt,name=revokedAt,proto3" json:"revokedAt,omitempty"`
 	Serial    string `protobuf:"bytes,5,opt,name=serial,proto3" json:"serial,omitempty"`
-	IssuerID  int64  `protobuf:"varint,6,opt,name=issuerID,proto3" json:"issuerID,omitempty"`
+	// TODO(#5152): Replace issuerID with issuerNameID.
+	IssuerID int64 `protobuf:"varint,6,opt,name=issuerID,proto3" json:"issuerID,omitempty"`
 }
 
 func (x *GenerateOCSPRequest) Reset() {

--- a/ca/proto/ca.proto
+++ b/ca/proto/ca.proto
@@ -44,6 +44,7 @@ message GenerateOCSPRequest {
   int32 reason = 3;
   int64 revokedAt = 4;
   string serial = 5;
+	// TODO(#5152): Replace issuerID with issuerNameID.
   int64 issuerID = 6;
 }
 

--- a/ca/proto/ca.proto
+++ b/ca/proto/ca.proto
@@ -44,7 +44,7 @@ message GenerateOCSPRequest {
   int32 reason = 3;
   int64 revokedAt = 4;
   string serial = 5;
-	// TODO(#5152): Replace issuerID with issuerNameID.
+  // TODO(#5152): Replace issuerID with issuerNameID.
   int64 issuerID = 6;
 }
 

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -217,6 +217,9 @@ func main() {
 		defer func() { _ = orphanQueue.Close() }()
 	}
 
+	serverMetrics := bgrpc.NewServerMetrics(scope)
+	var wg sync.WaitGroup
+
 	ocspi, err := ca.NewOCSPImpl(
 		sa,
 		boulderIssuers,
@@ -266,9 +269,6 @@ func main() {
 	if orphanQueue != nil {
 		go cai.OrphanIntegrationLoop()
 	}
-
-	serverMetrics := bgrpc.NewServerMetrics(scope)
-	var wg sync.WaitGroup
 
 	caSrv, caListener, err := bgrpc.NewServer(c.CA.GRPCCA, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup CA gRPC server")

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -152,6 +152,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 }
 
 func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.CertificateStatus) (*core.CertificateStatus, error) {
+	// TODO(#5152): Replace IssuerID with IssuerNameID.
 	if status.IssuerID == nil || *status.IssuerID == 0 {
 		return nil, errors.New("cert status has nil or 0 IssuerID")
 	}

--- a/core/objects.go
+++ b/core/objects.go
@@ -490,6 +490,7 @@ type CertificateStatus struct {
 	NotAfter  time.Time `db:"notAfter"`
 	IsExpired bool      `db:"isExpired"`
 
+	// TODO(#5152): Replace IssuerID with IssuerNameID.
 	IssuerID *int64
 }
 


### PR DESCRIPTION
Create a new `ocspImpl` struct which satisfies the interface required
by the `OCSPGenerator` gRPC service. Move the `GenerateOCSP`
method from the `certificateAuthorityImpl` to this new type. To support
existing gRPC clients, keep a reference to the new OCSP service in
the CA impl, and maintain a pass-through `GenerateOCSP` method.
Simplify some of the CA setup code, and make the CA implementation
non-exported because it doesn't need to be.

In order to maintain our existing signature and sign error metrics,
they now need to be initialized outside the CA and OCSP constructors.
This complicates the tests slightly, but seems like a worthwhile
tradeoff.

Fixes #5226
Fixes #5086