### PR TITLE
Simplify gosec linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,21 +25,18 @@ linters-settings:
     # ST1003: Poorly chosen identifier
     # ST1005: Incorrectly formatted error string
     checks: ["all", "-ST1003", "-ST1005"]
-issues:
-  exclude-rules:
-    - linters:
-      - gosec
-      # TODO: Identify, fix, and remove violations of each of these rules
-      # G101: Potential hardcoded credentials
-      # G102: Binds to all network interfaces
-      # G107: Potential HTTP request made with variable url
-      # G201: SQL string formatting
-      # G202: SQL string concatenation
-      # G306: Expect WriteFile permissions to be 0600 or less
-      # G401: Use of weak cryptographic primitive
-      # G402: TLS InsecureSkipVerify set true.
-      # G403: RSA keys should be at least 2048 bits
-      # G404: Use of weak random number generator (math/rand instead of crypto/rand)
-      # G501: Blacklisted import `crypto/md5`: weak cryptographic primitive
-      # G505: Blacklisted import `crypto/sha1`: weak cryptographic primitive
-      text: "G(101|102|107|201|202|306|401|402|403|404|501|505)"
+  gosec:
+    excludes:
+      # TODO: Identify, fix, and remove violations of most of these rules
+      - G101  # Potential hardcoded credentials
+      - G102  # Binds to all network interfaces
+      - G107  # Potential HTTP request made with variable url
+      - G201  # SQL string formatting
+      - G202  # SQL string concatenation
+      - G306  # Expect WriteFile permissions to be 0600 or less
+      - G401  # Use of weak cryptographic primitive
+      - G402  # TLS InsecureSkipVerify set true.
+      - G403  # RSA keys should be at least 2048 bits
+      - G404  # Use of weak random number generator (math/rand instead of crypto/rand)
+      - G501  # Blacklisted import `crypto/md5`: weak cryptographic primitive
+      - G505  # Blacklisted import `crypto/sha1`: weak cryptographic primitive


### PR DESCRIPTION
Replace regex-based filtering at the top-level with linter-specific
configuration.