### PR TITLE
expiration-mailer: allow limiting UPDATE statement

### DIFF
--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -10,6 +10,7 @@
       "maxOpenConns": 10
     },
     "certLimit": 100000,
+    "updateChunkSize": 1000,
     "nagTimes": ["480h", "240h"],
     "emailTemplate": "test/config-next/expiration-mailer.gotmpl",
     "debugAddr": ":8008",


### PR DESCRIPTION
This avoids the statements getting so big they can't run.

Also, drive-by add some comments to the expiration-mailer config.