### PR TITLE
Update config from config-next

### DIFF
--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -35,8 +35,8 @@
    "stdoutlevel": 6,
    "sysloglevel": 6
  },
-  "beeline": {
-      "mute": true,
-      "dataset": "Test"
-  }
+ "beeline": {
+    "mute": true,
+    "dataset": "Test"
+ }
 }

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -16,6 +16,7 @@
     },
     "grpc": {
       "address": ":9099",
+      "maxConnectionAge": "30s",
       "clientNames": [
         "health-checker.boulder",
         "ra.boulder"

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -5,11 +5,14 @@
       "maxOpenConns": 10
     },
     "hostnamePolicyFile": "test/hostname-policy.yaml",
+    "goodkey": {
+      "fermatRounds": 100
+    },
     "workers": 16,
     "unexpiredOnly": true,
     "badResultsOnly": true,
     "checkPeriod": "72h",
-    "acceptableValidityDurations": ["7775999s", "7776000s"],
+    "acceptableValidityDurations": ["7776000s"],
     "ignoredLints": [
       "n_subject_common_name_included"
     ]

--- a/test/config/nonce.json
+++ b/test/config/nonce.json
@@ -12,6 +12,7 @@
         },
         "debugAddr": ":8111",
         "grpc": {
+            "maxConnectionAge": "30s",
             "address": ":9101",
             "clientNames": [
                 "health-checker.boulder",

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -4,12 +4,23 @@
       "dbConnectFile": "test/secrets/ocsp_updater_dburl",
       "maxOpenConns": 10
     },
+    "readOnlyDB": {
+      "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
+      "maxOpenConns": 100
+    },
+    "issuers": {
+      ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
+      ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
+      ".hierarchy/intermediate-cert-rsa-a.pem": 3,
+      ".hierarchy/intermediate-cert-rsa-b.pem": 4
+    },
     "oldOCSPWindow": "2s",
     "oldOCSPBatchSize": 5000,
     "parallelGenerateOCSPRequests": 10,
     "ocspMinTimeToExpiry": "72h",
     "signFailureBackoffFactor": 1.2,
     "signFailureBackoffMax": "30m",
+    "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
     "debugAddr": ":8006",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -8,12 +8,6 @@
       "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
       "maxOpenConns": 100
     },
-    "issuers": {
-      ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
-      ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
-      ".hierarchy/intermediate-cert-rsa-a.pem": 3,
-      ".hierarchy/intermediate-cert-rsa-b.pem": 4
-    },
     "oldOCSPWindow": "2s",
     "oldOCSPBatchSize": 5000,
     "parallelGenerateOCSPRequests": 10,

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -6,7 +6,6 @@
     "/hierarchy/intermediate-cert-ecdsa-a.pem"
   ],
 
-
   "syslog": {
     "stdoutlevel": 7,
     "sysloglevel": 7

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -22,6 +22,7 @@
     ],
     "debugAddr": ":8009",
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9091",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -14,7 +14,11 @@
       "fermatRounds": 100
     },
     "orderLifetime": "168h",
-    "issuerCertPath":  "/hierarchy/intermediate-cert-rsa-a.pem",
+    "issuerCerts": [
+      "/hierarchy/intermediate-cert-rsa-a.pem",
+      "/hierarchy/intermediate-cert-rsa-b.pem",
+      "/hierarchy/intermediate-cert-ecdsa-a.pem"
+    ],
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/ra.boulder/cert.pem",
@@ -41,6 +45,7 @@
       "timeout": "15s"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9094",
       "clientNames": [
         "admin-revoker.boulder",

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -29,12 +29,6 @@
         "wfe.boulder"
       ]
     },
-    "issuers": {
-      ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
-      ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
-      ".hierarchy/intermediate-cert-rsa-a.pem": 3,
-      ".hierarchy/intermediate-cert-rsa-b.pem": 4
-    },
     "features": {
       "FasterNewOrdersRateLimit": true,
       "StoreRevokerInfo": true,

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -4,6 +4,10 @@
       "dbConnectFile": "test/secrets/sa_dburl",
       "maxOpenConns": 100
     },
