### PR TITLE
Run CI for commits and PRs to release branches

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -6,9 +6,13 @@ name: Boulder CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: 
+      - main
+      - release-branch-*
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - release-branch-*
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
In normal operation, Boulder does not have release branches, only
release tags. However, when we need to add hotfix commits on top of an
old release, we create a release branch, merge the commits there, and
then produce a new tag pointing at the tip of that branch. These release
branches are documented[1] to be named `refs/heads/release-branch-*`.
Therefore, we should run CI for PRs targeting, and new commits on, those
release branches.

[1] https://github.com/letsencrypt/boulder-release-process#when-main-is-dirty