### PR TITLE
test: tag and upload script

### DIFF
--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -10,18 +10,18 @@ GO_VERSIONS=( "1.17" "1.17.5" )
 echo "Please login to allow push to DockerHub"
 docker login
 
+# create a docker buildx node for cross-compilation.
+docker buildx create --use --name=cross
+
+# on EXIT, delete the docker buildx node if it exists.
+trap "if [ $(docker buildx ls | grep 'cross' | wc -l) != 0 ]; then docker buildx rm cross; fi" EXIT
+
 # Build and push a tagged image for each GO_VERSION.
 for GO_VERSION in "${GO_VERSIONS[@]}"
 do
   TAG_NAME="${DOCKER_REPO}:go${GO_VERSION}_${DATESTAMP}"
   echo "Building boulder-tools image ${TAG_NAME}"
-  
-  # create a docker buildx node for cross-compilation.
-  docker buildx create --use --name=cross
 
-  # on EXIT, delete the docker buildx node.
-  trap "docker buildx rm cross" EXIT
-  
   # build, tag, and push the image.
   docker buildx build --build-arg "GO_VERSION=${GO_VERSION}" \
     --push --tag "${TAG_NAME}" \


### PR DESCRIPTION
When looping over multiple Go versions this script currently exits in error.

- Only create the buildx cross-compiling node once
- Only delete the buildx cross-compiling node once
- `trap` should be set outside of the `GO_VERSION` loop