### PR TITLE
Add gRPC server stream interceptors

### DIFF
--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -31,7 +31,7 @@ func TestErrorWrapping(t *testing.T) {
 	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
-	srv := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
+	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)
 	lis, err := net.Listen("tcp", "127.0.0.1:")
@@ -62,7 +62,7 @@ func TestSubErrorWrapping(t *testing.T) {
 	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
-	srv := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
+	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)
 	lis, err := net.Listen("tcp", "127.0.0.1:")


### PR DESCRIPTION
Add both our custom error-wrapping and timeout-fudging, and
the default gRPC metrics interceptor to our set of always-active
gRPC stream server interceptors. This will ensure that we get
metrics and error propagation from our new streaming gRPC
methods, just like we do for all our existing unary methods.

To do this without duplicating code, factor most of the unary
interceptor out into a helper, and have both the unary and
stream interceptors rely on that. In addition, add a new small
type to help override the context on a server stream.

Fixes #6356

DO NOT MERGE until https://github.com/letsencrypt/boulder/pull/6366 has landed