### PR TITLE
Update to latest version of golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,6 +21,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.45.2
           args: --timeout 9m
           only-new-issues: true


### PR DESCRIPTION
Update from v1.42.1 to v1.45.2. This version has both
better support for go1.18, and better automatic detection
of which go version to use (based on our go.mod file,
it will currently use go1.17).