### PR TITLE
ROCSP Stage 6: Never write OCSP responses to DB

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -40,11 +40,12 @@ func _() {
 	_ = x[ROCSPStage1-29]
 	_ = x[ROCSPStage2-30]
 	_ = x[ROCSPStage3-31]
+	_ = x[ROCSPStage6-32]
 }
 
-const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsV1DisableNewValidationsExpirationMailerDontLookTwiceCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndexCheckFailedAuthorizationsFirstAllowReRevocationMozRevocationReasonsOldTLSOutboundOldTLSInboundSHA1CSRsAllowUnrecognizedFeaturesRejectDuplicateCSRExtensionsROCSPStage1ROCSPStage2ROCSPStage3"
+const _FeatureFlag_name = "unusedPrecertificateRevocationStripDefaultSchemePortNonCFSSLSignerStoreIssuerInfoStreamlineOrderAndAuthzsV1DisableNewValidationsExpirationMailerDontLookTwiceCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETAllowV1RegistrationStoreRevokerInfoRestrictRSAKeySizesFasterNewOrdersRateLimitECDSAForAllServeRenewalInfoGetAuthzReadOnlyGetAuthzUseIndexCheckFailedAuthorizationsFirstAllowReRevocationMozRevocationReasonsOldTLSOutboundOldTLSInboundSHA1CSRsAllowUnrecognizedFeaturesRejectDuplicateCSRExtensionsROCSPStage1ROCSPStage2ROCSPStage3ROCSPStage6"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 128, 157, 177, 190, 204, 222, 240, 259, 275, 294, 318, 329, 345, 361, 377, 407, 424, 444, 458, 471, 479, 504, 532, 543, 554, 565}
+var _FeatureFlag_index = [...]uint16{0, 6, 30, 52, 66, 81, 105, 128, 157, 177, 190, 204, 222, 240, 259, 275, 294, 318, 329, 345, 361, 377, 407, 424, 444, 458, 471, 479, 504, 532, 543, 554, 565, 576}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -112,6 +112,11 @@ const (
 	// than what's stored in Redis, we'll trigger a fresh signing and serve and
 	// store the result.
 	ROCSPStage3
+	// ROCSPStage6 disables writing full OCSP Responses to MariaDB during
+	// (pre)certificate issuance and during revocation. Because Stage 4 involved
+	// disabling ocsp-updater, this means that no ocsp response bytes will be
+	// written to the database anymore.
+	ROCSPStage6
 )
 
 // List of features and their default value, protected by fMu
@@ -148,6 +153,7 @@ var features = map[FeatureFlag]bool{
 	ROCSPStage1:                    false,
 	ROCSPStage2:                    false,
 	ROCSPStage3:                    false,
+	ROCSPStage6:                    false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/sa/precertificates_test.go
+++ b/sa/precertificates_test.go
@@ -106,58 +106,65 @@ func TestAddPrecertificate(t *testing.T) {
 
 	reg := createWorkingRegistration(t, sa)
 
-	addPrecert := func(expectIssuedNamesUpdate bool) {
-		// Create a throw-away self signed certificate with a random name and
-		// serial number
-		serial, testCert := test.ThrowAwayCert(t, 1)
+	// Create a throw-away self signed certificate with a random name and
+	// serial number
+	serial, testCert := test.ThrowAwayCert(t, 1)
 
-		// Add the cert as a precertificate
-		ocspResp := []byte{0, 0, 1}
-		regID := reg.Id
-		issuedTime := time.Date(2018, 4, 1, 7, 0, 0, 0, time.UTC)
-		_, err := sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
-			Der:      testCert.Raw,
-			RegID:    regID,
-			Ocsp:     ocspResp,
-			Issued:   issuedTime.UnixNano(),
-			IssuerID: 1,
-		})
-		test.AssertNotError(t, err, "Couldn't add test cert")
+	// Add the cert as a precertificate
+	ocspResp := []byte{0, 0, 1}
+	regID := reg.Id
+	issuedTime := time.Date(2018, 4, 1, 7, 0, 0, 0, time.UTC)
+	_, err := sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
+		Der:      testCert.Raw,
+		RegID:    regID,
+		Ocsp:     ocspResp,
+		Issued:   issuedTime.UnixNano(),
+		IssuerID: 1,
+	})
+	test.AssertNotError(t, err, "Couldn't add test cert")
 
