### PR TITLE
Fix typo in certStatusMetadata methods

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -115,7 +115,7 @@ func certStatusMetadataFields() []string {
 }
 
 func certStatusMetadataFieldsSelect(restOfQuery string) string {
-	fields := strings.Join(certStatusFields(), ",")
+	fields := strings.Join(certStatusMetadataFields(), ",")
 	return fmt.Sprintf("SELECT %s FROM certificateStatus %s", fields, restOfQuery)
 }
 


### PR DESCRIPTION
Change #5635 added new methods to the SA to select just
certificateStatus metadata columns, without selecting the
ocspResponse bytes themselves. However, one of those new
methods accidentally still called an old helper method, and
so the change had no effect overall.

Change the helper method to be the correct metadata helper.

Fixes #5632