### PR TITLE
Add CRL Validate and Diff library methods

### DIFF
--- a/crl/checker/checker.go
+++ b/crl/checker/checker.go
@@ -1,0 +1,110 @@
+package checker
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"sort"
+	"time"
+
+	"github.com/letsencrypt/boulder/crl/crl_x509"
+	"github.com/letsencrypt/boulder/issuance"
+	"github.com/letsencrypt/boulder/linter"
+	crlint "github.com/letsencrypt/boulder/linter/lints/crl"
+)
+
+// Validate runs the given CRL through our set of lints, ensures its signature
+// validates (if supplied with a non-nil issuer), and checks that the CRL is
+// less than ageLimit old. It returns an error if any of these conditions are
+// not met.
+func Validate(crl *crl_x509.RevocationList, issuer *issuance.Certificate, ageLimit time.Duration) error {
+	err := linter.ProcessResultSet(crlint.LintCRL(crl))
+	if err != nil {
+		return fmt.Errorf("linting CRL: %w", err)
+	}
+
+	if issuer != nil {
+		err = crl.CheckSignatureFrom(issuer.Certificate)
+		if err != nil {
+			return fmt.Errorf("checking CRL signature: %w", err)
+		}
+	}
+
+	if time.Since(crl.ThisUpdate) >= ageLimit {
+		return fmt.Errorf("thisUpdate more than %s in the past: %v", ageLimit, crl.ThisUpdate)
+	}
+
+	return nil
+}
+
+type diffResult struct {
+	Added   []*big.Int
+	Removed []*big.Int
+	// TODO: consider adding a "changed" field, for entries whose revocation time
+	// or revocation reason changes.
+}
+
+// Diff returns the sets of serials that were added and removed between two
+// CRLs. In order to be comparable, the CRLs must come from the same issuer, and
+// be given in the correct order (the "old" CRL's Number and ThisUpdate must
+// both precede the "new" CRL's).
+func Diff(old, new *crl_x509.RevocationList) (*diffResult, error) {
+	if !bytes.Equal(old.AuthorityKeyId, new.AuthorityKeyId) {
+		return nil, fmt.Errorf("CRLs were not issued by same issuer")
+	}
+
+	if !old.ThisUpdate.Before(new.ThisUpdate) {
+		return nil, fmt.Errorf("old CRL does not precede new CRL")
+	}
+
+	if old.Number.Cmp(new.Number) <= 0 {
+		return nil, fmt.Errorf("old CRL does not precede new CRL")
+	}
+
+	// Sort both sets of serials so we can march through them in order.
+	oldSerials := make([]*big.Int, len(old.RevokedCertificates))
+	for _, rc := range old.RevokedCertificates {
+		oldSerials = append(oldSerials, rc.SerialNumber)
+	}
+	sort.Slice(oldSerials, func(i, j int) bool {
+		return oldSerials[i].Cmp(oldSerials[j]) < 0
+	})
+
+	newSerials := make([]*big.Int, len(new.RevokedCertificates))
+	for _, rc := range new.RevokedCertificates {
+		newSerials = append(newSerials, rc.SerialNumber)
+	}
+	sort.Slice(newSerials, func(i, j int) bool {
+		return newSerials[i].Cmp(newSerials[j]) < 0
+	})
+
+	// Work our way through both lists of sorted serials. If the old list skips
+	// past a serial seen in the new list, then that serial was added. If the new
+	// list skips past a serial seen in the old list, then it was removed.
+	i, j := 0, 0
+	added := make([]*big.Int, 0)
+	removed := make([]*big.Int, 0)
+	for {
+		if i >= len(oldSerials) {
+			added = append(added, newSerials[j:]...)
+			break
+		}
+		if j >= len(newSerials) {
+			removed = append(removed, oldSerials[i:]...)
+			break
+		}
+		cmp := oldSerials[i].Cmp(newSerials[j])
+		if cmp < 0 {
+			removed = append(removed, oldSerials[i])
+			i++
+		} else if cmp > 0 {
+			added = append(added, newSerials[j])
+			j++
+		} else {
+			i++
+			j++
+		}
+	}
+
+	return &diffResult{added, removed}, nil
+}

--- a/crl/checker/checker.go
+++ b/crl/checker/checker.go
@@ -57,22 +57,22 @@ func Diff(old, new *crl_x509.RevocationList) (*diffResult, error) {
 		return nil, fmt.Errorf("old CRL does not precede new CRL")
 	}
 
