### PR TITLE
multi_source: copy deadline from original context

### DIFF
--- a/ocsp/responder/live/live.go
+++ b/ocsp/responder/live/live.go
@@ -34,6 +34,9 @@ func (s *Source) Response(ctx context.Context, req *ocsp.Request) (*responder.Re
 		return nil, err
 	}
 	defer s.sem.Release(1)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	resp, err := s.ra.GenerateOCSP(ctx, &rapb.GenerateOCSPRequest{
 		Serial: core.SerialToString(req.SerialNumber),

--- a/ocsp/responder/multi_source.go
+++ b/ocsp/responder/multi_source.go
@@ -63,7 +63,7 @@ func (src *multiSource) Response(ctx context.Context, req *ocsp.Request) (*Respo
 	redisCtx := context.Background()
 	deadline, ok := ctx.Deadline()
 	if ok {
-		// We don't call the CancelFunc returnwed by WithDeadline because it
+		// We don't call the CancelFunc returned by WithDeadline because it
 		// would defeat the purpose. That leaks the context, but only until
 		// the deadline is reached.
 		////nolint:govet

--- a/ocsp/responder/multi_source.go
+++ b/ocsp/responder/multi_source.go
@@ -60,7 +60,15 @@ func (src *multiSource) Response(ctx context.Context, req *ocsp.Request) (*Respo
 	// from reaching the backend layer (Redis) and causing connections to be closed
 	// unnecessarily.
 	// https://blog.uptrace.dev/posts/go-context-timeout.html
-	secondaryChan := getResponse(context.Background(), src.secondary, req)
+	redisCtx := context.Background()
+	cancel := func() {}
+	deadline, ok := ctx.Deadline()
+	if ok {
+		redisCtx, cancel = context.WithDeadline(redisCtx, deadline)
+	}
+	defer cancel()
+
+	secondaryChan := getResponse(redisCtx, src.secondary, req)
 
 	var primaryResponse *Response
 

--- a/ocsp/responder/multi_source.go
+++ b/ocsp/responder/multi_source.go
@@ -61,12 +61,14 @@ func (src *multiSource) Response(ctx context.Context, req *ocsp.Request) (*Respo
 	// unnecessarily.
 	// https://blog.uptrace.dev/posts/go-context-timeout.html
 	redisCtx := context.Background()
-	cancel := func() {}
 	deadline, ok := ctx.Deadline()
 	if ok {
-		redisCtx, cancel = context.WithDeadline(redisCtx, deadline)
+		// We don't call the CancelFunc returnwed by WithDeadline because it
+		// would defeat the purpose. That leaks the context, but only until
+		// the deadline is reached.
+		////nolint:govet
+		redisCtx, _ = context.WithDeadline(redisCtx, deadline)
 	}
-	defer cancel()
 
 	secondaryChan := getResponse(redisCtx, src.secondary, req)
 


### PR DESCRIPTION
This prevents a memory leak when rate of requests that require signing
exceeds the ability of the `live.Source` to sign them. Such requests
were getting stuck in semaphore.Weighted.Acquire with a context that had
no deadline.