### PR TITLE
Remove CONTRIBUTING.md policy requiring tests be run for vendored dependencies

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,10 +20,6 @@ guidelines for Boulder contributions.
 * You cannot review your own code.
 * If a branch contains commits from multiple authors, it needs a reviewer who
   is not an author of commits on that branch.
-* If a branch contains updates to files in the vendor/ directory, the author is
-  responsible for running tests in all updated dependencies, and commenting in
-  the review thread that they have done so. Reviewers must not approve reviews
-  that have changes in vendor/ but lack a comment about tests.
 * Review changes to or addition of tests just as rigorously as you review code
   changes. Consider: Do tests actually test what they mean to test? Is this the
   best way to test the functionality in question? Do the tests cover all the


### PR DESCRIPTION
When I first joined the team, I asked if this policy was still being followed. The answers were basically 

![larrydavid](https://user-images.githubusercontent.com/2382565/212167309-ebd5daaf-3581-4550-be0f-456d3de8f949.gif)

There's a few scenarios that we care about, ranked from easy to onerous;
1. A dependency with no transitive dependencies
2. A dependency with a single transitive dependency
3. A dependency with multiple transitive dependencies each with their own sprawling hellscape of further dependencies

We discussed removing this in standup and in chat.