### PR TITLE
rocsp-tool: cursor scans in load-from-db

### DIFF
--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -7,7 +7,8 @@
       },
       "speed": {
         "rowsPerSecond": 2000,
-        "parallelSigns": 100
+        "parallelSigns": 100,
+        "scanBatchSize": 10000
       },
       "gRPCTLS": {
         "caCertFile": "test/grpc-creds/minica.pem",


### PR DESCRIPTION
This is necessary because if a single query response gets too big, MariaDB will terminate it.

Fixes #5793