### PR TITLE
Remove leftover ACMEv1 combinations code

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -337,9 +337,6 @@ type Authorization struct {
 	// slice and the order of these challenges may not be predictable.
 	Challenges []Challenge `json:"challenges,omitempty" db:"-"`
 
-	// This field is deprecated. It's filled in by WFE for the ACMEv1 API.
-	Combinations [][]int `json:"combinations,omitempty" db:"combinations"`
-
 	// Wildcard is a Boulder-specific Authorization field that indicates the
 	// authorization was created as a result of an order containing a name with
 	// a `*.`wildcard prefix. This will help convey to users that an

--- a/core/proto/core.proto
+++ b/core/proto/core.proto
@@ -76,7 +76,7 @@ message Authorization {
   string status = 4;
   int64 expires = 5; // Unix timestamp (nanoseconds)
   repeated core.Challenge challenges = 6;
-  reserved 7; // previously combinations
+  reserved 7; // previously ACMEv1 combinations
   reserved 8; // previously v2
 }
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1144,10 +1144,6 @@ func (wfe *WebFrontEndImpl) prepAuthorizationForDisplay(request *http.Request, a
 	authz.ID = ""
 	authz.RegistrationID = 0
 
-	// Combinations are a relic of the V1 API. Since they are tagged omitempty we
-	// can set this field to nil to avoid sending it to users of the V2 API.
-	authz.Combinations = nil
-
 	// The ACME spec forbids allowing "*" in authorization identifiers. Boulder
 	// allows this internally as a means of tracking when an authorization
 	// corresponds to a wildcard request (e.g. to handle CAA properly). We strip

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3234,7 +3234,6 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 				ProvidedKeyAuthorization: "	🔑",
 			},
 		},
-		Combinations: [][]int{{1, 2, 3}, {4}, {5, 6}},
 	}
 
 	// Prep the wildcard authz for display
@@ -3244,12 +3243,6 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	test.AssertEquals(t, strings.HasPrefix(authz.Identifier.Value, "*."), false)
 	// The authz should be marked as corresponding to a wildcard name
 	test.AssertEquals(t, authz.Wildcard, true)
-	// The authz should not have any combinations
-	// NOTE(@cpu): We don't use test.AssertNotNil here because its use of
-	// interface{} types makes a comparison of [][]int{nil} and nil fail.
-	if authz.Combinations != nil {
-		t.Errorf("Authz had a non-nil combinations")
-	}
 
 	// We expect the authz challenge has its URL set and the URI emptied.
 	authz.ID = "12345"


### PR DESCRIPTION
Clean up unused ACMEv1 code.

Fixes #6624 