### PR TITLE
reloader: log reload events directly

### DIFF
--- a/log/mock.go
+++ b/log/mock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/syslog"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -114,6 +115,14 @@ func (m *Mock) GetAllMatching(reString string) []string {
 		}
 	}
 	return matches
+}
+
+func (m *Mock) ExpectMatch(reString string) error {
+	results := m.GetAllMatching(reString)
+	if len(results) == 0 {
+		return fmt.Errorf("expected log line %q, got %q", reString, strings.Join(m.GetAll(), "\n"))
+	}
+	return nil
 }
 
 // Clear resets the log buffer.

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -76,14 +76,10 @@ type blockedNamesPolicy struct {
 // SetHostnamePolicyFile will load the given policy file, returning error if it
 // fails. It will also start a reloader in case the file changes
 func (pa *AuthorityImpl) SetHostnamePolicyFile(f string) error {
-	if _, err := reloader.New(f, pa.loadHostnamePolicy, pa.hostnamePolicyLoadError); err != nil {
+	if _, err := reloader.New(f, pa.loadHostnamePolicy, pa.log); err != nil {
 		return err
 	}
 	return nil
-}
-
-func (pa *AuthorityImpl) hostnamePolicyLoadError(err error) {
-	pa.log.AuditErrf("error loading hostname policy: %s", err)
 }
 
 // loadHostnamePolicy is a callback suitable for use with reloader.New() that

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -226,16 +226,12 @@ func NewRegistrationAuthorityImpl(
 }
 
 func (ra *RegistrationAuthorityImpl) SetRateLimitPoliciesFile(filename string) error {
-	_, err := reloader.New(filename, ra.rlPolicies.LoadPolicies, ra.rateLimitPoliciesLoadError)
+	_, err := reloader.New(filename, ra.rlPolicies.LoadPolicies, ra.log)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (ra *RegistrationAuthorityImpl) rateLimitPoliciesLoadError(err error) {
-	ra.log.Errf("error reloading rate limit policy: %s", err)
 }
 
 // certificateRequestAuthz is a struct for holding information about a valid

--- a/reloader/reloader_test.go
+++ b/reloader/reloader_test.go
@@ -131,8 +131,8 @@ func TestReload(t *testing.T) {
 	}
 }
 
-/// existingFile implements fs.FileInfo / os.FileInfo and returns information
-/// as if it were a basic file that existed. This is used to mock out os.Stat.
+// existingFile implements fs.FileInfo / os.FileInfo and returns information
+// as if it were a basic file that existed. This is used to mock out os.Stat.
 type existingFile struct{}
 
 func (e existingFile) Name() string       { return "example" }

--- a/reloader/reloader_test.go
+++ b/reloader/reloader_test.go
@@ -2,31 +2,22 @@ package reloader
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	blog "github.com/letsencrypt/boulder/log"
 )
 
 func noop([]byte) error {
 	return nil
 }
 
-func testErrCb(t *testing.T) func(error) {
-	return func(e error) {
-		t.Error(e)
-	}
-}
-
-func testFatalCb(t *testing.T) func(error) {
-	return func(e error) {
-		t.Fatal(e)
-	}
-}
-
 func TestNoStat(t *testing.T) {
 	filename := os.TempDir() + "/doesntexist.123456789"
-	_, err := New(filename, noop, testErrCb(t))
+	_, err := New(filename, noop, blog.NewMock())
 	if err == nil {
 		t.Fatalf("Expected New to return error when the file doesn't exist.")
 	}
@@ -39,7 +30,7 @@ func TestNoRead(t *testing.T) {
 	readFile = func(string) ([]byte, error) {
 		return nil, fmt.Errorf("read failed")
 	}
-	_, err := New(f.Name(), noop, testErrCb(t))
+	_, err := New(f.Name(), noop, blog.NewMock())
 	if err == nil {
 		readFile = oldReadFile
 		t.Fatalf("Expected New to return error when permission denied.")
@@ -52,7 +43,7 @@ func TestFirstError(t *testing.T) {
 	defer os.Remove(f.Name())
 	_, err := New(f.Name(), func([]byte) error {
 		return fmt.Errorf("i die")
-	}, testErrCb(t))
+	}, blog.NewMock())
 	if err == nil {
 		t.Fatalf("Expected New to return error when the callback returned error the first time.")
 	}
@@ -63,7 +54,7 @@ func TestFirstSuccess(t *testing.T) {
 	defer os.Remove(f.Name())
 	r, err := New(f.Name(), func([]byte) error {
 		return nil
-	}, testErrCb(t))
+	}, blog.NewMock())
 	if err != nil {
 		t.Errorf("Expected New to succeed, got %s", err)
 	}
@@ -102,7 +93,7 @@ func TestReload(t *testing.T) {
 		bodies = append(bodies, string(b))
 		reloads <- b
 		return nil
-	}, testFatalCb(t))
+	}, blog.NewMock())
 	if err != nil {
 		t.Fatalf("Expected New to succeed, got %s", err)
 	}
