### PR TITLE
wfe2: don't pass through client-initiated cancellation

### DIFF
--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -111,7 +111,7 @@ func main() {
 	start, stop, err := bgrpc.NewServer(c.SA.GRPC).Add(
 		&sapb.StorageAuthorityReadOnly_ServiceDesc, saroi).Add(
 		&sapb.StorageAuthority_ServiceDesc, sai).Build(
-		tls, scope, clk, bgrpc.NoCancelInterceptor)
+		tls, scope, clk)
 	cmd.FailOnError(err, "Unable to setup SA gRPC server")
 
 	go cmd.CatchSignals(logger, stop)

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -280,23 +280,23 @@ func setupWFE(c Config, scope prometheus.Registerer, clk clock.Clock) (rapb.Regi
 	tlsConfig, err := c.WFE.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
-	raConn, err := bgrpc.ClientSetup(c.WFE.RAService, tlsConfig, scope, clk, bgrpc.CancelTo408Interceptor)
+	raConn, err := bgrpc.ClientSetup(c.WFE.RAService, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to RA")
 	rac := rapb.NewRegistrationAuthorityClient(raConn)
 
-	saConn, err := bgrpc.ClientSetup(c.WFE.SAService, tlsConfig, scope, clk, bgrpc.CancelTo408Interceptor)
+	saConn, err := bgrpc.ClientSetup(c.WFE.SAService, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := sapb.NewStorageAuthorityReadOnlyClient(saConn)
 
 	var rns noncepb.NonceServiceClient
 	npm := map[string]noncepb.NonceServiceClient{}
 	if c.WFE.GetNonceService != nil {
-		rnsConn, err := bgrpc.ClientSetup(c.WFE.GetNonceService, tlsConfig, scope, clk, bgrpc.CancelTo408Interceptor)
+		rnsConn, err := bgrpc.ClientSetup(c.WFE.GetNonceService, tlsConfig, scope, clk)
 		cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to get nonce service")
 		rns = noncepb.NewNonceServiceClient(rnsConn)
 		for prefix, serviceConfig := range c.WFE.RedeemNonceServices {
 			serviceConfig := serviceConfig
-			conn, err := bgrpc.ClientSetup(&serviceConfig, tlsConfig, scope, clk, bgrpc.CancelTo408Interceptor)
+			conn, err := bgrpc.ClientSetup(&serviceConfig, tlsConfig, scope, clk)
 			cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to redeem nonce service")
 			npm[prefix] = noncepb.NewNonceServiceClient(conn)
 		}

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
-	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/health"
 )
 
@@ -30,7 +29,7 @@ func TestClientSetup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := ClientSetup(tt.cfg, &tls.Config{}, metrics.NoopRegisterer, clock.NewFake(), []grpc.UnaryClientInterceptor{}...)
+			client, err := ClientSetup(tt.cfg, &tls.Config{}, metrics.NoopRegisterer, clock.NewFake())
 			if tt.wantErr {
 				test.AssertError(t, err, "expected error, got nil")
 			} else {

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -67,7 +67,7 @@ func (sb *serverBuilder) Add(desc *grpc.ServiceDesc, impl any) *serverBuilder {
 // all of the services added to the builder. It also exposes a health check
 // service. It returns two functions, start() and stop(), which should be used
 // to start and gracefully stop the server.
-func (sb *serverBuilder) Build(tlsConfig *tls.Config, statsRegistry prometheus.Registerer, clk clock.Clock, interceptors ...grpc.UnaryServerInterceptor) (func() error, func(), error) {
+func (sb *serverBuilder) Build(tlsConfig *tls.Config, statsRegistry prometheus.Registerer, clk clock.Clock) (func() error, func(), error) {
 	// Add the health service to all servers.
 	healthSrv := health.NewServer()
 	sb = sb.Add(&healthpb.Health_ServiceDesc, healthSrv)
@@ -127,12 +127,12 @@ func (sb *serverBuilder) Build(tlsConfig *tls.Config, statsRegistry prometheus.R
 
 	mi := newServerMetadataInterceptor(metrics, clk)
 
-	unaryInterceptors := append([]grpc.UnaryServerInterceptor{
+	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		mi.metrics.grpcMetrics.UnaryServerInterceptor(),
 		ai.Unary,
 		mi.Unary,
 		hnygrpc.UnaryServerInterceptor(),
-	}, interceptors...)
+	}
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		mi.metrics.grpcMetrics.StreamServerInterceptor(),

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -182,7 +182,10 @@ func (rs Responder) sampledError(format string, a ...interface{}) {
 // strings of repeated '/' into a single '/', which will break the base64
 // encoding.
 func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	ctx := request.Context()
+	// We specifically ignore request.Context() because we would prefer for clients
+	// to not be able to cancel our operations in arbitrary places. Instead we
+	// start a new context, and apply timeouts in our various RPCs.
+	ctx := context.Background()
 
 	if rs.timeout != 0 {
 		var cancel func()

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -185,6 +185,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	// We specifically ignore request.Context() because we would prefer for clients
 	// to not be able to cancel our operations in arbitrary places. Instead we
 	// start a new context, and apply timeouts in our various RPCs.
+	// TODO(go1.22?): Use context.Detach()
 	ctx := context.Background()
 
 	if rs.timeout != 0 {

--- a/web/context.go
+++ b/web/context.go
@@ -130,6 +130,7 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// We specifically override the default r.Context() because we would prefer
 	// for clients to not be able to cancel our operations in arbitrary places.
 	// Instead we start a new context, and apply timeouts in our various RPCs.
+	// TODO(go1.22?): Use context.Detach()
 	ctx := context.Background()
 	r = r.WithContext(ctx)
 	beeline.AddFieldToTrace(ctx, "real_ip", logEvent.RealIP)

--- a/web/context.go
+++ b/web/context.go
@@ -127,7 +127,11 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Origin:    r.Header.Get("Origin"),
 		Extra:     make(map[string]interface{}),
 	}
-	ctx := r.Context()
+	// We specifically override the default r.Context() because we would prefer
+	// for clients to not be able to cancel our operations in arbitrary places.
+	// Instead we start a new context, and apply timeouts in our various RPCs.
+	ctx := context.Background()
+	r = r.WithContext(ctx)
 	beeline.AddFieldToTrace(ctx, "real_ip", logEvent.RealIP)
 	beeline.AddFieldToTrace(ctx, "method", logEvent.Method)
 	beeline.AddFieldToTrace(ctx, "user_agent", logEvent.UserAgent)

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -16,7 +16,6 @@ import (
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/mocks"
-	noncepb "github.com/letsencrypt/boulder/nonce/proto"
 	"github.com/letsencrypt/boulder/probs"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
@@ -24,7 +23,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/emptypb"
 	"gopkg.in/go-jose/go-jose.v2"
 )
 
@@ -1648,21 +1646,4 @@ func TestMatchJWSURLs(t *testing.T) {
 			}
 		})
 	}
-}
-
-type alwaysCancelNonceService struct{}
-
-func (acns alwaysCancelNonceService) Redeem(ctx context.Context, msg *noncepb.NonceMessage, opts ...grpc.CallOption) (*noncepb.ValidMessage, error) {
-	return nil, probs.Canceled("user canceled request")
-}
-
-func (acns alwaysCancelNonceService) Nonce(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*noncepb.NonceMessage, error) {
-	return nil, probs.Canceled("user canceled request")
-}
-
-type alwaysCancelAccountGetter struct{}
-
-// GetRegistration implements AccountGetter
-func (alwaysCancelAccountGetter) GetRegistration(ctx context.Context, regID *sapb.RegistrationID, opts ...grpc.CallOption) (*corepb.Registration, error) {
-	return nil, probs.Canceled("user canceled request")
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1175,22 +1175,6 @@ func TestChallenge(t *testing.T) {
 	}
 }
 
-type mockSAGetCertificateCanceled struct {
-	*mocks.StorageAuthorityReadOnly
-}
-
-func (mockSAGetCertificateCanceled) GetCertificate(context.Context, *sapb.Serial, ...grpc.CallOption) (*corepb.Certificate, error) {
-	return nil, probs.Canceled("canceled!")
-}
-
-type mockSAGetAuthorization2Canceled struct {
-	*mocks.StorageAuthorityReadOnly
-}
-
-func (mockSAGetAuthorization2Canceled) GetAuthorization2(context.Context, *sapb.AuthorizationID2, ...grpc.CallOption) (*corepb.Authorization, error) {
-	return nil, probs.Canceled("canceled!")
-}
-
 // MockRAPerformValidationError is a mock RA that just returns an error on
 // PerformValidation.
 type MockRAPerformValidationError struct {
@@ -2834,14 +2818,6 @@ func TestKeyRolloverMismatchedJWSURLs(t *testing.T) {
 		}`)
 }
 
-type mockSAGetOrderCanceled struct {
-	sapb.StorageAuthorityReadOnlyClient
-}
-
-func (sa mockSAGetOrderCanceled) GetOrder(_ context.Context, req *sapb.OrderRequest, _ ...grpc.CallOption) (*corepb.Order, error) {
-	return nil, probs.Canceled("canceled!")
-}
-
 func TestGetOrder(t *testing.T) {
 	wfe, _, signer := setupWFE(t)
 
@@ -3201,14 +3177,6 @@ func TestNewAccountWhenGetRegByKeyFails(t *testing.T) {
 	}
 }
 
-type mockSAGetRegByKeyCanceled struct {
-	sapb.StorageAuthorityReadOnlyClient
-}
-
-func (sa *mockSAGetRegByKeyCanceled) GetRegistrationByKey(_ context.Context, req *sapb.JSONWebKey, _ ...grpc.CallOption) (*corepb.Registration, error) {
-	return nil, probs.Canceled("canceled!")
-}
-
 type mockSAGetRegByKeyNotFound struct {
 	sapb.StorageAuthorityReadOnlyClient
 }
@@ -3248,15 +3216,6 @@ func TestNewAccountWhenGetRegByKeyNotFound(t *testing.T) {
 		"detail": "No account exists with the provided key",
 		"status": 400
 	}`)
-}
-
-// mockRANewRegCanceled is a mock RA that always returns a `berrors.MissingSCTsError` from `FinalizeOrder`
-type mockRANewRegCanceled struct {
-	MockRegistrationAuthority
-}
-
-func (ra *mockRANewRegCanceled) NewRegistration(context.Context, *corepb.Registration, ...grpc.CallOption) (*corepb.Registration, error) {
-	return nil, probs.Canceled("canceled!")
 }
 
 func TestPrepAuthzForDisplay(t *testing.T) {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -420,23 +420,6 @@ func addHeadIfGet(s []string) []string {
 	return s
 }
 
-func TestGetNonceCancellationBecomes408(t *testing.T) {
-	wfe, _, _ := setupWFE(t)
-	mux := http.NewServeMux()
-	rw := httptest.NewRecorder()
-
-	for k := range wfe.noncePrefixMap {
-		wfe.noncePrefixMap[k] = alwaysCancelNonceService{}
-	}
-	wfe.remoteNonceService = alwaysCancelNonceService{}
-	wfe.HandleFunc(mux, "/foo", func(context.Context, *web.RequestEvent, http.ResponseWriter, *http.Request) {
-	}, "POST")
-	req, err := http.NewRequest("POST", "/foo", nil)
-	test.AssertNotError(t, err, "creating request")
-	mux.ServeHTTP(rw, req)
-	test.AssertEquals(t, rw.Code, 408)
-}
-
 func TestHandleFunc(t *testing.T) {
 	wfe, _, _ := setupWFE(t)
 	var mux *http.ServeMux
@@ -1200,44 +1183,12 @@ func (mockSAGetCertificateCanceled) GetCertificate(context.Context, *sapb.Serial
 	return nil, probs.Canceled("canceled!")
 }
 
-// When SA.GetCertificate is canceled, return 408.
-func TestGetCertificateCanceled(t *testing.T) {
-	wfe, _, _ := setupWFE(t)
-	wfe.sa = mockSAGetCertificateCanceled{}
-	responseWriter := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "333333333333333333333333333333333333", nil)
-	test.AssertNotError(t, err, "creating request")
-
-	wfe.Certificate(ctx, newRequestEvent(), responseWriter, req)
-	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
-}
-
 type mockSAGetAuthorization2Canceled struct {
 	*mocks.StorageAuthorityReadOnly
 }
 
 func (mockSAGetAuthorization2Canceled) GetAuthorization2(context.Context, *sapb.AuthorizationID2, ...grpc.CallOption) (*corepb.Authorization, error) {
 	return nil, probs.Canceled("canceled!")
-}
-
-// When SA.GetAuthorization2 is canceled during a Challenge POST or Authorization GET, return 408.
-func TestGetAuthorization2Canceled408(t *testing.T) {
-	wfe, _, signer := setupWFE(t)
-	wfe.sa = mockSAGetAuthorization2Canceled{}
-	post := func(path string) *http.Request {
-		signedURL := fmt.Sprintf("http://localhost/%s", path)
-		_, _, jwsBody := signer.byKeyID(1, nil, signedURL, `{}`)
-		return makePostRequestWithPath(path, jwsBody)
-	}
-	responseWriter := httptest.NewRecorder()
-	wfe.Challenge(ctx, newRequestEvent(), responseWriter, post("1/-ZfxEw"))
-	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
-
-	req, err := http.NewRequest("GET", "3", nil)
-	test.AssertNotError(t, err, "creating request")
-	responseWriter = httptest.NewRecorder()
-	wfe.Authorization(ctx, newRequestEvent(), responseWriter, req)
-	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
 }
 
 // MockRAPerformValidationError is a mock RA that just returns an error on
@@ -2891,22 +2842,6 @@ func (sa mockSAGetOrderCanceled) GetOrder(_ context.Context, req *sapb.OrderRequ
 	return nil, probs.Canceled("canceled!")
 }
 
-func TestGetOrderCanceled408(t *testing.T) {
-	wfe, _, signer := setupWFE(t)
-	wfe.sa = mockSAGetOrderCanceled{}
-	responseWriter := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "123/456", nil)
-	test.AssertNotError(t, err, "creating request")
-	wfe.GetOrder(ctx, newRequestEvent(), responseWriter, req)
-	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
-
-	_, _, jwsBody := signer.byKeyID(1, nil, "http://localhost/123/456", "{}")
-	postReq := makePostRequestWithPath("123/456", jwsBody)
-	responseWriter = httptest.NewRecorder()
-	wfe.FinalizeOrder(ctx, newRequestEvent(), responseWriter, postReq)
-	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
-}
-
 func TestGetOrder(t *testing.T) {
 	wfe, _, signer := setupWFE(t)
 
@@ -3274,21 +3209,6 @@ func (sa *mockSAGetRegByKeyCanceled) GetRegistrationByKey(_ context.Context, req
 	return nil, probs.Canceled("canceled!")
 }
 
-// When SA.GetRegistrationByKey is canceled (i.e. by the client), NewAccount should
-// return 408.
-func TestNewAccountWhenGetRegByKeyCanceled(t *testing.T) {
-	wfe, _, signer := setupWFE(t)
-	wfe.sa = &mockSAGetRegByKeyCanceled{wfe.sa}
-	key := loadKey(t, []byte(testE2KeyPrivatePEM))
-	_, ok := key.(*ecdsa.PrivateKey)
-	test.Assert(t, ok, "Couldn't load ECDSA key")
-	payload := `{"contact":["mailto:person@mail.com"],"agreement":"` + agreementURL + `"}`
-	responseWriter := httptest.NewRecorder()
-	_, _, body := signer.embeddedJWK(key, "http://localhost/new-account", payload)
-	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("/new-account", body))
-	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
-}
-
 type mockSAGetRegByKeyNotFound struct {
 	sapb.StorageAuthorityReadOnlyClient
 }
@@ -3337,21 +3257,6 @@ type mockRANewRegCanceled struct {
 
 func (ra *mockRANewRegCanceled) NewRegistration(context.Context, *corepb.Registration, ...grpc.CallOption) (*corepb.Registration, error) {
 	return nil, probs.Canceled("canceled!")
-}
-
-// When RA.GetRegistrationByKey is canceled (i.e. by the client), NewAccount should
-// return 408.
-func TestNewAccountWhenRANewRegCanceled(t *testing.T) {
-	wfe, _, signer := setupWFE(t)
-	wfe.ra = &mockRANewRegCanceled{}
-	key := loadKey(t, []byte(testE2KeyPrivatePEM))
-	_, ok := key.(*ecdsa.PrivateKey)
-	test.Assert(t, ok, "Couldn't load ECDSA key")
-	payload := `{"contact":["mailto:person@mail.com"],"termsOfServiceAgreed":true}`
-	responseWriter := httptest.NewRecorder()
-	_, _, body := signer.embeddedJWK(key, "http://localhost/new-account", payload)
-	wfe.NewAccount(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("/new-account", body))
-	test.AssertEquals(t, responseWriter.Code, http.StatusRequestTimeout)
 }
 
 func TestPrepAuthzForDisplay(t *testing.T) {


### PR DESCRIPTION
And clean up the code and tests that were used for cancellation pass-through.

Fixes #6603