### PR TITLE
Update CI to test go1.18beta2

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -33,7 +33,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.17.7_2022-02-10
+          - go1.17.7_2022-03-08
+          - go1.18beta2_2022-03-08
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   boulder:
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17.7_2022-02-10}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17.7_2022-03-08}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,16 @@
 version: '3'
 services:
   boulder:
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17.7_2022-03-08}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.18beta2_2022-03-08}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config
       GOFLAGS: -mod=vendor
+      # Go 1.18 turns off SHA-1 validation on CSRs (and certs, but that doesn't
+      # affect us). It also turns off TLS 1.0 and TLS 1.1. Temporarily go back
+      # to allowing these so we can upgrade to Go 1.18 while doing a deprecation
+      # window. These overrides will stop working in Go 1.19.
+      GODEBUG: x509sha1=1,tls10default=1
     volumes:
       - .:/go/src/github.com/letsencrypt/boulder:cached
       - ./.gocache:/root/.cache/go-build:cached

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -1,19 +1,40 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -feuxo pipefail
 
 cd $(dirname $0)
 
 DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
 
-GO_VERSIONS=( "1.17.7" )
+GO_VERSIONS=( "1.17.7" "1.18beta2" )
 
 echo "Please login to allow push to DockerHub"
 docker login
 
 # Create a docker buildx node for cross-compilation if it doesn't already exist.
-if !(docker buildx ls | grep -q "cross")
+if ! docker buildx ls | grep -q "cross.*linux/arm64" ||
+   ! docker buildx ls | grep -q "cross.*linux/amd64"
 then
-  docker buildx create --use --name=cross
+  cat 2>&1 <<<EOF
+Docker on this host cannot cross-build. Run:
+
+docker buildx ls
+
+It should show an entry like:
+cross0  unix:///var/run/docker.sock running linux/amd64, linux/386, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
+
+If not, run:
+
+docker buildx create --use --name=cross
+
+Also, you may need to install some qemu packages. For instance:
+
+https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/
+
+sudo sudo apt-get install qemu binfmt-support qemu-user-static
+EOF
+  exit 1
 fi
 
 # Build and push a tagged image for each GO_VERSION.
@@ -24,6 +45,7 @@ do
 
   # build, tag, and push the image.
   docker buildx build --build-arg "GO_VERSION=${GO_VERSION}" \
+    --progress plain \
     --push --tag "${TAG_NAME}" \
     --platform=linux/amd64,linux/arm64 .
 done


### PR DESCRIPTION
This requires using GODEBUG to enable a couple of thing turned off by go1.18 (TLS 1.0/1.1, SHA-1 CSRs).

Also add help for a failure mode of cross builds.