### PR TITLE
sa: quote sql_mode

### DIFF
--- a/sa/database.go
+++ b/sa/database.go
@@ -194,7 +194,7 @@ func adjustMySQLConfig(conf *mysql.Config) {
 		}
 	}
 
-	setDefault("sql_mode", "STRICT_ALL_TABLES")
+	setDefault("sql_mode", "'STRICT_ALL_TABLES'")
 
 	// If a read timeout is set, we set max_statement_time to 95% of that, and
 	// long_query_time to 80% of that. That way we get logs of queries that are

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -79,7 +79,7 @@ func TestDbSettings(t *testing.T) {
 
 func TestNewDbMap(t *testing.T) {
 	const mysqlConnectURL = "policy:password@tcp(boulder-mysql:3306)/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms"
-	const expected = "policy:password@tcp(boulder-mysql:3306)/boulder_policy_integration?clientFoundRows=true&parseTime=true&readTimeout=800ms&writeTimeout=800ms&long_query_time=0.6400000000000001&max_statement_time=0.76&sql_mode=STRICT_ALL_TABLES"
+	const expected = "policy:password@tcp(boulder-mysql:3306)/boulder_policy_integration?clientFoundRows=true&parseTime=true&readTimeout=800ms&writeTimeout=800ms&long_query_time=0.6400000000000001&max_statement_time=0.76&sql_mode=%27STRICT_ALL_TABLES%27"
 	oldSQLOpen := sqlOpen
 	defer func() {
 		sqlOpen = oldSQLOpen
@@ -160,13 +160,13 @@ func TestAdjustMySQLConfig(t *testing.T) {
 	conf := &mysql.Config{}
 	adjustMySQLConfig(conf)
 	test.AssertDeepEquals(t, conf.Params, map[string]string{
-		"sql_mode": "STRICT_ALL_TABLES",
+		"sql_mode": "'STRICT_ALL_TABLES'",
 	})
 
 	conf = &mysql.Config{ReadTimeout: 100 * time.Second}
 	adjustMySQLConfig(conf)
 	test.AssertDeepEquals(t, conf.Params, map[string]string{
-		"sql_mode":           "STRICT_ALL_TABLES",
+		"sql_mode":           "'STRICT_ALL_TABLES'",
 		"max_statement_time": "95",
 		"long_query_time":    "80",
 	})
@@ -179,7 +179,7 @@ func TestAdjustMySQLConfig(t *testing.T) {
 	}
 	adjustMySQLConfig(conf)
 	test.AssertDeepEquals(t, conf.Params, map[string]string{
-		"sql_mode":        "STRICT_ALL_TABLES",
+		"sql_mode":        "'STRICT_ALL_TABLES'",
 		"long_query_time": "80",
 	})
 
@@ -190,6 +190,6 @@ func TestAdjustMySQLConfig(t *testing.T) {
 	}
 	adjustMySQLConfig(conf)
 	test.AssertDeepEquals(t, conf.Params, map[string]string{
-		"sql_mode": "STRICT_ALL_TABLES",
+		"sql_mode": "'STRICT_ALL_TABLES'",
 	})
 }


### PR DESCRIPTION
When sql_mode is set as part of a multi-variable SET command (which happens in go-sql-driver/mysql 1.6.0+), ProxySQL can mis-parse parts of the SET command that come after it. For instance, if we run:

SET sql_mode=STRICT_ALL_TABLES,log_queries_not_using_indexes=ON;

Then ProxySQL would mis-parse that and pass along to its upstream:

SET sql_mode=STRICT_ALL_TABLES,log_queries_not_using_indexes;

Adding quotes around sql_mode (a string-valued variables) causes ProxySQL to parse this correctly.