### PR TITLE
expiration-mailer: avoid re-examining certificates

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -69,9 +69,6 @@ type mailerStats struct {
 }
 
 func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
-	if len(contacts) == 0 {
-		return nil
-	}
 	if len(certs) == 0 {
 		return errors.New("no certs given to send nags for")
 	}
@@ -252,10 +249,6 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 
 		if len(parsedCerts) == 0 {
 			// all certificates are renewed
-			continue
-		}
-
-		if len(reg.Contact) == 0 {
 			continue
 		}
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -255,7 +255,7 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 			continue
 		}
 
-		if reg.Contact == nil {
+		if len(reg.Contact) == 0 {
 			continue
 		}
 

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -198,7 +198,7 @@ func TestProcessCerts(t *testing.T) {
 
 // There's an account with an expiring certificate but no email address. We shouldn't examine
 // that certificate repeatedly; we should mark it as if it had an email sent already.
-func TestNoContactNotRenewed(t *testing.T) {
+func TestNoContactCertIsNotRenewed(t *testing.T) {
 	testCtx := setup(t, []time.Duration{time.Hour * 24 * 7})
 
 	reg, err := makeRegistration(testCtx.ssa, 1, jsonKeyA, nil)
@@ -221,6 +221,51 @@ func TestNoContactNotRenewed(t *testing.T) {
 
 	// We should have sent no mail, because there was no contact address
 	test.AssertEquals(t, len(testCtx.mc.Messages), 0)
+
+	// We should have examined exactly one certificate
+	certsExamined := testCtx.m.stats.certificatesExamined
+	test.AssertMetricWithLabelsEquals(t, certsExamined, prometheus.Labels{}, 1.0)
+
+	// Run findExpiringCertificates again. The count of examined certificates
+	// should not increase again.
+	err = testCtx.m.findExpiringCertificates(context.Background())
+	test.AssertNotError(t, err, "finding expired certificates")
+	test.AssertMetricWithLabelsEquals(t, certsExamined, prometheus.Labels{}, 1.0)
+}
+
+// An account with no contact info has a certificate that is expiring but has been renewed.
+// We should only examine that certificate once.
+func TestNoContactCertIsRenewed(t *testing.T) {
+	testCtx := setup(t, []time.Duration{time.Hour * 24 * 7})
+
+	reg, err := makeRegistration(testCtx.ssa, 1, jsonKeyA, []string{})
+	test.AssertNotError(t, err, "Couldn't store regA")
+
+	names := []string{"example-a.com"}
+	cert, err := makeCertificate(
+		reg.Id,
+		serial1,
+		names,
+		23*time.Hour,
+		testCtx.fc)
+	test.AssertNotError(t, err, "creating cert A")
+
+	err = insertCertificate(cert, time.Time{})
+	test.AssertNotError(t, err, "inserting certificate")
+
+	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	test.AssertNotError(t, err, "setting up DB")
+	err = setupDBMap.Insert(&core.FQDNSet{
+		SetHash: sa.HashNames(names),
+		Serial:  core.SerialToString(serial2),
+		Issued:  cert.Issued.Add(time.Hour),
+		Expires: cert.Expires.Add(time.Hour),
+	})
+	test.AssertNotError(t, err, "inserting FQDNSet for renewal")
+
+	log.Clear()
+	err = testCtx.m.findExpiringCertificates(context.Background())
+	test.AssertNotError(t, err, "finding expired certificates")
 
 	// We should have examined exactly one certificate
 	certsExamined := testCtx.m.stats.certificatesExamined

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -226,11 +226,15 @@ func TestNoContactCertIsNotRenewed(t *testing.T) {
 	certsExamined := testCtx.m.stats.certificatesExamined
 	test.AssertMetricWithLabelsEquals(t, certsExamined, prometheus.Labels{}, 1.0)
 
+	certsAlreadyRenewed := testCtx.m.stats.certificatesAlreadyRenewed
+	test.AssertMetricWithLabelsEquals(t, certsAlreadyRenewed, prometheus.Labels{}, 0.0)
+
 	// Run findExpiringCertificates again. The count of examined certificates
 	// should not increase again.
 	err = testCtx.m.findExpiringCertificates(context.Background())
 	test.AssertNotError(t, err, "finding expired certificates")
 	test.AssertMetricWithLabelsEquals(t, certsExamined, prometheus.Labels{}, 1.0)
+	test.AssertMetricWithLabelsEquals(t, certsAlreadyRenewed, prometheus.Labels{}, 0.0)
 }
 
 // An account with no contact info has a certificate that is expiring but has been renewed.
@@ -271,11 +275,15 @@ func TestNoContactCertIsRenewed(t *testing.T) {
 	certsExamined := testCtx.m.stats.certificatesExamined
 	test.AssertMetricWithLabelsEquals(t, certsExamined, prometheus.Labels{}, 1.0)
 
+	certsAlreadyRenewed := testCtx.m.stats.certificatesAlreadyRenewed
+	test.AssertMetricWithLabelsEquals(t, certsAlreadyRenewed, prometheus.Labels{}, 1.0)
+
 	// Run findExpiringCertificates again. The count of examined certificates
 	// should not increase again.
 	err = testCtx.m.findExpiringCertificates(context.Background())
 	test.AssertNotError(t, err, "finding expired certificates")
 	test.AssertMetricWithLabelsEquals(t, certsExamined, prometheus.Labels{}, 1.0)
+	test.AssertMetricWithLabelsEquals(t, certsAlreadyRenewed, prometheus.Labels{}, 1.0)
 }
 
 func TestFindExpiringCertificates(t *testing.T) {

--- a/test/asserts.go
+++ b/test/asserts.go
@@ -151,8 +151,8 @@ func AssertNotContains(t *testing.T, haystack string, needle string) {
 	}
 }
 
-// AssertMetricWithLabelsEquals determines whether the value held by a prometheus Collector
-// (e.g. Gauge, Counter, CounterVec, etc) is equal to the expected float64.
+// AssertMetricEquals determines whether the value held by a prometheus Collector
+// (e.g. Gauge, Counter, CounterVec, etc) is equal to the expected integer.
 // In order to make useful assertions about just a subset of labels (e.g. for a
 // CounterVec with fields "host" and "valid", being able to assert that two
 // "valid": "true" increments occurred, without caring which host was tagged in
@@ -161,7 +161,6 @@ func AssertNotContains(t *testing.T, haystack string, needle string) {
 // Only works for simple metrics (Counters and Gauges), or for the *count*
 // (not value) of data points in a Histogram.
 func AssertMetricWithLabelsEquals(t *testing.T, c prometheus.Collector, l prometheus.Labels, expected float64) {
-	t.Helper()
 	ch := make(chan prometheus.Metric)
 	done := make(chan struct{})
 	go func() {

--- a/test/asserts.go
+++ b/test/asserts.go
@@ -161,6 +161,7 @@ func AssertNotContains(t *testing.T, haystack string, needle string) {
 // Only works for simple metrics (Counters and Gauges), or for the *count*
 // (not value) of data points in a Histogram.
 func AssertMetricWithLabelsEquals(t *testing.T, c prometheus.Collector, l prometheus.Labels, expected float64) {
+	t.Helper()
 	ch := make(chan prometheus.Metric)
 	done := make(chan struct{})
 	go func() {

--- a/test/asserts.go
+++ b/test/asserts.go
@@ -151,8 +151,8 @@ func AssertNotContains(t *testing.T, haystack string, needle string) {
 	}
 }
 
-// AssertMetricEquals determines whether the value held by a prometheus Collector
-// (e.g. Gauge, Counter, CounterVec, etc) is equal to the expected integer.
+// AssertMetricWithLabelsEquals determines whether the value held by a prometheus Collector
+// (e.g. Gauge, Counter, CounterVec, etc) is equal to the expected float64.
 // In order to make useful assertions about just a subset of labels (e.g. for a
 // CounterVec with fields "host" and "valid", being able to assert that two
 // "valid": "true" increments occurred, without caring which host was tagged in


### PR DESCRIPTION
findExpiringCertificates had a previously unstated invariant: It is supposed to only examine each certificate once per nag window. Otherwise, the set of certificates it has to examine may get clogged up with certificates it has previously looked at, and it will fall behind. It does this by updating lastExpirationNagSent after examining each certificate. For certificates that have already been renewed, we update this field even though we didn't actually send any mail.

We accidentally broke this invariant in #6057. When that change rolled out to staging, suddenly our rate of sent mail plummeted to near-zero, and our nags_at_capacity metric went to 1 for all expiration windows, and stayed there until we deployed a revert.

The problem was here: https://github.com/letsencrypt/boulder/pull/6057/files#diff-ae49e23ff8be05aae6145106f04c76fc1f0b7b336c0cdcbe8183f572dedf47c5R261-R263. We check if `reg.Contacts` is empty, and bail. Prior to #6057, that check happened _after_ checking for renewal and updating lastExpirationNagSent. In the code shuffle of #6057, that check got moved to _before_ checking for renewal. So expiration-mailer's input became clogged with certificates that had already been renewed, but were issued by accounts with no contact.

There's a second problem that has existed practically forever: we hit the `reg.Contacts` check for no-contact-info certificates that have _not_ been renewed, and those also clog up expiration mailer. This problem is probably causing some amount of slowness today in both prod and staging.

I wrote unittests to check the first and second problem, and verified that they fail as appropriate. The second one fails with current `main`; the first one fails if I simulate #6057 by moving the `reg.Contacts` check higher in the file.

The fix is simple: delete the `reg.Contacts` check entirely. It's valid to call `sendNags` with an empty contacts list, and will return a nil error. That allows findExpiringCertificates to proceed to updating lastExpirationNagSent for those certificates, so they won't be examined again on the next iteration. I also removed another spurious length check in `sendNags`, since there's an equivalent length check a few lines lower.

Related to #5682