### PR TITLE
Make boulder-observer HTTP User-Agent configurable

### DIFF
--- a/cmd/boulder-observer/README.md
+++ b/cmd/boulder-observer/README.md
@@ -156,7 +156,8 @@ monitors:
 
 `rcodes`: List of expected HTTP response codes.
 
-`useragent`: String to set HTTP header User-Agent.
+`useragent`: String to set HTTP header User-Agent. If no useragent string
+is provided it will default to `letsencrypt/boulder-observer-http-client`.
 
 ##### Example
 

--- a/cmd/boulder-observer/README.md
+++ b/cmd/boulder-observer/README.md
@@ -169,7 +169,7 @@ monitors:
     settings: 
       url: http://letsencrypt.org/FOO
       rcodes: [200, 404]
-      useragent: boulder_observer
+      useragent: letsencrypt/boulder-observer-http-client
 ```
 
 ## Metrics

--- a/cmd/boulder-observer/README.md
+++ b/cmd/boulder-observer/README.md
@@ -156,6 +156,8 @@ monitors:
 
 `rcodes`: List of expected HTTP response codes.
 
+`useragent`: String to set HTTP header User-Agent.
+
 ##### Example
 
 ```yaml
@@ -166,6 +168,7 @@ monitors:
     settings: 
       url: http://letsencrypt.org/FOO
       rcodes: [200, 404]
