### PR TITLE
Enable CRL test in config integration tests

### DIFF
--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -24,6 +24,14 @@
         "orphan-finder.boulder"
       ]
     },
+    "grpcCRLGenerator": {
+      "maxConnectionAge": "30s",
+      "address": ":9106",
+      "clientNames": [
+        "health-checker.boulder",
+        "crl-updater.boulder"
+      ]
+    },
     "saService": {
       "serverAddress": "sa.boulder:9095",
       "timeout": "15s"

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -24,6 +24,14 @@
         "orphan-finder.boulder"
       ]
     },
+    "grpcCRLGenerator": {
+      "maxConnectionAge": "30s",
+      "address": ":9106",
+      "clientNames": [
+        "health-checker.boulder",
+        "crl-updater.boulder"
+      ]
+    },
     "saService": {
       "serverAddress": "sa.boulder:9095",
       "timeout": "15s"

--- a/test/config/crl-updater.json
+++ b/test/config/crl-updater.json
@@ -14,6 +14,10 @@
       "serverAddress": "ca.boulder:9106",
       "timeout": "15s"
     },
+    "crlStorerService": {
+      "serverAddress": "crl-storer.boulder:9109",
+      "timeout": "15s"
+    },
     "issuerCerts": [
       "/hierarchy/intermediate-cert-rsa-a.pem",
       "/hierarchy/intermediate-cert-rsa-b.pem",

--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/letsencrypt/boulder/core"
@@ -34,15 +33,7 @@ func runUpdater(t *testing.T, configFile string) {
 // to our fake S3 service.
 func TestCRLPipeline(t *testing.T) {
 	configDir, ok := os.LookupEnv("BOULDER_CONFIG_DIR")
-	if !ok {
-		t.Fatal("failed to look up test config directory")
-	}
-
-	// The crl-updater and crl-storer are not yet deployed in Prod, so only run
-	// this test in config-next.
-	if !strings.Contains(configDir, "config-next") {
-		return
-	}
+	test.Assert(t, ok, "failed to look up test config directory")
 
 	// Basic setup.
 	os.Setenv("DIRECTORY", "http://boulder:4001/directory")


### PR DESCRIPTION
Now that both crl-updater and crl-storer are running in prod,
run this integration test in both test environments as well.

In addition, remove the fake storer grpc client that the updater
used when no storer client was configured, as storer clients
are now configured in all environments.