### PR TITLE
Remove go1.16 backwards compatibility hacks

### DIFF
--- a/core/util_test.go
+++ b/core/util_test.go
@@ -1,9 +1,7 @@
 package core
 
 import (
-	"encoding/asn1"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -172,10 +170,7 @@ func TestLoadCert(t *testing.T) {
 
 	_, err = LoadCert("../test/test-ca.key")
 	test.AssertError(t, err, "Loading non-cert file did not error")
-	var asnStructuralErr asn1.StructuralError
-	go116ok := errors.As(err, &asnStructuralErr)
-	go117ok := (err.Error() == "x509: malformed tbs certificate")
-	test.Assert(t, go116ok != go117ok, "Only one of go1.16 or go1.17 should pass")
+	test.AssertEquals(t, err.Error(), "x509: malformed tbs certificate")
 
 	cert, err := LoadCert("../test/test-ca.pem")
 	test.AssertNotError(t, err, "Failed to load cert file")

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -478,12 +478,7 @@ func TestValidateTLSALPN01UnawareSrv(t *testing.T) {
 	if prob == nil {
 		t.Fatalf("TLS ALPN validation should have failed.")
 	}
-	// In go1.16 it makes the connection but shouldn't be able to complete it;
-	// in go1.17 the stdlib refuses to handshake when there is no overlap in
-	// negotiated TLS application protocols.
-	go116ok := prob.Type == probs.UnauthorizedProblem
-	go117ok := prob.Type == probs.TLSProblem
-	test.Assert(t, go116ok != go117ok, "Only one of go1.16 or go1.17 should pass")
+	test.AssertEquals(t, prob.Type, probs.TLSProblem)
 }
 
 // TestValidateTLSALPN01BadUTFSrv tests that validating TLS-ALPN-01 against


### PR DESCRIPTION
These were needed for the transition from go1.16 to go1.17. We
don't run go1.16 anywhere anymore, so they can be removed.