### PR TITLE
RA: Use OCSPGenerator gRPC service

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -54,9 +54,10 @@ type certificateAuthorityImpl struct {
 	capb.UnimplementedOCSPGeneratorServer
 	sa      sapb.StorageAuthorityCertificateClient
 	pa      core.PolicyAuthority
-	ocsp    *ocspImpl
-	crl     *crlImpl
 	issuers issuerMaps
+	// TODO(#6448): Remove these.
+	ocsp *ocspImpl
+	crl  *crlImpl
 
 	// This is temporary, and will be used for testing and slow roll-out
 	// of ECDSA issuance, but will then be removed.
@@ -580,6 +581,7 @@ func (ca *certificateAuthorityImpl) integrateOrphan() error {
 // GenerateOCSP is simply a passthrough to ocspImpl.GenerateOCSP so that other
 // services which need to talk to the CA anyway can do so without configuring
 // two separate gRPC service backends.
+// TODO(#6448): Remove this passthrough to fully separate the services.
 func (ca *certificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	return ca.ocsp.GenerateOCSP(ctx, req)
 }
@@ -587,6 +589,7 @@ func (ca *certificateAuthorityImpl) GenerateOCSP(ctx context.Context, req *capb.
 // GenerateCRL is simply a passthrough to crlImpl.GenerateCRL so that other
 // services which need to talk to the CA anyway can do so without configuring
 // two separate gRPC service backends.
+// TODO(#6448): Remove this passthrough to fully separate the services.
 func (ca *certificateAuthorityImpl) GenerateCRL(stream capb.CertificateAuthority_GenerateCRLServer) error {
 	return ca.crl.GenerateCRL(stream)
 }

--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -39,11 +39,11 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type mockCA struct {
+type mockOCSPA struct {
 	mocks.MockCA
 }
 
-func (ca *mockCA) GenerateOCSP(context.Context, *capb.GenerateOCSPRequest, ...grpc.CallOption) (*capb.OCSPResponse, error) {
+func (ca *mockOCSPA) GenerateOCSP(context.Context, *capb.GenerateOCSPRequest, ...grpc.CallOption) (*capb.OCSPResponse, error) {
 	return &capb.OCSPResponse{Response: []byte("fakeocspbytes")}, nil
 }
 
@@ -484,7 +484,7 @@ func setup(t *testing.T) testCtx {
 		[]*issuance.Certificate{issuer},
 	)
 	ra.SA = isa.SA{Impl: ssa}
-	ra.CA = &mockCA{}
+	ra.OCSP = &mockOCSPA{}
 	rac := ira.RA{Impl: ra}
 
 	return testCtx{

--- a/cmd/orphan-finder/main_test.go
+++ b/cmd/orphan-finder/main_test.go
@@ -98,9 +98,9 @@ func (m *mockSA) AddSerial(ctx context.Context, req *sapb.AddSerialRequest, _ ..
 	return &emptypb.Empty{}, nil
 }
 
-type mockCA struct{}
+type mockOCSPA struct{}
 
-func (ca *mockCA) GenerateOCSP(context.Context, *capb.GenerateOCSPRequest, ...grpc.CallOption) (*capb.OCSPResponse, error) {
+func (ca *mockOCSPA) GenerateOCSP(context.Context, *capb.GenerateOCSPRequest, ...grpc.CallOption) (*capb.OCSPResponse, error) {
 	return &capb.OCSPResponse{
 		Response: []byte("HI"),
 	}, nil
@@ -127,7 +127,7 @@ func TestParseLine(t *testing.T) {
 
 	opf := &orphanFinder{
 		sa:       &mockSA{},
-		ca:       &mockCA{},
+		ca:       &mockOCSPA{},
 		logger:   blog.UseMock(),
 		issuers:  map[issuance.IssuerNameID]*issuance.Certificate{issuer.NameID(): issuer},
 		backdate: time.Hour,
@@ -289,7 +289,7 @@ func TestNotOrphan(t *testing.T) {
 	ctx := context.Background()
 	opf := &orphanFinder{
 		sa:       &mockSA{},
-		ca:       &mockCA{},
+		ca:       &mockOCSPA{},
 		logger:   blog.UseMock(),
 		backdate: time.Hour,
 	}

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -21,7 +21,8 @@
       "clientNames": [
         "health-checker.boulder",
         "ocsp-updater.boulder",
-        "orphan-finder.boulder"
+        "orphan-finder.boulder",
+        "ra.boulder"
       ]
     },
     "grpcCRLGenerator": {

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -21,7 +21,8 @@
       "clientNames": [
         "health-checker.boulder",
         "ocsp-updater.boulder",
-        "orphan-finder.boulder"
+        "orphan-finder.boulder",
+        "ra.boulder"
       ]
     },
     "grpcCRLGenerator": {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -40,6 +40,14 @@
       "timeout": "15s",
       "hostOverride": "ca.boulder"
     },
+    "ocspService": {
+      "srvLookup": {
+        "service": "ca-ocsp",
+        "domain": "service.consul"
+      },
+      "timeout": "15s",
+      "hostOverride": "ca.boulder"
+    },
     "publisherService": {
       "srvLookup": {
         "service": "publisher",


### PR DESCRIPTION
When the RA is generating OCSP (as part of new issuance, revocation,
or when its own GenerateOCSP method is called by the ocsp-responder)
have it use the CA's dedicated OCSPGenerator service, rather than
calling the method exposed by the CA's catch-all CertificateAuthority
service. To facilitate this, add a new GRPCClientConfig stanza to the RA.

This change will allow us to remove the GenerateOCSP and GenerateCRL
methods from the catch-all CertificateAuthority service, allowing us to
independently control which kinds of objects the CA is willing to sign by
turning off individual service interfaces. The RA's new config stanza will
need to be populated in prod before further changes are possible.

Fixes #6451