### PR TITLE
Fix typo for omitZero in database.go from PR #6492

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -266,7 +266,7 @@ func adjustMySQLConfig(conf *mysql.Config) {
 	}
 
 	omitZero("max_statement_time")
-	omitZero("max_statement_time")
+	omitZero("long_query_time")
 }
 
 // SetSQLDebug enables GORP SQL-level Debugging


### PR DESCRIPTION
We have a new method, omitZero, which is to allow `max_statement_time` and `long_query_time` to be zeroed out, but copy/paste error left `long_query_time` out. Which is probably OK ,but we should fix it.