### PR TITLE
Improve error checking paradigm

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -513,7 +513,8 @@ func (ca *certificateAuthorityImpl) queueOrphan(o *orphanedCert) {
 // testing the orphan queue functionality somewhat more simple.
 func (ca *certificateAuthorityImpl) OrphanIntegrationLoop() {
 	for {
-		if err := ca.integrateOrphan(); err != nil {
+		err := ca.integrateOrphan()
+		if err != nil {
 			if err == goque.ErrEmpty {
 				time.Sleep(time.Minute)
 				continue

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -67,7 +67,8 @@ func (ap *akamaiPurger) purge() error {
 		return nil
 	}
 
-	if err := ap.client.Purge(urls); err != nil {
+	err := ap.client.Purge(urls)
+	if err != nil {
 		// Add the URLs back to the queue
 		ap.mu.Lock()
 		ap.toPurge = append(urls, ap.toPurge...)
@@ -229,7 +230,8 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 		// in case there is anything that still needs to be purged.
 		if queueLen := ap.len(); queueLen > 0 {
 			logger.Info(fmt.Sprintf("Shutting down; purging %d queue entries before exit.", queueLen))
-			if err := ap.purge(); err != nil {
+			err := ap.purge()
+			if err != nil {
 				cmd.Fail(fmt.Sprintf("Shutting down; failed to purge %d queue entries before exit: %s",
 					queueLen, err))
 			} else {

--- a/cmd/caa-log-checker/main.go
+++ b/cmd/caa-log-checker/main.go
@@ -107,7 +107,8 @@ func loadIssuanceLog(path string) (map[string][]time.Time, time.Time, time.Time,
 			issuanceMap[name] = append(issuanceMap[name], ie.issuanceTime)
 		}
 	}
-	if err := scanner.Err(); err != nil {
+	err = scanner.Err()
+	if err != nil {
 		return nil, earliest, latest, err
 	}
 

--- a/cmd/ceremony/key.go
+++ b/cmd/ceremony/key.go
@@ -78,7 +78,8 @@ func generateKey(session *pkcs11helpers.Session, label string, outputPath string
 
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
 	log.Printf("Public key PEM:\n%s\n", pemBytes)
-	if err := writeFile(outputPath, pemBytes); err != nil {
+	err = writeFile(outputPath, pemBytes)
+	if err != nil {
 		return nil, fmt.Errorf("Failed to write public key to %q: %s", outputPath, err)
 	}
 	log.Printf("Public key written to %q\n", outputPath)

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -106,25 +106,30 @@ type rootConfig struct {
 }
 
 func (rc rootConfig) validate() error {
-	if err := rc.PKCS11.validate(); err != nil {
+	err := rc.PKCS11.validate()
+	if err != nil {
 		return err
 	}
 
 	// Key gen fields
-	if err := rc.Key.validate(); err != nil {
+	err = rc.Key.validate()
+	if err != nil {
 		return err
 	}
 
 	// Output fields
-	if err := checkOutputFile(rc.Outputs.PublicKeyPath, "public-key-path"); err != nil {
+	err = checkOutputFile(rc.Outputs.PublicKeyPath, "public-key-path")
+	if err != nil {
 		return err
 	}
-	if err := checkOutputFile(rc.Outputs.CertificatePath, "certificate-path"); err != nil {
+	err = checkOutputFile(rc.Outputs.CertificatePath, "certificate-path")
+	if err != nil {
 		return err
 	}
 
 	// Certificate profile
-	if err := rc.CertProfile.verifyProfile(rootCert); err != nil {
+	err = rc.CertProfile.verifyProfile(rootCert)
+	if err != nil {
 		return err
 	}
 
@@ -164,7 +169,8 @@ type intermediateConfig struct {
 }
 
 func (ic intermediateConfig) validate(ct certType) error {
-	if err := ic.PKCS11.validate(); err != nil {
+	err := ic.PKCS11.validate()
+	if err != nil {
 		return err
 	}
 
@@ -177,12 +183,14 @@ func (ic intermediateConfig) validate(ct certType) error {
 	}
 
 	// Output fields
-	if err := checkOutputFile(ic.Outputs.CertificatePath, "certificate-path"); err != nil {
+	err = checkOutputFile(ic.Outputs.CertificatePath, "certificate-path")
+	if err != nil {
 		return err
 	}
 
 	// Certificate profile
-	if err := ic.CertProfile.verifyProfile(ct); err != nil {
+	err = ic.CertProfile.verifyProfile(ct)
+	if err != nil {
 		return err
 	}
 
@@ -202,7 +210,8 @@ type csrConfig struct {
 }
 
 func (cc csrConfig) validate() error {
-	if err := cc.PKCS11.validate(); err != nil {
+	err := cc.PKCS11.validate()
+	if err != nil {
 		return err
 	}
 
@@ -212,12 +221,14 @@ func (cc csrConfig) validate() error {
 	}
 
 	// Output fields
-	if err := checkOutputFile(cc.Outputs.CSRPath, "csr-path"); err != nil {
+	err = checkOutputFile(cc.Outputs.CSRPath, "csr-path")
+	if err != nil {
 		return err
 	}
 
 	// Certificate profile
-	if err := cc.CertProfile.verifyProfile(requestCert); err != nil {
+	err = cc.CertProfile.verifyProfile(requestCert)
+	if err != nil {
 		return err
 	}
 
@@ -234,17 +245,20 @@ type keyConfig struct {
 }
 
 func (kc keyConfig) validate() error {
-	if err := kc.PKCS11.validate(); err != nil {
+	err := kc.PKCS11.validate()
+	if err != nil {
 		return err
 	}
 
 	// Key gen fields
-	if err := kc.Key.validate(); err != nil {
+	err = kc.Key.validate()
+	if err != nil {
 		return err
 	}
 
 	// Output fields
-	if err := checkOutputFile(kc.Outputs.PublicKeyPath, "public-key-path"); err != nil {
+	err = checkOutputFile(kc.Outputs.PublicKeyPath, "public-key-path")
+	if err != nil {
 		return err
 	}
 
@@ -270,7 +284,8 @@ type ocspRespConfig struct {
 }
 
 func (orc ocspRespConfig) validate() error {
-	if err := orc.PKCS11.validate(); err != nil {
+	err := orc.PKCS11.validate()
+	if err != nil {
 		return err
 	}
 
@@ -284,7 +299,8 @@ func (orc ocspRespConfig) validate() error {
 	// DelegatedIssuerCertificatePath may be omitted
 
 	// Output fields
-	if err := checkOutputFile(orc.Outputs.ResponsePath, "response-path"); err != nil {
+	err = checkOutputFile(orc.Outputs.ResponsePath, "response-path")
+	if err != nil {
 		return err
 	}
 
@@ -324,7 +340,8 @@ type crlConfig struct {
 }
 
 func (cc crlConfig) validate() error {
-	if err := cc.PKCS11.validate(); err != nil {
+	err := cc.PKCS11.validate()
+	if err != nil {
 		return err
 	}
 
@@ -334,7 +351,8 @@ func (cc crlConfig) validate() error {
 	}
 
 	// Output fields
-	if err := checkOutputFile(cc.Outputs.CRLPath, "crl-path"); err != nil {
+	err = checkOutputFile(cc.Outputs.CRLPath, "crl-path")
+	if err != nil {
 		return err
 	}
 
@@ -434,10 +452,12 @@ func signAndWriteCert(tbs, issuer *x509.Certificate, subjectPubKey crypto.Public
 		issuer.PublicKeyAlgorithm = cert.PublicKeyAlgorithm
 	}
 
-	if err := cert.CheckSignatureFrom(issuer); err != nil {
+	err = cert.CheckSignatureFrom(issuer)
+	if err != nil {
 		return fmt.Errorf("failed to verify certificate signature: %s", err)
 	}
-	if err := writeFile(certPath, pemBytes); err != nil {
+	err = writeFile(certPath, pemBytes)
+	if err != nil {
 		return fmt.Errorf("failed to write certificate to %q: %s", certPath, err)
 	}
 	log.Printf("Certificate written to %q\n", certPath)
@@ -450,7 +470,8 @@ func rootCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
-	if err := config.validate(); err != nil {
+	err = config.validate()
+	if err != nil {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 	session, err := pkcs11helpers.Initialize(config.PKCS11.Module, config.PKCS11.StoreSlot, config.PKCS11.PIN)
@@ -485,7 +506,8 @@ func intermediateCeremony(configBytes []byte, ct certType) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
-	if err := config.validate(ct); err != nil {
+	err = config.validate(ct)
+	if err != nil {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 
@@ -531,7 +553,8 @@ func csrCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
-	if err := config.validate(); err != nil {
+	err = config.validate()
+	if err != nil {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 
@@ -558,7 +581,8 @@ func csrCeremony(configBytes []byte) error {
 		return fmt.Errorf("failed to generate CSR: %s", err)
 	}
 	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
-	if err := writeFile(config.Outputs.CSRPath, csrPEM); err != nil {
+	err = writeFile(config.Outputs.CSRPath, csrPEM)
+	if err != nil {
 		return fmt.Errorf("failed to write CSR to %q: %s", config.Outputs.CSRPath, err)
 	}
 	log.Printf("CSR written to %q\n", config.Outputs.CSRPath)
@@ -572,7 +596,8 @@ func keyCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
-	if err := config.validate(); err != nil {
+	err = config.validate()
+	if err != nil {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 	session, err := pkcs11helpers.Initialize(config.PKCS11.Module, config.PKCS11.StoreSlot, config.PKCS11.PIN)
@@ -593,7 +618,8 @@ func ocspRespCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
-	if err := config.validate(); err != nil {
+	err = config.validate()
+	if err != nil {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 
@@ -648,7 +674,8 @@ func ocspRespCeremony(configBytes []byte) error {
 		return err
 	}
 
-	if err := writeFile(config.Outputs.ResponsePath, resp); err != nil {
+	err = writeFile(config.Outputs.ResponsePath, resp)
+	if err != nil {
 		return fmt.Errorf("failed to write OCSP response to %q: %s", config.Outputs.ResponsePath, err)
 	}
 
@@ -661,7 +688,8 @@ func crlCeremony(configBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
-	if err := config.validate(); err != nil {
+	err = config.validate()
+	if err != nil {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 
@@ -715,7 +743,8 @@ func crlCeremony(configBytes []byte) error {
 
 	log.Printf("Signed CRL PEM:\n%s", crlBytes)
 
-	if err := writeFile(config.Outputs.CRLPath, crlBytes); err != nil {
+	err = writeFile(config.Outputs.CRLPath, crlBytes)
+	if err != nil {
 		return fmt.Errorf("failed to write CRL to %q: %s", config.Outputs.CRLPath, err)
 	}
 

--- a/cmd/ceremony/ocsp.go
+++ b/cmd/ceremony/ocsp.go
@@ -12,14 +12,16 @@ import (
 )
 
 func generateOCSPResponse(signer crypto.Signer, issuer, delegatedIssuer, cert *x509.Certificate, thisUpdate, nextUpdate time.Time, status int) ([]byte, error) {
-	if err := cert.CheckSignatureFrom(issuer); err != nil {
+	err := cert.CheckSignatureFrom(issuer)
+	if err != nil {
 		return nil, fmt.Errorf("invalid signature on certificate from issuer: %s", err)
 	}
 
 	signingCert := issuer
 	if delegatedIssuer != nil {
 		signingCert = delegatedIssuer
-		if err := delegatedIssuer.CheckSignatureFrom(issuer); err != nil {
+		err := delegatedIssuer.CheckSignatureFrom(issuer)
+		if err != nil {
 			return nil, fmt.Errorf("invalid signature on delegated issuer from issuer: %s", err)
 		}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -230,7 +230,8 @@ func (d ConfigDuration) MarshalJSON() ([]byte, error) {
 // parser (vs. the JSON parser).
 func (d *ConfigDuration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
-	if err := unmarshal(&s); err != nil {
+	err := unmarshal(&s)
+	if err != nil {
 		return err
 	}
 	dur, err := time.ParseDuration(s)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -241,7 +241,8 @@ func (m *mailer) processCerts(allCerts []core.Certificate) {
 			} else if renewed {
 				m.log.Debugf("Cert %s is already renewed", cert.Serial)
 				m.stats.renewalCount.With(prometheus.Labels{}).Inc()
-				if err := m.updateCertStatus(cert.Serial); err != nil {
+				err := m.updateCertStatus(cert.Serial)
+				if err != nil {
 					m.log.AuditErrf("Error updating certificate status for %s: %s", cert.Serial, err)
 					m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
 				}

--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -82,7 +82,8 @@ func validateFile(filename string) error {
 		if line == "" {
 			continue
 		}
-		if err := lineValid(line); err != nil {
+		err := lineValid(line)
+		if err != nil {
 			badFile = true
 			fmt.Fprintf(os.Stderr, "[line %d] %s: %s\n", i+1, err, line)
 		}
@@ -185,7 +186,8 @@ func main() {
 					logger.Errf("error while tailing %s: %s", t.Filename, err)
 					continue
 				}
-				if err := lineValid(line.Text); err != nil {
+				err := lineValid(line.Text)
+				if err != nil {
 					if errors.Is(err, errInvalidChecksum) {
 						lineCounter.WithLabelValues(t.Filename, "invalid checksum length").Inc()
 					} else {

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -70,7 +70,8 @@ func (i *interval) includes(s string) bool {
 
 // ok ensures that both the `targetRange` and `sleepInterval` are valid.
 func (m *mailer) ok() error {
-	if err := m.targetRange.ok(); err != nil {
+	err := m.targetRange.ok()
+	if err != nil {
 		return err
 	}
 
@@ -103,7 +104,8 @@ func sortAddresses(input addressToRecipientMap) []string {
 }
 
 func (m *mailer) run() error {
-	if err := m.ok(); err != nil {
+	err := m.ok()
+	if err != nil {
 		return err
 	}
 
@@ -151,7 +153,8 @@ func (m *mailer) run() error {
 			continue
 		}
 
-		if err := policy.ValidEmail(address); err != nil {
+		err := policy.ValidEmail(address)
+		if err != nil {
 			m.log.Infof("Skipping %q due to policy violation: %s", address, err)
 			continue
 		}
@@ -169,7 +172,7 @@ func (m *mailer) run() error {
 			return errors.New("message body was empty after interpolation")
 		}
 
-		err := m.mailer.SendMail([]string{address}, m.subject, messageBody.String())
+		err = m.mailer.SendMail([]string{address}, m.subject, messageBody.String())
 		if err != nil {
 			var badAddrErr bmail.BadAddressSMTPError
 			if errors.As(err, &badAddrErr) {

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -36,9 +36,8 @@ func TestIntervalOK(t *testing.T) {
 	}
 
 	badInterval := interval{start: "bb", end: "aa"}
-	if err := badInterval.ok(); err == nil {
-		t.Errorf("Bad interval %#v was considered ok", badInterval)
-	}
+	err := badInterval.ok()
+	test.AssertError(t, err, "bad interval was considered ok")
 }
 
 func setupMakeRecipientList(t *testing.T, contents string) string {

--- a/cmd/rocsp-tool/client.go
+++ b/cmd/rocsp-tool/client.go
@@ -173,7 +173,8 @@ func (cl *client) scanFromDBOneBatch(ctx context.Context, prevID int64, frequenc
 		<-rowTicker.C
 
 		status := new(sa.CertStatusMetadata)
-		if err := sa.ScanCertStatusMetadataRow(rows, status); err != nil {
+		err := sa.ScanCertStatusMetadataRow(rows, status)
+		if err != nil {
 			return -1, fmt.Errorf("scanning row %d (previous ID %d): %w", scanned, previousID, err)
 		}
 		scanned++

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -71,7 +71,8 @@ func init() {
 }
 
 func main() {
-	if err := main2(); err != nil {
+	err := main2()
+	if err != nil {
 		log.Fatal(err)
 	}
 }

--- a/core/objects.go
+++ b/core/objects.go
@@ -97,7 +97,8 @@ type RawCertificateRequest struct {
 // UnmarshalJSON provides an implementation for decoding CertificateRequest objects.
 func (cr *CertificateRequest) UnmarshalJSON(data []byte) error {
 	var raw RawCertificateRequest
-	if err := json.Unmarshal(data, &raw); err != nil {
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
 		return err
 	}
 
@@ -283,7 +284,8 @@ func (ch Challenge) RecordsSane() bool {
 // CheckConsistencyForClientOffer checks the fields of a challenge object before it is
 // given to the client.
 func (ch Challenge) CheckConsistencyForClientOffer() error {
-	if err := ch.checkConsistency(); err != nil {
+	err := ch.checkConsistency()
+	if err != nil {
 		return err
 	}
 
@@ -297,7 +299,8 @@ func (ch Challenge) CheckConsistencyForClientOffer() error {
 // CheckConsistencyForValidation checks the fields of a challenge object before it is
 // given to the VA.
 func (ch Challenge) CheckConsistencyForValidation() error {
-	if err := ch.checkConsistency(); err != nil {
+	err := ch.checkConsistency()
+	if err != nil {
 		return err
 	}
 

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -52,7 +52,8 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	if !ok {
 		return invalidPubKey
 	}
-	if err := keyPolicy.GoodKey(ctx, key); err != nil {
+	err := keyPolicy.GoodKey(ctx, key)
+	if err != nil {
 		if errors.Is(err, goodkey.ErrBadKey) {
 			return berrors.BadCSRError("invalid public key in CSR: %s", err)
 		}
@@ -61,7 +62,8 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	if !goodSignatureAlgorithms[csr.SignatureAlgorithm] {
 		return unsupportedSigAlg
 	}
-	if err := csr.CheckSignature(); err != nil {
+	err = csr.CheckSignature()
+	if err != nil {
 		return invalidSig
 	}
 	if len(csr.EmailAddresses) > 0 {
@@ -86,7 +88,8 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	for i, dnsName := range csr.DNSNames {
 		idents[i] = identifier.DNSIdentifier(dnsName)
 	}
-	if err := pa.WillingToIssueWildcards(idents); err != nil {
+	err = pa.WillingToIssueWildcards(idents)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/db/map.go
+++ b/db/map.go
@@ -226,7 +226,8 @@ func (we WrappedExecutor) Get(holder interface{}, keys ...interface{}) (interfac
 }
 
 func (we WrappedExecutor) Insert(list ...interface{}) error {
-	if err := we.SqlExecutor.Insert(list...); err != nil {
+	err := we.SqlExecutor.Insert(list...)
+	if err != nil {
 		return errForOp("insert", err, list)
 	}
 	return nil
@@ -257,7 +258,8 @@ func (we WrappedExecutor) Select(holder interface{}, query string, args ...inter
 }
 
 func (we WrappedExecutor) SelectOne(holder interface{}, query string, args ...interface{}) error {
-	if err := we.SqlExecutor.SelectOne(holder, query, args...); err != nil {
+	err := we.SqlExecutor.SelectOne(holder, query, args...)
+	if err != nil {
 		return errForQuery(query, "select one", err, []interface{}{holder})
 	}
 	return nil

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -60,7 +60,8 @@ func loadBlockedKeysList(filename string) (*blockedKeys, error) {
 		BlockedHashes    []string `yaml:"blocked"`
 		BlockedHashesHex []string `yaml:"blockedHashesHex"`
 	}
-	if err := yaml.Unmarshal(yamlBytes, &list); err != nil {
+	err = yaml.Unmarshal(yamlBytes, &list)
+	if err != nil {
 		return nil, err
 	}
 

--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -204,13 +204,15 @@ func (tc *serverTransportCredentials) ServerHandshake(rawConn net.Conn) (net.Con
 	// Perform the server <- client TLS handshake. This will validate the peer's
 	// client certificate.
 	conn := tls.Server(rawConn, tc.serverConfig)
-	if err := conn.Handshake(); err != nil {
+	err := conn.Handshake()
+	if err != nil {
 		return nil, nil, err
 	}
 
 	// In addition to the validation from `conn.Handshake()` we apply further
 	// constraints on what constitutes a valid peer
-	if err := tc.validateClient(conn.ConnectionState()); err != nil {
+	err = tc.validateClient(conn.ConnectionState())
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -67,7 +67,8 @@ func (si *serverInterceptor) intercept(ctx context.Context, req interface{}, inf
 	// a `clientRequestTimeKey` field, and it has a value, then observe the RPC
 	// latency with Prometheus.
 	if md, ok := metadata.FromIncomingContext(ctx); ok && len(md[clientRequestTimeKey]) > 0 {
-		if err := si.observeLatency(md[clientRequestTimeKey][0]); err != nil {
+		err := si.observeLatency(md[clientRequestTimeKey][0])
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -596,7 +596,8 @@ type IssuanceRequest struct {
 // is not signed using the issuer's key.
 func (i *Issuer) Issue(req *IssuanceRequest) ([]byte, error) {
 	// check request is valid according to the issuance profile
-	if err := i.Profile.requestValid(i.Clk, req); err != nil {
+	err := i.Profile.requestValid(i.Clk, req)
+	if err != nil {
 		return nil, err
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -199,7 +199,8 @@ func (log *impl) auditAtLevel(level syslog.Priority, msg string) {
 // AuditPanic catches panicking executables. This method should be added
 // in a defer statement as early as possible
 func (log *impl) AuditPanic() {
-	if err := recover(); err != nil {
+	err := recover()
+	if err != nil {
 		buf := make([]byte, 8192)
 		log.AuditErrf("Panic caused by err: %s", err)
 

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -103,7 +103,8 @@ func authenticateClient(t *testing.T, conn net.Conn) {
 	// failures will be caught on the connecting
 	// side
 	_, _ = conn.Write([]byte("220 smtp.example.com ESMTP\n"))
-	if err := expect(t, buf, "EHLO localhost"); err != nil {
+	err := expect(t, buf, "EHLO localhost")
+	if err != nil {
 		return
 	}
 
@@ -111,7 +112,8 @@ func authenticateClient(t *testing.T, conn net.Conn) {
 	_, _ = conn.Write([]byte("250-AUTH PLAIN LOGIN\n"))
 	_, _ = conn.Write([]byte("250 8BITMIME\n"))
 	// Base64 encoding of "\0user@example.com\0passwd"
-	if err := expect(t, buf, "AUTH PLAIN AHVzZXJAZXhhbXBsZS5jb20AcGFzc3dk"); err != nil {
+	err = expect(t, buf, "AUTH PLAIN AHVzZXJAZXhhbXBsZS5jb20AcGFzc3dk")
+	if err != nil {
 		return
 	}
 	_, _ = conn.Write([]byte("235 2.7.0 Authentication successful\n"))
@@ -147,7 +149,8 @@ func disconnectHandler(closeFirst int, goodbyeMsg string) connHandler {
 		authenticateClient(t, conn)
 
 		buf := bufio.NewReader(conn)
-		if err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME"); err != nil {
+		err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME")
+		if err != nil {
 			return
 		}
 
@@ -164,12 +167,14 @@ func disconnectHandler(closeFirst int, goodbyeMsg string) connHandler {
 		}
 		_, _ = conn.Write([]byte("250 Sure. Go on. \r\n"))
 
-		if err := expect(t, buf, "RCPT TO:<hi@bye.com>"); err != nil {
+		err = expect(t, buf, "RCPT TO:<hi@bye.com>")
+		if err != nil {
 			return
 		}
 		_, _ = conn.Write([]byte("250 Tell Me More \r\n"))
 
-		if err := expect(t, buf, "DATA"); err != nil {
+		err = expect(t, buf, "DATA")
+		if err != nil {
 			return
 		}
 		_, _ = conn.Write([]byte("354 Cool Data\r\n"))
@@ -188,17 +193,20 @@ func badEmailHandler(messagesToProcess int) connHandler {
 		authenticateClient(t, conn)
 
 		buf := bufio.NewReader(conn)
-		if err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME"); err != nil {
+		err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME")
+		if err != nil {
 			return
 		}
 
 		_, _ = conn.Write([]byte("250 Sure. Go on. \r\n"))
 
-		if err := expect(t, buf, "RCPT TO:<hi@bye.com>"); err != nil {
+		err = expect(t, buf, "RCPT TO:<hi@bye.com>")
+		if err != nil {
 			return
 		}
 		_, _ = conn.Write([]byte("401 4.1.3 Bad recipient address syntax\r\n"))
-		if err := expect(t, buf, "RSET"); err != nil {
+		err = expect(t, buf, "RSET")
+		if err != nil {
 			return
 		}
 		_, _ = conn.Write([]byte("250 Ok yr rset now\r\n"))
@@ -224,7 +232,8 @@ func rstHandler(rstFirst int) connHandler {
 		authenticateClient(t, tlsConn)
 
 		buf := bufio.NewReader(tlsConn)
-		if err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME"); err != nil {
+		err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME")
+		if err != nil {
 			return
 		}
 		// Set the socket of the listening connection to abruptively
@@ -240,12 +249,14 @@ func rstHandler(rstFirst int) connHandler {
 		}
 		_, _ = tlsConn.Write([]byte("250 Sure. Go on. \r\n"))
 
-		if err := expect(t, buf, "RCPT TO:<hi@bye.com>"); err != nil {
+		err = expect(t, buf, "RCPT TO:<hi@bye.com>")
+		if err != nil {
 			return
 		}
 		_, _ = tlsConn.Write([]byte("250 Tell Me More \r\n"))
 
-		if err := expect(t, buf, "DATA"); err != nil {
+		err = expect(t, buf, "DATA")
+		if err != nil {
 			return
 		}
 		_, _ = tlsConn.Write([]byte("354 Cool Data\r\n"))
@@ -406,19 +417,22 @@ func TestOtherError(t *testing.T) {
 		authenticateClient(t, conn)
 
 		buf := bufio.NewReader(conn)
-		if err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME"); err != nil {
+		err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME")
+		if err != nil {
 			return
 		}
 
 		_, _ = conn.Write([]byte("250 Sure. Go on. \r\n"))
 
-		if err := expect(t, buf, "RCPT TO:<hi@bye.com>"); err != nil {
+		err = expect(t, buf, "RCPT TO:<hi@bye.com>")
+		if err != nil {
 			return
 		}
 
 		_, _ = conn.Write([]byte("999 1.1.1 This would probably be bad?\r\n"))
 
-		if err := expect(t, buf, "RSET"); err != nil {
+		err = expect(t, buf, "RSET")
+		if err != nil {
 			return
 		}
 
@@ -453,19 +467,22 @@ func TestOtherError(t *testing.T) {
 		authenticateClient(t, conn)
 
 		buf := bufio.NewReader(conn)
-		if err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME"); err != nil {
+		err := expect(t, buf, "MAIL FROM:<<you-are-a-winner@example.com>> BODY=8BITMIME")
+		if err != nil {
 			return
 		}
 
 		_, _ = conn.Write([]byte("250 Sure. Go on. \r\n"))
 
-		if err := expect(t, buf, "RCPT TO:<hi@bye.com>"); err != nil {
+		err = expect(t, buf, "RCPT TO:<hi@bye.com>")
+		if err != nil {
 			return
 		}
 
 		_, _ = conn.Write([]byte("999 1.1.1 This would probably be bad?\r\n"))
 
-		if err := expect(t, buf, "RSET"); err != nil {
+		err = expect(t, buf, "RSET")
+		if err != nil {
 			return
 		}
 

--- a/observer/mon_conf_test.go
+++ b/observer/mon_conf_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/test"
 )
 
 func TestMonConf_validatePeriod(t *testing.T) {
@@ -25,8 +26,11 @@ func TestMonConf_validatePeriod(t *testing.T) {
 			c := &MonConf{
 				Period: tt.fields.Period,
 			}
-			if err := c.validatePeriod(); (err != nil) != tt.wantErr {
-				t.Errorf("MonConf.validatePeriod() error = %v, wantErr %v", err, tt.wantErr)
+			err := c.validatePeriod()
+			if tt.wantErr {
+				test.AssertError(t, err, "MonConf.validatePeriod() should have errored")
+			} else {
+				test.AssertNotError(t, err, "MonConf.validatePeriod() shouldn't have errored")
 			}
 		})
 	}

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
 	_ "github.com/letsencrypt/boulder/observer/probers/mock"
+	"github.com/letsencrypt/boulder/test"
 )
 
 const (
@@ -94,8 +95,11 @@ func TestObsConf_ValidateDebugAddr(t *testing.T) {
 			c := &ObsConf{
 				DebugAddr: tt.fields.DebugAddr,
 			}
-			if err := c.validateDebugAddr(); (err != nil) != tt.wantErr {
-				t.Errorf("ObsConf.ValidateDebugAddr() error = %v, wantErr %v", err, tt.wantErr)
+			err := c.validateDebugAddr()
+			if tt.wantErr {
+				test.AssertError(t, err, "ObsConf.ValidateDebugAddr() should have errored")
+			} else {
+				test.AssertNotError(t, err, "ObsConf.ValidateDebugAddr() shouldn't have errored")
 			}
 		})
 	}
@@ -125,8 +129,11 @@ func TestObsConf_validateSyslog(t *testing.T) {
 			c := &ObsConf{
 				Syslog: tt.fields.Syslog,
 			}
-			if err := c.validateSyslog(); (err != nil) != tt.wantErr {
-				t.Errorf("ObsConf.validateSyslog() error = %v, wantErr %v", err, tt.wantErr)
+			err := c.validateSyslog()
+			if tt.wantErr {
+				test.AssertError(t, err, "ObsConf.validateSyslog() should have errored")
+			} else {
+				test.AssertNotError(t, err, "ObsConf.validateSyslog() shouldn't have errored")
 			}
 		})
 	}

--- a/observer/probers/dns/dns_conf_test.go
+++ b/observer/probers/dns/dns_conf_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/test"
 	"gopkg.in/yaml.v2"
 )
 
@@ -54,8 +55,11 @@ func TestDNSConf_validateServer(t *testing.T) {
 			c := DNSConf{
 				Server: tt.fields.Server,
 			}
-			if err := c.validateServer(); (err != nil) != tt.wantErr {
-				t.Errorf("DNSConf.validateServer() error = %v, wantErr %v", err, tt.wantErr)
+			err := c.validateServer()
+			if tt.wantErr {
+				test.AssertError(t, err, "DNSConf.validateServer() should have errored")
+			} else {
+				test.AssertNotError(t, err, "DNSConf.validateServer() shouldn't have errored")
 			}
 		})
 	}
@@ -84,8 +88,11 @@ func TestDNSConf_validateQType(t *testing.T) {
 			c := DNSConf{
 				QType: tt.fields.QType,
 			}
-			if err := c.validateQType(); (err != nil) != tt.wantErr {
-				t.Errorf("DNSConf.validateQType() error = %v, wantErr %v", err, tt.wantErr)
+			err := c.validateQType()
+			if tt.wantErr {
+				test.AssertError(t, err, "DNSConf.validateQType() should have errored")
+			} else {
+				test.AssertNotError(t, err, "DNSConf.validateQType() shouldn't have errored")
 			}
 		})
 	}
@@ -111,8 +118,11 @@ func TestDNSConf_validateProto(t *testing.T) {
 			c := DNSConf{
 				Proto: tt.fields.Proto,
 			}
-			if err := c.validateProto(); (err != nil) != tt.wantErr {
-				t.Errorf("DNSConf.validateProto() error = %v, wantErr %v", err, tt.wantErr)
+			err := c.validateProto()
+			if tt.wantErr {
+				test.AssertError(t, err, "DNSConf.validateProto() should have errored")
+			} else {
+				test.AssertNotError(t, err, "DNSConf.validateProto() shouldn't have errored")
 			}
 		})
 	}
@@ -147,8 +157,11 @@ func TestDNSConf_MakeProber(t *testing.T) {
 				QName:   tt.fields.QName,
 				QType:   tt.fields.QType,
 			}
-			if _, err := c.MakeProber(); (err != nil) != tt.wantErr {
-				t.Errorf("HTTPConf.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			_, err := c.MakeProber()
+			if tt.wantErr {
+				test.AssertError(t, err, "DNSConf.MakeProber() should have errored")
+			} else {
+				test.AssertNotError(t, err, "DNSConf.MakeProber() shouldn't have errored")
 			}
 		})
 	}

--- a/pkcs11helpers/helpers.go
+++ b/pkcs11helpers/helpers.go
@@ -277,14 +277,16 @@ var ErrNoObject = errors.New("no objects found matching provided template")
 // In the case where zero or more than one objects are found to match the
 // template an error is returned.
 func (s *Session) FindObject(tmpl []*pkcs11.Attribute) (pkcs11.ObjectHandle, error) {
-	if err := s.Module.FindObjectsInit(s.Session, tmpl); err != nil {
+	err := s.Module.FindObjectsInit(s.Session, tmpl)
+	if err != nil {
 		return 0, err
 	}
 	handles, _, err := s.Module.FindObjects(s.Session, 2)
 	if err != nil {
 		return 0, err
 	}
-	if err := s.Module.FindObjectsFinal(s.Session); err != nil {
+	err = s.Module.FindObjectsFinal(s.Session)
+	if err != nil {
 		return 0, err
 	}
 	if len(handles) == 0 {

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -326,7 +326,8 @@ func ValidEmail(address string) error {
 	}
 	splitEmail := strings.SplitN(email.Address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])
-	if err := ValidDomain(domain); err != nil {
+	err = ValidDomain(domain)
+	if err != nil {
 		return berrors.InvalidEmailError(
 			"contact email %q has invalid domain : %s",
 			email.Address, err)
@@ -368,12 +369,14 @@ func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 	}
 	domain := id.Value
 
-	if err := ValidDomain(domain); err != nil {
+	err := ValidDomain(domain)
+	if err != nil {
 		return err
 	}
 
 	// Require no match against hostname block lists
-	if err := pa.checkHostLists(domain); err != nil {
+	err = pa.checkHostLists(domain)
+	if err != nil {
 		return err
 	}
 
@@ -402,7 +405,8 @@ func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
 func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
 	var subErrors []berrors.SubBoulderError
 	for _, ident := range idents {
-		if err := pa.willingToIssueWildcard(ident); err != nil {
+		err := pa.willingToIssueWildcard(ident)
+		if err != nil {
 			var bErr *berrors.BoulderError
 			if errors.As(err, &bErr) {
 				subErrors = append(subErrors, berrors.SubBoulderError{
@@ -479,7 +483,8 @@ func (pa *AuthorityImpl) willingToIssueWildcard(ident identifier.ACMEIdentifier)
 			return errICANNTLDWildcard
 		}
 		// The base domain can't be in the wildcard exact blocklist
-		if err := pa.checkWildcardHostList(baseDomain); err != nil {
+		err = pa.checkWildcardHostList(baseDomain)
+		if err != nil {
 			return err
 		}
 		// Check that the PA is willing to issue for the base domain

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -209,9 +209,8 @@ func TestWillingToIssue(t *testing.T) {
 	// Test acceptance of good names
 	for _, domain := range shouldBeAccepted {
 		ident := identifier.DNSIdentifier(domain)
-		if err := pa.WillingToIssue(ident); err != nil {
-			t.Error("Identifier was incorrectly forbidden: ", ident, err)
-		}
+		err := pa.WillingToIssue(ident)
+		test.AssertNotError(t, err, "identiier was incorrectly forbidden")
 	}
 }
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1777,9 +1777,8 @@ func (cf *caaFailer) IsCAAValid(
 func TestRecheckCAAEmpty(t *testing.T) {
 	_, _, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
-	if err := ra.recheckCAA(context.Background(), nil); err != nil {
-		t.Errorf("expected nil err, got %s", err)
-	}
+	err := ra.recheckCAA(context.Background(), nil)
+	test.AssertNotError(t, err, "expected nil")
 }
 
 func makeHTTP01Authorization(domain string) *core.Authorization {
@@ -1797,9 +1796,8 @@ func TestRecheckCAASuccess(t *testing.T) {
 		makeHTTP01Authorization("b.com"),
 		makeHTTP01Authorization("c.com"),
 	}
-	if err := ra.recheckCAA(context.Background(), authzs); err != nil {
-		t.Errorf("expected nil err, got %s", err)
-	}
+	err := ra.recheckCAA(context.Background(), authzs)
+	test.AssertNotError(t, err, "expected nil")
 }
 
 func TestRecheckCAAFail(t *testing.T) {

--- a/sa/model.go
+++ b/sa/model.go
@@ -669,7 +669,8 @@ func modelToAuthzPB(am authzModel) (*corepb.Authorization, error) {
 			// challenges "gone" per https://tools.ietf.org/html/rfc8555#section-7.1.4
 			if am.Attempted != nil {
 				if uintToChallType[*am.Attempted] == challType {
-					if err := populateAttemptedFields(am, challenge); err != nil {
+					err := populateAttemptedFields(am, challenge)
+					if err != nil {
 						return nil, err
 					}
 					// Get the attemptedAt time and assign to the challenge validated time.

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -60,13 +60,16 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 		var row struct {
 			Count int64
 		}
-		if err := txWithCtx.SelectOne(&row, "SELECT count(1) as count FROM precertificates WHERE serial=?", serialHex); err != nil {
+		err := txWithCtx.SelectOne(&row, "SELECT count(1) as count FROM precertificates WHERE serial=?", serialHex)
+		if err != nil {
 			return nil, err
 		}
 		if row.Count > 0 {
 			return nil, berrors.DuplicateError("cannot add a duplicate cert")
 		}
-		if err := txWithCtx.Insert(preCertModel); err != nil {
+
+		err = txWithCtx.Insert(preCertModel)
+		if err != nil {
 			return nil, err
 		}
 
@@ -100,10 +103,14 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 		if err != nil {
 			return nil, err
 		}
-		if err := addIssuedNames(txWithCtx, parsed, isRenewal); err != nil {
+
+		err = addIssuedNames(txWithCtx, parsed, isRenewal)
+		if err != nil {
 			return nil, err
 		}
-		if err := addKeyHash(txWithCtx, parsed); err != nil {
+
+		err = addKeyHash(txWithCtx, parsed)
+		if err != nil {
 			return nil, err
 		}
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -456,12 +456,14 @@ func (ssa *SQLStorageAuthority) AddCertificate(ctx context.Context, req *sapb.Ad
 		var row struct {
 			Count int64
 		}
-		if err := txWithCtx.SelectOne(&row, "SELECT count(1) as count FROM certificates WHERE serial=?", serial); err != nil {
+		err := txWithCtx.SelectOne(&row, "SELECT count(1) as count FROM certificates WHERE serial=?", serial)
+		if err != nil {
 			return nil, err
 		}
 		if row.Count > 0 {
 			return nil, berrors.DuplicateError("cannot add a duplicate cert")
 		}
+
 		// Save the final certificate
 		err = txWithCtx.Insert(cert)
 		if err != nil {
@@ -507,20 +509,22 @@ func (ssa *SQLStorageAuthority) AddCertificate(ctx context.Context, req *sapb.Ad
 		// don't count against the certificatesPerName limit.
 		if !isRenewal {
 			timeToTheHour := parsedCertificate.NotBefore.Round(time.Hour)
-			if err := ssa.addCertificatesPerName(ctx, txWithCtx, parsedCertificate.DNSNames, timeToTheHour); err != nil {
+			err := ssa.addCertificatesPerName(ctx, txWithCtx, parsedCertificate.DNSNames, timeToTheHour)
+			if err != nil {
 				return nil, err
 			}
 		}
 
 		// Update the FQDN sets now that there is a final certificate to ensure rate
 		// limits are calculated correctly.
-		if err := addFQDNSet(
+		err = addFQDNSet(
 			txWithCtx,
 			parsedCertificate.DNSNames,
 			core.SerialToString(parsedCertificate.SerialNumber),
 			parsedCertificate.NotBefore,
 			parsedCertificate.NotAfter,
-		); err != nil {
+		)
+		if err != nil {
 			return nil, err
 		}
 
@@ -816,7 +820,8 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *sapb.NewOrder
 			Created:        ssa.clk.Now(),
 		}
 
-		if err := txWithCtx.Insert(order); err != nil {
+		err := txWithCtx.Insert(order)
+		if err != nil {
 			return nil, err
 		}
 
@@ -825,7 +830,8 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *sapb.NewOrder
 				OrderID: order.ID,
 				AuthzID: id,
 			}
-			if err := txWithCtx.Insert(otoa); err != nil {
+			err := txWithCtx.Insert(otoa)
+			if err != nil {
 				return nil, err
 			}
 		}
@@ -835,14 +841,15 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *sapb.NewOrder
 				OrderID:      order.ID,
 				ReversedName: ReverseName(name),
 			}
-			if err := txWithCtx.Insert(reqdName); err != nil {
+			err := txWithCtx.Insert(reqdName)
+			if err != nil {
 				return nil, err
 			}
 		}
 
 		// Add an FQDNSet entry for the order
-		if err := addOrderFQDNSet(
-			txWithCtx, req.Names, order.ID, order.RegistrationID, order.Expires); err != nil {
+		err = addOrderFQDNSet(txWithCtx, req.Names, order.ID, order.RegistrationID, order.Expires)
+		if err != nil {
 			return nil, err
 		}
 
@@ -859,7 +866,8 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *sapb.NewOrder
 
 	if features.Enabled(features.FasterNewOrdersRateLimit) {
 		// Increment the order creation count
-		if err := addNewOrdersRateLimit(ctx, ssa.dbMap, req.RegistrationID, ssa.clk.Now().Truncate(time.Minute)); err != nil {
+		err := addNewOrdersRateLimit(ctx, ssa.dbMap, req.RegistrationID, ssa.clk.Now().Truncate(time.Minute))
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -939,7 +947,8 @@ func (ssa *SQLStorageAuthority) NewOrderAndAuthzs(ctx context.Context, req *sapb
 			Expires:        time.Unix(0, req.NewOrder.Expires),
 			Created:        ssa.clk.Now(),
 		}
-		if err := txWithCtx.Insert(order); err != nil {
+		err := txWithCtx.Insert(order)
+		if err != nil {
 			return nil, err
 		}
 
@@ -1013,7 +1022,8 @@ func (ssa *SQLStorageAuthority) NewOrderAndAuthzs(ctx context.Context, req *sapb
 
 	if features.Enabled(features.FasterNewOrdersRateLimit) {
 		// Increment the order creation count
-		if err := addNewOrdersRateLimit(ctx, ssa.dbMap, req.NewOrder.RegistrationID, ssa.clk.Now().Truncate(time.Minute)); err != nil {
+		err := addNewOrdersRateLimit(ctx, ssa.dbMap, req.NewOrder.RegistrationID, ssa.clk.Now().Truncate(time.Minute))
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -1126,7 +1136,8 @@ func (ssa *SQLStorageAuthority) FinalizeOrder(ctx context.Context, req *sapb.Fin
 
 		// Delete the orderFQDNSet row for the order now that it has been finalized.
 		// We use this table for order reuse and should not reuse a finalized order.
-		if err := deleteOrderFQDNSet(txWithCtx, req.Id); err != nil {
+		err = deleteOrderFQDNSet(txWithCtx, req.Id)
+		if err != nil {
 			return nil, err
 		}
 
@@ -1983,14 +1994,15 @@ func (ssa *SQLStorageAuthority) KeyBlocked(ctx context.Context, req *sapb.KeyBlo
 	if req == nil || req.KeyHash == nil {
 		return nil, errIncompleteRequest
 	}
-	exists := false
+
 	var id int64
-	if err := ssa.dbMap.SelectOne(&id, `SELECT ID FROM blockedKeys WHERE keyHash = ?`, req.KeyHash); err != nil {
+	err := ssa.dbMap.SelectOne(&id, `SELECT ID FROM blockedKeys WHERE keyHash = ?`, req.KeyHash)
+	if err != nil {
 		if db.IsNoRows(err) {
-			return &sapb.Exists{Exists: exists}, nil
+			return &sapb.Exists{Exists: false}, nil
 		}
 		return nil, err
 	}
-	exists = true
-	return &sapb.Exists{Exists: exists}, nil
+
+	return &sapb.Exists{Exists: true}, nil
 }

--- a/sa/type-converter.go
+++ b/sa/type-converter.go
@@ -49,7 +49,8 @@ func (tc BoulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, b
 				return errors.New("FromDb: Unable to convert *string")
 			}
 			b := []byte(*s)
-			if err := json.Unmarshal(b, target); err != nil {
+			err := json.Unmarshal(b, target)
+			if err != nil {
 				return badJSONError(
 					fmt.Sprintf("binder failed to unmarshal %T", target),
 					b,
@@ -72,7 +73,8 @@ func (tc BoulderTypeConverter) FromDb(target interface{}) (gorp.CustomScanner, b
 			if !ok {
 				return fmt.Errorf("FromDb: Unable to convert %T to *jose.JSONWebKey", target)
 			}
-			if err := k.UnmarshalJSON(b); err != nil {
+			err := k.UnmarshalJSON(b)
+			if err != nil {
 				return badJSONError(
 					"binder failed to unmarshal JWK",
 					b,

--- a/test/db.go
+++ b/test/db.go
@@ -39,11 +39,13 @@ func resetTestDatabase(t testing.TB, dbType string) func() {
 	if err != nil {
 		t.Fatalf("Couldn't create db: %s", err)
 	}
-	if err := deleteEverythingInAllTables(db); err != nil {
+	err = deleteEverythingInAllTables(db)
+	if err != nil {
 		t.Fatalf("Failed to delete everything: %s", err)
 	}
 	return func() {
-		if err := deleteEverythingInAllTables(db); err != nil {
+		err := deleteEverythingInAllTables(db)
+		if err != nil {
 			t.Fatalf("Failed to truncate tables after the test: %s", err)
 		}
 		_ = db.Close()

--- a/test/load-generator/acme/directory.go
+++ b/test/load-generator/acme/directory.go
@@ -195,7 +195,8 @@ func NewDirectory(directoryURL string) (*Directory, error) {
 
 	// Unmarshal the directory
 	var dirResource map[string]interface{}
-	if err := json.Unmarshal(dirContents, &dirResource); err != nil {
+	err = json.Unmarshal(dirContents, &dirResource)
+	if err != nil {
 		return nil, ErrInvalidDirectoryJSON
 	}
 

--- a/test/load-generator/boulder-calls.go
+++ b/test/load-generator/boulder-calls.go
@@ -395,7 +395,8 @@ func fulfillOrder(s *State, ctx *context) error {
 		}
 
 		// Complete the authorization by solving a challenge
-		if err := completeAuthorization(authz, s, ctx); err != nil {
+		err = completeAuthorization(authz, s, ctx)
+		if err != nil {
 			return err
 		}
 	}

--- a/test/mail-test-srv/main.go
+++ b/test/mail-test-srv/main.go
@@ -58,7 +58,8 @@ func (srv *mailSrv) handleConn(conn net.Conn) {
 
 	readBuf := bufio.NewReader(conn)
 	conn.Write([]byte("220 smtp.example.com ESMTP\r\n"))
-	if err := expectLine(readBuf, "EHLO localhost"); err != nil {
+	err := expectLine(readBuf, "EHLO localhost")
+	if err != nil {
 		log.Printf("mail-test-srv: %s: %v\n", conn.RemoteAddr(), err)
 		return
 	}
@@ -67,7 +68,8 @@ func (srv *mailSrv) handleConn(conn net.Conn) {
 	conn.Write([]byte("250 8BITMIME\r\n"))
 	// This AUTH PLAIN is the output of: echo -en '\0cert-manager@example.com\0password' | base64
 	// Must match the mail configs for integration tests.
-	if err := expectLine(readBuf, "AUTH PLAIN AGNlcnQtbWFuYWdlckBleGFtcGxlLmNvbQBwYXNzd29yZA=="); err != nil {
+	err = expectLine(readBuf, "AUTH PLAIN AGNlcnQtbWFuYWdlckBleGFtcGxlLmNvbQBwYXNzd29yZA==")
+	if err != nil {
 		log.Printf("mail-test-srv: %s: %v\n", conn.RemoteAddr(), err)
 		return
 	}

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -399,9 +399,8 @@ func TestCAAChecking(t *testing.T) {
 	params := &caaParams{accountURIID: accountURIID, validationMethod: method}
 
 	va, _ := setup(nil, 0, "", nil)
-	if err := features.Set(map[string]bool{"CAAValidationMethods": true, "CAAAccountURI": true}); err != nil {
-		t.Fatalf("Failed to enable feature: %v", err)
-	}
+	err := features.Set(map[string]bool{"CAAValidationMethods": true, "CAAAccountURI": true})
+	test.AssertNotError(t, err, "failed to enable features")
 
 	va.dnsClient = caaMockDNS{}
 	va.accountURIPrefixes = []string{"https://letsencrypt.org/acct/reg/"}

--- a/va/va.go
+++ b/va/va.go
@@ -361,7 +361,8 @@ func (va *ValidationAuthorityImpl) validate(
 }
 
 func (va *ValidationAuthorityImpl) validateChallenge(ctx context.Context, identifier identifier.ACMEIdentifier, challenge core.Challenge) ([]core.ValidationRecord, *probs.ProblemDetails) {
-	if err := challenge.CheckConsistencyForValidation(); err != nil {
+	err := challenge.CheckConsistencyForValidation()
+	if err != nil {
 		return nil, probs.Malformed("Challenge failed consistency check: %s", err)
 	}
 	switch challenge.Type {

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -299,7 +299,8 @@ func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*jose.JSONWebSignature, *prob
 		Header     map[string]string
 		Signatures []interface{}
 	}
-	if err := json.Unmarshal(body, &unprotected); err != nil {
+	err := json.Unmarshal(body, &unprotected)
+	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSUnmarshalFailed"}).Inc()
 		return nil, probs.Malformed("Parse error reading JWS")
 	}
@@ -513,7 +514,8 @@ func (wfe *WebFrontEndImpl) validJWSForKey(
 	logEvent *web.RequestEvent) ([]byte, *probs.ProblemDetails) {
 
 	// Check that the public key and JWS algorithms match expected
-	if err := checkAlgorithm(jwk, jws); err != nil {
+	err := checkAlgorithm(jwk, jws)
+	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSAlgorithmCheckFailed"}).Inc()
 		return nil, probs.BadSignatureAlgorithm(err.Error())
 	}
@@ -549,7 +551,8 @@ func (wfe *WebFrontEndImpl) validJWSForKey(
 	// trying to unmarshal the payload (when it is non-empty to allow POST-as-GET
 	// behaviour) as part of the verification and failing early if it isn't valid JSON.
 	var parsedBody struct{}
-	if err := json.Unmarshal(payload, &parsedBody); string(payload) != "" && err != nil {
+	err = json.Unmarshal(payload, &parsedBody)
+	if string(payload) != "" && err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSBodyUnmarshalFailed"}).Inc()
 		return nil, probs.Malformed("Request payload did not parse as JSON")
 	}
@@ -685,7 +688,8 @@ func (wfe *WebFrontEndImpl) validSelfAuthenticatedPOST(
 	}
 
 	// If the key doesn't meet the GoodKey policy return a problem
-	if err := wfe.keyPolicy.GoodKey(ctx, pubKey.Key); err != nil {
+	err := wfe.keyPolicy.GoodKey(ctx, pubKey.Key)
+	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWKRejectedByGoodKey"}).Inc()
 		return nil, nil, probs.BadPublicKey(err.Error())
 	}
@@ -740,13 +744,15 @@ func (wfe *WebFrontEndImpl) validKeyRollover(
 	}
 
 	// If the key doesn't meet the GoodKey policy return a problem immediately
-	if err := wfe.keyPolicy.GoodKey(ctx, jwk.Key); err != nil {
+	err := wfe.keyPolicy.GoodKey(ctx, jwk.Key)
+	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverJWKRejectedByGoodKey"}).Inc()
 		return nil, probs.BadPublicKey(err.Error())
 	}
 
 	// Check that the public key and JWS algorithms match expected
-	if err := checkAlgorithm(jwk, innerJWS); err != nil {
+	err = checkAlgorithm(jwk, innerJWS)
+	if err != nil {
 		return nil, probs.Malformed(err.Error())
 	}
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -815,7 +815,8 @@ func (wfe *WebFrontEndImpl) processRevocation(
 		CertificateDER core.JSONBuffer    `json:"certificate"`
 		Reason         *revocation.Reason `json:"reason"`
 	}
-	if err := json.Unmarshal(jwsBody, &revokeRequest); err != nil {
+	err := json.Unmarshal(jwsBody, &revokeRequest)
+	if err != nil {
 		return probs.Malformed("Unable to JSON parse revoke request")
 	}
 
@@ -1326,7 +1327,8 @@ func (wfe *WebFrontEndImpl) postChallenge(
 		// that the POST body is valid JSON. Any data/fields included are ignored to
 		// be kind to ACMEv2 implementations that still send a key authorization.
 		var challengeUpdate struct{}
-		if err := json.Unmarshal(body, &challengeUpdate); err != nil {
+		err := json.Unmarshal(body, &challengeUpdate)
+		if err != nil {
 			wfe.sendError(response, logEvent, probs.Malformed("Error unmarshaling challenge response"), err)
 			return
 		}
@@ -1441,7 +1443,8 @@ func (wfe *WebFrontEndImpl) updateAccount(
 		Status  core.AcmeStatus `json:"status"`
 	}
 
-	if err := json.Unmarshal(requestBody, &accountUpdateRequest); err != nil {
+	err := json.Unmarshal(requestBody, &accountUpdateRequest)
+	if err != nil {
 		return nil, probs.Malformed("Error unmarshaling account")
 	}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -667,7 +667,8 @@ func TestIndex(t *testing.T) {
 // object.
 func randomDirectoryKeyPresent(t *testing.T, buf []byte) bool {
 	var dir map[string]interface{}
-	if err := json.Unmarshal(buf, &dir); err != nil {
+	err := json.Unmarshal(buf, &dir)
+	if err != nil {
 		t.Errorf("Failed to unmarshal directory: %s", err)
 	}
 	for _, v := range dir {


### PR DESCRIPTION
We have decided that we don't like the `if err := call(); err != nil`
syntax, because it creates confusing scopes, but we have not cleaned up
all existing instances of that syntax. However, we have now found a case
where that syntax enables a bug: It caused readers to believe that a
later `err = call()` statement was assigning to an already-declared
`err` in the local scope, when in fact it was assigning to an
already-declared `err` in the *parent* scope of a closure. This caused
our `ineffassign` and `staticcheck` linters to be unable to analyze the
lifetime of the `err` variable, and so they did not complain when we
never checked the actual value of that error.

This change standardizes on the two-line error checking syntax everywhere,
so that we can more easily ensure that our linters are correctly analyzing
all error assignments.