### PR TITLE
Add GitHub Action for golangci-lint

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
-          - "./t.sh --lints --generate --make-artifacts"
+          - "./t.sh --generate --make-artifacts"
           - "./t.sh --integration"
           # Testing Config Changes:
           # Config changes that have landed in main but not yet been applied to

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,25 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.42.1
+          args: --timeout 9m
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,12 +1,13 @@
 name: golangci-lint
 on:
+  # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    tags:
-      - v*
-    branches:
-      - master
+    branches: 
       - main
+      - release-branch-*
   pull_request:
+    branches:
+      - '*'
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
Adapted from https://github.com/golangci/golangci-lint-action#how-to-use. Uses the same version we've been using in boulder-tools.

Part of #5946

Note: we will eventually want to go back to doing this in boulder-tools, so it's easy to run the lints locally. But this is useful so we can unblock testing on go 1.18beta2.