### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 
 updates:
   - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates I don't think it's enabled by default. It's a proposal to enable; however, I'm not sure if it's priority to have it. There are no closed (nor current open) PRs from dependabot in the repository.