### PR TITLE
Update cert-checker config to include all params

### DIFF
--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -5,6 +5,10 @@
       "maxOpenConns": 10
     },
     "hostnamePolicyFile": "test/hostname-policy.yaml",
+    "workers": 16,
+    "unexpiredOnly": true,
+    "badResultsOnly": true,
+    "checkPeriod": "72h",
     "acceptableValidityPeriods": [7776000],
     "ignoredLints": [
       "n_subject_common_name_included"


### PR DESCRIPTION
These parameters are currently accepted by cert-checker
either via the command line or via the config. Add them to
the config-next config as we move towards deprecating
their CLI equivalents.

Part of #5489