### PR TITLE
Don't write "null" to DB for missing contacts

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -212,11 +212,11 @@ type issuedNameModel struct {
 
 // regModel is the description of a core.Registration in the database before
 type regModel struct {
-	ID        int64    `db:"id"`
-	Key       []byte   `db:"jwk"`
-	KeySHA256 string   `db:"jwk_sha256"`
-	Contact   []string `db:"contact"`
-	Agreement string   `db:"agreement"`
+	ID        int64  `db:"id"`
+	Key       []byte `db:"jwk"`
+	KeySHA256 string `db:"jwk_sha256"`
+	Contact   []byte `db:"contact"`
+	Agreement string `db:"agreement"`
 	// InitialIP is stored as sixteen binary bytes, regardless of whether it
 	// represents a v4 or v6 IP address.
 	InitialIP []byte    `db:"initialIp"`
@@ -247,6 +247,10 @@ func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {
 	if len(contact) == 0 {
 		contact = []string{}
 	}
+	jsonContact, err := json.Marshal(contact)
+	if err != nil {
+		return nil, err
+	}
 
 	// For some reason we use different serialization formats for InitialIP
 	// in database models and in protobufs, despite the fact that both formats
@@ -269,7 +273,7 @@ func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {
 		ID:        reg.Id,
 		Key:       reg.Key,
 		KeySHA256: sha,
-		Contact:   contact,
+		Contact:   jsonContact,
 		Agreement: reg.Agreement,
 		InitialIP: []byte(initialIP.To16()),
 		CreatedAt: createdAt,
@@ -282,11 +286,16 @@ func registrationModelToPb(reg *regModel) (*corepb.Registration, error) {
 		return nil, errors.New("incomplete Registration retrieved from DB")
 	}
 
-	var contact []string
+	contact := []string{}
 	contactsPresent := false
-	if len(reg.Contact) != 0 {
-		contact = reg.Contact
-		contactsPresent = true
+	if len(reg.Contact) > 0 {
+		err := json.Unmarshal(reg.Contact, &contact)
+		if err != nil {
+			return nil, err
+		}
+		if len(contact) > 0 {
+			contactsPresent = true
+		}
 	}
 
 	// For some reason we use different serialization formats for InitialIP

--- a/sa/model.go
+++ b/sa/model.go
@@ -215,7 +215,7 @@ type regModel struct {
 	ID        int64  `db:"id"`
 	Key       []byte `db:"jwk"`
 	KeySHA256 string `db:"jwk_sha256"`
-	Contact   []byte `db:"contact"`
+	Contact   string `db:"contact"`
 	Agreement string `db:"agreement"`
 	// InitialIP is stored as sixteen binary bytes, regardless of whether it
 	// represents a v4 or v6 IP address.
@@ -241,7 +241,7 @@ func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {
 
 	// We don't want to write literal JSON "null" strings into the database if the
 	// list of contact addresses is empty. Replace any possibly-`nil` slice with
-	// an empty slice instead. We don't need to check reg.ContactPresent, because
+	// an empty JSON array. We don't need to check reg.ContactPresent, because
 	// we're going to write the whole object to the database anyway.
 	jsonContact := []byte("[]")
 	if len(reg.Contact) != 0 {
@@ -272,7 +272,7 @@ func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {
 		ID:        reg.Id,
 		Key:       reg.Key,
 		KeySHA256: sha,
-		Contact:   jsonContact,
+		Contact:   string(jsonContact),
 		Agreement: reg.Agreement,
 		InitialIP: []byte(initialIP.To16()),
 		CreatedAt: createdAt,
@@ -288,7 +288,7 @@ func registrationModelToPb(reg *regModel) (*corepb.Registration, error) {
 	contact := []string{}
 	contactsPresent := false
 	if len(reg.Contact) > 0 {
-		err := json.Unmarshal(reg.Contact, &contact)
+		err := json.Unmarshal([]byte(reg.Contact), &contact)
 		if err != nil {
 			return nil, err
 		}

--- a/sa/model.go
+++ b/sa/model.go
@@ -239,6 +239,15 @@ func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {
 		return nil, err
 	}
 
+	// We don't want to write literal JSON "null" strings into the database if the
+	// list of contact addresses is empty. Replace any possibly-`nil` slice with
+	// an empty slice instead. We don't need to reference reg.ContactPresent,
+	// because we're going to write the whole object to the database anyway.
+	contact := reg.Contact
+	if len(contact) == 0 {
+		contact = []string{}
+	}
+
 	// For some reason we use different serialization formats for InitialIP
 	// in database models and in protobufs, despite the fact that both formats
 	// are just []byte.
@@ -260,7 +269,7 @@ func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {
 		ID:        reg.Id,
 		Key:       reg.Key,
 		KeySHA256: sha,
-		Contact:   reg.Contact,
+		Contact:   contact,
 		Agreement: reg.Agreement,
 		InitialIP: []byte(initialIP.To16()),
 		CreatedAt: createdAt,

--- a/sa/model.go
+++ b/sa/model.go
@@ -241,15 +241,14 @@ func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {
 
 	// We don't want to write literal JSON "null" strings into the database if the
 	// list of contact addresses is empty. Replace any possibly-`nil` slice with
-	// an empty slice instead. We don't need to reference reg.ContactPresent,
-	// because we're going to write the whole object to the database anyway.
-	contact := reg.Contact
-	if len(contact) == 0 {
-		contact = []string{}
-	}
-	jsonContact, err := json.Marshal(contact)
-	if err != nil {
-		return nil, err
+	// an empty slice instead. We don't need to check reg.ContactPresent, because
+	// we're going to write the whole object to the database anyway.
+	jsonContact := []byte("[]")
+	if len(reg.Contact) != 0 {
+		jsonContact, err = json.Marshal(reg.Contact)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// For some reason we use different serialization formats for InitialIP


### PR DESCRIPTION
Instead write `[]`, a better representation of an empty contact set,
and avoid having literal JSON `null`s in our database.

As part of doing so, add some extra code to //sa/model.go that
bypasses the need for //sa/type-converter.go to do any magic
JSON-to-string-slice conversions for us.

Fixes #6074