### PR TITLE
Fix unproblematic race in parallel notify-mailer

### DIFF
--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -109,9 +109,6 @@ func sortAddresses(input addressToRecipientMap) []string {
 func (m *mailer) makeMessageBody(recipients []recipient) (string, error) {
 	var messageBody strings.Builder
 
-	// Ensure that in the event of a missing key, an informative error is
-	// returned.
-	m.emailTemplate.Option("missingkey=error")
 	err := m.emailTemplate.Execute(&messageBody, recipients)
 	if err != nil {
 		return "", err
@@ -554,6 +551,10 @@ func main() {
 	// Load and parse message body.
 	template, err := template.ParseFiles(*bodyFile)
 	cmd.FailOnError(err, "Couldn't parse message template")
+
+	// Ensure that in the event of a missing key, an informative error is
+	// returned.
+	template.Option("missingkey=error")
 
 	address, err := mail.ParseAddress(*from)
 	cmd.FailOnError(err, fmt.Sprintf("Couldn't parse %q to address", *from))

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -234,7 +234,7 @@ func TestMakeMessageBody(t *testing.T) {
 	m := &mailer{
 		log:           blog.UseMock(),
 		mailer:        &mocks.Mailer{},
-		emailTemplate: template.Must(template.New("email").Parse(emailTemplate)),
+		emailTemplate: template.Must(template.New("email").Parse(emailTemplate)).Option("missingkey=error"),
 		sleepInterval: 0,
 		targetRange:   interval{end: "\xFF"},
 		clk:           newFakeClock(t),


### PR DESCRIPTION
The newly-parallel notify-mailer has a potential race where multiple
goroutines all try to set an option on the email template at the same
time. This is not an issue, as they're all setting the same option, but
fix it anyway by moving that option-setting to before the parallelism
begins.