### PR TITLE
BadKeyRevoker: backoff on errors or no work

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -364,7 +364,7 @@ func main() {
 
 			// Interval specifies the minimum duration bad-key-revoker
 			// should sleep between attempting to find blockedKeys rows to
-			// process when there is no work to do.
+			// process when there is an error or no work to do.
 			Interval cmd.ConfigDuration
 
 			// BackoffDurationMax specifies a maximum amount of time the

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -533,6 +533,10 @@ type BackoffPolicy struct {
 // limit, the limit is used instead.
 func (b *BackoffPolicy) increase() {
 	b.Counter++
+	// If the minimum is zero, set to 1 second
+	if b.Minimum == 0 {
+		b.Minimum = time.Second * 1
+	}
 	// If the current backoff value is 0s then set it to the minimum
 	if b.Value == 0 {
 		b.Value = b.Minimum

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -59,11 +59,11 @@ type badKeyRevoker struct {
 	emailTemplate       *template.Template
 	logger              log.Logger
 	clk                 clock.Clock
+	backoffDuration     time.Duration
 	backoffDurationBase time.Duration
 	backoffDurationMax  time.Duration
 	backoffFactor       float64
 	backoffTicker       int
-	backoffDuration     time.Duration
 }
 
 // uncheckedBlockedKey represents a row in the blockedKeys table

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -463,4 +463,9 @@ func TestBackoffPolicy(t *testing.T) {
 	backoff.reset()
 	// reset() should have set the backoff.Value to backoff.Minimum
 	test.AssertEquals(t, time.Duration(0), backoff.Value)
+
+	// Make sure a minimum of zero sets backoff.Value to 1 second
+	backoff.Minimum = 0
+	backoff.increase()
+	test.AssertEquals(t, backoff.Value, time.Duration(float64(time.Second*1)))
 }

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -445,3 +445,22 @@ func TestInvokeRevokerHasNoExtantCerts(t *testing.T) {
 	test.AssertEquals(t, len(mm.Messages), 1)
 	test.AssertEquals(t, mm.Messages[0].To, "b@example.com")
 }
+
+func TestBackoffPolicy(t *testing.T) {
+	backoff := &BackoffPolicy{Limit: time.Second * 60, Value: time.Second * 1, Minimum: time.Second * 1, Factor: 1.3}
+
+	// Make sure the backoff increased by the desired backoff.Factor
+	backoff.increase()
+	test.AssertEquals(t, backoff.Value, time.Duration(float64(backoff.Minimum)*backoff.Factor))
+
+	// Increase a bunch of times to make sure the limit is hit and not exceeded.
+	for i := 0; i < 30; i++ {
+		backoff.increase()
+	}
+	// backoff should have incremented to backoff.Limit
+	test.AssertEquals(t, backoff.Limit, backoff.Value)
+
+	backoff.reset()
+	// reset() should have set the backoff.Value to backoff.Minimum
+	test.AssertEquals(t, time.Duration(0), backoff.Value)
+}

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -447,25 +447,33 @@ func TestInvokeRevokerHasNoExtantCerts(t *testing.T) {
 }
 
 func TestBackoffPolicy(t *testing.T) {
-	backoff := &BackoffPolicy{Limit: time.Second * 60, Value: time.Second * 1, Minimum: time.Second * 1, Factor: 1.3}
+	backoff := &backoffPolicy{
+		limit:   time.Second * 60,
+		value:   time.Second * 1,
+		minimum: time.Second * 1,
+		factor:  1.3,
+	}
 
-	// Make sure the backoff increased by the desired backoff.Factor
+	// Make sure the backoff increased by the desired `backoff.factor`.
 	backoff.increase()
-	test.AssertEquals(t, backoff.Value, time.Duration(float64(backoff.Minimum)*backoff.Factor))
+	test.AssertEquals(t, backoff.value, time.Duration(float64(backoff.minimum)*backoff.factor))
 
 	// Increase a bunch of times to make sure the limit is hit and not exceeded.
 	for i := 0; i < 30; i++ {
 		backoff.increase()
 	}
-	// backoff should have incremented to backoff.Limit
-	test.AssertEquals(t, backoff.Limit, backoff.Value)
 
+	// `backoff.value` should have incremented to `backoff.limit`.
+	test.AssertEquals(t, backoff.limit, backoff.value)
+
+	// Reset `backoff.value`.
 	backoff.reset()
-	// reset() should have set the backoff.Value to backoff.Minimum
-	test.AssertEquals(t, time.Duration(0), backoff.Value)
 
-	// Make sure a minimum of zero sets backoff.Value to 1 second
-	backoff.Minimum = 0
+	// Calling reset() should have set the `backoff.value` to `backoff.minimum`.
+	test.AssertEquals(t, time.Duration(0), backoff.value)
+
+	// Make sure a minimum of zero sets `backoff.value` to 1 second.
+	backoff.minimum = 0
 	backoff.increase()
-	test.AssertEquals(t, backoff.Value, time.Duration(float64(time.Second*1)))
+	test.AssertEquals(t, backoff.value, time.Duration(float64(time.Second*1)))
 }

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -469,7 +469,7 @@ func TestBackoffPolicy(t *testing.T) {
 	// Reset `backoff.value`.
 	backoff.reset()
 
-	// Calling reset() should have set the `backoff.value` to `backoff.minimum`.
+	// Calling reset should have set the `backoff.value` to `backoff.minimum`.
 	test.AssertEquals(t, time.Duration(0), backoff.value)
 
 	// Make sure a minimum of zero sets `backoff.value` to 1 second.

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -27,7 +27,7 @@
         "maximumRevocations": 15,
         "findCertificatesBatchSize": 10,
         "interval": "1s",
-        "backoffDurationMax": "60s"
+        "backoffIntervalMax": "60s"
     },
     "syslog": {
         "stdoutlevel": 4,

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -26,7 +26,8 @@
         },
         "maximumRevocations": 15,
         "findCertificatesBatchSize": 10,
-        "interval": "1s"
+        "interval": "1s",
+        "maxBackoff": "120s"
     },
     "syslog": {
         "stdoutlevel": 4,

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -27,7 +27,7 @@
         "maximumRevocations": 15,
         "findCertificatesBatchSize": 10,
         "interval": "1s",
-        "maxBackoff": "120s"
+        "backoffDurationMax": "60s"
     },
     "syslog": {
         "stdoutlevel": 4,


### PR DESCRIPTION
- Add exponential backoff
- Add key `backoffIntervalMax` to JSON config with a default of `60s`

Fixes #5559