### PR TITLE
va: filter invalid UTF-8 in IsCAAValid

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -42,10 +42,11 @@ func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsC
 		validationMethod: validationMethod,
 	}
 	if prob := va.checkCAA(ctx, acmeID, params); prob != nil {
+		detail := fmt.Sprintf("While processing CAA for %s: %s", req.Domain, prob.Detail)
 		return &vapb.IsCAAValidResponse{
 			Problem: &corepb.ProblemDetails{
 				ProblemType: string(prob.Type),
-				Detail:      fmt.Sprintf("While processing CAA for %s: %s", req.Domain, prob.Detail),
+				Detail:      replaceInvalidUTF8([]byte(detail)),
 			},
 		}, nil
 	}


### PR DESCRIPTION
Followup from #6506.

As noted in that PR: I'm not aware of any way to trigger invalid UTF-8 from the layers below this, so I can't think of a good way to unittest it.