### PR TITLE
notify-mailer: remove extraneous empty template

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -519,7 +519,7 @@ func main() {
 	cmd.FailOnError(err, "While initializing dbMap")
 
 	// Load and parse message body.
-	template, err := template.New("email").ParseFiles(*bodyFile)
+	template, err := template.ParseFiles(*bodyFile)
 	cmd.FailOnError(err, "Couldn't parse message template")
 
 	address, err := mail.ParseAddress(*from)


### PR DESCRIPTION
Fix the ""email" is an incomplete or empty template" error by removing
the "email" named template entirely, causing template execution to
automatically select the populated file template instead.

A template object can actually contain multiple different conceptual
templates, each associated with a name. Using `template.New("name")`
creates a new empty template with the name `name`. Using
`ParseFiles("filename")` creates another new template with the name
`filename`. It does not, as one might expect, simply populate the
already-named template.

When executing a template, if it contains multiple named templates, you
must either explicitly name the one you want (using `ExecuteTemplate`)
or it will by default pick the first one. Here, it was picking the empty
template named `email` because it was created first.

Fixes #6239