### PR TITLE
Enable go vet printf-auditing our logger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,16 @@ linters-settings:
   gosimple:
     # S1029: Range over the string directly
     checks: ["all", "-S1029"]
+  govet:
+    settings:
+      printf:
+        funcs:
+          - (github.com/letsencrypt/boulder/log.Logger).Errf
+          - (github.com/letsencrypt/boulder/log.Logger).Warningf
+          - (github.com/letsencrypt/boulder/log.Logger).Infof
+          - (github.com/letsencrypt/boulder/log.Logger).Debugf
+          - (github.com/letsencrypt/boulder/log.Logger).AuditInfof
+          - (github.com/letsencrypt/boulder/log.Logger).AuditErrf
   staticcheck:
     # SA1019: Using a deprecated function, variable, constant or field
     # SA6003: Converting a string to a slice of runes before ranging over it

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"math/big"
 	"sort"
 	"strings"
 	"time"
@@ -168,8 +169,8 @@ func (cu *crlUpdater) Run(ctx context.Context) error {
 				// We only log, rather than return, so that the long-lived process can
 				// continue and try again at the next tick.
 				cu.log.AuditErrf(
-					"Generating CRLs failed: number=[%d] err=[%s]",
-					crl.Number(atTime), err)
+					"Generating CRLs failed: number=[%s] err=[%s]",
+					(*big.Int)(crl.Number(atTime)), err)
 			}
 		case <-ctx.Done():
 			ticker.Stop()
@@ -202,7 +203,7 @@ func (cu *crlUpdater) Tick(ctx context.Context, atTime time.Time) (err error) {
 		if err != nil {
 			cu.log.AuditErrf(
 				"Generating CRLs for issuer failed: number=[%d] issuer=[%s] err=[%s]",
-				crl.Number(atTime), cu.issuers[id].Subject.CommonName, err)
+				(*big.Int)(crl.Number(atTime)), cu.issuers[id].Subject.CommonName, err)
 			errIssuers = append(errIssuers, cu.issuers[id].Subject.CommonName)
 		}
 	}
@@ -326,7 +327,7 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 		crlEntries = append(crlEntries, entry)
 	}
 
-	cu.log.Infof("Queried SA for CRL shard: id=[%s] numEntries=[%s]")
+	cu.log.Infof("Queried SA for CRL shard: id=[%s] numEntries=[%d]", crlID, len(crlEntries))
 
 	// Send the full list of CRL Entries to the CA.
 	caStream, err := cu.ca.GenerateCRL(ctx)

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -328,9 +328,8 @@ func (cu *crlUpdater) tickShard(ctx context.Context, atTime time.Time, issuerNam
 	}
 
 	cu.log.Infof(
-		"Queried SA for CRL shard: id=[%s] numEntries=[%s]",
+		"Queried SA for CRL shard: id=[%s] numEntries=[%d]",
 		crlID, len(crlEntries))
-
 
 	// Send the full list of CRL Entries to the CA.
 	caStream, err := cu.ca.GenerateCRL(ctx)

--- a/log/log.go
+++ b/log/log.go
@@ -21,7 +21,8 @@ import (
 
 // A Logger logs messages with explicit priority levels. It is
 // implemented by a logging back-end as provided by New() or
-// NewMock().
+// NewMock(). Any additions to this interface with format strings should be
+// added to the govet configuration in .golangci.yml
 type Logger interface {
 	Err(msg string)
 	Errf(format string, a ...interface{})

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -2264,7 +2264,7 @@ func (ssa *SQLStorageAuthority) GetRevokedCerts(req *sapb.GetRevokedCertsRequest
 	defer func() {
 		err := rows.Close()
 		if err != nil {
-			ssa.log.AuditErrf("closing row reader: %w", err)
+			ssa.log.AuditErrf("closing row reader: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
Because this is an interface, go vet can't see that they get piped into
Sprintf in the implementations.
