### PR TITLE
Run GitHub Actions on all PRs

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -10,6 +10,8 @@ on:
       - main
       - release-branch-*
   pull_request:
+    branches:
+      - '**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -10,9 +10,6 @@ on:
       - main
       - release-branch-*
   pull_request:
-    branches:
-      - main
-      - release-branch-*
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Currently we only run pre-submit CI for PRs which are against
our main branch or release branches. This means that "stacked"
PRs (a chain of PRs which all build on each other, and which will
need to be submitted in order) don't get any CI runs for PRs beyond
the first.

We don't expect large amounts of PR spam running us out of free
GH Actions credits, so just run CI for all PRs. Continue to run post-
submit CI only for commits to main and release branches so that we
don't prematurely run it on not-yet-PR-ready branches.