### PR TITLE
log: emit warnings and errors on stderr

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -187,8 +187,16 @@ func (t *TLSConfig) Load() (*tls.Config, error) {
 }
 
 // SyslogConfig defines the config for syslogging.
+// 3 means "error", 4 means "warning", 6 is "info" and 7 is "debug".
+// Configuring a given level causes all messages at that level and below to
+// be logged.
 type SyslogConfig struct {
+	// When absent or zero, this causes no logs to be emitted on stdout/stderr.
+	// Errors and warnings will be emitted on stderr if the configured level
+	// allows.
 	StdoutLevel int
+	// When absent or zero, this defaults to logging all messages of level 6
+	// or below. To disable syslog logging entirely, set this to -1.
 	SyslogLevel int
 }
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,9 +1,9 @@
 # Logging
 
-Boulder can log to stdout, syslog, or both. Boulder components generally have a
-`syslog` portion of their JSON config that indicates the maximum level of
-log that should be sent to a given destination. For instance, in
-`test/config/wfe2.json`:
+Boulder can log to stdout/stderr, syslog, or both. Boulder components
+generally have a `syslog` portion of their JSON config that indicates the
+maximum level of log that should be sent to a given destination. For instance,
+in `test/config/wfe2.json`:
 
 ```
   "syslog": {
@@ -13,16 +13,22 @@ log that should be sent to a given destination. For instance, in
 ```
 
 This indicates that logs of level 4 or below (error and warning) should be
-emitted to stdout, and logs of level 6 or below (error, warning, notice, and
+emitted to stdout/stderr, and logs of level 6 or below (error, warning, notice, and
 info) should be emitted to syslog, using the local Unix socket method. The
-highest meaningful value is 7, which enabled debug logging. The default value
-for these fields is 6 (INFO) for syslogLevel and 0 (no logs) for stdoutLevel.
+highest meaningful value is 7, which enables debug logging.
+
+The stdout/stderr logger uses ANSI escape codes to color warnings as yellow
+and errors as red, if stdout is detected to be a terminal.
+
+The default value for these fields is 6 (INFO) for syslogLevel and 0 (no logs)
+for stdoutLevel. To turn off syslog logging entirely, set syslogLevel to -1.
 
 In Boulder's development environment, we enable stdout logging because that
 makes it easier to see what's going on quickly. In production, we disable stdout
-logging because it would duplicate the syslog logging. We prefer the syslog
+logging because it would duplicate the syslog logging. We preferred the syslog
 logging because it provides things like severity level in a consistent way with
-other components.
+other components. But we may move to stdout/stderr logging to make it easier to
+containerize Boulder.
 
 Boulder has a number of adapters to take other packages' log APIs and send them
 to syslog as expected. For instance, we provide a custom logger for mysql, grpc,

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -85,11 +85,13 @@ func TestEmitEmpty(t *testing.T) {
 
 func TestStdoutLogger(t *testing.T) {
 	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
 	logger := &impl{
 		&stdoutWriter{
 			level:  7,
 			clk:    clock.NewFake(),
 			stdout: stdout,
+			stderr: stderr,
 		},
 	}
 
@@ -97,7 +99,8 @@ func TestStdoutLogger(t *testing.T) {
 	logger.Warning("Warning log")
 	logger.Info("Info log")
 
-	test.AssertEquals(t, stdout.String(), "1970-01-01T00:00:00+07:00 3 log.test [AUDIT] Error Audit\n1970-01-01T00:00:00+07:00 4 log.test Warning log\n1970-01-01T00:00:00+07:00 6 log.test Info log\n")
+	test.AssertEquals(t, stdout.String(), "1970-01-01T00:00:00+07:00 6 log.test Info log\n")
+	test.AssertEquals(t, stderr.String(), "1970-01-01T00:00:00+07:00 3 log.test [AUDIT] Error Audit\n1970-01-01T00:00:00+07:00 4 log.test Warning log\n")
 }
 
 func TestSyslogMethods(t *testing.T) {


### PR DESCRIPTION
Debug and Info messages still go to stdout.

Fix the CAA integration test, which asserted that stderr should be empty
when caa-log-checker finds a problem. That used to be the case because
we never logged to stderr, but now it is the case.

Update the logging docs.

Fixes #6324