### PR TITLE
redis-create.sh: run `exec` on the last line

### DIFF
--- a/test/redis-create.sh
+++ b/test/redis-create.sh
@@ -27,4 +27,4 @@ fi
 # The Boulder container will wait for this port on this container to be
 # available before starting up.
 echo "Starting a server so everything knows we're done."
-redis-server /test/redis.config
+exec redis-server /test/redis.config


### PR DESCRIPTION
Previously, when shutting down a `docker-compose` stack,
bredis_clusterer would take 10s to shut down. This decreases the time to
0.4s.

I believe this is because docker-compose was killing `bash` and waiting
for its children to die (they weren't), then hitting a timeout and hard
killing the container. Now, since `exec` replaces the current pid,
docker-compose can kill redis-server directly.