### PR TITLE
RA: Implement leaky bucket for duplicate certificate limit

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1376,7 +1376,7 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx contex
 		return nil
 	}
 
-	issuanceTimestampsInWindow, err := ra.SA.FQDNSetTimestampsForWindow(ctx, &sapb.CountFQDNSetsRequest{
+	issuance, err := ra.SA.FQDNSetTimestampsForWindow(ctx, &sapb.CountFQDNSetsRequest{
 		Domains: names,
 		Window:  limit.Window.Duration.Nanoseconds(),
 	})
@@ -1384,16 +1384,28 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx contex
 		return fmt.Errorf("checking duplicate certificate limit for %q: %s", names, err)
 	}
 
-	if int64(len(issuanceTimestampsInWindow.Timestamps)) >= threshold {
-		// FQDNSetTimestampsForWindow returns the issuance timestamps in
-		// ascending order so we can assume that the first one is the oldest.
-		retryAfter := time.Unix(0, issuanceTimestampsInWindow.Timestamps[0]).Add(limit.Window.Duration)
+	if int64(len(issuance.Timestamps)) < threshold {
+		// Issuance in window is below the threshold, no need to limit.
+		return nil
+	} else {
+		// Evaluate the rate limit using a leaky bucket algorithm. The bucket
+		// has a capacity of threshold and is refilled at a rate of 1 token per
+		// limit.Window/threshold from the time of each issuance timestamp.
+		nsPerToken := limit.Window.Nanoseconds() / threshold
+		for i, timestamp := range issuance.Timestamps {
+			nsUntilNextToken := int64(i+1) * nsPerToken
+			nsSinceIssuance := ra.clk.Now().Sub(time.Unix(0, timestamp)).Nanoseconds()
+			if nsSinceIssuance > nsUntilNextToken {
+				// Found a token.
+				return nil
+			}
+		}
+		retryTime := ra.clk.Now().Add(time.Duration(nsPerToken) - ra.clk.Now().Sub(time.Unix(0, issuance.Timestamps[0])))
 		return berrors.DuplicateCertificateError(
 			"too many certificates (%d) already issued for this exact set of domains in the last %.0f hours: %s, retry after %s",
-			threshold, limit.Window.Duration.Hours(), strings.Join(names, ","), retryAfter.Format(time.RFC3339),
+			threshold, limit.Window.Duration.Hours(), strings.Join(names, ","), retryTime.Format(time.RFC3339),
 		)
 	}
-	return nil
 }
 
 func (ra *RegistrationAuthorityImpl) checkLimits(ctx context.Context, names []string, regID int64) error {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -698,7 +698,7 @@ func (ssa *SQLStorageAuthority) CountFQDNSets(ctx context.Context, req *sapb.Cou
 
 // FQDNSetTimestampsForWindow returns the issuance timestamps for each
 // certificate, issued for a set of domains, during a given window of time, in
-// ascending order.
+// descending order.
 func (ssa *SQLStorageAuthority) FQDNSetTimestampsForWindow(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Timestamps, error) {
 	if req.Window == 0 || len(req.Domains) == 0 {
 		return nil, errIncompleteRequest
@@ -712,7 +712,7 @@ func (ssa *SQLStorageAuthority) FQDNSetTimestampsForWindow(ctx context.Context, 
 		`SELECT issued FROM fqdnSets 
 		WHERE setHash = ?
 		AND issued > ?
-		ORDER BY issued ASC`,
+		ORDER BY issued DESC`,
 		HashNames(req.Domains),
 		ssa.clk.Now().Add(-time.Duration(req.Window)),
 	)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -697,8 +697,8 @@ func (ssa *SQLStorageAuthority) CountFQDNSets(ctx context.Context, req *sapb.Cou
 }
 
 // FQDNSetTimestampsForWindow returns the issuance timestamps for each
-// certificate, issued for a set of domains, during a given window of time, in
-// descending order.
+// certificate, issued for a set of domains, during a given window of time,
+// starting from the most recent issuance.
 func (ssa *SQLStorageAuthority) FQDNSetTimestampsForWindow(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Timestamps, error) {
 	if req.Window == 0 || len(req.Domains) == 0 {
 		return nil, errIncompleteRequest

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -50,7 +50,7 @@ certificatesPerFQDNSet:
     ecdsa.le.wtf: 10000
     must-staple.le.wtf: 10000
 certificatesPerFQDNSetFast:
-  window: 2h
+  window: 3h
   threshold: 2
   overrides:
     le.wtf: 100


### PR DESCRIPTION
- Modify `ra.checkCertificatesPerFQDNSetLimit()` to use a leaky bucket algorithm
- Return issuance timestamps from `sa.FQDNSetTimestampsForWindow()` in descending order

Resolves #6154