### PR TITLE
SA: Standardize methods which use COUNT queries

### DIFF
--- a/db/map_test.go
+++ b/db/map_test.go
@@ -142,11 +142,11 @@ func TestTableFromQuery(t *testing.T) {
 			expectedTable: "`registrations`",
 		},
 		{
-			query:         "SELECT COUNT(1) FROM registrations WHERE initialIP = ? AND ? < createdAt AND createdAt <= ?",
+			query:         "SELECT COUNT(*) FROM registrations WHERE initialIP = ? AND ? < createdAt AND createdAt <= ?",
 			expectedTable: "registrations",
 		},
 		{
-			query:         "SELECT count(1) FROM orders WHERE registrationID = ? AND created >= ? AND created < ?",
+			query:         "SELECT COUNT(*) FROM orders WHERE registrationID = ? AND created >= ? AND created < ?",
 			expectedTable: "orders",
 		},
 		{

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -148,7 +148,7 @@ func TestAutoIncrementSchema(t *testing.T) {
 	var count int64
 	err = dbMap.SelectOne(
 		&count,
-		`SELECT COUNT(1) FROM columns WHERE
+		`SELECT COUNT(*) FROM columns WHERE
 			table_schema LIKE 'boulder%' AND
 			extra LIKE '%auto_increment%' AND
 			data_type != "bigint"`)

--- a/sa/precertificates.go
+++ b/sa/precertificates.go
@@ -94,7 +94,7 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 		var row struct {
 			Count int64
 		}
-		err := txWithCtx.SelectOne(&row, "SELECT count(1) as count FROM precertificates WHERE serial=?", serialHex)
+		err := txWithCtx.SelectOne(&row, "SELECT COUNT(*) as count FROM precertificates WHERE serial=?", serialHex)
 		if err != nil {
 			return nil, err
 		}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -183,7 +183,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(ctx context.Context, req *sapb.Ad
 		var row struct {
 			Count int64
 		}
-		err := txWithCtx.SelectOne(&row, "SELECT count(1) as count FROM certificates WHERE serial=?", serial)
+		err := txWithCtx.SelectOne(&row, "SELECT COUNT(*) as count FROM certificates WHERE serial=?", serial)
 		if err != nil {
 			return nil, err
 		}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1914,7 +1914,7 @@ func TestAddCertificateRenewalBit(t *testing.T) {
 		var count int
 		err := sa.dbMap.SelectOne(
 			&count,
-			`SELECT COUNT(1) FROM issuedNames
+			`SELECT COUNT(*) FROM issuedNames
 		WHERE reversedName = ?
 		AND renewal = ?`,
 			ReverseName(name),

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -194,7 +194,7 @@ func (ssa *SQLStorageAuthorityRO) CountRegistrationsByIP(ctx context.Context, re
 			"latest":   time.Unix(0, req.Range.Latest),
 		})
 	if err != nil {
-		return &sapb.Count{Count: 0}, err
+		return nil, err
 	}
 	return &sapb.Count{Count: count}, nil
 }
@@ -229,7 +229,7 @@ func (ssa *SQLStorageAuthorityRO) CountRegistrationsByIPRange(ctx context.Contex
 			"endIP":    endIP,
 		})
 	if err != nil {
-		return &sapb.Count{Count: 0}, err
+		return nil, err
 	}
 	return &sapb.Count{Count: count}, nil
 }

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -183,7 +183,7 @@ func (ssa *SQLStorageAuthorityRO) CountRegistrationsByIP(ctx context.Context, re
 	var count int64
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,
-		`SELECT COUNT(1) FROM registrations
+		`SELECT COUNT(*) FROM registrations
 		 WHERE
 		 initialIP = :ip AND
 		 :earliest < createdAt AND
@@ -194,7 +194,7 @@ func (ssa *SQLStorageAuthorityRO) CountRegistrationsByIP(ctx context.Context, re
 			"latest":   time.Unix(0, req.Range.Latest),
 		})
 	if err != nil {
-		return &sapb.Count{Count: -1}, err
+		return &sapb.Count{Count: 0}, err
 	}
 	return &sapb.Count{Count: count}, nil
 }
@@ -216,7 +216,7 @@ func (ssa *SQLStorageAuthorityRO) CountRegistrationsByIPRange(ctx context.Contex
 	beginIP, endIP := ipRange(req.Ip)
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,
-		`SELECT COUNT(1) FROM registrations
+		`SELECT COUNT(*) FROM registrations
 		 WHERE
 		 :beginIP <= initialIP AND
 		 initialIP < :endIP AND
@@ -229,7 +229,7 @@ func (ssa *SQLStorageAuthorityRO) CountRegistrationsByIPRange(ctx context.Contex
 			"endIP":    endIP,
 		})
 	if err != nil {
-		return &sapb.Count{Count: -1}, err
+		return &sapb.Count{Count: 0}, err
 	}
 	return &sapb.Count{Count: count}, nil
 }
@@ -430,7 +430,7 @@ func (ssa *SQLStorageAuthorityRO) CountFQDNSets(ctx context.Context, req *sapb.C
 	var count int64
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,
-		`SELECT COUNT(1) FROM fqdnSets
+		`SELECT COUNT(*) FROM fqdnSets
 		WHERE setHash = ?
 		AND issued > ?`,
 		HashNames(req.Domains),
@@ -548,7 +548,7 @@ func (ssa *SQLStorageAuthorityRO) PreviousCertificateExists(ctx context.Context,
 	var count int
 	err = ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,
-		`SELECT COUNT(1) FROM certificates
+		`SELECT COUNT(*) FROM certificates
 		WHERE serial = ?
 		AND registrationID = ?`,
 		serial,
@@ -1025,7 +1025,7 @@ func (ssa *SQLStorageAuthorityRO) CountPendingAuthorizations2(ctx context.Contex
 
 	var count int64
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(&count,
-		`SELECT COUNT(1) FROM authz2 WHERE
+		`SELECT COUNT(*) FROM authz2 WHERE
 		registrationID = :regID AND
 		expires > :expires AND
 		status = :status`,
@@ -1102,7 +1102,7 @@ func (ssa *SQLStorageAuthorityRO) CountInvalidAuthorizations2(ctx context.Contex
 	var count int64
 	err := ssa.dbReadOnlyMap.WithContext(ctx).SelectOne(
 		&count,
-		`SELECT COUNT(1) FROM authz2 WHERE
+		`SELECT COUNT(*) FROM authz2 WHERE
 		registrationID = :regID AND
 		status = :status AND
 		expires > :expiresEarliest AND


### PR DESCRIPTION
- Replace `-1` in return values with `0`. No callers were depending on `-1`.
- Replace `count(` with `COUNT(` for the sake of readability.
- Replace `COUNT(1)` with `COUNT(*)` (https://mariadb.com/kb/en/count). Both
  versions provide identical outputs but let's standardize on the docs.

Fixes #6494