### PR TITLE
responder: return InternalError for expired responses

### DIFF
--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -309,7 +309,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 				ocspRequest.SerialNumber, b64Body)
 			// HTTP StatusCode - unassigned
 			response.WriteHeader(533)
-			response.Write(ocsp.UnauthorizedErrorResponse)
+			response.Write(ocsp.InternalErrorErrorResponse)
 			rs.responseTypes.With(prometheus.Labels{"type": responseTypeToString[ocsp.Unauthorized]}).Inc()
 			return
 		}

--- a/ocsp/responder/responder_test.go
+++ b/ocsp/responder/responder_test.go
@@ -112,7 +112,7 @@ func TestResponseExpired(t *testing.T) {
 			if rw.Code != tc.expected {
 				t.Errorf("Incorrect response code: got %d, wanted %d", rw.Code, tc.expected)
 			}
-			test.AssertByteEquals(t, ocsp.UnauthorizedErrorResponse, rw.Body.Bytes())
+			test.AssertByteEquals(t, ocsp.InternalErrorErrorResponse, rw.Body.Bytes())
 		})
 	}
 }

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -35,6 +35,7 @@
       ],
       "timeout": "15s"
     },
+    "logSampleRate": 1,
     "path": "/",
     "listenAddress": "0.0.0.0:4002",
     "issuerCerts": [

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1416,19 +1416,22 @@ def test_ocsp_exp_unauth():
     if 'cert_file' not in ocsp_exp_unauth_setup_data:
         raise Exception("ocsp_exp_unauth_setup didn't run")
     cert_file = ocsp_exp_unauth_setup_data['cert_file']
+    last_error = ""
     while tries < 5:
         try:
             verify_ocsp(cert_file, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "XXX")
             raise(Exception("Unexpected return from verify_ocsp"))
         except subprocess.CalledProcessError as cpe:
+            last_error = cpe.output
             if cpe.output == b"Responder Error: unauthorized (6)\n":
                 break
-        except:
+        except e:
+            last_error = e
             pass
         tries += 1
         time.sleep(0.25)
     else:
-        raise(Exception("timed out waiting for unauthorized OCSP response for expired certificate"))
+        raise(Exception("timed out waiting for unauthorized OCSP response for expired certificate. Last error: {}".format(last_error)))
 
 def test_blocked_key_account():
     # Only config-next has a blocked keys file configured.


### PR DESCRIPTION
This was masking a bug, because the integration test for OCSP responses for expired certificates was looking for the "unauthorized" OCSP response status. Which we were returning, even though our HTTP-level response code was 533.

This is a followup of #6372. It turns out the integration test was already covering the case we care about (expired certificates), but was spuriously succeeding because we returned the wrong OCSP response status (https://www.rfc-editor.org/rfc/rfc6960#section-2.3).