### PR TITLE
Tidy up integration test environment

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -402,7 +402,7 @@ func (c *GRPCClientConfig) MakeTargetAndHostOverride() (string, string, error) {
 
 	} else if c.SRVLookups != nil {
 		if c.DNSAuthority == "" {
-			return "", "", errors.New("field 'dnsAuthority' is required in gRPC client config with SRVLookup")
+			return "", "", errors.New("field 'dnsAuthority' is required in gRPC client config with SRVLookups")
 		}
 		scheme, err := c.makeSRVScheme()
 		if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -257,9 +257,9 @@ type ServiceDomain struct {
 // connection. The following field combinations are allowed:
 //
 // ServerIPAddresses, [Timeout]
-// ServerAddress, [Timeout], [DNSAuthority], [HostOverride]
-// SRVLookup, [Timeout], [DNSAuthority], [HostOverride], [SRVResolver]
-// SRVLookups, [Timeout], [DNSAuthority], [HostOverride], [SRVResolver]
+// ServerAddress, DNSAuthority, [Timeout], [HostOverride]
+// SRVLookup, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
+// SRVLookups, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
 type GRPCClientConfig struct {
 	// DNSAuthority is a single <hostname|IPv4|[IPv6]>:<port> of the DNS server
 	// to be used for resolution of gRPC backends. If the address contains a
@@ -379,6 +379,9 @@ func (c *GRPCClientConfig) MakeTargetAndHostOverride() (string, string, error) {
 		return fmt.Sprintf("dns://%s/%s", c.DNSAuthority, c.ServerAddress), hostOverride, nil
 
 	} else if c.SRVLookup != nil {
+		if c.DNSAuthority == "" {
+			return "", "", errors.New("field 'dnsAuthority' is required in gRPC client config with SRVLookup")
+		}
 		scheme, err := c.makeSRVScheme()
 		if err != nil {
 			return "", "", err
@@ -398,6 +401,9 @@ func (c *GRPCClientConfig) MakeTargetAndHostOverride() (string, string, error) {
 		return fmt.Sprintf("%s://%s/%s", scheme, c.DNSAuthority, targetHost), hostOverride, nil
 
 	} else if c.SRVLookups != nil {
+		if c.DNSAuthority == "" {
+			return "", "", errors.New("field 'dnsAuthority' is required in gRPC client config with SRVLookup")
+		}
 		scheme, err := c.makeSRVScheme()
 		if err != nil {
 			return "", "", err

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,6 @@ services:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: &boulder_config_dir test/config
       GOFLAGS: -mod=vendor
-      # Go 1.18 turned off SHA-1 validation on CSRs (and certs, but that doesn't
-      # affect us) by default, but it can be turned back on with the x509sha1
-      # flag. This override will stop working in an unknown future release.
-      GODEBUG: x509sha1=1
     volumes:
       - .:/boulder:cached
       - ./.gocache:/root/.cache/go-build:cached
@@ -26,14 +22,14 @@ services:
         ipv4_address: 10.33.33.33
       consulnet:
         ipv4_address: 10.55.55.55
-    extra_hosts:
-      # This is used by TestOldTLS in va/http_test.go
-      # TODO(#6011): Remove once TLS 1.0 and 1.1 support is gone.
-      - "example.com:127.0.0.1"
-    # Use consul as a backup to Docker's embedded DNS server If there's a name
+    # Use consul as a backup to Docker's embedded DNS server. If there's a name
     # Docker's DNS server doesn't know about, it will forward the query to this
     # IP (running consul).
     # (https://docs.docker.com/config/containers/container-networking/#dns-services).
+    # This is used to look up service names via A records (like ra.service.consul) that
+    # are configured via the ServerAddress field of cmd.GRPCClientConfig.
+    # TODO: Remove this when ServerAddress is deprecated in favor of SRV records
+    # and DNSAuthority.
     dns: 10.55.55.10
     ports:
       - 4001:4001 # ACMEv2

--- a/test/config-next/admin-revoker.json
+++ b/test/config-next/admin-revoker.json
@@ -10,6 +10,7 @@
       "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
     },
     "raService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ra",
         "domain": "service.consul"
@@ -18,6 +19,7 @@
       "timeout": "15s"
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -11,6 +11,7 @@
       "keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
     },
     "raService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ra",
         "domain": "service.consul"

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -70,6 +70,7 @@
       }
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -70,6 +70,7 @@
       }
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -7,6 +7,7 @@
       "keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"
@@ -15,6 +16,7 @@
       "hostOverride": "sa.boulder"
     },
     "crlGeneratorService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ca",
         "domain": "service.consul"
@@ -23,6 +25,7 @@
       "hostOverride": "ca.boulder"
     },
     "crlStorerService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "crl-storer",
         "domain": "service.consul"

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -21,6 +21,7 @@
       "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -22,6 +22,7 @@
       "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
     },
     "raService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ra",
         "domain": "service.consul"
