### PR TITLE
Update TODOs for Issue #5152

### DIFF
--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -20,7 +20,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-// TODO(#5152): Remove this when we're only using IssuerNameIDs.
+// TODO(#5152): Simplify this when we've fully deprecated old-style IssuerIDs.
 type ocspIssuerMaps struct {
 	byID     map[issuance.IssuerID]*issuance.Issuer
 	byNameID map[issuance.IssuerNameID]*issuance.Issuer
@@ -29,8 +29,7 @@ type ocspIssuerMaps struct {
 // ocspImpl provides a backing implementation for the OCSP gRPC service.
 type ocspImpl struct {
 	capb.UnimplementedOCSPGeneratorServer
-	sa certificateStorage
-	// TODO(#5152): Replace IssuerID with IssuerNameID.
+	sa             certificateStorage
 	issuers        ocspIssuerMaps
 	ocspLifetime   time.Duration
 	ocspLogQueue   *ocspLogQueue

--- a/ca/proto/ca.pb.go
+++ b/ca/proto/ca.pb.go
@@ -220,8 +220,7 @@ type GenerateOCSPRequest struct {
 	Reason    int32  `protobuf:"varint,3,opt,name=reason,proto3" json:"reason,omitempty"`
 	RevokedAt int64  `protobuf:"varint,4,opt,name=revokedAt,proto3" json:"revokedAt,omitempty"`
 	Serial    string `protobuf:"bytes,5,opt,name=serial,proto3" json:"serial,omitempty"`
-	// TODO(#5152): Replace issuerID with issuerNameID.
-	IssuerID int64 `protobuf:"varint,6,opt,name=issuerID,proto3" json:"issuerID,omitempty"`
+	IssuerID  int64  `protobuf:"varint,6,opt,name=issuerID,proto3" json:"issuerID,omitempty"`
 }
 
 func (x *GenerateOCSPRequest) Reset() {

--- a/ca/proto/ca.proto
+++ b/ca/proto/ca.proto
@@ -44,7 +44,6 @@ message GenerateOCSPRequest {
   int32 reason = 3;
   int64 revokedAt = 4;
   string serial = 5;
-  // TODO(#5152): Replace issuerID with issuerNameID.
   int64 issuerID = 6;
 }
 

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -162,7 +162,6 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 }
 
 func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.CertificateStatus) (*core.CertificateStatus, error) {
-	// TODO(#5152): Replace IssuerID with IssuerNameID.
 	if status.IssuerID == nil || *status.IssuerID == 0 {
 		return nil, errors.New("cert status has nil or 0 IssuerID")
 	}

--- a/core/objects.go
+++ b/core/objects.go
@@ -490,7 +490,6 @@ type CertificateStatus struct {
 	NotAfter  time.Time `db:"notAfter"`
 	IsExpired bool      `db:"isExpired"`
 
-	// TODO(#5152): Replace IssuerID with IssuerNameID.
 	IssuerID *int64
 }
 

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -385,6 +385,8 @@ func (ic *Certificate) ID() IssuerID {
 // both CA and end-entity certs to link them together into a validation chain.
 // It is computed as a truncated hash over the issuer Subject Name bytes, or
 // over the end-entity's Issuer Name bytes, which are required to be equal.
+// TODO(#5152): Rename this "IssuerID" when we've fully deprecated the old-style
+// IssuerIDs and replaced them with NameIDs.
 type IssuerNameID int64
 
 // NameID computes the IssuerNameID from an issuer certificate, i.e. it


### PR DESCRIPTION
Changing how we're going to finally handle #5152: rather
than changing everything to use IssuerNameIDs, we're going
to change the meaning of IssuerID. This will allow us to avoid
renaming database columns and protobuf message fields.