### PR TITLE
Refactor cert-checker tests

### DIFF
--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -2,6 +2,7 @@ package notmain
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -165,130 +166,23 @@ func TestCheckCertReturnsDNSNames(t *testing.T) {
 	}
 }
 
-func TestCheckCertRSA(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
-	test.AssertNotError(t, err, "Couldn't connect to database")
-	saCleanup := test.ResetSATestDatabase(t)
-	defer func() {
-		saCleanup()
-	}()
-
-	testKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-
-	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations)
-
-	// Create a RFC 7633 OCSP Must Staple Extension.
-	// OID 1.3.6.1.5.5.7.1.24
-	ocspMustStaple := pkix.Extension{
-		Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24},
-		Critical: false,
-		Value:    []uint8{0x30, 0x3, 0x2, 0x1, 0x5},
-	}
-
-	// Create a made up PKIX extension
-	imaginaryExtension := pkix.Extension{
-		Id:       asn1.ObjectIdentifier{1, 3, 3, 7},
-		Critical: false,
-		Value:    []uint8{0xC0, 0xFF, 0xEE},
-	}
-
-	issued := checker.clock.Now().Add(-time.Minute)
-	goodExpiry := issued.Add(testValidityDuration - time.Second)
-	serial := big.NewInt(1337)
-	longName := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeexample.com"
-	rawCert := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName: longName,
-		},
-		NotBefore: issued,
-		NotAfter:  goodExpiry.AddDate(0, 0, 1), // Period too long
-		DNSNames: []string{
-			// longName should be flagged along with the long CN
-			longName,
-			"example-a.com",
-			"foodnotbombs.mil",
-			// `dev-myqnapcloud.com` is included because it is an exact private
-			// entry on the public suffix list
-			"dev-myqnapcloud.com",
-		},
-		SerialNumber:          serial,
-		BasicConstraintsValid: false,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature,
-		OCSPServer:            []string{"http://example.com/ocsp"},
-		IssuingCertificateURL: []string{"http://example.com/cert"},
-		ExtraExtensions:       []pkix.Extension{ocspMustStaple, imaginaryExtension},
-	}
-	brokenCertDer, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
-	test.AssertNotError(t, err, "Couldn't create certificate")
-	// Problems
-	//   Digest doesn't match
-	//   Serial doesn't match
-	//   Expiry doesn't match
-	//   Issued doesn't match
-	cert := core.Certificate{
-		Serial:  "8485f2687eba29ad455ae4e31c8679206fec",
-		DER:     brokenCertDer,
-		Issued:  issued.Add(12 * time.Hour),
-		Expires: goodExpiry.AddDate(0, 0, 2), // Expiration doesn't match
-	}
-
-	_, problems := checker.checkCert(cert, nil)
-
-	problemsMap := map[string]int{
-		"Stored digest doesn't match certificate digest":                            1,
-		"Stored serial doesn't match certificate serial":                            1,
-		"Stored expiration doesn't match certificate NotAfter":                      1,
-		"Certificate doesn't have basic constraints set":                            1,
-		"Certificate has unacceptable validity period":                              1,
-		"Stored issuance date is outside of 6 hour window of certificate NotBefore": 1,
-		"Certificate has incorrect key usage extensions":                            1,
-		"Certificate has common name >64 characters long (65)":                      1,
-		"Certificate contains an unexpected extension: 1.3.3.7":                     1,
-	}
-	for _, p := range problems {
-		_, ok := problemsMap[p]
-		if !ok {
-			t.Errorf("Found unexpected problem '%s'.", p)
-		}
-		delete(problemsMap, p)
-	}
-	for k := range problemsMap {
-		t.Errorf("Expected problem but didn't find it: '%s'.", k)
-	}
-
-	// Same settings as above, but the stored serial number in the DB is invalid.
-	cert.Serial = "not valid"
-	_, problems = checker.checkCert(cert, nil)
-	foundInvalidSerialProblem := false
-	for _, p := range problems {
-		if p == "Stored serial is invalid" {
-			foundInvalidSerialProblem = true
-		}
-	}
-	test.Assert(t, foundInvalidSerialProblem, "Invalid certificate serial number in DB did not trigger problem.")
-
-	// Fix the problems
-	rawCert.Subject.CommonName = "example-a.com"
-	rawCert.DNSNames = []string{"example-a.com"}
-	rawCert.NotAfter = goodExpiry
-	rawCert.BasicConstraintsValid = true
-	rawCert.ExtraExtensions = []pkix.Extension{ocspMustStaple}
-	rawCert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
-	goodCertDer, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
-	test.AssertNotError(t, err, "Couldn't create certificate")
-	parsed, err := x509.ParseCertificate(goodCertDer)
-	test.AssertNotError(t, err, "Couldn't parse created certificate")
-	cert.Serial = core.SerialToString(serial)
-	cert.Digest = core.Fingerprint256(goodCertDer)
-	cert.DER = goodCertDer
-	cert.Expires = parsed.NotAfter
-	cert.Issued = parsed.NotBefore
-	_, problems = checker.checkCert(cert, nil)
-	test.AssertEquals(t, len(problems), 0)
+type keyGen interface {
+	genKey() (crypto.Signer, error)
 }
 
