### PR TITLE
Make IssuerNameIDs the same length as old IssuerIDs

### DIFF
--- a/cmd/boulder-wfe2/main_test.go
+++ b/cmd/boulder-wfe2/main_test.go
@@ -190,7 +190,7 @@ func TestLoadCertificateChains(t *testing.T) {
 				"http://single-cert-chain.com": {"../../test/test-ca.pem"},
 			},
 			ExpectedMap: map[issuance.IssuerNameID][]byte{
-				issuance.IssuerNameID(37287262753088952): []byte(fmt.Sprintf("\n%s", string(certBytesA))),
+				issuance.IssuerNameID(2222494051): []byte(fmt.Sprintf("\n%s", string(certBytesA))),
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func TestLoadCertificateChains(t *testing.T) {
 				"http://two-cert-chain.com": {"../../test/test-ca.pem", "../../test/test-ca2.pem"},
 			},
 			ExpectedMap: map[issuance.IssuerNameID][]byte{
-				issuance.IssuerNameID(37287262753088952): []byte(fmt.Sprintf("\n%s\n%s", string(certBytesA), string(certBytesB))),
+				issuance.IssuerNameID(2222494051): []byte(fmt.Sprintf("\n%s\n%s", string(certBytesA), string(certBytesB))),
 			},
 		},
 		{
@@ -210,7 +210,7 @@ func TestLoadCertificateChains(t *testing.T) {
 			ExpectedMap: map[issuance.IssuerNameID][]byte{
 				// NOTE(@cpu): There should be a trailing \n added by the WFE that we
 				// expect in the format specifier below.
-				issuance.IssuerNameID(37287262753088952): []byte(fmt.Sprintf("\n%s\n", string(abruptPEMBytes))),
+				issuance.IssuerNameID(2222494051): []byte(fmt.Sprintf("\n%s\n", string(abruptPEMBytes))),
 			},
 		},
 		{
@@ -220,7 +220,7 @@ func TestLoadCertificateChains(t *testing.T) {
 				"http://two-cert-chain.com": {"../../test/test-ca.pem", "../../test/test-ca2.pem"},
 			},
 			ExpectedMap: map[issuance.IssuerNameID][]byte{
-				issuance.IssuerNameID(37287262753088952): []byte(fmt.Sprintf("\n%s\n%s", string(certBytesA), string(certBytesB))),
+				issuance.IssuerNameID(2222494051): []byte(fmt.Sprintf("\n%s\n%s", string(certBytesA), string(certBytesB))),
 			},
 		},
 		{

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -414,7 +414,7 @@ func truncatedHash(name []byte) IssuerNameID {
 	h := crypto.SHA1.New()
 	h.Write(name)
 	s := h.Sum(nil)
-	return IssuerNameID(big.NewInt(0).SetBytes(s[:7]).Int64())
+	return IssuerNameID(big.NewInt(0).SetBytes(s[:4]).Int64())
 }
 
 // Issuer is capable of issuing new certificates


### PR DESCRIPTION
These were different lengths (four bytes and seven bytes) for unclear
reasons. Make them the same length.