### PR TITLE
CA: Fail construction if no issuers are provided

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -132,8 +132,7 @@ func NewCertificateAuthorityImpl(
 	}
 
 	if len(boulderIssuers) == 0 {
-		err := errors.New("must have at least one issuer.")
-		return nil, err
+		return nil, errors.New("must have at least one issuer")
 	}
 
 	issuers := makeIssuerMaps(boulderIssuers)

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -132,7 +132,7 @@ func NewCertificateAuthorityImpl(
 	}
 
 	if len(boulderIssuers) == 0 {
-		err := errors.New("No issuers found, must have at least one issuer.")
+		err := errors.New("no issuers found, must have at least one issuer.")
 		return nil, err
 	}
 

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -79,11 +79,7 @@ type certificateAuthorityImpl struct {
 // nearly-unique identifiers of those issuers to the issuers themselves. Note
 // that, if two issuers have the same nearly-unique ID, the *latter* one in
 // the input list "wins".
-func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
-	if len(issuers) == 0 {
-		err := errors.New("No issuers found, must have at least one issuer.")
-		return issuerMaps{}, err
-	}
+func makeIssuerMaps(issuers []*issuance.Issuer) issuerMaps {
 	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*issuance.Issuer, 2)
 	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Issuer, len(issuers))
 	for _, issuer := range issuers {
@@ -96,7 +92,7 @@ func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
 		}
 		issuersByNameID[issuer.Cert.NameID()] = issuer
 	}
-	return issuerMaps{issuersByAlg, issuersByNameID}, nil
+	return issuerMaps{issuersByAlg, issuersByNameID}
 }
 
 // NewCertificateAuthorityImpl creates a CA instance that can sign certificates
@@ -135,10 +131,12 @@ func NewCertificateAuthorityImpl(
 		return nil, err
 	}
 
-	issuers, err := makeIssuerMaps(boulderIssuers)
-	if err != nil {
+	if len(boulderIssuers) == 0 {
+		err := errors.New("No issuers found, must have at least one issuer.")
 		return nil, err
 	}
+
+	issuers := makeIssuerMaps(boulderIssuers)
 
 	orphanCount := prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -132,7 +132,7 @@ func NewCertificateAuthorityImpl(
 	}
 
 	if len(boulderIssuers) == 0 {
-		err := errors.New("no issuers found, must have at least one issuer.")
+		err := errors.New("must have at least one issuer.")
 		return nil, err
 	}
 

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -443,7 +443,7 @@ func TestNoIssuers(t *testing.T) {
 		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertError(t, err, "No issuers found during CA construction.")
-	test.AssertEquals(t, err.Error(), "No issuers found, must have at least one issuer.")
+	test.AssertEquals(t, err.Error(), "no issuers found, must have at least one issuer.")
 }
 
 // Test issuing when multiple issuers are present.

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -443,7 +443,7 @@ func TestNoIssuers(t *testing.T) {
 		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertError(t, err, "No issuers found during CA construction.")
-	test.AssertEquals(t, err.Error(), "no issuers found, must have at least one issuer.")
+	test.AssertEquals(t, err.Error(), "must have at least one issuer.")
 }
 
 // Test issuing when multiple issuers are present.

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -421,6 +421,31 @@ func issueCertificateSubTestValidityUsesCAClock(t *testing.T, i *TestCertificate
 	test.AssertEquals(t, i.cert.NotAfter.Add(time.Second).Sub(i.cert.NotBefore), i.ca.validityPeriod)
 }
 
+// Test failure mode when no issuers are present.
+func TestNoIssuers(t *testing.T) {
+	testCtx := setup(t)
+	sa := &mockSA{}
+	_, err := NewCertificateAuthorityImpl(
+		sa,
+		testCtx.pa,
+		testCtx.ocsp,
+		nil, // No issuers
+		nil,
+		testCtx.certExpiry,
+		testCtx.certBackdate,
+		testCtx.serialPrefix,
+		testCtx.maxNames,
+		testCtx.keyPolicy,
+		nil,
+		testCtx.logger,
+		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
+		testCtx.fc)
+	test.AssertError(t, err, "No issuers found during CA construction.")
+	test.AssertEquals(t, err.Error(), "No issuers found, must have at least one issuer.")
+}
+
 // Test issuing when multiple issuers are present.
 func TestMultipleIssuers(t *testing.T) {
 	testCtx := setup(t)

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -443,7 +443,7 @@ func TestNoIssuers(t *testing.T) {
 		testCtx.signErrorCount,
 		testCtx.fc)
 	test.AssertError(t, err, "No issuers found during CA construction.")
-	test.AssertEquals(t, err.Error(), "must have at least one issuer.")
+	test.AssertEquals(t, err.Error(), "must have at least one issuer")
 }
 
 // Test issuing when multiple issuers are present.


### PR DESCRIPTION
If a CA config is created with an empty `issuers[]` json, then the CA should fail to start up. With no issuers present, the integration tests fail with the following error.
```
2023-03-09T20:35:26.789057+00:00Z 984f6bda59f5 unknown boulder-ra[973]: 6 boulder-ra tIiaHAA [AUDIT] Certificate request - error JSON={"ID":"X50PaQV2fEPO8cEty4c_UHVH0k8XgeysrHFiPAC_1Ig","Requester":4,"OrderID":4,"VerifiedFields":["subject.commonName","subjectAltName"],"NotBefore":"0001-01-01T00:00:00Z","NotAfter":"0001-01-01T00:00:00Z","RequestTime":"2022-09-10T20:35:20Z","ResponseTime":"2022-09-10T20:35:20Z","Error":"issuing precertificate: no issuer found for public key algorithm RSA","Authorizations":{"rand.d9f6c160.xyz":{"ID":"4","ChallengeType":"dns-01"}}}
```

Fixes https://github.com/letsencrypt/boulder/issues/6735