### PR TITLE
Add Retry-After to "processing" Order responses

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -438,6 +438,11 @@ func (sa *StorageAuthorityReadOnly) GetOrder(_ context.Context, req *sapb.OrderR
 		validOrder.Created = sa.clk.Now().AddDate(0, 0, 1).Unix()
 	}
 
+	// Order 10 is processing
+	if req.Id == 10 {
+		validOrder.Status = string(core.StatusProcessing)
+	}
+
 	return validOrder, nil
 }
 


### PR DESCRIPTION
[RFC 8555 section 7.4](https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4) states regarding Orders in the "processing" state:

> "processing": The certificate is being issued. Send a POST-as-GET
> request after the time given in the Retry-After header field of
> the response, if any.

Add a Retry-After header when serving Order objects that are in the "processing" state. This may help control clients which implement Order polling but without any built-in backoff. The retry interval is hard-coded to be 3s, slightly above our current 99th percentile Finalize latency.