### PR TITLE
Enable early ROCSP stages in integration tests

### DIFF
--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -42,6 +42,8 @@
     "debugAddr": ":8005",
     "requiredSerialPrefixes": ["ff"],
     "features": {
+      "ROCSPStage1": true,
+      "ROCSPStage2": true,
       "ROCSPStage3": true
     }
   },


### PR DESCRIPTION
For some reason ROCSPStage3 was enabled without also enabling
ROCSP Stages 1 and 2. Fix the oversight so we're actually running
all of the first three ROCSP stages in config-next integration tests.