### PR TITLE
Use OCSP NextUpdate to calculate Redis TTL

### DIFF
--- a/cmd/rocsp-tool/client_test.go
+++ b/cmd/rocsp-tool/client_test.go
@@ -111,8 +111,7 @@ func TestStoreResponse(t *testing.T) {
 		logger:        blog.NewMock(),
 	}
 
-	ttl := time.Hour
-	err = cl.storeResponse(context.Background(), response, &ttl)
+	err = cl.storeResponse(context.Background(), response)
 	test.AssertNotError(t, err, "storing response")
 }
 

--- a/ocsp/updater/updater_test.go
+++ b/ocsp/updater/updater_test.go
@@ -45,7 +45,7 @@ func (ca *mockOCSP) GenerateOCSP(_ context.Context, req *capb.GenerateOCSPReques
 type noopROCSP struct {
 }
 
-func (noopROCSP) StoreResponse(_ context.Context, _ []byte, _ byte, _ time.Duration) error {
+func (noopROCSP) StoreResponse(_ context.Context, _ []byte, _ byte) error {
 	return nil
 }
 
@@ -167,7 +167,6 @@ func TestGenerateAndStoreOCSPResponse(t *testing.T) {
 type rocspStorage struct {
 	shortIDIssuer byte
 	response      []byte
-	ttl           time.Duration
 }
 
 type recordingROCSP struct {
@@ -182,13 +181,12 @@ func (rr *recordingROCSP) get() []rocspStorage {
 	return append(ret, rr.storage...)
 }
 
-func (rr *recordingROCSP) StoreResponse(ctx context.Context, respBytes []byte, shortIssuerID byte, ttl time.Duration) error {
+func (rr *recordingROCSP) StoreResponse(ctx context.Context, respBytes []byte, shortIssuerID byte) error {
 	rr.Lock()
 	defer rr.Unlock()
 	rr.storage = append(rr.storage, rocspStorage{
 		shortIDIssuer: shortIssuerID,
 		response:      respBytes,
-		ttl:           ttl,
 	})
 	return nil
 }

--- a/rocsp/mocks.go
+++ b/rocsp/mocks.go
@@ -3,7 +3,6 @@ package rocsp
 import (
 	"context"
 	"fmt"
-	"time"
 )
 
 // MockWriteClient is a mock
@@ -13,7 +12,7 @@ type MockWriteClient struct {
 
 // StoreResponse mocks a rocsp.StoreResponse method and returns nil or an
 // error depending on the desired state.
-func (r MockWriteClient) StoreResponse(ctx context.Context, respBytes []byte, shortIssuerID byte, ttl time.Duration) error {
+func (r MockWriteClient) StoreResponse(ctx context.Context, respBytes []byte, shortIssuerID byte) error {
 	return r.StoreReponseReturnError
 }
 

--- a/rocsp/rocsp_test.go
+++ b/rocsp/rocsp_test.go
@@ -45,7 +45,7 @@ func TestSetAndGet(t *testing.T) {
 		t.Fatal(err)
 	}
 	var shortIssuerID byte = 99
-	err = client.StoreResponse(context.Background(), response, byte(shortIssuerID), time.Hour)
+	err = client.StoreResponse(context.Background(), response, byte(shortIssuerID))
 	if err != nil {
 		t.Fatalf("storing response: %s", err)
 	}

--- a/sa/rocsp_sa.go
+++ b/sa/rocsp_sa.go
@@ -2,44 +2,26 @@ package sa
 
 import (
 	"context"
-	"time"
 
 	rocsp_config "github.com/letsencrypt/boulder/rocsp/config"
-	"golang.org/x/crypto/ocsp"
 )
 
 type rocspWriter interface {
-	StoreResponse(ctx context.Context, respBytes []byte, shortIssuerID byte, ttl time.Duration) error
+	StoreResponse(ctx context.Context, respBytes []byte, shortIssuerID byte) error
 }
 
 // storeOCSPRedis stores an OCSP response in a redis cluster.
 func (ssa *SQLStorageAuthority) storeOCSPRedis(ctx context.Context, resp []byte, issuerID int64) error {
-	nextUpdate, err := getNextUpdate(resp)
-	if err != nil {
-		ssa.redisStoreResponse.WithLabelValues("parse_response_error").Inc()
-		return err
-	}
-	ttl := time.Until(nextUpdate)
-
 	shortIssuerID, err := rocsp_config.FindIssuerByID(issuerID, ssa.shortIssuers)
 	if err != nil {
 		ssa.redisStoreResponse.WithLabelValues("find_issuer_error").Inc()
 		return err
 	}
-	err = ssa.rocspWriteClient.StoreResponse(ctx, resp, shortIssuerID.ShortID(), ttl)
+	err = ssa.rocspWriteClient.StoreResponse(ctx, resp, shortIssuerID.ShortID())
 	if err != nil {
 		ssa.redisStoreResponse.WithLabelValues("store_response_error").Inc()
 		return err
 	}
 	ssa.redisStoreResponse.WithLabelValues("success").Inc()
 	return nil
-}
-
-// getNextUpdate returns the NextUpdate value from the OCSP response.
-func getNextUpdate(resp []byte) (time.Time, error) {
-	response, err := ocsp.ParseResponse(resp, nil)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return response.NextUpdate, nil
 }


### PR DESCRIPTION
`rocsp.StoreResponse()` no longer accepts a TTL as a parameter
and instead calculates the Redis TTL based on the OCSP response's
NextUpdate field.

Fixes #6020