### PR TITLE
Fix crl number formatting in logs

### DIFF
--- a/crl/crl.go
+++ b/crl/crl.go
@@ -10,7 +10,7 @@ import (
 
 // number represents the 'crlNumber' field of a CRL. It must be constructed by
 // calling `Number()`.
-type number *big.Int
+type number = *big.Int
 
 // Number derives the 'CRLNumber' field for a CRL from the value of the
 // 'thisUpdate' field provided as a `time.Time`.


### PR DESCRIPTION
Because the CRL number type was previously a type definition, it
did not inherit big.Int's method, including the Format method which
supports %d formatting. Make the CRL number type an alias instead,
so that it inherits the base type's methods, and can be formatted into
strings using %d.