### PR TITLE
Allow BoulderErrors to be interpreted as grpc.Statuses

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/identifier"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ErrorType provides a coarse category for BoulderErrors.
@@ -76,6 +78,54 @@ func (be *BoulderError) Error() string {
 
 func (be *BoulderError) Unwrap() error {
 	return be.Type
+}
+
+// GRPCStatus implements the interface implicitly defined by gRPC's
+// status.FromError, which uses this function to detect if the error produced
+// by the gRPC server implementation code is a gRPC status.Status. Implementing
+// this means that BoulderErrors serialized in gRPC response metadata can be
+// accompanied by a gRPC status other than "UNKNOWN".
+func (be *BoulderError) GRPCStatus() *status.Status {
+	var c codes.Code
+	switch be.Type {
+	case InternalServer:
+		c = codes.Internal
+	case Malformed:
+		c = codes.InvalidArgument
+	case Unauthorized:
+		c = codes.PermissionDenied
+	case NotFound:
+		c = codes.NotFound
+	case RateLimit:
+		c = codes.ResourceExhausted
+	case RejectedIdentifier:
+		c = codes.InvalidArgument
+	case InvalidEmail:
+		c = codes.InvalidArgument
+	case ConnectionFailure:
+		c = codes.Unavailable
+	case CAA:
+		c = codes.FailedPrecondition
+	case MissingSCTs:
+		c = codes.Internal
+	case Duplicate:
+		c = codes.AlreadyExists
+	case OrderNotReady:
+		c = codes.FailedPrecondition
+	case DNS:
+		c = codes.Unknown
+	case BadPublicKey:
+		c = codes.InvalidArgument
+	case BadCSR:
+		c = codes.InvalidArgument
+	case AlreadyRevoked:
+		c = codes.AlreadyExists
+	case BadRevocationReason:
+		c = codes.InvalidArgument
+	default:
+		c = codes.Unknown
+	}
+	return status.New(c, be.Error())
 }
 
 // WithSubErrors returns a new BoulderError instance created by adding the

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -58,29 +58,10 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, statsRegistry p
 		return nil, err
 	}
 
-	customConfig := fmt.Sprintf(`{
-		"loadBalancingConfig": [{"%s": {}}],
-		"methodConfig": [{
-			"name": [
-				{"service": "sa.StorageAuthority", "method": "GetRegistration"},
-				{"service": "sa.StorageAuthority", "method": "GetOrder"},
-				{"service": "sa.StorageAuthority", "method": "GetAuthorization2"}
-			],
-			"waitForReady": true,
-			"retryPolicy": {
-				"MaxAttempts": 2,
-				"InitialBackoff": ".01s",
-				"MaxBackoff": ".01s",
-				"BackoffMultiplier": 1.0,
-				"RetryableStatusCodes": [ "NOT_FOUND" ]
-			}
-		}]
-	}`, roundrobin.Name)
-
 	creds := bcreds.NewClientCredentials(tlsConfig.RootCAs, tlsConfig.Certificates, hostOverride)
 	return grpc.Dial(
 		target,
-		grpc.WithDefaultServiceConfig(customConfig),
+		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, roundrobin.Name)),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
@@ -136,7 +135,7 @@ func (s *testServer) Chill(ctx context.Context, in *test_proto.Time) (*test_prot
 		spent := int64(time.Since(start) / time.Nanosecond)
 		return &test_proto.Time{Time: spent}, nil
 	case <-ctx.Done():
-		return nil, status.Errorf(codes.Canceled, "the chiller overslept")
+		return nil, errors.New("unique error indicating that the server's shortened context timed itself out")
 	}
 }
 
@@ -182,7 +181,7 @@ func TestTimeouts(t *testing.T) {
 		timeout             time.Duration
 		expectedErrorPrefix string
 	}{
-		{250 * time.Millisecond, "rpc error: code = Canceled desc = the chiller overslept"},
+		{250 * time.Millisecond, "rpc error: code = Unknown desc = unique error indicating that the server's shortened context timed itself out"},
 		{100 * time.Millisecond, "Chiller.Chill timed out after 0 ms"},
 		{10 * time.Millisecond, "Chiller.Chill timed out after 0 ms"},
 	}

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -136,7 +136,7 @@ func (s *testServer) Chill(ctx context.Context, in *test_proto.Time) (*test_prot
 		spent := int64(time.Since(start) / time.Nanosecond)
 		return &test_proto.Time{Time: spent}, nil
 	case <-ctx.Done():
-		return nil, status.Errorf(codes.DeadlineExceeded, "the chiller overslept")
+		return nil, status.Errorf(codes.Canceled, "the chiller overslept")
 	}
 }
 
@@ -182,7 +182,7 @@ func TestTimeouts(t *testing.T) {
 		timeout             time.Duration
 		expectedErrorPrefix string
 	}{
-		{250 * time.Millisecond, "rpc error: code = Unknown desc = rpc error: code = DeadlineExceeded desc = the chiller overslept"},
+		{250 * time.Millisecond, "rpc error: code = Canceled desc = the chiller overslept"},
 		{100 * time.Millisecond, "Chiller.Chill timed out after 0 ms"},
 		{10 * time.Millisecond, "Chiller.Chill timed out after 0 ms"},
 	}


### PR DESCRIPTION
Add the GRPCStatus method to our BoulderError type, so that the gRPC server code can automatically set an appropriate Status on all gRPC responses, based on the kind of error that we return. We still serialize the whole BoulderError type and details into the response metadata, so that it can be rehydrated on the client side, but this allows the gRPC-native Status to be something other than Unknown. As part of this change, have our custom error serialization code stop manually setting the gRPC status code to codes.Unknown.

This change allows the default gRPC prometheus metrics to more accurately report the kinds of errors our gRPC requests experience, and may allow us to more elegantly transition to using grpc.Status errors in other places where they're relevant and useful.