### PR TITLE
va: filter invalid UTF-8 from ProblemDetails

### DIFF
--- a/va/dns.go
+++ b/va/dns.go
@@ -89,5 +89,5 @@ func (va *ValidationAuthorityImpl) validateDNS01(ctx context.Context, ident iden
 		andMore = fmt.Sprintf(" (and %d more)", len(txts)-1)
 	}
 	return nil, probs.Unauthorized(fmt.Sprintf("Incorrect TXT record %q%s found at %s",
-		replaceInvalidUTF8([]byte(invalidRecord)), andMore, challengeSubdomain))
+		invalidRecord, andMore, challengeSubdomain))
 }

--- a/va/http.go
+++ b/va/http.go
@@ -643,7 +643,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 	// resulting payload is the same size as maxResponseSize fail
 	if len(body) >= maxResponseSize {
 		return nil, records, newIPError(target, berrors.UnauthorizedError("Invalid response from %s: %q",
-			records[len(records)-1].URL, replaceInvalidUTF8(body)))
+			records[len(records)-1].URL, body))
 	}
 	return body, records, nil
 }

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -1083,23 +1083,6 @@ func TestFetchHTTP(t *testing.T) {
 	}
 }
 
-func TestFetchHTTPInvalidUTF8(t *testing.T) {
-	testSrv := httpTestSrv(t)
-	defer testSrv.Close()
-	va, _ := setup(testSrv, 0, "", nil)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer cancel()
-	_, _, prob := va.fetchHTTP(ctx, "example.com", "/invalid-utf8-body")
-	expectedResult := "f\ufffdoo"
-	// If the body of the http response is larger than the maxResponseSize
-	// a truncated body is returned as part of the error detail. If the
-	// body contains invalid UTF-8 the invalid characters must be replaced
-	// before the error is marshalled for grpc. This tests that the
-	// invalid string "f\xffoo" is expected to be converted to
-	// "f\ufffdoo".
-	test.AssertContains(t, prob.Detail, expectedResult)
-}
-
 // All paths that get assigned to tokens MUST be valid tokens
 const pathWrongToken = "i6lNAC4lOOLYCl-A08VJt9z_tKYvVk63Dumo8icsBjQ"
 const path404 = "404"

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -586,20 +586,6 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 		fmt.Fprint(resp, tooLargeBuf)
 	})
 
-	// Create a buffer that starts with invalid UTF8 and is bigger than
-	// maxResponseSize
-	tooLargeInvalidUTF8 := bytes.NewBuffer([]byte{})
-	tooLargeInvalidUTF8.WriteString("f\xffoo")
-	tooLargeInvalidUTF8.Write(tooLargeBuf.Bytes())
-	// invalid-utf8-body Responds with body that is larger than
-	// maxResponseSize and starts with an invalid UTF8 string. This is to
-	// test the codepath where invalid UTF8 is converted to valid UTF8
-	// that can be passed as an error message via grpc.
-	mux.HandleFunc("/invalid-utf8-body", func(resp http.ResponseWriter, req *http.Request) {
-		resp.WriteHeader(http.StatusOK)
-		fmt.Fprint(resp, tooLargeInvalidUTF8)
-	})
-
 	mux.HandleFunc("/redir-path-too-long", func(resp http.ResponseWriter, req *http.Request) {
 		http.Redirect(
 			resp,
@@ -1081,23 +1067,6 @@ func TestFetchHTTP(t *testing.T) {
 			test.AssertMarshaledEquals(t, records, tc.ExpectedRecords)
 		})
 	}
-}
-
-func TestFetchHTTPInvalidUTF8(t *testing.T) {
-	testSrv := httpTestSrv(t)
-	defer testSrv.Close()
-	va, _ := setup(testSrv, 0, "", nil)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer cancel()
-	_, _, prob := va.fetchHTTP(ctx, "example.com", "/invalid-utf8-body")
-	expectedResult := "f\ufffdoo"
-	// If the body of the http response is larger than the maxResponseSize
-	// a truncated body is returned as part of the error detail. If the
-	// body contains invalid UTF-8 the invalid characters must be replaced
-	// before the error is marshalled for grpc. This tests that the
-	// invalid string "f\xffoo" is expected to be converted to
-	// "f\ufffdoo".
-	test.AssertContains(t, prob.Detail, expectedResult)
 }
 
 // All paths that get assigned to tokens MUST be valid tokens

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -586,6 +586,20 @@ func httpTestSrv(t *testing.T) *httptest.Server {
 		fmt.Fprint(resp, tooLargeBuf)
 	})
 
