### PR TITLE
Add gRPC stream interceptors

### DIFF
--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -31,7 +31,7 @@ func TestErrorWrapping(t *testing.T) {
 	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
-	srv := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
+	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)
 	lis, err := net.Listen("tcp", "127.0.0.1:")
@@ -42,7 +42,7 @@ func TestErrorWrapping(t *testing.T) {
 	conn, err := grpc.Dial(
 		lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept),
+		grpc.WithUnaryInterceptor(ci.interceptUnary),
 	)
 	test.AssertNotError(t, err, "Failed to dial grpc test server")
 	client := test_proto.NewChillerClient(conn)
@@ -62,7 +62,7 @@ func TestSubErrorWrapping(t *testing.T) {
 	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
-	srv := grpc.NewServer(grpc.UnaryInterceptor(si.intercept))
+	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)
 	lis, err := net.Listen("tcp", "127.0.0.1:")
@@ -73,7 +73,7 @@ func TestSubErrorWrapping(t *testing.T) {
 	conn, err := grpc.Dial(
 		lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.intercept),
+		grpc.WithUnaryInterceptor(ci.interceptUnary),
 	)
 	test.AssertNotError(t, err, "Failed to dial grpc test server")
 	client := test_proto.NewChillerClient(conn)


### PR DESCRIPTION
Create new gRPC interceptors which are capable of working
on streaming gRPC methods. Add these new interceptors, as
well as the default metrics interceptor provided by grpc-prometheus,
to all of our gRPC clients and servers.

The new interceptors behave virtually identically to their unary
counterparts: they wrap and unwrap our custom errors from the
gRPC metadata, they increment and decrement the in-flight RPC
metric, and they ensure that the RPCs don't fail-fast and do have
enough time left in their deadline to actually finish.

Unfortunately, because the interfaces for unary and streaming
RPCs are so divergent, it's not feasible to share code between the
two kinds of interceptors. While much of the new code is copy-pasted
from the old interceptors, there are subtle differences (such as not
immediately deferring the local context's cancel() function).

Fixes #6356