+      useragent: boulder_observer
 ```
 
 ## Metrics

--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -3,19 +3,22 @@ package probers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
 // HTTPProbe is the exported 'Prober' object for monitors configured to
 // perform HTTP requests.
 type HTTPProbe struct {
-	url    string
-	rcodes []int
+	url       string
+	rcodes    []int
+	useragent string
 }
 
 // Name returns a string that uniquely identifies the monitor.
 func (p HTTPProbe) Name() string {
-	return fmt.Sprintf("%s-%d", p.url, p.rcodes)
+	// Trim trailing hyphen if useragent is not provided
+	return strings.TrimSuffix(fmt.Sprintf("%s-%d-%s", p.url, p.rcodes, p.useragent), "-")
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Prober`.
@@ -37,9 +40,14 @@ func (p HTTPProbe) isExpected(received int) bool {
 // Probe performs the configured HTTP request.
 func (p HTTPProbe) Probe(timeout time.Duration) (bool, time.Duration) {
 	client := http.Client{Timeout: timeout}
+	req, err := http.NewRequest("GET", p.url, nil)
+	if err != nil {
+		return false, 0
+	}
+	req.Header.Set("User-Agent", p.useragent)
 	start := time.Now()
 	// TODO(@beautifulentropy): add support for more than HTTP GET
-	resp, err := client.Get(p.url)
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, time.Since(start)
 	}

--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -3,7 +3,6 @@ package probers
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -17,8 +16,7 @@ type HTTPProbe struct {
 
 // Name returns a string that uniquely identifies the monitor.
 func (p HTTPProbe) Name() string {
-	// Trim trailing hyphen if useragent is not provided
-	return strings.TrimSuffix(fmt.Sprintf("%s-%d-%s", p.url, p.rcodes, p.useragent), "-")
+	return fmt.Sprintf("%s-%d-%s", p.url, p.rcodes, p.useragent)
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Prober`.

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -10,8 +10,9 @@ import (
 
 // HTTPConf is exported to receive YAML configuration.
 type HTTPConf struct {
-	URL    string `yaml:"url"`
-	RCodes []int  `yaml:"rcodes"`
+	URL       string `yaml:"url"`
+	RCodes    []int  `yaml:"rcodes"`
+	UserAgent string `yaml:"useragent"`
 }
 
 // UnmarshalSettings takes YAML as bytes and unmarshals it to the to an
@@ -68,7 +69,7 @@ func (c HTTPConf) MakeProber() (probers.Prober, error) {
 	if err != nil {
 		return nil, err
 	}
-	return HTTPProbe{c.URL, c.RCodes}, nil
+	return HTTPProbe{c.URL, c.RCodes, c.UserAgent}, nil
 }
 
 // init is called at runtime and registers `HTTPConf`, a `Prober`

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -69,6 +69,11 @@ func (c HTTPConf) MakeProber() (probers.Prober, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Set default User-Agent if none set.
+	if c.UserAgent == "" {
+		c.UserAgent = "letsencrypt/boulder-observer-http-client"
+	}
 	return HTTPProbe{c.URL, c.RCodes, c.UserAgent}, nil
 }
 

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/test"
 	"gopkg.in/yaml.v2"
 )
 
@@ -43,8 +44,9 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 
 func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 	type fields struct {
-		url    interface{}
-		rcodes interface{}
+		url       interface{}
+		rcodes    interface{}
+		useragent interface{}
 	}
 	tests := []struct {
 		name    string
@@ -52,14 +54,15 @@ func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 		want    probers.Configurer
 		wantErr bool
 	}{
-		{"valid", fields{"google.com", []int{200}}, HTTPConf{"google.com", []int{200}}, false},
-		{"invalid", fields{42, 42}, nil, true},
+		{"valid", fields{"google.com", []int{200}, "boulder_observer"}, HTTPConf{"google.com", []int{200}, "boulder_observer"}, false},
+		{"invalid", fields{42, 42, 42}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			settings := probers.Settings{
-				"url":    tt.fields.url,
-				"rcodes": tt.fields.rcodes,
+				"url":       tt.fields.url,
+				"rcodes":    tt.fields.rcodes,
+				"useragent": tt.fields.useragent,
 			}
 			settingsBytes, _ := yaml.Marshal(settings)
 			c := HTTPConf{}
@@ -73,4 +76,32 @@ func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPProberName(t *testing.T) {
+	// Test without optional field `useragent`
+	proberYAML := `
+url: https://www.google.com
+rcodes: [ 200 ]
+`
+	c := HTTPConf{}
+	configurer, err := c.UnmarshalSettings([]byte(proberYAML))
+	test.AssertNotError(t, err, "Got error for valid prober config")
+	prober, err := configurer.MakeProber()
+	test.AssertNotError(t, err, "Got error for valid prober config")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]")
+
+	// Test with optional field `useragent`
+	proberYAML = `
+url: https://www.google.com
+rcodes: [ 200 ]
+useragent: boulder_observer
+`
+	c = HTTPConf{}
+	configurer, err = c.UnmarshalSettings([]byte(proberYAML))
+	test.AssertNotError(t, err, "Got error for valid prober config")
+	prober, err = configurer.MakeProber()
+	test.AssertNotError(t, err, "Got error for valid prober config")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-boulder_observer")
+
 }

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -79,29 +79,30 @@ func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 }
 
 func TestHTTPProberName(t *testing.T) {
-	// Test without optional field `useragent`
+	// Test with blank `useragent`
 	proberYAML := `
 url: https://www.google.com
 rcodes: [ 200 ]
+useragent: ""
 `
 	c := HTTPConf{}
 	configurer, err := c.UnmarshalSettings([]byte(proberYAML))
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	prober, err := configurer.MakeProber()
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-letsencrypt/boulder-observer-http-client")
 
-	// Test with optional field `useragent`
+	// Test with custom `useragent`
 	proberYAML = `
 url: https://www.google.com
 rcodes: [ 200 ]
-useragent: boulder_observer
+useragent: fancy-custom-http-client
 `
 	c = HTTPConf{}
 	configurer, err = c.UnmarshalSettings([]byte(proberYAML))
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	prober, err = configurer.MakeProber()
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-boulder_observer")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client")
 
 }

--- a/test/config-next/observer.yml
+++ b/test/config-next/observer.yml
@@ -38,7 +38,7 @@ monitors:
     settings: 
       url: https://letsencrypt.org
       rcodes: [200]
-      useragent: "boulder_observer"
+      useragent: "letsencrypt/boulder-observer-http-client"
   -
     period: 5s
     kind: DNS
@@ -90,4 +90,4 @@ monitors:
     settings: 
       url: http://letsencrypt.org/foo
       rcodes: [200, 404]
-      useragent: "boulder_observer"
+      useragent: "letsencrypt/boulder-observer-http-client"

--- a/test/config/observer.yml
+++ b/test/config/observer.yml
@@ -38,7 +38,6 @@ monitors:
     settings: 
       url: https://letsencrypt.org
       rcodes: [200]
-      useragent: "boulder_observer"
   -
     period: 5s
     kind: DNS
@@ -90,4 +89,3 @@ monitors:
     settings: 
       url: http://letsencrypt.org/foo
       rcodes: [200, 404]
-      useragent: "boulder_observer"


### PR DESCRIPTION
- Make User-Agent confirable in config file
- Fix README example
- Add test

Fixes: #5424 