### PR TITLE
Nonce: Simplify Nonce Redeemer testing

### DIFF
--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -360,7 +360,7 @@ type Getter interface {
 	Nonce(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*noncepb.NonceMessage, error)
 }
 
-// Getter is an interface for an RPC client that can redeem a nonce.
+// Redeemer is an interface for an RPC client that can redeem a nonce.
 type Redeemer interface {
 	Redeem(ctx context.Context, in *noncepb.NonceMessage, opts ...grpc.CallOption) (*noncepb.ValidMessage, error)
 }

--- a/nonce/nonce_test.go
+++ b/nonce/nonce_test.go
@@ -181,14 +181,14 @@ func TestRemoteRedeem(t *testing.T) {
 	_, err = RemoteRedeem(context.Background(), prefixMap, "abcdbeef")
 	test.AssertError(t, err, "RemoteRedeem didn't return error when remote did")
 
-	// Attempt to redeem a nonce with a prefix in the prefix map, remote returns valid
-	// expect true, nil
+	// Attempt to redeem a nonce with a prefix in the prefix map, remote returns invalid
+	// expect false, nil
 	valid, err = RemoteRedeem(context.Background(), prefixMap, "wxyzdead")
 	test.AssertNotError(t, err, "RemoteRedeem failed")
 	test.Assert(t, !valid, "RemoteRedeem didn't honor remote result")
 
-	// Attempt to redeem a nonce with a prefix in the prefix map, remote returns invalid
-	// expect false, nil
+	// Attempt to redeem a nonce with a prefix in the prefix map, remote returns valid
+	// expect true, nil
 	prefixMap["wxyz"] = &validRedeemer{}
 	valid, err = RemoteRedeem(context.Background(), prefixMap, "wxyzdead")
 	test.AssertNotError(t, err, "RemoteRedeem failed")


### PR DESCRIPTION
Implements three nonce redeemer clients that are either valid, invalid, or broken.

Fixes https://github.com/letsencrypt/boulder/issues/6701