### PR TITLE
Fix merge conflict in sa_test.go

### DIFF
--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1736,7 +1736,7 @@ func TestRevokeCertificateNoResponse(t *testing.T) {
 
 	reg := createWorkingRegistration(t, sa)
 	// Add a cert to the DB to test with.
-	certDER, err := ioutil.ReadFile("www.eff.org.der")
+	certDER, err := os.ReadFile("www.eff.org.der")
 	test.AssertNotError(t, err, "Couldn't read example cert DER")
 	_, err = sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
 		Der:      certDER,


### PR DESCRIPTION
GitHub doesn't auto-rebase changes before merging, and doesn't re-run
tests against the current HEAD of the target branch before merging, so
it didn't catch that all imports of ioutil had been removed in #6286 while
a new usage was added in #6284. Replace the new usage of ioutil with
the appropriate function from the os package instead.