### PR TITLE
Add account cache to WFE

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -122,10 +122,17 @@ type config struct {
 		// date of pending authorizations by subtracting this value from the expiry.
 		// It should match the value configured in the RA.
 		PendingAuthorizationLifetimeDays int
+
+		AccountCache *CacheConfig
 	}
 
 	Syslog  cmd.SyslogConfig
 	Beeline cmd.BeelineConfig
+}
+
+type CacheConfig struct {
+	Size int
+	TTL  cmd.ConfigDuration
 }
 
 // loadCertificateFile loads a PEM certificate from the certFile provided. It
@@ -403,7 +410,31 @@ func main() {
 		pendingAuthorizationLifetime = time.Duration(c.WFE.PendingAuthorizationLifetimeDays) * (24 * time.Hour)
 	}
 
-	wfe, err := wfe2.NewWebFrontEndImpl(stats, clk, kp, allCertChains, issuerCerts, rns, npm, logger, c.WFE.StaleTimeout.Duration, authorizationLifetime, pendingAuthorizationLifetime, rac, sac)
+	var accountGetter wfe2.AccountGetter
+	if c.WFE.AccountCache != nil {
+		accountGetter = wfe2.NewAccountCache(sac,
+			c.WFE.AccountCache.Size,
+			c.WFE.AccountCache.TTL.Duration,
+			clk,
+			stats)
+	} else {
+		accountGetter = sac
+	}
+	wfe, err := wfe2.NewWebFrontEndImpl(
+		stats,
+		clk,
+		kp,
+		allCertChains,
+		issuerCerts,
+		rns,
+		npm,
+		logger,
+		c.WFE.StaleTimeout.Duration,
+		authorizationLifetime,
+		pendingAuthorizationLifetime,
+		rac,
+		sac,
+		accountGetter)
 	cmd.FailOnError(err, "Unable to create WFE")
 
 	wfe.SubscriberAgreementURL = c.WFE.SubscriberAgreementURL

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -434,7 +434,7 @@ func main() {
 		pendingAuthorizationLifetime,
 		rac,
 		sac,
-		accountGetter
+		accountGetter,
 	)
 	cmd.FailOnError(err, "Unable to create WFE")
 

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -407,6 +407,7 @@ func main() {
 	cmd.FailOnError(err, "Unable to create WFE")
 	wfe.RA = rac
 	wfe.SA = sac
+	wfe.AccountGetter = sac
 
 	wfe.SubscriberAgreementURL = c.WFE.SubscriberAgreementURL
 	wfe.AllowOrigins = c.WFE.AllowOrigins

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -434,7 +434,8 @@ func main() {
 		pendingAuthorizationLifetime,
 		rac,
 		sac,
-		accountGetter)
+		accountGetter
+	)
 	cmd.FailOnError(err, "Unable to create WFE")
 
 	wfe.SubscriberAgreementURL = c.WFE.SubscriberAgreementURL

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -403,11 +403,8 @@ func main() {
 		pendingAuthorizationLifetime = time.Duration(c.WFE.PendingAuthorizationLifetimeDays) * (24 * time.Hour)
 	}
 
-	wfe, err := wfe2.NewWebFrontEndImpl(stats, clk, kp, allCertChains, issuerCerts, rns, npm, logger, c.WFE.StaleTimeout.Duration, authorizationLifetime, pendingAuthorizationLifetime)
+	wfe, err := wfe2.NewWebFrontEndImpl(stats, clk, kp, allCertChains, issuerCerts, rns, npm, logger, c.WFE.StaleTimeout.Duration, authorizationLifetime, pendingAuthorizationLifetime, rac, sac)
 	cmd.FailOnError(err, "Unable to create WFE")
-	wfe.RA = rac
-	wfe.SA = sac
-	wfe.AccountGetter = sac
 
 	wfe.SubscriberAgreementURL = c.WFE.SubscriberAgreementURL
 	wfe.AllowOrigins = c.WFE.AllowOrigins

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/certificate-transparency-go v1.0.22-0.20181127102053-c25855a82c75
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/honeycombio/beeline-go v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -25,6 +25,10 @@
       "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