-func TestCheckCertECDSA(t *testing.T) {
+type ecP256Generator struct{}
+
+func (*ecP256Generator) genKey() (crypto.Signer, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+type rsa2048Generator struct{}
+
+func (*rsa2048Generator) genKey() (crypto.Signer, error) {
+	return rsa.GenerateKey(rand.Reader, 2048)
+}
+
+func TestCheckCert(t *testing.T) {
 	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	saCleanup := test.ResetSATestDatabase(t)
@@ -296,120 +190,136 @@ func TestCheckCertECDSA(t *testing.T) {
 		saCleanup()
 	}()
 
-	testKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	test.AssertNotError(t, err, "could not generate ecdsa key")
-
-	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations)
-
-	// Create a RFC 7633 OCSP Must Staple Extension.
-	// OID 1.3.6.1.5.5.7.1.24
-	ocspMustStaple := pkix.Extension{
-		Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24},
-		Critical: false,
-		Value:    []uint8{0x30, 0x3, 0x2, 0x1, 0x5},
-	}
-
-	// Create a made up PKIX extension
-	imaginaryExtension := pkix.Extension{
-		Id:       asn1.ObjectIdentifier{1, 3, 3, 7},
-		Critical: false,
-		Value:    []uint8{0xC0, 0xFF, 0xEE},
-	}
-
-	issued := checker.clock.Now().Add(-time.Minute)
-	goodExpiry := issued.Add(testValidityDuration - time.Second)
-	serial := big.NewInt(1337)
-	longName := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeexample.com"
-	rawCert := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName: longName,
+	testCases := []struct {
+		name string
+		key  keyGen
+	}{
+		{
+			name: "RSA 2048 key",
+			key:  &rsa2048Generator{},
 		},
-		NotBefore: issued,
-		NotAfter:  goodExpiry.AddDate(0, 0, 1), // Period too long
-		DNSNames: []string{
-			// longName should be flagged along with the long CN
-			longName,
-			"example-a.com",
-			"foodnotbombs.mil",
-			// `dev-myqnapcloud.com` is included because it is an exact private
-			// entry on the public suffix list
-			"dev-myqnapcloud.com",
+		{
+			name: "ECDSA P256 key",
+			key:  &ecP256Generator{},
 		},
-		SerialNumber:          serial,
-		BasicConstraintsValid: false,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature,
-		OCSPServer:            []string{"http://example.com/ocsp"},
-		IssuingCertificateURL: []string{"http://example.com/cert"},
-		ExtraExtensions:       []pkix.Extension{ocspMustStaple, imaginaryExtension},
 	}
-	brokenCertDer, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
-	test.AssertNotError(t, err, "Couldn't create certificate")
-	// Problems
-	//   Digest doesn't match
-	//   Serial doesn't match
-	//   Expiry doesn't match
-	//   Issued doesn't match
-	cert := core.Certificate{
-		Serial:  "8485f2687eba29ad455ae4e31c8679206fec",
-		DER:     brokenCertDer,
-		Issued:  issued.Add(12 * time.Hour),
-		Expires: goodExpiry.AddDate(0, 0, 2), // Expiration doesn't match
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testKey, _ := tc.key.genKey()
 
-	_, problems := checker.checkCert(cert, nil)
+			checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations)
 
-	problemsMap := map[string]int{
-		"Stored digest doesn't match certificate digest":                            1,
-		"Stored serial doesn't match certificate serial":                            1,
-		"Stored expiration doesn't match certificate NotAfter":                      1,
-		"Certificate doesn't have basic constraints set":                            1,
-		"Certificate has unacceptable validity period":                              1,
-		"Stored issuance date is outside of 6 hour window of certificate NotBefore": 1,
-		"Certificate has incorrect key usage extensions":                            1,
-		"Certificate has common name >64 characters long (65)":                      1,
-		"Certificate contains an unexpected extension: 1.3.3.7":                     1,
-	}
-	for _, p := range problems {
-		_, ok := problemsMap[p]
-		if !ok {
-			t.Errorf("Found unexpected problem '%s'.", p)
-		}
-		delete(problemsMap, p)
-	}
-	for k := range problemsMap {
-		t.Errorf("Expected problem but didn't find it: '%s'.", k)
-	}
+			// Create a RFC 7633 OCSP Must Staple Extension.
+			// OID 1.3.6.1.5.5.7.1.24
+			ocspMustStaple := pkix.Extension{
+				Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24},
+				Critical: false,
+				Value:    []uint8{0x30, 0x3, 0x2, 0x1, 0x5},
+			}
 
-	// Same settings as above, but the stored serial number in the DB is invalid.
-	cert.Serial = "not valid"
-	_, problems = checker.checkCert(cert, nil)
-	foundInvalidSerialProblem := false
-	for _, p := range problems {
-		if p == "Stored serial is invalid" {
-			foundInvalidSerialProblem = true
-		}
-	}
-	test.Assert(t, foundInvalidSerialProblem, "Invalid certificate serial number in DB did not trigger problem.")
+			// Create a made up PKIX extension
+			imaginaryExtension := pkix.Extension{
+				Id:       asn1.ObjectIdentifier{1, 3, 3, 7},
+				Critical: false,
+				Value:    []uint8{0xC0, 0xFF, 0xEE},
+			}
 
-	// Fix the problems
-	rawCert.Subject.CommonName = "example-a.com"
-	rawCert.DNSNames = []string{"example-a.com"}
-	rawCert.NotAfter = goodExpiry
-	rawCert.BasicConstraintsValid = true
-	rawCert.ExtraExtensions = []pkix.Extension{ocspMustStaple}
-	rawCert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
-	goodCertDer, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
-	test.AssertNotError(t, err, "Couldn't create certificate")
-	parsed, err := x509.ParseCertificate(goodCertDer)
-	test.AssertNotError(t, err, "Couldn't parse created certificate")
-	cert.Serial = core.SerialToString(serial)
-	cert.Digest = core.Fingerprint256(goodCertDer)
-	cert.DER = goodCertDer
-	cert.Expires = parsed.NotAfter
-	cert.Issued = parsed.NotBefore
-	_, problems = checker.checkCert(cert, nil)
-	test.AssertEquals(t, len(problems), 0)
+			issued := checker.clock.Now().Add(-time.Minute)
+			goodExpiry := issued.Add(testValidityDuration - time.Second)
+			serial := big.NewInt(1337)
+			longName := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeexample.com"
+			rawCert := x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: longName,
+				},
+				NotBefore: issued,
+				NotAfter:  goodExpiry.AddDate(0, 0, 1), // Period too long
+				DNSNames: []string{
+					// longName should be flagged along with the long CN
+					longName,
+					"example-a.com",
+					"foodnotbombs.mil",
+					// `dev-myqnapcloud.com` is included because it is an exact private
+					// entry on the public suffix list
+					"dev-myqnapcloud.com",
+				},
+				SerialNumber:          serial,
+				BasicConstraintsValid: false,
+				ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				KeyUsage:              x509.KeyUsageDigitalSignature,
+				OCSPServer:            []string{"http://example.com/ocsp"},
+				IssuingCertificateURL: []string{"http://example.com/cert"},
+				ExtraExtensions:       []pkix.Extension{ocspMustStaple, imaginaryExtension},
+			}
+			brokenCertDer, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, testKey.Public(), testKey)
+			test.AssertNotError(t, err, "Couldn't create certificate")
+			// Problems
+			//   Digest doesn't match
+			//   Serial doesn't match
+			//   Expiry doesn't match
+			//   Issued doesn't match
+			cert := core.Certificate{
+				Serial:  "8485f2687eba29ad455ae4e31c8679206fec",
+				DER:     brokenCertDer,
+				Issued:  issued.Add(12 * time.Hour),
+				Expires: goodExpiry.AddDate(0, 0, 2), // Expiration doesn't match
+			}
+
+			_, problems := checker.checkCert(cert, nil)
+
+			problemsMap := map[string]int{
+				"Stored digest doesn't match certificate digest":                            1,
+				"Stored serial doesn't match certificate serial":                            1,
+				"Stored expiration doesn't match certificate NotAfter":                      1,
+				"Certificate doesn't have basic constraints set":                            1,
+				"Certificate has unacceptable validity period":                              1,
+				"Stored issuance date is outside of 6 hour window of certificate NotBefore": 1,
+				"Certificate has incorrect key usage extensions":                            1,
+				"Certificate has common name >64 characters long (65)":                      1,
+				"Certificate contains an unexpected extension: 1.3.3.7":                     1,
+			}
+			for _, p := range problems {
+				_, ok := problemsMap[p]
+				if !ok {
+					t.Errorf("Found unexpected problem '%s'.", p)
+				}
+				delete(problemsMap, p)
+			}
+			for k := range problemsMap {
+				t.Errorf("Expected problem but didn't find it: '%s'.", k)
+			}
+
+			// Same settings as above, but the stored serial number in the DB is invalid.
+			cert.Serial = "not valid"
+			_, problems = checker.checkCert(cert, nil)
+			foundInvalidSerialProblem := false
+			for _, p := range problems {
+				if p == "Stored serial is invalid" {
+					foundInvalidSerialProblem = true
+				}
+			}
+			test.Assert(t, foundInvalidSerialProblem, "Invalid certificate serial number in DB did not trigger problem.")
+
+			// Fix the problems
+			rawCert.Subject.CommonName = "example-a.com"
+			rawCert.DNSNames = []string{"example-a.com"}
+			rawCert.NotAfter = goodExpiry
+			rawCert.BasicConstraintsValid = true
+			rawCert.ExtraExtensions = []pkix.Extension{ocspMustStaple}
+			rawCert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+			goodCertDer, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, testKey.Public(), testKey)
+			test.AssertNotError(t, err, "Couldn't create certificate")
+			parsed, err := x509.ParseCertificate(goodCertDer)
+			test.AssertNotError(t, err, "Couldn't parse created certificate")
+			cert.Serial = core.SerialToString(serial)
+			cert.Digest = core.Fingerprint256(goodCertDer)
+			cert.DER = goodCertDer
+			cert.Expires = parsed.NotAfter
+			cert.Issued = parsed.NotBefore
+			_, problems = checker.checkCert(cert, nil)
+			test.AssertEquals(t, len(problems), 0)
+		})
+	}
 }
 
 func TestGetAndProcessCerts(t *testing.T) {


### PR DESCRIPTION
Refactor `TestCheckCertRSA` and `TestCheckCertECDSA` to a table driven
test.

Fixes #5895