### PR TITLE
Remove functionality of NewAuthorization flow

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -14,13 +14,13 @@ func _() {
 	_ = x[NonCFSSLSigner-3]
 	_ = x[StoreIssuerInfo-4]
 	_ = x[StreamlineOrderAndAuthzs-5]
-	_ = x[CAAValidationMethods-6]
-	_ = x[CAAAccountURI-7]
-	_ = x[EnforceMultiVA-8]
-	_ = x[MultiVAFullResults-9]
-	_ = x[MandatoryPOSTAsGET-10]
-	_ = x[AllowV1Registration-11]
-	_ = x[V1DisableNewValidations-12]
+	_ = x[V1DisableNewValidations-6]
+	_ = x[CAAValidationMethods-7]
+	_ = x[CAAAccountURI-8]
+	_ = x[EnforceMultiVA-9]
+	_ = x[MultiVAFullResults-10]
+	_ = x[MandatoryPOSTAsGET-11]
+	_ = x[AllowV1Registration-12]
 	_ = x[StoreRevokerInfo-13]
 	_ = x[RestrictRSAKeySizes-14]
 	_ = x[FasterNewOrdersRateLimit-15]
@@ -31,9 +31,9 @@ func _() {
 	_ = x[CheckFailedAuthorizationsFirst-20]
 }
 
-const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationV1DisableNewValidationsStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndexCheckFailedAuthorizationsFirst"
+const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsV1DisableNewValidationsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndexCheckFailedAuthorizationsFirst"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 125, 138, 152, 170, 188, 207, 230, 246, 265, 289, 300, 316, 332, 348, 378}
+var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 128, 148, 161, 175, 193, 211, 230, 246, 265, 289, 300, 316, 332, 348, 378}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -17,6 +17,7 @@ const (
 	NonCFSSLSigner
 	StoreIssuerInfo
 	StreamlineOrderAndAuthzs
+	V1DisableNewValidations
 
 	//   Currently in-use features
 	// Check CAA and respect validationmethods parameter.
@@ -34,9 +35,6 @@ const (
 	MandatoryPOSTAsGET
 	// Allow creation of new registrations in ACMEv1.
 	AllowV1Registration
-	// V1DisableNewValidations disables validations for new domain names in the V1
-	// API.
-	V1DisableNewValidations
 	// StoreRevokerInfo enables storage of the revoker and a bool indicating if the row
 	// was checked for extant unrevoked certificates in the blockedKeys table.
 	StoreRevokerInfo

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -359,6 +359,9 @@ func ValidEmail(address string) error {
 //
 // If WillingToIssue returns an error, it will be of type MalformedRequestError
 // or RejectedIdentifierError
+//
+// TODO(#5816): Consider making this method private, as it has no callers
+// outside of this package.
 func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 	if id.Type != identifier.DNS {
 		return errInvalidIdentifier


### PR DESCRIPTION
Empty the bodies of the WFE's and RA's `NewAuthorization` methods. These
were used exclusively by the ACMEv1 flow. Also remove any helper functions
which were used exclusively by this code, and any tests which were testing
exclusively this code and which have equivalent tests for the ACMEv2 flow.

Greatly simply `SA.GetAuthorizations2`, as it no longer has to contend with
there being two different kinds of authorizations in the database. Add a few
TODOs to consider removing a few other SA gRPC methods which no longer
have any callers.

Part of #5681