+    "accountCache": {
+      "size": 9000,
+      "ttl": "5s"
+    },
     "getNonceService": {
       "serverAddress": "nonce.boulder:9101",
       "timeout": "15s"

--- a/vendor/github.com/golang/groupcache/LICENSE
+++ b/vendor/github.com/golang/groupcache/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/golang/groupcache/lru/lru.go
+++ b/vendor/github.com/golang/groupcache/lru/lru.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package lru
+
+import "container/list"
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	// MaxEntries is the maximum number of cache entries before
+	// an item is evicted. Zero means no limit.
+	MaxEntries int
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key Key, value interface{})
+
+	ll    *list.List
+	cache map[interface{}]*list.Element
+}
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+type entry struct {
+	key   Key
+	value interface{}
+}
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return &Cache{
+		MaxEntries: maxEntries,
+		ll:         list.New(),
+		cache:      make(map[interface{}]*list.Element),
+	}
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	if c.cache == nil {
+		c.cache = make(map[interface{}]*list.Element)
+		c.ll = list.New()
+	}
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.ll.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
+		c.RemoveOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	if c.cache == nil {
+		return
+	}
+	ele := c.ll.Back()
+	if ele != nil {
+		c.removeElement(ele)
+	}
+}
+
+func (c *Cache) removeElement(e *list.Element) {
+	c.ll.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.cache, kv.key)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}
+
+// Clear purges all stored items from the cache.
+func (c *Cache) Clear() {
+	if c.OnEvicted != nil {
+		for _, e := range c.cache {
+			kv := e.Value.(*entry)
+			c.OnEvicted(kv.key, kv.value)
+		}
+	}
+	c.ll = nil
+	c.cache = nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,6 +29,8 @@ github.com/go-redis/redis/v8/internal/rand
 github.com/go-redis/redis/v8/internal/util
 # github.com/go-sql-driver/mysql v1.5.0
 github.com/go-sql-driver/mysql
+# github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.5.2
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes

--- a/wfe2/cache.go
+++ b/wfe2/cache.go
@@ -26,6 +26,8 @@ type AccountGetter interface {
 // accountGetter. It is safe for concurrent access so long as the underlying
 // accountGetter is.
 type accountCache struct {
+	// Note: This must be a regular mutex, not an RWMutex, because cache.Get()
+	// actually mutates the lru.Cache (by updated the last-used info).
 	sync.Mutex
 	under    AccountGetter
 	ttl      time.Duration

--- a/wfe2/cache.go
+++ b/wfe2/cache.go
@@ -1,0 +1,80 @@
+package wfe2
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/groupcache/lru"
+	"github.com/jmhodges/clock"
+	corepb "github.com/letsencrypt/boulder/core/proto"
+	sapb "github.com/letsencrypt/boulder/sa/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// AccountGetter represents the ability to get an account by ID - either from the SA
+// or from a cache.
+type AccountGetter interface {
+	GetRegistration(ctx context.Context, regID *sapb.RegistrationID, opts ...grpc.CallOption) (*corepb.Registration, error)
+}
+
+// accountCache is an implementation of accountGetter that first tries a local
+// in-memory cache, and if the account is not there, calls out to an underlying
+// accountGetter. It is safe for concurrent access so long as the underlying
+// accountGetter is.
+type accountCache struct {
+	under AccountGetter
+	ttl   time.Duration
+	cache *lru.Cache
+	clk   clock.Clock
+}
+
+func NewAccountCache(under AccountGetter, maxEntries int, ttl time.Duration, clk clock.Clock) *accountCache {
+	return &accountCache{
+		under: under,
+		ttl:   ttl,
+		cache: lru.New(maxEntries),
+		clk:   clk,
+	}
+}
+
+type accountEntry struct {
+	account *corepb.Registration
+	expires time.Time
+}
+
+func (ac *accountCache) GetRegistration(ctx context.Context, regID *sapb.RegistrationID, opts ...grpc.CallOption) (*corepb.Registration, error) {
+	val, ok := ac.cache.Get(regID.Id)
+	if !ok {
+		return ac.queryAndStore(ctx, regID)
+	}
+	entry, ok := val.(accountEntry)
+	if !ok {
+		return nil, fmt.Errorf("shouldn't happen: wrong type %T for cache entry", entry)
+	}
+	if entry.expires.After(ac.clk.Now()) {
+		// Note: this has a slight TOCTOU issue but it's benign. If the entry for this account
+		// was expired off by some other goroutine and then a fresh one added, removing it a second
+		// time will just cause a slightly lower cache rate.
+		ac.cache.Remove(regID.Id)
+		return ac.queryAndStore(ctx, regID)
+	}
+	copied := new(corepb.Registration)
+	proto.Merge(copied, entry.account)
+	return copied, nil
+}
+
+func (ac *accountCache) queryAndStore(ctx context.Context, regID *sapb.RegistrationID) (*corepb.Registration, error) {
+	account, err := ac.under.GetRegistration(ctx, regID)
+	if err != nil {
+		return nil, err
+	}
+	ac.cache.Add(regID.Id, accountEntry{
+		account: account,
+		expires: ac.clk.Now().Add(ac.ttl),
+	})
+	copied := new(corepb.Registration)
+	proto.Merge(copied, account)
+	return copied, nil
+}

--- a/wfe2/cache.go
+++ b/wfe2/cache.go
@@ -21,13 +21,13 @@ type AccountGetter interface {
 	GetRegistration(ctx context.Context, regID *sapb.RegistrationID, opts ...grpc.CallOption) (*corepb.Registration, error)
 }
 
-// accountCache is an implementation of accountGetter that first tries a local
+// accountCache is an implementation of AccountGetter that first tries a local
 // in-memory cache, and if the account is not there, calls out to an underlying
-// accountGetter. It is safe for concurrent access so long as the underlying
-// accountGetter is.
+// AccountGetter. It is safe for concurrent access so long as the underlying
+// AccountGetter is.
 type accountCache struct {
 	// Note: This must be a regular mutex, not an RWMutex, because cache.Get()
-	// actually mutates the lru.Cache (by updated the last-used info).
+	// actually mutates the lru.Cache (by updating the last-used info).
 	sync.Mutex
 	under    AccountGetter
 	ttl      time.Duration

--- a/wfe2/cache.go
+++ b/wfe2/cache.go
@@ -34,7 +34,8 @@ type accountCache struct {
 	requests *prometheus.CounterVec
 }
 
-func NewAccountCache(under AccountGetter,
+func NewAccountCache(
+	under AccountGetter,
 	maxEntries int,
 	ttl time.Duration,
 	clk clock.Clock,
@@ -84,7 +85,7 @@ func (ac *accountCache) GetRegistration(ctx context.Context, regID *sapb.Registr
 		return ac.queryAndStore(ctx, regID)
 	}
 	if entry.account.Id != regID.Id {
-		ac.requests.WithLabelValues("wrongid").Inc()
+		ac.requests.WithLabelValues("wrong id from cache").Inc()
 		return nil, fmt.Errorf("shouldn't happen: wrong account ID. expected %d, got %d", regID.Id, entry.account.Id)
 	}
 	copied := new(corepb.Registration)
@@ -99,7 +100,7 @@ func (ac *accountCache) queryAndStore(ctx context.Context, regID *sapb.Registrat
 		return nil, err
 	}
 	if account.Id != regID.Id {
-		ac.requests.WithLabelValues("wrongid").Inc()
+		ac.requests.WithLabelValues("wrong id from SA").Inc()
 		return nil, fmt.Errorf("shouldn't happen: wrong account ID from backend. expected %d, got %d", regID.Id, account.Id)
 	}
 	// Make sure we have our own copy that no one has a pointer to.

--- a/wfe2/cache.go
+++ b/wfe2/cache.go
@@ -26,7 +26,7 @@ type AccountGetter interface {
 // accountGetter. It is safe for concurrent access so long as the underlying
 // accountGetter is.
 type accountCache struct {
-	sync.RWMutex
+	sync.Mutex
 	under    AccountGetter
 	ttl      time.Duration
 	cache    *lru.Cache
@@ -60,9 +60,9 @@ type accountEntry struct {
 }
 
 func (ac *accountCache) GetRegistration(ctx context.Context, regID *sapb.RegistrationID, opts ...grpc.CallOption) (*corepb.Registration, error) {
-	ac.RLock()
+	ac.Lock()
 	val, ok := ac.cache.Get(regID.Id)
-	ac.RUnlock()
+	ac.Unlock()
 	if !ok {
 		ac.requests.WithLabelValues("miss").Inc()
 		return ac.queryAndStore(ctx, regID)

--- a/wfe2/cache_test.go
+++ b/wfe2/cache_test.go
@@ -102,8 +102,6 @@ func TestCacheExpires(t *testing.T) {
 	_, err = cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
 	test.AssertNotError(t, err, "getting registration")
 	test.AssertEquals(t, len(backend.requests), 2)
-
-	test.AssertEquals(t, cache.cache.Len(), 0)
 }
 
 type wrongIDBackend struct{}

--- a/wfe2/cache_test.go
+++ b/wfe2/cache_test.go
@@ -18,7 +18,8 @@ type recordingBackend struct {
 	requests []int64
 }
 
-func (rb *recordingBackend) GetRegistration(ctx context.Context,
+func (rb *recordingBackend) GetRegistration(
+	ctx context.Context,
 	regID *sapb.RegistrationID,
 	opts ...grpc.CallOption,
 ) (*corepb.Registration, error) {
@@ -106,7 +107,8 @@ func TestCacheExpires(t *testing.T) {
 
 type wrongIDBackend struct{}
 
-func (wib wrongIDBackend) GetRegistration(ctx context.Context,
+func (wib wrongIDBackend) GetRegistration(
+	ctx context.Context,
 	regID *sapb.RegistrationID,
 	opts ...grpc.CallOption,
 ) (*corepb.Registration, error) {

--- a/wfe2/cache_test.go
+++ b/wfe2/cache_test.go
@@ -1,0 +1,145 @@
+package wfe2
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+	corepb "github.com/letsencrypt/boulder/core/proto"
+	"github.com/letsencrypt/boulder/metrics"
+	sapb "github.com/letsencrypt/boulder/sa/proto"
+	"github.com/letsencrypt/boulder/test"
+	"google.golang.org/grpc"
+)
+
+type recordingBackend struct {
+	requests []int64
+}
+
+func (rb *recordingBackend) GetRegistration(ctx context.Context,
+	regID *sapb.RegistrationID,
+	opts ...grpc.CallOption,
+) (*corepb.Registration, error) {
+	rb.requests = append(rb.requests, regID.Id)
+	return &corepb.Registration{
+		Id:      regID.Id,
+		Contact: []string{"example@example.com"},
+	}, nil
+}
+
+func TestCacheAddRetrieve(t *testing.T) {
+	ctx := context.Background()
+	backend := &recordingBackend{}
+
+	cache := NewAccountCache(backend, 10, time.Second, clock.NewFake(), metrics.NoopRegisterer)
+
+	result, err := cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, result.Id, int64(1234))
+	test.AssertEquals(t, len(backend.requests), 1)
+
+	// Request it again. This should hit the cache so our backend should not see additional requests.
+	result, err = cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, result.Id, int64(1234))
+	test.AssertEquals(t, len(backend.requests), 1)
+}
+
+// Test that the cache copies values before giving them out, so code that receives a cached
+// value can't modify the cache's contents.
+func TestCacheCopy(t *testing.T) {
+	ctx := context.Background()
+	backend := &recordingBackend{}
+
+	cache := NewAccountCache(backend, 10, time.Second, clock.NewFake(), metrics.NoopRegisterer)
+
+	_, err := cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, len(backend.requests), 1)
+
+	test.AssertEquals(t, cache.cache.Len(), 1)
+
+	// Request it again. This should hit the cache.
+	result, err := cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, len(backend.requests), 1)
+
+	// Modify a pointer value inside the result
+	result.Contact[0] = "different@example.com"
+
+	result, err = cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, len(backend.requests), 1)
+
+	test.AssertDeepEquals(t, result.Contact, []string{"example@example.com"})
+}
+
+// Test that the cache expires values.
+func TestCacheExpires(t *testing.T) {
+	ctx := context.Background()
+	backend := &recordingBackend{}
+
+	clk := clock.NewFake()
+	cache := NewAccountCache(backend, 10, time.Second, clk, metrics.NoopRegisterer)
+
+	_, err := cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, len(backend.requests), 1)
+
+	// Request it again. This should hit the cache.
+	_, err = cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, len(backend.requests), 1)
+
+	test.AssertEquals(t, cache.cache.Len(), 1)
+
+	// "Sleep" 10 seconds to expire the entry
+	clk.Sleep(10 * time.Second)
+
+	// This should not hit the cache
+	_, err = cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertNotError(t, err, "getting registration")
+	test.AssertEquals(t, len(backend.requests), 2)
+
+	test.AssertEquals(t, cache.cache.Len(), 0)
+}
+
+type wrongIDBackend struct{}
+
+func (wib wrongIDBackend) GetRegistration(ctx context.Context,
+	regID *sapb.RegistrationID,
+	opts ...grpc.CallOption,
+) (*corepb.Registration, error) {
+	return &corepb.Registration{
+		Id:      regID.Id + 1,
+		Contact: []string{"example@example.com"},
+	}, nil
+}
+
+func TestWrongId(t *testing.T) {
+	ctx := context.Background()
+	cache := NewAccountCache(wrongIDBackend{}, 10, time.Second, clock.NewFake(), metrics.NoopRegisterer)
+
+	_, err := cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertError(t, err, "expected error when backend returns wrong ID")
+}
+
+type errorBackend struct{}
+
+func (eb errorBackend) GetRegistration(ctx context.Context,
+	regID *sapb.RegistrationID,
+	opts ...grpc.CallOption,
+) (*corepb.Registration, error) {
+	return nil, errors.New("some error")
+}
+
+func TestErrorPassthrough(t *testing.T) {
+	ctx := context.Background()
+	cache := NewAccountCache(errorBackend{}, 10, time.Second, clock.NewFake(), metrics.NoopRegisterer)
+
+	_, err := cache.GetRegistration(ctx, &sapb.RegistrationID{Id: 1234})
+	test.AssertError(t, err, "expected error when backend errors")
+	test.AssertEquals(t, err.Error(), "some error")
+}

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -458,7 +458,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 	}
 
 	// Try to find the account for this account ID
-	account, err := wfe.SA.GetRegistration(ctx, &sapb.RegistrationID{Id: accountID})
+	account, err := wfe.AccountGetter.GetRegistration(ctx, &sapb.RegistrationID{Id: accountID})
 	if err != nil {
 		// If the account isn't found, return a suitable problem
 		if errors.Is(err, berrors.NotFound) {

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -458,7 +458,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 	}
 
 	// Try to find the account for this account ID
-	account, err := wfe.AccountGetter.GetRegistration(ctx, &sapb.RegistrationID{Id: accountID})
+	account, err := wfe.accountGetter.GetRegistration(ctx, &sapb.RegistrationID{Id: accountID})
 	if err != nil {
 		// If the account isn't found, return a suitable problem
 		if errors.Is(err, berrors.NotFound) {

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1014,7 +1014,7 @@ func TestLookupJWK(t *testing.T) {
 	nonNumericKeyIDJWS, nonNumericKeyIDJWSBody := signRequestSpecifyKeyID(t, wfe.LegacyKeyIDPrefix+"abcd", wfe.nonceService)
 
 	validJWS, validKey, validJWSBody := signRequestKeyID(t, 1, nil, "", "", wfe.nonceService)
-	validAccountPB, _ := wfe.SA.GetRegistration(context.Background(), &sapb.RegistrationID{Id: 1})
+	validAccountPB, _ := wfe.sa.GetRegistration(context.Background(), &sapb.RegistrationID{Id: 1})
 	validAccount, _ := bgrpc.PbToRegistration(validAccountPB)
 
 	// good key, log event requester is set
@@ -1269,7 +1269,7 @@ func TestValidPOSTForAccount(t *testing.T) {
 	wfe, _ := setupWFE(t)
 
 	validJWS, _, validJWSBody := signRequestKeyID(t, 1, nil, "http://localhost/test", `{"test":"passed"}`, wfe.nonceService)
-	validAccountPB, _ := wfe.SA.GetRegistration(context.Background(), &sapb.RegistrationID{Id: 1})
+	validAccountPB, _ := wfe.sa.GetRegistration(context.Background(), &sapb.RegistrationID{Id: 1})
 	validAccount, _ := bgrpc.PbToRegistration(validAccountPB)
 
 	// ID 102 is mocked to return missing
@@ -1430,7 +1430,8 @@ func (sa mockSADifferentStoredKey) GetRegistration(_ context.Context, _ *sapb.Re
 
 func TestValidPOSTForAccountSwappedKey(t *testing.T) {
 	wfe, fc := setupWFE(t)
-	wfe.SA = &mockSADifferentStoredKey{mocks.NewStorageAuthority(fc)}
+	wfe.sa = &mockSADifferentStoredKey{mocks.NewStorageAuthority(fc)}
+	wfe.AccountGetter = wfe.sa
 	event := newRequestEvent()
 
 	payload := `{"resource":"ima-payload"}`

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1431,7 +1431,7 @@ func (sa mockSADifferentStoredKey) GetRegistration(_ context.Context, _ *sapb.Re
 func TestValidPOSTForAccountSwappedKey(t *testing.T) {
 	wfe, fc := setupWFE(t)
 	wfe.sa = &mockSADifferentStoredKey{mocks.NewStorageAuthority(fc)}
-	wfe.AccountGetter = wfe.sa
+	wfe.accountGetter = wfe.sa
 	event := newRequestEvent()
 
 	payload := `{"resource":"ima-payload"}`

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -82,11 +82,12 @@ var errIncompleteGRPCResponse = errors.New("incomplete gRPC response message")
 // plus a few other data items used in ACME.  Its methods are primarily handlers
 // for HTTPS requests for the various ACME functions.
 type WebFrontEndImpl struct {
-	RA    rapb.RegistrationAuthorityClient
-	SA    sapb.StorageAuthorityGetterClient
-	log   blog.Logger
-	clk   clock.Clock
-	stats wfe2Stats
+	RA            rapb.RegistrationAuthorityClient
+	SA            sapb.StorageAuthorityGetterClient
+	AccountGetter accountGetter
+	log           blog.Logger
+	clk           clock.Clock
+	stats         wfe2Stats
 
 	// certificateChains maps IssuerNameIDs to slice of []byte containing a leading
 	// newline and one or more PEM encoded certificates separated by a newline,

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -82,9 +82,9 @@ var errIncompleteGRPCResponse = errors.New("incomplete gRPC response message")
 // plus a few other data items used in ACME.  Its methods are primarily handlers
 // for HTTPS requests for the various ACME functions.
 type WebFrontEndImpl struct {
-	RA            rapb.RegistrationAuthorityClient
-	SA            sapb.StorageAuthorityGetterClient
-	AccountGetter accountGetter
+	ra            rapb.RegistrationAuthorityClient
+	sa            sapb.StorageAuthorityGetterClient
+	AccountGetter AccountGetter
 	log           blog.Logger
 	clk           clock.Clock
 	stats         wfe2Stats
@@ -158,6 +158,8 @@ func NewWebFrontEndImpl(
 	staleTimeout time.Duration,
 	authorizationLifetime time.Duration,
 	pendingAuthorizationLifetime time.Duration,
+	rac rapb.RegistrationAuthorityClient,
+	sac sapb.StorageAuthorityClient,
 ) (WebFrontEndImpl, error) {
 	if issuerCertificates == nil || len(issuerCertificates) == 0 {
 		return WebFrontEndImpl{}, errors.New("must provide at least one issuer certificate")
@@ -179,6 +181,9 @@ func NewWebFrontEndImpl(
 		staleTimeout:                 staleTimeout,
 		authorizationLifetime:        authorizationLifetime,
 		pendingAuthorizationLifetime: pendingAuthorizationLifetime,
+		ra:                           rac,
+		sa:                           sac,
+		AccountGetter:                sac,
 	}
 
 	if wfe.remoteNonceService == nil {
@@ -643,7 +648,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 			web.ProblemDetailsForError(err, "Error creating new account"), err)
 		return
 	}
-	existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: keyBytes})
+	existingAcct, err := wfe.sa.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: keyBytes})
 	if err == nil {
 		returnExistingAcct(existingAcct)
 		return
@@ -701,10 +706,10 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	}
 
 	// Send the registration to the RA via grpc
-	acctPB, err := wfe.RA.NewRegistration(ctx, &reg)
+	acctPB, err := wfe.ra.NewRegistration(ctx, &reg)
 	if err != nil {
 		if errors.Is(err, berrors.Duplicate) {
-			existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: keyBytes})
+			existingAcct, err := wfe.sa.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: keyBytes})
 			if err == nil {
 				returnExistingAcct(existingAcct)
 				return
@@ -761,7 +766,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 }
 
 func (wfe *WebFrontEndImpl) acctHoldsAuthorizations(ctx context.Context, acctID int64, names []string) (bool, error) {
-	authzMapPB, err := wfe.SA.GetValidAuthorizations2(ctx, &sapb.GetValidAuthorizationsRequest{
+	authzMapPB, err := wfe.sa.GetValidAuthorizations2(ctx, &sapb.GetValidAuthorizationsRequest{
 		RegistrationID: acctID,
 		Domains:        names,
 		Now:            wfe.clk.Now().UnixNano(),
@@ -845,7 +850,7 @@ func (wfe *WebFrontEndImpl) processRevocation(
 
 	// Check the certificate status for the provided certificate to see if it is
 	// already revoked
-	certStatus, err := wfe.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
+	certStatus, err := wfe.sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
 	if err != nil || certStatus.Status == "" {
 		return probs.ServerInternal("Failed to get certificate status")
 	}
@@ -881,7 +886,7 @@ func (wfe *WebFrontEndImpl) processRevocation(
 
 	// Revoke the certificate. AcctID may be 0 if there is no associated account
 	// (e.g. it was a self-authenticated JWS using the certificate public key)
-	_, err = wfe.RA.RevokeCertificateWithReg(ctx, &rapb.RevokeCertificateWithRegRequest{
+	_, err = wfe.ra.RevokeCertificateWithReg(ctx, &rapb.RevokeCertificateWithRegRequest{
 		Cert:  parsedCertificate.Raw,
 		Code:  int64(reason),
 		RegID: acctID,
@@ -892,7 +897,7 @@ func (wfe *WebFrontEndImpl) processRevocation(
 			// performing the revocation, a parallel request happened and revoked the
 			// cert. In this case, just retrieve the certificate status again and
 			// return the alreadyRevoked status.
-			certStatus, err = wfe.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
+			certStatus, err = wfe.sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
 			if err != nil || certStatus.Status == "" {
 				return probs.ServerInternal("Failed to get certificate status")
 			}
@@ -938,11 +943,11 @@ func (wfe *WebFrontEndImpl) revokeCertByKeyID(
 
 		// Try to find a stored final certificate for the serial number
 		serial := core.SerialToString(parsedCertificate.SerialNumber)
-		cert, err := wfe.SA.GetCertificate(ctx, &sapb.Serial{Serial: serial})
+		cert, err := wfe.sa.GetCertificate(ctx, &sapb.Serial{Serial: serial})
 		if errors.Is(err, berrors.NotFound) {
 			// If there was an error and it was a not found error, then maybe they're
 			// trying to revoke via the precertificate. Try to find that instead.
-			cert, err = wfe.SA.GetPrecertificate(ctx, &sapb.Serial{Serial: serial})
+			cert, err = wfe.sa.GetPrecertificate(ctx, &sapb.Serial{Serial: serial})
 			if errors.Is(err, berrors.NotFound) {
 				// If looking up a precert also returned a not found error then return
 				// a not found problem.
@@ -1113,7 +1118,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 		return
 	}
 	challengeID := slug[1]
-	authzPB, err := wfe.SA.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: authorizationID})
+	authzPB, err := wfe.sa.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: authorizationID})
 	if err != nil {
 		if errors.Is(err, berrors.NotFound) {
 			notFound()
@@ -1332,7 +1337,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			return
 		}
 
-		authzPB, err = wfe.RA.PerformValidation(ctx, &rapb.PerformValidationRequest{
+		authzPB, err = wfe.ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
 			ChallengeIndex: int64(challengeIndex),
 		})
@@ -1474,7 +1479,7 @@ func (wfe *WebFrontEndImpl) updateAccount(
 		if updatePb.Status != string(core.StatusDeactivated) {
 			return nil, probs.Malformed("Invalid value provided for status field")
 		}
-		_, err := wfe.RA.DeactivateRegistration(ctx, basePb)
+		_, err := wfe.ra.DeactivateRegistration(ctx, basePb)
 		if err != nil {
 			return nil, web.ProblemDetailsForError(err, "Unable to deactivate account")
 		}
@@ -1489,7 +1494,7 @@ func (wfe *WebFrontEndImpl) updateAccount(
 	// JSON to send via RPC to the RA.
 	updatePb.Key = basePb.Key
 
-	updatedAcct, err := wfe.RA.UpdateRegistration(ctx, &rapb.UpdateRegistrationRequest{Base: basePb, Update: updatePb})
+	updatedAcct, err := wfe.ra.UpdateRegistration(ctx, &rapb.UpdateRegistrationRequest{Base: basePb, Update: updatePb})
 	if err != nil {
 		return nil, web.ProblemDetailsForError(err, "Unable to update account")
 	}
@@ -1526,7 +1531,7 @@ func (wfe *WebFrontEndImpl) deactivateAuthorization(
 		wfe.sendError(response, logEvent, probs.Malformed("Invalid status value"), err)
 		return false
 	}
-	_, err = wfe.RA.DeactivateAuthorization(ctx, authzPB)
+	_, err = wfe.ra.DeactivateAuthorization(ctx, authzPB)
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Error deactivating authorization"), err)
 		return false
@@ -1572,7 +1577,7 @@ func (wfe *WebFrontEndImpl) Authorization(
 		return
 	}
 
-	authzPB, err := wfe.SA.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: authzID})
+	authzPB, err := wfe.sa.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: authzID})
 	if errors.Is(err, berrors.NotFound) {
 		wfe.sendError(response, logEvent, probs.NotFound("No such authorization"), nil)
 		return
@@ -1698,7 +1703,7 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 	logEvent.Extra["RequestedSerial"] = serial
 	beeline.AddFieldToTrace(ctx, "request.serial", serial)
 
-	cert, err := wfe.SA.GetCertificate(ctx, &sapb.Serial{Serial: serial})
+	cert, err := wfe.sa.GetCertificate(ctx, &sapb.Serial{Serial: serial})
 	if err != nil {
 		ierr := fmt.Errorf("unable to get certificate by serial id %#v: %s", serial, err)
 		if strings.HasPrefix(err.Error(), "gorp: multiple rows returned") {
@@ -1949,7 +1954,7 @@ func (wfe *WebFrontEndImpl) KeyRollover(
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshaling new key"), err)
 	}
 	// Check that the new key isn't already being used for an existing account
-	if existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: newKeyBytes}); err == nil {
+	if existingAcct, err := wfe.sa.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: newKeyBytes}); err == nil {
 		response.Header().Set("Location",
 			web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, existingAcct.Id)))
 		wfe.sendError(response, logEvent,
@@ -1970,14 +1975,14 @@ func (wfe *WebFrontEndImpl) KeyRollover(
 	updatePb := &corepb.Registration{Key: newKeyBytes}
 
 	// Update the account key to the new key
-	updatedAcctPb, err := wfe.RA.UpdateRegistration(ctx, &rapb.UpdateRegistrationRequest{Base: regPb, Update: updatePb})
+	updatedAcctPb, err := wfe.ra.UpdateRegistration(ctx, &rapb.UpdateRegistrationRequest{Base: regPb, Update: updatePb})
 	if err != nil {
 		if errors.Is(err, berrors.Duplicate) {
 			// It is possible that between checking for the existing key, and preforming the update
 			// a parallel update or new account request happened and claimed the key. In this case
 			// just retrieve the account again, and return an error as we would above with a Location
 			// header
-			existingAcct, err := wfe.SA.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: newKeyBytes})
+			existingAcct, err := wfe.sa.GetRegistrationByKey(ctx, &sapb.JSONWebKey{Jwk: newKeyBytes})
 			if err != nil {
 				wfe.sendError(response, logEvent, probs.ServerInternal("Failed to lookup existing keys"), err)
 				return
@@ -2125,7 +2130,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		return
 	}
 
-	order, err := wfe.RA.NewOrder(ctx, &rapb.NewOrderRequest{
+	order, err := wfe.ra.NewOrder(ctx, &rapb.NewOrderRequest{
 		RegistrationID: acct.ID,
 		Names:          names,
 	})
@@ -2184,7 +2189,7 @@ func (wfe *WebFrontEndImpl) GetOrder(ctx context.Context, logEvent *web.RequestE
 		return
 	}
 
-	order, err := wfe.SA.GetOrder(ctx, &sapb.OrderRequest{Id: orderID})
+	order, err := wfe.sa.GetOrder(ctx, &sapb.OrderRequest{Id: orderID})
 	if err != nil {
 		if errors.Is(err, berrors.NotFound) {
 			wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("No order for ID %d", orderID)), err)
@@ -2258,7 +2263,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 		return
 	}
 
-	order, err := wfe.SA.GetOrder(ctx, &sapb.OrderRequest{Id: orderID})
+	order, err := wfe.sa.GetOrder(ctx, &sapb.OrderRequest{Id: orderID})
 	if err != nil {
 		if errors.Is(err, berrors.NotFound) {
 			wfe.sendError(response, logEvent, probs.NotFound(fmt.Sprintf("No order for ID %d", orderID)), err)
@@ -2334,7 +2339,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	// Inc CSR signature algorithm counter
 	wfe.stats.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()
 
-	updatedOrder, err := wfe.RA.FinalizeOrder(ctx, &rapb.FinalizeOrderRequest{
+	updatedOrder, err := wfe.ra.FinalizeOrder(ctx, &rapb.FinalizeOrderRequest{
 		Csr:   rawCSR.CSR,
 		Order: order,
 	})
@@ -2386,7 +2391,7 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 
 	// We use GetCertificate, not GetPrecertificate, because we don't intend to
 	// serve ARI for certs that never made it past the precert stage.
-	cert, err := wfe.SA.GetCertificate(ctx, &sapb.Serial{Serial: serial})
+	cert, err := wfe.sa.GetCertificate(ctx, &sapb.Serial{Serial: serial})
 	if err != nil {
 		if errors.Is(err, berrors.NotFound) {
 			wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -84,7 +84,7 @@ var errIncompleteGRPCResponse = errors.New("incomplete gRPC response message")
 type WebFrontEndImpl struct {
 	ra            rapb.RegistrationAuthorityClient
 	sa            sapb.StorageAuthorityGetterClient
-	AccountGetter AccountGetter
+	accountGetter AccountGetter
 	log           blog.Logger
 	clk           clock.Clock
 	stats         wfe2Stats
@@ -184,7 +184,7 @@ func NewWebFrontEndImpl(
 		pendingAuthorizationLifetime: pendingAuthorizationLifetime,
 		ra:                           rac,
 		sa:                           sac,
-		AccountGetter:                accountGetter,
+		accountGetter:                accountGetter,
 	}
 
 	if wfe.remoteNonceService == nil {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -160,6 +160,7 @@ func NewWebFrontEndImpl(
 	pendingAuthorizationLifetime time.Duration,
 	rac rapb.RegistrationAuthorityClient,
 	sac sapb.StorageAuthorityClient,
+	accountGetter AccountGetter,
 ) (WebFrontEndImpl, error) {
 	if issuerCertificates == nil || len(issuerCertificates) == 0 {
 		return WebFrontEndImpl{}, errors.New("must provide at least one issuer certificate")
@@ -183,7 +184,7 @@ func NewWebFrontEndImpl(
 		pendingAuthorizationLifetime: pendingAuthorizationLifetime,
 		ra:                           rac,
 		sa:                           sac,
-		AccountGetter:                sac,
+		AccountGetter:                accountGetter,
 	}
 
 	if wfe.remoteNonceService == nil {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -368,6 +368,8 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock) {
 		issuerCertificates[id] = certs[0]
 	}
 
+	mockSA := mocks.NewStorageAuthority(fc)
+
 	wfe, err := NewWebFrontEndImpl(
 		stats,
 		fc,
@@ -381,7 +383,8 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock) {
 		30*24*time.Hour,
 		7*24*time.Hour,
 		&MockRegistrationAuthority{},
-		mocks.NewStorageAuthority(fc))
+		mockSA,
+		mockSA)
 	test.AssertNotError(t, err, "Unable to create WFE")
 
 	wfe.SubscriberAgreementURL = agreementURL

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -368,13 +368,23 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock) {
 		issuerCertificates[id] = certs[0]
 	}
 
-	wfe, err := NewWebFrontEndImpl(stats, fc, testKeyPolicy, certChains, issuerCertificates, nil, nil, blog.NewMock(), 10*time.Second, 30*24*time.Hour, 7*24*time.Hour)
+	wfe, err := NewWebFrontEndImpl(
+		stats,
+		fc,
+		testKeyPolicy,
+		certChains,
+		issuerCertificates,
+		nil,
+		nil,
+		blog.NewMock(),
+		10*time.Second,
+		30*24*time.Hour,
+		7*24*time.Hour,
+		&MockRegistrationAuthority{},
+		mocks.NewStorageAuthority(fc))
 	test.AssertNotError(t, err, "Unable to create WFE")
 
 	wfe.SubscriberAgreementURL = agreementURL
-
-	wfe.RA = &MockRegistrationAuthority{}
-	wfe.SA = mocks.NewStorageAuthority(fc)
 
 	return wfe, fc
 }
@@ -1198,7 +1208,7 @@ func (ra *MockRAPerformValidationError) PerformValidation(context.Context, *rapb
 // the RA.
 func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.RA = &MockRAPerformValidationError{}
+	wfe.ra = &MockRAPerformValidationError{}
 	responseWriter := httptest.NewRecorder()
 
 	signedURL := "http://localhost/1/-ZfxEw"
@@ -1221,7 +1231,7 @@ func TestUpdateChallengeFinalizedAuthz(t *testing.T) {
 func TestUpdateChallengeRAError(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	// Mock the RA to always fail PerformValidation
-	wfe.RA = &MockRAPerformValidationError{}
+	wfe.ra = &MockRAPerformValidationError{}
 
 	// Update a pending challenge
 	signedURL := "http://localhost/2/-ZfxEw"
@@ -1620,7 +1630,7 @@ func TestAuthorizationChallengeNamespace(t *testing.T) {
 	wfe, clk := setupWFE(t)
 
 	mockSA := &mocks.SAWithFailedChallenges{Clk: clk}
-	wfe.SA = mockSA
+	wfe.sa = mockSA
 
 	// For "oldNS" the SA mock returns an authorization with a failed challenge
 	// that has an error with the type already prefixed by the v1 error NS
@@ -1801,7 +1811,7 @@ func (sa *mockSAWithCert) GetCertificateStatus(_ context.Context, req *sapb.Seri
 
 func TestGetCertificate(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 	mux := wfe.Handler(metrics.NoopRegisterer)
 
 	makeGet := func(path string) *http.Request {
@@ -2055,7 +2065,7 @@ func (sa *mockSAWithNewCert) GetCertificate(_ context.Context, req *sapb.Serial,
 // GET api.
 func TestGetCertificateNew(t *testing.T) {
 	wfe, fc := setupWFE(t)
-	wfe.SA = &mockSAWithNewCert{wfe.SA, fc}
+	wfe.sa = &mockSAWithNewCert{wfe.sa, fc}
 	mux := wfe.Handler(metrics.NoopRegisterer)
 
 	makeGet := func(path string) *http.Request {
@@ -2150,7 +2160,7 @@ func TestGetCertificateNew(t *testing.T) {
 // body from being sent like the net/http Server's actually do.
 func TestGetCertificateHEADHasCorrectBodyLength(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	certPemBytes, _ := ioutil.ReadFile("../test/hierarchy/ee-r3.cert.pem")
 	cert, err := core.LoadCert("../test/hierarchy/ee-r3.cert.pem")
@@ -2198,7 +2208,7 @@ func TestGetCertificateServerError(t *testing.T) {
 	// TODO: add tests for failure to parse the retrieved cert, a cert whose
 	// IssuerNameID is unknown, and a cert whose signature can't be verified.
 	wfe, _ := setupWFE(t)
-	wfe.SA = &mockSAWithError{wfe.SA}
+	wfe.sa = &mockSAWithError{wfe.sa}
 	mux := wfe.Handler(metrics.NoopRegisterer)
 
 	cert, err := core.LoadCert("../test/hierarchy/ee-r3.cert.pem")
@@ -2919,7 +2929,7 @@ func makeRevokeRequestJSONForCert(der []byte, reason *revocation.Reason) ([]byte
 // key.
 func TestRevokeCertificateValid(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	keyPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-r3.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
@@ -2941,7 +2951,7 @@ func TestRevokeCertificateValid(t *testing.T) {
 // if it was signed by the private key.
 func TestRevokeCertificateKeyCompromiseValid(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	mockLog := wfe.log.(*blog.Mock)
 	mockLog.Clear()
@@ -2968,7 +2978,7 @@ func TestRevokeCertificateKeyCompromiseValid(t *testing.T) {
 
 func TestRevokeCertificateKeyCompromiseInvalid(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	revocationReason := revocation.Reason(ocsp.KeyCompromise)
 	revokeRequestJSON, err := makeRevokeRequestJSON(&revocationReason)
@@ -2991,7 +3001,7 @@ func TestRevokeCertificateKeyCompromiseInvalid(t *testing.T) {
 // wasn't issued by any issuer the Boulder is aware of.
 func TestRevokeCertificateNotIssued(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	// Make a self-signed junk certificate
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -3027,8 +3037,8 @@ func TestRevokeCertificateNotIssued(t *testing.T) {
 
 func TestRevokeCertificateReasons(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
-	ra := wfe.RA.(*MockRegistrationAuthority)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	ra := wfe.ra.(*MockRegistrationAuthority)
 
 	keyPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-r3.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
@@ -3099,7 +3109,7 @@ func TestRevokeCertificateReasons(t *testing.T) {
 // that issued the cert.
 func TestRevokeCertificateIssuingAccount(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	mockLog := wfe.log.(*blog.Mock)
 	mockLog.Clear()
@@ -3142,7 +3152,7 @@ func (sa mockSAWithValidAuthz) GetValidAuthorizations2(_ context.Context, _ *sap
 // that has authorizations for names in cert
 func TestRevokeCertificateWithAuthorizations(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = mockSAWithValidAuthz{newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)}
+	wfe.sa = mockSAWithValidAuthz{newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)}
 
 	mockLog := wfe.log.(*blog.Mock)
 	mockLog.Clear()
@@ -3169,7 +3179,7 @@ func TestRevokeCertificateWithAuthorizations(t *testing.T) {
 // A revocation request signed by an unauthorized key.
 func TestRevokeCertificateWrongKey(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	test2JWK := loadKey(t, []byte(test2KeyPrivatePEM))
 
@@ -3188,7 +3198,7 @@ func TestRevokeCertificateWrongKey(t *testing.T) {
 
 func TestRevokeCertificateExpired(t *testing.T) {
 	wfe, fc := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	keyPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-r3.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
@@ -3215,7 +3225,7 @@ func TestRevokeCertificateExpired(t *testing.T) {
 // Valid revocation request for already-revoked cert
 func TestRevokeCertificateAlreadyRevoked(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusRevoked)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusRevoked)
 
 	responseWriter := httptest.NewRecorder()
 
@@ -3247,7 +3257,7 @@ func (sa *mockSAGetRegByKeyFails) GetRegistrationByKey(_ context.Context, req *s
 // return internal server errors.
 func TestNewAccountWhenGetRegByKeyFails(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = &mockSAGetRegByKeyFails{wfe.SA}
+	wfe.sa = &mockSAGetRegByKeyFails{wfe.sa}
 	key := loadKey(t, []byte(testE2KeyPrivatePEM))
 	_, ok := key.(*ecdsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load ECDSA key")
@@ -3276,7 +3286,7 @@ func (sa *mockSAGetRegByKeyNotFound) GetRegistrationByKey(_ context.Context, req
 
 func TestNewAccountWhenGetRegByKeyNotFound(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = &mockSAGetRegByKeyNotFound{wfe.SA}
+	wfe.sa = &mockSAGetRegByKeyNotFound{wfe.sa}
 	key := loadKey(t, []byte(testE2KeyPrivatePEM))
 	_, ok := key.(*ecdsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load ECDSA key")
@@ -3362,7 +3372,7 @@ func TestFinalizeSCTError(t *testing.T) {
 
 	// Set up an RA mock that always returns a berrors.MissingSCTsError from
 	// `FinalizeOrder`
-	wfe.RA = &noSCTMockRA{}
+	wfe.ra = &noSCTMockRA{}
 
 	// Create a response writer to capture the WFE response
 	responseWriter := httptest.NewRecorder()
@@ -3604,7 +3614,7 @@ func TestIndexGet404(t *testing.T) {
 // enough that we're no longer worried about stale info being cached.
 func TestGetAPIAndMandatoryPOSTAsGET(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	makeGet := func(path, endpoint string) (*http.Request, *web.RequestEvent) {
 		return &http.Request{URL: &url.URL{Path: path}, Method: "GET"},
@@ -3626,7 +3636,7 @@ func TestGetAPIAndMandatoryPOSTAsGET(t *testing.T) {
 // requests for certs that don't exist result in errors.
 func TestARI(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.SA = newMockSAWithCert(t, wfe.SA, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
 	makeGet := func(path, endpoint string) (*http.Request, *web.RequestEvent) {
 		return &http.Request{URL: &url.URL{Path: path}, Method: "GET"},


### PR DESCRIPTION
Followup from #5839.

I chose groupcache/lru as our LRU cache implementation because it's part of the golang org, written by one of the Go authors, and very simple and easy to read.

This adds an `AccountGetter` interface that is implemented by both the AccountCache and the SA. If the WFE config includes an AccountCache field, it will wrap the SA in an AccountCache with the configured max size and expiration time.

We set an expiration time on account cache entries because we want a bounded amount of time that they may be stale by. This will be used in conjunction with a delay on account-updating pathways to ensure we don't allow authentication with a deactivated account or changed key.

The account cache stores corepb.Registration objects because protobufs have an established way to do a deep copy. Deep copies are important so the cache can maintain its own internal state and ensure nothing external is modifying it.

As part of this process I changed construction of the WFE. Previously, "SA" and "RA" were public fields that were mutated after construction. Now they are parameters to the constructor, along with the new "accountGetter" parameter.

The cache includes stats for requests categorized by hits and misses.