### PR TITLE
mail: Rename RecoverableSMTPError to BadAddressSMTPError

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -163,8 +163,8 @@ func (m *mailer) run() error {
 		}
 		err := m.mailer.SendMail([]string{address}, m.subject, mailBody.String())
 		if err != nil {
-			var recoverableSMTPErr bmail.RecoverableSMTPError
-			if errors.As(err, &recoverableSMTPErr) {
+			var badAddrErr bmail.BadAddressSMTPError
+			if errors.As(err, &badAddrErr) {
 				m.log.Errf("address %q was rejected by server: %s", address, err)
 				continue
 			}

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -306,15 +306,15 @@ func (m *MailerImpl) sendOne(to []string, subject, msg string) error {
 	return nil
 }
 
-// RecoverableSMTPError is returned by SendMail when the server rejects a message
+// BadAddressSMTPError is returned by SendMail when the server rejects a message
 // but for a reason that doesn't prevent us from continuing to send mail. The
 // error message contains the error code and the error message returned from the
 // server.
-type RecoverableSMTPError struct {
+type BadAddressSMTPError struct {
 	Message string
 }
 
-func (e RecoverableSMTPError) Error() string {
+func (e BadAddressSMTPError) Error() string {
 	return e.Message
 }
 
@@ -379,7 +379,7 @@ func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
 			continue
 		} else if errors.As(err, &protoErr) && recoverableErrorCodes[protoErr.Code] {
 			m.sendMailAttempts.WithLabelValues("failure", fmt.Sprintf("SMTP %d", protoErr.Code)).Inc()
-			return RecoverableSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
+			return BadAddressSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
 		} else {
 			// If it wasn't an EOF error or a recoverable SMTP error it is unexpected and we
 			// return from SendMail() with the error

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -362,9 +362,9 @@ func TestBadEmailError(t *testing.T) {
 		t.Errorf("Expected SendMail() to return an RecoverableSMTPError, got nil")
 	}
 	expected := "401: 4.1.3 Bad recipient address syntax"
-	var rcptErr RecoverableSMTPError
-	test.AssertErrorWraps(t, err, &rcptErr)
-	test.AssertEquals(t, rcptErr.Message, expected)
+	var badAddrErr BadAddressSMTPError
+	test.AssertErrorWraps(t, err, &badAddrErr)
+	test.AssertEquals(t, badAddrErr.Message, expected)
 }
 
 func TestReconnectSMTP421(t *testing.T) {


### PR DESCRIPTION
Rename `RecoverableSMTPError` to `BadAddressSMTPError`. The former
implies that an operation resulting in this error can be retried.