### PR TITLE
grpc/rocsp: Use TLSv1.2 and TLSv1.3 exclusively

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -178,11 +178,9 @@ func (t *TLSConfig) Load() (*tls.Config, error) {
 		ClientCAs:    rootCAs,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{cert},
-		// Set the only acceptable TLS version to 1.2 and the only acceptable cipher suite
-		// to ECDHE-RSA-CHACHA20-POLY1305.
-		MinVersion:   tls.VersionTLS12,
-		MaxVersion:   tls.VersionTLS12,
-		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
+		// Set the only acceptable TLS version to 1.3.
+		MinVersion: tls.VersionTLS13,
+		MaxVersion: tls.VersionTLS13,
 	}, nil
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -178,9 +178,11 @@ func (t *TLSConfig) Load() (*tls.Config, error) {
 		ClientCAs:    rootCAs,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{cert},
-		// Set the only acceptable TLS version to 1.3.
-		MinVersion: tls.VersionTLS13,
+		// Set the only acceptable TLS to v1.2 and v1.3.
+		MinVersion: tls.VersionTLS12,
 		MaxVersion: tls.VersionTLS13,
+		// CipherSuites will be ignored for TLS v1.3.
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
 	}, nil
 }
 

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -2,6 +2,7 @@ package rocsp_config
 
 import (
 	"bytes"
+	"crypto/tls"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
@@ -110,6 +111,9 @@ func MakeClient(c *RedisConfig, clk clock.Clock, stats prometheus.Registerer) (r
 	if err != nil {
 		return nil, fmt.Errorf("loading TLS config: %w", err)
 	}
+	// Set TLS config to TLSv1.3 exclusively.
+	tlsConfig.MinVersion = tls.VersionTLS13
+	tlsConfig.MaxVersion = tls.VersionTLS13
 
 	timeout := c.Timeout.Duration
 

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -2,7 +2,6 @@ package rocsp_config
 
 import (
 	"bytes"
-	"crypto/tls"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
@@ -111,9 +110,6 @@ func MakeClient(c *RedisConfig, clk clock.Clock, stats prometheus.Registerer) (r
 	if err != nil {
 		return nil, fmt.Errorf("loading TLS config: %w", err)
 	}
-	// Set TLS config to TLSv1.3 exclusively.
-	tlsConfig.MinVersion = tls.VersionTLS13
-	tlsConfig.MaxVersion = tls.VersionTLS13
 
 	timeout := c.Timeout.Duration
 

--- a/test/redis-cluster.config
+++ b/test/redis-cluster.config
@@ -28,6 +28,7 @@ user replication-user  on +@all ~* >435e9c4225f08813ef3af7c725f0d30d263b9cd3
 user unittest-rw       on +@all ~* >824968fa490f4ecec1e52d5e34916bdb60d45f8d
 masteruser replication-user
 masterauth 435e9c4225f08813ef3af7c725f0d30d263b9cd3
+tls-protocols "TLSv1.3"
 tls-cert-file /test/redis-tls/redis/cert.pem
 tls-key-file /test/redis-tls/redis/key.pem
 tls-ca-cert-file /test/redis-tls/minica.pem

--- a/test/redis.config
+++ b/test/redis.config
@@ -28,6 +28,7 @@ user replication-user  on +@all ~* >435e9c4225f08813ef3af7c725f0d30d263b9cd3
 user unittest-rw       on +@all ~* >824968fa490f4ecec1e52d5e34916bdb60d45f8d
 masteruser replication-user
 masterauth 435e9c4225f08813ef3af7c725f0d30d263b9cd3
+tls-protocols "TLSv1.3"
 tls-cert-file /test/redis-tls/redis/cert.pem
 tls-key-file /test/redis-tls/redis/key.pem
 tls-ca-cert-file /test/redis-tls/minica.pem


### PR DESCRIPTION
Fixes #6580