### PR TITLE
Remove MandatoryPOSTasGET flag

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -7,9 +7,8 @@ Presently, Boulder diverges from the RFC 8555 ACME spec in the following ways:
 
 ## [Section 6.3](https://tools.ietf.org/html/rfc8555#section-6.3)
 
-Boulder supports POST-as-GET but does not mandate it by default for requests
+Boulder supports POST-as-GET but does not mandate it for requests
 that simply fetch a resource (certificate, order, authorization, or challenge).
-Neither the Let's Encrypt's Staging nor Production environment mandate POST-as-GET.
 
 ## [Section 6.6](https://tools.ietf.org/html/rfc8555#section-6.6)
 

--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -9,8 +9,7 @@ Presently, Boulder diverges from the RFC 8555 ACME spec in the following ways:
 
 Boulder supports POST-as-GET but does not mandate it by default for requests
 that simply fetch a resource (certificate, order, authorization, or challenge).
-This behavior is configurable with a flag: Let's Encrypt's Staging environment
-does mandate POST-as-GET, while the Production environment does not.
+Neither the Let's Encrypt's Staging nor Production environment mandate POST-as-GET.
 
 ## [Section 6.6](https://tools.ietf.org/html/rfc8555#section-6.6)
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -14,20 +14,19 @@ func _() {
 	_ = x[CAAAccountURI-3]
 	_ = x[EnforceMultiVA-4]
 	_ = x[MultiVAFullResults-5]
-	_ = x[MandatoryPOSTAsGET-6]
-	_ = x[ECDSAForAll-7]
-	_ = x[ServeRenewalInfo-8]
-	_ = x[AllowUnrecognizedFeatures-9]
-	_ = x[ROCSPStage6-10]
-	_ = x[ROCSPStage7-11]
-	_ = x[ExpirationMailerUsesJoin-12]
-	_ = x[CertCheckerChecksValidations-13]
-	_ = x[CertCheckerRequiresValidations-14]
+	_ = x[ECDSAForAll-6]
+	_ = x[ServeRenewalInfo-7]
+	_ = x[AllowUnrecognizedFeatures-8]
+	_ = x[ROCSPStage6-9]
+	_ = x[ROCSPStage7-10]
+	_ = x[ExpirationMailerUsesJoin-11]
+	_ = x[CertCheckerChecksValidations-12]
+	_ = x[CertCheckerRequiresValidations-13]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsMandatoryPOSTAsGETECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidations"
+const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidations"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 105, 116, 132, 157, 168, 179, 203, 231, 261}
+var _FeatureFlag_index = [...]uint8{0, 6, 22, 42, 55, 69, 87, 98, 114, 139, 150, 161, 185, 213, 243}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -26,9 +26,6 @@ const (
 	// MultiVAFullResults will cause the main VA to wait for all of the remote VA
 	// results, not just the threshold required to make a decision.
 	MultiVAFullResults
-	// MandatoryPOSTAsGET forbids legacy unauthenticated GET requests for ACME
-	// resources.
-	MandatoryPOSTAsGET
 	// ECDSAForAll enables all accounts, regardless of their presence in the CA's
 	// ecdsaAllowedAccounts config value, to get issuance from ECDSA issuers.
 	ECDSAForAll
@@ -72,7 +69,6 @@ var features = map[FeatureFlag]bool{
 	CAAAccountURI:                  false,
 	EnforceMultiVA:                 false,
 	MultiVAFullResults:             false,
-	MandatoryPOSTAsGET:             false,
 	StoreRevokerInfo:               false,
 	ECDSAForAll:                    false,
 	ServeRenewalInfo:               false,

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -90,7 +90,6 @@
     "authorizationLifetimeDays": 30,
     "pendingAuthorizationLifetimeDays": 7,
     "features": {
-      "MandatoryPOSTAsGET": true,
       "ServeRenewalInfo": true
     }
   },

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1054,11 +1054,6 @@ func (wfe *WebFrontEndImpl) Challenge(
 		return
 	}
 
-	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost && !requiredStale(request, logEvent) {
-		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
-		return
-	}
-
 	if authz.Expires == nil || authz.Expires.Before(wfe.clk.Now()) {
 		wfe.sendError(response, logEvent, probs.NotFound("Expired authorization"), nil)
 		return
@@ -1454,12 +1449,6 @@ func (wfe *WebFrontEndImpl) Authorization(
 	logEvent *web.RequestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
-
-	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost && !requiredStale(request, logEvent) {
-		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
-		return
-	}
-
 	var requestAccount *core.Registration
 	var requestBody []byte
 	// If the request is a POST it is either:
@@ -1560,11 +1549,6 @@ func (wfe *WebFrontEndImpl) Authorization(
 // Certificate is used by clients to request a copy of their current certificate, or to
 // request a reissuance of the certificate.
 func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
-	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost && !requiredStale(request, logEvent) {
-		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
-		return
-	}
-
 	var requesterAccount *core.Registration
 	// Any POSTs to the Certificate endpoint should be POST-as-GET requests. There are
 	// no POSTs with a body allowed for this endpoint.
@@ -2065,11 +2049,6 @@ func (wfe *WebFrontEndImpl) NewOrder(
 
 // GetOrder is used to retrieve a existing order object
 func (wfe *WebFrontEndImpl) GetOrder(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
-	if features.Enabled(features.MandatoryPOSTAsGET) && request.Method != http.MethodPost && !requiredStale(request, logEvent) {
-		wfe.sendError(response, logEvent, probs.MethodNotAllowed(), nil)
-		return
-	}
-
 	var requesterAccount *core.Registration
 	// Any POSTs to the Order endpoint should be POST-as-GET requests. There are
 	// no POSTs with a body allowed for this endpoint.


### PR DESCRIPTION
Remove the `MandatoryPOSTasGET` flag from the WFE2.
Update the ACMEv2 divergence doc to note that neither staging nor production use MandatoryPOSTasGET.

Fixes #6582.