### PR TITLE
Reject unrecognized config keys

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"log/syslog"
 	"net/http"
@@ -230,13 +229,17 @@ func FailOnError(err error, msg string) {
 
 // ReadConfigFile takes a file path as an argument and attempts to
 // unmarshal the content of the file into a struct containing a
-// configuration of a boulder component.
+// configuration of a boulder component. Any config keys in the JSON
+// file which do not correspond to expected keys in the config struct
+// will result in errors.
 func ReadConfigFile(filename string, out interface{}) error {
-	configData, err := ioutil.ReadFile(filename)
+	file, err := os.Open(filename)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(configData, out)
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(out)
 }
 
 // VersionString produces a friendly Application version string.

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -237,6 +237,8 @@ func ReadConfigFile(filename string, out interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer file.Close()
+
 	decoder := json.NewDecoder(file)
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(out)

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -122,10 +122,10 @@ func TestReadConfigFile(t *testing.T) {
 
 	type config struct {
 		NotifyMailer struct {
-			DBConfig
-			PasswordConfig
+			DB DBConfig
 			SMTPConfig
 		}
+		Syslog SyslogConfig
 	}
 	var c config
 	err = ReadConfigFile("../test/config/notify-mailer.json", &c)

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -2,6 +2,8 @@
   "akamaiPurger": {
     "debugAddr": ":9666",
     "purgeInterval": "1ms",
+    "purgeRetries": 10,
+    "purgeRetryBackoff": "50ms",
     "baseURL": "http://localhost:6789",
     "clientToken": "its-a-token",
     "clientSecret": "its-a-secret",

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -2,6 +2,8 @@
   "akamaiPurger": {
     "debugAddr": ":9666",
     "purgeInterval": "1ms",
+    "purgeRetries": 10,
+    "purgeRetryBackoff": "50ms",
     "baseURL": "http://localhost:6789",
     "clientToken": "its-a-token",
     "clientSecret": "its-a-secret",

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -9,7 +9,7 @@
     "unexpiredOnly": true,
     "badResultsOnly": true,
     "checkPeriod": "72h",
-    "acceptableValidityPeriods": [7775999, 7776000],
+    "acceptableValidityDurations": ["7775999s", "7776000s"],
     "ignoredLints": [
       "n_subject_common_name_included"
     ]

--- a/test/integration/testdata/akamai-purger-queue-drain-config.json
+++ b/test/integration/testdata/akamai-purger-queue-drain-config.json
@@ -17,15 +17,18 @@
         "grpc": {
           "address": ":9199",
           "clientNames": [
+            "health-checker.boulder",
             "ra.boulder"
           ]
         }
     },
+
     "syslog": {
       "stdoutlevel": 6,
       "sysloglevel": 6
     },
-    "common": {
-      "issuerCert": "/tmp/intermediate-cert-rsa-a.pem"
+    "beeline": {
+        "mute": true,
+        "dataset": "Test"
     }
 }

--- a/test/issuer-ocsp-responder.json
+++ b/test/issuer-ocsp-responder.json
@@ -3,17 +3,21 @@
     "source": "file:///tmp/intermediate-ocsp-rsa.b64",
     "path": "/",
     "listenAddress": "0.0.0.0:4003",
+    "issuerCerts": [
+      "/tmp/intermediate-cert-rsa-a.pem"
+    ],
+    "maxAge": "10s",
+    "timeout": "4.9s",
     "shutdownStopTimeout": "10s",
-    "shutdownKillTimeout": "1m",
     "debugAddr": "localhost:8010"
   },
-  "common": {
-    "issuerCert": "/tmp/intermediate-cert-rsa-a.pem"
-  },
-  "sql": {
-    "sqlDebug": true
-  },
+
   "syslog": {
-    "stdoutlevel": 6
-  }
+   "stdoutlevel": 6,
+   "sysloglevel": 6
+ },
+  "beeline": {
+      "mute": true,
+      "dataset": "Test"
+ }
 }


### PR DESCRIPTION
Instead of using the default `json.Unmarshal`, explicitly
construct and use a `json.Decoder` so that we can set the
`DisallowUnknownFields` flag on the decoder. This causes
any unrecognized config keys to result in errors at boulder
startup time.

Fixes #5643