### PR TITLE
RA: Log CAA reuse/recheck at order finalize time

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -30,6 +30,7 @@ type Logger interface {
 	Warningf(format string, a ...interface{})
 	Info(msg string)
 	Infof(format string, a ...interface{})
+	InfoObject(string, interface{})
 	Debug(msg string)
 	Debugf(format string, a ...interface{})
 	AuditPanic()
@@ -313,6 +314,17 @@ func (log *impl) Info(msg string) {
 // Infof level messages pass through normally.
 func (log *impl) Infof(format string, a ...interface{}) {
 	log.Info(fmt.Sprintf(format, a...))
+}
+
+// InfoObject logs an INFO level JSON-serialized object message.
+func (log *impl) InfoObject(msg string, obj interface{}) {
+	jsonObj, err := json.Marshal(obj)
+	if err != nil {
+		log.auditAtLevel(syslog.LOG_ERR, fmt.Sprintf("Object could not be serialized to JSON. Raw: %+v", obj))
+		return
+	}
+
+	log.Infof("%s JSON=%s", msg, jsonObj)
 }
 
 // Debug level messages pass through normally.

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1163,8 +1163,7 @@ func (ra *RegistrationAuthorityImpl) validateFinalizeRequest(
 
 		// Count the number of authorizations where the original CAA check was
 		// reused and the number where it was rechecked.
-		var caaRecheckAfter = ra.clk.Now().Add(caaRecheckDuration)
-		staleCAA, _ := validatedBefore(authz, caaRecheckAfter)
+		staleCAA, _ := validatedBefore(authz, ra.clk.Now().Add(caaRecheckDuration))
 		if err != nil {
 			// This should never happen because we just checked the same thing
 			// inside ra.checkOrderAuthorizations.

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -340,12 +340,12 @@ type certificateRevocationEvent struct {
 type finalizationCAACheckEvent struct {
 	// Requester is the associated account ID.
 	Requester int64 `json:",omitempty"`
-	// Rechecked is incremented for each Authz where a new CAA check was
-	// performed because the original check was older than 7 hours.
-	Rechecked int `json:",omitempty"`
-	// Reused is incremented for each Authz where the original CAA check was
-	// performed in the last 7 hours.
+	// Reused is a count of Authz where the original CAA check was performed in
+	// the last 7 hours.
 	Reused int `json:",omitempty"`
+	// Rechecked is a count of Authz where a new CAA check was performed because
+	// the original check was older than 7 hours.
+	Rechecked int `json:",omitempty"`
 }
 
 // noRegistrationID is used for the regID parameter to GetThreshold when no

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1163,7 +1163,7 @@ func (ra *RegistrationAuthorityImpl) validateFinalizeRequest(
 
 		// Count the number of authorizations where the original CAA check was
 		// reused and the number where it was rechecked.
-		staleCAA, _ := validatedBefore(authz, ra.clk.Now().Add(caaRecheckDuration))
+		staleCAA, err := validatedBefore(authz, ra.clk.Now().Add(caaRecheckDuration))
 		if err != nil {
 			// This should never happen because we just checked the same thing
 			// inside ra.checkOrderAuthorizations.

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -59,7 +59,7 @@ var (
 	// recheck the CAA records for a domain. Per Baseline Requirements, we must
 	// recheck CAA records within 8 hours of issuance. We set this to 7 hours to
 	// stay on the safe side.
-	caaRecheckDuration = time.Duration(-7 * time.Hour)
+	caaRecheckDuration = -7 * time.Hour
 )
 
 type caaChecker interface {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3093,7 +3093,8 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 
 	// Cast the RA's mock log so we can ensure its cleared and can access the
 	// matched log lines
-	mockLog := ra.log.(*blog.Mock)
+	mockLog, ok := ra.log.(*blog.Mock)
+	test.Assert(t, ok, "Failed to cast RA log to Mock")
 	mockLog.Clear()
 
 	// Finalize the order with the CSR
@@ -3146,6 +3147,96 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 		// The authz entry should have the correct challenge type
 		test.AssertEquals(t, authzEntry.ChallengeType, challs[i])
 	}
+}
+
+func TestIssueCertificateCAACheckLog(t *testing.T) {
+	_, sa, ra, fc, cleanUp := initAuthorities(t)
+	defer cleanUp()
+
+	// Set up order and authz expiries.
+	ra.orderLifetime = 24 * time.Hour
+	ra.authorizationLifetime = 15 * time.Hour
+
+	exp := fc.Now().Add(24 * time.Hour)
+	recent := fc.Now().Add(-1 * time.Hour)
+	older := fc.Now().Add(-8 * time.Hour)
+
+	// Make some valid authzs for four names. Half of them were validated
+	// recently and half were validated in excess of our CAA recheck time.
+	names := []string{"not-example.com", "www.not-example.com", "still.not-example.com", "definitely.not-example.com"}
+	var authzIDs []int64
+	for i, name := range names {
+		if i%2 == 0 {
+			authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, name, exp, core.ChallengeTypeHTTP01, recent))
+		} else {
+			authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, name, exp, core.ChallengeTypeHTTP01, older))
+		}
+	}
+
+	// Create a pending order for all of the names.
+	order, err := sa.NewOrderAndAuthzs(context.Background(), &sapb.NewOrderAndAuthzsRequest{
+		NewOrder: &sapb.NewOrderRequest{
+			RegistrationID:   Registration.Id,
+			Expires:          exp.UnixNano(),
+			Names:            names,
+			V2Authorizations: authzIDs,
+		},
+	})
+	test.AssertNotError(t, err, "Could not add test order with finalized authz IDs")
+
+	// Generate a CSR covering the order names with a random RSA key.
+	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	test.AssertNotError(t, err, "error generating test key")
+	csr, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		PublicKey:          testKey.PublicKey,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+		Subject:            pkix.Name{CommonName: "not-example.com"},
+		DNSNames:           names,
+	}, testKey)
+	test.AssertNotError(t, err, "Could not create test order CSR")
+
+	// Create a mock certificate for the fake CA to return.
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(12),
+		Subject: pkix.Name{
+			CommonName: "not-example.com",
+		},
+		DNSNames:              names,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, 1),
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, testKey.Public(), testKey)
+	test.AssertNotError(t, err, "Failed to create mock cert for test CA")
+
+	// Set up the RA's CA with a mock that returns the cert from above.
+	ra.CA = &mocks.MockCA{
+		PEM: pem.EncodeToMemory(&pem.Block{
+			Bytes: cert,
+		}),
+	}
+
+	// Cast the RA's mock log so we can ensure its cleared and can access the
+	// matched log lines.
+	mockLog, ok := ra.log.(*blog.Mock)
+	test.Assert(t, ok, "Failed to cast RA log to Mock")
+	mockLog.Clear()
+
+	// Finalize the order with the CSR.
+	order.Status = string(core.StatusReady)
+	_, err = ra.FinalizeOrder(context.Background(), &rapb.FinalizeOrderRequest{
+		Order: order,
+		Csr:   csr,
+	})
+	test.AssertNotError(t, err, "Error finalizing test order")
+
+	// Get the logged lines from the mock logger.
+	loglines := mockLog.GetAllMatching("finalizing order with")
+	// There should be exactly 1 matching log line.
+	test.AssertEquals(t, len(loglines), 1)
+	// The log line should contain the expected number of authzs and CAA reuses/rechecks.
+	test.AssertEquals(t, loglines[0], "INFO: Id 1 finalizing order with 4 Authzs (2 CAA reused, 2 CAA rechecked)")
 }
 
 // TestUpdateMissingAuthorization tests the race condition where a challenge is

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3166,11 +3166,11 @@ func TestIssueCertificateCAACheckLog(t *testing.T) {
 	names := []string{"not-example.com", "www.not-example.com", "still.not-example.com", "definitely.not-example.com"}
 	var authzIDs []int64
 	for i, name := range names {
+		attemptedAt := older
 		if i%2 == 0 {
-			authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, name, exp, core.ChallengeTypeHTTP01, recent))
-		} else {
-			authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, name, exp, core.ChallengeTypeHTTP01, older))
+			attemptedAt = recent
 		}
