### PR TITLE
Unexport some ports in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,6 @@ services:
     dns: 10.77.77.77
     ports:
       - 4001:4001 # ACMEv2
-      - 4002:4002 # OCSP
-      - 4003:4003 # OCSP
-      - 4431:4431 # ACMEv2 via HTTPS
-      - 8055:8055 # dns-test-srv updates
     depends_on:
       - bmysql
       - bredis_clusterer


### PR DESCRIPTION
When a Boulder component (e.g. ocsp-responder) listens on 0.0.0.0:4003, that port is accessible to from any IP within the docker network, including the host. So for instance, the host can fetch `http://10.77.77.77:4003` (where `10.77.77.77` is one of the IP addresses assigned to the boulder container). That doesn't require any port publishing by Docker.

What port publishing does: It sets up iptable rules to forward traffic from the _host's_ IP addresses to the container's IP address. This is useful for instance when you're running a service inside a container and want it available on the public internet.

When we originally added this I thought this was the only way to get Boulder listening on the host's `127.0.0.1:4003`. In a way it is, but the real answer is that Boulder doesn't _need_ to listen on the host's `127.0.0.1`. The integration tests are already running on `10.77.77.77`, so they don't care. And in the case where software on the host wants to talk directly to Boulder, it's better to use `10.77.77.77` (or add `boulder` to /etc/hosts).

So this tidies things up, meaning we don't export these ports on our dev boxes.

I'm leaving the WFE2 port in place for now because I think some integration tests (like maybe Certbot?) run `docker-compose up` and expect Boulder to show up on localhost. I'd like to follow up with them before making that change. I suspect the ports I'm removing are not used by third-party integration tests.