### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -942,9 +941,7 @@ func (qsa *queueSA) AddPrecertificate(ctx context.Context, req *sapb.AddCertific
 // uses the `queueSA` mock, which allows us to flip on and off a "fail" bit that
 // decides whether it errors in response to storage requests.
 func TestPrecertOrphanQueue(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "orphan-queue-tmp")
-	defer os.Remove(tmpDir)
-	test.AssertNotError(t, err, "Failed to create temp directory")
+	tmpDir := t.TempDir()
 	orphanQueue, err := goque.OpenQueue(tmpDir)
 	test.AssertNotError(t, err, "Failed to open orphaned certificate queue")
 
@@ -1008,9 +1005,7 @@ func TestPrecertOrphanQueue(t *testing.T) {
 }
 
 func TestOrphanQueue(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "orphan-queue-tmp")
-	defer os.Remove(tmpDir)
-	test.AssertNotError(t, err, "Failed to create temp directory")
+	tmpDir := t.TempDir()
 	orphanQueue, err := goque.OpenQueue(tmpDir)
 	test.AssertNotError(t, err, "Failed to open orphaned certificate queue")
 

--- a/cmd/ceremony/file_test.go
+++ b/cmd/ceremony/file_test.go
@@ -1,27 +1,20 @@
 package notmain
 
 import (
-	"io/ioutil"
 	"testing"
 )
 
 func TestWriteFileSuccess(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = writeFile(dir+"/example", []byte("hi"))
+	dir := t.TempDir()
+	err := writeFile(dir+"/example", []byte("hi"))
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestWriteFileFail(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = writeFile(dir+"/example", []byte("hi"))
+	dir := t.TempDir()
+	err := writeFile(dir+"/example", []byte("hi"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ceremony/key_test.go
+++ b/cmd/ceremony/key_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"io/ioutil"
 	"math/big"
-	"os"
 	"path"
 	"strings"
 	"testing"
@@ -44,9 +43,7 @@ func setupCtx() pkcs11helpers.MockCtx {
 }
 
 func TestGenerateKeyRSA(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "ceremony-testing-rsa")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	ctx := setupCtx()
 	rsaPriv, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -93,9 +90,7 @@ func setECGenerateFuncs(ctx *pkcs11helpers.MockCtx) {
 }
 
 func TestGenerateKeyEC(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "ceremony-testing-ec")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	ctx := setupCtx()
 	setECGenerateFuncs(&ctx)
@@ -134,16 +129,14 @@ func setFindObjectsFuncs(label string, ctx *pkcs11helpers.MockCtx) {
 }
 
 func TestGenerateKeySlotHasSomethingWithLabel(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "ceremony-testing-slot-has-something")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	ctx := setupCtx()
 	label := "someLabel"
 	setFindObjectsFuncs(label, &ctx)
 	keyPath := path.Join(tmp, "should-not-exist.pem")
 	s := &pkcs11helpers.Session{Module: &ctx, Session: 0}
-	_, err = generateKey(s, label, keyPath, keyGenConfig{
+	_, err := generateKey(s, label, keyPath, keyGenConfig{
 		Type:       "ecdsa",
 		ECDSACurve: "P-256",
 	})
@@ -152,16 +145,14 @@ func TestGenerateKeySlotHasSomethingWithLabel(t *testing.T) {
 }
 
 func TestGenerateKeySlotHasSomethingWithDifferentLabel(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "ceremony-testing-slot-has-something")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	ctx := setupCtx()
 	setECGenerateFuncs(&ctx)
 	setFindObjectsFuncs("someLabel", &ctx)
 	keyPath := path.Join(tmp, "should-not-exist.pem")
 	s := &pkcs11helpers.Session{Module: &ctx, Session: 0}
-	_, err = generateKey(s, "someOtherLabel", keyPath, keyGenConfig{
+	_, err := generateKey(s, "someOtherLabel", keyPath, keyGenConfig{
 		Type:       "ecdsa",
 		ECDSACurve: "P-256",
 	})

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -1,17 +1,13 @@
 package notmain
 
 import (
-	"io/ioutil"
 	"strings"
 	"testing"
 )
 
 func TestCheckOutputFileSucceeds(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = checkOutputFile(dir+"/example", "foo")
+	dir := t.TempDir()
+	err := checkOutputFile(dir+"/example", "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,12 +24,9 @@ func TestCheckOutputFileEmpty(t *testing.T) {
 }
 
 func TestCheckOutputFileExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	filename := dir + "/example"
-	err = writeFile(filename, []byte("hi"))
+	err := writeFile(filename, []byte("hi"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/goodkey/weak_test.go
+++ b/goodkey/weak_test.go
@@ -34,8 +34,7 @@ func TestLoadKeys(t *testing.T) {
 	mod := &big.Int{}
 	mod.SetBytes(modBytes)
 	testKey := rsa.PublicKey{N: mod}
-	tempDir, err := ioutil.TempDir("", "weak-keys")
-	test.AssertNotError(t, err, "Failed to create temporary directory")
+	tempDir := t.TempDir()
 	tempPath := filepath.Join(tempDir, "a.json")
 	err = ioutil.WriteFile(tempPath, []byte("[\"8df20e6961a16398b85a\"]"), os.ModePerm)
 	test.AssertNotError(t, err, "Failed to create temporary file")


### PR DESCRIPTION
Use the `T.TempDir` method from the `testing` package to create temporary
directories for tests. Directories created by `T.TempDir` are automatically
removed when tests complete.