### PR TITLE
Simplify setting up multiple gRPC services per server

### DIFF
--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -435,10 +435,9 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 		stopped <- true
 	}()
 
-	start, stopFn, err := bgrpc.Server[akamaipb.AkamaiPurgerServer]{}.Setup(
-		c.AkamaiPurger.GRPC, ap, akamaipb.RegisterAkamaiPurgerServer, tlsConfig, scope, clk,
-	)
+	srv, start, stopFn, err := bgrpc.NewServer(c.AkamaiPurger.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup Akamai purger gRPC server")
+	akamaipb.RegisterAkamaiPurgerServer(srv, ap)
 
 	go cmd.CatchSignals(logger, func() {
 		stopFn()

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -2,7 +2,6 @@ package notmain
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"sync"
 
@@ -215,7 +214,7 @@ func main() {
 	cmd.FailOnError(err, "Couldn't create PA")
 
 	if c.CA.HostnamePolicyFile == "" {
-		cmd.FailOnError(fmt.Errorf("HostnamePolicyFile was empty."), "")
+		cmd.Fail("HostnamePolicyFile was empty")
 	}
 	err = pa.SetHostnamePolicyFile(c.CA.HostnamePolicyFile)
 	cmd.FailOnError(err, "Couldn't load hostname policy file")
@@ -288,10 +287,10 @@ func main() {
 		cmd.FailOnError(err, "Failed to create OCSP impl")
 		go ocspiReal.LogOCSPLoop()
 
-		ocspStart, ocspStop, err := bgrpc.Server[capb.OCSPGeneratorServer]{}.Setup(
-			c.CA.GRPCOCSPGenerator, ocspiReal, capb.RegisterOCSPGeneratorServer, tlsConfig, scope, clk,
-		)
+		srv, ocspStart, ocspStop, err := bgrpc.NewServer(c.CA.GRPCOCSPGenerator, tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA OCSP gRPC server")
+		capb.RegisterOCSPGeneratorServer(srv, ocspiReal)
+
 		wg.Add(1)
 		go func() {
 			cmd.FailOnError(ocspStart(), "OCSPGenerator gRPC service failed")
@@ -316,10 +315,10 @@ func main() {
 		)
 		cmd.FailOnError(err, "Failed to create CRL impl")
 
-		crlStart, crlStop, err := bgrpc.Server[capb.CRLGeneratorServer]{}.Setup(
-			c.CA.GRPCCRLGenerator, crli, capb.RegisterCRLGeneratorServer, tlsConfig, scope, clk,
-		)
+		srv, crlStart, crlStop, err := bgrpc.NewServer(c.CA.GRPCCRLGenerator, tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA CRL gRPC server")
+		capb.RegisterCRLGeneratorServer(srv, crli)
+
 		wg.Add(1)
 		go func() {
 			cmd.FailOnError(crlStart(), "CRLGenerator gRPC service failed")
@@ -355,10 +354,10 @@ func main() {
 			go cai.OrphanIntegrationLoop()
 		}
 
-		caStart, caStop, err := bgrpc.Server[capb.CertificateAuthorityServer]{}.Setup(
-			c.CA.GRPCCA, cai, capb.RegisterCertificateAuthorityServer, tlsConfig, scope, clk,
-		)
+		srv, caStart, caStop, err := bgrpc.NewServer(c.CA.GRPCCA, tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA gRPC server")
+		capb.RegisterCertificateAuthorityServer(srv, cai)
+
 		wg.Add(1)
 		go func() {
 			cmd.FailOnError(caStart(), "CA gRPC service failed")

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -99,10 +99,9 @@ func main() {
 
 	pubi := publisher.New(bundles, c.Publisher.UserAgent, logger, scope)
 
-	start, stop, err := bgrpc.Server[pubpb.PublisherServer]{}.Setup(
-		c.Publisher.GRPC, pubi, pubpb.RegisterPublisherServer, tlsConfig, scope, clk,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.Publisher.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup Publisher gRPC server")
+	pubpb.RegisterPublisherServer(srv, pubi)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "Publisher gRPC service failed")

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -287,10 +287,9 @@ func main() {
 	rai.OCSP = ocspc
 	rai.SA = sac
 
-	start, stop, err := bgrpc.Server[rapb.RegistrationAuthorityServer]{}.Setup(
-		c.RA.GRPC, rai, rapb.RegisterRegistrationAuthorityServer, tlsConfig, scope, clk,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.RA.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup RA gRPC server")
+	rapb.RegisterRegistrationAuthorityServer(srv, rai)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "RA gRPC service failed")

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -106,10 +106,9 @@ func main() {
 	tls, err := c.SA.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
-	start, stop, err := bgrpc.Server[sapb.StorageAuthorityServer]{}.Setup(
-		c.SA.GRPC, sai, sapb.RegisterStorageAuthorityServer, tls, scope, clk, bgrpc.NoCancelInterceptor,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.SA.GRPC, tls, scope, clk, bgrpc.NoCancelInterceptor)
 	cmd.FailOnError(err, "Unable to setup SA gRPC server")
+	sapb.RegisterStorageAuthorityServer(srv, sai)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "SA gRPC service failed")

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"time"
 
-	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-
 	"github.com/honeycombio/beeline-go"
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/cmd"
@@ -183,23 +180,17 @@ func main() {
 		c.VA.AccountURIPrefixes)
 	cmd.FailOnError(err, "Unable to create VA server")
 
-	grpcSrv, l, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, scope, clk)
+	grpcSrv, start, stop, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup VA gRPC server")
 	vapb.RegisterVAServer(grpcSrv, vai)
-	cmd.FailOnError(err, "Unable to register VA gRPC server")
 	vapb.RegisterCAAServer(grpcSrv, vai)
-	cmd.FailOnError(err, "Unable to register CAA gRPC server")
-	hs := health.NewServer()
-	healthpb.RegisterHealthServer(grpcSrv, hs)
 
 	go cmd.CatchSignals(logger, func() {
 		servers.Stop()
-		hs.Shutdown()
-		grpcSrv.GracefulStop()
+		stop()
 	})
 
-	err = cmd.FilterShutdownErrors(grpcSrv.Serve(l))
-	cmd.FailOnError(err, "VA gRPC service failed")
+	cmd.FailOnError(start(), "VA gRPC service failed")
 }
 
 func init() {

--- a/cmd/crl-storer/main.go
+++ b/cmd/crl-storer/main.go
@@ -130,10 +130,9 @@ func main() {
 	csi, err := storer.New(issuers, s3client, c.CRLStorer.S3Bucket, scope, logger, clk)
 	cmd.FailOnError(err, "Failed to create CRLStorer impl")
 
-	start, stop, err := bgrpc.Server[cspb.CRLStorerServer]{}.Setup(
-		c.CRLStorer.GRPC, csi, cspb.RegisterCRLStorerServer, tlsConfig, scope, clk,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.CRLStorer.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup CRLStorer gRPC server")
+	cspb.RegisterCRLStorerServer(srv, csi)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "CRLStorer gRPC service failed")

--- a/cmd/nonce-service/main.go
+++ b/cmd/nonce-service/main.go
@@ -79,10 +79,9 @@ func main() {
 	cmd.FailOnError(err, "tlsConfig config")
 
 	nonceServer := &nonceServer{inner: ns}
-	start, stop, err := bgrpc.Server[noncepb.NonceServiceServer]{}.Setup(
-		c.NonceService.GRPC, nonceServer, noncepb.RegisterNonceServiceServer, tlsConfig, scope, cmd.Clock(),
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.NonceService.GRPC, tlsConfig, scope, cmd.Clock())
 	cmd.FailOnError(err, "Unable to setup nonce service gRPC server")
+	noncepb.RegisterNonceServiceServer(srv, nonceServer)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "Nonce service gRPC server failed")


### PR DESCRIPTION
Overhaul (again, sorry!) the bgrpc.NewServer helper to make registering multiple gRPC services on the same server easier. Return the server itself, so that services can be registered on it. Don't take the implementation and registerer as arguments (and therefore also get rid of the need for generics) since that is now handled in each main function. Still preserve the start and stop functions, to keep that simplification from the last round of refactoring.

Use the new mechanism in the VA. Enable using it in the SA when we split it soon. For now, don't use it in the CA, but we will in the future.

Part of #6454