### PR TITLE
Fix shadowing assignments inside closures

### DIFF
--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -189,7 +189,7 @@ func (c *WritingClient) StoreResponse(ctx context.Context, respBytes []byte, sho
 	metadataValue := metadataStruct.Marshal()
 
 	err = c.rdb.Watch(ctx, func(tx *redis.Tx) error {
-		err = tx.Set(ctx, responseKey, respBytes, ttl).Err()
+		err := tx.Set(ctx, responseKey, respBytes, ttl).Err()
 		if err != nil {
 			return fmt.Errorf("setting response: %w", err)
 		}

--- a/test/ocsp/ocsp_forever/main.go
+++ b/test/ocsp/ocsp_forever/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		err = http.ListenAndServe(*listenAddress, nil)
+		err := http.ListenAndServe(*listenAddress, nil)
 		if err != nil && err != http.ErrServerClosed {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
When inside a closure, it is important to not accidentally assign
to variables declared outside the scope of the closure. Doing so
causes static analysis tools (such as `errcheck`) to be unable to
evaluate the lifetime of the variable, and unable to determine if
it is appropriately read from before being assigned to again.

Fix two instances where we assign to a variable declared in the
closure's enclosing scope, rather than declaring a new variable
with the same name.