### PR TITLE
Add `MakeReadClient` for creating a redis reader

### DIFF
--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -64,7 +64,6 @@ func MakeMetadataKey(serial string) string {
 
 // Client represents a read-only Redis client.
 type Client struct {
-	prefix  string
 	rdb     *redis.ClusterClient
 	timeout time.Duration
 	clk     clock.Clock
@@ -72,8 +71,6 @@ type Client struct {
 
 // NewClient creates a Client. The timeout applies to all requests, though a shorter timeout can be
 // applied on a per-request basis using context.Context.
-// The prefix is used to simulate different Redis clusters for different purposes - for instance
-// integration testing and unittesting.
 func NewClient(rdb *redis.ClusterClient, timeout time.Duration, clk clock.Clock) *Client {
 	return &Client{
 		rdb:     rdb,

--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -74,7 +74,7 @@ type Client struct {
 // applied on a per-request basis using context.Context.
 // The prefix is used to simulate different Redis clusters for different purposes - for instance
 // integration testing and unittesting.
-func NewClient(rdb *redis.ClusterClient, prefix string, timeout time.Duration, clk clock.Clock) *Client {
+func NewClient(rdb *redis.ClusterClient, timeout time.Duration, clk clock.Clock) *Client {
 	return &Client{
 		rdb:     rdb,
 		timeout: timeout,


### PR DESCRIPTION
Adds a function to create and return a read only redis client.