### PR TITLE
rocsp: add "connection_pool" to metric names

### DIFF
--- a/rocsp/metrics.go
+++ b/rocsp/metrics.go
@@ -46,3 +46,32 @@ func (dbc metricsCollector) Collect(ch chan<- prometheus.Metric) {
 	writeGauge(dbc.idleConns, float64(stats.IdleConns))
 	writeGauge(dbc.staleConns, float64(stats.StaleConns))
 }
+
+func newMetricsCollector(labels prometheus.Labels) metricsCollector {
+	return metricsCollector{
+		hits: prometheus.NewDesc(
+			"redis_connection_pool_hits",
+			"Number of times free connection was found in the pool.",
+			nil, labels),
+		misses: prometheus.NewDesc(
+			"redis_redis_connection_pool_misses",
+			"Number of times free connection was NOT found in the pool.",
+			nil, labels),
+		timeouts: prometheus.NewDesc(
+			"redis_connection_pool_timeouts",
+			"Number of times a wait timeout occurred.",
+			nil, labels),
+		totalConns: prometheus.NewDesc(
+			"redis_connection_pool_total_conns",
+			"Number of total connections in the pool.",
+			nil, labels),
+		idleConns: prometheus.NewDesc(
+			"redis_connection_pool_idle_conns",
+			"Number of idle connections in the pool.",
+			nil, labels),
+		staleConns: prometheus.NewDesc(
+			"redis_connection_pool_stale_conns",
+			"Number of stale connections removed from the pool.",
+			nil, labels),
+	}
+}

