### PR TITLE
ocsp-updater: make sure rows get closed

### DIFF
--- a/ocsp_updater/updater.go
+++ b/ocsp_updater/updater.go
@@ -231,7 +231,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 		// If error, log and increment retries for backoff. Else no
 		// error, proceed to push statuses to channel.
 		if err != nil {
-			updater.log.AuditErrf("Failed to find stale OCSP responses: %s", err)
+			updater.log.AuditErrf("failed to find stale OCSP responses: %s", err)
 			updater.findStaleOCSPCounter.WithLabelValues("failed").Inc()
 			updater.readFailures.Add(1)
 			return
@@ -239,7 +239,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 		defer func() {
 			err := rows.Close()
 			if err != nil {
-				updater.log.AuditErrf("Closing query rows: %s", err)
+				updater.log.AuditErrf("closing query rows: %s", err)
 			}
 		}()
 
@@ -247,7 +247,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 			var status sa.CertStatusMetadata
 			err := sa.ScanCertStatusMetadataRow(rows, &status)
 			if err != nil {
-				updater.log.AuditErrf("Failed to scan metadata status row: %s", err)
+				updater.log.AuditErrf("failed to scan metadata status row: %s", err)
 				updater.findStaleOCSPCounter.WithLabelValues("failed").Inc()
 				updater.readFailures.Add(1)
 				return

--- a/ocsp_updater/updater.go
+++ b/ocsp_updater/updater.go
@@ -227,6 +227,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 			),
 			args...,
 		)
+
 		// If error, log and increment retries for backoff. Else no
 		// error, proceed to push statuses to channel.
 		if err != nil {
@@ -270,6 +271,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 			updater.log.AuditErrf("finishing row scan: %s", err)
 			updater.findStaleOCSPCounter.WithLabelValues("failed").Inc()
 			updater.readFailures.Add(1)
+			return
 		}
 
 		updater.findStaleOCSPCounter.WithLabelValues("success").Inc()


### PR DESCRIPTION
Previously there was an error path when we hit `ctx.Done()` that could
cause the DB rows object to not get closed. This might cause leaked
queries that stay alive indefinitely.

Also, when we finish iterating over our set of rows, check rows.Err().