### PR TITLE
ocsp-updater: Split work by a configurable serial suffix shard

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -440,7 +440,7 @@ func main() {
 
 	var serialSuffixes []string
 	if c.OCSPUpdater.SerialSuffixShards == "" {
-		serialSuffixes = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"}
+		serialSuffixes = strings.Fields("0 1 2 3 4 5 6 7 8 9 a b c d e f")
 	} else {
 		serialSuffixes = strings.Fields(c.OCSPUpdater.SerialSuffixShards)
 	}

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -96,7 +96,7 @@ func newUpdater(
 	}
 	for _, s := range serialSuffixes {
 		if len(s) != 1 || strings.ToLower(s) != s {
-			return nil, fmt.Errorf("Serial suffixes must all be one lowercase character")
+			return nil, fmt.Errorf("Serial suffixes must all be one lowercase character: %s", s)
 		}
 		c := s[0]
 		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -101,7 +101,7 @@ func newUpdater(
 		}
 		c := s[0]
 		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
-			return nil, errors.New("Valid range for suffixes is [0-9a-f]")
+			return nil, errors.New("valid range for suffixes is [0-9a-f]")
 		}
 	}
 	queryBody := fmt.Sprintf(`WHERE ocspLastUpdated < ?

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -169,6 +169,7 @@ func getQuestionsForShardList(count int) string {
 func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Time, batchSize int) ([]core.CertificateStatus, error) {
 	params := make([]interface{}, 0)
 	params = append(params, oldestLastUpdatedTime)
+
 	// If serialSuffixes is unset, this will be deliberately a no-op
 	for _, c := range updater.serialSuffixes {
 		params = append(params, c)

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -99,7 +99,7 @@ func newUpdater(
 			return nil, fmt.Errorf("Serial suffixes must all be one lowercase character")
 		}
 		c := s[0]
-		if ! (c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
 			return nil, fmt.Errorf("Valid range for suffixes is [0-9a-f]")
 		}
 	}
@@ -172,7 +172,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 		 ORDER BY ocspLastUpdated ASC
 		 LIMIT ?`, updater.getQuestionsForShardList())
 
-	params := make([]interface{},0)
+	params := make([]interface{}, 0)
 	params = append(params, oldestLastUpdatedTime)
 	params = updater.appendShardList(params)
 	params = append(params, batchSize)
