### PR TITLE
ocsp-updater: Remove issuers from config

### DIFF
--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -22,13 +22,6 @@ type Config struct {
 		DB         cmd.DBConfig
 		ReadOnlyDB cmd.DBConfig
 
-		// Issuers is a map from filenames to short issuer IDs.
-		// Each filename must contain an issuer certificate. The short issuer
-		// IDs are arbitrarily assigned and must be consistent across OCSP
-		// components. For production we'll use the number part of the CN, i.e.
-		// E1 -> 1, R3 -> 3, etc.
-		Issuers map[string]int
-
 		// OldOCSPWindow controls how frequently ocsp-updater signs a batch
 		// of responses.
 		OldOCSPWindow cmd.ConfigDuration


### PR DESCRIPTION
All references to `Config.OCSPUpdater.Issuers` were removed in #6201.