### PR TITLE
Stop testing on go1.17

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,6 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.17.9_2022-04-12
           - go1.18.1_2022-04-12
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/letsencrypt/boulder
 
-go 1.17
+go 1.18
 
 require (
 	github.com/beeker1121/goque v1.0.3-0.20191103205551-d618510128af

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -7,7 +7,7 @@ cd $(dirname $0)
 DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
 
-GO_VERSIONS=( "1.17.9" "1.18.1" )
+GO_VERSIONS=( "1.18.1" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
We are using exclusively go1.18 in our deployment environments.