### PR TITLE
Add unparam linter to CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - stylecheck
     - typecheck
     - unconvert
-    # TODO(#6104): Enable 'unparam' linter
+    - unparam
     - unused
     # TODO(#6202): Re-enable 'wastedassign' linter
 linters-settings:

--- a/akamai/cache-client.go
+++ b/akamai/cache-client.go
@@ -127,7 +127,7 @@ func NewCachePurgeClient(
 // is used to identify clients to Akamai's EdgeGrid APIs. For a more detailed
 // description of the generation process see their docs:
 // https://developer.akamai.com/introduction/Client_Auth.html
-func (cpc *CachePurgeClient) makeAuthHeader(body []byte, apiPath string, nonce string) (string, error) {
+func (cpc *CachePurgeClient) makeAuthHeader(body []byte, apiPath string, nonce string) string {
 	// The akamai API is very time sensitive (recommending reliance on a stratum 2
 	// or better time source). Additionally, timestamps MUST be in UTC.
 	timestamp := cpc.clk.Now().UTC().Format(timestampFormat)
@@ -158,7 +158,7 @@ func (cpc *CachePurgeClient) makeAuthHeader(body []byte, apiPath string, nonce s
 		"%ssignature=%s",
 		header,
 		base64.StdEncoding.EncodeToString(h.Sum(nil)),
-	), nil
+	)
 }
 
 // signingKey makes a signing key by HMAC'ing the timestamp
@@ -207,10 +207,7 @@ func (cpc *CachePurgeClient) authedRequest(endpoint string, body v3PurgeRequest)
 		return fmt.Errorf("while parsing %q as URL: %s: %w", endpoint, err, errFatal)
 	}
 
-	authorization, err := cpc.makeAuthHeader(reqBody, endpointURL.Path, core.RandomString(16))
-	if err != nil {
-		return fmt.Errorf("%s: %w", err, errFatal)
-	}
+	authorization := cpc.makeAuthHeader(reqBody, endpointURL.Path, core.RandomString(16))
 	req.Header.Set("Authorization", authorization)
 	req.Header.Set("Content-Type", "application/json")
 	cpc.log.Debugf("POSTing to endpoint %q (header %q) (body %q)", endpoint, authorization, reqBody)

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -43,7 +43,6 @@ func TestMakeAuthHeader(t *testing.T) {
 		"/testapi/v1/t3",
 		"nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 	)
-	test.AssertNotError(t, err, "Failed to create authorization header")
 	test.AssertEquals(t, authHeader, expectedHeader)
 }
 

--- a/akamai/cache-client_test.go
+++ b/akamai/cache-client_test.go
@@ -38,7 +38,7 @@ func TestMakeAuthHeader(t *testing.T) {
 	fc.Set(wantedTimestamp)
 
 	expectedHeader := "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=hXm4iCxtpN22m4cbZb4lVLW5rhX8Ca82vCFqXzSTPe4="
-	authHeader, err := cpc.makeAuthHeader(
+	authHeader := cpc.makeAuthHeader(
 		[]byte("datadatadatadatadatadatadatadata"),
 		"/testapi/v1/t3",
 		"nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -79,7 +79,7 @@ type certificateAuthorityImpl struct {
 // nearly-unique identifiers of those issuers to the issuers themselves. Note
 // that, if two issuers have the same nearly-unique ID, the *latter* one in
 // the input list "wins".
-func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
+func makeIssuerMaps(issuers []*issuance.Issuer) issuerMaps {
 	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*issuance.Issuer, 2)
 	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Issuer, len(issuers))
 	for _, issuer := range issuers {
@@ -92,7 +92,7 @@ func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
 		}
 		issuersByNameID[issuer.Cert.NameID()] = issuer
 	}
-	return issuerMaps{issuersByAlg, issuersByNameID}, nil
+	return issuerMaps{issuersByAlg, issuersByNameID}
 }
 
 // NewCertificateAuthorityImpl creates a CA instance that can sign certificates
@@ -131,10 +131,8 @@ func NewCertificateAuthorityImpl(
 		err = errors.New("Must have a positive non-zero serial prefix less than 256 for CA.")
 		return nil, err
 	}
