### PR TITLE
Unwrap SA Get[Pre]Certificate methods

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -43,7 +43,7 @@ const (
 
 type certificateStorage interface {
 	AddCertificate(context.Context, []byte, int64, []byte, *time.Time) (string, error)
-	GetCertificate(context.Context, string) (core.Certificate, error)
+	GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
 	AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*emptypb.Empty, error)
 	AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*emptypb.Empty, error)
 }
@@ -323,7 +323,7 @@ func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 	}
 
 	serialHex := core.SerialToString(precert.SerialNumber)
-	if _, err = ca.sa.GetCertificate(ctx, serialHex); err == nil {
+	if _, err = ca.sa.GetCertificate(ctx, &sapb.Serial{Serial: serialHex}); err == nil {
 		err = berrors.InternalServerError("issuance of duplicate final certificate requested: %s", serialHex)
 		ca.log.AuditErr(err.Error())
 		return nil, err

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -29,6 +29,7 @@ import (
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
@@ -162,8 +163,8 @@ func (m *mockSA) AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*em
 	return &emptypb.Empty{}, nil
 }
 
-func (m *mockSA) GetCertificate(ctx context.Context, serial string) (core.Certificate, error) {
-	return core.Certificate{}, berrors.NotFoundError("cannot find the cert")
+func (m *mockSA) GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
+	return nil, berrors.NotFoundError("cannot find the cert")
 }
 
 var caKey crypto.Signer
@@ -809,8 +810,8 @@ type dupeSA struct {
 	mockSA
 }
 
-func (m *dupeSA) GetCertificate(ctx context.Context, serial string) (core.Certificate, error) {
-	return core.Certificate{}, nil
+func (m *dupeSA) GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
+	return nil, nil
 }
 
 // getCertErrorSA always returns an error for GetCertificate
@@ -818,8 +819,8 @@ type getCertErrorSA struct {
 	mockSA
 }
 
-func (m *getCertErrorSA) GetCertificate(ctx context.Context, serial string) (core.Certificate, error) {
-	return core.Certificate{}, fmt.Errorf("i don't like it")
+func (m *getCertErrorSA) GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
+	return nil, fmt.Errorf("i don't like it")
 }
 
 func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -63,8 +63,8 @@ type config struct {
 type certificateStorage interface {
 	AddCertificate(context.Context, []byte, int64, []byte, *time.Time) (string, error)
 	AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*emptypb.Empty, error)
-	GetCertificate(ctx context.Context, serial string) (core.Certificate, error)
-	GetPrecertificate(ctx context.Context, reqSerial *sapb.Serial) (*corepb.Certificate, error)
+	GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
+	GetPrecertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
 }
 
 type ocspGenerator interface {
@@ -148,7 +148,7 @@ func checkDER(sai certificateStorage, der []byte) (*x509.Certificate, orphanType
 
 	switch orphanTyp {
 	case certOrphan:
-		_, err = sai.GetCertificate(ctx, orphanSerial)
+		_, err = sai.GetCertificate(ctx, &sapb.Serial{Serial: orphanSerial})
 	case precertOrphan:
 		_, err = sai.GetPrecertificate(ctx, &sapb.Serial{Serial: orphanSerial})
 	default:

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -99,7 +99,7 @@ type PolicyAuthority interface {
 type StorageGetter interface {
 	GetRegistration(ctx context.Context, req *sapb.RegistrationID) (*corepb.Registration, error)
 	GetRegistrationByKey(ctx context.Context, req *sapb.JSONWebKey) (*corepb.Registration, error)
-	GetCertificate(ctx context.Context, serial string) (Certificate, error)
+	GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
 	GetPrecertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
 	GetCertificateStatus(ctx context.Context, serial string) (CertificateStatus, error)
 	CountCertificatesByNames(ctx context.Context, domains []string, earliest, latest time.Time) (countByDomain []*sapb.CountByNames_MapElement, err error)

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -35,15 +35,8 @@ func (sac StorageAuthorityClientWrapper) GetRegistrationByKey(ctx context.Contex
 	return sac.inner.GetRegistrationByKey(ctx, req)
 }
 
-func (sac StorageAuthorityClientWrapper) GetCertificate(ctx context.Context, serial string) (core.Certificate, error) {
-	response, err := sac.inner.GetCertificate(ctx, &sapb.Serial{Serial: serial})
-	if err != nil {
-		return core.Certificate{}, err
-	}
-	if response == nil || response.RegistrationID == 0 || response.Serial == "" || response.Digest == "" || len(response.Der) == 0 || response.Issued == 0 || response.Expires == 0 {
-		return core.Certificate{}, errIncompleteResponse
-	}
-	return PBToCert(response)
+func (sac StorageAuthorityClientWrapper) GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
+	return sac.inner.GetCertificate(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) GetPrecertificate(ctx context.Context, serial *sapb.Serial) (*corepb.Certificate, error) {
@@ -463,16 +456,7 @@ func (sas StorageAuthorityServerWrapper) GetRegistrationByKey(ctx context.Contex
 }
 
 func (sas StorageAuthorityServerWrapper) GetCertificate(ctx context.Context, request *sapb.Serial) (*corepb.Certificate, error) {
-	if core.IsAnyNilOrZero(request, request.Serial) {
-		return nil, errIncompleteRequest
-	}
-
-	cert, err := sas.inner.GetCertificate(ctx, request.Serial)
-	if err != nil {
-		return nil, err
-	}
-
-	return CertToPB(cert), nil
+	return sas.inner.GetCertificate(ctx, request)
 }
 
 func (sas StorageAuthorityServerWrapper) GetPrecertificate(ctx context.Context, request *sapb.Serial) (*corepb.Certificate, error) {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -40,14 +40,7 @@ func (sac StorageAuthorityClientWrapper) GetCertificate(ctx context.Context, req
 }
 
 func (sac StorageAuthorityClientWrapper) GetPrecertificate(ctx context.Context, serial *sapb.Serial) (*corepb.Certificate, error) {
-	resp, err := sac.inner.GetPrecertificate(ctx, serial)
-	if err != nil {
-		return nil, err
-	}
-	if resp == nil {
-		return nil, errIncompleteResponse
-	}
-	return resp, nil
+	return sac.inner.GetPrecertificate(ctx, serial)
 }
 
 func (sac StorageAuthorityClientWrapper) GetCertificateStatus(ctx context.Context, serial string) (core.CertificateStatus, error) {
@@ -460,9 +453,6 @@ func (sas StorageAuthorityServerWrapper) GetCertificate(ctx context.Context, req
 }
 
 func (sas StorageAuthorityServerWrapper) GetPrecertificate(ctx context.Context, request *sapb.Serial) (*corepb.Certificate, error) {
-	if core.IsAnyNilOrZero(request, request.Serial) {
-		return nil, errIncompleteRequest
-	}
 	return sas.inner.GetPrecertificate(ctx, request)
 }
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -229,28 +229,28 @@ func (sa *StorageAuthority) GetAuthorization(_ context.Context, id string) (core
 }
 
 // GetCertificate is a mock
-func (sa *StorageAuthority) GetCertificate(_ context.Context, serial string) (core.Certificate, error) {
+func (sa *StorageAuthority) GetCertificate(_ context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
 	// Serial ee == 238.crt
-	if serial == "0000000000000000000000000000000000ee" {
+	if req.Serial == "0000000000000000000000000000000000ee" {
 		certPemBytes, _ := ioutil.ReadFile("test/238.crt")
 		certBlock, _ := pem.Decode(certPemBytes)
-		return core.Certificate{
+		return &corepb.Certificate{
 			RegistrationID: 1,
-			DER:            certBlock.Bytes,
-			Issued:         sa.clk.Now().Add(-1 * time.Hour),
+			Der:            certBlock.Bytes,
+			Issued:         sa.clk.Now().Add(-1 * time.Hour).UnixNano(),
 		}, nil
-	} else if serial == "0000000000000000000000000000000000b2" {
+	} else if req.Serial == "0000000000000000000000000000000000b2" {
 		certPemBytes, _ := ioutil.ReadFile("test/178.crt")
 		certBlock, _ := pem.Decode(certPemBytes)
-		return core.Certificate{
+		return &corepb.Certificate{
 			RegistrationID: 1,
-			DER:            certBlock.Bytes,
-			Issued:         sa.clk.Now().Add(-1 * time.Hour),
+			Der:            certBlock.Bytes,
+			Issued:         sa.clk.Now().Add(-1 * time.Hour).UnixNano(),
 		}, nil
-	} else if serial == "000000000000000000000000000000626164" {
-		return core.Certificate{}, errors.New("bad")
+	} else if req.Serial == "000000000000000000000000000000626164" {
+		return nil, errors.New("bad")
 	} else {
-		return core.Certificate{}, berrors.NotFoundError("No cert")
+		return nil, berrors.NotFoundError("No cert")
 	}
 }
 

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -134,17 +134,19 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 
 // GetPrecertificate takes a serial number and returns the corresponding
 // precertificate, or error if it does not exist.
-func (ssa *SQLStorageAuthority) GetPrecertificate(ctx context.Context, reqSerial *sapb.Serial) (*corepb.Certificate, error) {
-	if !core.ValidSerial(reqSerial.Serial) {
-		return nil,
-			fmt.Errorf("Invalid precertificate serial %q", reqSerial.Serial)
+func (ssa *SQLStorageAuthority) GetPrecertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
+	if req == nil || req.Serial == "" {
+		return nil, errIncompleteRequest
 	}
-	cert, err := SelectPrecertificate(ssa.dbMap.WithContext(ctx), reqSerial.Serial)
+	if !core.ValidSerial(req.Serial) {
+		return nil, fmt.Errorf("Invalid precertificate serial %q", req.Serial)
+	}
+	cert, err := SelectPrecertificate(ssa.dbMap.WithContext(ctx), req.Serial)
 	if err != nil {
 		if db.IsNoRows(err) {
 			return nil, berrors.NotFoundError(
 				"precertificate with serial %q not found",
-				reqSerial.Serial)
+				req.Serial)
 		}
 		return nil, err
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -195,12 +195,12 @@ func TestAddCertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
 	test.AssertEquals(t, digest, "qWoItDZmR4P9eFbeYgXXP3SR4ApnkQj8x4LsB_ORKBo")
 
-	retrievedCert, err := sa.GetCertificate(ctx, "000000000000000000000000000000021bd4")
+	retrievedCert, err := sa.GetCertificate(ctx, &sapb.Serial{Serial: "000000000000000000000000000000021bd4"})
 	test.AssertNotError(t, err, "Couldn't get www.eff.org.der by full serial")
-	test.AssertByteEquals(t, certDER, retrievedCert.DER)
+	test.AssertByteEquals(t, certDER, retrievedCert.Der)
 	// Because nil was provided as the Issued time we expect the cert was stored
 	// with an issued time equal to now
-	test.AssertEquals(t, retrievedCert.Issued, clk.Now())
+	test.AssertEquals(t, retrievedCert.Issued, clk.Now().UnixNano())
 
 	// Test cert generated locally by Boulder / CFSSL, names [example.com,
 	// www.example.com, admin.example.com]
@@ -214,12 +214,12 @@ func TestAddCertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't add test-cert.der")
 	test.AssertEquals(t, digest2, "vrlPN5wIPME1D2PPsCy-fGnTWh8dMyyYQcXPRkjHAQI")
 
-	retrievedCert2, err := sa.GetCertificate(ctx, serial)
+	retrievedCert2, err := sa.GetCertificate(ctx, &sapb.Serial{Serial: serial})
 	test.AssertNotError(t, err, "Couldn't get test-cert.der")
-	test.AssertByteEquals(t, certDER2, retrievedCert2.DER)
+	test.AssertByteEquals(t, certDER2, retrievedCert2.Der)
 	// The cert should have been added with the specific issued time we provided
 	// as the issued field.
-	test.AssertEquals(t, retrievedCert2.Issued, issuedTime)
+	test.AssertEquals(t, retrievedCert2.Issued, issuedTime.UnixNano())
 
 	// Test adding OCSP response with cert
 	certDER3, err := ioutil.ReadFile("test-cert2.der")

--- a/wfe2/stale.go
+++ b/wfe2/stale.go
@@ -29,8 +29,8 @@ func (wfe *WebFrontEndImpl) staleEnoughToGETOrder(order *corepb.Order) *probs.Pr
 
 // staleEnoughToGETCert checks if the given cert was issued long enough in the
 // past to be acceptably stale for accessing via the Boulder specific GET API.
-func (wfe *WebFrontEndImpl) staleEnoughToGETCert(cert core.Certificate) *probs.ProblemDetails {
-	return wfe.staleEnoughToGET("Certificate", cert.Issued)
+func (wfe *WebFrontEndImpl) staleEnoughToGETCert(cert *corepb.Certificate) *probs.ProblemDetails {
+	return wfe.staleEnoughToGET("Certificate", time.Unix(0, cert.Issued))
 }
 
 // staleEnoughToGETAuthz checks if the given authorization was created long


### PR DESCRIPTION
Make the gRPC wrappers for sa.GetCertificate and
sa.GetPrecertificate bare passthroughs. The latter of
these already took and returned appropriate protobufs,
so this change mostly just makes the former look like the
latter.

Part of #5532