### PR TITLE
contact-auditor: Add tool to audit registration contacts

### DIFF
--- a/cmd/contact-auditor/README.md
+++ b/cmd/contact-auditor/README.md
@@ -1,0 +1,38 @@
+# Contact-Auditor
+Audits subscriber registrations for e-mail addresses that
+`notify-mailer` is currently configured to skip.
+
+# Usage:
+
+```shell
+  -config string
+      File containing a JSON config.
+  -grace duration
+      Include contacts of subscribers with certificates that expired <grace>
+       period from now (default 48h0m0s)
+```
+
+## Output:
+When an invalid e-mail address is encountered an error log line will be
+output in the following format:
+
+```
+validation failed for address: <e-mail> for ID: <ID> for reason: "<reason>"
+```
+
+# Configuration file:
+The path to a database config file like the one below must be provided
+following the `-config` flag.
+
+```json
+{
+    "contactAuditor": {
+      "passwordFile": "path/to/secretFile",
+      "db": {
+        "dbConnectFile": "path/to/secretFile",
+        "maxOpenConns": 10
+      }
+    }
+  }
+  
+```

--- a/cmd/contact-auditor/README.md
+++ b/cmd/contact-auditor/README.md
@@ -72,6 +72,7 @@ following the `-config` flag.
 {
     "contactAuditor": {
       "db": {
+        "dbConnectFile": <string>,
         "maxOpenConns": <int>,
         "maxIdleConns": <int>,
 	      "connMaxLifetime": <int>,

--- a/cmd/contact-auditor/README.md
+++ b/cmd/contact-auditor/README.md
@@ -19,9 +19,7 @@ Audits subscriber registrations for e-mail addresses that
 ```
 I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
 I004823 contact-auditor qJ_zsQ4 Beginning database query
-I004823 contact-auditor 1JX1rQ8 Gathering query results
 I004823 contact-auditor je7V9QM Query completed successfully
-I004823 contact-auditor tK7J8gg Processing 1 results
 I004823 contact-auditor 7LzGvQI Audit finished successfully
 ```
 
@@ -30,12 +28,10 @@ I004823 contact-auditor 7LzGvQI Audit finished successfully
 ```
 I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
 I004823 contact-auditor qJ_zsQ4 Beginning database query
-I004823 contact-auditor 1JX1rQ8 Gathering query results
 I004823 contact-auditor je7V9QM Query completed successfully
-I004823 contact-auditor vZWg6gc Processing 1 results
 I004823 contact-auditor 1JX1rQ8 Validation failed for ID: 100 due to: [ "<contact entry>": "<reason>" ] [ "<contact entry>": "<reason>" ] ...
 ...
-I004823 contact-auditor 2fv7-QY Audit complete
+I004823 contact-auditor 2fv7-QY Audit finished successfully
 ```
 
 **Contact is not valid JSON:**
@@ -43,12 +39,10 @@ I004823 contact-auditor 2fv7-QY Audit complete
 ```
 I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
 I004823 contact-auditor qJ_zsQ4 Beginning database query
-I004823 contact-auditor 1JX1rQ8 Gathering query results
 I004823 contact-auditor je7V9QM Query completed successfully
-I004823 contact-auditor vZWg6gc Processing 1 results
 I004823 contact-auditor qJ_zsQ4 Unmarshal failed for ID: 100 due to: <error msg>
 ...
-I004823 contact-auditor 2fv7-QY Audit complete
+I004823 contact-auditor 2fv7-QY Audit finished successfully
 ```
 
 **Audit incomplete, query ended prematurely:**
@@ -56,9 +50,7 @@ I004823 contact-auditor 2fv7-QY Audit complete
 ```
 I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
 I004823 contact-auditor qJ_zsQ4 Beginning database query
-I004823 contact-auditor 1JX1rQ8 Gathering query results
 I004823 contact-auditor ydTVgA4 [AUDIT] Query was interrupted due to: <error msg>
-I004823 contact-auditor tK7J8gg Processing 1 results
 ...
 E004823 contact-auditor 8LmTgww [AUDIT] Audit was interrupted, results may be incomplete, see log for details
 Audit was interrupted, results may be incomplete, see log for details

--- a/cmd/contact-auditor/README.md
+++ b/cmd/contact-auditor/README.md
@@ -1,4 +1,5 @@
 # Contact-Auditor
+
 Audits subscriber registrations for e-mail addresses that
 `notify-mailer` is currently configured to skip.
 
@@ -7,53 +8,59 @@ Audits subscriber registrations for e-mail addresses that
 ```shell
   -config string
       File containing a JSON config.
-  -grace duration
-      Include contacts of subscribers with certificates that expired <grace>
-       period from now (default 48h0m0s)
+  -to-file
+      Write the audit results to a file.
+  -to-stdout
+      Print the audit results to stdout.
+```
+
+## Results format:
+
+```
+<id>    <createdAt>    <problem type>    "<contact contents or entry>"    "<error msg>"
 ```
 
 ## Example output:
 
-**Successful run with no violations encountered:**
+### Successful run with no violations encountered and `--to-file`:
 
 ```
-I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor nfWK_gM Running contact-auditor
 I004823 contact-auditor qJ_zsQ4 Beginning database query
 I004823 contact-auditor je7V9QM Query completed successfully
 I004823 contact-auditor 7LzGvQI Audit finished successfully
+I004823 contact-auditor 5Pbk_QM Audit results were written to: audit-2006-01-02T15:04.tsv
 ```
 
-**Contact JSON is valid but contains entries that are malformed or violate policy:**
+### Contact contains entries that violate policy and `--to-stdout`:
 
 ```
-I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor nfWK_gM Running contact-auditor
 I004823 contact-auditor qJ_zsQ4 Beginning database query
 I004823 contact-auditor je7V9QM Query completed successfully
-I004823 contact-auditor 1JX1rQ8 Validation failed for ID: 100 due to: [ "<contact entry>": "<reason>" ] [ "<contact entry>": "<reason>" ] ...
+1    2006-01-02 15:04:05    validation    "<contact entry>"    "<error msg>"
 ...
 I004823 contact-auditor 2fv7-QY Audit finished successfully
 ```
 
-**Contact is not valid JSON:**
+### Contact is not valid JSON and `--to-stdout`:
 
 ```
-I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor nfWK_gM Running contact-auditor
 I004823 contact-auditor qJ_zsQ4 Beginning database query
 I004823 contact-auditor je7V9QM Query completed successfully
-I004823 contact-auditor qJ_zsQ4 Unmarshal failed for ID: 100 due to: <error msg>
+3    2006-01-02 15:04:05    unmarshal    "<contact contents>"    "<error msg>"
 ...
 I004823 contact-auditor 2fv7-QY Audit finished successfully
 ```
 
-**Audit incomplete, query ended prematurely:**
+### Audit incomplete, query ended prematurely:
 
 ```
-I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor nfWK_gM Running contact-auditor
 I004823 contact-auditor qJ_zsQ4 Beginning database query
-I004823 contact-auditor ydTVgA4 [AUDIT] Query was interrupted due to: <error msg>
 ...
-E004823 contact-auditor 8LmTgww [AUDIT] Audit was interrupted, results may be incomplete, see log for details
-Audit was interrupted, results may be incomplete, see log for details
+E004823 contact-auditor 8LmTgww [AUDIT] Audit was interrupted, results may be incomplete: <error msg>
 exit status 1
 ```
 
@@ -64,10 +71,11 @@ following the `-config` flag.
 ```json
 {
     "contactAuditor": {
-      "passwordFile": "path/to/secretFile",
       "db": {
-        "dbConnectFile": "path/to/secretFile",
-        "maxOpenConns": 10
+        "maxOpenConns": <int>,
+        "maxIdleConns": <int>,
+	      "connMaxLifetime": <int>,
+	      "connMaxIdleTime": <int>
       }
     }
   }

--- a/cmd/contact-auditor/README.md
+++ b/cmd/contact-auditor/README.md
@@ -12,12 +12,57 @@ Audits subscriber registrations for e-mail addresses that
        period from now (default 48h0m0s)
 ```
 
-## Output:
-When an invalid e-mail address is encountered an error log line will be
-output in the following format:
+## Example output:
+
+**Successful run with no violations encountered:**
 
 ```
-validation failed for address: <e-mail> for ID: <ID> for reason: "<reason>"
+I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor qJ_zsQ4 Beginning database query
+I004823 contact-auditor 1JX1rQ8 Gathering query results
+I004823 contact-auditor je7V9QM Query completed successfully
+I004823 contact-auditor tK7J8gg Processing 1 results
+I004823 contact-auditor 7LzGvQI Audit finished successfully
+```
+
+**Contact JSON is valid but contains entries that are malformed or violate policy:**
+
+```
+I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor qJ_zsQ4 Beginning database query
+I004823 contact-auditor 1JX1rQ8 Gathering query results
+I004823 contact-auditor je7V9QM Query completed successfully
+I004823 contact-auditor vZWg6gc Processing 1 results
+I004823 contact-auditor 1JX1rQ8 Validation failed for ID: 100 due to: [ "<contact entry>": "<reason>" ] [ "<contact entry>": "<reason>" ] ...
+...
+I004823 contact-auditor 2fv7-QY Audit complete
+```
+
+**Contact is not valid JSON:**
+
+```
+I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor qJ_zsQ4 Beginning database query
+I004823 contact-auditor 1JX1rQ8 Gathering query results
+I004823 contact-auditor je7V9QM Query completed successfully
+I004823 contact-auditor vZWg6gc Processing 1 results
+I004823 contact-auditor qJ_zsQ4 Unmarshal failed for ID: 100 due to: <error msg>
+...
+I004823 contact-auditor 2fv7-QY Audit complete
+```
+
+**Audit incomplete, query ended prematurely:**
+
+```
+I004823 contact-auditor nfWK_gM Running contact-auditor with a grace period of >= 48h0m0s
+I004823 contact-auditor qJ_zsQ4 Beginning database query
+I004823 contact-auditor 1JX1rQ8 Gathering query results
+I004823 contact-auditor ydTVgA4 [AUDIT] Query was interrupted due to: <error msg>
+I004823 contact-auditor tK7J8gg Processing 1 results
+...
+E004823 contact-auditor 8LmTgww [AUDIT] Audit was interrupted, results may be incomplete, see log for details
+Audit was interrupted, results may be incomplete, see log for details
+exit status 1
 ```
 
 # Configuration file:

--- a/cmd/contact-auditor/main.go
+++ b/cmd/contact-auditor/main.go
@@ -57,7 +57,7 @@ func (c contactAuditor) collectContacts() (queryResults, error) {
 		`SELECT DISTINCT r.id, r.contact
 	    FROM registrations AS r
 		    INNER JOIN certificates AS c on c.registrationID = r.id
-	    WHERE r.contact != '[]'
+	    WHERE r.contact NOT IN ('[]', 'null')
 		    AND c.expires >= :expireCutoff`,
 		map[string]interface{}{
 			"expireCutoff": c.clk.Now().Add(-c.grace),

--- a/cmd/contact-auditor/main.go
+++ b/cmd/contact-auditor/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -10,101 +12,147 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/cmd"
-	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/policy"
-	"github.com/letsencrypt/boulder/sa"
 )
 
+var queryInterrupted bool
+
 type contactAuditor struct {
-	dbMap  *db.WrappedMap
+	db     *sql.DB
 	logger blog.Logger
 	clk    clock.Clock
 	grace  time.Duration
 }
 
-// queryResult is receiver for gorp select queries.
-type queryResult struct {
+type result struct {
 	// Receiver for the `id` column.
 	ID int64
 
 	// Receiver for the `contact` column.
-	Contact []byte
-
-	// Receiver for e-mail addresses unmarshalled from the `Contact`
-	// field.
-	addresses []string
+	Contact  []byte
+	contacts []string
 }
 
-// queryResults is a selectable 'holder' for gorp queries.
-type queryResults []*queryResult
-
-// collectContacts queries the database for all IDs and contacts with
-// certificates whose expiration falls within the expiry cuttoff.
-func (c contactAuditor) collectContacts() (queryResults, error) {
-	var holder queryResults
-	// Setting isolation level to `READ UNCOMMITTED` improves
-	// performance at the cost of consistency. For our purposes this is
-	// fine.
-	_, err := c.dbMap.Exec("SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;")
-	if err != nil {
-		return nil, fmt.Errorf("error while setting transaction level: %s", err)
-	}
-
-	// Run query.
-	_, err = c.dbMap.Select(
-		&holder,
-		`SELECT DISTINCT r.id, r.contact
-	    FROM registrations AS r
-		    INNER JOIN certificates AS c on c.registrationID = r.id
-	    WHERE r.contact NOT IN ('[]', 'null')
-		    AND c.expires >= :expireCutoff`,
-		map[string]interface{}{
-			"expireCutoff": c.clk.Now().Add(-c.grace),
-		})
-	if err != nil {
-		return nil, fmt.Errorf("error while querying database: %s", err)
-	}
-	return holder, nil
-}
-
-// unmarshalAddresses unmarshalls the `Contact` field of the inner
-// `queryResult` and extracts the email addresses.
-func (r *queryResult) unmarshalAddresses() error {
-	var contactFields []string
-	err := json.Unmarshal(r.Contact, &contactFields)
+func (r *result) unmarshalContact() error {
+	var contact []string
+	err := json.Unmarshal(r.Contact, &contact)
 	if err != nil {
 		return err
 	}
-	for _, entry := range contactFields {
-		if strings.HasPrefix(entry, "mailto:") {
-			r.addresses = append(r.addresses, strings.TrimPrefix(entry, "mailto:"))
+	r.contacts = append(r.contacts, contact...)
+	return nil
+}
+
+func (r *result) validateContact() error {
+	// Setup a buffer to store any validation problems we encounter.
+	var probsBuff strings.Builder
+
+	// Helper to write validation problems to our buffer.
+	writeProb := func(contact string, prob string) {
+		// Add validation problem to buffer.
+		probsBuff.WriteString(fmt.Sprintf("[ %q: %q ] ", contact, prob))
+	}
+
+	for _, contact := range r.contacts {
+		if strings.HasPrefix(contact, "mailto:") {
+			err := policy.ValidEmail(strings.TrimPrefix(contact, "mailto:"))
+			if err != nil {
+				writeProb(contact, err.Error())
+			}
+		} else {
+			writeProb(contact, "missing 'mailto:' prefix")
 		}
+	}
+
+	if probsBuff.String() != "" {
+		return errors.New(probsBuff.String())
 	}
 	return nil
 }
 
-// run extracts email addresses from the database and attempts to
-// validate each.
-func (c contactAuditor) run() (queryResults, error) {
+type results struct {
+	entries []*result
+	logger  blog.Logger
+}
+
+func (r *results) unmarshalContacts() {
+	for _, result := range r.entries {
+		err := result.unmarshalContact()
+		if err != nil {
+			r.logger.Errf("Unmarshal failed for ID: %d due to: %s", result.ID, err)
+			continue
+		}
+	}
+}
+
+func (r results) validateContacts() {
+	for _, result := range r.entries {
+		err := result.validateContact()
+		if err != nil {
+			r.logger.Errf("Validation failed for ID: %s due to: %s", result.ID, err)
+			continue
+		}
+	}
+}
+
+// collectContacts queries the database for all IDs and contacts with
+// unexpired certificates.
+func (c contactAuditor) collectContacts() (*results, error) {
+	// Setting isolation level to `READ UNCOMMITTED` improves
+	// performance at the cost of consistency.
+	_, err := c.db.Exec("SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;")
+	if err != nil {
+		return nil, fmt.Errorf("error setting db trancaction isolation level: %s", err)
+	}
+
+	rows, err := c.db.Query(
+		fmt.Sprintf(
+			"%s '%s';",
+			`SELECT DISTINCT r.id, r.contact
+			FROM registrations AS r
+				INNER JOIN certificates AS c on c.registrationID = r.id
+			WHERE r.contact NOT IN ('[]', 'null')
+				AND c.expires >=`,
+			c.clk.Now().Add(-c.grace).Format("2006-01-02T15:04:05Z")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error performing db query: %s", err)
+	}
+
+	c.logger.Infof("Gathering query results")
+	results := results{logger: c.logger}
+	for rows.Next() {
+		var result result
+		err := rows.Scan(&result.ID, &result.Contact)
+		if err != nil {
+			return nil, err
+		}
+		results.entries = append(results.entries, &result)
+	}
+
+	// Ensure the query wasn't interrupted before it could complete.
+	err = rows.Close()
+	if err != nil {
+		// Log an error but continue processing results.
+		c.logger.Errf("Query interrupted due to: %s", err)
+		queryInterrupted = true
+	} else {
+		c.logger.Info("Query completed successfully")
+	}
+	return &results, nil
+}
+
+func (c contactAuditor) run() (*results, error) {
+	c.logger.Infof("Beginning database query")
 	results, err := c.collectContacts()
 	if err != nil {
 		return nil, err
 	}
-	for _, result := range results {
-		err = result.unmarshalAddresses()
-		if err != nil {
-			return nil, err
-		}
-		for _, address := range result.addresses {
-			err := policy.ValidEmail(address)
-			if err != nil {
-				c.logger.Errf(
-					"validation failed for address: %q with ID: %d for reason: %q", address, result.ID, err)
-				continue
-			}
-		}
-	}
+
+	c.logger.Infof("Processing %d results", len(results.entries))
+	results.unmarshalContacts()
+	results.validateContacts()
 	return results, nil
 }
 
@@ -117,7 +165,7 @@ func main() {
 	logger := cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 7})
 
 	configData, err := ioutil.ReadFile(*configFile)
-	cmd.FailOnError(err, fmt.Sprintf("Error while reading file: %q", *configFile))
+	cmd.FailOnError(err, fmt.Sprintf("Error reading file: %q", *configFile))
 
 	// Load JSON configuration.
 	type config struct {
@@ -126,35 +174,40 @@ func main() {
 			cmd.PasswordConfig
 		}
 	}
+
 	var cfg config
 	err = json.Unmarshal(configData, &cfg)
 	cmd.FailOnError(err, "Couldn't unmarshal config")
 
-	// Parse database connect URL.
+	// Setup database client.
 	dbURL, err := cfg.ContactAuditor.DB.URL()
 	cmd.FailOnError(err, "Couldn't load DB URL")
 
-	// Setup database client.
-	dbSettings := sa.DbSettings{
-		MaxOpenConns:    cfg.ContactAuditor.DB.MaxOpenConns,
-		MaxIdleConns:    cfg.ContactAuditor.DB.MaxIdleConns,
-		ConnMaxLifetime: cfg.ContactAuditor.DB.ConnMaxLifetime.Duration,
-		ConnMaxIdleTime: cfg.ContactAuditor.DB.ConnMaxIdleTime.Duration,
-	}
-
-	dbMap, err := sa.NewDbMap(dbURL, dbSettings)
+	db, err := sql.Open("mysql", fmt.Sprintf("%s?readTimeout=14s&writeTimeout=14s&timeout=1s", dbURL))
 	cmd.FailOnError(err, "Couldn't setup database client")
+
+	// Apply database settings.
+	db.SetMaxOpenConns(cfg.ContactAuditor.DB.MaxOpenConns)
+	db.SetMaxIdleConns(cfg.ContactAuditor.DB.MaxIdleConns)
+	db.SetConnMaxLifetime(cfg.ContactAuditor.DB.ConnMaxLifetime.Duration)
+	db.SetConnMaxIdleTime(cfg.ContactAuditor.DB.ConnMaxIdleTime.Duration)
 
 	// Setup and run contact-auditor.
 	auditor := contactAuditor{
-		dbMap:  dbMap,
+		db:     db,
 		logger: logger,
 		clk:    clock.New(),
 		grace:  *grace,
 	}
-	logger.Infof("running contact-auditor with a grace period of >= %s", grace.String())
+
+	logger.Infof("Running contact-auditor with a grace period of >= %s", grace.String())
+
 	_, err = auditor.run()
-	if err != nil {
-		logger.Errf("problem encountered while running audit: %s", err)
+	cmd.FailOnError(err, "Audit was interrupted")
+
+	if queryInterrupted {
+		cmd.Fail("Audit was interrupted, results may be incomplete, see log for details")
+	} else {
+		logger.Info("Audit finished successfully")
 	}
 }

--- a/cmd/contact-auditor/main.go
+++ b/cmd/contact-auditor/main.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/db"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/policy"
+	"github.com/letsencrypt/boulder/sa"
+)
+
+type contactAuditor struct {
+	dbMap  *db.WrappedMap
+	logger blog.Logger
+	clk    clock.Clock
+	grace  time.Duration
+}
+
+// queryResult is receiver for gorp select queries.
+type queryResult struct {
+	// Receiver for the `id` column.
+	ID int64
+
+	// Receiver for the `contact` column.
+	Contact []byte
+
+	// Receiver for e-mail addresses unmarshalled from the `Contact`
+	// field.
+	addresses []string
+}
+
+// queryResults is a selectable 'holder' for gorp queries.
+type queryResults []*queryResult
+
+// collectContacts queries the database for all IDs and contacts with
+// certificates whose expiration falls within the expiry cuttoff.
+func (c contactAuditor) collectContacts() (queryResults, error) {
+	var holder queryResults
+	// Setting isolation level to `READ UNCOMMITTED` improves
+	// performance at the cost of consistency. For our purposes this is
+	// fine.
+	_, err := c.dbMap.Exec("SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;")
+	if err != nil {
+		return nil, fmt.Errorf("error while setting transaction level: %s", err)
+	}
+
+	// Run query.
+	_, err = c.dbMap.Select(
+		&holder,
+		`SELECT DISTINCT r.id, r.contact
+	    FROM registrations AS r
+		    INNER JOIN certificates AS c on c.registrationID = r.id
+	    WHERE r.contact != '[]'
+		    AND c.expires >= :expireCutoff`,
+		map[string]interface{}{
+			"expireCutoff": c.clk.Now().Add(-c.grace),
+		})
+	if err != nil {
+		return nil, fmt.Errorf("error while querying database: %s", err)
+	}
+	return holder, nil
+}
+
+// unmarshalAddresses unmarshalls the `Contact` field of the inner
+// `queryResult` and extracts the email addresses.
+func (r *queryResult) unmarshalAddresses() error {
+	var contactFields []string
+	err := json.Unmarshal(r.Contact, &contactFields)
+	if err != nil {
+		return err
+	}
+	for _, entry := range contactFields {
+		if strings.HasPrefix(entry, "mailto:") {
+			r.addresses = append(r.addresses, strings.TrimPrefix(entry, "mailto:"))
+		}
+	}
+	return nil
+}
+
+// run extracts email addresses from the database and attempts to
+// validate each.
+func (c contactAuditor) run() (queryResults, error) {
+	results, err := c.collectContacts()
+	if err != nil {
+		return nil, err
+	}
+	for _, result := range results {
+		err = result.unmarshalAddresses()
+		if err != nil {
+			return nil, err
+		}
+		for _, address := range result.addresses {
+			err := policy.ValidEmail(address)
+			if err != nil {
+				c.logger.Errf(
+					"validation failed for address: %q with ID: %d for reason: %q", address, result.ID, err)
+				continue
+			}
+		}
+	}
+	return results, nil
+}
+
+func main() {
+	configFile := flag.String("config", "", "File containing a JSON config.")
+	grace := flag.Duration(
+		"grace", 2*24*time.Hour, "Include contacts of subscribers with certificates that expired <grace>\n period from now")
+	flag.Parse()
+
+	logger := cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 7})
+
+	configData, err := ioutil.ReadFile(*configFile)
+	cmd.FailOnError(err, fmt.Sprintf("Error while reading file: %q", *configFile))
+
+	// Load JSON configuration.
+	type config struct {
+		ContactAuditor struct {
+			DB cmd.DBConfig
+			cmd.PasswordConfig
+		}
+	}
+	var cfg config
+	err = json.Unmarshal(configData, &cfg)
+	cmd.FailOnError(err, "Couldn't unmarshal config")
+
+	// Parse database connect URL.
+	dbURL, err := cfg.ContactAuditor.DB.URL()
+	cmd.FailOnError(err, "Couldn't load DB URL")
+
+	// Setup database client.
+	dbSettings := sa.DbSettings{
+		MaxOpenConns:    cfg.ContactAuditor.DB.MaxOpenConns,
+		MaxIdleConns:    cfg.ContactAuditor.DB.MaxIdleConns,
+		ConnMaxLifetime: cfg.ContactAuditor.DB.ConnMaxLifetime.Duration,
+		ConnMaxIdleTime: cfg.ContactAuditor.DB.ConnMaxIdleTime.Duration,
+	}
+
+	dbMap, err := sa.NewDbMap(dbURL, dbSettings)
+	cmd.FailOnError(err, "Couldn't setup database client")
+
+	// Setup and run contact-auditor.
+	auditor := contactAuditor{
+		dbMap:  dbMap,
+		logger: logger,
+		clk:    clock.New(),
+		grace:  *grace,
+	}
+	logger.Infof("running contact-auditor with a grace period of >= %s", grace.String())
+	_, err = auditor.run()
+	if err != nil {
+		logger.Errf("problem encountered while running audit: %s", err)
+	}
+}

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -373,7 +373,7 @@ func setup(t *testing.T) testCtx {
 		os.Remove(file.Name())
 	}
 
-	db, err := makeDBConnection()
+	db, err := makeDBConnection(vars.DBConnSAMailer)
 	if err != nil {
 		t.Fatalf("Couldn't connect to the database: %s", err)
 	}

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -59,16 +59,15 @@ func TestMailAuditor(t *testing.T) {
 	test.AssertEquals(t, len(results), 3)
 	for _, entry := range results {
 		switch entry.ID {
-		case 1:
-			test.AssertEquals(t, entry.ID, regA.ID)
+		case regA.ID:
 			test.AssertDeepEquals(t, entry.addresses, []string{"test@example.com"})
-		case 3:
-			test.AssertEquals(t, entry.ID, regC.ID)
+		case regC.ID:
 			test.AssertDeepEquals(t, entry.addresses, []string{"test-example@example.com"})
-		case 4:
-			test.AssertEquals(t, entry.ID, regD.ID)
+		case regD.ID:
 			// Should be empty.
 			test.AssertEquals(t, len(entry.addresses), 0)
+		default:
+			t.Errorf("ID: %d was not expected", entry.ID)
 		}
 	}
 
@@ -82,19 +81,17 @@ func TestMailAuditor(t *testing.T) {
 	test.AssertEquals(t, len(results), 4)
 	for _, entry := range results {
 		switch entry.ID {
-		case 1:
-			test.AssertEquals(t, entry.ID, regA.ID)
+		case regA.ID:
 			test.AssertDeepEquals(t, entry.addresses, []string{"test@example.com"})
-		case 2:
-			test.AssertEquals(t, entry.ID, regB.ID)
+		case regB.ID:
 			test.AssertDeepEquals(t, entry.addresses, []string{"example@example.com"})
-		case 3:
-			test.AssertEquals(t, entry.ID, regC.ID)
+		case regC.ID:
 			test.AssertDeepEquals(t, entry.addresses, []string{"test-example@example.com"})
-		case 4:
-			test.AssertEquals(t, entry.ID, regD.ID)
+		case regD.ID:
 			// Should be empty.
 			test.AssertEquals(t, len(entry.addresses), 0)
+		default:
+			t.Errorf("ID: %d was not expected", entry.ID)
 		}
 	}
 }

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/boulder/core"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/sa"
+	"github.com/letsencrypt/boulder/test"
+	"github.com/letsencrypt/boulder/test/vars"
+	"gopkg.in/square/go-jose.v2"
+)
+
+var (
+	regA core.Registration
+	regB core.Registration
+	regC core.Registration
+	regD core.Registration
+)
+
+const (
+	emailARaw = "test@example.com"
+	emailBRaw = "example@example.com"
+	emailCRaw = "test-example@example.com"
+	telNum    = "666-666-7777"
+)
+
+func TestMailAuditor(t *testing.T) {
+	testCtx := setup(t)
+	defer testCtx.cleanUp()
+
+	// Add some test registrations.
+	testCtx.addRegistrations(t)
+
+	// Should be 0 since we haven't added registrations.
+	results, err := testCtx.c.run()
+	test.AssertNotError(t, err, "received error")
+	test.AssertEquals(t, len(results), 0)
+
+	// Now add some certificates.
+	testCtx.addCertificates(t)
+
+	// With B expired, we should get A, C, and D but only A and C have
+	// email addresses in their contact.
+	results, err = testCtx.c.run()
+	test.AssertNotError(t, err, "received error")
+	test.AssertEquals(t, len(results), 3)
+	for _, entry := range results {
+		switch entry.ID {
+		case 1:
+			test.AssertEquals(t, entry.ID, regA.ID)
+			test.AssertDeepEquals(t, entry.addresses, []string{"test@example.com"})
+		case 3:
+			test.AssertEquals(t, entry.ID, regC.ID)
+			test.AssertDeepEquals(t, entry.addresses, []string{"test-example@example.com"})
+		case 4:
+			test.AssertEquals(t, entry.ID, regD.ID)
+			// Should be empty.
+			test.AssertEquals(t, len(entry.addresses), 0)
+		}
+	}
+
+	// Allow a 1 year grace period
+	testCtx.c.grace = 360 * 24 * time.Hour
+	results, err = testCtx.c.run()
+	test.AssertNotError(t, err, "received error")
+
+	// With none expired, we should get A, B, C, and D. Only A, B, and C
+	// should have email addresses in their contact.
+	test.AssertEquals(t, len(results), 4)
+
+	for _, entry := range results {
+		switch entry.ID {
+		case 1:
+			test.AssertEquals(t, entry.ID, regA.ID)
+			test.AssertDeepEquals(t, entry.addresses, []string{"test@example.com"})
+		case 2:
+			test.AssertEquals(t, entry.ID, regB.ID)
+			test.AssertDeepEquals(t, entry.addresses, []string{"example@example.com"})
+		case 3:
+			test.AssertEquals(t, entry.ID, regC.ID)
+			test.AssertDeepEquals(t, entry.addresses, []string{"test-example@example.com"})
+		case 4:
+			test.AssertEquals(t, entry.ID, regD.ID)
+			// Should be empty.
+			test.AssertEquals(t, len(entry.addresses), 0)
+		}
+	}
+}
+
+type testCtx struct {
+	c       contactAuditor
+	ssa     core.StorageAdder
+	cleanUp func()
+}
+
+func (c testCtx) addRegistrations(t *testing.T) {
+	emailA := "mailto:" + emailARaw
+	emailB := "mailto:" + emailBRaw
+	emailC := "mailto:" + emailCRaw
+	tel := "tel:" + telNum
+
+	// Every registration needs a unique JOSE key
+	jsonKeyA := []byte(`{
+  "kty":"RSA",
+  "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+  "e":"AQAB"
+}`)
+	jsonKeyB := []byte(`{
+  "kty":"RSA",
+  "n":"z8bp-jPtHt4lKBqepeKF28g_QAEOuEsCIou6sZ9ndsQsEjxEOQxQ0xNOQezsKa63eogw8YS3vzjUcPP5BJuVzfPfGd5NVUdT-vSSwxk3wvk_jtNqhrpcoG0elRPQfMVsQWmxCAXCVRz3xbcFI8GTe-syynG3l-g1IzYIIZVNI6jdljCZML1HOMTTW4f7uJJ8mM-08oQCeHbr5ejK7O2yMSSYxW03zY-Tj1iVEebROeMv6IEEJNFSS4yM-hLpNAqVuQxFGetwtwjDMC1Drs1dTWrPuUAAjKGrP151z1_dE74M5evpAhZUmpKv1hY-x85DC6N0hFPgowsanmTNNiV75w",
+  "e":"AAEAAQ"
+}`)
+	jsonKeyC := []byte(`{
+  "kty":"RSA",
+  "n":"rFH5kUBZrlPj73epjJjyCxzVzZuV--JjKgapoqm9pOuOt20BUTdHqVfC2oDclqM7HFhkkX9OSJMTHgZ7WaVqZv9u1X2yjdx9oVmMLuspX7EytW_ZKDZSzL-sCOFCuQAuYKkLbsdcA3eHBK_lwc4zwdeHFMKIulNvLqckkqYB9s8GpgNXBDIQ8GjR5HuJke_WUNjYHSd8jY1LU9swKWsLQe2YoQUz_ekQvBvBCoaFEtrtRaSJKNLIVDObXFr2TLIiFiM0Em90kK01-eQ7ZiruZTKomll64bRFPoNo4_uwubddg3xTqur2vdF3NyhTrYdvAgTem4uC0PFjEQ1bK_djBQ",
+  "e":"AQAB"
+}`)
+	jsonKeyD := []byte(`{
+  "kty":"RSA",
+  "n":"rFH5kUBZrlPj73epjJjyCxzVzZuV--JjKgapoqm9pOuOt20BUTdHqVfC2oDclqM7HFhkkX9OSJMTHgZ7WaVqZv9u1X2yjdx9oVmMLuspX7EytW_ZKDZSzL-FCOFCuQAuYKkLbsdcA3eHBK_lwc4zwdeHFMKIulNvLqckkqYB9s8GpgNXBDIQ8GjR5HuJke_WUNjYHSd8jY1LU9swKWsLQe2YoQUz_ekQvBvBCoaFEtrtRaSJKNLIVDObXFr2TLIiFiM0Em90kK01-eQ7ZiruZTKomll64bRFPoNo4_uwubddg3xTqur2vdF3NyhTrYdvAgTem4uC0PFjEQ1bK_djBQ",
+  "e":"AQAB"
+}`)
+
+	var keyA jose.JSONWebKey
+	var keyB jose.JSONWebKey
+	var keyC jose.JSONWebKey
+	var keyD jose.JSONWebKey
+	err := json.Unmarshal(jsonKeyA, &keyA)
+	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
+	err = json.Unmarshal(jsonKeyB, &keyB)
+	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
+	err = json.Unmarshal(jsonKeyC, &keyC)
+	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
+	err = json.Unmarshal(jsonKeyD, &keyD)
+	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
+
+	// Regs A through C have `mailto:` contact ACME URL's
+	regA = core.Registration{
+		ID: 1,
+		Contact: &[]string{
+			emailA,
+		},
+		Key:       &keyA,
+		InitialIP: net.ParseIP("127.0.0.1"),
+	}
+	regB = core.Registration{
+		ID: 2,
+		Contact: &[]string{
+			emailB,
+		},
+		Key:       &keyB,
+		InitialIP: net.ParseIP("127.0.0.1"),
+	}
+	regC = core.Registration{
+		ID: 3,
+		Contact: &[]string{
+			emailC,
+		},
+		Key:       &keyC,
+		InitialIP: net.ParseIP("127.0.0.1"),
+	}
+	// Reg D has a `tel:` contact ACME URL
+	regD = core.Registration{
+		ID: 4,
+		Contact: &[]string{
+			tel,
+		},
+		Key:       &keyD,
+		InitialIP: net.ParseIP("127.0.0.1"),
+	}
+
+	// Add the four test registrations
+	ctx := context.Background()
+	regA, err = c.ssa.NewRegistration(ctx, regA)
+	if err != nil {
+		t.Fatalf("Couldn't store regA: %s", err)
+	}
+	regB, err = c.ssa.NewRegistration(ctx, regB)
+	if err != nil {
+		t.Fatalf("Couldn't store regB: %s", err)
+	}
+	regC, err = c.ssa.NewRegistration(ctx, regC)
+	if err != nil {
+		t.Fatalf("Couldn't store regC: %s", err)
+	}
+	regD, err = c.ssa.NewRegistration(ctx, regD)
+	if err != nil {
+		t.Fatalf("Couldn't store regD: %s", err)
+	}
+}
+
+func (ctx testCtx) addCertificates(t *testing.T) {
+	serial1 := big.NewInt(1336)
+	serial1String := core.SerialToString(serial1)
+	serial2 := big.NewInt(1337)
+	serial2String := core.SerialToString(serial2)
+	serial3 := big.NewInt(1338)
+	serial3String := core.SerialToString(serial3)
+	serial4 := big.NewInt(1339)
+	serial4String := core.SerialToString(serial4)
+	n := bigIntFromB64("n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw==")
+	e := intFromB64("AQAB")
+	d := bigIntFromB64("bWUC9B-EFRIo8kpGfh0ZuyGPvMNKvYWNtB_ikiH9k20eT-O1q_I78eiZkpXxXQ0UTEs2LsNRS-8uJbvQ-A1irkwMSMkK1J3XTGgdrhCku9gRldY7sNA_AKZGh-Q661_42rINLRCe8W-nZ34ui_qOfkLnK9QWDDqpaIsA-bMwWWSDFu2MUBYwkHTMEzLYGqOe04noqeq1hExBTHBOBdkMXiuFhUq1BU6l-DqEiWxqg82sXt2h-LMnT3046AOYJoRioz75tSUQfGCshWTBnP5uDjd18kKhyv07lhfSJdrPdM5Plyl21hsFf4L_mHCuoFau7gdsPfHPxxjVOcOpBrQzwQ==")
+	p := bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
+	q := bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
+
+	testKey := rsa.PrivateKey{
+		PublicKey: rsa.PublicKey{N: n, E: e},
+		D:         d,
+		Primes:    []*big.Int{p, q},
+	}
+
+	fc := newFakeClock(t)
+
+	// Add one cert for RegA that expires in 30 days
+	rawCertA := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "happy A",
+		},
+		NotAfter:     fc.Now().Add(30 * 24 * time.Hour),
+		DNSNames:     []string{"example-a.com"},
+		SerialNumber: serial1,
+	}
+	certDerA, _ := x509.CreateCertificate(rand.Reader, &rawCertA, &rawCertA, &testKey.PublicKey, &testKey)
+	certA := &core.Certificate{
+		RegistrationID: regA.ID,
+		Serial:         serial1String,
+		Expires:        rawCertA.NotAfter,
+		DER:            certDerA,
+	}
+	err := ctx.c.dbMap.Insert(certA)
+	test.AssertNotError(t, err, "Couldn't add certA")
+	_, err = ctx.c.dbMap.Exec(
+		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
+		"com.example-a",
+		serial1String,
+	)
+	test.AssertNotError(t, err, "Couldn't add issued name for certA")
+
+	// Add one cert for RegB that already expired 30 days ago
+	rawCertB := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "happy B",
+		},
+		NotAfter:     fc.Now().Add(-30 * 24 * time.Hour),
+		DNSNames:     []string{"example-b.com"},
+		SerialNumber: serial2,
+	}
+	certDerB, _ := x509.CreateCertificate(rand.Reader, &rawCertB, &rawCertB, &testKey.PublicKey, &testKey)
+	certB := &core.Certificate{
+		RegistrationID: regB.ID,
+		Serial:         serial2String,
+		Expires:        rawCertB.NotAfter,
+		DER:            certDerB,
+	}
+	err = ctx.c.dbMap.Insert(certB)
+	test.AssertNotError(t, err, "Couldn't add certB")
+	_, err = ctx.c.dbMap.Exec(
+		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
+		"com.example-b",
+		serial2String,
+	)
+	test.AssertNotError(t, err, "Couldn't add issued name for certB")
+
+	// Add one cert for RegC that expires in 30 days
+	rawCertC := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "happy C",
+		},
+		NotAfter:     fc.Now().Add(30 * 24 * time.Hour),
+		DNSNames:     []string{"example-c.com"},
+		SerialNumber: serial3,
+	}
+	certDerC, _ := x509.CreateCertificate(rand.Reader, &rawCertC, &rawCertC, &testKey.PublicKey, &testKey)
+	certC := &core.Certificate{
+		RegistrationID: regC.ID,
+		Serial:         serial3String,
+		Expires:        rawCertC.NotAfter,
+		DER:            certDerC,
+	}
+	err = ctx.c.dbMap.Insert(certC)
+	test.AssertNotError(t, err, "Couldn't add certC")
+	_, err = ctx.c.dbMap.Exec(
+		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
+		"com.example-c",
+		serial3String,
+	)
+	test.AssertNotError(t, err, "Couldn't add issued name for certC")
+
+	// Add one cert for RegD that expires in 30 days
+	rawCertD := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "happy D",
+		},
+		NotAfter:     fc.Now().Add(30 * 24 * time.Hour),
+		DNSNames:     []string{"example-d.com"},
+		SerialNumber: serial4,
+	}
+	certDerD, _ := x509.CreateCertificate(rand.Reader, &rawCertD, &rawCertD, &testKey.PublicKey, &testKey)
+	certD := &core.Certificate{
+		RegistrationID: regD.ID,
+		Serial:         serial4String,
+		Expires:        rawCertD.NotAfter,
+		DER:            certDerD,
+	}
+	err = ctx.c.dbMap.Insert(certD)
+	test.AssertNotError(t, err, "Couldn't add certD")
+	_, err = ctx.c.dbMap.Exec(
+		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
+		"com.example-d",
+		serial4String,
+	)
+	test.AssertNotError(t, err, "Couldn't add issued name for certD")
+}
+
+func setup(t *testing.T) testCtx {
+	log := blog.UseMock()
+
+	// Using DBConnSAFullPerms to be able to insert registrations and
+	// certificates
+	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	if err != nil {
+		t.Fatalf("Couldn't connect the database: %s", err)
+	}
+	cleanUp := test.ResetSATestDatabase(t)
+
+	fc := newFakeClock(t)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, fc, log, metrics.NoopRegisterer, 1)
+	if err != nil {
+		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
+	}
+
+	return testCtx{
+		c: contactAuditor{
+			dbMap:  dbMap,
+			logger: blog.NewMock(),
+			clk:    fc,
+		},
+		ssa:     ssa,
+		cleanUp: cleanUp,
+	}
+}
+
+func bigIntFromB64(b64 string) *big.Int {
+	bytes, _ := base64.URLEncoding.DecodeString(b64)
+	x := big.NewInt(0)
+	x.SetBytes(bytes)
+	return x
+}
+
+func intFromB64(b64 string) int {
+	return int(bigIntFromB64(b64).Int64())
+}
+
+func newFakeClock(t *testing.T) clock.FakeClock {
+	const fakeTimeFormat = "2006-01-02T15:04:05.999999999Z"
+	ft, err := time.Parse(fakeTimeFormat, fakeTimeFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fc := clock.NewFake()
+	fc.Set(ft.UTC())
+	return fc
+}

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -80,7 +80,6 @@ func TestMailAuditor(t *testing.T) {
 	// With none expired, we should get A, B, C, and D. Only A, B, and C
 	// should have email addresses in their contact.
 	test.AssertEquals(t, len(results), 4)
-
 	for _, entry := range results {
 		switch entry.ID {
 		case 1:

--- a/test/config-next/contact-auditor.json
+++ b/test/config-next/contact-auditor.json
@@ -1,0 +1,9 @@
+{
+  "contactAuditor": {
+    "passwordFile": "test/secrets/smtp_password",
+    "db": {
+      "dbConnectFile": "test/secrets/mailer_dburl",
+      "maxOpenConns": 10
+    }
+  }
+}

--- a/test/config-next/contact-auditor.json
+++ b/test/config-next/contact-auditor.json
@@ -1,6 +1,7 @@
 {
   "contactAuditor": {
     "db": {
+      "dbConnectFile": "test/secrets/mailer_dburl",
       "maxOpenConns": 10
     }
   }

--- a/test/config-next/contact-auditor.json
+++ b/test/config-next/contact-auditor.json
@@ -1,8 +1,6 @@
 {
   "contactAuditor": {
-    "passwordFile": "test/secrets/smtp_password",
     "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
       "maxOpenConns": 10
     }
   }

--- a/test/config/contact-auditor.json
+++ b/test/config/contact-auditor.json
@@ -1,0 +1,9 @@
+{
+  "contactAuditor": {
+    "passwordFile": "test/secrets/smtp_password",
+    "db": {
+      "dbConnectFile": "test/secrets/mailer_dburl",
+      "maxOpenConns": 10
+    }
+  }
+}

--- a/test/config/contact-auditor.json
+++ b/test/config/contact-auditor.json
@@ -1,6 +1,7 @@
 {
   "contactAuditor": {
     "db": {
+      "dbConnectFile": "test/secrets/mailer_dburl",
       "maxOpenConns": 10
     }
   }

--- a/test/config/contact-auditor.json
+++ b/test/config/contact-auditor.json
@@ -1,8 +1,6 @@
 {
   "contactAuditor": {
-    "passwordFile": "test/secrets/smtp_password",
     "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
       "maxOpenConns": 10
     }
   }


### PR DESCRIPTION
Add tool to audit subscriber registrations for e-mail addresses that
`notify-mailer` is currently configured to skip.

- Add `cmd/contact-auditor` with README
- Add test coverage for `cmd/contact-auditor`
- Add config file at `test/config/contact-auditor`

Part of #5372 