### PR TITLE
add insecure option to HTTP Prober

### DIFF
--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -17,8 +17,14 @@ type HTTPProbe struct {
 }
 
 // Name returns a string that uniquely identifies the monitor.
+
 func (p HTTPProbe) Name() string {
-	return fmt.Sprintf("%s-%d-%s-insecure:%t", p.url, p.rcodes, p.useragent, p.insecure)
+	s := fmt.Sprintf("%s-%d-%s", p.url, p.rcodes, p.useragent)
+	if p.insecure {
+		return s + "-insecure"
+	} else {
+		return s + "-secure"
+	}
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Prober`.

--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -12,11 +12,12 @@ type HTTPProbe struct {
 	url       string
 	rcodes    []int
 	useragent string
+	insecure  bool
 }
 
 // Name returns a string that uniquely identifies the monitor.
 func (p HTTPProbe) Name() string {
-	return fmt.Sprintf("%s-%d-%s", p.url, p.rcodes, p.useragent)
+	return fmt.Sprintf("%s-%d-%s-%t", p.url, p.rcodes, p.useragent, p.insecure)
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Prober`.

--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -1,6 +1,7 @@
 package probers
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"time"
@@ -38,7 +39,11 @@ func (p HTTPProbe) isExpected(received int) bool {
 
 // Probe performs the configured HTTP request.
 func (p HTTPProbe) Probe(timeout time.Duration) (bool, time.Duration) {
-	client := http.Client{Timeout: timeout}
+	client := http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: p.insecure},
+		}}
 	req, err := http.NewRequest("GET", p.url, nil)
 	if err != nil {
 		return false, 0

--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -22,9 +22,8 @@ func (p HTTPProbe) Name() string {
 	s := fmt.Sprintf("%s-%d-%s", p.url, p.rcodes, p.useragent)
 	if p.insecure {
 		return s + "-insecure"
-	} else {
-		return s + "-secure"
 	}
+	return s
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Prober`.

--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -18,7 +18,7 @@ type HTTPProbe struct {
 
 // Name returns a string that uniquely identifies the monitor.
 func (p HTTPProbe) Name() string {
-	return fmt.Sprintf("%s-%d-%s-%t", p.url, p.rcodes, p.useragent, p.insecure)
+	return fmt.Sprintf("%s-%d-%s-insecure:%t", p.url, p.rcodes, p.useragent, p.insecure)
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Prober`.

--- a/observer/probers/http/http.go
+++ b/observer/probers/http/http.go
@@ -19,11 +19,11 @@ type HTTPProbe struct {
 // Name returns a string that uniquely identifies the monitor.
 
 func (p HTTPProbe) Name() string {
-	s := fmt.Sprintf("%s-%d-%s", p.url, p.rcodes, p.useragent)
+	insecure := ""
 	if p.insecure {
-		return s + "-insecure"
+		insecure = "-insecure"
 	}
-	return s
+	return fmt.Sprintf("%s-%d-%s%s", p.url, p.rcodes, p.useragent, insecure)
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Prober`.

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -14,6 +14,7 @@ type HTTPConf struct {
 	URL       string `yaml:"url"`
 	RCodes    []int  `yaml:"rcodes"`
 	UserAgent string `yaml:"useragent"`
+	Insecure  bool   `yaml:"insecure"`
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Configurer`.
@@ -80,7 +81,7 @@ func (c HTTPConf) MakeProber(_ map[string]prometheus.Collector) (probers.Prober,
 	if c.UserAgent == "" {
 		c.UserAgent = "letsencrypt/boulder-observer-http-client"
 	}
-	return HTTPProbe{c.URL, c.RCodes, c.UserAgent}, nil
+	return HTTPProbe{c.URL, c.RCodes, c.UserAgent, c.Insecure}, nil
 }
 
 // Instrument is a no-op to implement the `Configurer` interface.

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -86,25 +86,27 @@ func TestHTTPProberName(t *testing.T) {
 url: https://www.google.com
 rcodes: [ 200 ]
 useragent: ""
+insecure: true
 `
 	c := HTTPConf{}
 	configurer, err := c.UnmarshalSettings([]byte(proberYAML))
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	prober, err := configurer.MakeProber(nil)
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-letsencrypt/boulder-observer-http-client")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-letsencrypt/boulder-observer-http-client-insecure:true")
 
 	// Test with custom `useragent`
 	proberYAML = `
 url: https://www.google.com
 rcodes: [ 200 ]
 useragent: fancy-custom-http-client
+insucre: false
 `
 	c = HTTPConf{}
 	configurer, err = c.UnmarshalSettings([]byte(proberYAML))
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	prober, err = configurer.MakeProber(nil)
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client-insecure:false")
 
 }

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -93,7 +93,7 @@ insecure: true
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	prober, err := configurer.MakeProber(nil)
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-letsencrypt/boulder-observer-http-client-insecure:true")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-letsencrypt/boulder-observer-http-client-insecure")
 
 	// Test with custom `useragent`
 	proberYAML = `
@@ -107,6 +107,6 @@ insucre: false
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	prober, err = configurer.MakeProber(nil)
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client-insecure:false")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client-secure")
 
 }

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -100,13 +100,12 @@ insecure: true
 url: https://www.google.com
 rcodes: [ 200 ]
 useragent: fancy-custom-http-client
-insucre: false
 `
 	c = HTTPConf{}
 	configurer, err = c.UnmarshalSettings([]byte(proberYAML))
 	test.AssertNotError(t, err, "Got error for valid prober config")
 	prober, err = configurer.MakeProber(nil)
 	test.AssertNotError(t, err, "Got error for valid prober config")
-	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client-secure")
+	test.AssertEquals(t, prober.Name(), "https://www.google.com-[200]-fancy-custom-http-client")
 
 }

--- a/observer/probers/http/http_conf_test.go
+++ b/observer/probers/http/http_conf_test.go
@@ -47,6 +47,7 @@ func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 		url       interface{}
 		rcodes    interface{}
 		useragent interface{}
+		insecure  interface{}
 	}
 	tests := []struct {
 		name    string
@@ -54,8 +55,8 @@ func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 		want    probers.Configurer
 		wantErr bool
 	}{
-		{"valid", fields{"google.com", []int{200}, "boulder_observer"}, HTTPConf{"google.com", []int{200}, "boulder_observer"}, false},
-		{"invalid", fields{42, 42, 42}, nil, true},
+		{"valid", fields{"google.com", []int{200}, "boulder_observer", false}, HTTPConf{"google.com", []int{200}, "boulder_observer", false}, false},
+		{"invalid", fields{42, 42, 42, 42}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -63,6 +64,7 @@ func TestHTTPConf_UnmarshalSettings(t *testing.T) {
 				"url":       tt.fields.url,
 				"rcodes":    tt.fields.rcodes,
 				"useragent": tt.fields.useragent,
+				"insecure":  tt.fields.insecure,
 			}
 			settingsBytes, _ := yaml.Marshal(settings)
 			c := HTTPConf{}


### PR DESCRIPTION
Adding an insecure option to HTTP prober so that it can still check the status of sites that we expect to be insecure (e.g. expired sites).