### PR TITLE
CA: Add configs to disable each gRPC service

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -56,8 +56,8 @@ type certificateAuthorityImpl struct {
 	pa      core.PolicyAuthority
 	issuers issuerMaps
 	// TODO(#6448): Remove these.
-	ocsp *ocspImpl
-	crl  *crlImpl
+	ocsp capb.OCSPGeneratorServer
+	crl  capb.CRLGeneratorServer
 
 	// This is temporary, and will be used for testing and slow roll-out
 	// of ECDSA issuance, but will then be removed.
@@ -102,8 +102,8 @@ func makeIssuerMaps(issuers []*issuance.Issuer) issuerMaps {
 func NewCertificateAuthorityImpl(
 	sa sapb.StorageAuthorityCertificateClient,
 	pa core.PolicyAuthority,
-	ocsp *ocspImpl,
-	crl *crlImpl,
+	ocsp capb.OCSPGeneratorServer,
+	crl capb.CRLGeneratorServer,
 	boulderIssuers []*issuance.Issuer,
 	ecdsaAllowList *ECDSAAllowList,
 	certExpiry time.Duration,

--- a/ca/crl.go
+++ b/ca/crl.go
@@ -281,3 +281,19 @@ func makeIDPExt(base string, issuer issuance.IssuerNameID, shardIdx int64) (*pki
 		Critical: true,
 	}, nil
 }
+
+// disabledCRLImpl implements the capb.CRLGeneratorServer interface, but returns
+// an error for all gRPC methods. This is only used to replace a real impl when
+// the CRLGenerator service is disabled.
+// TODO(#6448): Remove this.
+type disabledCRLImpl struct {
+	capb.UnimplementedCRLGeneratorServer
+}
+
+func NewDisabledCRLImpl() *disabledCRLImpl {
+	return &disabledCRLImpl{}
+}
+
+func (ci *disabledCRLImpl) GenerateCRL(stream capb.CRLGenerator_GenerateCRLServer) error {
+	return errors.New("the CRLGenerator gRPC service is disabled")
+}

--- a/ca/crl.go
+++ b/ca/crl.go
@@ -291,7 +291,7 @@ type disabledCRLImpl struct {
 }
 
 // NewDiabledCRLImpl returns an object which implements the
-// capb.CRLGeneratorServer interface but alwasy returns errors.
+// capb.CRLGeneratorServer interface but always returns errors.
 func NewDisabledCRLImpl() *disabledCRLImpl {
 	return &disabledCRLImpl{}
 }

--- a/ca/crl.go
+++ b/ca/crl.go
@@ -290,10 +290,13 @@ type disabledCRLImpl struct {
 	capb.UnimplementedCRLGeneratorServer
 }
 
+// NewDiabledCRLImpl returns an object which implements the
+// capb.CRLGeneratorServer interface but alwasy returns errors.
 func NewDisabledCRLImpl() *disabledCRLImpl {
 	return &disabledCRLImpl{}
 }
 
+// GenerateCRL always returns an error because the service is disabled.
 func (ci *disabledCRLImpl) GenerateCRL(stream capb.CRLGenerator_GenerateCRLServer) error {
 	return errors.New("the CRLGenerator gRPC service is disabled")
 }

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -279,16 +279,21 @@ type disabledOCSPImpl struct {
 	capb.UnimplementedOCSPGeneratorServer
 }
 
+// NewDisabledOCSPImpl returns an object which implements the
+// capb.OCSPGeneratorServer interface, but always returns errors.
 func NewDisabledOCSPImpl() *disabledOCSPImpl {
 	return &disabledOCSPImpl{}
 }
 
+// GenerateOCSP always returns an error because the service is disabled.
 func (oi *disabledOCSPImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	return nil, errors.New("the OCSPGenerator gRPC service is disabled")
 }
 
+// LogOCSPLoop is an no-op because there is no OCSP issuance to be logged.
 func (oi *disabledOCSPImpl) LogOCSPLoop() {}
 
+// Stop is a no-op because there is no log loop to be stopped.
 func (oi *disabledOCSPImpl) Stop() {}
 
 // OCSPGenerator is an interface met by both the ocspImpl and disabledOCSPImpl

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -100,6 +100,16 @@ type Config struct {
 		// not end with a slash. Example: "http://prod.c.lencr.org".
 		CRLDPBase string
 
+		// DisableCertService causes the CertificateAuthority gRPC service to not
+		// start, preventing any certificates or precertificates from being issued.
+		DisableCertService bool
+		// DisableCertService causes the OCSPGenerator gRPC service to not start,
+		// preventing any OCSP responses from being issued.
+		DisableOCSPService bool
+		// DisableCRLService causes the CRLGenerator gRPC service to not start,
+		// preventing any CRLs from being issued.
+		DisableCRLService bool
+
 		Features map[string]bool
 	}
 
@@ -261,85 +271,102 @@ func main() {
 	var wg sync.WaitGroup
 	stopFns := make([]func(), 0)
 
-	ocspi, err := ca.NewOCSPImpl(
-		boulderIssuers,
-		c.CA.LifespanOCSP.Duration,
-		c.CA.OCSPLogMaxLength,
-		c.CA.OCSPLogPeriod.Duration,
-		logger,
-		scope,
-		signatureCount,
-		signErrorCount,
-		clk,
-	)
-	cmd.FailOnError(err, "Failed to create OCSP impl")
-	go ocspi.LogOCSPLoop()
+	// TODO(#6448): Remove this predeclaration when NewCertificateAuthorityImpl
+	// no longer needs ocspi as an argument.
+	var ocspi ca.OCSPGenerator
+	if !c.CA.DisableOCSPService {
+		ocspiReal, err := ca.NewOCSPImpl(
+			boulderIssuers,
+			c.CA.LifespanOCSP.Duration,
+			c.CA.OCSPLogMaxLength,
+			c.CA.OCSPLogPeriod.Duration,
+			logger,
+			scope,
+			signatureCount,
+			signErrorCount,
+			clk,
+		)
+		cmd.FailOnError(err, "Failed to create OCSP impl")
+		go ocspiReal.LogOCSPLoop()
 
-	ocspStart, ocspStop, err := bgrpc.Server[capb.OCSPGeneratorServer]{}.Setup(
-		c.CA.GRPCOCSPGenerator, ocspi, capb.RegisterOCSPGeneratorServer, tlsConfig, scope, clk,
-	)
-	cmd.FailOnError(err, "Unable to setup CA OCSP gRPC server")
-	wg.Add(1)
-	go func() {
-		cmd.FailOnError(ocspStart(), "OCSPGenerator gRPC service failed")
-		wg.Done()
-	}()
-	stopFns = append(stopFns, ocspStop)
-
-	crli, err := ca.NewCRLImpl(
-		boulderIssuers,
-		c.CA.LifespanCRL.Duration,
-		c.CA.CRLDPBase,
-		c.CA.OCSPLogMaxLength,
-		logger,
-	)
-	cmd.FailOnError(err, "Failed to create CRL impl")
-
-	crlStart, crlStop, err := bgrpc.Server[capb.CRLGeneratorServer]{}.Setup(
-		c.CA.GRPCCRLGenerator, crli, capb.RegisterCRLGeneratorServer, tlsConfig, scope, clk,
-	)
-	cmd.FailOnError(err, "Unable to setup CA CRL gRPC server")
-	wg.Add(1)
-	go func() {
-		cmd.FailOnError(crlStart(), "CRLGenerator gRPC service failed")
-		wg.Done()
-	}()
-	stopFns = append(stopFns, crlStop)
-
-	cai, err := ca.NewCertificateAuthorityImpl(
-		sa,
-		pa,
-		ocspi,
-		crli,
-		boulderIssuers,
-		ecdsaAllowList,
-		c.CA.Expiry.Duration,
-		c.CA.Backdate.Duration,
-		c.CA.SerialPrefix,
-		c.CA.MaxNames,
-		kp,
-		orphanQueue,
-		logger,
-		scope,
-		signatureCount,
-		signErrorCount,
-		clk)
-	cmd.FailOnError(err, "Failed to create CA impl")
-
-	if orphanQueue != nil {
-		go cai.OrphanIntegrationLoop()
+		ocspStart, ocspStop, err := bgrpc.Server[capb.OCSPGeneratorServer]{}.Setup(
+			c.CA.GRPCOCSPGenerator, ocspiReal, capb.RegisterOCSPGeneratorServer, tlsConfig, scope, clk,
+		)
+		cmd.FailOnError(err, "Unable to setup CA OCSP gRPC server")
+		wg.Add(1)
+		go func() {
+			cmd.FailOnError(ocspStart(), "OCSPGenerator gRPC service failed")
+			wg.Done()
+		}()
+		stopFns = append(stopFns, ocspStop)
+		ocspi = ca.OCSPGenerator(ocspiReal)
+	} else {
+		ocspi = ca.NewDisabledOCSPImpl()
 	}
 
-	caStart, caStop, err := bgrpc.Server[capb.CertificateAuthorityServer]{}.Setup(
-		c.CA.GRPCCA, cai, capb.RegisterCertificateAuthorityServer, tlsConfig, scope, clk,
-	)
-	cmd.FailOnError(err, "Unable to setup CA gRPC server")
-	wg.Add(1)
-	go func() {
-		cmd.FailOnError(caStart(), "CA gRPC service failed")
-		wg.Done()
-	}()
-	stopFns = append(stopFns, caStop)
+	// TODO(#6448): Remove this predeclaration when NewCertificateAuthorityImpl
+	// no longer needs crli as an argument.
+	var crli capb.CRLGeneratorServer
+	if !c.CA.DisableCRLService {
+		crli, err = ca.NewCRLImpl(
+			boulderIssuers,
+			c.CA.LifespanCRL.Duration,
+			c.CA.CRLDPBase,
+			c.CA.OCSPLogMaxLength,
+			logger,
+		)
+		cmd.FailOnError(err, "Failed to create CRL impl")
+
+		crlStart, crlStop, err := bgrpc.Server[capb.CRLGeneratorServer]{}.Setup(
+			c.CA.GRPCCRLGenerator, crli, capb.RegisterCRLGeneratorServer, tlsConfig, scope, clk,
+		)
+		cmd.FailOnError(err, "Unable to setup CA CRL gRPC server")
+		wg.Add(1)
+		go func() {
+			cmd.FailOnError(crlStart(), "CRLGenerator gRPC service failed")
+			wg.Done()
+		}()
+		stopFns = append(stopFns, crlStop)
+	} else {
+		crli = ca.NewDisabledCRLImpl()
+	}
+
+	if !c.CA.DisableCertService {
+		cai, err := ca.NewCertificateAuthorityImpl(
+			sa,
+			pa,
+			ocspi,
+			crli,
+			boulderIssuers,
+			ecdsaAllowList,
+			c.CA.Expiry.Duration,
+			c.CA.Backdate.Duration,
+			c.CA.SerialPrefix,
+			c.CA.MaxNames,
+			kp,
+			orphanQueue,
+			logger,
+			scope,
+			signatureCount,
+			signErrorCount,
+			clk)
+		cmd.FailOnError(err, "Failed to create CA impl")
+
+		if orphanQueue != nil {
+			go cai.OrphanIntegrationLoop()
+		}
+
+		caStart, caStop, err := bgrpc.Server[capb.CertificateAuthorityServer]{}.Setup(
+			c.CA.GRPCCA, cai, capb.RegisterCertificateAuthorityServer, tlsConfig, scope, clk,
+		)
+		cmd.FailOnError(err, "Unable to setup CA gRPC server")
+		wg.Add(1)
+		go func() {
+			cmd.FailOnError(caStart(), "CA gRPC service failed")
+			wg.Done()
+		}()
+		stopFns = append(stopFns, caStop)
+	}
 
 	go cmd.CatchSignals(logger, func() {
 		ecdsaAllowList.Stop()
@@ -347,7 +374,6 @@ func main() {
 			stopFn()
 		}
 		wg.Wait()
-		ocspi.Stop()
 	})
 
 	select {}


### PR DESCRIPTION
Add three new boolean config keys to the CA's config json:
- DisableCertService
- DisableOCSPService
- DisableCRLService

Setting any one of these flags to True and restarting the CA causes the corresponding gRPC service (CertificateAuthority, OCSPGenerator, or CRLGenerator, respectively) to not be started. The implementation is not instantiated, the port is not opened, and no requests will be listened for. All clients will receive failures to connect.

Also, create two temporary "dummy" implementations of the CRL and OCSP services (and an interface for the fake OCSP service to meet), These are necessary because the CertificateAuthority gRPC service currently contains wrapper methods which replicate the methods of the OCSP and CRL services, and which pass through calls to underlying implementation objects. These objects must be replaced with fake objects which always return an error when the service is disabled.

Fixes #6452