### PR TITLE
Add phony rules to .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BUILD_TIME_VAR = github.com/letsencrypt/boulder/core.BuildTime
 
 GO_BUILD_FLAGS = -ldflags "-X \"$(BUILD_ID_VAR)=$(BUILD_ID)\" -X \"$(BUILD_TIME_VAR)=$(BUILD_TIME)\" -X \"$(BUILD_HOST_VAR)=$(BUILD_HOST)\""
 
-.PHONY: all build
+.PHONY: all build build_cmds rpm deb
 all: build
 
 build: $(OBJECTS)


### PR DESCRIPTION
I was looking at the Makefile and noticed the .PHONY set was incomplete.

build_cmds, rpm, and deb are all phony rules:  They don't produce a
file named build_cmds, rpm, or deb.
