### PR TITLE
Honeycomb: emit sample rate 1 instead of 0

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -298,7 +298,7 @@ func makeSampler(rate uint32) func(fields map[string]interface{}) (bool, int) {
 		}
 		id, ok := fields["trace.trace_id"].(string)
 		if !ok {
-			return true, 0
+			return true, 1
 		}
 		h := fnv.New32()
 		h.Write([]byte(id))

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -126,8 +126,8 @@ func TestSampler(t *testing.T) {
 		{100, map[string]interface{}{"trace.trace_id": "foo", "meta.type": "grpc_server"}, false, 100},
 		{100, map[string]interface{}{"trace.trace_id": "foo", "meta.type": 123}, false, 100},
 		// A missing or non-string trace_id should result in sampling.
-		{100, map[string]interface{}{}, true, 0},
-		{100, map[string]interface{}{"trace.trace_id": 123}, true, 0},
+		{100, map[string]interface{}{}, true, 1},
+		{100, map[string]interface{}{"trace.trace_id": 123}, true, 1},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Rate(%d) Span(%s)", tc.samplerate, tc.span), func(t *testing.T) {


### PR DESCRIPTION
The sampling rate integer is used by the span collector to estimate
"how many spans does this span actually represent". This allows accurate
volume comparisons: for example, if you sample successful requests at
a rate of 1/100 and error requests at a rate of 1/10, the trace query
interface will know to scale its query results by those respective
values in order to arrive at accurate error rate estimates.

Previously, this code was returning a sample rate integer of 0 to
indicate that the span was selected for sampling due to an extraordinary
circumstance. This was wrong. This change updates the sample rate int
to be 1, indicating that every such span which exhibited this feature
was sampled, and represents only itself.