### PR TITLE
ARI: Suggest immediate renewal for revoked certs

### DIFF
--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -85,7 +85,7 @@ func TestARI(t *testing.T) {
 
 	// Revoke the cert, then request ARI again, and the window should now be in
 	// the past.
-	err = client.RevokeCertificate(client.Account, cert, key, 0)
+	err = client.RevokeCertificate(client.Account, cert, client.PrivateKey, 0)
 	test.AssertNotError(t, err, "failed to revoke cert")
 	resp, err = http.Get(url)
 	test.AssertNotError(t, err, "ARI request should have succeeded")

--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -10,13 +10,17 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/test"
 	ocsp_helper "github.com/letsencrypt/boulder/test/ocsp/helper"
 	"golang.org/x/crypto/ocsp"
@@ -78,6 +82,22 @@ func TestARI(t *testing.T) {
 	resp, err := http.Get(url)
 	test.AssertNotError(t, err, "ARI request should have succeeded")
 	test.AssertEquals(t, resp.StatusCode, http.StatusOK)
+
+	// Revoke the cert, then request ARI again, and the window should now be in
+	// the past.
+	err = client.RevokeCertificate(client.Account, cert, key, 0)
+	test.AssertNotError(t, err, "failed to revoke cert")
+	resp, err = http.Get(url)
+	test.AssertNotError(t, err, "ARI request should have succeeded")
+	test.AssertEquals(t, resp.StatusCode, http.StatusOK)
+
+	riBytes, err := io.ReadAll(resp.Body)
+	test.AssertNotError(t, err, "failed to read ARI response")
+	var ri core.RenewalInfo
+	err = json.Unmarshal(riBytes, &ri)
+	test.AssertNotError(t, err, "failed to parse ARI response")
+	test.Assert(t, ri.SuggestedWindow.End.Before(time.Now()), "suggested window should end in the past")
+	test.Assert(t, ri.SuggestedWindow.Start.Before(ri.SuggestedWindow.End), "suggested window should start before it ends")
 
 	// Try to make a new cert for a new domain, but have it fail so only
 	// a precert gets created.

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2320,7 +2320,17 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 		response.Header().Set(headerRetryAfter, fmt.Sprintf("%d", int(6*time.Hour/time.Second)))
 	}
 
-	// Check if the serial is part of an ongoing incident.
+	sendRI := func(ri core.RenewalInfo) {
+		err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, ri)
+		if err != nil {
+			wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling renewalInfo"), err)
+			return
+		}
+		setDefaultRetryAfterHeader(response)
+	}
+
+	// Check if the serial is part of an ongoing/active incident, in which case it
+	// should be replaced now.
 	result, err := wfe.sa.IncidentsForSerial(ctx, &sapb.Serial{Serial: serial})
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err,
@@ -2329,16 +2339,20 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 	}
 
 	if len(result.Incidents) > 0 {
-		// Since IncidentsForSerial() only returns enabled incidents we can
-		// assume that this serial is impacted by an ongoing incident.
-		ri := core.RenewalInfoImmediate(wfe.clk.Now())
+		sendRI(core.RenewalInfoImmediate(wfe.clk.Now()))
+		return
+	}
 
-		err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, ri)
-		if err != nil {
-			wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling renewalInfo"), err)
-			return
-		}
-		setDefaultRetryAfterHeader(response)
+	// Check if the serial is revoked, in which case it should be replaced now.
+	status, err := wfe.sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
+	if err != nil {
+		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err,
+			"checking if certificate has been revoked"), err)
+		return
+	}
+
+	if status.Status == string(core.OCSPStatusRevoked) {
+		sendRI(core.RenewalInfoImmediate(wfe.clk.Now()))
 		return
 	}
 
@@ -2359,14 +2373,9 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 	// using that to compute the actual issuerNameHash and issuerKeyHash, and
 	// comparing those to the ones in the request.
 
-	ri := core.RenewalInfoSimple(time.Unix(0, cert.Issued).UTC(), time.Unix(0, cert.Expires).UTC())
-
-	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, ri)
-	if err != nil {
-		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling renewalInfo"), err)
-		return
-	}
-	setDefaultRetryAfterHeader(response)
+	sendRI(core.RenewalInfoSimple(
+		time.Unix(0, cert.Issued).UTC(),
+		time.Unix(0, cert.Expires).UTC()))
 }
 
 func extractRequesterIP(req *http.Request) (net.IP, error) {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2329,8 +2329,8 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 		setDefaultRetryAfterHeader(response)
 	}
 
-	// Check if the serial is part of an ongoing/active incident, in which case it
-	// should be replaced now.
+	// Check if the serial is part of an ongoing/active incident, in which case
+	// the client should replace it now.
 	result, err := wfe.sa.IncidentsForSerial(ctx, &sapb.Serial{Serial: serial})
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err,
@@ -2343,7 +2343,8 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 		return
 	}
 
-	// Check if the serial is revoked, in which case it should be replaced now.
+	// Check if the serial is revoked, in which case the client should replace it
+	// now.
 	status, err := wfe.sa.GetCertificateStatus(ctx, &sapb.Serial{Serial: serial})
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err,


### PR DESCRIPTION
Update our implementation of ARI to return a renewal window entirely in the past (i.e., suggesting immediate renewal) if the certificate in question has been revoked for any reason. This will allow clients which implement ARI to discover that they need to replace their certificate without having to query OCSP directly, especially as we move into a future where OCSP is mostly supplanted by aggregated CRLs.

Fixes #6503