### PR TITLE
VA: Remove unused field CAADistributedResolver

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -22,14 +22,6 @@ type Config struct {
 
 		IssuerDomain string
 
-		// CAADistributedResolverConfig specifies the HTTP client setup and interfaces
-		// needed to resolve CAA addresses over multiple paths
-		CAADistributedResolver struct {
-			Timeout     cmd.ConfigDuration
-			MaxFailures int
-			Proxies     []string
-		}
-
 		// The number of times to try a DNS query (that has a temporary error)
 		// before giving up. May be short-circuited by deadlines. A zero value
 		// will be turned into 1.


### PR DESCRIPTION
This field doesn't appear to be in use.

Part of #6052