### PR TITLE
Map boulder error RateLimited to gRPC codes.Unavailable

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -97,7 +97,7 @@ func (be *BoulderError) GRPCStatus() *status.Status {
 	case NotFound:
 		c = codes.NotFound
 	case RateLimit:
-		c = codes.ResourceExhausted
+		c = codes.Unavailable
 	case RejectedIdentifier:
 		c = codes.InvalidArgument
 	case InvalidEmail:

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -97,7 +97,7 @@ func (be *BoulderError) GRPCStatus() *status.Status {
 	case NotFound:
 		c = codes.NotFound
 	case RateLimit:
-		c = codes.Unavailable
+		c = codes.Unknown
 	case RejectedIdentifier:
 		c = codes.InvalidArgument
 	case InvalidEmail:


### PR DESCRIPTION
Map boulder error RateLimited from gRPC `codes.ResourceExhausted` to `codes.Unknown`.  The gRPC HTTP Status Mapping document [1] states:
> This table is to be used only for clients that received a response that did not include grpc-status. If grpc-status was provided, it must be used. Servers _must not_ use this table to determine an HTTP status code to use;

To follow their recommendation, we'll use the 'ol reliable `Unknown` and still have the meaningful RateLimited error visible at the API layer.

Fixes https://github.com/letsencrypt/boulder/issues/6682

1. https://github.com/grpc/grpc/blob/420180c6d7a5ad00870f099d2e2c79ad367fe9ee/doc/http-grpc-status-mapping.md