+		authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, name, exp, core.ChallengeTypeHTTP01, attemptedAt))
 	}
 
 	// Create a pending order for all of the names.

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3093,7 +3093,7 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 
 	// Cast the RA's mock log so we can ensure its cleared and can access the
 	// matched log lines
-	mockLog, _ := ra.log.(*blog.Mock)
+	mockLog := ra.log.(*blog.Mock)
 	mockLog.Clear()
 
 	// Finalize the order with the CSR
@@ -3218,7 +3218,7 @@ func TestIssueCertificateCAACheckLog(t *testing.T) {
 
 	// Cast the RA's mock log so we can ensure its cleared and can access the
 	// matched log lines.
-	mockLog, _ := ra.log.(*blog.Mock)
+	mockLog := ra.log.(*blog.Mock)
 	mockLog.Clear()
 
 	// Finalize the order with the CSR.

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3234,19 +3234,20 @@ func TestIssueCertificateCAACheckLog(t *testing.T) {
 	// There should be exactly 1 matching log line.
 	test.AssertEquals(t, len(loglines), 1)
 
-	// Strip away the stuff before 'JSON='
+	// Strip away the stuff before 'JSON='.
 	jsonContent := strings.TrimPrefix(loglines[0], "INFO: FinalizationCaaCheck JSON=")
 
-	// Unmarshal the JSON into a certificate request event object
+	// Unmarshal the JSON into an event object.
 	var event finalizationCAACheckEvent
 	err = json.Unmarshal([]byte(jsonContent), &event)
-	// The JSON should unmarshal without error
+	// The JSON should unmarshal without error.
 	test.AssertNotError(t, err, "Error unmarshalling logged JSON issuance event.")
 	// The event requester should be the expected registration ID.
 	test.AssertEquals(t, event.Requester, Registration.Id)
 	// The event should have the expected number of Authzs where CAA was reused.
 	test.AssertEquals(t, event.Reused, 2)
-	// The event should have the expected number of Authzs where CAA was rechecked.
+	// The event should have the expected number of Authzs where CAA was
+	// rechecked.
 	test.AssertEquals(t, event.Rechecked, 2)
 }
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3093,8 +3093,7 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 
 	// Cast the RA's mock log so we can ensure its cleared and can access the
 	// matched log lines
-	mockLog, ok := ra.log.(*blog.Mock)
-	test.Assert(t, ok, "Failed to cast RA log to Mock")
+	mockLog, _ := ra.log.(*blog.Mock)
 	mockLog.Clear()
 
 	// Finalize the order with the CSR


### PR DESCRIPTION
- Log counts of Authzs where CAA was rechecked/reused.
- Move the CAA recheck duration to a single variable in the RA.
- Add new method `InfoObject` to our logger.

Fixes #6560
Part of #6623 