### PR TITLE
boulder-observer: Add support for prober specific metrics

### DIFF
--- a/observer/mon_conf.go
+++ b/observer/mon_conf.go
@@ -45,7 +45,7 @@ func (c MonConf) unmarshalConfigurer() (probers.Configurer, error) {
 // makeMonitor constructs a `monitor` object from the contents of the
 // bound `MonConf`. If the `MonConf` cannot be validated, an error
 // appropriate for end-user consumption is returned instead.
-func (c MonConf) makeMonitor(collectors map[string]*prometheus.Collector) (*monitor, error) {
+func (c MonConf) makeMonitor(collectors map[string]prometheus.Collector) (*monitor, error) {
 	err := c.validatePeriod()
 	if err != nil {
 		return nil, err

--- a/observer/obs_conf.go
+++ b/observer/obs_conf.go
@@ -60,7 +60,7 @@ func (c *ObsConf) validateDebugAddr() error {
 func (c *ObsConf) makeMonitors(metrics *prometheus.Registerer) ([]*monitor, []error, error) {
 	var errs []error
 	var monitors []*monitor
-	proberSpecificMetrics := make(map[string]map[string]*prometheus.Collector)
+	proberSpecificMetrics := make(map[string]map[string]prometheus.Collector)
 	for e, m := range c.MonConfs {
 		// set up custom metrics internal to each prober kind
 		kind := probers.NormalizedKind(m.Kind)
@@ -78,7 +78,7 @@ func (c *ObsConf) makeMonitors(metrics *prometheus.Registerer) ([]*monitor, []er
 			collectors := proberConf.Instrument()
 			for name, collector := range collectors {
 				// register the collector with the prometheus registry
-				(*metrics).MustRegister(*collector)
+				(*metrics).MustRegister(collector)
 				// store the registered collector so we can pass it to every
 				// monitor that will construct this kind of prober
 				proberSpecificMetrics[kind][name] = collector

--- a/observer/obs_conf.go
+++ b/observer/obs_conf.go
@@ -57,7 +57,7 @@ func (c *ObsConf) validateDebugAddr() error {
 	return nil
 }
 
-func (c *ObsConf) makeMonitors(metrics *prometheus.Registerer) ([]*monitor, []error, error) {
+func (c *ObsConf) makeMonitors(metrics prometheus.Registerer) ([]*monitor, []error, error) {
 	var errs []error
 	var monitors []*monitor
 	proberSpecificMetrics := make(map[string]map[string]prometheus.Collector)
@@ -78,7 +78,7 @@ func (c *ObsConf) makeMonitors(metrics *prometheus.Registerer) ([]*monitor, []er
 			collectors := proberConf.Instrument()
 			for name, collector := range collectors {
 				// register the collector with the prometheus registry
-				(*metrics).MustRegister(collector)
+				metrics.MustRegister(collector)
 				// store the registered collector so we can pass it to every
 				// monitor that will construct this kind of prober
 				proberSpecificMetrics[kind][name] = collector
@@ -146,7 +146,7 @@ func (c *ObsConf) MakeObserver() (*Observer, error) {
 	logger.Infof("Initializing boulder-observer daemon")
 	logger.Debugf("Using config: %+v", c)
 
-	monitors, errs, err := c.makeMonitors(&metrics)
+	monitors, errs, err := c.makeMonitors(metrics)
 	if len(errs) != 0 {
 		logger.Errf("%d of %d monitors failed validation", len(errs), len(c.MonConfs))
 		for _, err := range errs {

--- a/observer/obs_conf.go
+++ b/observer/obs_conf.go
@@ -74,14 +74,15 @@ func (c *ObsConf) makeMonitors(metrics prometheus.Registerer) ([]*monitor, []err
 				// append error to errs
 				message := fmt.Errorf("metrics for prober kind '%s' couldn't be registered: %v", kind, err)
 				errs = append(errs, message)
-			}
-			collectors := proberConf.Instrument()
-			for name, collector := range collectors {
-				// register the collector with the prometheus registry
-				metrics.MustRegister(collector)
-				// store the registered collector so we can pass it to every
-				// monitor that will construct this kind of prober
-				proberSpecificMetrics[kind][name] = collector
+			} else {
+				collectors := proberConf.Instrument()
+				for name, collector := range collectors {
+					// register the collector with the prometheus registry
+					metrics.MustRegister(collector)
+					// store the registered collector so we can pass it to every
+					// monitor that will construct this kind of prober
+					proberSpecificMetrics[kind][name] = collector
+				}
 			}
 		}
 
@@ -94,13 +95,13 @@ func (c *ObsConf) makeMonitors(metrics prometheus.Registerer) ([]*monitor, []err
 					"'monitors' entry #%s couldn't be validated: %v", entry, err))
 
 			// increment metrics
-			countMonitors.WithLabelValues(m.Kind, "false").Inc()
+			countMonitors.WithLabelValues(kind, "false").Inc()
 		} else {
 			// append monitor to monitors
 			monitors = append(monitors, monitor)
 
 			// increment metrics
-			countMonitors.WithLabelValues(m.Kind, "true").Inc()
+			countMonitors.WithLabelValues(kind, "true").Inc()
 		}
 	}
 	if len(c.MonConfs) == len(errs) {

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -61,7 +61,7 @@ func TestObsConf_makeMonitors(t *testing.T) {
 				MonConfs:  tt.fields.MonConfs,
 			}
 			var reg prometheus.Registerer = metrics.NoopRegisterer
-			_, errs, err := c.makeMonitors(&reg)
+			_, errs, err := c.makeMonitors(reg)
 			if len(errs) != len(tt.errs) {
 				t.Errorf("ObsConf.validateMonConfs() errs = %d, want %d", len(errs), len(tt.errs))
 				t.Logf("%v", errs)

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/letsencrypt/boulder/observer/probers"
 	_ "github.com/letsencrypt/boulder/observer/probers/mock"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -58,7 +59,8 @@ func TestObsConf_makeMonitors(t *testing.T) {
 				DebugAddr: tt.fields.DebugAddr,
 				MonConfs:  tt.fields.MonConfs,
 			}
-			_, errs, err := c.makeMonitors()
+			var reg prometheus.Registerer = prometheus.NewRegistry()
+			_, errs, err := c.makeMonitors(&reg)
 			if len(errs) != len(tt.errs) {
 				t.Errorf("ObsConf.validateMonConfs() errs = %d, want %d", len(errs), len(tt.errs))
 				t.Logf("%v", errs)

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/observer/probers"
 	_ "github.com/letsencrypt/boulder/observer/probers/mock"
 	"github.com/letsencrypt/boulder/test"
@@ -59,7 +60,7 @@ func TestObsConf_makeMonitors(t *testing.T) {
 				DebugAddr: tt.fields.DebugAddr,
 				MonConfs:  tt.fields.MonConfs,
 			}
-			var reg prometheus.Registerer = prometheus.NewRegistry()
+			var reg prometheus.Registerer = metrics.NoopRegisterer
 			_, errs, err := c.makeMonitors(&reg)
 			if len(errs) != len(tt.errs) {
 				t.Errorf("ObsConf.validateMonConfs() errs = %d, want %d", len(errs), len(tt.errs))

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/letsencrypt/boulder/observer/probers"
 	_ "github.com/letsencrypt/boulder/observer/probers/mock"
 	"github.com/letsencrypt/boulder/test"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -60,8 +60,7 @@ func TestObsConf_makeMonitors(t *testing.T) {
 				DebugAddr: tt.fields.DebugAddr,
 				MonConfs:  tt.fields.MonConfs,
 			}
-			var reg prometheus.Registerer = metrics.NoopRegisterer
-			_, errs, err := c.makeMonitors(reg)
+			_, errs, err := c.makeMonitors(metrics.NoopRegisterer)
 			if len(errs) != len(tt.errs) {
 				t.Errorf("ObsConf.validateMonConfs() errs = %d, want %d", len(errs), len(tt.errs))
 				t.Logf("%v", errs)

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -15,7 +15,7 @@ import (
 const (
 	debugAddr = ":8040"
 	errDBZMsg = "over 9000"
-	mockConf  = "MockConf"
+	mockConf  = "Mock"
 )
 
 func TestObsConf_makeMonitors(t *testing.T) {

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -92,12 +92,8 @@ func (c DNSConf) validateQType() error {
 }
 
 func (c DNSConf) validateCollectors(colls map[string]*prometheus.Collector) error {
-	for name := range colls {
-		switch name {
-		default:
-			message := fmt.Sprintf("dns prober received unexpected collector '%s'", name)
-			return errors.New(message)
-		}
+	if colls != nil {
+		return errors.New("dns prober defines no metrics but received non-nil collector map")
 	}
 	return nil
 }
@@ -148,9 +144,9 @@ func (c DNSConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Pro
 // Instrument constructs any `prometheus.Collector` objects the `DNSProbe` will
 // need to report its own metrics. A map is returned containing the constructed
 // objects, indexed by the name of the prometheus metric. If no objects were
-// constructed, an empty map is returned.
+// constructed, nil is returned.
 func (c DNSConf) Instrument() map[string]*prometheus.Collector {
-	return map[string]*prometheus.Collector{}
+	return nil
 }
 
 // init is called at runtime and registers `DNSConf`, a `Prober`

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -92,7 +93,7 @@ func (c DNSConf) validateQType() error {
 // MakeProber constructs a `DNSProbe` object from the contents of the
 // bound `DNSConf` object. If the `DNSConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
-func (c DNSConf) MakeProber() (probers.Prober, error) {
+func (c DNSConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
 	// validate `query_name`
 	if !dns.IsFqdn(dns.Fqdn(c.QName)) {
 		return nil, fmt.Errorf(
@@ -124,6 +125,10 @@ func (c DNSConf) MakeProber() (probers.Prober, error) {
 		server:  c.Server,
 		qtype:   validQTypes[strings.Trim(strings.ToUpper(c.QType), " ")],
 	}, nil
+}
+
+func (c DNSConf) Instrument() map[string]*prometheus.Collector {
+	return map[string]*prometheus.Collector{}
 }
 
 // init is called at runtime and registers `DNSConf`, a `Prober`

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -93,7 +93,7 @@ func (c DNSConf) validateQType() error {
 // MakeProber constructs a `DNSProbe` object from the contents of the
 // bound `DNSConf` object. If the `DNSConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
-func (c DNSConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
+func (c DNSConf) MakeProber(_ map[string]prometheus.Collector) (probers.Prober, error) {
 	// validate `query_name`
 	if !dns.IsFqdn(dns.Fqdn(c.QName)) {
 		return nil, fmt.Errorf(
@@ -128,7 +128,7 @@ func (c DNSConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober,
 }
 
 // Instrument is a no-op to implement the `Configurer` interface.
-func (c DNSConf) Instrument() map[string]*prometheus.Collector {
+func (c DNSConf) Instrument() map[string]prometheus.Collector {
 	return nil
 }
 

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -25,6 +25,11 @@ type DNSConf struct {
 	QType   string `yaml:"query_type"`
 }
 
+// Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
+func (p DNSConf) Kind() string {
+	return "DNS"
+}
+
 // UnmarshalSettings constructs a DNSConf object from YAML as bytes.
 func (c DNSConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf DNSConf
@@ -135,5 +140,5 @@ func (c DNSConf) Instrument() map[string]prometheus.Collector {
 // init is called at runtime and registers `DNSConf`, a `Prober`
 // `Configurer` type, as "DNS".
 func init() {
-	probers.Register("DNS", DNSConf{})
+	probers.Register(DNSConf{})
 }

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -93,7 +93,7 @@ func (c DNSConf) validateQType() error {
 // MakeProber constructs a `DNSProbe` object from the contents of the
 // bound `DNSConf` object. If the `DNSConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
-func (c DNSConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Prober, error) {
+func (c DNSConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
 	// validate `query_name`
 	if !dns.IsFqdn(dns.Fqdn(c.QName)) {
 		return nil, fmt.Errorf(
@@ -127,10 +127,7 @@ func (c DNSConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Pro
 	}, nil
 }
 
-// Instrument constructs any `prometheus.Collector` objects the `DNSProbe` will
-// need to report its own metrics. A map is returned containing the constructed
-// objects, indexed by the name of the prometheus metric. If no objects were
-// constructed, nil is returned.
+// Instrument is a no-op to implement the `Configurer` interface.
 func (c DNSConf) Instrument() map[string]*prometheus.Collector {
 	return nil
 }

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -26,7 +26,7 @@ type DNSConf struct {
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
-func (p DNSConf) Kind() string {
+func (c DNSConf) Kind() string {
 	return "DNS"
 }
 

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -127,6 +127,10 @@ func (c DNSConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober,
 	}, nil
 }
 
+// Instrument constructs any `prometheus.Collector` objects the `DNSProbe` will
+// need to report its own metrics. A map is returned containing the constructed
+// objects, indexed by the name of the prometheus metric. If no objects were
+// constructed, an empty map is returned.
 func (c DNSConf) Instrument() map[string]*prometheus.Collector {
 	return map[string]*prometheus.Collector{}
 }

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -1,7 +1,6 @@
 package probers
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -91,13 +90,6 @@ func (c DNSConf) validateQType() error {
 		"invalid `query_type`, got: %q, expected one in %s", c.QType, q)
 }
 
-func (c DNSConf) validateCollectors(colls map[string]*prometheus.Collector) error {
-	if colls != nil {
-		return errors.New("dns prober defines no metrics but received non-nil collector map")
-	}
-	return nil
-}
-
 // MakeProber constructs a `DNSProbe` object from the contents of the
 // bound `DNSConf` object. If the `DNSConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
@@ -122,12 +114,6 @@ func (c DNSConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Pro
 
 	// validate `query_type`
 	err = c.validateQType()
-	if err != nil {
-		return nil, err
-	}
-
-	// validate the prometheus collectors that were passed in
-	err = c.validateCollectors(colls)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/dns/dns_conf_test.go
+++ b/observer/probers/dns/dns_conf_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/letsencrypt/boulder/test"
-	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -130,8 +129,6 @@ func TestDNSConf_validateProto(t *testing.T) {
 }
 
 func TestDNSConf_MakeProber(t *testing.T) {
-	conf := DNSConf{}
-	colls := conf.Instrument()
 	type fields struct {
 		Proto   string
 		Server  string
@@ -142,15 +139,14 @@ func TestDNSConf_MakeProber(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		colls   map[string]prometheus.Collector
 		wantErr bool
 	}{
 		// valid
-		{"valid", fields{"udp", "1.1.1.1:53", true, "google.com", "A"}, colls, false},
+		{"valid", fields{"udp", "1.1.1.1:53", true, "google.com", "A"}, false},
 		// invalid
-		{"bad proto", fields{"can with string", "1.1.1.1:53", true, "google.com", "A"}, colls, true},
-		{"bad server", fields{"udp", "1.1.1.1:9000000", true, "google.com", "A"}, colls, true},
-		{"bad qtype", fields{"udp", "1.1.1.1:9000000", true, "google.com", "BAZ"}, colls, true},
+		{"bad proto", fields{"can with string", "1.1.1.1:53", true, "google.com", "A"}, true},
+		{"bad server", fields{"udp", "1.1.1.1:9000000", true, "google.com", "A"}, true},
+		{"bad qtype", fields{"udp", "1.1.1.1:9000000", true, "google.com", "BAZ"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -161,7 +157,7 @@ func TestDNSConf_MakeProber(t *testing.T) {
 				QName:   tt.fields.QName,
 				QType:   tt.fields.QType,
 			}
-			_, err := c.MakeProber(tt.colls)
+			_, err := c.MakeProber(nil)
 			if tt.wantErr {
 				test.AssertError(t, err, "DNSConf.MakeProber() should have errored")
 			} else {

--- a/observer/probers/dns/dns_conf_test.go
+++ b/observer/probers/dns/dns_conf_test.go
@@ -142,7 +142,7 @@ func TestDNSConf_MakeProber(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		colls   map[string]*prometheus.Collector
+		colls   map[string]prometheus.Collector
 		wantErr bool
 	}{
 		// valid

--- a/observer/probers/dns/dns_conf_test.go
+++ b/observer/probers/dns/dns_conf_test.go
@@ -138,7 +138,7 @@ func TestDNSConf_MakeProber(t *testing.T) {
 			Help: "Hmmm, this shouldn't be here...",
 		},
 		[]string{},
-	));
+	))
 	type fields struct {
 		Proto   string
 		Server  string

--- a/observer/probers/dns/dns_conf_test.go
+++ b/observer/probers/dns/dns_conf_test.go
@@ -184,6 +184,19 @@ func TestDNSConf_MakeProber(t *testing.T) {
 	}
 }
 
+func TestDNSConf_Instrument(t *testing.T) {
+	t.Run("instrument", func(t *testing.T) {
+		conf := DNSConf{}
+		colls := conf.Instrument()
+		for name := range colls {
+			switch name {
+			default:
+				t.Errorf("DNSConf.Instrument() returned unexpected Collector '%s'", name)
+			}
+		}
+	})
+}
+
 func TestDNSConf_UnmarshalSettings(t *testing.T) {
 	type fields struct {
 		protocol   interface{}

--- a/observer/probers/dns/dns_conf_test.go
+++ b/observer/probers/dns/dns_conf_test.go
@@ -132,13 +132,6 @@ func TestDNSConf_validateProto(t *testing.T) {
 func TestDNSConf_MakeProber(t *testing.T) {
 	conf := DNSConf{}
 	colls := conf.Instrument()
-	badColl := prometheus.Collector(prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "obs_dns_foo",
-			Help: "Hmmm, this shouldn't be here...",
-		},
-		[]string{},
-	))
 	type fields struct {
 		Proto   string
 		Server  string
@@ -158,12 +151,6 @@ func TestDNSConf_MakeProber(t *testing.T) {
 		{"bad proto", fields{"can with string", "1.1.1.1:53", true, "google.com", "A"}, colls, true},
 		{"bad server", fields{"udp", "1.1.1.1:9000000", true, "google.com", "A"}, colls, true},
 		{"bad qtype", fields{"udp", "1.1.1.1:9000000", true, "google.com", "BAZ"}, colls, true},
-		{
-			"unexpected collector",
-			fields{"udp", "1.1.1.1:53", true, "google.com", "A"},
-			map[string]*prometheus.Collector{"obs_dns_foo": &badColl},
-			true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -182,19 +169,6 @@ func TestDNSConf_MakeProber(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestDNSConf_Instrument(t *testing.T) {
-	t.Run("instrument", func(t *testing.T) {
-		conf := DNSConf{}
-		colls := conf.Instrument()
-		for name := range colls {
-			switch name {
-			default:
-				t.Errorf("DNSConf.Instrument() returned unexpected Collector '%s'", name)
-			}
-		}
-	})
 }
 
 func TestDNSConf_UnmarshalSettings(t *testing.T) {

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -58,7 +58,7 @@ func (c HTTPConf) validateRCodes() error {
 // MakeProber constructs a `HTTPProbe` object from the contents of the
 // bound `HTTPConf` object. If the `HTTPConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
-func (c HTTPConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
+func (c HTTPConf) MakeProber(_ map[string]prometheus.Collector) (probers.Prober, error) {
 	// validate `url`
 	err := c.validateURL()
 	if err != nil {
@@ -79,7 +79,7 @@ func (c HTTPConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober
 }
 
 // Instrument is a no-op to implement the `Configurer` interface.
-func (c HTTPConf) Instrument() map[string]*prometheus.Collector {
+func (c HTTPConf) Instrument() map[string]prometheus.Collector {
 	return nil
 }
 

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -16,6 +16,11 @@ type HTTPConf struct {
 	UserAgent string `yaml:"useragent"`
 }
 
+// Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
+func (p HTTPConf) Kind() string {
+	return "HTTP"
+}
+
 // UnmarshalSettings takes YAML as bytes and unmarshals it to the to an
 // HTTPConf object.
 func (c HTTPConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
@@ -86,5 +91,5 @@ func (c HTTPConf) Instrument() map[string]prometheus.Collector {
 // init is called at runtime and registers `HTTPConf`, a `Prober`
 // `Configurer` type, as "HTTP".
 func init() {
-	probers.Register("HTTP", HTTPConf{})
+	probers.Register(HTTPConf{})
 }

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -17,7 +17,7 @@ type HTTPConf struct {
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
-func (p HTTPConf) Kind() string {
+func (c HTTPConf) Kind() string {
 	return "HTTP"
 }
 

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -58,7 +58,7 @@ func (c HTTPConf) validateRCodes() error {
 // MakeProber constructs a `HTTPProbe` object from the contents of the
 // bound `HTTPConf` object. If the `HTTPConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
-func (c HTTPConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Prober, error) {
+func (c HTTPConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
 	// validate `url`
 	err := c.validateURL()
 	if err != nil {
@@ -78,10 +78,7 @@ func (c HTTPConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Pr
 	return HTTPProbe{c.URL, c.RCodes, c.UserAgent}, nil
 }
 
-// Instrument constructs any `prometheus.Collector` objects the `HTTPProbe` will
-// need to report its own metrics. A map is returned containing the constructed
-// objects, indexed by the name of the prometheus metric. If no objects were
-// constructed, nil is returned.
+// Instrument is a no-op to implement the `Configurer` interface.
 func (c HTTPConf) Instrument() map[string]*prometheus.Collector {
 	return nil
 }

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -1,7 +1,6 @@
 package probers
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -56,13 +55,6 @@ func (c HTTPConf) validateRCodes() error {
 	return nil
 }
 
-func (c HTTPConf) validateCollectors(colls map[string]*prometheus.Collector) error {
-	if colls != nil {
-		return errors.New("http prober defines no metrics but received non-nil collector map")
-	}
-	return nil
-}
-
 // MakeProber constructs a `HTTPProbe` object from the contents of the
 // bound `HTTPConf` object. If the `HTTPConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
@@ -75,12 +67,6 @@ func (c HTTPConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Pr
 
 	// validate `rcodes`
 	err = c.validateRCodes()
-	if err != nil {
-		return nil, err
-	}
-
-	// validate the prometheus collectors that were passed in
-	err = c.validateCollectors(colls)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -78,6 +78,10 @@ func (c HTTPConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober
 	return HTTPProbe{c.URL, c.RCodes, c.UserAgent}, nil
 }
 
+// Instrument constructs any `prometheus.Collector` objects the `HTTPProbe` will
+// need to report its own metrics. A map is returned containing the constructed
+// objects, indexed by the name of the prometheus metric. If no objects were
+// constructed, an empty map is returned.
 func (c HTTPConf) Instrument() map[string]*prometheus.Collector {
 	return map[string]*prometheus.Collector{}
 }

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -57,12 +57,8 @@ func (c HTTPConf) validateRCodes() error {
 }
 
 func (c HTTPConf) validateCollectors(colls map[string]*prometheus.Collector) error {
-	for name := range colls {
-		switch name {
-		default:
-			message := fmt.Sprintf("http prober received unexpected collector '%s'", name)
-			return errors.New(message)
-		}
+	if colls != nil {
+		return errors.New("http prober defines no metrics but received non-nil collector map")
 	}
 	return nil
 }
@@ -99,9 +95,9 @@ func (c HTTPConf) MakeProber(colls map[string]*prometheus.Collector) (probers.Pr
 // Instrument constructs any `prometheus.Collector` objects the `HTTPProbe` will
 // need to report its own metrics. A map is returned containing the constructed
 // objects, indexed by the name of the prometheus metric. If no objects were
-// constructed, an empty map is returned.
+// constructed, nil is returned.
 func (c HTTPConf) Instrument() map[string]*prometheus.Collector {
-	return map[string]*prometheus.Collector{}
+	return nil
 }
 
 // init is called at runtime and registers `HTTPConf`, a `Prober`

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -57,7 +58,7 @@ func (c HTTPConf) validateRCodes() error {
 // MakeProber constructs a `HTTPProbe` object from the contents of the
 // bound `HTTPConf` object. If the `HTTPConf` cannot be validated, an
 // error appropriate for end-user consumption is returned instead.
-func (c HTTPConf) MakeProber() (probers.Prober, error) {
+func (c HTTPConf) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
 	// validate `url`
 	err := c.validateURL()
 	if err != nil {
@@ -75,6 +76,10 @@ func (c HTTPConf) MakeProber() (probers.Prober, error) {
 		c.UserAgent = "letsencrypt/boulder-observer-http-client"
 	}
 	return HTTPProbe{c.URL, c.RCodes, c.UserAgent}, nil
+}
+
+func (c HTTPConf) Instrument() map[string]*prometheus.Collector {
+	return map[string]*prometheus.Collector{}
 }
 
 // init is called at runtime and registers `HTTPConf`, a `Prober`

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -13,13 +13,6 @@ import (
 func TestHTTPConf_MakeProber(t *testing.T) {
 	conf := HTTPConf{}
 	colls := conf.Instrument()
-	badColl := prometheus.Collector(prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "obs_http_foo",
-			Help: "Hmmm, this shouldn't be here...",
-		},
-		[]string{},
-	))
 	type fields struct {
 		URL    string
 		RCodes []int
@@ -39,12 +32,6 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 		{"valid fqdn 1 invalid rcode", fields{"http://example.com", []int{200, 1000}}, colls, true},
 		{"bad fqdn good rcode", fields{":::::", []int{200}}, colls, true},
 		{"missing scheme", fields{"example.com", []int{200}}, colls, true},
-		{
-			"unexpected collector",
-			fields{"http://example.com", []int{200}},
-			map[string]*prometheus.Collector{"obs_http_foo": &badColl},
-			true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -57,19 +44,6 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestHTTPConf_Instrument(t *testing.T) {
-	t.Run("instrument", func(t *testing.T) {
-		conf := HTTPConf{}
-		colls := conf.Instrument()
-		for name := range colls {
-			switch name {
-			default:
-				t.Errorf("HTTPConf.Instrument() returned unexpected Collector '%s'", name)
-			}
-		}
-	})
 }
 
 func TestHTTPConf_UnmarshalSettings(t *testing.T) {

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -6,13 +6,10 @@ import (
 
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/letsencrypt/boulder/test"
-	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 )
 
 func TestHTTPConf_MakeProber(t *testing.T) {
-	conf := HTTPConf{}
-	colls := conf.Instrument()
 	type fields struct {
 		URL    string
 		RCodes []int
@@ -20,18 +17,17 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		colls   map[string]prometheus.Collector
 		wantErr bool
 	}{
 		// valid
-		{"valid fqdn valid rcode", fields{"http://example.com", []int{200}}, colls, false},
-		{"valid hostname valid rcode", fields{"example", []int{200}}, colls, true},
+		{"valid fqdn valid rcode", fields{"http://example.com", []int{200}}, false},
+		{"valid hostname valid rcode", fields{"example", []int{200}}, true},
 		// invalid
-		{"valid fqdn no rcode", fields{"http://example.com", nil}, colls, true},
-		{"valid fqdn invalid rcode", fields{"http://example.com", []int{1000}}, colls, true},
-		{"valid fqdn 1 invalid rcode", fields{"http://example.com", []int{200, 1000}}, colls, true},
-		{"bad fqdn good rcode", fields{":::::", []int{200}}, colls, true},
-		{"missing scheme", fields{"example.com", []int{200}}, colls, true},
+		{"valid fqdn no rcode", fields{"http://example.com", nil}, true},
+		{"valid fqdn invalid rcode", fields{"http://example.com", []int{1000}}, true},
+		{"valid fqdn 1 invalid rcode", fields{"http://example.com", []int{200, 1000}}, true},
+		{"bad fqdn good rcode", fields{":::::", []int{200}}, true},
+		{"missing scheme", fields{"example.com", []int{200}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -39,7 +35,7 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 				URL:    tt.fields.URL,
 				RCodes: tt.fields.RCodes,
 			}
-			if _, err := c.MakeProber(tt.colls); (err != nil) != tt.wantErr {
+			if _, err := c.MakeProber(nil); (err != nil) != tt.wantErr {
 				t.Errorf("HTTPConf.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -90,10 +86,9 @@ rcodes: [ 200 ]
 useragent: ""
 `
 	c := HTTPConf{}
-	colls := c.Instrument()
 	configurer, err := c.UnmarshalSettings([]byte(proberYAML))
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	prober, err := configurer.MakeProber(colls)
+	prober, err := configurer.MakeProber(nil)
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-letsencrypt/boulder-observer-http-client")
 
@@ -104,10 +99,9 @@ rcodes: [ 200 ]
 useragent: fancy-custom-http-client
 `
 	c = HTTPConf{}
-	colls = c.Instrument()
 	configurer, err = c.UnmarshalSettings([]byte(proberYAML))
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	prober, err = configurer.MakeProber(colls)
+	prober, err = configurer.MakeProber(nil)
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client")
 

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -20,7 +20,7 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		colls   map[string]*prometheus.Collector
+		colls   map[string]prometheus.Collector
 		wantErr bool
 	}{
 		// valid

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -19,7 +19,7 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 			Help: "Hmmm, this shouldn't be here...",
 		},
 		[]string{},
-	));
+	))
 	type fields struct {
 		URL    string
 		RCodes []int

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -59,6 +59,19 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 	}
 }
 
+func TestHTTPConf_Instrument(t *testing.T) {
+	t.Run("instrument", func(t *testing.T) {
+		conf := HTTPConf{}
+		colls := conf.Instrument()
+		for name := range colls {
+			switch name {
+			default:
+				t.Errorf("HTTPConf.Instrument() returned unexpected Collector '%s'", name)
+			}
+		}
+	})
+}
+
 func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 	type fields struct {
 		url       interface{}

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -43,7 +43,7 @@ func TestHTTPConf_MakeProber(t *testing.T) {
 			"unexpected collector",
 			fields{"http://example.com", []int{200}},
 			map[string]*prometheus.Collector{"obs_http_foo": &badColl},
-			false,
+			true,
 		},
 	}
 	for _, tt := range tests {

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -35,7 +35,7 @@ func (c MockConfigurer) MakeProber(_ map[string]*prometheus.Collector) (probers.
 }
 
 func (c MockConfigurer) Instrument() map[string]*prometheus.Collector {
-	return map[string]*prometheus.Collector{}
+	return nil
 }
 
 func init() {

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,11 +27,15 @@ func (c MockConfigurer) UnmarshalSettings(settings []byte) (probers.Configurer, 
 	return conf, nil
 }
 
-func (c MockConfigurer) MakeProber() (probers.Prober, error) {
+func (c MockConfigurer) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
 	if !c.Valid {
 		return nil, errors.New("could not be validated")
 	}
 	return MockProber{c.PName, c.PKind, c.PTook, c.PSuccess}, nil
+}
+
+func (c MockConfigurer) Instrument() map[string]*prometheus.Collector {
+	return map[string]*prometheus.Collector{}
 }
 
 func init() {

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -27,14 +27,14 @@ func (c MockConfigurer) UnmarshalSettings(settings []byte) (probers.Configurer, 
 	return conf, nil
 }
 
-func (c MockConfigurer) MakeProber(_ map[string]*prometheus.Collector) (probers.Prober, error) {
+func (c MockConfigurer) MakeProber(_ map[string]prometheus.Collector) (probers.Prober, error) {
 	if !c.Valid {
 		return nil, errors.New("could not be validated")
 	}
 	return MockProber{c.PName, c.PKind, c.PTook, c.PSuccess}, nil
 }
 
-func (c MockConfigurer) Instrument() map[string]*prometheus.Collector {
+func (c MockConfigurer) Instrument() map[string]prometheus.Collector {
 	return nil
 }
 

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -18,6 +18,11 @@ type MockConfigurer struct {
 	PSuccess bool               `yaml:"psuccess"`
 }
 
+// Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
+func (p MockConfigurer) Kind() string {
+	return "Mock"
+}
+
 func (c MockConfigurer) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf MockConfigurer
 	err := yaml.Unmarshal(settings, &conf)
@@ -39,5 +44,5 @@ func (c MockConfigurer) Instrument() map[string]prometheus.Collector {
 }
 
 func init() {
-	probers.Register("MockConf", MockConfigurer{})
+	probers.Register(MockConfigurer{})
 }

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -19,7 +19,7 @@ type MockConfigurer struct {
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
-func (p MockConfigurer) Kind() string {
+func (c MockConfigurer) Kind() string {
 	return "Mock"
 }
 

--- a/observer/probers/prober.go
+++ b/observer/probers/prober.go
@@ -57,11 +57,17 @@ type Configurer interface {
 // the `MonConf`.
 type Settings map[string]interface{}
 
+// NormalizedKind normalizes the input string by stripping spaces and
+// transforming it into lowercase
+func NormalizedKind(kind string) string {
+	return strings.Trim(strings.ToLower(kind), " ")
+}
+
 // GetConfigurer returns the probe configurer specified by name from
 // `Registry`.
 func GetConfigurer(kind string) (Configurer, error) {
 	// normalize
-	name := strings.Trim(strings.ToLower(kind), " ")
+	name := NormalizedKind(kind)
 	// check if exists
 	if _, ok := Registry[name]; ok {
 		return Registry[name], nil
@@ -75,7 +81,7 @@ func GetConfigurer(kind string) (Configurer, error) {
 // `Configurer` Observer will exit after logging an error.
 func Register(kind string, c Configurer) {
 	// normalize
-	name := strings.Trim(strings.ToLower(kind), " ")
+	name := NormalizedKind(kind)
 	// check for name collision
 	if _, exists := Registry[name]; exists {
 		cmd.Fail(fmt.Sprintf(

--- a/observer/probers/prober.go
+++ b/observer/probers/prober.go
@@ -44,7 +44,8 @@ type Configurer interface {
 	// MakeProber constructs a `Prober` object from the contents of the
 	// bound `Configurer` object. If the `Configurer` cannot be
 	// validated, an error appropriate for end-user consumption is
-	// returned instead.
+	// returned instead. The map of `prometheus.Collector` objects passed to
+	// MakeProber should be the same as the return value from Instrument()
 	MakeProber(map[string]prometheus.Collector) (Prober, error)
 
 	// Instrument constructs any `prometheus.Collector` objects that a prober of

--- a/observer/probers/prober.go
+++ b/observer/probers/prober.go
@@ -46,8 +46,7 @@ type Configurer interface {
 	// Instrument constructs any `prometheus.Collector` objects that a prober of
 	// the configured type will need to report its own metrics. A map is
 	// returned containing the constructed objects, indexed by the name of the
-	// prometheus metric. If no objects were constructed, an empty map is
-	// returned.
+	// prometheus metric. If no objects were constructed, nil is returned.
 	Instrument() map[string]*prometheus.Collector
 }
 

--- a/observer/probers/prober.go
+++ b/observer/probers/prober.go
@@ -41,13 +41,13 @@ type Configurer interface {
 	// bound `Configurer` object. If the `Configurer` cannot be
 	// validated, an error appropriate for end-user consumption is
 	// returned instead.
-	MakeProber(map[string]*prometheus.Collector) (Prober, error)
+	MakeProber(map[string]prometheus.Collector) (Prober, error)
 
 	// Instrument constructs any `prometheus.Collector` objects that a prober of
 	// the configured type will need to report its own metrics. A map is
 	// returned containing the constructed objects, indexed by the name of the
 	// prometheus metric. If no objects were constructed, nil is returned.
-	Instrument() map[string]*prometheus.Collector
+	Instrument() map[string]prometheus.Collector
 }
 
 // Settings is exported as a temporary receiver for the `settings` field

--- a/observer/probers/prober.go
+++ b/observer/probers/prober.go
@@ -33,6 +33,10 @@ type Prober interface {
 
 // Configurer is the interface for `Configurer` types.
 type Configurer interface {
+	// Kind returns a name that uniquely identifies the `Kind` of
+	// `Configurer`.
+	Kind() string
+
 	// UnmarshalSettings unmarshals YAML as bytes to a `Configurer`
 	// object.
 	UnmarshalSettings([]byte) (Configurer, error)
@@ -78,13 +82,13 @@ func GetConfigurer(kind string) (Configurer, error) {
 // add the caller to the global `Registry` map. If the caller attempts
 // to add a `Configurer` to the registry using the same name as a prior
 // `Configurer` Observer will exit after logging an error.
-func Register(kind string, c Configurer) {
+func Register(c Configurer) {
 	// normalize
-	name := NormalizedKind(kind)
+	name := NormalizedKind(c.Kind())
 	// check for name collision
 	if _, exists := Registry[name]; exists {
 		cmd.Fail(fmt.Sprintf(
-			"problem registering configurer %s: name collision", kind))
+			"problem registering configurer %s: name collision", c.Kind()))
 	}
 	Registry[name] = c
 }

--- a/observer/probers/prober.go
+++ b/observer/probers/prober.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -40,7 +41,14 @@ type Configurer interface {
 	// bound `Configurer` object. If the `Configurer` cannot be
 	// validated, an error appropriate for end-user consumption is
 	// returned instead.
-	MakeProber() (Prober, error)
+	MakeProber(map[string]*prometheus.Collector) (Prober, error)
+
+	// Instrument constructs any `prometheus.Collector` objects that a prober of
+	// the configured type will need to report its own metrics. A map is
+	// returned containing the constructed objects, indexed by the name of the
+	// prometheus metric. If no objects were constructed, an empty map is
+	// returned.
+	Instrument() map[string]*prometheus.Collector
 }
 
 // Settings is exported as a temporary receiver for the `settings` field

--- a/observer/probers/prober.go
+++ b/observer/probers/prober.go
@@ -61,17 +61,16 @@ type Configurer interface {
 // the `MonConf`.
 type Settings map[string]interface{}
 
-// NormalizedKind normalizes the input string by stripping spaces and
+// normalizeKind normalizes the input string by stripping spaces and
 // transforming it into lowercase
-func NormalizedKind(kind string) string {
+func normalizeKind(kind string) string {
 	return strings.Trim(strings.ToLower(kind), " ")
 }
 
 // GetConfigurer returns the probe configurer specified by name from
 // `Registry`.
 func GetConfigurer(kind string) (Configurer, error) {
-	// normalize
-	name := NormalizedKind(kind)
+	name := normalizeKind(kind)
 	// check if exists
 	if _, ok := Registry[name]; ok {
 		return Registry[name], nil
@@ -84,8 +83,7 @@ func GetConfigurer(kind string) (Configurer, error) {
 // to add a `Configurer` to the registry using the same name as a prior
 // `Configurer` Observer will exit after logging an error.
 func Register(c Configurer) {
-	// normalize
-	name := NormalizedKind(c.Kind())
+	name := normalizeKind(c.Kind())
 	// check for name collision
 	if _, exists := Registry[name]; exists {
 		cmd.Fail(fmt.Sprintf(


### PR DESCRIPTION
This PR is a re-implementation of the foundational bits of #6277 with the suggestions from that review taken into account. I split this into its own PR since there were really two changes included in the original, and after code review, the foundational bits that made up one of those changes are now substantial enough to merit their own PR. If/when this gets merged, I'll open a follow-up PR that includes the new CRL prober type on its own