### PR TITLE
Quiet the output of wait-for-it

### DIFF
--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -10,29 +10,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
-wait_tcp_port() {
-    local host="$1" port="$2"
-
-    # see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
-    local max_tries="120"
-    for n in `seq 1 $max_tries` ; do
-      if exec 6<>/dev/tcp/$host/$port; then
-        break
-      else
-        echo "$(date) - still trying to connect to $host:$port"
-        sleep 1
-      fi
-      if [ "$n" -eq "$max_tries" ]; then
-        echo "unable to connect"
-        exit 1
-      fi
-    done
-    exec 6>&-
-    echo "Connected to $host:$port"
-}
 # make sure we can reach the mysqldb and Redis cluster is done being created.
-wait_tcp_port boulder-mysql 3306
-wait_tcp_port 10.33.33.10 4218
+./test/wait-for-it.sh boulder-mysql 3306
+./test/wait-for-it.sh 10.33.33.10 4218
 
 # create the database
 MYSQL_CONTAINER=1 $DIR/create_db.sh

--- a/test/wait-for-it.sh
+++ b/test/wait-for-it.sh
@@ -8,7 +8,7 @@ wait_tcp_port() {
     # see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
     local max_tries="40"
     for n in `seq 1 "${max_tries}"` ; do
-      if exec 6<>/dev/tcp/"${host}"/"${port}"; then
+      if { exec 6<>/dev/tcp/"${host}"/"${port}" ; } 2>/dev/null ; then
         break
       else
         echo "$(date) - still trying to connect to ${host}:${port}"


### PR DESCRIPTION
When wait-for-it is trying to connect and failing, bash emits errors on
stderr. This captures those errors and sends them to /dev/null.

This also replaces an internal wait_tcp_port function inside
entrypoint.sh with a call to wait-for-it.sh.

This reduces spammy log lines like:

```
boulder_1           | test/entrypoint.sh: connect: Connection refused
boulder_1           | test/entrypoint.sh: line 19: /dev/tcp/boulder-mysql/3306: Connection refused
```