### PR TITLE
Only convert gRPC cancellations into 408s at WFEs

### DIFF
--- a/cmd/boulder-wfe/main.go
+++ b/cmd/boulder-wfe/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
+	"github.com/letsencrypt/boulder/grpc"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
@@ -84,23 +85,23 @@ func setupWFE(c config, logger blog.Logger, stats prometheus.Registerer, clk clo
 	cmd.FailOnError(err, "TLS config")
 
 	clientMetrics := bgrpc.NewClientMetrics(stats)
-	raConn, err := bgrpc.ClientSetup(c.WFE.RAService, tlsConfig, clientMetrics, clk)
+	raConn, err := bgrpc.ClientSetup(c.WFE.RAService, tlsConfig, clientMetrics, clk, grpc.CancelTo408Interceptor)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to RA")
 	rac := bgrpc.NewRegistrationAuthorityClient(rapb.NewRegistrationAuthorityClient(raConn))
 
-	saConn, err := bgrpc.ClientSetup(c.WFE.SAService, tlsConfig, clientMetrics, clk)
+	saConn, err := bgrpc.ClientSetup(c.WFE.SAService, tlsConfig, clientMetrics, clk, grpc.CancelTo408Interceptor)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := bgrpc.NewStorageAuthorityClient(sapb.NewStorageAuthorityClient(saConn))
 
 	var rns noncepb.NonceServiceClient
 	npm := map[string]noncepb.NonceServiceClient{}
 	if c.WFE.GetNonceService != nil {
-		rnsConn, err := bgrpc.ClientSetup(c.WFE.GetNonceService, tlsConfig, clientMetrics, clk)
+		rnsConn, err := bgrpc.ClientSetup(c.WFE.GetNonceService, tlsConfig, clientMetrics, clk, grpc.CancelTo408Interceptor)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to get nonce service")
 		rns = noncepb.NewNonceServiceClient(rnsConn)
 		for prefix, serviceConfig := range c.WFE.RedeemNonceServices {
 			serviceConfig := serviceConfig
-			conn, err := bgrpc.ClientSetup(&serviceConfig, tlsConfig, clientMetrics, clk)
+			conn, err := bgrpc.ClientSetup(&serviceConfig, tlsConfig, clientMetrics, clk, grpc.CancelTo408Interceptor)
 			cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to redeem nonce service")
 			npm[prefix] = noncepb.NewNonceServiceClient(conn)
 		}

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -22,7 +22,7 @@ import (
 // a client certificate and validates the the server certificate based
 // on the provided *tls.Config.
 // It dials the remote service and returns a grpc.ClientConn if successful.
-func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientMetrics, clk clock.Clock) (*grpc.ClientConn, error) {
+func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientMetrics, clk clock.Clock, interceptors ...grpc.UnaryClientInterceptor) (*grpc.ClientConn, error) {
 	if c == nil {
 		return nil, errors.New("nil gRPC client config provided. JSON config is probably missing a fooService section.")
 	}
@@ -34,6 +34,12 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientM
 	}
 
 	ci := clientInterceptor{c.Timeout.Duration, metrics, clk}
+	allInterceptors := []grpc.UnaryClientInterceptor{
+		ci.intercept,
+		ci.metrics.grpcMetrics.UnaryClientInterceptor(),
+		hnygrpc.UnaryClientInterceptor(),
+	}
+	allInterceptors = append(allInterceptors, interceptors...)
 	host, _, err := net.SplitHostPort(c.ServerAddress)
 	if err != nil {
 		return nil, err
@@ -43,11 +49,7 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientM
 		"dns:///"+c.ServerAddress,
 		grpc.WithBalancerName("round_robin"),
 		grpc.WithTransportCredentials(creds),
-		grpc.WithChainUnaryInterceptor(
-			ci.intercept,
-			ci.metrics.grpcMetrics.UnaryClientInterceptor(),
-			hnygrpc.UnaryClientInterceptor(),
-		),
+		grpc.WithChainUnaryInterceptor(allInterceptors...),
 	)
 }
 

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -39,7 +39,7 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientM
 		ci.metrics.grpcMetrics.UnaryClientInterceptor(),
 		hnygrpc.UnaryClientInterceptor(),
 	}
