### PR TITLE
Fix unnecessary conversion lint

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -439,7 +439,7 @@ func (m *mailer) findExpiringCertificates(ctx context.Context) error {
 		// of any certificate in this batch because it's based on the first (oldest).
 		sendDelay := expiresIn - certs[0].Expires.Sub(m.clk.Now())
 		m.stats.sendDelay.With(prometheus.Labels{"nag_group": expiresIn.String()}).Set(
-			float64(sendDelay.Truncate(time.Second).Seconds()))
+			sendDelay.Truncate(time.Second).Seconds())
 
 		processingStarted := m.clk.Now()
 		err = m.processCerts(ctx, certs)


### PR DESCRIPTION
It's not clear to me why this lint failure wasn't caught in the
PR's boulder-ci runs, but it immediately started failing lints
on HEAD of main.