### PR TITLE
Improve github release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,26 +44,23 @@ jobs:
           path: ${{ steps.build.outputs.filename }}
 
   push-release:
-    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: build-release
     runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:
+      # This downloads every artifact uploaded by the matrix jobs above,
+      # directly into the current pwd.
       - name: Download .debs
         id: download
         uses: actions/download-artifact@v3
         with:
           name: boulder_debs
 
-      - name: Echo output
-        run: echo ${{ steps.download.outputs.download-path }}
-
-      - name: List files
-        run: ls -laR
-
-      # - name: Create release
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   # https://cli.github.com/manual/gh_release_create
-      #   run: gh release create "${GITHUB_REF_NAME}" "boulder deb/*"
+      # We have to pass the -R flag here because this job skipped checkout.
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://cli.github.com/manual/gh_release_create
+        run: gh release -R ${{ github.repository }} create "${GITHUB_REF_NAME}" boulder*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
         with:
           name: boulder deb
       - name: rename
-        run: mv boulder.deb boulder-1.0.0-$(git rev-parse --short HEAD).x86_64.deb
+        run: mv boulder.deb boulder-1.0.0-$(git rev-parse --short=8 HEAD).x86_64.deb
       - name: push release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://cli.github.com/manual/gh_release_create
-        run: gh release create "${GITHUB_REF_NAME}" boulder-1.0.0-$(git rev-parse --short HEAD).x86_64.deb
+        run: gh release create "${GITHUB_REF_NAME}" boulder-1.0.0-$(git rev-parse --short=8 HEAD).x86_64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   build-release:
+    strategy:
+      fail-fast: false
+      matrix:
+        GO_VERSION:
+          - 1.17.9
+          - 1.18.1
     runs-on: ubuntu-20.04
     permissions:
       contents: read
@@ -20,34 +26,44 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: build deb
+      # This step will create an output called `filename` which contains the
+      # path of the produced .deb file.
+      - name: Build .deb
+        id: build
+        env:
+          GO_VERSION: ${{ matrix.GO_VERSION }}
         run: ./tools/make-deb.sh
 
-      - name: upload deb
+      # Because each copy of this job (one for each entry in the matrix) uploads
+      # to the same artifact name, all of the files will live side-by-side in
+      # the same artifact, and can be downloaded as a single unit.
+      - name: Upload .deb
         uses: actions/upload-artifact@v3
         with:
-          name: boulder deb
-          path: boulder.deb
+          name: boulder_debs
+          path: ${{ steps.build.outputs.filename }}
 
   push-release:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: build-release
     runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-
-      - name: Download release artifact
+      - name: Download .debs
+        id: download
         uses: actions/download-artifact@v3
         with:
-          name: boulder deb
-      - name: rename
-        run: mv boulder.deb boulder-1.0.0-$(git rev-parse --short=8 HEAD).x86_64.deb
-      - name: push release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # https://cli.github.com/manual/gh_release_create
-        run: gh release create "${GITHUB_REF_NAME}" boulder-1.0.0-$(git rev-parse --short=8 HEAD).x86_64.deb
+          name: boulder_debs
+
+      - name: Echo output
+        run: echo ${{ steps.download.outputs.download-path }}
+
+      - name: List files
+        run: ls -laR
+
+      # - name: Create release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   # https://cli.github.com/manual/gh_release_create
+      #   run: gh release create "${GITHUB_REF_NAME}" "boulder deb/*"


### PR DESCRIPTION
Generate .deb packages for all currently configured Go versions
(usually the current and upcoming versions that we use in prod), rather
than just the one default version. Also ensure that the uploaded
artifacts have 8-character short hashes in their names.

Unfortunately this does require updating Go versions in one additional
place (the release.yml file), since we are no longer parsing it out of the
docker-compose.yml. This is unavoidable without hacks that I consider
to be even uglier than the repetition.

Fixes #6075
Fixes #6084