### PR TITLE
Strict YAML parsing

### DIFF
--- a/ca/ecdsa_allow_list.go
+++ b/ca/ecdsa_allow_list.go
@@ -3,10 +3,10 @@ package ca
 import (
 	"sync"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/reloader"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v3"
 )
 
 // ECDSAAllowList acts as a container for a map of Registration IDs, a
@@ -24,7 +24,7 @@ type ECDSAAllowList struct {
 // of a YAML list (as bytes).
 func (e *ECDSAAllowList) Update(contents []byte) error {
 	var regIDs []int64
-	err := yaml.Unmarshal(contents, &regIDs)
+	err := cmd.UnmarshalYAML(contents, &regIDs)
 	if err != nil {
 		return err
 	}

--- a/ca/ecdsa_allow_list.go
+++ b/ca/ecdsa_allow_list.go
@@ -3,9 +3,9 @@ package ca
 import (
 	"sync"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/reloader"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -24,7 +24,7 @@ type ECDSAAllowList struct {
 // of a YAML list (as bytes).
 func (e *ECDSAAllowList) Update(contents []byte) error {
 	var regIDs []int64
-	err := cmd.UnmarshalYAMLStrict(contents, &regIDs)
+	err := strictyaml.Unmarshal(contents, &regIDs)
 	if err != nil {
 		return err
 	}

--- a/ca/ecdsa_allow_list.go
+++ b/ca/ecdsa_allow_list.go
@@ -24,7 +24,7 @@ type ECDSAAllowList struct {
 // of a YAML list (as bytes).
 func (e *ECDSAAllowList) Update(contents []byte) error {
 	var regIDs []int64
-	err := cmd.UnmarshalYAML(contents, &regIDs)
+	err := cmd.UnmarshalYAMLStrict(contents, &regIDs)
 	if err != nil {
 		return err
 	}

--- a/cmd/boulder-observer/main.go
+++ b/cmd/boulder-observer/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	// Parse the YAML config file.
 	var config observer.ObsConf
-	err = cmd.UnmarshalYAML(configYAML, &config)
+	err = cmd.UnmarshalYAMLStrict(configYAML, &config)
 
 	if err != nil {
 		cmd.FailOnError(err, "failed to parse YAML config")

--- a/cmd/boulder-observer/main.go
+++ b/cmd/boulder-observer/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer"
+	"github.com/letsencrypt/boulder/strictyaml"
 )
 
 func main() {
@@ -18,7 +19,7 @@ func main() {
 
 	// Parse the YAML config file.
 	var config observer.ObsConf
-	err = cmd.UnmarshalYAMLStrict(configYAML, &config)
+	err = strictyaml.Unmarshal(configYAML, &config)
 
 	if err != nil {
 		cmd.FailOnError(err, "failed to parse YAML config")

--- a/cmd/boulder-observer/main.go
+++ b/cmd/boulder-observer/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer"
-	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -19,7 +18,8 @@ func main() {
 
 	// Parse the YAML config file.
 	var config observer.ObsConf
-	err = yaml.Unmarshal(configYAML, &config)
+	err = cmd.UnmarshalYAML(configYAML, &config)
+
 	if err != nil {
 		cmd.FailOnError(err, "failed to parse YAML config")
 	}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -794,7 +794,7 @@ func main() {
 	var ct struct {
 		CeremonyType string `yaml:"ceremony-type"`
 	}
-	err = yaml.Unmarshal(configBytes, &ct)
+	err = cmd.UnmarshalYAML(configBytes, &ct)
 	if err != nil {
 		log.Fatalf("Failed to parse config: %s", err)
 	}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -794,7 +794,12 @@ func main() {
 	var ct struct {
 		CeremonyType string `yaml:"ceremony-type"`
 	}
-	err = cmd.UnmarshalYAML(configBytes, &ct)
+
+	// We are intentionally using non-strict unmarshaling to read the top level
+	// tags to populate the "ct" struct for use in the switch statement below.
+	// Further strict processing of each yaml node is done on a case by case basis
+	// inside the switch statement.
+	err = yaml.Unmarshal(configBytes, &ct)
 	if err != nil {
 		log.Fatalf("Failed to parse config: %s", err)
 	}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/linter"
 	"github.com/letsencrypt/boulder/pkcs11helpers"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"golang.org/x/crypto/ocsp"
 	"gopkg.in/yaml.v3"
 )
@@ -465,11 +466,8 @@ func signAndWriteCert(tbs, issuer *x509.Certificate, subjectPubKey crypto.Public
 }
 
 func rootCeremony(configBytes []byte) error {
-	d := yaml.NewDecoder(bytes.NewReader(configBytes))
-	d.KnownFields(true)
-
 	var config rootConfig
-	err := d.Decode(&config)
+	err := strictyaml.Unmarshal(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
@@ -504,11 +502,8 @@ func rootCeremony(configBytes []byte) error {
 }
 
 func intermediateCeremony(configBytes []byte, ct certType) error {
-	d := yaml.NewDecoder(bytes.NewReader(configBytes))
-	d.KnownFields(true)
-
 	var config intermediateConfig
-	err := d.Decode(&config)
+	err := strictyaml.Unmarshal(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
@@ -554,11 +549,8 @@ func intermediateCeremony(configBytes []byte, ct certType) error {
 }
 
 func csrCeremony(configBytes []byte) error {
-	d := yaml.NewDecoder(bytes.NewReader(configBytes))
-	d.KnownFields(true)
-
 	var config csrConfig
-	err := d.Decode(&config)
+	err := strictyaml.Unmarshal(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
@@ -600,11 +592,8 @@ func csrCeremony(configBytes []byte) error {
 }
 
 func keyCeremony(configBytes []byte) error {
-	d := yaml.NewDecoder(bytes.NewReader(configBytes))
-	d.KnownFields(true)
-
 	var config keyConfig
-	err := d.Decode(&config)
+	err := strictyaml.Unmarshal(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
@@ -636,11 +625,8 @@ func keyCeremony(configBytes []byte) error {
 }
 
 func ocspRespCeremony(configBytes []byte) error {
-	d := yaml.NewDecoder(bytes.NewReader(configBytes))
-	d.KnownFields(true)
-
 	var config ocspRespConfig
-	err := d.Decode(&config)
+	err := strictyaml.Unmarshal(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}
@@ -709,11 +695,8 @@ func ocspRespCeremony(configBytes []byte) error {
 }
 
 func crlCeremony(configBytes []byte) error {
-	d := yaml.NewDecoder(bytes.NewReader(configBytes))
-	d.KnownFields(true)
-
 	var config crlConfig
-	err := d.Decode(&config)
+	err := strictyaml.Unmarshal(configBytes, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)
 	}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -2,13 +2,10 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"expvar"
 	"fmt"
-	"io"
 	"log"
 	"log/syslog"
 	"net/http"
@@ -22,7 +19,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/grpclog"
-	"gopkg.in/yaml.v3"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/go-sql-driver/mysql"
@@ -312,24 +308,6 @@ func ReadConfigFile(filename string, out interface{}) error {
 	decoder := json.NewDecoder(file)
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(out)
-}
-
-// UnmarshalYAMLStrict takes a byte array and an arbitrary interface as arguments and
-// attempts to unmarshal the contents of the byte array into a defined struct. Any
-// config keys from the incoming YAML document which do not correspond to
-// expected keys in the config struct will result in errors.
-//
-// TODO(https://github.com/go-yaml/yaml/issues/639): Replace this function with
-// yaml.Unmarshal once a more ergonomic way to set unmarshal options is added upstream.
-func UnmarshalYAMLStrict(b []byte, yamlObj interface{}) error {
-	decoder := yaml.NewDecoder(bytes.NewReader(b))
-	decoder.KnownFields(true)
-
-	err := decoder.Decode(yamlObj)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return err
-	}
-	return err
 }
 
 // VersionString produces a friendly Application version string.

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -2,10 +2,13 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"log/syslog"
 	"net/http"
@@ -19,6 +22,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc/grpclog"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/go-sql-driver/mysql"
@@ -308,6 +312,23 @@ func ReadConfigFile(filename string, out interface{}) error {
 	decoder := json.NewDecoder(file)
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(out)
+}
+
+// TODO(https://github.com/go-yaml/yaml/issues/639): Use yaml.Unmarshal again
+// once this is implemented.
+// UnmarshalYAML takes a byte array and an arbitrary interface as arguments and
+// attempts to unmarshal the contents of the byte array into a defined struct. Any
+// config keys from the incoming YAML document which do not correspond to
+// expected keys in the config struct will result in errors.
+func UnmarshalYAML(b []byte, yamlObj interface{}) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(b))
+	decoder.KnownFields(true)
+
+	err := decoder.Decode(yamlObj)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return err
 }
 
 // VersionString produces a friendly Application version string.

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -314,13 +314,14 @@ func ReadConfigFile(filename string, out interface{}) error {
 	return decoder.Decode(out)
 }
 
-// TODO(https://github.com/go-yaml/yaml/issues/639): Use yaml.Unmarshal again
-// once this is implemented.
-// UnmarshalYAML takes a byte array and an arbitrary interface as arguments and
+// UnmarshalYAMLStrict takes a byte array and an arbitrary interface as arguments and
 // attempts to unmarshal the contents of the byte array into a defined struct. Any
 // config keys from the incoming YAML document which do not correspond to
 // expected keys in the config struct will result in errors.
-func UnmarshalYAML(b []byte, yamlObj interface{}) error {
+//
+// TODO(https://github.com/go-yaml/yaml/issues/639): Replace this function with
+// yaml.Unmarshal once a more ergonomic way to set unmarshal options is added upstream.
+func UnmarshalYAMLStrict(b []byte, yamlObj interface{}) error {
 	decoder := yaml.NewDecoder(bytes.NewReader(b))
 	decoder.KnownFields(true)
 

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"os"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/strictyaml"
 )
 
 // blockedKeys is a type for maintaining a map of SHA256 hashes
@@ -57,7 +57,7 @@ func loadBlockedKeysList(filename string) (*blockedKeys, error) {
 		BlockedHashes    []string `yaml:"blocked"`
 		BlockedHashesHex []string `yaml:"blockedHashesHex"`
 	}
-	err = cmd.UnmarshalYAMLStrict(yamlBytes, &list)
+	err = strictyaml.Unmarshal(yamlBytes, &list)
 	if err != nil {
 		return nil, err
 	}

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -8,9 +8,8 @@ import (
 	"errors"
 	"os"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // blockedKeys is a type for maintaining a map of SHA256 hashes
@@ -58,7 +57,7 @@ func loadBlockedKeysList(filename string) (*blockedKeys, error) {
 		BlockedHashes    []string `yaml:"blocked"`
 		BlockedHashesHex []string `yaml:"blockedHashesHex"`
 	}
-	err = yaml.Unmarshal(yamlBytes, &list)
+	err = cmd.UnmarshalYAML(yamlBytes, &list)
 	if err != nil {
 		return nil, err
 	}

--- a/goodkey/blocked.go
+++ b/goodkey/blocked.go
@@ -57,7 +57,7 @@ func loadBlockedKeysList(filename string) (*blockedKeys, error) {
 		BlockedHashes    []string `yaml:"blocked"`
 		BlockedHashesHex []string `yaml:"blockedHashesHex"`
 	}
-	err = cmd.UnmarshalYAML(yamlBytes, &list)
+	err = cmd.UnmarshalYAMLStrict(yamlBytes, &list)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -28,7 +28,8 @@ func (c CRLConf) Kind() string {
 // UnmarshalSettings constructs a CRLConf object from YAML as bytes.
 func (c CRLConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf CRLConf
-	err := yaml.Unmarshal(settings, &conf)
+	err := cmd.UnmarshalYAML(settings, &conf)
+
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -28,7 +28,7 @@ func (c CRLConf) Kind() string {
 // UnmarshalSettings constructs a CRLConf object from YAML as bytes.
 func (c CRLConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf CRLConf
-	err := cmd.UnmarshalYAML(settings, &conf)
+	err := cmd.UnmarshalYAMLStrict(settings, &conf)
 
 	if err != nil {
 		return nil, err

--- a/observer/probers/crl/crl_conf.go
+++ b/observer/probers/crl/crl_conf.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -28,7 +28,7 @@ func (c CRLConf) Kind() string {
 // UnmarshalSettings constructs a CRLConf object from YAML as bytes.
 func (c CRLConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf CRLConf
-	err := cmd.UnmarshalYAMLStrict(settings, &conf)
+	err := strictyaml.Unmarshal(settings, &conf)
 
 	if err != nil {
 		return nil, err

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -33,7 +33,7 @@ func (c DNSConf) Kind() string {
 // UnmarshalSettings constructs a DNSConf object from YAML as bytes.
 func (c DNSConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf DNSConf
-	err := cmd.UnmarshalYAMLStrict(settings, &conf)
+	err := strictyaml.Unmarshal(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -33,7 +33,7 @@ func (c DNSConf) Kind() string {
 // UnmarshalSettings constructs a DNSConf object from YAML as bytes.
 func (c DNSConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf DNSConf
-	err := cmd.UnmarshalYAML(settings, &conf)
+	err := cmd.UnmarshalYAMLStrict(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/dns/dns_conf.go
+++ b/observer/probers/dns/dns_conf.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -33,7 +33,7 @@ func (c DNSConf) Kind() string {
 // UnmarshalSettings constructs a DNSConf object from YAML as bytes.
 func (c DNSConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf DNSConf
-	err := yaml.Unmarshal(settings, &conf)
+	err := cmd.UnmarshalYAML(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -26,7 +26,7 @@ func (c HTTPConf) Kind() string {
 // HTTPConf object.
 func (c HTTPConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf HTTPConf
-	err := cmd.UnmarshalYAML(settings, &conf)
+	err := cmd.UnmarshalYAMLStrict(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v3"
 )
 
 // HTTPConf is exported to receive YAML configuration.
@@ -26,7 +26,7 @@ func (c HTTPConf) Kind() string {
 // HTTPConf object.
 func (c HTTPConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf HTTPConf
-	err := yaml.Unmarshal(settings, &conf)
+	err := cmd.UnmarshalYAML(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/http/http_conf.go
+++ b/observer/probers/http/http_conf.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -26,7 +26,7 @@ func (c HTTPConf) Kind() string {
 // HTTPConf object.
 func (c HTTPConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf HTTPConf
-	err := cmd.UnmarshalYAMLStrict(settings, &conf)
+	err := strictyaml.Unmarshal(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -6,7 +6,6 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v3"
 )
 
 type MockConfigurer struct {
@@ -25,7 +24,7 @@ func (c MockConfigurer) Kind() string {
 
 func (c MockConfigurer) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf MockConfigurer
-	err := yaml.Unmarshal(settings, &conf)
+	err := cmd.UnmarshalYAML(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -24,7 +24,7 @@ func (c MockConfigurer) Kind() string {
 
 func (c MockConfigurer) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf MockConfigurer
-	err := cmd.UnmarshalYAML(settings, &conf)
+	err := cmd.UnmarshalYAMLStrict(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -24,7 +25,7 @@ func (c MockConfigurer) Kind() string {
 
 func (c MockConfigurer) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf MockConfigurer
-	err := cmd.UnmarshalYAMLStrict(settings, &conf)
+	err := strictyaml.Unmarshal(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/tls/tls_conf.go
+++ b/observer/probers/tls/tls_conf.go
@@ -32,7 +32,7 @@ func (c TLSConf) Kind() string {
 // object.
 func (c TLSConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf TLSConf
-	err := cmd.UnmarshalYAML(settings, &conf)
+	err := cmd.UnmarshalYAMLStrict(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/tls/tls_conf.go
+++ b/observer/probers/tls/tls_conf.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -32,7 +32,7 @@ func (c TLSConf) Kind() string {
 // object.
 func (c TLSConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf TLSConf
-	err := cmd.UnmarshalYAMLStrict(settings, &conf)
+	err := strictyaml.Unmarshal(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/observer/probers/tls/tls_conf.go
+++ b/observer/probers/tls/tls_conf.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -32,7 +32,7 @@ func (c TLSConf) Kind() string {
 // object.
 func (c TLSConf) UnmarshalSettings(settings []byte) (probers.Configurer, error) {
 	var conf TLSConf
-	err := yaml.Unmarshal(settings, &conf)
+	err := cmd.UnmarshalYAML(settings, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -89,7 +89,7 @@ func (pa *AuthorityImpl) loadHostnamePolicy(contents []byte) error {
 	hash := sha256.Sum256(contents)
 	pa.log.Infof("loading hostname policy, sha256: %s", hex.EncodeToString(hash[:]))
 	var policy blockedNamesPolicy
-	err := cmd.UnmarshalYAML(contents, &policy)
+	err := cmd.UnmarshalYAMLStrict(contents, &policy)
 	if err != nil {
 		return err
 	}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -16,13 +16,13 @@ import (
 	"golang.org/x/net/idna"
 	"golang.org/x/text/unicode/norm"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/iana"
 	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/reloader"
-	"gopkg.in/yaml.v3"
 )
 
 // AuthorityImpl enforces CA policy decisions.
@@ -89,7 +89,7 @@ func (pa *AuthorityImpl) loadHostnamePolicy(contents []byte) error {
 	hash := sha256.Sum256(contents)
 	pa.log.Infof("loading hostname policy, sha256: %s", hex.EncodeToString(hash[:]))
 	var policy blockedNamesPolicy
-	err := yaml.Unmarshal(contents, &policy)
+	err := cmd.UnmarshalYAML(contents, &policy)
 	if err != nil {
 		return err
 	}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -16,13 +16,13 @@ import (
 	"golang.org/x/net/idna"
 	"golang.org/x/text/unicode/norm"
 
-	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/iana"
 	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/reloader"
+	"github.com/letsencrypt/boulder/strictyaml"
 )
 
 // AuthorityImpl enforces CA policy decisions.
@@ -89,7 +89,7 @@ func (pa *AuthorityImpl) loadHostnamePolicy(contents []byte) error {
 	hash := sha256.Sum256(contents)
 	pa.log.Infof("loading hostname policy, sha256: %s", hex.EncodeToString(hash[:]))
 	var policy blockedNamesPolicy
-	err := cmd.UnmarshalYAMLStrict(contents, &policy)
+	err := strictyaml.Unmarshal(contents, &policy)
 	if err != nil {
 		return err
 	}

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/strictyaml"
 )
 
 // Limits is defined to allow mock implementations be provided during unit
@@ -116,7 +117,7 @@ func (r *limitsImpl) NewOrdersPerAccount() RateLimitPolicy {
 // YAML configuration (typically read from disk by a reloader)
 func (r *limitsImpl) LoadPolicies(contents []byte) error {
 	var newPolicy rateLimitConfig
-	err := cmd.UnmarshalYAMLStrict(contents, &newPolicy)
+	err := strictyaml.Unmarshal(contents, &newPolicy)
 	if err != nil {
 		return err
 	}

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -116,7 +116,7 @@ func (r *limitsImpl) NewOrdersPerAccount() RateLimitPolicy {
 // YAML configuration (typically read from disk by a reloader)
 func (r *limitsImpl) LoadPolicies(contents []byte) error {
 	var newPolicy rateLimitConfig
-	err := cmd.UnmarshalYAML(contents, &newPolicy)
+	err := cmd.UnmarshalYAMLStrict(contents, &newPolicy)
 	if err != nil {
 		return err
 	}

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -4,8 +4,6 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/letsencrypt/boulder/cmd"
 )
 
@@ -118,7 +116,7 @@ func (r *limitsImpl) NewOrdersPerAccount() RateLimitPolicy {
 // YAML configuration (typically read from disk by a reloader)
 func (r *limitsImpl) LoadPolicies(contents []byte) error {
 	var newPolicy rateLimitConfig
-	err := yaml.Unmarshal(contents, &newPolicy)
+	err := cmd.UnmarshalYAML(contents, &newPolicy)
 	if err != nil {
 		return err
 	}

--- a/strictyaml/yaml.go
+++ b/strictyaml/yaml.go
@@ -9,20 +9,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Unmarshal takes a byte array and an arbitrary interface as arguments and
-// attempts to unmarshal the contents of the byte array into a defined struct. Any
-// config keys from the incoming YAML document which do not correspond to
-// expected keys in the config struct will result in errors.
+// Unmarshal takes a byte array and an interface passed by reference. The
+// decode.Decode reads the next YAML-encoded value from its input and stores it
+// in the value pointed to by yamlObj. Any config keys from the incoming YAML
+// document which do not correspond to expected keys in the config struct will
+// result in errors.
 //
 // TODO(https://github.com/go-yaml/yaml/issues/639): Replace this function with
-// yaml.Unmarshal once a more ergonomic way to set unmarshal options is added upstream.
+// yaml.Unmarshal once a more ergonomic way to set unmarshal options is added
+// upstream.
 func Unmarshal(b []byte, yamlObj interface{}) error {
 	decoder := yaml.NewDecoder(bytes.NewReader(b))
 	decoder.KnownFields(true)
 
+	// decoder.Decode will mutate yamlObj
 	err := decoder.Decode(yamlObj)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
-	return err
+	return nil
 }

--- a/strictyaml/yaml.go
+++ b/strictyaml/yaml.go
@@ -4,14 +4,15 @@ package strictyaml
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Unmarshal takes a byte array and an interface passed by reference. The
-// decode.Decode will read the next YAML-encoded value from its input and store
-// it in the value pointed to by yamlObj. Any config keys from the incoming YAML
+// d.Decode will read the next YAML-encoded value from its input and store it in
+// the value pointed to by yamlObj. Any config keys from the incoming YAML
 // document which do not correspond to expected keys in the config struct will
 // result in errors.
 //
@@ -19,13 +20,33 @@ import (
 // yaml.Unmarshal once a more ergonomic way to set unmarshal options is added
 // upstream.
 func Unmarshal(b []byte, yamlObj interface{}) error {
-	decoder := yaml.NewDecoder(bytes.NewReader(b))
-	decoder.KnownFields(true)
+	r := bytes.NewReader(b)
 
-	// decoder.Decode will mutate yamlObj
-	err := decoder.Decode(yamlObj)
+	d := yaml.NewDecoder(r)
+	d.KnownFields(true)
+
+	// d.Decode will mutate yamlObj
+	err := d.Decode(yamlObj)
+
+	// As bytes are read, the length of the byte buffer should decrease. If it
+	// doesn't, there's a problem.
+	if r.Len() != 0 {
+		return fmt.Errorf("yaml object of size %d bytes had %d bytes of unexpected unconsumed trailers", r.Size(), r.Len())
+	}
+
+	// Show potential error other than EOF which we'll handle later.
 	if err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
+
+	// When Decode() attempts to parse an empty buffer (config file), an io.EOF is ultimately returned.
+	// 1) Parsing until the end of file returns a nil:
+	//    https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/decode.go#L160-L162
+	// 2) The Decode() checks for that nil and returns the io.EOF
+	//    https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/yaml.go#L123-L126
+	if errors.Is(err, io.EOF) {
+		return fmt.Errorf("yaml object is empty: %s", err)
+	}
+
 	return nil
 }

--- a/strictyaml/yaml.go
+++ b/strictyaml/yaml.go
@@ -1,0 +1,28 @@
+// Package strictyaml provides a strict YAML unmarshaller based on `go-yaml/yaml`
+package strictyaml
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Unmarshal takes a byte array and an arbitrary interface as arguments and
+// attempts to unmarshal the contents of the byte array into a defined struct. Any
+// config keys from the incoming YAML document which do not correspond to
+// expected keys in the config struct will result in errors.
+//
+// TODO(https://github.com/go-yaml/yaml/issues/639): Replace this function with
+// yaml.Unmarshal once a more ergonomic way to set unmarshal options is added upstream.
+func Unmarshal(b []byte, yamlObj interface{}) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(b))
+	decoder.KnownFields(true)
+
+	err := decoder.Decode(yamlObj)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return err
+}

--- a/strictyaml/yaml.go
+++ b/strictyaml/yaml.go
@@ -10,8 +10,8 @@ import (
 )
 
 // Unmarshal takes a byte array and an interface passed by reference. The
-// decode.Decode reads the next YAML-encoded value from its input and stores it
-// in the value pointed to by yamlObj. Any config keys from the incoming YAML
+// decode.Decode will read the next YAML-encoded value from its input and store
+// it in the value pointed to by yamlObj. Any config keys from the incoming YAML
 // document which do not correspond to expected keys in the config struct will
 // result in errors.
 //

--- a/strictyaml/yaml_test.go
+++ b/strictyaml/yaml_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	emptyConfig = []byte(``)
 	validConfig = []byte(`
 a: c
 d: c
@@ -23,7 +24,7 @@ x:
 `)
 )
 
-func TestCeremonyConfigUnmarshal(t *testing.T) {
+func TestStrictYAMLUnmarshal(t *testing.T) {
 	var config struct {
 		A string `yaml:"a"`
 		D string `yaml:"d"`
@@ -31,10 +32,15 @@ func TestCeremonyConfigUnmarshal(t *testing.T) {
 
 	err := Unmarshal(validConfig, &config)
 	test.AssertNotError(t, err, "yaml: unmarshal errors")
+	test.AssertNotError(t, err, "EOF")
 
 	err = Unmarshal(invalidConfig1, &config)
 	test.AssertError(t, err, "yaml: unmarshal errors")
 
 	err = Unmarshal(invalidConfig2, &config)
 	test.AssertError(t, err, "yaml: unmarshal errors")
+
+	// Test an empty buffer (config file)
+	err = Unmarshal(emptyConfig, &config)
+	test.AssertError(t, err, "EOF")
 }

--- a/strictyaml/yaml_test.go
+++ b/strictyaml/yaml_test.go
@@ -1,0 +1,40 @@
+package strictyaml
+
+import (
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+var (
+	validConfig = []byte(`
+a: c
+d: c
+`)
+	invalidConfig1 = []byte(`
+x: y
+`)
+
+	invalidConfig2 = []byte(`
+a: c
+d: c
+x:
+  - hey
+`)
+)
+
+func TestCeremonyConfigUnmarshal(t *testing.T) {
+	var config struct {
+		A string `yaml:"a"`
+		D string `yaml:"d"`
+	}
+
+	err := Unmarshal(validConfig, &config)
+	test.AssertNotError(t, err, "yaml: unmarshal errors")
+
+	err = Unmarshal(invalidConfig1, &config)
+	test.AssertError(t, err, "yaml: unmarshal errors")
+
+	err = Unmarshal(invalidConfig2, &config)
+	test.AssertError(t, err, "yaml: unmarshal errors")
+}

--- a/strictyaml/yaml_test.go
+++ b/strictyaml/yaml_test.go
@@ -1,6 +1,7 @@
 package strictyaml
 
 import (
+	"io"
 	"testing"
 
 	"github.com/letsencrypt/boulder/test"
@@ -42,5 +43,5 @@ func TestStrictYAMLUnmarshal(t *testing.T) {
 
 	// Test an empty buffer (config file)
 	err = Unmarshal(emptyConfig, &config)
-	test.AssertError(t, err, "EOF")
+	test.AssertErrorIs(t, err, io.EOF)
 }


### PR DESCRIPTION
Adds a custom YAML unmarshaller in the `//strictyaml` package based on `go-yaml/yaml v3` with unique key detection enabled and ensures that target struct is able to contain all target fields.

Fixes https://github.com/letsencrypt/boulder/issues/3344.