### PR TITLE
rocsp: use better buckets

### DIFF
--- a/rocsp/rocsp.go
+++ b/rocsp/rocsp.go
@@ -45,6 +45,8 @@ func NewClient(
 		prometheus.HistogramOpts{
 			Name: "rocsp_get_latency",
 			Help: "Histogram of latencies of rocsp.GetResponse calls with result",
+			// 8 buckets, ranging from 0.5ms to 2s
+			Buckets: prometheus.ExponentialBucketsRange(0.0005, 2, 8),
 		},
 		[]string{"result"},
 	)


### PR DESCRIPTION
In practice Redis queries often complete in under 1ms, but we were using
the default Prometheus histogram buckets, the lowest of which is 5ms.
That means we don't get very detailed latency information from this
histogram. Use a smaller value (0.5ms) for the lowest bucket.