### PR TITLE
Enable dependabot for zlint and the PSL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/zmap/zlint/v3"
+      - dependency-name: "github.com/weppos/publicsuffix-go"


### PR DESCRIPTION
These two dependencies regularly have updates which have meaningful
semantic content (new lints, new PSL entries) but which don't change any
APIs and are therefore trivial to integrate. They are also common sources
of external requests that we update these dependencies. Automate that
process.

Fixes #5796