### PR TITLE
Revert "Expiry mailer: fetch certificates in bulk"

### DIFF
--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -724,12 +724,12 @@ func TestDedupOnRegistration(t *testing.T) {
 	}
 	regA, err = testCtx.ssa.NewRegistration(ctx, regA)
 	test.AssertNotError(t, err, "Couldn't store regA")
-
 	rawCertA := newX509Cert("happy A",
 		testCtx.fc.Now().Add(72*time.Hour),
 		[]string{"example-a.com", "shared-example.com"},
 		serial1,
 	)
+
 	certDerA, _ := x509.CreateCertificate(rand.Reader, rawCertA, rawCertA, &testKey.PublicKey, &testKey)
 	certA := &core.Certificate{
 		RegistrationID: regA.Id,
@@ -764,8 +764,11 @@ func TestDedupOnRegistration(t *testing.T) {
 
 	err = testCtx.m.findExpiringCertificates()
 	test.AssertNotError(t, err, "error calling findExpiringCertificates")
-	if len(testCtx.mc.Messages) != 1 {
-		t.Fatalf("wrong num of messages, want 1, got %d", len(testCtx.mc.Messages))
+	if len(testCtx.mc.Messages) > 1 {
+		t.Errorf("num of messages, want %d, got %d", 1, len(testCtx.mc.Messages))
+	}
+	if len(testCtx.mc.Messages) == 0 {
+		t.Fatalf("no messages sent")
 	}
 	domains := "example-a.com\nexample-b.com\nshared-example.com"
 	expected := mocks.MailerMessage{

--- a/test/v1_integration.py
+++ b/test/v1_integration.py
@@ -402,13 +402,9 @@ def test_expiration_mailer():
 
     requests.post("http://localhost:9381/clear", data='')
     for time in (no_reminder, first_reminder, last_reminder):
-        try:
-            print(get_future_output(
-                ["./bin/expiration-mailer", "--config", "%s/expiration-mailer.json" % config_dir],
-                time))
-        except subprocess.CalledProcessError as e:
-            print(e.output.decode("unicode-escape"))
-            raise
+        print(get_future_output(
+            ["./bin/expiration-mailer", "--config", "%s/expiration-mailer.json" % config_dir],
+            time))
     resp = requests.get("http://localhost:9381/count?to=%s" % email_addr)
     mailcount = int(resp.text)
     if mailcount != 2:


### PR DESCRIPTION
This reverts commit e3ce8164253d7bdf39dca6683d232cd575ceff24,
which was reviewed in https://github.com/letsencrypt/boulder/pull/5607.

This change caused database queries to exceed the maximum packet size
and fail. Because this was an opportunistic optimization, reverting it
is the safest course moving forward.