### PR TITLE
db: remove unique indexes on some tables

### DIFF
--- a/sa/db/boulder_sa/20221117183600_NotUnique.sql
+++ b/sa/db/boulder_sa/20221117183600_NotUnique.sql
@@ -1,0 +1,25 @@
+-- +migrate Up
+-- We use partitioning to clean up old data in these tables, and partitioning
+-- is incompatible with unique indexes. Remove the unique indexes.
+
+ALTER TABLE certificateStatus DROP INDEX IF EXISTS serial, ADD INDEX serial (serial);
+ALTER TABLE certificateStatus PARTITION BY RANGE(id) (
+    PARTITION p_start VALUES LESS THAN MAXVALUE);
+
+ALTER TABLE certificates DROP INDEX IF EXISTS serial, ADD INDEX serial (serial);
+ALTER TABLE certificates DROP FOREIGN KEY IF EXISTS regId_certificates;
+ALTER TABLE certificates PARTITION BY RANGE(id) (
+    PARTITION p_start VALUES LESS THAN MAXVALUE);
+
+ALTER TABLE fqdnSets DROP INDEX IF EXISTS serial, ADD INDEX serial (serial);
+ALTER TABLE fqdnSets PARTITION BY RANGE(id) (
+    PARTITION p_start VALUES LESS THAN MAXVALUE);
+
+ALTER TABLE precertificates DROP INDEX IF EXISTS serial, ADD INDEX serial (serial);
+ALTER TABLE precertificates DROP FOREIGN KEY IF EXISTS regId_precertificates;
+ALTER TABLE precertificates PARTITION BY RANGE(id) (
+    PARTITION p_start VALUES LESS THAN MAXVALUE);
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+


### PR DESCRIPTION
We use partitioning to be able to clean up old data, and partitioning is incompatible with unique indexes. We still have a unique index on `serial`, and these tables are downstream from there. There still may some duplicates, like when a certificate is treated as orphaned but was actually successfully added to the DB; when we later go to incorporate it a duplicate will show up.

This reflects changes already made in prod.

This PR removes a unittest that coincidentally relied on these indexes to generate an error case it needed: `TestAddPrecertificateStatusFail`. That test was added in #5918. We can bring that test back with a significant refactoring to change `*db.WrappedMap` to an interface, but in the meantime we're prioritizing landing this PR so we have a more realistic integration test environment.