### PR TITLE
Add gRPC client stream interceptors

### DIFF
--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -42,7 +42,7 @@ func TestErrorWrapping(t *testing.T) {
 	conn, err := grpc.Dial(
 		lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept),
+		grpc.WithUnaryInterceptor(ci.interceptUnary),
 	)
 	test.AssertNotError(t, err, "Failed to dial grpc test server")
 	client := test_proto.NewChillerClient(conn)
@@ -73,7 +73,7 @@ func TestSubErrorWrapping(t *testing.T) {
 	conn, err := grpc.Dial(
 		lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept),
+		grpc.WithUnaryInterceptor(ci.interceptUnary),
 	)
 	test.AssertNotError(t, err, "Failed to dial grpc test server")
 	client := test_proto.NewChillerClient(conn)

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -75,10 +75,10 @@ func TestClientInterceptor(t *testing.T) {
 		metrics: NewClientMetrics(metrics.NoopRegisterer),
 		clk:     clock.NewFake(),
 	}
-	err := ci.intercept(context.Background(), "-service-test", nil, nil, nil, testInvoker)
+	err := ci.interceptUnary(context.Background(), "-service-test", nil, nil, nil, testInvoker)
 	test.AssertNotError(t, err, "ci.intercept failed with a non-nil grpc.UnaryServerInfo")
 
-	err = ci.intercept(context.Background(), "-service-brokeTest", nil, nil, nil, testInvoker)
+	err = ci.interceptUnary(context.Background(), "-service-brokeTest", nil, nil, nil, testInvoker)
 	test.AssertError(t, err, "ci.intercept didn't fail when handler returned a error")
 }
 
@@ -108,7 +108,7 @@ func TestFailFastFalse(t *testing.T) {
 	conn, err := grpc.Dial("localhost:19876", // random, probably unused port
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, roundrobin.Name)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept))
+		grpc.WithUnaryInterceptor(ci.interceptUnary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestTimeouts(t *testing.T) {
 	}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept))
+		grpc.WithUnaryInterceptor(ci.interceptUnary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestRequestTimeTagging(t *testing.T) {
 	}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept))
+		grpc.WithUnaryInterceptor(ci.interceptUnary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestInFlightRPCStat(t *testing.T) {
 	}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept))
+		grpc.WithUnaryInterceptor(ci.interceptUnary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}


### PR DESCRIPTION
Add both our custom error-handling and the default gRPC
metrics interceptor to our set of always-active gRPC Stream
interceptors. This will ensure that we get metrics and error
propagation from our new streaming gRPC methods, just
like we do for all our existing unary methods.

To do this without duplicating code, factor most of the unary
interceptor out into a helper, and have both the unary and
stream interceptors rely on that.

Note that this only adds client interceptors, server interceptors
require a different approach and will be handled in a separate
change.

Part of #6356