### PR TITLE
rocsp-tool: register start-from-id in main

### DIFF
--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -74,10 +74,11 @@ func main() {
 	}
 }
 
-var startFromID = flag.Int64("start-from-id", 0, "For load-from-db, the first ID in the certificateStatus table to scan")
+var startFromID *int64
 
 func main2() error {
 	configFile := flag.String("config", "", "File path to the configuration file for this service")
+	startFromID = flag.Int64("start-from-id", 0, "For load-from-db, the first ID in the certificateStatus table to scan")
 	flag.Usage = helpExit
 	flag.Parse()
 	if *configFile == "" || len(flag.Args()) < 1 {


### PR DESCRIPTION
Prior to this change, start-from-id was showing up in the -help output for all boulder binaries.

Note that this is a global variable because it is referenced in the LoadFromDB closure: https://github.com/letsencrypt/boulder/blob/582b5e346fbc3f2310f18b6b10cc724519698ac2/cmd/rocsp-tool/main.go#L199-L210