### PR TITLE
bgrpc.NewServer: support multiple services

### DIFF
--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -435,10 +435,9 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 		stopped <- true
 	}()
 
-	start, stopFn, err := bgrpc.Server[akamaipb.AkamaiPurgerServer]{}.Setup(
-		c.AkamaiPurger.GRPC, ap, akamaipb.RegisterAkamaiPurgerServer, tlsConfig, scope, clk,
-	)
+	srv, start, stopFn, err := bgrpc.NewServer(c.AkamaiPurger.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup Akamai purger gRPC server")
+	akamaipb.RegisterAkamaiPurgerServer(srv, ap)
 
 	go cmd.CatchSignals(logger, func() {
 		stopFn()

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -435,9 +435,9 @@ func daemon(c Config, ap *akamaiPurger, logger blog.Logger, scope prometheus.Reg
 		stopped <- true
 	}()
 
-	srv, start, stopFn, err := bgrpc.NewServer(c.AkamaiPurger.GRPC, tlsConfig, scope, clk)
+	start, stopFn, err := bgrpc.NewServer(c.AkamaiPurger.GRPC).Add(
+		&akamaipb.AkamaiPurger_ServiceDesc, ap).Build(tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup Akamai purger gRPC server")
-	akamaipb.RegisterAkamaiPurgerServer(srv, ap)
 
 	go cmd.CatchSignals(logger, func() {
 		stopFn()

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -287,9 +287,9 @@ func main() {
 		cmd.FailOnError(err, "Failed to create OCSP impl")
 		go ocspiReal.LogOCSPLoop()
 
-		srv, ocspStart, ocspStop, err := bgrpc.NewServer(c.CA.GRPCOCSPGenerator, tlsConfig, scope, clk)
+		ocspStart, ocspStop, err := bgrpc.NewServer(c.CA.GRPCOCSPGenerator).Add(
+			&capb.OCSPGenerator_ServiceDesc, ocspiReal).Build(tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA OCSP gRPC server")
-		capb.RegisterOCSPGeneratorServer(srv, ocspiReal)
 
 		wg.Add(1)
 		go func() {
@@ -315,9 +315,9 @@ func main() {
 		)
 		cmd.FailOnError(err, "Failed to create CRL impl")
 
-		srv, crlStart, crlStop, err := bgrpc.NewServer(c.CA.GRPCCRLGenerator, tlsConfig, scope, clk)
+		crlStart, crlStop, err := bgrpc.NewServer(c.CA.GRPCCRLGenerator).Add(
+			&capb.CRLGenerator_ServiceDesc, crli).Build(tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA CRL gRPC server")
-		capb.RegisterCRLGeneratorServer(srv, crli)
 
 		wg.Add(1)
 		go func() {
@@ -354,9 +354,9 @@ func main() {
 			go cai.OrphanIntegrationLoop()
 		}
 
-		srv, caStart, caStop, err := bgrpc.NewServer(c.CA.GRPCCA, tlsConfig, scope, clk)
+		caStart, caStop, err := bgrpc.NewServer(c.CA.GRPCCA).Add(
+			&capb.CertificateAuthority_ServiceDesc, cai).Build(tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA gRPC server")
-		capb.RegisterCertificateAuthorityServer(srv, cai)
 
 		wg.Add(1)
 		go func() {

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -2,7 +2,6 @@ package notmain
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"sync"
 
@@ -215,7 +214,7 @@ func main() {
 	cmd.FailOnError(err, "Couldn't create PA")
 
 	if c.CA.HostnamePolicyFile == "" {
-		cmd.FailOnError(fmt.Errorf("HostnamePolicyFile was empty."), "")
+		cmd.Fail("HostnamePolicyFile was empty")
 	}
 	err = pa.SetHostnamePolicyFile(c.CA.HostnamePolicyFile)
 	cmd.FailOnError(err, "Couldn't load hostname policy file")
@@ -288,10 +287,10 @@ func main() {
 		cmd.FailOnError(err, "Failed to create OCSP impl")
 		go ocspiReal.LogOCSPLoop()
 
-		ocspStart, ocspStop, err := bgrpc.Server[capb.OCSPGeneratorServer]{}.Setup(
-			c.CA.GRPCOCSPGenerator, ocspiReal, capb.RegisterOCSPGeneratorServer, tlsConfig, scope, clk,
-		)
+		srv, ocspStart, ocspStop, err := bgrpc.NewServer(c.CA.GRPCOCSPGenerator, tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA OCSP gRPC server")
+		capb.RegisterOCSPGeneratorServer(srv, ocspiReal)
+
 		wg.Add(1)
 		go func() {
 			cmd.FailOnError(ocspStart(), "OCSPGenerator gRPC service failed")
@@ -316,10 +315,10 @@ func main() {
 		)
 		cmd.FailOnError(err, "Failed to create CRL impl")
 
-		crlStart, crlStop, err := bgrpc.Server[capb.CRLGeneratorServer]{}.Setup(
-			c.CA.GRPCCRLGenerator, crli, capb.RegisterCRLGeneratorServer, tlsConfig, scope, clk,
-		)
+		srv, crlStart, crlStop, err := bgrpc.NewServer(c.CA.GRPCCRLGenerator, tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA CRL gRPC server")
+		capb.RegisterCRLGeneratorServer(srv, crli)
+
 		wg.Add(1)
 		go func() {
 			cmd.FailOnError(crlStart(), "CRLGenerator gRPC service failed")
@@ -355,10 +354,10 @@ func main() {
 			go cai.OrphanIntegrationLoop()
 		}
 
-		caStart, caStop, err := bgrpc.Server[capb.CertificateAuthorityServer]{}.Setup(
-			c.CA.GRPCCA, cai, capb.RegisterCertificateAuthorityServer, tlsConfig, scope, clk,
-		)
+		srv, caStart, caStop, err := bgrpc.NewServer(c.CA.GRPCCA, tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Unable to setup CA gRPC server")
+		capb.RegisterCertificateAuthorityServer(srv, cai)
+
 		wg.Add(1)
 		go func() {
 			cmd.FailOnError(caStart(), "CA gRPC service failed")

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -99,10 +99,9 @@ func main() {
 
 	pubi := publisher.New(bundles, c.Publisher.UserAgent, logger, scope)
 
-	start, stop, err := bgrpc.Server[pubpb.PublisherServer]{}.Setup(
-		c.Publisher.GRPC, pubi, pubpb.RegisterPublisherServer, tlsConfig, scope, clk,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.Publisher.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup Publisher gRPC server")
+	pubpb.RegisterPublisherServer(srv, pubi)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "Publisher gRPC service failed")

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -99,9 +99,9 @@ func main() {
 
 	pubi := publisher.New(bundles, c.Publisher.UserAgent, logger, scope)
 
-	srv, start, stop, err := bgrpc.NewServer(c.Publisher.GRPC, tlsConfig, scope, clk)
+	start, stop, err := bgrpc.NewServer(c.Publisher.GRPC).Add(
+		&pubpb.Publisher_ServiceDesc, pubi).Build(tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup Publisher gRPC server")
-	pubpb.RegisterPublisherServer(srv, pubi)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "Publisher gRPC service failed")

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -287,9 +287,9 @@ func main() {
 	rai.OCSP = ocspc
 	rai.SA = sac
 
-	srv, start, stop, err := bgrpc.NewServer(c.RA.GRPC, tlsConfig, scope, clk)
+	start, stop, err := bgrpc.NewServer(c.RA.GRPC).Add(
+		&rapb.RegistrationAuthority_ServiceDesc, rai).Build(tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup RA gRPC server")
-	rapb.RegisterRegistrationAuthorityServer(srv, rai)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "RA gRPC service failed")

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -287,10 +287,9 @@ func main() {
 	rai.OCSP = ocspc
 	rai.SA = sac
 
-	start, stop, err := bgrpc.Server[rapb.RegistrationAuthorityServer]{}.Setup(
-		c.RA.GRPC, rai, rapb.RegisterRegistrationAuthorityServer, tlsConfig, scope, clk,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.RA.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup RA gRPC server")
+	rapb.RegisterRegistrationAuthorityServer(srv, rai)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "RA gRPC service failed")

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -106,9 +106,9 @@ func main() {
 	tls, err := c.SA.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
-	srv, start, stop, err := bgrpc.NewServer(c.SA.GRPC, tls, scope, clk, bgrpc.NoCancelInterceptor)
+	start, stop, err := bgrpc.NewServer(c.SA.GRPC).Add(
+		&sapb.StorageAuthority_ServiceDesc, sai).Build(tls, scope, clk, bgrpc.NoCancelInterceptor)
 	cmd.FailOnError(err, "Unable to setup SA gRPC server")
-	sapb.RegisterStorageAuthorityServer(srv, sai)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "SA gRPC service failed")

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -106,10 +106,9 @@ func main() {
 	tls, err := c.SA.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
-	start, stop, err := bgrpc.Server[sapb.StorageAuthorityServer]{}.Setup(
-		c.SA.GRPC, sai, sapb.RegisterStorageAuthorityServer, tls, scope, clk, bgrpc.NoCancelInterceptor,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.SA.GRPC, tls, scope, clk, bgrpc.NoCancelInterceptor)
 	cmd.FailOnError(err, "Unable to setup SA gRPC server")
+	sapb.RegisterStorageAuthorityServer(srv, sai)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "SA gRPC service failed")

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"time"
 
-	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-
 	"github.com/honeycombio/beeline-go"
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/cmd"
@@ -183,23 +180,17 @@ func main() {
 		c.VA.AccountURIPrefixes)
 	cmd.FailOnError(err, "Unable to create VA server")
 
-	grpcSrv, l, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, scope, clk)
+	grpcSrv, start, stop, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup VA gRPC server")
 	vapb.RegisterVAServer(grpcSrv, vai)
-	cmd.FailOnError(err, "Unable to register VA gRPC server")
 	vapb.RegisterCAAServer(grpcSrv, vai)
-	cmd.FailOnError(err, "Unable to register CAA gRPC server")
-	hs := health.NewServer()
-	healthpb.RegisterHealthServer(grpcSrv, hs)
 
 	go cmd.CatchSignals(logger, func() {
 		servers.Stop()
-		hs.Shutdown()
-		grpcSrv.GracefulStop()
+		stop()
 	})
 
-	err = cmd.FilterShutdownErrors(grpcSrv.Serve(l))
-	cmd.FailOnError(err, "VA gRPC service failed")
+	cmd.FailOnError(start(), "VA gRPC service failed")
 }
 
 func init() {

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -180,10 +180,10 @@ func main() {
 		c.VA.AccountURIPrefixes)
 	cmd.FailOnError(err, "Unable to create VA server")
 
-	grpcSrv, start, stop, err := bgrpc.NewServer(c.VA.GRPC, tlsConfig, scope, clk)
+	start, stop, err := bgrpc.NewServer(c.VA.GRPC).Add(
+		&vapb.VA_ServiceDesc, vai).Add(
+		&vapb.CAA_ServiceDesc, vai).Build(tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup VA gRPC server")
-	vapb.RegisterVAServer(grpcSrv, vai)
-	vapb.RegisterCAAServer(grpcSrv, vai)
 
 	go cmd.CatchSignals(logger, func() {
 		servers.Stop()

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -389,19 +389,33 @@ func (c *GRPCClientConfig) MakeTargetAndHostOverride() (string, string, error) {
 	}
 }
 
-// GRPCServerConfig contains the information needed to run a gRPC service
+// GRPCServerConfig contains the information needed to start a gRPC server.
 type GRPCServerConfig struct {
 	Address string `json:"address"`
 	// ClientNames is a list of allowed client certificate subject alternate names
 	// (SANs). The server will reject clients that do not present a certificate
 	// with a SAN present on the `ClientNames` list.
+	// DEPRECATED: Use the ClientNames field within each Service instead.
 	ClientNames []string `json:"clientNames"`
+	// Services is a map of service names to configuration specific to that service.
+	// These service names must match the service names advertised by gRPC itself,
+	// which are identical to the names set in our gRPC .proto files.
+	Services map[string]GRPCServiceConfig `json:"services"`
 	// MaxConnectionAge specifies how long a connection may live before the server sends a GoAway to the
 	// client. Because gRPC connections re-resolve DNS after a connection close,
 	// this controls how long it takes before a client learns about changes to its
 	// backends.
 	// https://pkg.go.dev/google.golang.org/grpc/keepalive#ServerParameters
 	MaxConnectionAge ConfigDuration
+}
+
+// GRPCServiceConfig contains the information needed to configure a gRPC service.
+type GRPCServiceConfig struct {
+	// PerServiceClientNames is a map of gRPC service names to client certificate
+	// SANs. The upstream listening server will reject connections from clients
+	// which do not appear in this list, and the server interceptor will reject
+	// RPC calls for this service from clients which are not listed here.
+	ClientNames []string `json:"clientNames"`
 }
 
 // PortConfig specifies what ports the VA should call to on the remote

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -399,7 +399,8 @@ type GRPCServerConfig struct {
 	ClientNames []string `json:"clientNames"`
 	// Services is a map of service names to configuration specific to that service.
 	// These service names must match the service names advertised by gRPC itself,
-	// which are identical to the names set in our gRPC .proto files.
+	// which are identical to the names set in our gRPC .proto files prefixed by
+	// the package names set in those files (e.g. "ca.CertificateAuthority").
 	Services map[string]GRPCServiceConfig `json:"services"`
 	// MaxConnectionAge specifies how long a connection may live before the server sends a GoAway to the
 	// client. Because gRPC connections re-resolve DNS after a connection close,

--- a/cmd/crl-storer/main.go
+++ b/cmd/crl-storer/main.go
@@ -130,10 +130,9 @@ func main() {
 	csi, err := storer.New(issuers, s3client, c.CRLStorer.S3Bucket, scope, logger, clk)
 	cmd.FailOnError(err, "Failed to create CRLStorer impl")
 
-	start, stop, err := bgrpc.Server[cspb.CRLStorerServer]{}.Setup(
-		c.CRLStorer.GRPC, csi, cspb.RegisterCRLStorerServer, tlsConfig, scope, clk,
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.CRLStorer.GRPC, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup CRLStorer gRPC server")
+	cspb.RegisterCRLStorerServer(srv, csi)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "CRLStorer gRPC service failed")

--- a/cmd/crl-storer/main.go
+++ b/cmd/crl-storer/main.go
@@ -130,9 +130,9 @@ func main() {
 	csi, err := storer.New(issuers, s3client, c.CRLStorer.S3Bucket, scope, logger, clk)
 	cmd.FailOnError(err, "Failed to create CRLStorer impl")
 
-	srv, start, stop, err := bgrpc.NewServer(c.CRLStorer.GRPC, tlsConfig, scope, clk)
+	start, stop, err := bgrpc.NewServer(c.CRLStorer.GRPC).Add(
+		&cspb.CRLStorer_ServiceDesc, csi).Build(tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to setup CRLStorer gRPC server")
-	cspb.RegisterCRLStorerServer(srv, csi)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "CRLStorer gRPC service failed")

--- a/cmd/nonce-service/main.go
+++ b/cmd/nonce-service/main.go
@@ -79,9 +79,9 @@ func main() {
 	cmd.FailOnError(err, "tlsConfig config")
 
 	nonceServer := &nonceServer{inner: ns}
-	srv, start, stop, err := bgrpc.NewServer(c.NonceService.GRPC, tlsConfig, scope, cmd.Clock())
+	start, stop, err := bgrpc.NewServer(c.NonceService.GRPC).Add(
+		&noncepb.NonceService_ServiceDesc, nonceServer).Build(tlsConfig, scope, cmd.Clock())
 	cmd.FailOnError(err, "Unable to setup nonce service gRPC server")
-	noncepb.RegisterNonceServiceServer(srv, nonceServer)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "Nonce service gRPC server failed")

--- a/cmd/nonce-service/main.go
+++ b/cmd/nonce-service/main.go
@@ -79,10 +79,9 @@ func main() {
 	cmd.FailOnError(err, "tlsConfig config")
 
 	nonceServer := &nonceServer{inner: ns}
-	start, stop, err := bgrpc.Server[noncepb.NonceServiceServer]{}.Setup(
-		c.NonceService.GRPC, nonceServer, noncepb.RegisterNonceServiceServer, tlsConfig, scope, cmd.Clock(),
-	)
+	srv, start, stop, err := bgrpc.NewServer(c.NonceService.GRPC, tlsConfig, scope, cmd.Clock())
 	cmd.FailOnError(err, "Unable to setup nonce service gRPC server")
+	noncepb.RegisterNonceServiceServer(srv, nonceServer)
 
 	go cmd.CatchSignals(logger, stop)
 	cmd.FailOnError(start(), "Nonce service gRPC server failed")

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -332,19 +332,3 @@ func CatchSignals(logger blog.Logger, callback func()) {
 
 	os.Exit(0)
 }
-
-// FilterShutdownErrors returns the input error, with the exception of "use of
-// closed network connection," on which it returns nil
-// Per https://github.com/grpc/grpc-go/issues/1017, a gRPC server's `Serve()`
-// will always return an error, even when GracefulStop() is called. We don't
-// want to log graceful stops as errors, so we filter out the meaningless
-// error we get in that situation.
-func FilterShutdownErrors(err error) error {
-	if err == nil {
-		return nil
-	}
-	if strings.Contains(err.Error(), "use of closed network connection") {
-		return nil
-	}
-	return err
-}

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -24,50 +24,13 @@ var CodedError = status.Errorf
 
 var errNilTLS = errors.New("boulder/grpc: received nil tls.Config")
 
-// Server is a generic type that exists solely to allow its one method, Setup,
-// to be generic over the type of server it is setting up.
-type Server[T any] struct{}
-
-// Setup creates and registers a new gRPC server. It also creates and registers
-// a corresponding health server. It returns a function to start the server (so
-// that it may be run synchronously, or started in a goroutine), a function to
-// gracefully stop both the health and primary servers at shutdown time, and an
-// error in case any of the setup fails.
-func (s Server[T]) Setup(
-	config *cmd.GRPCServerConfig,
-	impl T,
-	registerer func(grpc.ServiceRegistrar, T),
-	tlsConfig *tls.Config,
-	statsRegistry prometheus.Registerer,
-	clk clock.Clock,
-	interceptors ...grpc.UnaryServerInterceptor,
-) (func() error, func(), error) {
-	server, listener, err := NewServer(config, tlsConfig, statsRegistry, clk, interceptors...)
-	if err != nil {
-		return nil, nil, err
-	}
-	registerer(server, impl)
-
-	healthServer := health.NewServer()
-	healthpb.RegisterHealthServer(server, healthServer)
-
-	start := func() error {
-		return cmd.FilterShutdownErrors(server.Serve(listener))
-	}
-	stop := func() {
-		healthServer.Shutdown()
-		server.GracefulStop()
-	}
-	return start, stop, nil
-}
-
 // NewServer creates a gRPC server that uses the provided *tls.Config, and
 // verifies that clients present a certificate that (a) is signed by one of
 // the configured ClientCAs, and (b) contains at least one
 // subjectAlternativeName matching the accepted list from GRPCServerConfig.
-func NewServer(c *cmd.GRPCServerConfig, tlsConfig *tls.Config, statsRegistry prometheus.Registerer, clk clock.Clock, interceptors ...grpc.UnaryServerInterceptor) (*grpc.Server, net.Listener, error) {
+func NewServer(c *cmd.GRPCServerConfig, tlsConfig *tls.Config, statsRegistry prometheus.Registerer, clk clock.Clock, interceptors ...grpc.UnaryServerInterceptor) (*grpc.Server, func() error, func(), error) {
 	if tlsConfig == nil {
-		return nil, nil, errNilTLS
+		return nil, nil, nil, errNilTLS
 	}
 	acceptedSANs := make(map[string]struct{})
 	for _, name := range c.ClientNames {
@@ -76,17 +39,17 @@ func NewServer(c *cmd.GRPCServerConfig, tlsConfig *tls.Config, statsRegistry pro
 
 	metrics, err := newServerMetrics(statsRegistry)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	creds, err := bcreds.NewServerCredentials(tlsConfig, acceptedSANs)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	l, err := net.Listen("tcp", c.Address)
+	listener, err := net.Listen("tcp", c.Address)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	si := newServerInterceptor(metrics, clk)
@@ -114,7 +77,21 @@ func NewServer(c *cmd.GRPCServerConfig, tlsConfig *tls.Config, statsRegistry pro
 				MaxConnectionAge: c.MaxConnectionAge.Duration,
 			}))
 	}
-	return grpc.NewServer(options...), l, nil
+
+	server := grpc.NewServer(options...)
+
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(server, healthServer)
+
+	start := func() error {
+		return cmd.FilterShutdownErrors(server.Serve(listener))
+	}
+	stop := func() {
+		healthServer.Shutdown()
+		server.GracefulStop()
+	}
+
+	return server, start, stop, nil
 }
 
 // serverMetrics is a struct type used to return a few registered metrics from

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -26,13 +26,16 @@ var CodedError = status.Errorf
 
 var errNilTLS = errors.New("boulder/grpc: received nil tls.Config")
 
+// service represents a single gRPC service that can be registered with a gRPC
+// server.
 type service struct {
 	cfg  cmd.GRPCServiceConfig
 	desc *grpc.ServiceDesc
 	impl any
 }
 
-// serverBuilder
+// serverBuilder implements a builder pattern for constructing new gRPC servers
+// and registering gRPC services on those servers.
 type serverBuilder struct {
 	cfg      *cmd.GRPCServerConfig
 	services map[string]service
@@ -90,9 +93,6 @@ func (sb *serverBuilder) Build(tlsConfig *tls.Config, statsRegistry prometheus.R
 		return nil, nil, sb.err
 	}
 
-	// TODO: Remove this check once all Boulder components have their services
-	// properly configured. In theory we'd like to keep this, but we can't do both
-	// this and the desired check in .Add() for deployability reasons.
 	for serviceName := range sb.cfg.Services {
 		_, ok := sb.services[serviceName]
 		if !ok {

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -20,10 +20,18 @@
     "grpc": {
       "address": ":9099",
       "maxConnectionAge": "30s",
-      "clientNames": [
-        "health-checker.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "akamai.AkamaiPurger": {
+          "clientNames": [
+            "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     }
   },
 

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -10,28 +10,52 @@
     "grpcCA": {
       "maxConnectionAge": "30s",
       "address": ":9093",
-      "clientNames": [
-        "health-checker.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "ca.CertificateAuthority": {
+          "clientNames": [
+            "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "grpcOCSPGenerator": {
       "maxConnectionAge": "30s",
       "address": ":9096",
-      "clientNames": [
-        "health-checker.boulder",
-        "ocsp-updater.boulder",
-        "orphan-finder.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "ca.OCSPGenerator": {
+          "clientNames": [
+            "ocsp-updater.boulder",
+            "orphan-finder.boulder",
+            "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "grpcCRLGenerator": {
       "maxConnectionAge": "30s",
       "address": ":9106",
-      "clientNames": [
-        "health-checker.boulder",
-        "crl-updater.boulder"
-      ]
+      "services": {
+        "ca.CRLGenerator": {
+          "clientNames": [
+            "crl-updater.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "saService": {
       "srvLookup": {

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -10,28 +10,52 @@
     "grpcCA": {
       "maxConnectionAge": "30s",
       "address": ":9093",
-      "clientNames": [
-        "health-checker.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "ca.CertificateAuthority": {
+          "clientNames": [
+            "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "grpcOCSPGenerator": {
       "maxConnectionAge": "30s",
       "address": ":9096",
-      "clientNames": [
-        "health-checker.boulder",
-        "ocsp-updater.boulder",
-        "orphan-finder.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "ca.OCSPGenerator": {
+          "clientNames": [
+            "ocsp-updater.boulder",
+            "orphan-finder.boulder",
+            "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "grpcCRLGenerator": {
       "maxConnectionAge": "30s",
       "address": ":9106",
-      "clientNames": [
-        "health-checker.boulder",
-        "crl-updater.boulder"
-      ]
+      "services": {
+        "ca.CRLGenerator": {
+          "clientNames": [
+            "crl-updater.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "saService": {
       "srvLookup": {

--- a/test/config-next/crl-storer.json
+++ b/test/config-next/crl-storer.json
@@ -9,10 +9,18 @@
     "grpc": {
       "address": ":9109",
       "maxConnectionAge": "30s",
-      "clientNames": [
-        "health-checker.boulder",
-        "crl-updater.boulder"
-      ]
+      "services": {
+        "storer.CRLStorer": {
+          "clientNames": [
+            "crl-updater.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "issuerCerts": [
       "/hierarchy/intermediate-cert-rsa-a.pem",

--- a/test/config-next/nonce.json
+++ b/test/config-next/nonce.json
@@ -1,29 +1,37 @@
 {
-    "NonceService": {
-        "maxUsed": 131072,
-        "noncePrefix": "taro",
-        "syslog": {
-            "stdoutLevel": 6,
-            "syslogLevel": -1
+  "NonceService": {
+    "maxUsed": 131072,
+    "noncePrefix": "taro",
+    "syslog": {
+      "stdoutLevel": 6,
+      "syslogLevel": -1
+    },
+    "beeline": {
+      "mute": true,
+      "serviceName": "Test",
+      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
+    },
+    "debugAddr": ":8111",
+    "grpc": {
+      "maxConnectionAge": "30s",
+      "address": ":9101",
+      "services": {
+        "nonce.NonceService": {
+          "clientNames": [
+            "wfe.boulder"
+          ]
         },
-        "beeline": {
-            "mute": true,
-            "serviceName": "Test",
-            "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-        },
-        "debugAddr": ":8111",
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9101",
-            "clientNames": [
-                "health-checker.boulder",
-                "wfe.boulder"
-            ]
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
         }
+      }
+    },
+    "tls": {
+      "caCertFile": "test/grpc-creds/minica.pem",
+      "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
+      "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
     }
+  }
 }

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -24,11 +24,19 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9091",
-      "clientNames": [
-        "health-checker.boulder",
-        "ocsp-updater.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "Publisher": {
+          "clientNames": [
+            "ocsp-updater.boulder",
+            "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -75,13 +75,21 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9094",
-      "clientNames": [
-        "admin-revoker.boulder",
-        "bad-key-revoker.boulder",
-        "health-checker.boulder",
-        "ocsp-responder.boulder",
-        "wfe.boulder"
-      ]
+      "services": {
+        "ra.RegistrationAuthority": {
+          "clientNames": [
+            "admin-revoker.boulder",
+            "bad-key-revoker.boulder",
+            "ocsp-responder.boulder",
+            "wfe.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "features": {
       "StoreRevokerInfo": true,

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -22,18 +22,26 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9095",
-      "clientNames": [
-        "admin-revoker.boulder",
-        "ca.boulder",
-        "crl-updater.boulder",
-        "expiration-mailer.boulder",
-        "health-checker.boulder",
-        "ocsp-responder.boulder",
-        "orphan-finder.boulder",
-        "ra.boulder",
-        "sa.boulder",
-        "wfe.boulder"
-      ]
+      "services": {
+        "sa.StorageAuthority": {
+          "clientNames": [
+            "admin-revoker.boulder",
+            "ca.boulder",
+            "crl-updater.boulder",
+            "expiration-mailer.boulder",
+            "ocsp-responder.boulder",
+            "orphan-finder.boulder",
+            "ra.boulder",
+            "sa.boulder",
+            "wfe.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "redis": {
       "username": "boulder-sa",

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -20,10 +20,21 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9097",
-      "clientNames": [
-        "health-checker.boulder",
-        "va.boulder"
-      ]
+      "services": {
+        "va.VA": {
+          "clientNames": [
+            "va.boulder"
+          ]
+        },
+        "va.CAA": {
+          "clientNames": []
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "features": {
       "CAAValidationMethods": true,

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -20,10 +20,21 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9098",
-      "clientNames": [
-        "health-checker.boulder",
-        "va.boulder"
-      ]
+      "services": {
+        "va.VA": {
+          "clientNames": [
+            "va.boulder"
+          ]
+        },
+        "va.CAA": {
+          "clientNames": []
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "features": {
       "CAAValidationMethods": true,

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -20,10 +20,23 @@
     "grpc": {
       "maxConnectionAge": "30s",
       "address": ":9092",
-      "clientNames": [
-        "health-checker.boulder",
-        "ra.boulder"
-      ]
+      "services": {
+        "va.VA": {
+          "clientNames": [
+            "ra.boulder"
+          ]
+        },
+        "va.CAA": {
+          "clientNames": [
+            "ra.boulder"
+          ]
+        },
+        "grpc.health.v1.Health": {
+          "clientNames": [
+            "health-checker.boulder"
+          ]
+        }
+      }
     },
     "features": {
       "CAAValidationMethods": true,


### PR DESCRIPTION
Turn bgrpc.NewServer into a builder-pattern, with a config-based initialization, multiple calls to Add to add new gRPC services, and a final call to Build to produce the start() and stop() functions which control server behavior. All calls are chainable to produce compact code in each component's main() function.

This improves the process of creating a new gRPC server in three ways:
1) It avoids the need for generics/templating, which was slightly verbose.
2) It allows the set of services to be registered on this server to be known ahead of time.
3) It greatly streamlines adding multiple services to the same server, which we use today in the VA and will be using soon in the SA and CA.

While we're here, add a new per-service config stanza to the GRPCServerConfig, so that individual services on the same server can have their own configuration. For now, only provide a "ClientNames" key, which will be used in a follow-up PR.

Part of #6454