### PR TITLE
RA: Reject emails that end with '#'

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -471,7 +471,7 @@ func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, conta
 		if parsed.RawQuery != "" || contact[len(contact)-1] == '?' {
 			return berrors.InvalidEmailError("contact email %q contains a question mark", contact)
 		}
-		if parsed.Fragment != "" {
+		if parsed.Fragment != "" || contact[len(contact)-1] == '#' {
 			return berrors.InvalidEmailError("contact email %q contains a '#'", contact)
 		}
 		if !core.IsASCII(contact) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -419,6 +419,9 @@ func TestValidateContacts(t *testing.T) {
 	err = ra.validateContacts(context.Background(), []string{"mailto:example@a.com?"})
 	test.AssertError(t, err, "No hfields in email")
 
+	err = ra.validateContacts(context.Background(), []string{"mailto:example@a.com#"})
+	test.AssertError(t, err, "No fragment")
+
 	err = ra.validateContacts(context.Background(), []string{"mailto:example@a.com#optional"})
 	test.AssertError(t, err, "No fragment")
 


### PR DESCRIPTION
The Fragment field of a parsed URL is only non-empty if there is
text following the octothorpe character. Check for the case that
the mailto: address ends in an octothorpe with no trailing value.

Fixes #6231