### PR TITLE
Update tests for go1.17 compatibility

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
@@ -61,8 +60,10 @@ func TestRevokeBatch(t *testing.T) {
 	defer test.ResetSATestDatabase(t)
 	reg := satest.CreateWorkingRegistration(t, ssa)
 
-	issuer, err := core.LoadCert("../../test/test-ca.pem")
+	issuer, err := issuance.LoadCertificate("../../test/hierarchy/int-r3.cert.pem")
 	test.AssertNotError(t, err, "Failed to load test issuer")
+	signer, err := test.LoadSigner("../../test/hierarchy/int-r3.key.pem")
+	test.AssertNotError(t, err, "failed to load test signer")
 
 	ra := ra.NewRegistrationAuthorityImpl(fc,
 		log,
@@ -78,7 +79,7 @@ func TestRevokeBatch(t *testing.T) {
 		0,
 		nil,
 		&mockPurger{},
-		[]*issuance.Certificate{{Certificate: issuer}},
+		[]*issuance.Certificate{issuer},
 	)
 	ra.SA = ssa
 	ra.CA = &mockCA{}
@@ -88,14 +89,12 @@ func TestRevokeBatch(t *testing.T) {
 	defer os.Remove(serialFile.Name())
 
 	serials := []*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)}
-	k, err := rsa.GenerateKey(rand.Reader, 512)
-	test.AssertNotError(t, err, "failed to generate test key")
 	for _, serial := range serials {
 		template := &x509.Certificate{
 			SerialNumber: serial,
 			DNSNames:     []string{"asd"},
 		}
-		der, err := x509.CreateCertificate(rand.Reader, template, issuer, &k.PublicKey, k)
+		der, err := x509.CreateCertificate(rand.Reader, template, issuer.Certificate, signer.Public(), signer)
 		test.AssertNotError(t, err, "failed to generate test cert")
 		_, err = ssa.AddPrecertificate(context.Background(), &sapb.AddCertificateRequest{
 			Der:      der,

--- a/cmd/orphan-finder/main_test.go
+++ b/cmd/orphan-finder/main_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -109,11 +107,11 @@ func (ca *mockCA) GenerateOCSP(context.Context, *capb.GenerateOCSPRequest, ...gr
 }
 
 func TestParseLine(t *testing.T) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	test.AssertNotError(t, err, "failed to generate test key")
-	issuer, err := issuance.LoadCertificate("../../test/test-ca2.pem")
+	issuer, err := issuance.LoadCertificate("../../test/hierarchy/int-e1.cert.pem")
 	test.AssertNotError(t, err, "failed to load test issuer")
-	cert, err := core.LoadCert("../../test/test-ee.pem")
+	signer, err := test.LoadSigner("../../test/hierarchy/int-e1.key.pem")
+	test.AssertNotError(t, err, "failed to load test signer")
+	cert, err := core.LoadCert("../../test/hierarchy/ee-e1.cert.pem")
 	test.AssertNotError(t, err, "failed to load test cert")
 	certStr := hex.EncodeToString(cert.Raw)
 	precertTmpl := x509.Certificate{
@@ -123,7 +121,7 @@ func TestParseLine(t *testing.T) {
 			{Id: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}, Critical: true, Value: []byte{0x05, 0x00}},
 		},
 	}
-	precertDER, err := x509.CreateCertificate(rand.Reader, &precertTmpl, issuer.Certificate, key.Public(), key)
+	precertDER, err := x509.CreateCertificate(rand.Reader, &precertTmpl, issuer.Certificate, signer.Public(), signer)
 	test.AssertNotError(t, err, "failed to generate test precert")
 	precertStr := hex.EncodeToString(precertDER)
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3983,7 +3983,7 @@ func TestRevocationAddBlockedKey(t *testing.T) {
 	digest, err := core.KeyDigest(k.Public())
 	test.AssertNotError(t, err, "core.KeyDigest failed")
 
-	template := x509.Certificate{PublicKey: k, SerialNumber: big.NewInt(257)}
+	template := x509.Certificate{SerialNumber: big.NewInt(257)}
 	der, err := x509.CreateCertificate(rand.Reader, &template, &template, k.Public(), k)
 	test.AssertNotError(t, err, "x509.CreateCertificate failed")
 	cert, err := x509.ParseCertificate(der)

--- a/test/asserts.go
+++ b/test/asserts.go
@@ -2,15 +2,9 @@ package test
 
 import (
 	"bytes"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"math/big"
 	"reflect"
 	"strings"
 	"testing"
@@ -202,54 +196,4 @@ loop:
 		}
 	}
 	AssertEquals(t, total, expected)
-}
-
-var throwawayCertIssuer *x509.Certificate
-
-// ThrowAwayCert is a small test helper function that creates a self-signed
-// certificate for nameCount random example.com subdomains and returns the
-// parsed certificate  and the random serial in string form or aborts the test.
-// The certificate returned from this function is the bare minimum needed for
-// most tests and isn't a robust example of a complete end entity certificate.
-func ThrowAwayCert(t *testing.T, nameCount int) (string, *x509.Certificate) {
-	var serialBytes [16]byte
-	_, _ = rand.Read(serialBytes[:])
-	sn := big.NewInt(0).SetBytes(serialBytes[:])
-
-	return ThrowAwayCertWithSerial(t, nameCount, sn, nil)
-}
-
-// ThrowAwayCertWithSerial is a small test helper function that creates a
-// certificate for nameCount random example.com subdomains and returns the
-// parsed certificate and the serial in string form or aborts the test.
-// The new throwaway certificate is always self-signed (with a random key),
-// but will appear to be issued from issuer if provided.
-// The certificate returned from this function is the bare minimum needed for
-// most tests and isn't a robust example of a complete end entity certificate.
-func ThrowAwayCertWithSerial(t *testing.T, nameCount int, sn *big.Int, issuer *x509.Certificate) (string, *x509.Certificate) {
-	k, err := rsa.GenerateKey(rand.Reader, 512)
-	AssertNotError(t, err, "rsa.GenerateKey failed")
-
-	var names []string
-	for i := 0; i < nameCount; i++ {
-		var nameBytes [3]byte
-		_, _ = rand.Read(nameBytes[:])
-		names = append(names, fmt.Sprintf("%s.example.com", hex.EncodeToString(nameBytes[:])))
-	}
-
-	template := &x509.Certificate{
-		SerialNumber:          sn,
-		DNSNames:              names,
-		IssuingCertificateURL: []string{"http://localhost:4000/acme/issuer-cert"},
-	}
-
-	if issuer == nil {
-		issuer = template
-	}
-
-	testCertDER, err := x509.CreateCertificate(rand.Reader, template, issuer, &k.PublicKey, k)
-	AssertNotError(t, err, "x509.CreateCertificate failed")
-	testCert, err := x509.ParseCertificate(testCertDER)
-	AssertNotError(t, err, "failed to parse self-signed cert DER")
-	return fmt.Sprintf("%036x", sn), testCert
 }

--- a/test/certs.go
+++ b/test/certs.go
@@ -1,0 +1,106 @@
+package test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"testing"
+)
+
+// LoadSigner loads a PEM private key specified by filename or returns an error.
+// Can be paired with issuance.LoadCertificate to get both a CA cert and its
+// associated private key for use in signing throwaway test certs.
+func LoadSigner(filename string) (crypto.Signer, error) {
+	keyBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	// pem.Decode does not return an error as its 2nd arg, but instead the "rest"
+	// that was leftover from parsing the PEM block. We only care if the decoded
+	// PEM block was empty for this test function.
+	block, _ := pem.Decode(keyBytes)
+	if block == nil {
+		return nil, errors.New("Unable to decode private key PEM bytes")
+	}
+
+	// Try decoding as an RSA private key
+	if rsaKey, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return rsaKey, nil
+	}
+
+	// Try decoding as a PKCS8 private key
+	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		// Determine the key's true type and return it as a crypto.Signer
+		switch k := key.(type) {
+		case *rsa.PrivateKey:
+			return k, nil
+		case *ecdsa.PrivateKey:
+			return k, nil
+		}
+	}
+
+	// Try as an ECDSA private key
+	if ecdsaKey, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return ecdsaKey, nil
+	}
+
+	// Nothing worked! Fail hard.
+	return nil, errors.New("Unable to decode private key PEM bytes")
+}
+
+// ThrowAwayCert is a small test helper function that creates a self-signed
+// certificate for nameCount random example.com subdomains and returns the
+// parsed certificate  and the random serial in string form or aborts the test.
+// The certificate returned from this function is the bare minimum needed for
+// most tests and isn't a robust example of a complete end entity certificate.
+func ThrowAwayCert(t *testing.T, nameCount int) (string, *x509.Certificate) {
+	var serialBytes [16]byte
+	_, _ = rand.Read(serialBytes[:])
+	sn := big.NewInt(0).SetBytes(serialBytes[:])
+
+	return ThrowAwayCertWithSerial(t, nameCount, sn, nil)
+}
+
+// ThrowAwayCertWithSerial is a small test helper function that creates a
+// certificate for nameCount random example.com subdomains and returns the
+// parsed certificate and the serial in string form or aborts the test.
+// The new throwaway certificate is always self-signed (with a random key),
+// but will appear to be issued from issuer if provided.
+// The certificate returned from this function is the bare minimum needed for
+// most tests and isn't a robust example of a complete end entity certificate.
+func ThrowAwayCertWithSerial(t *testing.T, nameCount int, sn *big.Int, issuer *x509.Certificate) (string, *x509.Certificate) {
+	k, err := rsa.GenerateKey(rand.Reader, 512)
+	AssertNotError(t, err, "rsa.GenerateKey failed")
+
+	var names []string
+	for i := 0; i < nameCount; i++ {
+		var nameBytes [3]byte
+		_, _ = rand.Read(nameBytes[:])
+		names = append(names, fmt.Sprintf("%s.example.com", hex.EncodeToString(nameBytes[:])))
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          sn,
+		DNSNames:              names,
+		IssuingCertificateURL: []string{"http://localhost:4000/acme/issuer-cert"},
+	}
+
+	if issuer == nil {
+		issuer = template
+	}
+
+	testCertDER, err := x509.CreateCertificate(rand.Reader, template, issuer, &k.PublicKey, k)
+	AssertNotError(t, err, "x509.CreateCertificate failed")
+	testCert, err := x509.ParseCertificate(testCertDER)
+	AssertNotError(t, err, "failed to parse self-signed cert DER")
+	return fmt.Sprintf("%036x", sn), testCert
+}


### PR DESCRIPTION
In several tests, change places where we were loading an
issuer certificate and pairing it with a newly-generated private
key to instead load both the certificate and signer side-by-side.
Add a new method `LoadSigner()` to our test utilities to
facilitate this pattern. Split our test utilities file into two separate
files for better readability.

Part of https://github.com/letsencrypt/boulder/issues/5480