### PR TITLE
notify-mailer: General overhaul and coverage improvements

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -363,16 +363,16 @@ func parseRecipientList(recipientList *csv.Reader) ([]recipient, error) {
 
 // makeRecipientList determines the format of the recipient list file,
 // constructs a reader, and returns the result of parsing with that reader.
-func makeRecipientList(csvFilename, tsvFilename string) ([]recipient, error) {
+func makeRecipientList(csvFilename, tsvFilename *string) ([]recipient, error) {
 	var filename string
 	var delimiter rune
 
-	if csvFilename != "" {
-		filename = csvFilename
-	} else if tsvFilename != "" {
+	if csvFilename != nil {
+		filename = *csvFilename
+	} else if tsvFilename != nil {
 		// We can use a `*csv.Reader` to parse a TSV file, we just have to
 		// supply a custom delimiter in rune form.
-		filename = tsvFilename
+		filename = *tsvFilename
 		delimiter = '\t'
 	}
 
@@ -535,7 +535,7 @@ func main() {
 	address, err := mail.ParseAddress(*from)
 	cmd.FailOnError(err, fmt.Sprintf("Parsing %q", *from))
 
-	recipients, err := makeRecipientList(*recipientListCSV, *recipientListTSV)
+	recipients, err := makeRecipientList(recipientListCSV, recipientListTSV)
 	cmd.FailOnError(err, "Couldn't populate recipients from provided recipient list")
 
 	var mailClient bmail.Mailer

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -61,8 +61,7 @@ func TestMakeRecipientList(t *testing.T) {
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	list, err := makeRecipientList(entryFile, "")
-	fmt.Println(list)
+	list, err := makeRecipientList(&entryFile, nil)
 	test.AssertNotError(t, err, "received an error for a valid CSV file")
 
 	expected := []recipient{
@@ -78,7 +77,7 @@ func TestMakeRecipientList(t *testing.T) {
 	entryFile = setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	list, err = makeRecipientList("", entryFile)
+	list, err = makeRecipientList(nil, &entryFile)
 	test.AssertNotError(t, err, "received an error for a valid TSV file")
 	test.AssertDeepEquals(t, list, expected)
 }
@@ -91,16 +90,17 @@ func TestMakeRecipientListNoExtraColumns(t *testing.T) {
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertNotError(t, err, "received an error for a valid CSV file")
 }
 
 // `MakeRecipientList` Sad Paths
 func TestMakeRecipientsListFileNoExist(t *testing.T) {
-	_, err := makeRecipientList("i_do_not_exist.csv", "")
+	var nilFilename *string
+	_, err := makeRecipientList(nilFilename, nil)
 	test.AssertError(t, err, "expected error for CSV file that doesn't exist")
 
-	_, err = makeRecipientList("", "i_do_not_exist.tsv")
+	_, err = makeRecipientList(nil, nilFilename)
 	test.AssertError(t, err, "expected error for TSV file that doesn't exist")
 }
 
@@ -112,7 +112,7 @@ func TestMakeRecipientListsWithTrailingDelimiters(t *testing.T) {
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "failed to error on CSV file with trailing delimiter in entry")
 
 	contents = `id, domainName, date,
@@ -122,7 +122,7 @@ func TestMakeRecipientListsWithTrailingDelimiters(t *testing.T) {
 	entryFile = setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err = makeRecipientList(entryFile, "")
+	_, err = makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "failed to error on CSV file with trailing delimiter in header")
 
 	contents = `id	domainName	date
@@ -132,7 +132,7 @@ func TestMakeRecipientListsWithTrailingDelimiters(t *testing.T) {
 	entryFile = setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err = makeRecipientList("", entryFile)
+	_, err = makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "failed to error on TSV file with trailing delimiter in entry")
 
 	contents = `id	domainName	date	
@@ -142,7 +142,7 @@ func TestMakeRecipientListsWithTrailingDelimiters(t *testing.T) {
 	entryFile = setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err = makeRecipientList("", entryFile)
+	_, err = makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "failed to error on TSV file with trailing delimiter in header")
 }
 
@@ -155,7 +155,7 @@ func TestMakeRecipientListWithEmptyLine(t *testing.T) {
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertNotError(t, err, "received an error for a valid CSV file")
 }
 
@@ -167,7 +167,7 @@ func TestMakeRecipientListWithMismatchedColumns(t *testing.T) {
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "failed to error on CSV file with mismatched columns")
 }
 
@@ -179,7 +179,7 @@ func TestMakeRecipientListWithDuplicateIDs(t *testing.T) {
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "expected error for CSV file that contains duplicate IDs")
 }
 
@@ -191,7 +191,7 @@ twenty,example.net,2018-11-22`
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "expected error for CSV file that contains an unparsable registration ID")
 }
 
@@ -203,7 +203,7 @@ twenty,example.net,2018-11-22`
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "expected error for CSV file missing header field `id`")
 }
 
@@ -213,7 +213,7 @@ func TestMakeRecipientListWithOnlyHeader(t *testing.T) {
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)
 
-	_, err := makeRecipientList(entryFile, "")
+	_, err := makeRecipientList(&entryFile, nil)
 	test.AssertError(t, err, "expected error for CSV file containing only a header")
 }
 

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -207,6 +207,16 @@ twenty,example.net,2018-11-22`
 	test.AssertError(t, err, "expected error for CSV file missing header field `id`")
 }
 
+func TestMakeRecipientListWithOnlyHeader(t *testing.T) {
+	contents := `id, domainName, date
+`
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, err := makeRecipientList(entryFile, "")
+	test.AssertError(t, err, "expected error for CSV file containing only a header")
+}
+
 func TestSleepInterval(t *testing.T) {
 	const sleepLen = 10
 	mc := &mocks.Mailer{}


### PR DESCRIPTION
- Add support for TSV recipient list files
- Set database transaction isolation level to `READ UNCOMMITTED`
  for each session
- Pass database config provided in JSON config
- Refactor contact lookup query to check for an additional empty
  case
- Refactor `readRecipientsList()` to `makeRecipientsList()` and
 `parseRecipientList()`
  - Add comments
  - Error on trailing or double delimiter in recipient lists
  - Error on duplicate registration IDs in recipient lists
  - Error on registration IDs that cannot be coerced to int64
  - Remove unnecessary newline check
  - Remove unnecessary entries (after header) length check
  - Remove unnecessary header and entry length checks
- Refactor `config` to remove redundant embedded password
  file field
- Refactor `recipient.id` from `int` to `int64`
- Refactor `contactJSON` to more accurate `queryResult`
- Refactor `mailer.destinations` to `mailer.recipients`

### Usage changes

- Add flag`recipient-list-tsv`
- Rename flag `dryRun` to POSIX compliant `dry-run`
- Rename flag `recipientList` to POSIX compliant `recipient-list-csv`
- Rename flag `reconnectBase` to POSIX compliant `retry-base`
- Rename flag `reconnectMax` to POSIX compliant `retry-max`
- Updated usage info with new flag names

### Testing changes

- Increase test coverage from 57.2% to 65.7%
- Add unit test for CSV and TSV recipient list loading and parsing
  happy path 
- Add unit test for each unnecessary check removed
- Add unit test for each newly handled edge case


Fixes #5420