### PR TITLE
RA: Make PerformValidation wrapper a passthrough

### DIFF
--- a/grpc/ra-wrappers.go
+++ b/grpc/ra-wrappers.go
@@ -61,19 +61,8 @@ func (rac RegistrationAuthorityClientWrapper) UpdateRegistration(ctx context.Con
 	return rac.inner.UpdateRegistration(ctx, req)
 }
 
-func (rac RegistrationAuthorityClientWrapper) PerformValidation(
-	ctx context.Context,
-	req *rapb.PerformValidationRequest) (*corepb.Authorization, error) {
-	authz, err := rac.inner.PerformValidation(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	if authz == nil || !authorizationValid(authz) {
-		return nil, errIncompleteResponse
-	}
-
-	return authz, nil
+func (rac RegistrationAuthorityClientWrapper) PerformValidation(ctx context.Context, req *rapb.PerformValidationRequest) (*corepb.Authorization, error) {
+	return rac.inner.PerformValidation(ctx, req)
 }
 
 func (rac RegistrationAuthorityClientWrapper) RevokeCertificateWithReg(ctx context.Context, req *rapb.RevokeCertificateWithRegRequest) (*emptypb.Empty, error) {
@@ -194,12 +183,7 @@ func (ras *RegistrationAuthorityServerWrapper) UpdateRegistration(ctx context.Co
 	return ras.inner.UpdateRegistration(ctx, req)
 }
 
-func (ras *RegistrationAuthorityServerWrapper) PerformValidation(
-	ctx context.Context,
-	request *rapb.PerformValidationRequest) (*corepb.Authorization, error) {
-	if request == nil || !authorizationValid(request.Authz) {
-		return nil, errIncompleteRequest
-	}
+func (ras *RegistrationAuthorityServerWrapper) PerformValidation(ctx context.Context, request *rapb.PerformValidationRequest) (*corepb.Authorization, error) {
 	return ras.inner.PerformValidation(ctx, request)
 }
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -981,6 +981,7 @@ func TestPerformValidationAlreadyValid(t *testing.T) {
 	// Create a finalized authorization
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
 	authz := core.Authorization{
+		ID:             "1337",
 		Identifier:     identifier.DNSIdentifier("not-example.com"),
 		RegistrationID: 1,
 		Status:         "valid",
@@ -3528,6 +3529,10 @@ func TestPerformValidationBadChallengeType(t *testing.T) {
 
 	exp := fc.Now().Add(10 * time.Hour)
 	authz := core.Authorization{
+		ID:             "1337",
+		Identifier:     identifier.DNSIdentifier("not-example.com"),
+		RegistrationID: 1,
+		Status:         "valid",
 		Challenges: []core.Challenge{
 			{
 				Status: core.StatusValid,

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1251,14 +1251,11 @@ func (wfe *WebFrontEndImpl) postChallenge(
 		authzPB, err = wfe.RA.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
 			ChallengeIndex: int64(challengeIndex)})
-		if err != nil {
-			wfe.sendError(
-				response,
-				logEvent,
-				web.ProblemDetailsForError(err, "Unable to perform validation for challenge"),
-				err)
+		if err != nil || authzPB == nil || authzPB.Id == "" || authzPB.Identifier == "" || authzPB.Status == "" || authzPB.Expires == 0 {
+			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to perform validation for challenge"), err)
 			return
 		}
+
 		updatedAuthz, err := bgrpc.PBToAuthz(authzPB)
 		if err != nil {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to deserialize authz"), err)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1283,7 +1283,8 @@ func (wfe *WebFrontEndImpl) postChallenge(
 
 		authzPB, err = wfe.RA.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
-			ChallengeIndex: int64(challengeIndex)})
+			ChallengeIndex: int64(challengeIndex),
+		})
 		if err != nil || authzPB == nil || authzPB.Id == "" || authzPB.Identifier == "" || authzPB.Status == "" || authzPB.Expires == 0 {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
 			return

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1283,12 +1283,12 @@ func (wfe *WebFrontEndImpl) postChallenge(
 
 		authzPB, err = wfe.RA.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
-			ChallengeIndex: int64(challengeIndex),
-		})
-		if err != nil {
+			ChallengeIndex: int64(challengeIndex)})
+		if err != nil || authzPB == nil || authzPB.Id == "" || authzPB.Identifier == "" || authzPB.Status == "" || authzPB.Expires == 0 {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
 			return
 		}
+
 		updatedAuthz, err := bgrpc.PBToAuthz(authzPB)
 		if err != nil {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to deserialize authz"), err)


### PR DESCRIPTION
- Move response validation from `RA` client wrapper to `WFE` and `WFE2`
- Move request validation from `RA` server wrapper to `RA`
- Refactor `RA` tests to construct valid `core.Authorization` objects
- Consolidate multiple error declarations to global `errIncompleteGRPCRequest`

Fixes #5439