### PR TITLE
Add duplicate serial to bad-key-revoker unittest

### DIFF
--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -210,6 +210,8 @@ func TestFindUnrevoked(t *testing.T) {
 	hashA := randHash(t)
 	// insert valid, unexpired
 	insertCert(t, dbMap, fc, hashA, "ff", regID, Unexpired, Unrevoked)
+	// insert valid, unexpired, duplicate
+	insertCert(t, dbMap, fc, hashA, "ff", regID, Unexpired, Unrevoked)
 	// insert valid, expired
 	insertCert(t, dbMap, fc, hashA, "ee", regID, Expired, Unrevoked)
 	// insert revoked


### PR DESCRIPTION
This tests the fix in #6531. Currently blocked on #6519.