### PR TITLE
Remove false positive in go version comment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   boulder:
     # CAUTION: Changing the Go version in this tag changes the version of Go
     # used for release builds. make-deb.sh relies on being able to parse the
-    # version between 'BOULDER_TOOLS_TAG:-go' and '_' if you make changes to
-    # these tokens, please update this parsing logic.
+    # numeric version between 'go' and the underscore-prefixed date. If you make
+    # changes to these tokens, please update this parsing logic.
     image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17.7_2022-02-10}
     environment:
       FAKE_DNS: 10.77.77.77


### PR DESCRIPTION
The presence of the full "BOULDER_TOOLS_TAG" string in this
comment was causing it to show up in the grep which is attempting
to find and parse the line below.