### PR TITLE
notify-mailer: Improve recipient list parser

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -264,66 +264,98 @@ type addressToRecipientMap map[string][]recipient
 
 // readRecipientsList parses the contents of a recipient list file into a list
 // of `recipient` objects.
-func readRecipientsList(filename string) ([]recipient, error) {
+func readRecipientsList(filename string, delimiter rune) ([]recipient, string, error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	reader := csv.NewReader(f)
+	reader.Comma = delimiter
+
+	// Parse header.
 	record, err := reader.Read()
 	if err != nil {
-		return nil, err
-	}
-
-	if len(record) == 0 {
-		return nil, errors.New("no records in CSV")
+		return nil, "", fmt.Errorf("failed to parse header: %w", err)
 	}
 
 	if record[0] != "id" {
-		return nil, errors.New("first field of CSV input must be \"id\"")
+		return nil, "", errors.New("header must begin with \"id\"")
 	}
 
+	// Collect the names of each header column after `id`.
 	var dataColumns []string
 	for _, v := range record[1:] {
 		dataColumns = append(dataColumns, strings.TrimSpace(v))
+		if len(v) == 0 {
+			return nil, "", errors.New("header contains an empty column")
+		}
 	}
 
+	var recordsWithEmptyColumns []int64
+	var recordsWithDuplicateIDs []int64
+	var probsBuff strings.Builder
+	stringProbs := func() string {
+		if len(recordsWithEmptyColumns) != 0 {
+			fmt.Fprintf(&probsBuff, "ID(s) %v contained empty columns and ",
+				recordsWithEmptyColumns)
+		}
+
+		if len(recordsWithDuplicateIDs) != 0 {
+			fmt.Fprintf(&probsBuff, "ID(s) %v were skipped as duplicates",
+				recordsWithDuplicateIDs)
+		}
+
+		if probsBuff.Len() == 0 {
+			return ""
+		}
+		return strings.TrimSuffix(probsBuff.String(), " and ")
+	}
+
+	// Parse records.
+	recipientIDs := make(map[int64]bool)
 	var recipients []recipient
 	for {
 		record, err := reader.Read()
 		if errors.Is(err, io.EOF) {
 			// Finished parsing the file.
 			if len(recipients) == 0 {
-				return nil, fmt.Errorf("no records after the header in CSV")
+				return nil, stringProbs(), errors.New("no records after header")
 			}
-			return recipients, nil
+			return recipients, stringProbs(), nil
 		} else if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 
-		if len(record) == 0 {
-			return nil, fmt.Errorf("empty line in CSV")
-		}
-
-		if len(record) != len(dataColumns)+1 {
-			return nil, fmt.Errorf("got (%d) columns, for (%d) header columns, for line %q",
-				len(record), len(dataColumns)+1, record)
-		}
-
-		// Ensure the ID in the record can be parsed as a valid ID.
+		// Ensure the first column of each record can be parsed as a valid
+		// registration ID.
 		recordID := record[0]
 		id, err := strconv.ParseInt(recordID, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf(
+			return nil, "", fmt.Errorf(
 				"%q couldn't be parsed as a registration ID due to: %s", recordID, err)
 		}
 
-		// Create a mapping of column names to extra data columns (anything
-		// after `id`).
+		// Skip records that have the same ID as those read previously.
+		if recipientIDs[id] {
+			recordsWithDuplicateIDs = append(recordsWithDuplicateIDs, id)
+			continue
+		}
+		recipientIDs[id] = true
+
+		// Collect the columns of data after `id` into a map.
+		var emptyColumn bool
 		data := make(map[string]string)
 		for i, v := range record[1:] {
+			if len(v) == 0 {
+				emptyColumn = true
+			}
 			data[dataColumns[i]] = v
+		}
+
+		// Only used for logging.
+		if emptyColumn {
+			recordsWithEmptyColumns = append(recordsWithEmptyColumns, id)
 		}
 
 		recipients = append(recipients, recipient{id, data})
@@ -413,6 +445,7 @@ func main() {
 	from := flag.String("from", "", "From header for emails. Must be a bare email address.")
 	subject := flag.String("subject", "", "Subject of emails")
 	recipientListFile := flag.String("recipientList", "", "File containing a CSV list of registration IDs and extra info.")
+	parseAsTSV := flag.Bool("tsv", false, "Parse the recipient list file as a TSV.")
 	bodyFile := flag.String("body", "", "File containing the email body in Golang template format.")
 	dryRun := flag.Bool("dryRun", true, "Whether to do a dry run.")
 	sleep := flag.Duration("sleep", 500*time.Millisecond, "How long to sleep between emails.")
@@ -469,8 +502,16 @@ func main() {
 	address, err := mail.ParseAddress(*from)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't parse %q to address", *from))
 
-	recipients, err := readRecipientsList(*recipientListFile)
+	recipientListDelimiter := ','
+	if *parseAsTSV {
+		recipientListDelimiter = '\t'
+	}
+	recipients, probs, err := readRecipientsList(*recipientListFile, recipientListDelimiter)
 	cmd.FailOnError(err, "Couldn't populate recipients")
+
+	if probs != "" {
+		log.Infof("While reading the recipient list file %s", probs)
+	}
 
 	var mailClient bmail.Mailer
 	if *dryRun {

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -39,37 +41,192 @@ func TestIntervalOK(t *testing.T) {
 	}
 }
 
-// makeFile writes the given content into a temporary file, returning
-// the filename (which should be deleted when done).
-func makeFile(content string) (string, error) {
-	tmpfile, err := ioutil.TempFile("", "")
-	if err != nil {
-		return "", err
-	}
+func setupMakeRecipientList(t *testing.T, contents string) string {
+	entryFile, err := ioutil.TempFile("", "")
+	test.AssertNotError(t, err, "couldn't create temp file")
 
-	if _, err := tmpfile.Write([]byte(content)); err != nil {
-		return "", err
-	}
-	if err := tmpfile.Close(); err != nil {
-		return "", err
-	}
-	return tmpfile.Name(), nil
+	_, err = entryFile.WriteString(contents)
+	test.AssertNotError(t, err, "couldn't write contents to temp file")
+
+	err = entryFile.Close()
+	test.AssertNotError(t, err, "couldn't close temp file")
+	return entryFile.Name()
 }
 
-func TestReadRecipientsListMismatchedColumns(t *testing.T) {
-	bad := `id, domainName, date
+// `MakeRecipientList` Happy Paths
+
+func TestMakeRecipientList(t *testing.T) {
+	contents := `id, domainName, date
+10,example.com,2018-11-21
+23,example.net,2018-11-22`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	list, _, err := readRecipientsList(entryFile, ',')
+	test.AssertNotError(t, err, "received an error for a valid CSV file")
+
+	expected := []recipient{
+		{id: 10, Data: map[string]string{"date": "2018-11-21", "domainName": "example.com"}},
+		{id: 23, Data: map[string]string{"date": "2018-11-22", "domainName": "example.net"}},
+	}
+	test.AssertDeepEquals(t, list, expected)
+
+	contents = `id	domainName	date
+10	example.com	2018-11-21
+23	example.net	2018-11-22`
+
+	entryFile = setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	list, _, err = readRecipientsList(entryFile, '\t')
+	test.AssertNotError(t, err, "received an error for a valid TSV file")
+	test.AssertDeepEquals(t, list, expected)
+}
+
+func TestMakeRecipientListNoExtraColumns(t *testing.T) {
+	contents := `id
+10
+23`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertNotError(t, err, "received an error for a valid CSV file")
+}
+
+// `MakeRecipientList` Sad Paths
+func TestMakeRecipientsListFileNoExist(t *testing.T) {
+	_, _, err := readRecipientsList("doesNotExist", ',')
+	test.AssertError(t, err, "expected error for a file that doesn't exist")
+}
+
+func TestMakeRecipientListWithEmptyColumnInHeader(t *testing.T) {
+	contents := `id, domainName,,date
 10,example.com,2018-11-21
 23,example.net`
-	badFileName, err := makeFile(bad)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(badFileName)
-	recipients, err := readRecipientsList(badFileName)
-	if err == nil {
-		t.Fatalf("reading bad CSV file should have errored, but got %v",
-			recipients)
-	}
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertError(t, err, "failed to error on CSV file with trailing delimiter in header")
+	test.AssertDeepEquals(t, err, errors.New("header contains an empty column"))
+}
+
+func TestMakeRecipientListWithProblems(t *testing.T) {
+	contents := `id, domainName, date
+10,example.com,2018-11-21
+23,example.net,
+10,example.com,2018-11-22
+42,example.net,
+24,example.com,2018-11-21
+24,example.com,2018-11-21
+`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	recipients, probs, err := readRecipientsList(entryFile, ',')
+	test.AssertNotError(t, err, "received an error for a valid CSV file")
+	test.AssertEquals(t, probs, "ID(s) [23 42] contained empty columns and ID(s) [10 24] were skipped as duplicates")
+	test.AssertEquals(t, len(recipients), 4)
+
+	// Ensure trailing " and " is trimmed from single problem.
+	contents = `id, domainName, date
+23,example.net,
+10,example.com,2018-11-21
+42,example.net,
+`
+
+	entryFile = setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, probs, err = readRecipientsList(entryFile, ',')
+	test.AssertNotError(t, err, "received an error for a valid CSV file")
+	test.AssertEquals(t, probs, "ID(s) [23 42] contained empty columns")
+}
+
+func TestMakeRecipientListWithEmptyLine(t *testing.T) {
+	contents := `id, domainName, date
+10,example.com,2018-11-21
+
+23,example.net,2018-11-22`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertNotError(t, err, "received an error for a valid CSV file")
+}
+
+func TestMakeRecipientListWithMismatchedColumns(t *testing.T) {
+	contents := `id, domainName, date
+10,example.com,2018-11-21
+23,example.net`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertError(t, err, "failed to error on CSV file with mismatched columns")
+}
+
+func TestMakeRecipientListWithDuplicateIDs(t *testing.T) {
+	contents := `id, domainName, date
+10,example.com,2018-11-21
+10,example.net,2018-11-22`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertNotError(t, err, "received an error for a valid CSV file")
+}
+
+func TestMakeRecipientListWithUnparsableID(t *testing.T) {
+	contents := `id, domainName, date
+10,example.com,2018-11-21
+twenty,example.net,2018-11-22`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertError(t, err, "expected error for CSV file that contains an unparsable registration ID")
+}
+
+func TestMakeRecipientListWithoutIDHeader(t *testing.T) {
+	contents := `notId, domainName, date
+10,example.com,2018-11-21
+twenty,example.net,2018-11-22`
+
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertError(t, err, "expected error for CSV file missing header field `id`")
+}
+
+func TestMakeRecipientListWithNoRecords(t *testing.T) {
+	contents := `id, domainName, date
+`
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertError(t, err, "expected error for CSV file containing only a header")
+}
+
+func TestMakeRecipientListWithNoHeaderOrRecords(t *testing.T) {
+	contents := ``
+	entryFile := setupMakeRecipientList(t, contents)
+	defer os.Remove(entryFile)
+
+	_, _, err := readRecipientsList(entryFile, ',')
+	test.AssertError(t, err, "expected error for CSV file containing only a header")
+	test.AssertErrorIs(t, err, io.EOF)
 }
 
 func TestSleepInterval(t *testing.T) {

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -53,9 +53,7 @@ func setupMakeRecipientList(t *testing.T, contents string) string {
 	return entryFile.Name()
 }
 
-// `MakeRecipientList` Happy Paths
-
-func TestMakeRecipientList(t *testing.T) {
+func TestReadRecipientList(t *testing.T) {
 	contents := `id, domainName, date
 10,example.com,2018-11-21
 23,example.net,2018-11-22`
@@ -84,7 +82,7 @@ func TestMakeRecipientList(t *testing.T) {
 	test.AssertDeepEquals(t, list, expected)
 }
 
-func TestMakeRecipientListNoExtraColumns(t *testing.T) {
+func TestReadRecipientListNoExtraColumns(t *testing.T) {
 	contents := `id
 10
 23`
@@ -96,13 +94,12 @@ func TestMakeRecipientListNoExtraColumns(t *testing.T) {
 	test.AssertNotError(t, err, "received an error for a valid CSV file")
 }
 
-// `MakeRecipientList` Sad Paths
-func TestMakeRecipientsListFileNoExist(t *testing.T) {
+func TestReadRecipientsListFileNoExist(t *testing.T) {
 	_, _, err := readRecipientsList("doesNotExist", ',')
 	test.AssertError(t, err, "expected error for a file that doesn't exist")
 }
 
-func TestMakeRecipientListWithEmptyColumnInHeader(t *testing.T) {
+func TestReadRecipientListWithEmptyColumnInHeader(t *testing.T) {
 	contents := `id, domainName,,date
 10,example.com,2018-11-21
 23,example.net`
@@ -115,7 +112,7 @@ func TestMakeRecipientListWithEmptyColumnInHeader(t *testing.T) {
 	test.AssertDeepEquals(t, err, errors.New("header contains an empty column"))
 }
 
-func TestMakeRecipientListWithProblems(t *testing.T) {
+func TestReadRecipientListWithProblems(t *testing.T) {
 	contents := `id, domainName, date
 10,example.com,2018-11-21
 23,example.net,
@@ -148,7 +145,7 @@ func TestMakeRecipientListWithProblems(t *testing.T) {
 	test.AssertEquals(t, probs, "ID(s) [23 42] contained empty columns")
 }
 
-func TestMakeRecipientListWithEmptyLine(t *testing.T) {
+func TestReadRecipientListWithEmptyLine(t *testing.T) {
 	contents := `id, domainName, date
 10,example.com,2018-11-21
 
@@ -161,7 +158,7 @@ func TestMakeRecipientListWithEmptyLine(t *testing.T) {
 	test.AssertNotError(t, err, "received an error for a valid CSV file")
 }
 
-func TestMakeRecipientListWithMismatchedColumns(t *testing.T) {
+func TestReadRecipientListWithMismatchedColumns(t *testing.T) {
 	contents := `id, domainName, date
 10,example.com,2018-11-21
 23,example.net`
@@ -173,7 +170,7 @@ func TestMakeRecipientListWithMismatchedColumns(t *testing.T) {
 	test.AssertError(t, err, "failed to error on CSV file with mismatched columns")
 }
 
-func TestMakeRecipientListWithDuplicateIDs(t *testing.T) {
+func TestReadRecipientListWithDuplicateIDs(t *testing.T) {
 	contents := `id, domainName, date
 10,example.com,2018-11-21
 10,example.net,2018-11-22`
@@ -185,7 +182,7 @@ func TestMakeRecipientListWithDuplicateIDs(t *testing.T) {
 	test.AssertNotError(t, err, "received an error for a valid CSV file")
 }
 
-func TestMakeRecipientListWithUnparsableID(t *testing.T) {
+func TestReadRecipientListWithUnparsableID(t *testing.T) {
 	contents := `id, domainName, date
 10,example.com,2018-11-21
 twenty,example.net,2018-11-22`
@@ -197,7 +194,7 @@ twenty,example.net,2018-11-22`
 	test.AssertError(t, err, "expected error for CSV file that contains an unparsable registration ID")
 }
 
-func TestMakeRecipientListWithoutIDHeader(t *testing.T) {
+func TestReadRecipientListWithoutIDHeader(t *testing.T) {
 	contents := `notId, domainName, date
 10,example.com,2018-11-21
 twenty,example.net,2018-11-22`
@@ -209,7 +206,7 @@ twenty,example.net,2018-11-22`
 	test.AssertError(t, err, "expected error for CSV file missing header field `id`")
 }
 
-func TestMakeRecipientListWithNoRecords(t *testing.T) {
+func TestReadRecipientListWithNoRecords(t *testing.T) {
 	contents := `id, domainName, date
 `
 	entryFile := setupMakeRecipientList(t, contents)
@@ -219,7 +216,7 @@ func TestMakeRecipientListWithNoRecords(t *testing.T) {
 	test.AssertError(t, err, "expected error for CSV file containing only a header")
 }
 
-func TestMakeRecipientListWithNoHeaderOrRecords(t *testing.T) {
+func TestReadRecipientListWithNoHeaderOrRecords(t *testing.T) {
 	contents := ``
 	entryFile := setupMakeRecipientList(t, contents)
 	defer os.Remove(entryFile)


### PR DESCRIPTION
- Parse recipient list file as a TSV when flag `-tsv` is provided
- Log recipient list records that contain empty columns
- Log and skip recipient list records that contain the same `id` as previously
  read records
- Remove unnecessary check for mismatched header and record column length, this
  is already handled by the `encoding/csv` package
- Remove unnecessary check for empty line, this is already handled by the
  `encoding/csv` package

Part of  #5420