### PR TITLE
TLS-ALPN-01: Check that challenge cert is self-signed

### DIFF
--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -56,9 +56,9 @@ func certAltNames(cert *x509.Certificate) []string {
 	return names
 }
 
-func (va *ValidationAuthorityImpl) tryGetTLSCerts(ctx context.Context,
+func (va *ValidationAuthorityImpl) tryGetChallengeCert(ctx context.Context,
 	identifier identifier.ACMEIdentifier, challenge core.Challenge,
-	tlsConfig *tls.Config) ([]*x509.Certificate, *tls.ConnectionState, []core.ValidationRecord, *probs.ProblemDetails) {
+	tlsConfig *tls.Config) (*x509.Certificate, *tls.ConnectionState, []core.ValidationRecord, *probs.ProblemDetails) {
 
 	allAddrs, err := va.getAddrs(ctx, identifier.Value)
 	validationRecords := []core.ValidationRecord{
@@ -87,11 +87,11 @@ func (va *ValidationAuthorityImpl) tryGetTLSCerts(ctx context.Context,
 		address := net.JoinHostPort(v6[0].String(), thisRecord.Port)
 		thisRecord.AddressUsed = v6[0]
 
-		certs, cs, prob := va.getTLSCerts(ctx, address, identifier, challenge, tlsConfig)
+		cert, cs, prob := va.getChallengeCert(ctx, address, identifier, challenge, tlsConfig)
 
 		// If there is no problem, return immediately
 		if err == nil {
-			return certs, cs, validationRecords, prob
+			return cert, cs, validationRecords, prob
 		}
 
 		// Otherwise, we note that we tried an address and fall back to trying IPv4
@@ -113,18 +113,18 @@ func (va *ValidationAuthorityImpl) tryGetTLSCerts(ctx context.Context,
 	// Otherwise if there are no IPv6 addresses, or there was an error
 	// talking to the first IPv6 address, try the first IPv4 address
 	thisRecord.AddressUsed = v4[0]
-	certs, cs, prob := va.getTLSCerts(ctx, net.JoinHostPort(v4[0].String(), thisRecord.Port),
+	cert, cs, prob := va.getChallengeCert(ctx, net.JoinHostPort(v4[0].String(), thisRecord.Port),
 		identifier, challenge, tlsConfig)
-	return certs, cs, validationRecords, prob
+	return cert, cs, validationRecords, prob
 }
 
-func (va *ValidationAuthorityImpl) getTLSCerts(
+func (va *ValidationAuthorityImpl) getChallengeCert(
 	ctx context.Context,
 	hostPort string,
 	identifier identifier.ACMEIdentifier,
 	challenge core.Challenge,
 	config *tls.Config,
-) ([]*x509.Certificate, *tls.ConnectionState, *probs.ProblemDetails) {
+) (*x509.Certificate, *tls.ConnectionState, *probs.ProblemDetails) {
 	va.log.Info(fmt.Sprintf("%s [%s] Attempting to validate for %s %s", challenge.Type, identifier, hostPort, config.ServerName))
 	// We expect a self-signed challenge certificate, do not verify it here.
 	config.InsecureSkipVerify = true
@@ -149,7 +149,7 @@ func (va *ValidationAuthorityImpl) getTLSCerts(
 		va.log.AuditInfof("%s challenge for %s received certificate (%d of %d): cert=[%s]",
 			challenge.Type, identifier.Value, i+1, len(certs), hex.EncodeToString(cert.Raw))
 	}
-	return certs, &cs, nil
+	return certs[0], &cs, nil
 }
 
 // tlsDial does the equivalent of tls.Dial, but obeying a context. Once
@@ -227,7 +227,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 		return nil, probs.Malformed("Identifier type for TLS-ALPN-01 was not DNS")
 	}
 
-	certs, cs, validationRecords, problem := va.tryGetTLSCerts(ctx, identifier, challenge, &tls.Config{
+	cert, cs, validationRecords, problem := va.tryGetChallengeCert(ctx, identifier, challenge, &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		NextProtos: []string{ACMETLS1Protocol},
 		ServerName: identifier.Value,
@@ -245,41 +245,52 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 		return validationRecords, probs.Unauthorized(errText)
 	}
 
-	leafCert := certs[0]
+	hostPort := net.JoinHostPort(validationRecords[0].AddressUsed.String(), validationRecords[0].Port)
+
+	// The certificate must be self-signed.
+	err := cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature)
+	if err != nil || !bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+		errText := fmt.Sprintf(
+			"Incorrect validation certificate for %s challenge. "+
+				"Requested %s from %s. "+
+				"Received certificate which is not self-signed.",
+			challenge.Type, identifier.Value, hostPort)
+		return validationRecords, probs.Unauthorized(errText)
+	}
 
 	// The certificate must have the subjectAltName and acmeIdentifier
 	// extensions, and only one of each.
 	allowedOIDs := []asn1.ObjectIdentifier{
 		IdPeAcmeIdentifier, IdCeSubjectAltName,
 	}
-	err := checkAcceptableExtensions(leafCert.Extensions, allowedOIDs)
+	err = checkAcceptableExtensions(cert.Extensions, allowedOIDs)
 	if err != nil {
-		hostPort := net.JoinHostPort(validationRecords[0].AddressUsed.String(), validationRecords[0].Port)
 		errText := fmt.Sprintf(
 			"Incorrect validation certificate for %s challenge. "+
-				"Requested %s from %s. Received %d certificate(s), "+
-				"first certificate had unexpected extensions; got error %s",
-			challenge.Type, identifier.Value, hostPort, len(certs), err)
+				"Requested %s from %s. "+
+				"Received certificate with unexpected extensions."+
+				"Got error: %q",
+			challenge.Type, identifier.Value, hostPort, err)
 		return validationRecords, probs.Unauthorized(errText)
 	}
 
 	// The certificate returned must have a subjectAltName extension containing
 	// only the dNSName being validated and no other entries.
-	err = checkExpectedSAN(leafCert, identifier)
+	err = checkExpectedSAN(cert, identifier)
 	if err != nil {
-		hostPort := net.JoinHostPort(validationRecords[0].AddressUsed.String(), validationRecords[0].Port)
-		names := certAltNames(leafCert)
+		names := certAltNames(cert)
 		errText := fmt.Sprintf(
 			"Incorrect validation certificate for %s challenge. "+
-				"Requested %s from %s. Received %d certificate(s), "+
-				"first certificate had identifiers %q; got error %s",
-			challenge.Type, identifier.Value, hostPort, len(certs), strings.Join(names, ", "), err)
+				"Requested %s from %s. "+
+				"Received certificate with unexpected identifiers: %q"+
+				"Got error: %q",
+			challenge.Type, identifier.Value, hostPort, strings.Join(names, ", "), err)
 		return validationRecords, probs.Unauthorized(errText)
 	}
 
 	// Verify key authorization in acmeValidation extension
 	h := sha256.Sum256([]byte(challenge.ProvidedKeyAuthorization))
-	for _, ext := range leafCert.Extensions {
+	for _, ext := range cert.Extensions {
 		if IdPeAcmeIdentifier.Equal(ext.Id) {
 			va.metrics.tlsALPNOIDCounter.WithLabelValues(IdPeAcmeIdentifier.String()).Inc()
 			if !ext.Critical {

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -268,7 +268,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 		errText := fmt.Sprintf(
 			"Incorrect validation certificate for %s challenge. "+
 				"Requested %s from %s. "+
-				"Received certificate with unexpected extensions."+
+				"Received certificate with unexpected extensions. "+
 				"Got error: %q",
 			challenge.Type, identifier.Value, hostPort, err)
 		return validationRecords, probs.Unauthorized(errText)
@@ -282,7 +282,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 		errText := fmt.Sprintf(
 			"Incorrect validation certificate for %s challenge. "+
 				"Requested %s from %s. "+
-				"Received certificate with unexpected identifiers: %q"+
+				"Received certificate with unexpected identifiers: %q. "+
 				"Got error: %q",
 			challenge.Type, identifier.Value, hostPort, strings.Join(names, ", "), err)
 		return validationRecords, probs.Unauthorized(errText)

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -618,6 +618,63 @@ func TestTLSALPN01ExtraNames(t *testing.T) {
 	test.AssertError(t, prob, "validation should have failed")
 }
 
+func TestTLSALPN01NotSelfSigned(t *testing.T) {
+	chall := tlsalpnChallenge()
+
+	// Create a cert with an extra non-dnsName identifier.
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1337),
+		Subject: pkix.Name{
+			Organization: []string{"tests"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().AddDate(0, 0, 1),
+
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+
+		DNSNames:    []string{"expected"},
+		IPAddresses: []net.IP{net.ParseIP("192.168.0.1")},
+	}
+
+	shasum := sha256.Sum256([]byte(chall.ProvidedKeyAuthorization))
+	encHash, err := asn1.Marshal(shasum[:])
+	test.AssertNotError(t, err, "failed to create key authorization")
+
+	acmeExtension := pkix.Extension{
+		Id:       IdPeAcmeIdentifier,
+		Critical: true,
+		Value:    encHash,
+	}
+	template.ExtraExtensions = []pkix.Extension{acmeExtension}
+
+	parent := &x509.Certificate{
+		SerialNumber: big.NewInt(1234),
+		Subject: pkix.Name{
+			Organization: []string{"testissuer"},
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, &TheKey.PublicKey, &TheKey)
+	test.AssertNotError(t, err, "failed to create acme-tls/1 cert")
+
+	acmeCert := &tls.Certificate{
+		Certificate: [][]byte{certBytes},
+		PrivateKey:  &TheKey,
+	}
+
+	hs := tlsalpn01SrvWithCert(t, chall, IdPeAcmeIdentifier, []string{"expected"}, acmeCert, tls.VersionTLS12)
+
+	va, _ := setup(hs, 0, "", nil)
+
+	_, prob := va.validateChallenge(ctx, dnsi("expected"), chall)
+	test.AssertError(t, prob, "validation should have failed")
+	test.AssertContains(t, prob.Detail, "not self-signed")
+}
+
 func TestTLSALPN01ExtraIdentifiers(t *testing.T) {
 	chall := tlsalpnChallenge()
 

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -658,6 +658,8 @@ func TestTLSALPN01NotSelfSigned(t *testing.T) {
 		BasicConstraintsValid: true,
 	}
 
+	// Note that this currently only tests that the subject and issuer are the
+	// same; it does not test the case where the cert is signed by a different key.
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, &TheKey.PublicKey, &TheKey)
 	test.AssertNotError(t, err, "failed to create acme-tls/1 cert")
 


### PR DESCRIPTION
RFC 8737 says "The client prepares for validation by constructing a self-signed
certificate...". Add a check for whether the challenge certificate is
self-signed by ensuring its issuer and subject are equal, and checking its
signature with its own public key.

Also slightly refactor the helper methods to return only a single cert, since we
only care about the first one returned. And add a test.