### PR TITLE
orphan-finder: use IssuerNameID in OCSP request

### DIFF
--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -380,13 +380,14 @@ func (opf *orphanFinder) parseDER(derPath string, regID int64) {
 
 // generateOCSP asks the CA to generate a new OCSP response for the given cert.
 func (opf *orphanFinder) generateOCSP(ctx context.Context, cert *x509.Certificate) ([]byte, error) {
-	issuer, ok := opf.issuers[issuance.GetIssuerNameID(cert)]
+	issuerID := issuance.GetIssuerNameID(cert)
+	_, ok := opf.issuers[issuerID]
 	if !ok {
 		return nil, errors.New("unrecognized issuer for orphan")
 	}
 	ocspResponse, err := opf.ca.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		Serial:    core.SerialToString(cert.SerialNumber),
-		IssuerID:  int64(issuer.ID()),
+		IssuerID:  int64(issuerID),
 		Status:    string(core.OCSPStatusGood),
 		Reason:    0,
 		RevokedAt: 0,


### PR DESCRIPTION
Make orphan-finder put an IssuerNameID in its GenerateOCSP
request to the CA. This will be recognized by the CA in the same
way as the old-style IssuerID would be (it keeps maps of both in
memory), and this same mechanism is already used by the RA
and the ocsp-updater.

Part of #5152