### PR TITLE
expiration-mailer: feature-gate bug fix

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -68,6 +68,12 @@ type mailerStats struct {
 }
 
 func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
+	// TODO(#6121): Remove this
+	if !features.Enabled(features.ExpirationMailerDontLookTwice) {
+		if len(contacts) == 0 {
+			return nil
+		}
+	}
 	if len(certs) == 0 {
 		return errors.New("no certs given to send nags for")
 	}
@@ -254,6 +260,13 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 		if len(parsedCerts) == 0 {
 			// all certificates are renewed
 			continue
+		}
+
+		// TODO(#6121): Remove this
+		if !features.Enabled(features.ExpirationMailerDontLookTwice) {
+			if reg.Contact == nil {
+				continue
+			}
 		}
 
 		err = m.sendNags(reg.Contact, parsedCerts)

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -264,7 +264,7 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 
 		// TODO(#6121): Remove this
 		if !features.Enabled(features.ExpirationMailerDontLookTwice) {
-			if reg.Contact == nil {
+			if len(reg.Contact) == 0 {
 				continue
 			}
 		}

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -19,6 +19,7 @@ import (
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/db"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/mocks"
@@ -200,6 +201,10 @@ func TestProcessCerts(t *testing.T) {
 // that certificate repeatedly; we should mark it as if it had an email sent already.
 func TestNoContactCertIsNotRenewed(t *testing.T) {
 	testCtx := setup(t, []time.Duration{time.Hour * 24 * 7})
+
+	_ = features.Set(map[string]bool{
+		features.ExpirationMailerDontLookTwice.String(): true,
+	})
 
 	reg, err := makeRegistration(testCtx.ssa, 1, jsonKeyA, nil)
 	test.AssertNotError(t, err, "Couldn't store regA")

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -35,11 +35,12 @@ func _() {
 	_ = x[OldTLSInbound-24]
 	_ = x[SHA1CSRs-25]
 	_ = x[AllowUnrecognizedFeatures-26]
+	_ = x[ExpirationMailerDontLookTwice-27]
 }
 
-const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsV1DisableNewValidationsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndexCheckFailedAuthorizationsFirstAllowReRevocationMozRevocationReasonsOldTLSOutboundOldTLSInboundSHA1CSRsAllowUnrecognizedFeatures"
+const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsV1DisableNewValidationsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndexCheckFailedAuthorizationsFirstAllowReRevocationMozRevocationReasonsOldTLSOutboundOldTLSInboundSHA1CSRsAllowUnrecognizedFeaturesExpirationMailerDontLookTwice"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 128, 148, 161, 175, 193, 211, 230, 246, 265, 289, 300, 316, 332, 348, 378, 395, 415, 429, 442, 450, 475}
+var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 128, 148, 161, 175, 193, 211, 230, 246, 265, 289, 300, 316, 332, 348, 378, 395, 415, 429, 442, 450, 475, 504}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -92,6 +92,11 @@ const (
 	// AllowUnrecognizedFeatures is internal to the features package: if true,
 	// skip error when unrecognized feature flag names are passed.
 	AllowUnrecognizedFeatures
+
+	// ExpirationMailerDontLookTwice enables a bug fix in expiration-mailer
+	// speeds up expiration-mailer processing by ensuring processed items
+	// get marked done.
+	ExpirationMailerDontLookTwice
 )
 
 // List of features and their default value, protected by fMu
@@ -123,6 +128,7 @@ var features = map[FeatureFlag]bool{
 	OldTLSInbound:                  true,
 	SHA1CSRs:                       true,
 	AllowUnrecognizedFeatures:      false,
+	ExpirationMailerDontLookTwice:  false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -23,7 +23,10 @@
       "timeout": "15s"
     },
     "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-    "frequency": "1h"
+    "frequency": "1h",
+    "features": {
+      "expirationMailerDontLookTwice": true
+    }
   },
 
   "syslog": {

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -25,7 +25,7 @@
     "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
     "frequency": "1h",
     "features": {
-      "expirationMailerDontLookTwice": true
+      "ExpirationMailerDontLookTwice": true
     }
   },
 


### PR DESCRIPTION
We [recently landed a fix](https://github.com/letsencrypt/boulder/pull/6100/) so the expiration-mailer won't look twice at
the same certificate. This will cause an immediate behavior change when
it is deployed, and that might have surprising effects. Put the fix
behind a feature flag so we can control when it rolls out more
carefully.