### PR TITLE
Change SetCommonName to RequireCommonName

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -442,13 +442,11 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		PublicKey:         csr.PublicKey,
 		Serial:            serialBigInt.Bytes(),
 		DNSNames:          names.SANs,
+		CommonName:        names.CN,
 		IncludeCTPoison:   true,
 		IncludeMustStaple: issuance.ContainsMustStaple(csr.Extensions),
 		NotBefore:         validity.NotBefore,
 		NotAfter:          validity.NotAfter,
-	}
-	if features.Enabled(features.SetCommonName) {
-		req.CommonName = names.CN
 	}
 
 	certDER, err := issuer.Issue(req)

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -75,7 +75,7 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	if len(names.SANs) == 0 && names.CN == "" {
 		return invalidNoDNS
 	}
-	if names.CN == "" && features.Enabled(features.SetCommonName) {
+	if names.CN == "" && features.Enabled(features.RequireCommonName) {
 		return invalidAllSANTooLong
 	}
 	if len(names.CN) > maxCNLength {
@@ -102,18 +102,16 @@ type names struct {
 }
 
 // NamesFromCSR deduplicates and lower-cases the Subject Common Name and Subject
-// Alternative Names from the CSR. It guarantees that the SANs include the CN.
-// It also enforces various conditions on the CN, based on feature flags.
+// Alternative Names from the CSR. If the CSR contains a CN, then it preserves
+// it and guarantees that the SANs also include it. If the CSR does not contain
+// a CN, then it also attempts to promote a SAN to the CN (if any is short
+// enough to fit).
 func NamesFromCSR(csr *x509.CertificateRequest) names {
 	sans := csr.DNSNames
 	if csr.Subject.CommonName != "" {
 		sans = append(sans, csr.Subject.CommonName)
 	}
 	sans = core.UniqueLowerNames(sans)
-
-	if !features.Enabled(features.SetCommonName) {
-		return names{SANs: sans}
-	}
 
 	if csr.Subject.CommonName != "" {
 		return names{SANs: sans, CN: strings.ToLower(csr.Subject.CommonName)}

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -218,59 +218,6 @@ func TestNamesFromCSR(t *testing.T) {
 	}
 }
 
-func TestNamesFromCSROmitCommonName(t *testing.T) {
-	features.Set(map[string]bool{features.SetCommonName.String(): false})
-	defer features.Reset()
-
-	tooLongString := strings.Repeat("a", maxCNLength+1)
-
-	cases := []struct {
-		name          string
-		csr           *x509.CertificateRequest
-		expectedNames []string
-	}{
-		{
-			"no explicit CN",
-			&x509.CertificateRequest{DNSNames: []string{"a.com"}},
-			[]string{"a.com"},
-		},
-		{
-			"explicit uppercase CN",
-			&x509.CertificateRequest{Subject: pkix.Name{CommonName: "A.com"}, DNSNames: []string{"a.com"}},
-			[]string{"a.com"},
-		},
-		{
-			"no explicit CN, too long leading SANs",
-			&x509.CertificateRequest{DNSNames: []string{
-				tooLongString + ".a.com",
-				tooLongString + ".b.com",
-				"a.com",
-				"b.com",
-			}},
-			[]string{"a.com", tooLongString + ".a.com", tooLongString + ".b.com", "b.com"},
-		},
-		{
-			"explicit CN, too long leading SANs",
-			&x509.CertificateRequest{
-				Subject: pkix.Name{CommonName: "A.com"},
-				DNSNames: []string{
-					tooLongString + ".a.com",
-					tooLongString + ".b.com",
-					"a.com",
-					"b.com",
-				}},
-			[]string{"a.com", tooLongString + ".a.com", tooLongString + ".b.com", "b.com"},
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			names := NamesFromCSR(tc.csr)
-			test.AssertEquals(t, names.CN, "")
-			test.AssertDeepEquals(t, names.SANs, tc.expectedNames)
-		})
-	}
-}
-
 func TestSHA1Deprecation(t *testing.T) {
 	features.Reset()
 

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -23,12 +23,12 @@ func _() {
 	_ = x[CertCheckerChecksValidations-12]
 	_ = x[CertCheckerRequiresValidations-13]
 	_ = x[AsyncFinalize-14]
-	_ = x[SetCommonName-15]
+	_ = x[RequireCommonName-15]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsAsyncFinalizeSetCommonName"
+const _FeatureFlag_name = "unusedStoreRevokerInfoCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesROCSPStage6ROCSPStage7ExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsAsyncFinalizeRequireCommonName"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 98, 114, 139, 150, 161, 185, 213, 243, 256, 269}
+var _FeatureFlag_index = [...]uint16{0, 6, 22, 42, 55, 69, 87, 98, 114, 139, 150, 161, 185, 213, 243, 256, 273}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -67,11 +67,14 @@ const (
 	// of "orphaned" certs we have. However, it also requires clients to properly
 	// implement polling the Order object to wait for the cert URL to appear.
 	AsyncFinalize
-	// SetCommonName defaults to true, and causes the CA to include the commonName
-	// field in the certificate Subject. When false, the commonName will be
-	// omitted. According to the BRs Section 7.1.4.2.2(a), the commonName field is
-	// Deprecated, and its inclusion is Discouraged but not (yet) prohibited.
-	SetCommonName
+
+	// RequireCommonName defaults to true, and causes the CA to fail to issue a
+	// certificate if there is no CommonName in the certificate. When false, the
+	// CA will be willing to issue certificates with no CN.
+	//
+	// According to the BRs Section 7.1.4.2.2(a), the commonName field is
+	// Deprecated, and its inclusion is discouraged but not (yet) prohibited.
+	RequireCommonName
 )
 
 // List of features and their default value, protected by fMu
@@ -91,7 +94,7 @@ var features = map[FeatureFlag]bool{
 	CertCheckerChecksValidations:   false,
 	CertCheckerRequiresValidations: false,
 	AsyncFinalize:                  false,
-	SetCommonName:                  true,
+	RequireCommonName:              true,
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -49,7 +49,7 @@
         "allowMustStaple": true,
         "allowCTPoison": true,
         "allowSCTList": true,
-        "allowCommonName": false,
+        "allowCommonName": true,
         "policies": [
           {
             "oid": "2.23.140.1.2.1"
@@ -125,7 +125,7 @@
     "ctLogListFile": "test/ct-test-srv/log_list.json",
     "features": {
       "ROCSPStage7": true,
-      "SetCommonName": false
+      "RequireCommonName": false
     }
   },
 

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -49,7 +49,7 @@
         "allowMustStaple": true,
         "allowCTPoison": true,
         "allowSCTList": true,
-        "allowCommonName": false,
+        "allowCommonName": true,
         "policies": [
           {
             "oid": "2.23.140.1.2.1"
@@ -125,7 +125,7 @@
     "ctLogListFile": "test/ct-test-srv/log_list.json",
     "features": {
       "ROCSPStage7": true,
-      "SetCommonName": false
+      "RequireCommonName": false
     }
   },
 

--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -52,7 +52,7 @@ func TestARI(t *testing.T) {
 
 	// Issue a cert.
 	name := random_domain()
-	ir, err := authAndIssue(client, key, []string{name})
+	ir, err := authAndIssue(client, key, []string{name}, true)
 	test.AssertNotError(t, err, "failed to issue test cert")
 	cert := ir.certs[0]
 
@@ -104,7 +104,7 @@ func TestARI(t *testing.T) {
 	name = random_domain()
 	err = ctAddRejectHost(name)
 	test.AssertNotError(t, err, "failed to add ct-test-srv reject host")
-	_, err = authAndIssue(client, key, []string{name})
+	_, err = authAndIssue(client, key, []string{name}, true)
 	test.AssertError(t, err, "expected error from authAndIssue, was nil")
 	cert, err = ctFindRejection([]string{name})
 	test.AssertNotError(t, err, "failed to find rejected precert")

--- a/test/integration/authz_test.go
+++ b/test/integration/authz_test.go
@@ -27,7 +27,7 @@ func TestValidAuthzExpires(t *testing.T) {
 
 	// Issue for a random domain
 	domains := []string{random_domain()}
-	result, err := authAndIssue(c, nil, domains)
+	result, err := authAndIssue(c, nil, domains, true)
 	// There should be no error
 	test.AssertNotError(t, err, "authAndIssue failed")
 	// The order should be valid

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -19,7 +19,7 @@ func TestCAALogChecker(t *testing.T) {
 	test.AssertNotError(t, err, "makeClient failed")
 
 	domains := []string{random_domain()}
-	result, err := authAndIssue(c, nil, domains)
+	result, err := authAndIssue(c, nil, domains, true)
 	test.AssertNotError(t, err, "authAndIssue failed")
 	test.AssertEquals(t, result.Order.Status, "valid")
 	test.AssertEquals(t, len(result.Order.Authorizations), 1)

--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -43,7 +43,7 @@ func TestCRLPipeline(t *testing.T) {
 	configFile := path.Join(configDir, "crl-updater.json")
 
 	// Issue a test certificate and save its serial number.
-	res, err := authAndIssue(client, nil, []string{random_domain()})
+	res, err := authAndIssue(client, nil, []string{random_domain()}, true)
 	test.AssertNotError(t, err, "failed to create test certificate")
 	cert := res.certs[0]
 	serial := core.SerialToString(cert.SerialNumber)

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -24,7 +24,7 @@ func TestTooBigOrderError(t *testing.T) {
 		domains = append(domains, fmt.Sprintf("%d.example.com", i))
 	}
 
-	_, err := authAndIssue(nil, nil, domains)
+	_, err := authAndIssue(nil, nil, domains, true)
 	test.AssertError(t, err, "authAndIssue failed")
 
 	var prob acme.Problem

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -13,7 +14,9 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestCommonName(t *testing.T) {
+// TestCommonNameInCSR ensures that CSRs which have a CN set result in certs
+// with the same CN set.
+func TestCommonNameInCSR(t *testing.T) {
 	t.Parallel()
 
 	// Create an account.
@@ -31,7 +34,7 @@ func TestCommonName(t *testing.T) {
 	san2 := random_domain()
 
 	// Issue a cert. authAndIssue includes the 0th name as the CN by default.
-	ir, err := authAndIssue(client, key, []string{cn, san1, san2})
+	ir, err := authAndIssue(client, key, []string{cn, san1, san2}, true)
 	test.AssertNotError(t, err, "failed to issue test cert")
 	cert := ir.certs[0]
 
@@ -40,12 +43,78 @@ func TestCommonName(t *testing.T) {
 	test.AssertSliceContains(t, cert.DNSNames, san1)
 	test.AssertSliceContains(t, cert.DNSNames, san2)
 
-	// Ensure that the CN is (or is not) set, per the SetCommonName flag.
-	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
-		// In config-next, the SetCommonName flag is false.
-		test.AssertEquals(t, cert.Subject.CommonName, "")
-	} else {
-		// In config, the SetCommonName flag is true.
-		test.AssertEquals(t, cert.Subject.CommonName, cn)
+	// Ensure that the CN is preserved as the CN.
+	test.AssertEquals(t, cert.Subject.CommonName, cn)
+}
+
+// TestCommonNameHoisted ensures that CSRs which have no CN set result in certs
+// with one of their SANs hoisted into the CN field.
+func TestCommonNameHoisted(t *testing.T) {
+	t.Parallel()
+
+	// Create an account.
+	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
+	client, err := makeClient("mailto:example@letsencrypt.org")
+	test.AssertNotError(t, err, "creating acme client")
+
+	// Create a private key.
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "creating random cert key")
+
+	// Put together some names.
+	san1 := random_domain()
+	san2 := random_domain()
+
+	// Issue a cert using a CSR with no CN set.
+	ir, err := authAndIssue(client, key, []string{san1, san2}, false)
+	test.AssertNotError(t, err, "failed to issue test cert")
+	cert := ir.certs[0]
+
+	// Ensure that the SANs are correct.
+	test.AssertSliceContains(t, cert.DNSNames, san1)
+	test.AssertSliceContains(t, cert.DNSNames, san2)
+
+	// Ensure that one of the SANs is the CN.
+	test.Assert(t, cert.Subject.CommonName == san1 || cert.Subject.CommonName == san2, "SAN should have been hoisted")
+}
+
+// TestCommonNameSANsTooLong tests that, when the names in an order and CSR are
+// too long to be hoisted into the CN, the correct behavior results (depending
+// on the state of the RequireCommonName feature flag).
+func TestCommonNameSANsTooLong(t *testing.T) {
+	t.Parallel()
+
+	// Create an account.
+	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
+	client, err := makeClient("mailto:example@letsencrypt.org")
+	test.AssertNotError(t, err, "creating acme client")
+
+	// Create a private key.
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "creating random cert key")
+
+	// Put together some names.
+	san1 := fmt.Sprintf("thisdomainnameismorethan64characterslongforthesakeoftesting-%s", random_domain())
+	san2 := fmt.Sprintf("thisdomainnameismorethan64characterslongforthesakeoftesting-%s", random_domain())
+
+	// Issue a cert using a CSR with no CN set.
+	ir, err := authAndIssue(client, key, []string{san1, san2}, false)
+
+	// By default, the RequireCommonName flag is true, so issuance should have failed.
+	if !strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
+		test.AssertError(t, err, "issuing cert with no CN")
+		return
 	}
+
+	// But in config-next, the RequireCommonName flag is false, so issuance should
+	// have succeeded.
+	test.AssertNotError(t, err, "failed to issue test cert")
+	cert := ir.certs[0]
+
+	// Ensure that the SANs are correct.
+	test.AssertSliceContains(t, cert.DNSNames, san1)
+	test.AssertSliceContains(t, cert.DNSNames, san2)
+
+	// Ensure that the CN is empty.
+	test.AssertEquals(t, cert.Subject.CommonName, "")
 }

--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -41,7 +41,7 @@ func TestOCSPBadSerialPrefix(t *testing.T) {
 	t.Parallel()
 	domain := random_domain()
 	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
-	res, err := authAndIssue(nil, nil, []string{domain})
+	res, err := authAndIssue(nil, nil, []string{domain}, true)
 	if err != nil || len(res.certs) < 1 {
 		t.Fatal("Failed to issue dummy cert for OCSP testing")
 	}
@@ -75,7 +75,7 @@ func TestOCSPRejectedPrecertificate(t *testing.T) {
 	}
 
 	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
-	_, err = authAndIssue(nil, nil, []string{domain})
+	_, err = authAndIssue(nil, nil, []string{domain}, true)
 	if err != nil {
 		if !strings.Contains(err.Error(), "urn:ietf:params:acme:error:serverInternal") ||
 			!strings.Contains(err.Error(), "SCT embedding") {

--- a/test/integration/ratelimit_test.go
+++ b/test/integration/ratelimit_test.go
@@ -14,12 +14,12 @@ func TestDuplicateFQDNRateLimit(t *testing.T) {
 	domain := random_domain()
 	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
-	_, err := authAndIssue(nil, nil, []string{domain})
+	_, err := authAndIssue(nil, nil, []string{domain}, true)
 	test.AssertNotError(t, err, "Failed to issue first certificate")
 
-	_, err = authAndIssue(nil, nil, []string{domain})
+	_, err = authAndIssue(nil, nil, []string{domain}, true)
 	test.AssertNotError(t, err, "Failed to issue second certificate")
 
-	_, err = authAndIssue(nil, nil, []string{domain})
+	_, err = authAndIssue(nil, nil, []string{domain}, true)
 	test.AssertError(t, err, "Somehow managed to issue third certificate")
 }

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -97,7 +97,7 @@ func TestRevocation(t *testing.T) {
 			var cert *x509.Certificate
 			switch tc.kind {
 			case finalcert:
-				res, err := authAndIssue(issueClient, certKey, []string{domain})
+				res, err := authAndIssue(issueClient, certKey, []string{domain}, true)
 				test.AssertNotError(t, err, "authAndIssue failed")
 				cert = res.certs[0]
 
@@ -107,7 +107,7 @@ func TestRevocation(t *testing.T) {
 				err := ctAddRejectHost(domain)
 				test.AssertNotError(t, err, "adding ct-test-srv reject host")
 
-				_, err = authAndIssue(issueClient, certKey, []string{domain})
+				_, err = authAndIssue(issueClient, certKey, []string{domain}, true)
 				test.AssertError(t, err, "expected error from authAndIssue, was nil")
 				if !strings.Contains(err.Error(), "urn:ietf:params:acme:error:serverInternal") ||
 					!strings.Contains(err.Error(), "SCT embedding") {
@@ -150,7 +150,7 @@ func TestRevocation(t *testing.T) {
 				// issuance.
 				revokeClient, err = makeClient()
 				test.AssertNotError(t, err, "creating second acme client")
-				_, _ = authAndIssue(revokeClient, certKey, []string{domain})
+				_, _ = authAndIssue(revokeClient, certKey, []string{domain}, true)
 				revokeKey = revokeClient.PrivateKey
 
 			case byKey:
@@ -238,7 +238,7 @@ func TestReRevocation(t *testing.T) {
 
 			// Try to issue a certificate for the name.
 			domain := random_domain()
-			res, err := authAndIssue(issueClient, certKey, []string{domain})
+			res, err := authAndIssue(issueClient, certKey, []string{domain}, true)
 			test.AssertNotError(t, err, "authAndIssue failed")
 			cert := res.certs[0]
 
@@ -353,7 +353,7 @@ func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 		certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		test.AssertNotError(t, err, "failed to generate cert key")
 
-		res, err := authAndIssue(c, certKey, []string{random_domain()})
+		res, err := authAndIssue(c, certKey, []string{random_domain()}, true)
 		test.AssertNotError(t, err, "authAndIssue failed")
 		cert := res.certs[0]
 
@@ -404,14 +404,14 @@ func TestBadKeyRevoker(t *testing.T) {
 	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	test.AssertNotError(t, err, "failed to generate cert key")
 
-	res, err := authAndIssue(revokerClient, certKey, []string{random_domain()})
+	res, err := authAndIssue(revokerClient, certKey, []string{random_domain()}, true)
 	test.AssertNotError(t, err, "authAndIssue failed")
 	badCert := res.certs[0]
 	t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
 
 	certs := []*x509.Certificate{}
 	for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
-		cert, err := authAndIssue(c, certKey, []string{random_domain()})
+		cert, err := authAndIssue(c, certKey, []string{random_domain()}, true)
 		t.Logf("TestBadKeyRevoker: Issued cert with serial %x", cert.certs[0].SerialNumber)
 		test.AssertNotError(t, err, "authAndIssue failed")
 		certs = append(certs, cert.certs[0])
@@ -484,14 +484,14 @@ func TestBadKeyRevokerByAccount(t *testing.T) {
 	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	test.AssertNotError(t, err, "failed to generate cert key")
 
-	res, err := authAndIssue(revokerClient, certKey, []string{random_domain()})
+	res, err := authAndIssue(revokerClient, certKey, []string{random_domain()}, true)
 	test.AssertNotError(t, err, "authAndIssue failed")
 	badCert := res.certs[0]
 	t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
 
 	certs := []*x509.Certificate{}
 	for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
-		cert, err := authAndIssue(c, certKey, []string{random_domain()})
+		cert, err := authAndIssue(c, certKey, []string{random_domain()}, true)
 		t.Logf("TestBadKeyRevokerByAccount: Issued cert with serial %x", cert.certs[0].SerialNumber)
 		test.AssertNotError(t, err, "authAndIssue failed")
 		certs = append(certs, cert.certs[0])


### PR DESCRIPTION
Change the SetCommonName flag, introduced in #6706, to RequireCommonName. Rather than having the flag control both whether or not a name is hoisted from the SANs into the CN *and* whether or not the CA is willing to issue certs with no CN, this updated flag now only controls the latter.

When we have rolled out this change, we can move on to the next flag in this series: HoistCommonName, which will control whether or not a SAN is hoisted at all, effectively giving the CSRs (and therefore the clients) full control over whether their certificate contains a SAN.

This change is safe because no environment explicitly sets the SetCommonName flag to false yet.

Fixes #5112