### PR TITLE
Use go1.18.1 by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # used for release builds. make-deb.sh relies on being able to parse the
     # numeric version between 'go' and the underscore-prefixed date. If you make
     # changes to these tokens, please update this parsing logic.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.17.9_2022-04-12}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.18.1_2022-04-12}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config


### PR DESCRIPTION
This also updates the version built by the build and release action.