### PR TITLE
Add error counter for TLD

### DIFF
--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -649,6 +649,7 @@ func TestRetry(t *testing.T) {
 						"qtype":    "TXT",
 						"type":     "out of retries",
 						"resolver": dnsLoopbackAddr,
+						"isTLD":    "false",
 					}, tc.metricsAllRetries)
 			}
 		})
@@ -699,6 +700,15 @@ func TestRetry(t *testing.T) {
 			"type":     "deadline exceeded",
 			"resolver": dnsLoopbackAddr,
 		}, 2)
+}
+
+func TestIsTLD(t *testing.T) {
+	if isTLD("com") != "true" {
+		t.Errorf("expected 'com' to be a TLD, got %q", isTLD("com"))
+	}
+	if isTLD("example.com") != "false" {
+		t.Errorf("expected 'example.com' to not a TLD, got %q", isTLD("example.com"))
+	}
 }
 
 type tempError bool


### PR DESCRIPTION
Sometimes when our Unbounds are overloaded, we get a spate of "query timeout looking up CAA for com" (and other TLDs). Since we expect that the TLD servers are very high availability, we can generally be confident that if we get a timeout querying a qname that is just a TLD, it's a problem on our side rather than the other side. We can use this metric as input to alerting and SLO calculations.

Related to #5346.