### PR TITLE
ctpolicy: Remove deprecated codepath and fix metrics

### DIFF
--- a/ctpolicy/ctconfig/ctconfig.go
+++ b/ctpolicy/ctconfig/ctconfig.go
@@ -86,10 +86,6 @@ func (ld LogDescription) Info(exp time.Time) (string, string, error) {
 type CTGroup struct {
 	Name string
 	Logs []LogDescription
-	// How long to wait for one log to accept a certificate before moving on to
-	// the next.
-	// TODO(#5938): Remove this when CTLogGroups2 is removed from the RA.
-	Stagger cmd.ConfigDuration
 }
 
 // CTConfig is the top-level config object expected to be embedded in an

--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -2,15 +2,11 @@ package ctpolicy
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
-	"github.com/letsencrypt/boulder/canceled"
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/ctpolicy/ctconfig"
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
 	berrors "github.com/letsencrypt/boulder/errors"
 	blog "github.com/letsencrypt/boulder/log"
@@ -18,207 +14,69 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	cert      = "cert"
+	precert   = "precert"
+	sct       = "sct"
+	inform    = "inform"
+	succeeded = "succeeded"
+	failed    = "failed"
+)
+
 // CTPolicy is used to hold information about SCTs required from various
 // groupings
 type CTPolicy struct {
-	pub pubpb.PublisherClient
-	// TODO(#5938): Remove groups, informational, and final
-	groups        []ctconfig.CTGroup
-	informational []ctconfig.LogDescription
-	final         []ctconfig.LogDescription
-	sctLogs       loglist.List
-	infoLogs      loglist.List
-	finalLogs     loglist.List
-	stagger       time.Duration
-
-	log           blog.Logger
-	winnerCounter *prometheus.CounterVec
+	pub               pubpb.PublisherClient
+	sctLogs           loglist.List
+	infoLogs          loglist.List
+	finalLogs         loglist.List
+	stagger           time.Duration
+	log               blog.Logger
+	submissionCounter *prometheus.CounterVec
 }
 
 // New creates a new CTPolicy struct
-func New(
-	pub pubpb.PublisherClient,
-	groups []ctconfig.CTGroup,
-	informational []ctconfig.LogDescription,
-	sctLogs loglist.List,
-	infoLogs loglist.List,
-	finalLogs loglist.List,
-	stagger time.Duration,
-	log blog.Logger,
-	stats prometheus.Registerer,
-) *CTPolicy {
-	var final []ctconfig.LogDescription
-	for _, group := range groups {
-		for _, log := range group.Logs {
-			if log.SubmitFinalCert {
-				final = append(final, log)
-			}
-		}
-	}
-	for _, log := range informational {
-		if log.SubmitFinalCert {
-			final = append(final, log)
-		}
-	}
-
-	winnerCounter := prometheus.NewCounterVec(
+func New(pub pubpb.PublisherClient, sctLogs loglist.List, infoLogs loglist.List, finalLogs loglist.List, stagger time.Duration, log blog.Logger, stats prometheus.Registerer) *CTPolicy {
+	submissionCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "sct_race_winner",
-			Help: "Counter of logs that win SCT submission races.",
+			Name: "ct_submissions",
+			Help: "Counter of CT logs that are selected for submission by url, type (cert or precert), kind (sct or inform), and result (succeeded or failed).",
 		},
-		[]string{"log", "group"},
+		[]string{"url", "type", "kind", "result"},
 	)
-	stats.MustRegister(winnerCounter)
+	stats.MustRegister(submissionCounter)
 
 	return &CTPolicy{
-		pub:           pub,
-		groups:        groups,
-		informational: informational,
-		final:         final,
-		sctLogs:       sctLogs,
-		infoLogs:      infoLogs,
-		finalLogs:     finalLogs,
-		stagger:       stagger,
-		log:           log,
-		winnerCounter: winnerCounter,
+		pub:               pub,
+		sctLogs:           sctLogs,
+		infoLogs:          infoLogs,
+		finalLogs:         finalLogs,
+		stagger:           stagger,
+		log:               log,
+		submissionCounter: submissionCounter,
 	}
 }
 
 type result struct {
 	sct []byte
-	log string
+	url string
 	err error
 }
 
