### PR TITLE
Export a metric with labels containing build metadata

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -31,7 +31,7 @@ import (
 )
 
 func command() string {
-  return path.Base(os.Args[0])
+	return path.Base(os.Args[0])
 }
 
 // Because we don't know when this init will be called with respect to
@@ -167,12 +167,11 @@ func StatsAndLogging(logConf SyslogConfig, addr string) (prometheus.Registerer, 
 func NewLogger(logConf SyslogConfig) blog.Logger {
 	var logger blog.Logger
 	if logConf.SyslogLevel >= 0 {
-		tag := command
 		syslogger, err := syslog.Dial(
 			"",
 			"",
 			syslog.LOG_INFO, // default, not actually used
-			tag)
+			command())
 		FailOnError(err, "Could not connect to Syslog")
 		syslogLevel := int(syslog.LOG_INFO)
 		if logConf.SyslogLevel != 0 {
@@ -219,7 +218,7 @@ func newVersionCollector() prometheus.Collector {
 			Name: "version",
 			Help: fmt.Sprintf(
 				"A metric with a constant value of '1' labeled by the short commit-id (buildId), build timestamp in RFC3339 format (buildTime), and Go release tag like 'go1.3' (goVersion) from which %s was built.",
-				command,
+				command(),
 			),
 			ConstLabels: prometheus.Labels{
 				"buildId":   core.BuildID,
@@ -315,7 +314,7 @@ func ReadConfigFile(filename string, out interface{}) error {
 
 // VersionString produces a friendly Application version string.
 func VersionString() string {
-	return fmt.Sprintf("Versions: %s=(%s %s) Golang=(%s) BuildHost=(%s)", command, core.BuildID, core.BuildTime, runtime.Version(), core.GetBuildHost())
+	return fmt.Sprintf("Versions: %s=(%s %s) Golang=(%s) BuildHost=(%s)", command(), core.BuildID, core.BuildTime, runtime.Version(), core.GetBuildHost())
 }
 
 // CatchSignals catches SIGTERM, SIGINT, SIGHUP and executes a callback

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -202,9 +202,9 @@ func NewLogger(logConf SyslogConfig) blog.Logger {
 
 func newVersionCollector() prometheus.Collector {
 	buildTime := core.Unspecified
-	if core.BuildTime != core.Unspecified {
-		// core.BuildTime is set by in our Makefile using the shell command 'date
-		// -u' which outputs consistently across all POSIX systems.
+	if core.GetBuildTime() != core.Unspecified {
+		// core.BuildTime is set by our Makefile using the shell command 'date
+		// -u' which outputs in a consistent format across all POSIX systems.
 		bt, err := time.Parse(time.UnixDate, core.BuildTime)
 		if err != nil {
 			// Should never happen unless the Makefile is changed.
@@ -221,7 +221,7 @@ func newVersionCollector() prometheus.Collector {
 				command(),
 			),
 			ConstLabels: prometheus.Labels{
-				"buildId":   core.BuildID,
+				"buildId":   core.GetBuildID(),
 				"buildTime": buildTime,
 				"goVersion": runtime.Version(),
 			},
@@ -314,7 +314,7 @@ func ReadConfigFile(filename string, out interface{}) error {
 
 // VersionString produces a friendly Application version string.
 func VersionString() string {
-	return fmt.Sprintf("Versions: %s=(%s %s) Golang=(%s) BuildHost=(%s)", command(), core.BuildID, core.BuildTime, runtime.Version(), core.GetBuildHost())
+	return fmt.Sprintf("Versions: %s=(%s %s) Golang=(%s) BuildHost=(%s)", command(), core.GetBuildID(), core.GetBuildTime(), runtime.Version(), core.GetBuildHost())
 }
 
 // CatchSignals catches SIGTERM, SIGINT, SIGHUP and executes a callback

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -30,7 +30,9 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-var command = func() string { return path.Base(os.Args[0]) }()
+func command() string {
+  return path.Base(os.Args[0])
+}
 
 // Because we don't know when this init will be called with respect to
 // flag.Parse() and other flag definitions, we can't rely on the regular

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -30,7 +30,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-var command = path.Base(os.Args[0])
+var command = func() string { return path.Base(os.Args[0]) }()
 
 // Because we don't know when this init will be called with respect to
 // flag.Parse() and other flag definitions, we can't rely on the regular

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -14,7 +14,6 @@ import (
 	"os/signal"
 	"path"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -213,14 +212,14 @@ func newVersionCollector() prometheus.Collector {
 			// Should never happen unless the Makefile is changed.
 			buildTime = "Unparsable"
 		} else {
-			buildTime = strconv.FormatInt(bt.Unix(), 10)
+			buildTime = bt.Format(time.RFC3339)
 		}
 	}
 	return prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Name: "version",
 			Help: fmt.Sprintf(
-				"A metric with a constant value of '1' labeled by the buildId=[short commit-id], buildTime=[unix timestamp in seconds], and goVersion=[release tag like 'go1.3']  from which %s was built.",
+				"A metric with a constant value of '1' labeled by the short commit-id (buildId), build timestamp in RFC3339 format (buildTime), and Go release tag like 'go1.3' (goVersion) from which %s was built.",
 				command,
 			),
 			ConstLabels: prometheus.Labels{

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -202,11 +202,8 @@ func NewLogger(logConf SyslogConfig) blog.Logger {
 }
 
 func newVersionCollector() prometheus.Collector {
-	var buildTime string
-	if core.BuildTime == core.Unspecified {
-		// Will happen if Boulder wasn't built using the Makefile.
-		buildTime = core.Unspecified
-	} else {
+	buildTime := core.Unspecified
+	if core.BuildTime != core.Unspecified {
 		// core.BuildTime is set by in our Makefile using the shell command 'date
 		// -u' which outputs consistently across all POSIX systems.
 		bt, err := time.Parse(time.UnixDate, core.BuildTime)

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -154,4 +155,10 @@ func TestGRPCLoggerWarningFilter(t *testing.T) {
 	l.Warningln("Server.processUnaryRPC failed to write status: connection error: desc = \"transport is closing\"")
 	lines = m.GetAllMatching(".*")
 	test.AssertEquals(t, len(lines), 0)
+}
+
+func Test_newVersionCollector(t *testing.T) {
+	core.BuildID = "TestBuildID"
+	version := newVersionCollector()
+	test.AssertMetricWithLabelsEquals(t, version, prometheus.Labels{"buildId": "TestBuildID"}, 1)
 }

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -169,8 +168,7 @@ func Test_newVersionCollector(t *testing.T) {
 	now := time.Now().UTC()
 	core.BuildTime = now.Format(time.UnixDate)
 	version = newVersionCollector()
-	expectBuildTime := strconv.FormatInt(now.Unix(), 10)
-	test.AssertMetricWithLabelsEquals(t, version, prometheus.Labels{"buildTime": expectBuildTime}, 1)
+	test.AssertMetricWithLabelsEquals(t, version, prometheus.Labels{"buildTime": now.Format(time.RFC3339)}, 1)
 	// Unparsable timestamp should emit 'Unsparsable'.
 	core.BuildTime = "outta time"
 	version = newVersionCollector()

--- a/core/util.go
+++ b/core/util.go
@@ -26,6 +26,8 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 )
 
+const Unspecified = "Unspecified"
+
 // Package Variables Variables
 
 // BuildID is set by the compiler (using -ldflags "-X core.BuildID $(git rev-parse --short HEAD)")
@@ -182,7 +184,7 @@ func ValidSerial(serial string) bool {
 func GetBuildID() (retID string) {
 	retID = BuildID
 	if retID == "" {
-		retID = "Unspecified"
+		retID = Unspecified
 	}
 	return
 }
@@ -191,7 +193,7 @@ func GetBuildID() (retID string) {
 func GetBuildTime() (retID string) {
 	retID = BuildTime
 	if retID == "" {
-		retID = "Unspecified"
+		retID = Unspecified
 	}
 	return
 }
@@ -200,7 +202,7 @@ func GetBuildTime() (retID string) {
 func GetBuildHost() (retID string) {
 	retID = BuildHost
 	if retID == "" {
-		retID = "Unspecified"
+		retID = Unspecified
 	}
 	return
 }

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -57,7 +57,7 @@ func TestSerialUtils(t *testing.T) {
 }
 
 func TestBuildID(t *testing.T) {
-	test.AssertEquals(t, "Unspecified", GetBuildID())
+	test.AssertEquals(t, Unspecified, GetBuildID())
 }
 
 const JWK1JSON = `{


### PR DESCRIPTION
Emit a metric (`version`) with a constant value of '1' labeled by the short
commit-id (`buildId`), build timestamp in RFC3339 format (`buildTime`), and Go
release tag like 'go1.3' (`goVersion`)  from which the Boulder binary was built.

Resolves #6405