### PR TITLE
rocsp-tool: add "get-pem" output

### DIFF
--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -3,6 +3,7 @@ package notmain
 import (
 	"context"
 	"encoding/base64"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -141,10 +142,15 @@ func main2() error {
 			}
 			parsed, err := ocsp.ParseResponse(resp, nil)
 			if err != nil {
-				logger.Infof("parsing error on %x: %s", resp, err)
+				fmt.Fprintf(os.Stderr, "parsing error on %x: %s", resp, err)
 				continue
 			} else {
-				logger.Infof("%s", helper.PrettyResponse(parsed))
+				block := pem.Block{
+					Bytes: resp,
+					Type:  "OCSP RESPONSE",
+				}
+				pem.Encode(os.Stdout, &block)
+				fmt.Printf("%s\n", helper.PrettyResponse(parsed))
 			}
 		}
 	case "store":

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -91,7 +91,6 @@ func main2() error {
 
 	_, logger := cmd.StatsAndLogging(c.Syslog, c.ROCSPTool.DebugAddr)
 	defer logger.AuditPanic()
-	logger.Info(cmd.VersionString())
 
 	clk := cmd.Clock()
 	redisClient, err := rocsp_config.MakeClient(&c.ROCSPTool.Redis, clk, metrics.NoopRegisterer)
@@ -145,20 +144,29 @@ func main2() error {
 				fmt.Fprintf(os.Stderr, "parsing error on %x: %s", resp, err)
 				continue
 			} else {
-				block := pem.Block{
-					Bytes: resp,
-					Type:  "OCSP RESPONSE",
-				}
-				pem.Encode(os.Stdout, &block)
 				fmt.Printf("%s\n", helper.PrettyResponse(parsed))
 			}
 		}
+	case "get-pem":
+		for _, serial := range flag.Args()[1:] {
+			resp, err := cl.redis.GetResponse(ctx, serial)
+			if err != nil {
+				return err
+			}
+			block := pem.Block{
+				Bytes: resp,
+				Type:  "OCSP RESPONSE",
+			}
+			pem.Encode(os.Stdout, &block)
+		}
 	case "store":
+		logger.Info(cmd.VersionString())
 		err := cl.storeResponsesFromFiles(ctx, flag.Args()[1:])
 		if err != nil {
 			return err
 		}
 	case "load-from-db":
+		logger.Info(cmd.VersionString())
 		if c.ROCSPTool.LoadFromDB == nil {
 			return fmt.Errorf("config field LoadFromDB was missing")
 		}
@@ -167,6 +175,7 @@ func main2() error {
 			return fmt.Errorf("loading OCSP responses from DB: %w", err)
 		}
 	case "scan-responses":
+		logger.Info(cmd.VersionString())
 		results := cl.redis.ScanResponses(ctx, "*")
 		for r := range results {
 			if r.Err != nil {

--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -1,26 +1,6 @@
 {
   "rocspTool": {
     "debugAddr": ":9101",
-    "loadFromDB": {
-      "db": {
-        "dbConnectFile": "test/secrets/ocsp_updater_dburl",
-        "maxOpenConns": 10
-      },
-      "speed": {
-        "rowsPerSecond": 2000,
-        "parallelSigns": 100,
-        "scanBatchSize": 10000
-      },
-      "gRPCTLS": {
-        "caCertFile": "test/grpc-creds/minica.pem",
-        "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
-        "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
-      },
-      "ocspGeneratorService": {
-        "serverAddress": "ca.boulder:9096",
-        "timeout": "0.5s"
-      }
-    },
     "redis": {
       "username": "ocsp-updater",
       "passwordFile": "test/secrets/rocsp_tool_password",

--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -1,5 +1,6 @@
 {
   "rocspTool": {
+    "debugAddr": ":9101",
     "loadFromDB": {
       "db": {
         "dbConnectFile": "test/secrets/ocsp_updater_dburl",
@@ -32,12 +33,6 @@
         "certFile": "test/redis-tls/boulder/cert.pem",
         "keyFile": "test/redis-tls/boulder/key.pem"
       }
-    },
-    "issuers": {
-      ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
-      ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
-      ".hierarchy/intermediate-cert-rsa-a.pem": 3,
-      ".hierarchy/intermediate-cert-rsa-b.pem": 4
     }
   },
   "syslog": {


### PR DESCRIPTION
Emit PEM output instead of pretty-printed output. Send the pretty-printed output straight to stdout instead of via a logger, so the internal newlines don't get escaped.

Fixes #6310

/cc @jcjones

Example output:

```
$ ./bin/rocsp-tool -config test/config/rocsp-tool.json get-pem ff164bd86f9c2671a426f8a400771780dd02
-----BEGIN OCSP RESPONSE-----
MIICBQoBAKCCAf4wggH6BgkrBgEFBQcwAQEEggHrMIIB5zCB0KFFMEMxCzAJBgNV
BAYTAlVTMRIwEAYDVQQKEwlnb29kIGd1eXMxIDAeBgNVBAMTF0NBIGludGVybWVk
aWF0ZSAoUlNBKSBBGA8yMDIyMDgyNDE4MzQwMFowdjB0MEwwCQYFKw4DAhoFAAQU
F3ec9n2EzURJovx+rEMfmCPYV1oEFFi0mxzldTKPt/oPatmGe4vbE1n1AhMA/xZL
2G+cJnGkJvikAHcXgN0CgAAYDzIwMjIwODI0MTgwMDAwWqARGA8yMDIyMDgyODE3
NTk1OVowDQYJKoZIhvcNAQELBQADggEBABlB/KkAzU0/0qnGUF6m0vesEOYcXki7
cCbFqDQwS437/R3N95oUHWfEzBTThJEh5OgeUGV2lRcyNpOorTzBBEkpf5boZy7f
hmz0A/6vk17vrYkpD3wYrS0uLpUDphmDyiM4Ug6QoStfTPCd4mJqhcUHRohnffob
FuurWZK0ywFVFjoZWEmNkkRjRdxK1VEQ9qqXHnyuU/rFffW3AIwnHyDNo3XxJkxs
VcUjqgoyB/HFfdXGN+SbMIMj7TY28/hJo3vRCtcwvLqT8DRc3lJ91V4RKjta+Mdw
lsdGyhXdBQjVAHbHXunJDHt3TZKnEUc7rGuDNj0q9nUho2cR4sO7F5c=
-----END OCSP RESPONSE-----
```