### PR TITLE
expiration-mailer: Deprecate NagCheckInterval

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -621,14 +621,13 @@ func main() {
 	defer cancel()
 
 	go cmd.CatchSignals(logger, func() {
-		fmt.Printf("exiting\n")
 		cancel()
 		select {} // wait for the `findExpiringCertificates` calls below to exit
 	})
 
 	if *daemon {
 		if c.Mailer.Frequency.Duration == 0 {
-			fmt.Fprintln(os.Stderr, "mailer.runPeriod is not set")
+			fmt.Fprintln(os.Stderr, "mailer.Frequency is not set in the JSON config")
 			os.Exit(1)
 		}
 		t := time.NewTicker(c.Mailer.Frequency.Duration)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -399,8 +399,9 @@ type Config struct {
 		CertLimit int
 		NagTimes  []string
 
-		// Deprecated: https://github.com/letsencrypt/boulder/issues/6097
+		// TODO(#6097): Remove this
 		NagCheckInterval string
+
 		// Path to a text/template email template
 		EmailTemplate string
 

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -409,7 +409,8 @@ func TestFindCertsAtCapacity(t *testing.T) {
 	// The "48h0m0s" nag group should have its prometheus stat incremented once.
 	// Note: this is not the 24h0m0s nag as you would expect sending time.Hour
 	// * 24 to setup() for the nag duration. This is because all of the nags are
-	// offset by Frequency, which is 24hrs.
+	// offset by 24 hours in this test file's setup() function, to mimic a 24h
+	// setting for the "Frequency" field in the JSON config.
 	test.AssertEquals(t, countGroupsAtCapacity("48h0m0s", testCtx.m.stats.nagsAtCapacity), 1)
 
 	// A consecutive run shouldn't find anything

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -409,11 +409,10 @@ func TestFindCertsAtCapacity(t *testing.T) {
 	// The "48h0m0s" nag group should have its prometheus stat incremented once.
 	// Note: this is not the 24h0m0s nag as you would expect sending time.Hour
 	// * 24 to setup() for the nag duration. This is because all of the nags are
-	// offset by defaultNagCheckInterval, which is 24hrs.
+	// offset by Frequency, which is 24hrs.
 	test.AssertEquals(t, countGroupsAtCapacity("48h0m0s", testCtx.m.stats.nagsAtCapacity), 1)
 
-	// A consecutive run shouldn't find anything - similarly we do not EXPECT()
-	// anything on statter to be called, and if it is then we have a test failure
+	// A consecutive run shouldn't find anything
 	testCtx.mc.Clear()
 	log.Clear()
 	err = testCtx.m.findExpiringCertificates(context.Background())
@@ -735,7 +734,7 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 
 	offsetNags := make([]time.Duration, len(nagTimes))
 	for i, t := range nagTimes {
-		offsetNags[i] = t + defaultNagCheckInterval
+		offsetNags[i] = t + 24*time.Hour
 	}
 
 	m := &mailer{

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -11,7 +11,6 @@
     },
     "certLimit": 100000,
     "nagTimes": ["480h", "240h"],
-    "nagCheckInterval": "24h",
     "emailTemplate": "test/example-expiration-template",
     "debugAddr": ":8008",
     "tls": {


### PR DESCRIPTION
This was introduced when expiration-mailer was run by cron, and was a
way for expiration-mailer to know something about its expected run
interval so it could send notifications "on time" rather than "just
after" the configured email time.

Now that expiration-mailer runs as a daemon we can simply pull this
value from `Frequency`, which is set to the same value in prod.

Fixes #6097