### PR TITLE
crl-updater: Check HTTP response code on CRL downloads

### DIFF
--- a/cmd/crl-checker/main.go
+++ b/cmd/crl-checker/main.go
@@ -20,6 +20,9 @@ func validateShard(url string, issuer *issuance.Certificate) error {
 	if err != nil {
 		return fmt.Errorf("downloading crl: %w", err)
 	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading crl: http status %d", resp.StatusCode)
+	}
 
 	crlBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/cmd/crl-checker/main.go
+++ b/cmd/crl-checker/main.go
@@ -69,7 +69,7 @@ func main() {
 		err = validateShard(url, issuer)
 		if err != nil {
 			errCount += 1
-			logger.Errf("CRL %q failed: %s\n", url, err)
+			logger.Errf("CRL %q failed: %s", url, err)
 		}
 	}
 


### PR DESCRIPTION
I got some URLs wrong when using this tool, which resulted in confusing errors as the error bodies tried to get parsed as a CRL.  As well, the errors had a stray \n at the end which I've also removed.  The logger interface escapes newlines, and already includes one at the end of the line.

