### PR TITLE
Patch cert-checker hard-coded log levels and handle nil mariadb response

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/syslog"
@@ -128,11 +129,10 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 	}
 	if !sni.Valid {
 		// a nil response was returned by the DB, so return error and fail
-		return fmt.Errorf("The SELECT query resulted in a NULL response from the DB.")
+		return errors.New("the SELECT query resulted in a NULL response from the DB")
 	}
 
 	initialID := sni.Int64
-
 	if initialID > 0 {
 		// decrement the initial ID so that we select below as we aren't using >=
 		initialID -= 1

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -119,11 +119,15 @@ func (c *certChecker) getCerts(unexpiredOnly bool) error {
 	}
 
 	initialID, err := c.dbMap.SelectInt(
-		"SELECT IFNULL(MIN(id), 0) FROM certificates WHERE issued >= :issued AND expires >= :now",
+		"SELECT IFNULL(MIN(id), -1) FROM certificates WHERE issued >= :issued AND expires >= :now",
 		args,
 	)
 	if err != nil {
 		return err
+	}
+	if initialID == -1 {
+		// a nil response was returned by the DB, so return error and fail
+		return fmt.Errorf("The SELECT query resulted in a nil respone from the DB.")
 	}
 	if initialID > 0 {
 		// decrement the initial ID so that we select below as we aren't using >=

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -428,7 +428,9 @@ func TestGetCertsEmptyResults(t *testing.T) {
 }
 
 // create emptyDB for testing that null response from mariadb are handled properly
-type emptyDB struct{}
+type emptyDB struct{
+	certDB
+}
 
 // set SelectNullInt to respond with false to reflect the empty DB response
 func (db emptyDB) SelectNullInt(_ string, _ ...interface{}) (sql.NullInt64, error) {

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"database/sql"
 	"encoding/asn1"
 	"encoding/pem"
 	"io/ioutil"
@@ -380,8 +381,12 @@ type mismatchedCountDB struct{}
 // `getCerts` calls `SelectInt` first to determine how many rows there are
 // matching the `getCertsCountQuery` criteria. For this mock we return
 // a non-zero number
-func (db mismatchedCountDB) SelectInt(_ string, _ ...interface{}) (int64, error) {
-	return 99999, nil
+func (db mismatchedCountDB) SelectNullInt(_ string, _ ...interface{}) (sql.NullInt64, error) {
+	return sql.NullInt64{
+			Int64: 99999,
+			Valid: true,
+		},
+		nil
 }
 
 // `getCerts` then calls `Select` to retrieve the Certificate rows. We pull
@@ -420,6 +425,31 @@ func TestGetCertsEmptyResults(t *testing.T) {
 	batchSize = 3
 	err = checker.getCerts(false)
 	test.AssertNotError(t, err, "Failed to retrieve certificates")
+}
+
+// create emptyDB for testing that null response from mariadb are handled properly
+type emptyDB struct{}
+
+// set SelectNullInt to respond with false to reflect the empty DB response
+func (db emptyDB) SelectNullInt(_ string, _ ...interface{}) (sql.NullInt64, error) {
+	return sql.NullInt64{Valid: false},
+		nil
+}
+
+// define Select so the compiler is happy. Not used.
+func (db emptyDB) Select(output interface{}, _ string, _ ...interface{}) ([]interface{}, error) {
+	return nil, nil
+}
+
+// check that a NULL response from the DB will be handled correctly
+func TestGetCertsNullResults(t *testing.T) {
+	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	test.AssertNotError(t, err, "Couldn't connect to database")
+	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations)
+	checker.dbMap = emptyDB{}
+
+	err = checker.getCerts(false)
+	test.AssertError(t, err, "Failed to handle NULL DB response")
 }
 
 func TestSaveReport(t *testing.T) {

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -449,7 +449,7 @@ func TestGetCertsNullResults(t *testing.T) {
 	checker.dbMap = emptyDB{}
 
 	err = checker.getCerts(false)
-	test.AssertError(t, err, "Failed to handle NULL DB response")
+	test.AssertError(t, err, "Should have gotten error from empty DB")
 }
 
 func TestSaveReport(t *testing.T) {

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -427,18 +427,23 @@ func TestGetCertsEmptyResults(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to retrieve certificates")
 }
 
-// create emptyDB for testing that null response from mariadb are handled properly
+// emptyDB is a certDB object with methods used for testing that 'null'
+// responses received from the database are handled properly.
 type emptyDB struct {
 	certDB
 }
 
-// set SelectNullInt to respond with false to reflect the empty DB response
+// SelectNullInt is a method that returns a false sql.NullInt64 struct to
+// mock a null DB response
 func (db emptyDB) SelectNullInt(_ string, _ ...interface{}) (sql.NullInt64, error) {
 	return sql.NullInt64{Valid: false},
 		nil
 }
 
-// check that a NULL response from the DB will be handled correctly
+// TestGetCertsNullResults tests that a null response from the database will
+// be handled properly. It uses the emptyDB above to mock the response
+// expected if the DB finds no certificates to match the SELECT query and
+// should return an error.
 func TestGetCertsNullResults(t *testing.T) {
 	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
 	test.AssertNotError(t, err, "Couldn't connect to database")

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -428,7 +428,7 @@ func TestGetCertsEmptyResults(t *testing.T) {
 }
 
 // create emptyDB for testing that null response from mariadb are handled properly
-type emptyDB struct{
+type emptyDB struct {
 	certDB
 }
 
@@ -436,11 +436,6 @@ type emptyDB struct{
 func (db emptyDB) SelectNullInt(_ string, _ ...interface{}) (sql.NullInt64, error) {
 	return sql.NullInt64{Valid: false},
 		nil
-}
-
-// define Select so the compiler is happy. Not used.
-func (db emptyDB) Select(output interface{}, _ string, _ ...interface{}) ([]interface{}, error) {
-	return nil, nil
 }
 
 // check that a NULL response from the DB will be handled correctly

--- a/log/log.go
+++ b/log/log.go
@@ -65,10 +65,9 @@ func New(log *syslog.Writer, stdoutLogLevel int, syslogLogLevel int) (Logger, er
 	}, nil
 }
 
-// initialize should only be used in unit tests.
+// initialize is used in unit tests and called by Get before the logger
+// is fully set up
 func initialize() {
-	// defaultPriority is never used because we always use specific priority-based
-	// logging methods.
 	const defaultPriority = syslog.LOG_INFO | syslog.LOG_LOCAL0
 	syslogger, err := syslog.Dial("", "", defaultPriority, "test")
 	if err != nil {

--- a/log/log.go
+++ b/log/log.go
@@ -65,8 +65,8 @@ func New(log *syslog.Writer, stdoutLogLevel int, syslogLogLevel int) (Logger, er
 	}, nil
 }
 
-// initialize is used in unit tests and called by Get before the logger
-// is fully set up
+// initialize is used in unit tests and called by `Get` before the logger
+// is fully set up.
 func initialize() {
 	const defaultPriority = syslog.LOG_INFO | syslog.LOG_LOCAL0
 	syslogger, err := syslog.Dial("", "", defaultPriority, "test")


### PR DESCRIPTION
- Fix cert-checker to use the syslog and stdout logging facilities it
reads from the config file instead of having them hard-coded to zero.
- Fix cert-checker to handle a nil response from mariadb if no records
are found.
- Fix comment in log.go to correctly describe when the initialize function
and therefore default values would be used.

Fixes #6067