### PR TITLE
Remove make-artifacts from test.sh

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -42,7 +42,7 @@ jobs:
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
-          - "./t.sh --lints --generate --make-artifacts"
+          - "./t.sh --lints --generate"
           - "./t.sh --integration && ./test/test-caa-log-checker.sh"
           # Testing Config Changes:
           # Config changes that have landed in main but not yet been applied to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         id: build
         env:
           GO_VERSION: ${{ matrix.GO_VERSION }}
-        run: ./tools/make-deb.sh
+        run: ./tools/make-assets.sh
 
       - name: Create release
         env:
@@ -43,4 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://cli.github.com/manual/gh_release_upload
-        run: gh release upload "${GITHUB_REF_NAME}" boulder*.deb
+        run: gh release upload "${GITHUB_REF_NAME}" boulder*.deb boulder*.tar.gz

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -28,4 +28,4 @@ jobs:
         id: build
         env:
           GO_VERSION: ${{ matrix.GO_VERSION }}
-        run: ./tools/make-deb.sh
+        run: ./tools/make-assets.sh

--- a/test.sh
+++ b/test.sh
@@ -111,7 +111,6 @@ With no options passed, runs standard battery of tests (lint, unit, and integrat
     -s, --start-py                        Adds start to the list of tests to run
     -v, --gomod-vendor                    Adds gomod-vendor to the list of tests to run
     -g, --generate                        Adds generate to the list of tests to run
-    -m, --make-artifacts                  Adds make-artifacts to the list of tests to run
     -o, --list-integration-tests          Outputs a list of the available integration tests
     -f <REGEX>, --filter=<REGEX>          Run only those tests matching the regular expression
 
@@ -145,7 +144,6 @@ while getopts lueciosvgmnhp:f:-: OPT; do
     s | start-py )                   RUN+=("start") ;;
     v | gomod-vendor )               RUN+=("gomod-vendor") ;;
     g | generate )                   RUN+=("generate") ;;
-    m | make-artifacts )             RUN+=("make-artifacts") ;;
     n | config-next )                BOULDER_CONFIG_DIR="test/config-next" ;;
     h | help )                       print_usage_exit ;;
     ??* )                            exit_msg "Illegal option --$OPT" ;;  # bad long option
@@ -284,12 +282,6 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   go install ./vendor/google.golang.org/grpc/codes
   run_and_expect_silence go generate ./...
   run_and_expect_silence git diff --exit-code .
-fi
-
-STAGE="make-artifacts"
-if [[ "${RUN[@]}" =~ "$STAGE" ]]; then
-  print_heading "Running Make Artifacts"
-  make deb rpm tar
 fi
 
 # Because set -e stops execution in the instance of a command or pipeline

--- a/test.sh
+++ b/test.sh
@@ -127,7 +127,7 @@ With no options passed, runs standard battery of tests (lint, unit, and integrat
 EOM
 )"
 
-while getopts lueciosvgmnhp:f:-: OPT; do
+while getopts lueciosvgnhp:f:-: OPT; do
   if [ "$OPT" = - ]; then     # long option: reformulate OPT and OPTARG
     OPT="${OPTARG%%=*}"       # extract long option name
     OPTARG="${OPTARG#$OPT}"   # extract long option argument (may be empty)

--- a/tools/make-assets.sh
+++ b/tools/make-assets.sh
@@ -38,5 +38,5 @@ export ARCHIVEDIR="${PWD}"
 # Set $VERSION to be a simulacrum of what is set in other build environments.
 export VERSION="${GO_VERSION}.$(date +%s)"
 
-# Build Boulder and produce a Debian Package at $PWD.
-make deb
+# Build Boulder and produce an RPM, a .deb, and a tar.gz file in $PWD.
+make rpm deb tar


### PR DESCRIPTION
The code path is now adequately tested in CI with try-release.yml. This means it will no longer be automatically tested locally with `./t.sh`, but it can be manually tested locally with `./tools/make-assets.sh`.

Also, to ensure CI has similar coverage to the old make-artifacts phase, change make-deb.sh to make-assets.sh, and have it make all of rpm, deb, and tar.

Change release.yml so it uploads the .tar.gz as well as the .deb.