### PR TITLE
Add load-from-db support to rocsp-tool

### DIFF
--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -414,6 +414,7 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
 func (cl *client) scanFromDB(ctx context.Context, minID int64, frequency time.Duration, inflightIDs *inflight) <-chan *sa.CertStatusMetadata {
 	statusesToSign := make(chan *sa.CertStatusMetadata)
 	go func() {
+		defer close(statusesToSign)
 		err := cl.scanFromDBInner(ctx, minID, frequency, statusesToSign, inflightIDs)
 		if err != nil {
 			log.Printf("error scanning rows: %s", err)
@@ -436,8 +437,6 @@ func (cl *client) scanFromDBInner(ctx context.Context, minID int64, frequency ti
 		if rerr != nil {
 			log.Printf("closing rows: %s", rerr)
 		}
-
-		close(output)
 	}()
 
 	var scanned int

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -411,7 +411,7 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
 // its output channel at a maximum frequency of `frequency`. When it's read all available rows, it
 // closes its output channel and exits.
 // If there is an error, it logs the error, closes its output channel, and exits.
-func (cl *client) scanFromDB(ctx context.Context, minID int64, frequency time.Duration, inflightIDs *inflight) (<-chan *sa.CertStatusMetadata) {
+func (cl *client) scanFromDB(ctx context.Context, minID int64, frequency time.Duration, inflightIDs *inflight) <-chan *sa.CertStatusMetadata {
 	statusesToSign := make(chan *sa.CertStatusMetadata)
 	go func() {
 		err := cl.scanFromDBInner(ctx, minID, frequency, statusesToSign, inflightIDs)

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -356,7 +356,7 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
 	defer func() {
 		rerr := rows.Close()
 		if rerr != nil {
-			log.Printf("closing rows: %w", rerr)
+			log.Printf("closing rows: %s", rerr)
 		}
 	}()
 

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -370,7 +370,7 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
 	statusesToSign := make(chan *sa.CertStatusMetadata)
 	// a set of all inflight certificate statuses, indexed by their `ID`.
 	inflightIDs := newInflight()
-	go cl.scanFromDB(ctx,  *minID, frequency, statusesToSign, inflightIDs)
+	go cl.scanFromDB(ctx, *minID, frequency, statusesToSign, inflightIDs)
 
 	results := make(chan processResult, speed.ParallelSigns)
 	var runningSigners int32
@@ -386,9 +386,9 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
 		if result.err != nil {
 			errorCount++
 			if errorCount < 10 ||
-			  (errorCount < 1000 && rand.Intn(1000) < 100) ||
-			  (errorCount < 100000 && rand.Intn(1000) < 10) ||
-			  (rand.Intn(1000) < 1) {
+				(errorCount < 1000 && rand.Intn(1000) < 100) ||
+				(errorCount < 100000 && rand.Intn(1000) < 10) ||
+				(rand.Intn(1000) < 1) {
 				log.Printf("error: %s", result.err)
 			}
 		} else {
@@ -459,7 +459,6 @@ func (cl *client) scanFromDBInner(ctx context.Context, minID int64, frequency ti
 	}
 	return nil
 }
-
 
 type signedResponse struct {
 	der []byte

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -310,8 +310,8 @@ func (i *inflight) remove(n uint64) {
 }
 
 func (i *inflight) len() int {
-	i.Lock()
-	defer i.Unlock()
+	i.RLock()
+	defer i.RUnlock()
 	return len(i.items)
 }
 
@@ -403,6 +403,9 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
 		}
 		scanned++
 		inflightIDs.add(uint64(status.ID))
+		// Emit a log line every 100000 rows. For our current ~215M rows, that
+		// will emit about 2150 log lines. This probably strikes a good balance
+		// between too spammy and having a reasonably frequent checkpoint.
 		if scanned%100000 == 0 {
 			log.Printf("scanned %d certificateStatus rows. minimum inflight ID %d", scanned, inflightIDs.min())
 		}

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -4,22 +4,31 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509/pkix"
+	"database/sql"
 	"encoding/asn1"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/jmhodges/clock"
+	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/issuance"
+	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/rocsp"
 	rocsp_config "github.com/letsencrypt/boulder/rocsp/config"
+	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test/ocsp/helper"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/ocsp"
 )
 
@@ -32,7 +41,34 @@ type config struct {
 		// components. For production we'll use the number part of the CN, i.e.
 		// E1 -> 1, R3 -> 3, etc.
 		Issuers map[string]int
+
+		// If using load-from-db, this provides credentials to connect to the DB
+		// and the CA. Otherwise, it's optional.
+		LoadFromDB *LoadFromDBConfig
 	}
+}
+
+// LoadFromDBConfig provides the credentials and configuration needed to load
+// data from the certificateStatuses table in the DB and get it signed.
+type LoadFromDBConfig struct {
+	// Credentials to connect to the DB.
+	DB cmd.DBConfig
+	// Credentials to request OCSP signatures from the CA.
+	GRPCTLS cmd.TLSConfig
+	// Timeouts and hostnames for the CA.
+	OCSPGeneratorService cmd.GRPCClientConfig
+	// How fast to process rows.
+	Speed ProcessingSpeed
+}
+
+type ProcessingSpeed struct {
+	// If using load-from-db, this limits how many items per second we
+	// scan from the DB. We might go slower than this depending on how fast
+	// we read rows from the DB, but we won't go faster. Defaults to 2000.
+	RowsPerSecond int
+	// If using load-from-db, this controls how many parallel requests to
+	// boulder-ca for OCSP signing we can make. Defaults to 100.
+	ParallelSigns int
 }
 
 func init() {
@@ -118,31 +154,285 @@ func main2() error {
 		return fmt.Errorf("'issuers' section of config JSON is required.")
 	}
 	clk := cmd.Clock()
-	client, err := rocsp_config.MakeClient(&c.ROCSPTool.Redis, clk)
+	redisClient, err := rocsp_config.MakeClient(&c.ROCSPTool.Redis, clk)
 	if err != nil {
 		return fmt.Errorf("making client: %w", err)
 	}
 
-	for _, respFile := range flag.Args() {
-		err := storeResponse(respFile, issuers, client, clk)
+	var db *sql.DB
+	var ocspGenerator capb.OCSPGeneratorClient
+	if c.ROCSPTool.LoadFromDB != nil {
+		db, err = configureDb(&c.ROCSPTool.LoadFromDB.DB)
 		if err != nil {
-			return err
+			return fmt.Errorf("connecting to DB: %w", err)
 		}
+
+		ocspGenerator, err = configureOCSPGenerator(c.ROCSPTool.LoadFromDB.GRPCTLS,
+			c.ROCSPTool.LoadFromDB.OCSPGeneratorService, clk, metrics.NoopRegisterer)
+		if err != nil {
+			return fmt.Errorf("configuring gRPC to CA: %w", err)
+		}
+	}
+
+	if len(flag.Args()) < 1 {
+		helpExit()
+	}
+
+	ctx := context.Background()
+	cl := client{
+		issuers:       issuers,
+		redis:         redisClient,
+		db:            db,
+		ocspGenerator: ocspGenerator,
+		clk:           clk,
+	}
+	switch flag.Args()[0] {
+	case "store":
+		for _, respFile := range flag.Args() {
+			respBytes, err := ioutil.ReadFile(respFile)
+			if err != nil {
+				return fmt.Errorf("reading response file %q: %w", respFile, err)
+			}
+			err = cl.storeResponse(ctx, respBytes, nil)
+			if err != nil {
+				return err
+			}
+		}
+	case "load-from-db":
+		if c.ROCSPTool.LoadFromDB == nil {
+			return fmt.Errorf("config field LoadFromDB was missing")
+		}
+		err = cl.loadFromDB(ctx, c.ROCSPTool.LoadFromDB.Speed)
+		if err != nil {
+			return fmt.Errorf("loading OCSP responses from DB: %w", err)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unrecognized subcommand %q\n", flag.Args()[0])
+		helpExit()
 	}
 	return nil
 }
 
-func storeResponse(respFile string, issuers []ShortIDIssuer, client *rocsp.WritingClient, clk clock.Clock) error {
-	ctx := context.Background()
-	respBytes, err := ioutil.ReadFile(respFile)
+func helpExit() {
+	fmt.Fprintf(os.Stderr, "Usage: %s [store|copy-from-db] --config path/to/config.json\n", os.Args[0])
+	fmt.Fprintln(os.Stderr, "  store -- for each command line arg, read that filename as an OCSP response and store it in Redis")
+	fmt.Fprintln(os.Stderr, "  load-from-db -- scan the database for all OCSP entries for unexpired certificates, and store in Redis")
+	fmt.Fprintln(os.Stderr)
+	flag.PrintDefaults()
+	os.Exit(1)
+}
+
+func configureOCSPGenerator(tlsConf cmd.TLSConfig, grpcConf cmd.GRPCClientConfig, clk clock.Clock, stats prometheus.Registerer) (capb.OCSPGeneratorClient, error) {
+	tlsConfig, err := tlsConf.Load()
 	if err != nil {
-		return fmt.Errorf("reading response file %q: %w", respFile, err)
+		return nil, fmt.Errorf("loading TLS config: %w", err)
 	}
+	clientMetrics := bgrpc.NewClientMetrics(stats)
+	caConn, err := bgrpc.ClientSetup(&grpcConf, tlsConfig, clientMetrics, clk)
+	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to CA")
+	return capb.NewOCSPGeneratorClient(caConn), nil
+}
+
+func configureDb(dbConfig *cmd.DBConfig) (*sql.DB, error) {
+	if dbConfig == nil {
+		return nil, nil
+	}
+	dsn, err := dbConfig.URL()
+	if err != nil {
+		return nil, fmt.Errorf("loading DB URL: %w", err)
+	}
+
+	conf, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing DSN from 'DBConnectFile': %s", err)
+	}
+
+	if len(conf.Params) == 0 {
+		conf.Params = make(map[string]string)
+	}
+	conf.Params["tx_isolation"] = "'READ-UNCOMMITTED'"
+	conf.Params["interpolateParams"] = "true"
+	conf.Params["parseTime"] = "true"
+
+	db, err := sql.Open("mysql", conf.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("couldn't setup database client: %s", err)
+	}
+
+	db.SetMaxOpenConns(dbConfig.MaxOpenConns)
+	db.SetMaxIdleConns(dbConfig.MaxIdleConns)
+	db.SetConnMaxLifetime(dbConfig.ConnMaxLifetime.Duration)
+	db.SetConnMaxIdleTime(dbConfig.ConnMaxIdleTime.Duration)
+	return db, nil
+}
+
+// setDefault sets the target to a default value, if it is zero.
+func setDefault(target *int, def int) {
+	if *target == 0 {
+		*target = def
+	}
+}
+
+type client struct {
+	issuers       []ShortIDIssuer
+	redis         *rocsp.WritingClient
+	db            *sql.DB // optional
+	ocspGenerator capb.OCSPGeneratorClient
+	clk           clock.Clock
+}
+
+func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
+	// To scan the DB efficiently, we want to select only currently-valid certificates. There's a
+	// handy expires index, but for selecting a large set of rows, using the primary key will be
+	// more efficient. So first we find a good id to start with, then scan from there. Note: since
+	// AUTO_INCREMENT can skip around a bit, we add padding to ensure we get all currently-valid
+	// certificates.
+	startTime := cl.clk.Now().Add(-24 * time.Hour)
+	var minID int64
+	err := cl.db.QueryRowContext(
+		ctx,
+		"SELECT MIN(id) FROM certificateStatus WHERE notAfter >= ?",
+		startTime,
+	).Scan(&minID)
+	if err != nil {
+		return fmt.Errorf("selecting minID: %w", err)
+	}
+
+	setDefault(&speed.RowsPerSecond, 2000)
+	setDefault(&speed.ParallelSigns, 100)
+
+	query := fmt.Sprintf("SELECT %s FROM certificateStatus WHERE id > ?",
+		strings.Join(sa.CertStatusMetadataFields(), ", "))
+	rows, err := cl.db.QueryContext(ctx, query, minID)
+	if err != nil {
+		return fmt.Errorf("scanning certificateStatus: %w", err)
+	}
+	defer rows.Close()
+
+	// Limit the rate of reading rows.
+	frequency := time.Duration(float64(time.Second) / float64(time.Duration(speed.RowsPerSecond)))
+	rowTicker := time.NewTicker(frequency)
+
+	statusesToSign := make(chan *sa.CertStatusMetadata)
+	successes := make(chan struct{}, speed.ParallelSigns)
+	errChan := make(chan error, speed.ParallelSigns)
+
+	var signersWg sync.WaitGroup
+
+	for i := 0; i < speed.ParallelSigns; i++ {
+		signersWg.Add(1)
+		go cl.signAndStoreResponses(statusesToSign, errChan, successes, &signersWg)
+	}
+	var n, errorCount int
+	// Consume all available successes and errors from the output channels.
+	// If none are immediately available, return.
+	consume := func() {
+		for {
+			select {
+			case <-successes:
+				n++
+			case err := <-errChan:
+				errorCount++
+				if errorCount < 10 {
+					log.Print(err)
+				} else if errorCount < 1000 && rand.Intn(1000) < 100 {
+					log.Print(err)
+				} else if errorCount < 100000 && rand.Intn(1000) < 10 {
+					log.Print(err)
+				} else if rand.Intn(1000) < 1 {
+					log.Print(err)
+				}
+			default:
+				return
+			}
+			if (n+errorCount)%10 == 0 {
+				log.Printf("stored %d response, %d errors", n, errorCount)
+			}
+		}
+	}
+	var scanned int
+	for rows.Next() {
+		<-rowTicker.C
+
+		status := new(sa.CertStatusMetadata)
+		if err := sa.ScanCertStatusMetadataRow(rows, status); err != nil {
+			return fmt.Errorf("scanning row %d: %w", n, err)
+		}
+		scanned++
+		if scanned%100000 == 0 {
+			log.Printf("scanned %d certificateStatus rows. current ID %d (note: subtract a safety margin from this if restarting)", scanned, status.ID)
+		}
+		statusesToSign <- status
+
+		consume()
+	}
+	rerr := rows.Close()
+	if rerr != nil {
+		return fmt.Errorf("closing rows: %w", rerr)
+	}
+
+	close(statusesToSign)
+
+	for n+errorCount < scanned {
+		select {
+		case <-successes:
+			n++
+		case <-errChan:
+			errorCount++
+		}
+	}
+	signersWg.Wait()
+	log.Printf("done. processed %d successes and %d errors\n", n, errorCount)
+
+	return nil
+}
+
+type signedResponse struct {
+	der []byte
+	ttl time.Duration
+}
+
+func (cl *client) signAndStoreResponses(input <-chan *sa.CertStatusMetadata, errors chan error, success chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for status := range input {
+		ocspReq := &capb.GenerateOCSPRequest{
+			Serial:    status.Serial,
+			IssuerID:  status.IssuerID,
+			Status:    string(status.Status),
+			Reason:    int32(status.RevokedReason),
+			RevokedAt: status.RevokedDate.UnixNano(),
+		}
+		result, err := cl.ocspGenerator.GenerateOCSP(context.Background(), ocspReq)
+		if err != nil {
+			errors <- err
+			continue
+		}
+		// ttl is the lifetime of the certificate
+		ttl := cl.clk.Now().Sub(status.NotAfter)
+		err = cl.storeResponse(context.Background(), result.Response, &ttl)
+		if err != nil {
+			errors <- err
+		} else {
+			success <- struct{}{}
+		}
+	}
+}
+
+type expiredError struct {
+	serial string
+	ago    time.Duration
+}
+
+func (e expiredError) Error() string {
+	return fmt.Sprintf("response for %s expired %s ago", e.serial, e.ago)
+}
+
+func (cl *client) storeResponse(ctx context.Context, respBytes []byte, ttl *time.Duration) error {
 	resp, err := ocsp.ParseResponse(respBytes, nil)
 	if err != nil {
 		return fmt.Errorf("parsing response: %w", err)
 	}
-	issuer, err := findIssuer(resp, issuers)
+	issuer, err := findIssuer(resp, cl.issuers)
 	if err != nil {
 		return fmt.Errorf("finding issuer for response: %w", err)
 	}
@@ -155,9 +445,11 @@ func storeResponse(respFile string, issuers []ShortIDIssuer, client *rocsp.Writi
 
 	serial := core.SerialToString(resp.SerialNumber)
 
-	if resp.NextUpdate.Before(clk.Now()) {
-		return fmt.Errorf("response for %s expired %s ago", serial,
-			clk.Now().Sub(resp.NextUpdate))
+	if resp.NextUpdate.Before(cl.clk.Now()) {
+		return expiredError{
+			serial: serial,
+			ago:    cl.clk.Now().Sub(resp.NextUpdate),
+		}
 	}
 
 	// Note: Here we set the TTL to slightly more than the lifetime of the
@@ -165,7 +457,10 @@ func storeResponse(respFile string, issuers []ShortIDIssuer, client *rocsp.Writi
 	// of the certificate, so that the metadata field doesn't fall out of
 	// storage even if we are down for days. However, in this tool we don't
 	// have the full certificate, so this will do.
-	ttl := resp.NextUpdate.Sub(clk.Now()) + time.Hour
+	if ttl == nil {
+		ttl_temp := resp.NextUpdate.Sub(cl.clk.Now()) + time.Hour
+		ttl = &ttl_temp
+	}
 
 	log.Printf("storing response for %s, generated %s, ttl %g hours",
 		serial,
@@ -173,12 +468,12 @@ func storeResponse(respFile string, issuers []ShortIDIssuer, client *rocsp.Writi
 		ttl.Hours(),
 	)
 
-	err = client.StoreResponse(ctx, respBytes, issuer.shortID, ttl)
+	err = cl.redis.StoreResponse(ctx, respBytes, issuer.shortID, *ttl)
 	if err != nil {
 		return fmt.Errorf("storing response: %w", err)
 	}
 
-	retrievedResponse, err := client.GetResponse(ctx, serial)
+	retrievedResponse, err := cl.redis.GetResponse(ctx, serial)
 	if err != nil {
 		return fmt.Errorf("getting response: %w", err)
 	}

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -400,7 +400,6 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed) error {
 			select {
 			case doneID := <-successes:
 				inflightIDs.remove(doneID)
-				fmt.Println("removed ", doneID)
 				successCount++
 			case err := <-errChan:
 				errorCount++

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -41,6 +41,7 @@ func MakeClient(c *RedisConfig, clk clock.Clock) (*rocsp.WritingClient, error) {
 		Username:  c.Username,
 		Password:  password,
 		TLSConfig: tlsConfig,
+		PoolSize: 100, // TODO(#5781): Make this configurable
 	})
 	return rocsp.NewWritingClient(rdb, timeout, clk), nil
 }

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -41,7 +41,7 @@ func MakeClient(c *RedisConfig, clk clock.Clock) (*rocsp.WritingClient, error) {
 		Username:  c.Username,
 		Password:  password,
 		TLSConfig: tlsConfig,
-		PoolSize: 100, // TODO(#5781): Make this configurable
+		PoolSize:  100, // TODO(#5781): Make this configurable
 	})
 	return rocsp.NewWritingClient(rdb, timeout, clk), nil
 }

--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -64,13 +64,17 @@ func MakeMetadataKey(serial string) string {
 
 // Client represents a read-only Redis client.
 type Client struct {
+	prefix  string
 	rdb     *redis.ClusterClient
 	timeout time.Duration
 	clk     clock.Clock
 }
 
-// NewClient creates a Client.
-func NewClient(rdb *redis.ClusterClient, timeout time.Duration, clk clock.Clock) *Client {
+// NewClient creates a Client. The timeout applies to all requests, though a shorter timeout can be
+// applied on a per-request basis using context.Context.
+// The prefix is used to simulate different Redis clusters for different purposes - for instance
+// integration testing and unittesting.
+func NewClient(rdb *redis.ClusterClient, prefix string, timeout time.Duration, clk clock.Clock) *Client {
 	return &Client{
 		rdb:     rdb,
 		timeout: timeout,

--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -1,5 +1,24 @@
 {
   "rocspTool": {
+    "loadFromDB": {
+      "db": {
+        "dbConnectFile": "test/secrets/ocsp_updater_dburl",
+        "maxOpenConns": 10
+      },
+      "speed": {
+        "rowsPerSecond": 2000,
+        "parallelSigns": 100
+      },
+      "gRPCTLS": {
+        "caCertFile": "test/grpc-creds/minica.pem",
+        "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
+        "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
+      },
+      "ocspGeneratorService": {
+        "serverAddress": "ca.boulder:9096",
+        "timeout": "0.1s"
+      }
+    },
     "redis": {
       "username": "ocsp-updater",
       "passwordFile": "test/secrets/rocsp_tool_password",

--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -16,7 +16,7 @@
       },
       "ocspGeneratorService": {
         "serverAddress": "ca.boulder:9096",
-        "timeout": "0.1s"
+        "timeout": "0.5s"
       }
     },
     "redis": {


### PR DESCRIPTION
This scans the database for certificateStatus rows, gets them signed by the CA, and writes them to Redis.

Also, bump the default PoolSize for Redis to 100.