### PR TITLE
notify-mailer: Improve error checking during template execution

### DIFF
--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -225,6 +225,54 @@ func TestReadRecipientListWithNoHeaderOrRecords(t *testing.T) {
 	test.AssertErrorIs(t, err, io.EOF)
 }
 
+func TestMakeMessageBody(t *testing.T) {
+	emailTemplate := `{{range . }}
+{{ .Data.date }}
+{{ .Data.domainName }}
+{{end}}`
+
+	m := &mailer{
+		log:           blog.UseMock(),
+		mailer:        &mocks.Mailer{},
+		emailTemplate: template.Must(template.New("email").Parse(emailTemplate)),
+		sleepInterval: 0,
+		targetRange:   interval{end: "\xFF"},
+		clk:           newFakeClock(t),
+		recipients:    nil,
+		dbMap:         mockEmailResolver{},
+	}
+
+	recipients := []recipient{
+		{id: 10, Data: map[string]string{"date": "2018-11-21", "domainName": "example.com"}},
+		{id: 23, Data: map[string]string{"date": "2018-11-22", "domainName": "example.net"}},
+	}
+
+	expectedMessageBody := `
+2018-11-21
+example.com
+
+2018-11-22
+example.net
+`
+
+	// Ensure that a very basic template with 2 recipients can be successfully
+	// executed.
+	messageBody, err := m.makeMessageBody(recipients)
+	test.AssertNotError(t, err, "failed to execute a valid template")
+	test.AssertEquals(t, messageBody, expectedMessageBody)
+
+	// With no recipients we should get an empty body error.
+	recipients = []recipient{}
+	_, err = m.makeMessageBody(recipients)
+	test.AssertError(t, err, "should have errored on empty body")
+
+	// With a missing key we should get an informative templating error.
+	recipients = []recipient{{id: 10, Data: map[string]string{"domainName": "example.com"}}}
+	_, err = m.makeMessageBody(recipients)
+	test.AssertEquals(t, err.Error(), "template: email:2:8: executing \"email\" at <.Data.date>: map has no entry for key \"date\"")
+
+}
+
 func TestSleepInterval(t *testing.T) {
 	const sleepLen = 10
 	mc := &mocks.Mailer{}

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -270,7 +270,6 @@ example.net
 	recipients = []recipient{{id: 10, Data: map[string]string{"domainName": "example.com"}}}
 	_, err = m.makeMessageBody(recipients)
 	test.AssertEquals(t, err.Error(), "template: email:2:8: executing \"email\" at <.Data.date>: map has no entry for key \"date\"")
-
 }
 
 func TestSleepInterval(t *testing.T) {


### PR DESCRIPTION
- Break message body construction out into a testable method.
- Ensure that in the event of a missing key, an informative error is returned instead
  of allowing the message to be populated with the zero value of the key.
- Add message body construction tests for success, empty map, and missing key. 
- Comment the `recipient` struct and it's `Data` field to make it clear that SRE
  must be informed of any modifications.

Fixes #5921