### PR TITLE
Register OCSP responder metrics

### DIFF
--- a/ocsp/responder/db_source.go
+++ b/ocsp/responder/db_source.go
@@ -33,6 +33,8 @@ func NewDbSource(dbMap dbSelector, stats prometheus.Registerer, log blog.Logger)
 		Name: "ocsp_db_responses",
 		Help: "Count of OCSP requests/responses by action taken by the dbSource",
 	}, []string{"result"})
+	stats.MustRegister(counter)
+
 	return &dbSource{
 		dbMap:   dbMap,
 		counter: counter,

--- a/ocsp/responder/filter_source.go
+++ b/ocsp/responder/filter_source.go
@@ -37,6 +37,7 @@ func NewFilterSource(issuerCerts []*issuance.Certificate, serialPrefixes []strin
 	if len(issuerCerts) < 1 {
 		return nil, errors.New("Filter must include at least 1 issuer cert")
 	}
+
 	issuersByNameId := make(map[issuance.IssuerNameID]responderID)
 	for _, issuerCert := range issuerCerts {
 		keyHash := issuerCert.KeyHash()
@@ -47,10 +48,13 @@ func NewFilterSource(issuerCerts []*issuance.Certificate, serialPrefixes []strin
 		}
 		issuersByNameId[issuerCert.NameID()] = rid
 	}
+
 	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ocsp_filter_responses",
 		Help: "Count of OCSP requests/responses by action taken by the filter",
 	}, []string{"result"})
+	stats.MustRegister(counter)
+
 	return &filterSource{
 		wrapped:        wrapped,
 		hashAlgorithm:  crypto.SHA1,

--- a/ocsp/responder/multi_source.go
+++ b/ocsp/responder/multi_source.go
@@ -26,6 +26,8 @@ func NewMultiSource(primary, secondary Source, stats prometheus.Registerer, log 
 		Name: "ocsp_multiplex_responses",
 		Help: "Count of OCSP requests/responses by action taken by the multiSource",
 	}, []string{"result"})
+	stats.MustRegister(counter)
+
 	return &multiSource{
 		primary:   primary,
 		secondary: secondary,

--- a/ocsp/responder/redis_source.go
+++ b/ocsp/responder/redis_source.go
@@ -25,6 +25,8 @@ func NewRedisSource(client *rocsp.Client, stats prometheus.Registerer, log blog.
 		Name: "ocsp_redis_responses",
 		Help: "Count of OCSP requests/responses by action taken by the redisSource",
 	}, []string{"result"})
+	stats.MustRegister(counter)
+
 	return &redisSource{
 		client:  client,
 		counter: counter,


### PR DESCRIPTION
These metrics were never registered, so although they are
being incremented, they are not being exported or collected.