### PR TITLE
Configure buckets for the expiration-mailer processing_latency metric

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -456,7 +456,7 @@ func initStats(stats prometheus.Registerer) mailerStats {
 		prometheus.HistogramOpts{
 			Name:    "processing_latency",
 			Help:    "Time the mailer takes processing certificates in seconds",
-			Buckets: []float64{0.01, 0.2, 0.5, 1, 2, 5, 10, 20, 60, 75, 90, 120},
+			Buckets: []float64{1, 15, 30, 60, 75, 90, 120},
 		})
 	stats.MustRegister(processingLatency)
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -447,15 +447,16 @@ func initStats(stats prometheus.Registerer) mailerStats {
 	sendLatency := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "send_latency",
-			Help:    "Time the mailer takes sending messages",
+			Help:    "Time the mailer takes sending messages in seconds",
 			Buckets: metrics.InternetFacingBuckets,
 		})
 	stats.MustRegister(sendLatency)
 
 	processingLatency := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "processing_latency",
-			Help: "Time the mailer takes processing certificates",
+			Name:    "processing_latency",
+			Help:    "Time the mailer takes processing certificates in seconds",
+			Buckets: []float64{0.01, 0.2, 0.5, 1, 2, 5, 10, 20, 60, 75, 90, 120},
 		})
 	stats.MustRegister(processingLatency)
 


### PR DESCRIPTION
Also updates metric text to explicitly mention the time is in seconds.

Current buckets are as follows. I removed some of the lower buckets in favor of times closer to the upstream TLS timeout from our mail service.
```
0.005
0.01
0.025
0.05
0.1
0.25
0.5
1
2.5
5
10
+Inf
```