### PR TITLE
OCSP: return 404 for all types of NotFound

### DIFF
--- a/ocsp/responder/redis/checked_redis_source.go
+++ b/ocsp/responder/redis/checked_redis_source.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/db"
+	berrors "github.com/letsencrypt/boulder/errors"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/ocsp/responder"
 	"github.com/letsencrypt/boulder/sa"
@@ -113,7 +114,7 @@ func (src *checkedRedisSource) Response(ctx context.Context, req *ocsp.Request) 
 	if dbErr != nil {
 		// If the DB says "not found", the certificate either doesn't exist or has
 		// expired and been removed from the DB. We don't need to check the Redis error.
-		if db.IsNoRows(dbErr) {
+		if db.IsNoRows(dbErr) || errors.Is(dbErr, berrors.NotFound) {
 			src.counter.WithLabelValues("not_found").Inc()
 			return nil, responder.ErrNotFound
 		}


### PR DESCRIPTION
When the ocsp-responder queries the database for a certificate status, we want to return a 404 if we don't find a certificate status row for the serial in question. This is because we often receive requests for serials which we never issued, and for very old (expired) serials whose status data we may have purged from the database.

Previously, we did this by checking whether the error returned by the database was the "ErrNoRows" used by Go's SQL library. However, when the ocsp-responder uses the SA to get this information, rather than querying the database directly, the SA's gRPC service returns berrors.NotFound instead. The code was not checking for this error, and therefore turned some requests that should have been 404s into 500s.

Check for both kinds of "not found" error, and return a 404 for both. Add tests to ensure that we return responder.ErrNotFound in both cases.