-		// It should have the expected certificate status
-		certStatus, err := sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
-		test.AssertNotError(t, err, "Couldn't get status for test cert")
-		test.Assert(
-			t,
-			bytes.Equal(certStatus.OcspResponse, ocspResp),
-			fmt.Sprintf("OCSP responses don't match, expected: %x, got %x", certStatus.OcspResponse, ocspResp),
-		)
-		test.AssertEquals(t, clk.Now().UnixNano(), certStatus.OcspLastUpdated)
+	// It should have the expected certificate status
+	certStatus, err := sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
+	test.AssertNotError(t, err, "Couldn't get status for test cert")
+	test.Assert(
+		t,
+		bytes.Equal(certStatus.OcspResponse, ocspResp),
+		fmt.Sprintf("OCSP responses don't match, expected: %x, got %x", certStatus.OcspResponse, ocspResp),
+	)
+	test.AssertEquals(t, clk.Now().UnixNano(), certStatus.OcspLastUpdated)
 
-		issuedNamesSerial, err := findIssuedName(sa.dbMap, testCert.DNSNames[0])
-		if expectIssuedNamesUpdate {
-			// If we expectIssuedNamesUpdate then there should be no err and the
-			// expected serial
-			test.AssertNotError(t, err, "expected no err querying issuedNames for precert")
-			test.AssertEquals(t, issuedNamesSerial, serial)
+	// It should show up in the issued names table
+	issuedNamesSerial, err := findIssuedName(sa.dbMap, testCert.DNSNames[0])
+	test.AssertNotError(t, err, "expected no err querying issuedNames for precert")
+	test.AssertEquals(t, issuedNamesSerial, serial)
 
-			// We should also be able to call AddCertificate with the same cert
-			// without it being an error. The duplicate err on inserting to
-			// issuedNames should be ignored.
-			_, err := sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
-				Der:    testCert.Raw,
-				RegID:  regID,
-				Issued: issuedTime.UnixNano(),
-			})
-			test.AssertNotError(t, err, "unexpected err adding final cert after precert")
-		} else {
-			// Otherwise we expect an ErrDatabaseOp that indicates NoRows because
-			// AddCertificate not AddPrecertificate will be updating this table.
-			test.AssertEquals(t, db.IsNoRows(err), true)
-		}
-	}
+	// We should also be able to call AddCertificate with the same cert
+	// without it being an error. The duplicate err on inserting to
+	// issuedNames should be ignored.
+	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
+		Der:    testCert.Raw,
+		RegID:  regID,
+		Issued: issuedTime.UnixNano(),
+	})
+	test.AssertNotError(t, err, "unexpected err adding final cert after precert")
+}
 
-	addPrecert(true)
+func TestAddPrecertificateNoOCSP(t *testing.T) {
+	sa, _, cleanUp := initSA(t)
+	defer cleanUp()
+
+	reg := createWorkingRegistration(t, sa)
+	_, testCert := test.ThrowAwayCert(t, 1)
+
+	regID := reg.Id
+	issuedTime := time.Date(2018, 4, 1, 7, 0, 0, 0, time.UTC)
+	_, err := sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
+		Der:      testCert.Raw,
+		RegID:    regID,
+		Issued:   issuedTime.UnixNano(),
+		IssuerID: 1,
+	})
+	test.AssertNotError(t, err, "Couldn't add test cert")
 }
 
 func TestAddPreCertificateDuplicate(t *testing.T) {
@@ -183,7 +190,6 @@ func TestAddPreCertificateDuplicate(t *testing.T) {
 		IssuerID: 1,
 	})
 	test.AssertDeepEquals(t, err, berrors.DuplicateError("cannot add a duplicate cert"))
