### PR TITLE
Handle redis lookup errors when value not found

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -226,8 +226,9 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 	case <-ctx.Done():
 		if errors.Is(ctx.Err(), context.Canceled) {
 			src.metrics.ocspLookups.WithLabelValues("mysql", "canceled").Inc()
+		} else {
+			src.metrics.ocspLookups.WithLabelValues("mysql", "deadline_exceeded").Inc()
 		}
-		src.metrics.ocspLookups.WithLabelValues("mysql", "deadline_exceeded").Inc()
 		return nil, nil, fmt.Errorf("looking up OCSP response for serial: %s err: %w", serialString, ctx.Err())
 	case primaryResult := <-primaryChan:
 		if primaryResult.err != nil {
@@ -259,8 +260,9 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.Canceled) {
 				src.metrics.ocspLookups.WithLabelValues("mysql", "canceled").Inc()
+			} else {
+				src.metrics.ocspLookups.WithLabelValues("mysql", "deadline_exceeded").Inc()
 			}
-			src.metrics.ocspLookups.WithLabelValues("mysql", "deadline_exceeded").Inc()
 			return nil, nil, fmt.Errorf("looking up OCSP response for serial: %s err: %w", serialString, ctx.Err())
 		case primaryResult = <-primaryChan:
 		}

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -235,7 +235,7 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 			if errors.Is(primaryResult.err, bocsp.ErrNotFound) {
 				src.metrics.ocspLookups.WithLabelValues("mysql", "success", "not_found").Inc()
 			} else {
-				src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
+				src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "other").Inc()
 			}
 			return nil, nil, primaryResult.err
 		}
@@ -244,7 +244,7 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		primaryParsed, err := ocsp.ParseResponse(primaryResult.bytes, nil)
 		if err != nil {
 			src.log.AuditErrf("parsing OCSP response: %s", err)
-			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "other").Inc()
 			return nil, nil, err
 		}
 		src.log.Debugf("returning ocsp from primary source: %v", helper.PrettyResponse(primaryParsed))
@@ -271,7 +271,7 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 			if errors.Is(primaryResult.err, bocsp.ErrNotFound) {
 				src.metrics.ocspLookups.WithLabelValues("mysql", "success", "not_found").Inc()
 			} else {
-				src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
+				src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "other").Inc()
 			}
 			return nil, nil, primaryResult.err
 		}
@@ -281,7 +281,7 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		primaryParsed, err := ocsp.ParseResponse(primaryResult.bytes, nil)
 		if err != nil {
 			src.log.AuditErrf("parsing OCSP response: %s", err)
-			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "other").Inc()
 			return nil, nil, err
 		}
 
@@ -294,7 +294,7 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 			if errors.Is(secondaryResult.err, bocsp.ErrNotFound) {
 				src.metrics.ocspLookups.WithLabelValues("redis", "failed", "not_found").Inc()
 			} else {
-				src.metrics.ocspLookups.WithLabelValues("redis", "failed", "error").Inc()
+				src.metrics.ocspLookups.WithLabelValues("redis", "failed", "other").Inc()
 			}
 			src.metrics.ocspLookups.WithLabelValues("mysql", "success", "").Inc()
 			return primaryResult.bytes, header, nil
@@ -305,7 +305,7 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		secondaryParsed, err := ocsp.ParseResponse(secondaryResult.bytes, nil)
 		if err != nil {
 			src.log.AuditErrf("parsing secondary OCSP response: %s", err)
-			src.metrics.ocspLookups.WithLabelValues("redis", "failed", "error").Inc()
+			src.metrics.ocspLookups.WithLabelValues("redis", "failed", "other").Inc()
 			src.metrics.ocspLookups.WithLabelValues("mysql", "success", "").Inc()
 			return primaryResult.bytes, header, nil
 		}

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -86,18 +86,11 @@ func newSourceMetrics(stats prometheus.Registerer) *sourceMetrics {
 	ocspLookups := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ocsp_lookups",
 		Help: "A counter of ocsp lookups labeled by source_result",
-	}, []string{"result"})
+	}, []string{"source", "result", "error"})
 	stats.MustRegister(ocspLookups)
-
-	sourceUsed := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lookup_source_used",
-		Help: "A counter of lookups returned labeled by source used",
-	}, []string{"source"})
-	stats.MustRegister(sourceUsed)
 
 	metrics := sourceMetrics{
 		ocspLookups: ocspLookups,
-		sourceUsed:  sourceUsed,
 	}
 	return &metrics
 }
@@ -233,15 +226,16 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 	select {
 	case <-ctx.Done():
 		if errors.Is(ctx.Err(), context.Canceled) {
-			src.metrics.ocspLookups.WithLabelValues("canceled").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "canceled").Inc()
 		}
