### PR TITLE
ARI: Improve error message and add tooling

### DIFF
--- a/test/ocsp/checkari/main.go
+++ b/test/ocsp/checkari/main.go
@@ -89,10 +89,21 @@ func checkARI(baseURL string, certPath string) (*core.RenewalInfo, error) {
 }
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `
+checkari [-url https://acme.api/ari/endpoint] FILE [FILE]...
+
+Tool for querying ARI. Provide a list of filenames for certificates in PEM
+format, and this tool will query for and output the suggested renewal window
+for each certificate.
+
+`)
+		flag.PrintDefaults()
+	}
 	url := flag.String("url", "https://acme-v02.api.letsencrypt.org/get/draft-ietf-acme-ari-00/renewalInfo/", "ACME server's RenewalInfo URL")
 	flag.Parse()
 	if len(flag.Args()) == 0 {
-		fmt.Println("Supply one or more paths to certs to check ARI for")
+		flag.Usage()
 		os.Exit(1)
 	}
 

--- a/test/ocsp/checkari/main.go
+++ b/test/ocsp/checkari/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"crypto"
+	_ "crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+
+	"github.com/letsencrypt/boulder/core"
+)
+
+// certID matches the ASN.1 structure of the CertID sequence defined by RFC6960.
+type certID struct {
+	HashAlgorithm  pkix.AlgorithmIdentifier
+	IssuerNameHash []byte
+	IssuerKeyHash  []byte
+	SerialNumber   *big.Int
+}
+
+type AuthorityKeyIdentifier struct {
+	KeyIdentifier []byte `asn1:"optional,tag:0"`
+}
+
+func createRequest(cert *x509.Certificate) ([]byte, error) {
+	if !crypto.SHA256.Available() {
+		return nil, x509.ErrUnsupportedAlgorithm
+	}
+	h := crypto.SHA256.New()
+
+	h.Write(cert.RawIssuer)
+	issuerNameHash := h.Sum(nil)
+
+	req := certID{
+		pkix.AlgorithmIdentifier{ // SHA256
+			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1},
+			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
+		},
+		issuerNameHash,
+		cert.AuthorityKeyId,
+		cert.SerialNumber,
+	}
+
+	return asn1.Marshal(req)
+}
+
+func parseResponse(resp *http.Response) (*core.RenewalInfo, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var res core.RenewalInfo
+	err = json.Unmarshal(body, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+func checkARI(baseURL string, certPath string) (*core.RenewalInfo, error) {
+	cert, err := core.LoadCert(certPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := createRequest(cert)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/%s", baseURL, base64.RawURLEncoding.EncodeToString(req))
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	ri, err := parseResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return ri, nil
+}
+
+func main() {
+	url := flag.String("url", "https://acme-v02.api.letsencrypt.org/get/draft-ietf-acme-ari-00/renewalInfo/", "ACME server's RenewalInfo URL")
+	flag.Parse()
+	if len(flag.Args()) == 0 {
+		fmt.Println("Supply one or more paths to certs to check ARI for")
+		os.Exit(1)
+	}
+
+	for _, cert := range flag.Args() {
+		fmt.Printf("%s:\n", cert)
+		window, err := checkARI(*url, cert)
+		if err != nil {
+			fmt.Printf("  %s\n", err)
+		} else {
+			fmt.Printf("  Renew after : %s\n", window.SuggestedWindow.Start)
+			fmt.Printf("  Renew before: %s\n", window.SuggestedWindow.End)
+		}
+	}
+}

--- a/test/ocsp/checkari/main.go
+++ b/test/ocsp/checkari/main.go
@@ -26,10 +26,6 @@ type certID struct {
 	SerialNumber   *big.Int
 }
 
-type AuthorityKeyIdentifier struct {
-	KeyIdentifier []byte `asn1:"optional,tag:0"`
-}
-
 func createRequest(cert *x509.Certificate) ([]byte, error) {
 	if !crypto.SHA256.Available() {
 		return nil, x509.ErrUnsupportedAlgorithm
@@ -104,10 +100,10 @@ func main() {
 		fmt.Printf("%s:\n", cert)
 		window, err := checkARI(*url, cert)
 		if err != nil {
-			fmt.Printf("  %s\n", err)
+			fmt.Printf("\t%s\n", err)
 		} else {
-			fmt.Printf("  Renew after : %s\n", window.SuggestedWindow.Start)
-			fmt.Printf("  Renew before: %s\n", window.SuggestedWindow.End)
+			fmt.Printf("\tRenew after : %s\n", window.SuggestedWindow.Start)
+			fmt.Printf("\tRenew before: %s\n", window.SuggestedWindow.End)
 		}
 	}
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2266,6 +2266,11 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 		return
 	}
 
+	if len(request.URL.Path) == 0 {
+		wfe.sendError(response, logEvent, probs.NotFound("Must specify a request path"), nil)
+		return
+	}
+
 	// The path prefix has already been stripped, so request.URL.Path here is just
 	// the base64url-encoded DER CertID sequence.
 	der, err := base64.RawURLEncoding.DecodeString(request.URL.Path)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2275,14 +2275,14 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 	// the base64url-encoded DER CertID sequence.
 	der, err := base64.RawURLEncoding.DecodeString(request.URL.Path)
 	if err != nil {
-		wfe.sendError(response, logEvent, probs.Malformed("Path was not base64url-encoded: %w", err), nil)
+		wfe.sendError(response, logEvent, probs.Malformed("Path was not base64url-encoded"), nil)
 		return
 	}
 
 	var id certID
 	rest, err := asn1.Unmarshal(der, &id)
 	if err != nil || len(rest) != 0 {
-		wfe.sendError(response, logEvent, probs.Malformed("Path was not a DER-encoded CertID sequence: %w", err), nil)
+		wfe.sendError(response, logEvent, probs.Malformed("Path was not a DER-encoded CertID sequence"), nil)
 		return
 	}
 


### PR DESCRIPTION
Give ARI improved error messages when no request path is specified and when parsing of the request path blob fails.

Also, add a tool which can be used to quickly generate ARI requests and print their results, to make manual spot-checking easier.

Fixes #6629