### PR TITLE
 Break the chain of cancellations at the SA

### DIFF
--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -92,7 +92,7 @@ func main() {
 	tls, err := c.SA.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 	serverMetrics := bgrpc.NewServerMetrics(scope)
-	grpcSrv, listener, err := bgrpc.NewServer(c.SA.GRPC, tls, serverMetrics, clk)
+	grpcSrv, listener, err := bgrpc.NewServer(c.SA.GRPC, tls, serverMetrics, clk, bgrpc.NoCancelInterceptor)
 	cmd.FailOnError(err, "Unable to setup SA gRPC server")
 	gw := bgrpc.NewStorageAuthorityServer(sai)
 	sapb.RegisterStorageAuthorityServer(grpcSrv, gw)

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -27,6 +27,10 @@ const (
 // NoCancelInterceptor is a gRPC interceptor that creates a new context,
 // separate from the original context, that has the same deadline but does
 // not propagate cancellation. This is used by SA.
+//
+// Because this interceptor throws away annotations on the context, it
+// breaks tracing for events that get the modified context. To minimize that
+// impact, this interceptor should always be last.
 func NoCancelInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 	cancel := func() {}
 	if deadline, ok := ctx.Deadline(); ok {


### PR DESCRIPTION
A recent mysql driver upgrade caused a performance regression. We
believe this may be due to cancellations getting passed through to the
database driver, which as of the upgrade will more aggressively tear
down connections that experienced a cancellation.

Also, we only recently started propagation cancellations all the way
from the frontend in #5404.

This makes it so the driver doesn't see the cancellation.

Second attempt at #5447