-		src.metrics.ocspLookups.WithLabelValues("deadline_exceeded").Inc()
+		src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "deadline_exceeded").Inc()
 		return nil, nil, fmt.Errorf("looking up OCSP response for serial: %s err: %w", serialString, ctx.Err())
 	case primaryResult := <-primaryChan:
 		if primaryResult.err != nil {
-			if !errors.Is(primaryResult.err, bocsp.ErrNotFound) {
-				src.metrics.ocspLookups.WithLabelValues("mysql_failed").Inc()
-				src.metrics.sourceUsed.WithLabelValues("error_returned").Inc()
+			if errors.Is(primaryResult.err, bocsp.ErrNotFound) {
+				src.metrics.ocspLookups.WithLabelValues("mysql", "success", "not_found").Inc()
+			} else {
+				src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
 			}
 			return nil, nil, primaryResult.err
 		}
@@ -250,13 +244,11 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		primaryParsed, err := ocsp.ParseResponse(primaryResult.bytes, nil)
 		if err != nil {
 			src.log.AuditErrf("parsing OCSP response: %s", err)
-			src.metrics.ocspLookups.WithLabelValues("mysql_parse_error").Inc()
-			src.metrics.sourceUsed.WithLabelValues("error_returned").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
 			return nil, nil, err
 		}
 		src.log.Debugf("returning ocsp from primary source: %v", helper.PrettyResponse(primaryParsed))
-		src.metrics.ocspLookups.WithLabelValues("mysql_success").Inc()
-		src.metrics.sourceUsed.WithLabelValues("mysql").Inc()
+		src.metrics.ocspLookups.WithLabelValues("mysql", "success", "").Inc()
 		return primaryResult.bytes, header, nil
 	case secondaryResult := <-secondaryChan:
 		// If secondary returns first, wait for primary to return for
@@ -267,18 +259,19 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		select {
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.Canceled) {
-				src.metrics.ocspLookups.WithLabelValues("canceled").Inc()
+				src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "canceled").Inc()
 			}
-			src.metrics.ocspLookups.WithLabelValues("deadline_exceeded").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "deadline_exceeded").Inc()
 			return nil, nil, fmt.Errorf("looking up OCSP response for serial: %s err: %w", serialString, ctx.Err())
 		case primaryResult = <-primaryChan:
 		}
 
 		// Check for error returned from the mysql lookup, return on error.
 		if primaryResult.err != nil {
-			if !errors.Is(primaryResult.err, bocsp.ErrNotFound) {
-				src.metrics.ocspLookups.WithLabelValues("mysql_failed").Inc()
-				src.metrics.sourceUsed.WithLabelValues("error_returned").Inc()
+			if errors.Is(primaryResult.err, bocsp.ErrNotFound) {
+				src.metrics.ocspLookups.WithLabelValues("mysql", "success", "not_found").Inc()
+			} else {
+				src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
 			}
 			return nil, nil, primaryResult.err
 		}
@@ -288,16 +281,22 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		primaryParsed, err := ocsp.ParseResponse(primaryResult.bytes, nil)
 		if err != nil {
 			src.log.AuditErrf("parsing OCSP response: %s", err)
-			src.metrics.ocspLookups.WithLabelValues("mysql_parse_error").Inc()
-			src.metrics.sourceUsed.WithLabelValues("error_returned").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "failed", "error").Inc()
 			return nil, nil, err
 		}
 
 		// Check for error returned from the redis lookup. If error return
 		// primary lookup result.
 		if secondaryResult.err != nil {
-			src.metrics.ocspLookups.WithLabelValues("redis_failed").Inc()
-			src.metrics.sourceUsed.WithLabelValues("mysql").Inc()
+			// If we made it this far then there was a successful lookup
+			// on mysql but an error on redis. Either the response exists
+			// in mysql and not in redis or a different error.
+			if errors.Is(secondaryResult.err, bocsp.ErrNotFound) {
+				src.metrics.ocspLookups.WithLabelValues("redis", "failed", "not_found").Inc()
+			} else {
+				src.metrics.ocspLookups.WithLabelValues("redis", "failed", "error").Inc()
+			}
+			src.metrics.ocspLookups.WithLabelValues("mysql", "success", "").Inc()
 			return primaryResult.bytes, header, nil
 		}
 
