### PR TITLE
Make RevokeCertificateWithReg wrappers passthroughs

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -71,7 +71,7 @@ type RegistrationAuthority interface {
 	PerformValidation(ctx context.Context, req *rapb.PerformValidationRequest) (*corepb.Authorization, error)
 
 	// [WebFrontEnd]
-	RevokeCertificateWithReg(ctx context.Context, cert x509.Certificate, code revocation.Reason, regID int64) error
+	RevokeCertificateWithReg(ctx context.Context, req *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error)
 
 	// [WebFrontEnd]
 	DeactivateRegistration(ctx context.Context, reg Registration) error

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -93,17 +93,8 @@ func (rac RegistrationAuthorityClientWrapper) PerformValidation(
 	return authz, nil
 }
 
-func (rac RegistrationAuthorityClientWrapper) RevokeCertificateWithReg(ctx context.Context, cert x509.Certificate, code revocation.Reason, regID int64) error {
-	_, err := rac.inner.RevokeCertificateWithReg(ctx, &rapb.RevokeCertificateWithRegRequest{
-		Cert:  cert.Raw,
-		Code:  int64(code),
-		RegID: regID,
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+func (rac RegistrationAuthorityClientWrapper) RevokeCertificateWithReg(ctx context.Context, req *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
+	return rac.inner.RevokeCertificateWithReg(ctx, req)
 }
 
 func (rac RegistrationAuthorityClientWrapper) DeactivateRegistration(ctx context.Context, reg core.Registration) error {

--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -236,18 +236,7 @@ func (ras *RegistrationAuthorityServerWrapper) PerformValidation(
 }
 
 func (ras *RegistrationAuthorityServerWrapper) RevokeCertificateWithReg(ctx context.Context, request *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
-	if request == nil || request.Cert == nil {
-		return nil, errIncompleteRequest
-	}
-	cert, err := x509.ParseCertificate(request.Cert)
-	if err != nil {
-		return nil, err
-	}
-	err = ras.inner.RevokeCertificateWithReg(ctx, *cert, revocation.Reason(request.Code), request.RegID)
-	if err != nil {
-		return nil, err
-	}
-	return &corepb.Empty{}, nil
+	return ras.inner.RevokeCertificateWithReg(ctx, request)
 }
 
 func (ras *RegistrationAuthorityServerWrapper) DeactivateRegistration(ctx context.Context, request *corepb.Registration) (*corepb.Empty, error) {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1810,9 +1810,20 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, cert
 }
 
 // RevokeCertificateWithReg terminates trust in the certificate provided.
-func (ra *RegistrationAuthorityImpl) RevokeCertificateWithReg(ctx context.Context, cert x509.Certificate, revocationCode revocation.Reason, regID int64) error {
+func (ra *RegistrationAuthorityImpl) RevokeCertificateWithReg(ctx context.Context, req *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
+	if req == nil || req.Cert == nil {
+		return nil, errors.New("Incomplete gRPC request message")
+	}
+
+	cert, err := x509.ParseCertificate(req.Cert)
+	if err != nil {
+		return nil, err
+	}
+
 	serialString := core.SerialToString(cert.SerialNumber)
-	err := ra.revokeCertificate(ctx, cert, revocationCode, regID, "API", "")
+	revocationCode := revocation.Reason(req.Code)
+
+	err = ra.revokeCertificate(ctx, *cert, revocationCode, req.RegID, "API", "")
 
 	state := "Failure"
 	defer func() {
@@ -1825,17 +1836,17 @@ func (ra *RegistrationAuthorityImpl) RevokeCertificateWithReg(ctx context.Contex
 		//   Error (if there was one)
 		ra.log.AuditInfof("%s, Request by registration ID: %d",
 			revokeEvent(state, serialString, cert.Subject.CommonName, cert.DNSNames, revocationCode),
-			regID)
+			req.RegID)
 	}()
 
 	if err != nil {
 		state = fmt.Sprintf("Failure -- %s", err)
-		return err
+		return nil, err
 	}
 
 	ra.revocationReasonCounter.WithLabelValues(revocation.ReasonToString[revocationCode]).Inc()
 	state = "Success"
-	return nil
+	return &corepb.Empty{}, nil
 }
 
 // AdministrativelyRevokeCertificate terminates trust in the certificate provided and

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1812,7 +1812,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, cert
 // RevokeCertificateWithReg terminates trust in the certificate provided.
 func (ra *RegistrationAuthorityImpl) RevokeCertificateWithReg(ctx context.Context, req *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
 	if req == nil || req.Cert == nil {
-		return nil, errors.New("Incomplete gRPC request message")
+		return nil, errors.New("incomplete gRPC request message")
 	}
 
 	cert, err := x509.ParseCertificate(req.Cert)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3991,13 +3991,21 @@ func TestRevocationAddBlockedKey(t *testing.T) {
 		ic.NameID(): &ic,
 	}
 
-	err = ra.RevokeCertificateWithReg(context.Background(), *cert, ocsp.Unspecified, 0)
+	_, err = ra.RevokeCertificateWithReg(context.Background(), &rapb.RevokeCertificateWithRegRequest{
+		Cert:  cert.Raw,
+		Code:  ocsp.Unspecified,
+		RegID: 0,
+	})
 	test.AssertNotError(t, err, "RevokeCertificateWithReg failed")
 	test.Assert(t, mockSA.added == nil, "blocked key was added when reason was not keyCompromise")
 	test.AssertMetricWithLabelsEquals(
 		t, ra.revocationReasonCounter, prometheus.Labels{"reason": "unspecified"}, 1)
 
-	err = ra.RevokeCertificateWithReg(context.Background(), *cert, ocsp.KeyCompromise, 0)
+	_, err = ra.RevokeCertificateWithReg(context.Background(), &rapb.RevokeCertificateWithRegRequest{
+		Cert:  cert.Raw,
+		Code:  ocsp.KeyCompromise,
+		RegID: 0,
+	})
 	test.AssertNotError(t, err, "RevokeCertificateWithReg failed")
 	test.Assert(t, mockSA.added != nil, "blocked key was not added when reason was keyCompromise")
 	test.Assert(t, bytes.Equal(digest[:], mockSA.added.KeyHash), "key hash mismatch")

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -933,7 +933,11 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(ctx context.Context, logEvent *web
 		reason = *revokeRequest.Reason
 	}
 
-	err = wfe.RA.RevokeCertificateWithReg(ctx, *parsedCertificate, reason, registration.ID)
+	_, err = wfe.RA.RevokeCertificateWithReg(ctx, &rapb.RevokeCertificateWithRegRequest{
+		Cert:  parsedCertificate.Raw,
+		Code:  int64(reason),
+		RegID: registration.ID,
+	})
 	if err != nil {
 		if errors.Is(err, berrors.Duplicate) {
 			// It is possible that between checking the certificate's status and

--- a/wfe/wfe_test.go
+++ b/wfe/wfe_test.go
@@ -226,9 +226,9 @@ func (ra *MockRegistrationAuthority) PerformValidation(_ context.Context, _ *rap
 	return nil, nil
 }
 
-func (ra *MockRegistrationAuthority) RevokeCertificateWithReg(ctx context.Context, cert x509.Certificate, reason revocation.Reason, reg int64) error {
-	ra.lastRevocationReason = reason
-	return nil
+func (ra *MockRegistrationAuthority) RevokeCertificateWithReg(ctx context.Context, req *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
+	ra.lastRevocationReason = revocation.Reason(req.Code)
+	return &corepb.Empty{}, nil
 }
 
 func (ra *MockRegistrationAuthority) AdministrativelyRevokeCertificate(ctx context.Context, cert x509.Certificate, reason revocation.Reason, user string) error {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -856,7 +856,11 @@ func (wfe *WebFrontEndImpl) processRevocation(
 
 	// Revoke the certificate. AcctID may be 0 if there is no associated account
 	// (e.g. it was a self-authenticated JWS using the certificate public key)
-	err = wfe.RA.RevokeCertificateWithReg(ctx, *parsedCertificate, reason, acctID)
+	_, err = wfe.RA.RevokeCertificateWithReg(ctx, &rapb.RevokeCertificateWithRegRequest{
+		Cert:  parsedCertificate.Raw,
+		Code:  int64(reason),
+		RegID: acctID,
+	})
 	if err != nil {
 		if errors.Is(err, berrors.Duplicate) {
 			// It is possible that between checking the certificate's status and

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -236,9 +236,9 @@ func (ra *MockRegistrationAuthority) PerformValidation(_ context.Context, _ *rap
 	return nil, nil
 }
 
-func (ra *MockRegistrationAuthority) RevokeCertificateWithReg(ctx context.Context, cert x509.Certificate, reason revocation.Reason, reg int64) error {
-	ra.lastRevocationReason = reason
-	return nil
+func (ra *MockRegistrationAuthority) RevokeCertificateWithReg(ctx context.Context, req *rapb.RevokeCertificateWithRegRequest) (*corepb.Empty, error) {
+	ra.lastRevocationReason = revocation.Reason(req.Code)
+	return &corepb.Empty{}, nil
 }
 
 func (ra *MockRegistrationAuthority) AdministrativelyRevokeCertificate(ctx context.Context, cert x509.Certificate, reason revocation.Reason, user string) error {


### PR DESCRIPTION
Update the signature of the RA's RevokeCertificateWithReg
method to exactly match that of the gRPC method it implements.
Remove all logic from the `RevokeCertificateWithReg` client
and server wrappers. Move the small amount of checking they
were performing directly into the server implementation.

Fixes #5440