### PR TITLE
Remove crlNumber from CRL S3 paths

### DIFF
--- a/crl/storer/storer.go
+++ b/crl/storer/storer.go
@@ -156,7 +156,7 @@ func (cs *crlStorer) UploadCRL(stream cspb.CRLStorer_UploadCRLServer) error {
 
 	start := cs.clk.Now()
 
-	filename := fmt.Sprintf("%d/%s/%d.crl", issuer.NameID(), crlNumber, shardIdx)
+	filename := fmt.Sprintf("%d/%d.crl", issuer.NameID(), shardIdx)
 	checksum := sha256.Sum256(crlBytes)
 	checksumb64 := base64.StdEncoding.EncodeToString(checksum[:])
 	crlContentType := "application/pkix-crl"
@@ -175,7 +175,7 @@ func (cs *crlStorer) UploadCRL(stream cspb.CRLStorer_UploadCRLServer) error {
 	} else {
 		cs.uploadCount.WithLabelValues(issuer.Subject.CommonName, "success").Inc()
 		cs.log.AuditInfof(
-			"CRL uploaded: issuerCN=[%s] id=[%s] thisUpdate=[%s] nextUpdate=[%s] numEntries=[%d]",
+			"CRL uploaded: id=[%s] issuerCN=[%s] thisUpdate=[%s] nextUpdate=[%s] numEntries=[%d]",
 			issuer.Subject.CommonName, crlId, crl.ThisUpdate, crl.NextUpdate, len(crl.RevokedCertificates),
 		)
 	}

--- a/crl/storer/storer.go
+++ b/crl/storer/storer.go
@@ -176,7 +176,7 @@ func (cs *crlStorer) UploadCRL(stream cspb.CRLStorer_UploadCRLServer) error {
 		cs.uploadCount.WithLabelValues(issuer.Subject.CommonName, "success").Inc()
 		cs.log.AuditInfof(
 			"CRL uploaded: id=[%s] issuerCN=[%s] thisUpdate=[%s] nextUpdate=[%s] numEntries=[%d]",
-			issuer.Subject.CommonName, crlId, crl.ThisUpdate, crl.NextUpdate, len(crl.RevokedCertificates),
+			crlId, issuer.Subject.CommonName, crl.ThisUpdate, crl.NextUpdate, len(crl.RevokedCertificates),
 		)
 	}
 


### PR DESCRIPTION
Change the S3 object paths to not include the CRL Number.

At one point, the plan was to upload all of the CRL shards to
S3 paths containing their CRL Number (which monotonically
increases every generation), and then later move or symlink
them into paths not containing that number. However, we saw
that S3 does not have any atomic move or rename semantics,
so we decided to instead enable object versioning and upload
the shards to the same path every time. Apparently I never fixed
the object key computation to match the updated design.

The CRL Number is still stored on the object as a metadata tag.