### PR TITLE
VA/config: Remove unused va.CAA service in config

### DIFF
--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -21,9 +21,6 @@
             "va.boulder"
           ]
         },
-        "va.CAA": {
-          "clientNames": []
-        },
         "grpc.health.v1.Health": {
           "clientNames": [
             "health-checker.boulder"

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -21,9 +21,6 @@
             "va.boulder"
           ]
         },
-        "va.CAA": {
-          "clientNames": []
-        },
         "grpc.health.v1.Health": {
           "clientNames": [
             "health-checker.boulder"


### PR DESCRIPTION
GRPC config from `va.VA` is used for both `va.VA` and `va.CAA`.