### PR TITLE
GRPC: Unwrap SA Count methods

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -104,7 +104,7 @@ type StorageGetter interface {
 	CountCertificatesByNames(ctx context.Context, domains []string, earliest, latest time.Time) (countByDomain []*sapb.CountByNames_MapElement, err error)
 	CountRegistrationsByIP(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error)
 	CountRegistrationsByIPRange(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error)
-	CountOrders(ctx context.Context, acctID int64, earliest, latest time.Time) (int, error)
+	CountOrders(ctx context.Context, req *sapb.CountOrdersRequest) (*sapb.Count, error)
 	CountFQDNSets(ctx context.Context, window time.Duration, domains []string) (count int64, err error)
 	FQDNSetExists(ctx context.Context, domains []string) (exists bool, err error)
 	PreviousCertificateExists(ctx context.Context, req *sapb.PreviousCertificateExistsRequest) (exists *sapb.Exists, err error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"time"
 
@@ -103,8 +102,8 @@ type StorageGetter interface {
 	GetPrecertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error)
 	GetCertificateStatus(ctx context.Context, serial string) (CertificateStatus, error)
 	CountCertificatesByNames(ctx context.Context, domains []string, earliest, latest time.Time) (countByDomain []*sapb.CountByNames_MapElement, err error)
-	CountRegistrationsByIP(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error)
-	CountRegistrationsByIPRange(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error)
+	CountRegistrationsByIP(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error)
+	CountRegistrationsByIPRange(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error)
 	CountOrders(ctx context.Context, acctID int64, earliest, latest time.Time) (int, error)
 	CountFQDNSets(ctx context.Context, window time.Duration, domains []string) (count int64, err error)
 	FQDNSetExists(ctx context.Context, domains []string) (exists bool, err error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -105,7 +105,7 @@ type StorageGetter interface {
 	CountRegistrationsByIP(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error)
 	CountRegistrationsByIPRange(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error)
 	CountOrders(ctx context.Context, req *sapb.CountOrdersRequest) (*sapb.Count, error)
-	CountFQDNSets(ctx context.Context, window time.Duration, domains []string) (count int64, err error)
+	CountFQDNSets(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Count, error)
 	FQDNSetExists(ctx context.Context, domains []string) (exists bool, err error)
 	PreviousCertificateExists(ctx context.Context, req *sapb.PreviousCertificateExistsRequest) (exists *sapb.Exists, err error)
 	GetOrder(ctx context.Context, req *sapb.OrderRequest) (*corepb.Order, error)

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -8,7 +8,6 @@ package grpc
 
 import (
 	"context"
-	"net"
 	"time"
 
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -76,48 +75,12 @@ func (sac StorageAuthorityClientWrapper) CountCertificatesByNames(ctx context.Co
 	return response.CountByNames, nil
 }
 
-func (sac StorageAuthorityClientWrapper) CountRegistrationsByIP(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error) {
-	earliestNano := earliest.UnixNano()
-	latestNano := latest.UnixNano()
-
-	response, err := sac.inner.CountRegistrationsByIP(ctx, &sapb.CountRegistrationsByIPRequest{
-		Range: &sapb.Range{
-			Earliest: earliestNano,
-			Latest:   latestNano,
-		},
-		Ip: ip,
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	if response == nil {
-		return 0, errIncompleteResponse
-	}
-
-	return int(response.Count), nil
+func (sac StorageAuthorityClientWrapper) CountRegistrationsByIP(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
+	return sac.inner.CountRegistrationsByIP(ctx, req)
 }
 
-func (sac StorageAuthorityClientWrapper) CountRegistrationsByIPRange(ctx context.Context, ip net.IP, earliest, latest time.Time) (int, error) {
-	earliestNano := earliest.UnixNano()
-	latestNano := latest.UnixNano()
-
-	response, err := sac.inner.CountRegistrationsByIPRange(ctx, &sapb.CountRegistrationsByIPRequest{
-		Range: &sapb.Range{
-			Earliest: earliestNano,
-			Latest:   latestNano,
-		},
-		Ip: ip,
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	if response == nil {
-		return 0, errIncompleteResponse
-	}
-
-	return int(response.Count), nil
+func (sac StorageAuthorityClientWrapper) CountRegistrationsByIPRange(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
+	return sac.inner.CountRegistrationsByIPRange(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) CountOrders(ctx context.Context, acctID int64, earliest, latest time.Time) (int, error) {
@@ -378,37 +341,11 @@ func (sas StorageAuthorityServerWrapper) CountCertificatesByNames(ctx context.Co
 }
 
 func (sas StorageAuthorityServerWrapper) CountRegistrationsByIP(ctx context.Context, request *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
-	if core.IsAnyNilOrZero(request, request.Range, request.Range.Earliest, request.Range.Latest, request.Ip) {
-		return nil, errIncompleteRequest
-	}
-
-	count, err := sas.inner.CountRegistrationsByIP(
-		ctx,
-		net.IP(request.Ip),
-		time.Unix(0, request.Range.Earliest),
-		time.Unix(0, request.Range.Latest))
-	if err != nil {
-		return nil, err
-	}
-
-	return &sapb.Count{Count: int64(count)}, nil
+	return sas.inner.CountRegistrationsByIP(ctx, request)
 }
 
 func (sas StorageAuthorityServerWrapper) CountRegistrationsByIPRange(ctx context.Context, request *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
-	if core.IsAnyNilOrZero(request, request.Range, request.Range.Earliest, request.Range.Latest, request.Ip) {
-		return nil, errIncompleteRequest
-	}
-
-	count, err := sas.inner.CountRegistrationsByIPRange(
-		ctx,
-		net.IP(request.Ip),
-		time.Unix(0, request.Range.Earliest),
-		time.Unix(0, request.Range.Latest))
-	if err != nil {
-		return nil, err
-	}
-
-	return &sapb.Count{Count: int64(count)}, nil
+	return sas.inner.CountRegistrationsByIPRange(ctx, request)
 }
 
 func (sas StorageAuthorityServerWrapper) CountOrders(ctx context.Context, request *sapb.CountOrdersRequest) (*sapb.Count, error) {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -87,22 +87,8 @@ func (sac StorageAuthorityClientWrapper) CountOrders(ctx context.Context, req *s
 	return sac.inner.CountOrders(ctx, req)
 }
 
-func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, window time.Duration, domains []string) (int64, error) {
-	windowNanos := window.Nanoseconds()
-
-	response, err := sac.inner.CountFQDNSets(ctx, &sapb.CountFQDNSetsRequest{
-		Window:  windowNanos,
-		Domains: domains,
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	if response == nil {
-		return 0, errIncompleteResponse
-	}
-
-	return response.Count, nil
+func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Count, error) {
+	return sac.inner.CountFQDNSets(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) PreviousCertificateExists(
@@ -335,18 +321,7 @@ func (sas StorageAuthorityServerWrapper) CountOrders(ctx context.Context, reques
 }
 
 func (sas StorageAuthorityServerWrapper) CountFQDNSets(ctx context.Context, request *sapb.CountFQDNSetsRequest) (*sapb.Count, error) {
-	if core.IsAnyNilOrZero(request, request.Window, request.Domains) {
-		return nil, errIncompleteRequest
-	}
-
-	window := time.Duration(request.Window)
-
-	count, err := sas.inner.CountFQDNSets(ctx, window, request.Domains)
-	if err != nil {
-		return nil, err
-	}
-
-	return &sapb.Count{Count: int64(count)}, nil
+	return sas.inner.CountFQDNSets(ctx, request)
 }
 
 func (sas StorageAuthorityServerWrapper) FQDNSetExists(ctx context.Context, request *sapb.FQDNSetExistsRequest) (*sapb.Exists, error) {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -83,26 +83,8 @@ func (sac StorageAuthorityClientWrapper) CountRegistrationsByIPRange(ctx context
 	return sac.inner.CountRegistrationsByIPRange(ctx, req)
 }
 
-func (sac StorageAuthorityClientWrapper) CountOrders(ctx context.Context, acctID int64, earliest, latest time.Time) (int, error) {
-	earliestNano := earliest.UnixNano()
-	latestNano := latest.UnixNano()
-
-	response, err := sac.inner.CountOrders(ctx, &sapb.CountOrdersRequest{
-		AccountID: acctID,
-		Range: &sapb.Range{
-			Earliest: earliestNano,
-			Latest:   latestNano,
-		},
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	if response == nil {
-		return 0, errIncompleteResponse
-	}
-
-	return int(response.Count), nil
+func (sac StorageAuthorityClientWrapper) CountOrders(ctx context.Context, req *sapb.CountOrdersRequest) (*sapb.Count, error) {
+	return sac.inner.CountOrders(ctx, req)
 }
 
 func (sac StorageAuthorityClientWrapper) CountFQDNSets(ctx context.Context, window time.Duration, domains []string) (int64, error) {
@@ -349,20 +331,7 @@ func (sas StorageAuthorityServerWrapper) CountRegistrationsByIPRange(ctx context
 }
 
 func (sas StorageAuthorityServerWrapper) CountOrders(ctx context.Context, request *sapb.CountOrdersRequest) (*sapb.Count, error) {
-	if core.IsAnyNilOrZero(request, request.AccountID, request.Range, request.Range.Earliest, request.Range.Latest) {
-		return nil, errIncompleteRequest
-	}
-
-	count, err := sas.inner.CountOrders(ctx,
-		request.AccountID,
-		time.Unix(0, request.Range.Earliest),
-		time.Unix(0, request.Range.Latest),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &sapb.Count{Count: int64(count)}, nil
+	return sas.inner.CountOrders(ctx, request)
 }
 
 func (sas StorageAuthorityServerWrapper) CountFQDNSets(ctx context.Context, request *sapb.CountFQDNSetsRequest) (*sapb.Count, error) {

--- a/grpc/sa-wrappers.go
+++ b/grpc/sa-wrappers.go
@@ -205,14 +205,7 @@ func (sas StorageAuthorityClientWrapper) GetPendingAuthorization2(ctx context.Co
 }
 
 func (sas StorageAuthorityClientWrapper) CountPendingAuthorizations2(ctx context.Context, req *sapb.RegistrationID) (*sapb.Count, error) {
-	count, err := sas.inner.CountPendingAuthorizations2(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if count == nil {
-		return nil, errIncompleteResponse
-	}
-	return count, nil
+	return sas.inner.CountPendingAuthorizations2(ctx, req)
 }
 
 func (sas StorageAuthorityClientWrapper) GetValidOrderAuthorizations2(ctx context.Context, req *sapb.GetValidOrderAuthorizationsRequest) (*sapb.Authorizations, error) {
@@ -220,14 +213,7 @@ func (sas StorageAuthorityClientWrapper) GetValidOrderAuthorizations2(ctx contex
 }
 
 func (sas StorageAuthorityClientWrapper) CountInvalidAuthorizations2(ctx context.Context, req *sapb.CountInvalidAuthorizationsRequest) (*sapb.Count, error) {
-	count, err := sas.inner.CountInvalidAuthorizations2(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if count == nil {
-		return nil, errIncompleteResponse
-	}
-	return count, nil
+	return sas.inner.CountInvalidAuthorizations2(ctx, req)
 }
 
 func (sas StorageAuthorityClientWrapper) GetValidAuthorizations2(ctx context.Context, req *sapb.GetValidAuthorizationsRequest) (*sapb.Authorizations, error) {
@@ -440,10 +426,6 @@ func (sas StorageAuthorityServerWrapper) GetPendingAuthorization2(ctx context.Co
 }
 
 func (sas StorageAuthorityServerWrapper) CountPendingAuthorizations2(ctx context.Context, req *sapb.RegistrationID) (*sapb.Count, error) {
-	if core.IsAnyNilOrZero(req, req.Id) {
-		return nil, errIncompleteRequest
-	}
-
 	return sas.inner.CountPendingAuthorizations2(ctx, req)
 }
 
@@ -452,10 +434,6 @@ func (sas StorageAuthorityServerWrapper) GetValidOrderAuthorizations2(ctx contex
 }
 
 func (sas StorageAuthorityServerWrapper) CountInvalidAuthorizations2(ctx context.Context, req *sapb.CountInvalidAuthorizationsRequest) (*sapb.Count, error) {
-	if core.IsAnyNilOrZero(req, req.RegistrationID, req.Hostname, req.Range, req.Range.Earliest, req.Range.Latest) {
-		return nil, errIncompleteRequest
-	}
-
 	return sas.inner.CountInvalidAuthorizations2(ctx, req)
 }
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -513,7 +513,7 @@ func (sa *StorageAuthority) DeactivateAuthorization2(ctx context.Context, req *s
 }
 
 func (sa *StorageAuthority) CountPendingAuthorizations2(ctx context.Context, req *sapb.RegistrationID) (*sapb.Count, error) {
-	return nil, nil
+	return &sapb.Count{}, nil
 }
 
 func (sa *StorageAuthority) GetValidOrderAuthorizations2(ctx context.Context, req *sapb.GetValidOrderAuthorizationsRequest) (*sapb.Authorizations, error) {
@@ -521,7 +521,7 @@ func (sa *StorageAuthority) GetValidOrderAuthorizations2(ctx context.Context, re
 }
 
 func (sa *StorageAuthority) CountInvalidAuthorizations2(ctx context.Context, req *sapb.CountInvalidAuthorizationsRequest) (*sapb.Count, error) {
-	return nil, nil
+	return &sapb.Count{}, nil
 }
 
 func (sa *StorageAuthority) GetValidAuthorizations2(ctx context.Context, req *sapb.GetValidAuthorizationsRequest) (*sapb.Authorizations, error) {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -387,8 +387,8 @@ func (sa *StorageAuthority) CountPendingAuthorizations(_ context.Context, _ int6
 }
 
 // CountOrders is a mock
-func (sa *StorageAuthority) CountOrders(_ context.Context, _ int64, _, _ time.Time) (int, error) {
-	return 0, nil
+func (sa *StorageAuthority) CountOrders(_ context.Context, _ *sapb.CountOrdersRequest) (*sapb.Count, error) {
+	return &sapb.Count{}, nil
 }
 
 // DeactivateAuthorization is a mock

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -372,13 +372,13 @@ func (sa *StorageAuthority) CountCertificatesByNames(_ context.Context, _ []stri
 }
 
 // CountRegistrationsByIP is a mock
-func (sa *StorageAuthority) CountRegistrationsByIP(_ context.Context, _ net.IP, _, _ time.Time) (int, error) {
-	return 0, nil
+func (sa *StorageAuthority) CountRegistrationsByIP(_ context.Context, _ *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
+	return &sapb.Count{}, nil
 }
 
 // CountRegistrationsByIPRange is a mock
-func (sa *StorageAuthority) CountRegistrationsByIPRange(_ context.Context, _ net.IP, _, _ time.Time) (int, error) {
-	return 0, nil
+func (sa *StorageAuthority) CountRegistrationsByIPRange(_ context.Context, _ *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
+	return &sapb.Count{}, nil
 }
 
 // CountPendingAuthorizations is a mock

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -311,8 +311,8 @@ func (sa *StorageAuthority) UpdateRegistration(_ context.Context, _ *corepb.Regi
 }
 
 // CountFQDNSets is a mock
-func (sa *StorageAuthority) CountFQDNSets(_ context.Context, since time.Duration, names []string) (int64, error) {
-	return 0, nil
+func (sa *StorageAuthority) CountFQDNSets(_ context.Context, _ *sapb.CountFQDNSetsRequest) (*sapb.Count, error) {
+	return &sapb.Count{}, nil
 }
 
 // FQDNSetExists is a mock

--- a/ra/mock_test.go
+++ b/ra/mock_test.go
@@ -2,7 +2,6 @@ package ra
 
 import (
 	"context"
-	"time"
 
 	"github.com/letsencrypt/boulder/mocks"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
@@ -13,8 +12,8 @@ type mockInvalidAuthorizationsAuthority struct {
 	domainWithFailures string
 }
 
-func (sa *mockInvalidAuthorizationsAuthority) CountOrders(ctx context.Context, _ int64, _ time.Time, _ time.Time) (int, error) {
-	return 0, nil
+func (sa *mockInvalidAuthorizationsAuthority) CountOrders(ctx context.Context, _ *sapb.CountOrdersRequest) (*sapb.Count, error) {
+	return &sapb.Count{}, nil
 }
 
 func (sa *mockInvalidAuthorizationsAuthority) PreviousCertificateExists(

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1746,14 +1746,14 @@ func (m mockSAWithFQDNSet) CountCertificatesByNames(ctx context.Context, names [
 	return results, nil
 }
 
-func (m mockSAWithFQDNSet) CountFQDNSets(_ context.Context, _ time.Duration, names []string) (int64, error) {
+func (m mockSAWithFQDNSet) CountFQDNSets(_ context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Count, error) {
 	var count int64
-	for _, name := range names {
+	for _, name := range req.Domains {
 		if entry, ok := m.nameCounts[name]; ok {
 			count += entry.Count
 		}
 	}
-	return count, nil
+	return &sapb.Count{Count: count}, nil
 }
 
 // Tests for boulder issue 1925[0] - that the `checkCertificatesPerNameLimit`

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1291,7 +1291,7 @@ func TestEarlyOrderRateLimiting(t *testing.T) {
 			Window:    cmd.ConfigDuration{Duration: rateLimitDuration},
 			// Setting the Threshold to 0 skips applying the rate limit. Setting an
 			// override to 0 does the trick.
-			Overrides: map[string]int{
+			Overrides: map[string]int64{
 				domain: 0,
 			},
 		},
@@ -1414,13 +1414,13 @@ func TestRateLimitLiveReload(t *testing.T) {
 	test.AssertNotError(t, err, "failed to SetRateLimitPoliciesFile")
 
 	// Test some fields of the initial policy to ensure it loaded correctly
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le.wtf"], 10000)
-	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP().Overrides["127.0.0.1"], 1000000)
-	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount().Threshold, 150)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, 6)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Overrides["le.wtf"], 10000)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSetFast().Threshold, 2)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSetFast().Overrides["le.wtf"], 100)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le.wtf"], int64(10000))
+	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP().Overrides["127.0.0.1"], int64(1000000))
+	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount().Threshold, int64(150))
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, int64(6))
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Overrides["le.wtf"], int64(10000))
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSetFast().Threshold, int64(2))
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSetFast().Overrides["le.wtf"], int64(100))
 
 	// Write a different  policy YAML to the monitored file, expect a reload.
 	// Sleep a few milliseconds before writing so the timestamp isn't identical to
@@ -1436,12 +1436,12 @@ func TestRateLimitLiveReload(t *testing.T) {
 
 	// Test fields of the policy to make sure writing the new policy to the monitored file
 	// resulted in the runtime values being updated
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le.wtf"], 9999)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le4.wtf"], 9999)
-	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP().Overrides["127.0.0.1"], 999990)
-	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount().Threshold, 999)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Overrides["le.wtf"], 9999)
-	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, 99999)
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le.wtf"], int64(9999))
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerName().Overrides["le4.wtf"], int64(9999))
+	test.AssertEquals(t, ra.rlPolicies.RegistrationsPerIP().Overrides["127.0.0.1"], int64(999990))
+	test.AssertEquals(t, ra.rlPolicies.PendingAuthorizationsPerAccount().Threshold, int64(999))
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Overrides["le.wtf"], int64(9999))
+	test.AssertEquals(t, ra.rlPolicies.CertificatesPerFQDNSet().Threshold, int64(99999))
 }
 
 type mockSAWithNameCounts struct {
@@ -1483,7 +1483,7 @@ func TestCheckCertificatesPerNameLimit(t *testing.T) {
 	rlp := ratelimit.RateLimitPolicy{
 		Threshold: 3,
 		Window:    cmd.ConfigDuration{Duration: 23 * time.Hour},
-		Overrides: map[string]int{
+		Overrides: map[string]int64{
 			"bigissuer.com":     100,
 			"smallissuer.co.uk": 1,
 		},

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -179,20 +179,20 @@ type RateLimitPolicy struct {
 	Window cmd.ConfigDuration `yaml:"window"`
 	// The max number of items that can be present before triggering the rate
 	// limit. Zero means "no limit."
-	Threshold int `yaml:"threshold"`
+	Threshold int64 `yaml:"threshold"`
 	// A per-key override setting different limits than the default (higher or lower).
 	// The key is defined on a per-limit basis and should match the key it counts on.
 	// For instance, a rate limit on the number of certificates per name uses name as
 	// a key, while a rate limit on the number of registrations per IP subnet would
 	// use subnet as a key. Note that a zero entry in the overrides map does not
 	// mean "no limit," it means a limit of zero.
-	Overrides map[string]int `yaml:"overrides"`
+	Overrides map[string]int64 `yaml:"overrides"`
 	// A per-registration override setting. This can be used, e.g. if there are
 	// hosting providers that we would like to grant a higher rate of issuance
 	// than the default. If both key-based and registration-based overrides are
 	// available, whichever is larger takes priority. Note that a zero entry in
 	// the overrides map does not mean "no limit", it means a limit of zero.
-	RegistrationOverrides map[int64]int `yaml:"registrationOverrides"`
+	RegistrationOverrides map[int64]int64 `yaml:"registrationOverrides"`
 }
 
 // Enabled returns true iff the RateLimitPolicy is enabled.
@@ -203,7 +203,7 @@ func (rlp *RateLimitPolicy) Enabled() bool {
 // GetThreshold returns the threshold for this rate limit, taking into account
 // any overrides for `key` or `regID`. If both `key` and `regID` have an
 // override the largest of the two will be used.
-func (rlp *RateLimitPolicy) GetThreshold(key string, regID int64) int {
+func (rlp *RateLimitPolicy) GetThreshold(key string, regID int64) int64 {
 	regOverride, regOverrideExists := rlp.RegistrationOverrides[regID]
 	keyOverride, keyOverrideExists := rlp.Overrides[key]
 

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -30,11 +30,11 @@ func TestNotEnabled(t *testing.T) {
 func TestGetThreshold(t *testing.T) {
 	policy := RateLimitPolicy{
 		Threshold: 1,
-		Overrides: map[string]int{
+		Overrides: map[string]int64{
 			"key": 2,
 			"baz": 99,
 		},
-		RegistrationOverrides: map[int64]int{
+		RegistrationOverrides: map[int64]int64{
 			101: 3,
 		},
 	}
@@ -43,7 +43,7 @@ func TestGetThreshold(t *testing.T) {
 		Name     string
 		Key      string
 		RegID    int64
-		Expected int
+		Expected int64
 	}{
 
 		{
@@ -111,8 +111,8 @@ func TestLoadPolicies(t *testing.T) {
 
 	// Test that the CertificatesPerName section parsed correctly
 	certsPerName := policy.CertificatesPerName()
-	test.AssertEquals(t, certsPerName.Threshold, 2)
-	test.AssertDeepEquals(t, certsPerName.Overrides, map[string]int{
+	test.AssertEquals(t, certsPerName.Threshold, int64(2))
+	test.AssertDeepEquals(t, certsPerName.Overrides, map[string]int64{
 		"ratelimit.me":          1,
 		"lim.it":                0,
 		"le.wtf":                10000,
@@ -125,28 +125,28 @@ func TestLoadPolicies(t *testing.T) {
 		"ecdsa.le.wtf":          10000,
 		"must-staple.le.wtf":    10000,
 	})
-	test.AssertDeepEquals(t, certsPerName.RegistrationOverrides, map[int64]int{
+	test.AssertDeepEquals(t, certsPerName.RegistrationOverrides, map[int64]int64{
 		101: 1000,
 	})
 
 	// Test that the RegistrationsPerIP section parsed correctly
 	regsPerIP := policy.RegistrationsPerIP()
-	test.AssertEquals(t, regsPerIP.Threshold, 10000)
-	test.AssertDeepEquals(t, regsPerIP.Overrides, map[string]int{
+	test.AssertEquals(t, regsPerIP.Threshold, int64(10000))
+	test.AssertDeepEquals(t, regsPerIP.Overrides, map[string]int64{
 		"127.0.0.1": 1000000,
 	})
 	test.AssertEquals(t, len(regsPerIP.RegistrationOverrides), 0)
 
 	// Test that the PendingAuthorizationsPerAccount section parsed correctly
 	pendingAuthsPerAcct := policy.PendingAuthorizationsPerAccount()
-	test.AssertEquals(t, pendingAuthsPerAcct.Threshold, 150)
+	test.AssertEquals(t, pendingAuthsPerAcct.Threshold, int64(150))
 	test.AssertEquals(t, len(pendingAuthsPerAcct.Overrides), 0)
 	test.AssertEquals(t, len(pendingAuthsPerAcct.RegistrationOverrides), 0)
 
 	// Test that the CertificatesPerFQDN section parsed correctly
 	certsPerFQDN := policy.CertificatesPerFQDNSet()
-	test.AssertEquals(t, certsPerFQDN.Threshold, 6)
-	test.AssertDeepEquals(t, certsPerFQDN.Overrides, map[string]int{
+	test.AssertEquals(t, certsPerFQDN.Threshold, int64(6))
+	test.AssertDeepEquals(t, certsPerFQDN.Overrides, map[string]int64{
 		"le.wtf":                10000,
 		"le1.wtf":               10000,
 		"le2.wtf":               10000,
@@ -159,8 +159,8 @@ func TestLoadPolicies(t *testing.T) {
 	})
 	test.AssertEquals(t, len(certsPerFQDN.RegistrationOverrides), 0)
 	certsPerFQDNFast := policy.CertificatesPerFQDNSetFast()
-	test.AssertEquals(t, certsPerFQDNFast.Threshold, 2)
-	test.AssertDeepEquals(t, certsPerFQDNFast.Overrides, map[string]int{
+	test.AssertEquals(t, certsPerFQDNFast.Threshold, int64(2))
+	test.AssertDeepEquals(t, certsPerFQDNFast.Overrides, map[string]int64{
 		"le.wtf": 100,
 	})
 	test.AssertEquals(t, len(certsPerFQDNFast.RegistrationOverrides), 0)
@@ -170,7 +170,7 @@ func TestLoadPolicies(t *testing.T) {
 	test.AssertError(t, err, "Failed to generate error loading invalid yaml policy file")
 	// Re-check a field of policy to make sure a LoadPolicies error doesn't
 	// corrupt the existing policies
-	test.AssertDeepEquals(t, policy.RegistrationsPerIP().Overrides, map[string]int{
+	test.AssertDeepEquals(t, policy.RegistrationsPerIP().Overrides, map[string]int64{
 		"127.0.0.1": 1000000,
 	})
 
@@ -178,9 +178,9 @@ func TestLoadPolicies(t *testing.T) {
 	// `LoadPolicy` call, and instead return empty RateLimitPolicy objects with default
 	// values.
 	emptyPolicy := New()
-	test.AssertEquals(t, emptyPolicy.CertificatesPerName().Threshold, 0)
-	test.AssertEquals(t, emptyPolicy.RegistrationsPerIP().Threshold, 0)
-	test.AssertEquals(t, emptyPolicy.RegistrationsPerIP().Threshold, 0)
-	test.AssertEquals(t, emptyPolicy.PendingAuthorizationsPerAccount().Threshold, 0)
-	test.AssertEquals(t, emptyPolicy.CertificatesPerFQDNSet().Threshold, 0)
+	test.AssertEquals(t, emptyPolicy.CertificatesPerName().Threshold, int64(0))
+	test.AssertEquals(t, emptyPolicy.RegistrationsPerIP().Threshold, int64(0))
+	test.AssertEquals(t, emptyPolicy.RegistrationsPerIP().Threshold, int64(0))
+	test.AssertEquals(t, emptyPolicy.PendingAuthorizationsPerAccount().Threshold, int64(0))
+	test.AssertEquals(t, emptyPolicy.CertificatesPerFQDNSet().Threshold, int64(0))
 }

--- a/sa/rate_limits_test.go
+++ b/sa/rate_limits_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -89,10 +90,16 @@ func TestNewOrdersRateLimitTable(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
-	zeroCountRegID := int64(1)
 	manyCountRegID := int64(2)
-
 	start := time.Now().Truncate(time.Minute)
+	req := &sapb.CountOrdersRequest{
+		AccountID: 1,
+		Range: &sapb.Range{
+			Earliest: start.UnixNano(),
+			Latest:   start.Add(time.Minute * 10).UnixNano(),
+		},
+	}
+
 	for i := 0; i <= 10; i++ {
 		tx, err := sa.dbMap.Begin()
 		test.AssertNotError(t, err, "failed to open tx")
@@ -103,14 +110,18 @@ func TestNewOrdersRateLimitTable(t *testing.T) {
 		test.AssertNotError(t, tx.Commit(), "failed to commit tx")
 	}
 
-	count, err := countNewOrders(context.Background(), sa.dbMap, zeroCountRegID, start, start.Add(time.Minute*10))
+	count, err := countNewOrders(context.Background(), sa.dbMap, req)
 	test.AssertNotError(t, err, "countNewOrders failed")
-	test.AssertEquals(t, count, 0)
+	test.AssertEquals(t, count.Count, int64(0))
 
-	count, err = countNewOrders(context.Background(), sa.dbMap, manyCountRegID, start, start.Add(time.Minute*10))
+	req.AccountID = manyCountRegID
+	count, err = countNewOrders(context.Background(), sa.dbMap, req)
 	test.AssertNotError(t, err, "countNewOrders failed")
-	test.AssertEquals(t, count, 65)
-	count, err = countNewOrders(context.Background(), sa.dbMap, manyCountRegID, start.Add(time.Minute*5), start.Add(time.Minute*10))
+	test.AssertEquals(t, count.Count, int64(65))
+
+	req.Range.Earliest = start.Add(time.Minute * 5).UnixNano()
+	req.Range.Latest = start.Add(time.Minute * 10).UnixNano()
+	count, err = countNewOrders(context.Background(), sa.dbMap, req)
 	test.AssertNotError(t, err, "countNewOrders failed")
-	test.AssertEquals(t, count, 45)
+	test.AssertEquals(t, count.Count, int64(45))
 }

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -196,7 +196,11 @@ func ipRange(ip net.IP) (net.IP, net.IP) {
 
 // CountRegistrationsByIP returns the number of registrations created in the
 // time range for a single IP address.
-func (ssa *SQLStorageAuthority) CountRegistrationsByIP(ctx context.Context, ip net.IP, earliest time.Time, latest time.Time) (int, error) {
+func (ssa *SQLStorageAuthority) CountRegistrationsByIP(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
+	if len(req.Ip) == 0 || req.Range.Earliest == 0 || req.Range.Latest == 0 {
+		return nil, errIncompleteRequest
+	}
+
 	var count int64
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,
@@ -206,23 +210,27 @@ func (ssa *SQLStorageAuthority) CountRegistrationsByIP(ctx context.Context, ip n
 		 :earliest < createdAt AND
 		 createdAt <= :latest`,
 		map[string]interface{}{
-			"ip":       []byte(ip),
-			"earliest": earliest,
-			"latest":   latest,
+			"ip":       req.Ip,
+			"earliest": time.Unix(0, req.Range.Earliest),
+			"latest":   time.Unix(0, req.Range.Latest),
 		})
 	if err != nil {
-		return -1, err
+		return &sapb.Count{Count: -1}, err
 	}
-	return int(count), nil
+	return &sapb.Count{Count: count}, nil
 }
 
 // CountRegistrationsByIPRange returns the number of registrations created in
 // the time range in an IP range. For IPv4 addresses, that range is limited to
 // the single IP. For IPv6 addresses, that range is a /48, since it's not
 // uncommon for one person to have a /48 to themselves.
-func (ssa *SQLStorageAuthority) CountRegistrationsByIPRange(ctx context.Context, ip net.IP, earliest time.Time, latest time.Time) (int, error) {
+func (ssa *SQLStorageAuthority) CountRegistrationsByIPRange(ctx context.Context, req *sapb.CountRegistrationsByIPRequest) (*sapb.Count, error) {
+	if len(req.Ip) == 0 || req.Range.Earliest == 0 || req.Range.Latest == 0 {
+		return nil, errIncompleteRequest
+	}
+
 	var count int64
-	beginIP, endIP := ipRange(ip)
+	beginIP, endIP := ipRange(req.Ip)
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,
 		`SELECT COUNT(1) FROM registrations
@@ -232,15 +240,15 @@ func (ssa *SQLStorageAuthority) CountRegistrationsByIPRange(ctx context.Context,
 		 :earliest < createdAt AND
 		 createdAt <= :latest`,
 		map[string]interface{}{
-			"earliest": earliest,
-			"latest":   latest,
-			"beginIP":  []byte(beginIP),
-			"endIP":    []byte(endIP),
+			"earliest": time.Unix(0, req.Range.Earliest),
+			"latest":   time.Unix(0, req.Range.Latest),
+			"beginIP":  beginIP,
+			"endIP":    endIP,
 		})
 	if err != nil {
-		return -1, err
+		return &sapb.Count{Count: -1}, err
 	}
-	return int(count), nil
+	return &sapb.Count{Count: count}, nil
 }
 
 // CountCertificatesByNames counts, for each input domain, the number of

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1751,6 +1751,10 @@ func (ssa *SQLStorageAuthority) GetPendingAuthorization2(ctx context.Context, re
 // CountPendingAuthorizations2 returns the number of pending, unexpired authorizations
 // for the given registration. This method is intended to deprecate CountPendingAuthorizations.
 func (ssa *SQLStorageAuthority) CountPendingAuthorizations2(ctx context.Context, req *sapb.RegistrationID) (*sapb.Count, error) {
+	if req.Id == 0 {
+		return nil, errIncompleteRequest
+	}
+
 	var count int64
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(&count,
 		`SELECT COUNT(1) FROM authz2 WHERE
@@ -1817,6 +1821,10 @@ func (ssa *SQLStorageAuthority) GetValidOrderAuthorizations2(ctx context.Context
 // in a given time range. This method is intended to deprecate CountInvalidAuthorizations.
 // This method only supports DNS identifier types.
 func (ssa *SQLStorageAuthority) CountInvalidAuthorizations2(ctx context.Context, req *sapb.CountInvalidAuthorizationsRequest) (*sapb.Count, error) {
+	if req.RegistrationID == 0 || req.Hostname == "" || req.Range.Earliest == 0 || req.Range.Latest == 0 {
+		return nil, errIncompleteRequest
+	}
+
 	var count int64
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -399,34 +399,43 @@ func TestCountRegistrationsByIP(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "Couldn't insert registration")
 
-	earliest := fc.Now().Add(-time.Hour * 24)
-	latest := fc.Now()
+	req := &sapb.CountRegistrationsByIPRequest{
+		Ip: net.ParseIP("1.1.1.1"),
+		Range: &sapb.Range{
+			Earliest: fc.Now().Add(-time.Hour * 24).UnixNano(),
+			Latest:   fc.Now().UnixNano(),
+		},
+	}
 
 	// There should be 0 registrations for an IPv4 address we didn't add
 	// a registration for
-	count, err := sa.CountRegistrationsByIP(ctx, net.ParseIP("1.1.1.1"), earliest, latest)
+	count, err := sa.CountRegistrationsByIP(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 0)
+	test.AssertEquals(t, count.Count, int64(0))
 	// There should be 1 registration for the IPv4 address we did add
-	// a registration for
-	count, err = sa.CountRegistrationsByIP(ctx, net.ParseIP("43.34.43.34"), earliest, latest)
+	// a registration for.
+	req.Ip = net.ParseIP("43.34.43.34")
+	count, err = sa.CountRegistrationsByIP(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 1)
+	test.AssertEquals(t, count.Count, int64(1))
 	// There should be 1 registration for the first IPv6 address we added
 	// a registration for
-	count, err = sa.CountRegistrationsByIP(ctx, net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9652"), earliest, latest)
+	req.Ip = net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9652")
+	count, err = sa.CountRegistrationsByIP(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 1)
+	test.AssertEquals(t, count.Count, int64(1))
 	// There should be 1 registration for the second IPv6 address we added
 	// a registration for as well
-	count, err = sa.CountRegistrationsByIP(ctx, net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9653"), earliest, latest)
+	req.Ip = net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9653")
+	count, err = sa.CountRegistrationsByIP(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 1)
+	test.AssertEquals(t, count.Count, int64(1))
 	// There should be 0 registrations for an IPv6 address in the same /48 as the
 	// two IPv6 addresses with registrations
-	count, err = sa.CountRegistrationsByIP(ctx, net.ParseIP("2001:cdba:1234:0000:0000:0000:0000:0000"), earliest, latest)
+	req.Ip = net.ParseIP("2001:cdba:1234:0000:0000:0000:0000:0000")
+	count, err = sa.CountRegistrationsByIP(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 0)
+	test.AssertEquals(t, count.Count, int64(0))
 }
 
 func TestCountRegistrationsByIPRange(t *testing.T) {
@@ -462,34 +471,44 @@ func TestCountRegistrationsByIPRange(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "Couldn't insert registration")
 
-	earliest := fc.Now().Add(-time.Hour * 24)
-	latest := fc.Now()
+	req := &sapb.CountRegistrationsByIPRequest{
+		Ip: net.ParseIP("1.1.1.1"),
+		Range: &sapb.Range{
+			Earliest: fc.Now().Add(-time.Hour * 24).UnixNano(),
+			Latest:   fc.Now().UnixNano(),
+		},
+	}
 
 	// There should be 0 registrations in the range for an IPv4 address we didn't
 	// add a registration for
-	count, err := sa.CountRegistrationsByIPRange(ctx, net.ParseIP("1.1.1.1"), earliest, latest)
+	req.Ip = net.ParseIP("1.1.1.1")
+	count, err := sa.CountRegistrationsByIPRange(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 0)
+	test.AssertEquals(t, count.Count, int64(0))
 	// There should be 1 registration in the range for the IPv4 address we did
 	// add a registration for
-	count, err = sa.CountRegistrationsByIPRange(ctx, net.ParseIP("43.34.43.34"), earliest, latest)
+	req.Ip = net.ParseIP("43.34.43.34")
+	count, err = sa.CountRegistrationsByIPRange(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 1)
+	test.AssertEquals(t, count.Count, int64(1))
 	// There should be 2 registrations in the range for the first IPv6 address we added
 	// a registration for because it's in the same /48
-	count, err = sa.CountRegistrationsByIPRange(ctx, net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9652"), earliest, latest)
+	req.Ip = net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9652")
+	count, err = sa.CountRegistrationsByIPRange(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 2)
+	test.AssertEquals(t, count.Count, int64(2))
 	// There should be 2 registrations in the range for the second IPv6 address
 	// we added a registration for as well, because it too is in the same /48
-	count, err = sa.CountRegistrationsByIPRange(ctx, net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9653"), earliest, latest)
+	req.Ip = net.ParseIP("2001:cdba:1234:5678:9101:1121:3257:9653")
+	count, err = sa.CountRegistrationsByIPRange(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 2)
+	test.AssertEquals(t, count.Count, int64(2))
 	// There should also be 2 registrations in the range for an arbitrary IPv6 address in
 	// the same /48 as the registrations we added
-	count, err = sa.CountRegistrationsByIPRange(ctx, net.ParseIP("2001:cdba:1234:0000:0000:0000:0000:0000"), earliest, latest)
+	req.Ip = net.ParseIP("2001:cdba:1234:0000:0000:0000:0000:0000")
+	count, err = sa.CountRegistrationsByIPRange(ctx, req)
 	test.AssertNotError(t, err, "Failed to count registrations")
-	test.AssertEquals(t, count, 2)
+	test.AssertEquals(t, count.Count, int64(2))
 }
 
 func TestFQDNSets(t *testing.T) {


### PR DESCRIPTION
- Make `CountRegistrationsByIP` a pass-through
- Make `CountRegistrationsByIPRange` a pass-through
- Make `CountOrders` a pass-through
- Make `CountFQDNSets` a pass-through
- Make `CountPendingAuthorizations2` a pass-through
- Make `CountInvalidAuthorizations2` a pass-through

Fixes #5535 