### PR TITLE
Run tests on Go 1.17.5

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -34,6 +34,7 @@ jobs:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
           - go1.17_2021-08-26
+          - go1.17_2021-08-26
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -33,8 +33,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.17_2021-12-09
-          - go1.17.5_2021-12-09
+          - go1.17_2021-12-10
+          - go1.17.5_2021-12-10
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -33,8 +33,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.17_2021-08-26
-          - go1.17_2021-08-26
+          - go1.17_2021-12-09
+          - go1.17.5_2021-12-09
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   boulder:
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17_2021-10-22}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17_2021-12-09}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   boulder:
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17_2021-12-09}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17_2021-12-10}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -43,11 +43,15 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 # Note: The version of golang/protobuf is partially tied to the version of grpc
 # used by Boulder overall. Updating it may require updating the grpc version
 # and vice versa.
-go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26.0
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
-go install bitbucket.org/liamstask/goose/cmd/goose@latest
-go install golang.org/x/tools/cmd/stringer@latest
-go install github.com/letsencrypt/pebble/cmd/pebble-challtestsrv@latest
+GO111MODULE=on go get \
+  bitbucket.org/liamstask/goose/cmd/goose \
+  google.golang.org/protobuf/cmd/protoc-gen-go@v1.26.0 \
+  google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0 \
+  golang.org/x/tools/cmd/stringer
+
+# Pebble's latest version is v2+, but it's not properly go mod compatible, so we
+# fetch it in GOPATH mode.
+GO111MODULE=off go get github.com/letsencrypt/pebble/cmd/pebble-challtestsrv
 
 go clean -cache
 go clean -modcache

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -37,15 +37,11 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 # Note: The version of golang/protobuf is partially tied to the version of grpc
 # used by Boulder overall. Updating it may require updating the grpc version
 # and vice versa.
-GO111MODULE=on go get \
-  bitbucket.org/liamstask/goose/cmd/goose \
-  google.golang.org/protobuf/cmd/protoc-gen-go@v1.26.0 \
-  google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0 \
-  golang.org/x/tools/cmd/stringer
-
-# Pebble's latest version is v2+, but it's not properly go mod compatible, so we
-# fetch it in GOPATH mode.
-GO111MODULE=off go get github.com/letsencrypt/pebble/cmd/pebble-challtestsrv
+go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26.0
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
+go install bitbucket.org/liamstask/goose/cmd/goose@latest
+go install golang.org/x/tools/cmd/stringer@latest
+go install github.com/letsencrypt/pebble/cmd/pebble-challtestsrv@latest
 
 go clean -cache
 go clean -modcache

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -5,7 +5,7 @@ cd $(dirname $0)
 DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
 
-GO_VERSIONS=( "1.17" )
+GO_VERSIONS=( "1.17" "1.17.5" )
 
 # Build a tagged image for each GO_VERSION
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
Build a new docker container for today's Go 1.17.5 security release,
which includes a fix for the net/http package. Update our CI to run
tests on both our current and the new go versions.