### PR TITLE
observer: Fix nil pointer in TLS prober 

### DIFF
--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -102,9 +102,6 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 			opts := x509.VerifyOptions{
 				CurrentTime: cs.PeerCertificates[0].NotAfter,
 			}
-			for _, cert := range cs.PeerCertificates[1:] {
-				opts.Intermediates.AddCert(cert)
-			}
 			_, err := cs.PeerCertificates[0].Verify(opts)
 			return err
 		},

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -100,7 +100,8 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 		InsecureSkipVerify: true,
 		VerifyConnection: func(cs tls.ConnectionState) error {
 			opts := x509.VerifyOptions{
-				CurrentTime: cs.PeerCertificates[0].NotAfter,
+				CurrentTime:   cs.PeerCertificates[0].NotAfter,
+				Intermediates: x509.NewCertPool(),
 			}
 			_, err := cs.PeerCertificates[0].Verify(opts)
 			return err

--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -103,6 +103,9 @@ func (p TLSProbe) probeExpired(timeout time.Duration) bool {
 				CurrentTime:   cs.PeerCertificates[0].NotAfter,
 				Intermediates: x509.NewCertPool(),
 			}
+			for _, cert := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
 			_, err := cs.PeerCertificates[0].Verify(opts)
 			return err
 		},


### PR DESCRIPTION
Initialize `Intermediates` field in `VerifyOptions`.