### PR TITLE
Fix ROCSP Stage 3 metric cardinality explosion

### DIFF
--- a/ocsp/responder/redis/checked_redis_source.go
+++ b/ocsp/responder/redis/checked_redis_source.go
@@ -123,7 +123,7 @@ func (src *checkedRedisSource) Response(ctx context.Context, req *ocsp.Request) 
 	}
 
 	// Otherwise, the DB is authoritative. Trigger a fresh signing.
-	freshResult, err := src.base.signAndSave(ctx, req, serialString)
+	freshResult, err := src.base.signAndSave(ctx, req, "stale_redis")
 	if err != nil {
 		src.counter.WithLabelValues("sign_and_save_error").Inc()
 		return nil, err


### PR DESCRIPTION
The third argument to signAndSave is intended to be a "cause", to
provide a description of why we are doing a fresh signing that can
be included in our metric labels.

It was mistakenly being set to the serial number of the cert whose
new OCSP response is being generated, causing the number of
unique labels on this metric to explode.

Part of #6339