### PR TITLE
Add interceptor for per-rpc client auth

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -389,19 +389,33 @@ func (c *GRPCClientConfig) MakeTargetAndHostOverride() (string, string, error) {
 	}
 }
 
-// GRPCServerConfig contains the information needed to run a gRPC service
+// GRPCServerConfig contains the information needed to start a gRPC server.
 type GRPCServerConfig struct {
 	Address string `json:"address"`
 	// ClientNames is a list of allowed client certificate subject alternate names
 	// (SANs). The server will reject clients that do not present a certificate
 	// with a SAN present on the `ClientNames` list.
+	// DEPRECATED: Use the ClientNames field within each Service instead.
 	ClientNames []string `json:"clientNames"`
+	// Services is a map of service names to configuration specific to that service.
+	// These service names must match the service names advertised by gRPC itself,
+	// which are identical to the names set in our gRPC .proto files.
+	Services map[string]GRPCServiceConfig `json:"services"`
 	// MaxConnectionAge specifies how long a connection may live before the server sends a GoAway to the
 	// client. Because gRPC connections re-resolve DNS after a connection close,
 	// this controls how long it takes before a client learns about changes to its
 	// backends.
 	// https://pkg.go.dev/google.golang.org/grpc/keepalive#ServerParameters
 	MaxConnectionAge ConfigDuration
+}
+
+// GRPCServiceConfig contains the information needed to configure a gRPC service.
+type GRPCServiceConfig struct {
+	// PerServiceClientNames is a map of gRPC service names to client certificate
+	// SANs. The upstream listening server will reject connections from clients
+	// which do not appear in this list, and the server interceptor will reject
+	// RPC calls for this service from clients which are not listed here.
+	ClientNames []string `json:"clientNames"`
 }
 
 // PortConfig specifies what ports the VA should call to on the remote

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -39,17 +39,17 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, statsRegistry p
 		return nil, err
 	}
 
