### PR TITLE
Unwrap SA Add/Revoke Certificate methods

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -103,8 +103,11 @@ func TestRevokeBatch(t *testing.T) {
 			IssuerID: 1,
 		})
 		test.AssertNotError(t, err, "failed to add test cert")
-		now := time.Now()
-		_, err = ssa.AddCertificate(context.Background(), der, reg.Id, nil, &now)
+		_, err = ssa.AddCertificate(context.Background(), &sapb.AddCertificateRequest{
+			Der:    der,
+			RegID:  reg.Id,
+			Issued: time.Now().UnixNano(),
+		})
 		test.AssertNotError(t, err, "failed to add test cert")
 		_, err = serialFile.WriteString(fmt.Sprintf("%s\n", core.SerialToString(serial)))
 		test.AssertNotError(t, err, "failed to write serial to temp file")

--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -35,7 +35,7 @@ type mockCA struct {
 }
 
 func (ca *mockCA) GenerateOCSP(context.Context, *capb.GenerateOCSPRequest, ...grpc.CallOption) (*capb.OCSPResponse, error) {
-	return &capb.OCSPResponse{}, nil
+	return &capb.OCSPResponse{Response: []byte("fakeocspbytes")}, nil
 }
 
 type mockPurger struct{}

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
+	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
@@ -282,8 +283,11 @@ func TestGetAndProcessCerts(t *testing.T) {
 		rawCert.SerialNumber = big.NewInt(mrand.Int63())
 		certDER, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
 		test.AssertNotError(t, err, "Couldn't create certificate")
-		issued := fc.Now()
-		_, err = sa.AddCertificate(context.Background(), certDER, reg.Id, nil, &issued)
+		_, err = sa.AddCertificate(context.Background(), &sapb.AddCertificateRequest{
+			Der:    certDER,
+			RegID:  reg.Id,
+			Issued: fc.Now().Add(time.Hour).UnixNano(),
+		})
 		test.AssertNotError(t, err, "Couldn't add certificate")
 	}
 

--- a/cmd/orphan-finder/main_test.go
+++ b/cmd/orphan-finder/main_test.go
@@ -33,23 +33,19 @@ type mockSA struct {
 	clk             clock.FakeClock
 }
 
-func (m *mockSA) AddCertificate(ctx context.Context, der []byte, regID int64, _ []byte, issued *time.Time) (string, error) {
-	parsed, err := x509.ParseCertificate(der)
+func (m *mockSA) AddCertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*sapb.AddCertificateResponse, error) {
+	parsed, err := x509.ParseCertificate(req.Der)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	cert := &corepb.Certificate{
-		Der:            der,
-		RegistrationID: regID,
+		Der:            req.Der,
+		RegistrationID: req.RegID,
 		Serial:         core.SerialToString(parsed.SerialNumber),
-	}
-	if issued == nil {
-		cert.Issued = m.clk.Now().UnixNano()
-	} else {
-		cert.Issued = issued.UnixNano()
+		Issued:         req.Issued,
 	}
 	m.certificates = append(m.certificates, cert)
-	return "", nil
+	return nil, nil
 }
 
 func (m *mockSA) GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -126,7 +126,7 @@ type StorageGetter interface {
 type StorageAdder interface {
 	NewRegistration(ctx context.Context, req *corepb.Registration) (*corepb.Registration, error)
 	UpdateRegistration(ctx context.Context, req *corepb.Registration) (*emptypb.Empty, error)
-	AddCertificate(ctx context.Context, der []byte, regID int64, ocsp []byte, issued *time.Time) (digest string, err error)
+	AddCertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*sapb.AddCertificateResponse, error)
 	AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*emptypb.Empty, error)
 	AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*emptypb.Empty, error)
 	DeactivateRegistration(ctx context.Context, req *sapb.RegistrationID) (*emptypb.Empty, error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -134,7 +134,7 @@ type StorageAdder interface {
 	SetOrderProcessing(ctx context.Context, order *corepb.Order) error
 	FinalizeOrder(ctx context.Context, order *corepb.Order) error
 	SetOrderError(ctx context.Context, order *corepb.Order) error
-	RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) error
+	RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*emptypb.Empty, error)
 	// New authz2 methods
 	NewAuthorizations2(ctx context.Context, req *sapb.AddPendingAuthorizationsRequest) (*sapb.Authorization2IDs, error)
 	FinalizeAuthorization2(ctx context.Context, req *sapb.FinalizeAuthorizationRequest) error

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -223,31 +223,8 @@ func (sac StorageAuthorityClientWrapper) UpdateRegistration(ctx context.Context,
 	return sac.inner.UpdateRegistration(ctx, req)
 }
 
