### PR TITLE
observer: TLS prober check root optionally

### DIFF
--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -132,7 +132,7 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 	}
 
 	root := peers[len(peers)-1].Issuer
-	err = p.checkRoot(root.Organization[0], root.CommonName) 
+	err = p.checkRoot(root.Organization[0], root.CommonName)
 	if err != nil {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
@@ -152,7 +152,8 @@ func (p TLSProbe) probeUnexpired(timeout time.Duration) bool {
 	defer conn.Close()
 	peers := conn.ConnectionState().PeerCertificates
 	root := peers[len(peers)-1].Issuer
-	if err = p.checkRoot(root.Organization[0], root.CommonName); err != nil {
+	err = p.checkRoot(root.Organization[0], root.CommonName)
+	if err != nil {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -146,7 +146,7 @@ func (p TLSProbe) probeUnexpired(timeout time.Duration) bool {
 	defer conn.Close()
 	peers := conn.ConnectionState().PeerCertificates
 	root := peers[len(peers)-1].Issuer
-	if !p.checkRoot(root.Organization[0], root.CommonName) {
+	if p.checkRoot(root.Organization[0], root.CommonName) {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -87,6 +87,10 @@ func checkOCSP(cert, issuer *x509.Certificate, want int) (bool, error) {
 	return ocspRes.Status == want, nil
 }
 
+func (p TLSProbe) checkRoot(rootOrg, rootCN string) bool {
+	return p.rootCN != "" && p.rootOrg != "" && (rootOrg != p.rootOrg || rootCN != p.rootCN)
+}
+
 // Export expiration timestamp and reason to Prometheus.
 func (p TLSProbe) exportMetrics(notAfter time.Time, reason reason) {
 	p.notAfter.WithLabelValues(p.hostname).Set(float64(notAfter.Unix()))
@@ -123,7 +127,7 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 	}
 
 	root := peers[len(peers)-1].Issuer
-	if p.rootCN != "" && (root.Organization[0] != p.rootOrg || root.CommonName != p.rootCN) {
+	if !p.checkRoot(root.Organization[0], root.CommonName) {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}
@@ -142,7 +146,7 @@ func (p TLSProbe) probeUnexpired(timeout time.Duration) bool {
 	defer conn.Close()
 	peers := conn.ConnectionState().PeerCertificates
 	root := peers[len(peers)-1].Issuer
-	if p.rootCN != "" && (root.Organization[0] != p.rootOrg || root.CommonName != p.rootCN) {
+	if !p.checkRoot(root.Organization[0], root.CommonName) {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -127,7 +127,7 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 	}
 
 	root := peers[len(peers)-1].Issuer
-	if !p.checkRoot(root.Organization[0], root.CommonName) {
+	if p.checkRoot(root.Organization[0], root.CommonName) {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -132,7 +132,8 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 	}
 
 	root := peers[len(peers)-1].Issuer
-	if err = p.checkRoot(root.Organization[0], root.CommonName); err != nil {
+	err = p.checkRoot(root.Organization[0], root.CommonName) 
+	if err != nil {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -123,7 +123,7 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 	}
 
 	root := peers[len(peers)-1].Issuer
-	if root.Organization[0] != p.rootOrg || root.CommonName != p.rootCN {
+	if p.rootCN != "" && (root.Organization[0] != p.rootOrg || root.CommonName != p.rootCN) {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}
@@ -142,7 +142,7 @@ func (p TLSProbe) probeUnexpired(timeout time.Duration) bool {
 	defer conn.Close()
 	peers := conn.ConnectionState().PeerCertificates
 	root := peers[len(peers)-1].Issuer
-	if root.Organization[0] != p.rootOrg || root.CommonName != p.rootCN {
+	if p.rootCN != "" && (root.Organization[0] != p.rootOrg || root.CommonName != p.rootCN) {
 		p.exportMetrics(peers[0].NotAfter, rootDidNotMatch)
 		return false
 	}

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -87,7 +87,7 @@ func checkOCSP(cert, issuer *x509.Certificate, want int) (bool, error) {
 	return ocspRes.Status == want, nil
 }
 
-// Return true if root settings are either or match the certificate root.
+// Return true if root settings are empty or match the certificate root.
 func (p TLSProbe) checkRoot(rootOrg, rootCN string) bool {
 	return (p.rootCN == "" && p.rootOrg == "") || (rootOrg == p.rootOrg && rootCN == p.rootCN)
 }

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -169,10 +169,11 @@ func (p TLSProbe) probeUnexpired(timeout time.Duration) bool {
 }
 
 // Probe performs the configured TLS probe. Return true if the root has the
-// expected Subject, and the end entity certificate has the correct expiration
-// status (either expired or unexpired, depending on what is configured).
-// Exports metrics for the NotAfter timestamp of the end entity certificate and
-// the reason for the Probe returning false ("none" if returns true).
+// expected Subject (or if no root is provided for comparison in settings), and
+// the end entity certificate has the correct expiration status (either expired
+// or unexpired, depending on what is configured). Exports metrics for the
+// NotAfter timestamp of the end entity certificate and the reason for the Probe
+// returning false ("none" if returns true).
 func (p TLSProbe) Probe(timeout time.Duration) (bool, time.Duration) {
 	start := time.Now()
 	var success bool

--- a/observer/probers/tls/tls_conf.go
+++ b/observer/probers/tls/tls_conf.go
@@ -83,11 +83,6 @@ func (c TLSConf) MakeProber(collectors map[string]prometheus.Collector) (probers
 		return nil, err
 	}
 
-	// Set default Root Organization if none set.
-	if c.RootOrg == "" {
-		c.RootOrg = "Internet Security Research Group"
-	}
-
 	// Validate the Prometheus collectors that were passed in
 	coll, ok := collectors[notAfterName]
 	if !ok {


### PR DESCRIPTION
To replace Sensu checks, we need another way to get the expiration date of some HTTPS sites. TLS prober already exports the expiration date and checks that a site is up, but it also checks that the root cert of the site matches the expected root given in settings. We should modify TLS prober to only check the root if one is provided.