### PR TITLE
Add SetCommonName feature flag

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -433,16 +433,21 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 	ca.log.AuditInfof("Signing precert: serial=[%s] regID=[%d] names=[%s] csr=[%s]",
 		serialHex, issueReq.RegistrationID, strings.Join(csr.DNSNames, ", "), hex.EncodeToString(csr.Raw))
 
-	certDER, err := issuer.Issue(&issuance.IssuanceRequest{
+	names := csrlib.NamesFromCSR(csr)
+	req := &issuance.IssuanceRequest{
 		PublicKey:         csr.PublicKey,
 		Serial:            serialBigInt.Bytes(),
-		CommonName:        csr.Subject.CommonName,
-		DNSNames:          csr.DNSNames,
+		DNSNames:          names.SANs,
 		IncludeCTPoison:   true,
 		IncludeMustStaple: issuance.ContainsMustStaple(csr.Extensions),
 		NotBefore:         validity.NotBefore,
 		NotAfter:          validity.NotAfter,
-	})
+	}
+	if !features.Enabled(features.OmitCommonName) {
+		req.CommonName = names.CN
+	}
+
+	certDER, err := issuer.Issue(req)
 	if err != nil {
 		ca.noteSignError(err)
 		ca.log.AuditErrf("Signing precert failed: serial=[%s] regID=[%d] names=[%s] err=[%v]",

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -443,7 +443,7 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		NotBefore:         validity.NotBefore,
 		NotAfter:          validity.NotAfter,
 	}
-	if !features.Enabled(features.OmitCommonName) {
+	if features.Enabled(features.SetCommonName) {
 		req.CommonName = names.CN
 	}
 

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -75,7 +75,7 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	if len(names.SANs) == 0 && names.CN == "" {
 		return invalidNoDNS
 	}
-	if names.CN == "" && !features.Enabled(features.OmitCommonName) {
+	if names.CN == "" && features.Enabled(features.SetCommonName) {
 		return invalidAllSANTooLong
 	}
 	if len(names.CN) > maxCNLength {
@@ -111,7 +111,7 @@ func NamesFromCSR(csr *x509.CertificateRequest) names {
 	}
 	sans = core.UniqueLowerNames(sans)
 
-	if features.Enabled(features.OmitCommonName) {
+	if !features.Enabled(features.SetCommonName) {
 		return names{SANs: sans}
 	}
 

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/identifier"
 )
@@ -43,7 +44,6 @@ var (
 // the CSR which lowers the case of DNS names and subject CN, and hoist a DNS name into the CN
 // if it is empty.
 func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, keyPolicy *goodkey.KeyPolicy, pa core.PolicyAuthority) error {
-	normalizeCSR(csr)
 	key, ok := csr.PublicKey.(crypto.PublicKey)
 	if !ok {
 		return invalidPubKey
@@ -69,21 +69,25 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	if len(csr.IPAddresses) > 0 {
 		return invalidIPPresent
 	}
-	if len(csr.DNSNames) == 0 && csr.Subject.CommonName == "" {
+
+	names := NamesFromCSR(csr)
+
+	if len(names.SANs) == 0 && names.CN == "" {
 		return invalidNoDNS
 	}
-	if csr.Subject.CommonName == "" {
+	if names.CN == "" && !features.Enabled(features.OmitCommonName) {
 		return invalidAllSANTooLong
 	}
-	if len(csr.Subject.CommonName) > maxCNLength {
+	if len(names.CN) > maxCNLength {
 		return berrors.BadCSRError("CN was longer than %d bytes", maxCNLength)
 	}
-	if len(csr.DNSNames) > maxNames {
+	if len(names.SANs) > maxNames {
 		return berrors.BadCSRError("CSR contains more than %d DNS names", maxNames)
 	}
-	idents := make([]identifier.ACMEIdentifier, len(csr.DNSNames))
-	for i, dnsName := range csr.DNSNames {
-		idents[i] = identifier.DNSIdentifier(dnsName)
+
+	idents := make([]identifier.ACMEIdentifier, len(names.SANs))
+	for i, name := range names.SANs {
+		idents[i] = identifier.DNSIdentifier(name)
 	}
 	err = pa.WillingToIssueWildcards(idents)
 	if err != nil {
@@ -92,22 +96,34 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	return nil
 }
 
-// normalizeCSR deduplicates and lowers the case of dNSNames and the subject CN.
-// It will also hoist a dNSName into the CN if it is empty.
-func normalizeCSR(csr *x509.CertificateRequest) {
-	if csr.Subject.CommonName == "" {
-		var forcedCN string
-		// Promote the first SAN that is less than maxCNLength (if any)
-		for _, name := range csr.DNSNames {
-			if len(name) <= maxCNLength {
-				forcedCN = name
-				break
-			}
-		}
-		csr.Subject.CommonName = forcedCN
-	} else if csr.Subject.CommonName != "" {
-		csr.DNSNames = append(csr.DNSNames, csr.Subject.CommonName)
+type names struct {
+	SANs []string
+	CN   string
+}
+
+// NamesFromCSR deduplicates and lower-cases the Subject Common Name and Subject
+// Alternative Names from the CSR. It guarantees that the SANs include the CN.
+// It also enforces various conditions on the CN, based on feature flags.
+func NamesFromCSR(csr *x509.CertificateRequest) names {
+	sans := csr.DNSNames
+	if csr.Subject.CommonName != "" {
+		sans = append(sans, csr.Subject.CommonName)
 	}
-	csr.Subject.CommonName = strings.ToLower(csr.Subject.CommonName)
-	csr.DNSNames = core.UniqueLowerNames(csr.DNSNames)
+	sans = core.UniqueLowerNames(sans)
+
+	if features.Enabled(features.OmitCommonName) {
+		return names{SANs: sans}
+	}
+
+	if csr.Subject.CommonName != "" {
+		return names{SANs: sans, CN: strings.ToLower(csr.Subject.CommonName)}
+	}
+
+	for _, name := range sans {
+		if len(name) <= maxCNLength {
+			return names{SANs: sans, CN: name}
+		}
+	}
+
+	return names{SANs: sans}
 }

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -119,6 +119,8 @@ func NamesFromCSR(csr *x509.CertificateRequest) names {
 		return names{SANs: sans, CN: strings.ToLower(csr.Subject.CommonName)}
 	}
 
+	// If there's no CN already, but we want to set one, promote the first SAN
+	// which is shorter than the the maximum acceptable CN length (if any).
 	for _, name := range sans {
 		if len(name) <= maxCNLength {
 			return names{SANs: sans, CN: name}

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -163,7 +163,7 @@ func TestVerifyCSR(t *testing.T) {
 	}
 }
 
-func TestNormalizeCSR(t *testing.T) {
+func TestNamesFromCSR(t *testing.T) {
 	tooLongString := strings.Repeat("a", maxCNLength+1)
 
 	cases := []struct {
@@ -209,11 +209,64 @@ func TestNormalizeCSR(t *testing.T) {
 			[]string{"a.com", tooLongString + ".a.com", tooLongString + ".b.com", "b.com"},
 		},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			normalizeCSR(c.csr)
-			test.AssertEquals(t, c.expectedCN, c.csr.Subject.CommonName)
-			test.AssertDeepEquals(t, c.expectedNames, c.csr.DNSNames)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := NamesFromCSR(tc.csr)
+			test.AssertEquals(t, names.CN, tc.expectedCN)
+			test.AssertDeepEquals(t, names.SANs, tc.expectedNames)
+		})
+	}
+}
+
+func TestNamesFromCSROmitCommonName(t *testing.T) {
+	features.Set(map[string]bool{features.OmitCommonName.String(): true})
+	defer features.Reset()
+
+	tooLongString := strings.Repeat("a", maxCNLength+1)
+
+	cases := []struct {
+		name          string
+		csr           *x509.CertificateRequest
+		expectedNames []string
+	}{
+		{
+			"no explicit CN",
+			&x509.CertificateRequest{DNSNames: []string{"a.com"}},
+			[]string{"a.com"},
+		},
+		{
+			"explicit uppercase CN",
+			&x509.CertificateRequest{Subject: pkix.Name{CommonName: "A.com"}, DNSNames: []string{"a.com"}},
+			[]string{"a.com"},
+		},
+		{
+			"no explicit CN, too long leading SANs",
+			&x509.CertificateRequest{DNSNames: []string{
+				tooLongString + ".a.com",
+				tooLongString + ".b.com",
+				"a.com",
+				"b.com",
+			}},
+			[]string{"a.com", tooLongString + ".a.com", tooLongString + ".b.com", "b.com"},
+		},
+		{
+			"explicit CN, too long leading SANs",
+			&x509.CertificateRequest{
+				Subject: pkix.Name{CommonName: "A.com"},
+				DNSNames: []string{
+					tooLongString + ".a.com",
+					tooLongString + ".b.com",
+					"a.com",
+					"b.com",
+				}},
+			[]string{"a.com", tooLongString + ".a.com", tooLongString + ".b.com", "b.com"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := NamesFromCSR(tc.csr)
+			test.AssertEquals(t, names.CN, "")
+			test.AssertDeepEquals(t, names.SANs, tc.expectedNames)
 		})
 	}
 }

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -219,7 +219,7 @@ func TestNamesFromCSR(t *testing.T) {
 }
 
 func TestNamesFromCSROmitCommonName(t *testing.T) {
-	features.Set(map[string]bool{features.OmitCommonName.String(): true})
+	features.Set(map[string]bool{features.SetCommonName.String(): false})
 	defer features.Reset()
 
 	tooLongString := strings.Repeat("a", maxCNLength+1)

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -23,12 +23,12 @@ func _() {
 	_ = x[CertCheckerChecksValidations-12]
 	_ = x[CertCheckerRequiresValidations-13]
 	_ = x[AsyncFinalize-14]
-	_ = x[OmitCommonName-15]
+	_ = x[SetCommonName-15]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsAsyncFinalizeOmitCommonName"
+const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsAsyncFinalizeSetCommonName"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 98, 114, 139, 150, 161, 185, 213, 243, 256, 270}
+var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 98, 114, 139, 150, 161, 185, 213, 243, 256, 269}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -23,11 +23,12 @@ func _() {
 	_ = x[CertCheckerChecksValidations-12]
 	_ = x[CertCheckerRequiresValidations-13]
 	_ = x[AsyncFinalize-14]
+	_ = x[OmitCommonName-15]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsAsyncFinalize"
+const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsAsyncFinalizeOmitCommonName"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 98, 114, 139, 150, 161, 185, 213, 243, 256}
+var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 98, 114, 139, 150, 161, 185, 213, 243, 256, 270}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -67,10 +67,10 @@ const (
 	// of "orphaned" certs we have. However, it also requires clients to properly
 	// implement polling the Order object to wait for the cert URL to appear.
 	AsyncFinalize
-	// SetCommonName causes the certificates issued to omit the commonName field
-	// from the certificate Subject, only setting the Subject Alternative Name
-	// extension. According to the BRs Section 7.1.4.2.2(a), the commonName field
-	// is Deprecated, and its inclusion is Discouraged but not (yet) prohibited.
+	// SetCommonName defaults to true, and causes the CA to include the commonName
+	// field in the certificate Subject. When false, the commonName will be
+	// omitted. According to the BRs Section 7.1.4.2.2(a), the commonName field is
+	// Deprecated, and its inclusion is Discouraged but not (yet) prohibited.
 	SetCommonName
 )
 

--- a/features/features.go
+++ b/features/features.go
@@ -67,11 +67,11 @@ const (
 	// of "orphaned" certs we have. However, it also requires clients to properly
 	// implement polling the Order object to wait for the cert URL to appear.
 	AsyncFinalize
-	// OmitCommonName causes the certificates issued to omit the commonName field
+	// SetCommonName causes the certificates issued to omit the commonName field
 	// from the certificate Subject, only setting the Subject Alternative Name
 	// extension. According to the BRs Section 7.1.4.2.2(a), the commonName field
 	// is Deprecated, and its inclusion is Discouraged but not (yet) prohibited.
-	OmitCommonName
+	SetCommonName
 )
 
 // List of features and their default value, protected by fMu
@@ -91,7 +91,7 @@ var features = map[FeatureFlag]bool{
 	CertCheckerChecksValidations:   false,
 	CertCheckerRequiresValidations: false,
 	AsyncFinalize:                  false,
-	OmitCommonName:                 false,
+	SetCommonName:                  true,
 }
 
 var fMu = new(sync.RWMutex)

--- a/features/features.go
+++ b/features/features.go
@@ -67,6 +67,11 @@ const (
 	// of "orphaned" certs we have. However, it also requires clients to properly
 	// implement polling the Order object to wait for the cert URL to appear.
 	AsyncFinalize
+	// OmitCommonName causes the certificates issued to omit the commonName field
+	// from the certificate Subject, only setting the Subject Alternative Name
+	// extension. According to the BRs Section 7.1.4.2.2(a), the commonName field
+	// is Deprecated, and its inclusion is Discouraged but not (yet) prohibited.
+	OmitCommonName
 )
 
 // List of features and their default value, protected by fMu
@@ -86,6 +91,7 @@ var features = map[FeatureFlag]bool{
 	CertCheckerChecksValidations:   false,
 	CertCheckerRequiresValidations: false,
 	AsyncFinalize:                  false,
+	OmitCommonName:                 false,
 }
 
 var fMu = new(sync.RWMutex)

--- a/issuance/issuance_test.go
+++ b/issuance/issuance_test.go
@@ -607,6 +607,51 @@ func TestIssueRSA(t *testing.T) {
 	test.AssertEquals(t, cert.KeyUsage, x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment)
 }
 
+func TestIssueCommonName(t *testing.T) {
+	fc := clock.NewFake()
+	fc.Set(time.Now())
+	linter, err := linter.New(
+		issuerCert.Certificate,
+		issuerSigner,
+		[]string{
+			"w_ct_sct_policy_count_unsatisfied",
+			"e_scts_from_same_operator",
+			"n_subject_common_name_included",
+		},
+	)
+	test.AssertNotError(t, err, "failed to create linter")
+	signer, err := NewIssuer(issuerCert, issuerSigner, defaultProfile(), linter, fc)
+	test.AssertNotError(t, err, "NewIssuer failed")
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "failed to generate test key")
+	ir := &IssuanceRequest{
+		PublicKey:  pk.Public(),
+		Serial:     []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		CommonName: "example.com",
+		DNSNames:   []string{"example.com", "www.example.com"},
+		NotBefore:  fc.Now(),
+		NotAfter:   fc.Now().Add(time.Hour - time.Second),
+	}
+
+	certBytes, err := signer.Issue(ir)
+	test.AssertNotError(t, err, "Issue failed")
+	cert, err := x509.ParseCertificate(certBytes)
+	test.AssertNotError(t, err, "failed to parse certificate")
+	test.AssertEquals(t, cert.Subject.CommonName, "example.com")
+
+	signer.Profile.allowCommonName = false
+	_, err = signer.Issue(ir)
+	test.AssertError(t, err, "Issue should have failed")
+
+	ir.CommonName = ""
+	certBytes, err = signer.Issue(ir)
+	test.AssertNotError(t, err, "Issue failed")
+	cert, err = x509.ParseCertificate(certBytes)
+	test.AssertNotError(t, err, "failed to parse certificate")
+	test.AssertEquals(t, cert.Subject.CommonName, "")
+	test.AssertDeepEquals(t, cert.DNSNames, []string{"example.com", "www.example.com"})
+}
+
 func TestIssueCTPoison(t *testing.T) {
 	fc := clock.NewFake()
 	fc.Set(time.Now())

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -690,7 +690,10 @@ func (ra *RegistrationAuthorityImpl) matchesCSR(parsedCertificate *x509.Certific
 			return berrors.InternalServerError("generated certificate CommonName doesn't match CSR CommonName")
 		}
 	}
-	if !reflect.DeepEqual(parsedCertificate.DNSNames, csrNames.SANs) {
+
+	parsedNames := parsedCertificate.DNSNames
+	sort.Strings(parsedNames)
+	if !reflect.DeepEqual(parsedNames, csrNames.SANs) {
 		return berrors.InternalServerError("generated certificate DNSNames don't match CSR DNSNames")
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -677,25 +677,18 @@ func (ra *RegistrationAuthorityImpl) checkNewOrdersPerAccountLimit(ctx context.C
 //   - ExtKeyUsage only contains ExtKeyUsageServerAuth & ExtKeyUsageClientAuth
 //   - Subject only contains CommonName & Names
 func (ra *RegistrationAuthorityImpl) matchesCSR(parsedCertificate *x509.Certificate, csr *x509.CertificateRequest) error {
-	// Check issued certificate matches what was expected from the CSR
-	hostNames := make([]string, len(csr.DNSNames))
-	copy(hostNames, csr.DNSNames)
-	if len(csr.Subject.CommonName) > 0 {
-		hostNames = append(hostNames, csr.Subject.CommonName)
-	}
-	hostNames = core.UniqueLowerNames(hostNames)
+	csrNames := csrlib.NamesFromCSR(csr)
 
 	if !core.KeyDigestEquals(parsedCertificate.PublicKey, csr.PublicKey) {
 		return berrors.InternalServerError("generated certificate public key doesn't match CSR public key")
 	}
-	if parsedCertificate.Subject.CommonName != strings.ToLower(csr.Subject.CommonName) {
+	if parsedCertificate.Subject.CommonName != csrNames.CN {
 		return berrors.InternalServerError("generated certificate CommonName doesn't match CSR CommonName")
 	}
-	// Sort both slices of names before comparison.
+
 	parsedNames := parsedCertificate.DNSNames
 	sort.Strings(parsedNames)
-	sort.Strings(hostNames)
-	if !reflect.DeepEqual(parsedNames, hostNames) {
+	if !reflect.DeepEqual(parsedNames, csrNames.SANs) {
 		return berrors.InternalServerError("generated certificate DNSNames don't match CSR DNSNames")
 	}
 	if !reflect.DeepEqual(parsedCertificate.IPAddresses, csr.IPAddresses) {
@@ -704,6 +697,7 @@ func (ra *RegistrationAuthorityImpl) matchesCSR(parsedCertificate *x509.Certific
 	if !reflect.DeepEqual(parsedCertificate.EmailAddresses, csr.EmailAddresses) {
 		return berrors.InternalServerError("generated certificate EmailAddresses don't match CSR EmailAddresses")
 	}
+
 	if len(parsedCertificate.Subject.Country) > 0 || len(parsedCertificate.Subject.Organization) > 0 ||
 		len(parsedCertificate.Subject.OrganizationalUnit) > 0 || len(parsedCertificate.Subject.Locality) > 0 ||
 		len(parsedCertificate.Subject.Province) > 0 || len(parsedCertificate.Subject.StreetAddress) > 0 ||
@@ -1122,7 +1116,7 @@ func (ra *RegistrationAuthorityImpl) validateFinalizeRequest(
 
 	// Dedupe, lowercase and sort both the names from the CSR and the names in the
 	// order.
-	csrNames := core.UniqueLowerNames(csr.DNSNames)
+	csrNames := csrlib.NamesFromCSR(csr).SANs
 	orderNames := core.UniqueLowerNames(req.Order.Names)
 
 	// Immediately reject the request if the number of names differ

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -83,7 +83,7 @@
         "allowMustStaple": true,
         "allowCTPoison": true,
         "allowSCTList": true,
-        "allowCommonName": true,
+        "allowCommonName": false,
         "policies": [
           {
             "oid": "2.23.140.1.2.1"
@@ -158,7 +158,8 @@
     "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
     "ctLogListFile": "test/ct-test-srv/log_list.json",
     "features": {
-      "ROCSPStage7": true
+      "ROCSPStage7": true,
+      "OmitCommonName": true
     }
   },
 

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -159,7 +159,7 @@
     "ctLogListFile": "test/ct-test-srv/log_list.json",
     "features": {
       "ROCSPStage7": true,
-      "OmitCommonName": true
+      "SetCommonName": false
     }
   },
 

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -83,7 +83,7 @@
         "allowMustStaple": true,
         "allowCTPoison": true,
         "allowSCTList": true,
-        "allowCommonName": true,
+        "allowCommonName": false,
         "policies": [
           {
             "oid": "2.23.140.1.2.1"
@@ -158,7 +158,8 @@
     "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
     "ctLogListFile": "test/ct-test-srv/log_list.json",
     "features": {
-      "ROCSPStage7": true
+      "ROCSPStage7": true,
+      "OmitCommonName": true
     }
   },
 

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -159,7 +159,7 @@
     "ctLogListFile": "test/ct-test-srv/log_list.json",
     "features": {
       "ROCSPStage7": true,
-      "OmitCommonName": true
+      "SetCommonName": false
     }
   },
 

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -100,8 +100,7 @@
     "features": {
       "StoreRevokerInfo": true,
       "ROCSPStage7": true,
-      "AsyncFinalize": true,
-      "OmitCommonName": true
+      "AsyncFinalize": true
     },
     "ctLogs": {
       "stagger": "500ms",

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -100,7 +100,8 @@
     "features": {
       "StoreRevokerInfo": true,
       "ROCSPStage7": true,
-      "AsyncFinalize": true
+      "AsyncFinalize": true,
+      "OmitCommonName": true
     },
     "ctLogs": {
       "stagger": "500ms",

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -40,12 +40,12 @@ func TestCommonName(t *testing.T) {
 	test.AssertSliceContains(t, cert.DNSNames, san1)
 	test.AssertSliceContains(t, cert.DNSNames, san2)
 
-	// Ensure that the CN is (or is not) set, per the OmitCommonName flag.
+	// Ensure that the CN is (or is not) set, per the SetCommonName flag.
 	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
-		// In config-next, the OmitCommonName flag is true.
+		// In config-next, the SetCommonName flag is false.
 		test.AssertEquals(t, cert.Subject.CommonName, "")
 	} else {
-		// In config, the OmitCommonName flag is false.
+		// In config, the SetCommonName flag is true.
 		test.AssertEquals(t, cert.Subject.CommonName, cn)
 	}
 }

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package integration
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestCommonName(t *testing.T) {
+	t.Parallel()
+
+	// Create an account.
+	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
+	client, err := makeClient("mailto:example@letsencrypt.org")
+	test.AssertNotError(t, err, "creating acme client")
+
+	// Create a private key.
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "creating random cert key")
+
+	// Put together some names.
+	cn := random_domain()
+	san1 := random_domain()
+	san2 := random_domain()
+
+	// Issue a cert. authAndIssue includes the 0th name as the CN by default.
+	ir, err := authAndIssue(client, key, []string{cn, san1, san2})
+	test.AssertNotError(t, err, "failed to issue test cert")
+	cert := ir.certs[0]
+
+	// Ensure that the CN is incorporated into the SANs.
+	test.AssertSliceContains(t, cert.DNSNames, cn)
+	test.AssertSliceContains(t, cert.DNSNames, san1)
+	test.AssertSliceContains(t, cert.DNSNames, san2)
+
+	// Ensure that the CN is (or is not) set, per the OmitCommonName flag.
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
+		// In config-next, the OmitCommonName flag is true.
+		test.AssertEquals(t, cert.Subject.CommonName, "")
+	} else {
+		// In config, the OmitCommonName flag is false.
+		test.AssertEquals(t, cert.Subject.CommonName, cn)
+	}
+}


### PR DESCRIPTION
Add a new feature flag, `SetCommonName`, which defaults to `true`. In this default state, no behavior changes.

When set to `false` on the CA, this flag will cause the CA to leave the Subject commonName field of the certificate blank, as is recommended by the Baseline Requirements Section 7.1.4.2.2(a).

Also slightly modify the behavior of the RA's `matchesCSR()` function, to allow for both certificates that have a CN and certificates that don't. It is not feasible to put this behavior behind the same SetCommonName flag, because that would require an atomic deploy of both the RA and the CA.

Obsoletes #5112