### PR TITLE
Allow the operator of ct-test-srv to change the user agent based on the configuration

### DIFF
--- a/test/ct-test-srv/ct-test-srv.json
+++ b/test/ct-test-srv/ct-test-srv.json
@@ -1,6 +1,7 @@
 {
   "Personalities": [
     {
+      "UserAgent": "boulder/1.0",
       "Addr": ":4500",
       "PrivKey": "MHcCAQEEIOCtGlGt/WT7471dOHdfBg43uJWJoZDkZAQjWfTitcVNoAoGCCqGSM49AwEHoUQDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q==",
       "LatencySchedule": [
@@ -14,6 +15,7 @@
       ]
     },
     {
+      "UserAgent": "boulder/1.0",
       "Addr": ":4501",
       "PrivKey": "MHcCAQEEIJSCFDYXt2xCIxv+G8BCzGdUsFIQDWEjxfJDfnn9JB5loAoGCCqGSM49AwEHoUQDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA==",
       "LatencySchedule": [
@@ -31,6 +33,7 @@
       ]
     },
     {
+      "UserAgent": "boulder/1.0",
       "Addr": ":4510",
       "PrivKey": "MHcCAQEEIBtqLTgjiM9nMaUQkbsE1vQWYXpJP0uLqVLV73U2UzlioAoGCCqGSM49AwEHoUQDQgAEyw1HymhJkuxSIgt3gqW3sVXqMqB3EFsXcMfPFo0vYwjNiRmCJDXKsR0Flp7MAK+wc3X/7Hpc8liUbMhPet7tEA==",
       "LatencySchedule": [
@@ -48,6 +51,7 @@
       ]
     },
     {
+      "UserAgent": "boulder/1.0",
       "Addr": ":4511",
       "PrivKey": "MHcCAQEEINwaal89BqkwvQ6r3uOj7R5VEjJi5iSDbAhlYyDhZv/joAoGCCqGSM49AwEHoUQDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
       "LatencySchedule": [
@@ -55,6 +59,7 @@
       ]
     },
     {
+      "UserAgent": "boulder/1.0",
       "Addr": ":4512",
       "PrivKey": "MHcCAQEEINwaal89BqkwvQ6r3uOj7R5VEjJi5iSDbAhlYyDhZv/joAoGCCqGSM49AwEHoUQDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
       "LatencySchedule": [


### PR DESCRIPTION
We use different user agents depending on the environment ct-test-srv is running, allowing us the flexibility to change the expected user-agent will go a long way to making sure we can test with this tool.