### PR TITLE
Package ct-test-srv into .deb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ $(OBJDIR):
 $(CMD_BINS): build_cmds
 
 build_cmds: | $(OBJDIR)
+	echo $(OBJECTS)
 	GOBIN=$(OBJDIR) GO111MODULE=on go install -mod=vendor $(GO_BUILD_FLAGS) ./...
 	cp $(OBJDIR)/boulder-va $(OBJDIR)/boulder-remoteva
 
@@ -63,4 +64,4 @@ deb: build
 		--package "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).x86_64.deb" \
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
 		--maintainer "$(MAINTAINER)" \
-		test/config/ sa/_db data/ $(OBJECTS)
+		test/config/ sa/_db data/ $(OBJECTS) bin/ct-test-srv


### PR DESCRIPTION
Because ct-test-srv is lives in `//test` instead of in `//cmd`, it is not
included by default in the set of objects which are bundled into the
.deb and .rpb packages produced by the Makefile (although it is
compiled by the `make build` command). Add it to the set of files
bundled into the .deb, for the sake of our SREs.