### PR TITLE
Refactor admin-revoker for consistency between commands

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -87,6 +87,13 @@ func TestRevokeBatch(t *testing.T) {
 	ra.CA = &mockCA{}
 	rac := ira.RA{Impl: ra}
 
+	r := revoker{
+		rac:   rac,
+		sac:   isa.SA{Impl: ssa},
+		dbMap: dbMap,
+		log:   log,
+	}
+
 	serialFile, err := ioutil.TempFile("", "serials")
 	test.AssertNotError(t, err, "failed to open temp file")
 	defer os.Remove(serialFile.Name())
@@ -116,7 +123,7 @@ func TestRevokeBatch(t *testing.T) {
 		test.AssertNotError(t, err, "failed to write serial to temp file")
 	}
 
-	err = revokeBatch(rac, log, dbMap, serialFile.Name(), 0, 2)
+	err = r.revokeBySerialBatch(context.Background(), serialFile.Name(), 0, 2)
 	test.AssertNotError(t, err, "revokeBatch failed")
 
 	for _, serial := range serials {


### PR DESCRIPTION
Make a few changes to admin-revoker to help its various modes all fit
the same general interface:
- Create a `revoker` struct with the various revocation mechanisms as
  methods so that the gRPC clients and other infra don't need to be
  passed as arguments.
- Standardize all methods to take a `ctx` as their first argument.
- Remove transactions from the mechanism cases in `main`, since the
  transactions don't gain us anything: the reads use the transaction
  object but the writes don't (they use gRPC) so we don't gain any
  consistency).
- Move non-cli-parsing logic from `main` into revoker methods so that
  cases in `main` all look basically the same.
- Reorder helper methods and cases to match the documented order
  of the various subcommands.

This will make it easier to add new revocation methods to admin-revoker
in the future, e.g. for #5759 and #5785.