### PR TITLE
Improve how crl-updater formats and surfaces errors

### DIFF
--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -155,11 +155,12 @@ func main() {
 
 	if *runOnce {
 		err = u.Tick(ctx, clk.Now())
+		cmd.FailOnError(err, "")
 	} else {
 		err = u.Run(ctx)
-	}
-	if err != nil {
-		logger.Err(err.Error())
+		if err != nil {
+			logger.Err(err.Error())
+		}
 	}
 }
 

--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -154,9 +154,12 @@ func main() {
 	go cmd.CatchSignals(logger, cancel)
 
 	if *runOnce {
-		u.Tick(ctx)
+		err = u.Tick(ctx, clk.Now())
 	} else {
-		u.Run(ctx)
+		err = u.Run(ctx)
+	}
+	if err != nil {
+		logger.Err(err.Error())
 	}
 }
 

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -3,8 +3,10 @@ package updater
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/jmhodges/clock"
@@ -135,7 +137,7 @@ func NewUpdater(
 // Run causes the crl-updater to run immediately, and then re-run continuously
 // on the frequency specified by crlUpdater.updatePeriod. The provided context
 // can be used to gracefully stop (cancel) the process.
-func (cu *crlUpdater) Run(ctx context.Context) {
+func (cu *crlUpdater) Run(ctx context.Context) error {
 	// We don't want the times at which crl-updater runs to be dependent on when
 	// the process starts. So wait until the appropriate time before kicking off
 	// the first run and the main ticker loop.
@@ -148,64 +150,88 @@ func (cu *crlUpdater) Run(ctx context.Context) {
 	}
 	select {
 	case <-ctx.Done():
-		return
+		return ctx.Err()
 	case <-time.After(time.Duration(waitNanos)):
 	}
 
 	// Tick once immediately, but create the ticker first so that it starts
 	// counting from the appropriate time.
 	ticker := time.NewTicker(cu.updatePeriod)
-	cu.Tick(ctx)
+	cu.Tick(ctx, cu.clk.Now())
 
 	for {
 		// If we have overrun *and* been canceled, both of the below cases could be
 		// selectable at the same time, so check for context cancellation first.
 		if ctx.Err() != nil {
 			ticker.Stop()
-			return
+			return ctx.Err()
 		}
 		select {
 		case <-ticker.C:
-			cu.Tick(ctx)
+			atTime := cu.clk.Now()
+			err := cu.Tick(ctx, atTime)
+			if err != nil {
+				// We only log, rather than return, so that the long-lived process can
+				// continue and try again at the next tick.
+				cu.log.AuditErrf("tick at time %s failed: %s", atTime, err)
+			}
 		case <-ctx.Done():
 			ticker.Stop()
-			return
+			return ctx.Err()
 		}
 	}
 }
 
-// TODO(#6261): Unify all error messages to identify the shard they're working
-// on as a JSON object including issuer, crl number, and shard number.
-
-func (cu *crlUpdater) Tick(ctx context.Context) {
-	atTime := cu.clk.Now()
-	result := "success"
+// Tick runs the entire update process once immediately. It processes each
+// configured issuer serially, and processes all of them even if an early one
+// encounters an error. All errors encountered are returned as a single combined
+// error at the end.
+func (cu *crlUpdater) Tick(ctx context.Context, atTime time.Time) (err error) {
 	defer func() {
+		// Each return statement in this function assigns its returned value to the
+		// named return variable `err`. This deferred function closes over that
+		// variable, and so can reference and modify it.
+		result := "success"
+		if err != nil {
+			result = "failed"
+			err = fmt.Errorf("tick %s: %w", atTime.Format(time.RFC3339Nano), err)
+		}
 		cu.tickHistogram.WithLabelValues("all", result).Observe(cu.clk.Since(atTime).Seconds())
 	}()
 	cu.log.Debugf("Ticking at time %s", atTime)
 
-	for id, iss := range cu.issuers {
+	var errStrs []string
+	for id := range cu.issuers {
 		// For now, process each issuer serially. This keeps the worker pool system
 		// simple, and processing all of the issuers in parallel likely wouldn't
 		// meaningfully speed up the overall process.
 		err := cu.tickIssuer(ctx, atTime, id)
 		if err != nil {
-			cu.log.AuditErrf(
-				"tick for issuer %s at time %s failed: %s",
-				iss.Subject.CommonName,
-				atTime.Format(time.RFC3339Nano),
-				err)
-			result = "failed"
+			errStrs = append(errStrs, err.Error())
 		}
 	}
+
+	if len(errStrs) != 0 {
+		return errors.New(strings.Join(errStrs, "; "))
+	}
+	return nil
 }
 
-// tickIssuer performs the full CRL issuance cycle for a single issuer cert.
-func (cu *crlUpdater) tickIssuer(ctx context.Context, atTime time.Time, issuerNameID issuance.IssuerNameID) error {
+// tickIssuer performs the full CRL issuance cycle for a single issuer cert. It
+// processes all of the shards of this issuer's CRL concurrently, and processes
+// all of them even if an early one encounters an error. All errors encountered
+// are returned as a single combined error at the end.
+func (cu *crlUpdater) tickIssuer(ctx context.Context, atTime time.Time, issuerNameID issuance.IssuerNameID) (err error) {
 	start := cu.clk.Now()
-	result := "success"
 	defer func() {
+		// Each return statement in this function assigns its returned value to the
+		// named return variable `err`. This deferred function closes over that
+		// variable, and so can reference and modify it.
+		result := "success"
+		if err != nil {
+			result = "failed"
+			err = fmt.Errorf("%s: %w", cu.issuers[issuerNameID].Subject.CommonName, err)
+		}
 		cu.tickHistogram.WithLabelValues(cu.issuers[issuerNameID].Subject.CommonName+" (Overall)", result).Observe(cu.clk.Since(start).Seconds())
 	}()
 	cu.log.Debugf("Ticking issuer %d at time %s", issuerNameID, atTime)
@@ -240,25 +266,35 @@ func (cu *crlUpdater) tickIssuer(ctx context.Context, atTime time.Time, issuerNa
 	}
 	close(shardIdxs)
 
+	var errStrs []string
 	for i := 0; i < cu.numShards; i++ {
 		res := <-shardResults
 		if res.err != nil {
-			result = "failed"
-			return fmt.Errorf("updating shard %d: %w", res.shardIdx, res.err)
+			errStrs = append(errStrs, res.err.Error())
 		}
 	}
 
+	if len(errStrs) != 0 {
+		return errors.New(strings.Join(errStrs, "; "))
+	}
 	return nil
 }
 
-func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNameID issuance.IssuerNameID, shardIdx int) error {
+// tickShard processes a single shard. It computes the shard's boundaries, gets
+// the list of revoked certs in that shard from the SA, gets the CA to sign the
+// resulting CRL, and gets the crl-storer to upload it. It returns an error if
+// any of these operations fail.
+func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNameID issuance.IssuerNameID, shardIdx int) (err error) {
 	start := cu.clk.Now()
-	crlId, err := crl.Id(issuerNameID, crl.Number(atTime), shardIdx)
-	if err != nil {
-		return err
-	}
-	result := "success"
 	defer func() {
+		// Each return statement in this function assigns its returned value to the
+		// named return variable `err`. This deferred function closes over that
+		// variable, and so can reference and modify it.
+		result := "success"
+		if err != nil {
+			result = "failed"
+			err = fmt.Errorf("%d: %w", shardIdx, err)
+		}
 		cu.tickHistogram.WithLabelValues(cu.issuers[issuerNameID].Subject.CommonName, result).Observe(cu.clk.Since(start).Seconds())
 		cu.updatedCounter.WithLabelValues(result).Inc()
 	}()
@@ -273,14 +309,12 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 		RevokedBefore: atTime.UnixNano(),
 	})
 	if err != nil {
-		result = "failed"
-		return fmt.Errorf("connecting to SA for %s: %w", crlId, err)
+		return fmt.Errorf("connecting to SA: %w", err)
 	}
 
 	caStream, err := cu.ca.GenerateCRL(ctx)
 	if err != nil {
-		result = "failed"
-		return fmt.Errorf("connecting to CA for %s: %w", crlId, err)
+		return fmt.Errorf("connecting to CA: %w", err)
 	}
 
 	err = caStream.Send(&capb.GenerateCRLRequest{
@@ -293,8 +327,7 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 		},
 	})
 	if err != nil {
-		result = "failed"
-		return fmt.Errorf("sending CA metadata for %s: %w", crlId, err)
+		return fmt.Errorf("sending CA metadata: %w", err)
 	}
 
 	for {
@@ -303,8 +336,7 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 			if err == io.EOF {
 				break
 			}
-			result = "failed"
-			return fmt.Errorf("retrieving entry from SA for %s: %w", crlId, err)
+			return fmt.Errorf("retrieving entry from SA: %w", err)
 		}
 
 		err = caStream.Send(&capb.GenerateCRLRequest{
@@ -313,8 +345,7 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 			},
 		})
 		if err != nil {
-			result = "failed"
-			return fmt.Errorf("sending entry to CA for %s: %w", crlId, err)
+			return fmt.Errorf("sending entry to CA: %w", err)
 		}
 	}
 
