### PR TITLE
web: remove duplicate log of errors

### DIFF
--- a/web/send_error.go
+++ b/web/send_error.go
@@ -1,14 +1,10 @@
 package web
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/probs"
@@ -44,19 +40,6 @@ func SendError(
 	}
 	if ierr != nil {
 		logEvent.AddError(fmt.Sprintf("%s", ierr))
-	}
-
-	// Only audit log internal errors so users cannot purposefully cause
-	// auditable events. Also, skip the audit log for deadline exceeded errors
-	// since we don't need to keep those long-term. Note that they are still
-	// included in the request logs.
-	deadlineExceeded := ierr == context.DeadlineExceeded || status.Code(ierr) == codes.DeadlineExceeded
-	if prob.Type == probs.ServerInternalProblem && !deadlineExceeded {
-		if ierr != nil {
-			log.AuditErrf("Internal error - %s - %s", prob.Detail, ierr)
-		} else {
-			log.AuditErrf("Internal error - %s", prob.Detail)
-		}
 	}
 
 	// Set the proper namespace for the problem and any


### PR DESCRIPTION
The WFE logs internal errors as part of its request logging. These
errors are mostly passed along from other components, particularly the
SA, and spike whenever the database struggles with availability.

Since these are logged at error level, they mask other, potentially more
useful error logs. Remove these error logs in preference for the
info-level request logs, plus metrics that indicate when we are serving
a large proportion of 500s.