### PR TITLE
Make rocsp config robust to empty "addrs" config

### DIFF
--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -114,6 +115,10 @@ func MakeClient(c *RedisConfig, clk clock.Clock, stats prometheus.Registerer) (*
 
 // MakeReadClient produces a *rocsp.Client from a config.
 func MakeReadClient(c *RedisConfig, clk clock.Clock, stats prometheus.Registerer) (*rocsp.Client, error) {
+	if len(c.Addrs) == 0 {
+		return nil, errors.New("redis config's 'addrs' field was empty")
+	}
+
 	password, err := c.PasswordConfig.Pass()
 	if err != nil {
 		return nil, fmt.Errorf("loading password: %w", err)


### PR DESCRIPTION
Before this change, an empty "addrs" config would result in a panic.
After this change, it will result in a clean error message.

Also, for stats generation use all addresses, not just the first one.