### PR TITLE
Revert "wfe: Log TLS version (#6001)"

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -123,7 +123,6 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logEvent := &RequestEvent{
 		RealIP:    realIP,
 		Method:    r.Method,
-		TLS:       r.Header.Get("TLS-Version"),
 		UserAgent: r.Header.Get("User-Agent"),
 		Origin:    r.Header.Get("Origin"),
 		Extra:     make(map[string]interface{}),


### PR DESCRIPTION
This reverts commit 7336f1acce88a48b0c9ddbf1371f0621eae7cf35.

We've finished the TLS 1.0 and TLS 1.1 deprecation and don't need to collect these data anymore.