### PR TITLE
expiration-mailer: on send failure, log error

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -179,7 +179,7 @@ func (m *mailer) sendNags(conn bmail.Conn, contacts []string, certs []*x509.Cert
 	startSending := m.clk.Now()
 	err = conn.SendMail(emails, subjBuf.String(), msgBuf.String())
 	if err != nil {
-		m.log.Errf("failed send JSON=%s", string(logStr))
+		m.log.Errf("failed send JSON=%s err=%s", string(logStr), err)
 		return err
 	}
 	finishSending := m.clk.Now()


### PR DESCRIPTION
Previously we were logging only the parameters of the send, not the
resulting error.