### PR TITLE
Enable USE INDEX hints when querying authz2 table

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -27,11 +27,12 @@ func _() {
 	_ = x[ECDSAForAll-16]
 	_ = x[ServeRenewalInfo-17]
 	_ = x[GetAuthzReadOnly-18]
+	_ = x[GetAuthzUseIndex-19]
 }
 
-const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationV1DisableNewValidationsStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnly"
+const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationV1DisableNewValidationsStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndex"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 125, 138, 152, 170, 188, 207, 230, 246, 265, 289, 300, 316, 332}
+var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 125, 138, 152, 170, 188, 207, 230, 246, 265, 289, 300, 316, 332, 348}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -56,6 +56,9 @@ const (
 	// (which is generally pointed at a replica rather than the primary db) when
 	// querying the authz2 table.
 	GetAuthzReadOnly
+	// GetAuthzUseIndex causes the SA to use to add a USE INDEX hint when it
+	// queries the authz2 table.
+	GetAuthzUseIndex
 )
 
 // List of features and their default value, protected by fMu
@@ -79,6 +82,7 @@ var features = map[FeatureFlag]bool{
 	StreamlineOrderAndAuthzs: false,
 	ServeRenewalInfo:         false,
 	GetAuthzReadOnly:         false,
+	GetAuthzUseIndex:         false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -32,7 +32,8 @@
     "features": {
       "FasterNewOrdersRateLimit": true,
       "StoreRevokerInfo": true,
-      "GetAuthzReadOnly": true
+      "GetAuthzReadOnly": true,
+      "GetAuthzUseIndex": true
     }
   },
 


### PR DESCRIPTION
Add a new feature flag `GetAuthzUseIndex` which causes the SA
to add `USE INDEX (regID_identifer_status_expires_idx)` to its authz2
database queries. This should encourage the query planner to actually
use that index instead of falling back to large table-scans.

Fixes #5822