@@ -30,6 +31,7 @@
       "timeout": "15s"
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -22,6 +22,7 @@
       "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
     },
     "ocspGeneratorService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ca",
         "domain": "service.consul"

--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -18,6 +18,7 @@
   },
 
   "ocspGeneratorService": {
+    "dnsAuthority": "10.55.55.10",
     "srvLookup": {
       "service": "ca",
       "domain": "service.consul"
@@ -26,6 +27,7 @@
     "hostOverride": "ca.boulder"
   },
   "saService": {
+    "dnsAuthority": "10.55.55.10",
     "srvLookup": {
       "service": "sa",
       "domain": "service.consul"

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -24,6 +24,7 @@
       "keyFile": "test/grpc-creds/ra.boulder/key.pem"
     },
     "vaService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "va",
         "domain": "service.consul"
@@ -32,6 +33,7 @@
       "hostOverride": "va.boulder"
     },
     "caService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ca",
         "domain": "service.consul"
@@ -40,6 +42,7 @@
       "hostOverride": "ca.boulder"
     },
     "ocspService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ca",
         "domain": "service.consul"
@@ -48,6 +51,7 @@
       "hostOverride": "ca.boulder"
     },
     "publisherService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "publisher",
         "domain": "service.consul"
@@ -56,6 +60,7 @@
       "hostOverride": "publisher.boulder"
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"
@@ -64,6 +69,7 @@
       "hostOverride": "sa.boulder"
     },
     "akamaiPurgerService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "akamai-purger",
         "domain": "service.consul"

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -21,6 +21,7 @@
       "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
     },
     "raService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "ra",
         "domain": "service.consul"
@@ -29,6 +30,7 @@
       "hostOverride": "ra.boulder"
     },
     "saService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "sa",
         "domain": "service.consul"

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -43,6 +43,7 @@
       "ttl": "5s"
     },
     "getNonceService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookup": {
         "service": "nonce",
         "domain": "service.consul"
@@ -51,6 +52,7 @@
       "hostOverride": "nonce.boulder"
     },
     "redeemNonceService": {
+      "dnsAuthority": "10.55.55.10",
       "srvLookups": [
         {
           "service": "nonce1",

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -26,18 +26,12 @@
       "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
     },
     "raService": {
-      "srvLookup": {
-        "service": "ra",
-        "domain": "service.consul"
-      },
+      "serverAddress": "ra.service.consul:9094",
       "hostOverride": "ra.boulder",
       "timeout": "15s"
     },
     "saService": {
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
+      "serverAddress": "sa.service.consul:9095",
       "timeout": "15s",
       "hostOverride": "sa.boulder"
     },


### PR DESCRIPTION
Remove `example.com` domain name, which was used by the deleted OldTLS tests.

Remove GODEBUG=x509sha1=1.

Add a longer comment for the Consul DNS fallback in docker-compose.yml.

Use the "dnsAuthority" field for all gRPC clients in config-next, instead of implicitly relying on the system DNS. This matches what we do in prod.

Make "dnsAuthority" field of GRPCClientConfig mandatory whenever SRVLookup or SRVLookups is used.

Make test/config/ocsp-responder.json use ServerAddress instead of SRVLookup, like the rest of test/config.