### PR TITLE
log-validator: ensure that log lines contain a checksum

### DIFF
--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -47,9 +47,14 @@ func lineValid(text string) error {
 		return fmt.Errorf("%s line doesn't match expected format", errorPrefix)
 	}
 	checksum := fields[5]
-	_, err := base64.RawURLEncoding.DecodeString(fields[5])
+	_, err := base64.RawURLEncoding.DecodeString(checksum)
 	if err != nil || len(checksum) != 7 {
-		return fmt.Errorf("%s expected a 7 character base64 raw URL decodable string, got %q) %w", errorPrefix, checksum, invalidChecksumErr)
+		return fmt.Errorf(
+			"%s expected a 7 character base64 raw URL decodable string, got %q: %w",
+			errorPrefix,
+			checksum,
+			invalidChecksumErr,
+		)
 	}
 
 	// Reconstruct just the message portion of the line

--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -1,6 +1,7 @@
 package notmain
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -17,6 +18,8 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	blog "github.com/letsencrypt/boulder/log"
 )
+
+var invalidChecksumErr = errors.New("invalid checksum length")
 
 func lineValid(text string) error {
 	// Line format should match the following rsyslog omfile template:
@@ -38,12 +41,17 @@ func lineValid(text string) error {
 	//   timestamp hostname datacenter syslogseverity binary-name[pid]: checksum msg
 
 	fields := strings.Split(text, " ")
-	const errorPrefix = "log-validator: "
+	const errorPrefix = "log-validator:"
 	// Extract checksum from line
 	if len(fields) < 6 {
-		return fmt.Errorf("%sline doesn't match expected format", errorPrefix)
+		return fmt.Errorf("%s line doesn't match expected format", errorPrefix)
 	}
 	checksum := fields[5]
+	_, err := base64.RawURLEncoding.DecodeString(fields[5])
+	if err != nil || len(checksum) != 7 {
+		return fmt.Errorf("%s expected a 7 character base64 raw URL decodable string, got %q) %w", errorPrefix, checksum, invalidChecksumErr)
+	}
+
 	// Reconstruct just the message portion of the line
 	line := strings.Join(fields[6:], " ")
 
@@ -171,7 +179,11 @@ func main() {
 					continue
 				}
 				if err := lineValid(line.Text); err != nil {
-					lineCounter.WithLabelValues(t.Filename, "bad").Inc()
+					if errors.Is(err, invalidChecksumErr) {
+						lineCounter.WithLabelValues(t.Filename, "invalid checksum length").Inc()
+					} else {
+						lineCounter.WithLabelValues(t.Filename, "bad").Inc()
+					}
 					select {
 					case <-outputLimiter.C:
 						logger.Errf("%s: %s %q", t.Filename, err, line.Text)

--- a/cmd/log-validator/main_test.go
+++ b/cmd/log-validator/main_test.go
@@ -16,6 +16,12 @@ func TestLineValidRejects(t *testing.T) {
 	test.AssertError(t, err, "didn't error on invalid checksum")
 }
 
+func TestLineValidRejectsNotAChecksum(t *testing.T) {
+	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: xxxx Caught SIGTERM")
+	test.AssertError(t, err, "didn't error on invalid checksum")
+	test.AssertErrorIs(t, err, invalidChecksumErr)
+}
+
 func TestLineValidNonOurobouros(t *testing.T) {
 	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: xxxxxxx Caught SIGTERM")
 	test.AssertError(t, err, "didn't error on invalid checksum")


### PR DESCRIPTION
Most Boulder logging is supposed to go through our logging subsystem, where a
checksum is added. However, very occasionally Boulder emits output on stdout or
stderr. For instance this can happen during panics, or if we load a pkcs11
module that emits messages on stdout or stderr.

When that happens, the logs are collected by systemd and sent into rsyslog with
the same programname as the lines that went through our logging subsystem. This
causes spurious alerts from log-validator because it can't find the checksum in
those log lines.

This change reduces the risk of spurious alerting by providing a separate metric
for "malformed log line" vs "well-formed log line with a checksum mismatch."
We'll still want to alert on "malformed log line", in case a future change to
logging causes all log lines to be malformed. But we can set the threshold for
it much higher.

Fixes #5771 