### PR TITLE
Remove ReuseValidAuthz code

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -469,7 +469,6 @@ func setup(t *testing.T) testCtx {
 		1,
 		goodkey.KeyPolicy{},
 		100,
-		true,
 		300*24*time.Hour,
 		7*24*time.Hour,
 		nil,

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -43,13 +43,6 @@ type Config struct {
 
 		MaxNames int
 
-		// Controls behaviour of the RA when asked to create a new authz for
-		// a name/regID that already has a valid authz. False preserves historic
-		// behaviour and ignores the existing authz and creates a new one. True
-		// instructs the RA to reuse the previously created authz in lieu of
-		// creating another.
-		ReuseValidAuthz bool
-
 		// AuthorizationLifetimeDays defines how long authorizations will be
 		// considered valid for. Given a value of 300 days when used with a 90-day
 		// cert lifetime, this allows creation of certs that will cover a whole
@@ -253,7 +246,6 @@ func main() {
 		c.RA.MaxContactsPerRegistration,
 		kp,
 		c.RA.MaxNames,
-		c.RA.ReuseValidAuthz,
 		authorizationLifetime,
 		pendingAuthorizationLifetime,
 		pubc,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2422,9 +2422,6 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	// authorizations correspond to
 	nameToExistingAuthz := make(map[string]*corepb.Authorization, len(newOrder.Names))
 	for _, v := range existingAuthz.Authz {
-		if v.Authz.Status == string(core.StatusValid) {
-			continue
-		}
 		nameToExistingAuthz[v.Domain] = v.Authz
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -95,7 +95,6 @@ type RegistrationAuthorityImpl struct {
 	rlPolicies                   ratelimit.Limits
 	maxContactsPerReg            int
 	maxNames                     int
-	reuseValidAuthz              bool
 	orderLifetime                time.Duration
 	finalizeTimeout              time.Duration
 	finalizeWG                   sync.WaitGroup
@@ -128,7 +127,6 @@ func NewRegistrationAuthorityImpl(
 	maxContactsPerReg int,
 	keyPolicy goodkey.KeyPolicy,
 	maxNames int,
-	reuseValidAuthz bool,
 	authorizationLifetime time.Duration,
 	pendingAuthorizationLifetime time.Duration,
 	pubc pubpb.PublisherClient,
@@ -248,28 +246,26 @@ func NewRegistrationAuthorityImpl(
 		maxContactsPerReg:            maxContactsPerReg,
 		keyPolicy:                    keyPolicy,
 		maxNames:                     maxNames,
-		// TODO(#2734): Remove reuseValidAuthz hardcoding.
-		reuseValidAuthz:             true,
-		publisher:                   pubc,
-		caa:                         caaClient,
-		orderLifetime:               orderLifetime,
-		finalizeTimeout:             finalizeTimeout,
-		ctpolicy:                    ctp,
-		ctpolicyResults:             ctpolicyResults,
-		purger:                      purger,
-		issuersByNameID:             issuersByNameID,
-		issuersByID:                 issuersByID,
-		namesPerCert:                namesPerCert,
-		rateLimitCounter:            rateLimitCounter,
-		newRegCounter:               newRegCounter,
-		reusedValidAuthzCounter:     reusedValidAuthzCounter,
-		recheckCAACounter:           recheckCAACounter,
-		newCertCounter:              newCertCounter,
-		revocationReasonCounter:     revocationReasonCounter,
-		recheckCAAUsedAuthzLifetime: recheckCAAUsedAuthzLifetime,
-		authzAges:                   authzAges,
-		orderAges:                   orderAges,
-		inflightFinalizes:           inflightFinalizes,
+		publisher:                    pubc,
+		caa:                          caaClient,
+		orderLifetime:                orderLifetime,
+		finalizeTimeout:              finalizeTimeout,
+		ctpolicy:                     ctp,
+		ctpolicyResults:              ctpolicyResults,
+		purger:                       purger,
+		issuersByNameID:              issuersByNameID,
+		issuersByID:                  issuersByID,
+		namesPerCert:                 namesPerCert,
+		rateLimitCounter:             rateLimitCounter,
+		newRegCounter:                newRegCounter,
+		reusedValidAuthzCounter:      reusedValidAuthzCounter,
+		recheckCAACounter:            recheckCAACounter,
+		newCertCounter:               newCertCounter,
+		revocationReasonCounter:      revocationReasonCounter,
+		recheckCAAUsedAuthzLifetime:  recheckCAAUsedAuthzLifetime,
+		authzAges:                    authzAges,
+		orderAges:                    orderAges,
+		inflightFinalizes:            inflightFinalizes,
 	}
 	return ra
 }
@@ -1734,12 +1730,12 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 		return nil, berrors.MalformedError("challenge type %q no longer allowed", ch.Type)
 	}
 
-	// When configured with `reuseValidAuthz` we can expect some clients to try
-	// and update a challenge for an authorization that is already valid. In this
-	// case we don't need to process the challenge update. It wouldn't be helpful,
-	// the overall authorization is already good! We increment a stat for this
-	// case and return early.
-	if ra.reuseValidAuthz && authz.Status == core.StatusValid {
+	// We expect some clients to try and update a challenge for an authorization
+	// that is already valid. In this case we don't need to process the
+	// challenge update. It wouldn't be helpful, the overall authorization is
+	// already good! We increment a stat for this reusing valid authz case and
+	// return early.
+	if authz.Status == core.StatusValid {
 		return req.Authz, nil
 	}
 
@@ -2427,9 +2423,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	// authorizations correspond to
 	nameToExistingAuthz := make(map[string]*corepb.Authorization, len(newOrder.Names))
 	for _, v := range existingAuthz.Authz {
-		// Don't reuse a valid authorization if the reuseValidAuthz flag is
-		// disabled.
-		if v.Authz.Status == string(core.StatusValid) && !ra.reuseValidAuthz {
+		if v.Authz.Status == string(core.StatusValid) {
 			continue
 		}
 		nameToExistingAuthz[v.Domain] = v.Authz

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1733,8 +1733,7 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 	// We expect some clients to try and update a challenge for an authorization
 	// that is already valid. In this case we don't need to process the
 	// challenge update. It wouldn't be helpful, the overall authorization is
-	// already good! We increment a stat for this reusing valid authz case and
-	// return early.
+	// already good! We return early for the valid authz reuse case.
 	if authz.Status == core.StatusValid {
 		return req.Authz, nil
 	}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -790,10 +790,11 @@ func TestPerformValidationAlreadyValid(t *testing.T) {
 
 	// A subsequent call to perform validation should return nil due
 	// to being short-circuited because of valid authz reuse.
-	_, err = ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
+	val, err := ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 		Authz:          authzPB,
 		ChallengeIndex: int64(ResponseIndex),
 	})
+	test.Assert(t, core.AcmeStatus(val.Status) == core.StatusValid, "Validation should have been valid")
 	test.AssertNotError(t, err, "Error was not nil, but should have been nil")
 }
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -361,20 +361,13 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 		},
 	}, nil, nil, 0, log, metrics.NoopRegisterer)
 
-<<<<<<< HEAD
 	ra := NewRegistrationAuthorityImpl(
 		fc, log, stats,
-		1, testKeyPolicy, 100, true,
+		1, testKeyPolicy, 100,
 		300*24*time.Hour, 7*24*time.Hour,
 		nil, noopCAA{},
 		0, 5*time.Minute,
 		ctp, nil, nil)
-=======
-	ra := NewRegistrationAuthorityImpl(fc,
-		log,
-		stats,
-		1, testKeyPolicy, 100, 300*24*time.Hour, 7*24*time.Hour, nil, noopCAA{}, 0, ctp, nil, nil)
->>>>>>> 433e15f43 (Remove ReuseValidAuthz flag code)
 	ra.SA = sa
 	ra.VA = va
 	ra.CA = ca

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2536,14 +2536,9 @@ func TestNewOrderExpiry(t *testing.T) {
 
 	// Create an order for that request
 	order, err := ra.NewOrder(ctx, orderReq)
-	fmt.Println(order)
-	fmt.Println(err)
 	// It shouldn't fail
 	test.AssertNotError(t, err, "Adding an order for regA failed")
-	fmt.Println(1)
-	fmt.Println(numAuthorizations(order))
 	test.AssertEquals(t, numAuthorizations(order), 1)
-	fmt.Println(2)
 	// It should be the fake near-expired-authz authz
 	test.AssertEquals(t, order.V2Authorizations[0], int64(1))
 	// The order's expiry should be the fake authz's expiry since it is sooner

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -788,14 +788,13 @@ func TestPerformValidationAlreadyValid(t *testing.T) {
 		Problems: nil,
 	}
 
-	// A subsequent call to perform validation should return the expected error
-	whatisit, err := ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
+	// A subsequent call to perform validation should return nil due
+	// to being short-circuited because of valid authz reuse.
+	_, err = ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 		Authz:          authzPB,
 		ChallengeIndex: int64(ResponseIndex),
 	})
-	fmt.Println(whatisit)
-	fmt.Println(err)
-	test.AssertErrorIs(t, err, berrors.Malformed)
+	test.AssertNotError(t, err, "Error was not nil, but should have been nil")
 }
 
 func TestPerformValidationSuccess(t *testing.T) {
@@ -2536,9 +2535,14 @@ func TestNewOrderExpiry(t *testing.T) {
 
 	// Create an order for that request
 	order, err := ra.NewOrder(ctx, orderReq)
+	fmt.Println(order)
+	fmt.Println(err)
 	// It shouldn't fail
 	test.AssertNotError(t, err, "Adding an order for regA failed")
+	fmt.Println(1)
+	fmt.Println(numAuthorizations(order))
 	test.AssertEquals(t, numAuthorizations(order), 1)
+	fmt.Println(2)
 	// It should be the fake near-expired-authz authz
 	test.AssertEquals(t, order.V2Authorizations[0], int64(1))
 	// The order's expiry should be the fake authz's expiry since it is sooner

--- a/test.sh
+++ b/test.sh
@@ -86,7 +86,8 @@ function run_unit_tests() {
     # spuriously because one test is modifying a table (especially
     # registrations) while another test is reading it.
     # https://github.com/letsencrypt/boulder/issues/1499
-    go test -v -count=1 "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
+    #go test -v "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
+    go test "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
   fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -86,7 +86,7 @@ function run_unit_tests() {
     # spuriously because one test is modifying a table (especially
     # registrations) while another test is reading it.
     # https://github.com/letsencrypt/boulder/issues/1499
-    go test "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
+    go test -v -count=1 "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
   fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -86,7 +86,6 @@ function run_unit_tests() {
     # spuriously because one test is modifying a table (especially
     # registrations) while another test is reading it.
     # https://github.com/letsencrypt/boulder/issues/1499
-    #go test -v "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
     go test "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
   fi
 }

--- a/test/asserts.go
+++ b/test/asserts.go
@@ -93,6 +93,11 @@ func AssertErrorWraps(t *testing.T, err error, target interface{}) {
 // AssertErrorIs checks that err wraps the given error
 func AssertErrorIs(t *testing.T, err error, target error) {
 	t.Helper()
+
+	if err == nil {
+		t.Fatal("err was unexpectedly nil and should not have been")
+	}
+
 	if !errors.Is(err, target) {
 		t.Fatalf("error does not wrap expected error: %q !> %q", err.Error(), target.Error())
 	}

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -5,7 +5,6 @@
     "debugAddr": ":8002",
     "hostnamePolicyFile": "test/hostname-policy.yaml",
     "maxNames": 100,
-    "reuseValidAuthz": true,
     "authorizationLifetimeDays": 30,
     "pendingAuthorizationLifetimeDays": 7,
     "goodkey": {


### PR DESCRIPTION
Removes all code related to the `ReuseValidAuthz` feature flag. The Boulder default is to now always reuse valid authorizations.

Fixes a panic in `test.AssertErrorIs` when `err` is unexpectedly `nil` that was found this while reworking the `TestPerformValidationAlreadyValid` test. The go stdlib `func Is`[1] does not check for this.

1. https://go.dev/src/errors/wrap.go

Part 2/2, fixes https://github.com/letsencrypt/boulder/issues/2734