-	ci := clientInterceptor{c.Timeout.Duration, metrics, clk}
+	mi := clientMetadataInterceptor{c.Timeout.Duration, metrics, clk}
 
 	unaryInterceptors := append(interceptors, []grpc.UnaryClientInterceptor{
-		ci.interceptUnary,
-		ci.metrics.grpcMetrics.UnaryClientInterceptor(),
+		mi.Unary,
+		mi.metrics.grpcMetrics.UnaryClientInterceptor(),
 		hnygrpc.UnaryClientInterceptor(),
 	}...)
 
 	streamInterceptors := []grpc.StreamClientInterceptor{
-		ci.interceptStream,
-		ci.metrics.grpcMetrics.StreamClientInterceptor(),
+		mi.Stream,
+		mi.metrics.grpcMetrics.StreamClientInterceptor(),
 		// TODO(#6361): Get a tracing interceptor that works for gRPC streams.
 	}
 

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -31,11 +31,11 @@ func (s *errorServer) Chill(_ context.Context, _ *test_proto.Time) (*test_proto.
 func TestErrorWrapping(t *testing.T) {
 	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating server metrics")
-	si := newServerInterceptor(serverMetrics, clock.NewFake())
+	si := newServerMetadataInterceptor(serverMetrics, clock.NewFake())
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	ci := clientInterceptor{time.Second, clientMetrics, clock.NewFake()}
-	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
+	ci := clientMetadataInterceptor{time.Second, clientMetrics, clock.NewFake()}
+	srv := grpc.NewServer(grpc.UnaryInterceptor(si.Unary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)
 	lis, err := net.Listen("tcp", "127.0.0.1:")
@@ -46,7 +46,7 @@ func TestErrorWrapping(t *testing.T) {
 	conn, err := grpc.Dial(
 		lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.interceptUnary),
+		grpc.WithUnaryInterceptor(ci.Unary),
 	)
 	test.AssertNotError(t, err, "Failed to dial grpc test server")
 	client := test_proto.NewChillerClient(conn)
@@ -74,11 +74,11 @@ func TestErrorWrapping(t *testing.T) {
 func TestSubErrorWrapping(t *testing.T) {
 	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating server metrics")
-	si := newServerInterceptor(serverMetrics, clock.NewFake())
+	si := newServerMetadataInterceptor(serverMetrics, clock.NewFake())
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	ci := clientInterceptor{time.Second, clientMetrics, clock.NewFake()}
-	srv := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
+	ci := clientMetadataInterceptor{time.Second, clientMetrics, clock.NewFake()}
+	srv := grpc.NewServer(grpc.UnaryInterceptor(si.Unary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)
 	lis, err := net.Listen("tcp", "127.0.0.1:")
@@ -89,7 +89,7 @@ func TestSubErrorWrapping(t *testing.T) {
 	conn, err := grpc.Dial(
 		lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.interceptUnary),
+		grpc.WithUnaryInterceptor(ci.Unary),
 	)
 	test.AssertNotError(t, err, "Failed to dial grpc test server")
 	client := test_proto.NewChillerClient(conn)

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -56,37 +56,37 @@ func testInvoker(_ context.Context, method string, _, _ interface{}, _ *grpc.Cli
 func TestServerInterceptor(t *testing.T) {
 	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating server metrics")
-	si := newServerInterceptor(serverMetrics, clock.NewFake())
+	si := newServerMetadataInterceptor(serverMetrics, clock.NewFake())
 
 	md := metadata.New(map[string]string{clientRequestTimeKey: "0"})
 	ctxWithMetadata := metadata.NewIncomingContext(context.Background(), md)
 
-	_, err = si.interceptUnary(context.Background(), nil, nil, testHandler)
+	_, err = si.Unary(context.Background(), nil, nil, testHandler)
 	test.AssertError(t, err, "si.intercept didn't fail with a context missing metadata")
 
-	_, err = si.interceptUnary(ctxWithMetadata, nil, nil, testHandler)
+	_, err = si.Unary(ctxWithMetadata, nil, nil, testHandler)
 	test.AssertError(t, err, "si.intercept didn't fail with a nil grpc.UnaryServerInfo")
 
-	_, err = si.interceptUnary(ctxWithMetadata, nil, &grpc.UnaryServerInfo{FullMethod: "-service-test"}, testHandler)
+	_, err = si.Unary(ctxWithMetadata, nil, &grpc.UnaryServerInfo{FullMethod: "-service-test"}, testHandler)
 	test.AssertNotError(t, err, "si.intercept failed with a non-nil grpc.UnaryServerInfo")
 
-	_, err = si.interceptUnary(ctxWithMetadata, 0, &grpc.UnaryServerInfo{FullMethod: "brokeTest"}, testHandler)
+	_, err = si.Unary(ctxWithMetadata, 0, &grpc.UnaryServerInfo{FullMethod: "brokeTest"}, testHandler)
 	test.AssertError(t, err, "si.intercept didn't fail when handler returned a error")
 }
 
 func TestClientInterceptor(t *testing.T) {
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	ci := clientInterceptor{
+	ci := clientMetadataInterceptor{
 		timeout: time.Second,
 		metrics: clientMetrics,
 		clk:     clock.NewFake(),
 	}
 
-	err = ci.interceptUnary(context.Background(), "-service-test", nil, nil, nil, testInvoker)
+	err = ci.Unary(context.Background(), "-service-test", nil, nil, nil, testInvoker)
 	test.AssertNotError(t, err, "ci.intercept failed with a non-nil grpc.UnaryServerInfo")
 
-	err = ci.interceptUnary(context.Background(), "-service-brokeTest", nil, nil, nil, testInvoker)
+	err = ci.Unary(context.Background(), "-service-brokeTest", nil, nil, nil, testInvoker)
 	test.AssertError(t, err, "ci.intercept didn't fail when handler returned a error")
 }
 
@@ -110,7 +110,7 @@ func TestCancelTo408Interceptor(t *testing.T) {
 func TestFailFastFalse(t *testing.T) {
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	ci := &clientInterceptor{
+	ci := &clientMetadataInterceptor{
 		timeout: 100 * time.Millisecond,
 		metrics: clientMetrics,
 		clk:     clock.NewFake(),
@@ -118,7 +118,7 @@ func TestFailFastFalse(t *testing.T) {
 	conn, err := grpc.Dial("localhost:19876", // random, probably unused port
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, roundrobin.Name)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.interceptUnary))
+		grpc.WithUnaryInterceptor(ci.Unary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -165,8 +165,8 @@ func TestTimeouts(t *testing.T) {
 
 	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating server metrics")
-	si := newServerInterceptor(serverMetrics, clock.NewFake())
-	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
+	si := newServerMetadataInterceptor(serverMetrics, clock.NewFake())
+	s := grpc.NewServer(grpc.UnaryInterceptor(si.Unary))
 	test_proto.RegisterChillerServer(s, &testServer{})
 	go func() {
 		start := time.Now()
@@ -180,14 +180,14 @@ func TestTimeouts(t *testing.T) {
 	// make client
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	ci := &clientInterceptor{
+	ci := &clientMetadataInterceptor{
 		timeout: 30 * time.Second,
 		metrics: clientMetrics,
 		clk:     clock.NewFake(),
 	}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.interceptUnary))
+		grpc.WithUnaryInterceptor(ci.Unary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -229,8 +229,8 @@ func TestRequestTimeTagging(t *testing.T) {
 	// Create a new ChillerServer
 	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating server metrics")
-	si := newServerInterceptor(serverMetrics, clk)
-	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
+	si := newServerMetadataInterceptor(serverMetrics, clk)
+	s := grpc.NewServer(grpc.UnaryInterceptor(si.Unary))
 	test_proto.RegisterChillerServer(s, &testServer{})
 	// Chill until ill
 	go func() {
@@ -245,14 +245,14 @@ func TestRequestTimeTagging(t *testing.T) {
 	// Dial the ChillerServer
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	ci := &clientInterceptor{
+	ci := &clientMetadataInterceptor{
 		timeout: 30 * time.Second,
 		metrics: clientMetrics,
 		clk:     clk,
 	}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.interceptUnary))
+		grpc.WithUnaryInterceptor(ci.Unary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -318,8 +318,8 @@ func TestInFlightRPCStat(t *testing.T) {
 
 	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating server metrics")
-	si := newServerInterceptor(serverMetrics, clk)
-	s := grpc.NewServer(grpc.UnaryInterceptor(si.interceptUnary))
+	si := newServerMetadataInterceptor(serverMetrics, clk)
+	s := grpc.NewServer(grpc.UnaryInterceptor(si.Unary))
 	test_proto.RegisterChillerServer(s, server)
 	// Chill until ill
 	go func() {
@@ -334,14 +334,14 @@ func TestInFlightRPCStat(t *testing.T) {
 	// Dial the ChillerServer
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	ci := &clientInterceptor{
+	ci := &clientMetadataInterceptor{
 		timeout: 30 * time.Second,
 		metrics: clientMetrics,
 		clk:     clk,
 	}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(ci.interceptUnary))
+		grpc.WithUnaryInterceptor(ci.Unary))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestNoCancelInterceptor(t *testing.T) {
 }
 
 func TestServiceAuthChecker(t *testing.T) {
-	ac := serviceAuthChecker{
+	ac := authInterceptor{
 		map[string]map[string]struct{}{
 			"package.ServiceName": {
 				"allowed.client": {},
@@ -410,10 +410,10 @@ func TestServiceAuthChecker(t *testing.T) {
 		},
 	}
 
-	// No allowlist means all clients are allowed.
+	// No allowlist is a bad configuration.
 	ctx := context.Background()
 	err := ac.checkContextAuth(ctx, "/package.OtherService/Method/")
-	test.AssertNotError(t, err, "checking unrestricted service")
+	test.AssertError(t, err, "checking empty allowlist")
 
 	// Context with no peering information is disallowed.
 	err = ac.checkContextAuth(ctx, "/package.ServiceName/Method/")

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -95,20 +95,26 @@ func NewServer(c *cmd.GRPCServerConfig, tlsConfig *tls.Config, statsRegistry pro
 		return nil, nil, err
 	}
 
-	si := newServerInterceptor(metrics, clk)
-	ac := newServiceAuthChecker(c)
+	var ai serverInterceptor
+	if len(c.Services) > 0 {
+		ai = newServiceAuthChecker(c)
+	} else {
+		ai = &noopServerInterceptor{}
+	}
+
+	mi := newServerMetadataInterceptor(metrics, clk)
 
 	unaryInterceptors := append([]grpc.UnaryServerInterceptor{
-		ac.UnaryInterceptor(),
-		si.interceptUnary,
-		si.metrics.grpcMetrics.UnaryServerInterceptor(),
+		mi.metrics.grpcMetrics.UnaryServerInterceptor(),
+		ai.Unary,
+		mi.Unary,
 		hnygrpc.UnaryServerInterceptor(),
 	}, interceptors...)
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
-		ac.StreamInterceptor(),
-		si.interceptStream,
-		si.metrics.grpcMetrics.StreamServerInterceptor(),
+		mi.metrics.grpcMetrics.StreamServerInterceptor(),
+		ai.Stream,
+		mi.Stream,
 		// TODO(#6361): Get a tracing interceptor that works for gRPC streams.
 	}
 

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -20,10 +20,19 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9097",
-      "clientNames": [
-        "health-checker.boulder",
-        "va.boulder"
-      ]
+      "services": {
+        "va.VA": {
+          "clientNames": [
+            "health-checker.boulder",
+            "va.boulder"
+          ]
+        },
+        "va.CAA": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "features": {
       "CAAValidationMethods": true,

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -23,11 +23,13 @@
       "services": {
         "va.VA": {
           "clientNames": [
-            "health-checker.boulder",
             "va.boulder"
           ]
         },
         "va.CAA": {
+          "clientNames": []
+        },
+        "grpc.health.v1.Health": {
           "clientNames": [
             "health-checker.boulder"
           ]

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -23,11 +23,13 @@
       "services": {
         "va.VA": {
           "clientNames": [
-            "health-checker.boulder",
             "va.boulder"
           ]
         },
         "va.CAA": {
+          "clientNames": []
+        },
+        "grpc.health.v1.Health": {
           "clientNames": [
             "health-checker.boulder"
           ]

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -20,10 +20,19 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9098",
-      "clientNames": [
-        "health-checker.boulder",
-        "va.boulder"
-      ]
+      "services": {
+        "va.VA": {
+          "clientNames": [
+            "health-checker.boulder",
+            "va.boulder"
+          ]
+        },
+        "va.CAA": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "features": {
       "CAAValidationMethods": true,

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -23,14 +23,17 @@
       "services": {
         "va.VA": {
           "clientNames": [
-            "health-checker.boulder",
             "ra.boulder"
           ]
         },
         "va.CAA": {
           "clientNames": [
-            "health-checker.boulder",
             "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
           ]
         }
       }

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -20,10 +20,20 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9092",
-      "clientNames": [
-        "health-checker.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "va.VA": {
+          "clientNames": [
+            "health-checker.boulder",
+            "ra.boulder"
+          ]
+        },
+        "va.CAA": {
+          "clientNames": [
+            "health-checker.boulder",
+            "ra.boulder"
+          ]
+        }
+      }
     },
     "features": {
       "CAAValidationMethods": true,


### PR DESCRIPTION
Add a new config key to the existing GRPCServerConfig which allows per-service configuration items to be set. For now, only provide one per-service item: the list of client names which are allowed to connect to that service.

Add a new gRPC server interceptor (both unary and streaming) which verifies that the mTLS info set on the persistent connection has a client cert which contains a name which is allowlisted for the particular service being called, not just for the overall server.

Update the config-next tests to use this new facility to control access to the VA's two services, because it is (as of right now) the only gRPC server which exposes multiple services on the same listening address.

This will allow us to make more services -- particularly the CA and the SA -- more similar to the VA. We will be able to run multiple services on the same port, while still being able to control access to those services on a per-client basis. It will also let us split those services (e.g. into read-only and read-write subsets) much more easily, because a client will be able to switch which service it is calling without also having to be reconfigured to call a different address. And finally, it will allow us to simplify configuration for clients (such as the RA) which maintain connections to multiple different services on the same server, as they'll be able to re-use the same address configuration.

Part of #6454