### PR TITLE
Add link for funding in GitHub repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://letsencrypt.org/donate/


### PR DESCRIPTION
I submitted the same PR to Certbot a while ago. Although many probably know of LetsEncrypt's website, it doesn't hurt to have the link, when it's supported.

Please see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository for more information.