### PR TITLE
Quiet log output for successful /directory requests

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -543,6 +543,7 @@ func (wfe *WebFrontEndImpl) Directory(
 		return
 	}
 
+	logEvent.Suppress()
 	response.Write(relDir)
 }
 


### PR DESCRIPTION
Add functionality to the ubiquitous RequestEvent (aka logEvent) to
allow handlers to suppress the final log line that is printed when
a non-500 response is being sent.

Use this functionality to suppress logging GET requests for the /directory
endpoint. We can expand this in the future to quiet other logs that
are not helpful for metrics or analysis.

Fixes #6094