### PR TITLE
Enable GetAuthzReadOnly flag in prod tests

### DIFF
--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -27,7 +27,8 @@
     },
     "features": {
       "FasterNewOrdersRateLimit": true,
-      "StoreRevokerInfo": true
+      "StoreRevokerInfo": true,
+      "GetAuthzReadOnly": true
     }
   },
 


### PR DESCRIPTION
This flag has been enabled in prod. Not deprecating it yet because it
hasn't been live for very long.