### PR TITLE
Remove PasswordConfig's in-config option

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,24 +16,18 @@ import (
 	"github.com/letsencrypt/boulder/core"
 )
 
-// PasswordConfig either contains a password or the path to a file
-// containing a password
+// PasswordConfig contains a path to a file containing a password.
 type PasswordConfig struct {
-	Password     string
 	PasswordFile string
 }
 
-// Pass returns a password, either directly from the configuration
-// struct or by reading from a specified file
+// Pass returns a password, extracted from the PasswordConfig's PasswordFile
 func (pc *PasswordConfig) Pass() (string, error) {
-	if pc.PasswordFile != "" {
-		contents, err := ioutil.ReadFile(pc.PasswordFile)
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimRight(string(contents), "\n"), nil
+	contents, err := ioutil.ReadFile(pc.PasswordFile)
+	if err != nil {
+		return "", err
 	}
-	return pc.Password, nil
+	return strings.TrimRight(string(contents), "\n"), nil
 }
 
 // ServiceConfig contains config items that are common to all our services, to

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,6 +23,10 @@ type PasswordConfig struct {
 
 // Pass returns a password, extracted from the PasswordConfig's PasswordFile
 func (pc *PasswordConfig) Pass() (string, error) {
+	// Make PasswordConfigs optional, for backwards compatibility.
+	if pc.PasswordFile == "" {
+		return "", nil
+	}
 	contents, err := ioutil.ReadFile(pc.PasswordFile)
 	if err != nil {
 		return "", err

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -38,8 +38,6 @@ func TestPasswordConfig(t *testing.T) {
 		expected string
 	}{
 		{pc: PasswordConfig{}, expected: ""},
-		{pc: PasswordConfig{Password: "config"}, expected: "config"},
-		{pc: PasswordConfig{Password: "config", PasswordFile: "testdata/test_secret"}, expected: "secret"},
 		{pc: PasswordConfig{PasswordFile: "testdata/test_secret"}, expected: "secret"},
 	}
 


### PR DESCRIPTION
We never really want to be using in-config passwords
anyway, so remove this option.

Fixes #5426