### PR TITLE
Unwrap SA FQDNSet and PreviousCertificate existence methods

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -107,7 +107,7 @@ type StorageGetter interface {
 	CountRegistrationsByIPRange(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error)
 	CountOrders(ctx context.Context, acctID int64, earliest, latest time.Time) (int, error)
 	CountFQDNSets(ctx context.Context, window time.Duration, domains []string) (count int64, err error)
-	FQDNSetExists(ctx context.Context, domains []string) (exists bool, err error)
+	FQDNSetExists(ctx context.Context, req *sapb.FQDNSetExistsRequest) (*sapb.Exists, error)
 	PreviousCertificateExists(ctx context.Context, req *sapb.PreviousCertificateExistsRequest) (exists *sapb.Exists, err error)
 	GetOrder(ctx context.Context, req *sapb.OrderRequest) (*corepb.Order, error)
 	GetOrderForNames(ctx context.Context, req *sapb.GetOrderForNamesRequest) (*corepb.Order, error)

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -153,18 +153,8 @@ func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, wind
 	return response.Count, nil
 }
 
-func (sac StorageAuthorityClientWrapper) PreviousCertificateExists(
-	ctx context.Context,
-	req *sapb.PreviousCertificateExistsRequest,
-) (*sapb.Exists, error) {
-	exists, err := sac.inner.PreviousCertificateExists(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if exists == nil {
-		return nil, errIncompleteResponse
-	}
-	return exists, err
+func (sac StorageAuthorityClientWrapper) PreviousCertificateExists(ctx context.Context, req *sapb.PreviousCertificateExistsRequest) (*sapb.Exists, error) {
+	return sac.inner.PreviousCertificateExists(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) AddPrecertificate(ctx context.Context, req *sapb.AddCertificateRequest) (*emptypb.Empty, error) {
@@ -476,13 +466,7 @@ func (sas StorageAuthorityServerWrapper) FQDNSetExists(ctx context.Context, requ
 	return sas.inner.FQDNSetExists(ctx, request)
 }
 
-func (sac StorageAuthorityServerWrapper) PreviousCertificateExists(
-	ctx context.Context,
-	req *sapb.PreviousCertificateExistsRequest,
-) (*sapb.Exists, error) {
-	if core.IsAnyNilOrZero(req, req.Domain, req.RegID) {
-		return nil, errIncompleteRequest
-	}
+func (sac StorageAuthorityServerWrapper) PreviousCertificateExists(ctx context.Context, req *sapb.PreviousCertificateExistsRequest) (*sapb.Exists, error) {
 	return sac.inner.PreviousCertificateExists(ctx, req)
 }
 

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -175,17 +175,8 @@ func (sac StorageAuthorityClientWrapper) AddSerial(ctx context.Context, req *sap
 	return sac.inner.AddSerial(ctx, req)
 }
 
-func (sac StorageAuthorityClientWrapper) FQDNSetExists(ctx context.Context, domains []string) (bool, error) {
-	response, err := sac.inner.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: domains})
-	if err != nil {
-		return false, err
-	}
-
-	if response == nil {
-		return false, errIncompleteResponse
-	}
-
-	return response.Exists, nil
+func (sac StorageAuthorityClientWrapper) FQDNSetExists(ctx context.Context, req *sapb.FQDNSetExistsRequest) (*sapb.Exists, error) {
+	return sac.inner.FQDNSetExists(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) NewRegistration(ctx context.Context, req *corepb.Registration) (*corepb.Registration, error) {
@@ -482,16 +473,7 @@ func (sas StorageAuthorityServerWrapper) CountFQDNSets(ctx context.Context, requ
 }
 
 func (sas StorageAuthorityServerWrapper) FQDNSetExists(ctx context.Context, request *sapb.FQDNSetExistsRequest) (*sapb.Exists, error) {
-	if request == nil || request.Domains == nil {
-		return nil, errIncompleteRequest
-	}
-
-	exists, err := sas.inner.FQDNSetExists(ctx, request.Domains)
-	if err != nil {
-		return nil, err
-	}
-
-	return &sapb.Exists{Exists: exists}, nil
+	return sas.inner.FQDNSetExists(ctx, request)
 }
 
 func (sac StorageAuthorityServerWrapper) PreviousCertificateExists(

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -316,8 +316,8 @@ func (sa *StorageAuthority) CountFQDNSets(_ context.Context, since time.Duration
 }
 
 // FQDNSetExists is a mock
-func (sa *StorageAuthority) FQDNSetExists(_ context.Context, names []string) (bool, error) {
-	return false, nil
+func (sa *StorageAuthority) FQDNSetExists(_ context.Context, _ *sapb.FQDNSetExistsRequest) (*sapb.Exists, error) {
+	return &sapb.Exists{Exists: false}, nil
 }
 
 func (sa *StorageAuthority) PreviousCertificateExists(

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1393,11 +1393,11 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 	// check if there is already an existing certificate for
 	// the exact name set we are issuing for. If so bypass the
 	// the certificatesPerName limit.
-	exists, err := ra.SA.FQDNSetExists(ctx, names)
+	exists, err := ra.SA.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: names})
 	if err != nil {
 		return fmt.Errorf("checking renewal exemption for %q: %s", names, err)
 	}
-	if exists {
+	if exists.Exists {
 		ra.rateLimitCounter.WithLabelValues("certificates_for_domain", "FQDN set bypass").Inc()
 		return nil
 	}
@@ -1417,11 +1417,11 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 		// check if there is already an existing certificate for
 		// the exact name set we are issuing for. If so bypass the
 		// the certificatesPerName limit.
-		exists, err := ra.SA.FQDNSetExists(ctx, names)
+		exists, err := ra.SA.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: names})
 		if err != nil {
 			return fmt.Errorf("checking renewal exemption for %q: %s", names, err)
 		}
-		if exists {
+		if exists.Exists {
 			ra.rateLimitCounter.WithLabelValues("certificates_for_domain", "FQDN set bypass").Inc()
 			return nil
 		}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1727,12 +1727,12 @@ func (m mockSAWithFQDNSet) addFQDNSet(names []string) {
 }
 
 // Search for a set of domain names in the FQDN set map
-func (m mockSAWithFQDNSet) FQDNSetExists(_ context.Context, names []string) (bool, error) {
-	hash := m.hashNames(names)
+func (m mockSAWithFQDNSet) FQDNSetExists(_ context.Context, req *sapb.FQDNSetExistsRequest) (*sapb.Exists, error) {
+	hash := m.hashNames(req.Domains)
 	if _, exists := m.fqdnSet[hash]; exists {
-		return true, nil
+		return &sapb.Exists{Exists: true}, nil
 	}
-	return false, nil
+	return &sapb.Exists{Exists: false}, nil
 }
 
 // Return a map of domain -> certificate count.

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -764,14 +764,15 @@ func (ssa *SQLStorageAuthority) getNewIssuancesByFQDNSet(
 
 // FQDNSetExists returns a bool indicating if one or more FQDN sets |names|
 // exists in the database
-func (ssa *SQLStorageAuthority) FQDNSetExists(ctx context.Context, names []string) (bool, error) {
-	exists, err := ssa.checkFQDNSetExists(
-		ssa.dbMap.WithContext(ctx).SelectOne,
-		names)
-	if err != nil {
-		return false, err
+func (ssa *SQLStorageAuthority) FQDNSetExists(ctx context.Context, req *sapb.FQDNSetExistsRequest) (*sapb.Exists, error) {
+	if len(req.Domains) == 0 {
+		return nil, errIncompleteRequest
 	}
-	return exists, nil
+	exists, err := ssa.checkFQDNSetExists(ssa.dbMap.WithContext(ctx).SelectOne, req.Domains)
+	if err != nil {
+		return nil, err
+	}
+	return &sapb.Exists{Exists: exists}, nil
 }
 
 // oneSelectorFunc is a func type that matches both gorp.Transaction.SelectOne

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -799,10 +799,11 @@ func (ssa *SQLStorageAuthority) checkFQDNSetExists(selector oneSelectorFunc, nam
 // used to determine if a certificate has previously been issued for a given
 // domain name in order to determine if validations should be allowed during
 // the v1 API shutoff.
-func (ssa *SQLStorageAuthority) PreviousCertificateExists(
-	ctx context.Context,
-	req *sapb.PreviousCertificateExistsRequest,
-) (*sapb.Exists, error) {
+func (ssa *SQLStorageAuthority) PreviousCertificateExists(ctx context.Context, req *sapb.PreviousCertificateExistsRequest) (*sapb.Exists, error) {
+	if req.Domain == "" || req.RegID == 0 {
+		return nil, errIncompleteRequest
+	}
+
 	exists := &sapb.Exists{Exists: true}
 	notExists := &sapb.Exists{Exists: false}
 

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -551,9 +551,9 @@ func TestFQDNSetsExists(t *testing.T) {
 	defer cleanUp()
 
 	names := []string{"a.example.com", "B.example.com"}
-	exists, err := sa.FQDNSetExists(ctx, names)
+	exists, err := sa.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: names})
 	test.AssertNotError(t, err, "Failed to check FQDN set existence")
-	test.Assert(t, !exists, "FQDN set shouldn't exist")
+	test.Assert(t, !exists.Exists, "FQDN set shouldn't exist")
 
 	tx, err := sa.dbMap.Begin()
 	test.AssertNotError(t, err, "Failed to open transaction")
@@ -563,9 +563,9 @@ func TestFQDNSetsExists(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to add name set")
 	test.AssertNotError(t, tx.Commit(), "Failed to commit transaction")
 
-	exists, err = sa.FQDNSetExists(ctx, names)
+	exists, err = sa.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: names})
 	test.AssertNotError(t, err, "Failed to check FQDN set existence")
-	test.Assert(t, exists, "FQDN set does exist")
+	test.Assert(t, exists.Exists, "FQDN set does exist")
 }
 
 type execRecorder struct {


### PR DESCRIPTION
Turn the `sa.FQDNSetExists` and `sa.PreviousCertificateExists`
wrappers into passthroughs.

Fixes #5532