### PR TITLE
Use go1.18 in CI, and fix up Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # used for release builds. make-deb.sh relies on being able to parse the
     # numeric version between 'go' and the underscore-prefixed date. If you make
     # changes to these tokens, please update this parsing logic.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17.7_2022-02-10}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.18_2022-03-15}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config
@@ -16,7 +16,7 @@ services:
       # window. These overrides will stop working in Go 1.19.
       GODEBUG: x509sha1=1,tls10default=1
     volumes:
-      - .:/go/src/github.com/letsencrypt/boulder:cached
+      - .:/boulder:cached
       - ./.gocache:/root/.cache/go-build:cached
       - ./.hierarchy:/hierarchy/:cached
       - ./.softhsm-tokens/:/var/lib/softhsm/tokens/:cached
@@ -42,7 +42,7 @@ services:
       - bmysql
       - bredis_clusterer
     entrypoint: test/entrypoint.sh
-    working_dir: &boulder_working_dir /go/src/github.com/letsencrypt/boulder
+    working_dir: &boulder_working_dir /boulder
 
   bmysql:
     image: mariadb:10.5
@@ -143,7 +143,7 @@ services:
     networks:
       - bluenet
     volumes:
-      - .:/go/src/github.com/letsencrypt/boulder
+      - .:/boulder
     working_dir: *boulder_working_dir
     entrypoint: test/entrypoint-netaccess.sh
 

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -5,11 +5,7 @@ ARG GO_VERSION
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-# Copied from https://github.com/docker-library/golang/blob/master/Dockerfile-debian.template
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:/usr/local/protoc/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-WORKDIR $GOPATH
+ENV PATH /usr/local/go/bin:/usr/local/protoc/bin:$PATH
 
 RUN arch=$(echo $TARGETPLATFORM | sed 's|\/|-|') && wget -O go.tgz "https://dl.google.com/go/go${GO_VERSION}.${arch}.tar.gz" && tar -C /usr/local -xzf go.tgz && rm go.tgz;
 COPY requirements.txt /tmp/requirements.txt

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -7,35 +7,10 @@ cd $(dirname $0)
 DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
 
-GO_VERSIONS=( "1.17.7" "1.18beta2" )
+GO_VERSIONS=( "1.17.7" "1.18" )
 
 echo "Please login to allow push to DockerHub"
 docker login
-
-# Create a docker buildx node for cross-compilation if it doesn't already exist.
-if ! docker buildx ls | grep -q "cross.*linux/arm64" ||
-   ! docker buildx ls | grep -q "cross.*linux/amd64"
-then
-  cat 2>&1 <<<EOF
-Docker on this host cannot cross-build. Run:
-
-docker buildx ls
-
-It should show an entry like:
-cross0  unix:///var/run/docker.sock running linux/amd64, linux/386, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
-
-If not, run:
-
-docker buildx create --use --name=cross
-
-Also, you may need to install some qemu packages. For instance:
-
-https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/
-
-sudo sudo apt-get install qemu binfmt-support qemu-user-static
-EOF
-  exit 1
-fi
 
 # Build and push a tagged image for each GO_VERSION.
 for GO_VERSION in "${GO_VERSIONS[@]}"


### PR DESCRIPTION
- Remove GOPATH-style path structure, which isn't needed with Go
  modules.
- Remove check for existing of docker buildx builder instance, since it
  was unreliable.