@@ -440,7 +440,7 @@ func main() {
 
 	var serialSuffixes []string
 	if c.OCSPUpdater.SerialSuffixShards == "" {
-		serialSuffixes = []string{"0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"}
+		serialSuffixes = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"}
 	} else {
 		serialSuffixes = strings.Fields(c.OCSPUpdater.SerialSuffixShards)
 	}

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -610,23 +610,3 @@ func TestGetQuestionsForShardList(t *testing.T) {
 	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
 	test.AssertEquals(t, u.getQuestionsForShardList(), "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?")
 }
-
-func TestAppendShardList(t *testing.T) {
-	list := make([]interface{}, 0)
-	u, err := mkNewUpdaterWithStrings(t, strings.Fields("0 1"))
-	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	list = u.appendShardList(list)
-	test.AssertDeepEquals(t, list, []interface{}{"0", "1"})
-
-	list = make([]interface{}, 0)
-	u, err = mkNewUpdaterWithStrings(t, strings.Fields("f"))
-	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	list = u.appendShardList(list)
-	test.AssertDeepEquals(t, list, []interface{}{"f"})
-
-	list = make([]interface{}, 0)
-	u, err = mkNewUpdaterWithStrings(t, strings.Fields("0 1 2 3 4 5 6 7 8 9 a b c d e f"))
-	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	list = u.appendShardList(list)
-	test.AssertDeepEquals(t, list, []interface{}{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"})
-}

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -594,7 +594,7 @@ func TestUpdaterConfiguration(t *testing.T) {
 	test.AssertError(t, err, "No multi-letter shards allowed")
 
 	_, err = mkNewUpdaterWithStrings(t, []string{})
-	test.AssertError(t, err, "Shard must not be empty")
+	test.AssertNotError(t, err, "Empty should be valid, meaning use old queries")
 }
 
 func TestGetQuestionsForShardList(t *testing.T) {

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -616,17 +616,17 @@ func TestAppendShardList(t *testing.T) {
 	u, err := mkNewUpdaterWithStrings(t, strings.Fields("0 1"))
 	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
 	list = u.appendShardList(list)
-	test.AssertEquals(t, list, []interface{}{"0", "1"})
+	test.AssertDeepEquals(t, list, []interface{}{"0", "1"})
 
 	list = make([]interface{}, 0)
 	u, err = mkNewUpdaterWithStrings(t, strings.Fields("f"))
 	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
 	list = u.appendShardList(list)
-	test.AssertEquals(t, list, []interface{}{"f"})
+	test.AssertDeepEquals(t, list, []interface{}{"f"})
 
 	list = make([]interface{}, 0)
 	u, err = mkNewUpdaterWithStrings(t, strings.Fields("0 1 2 3 4 5 6 7 8 9 a b c d e f"))
 	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
 	list = u.appendShardList(list)
-	test.AssertEquals(t, list, []interface{}{"0", "1"})
+	test.AssertDeepEquals(t, list, []interface{}{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"})
 }

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -597,17 +597,36 @@ func TestUpdaterConfiguration(t *testing.T) {
 	test.AssertError(t, err, "Shard must not be empty")
 }
 
-func TestGetSerialShardList(t *testing.T) {
+func TestGetQuestionsForShardList(t *testing.T) {
 	u, err := mkNewUpdaterWithStrings(t, strings.Fields("0 1"))
 	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	test.AssertEquals(t, u.getSerialShardList(), "'0','1'")
+	test.AssertEquals(t, u.getQuestionsForShardList(), "?,?")
 
 	u, err = mkNewUpdaterWithStrings(t, strings.Fields("f"))
 	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	test.AssertEquals(t, u.getSerialShardList(), "'f'")
+	test.AssertEquals(t, u.getQuestionsForShardList(), "?")
 
 	u, err = mkNewUpdaterWithStrings(t, strings.Fields("0 1 2 3 4 5 6 7 8 9 a b c d e f"))
 	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	test.AssertEquals(t, u.getSerialShardList(), "'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'")
+	test.AssertEquals(t, u.getQuestionsForShardList(), "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?")
+}
 
+func TestAppendShardList(t *testing.T) {
+	list := make([]interface{}, 0)
+	u, err := mkNewUpdaterWithStrings(t, strings.Fields("0 1"))
+	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
+	list = u.appendShardList(list)
+	test.AssertEquals(t, list, []interface{}{"0", "1"})
+
+	list = make([]interface{}, 0)
+	u, err = mkNewUpdaterWithStrings(t, strings.Fields("f"))
+	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
+	list = u.appendShardList(list)
+	test.AssertEquals(t, list, []interface{}{"f"})
+
+	list = make([]interface{}, 0)
+	u, err = mkNewUpdaterWithStrings(t, strings.Fields("0 1 2 3 4 5 6 7 8 9 a b c d e f"))
+	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
+	list = u.appendShardList(list)
+	test.AssertEquals(t, list, []interface{}{"0", "1"})
 }

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +60,7 @@ func setup(t *testing.T) (*OCSPUpdater, core.StorageAuthority, *db.WrappedMap, c
 		fc,
 		dbMap,
 		dbMap,
+		strings.Fields("0 1 2 3 4 5 6 7 8 9 a b c d e f"),
 		&mockOCSP{},
 		OCSPUpdaterConfig{
 			OldOCSPBatchSize:         1,
@@ -546,4 +548,48 @@ func TestTickSleep(t *testing.T) {
 	took = fc.Since(before)
 	test.AssertEquals(t, took, updater.tickWindow)
 
+}
+
+func mkNewUpdaterWithStrings(t *testing.T, shards []string) error {
+	dbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	test.AssertNotError(t, err, "Failed to create dbMap")
+	sa.SetSQLDebug(dbMap, log)
+
+	fc := clock.NewFake()
+
+	_, err = newUpdater(
+		metrics.NoopRegisterer,
+		fc,
+		dbMap,
+		dbMap,
+		shards,
+		&mockOCSP{},
+		OCSPUpdaterConfig{
+			OldOCSPBatchSize:         1,
+			OldOCSPWindow:            cmd.ConfigDuration{Duration: time.Second},
+			SignFailureBackoffFactor: 1.5,
+			SignFailureBackoffMax: cmd.ConfigDuration{
+				Duration: time.Minute,
+			},
+		},
+		blog.NewMock(),
+	)
+	return err
+}
+
+func TestUpdaterConfiguration(t *testing.T) {
+	err := mkNewUpdaterWithStrings(t, strings.Fields("0 1 2 3 4 5 6 7 8 9 a B c d e f"))
+	test.AssertError(t, err, "No uppercase allowed")
+
+	err = mkNewUpdaterWithStrings(t, strings.Fields("0 1 g"))
+	test.AssertError(t, err, "No letters > f allowed")
+
+	err = mkNewUpdaterWithStrings(t, strings.Fields("0 *"))
+	test.AssertError(t, err, "No special chars allowed")
+
+	err = mkNewUpdaterWithStrings(t, strings.Fields("0 -1"))
+	test.AssertError(t, err, "No negative numbers allowed")
+
+	err = mkNewUpdaterWithStrings(t, strings.Fields("wazzup 0 a b c"))
+	test.AssertError(t, err, "No multi-letter shards allowed")
 }

--- a/cmd/ocsp-updater/main_test.go
+++ b/cmd/ocsp-updater/main_test.go
@@ -598,15 +598,7 @@ func TestUpdaterConfiguration(t *testing.T) {
 }
 
 func TestGetQuestionsForShardList(t *testing.T) {
-	u, err := mkNewUpdaterWithStrings(t, strings.Fields("0 1"))
-	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	test.AssertEquals(t, u.getQuestionsForShardList(), "?,?")
-
-	u, err = mkNewUpdaterWithStrings(t, strings.Fields("f"))
-	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	test.AssertEquals(t, u.getQuestionsForShardList(), "?")
-
-	u, err = mkNewUpdaterWithStrings(t, strings.Fields("0 1 2 3 4 5 6 7 8 9 a b c d e f"))
-	test.AssertNotError(t, err, "mkNewUpdaterWithStrings failed")
-	test.AssertEquals(t, u.getQuestionsForShardList(), "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?")
+	test.AssertEquals(t, getQuestionsForShardList(2), "?,?")
+	test.AssertEquals(t, getQuestionsForShardList(1), "?")
+	test.AssertEquals(t, getQuestionsForShardList(16), "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?")
 }

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -14,6 +14,7 @@
     "ocspMinTimeToExpiry": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
+    "serialSuffixShards": "0123456789abcdef",
     "debugAddr": ":8006",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -14,7 +14,7 @@
     "ocspMinTimeToExpiry": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
-    "serialSuffixShards": "0123456789abcdef",
+    "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
     "debugAddr": ":8006",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",


### PR DESCRIPTION
- Enable`ocsp-updater` to query for serials matching a configurable suffix to
  allow for multiple `ocsp-updater` instances at once
- Add field `SerialSuffixShards` to `OCSPUpdaterConfig`
- Add field `serialSuffixShards` to `test/config-next/ocsp-updater.json`
- Add codepath to default to the previous query when `serialSuffixShards` is
  missing from the JSON config

Part of #5629
Fixes #5625