### PR TITLE
Reduce redundant audit logging of CSR

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -311,18 +311,27 @@ func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 	if err != nil {
 		return nil, err
 	}
+
+	ca.log.AuditInfof("Signing cert: serial=[%s] regID=[%d] names=[%s] precert=[%s]",
+		serialHex, req.RegistrationID, strings.Join(issuanceReq.DNSNames, ", "), hex.EncodeToString(precert.Raw))
+
 	certDER, err := issuer.Issue(issuanceReq)
 	if err != nil {
-		return nil, err
+		ca.noteSignError(err)
+		ca.log.AuditErrf("Signing cert failed: serial=[%s] regID=[%d] names=[%s] err=[%v]",
+			serialHex, req.RegistrationID, strings.Join(precert.DNSNames, ", "), err)
+		return nil, berrors.InternalServerError("failed to sign precertificate: %s", err)
 	}
+
 	ca.signatureCount.With(prometheus.Labels{"purpose": string(certType), "issuer": issuer.Name()}).Inc()
-	ca.log.AuditInfof("Signing success: serial=[%s] regID=[%d] names=[%s] csr=[%s] certificate=[%s]",
-		serialHex, req.RegistrationID, strings.Join(precert.DNSNames, ", "), hex.EncodeToString(req.DER),
-		hex.EncodeToString(certDER))
+	ca.log.AuditInfof("Signing cert success: serial=[%s] regID=[%d] names=[%s] certificate=[%s]",
+		serialHex, req.RegistrationID, strings.Join(precert.DNSNames, ", "), hex.EncodeToString(certDER))
+
 	err = ca.storeCertificate(ctx, req.RegistrationID, req.OrderID, precert.SerialNumber, certDER, int64(issuer.Cert.NameID()))
 	if err != nil {
 		return nil, err
 	}
+
 	return &corepb.Certificate{
 		RegistrationID: req.RegistrationID,
 		Serial:         core.SerialToString(precert.SerialNumber),
@@ -416,8 +425,9 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		return nil, nil, nil, err
 	}
 
