### PR TITLE
cert-checker: avoid accidentally mis-ordered certs

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -114,8 +114,7 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 
 	args := map[string]interface{}{"issued": c.issuedReport.begin, "now": 0}
 	if unexpiredOnly {
-		now := c.clock.Now()
-		args["now"] = now
+		args["now"] = c.clock.Now()
 	}
 	count, err := c.dbMap.SelectInt(
 		"SELECT count(*) FROM certificates WHERE issued >= :issued AND expires >= :now",
@@ -145,7 +144,7 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 	for offset := 0; offset < int(count); {
 		certs, err := sa.SelectCertificates(
 			c.dbMap,
-			"WHERE id > :id AND expires >= :now ORDER BY id LIMIT :limit",
+			"WHERE id > :id AND issued >= :issued AND expires >= :now ORDER BY id LIMIT :limit",
 			args,
 		)
 		if err != nil {


### PR DESCRIPTION
It's possible for an AUTO_INCREMENT database field (such as the ID
field on the Certificates table) to not actually be monotonically
increasing. As such, it is possible for cert-checker to get into a
state where it correctly queries for the number of certs it has to
process and the minimum ID from among those certs, but then actually
retrieves much older certs when querying for them just by ID.

Update cert-checker's query to predicate on id, expiry, and issuance
time, to avoid checking certs which were issued a significant time in
the past.

Part of #5541