### PR TITLE
test: Remove `appendonly` from Redis config

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -246,11 +246,11 @@ STAGE="start"
 if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   print_heading "Running Start Test"
   python3 start.py &
-  for I in $(seq 1 100); do
+  for I in $(seq 1 200); do
     sleep 1
     curl -s http://localhost:4000/directory && break
   done
-  if [[ "$I" = 100 ]]; then
+  if [[ "$I" = 200 ]]; then
     echo "Boulder did not come up after ./start.py."
     exit 1
   fi

--- a/test.sh
+++ b/test.sh
@@ -246,11 +246,11 @@ STAGE="start"
 if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   print_heading "Running Start Test"
   python3 start.py &
-  for I in $(seq 1 200); do
+  for I in $(seq 1 100); do
     sleep 1
     curl -s http://localhost:4000/directory && break
   done
-  if [[ "$I" = 200 ]]; then
+  if [[ "$I" = 100 ]]; then
     echo "Boulder did not come up after ./start.py."
     exit 1
   fi

--- a/test/redis.config
+++ b/test/redis.config
@@ -25,6 +25,8 @@ user ocsp-responder    on +@all ~* >0e5a4c8b5faaf3194c8ad83c3dd9a0dd8a75982b
 user boulder-ra        on +@all ~* >b3b2fcbbf46fe39fd522c395a51f84d93a98ff2f
 user replication-user  on +@all ~* >435e9c4225f08813ef3af7c725f0d30d263b9cd3
 user unittest-rw       on +@all ~* >824968fa490f4ecec1e52d5e34916bdb60d45f8d
+masteruser replication-user
+masterauth 435e9c4225f08813ef3af7c725f0d30d263b9cd3
 tls-cert-file /test/redis-tls/redis/cert.pem
 tls-key-file /test/redis-tls/redis/key.pem
 tls-ca-cert-file /test/redis-tls/minica.pem
@@ -34,3 +36,4 @@ cluster-enabled yes
 cluster-config-file cluster-config-1234.conf
 cluster-node-timeout 5000
 cluster-require-full-coverage no
+appendonly yes

--- a/test/redis.config
+++ b/test/redis.config
@@ -26,7 +26,6 @@ user boulder-ra        on +@all ~* >b3b2fcbbf46fe39fd522c395a51f84d93a98ff2f
 user replication-user  on +@all ~* >435e9c4225f08813ef3af7c725f0d30d263b9cd3
 user unittest-rw       on +@all ~* >824968fa490f4ecec1e52d5e34916bdb60d45f8d
 masteruser replication-user
-masterauth 435e9c4225f08813ef3af7c725f0d30d263b9cd3
 tls-cert-file /test/redis-tls/redis/cert.pem
 tls-key-file /test/redis-tls/redis/key.pem
 tls-ca-cert-file /test/redis-tls/minica.pem
@@ -36,4 +35,3 @@ cluster-enabled yes
 cluster-config-file cluster-config-1234.conf
 cluster-node-timeout 5000
 cluster-require-full-coverage no
-appendonly yes

--- a/test/redis.config
+++ b/test/redis.config
@@ -25,8 +25,6 @@ user ocsp-responder    on +@all ~* >0e5a4c8b5faaf3194c8ad83c3dd9a0dd8a75982b
 user boulder-ra        on +@all ~* >b3b2fcbbf46fe39fd522c395a51f84d93a98ff2f
 user replication-user  on +@all ~* >435e9c4225f08813ef3af7c725f0d30d263b9cd3
 user unittest-rw       on +@all ~* >824968fa490f4ecec1e52d5e34916bdb60d45f8d
-masteruser replication-user
-masterauth 435e9c4225f08813ef3af7c725f0d30d263b9cd3
 tls-cert-file /test/redis-tls/redis/cert.pem
 tls-key-file /test/redis-tls/redis/key.pem
 tls-ca-cert-file /test/redis-tls/minica.pem
@@ -36,4 +34,3 @@ cluster-enabled yes
 cluster-config-file cluster-config-1234.conf
 cluster-node-timeout 5000
 cluster-require-full-coverage no
-appendonly yes

--- a/test/redis.config
+++ b/test/redis.config
@@ -26,6 +26,7 @@ user boulder-ra        on +@all ~* >b3b2fcbbf46fe39fd522c395a51f84d93a98ff2f
 user replication-user  on +@all ~* >435e9c4225f08813ef3af7c725f0d30d263b9cd3
 user unittest-rw       on +@all ~* >824968fa490f4ecec1e52d5e34916bdb60d45f8d
 masteruser replication-user
+masterauth 435e9c4225f08813ef3af7c725f0d30d263b9cd3
 tls-cert-file /test/redis-tls/redis/cert.pem
 tls-key-file /test/redis-tls/redis/key.pem
 tls-ca-cert-file /test/redis-tls/minica.pem


### PR DESCRIPTION
Remove `appendonly`, we intend to rely on snapshots only.