### PR TITLE
ocsp: fix handling of expired certificates

### DIFF
--- a/ocsp/responder/filter_source.go
+++ b/ocsp/responder/filter_source.go
@@ -87,7 +87,7 @@ func (src *filterSource) Response(ctx context.Context, req *ocsp.Request) (*Resp
 
 	err = src.checkResponse(iss, resp)
 	if err != nil {
-		src.log.Warningf("OCSP Response not sent for CA=%s, Serial=%s, err: %w", hex.EncodeToString(req.IssuerKeyHash), core.SerialToString(req.SerialNumber), err)
+		src.log.Warningf("OCSP Response not sent for CA=%s, Serial=%s, err: %s", hex.EncodeToString(req.IssuerKeyHash), core.SerialToString(req.SerialNumber), err)
 		src.counter.WithLabelValues("response_filtered").Inc()
 		return nil, err
 	}

--- a/ocsp/responder/live/live.go
+++ b/ocsp/responder/live/live.go
@@ -2,9 +2,11 @@ package live
 
 import (
 	"context"
+	"errors"
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
+	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/ocsp/responder"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"golang.org/x/crypto/ocsp"
@@ -42,6 +44,9 @@ func (s *Source) Response(ctx context.Context, req *ocsp.Request) (*responder.Re
 		Serial: core.SerialToString(req.SerialNumber),
 	})
 	if err != nil {
+		if errors.Is(err, berrors.NotFound) {
+			return nil, responder.ErrNotFound
+		}
 		return nil, err
 	}
 	parsed, err := ocsp.ParseResponse(resp.Response, nil)

--- a/ocsp/responder/live/live_test.go
+++ b/ocsp/responder/live/live_test.go
@@ -2,12 +2,15 @@ package live
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"testing"
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
+	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/ocsp/responder"
 	ocsp_test "github.com/letsencrypt/boulder/ocsp/test"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/test"
@@ -30,6 +33,13 @@ func (m mockOCSPGenerator) GenerateOCSP(ctx context.Context, in *rapb.GenerateOC
 	return &capb.OCSPResponse{Response: m.resp}, nil
 }
 
+// notFoundOCSPGenerator always returns berrors.NotFound
+type notFoundOCSPGenerator struct{}
+
+func (n notFoundOCSPGenerator) GenerateOCSP(ctx context.Context, in *rapb.GenerateOCSPRequest, opts ...grpc.CallOption) (*capb.OCSPResponse, error) {
+	return nil, berrors.NotFoundError("not found")
+}
+
 func TestLiveResponse(t *testing.T) {
 	eeSerial := big.NewInt(1)
 	fakeResp, _, _ := ocsp_test.FakeResponse(ocsp.Response{
@@ -44,5 +54,16 @@ func TestLiveResponse(t *testing.T) {
 	expectedSerial := "000000000000000000000000000000000001"
 	if core.SerialToString(resp.SerialNumber) != expectedSerial {
 		t.Errorf("expected serial %s, got %s", expectedSerial, resp.SerialNumber)
+	}
+}
+
+func TestNotFound(t *testing.T) {
+	eeSerial := big.NewInt(1)
+	source := New(notFoundOCSPGenerator{}, 1)
+	_, err := source.Response(context.Background(), &ocsp.Request{
+		SerialNumber: eeSerial,
+	})
+	if !errors.Is(err, responder.ErrNotFound) {
+		t.Errorf("expected responder.ErrNotFound, got %#v", err)
 	}
 }

--- a/ocsp/responder/redis/redis_source_test.go
+++ b/ocsp/responder/redis/redis_source_test.go
@@ -228,7 +228,7 @@ func TestCertificateNotFound(t *testing.T) {
 	}
 }
 
-func TestServeStale(t *testing.T) {
+func TestNoServeStale(t *testing.T) {
 	clk := clock.NewFake()
 	src, err := NewRedisSource(nil, errorSigner{}, time.Second, clk, metrics.NoopRegisterer, log.NewMock())
 	test.AssertNotError(t, err, "making source")
@@ -242,5 +242,5 @@ func TestServeStale(t *testing.T) {
 	_, err = src.Response(context.Background(), &ocsp.Request{
 		SerialNumber: serial,
 	})
-	test.AssertNotError(t, err, "expected to serve stale response when signer was down")
+	test.AssertError(t, err, "expected to error when signer was down")
 }


### PR DESCRIPTION
In live.Source, translate berrors.NotFound (returned by RA when the certificate is expired) into responder.NotFound (which causes an Unauthorized response rather than a 5xx).

In the Redis source, remove the special case that will return a stale response if live signing fails, and simply pass through the error from the live source.

Before this fix, if we found a stale response in Redis, tried to get a fresh response, and found that the certificate was expired, we would have served the stale response rather than our usual 404 for expired certificates. Since that messes with our metrics, we don't want to do it.

Also, fix an incorrect use of `%w` in log.Warningf.