### PR TITLE
Unify how we do streaming database selects

### DIFF
--- a/cmd/rocsp-tool/client.go
+++ b/cmd/rocsp-tool/client.go
@@ -159,8 +159,8 @@ func (cl *client) scanFromDBOneBatch(ctx context.Context, prevID int64, frequenc
 	clauses := "WHERE id > ? ORDER BY id LIMIT ?"
 	params := []interface{}{prevID, cl.scanBatchSize}
 
-	selector := db.NewTypeSelector[sa.CertStatusMetadata](cl.db)
-	rows, err := selector.SelectRows(ctx, clauses, params...)
+	selector := db.NewMappedSelector[sa.CertStatusMetadata](cl.db)
+	rows, err := selector.Query(ctx, clauses, params...)
 	if err != nil {
 		return -1, fmt.Errorf("scanning certificateStatus: %w", err)
 	}

--- a/cmd/rocsp-tool/client.go
+++ b/cmd/rocsp-tool/client.go
@@ -159,7 +159,11 @@ func (cl *client) scanFromDBOneBatch(ctx context.Context, prevID int64, frequenc
 	clauses := "WHERE id > ? ORDER BY id LIMIT ?"
 	params := []interface{}{prevID, cl.scanBatchSize}
 
-	selector := db.NewMappedSelector[sa.CertStatusMetadata](cl.db)
+	selector, err := db.NewMappedSelector[sa.CertStatusMetadata](cl.db)
+	if err != nil {
+		return -1, fmt.Errorf("initializing db map: %w", err)
+	}
+
 	rows, err := selector.Query(ctx, clauses, params...)
 	if err != nil {
 		return -1, fmt.Errorf("scanning certificateStatus: %w", err)

--- a/cmd/rocsp-tool/client.go
+++ b/cmd/rocsp-tool/client.go
@@ -2,17 +2,16 @@ package notmain
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/jmhodges/clock"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/rocsp"
 	rocsp_config "github.com/letsencrypt/boulder/rocsp/config"
@@ -24,7 +23,7 @@ import (
 type client struct {
 	issuers       []rocsp_config.ShortIDIssuer
 	redis         *rocsp.WritingClient
-	db            *sql.DB // optional
+	db            *db.WrappedMap // optional
 	ocspGenerator capb.OCSPGeneratorClient
 	clk           clock.Clock
 	scanBatchSize int
@@ -39,7 +38,7 @@ type processResult struct {
 	err error
 }
 
-func getStartingID(ctx context.Context, clk clock.Clock, db *sql.DB) (int64, error) {
+func getStartingID(ctx context.Context, clk clock.Clock, db *db.WrappedMap) (int64, error) {
 	// To scan the DB efficiently, we want to select only currently-valid certificates. There's a
 	// handy expires index, but for selecting a large set of rows, using the primary key will be
 	// more efficient. So first we find a good id to start with, then scan from there. Note: since
@@ -47,8 +46,7 @@ func getStartingID(ctx context.Context, clk clock.Clock, db *sql.DB) (int64, err
 	// certificates.
 	startTime := clk.Now().Add(-24 * time.Hour)
 	var minID *int64
-	err := db.QueryRowContext(
-		ctx,
+	err := db.WithContext(ctx).QueryRow(
 		"SELECT MIN(id) FROM certificateStatus WHERE notAfter >= ?",
 		startTime,
 	).Scan(&minID)
@@ -74,8 +72,7 @@ func (cl *client) loadFromDB(ctx context.Context, speed ProcessingSpeed, startFr
 	// Find the current maximum id in certificateStatus. We do this because the table is always
 	// growing. If we scanned until we saw a batch with no rows, we would scan forever.
 	var maxID *int64
-	err = cl.db.QueryRowContext(
-		ctx,
+	err = cl.db.WithContext(ctx).QueryRow(
 		"SELECT MAX(id) FROM certificateStatus",
 	).Scan(&maxID)
 	if err != nil {
@@ -159,9 +156,11 @@ func (cl *client) scanFromDB(ctx context.Context, prevID int64, maxID int64, fre
 func (cl *client) scanFromDBOneBatch(ctx context.Context, prevID int64, frequency time.Duration, output chan<- *sa.CertStatusMetadata, inflightIDs *inflight) (int64, error) {
 	rowTicker := time.NewTicker(frequency)
 
-	query := fmt.Sprintf("SELECT %s FROM certificateStatus WHERE id > ? ORDER BY id LIMIT ?",
-		strings.Join(sa.CertStatusMetadataFields(), ", "))
-	rows, err := cl.db.QueryContext(ctx, query, prevID, cl.scanBatchSize)
+	clauses := "WHERE id > ? ORDER BY id LIMIT ?"
+	params := []interface{}{prevID, cl.scanBatchSize}
+
+	selector := db.NewTypeSelector[sa.CertStatusMetadata](cl.db)
+	rows, err := selector.SelectRows(ctx, clauses, params...)
 	if err != nil {
 		return -1, fmt.Errorf("scanning certificateStatus: %w", err)
 	}
@@ -177,8 +176,7 @@ func (cl *client) scanFromDBOneBatch(ctx context.Context, prevID int64, frequenc
 	for rows.Next() {
 		<-rowTicker.C
 
-		status := new(sa.CertStatusMetadata)
-		err := sa.ScanCertStatusMetadataRow(rows, status)
+		status, err := rows.Get()
 		if err != nil {
 			return -1, fmt.Errorf("scanning row %d (previous ID %d): %w", scanned, previousID, err)
 		}

--- a/cmd/rocsp-tool/client_test.go
+++ b/cmd/rocsp-tool/client_test.go
@@ -73,7 +73,7 @@ func TestGetStartingID(t *testing.T) {
 
 	clk.Sleep(48 * time.Hour)
 
-	startingID, err := getStartingID(context.Background(), clk, dbMap.Db)
+	startingID, err := getStartingID(context.Background(), clk, dbMap)
 	test.AssertNotError(t, err, "getting starting ID")
 
 	test.AssertEquals(t, startingID, secondID)
@@ -149,7 +149,7 @@ func TestLoadFromDB(t *testing.T) {
 	rocspToolClient := client{
 		issuers:       nil,
 		redis:         redisClient,
-		db:            dbMap.Db,
+		db:            dbMap,
 		ocspGenerator: mockOCSPGenerator{},
 		clk:           clk,
 		scanBatchSize: 10,

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -2,7 +2,6 @@ package notmain
 
 import (
 	"context"
-	"database/sql"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"github.com/jmhodges/clock"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/db"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/metrics"
 	rocsp_config "github.com/letsencrypt/boulder/rocsp/config"
@@ -111,12 +111,12 @@ func main2() error {
 		return fmt.Errorf("making client: %w", err)
 	}
 
-	var db *sql.DB
+	var db *db.WrappedMap
 	var ocspGenerator capb.OCSPGeneratorClient
 	var scanBatchSize int
 	if c.ROCSPTool.LoadFromDB != nil {
 		lfd := c.ROCSPTool.LoadFromDB
-		db, err = sa.InitSqlDb(lfd.DB, nil)
+		db, err = sa.InitWrappedDb(lfd.DB, nil, logger)
 		if err != nil {
 			return fmt.Errorf("connecting to DB: %w", err)
 		}

--- a/db/gorm.go
+++ b/db/gorm.go
@@ -13,23 +13,57 @@ var safeNameRE = regexp.MustCompile("^[a-zA-Z0-9_]+$")
 
 // NewMappedSelector returns an object which can be used to automagically query
 // the provided type-mapped database for rows of the parameterized type.
-func NewMappedSelector[T any](executor MappedExecutor) MappedSelector[T] {
-	return &mappedSelector[T]{wrapped: executor}
+func NewMappedSelector[T any](executor MappedExecutor) (MappedSelector[T], error) {
+	var throwaway T
+	t := reflect.TypeOf(throwaway)
+
+	// We use a very strict mapping of struct fields to table columns here:
+	// - The struct must not have any embedded structs, only named fields.
+	// - The struct field names must be case-insensitively identical to the
+	//   column names (no struct tags necessary).
+	// - The struct field names must be case-insensitively unique.
+	// - Every field of the struct must correspond to a database column.
+	//   - Note that the reverse is not true: it's perfectly okay for there to be
+	//     database columns which do not correspond to fields in the struct; those
+	//     columns will be ignored.
+	// TODO: In the future, when we replace gorp's TableMap with our own, this
+	// check should be performed at the time the mapping is declared.
+	columns := make([]string, 0)
+	seen := make(map[string]struct{})
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Anonymous {
+			return nil, fmt.Errorf("struct contains anonymous embedded struct %q", field.Name)
+		}
+		column := strings.ToLower(t.Field(i).Name)
+		if !safeNameRE.MatchString(column) {
+			return nil, fmt.Errorf("struct field maps to unsafe db column name %q", column)
+		}
+		if _, found := seen[column]; found {
+			return nil, fmt.Errorf("struct fields map to duplicate column name %q", column)
+		}
+		seen[column] = struct{}{}
+		columns = append(columns, column)
+	}
+
+	return &mappedSelector[T]{wrapped: executor, columns: columns}, nil
 }
 
 type mappedSelector[T any] struct {
 	wrapped MappedExecutor
+	columns []string
 }
 
-// Query combines the best features of gorp, the go stdlib, and generics.
-// It uses the type parameter of the typeSelector object to automatically look
-// up the proper table name and columns to select. It returns an iterable which
-// yields fully-populated objects of the parameterized type directly. The given
-// clauses MUST be only the bits of a sql query from "WHERE ..." onwards; if
-// they contain any of the "SELECT ... FROM ..." portion of the query it will
-// result in an error. The args take the same kinds of values as gorp's SELECT:
-// either one argument per positional placeholder, or a map of placeholder names
-// to their arguments (https://pkg.go.dev/gopkg.in/gorp.v2#readme-ad-hoc-sql).
+// Query performs a SELECT on the appropriate table for T. It combines the best
+// features of gorp, the go stdlib, and generics, using the type parameter of
+// the typeSelector object to automatically look up the proper table name and
+// columns to select. It returns an iterable which yields fully-populated
+// objects of the parameterized type directly. The given clauses MUST be only
+// the bits of a sql query from "WHERE ..." onwards; if they contain any of the
+// "SELECT ... FROM ..." portion of the query it will result in an error. The
+// args take the same kinds of values as gorp's SELECT: either one argument per
+// positional placeholder, or a map of placeholder names to their arguments
+// (see https://pkg.go.dev/gopkg.in/gorp.v2#readme-ad-hoc-sql).
 //
 // The caller is responsible for calling `Rows.Close()` when they are done with
 // the query. The caller is also responsible for ensuring that the clauses
@@ -57,33 +91,11 @@ func (ts mappedSelector[T]) QueryFrom(ctx context.Context, tablename string, cla
 		return nil, fmt.Errorf("unsafe db table name %q", tablename)
 	}
 
-	// We use a very strict mapping of struct fields to table columns here:
-	// - The struct must not have any nested structs, only basic types.
-	// - The struct field names must be case-insensitively identical to the
-	//   column names (no struct tags necessary).
-	// - Every field of the struct must correspond to a database column.
-	//   - Note that the reverse is not true: it's perfectly okay for there to be
-	//     database columns which do not correspond to fields in the struct; those
-	//     columns will be ignored.
-	// TODO: In the future, when we replace gorp's TableMap with our own, this
-	// check should be performed at the time the mapping is declared.
-	columns := make([]string, 0)
-	var throwaway T
-	for _, field := range reflect.VisibleFields(reflect.TypeOf(throwaway)) {
-		if len(field.Index) != 1 {
-			return nil, fmt.Errorf("database model type contains nested struct field %q", field.Name)
-		}
-		column := strings.ToLower(field.Name)
-		if !safeNameRE.MatchString(column) {
-			return nil, fmt.Errorf("unsafe db column name %q", column)
-		}
-		columns = append(columns, column)
-	}
-
 	// Construct the query from the column names, table name, and given clauses.
+	// Note that the column names here are in the order given by
 	query := fmt.Sprintf(
 		"SELECT %s FROM %s %s",
-		strings.Join(columns, ", "),
+		strings.Join(ts.columns, ", "),
 		tablename,
 		clauses,
 	)
@@ -93,14 +105,14 @@ func (ts mappedSelector[T]) QueryFrom(ctx context.Context, tablename string, cla
 		return nil, fmt.Errorf("reading db: %w", err)
 	}
 
-	return &rows[T]{wrapped: r, columns: columns}, nil
+	return &rows[T]{wrapped: r, numCols: len(ts.columns)}, nil
 }
 
 // rows is a wrapper around the stdlib's sql.rows, but with a more
 // type-safe method to get actual row content.
 type rows[T any] struct {
 	wrapped *sql.Rows
-	columns []string
+	numCols int
 }
 
 // Next is a wrapper around sql.Rows.Next(). It must be called before every call
@@ -119,8 +131,8 @@ func (r rows[T]) Get() (*T, error) {
 	// Because sql.Rows.Scan(...) takes a variadic number of individual targets to
 	// read values into, build a slice that can be splatted into the call. Use the
 	// pre-computed list of in-order column names to populate it.
-	scanTargets := make([]interface{}, len(r.columns))
-	for i := range r.columns {
+	scanTargets := make([]interface{}, r.numCols)
+	for i := range scanTargets {
 		field := v.Elem().Field(i)
 		scanTargets[i] = field.Addr().Interface()
 	}

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"reflect"
 
 	"github.com/go-gorp/gorp/v3"
 )
@@ -67,5 +68,12 @@ type Transaction interface {
 	Executor
 	Rollback() error
 	Commit() error
+	WithContext(ctx context.Context) gorp.SqlExecutor
+}
+
+// MappedExecutor is anything that can map types to tables, and which can
+// produce a contextual SqlExecutor.
+type MappedExecutor interface {
+	TableFor(reflect.Type, bool) (*gorp.TableMap, error)
 	WithContext(ctx context.Context) gorp.SqlExecutor
 }

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -72,8 +72,24 @@ type Transaction interface {
 }
 
 // MappedExecutor is anything that can map types to tables, and which can
-// produce a contextual SqlExecutor.
+// produce a SqlExecutor bound to a context.
 type MappedExecutor interface {
 	TableFor(reflect.Type, bool) (*gorp.TableMap, error)
 	WithContext(ctx context.Context) gorp.SqlExecutor
+}
+
+// MappedSelector is anything that can execute various kinds of SQL statements
+// against a table automatically determined from the parameterized type.
+type MappedSelector[T any] interface {
+	Query(ctx context.Context, clauses string, args ...interface{}) (Rows[T], error)
+	QueryFrom(ctx context.Context, tablename string, clauses string, args ...interface{}) (Rows[T], error)
+}
+
+// Rows is anything which lets you iterate over the result rows of a SELECT
+// query. It is similar to sql.Rows, but generic.
+type Rows[T any] interface {
+	Next() bool
+	Get() (*T, error)
+	Err() error
+	Close() error
 }

--- a/db/selector.go
+++ b/db/selector.go
@@ -127,12 +127,8 @@ func (r rows[T]) Next() bool {
 // number of &interface{} arguments, it returns a populated object of the
 // parameterized type.
 func (r rows[T]) Get() (*T, error) {
-	// We have to use reflect.New(reflect.TypeOf(var T)) to create our result
-	// value to ensure that it gets allocated on the heap and its individual
-	// fields are all addressable.
-	var throwaway T
-	t := reflect.TypeOf(throwaway)
-	v := reflect.New(t)
+	result := new(T)
+	v := reflect.ValueOf(result)
 
 	// Because sql.Rows.Scan(...) takes a variadic number of individual targets to
 	// read values into, build a slice that can be splatted into the call. Use the
@@ -148,9 +144,7 @@ func (r rows[T]) Get() (*T, error) {
 		return nil, fmt.Errorf("reading db row: %w", err)
 	}
 
-	// Finally cast our *reflect.Value back into a T so we can return it.
-	result := v.Elem().Interface().(T)
-	return &result, nil
+	return result, nil
 }
 
 // Err is a wrapper around sql.Rows.Err(). It should be checked immediately

--- a/db/selector.go
+++ b/db/selector.go
@@ -1,0 +1,114 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type TypeSelector[T any] struct {
+	wrapped *WrappedMap
+}
+
+func NewTypeSelector[T any](wm *WrappedMap) *TypeSelector[T] {
+	return &TypeSelector[T]{wrapped: wm}
+}
+
+// SelectRows combines the best features of gorp, the go stdlib, and generics.
+// It uses the type parameter of the TypeSelector object to automatically look
+// up the proper table name and columns to select. It returns an iterable which
+// yields fully-populated objects of the parameterized type directly. The given
+// clauses MUST be only the bits of a sql query from "WHERE ..." onwards; if
+// they contain any of the "SELECT ... FROM ..." portion of the query it will
+// result in an error. The caller is responsible for calling `Rows.Close()`
+// when they are done with the query.
+func (ts TypeSelector[T]) SelectRows(ctx context.Context, clauses string, args ...interface{}) (*typeRows[T], error) {
+	// Look up the table to use based on the type of this TypeSelector.
+	var t T
+	tableMap, err := ts.wrapped.TableFor(reflect.TypeOf(t), false)
+	if err != nil {
+		return nil, fmt.Errorf("database model type not mapped to table name: %w", err)
+	}
+
+	// Extract the list of column names from the type's struct tags.
+	var columns []string
+	for _, column := range tableMap.Columns {
+		columns = append(columns, column.ColumnName)
+	}
+
+	// Construct the query from the column names, table name, and given clauses.
+	query := fmt.Sprintf(
+		"SELECT %s FROM %s %s",
+		strings.Join(columns, ", "),
+		tableMap.TableName,
+		clauses,
+	)
+
+	rows, err := ts.wrapped.WithContext(ctx).Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read db: %w", err)
+	}
+
+	return &typeRows[T]{wrapped: rows}, nil
+}
+
+// typeRows is a wrapper around the stdlib's sql.typeRows, but with a more
+// type-safe method to get actual row content.
+type typeRows[T any] struct {
+	wrapped *sql.Rows
+}
+
+// Next is a wrapper around sql.Rows.Next(). It must be called before every call
+// to Get(), including the first.
+func (r typeRows[T]) Next() bool {
+	return r.wrapped.Next()
+}
+
+// Get is a wrapper around sql.Rows.Scan(). Rather than populating an arbitrary
+// number of &interface{} arguments, it returns a populated object of the
+// parameterized type.
+func (r typeRows[T]) Get() (*T, error) {
+	var res T
+
+	columns, err := r.wrapped.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read column names: %w", err)
+	}
+
+	scanTarget := make([]interface{}, len(columns))
+	fields := reflect.VisibleFields(reflect.TypeOf(res))
+
+	// Iterate over the columns in the order they appear. For each, find the field
+	// on the result struct that has a matching `db:"colname"` struct tag. Put the
+	// address of that field into the slice which will be Scan()ed into.
+	for i, column := range columns {
+		for _, field := range fields {
+			if field.Tag.Get("db") == column {
+				scanTarget[i] = reflect.ValueOf(res).FieldByIndex(field.Index)
+				break
+			}
+			return nil, fmt.Errorf("no struct field found with tag matching column %q", column)
+		}
+	}
+
+	err = r.wrapped.Scan(scanTarget...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read row: %w", err)
+	}
+
+	return &res, nil
+}
+
+// Err is a wrapper around sql.Rows.Err(). It should be checked immediately
+// after Next() returns false for any reason.
+func (r typeRows[T]) Err() error {
+	return r.wrapped.Err()
+}
+
+// Close is a wrapper around sql.Rows.Close(). It must be called when the caller
+// is done reading rows, regardless of success or error.
+func (r typeRows[T]) Close() error {
+	return r.wrapped.Close()
+}

--- a/db/selector.go
+++ b/db/selector.go
@@ -5,53 +5,74 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 )
 
-type typeSelector[T any] struct {
+var safeNameRE = regexp.MustCompile("^[a-zA-Z0-9_]+$")
+
+// NewMappedSelector returns an object which can be used to automagically query
+// the provided type-mapped database for rows of the parameterized type.
+func NewMappedSelector[T any](executor MappedExecutor) MappedSelector[T] {
+	return &mappedSelector[T]{wrapped: executor}
+}
+
+type mappedSelector[T any] struct {
 	wrapped MappedExecutor
 }
 
-// NewTypeSelector returns an object which can be used to automagically query
-// the provided type-mapped database for rows of the parameterized type.
-func NewTypeSelector[T any](wm MappedExecutor) *typeSelector[T] {
-	return &typeSelector[T]{wrapped: wm}
-}
-
-// SelectRows combines the best features of gorp, the go stdlib, and generics.
+// Query combines the best features of gorp, the go stdlib, and generics.
 // It uses the type parameter of the typeSelector object to automatically look
 // up the proper table name and columns to select. It returns an iterable which
 // yields fully-populated objects of the parameterized type directly. The given
 // clauses MUST be only the bits of a sql query from "WHERE ..." onwards; if
 // they contain any of the "SELECT ... FROM ..." portion of the query it will
-// result in an error. The caller is responsible for calling `Rows.Close()`
-// when they are done with the query.
-func (ts typeSelector[T]) SelectRows(ctx context.Context, clauses string, args ...interface{}) (*typeRows[T], error) {
+// result in an error. The args take the same kinds of values as gorp's SELECT:
+// either one argument per positional placeholder, or a map of placeholder names
+// to their arguments (https://pkg.go.dev/gopkg.in/gorp.v2#readme-ad-hoc-sql).
+//
+// The caller is responsible for calling `Rows.Close()` when they are done with
+// the query. The caller is also responsible for ensuring that the clauses
+// argument does not contain any user-influenced input.
+func (ts mappedSelector[T]) Query(ctx context.Context, clauses string, args ...interface{}) (Rows[T], error) {
 	// Look up the table to use based on the type of this TypeSelector.
-	var t T
-	tableMap, err := ts.wrapped.TableFor(reflect.TypeOf(t), false)
+	var throwaway T
+	tableMap, err := ts.wrapped.TableFor(reflect.TypeOf(throwaway), false)
 	if err != nil {
 		return nil, fmt.Errorf("database model type not mapped to table name: %w", err)
 	}
 
-	return ts.SelectRowsFrom(ctx, tableMap.TableName, clauses, args...)
+	return ts.QueryFrom(ctx, tableMap.TableName, clauses, args...)
 }
 
-// SelectRowsFrom is the same as SelectRows, but it additionally takes a table
-// name to select from, rather than automatically computing the table name from
-// gorp's DbMap.
-func (ts typeSelector[T]) SelectRowsFrom(ctx context.Context, tablename string, clauses string, args ...interface{}) (*typeRows[T], error) {
-	// Look up the table to use based on the type of this TypeSelector.
+// QueryFrom is the same as Query, but it additionally takes a table name to
+// select from, rather than automatically computing the table name from gorp's
+// DbMap.
+//
+// The caller is responsible for calling `Rows.Close()` when they are done with
+// the query. The caller is also responsible for ensuring that the clauses
+// argument does not contain any user-influenced input.
+func (ts mappedSelector[T]) QueryFrom(ctx context.Context, tablename string, clauses string, args ...interface{}) (Rows[T], error) {
+	if !safeNameRE.MatchString(tablename) {
+		return nil, fmt.Errorf("unsafe db table name %q", tablename)
+	}
+
+	// Look up the table to use based on the type of this TypeSelector. We have to
+	// do this despite the tablename argument in order to get the table's columns.
 	var throwaway T
 	t := reflect.TypeOf(throwaway)
 	tableMap, err := ts.wrapped.TableFor(t, false)
 	if err != nil {
-		return nil, fmt.Errorf("database model type not mapped to table name: %w", err)
+		return nil, fmt.Errorf("database model type not mapped to table: %w", err)
 	}
 
-	// Extract the list of column names from the type's struct tags.
+	// Extract the list of column names from the tableMap, which got them from
+	// the type's struct tags.
 	var columns []string
 	for _, column := range tableMap.Columns {
+		if !safeNameRE.MatchString(column.ColumnName) {
+			return nil, fmt.Errorf("unsafe db column name %q", column.ColumnName)
+		}
 		columns = append(columns, column.ColumnName)
 	}
 
@@ -81,31 +102,31 @@ func (ts typeSelector[T]) SelectRowsFrom(ctx context.Context, tablename string, 
 		clauses,
 	)
 
-	rows, err := ts.wrapped.WithContext(ctx).Query(query, args...)
+	r, err := ts.wrapped.WithContext(ctx).Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("reading db: %w", err)
 	}
 
-	return &typeRows[T]{wrapped: rows, idxMap: colIndexToFieldIndex}, nil
+	return &rows[T]{wrapped: r, idxMap: colIndexToFieldIndex}, nil
 }
 
-// typeRows is a wrapper around the stdlib's sql.typeRows, but with a more
+// rows is a wrapper around the stdlib's sql.rows, but with a more
 // type-safe method to get actual row content.
-type typeRows[T any] struct {
+type rows[T any] struct {
 	wrapped *sql.Rows
 	idxMap  [][]int
 }
 
 // Next is a wrapper around sql.Rows.Next(). It must be called before every call
 // to Get(), including the first.
-func (r typeRows[T]) Next() bool {
+func (r rows[T]) Next() bool {
 	return r.wrapped.Next()
 }
 
 // Get is a wrapper around sql.Rows.Scan(). Rather than populating an arbitrary
 // number of &interface{} arguments, it returns a populated object of the
 // parameterized type.
-func (r typeRows[T]) Get() (*T, error) {
+func (r rows[T]) Get() (*T, error) {
 	// We have to use reflect.New(reflect.TypeOf(var T)) to create our result
 	// value to ensure that it gets allocated on the heap and its individual
 	// fields are all addressable.
@@ -134,12 +155,12 @@ func (r typeRows[T]) Get() (*T, error) {
 
 // Err is a wrapper around sql.Rows.Err(). It should be checked immediately
 // after Next() returns false for any reason.
-func (r typeRows[T]) Err() error {
+func (r rows[T]) Err() error {
 	return r.wrapped.Err()
 }
 
 // Close is a wrapper around sql.Rows.Close(). It must be called when the caller
 // is done reading rows, regardless of success or error.
-func (r typeRows[T]) Close() error {
+func (r rows[T]) Close() error {
 	return r.wrapped.Close()
 }

--- a/ocsp/updater/updater.go
+++ b/ocsp/updater/updater.go
@@ -244,8 +244,8 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 	go func() {
 		defer close(staleStatusesOut)
 
-		selector := db.NewTypeSelector[sa.CertStatusMetadata](updater.readOnlyDb)
-		rows, err := selector.SelectRows(ctx, updater.queryBody, args...)
+		selector := db.NewMappedSelector[sa.CertStatusMetadata](updater.readOnlyDb)
+		rows, err := selector.Query(ctx, updater.queryBody, args...)
 
 		// If error, log and increment retries for backoff. Else no
 		// error, proceed to push statuses to channel.

--- a/ocsp/updater/updater.go
+++ b/ocsp/updater/updater.go
@@ -14,23 +14,16 @@ import (
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
 	rocsp_config "github.com/letsencrypt/boulder/rocsp/config"
 	"github.com/letsencrypt/boulder/sa"
 )
 
-// ocspDB and ocspReadOnlyDB are interfaces collecting the `sql.DB` methods that
-// the various parts of OCSPUpdater rely on. Using this adapter shim allows tests to
-// swap out the `sql.DB` implementation.
-
-// ocspReadOnlyDb provides only read-only portions of the `sql.DB` interface.
-type ocspReadOnlyDb interface {
-	Query(query string, args ...interface{}) (*sql.Rows, error)
-}
-
-// ocspDb provides read-write portions of the `sql.DB` interface.
+// ocspDb is an interface collecting the methods that the read/write parts of
+// OCSPUpdater rely on. This allows the tests to swap out the db implementation.
 type ocspDb interface {
-	ocspReadOnlyDb
+	db.MappedExecutor
 	Exec(query string, args ...interface{}) (sql.Result, error)
 }
 
@@ -68,7 +61,7 @@ type OCSPUpdater struct {
 	clk clock.Clock
 
 	db          ocspDb
-	readOnlyDb  ocspReadOnlyDb
+	readOnlyDb  db.MappedExecutor
 	rocspClient rocspClientInterface
 
 	issuers []rocsp_config.ShortIDIssuer
@@ -106,8 +99,8 @@ type OCSPUpdater struct {
 func New(
 	stats prometheus.Registerer,
 	clk clock.Clock,
-	db ocspDb,
-	readOnlyDb ocspReadOnlyDb,
+	db *db.WrappedMap,
+	readOnlyDb *db.WrappedMap,
 	rocspClient rocspClientInterface,
 	issuers []rocsp_config.ShortIDIssuer,
 	serialSuffixes []string,
@@ -234,10 +227,10 @@ func getQuestionsForShardList(count int) string {
 
 // findStaleOCSPResponses sends a goroutine to fetch rows of stale OCSP
 // responses from the database and returns results on a channel.
-func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLastUpdatedTime time.Time, batchSize int) <-chan sa.CertStatusMetadata {
+func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLastUpdatedTime time.Time, batchSize int) <-chan *sa.CertStatusMetadata {
 	// staleStatusesOut channel contains all stale ocsp responses that need
 	// updating.
-	staleStatusesOut := make(chan sa.CertStatusMetadata)
+	staleStatusesOut := make(chan *sa.CertStatusMetadata)
 
 	args := make([]interface{}, 0)
 	args = append(args, oldestLastUpdatedTime)
@@ -251,14 +244,8 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 	go func() {
 		defer close(staleStatusesOut)
 
-		rows, err := updater.readOnlyDb.Query(
-			fmt.Sprintf(
-				"SELECT %s FROM certificateStatus %s",
-				strings.Join(sa.CertStatusMetadataFields(), ","),
-				updater.queryBody,
-			),
-			args...,
-		)
+		selector := db.NewTypeSelector[sa.CertStatusMetadata](updater.readOnlyDb)
+		rows, err := selector.SelectRows(ctx, updater.queryBody, args...)
 
 		// If error, log and increment retries for backoff. Else no
 		// error, proceed to push statuses to channel.
@@ -276,15 +263,14 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 		}()
 
 		for rows.Next() {
-			var status sa.CertStatusMetadata
-			err := sa.ScanCertStatusMetadataRow(rows, &status)
+			meta, err := rows.Get()
 			if err != nil {
 				updater.log.AuditErrf("failed to scan metadata status row: %s", err)
 				updater.findStaleOCSPCounter.WithLabelValues("failed").Inc()
 				updater.readFailures.Add(1)
 				return
 			}
-			staleness := oldestLastUpdatedTime.Sub(status.OCSPLastUpdated).Seconds()
+			staleness := oldestLastUpdatedTime.Sub(meta.OCSPLastUpdated).Seconds()
 			updater.stalenessHistogram.Observe(staleness)
 			select {
 			case <-ctx.Done():
@@ -293,7 +279,7 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 					updater.log.AuditErrf("context done reading rows: %s", err)
 				}
 				return
-			case staleStatusesOut <- status:
+			case staleStatusesOut <- meta:
 			}
 		}
 
@@ -313,18 +299,33 @@ func (updater *OCSPUpdater) findStaleOCSPResponses(ctx context.Context, oldestLa
 	return staleStatusesOut
 }
 
+func statusFromMetaAndResp(meta *sa.CertStatusMetadata, resp []byte) *core.CertificateStatus {
+	return &core.CertificateStatus{
+		ID:                    meta.ID,
+		Serial:                meta.Serial,
+		Status:                meta.Status,
+		OCSPLastUpdated:       meta.OCSPLastUpdated,
+		RevokedDate:           meta.RevokedDate,
+		RevokedReason:         meta.RevokedReason,
+		LastExpirationNagSent: meta.LastExpirationNagSent,
+		OCSPResponse:          resp,
+		NotAfter:              meta.NotAfter,
+		IsExpired:             meta.IsExpired,
+		IssuerID:              meta.IssuerID,
+	}
+}
+
 // generateResponse signs an new OCSP response for a given certStatus row.
-// Takes its argument by value to force a copy, then returns a reference to that copy.
-func (updater *OCSPUpdater) generateResponse(ctx context.Context, status sa.CertStatusMetadata) (*sa.CertStatusMetadata, error) {
-	if status.IssuerID == 0 {
+func (updater *OCSPUpdater) generateResponse(ctx context.Context, meta *sa.CertStatusMetadata) (*core.CertificateStatus, error) {
+	if meta.IssuerID == 0 {
 		return nil, errors.New("cert status has 0 IssuerID")
 	}
 	ocspReq := capb.GenerateOCSPRequest{
-		Serial:    status.Serial,
-		IssuerID:  status.IssuerID,
-		Status:    string(status.Status),
-		Reason:    int32(status.RevokedReason),
-		RevokedAt: status.RevokedDate.UnixNano(),
+		Serial:    meta.Serial,
+		IssuerID:  meta.IssuerID,
+		Status:    string(meta.Status),
+		Reason:    int32(meta.RevokedReason),
+		RevokedAt: meta.RevokedDate.UnixNano(),
 	}
 
 	ocspResponse, err := updater.ogc.GenerateOCSP(ctx, &ocspReq)
@@ -332,14 +333,12 @@ func (updater *OCSPUpdater) generateResponse(ctx context.Context, status sa.Cert
 		return nil, err
 	}
 
-	status.OCSPLastUpdated = updater.clk.Now()
-	status.OCSPResponse = ocspResponse.Response
-
-	return &status, nil
+	meta.OCSPLastUpdated = updater.clk.Now()
+	return statusFromMetaAndResp(meta, ocspResponse.Response), nil
 }
 
 // storeResponse stores a given CertificateStatus in the database.
-func (updater *OCSPUpdater) storeResponse(ctx context.Context, status *sa.CertStatusMetadata) error {
+func (updater *OCSPUpdater) storeResponse(ctx context.Context, status *core.CertificateStatus) error {
 	// If a redis client is configured, try to store the response in redis.
 	if updater.rocspClient != nil {
 		// Create a context to set a deadline for the goroutine that stores
@@ -391,26 +390,26 @@ func (updater *OCSPUpdater) storeResponse(ctx context.Context, status *sa.CertSt
 }
 
 // markExpired updates a given CertificateStatus to have `isExpired` set.
-func (updater *OCSPUpdater) markExpired(status sa.CertStatusMetadata) error {
+func (updater *OCSPUpdater) markExpired(meta *sa.CertStatusMetadata) error {
 	_, err := updater.db.Exec(
 		`UPDATE certificateStatus
  		SET isExpired = TRUE
  		WHERE id = ?`,
-		status.ID,
+		meta.ID,
 	)
 	return err
 }
 
 // processExpired is a pipeline step to process a channel of
-// `core.CertificateStatus` and set `isExpired` in the database.
-func (updater *OCSPUpdater) processExpired(ctx context.Context, staleStatusesIn <-chan sa.CertStatusMetadata) <-chan sa.CertStatusMetadata {
+// `sa.CertStatusMetadata` and set `isExpired` in the database.
+func (updater *OCSPUpdater) processExpired(ctx context.Context, staleStatusesIn <-chan *sa.CertStatusMetadata) <-chan *sa.CertStatusMetadata {
 	tickStart := updater.clk.Now()
-	staleStatusesOut := make(chan sa.CertStatusMetadata)
+	staleStatusesOut := make(chan *sa.CertStatusMetadata)
 	go func() {
 		defer close(staleStatusesOut)
-		for status := range staleStatusesIn {
-			if !status.IsExpired && tickStart.After(status.NotAfter) {
-				err := updater.markExpired(status)
+		for meta := range staleStatusesIn {
+			if !meta.IsExpired && tickStart.After(meta.NotAfter) {
+				err := updater.markExpired(meta)
 				if err != nil {
 					// Update error counters and log
 					updater.log.AuditErrf("Failed to set certificate expired: %s", err)
@@ -422,7 +421,7 @@ func (updater *OCSPUpdater) processExpired(ctx context.Context, staleStatusesIn 
 			select {
 			case <-ctx.Done():
 				return
-			case staleStatusesOut <- status:
+			case staleStatusesOut <- meta:
 			}
 		}
 	}()
@@ -433,7 +432,7 @@ func (updater *OCSPUpdater) processExpired(ctx context.Context, staleStatusesIn 
 // generateOCSPResponses is the final stage of a pipeline. It takes a
 // channel of `core.CertificateStatus` and sends a goroutine for each to
 // obtain a new OCSP response and update the status in the database.
-func (updater *OCSPUpdater) generateOCSPResponses(ctx context.Context, staleStatusesIn <-chan sa.CertStatusMetadata) {
+func (updater *OCSPUpdater) generateOCSPResponses(ctx context.Context, staleStatusesIn <-chan *sa.CertStatusMetadata) {
 	// Use the semaphore pattern from
 	// https://github.com/golang/go/wiki/BoundingResourceUse to send a number of
 	// GenerateOCSP / storeResponse requests in parallel, while limiting the total number of
@@ -450,10 +449,10 @@ func (updater *OCSPUpdater) generateOCSPResponses(ctx context.Context, staleStat
 
 	// Work runs as a goroutine per ocsp response to obtain a new ocsp
 	// response and store it in the database.
-	work := func(status sa.CertStatusMetadata) {
+	work := func(meta *sa.CertStatusMetadata) {
 		defer done(updater.clk.Now())
 
-		meta, err := updater.generateResponse(ctx, status)
+		status, err := updater.generateResponse(ctx, meta)
 		if err != nil {
 			updater.log.AuditErrf("Failed to generate OCSP response: %s", err)
 			updater.generatedCounter.WithLabelValues("failed").Inc()
@@ -461,7 +460,7 @@ func (updater *OCSPUpdater) generateOCSPResponses(ctx context.Context, staleStat
 		}
 		updater.generatedCounter.WithLabelValues("success").Inc()
 
-		err = updater.storeResponse(ctx, meta)
+		err = updater.storeResponse(ctx, status)
 		if err != nil {
 			updater.log.AuditErrf("Failed to store OCSP response: %s", err)
 			updater.storedCounter.WithLabelValues("failed").Inc()

--- a/sa/database.go
+++ b/sa/database.go
@@ -279,4 +279,7 @@ func initTables(dbMap *gorp.DbMap) {
 	dbMap.AddTableWithName(keyHashModel{}, "keyHashToSerial").SetKeys(true, "ID")
 	dbMap.AddTableWithName(incidentModel{}, "incidents").SetKeys(true, "ID")
 	dbMap.AddTable(incidentSerialModel{})
+
+	// Read-only maps used for selecting subsets of columns.
+	dbMap.AddTableWithName(CertStatusMetadata{}, "certificateStatus")
 }

--- a/sa/model.go
+++ b/sa/model.go
@@ -19,6 +19,7 @@ import (
 	"github.com/letsencrypt/boulder/db"
 	"github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/probs"
+	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
 

--- a/sa/model.go
+++ b/sa/model.go
@@ -122,7 +122,16 @@ func SelectPrecertificates(s db.Selector, q string, args map[string]interface{})
 }
 
 type CertStatusMetadata struct {
-	core.CertificateStatus
+	ID                    int64             `db:"id"`
+	Serial                string            `db:"serial"`
+	Status                core.OCSPStatus   `db:"status"`
+	OCSPLastUpdated       time.Time         `db:"ocspLastUpdated"`
+	RevokedDate           time.Time         `db:"revokedDate"`
+	RevokedReason         revocation.Reason `db:"revokedReason"`
+	LastExpirationNagSent time.Time         `db:"lastExpirationNagSent"`
+	NotAfter              time.Time         `db:"notAfter"`
+	IsExpired             bool              `db:"isExpired"`
+	IssuerID              int64             `db:"issuerID"`
 }
 
 // CertStatusMetadataFields returns a slice of column names for rows in the

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -193,52 +193,6 @@ func TestPopulateAttemptedFieldsBadJSON(t *testing.T) {
 	}
 }
 
-func TestScanCertStatusMetadataRow(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
-	defer cleanUp()
-
-	inputStatus := core.CertificateStatus{
-		Serial: "ff00ff00",
-		Status: "good",
-	}
-	err := sa.dbMap.Insert(&inputStatus)
-	test.AssertNotError(t, err, "couldn't insert certificateStatus")
-
-	rows, err := sa.dbMap.Query("SELECT serial, status, ocspLastUpdated FROM certificateStatus")
-	test.AssertNotError(t, err, "selecting")
-
-	if !rows.Next() {
-		t.Fatal("got no rows")
-	}
-	var certStatus CertStatusMetadata
-	err = ScanCertStatusMetadataRow(rows, &certStatus)
-
-	if err == nil {
-		t.Fatal("expected error, got none")
-	}
-	expected := "incorrect number of columns in scanned rows: got 3, expected 10"
-	if err.Error() != expected {
-		t.Errorf("wrong error: got %q, expected %q", err, expected)
-	}
-
-	rows, err = sa.dbMap.Query("SELECT id, status, serial, ocspLastUpdated, revokedDate, revokedReason, lastExpirationNagSent, notAfter, isExpired, issuerID FROM certificateStatus")
-	test.AssertNotError(t, err, "selecting")
-
-	if !rows.Next() {
-		t.Fatal("got no rows")
-	}
-
-	err = ScanCertStatusMetadataRow(rows, &certStatus)
-
-	if err == nil {
-		t.Fatal("expected error, got none")
-	}
-	expected = "incorrect column 1 in scanned rows: got \"status\", expected \"serial\""
-	if err.Error() != expected {
-		t.Errorf("wrong error: got %q, expected %q", err, expected)
-	}
-}
-
 func TestCertificatesTableContainsDuplicateSerials(t *testing.T) {
 	sa, fc, cleanUp := initSA(t)
 	defer cleanUp()

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -2152,8 +2152,8 @@ func (ssa *SQLStorageAuthority) SerialsForIncident(req *sapb.SerialsForIncidentR
 		return fmt.Errorf("malformed table name %q", req.IncidentTable)
 	}
 
-	selector := db.NewTypeSelector[incidentSerialModel](ssa.dbReadOnlyMap)
-	rows, err := selector.SelectRowsFrom(stream.Context(), req.IncidentTable, "")
+	selector := db.NewMappedSelector[incidentSerialModel](ssa.dbReadOnlyMap)
+	rows, err := selector.QueryFrom(stream.Context(), req.IncidentTable, "")
 	if err != nil {
 		return fmt.Errorf("starting db query: %w", err)
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -2153,47 +2152,17 @@ func (ssa *SQLStorageAuthority) SerialsForIncident(req *sapb.SerialsForIncidentR
 		return fmt.Errorf("malformed table name %q", req.IncidentTable)
 	}
 
-	// Retrieve the `*gorp.TableMap` for the incident table.
-	tableMap, err := ssa.dbMap.TableFor(reflect.TypeOf(incidentSerialModel{}), false)
+	selector := db.NewTypeSelector[incidentSerialModel](ssa.dbReadOnlyMap)
+	rows, err := selector.SelectRowsFrom(stream.Context(), req.IncidentTable, "")
 	if err != nil {
-		// This should never happen, the schema is always added at startup.
-		return fmt.Errorf(
-			"while retrieving table map for incident table %q: %s", req.IncidentTable, err)
-	}
-
-	// Use the `*gorp.TableMap` to construct a list of the expected column names
-	// for an incident table.
-	var modelColumns []string
-	for _, column := range tableMap.Columns {
-		modelColumns = append(modelColumns, column.ColumnName)
-	}
-
-	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(modelColumns, ", "), req.IncidentTable)
-	rows, err := ssa.dbMap.WithContext(stream.Context()).Query(query)
-	if err != nil {
-		return err
+		return fmt.Errorf("starting db query: %w", err)
 	}
 	defer rows.Close()
-
-	// Ensure that the columns in the model match the columns returned from the
-	// query. A mismatch indicates that the query returned a column that is
-	// either not in the model or not in the expected order.
-	dbColumns, err := rows.Columns()
-	if err != nil {
-		return err
-	}
-	for i, modelColumn := range dbColumns {
-		if modelColumns[i] != modelColumn {
-			return fmt.Errorf("incident table %q has column %q. Expected %q",
-				req.IncidentTable, modelColumns[i], modelColumn)
-		}
-	}
 
 	for rows.Next() {
 		// Scan the row into the model. Note: the fields must be passed in the
 		// same order as the columns returned by the query above.
-		var ism incidentSerialModel
-		err := rows.Scan(&ism.Serial, &ism.RegistrationID, &ism.OrderID, &ism.LastNoticeSent)
+		ism, err := rows.Get()
 		if err != nil {
 			return err
 		}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -2152,7 +2152,11 @@ func (ssa *SQLStorageAuthority) SerialsForIncident(req *sapb.SerialsForIncidentR
 		return fmt.Errorf("malformed table name %q", req.IncidentTable)
 	}
 
-	selector := db.NewMappedSelector[incidentSerialModel](ssa.dbReadOnlyMap)
+	selector, err := db.NewMappedSelector[incidentSerialModel](ssa.dbReadOnlyMap)
+	if err != nil {
+		return fmt.Errorf("initializing db map: %w", err)
+	}
+
 	rows, err := selector.QueryFrom(stream.Context(), req.IncidentTable, "")
 	if err != nil {
 		return fmt.Errorf("starting db query: %w", err)


### PR DESCRIPTION
Create a new type `db.MappedSelector` which exposes a new
`Query` method. This method behaves similar to gorp's
`SelectFoo` methods, in that it uses the desired result type to
look up the correct table to query and uses reflection to map
the table columns to the struct fields. It behaves similarly to
the stdlib's `sql.Query` in that it returns a `Rows` object which
can be iterated over to get one row of results at a time. And it
improves both of those by using generics, rather than `interface{}`,
to provide a nicely-typed calling interface.

Use this new type to simplify the existing streaming query in
`SerialsForIncident`. Similarly use the new type to simplify
rocsp-tool's and ocsp-updater's streams of `CertStatusMetadata`.
This new type will also be used by the crl-updater's upcoming
`GetRevokedCerts` streaming query.

Fixes #6173