### PR TITLE
Update boulder test validity period to match prod

### DIFF
--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -48,7 +48,7 @@
             ]
           }
         ],
-        "maxValidityPeriod": "2160h",
+        "maxValidityPeriod": "7775999s",
         "maxValidityBackdate": "1h5m"
       },
       "issuers": [
@@ -79,7 +79,7 @@
       ],
       "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "2160h",
+    "expiry": "7775999s",
     "backdate": "1h",
     "serialPrefix": 255,
     "maxNames": 100,

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -48,7 +48,7 @@
             ]
           }
         ],
-        "maxValidityPeriod": "2160h",
+        "maxValidityPeriod": "7775999s",
         "maxValidityBackdate": "1h5m"
       },
       "issuers": [
@@ -79,7 +79,7 @@
       ],
       "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "2160h",
+    "expiry": "7775999s",
     "backdate": "1h",
     "serialPrefix": 255,
     "maxNames": 100,

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -46,7 +46,7 @@
             ]
           }
         ],
-        "maxValidityPeriod": "2160h",
+        "maxValidityPeriod": "7775999s",
         "maxValidityBackdate": "1h5m"
       },
       "issuers": [
@@ -77,7 +77,7 @@
       ],
       "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "2160h",
+    "expiry": "7775999s",
     "backdate": "1h",
     "serialPrefix": 255,
     "maxNames": 100,

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -46,7 +46,7 @@
             ]
           }
         ],
-        "maxValidityPeriod": "2160h",
+        "maxValidityPeriod": "7775999s",
         "maxValidityBackdate": "1h5m"
       },
       "issuers": [
@@ -77,7 +77,7 @@
       ],
       "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "2160h",
+    "expiry": "7775999s",
     "backdate": "1h",
     "serialPrefix": 255,
     "maxNames": 100,


### PR DESCRIPTION
In prod, the CA is now configured to issue certificates with
notAfter timestamps 7775999 seconds after their notBefore
timestamp, and to enforce that same difference when validating
issuance requests.

Update our test configs to match.