### PR TITLE
 Make test matrix results more readable

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -18,11 +18,11 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  #  Boulder_ci_tests job. This looks like a single job, but the matrix
-  #  items will mulitply it. For example every entry in the
+  #  Main test jobs. This looks like a single job, but the matrix
+  #  items will multiply it. For example every entry in the
   #  BOULDER_TOOLS_TAG list will run with every test. If there were two
   #  tags and 5 tests there would be 10 jobs run.
-  boulder_ci_tests:
+  b:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
 
@@ -37,8 +37,8 @@ jobs:
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
-          - "docker-compose run --use-aliases boulder ./test.sh --lints --generate --make-artifacts"
-          - "docker-compose run --use-aliases boulder ./test.sh --integration"
+          - "./t.sh --lints --generate --make-artifacts"
+          - "./t.sh --integration"
           # Testing Config Changes:
           # Config changes that have landed in main but not yet been applied to
           # production can be made in `test/config-next/<component>.json`.
@@ -47,10 +47,10 @@ jobs:
           # Database migrations in `sa/_db-next/migrations` are only performed 
           # when `docker-compose` is called using `-f docker-compose.yml -f 
           # docker-compose.next.yml`.
-          - "docker-compose -f docker-compose.yml -f docker-compose.next.yml run --use-aliases boulder ./test.sh --integration"
-          - "docker-compose run --use-aliases boulder ./test.sh --unit --enable-race-detection"
-          - "docker-compose -f docker-compose.yml -f docker-compose.next.yml run --use-aliases boulder ./test.sh --unit --enable-race-detection"
-          - "docker-compose run --use-aliases boulder ./test.sh --start-py"
+          - "./tn.sh --integration"
+          - "./t.sh --unit --enable-race-detection"
+          - "./tn.sh ./test.sh --unit --enable-race-detection"
+          - "./t.sh --start-py"
           # gomod-vendor runs with a separate network access definition
           # because it needs to fetch packages from GitHub et. al., which
           # is incompatible with the DNS server override in the boulder
@@ -102,8 +102,8 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Boulder CI Test Matrix
-    needs: boulder_ci_tests
+    needs: b
     steps:
       - name: Check boulder ci test matrix status
-        if: ${{ needs.boulder_ci_tests.result != 'success' }}
+        if: ${{ needs.b.result != 'success' }}
         run: exit 1

--- a/t.sh
+++ b/t.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Outer wrapper for invoking test.sh inside docker-compose.
+#
+if type realpath >/dev/null 2>&1 ; then
+  cd "$(realpath -- $(dirname -- "$0"))"
+fi
+exec docker-compose run boulder ./test.sh "$@"

--- a/tn.sh
+++ b/tn.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Outer wrapper for invoking test.sh with config-next inside docker-compose.
+#
+if type realpath >/dev/null 2>&1 ; then
+  cd "$(realpath -- $(dirname -- "$0"))"
+fi
+exec docker-compose -f docker-compose.yml -f docker-compose.next.yml run boulder ./test.sh "$@"


### PR DESCRIPTION
Right now when looking at a list of Boulder CI test results, they all
say:

boulder_ci_tests (go_1.17_2021-...

Which is not very informative as to which type of test failed. This
shortens the test name to "b", and also changes the invoked command so
more of it fits on the screen. That involves adding two new scripts,
t.sh and tn.sh, which each run `docker-compose run ... test.sh`. tn.sh
runs it with the appropriate flags to use config-next.