### PR TITLE
Enable additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - typecheck
     - unconvert
     - unused
+    - varcheck
 linters-settings:
   errcheck:
     ignore: fmt:[FS]?[Pp]rint*,io:Write,os:Remove,net/http:Write,github.com/miekg/dns:WriteMsg,net:Write,encoding/binary:Write

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   disable-all: true
   enable:
+    - deadcode
     - errcheck
     - gofmt
     - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
+    - structcheck
     - stylecheck
     - unconvert
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ linters:
   disable-all: true
   enable:
     - deadcode
+    # TODO(#6105): add 'gci' linter
     - gofmt
     - gosec
     - gosimple
@@ -13,6 +14,7 @@ linters:
     - stylecheck
     - typecheck
     - unconvert
+    # TODO(#6104): Enable 'unparam' linter
     - unused
     - varcheck
     - wastedassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - misspell
     - staticcheck
     - stylecheck
+    - unconvert
     - unused
 linters-settings:
   errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
+    - typecheck
     - unconvert
     - unused
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   disable-all: true
   enable:
     - deadcode
-    - errcheck
     - gofmt
     - gosec
     - gosimple
@@ -16,6 +15,7 @@ linters:
     - unconvert
     - unused
     - varcheck
+    - wastedassign
 linters-settings:
   errcheck:
     ignore: fmt:[FS]?[Pp]rint*,io:Write,os:Remove,net/http:Write,github.com/miekg/dns:WriteMsg,net:Write,encoding/binary:Write

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -212,8 +212,8 @@ func serveLoopResolver(stopChan chan bool) {
 }
 
 func pollServer() {
-	backoff := time.Duration(200 * time.Millisecond)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
+	backoff := 200 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	ticker := time.NewTicker(backoff)
 

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -31,15 +31,6 @@ import (
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
 
-// Metrics for CA statistics
-const (
-	csrExtensionCategory          = "category"
-	csrExtensionBasic             = "basic"
-	csrExtensionTLSFeature        = "tls-feature"
-	csrExtensionTLSFeatureInvalid = "tls-feature-invalid"
-	csrExtensionOther             = "other"
-)
-
 type certificateType string
 
 const (
@@ -78,7 +69,6 @@ type certificateAuthorityImpl struct {
 	clk                clock.Clock
 	log                blog.Logger
 	signatureCount     *prometheus.CounterVec
-	csrExtensionCount  *prometheus.CounterVec
 	orphanCount        *prometheus.CounterVec
 	adoptedOrphanCount *prometheus.CounterVec
 	signErrorCount     *prometheus.CounterVec
@@ -144,14 +134,6 @@ func NewCertificateAuthorityImpl(
 		return nil, err
 	}
 
-	csrExtensionCount := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "csr_extensions",
-			Help: "Number of CSRs with extensions of the given category",
-		},
-		[]string{csrExtensionCategory})
-	stats.MustRegister(csrExtensionCount)
-
 	orphanCount := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "orphans",
@@ -181,7 +163,6 @@ func NewCertificateAuthorityImpl(
 		orphanQueue:        orphanQueue,
 		log:                logger,
 		signatureCount:     signatureCount,
-		csrExtensionCount:  csrExtensionCount,
 		orphanCount:        orphanCount,
 		adoptedOrphanCount: adoptedOrphanCount,
 		signErrorCount:     signErrorCount,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -96,22 +96,6 @@ var (
 
 	// OIDExtensionSCTList is defined in RFC 6962 s3.3.
 	OIDExtensionSCTList = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}
-
-	// The "certificate-for-precertificate" tests use the precertificate from a
-	// previous "precertificate" test, in order to verify that the CA is
-	// stateless with respect to these two operations, since a separate CA
-	// object instance will be used for generating each. Consequently, the
-	// "precertificate" tests must be before the "certificate-for-precertificate"
-	// tests in this list, and we cannot run these sub-tests concurrently.
-	//
-	// In order to test the case where the same CA object is used for issuing
-	// both the precertificate and the certificate, we'd need to contort
-	// |TestIssueCertificate| quite a bit, and since it isn't clear that that
-	// would be useful, we've avoided adding that case, at least for now.
-	issuanceModes = []IssuanceMode{
-		{name: "precertificate", issueCertificateForPrecertificate: false},
-		{name: "certificate-for-precertificate", issueCertificateForPrecertificate: true},
-	}
 )
 
 const arbitraryRegID int64 = 1001
@@ -317,14 +301,8 @@ type TestCertificateIssuance struct {
 	ca      *certificateAuthorityImpl
 	sa      *mockSA
 	req     *x509.CertificateRequest
-	mode    IssuanceMode
 	certDER []byte
 	cert    *x509.Certificate
-}
-
-type IssuanceMode struct {
-	name                              string
-	issueCertificateForPrecertificate bool
 }
 
 func TestIssuePrecertificate(t *testing.T) {
@@ -345,14 +323,14 @@ func TestIssuePrecertificate(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		// The loop through |issuanceModes| must be inside the loop through
+		// The loop through the issuance modes must be inside the loop through
 		// |testCases| because the "certificate-for-precertificate" tests use
 		// the precertificates previously generated from the preceding
-		// "precertificate" test. See also the comment above |issuanceModes|.
-		for _, mode := range issuanceModes {
+		// "precertificate" test.
+		for _, mode := range []string{"precertificate", "certificate-for-precertificate"} {
 			ca, sa := issueCertificateSubTestSetup(t)
 
-			t.Run(fmt.Sprintf("%s - %s", mode.name, testCase.name), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s - %s", mode, testCase.name), func(t *testing.T) {
 				req, err := x509.ParseCertificateRequest(testCase.csr)
 				test.AssertNotError(t, err, "Certificate request failed to parse")
 
@@ -378,7 +356,6 @@ func TestIssuePrecertificate(t *testing.T) {
 					ca:      ca,
 					sa:      sa,
 					req:     req,
-					mode:    mode,
 					certDER: certDER,
 					cert:    cert,
 				}

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -487,7 +487,7 @@ func TestECDSAAllowList(t *testing.T) {
 
 	// With allowlist containing arbitraryRegID, issuance should come from ECDSA issuer.
 	ca, _ := issueCertificateSubTestSetup(t)
-	contents := makeECDSAAllowListBytes(int64(arbitraryRegID))
+	contents := makeECDSAAllowListBytes(arbitraryRegID)
 	err := ca.ecdsaAllowList.Update(contents)
 	if err != nil {
 		t.Errorf("%s %s", yamlLoadErrMsg, err)

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -43,16 +43,15 @@ func TestMux(t *testing.T) {
 	h := mux("/foobar/", src, time.Second, metrics.NoopRegisterer, blog.NewMock())
 
 	type muxTest struct {
-		method       string
-		path         string
-		reqBody      []byte
-		respBody     []byte
-		expectedType string
+		method   string
+		path     string
+		reqBody  []byte
+		respBody []byte
 	}
 	mts := []muxTest{
-		{"POST", "/foobar/", reqBytes, respBytes, "Success"},
-		{"GET", "/", nil, nil, ""},
-		{"GET", "/foobar/MFMwUTBPME0wSzAJBgUrDgMCGgUABBR+5mrncpqz/PiiIGRsFqEtYHEIXQQUqEpqYwR93brm0Tm3pkVl7/Oo7KECEgO/AC2R1FW8hePAj4xp//8Jhw==", nil, respBytes, "Success"},
+		{"POST", "/foobar/", reqBytes, respBytes},
+		{"GET", "/", nil, nil},
+		{"GET", "/foobar/MFMwUTBPME0wSzAJBgUrDgMCGgUABBR+5mrncpqz/PiiIGRsFqEtYHEIXQQUqEpqYwR93brm0Tm3pkVl7/Oo7KECEgO/AC2R1FW8hePAj4xp//8Jhw==", nil, respBytes},
 	}
 	for i, mt := range mts {
 		w := httptest.NewRecorder()

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -22,7 +22,6 @@ const (
 	returnOverhead         = 20 * time.Millisecond
 	meaningfulWorkOverhead = 100 * time.Millisecond
 	clientRequestTimeKey   = "client-request-time"
-	serverLatencyKey       = "server-latency"
 )
 
 // NoCancelInterceptor is a gRPC interceptor that creates a new context,

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -148,7 +148,7 @@ func (sa *StorageAuthority) GetRegistrationByKey(_ context.Context, req *sapb.JS
 		return &corepb.Registration{Id: 5}, berrors.NotFoundError("reg not found")
 	}
 
-	if bytes.Equal(req.Jwk, []byte(test5KeyPublicJSON)) {
+	if bytes.Equal(req.Jwk, test5KeyPublicJSON) {
 		// No key found
 		return &corepb.Registration{Id: 5}, berrors.NotFoundError("reg not found")
 	}

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -301,7 +301,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	response.Header().Add("Last-Modified", ocspResponse.ThisUpdate.Format(time.RFC1123))
 	response.Header().Add("Expires", ocspResponse.NextUpdate.Format(time.RFC1123))
 	now := rs.clk.Now()
-	maxAge := 0
+	var maxAge int
 	if now.Before(ocspResponse.NextUpdate) {
 		maxAge = int(ocspResponse.NextUpdate.Sub(now) / time.Second)
 	} else {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -566,7 +566,7 @@ func (ra *RegistrationAuthorityImpl) checkInvalidAuthorizationLimit(ctx context.
 	// Most rate limits have a key for overrides, but there is no meaningful key
 	// here.
 	noKey := ""
-	if count.Count >= int64(limit.GetThreshold(noKey, regID)) {
+	if count.Count >= limit.GetThreshold(noKey, regID) {
 		ra.log.Infof("Rate limit exceeded, InvalidAuthorizationsByRegID, regID: %d", regID)
 		return berrors.RateLimitError("too many failed authorizations recently")
 	}
@@ -998,7 +998,7 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 	}
 
 	// Parse the issued certificate to get the serial
-	parsedCertificate, err := x509.ParseCertificate([]byte(cert.DER))
+	parsedCertificate, err := x509.ParseCertificate(cert.DER)
 	if err != nil {
 		// Fail the order with a server internal error. The certificate we failed
 		// to parse was from our own CA. Bad news!
@@ -1199,7 +1199,7 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 		return emptyCert, wrapError(err, "issuing certificate for precertificate")
 	}
 
-	parsedCertificate, err := x509.ParseCertificate([]byte(cert.Der))
+	parsedCertificate, err := x509.ParseCertificate(cert.Der)
 	if err != nil {
 		// berrors.InternalServerError because the certificate from the CA should be
 		// parseable.
@@ -1829,7 +1829,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, seri
 
 	ocspResponse, err := ra.CA.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		Serial:    serialString,
-		IssuerID:  int64(issuerID),
+		IssuerID:  issuerID,
 		Status:    string(core.OCSPStatusRevoked),
 		Reason:    int32(reason),
 		RevokedAt: revokedAt,
@@ -1843,7 +1843,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, seri
 		Reason:   int64(reason),
 		Date:     revokedAt,
 		Response: ocspResponse.Response,
-		IssuerID: int64(issuerID),
+		IssuerID: issuerID,
 	})
 	if err != nil {
 		return err
@@ -1880,7 +1880,7 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 	// The new OCSP response has to be back-dated to the original date.
 	ocspResponse, err := ra.CA.GenerateOCSP(ctx, &capb.GenerateOCSPRequest{
 		Serial:    serialString,
-		IssuerID:  int64(issuerID),
+		IssuerID:  issuerID,
 		Status:    string(core.OCSPStatusRevoked),
 		Reason:    int32(ocsp.KeyCompromise),
 		RevokedAt: status.RevokedDate,
@@ -1895,7 +1895,7 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 		Date:     thisUpdate,
 		Backdate: status.RevokedDate,
 		Response: ocspResponse.Response,
-		IssuerID: int64(issuerID),
+		IssuerID: issuerID,
 	})
 	if err != nil {
 		return err
@@ -2311,7 +2311,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 		}
 	}
 
-	err = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+	err = ra.purgeOCSPCache(ctx, cert, issuerID)
 	if err != nil {
 		return nil, err
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2244,11 +2244,11 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	var issuerID int64 // TODO(#5152) make this an issuance.IssuerNameID
 	var err error
 	if req.Cert == nil {
-		cert = nil
 		serial, err := core.StringToSerial(req.Serial)
 		if err != nil {
 			return nil, err
 		}
+
 		cert = &x509.Certificate{
 			SerialNumber: serial,
 		}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -802,7 +802,7 @@ func TestPerformValidationSuccess(t *testing.T) {
 	}
 
 	// Verify that the VA got the request, and it's the same as the others
-	test.AssertEquals(t, string(authzPB.Challenges[challIdx].Type), vaRequest.Challenge.Type)
+	test.AssertEquals(t, authzPB.Challenges[challIdx].Type, vaRequest.Challenge.Type)
 	test.AssertEquals(t, authzPB.Challenges[challIdx].Token, vaRequest.Challenge.Token)
 
 	// Sleep so the RA has a chance to write to the SA
@@ -853,7 +853,7 @@ func TestPerformValidationVAError(t *testing.T) {
 	}
 
 	// Verify that the VA got the request, and it's the same as the others
-	test.AssertEquals(t, string(authzPB.Challenges[challIdx].Type), vaRequest.Challenge.Type)
+	test.AssertEquals(t, authzPB.Challenges[challIdx].Type, vaRequest.Challenge.Type)
 	test.AssertEquals(t, authzPB.Challenges[challIdx].Token, vaRequest.Challenge.Token)
 
 	// Sleep so the RA has a chance to write to the SA

--- a/rocsp/rocsp_test.go
+++ b/rocsp/rocsp_test.go
@@ -45,7 +45,7 @@ func TestSetAndGet(t *testing.T) {
 		t.Fatal(err)
 	}
 	var shortIssuerID byte = 99
-	err = client.StoreResponse(context.Background(), response, byte(shortIssuerID))
+	err = client.StoreResponse(context.Background(), response, shortIssuerID)
 	if err != nil {
 		t.Fatalf("storing response: %s", err)
 	}

--- a/sa/type-converter_test.go
+++ b/sa/type-converter_test.go
@@ -48,7 +48,7 @@ func TestAcmeIdentifierBadJSON(t *testing.T) {
 	test.AssertError(t, err, "expected error from scanner.Binder")
 	var badJSONErr errBadJSON
 	test.AssertErrorWraps(t, err, &badJSONErr)
-	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
+	test.AssertEquals(t, string(badJSONErr.json), badJSON)
 }
 
 func TestJSONWebKey(t *testing.T) {
@@ -85,7 +85,7 @@ func TestJSONWebKeyBadJSON(t *testing.T) {
 	test.AssertError(t, err, "expected error from scanner.Binder")
 	var badJSONErr errBadJSON
 	test.AssertErrorWraps(t, err, &badJSONErr)
-	test.AssertEquals(t, string(badJSONErr.json), string(badJSON))
+	test.AssertEquals(t, string(badJSONErr.json), badJSON)
 }
 
 func TestAcmeStatus(t *testing.T) {

--- a/va/http.go
+++ b/va/http.go
@@ -280,7 +280,7 @@ func (va *ValidationAuthorityImpl) extractRequestTarget(req *http.Request) (stri
 	// one we need to make sure its a valid port. If there isn't one we need to
 	// pick the port based on the reqScheme default port.
 	reqHost := req.URL.Host
-	reqPort := 0
+	var reqPort int
 	if h, p, err := net.SplitHostPort(reqHost); err == nil {
 		reqHost = h
 		reqPort, err = strconv.Atoi(p)

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -1103,7 +1103,7 @@ func TestFetchHTTPInvalidUTF8(t *testing.T) {
 	// before the error is marshalled for grpc. This tests that the
 	// invalid string "f\xffoo" is expected to be converted to
 	// "f\ufffdoo".
-	test.AssertContains(t, string(prob.Detail), expectedResult)
+	test.AssertContains(t, prob.Detail, expectedResult)
 }
 
 // All paths that get assigned to tokens MUST be valid tokens

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -507,7 +507,7 @@ func TestMultiVA(t *testing.T) {
 			} else if res.Problems != nil {
 				// That result should match expected.
 				test.AssertEquals(t, res.Problems.ProblemType, string(tc.ExpectedProb.Type))
-				test.AssertEquals(t, res.Problems.Detail, string(tc.ExpectedProb.Detail))
+				test.AssertEquals(t, res.Problems.Detail, tc.ExpectedProb.Detail)
 			}
 
 			if tc.ExpectedLog != "" {

--- a/web/probs_test.go
+++ b/web/probs_test.go
@@ -43,7 +43,7 @@ func TestProblemDetailsFromError(t *testing.T) {
 		if p.HTTPStatus != c.statusCode {
 			t.Errorf("Incorrect status code for %s. Expected %d, got %d", reflect.TypeOf(c.err).Name(), c.statusCode, p.HTTPStatus)
 		}
-		if probs.ProblemType(p.Type) != c.problem {
+		if p.Type != c.problem {
 			t.Errorf("Expected problem urn %#v, got %#v", c.problem, p.Type)
 		}
 		if p.Detail != c.detail {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -821,7 +821,7 @@ func (wfe *WebFrontEndImpl) parseRevocation(
 	reason := revocation.Reason(0)
 	if revokeRequest.Reason != nil {
 		if _, present := revocation.UserAllowedReasons[*revokeRequest.Reason]; !present {
-			reasonStr, ok := revocation.ReasonToString[revocation.Reason(*revokeRequest.Reason)]
+			reasonStr, ok := revocation.ReasonToString[*revokeRequest.Reason]
 			if !ok {
 				reasonStr = "unknown"
 			}
@@ -1504,7 +1504,7 @@ func (wfe *WebFrontEndImpl) Authorization(
 		logEvent.DNSName = authzPB.Identifier
 		beeline.AddFieldToTrace(ctx, "authz.dnsname", authzPB.Identifier)
 	}
-	logEvent.Status = string(authzPB.Status)
+	logEvent.Status = authzPB.Status
 	beeline.AddFieldToTrace(ctx, "authz.status", authzPB.Status)
 
 	// After expiring, authorizations are inaccessible
@@ -2309,7 +2309,7 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 	// This is a very simple renewal calculation: Calculate a point 2/3rds of the
 	// way through the validity period, then give a 2-day window around that.
 	validity := time.Unix(0, cert.Expires).Add(time.Second).Sub(time.Unix(0, cert.Issued))
-	renewalOffset := time.Duration(int64(0.33 * float64(validity.Seconds())))
+	renewalOffset := time.Duration(int64(0.33 * validity.Seconds()))
 	idealRenewal := time.Unix(0, cert.Expires).UTC().Add(-renewalOffset)
 	ri := core.RenewalInfo{
 		SuggestedWindow: core.SuggestedWindow{
@@ -2341,5 +2341,5 @@ func extractRequesterIP(req *http.Request) (net.IP, error) {
 }
 
 func urlForAuthz(authz core.Authorization, request *http.Request) string {
-	return web.RelativeEndpoint(request, authzPath+string(authz.ID))
+	return web.RelativeEndpoint(request, authzPath+authz.ID)
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -165,12 +165,6 @@ ycBzDV9u6cX9qNLc9Bn5DAumz7Zp2AuA+Q==
 -----END EC PRIVATE KEY-----
 `
 
-	testE2KeyPublicJSON = `{
-    "kty":"EC",
-    "crv":"P-256",
-    "x":"S8FOmrZ3ywj4yyFqt0etAD90U-EnkNaOBSLfQmf7pNg",
-    "y":"vMvpDyqFDRHjGfZ1siDOm5LS6xNdR5xTpyoQGLDOX2Q"
-  }`
 	testE2KeyPrivatePEM = `
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIFRcPxQ989AY6se2RyIoF1ll9O6gHev4oY15SWJ+Jf5eoAoGCCqGSM49


### PR DESCRIPTION
These new linters are almost all part of golangci-lint's collection
of default linters, that would all be running if we weren't setting
`disable-all: true`. By adding them, we now have parity with the
default configuration, as well as the additional linters we like.