### PR TITLE
Remove unnecessary cmd.ServiceConfig embeds

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -31,7 +31,7 @@ import (
 
 type Config struct {
 	WFE struct {
-		cmd.ServiceConfig
+		DebugAddr        string
 		ListenAddress    string
 		TLSListenAddress string
 

--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -20,7 +20,10 @@ import (
 
 type Config struct {
 	CRLUpdater struct {
-		cmd.ServiceConfig
+		DebugAddr string
+
+		// TLS client certificate, private key, and trusted root bundle.
+		TLS cmd.TLSConfig
 
 		SAService           *cmd.GRPCClientConfig
 		CRLGeneratorService *cmd.GRPCClientConfig

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -640,8 +640,8 @@ func (ds durationSlice) Swap(a, b int) {
 
 type Config struct {
 	Mailer struct {
-		cmd.ServiceConfig
-		DB cmd.DBConfig
+		DebugAddr string
+		DB        cmd.DBConfig
 		cmd.SMTPConfig
 
 		// From is the "From" address for reminder messages.

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -32,8 +32,8 @@ import (
 
 type Config struct {
 	OCSPResponder struct {
-		cmd.ServiceConfig
-		DB cmd.DBConfig
+		DebugAddr string
+		DB        cmd.DBConfig
 
 		// Source indicates the source of pre-signed OCSP responses to be used. It
 		// can be a DBConnect string or a file URL. The file URL style is used

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -18,7 +18,10 @@ import (
 
 type Config struct {
 	OCSPUpdater struct {
-		cmd.ServiceConfig
+		DebugAddr string
+
+		// TLS client certificate, private key, and trusted root bundle.
+		TLS        cmd.TLSConfig
 		DB         cmd.DBConfig
 		ReadOnlyDB cmd.DBConfig
 


### PR DESCRIPTION
Replace the cmd.ServiceConfig embed with just its components (i.e. DebugAddr and sometimes TLS) in the WFE, crl-updater, ocsp-updater, ocsp-responder, and expiration-mailer. These services are not gRPC services, and therefore do not need the full suite of config keys introduced by cmd.ServiceConfig.

Blocks #6674
Part of #6052