### PR TITLE
Invert caa-log-checker's processing to save memory

### DIFF
--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -7,16 +7,27 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
 )
 
-var debug = flag.Bool("debug", false, "Enable debug logging")
+var raIssuanceLineRE = regexp.MustCompile(`Certificate request - successful JSON=(.*)`)
+
+// TODO: Extract the "Valid for issuance: (true|false)" field too.
+var vaCAALineRE = regexp.MustCompile(`Checked CAA records for ([a-z0-9-.*]+), \[Present: (true|false)`)
+
+type issuanceEvent struct {
+	SerialNumber string
+	Names        []string
+	Requester    int64
+
+	issuanceTime time.Time
+}
 
 func openFile(path string) (*bufio.Scanner, error) {
 	f, err := os.Open(path)
@@ -35,16 +46,6 @@ func openFile(path string) (*bufio.Scanner, error) {
 	return scanner, nil
 }
 
-type issuanceEvent struct {
-	SerialNumber string
-	Names        []string
-	Requester    int64
-
-	issuanceTime time.Time
-}
-
-var raIssuanceLineRE = regexp.MustCompile(`Certificate request - successful JSON=(.*)`)
-
 func parseTimestamp(line string) (time.Time, error) {
 	datestampText := line[0:32]
 	datestamp, err := time.Parse(time.RFC3339, datestampText)
@@ -54,138 +55,151 @@ func parseTimestamp(line string) (time.Time, error) {
 	return datestamp, nil
 }
 
-func checkIssuances(scanner *bufio.Scanner, checkedMap map[string][]time.Time, timeTolerance time.Duration,
-	earliest time.Time, latest time.Time, stderr *os.File) (bool, error) {
-	linesRead := 0
-	skipCount := 0
-	evaluatedCount := 0
-	foundErrors := false
+// loadIssuanceLog processes a single issuance (RA) log file. It returns a map
+// of names to slices of timestamps at which certificates for those names were
+// issued.
+// TODO: plumb through earliest and latest for parity with old implementation.
+func loadIssuanceLog(path string) (map[string][]time.Time, error) {
+	scanner, err := openFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %q: %w", path, err)
+	}
+
+	linesCount := 0
+	issuancesCount := 0
+
+	issuanceMap := map[string][]time.Time{}
 	for scanner.Scan() {
-		linesRead++
 		line := scanner.Text()
+		linesCount++
+
 		matches := raIssuanceLineRE.FindStringSubmatch(line)
 		if matches == nil {
 			continue
 		}
 		if len(matches) != 2 {
-			return foundErrors, fmt.Errorf("line %d: unexpected number of regex matches", linesRead)
+			return nil, fmt.Errorf("line %d: unexpected number of regex matches", linesCount)
 		}
+
 		var ie issuanceEvent
 		err := json.Unmarshal([]byte(matches[1]), &ie)
 		if err != nil {
-			return foundErrors, fmt.Errorf("line %d: failed to unmarshal JSON: %s", linesRead, err)
+			return nil, fmt.Errorf("line %d: failed to unmarshal JSON: %w", linesCount, err)
 		}
 
-		// populate the issuance time from the syslog timestamp, rather than the ResponseTime
-		// member of the JSON. This makes testing a lot simpler because of how we mess with
-		// time sometimes. Given these timestamps are generated on the same system they should
-		// be tightly coupled anyway.
+		// Populate the issuance time from the syslog timestamp, rather than the
+		// ResponseTime member of the JSON. This makes testing a lot simpler because
+		// of how we mess with time sometimes. Given that these timestamps are
+		// generated on the same system, they should be tightly coupled anyway.
 		ie.issuanceTime, err = parseTimestamp(line)
 		if err != nil {
-			return foundErrors, fmt.Errorf("line %d: failed to parse timestamp: %s", linesRead, err)
+			return nil, fmt.Errorf("line %d: failed to parse timestamp: %w", linesCount, err)
 		}
 
-		if !earliest.IsZero() && !latest.IsZero() &&
-			(ie.issuanceTime.Before(earliest) || ie.issuanceTime.After(latest)) {
-			skipCount++
-			continue
-		}
-		evaluatedCount++
-
-		var badNames []string
-		var timeErrors []float64
-
+		issuancesCount++
 		for _, name := range ie.Names {
-			nameOk := false
-
-			var minTimeError float64 = math.Inf(+1)
-
-			for _, t := range checkedMap[name] {
-				validStart := ie.issuanceTime.Add(-8 * time.Hour)
-				validEnd := ie.issuanceTime
-				if t.After(validStart) && t.Before(validEnd.Add(timeTolerance)) {
-					nameOk = true
-				} else if t.After(validStart) {
-					// If the check didn't pass and the check is in the future, calculate how much tolerance
-					// we'd need for it to pass, to make it easier to diagnose log timestamp desync.
-					timeError := t.Sub(validEnd)
-					// ...however only if its <1h, otherwise it's probably not a match
-					if timeError < timeTolerance+time.Hour {
-						minTimeError = math.Min(minTimeError, float64(timeError)/float64(time.Second))
-					}
-				}
-			}
-			if !nameOk {
-				badNames = append(badNames, name)
-				timeErrors = append(timeErrors, minTimeError)
-			}
-		}
-		if len(badNames) > 0 {
-			foundErrors = true
-			fmt.Fprintf(stderr, "Issuance missing CAA checks: issued at=%s, serial=%s, requester=%d, names=%s, missing checks for names=%s, timeError=%.3f\n", ie.issuanceTime, ie.SerialNumber, ie.Requester, ie.Names, badNames, timeErrors)
+			issuanceMap[name] = append(issuanceMap[name], ie.issuanceTime)
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return foundErrors, err
+		return nil, err
 	}
-	if *debug {
-		fmt.Fprintf(stderr, "Issuance log lines read %d evaluated %d skipped %d\n", linesRead, evaluatedCount, skipCount)
-	}
-	return foundErrors, nil
+
+	return issuanceMap, nil
 }
 
-var vaCAALineRE = regexp.MustCompile(`Checked CAA records for ([a-z0-9-.*]+), \[Present: (true|false)`)
+// processCAALog processes a single CAA (VA) log file. It modifies the input map
+// (of issuance names to times, as returned by `loadIssuanceLog`) to remove any
+// timestamps which are covered by (i.e. less than 8 hours after) a CAA check
+// for that name in the log file. It also prunes any names whose slice of
+// issuance times becomes empty.
+func processCAALog(path string, issuances map[string][]time.Time) error {
+	scanner, err := openFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %w", path, err)
+	}
 
-func processVALog(checkedMap map[string][]time.Time, scanner *bufio.Scanner) error {
-	lNum := 0
+	linesCount := 0
+
 	for scanner.Scan() {
-		lNum++
 		line := scanner.Text()
+		linesCount++
+
 		matches := vaCAALineRE.FindStringSubmatch(line)
 		if matches == nil {
 			continue
 		}
 		if len(matches) != 3 {
-			return fmt.Errorf("line %d: unexpected number of regex matches", lNum)
+			return fmt.Errorf("line %d: unexpected number of regex matches", linesCount)
 		}
-		domain := matches[1]
-		labels := strings.Split(domain, ".")
+		name := matches[1]
 		present := matches[2]
 
-		datestamp, err := parseTimestamp(line)
+		checkTime, err := parseTimestamp(line)
 		if err != nil {
-			return fmt.Errorf("line %d: failed to parse timestamp: %s", lNum, err)
+			return fmt.Errorf("line %d: failed to parse timestamp: %w", linesCount, err)
 		}
 
-		checkedMap[domain] = append(checkedMap[domain], datestamp)
-		// If we checked x.y.z, and the result was Present: false, that means we
-		// also checked y.z and z, and found no records there.
-		// We'll add y.z to the map, but not z (to save memory space, since we don't issue
-		// for z).
+		// TODO: Only remove covered issuance timestamps if the CAA check actually
+		// said that we're allowed to issue (i.e. had "Valid for issuance: true").
+		issuances[name] = removeCoveredTimestamps(issuances[name], checkTime)
+		if len(issuances[name]) == 0 {
+			delete(issuances, name)
+		}
+
+		// If the CAA check didn't find any CAA records for w.x.y.z, then that means
+		// that we checked the CAA records for x.y.z, y.z, and z as well, and are
+		// covered for any issuance for those names.
 		if present == "false" {
+			labels := strings.Split(name, ".")
 			for i := 1; i < len(labels)-1; i++ {
-				parent := strings.Join(labels[i:], ".")
-				checkedMap[parent] = append(checkedMap[parent], datestamp)
+				tailName := strings.Join(labels[i:], ".")
+				issuances[tailName] = removeCoveredTimestamps(issuances[tailName], checkTime)
+				if len(issuances[tailName]) == 0 {
+					delete(issuances, tailName)
+				}
 			}
 		}
 	}
+
 	return scanner.Err()
 }
 
-func loadMap(paths []string) (map[string][]time.Time, error) {
-	var checkedMap = make(map[string][]time.Time)
-
-	for _, path := range paths {
-		scanner, err := openFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open %q: %s", path, err)
+// removeCoveredTimestamps returns a new slice of timestamps which contains all
+// timestamps that are *not* within 8 hours after the input timestamp.
+// TODO: plumb through time-tolerance to account for slight slop.
+func removeCoveredTimestamps(timestamps []time.Time, cover time.Time) []time.Time {
+	r := make([]time.Time, len(timestamps))
+	for _, ts := range timestamps {
+		// Copy the timestamp into the results slice if it is before the covering
+		// timestamp, or more than 8 hours after the covering timestamp (i.e. if
+		// it is *not* covered by the covering timestamp).
+		diff := ts.Sub(cover)
+		if diff < 0 || diff > 8*time.Hour {
+			ts := ts
+			r = append(r, ts)
 		}
-		if err = processVALog(checkedMap, scanner); err != nil {
-			return nil, fmt.Errorf("failed to process %q: %s", path, err)
+	}
+	return r
+}
+
+// formatErrors returns nil if the input map is empty. Otherwise, it returns an
+// error containing a listing of every name and issuance time that was not
+// covered by a CAA check.
+func formatErrors(remaining map[string][]time.Time) error {
+	if len(remaining) == 0 {
+		return nil
+	}
+
+	messages := make([]string, len(remaining))
+	for name, timestamps := range remaining {
+		for _, timestamp := range timestamps {
+			messages = append(messages, fmt.Sprintf("%v: %s", timestamp, name))
 		}
 	}
 
-	return checkedMap, nil
+	sort.Strings(messages)
+	return fmt.Errorf("\n%s", strings.Join(messages, "\n"))
 }
 
 func main() {
@@ -227,18 +241,17 @@ func main() {
 		SyslogLevel: *logSyslogLevel,
 	})
 
-	// Build a map from hostnames to a list of times those hostnames were checked
-	// for CAA.
-	checkedMap, err := loadMap(strings.Split(*vaLogs, ","))
-	cmd.FailOnError(err, "failed while loading VA logs")
+	// Build a map from hostnames to times at which those names were issued for.
+	issuanceMap, err := loadIssuanceLog(*raLog)
+	cmd.FailOnError(err, "failed to load issuance logs")
 
-	raScanner, err := openFile(*raLog)
-	cmd.FailOnError(err, fmt.Sprintf("failed to open %q", *raLog))
-
-	foundErrors, err := checkIssuances(raScanner, checkedMap, *timeTolerance, earliest, latest, os.Stderr)
-	cmd.FailOnError(err, "failed while processing RA log")
-
-	if foundErrors {
-		os.Exit(1)
+	// Try to pare the issuance map down to nothing by removing every entry which
+	// is covered by a CAA check.
+	for _, vaLog := range strings.Split(*vaLogs, ",") {
+		err = processCAALog(vaLog, issuanceMap)
+		cmd.FailOnError(err, "failed to process CAA checking logs")
 	}
+
+	err = formatErrors(issuanceMap)
+	cmd.FailOnError(err, "the following issuances were missing CAA checks")
 }

--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -180,7 +180,7 @@ func processCAALog(path string, issuances map[string][]time.Time, earliest time.
 // removeCoveredTimestamps returns a new slice of timestamps which contains all
 // timestamps that are *not* within 8 hours after the input timestamp.
 func removeCoveredTimestamps(timestamps []time.Time, cover time.Time, tolerance time.Duration) []time.Time {
-	r := make([]time.Time, len(timestamps))
+	r := make([]time.Time, 0)
 	for _, ts := range timestamps {
 		// Copy the timestamp into the results slice if it is before the covering
 		// timestamp, or more than 8 hours after the covering timestamp (i.e. if
@@ -258,7 +258,7 @@ func main() {
 	// Try to pare the issuance map down to nothing by removing every entry which
 	// is covered by a CAA check.
 	for _, vaLog := range strings.Split(*vaLogs, ",") {
-		err = processCAALog(vaLog, issuanceMap, earliest, latest, timeTolerance)
+		err = processCAALog(vaLog, issuanceMap, earliest, latest, *timeTolerance)
 		cmd.FailOnError(err, "failed to process CAA checking logs")
 	}
 

--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -229,7 +229,7 @@ func main() {
 	}
 
 	if *earliestFlag != "" || *latestFlag != "" {
-		fmt.Printf("The -earliest and -lastest flags are deprecated and ignored.")
+		fmt.Printf("The -earliest and -latest flags are deprecated and ignored.")
 	}
 
 	_ = cmd.NewLogger(cmd.SyslogConfig{

--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -57,16 +57,17 @@ func parseTimestamp(line string) (time.Time, error) {
 
 // loadIssuanceLog processes a single issuance (RA) log file. It returns a map
 // of names to slices of timestamps at which certificates for those names were
-// issued.
-// TODO: plumb through earliest and latest for parity with old implementation.
-func loadIssuanceLog(path string) (map[string][]time.Time, error) {
+// issued. It also returns the earliest and latest timestamps seen, to allow
+// CAA log processing to quickly skip irrelevant entries.
+func loadIssuanceLog(path string) (map[string][]time.Time, time.Time, time.Time, error) {
 	scanner, err := openFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open %q: %w", path, err)
+		return nil, time.Time{}, time.Time{}, fmt.Errorf("failed to open %q: %w", path, err)
 	}
 
 	linesCount := 0
-	issuancesCount := 0
+	earliest := time.Time{}
+	latest := time.Time{}
 
 	issuanceMap := map[string][]time.Time{}
 	for scanner.Scan() {
@@ -78,13 +79,13 @@ func loadIssuanceLog(path string) (map[string][]time.Time, error) {
 			continue
 		}
 		if len(matches) != 2 {
-			return nil, fmt.Errorf("line %d: unexpected number of regex matches", linesCount)
+			return nil, earliest, latest, fmt.Errorf("line %d: unexpected number of regex matches", linesCount)
 		}
 
 		var ie issuanceEvent
 		err := json.Unmarshal([]byte(matches[1]), &ie)
 		if err != nil {
-			return nil, fmt.Errorf("line %d: failed to unmarshal JSON: %w", linesCount, err)
+			return nil, earliest, latest, fmt.Errorf("line %d: failed to unmarshal JSON: %w", linesCount, err)
 		}
 
 		// Populate the issuance time from the syslog timestamp, rather than the
@@ -93,19 +94,24 @@ func loadIssuanceLog(path string) (map[string][]time.Time, error) {
 		// generated on the same system, they should be tightly coupled anyway.
 		ie.issuanceTime, err = parseTimestamp(line)
 		if err != nil {
-			return nil, fmt.Errorf("line %d: failed to parse timestamp: %w", linesCount, err)
+			return nil, earliest, latest, fmt.Errorf("line %d: failed to parse timestamp: %w", linesCount, err)
 		}
 
-		issuancesCount++
+		if earliest.IsZero() || ie.issuanceTime.Before(earliest) {
+			earliest = ie.issuanceTime
+		}
+		if latest.IsZero() || ie.issuanceTime.After(latest) {
+			latest = ie.issuanceTime
+		}
 		for _, name := range ie.Names {
 			issuanceMap[name] = append(issuanceMap[name], ie.issuanceTime)
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return nil, earliest, latest, err
 	}
 
-	return issuanceMap, nil
+	return issuanceMap, earliest, latest, nil
 }
 
 // processCAALog processes a single CAA (VA) log file. It modifies the input map
@@ -113,7 +119,7 @@ func loadIssuanceLog(path string) (map[string][]time.Time, error) {
 // timestamps which are covered by (i.e. less than 8 hours after) a CAA check
 // for that name in the log file. It also prunes any names whose slice of
 // issuance times becomes empty.
-func processCAALog(path string, issuances map[string][]time.Time) error {
+func processCAALog(path string, issuances map[string][]time.Time, earliest time.Time, latest time.Time, tolerance time.Duration) error {
 	scanner, err := openFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to open %q: %w", path, err)
@@ -140,9 +146,15 @@ func processCAALog(path string, issuances map[string][]time.Time) error {
 			return fmt.Errorf("line %d: failed to parse timestamp: %w", linesCount, err)
 		}
 
+		// Don't bother processing rows that definitely fall outside the period we
+		// care about.
+		if checkTime.After(latest) || checkTime.Before(earliest.Add(-8*time.Hour)) {
+			continue
+		}
+
 		// TODO: Only remove covered issuance timestamps if the CAA check actually
 		// said that we're allowed to issue (i.e. had "Valid for issuance: true").
-		issuances[name] = removeCoveredTimestamps(issuances[name], checkTime)
+		issuances[name] = removeCoveredTimestamps(issuances[name], checkTime, tolerance)
 		if len(issuances[name]) == 0 {
 			delete(issuances, name)
 		}
@@ -154,7 +166,7 @@ func processCAALog(path string, issuances map[string][]time.Time) error {
 			labels := strings.Split(name, ".")
 			for i := 1; i < len(labels)-1; i++ {
 				tailName := strings.Join(labels[i:], ".")
-				issuances[tailName] = removeCoveredTimestamps(issuances[tailName], checkTime)
+				issuances[tailName] = removeCoveredTimestamps(issuances[tailName], checkTime, tolerance)
 				if len(issuances[tailName]) == 0 {
 					delete(issuances, tailName)
 				}
@@ -167,15 +179,14 @@ func processCAALog(path string, issuances map[string][]time.Time) error {
 
 // removeCoveredTimestamps returns a new slice of timestamps which contains all
 // timestamps that are *not* within 8 hours after the input timestamp.
-// TODO: plumb through time-tolerance to account for slight slop.
-func removeCoveredTimestamps(timestamps []time.Time, cover time.Time) []time.Time {
+func removeCoveredTimestamps(timestamps []time.Time, cover time.Time, tolerance time.Duration) []time.Time {
 	r := make([]time.Time, len(timestamps))
 	for _, ts := range timestamps {
 		// Copy the timestamp into the results slice if it is before the covering
 		// timestamp, or more than 8 hours after the covering timestamp (i.e. if
 		// it is *not* covered by the covering timestamp).
 		diff := ts.Sub(cover)
-		if diff < 0 || diff > 8*time.Hour {
+		if diff < -tolerance || diff > 8*time.Hour+tolerance {
 			ts := ts
 			r = append(r, ts)
 		}
@@ -208,10 +219,8 @@ func main() {
 	raLog := flag.String("ra-log", "", "Path to a single boulder-ra log file")
 	vaLogs := flag.String("va-logs", "", "List of paths to boulder-va logs, separated by commas")
 	timeTolerance := flag.Duration("time-tolerance", 0, "How much slop to allow when comparing timestamps for ordering")
-	earliestFlag := flag.String("earliest", "", "Day at which to start checking issuances "+
-		"(inclusive). Formatted like '20060102' Optional. If specified, -latest is required.")
-	latestFlag := flag.String("latest", "", "Day at which to stop checking issuances "+
-		"(exclusive). Formatted like '20060102'. Optional. If specified, -earliest is required.")
+	earliestFlag := flag.String("earliest", "", "Deprecated.")
+	latestFlag := flag.String("latest", "", "Deprecated.")
 
 	flag.Parse()
 
@@ -222,6 +231,7 @@ func main() {
 	var earliest time.Time
 	var latest time.Time
 	if *earliestFlag != "" || *latestFlag != "" {
+		fmt.Printf("The -earliest and -lastest flags are deprecated and ignored.")
 		if *earliestFlag == "" || *latestFlag == "" {
 			cmd.Fail("-earliest and -latest must be both set or both unset")
 		}
@@ -242,13 +252,13 @@ func main() {
 	})
 
 	// Build a map from hostnames to times at which those names were issued for.
-	issuanceMap, err := loadIssuanceLog(*raLog)
+	issuanceMap, earliest, latest, err := loadIssuanceLog(*raLog)
 	cmd.FailOnError(err, "failed to load issuance logs")
 
 	// Try to pare the issuance map down to nothing by removing every entry which
 	// is covered by a CAA check.
 	for _, vaLog := range strings.Split(*vaLogs, ",") {
-		err = processCAALog(vaLog, issuanceMap)
+		err = processCAALog(vaLog, issuanceMap, earliest, latest, timeTolerance)
 		cmd.FailOnError(err, "failed to process CAA checking logs")
 	}
 

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -26,7 +26,7 @@ func TestCAALogChecker(t *testing.T) {
 	test.AssertEquals(t, len(result.Order.Authorizations), 1)
 
 	// Should be no specific output, since everything is good
-	cmd := exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", "/var/log/boulder-va.log", "-earliest", "19010101", "-latest", "30000101")
+	cmd := exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", "/var/log/boulder-va.log")
 	var stdErr bytes.Buffer
 	cmd.Stderr = &stdErr
 	out, err := cmd.Output()


### PR DESCRIPTION
Previously, caa-log-checker's core algorithm was:
1) Load every single VA (CAA) log file, producing an in-memory map of
   names to the time at which they were checked
2) Iterate over the RA (Issuance) log file, checking each issuance event
   to see if it occurred less than 8 hours after an event in the
   in-memory map.

This consumes significant memory, as the map of all CAA checks is
redundant (contains entries for w.x.y.z, x.y.z, and y.z) and holds
unnecessary data (contains entries for CAA checks that occurred much
more than 8 hours before or after any issuance in the RA log).

Invert this algorithm, as such:
1) Load the RA (Issuance) log file, producing an in-memory map of names
   to the time at which they were issued
2) Iterate over each VA (CAA) log file, removing entries from the
   in-memory map if they occurred less than 8 hours after the current
   CAA checking event.

This reduces the memory consumption of caa-log-checker, because the
total number of issuance events is much smaller and the map does not
need to hold redundant data. The tradeoff is that caa-log-checker can no
longer print partial output as it runs; all results are held until the
very end, when it can inspect the in-memory map to see if it is empty.

Fixes #5552