### PR TITLE
Use io and os instead of deprecated ioutil

### DIFF
--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -227,7 +227,7 @@ func (cpc *CachePurgeClient) authedRequest(endpoint string, body v3PurgeRequest)
 		return fmt.Errorf("response body was empty from URL %q", resp.Request.URL)
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -3,7 +3,7 @@ package akamai
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -67,7 +67,7 @@ func (as *akamaiServer) purgeHandler(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Objects []string
 	}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		fmt.Printf("Failed to read request body: %s\n", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -11,8 +11,8 @@ import (
 	"encoding/asn1"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -107,7 +107,7 @@ const caCertFile = "../test/test-ca.pem"
 const caCertFile2 = "../test/test-ca2.pem"
 
 func mustRead(path string) []byte {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		panic(fmt.Sprintf("unable to read %#v: %s", path, err))
 	}

--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -107,7 +106,7 @@ func TestRevokeBatch(t *testing.T) {
 		log:   log,
 	}
 
-	serialFile, err := ioutil.TempFile("", "serials")
+	serialFile, err := os.CreateTemp("", "serials")
 	test.AssertNotError(t, err, "failed to open temp file")
 	defer os.Remove(serialFile.Name())
 
@@ -159,7 +158,7 @@ func TestBlockAndRevokeByPrivateKey(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to generate test key 3")
 
 	// Write the contents of testKey1 to a temp file.
-	testKey1File, err := ioutil.TempFile("", "key")
+	testKey1File, err := os.CreateTemp("", "key")
 	test.AssertNotError(t, err, "failed to create temp file")
 	der, err := x509.MarshalPKCS8PrivateKey(testKey1)
 	test.AssertNotError(t, err, "failed to marshal testKey1 to DER")
@@ -284,7 +283,7 @@ func TestPrivateKeyBlock(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to generate test key 3")
 
 	// Write the contents of testKey1 to a temp file.
-	testKey1File, err := ioutil.TempFile("", "key")
+	testKey1File, err := os.CreateTemp("", "key")
 	test.AssertNotError(t, err, "failed to create temp file")
 	der, err := x509.MarshalPKCS8PrivateKey(testKey1)
 	test.AssertNotError(t, err, "failed to marshal testKey1 to DER")
@@ -374,7 +373,7 @@ func TestPrivateKeyRevoke(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to generate test key 3")
 
 	// Write the contents of testKey1 to a temp file.
-	testKey1File, err := ioutil.TempFile("", "key")
+	testKey1File, err := os.CreateTemp("", "key")
 	test.AssertNotError(t, err, "failed to create temp file")
 	der, err := x509.MarshalPKCS8PrivateKey(testKey1)
 	test.AssertNotError(t, err, "failed to marshal testKey1 to DER")

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	netmail "net/mail"
 	"os"
 	"strings"
@@ -458,7 +457,7 @@ func main() {
 
 	var smtpRoots *x509.CertPool
 	if config.BadKeyRevoker.Mailer.SMTPTrustedRootFile != "" {
-		pem, err := ioutil.ReadFile(config.BadKeyRevoker.Mailer.SMTPTrustedRootFile)
+		pem, err := os.ReadFile(config.BadKeyRevoker.Mailer.SMTPTrustedRootFile)
 		cmd.FailOnError(err, "Loading trusted roots file")
 		smtpRoots = x509.NewCertPool()
 		if !smtpRoots.AppendCertsFromPEM(pem) {
@@ -487,7 +486,7 @@ func main() {
 	if config.BadKeyRevoker.Mailer.EmailSubject == "" {
 		cmd.Fail("BadKeyRevoker.Mailer.EmailSubject must be populated")
 	}
-	templateBytes, err := ioutil.ReadFile(config.BadKeyRevoker.Mailer.EmailTemplate)
+	templateBytes, err := os.ReadFile(config.BadKeyRevoker.Mailer.EmailTemplate)
 	cmd.FailOnError(err, fmt.Sprintf("failed to read email template %q: %s", config.BadKeyRevoker.Mailer.EmailTemplate, err))
 	emailTemplate, err := template.New("email").Parse(string(templateBytes))
 	cmd.FailOnError(err, fmt.Sprintf("failed to parse email template %q: %s", config.BadKeyRevoker.Mailer.EmailTemplate, err))

--- a/cmd/boulder-observer/main.go
+++ b/cmd/boulder-observer/main.go
@@ -2,7 +2,7 @@ package notmain
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer"
@@ -14,7 +14,7 @@ func main() {
 		"config", "config.yml", "Path to boulder-observer configuration file")
 	flag.Parse()
 
-	configYAML, err := ioutil.ReadFile(*configPath)
+	configYAML, err := os.ReadFile(*configPath)
 	cmd.FailOnError(err, "failed to read config file")
 
 	// Parse the YAML config file.

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -140,7 +139,7 @@ type CacheConfig struct {
 // a certFile do not have a trailing newline one is added.
 // TODO(5164): Remove this after all configs have migrated to `Chains`.
 func loadCertificateFile(aiaIssuerURL, certFile string) ([]byte, *issuance.Certificate, error) {
-	pemBytes, err := ioutil.ReadFile(certFile)
+	pemBytes, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"CertificateChain entry for AIA issuer url %q has an "+

--- a/cmd/boulder-wfe2/main_test.go
+++ b/cmd/boulder-wfe2/main_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -59,8 +59,8 @@ func TestLoadChain_Unloadable(t *testing.T) {
 	})
 	test.AssertError(t, err, "Should reject unloadable chain")
 
-	invalidPEMFile, _ := ioutil.TempFile("", "invalid.pem")
-	err = ioutil.WriteFile(invalidPEMFile.Name(), []byte(""), 0640)
+	invalidPEMFile, _ := os.CreateTemp("", "invalid.pem")
+	err = os.WriteFile(invalidPEMFile.Name(), []byte(""), 0640)
 	test.AssertNotError(t, err, "Error writing invalid PEM tmp file")
 	_, _, err = loadChain([]string{
 		invalidPEMFile.Name(),
@@ -84,35 +84,35 @@ func TestLoadChain_NoRoot(t *testing.T) {
 
 func TestLoadCertificateChains(t *testing.T) {
 	// Read some cert bytes to use for expected chain content
-	certBytesA, err := ioutil.ReadFile("../../test/test-ca.pem")
+	certBytesA, err := os.ReadFile("../../test/test-ca.pem")
 	test.AssertNotError(t, err, "Error reading../../test/test-ca.pem")
-	certBytesB, err := ioutil.ReadFile("../../test/test-ca2.pem")
+	certBytesB, err := os.ReadFile("../../test/test-ca2.pem")
 	test.AssertNotError(t, err, "Error reading../../test/test-ca2.pem")
 
 	// Make a .pem file with invalid contents
-	invalidPEMFile, _ := ioutil.TempFile("", "invalid.pem")
-	err = ioutil.WriteFile(invalidPEMFile.Name(), []byte(""), 0640)
+	invalidPEMFile, _ := os.CreateTemp("", "invalid.pem")
+	err = os.WriteFile(invalidPEMFile.Name(), []byte(""), 0640)
 	test.AssertNotError(t, err, "Error writing invalid PEM tmp file")
 
 	// Make a .pem file with a valid cert but also some leftover bytes
-	leftoverPEMFile, _ := ioutil.TempFile("", "leftovers.pem")
+	leftoverPEMFile, _ := os.CreateTemp("", "leftovers.pem")
 	leftovers := "vegan curry, cold rice, soy milk"
 	leftoverBytes := append(certBytesA, []byte(leftovers)...)
-	err = ioutil.WriteFile(leftoverPEMFile.Name(), leftoverBytes, 0640)
+	err = os.WriteFile(leftoverPEMFile.Name(), leftoverBytes, 0640)
 	test.AssertNotError(t, err, "Error writing leftover PEM tmp file")
 
 	// Make a .pem file that is test-ca2.pem but with Windows/DOS CRLF line
 	// endings
-	crlfPEM, _ := ioutil.TempFile("", "crlf.pem")
+	crlfPEM, _ := os.CreateTemp("", "crlf.pem")
 	crlfPEMBytes := []byte(strings.Replace(string(certBytesB), "\n", "\r\n", -1))
-	err = ioutil.WriteFile(crlfPEM.Name(), crlfPEMBytes, 0640)
-	test.AssertNotError(t, err, "ioutil.WriteFile failed")
+	err = os.WriteFile(crlfPEM.Name(), crlfPEMBytes, 0640)
+	test.AssertNotError(t, err, "os.WriteFile failed")
 
 	// Make a .pem file that is test-ca.pem but with no trailing newline
-	abruptPEM, _ := ioutil.TempFile("", "abrupt.pem")
+	abruptPEM, _ := os.CreateTemp("", "abrupt.pem")
 	abruptPEMBytes := certBytesA[:len(certBytesA)-1]
-	err = ioutil.WriteFile(abruptPEM.Name(), abruptPEMBytes, 0640)
-	test.AssertNotError(t, err, "ioutil.WriteFile failed")
+	err = os.WriteFile(abruptPEM.Name(), abruptPEMBytes, 0640)
+	test.AssertNotError(t, err, "os.WriteFile failed")
 
 	testCases := []struct {
 		Name            string

--- a/cmd/caa-log-checker/main_test.go
+++ b/cmd/caa-log-checker/main_test.go
@@ -3,7 +3,6 @@ package notmain
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -18,14 +17,14 @@ import (
 var testTime = time.Time{}.Add(time.Hour + time.Minute + time.Second + time.Millisecond + time.Microsecond).Local()
 
 func TestOpenFile(t *testing.T) {
-	tmpPlain, err := ioutil.TempFile(os.TempDir(), "plain")
+	tmpPlain, err := os.CreateTemp(os.TempDir(), "plain")
 	test.AssertNotError(t, err, "failed to create temporary file")
 	defer os.Remove(tmpPlain.Name())
 	_, err = tmpPlain.Write([]byte("test-1\ntest-2"))
 	test.AssertNotError(t, err, "failed to write to temp file")
 	tmpPlain.Close()
 
-	tmpGzip, err := ioutil.TempFile(os.TempDir(), "gzip-*.gz")
+	tmpGzip, err := os.CreateTemp(os.TempDir(), "gzip-*.gz")
 	test.AssertNotError(t, err, "failed to create temporary file")
 	defer os.Remove(tmpGzip.Name())
 	gzipWriter := gzip.NewWriter(tmpGzip)
@@ -113,7 +112,7 @@ trailer`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tmp, err := ioutil.TempFile(os.TempDir(), "TestLoadIssuanceLog")
+			tmp, err := os.CreateTemp(os.TempDir(), "TestLoadIssuanceLog")
 			test.AssertNotError(t, err, "failed to create temporary log file")
 			defer os.Remove(tmp.Name())
 			_, err = tmp.Write([]byte(tc.loglines))
@@ -214,7 +213,7 @@ trailer`,
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fmt.Println(tc.name)
-			tmp, err := ioutil.TempFile(os.TempDir(), "TestProcessCAALog")
+			tmp, err := os.CreateTemp(os.TempDir(), "TestProcessCAALog")
 			test.AssertNotError(t, err, "failed to create temporary log file")
 			defer os.Remove(tmp.Name())
 			_, err = tmp.Write([]byte(tc.loglines))

--- a/cmd/ceremony/key_test.go
+++ b/cmd/ceremony/key_test.go
@@ -8,8 +8,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -65,7 +65,7 @@ func TestGenerateKeyRSA(t *testing.T) {
 		RSAModLength: 1024,
 	})
 	test.AssertNotError(t, err, "Failed to generate RSA key")
-	diskKeyBytes, err := ioutil.ReadFile(keyPath)
+	diskKeyBytes, err := os.ReadFile(keyPath)
 	test.AssertNotError(t, err, "Failed to load key from disk")
 	block, _ := pem.Decode(diskKeyBytes)
 	diskKey, err := x509.ParsePKIXPublicKey(block.Bytes)
@@ -101,7 +101,7 @@ func TestGenerateKeyEC(t *testing.T) {
 		ECDSACurve: "P-256",
 	})
 	test.AssertNotError(t, err, "Failed to generate ECDSA key")
-	diskKeyBytes, err := ioutil.ReadFile(keyPath)
+	diskKeyBytes, err := os.ReadFile(keyPath)
 	test.AssertNotError(t, err, "Failed to load key from disk")
 	block, _ := pem.Decode(diskKeyBytes)
 	diskKey, err := x509.ParsePKIXPublicKey(block.Bytes)

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -384,7 +383,7 @@ func (cc crlConfig) validate() error {
 
 // loadCert loads a PEM certificate specified by filename or returns an error
 func loadCert(filename string) (cert *x509.Certificate, err error) {
-	certPEM, err := ioutil.ReadFile(filename)
+	certPEM, err := os.ReadFile(filename)
 	if err != nil {
 		return
 	}
@@ -518,7 +517,7 @@ func intermediateCeremony(configBytes []byte, ct certType) error {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 
-	pubPEMBytes, err := ioutil.ReadFile(config.Inputs.PublicKeyPath)
+	pubPEMBytes, err := os.ReadFile(config.Inputs.PublicKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read public key %q: %s", config.Inputs.PublicKeyPath, err)
 	}
@@ -568,7 +567,7 @@ func csrCeremony(configBytes []byte) error {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 
-	pubPEMBytes, err := ioutil.ReadFile(config.Inputs.PublicKeyPath)
+	pubPEMBytes, err := os.ReadFile(config.Inputs.PublicKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read public key %q: %s", config.Inputs.PublicKeyPath, err)
 	}
@@ -788,7 +787,7 @@ func main() {
 	if *configPath == "" {
 		log.Fatal("--config is required")
 	}
-	configBytes, err := ioutil.ReadFile(*configPath)
+	configBytes, err := os.ReadFile(*configPath)
 	if err != nil {
 		log.Fatalf("Failed to read config file: %s", err)
 	}

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -12,10 +12,10 @@ import (
 	"database/sql"
 	"encoding/asn1"
 	"encoding/pem"
-	"io/ioutil"
 	"log"
 	"math/big"
 	mrand "math/rand"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -144,7 +144,7 @@ func TestCheckCertReturnsDNSNames(t *testing.T) {
 	}()
 	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations, blog.NewMock())
 
-	certPEM, err := ioutil.ReadFile("testdata/quite_invalid.pem")
+	certPEM, err := os.ReadFile("testdata/quite_invalid.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -30,7 +29,7 @@ func (pc *PasswordConfig) Pass() (string, error) {
 	if pc.PasswordFile == "" {
 		return "", nil
 	}
-	contents, err := ioutil.ReadFile(pc.PasswordFile)
+	contents, err := os.ReadFile(pc.PasswordFile)
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +83,7 @@ type DBConfig struct {
 // whitespace is stripped.
 func (d *DBConfig) URL() (string, error) {
 	if d.DBConnectFile != "" {
-		url, err := ioutil.ReadFile(d.DBConnectFile)
+		url, err := os.ReadFile(d.DBConnectFile)
 		return strings.TrimSpace(string(url)), err
 	}
 	return d.DBConnect, nil
@@ -127,7 +126,7 @@ func (pc PAConfig) CheckChallenges() error {
 	}
 	for c := range pc.Challenges {
 		if !c.IsValid() {
-			return fmt.Errorf("Invalid challenge in PA config: %s", c)
+			return fmt.Errorf("invalid challenge in PA config: %s", c)
 		}
 	}
 	return nil
@@ -161,7 +160,7 @@ func (t *TLSConfig) Load() (*tls.Config, error) {
 	if t.CACertFile == nil {
 		return nil, fmt.Errorf("nil CACertFile in TLSConfig")
 	}
-	caCertBytes, err := ioutil.ReadFile(*t.CACertFile)
+	caCertBytes, err := os.ReadFile(*t.CACertFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading CA cert from %q: %s", *t.CACertFile, err)
 	}

--- a/cmd/contact-auditor/main.go
+++ b/cmd/contact-auditor/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -160,7 +159,7 @@ func main() {
 	logger := cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 7})
 
 	// Load config from JSON.
-	configData, err := ioutil.ReadFile(*configFile)
+	configData, err := os.ReadFile(*configFile)
 	cmd.FailOnError(err, fmt.Sprintf("Error reading config file: %q", *configFile))
 
 	var cfg Config

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -3,7 +3,6 @@ package notmain
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -85,7 +84,7 @@ func TestContactAuditor(t *testing.T) {
 	}
 
 	// Load results file.
-	data, err := ioutil.ReadFile(testCtx.c.resultsFile.Name())
+	data, err := os.ReadFile(testCtx.c.resultsFile.Name())
 	if err != nil {
 		t.Error(err)
 	}
@@ -187,7 +186,7 @@ func setup(t *testing.T) testCtx {
 	}
 
 	// Make temp results file
-	file, err := ioutil.TempFile("", fmt.Sprintf("audit-%s", time.Now().Format("2006-01-02T15:04")))
+	file, err := os.CreateTemp("", fmt.Sprintf("audit-%s", time.Now().Format("2006-01-02T15:04")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	netmail "net/mail"
 	"net/url"
@@ -645,7 +644,7 @@ func main() {
 
 	var smtpRoots *x509.CertPool
 	if c.Mailer.SMTPTrustedRootFile != "" {
-		pem, err := ioutil.ReadFile(c.Mailer.SMTPTrustedRootFile)
+		pem, err := os.ReadFile(c.Mailer.SMTPTrustedRootFile)
 		cmd.FailOnError(err, "Loading trusted roots file")
 		smtpRoots = x509.NewCertPool()
 		if !smtpRoots.AppendCertsFromPEM(pem) {
@@ -654,7 +653,7 @@ func main() {
 	}
 
 	// Load email template
-	emailTmpl, err := ioutil.ReadFile(c.Mailer.EmailTemplate)
+	emailTmpl, err := os.ReadFile(c.Mailer.EmailTemplate)
 	cmd.FailOnError(err, fmt.Sprintf("Could not read email template file [%s]", c.Mailer.EmailTemplate))
 	tmpl, err := template.New("expiry-email").Parse(string(emailTmpl))
 	cmd.FailOnError(err, "Could not parse email template")

--- a/cmd/id-exporter/main.go
+++ b/cmd/id-exporter/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -65,7 +64,7 @@ func (i *idExporterResults) writeToFile(outfile string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(outfile, data, 0644)
+	return os.WriteFile(outfile, data, 0644)
 }
 
 // findIDs gathers all registration IDs with unexpired certificates.
@@ -254,7 +253,7 @@ func main() {
 	log := cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 7})
 
 	// Load configuration file.
-	configData, err := ioutil.ReadFile(*configFile)
+	configData, err := os.ReadFile(*configFile)
 	cmd.FailOnError(err, fmt.Sprintf("Reading %q", *configFile))
 
 	// Unmarshal JSON config file.

--- a/cmd/id-exporter/main_test.go
+++ b/cmd/id-exporter/main_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -189,51 +188,51 @@ func TestWriteToFile(t *testing.T) {
 	mockResults := idExporterResults{{ID: 1}, {ID: 2}, {ID: 3}}
 	dir := os.TempDir()
 
-	f, err := ioutil.TempFile(dir, "ids_test")
-	test.AssertNotError(t, err, "ioutil.TempFile produced an error")
+	f, err := os.CreateTemp(dir, "ids_test")
+	test.AssertNotError(t, err, "os.CreateTemp produced an error")
 
 	// Writing the result to an outFile should produce the correct results
 	err = mockResults.writeToFile(f.Name())
 	test.AssertNotError(t, err, fmt.Sprintf("writeIDs produced an error writing to %s", f.Name()))
 
-	contents, err := ioutil.ReadFile(f.Name())
-	test.AssertNotError(t, err, fmt.Sprintf("ioutil.ReadFile produced an error reading from %s", f.Name()))
+	contents, err := os.ReadFile(f.Name())
+	test.AssertNotError(t, err, fmt.Sprintf("os.ReadFile produced an error reading from %s", f.Name()))
 
 	test.AssertEquals(t, string(contents), expected+"\n")
 }
 
 func Test_unmarshalHostnames(t *testing.T) {
 	testDir := os.TempDir()
-	testFile, err := ioutil.TempFile(testDir, "ids_test")
-	test.AssertNotError(t, err, "ioutil.TempFile produced an error")
+	testFile, err := os.CreateTemp(testDir, "ids_test")
+	test.AssertNotError(t, err, "os.CreateTemp produced an error")
 
 	// Non-existent hostnamesFile
 	_, err = unmarshalHostnames("file_does_not_exist")
 	test.AssertError(t, err, "expected error for non-existent file")
 
 	// Empty hostnamesFile
-	err = ioutil.WriteFile(testFile.Name(), []byte(""), 0644)
-	test.AssertNotError(t, err, "ioutil.WriteFile produced an error")
+	err = os.WriteFile(testFile.Name(), []byte(""), 0644)
+	test.AssertNotError(t, err, "os.WriteFile produced an error")
 	_, err = unmarshalHostnames(testFile.Name())
 	test.AssertError(t, err, "expected error for file containing 0 entries")
 
 	// One hostname present in the hostnamesFile
-	err = ioutil.WriteFile(testFile.Name(), []byte("example-a.com"), 0644)
-	test.AssertNotError(t, err, "ioutil.WriteFile produced an error")
+	err = os.WriteFile(testFile.Name(), []byte("example-a.com"), 0644)
+	test.AssertNotError(t, err, "os.WriteFile produced an error")
 	results, err := unmarshalHostnames(testFile.Name())
 	test.AssertNotError(t, err, "error when unmarshalling hostnamesFile with a single hostname")
 	test.AssertEquals(t, len(results), 1)
 
 	// Two hostnames present in the hostnamesFile
-	err = ioutil.WriteFile(testFile.Name(), []byte("example-a.com\nexample-b.com"), 0644)
-	test.AssertNotError(t, err, "ioutil.WriteFile produced an error")
+	err = os.WriteFile(testFile.Name(), []byte("example-a.com\nexample-b.com"), 0644)
+	test.AssertNotError(t, err, "os.WriteFile produced an error")
 	results, err = unmarshalHostnames(testFile.Name())
 	test.AssertNotError(t, err, "error when unmarshalling hostnamesFile with a two hostnames")
 	test.AssertEquals(t, len(results), 2)
 
 	// Three hostnames present in the hostnamesFile but two are separated only by a space
-	err = ioutil.WriteFile(testFile.Name(), []byte("example-a.com\nexample-b.com example-c.com"), 0644)
-	test.AssertNotError(t, err, "ioutil.WriteFile produced an error")
+	err = os.WriteFile(testFile.Name(), []byte("example-a.com\nexample-b.com example-c.com"), 0644)
+	test.AssertNotError(t, err, "os.WriteFile produced an error")
 	_, err = unmarshalHostnames(testFile.Name())
 	test.AssertError(t, err, "error when unmarshalling hostnamesFile with three space separated domains")
 }

--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -73,7 +72,7 @@ func lineValid(text string) error {
 }
 
 func validateFile(filename string) error {
-	file, err := ioutil.ReadFile(filename)
+	file, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -147,7 +146,7 @@ func main() {
 		return
 	}
 
-	configBytes, err := ioutil.ReadFile(*configPath)
+	configBytes, err := os.ReadFile(*configPath)
 	cmd.FailOnError(err, "failed to read config file")
 	var config Config
 	err = json.Unmarshal(configBytes, &config)

--- a/cmd/notify-mailer/main.go
+++ b/cmd/notify-mailer/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/mail"
 	"os"
 	"sort"
@@ -534,7 +533,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	configData, err := ioutil.ReadFile(*configFile)
+	configData, err := os.ReadFile(*configFile)
 	cmd.FailOnError(err, "Couldn't load JSON config file")
 
 	// Parse JSON config.

--- a/cmd/notify-mailer/main_test.go
+++ b/cmd/notify-mailer/main_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"text/template"
@@ -41,7 +40,7 @@ func TestIntervalOK(t *testing.T) {
 }
 
 func setupMakeRecipientList(t *testing.T, contents string) string {
-	entryFile, err := ioutil.TempFile("", "")
+	entryFile, err := os.CreateTemp("", "")
 	test.AssertNotError(t, err, "couldn't create temp file")
 
 	_, err = entryFile.WriteString(contents)

--- a/cmd/ocsp-responder/main_test.go
+++ b/cmd/ocsp-responder/main_test.go
@@ -3,9 +3,9 @@ package notmain
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMux(t *testing.T) {
-	reqBytes, err := ioutil.ReadFile("./testdata/ocsp.req")
+	reqBytes, err := os.ReadFile("./testdata/ocsp.req")
 	test.AssertNotError(t, err, "failed to read OCSP request")
 	req, err := ocsp.ParseRequest(reqBytes)
 	test.AssertNotError(t, err, "failed to parse OCSP request")
@@ -28,7 +28,7 @@ func TestMux(t *testing.T) {
 	doubleSlashReq, err := ocsp.ParseRequest(doubleSlashBytes)
 	test.AssertNotError(t, err, "failed to parse double slash OCSP request")
 
-	respBytes, err := ioutil.ReadFile("./testdata/ocsp.resp")
+	respBytes, err := os.ReadFile("./testdata/ocsp.resp")
 	test.AssertNotError(t, err, "failed to read OCSP response")
 	resp, err := ocsp.ParseResponse(respBytes, nil)
 	test.AssertNotError(t, err, "failed to parse OCSP response")

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -198,7 +197,7 @@ type orphanFinder struct {
 }
 
 func newOrphanFinder(configFile string) *orphanFinder {
-	configJSON, err := ioutil.ReadFile(configFile)
+	configJSON, err := os.ReadFile(configFile)
 	cmd.FailOnError(err, "Failed to read config file")
 	var conf Config
 	err = json.Unmarshal(configJSON, &conf)
@@ -240,7 +239,7 @@ func newOrphanFinder(configFile string) *orphanFinder {
 // found, and how many it successfully stored.
 func (opf *orphanFinder) parseCALog(logPath string) {
 	ctx := context.Background()
-	logData, err := ioutil.ReadFile(logPath)
+	logData, err := os.ReadFile(logPath)
 	cmd.FailOnError(err, "Failed to read log file")
 
 	var certOrphansFound, certOrphansAdded, precertOrphansFound, precertOrphansAdded int64
@@ -347,7 +346,7 @@ func (opf *orphanFinder) storeLogLine(ctx context.Context, line string) (found b
 // parseDER loads and attempts to store a single orphan from a single DER file.
 func (opf *orphanFinder) parseDER(derPath string, regID int64) {
 	ctx := context.Background()
-	der, err := ioutil.ReadFile(derPath)
+	der, err := os.ReadFile(derPath)
 	cmd.FailOnError(err, "Failed to read DER file")
 	cert, typ, err := checkDER(opf.sa, der)
 	cmd.FailOnError(err, "Pre-AddCertificate checks failed")

--- a/cmd/rocsp-tool/client.go
+++ b/cmd/rocsp-tool/client.go
@@ -3,8 +3,8 @@ package notmain
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -244,7 +244,7 @@ func (e expiredError) Error() string {
 
 func (cl *client) storeResponsesFromFiles(ctx context.Context, files []string) error {
 	for _, respFile := range files {
-		respBytes, err := ioutil.ReadFile(respFile)
+		respBytes, err := os.ReadFile(respFile)
 		if err != nil {
 			return fmt.Errorf("reading response file %q: %w", respFile, err)
 		}

--- a/core/util.go
+++ b/core/util.go
@@ -13,9 +13,9 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	mrand "math/rand"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -245,7 +245,7 @@ func UniqueLowerNames(names []string) (unique []string) {
 
 // LoadCert loads a PEM certificate specified by filename or returns an error
 func LoadCert(filename string) (*x509.Certificate, error) {
-	certPEM, err := ioutil.ReadFile(filename)
+	certPEM, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/crl/storer/storer_test.go
+++ b/crl/storer/storer_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"testing"
 	"time"
@@ -271,7 +270,7 @@ type fakeS3Putter struct {
 }
 
 func (p *fakeS3Putter) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
-	recvBytes, err := ioutil.ReadAll(params.Body)
+	recvBytes, err := io.ReadAll(params.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -105,7 +105,7 @@ func usableForPurpose(s state, p purpose) bool {
 // the given path. The file must conform to the JSON Schema published by Google:
 // https://www.gstatic.com/ct/log_list/v3/log_list_schema.json
 func New(path string) (List, error) {
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CT Log List: %w", err)
 	}

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/letsencrypt/boulder/core"
 
@@ -51,7 +51,7 @@ func (b blockedKeys) blocked(key crypto.PublicKey) (bool, error) {
 //
 // If no hashes are found in the input YAML an error is returned.
 func loadBlockedKeysList(filename string) (*blockedKeys, error) {
-	yamlBytes, err := ioutil.ReadFile(filename)
+	yamlBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/goodkey/blocked_test.go
+++ b/goodkey/blocked_test.go
@@ -3,7 +3,6 @@ package goodkey
 import (
 	"context"
 	"crypto"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -23,11 +22,11 @@ func TestBlockedKeys(t *testing.T) {
 	yamlList, err := yaml.Marshal(&inList)
 	test.AssertNotError(t, err, "error marshaling test blockedKeys list")
 
-	yamlListFile, err := ioutil.TempFile("", "test-blocked-keys-list.*.yaml")
+	yamlListFile, err := os.CreateTemp("", "test-blocked-keys-list.*.yaml")
 	test.AssertNotError(t, err, "error creating test blockedKeys yaml file")
 	defer os.Remove(yamlListFile.Name())
 
-	err = ioutil.WriteFile(yamlListFile.Name(), yamlList, 0640)
+	err = os.WriteFile(yamlListFile.Name(), yamlList, 0640)
 	test.AssertNotError(t, err, "error writing test blockedKeys yaml file")
 
 	// Trying to load it should error
@@ -65,11 +64,11 @@ func TestBlockedKeys(t *testing.T) {
 	yamlList, err = yaml.Marshal(&inList)
 	test.AssertNotError(t, err, "error marshaling test blockedKeys list")
 
-	yamlListFile, err = ioutil.TempFile("", "test-blocked-keys-list.*.yaml")
+	yamlListFile, err = os.CreateTemp("", "test-blocked-keys-list.*.yaml")
 	test.AssertNotError(t, err, "error creating test blockedKeys yaml file")
 	defer os.Remove(yamlListFile.Name())
 
-	err = ioutil.WriteFile(yamlListFile.Name(), yamlList, 0640)
+	err = os.WriteFile(yamlListFile.Name(), yamlList, 0640)
 	test.AssertNotError(t, err, "error writing test blockedKeys yaml file")
 
 	// Trying to load it should not error

--- a/goodkey/weak.go
+++ b/goodkey/weak.go
@@ -11,7 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 type truncatedHash [10]byte
@@ -21,7 +21,7 @@ type WeakRSAKeys struct {
 }
 
 func LoadWeakRSASuffixes(path string) (*WeakRSAKeys, error) {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/goodkey/weak_test.go
+++ b/goodkey/weak_test.go
@@ -3,7 +3,6 @@ package goodkey
 import (
 	"crypto/rsa"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -36,7 +35,7 @@ func TestLoadKeys(t *testing.T) {
 	testKey := rsa.PublicKey{N: mod}
 	tempDir := t.TempDir()
 	tempPath := filepath.Join(tempDir, "a.json")
-	err = ioutil.WriteFile(tempPath, []byte("[\"8df20e6961a16398b85a\"]"), os.ModePerm)
+	err = os.WriteFile(tempPath, []byte("[\"8df20e6961a16398b85a\"]"), os.ModePerm)
 	test.AssertNotError(t, err, "Failed to create temporary file")
 
 	wk, err := LoadWeakRSASuffixes(tempPath)

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -15,8 +15,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -124,7 +124,7 @@ func loadSigner(location IssuerLoc, cert *Certificate) (crypto.Signer, error) {
 
 	var pkcs11Config *pkcs11key.Config
 	if location.ConfigFile != "" {
-		contents, err := ioutil.ReadFile(location.ConfigFile)
+		contents, err := os.ReadFile(location.ConfigFile)
 		if err != nil {
 			return nil, err
 		}

--- a/issuance/issuance_test.go
+++ b/issuance/issuance_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strings"
@@ -790,8 +789,8 @@ func TestLoadChain_Unloadable(t *testing.T) {
 	})
 	test.AssertError(t, err, "Should reject unloadable chain")
 
-	invalidPEMFile, _ := ioutil.TempFile("", "invalid.pem")
-	err = ioutil.WriteFile(invalidPEMFile.Name(), []byte(""), 0640)
+	invalidPEMFile, _ := os.CreateTemp("", "invalid.pem")
+	err = os.WriteFile(invalidPEMFile.Name(), []byte(""), 0640)
 	test.AssertNotError(t, err, "Error writing invalid PEM tmp file")
 	_, err = LoadChain([]string{
 		invalidPEMFile.Name(),

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/mail"
 	"net/textproto"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -285,7 +285,7 @@ func setup(t *testing.T) (*mailerImpl, *net.TCPListener, func()) {
 		}
 	}
 
-	pem, err := ioutil.ReadFile("../test/mail-test-srv/minica.pem")
+	pem, err := os.ReadFile("../test/mail-test-srv/minica.pem")
 	if err != nil {
 		t.Fatalf("loading smtp root: %s", err)
 	}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -7,9 +7,9 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -113,7 +113,7 @@ func (sa *StorageAuthority) GetRegistration(_ context.Context, req *sapb.Registr
 
 // GetRegistrationByKey is a mock
 func (sa *StorageAuthority) GetRegistrationByKey(_ context.Context, req *sapb.JSONWebKey, _ ...grpc.CallOption) (*corepb.Registration, error) {
-	test5KeyBytes, err := ioutil.ReadFile("../test/test-key-5.der")
+	test5KeyBytes, err := os.ReadFile("../test/test-key-5.der")
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (sa *StorageAuthority) GetSerialMetadata(ctx context.Context, req *sapb.Ser
 func (sa *StorageAuthority) GetCertificate(_ context.Context, req *sapb.Serial, _ ...grpc.CallOption) (*corepb.Certificate, error) {
 	// Serial ee == 238.crt
 	if req.Serial == "0000000000000000000000000000000000ee" {
-		certPemBytes, _ := ioutil.ReadFile("test/238.crt")
+		certPemBytes, _ := os.ReadFile("test/238.crt")
 		certBlock, _ := pem.Decode(certPemBytes)
 		return &corepb.Certificate{
 			RegistrationID: 1,
@@ -206,7 +206,7 @@ func (sa *StorageAuthority) GetCertificate(_ context.Context, req *sapb.Serial, 
 			Issued:         sa.clk.Now().Add(-1 * time.Hour).UnixNano(),
 		}, nil
 	} else if req.Serial == "0000000000000000000000000000000000b2" {
-		certPemBytes, _ := ioutil.ReadFile("test/178.crt")
+		certPemBytes, _ := os.ReadFile("test/178.crt")
 		certBlock, _ := pem.Decode(certPemBytes)
 		return &corepb.Certificate{
 			RegistrationID: 1,

--- a/ocsp/responder/db_source_test.go
+++ b/ocsp/responder/db_source_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -52,12 +52,12 @@ func (s errorSelector) WithContext(context.Context) gorp.SqlExecutor {
 }
 
 func TestDbSource(t *testing.T) {
-	reqBytes, err := ioutil.ReadFile("./testdata/ocsp.req")
+	reqBytes, err := os.ReadFile("./testdata/ocsp.req")
 	test.AssertNotError(t, err, "failed to read OCSP request")
 	req, err := ocsp.ParseRequest(reqBytes)
 	test.AssertNotError(t, err, "failed to parse OCSP request")
 
-	respBytes, err := ioutil.ReadFile("./testdata/ocsp.resp")
+	respBytes, err := os.ReadFile("./testdata/ocsp.resp")
 	test.AssertNotError(t, err, "failed to read OCSP response")
 
 	// Test for failure when the database lookup fails.

--- a/ocsp/responder/filter_source.go
+++ b/ocsp/responder/filter_source.go
@@ -37,7 +37,7 @@ type filterSource struct {
 // by it.
 func NewFilterSource(issuerCerts []*issuance.Certificate, serialPrefixes []string, wrapped Source, stats prometheus.Registerer, log blog.Logger, clk clock.Clock) (*filterSource, error) {
 	if len(issuerCerts) < 1 {
-		return nil, errors.New("Filter must include at least 1 issuer cert")
+		return nil, errors.New("filter must include at least 1 issuer cert")
 	}
 
 	issuersByNameId := make(map[issuance.IssuerNameID]responderID)

--- a/ocsp/responder/filter_source_test.go
+++ b/ocsp/responder/filter_source_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto"
 	"encoding/hex"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -57,7 +57,7 @@ func TestCheckRequest(t *testing.T) {
 	f, err := NewFilterSource([]*issuance.Certificate{issuer}, []string{"00"}, nil, metrics.NoopRegisterer, blog.NewMock(), clock.New())
 	test.AssertNotError(t, err, "errored when creating good filter")
 
-	reqBytes, err := ioutil.ReadFile("./testdata/ocsp.req")
+	reqBytes, err := os.ReadFile("./testdata/ocsp.req")
 	test.AssertNotError(t, err, "failed to read OCSP request")
 
 	// Select a bad hash algorithm.
@@ -96,12 +96,12 @@ func TestCheckResponse(t *testing.T) {
 	issuer, err := issuance.LoadCertificate("./testdata/test-ca.der.pem")
 	test.AssertNotError(t, err, "failed to load issuer cert")
 
-	reqBytes, err := ioutil.ReadFile("./testdata/ocsp.req")
+	reqBytes, err := os.ReadFile("./testdata/ocsp.req")
 	test.AssertNotError(t, err, "failed to read OCSP request")
 	req, err := ocsp.ParseRequest(reqBytes)
 	test.AssertNotError(t, err, "failed to prepare fake ocsp request")
 
-	respBytes, err := ioutil.ReadFile("./testdata/ocsp.resp")
+	respBytes, err := os.ReadFile("./testdata/ocsp.resp")
 	test.AssertNotError(t, err, "failed to read OCSP response")
 	resp, err := ocsp.ParseResponse(respBytes, nil)
 	test.AssertNotError(t, err, "failed to parse OCSP response")

--- a/ocsp/responder/inmem_source.go
+++ b/ocsp/responder/inmem_source.go
@@ -3,7 +3,7 @@ package responder
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 	"regexp"
 
 	blog "github.com/letsencrypt/boulder/log"
@@ -32,7 +32,7 @@ func NewMemorySource(responses map[string]*Response, logger blog.Logger) (*inMem
 // PEM without headers or whitespace).  Invalid responses are ignored.
 // This function pulls the entire file into an InMemorySource.
 func NewMemorySourceFromFile(responseFile string, logger blog.Logger) (*inMemorySource, error) {
-	fileContents, err := ioutil.ReadFile(responseFile)
+	fileContents, err := os.ReadFile(responseFile)
 	if err != nil {
 		return nil, err
 	}

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -39,7 +39,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -55,7 +55,7 @@ import (
 
 // ErrNotFound indicates the request OCSP response was not found. It is used to
 // indicate that the responder should reply with unauthorizedErrorResponse.
-var ErrNotFound = errors.New("Request OCSP Response not found")
+var ErrNotFound = errors.New("request OCSP Response not found")
 
 // errOCSPResponseExpired indicates that the nextUpdate field of the requested
 // OCSP response occurred in the past and an HTTP status code of 533 should be
@@ -155,11 +155,13 @@ var hashToString = map[crypto.Hash]string{
 // decodes the request, and passes back whatever response is provided by the
 // source.
 // The Responder will set these headers:
-//   Cache-Control: "max-age=(response.NextUpdate-now), public, no-transform, must-revalidate",
-//   Last-Modified: response.ThisUpdate,
-//   Expires: response.NextUpdate,
-//   ETag: the SHA256 hash of the response, and
-//   Content-Type: application/ocsp-response.
+//
+//	Cache-Control: "max-age=(response.NextUpdate-now), public, no-transform, must-revalidate",
+//	Last-Modified: response.ThisUpdate,
+//	Expires: response.NextUpdate,
+//	ETag: the SHA256 hash of the response, and
+//	Content-Type: application/ocsp-response.
+//
 // Note: The caller must use http.StripPrefix to strip any path components
 // (including '/') on GET requests.
 // Do not use this responder in conjunction with http.NewServeMux, because the
@@ -240,7 +242,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 			return
 		}
 	case "POST":
-		requestBody, err = ioutil.ReadAll(http.MaxBytesReader(nil, request.Body, 10000))
+		requestBody, err = io.ReadAll(http.MaxBytesReader(nil, request.Body, 10000))
 		if err != nil {
 			rs.log.Errf("Problem reading body of POST: %s", err)
 			response.WriteHeader(http.StatusBadRequest)

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -151,9 +150,9 @@ func TestWillingToIssue(t *testing.T) {
 
 	yamlPolicyBytes, err := yaml.Marshal(policy)
 	test.AssertNotError(t, err, "Couldn't YAML serialize blocklist")
-	yamlPolicyFile, _ := ioutil.TempFile("", "test-blocklist.*.yaml")
+	yamlPolicyFile, _ := os.CreateTemp("", "test-blocklist.*.yaml")
 	defer os.Remove(yamlPolicyFile.Name())
-	err = ioutil.WriteFile(yamlPolicyFile.Name(), yamlPolicyBytes, 0640)
+	err = os.WriteFile(yamlPolicyFile.Name(), yamlPolicyBytes, 0640)
 	test.AssertNotError(t, err, "Couldn't write YAML blocklist")
 
 	pa := paImpl(t)
@@ -228,9 +227,9 @@ func TestWillingToIssueWildcard(t *testing.T) {
 		ExactBlockedNames:    exactBannedDomains,
 	})
 	test.AssertNotError(t, err, "Couldn't serialize banned list")
-	f, _ := ioutil.TempFile("", "test-wildcard-banlist.*.yaml")
+	f, _ := os.CreateTemp("", "test-wildcard-banlist.*.yaml")
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), bannedBytes, 0640)
+	err = os.WriteFile(f.Name(), bannedBytes, 0640)
 	test.AssertNotError(t, err, "Couldn't write serialized banned list to file")
 	err = pa.SetHostnamePolicyFile(f.Name())
 	test.AssertNotError(t, err, "Couldn't load policy contents from file")
@@ -319,9 +318,9 @@ func TestWillingToIssueWildcards(t *testing.T) {
 		ExactBlockedNames:    banned,
 	})
 	test.AssertNotError(t, err, "Couldn't serialize banned list")
-	f, _ := ioutil.TempFile("", "test-wildcard-banlist.*.yaml")
+	f, _ := os.CreateTemp("", "test-wildcard-banlist.*.yaml")
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), bannedBytes, 0640)
+	err = os.WriteFile(f.Name(), bannedBytes, 0640)
 	test.AssertNotError(t, err, "Couldn't write serialized banned list to file")
 	err = pa.SetHostnamePolicyFile(f.Name())
 	test.AssertNotError(t, err, "Couldn't load policy contents from file")
@@ -445,10 +444,10 @@ func TestMalformedExactBlocklist(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't serialize banned list")
 
 	// Create a temp file for the YAML contents
-	f, _ := ioutil.TempFile("", "test-invalid-exactblocklist.*.yaml")
+	f, _ := os.CreateTemp("", "test-invalid-exactblocklist.*.yaml")
 	defer os.Remove(f.Name())
 	// Write the YAML to the temp file
-	err = ioutil.WriteFile(f.Name(), bannedBytes, 0640)
+	err = os.WriteFile(f.Name(), bannedBytes, 0640)
 	test.AssertNotError(t, err, "Couldn't write serialized banned list to file")
 
 	// Try to use the YAML tempfile as the hostname policy. It should produce an

--- a/privatekey/privatekey.go
+++ b/privatekey/privatekey.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"os"
 )
 
 func makeVerifyHash() (hash.Hash, error) {
@@ -87,7 +87,7 @@ func verify(privateKey crypto.Signer) (crypto.Signer, crypto.PublicKey, error) {
 // match for the private key and returned as a crypto.PublicKey. This function
 // is only intended for use in administrative tooling and tests.
 func Load(keyPath string) (crypto.Signer, crypto.PublicKey, error) {
-	keyBytes, err := ioutil.ReadFile(keyPath)
+	keyBytes, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not read key file %q", keyPath)
 	}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	mrand "math/rand"
 	"net"
@@ -1072,15 +1071,15 @@ func TestRateLimitLiveReload(t *testing.T) {
 
 	// We'll work with a temporary file as the reloader monitored rate limit
 	// policy file
-	policyFile, tempErr := ioutil.TempFile("", "rate-limit-policies.yml")
+	policyFile, tempErr := os.CreateTemp("", "rate-limit-policies.yml")
 	test.AssertNotError(t, tempErr, "should not fail to create TempFile")
 	filename := policyFile.Name()
 	defer os.Remove(filename)
 
 	// Start with bodyOne in the temp file
-	bodyOne, readErr := ioutil.ReadFile("../test/rate-limit-policies.yml")
+	bodyOne, readErr := os.ReadFile("../test/rate-limit-policies.yml")
 	test.AssertNotError(t, readErr, "should not fail to read ../test/rate-limit-policies.yml")
-	writeErr := ioutil.WriteFile(filename, bodyOne, 0644)
+	writeErr := os.WriteFile(filename, bodyOne, 0644)
 	test.AssertNotError(t, writeErr, "should not fail to write temp file")
 
 	// Configure the RA to use the monitored temp file as the policy file
@@ -1099,10 +1098,10 @@ func TestRateLimitLiveReload(t *testing.T) {
 	// Write a different  policy YAML to the monitored file, expect a reload.
 	// Sleep a few milliseconds before writing so the timestamp isn't identical to
 	// when we wrote bodyOne to the file earlier.
-	bodyTwo, readErr := ioutil.ReadFile("../test/rate-limit-policies-b.yml")
+	bodyTwo, readErr := os.ReadFile("../test/rate-limit-policies-b.yml")
 	test.AssertNotError(t, readErr, "should not fail to read ../test/rate-limit-policies-b.yml")
 	time.Sleep(1 * time.Second)
-	writeErr = ioutil.WriteFile(filename, bodyTwo, 0644)
+	writeErr = os.WriteFile(filename, bodyTwo, 0644)
 	test.AssertNotError(t, writeErr, "should not fail to write temp file")
 
 	// Sleep to allow the reloader a chance to catch that an update occurred

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -1,7 +1,7 @@
 package ratelimit
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -102,7 +102,7 @@ func TestWindowBegin(t *testing.T) {
 func TestLoadPolicies(t *testing.T) {
 	policy := New()
 
-	policyContent, readErr := ioutil.ReadFile("../test/rate-limit-policies.yml")
+	policyContent, readErr := os.ReadFile("../test/rate-limit-policies.yml")
 	test.AssertNotError(t, readErr, "Failed to load rate-limit-policies.yml")
 
 	// Test that loading a good policy from YAML doesn't error

--- a/reloader/reloader.go
+++ b/reloader/reloader.go
@@ -2,7 +2,6 @@
 package reloader
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 )
@@ -24,7 +23,7 @@ func (r *Reloader) Stop() {
 }
 
 // A pointer we can override for testing.
-var readFile = ioutil.ReadFile
+var readFile = os.ReadFile
 
 // New loads the filename provided, and calls the callback.  It then spawns a
 // goroutine to check for updates to that file, calling the callback again with

--- a/reloader/reloader_test.go
+++ b/reloader/reloader_test.go
@@ -2,7 +2,6 @@ package reloader
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -34,7 +33,7 @@ func TestNoStat(t *testing.T) {
 }
 
 func TestNoRead(t *testing.T) {
-	f, _ := ioutil.TempFile("", "test-no-read.txt")
+	f, _ := os.CreateTemp("", "test-no-read.txt")
 	defer os.Remove(f.Name())
 	oldReadFile := readFile
 	readFile = func(string) ([]byte, error) {
@@ -49,7 +48,7 @@ func TestNoRead(t *testing.T) {
 }
 
 func TestFirstError(t *testing.T) {
-	f, _ := ioutil.TempFile("", "test-first-error.txt")
+	f, _ := os.CreateTemp("", "test-first-error.txt")
 	defer os.Remove(f.Name())
 	_, err := New(f.Name(), func([]byte) error {
 		return fmt.Errorf("i die")
@@ -60,7 +59,7 @@ func TestFirstError(t *testing.T) {
 }
 
 func TestFirstSuccess(t *testing.T) {
-	f, _ := ioutil.TempFile("", "test-first-success.txt")
+	f, _ := os.CreateTemp("", "test-first-success.txt")
 	defer os.Remove(f.Name())
 	r, err := New(f.Name(), func([]byte) error {
 		return nil
@@ -90,7 +89,7 @@ func TestReload(t *testing.T) {
 	fakeTick, restoreMakeTicker := makeFakeMakeTicker()
 	defer restoreMakeTicker()
 
-	f, _ := ioutil.TempFile("", "test-reload.txt")
+	f, _ := os.CreateTemp("", "test-reload.txt")
 	filename := f.Name()
 	defer os.Remove(filename)
 
@@ -121,7 +120,7 @@ func TestReload(t *testing.T) {
 	// Write to the file, expect a reload. Sleep a few milliseconds first so the
 	// timestamps actually differ.
 	time.Sleep(1 * time.Second)
-	err = ioutil.WriteFile(filename, []byte("second body"), 0644)
+	err = os.WriteFile(filename, []byte("second body"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +144,7 @@ func TestReloadFailure(t *testing.T) {
 	// Mock out makeTicker
 	fakeTick, restoreMakeTicker := makeFakeMakeTicker()
 
-	f, _ := ioutil.TempFile("", "test-reload-failure.txt")
+	f, _ := os.CreateTemp("", "test-reload-failure.txt")
 	filename := f.Name()
 	defer func() {
 		restoreMakeTicker()
@@ -200,7 +199,7 @@ func TestReloadFailure(t *testing.T) {
 	}
 	readFile = oldReadFile
 
-	err = ioutil.WriteFile(filename, []byte("third body"), 0644)
+	err = os.WriteFile(filename, []byte("third body"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rocsp/rocsp_test.go
+++ b/rocsp/rocsp_test.go
@@ -3,7 +3,7 @@ package rocsp
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -41,7 +41,7 @@ func makeClient() (*WritingClient, clock.Clock) {
 func TestSetAndGet(t *testing.T) {
 	client, _ := makeClient()
 
-	respBytes, err := ioutil.ReadFile("testdata/ocsp.response")
+	respBytes, err := os.ReadFile("testdata/ocsp.response")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -10,11 +10,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/bits"
 	mrand "math/rand"
 	"net"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -233,7 +233,7 @@ func TestAddCertificate(t *testing.T) {
 	reg := createWorkingRegistration(t, sa)
 
 	// An example cert taken from EFF's website
-	certDER, err := ioutil.ReadFile("www.eff.org.der")
+	certDER, err := os.ReadFile("www.eff.org.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 
 	// Calling AddCertificate with a non-nil issued should succeed
@@ -254,7 +254,7 @@ func TestAddCertificate(t *testing.T) {
 
 	// Test cert generated locally by Boulder, with names [example.com,
 	// www.example.com, admin.example.com]
-	certDER2, err := ioutil.ReadFile("test-cert.der")
+	certDER2, err := os.ReadFile("test-cert.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 	serial := "ffdd9b8a82126d96f61d378d5ba99a0474f0"
 
@@ -276,7 +276,7 @@ func TestAddCertificate(t *testing.T) {
 	test.AssertEquals(t, retrievedCert2.Issued, issuedTime.UnixNano())
 
 	// Test adding OCSP response with cert
-	certDER3, err := ioutil.ReadFile("test-cert2.der")
+	certDER3, err := os.ReadFile("test-cert2.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 	ocspResp := []byte{0, 0, 1}
 	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
@@ -319,7 +319,7 @@ func TestCountCertificatesByNames(t *testing.T) {
 
 	// Test cert generated locally by Boulder, with names [example.com,
 	// www.example.com, admin.example.com]
-	certDER, err := ioutil.ReadFile("test-cert.der")
+	certDER, err := os.ReadFile("test-cert.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 
 	cert, err := x509.ParseCertificate(certDER)
@@ -395,7 +395,7 @@ func TestCountCertificatesByNames(t *testing.T) {
 		return oldCertCountFunc(sel, domain, timeRange)
 	}
 
-	certDER2, err := ioutil.ReadFile("test-cert2.der")
+	certDER2, err := os.ReadFile("test-cert2.der")
 	test.AssertNotError(t, err, "Couldn't read test-cert2.der")
 	_, err = sa.AddCertificate(ctx, &sapb.AddCertificateRequest{
 		Der:    certDER2,
@@ -838,7 +838,7 @@ func TestPreviousCertificateExists(t *testing.T) {
 	reg := createWorkingRegistration(t, sa)
 
 	// An example cert taken from EFF's website
-	certDER, err := ioutil.ReadFile("www.eff.org.der")
+	certDER, err := os.ReadFile("www.eff.org.der")
 	test.AssertNotError(t, err, "reading cert DER")
 
 	issued := sa.clk.Now()
@@ -1671,7 +1671,7 @@ func TestRevokeCertificate(t *testing.T) {
 
 	reg := createWorkingRegistration(t, sa)
 	// Add a cert to the DB to test with.
-	certDER, err := ioutil.ReadFile("www.eff.org.der")
+	certDER, err := os.ReadFile("www.eff.org.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 	_, err = sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
 		Der:      certDER,
@@ -1724,7 +1724,7 @@ func TestUpdateRevokedCertificate(t *testing.T) {
 
 	// Add a cert to the DB to test with.
 	reg := createWorkingRegistration(t, sa)
-	certDER, err := ioutil.ReadFile("www.eff.org.der")
+	certDER, err := os.ReadFile("www.eff.org.der")
 	serial := "000000000000000000000000000000021bd4"
 	issuedTime := fc.Now().UnixNano()
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
@@ -1827,7 +1827,7 @@ func TestAddCertificateRenewalBit(t *testing.T) {
 	reg := createWorkingRegistration(t, sa)
 
 	// An example cert taken from EFF's website
-	certDER, err := ioutil.ReadFile("www.eff.org.der")
+	certDER, err := os.ReadFile("www.eff.org.der")
 	test.AssertNotError(t, err, "Unexpected error reading www.eff.org.der test file")
 	cert, err := x509.ParseCertificate(certDER)
 	test.AssertNotError(t, err, "Unexpected error parsing www.eff.org.der test file")
@@ -1880,7 +1880,7 @@ func TestAddCertificateRenewalBit(t *testing.T) {
 	}
 
 	// Add a certificate with different names.
-	certDER, err = ioutil.ReadFile("test-cert.der")
+	certDER, err = os.ReadFile("test-cert.der")
 	test.AssertNotError(t, err, "Unexpected error reading test-cert.der test file")
 	cert, err = x509.ParseCertificate(certDER)
 	test.AssertNotError(t, err, "Unexpected error parsing test-cert.der test file")

--- a/test/akamai-test-srv/main.go
+++ b/test/akamai-test-srv/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sync"
@@ -52,7 +52,7 @@ func main() {
 		var purgeRequest struct {
 			Objects []string `json:"objects"`
 		}
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Println("Can't read body:", err)

--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -47,11 +46,11 @@ func genKey(path string, inSlot string) error {
 // rewriteConfig creates a temporary config based on the template at path
 // using the variables in rewrites.
 func rewriteConfig(path string, rewrites map[string]string) (string, error) {
-	tmplBytes, err := ioutil.ReadFile(path)
+	tmplBytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	tmp, err := ioutil.TempFile(os.TempDir(), "ceremony-config")
+	tmp, err := os.CreateTemp(os.TempDir(), "ceremony-config")
 	if err != nil {
 		return "", err
 	}

--- a/test/certs.go
+++ b/test/certs.go
@@ -10,8 +10,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 )
 
@@ -19,7 +19,7 @@ import (
 // Can be paired with issuance.LoadCertificate to get both a CA cert and its
 // associated private key for use in signing throwaway test certs.
 func LoadSigner(filename string) (crypto.Signer, error) {
-	keyBytes, err := ioutil.ReadFile(filename)
+	keyBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -10,10 +10,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -43,7 +44,7 @@ func readJSON(w http.ResponseWriter, r *http.Request, output interface{}) error 
 	if r.Method != "POST" {
 		return fmt.Errorf("incorrect method; only POST allowed")
 	}
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}
@@ -119,7 +120,7 @@ func (is *integrationSrv) addChainOrPre(w http.ResponseWriter, r *http.Request, 
 		http.NotFound(w, r)
 		return
 	}
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -238,7 +239,7 @@ func runPersonality(p Personality) {
 func main() {
 	configFile := flag.String("config", "", "Path to config file.")
 	flag.Parse()
-	data, err := ioutil.ReadFile(*configFile)
+	data, err := os.ReadFile(*configFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -39,7 +38,7 @@ func TestCAALogChecker(t *testing.T) {
 	// we don't know how many issuances there have been. We just
 	// test for caa-log-checker outputting _something_ since any
 	// output, with a 0 exit code, indicates it's found bad issuances.
-	tmp, err := ioutil.TempFile(os.TempDir(), "boulder-va-empty")
+	tmp, err := os.CreateTemp(os.TempDir(), "boulder-va-empty")
 	test.AssertNotError(t, err, "failed to create temporary file")
 	defer os.Remove(tmp.Name())
 	cmd = exec.Command("bin/caa-log-checker", "-ra-log", "/var/log/boulder-ra.log", "-va-logs", tmp.Name())

--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -79,7 +79,7 @@ func TestCRLPipeline(t *testing.T) {
 	test.AssertEquals(t, resp.StatusCode, 200)
 
 	// Confirm that the revoked certificate entry has the correct reason.
-	reason, err := ioutil.ReadAll(resp.Body)
+	reason, err := io.ReadAll(resp.Body)
 	test.AssertNotError(t, err, "reading revocation reason")
 	test.AssertEquals(t, string(reason), "5")
 	resp.Body.Close()

--- a/test/integration/orphan_finder_test.go
+++ b/test/integration/orphan_finder_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
@@ -40,7 +39,7 @@ func TestOrphanFinder(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	f, _ := ioutil.TempFile("", "orphaned.log")
+	f, _ := os.CreateTemp("", "orphaned.log")
 	io.WriteString(f, fmt.Sprintf(template, precert.SerialNumber.Bytes(),
 		precert.Raw, cert.SerialNumber.Bytes(), cert.Raw))
 	f.Close()
@@ -75,7 +74,7 @@ func makeFakeCert(precert bool) (*x509.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	pubKeyBytes, err := ioutil.ReadFile("/hierarchy/intermediate-signing-pub-rsa.pem")
+	pubKeyBytes, err := os.ReadFile("/hierarchy/intermediate-signing-pub-rsa.pem")
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +87,7 @@ func makeFakeCert(precert bool) (*x509.Certificate, error) {
 		return nil, fmt.Errorf("parsing issuer public key: %s", err)
 	}
 	var pkcs11Config pkcs11key.Config
-	contents, err := ioutil.ReadFile("test/test-ca.key-pkcs11.json")
+	contents, err := os.ReadFile("test/test-ca.key-pkcs11.json")
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +114,7 @@ func makeFakeCert(precert bool) (*x509.Certificate, error) {
 	}
 	if precert {
 		template.ExtraExtensions = []pkix.Extension{
-			pkix.Extension{
+			{
 				Id:       OIDExtensionCTPoison,
 				Critical: true,
 				Value:    []byte{5, 0},

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -9,7 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -679,21 +679,21 @@ func TestBadKeyRevoker(t *testing.T) {
 	revokeeCount, err := http.Get("http://boulder:9381/count?to=revokee@letsencrypt.org&from=bad-key-revoker@test.org")
 	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
 	defer func() { _ = revokeeCount.Body.Close() }()
-	body, err := ioutil.ReadAll(revokeeCount.Body)
+	body, err := io.ReadAll(revokeeCount.Body)
 	test.AssertNotError(t, err, "failed to read body")
 	test.AssertEquals(t, string(body), "1\n")
 
 	revokerCount, err := http.Get("http://boulder:9381/count?to=revoker@letsencrypt.org&from=bad-key-revoker@test.org")
 	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
 	defer func() { _ = revokerCount.Body.Close() }()
-	body, err = ioutil.ReadAll(revokerCount.Body)
+	body, err = io.ReadAll(revokerCount.Body)
 	test.AssertNotError(t, err, "failed to read body")
 	test.AssertEquals(t, string(body), "1\n")
 
 	sharedCount, err := http.Get("http://boulder:9381/count?to=shared@letsencrypt.org&from=bad-key-revoker@test.org")
 	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
 	defer func() { _ = sharedCount.Body.Close() }()
-	body, err = ioutil.ReadAll(sharedCount.Body)
+	body, err = io.ReadAll(sharedCount.Body)
 	test.AssertNotError(t, err, "failed to read body")
 	test.AssertEquals(t, string(body), "1\n")
 }
@@ -767,21 +767,21 @@ func TestBadKeyRevokerByAccount(t *testing.T) {
 	revokeeCount, err := http.Get("http://boulder:9381/count?to=revokee-moz@letsencrypt.org&from=bad-key-revoker@test.org")
 	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
 	defer func() { _ = revokeeCount.Body.Close() }()
-	body, err := ioutil.ReadAll(revokeeCount.Body)
+	body, err := io.ReadAll(revokeeCount.Body)
 	test.AssertNotError(t, err, "failed to read body")
 	test.AssertEquals(t, string(body), "0\n")
 
 	revokerCount, err := http.Get("http://boulder:9381/count?to=revoker-moz@letsencrypt.org&from=bad-key-revoker@test.org")
 	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
 	defer func() { _ = revokerCount.Body.Close() }()
-	body, err = ioutil.ReadAll(revokerCount.Body)
+	body, err = io.ReadAll(revokerCount.Body)
 	test.AssertNotError(t, err, "failed to read body")
 	test.AssertEquals(t, string(body), "0\n")
 
 	sharedCount, err := http.Get("http://boulder:9381/count?to=shared-moz@letsencrypt.org&from=bad-key-revoker@test.org")
 	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
 	defer func() { _ = sharedCount.Body.Close() }()
-	body, err = ioutil.ReadAll(sharedCount.Body)
+	body, err = io.ReadAll(sharedCount.Body)
 	test.AssertNotError(t, err, "failed to read body")
 	test.AssertEquals(t, string(body), "0\n")
 }

--- a/test/integration/wfe_test.go
+++ b/test/integration/wfe_test.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -45,7 +45,7 @@ func TestWFEHTTPMetrics(t *testing.T) {
 	resp, err = http.Get("http://boulder:8013/metrics")
 	test.AssertNotError(t, err, "GET boulder-wfe2 metrics")
 	test.AssertEquals(t, resp.StatusCode, http.StatusOK)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	test.AssertNotError(t, err, "Reading boulder-wfe2 metrics response")
 	test.AssertContains(t, string(body), `response_time_count{code="200",endpoint="/directory",method="GET"}`)
 	resp.Body.Close()

--- a/test/load-generator/acme/directory.go
+++ b/test/load-generator/acme/directory.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -150,7 +150,7 @@ func getRawDirectory(directoryURL string) ([]byte, error) {
 		return nil, ErrInvalidDirectoryHTTPCode
 	}
 
-	rawDirectory, err := ioutil.ReadAll(resp.Body)
+	rawDirectory, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/test/load-generator/boulder-calls.go
+++ b/test/load-generator/boulder-calls.go
@@ -15,7 +15,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	mrand "math/rand"
 	"net/http"
 	"time"
@@ -203,7 +203,7 @@ func newOrder(s *State, ctx *context) error {
 		return fmt.Errorf("%s, post failed: %s", newOrderURL, err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s, bad response: %s", newOrderURL, body)
 	}
@@ -248,7 +248,7 @@ func getAuthorization(s *State, ctx *context, url string) (*core.Authorization, 
 
 	// Read the response body
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func completeAuthorization(authz *core.Authorization, s *State, ctx *context) er
 
 	// Read the response body and cleanup when finished
 	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -419,7 +419,7 @@ func getOrder(s *State, ctx *context, url string) (*OrderJSON, error) {
 	}
 	// Read the response body
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%s, bad response: %s", url, body)
 	}
@@ -538,7 +538,7 @@ func finalizeOrder(s *State, ctx *context) error {
 	defer resp.Body.Close()
 	// Read the body to ensure there isn't an error. We don't need the actual
 	// contents.
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -592,7 +592,7 @@ func getCert(s *State, ctx *context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("%s bad response: %s", url, err)
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // revokeCertificate removes a certificate url from the context, retrieves it,
@@ -648,7 +648,7 @@ func revokeCertificate(s *State, ctx *context) error {
 	}
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/test/load-generator/main.go
+++ b/test/load-generator/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -52,7 +51,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	configBytes, err := ioutil.ReadFile(*configPath)
+	configBytes, err := os.ReadFile(*configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read load-generator config file %q: %s\n", *configPath, err)
 		os.Exit(1)

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -228,7 +228,7 @@ func (s *State) Snapshot(filename string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, cont, os.ModePerm)
+	return os.WriteFile(filename, cont, os.ModePerm)
 }
 
 // Restore previously generated accounts
@@ -241,7 +241,7 @@ func (s *State) Restore(filename string) error {
 		return err
 	}
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -56,7 +55,7 @@ var DefaultConfig = Config{
 	ignoreExpiredCerts: *ignoreExpiredCerts,
 	expectStatus:       *expectStatus,
 	expectReason:       *expectReason,
-	output:             ioutil.Discard,
+	output:             io.Discard,
 	issuerFile:         *issuerFile,
 }
 
@@ -64,7 +63,7 @@ var parseFlagsOnce sync.Once
 
 // ConfigFromFlags returns a Config whose values are populated from any command
 // line flags passed by the user, or default values if not passed.  However, it
-// replaces ioutil.Discard with os.Stdout so that CLI usages of this package
+// replaces io.Discard with os.Stdout so that CLI usages of this package
 // will produce output on stdout by default.
 func ConfigFromFlags() Config {
 	parseFlagsOnce.Do(func() {
@@ -108,7 +107,7 @@ func (template Config) WithOutput(w io.Writer) Config {
 }
 
 func GetIssuerFile(f string) (*x509.Certificate, error) {
-	certFileBytes, err := ioutil.ReadFile(f)
+	certFileBytes, err := os.ReadFile(f)
 	if err != nil {
 		return nil, fmt.Errorf("reading issuer file: %w", err)
 	}
@@ -136,7 +135,7 @@ func GetIssuer(cert *x509.Certificate) (*x509.Certificate, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +194,7 @@ func parseCMS(body []byte) (*x509.Certificate, error) {
 // ReqFle makes an OCSP request using the given config for the PEM-encoded
 // certificate in fileName, and returns the response.
 func ReqFile(fileName string, config Config) (*ocsp.Response, error) {
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +253,7 @@ func Req(cert *x509.Certificate, config Config) (*ocsp.Response, error) {
 	if httpResp.StatusCode != 200 {
 		return nil, fmt.Errorf("http status code %d", httpResp.StatusCode)
 	}
-	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	respBytes, err := io.ReadAll(httpResp.Body)
 	defer httpResp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/va/http.go
+++ b/va/http.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -649,7 +648,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 
 	// At this point we've made a successful request (be it from a retry or
 	// otherwise) and can read and process the response body.
-	body, err := ioutil.ReadAll(&io.LimitedReader{R: httpResponse.Body, N: maxResponseSize})
+	body, err := io.ReadAll(&io.LimitedReader{R: httpResponse.Body, N: maxResponseSize})
 	closeErr := httpResponse.Body.Close()
 	if err == nil {
 		err = closeErr

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	mrand "math/rand"
 	"net"
 	"net/http"
@@ -1613,7 +1613,7 @@ func TestOldTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/jwk.go
+++ b/web/jwk.go
@@ -2,7 +2,7 @@ package web
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	jose "gopkg.in/square/go-jose.v2"
 )
@@ -10,7 +10,7 @@ import (
 // LoadJWK loads a JSON encoded JWK specified by filename or returns an error
 func LoadJWK(filename string) (*jose.JSONWebKey, error) {
 	var jwk jose.JSONWebKey
-	if jsonBytes, err := ioutil.ReadFile(filename); err != nil {
+	if jsonBytes, err := os.ReadFile(filename); err != nil {
 		return nil, err
 	} else if err = json.Unmarshal(jsonBytes, &jwk); err != nil {
 		return nil, err

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -354,7 +354,7 @@ func (wfe *WebFrontEndImpl) parseJWSRequest(request *http.Request) (*jose.JSONWe
 
 	// Read the POST request body's bytes. validPOSTRequest has already checked
 	// that the body is non-nil
-	bodyBytes, err := ioutil.ReadAll(http.MaxBytesReader(nil, request.Body, maxRequestSize))
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(nil, request.Body, maxRequestSize))
 	if err != nil {
 		if err.Error() == "http: request body too large" {
 			return nil, probs.Unauthorized("request body too large")

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -15,11 +15,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -248,7 +248,7 @@ func (ra *MockRegistrationAuthority) FinalizeOrder(ctx context.Context, in *rapb
 }
 
 func makeBody(s string) io.ReadCloser {
-	return ioutil.NopCloser(strings.NewReader(s))
+	return io.NopCloser(strings.NewReader(s))
 }
 
 // loadKey loads a private key from PEM/DER-encoded data and returns
@@ -1800,14 +1800,14 @@ func TestGetCertificate(t *testing.T) {
 	_, ok := altKey.(*rsa.PrivateKey)
 	test.Assert(t, ok, "Couldn't load RSA key")
 
-	certPemBytes, _ := ioutil.ReadFile("../test/hierarchy/ee-r3.cert.pem")
+	certPemBytes, _ := os.ReadFile("../test/hierarchy/ee-r3.cert.pem")
 	cert, err := core.LoadCert("../test/hierarchy/ee-r3.cert.pem")
 	test.AssertNotError(t, err, "failed to load test certificate")
 
-	chainPemBytes, err := ioutil.ReadFile("../test/hierarchy/int-r3.cert.pem")
+	chainPemBytes, err := os.ReadFile("../test/hierarchy/int-r3.cert.pem")
 	test.AssertNotError(t, err, "Error reading ../test/hierarchy/int-r3.cert.pem")
 
-	chainCrossPemBytes, err := ioutil.ReadFile("../test/hierarchy/int-r3-cross.cert.pem")
+	chainCrossPemBytes, err := os.ReadFile("../test/hierarchy/int-r3-cross.cert.pem")
 	test.AssertNotError(t, err, "Error reading ../test/hierarchy/int-r3-cross.cert.pem")
 
 	reqPath := fmt.Sprintf("/acme/cert/%s", core.SerialToString(cert.SerialNumber))
@@ -1994,7 +1994,7 @@ func (sa *mockSAWithNewCert) GetCertificate(_ context.Context, req *sapb.Serial,
 		return nil, fmt.Errorf("failed to load test issuer cert: %w", err)
 	}
 
-	issuerKeyPem, err := ioutil.ReadFile("../test/hierarchy/int-e1.key.pem")
+	issuerKeyPem, err := os.ReadFile("../test/hierarchy/int-e1.key.pem")
 	if err != nil {
 		return nil, fmt.Errorf("failed to load test issuer key: %w", err)
 	}
@@ -2135,11 +2135,11 @@ func TestGetCertificateHEADHasCorrectBodyLength(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
-	certPemBytes, _ := ioutil.ReadFile("../test/hierarchy/ee-r3.cert.pem")
+	certPemBytes, _ := os.ReadFile("../test/hierarchy/ee-r3.cert.pem")
 	cert, err := core.LoadCert("../test/hierarchy/ee-r3.cert.pem")
 	test.AssertNotError(t, err, "failed to load test certificate")
 
-	chainPemBytes, err := ioutil.ReadFile("../test/hierarchy/int-r3.cert.pem")
+	chainPemBytes, err := os.ReadFile("../test/hierarchy/int-r3.cert.pem")
 	test.AssertNotError(t, err, "Error reading ../test/hierarchy/int-r3.cert.pem")
 	chain := fmt.Sprintf("%s\n%s", string(certPemBytes), string(chainPemBytes))
 	chainLen := strconv.Itoa(len(chain))
@@ -2156,7 +2156,7 @@ func TestGetCertificateHEADHasCorrectBodyLength(t *testing.T) {
 	if err != nil {
 		test.AssertNotError(t, err, "do error")
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		test.AssertNotEquals(t, err, "readall error")
 	}
@@ -2666,7 +2666,7 @@ func TestKeyRollover(t *testing.T) {
 	existingKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	test.AssertNotError(t, err, "Error creating random 2048 RSA key")
 
-	newKeyBytes, err := ioutil.ReadFile("../test/test-key-5.der")
+	newKeyBytes, err := os.ReadFile("../test/test-key-5.der")
 	test.AssertNotError(t, err, "Failed to read ../test/test-key-5.der")
 	newKeyPriv, err := x509.ParsePKCS1PrivateKey(newKeyBytes)
 	test.AssertNotError(t, err, "Failed parsing private key")
@@ -2756,7 +2756,7 @@ func TestKeyRolloverMismatchedJWSURLs(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	wfe, _ := setupWFE(t)
 
-	newKeyBytes, err := ioutil.ReadFile("../test/test-key-5.der")
+	newKeyBytes, err := os.ReadFile("../test/test-key-5.der")
 	test.AssertNotError(t, err, "Failed to read ../test/test-key-5.der")
 	newKeyPriv, err := x509.ParsePKCS1PrivateKey(newKeyBytes)
 	test.AssertNotError(t, err, "Failed parsing private key")
@@ -2872,7 +2872,7 @@ func TestGetOrder(t *testing.T) {
 }
 
 func makeRevokeRequestJSON(reason *revocation.Reason) ([]byte, error) {
-	certPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-r3.cert.pem")
+	certPemBytes, err := os.ReadFile("../test/hierarchy/ee-r3.cert.pem")
 	if err != nil {
 		return nil, err
 	}
@@ -2932,7 +2932,7 @@ func TestRevokeCertificateByKeyValid(t *testing.T) {
 	mockLog := wfe.log.(*blog.Mock)
 	mockLog.Clear()
 
-	keyPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-r3.key.pem")
+	keyPemBytes, err := os.ReadFile("../test/hierarchy/ee-r3.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
 	key := loadKey(t, keyPemBytes)
 
@@ -2974,7 +2974,7 @@ func TestRevokeCertificateNotIssued(t *testing.T) {
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, k.Public(), k)
 	test.AssertNotError(t, err, "Unexpected error creating self-signed junk cert")
 
-	keyPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-r3.key.pem")
+	keyPemBytes, err := os.ReadFile("../test/hierarchy/ee-r3.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
 	key := loadKey(t, keyPemBytes)
 
@@ -2995,7 +2995,7 @@ func TestRevokeCertificateExpired(t *testing.T) {
 	wfe, fc := setupWFE(t)
 	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
-	keyPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-r3.key.pem")
+	keyPemBytes, err := os.ReadFile("../test/hierarchy/ee-r3.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
 	key := loadKey(t, keyPemBytes)
 
@@ -3088,7 +3088,7 @@ func TestRevokeCertificateWrongCertificateKey(t *testing.T) {
 	wfe, _ := setupWFE(t)
 	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
 
-	keyPemBytes, err := ioutil.ReadFile("../test/hierarchy/ee-e1.key.pem")
+	keyPemBytes, err := os.ReadFile("../test/hierarchy/ee-e1.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
 	key := loadKey(t, keyPemBytes)
 


### PR DESCRIPTION
The iotuil package has been deprecated since go1.16; the various
functions it provided now exist in the os and io packages. Replace all
instances of ioutil with either io or os, as appropriate.