### PR TITLE
ROCSP: Catch correct live-signing NotFound error

### DIFF
--- a/ocsp/responder/redis/redis_source.go
+++ b/ocsp/responder/redis/redis_source.go
@@ -154,7 +154,7 @@ const (
 func (src *redisSource) signAndSave(ctx context.Context, req *ocsp.Request, cause signAndSaveCause) (*responder.Response, error) {
 	resp, err := src.signer.Response(ctx, req)
 	if err != nil {
-		if errors.Is(err, rocsp.ErrRedisNotFound) {
+		if errors.Is(err, responder.ErrNotFound) {
 			src.signAndSaveCounter.WithLabelValues(string(cause), "certificate_not_found").Inc()
 			return nil, responder.ErrNotFound
 		}


### PR DESCRIPTION
Previously, the live-signing routine was lookking for `rocsp.ErrRedisNotFound` errors in order to increment the `certificate_not_found` metrics. But this was a bug, copy-pasted from code higher in the file that does a similar check. The live-signing code actually returns `responder.ErrNotFound`. Check for that error instead, to properly increment our metrics.