-// race submits an SCT to each log in a group and waits for the first response back,
-// once it has the first SCT it cancels all of the other submissions and returns.
-// It allows up to len(group)-1 of the submissions to fail as we only care about
-// getting a single SCT.
-// TODO(#5938): Remove this when it becomes dead code.
-func (ctp *CTPolicy) race(ctx context.Context, cert core.CertDER, group ctconfig.CTGroup, expiration time.Time) ([]byte, error) {
-	results := make(chan result, len(group.Logs))
-	isPrecert := true
-	// Randomize the order in which we send requests to the logs in a group
-	// so we maximize the distribution of logs we get SCTs from.
-	for i, logNum := range rand.Perm(len(group.Logs)) {
-		ld := group.Logs[logNum]
-		go func(i int, ld ctconfig.LogDescription) {
-			// Each submission waits a bit longer than the previous one, to give the
-			// previous log a chance to reply. If the context is already done by the
-			// time we get here, don't bother submitting. That generally means the
-			// context was canceled because another log returned a success already.
-			time.Sleep(time.Duration(i) * group.Stagger.Duration)
-			if ctx.Err() != nil {
-				return
-			}
-			uri, key, err := ld.Info(expiration)
-			if err != nil {
-				ctp.log.Errf("unable to get log info: %s", err)
-				return
-			}
-			sct, err := ctp.pub.SubmitToSingleCTWithResult(ctx, &pubpb.Request{
-				LogURL:       uri,
-				LogPublicKey: key,
-				Der:          cert,
-				Precert:      isPrecert,
-			})
-			if err != nil {
-				// Only log the error if it is not a result of the context being canceled
-				if !canceled.Is(err) {
-					ctp.log.Warningf("ct submission to %q failed: %s", uri, err)
-				}
-				results <- result{err: err}
-				return
-			}
-			results <- result{sct: sct.Sct, log: uri}
-		}(i, ld)
-	}
-
-	for i := 0; i < len(group.Logs); i++ {
-		select {
-		case <-ctx.Done():
-			ctp.winnerCounter.With(prometheus.Labels{"log": "timeout", "group": group.Name}).Inc()
-			return nil, ctx.Err()
-		case res := <-results:
-			if res.sct != nil {
-				ctp.winnerCounter.With(prometheus.Labels{"log": res.log, "group": group.Name}).Inc()
-				// Return the very first SCT we get back. Returning triggers
-				// the defer'd context cancellation method.
-				return res.sct, nil
-			}
-			// We will continue waiting for an SCT until we've seen the same number
-			// of errors as there are logs in the group as we may still get a SCT
-			// back from another log.
-		}
-	}
-	ctp.winnerCounter.With(prometheus.Labels{"log": "all_failed", "group": group.Name}).Inc()
-	return nil, errors.New("all submissions failed")
-}
-
-// GetSCTs attempts to retrieve two SCTs from the configured log groups and
-// returns the set of SCTs to the caller.
+// GetSCTs retrieves exactly two SCTs from the total collection of configured
+// log groups, with at most one SCT coming from each group. It expects that all
+// logs run by a single operator (e.g. Google) are in the same group, to
+// guarantee that SCTs from logs in different groups do not end up coming from
+// the same operator. As such, it enforces Google's current CT Policy, which
+// requires that certs have two SCTs from logs run by different operators.
 func (ctp *CTPolicy) GetSCTs(ctx context.Context, cert core.CertDER, expiration time.Time) (core.SCTDERs, error) {
-	if len(ctp.sctLogs) != 0 {
-		return ctp.getOperatorSCTs(ctx, cert, expiration)
-	}
-	return ctp.getGoogleSCTs(ctx, cert, expiration)
-}
-
-// getGoogleSCTs retrieves exactly one SCT from each of the configured log
-// groups. It expects that there are exactly 2 such groups, and that one of
-// those groups contains only logs operated by Google. As such, it enforces
-// Google's *old* CT Policy, which required that certs have two SCTs, one of
-// which was from a Google log.
-// DEPRECATED: Google no longer enforces the "one Google, one non-Google" log
-// policy. Use getOperatorSCTs instead.
-// TODO(#5938): Remove this after the configured groups have been rearranged.
-func (ctp *CTPolicy) getGoogleSCTs(ctx context.Context, cert core.CertDER, expiration time.Time) (core.SCTDERs, error) {
-	results := make(chan result, len(ctp.groups))
-	subCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	for _, g := range ctp.groups {
-		go func(g ctconfig.CTGroup) {
-			sct, err := ctp.race(subCtx, cert, g, expiration)
-			// Only one of these will be non-nil
-			if err != nil {
-				results <- result{err: berrors.MissingSCTsError("CT log group %q: %s", g.Name, err)}
-			}
-			results <- result{sct: sct}
-		}(g)
-	}
-
-	go ctp.submitPrecertInformational(cert, expiration)
-
-	var ret core.SCTDERs
-	for i := 0; i < len(ctp.groups); i++ {
-		res := <-results
-		// If any one group fails to get a SCT then we fail out immediately
-		// cancel any other in progress work as we can't continue
-		if res.err != nil {
-			// Returning triggers the defer'd context cancellation method
-			return nil, res.err
-		}
-		ret = append(ret, res.sct)
-	}
-	return ret, nil
-}
-
-// getOperatorSCTs retrieves exactly two SCTs from the total collection of
-// configured log groups, with at most one SCT coming from each group. It
-// expects that all logs run by a single operator (e.g. Google) are in the same
-// group, to guarantee that SCTs from logs in different groups do not end up
-// coming from the same operator. As such, it enforces Google's current CT
-// Policy, which requires that certs have two SCTs from logs run by different
-// operators.
-// TODO(#5938): Inline this into GetSCTs when getGoogleSCTs is removed.
-func (ctp *CTPolicy) getOperatorSCTs(ctx context.Context, cert core.CertDER, expiration time.Time) (core.SCTDERs, error) {
 	// We'll cancel this sub-context when we have the two SCTs we need, to cause
 	// any other ongoing submission attempts to quit.
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// This closure will be called in parallel once for each operator group.
-	getOne := func(i int, g string) ([]byte, error) {
+	getOne := func(i int, g string) ([]byte, string, error) {
 		// Sleep a little bit to stagger our requests to the later groups. Use `i-1`
 		// to compute the stagger duration so that the first two groups (indices 0
 		// and 1) get negative or zero (i.e. instant) sleep durations. If the
@@ -226,28 +84,28 @@ func (ctp *CTPolicy) getOperatorSCTs(ctx context.Context, cert core.CertDER, exp
 		// groups returned SCTs already) before the sleep is complete, quit instead.
 		select {
 		case <-subCtx.Done():
-			return nil, subCtx.Err()
+			return nil, "", subCtx.Err()
 		case <-time.After(time.Duration(i-1) * ctp.stagger):
 		}
 
 		// Pick a random log from among those in the group. In practice, very few
 		// operator groups have more than one log, so this loses little flexibility.
-		uri, key, err := ctp.sctLogs.PickOne(g, expiration)
+		url, key, err := ctp.sctLogs.PickOne(g, expiration)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get log info: %w", err)
+			return nil, "", fmt.Errorf("unable to get log info: %w", err)
 		}
 
 		sct, err := ctp.pub.SubmitToSingleCTWithResult(ctx, &pubpb.Request{
-			LogURL:       uri,
+			LogURL:       url,
 			LogPublicKey: key,
 			Der:          cert,
 			Precert:      true,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("ct submission to %q (%q) failed: %w", g, uri, err)
+			return nil, url, fmt.Errorf("ct submission to %q (%q) failed: %w", g, url, err)
 		}
 
-		return sct.Sct, nil
+		return sct.Sct, url, nil
 	}
 
 	// Ensure that this channel has a buffer equal to the number of goroutines
@@ -260,8 +118,8 @@ func (ctp *CTPolicy) getOperatorSCTs(ctx context.Context, cert core.CertDER, exp
 	// always trying to submit to the same two operators.
 	for i, group := range ctp.sctLogs.Permute() {
 		go func(i int, g string) {
-			sctDER, err := getOne(i, g)
-			results <- result{sct: sctDER, err: err}
+			sctDER, url, err := getOne(i, g)
+			results <- result{sct: sctDER, url: url, err: err}
 		}(i, group)
 	}
 
@@ -276,9 +134,13 @@ func (ctp *CTPolicy) getOperatorSCTs(ctx context.Context, cert core.CertDER, exp
 		res := <-results
 		if res.err != nil {
 			errs = append(errs, res.err.Error())
+			if res.url != "" {
+				ctp.submissionCounter.WithLabelValues(res.url, precert, sct, failed).Inc()
+			}
 			continue
 		}
 		scts = append(scts, res.sct)
+		ctp.submissionCounter.WithLabelValues(res.url, precert, sct, succeeded).Inc()
 		if len(scts) >= 2 {
 			return scts, nil
 		}
@@ -291,16 +153,21 @@ func (ctp *CTPolicy) getOperatorSCTs(ctx context.Context, cert core.CertDER, exp
 		// thereby causing all of our getOne sub-goroutines to be cancelled.
 		return nil, berrors.MissingSCTsError("failed to get 2 SCTs before ctx finished: %s", ctx.Err())
 	}
-	return nil, berrors.MissingSCTsError("failed to get 2 SCTs, got error(s): %s", strings.Join(errs, "; "))
+	return nil, berrors.MissingSCTsError("failed to get 2 SCTs, got %d error(s): %s", len(errs), strings.Join(errs, "; "))
 }
 
 // submitAllBestEffort submits the given certificate or precertificate to every
 // log ("informational" for precerts, "final" for certs) configured in the policy.
 // It neither waits for these submission to complete, nor tracks their success.
-func (ctp *CTPolicy) submitAllBestEffort(blob core.CertDER, precert bool, expiry time.Time) {
+func (ctp *CTPolicy) submitAllBestEffort(blob core.CertDER, isPrecert bool, expiry time.Time) {
 	logs := ctp.finalLogs
-	if precert {
+	result := succeeded
+	logType := cert
+	logKind := sct
+	if isPrecert {
 		logs = ctp.infoLogs
+		logType = precert
+		logKind = inform
 	}
 
 	for _, group := range logs {
@@ -316,12 +183,14 @@ func (ctp *CTPolicy) submitAllBestEffort(blob core.CertDER, precert bool, expiry
 						LogURL:       log.Url,
 						LogPublicKey: log.Key,
 						Der:          blob,
-						Precert:      precert,
+						Precert:      isPrecert,
 					},
 				)
 				if err != nil {
+					result = failed
 					ctp.log.Warningf("ct submission of cert to log %q failed: %s", log.Url, err)
 				}
+				ctp.submissionCounter.WithLabelValues(log.Url, logType, logKind, result).Inc()
 			}(log)
 		}
 	}
@@ -331,61 +200,11 @@ func (ctp *CTPolicy) submitAllBestEffort(blob core.CertDER, precert bool, expiry
 // submitPrecertInformational submits precertificates to any configured
 // "informational" logs, but does not care about success or returned SCTs.
 func (ctp *CTPolicy) submitPrecertInformational(cert core.CertDER, expiration time.Time) {
-	if len(ctp.sctLogs) != 0 {
-		ctp.submitAllBestEffort(cert, true, expiration)
-		return
-	}
-
-	// TODO(#5938): Remove this when it becomes dead code.
-	for _, log := range ctp.informational {
-		go func(l ctconfig.LogDescription) {
-			// We use a context.Background() here instead of a context from the parent
-			// because these submissions are running in a goroutine and we don't want
-			// them to be cancelled when the caller of CTPolicy.GetSCTs returns and
-			// cancels its RPC context.
-			uri, key, err := l.Info(expiration)
-			if err != nil {
-				ctp.log.Errf("unable to get log info: %s", err)
-				return
-			}
-			_, err = ctp.pub.SubmitToSingleCTWithResult(context.Background(), &pubpb.Request{
-				LogURL:       uri,
-				LogPublicKey: key,
-				Der:          cert,
-				Precert:      true,
-			})
-			if err != nil {
-				ctp.log.Warningf("ct submission to informational log %q failed: %s", uri, err)
-			}
-		}(log)
-	}
+	ctp.submitAllBestEffort(cert, true, expiration)
 }
 
 // SubmitFinalCert submits finalized certificates created from precertificates
 // to any configured "final" logs, but does not care about success.
 func (ctp *CTPolicy) SubmitFinalCert(cert core.CertDER, expiration time.Time) {
-	if len(ctp.sctLogs) != 0 {
-		ctp.submitAllBestEffort(cert, false, expiration)
-		return
-	}
-
-	// TODO(#5938): Remove this when it becomes dead code.
-	for _, log := range ctp.final {
-		go func(l ctconfig.LogDescription) {
-			uri, key, err := l.Info(expiration)
-			if err != nil {
-				ctp.log.Errf("unable to get log info: %s", err)
-				return
-			}
-			_, err = ctp.pub.SubmitToSingleCTWithResult(context.Background(), &pubpb.Request{
-				LogURL:       uri,
-				LogPublicKey: key,
-				Der:          cert,
-				Precert:      false,
-			})
-			if err != nil {
-				ctp.log.Warningf("ct submission of final cert to log %q failed: %s", uri, err)
-			}
-		}(log)
-	}
+	ctp.submitAllBestEffort(cert, false, expiration)
 }

--- a/ctpolicy/ctpolicy_test.go
+++ b/ctpolicy/ctpolicy_test.go
@@ -3,14 +3,11 @@ package ctpolicy
 import (
 	"context"
 	"errors"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/ctpolicy/ctconfig"
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
 	berrors "github.com/letsencrypt/boulder/errors"
 	blog "github.com/letsencrypt/boulder/log"
@@ -40,106 +37,6 @@ func (mp *mockSlowPub) SubmitToSingleCTWithResult(ctx context.Context, _ *pubpb.
 	return nil, errors.New("timed out")
 }
 
-func TestGetGoogleSCTs(t *testing.T) {
-	expired, cancel := context.WithDeadline(context.Background(), time.Now())
-	defer cancel()
-	missingSCTErr := berrors.MissingSCTs
-	testCases := []struct {
-		name       string
-		mock       pubpb.PublisherClient
-		groups     []ctconfig.CTGroup
-		ctx        context.Context
-		result     core.SCTDERs
-		errRegexp  *regexp.Regexp
-		berrorType *berrors.ErrorType
-	}{
-		{
-			name: "basic success case",
-			mock: &mockPub{},
-			groups: []ctconfig.CTGroup{
-				{
-					Name: "a",
-					Logs: []ctconfig.LogDescription{
-						{URI: "abc", Key: "def"},
-						{URI: "ghi", Key: "jkl"},
-					},
-				},
-				{
-					Name: "b",
-					Logs: []ctconfig.LogDescription{
-						{URI: "abc", Key: "def"},
-						{URI: "ghi", Key: "jkl"},
-					},
-				},
-			},
-			ctx:    context.Background(),
-			result: core.SCTDERs{[]byte{0}, []byte{0}},
-		},
-		{
-			name: "basic failure case",
-			mock: &mockFailPub{},
-			groups: []ctconfig.CTGroup{
-				{
-					Name: "a",
-					Logs: []ctconfig.LogDescription{
-						{URI: "abc", Key: "def"},
-						{URI: "ghi", Key: "jkl"},
-					},
-				},
-				{
-					Name: "b",
-					Logs: []ctconfig.LogDescription{
-						{URI: "abc", Key: "def"},
-						{URI: "ghi", Key: "jkl"},
-					},
-				},
-			},
-			ctx:        context.Background(),
-			errRegexp:  regexp.MustCompile("CT log group \".\": all submissions failed"),
-			berrorType: &missingSCTErr,
-		},
-		{
-			name: "parent context timeout failure case",
-			mock: &mockSlowPub{},
-			groups: []ctconfig.CTGroup{
-				{
-					Name: "a",
-					Logs: []ctconfig.LogDescription{
-						{URI: "abc", Key: "def"},
-						{URI: "ghi", Key: "jkl"},
-					},
-				},
-				{
-					Name: "b",
-					Logs: []ctconfig.LogDescription{
-						{URI: "abc", Key: "def"},
-						{URI: "ghi", Key: "jkl"},
-					},
-				},
-			},
-			ctx:       expired,
-			errRegexp: regexp.MustCompile("CT log group \".\": context deadline exceeded"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctp := New(tc.mock, tc.groups, nil, nil, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
-			ret, err := ctp.GetSCTs(tc.ctx, []byte{0}, time.Time{})
-			if tc.result != nil {
-				test.AssertDeepEquals(t, ret, tc.result)
-			} else if tc.errRegexp != nil {
-				if !tc.errRegexp.MatchString(err.Error()) {
-					t.Errorf("Error %q did not match expected regexp %q", err, tc.errRegexp)
-				}
-				if tc.berrorType != nil {
-					test.AssertErrorIs(t, err, *tc.berrorType)
-				}
-			}
-		})
-	}
-}
-
 func TestGetOperatorSCTs(t *testing.T) {
 	expired, cancel := context.WithDeadline(context.Background(), time.Now())
 	defer cancel()
@@ -159,13 +56,9 @@ func TestGetOperatorSCTs(t *testing.T) {
 			groups: loglist.List{
 				"OperA": {
 					"LogA1": {Url: "UrlA1", Key: "KeyA1"},
-					"LogA2": {Url: "UrlA2", Key: "KeyA2"},
 				},
 				"OperB": {
 					"LogB1": {Url: "UrlB1", Key: "KeyB1"},
-				},
-				"OperC": {
-					"LogC1": {Url: "UrlC1", Key: "KeyC1"},
 				},
 			},
 			ctx:    context.Background(),
@@ -177,17 +70,10 @@ func TestGetOperatorSCTs(t *testing.T) {
 			groups: loglist.List{
 				"OperA": {
 					"LogA1": {Url: "UrlA1", Key: "KeyA1"},
-					"LogA2": {Url: "UrlA2", Key: "KeyA2"},
-				},
-				"OperB": {
-					"LogB1": {Url: "UrlB1", Key: "KeyB1"},
-				},
-				"OperC": {
-					"LogC1": {Url: "UrlC1", Key: "KeyC1"},
 				},
 			},
 			ctx:        context.Background(),
-			expectErr:  "failed to get 2 SCTs, got error(s):",
+			expectErr:  "failed to get 2 SCTs, got 1 error(s): ct submission to \"OperA\" (\"UrlA1\") failed: BAD",
 			berrorType: &missingSCTErr,
 		},
 		{
@@ -196,23 +82,20 @@ func TestGetOperatorSCTs(t *testing.T) {
 			groups: loglist.List{
 				"OperA": {
 					"LogA1": {Url: "UrlA1", Key: "KeyA1"},
-					"LogA2": {Url: "UrlA2", Key: "KeyA2"},
 				},
 				"OperB": {
 					"LogB1": {Url: "UrlB1", Key: "KeyB1"},
 				},
-				"OperC": {
-					"LogC1": {Url: "UrlC1", Key: "KeyC1"},
-				},
 			},
-			ctx:       expired,
-			expectErr: "failed to get 2 SCTs before ctx finished",
+			ctx:        expired,
+			expectErr:  "failed to get 2 SCTs before ctx finished",
+			berrorType: &missingSCTErr,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctp := New(tc.mock, nil, nil, tc.groups, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
+			ctp := New(tc.mock, tc.groups, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
 			ret, err := ctp.GetSCTs(tc.ctx, []byte{0}, time.Time{})
 			if tc.result != nil {
 				test.AssertDeepEquals(t, ret, tc.result)
@@ -228,108 +111,59 @@ func TestGetOperatorSCTs(t *testing.T) {
 	}
 }
 
-type failOne struct {
+type mockFailOnePub struct {
 	badURL string
 }
 
-func (mp *failOne) SubmitToSingleCTWithResult(_ context.Context, req *pubpb.Request, _ ...grpc.CallOption) (*pubpb.Result, error) {
+func (mp *mockFailOnePub) SubmitToSingleCTWithResult(_ context.Context, req *pubpb.Request, _ ...grpc.CallOption) (*pubpb.Result, error) {
 	if req.LogURL == mp.badURL {
 		return nil, errors.New("BAD")
 	}
 	return &pubpb.Result{Sct: []byte{0}}, nil
 }
 
-type slowPublisher struct{}
-
-func (sp *slowPublisher) SubmitToSingleCTWithResult(_ context.Context, req *pubpb.Request, _ ...grpc.CallOption) (*pubpb.Result, error) {
-	time.Sleep(time.Second)
-	return &pubpb.Result{Sct: []byte{0}}, nil
-}
-
 func TestGetSCTsMetrics(t *testing.T) {
-	ctp := New(&failOne{badURL: "abc"}, []ctconfig.CTGroup{
-		{
-			Name: "a",
-			Logs: []ctconfig.LogDescription{
-				{URI: "abc", Key: "def"},
-				{URI: "ghi", Key: "jkl"},
-			},
+	ctp := New(&mockFailOnePub{badURL: "UrlA1"}, loglist.List{
+		"OperA": {
+			"LogA1": {Url: "UrlA1", Key: "KeyA1"},
 		},
-		{
-			Name: "b",
-			Logs: []ctconfig.LogDescription{
-				{URI: "abc", Key: "def"},
-				{URI: "ghi", Key: "jkl"},
-			},
+		"OperB": {
+			"LogB1": {Url: "UrlB1", Key: "KeyB1"},
 		},
-	}, nil, nil, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
+		"OperC": {
+			"LogC1": {Url: "UrlC1", Key: "KeyC1"},
+		},
+	}, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
 	_, err := ctp.GetSCTs(context.Background(), []byte{0}, time.Time{})
 	test.AssertNotError(t, err, "GetSCTs failed")
-	test.AssertMetricWithLabelsEquals(t, ctp.winnerCounter, prometheus.Labels{"log": "ghi", "group": "a"}, 1)
-	test.AssertMetricWithLabelsEquals(t, ctp.winnerCounter, prometheus.Labels{"log": "ghi", "group": "b"}, 1)
+	test.AssertMetricWithLabelsEquals(t, ctp.submissionCounter, prometheus.Labels{"url": "UrlB1", "type": "precert", "kind": "sct", "result": succeeded}, 1)
+	test.AssertMetricWithLabelsEquals(t, ctp.submissionCounter, prometheus.Labels{"url": "UrlC1", "type": "precert", "kind": "sct", "result": succeeded}, 1)
 }
 
 func TestGetSCTsFailMetrics(t *testing.T) {
-	// When an entire log group fails, we should increment the "winner of SCT
-	// race" stat for that group under the fictional log "all_failed".
-	ctp := New(&failOne{badURL: "abc"}, []ctconfig.CTGroup{
-		{
-			Name: "a",
-			Logs: []ctconfig.LogDescription{
-				{URI: "abc", Key: "def"},
-			},
+	// Ensure the proper metrics are incremented when GetSCTs fails.
+	ctp := New(&mockFailOnePub{badURL: "UrlA1"}, loglist.List{
+		"OperA": {
+			"LogA1": {Url: "UrlA1", Key: "KeyA1"},
 		},
-	}, nil, nil, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
+	}, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
 	_, err := ctp.GetSCTs(context.Background(), []byte{0}, time.Time{})
-	if err == nil {
-		t.Fatal("GetSCTs should have failed")
-	}
-	test.AssertMetricWithLabelsEquals(t, ctp.winnerCounter, prometheus.Labels{"log": "all_failed", "group": "a"}, 1)
+	test.AssertError(t, err, "GetSCTs should have failed")
+	test.AssertErrorIs(t, err, berrors.MissingSCTs)
+	test.AssertMetricWithLabelsEquals(t, ctp.submissionCounter, prometheus.Labels{"url": "UrlA1", "result": failed}, 1)
 
-	// Same thing, but for when an entire log group times out.
+	// Ensure the proper metrics are incremented when GetSCTs times out.
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	ctp = New(&slowPublisher{}, []ctconfig.CTGroup{
-		{
-			Name: "a",
-			Logs: []ctconfig.LogDescription{
-				{URI: "abc", Key: "def"},
-			},
+	ctp = New(&mockSlowPub{}, loglist.List{
+		"OperA": {
+			"LogA1": {Url: "UrlA1", Key: "KeyA1"},
 		},
-	}, nil, nil, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
+	}, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
 	_, err = ctp.GetSCTs(ctx, []byte{0}, time.Time{})
-	if err == nil {
-		t.Fatal("GetSCTs should have failed")
-	}
-	test.AssertMetricWithLabelsEquals(t, ctp.winnerCounter, prometheus.Labels{"log": "timeout", "group": "a"}, 1)
-}
-
-// A mock publisher that counts submissions
-type countEm struct {
-	count int
-}
-
-func (ce *countEm) SubmitToSingleCTWithResult(_ context.Context, _ *pubpb.Request, _ ...grpc.CallOption) (*pubpb.Result, error) {
-	ce.count++
-	return &pubpb.Result{Sct: []byte{0}}, nil
-}
-
-func TestStagger(t *testing.T) {
-	countingPub := &countEm{}
-	ctp := New(countingPub, []ctconfig.CTGroup{
-		{
-			Name:    "a",
-			Stagger: cmd.ConfigDuration{Duration: 500 * time.Millisecond},
-			Logs: []ctconfig.LogDescription{
-				{URI: "abc", Key: "def"},
-				{URI: "ghi", Key: "jkl"},
-			},
-		},
-	}, nil, nil, nil, nil, 0, blog.NewMock(), metrics.NoopRegisterer)
-	_, err := ctp.GetSCTs(context.Background(), []byte{0}, time.Time{})
-	test.AssertNotError(t, err, "GetSCTs failed")
-	if countingPub.count != 1 {
-		t.Errorf("wrong number of requests to publisher. got %d, expected 1", countingPub.count)
-	}
+	test.AssertError(t, err, "GetSCTs should have timed out")
+	test.AssertErrorIs(t, err, berrors.MissingSCTs)
+	test.AssertContains(t, err.Error(), context.DeadlineExceeded.Error())
+	test.AssertMetricWithLabelsEquals(t, ctp.submissionCounter, prometheus.Labels{"url": "UrlA1", "result": failed}, 1)
 }

--- a/ctpolicy/ctpolicy_test.go
+++ b/ctpolicy/ctpolicy_test.go
@@ -56,9 +56,13 @@ func TestGetSCTs(t *testing.T) {
 			groups: loglist.List{
 				"OperA": {
 					"LogA1": {Url: "UrlA1", Key: "KeyA1"},
+					"LogA2": {Url: "UrlA2", Key: "KeyA2"},
 				},
 				"OperB": {
 					"LogB1": {Url: "UrlB1", Key: "KeyB1"},
+				},
+				"OperC": {
+					"LogC1": {Url: "UrlC1", Key: "KeyC1"},
 				},
 			},
 			ctx:    context.Background(),
@@ -70,10 +74,17 @@ func TestGetSCTs(t *testing.T) {
 			groups: loglist.List{
 				"OperA": {
 					"LogA1": {Url: "UrlA1", Key: "KeyA1"},
+					"LogA2": {Url: "UrlA2", Key: "KeyA2"},
+				},
+				"OperB": {
+					"LogB1": {Url: "UrlB1", Key: "KeyB1"},
+				},
+				"OperC": {
+					"LogC1": {Url: "UrlC1", Key: "KeyC1"},
 				},
 			},
 			ctx:        context.Background(),
-			expectErr:  "failed to get 2 SCTs, got 1 error(s): ct submission to \"OperA\" (\"UrlA1\") failed: BAD",
+			expectErr:  "failed to get 2 SCTs, got 3 error(s)",
 			berrorType: &missingSCTErr,
 		},
 		{
@@ -82,9 +93,13 @@ func TestGetSCTs(t *testing.T) {
 			groups: loglist.List{
 				"OperA": {
 					"LogA1": {Url: "UrlA1", Key: "KeyA1"},
+					"LogA2": {Url: "UrlA2", Key: "KeyA2"},
 				},
 				"OperB": {
 					"LogB1": {Url: "UrlB1", Key: "KeyB1"},
+				},
+				"OperC": {
+					"LogC1": {Url: "UrlC1", Key: "KeyC1"},
 				},
 			},
 			ctx:        expired,

--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -276,9 +276,6 @@ func (ll List) OperatorForLogID(logID string) (string, error) {
 
 // Permute returns the list of operator group names in a randomized order.
 func (ll List) Permute() []string {
-	// Seed the RNG.
-	rand.Seed(time.Now().UnixNano())
-
 	keys := make([]string, 0, len(ll))
 	for k := range ll {
 		keys = append(keys, k)
@@ -317,10 +314,10 @@ func (ll List) PickOne(operator string, expiry time.Time) (string, string, error
 		return "", "", fmt.Errorf("no log found for group %q and expiry %s", operator, expiry)
 	}
 
-	// Seed the RNG.
-	rand.Seed(time.Now().UnixNano())
-
-	// Pick a random log from the list of candidates.
 	log := candidates[rand.Intn(len(candidates))]
 	return log.Url, log.Key, nil
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }

--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -276,6 +276,9 @@ func (ll List) OperatorForLogID(logID string) (string, error) {
 
 // Permute returns the list of operator group names in a randomized order.
 func (ll List) Permute() []string {
+	// Seed the RNG.
+	rand.Seed(time.Now().UnixNano())
+
 	keys := make([]string, 0, len(ll))
 	for k := range ll {
 		keys = append(keys, k)
@@ -285,7 +288,6 @@ func (ll List) Permute() []string {
 	for i, j := range rand.Perm(len(ll)) {
 		result[i] = keys[j]
 	}
-
 	return result
 }
 
@@ -315,6 +317,10 @@ func (ll List) PickOne(operator string, expiry time.Time) (string, string, error
 		return "", "", fmt.Errorf("no log found for group %q and expiry %s", operator, expiry)
 	}
 
+	// Seed the RNG.
+	rand.Seed(time.Now().UnixNano())
+
+	// Pick a random log from the list of candidates.
 	log := candidates[rand.Intn(len(candidates))]
 	return log.Url, log.Key, nil
 }

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -583,7 +583,7 @@ type PublisherClient struct {
 
 // SubmitToSingleCTWithResult is a mock
 func (*PublisherClient) SubmitToSingleCTWithResult(_ context.Context, _ *pubpb.Request, _ ...grpc.CallOption) (*pubpb.Result, error) {
-	return nil, nil
+	return &pubpb.Result{}, nil
 }
 
 // Mailer is a mock

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/ctpolicy"
-	"github.com/letsencrypt/boulder/ctpolicy/ctconfig"
+	"github.com/letsencrypt/boulder/ctpolicy/loglist"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
@@ -346,7 +346,14 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 		Status:    string(core.StatusValid),
 	})
 
-	ctp := ctpolicy.New(&mocks.PublisherClient{}, nil, nil, nil, nil, nil, 0, log, metrics.NoopRegisterer)
+	ctp := ctpolicy.New(&mocks.PublisherClient{}, loglist.List{
+		"OperA": {
+			"LogA1": {Url: "UrlA1", Key: "KeyA1"},
+		},
+		"OperB": {
+			"LogB1": {Url: "UrlB1", Key: "KeyB1"},
+		},
+	}, nil, nil, 0, log, metrics.NoopRegisterer)
 
 	ra := NewRegistrationAuthorityImpl(fc,
 		log,
@@ -3193,7 +3200,14 @@ func TestCTPolicyMeasurements(t *testing.T) {
 	_, ssa, ra, _, cleanup := initAuthorities(t)
 	defer cleanup()
 
-	ra.ctpolicy = ctpolicy.New(&timeoutPub{}, []ctconfig.CTGroup{{}}, nil, nil, nil, nil, 0, log, metrics.NoopRegisterer)
+	ra.ctpolicy = ctpolicy.New(&timeoutPub{}, loglist.List{
+		"OperA": {
+			"LogA1": {Url: "UrlA1", Key: "KeyA1"},
+		},
+		"OperB": {
+			"LogB1": {Url: "UrlB1", Key: "KeyB1"},
+		},
+	}, nil, nil, 0, log, metrics.NoopRegisterer)
 
 	// Create valid authorizations for not-example.com and www.not-example.com
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -65,68 +65,31 @@
       "RestrictRSAKeySizes": true,
       "StreamlineOrderAndAuthzs": true
     },
-    "CTLogGroups2": [
-      {
-        "name": "a",
-        "stagger": "500ms",
-        "logs": [
-          {
-            "uri": "http://boulder.service.consul:4500",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q==",
-            "submitFinalCert": false
-          },
-          {
-            "uri": "http://boulder.service.consul:4501",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA==",
-            "submitFinalCert": false
-          }
-        ]
-      },
-      {
-        "name": "b",
-        "stagger": "500ms",
-        "logs": [
-          {
-            "uri": "http://boulder.service.consul:4510",
-            "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyw1HymhJkuxSIgt3gqW3sVXqMqB3EFsXcMfPFo0vYwjNiRmCJDXKsR0Flp7MAK+wc3X/7Hpc8liUbMhPet7tEA==",
-            "submitFinalCert": true
-          },
-          {
-            "name": "temporal test set",
-            "shards": [
-              {
-                "uri": "http://boulder.service.consul:4511",
-                "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
-                "windowStart": "2006-01-02T15:04:05Z",
-                "windowEnd": "2017-01-02T15:04:05Z"
-              },
-              {
-                "uri": "http://boulder.service.consul:4511",
-                "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
-                "windowStart": "2017-01-02T15:04:05Z",
-                "windowEnd": "2022-01-02T15:04:05Z"
-              },
-              {
-                "uri": "http://boulder.service.consul:4511",
-                "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
-                "windowStart": "2022-01-02T15:04:05Z",
-                "windowEnd": "2050-01-02T15:04:05Z"
-              }
-            ],
-            "submitFinalCert": true
-          }
-        ]
-      }
-    ],
-    "InformationalCTLogs": [
-      {
-        "uri": "http://boulder.service.consul:4512",
-        "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
-        "submitFinalCert": true
-      }
-    ]
+    "ctLogs": {
+      "stagger": "500ms",
+      "logListFile": "test/ct-test-srv/log_list.json",
+      "sctLogs": [
+        "A1 Current",
+        "A1 Future",
+        "A2 Past",
+        "A2 Current",
+        "B1",
+        "B2",
+        "C1",
+        "D1",
+        "E1"
+      ],
+      "infoLogs": [
+        "F1"
+      ],
+      "finalLogs": [
+        "A1 Current",
+        "A1 Future",
+        "C1",
+        "F1"
+      ]
+    }
   },
-
   "pa": {
     "challenges": {
       "http-01": true,

--- a/test/ct-test-srv/log_list.json
+++ b/test/ct-test-srv/log_list.json
@@ -181,62 +181,6 @@
       ]
     },
     {
-      "name": "Fake Google TODO(#5938): Remove this group",
-      "email": ["fake@example.org"],
-      "logs": [
-        {
-          "description": "G4500",
-          "log_id": "KHYaGJAn++880NYaAY12sFBXKcenQRvMvfYE9F1CYVM=",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q==",
-          "url": "http://boulder.service.consul:4500",
-          "state": {
-            "usable": {
-              "timestamp": "2000-00-00T00:00:00Z"
-            }
-          }
-        },
-        {
-          "description": "G4501",
-          "log_id": "3Zk0/KXnJIDJVmh9gTSZCEmySfe1adjHvKs/XMHzbmQ=",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA==",
-          "url": "http://boulder.service.consul:4501",
-          "state": {
-            "usable": {
-              "timestamp": "2000-00-00T00:00:00Z"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "Fake Everyone Else TODO(#5938): Remove this group",
-      "email": ["fake@example.org"],
-      "logs": [
-        {
-          "description": "O4510",
-          "log_id": "FuhpwdGV6tfD+Jca4/B2AfeM4badMahSGLaDfzGoFQg=",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyw1HymhJkuxSIgt3gqW3sVXqMqB3EFsXcMfPFo0vYwjNiRmCJDXKsR0Flp7MAK+wc3X/7Hpc8liUbMhPet7tEA==",
-          "url": "http://boulder.service.consul:4510",
-          "state": {
-            "usable": {
-              "timestamp": "2000-00-00T00:00:00Z"
-            }
-          }
-        },
-        {
-          "description": "O4511",
-          "log_id": "NvR3OcSRDDWwwb0Hg+t9aKCpL3+tDuk99WrHkTwabYo=",
-          "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFRu37ZRLg8lT4rVQwMwh4oAOpXb4Sx+9hgQ+JFCjmAv3oDV+sDOMsC7hULkGTn+LB5L1SRo/XIY4Kw5V+nFXgg==",
-          "url": "http://boulder.service.consul:4511",
-          "state": {
-            "usable": {
-              "timestamp": "2000-00-00T00:00:00Z"
-            }
-          }
-        }
-      ]
-    },
-    {
       "name": "Unused",
       "email": ["fake@example.org"],
       "logs": [

--- a/test/integration/common_mock.go
+++ b/test/integration/common_mock.go
@@ -13,8 +13,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 )
 
-// TODO(#5938): Remove 45XX ports.
-var ctSrvPorts = []int{4500, 4501, 4510, 4511, 4600, 4601, 4602, 4603, 4604, 4605, 4606, 4607, 4608, 4609}
+var ctSrvPorts = []int{4600, 4601, 4602, 4603, 4604, 4605, 4606, 4607, 4608, 4609}
 
 // ctAddRejectHost adds a domain to all of the CT test server's reject-host
 // lists. If this fails the test is aborted with a fatal error.

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1299,7 +1299,7 @@ def test_ocsp():
     # checking OCSP until we either see a good response or we timeout (5s).
     verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "good")
 
-def test_ct_submission_operator():
+def test_ct_submission():
     hostname = random_domain()
 
     chisel2.auth_and_issue([hostname])

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1299,11 +1299,7 @@ def test_ocsp():
     # checking OCSP until we either see a good response or we timeout (5s).
     verify_ocsp(cert_file.name, "/hierarchy/intermediate-cert-rsa-a.pem", "http://localhost:4002", "good")
 
-# TODO(#5938): Remove _operator suffix from this test and remove CONFIG_NEXT check.
 def test_ct_submission_operator():
-    if not CONFIG_NEXT:
-        return
-
     hostname = random_domain()
 
     chisel2.auth_and_issue([hostname])
@@ -1348,34 +1344,6 @@ def test_ct_submission_operator():
         total_count += group_count
     if total_count < 2:
         raise(Exception("Got %d total submissions, expected at least 2" % total_count))
-
-# TODO(#5938): Remove this test.
-def test_ct_submission_google():
-    if CONFIG_NEXT:
-        return
-
-    hostname = random_domain()
-
-    # These should correspond to the configured logs in ra.json.
-    log_groups = [
-        ["http://boulder.service.consul:4500/submissions", "http://boulder.service.consul:4501/submissions"],
-        ["http://boulder.service.consul:4510/submissions", "http://boulder.service.consul:4511/submissions"],
-    ]
-    def submissions(group):
-        count = 0
-        for log in group:
-            count += int(requests.get(log + "?hostnames=%s" % hostname).text)
-        return count
-
-    chisel2.auth_and_issue([hostname])
-
-    got = [ submissions(log_groups[0]), submissions(log_groups[1]) ]
-    expected = [ 1, 2 ]
-
-    for i in range(len(log_groups)):
-        if got[i] < expected[i]:
-            raise(Exception("For log group %d, got %d submissions, expected %d." %
-                (i, got[i], expected[i])))
 
 def check_ocsp_basic_oid(cert_file, issuer_file, url):
     """


### PR DESCRIPTION
- Remove deprecated code for #5938
- Fix broken metrics flagged in #6435
- Make CT operator and log selection random

Fixes #6435
Fixes #5938
Fixes #6486