### PR TITLE
Add latency metrics to rocsp

### DIFF
--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -68,15 +68,22 @@ func MakeMetadataKey(serial string) string {
 
 // Client represents a read-only Redis client.
 type Client struct {
-	rdb     *redis.ClusterClient
-	timeout time.Duration
-	clk     clock.Clock
-	rdc     metricsCollector
+	rdb                *redis.ClusterClient
+	timeout            time.Duration
+	clk                clock.Clock
+	rdc                metricsCollector
+	getResponseLatency *prometheus.HistogramVec
+	getMetadataLatency *prometheus.HistogramVec
 }
 
 // NewClient creates a Client. The timeout applies to all requests, though a shorter timeout can be
 // applied on a per-request basis using context.Context.
-func NewClient(rdb *redis.ClusterClient, timeout time.Duration, clk clock.Clock, stats prometheus.Registerer) *Client {
+func NewClient(
+	rdb *redis.ClusterClient,
+	timeout time.Duration,
+	clk clock.Clock,
+	stats prometheus.Registerer,
+) *Client {
 	dbc := metricsCollector{rdb: rdb}
 
 	labels := prometheus.Labels{"address": rdb.Options().Addrs[0], "user": rdb.Options().Username}
@@ -104,25 +111,51 @@ func NewClient(rdb *redis.ClusterClient, timeout time.Duration, clk clock.Clock,
 		"redis_stale_conns",
 		"Number of stale connections removed from the pool.",
 		nil, labels)
-
 	stats.MustRegister(dbc)
+	getResponseLatency := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "rocsp_get_response_latency",
+			Help: "Histogram of latencies of rocsp.GetResponse calls with result labels",
+		},
+		[]string{"result"},
+	)
+	stats.MustRegister(getResponseLatency)
+	getMetadataLatency := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "rocsp_get_metadata_latency",
+			Help: "Histogram of latencies of rocsp.GetMetadata calls with result labels",
+		},
+		[]string{"result"},
+	)
+	stats.MustRegister(getMetadataLatency)
 
 	return &Client{
-		rdb:     rdb,
-		timeout: timeout,
-		clk:     clk,
-		rdc:     dbc,
+		rdb:                rdb,
+		timeout:            timeout,
+		clk:                clk,
+		rdc:                dbc,
+		getResponseLatency: getResponseLatency,
+		getMetadataLatency: getMetadataLatency,
 	}
 }
 
 // WritingClient represents a Redis client that can both read and write.
 type WritingClient struct {
 	*Client
+	storeResponseLatency *prometheus.HistogramVec
 }
 
 // NewWritingClient creates a WritingClient.
 func NewWritingClient(rdb *redis.ClusterClient, timeout time.Duration, clk clock.Clock, stats prometheus.Registerer) *WritingClient {
-	return &WritingClient{NewClient(rdb, timeout, clk, stats)}
+	storeResponseLatency := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "rocsp_store_response_latency",
+			Help: "Histogram of latencies of rocsp.StoreResponse calls with result labels",
+		},
+		[]string{"result"},
+	)
+	stats.MustRegister(storeResponseLatency)
+	return &WritingClient{NewClient(rdb, timeout, clk, stats), storeResponseLatency}
 }
 
 // StoreResponse parses the given bytes as an OCSP response, and stores it into
@@ -131,6 +164,7 @@ func NewWritingClient(rdb *redis.ClusterClient, timeout time.Duration, clk clock
 // same across OCSP components. Returns error if the OCSP response fails to
 // parse.
 func (c *WritingClient) StoreResponse(ctx context.Context, respBytes []byte, shortIssuerID byte, ttl time.Duration) error {
+	start := c.clk.Now()
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -164,9 +198,17 @@ func (c *WritingClient) StoreResponse(ctx context.Context, respBytes []byte, sho
 		return nil
 	}, metadataKey, responseKey)
 	if err != nil {
+		state := "failed"
+		if errors.Is(err, context.DeadlineExceeded) {
+			state = "deadlineExceeded"
+		} else if errors.Is(err, context.Canceled) {
+			state = "canceled"
+		}
+		c.storeResponseLatency.With(prometheus.Labels{"result": state}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("transaction failed: %w", err)
 	}
 
+	c.storeResponseLatency.With(prometheus.Labels{"result": "success"}).Observe(time.Since(start).Seconds())
 	return nil
 }
 
@@ -174,6 +216,7 @@ func (c *WritingClient) StoreResponse(ctx context.Context, respBytes []byte, sho
 // Returns error if the OCSP response fails to parse.
 // Does not check the metadata field.
 func (c *Client) GetResponse(ctx context.Context, serial string) ([]byte, error) {
+	start := c.clk.Now()
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -184,16 +227,27 @@ func (c *Client) GetResponse(ctx context.Context, serial string) ([]byte, error)
 		// go-redis `Get` returns redis.Nil error when key does not exist. In
 		// that case return a `ErrRedisNotFound` error.
 		if errors.Is(err, redis.Nil) {
+			c.getResponseLatency.With(prometheus.Labels{"result": "notFound"}).Observe(time.Since(start).Seconds())
 			return nil, ErrRedisNotFound
 		}
+
+		state := "failed"
+		if errors.Is(err, context.DeadlineExceeded) {
+			state = "deadlineExceeded"
+		} else if errors.Is(err, context.Canceled) {
+			state = "canceled"
+		}
+		c.getResponseLatency.With(prometheus.Labels{"result": state}).Observe(time.Since(start).Seconds())
 		return nil, fmt.Errorf("getting response: %w", err)
 	}
 
+	c.getResponseLatency.With(prometheus.Labels{"result": "success"}).Observe(time.Since(start).Seconds())
 	return []byte(resp), nil
 }
 
 // GetMetadata fetches the metadata for the given serial number.
 func (c *Client) GetMetadata(ctx context.Context, serial string) (*Metadata, error) {
+	start := c.clk.Now()
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -204,13 +258,25 @@ func (c *Client) GetMetadata(ctx context.Context, serial string) (*Metadata, err
 		// go-redis `Get` returns redis.Nil error when key does not exist. In
 		// that case return a `ErrRedisNotFound` error.
 		if errors.Is(err, redis.Nil) {
+			c.getMetadataLatency.With(prometheus.Labels{"result": "notFound"}).Observe(time.Since(start).Seconds())
 			return nil, ErrRedisNotFound
 		}
+
+		state := "failed"
+		if errors.Is(err, context.DeadlineExceeded) {
+			state = "deadlineExceeded"
+		} else if errors.Is(err, context.Canceled) {
+			state = "canceled"
+		}
+		c.getMetadataLatency.With(prometheus.Labels{"result": state}).Observe(time.Since(start).Seconds())
 		return nil, fmt.Errorf("getting metadata: %w", err)
 	}
 	metadata, err := UnmarshalMetadata([]byte(resp))
 	if err != nil {
+		c.getMetadataLatency.With(prometheus.Labels{"result": "failed"}).Observe(time.Since(start).Seconds())
 		return nil, fmt.Errorf("unmarshaling metadata: %w", err)
 	}
+
+	c.getMetadataLatency.With(prometheus.Labels{"result": "success"}).Observe(time.Since(start).Seconds())
 	return &metadata, nil
 }


### PR DESCRIPTION
Measure and export latency histogram metrics for ocsp storage and lookup
operations in redis.

Fixes #5832 