### PR TITLE
Embed goodkey.Config by value not reference

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -218,7 +218,7 @@ func main() {
 	if c.CA.GoodKey.BlockedKeyFile == "" && c.CA.BlockedKeyFile != "" {
 		c.CA.GoodKey.BlockedKeyFile = c.CA.BlockedKeyFile
 	}
-	kp, err := goodkey.NewKeyPolicy(c.CA.GoodKey, sa.KeyBlocked)
+	kp, err := goodkey.NewKeyPolicy(&c.CA.GoodKey, sa.KeyBlocked)
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	var orphanQueue *goque.Queue

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -60,7 +60,7 @@ type config struct {
 		LifespanOCSP cmd.ConfigDuration
 
 		// GoodKey is an embedded config stanza for the goodkey library.
-		GoodKey *goodkey.Config
+		GoodKey goodkey.Config
 
 		// WeakKeyFile is DEPRECATED. Populate GoodKey.WeakKeyFile instead.
 		// TODO(#5851): Remove this.
@@ -212,9 +212,6 @@ func main() {
 	sa := sapb.NewStorageAuthorityClient(conn)
 
 	// TODO(#5851): Remove these fallbacks when the old config keys are gone.
-	if c.CA.GoodKey == nil {
-		c.CA.GoodKey = &goodkey.Config{}
-	}
 	if c.CA.GoodKey.WeakKeyFile == "" && c.CA.WeakKeyFile != "" {
 		c.CA.GoodKey.WeakKeyFile = c.CA.WeakKeyFile
 	}

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -230,7 +230,7 @@ func main() {
 	if c.RA.GoodKey.BlockedKeyFile == "" && c.RA.BlockedKeyFile != "" {
 		c.RA.GoodKey.BlockedKeyFile = c.RA.BlockedKeyFile
 	}
-	kp, err := goodkey.NewKeyPolicy(c.RA.GoodKey, sac.KeyBlocked)
+	kp, err := goodkey.NewKeyPolicy(&c.RA.GoodKey, sac.KeyBlocked)
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	if c.RA.MaxNames == 0 {

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -63,7 +63,7 @@ type config struct {
 		PendingAuthorizationLifetimeDays int
 
 		// GoodKey is an embedded config stanza for the goodkey library.
-		GoodKey *goodkey.Config
+		GoodKey goodkey.Config
 
 		// WeakKeyFile is DEPRECATED. Populate GoodKey.WeakKeyFile instead.
 		// TODO(#5851): Remove this.
@@ -224,9 +224,6 @@ func main() {
 	}
 
 	// TODO(#5851): Remove these fallbacks when the old config keys are gone.
-	if c.RA.GoodKey == nil {
-		c.RA.GoodKey = &goodkey.Config{}
-	}
 	if c.RA.GoodKey.WeakKeyFile == "" && c.RA.WeakKeyFile != "" {
 		c.RA.GoodKey.WeakKeyFile = c.RA.WeakKeyFile
 	}

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -104,7 +104,7 @@ type config struct {
 		LegacyKeyIDPrefix string
 
 		// GoodKey is an embedded config stanza for the goodkey library.
-		GoodKey *goodkey.Config
+		GoodKey goodkey.Config
 
 		// WeakKeyFile is DEPRECATED. Populate GoodKey.BlockedKeyFile instead.
 		// TODO(#5851): Remove this.
@@ -397,9 +397,6 @@ func main() {
 
 	// TODO(#5851): Remove these fallbacks when the old config keys are gone.
 	// The WFE does not do weak key checking, just blocked key checking.
-	if c.WFE.GoodKey == nil {
-		c.WFE.GoodKey = &goodkey.Config{}
-	}
 	if c.WFE.GoodKey.BlockedKeyFile == "" && c.WFE.BlockedKeyFile != "" {
 		c.WFE.GoodKey.BlockedKeyFile = c.WFE.BlockedKeyFile
 	}

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -400,7 +400,7 @@ func main() {
 	if c.WFE.GoodKey.BlockedKeyFile == "" && c.WFE.BlockedKeyFile != "" {
 		c.WFE.GoodKey.BlockedKeyFile = c.WFE.BlockedKeyFile
 	}
-	kp, err := goodkey.NewKeyPolicy(c.WFE.GoodKey, sac.KeyBlocked)
+	kp, err := goodkey.NewKeyPolicy(&c.WFE.GoodKey, sac.KeyBlocked)
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	if c.WFE.StaleTimeout.Duration == 0 {


### PR DESCRIPTION
This means that we don't have to test whether it is nil before
filling it in with the old deprecated values; we can just assume
that it exists whether or not the json config has a matching stanza.

All handling of uninitialized values (i.e. empty strings for key files)
is handled in `goodkey.NewKeyPolicy`.