### PR TITLE
Update Boulder to go1.18.4

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.18.1_2022-05-19
+          - go1.18.4_2022-07-20
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,6 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
+          - go1.18.1_2022-05-19
           - go1.18.4_2022-07-20
         # Tests command definitions. Use the entire docker-compose command you want to run.
         tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # used for release builds. make-deb.sh relies on being able to parse the
     # numeric version between 'go' and the underscore-prefixed date. If you make
     # changes to these tokens, please update this parsing logic.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.18.1_2022-05-19}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.18.4_2022-07-20}
     environment:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -7,7 +7,7 @@ cd $(dirname $0)
 DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
 
-GO_VERSIONS=( "1.18.4" )
+GO_VERSIONS=( "1.18.1" "1.18.4" )
 
 echo "Please login to allow push to DockerHub"
 docker login

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -7,7 +7,7 @@ cd $(dirname $0)
 DATESTAMP=$(date +%Y-%m-%d)
 DOCKER_REPO="letsencrypt/boulder-tools"
 
-GO_VERSIONS=( "1.18.1" )
+GO_VERSIONS=( "1.18.4" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
Version go1.18.4 contains a number of security fixes related
to stack exhaustion in a variety of standard library packages,
some of which we (directly or indirectly) rely on.

Full release notes are at:
https://groups.google.com/g/golang-announce/c/nqrv9fbR0zE/m/3SeTTJs9AwAJ