### PR TITLE
Create add-to-project action

### DIFF
--- a/.github/workflows/add-to-project
+++ b/.github/workflows/add-to-project
@@ -1,0 +1,16 @@
+name: Add new bugs to triage project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to triage project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/letsencrypt/projects/6
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Create a GitHub Actions workflow that automatically adds
newly-filed bugs to https://github.com/orgs/letsencrypt/projects/6.
The `ADD_TO_PROJECT_PAT` secret is a Personal Access
Token configured as laid out at
https://github.com/actions/add-to-project#creating-a-pat-and-adding-it-to-your-repository