+    "readOnlyDB": {
+      "dbConnectFile": "test/secrets/sa_ro_dburl",
+      "maxOpenConns": 100
+    },
     "ParallelismPerRPC": 20,
     "debugAddr": ":8003",
     "tls": {
@@ -12,23 +16,30 @@
       "keyFile": "test/grpc-creds/sa.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9095",
       "clientNames": [
         "admin-revoker.boulder",
         "ca.boulder",
         "expiration-mailer.boulder",
         "health-checker.boulder",
-        "ocsp-updater.boulder",
         "orphan-finder.boulder",
         "ra.boulder",
         "sa.boulder",
         "wfe.boulder"
       ]
     },
+    "issuers": {
+      ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
+      ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
+      ".hierarchy/intermediate-cert-rsa-a.pem": 3,
+      ".hierarchy/intermediate-cert-rsa-b.pem": 4
+    },
     "features": {
       "FasterNewOrdersRateLimit": true,
       "StoreRevokerInfo": true,
-      "GetAuthzReadOnly": true
+      "GetAuthzReadOnly": true,
+      "GetAuthzUseIndex": true
     }
   },
 

--- a/test/config/va-remote-a.json
+++ b/test/config/va-remote-a.json
@@ -19,6 +19,7 @@
       "keyFile": "test/grpc-creds/va.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9097",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config/va-remote-b.json
+++ b/test/config/va-remote-b.json
@@ -19,6 +19,7 @@
       "keyFile": "test/grpc-creds/va.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9098",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -8,10 +8,7 @@
       "tlsPort": 5001
     },
     "dnsTries": 3,
-    "dnsResolvers": [
-      "127.0.0.1:8053",
-      "127.0.0.1:8054"
-    ],
+    "dnsResolver": "boulder",
     "issuerDomain": "happy-hacker-ca.invalid",
     "tls": {
       "caCertfile": "test/grpc-creds/minica.pem",
@@ -19,6 +16,7 @@
       "keyFile": "test/grpc-creds/va.boulder/key.pem"
     },
     "grpc": {
+      "maxConnectionAge": "30s",
       "address": ":9092",
       "clientNames": [
         "health-checker.boulder",

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -27,6 +27,10 @@
       "serverAddress": "sa.boulder:9095",
       "timeout": "15s"
     },
+    "accountCache": {
+      "size": 9000,
+      "ttl": "5s"
+    },
     "getNonceService": {
       "serverAddress": "nonce.boulder:9101",
       "timeout": "15s"

--- a/test/sd-test-srv/main.go
+++ b/test/sd-test-srv/main.go
@@ -75,13 +75,11 @@ func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 			Class:  dns.ClassINET,
 			Ttl:    0,
 		}
-		// These two hardcoded IPs correspond to the configured addresses for boulder
-		// in docker-compose.yml. In our Docker setup, boulder is present on two
-		// networks, rednet and bluenet, with a different IP address on each. This
-		// allows us to test load balance across gRPC backends.
-		// These two hardcoded names:port combos correspond to the configured names
-		// in docker-compose.yml, which in turn point to the local IPs on which our
-		// local resolver runs.
+		// A SRV record contains host:port combinations. The hosts in turn will be
+		// looked up in a subsequent query. These will resolve to 10.77.77.77:8053
+		// and 10.77.77.77:8054, respectively. The former will have challtestsrv
+		// listening on it. The latter doesn't have anything listening on it, but
+		// that's fine; the VA will just retry on a working port.
 		m.Answer = append(m.Answer, &dns.SRV{
 			Target: "dns1.boulder.",
 			Port:   8053,


### PR DESCRIPTION
This copies over settings from config-next that are now deployed in prod.

Also, I updated a comment in sd-test-srv to more accurately describe how SRV records work.