### PR TITLE
ct-test-srv should print the logID

### DIFF
--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -234,8 +235,9 @@ func runPersonality(p Personality) {
 		Addr:    p.Addr,
 		Handler: m,
 	}
-	log.Printf("ct-test-srv on %s with pubkey %s", p.Addr,
-		base64.StdEncoding.EncodeToString(pubKeyBytes))
+	logID := sha256.Sum256(pubKeyBytes)
+	log.Printf("ct-test-srv on %s with pubkey %s and log ID %s", p.Addr,
+		base64.StdEncoding.EncodeToString(pubKeyBytes), base64.StdEncoding.EncodeToString(logID[:]))
 	log.Fatal(srv.ListenAndServe())
 }
 


### PR DESCRIPTION
When using `ct-test-srv` with Boulder infrastructure, it's important now that the logIDs are correctly configured. This is a nice-to-have that prints the logID for the provided EC privkey on startup, the same way that `ct-test-srv` prints the EC pubkey.