### PR TITLE
SA: Use read-only connector for GetAuthorizations2

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -26,11 +26,12 @@ func _() {
 	_ = x[FasterNewOrdersRateLimit-15]
 	_ = x[ECDSAForAll-16]
 	_ = x[ServeRenewalInfo-17]
+	_ = x[GetAuthzReadOnly-18]
 }
 
-const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationV1DisableNewValidationsStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfo"
+const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationV1DisableNewValidationsStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnly"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 125, 138, 152, 170, 188, 207, 230, 246, 265, 289, 300, 316}
+var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 125, 138, 152, 170, 188, 207, 230, 246, 265, 289, 300, 316, 332}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -52,6 +52,10 @@ const (
 	// ServeRenewalInfo exposes the renewalInfo endpoint in the directory and for
 	// GET requests. WARNING: This feature is a draft and highly unstable.
 	ServeRenewalInfo
+	// GetAuthzReadOnly causes the SA to use its read-only database connection
+	// (which is generally pointed at a replica rather than the primary db) when
+	// querying the authz2 table.
+	GetAuthzReadOnly
 )
 
 // List of features and their default value, protected by fMu
@@ -74,6 +78,7 @@ var features = map[FeatureFlag]bool{
 	ECDSAForAll:              false,
 	StreamlineOrderAndAuthzs: false,
 	ServeRenewalInfo:         false,
+	GetAuthzReadOnly:         false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1616,12 +1616,48 @@ func (ssa *SQLStorageAuthority) GetAuthorizations2(ctx context.Context, req *sap
 		return &sapb.Authorizations{}, nil
 	}
 
+	// Previously we used a JOIN on the orderToAuthz2 table in order to make sure
+	// we only returned authorizations created using the ACME v2 API. Each time an
+	// order is created a pivot row (order ID + authz ID) is added to the
+	// orderToAuthz2 table. If a large number of orders are created that all contain
+	// the same authorization, due to reuse, then the JOINd query would return a full
+	// authorization row for each entry in the orderToAuthz2 table with the authorization
+	// ID.
+	//
+	// Instead we now filter out these authorizations by doing a second query against
+	// the orderToAuthz2 table. Using this query still requires examining a large number
+	// of rows, but because we don't need to construct a temporary table for the JOIN
+	// and fill it with all the full authorization rows we should save resources.
+	var ids []interface{}
+	qmarks = make([]string, len(authzModels))
+	for i, am := range authzModels {
+		ids = append(ids, am.ID)
+		qmarks[i] = "?"
+	}
+	var authzIDs []int64
+	_, err = ssa.dbMap.Select(
+		&authzIDs,
+		fmt.Sprintf(`SELECT DISTINCT(authzID) FROM orderToAuthz2 WHERE authzID IN (%s)`, strings.Join(qmarks, ",")),
+		ids...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	authzIDMap := map[int64]bool{}
+	for _, id := range authzIDs {
+		authzIDMap[id] = true
+	}
+
 	authzModelMap := make(map[string]authzModel)
 	for _, am := range authzModels {
-		// Add this model to the map if there isn't a model for this identifier yet,
-		// or if there is one but it is pending while this new one is valid.
-		existing, present := authzModelMap[am.IdentifierValue]
-		if !present || uintToStatus[existing.Status] == string(core.StatusPending) && uintToStatus[am.Status] == string(core.StatusValid) {
+		// Anything not found in the ID map wasn't in the pivot table, meaning it
+		// didn't correspond to an order, meaning it wasn't created with ACMEv2.
+		// Don't return it for ACMEv2 requests.
+		if _, present := authzIDMap[am.ID]; !present {
+			continue
+		}
+		if existing, present := authzModelMap[am.IdentifierValue]; !present ||
+			uintToStatus[existing.Status] == string(core.StatusPending) && uintToStatus[am.Status] == string(core.StatusValid) {
 			authzModelMap[am.IdentifierValue] = am
 		}
 	}

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -31,7 +31,8 @@
     },
     "features": {
       "FasterNewOrdersRateLimit": true,
-      "StoreRevokerInfo": true
+      "StoreRevokerInfo": true,
+      "GetAuthzReadOnly": true
     }
   },
 


### PR DESCRIPTION
Add a feature flag which causes the SA to switch between using the
traditional read-write database connector (pointed at the primary db)
or the newer read-only database connector (usually pointed at a
replica) when executing the `GetAuthorizations2` query.