### PR TITLE
Simplify contact-auditor's query

### DIFF
--- a/cmd/contact-auditor/main.go
+++ b/cmd/contact-auditor/main.go
@@ -69,11 +69,10 @@ func validateContacts(id int64, createdAt string, contacts []string) error {
 // beginAuditQuery executes the audit query and returns a cursor used to
 // stream the results.
 func (c contactAuditor) beginAuditQuery() (*sql.Rows, error) {
-	rows, err := c.db.Query(
-		`SELECT DISTINCT r.id, r.contact, r.createdAt
-		FROM registrations AS r
-			INNER JOIN certificates AS c on c.registrationID = r.id
-		WHERE r.contact NOT IN ('[]', 'null');`)
+	rows, err := c.db.Query(`
+		SELECT DISTINCT id, contact, createdAt
+		FROM registrations
+		WHERE contact NOT IN ('[]', 'null');`)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -2,10 +2,6 @@ package notmain
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -18,7 +14,6 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/boulder/cmd"
-	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
@@ -42,29 +37,12 @@ const (
 	telNum    = "666-666-7777"
 )
 
-func TestMailAuditor(t *testing.T) {
+func TestContactAuditor(t *testing.T) {
 	testCtx := setup(t)
 	defer testCtx.cleanUp()
 
 	// Add some test registrations.
 	testCtx.addRegistrations(t)
-
-	// Should be 0 since we haven't added registrations.
-	resChan := make(chan *result, 10)
-	err := testCtx.c.run(resChan)
-	test.AssertNotError(t, err, "received error")
-	test.AssertEquals(t, len(resChan), 0)
-}
-
-func TestMailAuditorWithResults(t *testing.T) {
-	testCtx := setup(t)
-	defer testCtx.cleanUp()
-
-	// Add some test registrations.
-	testCtx.addRegistrations(t)
-
-	// Now add some certificates.
-	testCtx.addCertificates(t)
 
 	resChan := make(chan *result, 10)
 	err := testCtx.c.run(resChan)
@@ -198,130 +176,6 @@ func (tc testCtx) addRegistrations(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't store regC")
 	regD, err = tc.ssa.NewRegistration(ctx, regD)
 	test.AssertNotError(t, err, "Couldn't store regD")
-}
-
-func (tc testCtx) addCertificates(t *testing.T) {
-	serial1 := big.NewInt(1336)
-	serial1String := core.SerialToString(serial1)
-	serial2 := big.NewInt(1337)
-	serial2String := core.SerialToString(serial2)
-	serial3 := big.NewInt(1338)
-	serial3String := core.SerialToString(serial3)
-	serial4 := big.NewInt(1339)
-	serial4String := core.SerialToString(serial4)
-	n := bigIntFromB64("n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw==")
-	e := intFromB64("AQAB")
-	d := bigIntFromB64("bWUC9B-EFRIo8kpGfh0ZuyGPvMNKvYWNtB_ikiH9k20eT-O1q_I78eiZkpXxXQ0UTEs2LsNRS-8uJbvQ-A1irkwMSMkK1J3XTGgdrhCku9gRldY7sNA_AKZGh-Q661_42rINLRCe8W-nZ34ui_qOfkLnK9QWDDqpaIsA-bMwWWSDFu2MUBYwkHTMEzLYGqOe04noqeq1hExBTHBOBdkMXiuFhUq1BU6l-DqEiWxqg82sXt2h-LMnT3046AOYJoRioz75tSUQfGCshWTBnP5uDjd18kKhyv07lhfSJdrPdM5Plyl21hsFf4L_mHCuoFau7gdsPfHPxxjVOcOpBrQzwQ==")
-	p := bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
-	q := bigIntFromB64("uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc=")
-
-	testKey := rsa.PrivateKey{
-		PublicKey: rsa.PublicKey{N: n, E: e},
-		D:         d,
-		Primes:    []*big.Int{p, q},
-	}
-
-	fc := newFakeClock(t)
-
-	// Add one cert for RegA that expires in 30 days
-	rawCertA := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName: "happy A",
-		},
-		NotAfter:     fc.Now().Add(30 * 24 * time.Hour),
-		DNSNames:     []string{"example-a.com"},
-		SerialNumber: serial1,
-	}
-	certDerA, _ := x509.CreateCertificate(rand.Reader, &rawCertA, &rawCertA, &testKey.PublicKey, &testKey)
-	certA := &core.Certificate{
-		RegistrationID: regA.Id,
-		Serial:         serial1String,
-		Expires:        rawCertA.NotAfter,
-		DER:            certDerA,
-	}
-	err := tc.dbMap.Insert(certA)
-	test.AssertNotError(t, err, "Couldn't add certA")
-	_, err = tc.dbMap.Exec(
-		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
-		"com.example-a",
-		serial1String,
-	)
-	test.AssertNotError(t, err, "Couldn't add issued name for certA")
-
-	// Add one cert for RegB that already expired 30 days ago
-	rawCertB := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName: "happy B",
-		},
-		NotAfter:     fc.Now().Add(-30 * 24 * time.Hour),
-		DNSNames:     []string{"example-b.com"},
-		SerialNumber: serial2,
-	}
-	certDerB, _ := x509.CreateCertificate(rand.Reader, &rawCertB, &rawCertB, &testKey.PublicKey, &testKey)
-	certB := &core.Certificate{
-		RegistrationID: regB.Id,
-		Serial:         serial2String,
-		Expires:        rawCertB.NotAfter,
-		DER:            certDerB,
-	}
-	err = tc.dbMap.Insert(certB)
-	test.AssertNotError(t, err, "Couldn't add certB")
-	_, err = tc.dbMap.Exec(
-		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
-		"com.example-b",
-		serial2String,
-	)
-	test.AssertNotError(t, err, "Couldn't add issued name for certB")
-
-	// Add one cert for RegC that expires in 30 days
-	rawCertC := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName: "happy C",
-		},
-		NotAfter:     fc.Now().Add(30 * 24 * time.Hour),
-		DNSNames:     []string{"example-c.com"},
-		SerialNumber: serial3,
-	}
-	certDerC, _ := x509.CreateCertificate(rand.Reader, &rawCertC, &rawCertC, &testKey.PublicKey, &testKey)
-	certC := &core.Certificate{
-		RegistrationID: regC.Id,
-		Serial:         serial3String,
-		Expires:        rawCertC.NotAfter,
-		DER:            certDerC,
-	}
-	err = tc.dbMap.Insert(certC)
-	test.AssertNotError(t, err, "Couldn't add certC")
-	_, err = tc.dbMap.Exec(
-		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
-		"com.example-c",
-		serial3String,
-	)
-	test.AssertNotError(t, err, "Couldn't add issued name for certC")
-
-	// Add one cert for RegD that expires in 30 days
-	rawCertD := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName: "happy D",
-		},
-		NotAfter:     fc.Now().Add(30 * 24 * time.Hour),
-		DNSNames:     []string{"example-d.com"},
-		SerialNumber: serial4,
-	}
-	certDerD, _ := x509.CreateCertificate(rand.Reader, &rawCertD, &rawCertD, &testKey.PublicKey, &testKey)
-	certD := &core.Certificate{
-		RegistrationID: regD.Id,
-		Serial:         serial4String,
-		Expires:        rawCertD.NotAfter,
-		DER:            certDerD,
-	}
-	err = tc.dbMap.Insert(certD)
-	test.AssertNotError(t, err, "Couldn't add certD")
-	_, err = tc.dbMap.Exec(
-		"INSERT INTO issuedNames (reversedName, serial, notBefore) VALUES (?,?,0)",
-		"com.example-d",
-		serial4String,
-	)
-	test.AssertNotError(t, err, "Couldn't add issued name for certD")
 }
 
 func setup(t *testing.T) testCtx {

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -2,10 +2,8 @@ package notmain
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"net"
 	"os"
 	"strings"
@@ -220,26 +218,4 @@ func setup(t *testing.T) testCtx {
 		ssa:     ssa,
 		cleanUp: cleanUp,
 	}
-}
-
-func bigIntFromB64(b64 string) *big.Int {
-	bytes, _ := base64.URLEncoding.DecodeString(b64)
-	x := big.NewInt(0)
-	x.SetBytes(bytes)
-	return x
-}
-
-func intFromB64(b64 string) int {
-	return int(bigIntFromB64(b64).Int64())
-}
-
-func newFakeClock(t *testing.T) clock.FakeClock {
-	const fakeTimeFormat = "2006-01-02T15:04:05.999999999Z"
-	ft, err := time.Parse(fakeTimeFormat, fakeTimeFormat)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fc := clock.NewFake()
-	fc.Set(ft.UTC())
-	return fc
 }


### PR DESCRIPTION
The inner join was not being used for anything, as no
columns from the certificates table were included in
either the SELECT or WHERE clauses.

Fixes #6230