### PR TITLE
Don't panic on duplicate db metrics

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -72,10 +72,15 @@ func InitWrappedDb(config cmd.DBConfig, scope prometheus.Registerer, logger blog
 	}
 
 	addr, user, err := config.DSNAddressAndUser()
-	cmd.FailOnError(err, "while parsing DSN")
+	if err != nil {
+		return nil, fmt.Errorf("while parsing DSN: %w", err)
+	}
 
 	if scope != nil {
-		InitDBMetrics(dbMap.Db, scope, settings, addr, user)
+		err = InitDBMetrics(dbMap.Db, scope, settings, addr, user)
+		if err != nil {
+			return nil, fmt.Errorf("while initializing metrics: %w", err)
+		}
 	}
 	return dbMap, nil
 }
@@ -114,7 +119,9 @@ func InitSqlDb(config cmd.DBConfig, scope prometheus.Registerer) (*sql.DB, error
 	db.SetConnMaxIdleTime(config.ConnMaxIdleTime.Duration)
 
 	addr, user, err := config.DSNAddressAndUser()
-	cmd.FailOnError(err, "while parsing DSN")
+	if err != nil {
+		return nil, fmt.Errorf("while parsing DSN: %w", err)
+	}
 
 	if scope != nil {
 		settings := DbSettings{
@@ -123,7 +130,10 @@ func InitSqlDb(config cmd.DBConfig, scope prometheus.Registerer) (*sql.DB, error
 			ConnMaxLifetime: config.ConnMaxLifetime.Duration,
 			ConnMaxIdleTime: config.ConnMaxIdleTime.Duration,
 		}
-		InitDBMetrics(db, scope, settings, addr, user)
+		err = InitDBMetrics(db, scope, settings, addr, user)
+		if err != nil {
+			return nil, fmt.Errorf("while initializing metrics: %w", err)
+		}
 	}
 	return db, nil
 }

--- a/sa/metrics.go
+++ b/sa/metrics.go
@@ -64,7 +64,7 @@ func (dbc dbMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 // InitDBMetrics will register a Collector that translates the provided dbMap's
 // stats and DbSettings into Prometheus metrics on the fly. The stat values will
 // be translated from the gorp dbMap's inner sql.DBMap's DBStats structure values
-func InitDBMetrics(db *sql.DB, stats prometheus.Registerer, dbSettings DbSettings, address string, user string) {
+func InitDBMetrics(db *sql.DB, stats prometheus.Registerer, dbSettings DbSettings, address string, user string) error {
 	// Create a dbMetricsCollector and register it
 	dbc := dbMetricsCollector{db: db, dbSettings: dbSettings}
 
@@ -125,5 +125,5 @@ func InitDBMetrics(db *sql.DB, stats prometheus.Registerer, dbSettings DbSetting
 		"Total number of connections closed due to SetConnMaxLifetime.",
 		nil, labels)
 
-	stats.MustRegister(dbc)
+	return stats.Register(dbc)
 }


### PR DESCRIPTION
Use `prometheus.Register` instead of `.MustRegister` when
setting up database metrics. This allows us to capture and
return up the call-chain any errors encountered during metric
initialization. While this does not actually help mitigate or
prevent any future duplicate-metrics errors, it will make them
easier to debug by surfacing them as well-formed errors rather
than simply stack-traces.

Fixes #6150