### PR TITLE
Reland "Allow expiration mailer to work in parallel"

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -194,12 +194,12 @@ var maxSerials = 100
 // sendMessage sends a single email to the provided address with the revoked
 // serials
 func (bkr *badKeyRevoker) sendMessage(addr string, serials []string) error {
-	err := bkr.mailer.Connect()
+	conn, err := bkr.mailer.Connect()
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = bkr.mailer.Close()
+		_ = conn.Close()
 	}()
 	mutSerials := make([]string, len(serials))
 	copy(mutSerials, serials)
@@ -213,7 +213,7 @@ func (bkr *badKeyRevoker) sendMessage(addr string, serials []string) error {
 	if err != nil {
 		return err
 	}
-	err = bkr.mailer.SendMail([]string{addr}, bkr.emailSubject, message.String())
+	err = conn.SendMail([]string{addr}, bkr.emailSubject, message.String())
 	if err != nil {
 		return err
 	}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -52,6 +53,7 @@ type mailer struct {
 	emailTemplate   *template.Template
 	subjectTemplate *template.Template
 	nagTimes        []time.Duration
+	parallelSends   uint
 	limit           int
 	clk             clock.Clock
 	stats           mailerStats
@@ -67,7 +69,7 @@ type mailerStats struct {
 	certificatesPerAccountNeedingMail prometheus.Histogram
 }
 
-func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
+func (m *mailer) sendNags(conn bmail.Conn, contacts []string, certs []*x509.Certificate) error {
 	// TODO(#6121): Remove this
 	if !features.Enabled(features.ExpirationMailerDontLookTwice) {
 		if len(contacts) == 0 {
@@ -165,7 +167,7 @@ func (m *mailer) sendNags(contacts []string, certs []*x509.Certificate) error {
 	m.log.Infof("attempting send JSON=%s", string(logStr))
 
 	startSending := m.clk.Now()
-	err = m.mailer.SendMail(emails, subjBuf.String(), msgBuf.String())
+	err = conn.SendMail(emails, subjBuf.String(), msgBuf.String())
 	if err != nil {
 		m.log.Errf("failed send JSON=%s", string(logStr))
 		return err
@@ -196,6 +198,11 @@ func (m *mailer) certIsRenewed(ctx context.Context, names []string, issued time.
 	return present, err
 }
 
+type work struct {
+	regID int64
+	certs []core.Certificate
+}
+
 func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) error {
 	regIDToCerts := make(map[int64][]core.Certificate)
 
@@ -205,87 +212,114 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 		regIDToCerts[cert.RegistrationID] = cs
 	}
 
-	err := m.mailer.Connect()
-	if err != nil {
-		return fmt.Errorf("connecting to SMTP server: %w", err)
-	}
-	defer func() {
-		_ = m.mailer.Close()
-	}()
+	var wg sync.WaitGroup
+	workChan := make(chan work)
 
-	for regID, certs := range regIDToCerts {
+	parallelSends := m.parallelSends
+	if parallelSends == 0 {
+		parallelSends = 1
+	}
+
+	for senderNum := uint(0); senderNum < parallelSends; senderNum++ {
+		// For politeness' sake, don't open more than 1 new connection per
+		// second.
+		if senderNum > 0 {
+			time.Sleep(time.Second)
+		}
+
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		reg, err := m.rs.GetRegistration(ctx, &sapb.RegistrationID{Id: regID})
+
+		conn, err := m.mailer.Connect()
 		if err != nil {
-			m.log.AuditErrf("Error fetching registration %d: %s", regID, err)
-			m.stats.errorCount.With(prometheus.Labels{"type": "GetRegistration"}).Inc()
-			continue
+			m.log.AuditErrf("connecting parallel sender %d: %s", senderNum, err)
+			close(workChan)
+			return err
 		}
-
-		parsedCerts := []*x509.Certificate{}
-		for _, cert := range certs {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			parsedCert, err := x509.ParseCertificate(cert.DER)
-			if err != nil {
-				// TODO(#1420): tell registration about this error
-				m.log.AuditErrf("Error parsing certificate %s: %s", cert.Serial, err)
-				m.stats.errorCount.With(prometheus.Labels{"type": "ParseCertificate"}).Inc()
-				continue
-			}
-
-			renewed, err := m.certIsRenewed(ctx, parsedCert.DNSNames, parsedCert.NotBefore)
-			if err != nil {
-				m.log.AuditErrf("expiration-mailer: error fetching renewal state: %v", err)
-				// assume not renewed
-			} else if renewed {
-				m.log.Debugf("Cert %s is already renewed", cert.Serial)
-				m.stats.certificatesAlreadyRenewed.Add(1)
-				err := m.updateCertStatus(ctx, cert.Serial)
+		wg.Add(1)
+		go func(conn bmail.Conn, ch <-chan work) {
+			defer wg.Done()
+			for w := range ch {
+				err := m.sendToOneRegID(ctx, conn, w.regID, w.certs)
 				if err != nil {
-					m.log.AuditErrf("Error updating certificate status for %s: %s", cert.Serial, err)
-					m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
+					m.log.AuditErr(err.Error())
 				}
-				continue
 			}
+			conn.Close()
+		}(conn, workChan)
+	}
+	for regID, certs := range regIDToCerts {
+		workChan <- work{regID, certs}
+	}
+	close(workChan)
+	wg.Wait()
+	return nil
+}
 
-			parsedCerts = append(parsedCerts, parsedCert)
-		}
+func (m *mailer) sendToOneRegID(ctx context.Context, conn bmail.Conn, regID int64, certs []core.Certificate) error {
+	reg, err := m.rs.GetRegistration(ctx, &sapb.RegistrationID{Id: regID})
+	if err != nil {
+		m.stats.errorCount.With(prometheus.Labels{"type": "GetRegistration"}).Inc()
+		return fmt.Errorf("fetching registration %d: %w", regID, err)
+	}
 
-		m.stats.certificatesPerAccountNeedingMail.Observe(float64(len(parsedCerts)))
+	if reg.Contact == nil {
+		return nil
+	}
 
-		if len(parsedCerts) == 0 {
-			// all certificates are renewed
-			continue
-		}
-
-		// TODO(#6121): Remove this
-		if !features.Enabled(features.ExpirationMailerDontLookTwice) {
-			if len(reg.Contact) == 0 {
-				continue
-			}
-		}
-
-		err = m.sendNags(reg.Contact, parsedCerts)
+	parsedCerts := []*x509.Certificate{}
+	for _, cert := range certs {
+		parsedCert, err := x509.ParseCertificate(cert.DER)
 		if err != nil {
-			m.stats.errorCount.With(prometheus.Labels{"type": "SendNags"}).Inc()
-			m.log.AuditErrf("Error sending nag emails: %s", err)
+			m.stats.errorCount.With(prometheus.Labels{"type": "ParseCertificate"}).Inc()
+			// TODO(#1420): tell registration about this error
+			return fmt.Errorf("parsing certificate %s: %w", cert.Serial, err)
+		}
+
+		renewed, err := m.certIsRenewed(ctx, parsedCert.DNSNames, parsedCert.NotBefore)
+		if err != nil {
+			return fmt.Errorf("expiration-mailer: error fetching renewal state: %w", err)
+		} else if renewed {
+			m.stats.certificatesAlreadyRenewed.Add(1)
+			err := m.updateCertStatus(ctx, cert.Serial)
+			if err != nil {
+				m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
+				return fmt.Errorf("updating certificate status for %s: %w", cert.Serial, err)
+			}
 			continue
 		}
-		for _, cert := range parsedCerts {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			serial := core.SerialToString(cert.SerialNumber)
-			err = m.updateCertStatus(ctx, serial)
-			if err != nil {
-				m.log.AuditErrf("Error updating certificate status for %s: %s", serial, err)
-				m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
-				continue
-			}
+
+		parsedCerts = append(parsedCerts, parsedCert)
+	}
+
+	if len(parsedCerts) == 0 {
+		// all certificates are renewed
+		return nil
+	}
+
+	// TODO(#6121): Remove this
+	if !features.Enabled(features.ExpirationMailerDontLookTwice) {
+		if len(reg.Contact) == 0 {
+			return nil
+		}
+	}
+
+	err = m.sendNags(conn, reg.Contact, parsedCerts)
+	if err != nil {
+		m.stats.errorCount.With(prometheus.Labels{"type": "SendNags"}).Inc()
+		return fmt.Errorf("sending nag emails: %w", err)
+	}
+	for _, cert := range parsedCerts {
+		serial := core.SerialToString(cert.SerialNumber)
+		err = m.updateCertStatus(ctx, serial)
+		if err != nil {
+			// Don't return immediately; we'd like to at least try and update the status for
+			// all certificates, even if one of them experienced an error (which might have
+			// been intermittent)
+			m.log.AuditErrf("updating certificate status for %s: %s", serial, err)
+			m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()
+			continue
 		}
 	}
 	return nil
@@ -635,6 +669,7 @@ func main() {
 		emailTemplate:   tmpl,
 		nagTimes:        nags,
 		limit:           c.Mailer.CertLimit,
+		parallelSends:   c.Mailer.ParallelSends,
 		clk:             clk,
 		stats:           initStats(scope),
 	}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -221,12 +221,6 @@ func (m *mailer) processCerts(ctx context.Context, allCerts []core.Certificate) 
 	}
 
 	for senderNum := uint(0); senderNum < parallelSends; senderNum++ {
-		// For politeness' sake, don't open more than 1 new connection per
-		// second.
-		if senderNum > 0 {
-			time.Sleep(time.Second)
-		}
-
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -315,7 +315,7 @@ func (m *mailer) sendToOneRegID(ctx context.Context, conn bmail.Conn, regID int6
 	err = m.sendNags(conn, reg.Contact, parsedCerts)
 	if err != nil {
 		m.stats.errorCount.With(prometheus.Labels{"type": "SendNags"}).Inc()
-		return fmt.Errorf("Error sending nag emails: %s", err)
+		return fmt.Errorf("sending nag emails: %s", err)
 	}
 	for _, cert := range parsedCerts {
 		if ctx.Err() != nil {

--- a/cmd/expiration-mailer/send_test.go
+++ b/cmd/expiration-mailer/send_test.go
@@ -33,7 +33,9 @@ func TestSendEarliestCertInfo(t *testing.T) {
 		serial2,
 	)
 
-	err := ctx.m.sendNags([]string{email1, email2}, []*x509.Certificate{rawCertA, rawCertB})
+	conn, err := ctx.m.mailer.Connect()
+	test.AssertNotError(t, err, "connecting SMTP")
+	err = ctx.m.sendNags(conn, []string{email1, email2}, []*x509.Certificate{rawCertA, rawCertB})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -154,12 +154,12 @@ func (m *mailer) run() error {
 	m.log.Infof("Address %q was associated with the most recipients (%d)",
 		mostRecipients, mostRecipientsLen)
 
-	err = m.mailer.Connect()
+	conn, err := m.mailer.Connect()
 	if err != nil {
 		return err
 	}
 
-	defer func() { _ = m.mailer.Close() }()
+	defer func() { _ = conn.Close() }()
 
 	startTime := m.clk.Now()
 	sortedAddresses := sortAddresses(addressToRecipient)
@@ -186,7 +186,7 @@ func (m *mailer) run() error {
 			continue
 		}
 
-		err = m.mailer.SendMail([]string{address}, m.subject, messageBody)
+		err = conn.SendMail([]string{address}, m.subject, messageBody)
 		if err != nil {
 			var badAddrErr bmail.BadAddressSMTPError
 			if errors.As(err, &badAddrErr) {

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -264,7 +264,7 @@ func rstHandler(rstFirst int) connHandler {
 	}
 }
 
-func setup(t *testing.T) (*MailerImpl, *net.TCPListener, func()) {
+func setup(t *testing.T) (*mailerImpl, *net.TCPListener, func()) {
 	fromAddress, _ := mail.ParseAddress("you-are-a-winner@example.com")
 	log := blog.UseMock()
 
@@ -322,11 +322,11 @@ func TestConnect(t *testing.T) {
 	defer cleanUp()
 
 	go listenForever(l, t, normalHandler)
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.Close()
+	err = conn.Close()
 	if err != nil {
 		t.Errorf("Failed to clean up: %s", err)
 	}
@@ -344,11 +344,11 @@ func TestReconnectSuccess(t *testing.T) {
 	// With a mailer client that has a max attempt > `closedConns` we expect no
 	// error. The message should be delivered after `closedConns` reconnect
 	// attempts.
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	if err != nil {
 		t.Errorf("Expected SendMail() to not fail. Got err: %s", err)
 	}
@@ -361,12 +361,12 @@ func TestBadEmailError(t *testing.T) {
 
 	go listenForever(l, t, badEmailHandler(messages))
 
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
 
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	// We expect there to be an error
 	if err == nil {
 		t.Errorf("Expected SendMail() to return an BadAddressSMTPError, got nil")
@@ -393,11 +393,11 @@ func TestReconnectSMTP421(t *testing.T) {
 	// With a mailer client that has a max attempt > `closedConns` we expect no
 	// error. The message should be delivered after `closedConns` reconnect
 	// attempts.
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	if err != nil {
 		t.Errorf("Expected SendMail() to not fail. Got err: %s", err)
 	}
@@ -439,12 +439,12 @@ func TestOtherError(t *testing.T) {
 		_, _ = conn.Write([]byte("250 Ok yr rset now\r\n"))
 	})
 
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
 
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	// We expect there to be an error
 	if err == nil {
 		t.Errorf("Expected SendMail() to return an error, got nil")
@@ -488,12 +488,12 @@ func TestOtherError(t *testing.T) {
 
 		_, _ = conn.Write([]byte("nop\r\n"))
 	})
-	err = m.Connect()
+	conn, err = m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
 
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	// We expect there to be an error
 	test.AssertError(t, err, "SendMail didn't fail as expected")
 	test.AssertEquals(t, err.Error(), "999 1.1.1 This would probably be bad? (also, on sending RSET: short response: nop)")
@@ -511,11 +511,11 @@ func TestReconnectAfterRST(t *testing.T) {
 	// With a mailer client that has a max attempt > `closedConns` we expect no
 	// error. The message should be delivered after `closedConns` reconnect
 	// attempts.
-	err := m.Connect()
+	conn, err := m.Connect()
 	if err != nil {
 		t.Errorf("Failed to connect: %s", err)
 	}
-	err = m.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
+	err = conn.SendMail([]string{"hi@bye.com"}, "You are already a winner!", "Just kidding")
 	if err != nil {
 		t.Errorf("Expected SendMail() to not fail. Got err: %s", err)
 	}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/jmhodges/clock"
@@ -22,6 +23,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/identifier"
+	"github.com/letsencrypt/boulder/mail"
 	"github.com/letsencrypt/boulder/probs"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
@@ -560,8 +562,18 @@ func (*PublisherClient) SubmitToSingleCTWithResult(_ context.Context, _ *pubpb.R
 
 // Mailer is a mock
 type Mailer struct {
+	sync.Mutex
 	Messages []MailerMessage
 }
+
+var _ mail.Mailer = &Mailer{}
+
+// mockMailerConn is a mock that satisfies the mail.Conn interface
+type mockMailerConn struct {
+	parent *Mailer
+}
+
+var _ mail.Conn = &mockMailerConn{}
 
 // MailerMessage holds the captured emails from SendMail()
 type MailerMessage struct {
@@ -572,13 +584,17 @@ type MailerMessage struct {
 
 // Clear removes any previously recorded messages
 func (m *Mailer) Clear() {
+	m.Lock()
+	defer m.Unlock()
 	m.Messages = nil
 }
 
 // SendMail is a mock
-func (m *Mailer) SendMail(to []string, subject, msg string) error {
+func (m *mockMailerConn) SendMail(to []string, subject, msg string) error {
+	m.parent.Lock()
+	defer m.parent.Unlock()
 	for _, rcpt := range to {
-		m.Messages = append(m.Messages, MailerMessage{
+		m.parent.Messages = append(m.parent.Messages, MailerMessage{
 			To:      rcpt,
 			Subject: subject,
 			Body:    msg,
@@ -588,13 +604,13 @@ func (m *Mailer) SendMail(to []string, subject, msg string) error {
 }
 
 // Close is a mock
-func (m *Mailer) Close() error {
+func (m *mockMailerConn) Close() error {
 	return nil
 }
 
 // Connect is a mock
-func (m *Mailer) Connect() error {
-	return nil
+func (m *Mailer) Connect() (mail.Conn, error) {
+	return &mockMailerConn{parent: m}, nil
 }
 
 // SAWithFailedChallenges is a mocks.StorageAuthority that has

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -13,6 +13,7 @@
     "nagTimes": ["480h", "240h"],
     "emailTemplate": "test/example-expiration-template",
     "debugAddr": ":8008",
+    "parallelSends": 10,
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",
       "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",


### PR DESCRIPTION
This reverts commit 7ef6913e7152529b8d275a1a126a5eceb3a953e4.

We turned on the `ExpirationMailerDontLookTwice` feature flag in prod, and it's
working fine but not clearing the backlog. Since
https://github.com/letsencrypt/boulder/pull/6100 fixed the issue that caused us
to (nearly) stop sending mail when we deployed #6057, this should be safe to
roll forward.

The revert of the revert applied cleanly, except for expiration-mailer/main.go
and `main_test.go`, particularly around the contents `processCerts` (where
`sendToOneRegID` was extracted from) and `sendToOneRegID` itself. So those areas
are good targets for extra attention.