### PR TITLE
Batch multiple authz into single SQL statements

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -418,7 +418,8 @@ func statusUint(status core.AcmeStatus) uint8 {
 	return statusToUint[string(status)]
 }
 
-// Changes to this string must be carried through to sa.NewAuthorizations2
+// authzFields is used in a variety of places in sa.go, and modifications to
+// it must be carried through to every use in sa.go
 const authzFields = "id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, token, validationError, validationRecord"
 
 type authzModel struct {

--- a/sa/model.go
+++ b/sa/model.go
@@ -418,6 +418,7 @@ func statusUint(status core.AcmeStatus) uint8 {
 	return statusToUint[string(status)]
 }
 
+// Changes to this string must be carried through to sa.NewAuthorizations2
 const authzFields = "id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, token, validationError, validationRecord"
 
 type authzModel struct {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1380,8 +1380,8 @@ func (ssa *SQLStorageAuthority) NewAuthorizations2(ctx context.Context, req *sap
 		}
 
 		// Each authz needs a (?,?...), in the VALUES block. We need one
-		// for each element in the authzFields string with no trailing ','.
-		fmt.Fprintf(&questionsBuf, "(%s),", strings.TrimRight(strings.Repeat(" ?,", 11), ","))
+		// for each element in the authzFields string.
+		fmt.Fprint(&questionsBuf, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?),")
 
 		// The query arguments must follow the order of the authzFields string.
 		// Note that the AttemptedAt field is not included in the authzFields.
@@ -1413,6 +1413,7 @@ func (ssa *SQLStorageAuthority) NewAuthorizations2(ctx context.Context, req *sap
 		var idField int64
 		err = rows.Scan(&idField)
 		if err != nil {
+			_ = rows.Close()
 			return nil, err
 		}
 		ids.Ids = append(ids.Ids, idField)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1413,7 +1413,7 @@ func (ssa *SQLStorageAuthority) NewAuthorizations2(ctx context.Context, req *sap
 		var idField int64
 		err = rows.Scan(&idField)
 		if err != nil {
-			_ = rows.Close()
+			rows.Close()
 			return nil, err
 		}
 		ids.Ids = append(ids.Ids, idField)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1409,7 +1409,6 @@ func (ssa *SQLStorageAuthority) NewAuthorizations2(ctx context.Context, req *sap
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 	for rows.Next() {
 		var idField int64
 		err = rows.Scan(&idField)
@@ -1417,6 +1416,12 @@ func (ssa *SQLStorageAuthority) NewAuthorizations2(ctx context.Context, req *sap
 			return nil, err
 		}
 		ids.Ids = append(ids.Ids, idField)
+	}
+
+	// Ensure the query wasn't interrupted before it could complete.
+	err = rows.Close()
+	if err != nil {
+		return nil, err
 	}
 	return ids, nil
 }

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1863,7 +1863,7 @@ func TestNewAuthorizations2_100(t *testing.T) {
 	var allAuthz [100]*corepb.Authorization
 
 	for i := 0; i < 100; i++ {
-		all_authz[i] = &corepb.Authorization{
+		allAuthz[i] = &corepb.Authorization{
 			Identifier:     fmt.Sprintf("%08x", i),
 			RegistrationID: reg.Id,
 			Status:         string(core.StatusPending),

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1858,7 +1858,7 @@ func TestNewAuthorizations2_100(t *testing.T) {
 	defer cleanUp()
 
 	reg := satest.CreateWorkingRegistration(t, sa)
-	expires := fc.Now().Add(time.Hour).UTC().UnixNano()
+	expires := fc.Now().Add(time.Hour).UnixNano()
 
 	var allAuthz [100]*corepb.Authorization
 

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1860,8 +1860,7 @@ func TestNewAuthorizations2_100(t *testing.T) {
 	reg := satest.CreateWorkingRegistration(t, sa)
 	expires := fc.Now().Add(time.Hour).UnixNano()
 
-	var allAuthz [100]*corepb.Authorization
-
+	allAuthz := make([]*corepb.Authorization, 100)
 	for i := 0; i < 100; i++ {
 		allAuthz[i] = &corepb.Authorization{
 			Identifier:     fmt.Sprintf("%08x", i),
@@ -1878,7 +1877,7 @@ func TestNewAuthorizations2_100(t *testing.T) {
 		}
 	}
 
-	req := &sapb.AddPendingAuthorizationsRequest{Authz: allAuthz[:]}
+	req := &sapb.AddPendingAuthorizationsRequest{Authz: allAuthz}
 	ids, err := sa.NewAuthorizations2(context.Background(), req)
 	test.AssertNotError(t, err, "sa.NewAuthorizations failed")
 	test.AssertEquals(t, len(ids.Ids), 100)

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1860,7 +1860,7 @@ func TestNewAuthorizations2_100(t *testing.T) {
 	reg := satest.CreateWorkingRegistration(t, sa)
 	expires := fc.Now().Add(time.Hour).UTC().UnixNano()
 
-	var all_authz [100]*corepb.Authorization
+	var allAuthz [100]*corepb.Authorization
 
 	for i := 0; i < 100; i++ {
 		all_authz[i] = &corepb.Authorization{
@@ -1878,7 +1878,7 @@ func TestNewAuthorizations2_100(t *testing.T) {
 		}
 	}
 
-	req := &sapb.AddPendingAuthorizationsRequest{Authz: all_authz[:]}
+	req := &sapb.AddPendingAuthorizationsRequest{Authz: allAuthz[:]}
 	ids, err := sa.NewAuthorizations2(context.Background(), req)
 	test.AssertNotError(t, err, "sa.NewAuthorizations failed")
 	test.AssertEquals(t, len(ids.Ids), 100)
@@ -1886,7 +1886,7 @@ func TestNewAuthorizations2_100(t *testing.T) {
 		id := id
 		dbVer, err := sa.GetAuthorization2(context.Background(), &sapb.AuthorizationID2{Id: id})
 		test.AssertNotError(t, err, "sa.GetAuthorization failed")
-		// Everything but ID should match
+		// Everything but the ID should match.
 		req.Authz[i].Id = dbVer.Id
 		test.AssertDeepEquals(t, req.Authz[i], dbVer)
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1844,10 +1844,10 @@ func TestNewAuthorizations2(t *testing.T) {
 	test.AssertNotError(t, err, "sa.NewAuthorizations failed")
 	test.AssertEquals(t, len(ids.Ids), 2)
 	for i, id := range ids.Ids {
-		id := id
 		dbVer, err := sa.GetAuthorization2(context.Background(), &sapb.AuthorizationID2{Id: id})
 		test.AssertNotError(t, err, "sa.GetAuthorization failed")
-		// Everything but ID should match
+
+		// Everything but ID should match.
 		req.Authz[i].Id = dbVer.Id
 		test.AssertDeepEquals(t, req.Authz[i], dbVer)
 	}
@@ -1883,7 +1883,6 @@ func TestNewAuthorizations2_100(t *testing.T) {
 	test.AssertNotError(t, err, "sa.NewAuthorizations failed")
 	test.AssertEquals(t, len(ids.Ids), 100)
 	for i, id := range ids.Ids {
-		id := id
 		dbVer, err := sa.GetAuthorization2(context.Background(), &sapb.AuthorizationID2{Id: id})
 		test.AssertNotError(t, err, "sa.GetAuthorization failed")
 		// Everything but the ID should match.


### PR DESCRIPTION
- Makes NewAuthorizations2 batch all authorizations given into a single
  SQL statement.
- Add a unit test that pushes 100 authz at a time

Fixes #5578 