### PR TITLE
Plumb through Redis config options.

### DIFF
--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -21,6 +21,51 @@ type RedisConfig struct {
 	Addrs []string
 	// Timeout is a per-request timeout applied to all Redis requests.
 	Timeout cmd.ConfigDuration
+
+	// Maximum number of retries before giving up.
+	// Default is to not retry failed commands.
+	MaxRetries int
+	// Minimum backoff between each retry.
+	// Default is 8 milliseconds; -1 disables backoff.
+	MinRetryBackoff cmd.ConfigDuration
+	// Maximum backoff between each retry.
+	// Default is 512 milliseconds; -1 disables backoff.
+	MaxRetryBackoff cmd.ConfigDuration
+
+	// Dial timeout for establishing new connections.
+	// Default is 5 seconds.
+	DialTimeout cmd.ConfigDuration
+	// Timeout for socket reads. If reached, commands will fail
+	// with a timeout instead of blocking. Use value -1 for no timeout and 0 for default.
+	// Default is 3 seconds.
+	ReadTimeout cmd.ConfigDuration
+	// Timeout for socket writes. If reached, commands will fail
+	// with a timeout instead of blocking.
+	// Default is ReadTimeout.
+	WriteTimeout cmd.ConfigDuration
+
+	// Maximum number of socket connections.
+	// Default is 10 connections per every CPU as reported by runtime.NumCPU.
+	PoolSize int
+	// Minimum number of idle connections which is useful when establishing
+	// new connection is slow.
+	MinIdleConns int
+	// Connection age at which client retires (closes) the connection.
+	// Default is to not close aged connections.
+	MaxConnAge cmd.ConfigDuration
+	// Amount of time client waits for connection if all connections
+	// are busy before returning an error.
+	// Default is ReadTimeout + 1 second.
+	PoolTimeout cmd.ConfigDuration
+	// Amount of time after which client closes idle connections.
+	// Should be less than server's timeout.
+	// Default is 5 minutes. -1 disables idle timeout check.
+	IdleTimeout cmd.ConfigDuration
+	// Frequency of idle checks made by idle connections reaper.
+	// Default is 1 minute. -1 disables idle connections reaper,
+	// but idle connections are still discarded by the client
+	// if IdleTimeout is set.
+	IdleCheckFrequency cmd.ConfigDuration
 }
 
 func MakeClient(c *RedisConfig, clk clock.Clock) (*rocsp.WritingClient, error) {
@@ -41,7 +86,20 @@ func MakeClient(c *RedisConfig, clk clock.Clock) (*rocsp.WritingClient, error) {
 		Username:  c.Username,
 		Password:  password,
 		TLSConfig: tlsConfig,
-		PoolSize:  100, // TODO(#5781): Make this configurable
+
+		MaxRetries:      c.MaxRetries,
+		MinRetryBackoff: c.MinRetryBackoff.Duration,
+		MaxRetryBackoff: c.MaxRetryBackoff.Duration,
+		DialTimeout:     c.DialTimeout.Duration,
+		ReadTimeout:     c.ReadTimeout.Duration,
+		WriteTimeout:    c.WriteTimeout.Duration,
+
+		PoolSize:           c.PoolSize,
+		MinIdleConns:       c.MinIdleConns,
+		MaxConnAge:         c.MaxConnAge.Duration,
+		PoolTimeout:        c.PoolTimeout.Duration,
+		IdleTimeout:        c.IdleTimeout.Duration,
+		IdleCheckFrequency: c.IdleCheckFrequency.Duration,
 	})
 	return rocsp.NewWritingClient(rdb, timeout, clk), nil
 }


### PR DESCRIPTION
All the options from
https://pkg.go.dev/github.com/go-redis/redis#Options (except "DB int",
which we don't use) are now available via our JSON config.

Fixes #5781.