### PR TITLE
lint: treat logEvent.AddError as a formatter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters-settings:
           - (github.com/letsencrypt/boulder/log.Logger).AuditInfof
           - (github.com/letsencrypt/boulder/log.Logger).AuditErrf
           - (github.com/letsencrypt/boulder/ocsp/responder).SampledError
+          - (github.com/letsencrypt/boulder/web.RequestEvent).AddError
   staticcheck:
     # SA1019: Using a deprecated function, variable, constant or field
     # SA6003: Converting a string to a slice of runes before ranging over it

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -469,7 +469,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 		// a ServerInternal problem since this is unexpected.
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDLookupFailed"}).Inc()
 		// Add an error to the log event with the internal error message
-		logEvent.AddError(fmt.Sprintf("Error calling SA.GetRegistration: %s", err.Error()))
+		logEvent.AddError("Error calling SA.GetRegistration: %s", err)
 		return nil, nil, probs.ServerInternal(fmt.Sprintf(
 			"Error retrieving account %q", accountURL))
 	}

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -328,7 +328,7 @@ func (wfe *WebFrontEndImpl) writeJsonResponse(response http.ResponseWriter, logE
 		// Don't worry about returning this error because the caller will
 		// never handle it.
 		wfe.log.Warningf("Could not write response: %s", err)
-		logEvent.AddError(fmt.Sprintf("failed to write response: %s", err))
+		logEvent.AddError("failed to write response: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Also fix a couple of places that called fmt.Sprintf and err.Error() redundantly.