### PR TITLE
Cleanup deprecated

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -9,37 +9,24 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[unused-0]
-	_ = x[PrecertificateRevocation-1]
-	_ = x[StripDefaultSchemePort-2]
-	_ = x[NonCFSSLSigner-3]
-	_ = x[StoreIssuerInfo-4]
-	_ = x[StreamlineOrderAndAuthzs-5]
-	_ = x[V1DisableNewValidations-6]
-	_ = x[CAAValidationMethods-7]
-	_ = x[CAAAccountURI-8]
-	_ = x[EnforceMultiVA-9]
-	_ = x[MultiVAFullResults-10]
-	_ = x[MandatoryPOSTAsGET-11]
-	_ = x[AllowV1Registration-12]
-	_ = x[StoreRevokerInfo-13]
-	_ = x[RestrictRSAKeySizes-14]
-	_ = x[FasterNewOrdersRateLimit-15]
-	_ = x[ECDSAForAll-16]
-	_ = x[ServeRenewalInfo-17]
-	_ = x[GetAuthzReadOnly-18]
-	_ = x[GetAuthzUseIndex-19]
-	_ = x[CheckFailedAuthorizationsFirst-20]
-	_ = x[AllowReRevocation-21]
-	_ = x[MozRevocationReasons-22]
-	_ = x[OldTLSOutbound-23]
-	_ = x[OldTLSInbound-24]
-	_ = x[SHA1CSRs-25]
-	_ = x[AllowUnrecognizedFeatures-26]
+	_ = x[CAAValidationMethods-1]
+	_ = x[CAAAccountURI-2]
+	_ = x[EnforceMultiVA-3]
+	_ = x[MultiVAFullResults-4]
+	_ = x[MandatoryPOSTAsGET-5]
+	_ = x[ECDSAForAll-6]
+	_ = x[ServeRenewalInfo-7]
+	_ = x[AllowReRevocation-8]
+	_ = x[MozRevocationReasons-9]
+	_ = x[OldTLSOutbound-10]
+	_ = x[OldTLSInbound-11]
+	_ = x[SHA1CSRs-12]
+	_ = x[AllowUnrecognizedFeatures-13]
 }
 
