### PR TITLE
GRPC: Log user-initiated cancellations as HTTP 408

### DIFF
--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -202,16 +202,16 @@ func (ci *clientInterceptor) intercept(
 	err := invoker(localCtx, fullMethod, req, reply, cc, opts...)
 	if err != nil {
 		err = unwrapError(err, respMD)
-	}
-	if status.Code(err) == codes.DeadlineExceeded {
-		return deadlineDetails{
-			service: service,
-			method:  method,
-			latency: ci.clk.Since(begin),
+		switch status.Code(err) {
+		case codes.DeadlineExceeded:
+			return deadlineDetails{
+				service: service,
+				method:  method,
+				latency: ci.clk.Since(begin),
+			}
+		case codes.Canceled:
+			return probs.Canceled(err.Error())
 		}
-	}
-	if status.Code(err) == codes.Canceled {
-		return probs.Canceled(err.Error())
 	}
 	return err
 }

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/probs"
 )
 
 const (
@@ -208,6 +209,9 @@ func (ci *clientInterceptor) intercept(
 			method:  method,
 			latency: ci.clk.Since(begin),
 		}
+	}
+	if status.Code(err) == codes.Canceled {
+		return probs.Canceled(err.Error())
 	}
 	return err
 }

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -27,6 +27,7 @@ const (
 	BadPublicKeyProblem          = ProblemType("badPublicKey")
 	BadRevocationReasonProblem   = ProblemType("badRevocationReason")
 	BadCSRProblem                = ProblemType("badCSR")
+	CanceledProblem              = ProblemType("requesterCanceled")
 
 	V1ErrorNS = "urn:acme:error:"
 	V2ErrorNS = "urn:ietf:params:acme:error:"
@@ -158,6 +159,19 @@ func Malformed(detail string, args ...interface{}) *ProblemDetails {
 		Type:       MalformedProblem,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// Canceled returns a ProblemDetails with a CanceledProblem and a 408 Request
+// Timeout status code.
+func Canceled(detail string, args ...interface{}) *ProblemDetails {
+	if len(args) > 0 {
+		detail = fmt.Sprintf(detail, args...)
+	}
+	return &ProblemDetails{
+		Type:       CanceledProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusRequestTimeout,
 	}
 }
 

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -27,7 +27,6 @@ const (
 	BadPublicKeyProblem          = ProblemType("badPublicKey")
 	BadRevocationReasonProblem   = ProblemType("badRevocationReason")
 	BadCSRProblem                = ProblemType("badCSR")
-	CanceledProblem              = ProblemType("requesterCanceled")
 
 	V1ErrorNS = "urn:acme:error:"
 	V2ErrorNS = "urn:ietf:params:acme:error:"
@@ -162,14 +161,14 @@ func Malformed(detail string, args ...interface{}) *ProblemDetails {
 	}
 }
 
-// Canceled returns a ProblemDetails with a CanceledProblem and a 408 Request
+// Canceled returns a ProblemDetails with a MalformedProblem and a 408 Request
 // Timeout status code.
 func Canceled(detail string, args ...interface{}) *ProblemDetails {
 	if len(args) > 0 {
 		detail = fmt.Sprintf(detail, args...)
 	}
 	return &ProblemDetails{
-		Type:       CanceledProblem,
+		Type:       MalformedProblem,
 		Detail:     detail,
 		HTTPStatus: http.StatusRequestTimeout,
 	}


### PR DESCRIPTION
- Log user-initiated cancellations as HTTP 408 instead of HTTP 500
- Only check status code of `err` if an error was intercepted

Fixes #5444