### PR TITLE
Initialize a stdout/stderr logger for the generate tool

### DIFF
--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -73,8 +73,7 @@ func genCert(path string) error {
 }
 
 func main() {
-	logger := cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 6, SyslogLevel: -1})
-	logger.Info("Logging to stdout/stderr only, not syslog.")
+	_ = cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 6, SyslogLevel: -1})
 
 	// If one of the output files already exists, assume this ran once
 	// already for the container and don't re-run.
@@ -83,9 +82,9 @@ func main() {
 		fmt.Println("skipping certificate generation: already exists")
 		return
 	} else if err == nil && !loc.Mode().IsRegular() {
-		logger.Errf("statting %q: not a regular file", outputFile)
+		cmd.Fail(fmt.Sprintf("statting %q: not a regular file", outputFile))
 	} else if err != nil && !os.IsNotExist(err) {
-		logger.Errf("statting %q: %s", outputFile, err)
+		cmd.Fail(fmt.Sprintf("statting %q: %s", outputFile, err))
 	}
 	// Create SoftHSM slots for the root signing keys
 	rsaRootKeySlot, err := createSlot("root signing key (rsa)")

--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/letsencrypt/boulder/cmd"
+	blog "github.com/letsencrypt/boulder/log"
 )
 
 // createSlot initializes a SoftHSM slot and token. SoftHSM chooses the highest empty
@@ -73,7 +74,7 @@ func genCert(path string) error {
 }
 
 func main() {
-	_ = cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 6, SyslogLevel: -1})
+	blog.Set(blog.StdoutLogger(6))
 
 	// If one of the output files already exists, assume this ran once
 	// already for the container and don't re-run.

--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -1,9 +1,9 @@
+// generate.go is a helper utility for integration tests.
 package main
 
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -73,6 +73,9 @@ func genCert(path string) error {
 }
 
 func main() {
+	logger := cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 6, SyslogLevel: -1})
+	logger.Info("Logging to stdout/stderr only, not syslog.")
+
 	// If one of the output files already exists, assume this ran once
 	// already for the container and don't re-run.
 	outputFile := "/hierarchy/root-signing-pub-rsa.pem"
@@ -80,9 +83,9 @@ func main() {
 		fmt.Println("skipping certificate generation: already exists")
 		return
 	} else if err == nil && !loc.Mode().IsRegular() {
-		log.Fatalf("statting %q: not a regular file", outputFile)
+		logger.Errf("statting %q: not a regular file", outputFile)
 	} else if err != nil && !os.IsNotExist(err) {
-		log.Fatalf("statting %q: %s", outputFile, err)
+		logger.Errf("statting %q: %s", outputFile, err)
 	}
 	// Create SoftHSM slots for the root signing keys
 	rsaRootKeySlot, err := createSlot("root signing key (rsa)")


### PR DESCRIPTION
Return errors to user in the cert-ceremony generate tool rather than throwing a panic if syslog facilities are unavailable. Defaults the tool to only using stdout/stderr.

Fixes #6653 