### PR TITLE
CA: Store IssuerNameID in certificateStatus table

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -243,7 +243,7 @@ func (ca *certificateAuthorityImpl) IssuePrecertificate(ctx context.Context, iss
 	if err != nil {
 		return nil, err
 	}
-	issuerID := issuer.Cert.ID()
+	issuerID := issuer.Cert.NameID()
 
 	ocspResp, err := ca.ocsp.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		Serial:   serialHex,
@@ -357,7 +357,7 @@ func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 	ca.log.AuditInfof("Signing success: serial=[%s] names=[%s] csr=[%s] certificate=[%s]",
 		serialHex, strings.Join(precert.DNSNames, ", "), hex.EncodeToString(req.DER),
 		hex.EncodeToString(certDER))
-	err = ca.storeCertificate(ctx, req.RegistrationID, req.OrderID, precert.SerialNumber, certDER, int64(issuer.Cert.ID()))
+	err = ca.storeCertificate(ctx, req.RegistrationID, req.OrderID, precert.SerialNumber, certDER, int64(issuer.Cert.NameID()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Update the CA to store the IssuerNameID instead of the IssuerID in the
issuerID column of the certificateStatus table. This value will be
blindly plumbed through by ocsp-updater to the CA's OCSP component,
which will handle it correctly.

Depends on #5515
Part of #5152