### PR TITLE
"go mod tidy" before "go mod vendor" in test.sh / CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,9 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/test.sh
+++ b/test.sh
@@ -258,6 +258,8 @@ fi
 # vendor/ really exist in the remote repo and match what we have.
 STAGE="gomod-vendor"
 if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
+  print_heading "Running Go Mod Tidy"
+  go mod tidy
   print_heading "Running Go Mod Vendor"
   go mod vendor
   run_and_expect_silence git diff --exit-code .

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -216,6 +216,8 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rogpeppe/go-internal v1.9.0
+## explicit; go 1.17
 # github.com/syndtr/goleveldb v1.0.0
 ## explicit
 github.com/syndtr/goleveldb/leveldb


### PR DESCRIPTION
This ensures that not only have we consistently vendored the dependencies but also checks our modules are "Tidy".

Currently they are not, and so this commits a "go mod tidy" / "go mod vendor" change.  However, that change is somewhat confusing:  Why did removing a dependency (beeline, in #6733) add a new indirect dependency?  I'm not sure enough about the internals of module loading (especially the lazy / pruning parts) to fully understand.

But certainly there's a legimite-looking dependency path:

```
$ go mod why -m github.com/rogpeppe/go-internal
# github.com/rogpeppe/go-internal
github.com/letsencrypt/boulder/cmd/ceremony
gopkg.in/yaml.v3
gopkg.in/yaml.v3.test
gopkg.in/check.v1
github.com/kr/pretty
github.com/rogpeppe/go-internal/fmtsort
```

Any of the currently-open dependabot PRs are also pulling in rogpeppe/go-internal so if one of them merges first, it'll drop off this PR.