### PR TITLE
Consolidate name resolution in sd-test-srv.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,26 +12,8 @@ services:
     networks:
       bluenet:
         ipv4_address: 10.77.77.77
-        aliases:
-          - sa1.boulder
-          - ca1.boulder
-          - ra1.boulder
-          - va1.boulder
-          - publisher1.boulder
-          - ocsp-updater.boulder
-          - admin-revoker.boulder
-          - nonce1.boulder
-          - dns1.boulder
       rednet:
         ipv4_address: 10.88.88.88
-        aliases:
-          - sa2.boulder
-          - ca2.boulder
-          - ra2.boulder
-          - va2.boulder
-          - publisher2.boulder
-          - nonce2.boulder
-          - dns2.boulder
     # Use sd-test-srv as a backup to Docker's embedded DNS server
     # (https://docs.docker.com/config/containers/container-networking/#dns-services).
     # If there's a name Docker's DNS server doesn't know about, it will


### PR DESCRIPTION
Previously we relied on aliases in Docker's DNS for some names, and
sd-test-srv for some other names. This moves them all into sd-test-srv.