### PR TITLE
akamai-purger: Make the purger queue a stack

### DIFF
--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -39,9 +39,8 @@ const (
 	// OCSP response.
 	urlsPerQueueEntry = 3
 
-	// defaultQueueEntriesPerBatch is the default value for
-	// 'queueEntriesPerBatch'.
-	defaultQueueEntriesPerBatch = 2
+	// defaultEntriesPerBatch is the default value for 'queueEntriesPerBatch'.
+	defaultEntriesPerBatch = 2
 
 	// defaultPurgeBatchInterval is the default value for 'purgeBatchInterval'.
 	defaultPurgeBatchInterval = time.Millisecond * 32
@@ -83,7 +82,7 @@ type Throughput struct {
 
 func (t *Throughput) useOptimizedDefaults() {
 	if t.QueueEntriesPerBatch == 0 {
-		t.QueueEntriesPerBatch = defaultQueueEntriesPerBatch
+		t.QueueEntriesPerBatch = defaultEntriesPerBatch
 	}
 	if t.PurgeBatchInterval.Duration == 0 {
 		t.PurgeBatchInterval.Duration = defaultPurgeBatchInterval
@@ -136,7 +135,7 @@ type Config struct {
 		// `Throughput.PurgeBatchInterval`.
 		PurgeInterval cmd.ConfigDuration
 
-		// MaxQueueSize is the maximum size of the purger queue. If this value
+		// MaxQueueSize is the maximum size of the purger stack. If this value
 		// isn't provided it will default to `defaultQueueSize`.
 		MaxQueueSize int
 
@@ -151,7 +150,7 @@ type Config struct {
 		Throughput Throughput
 
 		// PurgeRetries is the maximum number of attempts that will be made to purge a
-		// batch of URLs before the batch is added back to the queue.
+		// batch of URLs before the batch is added back to the stack.
 		PurgeRetries int
 
 		// PurgeRetryBackoff is the base duration that will be waited before
@@ -169,20 +168,26 @@ func (c *Config) useDeprecatedSettings() {
 	c.AkamaiPurger.Throughput.QueueEntriesPerBatch = DeprecatedQueueEntriesPerBatch
 }
 
+// CachePurgeClient is testing interface.
+type CachePurgeClient interface {
+	Purge(urls []string) error
+}
+
 // akamaiPurger is a mutex protected container for a gRPC server which receives
-// requests to purge the URLs associated with OCSP responses cached by Akamai,
-// stores these URLs as a slice in an inner slice, and dispatches them to
-// Akamai's Fast Purge API in batches.
+// requests containing a slice of URLs associated with an OCSP response cached
+// by Akamai. This slice of URLs is stored on a stack, and dispatched in batches
+// to Akamai's Fast Purge API at regular intervals.
 type akamaiPurger struct {
 	sync.Mutex
 	akamaipb.UnimplementedAkamaiPurgerServer
 
-	// toPurge functions as a queue where each entry contains the three OCSP response URLs
-	// associated with a given certificate.
-	toPurge      [][]string
-	maxQueueSize int
-	client       *akamai.CachePurgeClient
-	log          blog.Logger
+	// toPurge functions as a stack where each entry contains the three OCSP
+	// response URLs associated with a given certificate.
+	toPurge         [][]string
+	maxStackSize    int
+	entriesPerBatch int
+	client          CachePurgeClient
+	log             blog.Logger
 }
 
 func (ap *akamaiPurger) len() int {
@@ -191,43 +196,65 @@ func (ap *akamaiPurger) len() int {
 	return len(ap.toPurge)
 }
 
-func (ap *akamaiPurger) purge() error {
-	ap.Lock()
-	queueEntries := ap.toPurge[:]
-	ap.toPurge = [][]string{}
-	ap.Unlock()
-	if len(queueEntries) == 0 {
-		return nil
+func (ap *akamaiPurger) purgeBatch(batch [][]string) error {
+	// Flatten the batch of stack entries into a single slice of URLs.
+	var urls []string
+	for _, url := range batch {
+		urls = append(urls, url...)
 	}
 
-	stoppedAt, err := ap.client.Purge(queueEntries)
+	err := ap.client.Purge(urls)
 	if err != nil {
 		ap.Lock()
-
-		// Add the remaining queue entries back, but at the end of the queue. If somehow
-		// there's a URL which repeatedly results in error, it won't block the
-		// entire queue, only a single batch.
-		ap.toPurge = append(ap.toPurge, queueEntries[stoppedAt:]...)
-		ap.Unlock()
-		ap.log.Errf("Failed to purge OCSP responses for %d certificates: %s", len(queueEntries), err)
+		defer ap.Unlock()
+		if len(ap.toPurge) >= ap.maxStackSize {
+			// Drop the oldest entry from the bottom of the stack to make room.
+			ap.toPurge = ap.toPurge[len(batch):]
+		}
+		// Add the entries from the failed batch to the bottom of the stack to
+		// avoid blocking.
+		ap.toPurge = append(batch, ap.toPurge...)
+		ap.log.Errf("Failed to purge OCSP responses for %d certificates: %s", len(batch), err)
 		return err
 	}
 	return nil
 }
 
+func (ap *akamaiPurger) takeBatch() [][]string {
+	ap.Lock()
+	defer ap.Unlock()
+	stackSize := len(ap.toPurge)
+
+	// If the stack is empty, return immediately.
+	if stackSize <= 0 {
+		return nil
+	}
+
+	// If the stack contains less than a full batch, set the batch size to the
+	// current stack size.
+	batchSize := ap.entriesPerBatch
+	if stackSize < batchSize {
+		batchSize = stackSize
+	}
+
+	batchBegin := stackSize - batchSize
+	batch := ap.toPurge[batchBegin:]
+	ap.toPurge = ap.toPurge[:batchBegin]
+	return batch
+}
+
 // Purge is an exported gRPC method which receives purge requests containing
-// URLs and prepends them to the purger queue.
+// URLs and prepends them to the purger stack.
 func (ap *akamaiPurger) Purge(ctx context.Context, req *akamaipb.PurgeRequest) (*emptypb.Empty, error) {
 	ap.Lock()
 	defer ap.Unlock()
-	queueLength := len(ap.toPurge)
-	if queueLength >= ap.maxQueueSize {
-		// Drop the oldest entry from the queue to make room for the new
-		// request.
-		ap.toPurge = ap.toPurge[:queueLength-1]
+	stackSize := len(ap.toPurge)
+	if stackSize >= ap.maxStackSize {
+		// Drop the oldest entry from the bottom of the stack to make room.
+		ap.toPurge = ap.toPurge[1:]
 	}
-	// Add the entry from the new request to the front of the queue.
-	ap.toPurge = append([][]string{req.Urls}, ap.toPurge...)
+	// Add the entry from the new request to the top of the stack.
+	ap.toPurge = append(ap.toPurge, req.Urls)
 	return &emptypb.Empty{}, nil
 }
 
@@ -331,8 +358,6 @@ func main() {
 		apc.ClientSecret,
 		apc.AccessToken,
 		apc.V3Network,
-		apc.Throughput.PurgeBatchInterval.Duration,
-		apc.Throughput.QueueEntriesPerBatch,
 		apc.PurgeRetries,
 		apc.PurgeRetryBackoff.Duration,
 		logger,
@@ -341,9 +366,10 @@ func main() {
 	cmd.FailOnError(err, "Failed to setup Akamai CCU client")
 
 	ap := &akamaiPurger{
-		maxQueueSize: apc.MaxQueueSize,
-		client:       ccu,
-		log:          logger,
+		maxStackSize:    apc.MaxQueueSize,
+		entriesPerBatch: apc.Throughput.QueueEntriesPerBatch,
+		client:          ccu,
+		log:             logger,
 	}
 
 	var gaugePurgeQueueLength = prometheus.NewGaugeFunc(
@@ -394,7 +420,11 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 		for {
 			select {
 			case <-ticker.C:
-				_ = ap.purge()
+				batch := ap.takeBatch()
+				if batch == nil {
+					continue
+				}
+				_ = ap.purgeBatch(batch)
 			case <-stop:
 				break loop
 			}
@@ -403,12 +433,13 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 		// As we may have missed a tick by calling ticker.Stop() and
 		// writing to the stop channel call ap.purge one last time just
 		// in case there is anything that still needs to be purged.
-		queueLen := ap.len()
-		if queueLen > 0 {
-			logger.Infof("Shutting down; purging OCSP responses for %d certificates before exit.", queueLen)
-			err := ap.purge()
-			cmd.FailOnError(err, fmt.Sprintf("Shutting down; failed to purge OCSP responses for %d certificates before exit", queueLen))
-			logger.Infof("Shutting down; finished purging OCSP responses for %d certificates.", queueLen)
+		stackLen := ap.len()
+		if stackLen > 0 {
+			logger.Infof("Shutting down; purging OCSP responses for %d certificates before exit.", stackLen)
+			batch := ap.takeBatch()
+			err := ap.purgeBatch(batch)
+			cmd.FailOnError(err, fmt.Sprintf("Shutting down; failed to purge OCSP responses for %d certificates before exit", stackLen))
+			logger.Infof("Shutting down; finished purging OCSP responses for %d certificates.", stackLen)
 		} else {
 			logger.Info("Shutting down; queue is already empty.")
 		}
@@ -430,7 +461,7 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 
 		// Stop the ticker and signal that we want to shutdown by writing to the
 		// stop channel. We wait 15 seconds for any remaining URLs to be emptied
-		// from the current queue, if we pass that deadline we exit early.
+		// from the current stack, if we pass that deadline we exit early.
 		ticker.Stop()
 		stop <- true
 		select {
@@ -444,7 +475,7 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 
 	// When we get a SIGTERM, we will exit from grpcSrv.Serve as soon as all
 	// extant RPCs have been processed, but we want the process to stick around
-	// while we still have a goroutine purging the last elements from the queue.
+	// while we still have a goroutine purging the last elements from the stack.
 	// Once that's done, CatchSignals will call os.Exit().
 	select {}
 }

--- a/cmd/akamai-purger/main_test.go
+++ b/cmd/akamai-purger/main_test.go
@@ -2,11 +2,11 @@ package notmain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/letsencrypt/boulder/akamai"
 	"github.com/letsencrypt/boulder/akamai/proto"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/test"
@@ -34,19 +34,19 @@ func TestThroughput_validate(t *testing.T) {
 		},
 		{"optimized defaults, should succeed",
 			fields{
-				QueueEntriesPerBatch: defaultQueueEntriesPerBatch,
+				QueueEntriesPerBatch: defaultEntriesPerBatch,
 				PurgeBatchInterval:   defaultPurgeBatchInterval},
 			false,
 		},
 		{"2ms faster than optimized defaults, should succeed",
 			fields{
-				QueueEntriesPerBatch: defaultQueueEntriesPerBatch,
+				QueueEntriesPerBatch: defaultEntriesPerBatch,
 				PurgeBatchInterval:   defaultPurgeBatchInterval + 2*time.Millisecond},
 			false,
 		},
 		{"exceeds URLs per second by 4 URLs",
 			fields{
-				QueueEntriesPerBatch: defaultQueueEntriesPerBatch,
+				QueueEntriesPerBatch: defaultEntriesPerBatch,
 				PurgeBatchInterval:   29 * time.Millisecond},
 			true,
 		},
@@ -76,31 +76,88 @@ func TestThroughput_validate(t *testing.T) {
 	}
 }
 
+type mockCCU struct {
+	proto.AkamaiPurgerClient
+}
+
+func (m *mockCCU) Purge(urls []string) error {
+	return errors.New("Lol, I'm a mock")
+}
+
 func TestAkamaiPurgerQueue(t *testing.T) {
 	ap := &akamaiPurger{
-		maxQueueSize: 250,
-		client:       &akamai.CachePurgeClient{},
-		log:          blog.NewMock(),
+		maxStackSize:    250,
+		entriesPerBatch: 2,
+		client:          &mockCCU{},
+		log:             blog.NewMock(),
 	}
 
-	// Add 250 entries to fill the queue.
+	// Add 250 entries to fill the stack.
 	for i := 0; i < 250; i++ {
 		req := proto.PurgeRequest{Urls: []string{fmt.Sprintf("http://test.com/%d", i)}}
 		_, err := ap.Purge(context.Background(), &req)
 		test.AssertNotError(t, err, fmt.Sprintf("Purge failed for entry %d.", i))
 	}
 
-	// Add another entry to the queue and call purge.
-	req := proto.PurgeRequest{Urls: []string{"http://test.com/251"}}
+	// Add another entry to the stack and using the Purge method.
+	req := proto.PurgeRequest{Urls: []string{"http://test.com/250"}}
 	_, err := ap.Purge(context.Background(), &req)
 	test.AssertNotError(t, err, "Purge failed.")
 
-	// Verify that the queue is full.
+	// Verify that the stack is still full.
 	test.AssertEquals(t, len(ap.toPurge), 250)
 
-	// Verify that the first entry in the queue is the one we just added.
-	test.AssertEquals(t, ap.toPurge[0][0], "http://test.com/251")
+	// Verify that the first entry in the stack is the entry we just added.
+	test.AssertEquals(t, ap.toPurge[len(ap.toPurge)-1][0], "http://test.com/250")
 
-	// Verify that the last entry in the queue is the second entry we added.
-	test.AssertEquals(t, ap.toPurge[249][0], "http://test.com/1")
+	// Verify that the last entry in the stack is the second entry we added.
+	test.AssertEquals(t, ap.toPurge[0][0], "http://test.com/1")
+
+	expectBottomAfterFailure := ap.toPurge[len(ap.toPurge)-ap.entriesPerBatch][0]
+	expectTopAfterFailure := ap.toPurge[len(ap.toPurge)-(ap.entriesPerBatch+1)][0]
+
+	// Fail to purge a batch of entries from the stack.
+	batch := ap.takeBatch()
+	test.AssertNotNil(t, batch, "Batch should not be nil.")
+
+	err = ap.purgeBatch(batch)
+	test.AssertError(t, err, "Mock should have failed to purge.")
+
+	// Verify that the stack is still full.
+	test.AssertEquals(t, len(ap.toPurge), 250)
+
+	// The first entry of the next batch should be on the top after the failed
+	// purge.
+	test.AssertEquals(t, ap.toPurge[len(ap.toPurge)-1][0], expectTopAfterFailure)
+
+	// The firtst entry of the batch we failed to purge should be on the bottom
+	// of the stack.
+	test.AssertEquals(t, ap.toPurge[0][0], expectBottomAfterFailure)
+}
+
+func TestAkamaiPurgerQueueWithOneEntry(t *testing.T) {
+	ap := &akamaiPurger{
+		maxStackSize:    250,
+		entriesPerBatch: 2,
+		client:          &mockCCU{},
+		log:             blog.NewMock(),
+	}
+
+	// Add one entry to the stack and using the Purge method.
+	req := proto.PurgeRequest{Urls: []string{"http://test.com/0"}}
+	_, err := ap.Purge(context.Background(), &req)
+	test.AssertNotError(t, err, "Purge failed.")
+	test.AssertEquals(t, len(ap.toPurge), 1)
+	test.AssertEquals(t, ap.toPurge[len(ap.toPurge)-1][0], "http://test.com/0")
+
+	// Fail to purge a batch of entries from the stack.
+	batch := ap.takeBatch()
+	test.AssertNotNil(t, batch, "Batch should not be nil.")
+
+	err = ap.purgeBatch(batch)
+	test.AssertError(t, err, "Mock should have failed to purge.")
+
+	// Verify that the stack still contains our singular entry.
+	test.AssertEquals(t, len(ap.toPurge), 1)
+	test.AssertDeepEquals(t, ap.toPurge, [][]string{{"http://test.com/0"}})
 }

--- a/cmd/akamai-purger/main_test.go
+++ b/cmd/akamai-purger/main_test.go
@@ -113,8 +113,7 @@ func TestAkamaiPurgerQueue(t *testing.T) {
 	// Verify that the last entry in the stack is the second entry we added.
 	test.AssertEquals(t, ap.toPurge[0][0], "http://test.com/1")
 
-	expectBottomAfterFailure := ap.toPurge[len(ap.toPurge)-ap.entriesPerBatch][0]
-	expectTopAfterFailure := ap.toPurge[len(ap.toPurge)-(ap.entriesPerBatch+1)][0]
+	expectedTopEntryAfterFailure := ap.toPurge[len(ap.toPurge)-(ap.entriesPerBatch+1)][0]
 
 	// Fail to purge a batch of entries from the stack.
 	batch := ap.takeBatch()
@@ -123,16 +122,12 @@ func TestAkamaiPurgerQueue(t *testing.T) {
 	err = ap.purgeBatch(batch)
 	test.AssertError(t, err, "Mock should have failed to purge.")
 
-	// Verify that the stack is still full.
-	test.AssertEquals(t, len(ap.toPurge), 250)
+	// Verify that the stack is no longer full.
+	test.AssertEquals(t, len(ap.toPurge), 248)
 
 	// The first entry of the next batch should be on the top after the failed
 	// purge.
-	test.AssertEquals(t, ap.toPurge[len(ap.toPurge)-1][0], expectTopAfterFailure)
-
-	// The firtst entry of the batch we failed to purge should be on the bottom
-	// of the stack.
-	test.AssertEquals(t, ap.toPurge[0][0], expectBottomAfterFailure)
+	test.AssertEquals(t, ap.toPurge[len(ap.toPurge)-1][0], expectedTopEntryAfterFailure)
 }
 
 func TestAkamaiPurgerQueueWithOneEntry(t *testing.T) {
@@ -157,7 +152,6 @@ func TestAkamaiPurgerQueueWithOneEntry(t *testing.T) {
 	err = ap.purgeBatch(batch)
 	test.AssertError(t, err, "Mock should have failed to purge.")
 
-	// Verify that the stack still contains our singular entry.
-	test.AssertEquals(t, len(ap.toPurge), 1)
-	test.AssertDeepEquals(t, ap.toPurge, [][]string{{"http://test.com/0"}})
+	// Verify that the stack no longer contains our entry.
+	test.AssertEquals(t, len(ap.toPurge), 0)
 }


### PR DESCRIPTION
Avoid rejecting new purge requests by making the `akamai-purger` queue a stack
that pops entries off the bottom (oldest) to make room.

Fixes #5941