### PR TITLE
ARI: Set Retry-After header to 6 hours

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2415,6 +2415,10 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling renewalInfo"), err)
 		return
 	}
+
+	pollPeriod := int(6 * time.Hour / time.Second)
+	response.Header().Set("Retry-After", fmt.Sprintf("%d", pollPeriod))
+	response.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public, no-transform, must-revalidate", pollPeriod))
 }
 
 func extractRequesterIP(req *http.Request) (net.IP, error) {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2418,7 +2418,6 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 
 	pollPeriod := int(6 * time.Hour / time.Second)
 	response.Header().Set("Retry-After", fmt.Sprintf("%d", pollPeriod))
-	response.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public, no-transform, must-revalidate", pollPeriod))
 }
 
 func extractRequesterIP(req *http.Request) (net.IP, error) {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3658,6 +3658,7 @@ func TestARI(t *testing.T) {
 	resp := httptest.NewRecorder()
 	wfe.RenewalInfo(context.Background(), event, resp, req)
 	test.AssertEquals(t, resp.Code, 200)
+	test.AssertEquals(t, resp.Header().Get("Retry-After"), "21600")
 
 	// Ensure that a mangled query (wrong serial) results in a 404.
 	path = fmt.Sprintf(
@@ -3670,4 +3671,5 @@ func TestARI(t *testing.T) {
 	resp = httptest.NewRecorder()
 	wfe.RenewalInfo(context.Background(), event, resp, req)
 	test.AssertEquals(t, resp.Code, 404)
+	test.AssertEquals(t, resp.Header().Get("Retry-After"), "")
 }


### PR DESCRIPTION
The draft requires that the renewalInfo endpoint have a
Retry-After header indicating how often clients should poll
for their renewal information. As per our previous thinking,
set this timer to 6 hours for now.

Also set a cache header with the same time period to help
offload clients that don't respect the Retry-After period.

Fixes #5765