### PR TITLE
Check column names in ScanCertStatusMetadataRow

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -148,7 +148,20 @@ func CertStatusMetadataFields() []string {
 // `CertStatusMetadataFields()`, and the `*core.CerticateStatus` field name
 // being copied to.
 func ScanCertStatusMetadataRow(rows *sql.Rows, status *CertStatusMetadata) error {
-	err := rows.Scan(
+	columns, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	expectedColumns := CertStatusMetadataFields()
+	if len(columns) != len(expectedColumns) {
+		return fmt.Errorf("incorrect number of columns in scanned rows: got %d, expected %d", len(columns), len(expectedColumns))
+	}
+	for i, v := range columns {
+		if v != expectedColumns[i] {
+			return fmt.Errorf("incorrect column %d in scanned rows: got %q, expected %q", i, v, expectedColumns[i])
+		}
+	}
+	err = rows.Scan(
 		&status.ID,
 		&status.Serial,
 		&status.Status,

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -227,7 +227,53 @@ func TestPopulateAttemptedFieldsBadJSON(t *testing.T) {
 	}
 }
 
-func TestCerficatesTableContainsDuplicateSerials(t *testing.T) {
+func TestScanCertStatusMetadataRow(t *testing.T) {
+	sa, _, cleanUp := initSA(t)
+	defer cleanUp()
+
+	inputStatus := core.CertificateStatus{
+		Serial: "ff00ff00",
+		Status: "good",
+	}
+	err := sa.dbMap.Insert(&inputStatus)
+	test.AssertNotError(t, err, "couldn't insert certificateStatus")	
+
+	rows, err := sa.dbMap.Query("SELECT serial, status, ocspLastUpdated FROM certificateStatus");
+	test.AssertNotError(t, err, "selecting")
+
+	if !rows.Next() {
+		t.Fatal("got no rows")
+	}
+	var certStatus CertStatusMetadata
+	err = ScanCertStatusMetadataRow(rows, &certStatus)
+
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	expected := "incorrect number of columns in scanned rows: got 3, expected 10"
+	if err.Error() != expected {
+		t.Errorf("wrong error: got %q, expected %q", err, expected)
+	}
+
+	rows, err = sa.dbMap.Query("SELECT id, status, serial, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, notAfter, isExpired, issuerID FROM certificateStatus");
+	test.AssertNotError(t, err, "selecting")
+
+	if !rows.Next() {
+		t.Fatal("got no rows")
+	}
+
+	err = ScanCertStatusMetadataRow(rows, &certStatus)
+
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	expected = "incorrect column 1 in scanned rows: got \"status\", expected \"serial\""
+	if err.Error() != expected {
+		t.Errorf("wrong error: got %q, expected %q", err, expected)
+	}
+}
+
+func TestCertificatesTableContainsDuplicateSerials(t *testing.T) {
 	sa, fc, cleanUp := initSA(t)
 	defer cleanUp()
 

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -236,9 +236,9 @@ func TestScanCertStatusMetadataRow(t *testing.T) {
 		Status: "good",
 	}
 	err := sa.dbMap.Insert(&inputStatus)
-	test.AssertNotError(t, err, "couldn't insert certificateStatus")	
+	test.AssertNotError(t, err, "couldn't insert certificateStatus")
 
-	rows, err := sa.dbMap.Query("SELECT serial, status, ocspLastUpdated FROM certificateStatus");
+	rows, err := sa.dbMap.Query("SELECT serial, status, ocspLastUpdated FROM certificateStatus")
 	test.AssertNotError(t, err, "selecting")
 
 	if !rows.Next() {
@@ -255,7 +255,7 @@ func TestScanCertStatusMetadataRow(t *testing.T) {
 		t.Errorf("wrong error: got %q, expected %q", err, expected)
 	}
 
-	rows, err = sa.dbMap.Query("SELECT id, status, serial, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, notAfter, isExpired, issuerID FROM certificateStatus");
+	rows, err = sa.dbMap.Query("SELECT id, status, serial, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, notAfter, isExpired, issuerID FROM certificateStatus")
 	test.AssertNotError(t, err, "selecting")
 
 	if !rows.Next() {


### PR DESCRIPTION
This ensures we queried the right set of columns, and didn't get them
out of order.