### PR TITLE
Conditionally call Sprintf in log package

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -274,8 +274,8 @@ func (w *stdoutWriter) logAtLevel(level syslog.Priority, msg string, a ...interf
 }
 
 func (log *impl) auditAtLevel(level syslog.Priority, msg string, a ...interface{}) {
-	text := fmt.Sprintf("%s %s", auditTag, fmt.Sprintf(msg, a...))
-	log.w.logAtLevel(level, text)
+	msg = fmt.Sprintf("%s %s", auditTag, msg)
+	log.w.logAtLevel(level, msg, a...)
 }
 
 // AuditPanic catches panicking executables. This method should be added
@@ -352,14 +352,12 @@ func (log *impl) Debugf(format string, a ...interface{}) {
 // audit tag, for special handling at the upstream system logger.
 func (log *impl) AuditInfo(msg string) {
 	log.AuditInfof(msg)
-
 }
 
 // AuditInfof sends an INFO-severity message that is prefixed with the
 // audit tag, for special handling at the upstream system logger.
 func (log *impl) AuditInfof(format string, a ...interface{}) {
 	log.auditAtLevel(syslog.LOG_INFO, format, a...)
-
 }
 
 // AuditObject sends an INFO-severity JSON-serialized object message that is prefixed
@@ -377,7 +375,6 @@ func (log *impl) AuditObject(msg string, obj interface{}) {
 // AuditErr can format an error for auditing; it does so at ERR level.
 func (log *impl) AuditErr(msg string) {
 	log.AuditErrf(msg)
-
 }
 
 // AuditErrf can format an error for auditing; it does so at ERR level.

--- a/log/log.go
+++ b/log/log.go
@@ -247,17 +247,15 @@ func (w *stdoutWriter) logAtLevel(level syslog.Priority, msg string, a ...interf
 
 		const red = "\033[31m\033[1m"
 		const yellow = "\033[33m"
-		const gray = "\033[37m\033[2m"
 
 		if w.isatty {
-			if int(level) == int(syslog.LOG_DEBUG) {
-				color = gray
-			} else if int(level) == int(syslog.LOG_WARNING) {
+			if int(level) == int(syslog.LOG_WARNING) {
 				color = yellow
+				reset = "\033[0m"
 			} else if int(level) <= int(syslog.LOG_ERR) {
 				color = red
+				reset = "\033[0m"
 			}
-			reset = "\033[0m"
 		}
 
 		if _, err := fmt.Fprintf(output, "%s%s %s %d %s %s%s\n",

--- a/log/log.go
+++ b/log/log.go
@@ -62,8 +62,7 @@ const auditTag = "[AUDIT]"
 // and also writes to stdout/stderr. It is safe for concurrent use.
 func New(log *syslog.Writer, stdoutLogLevel int, syslogLogLevel int) (Logger, error) {
 	if log == nil {
-		//lint:ignore ST1005 We like to keep punctuation at the end of the error line.
-		return nil, errors.New("Attempted to use a nil System Logger.")
+		return nil, errors.New("Attempted to use a nil System Logger")
 	}
 	return &impl{
 		&bothWriter{
@@ -126,8 +125,7 @@ func initialize() {
 // first time.
 func Set(logger Logger) (err error) {
 	if _Singleton.log != nil {
-		//lint:ignore ST1005 We like to keep punctuation at the end of the error line.
-		err = errors.New("You may not call Set after it has already been implicitly or explicitly set.")
+		err = errors.New("You may not call Set after it has already been implicitly or explicitly set")
 		_Singleton.log.Warning(err.Error())
 	} else {
 		_Singleton.log = logger

--- a/log/log.go
+++ b/log/log.go
@@ -62,6 +62,7 @@ const auditTag = "[AUDIT]"
 // and also writes to stdout/stderr. It is safe for concurrent use.
 func New(log *syslog.Writer, stdoutLogLevel int, syslogLogLevel int) (Logger, error) {
 	if log == nil {
+		//lint:ignore ST1005 We like to keep punctuation at the end of the error line.
 		return nil, errors.New("Attempted to use a nil System Logger.")
 	}
 	return &impl{
@@ -125,6 +126,7 @@ func initialize() {
 // first time.
 func Set(logger Logger) (err error) {
 	if _Singleton.log != nil {
+		//lint:ignore ST1005 We like to keep punctuation at the end of the error line.
 		err = errors.New("You may not call Set after it has already been implicitly or explicitly set.")
 		_Singleton.log.Warning(err.Error())
 	} else {

--- a/log/log.go
+++ b/log/log.go
@@ -189,13 +189,14 @@ func checkSummed(msg string) string {
 func (w *bothWriter) logAtLevel(level syslog.Priority, msg string, a ...interface{}) {
 	var err error
 
-	// Since messages are delimited by newlines, we have to escape any internal or
-	// trailing newlines before generating the checksum or outputting the message.
-	msg = strings.Replace(msg, "\n", "\\n", -1)
-
+	// Apply conditional formatting for f functions
 	if a != nil {
 		msg = fmt.Sprintf(msg, a...)
 	}
+
+	// Since messages are delimited by newlines, we have to escape any internal or
+	// trailing newlines before generating the checksum or outputting the message.
+	msg = strings.Replace(msg, "\n", "\\n", -1)
 
 	w.Lock()
 	defer w.Unlock()
@@ -236,11 +237,12 @@ func (w *stdoutWriter) logAtLevel(level syslog.Priority, msg string, a ...interf
 			output = w.stderr
 		}
 
-		msg = strings.Replace(msg, "\n", "\\n", -1)
-
+		// Apply conditional formatting for f functions
 		if a != nil {
 			msg = fmt.Sprintf(msg, a...)
 		}
+
+		msg = strings.Replace(msg, "\n", "\\n", -1)
 
 		var color string
 		var reset string

--- a/log/mock.go
+++ b/log/mock.go
@@ -57,8 +57,7 @@ var levelName = map[syslog.Priority]string{
 }
 
 func (w *mockWriter) logAtLevel(p syslog.Priority, msg string, a ...interface{}) {
-	format := fmt.Sprintf(msg, a...)
-	w.msgChan <- fmt.Sprintf("%s: %s", levelName[p&7], format)
+	w.msgChan <- fmt.Sprintf("%s: %s", levelName[p&7], fmt.Sprintf(msg, a...))
 }
 
 // newMockWriter returns a new mockWriter
@@ -145,8 +144,7 @@ func newWaitingMockWriter() *waitingMockWriter {
 }
 
 func (m *waitingMockWriter) logAtLevel(p syslog.Priority, msg string, a ...interface{}) {
-	format := fmt.Sprintf(msg, a...)
-	m.logChan <- fmt.Sprintf("%s: %s", levelName[p&7], format)
+	m.logChan <- fmt.Sprintf("%s: %s", levelName[p&7], fmt.Sprintf(msg, a...))
 }
 
 // WaitForMatch returns the first log line matching a regex. It accepts a

--- a/log/mock.go
+++ b/log/mock.go
@@ -56,8 +56,9 @@ var levelName = map[syslog.Priority]string{
 	syslog.LOG_DEBUG:   "DEBUG",
 }
 
-func (w *mockWriter) logAtLevel(p syslog.Priority, msg string) {
-	w.msgChan <- fmt.Sprintf("%s: %s", levelName[p&7], msg)
+func (w *mockWriter) logAtLevel(p syslog.Priority, msg string, a ...interface{}) {
+	format := fmt.Sprintf(msg, a...)
+	w.msgChan <- fmt.Sprintf("%s: %s", levelName[p&7], format)
 }
 
 // newMockWriter returns a new mockWriter
@@ -143,8 +144,9 @@ func newWaitingMockWriter() *waitingMockWriter {
 	}
 }
 
-func (m *waitingMockWriter) logAtLevel(p syslog.Priority, msg string) {
-	m.logChan <- fmt.Sprintf("%s: %s", levelName[p&7], msg)
+func (m *waitingMockWriter) logAtLevel(p syslog.Priority, msg string, a ...interface{}) {
+	format := fmt.Sprintf(msg, a...)
+	m.logChan <- fmt.Sprintf("%s: %s", levelName[p&7], format)
 }
 
 // WaitForMatch returns the first log line matching a regex. It accepts a


### PR DESCRIPTION
The Debug, Info, Warn, and Err log levels are now helper functions that call their respective <LogLevel>f function. Each <LogLevel>f function takes a variadic amount of format specifiers to pass to auditAtLevel or logAtLevel which in turn will perform a nil check on the variadic input parameter 'a' and call/ignore an Sprintf accordingly.

Fixes #6131 