-func (sac StorageAuthorityClientWrapper) AddCertificate(
-	ctx context.Context,
-	der []byte,
-	regID int64,
-	ocspResponse []byte,
-	issued *time.Time) (string, error) {
-	issuedTS := int64(0)
-	if issued != nil {
-		issuedTS = issued.UnixNano()
-	}
-	response, err := sac.inner.AddCertificate(ctx, &sapb.AddCertificateRequest{
-		Der:    der,
-		RegID:  regID,
-		Ocsp:   ocspResponse,
-		Issued: issuedTS,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	if response == nil {
-		return "", errIncompleteResponse
-	}
-
-	return response.Digest, nil
+func (sac StorageAuthorityClientWrapper) AddCertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*sapb.AddCertificateResponse, error) {
+	return sac.inner.AddCertificate(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) DeactivateRegistration(ctx context.Context, request *sapb.RegistrationID) (*emptypb.Empty, error) {
@@ -580,17 +557,7 @@ func (sas StorageAuthorityServerWrapper) UpdateRegistration(ctx context.Context,
 }
 
 func (sas StorageAuthorityServerWrapper) AddCertificate(ctx context.Context, request *sapb.AddCertificateRequest) (*sapb.AddCertificateResponse, error) {
-	if core.IsAnyNilOrZero(request, request.Der, request.RegID, request.Issued) {
-		return nil, errIncompleteRequest
-	}
-
-	reqIssued := time.Unix(0, request.Issued)
-	digest, err := sas.inner.AddCertificate(ctx, request.Der, request.RegID, request.Ocsp, &reqIssued)
-	if err != nil {
-		return nil, err
-	}
-
-	return &sapb.AddCertificateResponse{Digest: digest}, nil
+	return sas.inner.AddCertificate(ctx, request)
 }
 
 func (sas StorageAuthorityServerWrapper) DeactivateRegistration(ctx context.Context, request *sapb.RegistrationID) (*emptypb.Empty, error) {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -178,18 +178,8 @@ func (sac StorageAuthorityClientWrapper) AddPrecertificate(ctx context.Context, 
 	return sac.inner.AddPrecertificate(ctx, req)
 }
 
-func (sac StorageAuthorityClientWrapper) AddSerial(
-	ctx context.Context,
-	req *sapb.AddSerialRequest,
-) (*emptypb.Empty, error) {
-	empty, err := sac.inner.AddSerial(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if empty == nil {
-		return nil, errIncompleteResponse
-	}
-	return empty, nil
+func (sac StorageAuthorityClientWrapper) AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*emptypb.Empty, error) {
+	return sac.inner.AddSerial(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) FQDNSetExists(ctx context.Context, domains []string) (bool, error) {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -277,9 +277,8 @@ func (sas StorageAuthorityClientWrapper) GetAuthorization2(ctx context.Context, 
 	return resp, nil
 }
 
-func (sas StorageAuthorityClientWrapper) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) error {
-	_, err := sas.inner.RevokeCertificate(ctx, req)
-	return err
+func (sas StorageAuthorityClientWrapper) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*emptypb.Empty, error) {
+	return sas.inner.RevokeCertificate(ctx, req)
 }
 
 func (sas StorageAuthorityClientWrapper) NewAuthorizations2(ctx context.Context, req *sapb.AddPendingAuthorizationsRequest) (*sapb.Authorization2IDs, error) {
@@ -614,10 +613,7 @@ func (sas StorageAuthorityServerWrapper) GetAuthorization2(ctx context.Context, 
 }
 
 func (sas StorageAuthorityServerWrapper) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*emptypb.Empty, error) {
-	if core.IsAnyNilOrZero(req, req.Serial, req.Date, req.Response) {
-		return nil, errIncompleteRequest
-	}
-	return &emptypb.Empty{}, sas.inner.RevokeCertificate(ctx, req)
+	return sas.inner.RevokeCertificate(ctx, req)
 }
 
 func (sas StorageAuthorityServerWrapper) NewAuthorizations2(ctx context.Context, req *sapb.AddPendingAuthorizationsRequest) (*sapb.Authorization2IDs, error) {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -174,18 +174,8 @@ func (sac StorageAuthorityClientWrapper) PreviousCertificateExists(
 	return exists, err
 }
 
-func (sac StorageAuthorityClientWrapper) AddPrecertificate(
-	ctx context.Context,
-	req *sapb.AddCertificateRequest,
-) (*emptypb.Empty, error) {
-	empty, err := sac.inner.AddPrecertificate(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if empty == nil {
-		return nil, errIncompleteResponse
-	}
-	return empty, nil
+func (sac StorageAuthorityClientWrapper) AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*emptypb.Empty, error) {
+	return sac.inner.AddPrecertificate(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) AddSerial(

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -286,8 +286,8 @@ func (sa *StorageAuthority) AddSerial(ctx context.Context, req *sapb.AddSerialRe
 }
 
 // AddCertificate is a mock
-func (sa *StorageAuthority) AddCertificate(_ context.Context, certDER []byte, regID int64, _ []byte, _ *time.Time) (digest string, err error) {
-	return
+func (sa *StorageAuthority) AddCertificate(_ context.Context, _ *sapb.AddCertificateRequest) (*sapb.AddCertificateResponse, error) {
+	return nil, nil
 }
 
 // FinalizeAuthorization is a mock

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -623,8 +623,8 @@ func (sa *StorageAuthority) GetAuthorization2(ctx context.Context, id *sapb.Auth
 }
 
 // RevokeCertificate is a mock
-func (sa *StorageAuthority) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) error {
-	return nil
+func (sa *StorageAuthority) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*emptypb.Empty, error) {
+	return nil, nil
 }
 
 // AddBlockedKey is a mock

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1819,7 +1819,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, cert
 		return err
 	}
 
-	err = ra.SA.RevokeCertificate(ctx, &sapb.RevokeCertificateRequest{
+	_, err = ra.SA.RevokeCertificate(ctx, &sapb.RevokeCertificateRequest{
 		Serial:   serial,
 		Reason:   int64(code),
 		Date:     revokedAt,

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -42,21 +42,20 @@ func (ssa *SQLStorageAuthority) AddSerial(ctx context.Context, req *sapb.AddSeri
 // certificate multiple times. Calling code needs to first insert the cert's
 // serial into the Serials table to ensure uniqueness.
 func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*emptypb.Empty, error) {
-	if core.IsAnyNilOrZero(req.Der, req.Issued, req.RegID, req.IssuerID) {
+	if req.Der == nil || req.RegID == 0 || req.Issued == 0 || req.IssuerID == 0 {
 		return nil, errIncompleteRequest
 	}
 	parsed, err := x509.ParseCertificate(req.Der)
 	if err != nil {
 		return nil, err
 	}
-	issued := time.Unix(0, req.Issued)
 	serialHex := core.SerialToString(parsed.SerialNumber)
 
 	preCertModel := &precertificateModel{
 		Serial:         serialHex,
 		RegistrationID: req.RegID,
 		DER:            req.Der,
-		Issued:         issued,
+		Issued:         time.Unix(0, req.Issued),
 		Expires:        parsed.NotAfter,
 	}
 

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -22,7 +22,7 @@ var errIncompleteRequest = errors.New("Incomplete gRPC request message")
 
 // AddSerial writes a record of a serial number generation to the DB.
 func (ssa *SQLStorageAuthority) AddSerial(ctx context.Context, req *sapb.AddSerialRequest) (*emptypb.Empty, error) {
-	if core.IsAnyNilOrZero(req.Created, req.Expires, req.Serial, req.RegID) {
+	if req.Serial == "" || req.RegID == 0 || req.Created == 0 || req.Expires == 0 {
 		return nil, errIncompleteRequest
 	}
 	err := ssa.dbMap.WithContext(ctx).Insert(&recordedSerialModel{

--- a/sa/precertificates_test.go
+++ b/sa/precertificates_test.go
@@ -76,7 +76,11 @@ func TestAddPrecertificate(t *testing.T) {
 			// We should also be able to call AddCertificate with the same cert
 			// without it being an error. The duplicate err on inserting to
 			// issuedNames should be ignored.
-			_, err := sa.AddCertificate(ctx, testCert.Raw, regID, nil, &issuedTime)
+			_, err := sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+				Der:    testCert.Raw,
+				RegID:  regID,
+				Issued: issuedTime.UnixNano(),
+			})
 			test.AssertNotError(t, err, "unexpected err adding final cert after precert")
 		} else {
 			// Otherwise we expect an ErrDatabaseOp that indicates NoRows because

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -190,10 +190,13 @@ func TestAddCertificate(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 
 	// Calling AddCertificate with a non-nil issued should succeed
-	issued := sa.clk.Now()
-	digest, err := sa.AddCertificate(ctx, certDER, reg.Id, nil, &issued)
+	digest, err := sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER,
+		RegID:  reg.Id,
+		Issued: sa.clk.Now().UnixNano(),
+	})
 	test.AssertNotError(t, err, "Couldn't add www.eff.org.der")
-	test.AssertEquals(t, digest, "qWoItDZmR4P9eFbeYgXXP3SR4ApnkQj8x4LsB_ORKBo")
+	test.AssertEquals(t, digest.Digest, "qWoItDZmR4P9eFbeYgXXP3SR4ApnkQj8x4LsB_ORKBo")
 
 	retrievedCert, err := sa.GetCertificate(ctx, &sapb.Serial{Serial: "000000000000000000000000000000021bd4"})
 	test.AssertNotError(t, err, "Couldn't get www.eff.org.der by full serial")
@@ -210,9 +213,13 @@ func TestAddCertificate(t *testing.T) {
 
 	// Add the certificate with a specific issued time instead of nil
 	issuedTime := time.Date(2018, 4, 1, 7, 0, 0, 0, time.UTC)
-	digest2, err := sa.AddCertificate(ctx, certDER2, reg.Id, nil, &issuedTime)
+	digest2, err := sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER2,
+		RegID:  reg.Id,
+		Issued: issuedTime.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Couldn't add test-cert.der")
-	test.AssertEquals(t, digest2, "vrlPN5wIPME1D2PPsCy-fGnTWh8dMyyYQcXPRkjHAQI")
+	test.AssertEquals(t, digest2.Digest, "vrlPN5wIPME1D2PPsCy-fGnTWh8dMyyYQcXPRkjHAQI")
 
 	retrievedCert2, err := sa.GetCertificate(ctx, &sapb.Serial{Serial: serial})
 	test.AssertNotError(t, err, "Couldn't get test-cert.der")
@@ -225,7 +232,12 @@ func TestAddCertificate(t *testing.T) {
 	certDER3, err := ioutil.ReadFile("test-cert2.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 	ocspResp := []byte{0, 0, 1}
-	_, err = sa.AddCertificate(ctx, certDER3, reg.Id, ocspResp, &issuedTime)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER3,
+		RegID:  reg.Id,
+		Ocsp:   ocspResp,
+		Issued: issuedTime.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Couldn't add test-cert2.der")
 }
 
@@ -238,10 +250,18 @@ func TestAddCertificateDuplicate(t *testing.T) {
 	_, testCert := test.ThrowAwayCert(t, 1)
 
 	issuedTime := clk.Now()
-	_, err := sa.AddCertificate(ctx, testCert.Raw, reg.Id, nil, &issuedTime)
+	_, err := sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    testCert.Raw,
+		RegID:  reg.Id,
+		Issued: issuedTime.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Couldn't add test certificate")
 
-	_, err = sa.AddCertificate(ctx, testCert.Raw, reg.Id, nil, &issuedTime)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    testCert.Raw,
+		RegID:  reg.Id,
+		Issued: issuedTime.UnixNano(),
+	})
 	test.AssertDeepEquals(t, err, berrors.DuplicateError("cannot add a duplicate cert"))
 
 }
@@ -276,7 +296,11 @@ func TestCountCertificatesByNames(t *testing.T) {
 	// Add the test cert and query for its names.
 	reg := satest.CreateWorkingRegistration(t, sa)
 	issued := sa.clk.Now()
-	_, err = sa.AddCertificate(ctx, certDER, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Couldn't add test-cert.der")
 
 	// Time range including now should find the cert
@@ -319,7 +343,11 @@ func TestCountCertificatesByNames(t *testing.T) {
 
 	certDER2, err := ioutil.ReadFile("test-cert2.der")
 	test.AssertNotError(t, err, "Couldn't read test-cert2.der")
-	_, err = sa.AddCertificate(ctx, certDER2, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER2,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Couldn't add test-cert2.der")
 	counts, err = sa.CountCertificatesByNames(ctx, names, yesterday, now.Add(10000*time.Hour))
 	test.AssertNotError(t, err, "Error counting certs.")
@@ -672,7 +700,11 @@ func TestPreviousCertificateExists(t *testing.T) {
 		IssuerID: 1,
 	})
 	test.AssertNotError(t, err, "Failed to add precertificate")
-	_, err = sa.AddCertificate(ctx, certDER, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "calling AddCertificate")
 
 	cases := []struct {
@@ -1680,7 +1712,11 @@ func TestAddCertificateRenewalBit(t *testing.T) {
 		IssuerID: 1,
 	})
 	test.AssertNotError(t, err, "Failed to add precertificate")
-	_, err = sa.AddCertificate(ctx, certDER, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Failed to add certificate")
 
 	assertIsRenewal := func(t *testing.T, name string, expected bool) {
@@ -1717,7 +1753,11 @@ func TestAddCertificateRenewalBit(t *testing.T) {
 		IssuerID: 1,
 	})
 	test.AssertNotError(t, err, "Failed to add precertificate")
-	_, err = sa.AddCertificate(ctx, certDER, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certDER,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Failed to add certificate")
 
 	// None of the names should have a issuedNames row marking it as a renewal.
@@ -1783,7 +1823,11 @@ func TestCountCertificatesRenewalBit(t *testing.T) {
 
 	// Add the first certificate - it won't be considered a renewal.
 	issued := certA.NotBefore
-	_, err = sa.AddCertificate(ctx, certADER, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certADER,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Failed to add CertA test certificate")
 
 	// The count for the base domain should be 1 - just certA has been added.
@@ -1791,7 +1835,11 @@ func TestCountCertificatesRenewalBit(t *testing.T) {
 
 	// Add the second certificate - it should be considered a renewal
 	issued = certB.NotBefore
-	_, err = sa.AddCertificate(ctx, certBDER, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certBDER,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Failed to add CertB test certificate")
 
 	// The count for the base domain should still be 1, just certA. CertB should
@@ -1799,7 +1847,11 @@ func TestCountCertificatesRenewalBit(t *testing.T) {
 	test.AssertEquals(t, countName(t, "not-example.com"), int64(1))
 
 	// Add the third certificate - it should not be considered a renewal
-	_, err = sa.AddCertificate(ctx, certCDER, reg.Id, nil, &issued)
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    certCDER,
+		RegID:  reg.Id,
+		Issued: issued.UnixNano(),
+	})
 	test.AssertNotError(t, err, "Failed to add CertC test certificate")
 
 	// The count for the base domain should be 2 now: certA and certC.

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1655,7 +1655,7 @@ func TestRevokeCertificate(t *testing.T) {
 	dateUnix := now.UnixNano()
 	reason := int64(1)
 	response := []byte{1, 2, 3}
-	err = sa.RevokeCertificate(context.Background(), &sapb.RevokeCertificateRequest{
+	_, err = sa.RevokeCertificate(context.Background(), &sapb.RevokeCertificateRequest{
 		Serial:   serial,
 		Date:     dateUnix,
 		Reason:   reason,
@@ -1671,7 +1671,7 @@ func TestRevokeCertificate(t *testing.T) {
 	test.AssertEquals(t, status.OCSPLastUpdated, now)
 	test.AssertDeepEquals(t, status.OCSPResponse, response)
 
-	err = sa.RevokeCertificate(context.Background(), &sapb.RevokeCertificateRequest{
+	_, err = sa.RevokeCertificate(context.Background(), &sapb.RevokeCertificateRequest{
 		Serial:   serial,
 		Date:     dateUnix,
 		Reason:   reason,


### PR DESCRIPTION
Make the gRPC wrappers for the SA's `AddCertificate`,
`AddPrecertificate`, `AddSerial`, and `RevokeCertificate`
methods simple pass-throughs.

Fixup a couple tests that were passing only because their
requests to in-memory SA objects were not passing through
the wrapper's consistency checks.

Part of #5532