### PR TITLE
akamai-purger: Improve throughput and configuration safety

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -63,9 +63,9 @@ type CachePurgeClient struct {
 	clientSecret      string
 	accessToken       string
 	v3Network         string
+	purgeBatchEvery   time.Duration
 	responsesPerBatch int
 	retries           int
-	purgeBatchEvery   time.Duration
 	retryBackoff      time.Duration
 	log               blog.Logger
 	purgeLatency      prometheus.Histogram
@@ -81,10 +81,10 @@ func NewCachePurgeClient(
 	secret,
 	accessToken,
 	network string,
+	purgeBatchEvery time.Duration,
 	responsesPerBatch,
 	retries int,
-	backoff,
-	purgeBatchEvery time.Duration,
+	backoff time.Duration,
 	log blog.Logger, scope prometheus.Registerer,
 ) (*CachePurgeClient, error) {
 	if network != "production" && network != "staging" {

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -55,22 +55,22 @@ type purgeResponse struct {
 // CachePurgeClient talks to the Akamai CCU REST API. It is safe to make
 // concurrent requests using this client.
 type CachePurgeClient struct {
-	client            *http.Client
-	apiEndpoint       string
-	apiHost           string
-	apiScheme         string
-	clientToken       string
-	clientSecret      string
-	accessToken       string
-	v3Network         string
-	purgeBatchEvery   time.Duration
-	responsesPerBatch int
-	retries           int
-	retryBackoff      time.Duration
-	log               blog.Logger
-	purgeLatency      prometheus.Histogram
-	purges            *prometheus.CounterVec
-	clk               clock.Clock
+	client               *http.Client
+	apiEndpoint          string
+	apiHost              string
+	apiScheme            string
+	clientToken          string
+	clientSecret         string
+	accessToken          string
+	v3Network            string
+	purgeBatchInterval   time.Duration
+	queueEntriesPerBatch int
+	retries              int
+	retryBackoff         time.Duration
+	log                  blog.Logger
+	purgeLatency         prometheus.Histogram
+	purges               *prometheus.CounterVec
+	clk                  clock.Clock
 }
 
 // NewCachePurgeClient performs some basic validation of supplied configuration
@@ -81,8 +81,8 @@ func NewCachePurgeClient(
 	secret,
 	accessToken,
 	network string,
-	purgeBatchEvery time.Duration,
-	responsesPerBatch,
+	purgeBatchInterval time.Duration,
+	queueEntriesPerBatch,
 	retries int,
 	retryBackoff time.Duration,
 	log blog.Logger, scope prometheus.Registerer,
@@ -110,22 +110,22 @@ func NewCachePurgeClient(
 	scope.MustRegister(purges)
 
 	return &CachePurgeClient{
-		client:            new(http.Client),
-		apiEndpoint:       endpoint.String(),
-		apiHost:           endpoint.Host,
-		apiScheme:         strings.ToLower(endpoint.Scheme),
-		clientToken:       clientToken,
-		clientSecret:      secret,
-		accessToken:       accessToken,
-		v3Network:         network,
-		purgeBatchEvery:   purgeBatchEvery,
-		responsesPerBatch: responsesPerBatch,
-		retries:           retries,
-		retryBackoff:      retryBackoff,
-		log:               log,
-		clk:               clock.New(),
-		purgeLatency:      purgeLatency,
-		purges:            purges,
+		client:               new(http.Client),
+		apiEndpoint:          endpoint.String(),
+		apiHost:              endpoint.Host,
+		apiScheme:            strings.ToLower(endpoint.Scheme),
+		clientToken:          clientToken,
+		clientSecret:         secret,
+		accessToken:          accessToken,
+		v3Network:            network,
+		purgeBatchInterval:   purgeBatchInterval,
+		queueEntriesPerBatch: queueEntriesPerBatch,
+		retries:              retries,
+		retryBackoff:         retryBackoff,
+		log:                  log,
+		clk:                  clock.New(),
+		purgeLatency:         purgeLatency,
+		purges:               purges,
 	}, nil
 }
 
@@ -323,7 +323,7 @@ func (cpc *CachePurgeClient) purgeBatch(queueEntries [][]string) error {
 func (cpc *CachePurgeClient) Purge(queueEntries [][]string) (int, error) {
 	totalEntries := len(queueEntries)
 	for batchBegin := 0; batchBegin < totalEntries; {
-		batchEnd := batchBegin + cpc.responsesPerBatch
+		batchEnd := batchBegin + cpc.queueEntriesPerBatch
 		if batchEnd > totalEntries {
 			// Avoid index out of range error.
 			batchEnd = totalEntries
@@ -333,7 +333,7 @@ func (cpc *CachePurgeClient) Purge(queueEntries [][]string) (int, error) {
 		if err != nil {
 			return batchBegin, err
 		}
-		batchBegin += cpc.responsesPerBatch
+		batchBegin += cpc.queueEntriesPerBatch
 	}
 	return totalEntries, nil
 }
@@ -387,9 +387,11 @@ func makeOCSPCacheURLs(req []byte, ocspServer string) []string {
 		// the first two uint32s in little endian order in hex of the MD5 hash
 		// of the OCSP request body.
 		//
-		// There is no public documentation of this feature. However, this entry
-		// is what triggers the Cache Behavior that allows Akamai to redirect
-		// POST based OCSP requests to the associated cached response.
+		// There is limited public documentation of this feature. However, this
+		// entry is what triggers the Akamai cache behavior that allows Akamai to
+		// identify POST based OCSP for purging. For more information, see:
+		// https://techdocs.akamai.com/property-mgr/reference/v2020-03-04-cachepost
+		// https://techdocs.akamai.com/property-mgr/docs/cache-post-responses
 		fmt.Sprintf("%s?body-md5=%x%x", ocspServer, reverseBytes(hash[0:4]), reverseBytes(hash[4:8])),
 
 		// URL (un-encoded): RFC 2560 and RFC 5019 state OCSP GET URLs 'MUST

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	akamaiBatchSize = 100
 	timestampFormat = "20060102T15:04:05-0700"
 	v3PurgePath     = "/ccu/v3/delete/url/"
 	v3PurgeTagPath  = "/ccu/v3/delete/tag/"
@@ -56,20 +55,22 @@ type purgeResponse struct {
 // CachePurgeClient talks to the Akamai CCU REST API. It is safe to make
 // concurrent requests using this client.
 type CachePurgeClient struct {
-	client       *http.Client
-	apiEndpoint  string
-	apiHost      string
-	apiScheme    string
-	clientToken  string
-	clientSecret string
-	accessToken  string
-	v3Network    string
-	retries      int
-	retryBackoff time.Duration
-	log          blog.Logger
-	purgeLatency prometheus.Histogram
-	purges       *prometheus.CounterVec
-	clk          clock.Clock
+	client            *http.Client
+	apiEndpoint       string
+	apiHost           string
+	apiScheme         string
+	clientToken       string
+	clientSecret      string
+	accessToken       string
+	v3Network         string
+	responsesPerBatch int
+	retries           int
+	purgeBatchEvery   time.Duration
+	retryBackoff      time.Duration
+	log               blog.Logger
+	purgeLatency      prometheus.Histogram
+	purges            *prometheus.CounterVec
+	clk               clock.Clock
 }
 
 // NewCachePurgeClient performs some basic validation of supplied configuration
@@ -80,8 +81,10 @@ func NewCachePurgeClient(
 	secret,
 	accessToken,
 	network string,
+	responsesPerBatch,
 	retries int,
-	backoff time.Duration,
+	backoff,
+	purgeBatchEvery time.Duration,
 	log blog.Logger, scope prometheus.Registerer,
 ) (*CachePurgeClient, error) {
 	if network != "production" && network != "staging" {
@@ -107,20 +110,22 @@ func NewCachePurgeClient(
 	scope.MustRegister(purges)
 
 	return &CachePurgeClient{
-		client:       new(http.Client),
-		apiEndpoint:  endpoint.String(),
-		apiHost:      endpoint.Host,
-		apiScheme:    strings.ToLower(endpoint.Scheme),
-		clientToken:  clientToken,
-		clientSecret: secret,
-		accessToken:  accessToken,
-		v3Network:    network,
-		retries:      retries,
-		retryBackoff: backoff,
-		log:          log,
-		clk:          clock.New(),
-		purgeLatency: purgeLatency,
-		purges:       purges,
+		client:            new(http.Client),
+		apiEndpoint:       endpoint.String(),
+		apiHost:           endpoint.Host,
+		apiScheme:         strings.ToLower(endpoint.Scheme),
+		clientToken:       clientToken,
+		clientSecret:      secret,
+		accessToken:       accessToken,
+		v3Network:         network,
+		retries:           retries,
+		responsesPerBatch: responsesPerBatch,
+		retryBackoff:      backoff,
+		purgeBatchEvery:   purgeBatchEvery,
+		log:               log,
+		clk:               clock.New(),
+		purgeLatency:      purgeLatency,
+		purges:            purges,
 	}, nil
 }
 
@@ -172,6 +177,7 @@ func signingKey(clientSecret string, timestamp string) []byte {
 	return key
 }
 
+// PurgeTags constructs and dispatches a request to purge a batch of Tags.
 func (cpc *CachePurgeClient) PurgeTags(tags []string) error {
 	purgeReq := v3PurgeRequest{
 		Objects: tags,
@@ -180,8 +186,8 @@ func (cpc *CachePurgeClient) PurgeTags(tags []string) error {
 	return cpc.authedRequest(endpoint, purgeReq)
 }
 
-// purge dispatches an individual purge request.
-func (cpc *CachePurgeClient) purge(urls []string) error {
+// sendPurgeRequestForURLs constructs and dispatches a request to purge a batch of URLs.
+func (cpc *CachePurgeClient) sendPurgeRequestForURLs(urls []string) error {
 	purgeReq := v3PurgeRequest{
 		Objects: urls,
 	}
@@ -277,12 +283,17 @@ func (cpc *CachePurgeClient) authedRequest(endpoint string, body v3PurgeRequest)
 	return nil
 }
 
-func (cpc *CachePurgeClient) purgeBatch(urls []string) error {
+func (cpc *CachePurgeClient) purgeURLs(responses [][]string) error {
 	successful := false
 	for i := 0; i <= cpc.retries; i++ {
 		cpc.clk.Sleep(core.RetryBackoff(i, cpc.retryBackoff, time.Minute, 1.3))
 
-		err := cpc.purge(urls)
+		var urls []string
+		for _, response := range responses {
+			urls = append(urls, response...)
+		}
+
+		err := cpc.sendPurgeRequestForURLs(urls)
 		if err != nil {
 			if errors.Is(err, errFatal) {
 				cpc.purges.WithLabelValues("fatal failure").Inc()
@@ -305,26 +316,26 @@ func (cpc *CachePurgeClient) purgeBatch(urls []string) error {
 	return nil
 }
 
-// Purge dispatches the provided urls in batched requests to the Akamai CCU API.
-// Requests will be attempted cpc.retries number of times before giving up and
-// returning ErrAllRetriesFailed and the beginning index position of the batch
-// where the failure was encountered.
-func (cpc *CachePurgeClient) Purge(urls []string) (int, error) {
-	totalURLs := len(urls)
-	for batchBegin := 0; batchBegin < totalURLs; {
-		batchEnd := batchBegin + akamaiBatchSize
-		if batchEnd > totalURLs {
+// Purge dispatches the provided URLs as batched requests to the Akamai
+// Fast-Purge API. Requests will be attempted cpc.retries number of times before
+// giving up and returning ErrAllRetriesFailed and the beginning index position
+// of the batch where the failure was encountered.
+func (cpc *CachePurgeClient) Purge(entries [][]string) (int, error) {
+	totalEntries := len(entries)
+	for batchBegin := 0; batchBegin < totalEntries; {
+		batchEnd := batchBegin + cpc.responsesPerBatch
+		if batchEnd > totalEntries {
 			// Avoid index out of range error.
-			batchEnd = totalURLs
+			batchEnd = totalEntries
 		}
 
-		err := cpc.purgeBatch(urls[batchBegin:batchEnd])
+		err := cpc.purgeURLs(entries[batchBegin:batchEnd])
 		if err != nil {
 			return batchBegin, err
 		}
-		batchBegin += akamaiBatchSize
+		batchBegin += cpc.responsesPerBatch
 	}
-	return totalURLs, nil
+	return totalEntries, nil
 }
 
 // CheckSignature is exported for use in tests and akamai-test-srv.
@@ -365,26 +376,35 @@ func reverseBytes(b []byte) []byte {
 	return b
 }
 
-func generateOCSPCacheKeys(req []byte, ocspServer string) []string {
+// makeOCSPCacheURLs constructs the 3 URLs associated with each cached OCSP
+// response.
+func makeOCSPCacheURLs(req []byte, ocspServer string) []string {
 	hash := md5.Sum(req)
 	encReq := base64.StdEncoding.EncodeToString(req)
 	return []string{
-		// Generate POST key, format is the URL that was POST'd to with a query string with
-		// the parameter 'body-md5' and the value of the first two uint32s in little endian
-		// order in hex of the MD5 hash of the OCSP request body.
+		// POST Cache Key: the format of this entry is the URL that was POSTed
+		// to with a query string with the parameter 'body-md5' and the value of
+		// the first two uint32s in little endian order in hex of the MD5 hash
+		// of the OCSP request body.
 		//
-		// There is no public documentation of this feature that has been published by Akamai
-		// as far as we are aware.
+		// There is no public documentation of this feature. However, this entry
+		// is what triggers the Cache Behavior that allows Akamai to redirect
+		// POST based OCSP requests to the associated cached response.
 		fmt.Sprintf("%s?body-md5=%x%x", ocspServer, reverseBytes(hash[0:4]), reverseBytes(hash[4:8])),
-		// RFC 2560 and RFC 5019 state OCSP GET URLs 'MUST properly url-encode the base64
-		// encoded' request but a large enough portion of tools do not properly do this
-		// (~10% of GET requests we receive) such that we must purge both the encoded
-		// and un-encoded URLs.
+
+		// URL (un-encoded): RFC 2560 and RFC 5019 state OCSP GET URLs 'MUST
+		// properly url-encode the base64 encoded' request but a large enough
+		// portion of tools do not properly do this (~10% of GET requests we
+		// receive) such that we must purge both the encoded and un-encoded
+		// URLs.
 		//
 		// Due to Akamai proxy/cache behavior which collapses '//' -> '/' we also
 		// collapse double slashes in the un-encoded URL so that we properly purge
 		// what is stored in the cache.
 		fmt.Sprintf("%s%s", ocspServer, strings.Replace(encReq, "//", "/", -1)),
+
+		// URL (encoded): this entry is the url-encoded GET URL used to request
+		// OCSP as specified in RFC 2560 and RFC 5019.
 		fmt.Sprintf("%s%s", ocspServer, url.QueryEscape(encReq)),
 	}
 }
@@ -406,7 +426,7 @@ func GeneratePurgeURLs(cert, issuer *x509.Certificate) ([]string, error) {
 		if !strings.HasSuffix(ocspServer, "/") {
 			ocspServer += "/"
 		}
-		urls = append(urls, generateOCSPCacheKeys(req, ocspServer)...)
+		urls = append(urls, makeOCSPCacheURLs(req, ocspServer)...)
 	}
 	return urls, nil
 }

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -84,7 +84,7 @@ func NewCachePurgeClient(
 	purgeBatchEvery time.Duration,
 	responsesPerBatch,
 	retries int,
-	backoff time.Duration,
+	retryBackoff time.Duration,
 	log blog.Logger, scope prometheus.Registerer,
 ) (*CachePurgeClient, error) {
 	if network != "production" && network != "staging" {
@@ -118,10 +118,10 @@ func NewCachePurgeClient(
 		clientSecret:      secret,
 		accessToken:       accessToken,
 		v3Network:         network,
-		retries:           retries,
-		responsesPerBatch: responsesPerBatch,
-		retryBackoff:      backoff,
 		purgeBatchEvery:   purgeBatchEvery,
+		responsesPerBatch: responsesPerBatch,
+		retries:           retries,
+		retryBackoff:      retryBackoff,
 		log:               log,
 		clk:               clock.New(),
 		purgeLatency:      purgeLatency,

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -26,7 +26,9 @@ func TestMakeAuthHeader(t *testing.T) {
 		"akab-access-token-xxx-xxxxxxxxxxxxxxxx",
 		"production",
 		0,
+		2,
 		time.Second,
+		time.Millisecond*32,
 		log,
 		stats,
 	)
@@ -129,8 +131,10 @@ func TestV3Purge(t *testing.T) {
 		"secret",
 		"accessToken",
 		"production",
+		2,
 		3,
 		time.Second,
+		time.Millisecond*32,
 		blog.NewMock(),
 		metrics.NoopRegisterer,
 	)
@@ -138,18 +142,19 @@ func TestV3Purge(t *testing.T) {
 	fc := clock.NewFake()
 	client.clk = fc
 
-	_, err = client.Purge([]string{"http://test.com"})
+	_, err = client.Purge([][]string{{"http://test.com"}})
 	test.AssertNotError(t, err, "Purge failed; expected 201 response")
 
 	started := client.clk.Now()
 	as.responseCode = http.StatusInternalServerError
-	_, err = client.Purge([]string{"http://test.com"})
+	_, err = client.Purge([][]string{{"http://test.com"}})
 	test.AssertError(t, err, "Purge succeeded; expected 500 response")
+	t.Log(client.clk.Since(started))
 	test.Assert(t, client.clk.Since(started) > (time.Second*4), "Retries should've taken at least 4.4 seconds")
 
 	started = client.clk.Now()
 	as.responseCode = http.StatusCreated
-	_, err = client.Purge([]string{"http:/test.com"})
+	_, err = client.Purge([][]string{{"http:/test.com"}})
 	test.AssertError(t, err, "Purge succeeded; expected a 403 response from malformed URL")
 	test.Assert(t, client.clk.Since(started) < time.Second, "Purge should've failed out immediately")
 }
@@ -165,8 +170,10 @@ func TestPurgeTags(t *testing.T) {
 		"secret",
 		"accessToken",
 		"production",
+		2,
 		3,
 		time.Second,
+		time.Millisecond*32,
 		blog.NewMock(),
 		metrics.NoopRegisterer,
 	)
@@ -190,8 +197,10 @@ func TestNewCachePurgeClient(t *testing.T) {
 		"secret",
 		"accessToken",
 		"fake",
+		2,
 		3,
 		time.Second,
+		time.Millisecond*32,
 		blog.NewMock(),
 		metrics.NoopRegisterer,
 	)
@@ -204,8 +213,10 @@ func TestNewCachePurgeClient(t *testing.T) {
 		"secret",
 		"accessToken",
 		"staging",
+		2,
 		3,
 		time.Second,
+		time.Millisecond*32,
 		blog.NewMock(),
 		metrics.NoopRegisterer,
 	)
@@ -218,8 +229,10 @@ func TestNewCachePurgeClient(t *testing.T) {
 		"secret",
 		"accessToken",
 		"staging",
+		2,
 		3,
 		time.Second,
+		time.Millisecond*32,
 		blog.NewMock(),
 		metrics.NoopRegisterer,
 	)
@@ -237,16 +250,18 @@ func TestBigBatchPurge(t *testing.T) {
 		"secret",
 		"accessToken",
 		"production",
+		2,
 		3,
 		time.Second,
+		time.Millisecond*32,
 		log,
 		metrics.NoopRegisterer,
 	)
 	test.AssertNotError(t, err, "Failed to create CachePurgeClient")
 
-	var urls []string
+	var urls [][]string
 	for i := 0; i < 250; i++ {
-		urls = append(urls, fmt.Sprintf("http://test.com/%d", i))
+		urls = append(urls, []string{fmt.Sprintf("http://test.com/%d", i)})
 	}
 
 	stoppedAt, err := client.Purge(urls)
@@ -254,16 +269,16 @@ func TestBigBatchPurge(t *testing.T) {
 	test.AssertEquals(t, stoppedAt, 250)
 
 	// Add a malformed URL.
-	urls = append(urls, "http:/test.com")
+	urls = append(urls, []string{"http:/test.com"})
 
 	// Add 10 more valid entries.
 	for i := 0; i < 10; i++ {
-		urls = append(urls, fmt.Sprintf("http://test.com/%d", i))
+		urls = append(urls, []string{fmt.Sprintf("http://test.com/%d", i)})
 	}
 
 	stoppedAt, err = client.Purge(urls)
 	test.AssertError(t, err, "Purge succeeded with a malformed URL")
-	test.AssertEquals(t, stoppedAt, 200)
+	test.AssertEquals(t, stoppedAt, 250)
 }
 
 func TestReverseBytes(t *testing.T) {
@@ -275,7 +290,7 @@ func TestGenerateOCSPCacheKeys(t *testing.T) {
 	der := []byte{105, 239, 255}
 	test.AssertDeepEquals(
 		t,
-		generateOCSPCacheKeys(der, "ocsp.invalid/"),
+		makeOCSPCacheURLs(der, "ocsp.invalid/"),
 		[]string{
 			"ocsp.invalid/?body-md5=d6101198a9d9f1f6",
 			"ocsp.invalid/ae/",

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -259,30 +259,30 @@ func TestBigBatchPurge(t *testing.T) {
 	)
 	test.AssertNotError(t, err, "Failed to create CachePurgeClient")
 
-	var urls [][]string
+	var queueEntries [][]string
 	for i := 0; i < 250; i++ {
-		urls = append(urls, []string{fmt.Sprintf("http://test.com/%d", i)})
+		queueEntries = append(queueEntries, []string{fmt.Sprintf("http://test.com/%d", i)})
 	}
 
-	stoppedAt, err := client.Purge(urls)
+	stoppedAt, err := client.Purge(queueEntries)
 	test.AssertNotError(t, err, "Purge failed with 201 response")
 	test.AssertEquals(t, stoppedAt, 250)
 
-	// Add a malformed URL.
-	malformedURL := []string{"http:/test.com"}
-	urls = append(urls, malformedURL)
+	// Add an entry with a malformed URL.
+	entryWithMalformedURL := []string{"http:/test.com"}
+	queueEntries = append(queueEntries, entryWithMalformedURL)
 
 	// Add 10 more valid entries.
 	for i := 0; i < 10; i++ {
-		urls = append(urls, []string{fmt.Sprintf("http://test.com/%d", i)})
+		queueEntries = append(queueEntries, []string{fmt.Sprintf("http://test.com/%d", i)})
 	}
 
 	// Should stop at URL entry 250 ('http:/test.com') of 261 as this is the
 	// batch that results in errFatal.
-	stoppedAt, err = client.Purge(urls)
+	stoppedAt, err = client.Purge(queueEntries)
 	test.AssertError(t, err, "Purge succeeded with a malformed URL")
 	test.AssertErrorIs(t, err, errFatal)
-	test.AssertDeepEquals(t, urls[stoppedAt], malformedURL)
+	test.AssertDeepEquals(t, queueEntries[stoppedAt], entryWithMalformedURL)
 	test.AssertEquals(t, stoppedAt, 250)
 }
 

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -112,7 +113,7 @@ func (t *Throughput) validate() error {
 	}
 
 	// Send no more than the 50 API requests we’re allotted each second.
-	requestsPerSecond := int(time.Second / t.PurgeBatchEvery.Duration)
+	requestsPerSecond := int(math.Ceil(float64(time.Second) / float64(t.PurgeBatchEvery.Duration)))
 	if requestsPerSecond > akamaiAPIReqPerSecondLimit {
 		return fmt.Errorf("config exceeds Akamai's requests per second limit (%d requests) by %d",
 			akamaiAPIReqPerSecondLimit, requestsPerSecond-akamaiAPIReqPerSecondLimit)

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -24,40 +23,150 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-// defaultQueueSize is the default akamai-purger queue size.
-const defaultQueueSize = 1000000
+const (
+	// TODO(#6003) remove entirely.
+	DeprecatedURLBatchSize = 33
+
+	// defaultQueueSize is the size of the queue when the configuration key
+	// 'maxQueueSize' is unspecified. A queue size of 1.25M cached OCSP
+	// responses, assuming 3 URLs per request, is about 6 hours of work using
+	// default settings.
+	defaultQueueSize         = 1250000
+	defaultResponsesPerBatch = 2
+	defaultPurgeBatchEvery   = time.Millisecond * 32
+
+	// akamaiBytesPerResponse is the total bytes of all 3 URLs of cached OCSP responses associated with
+	// each certificate.
+	akamaiBytesPerResponse = 400
+
+	// akamaiBytesPerReqLimit is the limit of bytes allowed in a single request
+	// to the Fast-Purge API. With a limit of no more than 50,000 bytes, we
+	// subtract 1 byte to get the limit, and subtract an additional 19 bytes for
+	// overhead of the 'objects' key and array.
+	akamaiBytesPerReqLimit = 50000 - 1 - 19
+
+	// akamaiAPIReqPerSecondLimit is the limit of requests, per second, that
+	// we're allowed to make to the Fast-Purge API.
+	akamaiAPIReqPerSecondLimit = 50
+
+	// akamaiAPIReqPerSecondLimit is the limit of URLs, sent per second, that
+	// we're allowed to make to the Fast-Purge API.
+	akamaiURLsPerSecondLimit = 200
+)
+
+// Throughput is a container for all throuput related akamai-purger
+// configuration settings.
+type Throughput struct {
+
+	// ResponsesPerBatch the number of cached OCSP responses to included in each
+	// purge request. One cached OCSP response is composed of 3 URLs totaling <
+	// 400 bytes. If this value isn't provided it will default to
+	// 'defaultResponsesPerBatch'.
+	ResponsesPerBatch int
+
+	// PurgeBatchEvery is the duration waited between dispatching an Akamai
+	// purge request containing 'ResponsesPerBatch' * 3 URLs. If this value
+	// isn't provided it will default to 'defaultPurgeBatchEvery'.
+	PurgeBatchEvery cmd.ConfigDuration
+}
+
+func (t *Throughput) useOptimizedDefaults() {
+	if t.ResponsesPerBatch == 0 {
+		t.ResponsesPerBatch = defaultResponsesPerBatch
+	}
+	if t.PurgeBatchEvery.Duration == 0 {
+		t.PurgeBatchEvery.Duration = defaultPurgeBatchEvery
+	}
+}
+
+// validate ensures that the provided throughput configuration will not violate
+// the Akamai Fast-Purge API limits. For more information see the official
+// documentation:
+// https://techdocs.akamai.com/purge-cache/reference/rate-limiting
+func (t *Throughput) validate() error {
+	if t.PurgeBatchEvery.Duration == 0 {
+		// TODO(#6003) remove /'purgeInterval'.
+		return errors.New("'purgeBatchEvery'/'purgeInterval' must be > 0 nanoseconds")
+	}
+	if t.ResponsesPerBatch <= 0 {
+		return errors.New("'responsesPerBatch' must be > 0")
+	}
+
+	// Send no more than the 50,000 bytes of objects we’re allotted per request.
+	bytesPerRequest := (t.ResponsesPerBatch * akamaiBytesPerResponse)
+	if bytesPerRequest > akamaiBytesPerReqLimit {
+		return fmt.Errorf("configuration exceeds Akamai's bytes per request limit (%d bytes) by %d",
+			akamaiBytesPerReqLimit, bytesPerRequest-akamaiBytesPerReqLimit)
+	}
+
+	// Send no more than the 50 API requests we’re allotted each second.
+	requestsPerSecond := int(time.Second / t.PurgeBatchEvery.Duration)
+	if requestsPerSecond > akamaiAPIReqPerSecondLimit {
+		return fmt.Errorf("configuration exceeds Akamai's requests per second limit (%d requests) by %d",
+			akamaiAPIReqPerSecondLimit, requestsPerSecond-akamaiAPIReqPerSecondLimit)
+	}
+
+	// Purge no more than the 200 URLs we’re allotted each second.
+	urlsPurgedPerSecond := requestsPerSecond * (t.ResponsesPerBatch * 3)
+	if urlsPurgedPerSecond > akamaiURLsPerSecondLimit {
+		return fmt.Errorf("configuration exceeds Akamai's URLs purged per second limit (%d URLs) by %d",
+			akamaiURLsPerSecondLimit, urlsPurgedPerSecond-akamaiURLsPerSecondLimit)
+	}
+	return nil
+}
 
 type Config struct {
 	AkamaiPurger struct {
 		cmd.ServiceConfig
 
-		// PurgeInterval is the duration waited between purge requests.
+		// PurgeInterval is DEPRECATED in favor of the 'PurgeBatchEvery' field
+		// of the 'Throughput' struct. TODO(#6003) remove this field.
 		PurgeInterval cmd.ConfigDuration
 
 		// MaxQueueSize is the maximum size of the purger queue. If this value
 		// isn't provided it will default to `defaultQueueSize`.
 		MaxQueueSize int
 
-		BaseURL           string
-		ClientToken       string
-		ClientSecret      string
-		AccessToken       string
-		V3Network         string
-		PurgeRetries      int
+		BaseURL      string
+		ClientToken  string
+		ClientSecret string
+		AccessToken  string
+		V3Network    string
+
+		// Throughput is a container for all throughput related akamai-purger
+		// settings.
+		Throughput Throughput
+
+		// PurgeRetries is the maximum number of attempts that will be made to purge a
+		// batch of URLs before the batch is added back to the queue.
+		PurgeRetries int
+
+		// PurgeRetryBackoff is the base duration that will be waited before
+		// attempting to purge a batch of URLs which previously failed to be
+		// purged.
 		PurgeRetryBackoff cmd.ConfigDuration
 	}
 	Syslog  cmd.SyslogConfig
 	Beeline cmd.BeelineConfig
 }
 
+// TODO(#6003) remove entirely.
+func (c *Config) useDeprecatedSettings() {
+	c.AkamaiPurger.Throughput.PurgeBatchEvery = c.AkamaiPurger.PurgeInterval
+	c.AkamaiPurger.Throughput.ResponsesPerBatch = DeprecatedURLBatchSize
+}
+
 // akamaiPurger is a mutex protected container for a gRPC server which receives
 // requests to purge the URLs of OCSP responses cached by Akamai, stores these
-// URLs in an inner slice, and dispatches them to Akamai's Fast Purge API in
-// batches.
+// URLs as a slice in an inner slice, and dispatches them to Akamai's Fast Purge
+// API in batches.
 type akamaiPurger struct {
 	sync.Mutex
 	akamaipb.UnimplementedAkamaiPurgerServer
-	toPurge      []string
+
+	// toPurge functions as a queue where each entry contains the three OCSP response URLs
+	// associated with a given certificate.
+	toPurge      [][]string
 	maxQueueSize int
 	client       *akamai.CachePurgeClient
 	log          blog.Logger
@@ -71,35 +180,37 @@ func (ap *akamaiPurger) len() int {
 
 func (ap *akamaiPurger) purge() error {
 	ap.Lock()
-	urls := ap.toPurge[:]
-	ap.toPurge = []string{}
+	entries := ap.toPurge[:]
+	ap.toPurge = [][]string{}
 	ap.Unlock()
-	if len(urls) == 0 {
+	if len(entries) == 0 {
 		return nil
 	}
 
-	stoppedAt, err := ap.client.Purge(urls)
+	stoppedAt, err := ap.client.Purge(entries)
 	if err != nil {
 		ap.Lock()
 
 		// Add the remaining URLs back, but at the end of the queue. If somehow
 		// there's a URL which repeatedly results in error, it won't block the
 		// entire queue, only a single batch.
-		ap.toPurge = append(ap.toPurge, urls[stoppedAt:]...)
+		ap.toPurge = append(ap.toPurge, entries[stoppedAt:]...)
 		ap.Unlock()
-		ap.log.Errf("Failed to purge %d URLs: %s", len(urls), err)
+		ap.log.Errf("Failed to purge %d URLs: %s", len(entries), err)
 		return err
 	}
 	return nil
 }
 
+// Purge is an exported gRPC method which receives purge requests and appends
+// them to the queue.
 func (ap *akamaiPurger) Purge(ctx context.Context, req *akamaipb.PurgeRequest) (*emptypb.Empty, error) {
 	ap.Lock()
 	defer ap.Unlock()
 	if len(ap.toPurge) >= ap.maxQueueSize {
 		return nil, errors.New("akamai-purger queue too large")
 	}
-	ap.toPurge = append(ap.toPurge, req.Urls...)
+	ap.toPurge = append(ap.toPurge, req.Urls)
 	return &emptypb.Empty{}, nil
 }
 
@@ -123,6 +234,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Check if the purger is being started in daemon (URL purging gRPC service)
+	// or manual (ad-hoc tag purging) mode.
 	var manualMode bool
 	if os.Args[1] == "manual" {
 		manualMode = true
@@ -136,7 +249,6 @@ func main() {
 		} else if *tag != "" && *tagFile != "" {
 			cmd.Fail("Cannot specify both of --tag and --tag-file for manual purge")
 		}
-
 		configFile = manualConfigFile
 	} else {
 		_ = daemonFlags.Parse(os.Args[1:])
@@ -150,11 +262,14 @@ func main() {
 	err := cmd.ReadConfigFile(*configFile, &c)
 	cmd.FailOnError(err, "Reading JSON config file into config structure")
 
+	// Make references to the service config cleaner.
+	apc := &c.AkamaiPurger
+
 	if *grpcAddr != "" {
-		c.AkamaiPurger.GRPC.Address = *grpcAddr
+		apc.GRPC.Address = *grpcAddr
 	}
 	if *debugAddr != "" {
-		c.AkamaiPurger.DebugAddr = *debugAddr
+		apc.DebugAddr = *debugAddr
 	}
 
 	bc, err := c.Beeline.Load()
@@ -162,33 +277,50 @@ func main() {
 	beeline.Init(bc)
 	defer beeline.Close()
 
-	scope, logger := cmd.StatsAndLogging(c.Syslog, c.AkamaiPurger.DebugAddr)
+	scope, logger := cmd.StatsAndLogging(c.Syslog, apc.DebugAddr)
 	defer logger.AuditPanic()
 	logger.Info(cmd.VersionString())
 
-	if c.AkamaiPurger.PurgeInterval.Duration == 0 {
-		cmd.Fail("'PurgeInterval' must be > 0")
+	// TODO(#6003) This block satisfies our deployability guidelines and can be
+	// removed entirely once the 'purgeInterval' key has been removed from all
+	// staging and production configuration.
+	usingDeprecatedThroughput := apc.PurgeInterval.Duration != 0
+	usingNewThroughput := apc.Throughput != Throughput{}
+	if usingDeprecatedThroughput && usingNewThroughput {
+		cmd.Fail("Config cannot specify both 'throughput': {...} AND 'purgeInterval'")
+	}
+	if usingDeprecatedThroughput && !usingNewThroughput {
+		c.useDeprecatedSettings()
 	}
 
-	if c.AkamaiPurger.MaxQueueSize == 0 {
-		c.AkamaiPurger.MaxQueueSize = defaultQueueSize
+	// When the operator hasn't specified any throughput settings, use the
+	// optimized defaults. TODO(#6003) remove 'usingDeprecatedThroughput'.
+	if !usingDeprecatedThroughput && !usingNewThroughput {
+		apc.Throughput.useOptimizedDefaults()
+	}
+	cmd.FailOnError(apc.Throughput.validate(), "")
+
+	if apc.MaxQueueSize == 0 {
+		apc.MaxQueueSize = defaultQueueSize
 	}
 
 	ccu, err := akamai.NewCachePurgeClient(
-		c.AkamaiPurger.BaseURL,
-		c.AkamaiPurger.ClientToken,
-		c.AkamaiPurger.ClientSecret,
-		c.AkamaiPurger.AccessToken,
-		c.AkamaiPurger.V3Network,
-		c.AkamaiPurger.PurgeRetries,
-		c.AkamaiPurger.PurgeRetryBackoff.Duration,
+		apc.BaseURL,
+		apc.ClientToken,
+		apc.ClientSecret,
+		apc.AccessToken,
+		apc.V3Network,
+		apc.Throughput.ResponsesPerBatch,
+		apc.PurgeRetries,
+		apc.PurgeRetryBackoff.Duration,
+		apc.Throughput.PurgeBatchEvery.Duration,
 		logger,
 		scope,
 	)
 	cmd.FailOnError(err, "Failed to setup Akamai CCU client")
 
 	ap := &akamaiPurger{
-		maxQueueSize: c.AkamaiPurger.MaxQueueSize,
+		maxQueueSize: apc.MaxQueueSize,
 		client:       ccu,
 		log:          logger,
 	}
@@ -203,19 +335,23 @@ func main() {
 	scope.MustRegister(gaugePurgeQueueLength)
 
 	if manualMode {
-		manualPurge(ccu, *tag, *tagFile, logger)
+		purgeByTag(ccu, *tag, *tagFile, logger)
 	} else {
-		daemon(c, ap, logger, scope)
+		startAkamaiPurger(c, ap, logger, scope)
 	}
 }
 
-func manualPurge(purgeClient *akamai.CachePurgeClient, tag, tagFile string, logger blog.Logger) {
+// purgeByTag is called ad-hoc to purge either a single tag, or a batch of tags,
+// passed on the CLI. All tags will be added to a single request, please ensure
+// that you don't violate the Fast-Purge API limits for tags detailed here:
+// https://techdocs.akamai.com/purge-cache/reference/rate-limiting
+func purgeByTag(purgeClient *akamai.CachePurgeClient, tag, tagFile string, logger blog.Logger) {
 	var tags []string
 	if tag != "" {
 		tags = []string{tag}
 	} else {
-		contents, err := ioutil.ReadFile(tagFile)
-		cmd.FailOnError(err, "Reading --tag-file")
+		contents, err := os.ReadFile(tagFile)
+		cmd.FailOnError(err, fmt.Sprintf("While reading %q", tagFile))
 		tags = strings.Split(string(contents), "\n")
 	}
 
@@ -223,14 +359,15 @@ func manualPurge(purgeClient *akamai.CachePurgeClient, tag, tagFile string, logg
 	cmd.FailOnError(err, "Purging tags")
 }
 
-func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Registerer) {
+// startAkamaiPurger initializes the akamai-purger gRPC service.
+func startAkamaiPurger(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Registerer) {
 	clk := cmd.Clock()
 
 	tlsConfig, err := c.AkamaiPurger.TLS.Load()
 	cmd.FailOnError(err, "tlsConfig config")
 
 	stop, stopped := make(chan bool, 1), make(chan bool, 1)
-	ticker := time.NewTicker(c.AkamaiPurger.PurgeInterval.Duration)
+	ticker := time.NewTicker(c.AkamaiPurger.Throughput.PurgeBatchEvery.Duration)
 	go func() {
 	loop:
 		for {

--- a/cmd/akamai-purger/main_test.go
+++ b/cmd/akamai-purger/main_test.go
@@ -49,10 +49,10 @@ func TestThroughput_validate(t *testing.T) {
 				PurgeBatchEvery:   1 * time.Second},
 			true,
 		},
-		{"exceeds requests per second by 2 requests",
+		{"exceeds requests per second by 1 request",
 			fields{
 				ResponsesPerBatch: 1,
-				PurgeBatchEvery:   19 * time.Millisecond},
+				PurgeBatchEvery:   19999 * time.Microsecond},
 			true,
 		},
 	}

--- a/cmd/akamai-purger/main_test.go
+++ b/cmd/akamai-purger/main_test.go
@@ -1,0 +1,60 @@
+package notmain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThroughput_validate(t *testing.T) {
+	type fields struct {
+		ResponsesPerBatch int
+		PurgeBatchEvery   time.Duration
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{"deployability defaults",
+			fields{
+				ResponsesPerBatch: 33,
+				PurgeBatchEvery:   10 * time.Second},
+			false,
+		},
+		{"optimized defaults, should succeed",
+			fields{
+				ResponsesPerBatch: defaultResponsesPerBatch,
+				PurgeBatchEvery:   defaultPurgeBatchEvery},
+			false,
+		},
+		{"2ms faster than optimized defaults, should succeed",
+			fields{
+				ResponsesPerBatch: defaultResponsesPerBatch,
+				PurgeBatchEvery:   30 * time.Millisecond},
+			false,
+		},
+		{"3ms faster than optimized defaults, exceed by 4 URLs",
+			fields{
+				ResponsesPerBatch: defaultResponsesPerBatch,
+				PurgeBatchEvery:   29 * time.Millisecond},
+			true,
+		},
+		{"exceed by 20 bytes",
+			fields{
+				ResponsesPerBatch: 125,
+				PurgeBatchEvery:   1 * time.Second},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &Throughput{
+				ResponsesPerBatch: tt.fields.ResponsesPerBatch,
+			}
+			tr.PurgeBatchEvery.Duration = tt.fields.PurgeBatchEvery
+			if err := tr.validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Throughput.validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/akamai-purger/main_test.go
+++ b/cmd/akamai-purger/main_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestThroughput_validate(t *testing.T) {
 	type fields struct {
-		ResponsesPerBatch int
-		PurgeBatchEvery   time.Duration
+		QueueEntriesPerBatch int
+		PurgeBatchInterval   time.Duration
 	}
 	tests := []struct {
 		name    string
@@ -21,47 +21,47 @@ func TestThroughput_validate(t *testing.T) {
 		// seconds of wait to verify_akamai_purge() in test/helpers.py.
 		{"production configuration prior to this change",
 			fields{
-				ResponsesPerBatch: DeprecatedResponsesPerBatch,
-				PurgeBatchEvery:   10 * time.Second},
+				QueueEntriesPerBatch: DeprecatedQueueEntriesPerBatch,
+				PurgeBatchInterval:   10 * time.Second},
 			false,
 		},
 		{"optimized defaults, should succeed",
 			fields{
-				ResponsesPerBatch: defaultResponsesPerBatch,
-				PurgeBatchEvery:   defaultPurgeBatchEvery},
+				QueueEntriesPerBatch: defaultQueueEntriesPerBatch,
+				PurgeBatchInterval:   defaultPurgeBatchInterval},
 			false,
 		},
 		{"2ms faster than optimized defaults, should succeed",
 			fields{
-				ResponsesPerBatch: defaultResponsesPerBatch,
-				PurgeBatchEvery:   defaultPurgeBatchEvery + 2*time.Millisecond},
+				QueueEntriesPerBatch: defaultQueueEntriesPerBatch,
+				PurgeBatchInterval:   defaultPurgeBatchInterval + 2*time.Millisecond},
 			false,
 		},
 		{"exceeds URLs per second by 4 URLs",
 			fields{
-				ResponsesPerBatch: defaultResponsesPerBatch,
-				PurgeBatchEvery:   29 * time.Millisecond},
+				QueueEntriesPerBatch: defaultQueueEntriesPerBatch,
+				PurgeBatchInterval:   29 * time.Millisecond},
 			true,
 		},
 		{"exceeds bytes per second by 20 bytes",
 			fields{
-				ResponsesPerBatch: 125,
-				PurgeBatchEvery:   1 * time.Second},
+				QueueEntriesPerBatch: 125,
+				PurgeBatchInterval:   1 * time.Second},
 			true,
 		},
 		{"exceeds requests per second by 1 request",
 			fields{
-				ResponsesPerBatch: 1,
-				PurgeBatchEvery:   19999 * time.Microsecond},
+				QueueEntriesPerBatch: 1,
+				PurgeBatchInterval:   19999 * time.Microsecond},
 			true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := &Throughput{
-				ResponsesPerBatch: tt.fields.ResponsesPerBatch,
+				QueueEntriesPerBatch: tt.fields.QueueEntriesPerBatch,
 			}
-			tr.PurgeBatchEvery.Duration = tt.fields.PurgeBatchEvery
+			tr.PurgeBatchInterval.Duration = tt.fields.PurgeBatchInterval
 			if err := tr.validate(); (err != nil) != tt.wantErr {
 				t.Errorf("Throughput.validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -4,8 +4,8 @@
     "purgeRetries": 10,
     "purgeRetryBackoff": "50ms",
     "throughput": {
-      "responsesPerBatch": 2,
-      "purgeBatchEvery": "32ms"
+      "queueEntriesPerBatch": 2,
+      "purgeBatchInterval": "32ms"
     },
     "baseURL": "http://localhost:6789",
     "clientToken": "its-a-token",

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -1,7 +1,6 @@
 {
   "akamaiPurger": {
     "debugAddr": ":9666",
-    "purgeInterval": "1ms",
     "purgeRetries": 10,
     "purgeRetryBackoff": "50ms",
     "baseURL": "http://localhost:6789",

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -3,6 +3,10 @@
     "debugAddr": ":9666",
     "purgeRetries": 10,
     "purgeRetryBackoff": "50ms",
+    "throughput": {
+      "responsesPerBatch": 2,
+      "purgeBatchEvery": "32ms"
+    },
     "baseURL": "http://localhost:6789",
     "clientToken": "its-a-token",
     "clientSecret": "its-a-secret",

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -1,7 +1,7 @@
 {
   "akamaiPurger": {
     "debugAddr": ":9666",
-    "purgeInterval": "350ms",
+    "purgeInterval": "800ms",
     "purgeRetries": 10,
     "purgeRetryBackoff": "50ms",
     "baseURL": "http://localhost:6789",

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -1,7 +1,7 @@
 {
   "akamaiPurger": {
     "debugAddr": ":9666",
-    "purgeInterval": "1ms",
+    "purgeInterval": "350ms",
     "purgeRetries": 10,
     "purgeRetryBackoff": "50ms",
     "baseURL": "http://localhost:6789",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -120,7 +120,8 @@ def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges", data="{}")
 
 def verify_akamai_purge():
-    deadline = time.time() + 0.5
+    # TODO(#6003): reduce '+ 1' to '.40'
+    deadline = time.time() + 1
     while True:
         time.sleep(0.05)
         if time.time() > deadline:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -120,7 +120,7 @@ def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges", data="{}")
 
 def verify_akamai_purge():
-    deadline = time.time() + 0.25
+    deadline = time.time() + 0.5
     while True:
         time.sleep(0.05)
         if time.time() > deadline:

--- a/test/integration/akamai_purger_drain_queue_test.go
+++ b/test/integration/akamai_purger_drain_queue_test.go
@@ -87,7 +87,7 @@ func TestAkamaiPurgerDrainQueueFails(t *testing.T) {
 	if err == nil {
 		t.Error("expected error shutting down akamai-purger that could not reach backend")
 	}
-	expectedOutput := "failed to purge 1 queue entries before exit: all attempts to submit purge request failed"
+	expectedOutput := "failed to purge OCSP responses for 1 certificates before exit: all attempts to submit purge request failed"
 	if !strings.Contains(outputBuffer.String(), expectedOutput) {
 		t.Errorf("akamai-purger stdout did not contain expected %q. Output was:\n%s", expectedOutput, outputBuffer.String())
 	}
@@ -119,7 +119,7 @@ func TestAkamaiPurgerDrainQueueSucceeds(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error shutting down akamai-purger: %s. Output was:\n%s", err, outputBuffer.String())
 	}
-	expectedOutput := "Shutting down; finished purging 10 queue entries."
+	expectedOutput := "Shutting down; finished purging OCSP responses for 10 certificates."
 	if !strings.Contains(outputBuffer.String(), expectedOutput) {
 		t.Errorf("akamai-purger stdout did not contain expected %q. Output was:\n%s", expectedOutput, outputBuffer.String())
 	}


### PR DESCRIPTION
- Add new configuration key `throughput`, a mapping which contains all
  throughput related akamai-purger settings.
- Deprecate configuration key `purgeInterval` in favor of `purgeBatchInterval` in
  the new `throughput` configuration mapping.
- When no `throughput` or `purgeInterval` is provided, the purger uses optimized
  default settings which offer 1.9x the throughput of current production settings.
- At startup, all throughput related settings are modeled to ensure that we
  don't exceed the limits imposed on us by Akamai.
- Queue is now `[][]string`, instead of `[]string`.
  - When a given queue entry is purged we know all 3 of it's URLs were purged.
  - At startup we know the size of a theoretical request to purge based on the
    number of queue entries included
- Raises the queue size from ~333-thousand cached OCSP responses to
  1.25-million, which is roughly 6 hours of work using the optimized default
  settings
- Raise `purgeInterval` in test config from 1ms, which violates API limits, to 800ms

Fixes #5984