### PR TITLE
Make CertificateStatus.IssuerID not a reference

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -117,7 +117,7 @@ func (f *ocspFilter) checkRequest(req *ocsp.Request) error {
 // This filters out, for example, responses which are for a serial that we
 // issued, but from a different issuer than that contained in the request.
 func (f *ocspFilter) responseMatchesIssuer(req *ocsp.Request, status core.CertificateStatus) bool {
-	issuerKeyHash, ok := f.issuerKeyHashes[issuance.IssuerID(*status.IssuerID)]
+	issuerKeyHash, ok := f.issuerKeyHashes[issuance.IssuerID(status.IssuerID)]
 	if !ok {
 		return false
 	}

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -33,7 +33,7 @@ var (
 		OCSPResponse:    mustRead("./testdata/ocsp.resp"),
 		IsExpired:       false,
 		OCSPLastUpdated: time.Now(),
-		IssuerID:        &issuerID,
+		IssuerID:        issuerID,
 	}
 	stats = metrics.NoopRegisterer
 )
@@ -151,7 +151,7 @@ func TestResponseMatchesIssuer(t *testing.T) {
 		OCSPResponse:    mustRead("./testdata/ocsp.resp"),
 		IsExpired:       false,
 		OCSPLastUpdated: time.Now(),
-		IssuerID:        &fakeID,
+		IssuerID:        fakeID,
 	}
 	test.AssertEquals(t, f.responseMatchesIssuer(ocspReq, ocspResp), false)
 }
@@ -328,7 +328,7 @@ func (es expiredSelector) SelectOne(obj interface{}, _ string, _ ...interface{})
 	rows.IsExpired = true
 	rows.OCSPLastUpdated = time.Time{}.Add(time.Hour)
 	issuerID = int64(123456)
-	rows.IssuerID = &issuerID
+	rows.IssuerID = issuerID
 	return nil
 }
 

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -162,12 +162,12 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 }
 
 func (updater *OCSPUpdater) generateResponse(ctx context.Context, status core.CertificateStatus) (*core.CertificateStatus, error) {
-	if status.IssuerID == nil || *status.IssuerID == 0 {
-		return nil, errors.New("cert status has nil or 0 IssuerID")
+	if status.IssuerID == 0 {
+		return nil, errors.New("cert status has 0 IssuerID")
 	}
 	ocspReq := capb.GenerateOCSPRequest{
 		Serial:    status.Serial,
-		IssuerID:  *status.IssuerID,
+		IssuerID:  status.IssuerID,
 		Status:    string(status.Status),
 		Reason:    int32(status.RevokedReason),
 		RevokedAt: status.RevokedDate.UnixNano(),

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -490,7 +490,7 @@ func TestIssuerInfo(t *testing.T) {
 	statuses, err := updater.findStaleOCSPResponses(fc.Now().Add(-time.Hour), 10)
 	test.AssertNotError(t, err, "findStaleOCSPResponses failed")
 	test.AssertEquals(t, len(statuses), 1)
-	test.AssertEquals(t, *statuses[0].IssuerID, id)
+	test.AssertEquals(t, statuses[0].IssuerID, id)
 
 	_, err = updater.generateResponse(context.Background(), statuses[0])
 	test.AssertNotError(t, err, "generateResponse failed")

--- a/core/objects.go
+++ b/core/objects.go
@@ -490,7 +490,9 @@ type CertificateStatus struct {
 	NotAfter  time.Time `db:"notAfter"`
 	IsExpired bool      `db:"isExpired"`
 
-	IssuerID *int64
+	// TODO(#5152): Change this to an issuance.Issuer(Name)ID after it no longer
+	// has to support both IssuerNameIDs and IssuerIDs.
+	IssuerID int64
 }
 
 // FQDNSet contains the SHA256 hash of the lowercased, comma joined dNSNames


### PR DESCRIPTION
Change `CertificateStatus.IssuerID` from `*int64` to just an
`int64`. It might make sense for this field to be nillable in a world
where we want to distinguish between it being missing and it
being zero, but none of our code actually does that: we error
out either way.

Part of #5152