### PR TITLE
Add histogram to track authz reuse ages

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -236,6 +236,7 @@ func NewRegistrationAuthorityImpl(
 		newCertCounter:               newCertCounter,
 		revocationReasonCounter:      revocationReasonCounter,
 		recheckCAAUsedAuthzLifetime:  recheckCAAUsedAuthzLifetime,
+		authzAges:                    authzAges,
 	}
 	return ra
 }


### PR DESCRIPTION
Although we have a metric for counting how often we reuse a valid authorization, no code has been incrementing that metric since 2021. Re-enable it.

Additionally, that metric doesn't help us know how old authorizations are when they get reused, which is useful information when deciding whether or how much to shrink our authorization reuse lifetime. Add a new histogram metric to track the ages of authorizations when they're attached to an order.