### PR TITLE
Add replication lag retries to some SA methods

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -447,7 +447,7 @@ func setup(t *testing.T) testCtx {
 	incidentsDbMap, err := sa.NewDbMap(vars.DBConnIncidents, sa.DbSettings{})
 	test.AssertNotError(t, err, "Couldn't create test dbMap")
 
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, incidentsDbMap, 1, fc, log, metrics.NoopRegisterer)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, incidentsDbMap, 1, 0, fc, log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -27,6 +27,9 @@ type Config struct {
 
 		// Max simultaneous SQL queries caused by a single RPC.
 		ParallelismPerRPC int
+		// LagFactor is how long to sleep before retrying a read request that may
+		// have failed solely due to replication lag.
+		LagFactor cmd.ConfigDuration
 	}
 
 	Syslog  cmd.SyslogConfig
@@ -91,7 +94,8 @@ func main() {
 	tls, err := c.SA.TLS.Load()
 	cmd.FailOnError(err, "TLS config")
 
-	saroi, err := sa.NewSQLStorageAuthorityRO(dbReadOnlyMap, dbIncidentsMap, parallel, clk, logger)
+	saroi, err := sa.NewSQLStorageAuthorityRO(
+		dbReadOnlyMap, dbIncidentsMap, parallel, c.SA.LagFactor.Duration, clk, logger)
 	cmd.FailOnError(err, "Failed to create read-only SA impl")
 
 	sai, err := sa.NewSQLStorageAuthorityWrapping(saroi, dbMap, scope)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -331,7 +331,7 @@ func TestGetAndProcessCerts(t *testing.T) {
 	fc.Set(fc.Now().Add(time.Hour))
 
 	checker := newChecker(saDbMap, fc, pa, kp, time.Hour, testValidityDurations, blog.NewMock())
-	sa, err := sa.NewSQLStorageAuthority(saDbMap, saDbMap, nil, 1, fc, blog.NewMock(), metrics.NoopRegisterer)
+	sa, err := sa.NewSQLStorageAuthority(saDbMap, saDbMap, nil, 1, 0, fc, blog.NewMock(), metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "Couldn't create SA to insert certificates")
 	saCleanUp := test.ResetBoulderTestDatabase(t)
 	defer func() {

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -201,7 +201,7 @@ func setup(t *testing.T) testCtx {
 		t.Fatalf("Couldn't connect to the database: %s", err)
 	}
 
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, clock.New(), log, metrics.NoopRegisterer)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, clock.New(), log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
 	}

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -899,7 +899,7 @@ func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 
 	fc := newFakeClock(t)
 	log := blog.NewMock()
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, fc, log, metrics.NoopRegisterer)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, fc, log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
 	}

--- a/cmd/id-exporter/main_test.go
+++ b/cmd/id-exporter/main_test.go
@@ -448,7 +448,7 @@ func setup(t *testing.T) testCtx {
 	cleanUp := test.ResetBoulderTestDatabase(t)
 
 	fc := newFakeClock(t)
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, fc, log, metrics.NoopRegisterer)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, fc, log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
 	}

