### PR TITLE
Add a minimum loop duration to the bad-key-revoker

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -475,7 +475,7 @@ func main() {
 		} else {
 			if noWork {
 				logger.Info(fmt.Sprintf(
-					"No work to do. Sleeping for %s", config.BadKeyRevoker.Interval.Duration))
+					"No work to do. Sleeping for at most %s", config.BadKeyRevoker.Interval.Duration))
 			} else {
 				keysProcessed.WithLabelValues("success").Inc()
 			}


### PR DESCRIPTION
Fixes #5559 so that we don't tight-loop when an error occurs. This also makes scheduling more predictable for ops, too, compared to a pure sleep.