### PR TITLE
Remove base64 helper functions

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -414,22 +414,9 @@ func (authz *Authorization) SolvedBy() (*AcmeChallenge, error) {
 // with stripped padding.
 type JSONBuffer []byte
 
-// URL-safe base64 encode that strips padding
-func base64URLEncode(data []byte) string {
-	var result = base64.URLEncoding.EncodeToString(data)
-	return strings.TrimRight(result, "=")
-}
-
-// URL-safe base64 decoder that adds padding
-func base64URLDecode(data string) ([]byte, error) {
-	var missing = (4 - len(data)%4) % 4
-	data += strings.Repeat("=", missing)
-	return base64.URLEncoding.DecodeString(data)
-}
-
 // MarshalJSON encodes a JSONBuffer for transmission.
 func (jb JSONBuffer) MarshalJSON() (result []byte, err error) {
-	return json.Marshal(base64URLEncode(jb))
+	return json.Marshal(base64.RawURLEncoding.EncodeToString(jb))
 }
 
 // UnmarshalJSON decodes a JSONBuffer to an object.
@@ -439,7 +426,7 @@ func (jb *JSONBuffer) UnmarshalJSON(data []byte) (err error) {
 	if err != nil {
 		return err
 	}
-	*jb, err = base64URLDecode(str)
+	*jb, err = base64.RawURLEncoding.DecodeString(strings.TrimRight(str, "="))
 	return
 }
 


### PR DESCRIPTION
These helpers are only called in one place each, and provide no real value via abstraction. Also, they're performing gymnastics in order to be able to use `base64.URLEncoding`, instead of simply using `base64.RawURLEncoding`.