### PR TITLE
observer: Make monitors probe immediately instead of waiting a single duration

### DIFF
--- a/observer/monitor.go
+++ b/observer/monitor.go
@@ -18,8 +18,8 @@ type monitor struct {
 func (m monitor) start(logger blog.Logger) {
 	ticker := time.NewTicker(m.period)
 	timeout := m.period / 2
-	go func() {
-		for range ticker.C {
+	for {
+		go func() {
 			// Attempt to probe the configured target.
 			success, dur := m.prober.Probe(timeout)
 
@@ -32,6 +32,7 @@ func (m monitor) start(logger blog.Logger) {
 			logger.Infof(
 				"kind=[%s] success=[%v] duration=[%f] name=[%s]",
 				m.prober.Kind(), success, dur.Seconds(), m.prober.Name())
-		}
-	}()
+		}()
+		<-ticker.C
+	}
 }


### PR DESCRIPTION
Because of how Ticker works, the loop waits `m.period` amount of time before running the first probe, instead of running a probe immediately upon startup like might be expected. It would be very useful to not have to wait for that first probe to happen on launch, both for debugging and deployment purposes.

This behavior recently contributed to an interesting issue when release-2023-01-17 was deployed to staging via Nomad. The bug noted in #6591 caused observer to panic, but not until *after* the canary had been promoted and the deployment considered successful. This happened because all of the TLS monitors were configured with `period: 60s` and the Nomad jobspec had the following `update` stanza:

```hcl
    update {
      auto_revert       = true
      auto_promote      = true
      canary            = 1
      healthy_deadline  = "9m"
    }
```

With the above `update` stanza, the job took the default value `min_healthy_time = "10s"`, and thus Nomad only waited 10 seconds after observer came up to determine its allocation was healthy and promote it. Once the initial 60 seconds passed, observer hit the offending codepath, panicked, and was eventually restarted/rescheduled; this crash-restart cycle happened endlessly until the problem was noticed and the boulder version was rolled back.

The Nomad deploy, for all intents and purposes, had succeeded, but only because of this race. Had the `period` been shorter or the `min_healthy_time` been longer, the deployment would have failed and been rolled back automatically, notifying the SRE who deployed it immediately. While a simple fix to prevent this from happening again would be to edit `min_healthy_time` and/or the configured `period` values, I think the more systematic and permanent fix would be to implement the change in this PR. If observer is going to hit an offending codepath that causes it to crash, it makes sense for that to happen immediately, and avoid the need to set `min_healthy_time` as a function of the largest `period`.

Additional tweak: the way the loop was written before, observer wasn't actually spawning a new goroutine for each probe attempt, as implied was the original intent by the comment above. This PR brings the behavior in line with that original intent.