### PR TITLE
Streamline gRPC server creation

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -3,16 +3,12 @@ package notmain
 import (
 	"flag"
 	"fmt"
-	"net"
 	"os"
 	"sync"
 
 	"github.com/beeker1121/goque"
 	"github.com/honeycombio/beeline-go"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/letsencrypt/boulder/ca"
 	capb "github.com/letsencrypt/boulder/ca/proto"
@@ -262,8 +258,8 @@ func main() {
 
 	}
 
-	serverMetrics := bgrpc.NewServerMetrics(scope)
 	var wg sync.WaitGroup
+	stopFns := make([]func(), 0)
 
 	ocspi, err := ca.NewOCSPImpl(
 		boulderIssuers,
@@ -279,17 +275,16 @@ func main() {
 	cmd.FailOnError(err, "Failed to create OCSP impl")
 	go ocspi.LogOCSPLoop()
 
-	ocspSrv, ocspListener, err := bgrpc.NewServer(c.CA.GRPCOCSPGenerator, tlsConfig, serverMetrics, clk)
+	ocspStart, ocspStop, err := bgrpc.Server[capb.OCSPGeneratorServer]{}.Setup(
+		c.CA.GRPCOCSPGenerator, ocspi, capb.RegisterOCSPGeneratorServer, tlsConfig, scope, clk,
+	)
 	cmd.FailOnError(err, "Unable to setup CA OCSP gRPC server")
-	capb.RegisterOCSPGeneratorServer(ocspSrv, ocspi)
-	ocspHealth := health.NewServer()
-	healthpb.RegisterHealthServer(ocspSrv, ocspHealth)
 	wg.Add(1)
 	go func() {
-		cmd.FailOnError(cmd.FilterShutdownErrors(ocspSrv.Serve(ocspListener)),
-			"OCSPGenerator gRPC service failed")
+		cmd.FailOnError(ocspStart(), "OCSPGenerator gRPC service failed")
 		wg.Done()
 	}()
+	stopFns = append(stopFns, ocspStop)
 
 	crli, err := ca.NewCRLImpl(
 		boulderIssuers,
@@ -299,26 +294,16 @@ func main() {
 	)
 	cmd.FailOnError(err, "Failed to create CRL impl")
 
-	// TODO(#6161): Make this unconditional after this config is deployed. We have
-	// to pre-declare crlListener even though it is only used inside the if block
-	// so that the other assignments inside the block don't shadow crlSrv and
-	// crlHealth, leaving them nil.
-	var crlSrv *grpc.Server
-	var crlHealth *health.Server
-	var crlListener net.Listener
-	if c.CA.GRPCCRLGenerator != nil {
-		crlSrv, crlListener, err = bgrpc.NewServer(c.CA.GRPCCRLGenerator, tlsConfig, serverMetrics, clk)
-		cmd.FailOnError(err, "Unable to setup CA CRL gRPC server")
-		capb.RegisterCRLGeneratorServer(crlSrv, crli)
-		crlHealth = health.NewServer()
-		healthpb.RegisterHealthServer(crlSrv, crlHealth)
-		wg.Add(1)
-		go func() {
-			cmd.FailOnError(cmd.FilterShutdownErrors(crlSrv.Serve(crlListener)),
-				"CRLGenerator gRPC service failed")
-			wg.Done()
-		}()
-	}
+	crlStart, crlStop, err := bgrpc.Server[capb.CRLGeneratorServer]{}.Setup(
+		c.CA.GRPCCRLGenerator, crli, capb.RegisterCRLGeneratorServer, tlsConfig, scope, clk,
+	)
+	cmd.FailOnError(err, "Unable to setup CA CRL gRPC server")
+	wg.Add(1)
+	go func() {
+		cmd.FailOnError(crlStart(), "CRLGenerator gRPC service failed")
+		wg.Done()
+	}()
+	stopFns = append(stopFns, crlStop)
 
 	cai, err := ca.NewCertificateAuthorityImpl(
 		sa,
@@ -344,30 +329,21 @@ func main() {
 		go cai.OrphanIntegrationLoop()
 	}
 
-	caSrv, caListener, err := bgrpc.NewServer(c.CA.GRPCCA, tlsConfig, serverMetrics, clk)
+	caStart, caStop, err := bgrpc.Server[capb.CertificateAuthorityServer]{}.Setup(
+		c.CA.GRPCCA, cai, capb.RegisterCertificateAuthorityServer, tlsConfig, scope, clk,
+	)
 	cmd.FailOnError(err, "Unable to setup CA gRPC server")
-	capb.RegisterCertificateAuthorityServer(caSrv, cai)
-	caHealth := health.NewServer()
-	healthpb.RegisterHealthServer(caSrv, caHealth)
 	wg.Add(1)
 	go func() {
-		cmd.FailOnError(cmd.FilterShutdownErrors(caSrv.Serve(caListener)), "CA gRPC service failed")
+		cmd.FailOnError(caStart(), "CA gRPC service failed")
 		wg.Done()
 	}()
+	stopFns = append(stopFns, caStop)
 
 	go cmd.CatchSignals(logger, func() {
-		caHealth.Shutdown()
-		ocspHealth.Shutdown()
-		// TODO(#6161): Make this unconditional.
-		if crlHealth != nil {
-			crlHealth.Shutdown()
-		}
 		ecdsaAllowList.Stop()
-		caSrv.GracefulStop()
-		ocspSrv.GracefulStop()
-		// TODO(#6161): Make this unconditional.
-		if crlSrv != nil {
-			crlSrv.GracefulStop()
+		for _, stopFn := range stopFns {
+			stopFn()
 		}
 		wg.Wait()
 		ocspi.Stop()

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"time"
 
-	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-
 	"github.com/honeycombio/beeline-go"
 	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
 	capb "github.com/letsencrypt/boulder/ca/proto"
@@ -281,20 +278,13 @@ func main() {
 	rai.CA = cac
 	rai.SA = sac
 
-	serverMetrics := bgrpc.NewServerMetrics(scope)
-	grpcSrv, listener, err := bgrpc.NewServer(c.RA.GRPC, tlsConfig, serverMetrics, clk)
+	start, stop, err := bgrpc.Server[rapb.RegistrationAuthorityServer]{}.Setup(
+		c.RA.GRPC, rai, rapb.RegisterRegistrationAuthorityServer, tlsConfig, scope, clk,
+	)
 	cmd.FailOnError(err, "Unable to setup RA gRPC server")
-	rapb.RegisterRegistrationAuthorityServer(grpcSrv, rai)
-	hs := health.NewServer()
-	healthpb.RegisterHealthServer(grpcSrv, hs)
 
-	go cmd.CatchSignals(logger, func() {
-		hs.Shutdown()
-		grpcSrv.GracefulStop()
-	})
-
-	err = cmd.FilterShutdownErrors(grpcSrv.Serve(listener))
-	cmd.FailOnError(err, "RA gRPC service failed")
+	go cmd.CatchSignals(logger, stop)
+	cmd.FailOnError(start(), "RA gRPC service failed")
 }
 
 func init() {

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -184,8 +184,7 @@ func main() {
 		c.VA.AccountURIPrefixes)
 	cmd.FailOnError(err, "Unable to create VA server")
 
-	serverMetrics := bgrpc.NewServerMetrics(scope)
-	grpcSrv, l, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, serverMetrics, clk)
+	grpcSrv, l, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup VA gRPC server")
 	vapb.RegisterVAServer(grpcSrv, vai)
 	cmd.FailOnError(err, "Unable to register VA gRPC server")

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -63,10 +63,6 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, metrics clientM
 	)
 }
 
-type registry interface {
-	MustRegister(...prometheus.Collector)
-}
-
 // clientMetrics is a struct type used to return registered metrics from
 // `NewClientMetrics`
 type clientMetrics struct {
@@ -77,20 +73,26 @@ type clientMetrics struct {
 }
 
 // NewClientMetrics constructs a *grpc_prometheus.ClientMetrics, registered with
-// the given registry, with timing histogram enabled. It must be called a
-// maximum of once per registry, or there will be conflicting names.
-func NewClientMetrics(stats registry) clientMetrics {
+// the given registry, with timing histogram enabled. If called more than once
+// on a single registry, it will gracefully avoid registering duplicate metrics.
+func NewClientMetrics(stats prometheus.Registerer) clientMetrics {
 	// Create the grpc prometheus client metrics instance and register it
 	grpcMetrics := grpc_prometheus.NewClientMetrics()
 	grpcMetrics.EnableClientHandlingTimeHistogram()
-	stats.MustRegister(grpcMetrics)
+	err := stats.Register(grpcMetrics)
+	if err != nil && !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+		panic(err)
+	}
 
 	// Create a gauge to track in-flight RPCs and register it.
 	inFlightGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "grpc_in_flight",
 		Help: "Number of in-flight (sent, not yet completed) RPCs",
 	}, []string{"method", "service"})
-	stats.MustRegister(inFlightGauge)
+	err = stats.Register(inFlightGauge)
+	if err != nil && !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+		panic(err)
+	}
 
 	return clientMetrics{
 		grpcMetrics:  grpcMetrics,

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -29,7 +29,7 @@ func (s *errorServer) Chill(_ context.Context, _ *test_proto.Time) (*test_proto.
 }
 
 func TestErrorWrapping(t *testing.T) {
-	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
+	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
 	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
@@ -69,7 +69,7 @@ func TestErrorWrapping(t *testing.T) {
 // TestSubErrorWrapping tests that a boulder error with suberrors can be
 // correctly wrapped and unwrapped across the RPC layer.
 func TestSubErrorWrapping(t *testing.T) {
-	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
+	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
 	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -29,7 +29,8 @@ func (s *errorServer) Chill(_ context.Context, _ *test_proto.Time) (*test_proto.
 }
 
 func TestErrorWrapping(t *testing.T) {
-	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
+	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "creating server metrics")
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
 	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
@@ -69,7 +70,8 @@ func TestErrorWrapping(t *testing.T) {
 // TestSubErrorWrapping tests that a boulder error with suberrors can be
 // correctly wrapped and unwrapped across the RPC layer.
 func TestSubErrorWrapping(t *testing.T) {
-	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
+	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "creating server metrics")
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	ci := clientInterceptor{time.Second, NewClientMetrics(metrics.NoopRegisterer), clock.NewFake()}
 	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -50,7 +50,7 @@ func testInvoker(_ context.Context, method string, _, _ interface{}, _ *grpc.Cli
 }
 
 func TestServerInterceptor(t *testing.T) {
-	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
+	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 
 	md := metadata.New(map[string]string{clientRequestTimeKey: "0"})
@@ -153,7 +153,7 @@ func TestTimeouts(t *testing.T) {
 	}
 	port := lis.Addr().(*net.TCPAddr).Port
 
-	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
+	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	test_proto.RegisterChillerServer(s, &testServer{})
@@ -214,7 +214,7 @@ func TestRequestTimeTagging(t *testing.T) {
 	port := lis.Addr().(*net.TCPAddr).Port
 
 	// Create a new ChillerServer
-	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
+	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clk)
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	test_proto.RegisterChillerServer(s, &testServer{})
@@ -300,7 +300,7 @@ func TestInFlightRPCStat(t *testing.T) {
 	numRPCs := 5
 	server.received.Add(numRPCs)
 
-	serverMetrics := NewServerMetrics(metrics.NoopRegisterer)
+	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
 	si := newServerInterceptor(serverMetrics, clk)
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	test_proto.RegisterChillerServer(s, server)

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -50,13 +50,14 @@ func testInvoker(_ context.Context, method string, _, _ interface{}, _ *grpc.Cli
 }
 
 func TestServerInterceptor(t *testing.T) {
-	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
+	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "creating server metrics")
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 
 	md := metadata.New(map[string]string{clientRequestTimeKey: "0"})
 	ctxWithMetadata := metadata.NewIncomingContext(context.Background(), md)
 
-	_, err := si.interceptUnary(context.Background(), nil, nil, testHandler)
+	_, err = si.interceptUnary(context.Background(), nil, nil, testHandler)
 	test.AssertError(t, err, "si.intercept didn't fail with a context missing metadata")
 
 	_, err = si.interceptUnary(ctxWithMetadata, nil, nil, testHandler)
@@ -153,7 +154,8 @@ func TestTimeouts(t *testing.T) {
 	}
 	port := lis.Addr().(*net.TCPAddr).Port
 
-	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
+	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "creating server metrics")
 	si := newServerInterceptor(serverMetrics, clock.NewFake())
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	test_proto.RegisterChillerServer(s, &testServer{})
@@ -214,7 +216,8 @@ func TestRequestTimeTagging(t *testing.T) {
 	port := lis.Addr().(*net.TCPAddr).Port
 
 	// Create a new ChillerServer
-	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
+	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "creating server metrics")
 	si := newServerInterceptor(serverMetrics, clk)
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	test_proto.RegisterChillerServer(s, &testServer{})
@@ -300,7 +303,8 @@ func TestInFlightRPCStat(t *testing.T) {
 	numRPCs := 5
 	server.received.Add(numRPCs)
 
-	serverMetrics := newServerMetrics(metrics.NoopRegisterer)
+	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "creating server metrics")
 	si := newServerInterceptor(serverMetrics, clk)
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
 	test_proto.RegisterChillerServer(s, server)


### PR DESCRIPTION
Collapse most of our boilerplate gRPC creation steps (in particular,
creating default metrics, making the server and listener, registering
the server, creating and registering the health service, filtering
shutdown errors from the output, and gracefully stopping) into a single
function in the existing bgrpc package. This allows all but one of our
server main functions to drop their calls to NewServer and
NewServerMetrics.

To enable this, create a new helper type and method in the bgrpc
package. Conceptually, this could be just a new function, but it must be
attached to a new type so that it can be generic over the type of gRPC
server being created. (Unfortunately, the grpc.RegisterFooServer methods
do not accept an interface type for their second argument).

The only main function which is not updated is the boulder-va, which is
a special case because it creates multiple gRPC servers but (unlike the
CA) serves them all on the same port with the same server and listener.

Part of #6452