+	// Create a buffer that starts with invalid UTF8 and is bigger than
+	// maxResponseSize
+	tooLargeInvalidUTF8 := bytes.NewBuffer([]byte{})
+	tooLargeInvalidUTF8.WriteString("f\xffoo")
+	tooLargeInvalidUTF8.Write(tooLargeBuf.Bytes())
+	// invalid-utf8-body Responds with body that is larger than
+	// maxResponseSize and starts with an invalid UTF8 string. This is to
+	// test the codepath where invalid UTF8 is converted to valid UTF8
+	// that can be passed as an error message via grpc.
+	mux.HandleFunc("/invalid-utf8-body", func(resp http.ResponseWriter, req *http.Request) {
+		resp.WriteHeader(http.StatusOK)
+		fmt.Fprint(resp, tooLargeInvalidUTF8)
+	})
+
 	mux.HandleFunc("/redir-path-too-long", func(resp http.ResponseWriter, req *http.Request) {
 		http.Redirect(
 			resp,
@@ -1067,6 +1081,23 @@ func TestFetchHTTP(t *testing.T) {
 			test.AssertMarshaledEquals(t, records, tc.ExpectedRecords)
 		})
 	}
+}
+
+func TestFetchHTTPInvalidUTF8(t *testing.T) {
+	testSrv := httpTestSrv(t)
+	defer testSrv.Close()
+	va, _ := setup(testSrv, 0, "", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer cancel()
+	_, _, prob := va.fetchHTTP(ctx, "example.com", "/invalid-utf8-body")
+	expectedResult := "f\ufffdoo"
+	// If the body of the http response is larger than the maxResponseSize
+	// a truncated body is returned as part of the error detail. If the
+	// body contains invalid UTF-8 the invalid characters must be replaced
+	// before the error is marshalled for grpc. This tests that the
+	// invalid string "f\xffoo" is expected to be converted to
+	// "f\ufffdoo".
+	test.AssertContains(t, prob.Detail, expectedResult)
 }
 
 // All paths that get assigned to tokens MUST be valid tokens

--- a/va/utf8filter.go
+++ b/va/utf8filter.go
@@ -1,10 +1,19 @@
 package va
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/letsencrypt/boulder/probs"
+)
 
 // replaceInvalidUTF8 replaces all invalid UTF-8 encodings with
 // Unicode REPLACEMENT CHARACTER.
 func replaceInvalidUTF8(input []byte) string {
+	if utf8.Valid(input) {
+		return string(input)
+	}
+
 	var b strings.Builder
 
 	// Ranging over a string in Go produces runes. When the range keyword
@@ -13,4 +22,17 @@ func replaceInvalidUTF8(input []byte) string {
 		b.WriteRune(v)
 	}
 	return b.String()
+}
+
+// Call replaceInvalidUTF8 on all string fields of a ProblemDetails
+// and return the result.
+func filterProblemDetails(prob *probs.ProblemDetails) *probs.ProblemDetails {
+	if prob == nil {
+		return nil
+	}
+	return &probs.ProblemDetails{
+		Type:       probs.ProblemType(replaceInvalidUTF8([]byte(prob.Type))),
+		Detail:     replaceInvalidUTF8([]byte(prob.Detail)),
+		HTTPStatus: prob.HTTPStatus,
+	}
 }

--- a/va/utf8filter_test.go
+++ b/va/utf8filter_test.go
@@ -1,6 +1,11 @@
 package va
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/letsencrypt/boulder/probs"
+	"github.com/letsencrypt/boulder/test"
+)
 
 func TestReplaceInvalidUTF8(t *testing.T) {
 	input := "f\xffoo"
@@ -9,4 +14,20 @@ func TestReplaceInvalidUTF8(t *testing.T) {
 	if result != expected {
 		t.Errorf("replaceInvalidUTF8(%q): got %q, expected %q", input, result, expected)
 	}
+}
+
+func TestFilterProblemDetails(t *testing.T) {
+	test.Assert(t, filterProblemDetails(nil) == nil, "nil should filter to nil")
+	result := filterProblemDetails(&probs.ProblemDetails{
+		Type:       probs.ProblemType([]byte{0xff, 0xfe, 0xfd}),
+		Detail:     "seems okay so far whoah no \xFF\xFE\xFD",
+		HTTPStatus: 999,
+	})
+
+	expected := &probs.ProblemDetails{
+		Type:       "���",
+		Detail:     "seems okay so far whoah no ���",
+		HTTPStatus: 999,
+	}
+	test.AssertDeepEquals(t, result, expected)
 }

--- a/va/va.go
+++ b/va/va.go
@@ -374,9 +374,14 @@ func (va *ValidationAuthorityImpl) validate(
 	}()
 
 	// TODO(#1292): send into another goroutine
-	validationRecords, err := va.validateChallenge(ctx, baseIdentifier, challenge)
-	if err != nil {
-		return validationRecords, err
+	validationRecords, prob := va.validateChallenge(ctx, baseIdentifier, challenge)
+	if prob != nil {
+		// The ProblemDetails will be serialized through gRPC, which requires UTF-8.
+		// It will also later be serialized in JSON, which defaults to UTF-8. Make
+		// sure it is UTF-8 clean now.
+		prob = filterProblemDetails(prob)
+
+		return validationRecords, prob
 	}
 
 	for i := 0; i < cap(ch); i++ {
@@ -660,11 +665,6 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, req *v
 	if !challenge.RecordsSane() && prob == nil {
 		prob = probs.ServerInternal("Records for validation failed sanity check")
 	}
-
-	// The ProblemDetails will be serialized through gRPC, which requires UTF-8.
-	// It will also later be serialized in JSON, which defaults to UTF-8. Make
-	// sure it is UTF-8 clean now.
-	prob = filterProblemDetails(prob)
 
 	var problemType string
 	if prob != nil {

--- a/va/va.go
+++ b/va/va.go
@@ -661,6 +661,11 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, req *v
 		prob = probs.ServerInternal("Records for validation failed sanity check")
 	}
 
+	// The ProblemDetails will be serialized through gRPC, which requires UTF-8.
+	// It will also later be serialized in JSON, which defaults to UTF-8. Make
+	// sure it is UTF-8 clean now.
+	prob = filterProblemDetails(prob)
+
 	var problemType string
 	if prob != nil {
 		problemType = string(prob.Type)


### PR DESCRIPTION
This avoids serialization errors passing through gRPC.

Also, add a pass-through path in replaceInvalidUTF8 that saves an allocation in the trivial case.

Fixes #6490