### PR TITLE
redis_source: improve metrics

### DIFF
--- a/ocsp/responder/redis/checked_redis_source_test.go
+++ b/ocsp/responder/redis/checked_redis_source_test.go
@@ -34,7 +34,7 @@ func (es echoSource) Response(ctx context.Context, req *ocsp.Request) (*responde
 	return &responder.Response{Response: es.resp, Raw: es.resp.Raw}, nil
 }
 
-func (es echoSource) signAndSave(ctx context.Context, req *ocsp.Request, cause string) (*responder.Response, error) {
+func (es echoSource) signAndSave(ctx context.Context, req *ocsp.Request, cause signAndSaveCause) (*responder.Response, error) {
 	panic("should not happen")
 }
 
@@ -46,7 +46,7 @@ type recordingEchoSource struct {
 	ch         chan string
 }
 
-func (res recordingEchoSource) signAndSave(ctx context.Context, req *ocsp.Request, cause string) (*responder.Response, error) {
+func (res recordingEchoSource) signAndSave(ctx context.Context, req *ocsp.Request, cause signAndSaveCause) (*responder.Response, error) {
 	res.ch <- req.SerialNumber.String()
 	return res.secondResp, nil
 }
@@ -58,7 +58,7 @@ func (es errorSource) Response(ctx context.Context, req *ocsp.Request) (*respond
 	return nil, errors.New("sad trombone")
 }
 
-func (es errorSource) signAndSave(ctx context.Context, req *ocsp.Request, cause string) (*responder.Response, error) {
+func (es errorSource) signAndSave(ctx context.Context, req *ocsp.Request, cause signAndSaveCause) (*responder.Response, error) {
 	panic("should not happen")
 }
 

--- a/ocsp/responder/redis/redis_source.go
+++ b/ocsp/responder/redis/redis_source.go
@@ -66,7 +66,7 @@ func NewRedisSource(
 		Name: "ocsp_redis_sign_and_save",
 		Help: "Count of OCSP sign and save requests",
 	}, []string{"cause", "result"})
-	stats.MustRegister(counter)
+	stats.MustRegister(signAndSaveCounter)
 
 	// Set up 12-hour-wide buckets, measured in seconds.
 	buckets := make([]float64, 14)

--- a/ocsp/responder/redis/redis_source.go
+++ b/ocsp/responder/redis/redis_source.go
@@ -106,7 +106,7 @@ func (src *redisSource) Response(ctx context.Context, req *ocsp.Request) (*respo
 	if err != nil {
 		if errors.Is(err, rocsp.ErrRedisNotFound) {
 			src.counter.WithLabelValues("not_found").Inc()
-			return src.signAndSave(ctx, req, "not_found_redis")
+			return src.signAndSave(ctx, req, causeNotFound)
 		}
 		src.counter.WithLabelValues("lookup_error").Inc()
 		return nil, err
@@ -120,7 +120,7 @@ func (src *redisSource) Response(ctx context.Context, req *ocsp.Request) (*respo
 
 	if src.isStale(resp) {
 		src.counter.WithLabelValues("stale").Inc()
-		freshResp, err := src.signAndSave(ctx, req, "stale_redis")
+		freshResp, err := src.signAndSave(ctx, req, causeStale)
 		if err != nil {
 			return &responder.Response{Response: resp, Raw: respBytes}, nil
 		}

--- a/ocsp/responder/redis/redis_source.go
+++ b/ocsp/responder/redis/redis_source.go
@@ -37,6 +37,7 @@ type redisSource struct {
 	client             rocspClient
 	signer             responder.Source
 	counter            *prometheus.CounterVec
+	signAndSaveCounter *prometheus.CounterVec
 	cachedResponseAges prometheus.Histogram
 	clk                clock.Clock
 	liveSigningPeriod  time.Duration
@@ -61,6 +62,12 @@ func NewRedisSource(
 	}, []string{"result"})
 	stats.MustRegister(counter)
 
+	signAndSaveCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ocsp_redis_sign_and_save",
+		Help: "Count of OCSP sign and save requests",
+	}, []string{"cause", "result"})
+	stats.MustRegister(counter)
+
 	// Set up 12-hour-wide buckets, measured in seconds.
 	buckets := make([]float64, 14)
 	for i := range buckets {
@@ -82,6 +89,7 @@ func NewRedisSource(
 		client:             rocspReader,
 		signer:             signer,
 		counter:            counter,
+		signAndSaveCounter: signAndSaveCounter,
 		cachedResponseAges: cachedResponseAges,
 		liveSigningPeriod:  liveSigningPeriod,
 		clk:                clk,
@@ -97,6 +105,7 @@ func (src *redisSource) Response(ctx context.Context, req *ocsp.Request) (*respo
 	respBytes, err := src.client.GetResponse(ctx, serialString)
 	if err != nil {
 		if errors.Is(err, rocsp.ErrRedisNotFound) {
+			src.counter.WithLabelValues("not_found").Inc()
 			return src.signAndSave(ctx, req, "not_found_redis")
 		}
 		src.counter.WithLabelValues("lookup_error").Inc()
@@ -128,17 +137,25 @@ func (src *redisSource) isStale(resp *ocsp.Response) bool {
 	return age > src.liveSigningPeriod
 }
 
-func (src *redisSource) signAndSave(ctx context.Context, req *ocsp.Request, cause string) (*responder.Response, error) {
+type signAndSaveCause string
+
+const (
+	causeStale    signAndSaveCause = "stale"
+	causeNotFound signAndSaveCause = "not_found"
+	causeMismatch signAndSaveCause = "mismatch"
+)
+
+func (src *redisSource) signAndSave(ctx context.Context, req *ocsp.Request, cause signAndSaveCause) (*responder.Response, error) {
 	resp, err := src.signer.Response(ctx, req)
 	if err != nil {
 		if errors.Is(err, rocsp.ErrRedisNotFound) {
-			src.counter.WithLabelValues(cause + "_certificate_not_found").Inc()
+			src.signAndSaveCounter.WithLabelValues(string(cause), "certificate_not_found").Inc()
 			return nil, responder.ErrNotFound
 		}
-		src.counter.WithLabelValues(cause + "_signing_error").Inc()
+		src.signAndSaveCounter.WithLabelValues(string(cause), "signing_error").Inc()
 		return nil, err
 	}
-	src.counter.WithLabelValues(cause + "_signing_success").Inc()
+	src.signAndSaveCounter.WithLabelValues(string(cause), "signing_success").Inc()
 	go src.client.StoreResponse(context.Background(), resp.Response)
 	return resp, nil
 }


### PR DESCRIPTION
This gives less confusing naming to the metrics in checked_redis_source ("revocation_re_sign_success" instead of "sign_and_save_success").

It also uses a new type as the `cause` parameter to signAndSave, to make it clear what should be passed.

In redis_source, it splits `counter` into two separate Prometheus counters: one for requests in general, and a separate one for signAndSave. The counter for signAndSave has two labels: cause and result.

Fixes #6339