### PR TITLE
Split up build and release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,51 @@
-name: Build and Release
+# Build the Boulder .deb package on every PR, push to main, and tag push. On tag pushes, additionally create a release with the resulting .deb.
+name: Build release
 on:
-  # Runs automatically when a tag beginning with 'release-' is pushed.
   push:
     tags:
       - release-*
-
-permissions:
-  # Overrides the org default of 'read'. This allows us to upload and post the
-  # resulting package file as part of a release.
-  contents: write
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  gh-release:
+  build-release:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
 
-      - name: build and release
+      - name: build deb
+        run: ./tools/make-deb.sh
+
+      - name: upload deb
+        uses: actions/upload-artifact@v3
+        with:
+          name: boulder deb
+          path: boulder.deb
+
+  push-release:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: build-release
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: boulder deb
+      - name: rename
+        run: mv boulder.deb boulder-1.0.0-$(git rev-parse --short HEAD).x86_64.deb
+      - name: push release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://cli.github.com/manual/gh_release_create
-        run: |
-          ./tools/make-deb.sh
-          gh release create "${GITHUB_REF_NAME}" *.deb
+        run: gh release create "${GITHUB_REF_NAME}" boulder-1.0.0-$(git rev-parse --short HEAD).x86_64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
-# Build the Boulder .deb package on every PR, push to main, and tag push. On tag pushes, additionally create a release with the resulting .deb.
+# Build the Boulder Debian package on every PR, push to main, and tag push. On
+# tag pushes, additionally create a GitHub release and with the resulting Debian
+# package.
 name: Build release
 on:
   push:

--- a/tools/make-deb.sh
+++ b/tools/make-deb.sh
@@ -39,3 +39,6 @@ export ARCHIVEDIR="${PWD}"
 
 # Build Boulder and produce a Debian Package at $PWD.
 make deb
+
+# Rename .deb to a predictable path.
+mv boulder-*.deb boulder.deb


### PR DESCRIPTION
This allows us to narrow permissions by only granting write privileges
to the upload portion of the job (which doesn't run any code from our
repo). It also allows us to verify that the release build works on every
commit, while only generating releases on actual release tags.