### PR TITLE
Move cmd.ConfigDuration to config.Duration

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
@@ -194,8 +194,8 @@ func setup(t *testing.T) *testCtx {
 				Policies: []issuance.PolicyInformation{
 					{OID: "2.23.140.1.2.1"},
 				},
-				MaxValidityPeriod:   cmd.ConfigDuration{Duration: time.Hour * 8760},
-				MaxValidityBackdate: cmd.ConfigDuration{Duration: time.Hour},
+				MaxValidityPeriod:   config.Duration{Duration: time.Hour * 8760},
+				MaxValidityBackdate: config.Duration{Duration: time.Hour},
 			},
 			issuance.IssuerConfig{
 				UseForECDSALeaves: ecdsa,

--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/letsencrypt/boulder/akamai"
 	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
 )
@@ -72,7 +73,7 @@ type Throughput struct {
 	// PurgeBatchInterval is the duration waited between dispatching an Akamai
 	// purge request containing 'QueueEntriesPerBatch' * 3 URLs. If this value
 	// isn't provided it will default to 'defaultPurgeBatchInterval'.
-	PurgeBatchInterval cmd.ConfigDuration
+	PurgeBatchInterval config.Duration
 }
 
 func (t *Throughput) useOptimizedDefaults() {
@@ -144,7 +145,7 @@ type Config struct {
 		// PurgeRetryBackoff is the base duration that will be waited before
 		// attempting to purge a batch of URLs which previously failed to be
 		// purged.
-		PurgeRetryBackoff cmd.ConfigDuration
+		PurgeRetryBackoff config.Duration
 	}
 	Syslog  cmd.SyslogConfig
 	Beeline cmd.BeelineConfig

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -14,7 +14,13 @@ import (
 
 	"github.com/honeycombio/beeline-go"
 	"github.com/jmhodges/clock"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/crypto/ocsp"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/db"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
@@ -22,10 +28,6 @@ import (
 	"github.com/letsencrypt/boulder/mail"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/sa"
-	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/crypto/ocsp"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const blockedKeysGaugeLimit = 1000
@@ -402,12 +404,12 @@ type Config struct {
 		// Interval specifies the minimum duration bad-key-revoker
 		// should sleep between attempting to find blockedKeys rows to
 		// process when there is an error or no work to do.
-		Interval cmd.ConfigDuration
+		Interval config.Duration
 
 		// BackoffIntervalMax specifies a maximum duration the backoff
 		// algorithm will wait before retrying in the event of error
 		// or no work to do.
-		BackoffIntervalMax cmd.ConfigDuration
+		BackoffIntervalMax config.Duration
 
 		Mailer struct {
 			cmd.SMTPConfig

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/letsencrypt/boulder/ca"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
@@ -44,10 +45,10 @@ type Config struct {
 		}
 
 		// How long issued certificates are valid for.
-		Expiry cmd.ConfigDuration
+		Expiry config.Duration
 
 		// How far back certificates should be backdated.
-		Backdate cmd.ConfigDuration
+		Backdate config.Duration
 
 		// What digits we should prepend to serials after randomly generating them.
 		SerialPrefix int
@@ -58,12 +59,12 @@ type Config struct {
 		// LifespanOCSP is how long OCSP responses are valid for. It should be
 		// longer than the minTimeToExpiry field for the OCSP Updater. Per the BRs,
 		// Section 4.9.10, it MUST NOT be more than 10 days.
-		LifespanOCSP cmd.ConfigDuration
+		LifespanOCSP config.Duration
 
 		// LifespanCRL is how long CRLs are valid for. It should be longer than the
 		// `period` field of the CRL Updater. Per the BRs, Section 4.9.7, it MUST
 		// NOT be more than 10 days.
-		LifespanCRL cmd.ConfigDuration
+		LifespanCRL config.Duration
 
 		// GoodKey is an embedded config stanza for the goodkey library.
 		GoodKey goodkey.Config
@@ -84,7 +85,7 @@ type Config struct {
 		// means logging more often than necessary, which is inefficient in terms
 		// of bytes and log system resources.
 		// Recommended to be around 500ms.
-		OCSPLogPeriod cmd.ConfigDuration
+		OCSPLogPeriod config.Duration
 
 		// Path of a YAML file containing the list of int64 RegIDs
 		// allowed to request ECDSA issuance

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/honeycombio/beeline-go"
+
 	akamaipb "github.com/letsencrypt/boulder/akamai/proto"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/ctpolicy"
 	"github.com/letsencrypt/boulder/ctpolicy/ctconfig"
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
@@ -66,7 +68,7 @@ type Config struct {
 
 		// OrderLifetime is how far in the future an Order's expiration date should
 		// be set when it is first created.
-		OrderLifetime cmd.ConfigDuration
+		OrderLifetime config.Duration
 
 		// FinalizeTimeout is how long the RA is willing to wait for the Order
 		// finalization process to take. This config parameter only has an effect
@@ -74,7 +76,7 @@ type Config struct {
 		// manage the shutdown of an RA must be willing to wait at least this long
 		// after sending the shutdown signal, to allow background goroutines to
 		// complete.
-		FinalizeTimeout cmd.ConfigDuration
+		FinalizeTimeout config.Duration
 
 		// CTLogs contains groupings of CT logs organized by what organization
 		// operates them. When we submit precerts to logs in order to get SCTs, we

--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -5,7 +5,9 @@ import (
 	"os"
 
 	"github.com/honeycombio/beeline-go"
+
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/sa"
@@ -27,7 +29,7 @@ type Config struct {
 		ParallelismPerRPC int
 		// LagFactor is how long to sleep before retrying a read request that may
 		// have failed solely due to replication lag.
-		LagFactor cmd.ConfigDuration
+		LagFactor config.Duration
 	}
 
 	Syslog  cmd.SyslogConfig

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -14,7 +14,10 @@ import (
 
 	"github.com/honeycombio/beeline-go"
 	"github.com/jmhodges/clock"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/goodkey/sagoodkey"
@@ -26,7 +29,6 @@ import (
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/wfe2"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Config struct {
@@ -37,14 +39,14 @@ type Config struct {
 
 		// Timeout is the per-request overall timeout. This should be slightly
 		// lower than the upstream's timeout when making request to the WFE.
-		Timeout cmd.ConfigDuration
+		Timeout config.Duration
 
 		ServerCertificatePath string
 		ServerKeyPath         string
 
 		AllowOrigins []string
 
-		ShutdownStopTimeout cmd.ConfigDuration
+		ShutdownStopTimeout config.Duration
 
 		SubscriberAgreementURL string
 
@@ -131,7 +133,7 @@ type Config struct {
 		GoodKey goodkey.Config
 
 		// StaleTimeout determines how old should data be to be accessed via Boulder-specific GET-able APIs
-		StaleTimeout cmd.ConfigDuration
+		StaleTimeout config.Duration
 
 		// AuthorizationLifetimeDays defines how long authorizations will be
 		// considered valid for. The WFE uses this to find the creation date of
@@ -154,7 +156,7 @@ type Config struct {
 
 type CacheConfig struct {
 	Size int
-	TTL  cmd.ConfigDuration
+	TTL  config.Duration
 }
 
 // loadCertificateFile loads a PEM certificate from the certFile provided. It

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zmap/zlint/v3/lint"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
@@ -412,11 +413,11 @@ type Config struct {
 		Workers        int
 		UnexpiredOnly  bool
 		BadResultsOnly bool
-		CheckPeriod    cmd.ConfigDuration
+		CheckPeriod    config.Duration
 
 		// AcceptableValidityDurations is a list of durations which are
 		// acceptable for certificates we issue.
-		AcceptableValidityDurations []cmd.ConfigDuration
+		AcceptableValidityDurations []config.Duration
 
 		// GoodKey is an embedded config stanza for the goodkey library. If this
 		// is populated, the cert-checker will perform static checks against the

--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -10,6 +10,7 @@ import (
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	cspb "github.com/letsencrypt/boulder/crl/storer/proto"
 	"github.com/letsencrypt/boulder/crl/updater"
 	"github.com/letsencrypt/boulder/features"
@@ -47,14 +48,14 @@ type Config struct {
 		// with more confusing mappings of serials to shards).
 		// WARNING: When this number is changed, revocation entries will move
 		// between shards.
-		ShardWidth cmd.ConfigDuration
+		ShardWidth config.Duration
 
 		// LookbackPeriod is how far back the updater should look for revoked expired
 		// certificates. We are required to include every revoked cert in at least
 		// one CRL, even if it is revoked seconds before it expires, so this must
 		// always be greater than the UpdatePeriod, and should be increased when
 		// recovering from an outage to ensure continuity of coverage.
-		LookbackPeriod cmd.ConfigDuration
+		LookbackPeriod config.Duration
 
 		// CertificateLifetime is the validity period (usually expressed in hours,
 		// like "2160h") of the longest-lived currently-unexpired certificate. For
@@ -65,21 +66,21 @@ type Config struct {
 		// the old validity period have expired.
 		// DEPRECATED: This config value is no longer used.
 		// TODO(#6438): Remove this value.
-		CertificateLifetime cmd.ConfigDuration
+		CertificateLifetime config.Duration
 
 		// UpdatePeriod controls how frequently the crl-updater runs and publishes
 		// new versions of every CRL shard. The Baseline Requirements, Section 4.9.7
 		// state that this MUST NOT be more than 7 days. We believe that future
 		// updates may require that this not be more than 24 hours, and currently
 		// recommend an UpdatePeriod of 6 hours.
-		UpdatePeriod cmd.ConfigDuration
+		UpdatePeriod config.Duration
 
 		// UpdateOffset controls the times at which crl-updater runs, to avoid
 		// scheduling the batch job at exactly midnight. The updater runs every
 		// UpdatePeriod, starting from the Unix Epoch plus UpdateOffset, and
 		// continuing forward into the future forever. This value must be strictly
 		// less than the UpdatePeriod.
-		UpdateOffset cmd.ConfigDuration
+		UpdateOffset config.Duration
 
 		// MaxParallelism controls how many workers may be running in parallel.
 		// A higher value reduces the total time necessary to update all CRL shards

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -22,7 +22,10 @@ import (
 	"github.com/jmhodges/clock"
 	"google.golang.org/grpc"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/db"
@@ -33,7 +36,6 @@ import (
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/sa"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -676,7 +678,7 @@ type Config struct {
 		EmailTemplate string
 
 		// How often to process a batch of certificates
-		Frequency cmd.ConfigDuration
+		Frequency config.Duration
 
 		// How many parallel goroutines should process each batch of emails
 		ParallelSends uint

--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/db"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
@@ -48,11 +49,11 @@ type Config struct {
 		Path          string
 		ListenAddress string
 		// Deprecated and unused.
-		MaxAge cmd.ConfigDuration
+		MaxAge config.Duration
 
 		// When to timeout a request. This should be slightly lower than the
 		// upstream's timeout when making request to ocsp-responder.
-		Timeout cmd.ConfigDuration
+		Timeout config.Duration
 
 		// The worst-case freshness of a response during normal operations.
 		//
@@ -71,11 +72,11 @@ type Config struct {
 		// would be: OCSPMinTimeToExpiry + OldOCSPWindow.
 		//
 		// This has a default value of 61h.
-		ExpectedFreshness cmd.ConfigDuration
+		ExpectedFreshness config.Duration
 
 		// How often a response should be signed when using Redis/live-signing
 		// path. This has a default value of 60h.
-		LiveSigningPeriod cmd.ConfigDuration
+		LiveSigningPeriod config.Duration
 
 		// A limit on how many requests to the RA (and onwards to the CA) will
 		// be made to sign responses that are not fresh in the cache. This
@@ -97,7 +98,7 @@ type Config struct {
 		// 40 * 5 / 0.02 = 10,000 requests before the oldest request times out.
 		MaxSigningWaiters int
 
-		ShutdownStopTimeout cmd.ConfigDuration
+		ShutdownStopTimeout config.Duration
 
 		RequiredSerialPrefixes []string
 

--- a/cmd/ocsp-updater/main.go
+++ b/cmd/ocsp-updater/main.go
@@ -9,6 +9,7 @@ import (
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/db"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
@@ -27,7 +28,7 @@ type Config struct {
 
 		// OldOCSPWindow controls how frequently ocsp-updater signs a batch
 		// of responses.
-		OldOCSPWindow cmd.ConfigDuration
+		OldOCSPWindow config.Duration
 		// OldOCSPBatchSize controls the maximum number of responses
 		// ocsp-updater will sign every OldOCSPWindow.
 		OldOCSPBatchSize int
@@ -36,7 +37,7 @@ type Config struct {
 		// This is related to to ExpectedFreshness in ocsp-responder's config,
 		// and both are related to the mandated refresh times in the BRs and
 		// root programs (minus a safety margin).
-		OCSPMinTimeToExpiry cmd.ConfigDuration
+		OCSPMinTimeToExpiry config.Duration
 
 		// ParallelGenerateOCSPRequests determines how many requests to the CA
 		// may be inflight at once.
@@ -44,7 +45,7 @@ type Config struct {
 
 		// TODO(#5933): Replace this with a unifed RetryBackoffConfig
 		SignFailureBackoffFactor float64
-		SignFailureBackoffMax    cmd.ConfigDuration
+		SignFailureBackoffMax    config.Duration
 
 		// SerialSuffixShards is a whitespace-separated list of single hex
 		// digits. When searching for work to do, ocsp-updater will query

--- a/cmd/orphan-finder/main.go
+++ b/cmd/orphan-finder/main.go
@@ -15,8 +15,11 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
+
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
@@ -25,7 +28,6 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
-	"google.golang.org/grpc"
 )
 
 var usageString = `
@@ -49,7 +51,7 @@ type Config struct {
 	// Backdate specifies how to adjust a certificate's NotBefore date to get back
 	// to the original issued date. It should match the value used in
 	// `test/config/ca.json` for the CA "backdate" value.
-	Backdate cmd.ConfigDuration
+	Backdate config.Duration
 	// IssuerCerts is a list of paths to all intermediate certificates which may
 	// have been used to issue certificates in the last 90 days. These are used
 	// to form OCSP generation requests.

--- a/config/duration.go
+++ b/config/duration.go
@@ -55,4 +55,3 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	d.Duration = dur
 	return nil
 }
-

--- a/config/duration.go
+++ b/config/duration.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Duration is just an alias for time.Duration that allows
+// serialization to YAML as well as JSON.
+type Duration struct {
+	time.Duration
+}
+
+// ErrDurationMustBeString is returned when a non-string value is
+// presented to be deserialized as a ConfigDuration
+var ErrDurationMustBeString = errors.New("cannot JSON unmarshal something other than a string into a ConfigDuration")
+
+// UnmarshalJSON parses a string into a ConfigDuration using
+// time.ParseDuration.  If the input does not unmarshal as a
+// string, then UnmarshalJSON returns ErrDurationMustBeString.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	s := ""
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		var jsonUnmarshalTypeErr *json.UnmarshalTypeError
+		if errors.As(err, &jsonUnmarshalTypeErr) {
+			return ErrDurationMustBeString
+		}
+		return err
+	}
+	dd, err := time.ParseDuration(s)
+	d.Duration = dd
+	return err
+}
+
+// MarshalJSON returns the string form of the duration, as a byte array.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return []byte(d.Duration.String()), nil
+}
+
+// UnmarshalYAML uses the same format as JSON, but is called by the YAML
+// parser (vs. the JSON parser).
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	dur, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+
+	d.Duration = dur
+	return nil
+}
+

--- a/ctpolicy/ctconfig/ctconfig.go
+++ b/ctpolicy/ctconfig/ctconfig.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 )
 
 // LogShard describes a single shard of a temporally sharded
@@ -94,7 +94,7 @@ type CTConfig struct {
 	// Stagger is duration (e.g. "200ms") indicating how long to wait for a log
 	// from one operator group to accept a certificate before attempting
 	// submission to a log run by a different operator instead.
-	Stagger cmd.ConfigDuration
+	Stagger config.Duration
 	// LogListFile is a path to a JSON log list file. The file must match Chrome's
 	// schema: https://www.gstatic.com/ct/log_list/v3/log_list_schema.json
 	LogListFile string

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -25,13 +25,14 @@ import (
 	cttls "github.com/google/certificate-transparency-go/tls"
 	ctx509 "github.com/google/certificate-transparency-go/x509"
 	"github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/cmd"
+	"golang.org/x/crypto/ocsp"
+
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/linter"
 	"github.com/letsencrypt/boulder/policyasn1"
 	"github.com/letsencrypt/boulder/privatekey"
 	"github.com/letsencrypt/pkcs11key/v4"
-	"golang.org/x/crypto/ocsp"
 )
 
 // ProfileConfig describes the certificate issuance constraints for all issuers.
@@ -42,8 +43,8 @@ type ProfileConfig struct {
 	AllowCommonName bool
 
 	Policies            []PolicyInformation
-	MaxValidityPeriod   cmd.ConfigDuration
-	MaxValidityBackdate cmd.ConfigDuration
+	MaxValidityPeriod   config.Duration
+	MaxValidityBackdate config.Duration
 }
 
 // PolicyInformation describes a policy

--- a/issuance/issuance_test.go
+++ b/issuance/issuance_test.go
@@ -21,7 +21,9 @@ import (
 
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/jmhodges/clock"
+
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
 	"github.com/letsencrypt/boulder/linter"
@@ -38,8 +40,8 @@ func defaultProfileConfig() ProfileConfig {
 		Policies: []PolicyInformation{
 			{OID: "1.2.3"},
 		},
-		MaxValidityPeriod:   cmd.ConfigDuration{Duration: time.Hour},
-		MaxValidityBackdate: cmd.ConfigDuration{Duration: time.Hour},
+		MaxValidityPeriod:   config.Duration{Duration: time.Hour},
+		MaxValidityBackdate: config.Duration{Duration: time.Hour},
 	}
 }
 

--- a/observer/mon_conf.go
+++ b/observer/mon_conf.go
@@ -4,17 +4,18 @@ import (
 	"errors"
 	"time"
 
-	"github.com/letsencrypt/boulder/cmd"
-	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
+
+	"github.com/letsencrypt/boulder/config"
+	"github.com/letsencrypt/boulder/observer/probers"
 )
 
 // MonConf is exported to receive YAML configuration in `ObsConf`.
 type MonConf struct {
-	Period   cmd.ConfigDuration `yaml:"period"`
-	Kind     string             `yaml:"kind"`
-	Settings probers.Settings   `yaml:"settings"`
+	Period   config.Duration  `yaml:"period"`
+	Kind     string           `yaml:"kind"`
+	Settings probers.Settings `yaml:"settings"`
 }
 
 // validatePeriod ensures the received `Period` field is at least 1µs.

--- a/observer/mon_conf_test.go
+++ b/observer/mon_conf_test.go
@@ -4,22 +4,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/test"
 )
 
 func TestMonConf_validatePeriod(t *testing.T) {
 	type fields struct {
-		Period cmd.ConfigDuration
+		Period config.Duration
 	}
 	tests := []struct {
 		name    string
 		fields  fields
 		wantErr bool
 	}{
-		{"valid", fields{cmd.ConfigDuration{Duration: 1 * time.Microsecond}}, false},
-		{"1 nanosecond", fields{cmd.ConfigDuration{Duration: 1 * time.Nanosecond}}, true},
-		{"none supplied", fields{cmd.ConfigDuration{}}, true},
+		{"valid", fields{config.Duration{Duration: 1 * time.Microsecond}}, false},
+		{"1 nanosecond", fields{config.Duration{Duration: 1 * time.Nanosecond}}, true},
+		{"none supplied", fields{config.Duration{}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/observer/obs_conf_test.go
+++ b/observer/obs_conf_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/observer/probers"
 	_ "github.com/letsencrypt/boulder/observer/probers/mock"
@@ -21,7 +22,7 @@ const (
 func TestObsConf_makeMonitors(t *testing.T) {
 	var errDBZ = errors.New(errDBZMsg)
 	var cfgSyslog = cmd.SyslogConfig{StdoutLevel: 6, SyslogLevel: 6}
-	var cfgDur = cmd.ConfigDuration{Duration: time.Second * 5}
+	var cfgDur = config.Duration{Duration: time.Second * 5}
 	var cfgBuckets = []float64{.001}
 	var validMonConf = &MonConf{
 		cfgDur, mockConf, probers.Settings{"valid": true, "pname": "foo", "pkind": "bar"}}

--- a/observer/probers/mock/mock_conf.go
+++ b/observer/probers/mock/mock_conf.go
@@ -3,19 +3,20 @@ package probers
 import (
 	"errors"
 
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/observer/probers"
 	"github.com/letsencrypt/boulder/strictyaml"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type MockConfigurer struct {
-	Valid    bool               `yaml:"valid"`
-	ErrMsg   string             `yaml:"errmsg"`
-	PName    string             `yaml:"pname"`
-	PKind    string             `yaml:"pkind"`
-	PTook    cmd.ConfigDuration `yaml:"ptook"`
-	PSuccess bool               `yaml:"psuccess"`
+	Valid    bool            `yaml:"valid"`
+	ErrMsg   string          `yaml:"errmsg"`
+	PName    string          `yaml:"pname"`
+	PKind    string          `yaml:"pkind"`
+	PTook    config.Duration `yaml:"ptook"`
+	PSuccess bool            `yaml:"psuccess"`
 }
 
 // Kind returns a name that uniquely identifies the `Kind` of `Configurer`.

--- a/observer/probers/mock/mock_prober.go
+++ b/observer/probers/mock/mock_prober.go
@@ -3,13 +3,13 @@ package probers
 import (
 	"time"
 
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 )
 
 type MockProber struct {
 	name    string
 	kind    string
-	took    cmd.ConfigDuration
+	took    config.Duration
 	success bool
 }
 

--- a/ratelimit/rate-limits.go
+++ b/ratelimit/rate-limits.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/strictyaml"
 )
 
@@ -175,7 +175,7 @@ type rateLimitConfig struct {
 // RateLimitPolicy describes a general limiting policy
 type RateLimitPolicy struct {
 	// How long to count items for
-	Window cmd.ConfigDuration `yaml:"window"`
+	Window config.Duration `yaml:"window"`
 	// The max number of items that can be present before triggering the rate
 	// limit. Zero means "no limit."
 	Threshold int64 `yaml:"threshold"`

--- a/ratelimit/rate-limits_test.go
+++ b/ratelimit/rate-limits_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -89,7 +89,7 @@ func TestGetThreshold(t *testing.T) {
 
 func TestWindowBegin(t *testing.T) {
 	policy := RateLimitPolicy{
-		Window: cmd.ConfigDuration{Duration: 24 * time.Hour},
+		Window: config.Duration{Duration: 24 * time.Hour},
 	}
 	now := time.Date(2015, 9, 22, 0, 0, 0, 0, time.UTC)
 	expected := time.Date(2015, 9, 21, 0, 0, 0, 0, time.UTC)

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -10,11 +10,13 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/cmd"
-	"github.com/letsencrypt/boulder/issuance"
-	"github.com/letsencrypt/boulder/rocsp"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/ocsp"
+
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
+	"github.com/letsencrypt/boulder/issuance"
+	"github.com/letsencrypt/boulder/rocsp"
 )
 
 // RedisConfig contains the configuration needed to act as a Redis client.
@@ -30,7 +32,7 @@ type RedisConfig struct {
 	// Servers based on a consistent hashing algorithm.
 	ShardAddrs map[string]string
 	// Timeout is a per-request timeout applied to all Redis requests.
-	Timeout cmd.ConfigDuration
+	Timeout config.Duration
 
 	// Enables read-only commands on replicas.
 	ReadOnly bool
@@ -49,22 +51,22 @@ type RedisConfig struct {
 	MaxRetries int
 	// Minimum backoff between each retry.
 	// Default is 8 milliseconds; -1 disables backoff.
-	MinRetryBackoff cmd.ConfigDuration
+	MinRetryBackoff config.Duration
 	// Maximum backoff between each retry.
 	// Default is 512 milliseconds; -1 disables backoff.
-	MaxRetryBackoff cmd.ConfigDuration
+	MaxRetryBackoff config.Duration
 
 	// Dial timeout for establishing new connections.
 	// Default is 5 seconds.
-	DialTimeout cmd.ConfigDuration
+	DialTimeout config.Duration
 	// Timeout for socket reads. If reached, commands will fail
 	// with a timeout instead of blocking. Use value -1 for no timeout and 0 for default.
 	// Default is 3 seconds.
-	ReadTimeout cmd.ConfigDuration
+	ReadTimeout config.Duration
 	// Timeout for socket writes. If reached, commands will fail
 	// with a timeout instead of blocking.
 	// Default is ReadTimeout.
-	WriteTimeout cmd.ConfigDuration
+	WriteTimeout config.Duration
 
 	// Maximum number of socket connections.
 	// Default is 5 connections per every CPU as reported by runtime.NumCPU.
@@ -77,20 +79,20 @@ type RedisConfig struct {
 	MinIdleConns int
 	// Connection age at which client retires (closes) the connection.
 	// Default is to not close aged connections.
-	MaxConnAge cmd.ConfigDuration
+	MaxConnAge config.Duration
 	// Amount of time client waits for connection if all connections
 	// are busy before returning an error.
 	// Default is ReadTimeout + 1 second.
-	PoolTimeout cmd.ConfigDuration
+	PoolTimeout config.Duration
 	// Amount of time after which client closes idle connections.
 	// Should be less than server's timeout.
 	// Default is 5 minutes. -1 disables idle timeout check.
-	IdleTimeout cmd.ConfigDuration
+	IdleTimeout config.Duration
 	// Frequency of idle checks made by idle connections reaper.
 	// Default is 1 minute. -1 disables idle connections reaper,
 	// but idle connections are still discarded by the client
 	// if IdleTimeout is set.
-	IdleCheckFrequency cmd.ConfigDuration
+	IdleCheckFrequency config.Duration
 }
 
 // MakeClient produces a read-write ROCSP client from a config.


### PR DESCRIPTION
We rely on the ratelimit/ package in CI to validate our ratelimit configurations.  However, because that package relies on cmd/ just for cmd.ConfigDuration, many additional dependencies get pulled in.

This refactors just that struct to a separate config package.  This was done using Goland's automatic refactoring tooling, which also organized a few imports while it was touching them, keeping standard library, internal and external dependencies grouped.
