### PR TITLE
Remove special-casing of EC padding parse error

### DIFF
--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -327,9 +327,6 @@ func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*jose.JSONWebSignature, *prob
 	parsedJWS, err := jose.ParseSigned(bodyStr)
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSParseError"}).Inc()
-		if strings.HasPrefix(err.Error(), "failed to unmarshal JWK: square/go-jose: invalid EC public key, wrong length") {
-			return nil, probs.Malformed("Parse error reading JWS: EC public key has incorrect padding")
-		}
 		return nil, probs.Malformed("Parse error reading JWS")
 	}
 	if len(parsedJWS.Signatures) > 1 {

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1597,14 +1597,3 @@ func TestMatchJWSURLs(t *testing.T) {
 		})
 	}
 }
-
-func TestBadPaddingError(t *testing.T) {
-	wfe, _ := setupWFE(t)
-
-	_, prob := wfe.parseJWS([]byte(`{"protected":"eyJhbGciOiJFUzI1NiIsImp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6Im5QVElBQmNEQVNZNkZOR1NOZkhDQjUxdFk3cUNodGd6ZVZhek90THJ3USIsInkiOiJ2RUVzNFYwZWdKa055TTJRNHBwMDAxenUxNFZjcFEwX0VpOHhPT1B4S1pzIn19","payload":""}`))
-	test.Assert(t, prob != nil, "parseJWS didn't return a problem")
-	test.AssertEquals(t, prob.Detail, "Parse error reading JWS: EC public key has incorrect padding")
-	_, prob = wfe.parseJWS([]byte(`{"protected":"eyJhbGciOiJFUzI1NiIsImp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InZFRXM0VjBlZ0prTnlNMlE0cHAwMDF6dTE0VmNwUTBfRWk4eE9PUHhLWnMiLCJ5IjoiblBUSUFCY0RBU1k2Rk5HU05mSENCNTF0WTdxQ2h0Z3plVmF6T3RMcndRIn19","payload":""}`))
-	test.Assert(t, prob != nil, "parseJWS didn't return a problem")
-	test.AssertEquals(t, prob.Detail, "Parse error reading JWS: EC public key has incorrect padding")
-}


### PR DESCRIPTION
This special casing was originally added to catch a bug where
the underlying library said that the EC *private* key was the
wrong length. We were also interested in exposing this specific
error to clients because EC key-length strictness was added to
go-jose and we wanted to ensure that upgrading to the new
version wouldn't break existing clients.

We are now several years past that upgrade, and hit this error
case very infrequently. There is no need to continue special-
casing it.