### PR TITLE
checkocsp: allow fetching by serial number

### DIFF
--- a/test/ocsp/checkocsp/checkocsp.go
+++ b/test/ocsp/checkocsp/checkocsp.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"log"
+	"math/big"
 	"os"
+	"strings"
 
 	"github.com/letsencrypt/boulder/test/ocsp/helper"
 )
@@ -24,6 +27,7 @@ stale.
 		flag.PrintDefaults()
 	}
 	helper.RegisterFlags()
+	serials := flag.Bool("serials", false, "Parameters are hex-encoded serial numbers instead of filenames. Requires --issuer-file and --url.")
 	flag.Parse()
 	var errors bool
 	if len(flag.Args()) == 0 {
@@ -34,10 +38,22 @@ stale.
 	if err != nil {
 		log.Fatal(err)
 	}
-	for _, f := range flag.Args() {
-		_, err := helper.ReqFile(f, config)
+	for _, a := range flag.Args() {
+		var err error
+		var bytes []byte
+		if *serials {
+			bytes, err = hex.DecodeString(strings.Replace(a, ":", "", -1))
+			if err != nil {
+				log.Printf("error for %s (line %d): %s\n", a, err)
+			}
+			serialNumber := big.NewInt(0).SetBytes(bytes)
+			_, err = helper.ReqSerial(serialNumber, config)
+
+		} else {
+			_, err = helper.ReqFile(a, config)
+		}
 		if err != nil {
-			log.Printf("error for %s: %s\n", f, err)
+			log.Printf("error for %s: %s\n", a, err)
 			errors = true
 		}
 	}


### PR DESCRIPTION
This requires setting --issuer-file and --url, but it allows (for instance) collecting a big pile of serial numbers for a known issuer, rather than having to keep whole certificates.