### PR TITLE
Improve readability of A and AAAA lookup errors

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -515,7 +515,7 @@ func (dnsClient *impl) LookupHost(ctx context.Context, hostname string) ([]net.I
 		// branching. We don't use ProblemDetails and SubProblemDetails here, because
 		// this error will get wrapped in a DNSError and further munged by higher
 		// layers in the stack.
-		return nil, fmt.Errorf("multiple errors looking up DNS: A: %w; AAAA: %s", errA, errAAAA)
+		return nil, fmt.Errorf("%w; %s", errA, errAAAA)
 	}
 
 	return append(addrsA, addrsAAAA...), nil

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -264,7 +264,7 @@ func TestDNSOneServer(t *testing.T) {
 
 	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
-	_, err = obj.LookupHost(context.Background(), "letsencrypt.org")
+	_, err = obj.LookupHost(context.Background(), "cps.letsencrypt.org")
 
 	test.AssertNotError(t, err, "No message")
 }
@@ -275,7 +275,7 @@ func TestDNSDuplicateServers(t *testing.T) {
 
 	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, blog.UseMock())
 
-	_, err = obj.LookupHost(context.Background(), "letsencrypt.org")
+	_, err = obj.LookupHost(context.Background(), "cps.letsencrypt.org")
 
 	test.AssertNotError(t, err, "No message")
 }
@@ -328,7 +328,7 @@ func TestDNSLookupHost(t *testing.T) {
 
 	ip, err = obj.LookupHost(context.Background(), "nonexistent.letsencrypt.org")
 	t.Logf("nonexistent.letsencrypt.org - IP: %s, Err: %s", ip, err)
-	test.AssertNotError(t, err, "Not an error to not exist")
+	test.AssertError(t, err, "No valid A or AAAA records should error")
 	test.Assert(t, len(ip) == 0, "Should not have IPs")
 
 	// Single IPv4 address

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -84,7 +84,7 @@ def check_challenge_dns_err(chalType):
 
     # Expect a DNS problem with a detail that matches a regex
     expectedProbType = "dns"
-    expectedProbRegex = re.compile(r"DNS problem: SERVFAIL looking up (A|AAAA|TXT|CAA) for {0}".format(d))
+    expectedProbRegex = re.compile(r"SERVFAIL looking up (A|AAAA|TXT|CAA) for {0}".format(d))
 
     # Try and issue for the domain with the given challenge type.
     failed = False
@@ -109,7 +109,7 @@ def check_challenge_dns_err(chalType):
             error = c.error
             if error is None or error.typ != "urn:ietf:params:acme:error:{0}".format(expectedProbType):
                 raise(Exception("Expected {0} prob, got {1}".format(expectedProbType, error.typ)))
-            if not expectedProbRegex.match(error.detail):
+            if not expectedProbRegex.search(error.detail):
                 raise(Exception("Prob detail did not match expectedProbRegex, got \"{0}\"".format(error.detail)))
     finally:
         challSrv.remove_servfail_response(d)

--- a/va/dns.go
+++ b/va/dns.go
@@ -27,6 +27,8 @@ func (va ValidationAuthorityImpl) getAddrs(ctx context.Context, hostname string)
 	}
 
 	if len(addrs) == 0 {
+		// This should be unreachable, as no valid IP addresses being found results
+		// in an error being returned from LookupHost.
 		return nil, berrors.DNSError("No valid IP addresses found for %s", hostname)
 	}
 	va.log.Debugf("Resolved addresses for %s: %s", hostname, addrs)


### PR DESCRIPTION
When we query DNS for a host, and both the A and AAAA lookups fail or
are empty, combine both errors into a single error rather than only
returning the error from the A lookup.

Fixes #5819
Fixes #5319