### PR TITLE
Use the MIN aggregation function for cert-checker's start-of-window

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -128,7 +128,7 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 	}
 
 	initialID, err := c.dbMap.SelectInt(
-		"SELECT id FROM certificates WHERE issued >= :issued AND expires >= :now ORDER BY id ASC LIMIT 1",
+		"SELECT MIN(id) FROM certificates WHERE issued >= :issued AND expires >= :now",
 		args,
 	)
 	if err != nil {


### PR DESCRIPTION
Relational databases are most optimized for set aggregation functions, and anywhere that aggregations can be used for SELECT queries tends to bring performance improvements.

This change switches from using `ORDER BY` and `LIMIT` to obtain a minimum `id` from certificates (which I raised in #5393) to using the `MIN()` aggregation function. Experimentally this is an order-of-magnitude improvement in query time.

Theoretically the query optimizer should have constructed the same underlying query from each, but it didn't.

Partially reverts #5400.