### PR TITLE
Fix iteration in rocsp-tool load-from-db

### DIFF
--- a/cmd/rocsp-tool/client.go
+++ b/cmd/rocsp-tool/client.go
@@ -138,7 +138,7 @@ func (cl *client) scanFromDB(ctx context.Context, prevID int64, maxID int64, fre
 		var err error
 		currentMin := prevID
 		for currentMin < maxID {
-			currentMin, err = cl.scanFromDBOneBatch(ctx, prevID, frequency, statusesToSign, inflightIDs)
+			currentMin, err = cl.scanFromDBOneBatch(ctx, currentMin, frequency, statusesToSign, inflightIDs)
 			if err != nil {
 				log.Printf("error scanning rows: %s", err)
 			}


### PR DESCRIPTION
rocsp-tool load-from-db scans in batches. On each iteration, it is supposed to update its starting position based on the highest seen ID from the last batch. However, it was always setting its starting position to the same value, and not making progress if the DB was larger than the batch size.