### PR TITLE
Allow expiration mailer to work in parallel

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -194,12 +194,12 @@ var maxSerials = 100
 // sendMessage sends a single email to the provided address with the revoked
 // serials
 func (bkr *badKeyRevoker) sendMessage(addr string, serials []string) error {
-	err := bkr.mailer.Connect()
+	conn, err := bkr.mailer.Connect()
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = bkr.mailer.Close()
+		_ = conn.Close()
 	}()
 	mutSerials := make([]string, len(serials))
 	copy(mutSerials, serials)
@@ -213,7 +213,7 @@ func (bkr *badKeyRevoker) sendMessage(addr string, serials []string) error {
 	if err != nil {
 		return err
 	}
-	err = bkr.mailer.SendMail([]string{addr}, bkr.emailSubject, message.String())
+	err = conn.SendMail([]string{addr}, bkr.emailSubject, message.String())
 	if err != nil {
 		return err
 	}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -220,10 +220,10 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 		parallelSends = 1
 	}
 
-	for i := uint(0); i < parallelSends; i++ {
+	for senderNum := uint(0); senderNum < parallelSends; senderNum++ {
 		conn, err := m.mailer.Connect()
 		if err != nil {
-			m.log.AuditErrf("connecting parallel sender %d: %s", i, err)
+			m.log.AuditErrf("connecting parallel sender %d: %s", senderNum, err)
 			close(workChan)
 			return
 		}
@@ -241,7 +241,7 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 		}(conn, workChan)
 
 		// For politeness' sake, don't open more than 1 new connection per
-		// second
+		// second.
 		time.Sleep(time.Second)
 	}
 	for regID, certs := range regIDToCerts {

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -54,7 +54,7 @@ type mailer struct {
 	emailTemplate   *template.Template
 	subjectTemplate *template.Template
 	nagTimes        []time.Duration
-	parallelSends   int
+	parallelSends   uint
 	limit           int
 	clk             clock.Clock
 	stats           mailerStats
@@ -219,7 +219,7 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 		parallelSends = 1
 	}
 
-	for i := 0; i < parallelSends; i++ {
+	for i := uint(0); i < parallelSends; i++ {
 		wg.Add(1)
 		go func(ch <-chan work) {
 			conn, err := m.mailer.Connect()
@@ -437,7 +437,7 @@ type Config struct {
 		Frequency cmd.ConfigDuration
 
 		// How many parallel goroutines should process each batch of emails
-		ParallelSends int
+		ParallelSends uint
 
 		TLS       cmd.TLSConfig
 		SAService *cmd.GRPCClientConfig

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/mail"
 	bmail "github.com/letsencrypt/boulder/mail"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/sa"
@@ -53,6 +55,7 @@ type mailer struct {
 	emailTemplate   *template.Template
 	subjectTemplate *template.Template
 	nagTimes        []time.Duration
+	parallelSends   int
 	limit           int
 	clk             clock.Clock
 	stats           mailerStats
@@ -66,7 +69,7 @@ type mailerStats struct {
 	processingLatency prometheus.Histogram
 }
 
-func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
+func (m *mailer) sendNags(conn mail.Conn, contacts []string, certs []*x509.Certificate) error {
 	if len(contacts) == 0 {
 		return nil
 	}
@@ -161,7 +164,7 @@ func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
 	m.log.Infof("attempting send JSON=%s", string(logStr))
 
 	startSending := m.clk.Now()
-	err = m.mailer.SendMail(emails, subjBuf.String(), msgBuf.String())
+	err = conn.SendMail(emails, subjBuf.String(), msgBuf.String())
 	if err != nil {
 		m.log.Errf("failed send JSON=%s", string(logStr))
 		return err
@@ -196,6 +199,11 @@ func (m *mailer) certIsRenewed(names []string, issued time.Time) (bool, error) {
 	return present, err
 }
 
+type work struct {
+	regID int64
+	certs []core.Certificate
+}
+
 func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) {
 	regIDToCerts := make(map[int64][]core.Certificate)
 
@@ -205,76 +213,100 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 		regIDToCerts[cert.RegistrationID] = cs
 	}
 
-	err := m.mailer.Connect()
-	if err != nil {
-		m.log.AuditErrf("Error connecting to send nag emails: %s", err)
-		return
+	var wg sync.WaitGroup
+	workChan := make(chan work)
+	parallelSends := m.parallelSends
+	if parallelSends == 0 {
+		parallelSends = 1
 	}
-	defer func() {
-		_ = m.mailer.Close()
-	}()
 
-	for regID, certs := range regIDToCerts {
-		reg, err := m.rs.GetRegistration(ctx, &sapb.RegistrationID{Id: regID})
-		if err != nil {
-			m.log.AuditErrf("Error fetching registration %d: %s", regID, err)
-			m.stats.errorCount.With(prometheus.Labels{"type": "GetRegistration"}).Inc()
-			continue
-		}
-
-		parsedCerts := []*x509.Certificate{}
-		for _, cert := range certs {
-			parsedCert, err := x509.ParseCertificate(cert.DER)
+	for i := 0; i < parallelSends; i++ {
+		wg.Add(1)
+		go func(ch <-chan work) {
+			conn, err := m.mailer.Connect()
 			if err != nil {
-				// TODO(#1420): tell registration about this error
-				m.log.AuditErrf("Error parsing certificate %s: %s", cert.Serial, err)
-				m.stats.errorCount.With(prometheus.Labels{"type": "ParseCertificate"}).Inc()
-				continue
+				m.log.AuditErrf("Error connecting to send nag emails: %s", err)
+				return
 			}
+			defer func() {
+				_ = conn.Close()
+			}()
 
-			renewed, err := m.certIsRenewed(parsedCert.DNSNames, parsedCert.NotBefore)
-			if err != nil {
-				m.log.AuditErrf("expiration-mailer: error fetching renewal state: %v", err)
-				// assume not renewed
-			} else if renewed {
-				m.log.Debugf("Cert %s is already renewed", cert.Serial)
-				m.stats.renewalCount.With(prometheus.Labels{}).Inc()
-				err := m.updateCertStatus(cert.Serial)
+			for w := range ch {
+				err := m.sendToOneRegID(ctx, conn, w.regID, w.certs)
 				if err != nil {
-					m.log.AuditErrf("Error updating certificate status for %s: %s", cert.Serial, err)
-					m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
+					m.log.AuditErr(err.Error())
 				}
-				continue
 			}
+			wg.Done()
+		}(workChan)
+	}
+	for regID, certs := range regIDToCerts {
+		workChan <- work{regID, certs}
+	}
+	close(workChan)
+	wg.Wait()
+}
 
-			parsedCerts = append(parsedCerts, parsedCert)
-		}
+func (m *mailer) sendToOneRegID(ctx context.Context, conn mail.Conn, regID int64, certs []core.Certificate) error {
+	reg, err := m.rs.GetRegistration(ctx, &sapb.RegistrationID{Id: regID})
+	if err != nil {
+		m.stats.errorCount.With(prometheus.Labels{"type": "GetRegistration"}).Inc()
+		return fmt.Errorf("fetching registration %d: %w", regID, err)
+	}
 
-		if len(parsedCerts) == 0 {
-			// all certificates are renewed
-			continue
-		}
+	if reg.Contact == nil {
+		return nil
+	}
 
-		if reg.Contact == nil {
-			continue
-		}
-
-		err = m.sendNags(reg.Contact, parsedCerts)
+	parsedCerts := []*x509.Certificate{}
+	for _, cert := range certs {
+		parsedCert, err := x509.ParseCertificate(cert.DER)
 		if err != nil {
-			m.stats.errorCount.With(prometheus.Labels{"type": "SendNags"}).Inc()
-			m.log.AuditErrf("Error sending nag emails: %s", err)
+			m.stats.errorCount.With(prometheus.Labels{"type": "ParseCertificate"}).Inc()
+			// TODO(#1420): tell registration about this error
+			return fmt.Errorf("parsing certificate %s: %w", cert.Serial, err)
+		}
+
+		renewed, err := m.certIsRenewed(parsedCert.DNSNames, parsedCert.NotBefore)
+		if err != nil {
+			return fmt.Errorf("expiration-mailer: error fetching renewal state: %w", err)
+		} else if renewed {
+			m.stats.renewalCount.With(prometheus.Labels{}).Inc()
+			err := m.updateCertStatus(cert.Serial)
+			if err != nil {
+				m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
+				return fmt.Errorf("updating certificate status for %s: %w", cert.Serial, err)
+			}
 			continue
 		}
-		for _, cert := range parsedCerts {
-			serial := core.SerialToString(cert.SerialNumber)
-			err = m.updateCertStatus(serial)
-			if err != nil {
-				m.log.AuditErrf("Error updating certificate status for %s: %s", serial, err)
-				m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
-				continue
-			}
+
+		parsedCerts = append(parsedCerts, parsedCert)
+	}
+
+	if len(parsedCerts) == 0 {
+		// all certificates are renewed
+		return nil
+	}
+
+	err = m.sendNags(conn, reg.Contact, parsedCerts)
+	if err != nil {
+		m.stats.errorCount.With(prometheus.Labels{"type": "SendNags"}).Inc()
+		return fmt.Errorf("sending nag emails: %w", err)
+	}
+	for _, cert := range parsedCerts {
+		serial := core.SerialToString(cert.SerialNumber)
+		err = m.updateCertStatus(serial)
+		if err != nil {
+			// Don't return immediately; we'd like to at least try and update the status for
+			// all certificates, even if one of them experienced an error (which might have
+			// been intermittent)
+			m.log.AuditErrf("updating certificate status for %s: %s", serial, err)
+			m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
+			continue
 		}
 	}
+	return nil
 }
 
 func (m *mailer) findExpiringCertificates(ctx context.Context) error {
@@ -402,7 +434,11 @@ type Config struct {
 		// Path to a text/template email template
 		EmailTemplate string
 
+		// How often to process a batch of certificates
 		Frequency cmd.ConfigDuration
+
+		// How many parallel goroutines should process each batch of emails
+		ParallelSends int
 
 		TLS       cmd.TLSConfig
 		SAService *cmd.GRPCClientConfig
@@ -589,6 +625,7 @@ func main() {
 		emailTemplate:   tmpl,
 		nagTimes:        nags,
 		limit:           c.Mailer.CertLimit,
+		parallelSends:   c.Mailer.ParallelSends,
 		clk:             clk,
 		stats:           initStats(scope),
 	}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
-	"github.com/letsencrypt/boulder/mail"
 	bmail "github.com/letsencrypt/boulder/mail"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/sa"
@@ -69,7 +68,7 @@ type mailerStats struct {
 	processingLatency prometheus.Histogram
 }
 
-func (m *mailer) sendNags(conn mail.Conn, contacts []string, certs []*x509.Certificate) error {
+func (m *mailer) sendNags(conn bmail.Conn, contacts []string, certs []*x509.Certificate) error {
 	if len(contacts) == 0 {
 		return nil
 	}
@@ -248,7 +247,7 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 	wg.Wait()
 }
 
-func (m *mailer) sendToOneRegID(ctx context.Context, conn mail.Conn, regID int64, certs []core.Certificate) error {
+func (m *mailer) sendToOneRegID(ctx context.Context, conn bmail.Conn, regID int64, certs []core.Certificate) error {
 	reg, err := m.rs.GetRegistration(ctx, &sapb.RegistrationID{Id: regID})
 	if err != nil {
 		m.stats.errorCount.With(prometheus.Labels{"type": "GetRegistration"}).Inc()

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -128,7 +128,9 @@ func TestSendNags(t *testing.T) {
 		DNSNames: []string{"example.com"},
 	}
 
-	err := m.sendNags([]string{emailA}, []*x509.Certificate{cert})
+	conn, err := m.mailer.Connect()
+	test.AssertNotError(t, err, "connecting SMTP")
+	err = m.sendNags(conn, []string{emailA}, []*x509.Certificate{cert})
 	test.AssertNotError(t, err, "Failed to send warning messages")
 	test.AssertEquals(t, len(mc.Messages), 1)
 	test.AssertEquals(t, mocks.MailerMessage{
@@ -138,7 +140,9 @@ func TestSendNags(t *testing.T) {
 	}, mc.Messages[0])
 
 	mc.Clear()
-	err = m.sendNags([]string{emailA, emailB}, []*x509.Certificate{cert})
+	conn, err = m.mailer.Connect()
+	test.AssertNotError(t, err, "connecting SMTP")
+	err = m.sendNags(conn, []string{emailA, emailB}, []*x509.Certificate{cert})
 	test.AssertNotError(t, err, "Failed to send warning messages")
 	test.AssertEquals(t, len(mc.Messages), 2)
 	test.AssertEquals(t, mocks.MailerMessage{
@@ -153,7 +157,9 @@ func TestSendNags(t *testing.T) {
 	}, mc.Messages[1])
 
 	mc.Clear()
-	err = m.sendNags([]string{}, []*x509.Certificate{cert})
+	conn, err = m.mailer.Connect()
+	test.AssertNotError(t, err, "connecting SMTP")
+	err = m.sendNags(conn, []string{}, []*x509.Certificate{cert})
 	test.AssertNotError(t, err, "Not an error to pass no email contacts")
 	test.AssertEquals(t, len(mc.Messages), 0)
 

--- a/cmd/expiration-mailer/send_test.go
+++ b/cmd/expiration-mailer/send_test.go
@@ -33,7 +33,9 @@ func TestSendEarliestCertInfo(t *testing.T) {
 		serial2,
 	)
 
-	err := ctx.m.sendNags([]string{email1, email2}, []*x509.Certificate{rawCertA, rawCertB})
+	conn, err := ctx.m.mailer.Connect()
+	test.AssertNotError(t, err, "connecting SMTP")
+	err = ctx.m.sendNags(conn, []string{email1, email2}, []*x509.Certificate{rawCertA, rawCertB})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -154,12 +154,12 @@ func (m *mailer) run() error {
 	m.log.Infof("Address %q was associated with the most recipients (%d)",
 		mostRecipients, mostRecipientsLen)
 
-	err = m.mailer.Connect()
+	conn, err := m.mailer.Connect()
 	if err != nil {
 		return err
 	}
 
-	defer func() { _ = m.mailer.Close() }()
+	defer func() { _ = conn.Close() }()
 
 	startTime := m.clk.Now()
 	sortedAddresses := sortAddresses(addressToRecipient)
@@ -186,7 +186,7 @@ func (m *mailer) run() error {
 			continue
 		}
 
-		err = m.mailer.SendMail([]string{address}, m.subject, messageBody)
+		err = conn.SendMail([]string{address}, m.subject, messageBody)
 		if err != nil {
 			var badAddrErr bmail.BadAddressSMTPError
 			if errors.As(err, &badAddrErr) {

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -45,18 +45,31 @@ func (s realSource) generate() *big.Int {
 
 // Mailer provides the interface for a mailer
 type Mailer interface {
+	Connect() (Conn, error)
+}
+
+type Conn interface {
 	SendMail([]string, string, string) error
-	Connect() error
 	Close() error
+}
+
+// connImpl represents a single connection to a mail server. It is not safe
+// for concurrent use.
+type connImpl struct {
+	config
+	client smtpClient
 }
 
 // MailerImpl defines a mail transfer agent to use for sending mail. It is not
 // safe for concurrent access.
 type MailerImpl struct {
+	config
+}
+
+type config struct {
 	log              blog.Logger
 	dialer           dialer
 	from             mail.Address
-	client           smtpClient
 	clk              clock.Clock
 	csprgSource      idGenerator
 	reconnectBase    time.Duration
@@ -135,20 +148,22 @@ func New(
 	stats.MustRegister(sendMailAttempts)
 
 	return &MailerImpl{
-		dialer: &dialerImpl{
-			username: username,
-			password: password,
-			server:   server,
-			port:     port,
-			rootCAs:  rootCAs,
+		config: config{
+			dialer: &dialerImpl{
+				username: username,
+				password: password,
+				server:   server,
+				port:     port,
+				rootCAs:  rootCAs,
+			},
+			log:              logger,
+			from:             from,
+			clk:              clock.New(),
+			csprgSource:      realSource{},
+			reconnectBase:    reconnectBase,
+			reconnectMax:     reconnectMax,
+			sendMailAttempts: sendMailAttempts,
 		},
-		log:              logger,
-		from:             from,
-		clk:              clock.New(),
-		csprgSource:      realSource{},
-		reconnectBase:    reconnectBase,
-		reconnectMax:     reconnectMax,
-		sendMailAttempts: sendMailAttempts,
 	}
 }
 
@@ -156,20 +171,22 @@ func New(
 // command that would have been run, at debug level.
 func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
 	return &MailerImpl{
-		dialer:      dryRunClient{logger},
-		from:        from,
-		clk:         clock.New(),
-		csprgSource: realSource{},
-		sendMailAttempts: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "send_mail_attempts",
-			Help: "A counter of send mail attempts labelled by result",
-		}, []string{"result", "error"}),
+		config: config{
+			dialer:      dryRunClient{logger},
+			from:        from,
+			clk:         clock.New(),
+			csprgSource: realSource{},
+			sendMailAttempts: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "send_mail_attempts",
+				Help: "A counter of send mail attempts labelled by result",
+			}, []string{"result", "error"}),
+		},
 	}
 }
 
-func (m *MailerImpl) generateMessage(to []string, subject, body string) ([]byte, error) {
-	mid := m.csprgSource.generate()
-	now := m.clk.Now().UTC()
+func (c *connImpl) generateMessage(to []string, subject, body string) ([]byte, error) {
+	mid := c.csprgSource.generate()
+	now := c.clk.Now().UTC()
 	addrs := []string{}
 	for _, a := range to {
 		if !core.IsASCII(a) {
@@ -179,10 +196,10 @@ func (m *MailerImpl) generateMessage(to []string, subject, body string) ([]byte,
 	}
 	headers := []string{
 		fmt.Sprintf("To: %s", strings.Join(addrs, ", ")),
-		fmt.Sprintf("From: %s", m.from.String()),
+		fmt.Sprintf("From: %s", c.from.String()),
 		fmt.Sprintf("Subject: %s", subject),
 		fmt.Sprintf("Date: %s", now.Format(time.RFC822)),
-		fmt.Sprintf("Message-Id: <%s.%s.%s>", now.Format("20060102T150405"), mid.String(), m.from.Address),
+		fmt.Sprintf("Message-Id: <%s.%s.%s>", now.Format("20060102T150405"), mid.String(), c.from.Address),
 		"MIME-Version: 1.0",
 		"Content-Type: text/plain; charset=UTF-8",
 		"Content-Transfer-Encoding: quoted-printable",
@@ -208,31 +225,31 @@ func (m *MailerImpl) generateMessage(to []string, subject, body string) ([]byte,
 	)), nil
 }
 
-func (m *MailerImpl) reconnect() {
+func (c *connImpl) reconnect() {
 	for i := 0; ; i++ {
-		sleepDuration := core.RetryBackoff(i, m.reconnectBase, m.reconnectMax, 2)
-		m.log.Infof("sleeping for %s before reconnecting mailer", sleepDuration)
-		m.clk.Sleep(sleepDuration)
-		m.log.Info("attempting to reconnect mailer")
-		err := m.Connect()
+		sleepDuration := core.RetryBackoff(i, c.reconnectBase, c.reconnectMax, 2)
+		c.log.Infof("sleeping for %s before reconnecting mailer", sleepDuration)
+		c.clk.Sleep(sleepDuration)
+		c.log.Info("attempting to reconnect mailer")
+		client, err := c.dialer.Dial()
 		if err != nil {
-			m.log.Warningf("reconnect error: %s", err)
+			c.log.Warningf("reconnect error: %s", err)
 			continue
 		}
+		c.client = client
 		break
 	}
-	m.log.Info("reconnected successfully")
+	c.log.Info("reconnected successfully")
 }
 
 // Connect opens a connection to the specified mail server. It must be called
 // before SendMail.
-func (m *MailerImpl) Connect() error {
+func (m *MailerImpl) Connect() (Conn, error) {
 	client, err := m.dialer.Dial()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	m.client = client
-	return nil
+	return &connImpl{m.config, client}, nil
 }
 
 type dialerImpl struct {
@@ -265,43 +282,43 @@ func (di *dialerImpl) Dial() (smtpClient, error) {
 // argument as an error. If the reset command also errors, it combines both
 // errors and returns them. Without this we would get `nested MAIL command`.
 // https://github.com/letsencrypt/boulder/issues/3191
-func (m *MailerImpl) resetAndError(err error) error {
+func (c *connImpl) resetAndError(err error) error {
 	if err == io.EOF {
 		return err
 	}
-	if err2 := m.client.Reset(); err2 != nil {
+	if err2 := c.client.Reset(); err2 != nil {
 		return fmt.Errorf("%s (also, on sending RSET: %s)", err, err2)
 	}
 	return err
 }
 
-func (m *MailerImpl) sendOne(to []string, subject, msg string) error {
-	if m.client == nil {
+func (c *connImpl) sendOne(to []string, subject, msg string) error {
+	if c.client == nil {
 		return errors.New("call Connect before SendMail")
 	}
-	body, err := m.generateMessage(to, subject, msg)
+	body, err := c.generateMessage(to, subject, msg)
 	if err != nil {
 		return err
 	}
-	if err = m.client.Mail(m.from.String()); err != nil {
+	if err = c.client.Mail(c.from.String()); err != nil {
 		return err
 	}
 	for _, t := range to {
-		if err = m.client.Rcpt(t); err != nil {
-			return m.resetAndError(err)
+		if err = c.client.Rcpt(t); err != nil {
+			return c.resetAndError(err)
 		}
 	}
-	w, err := m.client.Data()
+	w, err := c.client.Data()
 	if err != nil {
-		return m.resetAndError(err)
+		return c.resetAndError(err)
 	}
 	_, err = w.Write(body)
 	if err != nil {
-		return m.resetAndError(err)
+		return c.resetAndError(err)
 	}
 	err = w.Close()
 	if err != nil {
-		return m.resetAndError(err)
+		return c.resetAndError(err)
 	}
 	return nil
 }
@@ -336,34 +353,34 @@ var badAddressErrorCodes = map[int]bool{
 
 // SendMail sends an email to the provided list of recipients. The email body
 // is simple text.
-func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
+func (c *connImpl) SendMail(to []string, subject, msg string) error {
 	var protoErr *textproto.Error
 	for {
-		err := m.sendOne(to, subject, msg)
+		err := c.sendOne(to, subject, msg)
 		if err == nil {
 			// If the error is nil, we sent the mail without issue. nice!
 			break
 		} else if err == io.EOF {
-			m.sendMailAttempts.WithLabelValues("failure", "EOF").Inc()
+			c.sendMailAttempts.WithLabelValues("failure", "EOF").Inc()
 			// If the error is an EOF, we should try to reconnect on a backoff
 			// schedule, sleeping between attempts.
-			m.reconnect()
+			c.reconnect()
 			// After reconnecting, loop around and try `sendOne` again.
 			continue
 		} else if errors.Is(err, syscall.ECONNRESET) {
-			m.sendMailAttempts.WithLabelValues("failure", "TCP RST").Inc()
+			c.sendMailAttempts.WithLabelValues("failure", "TCP RST").Inc()
 			// If the error is `syscall.ECONNRESET`, we should try to reconnect on a backoff
 			// schedule, sleeping between attempts.
-			m.reconnect()
+			c.reconnect()
 			// After reconnecting, loop around and try `sendOne` again.
 			continue
 		} else if errors.Is(err, syscall.EPIPE) {
 			// EPIPE also seems to be a common way to signal TCP RST.
-			m.sendMailAttempts.WithLabelValues("failure", "EPIPE").Inc()
-			m.reconnect()
+			c.sendMailAttempts.WithLabelValues("failure", "EPIPE").Inc()
+			c.reconnect()
 			continue
 		} else if errors.As(err, &protoErr) && protoErr.Code == 421 {
-			m.sendMailAttempts.WithLabelValues("failure", "SMTP 421").Inc()
+			c.sendMailAttempts.WithLabelValues("failure", "SMTP 421").Inc()
 			/*
 			 *  If the error is an instance of `textproto.Error` with a SMTP error code,
 			 *  and that error code is 421 then treat this as a reconnect-able event.
@@ -379,28 +396,30 @@ func (m *MailerImpl) SendMail(to []string, subject, msg string) error {
 			 *
 			 * [0] - https://github.com/letsencrypt/boulder/issues/2249
 			 */
-			m.reconnect()
+			c.reconnect()
 			// After reconnecting, loop around and try `sendOne` again.
 			continue
 		} else if errors.As(err, &protoErr) && badAddressErrorCodes[protoErr.Code] {
-			m.sendMailAttempts.WithLabelValues("failure", fmt.Sprintf("SMTP %d", protoErr.Code)).Inc()
+			c.sendMailAttempts.WithLabelValues("failure", fmt.Sprintf("SMTP %d", protoErr.Code)).Inc()
 			return BadAddressSMTPError{fmt.Sprintf("%d: %s", protoErr.Code, protoErr.Msg)}
 		} else {
 			// If it wasn't an EOF error or a recoverable SMTP error it is unexpected and we
 			// return from SendMail() with the error
-			m.sendMailAttempts.WithLabelValues("failure", "unexpected").Inc()
+			c.sendMailAttempts.WithLabelValues("failure", "unexpected").Inc()
 			return err
 		}
 	}
 
-	m.sendMailAttempts.WithLabelValues("success", "").Inc()
+	c.sendMailAttempts.WithLabelValues("success", "").Inc()
 	return nil
 }
 
 // Close closes the connection.
-func (m *MailerImpl) Close() error {
-	if m.client == nil {
-		return errors.New("call Connect before Close")
+func (c *connImpl) Close() error {
+	err := c.client.Close()
+	if err != nil {
+		return err
 	}
-	return m.client.Close()
+	c.client = nil
+	return nil
 }

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -50,7 +50,8 @@ type Mailer interface {
 }
 
 // Conn is an interface that allows sending mail. When you are done with a
-// Conn, call Close().
+// Conn, call Close(). Implementations are not required to be safe for
+// concurrent use.
 type Conn interface {
 	SendMail([]string, string, string) error
 	Close() error

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -184,7 +184,7 @@ func NewDryRun(from mail.Address, logger blog.Logger) *MailerImpl {
 	}
 }
 
-func (c *connImpl) generateMessage(to []string, subject, body string) ([]byte, error) {
+func (c config) generateMessage(to []string, subject, body string) ([]byte, error) {
 	mid := c.csprgSource.generate()
 	now := c.clk.Now().UTC()
 	addrs := []string{}

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -322,11 +322,11 @@ func TestConnect(t *testing.T) {
 	defer cleanUp()
 
 	go listenForever(l, t, normalHandler)
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.Close()
+	err = conn.Close()
 	if err != nil {
 		t.Errorf("Failed to clean up: %s", err)
 	}
@@ -344,11 +344,11 @@ func TestReconnectSuccess(t *testing.T) {
 	// With a mailer client that has a max attempt > `closedConns` we expect no
 	// error. The message should be delivered after `closedConns` reconnect
 	// attempts.
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	if err != nil {
 		t.Errorf("Expected SendMail() to not fail. Got err: %s", err)
 	}
@@ -361,12 +361,12 @@ func TestBadEmailError(t *testing.T) {
 
 	go listenForever(l, t, badEmailHandler(messages))
 
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
 
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	// We expect there to be an error
 	if err == nil {
 		t.Errorf("Expected SendMail() to return an BadAddressSMTPError, got nil")
@@ -393,11 +393,11 @@ func TestReconnectSMTP421(t *testing.T) {
 	// With a mailer client that has a max attempt > `closedConns` we expect no
 	// error. The message should be delivered after `closedConns` reconnect
 	// attempts.
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	if err != nil {
 		t.Errorf("Expected SendMail() to not fail. Got err: %s", err)
 	}
@@ -439,12 +439,12 @@ func TestOtherError(t *testing.T) {
 		_, _ = conn.Write([]byte("250 Ok yr rset now\r\n"))
 	})
 
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
 
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	// We expect there to be an error
 	if err == nil {
 		t.Errorf("Expected SendMail() to return an error, got nil")
@@ -488,12 +488,12 @@ func TestOtherError(t *testing.T) {
 
 		_, _ = conn.Write([]byte("nop\r\n"))
 	})
-	err = m.Connect()
+	conn, err = m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
 
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	// We expect there to be an error
 	test.AssertError(t, err, "SendMail didn't fail as expected")
 	test.AssertEquals(t, err.Error(), "999 1.1.1 This would probably be bad? (also, on sending RSET: short response: nop)")
@@ -511,11 +511,11 @@ func TestReconnectAfterRST(t *testing.T) {
 	// With a mailer client that has a max attempt > `closedConns` we expect no
 	// error. The message should be delivered after `closedConns` reconnect
 	// attempts.
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	if err != nil {
 		t.Errorf("Expected SendMail() to not fail. Got err: %s", err)
 	}

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -264,7 +264,7 @@ func rstHandler(rstFirst int) connHandler {
 	}
 }
 
-func setup(t *testing.T) (*MailerImpl, *net.TCPListener, func()) {
+func setup(t *testing.T) (*mailerImpl, *net.TCPListener, func()) {
 	fromAddress, _ := mail.ParseAddress("you-are-a-winner@example.com")
 	log := blog.UseMock()
 

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -14,6 +14,7 @@
     "nagCheckInterval": "24h",
     "emailTemplate": "test/example-expiration-template",
     "debugAddr": ":8008",
+    "parallelSends": 10,
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",


### PR DESCRIPTION
Previously, each accounts email would be sent in serial, along with several reads from the database (to check for certificate renewal) and several writes to the database (to update `certificateStatus.lastExpirationNagSent`). This adds a config field for the expiration mailer that sets the parallelism it will use.

That means making and using multiple SMTP connections as well. Previously, `bmail.Mailer` was not safe for concurrent use. It also had a piece of API awkwardness: after you created a Mailer, you had to call Connect on it to change its state.

Instead of treating that as a state change on Mailer, I split out a separate component: `bmail.Conn`. Now, when you call `Mailer.Connect()`, you get a Conn. You can send mail on that Conn and Close it when you're done. A single Mailer instance can produce multiple Conns, so Mailer is now concurrency-safe (while Conn is not).

This involved a moderate amount of renaming and code movement, and GitHub's move detector is not keeping up 100%, so an eye towards "is this moved code?" may help. Also adding `?w=1` to the diff URL to ignore whitespace diffs.