### PR TITLE
Separate install / build steps of tests.

### DIFF
--- a/start.py
+++ b/start.py
@@ -17,10 +17,13 @@ import time
 sys.path.append('./test')
 import startservers
 
+if not startservers.install(race_detection=False):
+    raise(Exception("failed to build"))
+
 # Setup issuance hierarchy
 startservers.setupHierarchy()
 
-if not startservers.start(race_detection=False, fakeclock=None):
+if not startservers.start(fakeclock=None):
     sys.exit(1)
 try:
     os.wait()

--- a/test.sh
+++ b/test.sh
@@ -248,7 +248,7 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   python3 start.py &
   for I in $(seq 1 100); do
     sleep 1
-    curl http://localhost:4000/directory && break
+    curl -s http://localhost:4000/directory && break
   done
   if [[ "$I" = 100 ]]; then
     echo "Boulder did not come up after ./start.py."

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -106,6 +106,9 @@ def main():
     if not (args.run_chisel or args.custom  or args.run_go is not None):
         raise(Exception("must run at least one of the letsencrypt or chisel tests with --chisel, --gotest, or --custom"))
 
+    if not startservers.install(race_detection=race_detection):
+        raise(Exception("failed to build"))
+
     # Setup issuance hierarchy
     startservers.setupHierarchy()
 
@@ -113,19 +116,19 @@ def main():
         now = datetime.datetime.utcnow()
 
         six_months_ago = now+datetime.timedelta(days=-30*6)
-        if not startservers.start(race_detection=race_detection, fakeclock=fakeclock(six_months_ago)):
+        if not startservers.start(fakeclock=fakeclock(six_months_ago)):
             raise(Exception("startservers failed (mocking six months ago)"))
         v1_integration.caa_client = caa_client = chisel.make_client()
         setup_six_months_ago()
         startservers.stop()
 
         twenty_days_ago = now+datetime.timedelta(days=-20)
-        if not startservers.start(race_detection=race_detection, fakeclock=fakeclock(twenty_days_ago)):
+        if not startservers.start(fakeclock=fakeclock(twenty_days_ago)):
             raise(Exception("startservers failed (mocking twenty days ago)"))
         setup_twenty_days_ago()
         startservers.stop()
 
-    if not startservers.start(race_detection=race_detection, fakeclock=None):
+    if not startservers.start(fakeclock=None):
         raise(Exception("startservers failed"))
 
     if args.run_chisel:


### PR DESCRIPTION
Previously, `startservers.start()` would implicitly build the binaries.
This separates the `startservers.install()` step as a separate one that
must happen first. This is useful because it allows us to ensure the
`ceremony` tool has been built before we run `setupHierarchy`.

Also, add a `-s` flag to `curl` when checking whether start.py resulted
in a successful startup. This reduces the amount of log spam when it
failed to come up.