### PR TITLE
Speed up load-from-db and reduce stderr noisiness

### DIFF
--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -134,7 +134,6 @@ func findIssuerByID(longID int64, issuers []ShortIDIssuer) (*ShortIDIssuer, erro
 	return nil, fmt.Errorf("no issuer found for an ID in certificateStatus: %d", longID)
 }
 
-
 func findIssuerByName(resp *ocsp.Response, issuers []ShortIDIssuer) (*ShortIDIssuer, error) {
 	var responder pkix.RDNSequence
 	_, err := asn1.Unmarshal(resp.RawResponderName, &responder)


### PR DESCRIPTION
Previously loadFromDB was calling cl.storeResponse, which parses, stores, and
then fetches a response, and logs it to stderr. Since we'll be storing
responses at high volume, we don't want to log them all to stderr. And
we're willing to trust that the CA signed a valid response, so we don't
need to parse it again. And we certainly don't need to fetch it right
after storing it.

Fixes #5782 