### PR TITLE
Disallow rate limit overrides lower than default

### DIFF
--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -207,23 +207,27 @@ func (rlp *RateLimitPolicy) GetThreshold(key string, regID int64) int64 {
 	regOverride, regOverrideExists := rlp.RegistrationOverrides[regID]
 	keyOverride, keyOverrideExists := rlp.Overrides[key]
 
+	var override int64
 	if regOverrideExists && !keyOverrideExists {
 		// If there is a regOverride and no keyOverride use the regOverride
-		return regOverride
+		override = regOverride
 	} else if !regOverrideExists && keyOverrideExists {
 		// If there is a keyOverride and no regOverride use the keyOverride
-		return keyOverride
+		override = keyOverride
 	} else if regOverrideExists && keyOverrideExists {
 		// If there is both a regOverride and a keyOverride use whichever is larger.
 		if regOverride > keyOverride {
-			return regOverride
+			override = regOverride
 		} else {
-			return keyOverride
+			override = keyOverride
 		}
 	}
 
-	// Otherwise there was no regOverride and no keyOverride, use the base
-	// Threshold
+	// Finally, return the greater of the override and the default threshold,
+	// which will always be the default if the override remained 0.
+	if override > rlp.Threshold {
+		return override
+	}
 	return rlp.Threshold
 }
 

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -29,13 +29,14 @@ func TestNotEnabled(t *testing.T) {
 
 func TestGetThreshold(t *testing.T) {
 	policy := RateLimitPolicy{
-		Threshold: 1,
+		Threshold: 2,
 		Overrides: map[string]int64{
-			"key": 2,
+			"key": 3,
 			"baz": 99,
+			"bar": 1,
 		},
 		RegistrationOverrides: map[int64]int64{
-			101: 3,
+			101: 4,
 		},
 	}
 
@@ -50,11 +51,17 @@ func TestGetThreshold(t *testing.T) {
 			Name:     "No key or reg overrides",
 			Key:      "foo",
 			RegID:    11,
-			Expected: 1,
+			Expected: 2,
 		},
 		{
 			Name:     "Key override, no reg override",
 			Key:      "key",
+			RegID:    11,
+			Expected: 3,
+		},
+		{
+			Name:     "Key override, but smaller than default",
+			Key:      "bar",
 			RegID:    11,
 			Expected: 2,
 		},
@@ -62,13 +69,13 @@ func TestGetThreshold(t *testing.T) {
 			Name:     "No key override, reg override",
 			Key:      "foo",
 			RegID:    101,
-			Expected: 3,
+			Expected: 4,
 		},
 		{
 			Name:     "Key override, larger reg override",
 			Key:      "foo",
 			RegID:    101,
-			Expected: 3,
+			Expected: 4,
 		},
 		{
 			Name:     "Key override, smaller reg override",


### PR DESCRIPTION
Sometimes we greatly increase the default rate limits in order to
allow all clients to catch up after an incident. If we increase the
defaults beyond the overrides certain clients already have, those
clients don't get to benefit.

Change the rate limit override logic so that it always takes the greater
of the default and the configured override.