### PR TITLE
crl-updater: add UpdateOffset config to run on a schedule

### DIFF
--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -54,7 +54,8 @@ type Config struct {
 		// UpdateOffset controls the times at which crl-updater runs, to avoid
 		// scheduling the batch job at exactly midnight. The updater runs every
 		// UpdatePeriod, starting from the Unix Epoch plus UpdateOffset, and
-		// continuing forward into the future forever.
+		// continuing forward into the future forever. This value is clamped to the
+		// interval [0, UpdatePeriod] (i.e. it cannot be greater than UpdatePeriod.)
 		UpdateOffset cmd.ConfigDuration
 
 		// MaxParallelism controls how many workers may be running in parallel.

--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -72,6 +72,7 @@ type Config struct {
 
 func main() {
 	configFile := flag.String("config", "", "File path to the configuration file for this service")
+	runOnce := flag.Bool("runOnce", false, "If true, run once immediately and then exit")
 	flag.Parse()
 	if *configFile == "" {
 		flag.Usage()
@@ -134,7 +135,12 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go cmd.CatchSignals(logger, cancel)
-	u.Run(ctx)
+
+	if *runOnce {
+		u.Tick(ctx)
+	} else {
+		u.Run(ctx)
+	}
 }
 
 func init() {

--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -54,8 +54,8 @@ type Config struct {
 		// UpdateOffset controls the times at which crl-updater runs, to avoid
 		// scheduling the batch job at exactly midnight. The updater runs every
 		// UpdatePeriod, starting from the Unix Epoch plus UpdateOffset, and
-		// continuing forward into the future forever. This value is clamped to the
-		// interval [0, UpdatePeriod] (i.e. it cannot be greater than UpdatePeriod.)
+		// continuing forward into the future forever. This value must be strictly
+		// less than the UpdatePeriod.
 		UpdateOffset cmd.ConfigDuration
 
 		// MaxParallelism controls how many workers may be running in parallel.

--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -51,6 +51,12 @@ type Config struct {
 		// recommend an UpdatePeriod of 6 hours.
 		UpdatePeriod cmd.ConfigDuration
 
+		// UpdateOffset controls the times at which crl-updater runs, to avoid
+		// scheduling the batch job at exactly midnight. The updater runs every
+		// UpdatePeriod, starting from the Unix Epoch plus UpdateOffset, and
+		// continuing forward into the future forever.
+		UpdateOffset cmd.ConfigDuration
+
 		// MaxParallelism controls how many workers may be running in parallel.
 		// A higher value reduces the total time necessary to update all CRL shards
 		// that this updater is responsible for, but also increases the memory used
@@ -116,6 +122,7 @@ func main() {
 		c.CRLUpdater.NumShards,
 		c.CRLUpdater.CertificateLifetime.Duration,
 		c.CRLUpdater.UpdatePeriod.Duration,
+		c.CRLUpdater.UpdateOffset.Duration,
 		c.CRLUpdater.MaxParallelism,
 		sac,
 		cac,

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -141,7 +141,7 @@ func (cu *crlUpdater) Run(ctx context.Context) {
 	// Tick once immediately, but create the ticker first so that it starts
 	// counting from the appropriate time.
 	ticker := time.NewTicker(cu.updatePeriod)
-	cu.tick(ctx)
+	cu.Tick(ctx)
 
 	for {
 		// If we have overrun *and* been canceled, both of the below cases could be
@@ -152,7 +152,7 @@ func (cu *crlUpdater) Run(ctx context.Context) {
 		}
 		select {
 		case <-ticker.C:
-			cu.tick(ctx)
+			cu.Tick(ctx)
 		case <-ctx.Done():
 			ticker.Stop()
 			return
@@ -160,7 +160,7 @@ func (cu *crlUpdater) Run(ctx context.Context) {
 	}
 }
 
-func (cu *crlUpdater) tick(ctx context.Context) {
+func (cu *crlUpdater) Tick(ctx context.Context) {
 	atTime := cu.clk.Now()
 	result := "success"
 	defer func() {

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -22,6 +22,7 @@ type crlUpdater struct {
 	lookbackPeriod    time.Duration
 	lookforwardPeriod time.Duration
 	updatePeriod      time.Duration
+	updateOffset      time.Duration
 	maxParallelism    int
 
 	sa sapb.StorageAuthorityClient
@@ -40,6 +41,7 @@ func NewUpdater(
 	numShards int,
 	certLifetime time.Duration,
 	updatePeriod time.Duration,
+	updateOffset time.Duration,
 	maxParallelism int,
 	sa sapb.StorageAuthorityClient,
 	ca capb.CRLGeneratorClient,
@@ -105,6 +107,7 @@ func NewUpdater(
 		lookbackPeriod,
 		lookforwardPeriod,
 		updatePeriod,
+		updateOffset,
 		maxParallelism,
 		sa,
 		ca,
@@ -119,11 +122,34 @@ func NewUpdater(
 // on the frequency specified by crlUpdater.updatePeriod. The provided context
 // can be used to gracefully stop (cancel) the process.
 func (cu *crlUpdater) Run(ctx context.Context) {
-	// TODO(#6163): Should there also be a configurable per-run timeout, to
-	// prevent overruns, used in a context.WithTimeout here?
-	cu.tick(ctx)
+	// We don't want the times at which crl-updater runs to be dependent on when
+	// the process starts. So wait until the appropriate time before kicking off
+	// the first run and the main ticker loop.
+	currOffset := cu.clk.Now().UnixNano() % cu.updatePeriod.Nanoseconds()
+	var waitNanos int64
+	if currOffset <= cu.updateOffset.Nanoseconds() {
+		waitNanos = cu.updateOffset.Nanoseconds() - currOffset
+	} else {
+		waitNanos = cu.updatePeriod.Nanoseconds() - currOffset + cu.updateOffset.Nanoseconds()
+	}
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(time.Duration(waitNanos)):
+	}
+
+	// Tick once immediately, but create the ticker first so that it starts
+	// counting from the appropriate time.
 	ticker := time.NewTicker(cu.updatePeriod)
+	cu.tick(ctx)
+
 	for {
+		// If we have overrun *and* been canceled, both of the below cases could be
+		// selectable at the same time, so check for context cancellation first.
+		if ctx.Err() != nil {
+			ticker.Stop()
+			return
+		}
 		select {
 		case <-ticker.C:
 			cu.tick(ctx)

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -62,6 +62,10 @@ func NewUpdater(
 		return nil, fmt.Errorf("must update CRLs at least every 7 days, got: %s", updatePeriod)
 	}
 
+	if updateOffset > updatePeriod {
+		updateOffset = updatePeriod
+	}
+
 	// Set the lookback period to be significantly greater than the update period.
 	// This guarantees that a certificate which was revoked very shortly before it
 	// expired will still appear on at least one CRL, as required by RFC 5280

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -29,8 +29,9 @@ type crlUpdater struct {
 	ca capb.CRLGeneratorClient
 	// TODO(#6162): Add a crl-storer gRPC client.
 
-	tickHistogram    *prometheus.HistogramVec
-	generatedCounter *prometheus.CounterVec
+	tickHistogram       *prometheus.HistogramVec
+	generatedCounter    *prometheus.CounterVec
+	secondsSinceSuccess *prometheus.GaugeVec
 
 	log blog.Logger
 	clk clock.Clock
@@ -103,6 +104,12 @@ func NewUpdater(
 	}, []string{"result"})
 	stats.MustRegister(generatedCounter)
 
+	secondsSinceSuccess := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "crl_updater_secs_since_success",
+		Help: "The number of seconds since crl-updater last succeeded labeled by issuer",
+	}, []string{"issuer"})
+	stats.MustRegister(secondsSinceSuccess)
+
 	// TODO(#6162): Add a storedCounter when sending to the crl-storer.
 
 	return &crlUpdater{
@@ -117,6 +124,7 @@ func NewUpdater(
 		ca,
 		tickHistogram,
 		generatedCounter,
+		secondsSinceSuccess,
 		log,
 		clk,
 	}, nil

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -63,8 +63,8 @@ func NewUpdater(
 		return nil, fmt.Errorf("must update CRLs at least every 7 days, got: %s", updatePeriod)
 	}
 
-	if updateOffset > updatePeriod {
-		updateOffset = updatePeriod
+	if updateOffset >= updatePeriod {
+		return nil, fmt.Errorf("update offset must be less than period: %s !< %s", updateOffset, updatePeriod)
 	}
 
 	// Set the lookback period to be significantly greater than the update period.

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -22,6 +22,7 @@
     "numShards": 10,
     "certificateLifetime": "2160h",
     "updatePeriod": "6h",
+    "updateOffset": "9120s",
     "maxParallelism": 10
   },
 

--- a/test/config/crl-updater.json
+++ b/test/config/crl-updater.json
@@ -22,6 +22,7 @@
     "numShards": 10,
     "certificateLifetime": "2160h",
     "updatePeriod": "6h",
+    "updateOffset": "9120s",
     "maxParallelism": 10
   },
 


### PR DESCRIPTION
Add a new config key `UpdateOffset` to crl-updater, which causes it to
run on a regular schedule rather than running immediately upon startup
and then every `UpdatePeriod` after that. It is safe for this new config
key to be omitted and take the default zero value.

Also add a new command line flag `runOnce` to crl-updater which causes
it to immediately run a single time and then exit, rather than running
continuously as a daemon. This will be useful for integration tests and
emergency situations.

Part of #6163