### PR TITLE
Add Edge-Cache-Tag to OCSP responses

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -173,7 +173,10 @@ func (src *dbSource) Response(req *ocsp.Request) ([]byte, http.Header, error) {
 
 	var header http.Header = make(map[string][]string)
 	if len(serialString) > 2 {
-		header.Add("Edge-Cache-Tag", serialString[:2])
+		// Set a cache tag that is equal to the last two bytes of the serial.
+		// We expect that to be randomly distributed, so each tag should map to
+		// about 1/256 of our responses.
+		header.Add("Edge-Cache-Tag", serialString[len(serialString)-2:])
 	}
 
 	var certStatus core.CertificateStatus

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -175,7 +175,7 @@ func TestDBHandler(t *testing.T) {
 		t.Errorf("Code: want %d, got %d", http.StatusOK, w.Code)
 	}
 	cacheTag := w.Result().Header["Edge-Cache-Tag"]
-	expectedCacheTag := []string{"00"}
+	expectedCacheTag := []string{"08"}
 	if !reflect.DeepEqual(cacheTag, expectedCacheTag) {
 		t.Errorf("Edge-Cache-Tag: expected %q, got %q", expectedCacheTag, cacheTag)
 	}


### PR DESCRIPTION
Introduce one cache tag: the last byte (hex-encoded) of the serial
number. This allows us to purge groups of responses, in chunks of
1/256 of our whole cache. We assume this is more or less evenly
distributed because serial numbers are random.

Fixes #5736.