### PR TITLE
Separate release creation and asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.19.5"
+          - "1.20"
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -34,4 +35,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://cli.github.com/manual/gh_release_create
-        run: gh release create "${GITHUB_REF_NAME}" boulder*.deb
+        run: gh release create "${GITHUB_REF_NAME}"
+        continue-on-error: true
+
+      - name: Upload release files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://cli.github.com/manual/gh_release_upload
+        run: gh release upload "${GITHUB_REF_NAME}" boulder*.deb


### PR DESCRIPTION
Split creating a release and uploading build assets to that release into two separate steps. This allows the release creation step to have the "continue on error" flag set, so that whichever release job completes first can create the release, while the slower one will fail, move on, and still successfully upload its files.