### PR TITLE
Add checking of validations to cert-checker

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -250,10 +250,11 @@ func (c *certChecker) checkValidations(cert core.Certificate, dnsNames []string)
 	}
 
 	if len(authzs) == 0 {
-		return fmt.Errorf("no relevant authzs found valid at %s",
-			cert.Issued)
+		return fmt.Errorf("no relevant authzs found valid at %s", cert.Issued)
 	}
 
+	// We may get multiple authorizations for the same name, but that's okay.
+	// Any authorization for a given name is sufficient.
 	nameToAuthz := make(map[string]*corepb.Authorization)
 	for _, m := range authzs {
 		nameToAuthz[m.Identifier] = m

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
@@ -238,10 +239,45 @@ var expectedExtensionContent = map[string][]byte{
 	"1.3.6.1.5.5.7.1.24": {0x30, 0x03, 0x02, 0x01, 0x05}, // Must staple feature
 }
 
+// checkValidations checks the database for matching authorizations that were
+// likely valid at the time the certificate was issued. Authorizations with
+// status = "deactivated" are counted for this, so long as their validatedAt
+// is before the issuance and expiration is after.
+func (c *certChecker) checkValidations(cert core.Certificate, dnsNames []string) error {
+	authzs, err := sa.SelectAuthzsMatchingIssuance(c.dbMap, cert.RegistrationID, cert.Issued, dnsNames)
+	if err != nil {
+		return fmt.Errorf("error checking authzs for certificate %s: %w", cert.Serial, err)
+	}
+
+	if len(authzs) == 0 {
+		return fmt.Errorf("no relevant authzs found valid at %s",
+			cert.Issued)
+	}
+
+	nameToAuthz := make(map[string]*corepb.Authorization)
+	for _, m := range authzs {
+		nameToAuthz[m.Identifier] = m
+	}
+
+	var errors []error
+	for _, name := range dnsNames {
+		_, ok := nameToAuthz[name]
+		if !ok {
+			errors = append(errors, fmt.Errorf("missing authz for %q", name))
+			continue
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("%s", errors)
+	}
+	return nil
+}
+
 // checkCert returns a list of DNS names in the certificate and a list of problems with the certificate.
 func (c *certChecker) checkCert(cert core.Certificate, ignoredLints map[string]bool) ([]string, []string) {
 	var dnsNames []string
 	var problems []string
+
 	// Check that the digests match.
 	if cert.Digest != core.Fingerprint256(cert.DER) {
 		problems = append(problems, "Stored digest doesn't match certificate digest")
@@ -350,6 +386,17 @@ func (c *certChecker) checkCert(cert core.Certificate, ignoredLints map[string]b
 		err = c.kp.GoodKey(context.Background(), p.PublicKey)
 		if err != nil {
 			problems = append(problems, fmt.Sprintf("Key Policy isn't willing to issue for public key: %s", err))
+		}
+
+		if features.Enabled(features.CertCheckerChecksValidations) {
+			err = c.checkValidations(cert, parsedCert.DNSNames)
+			if err != nil {
+				if features.Enabled(features.CertCheckerRequiresValidations) {
+					problems = append(problems, err.Error())
+				} else {
+					c.logger.Errf("Certificate %s %s: %s", cert.Serial, parsedCert.DNSNames, err)
+				}
+			}
 		}
 	}
 	return dnsNames, problems

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -21,11 +21,13 @@ func _() {
 	_ = x[ROCSPStage6-10]
 	_ = x[ROCSPStage7-11]
 	_ = x[ExpirationMailerUsesJoin-12]
+	_ = x[CertCheckerChecksValidations-13]
+	_ = x[CertCheckerRequiresValidations-14]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoin"
+const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidations"
 
-var _FeatureFlag_index = [...]uint8{0, 6, 22, 42, 55, 69, 87, 105, 116, 132, 157, 168, 179, 203}
+var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 105, 116, 132, 157, 168, 179, 203, 231, 261}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -53,23 +53,33 @@ const (
 	// rather than a SELECT from certificateStatus followed by thousands of
 	// one-row SELECTs from certificates.
 	ExpirationMailerUsesJoin
+
+	// CertCheckerChecksValidations enables an extra query for each certificate
+	// checked, to find the relevant authzs. Since this query might be
+	// expensive, we get it behind a feature flag.
+	CertCheckerChecksValidations
+
+	// CertCheckerChecksValidations ...
+	CertCheckerRequiresValidations
 )
 
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
-	unused:                    false,
-	CAAValidationMethods:      false,
-	CAAAccountURI:             false,
-	EnforceMultiVA:            false,
-	MultiVAFullResults:        false,
-	MandatoryPOSTAsGET:        false,
-	StoreRevokerInfo:          false,
-	ECDSAForAll:               false,
-	ServeRenewalInfo:          false,
-	AllowUnrecognizedFeatures: false,
-	ROCSPStage6:               false,
-	ROCSPStage7:               false,
-	ExpirationMailerUsesJoin:  false,
+	unused:                         false,
+	CAAValidationMethods:           false,
+	CAAAccountURI:                  false,
+	EnforceMultiVA:                 false,
+	MultiVAFullResults:             false,
+	MandatoryPOSTAsGET:             false,
+	StoreRevokerInfo:               false,
+	ECDSAForAll:                    false,
+	ServeRenewalInfo:               false,
+	AllowUnrecognizedFeatures:      false,
+	ROCSPStage6:                    false,
+	ROCSPStage7:                    false,
+	ExpirationMailerUsesJoin:       false,
+	CertCheckerChecksValidations:   false,
+	CertCheckerRequiresValidations: false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/features/features.go
+++ b/features/features.go
@@ -59,7 +59,9 @@ const (
 	// expensive, we get it behind a feature flag.
 	CertCheckerChecksValidations
 
-	// CertCheckerChecksValidations ...
+	// CertCheckerRequiresValidations causes cert-checker to fail if the
+	// query enabled by CertCheckerChecksValidations didn't find corresponding
+	// authorizations.
 	CertCheckerRequiresValidations
 )
 

--- a/sa/db-users/boulder_sa.sql
+++ b/sa/db-users/boulder_sa.sql
@@ -79,6 +79,7 @@ GRANT SELECT ON fqdnSets TO 'mailer'@'localhost';
 
 -- Cert checker
 GRANT SELECT ON certificates TO 'cert_checker'@'localhost';
+GRANT SELECT ON authz2 TO 'cert_checker'@'localhost';
 
 -- Bad Key Revoker
 GRANT SELECT,UPDATE ON blockedKeys TO 'badkeyrevoker'@'localhost';

--- a/sa/model.go
+++ b/sa/model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/letsencrypt/boulder/db"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
@@ -443,6 +444,72 @@ type authzModel struct {
 	Token            []byte     `db:"token"`
 	ValidationError  []byte     `db:"validationError"`
 	ValidationRecord []byte     `db:"validationRecord"`
+}
+
+func eraseSliceType(input []string) []any {
+	var output []any
+	for _, in := range input {
+		output = append(output, in)
+	}
+	return output
+}
+
+// SelectAuthzsMatchingIssuance looks for a set of authzs that would have
+// authorized a given issuance that is known to have occurred. The returned
+// authzs will all belong to the given regID, will have potentially been valid
+// at the time of issuance, and will have the appropriate identifier type and
+// value. This may return multiple authzs for the same identifier type and value.
+//
+// This returns "potentially" valid authzs because a client may have set an
+// authzs status to deactivated after issuance, so we return both valid and
+// deactivated authzs. It also uses a small amount of leeway (1s) to account
+// for possible clock skew.
+//
+// This function doesn't do anything special for authzs with an expiration in
+// the past. If the stored authz has a valid status, it is returned with a
+// valid status regardless of whether it is also expired.
+func SelectAuthzsMatchingIssuance(
+	s db.Selector,
+	regID int64,
+	issued time.Time,
+	dnsNames []string,
+) ([]*corepb.Authorization, error) {
+	var authzModels []authzModel
+	query := fmt.Sprintf(`SELECT %s FROM authz2 WHERE
+			registrationID = ? AND
+			status IN (?, ?) AND
+			expires >= ? AND
+			attemptedAt <= ? AND
+			identifierType = ? AND
+			identifierValue IN (%s)`,
+		authzFields,
+		db.QuestionMarks(len(dnsNames)))
+	var args []any
+	args = append(args,
+		regID,
+		statusToUint[core.StatusValid],
+		statusToUint[core.StatusDeactivated],
+		issued.Add(-1*time.Second), // leeway for clock skew
+		issued.Add(1*time.Second),  // leeway for clock skew
+		identifierTypeToUint[string(identifier.DNS)],
+	)
+	args = append(args, eraseSliceType(dnsNames)...)
+
+	_, err := s.Select(&authzModels, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var authzs []*corepb.Authorization
+	for _, model := range authzModels {
+		authz, err := modelToAuthzPB(model)
+		if err != nil {
+			return nil, err
+		}
+		authzs = append(authzs, authz)
+
+	}
+	return authzs, err
 }
 
 // hasMultipleNonPendingChallenges checks if a slice of challenges contains

--- a/sa/model.go
+++ b/sa/model.go
@@ -446,14 +446,6 @@ type authzModel struct {
 	ValidationRecord []byte     `db:"validationRecord"`
 }
 
-func eraseSliceType(input []string) []any {
-	var output []any
-	for _, in := range input {
-		output = append(output, in)
-	}
-	return output
-}
-
 // SelectAuthzsMatchingIssuance looks for a set of authzs that would have
 // authorized a given issuance that is known to have occurred. The returned
 // authzs will all belong to the given regID, will have potentially been valid
@@ -493,7 +485,9 @@ func SelectAuthzsMatchingIssuance(
 		issued.Add(1*time.Second),  // leeway for clock skew
 		identifierTypeToUint[string(identifier.DNS)],
 	)
-	args = append(args, eraseSliceType(dnsNames)...)
+	for _, name := range dnsNames {
+		args = append(args, name)
+	}
 
 	_, err := s.Select(&authzModels, query, args...)
 	if err != nil {

--- a/sa/model.go
+++ b/sa/model.go
@@ -466,7 +466,6 @@ func SelectAuthzsMatchingIssuance(
 	issued time.Time,
 	dnsNames []string,
 ) ([]*corepb.Authorization, error) {
-	var authzModels []authzModel
 	query := fmt.Sprintf(`SELECT %s FROM authz2 WHERE
 			registrationID = ? AND
 			status IN (?, ?) AND
@@ -489,6 +488,7 @@ func SelectAuthzsMatchingIssuance(
 		args = append(args, name)
 	}
 
+	var authzModels []authzModel
 	_, err := s.Select(&authzModels, query, args...)
 	if err != nil {
 		return nil, err

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -16,7 +16,11 @@
     "ignoredLints": [
       "n_subject_common_name_included"
     ],
-    "ctLogListFile": "test/ct-test-srv/log_list.json"
+    "ctLogListFile": "test/ct-test-srv/log_list.json",
+    "features": {
+      "CertCheckerChecksValidations": true,
+      "CertCheckerRequiresValidations": true
+    }
   },
 
   "pa": {


### PR DESCRIPTION
This includes two feature flags: one that controls turning on the extra database queries, and one that causes cert-checker to fail on missing validations. If the second flag isn't turned on, it will just emit error log lines. This will help us find any edge conditions we need to deal with before making the new code trigger alerts.

Fixes #6562 