### PR TITLE
wfe: pass through problem details

### DIFF
--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1607,7 +1607,7 @@ func (acns alwaysCancelNonceService) Redeem(ctx context.Context, msg *noncepb.No
 }
 
 func (acns alwaysCancelNonceService) Nonce(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*noncepb.NonceMessage, error) {
-	return nil, nil
+	return nil, probs.Canceled("user canceled request")
 }
 
 // mockNonceSource implements jose.NonceSource

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2889,6 +2889,12 @@ func TestGetOrderCanceled408(t *testing.T) {
 	test.AssertNotError(t, err, "creating request")
 	wfe.GetOrder(ctx, newRequestEvent(), responseWriter, req)
 	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
+
+	_, _, jwsBody := signRequestKeyID(t, 1, nil, "http://localhost/123/456", "{}", wfe.nonceService)
+	postReq := makePostRequestWithPath("123/456", jwsBody)
+	responseWriter = httptest.NewRecorder()
+	wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, postReq)
+	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
 }
 
 func TestGetOrder(t *testing.T) {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3361,7 +3361,7 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 		Identifier:     identifier.DNSIdentifier("*.example.com"),
 		Challenges: []core.Challenge{
 			{
-				Type: "dns",
+				Type:                     "dns",
 				ProvidedKeyAuthorization: "	🔑",
 			},
 		},


### PR DESCRIPTION
When a client cancels their HTTP request, that propagates into gRPC-level cancellation. But we don't want those canceled RPCs to show up as 500s, we want them to show up as 408s. We do that by producing a special ProblemDetails at the gRPC level. However, for that trick to work, we need to make sure errors from RPC methods get passed through web.ProblemDetailsForError. There were some places where we didn't do this and instead created a from-scratch ProblemDetails. This resulted in spurious 500s.

My methodology was to look at every method call on each of the WFE's fields that represents a gRPC backend: `ra`, `sa`, `accountGetter`, `nonceService`, `remoteNonceServe`. If the error handling for that call did not use web.ProblemDetailsForError, I changed it to use that.

Fixes #6524

In draft because still needs tests.