### PR TITLE
cmd: Make msg optional for FailOnError

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -226,13 +226,11 @@ func FailOnError(err error, msg string) {
 	if err == nil {
 		return
 	}
-	if msg != "" {
-		Fail(fmt.Sprintf("%s: %s", msg, err))
-	}
 	if msg == "" {
 		Fail(err.Error())
+	} else {
+		Fail(fmt.Sprintf("%s: %s", msg, err))
 	}
-
 }
 
 // ReadConfigFile takes a file path as an argument and attempts to

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -221,12 +221,18 @@ func Fail(msg string) {
 }
 
 // FailOnError exits and prints an error message, but only if we encountered
-// a problem and err != nil
+// a problem and err != nil. err is required but msg can be "".
 func FailOnError(err error, msg string) {
-	if err != nil {
-		msg := fmt.Sprintf("%s: %s", msg, err)
-		Fail(msg)
+	if err == nil {
+		return
 	}
+	if msg != "" {
+		Fail(fmt.Sprintf("%s: %s", msg, err))
+	}
+	if msg == "" {
+		Fail(err.Error())
+	}
+
 }
 
 // ReadConfigFile takes a file path as an argument and attempts to


### PR DESCRIPTION
Make the `msg` parameter of `cmd.FailOnError` optional.