### PR TITLE
Don't use magic strings for authz statuses

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -455,24 +455,24 @@ var uintToIdentifierType = map[uint8]string{
 	0: "dns",
 }
 
-var statusToUint = map[string]uint8{
-	"pending":     0,
-	"valid":       1,
-	"invalid":     2,
-	"deactivated": 3,
-	"revoked":     4,
+var statusToUint = map[core.AcmeStatus]uint8{
+	core.StatusPending:     0,
+	core.StatusValid:       1,
+	core.StatusInvalid:     2,
+	core.StatusDeactivated: 3,
+	core.StatusRevoked:     4,
 }
 
-var uintToStatus = map[uint8]string{
-	0: "pending",
-	1: "valid",
-	2: "invalid",
-	3: "deactivated",
-	4: "revoked",
+var uintToStatus = map[uint8]core.AcmeStatus{
+	0: core.StatusPending,
+	1: core.StatusValid,
+	2: core.StatusInvalid,
+	3: core.StatusDeactivated,
+	4: core.StatusRevoked,
 }
 
 func statusUint(status core.AcmeStatus) uint8 {
-	return statusToUint[string(status)]
+	return statusToUint[status]
 }
 
 // authzFields is used in a variety of places in sa.go, and modifications to
@@ -516,7 +516,7 @@ func authzPBToModel(authz *corepb.Authorization) (*authzModel, error) {
 	am := &authzModel{
 		IdentifierValue: authz.Identifier,
 		RegistrationID:  authz.RegistrationID,
-		Status:          statusToUint[authz.Status],
+		Status:          statusToUint[core.AcmeStatus(authz.Status)],
 		Expires:         time.Unix(0, authz.Expires).UTC(),
 	}
 	if authz.Id != "" {
@@ -642,7 +642,7 @@ func populateAttemptedFields(am authzModel, challenge *corepb.Challenge) error {
 func modelToAuthzPB(am authzModel) (*corepb.Authorization, error) {
 	pb := &corepb.Authorization{
 		Id:             fmt.Sprintf("%d", am.ID),
-		Status:         uintToStatus[am.Status],
+		Status:         string(uintToStatus[am.Status]),
 		Identifier:     am.IdentifierValue,
 		RegistrationID: am.RegistrationID,
 		Expires:        am.Expires.UTC().UnixNano(),

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1371,7 +1371,7 @@ func (ssa *SQLStorageAuthority) getAuthorizationStatuses(ctx context.Context, id
 	allAuthzValidity := make([]authzValidity, len(validityInfo))
 	for i, info := range validityInfo {
 		allAuthzValidity[i] = authzValidity{
-			Status:  uintToStatus[info.Status],
+			Status:  string(uintToStatus[info.Status]),
 			Expires: info.Expires,
 		}
 	}
@@ -1612,7 +1612,7 @@ func (ssa *SQLStorageAuthority) GetAuthorizations2(ctx context.Context, req *sap
 	authzModelMap := make(map[string]authzModel)
 	for _, am := range authzModels {
 		existing, present := authzModelMap[am.IdentifierValue]
-		if !present || uintToStatus[existing.Status] == string(core.StatusPending) && uintToStatus[am.Status] == string(core.StatusValid) {
+		if !present || uintToStatus[existing.Status] == core.StatusPending && uintToStatus[am.Status] == core.StatusValid {
 			authzModelMap[am.IdentifierValue] = am
 		}
 	}
@@ -1673,7 +1673,7 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization2(ctx context.Context, req 
 		attemptedTime = &val
 	}
 	params := map[string]interface{}{
-		"status":           statusToUint[req.Status],
+		"status":           statusToUint[core.AcmeStatus(req.Status)],
 		"attempted":        challTypeToUint[req.Attempted],
 		"attemptedAt":      attemptedTime,
 		"validationRecord": vrJSON,

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2104,7 +2104,7 @@ func TestAuthzModelMapToPB(t *testing.T) {
 		test.AssertEquals(t, authzPB.Id, fmt.Sprintf("%d", model.ID))
 		test.AssertEquals(t, authzPB.Identifier, model.IdentifierValue)
 		test.AssertEquals(t, authzPB.RegistrationID, model.RegistrationID)
-		test.AssertEquals(t, authzPB.Status, uintToStatus[model.Status])
+		test.AssertEquals(t, authzPB.Status, string(uintToStatus[model.Status]))
 		gotTime := time.Unix(0, authzPB.Expires).UTC()
 		if !model.Expires.Equal(gotTime) {
 			t.Errorf("Times didn't match. Got %s, expected %s (%d)", gotTime, model.Expires, authzPB.Expires)


### PR DESCRIPTION
We have the `core.AcmeStatus` type precisely so that we don't have to
rely on correctly typing the word `"pending"` everywhere. Use those values
instead of raw strings when converting between string-like Authz statuses
and the database bitfield.