### PR TITLE
crl/updater: fix incorrect logging of error

### DIFF
--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -182,7 +182,7 @@ func main() {
 		go func() {
 			for line := range t.Lines {
 				if line.Err != nil {
-					logger.Errf("error while tailing %s: %s", t.Filename, err)
+					logger.Errf("error while tailing %s: %s", t.Filename, line.Err)
 					continue
 				}
 				err := lineValid(line.Text)

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -264,7 +264,7 @@ func (cu *crlUpdater) tickIssuer(ctx context.Context, atTime time.Time, issuerNa
 		if res.err != nil {
 			cu.log.AuditErrf(
 				"Generating CRL failed: id=[%s] err=[%s]",
-				crl.Id(issuerNameID, crl.Number(atTime), res.shardIdx), err)
+				crl.Id(issuerNameID, crl.Number(atTime), res.shardIdx), res.err)
 			errShards = append(errShards, res.shardIdx)
 		}
 	}

--- a/reloader/reloader_test.go
+++ b/reloader/reloader_test.go
@@ -207,7 +207,7 @@ func TestReloadFailure(t *testing.T) {
 	select {
 	case r := <-reloads:
 		if r.err != nil {
-			t.Errorf("Unexpected error: %s", err)
+			t.Errorf("Unexpected error: %s", r.err)
 		}
 		if string(r.b) != "third body" {
 			t.Errorf("Expected 'third body' reading file after restoring it.")


### PR DESCRIPTION
Also fix some other instances, found by:

    rg '\.err != nil' -g '!vendor/' -A 4 -B 0
