### PR TITLE
rocsp/config: fix PoolSize comment

### DIFF
--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -55,6 +55,8 @@ type RedisConfig struct {
 	// Maximum number of socket connections.
 	// Default is 5 connections per every CPU as reported by runtime.NumCPU.
 	// If this is set to an explicit value, that's not multiplied by NumCPU.
+	// PoolSize applies per cluster node and not for the whole cluster.
+	// https://pkg.go.dev/github.com/go-redis/redis#ClusterOptions
 	PoolSize int
 	// Minimum number of idle connections which is useful when establishing
 	// new connection is slow.

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -53,7 +53,8 @@ type RedisConfig struct {
 	WriteTimeout cmd.ConfigDuration
 
 	// Maximum number of socket connections.
-	// Default is 10 connections per every CPU as reported by runtime.NumCPU.
+	// Default is 5 connections per every CPU as reported by runtime.NumCPU.
+	// If this is set to an explicit value, that's not multiplied by NumCPU.
 	PoolSize int
 	// Minimum number of idle connections which is useful when establishing
 	// new connection is slow.

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -11,6 +11,7 @@
         "10.33.33.7:4218"
       ],
       "timeout": "5s",
+      "poolSize": 100,
       "tls": {
         "caCertFile": "test/redis-tls/minica.pem",
         "certFile": "test/redis-tls/boulder/cert.pem",


### PR DESCRIPTION
The go-redis docs say default is 10 * NumCPU, but the actual code says 5.