--- a/rocsp/metrics.go
+++ b/rocsp/metrics.go
@@ -5,14 +5,19 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// An interface satisfied by *redis.ClusterClient and also by a mock in our tests.
+type poolStatGetter interface {
+	PoolStats() *redis.PoolStats
+}
+
+var _ poolStatGetter = (*redis.ClusterClient)(nil)
+
 type metricsCollector struct {
-	rdb *redis.ClusterClient
+	statGetter poolStatGetter
 
 	// Stats accessible from the go-redis connector:
 	// https://pkg.go.dev/github.com/go-redis/redis@v6.15.9+incompatible/internal/pool#Stats
-	hits       *prometheus.Desc
-	misses     *prometheus.Desc
-	timeouts   *prometheus.Desc
+	lookups    *prometheus.Desc
 	totalConns *prometheus.Desc
 	idleConns  *prometheus.Desc
 	staleConns *prometheus.Desc
@@ -31,36 +36,26 @@ func (dbc metricsCollector) Describe(ch chan<- *prometheus.Desc) {
 // Note that Collect could be called concurrently, so we depend on PoolStats()
 // to be concurrency-safe.
 func (dbc metricsCollector) Collect(ch chan<- prometheus.Metric) {
-	writeStat := func(stat *prometheus.Desc, typ prometheus.ValueType, val float64) {
-		ch <- prometheus.MustNewConstMetric(stat, typ, val)
-	}
-	writeGauge := func(stat *prometheus.Desc, val float64) {
-		writeStat(stat, prometheus.GaugeValue, val)
+	writeGauge := func(stat *prometheus.Desc, val uint32, labelValues ...string) {
+		ch <- prometheus.MustNewConstMetric(stat, prometheus.GaugeValue, float64(val), labelValues...)
 	}
 
-	stats := dbc.rdb.PoolStats()
-	writeGauge(dbc.hits, float64(stats.Hits))
-	writeGauge(dbc.misses, float64(stats.Misses))
-	writeGauge(dbc.timeouts, float64(stats.Timeouts))
-	writeGauge(dbc.totalConns, float64(stats.TotalConns))
-	writeGauge(dbc.idleConns, float64(stats.IdleConns))
-	writeGauge(dbc.staleConns, float64(stats.StaleConns))
+	stats := dbc.statGetter.PoolStats()
+	writeGauge(dbc.lookups, stats.Hits, "hit")
+	writeGauge(dbc.lookups, stats.Misses, "miss")
+	writeGauge(dbc.lookups, stats.Timeouts, "timeout")
+	writeGauge(dbc.totalConns, stats.TotalConns)
+	writeGauge(dbc.idleConns, stats.IdleConns)
+	writeGauge(dbc.staleConns, stats.StaleConns)
 }
 
-func newMetricsCollector(labels prometheus.Labels) metricsCollector {
+func newMetricsCollector(statGetter poolStatGetter, labels prometheus.Labels) metricsCollector {
 	return metricsCollector{
-		hits: prometheus.NewDesc(
-			"redis_connection_pool_hits",
-			"Number of times free connection was found in the pool.",
-			nil, labels),
-		misses: prometheus.NewDesc(
-			"redis_redis_connection_pool_misses",
-			"Number of times free connection was NOT found in the pool.",
-			nil, labels),
-		timeouts: prometheus.NewDesc(
-			"redis_connection_pool_timeouts",
-			"Number of times a wait timeout occurred.",
-			nil, labels),
+		statGetter: statGetter,
+		lookups: prometheus.NewDesc(
+			"redis_connection_pool_lookups",
+			"Number of lookups for a connection in the pool, labeled by hit/miss",
+			[]string{"result"}, labels),
 		totalConns: prometheus.NewDesc(
 			"redis_connection_pool_total_conns",
 			"Number of total connections in the pool.",

--- a/rocsp/metrics_test.go
+++ b/rocsp/metrics_test.go
@@ -1,0 +1,64 @@
+package rocsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type mockPoolStatGetter struct{}
+
+var _ poolStatGetter = mockPoolStatGetter{}
+
+func (mockPoolStatGetter) PoolStats() *redis.PoolStats {
+	return &redis.PoolStats{
+		Hits:       13,
+		Misses:     7,
+		Timeouts:   4,
+		TotalConns: 1000,
+		IdleConns:  500,
+		StaleConns: 10,
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	mets := newMetricsCollector(mockPoolStatGetter{},
+		prometheus.Labels{
+			"foo": "bar",
+		})
+	// Check that it has the correct type to satisfy MustRegister
+	metrics.NoopRegisterer.MustRegister(mets)
+
+	expectedMetrics := 6
+	outChan := make(chan prometheus.Metric, expectedMetrics)
+	mets.Collect(outChan)
+
+	results := make(map[string]bool)
+	for i := 0; i < expectedMetrics; i++ {
+		metric := <-outChan
+		results[metric.Desc().String()] = true
+	}
+
+	expected := strings.Split(
+		`Desc{fqName: "redis_connection_pool_lookups", help: "Number of lookups for a connection in the pool, labeled by hit/miss", constLabels: {foo="bar"}, variableLabels: [result]}
+Desc{fqName: "redis_connection_pool_lookups", help: "Number of lookups for a connection in the pool, labeled by hit/miss", constLabels: {foo="bar"}, variableLabels: [result]}
+Desc{fqName: "redis_connection_pool_lookups", help: "Number of lookups for a connection in the pool, labeled by hit/miss", constLabels: {foo="bar"}, variableLabels: [result]}
+Desc{fqName: "redis_connection_pool_total_conns", help: "Number of total connections in the pool.", constLabels: {foo="bar"}, variableLabels: []}
+Desc{fqName: "redis_connection_pool_idle_conns", help: "Number of idle connections in the pool.", constLabels: {foo="bar"}, variableLabels: []}
+Desc{fqName: "redis_connection_pool_stale_conns", help: "Number of stale connections removed from the pool.", constLabels: {foo="bar"}, variableLabels: []}`,
+		"\n")
+
+	for _, e := range expected {
+		if !results[e] {
+			t.Errorf("expected metrics to contain %q, but they didn't", e)
+		}
+	}
+
+	if len(results) > len(expected) {
+		t.Errorf("expected metrics to contain %d entries, but they contained %d",
+			len(expected), len(results))
+	}
+}

--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -108,31 +108,7 @@ func NewClient(
 		"addresses": strings.Join(rdb.Options().Addrs, ", "),
 		"user":      rdb.Options().Username,
 	}
-	dbc.hits = prometheus.NewDesc(
-		"redis_hits",
-		"Number of times free connection was found in the pool.",
-		nil, labels)
-	dbc.misses = prometheus.NewDesc(
-		"redis_misses",
-		"Number of times free connection was NOT found in the pool.",
-		nil, labels)
-	dbc.timeouts = prometheus.NewDesc(
-		"redis_timeouts",
-		"Number of times a wait timeout occurred.",
-		nil, labels)
-	dbc.totalConns = prometheus.NewDesc(
-		"redis_total_conns",
-		"Number of total connections in the pool.",
-		nil, labels)
-	dbc.idleConns = prometheus.NewDesc(
-		"redis_idle_conns",
-		"Number of idle connections in the pool.",
-		nil, labels)
-	dbc.staleConns = prometheus.NewDesc(
-		"redis_stale_conns",
-		"Number of stale connections removed from the pool.",
-		nil, labels)
-	stats.MustRegister(dbc)
+	stats.MustRegister(newMetricsCollector(labels))
 	getLatency := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "rocsp_get_latency",

--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -86,7 +86,6 @@ type Client struct {
 	rdb        *redis.ClusterClient
 	timeout    time.Duration
 	clk        clock.Clock
-	rdc        metricsCollector
 	getLatency *prometheus.HistogramVec
 }
 
@@ -99,8 +98,6 @@ func NewClient(
 	clk clock.Clock,
 	stats prometheus.Registerer,
 ) *Client {
-	dbc := metricsCollector{rdb: rdb}
-
 	if len(rdb.Options().Addrs) == 0 {
 		return nil
 	}
@@ -108,7 +105,7 @@ func NewClient(
 		"addresses": strings.Join(rdb.Options().Addrs, ", "),
 		"user":      rdb.Options().Username,
 	}
-	stats.MustRegister(newMetricsCollector(labels))
+	stats.MustRegister(newMetricsCollector(rdb, labels))
 	getLatency := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "rocsp_get_latency",
@@ -122,7 +119,6 @@ func NewClient(
 		rdb:        rdb,
 		timeout:    timeout,
 		clk:        clk,
-		rdc:        dbc,
 		getLatency: getLatency,
 	}
 }


### PR DESCRIPTION
Most of our existing Redis metrics are related to the connection pool, but some sound like they could be request-oriented (like redis_hits and redis_misses). Fix that with better naming. Also, join three related metrics (hits, misses, and timeouts) under a single metric name with labels so they more easily by grouped and counted.

Move the stat creation into rocsp/metrics.go so the names are in the same file as the collector.

Add a unittest for rocsp metrics.