### PR TITLE
PA: Make `idnReservedRegexp` more strict

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -164,7 +164,7 @@ const (
 
 var dnsLabelRegexp = regexp.MustCompile("^[a-z0-9][a-z0-9-]{0,62}$")
 var punycodeRegexp = regexp.MustCompile("^xn--")
-var idnReservedRegexp = regexp.MustCompile("^[a-z0-9]{2}--")
+var idnReservedRegexp = regexp.MustCompile("^[a-z0-9-]{2}--")
 
 func isDNSCharacter(ch byte) bool {
 	return ('a' <= ch && ch <= 'z') ||

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -52,6 +52,10 @@ func TestWillingToIssue(t *testing.T) {
 		{`www.-ombo.com`, errInvalidDNSCharacter}, // Label starts with '-'
 		{`www.zomb-.com`, errInvalidDNSCharacter}, // Label ends with '-'
 		{`xn--.net`, errInvalidDNSCharacter},      // Label ends with '-'
+		{`-0b.net`, errInvalidDNSCharacter},       // First label begins with '-'
+		{`-0.net`, errInvalidDNSCharacter},        // First label begins with '-'
+		{`-.net`, errInvalidDNSCharacter},         // First label is only '-'
+		{`---.net`, errInvalidDNSCharacter},       // First label is only hyphens
 		{`0`, errTooFewLabels},
 		{`1`, errTooFewLabels},
 		{`*`, errInvalidDNSCharacter},
@@ -93,6 +97,10 @@ func TestWillingToIssue(t *testing.T) {
 		{`www.zombo.163`, errNonPublic},
 		{`xn--109-3veba6djs1bfxlfmx6c9g.xn--f1awi.xn--p1ai`, errMalformedIDN}, // Not in Unicode NFC
 		{`bq--abwhky3f6fxq.jakacomo.com`, errInvalidRLDH},
+		// Three hyphens starting at third second char of first label.
+		{`bq---abwhky3f6fxq.jakacomo.com`, errInvalidRLDH},
+		// Three hyphens starting at second char of first label.
+		{`h---test.hk2yz.org`, errInvalidRLDH},
 	}
 
 	shouldBeTLDError := []string{


### PR DESCRIPTION
- `idnReservedRegexp` matches two more classes of non-punycode reserved labels
- Add 2 new tests for `errInvalidRLDH`
- Add 4 new tests for `errInvalidDNSCharacter`