### PR TITLE
crl/checker: remove dependency on issuance package

### DIFF
--- a/cmd/crl-checker/main.go
+++ b/cmd/crl-checker/main.go
@@ -1,6 +1,7 @@
 package notmain
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -15,7 +16,6 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/crl/checker"
 	"github.com/letsencrypt/boulder/crl/crl_x509"
-	"github.com/letsencrypt/boulder/issuance"
 )
 
 func downloadShard(url string) (*crl_x509.RevocationList, error) {
@@ -61,9 +61,9 @@ func main() {
 		cmd.Fail("-issuer is required, but may be '-' to disable validation")
 	}
 
-	var issuer *issuance.Certificate
+	var issuer *x509.Certificate
 	if *issuerFile != "-" {
-		issuer, err = issuance.LoadCertificate(*issuerFile)
+		issuer, err = core.LoadCert(*issuerFile)
 		cmd.FailOnError(err, "Loading issuer certificate")
 	} else {
 		logger.Warning("CRL signature validation disabled")

--- a/crl/checker/checker.go
+++ b/crl/checker/checker.go
@@ -2,13 +2,13 @@ package checker
 
 import (
 	"bytes"
+	"crypto/x509"
 	"fmt"
 	"math/big"
 	"sort"
 	"time"
 
 	"github.com/letsencrypt/boulder/crl/crl_x509"
-	"github.com/letsencrypt/boulder/issuance"
 	"github.com/letsencrypt/boulder/linter"
 	crlint "github.com/letsencrypt/boulder/linter/lints/crl"
 )
@@ -17,14 +17,14 @@ import (
 // validates (if supplied with a non-nil issuer), and checks that the CRL is
 // less than ageLimit old. It returns an error if any of these conditions are
 // not met.
-func Validate(crl *crl_x509.RevocationList, issuer *issuance.Certificate, ageLimit time.Duration) error {
+func Validate(crl *crl_x509.RevocationList, issuer *x509.Certificate, ageLimit time.Duration) error {
 	err := linter.ProcessResultSet(crlint.LintCRL(crl))
 	if err != nil {
 		return fmt.Errorf("linting CRL: %w", err)
 	}
 
 	if issuer != nil {
-		err = crl.CheckSignatureFrom(issuer.Certificate)
+		err = crl.CheckSignatureFrom(issuer)
 		if err != nil {
 			return fmt.Errorf("checking CRL signature: %w", err)
 		}

--- a/crl/checker/checker_test.go
+++ b/crl/checker/checker_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/crl/crl_x509"
 	"github.com/letsencrypt/boulder/issuance"
 	"github.com/letsencrypt/boulder/test"
@@ -22,7 +23,7 @@ func TestValidate(t *testing.T) {
 	crlDER, _ := pem.Decode(crlPEM)
 	crl, err := crl_x509.ParseRevocationList(crlDER.Bytes)
 	test.AssertNotError(t, err, "parsing test crl")
-	issuer, err := issuance.LoadCertificate("../../test/hierarchy/int-e1.cert.pem")
+	issuer, err := core.LoadCert("../../test/hierarchy/int-e1.cert.pem")
 	test.AssertNotError(t, err, "loading test issuer")
 
 	err = Validate(crl, issuer, 100*365*24*time.Hour)
@@ -32,7 +33,7 @@ func TestValidate(t *testing.T) {
 	test.AssertError(t, err, "validating too-old crl")
 	test.AssertContains(t, err.Error(), "in the past")
 
-	issuer2, err := issuance.LoadCertificate("../../test/hierarchy/int-r3.cert.pem")
+	issuer2, err := core.LoadCert("../../test/hierarchy/int-r3.cert.pem")
 	test.AssertNotError(t, err, "loading test issuer")
 	err = Validate(crl, issuer2, 100*365*24*time.Hour)
 	test.AssertError(t, err, "validating crl from wrong issuer")


### PR DESCRIPTION
The things we need in crl/checker really only need x509.Certificate. This allows us to remove a dependency on pkcs11key from the crl checker, and transitively on CGO.