### PR TITLE
Log endpoint and slug for all requests to wfe

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -402,6 +402,13 @@ func (wfe *WebFrontEndImpl) Handler(stats prometheus.Registerer) http.Handler {
 
 // Index serves a simple identification page. It is not part of the ACME spec.
 func (wfe *WebFrontEndImpl) Index(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	// All requests that are not handled by our ACME endpoints ends up
+	// here. Set the our logEvent endpoint to "/" and the slug to the path
+	// minus "/" to make sure that we properly set log information about
+	// the request, even in the case of a 404
+	logEvent.Endpoint = "/"
+	logEvent.Slug = request.URL.Path[1:]
+
 	// http://golang.org/pkg/net/http/#example_ServeMux_Handle
 	// The "/" pattern matches everything, so we need to check
 	// that we're at the root here.

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3509,6 +3509,29 @@ func TestGETAPIChallenge(t *testing.T) {
 	}
 }
 
+// TestGet404 tests that a 404 is served and that the expected endpoint of
+// "/" is logged when an unknown path is requested. This will test the
+// codepath to the wfe.Index() handler which handles "/" and all non-api
+// endpoint requests to make sure the endpoint is set properly in the logs.
+func TestIndexGet404(t *testing.T) {
+	// Setup
+	wfe, _ := setupWFE(t)
+	path := "/nopathhere/nope/nofilehere"
+	req := &http.Request{URL: &url.URL{Path: path}, Method: "GET"}
+	logEvent := &web.RequestEvent{}
+	responseWriter := httptest.NewRecorder()
+
+	// Send a request to wfe.Index()
+	wfe.Index(context.Background(), logEvent, responseWriter, req)
+
+	// Test that a 404 is received as expected
+	test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
+	// Test that we logged the "/" endpoint
+	test.AssertEquals(t, logEvent.Endpoint, "/")
+	// Test that the rest of the path is logged as the slug
+	test.AssertEquals(t, logEvent.Slug, path[1:])
+}
+
 func TestGetAPIAndMandatoryPOSTAsGET(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)


### PR DESCRIPTION
Set logEvent.endpoint and slug so requests to "/" and 404 paths are logged

Fixes: #5432