### PR TITLE
SA.GetOrder: conduct queries inside a transaction

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -960,3 +960,32 @@ func getAuthorizationStatuses(s db.Selector, ids []int64) ([]authzValidity, erro
 	}
 	return allAuthzValidity, nil
 }
+
+// authzForOrder retrieves the authorization IDs for an order. It assumes that
+// the provided database selector already has a context associated with it.
+func authzForOrder(s db.Selector, orderID int64) ([]int64, error) {
+	var v2IDs []int64
+	_, err := s.Select(
+		&v2IDs,
+		"SELECT authzID FROM orderToAuthz2 WHERE orderID = ?",
+		orderID,
+	)
+	return v2IDs, err
+}
+
+// namesForOrder finds all of the requested names associated with an order. The
+// names are returned in their reversed form (see `sa.ReverseName`). It assumes
+// that the provided database selector already has a context associated with it.
+func namesForOrder(s db.Selector, orderID int64) ([]string, error) {
+	var reversedNames []string
+	_, err := s.Select(
+		&reversedNames,
+		`SELECT reversedName
+	   FROM requestedNames
+	   WHERE orderID = ?`,
+		orderID)
+	if err != nil {
+		return nil, err
+	}
+	return reversedNames, nil
+}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -986,7 +986,7 @@ func TestNewOrderAndAuthzs(t *testing.T) {
 	test.AssertEquals(t, len(authzIDs), 4)
 	test.AssertDeepEquals(t, authzIDs, []int64{1, 2, 3, 4})
 
-	names, err := sa.namesForOrder(context.Background(), order.Id)
+	names, err := namesForOrder(sa.dbReadOnlyMap, order.Id)
 	test.AssertNotError(t, err, "namesForOrder errored")
 	test.AssertEquals(t, len(names), 4)
 	test.AssertDeepEquals(t, names, []string{"com.a", "com.b", "com.c", "com.d"})


### PR DESCRIPTION
The SA's GetOrder method issues four separate database queries:
- get the Order object itself
- get the list of Names associated with it
- get the list of Authorization IDs associated with it
- get the contents of those Authorizations themselves

These four queries can hit different database replicas with different amounts of replication lag, and therefore different views of the universe. This can result in inconsistent results, such as the Order existing, but not having any Authorization IDs associated with it.

Conduct these four queries all within a single transaction, to ensure they all hit a single read-replica with a consistent view of the world.

Fixes #6540