### PR TITLE
akamai-purger: Cleanup

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
+	akamaiBatchSize = 100
+	timestampFormat = "20060102T15:04:05-0700"
 	v3PurgePath     = "/ccu/v3/delete/url/"
 	v3PurgeTagPath  = "/ccu/v3/delete/tag/"
-	timestampFormat = "20060102T15:04:05-0700"
 )
 
 type v3PurgeRequest struct {
@@ -41,8 +42,8 @@ type purgeResponse struct {
 	PurgeID          string `json:"purgeId"`
 }
 
-// CachePurgeClient talks to the Akamai CCU REST API. It is safe to make concurrent
-// purge requests.
+// CachePurgeClient talks to the Akamai CCU REST API. It is safe to make
+// concurrent requests using this client.
 type CachePurgeClient struct {
 	client       *http.Client
 	apiEndpoint  string
@@ -60,63 +61,49 @@ type CachePurgeClient struct {
 	clk          clock.Clock
 }
 
-// errFatal is used by CachePurgeClient.purge to indicate that it failed for a
-// reason that cannot be remediated by retrying a purge request
-type errFatal string
+// ErrAllRetriesFailed indicates that all purge submission attempts have failed.
+var ErrAllRetriesFailed = errors.New("all attempts to submit purge request failed")
 
-func (e errFatal) Error() string { return string(e) }
+// errFatal is returned by the purge method of CachePurgeClient to indicate that
+// it failed for a reason that cannot be remediated by retrying the request.
+var errFatal = errors.New("a non-retryable error was encountered")
 
-var (
-	// ErrAllRetriesFailed lets the caller of Purge to know if all the purge submission
-	// attempts failed
-	ErrAllRetriesFailed = errors.New("All attempts to submit purge request failed")
-)
+// NewCachePurgeClient performs some basic validation of supplied configuration
+// and returns a newly constructed CachePurgeClient.
+func NewCachePurgeClient(baseURL, cToken, secret, aToken, network string, retries int, backoff time.Duration, log blog.Logger, scope prometheus.Registerer) (*CachePurgeClient, error) {
+	if network != "production" && network != "staging" {
+		return nil, fmt.Errorf("'V3Network' must be \"staging\" or \"production\", got %q", network)
+	}
 
-// NewCachePurgeClient constructs a new CachePurgeClient
-func NewCachePurgeClient(
-	endpoint,
-	clientToken,
-	clientSecret,
-	accessToken string,
-	v3Network string,
-	retries int,
-	retryBackoff time.Duration,
-	log blog.Logger,
-	stats prometheus.Registerer,
-) (*CachePurgeClient, error) {
+	endpoint, err := url.Parse(strings.TrimSuffix(baseURL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse 'BaseURL' as a URL: %s", err)
+	}
+
 	purgeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "ccu_purge_latency",
 		Help:    "Histogram of latencies of CCU purges",
 		Buckets: metrics.InternetFacingBuckets,
 	})
-	stats.MustRegister(purgeLatency)
+	scope.MustRegister(purgeLatency)
+
 	purges := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ccu_purges",
 		Help: "A counter of CCU purges labelled by the result",
 	}, []string{"type"})
-	stats.MustRegister(purges)
+	scope.MustRegister(purges)
 
-	endpoint = strings.TrimSuffix(endpoint, "/")
-	apiURL, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	// The network string must be either "production" or "staging".
-	if v3Network != "production" && v3Network != "staging" {
-		return nil, fmt.Errorf(
-			"Invalid CCU v3 network: %q. Must be \"staging\" or \"production\"", v3Network)
-	}
 	return &CachePurgeClient{
 		client:       new(http.Client),
-		apiEndpoint:  endpoint,
-		apiHost:      apiURL.Host,
-		apiScheme:    strings.ToLower(apiURL.Scheme),
-		clientToken:  clientToken,
-		clientSecret: clientSecret,
-		accessToken:  accessToken,
-		v3Network:    v3Network,
+		apiEndpoint:  endpoint.String(),
+		apiHost:      endpoint.Host,
+		apiScheme:    strings.ToLower(endpoint.Scheme),
+		clientToken:  cToken,
+		clientSecret: secret,
+		accessToken:  aToken,
+		v3Network:    network,
 		retries:      retries,
-		retryBackoff: retryBackoff,
+		retryBackoff: backoff,
 		log:          log,
 		clk:          clock.New(),
 		purgeLatency: purgeLatency,
@@ -124,13 +111,13 @@ func NewCachePurgeClient(
 	}, nil
 }
 
-// Akamai uses a special authorization header to identify clients to their EdgeGrid
-// APIs, their docs (https://developer.akamai.com/introduction/Client_Auth.html)
-// provide a  description of the required generation process.
-func (cpc *CachePurgeClient) constructAuthHeader(body []byte, apiPath string, nonce string) (string, error) {
+// makeAuthHeader constructs a special Akamai authorization header. This header
+// is used to identify clients to Akamai's EdgeGrid APIs. For a more detailed
+// description of the generation process see their docs:
+// https://developer.akamai.com/introduction/Client_Auth.html
+func (cpc *CachePurgeClient) makeAuthHeader(body []byte, apiPath string, nonce string) (string, error) {
 	// The akamai API is very time sensitive (recommending reliance on a stratum 2
-	// or better time source) and, although it doesn't say it anywhere, really wants
-	// the timestamp to be in the UTC timezone for some reason.
+	// or better time source). Additionally, timestamps MUST be in UTC.
 	timestamp := cpc.clk.Now().UTC().Format(timestampFormat)
 	header := fmt.Sprintf(
 		"EG1-HMAC-SHA256 client_token=%s;access_token=%s;timestamp=%s;nonce=%s;",
@@ -146,12 +133,12 @@ func (cpc *CachePurgeClient) constructAuthHeader(body []byte, apiPath string, no
 		cpc.apiScheme,
 		cpc.apiHost,
 		apiPath,
-		"", // We don't need to send any signed headers for a purge so this can be blank
+		// Signed headers are not required for this request type.
+		"",
 		base64.StdEncoding.EncodeToString(bodyHash[:]),
 		header,
 	)
-
-	cpc.log.Debugf("To-be-signed Akamai EdgeGrid authentication: %q", tbs)
+	cpc.log.Debugf("To-be-signed Akamai EdgeGrid authentication %q", tbs)
 
 	h := hmac.New(sha256.New, signingKey(cpc.clientSecret, timestamp))
 	h.Write([]byte(tbs))
@@ -180,8 +167,7 @@ func (cpc *CachePurgeClient) PurgeTags(tags []string) error {
 	return cpc.authedRequest(endpoint, purgeReq)
 }
 
-// purge actually sends the individual requests to the Akamai endpoint and checks
-// if they are successful
+// purge dispatches an individual purge request.
 func (cpc *CachePurgeClient) purge(urls []string) error {
 	purgeReq := v3PurgeRequest{
 		Objects: urls,
@@ -190,77 +176,65 @@ func (cpc *CachePurgeClient) purge(urls []string) error {
 	return cpc.authedRequest(endpoint, purgeReq)
 }
 
-// POST to the given URL with the body that results from json.Marshal'ing `body`,
-// using the Akamai authentication mechanism.
-func (cpc *CachePurgeClient) authedRequest(target string, requestBody interface{}) error {
-	reqJSON, err := json.Marshal(requestBody)
+// authedRequest POSTs the JSON marshaled purge request to the provided endpoint
+// along with an Akamai authorization header.
+func (cpc *CachePurgeClient) authedRequest(endpoint string, body v3PurgeRequest) error {
+	reqBody, err := json.Marshal(body)
 	if err != nil {
-		return errFatal(err.Error())
-	}
-	req, err := http.NewRequest(
-		"POST",
-		target,
-		bytes.NewBuffer(reqJSON),
-	)
-	if err != nil {
-		return errFatal(err.Error())
+		return fmt.Errorf("%s: %w", err, errFatal)
 	}
 
-	parsedTarget, err := url.Parse(target)
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(reqBody))
 	if err != nil {
-		return errFatal(fmt.Sprintf("parsing url %q: %s", target, err))
+		return fmt.Errorf("%s: %w", err, errFatal)
 	}
 
-	// Create authorization header for request
-	authHeader, err := cpc.constructAuthHeader(
-		reqJSON,
-		parsedTarget.Path,
-		core.RandomString(16),
-	)
+	endpointURL, err := url.Parse(endpoint)
 	if err != nil {
-		return errFatal(err.Error())
+		return fmt.Errorf("while parsing %q as URL: %s: %w", endpoint, err, errFatal)
 	}
-	req.Header.Set("Authorization", authHeader)
+
+	authorization, err := cpc.makeAuthHeader(reqBody, endpointURL.Path, core.RandomString(16))
+	if err != nil {
+		return fmt.Errorf("%s: %w", err, errFatal)
+	}
+	req.Header.Set("Authorization", authorization)
 	req.Header.Set("Content-Type", "application/json")
+	cpc.log.Debugf("POSTing to %q with header %q, and body %q", endpoint, authorization, reqBody)
 
-	cpc.log.Debugf("POSTing to %s with Authorization %s: %s",
-		target, authHeader, reqJSON)
-
-	s := cpc.clk.Now()
+	start := cpc.clk.Now()
 	resp, err := cpc.client.Do(req)
-	cpc.purgeLatency.Observe(cpc.clk.Since(s).Seconds())
+	cpc.purgeLatency.Observe(cpc.clk.Since(start).Seconds())
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.Body == nil {
-		return fmt.Errorf("No response body")
+		return fmt.Errorf("response body was empty")
 	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		_ = resp.Body.Close()
-		return err
-	}
-	err = resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 
-	// Check purge was successful
+	// Ensure that the purge request was successful.
 	var purgeInfo purgeResponse
-	err = json.Unmarshal(body, &purgeInfo)
+	err = json.Unmarshal(respBody, &purgeInfo)
 	if err != nil {
-		return fmt.Errorf("response to %s: json.Unmarshal(%q): %w", target, body, err)
+		return fmt.Errorf("while unmarshalling response %q from endpoint %q as JSON: %w", respBody, endpoint, err)
 	}
+
 	if purgeInfo.HTTPStatus != http.StatusCreated || resp.StatusCode != http.StatusCreated {
 		if purgeInfo.HTTPStatus == http.StatusForbidden {
-			return errFatal("Unauthorized to purge URLs")
+			return fmt.Errorf("the client was not authorized to make this request: %w", errFatal)
 		}
-		return fmt.Errorf("Unexpected HTTP status code '%d': %s", resp.StatusCode, string(body))
+		return fmt.Errorf("received unexpected HTTP response code '%d', for body %q", resp.StatusCode, respBody)
 	}
 
 	cpc.log.AuditInfof("Sent successful purge request purgeID: %s, purge expected in: %ds, for request body: %s",
-		purgeInfo.PurgeID, purgeInfo.EstimatedSeconds, reqJSON)
-
+		purgeInfo.PurgeID, purgeInfo.EstimatedSeconds, reqBody)
 	return nil
 }
 
@@ -271,8 +245,7 @@ func (cpc *CachePurgeClient) purgeBatch(urls []string) error {
 
 		err := cpc.purge(urls)
 		if err != nil {
-			var errorFatal errFatal
-			if errors.As(err, &errorFatal) {
+			if errors.Is(err, errFatal) {
 				cpc.purges.WithLabelValues("fatal failure").Inc()
 				return err
 			}
@@ -293,10 +266,8 @@ func (cpc *CachePurgeClient) purgeBatch(urls []string) error {
 	return nil
 }
 
-var akamaiBatchSize = 100
-
-// Purge attempts to send a purge request to the Akamai CCU API cpc.retries number
-//  of times before giving up and returning ErrAllRetriesFailed
+// Purge attempts to send a purge request to the Akamai CCU API cpc.retries
+// number of times before giving up and returning ErrAllRetriesFailed.
 func (cpc *CachePurgeClient) Purge(urls []string) error {
 	for i := 0; i < len(urls); {
 		sliceEnd := i + akamaiBatchSize
@@ -312,7 +283,7 @@ func (cpc *CachePurgeClient) Purge(urls []string) error {
 	return nil
 }
 
-// CheckSignature is used for tests, it exported so that it can be used in akamai-test-srv
+// CheckSignature is exported for use in tests and akamai-test-srv.
 func CheckSignature(secret string, url string, r *http.Request, body []byte) error {
 	bodyHash := sha256.Sum256(body)
 	bodyHashB64 := base64.StdEncoding.EncodeToString(bodyHash[:])
@@ -337,7 +308,7 @@ func CheckSignature(secret string, url string, r *http.Request, body []byte) err
 	h.Write(input)
 	expectedSignature := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	if signature != expectedSignature {
-		return fmt.Errorf("Wrong signature %q in %q. Expected %q\n",
+		return fmt.Errorf("expected signature %q, got %q in %q",
 			signature, authorization, expectedSignature)
 	}
 	return nil
@@ -384,7 +355,8 @@ func GeneratePurgeURLs(cert, issuer *x509.Certificate) ([]string, error) {
 		return nil, err
 	}
 
-	// Create a GET and special Akamai POST style OCSP url for each endpoint in cert.OCSPServer
+	// Create a GET and special Akamai POST style OCSP url for each endpoint in
+	// cert.OCSPServer.
 	urls := []string{}
 	for _, ocspServer := range cert.OCSPServer {
 		if !strings.HasSuffix(ocspServer, "/") {

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -242,7 +242,7 @@ func (cpc *CachePurgeClient) authedRequest(endpoint string, body v3PurgeRequest)
 		return fmt.Errorf("received HTTP %d (body %q) from URL %q", resp.StatusCode, respBody, resp.Request.URL)
 	}
 
-	cpc.log.AuditInfof("Purge request sent successfuly (ID %s) (body %s). Purge expected in %ds",
+	cpc.log.AuditInfof("Purge request sent successfully (ID %s) (body %s). Purge expected in %ds",
 		purgeInfo.PurgeID, purgeInfo.EstimatedSeconds, reqBody)
 	return nil
 }

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -220,7 +220,7 @@ func (cpc *CachePurgeClient) authedRequest(endpoint string, body v3PurgeRequest)
 	defer resp.Body.Close()
 
 	if resp.Body == nil {
-		return fmt.Errorf("response body was empty for URL %q", resp.Request.URL)
+		return fmt.Errorf("response body was empty from URL %q", resp.Request.URL)
 	}
 
 	respBody, err := ioutil.ReadAll(resp.Body)
@@ -239,10 +239,10 @@ func (cpc *CachePurgeClient) authedRequest(endpoint string, body v3PurgeRequest)
 		if purgeInfo.HTTPStatus == http.StatusForbidden {
 			return fmt.Errorf("client not authorized to make requests to URL %q: %w", resp.Request.URL, errFatal)
 		}
-		return fmt.Errorf("received HTTP %d (body %q) (URL %q)", resp.StatusCode, respBody, resp.Request.URL)
+		return fmt.Errorf("received HTTP %d (body %q) from URL %q", resp.StatusCode, respBody, resp.Request.URL)
 	}
 
-	cpc.log.AuditInfof("Sent successful purge request (purgeID: %s), purge expected in: %ds, for request body: %s",
+	cpc.log.AuditInfof("Purge request sent successfuly (ID %s) (body %s). Purge expected in %ds",
 		purgeInfo.PurgeID, purgeInfo.EstimatedSeconds, reqBody)
 	return nil
 }

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestConstructAuthHeader(t *testing.T) {
+func TestMakeAuthHeader(t *testing.T) {
 	log := blog.NewMock()
 	stats := metrics.NoopRegisterer
 	cpc, err := NewCachePurgeClient(
@@ -38,7 +38,7 @@ func TestConstructAuthHeader(t *testing.T) {
 	fc.Set(wantedTimestamp)
 
 	expectedHeader := "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=hXm4iCxtpN22m4cbZb4lVLW5rhX8Ca82vCFqXzSTPe4="
-	authHeader, err := cpc.constructAuthHeader(
+	authHeader, err := cpc.makeAuthHeader(
 		[]byte("datadatadatadatadatadatadatadata"),
 		"/testapi/v1/t3",
 		"nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -28,7 +28,7 @@ type Config struct {
 	AkamaiPurger struct {
 		cmd.ServiceConfig
 
-		// PurgeInterval is how often we will send a purge request
+		// PurgeInterval is the duration waited between purge requests.
 		PurgeInterval cmd.ConfigDuration
 
 		BaseURL           string
@@ -69,7 +69,7 @@ func (ap *akamaiPurger) purge() error {
 
 	err := ap.client.Purge(urls)
 	if err != nil {
-		// Add the URLs back to the queue
+		// Add the URLs back to the queue.
 		ap.mu.Lock()
 		ap.toPurge = append(urls, ap.toPurge...)
 		ap.mu.Unlock()
@@ -79,15 +79,15 @@ func (ap *akamaiPurger) purge() error {
 	return nil
 }
 
-// maxQueueSize is used to reject Purge requests if the queue contains
-// >= the number of URLs to purge so that it can catch up.
+// maxQueueSize is used to reject Purge requests if the queue contains >= the
+// number of URLs to purge so that it can catch up.
 var maxQueueSize = 1000000
 
 func (ap *akamaiPurger) Purge(ctx context.Context, req *akamaipb.PurgeRequest) (*emptypb.Empty, error) {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
 	if len(ap.toPurge) >= maxQueueSize {
-		return nil, errors.New("Akamai purge queue too large")
+		return nil, errors.New("akamai-purger queue too large")
 	}
 	ap.toPurge = append(ap.toPurge, req.Urls...)
 	return &emptypb.Empty{}, nil
@@ -155,8 +155,9 @@ func main() {
 	scope, logger := cmd.StatsAndLogging(c.Syslog, c.AkamaiPurger.DebugAddr)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString())
+
 	if c.AkamaiPurger.PurgeInterval.Duration == 0 {
-		cmd.Fail("PurgeInterval must be > 0")
+		cmd.Fail("'PurgeInterval' must be > 0")
 	}
 
 	ccu, err := akamai.NewCachePurgeClient(
@@ -225,18 +226,16 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 				break loop
 			}
 		}
+
 		// As we may have missed a tick by calling ticker.Stop() and
 		// writing to the stop channel call ap.purge one last time just
 		// in case there is anything that still needs to be purged.
-		if queueLen := ap.len(); queueLen > 0 {
-			logger.Info(fmt.Sprintf("Shutting down; purging %d queue entries before exit.", queueLen))
+		queueLen := ap.len()
+		if queueLen > 0 {
+			logger.Infof("Shutting down; purging %d queue entries before exit.", queueLen)
 			err := ap.purge()
-			if err != nil {
-				cmd.Fail(fmt.Sprintf("Shutting down; failed to purge %d queue entries before exit: %s",
-					queueLen, err))
-			} else {
-				logger.Info(fmt.Sprintf("Shutting down; finished purging %d queue entries.", queueLen))
-			}
+			cmd.FailOnError(err, fmt.Sprintf("Shutting down; failed to purge %d queue entries before exit", queueLen))
+			logger.Infof("Shutting down; finished purging %d queue entries.", queueLen)
 		} else {
 			logger.Info("Shutting down; queue is already empty.")
 		}
@@ -244,8 +243,10 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 	}()
 
 	serverMetrics := bgrpc.NewServerMetrics(scope)
+
 	grpcSrv, l, err := bgrpc.NewServer(c.AkamaiPurger.GRPC, tlsConfig, serverMetrics, clk)
 	cmd.FailOnError(err, "Unable to setup Akamai purger gRPC server")
+
 	akamaipb.RegisterAkamaiPurgerServer(grpcSrv, ap)
 	hs := health.NewServer()
 	healthpb.RegisterHealthServer(grpcSrv, hs)
@@ -253,6 +254,7 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 	go cmd.CatchSignals(logger, func() {
 		hs.Shutdown()
 		grpcSrv.GracefulStop()
+
 		// Stop the ticker and signal that we want to shutdown by writing to the
 		// stop channel. We wait 15 seconds for any remaining URLs to be emptied
 		// from the current queue, if we pass that deadline we exit early.
@@ -264,9 +266,9 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 		case <-stopped:
 		}
 	})
-
 	err = cmd.FilterShutdownErrors(grpcSrv.Serve(l))
-	cmd.FailOnError(err, "Akamai purger gRPC service failed")
+	cmd.FailOnError(err, "akamai-purger gRPC service failed")
+
 	// When we get a SIGTERM, we will exit from grpcSrv.Serve as soon as all
 	// extant RPCs have been processed, but we want the process to stick around
 	// while we still have a goroutine purging the last elements from the queue.

--- a/test/integration/akamai_purger_drain_queue_test.go
+++ b/test/integration/akamai_purger_drain_queue_test.go
@@ -87,7 +87,7 @@ func TestAkamaiPurgerDrainQueueFails(t *testing.T) {
 	if err == nil {
 		t.Error("expected error shutting down akamai-purger that could not reach backend")
 	}
-	expectedOutput := "failed to purge 1 queue entries before exit: All attempts to submit purge request failed"
+	expectedOutput := "failed to purge 1 queue entries before exit: all attempts to submit purge request failed"
 	if !strings.Contains(outputBuffer.String(), expectedOutput) {
 		t.Errorf("akamai-purger stdout did not contain expected %q. Output was:\n%s", expectedOutput, outputBuffer.String())
 	}


### PR DESCRIPTION
Light cleanup of akamai-purger and the akamai cache-client. This does not make
any material changes to logic.

- Use `errors.New` and `errors.Is` instead of a custom `ErrFatal` type and
  `errors.As`
- Add whitespace to separate chunks of execution and error checking from one
  another
- Use `logger.Infof` and `logger.Errorf` instead of wrapped calls to
  `fmt.Sprintf`
- Remove capital letters from the beginning of error messages
- Additional comments and removal of some that are no longer accurate