### PR TITLE
Remove MandatoryPOSTAsGET from config-next

### DIFF
--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -87,7 +87,6 @@
     "authorizationLifetimeDays": 30,
     "pendingAuthorizationLifetimeDays": 7,
     "features": {
-      "MandatoryPOSTAsGET": true,
       "PrecertificateRevocation": true,
       "ServeRenewalInfo": true
     }


### PR DESCRIPTION
In preparation for removing this flag completely in #6582 , remove it from config-next.  This matches boulder's configuration in all LE environments.
