### PR TITLE
Clean up lint settings in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
-    # TODO(#6105): add 'gci' linter
     - gofmt
     - gosec
     - gosimple
@@ -10,14 +8,12 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     # TODO(#6104): Enable 'unparam' linter
     - unused
-    - varcheck
-    - wastedassign
+    # TODO(#6202): Re-enable 'wastedassign' linter
 linters-settings:
   errcheck:
     ignore: fmt:[FS]?[Pp]rint*,io:Write,os:Remove,net/http:Write,github.com/miekg/dns:WriteMsg,net:Write,encoding/binary:Write


### PR DESCRIPTION
structcheck and deadcode [are redundant with unused](https://github.com/golangci/golangci-lint/issues/1841).

wastedassign is currently disabled for Go 1.18.