### PR TITLE
rocsp-tool: remove ServiceConfig from config

### DIFF
--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -24,8 +24,8 @@ import (
 
 type Config struct {
 	ROCSPTool struct {
-		cmd.ServiceConfig
-		Redis rocsp_config.RedisConfig
+		DebugAddr string
+		Redis     rocsp_config.RedisConfig
 		// Issuers is a map from filenames to short issuer IDs.
 		// Each filename must contain an issuer certificate. The short issuer
 		// IDs are arbitrarily assigned and must be consistent across OCSP


### PR DESCRIPTION
ServiceConfig is only needed for components that act as gRPC services.
For rocsp-tool, which is a gRPC client but is long-running enough to
merit a debug port, we should provide DebugAddr in the config.