@@ -323,14 +354,12 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 	// in memory before it can sign it and start returning the real CRL.
 	err = caStream.CloseSend()
 	if err != nil {
-		result = "failed"
-		return fmt.Errorf("closing CA request stream for %s: %w", crlId, err)
+		return fmt.Errorf("closing CA request stream: %w", err)
 	}
 
 	csStream, err := cu.cs.UploadCRL(ctx)
 	if err != nil {
-		result = "failed"
-		return fmt.Errorf("connecting to CRLStorer for %s: %w", crlId, err)
+		return fmt.Errorf("connecting to CRLStorer: %w", err)
 	}
 
 	err = csStream.Send(&cspb.UploadCRLRequest{
@@ -343,8 +372,7 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 		},
 	})
 	if err != nil {
-		result = "failed"
-		return fmt.Errorf("sending CRLStorer metadata for %s: %w", crlId, err)
+		return fmt.Errorf("sending CRLStorer metadata: %w", err)
 	}
 
 	crlLen := 0
@@ -355,8 +383,7 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 			if err == io.EOF {
 				break
 			}
-			result = "failed"
-			return fmt.Errorf("receiving CRL bytes for %s: %w", crlId, err)
+			return fmt.Errorf("receiving CRL bytes: %w", err)
 		}
 
 		err = csStream.Send(&cspb.UploadCRLRequest{
@@ -365,22 +392,23 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 			},
 		})
 		if err != nil {
-			result = "failed"
-			return fmt.Errorf("uploading CRL bytes for %s: %w", crlId, err)
+			return fmt.Errorf("uploading CRL bytes: %w", err)
 		}
 
 		crlLen += len(out.Chunk)
 		crlHash.Write(out.Chunk)
 	}
 
