### PR TITLE
Remove default authorization lifetime values

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -211,18 +211,18 @@ func main() {
 	}
 	ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, c.RA.InformationalCTLogs, logger, scope)
 
-	// Baseline Requirements 4.2.1: "any reused data, document, or
-	// completed validation MUST be obtained no more than 398 days prior
-	// to issuing the Certificate". If unconfigured or the configured
-	// value is greater than 397 days, bail out.
+	// Baseline Requirements v1.8.1 section 4.2.1: "any reused data, document,
+	// or completed validation MUST be obtained no more than 398 days prior
+	// to issuing the Certificate". If unconfigured or the configured value is
+	// greater than 397 days, bail out.
 	if c.RA.AuthorizationLifetimeDays <= 0 || c.RA.AuthorizationLifetimeDays > 397 {
 		cmd.Fail("authorizationLifetimeDays value must be greater than 0 and less than 398")
 	}
 	authorizationLifetime := time.Duration(c.RA.AuthorizationLifetimeDays) * 24 * time.Hour
 
-	// The Baseline Requirements state that validation tokens "MUST NOT be
-	// used for more than 30 days from its creation". If unconfigured or
-	// the configured value pendingAuthorizationLifetimeDays is greater
+	// The Baseline Requirements v1.8.1 state that validation tokens "MUST
+	// NOT be used for more than 30 days from its creation". If unconfigured
+	// or the configured value pendingAuthorizationLifetimeDays is greater
 	// than 29 days, bail out.
 	if c.RA.PendingAuthorizationLifetimeDays <= 0 || c.RA.PendingAuthorizationLifetimeDays > 29 {
 		cmd.Fail("pendingAuthorizationLifetimeDays value must be greater than 0 and less than 30")

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -211,17 +211,23 @@ func main() {
 	}
 	ctp = ctpolicy.New(pubc, c.RA.CTLogGroups2, c.RA.InformationalCTLogs, logger, scope)
 
-	// TODO(patf): remove once RA.authorizationLifetimeDays is deployed
-	authorizationLifetime := 300 * 24 * time.Hour
-	if c.RA.AuthorizationLifetimeDays != 0 {
-		authorizationLifetime = time.Duration(c.RA.AuthorizationLifetimeDays) * 24 * time.Hour
+	// Baseline Requirements 4.2.1: "any reused data, document, or
+	// completed validation MUST be obtained no more than 398 days prior
+	// to issuing the Certificate". If unconfigured or the configured
+	// value is greater than 397 days, bail out.
+	if c.RA.AuthorizationLifetimeDays <= 0 || c.RA.AuthorizationLifetimeDays > 397 {
+		cmd.Fail("authorizationLifetimeDays value must be greater than 0 and less than 398")
 	}
+	authorizationLifetime := time.Duration(c.RA.AuthorizationLifetimeDays) * 24 * time.Hour
 
-	// TODO(patf): remove once RA.pendingAuthorizationLifetimeDays is deployed
-	pendingAuthorizationLifetime := 7 * 24 * time.Hour
-	if c.RA.PendingAuthorizationLifetimeDays != 0 {
-		pendingAuthorizationLifetime = time.Duration(c.RA.PendingAuthorizationLifetimeDays) * 24 * time.Hour
+	// The Baseline Requirements state that validation tokens "MUST NOT be
+	// used for more than 30 days from its creation". If unconfigured or
+	// the configured value pendingAuthorizationLifetimeDays is greater
+	// than 29 days, bail out.
+	if c.RA.PendingAuthorizationLifetimeDays <= 0 || c.RA.PendingAuthorizationLifetimeDays > 29 {
+		cmd.Fail("pendingAuthorizationLifetimeDays value must be greater than 0 and less than 30")
 	}
+	pendingAuthorizationLifetime := time.Duration(c.RA.PendingAuthorizationLifetimeDays) * 24 * time.Hour
 
 	// TODO(#5851): Remove these fallbacks when the old config keys are gone.
 	if c.RA.GoodKey.WeakKeyFile == "" && c.RA.WeakKeyFile != "" {

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -406,15 +406,23 @@ func main() {
 		c.WFE.StaleTimeout.Duration = time.Minute * 10
 	}
 
-	authorizationLifetime := 30 * (24 * time.Hour)
-	if c.WFE.AuthorizationLifetimeDays != 0 {
-		authorizationLifetime = time.Duration(c.WFE.AuthorizationLifetimeDays) * (24 * time.Hour)
+	// Baseline Requirements 4.2.1: "any reused data, document, or
+	// completed validation MUST be obtained no more than 398 days prior
+	// to issuing the Certificate". If unconfigured or the configured
+	// value is greater than 397 days, bail out.
+	if c.WFE.AuthorizationLifetimeDays <= 0 || c.WFE.AuthorizationLifetimeDays > 397 {
+		cmd.Fail("authorizationLifetimeDays value must be greater than 0 and less than 398")
 	}
+	authorizationLifetime := time.Duration(c.WFE.AuthorizationLifetimeDays) * 24 * time.Hour
 
-	pendingAuthorizationLifetime := 7 * (24 * time.Hour)
-	if c.WFE.PendingAuthorizationLifetimeDays != 0 {
-		pendingAuthorizationLifetime = time.Duration(c.WFE.PendingAuthorizationLifetimeDays) * (24 * time.Hour)
+	// The Baseline Requirements state that validation tokens "MUST NOT be
+	// used for more than 30 days from its creation". If unconfigured or
+	// the configured value pendingAuthorizationLifetimeDays is greater
+	// than 29 days, bail out.
+	if c.WFE.PendingAuthorizationLifetimeDays <= 0 || c.WFE.PendingAuthorizationLifetimeDays > 29 {
+		cmd.Fail("pendingAuthorizationLifetimeDays value must be greater than 0 and less than 30")
 	}
+	pendingAuthorizationLifetime := time.Duration(c.WFE.PendingAuthorizationLifetimeDays) * 24 * time.Hour
 
 	var accountGetter wfe2.AccountGetter
 	if c.WFE.AccountCache != nil {

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -406,18 +406,18 @@ func main() {
 		c.WFE.StaleTimeout.Duration = time.Minute * 10
 	}
 
-	// Baseline Requirements 4.2.1: "any reused data, document, or
-	// completed validation MUST be obtained no more than 398 days prior
-	// to issuing the Certificate". If unconfigured or the configured
-	// value is greater than 397 days, bail out.
+	// Baseline Requirements v1.8.1 section 4.2.1: "any reused data, document,
+	// or completed validation MUST be obtained no more than 398 days prior
+	// to issuing the Certificate". If unconfigured or the configured value is
+	// greater than 397 days, bail out.
 	if c.WFE.AuthorizationLifetimeDays <= 0 || c.WFE.AuthorizationLifetimeDays > 397 {
 		cmd.Fail("authorizationLifetimeDays value must be greater than 0 and less than 398")
 	}
 	authorizationLifetime := time.Duration(c.WFE.AuthorizationLifetimeDays) * 24 * time.Hour
 
-	// The Baseline Requirements state that validation tokens "MUST NOT be
-	// used for more than 30 days from its creation". If unconfigured or
-	// the configured value pendingAuthorizationLifetimeDays is greater
+	// The Baseline Requirements v1.8.1 state that validation tokens "MUST
+	// NOT be used for more than 30 days from its creation". If unconfigured
+	// or the configured value pendingAuthorizationLifetimeDays is greater
 	// than 29 days, bail out.
 	if c.WFE.PendingAuthorizationLifetimeDays <= 0 || c.WFE.PendingAuthorizationLifetimeDays > 29 {
 		cmd.Fail("pendingAuthorizationLifetimeDays value must be greater than 0 and less than 30")


### PR DESCRIPTION
Enforce that authorizationLifetimeDays and
pendingAuthorizationLifetimeDays values are configured and set
to a value compliant with the CA/B Forum Baseline Requirements.

Fixes #5923