-	if old.Number.Cmp(new.Number) <= 0 {
+	if old.Number.Cmp(new.Number) >= 0 {
 		return nil, fmt.Errorf("old CRL does not precede new CRL")
 	}
 
 	// Sort both sets of serials so we can march through them in order.
 	oldSerials := make([]*big.Int, len(old.RevokedCertificates))
-	for _, rc := range old.RevokedCertificates {
-		oldSerials = append(oldSerials, rc.SerialNumber)
+	for i, rc := range old.RevokedCertificates {
+		oldSerials[i] = rc.SerialNumber
 	}
 	sort.Slice(oldSerials, func(i, j int) bool {
 		return oldSerials[i].Cmp(oldSerials[j]) < 0
 	})
 
 	newSerials := make([]*big.Int, len(new.RevokedCertificates))
-	for _, rc := range new.RevokedCertificates {
-		newSerials = append(newSerials, rc.SerialNumber)
+	for j, rc := range new.RevokedCertificates {
+		newSerials[j] = rc.SerialNumber
 	}
 	sort.Slice(newSerials, func(i, j int) bool {
 		return newSerials[i].Cmp(newSerials[j]) < 0

--- a/crl/checker/checker_test.go
+++ b/crl/checker/checker_test.go
@@ -1,0 +1,102 @@
+package checker
+
+import (
+	"crypto/rand"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/letsencrypt/boulder/crl/crl_x509"
+	"github.com/letsencrypt/boulder/issuance"
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestValidate(t *testing.T) {
+	crlFile, err := os.Open("../../test/hierarchy/int-e1.crl.pem")
+	test.AssertNotError(t, err, "opening test crl file")
+	crlPEM, err := io.ReadAll(crlFile)
+	test.AssertNotError(t, err, "reading test crl file")
+	crlDER, _ := pem.Decode(crlPEM)
+	crl, err := crl_x509.ParseRevocationList(crlDER.Bytes)
+	test.AssertNotError(t, err, "parsing test crl")
+	issuer, err := issuance.LoadCertificate("../../test/hierarchy/int-e1.cert.pem")
+	test.AssertNotError(t, err, "loading test issuer")
+
+	err = Validate(crl, issuer, 100*365*24*time.Hour)
+	test.AssertNotError(t, err, "validating good crl")
+
+	err = Validate(crl, issuer, 0)
+	test.AssertError(t, err, "validating too-old crl")
+	test.AssertContains(t, err.Error(), "in the past")
+
+	issuer2, err := issuance.LoadCertificate("../../test/hierarchy/int-r3.cert.pem")
+	test.AssertNotError(t, err, "loading test issuer")
+	err = Validate(crl, issuer2, 100*365*24*time.Hour)
+	test.AssertError(t, err, "validating crl from wrong issuer")
+	test.AssertContains(t, err.Error(), "signature")
+
+	crl.Number = nil
+	err = Validate(crl, issuer, 100*365*24*time.Hour)
+	test.AssertError(t, err, "validaint crl with lint error")
+	test.AssertContains(t, err.Error(), "linting")
+}
+
+func TestDiff(t *testing.T) {
+	issuer, signer, err := issuance.LoadIssuer(issuance.IssuerLoc{
+		File:     "../../test/hierarchy/int-e1.key.pem",
+		CertFile: "../../test/hierarchy/int-e1.cert.pem",
+	})
+	test.AssertNotError(t, err, "loading test issuer")
+
+	now := time.Now()
+	template := crl_x509.RevocationList{
+		ThisUpdate: now,
+		NextUpdate: now.Add(24 * time.Hour),
+		Number:     big.NewInt(1),
+		RevokedCertificates: []crl_x509.RevokedCertificate{
+			{
+				SerialNumber:   big.NewInt(1),
+				RevocationTime: now.Add(-time.Hour),
+			},
+			{
+				SerialNumber:   big.NewInt(2),
+				RevocationTime: now.Add(-time.Hour),
+			},
+		},
+	}
+
+	oldCRLDER, err := crl_x509.CreateRevocationList(rand.Reader, &template, issuer.Certificate, signer)
+	test.AssertNotError(t, err, "creating old crl")
+	oldCRL, err := crl_x509.ParseRevocationList(oldCRLDER)
+	test.AssertNotError(t, err, "parsing old crl")
+
+	now = now.Add(time.Hour)
+	template = crl_x509.RevocationList{
+		ThisUpdate: now,
+		NextUpdate: now.Add(24 * time.Hour),
+		Number:     big.NewInt(2),
+		RevokedCertificates: []crl_x509.RevokedCertificate{
+			{
+				SerialNumber:   big.NewInt(1),
+				RevocationTime: now.Add(-2 * time.Hour),
+			},
+			{
+				SerialNumber:   big.NewInt(3),
+				RevocationTime: now.Add(-time.Hour),
+			},
+		},
+	}
+
+	newCRLDER, err := crl_x509.CreateRevocationList(rand.Reader, &template, issuer.Certificate, signer)
+	test.AssertNotError(t, err, "creating old crl")
+	newCRL, err := crl_x509.ParseRevocationList(newCRLDER)
+	test.AssertNotError(t, err, "parsing old crl")
+
+	res, err := Diff(oldCRL, newCRL)
+	test.AssertNotError(t, err, "diffing crls")
+	test.AssertEquals(t, len(res.Added), 1)
+	test.AssertEquals(t, len(res.Removed), 1)
+}


### PR DESCRIPTION
Move Validate into a library, and add a Diff method, so that various
binaries can easily check and compare CRLs.

Fixes #6433