### PR TITLE
Unwrap sa.GetCertificateStatus

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -117,8 +117,8 @@ func TestRevokeBatch(t *testing.T) {
 	test.AssertNotError(t, err, "revokeBatch failed")
 
 	for _, serial := range serials {
-		status, err := ssa.GetCertificateStatus(context.Background(), core.SerialToString(serial))
+		status, err := ssa.GetCertificateStatus(context.Background(), &sapb.Serial{Serial: core.SerialToString(serial)})
 		test.AssertNotError(t, err, "failed to retrieve certificate status")
-		test.AssertEquals(t, status.Status, core.OCSPStatusRevoked)
+		test.AssertEquals(t, core.OCSPStatus(status.Status), core.OCSPStatusRevoked)
 	}
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -101,7 +101,7 @@ type StorageGetter interface {
 	GetRegistrationByKey(ctx context.Context, req *sapb.JSONWebKey) (*corepb.Registration, error)
 	GetCertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
 	GetPrecertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
-	GetCertificateStatus(ctx context.Context, serial string) (CertificateStatus, error)
+	GetCertificateStatus(ctx context.Context, req *sapb.Serial) (*corepb.CertificateStatus, error)
 	CountCertificatesByNames(ctx context.Context, domains []string, earliest, latest time.Time) (countByDomain []*sapb.CountByNames_MapElement, err error)
 	CountRegistrationsByIP(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error)
 	CountRegistrationsByIPRange(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error)

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -43,15 +43,8 @@ func (sac StorageAuthorityClientWrapper) GetPrecertificate(ctx context.Context, 
 	return sac.inner.GetPrecertificate(ctx, serial)
 }
 
-func (sac StorageAuthorityClientWrapper) GetCertificateStatus(ctx context.Context, serial string) (core.CertificateStatus, error) {
-	response, err := sac.inner.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
-	if err != nil {
-		return core.CertificateStatus{}, err
-	}
-	if response == nil || response.Serial == "" || response.Status == "" || response.OcspLastUpdated == 0 || response.LastExpirationNagSent == 0 || response.OcspResponse == nil || response.NotAfter == 0 {
-		return core.CertificateStatus{}, errIncompleteResponse
-	}
-	return PBToCertStatus(response)
+func (sac StorageAuthorityClientWrapper) GetCertificateStatus(ctx context.Context, req *sapb.Serial) (*corepb.CertificateStatus, error) {
+	return sac.inner.GetCertificateStatus(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) CountCertificatesByNames(ctx context.Context, domains []string, earliest, latest time.Time) ([]*sapb.CountByNames_MapElement, error) {
@@ -352,16 +345,7 @@ func (sas StorageAuthorityServerWrapper) GetPrecertificate(ctx context.Context, 
 }
 
 func (sas StorageAuthorityServerWrapper) GetCertificateStatus(ctx context.Context, request *sapb.Serial) (*corepb.CertificateStatus, error) {
-	if core.IsAnyNilOrZero(request, request.Serial) {
-		return nil, errIncompleteRequest
-	}
-
-	certStatus, err := sas.inner.GetCertificateStatus(ctx, request.Serial)
-	if err != nil {
-		return nil, err
-	}
-
-	return CertStatusToPB(certStatus), nil
+	return sas.inner.GetCertificateStatus(ctx, request)
 }
 
 func (sas StorageAuthorityServerWrapper) CountCertificatesByNames(ctx context.Context, request *sapb.CountCertificatesByNamesRequest) (*sapb.CountByNames, error) {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -260,18 +260,18 @@ func (sa *StorageAuthority) GetPrecertificate(_ context.Context, _ *sapb.Serial)
 }
 
 // GetCertificateStatus is a mock
-func (sa *StorageAuthority) GetCertificateStatus(_ context.Context, serial string) (core.CertificateStatus, error) {
+func (sa *StorageAuthority) GetCertificateStatus(_ context.Context, req *sapb.Serial) (*corepb.CertificateStatus, error) {
 	// Serial ee == 238.crt
-	if serial == "0000000000000000000000000000000000ee" {
-		return core.CertificateStatus{
-			Status: core.OCSPStatusGood,
+	if req.Serial == "0000000000000000000000000000000000ee" {
+		return &corepb.CertificateStatus{
+			Status: string(core.OCSPStatusGood),
 		}, nil
-	} else if serial == "0000000000000000000000000000000000b2" {
-		return core.CertificateStatus{
-			Status: core.OCSPStatusRevoked,
+	} else if req.Serial == "0000000000000000000000000000000000b2" {
+		return &corepb.CertificateStatus{
+			Status: string(core.OCSPStatusRevoked),
 		}, nil
 	} else {
-		return core.CertificateStatus{}, errors.New("No cert status")
+		return nil, errors.New("No cert status")
 	}
 }
 

--- a/sa/precertificates_test.go
+++ b/sa/precertificates_test.go
@@ -53,18 +53,14 @@ func TestAddPrecertificate(t *testing.T) {
 		test.AssertNotError(t, err, "Couldn't add test cert")
 
 		// It should have the expected certificate status
-		certStatus, err := sa.GetCertificateStatus(ctx, serial)
+		certStatus, err := sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
 		test.AssertNotError(t, err, "Couldn't get status for test cert")
 		test.Assert(
 			t,
-			bytes.Compare(certStatus.OCSPResponse, ocspResp) == 0,
-			fmt.Sprintf("OCSP responses don't match, expected: %x, got %x", certStatus.OCSPResponse, ocspResp),
+			bytes.Compare(certStatus.OcspResponse, ocspResp) == 0,
+			fmt.Sprintf("OCSP responses don't match, expected: %x, got %x", certStatus.OcspResponse, ocspResp),
 		)
-		test.Assert(
-			t,
-			clk.Now().Equal(certStatus.OCSPLastUpdated),
-			fmt.Sprintf("OCSPLastUpdated doesn't match, expected %s, got %s", clk.Now(), certStatus.OCSPLastUpdated),
-		)
+		test.AssertEquals(t, clk.Now().UnixNano(), certStatus.OcspLastUpdated)
 
 		issuedNamesSerial, err := findIssuedName(sa.dbMap, testCert.DNSNames[0])
 		if expectIssuedNamesUpdate {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -341,18 +341,21 @@ func (ssa *SQLStorageAuthority) GetCertificate(ctx context.Context, req *sapb.Se
 // GetCertificateStatus takes a hexadecimal string representing the full 128-bit serial
 // number of a certificate and returns data about that certificate's current
 // validity.
-func (ssa *SQLStorageAuthority) GetCertificateStatus(ctx context.Context, serial string) (core.CertificateStatus, error) {
-	if !core.ValidSerial(serial) {
-		err := fmt.Errorf("Invalid certificate serial %s", serial)
-		return core.CertificateStatus{}, err
+func (ssa *SQLStorageAuthority) GetCertificateStatus(ctx context.Context, req *sapb.Serial) (*corepb.CertificateStatus, error) {
+	if req.Serial == "" {
+		return nil, errIncompleteRequest
+	}
+	if !core.ValidSerial(req.Serial) {
+		err := fmt.Errorf("Invalid certificate serial %s", req.Serial)
+		return nil, err
 	}
 
-	certStatus, err := SelectCertificateStatus(ssa.dbMap.WithContext(ctx), serial)
+	certStatus, err := SelectCertificateStatus(ssa.dbMap.WithContext(ctx), req.Serial)
 	if err != nil {
-		return core.CertificateStatus{}, err
+		return nil, err
 	}
 
-	return certStatus, nil
+	return bgrpc.CertStatusToPB(certStatus), nil
 }
 
 // NewRegistration stores a new Registration

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -27,7 +27,6 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
-	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/sa/satest"
 	"github.com/letsencrypt/boulder/test"
@@ -1645,35 +1644,34 @@ func TestRevokeCertificate(t *testing.T) {
 
 	serial := "000000000000000000000000000000021bd4"
 
-	status, err := sa.GetCertificateStatus(ctx, serial)
+	status, err := sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
 	test.AssertNotError(t, err, "GetCertificateStatus failed")
-	test.AssertEquals(t, status.Status, core.OCSPStatusGood)
+	test.AssertEquals(t, core.OCSPStatus(status.Status), core.OCSPStatusGood)
 
 	fc.Add(1 * time.Hour)
 
 	now := fc.Now()
-	dateUnix := now.UnixNano()
 	reason := int64(1)
 	response := []byte{1, 2, 3}
 	_, err = sa.RevokeCertificate(context.Background(), &sapb.RevokeCertificateRequest{
 		Serial:   serial,
-		Date:     dateUnix,
+		Date:     now.UnixNano(),
 		Reason:   reason,
 		Response: response,
 	})
 	test.AssertNotError(t, err, "RevokeCertificate failed")
 
-	status, err = sa.GetCertificateStatus(ctx, serial)
+	status, err = sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
 	test.AssertNotError(t, err, "GetCertificateStatus failed")
-	test.AssertEquals(t, status.Status, core.OCSPStatusRevoked)
-	test.AssertEquals(t, status.RevokedReason, revocation.Reason(reason))
-	test.AssertEquals(t, status.RevokedDate, now)
-	test.AssertEquals(t, status.OCSPLastUpdated, now)
-	test.AssertDeepEquals(t, status.OCSPResponse, response)
+	test.AssertEquals(t, core.OCSPStatus(status.Status), core.OCSPStatusRevoked)
+	test.AssertEquals(t, status.RevokedReason, reason)
+	test.AssertEquals(t, status.RevokedDate, now.UnixNano())
+	test.AssertEquals(t, status.OcspLastUpdated, now.UnixNano())
+	test.AssertDeepEquals(t, status.OcspResponse, response)
 
 	_, err = sa.RevokeCertificate(context.Background(), &sapb.RevokeCertificateRequest{
 		Serial:   serial,
-		Date:     dateUnix,
+		Date:     now.UnixNano(),
 		Reason:   reason,
 		Response: response,
 	})

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1786,14 +1786,14 @@ func (sa *mockSAWithCert) GetCertificate(_ context.Context, req *sapb.Serial) (*
 
 // GetCertificateStatus returns the mock SA's status, if the given serial matches.
 // Otherwise, returns not found.
-func (sa *mockSAWithCert) GetCertificateStatus(_ context.Context, serial string) (core.CertificateStatus, error) {
-	if serial != core.SerialToString(sa.cert.SerialNumber) {
-		return core.CertificateStatus{}, berrors.NotFoundError("Status for certificate with serial %q not found", serial)
+func (sa *mockSAWithCert) GetCertificateStatus(_ context.Context, req *sapb.Serial) (*corepb.CertificateStatus, error) {
+	if req.Serial != core.SerialToString(sa.cert.SerialNumber) {
+		return nil, berrors.NotFoundError("Status for certificate with serial %q not found", req.Serial)
 	}
 
-	return core.CertificateStatus{
+	return &corepb.CertificateStatus{
 		Serial: core.SerialToString(sa.cert.SerialNumber),
-		Status: sa.status,
+		Status: string(sa.status),
 	}, nil
 }
 


### PR DESCRIPTION
Turn the `GetCertificateStatus` wrappers into pass-throughs.

Part of #5532