### PR TITLE
Remove cmd.FailOnError's raw stderr output

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -217,7 +217,6 @@ func newStatsRegistry(addr string, logger blog.Logger) prometheus.Registerer {
 func Fail(msg string) {
 	logger := blog.Get()
 	logger.AuditErr(msg)
-	fmt.Fprintln(os.Stderr, msg)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Currently, `cmd.FailOnError` both audit-logs the message and error, and
prints it directly to stderr. It does both because originally it only
printed to stderr, and the audit logging capability was added later.
Since audit logs are printed to stderr anyway, and since printing to
stderr without going through the logger produces lines of output that
violate the log-validator's expected checksums, remove the now-redundant
print.

Fixes #5790