-	allInterceptors = append(allInterceptors, interceptors...)
+	allInterceptors = append(interceptors, allInterceptors...)
 	host, _, err := net.SplitHostPort(c.ServerAddress)
 	if err != nil {
 		return nil, err

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -202,16 +202,27 @@ func (ci *clientInterceptor) intercept(
 	err := invoker(localCtx, fullMethod, req, reply, cc, opts...)
 	if err != nil {
 		err = unwrapError(err, respMD)
-		switch status.Code(err) {
-		case codes.DeadlineExceeded:
+		if status.Code(err) == codes.DeadlineExceeded {
 			return deadlineDetails{
 				service: service,
 				method:  method,
 				latency: ci.clk.Since(begin),
 			}
-		case codes.Canceled:
-			return probs.Canceled(err.Error())
 		}
+	}
+	return err
+}
+
+// CancelTo408Interceptor calls the underlying invoker, checks to see if the
+// resulting error was a gRPC Cancelled error (because this client cancelled
+// the request, likely because the ACME client itself cancelled the HTTP
+// request), and converts that into a Problem which can be "returned" to the
+// (now missing) client, and into our logs. This should be the outermost client
+// interceptor, and should only be enabled in the WFEs.
+func CancelTo408Interceptor(ctx context.Context, fullMethod string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	err := invoker(ctx, fullMethod, req, reply, cc, opts...)
+	if err != nil && status.Code(err) == codes.Canceled {
+		return probs.Canceled(err.Error())
 	}
 	return err
 }

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -214,8 +214,8 @@ func (ci *clientInterceptor) intercept(
 }
 
 // CancelTo408Interceptor calls the underlying invoker, checks to see if the
-// resulting error was a gRPC Cancelled error (because this client cancelled
-// the request, likely because the ACME client itself cancelled the HTTP
+// resulting error was a gRPC Canceled error (because this client cancelled
+// the request, likely because the ACME client itself canceled the HTTP
 // request), and converts that into a Problem which can be "returned" to the
 // (now missing) client, and into our logs. This should be the outermost client
 // interceptor, and should only be enabled in the WFEs.

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -77,9 +77,14 @@ func TestClientInterceptor(t *testing.T) {
 
 	err = ci.intercept(context.Background(), "-service-brokeTest", nil, nil, nil, testInvoker)
 	test.AssertError(t, err, "ci.intercept didn't fail when handler returned a error")
+}
 
-	err = ci.intercept(context.Background(), "-service-requesterCanceledTest", nil, nil, nil, testInvoker)
-	test.AssertError(t, err, "ci.intercept didn't fail when handler returned a error")
+func TestCancelTo408Interceptor(t *testing.T) {
+	err := CancelTo408Interceptor(context.Background(), "-service-test", nil, nil, nil, testInvoker)
+	test.AssertNotError(t, err, "CancelTo408Interceptor returned an error when it shouldn't")
+
+	err = CancelTo408Interceptor(context.Background(), "-service-requesterCanceledTest", nil, nil, nil, testInvoker)
+	test.AssertError(t, err, "CancelTo408Interceptor didn't return an error when it should")
 
 	var probDetails *probs.ProblemDetails
 	test.AssertErrorWraps(t, err, &probDetails)


### PR DESCRIPTION
Pull the "was the gRPC error a Canceled error" checking code out into a
separate interceptor, and add that interceptor only in the wfe and wfe2
gRPC clients.

Although the vast majority of our cancelations come from the HTTP client
disconnecting (and that cancelation being propagated through our gRPC
stack), there are a few other situations in which we cancel gRPC
connections, including when we receive a quorum of responses from VAs
and no longer need responses from the remaining remote VA(s). This
change ensures that we do not treat those other kinds of cancelations in
the same way that we treat client-initiated cancelations.

Fixes #5444