### PR TITLE
Remove libtool-ltdl dependency in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ rpm: build
 		--version "$(VERSION)" --iteration "$(COMMIT_ID)" --epoch "$(EPOCH)" \
 		--package "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).x86_64.rpm" \
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
-		--depends "libtool-ltdl" --maintainer "$(MAINTAINER)" \
+		--maintainer "$(MAINTAINER)" \
 		test/config/ sa/_db data/ $(OBJECTS)
 
 deb: build
@@ -62,5 +62,5 @@ deb: build
 		--version "$(VERSION)" --iteration "$(COMMIT_ID)" --epoch "$(EPOCH)" \
 		--package "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).x86_64.deb" \
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
-		--depends "libtool-ltdl" --maintainer "$(MAINTAINER)" \
+		--maintainer "$(MAINTAINER)" \
 		test/config/ sa/_db data/ $(OBJECTS)


### PR DESCRIPTION
The `make deb` target had set a dependency on `libtool-ltdl` which does
not exist in Ubuntu/Debian world, instead the package should have been
`libtool` to provide the correct `.so` files for protobuf compilation. Since 
the `make rpm` and `make deb` package up a compiled boulder, the 
dependency seems to be irrelevant because the protobufs should have
been committed or built prior to the packaging step.

```
phil@laptappy2:~$ apt-file search libltdl.so
libltdl-dev: /usr/lib/x86_64-linux-gnu/libltdl.so
libltdl7: /usr/lib/x86_64-linux-gnu/libltdl.so.7
libltdl7: /usr/lib/x86_64-linux-gnu/libltdl.so.7.3.1

phil@laptappy2:$ grep -ri 'libtool'
vendor/golang.org/x/net/http2/Dockerfile:       autotools-dev libtool pkg-config zlib1g-dev \
vendor/golang.org/x/net/http2/Dockerfile:        libtool pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
test/boulder-tools/build.sh:  libtool \
test/boulder-tools/build.sh:apt-get autoremove -y libssl-dev ruby-dev cmake pkg-config libtool autoconf automake
```
[protobuf installation/build doc](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)