### PR TITLE
Use time format constants

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1003,7 +1003,7 @@ func TestOrphanQueue(t *testing.T) {
 
 	qsa := &queueSA{fail: true}
 	testCtx := setup(t)
-	fakeNow, err := time.Parse("Mon Jan 2 15:04:05 2006", "Mon Jan 2 15:04:05 2006")
+	fakeNow, err := time.Parse(time.ANSIC, "Mon Jan 2 15:04:05 2006")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -99,7 +99,7 @@ func TestRevokeIncidentTableSerials(t *testing.T) {
 			core.SerialToString(entries[0].serial),
 			entries[0].regId,
 			42,
-			testCtx.revoker.clk.Now().Add(-time.Hour*24*7).Format("2006-01-02 15:04:05"),
+			testCtx.revoker.clk.Now().Add(-time.Hour*24*7).Format(time.DateTime),
 		),
 	)
 	test.AssertNotError(t, err, "while inserting row into incident table")

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -284,12 +284,12 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 			return nil, fmt.Errorf("unsupported signature algorithm %q", profile.SignatureAlgorithm)
 		}
 		cert.SignatureAlgorithm = sigAlg
-		notBefore, err := time.Parse(configDateLayout, profile.NotBefore)
+		notBefore, err := time.Parse(time.DateTime, profile.NotBefore)
 		if err != nil {
 			return nil, err
 		}
 		cert.NotBefore = notBefore
-		notAfter, err := time.Parse(configDateLayout, profile.NotAfter)
+		notAfter, err := time.Parse(time.DateTime, profile.NotAfter)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -22,8 +22,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const configDateLayout = "2006-01-02 15:04:05"
-
 type keyGenConfig struct {
 	Type         string `yaml:"type"`
 	RSAModLength uint   `yaml:"rsa-mod-length"`
@@ -662,11 +660,11 @@ func ocspRespCeremony(configBytes []byte) error {
 		}
 	}
 
-	thisUpdate, err := time.Parse(configDateLayout, config.OCSPProfile.ThisUpdate)
+	thisUpdate, err := time.Parse(time.DateTime, config.OCSPProfile.ThisUpdate)
 	if err != nil {
 		return fmt.Errorf("unable to parse ocsp-profile.this-update: %s", err)
 	}
-	nextUpdate, err := time.Parse(configDateLayout, config.OCSPProfile.NextUpdate)
+	nextUpdate, err := time.Parse(time.DateTime, config.OCSPProfile.NextUpdate)
 	if err != nil {
 		return fmt.Errorf("unable to parse ocsp-profile.next-update: %s", err)
 	}
@@ -714,11 +712,11 @@ func crlCeremony(configBytes []byte) error {
 		return err
 	}
 
-	thisUpdate, err := time.Parse(configDateLayout, config.CRLProfile.ThisUpdate)
+	thisUpdate, err := time.Parse(time.DateTime, config.CRLProfile.ThisUpdate)
 	if err != nil {
 		return fmt.Errorf("unable to parse crl-profile.this-update: %s", err)
 	}
-	nextUpdate, err := time.Parse(configDateLayout, config.CRLProfile.NextUpdate)
+	nextUpdate, err := time.Parse(time.DateTime, config.CRLProfile.NextUpdate)
 	if err != nil {
 		return fmt.Errorf("unable to parse crl-profile.next-update: %s", err)
 	}
