### PR TITLE
Don't allow multiple certificate extensions from TLS-ALPN-01

### DIFF
--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -180,8 +180,12 @@ func checkExpectedSAN(cert *x509.Certificate, name identifier.ACMEIdentifier) er
 		return errors.New("wrong number of dNSNames")
 	}
 
+	countSANExtensions := 0
+
 	for _, ext := range cert.Extensions {
 		if IdCeSubjectAltName.Equal(ext.Id) {
+			countSANExtensions += 1
+
 			expectedSANs, err := asn1.Marshal([]asn1.RawValue{
 				{Tag: 2, Class: 2, Bytes: []byte(cert.DNSNames[0])},
 			})
@@ -193,6 +197,10 @@ func checkExpectedSAN(cert *x509.Certificate, name identifier.ACMEIdentifier) er
 
 	if !strings.EqualFold(cert.DNSNames[0], name.Value) {
 		return errors.New("dNSName does not match expected identifier")
+	}
+
+	if countSANExtensions != 1 {
+		return errors.New("Only a single SubjectAlternativeName extension is allowed")
 	}
 
 	return nil

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -7,6 +7,7 @@ import (
 	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/hex"
 	"errors"
@@ -206,6 +207,30 @@ func checkExpectedSAN(cert *x509.Certificate, name identifier.ACMEIdentifier) er
 	return nil
 }
 
+// Confirm that of the OIDs provided, all of them are in the provided list of
+// extensions. Also confirms that of the extensions provided that none are
+// repeated. Per RFC8737, allows unexpected extensions.
+func checkAcceptableExtensions(exts []pkix.Extension, requiredOIDs []asn1.ObjectIdentifier) error {
+	oidSeen := make(map[string]bool)
+
+	for _, ext := range exts {
+		if oidSeen[ext.Id.String()] {
+			return errors.New("Extension seen twice")
+		}
+		oidSeen[ext.Id.String()] = true
+	}
+
+	for _, required := range requiredOIDs {
+		_, requiredOIDisPresent := oidSeen[required.String()]
+
+		if !requiredOIDisPresent {
+			return errors.New("Required extension is not present")
+		}
+	}
+
+	return nil
+}
+
 func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identifier identifier.ACMEIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
 	if identifier.Type != "dns" {
 		va.log.Info(fmt.Sprintf("Identifier type for TLS-ALPN-01 was not DNS: %s", identifier))
@@ -232,9 +257,25 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 
 	leafCert := certs[0]
 
+	// The certificate may only have the subjectAltName and acmeIdentifier
+	// extensions, and only one of each.
+	allowedOIDs := []asn1.ObjectIdentifier{
+		IdPeAcmeIdentifier, IdCeSubjectAltName,
+	}
+	err := checkAcceptableExtensions(leafCert.Extensions, allowedOIDs)
+	if err != nil {
+		hostPort := net.JoinHostPort(validationRecords[0].AddressUsed.String(), validationRecords[0].Port)
+		errText := fmt.Sprintf(
+			"Incorrect validation certificate for %s challenge. "+
+				"Requested %s from %s. Received %d certificate(s), "+
+				"first certificate had unexpected extensions; got error %s",
+			challenge.Type, identifier.Value, hostPort, len(certs), err)
+		return validationRecords, probs.Unauthorized(errText)
+	}
+
 	// The certificate returned must have a subjectAltName extension containing
 	// only the dNSName being validated and no other entries.
-	err := checkExpectedSAN(leafCert, identifier)
+	err = checkExpectedSAN(leafCert, identifier)
 	if err != nil {
 		hostPort := net.JoinHostPort(validationRecords[0].AddressUsed.String(), validationRecords[0].Port)
 		names := certAltNames(leafCert)

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -247,7 +247,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 
 	leafCert := certs[0]
 
-	// The certificate may only have the subjectAltName and acmeIdentifier
+	// The certificate must have the subjectAltName and acmeIdentifier
 	// extensions, and only one of each.
 	allowedOIDs := []asn1.ObjectIdentifier{
 		IdPeAcmeIdentifier, IdCeSubjectAltName,

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -250,26 +250,26 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 	countAcmeExtensions := 0
 	var acmeExtension *pkix.Extension
 
-	for _, ext := range leafCert.Extensions {
+	for idx, ext := range leafCert.Extensions {
 		if IdPeAcmeIdentifier.Equal(ext.Id) {
 			countAcmeExtensions += 1
-			acmeExtension = &ext
+			acmeExtension = &leafCert.Extensions[idx]
 		}
 	}
 
 	if acmeExtension == nil {
 		errText := fmt.Sprintf(
-		"Incorrect validation certificate for %s challenge. "+
-			"Missing acmeValidationV1 extension.",
-		core.ChallengeTypeTLSALPN01)
+			"Incorrect validation certificate for %s challenge. "+
+				"Missing acmeValidationV1 extension.",
+			core.ChallengeTypeTLSALPN01)
 		return validationRecords, probs.Unauthorized(errText)
 	}
 
 	if countAcmeExtensions > 1 {
 		errText := fmt.Sprintf(
-		"Incorrect validation certificate for %s challenge. "+
-			"More than one acmeValidationV1 extension.",
-		core.ChallengeTypeTLSALPN01)
+			"Incorrect validation certificate for %s challenge. "+
+				"More than one acmeValidationV1 extension.",
+			core.ChallengeTypeTLSALPN01)
 		return validationRecords, probs.Unauthorized(errText)
 	}
 

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -207,7 +207,7 @@ func checkAcceptableExtensions(exts []pkix.Extension, requiredOIDs []asn1.Object
 
 	for _, ext := range exts {
 		if oidSeen[ext.Id.String()] {
-			return errors.New(fmt.Sprintf("Extension OID %s seen twice", ext.Id))
+			return fmt.Errorf("Extension OID %s seen twice", ext.Id)
 		}
 		oidSeen[ext.Id.String()] = true
 	}
@@ -216,7 +216,7 @@ func checkAcceptableExtensions(exts []pkix.Extension, requiredOIDs []asn1.Object
 		_, requiredOIDisPresent := oidSeen[required.String()]
 
 		if !requiredOIDisPresent {
-			return errors.New(fmt.Sprintf("Required extension OID %s is not present", required))
+			return fmt.Errorf("Required extension OID %s is not present", required)
 		}
 	}
 

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -213,9 +213,7 @@ func checkAcceptableExtensions(exts []pkix.Extension, requiredOIDs []asn1.Object
 	}
 
 	for _, required := range requiredOIDs {
-		_, requiredOIDisPresent := oidSeen[required.String()]
-
-		if !requiredOIDisPresent {
+		if !oidSeen[required.String()] {
 			return fmt.Errorf("Required extension OID %s is not present", required)
 		}
 	}

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -181,12 +181,8 @@ func checkExpectedSAN(cert *x509.Certificate, name identifier.ACMEIdentifier) er
 		return errors.New("wrong number of dNSNames")
 	}
 
-	countSANExtensions := 0
-
 	for _, ext := range cert.Extensions {
 		if IdCeSubjectAltName.Equal(ext.Id) {
-			countSANExtensions += 1
-
 			expectedSANs, err := asn1.Marshal([]asn1.RawValue{
 				{Tag: 2, Class: 2, Bytes: []byte(cert.DNSNames[0])},
 			})
@@ -198,10 +194,6 @@ func checkExpectedSAN(cert *x509.Certificate, name identifier.ACMEIdentifier) er
 
 	if !strings.EqualFold(cert.DNSNames[0], name.Value) {
 		return errors.New("dNSName does not match expected identifier")
-	}
-
-	if countSANExtensions != 1 {
-		return errors.New("Only a single SubjectAlternativeName extension is allowed")
 	}
 
 	return nil

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -7,6 +7,7 @@ import (
 	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/hex"
 	"errors"
@@ -246,36 +247,52 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 		return validationRecords, probs.Unauthorized(errText)
 	}
 
-	// Verify key authorization in acmeValidation extension
-	h := sha256.Sum256([]byte(challenge.ProvidedKeyAuthorization))
+	countAcmeExtensions := 0
+	var acmeExtension *pkix.Extension
+
 	for _, ext := range leafCert.Extensions {
 		if IdPeAcmeIdentifier.Equal(ext.Id) {
-			va.metrics.tlsALPNOIDCounter.WithLabelValues(IdPeAcmeIdentifier.String()).Inc()
-			if !ext.Critical {
-				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"acmeValidationV1 extension not critical", core.ChallengeTypeTLSALPN01)
-				return validationRecords, probs.Unauthorized(errText)
-			}
-			var extValue []byte
-			rest, err := asn1.Unmarshal(ext.Value, &extValue)
-			if err != nil || len(rest) > 0 || len(h) != len(extValue) {
-				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"Malformed acmeValidationV1 extension value", core.ChallengeTypeTLSALPN01)
-				return validationRecords, probs.Unauthorized(errText)
-			}
-			if subtle.ConstantTimeCompare(h[:], extValue) != 1 {
-				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"Expected acmeValidationV1 extension value %s for this challenge but got %s",
-					core.ChallengeTypeTLSALPN01, hex.EncodeToString(h[:]), hex.EncodeToString(extValue))
-				return validationRecords, probs.Unauthorized(errText)
-			}
-			return validationRecords, nil
+			countAcmeExtensions += 1
+			acmeExtension = &ext
 		}
 	}
 
-	errText := fmt.Sprintf(
+	if acmeExtension == nil {
+		errText := fmt.Sprintf(
 		"Incorrect validation certificate for %s challenge. "+
 			"Missing acmeValidationV1 extension.",
 		core.ChallengeTypeTLSALPN01)
-	return validationRecords, probs.Unauthorized(errText)
+		return validationRecords, probs.Unauthorized(errText)
+	}
+
+	if countAcmeExtensions > 1 {
+		errText := fmt.Sprintf(
+		"Incorrect validation certificate for %s challenge. "+
+			"More than one acmeValidationV1 extension.",
+		core.ChallengeTypeTLSALPN01)
+		return validationRecords, probs.Unauthorized(errText)
+	}
+
+	// Verify key authorization in acmeValidation extension
+	h := sha256.Sum256([]byte(challenge.ProvidedKeyAuthorization))
+	va.metrics.tlsALPNOIDCounter.WithLabelValues(IdPeAcmeIdentifier.String()).Inc()
+	if !acmeExtension.Critical {
+		errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
+			"acmeValidationV1 extension not critical", core.ChallengeTypeTLSALPN01)
+		return validationRecords, probs.Unauthorized(errText)
+	}
+	var extValue []byte
+	rest, err := asn1.Unmarshal(acmeExtension.Value, &extValue)
+	if err != nil || len(rest) > 0 || len(h) != len(extValue) {
+		errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
+			"Malformed acmeValidationV1 extension value", core.ChallengeTypeTLSALPN01)
+		return validationRecords, probs.Unauthorized(errText)
+	}
+	if subtle.ConstantTimeCompare(h[:], extValue) != 1 {
+		errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
+			"Expected acmeValidationV1 extension value %s for this challenge but got %s",
+			core.ChallengeTypeTLSALPN01, hex.EncodeToString(h[:]), hex.EncodeToString(extValue))
+		return validationRecords, probs.Unauthorized(errText)
+	}
+	return validationRecords, nil
 }

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -207,7 +207,7 @@ func checkAcceptableExtensions(exts []pkix.Extension, requiredOIDs []asn1.Object
 
 	for _, ext := range exts {
 		if oidSeen[ext.Id.String()] {
-			return errors.New("Extension seen twice")
+			return errors.New(fmt.Sprintf("Extension OID %s seen twice", ext.Id))
 		}
 		oidSeen[ext.Id.String()] = true
 	}
@@ -216,7 +216,7 @@ func checkAcceptableExtensions(exts []pkix.Extension, requiredOIDs []asn1.Object
 		_, requiredOIDisPresent := oidSeen[required.String()]
 
 		if !requiredOIDisPresent {
-			return errors.New("Required extension is not present")
+			return errors.New(fmt.Sprintf("Required extension OID %s is not present", required))
 		}
 	}
 

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -722,7 +722,7 @@ func TestTLSALPN01ExtraSANs(t *testing.T) {
 
 	_, prob := va.validateChallenge(ctx, dnsi("expected"), chall)
 	test.AssertError(t, prob, "validation should have failed")
-	test.AssertContains(t, prob.Error(), "Extension seen twice")
+	test.AssertContains(t, prob.Error(), "Extension OID 2.5.29.17 seen twice")
 }
 
 func TestTLSALPN01ExtraAcmeExtensions(t *testing.T) {
@@ -775,7 +775,7 @@ func TestTLSALPN01ExtraAcmeExtensions(t *testing.T) {
 
 	_, prob := va.validateChallenge(ctx, dnsi("expected"), chall)
 	test.AssertError(t, prob, "validation should have failed")
-	test.AssertContains(t, prob.Error(), "Extension seen twice")
+	test.AssertContains(t, prob.Error(), "Extension OID 1.3.6.1.5.5.7.1.31 seen twice")
 }
 
 func TestAcceptableExtensions(t *testing.T) {
@@ -816,6 +816,7 @@ func TestAcceptableExtensions(t *testing.T) {
 	onlyUnexpectedExt := []pkix.Extension{weirdExt}
 	err = checkAcceptableExtensions(onlyUnexpectedExt, requireAcmeAndSAN)
 	test.AssertError(t, err, "Missing required extensions")
+	test.AssertContains(t, err.Error(), "Required extension OID 1.3.6.1.5.5.7.1.31 is not present")
 
 	okayExts := []pkix.Extension{acmeExtension, subjectAltName}
 	err = checkAcceptableExtensions(okayExts, requireAcmeAndSAN)

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -697,6 +697,7 @@ func TestTLSALPN01ExtraSANs(t *testing.T) {
 	subjectAltName.Value, err = asn1.Marshal([]asn1.RawValue{
 		{Tag: 2, Class: 2, Bytes: []byte(`expected`)},
 	})
+	test.AssertNotError(t, err, "failed to marshal first SAN")
 
 	extraSubjectAltName := pkix.Extension{}
 	extraSubjectAltName.Id = asn1.ObjectIdentifier{2, 5, 29, 17}

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -692,25 +692,23 @@ func TestTLSALPN01ExtraSANs(t *testing.T) {
 	}
 
 	subjectAltName := pkix.Extension{}
-    subjectAltName.Id = asn1.ObjectIdentifier{2, 5, 29, 17}
-    subjectAltName.Critical = false
-    subjectAltName.Value, err = asn1.Marshal([]asn1.RawValue{
-				{Tag: 2, Class: 2, Bytes: []byte(`expected`)},
-			})
+	subjectAltName.Id = asn1.ObjectIdentifier{2, 5, 29, 17}
+	subjectAltName.Critical = false
+	subjectAltName.Value, err = asn1.Marshal([]asn1.RawValue{
+		{Tag: 2, Class: 2, Bytes: []byte(`expected`)},
+	})
 
 	extraSubjectAltName := pkix.Extension{}
-    extraSubjectAltName.Id = asn1.ObjectIdentifier{2, 5, 29, 17}
-    extraSubjectAltName.Critical = false
-    extraSubjectAltName.Value, err = asn1.Marshal([]asn1.RawValue{
-				{Tag: 2, Class: 2, Bytes: []byte(`expected`)},
-			})
-    test.AssertNotError(t, err, "failed to marshal extra SAN")
+	extraSubjectAltName.Id = asn1.ObjectIdentifier{2, 5, 29, 17}
+	extraSubjectAltName.Critical = false
+	extraSubjectAltName.Value, err = asn1.Marshal([]asn1.RawValue{
+		{Tag: 2, Class: 2, Bytes: []byte(`expected`)},
+	})
+	test.AssertNotError(t, err, "failed to marshal extra SAN")
 
 	template.ExtraExtensions = []pkix.Extension{acmeExtension, subjectAltName, extraSubjectAltName}
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, &TheKey.PublicKey, &TheKey)
 	test.AssertNotError(t, err, "failed to create acme-tls/1 cert")
-
-	fmt.Println(hex.EncodeToString(certBytes))
 
 	cert, err := x509.ParseCertificate(certBytes)
 	test.AssertNotError(t, err, "Error parsing certificate")


### PR DESCRIPTION
Detect when a non-compliant ACME client presents a non-compliant x.509
certificate that contains multiple copies of the SubjectAlternativeName or ACME
Identifier extensions; this should be forbidden.