### PR TITLE
Web: Preserve context from request

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -57,8 +57,7 @@ func (e *RequestEvent) AddError(msg string, args ...interface{}) {
 type WFEHandlerFunc func(context.Context, *RequestEvent, http.ResponseWriter, *http.Request)
 
 func (f WFEHandlerFunc) ServeHTTP(e *RequestEvent, w http.ResponseWriter, r *http.Request) {
-	ctx := context.TODO()
-	f(ctx, e, w, r)
+	f(r.Context(), e, w, r)
 }
 
 type wfeHandler interface {


### PR DESCRIPTION
The `http.Request` object can already have a context associated
with it. If it does, preserve that context rather than creating a new
one. If it doesn't, create a new `context.Background` instead.