@@ -729,7 +727,7 @@ func crlCeremony(configBytes []byte) error {
 		if err != nil {
 			return fmt.Errorf("failed to load revoked certificate %q: %s", rc.CertificatePath, err)
 		}
-		revokedAt, err := time.Parse(configDateLayout, rc.RevocationDate)
+		revokedAt, err := time.Parse(time.DateTime, rc.RevocationDate)
 		if err != nil {
 			return fmt.Errorf("unable to parse crl-profile.revoked-certificates.revocation-date")
 		}

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -504,7 +504,7 @@ func (m *mailer) findExpiringCertificates(ctx context.Context) error {
 		m.stats.nagsAtCapacity.With(prometheus.Labels{"nag_group": expiresIn.String()}).Set(atCapacity)
 
 		m.log.Infof("Found %d certificates expiring between %s and %s", len(certs),
-			left.Format("2006-01-02 03:04"), right.Format("2006-01-02 03:04"))
+			left.Format(time.DateTime), right.Format(time.DateTime))
 
 		if len(certs) == 0 {
 			continue // nothing to do

--- a/cmd/id-exporter/main_test.go
+++ b/cmd/id-exporter/main_test.go
@@ -334,7 +334,7 @@ func (tc testCtx) addCertificates(t *testing.T) {
 		Primes:    []*big.Int{p, q},
 	}
 
-	fc := newFakeClock(t)
+	fc := clock.NewFake()
 
 	// Add one cert for RegA that expires in 30 days
 	rawCertA := x509.Certificate{
@@ -439,6 +439,7 @@ func (tc testCtx) addCertificates(t *testing.T) {
 
 func setup(t *testing.T) testCtx {
 	log := blog.UseMock()
+	fc := clock.NewFake()
 
 	// Using DBConnSAFullPerms to be able to insert registrations and certificates
 	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
@@ -447,7 +448,6 @@ func setup(t *testing.T) testCtx {
 	}
 	cleanUp := test.ResetBoulderTestDatabase(t)
 
-	fc := newFakeClock(t)
 	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, fc, log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)
@@ -473,15 +473,4 @@ func bigIntFromB64(b64 string) *big.Int {
 
 func intFromB64(b64 string) int {
 	return int(bigIntFromB64(b64).Int64())
-}
-
-func newFakeClock(t *testing.T) clock.FakeClock {
-	const fakeTimeFormat = "2006-01-02T15:04:05.999999999Z"
-	ft, err := time.Parse(fakeTimeFormat, fakeTimeFormat)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fc := clock.NewFake()
-	fc.Set(ft.UTC())
-	return fc
 }

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2647,7 +2647,7 @@ func TestIncidentsForSerial(t *testing.T) {
 			affectedCertA.Serial,
 			affectedCertA.RegistrationID,
 			affectedCertA.OrderID,
-			affectedCertA.LastNoticeSent.Format("2006-01-02 15:04:05"),
+			affectedCertA.LastNoticeSent.Format(time.DateTime),
 		),
 	)
 	test.AssertNotError(t, err, "Error while inserting row for '1338' into incident table")
@@ -2670,7 +2670,7 @@ func TestIncidentsForSerial(t *testing.T) {
 			affectedCertB.Serial,
 			affectedCertB.RegistrationID,
 			affectedCertB.OrderID,
-			affectedCertB.LastNoticeSent.Format("2006-01-02 15:04:05"),
+			affectedCertB.LastNoticeSent.Format(time.DateTime),
 		),
 	)
 	test.AssertNotError(t, err, "Error while inserting row for '1337' into incident table")
@@ -2777,7 +2777,7 @@ func TestSerialsForIncident(t *testing.T) {
 				i,
 				randInt(),
 				randInt(),
-				sa.clk.Now().Add(time.Hour*24*7).Format("2006-01-02 15:04:05"),
+				sa.clk.Now().Add(time.Hour*24*7).Format(time.DateTime),
 			),
 		)
 		test.AssertNotError(t, err, fmt.Sprintf("Error while inserting row for '%s' into incident table", i))

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -415,7 +415,7 @@ func (s *State) Run(
 			curReqTotal := atomic.LoadInt64(&s.reqTotal)
 			fmt.Printf(
 				"%s Action rate: %d/s [expected: %d/s], Request rate: %d/s, Responses: [%s]\n",
-				time.Now().Format("2006-01-02 15:04:05"),
+				time.Now().Format(time.DateTime),
 				curTotal-lastTotal,
 				atomic.LoadInt64(&p.Rate),
 				curReqTotal-lastReqTotal,


### PR DESCRIPTION
Use constants from the go stdlib time package, such as time.DateTime and time.RFC3339, when parsing and formatting timestamps. Additionally, simplify or remove some of our uses of parsing timestamps, such as to set fake clocks in tests.