### PR TITLE
Put errors at end of log lines

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -584,14 +584,14 @@ func logDNSError(
 		}
 
 		logger.Infof(
-			"logDNSError ID mismatch chosenServer=[%s] hostname=[%s] respHostname=[%s] queryType=[%s] err=[%s] msg=[%s] resp=[%s]",
+			"logDNSError ID mismatch chosenServer=[%s] hostname=[%s] respHostname=[%s] queryType=[%s] msg=[%s] resp=[%s] err=[%s]",
 			chosenServer,
 			hostname,
 			respQname,
 			queryType,
-			underlying,
 			encodedMsg,
-			encodedResp)
+			encodedResp,
+			underlying)
 	} else {
 		// Otherwise log a general DNS error
 		logger.Infof("logDNSError chosenServer=[%s] hostname=[%s] queryType=[%s] err=[%s]",

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -478,8 +478,8 @@ func (ca *certificateAuthorityImpl) storeCertificate(
 		err = berrors.InternalServerError(err.Error())
 		// Note: This log line is parsed by cmd/orphan-finder. If you make any
 		// changes here, you should make sure they are reflected in orphan-finder.
-		ca.log.AuditErrf("Failed RPC to store at SA, orphaning certificate: serial=[%s] cert=[%s] err=[%v], regID=[%d], orderID=[%d]",
-			core.SerialToString(serialBigInt), hex.EncodeToString(certDER), err, regID, orderID)
+		ca.log.AuditErrf("Failed RPC to store at SA, orphaning certificate: serial=[%s], cert=[%s], issuerID=[%d], regID=[%d], orderID=[%d], err=[%v]",
+			core.SerialToString(serialBigInt), hex.EncodeToString(certDER), issuerID, regID, orderID, err)
 		if ca.orphanQueue != nil {
 			ca.queueOrphan(&orphanedCert{
 				DER:      certDER,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1743,8 +1743,8 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 
 		err = ra.recordValidation(vaCtx, authz.ID, authz.Expires, challenge)
 		if err != nil {
-			ra.log.AuditErrf("Could not record updated validation: err=[%s] regID=[%d] authzID=[%s]",
-				err, authz.RegistrationID, authz.ID)
+			ra.log.AuditErrf("Could not record updated validation: regID=[%d] authzID=[%s] err=[%s]",
+				authz.RegistrationID, authz.ID, err)
 		}
 	}(authz)
 	return bgrpc.AuthzToPB(authz)

--- a/test/integration/orphan_finder_test.go
+++ b/test/integration/orphan_finder_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/letsencrypt/pkcs11key/v4"
 )
 
-var template = `[AUDIT] Failed RPC to store at SA, orphaning precertificate: serial=[%x] cert=[%x] err=[sa.StorageAuthority.AddCertificate timed out after 5000 ms], issuerID=[1], regID=[1], orderID=[1]
-[AUDIT] Failed RPC to store at SA, orphaning certificate: serial=[%x] cert=[%x] err=[sa.StorageAuthority.AddCertificate timed out after 5000 ms], issuerID=[1], regID=[1], orderID=[1]`
+var template = `[AUDIT] Failed RPC to store at SA, orphaning precertificate: serial=[%x], cert=[%x], issuerID=[1], regID=[1], orderID=[1], err=[sa.StorageAuthority.AddPrecertificate timed out after 5000 ms]
+[AUDIT] Failed RPC to store at SA, orphaning certificate: serial=[%x], cert=[%x], issuerID=[1], regID=[1], orderID=[1], err=[sa.StorageAuthority.AddCertificate timed out after 5000 ms]`
 
 // TestOrphanFinder runs the orphan-finder with an example input file. This must
 // be run after other tests so the account ID 1 exists (since the inserted

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -348,9 +348,9 @@ func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 			`hostname=\[id\.mismatch\] ` +
 			`respHostname=\[id\.mismatch\.\] ` +
 			`queryType=\[A\] ` +
-			`err\=\[dns: id mismatch\] ` +
 			`msg=\[([A-Za-z0-9+=/\=]+)\] ` +
-			`resp=\[([A-Za-z0-9+=/\=]+)\]`,
+			`resp=\[([A-Za-z0-9+=/\=]+)\] ` +
+			`err\=\[dns: id mismatch\]`,
 	)
 
 	matches := expectedRegex.FindAllStringSubmatch(matchingLines[0], -1)


### PR DESCRIPTION
For consistency, put the error field at the end of unstructured log lines to make them more ... structured.

Adds the `issuerID` field to "orphaning certificate" log line in the CA to match the "orphaning precertificate" log line.

Fixes broken tests as a result of the CA and bdns log line change.

Fixes #5457