### PR TITLE
Quote go version to prevent yaml truncating trailing zero

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - 1.19.5
-          - 1.20
+          - "1.19.5"
+          - "1.20"
     runs-on: ubuntu-20.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Build .deb
         id: build
         env:
-          GO_VERSION: 1.19.5
+          GO_VERSION: "1.19.5"
         run: ./tools/make-deb.sh


### PR DESCRIPTION
There was a [release build failure](https://github.com/letsencrypt/boulder/actions/runs/4108910167/jobs/7090140890) for `push-release (1.2)` which is great, except for the fact that we wanted `push-release (1.20)` and got bitten by a YAML.