@@ -306,22 +305,21 @@ func (src *dbSource) Response(ctx context.Context, req *ocsp.Request) ([]byte, h
 		secondaryParsed, err := ocsp.ParseResponse(secondaryResult.bytes, nil)
 		if err != nil {
 			src.log.AuditErrf("parsing secondary OCSP response: %s", err)
-			src.metrics.ocspLookups.WithLabelValues("redis_parse_error").Inc()
-			src.metrics.sourceUsed.WithLabelValues("mysql").Inc()
+			src.metrics.ocspLookups.WithLabelValues("redis", "failed", "error").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "success", "").Inc()
 			return primaryResult.bytes, header, nil
 		}
 
 		// If the secondary response status doesn't match primary return
 		// primary response.
 		if primaryParsed.Status != secondaryParsed.Status {
-			src.metrics.ocspLookups.WithLabelValues("redis_mismatch").Inc()
-			src.metrics.sourceUsed.WithLabelValues("mysql").Inc()
+			src.metrics.ocspLookups.WithLabelValues("redis", "failed", "mismatch").Inc()
+			src.metrics.ocspLookups.WithLabelValues("mysql", "success", "").Inc()
 			return primaryResult.bytes, header, nil
 		}
 
 		// The secondary response has passed checks, return it.
-		src.metrics.ocspLookups.WithLabelValues("redis_success").Inc()
-		src.metrics.sourceUsed.WithLabelValues("redis").Inc()
+		src.metrics.ocspLookups.WithLabelValues("redis", "success", "").Inc()
 		return secondaryResult.bytes, header, nil
 	}
 }
@@ -404,6 +402,10 @@ func (src redisReceiver) getResponse(ctx context.Context, req *ocsp.Request) cha
 	go func() {
 		defer close(responseChan)
 		respBytes, err := src.rocspReader.GetResponse(ctx, serialString)
+		if errors.Is(err, rocsp.ErrRedisNotFound) {
+			responseChan <- lookupResponse{nil, bocsp.ErrNotFound}
+			return
+		}
 		responseChan <- lookupResponse{respBytes, err}
 	}()
 

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -85,7 +85,7 @@ func newSourceMetrics(stats prometheus.Registerer) *sourceMetrics {
 	// Metrics for response lookups
 	ocspLookups := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ocsp_lookups",
-		Help: "A counter of ocsp lookups labeled by source_result",
+		Help: "A counter of ocsp lookups labeled with source, result and error",
 	}, []string{"source", "result", "error"})
 	stats.MustRegister(ocspLookups)
 

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -78,7 +78,6 @@ func newFilter(issuerCerts []string, serialPrefixes []string) (*ocspFilter, erro
 // between redis and mysql.
 type sourceMetrics struct {
 	ocspLookups *prometheus.CounterVec
-	sourceUsed  *prometheus.CounterVec
 }
 
 func newSourceMetrics(stats prometheus.Registerer) *sourceMetrics {

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -84,7 +84,7 @@ func newSourceMetrics(stats prometheus.Registerer) *sourceMetrics {
 	// Metrics for response lookups
 	ocspLookups := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ocsp_lookups",
-		Help: "A counter of ocsp lookups labeled with source, result and error",
+		Help: "A counter of ocsp lookups labeled with source and result",
 	}, []string{"source", "result"})
 	stats.MustRegister(ocspLookups)
 

--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -183,7 +183,7 @@ func (c *Client) GetResponse(ctx context.Context, serial string) ([]byte, error)
 	resp, err := c.rdb.Get(ctx, responseKey).Result()
 	if err != nil {
 		// go-redis `Get` returns redis.Nil error when key does not exist. In
-		// that case return a ErrNotFound error.
+		// that case return a `ErrRedisNotFound` error.
 		if errors.Is(err, redis.Nil) {
 			return nil, ErrRedisNotFound
 		}

--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -180,18 +180,17 @@ func (c *Client) GetResponse(ctx context.Context, serial string) ([]byte, error)
 
 	responseKey := MakeResponseKey(serial)
 
-	resp := c.rdb.Get(ctx, responseKey)
-	// go-redis `Get` returns redis.Nil error when key does not exist. In
-	// that case return a ErrNotFound error.
-	if errors.Is(resp.Err(), redis.Nil) {
-		return nil, ErrRedisNotFound
-	}
-	val, err := resp.Result()
+	resp, err := c.rdb.Get(ctx, responseKey).Result()
 	if err != nil {
+		// go-redis `Get` returns redis.Nil error when key does not exist. In
+		// that case return a ErrNotFound error.
+		if errors.Is(err, redis.Nil) {
+			return nil, ErrRedisNotFound
+		}
 		return nil, fmt.Errorf("getting response: %w", err)
 	}
 
-	return []byte(val), nil
+	return []byte(resp), nil
 }
 
 // GetMetadata fetches the metadata for the given serial number.


### PR DESCRIPTION
Add a not found error type to rocsp.

Handle redis value not found lookup errors in the ocsp-responder different
than other redis lookup errors.

Add labels to the to ocspLookup metric and delete the source used
metric. This can now be determined based on which lookup metric
reports success.

Fixes #5833