### PR TITLE
Extract out `db.QuestionMarks` function

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -212,20 +212,18 @@ func (m *mailer) updateLastNagTimestamps(ctx context.Context, certs []*x509.Cert
 
 // updateLastNagTimestampsChunk processes a single chunk (up to 65k) of certificates.
 func (m *mailer) updateLastNagTimestampsChunk(ctx context.Context, certs []*x509.Certificate) {
-	serials := make([]interface{}, len(certs))
-	for _, cert := range certs {
-		serials = append(serials, core.SerialToString(cert.SerialNumber))
+	params := make([]interface{}, len(certs)+1)
+	for i, cert := range certs {
+		params[i+1] = core.SerialToString(cert.SerialNumber)
 	}
 
 	query := fmt.Sprintf(
 		"UPDATE certificateStatus SET lastExpirationNagSent = ? WHERE serial IN (%s)",
-		db.QuestionMarks(len(serials)),
+		db.QuestionMarks(len(certs)),
 	)
+	params[0] = m.clk.Now()
 
-	var params []interface{}
-	params = append(params, m.clk.Now())
-	params = append(params, serials...)
-	_, err := m.dbMap.WithContext(ctx).Exec(query, params)
+	_, err := m.dbMap.WithContext(ctx).Exec(query, params...)
 	if err != nil {
 		m.log.AuditErrf("Error updating certificate status for %d certs: %s", len(certs), err)
 		m.stats.errorCount.With(prometheus.Labels{"type": "UpdateCertificateStatus"}).Inc()

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -64,6 +64,14 @@ type Executor interface {
 	Query(string, ...interface{}) (*sql.Rows, error)
 }
 
+// Queryer offers the Query method. Note that this is not read-only (i.e. not
+// Selector), since a Query can be `INSERT`, `UPDATE`, etc. The difference
+// between Query and Exec is that Query can return rows. So for instance it is
+// suitable for inserting rows and getting back ids.
+type Queryer interface {
+	Query(string, ...interface{}) (*sql.Rows, error)
+}
+
 // Transaction extends an Executor and adds Rollback, Commit, and WithContext.
 type Transaction interface {
 	Executor

--- a/db/multi.go
+++ b/db/multi.go
@@ -18,20 +18,23 @@ type MultiInserter struct {
 }
 
 // NewMultiInserter creates a new MultiInserter, checking for reasonable table
-// name and list of fields.
-func NewMultiInserter(table string, fields string, retCol string) (*MultiInserter, error) {
+// name and list of fields. returningColumn is the name of a column to be used
+// in a `RETURNING xyz` clause at the end. If it is empty, no `RETURNING xyz`
+// clause is used. If returningColumn is present, it must refer to a column
+// that can be parsed into an int64.
+func NewMultiInserter(table string, fields string, returningColumn string) (*MultiInserter, error) {
 	numFields := len(strings.Split(fields, ","))
 	if len(table) == 0 || len(fields) == 0 || numFields == 0 {
 		return nil, fmt.Errorf("empty table name or fields list")
 	}
-	if strings.Contains(retCol, ",") {
-		return nil, fmt.Errorf("return column must be singular, but got %q", retCol)
+	if strings.Contains(returningColumn, ",") {
+		return nil, fmt.Errorf("return column must be singular, but got %q", returningColumn)
 	}
 
 	return &MultiInserter{
 		table:     table,
 		fields:    fields,
-		retCol:    retCol,
+		retCol:    returningColumn,
 		numFields: numFields,
 		values:    make([][]interface{}, 0),
 	}, nil
@@ -50,12 +53,10 @@ func (mi *MultiInserter) Add(row []interface{}) error {
 // for gorp to use in place of the query's question marks. Currently only
 // used by .Insert(), below.
 func (mi *MultiInserter) query() (string, []interface{}) {
-	questionsRow := strings.TrimRight(strings.Repeat("?,", mi.numFields), ",")
-
 	var questionsBuf strings.Builder
 	var queryArgs []interface{}
 	for _, row := range mi.values {
-		fmt.Fprintf(&questionsBuf, "(%s),", questionsRow)
+		fmt.Fprintf(&questionsBuf, "(%s),", QuestionMarks(mi.numFields))
 		queryArgs = append(queryArgs, row...)
 	}
 
@@ -71,9 +72,9 @@ func (mi *MultiInserter) query() (string, []interface{}) {
 }
 
 // Insert performs the action represented by .query() on the provided database,
-// which is assumed to already have a context attached. If a non-empty retCol
-// was provided, then it returns the list of values from that column returned
-// by the query.
+// which is assumed to already have a context attached. If a non-empty
+// returningColumn was provided, then it returns the list of values from that
+// column returned by the query.
 func (mi *MultiInserter) Insert(exec Executor) ([]int64, error) {
 	query, queryArgs := mi.query()
 	rows, err := exec.Query(query, queryArgs...)

--- a/db/qmarks.go
+++ b/db/qmarks.go
@@ -1,0 +1,18 @@
+package db
+
+import "strings"
+
+// QuestionMarks returns a string consisting of N question marks, joined by
+// commas.
+func QuestionMarks(n int) string {
+	var qmarks strings.Builder
+	qmarks.Grow(2 * n)
+	for i := 0; i < n; i++ {
+		if i == 0 {
+			qmarks.WriteString("?")
+		} else {
+			qmarks.WriteString(",?")
+		}
+	}
+	return qmarks.String()
+}

--- a/db/qmarks.go
+++ b/db/qmarks.go
@@ -3,8 +3,11 @@ package db
 import "strings"
 
 // QuestionMarks returns a string consisting of N question marks, joined by
-// commas.
+// commas. If n is <= 0, panics.
 func QuestionMarks(n int) string {
+	if n <= 0 {
+		panic("db.QuestionMarks called with n <=0")
+	}
 	var qmarks strings.Builder
 	qmarks.Grow(2 * n)
 	for i := 0; i < n; i++ {

--- a/db/qmarks_test.go
+++ b/db/qmarks_test.go
@@ -1,0 +1,11 @@
+package db
+
+import "testing"
+import "github.com/letsencrypt/boulder/test"
+
+func TestQuestionMarks(t *testing.T) {
+	test.AssertEquals(t, QuestionMarks(0), "")
+	test.AssertEquals(t, QuestionMarks(1), "?")
+	test.AssertEquals(t, QuestionMarks(2), "?,?")
+	test.AssertEquals(t, QuestionMarks(3), "?,?,?")
+}

--- a/db/qmarks_test.go
+++ b/db/qmarks_test.go
@@ -1,11 +1,19 @@
 package db
 
-import "testing"
-import "github.com/letsencrypt/boulder/test"
+import (
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
 
 func TestQuestionMarks(t *testing.T) {
-	test.AssertEquals(t, QuestionMarks(0), "")
 	test.AssertEquals(t, QuestionMarks(1), "?")
 	test.AssertEquals(t, QuestionMarks(2), "?,?")
 	test.AssertEquals(t, QuestionMarks(3), "?,?,?")
+}
+
+func TestQuestionMarksPanic(t *testing.T) {
+	defer func() { recover() }()
+	QuestionMarks(0)
+	t.Errorf("calling QuestionMarks(0) did not panic as expected")
 }

--- a/sa/model.go
+++ b/sa/model.go
@@ -765,22 +765,27 @@ func deleteOrderFQDNSet(
 	return nil
 }
 
-func addIssuedNames(db db.Execer, cert *x509.Certificate, isRenewal bool) error {
+func addIssuedNames(execer db.Execer, cert *x509.Certificate, isRenewal bool) error {
 	if len(cert.DNSNames) == 0 {
 		return berrors.InternalServerError("certificate has no DNSNames")
 	}
-	var qmarks []string
-	var values []interface{}
+
+	multiInserter, err := db.NewMultiInserter("issuedNames", "reversedName, serial, notBefore, renewal", "")
+	if err != nil {
+		return err
+	}
 	for _, name := range cert.DNSNames {
-		values = append(values,
+		err = multiInserter.Add([]interface{}{
 			ReverseName(name),
 			core.SerialToString(cert.SerialNumber),
 			cert.NotBefore,
-			isRenewal)
-		qmarks = append(qmarks, "(?, ?, ?, ?)")
+			isRenewal,
+		})
+		if err != nil {
+			return err
+		}
 	}
-	query := `INSERT INTO issuedNames (reversedName, serial, notBefore, renewal) VALUES ` + strings.Join(qmarks, ", ") + `;`
-	_, err := db.Exec(query, values...)
+	_, err = multiInserter.Insert(execer)
 	return err
 }
 
@@ -932,10 +937,8 @@ type authzValidity struct {
 // status and expiration date of each of them. It assumes that the provided
 // database selector already has a context associated with it.
 func getAuthorizationStatuses(s db.Selector, ids []int64) ([]authzValidity, error) {
-	var qmarks []string
 	var params []interface{}
 	for _, id := range ids {
-		qmarks = append(qmarks, "?")
 		params = append(params, id)
 	}
 	var validityInfo []struct {
@@ -944,7 +947,8 @@ func getAuthorizationStatuses(s db.Selector, ids []int64) ([]authzValidity, erro
 	}
 	_, err := s.Select(
 		&validityInfo,
-		fmt.Sprintf("SELECT status, expires FROM authz2 WHERE id IN (%s)", strings.Join(qmarks, ",")),
+		fmt.Sprintf("SELECT status, expires FROM authz2 WHERE id IN (%s)",
+			db.QuestionMarks(len(params))),
 		params...,
 	)
 	if err != nil {

--- a/sa/model.go
+++ b/sa/model.go
@@ -765,7 +765,7 @@ func deleteOrderFQDNSet(
 	return nil
 }
 
-func addIssuedNames(execer db.Execer, cert *x509.Certificate, isRenewal bool) error {
+func addIssuedNames(queryer db.Queryer, cert *x509.Certificate, isRenewal bool) error {
 	if len(cert.DNSNames) == 0 {
 		return berrors.InternalServerError("certificate has no DNSNames")
 	}
@@ -785,7 +785,7 @@ func addIssuedNames(execer db.Execer, cert *x509.Certificate, isRenewal bool) er
 			return err
 		}
 	}
-	_, err = multiInserter.Insert(execer)
+	_, err = multiInserter.Insert(queryer)
 	return err
 }
 

--- a/sa/model.go
+++ b/sa/model.go
@@ -948,7 +948,7 @@ func getAuthorizationStatuses(s db.Selector, ids []int64) ([]authzValidity, erro
 	_, err := s.Select(
 		&validityInfo,
 		fmt.Sprintf("SELECT status, expires FROM authz2 WHERE id IN (%s)",
-			db.QuestionMarks(len(params))),
+			db.QuestionMarks(len(ids))),
 		params...,
 	)
 	if err != nil {

--- a/sa/rate_limits.go
+++ b/sa/rate_limits.go
@@ -42,8 +42,11 @@ func (ssa *SQLStorageAuthority) addCertificatesPerName(execer db.SelectExecer, n
 		}
 	}
 
-	_, err := execer.Exec(`INSERT INTO certificatesPerName (eTLDPlusOne, time, count) VALUES `+
-		db.QuestionMarks(len(values))+` ON DUPLICATE KEY UPDATE count=count+1;`,
+	_, err := execer.Exec(`
+		INSERT INTO certificatesPerName
+		(eTLDPlusOne, time, count) VALUES (`+
+		db.QuestionMarks(len(values))+
+		`) ON DUPLICATE KEY UPDATE count=count+1;`,
 		values...)
 	if err != nil {
 		return err

--- a/sa/rate_limits.go
+++ b/sa/rate_limits.go
@@ -1,6 +1,7 @@
 package sa
 
 import (
+	"strings"
 	"time"
 
 	"github.com/letsencrypt/boulder/db"
@@ -30,23 +31,22 @@ func baseDomain(name string) string {
 // domains, in a specific time bucket. It must be executed in a transaction, and
 // the input timeToTheHour must be a time rounded to an hour. It assumes that
 // the given db already has a context associated with it.
-func (ssa *SQLStorageAuthority) addCertificatesPerName(execer db.SelectExecer, names []string, timeToTheHour time.Time) error {
+func (ssa *SQLStorageAuthority) addCertificatesPerName(db db.SelectExecer, names []string, timeToTheHour time.Time) error {
 	// De-duplicate the base domains.
 	baseDomainsMap := make(map[string]bool)
+	var qmarks []string
 	var values []interface{}
 	for _, name := range names {
 		base := baseDomain(name)
 		if !baseDomainsMap[base] {
 			baseDomainsMap[base] = true
 			values = append(values, base, timeToTheHour, 1)
+			qmarks = append(qmarks, "(?, ?, ?)")
 		}
 	}
 
-	_, err := execer.Exec(`
-		INSERT INTO certificatesPerName
-		(eTLDPlusOne, time, count) VALUES (`+
-		db.QuestionMarks(len(values))+
-		`) ON DUPLICATE KEY UPDATE count=count+1;`,
+	_, err := db.Exec(`INSERT INTO certificatesPerName (eTLDPlusOne, time, count) VALUES `+
+		strings.Join(qmarks, ", ")+` ON DUPLICATE KEY UPDATE count=count+1;`,
 		values...)
 	if err != nil {
 		return err

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -760,10 +760,8 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorizations2(ctx context.Context, req *s
 		identifierTypeToUint[string(identifier.DNS)],
 	}
 
-	qmarks := make([]string, len(req.Domains))
-	for i, n := range req.Domains {
-		qmarks[i] = "?"
-		params = append(params, n)
+	for _, name := range req.Domains {
+		params = append(params, name)
 	}
 
 	query := fmt.Sprintf(
@@ -775,7 +773,7 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorizations2(ctx context.Context, req *s
 			identifierType = ? AND
 			identifierValue IN (%s)`,
 		authzFields,
-		strings.Join(qmarks, ","),
+		db.QuestionMarks(len(params)),
 	)
 
 	_, err := ssa.dbReadOnlyMap.Select(
@@ -973,11 +971,6 @@ func (ssa *SQLStorageAuthorityRO) GetValidAuthorizations2(ctx context.Context, r
 		time.Unix(0, req.Now),
 		identifierTypeToUint[string(identifier.DNS)],
 	}
-	qmarks := make([]string, len(req.Domains))
-	for i, n := range req.Domains {
-		qmarks[i] = "?"
-		params = append(params, n)
-	}
 	_, err := ssa.dbReadOnlyMap.Select(
 		&authzModels,
 		fmt.Sprintf(
@@ -988,7 +981,7 @@ func (ssa *SQLStorageAuthorityRO) GetValidAuthorizations2(ctx context.Context, r
 			identifierType = ? AND
 			identifierValue IN (%s)`,
 			authzFields,
-			strings.Join(qmarks, ","),
+			db.QuestionMarks(len(params)),
 		),
 		params...,
 	)


### PR DESCRIPTION
We use this pattern in several places: there is a query that needs to have a variable number of placeholders (question marks) in it, depending on how many items we are inserting or querying for. For instance, when issuing a precertificate we add that precertificate's names to the "issuedNames" table. To make things more efficient, we do that in a single query, whether there is one name on the certificate or a hundred. That means interpolating into the query string with series of question marks that matches the number of names.

We have a helper type MultiInserter that solves this problem for simple inserts, but it does not solve the problem for selects or more complex inserts, and we still have a number of places that generate their sequence of question marks manually.

This change updates addIssuedNames to use MultiInserter. To enable that, it also narrows the interface required by MultiInserter.Insert, so it's easier to mock in tests.

This change adds the new function db.QuestionMarks, which generates e.g. `?,?,?` depending on the input N.

In a few places I had to rename a function parameter named `db` to avoid shadowing the `db` package.