### PR TITLE
Use dirty reads for cert-checker

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -384,6 +384,11 @@ func main() {
 
 	sa.InitDBMetrics(saDbMap, prometheus.DefaultRegisterer, dbSettings)
 
+	_, err = saDbMap.Exec(
+		"SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;",
+	)
+	cmd.FailOnError(err, "Failed to set transaction isolation level at the DB")
+
 	checkerLatency := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "cert_checker_latency",
 		Help: "Histogram of latencies a cert-checker worker takes to complete a batch",


### PR DESCRIPTION
This updates #5400 and #5393 by explicitly opting in to the least-consistent transaction coherency for the duration of all of the cert-checker's queries.

The primary risk here is that the windowed table scan across the certificates table can, on replicas, read a series of rows that aren't from consistent timesteps. However, the certificates table is append-only, so in practice this is not a concern, and there is no risk to enabling the dirtiest of reads, done dirt cheap.

This doesn't impact the length of the window function, so existing overlap mechanisms to ensure coverage will remain as good as they are today.