### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -17,6 +17,9 @@ on:
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   #  Main test jobs. This looks like a single job, but the matrix
   #  items will multiply it. For example every entry in the
@@ -102,6 +105,8 @@ jobs:
   # one static job name that can be used to determine success of the job
   # in GitHub branch protection.
   boulder_ci_test_matrix_status:
+    permissions:
+      contents: none
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Boulder CI Test Matrix


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
