### PR TITLE
Add CRLDPBase config key to boulder-ca

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -99,6 +99,11 @@ type Config struct {
 		// https://www.gstatic.com/ct/log_list/v3/log_list_schema.json
 		CTLogListFile string
 
+		// CRLDPBase is the piece of the CRL Distribution Point URI which is common
+		// across all issuers and shards. It must use the http:// scheme, and must
+		// not end with a slash. Example: "http://prod.c.lencr.org".
+		CRLDPBase string
+
 		Features map[string]bool
 	}
 

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -108,6 +108,7 @@
     "maxNames": 100,
     "lifespanOCSP": "96h",
     "lifespanCRL": "216h",
+    "crldpBase": "http://c.boulder.test",
     "goodkey": {
       "weakKeyFile": "test/example-weak-keys.json",
       "blockedKeyFile": "test/example-blocked-keys.yaml",

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -108,6 +108,7 @@
     "maxNames": 100,
     "lifespanOCSP": "96h",
     "lifespanCRL": "216h",
+    "crldpBase": "http://c.boulder.test",
     "goodkey": {
       "weakKeyFile": "test/example-weak-keys.json",
       "blockedKeyFile": "test/example-blocked-keys.yaml",


### PR DESCRIPTION
Add a new configuration key to the CA which allows us to
specify the "base URL" for our CRLs. This will be necessary
before including an Issuing Distribution Point extension in our
CRLs, or a CRL Distribution Point in our certificates.

Part of #6410