### PR TITLE
Use authorization attemptedAt date for CAA recheck

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -436,9 +436,10 @@ func (sa *StorageAuthority) GetValidAuthorizations2(ctx context.Context, req *sa
 				},
 				Challenges: []core.Challenge{
 					{
-						Status: core.StatusValid,
-						Type:   core.ChallengeTypeDNS01,
-						Token:  "exampleToken",
+						Status:    core.StatusValid,
+						Type:      core.ChallengeTypeDNS01,
+						Token:     "exampleToken",
+						Validated: &now,
 					},
 				},
 			})

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -92,14 +92,15 @@ type RegistrationAuthorityImpl struct {
 
 	ctpolicy *ctpolicy.CTPolicy
 
-	ctpolicyResults         *prometheus.HistogramVec
-	rateLimitCounter        *prometheus.CounterVec
-	revocationReasonCounter *prometheus.CounterVec
-	namesPerCert            *prometheus.HistogramVec
-	newRegCounter           prometheus.Counter
-	reusedValidAuthzCounter prometheus.Counter
-	recheckCAACounter       prometheus.Counter
-	newCertCounter          prometheus.Counter
+	ctpolicyResults             *prometheus.HistogramVec
+	rateLimitCounter            *prometheus.CounterVec
+	revocationReasonCounter     *prometheus.CounterVec
+	namesPerCert                *prometheus.HistogramVec
+	newRegCounter               prometheus.Counter
+	reusedValidAuthzCounter     prometheus.Counter
+	recheckCAACounter           prometheus.Counter
+	newCertCounter              prometheus.Counter
+	recheckCAAUsedAuthzLifetime prometheus.Counter
 }
 
 // NewRegistrationAuthorityImpl constructs a new RA object.
@@ -167,6 +168,12 @@ func NewRegistrationAuthorityImpl(
 	})
 	stats.MustRegister(recheckCAACounter)
 
+	recheckCAAUsedAuthzLifetime := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "recheck_caa_used_authz_lifetime",
+		Help: "A counter times the old codepath was used for CAA recheck time",
+	})
+	stats.MustRegister(recheckCAAUsedAuthzLifetime)
+
 	newCertCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "new_certificates",
 		Help: "A counter of new certificates",
@@ -208,6 +215,7 @@ func NewRegistrationAuthorityImpl(
 		recheckCAACounter:            recheckCAACounter,
 		newCertCounter:               newCertCounter,
 		revocationReasonCounter:      revocationReasonCounter,
+		recheckCAAUsedAuthzLifetime:  recheckCAAUsedAuthzLifetime,
 	}
 	return ra
 }
@@ -797,6 +805,19 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizations(ctx context.Context, na
 	return auths, nil
 }
 
+// validatedBefore checks if a given authorization's challenge was
+// validated before a given time. Returns a bool.
+func validatedBefore(authz *core.Authorization, caaRecheckTime time.Time) (bool, error) {
+	numChallenges := len(authz.Challenges)
+	if numChallenges != 1 {
+		return false, fmt.Errorf("authorization has incorrect number of challenges. 1 expected, %d found for: id %s", numChallenges, authz.ID)
+	}
+	if authz.Challenges[0].Validated == nil {
+		return false, fmt.Errorf("authorization's challenge has no validated timestamp for: id %s", authz.ID)
+	}
+	return authz.Challenges[0].Validated.Before(caaRecheckTime), nil
+}
+
 // checkAuthorizationsCAA implements the common logic of validating a set of
 // authorizations against a set of names that is used by both
 // `checkAuthorizations` and `checkOrderAuthorizations`. If required CAA will be
