### PR TITLE
loglist: handle logs with no state

### DIFF
--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -71,7 +71,9 @@ const (
 )
 
 func stateFromState(s *schema.LogListSchemaJsonOperatorsElemLogsElemState) state {
-	if s.Rejected != nil {
+	if s == nil {
+		return unknown
+	} else if s.Rejected != nil {
 		return rejected
 	} else if s.Retired != nil {
 		return retired

--- a/test/ct-test-srv/log_list.json
+++ b/test/ct-test-srv/log_list.json
@@ -259,6 +259,17 @@
             "start_inclusive": "1970-01-01T00:00:01Z",
             "end_exclusive": "2070-01-01T00:00:01Z"
           }
+        },
+        {
+          "description": "This Log Is Missing State To Ensure We Can Handle It",
+          "log_id": "SomeOtherFakeLogID=",
+          "key": "SomeOtherFakeKey=",
+          "url": "https://example.net/ct/",
+          "mmd": 86400,
+          "temporal_interval": {
+            "start_inclusive": "1970-01-01T00:00:01Z",
+            "end_exclusive": "2070-01-01T00:00:01Z"
+          }
         }
       ]
     }


### PR DESCRIPTION
While the Chrome log_list.json has a `state` stanza for every
log, the all_logs_list.json file does not. This code was originally
tested against the former file, but we are actually using the
latter file in production. Add a check for missing `state` stanzas
to avoid a nil pointer dereference.