### PR TITLE
Orphan finder: Fix redundant syslog config value

### DIFF
--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -8,7 +8,7 @@
 
   "syslog": {
     "stdoutlevel": 7,
-    "stdoutlevel": 7
+    "sysloglevel": 7
   },
 
   "tls": {

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -9,7 +9,7 @@
 
   "syslog": {
     "stdoutlevel": 7,
-    "stdoutlevel": 7
+    "sysloglevel": 7
   },
 
   "tls": {


### PR DESCRIPTION
Replace redundant stdoutlevel with a sysloglevel value in test configs.