### PR TITLE
crl-checker: allow disabling signature validation

### DIFF
--- a/cmd/crl-checker/main.go
+++ b/cmd/crl-checker/main.go
@@ -61,7 +61,7 @@ func validateShard(crl *crl_x509.RevocationList, issuer *issuance.Certificate, a
 
 func main() {
 	urlFile := flag.String("crls", "", "path to a file containing a JSON Array of CRL URLs")
-	issuerFile := flag.String("issuer", "", "path to an issuer certificate on disk")
+	issuerFile := flag.String("issuer", "", "path to an issuer certificate on disk, required, '-' to disable validation")
 	ageLimitStr := flag.String("ageLimit", "168h", "maximum allowable age of a CRL shard")
 	emitRevoked := flag.Bool("emitRevoked", false, "emit revoked serial numbers on stdout, one per line, hex-encoded")
 	flag.Parse()


### PR DESCRIPTION
Allow the -issuer flag to take the special value "-", which
causes no issuer file to be loaded and no CRL signatures
to be validated. Also improve the error message if no
-issuer flag is provided at all.

Fixes #6409

Note to reviewers: this is a recreation of https://github.com/letsencrypt/boulder/pull/6428, which got merged into the wrong branch.