### PR TITLE
admin-revoker: document malformed-revoke

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -49,7 +49,7 @@ descriptions:
   malformed-revoke       Revoke a single certificate by the hex serial number. Works even
                          if the certificate cannot be parsed from the database.
                          Note: This does not purge the Akamai cache.
-												 Note: This cannot be used to revoke for key compromise.
+			 Note: This cannot be used to revoke for key compromise.
   batched-serial-revoke  Revoke all certificates contained in a file of hex serial numbers.
   incident-table-revoke  Revoke all certificates in the provided incident table.
   reg-revoke             Revoke all certificates associated with a registration ID.

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -49,6 +49,7 @@ descriptions:
   malformed-revoke       Revoke a single certificate by the hex serial number. Works even
                          if the certificate cannot be parsed from the database.
                          Note: This does not purge the Akamai cache.
+												 Note: This cannot be used to revoke for key compromise.
   batched-serial-revoke  Revoke all certificates contained in a file of hex serial numbers.
   incident-table-revoke  Revoke all certificates in the provided incident table.
   reg-revoke             Revoke all certificates associated with a registration ID.

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -44,18 +44,21 @@ usage:
 
 
 descriptions:
-  list-reasons           List all revocation reason codes
-  serial-revoke          Revoke a single certificate by the hex serial number
-  batched-serial-revoke  Revokes all certificates contained in a file of hex serial numbers
-  incident-table-revoke  Revokes all certificates in the provided incident table
-  reg-revoke             Revoke all certificates associated with a registration ID
+  list-reasons           List all revocation reason codes.
+  serial-revoke          Revoke a single certificate by the hex serial number.
+  malformed-revoke       Revoke a single certificate by the hex serial number. Works even
+                         if the certificate cannot be parsed from the database.
+                         Note: This does not purge the Akamai cache.
+  batched-serial-revoke  Revoke all certificates contained in a file of hex serial numbers.
+  incident-table-revoke  Revoke all certificates in the provided incident table.
+  reg-revoke             Revoke all certificates associated with a registration ID.
   private-key-block      Adds the SPKI hash, derived from the provided private key, to the
                          blocked keys table. <priv-key-path> is expected to be the path
-                         to a PEM formatted file containing an RSA or ECDSA private key
-  private-key-revoke     Revokes all certificates matching the SPKI hash derived from the
+                         to a PEM formatted file containing an RSA or ECDSA private key.
+  private-key-revoke     Revoke all certificates matching the SPKI hash derived from the
                          provided private key. Then adds the hash to the blocked keys
                          table. <priv-key-path> is expected to be the path to a PEM
-                         formatted file containing an RSA or ECDSA private key
+                         formatted file containing an RSA or ECDSA private key.
 
 flags:
   all:
@@ -138,6 +141,7 @@ func (r *revoker) revokeCertificate(ctx context.Context, certObj core.Certificat
 		}
 		req = &rapb.AdministrativelyRevokeCertificateRequest{
 			Cert:         cert.Raw,
+			Serial:       core.SerialToString(cert.SerialNumber),
 			Code:         int64(reasonCode),
 			AdminName:    u.Username,
 			SkipBlockKey: skipBlockKey,

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -262,6 +262,7 @@ func (bkr *badKeyRevoker) revokeCerts(revokerEmails []string, emailToCerts map[s
 			}
 			_, err := bkr.raClient.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
 				Cert:      cert.DER,
+				Serial:    cert.Serial,
 				Code:      int64(ocsp.KeyCompromise),
 				AdminName: "bad-key-revoker",
 			})

--- a/ra/proto/ra.pb.go
+++ b/ra/proto/ra.pb.go
@@ -358,7 +358,12 @@ type AdministrativelyRevokeCertificateRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Cert         []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	// The `cert` field may be omitted. If it is omitted,
+	// the revocation reason (`code`) must not be keyCompromise,
+	// and purging the Akamai cache will not happen because the
+	// base URL for the certificate's OCSP server is not known.
+	Cert []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	// The `serial` field is required.
 	Serial       string `protobuf:"bytes,4,opt,name=serial,proto3" json:"serial,omitempty"`
 	Code         int64  `protobuf:"varint,2,opt,name=code,proto3" json:"code,omitempty"`
 	AdminName    string `protobuf:"bytes,3,opt,name=adminName,proto3" json:"adminName,omitempty"`

