### PR TITLE
Remove note saying specific crl x509 differs from upstream

### DIFF
--- a/crl/crl_x509/crl.go
+++ b/crl/crl_x509/crl.go
@@ -281,7 +281,6 @@ func ParseRevocationList(der []byte) (*RevocationList, error) {
 			if err != nil {
 				return nil, err
 			}
-			// NOTE: The block does not exist in upstream.
 			if ext.Id.Equal(oidExtensionAuthorityKeyId) {
 				rl.AuthorityKeyId = ext.Value
 			} else if ext.Id.Equal(oidExtensionCRLNumber) {


### PR DESCRIPTION
This block does exist in upstream now (Thanks Aaron for PRing this up).

https://github.com/golang/go/blob/74a9d283e4d498b78521f4a40c23b4c3f5ff7387/src/crypto/x509/parser.go#L1161