-const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsV1DisableNewValidationsCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndexCheckFailedAuthorizationsFirstAllowReRevocationMozRevocationReasonsOldTLSOutboundOldTLSInboundSHA1CSRsAllowUnrecognizedFeatures"
+const _FeatureFlag_name = "unusedCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETECDSAForAllServeRenewalInfoAllowReRevocationMozRevocationReasonsOldTLSOutboundOldTLSInboundSHA1CSRsAllowUnrecognizedFeatures"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 128, 148, 161, 175, 193, 211, 230, 246, 265, 289, 300, 316, 332, 348, 378, 395, 415, 429, 442, 450, 475}
+var _FeatureFlag_index = [...]uint8{0, 6, 26, 39, 53, 71, 89, 100, 116, 133, 153, 167, 180, 188, 213}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -12,13 +12,6 @@ type FeatureFlag int
 
 const (
 	unused FeatureFlag = iota // unused is used for testing
-	//   Deprecated features, these can be removed once stripped from production configs
-	PrecertificateRevocation
-	StripDefaultSchemePort
-	NonCFSSLSigner
-	StoreIssuerInfo
-	StreamlineOrderAndAuthzs
-	V1DisableNewValidations
 
 	//   Currently in-use features
 	// Check CAA and respect validationmethods parameter.
@@ -34,32 +27,12 @@ const (
 	// MandatoryPOSTAsGET forbids legacy unauthenticated GET requests for ACME
 	// resources.
 	MandatoryPOSTAsGET
-	// Allow creation of new registrations in ACMEv1.
-	AllowV1Registration
-	// StoreRevokerInfo enables storage of the revoker and a bool indicating if the row
-	// was checked for extant unrevoked certificates in the blockedKeys table.
-	StoreRevokerInfo
-	// RestrictRSAKeySizes enables restriction of acceptable RSA public key moduli to
-	// the common sizes (2048, 3072, and 4096 bits).
-	RestrictRSAKeySizes
-	// FasterNewOrdersRateLimit enables use of a separate table for counting the
-	// new orders rate limit.
-	FasterNewOrdersRateLimit
 	// ECDSAForAll enables all accounts, regardless of their presence in the CA's
 	// ecdsaAllowedAccounts config value, to get issuance from ECDSA issuers.
 	ECDSAForAll
 	// ServeRenewalInfo exposes the renewalInfo endpoint in the directory and for
 	// GET requests. WARNING: This feature is a draft and highly unstable.
 	ServeRenewalInfo
-	// GetAuthzReadOnly causes the SA to use its read-only database connection
-	// (which is generally pointed at a replica rather than the primary db) when
-	// querying the authz2 table.
-	GetAuthzReadOnly
-	// GetAuthzUseIndex causes the SA to use to add a USE INDEX hint when it
-	// queries the authz2 table.
-	GetAuthzUseIndex
-	// Check the failed authorization limit before doing authz reuse.
-	CheckFailedAuthorizationsFirst
 	// AllowReRevocation causes the RA to allow the revocation reason of an
 	// already-revoked certificate to be updated to `keyCompromise` from any
 	// other reason if that compromise is demonstrated by making the second
@@ -96,33 +69,20 @@ const (
 
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
-	unused:                         false,
-	CAAValidationMethods:           false,
-	CAAAccountURI:                  false,
-	EnforceMultiVA:                 false,
-	MultiVAFullResults:             false,
-	MandatoryPOSTAsGET:             false,
-	AllowV1Registration:            true,
-	V1DisableNewValidations:        false,
-	PrecertificateRevocation:       false,
-	StripDefaultSchemePort:         false,
-	StoreIssuerInfo:                false,
-	StoreRevokerInfo:               false,
-	RestrictRSAKeySizes:            false,
-	FasterNewOrdersRateLimit:       false,
-	NonCFSSLSigner:                 false,
-	ECDSAForAll:                    false,
-	StreamlineOrderAndAuthzs:       false,
-	ServeRenewalInfo:               false,
-	GetAuthzReadOnly:               false,
-	GetAuthzUseIndex:               false,
-	CheckFailedAuthorizationsFirst: false,
-	AllowReRevocation:              false,
-	MozRevocationReasons:           false,
-	OldTLSOutbound:                 true,
-	OldTLSInbound:                  true,
-	SHA1CSRs:                       true,
-	AllowUnrecognizedFeatures:      false,
+	unused:                    false,
+	CAAValidationMethods:      false,
+	CAAAccountURI:             false,
+	EnforceMultiVA:            false,
+	MultiVAFullResults:        false,
+	MandatoryPOSTAsGET:        false,
+	ECDSAForAll:               false,
+	ServeRenewalInfo:          false,
+	AllowReRevocation:         false,
+	MozRevocationReasons:      false,
+	OldTLSOutbound:            true,
+	OldTLSInbound:             true,
+	SHA1CSRs:                  true,
+	AllowUnrecognizedFeatures: false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
-	"github.com/letsencrypt/boulder/features"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"google.golang.org/grpc"
 
@@ -294,23 +293,8 @@ func (policy *KeyPolicy) goodKeyRSA(key *rsa.PublicKey) (err error) {
 	// Modulus must be >= 2048 bits and <= 4096 bits
 	modulus := key.N
 	modulusBitLen := modulus.BitLen()
-	if features.Enabled(features.RestrictRSAKeySizes) {
-		if !acceptableRSAKeySizes[modulusBitLen] {
-			return badKey("key size not supported: %d", modulusBitLen)
-		}
-	} else {
-		const maxKeySize = 4096
-		if modulusBitLen < 2048 {
-			return badKey("key too small: %d", modulusBitLen)
-		}
-		if modulusBitLen > maxKeySize {
-			return badKey("key too large: %d > %d", modulusBitLen, maxKeySize)
-		}
-		// Bit lengths that are not a multiple of 8 may cause problems on some
-		// client implementations.
-		if modulusBitLen%8 != 0 {
-			return badKey("key length wasn't a multiple of 8: %d", modulusBitLen)
-		}
+	if !acceptableRSAKeySizes[modulusBitLen] {
+		return badKey("key size not supported: %d", modulusBitLen)
 	}
 
 	// Rather than support arbitrary exponents, which significantly increases

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/letsencrypt/boulder/features"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
 	"google.golang.org/grpc"
@@ -54,7 +53,7 @@ func TestSmallModulus(t *testing.T) {
 	}
 	err := testingPolicy.GoodKey(context.Background(), &pubKey)
 	test.AssertError(t, err, "Should have rejected too-short key")
-	test.AssertEquals(t, err.Error(), "key too small: 2040")
+	test.AssertEquals(t, err.Error(), "key size not supported: 2040")
 }
 
 func TestLargeModulus(t *testing.T) {
@@ -69,7 +68,7 @@ func TestLargeModulus(t *testing.T) {
 	}
 	err := testingPolicy.GoodKey(context.Background(), &pubKey)
 	test.AssertError(t, err, "Should have rejected too-long key")
-	test.AssertEquals(t, err.Error(), "key too large: 4097 > 4096")
+	test.AssertEquals(t, err.Error(), "key size not supported: 4097")
 }
 
 func TestModulusModulo8(t *testing.T) {
@@ -80,7 +79,7 @@ func TestModulusModulo8(t *testing.T) {
 	}
 	err := testingPolicy.GoodKey(context.Background(), &key)
 	test.AssertError(t, err, "Should have rejected modulus with length not divisible by 8")
-	test.AssertEquals(t, err.Error(), "key length wasn't a multiple of 8: 2049")
+	test.AssertEquals(t, err.Error(), "key size not supported: 2049")
 }
 
 var mod2048 = big.NewInt(0).Sub(big.NewInt(0).Lsh(big.NewInt(1), 2048), big.NewInt(1))
@@ -290,12 +289,8 @@ func TestDBBlocklistReject(t *testing.T) {
 }
 
 func TestRSAStrangeSize(t *testing.T) {
-	err := features.Set(map[string]bool{"RestrictRSAKeySizes": true})
-	test.AssertNotError(t, err, "failed to set features")
-	defer features.Reset()
-
 	k := &rsa.PublicKey{N: big.NewInt(10)}
-	err = testingPolicy.GoodKey(context.Background(), k)
+	err := testingPolicy.GoodKey(context.Background(), k)
 	test.AssertError(t, err, "expected GoodKey to fail")
 	test.AssertEquals(t, err.Error(), "key size not supported: 4")
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1800,7 +1800,7 @@ func (ra *RegistrationAuthorityImpl) deprecatedRevokeCertificate(ctx context.Con
 		if comment != "" {
 			req.Comment = comment
 		}
-		if features.Enabled(features.StoreRevokerInfo) && revokedBy != 0 {
+		if revokedBy != 0 {
 			req.RevokedBy = revokedBy
 		}
 		if _, err = ra.SA.AddBlockedKey(ctx, req); err != nil {
@@ -2426,11 +2426,9 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	if err != nil {
 		return nil, err
 	}
-	if features.Enabled(features.CheckFailedAuthorizationsFirst) {
-		err := ra.checkInvalidAuthorizationLimits(ctx, newOrder.RegistrationID, newOrder.Names)
-		if err != nil {
-			return nil, err
-		}
+	err = ra.checkInvalidAuthorizationLimits(ctx, newOrder.RegistrationID, newOrder.Names)
+	if err != nil {
+		return nil, err
 	}
 
 	// An order's lifetime is effectively bound by the shortest remaining lifetime
@@ -2511,12 +2509,6 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		err := ra.checkPendingAuthorizationLimit(ctx, newOrder.RegistrationID)
 		if err != nil {
 			return nil, err
-		}
-		if !features.Enabled(features.CheckFailedAuthorizationsFirst) {
-			err := ra.checkInvalidAuthorizationLimits(ctx, newOrder.RegistrationID, missingAuthzNames)
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2459,11 +2459,7 @@ func TestBlockedKeyRevokedBy(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
-	err := features.Set(map[string]bool{"StoreRevokerInfo": true})
-	test.AssertNotError(t, err, "failed to set features")
-	defer features.Reset()
-
-	_, err = sa.AddBlockedKey(context.Background(), &sapb.AddBlockedKeyRequest{
+	_, err := sa.AddBlockedKey(context.Background(), &sapb.AddBlockedKeyRequest{
 		KeyHash: []byte{1},
 		Added:   1,
 		Source:  "API",


### PR DESCRIPTION
Thanks to the "AllowUnrecognizedFeatures" flag, we don't need to do a two-phase deprecate-then-remove process anymore. All these flags are enabled in prod, so we can delete them outright (and remove them from prod configs separately).