### PR TITLE
CI: Update make-deb.sh path in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://cli.github.com/manual/gh_release_create
         run: |
-          ./make-deb.sh
+          ./tools/make-deb.sh
           gh release create "${GITHUB_REF_NAME}" *.deb


### PR DESCRIPTION
Update the path to `make-deb.sh` in the release workflow, to the path it was
moved to in #6005.