-	ca.log.AuditInfof("Signing: serial=[%s] regID=[%d] names=[%s] csr=[%s]",
+	ca.log.AuditInfof("Signing precert: serial=[%s] regID=[%d] names=[%s] csr=[%s]",
 		serialHex, issueReq.RegistrationID, strings.Join(csr.DNSNames, ", "), hex.EncodeToString(csr.Raw))
+
 	certDER, err := issuer.Issue(&issuance.IssuanceRequest{
 		PublicKey:         csr.PublicKey,
 		Serial:            serialBigInt.Bytes(),
@@ -428,17 +438,16 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		NotBefore:         validity.NotBefore,
 		NotAfter:          validity.NotAfter,
 	})
-	ca.noteSignError(err)
 	if err != nil {
-		err = berrors.InternalServerError("failed to sign certificate: %s", err)
-		ca.log.AuditErrf("Signing failed: serial=[%s] err=[%v]", serialHex, err)
-		return nil, nil, nil, err
+		ca.noteSignError(err)
+		ca.log.AuditErrf("Signing precert failed: serial=[%s] regID=[%d] names=[%s] err=[%v]",
+			serialHex, issueReq.RegistrationID, strings.Join(csr.DNSNames, ", "), err)
+		return nil, nil, nil, berrors.InternalServerError("failed to sign precertificate: %s", err)
 	}
-	ca.signatureCount.With(prometheus.Labels{"purpose": string(precertType), "issuer": issuer.Name()}).Inc()
 
-	ca.log.AuditInfof("Signing success: serial=[%s] regID=[%d] names=[%s] csr=[%s] precertificate=[%s]",
-		serialHex, issueReq.RegistrationID, strings.Join(csr.DNSNames, ", "), hex.EncodeToString(csr.Raw),
-		hex.EncodeToString(certDER))
+	ca.signatureCount.With(prometheus.Labels{"purpose": string(precertType), "issuer": issuer.Name()}).Inc()
+	ca.log.AuditInfof("Signing precert success: serial=[%s] regID=[%d] names=[%s] precertificate=[%s]",
+		serialHex, issueReq.RegistrationID, strings.Join(csr.DNSNames, ", "), hex.EncodeToString(certDER))
 
 	return certDER, ocspResp, issuer, nil
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -3,7 +3,6 @@ package wfe2
 import (
 	"context"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -987,19 +986,6 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(
 	response.WriteHeader(http.StatusOK)
 }
 
-func (wfe *WebFrontEndImpl) logCsr(request *http.Request, cr core.CertificateRequest, account core.Registration) {
-	var csrLog = struct {
-		ClientAddr string
-		CSR        string
-		Requester  int64
-	}{
-		ClientAddr: web.GetClientAddr(request),
-		CSR:        hex.EncodeToString(cr.Bytes),
-		Requester:  account.ID,
-	}
-	wfe.log.AuditObject("Certificate request", csrLog)
-}
-
 // Challenge handles POST requests to challenge URLs.
 // Such requests are clients' responses to the server's challenges.
 func (wfe *WebFrontEndImpl) Challenge(
@@ -1964,7 +1950,8 @@ func (wfe *WebFrontEndImpl) orderToOrderJSON(request *http.Request, order *corep
 	return respObj
 }
 
-// NewOrder is used by clients to create a new order object from a CSR
+// NewOrder is used by clients to create a new order object and a set of
+// authorizations to fulfill for issuance.
 func (wfe *WebFrontEndImpl) NewOrder(
 	ctx context.Context,
 	logEvent *web.RequestEvent,
@@ -2228,18 +2215,14 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 		return
 	}
 
-	certificateRequest := core.CertificateRequest{Bytes: rawCSR.CSR}
-	certificateRequest.CSR = csr
-	wfe.logCsr(request, certificateRequest, *acct)
-
-	logEvent.Extra["CSRDNSNames"] = certificateRequest.CSR.DNSNames
-	beeline.AddFieldToTrace(ctx, "csr.dnsnames", certificateRequest.CSR.DNSNames)
-	logEvent.Extra["CSREmailAddresses"] = certificateRequest.CSR.EmailAddresses
-	beeline.AddFieldToTrace(ctx, "csr.email_addrs", certificateRequest.CSR.EmailAddresses)
-	logEvent.Extra["CSRIPAddresses"] = certificateRequest.CSR.IPAddresses
-	beeline.AddFieldToTrace(ctx, "csr.ip_addrs", certificateRequest.CSR.IPAddresses)
-	logEvent.Extra["KeyType"] = web.KeyTypeToString(certificateRequest.CSR.PublicKey)
-	beeline.AddFieldToTrace(ctx, "csr.key_type", web.KeyTypeToString(certificateRequest.CSR.PublicKey))
+	logEvent.Extra["CSRDNSNames"] = csr.DNSNames
+	beeline.AddFieldToTrace(ctx, "csr.dnsnames", csr.DNSNames)
+	logEvent.Extra["CSREmailAddresses"] = csr.EmailAddresses
+	beeline.AddFieldToTrace(ctx, "csr.email_addrs", csr.EmailAddresses)
+	logEvent.Extra["CSRIPAddresses"] = csr.IPAddresses
+	beeline.AddFieldToTrace(ctx, "csr.ip_addrs", csr.IPAddresses)
+	logEvent.Extra["KeyType"] = web.KeyTypeToString(csr.PublicKey)
+	beeline.AddFieldToTrace(ctx, "csr.key_type", web.KeyTypeToString(csr.PublicKey))
 
 	updatedOrder, err := wfe.ra.FinalizeOrder(ctx, &rapb.FinalizeOrderRequest{
 		Csr:   rawCSR.CSR,
@@ -2255,7 +2238,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	}
 
 	// Inc CSR signature algorithm counter
-	wfe.stats.csrSignatureAlgs.With(prometheus.Labels{"type": certificateRequest.CSR.SignatureAlgorithm.String()}).Inc()
+	wfe.stats.csrSignatureAlgs.With(prometheus.Labels{"type": csr.SignatureAlgorithm.String()}).Inc()
 
 	orderURL := web.RelativeEndpoint(request,
 		fmt.Sprintf("%s%d/%d", orderPath, acct.ID, updatedOrder.Id))


### PR DESCRIPTION
Stop logging the full CSR bytes at the WFE; we log these bytes in the
CA immediately before attempting to sign a precertificate anyway.

Also unify the way we log precertificate and final certificate signing
events in the CA: an Info containing the request prior to signing, and
then either an Info or an Error containing the result afterwards.

Fixes #6088