### PR TITLE
Fix CA CRL log lines

### DIFF
--- a/ca/crl.go
+++ b/ca/crl.go
@@ -120,11 +120,14 @@ func (ci *crlImpl) GenerateCRL(stream capb.CRLGenerator_GenerateCRLServer) error
 		}
 		fmt.Fprintf(&builder, "%x:%d,", rcs[i].SerialNumber.Bytes(), reason)
 
-		if builder.Len() != ci.maxLogLen {
+		if builder.Len() >= ci.maxLogLen {
+			fmt.Fprint(&builder, "]")
 			ci.log.AuditInfo(builder.String())
 			builder = strings.Builder{}
 		}
 	}
+	fmt.Fprint(&builder, "]")
+	ci.log.AuditInfo(builder.String())
 
 	template.RevokedCertificates = rcs
 


### PR DESCRIPTION
Add a closing bracket both when ending a line due to max log length
and when ending a line due to the end of the entry list. Change the
max log length check to a greater-than to prevent it from incorrectly
firing every time.