### PR TITLE
Move endpoint and tracing to top of HandlerFunc

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -211,6 +211,12 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h web
 	methodsStr := strings.Join(methods, ", ")
 	handler := http.StripPrefix(pattern, web.NewTopHandler(wfe.log,
 		web.WFEHandlerFunc(func(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+			logEvent.Endpoint = pattern
+			beeline.AddFieldToTrace(ctx, "endpoint", pattern)
+			if request.URL != nil {
+				logEvent.Slug = request.URL.Path
+				beeline.AddFieldToTrace(ctx, "slug", request.URL.Path)
+			}
 			if request.Method != "GET" || pattern == newNoncePath {
 				// Historically we did not return a error to the client
 				// if we failed to get a new nonce. We preserve that
@@ -241,13 +247,6 @@ func (wfe *WebFrontEndImpl) HandleFunc(mux *http.ServeMux, pattern string, h web
 			if pattern != directoryPath {
 				directoryURL := web.RelativeEndpoint(request, directoryPath)
 				response.Header().Add("Link", link(directoryURL, "index"))
-			}
-
-			logEvent.Endpoint = pattern
-			beeline.AddFieldToTrace(ctx, "endpoint", pattern)
-			if request.URL != nil {
-				logEvent.Slug = request.URL.Path
-				beeline.AddFieldToTrace(ctx, "slug", request.URL.Path)
 			}
 
 			switch request.Method {


### PR DESCRIPTION
Move the logEvent.Endpoint and .Slug assignment as well as tracing to the
top of the HandlerFunc so a return cannot happen before the assignment.
Fixes cases where the endpoint is blank in logs due to an error returned.

Fixes: #5432