### PR TITLE
wfe: fix comment about RA checking revocation

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -944,9 +944,8 @@ func (wfe *WebFrontEndImpl) revokeCertByCertKey(
 		Method: "privkey",
 	})
 
-	// The RA will confirm that the authenticated account either originally
-	// issued the certificate, or has demonstrated control over all identifiers
-	// in the certificate.
+	// The RA assumes here that the WFE2 has validated the JWS as proving
+	// control of the private key corresponding to this certificate.
 	_, err := wfe.ra.RevokeCertByKey(ctx, &rapb.RevokeCertByKeyRequest{
 		Cert: cert.Raw,
 	})


### PR DESCRIPTION
This was introduced as a copy-paste error in #5983:

https://github.com/letsencrypt/boulder/pull/5983/files#diff-3f950e720c205ce9fa8dea12c6fd7fd44272c2671f19d0e06962abfbea00d491R919-R921

vs

https://github.com/letsencrypt/boulder/pull/5983/files#diff-3f950e720c205ce9fa8dea12c6fd7fd44272c2671f19d0e06962abfbea00d491R866-R868