### PR TITLE
Use Redis 6.2.7 because Redis 7.0.0 breaks go-redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
         driver: none
 
   bredis_1:
-    image: redis:latest
+    image: redis:6.2.7
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis.config
@@ -75,7 +75,7 @@ services:
           ipv4_address: 10.33.33.2
 
   bredis_2:
-    image: redis:latest
+    image: redis:6.2.7
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis.config
@@ -84,7 +84,7 @@ services:
           ipv4_address: 10.33.33.3
 
   bredis_3:
-    image: redis:latest
+    image: redis:6.2.7
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis.config
@@ -93,7 +93,7 @@ services:
           ipv4_address: 10.33.33.4
 
   bredis_4:
-    image: redis:latest
+    image: redis:6.2.7
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis.config
@@ -102,7 +102,7 @@ services:
           ipv4_address: 10.33.33.5
 
   bredis_5:
-    image: redis:latest
+    image: redis:6.2.7
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis.config
@@ -111,7 +111,7 @@ services:
           ipv4_address: 10.33.33.6
 
   bredis_6:
-    image: redis:latest
+    image: redis:6.2.7
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis.config
@@ -120,7 +120,7 @@ services:
           ipv4_address: 10.33.33.7
 
   bredis_clusterer:
-    image: redis:latest
+    image: redis:6.2.7
     volumes:
       - ./test/:/test/:cached
       - ./cluster/:/cluster/:cached


### PR DESCRIPTION
Redis recently released version 7.0.0, which has several breaking
changes. The go-redis library that we rely on does not yet support
communicating with a Redis 7.0.0 cluster.

Pin ourselves to the latest non-7.0.0 version, 6.2.7, until such time
as go-redis releases a version with support for 7.0.0.

Fixes #6071