### PR TITLE
Add logging of "oldTLS" bit

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -172,6 +172,7 @@ type ValidationRecord struct {
 
 	// OldTLS is true if any request in the validation chain used HTTPS and negotiated
 	// a TLS version lower than 1.2.
+	// TODO(#6011): Remove once TLS 1.0 and 1.1 support is gone.
 	OldTLS bool `json:"oldTLS,omitempty"`
 }
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -169,6 +169,10 @@ type ValidationRecord struct {
 	//   ...
 	// }
 	AddressesTried []net.IP `json:"addressesTried,omitempty"`
+
+	// OldTLS is true if any request in the validation chain used HTTPS and negotiated
+	// a TLS version lower than 1.2.
+	OldTLS bool `json:"oldTLS,omitempty"`
 }
 
 func looksLikeKeyAuthorization(str string) error {

--- a/va/http.go
+++ b/va/http.go
@@ -504,6 +504,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		numRedirects++
 		va.metrics.http01Redirects.Inc()
 
+		// TODO(#6011): Remove once TLS 1.0 and 1.1 support is gone.
 		if req.Response.TLS != nil && req.Response.TLS.Version < tls.VersionTLS12 {
 			oldTLS = true
 		}
@@ -623,6 +624,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 			records[len(records)-1].URL, records[len(records)-1].AddressUsed, httpResponse.StatusCode)
 	}
 
+	// TODO(#6011): Remove once TLS 1.0 and 1.1 support is gone.
 	if httpResponse.TLS != nil && httpResponse.TLS.Version < tls.VersionTLS12 {
 		oldTLS = true
 	}
@@ -648,7 +650,6 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		return nil, records, berrors.UnauthorizedError("Invalid response from %s [%s]: %q",
 			records[len(records)-1].URL, records[len(records)-1].AddressUsed, replaceInvalidUTF8(body))
 	}
-
 	return body, records, nil
 }
 

--- a/va/http.go
+++ b/va/http.go
@@ -494,6 +494,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 	// addresses explicitly, not following redirects to ports != [80,443], etc)
 	records := []core.ValidationRecord{baseRecord}
 	numRedirects := 0
+	var oldTLS bool
 	processRedirect := func(req *http.Request, via []*http.Request) error {
 		va.log.Debugf("processing a HTTP redirect from the server to %q", req.URL.String())
 		// Only process up to maxRedirect redirects
@@ -502,6 +503,10 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		}
 		numRedirects++
 		va.metrics.http01Redirects.Inc()
+
+		if req.Response.TLS != nil && req.Response.TLS.Version < tls.VersionTLS12 {
+			oldTLS = true
+		}
 
 		// If the response contains an HTTP 303 or any other forbidden redirect,
 		// do not follow it. The four allowed redirect status codes are defined
@@ -635,6 +640,15 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		return nil, records, berrors.UnauthorizedError("Invalid response from %s [%s]: %q",
 			records[len(records)-1].URL, records[len(records)-1].AddressUsed, replaceInvalidUTF8(body))
 	}
+
+	if httpResponse.TLS != nil && httpResponse.TLS.Version < tls.VersionTLS12 {
+		oldTLS = true
+	}
+
+	if oldTLS {
+		records[len(records)-1].OldTLS = true
+	}
+
 	return body, records, nil
 }
 


### PR DESCRIPTION
That causes the VA to emit ValidationRecords with the OldTLS bit set if it observes a redirect to HTTPS that negotiates TLS < 1.2.

I've manually tested but there is not yet an integration test. I need to make a parallel change in challtestsrv and then incorporate here.