### PR TITLE
Remove the CertificateRequest wrapper type

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -40,43 +40,6 @@ func TestChallenges(t *testing.T) {
 	test.Assert(t, !AcmeChallenge("nonsense-71").IsValid(), "Accepted invalid challenge")
 }
 
-// objects.go
-
-var testCertificateRequestBadCSR = []byte(`{"csr":"AAAA"}`)
-var testCertificateRequestGood = []byte(`{
-  "csr": "MIHRMHgCAQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQWUlnRrm5ErSVkTzBTk3isg1hNydfyY4NM1P_N1S-ZeD39HMrYJsQkUh2tKvy3ztfmEqWpekvO4WRktSa000BPoAAwCgYIKoZIzj0EAwMDSQAwRgIhAIZIBwu4xOUD_4dJuGgceSKaoXTFBQKA3BFBNVJvbpdsAiEAlfq3Dq_8dnYbtmyDdXgopeKkSV5_76VSpcog-wkwEwo"
-}`)
-
-func TestCertificateRequest(t *testing.T) {
-
-	// Good
-	var goodCR CertificateRequest
-	err := json.Unmarshal(testCertificateRequestGood, &goodCR)
-	if err != nil {
-		t.Errorf("Error unmarshaling good certificate request: %v", err)
-	}
-	if err = goodCR.CSR.CheckSignature(); err != nil {
-		t.Errorf("Valid CSR in CertificateRequest failed to verify: %v", err)
-	}
-
-	// Bad CSR
-	var badCR CertificateRequest
-	err = json.Unmarshal(testCertificateRequestBadCSR, &badCR)
-	if err == nil {
-		t.Errorf("Unexpectedly accepted certificate request with bad CSR")
-	}
-
-	// Marshal
-	jsonCR, err := json.Marshal(goodCR)
-	if err != nil {
-		t.Errorf("Failed to marshal good certificate request: %v", err)
-	}
-	err = json.Unmarshal(jsonCR, &goodCR)
-	if err != nil {
-		t.Errorf("Marshalled certificate request failed to unmarshal: %v", err)
-	}
-}
-
 // util.go
 
 func TestRandomString(t *testing.T) {

--- a/core/objects.go
+++ b/core/objects.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"crypto"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -86,42 +85,8 @@ var OCSPStatusToInt = map[OCSPStatus]int{
 // DNSPrefix is attached to DNS names in DNS challenges
 const DNSPrefix = "_acme-challenge"
 
-// CertificateRequest is just a CSR
-//
-// This data is unmarshalled from JSON by way of RawCertificateRequest, which
-// represents the actual structure received from the client.
-type CertificateRequest struct {
-	CSR   *x509.CertificateRequest // The CSR
-	Bytes []byte                   // The original bytes of the CSR, for logging.
-}
-
 type RawCertificateRequest struct {
 	CSR JSONBuffer `json:"csr"` // The encoded CSR
-}
-
-// UnmarshalJSON provides an implementation for decoding CertificateRequest objects.
-func (cr *CertificateRequest) UnmarshalJSON(data []byte) error {
-	var raw RawCertificateRequest
-	err := json.Unmarshal(data, &raw)
-	if err != nil {
-		return err
-	}
-
-	csr, err := x509.ParseCertificateRequest(raw.CSR)
-	if err != nil {
-		return err
-	}
-
-	cr.CSR = csr
-	cr.Bytes = raw.CSR
-	return nil
-}
-
-// MarshalJSON provides an implementation for encoding CertificateRequest objects.
-func (cr CertificateRequest) MarshalJSON() ([]byte, error) {
-	return json.Marshal(RawCertificateRequest{
-		CSR: cr.CSR.Raw,
-	})
 }
 
 // Registration objects represent non-public metadata attached

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3333,10 +3333,6 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 	csrOb, err := x509.ParseCertificateRequest(csr)
 	test.AssertNotError(t, err, "Error pasring generated CSR")
 
-	req := core.CertificateRequest{
-		Bytes: csr,
-		CSR:   csrOb,
-	}
 	logEvent := &certificateRequestEvent{}
 
 	testCases := []struct {
@@ -3386,7 +3382,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 			// Mock the CA
 			ra.CA = tc.Mock
 			// Attempt issuance
-			_, err = ra.issueCertificateInner(ctx, req, accountID(Registration.Id), orderID(order.Id), issuance.IssuerNameID(0), logEvent)
+			_, err = ra.issueCertificateInner(ctx, csrOb, accountID(Registration.Id), orderID(order.Id), issuance.IssuerNameID(0), logEvent)
 			// We expect all of the testcases to fail because all use mocked CAs that deliberately error
 			test.AssertError(t, err, "issueCertificateInner with failing mock CA did not fail")
 			// If there is an expected `error` then match the error message


### PR DESCRIPTION
The core.CertificateRequest wrapper type only had two fields: an x509.CertificateRequest, and a slice of bytes representing the unparsed version of the same request. However, x509.CertificateRequest carries around its own field .Raw, which serves the same purpose. Also, we weren't even referencing the .Bytes field anyway. Therefore, get rid of this redundant wrapper type.

This also makes it clearer just how far the original CSR makes it through our system. I'd like a future change to remove the CSR from the request to the CA service, replacing it with a structured object that only exposes exactly the fields of the CSR we care about, such as names, public key, and whether or not the must-staple extension should be set.