### PR TITLE
Make cert-checker's stderr less misleading

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -450,7 +450,7 @@ func main() {
 	wg.Wait()
 	fmt.Fprintf(
 		os.Stderr,
-		"# Finished processing certificates, sample: %d, good: %d, bad: %d\n",
+		"# Finished processing certificates, report length: %d, good: %d, bad: %d\n",
 		len(checker.issuedReport.Entries),
 		checker.issuedReport.GoodCerts,
 		checker.issuedReport.BadCerts,


### PR DESCRIPTION
The stderr, when reviewing logs, saying that the sample size was 0
implies that cert-checker sampled no certificates. In reality, it
is working fine; that zero indicates that the JSON array dumped to
stdout has 0 entries, which is actually good.

Let's just fix this stderr message (which isn't parsed by any tooling we
have) so that the next poor SRE that sees it doesn't freak out and file
tickets to start incident response.