### PR TITLE
timeout connection failure: provide more details

### DIFF
--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -247,7 +247,7 @@ func TestTLSALPN01DialTimeout(t *testing.T) {
 		t.Fatalf("Connection should've timed out")
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
-	expected := "198.51.100.1: Timeout during connect (likely firewall problem)"
+	expected := "198.51.100.1: Timeout during connect (likely firewall problem, cannot connect anymore)"
 	if prob.Detail != expected {
 		t.Errorf("Wrong error detail. Expected %q, got %q", expected, prob.Detail)
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -305,7 +305,7 @@ func detailedError(err error) *probs.ProblemDetails {
 			// user. Confirmed against Go 1.8.
 			return probs.TLSError(netOpErr.Error())
 		} else if netOpErr.Timeout() && netOpErr.Op == "dial" {
-			return probs.ConnectionFailure("Timeout during connect (likely firewall problem)")
+			return probs.ConnectionFailure("Timeout during connect (likely firewall problem, cannot connect anymore)")
 		} else if netOpErr.Timeout() {
 			return probs.ConnectionFailure(fmt.Sprintf("Timeout during %s (your server may be slow or overloaded)", netOpErr.Op))
 		}


### PR DESCRIPTION
    "likely firewall problem" is a good description of the problem, but
    since it's such an unusual situation, providing more info can ease
    debugging.

    Personal experience: if I knew this information, it would immediately
    help me narrow down the problem to my router/ISP and not waste time with
    IPv6 and DNS that were unrelated.

Would love to improve the error message after a recent debugging session.

Please let me know if this is not the right place and I should improve documentation instead.