### PR TITLE
entrypoint: fix quoting

### DIFF
--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -21,4 +21,4 @@ if [[ $# -eq 0 ]]; then
     exec python3 ./start.py
 fi
 
-exec $@
+exec "$@"


### PR DESCRIPTION
Expanding `$@` means that if a positional parameter has an internal
space, e.g. "foo bar", it will be split into two positional parameters
in the resulting command, e.g. "foo" "bar". Expanding `"$@"` ensures
that such parameters are quoted during expansion, so we still get
"foo bar" in the exec command, which is always what we wanted.