### PR TITLE
Disallow affiliationChanged revocation reason

### DIFF
--- a/ca/crl_test.go
+++ b/ca/crl_test.go
@@ -222,15 +222,6 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Entry{
 			Entry: &corepb.CRLEntry{
-				Serial:    "333333333333333333333333333333333333",
-				Reason:    3, // affiliationChanged
-				RevokedAt: time.Now().UnixNano(),
-			},
-		},
-	}
-	ins <- &capb.GenerateCRLRequest{
-		Payload: &capb.GenerateCRLRequest_Entry{
-			Entry: &corepb.CRLEntry{
 				Serial:    "444444444444444444444444444444444444",
 				Reason:    4, // superseded
 				RevokedAt: time.Now().UnixNano(),
@@ -262,7 +253,7 @@ func TestGenerateCRL(t *testing.T) {
 	test.Assert(t, len(crlBytes) > 0, "should have gotten some CRL bytes")
 	crl, err = x509.ParseCRL(crlBytes)
 	test.AssertNotError(t, err, "should be able to parse empty CRL")
-	test.AssertEquals(t, len(crl.TBSCertList.RevokedCertificates), 6)
+	test.AssertEquals(t, len(crl.TBSCertList.RevokedCertificates), 5)
 	err = testCtx.boulderIssuers[0].Cert.CheckCRLSignature(crl)
 	test.AssertNotError(t, err, "CRL signature should validate")
 }

--- a/revocation/reasons.go
+++ b/revocation/reasons.go
@@ -31,7 +31,6 @@ var ReasonToString = map[Reason]string{
 var UserAllowedReasons = map[Reason]struct{}{
 	ocsp.Unspecified:          {},
 	ocsp.KeyCompromise:        {},
-	ocsp.AffiliationChanged:   {},
 	ocsp.Superseded:           {},
 	ocsp.CessationOfOperation: {},
 }
@@ -42,7 +41,6 @@ var UserAllowedReasons = map[Reason]struct{}{
 var AdminAllowedReasons = map[Reason]struct{}{
 	ocsp.Unspecified:          {},
 	ocsp.KeyCompromise:        {},
-	ocsp.AffiliationChanged:   {},
 	ocsp.Superseded:           {},
 	ocsp.CessationOfOperation: {},
 	ocsp.PrivilegeWithdrawn:   {},

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -710,8 +710,8 @@ def test_revoke_by_account_with_reason():
         else:
             raise(Exception("Revoked by applicant with reason keyCompromise"))
 
-        client.revoke(josepy.ComparableX509(cert), 3)
-        verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "revoked", "affiliationChanged")
+        client.revoke(josepy.ComparableX509(cert), 4)
+        verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "revoked", "superseded")
 
     verify_akamai_purge()
 
@@ -743,8 +743,8 @@ def test_revoke_by_authz():
         else:
             raise(Exception("Revoked by applicant with reason keyCompromise"))
 
-        client.revoke(josepy.ComparableX509(cert), 3)
-        verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "revoked", "affiliationChanged")
+        client.revoke(josepy.ComparableX509(cert), 4)
+        verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "revoked", "superseded")
 
     verify_akamai_purge()
 
@@ -792,8 +792,8 @@ def test_revoke_by_privkey():
 
     else:
         # Revocation should work for any reason.
-        revoke_client.revoke(josepy.ComparableX509(cert), 3)
-        verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "revoked", "affiliationChanged")
+        revoke_client.revoke(josepy.ComparableX509(cert), 4)
+        verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "revoked", "superseded")
 
     verify_akamai_purge()
 
@@ -1771,8 +1771,8 @@ def ocsp_resigning_setup():
 
     cert = OpenSSL.crypto.load_certificate(
         OpenSSL.crypto.FILETYPE_PEM, order.fullchain_pem)
-    # Revoke for reason 3: affiliationChanged
-    client.revoke(josepy.ComparableX509(cert), 3)
+    # Revoke for reason 5: cessationOfOperation
+    client.revoke(josepy.ComparableX509(cert), 5)
 
     ocsp_response, reason = get_ocsp_response_and_reason(
         cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002")
@@ -1802,5 +1802,5 @@ def test_ocsp_resigning():
     if reason != ocsp_resigning_setup_data['reason']:
         raise(Exception("re-signed ocsp response has different reason %s expected %s" % (
             reason, ocsp_resigning_setup_data['reason'])))
-    if reason != "affiliationChanged":
+    if reason != "cessationOfOperation":
         raise(Exception("re-signed ocsp response has wrong reason %s" % reason))

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3049,13 +3049,13 @@ func TestRevokeCertificateReasons(t *testing.T) {
 			Name:             "Unsupported reason",
 			Reason:           &reason2,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), affiliationChanged (3), superseded (4), cessationOfOperation (5)","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
 		},
 		{
 			Name:             "Non-existent reason",
 			Reason:           &reason100,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: unknown (100). Supported reasons: unspecified (0), keyCompromise (1), affiliationChanged (3), superseded (4), cessationOfOperation (5)","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: unknown (100). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
 		},
 	}
 


### PR DESCRIPTION
The `affiliationChanged` revocation reason is only relevant
to certificates which contain Subject Identity Information.
As we only issue DV certificates, which cannot contain such
information, our certificates should not be able to be revoked
for this reason.

See https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/m3-XPcVcJ9M