-	issuers, err := makeIssuerMaps(boulderIssuers)
-	if err != nil {
-		return nil, err
-	}
+
+	issuers := makeIssuerMaps(boulderIssuers)
 
 	orphanCount := prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -42,14 +42,14 @@ type ocspImpl struct {
 // nearly-unique identifiers of those issuers to the issuers themselves. Note
 // that, if two issuers have the same nearly-unique ID, the *latter* one in
 // the input list "wins".
-func makeOCSPIssuerMaps(issuers []*issuance.Issuer) (ocspIssuerMaps, error) {
+func makeOCSPIssuerMaps(issuers []*issuance.Issuer) ocspIssuerMaps {
 	issuersByID := make(map[issuance.IssuerID]*issuance.Issuer, len(issuers))
 	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Issuer, len(issuers))
 	for _, issuer := range issuers {
 		issuersByID[issuer.ID()] = issuer
 		issuersByNameID[issuer.Cert.NameID()] = issuer
 	}
-	return ocspIssuerMaps{issuersByID, issuersByNameID}, nil
+	return ocspIssuerMaps{issuersByID, issuersByNameID}
 }
 
 func NewOCSPImpl(
@@ -73,10 +73,7 @@ func NewOCSPImpl(
 		ocspLogQueue = newOCSPLogQueue(ocspLogMaxLength, ocspLogPeriod, stats, logger)
 	}
 
-	issuerMaps, err := makeOCSPIssuerMaps(issuers)
-	if err != nil {
-		return nil, err
-	}
+	issuerMaps := makeOCSPIssuerMaps(issuers)
 
 	oi := &ocspImpl{
 		issuers:        issuerMaps,

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -373,7 +373,7 @@ func main() {
 	scope.MustRegister(gaugePurgeQueueLength)
 
 	if manualMode {
-		manualPurge(ccu, *tag, *tagFile, logger)
+		manualPurge(ccu, *tag, *tagFile)
 	} else {
 		daemon(c, ap, logger, scope)
 	}
@@ -383,7 +383,7 @@ func main() {
 // passed on the CLI. All tags will be added to a single request, please ensure
 // that you don't violate the Fast-Purge API limits for tags detailed here:
 // https://techdocs.akamai.com/purge-cache/reference/rate-limiting
-func manualPurge(purgeClient *akamai.CachePurgeClient, tag, tagFile string, logger blog.Logger) {
+func manualPurge(purgeClient *akamai.CachePurgeClient, tag, tagFile string) {
 	var tags []string
 	if tag != "" {
 		tags = []string{tag}

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -276,7 +276,7 @@ func loadChain(certFiles []string) (*issuance.Certificate, []byte, error) {
 	return certs[0], buf.Bytes(), nil
 }
 
-func setupWFE(c Config, logger blog.Logger, stats prometheus.Registerer, clk clock.Clock) (rapb.RegistrationAuthorityClient, sapb.StorageAuthorityClient, noncepb.NonceServiceClient, map[string]noncepb.NonceServiceClient) {
+func setupWFE(c Config, stats prometheus.Registerer, clk clock.Clock) (rapb.RegistrationAuthorityClient, sapb.StorageAuthorityClient, noncepb.NonceServiceClient, map[string]noncepb.NonceServiceClient) {
 	tlsConfig, err := c.WFE.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 	clientMetrics := bgrpc.NewClientMetrics(stats)
@@ -387,7 +387,7 @@ func main() {
 
 	clk := cmd.Clock()
 
-	rac, sac, rns, npm := setupWFE(c, logger, stats, clk)
+	rac, sac, rns, npm := setupWFE(c, stats, clk)
 
 	kp, err := goodkey.NewKeyPolicy(&c.WFE.GoodKey, sac.KeyBlocked)
 	cmd.FailOnError(err, "Unable to create key policy")

--- a/cmd/ceremony/key.go
+++ b/cmd/ceremony/key.go
@@ -34,10 +34,6 @@ type generateArgs struct {
 	publicAttrs  []*pkcs11.Attribute
 }
 
-const (
-	rsaExp = 65537
-)
-
 // keyInfo is a struct used to pass around information about the public key
 // associated with the generated private key. der contains the DER encoding
 // of the SubjectPublicKeyInfo structure for the public key. id contains the
@@ -60,7 +56,7 @@ func generateKey(session *pkcs11helpers.Session, label string, outputPath string
 	var keyID []byte
 	switch config.Type {
 	case "rsa":
-		pubKey, keyID, err = rsaGenerate(session, label, config.RSAModLength, rsaExp)
+		pubKey, keyID, err = rsaGenerate(session, label, config.RSAModLength)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate RSA key pair: %s", err)
 		}

--- a/cmd/ceremony/rsa.go
+++ b/cmd/ceremony/rsa.go
@@ -10,6 +10,10 @@ import (
 	"github.com/miekg/pkcs11"
 )
 
+const (
+	rsaExp = 65537
+)
+
 // rsaArgs constructs the private and public key template attributes sent to the
 // device and specifies which mechanism should be used. modulusLen specifies the
 // length of the modulus to be generated on the device in bits and exponent
@@ -68,24 +72,24 @@ func rsaPub(session *pkcs11helpers.Session, object pkcs11.ObjectHandle, modulusL
 }
 
 // rsaGenerate is used to generate and verify a RSA key pair of the size
-// specified by modulusLen and with the exponent specified by pubExponent.
+// specified by modulusLen and with the exponent 65537.
 // It returns the public part of the generated key pair as a rsa.PublicKey
 // and the random key ID that the HSM uses to identify the key pair.
-func rsaGenerate(session *pkcs11helpers.Session, label string, modulusLen, pubExponent uint) (*rsa.PublicKey, []byte, error) {
+func rsaGenerate(session *pkcs11helpers.Session, label string, modulusLen uint) (*rsa.PublicKey, []byte, error) {
 	keyID := make([]byte, 4)
 	_, err := newRandReader(session).Read(keyID)
 	if err != nil {
 		return nil, nil, err
 	}
-	log.Printf("Generating RSA key with %d bit modulus and public exponent %d and ID %x\n", modulusLen, pubExponent, keyID)
-	args := rsaArgs(label, modulusLen, pubExponent, keyID)
+	log.Printf("Generating RSA key with %d bit modulus and public exponent %d and ID %x\n", modulusLen, rsaExp, keyID)
+	args := rsaArgs(label, modulusLen, rsaExp, keyID)
 	pub, _, err := session.GenerateKeyPair(args.mechanism, args.publicAttrs, args.privateAttrs)
 	if err != nil {
 		return nil, nil, err
 	}
 	log.Println("Key generated")
 	log.Println("Extracting public key")
-	pk, err := rsaPub(session, pub, modulusLen, pubExponent)
+	pk, err := rsaPub(session, pub, modulusLen, rsaExp)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/ceremony/rsa_test.go
+++ b/cmd/ceremony/rsa_test.go
@@ -60,7 +60,7 @@ func TestRSAGenerate(t *testing.T) {
 	ctx.GenerateKeyPairFunc = func(pkcs11.SessionHandle, []*pkcs11.Mechanism, []*pkcs11.Attribute, []*pkcs11.Attribute) (pkcs11.ObjectHandle, pkcs11.ObjectHandle, error) {
 		return 0, 0, errors.New("bad")
 	}
-	_, _, err = rsaGenerate(s, "", 1024, 65537)
+	_, _, err = rsaGenerate(s, "", 1024)
 	test.AssertError(t, err, "rsaGenerate didn't fail on GenerateKeyPair error")
 
 	// Test rsaGenerate fails when rsaPub fails
@@ -70,7 +70,7 @@ func TestRSAGenerate(t *testing.T) {
 	ctx.GetAttributeValueFunc = func(pkcs11.SessionHandle, pkcs11.ObjectHandle, []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
 		return nil, errors.New("bad")
 	}
-	_, _, err = rsaGenerate(s, "", 1024, 65537)
+	_, _, err = rsaGenerate(s, "", 1024)
 	test.AssertError(t, err, "rsaGenerate didn't fail on rsaPub error")
 
 	// Test rsaGenerate fails when rsaVerify fails
@@ -83,7 +83,7 @@ func TestRSAGenerate(t *testing.T) {
 	ctx.GenerateRandomFunc = func(pkcs11.SessionHandle, int) ([]byte, error) {
 		return nil, errors.New("yup")
 	}
-	_, _, err = rsaGenerate(s, "", 1024, 65537)
+	_, _, err = rsaGenerate(s, "", 1024)
 	test.AssertError(t, err, "rsaGenerate didn't fail on rsaVerify error")
 
 	// Test rsaGenerate doesn't fail when everything works
@@ -97,6 +97,6 @@ func TestRSAGenerate(t *testing.T) {
 		// Chop of the hash identifier and feed back into rsa.SignPKCS1v15
 		return rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, msg[19:])
 	}
-	_, _, err = rsaGenerate(s, "", 1024, 65537)
+	_, _, err = rsaGenerate(s, "", 1024)
 	test.AssertNotError(t, err, "rsaGenerate didn't succeed when everything worked as expected")
 }

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -153,7 +153,7 @@ func checkDER(sai sapb.StorageAuthorityCertificateClient, der []byte) (*x509.Cer
 	return nil, orphanTyp, fmt.Errorf("Existing %s lookup failed: %s", orphanTyp, err)
 }
 
-func parseLogLine(line string, logger blog.Logger) (parsedLine, error) {
+func parseLogLine(line string) (parsedLine, error) {
 	derStr := derOrphan.FindStringSubmatch(line)
 	if len(derStr) <= 1 {
 		return parsedLine{}, fmt.Errorf("unable to find cert der: %s", line)
@@ -286,7 +286,7 @@ func (opf *orphanFinder) storeLogLine(ctx context.Context, line string) (found b
 		return false, false, unknownOrphan
 	}
 
-	parsed, err := parseLogLine(line, opf.logger)
+	parsed, err := parseLogLine(line)
 	if err != nil {
 		opf.logger.AuditErr(fmt.Sprintf("Couldn't parse log line: %s", err))
 		return true, false, unknownOrphan

--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -176,15 +176,15 @@ func (ctp *CTPolicy) getGoogleSCTs(ctx context.Context, cert core.CertDER, expir
 	results := make(chan result, len(ctp.groups))
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	for i, g := range ctp.groups {
-		go func(i int, g ctconfig.CTGroup) {
+	for _, g := range ctp.groups {
+		go func(g ctconfig.CTGroup) {
 			sct, err := ctp.race(subCtx, cert, g, expiration)
 			// Only one of these will be non-nil
 			if err != nil {
 				results <- result{err: berrors.MissingSCTsError("CT log group %q: %s", g.Name, err)}
 			}
 			results <- result{sct: sct}
-		}(i, g)
+		}(g)
 	}
 
 	go ctp.submitPrecertInformational(cert, expiration)

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -314,7 +314,7 @@ var defaultEKU = []x509.ExtKeyUsage{
 	x509.ExtKeyUsageClientAuth,
 }
 
-func (p *Profile) generateTemplate(clk clock.Clock) *x509.Certificate {
+func (p *Profile) generateTemplate() *x509.Certificate {
 	template := &x509.Certificate{
 		SignatureAlgorithm:    p.sigAlg,
 		ExtKeyUsage:           defaultEKU,
@@ -610,7 +610,7 @@ func (i *Issuer) Issue(req *IssuanceRequest) ([]byte, error) {
 	}
 
 	// generate template from the issuance profile
-	template := i.Profile.generateTemplate(i.Clk)
+	template := i.Profile.generateTemplate()
 
 	// populate template from the issuance request
 	template.NotBefore, template.NotAfter = req.NotBefore, req.NotAfter

--- a/issuance/issuance_test.go
+++ b/issuance/issuance_test.go
@@ -417,8 +417,7 @@ func TestGenerateTemplate(t *testing.T) {
 			},
 		},
 	}
-	fc := clock.NewFake()
-	fc.Set(time.Time{}.Add(time.Hour))
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			template := tc.profile.generateTemplate()

--- a/issuance/issuance_test.go
+++ b/issuance/issuance_test.go
@@ -421,7 +421,7 @@ func TestGenerateTemplate(t *testing.T) {
 	fc.Set(time.Time{}.Add(time.Hour))
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			template := tc.profile.generateTemplate(fc)
+			template := tc.profile.generateTemplate()
 			test.AssertDeepEquals(t, *template, *tc.expectedTemplate)
 		})
 	}

--- a/ocsp/responder/multi_source.go
+++ b/ocsp/responder/multi_source.go
@@ -112,7 +112,7 @@ func (src *multiSource) Response(ctx context.Context, req *ocsp.Request) (*Respo
 
 	// The primary response was fresh enough to serve, go ahead and serve it.
 	if time.Since(primaryResponse.ThisUpdate) < src.expectedFreshness {
-		src.checkSecondary(primaryResponse, secondaryChan)
+		src.checkSecondary(secondaryChan)
 		src.counter.WithLabelValues("primary_result").Inc()
 		return primaryResponse, nil
 	}
@@ -163,7 +163,7 @@ func (src *multiSource) Response(ctx context.Context, req *ocsp.Request) (*Respo
 // checkSecondary updates the src.counter metrics when we're planning to return
 // a primary response. It checks if the secondary result has already arrived
 // (without blocking on it) and updates the metrics accordingly.
-func (src *multiSource) checkSecondary(primaryResponse *Response, secondaryChan <-chan responseResult) {
+func (src *multiSource) checkSecondary(secondaryChan <-chan responseResult) {
 	select {
 	case secondaryResult := <-secondaryChan:
 		if secondaryResult.err != nil {

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/letsencrypt/boulder/canceled"
-	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -249,12 +248,7 @@ func (pub *Impl) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Requ
 
 	isPrecert := req.Precert
 
-	sct, err := pub.singleLogSubmit(
-		ctx,
-		chain,
-		isPrecert,
-		core.SerialToString(cert.SerialNumber),
-		ctLog)
+	sct, err := pub.singleLogSubmit(ctx, chain, isPrecert, ctLog)
 	if err != nil {
 		if canceled.Is(err) {
 			return nil, err
@@ -280,7 +274,6 @@ func (pub *Impl) singleLogSubmit(
 	ctx context.Context,
 	chain []ct.ASN1Cert,
 	isPrecert bool,
-	serial string,
 	ctLog *Log,
 ) (*ct.SignedCertificateTimestamp, error) {
 	var submissionMethod func(context.Context, []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error)

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -162,7 +162,7 @@ func setup(t *testing.T) (*Impl, *x509.Certificate, *ecdsa.PrivateKey) {
 	return pub, leaf, k
 }
 
-func addLog(t *testing.T, pub *Impl, port int, pubKey *ecdsa.PublicKey) *Log {
+func addLog(t *testing.T, port int, pubKey *ecdsa.PublicKey) *Log {
 	uri := fmt.Sprintf("http://localhost:%d", port)
 	der, err := x509.MarshalPKIXPublicKey(pubKey)
 	test.AssertNotError(t, err, "Failed to marshal key")
@@ -217,7 +217,7 @@ func TestTimestampVerificationFuture(t *testing.T) {
 	defer server.Close()
 	port, err := getPort(server.URL)
 	test.AssertNotError(t, err, "Failed to get test server port")
-	testLog := addLog(t, pub, port, &k.PublicKey)
+	testLog := addLog(t, port, &k.PublicKey)
 
 	// Precert
 	issuerBundles, precert, err := makePrecert(k)
@@ -240,7 +240,7 @@ func TestTimestampVerificationPast(t *testing.T) {
 	defer server.Close()
 	port, err := getPort(server.URL)
 	test.AssertNotError(t, err, "Failed to get test server port")
-	testLog := addLog(t, pub, port, &k.PublicKey)
+	testLog := addLog(t, port, &k.PublicKey)
 
 	// Precert
 	issuerBundles, precert, err := makePrecert(k)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1260,7 +1260,7 @@ func (ra *RegistrationAuthorityImpl) getSCTs(ctx context.Context, cert []byte, e
 // domainsForRateLimiting transforms a list of FQDNs into a list of eTLD+1's
 // for the purpose of rate limiting. It also de-duplicates the output
 // domains. Exact public suffix matches are included.
-func domainsForRateLimiting(names []string) ([]string, error) {
+func domainsForRateLimiting(names []string) []string {
 	var domains []string
 	for _, name := range names {
 		domain, err := publicsuffix.Domain(name)
@@ -1274,7 +1274,7 @@ func domainsForRateLimiting(names []string) ([]string, error) {
 			domains = append(domains, domain)
 		}
 	}
-	return core.UniqueLowerNames(domains), nil
+	return core.UniqueLowerNames(domains)
 }
 
 // enforceNameCounts uses the provided count RPC to find a count of certificates
@@ -1325,11 +1325,7 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 		return nil
 	}
 
-	tldNames, err := domainsForRateLimiting(names)
-	if err != nil {
-		return err
-	}
-
+	tldNames := domainsForRateLimiting(names)
 	namesOutOfLimit, err := ra.enforceNameCounts(ctx, tldNames, limit, regID)
 	if err != nil {
 		return fmt.Errorf("checking certificates per name limit for %q: %s",

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -691,7 +691,7 @@ func (ra *RegistrationAuthorityImpl) checkOrderAuthorizations(
 	// Ensure the names from the CSR are free of duplicates & lowercased.
 	names = core.UniqueLowerNames(names)
 	// Check the authorizations to ensure validity for the names required.
-	if err = ra.checkAuthorizationsCAA(ctx, names, authzs, int64(acctID), ra.clk.Now()); err != nil {
+	if err = ra.checkAuthorizationsCAA(ctx, names, authzs, ra.clk.Now()); err != nil {
 		return nil, err
 	}
 
@@ -720,7 +720,6 @@ func (ra *RegistrationAuthorityImpl) checkAuthorizationsCAA(
 	ctx context.Context,
 	names []string,
 	authzs map[string]*core.Authorization,
-	regID int64,
 	now time.Time) error {
 	// badNames contains the names that were unauthorized
 	var badNames []string

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -410,7 +410,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, reques
 	if err != nil {
 		return nil, err
 	}
-	err = ra.validateContacts(ctx, request.Contact)
+	err = ra.validateContacts(request.Contact)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, reques
 // * A list containing a mailto contact that contains hfields
 // * A list containing a contact that has non-ascii characters
 // * A list containing a contact that doesn't pass `policy.ValidEmail`
-func (ra *RegistrationAuthorityImpl) validateContacts(ctx context.Context, contacts []string) error {
+func (ra *RegistrationAuthorityImpl) validateContacts(contacts []string) error {
 	if len(contacts) == 0 {
 		return nil // Nothing to validate
 	}
@@ -1451,7 +1451,7 @@ func (ra *RegistrationAuthorityImpl) UpdateRegistration(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	err = ra.validateContacts(ctx, req.Update.Contact)
+	err = ra.validateContacts(req.Update.Contact)
 	if err != nil {
 		return nil, err
 	}
@@ -2569,7 +2569,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	// authorization for each.
 	var newAuthzs []*corepb.Authorization
 	for _, name := range missingAuthzNames {
-		pb, err := ra.createPendingAuthz(ctx, newOrder.RegistrationID, identifier.ACMEIdentifier{
+		pb, err := ra.createPendingAuthz(newOrder.RegistrationID, identifier.ACMEIdentifier{
 			Type:  identifier.DNS,
 			Value: name,
 		})
@@ -2632,7 +2632,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 // createPendingAuthz checks that a name is allowed for issuance and creates the
 // necessary challenges for it and puts this and all of the relevant information
 // into a corepb.Authorization for transmission to the SA to be stored
-func (ra *RegistrationAuthorityImpl) createPendingAuthz(ctx context.Context, reg int64, identifier identifier.ACMEIdentifier) (*corepb.Authorization, error) {
+func (ra *RegistrationAuthorityImpl) createPendingAuthz(reg int64, identifier identifier.ACMEIdentifier) (*corepb.Authorization, error) {
 	authz := &corepb.Authorization{
 		Identifier:     identifier.Value,
 		RegistrationID: reg,

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -373,55 +373,55 @@ func TestValidateContacts(t *testing.T) {
 	unparsable := "mailto:a@email.com, b@email.com"
 	forbidden := "mailto:a@example.org"
 
-	err := ra.validateContacts(context.Background(), []string{})
+	err := ra.validateContacts([]string{})
 	test.AssertNotError(t, err, "No Contacts")
 
-	err = ra.validateContacts(context.Background(), []string{validEmail, otherValidEmail})
+	err = ra.validateContacts([]string{validEmail, otherValidEmail})
 	test.AssertError(t, err, "Too Many Contacts")
 
-	err = ra.validateContacts(context.Background(), []string{validEmail})
+	err = ra.validateContacts([]string{validEmail})
 	test.AssertNotError(t, err, "Valid Email")
 
-	err = ra.validateContacts(context.Background(), []string{malformedEmail})
+	err = ra.validateContacts([]string{malformedEmail})
 	test.AssertError(t, err, "Malformed Email")
 
-	err = ra.validateContacts(context.Background(), []string{ansible})
+	err = ra.validateContacts([]string{ansible})
 	test.AssertError(t, err, "Unknown scheme")
 
-	err = ra.validateContacts(context.Background(), []string{""})
+	err = ra.validateContacts([]string{""})
 	test.AssertError(t, err, "Empty URL")
 
-	err = ra.validateContacts(context.Background(), []string{nonASCII})
+	err = ra.validateContacts([]string{nonASCII})
 	test.AssertError(t, err, "Non ASCII email")
 
-	err = ra.validateContacts(context.Background(), []string{unparsable})
+	err = ra.validateContacts([]string{unparsable})
 	test.AssertError(t, err, "Unparsable email")
 
-	err = ra.validateContacts(context.Background(), []string{forbidden})
+	err = ra.validateContacts([]string{forbidden})
 	test.AssertError(t, err, "Forbidden email")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:admin@localhost"})
+	err = ra.validateContacts([]string{"mailto:admin@localhost"})
 	test.AssertError(t, err, "Forbidden email")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:admin@example.not.a.iana.suffix"})
+	err = ra.validateContacts([]string{"mailto:admin@example.not.a.iana.suffix"})
 	test.AssertError(t, err, "Forbidden email")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:admin@1.2.3.4"})
+	err = ra.validateContacts([]string{"mailto:admin@1.2.3.4"})
 	test.AssertError(t, err, "Forbidden email")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:admin@[1.2.3.4]"})
+	err = ra.validateContacts([]string{"mailto:admin@[1.2.3.4]"})
 	test.AssertError(t, err, "Forbidden email")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:admin@a.com?no-reminder-emails"})
+	err = ra.validateContacts([]string{"mailto:admin@a.com?no-reminder-emails"})
 	test.AssertError(t, err, "No hfields in email")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:example@a.com?"})
+	err = ra.validateContacts([]string{"mailto:example@a.com?"})
 	test.AssertError(t, err, "No hfields in email")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:example@a.com#"})
+	err = ra.validateContacts([]string{"mailto:example@a.com#"})
 	test.AssertError(t, err, "No fragment")
 
-	err = ra.validateContacts(context.Background(), []string{"mailto:example@a.com#optional"})
+	err = ra.validateContacts([]string{"mailto:example@a.com#optional"})
 	test.AssertError(t, err, "No fragment")
 
 	// The registrations.contact field is VARCHAR(191). 175 'a' characters plus
@@ -434,7 +434,7 @@ func TestValidateContacts(t *testing.T) {
 	}
 	longStringBuf.WriteString("@a.com")
 
-	err = ra.validateContacts(context.Background(), []string{longStringBuf.String()})
+	err = ra.validateContacts([]string{longStringBuf.String()})
 	test.AssertError(t, err, "Too long contacts")
 }
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1040,28 +1040,22 @@ func TestAuthzFailedRateLimitingNewOrder(t *testing.T) {
 }
 
 func TestDomainsForRateLimiting(t *testing.T) {
-	domains, err := domainsForRateLimiting([]string{})
-	test.AssertNotError(t, err, "failed on empty")
+	domains := domainsForRateLimiting([]string{})
 	test.AssertEquals(t, len(domains), 0)
 
-	domains, err = domainsForRateLimiting([]string{"www.example.com", "example.com"})
-	test.AssertNotError(t, err, "failed on example.com")
+	domains = domainsForRateLimiting([]string{"www.example.com", "example.com"})
 	test.AssertDeepEquals(t, domains, []string{"example.com"})
 
-	domains, err = domainsForRateLimiting([]string{"www.example.com", "example.com", "www.example.co.uk"})
-	test.AssertNotError(t, err, "failed on example.co.uk")
+	domains = domainsForRateLimiting([]string{"www.example.com", "example.com", "www.example.co.uk"})
 	test.AssertDeepEquals(t, domains, []string{"example.co.uk", "example.com"})
 
-	domains, err = domainsForRateLimiting([]string{"www.example.com", "example.com", "www.example.co.uk", "co.uk"})
-	test.AssertNotError(t, err, "should not fail on public suffix")
+	domains = domainsForRateLimiting([]string{"www.example.com", "example.com", "www.example.co.uk", "co.uk"})
 	test.AssertDeepEquals(t, domains, []string{"co.uk", "example.co.uk", "example.com"})
 
-	domains, err = domainsForRateLimiting([]string{"foo.bar.baz.www.example.com", "baz.example.com"})
-	test.AssertNotError(t, err, "failed on foo.bar.baz")
+	domains = domainsForRateLimiting([]string{"foo.bar.baz.www.example.com", "baz.example.com"})
 	test.AssertDeepEquals(t, domains, []string{"example.com"})
 
-	domains, err = domainsForRateLimiting([]string{"github.io", "foo.github.io", "bar.github.io"})
-	test.AssertNotError(t, err, "failed on public suffix private domain")
+	domains = domainsForRateLimiting([]string{"github.io", "foo.github.io", "bar.github.io"})
 	test.AssertDeepEquals(t, domains, []string{"bar.github.io", "foo.github.io", "github.io"})
 }
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1734,22 +1734,22 @@ func TestRecheckCAADates(t *testing.T) {
 	// NOTE: The names provided here correspond to authorizations in the
 	// `mockSAWithRecentAndOlder`
 	names := []string{"recent.com", "older.com", "older2.com", "wildcard.com", "*.wildcard.com"}
-	err := ra.checkAuthorizationsCAA(context.Background(), names, authzs, 999, fc.Now())
+	err := ra.checkAuthorizationsCAA(context.Background(), names, authzs, fc.Now())
 	// We expect that there is no error rechecking authorizations for these names
 	if err != nil {
 		t.Errorf("expected nil err, got %s", err)
 	}
 
 	// Should error if a authorization has `!= 1` challenge
-	err = ra.checkAuthorizationsCAA(context.Background(), []string{"twochallenges.com"}, authzs, 999, fc.Now())
+	err = ra.checkAuthorizationsCAA(context.Background(), []string{"twochallenges.com"}, authzs, fc.Now())
 	test.AssertEquals(t, err.Error(), "authorization has incorrect number of challenges. 1 expected, 2 found for: id twochal")
 
 	// Should error if a authorization has `!= 1` challenge
-	err = ra.checkAuthorizationsCAA(context.Background(), []string{"nochallenges.com"}, authzs, 999, fc.Now())
+	err = ra.checkAuthorizationsCAA(context.Background(), []string{"nochallenges.com"}, authzs, fc.Now())
 	test.AssertEquals(t, err.Error(), "authorization has incorrect number of challenges. 1 expected, 0 found for: id nochal")
 
 	// Should error if authorization's challenge has no validated timestamp
-	err = ra.checkAuthorizationsCAA(context.Background(), []string{"novalidationtime.com"}, authzs, 999, fc.Now())
+	err = ra.checkAuthorizationsCAA(context.Background(), []string{"novalidationtime.com"}, authzs, fc.Now())
 	test.AssertEquals(t, err.Error(), "authorization's challenge has no validated timestamp for: id noval")
 
 	// Test to make sure the authorization lifetime codepath was not used

--- a/sa/rate_limits_test.go
+++ b/sa/rate_limits_test.go
@@ -1,7 +1,6 @@
 package sa
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -46,7 +45,7 @@ func TestCertsPerNameRateLimitTable(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = sa.addCertificatesPerName(context.Background(), tx, input.names, input.time)
+		err = sa.addCertificatesPerName(tx, input.names, input.time)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,24 +107,24 @@ func TestNewOrdersRateLimitTable(t *testing.T) {
 		tx, err := sa.dbMap.Begin()
 		test.AssertNotError(t, err, "failed to open tx")
 		for j := 0; j < i+1; j++ {
-			err = addNewOrdersRateLimit(context.Background(), tx, manyCountRegID, start.Add(time.Minute*time.Duration(i)))
+			err = addNewOrdersRateLimit(tx, manyCountRegID, start.Add(time.Minute*time.Duration(i)))
 		}
 		test.AssertNotError(t, err, "addNewOrdersRateLimit failed")
 		test.AssertNotError(t, tx.Commit(), "failed to commit tx")
 	}
 
-	count, err := countNewOrders(context.Background(), sa.dbMap, req)
+	count, err := countNewOrders(sa.dbMap, req)
 	test.AssertNotError(t, err, "countNewOrders failed")
 	test.AssertEquals(t, count.Count, int64(0))
 
 	req.AccountID = manyCountRegID
-	count, err = countNewOrders(context.Background(), sa.dbMap, req)
+	count, err = countNewOrders(sa.dbMap, req)
 	test.AssertNotError(t, err, "countNewOrders failed")
 	test.AssertEquals(t, count.Count, int64(65))
 
 	req.Range.Earliest = start.Add(time.Minute * 5).UnixNano()
 	req.Range.Latest = start.Add(time.Minute * 10).UnixNano()
-	count, err = countNewOrders(context.Background(), sa.dbMap, req)
+	count, err = countNewOrders(sa.dbMap, req)
 	test.AssertNotError(t, err, "countNewOrders failed")
 	test.AssertEquals(t, count.Count, int64(45))
 }

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -557,7 +557,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(ctx context.Context, req *sapb.Ad
 		// don't count against the certificatesPerName limit.
 		if !isRenewal {
 			timeToTheHour := parsedCertificate.NotBefore.Round(time.Hour)
-			err := ssa.addCertificatesPerName(ctx, txWithCtx, parsedCertificate.DNSNames, timeToTheHour)
+			err := ssa.addCertificatesPerName(txWithCtx, parsedCertificate.DNSNames, timeToTheHour)
 			if err != nil {
 				return nil, err
 			}
@@ -594,7 +594,7 @@ func (ssa *SQLStorageAuthority) CountOrders(ctx context.Context, req *sapb.Count
 	}
 
 	if features.Enabled(features.FasterNewOrdersRateLimit) {
-		return countNewOrders(ctx, ssa.dbReadOnlyMap, req)
+		return countNewOrders(ssa.dbReadOnlyMap.WithContext(ctx), req)
 	}
 
 	var count int64
@@ -934,7 +934,7 @@ func (ssa *SQLStorageAuthority) NewOrder(ctx context.Context, req *sapb.NewOrder
 
 	if features.Enabled(features.FasterNewOrdersRateLimit) {
 		// Increment the order creation count
-		err := addNewOrdersRateLimit(ctx, ssa.dbMap, req.RegistrationID, ssa.clk.Now().Truncate(time.Minute))
+		err := addNewOrdersRateLimit(ssa.dbMap.WithContext(ctx), req.RegistrationID, ssa.clk.Now().Truncate(time.Minute))
 		if err != nil {
 			return nil, err
 		}
@@ -1090,7 +1090,7 @@ func (ssa *SQLStorageAuthority) NewOrderAndAuthzs(ctx context.Context, req *sapb
 
 	if features.Enabled(features.FasterNewOrdersRateLimit) {
 		// Increment the order creation count
-		err := addNewOrdersRateLimit(ctx, ssa.dbMap, req.NewOrder.RegistrationID, ssa.clk.Now().Truncate(time.Minute))
+		err := addNewOrdersRateLimit(ssa.dbMap.WithContext(ctx), req.NewOrder.RegistrationID, ssa.clk.Now().Truncate(time.Minute))
 		if err != nil {
 			return nil, err
 		}

--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -40,7 +40,7 @@ type integrationSrv struct {
 	userAgent     string
 }
 
-func readJSON(w http.ResponseWriter, r *http.Request, output interface{}) error {
+func readJSON(r *http.Request, output interface{}) error {
 	if r.Method != "POST" {
 		return fmt.Errorf("incorrect method; only POST allowed")
 	}
@@ -66,7 +66,7 @@ func (is *integrationSrv) addRejectHost(w http.ResponseWriter, r *http.Request) 
 	var rejectHostReq struct {
 		Host string
 	}
-	err := readJSON(w, r, &rejectHostReq)
+	err := readJSON(r, &rejectHostReq)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/test/load-generator/config/integration-test-config.json
+++ b/test/load-generator/config/integration-test-config.json
@@ -19,7 +19,6 @@
     "dnsAddrs": [":8053", ":8054"],
     "fakeDNS": "10.77.77.77",
     "regKeySize": 2048,
-    "certKeySize": 2048,
     "regEmail": "loadtesting@letsencrypt.org",
     "maxRegs": 20,
     "maxNamesPerCert": 20,

--- a/test/load-generator/example-config.json
+++ b/test/load-generator/example-config.json
@@ -14,7 +14,6 @@
     "domainBase": "com",
     "httpOneAddr": "localhost:5002",
     "regKeySize": 2048,
-    "certKeySize": 2048,
     "regEmail": "loadtesting@letsencrypt.org",
     "maxRegs": 20,
     "maxNamesPerCert": 20,

--- a/test/load-generator/main.go
+++ b/test/load-generator/main.go
@@ -29,7 +29,6 @@ type Config struct {
 	DNSAddrs          []string // addresses to listen for DNS requests on
 	FakeDNS           string   // IPv6 address to use for all DNS A requests
 	RealIP            string   // value of the Real-IP header to use when bypassing CDN
-	CertKeySize       int      // size of the key to use when creating CSRs
 	RegEmail          string   // email to use in registrations
 	Results           string   // path to save metrics to
 	MaxRegs           int      // maximum number of registrations to create
@@ -78,7 +77,6 @@ func main() {
 
 	s, err := New(
 		config.DirectoryURL,
-		config.CertKeySize,
 		config.DomainBase,
 		config.RealIP,
 		config.MaxRegs,

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -277,7 +277,6 @@ func (s *State) Restore(filename string) error {
 // New returns a pointer to a new State struct or an error
 func New(
 	directoryURL string,
-	keySize int,
 	domainBase string,
 	realIP string,
 	maxRegs, maxNamesPerCert int,

--- a/va/http.go
+++ b/va/http.go
@@ -343,7 +343,6 @@ func (va *ValidationAuthorityImpl) extractRequestTarget(req *http.Request) (stri
 // the validation target is nil or has no available IP addresses, an error will
 // be returned.
 func (va *ValidationAuthorityImpl) setupHTTPValidation(
-	ctx context.Context,
 	reqURL string,
 	target *httpValidationTarget) (*preresolvedDialer, core.ValidationRecord, error) {
 	if reqURL == "" {
@@ -483,7 +482,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 	initialReq.Header.Set("Accept", "*/*")
 
 	// Set up the initial validation request and a base validation record
-	dialer, baseRecord, err := va.setupHTTPValidation(ctx, initialReq.URL.String(), target)
+	dialer, baseRecord, err := va.setupHTTPValidation(initialReq.URL.String(), target)
 	if err != nil {
 		return nil, []core.ValidationRecord{}, newIPError(target, err)
 	}
@@ -569,7 +568,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		// Setup validation for the target. This will produce a preresolved dialer we can
 		// assign to the client transport in order to connect to the redirect target using
 		// the IP address we selected.
-		redirDialer, redirRecord, err := va.setupHTTPValidation(ctx, req.URL.String(), redirTarget)
+		redirDialer, redirRecord, err := va.setupHTTPValidation(req.URL.String(), redirTarget)
 		records = append(records, redirRecord)
 		if err != nil {
 			return err
@@ -604,7 +603,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 
 		// setup another validation to retry the target with the new IP and append
 		// the retry record.
-		retryDialer, retryRecord, err := va.setupHTTPValidation(ctx, initialReq.URL.String(), target)
+		retryDialer, retryRecord, err := va.setupHTTPValidation(initialReq.URL.String(), target)
 		records = append(records, retryRecord)
 		if err != nil {
 			return nil, records, newIPError(target, err)

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -466,11 +466,7 @@ func TestSetupHTTPValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			outDialer, outRecord, err := va.setupHTTPValidation(
-				context.Background(),
-				tc.InputURL,
-				tc.InputTarget)
-
+			outDialer, outRecord, err := va.setupHTTPValidation(tc.InputURL, tc.InputTarget)
 			if err != nil && tc.ExpectedError == nil {
 				t.Errorf("Expected nil error, got %v", err)
 			} else if err == nil && tc.ExpectedError != nil {

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -491,6 +491,7 @@ func TestSetupHTTPValidation(t *testing.T) {
 
 // A more concise version of httpSrv() that supports http.go tests
 func httpTestSrv(t *testing.T) *httptest.Server {
+	t.Helper()
 	mux := http.NewServeMux()
 	server := httptest.NewUnstartedServer(mux)
 

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -60,7 +60,7 @@ func makeACert(names []string) *tls.Certificate {
 }
 
 // tlssniSrvWithNames is kept around for the use of TestValidateTLSALPN01UnawareSrv
-func tlssniSrvWithNames(t *testing.T, chall core.Challenge, names ...string) *httptest.Server {
+func tlssniSrvWithNames(t *testing.T, names ...string) *httptest.Server {
 	t.Helper()
 
 	cert := makeACert(names)
@@ -79,13 +79,7 @@ func tlssniSrvWithNames(t *testing.T, chall core.Challenge, names ...string) *ht
 	return hs
 }
 
-func tlsalpn01SrvWithCert(
-	t *testing.T,
-	chall core.Challenge,
-	oid asn1.ObjectIdentifier,
-	names []string,
-	acmeCert *tls.Certificate,
-	tlsVersion uint16) *httptest.Server {
+func tlsalpn01SrvWithCert(t *testing.T, acmeCert *tls.Certificate, tlsVersion uint16) *httptest.Server {
 	t.Helper()
 
 	tlsConfig := &tls.Config{
@@ -140,7 +134,7 @@ func tlsalpn01Srv(
 		PrivateKey:  &TheKey,
 	}
 
-	return tlsalpn01SrvWithCert(t, chall, oid, names, acmeCert, tlsVersion), nil
+	return tlsalpn01SrvWithCert(t, acmeCert, tlsVersion), nil
 }
 
 func TestTLSALPN01FailIP(t *testing.T) {
@@ -472,7 +466,7 @@ func TestValidateTLSALPN01BrokenSrv(t *testing.T) {
 
 func TestValidateTLSALPN01UnawareSrv(t *testing.T) {
 	chall := tlsalpnChallenge()
-	hs := tlssniSrvWithNames(t, chall, "expected")
+	hs := tlssniSrvWithNames(t, "expected")
 
 	va, _ := setup(hs, 0, "", nil)
 
@@ -525,7 +519,7 @@ func TestValidateTLSALPN01MalformedExtnValue(t *testing.T) {
 			PrivateKey:  &TheKey,
 		}
 
-		hs := tlsalpn01SrvWithCert(t, chall, IdPeAcmeIdentifier, names, acmeCert, 0)
+		hs := tlsalpn01SrvWithCert(t, acmeCert, 0)
 		va, _ := setup(hs, 0, "", nil)
 
 		_, prob := va.validateTLSALPN01(ctx, dnsi("expected"), chall)
@@ -662,7 +656,7 @@ func TestTLSALPN01NotSelfSigned(t *testing.T) {
 		PrivateKey:  &TheKey,
 	}
 
-	hs := tlsalpn01SrvWithCert(t, chall, IdPeAcmeIdentifier, []string{"expected"}, acmeCert, tls.VersionTLS12)
+	hs := tlsalpn01SrvWithCert(t, acmeCert, tls.VersionTLS12)
 
 	va, _ := setup(hs, 0, "", nil)
 
@@ -709,7 +703,7 @@ func TestTLSALPN01ExtraIdentifiers(t *testing.T) {
 		PrivateKey:  &TheKey,
 	}
 
-	hs := tlsalpn01SrvWithCert(t, chall, IdPeAcmeIdentifier, []string{"expected"}, acmeCert, tls.VersionTLS12)
+	hs := tlsalpn01SrvWithCert(t, acmeCert, tls.VersionTLS12)
 
 	va, _ := setup(hs, 0, "", nil)
 
@@ -769,7 +763,7 @@ func TestTLSALPN01ExtraSANs(t *testing.T) {
 		PrivateKey:  &TheKey,
 	}
 
-	hs := tlsalpn01SrvWithCert(t, chall, IdPeAcmeIdentifier, []string{"expected"}, acmeCert, tls.VersionTLS12)
+	hs := tlsalpn01SrvWithCert(t, acmeCert, tls.VersionTLS12)
 
 	va, _ := setup(hs, 0, "", nil)
 
@@ -829,7 +823,7 @@ func TestTLSALPN01ExtraAcmeExtensions(t *testing.T) {
 		PrivateKey:  &TheKey,
 	}
 
-	hs := tlsalpn01SrvWithCert(t, chall, IdPeAcmeIdentifier, []string{"expected"}, acmeCert, tls.VersionTLS12)
+	hs := tlsalpn01SrvWithCert(t, acmeCert, tls.VersionTLS12)
 
 	va, _ := setup(hs, 0, "", nil)
 

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -61,6 +61,8 @@ func makeACert(names []string) *tls.Certificate {
 
 // tlssniSrvWithNames is kept around for the use of TestValidateTLSALPN01UnawareSrv
 func tlssniSrvWithNames(t *testing.T, chall core.Challenge, names ...string) *httptest.Server {
+	t.Helper()
+
 	cert := makeACert(names)
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{*cert},
@@ -84,6 +86,8 @@ func tlsalpn01SrvWithCert(
 	names []string,
 	acmeCert *tls.Certificate,
 	tlsVersion uint16) *httptest.Server {
+	t.Helper()
+
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{},
 		ClientAuth:   tls.NoClientCert,

--- a/va/va.go
+++ b/va/va.go
@@ -417,7 +417,7 @@ func (va *ValidationAuthorityImpl) performRemoteValidation(
 	results chan *remoteValidationResult) {
 	for _, i := range rand.Perm(len(va.remoteVAs)) {
 		remoteVA := va.remoteVAs[i]
-		go func(rva RemoteVA, index int) {
+		go func(rva RemoteVA) {
 			result := &remoteValidationResult{
 				VAHostname: rva.Address,
 			}
@@ -444,7 +444,7 @@ func (va *ValidationAuthorityImpl) performRemoteValidation(
 				}
 			}
 			results <- result
-		}(remoteVA, i)
+		}(remoteVA)
 	}
 }
 

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -177,6 +177,7 @@ func (s *multiSrv) setAllowedUAs(allowedUAs map[string]bool) {
 const slowRemoteSleepMillis = 1000
 
 func httpMultiSrv(t *testing.T, token string, allowedUAs map[string]bool) *multiSrv {
+	t.Helper()
 	m := http.NewServeMux()
 
 	server := httptest.NewUnstartedServer(m)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -153,12 +153,9 @@ func setup(srv *httptest.Server, maxRemoteFailures int, userAgent string, remote
 	return va, logger
 }
 
-func setupRemote(srv *httptest.Server, maxRemoteFailures int, userAgent string) (vapb.VAClient, *blog.Mock) {
-	innerVA, mockLog := setup(srv, maxRemoteFailures, userAgent, nil)
-	res := localRemoteVA{
-		remote: *innerVA,
-	}
-	return &res, mockLog
+func setupRemote(srv *httptest.Server, userAgent string) vapb.VAClient {
+	innerVA, _ := setup(srv, 0, userAgent, nil)
+	return &localRemoteVA{remote: *innerVA}
 }
 
 type multiSrv struct {
@@ -329,8 +326,8 @@ func TestMultiVA(t *testing.T) {
 	ms := httpMultiSrv(t, expectedToken, allowedUAs)
 	defer ms.Close()
 
-	remoteVA1, _ := setupRemote(ms.Server, 0, remoteUA1)
-	remoteVA2, _ := setupRemote(ms.Server, 0, remoteUA2)
+	remoteVA1 := setupRemote(ms.Server, remoteUA1)
+	remoteVA2 := setupRemote(ms.Server, remoteUA2)
 
 	remoteVAs := []RemoteVA{
 		{remoteVA1, remoteUA1},
@@ -539,8 +536,8 @@ func TestMultiVAEarlyReturn(t *testing.T) {
 	ms := httpMultiSrv(t, expectedToken, allowedUAs)
 	defer ms.Close()
 
-	remoteVA1, _ := setupRemote(ms.Server, 0, remoteUA1)
-	remoteVA2, _ := setupRemote(ms.Server, 0, remoteUA2)
+	remoteVA1 := setupRemote(ms.Server, remoteUA1)
+	remoteVA2 := setupRemote(ms.Server, remoteUA2)
 
 	remoteVAs := []RemoteVA{
 		{remoteVA1, remoteUA1},
@@ -627,8 +624,8 @@ func TestMultiVAPolicy(t *testing.T) {
 	ms := httpMultiSrv(t, expectedToken, allowedUAs)
 	defer ms.Close()
 
-	remoteVA1, _ := setupRemote(ms.Server, 0, remoteUA1)
-	remoteVA2, _ := setupRemote(ms.Server, 0, remoteUA2)
+	remoteVA1 := setupRemote(ms.Server, remoteUA1)
+	remoteVA2 := setupRemote(ms.Server, remoteUA2)
 
 	remoteVAs := []RemoteVA{
 		{remoteVA1, remoteUA1},
@@ -710,9 +707,9 @@ func TestDetailedError(t *testing.T) {
 
 func TestLogRemoteValidationDifferentials(t *testing.T) {
 	// Create some remote VAs
-	remoteVA1, _ := setupRemote(nil, 0, "remote 1")
-	remoteVA2, _ := setupRemote(nil, 0, "remote 2")
-	remoteVA3, _ := setupRemote(nil, 0, "remote 3")
+	remoteVA1 := setupRemote(nil, "remote 1")
+	remoteVA2 := setupRemote(nil, "remote 2")
+	remoteVA3 := setupRemote(nil, "remote 3")
 	remoteVAs := []RemoteVA{
 		{remoteVA1, "remote 1"},
 		{remoteVA2, "remote 2"},

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -731,8 +731,7 @@ func (wfe *WebFrontEndImpl) validKeyRollover(
 	ctx context.Context,
 	outerJWS *jose.JSONWebSignature,
 	innerJWS *jose.JSONWebSignature,
-	oldKey *jose.JSONWebKey,
-	logEvent *web.RequestEvent) (*rolloverOperation, *probs.ProblemDetails) {
+	oldKey *jose.JSONWebKey) (*rolloverOperation, *probs.ProblemDetails) {
 
 	// Extract the embedded JWK from the inner JWS
 	jwk, prob := wfe.extractJWK(innerJWS)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1803,7 +1803,7 @@ func (wfe *WebFrontEndImpl) KeyRollover(
 	}
 
 	// Validate the inner JWS as a key rollover request for the outer JWS
-	rolloverOperation, prob := wfe.validKeyRollover(ctx, outerJWS, innerJWS, oldKey, logEvent)
+	rolloverOperation, prob := wfe.validKeyRollover(ctx, outerJWS, innerJWS, oldKey)
 	if prob != nil {
 		wfe.sendError(response, logEvent, prob, nil)
 		return

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1062,7 +1062,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 	challenge := authz.Challenges[challengeIndex]
 	switch request.Method {
 	case "GET", "HEAD":
-		wfe.getChallenge(ctx, response, request, authz, &challenge, logEvent)
+		wfe.getChallenge(response, request, authz, &challenge, logEvent)
 
 	case "POST":
 		logEvent.ChallengeType = string(challenge.Type)
@@ -1146,7 +1146,6 @@ func (wfe *WebFrontEndImpl) prepAuthorizationForDisplay(request *http.Request, a
 }
 
 func (wfe *WebFrontEndImpl) getChallenge(
-	ctx context.Context,
 	response http.ResponseWriter,
 	request *http.Request,
 	authz core.Authorization,
@@ -1198,7 +1197,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	// challenge details, not a POST to initiate a challenge
 	if string(body) == "" {
 		challenge := authz.Challenges[challengeIndex]
-		wfe.getChallenge(ctx, response, request, authz, &challenge, logEvent)
+		wfe.getChallenge(response, request, authz, &challenge, logEvent)
 		return
 	}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3189,7 +3189,7 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 		Identifier:     identifier.DNSIdentifier("*.example.com"),
 		Challenges: []core.Challenge{
 			{
-				Type:                     "dns",
+				Type: "dns",
 				ProvidedKeyAuthorization: "	🔑",
 			},
 		},

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -381,12 +381,12 @@ func makePostRequestWithPath(path string, body string) *http.Request {
 	return request
 }
 
-// signAndPost constructs a JWS signed by the given account ID, over the given
+// signAndPost constructs a JWS signed by the account with ID 1, over the given
 // payload, with the protected URL set to the provided signedURL. An HTTP
 // request constructed to the provided path with the encoded JWS body as the
 // POST body is returned.
-func signAndPost(t *testing.T, path, signedURL, payload string, accountID int64, ns *nonce.NonceService) *http.Request {
-	_, _, body := signRequestKeyID(t, accountID, nil, signedURL, payload, ns)
+func signAndPost(t *testing.T, path, signedURL, payload string, ns *nonce.NonceService) *http.Request {
+	_, _, body := signRequestKeyID(t, 1, nil, signedURL, payload, ns)
 	return makePostRequestWithPath(path, body)
 }
 
@@ -1746,10 +1746,10 @@ type mockSAWithCert struct {
 	status core.OCSPStatus
 }
 
-func newMockSAWithCert(t *testing.T, sa sapb.StorageAuthorityGetterClient, status core.OCSPStatus) *mockSAWithCert {
+func newMockSAWithGoodCert(t *testing.T, sa sapb.StorageAuthorityGetterClient) *mockSAWithCert {
 	cert, err := core.LoadCert("../test/hierarchy/ee-r3.cert.pem")
 	test.AssertNotError(t, err, "Failed to load test cert")
-	return &mockSAWithCert{sa, cert, status}
+	return &mockSAWithCert{sa, cert, core.OCSPStatusGood}
 }
 
 // GetCertificate returns the mock SA's hard-coded certificate, issued by the
@@ -1784,7 +1784,7 @@ func (sa *mockSAWithCert) GetCertificateStatus(_ context.Context, req *sapb.Seri
 
 func TestGetCertificate(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 	mux := wfe.Handler(metrics.NoopRegisterer)
 
 	makeGet := func(path string) *http.Request {
@@ -2133,7 +2133,7 @@ func TestGetCertificateNew(t *testing.T) {
 // body from being sent like the net/http Server's actually do.
 func TestGetCertificateHEADHasCorrectBodyLength(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	certPemBytes, _ := os.ReadFile("../test/hierarchy/ee-r3.cert.pem")
 	cert, err := core.LoadCert("../test/hierarchy/ee-r3.cert.pem")
@@ -2432,37 +2432,37 @@ func TestNewOrder(t *testing.T) {
 		},
 		{
 			Name:         "POST, properly signed JWS, payload isn't valid",
-			Request:      signAndPost(t, targetPath, signedURL, "foo", 1, wfe.nonceService),
+			Request:      signAndPost(t, targetPath, signedURL, "foo", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 		{
 			Name:         "POST, empty domain name identifier",
-			Request:      signAndPost(t, targetPath, signedURL, `{"identifiers":[{"type":"dns","value":""}]}`, 1, wfe.nonceService),
+			Request:      signAndPost(t, targetPath, signedURL, `{"identifiers":[{"type":"dns","value":""}]}`, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request included empty domain name","status":400}`,
 		},
 		{
 			Name:         "POST, no identifiers in payload",
-			Request:      signAndPost(t, targetPath, signedURL, "{}", 1, wfe.nonceService),
+			Request:      signAndPost(t, targetPath, signedURL, "{}", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request did not specify any identifiers","status":400}`,
 		},
 		{
 			Name:         "POST, invalid identifier in payload",
-			Request:      signAndPost(t, targetPath, signedURL, nonDNSIdentifierBody, 1, wfe.nonceService),
+			Request:      signAndPost(t, targetPath, signedURL, nonDNSIdentifierBody, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request included invalid non-DNS type identifier: type \"fakeID\", value \"www.i-am-21.com\"","status":400}`,
 		},
 		{
 			Name:         "POST, notAfter and notBefore in payload",
-			Request:      signAndPost(t, targetPath, signedURL, `{"identifiers":[{"type": "dns", "value": "not-example.com"}], "notBefore":"now", "notAfter": "later"}`, 1, wfe.nonceService),
+			Request:      signAndPost(t, targetPath, signedURL, `{"identifiers":[{"type": "dns", "value": "not-example.com"}], "notBefore":"now", "notAfter": "later"}`, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NotBefore and NotAfter are not supported","status":400}`,
 		},
 		{
 			Name:         "POST, no potential CNs 64 bytes or smaller",
-			Request:      signAndPost(t, targetPath, signedURL, tooLongCNBody, 1, wfe.nonceService),
+			Request:      signAndPost(t, targetPath, signedURL, tooLongCNBody, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `rejectedIdentifier","detail":"NewOrder request did not include a SAN short enough to fit in CN","status":400}`,
 		},
 		{
 			Name:    "POST, good payload, one potential CNs less than 64 bytes and one longer",
-			Request: signAndPost(t, targetPath, signedURL, oneLongOneShortCNBody, 1, wfe.nonceService),
+			Request: signAndPost(t, targetPath, signedURL, oneLongOneShortCNBody, wfe.nonceService),
 			ExpectedBody: `
 			{
 				"status": "pending",
@@ -2479,7 +2479,7 @@ func TestNewOrder(t *testing.T) {
 		},
 		{
 			Name:    "POST, good payload",
-			Request: signAndPost(t, targetPath, signedURL, validOrderBody, 1, wfe.nonceService),
+			Request: signAndPost(t, targetPath, signedURL, validOrderBody, wfe.nonceService),
 			ExpectedBody: `
 					{
 						"status": "pending",
@@ -2512,7 +2512,7 @@ func TestNewOrder(t *testing.T) {
 
 	// Test that we log the "Created" field.
 	responseWriter.Body.Reset()
-	request := signAndPost(t, targetPath, signedURL, validOrderBody, 1, wfe.nonceService)
+	request := signAndPost(t, targetPath, signedURL, validOrderBody, wfe.nonceService)
 	requestEvent := newRequestEvent()
 	wfe.NewOrder(ctx, requestEvent, responseWriter, request)
 
@@ -2563,17 +2563,17 @@ func TestFinalizeOrder(t *testing.T) {
 		},
 		{
 			Name:         "POST, properly signed JWS, payload isn't valid",
-			Request:      signAndPost(t, targetPath, signedURL, "foo", 1, wfe.nonceService),
+			Request:      signAndPost(t, targetPath, signedURL, "foo", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 		{
 			Name:         "Invalid path",
-			Request:      signAndPost(t, "1", "http://localhost/1", "{}", 1, wfe.nonceService),
+			Request:      signAndPost(t, "1", "http://localhost/1", "{}", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid request path","status":404}`,
 		},
 		{
 			Name:         "Bad acct ID in path",
-			Request:      signAndPost(t, "a/1", "http://localhost/a/1", "{}", 1, wfe.nonceService),
+			Request:      signAndPost(t, "a/1", "http://localhost/a/1", "{}", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid account ID","status":400}`,
 		},
 		{
@@ -2583,40 +2583,40 @@ func TestFinalizeOrder(t *testing.T) {
 			// handler directly and it normally has the initial path component
 			// stripped by the global WFE2 handler. We need the JWS URL to match the request
 			// URL so we fudge both such that the finalize-order prefix has been removed.
-			Request:      signAndPost(t, "2/1", "http://localhost/2/1", "{}", 1, wfe.nonceService),
+			Request:      signAndPost(t, "2/1", "http://localhost/2/1", "{}", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order found for account ID 2","status":404}`,
 		},
 		{
 			Name:         "Order ID is invalid",
-			Request:      signAndPost(t, "1/okwhatever/finalize-order", "http://localhost/1/okwhatever/finalize-order", "{}", 1, wfe.nonceService),
+			Request:      signAndPost(t, "1/okwhatever/finalize-order", "http://localhost/1/okwhatever/finalize-order", "{}", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid order ID","status":400}`,
 		},
 		{
 			Name: "Order doesn't exist",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 2 as missing
-			Request:      signAndPost(t, "1/2", "http://localhost/1/2", "{}", 1, wfe.nonceService),
+			Request:      signAndPost(t, "1/2", "http://localhost/1/2", "{}", wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order for ID 2","status":404}`,
 		},
 		{
 			Name: "Order is already finalized",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 1 as an Order with a Serial
-			Request:      signAndPost(t, "1/1", "http://localhost/1/1", goodCertCSRPayload, 1, wfe.nonceService),
+			Request:      signAndPost(t, "1/1", "http://localhost/1/1", goodCertCSRPayload, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `orderNotReady","detail":"Order's status (\"valid\") is not acceptable for finalization","status":403}`,
 		},
 		{
 			Name: "Order is expired",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 7 as an Order that has already expired
-			Request:      signAndPost(t, "1/7", "http://localhost/1/7", goodCertCSRPayload, 1, wfe.nonceService),
+			Request:      signAndPost(t, "1/7", "http://localhost/1/7", goodCertCSRPayload, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order 7 is expired","status":404}`,
 		},
 		{
 			Name:         "Good CSR, Pending Order",
-			Request:      signAndPost(t, "1/4", "http://localhost/1/4", goodCertCSRPayload, 1, wfe.nonceService),
+			Request:      signAndPost(t, "1/4", "http://localhost/1/4", goodCertCSRPayload, wfe.nonceService),
 			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `orderNotReady","detail":"Order's status (\"pending\") is not acceptable for finalization","status":403}`,
 		},
 		{
 			Name:            "Good CSR, Ready Order",
-			Request:         signAndPost(t, "1/8", "http://localhost/1/8", goodCertCSRPayload, 1, wfe.nonceService),
+			Request:         signAndPost(t, "1/8", "http://localhost/1/8", goodCertCSRPayload, wfe.nonceService),
 			ExpectedHeaders: map[string]string{"Location": "http://localhost/acme/order/1/8"},
 			ExpectedBody: `
 {
@@ -2652,7 +2652,7 @@ func TestFinalizeOrder(t *testing.T) {
 	// to match the whole response body because the "detail" of a bad CSR problem
 	// contains a verbose Go error message that can change between versions (e.g.
 	// Go 1.10.4 to 1.11 changed the expected format)
-	badCSRReq := signAndPost(t, "1/8", "http://localhost/1/8", `{"CSR": "ABCD"}`, 1, wfe.nonceService)
+	badCSRReq := signAndPost(t, "1/8", "http://localhost/1/8", `{"CSR": "ABCD"}`, wfe.nonceService)
 	responseWriter.Body.Reset()
 	wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, badCSRReq)
 	responseBody := responseWriter.Body.String()
@@ -2902,7 +2902,7 @@ func makeRevokeRequestJSONForCert(der []byte, reason *revocation.Reason) ([]byte
 // issuing account key.
 func TestRevokeCertificateByApplicantValid(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	mockLog := wfe.log.(*blog.Mock)
 	mockLog.Clear()
@@ -2927,7 +2927,7 @@ func TestRevokeCertificateByApplicantValid(t *testing.T) {
 // certificate private key.
 func TestRevokeCertificateByKeyValid(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	mockLog := wfe.log.(*blog.Mock)
 	mockLog.Clear()
@@ -2957,7 +2957,7 @@ func TestRevokeCertificateByKeyValid(t *testing.T) {
 // wasn't issued by any issuer the Boulder is aware of.
 func TestRevokeCertificateNotIssued(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	// Make a self-signed junk certificate
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -2993,7 +2993,7 @@ func TestRevokeCertificateNotIssued(t *testing.T) {
 
 func TestRevokeCertificateExpired(t *testing.T) {
 	wfe, fc := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	keyPemBytes, err := os.ReadFile("../test/hierarchy/ee-r3.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
@@ -3019,7 +3019,7 @@ func TestRevokeCertificateExpired(t *testing.T) {
 
 func TestRevokeCertificateReasons(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 	ra := wfe.ra.(*MockRegistrationAuthority)
 
 	reason0 := revocation.Reason(ocsp.Unspecified)
@@ -3086,7 +3086,7 @@ func TestRevokeCertificateReasons(t *testing.T) {
 // A revocation request signed by an incorrect certificate private key.
 func TestRevokeCertificateWrongCertificateKey(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	keyPemBytes, err := os.ReadFile("../test/hierarchy/ee-e1.key.pem")
 	test.AssertNotError(t, err, "Failed to load key")
@@ -3189,7 +3189,7 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 		Identifier:     identifier.DNSIdentifier("*.example.com"),
 		Challenges: []core.Challenge{
 			{
-				Type: "dns",
+				Type:                     "dns",
 				ProvidedKeyAuthorization: "	🔑",
 			},
 		},
@@ -3246,7 +3246,7 @@ func TestFinalizeSCTError(t *testing.T) {
 	}`
 
 	// Create a finalization request with the above payload
-	request := signAndPost(t, "1/8", "http://localhost/1/8", goodCertCSRPayload, 1, wfe.nonceService)
+	request := signAndPost(t, "1/8", "http://localhost/1/8", goodCertCSRPayload, wfe.nonceService)
 
 	// POST the finalize order request.
 	wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, request)
@@ -3475,7 +3475,7 @@ func TestIndexGet404(t *testing.T) {
 // enough that we're no longer worried about stale info being cached.
 func TestGetAPIAndMandatoryPOSTAsGET(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	makeGet := func(path, endpoint string) (*http.Request, *web.RequestEvent) {
 		return &http.Request{URL: &url.URL{Path: path}, Method: "GET"},
@@ -3497,7 +3497,7 @@ func TestGetAPIAndMandatoryPOSTAsGET(t *testing.T) {
 // requests for certs that don't exist result in errors.
 func TestARI(t *testing.T) {
 	wfe, _ := setupWFE(t)
-	wfe.sa = newMockSAWithCert(t, wfe.sa, core.OCSPStatusGood)
+	wfe.sa = newMockSAWithGoodCert(t, wfe.sa)
 
 	makeGet := func(path, endpoint string) (*http.Request, *web.RequestEvent) {
 		return &http.Request{URL: &url.URL{Path: path}, Method: "GET"},


### PR DESCRIPTION
Enable the "unparam" linter, which checks for unused function
parameters, unused function return values, and parameters and
return values that always have the same value every time they
are used.

In addition, fix many instances where the unparam linter complains
about our existing codebase. Remove error return values from a
number of functions that never return an error, remove or use
context and test parameters that were previously unused, and
simplify a number of (mostly test-only) functions that always take the
same value for their parameter. Most notably, remove the ability to
customize the RSA Public Exponent from the ceremony tooling,
since it should always be 65537 anyway.

Fixes #6104