### PR TITLE
rocsp-tool: don't log every 10th insert

### DIFF
--- a/cmd/rocsp-tool/client.go
+++ b/cmd/rocsp-tool/client.go
@@ -114,7 +114,11 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed, startFr
 			successCount++
 		}
 
-		if (successCount+errorCount)%10 == 0 {
+		total := successCount + errorCount
+		if total < 10 ||
+			(total < 1000 && rand.Intn(1000) < 100) ||
+			(total < 100000 && rand.Intn(1000) < 10) ||
+			(rand.Intn(1000) < 1) {
 			cl.logger.Infof("stored %d responses, %d errors", successCount, errorCount)
 		}
 	}


### PR DESCRIPTION
Logging every 10 is quite noisy; instead adopt the same strategy we use
for errors, and log all of them at first, fading out to fewer of them as
we get to bigger numbers.