-
 }
 
 func TestAddPrecertificateIncomplete(t *testing.T) {

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1278,16 +1278,17 @@ func (ssa *SQLStorageAuthority) GetOrder(ctx context.Context, req *sapb.OrderReq
 
 // statusForOrder examines the status of a provided order's authorizations to
 // determine what the overall status of the order should be. In summary:
-//   * If the order has an error, the order is invalid
-//   * If any of the order's authorizations are in any state other than
+//   - If the order has an error, the order is invalid
+//   - If any of the order's authorizations are in any state other than
 //     valid or pending, the order is invalid.
-//   * If any of the order's authorizations are pending, the order is pending.
-//   * If all of the order's authorizations are valid, and there is
+//   - If any of the order's authorizations are pending, the order is pending.
+//   - If all of the order's authorizations are valid, and there is
 //     a certificate serial, the order is valid.
-//   * If all of the order's authorizations are valid, and we have began
+//   - If all of the order's authorizations are valid, and we have began
 //     processing, but there is no certificate serial, the order is processing.
-//   * If all of the order's authorizations are valid, and we haven't begun
+//   - If all of the order's authorizations are valid, and we haven't begun
 //     processing, then the order is status ready.
+//
 // An error is returned for any other case.
 func (ssa *SQLStorageAuthority) statusForOrder(ctx context.Context, order *corepb.Order) (string, error) {
 	// Without any further work we know an order with an error is invalid
@@ -1759,10 +1760,19 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization2(ctx context.Context, req 
 // RevokeCertificate stores revocation information about a certificate. It will only store this
 // information if the certificate is not already marked as revoked.
 func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*emptypb.Empty, error) {
-	if req.Serial == "" || req.Date == 0 || req.Response == nil {
+	if req.Serial == "" || req.Date == 0 {
 		return nil, errIncompleteRequest
 	}
+	if req.Response == nil && !features.Enabled(features.ROCSPStage6) {
+		return nil, errIncompleteRequest
+	}
+
 	revokedDate := time.Unix(0, req.Date)
+	ocspResponse := req.Response
+	if features.Enabled(features.ROCSPStage6) {
+		ocspResponse = nil
+	}
+
 	res, err := ssa.dbMap.Exec(
 		`UPDATE certificateStatus SET
 				status = ?,
@@ -1775,7 +1785,7 @@ func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb
 		revocation.Reason(req.Reason),
 		revokedDate,
 		revokedDate,
-		req.Response,
+		ocspResponse,
 		req.Serial,
 		string(core.OCSPStatusRevoked),
 	)
@@ -1798,14 +1808,23 @@ func (ssa *SQLStorageAuthority) RevokeCertificate(ctx context.Context, req *sapb
 // cert is already revoked, if the new revocation reason is `KeyCompromise`,
 // and if the revokedDate is identical to the current revokedDate.
 func (ssa *SQLStorageAuthority) UpdateRevokedCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest) (*emptypb.Empty, error) {
-	if req.Serial == "" || req.Date == 0 || req.Backdate == 0 || req.Response == nil {
+	if req.Serial == "" || req.Date == 0 || req.Backdate == 0 {
+		return nil, errIncompleteRequest
+	}
+	if req.Response == nil && !features.Enabled(features.ROCSPStage6) {
 		return nil, errIncompleteRequest
 	}
 	if req.Reason != ocsp.KeyCompromise {
 		return nil, fmt.Errorf("cannot update revocation for any reason other than keyCompromise (1); got: %d", req.Reason)
 	}
+
 	thisUpdate := time.Unix(0, req.Date)
 	revokedDate := time.Unix(0, req.Backdate)
+	ocspResponse := req.Response
+	if features.Enabled(features.ROCSPStage6) {
+		ocspResponse = nil
+	}
+
 	res, err := ssa.dbMap.Exec(
 		`UPDATE certificateStatus SET
 				revokedReason = ?,
@@ -1814,7 +1833,7 @@ func (ssa *SQLStorageAuthority) UpdateRevokedCertificate(ctx context.Context, re
 			WHERE serial = ? AND status = ? AND revokedReason != ? AND revokedDate = ?`,
 		revocation.Reason(ocsp.KeyCompromise),
 		thisUpdate,
-		req.Response,
+		ocspResponse,
 		req.Serial,
 		string(core.OCSPStatusRevoked),
 		revocation.Reason(ocsp.KeyCompromise),

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -42,6 +42,8 @@
     "debugAddr": ":8005",
     "requiredSerialPrefixes": ["ff"],
     "features": {
+      "ROCSPStage1": true,
+      "ROCSPStage2": true,
       "ROCSPStage3": true
     }
   },

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -53,7 +53,8 @@
       "FasterNewOrdersRateLimit": true,
       "StoreRevokerInfo": true,
       "GetAuthzReadOnly": true,
-      "GetAuthzUseIndex": true
+      "GetAuthzUseIndex": true,
+      "ROCSPStage6": true
     }
   },
 


### PR DESCRIPTION
Create a new `ROCSPStage6` feature flag which affects the behavior of
the SA. When enabled, this flag causes the `AddPrecertificate`,
`RevokeCertificate`, and `UpdateRevokedCertificate` methods to ignore
the OCSP response bytes provided by their caller. They will no longer
error out if those bytes are missing, and if the bytes are present they
will still not be written to the database.

This allows us to, in the future, cause the RA and CA to stop generating
those OCSP responses entirely, and stop providing them to the SA,
without causing any errors when we do.

Part of #6079