### PR TITLE
Fix crl-updater goroutine leak

### DIFF
--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -252,6 +252,9 @@ func (cu *crlUpdater) tickIssuer(ctx context.Context, atTime time.Time, issuerNa
 }
 
 func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNameID issuance.IssuerNameID, shardIdx int) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	start := cu.clk.Now()
 	crlId, err := crl.Id(issuerNameID, crl.Number(atTime), shardIdx)
 	if err != nil {


### PR DESCRIPTION
In crl-updater's tickShard, which handles all of the gRPC requests
to the SA, CA, and crl-storer, ensure that any open gRPC connections
get closed when the function returns for any reason by canceling the
context object used in those connections.

This fixes a goroutine leak where the updater would open simultaneous
connections to the SA and CA, get an error from the SA, and then return
without closing the connection to the CA. This left the CA stream open
forever, leading to goroutine and memory leaks in the updater.