### PR TITLE
ocsp-updater: don't retrieve ocsp response bytes

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -176,7 +176,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(oldestLastUpdatedTime time.Ti
 	}
 	params = append(params, batchSize)
 
-	statuses, err := sa.SelectCertificateStatuses(
+	statuses, err := sa.SelectCertificateStatusMetadata(
 		updater.readOnlyDbMap,
 		updater.queryBody,
 		params...,


### PR DESCRIPTION
Create a new set of methods in the SA which are designed to work with
just certificate status metadata, not the current OCSP response itself.
Use these new methods from the ocsp-updater, so that it isn't taking the
database cpu time or the network bandwidth to handle those large byte
blobs that it doesn't even care about.

Also, remove the old `SelectCertificateStatuses` (plural) method, because
its only user was the ocsp-updater.

Fixes #5632

(cherry picked from commit 1a4b40d2ceb0fdd4a3ef408985ede54c0402efcf)