### PR TITLE
Remove go1.19 from CI

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,8 +36,6 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.19.5_2023-02-15
-          - go1.19.6_2023-02-15
           - go1.20.1_2023-02-15
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.19.5"
-          - "1.19.6"
           - "1.20.1"
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.19.5"
-          - "1.19.6"
           - "1.20.1"
     runs-on: ubuntu-20.04
     steps:

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.19.5" "1.19.6" "1.20.1" )
+GO_CI_VERSIONS=( "1.20.1" )
 # These versions are built for both platforms that boulder devs use.
 # When updating GO_DEV_VERSIONS, please also update
 # ../../docker-compose.yml's default Go version.


### PR DESCRIPTION
Go 1.20.1 is now deployed everywhere. Removing go 1.19 from CI will allow us to begin adopting various go 1.20-only features that we want, such as the new crypto/ecdh package.