### PR TITLE
Allow IssuerID or IssuerNameID in OCSP requests

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -92,6 +92,10 @@ type certificateAuthorityImpl struct {
 	signErrorCount     *prometheus.CounterVec
 }
 
+// makeIssuerMaps processes a list of issuers into a set of maps, mapping
+// nearly-unique identifiers of those issuers to the issuers themselves. Note
+// that, if two issuers have the same nearly-unique ID, the *latter* one in
+// the input list "wins".
 func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
 	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*issuance.Issuer, 2)
 	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Issuer, len(issuers))


### PR DESCRIPTION
Have the OCSP component of the CA keep track of both the (old-style)
IssuerID and the (new-style) IssuerNameID of all issuer certificates
loaded by its config. When receiving a requests to generate an OCSP
response, check the ID contained in that request against both lists,
preferring the IssuerNameID list.

This allows us to have GenerateOCSP clients (the RA and ocsp-updater)
begin specifying IssuerNameIDs in their requests, so that we can get
rid of the old IssuerID entirely.

Part of #5152