### PR TITLE
expiration-mailer: Don't bail early on error

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -352,7 +352,7 @@ func (m *mailer) findExpiringCertificates(ctx context.Context) error {
 					continue
 				}
 				m.log.AuditErrf("expiration-mailer: Error loading cert %q: %s", cert.Serial, err)
-				return err
+				continue
 			}
 			certs = append(certs, cert)
 		}


### PR DESCRIPTION
If there is an error in SelectCertificate, we can continue doing work
with the remaining certificates.

Fixes #6095.