### PR TITLE
Ceremony: use SHA256 to compute Subject Key IDs

### DIFF
--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -2,7 +2,7 @@ package notmain
 
 import (
 	"crypto"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -219,7 +219,7 @@ func generateSKID(pk []byte) ([]byte, error) {
 	if _, err := asn1.Unmarshal(pk, &pkixPublicKey); err != nil {
 		return nil, err
 	}
-	skid := sha1.Sum(pkixPublicKey.BitString.Bytes)
+	skid := sha256.Sum256(pkixPublicKey.BitString.Bytes)
 	return skid[:], nil
 }
 


### PR DESCRIPTION
Use SHA256 instead of SHA1 to compute the Subject Key Identifier when producing new CA certs with the ceremony tool.

This change is safe, as the issuance package ensures that we directly copy the Issuing CA's Subject Key Identifier value into the Authority Key Identifier field of the template certificate we pass to x509.CreateCertificate. Thus, all end-entity certs issued from a CA with a SHA256 Subject Key Identifier will have the correct value for their Authority Key Identifier, regardless of the method used to initially compute that value.

This change adds 12 bytes to each self-signed Root CA certificate issued with this change, 24 bytes to each Subordinate CA certificate (whether a normal intermediate or a cross-signed root), and 12 bytes to each end-entity issued from those intermediates.

Fixes #6630