-	cu.log.Infof("Generated CRL: id=[%s] size=[%d] hash=[%x]", crlId, crlLen, crlHash.Sum(nil))
-
 	_, err = csStream.CloseAndRecv()
 	if err != nil {
-		result = "failed"
-		return fmt.Errorf("closing CRLStorer upload stream for %s: %w", crlId, err)
+		return fmt.Errorf("closing CRLStorer upload stream: %w", err)
 	}
 
+	crlId, err := crl.Id(issuerNameID, crl.Number(atTime), shardIdx)
+	if err != nil {
+		return err
+	}
+	cu.log.Infof("Generated CRL: id=[%s] size=[%d] hash=[%x]", crlId, crlLen, crlHash.Sum(nil))
 	return nil
 }
 

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -74,6 +74,17 @@
         },
         {
           "useForRSALeaves": false,
+          "useForECDSALeaves": true,
+          "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+          "ocspURL": "http://127.0.0.1:4002/",
+          "location": {
+            "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+            "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+            "numSessions": 2
+          }
+        },
+        {
+          "useForRSALeaves": false,
           "useForECDSALeaves": false,
           "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
           "ocspURL": "http://127.0.0.1:4002/",

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -74,6 +74,17 @@
         },
         {
           "useForRSALeaves": false,
+          "useForECDSALeaves": true,
+          "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+          "ocspURL": "http://127.0.0.1:4002/",
+          "location": {
+            "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+            "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+            "numSessions": 2
+          }
+        },
+        {
+          "useForRSALeaves": false,
           "useForECDSALeaves": false,
           "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
           "ocspURL": "http://127.0.0.1:4002/",

--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -25,8 +26,8 @@ func runUpdater(t *testing.T, configFile string) {
 	test.AssertNotError(t, err, "computing crl-updater path")
 
 	c := exec.Command(binPath, "-config", configFile, "-debug-addr", ":8022", "-runOnce")
-	err = c.Run()
-	test.AssertNotError(t, err, "failed to run crl-updater")
+	out, err := c.CombinedOutput()
+	test.AssertNotError(t, err, fmt.Sprintf("crl-updater failed: %s", out))
 }
 
 // TestCRLPipeline runs an end-to-end test of the crl issuance process, ensuring


### PR DESCRIPTION
Make every function in the Run -> Tick -> tickIssuer -> tickShard
chain return an error. Make that return value a named return (which
we usually avoid) so that we can remove the manual setting of the
metric result label and have the deferred metric handling function
take care of that instead. In addition, let that cleanup function wrap
the returned error (if any) with the identity of the shard, issuer, or
tick that is returning it, so that we don't have to include that info in
every individual error message. Finally, have the functions which
spin off many helpers (Tick and tickIssuer) collect all of their helpers'
errors and only surface that error at the end, to ensure the process
completes even in the presence of transient errors.

In crl-updater's main, surface the error returned by Run or Tick, to
make debugging easier.