@@ -820,7 +841,14 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizationsCAA(
 	// check to see if the authorized challenge `AttemptedAt`
 	// (`Validated`) value from the database is before our caaRecheckTime.
 	// Set the recheck time to 7 hours ago.
-	caaRecheckTime := now.Add(-7 * time.Hour)
+	caaRecheckAfter := now.Add(-7 * time.Hour)
+
+	// Set a CAA recheck time based on the assumption of a 30 day authz
+	// lifetime. This has been deprecated in favor of a new check based
+	// off the Validated time stored in the database, but we want to check
+	// both for a time and increment a stat if this code path is hit for
+	// compliance safety.
+	caaRecheckTime := now.Add(ra.authorizationLifetime).Add(-7 * time.Hour)
 
 	for _, name := range names {
 		authz := authzs[name]
@@ -830,13 +858,18 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizationsCAA(
 			return berrors.InternalServerError("found an authorization with a nil Expires field: id %s", authz.ID)
 		} else if authz.Expires.Before(now) {
 			badNames = append(badNames, name)
-		} else if authz.Challenges[0].Validated == nil {
-			return berrors.InternalServerError("found an authorization with a nil Validated field: id %s", authz.ID)
-		} else if authz.Challenges[0].Validated != nil {
-			if authz.Challenges[0].Validated.Before(caaRecheckTime) {
-				// Ensure that CAA is rechecked for this name
-				recheckAuthzs = append(recheckAuthzs, authz)
-			}
+		} else if staleCAA, err := validatedBefore(authz, caaRecheckAfter); err != nil {
+			return berrors.InternalServerError(err.Error())
+		} else if staleCAA {
+			// Ensure that CAA is rechecked for this name
+			recheckAuthzs = append(recheckAuthzs, authz)
+		} else if authz.Expires.Before(caaRecheckTime) {
+			// Ensure that CAA is rechecked for this name
+			recheckAuthzs = append(recheckAuthzs, authz)
+			// This codepath should not be used, but is here as a safety
+			// net until the new codepath is proven. Increment metric if
+			// it is used.
+			ra.recheckCAAUsedAuthzLifetime.Add(1)
 		}
 	}
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2066,7 +2066,7 @@ func TestRecheckCAADates(t *testing.T) {
 	test.AssertEquals(t, err.Error(), "authorization's challenge has no validated timestamp for: id noval")
 
 	// Test to make sure the authorization lifetime codepath was not used
-	// to determin if CAA needed recheck.
+	// to determine if CAA needed recheck.
 	test.AssertMetricWithLabelsEquals(t, ra.recheckCAAUsedAuthzLifetime, prometheus.Labels{}, 0)
 
 	// We expect that "recent.com" is not checked because its mock authorization

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -88,14 +88,15 @@ func createPendingAuthorization(t *testing.T, sa sapb.StorageAuthorityClient, do
 	return ids.Ids[0]
 }
 
-func createFinalizedAuthorization(t *testing.T, sa sapb.StorageAuthorityClient, domain string, exp time.Time, status string) int64 {
+func createFinalizedAuthorization(t *testing.T, sa sapb.StorageAuthorityClient, domain string, exp time.Time, status string, attemptedAt time.Time) int64 {
 	t.Helper()
 	pendingID := createPendingAuthorization(t, sa, domain, exp)
 	_, err := sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
-		Id:        pendingID,
-		Status:    status,
-		Expires:   exp.UnixNano(),
-		Attempted: string(core.ChallengeTypeHTTP01),
+		Id:          pendingID,
+		Status:      status,
+		Expires:     exp.UnixNano(),
+		Attempted:   string(core.ChallengeTypeHTTP01),
+		AttemptedAt: attemptedAt.UnixNano(),
 	})
 	test.AssertNotError(t, err, "sa.FinalizeAuthorizations2 failed")
 	return pendingID
@@ -760,7 +761,7 @@ func TestReuseValidAuthorization(t *testing.T) {
 
 	// Create one finalized authorization
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	authzIDA := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
+	authzIDA := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
 
 	// Now create another authorization for the same Reg.ID/domain
 	secondAuthz, err := ra.NewAuthorization(ctx, AuthzRequest)
@@ -875,7 +876,7 @@ func TestReuseAuthorizationDisabled(t *testing.T) {
 
 	// Create one finalized authorization
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	authzID := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
+	authzID := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
 
 	// Now create another authorization for the same Reg.ID/domain
 	secondAuthz, err := ra.NewAuthorization(ctx, AuthzRequest)
@@ -900,7 +901,7 @@ func TestReuseExpiringAuthorization(t *testing.T) {
 
 	// Create one finalized authorization that expires in 12 hours from now
 	exp := ra.clk.Now().Add(12 * time.Hour)
-	authzID := createFinalizedAuthorization(t, sa, "not-example", exp, "valid")
+	authzID := createFinalizedAuthorization(t, sa, "not-example", exp, "valid", ra.clk.Now())
 
 	// Now create another authorization for the same Reg.ID/domain
 	secondAuthz, err := ra.NewAuthorization(ctx, AuthzRequest)
@@ -1123,7 +1124,7 @@ func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	_ = createFinalizedAuthorization(t, sa, "www.example.com", exp, "valid")
+	_ = createFinalizedAuthorization(t, sa, "www.example.com", exp, "valid", ra.clk.Now())
 	csr := x509.CertificateRequest{
 		SignatureAlgorithm: x509.SHA256WithRSA,
 		PublicKey:          AccountKeyA.Key,
@@ -1147,7 +1148,7 @@ func TestAuthorizationRequired(t *testing.T) {
 	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	_ = createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
+	_ = createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
 
 	_, err := ra.NewCertificate(ctx,
 		&rapb.NewCertificateRequest{
@@ -1163,8 +1164,8 @@ func TestNewCertificate(t *testing.T) {
 	defer cleanUp()
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
 	// Create valid authorizations for not-example.com and www.not-example.com
-	_ = createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
-	_ = createFinalizedAuthorization(t, sa, "www.not-example.com", exp, "valid")
+	_ = createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
+	_ = createFinalizedAuthorization(t, sa, "www.not-example.com", exp, "valid", ra.clk.Now())
 
 	// Check that we fail if the CSR signature is invalid
 	ExampleCSR.Raw[len(ExampleCSR.Raw)-1]++
@@ -1843,7 +1844,7 @@ func TestDeactivateAuthorization(t *testing.T) {
 	defer cleanUp()
 
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	authzID := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
+	authzID := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
 	dbAuthzPB := getAuthorization(t, fmt.Sprint(authzID), sa)
 	_, err := ra.DeactivateAuthorization(ctx, dbAuthzPB)
 	test.AssertNotError(t, err, "Could not deactivate authorization")
@@ -1912,40 +1913,75 @@ type mockSAWithRecentAndOlder struct {
 	mocks.StorageAuthority
 }
 
-func newMockSAWithRecentAndOlder(recent, older time.Time) *mockSAWithRecentAndOlder {
+func newMockSAWithRecentAndOlder(pastExpired, beforeExpired, recentValidated, olderValidated time.Time) *mockSAWithRecentAndOlder {
 	makeIdentifier := func(name string) identifier.ACMEIdentifier {
 		return identifier.ACMEIdentifier{
 			Type:  identifier.DNS,
 			Value: name,
 		}
 	}
-	basicChallenge := core.Challenge{Status: core.StatusValid, Type: core.ChallengeTypeHTTP01, Token: "exampleToken"}
+
 	return &mockSAWithRecentAndOlder{
 		authzMap: map[string]*core.Authorization{
 			"recent.com": {
 				Identifier: makeIdentifier("recent.com"),
-				Expires:    &recent,
-				Challenges: []core.Challenge{basicChallenge},
+				Expires:    &beforeExpired,
+				Challenges: []core.Challenge{
+					{
+						Status:    core.StatusValid,
+						Type:      core.ChallengeTypeHTTP01,
+						Token:     "exampleToken",
+						Validated: &recentValidated,
+					},
+				},
 			},
 			"older.com": {
 				Identifier: makeIdentifier("older.com"),
-				Expires:    &older,
-				Challenges: []core.Challenge{basicChallenge},
+				Expires:    &beforeExpired,
+				Challenges: []core.Challenge{
+					{
+						Status:    core.StatusValid,
+						Type:      core.ChallengeTypeHTTP01,
+						Token:     "exampleToken",
+						Validated: &olderValidated,
+					},
+				},
 			},
 			"older2.com": {
 				Identifier: makeIdentifier("older2.com"),
-				Expires:    &older,
-				Challenges: []core.Challenge{basicChallenge},
+				Expires:    &pastExpired,
+				Challenges: []core.Challenge{
+					{
+						Status:    core.StatusValid,
+						Type:      core.ChallengeTypeHTTP01,
+						Token:     "exampleToken",
+						Validated: &olderValidated,
+					},
+				},
 			},
 			"wildcard.com": {
 				Identifier: makeIdentifier("wildcard.com"),
-				Expires:    &older,
-				Challenges: []core.Challenge{basicChallenge},
+				Expires:    &beforeExpired,
+				Challenges: []core.Challenge{
+					{
+						Status:    core.StatusValid,
+						Type:      core.ChallengeTypeHTTP01,
+						Token:     "exampleToken",
+						Validated: &olderValidated,
+					},
+				},
 			},
 			"*.wildcard.com": {
 				Identifier: makeIdentifier("*.wildcard.com"),
-				Expires:    &older,
-				Challenges: []core.Challenge{basicChallenge},
+				Expires:    &beforeExpired,
+				Challenges: []core.Challenge{
+					{
+						Status:    core.StatusValid,
+						Type:      core.ChallengeTypeHTTP01,
+						Token:     "exampleToken",
+						Validated: &olderValidated,
+					},
+				},
 			},
 		},
 	}
@@ -1956,7 +1992,7 @@ func (m *mockSAWithRecentAndOlder) GetValidAuthorizations2(_ context.Context, _ 
 }
 
 // Test that the right set of domain names have their CAA rechecked, based on
-// expiration time.
+// their `Validated` (attemptedAt in the database) timestamp.
 func TestRecheckCAADates(t *testing.T) {
 	_, _, ra, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
@@ -1966,6 +2002,8 @@ func TestRecheckCAADates(t *testing.T) {
 	ra.SA = newMockSAWithRecentAndOlder(
 		fc.Now().Add(15*time.Hour),
 		fc.Now().Add(5*time.Hour),
+		fc.Now().Add(-1*time.Hour),
+		fc.Now().Add(-8*time.Hour),
 	)
 
 	// NOTE: The names provided here correspond to authorizations in the
@@ -2192,7 +2230,7 @@ func TestNewOrderLegacyAuthzReuse(t *testing.T) {
 
 	// Create a legacy pending authz, not associated with an order
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	authzID := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
+	authzID := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
 
 	// Create an order request for the same name as the legacy authz
 	order, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
@@ -2352,10 +2390,11 @@ func TestNewOrderReuseInvalidAuthz(t *testing.T) {
 	test.AssertEquals(t, numAuthorizations(order), 1)
 
 	_, err = ra.SA.FinalizeAuthorization2(ctx, &sapb.FinalizeAuthorizationRequest{
-		Id:        order.V2Authorizations[0],
-		Status:    string(core.StatusInvalid),
-		Expires:   order.Expires,
-		Attempted: string(core.ChallengeTypeDNS01),
+		Id:          order.V2Authorizations[0],
+		Status:      string(core.StatusInvalid),
+		Expires:     order.Expires,
+		Attempted:   string(core.ChallengeTypeDNS01),
+		AttemptedAt: ra.clk.Now().UnixNano(),
 	})
 	test.AssertNotError(t, err, "FinalizeAuthorization2 failed")
 
@@ -2800,8 +2839,8 @@ func TestFinalizeOrder(t *testing.T) {
 	// Create one finalized authorization for not-example.com and one finalized
 	// authorization for www.not-example.org
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	authzIDA := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
-	authzIDB := createFinalizedAuthorization(t, sa, "www.not-example.com", exp, "valid")
+	authzIDA := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
+	authzIDB := createFinalizedAuthorization(t, sa, "www.not-example.com", exp, "valid", ra.clk.Now())
 
 	// Create an order with valid authzs, it should end up status ready in the
 	// resulting returned order
@@ -3026,8 +3065,8 @@ func TestFinalizeOrderWithMixedSANAndCN(t *testing.T) {
 
 	// Create one finalized authorization for Registration.Id for not-example.com and
 	// one finalized authorization for Registration.Id for www.not-example.org
-	authzIDA := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid")
-	authzIDB := createFinalizedAuthorization(t, sa, "www.not-example.com", exp, "valid")
+	authzIDA := createFinalizedAuthorization(t, sa, "not-example.com", exp, "valid", ra.clk.Now())
+	authzIDB := createFinalizedAuthorization(t, sa, "www.not-example.com", exp, "valid", ra.clk.Now())
 
 	// Create a new order to finalize with names in SAN and CN
 	mixedOrder, err := sa.NewOrder(context.Background(), &sapb.NewOrderRequest{
@@ -3126,7 +3165,7 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 	test.AssertNotError(t, err, "NewOrder failed for wildcard domain order")
 
 	// Create one standard finalized authorization for Registration.Id for zombo.com
-	_ = createFinalizedAuthorization(t, sa, "zombo.com", exp, "valid")
+	_ = createFinalizedAuthorization(t, sa, "zombo.com", exp, "valid", ra.clk.Now())
 
 	// Finalizing the order should *not* work since the existing validated authz
 	// is not a special DNS-01-Wildcard challenge authz, so the order will be
@@ -3151,10 +3190,11 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 
 	// Finalize the authorization with the challenge validated
 	_, err = sa.FinalizeAuthorization2(ctx, &sapb.FinalizeAuthorizationRequest{
-		Id:        validOrder.V2Authorizations[0],
-		Status:    string(core.StatusValid),
-		Expires:   ra.clk.Now().Add(time.Hour * 24 * 7).UnixNano(),
-		Attempted: string(core.ChallengeTypeDNS01),
+		Id:          validOrder.V2Authorizations[0],
+		Status:      string(core.StatusValid),
+		Expires:     ra.clk.Now().Add(time.Hour * 24 * 7).UnixNano(),
+		Attempted:   string(core.ChallengeTypeDNS01),
+		AttemptedAt: ra.clk.Now().UnixNano(),
 	})
 	test.AssertNotError(t, err, "sa.FinalizeAuthorization2 failed")
 
@@ -3217,10 +3257,11 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 		test.AssertNotError(t, err, "sa.NewAuthorzations2 failed")
 		// Finalize the authz
 		_, err = sa.FinalizeAuthorization2(ctx, &sapb.FinalizeAuthorizationRequest{
-			Id:        ids.Ids[0],
-			Status:    "valid",
-			Expires:   exp.UnixNano(),
-			Attempted: chalType,
+			Id:          ids.Ids[0],
+			Status:      "valid",
+			Expires:     exp.UnixNano(),
+			Attempted:   chalType,
+			AttemptedAt: ra.clk.Now().UnixNano(),
 		})
 		test.AssertNotError(t, err, "sa.FinalizeAuthorization2 failed")
 		return ids.Ids[0]
@@ -3441,8 +3482,8 @@ func TestCTPolicyMeasurements(t *testing.T) {
 
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
 	// Create valid authorizatiosn for not-example.com and www.not-example.com
-	_ = createFinalizedAuthorization(t, ssa, "not-example.com", exp, "valid")
-	_ = createFinalizedAuthorization(t, ssa, "www.not-example.com", exp, "valid")
+	_ = createFinalizedAuthorization(t, ssa, "not-example.com", exp, "valid", ra.clk.Now())
+	_ = createFinalizedAuthorization(t, ssa, "www.not-example.com", exp, "valid", ra.clk.Now())
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -3572,10 +3613,11 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 		// Finalize the authz
 		attempted := string(httpChal.Type)
 		_, err = sa.FinalizeAuthorization2(ctx, &sapb.FinalizeAuthorizationRequest{
-			Id:        ids.Ids[0],
-			Status:    "valid",
-			Expires:   exp.UnixNano(),
-			Attempted: attempted,
+			Id:          ids.Ids[0],
+			Status:      "valid",
+			Expires:     exp.UnixNano(),
+			Attempted:   attempted,
+			AttemptedAt: ra.clk.Now().UnixNano(),
 		})
 		test.AssertNotError(t, err, "sa.FinalizeAuthorization2 failed")
 		return ids.Ids[0]

--- a/sa/model.go
+++ b/sa/model.go
@@ -477,7 +477,7 @@ func statusUint(status core.AcmeStatus) uint8 {
 
 // authzFields is used in a variety of places in sa.go, and modifications to
 // it must be carried through to every use in sa.go
-const authzFields = "id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, token, validationError, validationRecord"
+const authzFields = "id, identifierType, identifierValue, registrationID, status, expires, challenges, attempted, attemptedAt, token, validationError, validationRecord"
 
 type authzModel struct {
 	ID               int64      `db:"id"`

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -920,6 +920,7 @@ func (ssa *SQLStorageAuthority) NewOrderAndAuthzs(ctx context.Context, req *sapb
 					am.Expires,
 					am.Challenges,
 					am.Attempted,
+					am.AttemptedAt,
 					am.Token,
 					am.ValidationError,
 					am.ValidationRecord,
@@ -1486,10 +1487,9 @@ func (ssa *SQLStorageAuthority) NewAuthorizations2(ctx context.Context, req *sap
 
 		// Each authz needs a (?,?...), in the VALUES block. We need one
 		// for each element in the authzFields string.
-		fmt.Fprint(&questionsBuf, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?),")
+		fmt.Fprint(&questionsBuf, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?),")
 
 		// The query arguments must follow the order of the authzFields string.
-		// Note that the AttemptedAt field is not included in the authzFields.
 		queryArgs = append(queryArgs,
 			am.ID,
 			am.IdentifierType,
@@ -1499,6 +1499,7 @@ func (ssa *SQLStorageAuthority) NewAuthorizations2(ctx context.Context, req *sap
 			am.Expires,
 			am.Challenges,
 			am.Attempted,
+			am.AttemptedAt,
 			am.Token,
 			am.ValidationError,
 			am.ValidationRecord,


### PR DESCRIPTION
When a valid authorization is stored in the database the authorization
column attemptedAt is set based on the challenge `Validated` value. Use
this value in `checkAuthorizationsCAA` to determine if an authorization is 
sufficiently stale to need a recheck of the CAA DNS record. Error if the time
is nil.

Fixes: #5696