@@ -140,6 +131,17 @@ func TestReload(t *testing.T) {
 	}
 }
 
+/// existingFile implements fs.FileInfo / os.FileInfo and returns information
+/// as if it were a basic file that existed. This is used to mock out os.Stat.
+type existingFile struct{}
+
+func (e existingFile) Name() string       { return "example" }
+func (e existingFile) Size() int64        { return 10 }
+func (e existingFile) Mode() fs.FileMode  { return 0 }
+func (e existingFile) ModTime() time.Time { return time.Now() }
+func (e existingFile) IsDir() bool        { return false }
+func (e existingFile) Sys() any           { return nil }
+
 func TestReloadFailure(t *testing.T) {
 	// Mock out makeTicker
 	fakeTick, restoreMakeTicker := makeFakeMakeTicker()
@@ -160,44 +162,43 @@ func TestReloadFailure(t *testing.T) {
 	}
 
 	reloads := make(chan res, 1)
+	log := blog.NewMock()
 	_, err := New(filename, func(b []byte) error {
 		reloads <- res{b, nil}
 		return nil
-	}, func(e error) {
-		reloads <- res{nil, e}
-	})
+	}, log)
 	if err != nil {
 		t.Fatalf("Expected New to succeed.")
 	}
 	<-reloads
 	os.Remove(filename)
 	fakeTick <- time.Now()
-	select {
-	case r := <-reloads:
-		if r.err == nil {
-			t.Errorf("Expected error trying to read missing file.")
-		}
-	case <-time.After(5 * time.Second):
-		t.Errorf("timed out waiting for reload")
+	time.Sleep(50 * time.Millisecond)
+	err = log.ExpectMatch("statting .* no such file or directory")
+	if err != nil {
+		t.Error(err)
 	}
 
-	time.Sleep(1 * time.Second)
-	// Create a file with no permissions
+	log.Clear()
+
+	// Mock a file with no permissions
 	oldReadFile := readFile
 	readFile = func(string) ([]byte, error) {
 		return nil, fmt.Errorf("permission denied")
 	}
+	oldStatFile := statFile
+	statFile = func(string) (fs.FileInfo, error) {
+		return existingFile{}, nil
+	}
 
 	fakeTick <- time.Now()
-	select {
-	case r := <-reloads:
-		if r.err == nil {
-			t.Errorf("Expected error trying to read file with no permissions.")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatalf("timed out waiting for reload")
+	time.Sleep(50 * time.Millisecond)
+	err = log.ExpectMatch("reading .* permission denied")
+	if err != nil {
+		t.Error(err)
 	}
 	readFile = oldReadFile
+	statFile = oldStatFile
 
 	err = os.WriteFile(filename, []byte("third body"), 0644)
 	if err != nil {


### PR DESCRIPTION
Previously, the reloader relied on user code to log errors and changes. But this led to gaps (for instance the RA not logging reloads of the rate limit file). Instead, make the reloader responsible for this.

This allowed removing the error callback, at the minor cost of removing the status gauge for the ECDSA allowlist.