### PR TITLE
boulder-observer: Add a CRL prober type

### DIFF
--- a/cmd/boulder-observer/README.md
+++ b/cmd/boulder-observer/README.md
@@ -22,9 +22,17 @@ Prometheus.
       * [HTTP](#http)
         * [Schema](#schema-3)
         * [Example](#example-3)
+      * [CRL](#crl)
+        * [Schema](#schema-4)
+        * [Example](#example-4)
   * [Metrics](#metrics)
-    * [obs_monitors](#obs_monitors)
-    * [obs_observations](#obs_observations)
+    * [Global Metrics](#global-metrics)
+      * [obs_monitors](#obs_monitors)
+      * [obs_observations](#obs_observations)
+    * [CRL Metrics](#crl-metrics)
+      * [obs_crl_this_update](#obs_crl_this_update)
+      * [obs_crl_next_update](#obs_crl_next_update)
+      * [obs_crl_revoked_cert_count](#obs_crl_revoked_cert_count)
   * [Development](#development)
     * [Starting Prometheus locally](#starting-prometheus-locally)
     * [Viewing metrics locally](#viewing-metrics-locally)
@@ -166,17 +174,38 @@ monitors:
   - 
     period: 2s
     kind: HTTP
-    settings: 
+    settings:
       url: http://letsencrypt.org/FOO
       rcodes: [200, 404]
       useragent: letsencrypt/boulder-observer-http-client
+```
+
+#### CRL
+
+##### Schema
+
+`url`: Scheme + Hostname to grab the CRL from (e.g. `http://x1.c.lencr.org/`).
+
+##### Example
+
+```yaml
+monitors:
+  - 
+    period: 1h
+    kind: CRL
+    settings:
+      url: http://x1.c.lencr.org/
 ```
 
 ## Metrics
 
 Observer provides the following metrics.
 
-### obs_monitors
+### Global Metrics
+
+These metrics will always be available.
+
+#### obs_monitors
 
 Count of configured monitors.
 
@@ -187,7 +216,7 @@ Count of configured monitors.
 `valid`: Bool indicating whether settings provided could be validated
 for the `kind` of Prober specified.
 
-### obs_observations
+#### obs_observations
 
 **Labels:**
 
@@ -203,6 +232,34 @@ successful.
 **Bucketed response times:**
 
 This is configurable, see `buckets` under [root/schema](#schema).
+
+### CRL Metrics
+
+These metrics will be available whenever a valid CRL prober is configured.
+
+#### obs_crl_this_update
+
+Unix timestamp value of the thisUpdate field for a CRL.
+
+**Labels:**
+
+`url`: Url of the CRL
+
+#### obs_crl_next_update
+
+Unix timestamp value of the nextUpdate field for a CRL.
+
+**Labels:**
+
+`url`: Url of the CRL
+
+#### obs_crl_revoked_cert_count
+
+Count of revoked certificates in a CRL.
+
+**Labels:**
+
+`url`: Url of the CRL
 
 ## Development
 

--- a/cmd/boulder-observer/README.md
+++ b/cmd/boulder-observer/README.md
@@ -239,7 +239,7 @@ These metrics will be available whenever a valid CRL prober is configured.
 
 #### obs_crl_this_update
 
-Unix timestamp value of the thisUpdate field for a CRL.
+Unix timestamp value (in seconds) of the thisUpdate field for a CRL.
 
 **Labels:**
 
@@ -260,7 +260,7 @@ This is a sample rule that alerts when a CRL has a thisUpdate timestamp in the f
 
 #### obs_crl_next_update
 
-Unix timestamp value of the nextUpdate field for a CRL.
+Unix timestamp value (in seconds) of the nextUpdate field for a CRL.
 
 **Labels:**
 

--- a/cmd/boulder-observer/README.md
+++ b/cmd/boulder-observer/README.md
@@ -245,6 +245,19 @@ Unix timestamp value of the thisUpdate field for a CRL.
 
 `url`: Url of the CRL
 
+**Example Usage:**
+
+This is a sample rule that alerts when a CRL has a thisUpdate timestamp in the future, signalling that something may have gone wrong during its creation:
+
+```yaml
+- alert: CRLThisUpdateInFuture
+  expr: obs_crl_this_update{url="http://x1.c.lencr.org/"} > time()
+  labels:
+    severity: critical
+  annotations:
+    description: 'CRL thisUpdate is in the future'
+```
+
 #### obs_crl_next_update
 
 Unix timestamp value of the nextUpdate field for a CRL.
@@ -252,6 +265,21 @@ Unix timestamp value of the nextUpdate field for a CRL.
 **Labels:**
 
 `url`: Url of the CRL
+
+**Example Usage:**
+
+This is a sample rule that alerts when a CRL has a nextUpdate timestamp in the past, signalling that the CRL was not updated on time:
+
+```yaml
+- alert: CRLNextUpdateInPast
+  expr: obs_crl_next_update{url="http://x1.c.lencr.org/"} < time()
+  labels:
+    severity: critical
+  annotations:
+    description: 'CRL nextUpdate is in the past'
+```
+
+Another potentially useful rule would be to notify when nextUpdate is within X days from the current time, as a reminder that the update is coming up soon.
 
 #### obs_crl_revoked_cert_count
 

--- a/observer/obs_conf.go
+++ b/observer/obs_conf.go
@@ -80,6 +80,7 @@ func (c *ObsConf) makeMonitors(metrics prometheus.Registerer) ([]*monitor, []err
 			// we haven't seen this prober kind before, so we need to request
 			// any custom metrics it may have and register them with the
 			// prometheus registry
+			proberSpecificMetrics[kind] = make(map[string]prometheus.Collector)
 			for name, collector := range proberConf.Instrument() {
 				// register the collector with the prometheus registry
 				metrics.MustRegister(collector)

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -2,6 +2,7 @@ package observer
 
 import (
 	blog "github.com/letsencrypt/boulder/log"
+	_ "github.com/letsencrypt/boulder/observer/probers/crl"
 	_ "github.com/letsencrypt/boulder/observer/probers/dns"
 	_ "github.com/letsencrypt/boulder/observer/probers/http"
 )

--- a/observer/probers/crl/crl.go
+++ b/observer/probers/crl/crl.go
@@ -44,7 +44,7 @@ func (p CRLProbe) Probe(timeout time.Duration) (bool, time.Duration) {
 
 	crl, err := crl_x509.ParseRevocationList(body)
 	if err != nil {
-		return false, time.Since(start)
+		return false, dur
 	}
 
 	// Report metrics for this CRL

--- a/observer/probers/crl/crl.go
+++ b/observer/probers/crl/crl.go
@@ -40,12 +40,12 @@ func (p CRLProbe) Probe(timeout time.Duration) (bool, time.Duration) {
 	if err != nil {
 		return false, time.Since(start)
 	}
+	dur := time.Since(start)
 
 	crl, err := crl_x509.ParseRevocationList(body)
 	if err != nil {
 		return false, time.Since(start)
 	}
-	dur := time.Since(start)
 
 	// Report metrics for this CRL
 	p.cThisUpdate.WithLabelValues(p.url).Set(float64(crl.ThisUpdate.Unix()))

--- a/observer/probers/crl/crl.go
+++ b/observer/probers/crl/crl.go
@@ -1,0 +1,56 @@
+package probers
+
+import (
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/letsencrypt/boulder/crl/crl_x509"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// CRLProbe is the exported 'Prober' object for monitors configured to
+// monitor CRL availability & characteristics.
+type CRLProbe struct {
+	url         string
+	cNextUpdate *prometheus.GaugeVec
+	cThisUpdate *prometheus.GaugeVec
+	cCertCount  *prometheus.GaugeVec
+}
+
+// Name returns a string that uniquely identifies the monitor.
+func (p CRLProbe) Name() string {
+	return p.url
+}
+
+// Kind returns a name that uniquely identifies the `Kind` of `Prober`.
+func (p CRLProbe) Kind() string {
+	return "CRL"
+}
+
+// Probe requests the configured CRL and publishes metrics about it if found.
+func (p CRLProbe) Probe(timeout time.Duration) (bool, time.Duration) {
+	start := time.Now()
+	resp, err := http.Get(p.url)
+	if err != nil {
+		return false, time.Since(start)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, time.Since(start)
+	}
+
+	crl, err := crl_x509.ParseRevocationList(body)
+	if err != nil {
+		return false, time.Since(start)
+	}
+
+	dur := time.Since(start)
+
+	p.cThisUpdate.WithLabelValues(p.url).Set(float64(crl.ThisUpdate.Unix()))
+	p.cNextUpdate.WithLabelValues(p.url).Set(float64(crl.NextUpdate.Unix()))
+	p.cCertCount.WithLabelValues(p.url).Set(float64(len(crl.RevokedCertificates)))
+
+	return true, dur
+}

--- a/observer/probers/crl/crl.go
+++ b/observer/probers/crl/crl.go
@@ -45,9 +45,9 @@ func (p CRLProbe) Probe(timeout time.Duration) (bool, time.Duration) {
 	if err != nil {
 		return false, time.Since(start)
 	}
-
 	dur := time.Since(start)
 
+	// Report metrics for this CRL
 	p.cThisUpdate.WithLabelValues(p.url).Set(float64(crl.ThisUpdate.Unix()))
 	p.cNextUpdate.WithLabelValues(p.url).Set(float64(crl.NextUpdate.Unix()))
 	p.cCertCount.WithLabelValues(p.url).Set(float64(len(crl.RevokedCertificates)))

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -103,13 +103,13 @@ func (c CRLConf) Instrument() map[string]prometheus.Collector {
 	nextUpdate := prometheus.Collector(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: nextUpdateName,
-			Help: "CRL nextUpdate unix timestamp",
+			Help: "CRL nextUpdate Unix timestamp in seconds",
 		}, []string{"url"},
 	))
 	thisUpdate := prometheus.Collector(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: thisUpdateName,
-			Help: "CRL thisUpdate unix timestamp",
+			Help: "CRL thisUpdate Unix timestamp in seconds",
 		}, []string{"url"},
 	))
 	certCount := prometheus.Collector(prometheus.NewGaugeVec(

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -61,25 +61,23 @@ func (c CRLConf) MakeProber(collectors map[string]prometheus.Collector) (probers
 
 	// validate the prometheus collectors that were passed in
 	for name, coll := range collectors {
+		var ok bool
 		switch name {
 		case nextUpdateName:
-			_, ok := coll.(*prometheus.GaugeVec)
+			probe.cNextUpdate, ok = coll.(*prometheus.GaugeVec)
 			if !ok {
 				return nil, fmt.Errorf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
 			}
-			probe.cNextUpdate = coll.(*prometheus.GaugeVec)
 		case thisUpdateName:
-			_, ok := coll.(*prometheus.GaugeVec)
+			probe.cThisUpdate, ok = coll.(*prometheus.GaugeVec)
 			if !ok {
 				return nil, fmt.Errorf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
 			}
-			probe.cThisUpdate = coll.(*prometheus.GaugeVec)
 		case certCountName:
-			_, ok := coll.(*prometheus.GaugeVec)
+			probe.cCertCount, ok = coll.(*prometheus.GaugeVec)
 			if !ok {
 				return nil, fmt.Errorf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
 			}
-			probe.cCertCount = coll.(*prometheus.GaugeVec)
 		default:
 			return nil, fmt.Errorf("crl prober received unexpected collector '%s'", name)
 		}

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -66,30 +66,30 @@ func (c CRLConf) MakeProber(collectors map[string]prometheus.Collector) (probers
 		case nextUpdateName:
 			probe.cNextUpdate, ok = coll.(*prometheus.GaugeVec)
 			if !ok {
-				return nil, fmt.Errorf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
+				return nil, fmt.Errorf("crl prober received collector %q of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
 			}
 		case thisUpdateName:
 			probe.cThisUpdate, ok = coll.(*prometheus.GaugeVec)
 			if !ok {
-				return nil, fmt.Errorf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
+				return nil, fmt.Errorf("crl prober received collector %q of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
 			}
 		case certCountName:
 			probe.cCertCount, ok = coll.(*prometheus.GaugeVec)
 			if !ok {
-				return nil, fmt.Errorf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
+				return nil, fmt.Errorf("crl prober received collector %q of wrong type, got: %T, expected *prometheus.GaugeVec", name, coll)
 			}
 		default:
-			return nil, fmt.Errorf("crl prober received unexpected collector '%s'", name)
+			return nil, fmt.Errorf("crl prober received unexpected collector %q", name)
 		}
 	}
 	if probe.cNextUpdate == nil {
-		return nil, fmt.Errorf("crl prober did not receive collector '%s'", nextUpdateName)
+		return nil, fmt.Errorf("crl prober did not receive collector %q", nextUpdateName)
 	}
 	if probe.cThisUpdate == nil {
-		return nil, fmt.Errorf("crl prober did not receive collector '%s'", thisUpdateName)
+		return nil, fmt.Errorf("crl prober did not receive collector %q", thisUpdateName)
 	}
 	if probe.cCertCount == nil {
-		return nil, fmt.Errorf("crl prober did not receive collector '%s'", certCountName)
+		return nil, fmt.Errorf("crl prober did not receive collector %q", certCountName)
 	}
 
 	return probe, nil

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -60,8 +60,8 @@ func (c CRLConf) MakeProber(collectors map[string]prometheus.Collector) (probers
 	probe := CRLProbe{c.URL, nil, nil, nil}
 
 	// validate the prometheus collectors that were passed in
+	var ok bool
 	for name, coll := range collectors {
-		var ok bool
 		switch name {
 		case nextUpdateName:
 			probe.cNextUpdate, ok = coll.(*prometheus.GaugeVec)

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -1,0 +1,152 @@
+package probers
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	nextUpdateName = "obs_crl_next_update"
+	thisUpdateName = "obs_crl_this_update"
+	certCountName  = "obs_crl_revoked_cert_count"
+)
+
+// CRLConf is exported to receive YAML configuration
+type CRLConf struct {
+	URL string `yaml:"url"`
+}
+
+// Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
+func (c CRLConf) Kind() string {
+	return "CRL"
+}
+
+// UnmarshalSettings constructs a CRLConf object from YAML as bytes.
+func (c CRLConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
+	var conf CRLConf
+	err := yaml.Unmarshal(settings, &conf)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
+
+func (c CRLConf) validateURL() error {
+	url, err := url.Parse(c.URL)
+	if err != nil {
+		return fmt.Errorf(
+			"invalid 'url', got: %q, expected a valid url", c.URL)
+	}
+	if url.Scheme == "" {
+		return fmt.Errorf(
+			"invalid 'url', got: %q, missing scheme", c.URL)
+	}
+	return nil
+}
+
+func (c CRLConf) validateCollectors(colls map[string]prometheus.Collector) (*prometheus.GaugeVec, *prometheus.GaugeVec, *prometheus.GaugeVec, error) {
+	if colls == nil {
+		message := "crl prober defines metrics but received nil collector map"
+		return nil, nil, nil, errors.New(message)
+	}
+	var nu, tu, rcc *prometheus.GaugeVec
+	for name, coll := range colls {
+		switch name {
+		case nextUpdateName:
+			_, ok := coll.(*prometheus.GaugeVec)
+			if !ok {
+				message := fmt.Sprintf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, nu)
+				return nil, nil, nil, errors.New(message)
+			}
+			nu = coll.(*prometheus.GaugeVec)
+		case thisUpdateName:
+			_, ok := coll.(*prometheus.GaugeVec)
+			if !ok {
+				message := fmt.Sprintf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, tu)
+				return nil, nil, nil, errors.New(message)
+			}
+			tu = coll.(*prometheus.GaugeVec)
+		case certCountName:
+			_, ok := coll.(*prometheus.GaugeVec)
+			if !ok {
+				message := fmt.Sprintf("crl prober received collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, rcc)
+				return nil, nil, nil, errors.New(message)
+			}
+			rcc = coll.(*prometheus.GaugeVec)
+		default:
+			message := fmt.Sprintf("crl prober received unexpected collector '%s'", name)
+			return nil, nil, nil, errors.New(message)
+		}
+	}
+	if nu == nil {
+		message := fmt.Sprintf("crl prober did not receive collector '%s'", nextUpdateName)
+		return nil, nil, nil, errors.New(message)
+	}
+	if tu == nil {
+		message := fmt.Sprintf("crl prober did not receive collector '%s'", thisUpdateName)
+		return nil, nil, nil, errors.New(message)
+	}
+	if rcc == nil {
+		message := fmt.Sprintf("crl prober did not receive collector '%s'", certCountName)
+		return nil, nil, nil, errors.New(message)
+	}
+	return nu, tu, rcc, nil
+}
+
+// MakeProber constructs a `CRLProbe` object from the contents of the
+// bound `CRLConf` object. If the `CRLConf` cannot be validated, an
+// error appropriate for end-user consumption is returned instead.
+func (c CRLConf) MakeProber(collectors map[string]prometheus.Collector) (probers.Prober, error) { // validate `url` err := c.validateURL()
+	// validate `url`
+	err := c.validateURL()
+	if err != nil {
+		return nil, err
+	}
+	// validate the prometheus collectors that were passed in
+	nu, tu, rcc, err := c.validateCollectors(collectors)
+	if err != nil {
+		return nil, err
+	}
+	return CRLProbe{c.URL, nu, tu, rcc}, nil
+}
+
+// Instrument constructs any `prometheus.Collector` objects the `CRLProbe` will
+// need to report its own metrics. A map is returned containing the constructed
+// objects, indexed by the name of the prometheus metric. If no objects were
+// constructed, nil is returned.
+func (c CRLConf) Instrument() map[string]prometheus.Collector {
+	nextUpdate := prometheus.Collector(prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: nextUpdateName,
+			Help: "CRL nextUpdate unix timestamp",
+		}, []string{"url"},
+	))
+	thisUpdate := prometheus.Collector(prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: thisUpdateName,
+			Help: "CRL thisUpdate unix timestamp",
+		}, []string{"url"},
+	))
+	certCount := prometheus.Collector(prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: certCountName,
+			Help: "number of certificates revoked in CRL",
+		}, []string{"url"},
+	))
+	return map[string]prometheus.Collector{
+		nextUpdateName: nextUpdate,
+		thisUpdateName: thisUpdate,
+		certCountName:  certCount,
+	}
+}
+
+// init is called at runtime and registers `CRLConf`, a `Prober`
+// `Configurer` type, as "CRL".
+func init() {
+	probers.Register(CRLConf{})
+}

--- a/observer/probers/crl/crl_conf_test.go
+++ b/observer/probers/crl/crl_conf_test.go
@@ -1,10 +1,10 @@
 package probers
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 )
@@ -54,23 +54,16 @@ func TestCRLConf_MakeProber(t *testing.T) {
 				URL: tt.fields.URL,
 			}
 			p, err := c.MakeProber(tt.colls)
-			if err == nil {
-				if tt.wantErr {
-					t.Errorf("CRLConf.MakeProber() error = %v, wantErr %v", err, tt.wantErr)
-				} else {
-					prober := p.(CRLProbe)
-					if prober.cThisUpdate == nil {
-						t.Errorf("CRLConf.MakeProber() returned CRLProbe with nil cThisUpdate")
-					}
-					if prober.cNextUpdate == nil {
-						t.Errorf("CRLConf.MakeProber() returned CRLProbe with nil cNextUpdate")
-					}
-					if prober.cCertCount == nil {
-						t.Errorf("CRLConf.MakeProber() returned CRLProbe with nil cCertCount")
-					}
-				}
-			} else if err != nil && !tt.wantErr {
-				t.Errorf("CRLConf.MakeProber() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				test.AssertError(t, err, "CRLConf.MakeProber()")
+			} else {
+				test.AssertNotError(t, err, "CRLConf.MakeProber()")
+
+				test.AssertNotNil(t, p, "CRLConf.MakeProber(): nil prober")
+				prober := p.(CRLProbe)
+				test.AssertNotNil(t, prober.cThisUpdate, "CRLConf.MakeProber(): nil cThisUpdate")
+				test.AssertNotNil(t, prober.cNextUpdate, "CRLConf.MakeProber(): nil cNextUpdate")
+				test.AssertNotNil(t, prober.cCertCount, "CRLConf.MakeProber(): nil cCertCount")
 			}
 		})
 	}
@@ -99,13 +92,12 @@ func TestCRLConf_UnmarshalSettings(t *testing.T) {
 			t.Log(string(settingsBytes))
 			c := CRLConf{}
 			got, err := c.UnmarshalSettings(settingsBytes)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CRLConf.UnmarshalSettings() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				test.AssertError(t, err, "CRLConf.UnmarshalSettings()")
+			} else {
+				test.AssertNotError(t, err, "CRLConf.UnmarshalSettings()")
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CRLConf.UnmarshalSettings() = %v, want %v", got, tt.want)
-			}
+			test.AssertDeepEquals(t, got, tt.want)
 		})
 	}
 }

--- a/observer/probers/crl/crl_conf_test.go
+++ b/observer/probers/crl/crl_conf_test.go
@@ -1,0 +1,146 @@
+package probers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCRLConf_MakeProber(t *testing.T) {
+	conf := CRLConf{}
+	colls := conf.Instrument()
+	badColl := prometheus.Collector(prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "obs_crl_foo",
+			Help: "Hmmm, this shouldn't be here...",
+		},
+		[]string{},
+	))
+	type fields struct {
+		URL string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		colls   map[string]prometheus.Collector
+		wantErr bool
+	}{
+		// valid
+		{"valid fqdn", fields{"http://example.com"}, colls, false},
+		{"valid fqdn with path", fields{"http://example.com/foo/bar"}, colls, false},
+		{"valid hostname", fields{"http://example"}, colls, false},
+		// invalid
+		{"bad fqdn", fields{":::::"}, colls, true},
+		{"missing scheme", fields{"example.com"}, colls, true},
+		{
+			"unexpected collector",
+			fields{"http://example.com"},
+			map[string]prometheus.Collector{"obs_crl_foo": badColl},
+			true,
+		},
+		{
+			"missing collectors",
+			fields{"http://example.com"},
+			map[string]prometheus.Collector{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := CRLConf{
+				URL: tt.fields.URL,
+			}
+			if _, err := c.MakeProber(tt.colls); (err != nil) != tt.wantErr {
+				t.Errorf("CRLConf.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCRLConf_Instrument(t *testing.T) {
+	t.Run("instrument", func(t *testing.T) {
+		conf := CRLConf{}
+		colls := conf.Instrument()
+		if colls == nil {
+			t.Errorf("crl prober defines metrics but received nil collector map")
+			return
+		}
+		var nu, tu, rcc *prometheus.GaugeVec
+		for name, coll := range colls {
+			switch name {
+			case nextUpdateName:
+				_, ok := coll.(*prometheus.GaugeVec)
+				if !ok {
+					t.Errorf("CRLConf.Instrument() returned collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, nu)
+					return
+				}
+				nu = coll.(*prometheus.GaugeVec)
+			case thisUpdateName:
+				_, ok := coll.(*prometheus.GaugeVec)
+				if !ok {
+					t.Errorf("CRLConf.Instrument() returned collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, tu)
+					return
+				}
+				tu = coll.(*prometheus.GaugeVec)
+			case certCountName:
+				_, ok := coll.(*prometheus.GaugeVec)
+				if !ok {
+					t.Errorf("CRLConf.Instrument() returned collector '%s' of wrong type, got: %T, expected *prometheus.GaugeVec", name, rcc)
+					return
+				}
+				rcc = coll.(*prometheus.GaugeVec)
+			default:
+				t.Errorf("CRLConf.Instrument() returned unexpected collector '%s'", name)
+				return
+			}
+		}
+		if nu == nil {
+			t.Errorf("CRLConf.Instrument() did not return collector '%s'", nextUpdateName)
+			return
+		}
+		if tu == nil {
+			t.Errorf("CRLConf.Instrument() did not return collector '%s'", thisUpdateName)
+			return
+		}
+		if rcc == nil {
+			t.Errorf("CRLConf.Instrument() did not return collector '%s'", certCountName)
+		}
+	})
+}
+
+func TestCRLConf_UnmarshalSettings(t *testing.T) {
+	type fields struct {
+		url interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    probers.Configurer
+		wantErr bool
+	}{
+		{"valid", fields{"google.com"}, CRLConf{"google.com"}, false},
+		{"invalid (map)", fields{make(map[string]interface{})}, nil, true},
+		{"invalid (list)", fields{make([]string, 0)}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := probers.Settings{
+				"url": tt.fields.url,
+			}
+			settingsBytes, _ := yaml.Marshal(settings)
+			t.Log(string(settingsBytes))
+			c := CRLConf{}
+			got, err := c.UnmarshalSettings(settingsBytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CRLConf.UnmarshalSettings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CRLConf.UnmarshalSettings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is a follow-up to #6277 and #6290 to add a new prober type to boulder-observer for monitoring CRLs, making use of the new prober-specific metrics capability to define the following new metrics:

- `obs_crl_this_update` the Unix timestamp of the CRL's thisUpdate value
- `obs_crl_next_update` the Unix timestamp of the CRL's nextUpdate value
- `obs_crl_revoked_cert_count` the number of certificates listed in the CRL

**Configuration:** Each defined CRL monitor takes a single configuration option, a URL that specifies the location of the CRL to monitor.

**Metrics:** The three CRL-specific metrics described above are only published at /metrics if at least one valid monitor is defined in the config.yml. The metrics have a single label `url` that is set to the URL configured for the monitor