### PR TITLE
Compute OCSP validity interval correctly

### DIFF
--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -135,7 +135,7 @@ func (oi *ocspImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequ
 		Status:       ocspStatusToCode[req.Status],
 		SerialNumber: serial,
 		ThisUpdate:   now,
-		NextUpdate:   now.Add(oi.ocspLifetime),
+		NextUpdate:   now.Add(oi.ocspLifetime - time.Second),
 	}
 	if tbsResponse.Status == ocsp.Revoked {
 		tbsResponse.RevokedAt = time.Unix(0, req.RevokedAt)


### PR DESCRIPTION
Like certificates, the validity of an OCSP response is measured
inclusive of its final second. Ensure that we set the `nextUpdate`
timestamp taking this into account.

Fixes #5667