### PR TITLE
Use HMAC instead of AES-GCM

### DIFF
--- a/nonce/nonce_test.go
+++ b/nonce/nonce_test.go
@@ -35,7 +35,7 @@ func TestRejectMalformed(t *testing.T) {
 	test.AssertNotError(t, err, "Could not create nonce service")
 	n, err := ns.Nonce()
 	test.AssertNotError(t, err, "Could not create nonce")
-	test.Assert(t, !ns.Valid("asdf"+n), "Accepted an invalid nonce")
+	test.Assert(t, !ns.Valid(n+"asdf"), "Accepted an invalid nonce")
 }
 
 func TestRejectShort(t *testing.T) {


### PR DESCRIPTION
AES-GCM is susceptible (no known threat actors as of yet, but there probably will be in the future) to known plaintext attacks. An adversary could have a pretty good idea on what the encrypted payload is, and use that to launch a potential attack on us. We also don't really rate limit users on the new-nonce endpoint, so getting us to keep encrypting new payloads won't be that difficult.

We also don't need to encrypt/decrypt values. From my understanding of what this works, we just want authentication of data using a symmetric key, rather than encryption of that data.

I didn't try to rock the boat too much with this (although, I think I have one failing test I'll need help with) - we should also reconsider the use of counters, and just replace them with random entropy (in that case we might not even need hmac?). Or, replace them with timestamps and entropy (that way we could just look at the ts value, and if it's too old, dump it).

The other benefit of this change is that it made the code a lot easier to follow and reason about (at least to me). Our verification of MAC step is no longer an encrypt/decrypt step.

Furthermore, if we think this is too much of a change to bring into Boulder - at the very least I think we should increase our key size to 32 bytes, rather than the 16 it is now. And consider moving away from counters for the aforementioned reasons.
