### PR TITLE
Reduce InternetFacingBuckets histogram buckets

### DIFF
--- a/metrics/scope.go
+++ b/metrics/scope.go
@@ -4,7 +4,7 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // InternetFacingBuckets are the histogram buckets that should be used when
 // measuring latencies that involve traversing the public internet.
-var InternetFacingBuckets = []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 45}
+var InternetFacingBuckets = []float64{.1, .5, 1, 5, 10, 30, 45}
 
 // noopRegisterer mocks prometheus.Registerer. It is used when we need to
 // register prometheus metrics in tests where multiple registrations would


### PR DESCRIPTION
The histogram is more granular than we need, making it more expensive to
store. Reduce from 11 to 7 buckets.

Part of #5749 