### PR TITLE
Use 401 for Unauthorized, not 403

### DIFF
--- a/probs/probs.go
+++ b/probs/probs.go
@@ -97,9 +97,9 @@ func ProblemDetailsToStatusCode(prob *ProblemDetails) int {
 		return http.StatusBadRequest
 	case ServerInternalProblem:
 		return http.StatusInternalServerError
-	case
-		UnauthorizedProblem,
-		CAAProblem:
+	case UnauthorizedProblem:
+		return http.StatusUnauthorized
+	case CAAProblem:
 		return http.StatusForbidden
 	case RateLimitedProblem:
 		return statusTooManyRequests
@@ -220,7 +220,7 @@ func Unauthorized(detail string) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       UnauthorizedProblem,
 		Detail:     detail,
-		HTTPStatus: http.StatusForbidden,
+		HTTPStatus: http.StatusUnauthorized,
 	}
 }
 


### PR DESCRIPTION
DO NOT MERGE I intend to use this PR as a place for discussion first. I'm not 100% convinced this is the right thing to do, and would like to solicit others' opinions.

A 401 "indicates that the client request has not been completed because it lacks valid authentication credentials for the requested resource." In contrast, a 403 "indicates that the server understands the request but refuses to authorize it." These both seem like reasonable status codes to accompany RFC8555's Unathorized, except that [the MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) also has this to say about 401: "This status code is similar to the 403 Forbidden status code, except that in situations resulting in this status code, user authentication can allow access to the resource."

Most of our Unauthorized return paths are due to the authenticated RegID not being the correct owner of the accessed resource (e.g. order, authz). It seems to me like that matches better with 401, because they could access it if they authenticated properly.

But maybe a bunch of clients would break if we did this? Maybe there are other Unauthorized return paths which more correctly map onto 403, and we should preserve those? Thoughts and opinions apprecated.