### PR TITLE
BDNS: Ensure DNS server addresses are dialable 

### DIFF
--- a/bdns/servers_test.go
+++ b/bdns/servers_test.go
@@ -1,0 +1,62 @@
+package bdns
+
+import (
+	"testing"
+)
+
+func Test_validateServerAddress(t *testing.T) {
+	type args struct {
+		server string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// ipv4 cases
+		{"ipv4 with port", args{"1.1.1.1:53"}, false},
+		// sad path
+		{"ipv4 without port", args{"1.1.1.1"}, true},
+		{"ipv4 port num missing", args{"1.1.1.1:"}, true},
+		{"ipv4 string for port", args{"1.1.1.1:foo"}, true},
+		{"ipv4 port out of range high", args{"1.1.1.1:65536"}, true},
+		{"ipv4 port out of range low", args{"1.1.1.1:0"}, true},
+
+		// ipv6 cases
+		{"ipv6 with port", args{"[2606:4700:4700::1111]:53"}, false},
+		// sad path
+		{"ipv6 sans brackets", args{"2606:4700:4700::1111:53"}, true},
+		{"ipv6 without port", args{"[2606:4700:4700::1111]"}, true},
+		{"ipv6 port num missing", args{"[2606:4700:4700::1111]:"}, true},
+		{"ipv6 string for port", args{"[2606:4700:4700::1111]:foo"}, true},
+		{"ipv6 port out of range high", args{"[2606:4700:4700::1111]:65536"}, true},
+		{"ipv6 port out of range low", args{"[2606:4700:4700::1111]:0"}, true},
+
+		// hostname cases
+		{"hostname with port", args{"foo:53"}, false},
+		// sad path
+		{"hostname without port", args{"foo"}, true},
+		{"hostname port num missing", args{"foo:"}, true},
+		{"hostname string for port", args{"foo:bar"}, true},
+		{"hostname port out of range high", args{"foo:65536"}, true},
+		{"hostname port out of range low", args{"foo:0"}, true},
+
+		// fqdn cases
+		{"fqdn with port", args{"bar.foo.baz:53"}, false},
+		// sad path
+		{"fqdn without port", args{"bar.foo.baz"}, true},
+		{"fqdn port num missing", args{"bar.foo.baz:"}, true},
+		{"fqdn string for port", args{"bar.foo.baz:bar"}, true},
+		{"fqdn port out of range high", args{"bar.foo.baz:65536"}, true},
+		{"fqdn port out of range low", args{"bar.foo.baz:0"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServerAddress(tt.args.server)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("formatServer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -128,7 +128,8 @@ func main() {
 		servers, err = bdns.StartDynamicProvider(c.VA.DNSResolver, 60*time.Second)
 		cmd.FailOnError(err, "Couldn't start dynamic DNS server resolver")
 	} else {
-		servers = bdns.NewStaticProvider(c.VA.DNSResolvers)
+		servers, err = bdns.NewStaticProvider(c.VA.DNSResolvers)
+		cmd.FailOnError(err, "Couldn't parse static DNS server(s)")
 	}
 
 	var resolver bdns.Client

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -136,9 +136,12 @@ func TestDNSValidationServFail(t *testing.T) {
 
 func TestDNSValidationNoServer(t *testing.T) {
 	va, log := setup(nil, 0, "", nil)
+	staticProvider, err := bdns.NewStaticProvider([]string{})
+	test.AssertNotError(t, err, "Couldn't make new static provider")
+
 	va.dnsClient = bdns.NewTest(
 		time.Second*5,
-		bdns.NewStaticProvider([]string{}),
+		staticProvider,
 		metrics.NoopRegisterer,
 		clock.New(),
 		1,


### PR DESCRIPTION
- Add function `validateServerAddress()` to `bdns/servers.go` which ensures that
  DNS server addresses are TCP/ UDP dial-able per: https://golang.org/src/net/dial.go?#L281
- Add unit test for `validateServerAddress()` in `bdns/servers_test.go`
- Update `cmd/boulder-va/main.go` to handle `bdns.NewStaticProvider()`
  potentially returning an error.
- Update unit tests in `bdns/dns_test.go`:
  - Handle `bdns.NewStaticProvider()` potentially returning an error
  - Add an IPv6 address to `TestRotateServerOnErr`
- Ensure DNS server addresses are validated by `validateServerAddress` whenever:
  - `dynamicProvider.update() is called`
  - `staticProvider` is constructed
- Construct server addresses using `net.JoinHostPost()` when
  `dynamicProvider.Addrs()` is called

Fixes #5463 