### PR TITLE
refactor log package to use hashicorp/go-syslog to support windows 

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log/syslog"
 	"os"
 	"reflect"
 	"regexp"
@@ -15,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	zX509 "github.com/zmap/zcrypto/x509"
@@ -365,7 +365,7 @@ func main() {
 	err = features.Set(config.CertChecker.Features)
 	cmd.FailOnError(err, "Failed to set feature flags")
 
-	syslogger, err := syslog.Dial("", "", syslog.LOG_INFO|syslog.LOG_LOCAL0, "")
+	syslogger, err := gsyslog.DialLogger("", "", gsyslog.LOG_INFO, "LOCAL0", "")
 	cmd.FailOnError(err, "Failed to dial syslog")
 
 	logger, err := blog.New(syslogger, 0, 0)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -6,7 +6,6 @@ import (
 	"expvar"
 	"fmt"
 	"log"
-	"log/syslog"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -20,6 +19,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/go-sql-driver/mysql"
+	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -151,13 +151,14 @@ func StatsAndLogging(logConf SyslogConfig, addr string) (prometheus.Registerer, 
 
 func NewLogger(logConf SyslogConfig) blog.Logger {
 	tag := path.Base(os.Args[0])
-	syslogger, err := syslog.Dial(
+	syslogger, err := gsyslog.DialLogger(
 		"",
 		"",
-		syslog.LOG_INFO, // default, not actually used
+		gsyslog.LOG_INFO, // default, not actually used
+		"LOCAL0",
 		tag)
 	FailOnError(err, "Could not connect to Syslog")
-	syslogLevel := int(syslog.LOG_INFO)
+	syslogLevel := int(gsyslog.LOG_INFO)
 	if logConf.SyslogLevel != 0 {
 		syslogLevel = logConf.SyslogLevel
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/certificate-transparency-go v1.0.22-0.20181127102053-c25855a82c75
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/hashicorp/go-syslog v1.0.0
 	github.com/honeycombio/beeline-go v1.1.1
 	github.com/hpcloud/tail v1.0.0
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=
+github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/honeycombio/beeline-go v1.1.1 h1:sU8r4ae34uEL3/CguSl8Mr+Asz9DL1nfH9Wwk85Pc7U=
 github.com/honeycombio/beeline-go v1.1.1/go.mod h1:kN0cfUGBMfA87DyCYbiiLoSzWsnw3bluZvNEWtatHxk=

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -21,7 +22,7 @@ const syslogLevel = 7
 func setup(t *testing.T) *impl {
 	// Write all logs to UDP on a high port so as to not bother the system
 	// which is running the test
-	writer, err := syslog.Dial("udp", "127.0.0.1:65530", syslog.LOG_INFO|syslog.LOG_LOCAL0, "")
+	writer, err := gsyslog.DialLogger("udp", "127.0.0.1:65530", gsyslog.LOG_INFO, "LOCAL0", "")
 	test.AssertNotError(t, err, "Could not construct syslog object")
 
 	logger, err := New(writer, stdoutLevel, syslogLevel)
@@ -86,7 +87,7 @@ func TestEmitEmpty(t *testing.T) {
 func ExampleLogger() {
 	// Write all logs to UDP on a high port so as to not bother the system
 	// which is running the test
-	writer, err := syslog.Dial("udp", "127.0.0.1:65530", syslog.LOG_INFO|syslog.LOG_LOCAL0, "")
+	writer, err := gsyslog.DialLogger("udp", "127.0.0.1:65530", gsyslog.LOG_INFO, "LOCAL0", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -192,7 +193,7 @@ func TestTransmission(t *testing.T) {
 	}()
 
 	fmt.Printf("Going to %s\n", l.LocalAddr().String())
-	writer, err := syslog.Dial("udp", l.LocalAddr().String(), syslog.LOG_INFO|syslog.LOG_LOCAL0, "")
+	writer, err := gsyslog.DialLogger("udp", l.LocalAddr().String(), gsyslog.LOG_INFO, "LOCAL0", "")
 	test.AssertNotError(t, err, "Failed to find connect to log server")
 
 	impl, err := New(writer, stdoutLevel, syslogLevel)
@@ -260,7 +261,7 @@ func TestSyslogLevels(t *testing.T) {
 	}()
 
 	fmt.Printf("Going to %s\n", l.LocalAddr().String())
-	writer, err := syslog.Dial("udp", l.LocalAddr().String(), syslog.LOG_INFO|syslog.LOG_LOCAL0, "")
+	writer, err := gsyslog.DialLogger("udp", l.LocalAddr().String(), gsyslog.LOG_INFO, "LOCAL0", "")
 	test.AssertNotError(t, err, "Failed to find connect to log server")
 
 	// create a logger with syslog level debug

--- a/log/mock.go
+++ b/log/mock.go
@@ -2,9 +2,10 @@ package log
 
 import (
 	"fmt"
-	"log/syslog"
 	"regexp"
 	"time"
+
+	gsyslog "github.com/hashicorp/go-syslog"
 )
 
 // UseMock sets a mock logger as the default logger, and returns it.
@@ -48,14 +49,14 @@ type mockWriter struct {
 	closeChan chan<- struct{}
 }
 
-var levelName = map[syslog.Priority]string{
-	syslog.LOG_ERR:     "ERR",
-	syslog.LOG_WARNING: "WARNING",
-	syslog.LOG_INFO:    "INFO",
-	syslog.LOG_DEBUG:   "DEBUG",
+var levelName = map[gsyslog.Priority]string{
+	gsyslog.LOG_ERR:     "ERR",
+	gsyslog.LOG_WARNING: "WARNING",
+	gsyslog.LOG_INFO:    "INFO",
+	gsyslog.LOG_DEBUG:   "DEBUG",
 }
 
-func (w *mockWriter) logAtLevel(p syslog.Priority, msg string) {
+func (w *mockWriter) logAtLevel(p gsyslog.Priority, msg string) {
 	w.msgChan <- fmt.Sprintf("%s: %s", levelName[p&7], msg)
 }
 
@@ -134,7 +135,7 @@ func newWaitingMockWriter() *waitingMockWriter {
 	}
 }
 
-func (m *waitingMockWriter) logAtLevel(p syslog.Priority, msg string) {
+func (m *waitingMockWriter) logAtLevel(p gsyslog.Priority, msg string) {
 	m.logChan <- fmt.Sprintf("%s: %s", levelName[p&7], msg)
 }
 

--- a/vendor/github.com/hashicorp/go-syslog/.gitignore
+++ b/vendor/github.com/hashicorp/go-syslog/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/hashicorp/go-syslog/LICENSE
+++ b/vendor/github.com/hashicorp/go-syslog/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Armon Dadgar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/hashicorp/go-syslog/README.md
+++ b/vendor/github.com/hashicorp/go-syslog/README.md
@@ -1,0 +1,11 @@
+go-syslog
+=========
+
+This repository provides a very simple `gsyslog` package. The point of this
+package is to allow safe importing of syslog without introducing cross-compilation
+issues. The stdlib `log/syslog` cannot be imported on Windows systems, and without
+conditional compilation this adds complications.
+
+Instead, `gsyslog` provides a very simple wrapper around `log/syslog` but returns
+a runtime error if attempting to initialize on a non Linux or OSX system.
+

--- a/vendor/github.com/hashicorp/go-syslog/builtin.go
+++ b/vendor/github.com/hashicorp/go-syslog/builtin.go
@@ -1,0 +1,214 @@
+// This file is taken from the log/syslog in the standard lib.
+// However, there is a bug with overwhelming syslog that causes writes
+// to block indefinitely. This is fixed by adding a write deadline.
+//
+// +build !windows,!nacl,!plan9
+
+package gsyslog
+
+import (
+	"errors"
+	"fmt"
+	"log/syslog"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const severityMask = 0x07
+const facilityMask = 0xf8
+const localDeadline = 20 * time.Millisecond
+const remoteDeadline = 50 * time.Millisecond
+
+// A builtinWriter is a connection to a syslog server.
+type builtinWriter struct {
+	priority syslog.Priority
+	tag      string
+	hostname string
+	network  string
+	raddr    string
+
+	mu   sync.Mutex // guards conn
+	conn serverConn
+}
+
+// This interface and the separate syslog_unix.go file exist for
+// Solaris support as implemented by gccgo.  On Solaris you can not
+// simply open a TCP connection to the syslog daemon.  The gccgo
+// sources have a syslog_solaris.go file that implements unixSyslog to
+// return a type that satisfies this interface and simply calls the C
+// library syslog function.
+type serverConn interface {
+	writeString(p syslog.Priority, hostname, tag, s, nl string) error
+	close() error
+}
+
+type netConn struct {
+	local bool
+	conn  net.Conn
+}
+
+// New establishes a new connection to the system log daemon.  Each
+// write to the returned writer sends a log message with the given
+// priority and prefix.
+func newBuiltin(priority syslog.Priority, tag string) (w *builtinWriter, err error) {
+	return dialBuiltin("", "", priority, tag)
+}
+
+// Dial establishes a connection to a log daemon by connecting to
+// address raddr on the specified network.  Each write to the returned
+// writer sends a log message with the given facility, severity and
+// tag.
+// If network is empty, Dial will connect to the local syslog server.
+func dialBuiltin(network, raddr string, priority syslog.Priority, tag string) (*builtinWriter, error) {
+	if priority < 0 || priority > syslog.LOG_LOCAL7|syslog.LOG_DEBUG {
+		return nil, errors.New("log/syslog: invalid priority")
+	}
+
+	if tag == "" {
+		tag = os.Args[0]
+	}
+	hostname, _ := os.Hostname()
+
+	w := &builtinWriter{
+		priority: priority,
+		tag:      tag,
+		hostname: hostname,
+		network:  network,
+		raddr:    raddr,
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	err := w.connect()
+	if err != nil {
+		return nil, err
+	}
+	return w, err
+}
+
+// connect makes a connection to the syslog server.
+// It must be called with w.mu held.
+func (w *builtinWriter) connect() (err error) {
+	if w.conn != nil {
+		// ignore err from close, it makes sense to continue anyway
+		w.conn.close()
+		w.conn = nil
+	}
+
+	if w.network == "" {
+		w.conn, err = unixSyslog()
+		if w.hostname == "" {
+			w.hostname = "localhost"
+		}
+	} else {
+		var c net.Conn
+		c, err = net.DialTimeout(w.network, w.raddr, remoteDeadline)
+		if err == nil {
+			w.conn = &netConn{conn: c}
+			if w.hostname == "" {
+				w.hostname = c.LocalAddr().String()
+			}
+		}
+	}
+	return
+}
+
+// Write sends a log message to the syslog daemon.
+func (w *builtinWriter) Write(b []byte) (int, error) {
+	return w.writeAndRetry(w.priority, string(b))
+}
+
+// Close closes a connection to the syslog daemon.
+func (w *builtinWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil {
+		err := w.conn.close()
+		w.conn = nil
+		return err
+	}
+	return nil
+}
+
+func (w *builtinWriter) writeAndRetry(p syslog.Priority, s string) (int, error) {
+	pr := (w.priority & facilityMask) | (p & severityMask)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil {
+		if n, err := w.write(pr, s); err == nil {
+			return n, err
+		}
+	}
+	if err := w.connect(); err != nil {
+		return 0, err
+	}
+	return w.write(pr, s)
+}
+
+// write generates and writes a syslog formatted string. The
+// format is as follows: <PRI>TIMESTAMP HOSTNAME TAG[PID]: MSG
+func (w *builtinWriter) write(p syslog.Priority, msg string) (int, error) {
+	// ensure it ends in a \n
+	nl := ""
+	if !strings.HasSuffix(msg, "\n") {
+		nl = "\n"
+	}
+
+	err := w.conn.writeString(p, w.hostname, w.tag, msg, nl)
+	if err != nil {
+		return 0, err
+	}
+	// Note: return the length of the input, not the number of
+	// bytes printed by Fprintf, because this must behave like
+	// an io.Writer.
+	return len(msg), nil
+}
+
+func (n *netConn) writeString(p syslog.Priority, hostname, tag, msg, nl string) error {
+	if n.local {
+		// Compared to the network form below, the changes are:
+		//	1. Use time.Stamp instead of time.RFC3339.
+		//	2. Drop the hostname field from the Fprintf.
+		timestamp := time.Now().Format(time.Stamp)
+		n.conn.SetWriteDeadline(time.Now().Add(localDeadline))
+		_, err := fmt.Fprintf(n.conn, "<%d>%s %s[%d]: %s%s",
+			p, timestamp,
+			tag, os.Getpid(), msg, nl)
+		return err
+	}
+	timestamp := time.Now().Format(time.RFC3339)
+	n.conn.SetWriteDeadline(time.Now().Add(remoteDeadline))
+	_, err := fmt.Fprintf(n.conn, "<%d>%s %s %s[%d]: %s%s",
+		p, timestamp, hostname,
+		tag, os.Getpid(), msg, nl)
+	return err
+}
+
+func (n *netConn) close() error {
+	return n.conn.Close()
+}
+
+// unixSyslog opens a connection to the syslog daemon running on the
+// local machine using a Unix domain socket.
+func unixSyslog() (conn serverConn, err error) {
+	logTypes := []string{"unixgram", "unix"}
+	logPaths := []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
+	for _, network := range logTypes {
+		for _, path := range logPaths {
+			conn, err := net.DialTimeout(network, path, localDeadline)
+			if err != nil {
+				continue
+			} else {
+				return &netConn{conn: conn, local: true}, nil
+			}
+		}
+	}
+	return nil, errors.New("Unix syslog delivery error")
+}

--- a/vendor/github.com/hashicorp/go-syslog/syslog.go
+++ b/vendor/github.com/hashicorp/go-syslog/syslog.go
@@ -1,0 +1,27 @@
+package gsyslog
+
+// Priority maps to the syslog priority levels
+type Priority int
+
+const (
+	LOG_EMERG Priority = iota
+	LOG_ALERT
+	LOG_CRIT
+	LOG_ERR
+	LOG_WARNING
+	LOG_NOTICE
+	LOG_INFO
+	LOG_DEBUG
+)
+
+// Syslogger interface is used to write log messages to syslog
+type Syslogger interface {
+	// WriteLevel is used to write a message at a given level
+	WriteLevel(Priority, []byte) error
+
+	// Write is used to write a message at the default level
+	Write([]byte) (int, error)
+
+	// Close is used to close the connection to the logger
+	Close() error
+}

--- a/vendor/github.com/hashicorp/go-syslog/unix.go
+++ b/vendor/github.com/hashicorp/go-syslog/unix.go
@@ -1,0 +1,123 @@
+// +build linux darwin dragonfly freebsd netbsd openbsd solaris
+
+package gsyslog
+
+import (
+	"fmt"
+	"log/syslog"
+	"strings"
+)
+
+// builtinLogger wraps the Golang implementation of a
+// syslog.Writer to provide the Syslogger interface
+type builtinLogger struct {
+	*builtinWriter
+}
+
+// NewLogger is used to construct a new Syslogger
+func NewLogger(p Priority, facility, tag string) (Syslogger, error) {
+	fPriority, err := facilityPriority(facility)
+	if err != nil {
+		return nil, err
+	}
+	priority := syslog.Priority(p) | fPriority
+	l, err := newBuiltin(priority, tag)
+	if err != nil {
+		return nil, err
+	}
+	return &builtinLogger{l}, nil
+}
+
+// DialLogger is used to construct a new Syslogger that establishes connection to remote syslog server
+func DialLogger(network, raddr string, p Priority, facility, tag string) (Syslogger, error) {
+	fPriority, err := facilityPriority(facility)
+	if err != nil {
+		return nil, err
+	}
+
+	priority := syslog.Priority(p) | fPriority
+
+	l, err := dialBuiltin(network, raddr, priority, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return &builtinLogger{l}, nil
+}
+
+// WriteLevel writes out a message at the given priority
+func (b *builtinLogger) WriteLevel(p Priority, buf []byte) error {
+	var err error
+	m := string(buf)
+	switch p {
+	case LOG_EMERG:
+		_, err = b.writeAndRetry(syslog.LOG_EMERG, m)
+	case LOG_ALERT:
+		_, err = b.writeAndRetry(syslog.LOG_ALERT, m)
+	case LOG_CRIT:
+		_, err = b.writeAndRetry(syslog.LOG_CRIT, m)
+	case LOG_ERR:
+		_, err = b.writeAndRetry(syslog.LOG_ERR, m)
+	case LOG_WARNING:
+		_, err = b.writeAndRetry(syslog.LOG_WARNING, m)
+	case LOG_NOTICE:
+		_, err = b.writeAndRetry(syslog.LOG_NOTICE, m)
+	case LOG_INFO:
+		_, err = b.writeAndRetry(syslog.LOG_INFO, m)
+	case LOG_DEBUG:
+		_, err = b.writeAndRetry(syslog.LOG_DEBUG, m)
+	default:
+		err = fmt.Errorf("Unknown priority: %v", p)
+	}
+	return err
+}
+
+// facilityPriority converts a facility string into
+// an appropriate priority level or returns an error
+func facilityPriority(facility string) (syslog.Priority, error) {
+	facility = strings.ToUpper(facility)
+	switch facility {
+	case "KERN":
+		return syslog.LOG_KERN, nil
+	case "USER":
+		return syslog.LOG_USER, nil
+	case "MAIL":
+		return syslog.LOG_MAIL, nil
+	case "DAEMON":
+		return syslog.LOG_DAEMON, nil
+	case "AUTH":
+		return syslog.LOG_AUTH, nil
+	case "SYSLOG":
+		return syslog.LOG_SYSLOG, nil
+	case "LPR":
+		return syslog.LOG_LPR, nil
+	case "NEWS":
+		return syslog.LOG_NEWS, nil
+	case "UUCP":
+		return syslog.LOG_UUCP, nil
+	case "CRON":
+		return syslog.LOG_CRON, nil
+	case "AUTHPRIV":
+		return syslog.LOG_AUTHPRIV, nil
+	case "FTP":
+		return syslog.LOG_FTP, nil
+	case "LOCAL0":
+		return syslog.LOG_LOCAL0, nil
+	case "LOCAL1":
+		return syslog.LOG_LOCAL1, nil
+	case "LOCAL2":
+		return syslog.LOG_LOCAL2, nil
+	case "LOCAL3":
+		return syslog.LOG_LOCAL3, nil
+	case "LOCAL4":
+		return syslog.LOG_LOCAL4, nil
+	case "LOCAL5":
+		return syslog.LOG_LOCAL5, nil
+	case "LOCAL6":
+		return syslog.LOG_LOCAL6, nil
+	case "LOCAL7":
+		return syslog.LOG_LOCAL7, nil
+	default:
+		return 0, fmt.Errorf("invalid syslog facility: %s", facility)
+	}
+}

--- a/vendor/github.com/hashicorp/go-syslog/unsupported.go
+++ b/vendor/github.com/hashicorp/go-syslog/unsupported.go
@@ -1,0 +1,17 @@
+// +build windows plan9 nacl
+
+package gsyslog
+
+import (
+	"fmt"
+)
+
+// NewLogger is used to construct a new Syslogger
+func NewLogger(p Priority, facility, tag string) (Syslogger, error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}
+
+// DialLogger is used to construct a new Syslogger that establishes connection to remote syslog server
+func DialLogger(network, raddr string, p Priority, facility, tag string) (Syslogger, error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -67,6 +67,9 @@ github.com/google/certificate-transparency-go/x509/pkix
 # github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 ## explicit
 github.com/grpc-ecosystem/go-grpc-prometheus
+# github.com/hashicorp/go-syslog v1.0.0
+## explicit
+github.com/hashicorp/go-syslog
 # github.com/honeycombio/beeline-go v1.1.1
 ## explicit; go 1.14
 github.com/honeycombio/beeline-go


### PR DESCRIPTION
In the change https://github.com/sigstore/cosign/pull/1676 introduce the dependency for `boulder` and we compile the tool for several target archs and one is windows, looks like the `"log/syslog"` does not have support for windows, however, there is a project from hashicorp https://github.com/hashicorp/go-syslog that helps on this side to be same to cross-compile.

I did a update in our side in this testing PR and tested our tool and seems to work fine: https://github.com/cpanato/cosign/pull/175

Hopefully, this is ok :) Let me know what your thoughts on this

This PR updates the `log` package to use `github.com/hashicorp/go-syslog` and adjust where that is used.