### PR TITLE
Make pa.WillingToIssue private

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -7,7 +7,6 @@ import (
 // PolicyAuthority defines the public interface for the Boulder PA
 // TODO(#5891): Move this interface to a more appropriate location.
 type PolicyAuthority interface {
-	WillingToIssue(domain identifier.ACMEIdentifier) error
 	WillingToIssueWildcards(identifiers []identifier.ACMEIdentifier) error
 	ChallengesFor(domain identifier.ACMEIdentifier) ([]Challenge, error)
 	ChallengeTypeEnabled(t AcmeChallenge) bool

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -31,10 +31,6 @@ func (pa *mockPA) ChallengesFor(identifier identifier.ACMEIdentifier) (challenge
 	return
 }
 
-func (pa *mockPA) WillingToIssue(id identifier.ACMEIdentifier) error {
-	return nil
-}
-
 func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
 	for _, ident := range idents {
 		if ident.Value == "bad-name.com" || ident.Value == "other-bad-name.com" {

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -340,9 +340,9 @@ func ValidEmail(address string) error {
 	return nil
 }
 
-// WillingToIssue determines whether the CA is willing to issue for the provided
+// willingToIssue determines whether the CA is willing to issue for the provided
 // identifier. It expects domains in id to be lowercase to prevent mismatched
-// cases breaking queries.
+// cases breaking queries. It is a helper method for WillingToIssueWildcards.
 //
 // We place several criteria on identifiers we are willing to issue for:
 //   - MUST self-identify as DNS identifiers
@@ -358,12 +358,9 @@ func ValidEmail(address string) error {
 //   - MUST NOT be a label-wise suffix match for a name on the block list,
 //     where comparison is case-independent (normalized to lower case)
 //
-// If WillingToIssue returns an error, it will be of type MalformedRequestError
+// If willingToIssue returns an error, it will be of type MalformedRequestError
 // or RejectedIdentifierError
-//
-// TODO(#5816): Consider making this method private, as it has no callers
-// outside of this package.
-func (pa *AuthorityImpl) WillingToIssue(id identifier.ACMEIdentifier) error {
+func (pa *AuthorityImpl) willingToIssue(id identifier.ACMEIdentifier) error {
 	if id.Type != identifier.DNS {
 		return errInvalidIdentifier
 	}
@@ -495,13 +492,13 @@ func (pa *AuthorityImpl) willingToIssueWildcard(ident identifier.ACMEIdentifier)
 		// NOTE(@cpu): This is pretty hackish! Boulder issue #3323[0] describes
 		// a better follow-up that we should land to replace this code.
 		// [0] https://github.com/letsencrypt/boulder/issues/3323
-		return pa.WillingToIssue(identifier.ACMEIdentifier{
+		return pa.willingToIssue(identifier.ACMEIdentifier{
 			Type:  identifier.DNS,
 			Value: "x." + baseDomain,
 		})
 	}
 
-	return pa.WillingToIssue(ident)
+	return pa.willingToIssue(ident)
 }
 
 // checkWildcardHostList checks the wildcardExactBlocklist for a given domain.

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -199,7 +199,7 @@ var (
 	errWildcardNotSupported = berrors.MalformedError("Wildcard domain names are not supported")
 )
 
-// ValidDomain checks that a domain isn't:
+// validDomain checks that a domain isn't:
 //
 // * empty
 // * prefixed with the wildcard label `*.`
@@ -213,7 +213,7 @@ var (
 // * exactly equal to an IANA registered TLD
 //
 // It does _not_ check that the domain isn't on any PA blocked lists.
-func ValidDomain(domain string) error {
+func validDomain(domain string) error {
 	if domain == "" {
 		return errEmptyName
 	}
@@ -326,7 +326,7 @@ func ValidEmail(address string) error {
 	}
 	splitEmail := strings.SplitN(email.Address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])
-	err = ValidDomain(domain)
+	err = validDomain(domain)
 	if err != nil {
 		return berrors.InvalidEmailError(
 			"contact email %q has invalid domain : %s",
@@ -366,7 +366,7 @@ func (pa *AuthorityImpl) willingToIssue(id identifier.ACMEIdentifier) error {
 	}
 	domain := id.Value
 
-	err := ValidDomain(domain)
+	err := validDomain(domain)
 	if err != nil {
 		return err
 	}

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -162,7 +162,7 @@ func TestWillingToIssue(t *testing.T) {
 
 	// Test for invalid identifier type
 	ident := identifier.ACMEIdentifier{Type: "ip", Value: "example.com"}
-	err = pa.WillingToIssue(ident)
+	err = pa.willingToIssue(ident)
 	if err != errInvalidIdentifier {
 		t.Error("Identifier was not correctly forbidden: ", ident)
 	}
@@ -170,27 +170,27 @@ func TestWillingToIssue(t *testing.T) {
 	// Test syntax errors
 	for _, tc := range testCases {
 		ident := identifier.DNSIdentifier(tc.domain)
-		err := pa.WillingToIssue(ident)
+		err := pa.willingToIssue(ident)
 		if err != tc.err {
 			t.Errorf("WillingToIssue(%q) = %q, expected %q", tc.domain, err, tc.err)
 		}
 	}
 
 	// Invalid encoding
-	err = pa.WillingToIssue(identifier.DNSIdentifier("www.xn--m.com"))
+	err = pa.willingToIssue(identifier.DNSIdentifier("www.xn--m.com"))
 	test.AssertError(t, err, "WillingToIssue didn't fail on a malformed IDN")
 	// Valid encoding
-	err = pa.WillingToIssue(identifier.DNSIdentifier("www.xn--mnich-kva.com"))
+	err = pa.willingToIssue(identifier.DNSIdentifier("www.xn--mnich-kva.com"))
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed IDN")
 	// IDN TLD
-	err = pa.WillingToIssue(identifier.DNSIdentifier("xn--example--3bhk5a.xn--p1ai"))
+	err = pa.willingToIssue(identifier.DNSIdentifier("xn--example--3bhk5a.xn--p1ai"))
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed domain with IDN TLD")
 	features.Reset()
 
 	// Test domains that are equal to public suffixes
 	for _, domain := range shouldBeTLDError {
 		ident := identifier.DNSIdentifier(domain)
-		err := pa.WillingToIssue(ident)
+		err := pa.willingToIssue(ident)
 		if err != errICANNTLD {
 			t.Error("Identifier was not correctly forbidden: ", ident, err)
 		}
@@ -199,7 +199,7 @@ func TestWillingToIssue(t *testing.T) {
 	// Test expected blocked domains
 	for _, domain := range shouldBeBlocked {
 		ident := identifier.DNSIdentifier(domain)
-		err := pa.WillingToIssue(ident)
+		err := pa.willingToIssue(ident)
 		if err != errPolicyForbidden {
 			t.Error("Identifier was not correctly forbidden: ", ident, err)
 		}
@@ -208,7 +208,7 @@ func TestWillingToIssue(t *testing.T) {
 	// Test acceptance of good names
 	for _, domain := range shouldBeAccepted {
 		ident := identifier.DNSIdentifier(domain)
-		err := pa.WillingToIssue(ident)
+		err := pa.willingToIssue(ident)
 		test.AssertNotError(t, err, "identiier was incorrectly forbidden")
 	}
 }


### PR DESCRIPTION
By making this method private, we ensure that all policy
decisions go through WillingToIssueWildcards, which
attaches the failing identifier to each error message.

Fixes #2526
Part of #5816