--- a/ocsp/updater/updater_test.go
+++ b/ocsp/updater/updater_test.go
@@ -55,7 +55,7 @@ func setup(t *testing.T) (*OCSPUpdater, sapb.StorageAuthorityClient, *db.Wrapped
 	fc := clock.NewFake()
 	fc.Add(1 * time.Hour)
 
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, fc, log, metrics.NoopRegisterer)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, fc, log, metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "Failed to create SA")
 
 	updater, err := New(

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -314,7 +314,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, fc, log, metrics.NoopRegisterer)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, fc, log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -81,11 +81,13 @@ func NewSQLStorageAuthority(
 	dbReadOnlyMap *db.WrappedMap,
 	dbIncidentsMap *db.WrappedMap,
 	parallelismPerRPC int,
+	lagFactor time.Duration,
 	clk clock.Clock,
 	logger blog.Logger,
 	stats prometheus.Registerer,
 ) (*SQLStorageAuthority, error) {
-	ssaro, err := NewSQLStorageAuthorityRO(dbReadOnlyMap, dbIncidentsMap, parallelismPerRPC, clk, logger)
+	ssaro, err := NewSQLStorageAuthorityRO(
+		dbReadOnlyMap, dbIncidentsMap, parallelismPerRPC, lagFactor, clk, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -72,7 +72,7 @@ func initSA(t *testing.T) (*SQLStorageAuthority, clock.FakeClock, func()) {
 	fc := clock.NewFake()
 	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
 
-	saro, err := NewSQLStorageAuthorityRO(dbMap, dbIncidentsMap, 1, fc, log)
+	saro, err := NewSQLStorageAuthorityRO(dbMap, dbIncidentsMap, 1, 0, fc, log)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -226,6 +226,39 @@ func TestNoSuchRegistrationErrors(t *testing.T) {
 	test.AssertErrorIs(t, err, berrors.NotFound)
 }
 
+func TestReplicationLagRetries(t *testing.T) {
+	sa, clk, cleanUp := initSA(t)
+	defer cleanUp()
+
+	reg := createWorkingRegistration(t, sa)
+
+	// First, set the lagFactor to 0. Neither selecting a real registration nor
+	// selecting a nonexistent registration should cause the clock to advance.
+	sa.lagFactor = 0
+	start := clk.Now()
+
+	_, err := sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id})
+	test.AssertNotError(t, err, "selecting extant registration")
+	test.AssertEquals(t, clk.Now(), start)
+
+	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
+	test.AssertError(t, err, "selecting nonexistent registration")
+	test.AssertEquals(t, clk.Now(), start)
+
+	// Now, set the lagFactor to 1. Trying to select a nonexistent registration
+	// should cause the clock to advance when GetRegistration sleeps and retries.
+	sa.lagFactor = 1
+	start = clk.Now()
+
+	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id})
+	test.AssertNotError(t, err, "selecting extant registration")
+	test.AssertEquals(t, clk.Now(), start)
+
+	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
+	test.AssertError(t, err, "selecting nonexistent registration")
+	test.AssertEquals(t, clk.Now(), start.Add(1))
+}
+
 func TestAddCertificate(t *testing.T) {
 	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -97,7 +97,7 @@ func (ssa *SQLStorageAuthorityRO) GetRegistration(ctx context.Context, req *sapb
 		// GetRegistration is often called to validate a JWK belonging to a brand
 		// new account whose registrations table row hasn't propagated to the read
 		// replica yet. If we get a NoRows, wait a little bit and retry, once.
-		time.Sleep(ssa.lagFactor)
+		ssa.clk.Sleep(ssa.lagFactor)
 		model, err = selectRegistration(ssa.dbReadOnlyMap.WithContext(ctx), query, req.Id)
 	}
 	if err != nil {
@@ -653,7 +653,7 @@ func (ssa *SQLStorageAuthorityRO) GetOrder(ctx context.Context, req *sapb.OrderR
 		// GetOrder is often called shortly after a new order is created, sometimes
 		// before the order or its associated rows have propagated to the read
 		// replica yet. If we get a NoRows, wait a little bit and retry, once.
-		time.Sleep(ssa.lagFactor)
+		ssa.clk.Sleep(ssa.lagFactor)
 		output, err = db.WithTransaction(ctx, ssa.dbReadOnlyMap, txn)
 	}
 	if err != nil {
@@ -749,7 +749,7 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorization2(ctx context.Context, req *sa
 		// GetAuthorization2 is often called shortly after a new order is created,
 		// sometimes before the order's associated authz rows have propagated to the
 		// read replica yet. If we get a NoRows, wait a little bit and retry, once.
-		time.Sleep(ssa.lagFactor)
+		ssa.clk.Sleep(ssa.lagFactor)
 		obj, err = ssa.dbReadOnlyMap.Get(authzModel{}, req.Id)
 	}
 	if err != nil {

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -123,8 +123,8 @@ func (ssa *SQLStorageAuthorityRO) GetRegistration(ctx context.Context, req *sapb
 	}
 
 	ssa.highestSeenMutex.Lock()
-	if req.Id > ssa.highestSeenIDs["registrations"] {
-		ssa.highestSeenIDs["registrations"] = req.Id
+	if model.ID > ssa.highestSeenIDs["registrations"] {
+		ssa.highestSeenIDs["registrations"] = model.ID
 	}
 	ssa.highestSeenMutex.Unlock()
 
@@ -159,6 +159,12 @@ func (ssa *SQLStorageAuthorityRO) GetRegistrationByKey(ctx context.Context, req 
 		}
 		return nil, err
 	}
+
+	ssa.highestSeenMutex.Lock()
+	if model.ID > ssa.highestSeenIDs["registrations"] {
+		ssa.highestSeenIDs["registrations"] = model.ID
+	}
+	ssa.highestSeenMutex.Unlock()
 
 	return registrationModelToPb(model)
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -13,6 +13,7 @@
       "maxOpenConns": 100
     },
     "ParallelismPerRPC": 20,
+    "lagFactor": "200ms",
     "debugAddr": ":8003",
     "tls": {
       "caCertFile": "test/grpc-creds/minica.pem",


### PR DESCRIPTION
Add a new time.Duration field, LagFactor, to both the SA's config struct and the read-only SA's implementation struct. In the GetRegistration, GetOrder, and GetAuthorization2 methods, if the database select returned a NoRows error and a lagFactor duration is configured, then sleep for lagFactor seconds and retry the select.

This allows us to compensate for the replication lag between our primary write database and our read-only replica databases. Sometimes clients will fire requests in rapid succession (such as creating a new order, then immediately querying the authorizations associated with that order), and the subsequent requests will fail because they are directed to read replicas which are lagging behind the primary. Adding this simple sleep-and-retry will let us mitigate many of these failures, without adding too much complexity.

Fixes #6593