### PR TITLE
mail: Fix data race in unit tests

### DIFF
--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -88,7 +88,6 @@ func listenForever(l *net.TCPListener, t *testing.T, handler connHandler) {
 	for {
 		tcpConn, err := l.AcceptTCP()
 		if err != nil {
-			t.Log(err)
 			return
 		}
 


### PR DESCRIPTION
Fix data race introduced in #5461.

- Remove logging of `err` after test case has already returned

Fixes #5466