--- a/ra/proto/ra.proto
+++ b/ra/proto/ra.proto
@@ -54,7 +54,12 @@ message RevokeCertByKeyRequest {
 }
 
 message AdministrativelyRevokeCertificateRequest {
+  // The `cert` field may be omitted. If it is omitted,
+  // the revocation reason (`code`) must not be keyCompromise,
+  // and purging the Akamai cache will not happen because the
+  // base URL for the certificate's OCSP server is not known.
   bytes cert = 1;
+  // The `serial` field is required.
   string serial = 4;
   int64 code = 2;
   string adminName = 3;

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2106,7 +2106,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	if req == nil || req.AdminName == "" {
 		return nil, errIncompleteGRPCRequest
 	}
-	if req.Cert == nil && req.Serial == "" {
+	if req.Serial == "" {
 		return nil, errIncompleteGRPCRequest
 	}
 
@@ -2122,8 +2122,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 		return nil, fmt.Errorf("cannot revoke for reason %d", reasonCode)
 	}
 
-	// If we don't have a real cert, we create a fake cert (containing just the
-	// serial number, which is all we need) and look up the IssuerID from the db.
+	// If we weren't passed a cert in the request, find IssuerID from the db.
 	// We could instead look up and parse the certificate itself, but we avoid
 	// that in case we are administratively revoking the certificate because it is
 	// so badly malformed that it can't be parsed.
@@ -2131,18 +2130,9 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	var issuerID int64 // TODO(#5152) make this an issuance.IssuerNameID
 	var err error
 	if req.Cert == nil {
-		serial, err := core.StringToSerial(req.Serial)
-		if err != nil {
-			return nil, err
-		}
-
-		cert = &x509.Certificate{
-			SerialNumber: serial,
-		}
-
 		status, err := ra.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: req.Serial})
 		if err != nil {
-			return nil, fmt.Errorf("unable to confirm that serial %q was ever issued: %w", serial, err)
+			return nil, fmt.Errorf("unable to confirm that serial %q was ever issued: %w", req.Serial, err)
 		}
 		issuerID = status.IssuerID
 	} else {
@@ -2157,7 +2147,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 		ID:           core.NewToken(),
 		Method:       "key",
 		AdminName:    req.AdminName,
-		SerialNumber: core.SerialToString(cert.SerialNumber),
+		SerialNumber: req.Serial,
 	}
 
 	// Below this point, do not re-declare `err` (i.e. type `err :=`) in a
@@ -2170,10 +2160,16 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 		ra.log.AuditObject("Revocation request:", logEvent)
 	}()
 
-	err = ra.revokeCertificate(ctx, cert.SerialNumber, issuerID, revocation.Reason(req.Code))
+	var serialInt *big.Int
+	serialInt, err = core.StringToSerial(req.Serial)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ra.revokeCertificate(ctx, serialInt, issuerID, revocation.Reason(req.Code))
 	if err != nil {
 		if req.Code == ocsp.KeyCompromise && errors.Is(err, berrors.AlreadyRevoked) {
-			err = ra.updateRevocationForKeyCompromise(ctx, cert.SerialNumber, issuerID)
+			err = ra.updateRevocationForKeyCompromise(ctx, serialInt, issuerID)
 			if err != nil {
 				return nil, err
 			}
@@ -2182,6 +2178,9 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	}
 
 	if req.Code == ocsp.KeyCompromise && !req.SkipBlockKey {
+		if cert == nil {
+			return nil, errors.New("revoking for key compromise requires providing the certificate's DER")
+		}
 		var digest core.Sha256Digest
 		digest, err = core.KeyDigest(cert.PublicKey)
 		if err != nil {
@@ -2198,9 +2197,11 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 		}
 	}
 
-	err = ra.purgeOCSPCache(ctx, cert, issuerID)
-	if err != nil {
-		return nil, err
+	if cert != nil {
+		err = ra.purgeOCSPCache(ctx, cert, issuerID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &emptypb.Empty{}, nil

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3900,7 +3900,10 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	digest, err := core.KeyDigest(k.Public())
 	test.AssertNotError(t, err, "core.KeyDigest failed")
 
-	template := x509.Certificate{SerialNumber: big.NewInt(257)}
+	serial := "04eac294a0e61035d8254d5a04f61a37c802"
+	serialInt, err := core.StringToSerial(serial)
+	test.AssertNotError(t, err, "decoding serial number")
+	template := x509.Certificate{SerialNumber: serialInt}
 	der, err := x509.CreateCertificate(rand.Reader, &template, &template, k.Public(), k)
 	test.AssertNotError(t, err, "x509.CreateCertificate failed")
 	cert, err := x509.ParseCertificate(der)
@@ -3938,6 +3941,7 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	// Revoking without an admin name should fail immediately.
 	_, err = ra.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
 		Cert:      cert.Raw,
+		Serial:    serial,
 		Code:      ocsp.KeyCompromise,
 		AdminName: "",
 	})
@@ -3946,6 +3950,7 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	// Revoking for a forbidden reason should fail immediately.
 	_, err = ra.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
 		Cert:      cert.Raw,
+		Serial:    serial,
 		Code:      ocsp.CertificateHold,
 		AdminName: "root",
 	})
@@ -3954,6 +3959,7 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	// Revoking a cert for an unspecified reason should work but not block the key.
 	_, err = ra.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
 		Cert:      cert.Raw,
+		Serial:    serial,
 		Code:      ocsp.Unspecified,
 		AdminName: "root",
 	})
@@ -3978,6 +3984,7 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	mockSA.revoked = make(map[string]int64)
 	_, err = ra.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
 		Cert:      cert.Raw,
+		Serial:    serial,
 		Code:      ocsp.KeyCompromise,
 		AdminName: "root",
 	})


### PR DESCRIPTION
In particular, document that it does not purge the Akamai cache.

Also, in the RA, avoid creating a "fake" certificate object containing only the serial. Instead, use `req.Serial` directly in most places. This uncovered some incorrect logic. Fix that logic by gating the operations that actually need a full *x509.Certificate: revoking by key, and purging the Akamai cache.

Also, make `req.Serial` mandatory for AdministrativelyRevokeCertificate.