### PR TITLE
privatekey: emit clearer error on parse

### DIFF
--- a/privatekey/privatekey.go
+++ b/privatekey/privatekey.go
@@ -114,6 +114,9 @@ func Load(keyPath string) (crypto.Signer, crypto.PublicKey, error) {
 
 	// Attempt to parse the PEM block as a private key in a PKCS #1 container.
 	rsaSigner, err := x509.ParsePKCS1PrivateKey(keyDER.Bytes)
+	if err != nil && keyDER.Type == "RSA PRIVATE KEY" {
+		return nil, nil, fmt.Errorf("unable to parse %q as a PKCS#1 RSA private key: %w", keyPath, err)
+	}
 	if err == nil {
 		return verify(rsaSigner)
 	}

--- a/privatekey/privatekey.go
+++ b/privatekey/privatekey.go
@@ -106,9 +106,9 @@ func Load(keyPath string) (crypto.Signer, crypto.PublicKey, error) {
 	// Attempt to parse the PEM block as a private key in a PKCS #8 container.
 	signer, err := x509.ParsePKCS8PrivateKey(keyDER.Bytes)
 	if err == nil {
-		crytoSigner, ok := signer.(crypto.Signer)
+		cryptoSigner, ok := signer.(crypto.Signer)
 		if ok {
-			return verify(crytoSigner)
+			return verify(cryptoSigner)
 		}
 	}
 


### PR DESCRIPTION
If the input key asserts that it is a PKCS#1 key ("BEGIN RSA PRIVATE KEY"), we can safely return the error from parsing as PKCS1, rather than trying all key types and returning a generic error.