### PR TITLE
docker: re-export OCSP ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     dns: 10.77.77.77
     ports:
       - 4001:4001 # ACMEv2
+      - 4002:4002 # OCSP
+      - 4003:4003 # OCSP
     depends_on:
       - bmysql
       - bredis_clusterer


### PR DESCRIPTION
In #5990, the OCSP ports of 4002/tcp and 4003/tcp were unexported in `docker-compose`.

For Certbot's integration tests that check revocation, this poses a slight problem, because the AIA OCSP URL in the certificates issued by Boulder points to `http://127.0.0.1:4002`. Certbot tries to use that URL.

Although Certbot won't crash if the OCSP responder is unavailable, it does mean that the revocation integration tests do not pass.

I think it would be useful if either this change was reverted, or maybe if the URL in the certificates was updated to the IP address where the OCSP responder is available. This PR implements the former but any form of help is welcome! Thanks.