### PR TITLE
lints: Consistently format JSON configuration files

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -218,8 +218,8 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   run_and_expect_silence codespell \
     --ignore-words=.codespell.ignore.txt \
     --skip=.git,.gocache,go.sum,go.mod,vendor,bin,*.pyc,*.pem,*.der,*.resp,*.req,*.csr,.codespell.ignore.txt,.*.swp
-  # Check test configs are formatted consistently
-  find test/config test/config-next -name \*.json -exec sh -c 'python3 -m json.tool "$1" "$1.tmp" && mv "$1.tmp" "$1"' shell {} \;
+  # Check test JSON configs are formatted consistently
+  ./test/format-configs.py
   run_and_expect_silence git diff --exit-code .
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -219,7 +219,7 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
     --ignore-words=.codespell.ignore.txt \
     --skip=.git,.gocache,go.sum,go.mod,vendor,bin,*.pyc,*.pem,*.der,*.resp,*.req,*.csr,.codespell.ignore.txt,.*.swp
   # Check test JSON configs are formatted consistently
-  ./test/format-configs.py
+  ./test/format-configs.py "test/config*/*.json"
   run_and_expect_silence git diff --exit-code .
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -219,7 +219,7 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
     --ignore-words=.codespell.ignore.txt \
     --skip=.git,.gocache,go.sum,go.mod,vendor,bin,*.pyc,*.pem,*.der,*.resp,*.req,*.csr,.codespell.ignore.txt,.*.swp
   # Check test JSON configs are formatted consistently
-  ./test/format-configs.py "test/config*/*.json"
+  ./test/format-configs.py 'test/config*/*.json'
   run_and_expect_silence git diff --exit-code .
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -218,6 +218,9 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   run_and_expect_silence codespell \
     --ignore-words=.codespell.ignore.txt \
     --skip=.git,.gocache,go.sum,go.mod,vendor,bin,*.pyc,*.pem,*.der,*.resp,*.req,*.csr,.codespell.ignore.txt,.*.swp
+  # Check test configs are formatted consistently
+  find test/config test/config-next -name \*.json -exec sh -c 'python3 -m json.tool "$1" "$1.tmp" && mv "$1.tmp" "$1"' shell {} \;
+  run_and_expect_silence git diff --exit-code .
 fi
 
 #

--- a/test/config-next/admin-revoker.json
+++ b/test/config-next/admin-revoker.json
@@ -1,36 +1,36 @@
 {
-    "revoker": {
-        "db": {
-            "dbConnectFile": "test/secrets/revoker_dburl",
-            "maxOpenConns": 1
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
-        },
-        "raService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ra",
-                "domain": "service.consul"
-            },
-            "hostOverride": "ra.boulder",
-            "timeout": "15s"
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"revoker": {
+		"db": {
+			"dbConnectFile": "test/secrets/revoker_dburl",
+			"maxOpenConns": 1
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
+		},
+		"raService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
+			"hostOverride": "ra.boulder",
+			"timeout": "15s"
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/admin-revoker.json
+++ b/test/config-next/admin-revoker.json
@@ -1,36 +1,36 @@
 {
-  "revoker": {
-    "db": {
-      "dbConnectFile": "test/secrets/revoker_dburl",
-      "maxOpenConns": 1
+    "revoker": {
+        "db": {
+            "dbConnectFile": "test/secrets/revoker_dburl",
+            "maxOpenConns": 1
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
+        },
+        "raService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ra",
+                "domain": "service.consul"
+            },
+            "hostOverride": "ra.boulder",
+            "timeout": "15s"
+        },
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "features": {}
     },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
-    },
-    "raService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ra",
-        "domain": "service.consul"
-      },
-      "hostOverride": "ra.boulder",
-      "timeout": "15s"
-    },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "features": {}
-  },
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -1,42 +1,41 @@
 {
-  "akamaiPurger": {
-    "debugAddr": ":9666",
-    "purgeRetries": 10,
-    "purgeRetryBackoff": "50ms",
-    "throughput": {
-      "queueEntriesPerBatch": 2,
-      "purgeBatchInterval": "32ms"
-    },
-    "baseURL": "http://localhost:6789",
-    "clientToken": "its-a-token",
-    "clientSecret": "its-a-secret",
-    "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
-    "v3Network": "staging",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
-    },
-    "grpc": {
-      "address": ":9099",
-      "maxConnectionAge": "30s",
-      "services": {
-        "akamai.AkamaiPurger": {
-          "clientNames": [
-            "ra.boulder"
-          ]
+    "akamaiPurger": {
+        "debugAddr": ":9666",
+        "purgeRetries": 10,
+        "purgeRetryBackoff": "50ms",
+        "throughput": {
+            "queueEntriesPerBatch": 2,
+            "purgeBatchInterval": "32ms"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
+        "baseURL": "http://localhost:6789",
+        "clientToken": "its-a-token",
+        "clientSecret": "its-a-secret",
+        "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
+        "v3Network": "staging",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
+        },
+        "grpc": {
+            "address": ":9099",
+            "maxConnectionAge": "30s",
+            "services": {
+                "akamai.AkamaiPurger": {
+                    "clientNames": [
+                        "ra.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         }
-      }
+    },
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
 }

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -1,41 +1,41 @@
 {
-    "akamaiPurger": {
-        "debugAddr": ":9666",
-        "purgeRetries": 10,
-        "purgeRetryBackoff": "50ms",
-        "throughput": {
-            "queueEntriesPerBatch": 2,
-            "purgeBatchInterval": "32ms"
-        },
-        "baseURL": "http://localhost:6789",
-        "clientToken": "its-a-token",
-        "clientSecret": "its-a-secret",
-        "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
-        "v3Network": "staging",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
-        },
-        "grpc": {
-            "address": ":9099",
-            "maxConnectionAge": "30s",
-            "services": {
-                "akamai.AkamaiPurger": {
-                    "clientNames": [
-                        "ra.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"akamaiPurger": {
+		"debugAddr": ":9666",
+		"purgeRetries": 10,
+		"purgeRetryBackoff": "50ms",
+		"throughput": {
+			"queueEntriesPerBatch": 2,
+			"purgeBatchInterval": "32ms"
+		},
+		"baseURL": "http://localhost:6789",
+		"clientToken": "its-a-token",
+		"clientSecret": "its-a-secret",
+		"accessToken": "idk-how-this-is-different-from-client-token-but-okay",
+		"v3Network": "staging",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
+		},
+		"grpc": {
+			"address": ":9099",
+			"maxConnectionAge": "30s",
+			"services": {
+				"akamai.AkamaiPurger": {
+					"clientNames": [
+						"ra.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -1,41 +1,41 @@
 {
-  "BadKeyRevoker": {
-    "db": {
-      "dbConnectFile": "test/secrets/badkeyrevoker_dburl",
-      "maxOpenConns": 10
+    "BadKeyRevoker": {
+        "db": {
+            "dbConnectFile": "test/secrets/badkeyrevoker_dburl",
+            "maxOpenConns": 10
+        },
+        "debugAddr": ":8020",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
+        },
+        "raService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ra",
+                "domain": "service.consul"
+            },
+            "hostOverride": "ra.boulder",
+            "timeout": "15s"
+        },
+        "mailer": {
+            "server": "localhost",
+            "port": "9380",
+            "username": "cert-manager@example.com",
+            "from": "bad key revoker <bad-key-revoker@test.org>",
+            "passwordFile": "test/secrets/smtp_password",
+            "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+            "emailSubject": "Certificates you've issued have been revoked due to key compromise",
+            "emailTemplate": "test/example-bad-key-revoker-template"
+        },
+        "maximumRevocations": 15,
+        "findCertificatesBatchSize": 10,
+        "interval": "1s",
+        "backoffIntervalMax": "2s"
     },
-    "debugAddr": ":8020",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
-    },
-    "raService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ra",
-        "domain": "service.consul"
-      },
-      "hostOverride": "ra.boulder",
-      "timeout": "15s"
-    },
-    "mailer": {
-      "server": "localhost",
-      "port": "9380",
-      "username": "cert-manager@example.com",
-      "from": "bad key revoker <bad-key-revoker@test.org>",
-      "passwordFile": "test/secrets/smtp_password",
-      "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-      "emailSubject": "Certificates you've issued have been revoked due to key compromise",
-      "emailTemplate": "test/example-bad-key-revoker-template"
-    },
-    "maximumRevocations": 15,
-    "findCertificatesBatchSize": 10,
-    "interval": "1s",
-    "backoffIntervalMax": "2s"
-  },
-  "syslog": {
-    "stdoutlevel": 4,
-    "sysloglevel": -1
-  }
+    "syslog": {
+        "stdoutlevel": 4,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -1,41 +1,41 @@
 {
-    "BadKeyRevoker": {
-        "db": {
-            "dbConnectFile": "test/secrets/badkeyrevoker_dburl",
-            "maxOpenConns": 10
-        },
-        "debugAddr": ":8020",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
-        },
-        "raService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ra",
-                "domain": "service.consul"
-            },
-            "hostOverride": "ra.boulder",
-            "timeout": "15s"
-        },
-        "mailer": {
-            "server": "localhost",
-            "port": "9380",
-            "username": "cert-manager@example.com",
-            "from": "bad key revoker <bad-key-revoker@test.org>",
-            "passwordFile": "test/secrets/smtp_password",
-            "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-            "emailSubject": "Certificates you've issued have been revoked due to key compromise",
-            "emailTemplate": "test/example-bad-key-revoker-template"
-        },
-        "maximumRevocations": 15,
-        "findCertificatesBatchSize": 10,
-        "interval": "1s",
-        "backoffIntervalMax": "2s"
-    },
-    "syslog": {
-        "stdoutlevel": 4,
-        "sysloglevel": -1
-    }
+	"BadKeyRevoker": {
+		"db": {
+			"dbConnectFile": "test/secrets/badkeyrevoker_dburl",
+			"maxOpenConns": 10
+		},
+		"debugAddr": ":8020",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
+		},
+		"raService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
+			"hostOverride": "ra.boulder",
+			"timeout": "15s"
+		},
+		"mailer": {
+			"server": "localhost",
+			"port": "9380",
+			"username": "cert-manager@example.com",
+			"from": "bad key revoker <bad-key-revoker@test.org>",
+			"passwordFile": "test/secrets/smtp_password",
+			"SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+			"emailSubject": "Certificates you've issued have been revoked due to key compromise",
+			"emailTemplate": "test/example-bad-key-revoker-template"
+		},
+		"maximumRevocations": 15,
+		"findCertificatesBatchSize": 10,
+		"interval": "1s",
+		"backoffIntervalMax": "2s"
+	},
+	"syslog": {
+		"stdoutlevel": 4,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -1,144 +1,144 @@
 {
-  "ca": {
-    "debugAddr": ":8001",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-    },
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "grpcCA": {
-      "maxConnectionAge": "30s",
-      "address": ":9093",
-      "services": {
-        "ca.CertificateAuthority": {
-          "clientNames": [
-            "ra.boulder"
-          ]
+    "ca": {
+        "debugAddr": ":8001",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
         },
-        "ca.OCSPGenerator": {
-          "clientNames": [
-            "ocsp-updater.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder"
-          ]
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "grpcCA": {
+            "maxConnectionAge": "30s",
+            "address": ":9093",
+            "services": {
+                "ca.CertificateAuthority": {
+                    "clientNames": [
+                        "ra.boulder"
+                    ]
+                },
+                "ca.OCSPGenerator": {
+                    "clientNames": [
+                        "ocsp-updater.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "ca.CRLGenerator": {
+                    "clientNames": [
+                        "crl-updater.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "ca.CRLGenerator": {
-          "clientNames": [
-            "crl-updater.boulder"
-          ]
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "issuance": {
-      "profile": {
-        "allowMustStaple": true,
-        "allowCTPoison": true,
-        "allowSCTList": true,
-        "allowCommonName": false,
-        "policies": [
-          {
-            "oid": "2.23.140.1.2.1"
-          },
-          {
-            "oid": "1.2.3.4",
-            "qualifiers": [
-              {
-                "type": "id-qt-cps",
-                "value": "http://example.com/cps"
-              }
+        "issuance": {
+            "profile": {
+                "allowMustStaple": true,
+                "allowCTPoison": true,
+                "allowSCTList": true,
+                "allowCommonName": false,
+                "policies": [
+                    {
+                        "oid": "2.23.140.1.2.1"
+                    },
+                    {
+                        "oid": "1.2.3.4",
+                        "qualifiers": [
+                            {
+                                "type": "id-qt-cps",
+                                "value": "http://example.com/cps"
+                            }
+                        ]
+                    }
+                ],
+                "maxValidityPeriod": "7776000s",
+                "maxValidityBackdate": "1h5m"
+            },
+            "issuers": [
+                {
+                    "useForRSALeaves": true,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": false,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+                        "numSessions": 2
+                    }
+                }
+            ],
+            "ignoredLints": [
+                "n_subject_common_name_included"
             ]
-          }
-        ],
-        "maxValidityPeriod": "7776000s",
-        "maxValidityBackdate": "1h5m"
-      },
-      "issuers": [
-        {
-          "useForRSALeaves": true,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-            "numSessions": 2
-          }
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-            "numSessions": 2
-          }
+        "expiry": "7776000s",
+        "backdate": "1h",
+        "serialPrefix": 255,
+        "maxNames": 100,
+        "lifespanOCSP": "96h",
+        "lifespanCRL": "216h",
+        "crldpBase": "http://c.boulder.test",
+        "goodkey": {
+            "weakKeyFile": "test/example-weak-keys.json",
+            "blockedKeyFile": "test/example-blocked-keys.yaml",
+            "fermatRounds": 100
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": false,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-            "numSessions": 2
-          }
+        "orphanQueueDir": "/tmp/orphaned-certificates-a",
+        "ocspLogMaxLength": 4000,
+        "ocspLogPeriod": "500ms",
+        "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
+        "ctLogListFile": "test/ct-test-srv/log_list.json",
+        "features": {
+            "ROCSPStage7": true,
+            "SetCommonName": false
         }
-      ],
-      "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "7776000s",
-    "backdate": "1h",
-    "serialPrefix": 255,
-    "maxNames": 100,
-    "lifespanOCSP": "96h",
-    "lifespanCRL": "216h",
-    "crldpBase": "http://c.boulder.test",
-    "goodkey": {
-      "weakKeyFile": "test/example-weak-keys.json",
-      "blockedKeyFile": "test/example-blocked-keys.yaml",
-      "fermatRounds": 100
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
+        }
     },
-    "orphanQueueDir": "/tmp/orphaned-certificates-a",
-    "ocspLogMaxLength": 4000,
-    "ocspLogPeriod": "500ms",
-    "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
-    "ctLogListFile": "test/ct-test-srv/log_list.json",
-    "features": {
-      "ROCSPStage7": true,
-      "SetCommonName": false
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     }
-  },
-
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
-    }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
 }

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -1,144 +1,144 @@
 {
-    "ca": {
-        "debugAddr": ":8001",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-        },
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "grpcCA": {
-            "maxConnectionAge": "30s",
-            "address": ":9093",
-            "services": {
-                "ca.CertificateAuthority": {
-                    "clientNames": [
-                        "ra.boulder"
-                    ]
-                },
-                "ca.OCSPGenerator": {
-                    "clientNames": [
-                        "ocsp-updater.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "ca.CRLGenerator": {
-                    "clientNames": [
-                        "crl-updater.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "issuance": {
-            "profile": {
-                "allowMustStaple": true,
-                "allowCTPoison": true,
-                "allowSCTList": true,
-                "allowCommonName": false,
-                "policies": [
-                    {
-                        "oid": "2.23.140.1.2.1"
-                    },
-                    {
-                        "oid": "1.2.3.4",
-                        "qualifiers": [
-                            {
-                                "type": "id-qt-cps",
-                                "value": "http://example.com/cps"
-                            }
-                        ]
-                    }
-                ],
-                "maxValidityPeriod": "7776000s",
-                "maxValidityBackdate": "1h5m"
-            },
-            "issuers": [
-                {
-                    "useForRSALeaves": true,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": false,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-                        "numSessions": 2
-                    }
-                }
-            ],
-            "ignoredLints": [
-                "n_subject_common_name_included"
-            ]
-        },
-        "expiry": "7776000s",
-        "backdate": "1h",
-        "serialPrefix": 255,
-        "maxNames": 100,
-        "lifespanOCSP": "96h",
-        "lifespanCRL": "216h",
-        "crldpBase": "http://c.boulder.test",
-        "goodkey": {
-            "weakKeyFile": "test/example-weak-keys.json",
-            "blockedKeyFile": "test/example-blocked-keys.yaml",
-            "fermatRounds": 100
-        },
-        "orphanQueueDir": "/tmp/orphaned-certificates-a",
-        "ocspLogMaxLength": 4000,
-        "ocspLogPeriod": "500ms",
-        "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
-        "ctLogListFile": "test/ct-test-srv/log_list.json",
-        "features": {
-            "ROCSPStage7": true,
-            "SetCommonName": false
-        }
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"ca": {
+		"debugAddr": ":8001",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ca.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ca.boulder/key.pem"
+		},
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"grpcCA": {
+			"maxConnectionAge": "30s",
+			"address": ":9093",
+			"services": {
+				"ca.CertificateAuthority": {
+					"clientNames": [
+						"ra.boulder"
+					]
+				},
+				"ca.OCSPGenerator": {
+					"clientNames": [
+						"ocsp-updater.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder"
+					]
+				},
+				"ca.CRLGenerator": {
+					"clientNames": [
+						"crl-updater.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"issuance": {
+			"profile": {
+				"allowMustStaple": true,
+				"allowCTPoison": true,
+				"allowSCTList": true,
+				"allowCommonName": false,
+				"policies": [
+					{
+						"oid": "2.23.140.1.2.1"
+					},
+					{
+						"oid": "1.2.3.4",
+						"qualifiers": [
+							{
+								"type": "id-qt-cps",
+								"value": "http://example.com/cps"
+							}
+						]
+					}
+				],
+				"maxValidityPeriod": "7776000s",
+				"maxValidityBackdate": "1h5m"
+			},
+			"issuers": [
+				{
+					"useForRSALeaves": true,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": false,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+						"numSessions": 2
+					}
+				}
+			],
+			"ignoredLints": [
+				"n_subject_common_name_included"
+			]
+		},
+		"expiry": "7776000s",
+		"backdate": "1h",
+		"serialPrefix": 255,
+		"maxNames": 100,
+		"lifespanOCSP": "96h",
+		"lifespanCRL": "216h",
+		"crldpBase": "http://c.boulder.test",
+		"goodkey": {
+			"weakKeyFile": "test/example-weak-keys.json",
+			"blockedKeyFile": "test/example-blocked-keys.yaml",
+			"fermatRounds": 100
+		},
+		"orphanQueueDir": "/tmp/orphaned-certificates-a",
+		"ocspLogMaxLength": 4000,
+		"ocspLogPeriod": "500ms",
+		"ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
+		"ctLogListFile": "test/ct-test-srv/log_list.json",
+		"features": {
+			"ROCSPStage7": true,
+			"SetCommonName": false
+		}
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -1,144 +1,144 @@
 {
-  "ca": {
-    "debugAddr": ":8001",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-    },
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "grpcCA": {
-      "maxConnectionAge": "30s",
-      "address": ":9093",
-      "services": {
-        "ca.CertificateAuthority": {
-          "clientNames": [
-            "ra.boulder"
-          ]
+    "ca": {
+        "debugAddr": ":8001",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
         },
-        "ca.OCSPGenerator": {
-          "clientNames": [
-            "ocsp-updater.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder"
-          ]
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "grpcCA": {
+            "maxConnectionAge": "30s",
+            "address": ":9093",
+            "services": {
+                "ca.CertificateAuthority": {
+                    "clientNames": [
+                        "ra.boulder"
+                    ]
+                },
+                "ca.OCSPGenerator": {
+                    "clientNames": [
+                        "ocsp-updater.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "ca.CRLGenerator": {
+                    "clientNames": [
+                        "crl-updater.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "ca.CRLGenerator": {
-          "clientNames": [
-            "crl-updater.boulder"
-          ]
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "issuance": {
-      "profile": {
-        "allowMustStaple": true,
-        "allowCTPoison": true,
-        "allowSCTList": true,
-        "allowCommonName": false,
-        "policies": [
-          {
-            "oid": "2.23.140.1.2.1"
-          },
-          {
-            "oid": "1.2.3.4",
-            "qualifiers": [
-              {
-                "type": "id-qt-cps",
-                "value": "http://example.com/cps"
-              }
+        "issuance": {
+            "profile": {
+                "allowMustStaple": true,
+                "allowCTPoison": true,
+                "allowSCTList": true,
+                "allowCommonName": false,
+                "policies": [
+                    {
+                        "oid": "2.23.140.1.2.1"
+                    },
+                    {
+                        "oid": "1.2.3.4",
+                        "qualifiers": [
+                            {
+                                "type": "id-qt-cps",
+                                "value": "http://example.com/cps"
+                            }
+                        ]
+                    }
+                ],
+                "maxValidityPeriod": "7776000s",
+                "maxValidityBackdate": "1h5m"
+            },
+            "issuers": [
+                {
+                    "useForRSALeaves": true,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": false,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+                        "numSessions": 2
+                    }
+                }
+            ],
+            "ignoredLints": [
+                "n_subject_common_name_included"
             ]
-          }
-        ],
-        "maxValidityPeriod": "7776000s",
-        "maxValidityBackdate": "1h5m"
-      },
-      "issuers": [
-        {
-          "useForRSALeaves": true,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-            "numSessions": 2
-          }
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-            "numSessions": 2
-          }
+        "expiry": "7776000s",
+        "backdate": "1h",
+        "serialPrefix": 255,
+        "maxNames": 100,
+        "lifespanOCSP": "96h",
+        "lifespanCRL": "216h",
+        "crldpBase": "http://c.boulder.test",
+        "goodkey": {
+            "weakKeyFile": "test/example-weak-keys.json",
+            "blockedKeyFile": "test/example-blocked-keys.yaml",
+            "fermatRounds": 100
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": false,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-            "numSessions": 2
-          }
+        "orphanQueueDir": "/tmp/orphaned-certificates-b",
+        "ocspLogMaxLength": 4000,
+        "ocspLogPeriod": "500ms",
+        "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
+        "ctLogListFile": "test/ct-test-srv/log_list.json",
+        "features": {
+            "ROCSPStage7": true,
+            "SetCommonName": false
         }
-      ],
-      "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "7776000s",
-    "backdate": "1h",
-    "serialPrefix": 255,
-    "maxNames": 100,
-    "lifespanOCSP": "96h",
-    "lifespanCRL": "216h",
-    "crldpBase": "http://c.boulder.test",
-    "goodkey": {
-      "weakKeyFile": "test/example-weak-keys.json",
-      "blockedKeyFile": "test/example-blocked-keys.yaml",
-      "fermatRounds": 100
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
+        }
     },
-    "orphanQueueDir": "/tmp/orphaned-certificates-b",
-    "ocspLogMaxLength": 4000,
-    "ocspLogPeriod": "500ms",
-    "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
-    "ctLogListFile": "test/ct-test-srv/log_list.json",
-    "features": {
-      "ROCSPStage7": true,
-      "SetCommonName": false
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     }
-  },
-
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
-    }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
 }

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -1,144 +1,144 @@
 {
-    "ca": {
-        "debugAddr": ":8001",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-        },
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "grpcCA": {
-            "maxConnectionAge": "30s",
-            "address": ":9093",
-            "services": {
-                "ca.CertificateAuthority": {
-                    "clientNames": [
-                        "ra.boulder"
-                    ]
-                },
-                "ca.OCSPGenerator": {
-                    "clientNames": [
-                        "ocsp-updater.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "ca.CRLGenerator": {
-                    "clientNames": [
-                        "crl-updater.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "issuance": {
-            "profile": {
-                "allowMustStaple": true,
-                "allowCTPoison": true,
-                "allowSCTList": true,
-                "allowCommonName": false,
-                "policies": [
-                    {
-                        "oid": "2.23.140.1.2.1"
-                    },
-                    {
-                        "oid": "1.2.3.4",
-                        "qualifiers": [
-                            {
-                                "type": "id-qt-cps",
-                                "value": "http://example.com/cps"
-                            }
-                        ]
-                    }
-                ],
-                "maxValidityPeriod": "7776000s",
-                "maxValidityBackdate": "1h5m"
-            },
-            "issuers": [
-                {
-                    "useForRSALeaves": true,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": false,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-                        "numSessions": 2
-                    }
-                }
-            ],
-            "ignoredLints": [
-                "n_subject_common_name_included"
-            ]
-        },
-        "expiry": "7776000s",
-        "backdate": "1h",
-        "serialPrefix": 255,
-        "maxNames": 100,
-        "lifespanOCSP": "96h",
-        "lifespanCRL": "216h",
-        "crldpBase": "http://c.boulder.test",
-        "goodkey": {
-            "weakKeyFile": "test/example-weak-keys.json",
-            "blockedKeyFile": "test/example-blocked-keys.yaml",
-            "fermatRounds": 100
-        },
-        "orphanQueueDir": "/tmp/orphaned-certificates-b",
-        "ocspLogMaxLength": 4000,
-        "ocspLogPeriod": "500ms",
-        "ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
-        "ctLogListFile": "test/ct-test-srv/log_list.json",
-        "features": {
-            "ROCSPStage7": true,
-            "SetCommonName": false
-        }
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"ca": {
+		"debugAddr": ":8001",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ca.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ca.boulder/key.pem"
+		},
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"grpcCA": {
+			"maxConnectionAge": "30s",
+			"address": ":9093",
+			"services": {
+				"ca.CertificateAuthority": {
+					"clientNames": [
+						"ra.boulder"
+					]
+				},
+				"ca.OCSPGenerator": {
+					"clientNames": [
+						"ocsp-updater.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder"
+					]
+				},
+				"ca.CRLGenerator": {
+					"clientNames": [
+						"crl-updater.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"issuance": {
+			"profile": {
+				"allowMustStaple": true,
+				"allowCTPoison": true,
+				"allowSCTList": true,
+				"allowCommonName": false,
+				"policies": [
+					{
+						"oid": "2.23.140.1.2.1"
+					},
+					{
+						"oid": "1.2.3.4",
+						"qualifiers": [
+							{
+								"type": "id-qt-cps",
+								"value": "http://example.com/cps"
+							}
+						]
+					}
+				],
+				"maxValidityPeriod": "7776000s",
+				"maxValidityBackdate": "1h5m"
+			},
+			"issuers": [
+				{
+					"useForRSALeaves": true,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": false,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+						"numSessions": 2
+					}
+				}
+			],
+			"ignoredLints": [
+				"n_subject_common_name_included"
+			]
+		},
+		"expiry": "7776000s",
+		"backdate": "1h",
+		"serialPrefix": 255,
+		"maxNames": 100,
+		"lifespanOCSP": "96h",
+		"lifespanCRL": "216h",
+		"crldpBase": "http://c.boulder.test",
+		"goodkey": {
+			"weakKeyFile": "test/example-weak-keys.json",
+			"blockedKeyFile": "test/example-blocked-keys.yaml",
+			"fermatRounds": 100
+		},
+		"orphanQueueDir": "/tmp/orphaned-certificates-b",
+		"ocspLogMaxLength": 4000,
+		"ocspLogPeriod": "500ms",
+		"ecdsaAllowListFilename": "test/config-next/ecdsaAllowList.yml",
+		"ctLogListFile": "test/ct-test-srv/log_list.json",
+		"features": {
+			"ROCSPStage7": true,
+			"SetCommonName": false
+		}
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -1,38 +1,38 @@
 {
-    "certChecker": {
-        "db": {
-            "dbConnectFile": "test/secrets/cert_checker_dburl",
-            "maxOpenConns": 10
-        },
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "goodkey": {
-            "fermatRounds": 100
-        },
-        "workers": 16,
-        "unexpiredOnly": true,
-        "badResultsOnly": true,
-        "checkPeriod": "72h",
-        "acceptableValidityDurations": [
-            "7776000s"
-        ],
-        "ignoredLints": [
-            "n_subject_common_name_included"
-        ],
-        "ctLogListFile": "test/ct-test-srv/log_list.json",
-        "features": {
-            "CertCheckerChecksValidations": true,
-            "CertCheckerRequiresValidations": true
-        }
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"certChecker": {
+		"db": {
+			"dbConnectFile": "test/secrets/cert_checker_dburl",
+			"maxOpenConns": 10
+		},
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"goodkey": {
+			"fermatRounds": 100
+		},
+		"workers": 16,
+		"unexpiredOnly": true,
+		"badResultsOnly": true,
+		"checkPeriod": "72h",
+		"acceptableValidityDurations": [
+			"7776000s"
+		],
+		"ignoredLints": [
+			"n_subject_common_name_included"
+		],
+		"ctLogListFile": "test/ct-test-srv/log_list.json",
+		"features": {
+			"CertCheckerChecksValidations": true,
+			"CertCheckerRequiresValidations": true
+		}
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -1,38 +1,38 @@
 {
-  "certChecker": {
-    "db": {
-      "dbConnectFile": "test/secrets/cert_checker_dburl",
-      "maxOpenConns": 10
+    "certChecker": {
+        "db": {
+            "dbConnectFile": "test/secrets/cert_checker_dburl",
+            "maxOpenConns": 10
+        },
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "goodkey": {
+            "fermatRounds": 100
+        },
+        "workers": 16,
+        "unexpiredOnly": true,
+        "badResultsOnly": true,
+        "checkPeriod": "72h",
+        "acceptableValidityDurations": [
+            "7776000s"
+        ],
+        "ignoredLints": [
+            "n_subject_common_name_included"
+        ],
+        "ctLogListFile": "test/ct-test-srv/log_list.json",
+        "features": {
+            "CertCheckerChecksValidations": true,
+            "CertCheckerRequiresValidations": true
+        }
     },
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "goodkey": {
-      "fermatRounds": 100
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
+        }
     },
-    "workers": 16,
-    "unexpiredOnly": true,
-    "badResultsOnly": true,
-    "checkPeriod": "72h",
-    "acceptableValidityDurations": ["7776000s"],
-    "ignoredLints": [
-      "n_subject_common_name_included"
-    ],
-    "ctLogListFile": "test/ct-test-srv/log_list.json",
-    "features": {
-      "CertCheckerChecksValidations": true,
-      "CertCheckerRequiresValidations": true
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     }
-  },
-
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
-    }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
 }

--- a/test/config-next/contact-auditor.json
+++ b/test/config-next/contact-auditor.json
@@ -1,8 +1,8 @@
 {
-    "contactAuditor": {
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        }
-    }
+	"contactAuditor": {
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		}
+	}
 }

--- a/test/config-next/contact-auditor.json
+++ b/test/config-next/contact-auditor.json
@@ -1,8 +1,8 @@
 {
-  "contactAuditor": {
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "contactAuditor": {
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        }
     }
-  }
 }

--- a/test/config-next/contact-exporter.json
+++ b/test/config-next/contact-exporter.json
@@ -1,9 +1,9 @@
 {
-    "contactExporter": {
-        "passwordFile": "test/secrets/smtp_password",
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        }
-    }
+	"contactExporter": {
+		"passwordFile": "test/secrets/smtp_password",
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		}
+	}
 }

--- a/test/config-next/contact-exporter.json
+++ b/test/config-next/contact-exporter.json
@@ -1,9 +1,9 @@
 {
-  "contactExporter": {
-    "passwordFile": "test/secrets/smtp_password",
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "contactExporter": {
+        "passwordFile": "test/secrets/smtp_password",
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        }
     }
-  }
 }

--- a/test/config-next/crl-storer.json
+++ b/test/config-next/crl-storer.json
@@ -1,40 +1,39 @@
 {
-  "crlStorer": {
-    "debugAddr": ":9667",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
-    },
-    "grpc": {
-      "address": ":9109",
-      "maxConnectionAge": "30s",
-      "services": {
-        "storer.CRLStorer": {
-          "clientNames": [
-            "crl-updater.boulder"
-          ]
+    "crlStorer": {
+        "debugAddr": ":9667",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
+        "grpc": {
+            "address": ":9109",
+            "maxConnectionAge": "30s",
+            "services": {
+                "storer.CRLStorer": {
+                    "clientNames": [
+                        "crl-updater.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "s3Endpoint": "http://localhost:7890",
+        "s3Bucket": "lets-encrypt-crls",
+        "awsConfigFile": "test/config-next/crl-storer.ini",
+        "awsCredsFile": "test/secrets/aws_creds.ini"
     },
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "s3Endpoint": "http://localhost:7890",
-    "s3Bucket": "lets-encrypt-crls",
-    "awsConfigFile": "test/config-next/crl-storer.ini",
-    "awsCredsFile": "test/secrets/aws_creds.ini"
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/crl-storer.json
+++ b/test/config-next/crl-storer.json
@@ -1,39 +1,39 @@
 {
-    "crlStorer": {
-        "debugAddr": ":9667",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
-        },
-        "grpc": {
-            "address": ":9109",
-            "maxConnectionAge": "30s",
-            "services": {
-                "storer.CRLStorer": {
-                    "clientNames": [
-                        "crl-updater.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "s3Endpoint": "http://localhost:7890",
-        "s3Bucket": "lets-encrypt-crls",
-        "awsConfigFile": "test/config-next/crl-storer.ini",
-        "awsCredsFile": "test/secrets/aws_creds.ini"
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"crlStorer": {
+		"debugAddr": ":9667",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
+		},
+		"grpc": {
+			"address": ":9109",
+			"maxConnectionAge": "30s",
+			"services": {
+				"storer.CRLStorer": {
+					"clientNames": [
+						"crl-updater.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"s3Endpoint": "http://localhost:7890",
+		"s3Bucket": "lets-encrypt-crls",
+		"awsConfigFile": "test/config-next/crl-storer.ini",
+		"awsCredsFile": "test/secrets/aws_creds.ini"
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -1,53 +1,52 @@
 {
-  "crlUpdater": {
-    "debugAddr": ":8021",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
+    "crlUpdater": {
+        "debugAddr": ":8021",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
+        },
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "crlGeneratorService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ca",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "crlStorerService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "crl-storer",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "crl-storer.boulder"
+        },
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "numShards": 10,
+        "shardWidth": "18h",
+        "lookbackPeriod": "24h",
+        "updatePeriod": "6h",
+        "updateOffset": "9120s",
+        "maxParallelism": 10
     },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "crlGeneratorService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ca",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "crlStorerService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "crl-storer",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "crl-storer.boulder"
-    },
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "numShards": 10,
-    "shardWidth": "18h",
-    "lookbackPeriod": "24h",
-    "updatePeriod": "6h",
-    "updateOffset": "9120s",
-    "maxParallelism": 10
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -1,52 +1,52 @@
 {
-    "crlUpdater": {
-        "debugAddr": ":8021",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "crlGeneratorService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ca",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "crlStorerService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "crl-storer",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "crl-storer.boulder"
-        },
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "numShards": 10,
-        "shardWidth": "18h",
-        "lookbackPeriod": "24h",
-        "updatePeriod": "6h",
-        "updateOffset": "9120s",
-        "maxParallelism": 10
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"crlUpdater": {
+		"debugAddr": ":8021",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"crlGeneratorService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ca",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"crlStorerService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "crl-storer",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "crl-storer.boulder"
+		},
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"numShards": 10,
+		"shardWidth": "18h",
+		"lookbackPeriod": "24h",
+		"updatePeriod": "6h",
+		"updateOffset": "9120s",
+		"maxParallelism": 10
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -1,46 +1,46 @@
 {
-    "mailer": {
-        "server": "localhost",
-        "port": "9380",
-        "username": "cert-manager@example.com",
-        "from": "Expiry bot <expiration-mailer@test.org>",
-        "passwordFile": "test/secrets/smtp_password",
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        },
-        "certLimit": 100000,
-        "mailsPerAddressPerDay": 4,
-        "updateChunkSize": 1000,
-        "nagTimes": [
-            "480h",
-            "240h"
-        ],
-        "emailTemplate": "test/config-next/expiration-mailer.gotmpl",
-        "debugAddr": ":8008",
-        "parallelSends": 10,
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-        "frequency": "1h",
-        "features": {
-            "ExpirationMailerUsesJoin": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"mailer": {
+		"server": "localhost",
+		"port": "9380",
+		"username": "cert-manager@example.com",
+		"from": "Expiry bot <expiration-mailer@test.org>",
+		"passwordFile": "test/secrets/smtp_password",
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		},
+		"certLimit": 100000,
+		"mailsPerAddressPerDay": 4,
+		"updateChunkSize": 1000,
+		"nagTimes": [
+			"480h",
+			"240h"
+		],
+		"emailTemplate": "test/config-next/expiration-mailer.gotmpl",
+		"debugAddr": ":8008",
+		"parallelSends": 10,
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+		"frequency": "1h",
+		"features": {
+			"ExpirationMailerUsesJoin": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -1,44 +1,46 @@
 {
-  "mailer": {
-    "server": "localhost",
-    "port": "9380",
-    "username": "cert-manager@example.com",
-    "from": "Expiry bot <expiration-mailer@test.org>",
-    "passwordFile": "test/secrets/smtp_password",
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "mailer": {
+        "server": "localhost",
+        "port": "9380",
+        "username": "cert-manager@example.com",
+        "from": "Expiry bot <expiration-mailer@test.org>",
+        "passwordFile": "test/secrets/smtp_password",
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        },
+        "certLimit": 100000,
+        "mailsPerAddressPerDay": 4,
+        "updateChunkSize": 1000,
+        "nagTimes": [
+            "480h",
+            "240h"
+        ],
+        "emailTemplate": "test/config-next/expiration-mailer.gotmpl",
+        "debugAddr": ":8008",
+        "parallelSends": 10,
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
+        },
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+        "frequency": "1h",
+        "features": {
+            "ExpirationMailerUsesJoin": true
+        }
     },
-    "certLimit": 100000,
-    "mailsPerAddressPerDay": 4,
-    "updateChunkSize": 1000,
-    "nagTimes": ["480h", "240h"],
-    "emailTemplate": "test/config-next/expiration-mailer.gotmpl",
-    "debugAddr": ":8008",
-    "parallelSends": 10,
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
-    },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-    "frequency": "1h",
-    "features": {
-      "ExpirationMailerUsesJoin": true
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
 }

--- a/test/config-next/health-checker.json
+++ b/test/config-next/health-checker.json
@@ -1,10 +1,10 @@
 {
-  "grpc": {
-    "timeout": "1s"
-  },
-  "tls": {
-    "caCertFile": "test/grpc-creds/minica.pem",
-    "certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
-    "keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
-  }
+    "grpc": {
+        "timeout": "1s"
+    },
+    "tls": {
+        "caCertFile": "test/grpc-creds/minica.pem",
+        "certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
+        "keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
+    }
 }

--- a/test/config-next/health-checker.json
+++ b/test/config-next/health-checker.json
@@ -1,10 +1,10 @@
 {
-    "grpc": {
-        "timeout": "1s"
-    },
-    "tls": {
-        "caCertFile": "test/grpc-creds/minica.pem",
-        "certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
-        "keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
-    }
+	"grpc": {
+		"timeout": "1s"
+	},
+	"tls": {
+		"caCertFile": "test/grpc-creds/minica.pem",
+		"certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
+		"keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
+	}
 }

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -1,23 +1,23 @@
 {
-    "syslog": {
-        "stdoutLevel": 7
-    },
-    "debugAddr": ":8016",
-    "files": [
-        "/var/log/akamai-purger.log",
-        "/var/log/bad-key-revoker.log",
-        "/var/log/boulder-ca.log",
-        "/var/log/boulder-observer.log",
-        "/var/log/boulder-publisher.log",
-        "/var/log/boulder-ra.log",
-        "/var/log/boulder-remoteva.log",
-        "/var/log/boulder-sa.log",
-        "/var/log/boulder-va.log",
-        "/var/log/boulder-wfe2.log",
-        "/var/log/crl-storer.log",
-        "/var/log/crl-updater.log",
-        "/var/log/nonce-service.log",
-        "/var/log/ocsp-responder.log",
-        "/var/log/ocsp-updater.log"
-    ]
+	"syslog": {
+		"stdoutLevel": 7
+	},
+	"debugAddr": ":8016",
+	"files": [
+		"/var/log/akamai-purger.log",
+		"/var/log/bad-key-revoker.log",
+		"/var/log/boulder-ca.log",
+		"/var/log/boulder-observer.log",
+		"/var/log/boulder-publisher.log",
+		"/var/log/boulder-ra.log",
+		"/var/log/boulder-remoteva.log",
+		"/var/log/boulder-sa.log",
+		"/var/log/boulder-va.log",
+		"/var/log/boulder-wfe2.log",
+		"/var/log/crl-storer.log",
+		"/var/log/crl-updater.log",
+		"/var/log/nonce-service.log",
+		"/var/log/ocsp-responder.log",
+		"/var/log/ocsp-updater.log"
+	]
 }

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -1,23 +1,23 @@
 {
-  "syslog": {
-    "stdoutLevel": 7
-  },
-  "debugAddr": ":8016",
-  "files": [
-    "/var/log/akamai-purger.log",
-    "/var/log/bad-key-revoker.log",
-    "/var/log/boulder-ca.log",
-    "/var/log/boulder-observer.log",
-    "/var/log/boulder-publisher.log",
-    "/var/log/boulder-ra.log",
-    "/var/log/boulder-remoteva.log",
-    "/var/log/boulder-sa.log",
-    "/var/log/boulder-va.log",
-    "/var/log/boulder-wfe2.log",
-    "/var/log/crl-storer.log",
-    "/var/log/crl-updater.log",
-    "/var/log/nonce-service.log",
-    "/var/log/ocsp-responder.log",
-    "/var/log/ocsp-updater.log"
-  ]
+    "syslog": {
+        "stdoutLevel": 7
+    },
+    "debugAddr": ":8016",
+    "files": [
+        "/var/log/akamai-purger.log",
+        "/var/log/bad-key-revoker.log",
+        "/var/log/boulder-ca.log",
+        "/var/log/boulder-observer.log",
+        "/var/log/boulder-publisher.log",
+        "/var/log/boulder-ra.log",
+        "/var/log/boulder-remoteva.log",
+        "/var/log/boulder-sa.log",
+        "/var/log/boulder-va.log",
+        "/var/log/boulder-wfe2.log",
+        "/var/log/crl-storer.log",
+        "/var/log/crl-updater.log",
+        "/var/log/nonce-service.log",
+        "/var/log/ocsp-responder.log",
+        "/var/log/ocsp-updater.log"
+    ]
 }

--- a/test/config-next/nonce-a.json
+++ b/test/config-next/nonce-a.json
@@ -1,33 +1,35 @@
 {
-  "NonceService": {
-    "maxUsed": 131072,
-    "useDerivablePrefix": true,
-    "noncePrefixKey": {"passwordFile": "test/secrets/nonce_prefix_key"},
-    "syslog": {
-      "stdoutLevel": 6,
-      "syslogLevel": -1
-    },
-    "debugAddr": ":8111",
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9101",
-      "services": {
-        "nonce.NonceService": {
-          "clientNames": [
-            "wfe.boulder"
-          ]
+    "NonceService": {
+        "maxUsed": 131072,
+        "useDerivablePrefix": true,
+        "noncePrefixKey": {
+            "passwordFile": "test/secrets/nonce_prefix_key"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
+        "syslog": {
+            "stdoutLevel": 6,
+            "syslogLevel": -1
+        },
+        "debugAddr": ":8111",
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9101",
+            "services": {
+                "nonce.NonceService": {
+                    "clientNames": [
+                        "wfe.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
         }
-      }
-    },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
     }
-  }
 }

--- a/test/config-next/nonce-a.json
+++ b/test/config-next/nonce-a.json
@@ -1,35 +1,35 @@
 {
-    "NonceService": {
-        "maxUsed": 131072,
-        "useDerivablePrefix": true,
-        "noncePrefixKey": {
-            "passwordFile": "test/secrets/nonce_prefix_key"
-        },
-        "syslog": {
-            "stdoutLevel": 6,
-            "syslogLevel": -1
-        },
-        "debugAddr": ":8111",
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9101",
-            "services": {
-                "nonce.NonceService": {
-                    "clientNames": [
-                        "wfe.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
-        }
-    }
+	"NonceService": {
+		"maxUsed": 131072,
+		"useDerivablePrefix": true,
+		"noncePrefixKey": {
+			"passwordFile": "test/secrets/nonce_prefix_key"
+		},
+		"syslog": {
+			"stdoutLevel": 6,
+			"syslogLevel": -1
+		},
+		"debugAddr": ":8111",
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9101",
+			"services": {
+				"nonce.NonceService": {
+					"clientNames": [
+						"wfe.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/nonce.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/nonce.boulder/key.pem"
+		}
+	}
 }

--- a/test/config-next/nonce-b.json
+++ b/test/config-next/nonce-b.json
@@ -1,33 +1,35 @@
 {
-  "NonceService": {
-    "maxUsed": 131072,
-    "useDerivablePrefix": true,
-    "noncePrefixKey": {"passwordFile": "test/secrets/nonce_prefix_key"},
-    "syslog": {
-      "stdoutLevel": 6,
-      "syslogLevel": -1
-    },
-    "debugAddr": ":8111",
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9101",
-      "services": {
-        "nonce.NonceService": {
-          "clientNames": [
-            "wfe.boulder"
-          ]
+    "NonceService": {
+        "maxUsed": 131072,
+        "useDerivablePrefix": true,
+        "noncePrefixKey": {
+            "passwordFile": "test/secrets/nonce_prefix_key"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
+        "syslog": {
+            "stdoutLevel": 6,
+            "syslogLevel": -1
+        },
+        "debugAddr": ":8111",
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9101",
+            "services": {
+                "nonce.NonceService": {
+                    "clientNames": [
+                        "wfe.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
         }
-      }
-    },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
     }
-  }
 }

--- a/test/config-next/nonce-b.json
+++ b/test/config-next/nonce-b.json
@@ -1,35 +1,35 @@
 {
-    "NonceService": {
-        "maxUsed": 131072,
-        "useDerivablePrefix": true,
-        "noncePrefixKey": {
-            "passwordFile": "test/secrets/nonce_prefix_key"
-        },
-        "syslog": {
-            "stdoutLevel": 6,
-            "syslogLevel": -1
-        },
-        "debugAddr": ":8111",
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9101",
-            "services": {
-                "nonce.NonceService": {
-                    "clientNames": [
-                        "wfe.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
-        }
-    }
+	"NonceService": {
+		"maxUsed": 131072,
+		"useDerivablePrefix": true,
+		"noncePrefixKey": {
+			"passwordFile": "test/secrets/nonce_prefix_key"
+		},
+		"syslog": {
+			"stdoutLevel": 6,
+			"syslogLevel": -1
+		},
+		"debugAddr": ":8111",
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9101",
+			"services": {
+				"nonce.NonceService": {
+					"clientNames": [
+						"wfe.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/nonce.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/nonce.boulder/key.pem"
+		}
+	}
 }

--- a/test/config-next/notify-mailer.json
+++ b/test/config-next/notify-mailer.json
@@ -1,16 +1,16 @@
 {
-    "notifyMailer": {
-        "server": "localhost",
-        "port": "9380",
-        "username": "cert-manager@example.com",
-        "passwordFile": "test/secrets/smtp_password",
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        }
-    },
-    "syslog": {
-        "stdoutLevel": 7,
-        "syslogLevel": -1
-    }
+	"notifyMailer": {
+		"server": "localhost",
+		"port": "9380",
+		"username": "cert-manager@example.com",
+		"passwordFile": "test/secrets/smtp_password",
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		}
+	},
+	"syslog": {
+		"stdoutLevel": 7,
+		"syslogLevel": -1
+	}
 }

--- a/test/config-next/notify-mailer.json
+++ b/test/config-next/notify-mailer.json
@@ -1,16 +1,16 @@
 {
-  "notifyMailer": {
-    "server": "localhost",
-    "port": "9380",
-    "username": "cert-manager@example.com",
-    "passwordFile": "test/secrets/smtp_password",
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "notifyMailer": {
+        "server": "localhost",
+        "port": "9380",
+        "username": "cert-manager@example.com",
+        "passwordFile": "test/secrets/smtp_password",
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        }
+    },
+    "syslog": {
+        "stdoutLevel": 7,
+        "syslogLevel": -1
     }
-  },
-  "syslog": {
-    "stdoutLevel": 7,
-    "syslogLevel": -1
-  }
 }

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -1,65 +1,65 @@
 {
-    "ocspResponder": {
-        "redis": {
-            "username": "ocsp-responder",
-            "passwordFile": "test/secrets/ocsp_responder_redis_password",
-            "shardAddrs": {
-                "shard1": "10.33.33.2:4218",
-                "shard2": "10.33.33.3:4218"
-            },
-            "timeout": "5s",
-            "poolSize": 100,
-            "routeRandomly": true,
-            "tls": {
-                "caCertFile": "test/redis-tls/minica.pem",
-                "certFile": "test/redis-tls/boulder/cert.pem",
-                "keyFile": "test/redis-tls/boulder/key.pem"
-            }
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
-        },
-        "raService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ra",
-                "domain": "service.consul"
-            },
-            "hostOverride": "ra.boulder",
-            "timeout": "15s"
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "logSampleRate": 1,
-        "path": "/",
-        "listenAddress": "0.0.0.0:4002",
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "liveSigningPeriod": "60h",
-        "timeout": "4.9s",
-        "maxInflightSignings": 2,
-        "maxSigningWaiters": 1,
-        "shutdownStopTimeout": "10s",
-        "debugAddr": ":8005",
-        "requiredSerialPrefixes": [
-            "ff"
-        ],
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"ocspResponder": {
+		"redis": {
+			"username": "ocsp-responder",
+			"passwordFile": "test/secrets/ocsp_responder_redis_password",
+			"shardAddrs": {
+				"shard1": "10.33.33.2:4218",
+				"shard2": "10.33.33.3:4218"
+			},
+			"timeout": "5s",
+			"poolSize": 100,
+			"routeRandomly": true,
+			"tls": {
+				"caCertFile": "test/redis-tls/minica.pem",
+				"certFile": "test/redis-tls/boulder/cert.pem",
+				"keyFile": "test/redis-tls/boulder/key.pem"
+			}
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
+		},
+		"raService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
+			"hostOverride": "ra.boulder",
+			"timeout": "15s"
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"logSampleRate": 1,
+		"path": "/",
+		"listenAddress": "0.0.0.0:4002",
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"liveSigningPeriod": "60h",
+		"timeout": "4.9s",
+		"maxInflightSignings": 2,
+		"maxSigningWaiters": 1,
+		"shutdownStopTimeout": "10s",
+		"debugAddr": ":8005",
+		"requiredSerialPrefixes": [
+			"ff"
+		],
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -1,64 +1,65 @@
 {
-  "ocspResponder": {
-    "redis": {
-      "username": "ocsp-responder",
-      "passwordFile": "test/secrets/ocsp_responder_redis_password",
-      "shardAddrs": {
-        "shard1": "10.33.33.2:4218",
-        "shard2": "10.33.33.3:4218"
-      },
-      "timeout": "5s",
-      "poolSize": 100,
-      "routeRandomly": true,
-      "tls": {
-        "caCertFile": "test/redis-tls/minica.pem",
-        "certFile": "test/redis-tls/boulder/cert.pem",
-        "keyFile": "test/redis-tls/boulder/key.pem"
-      }
+    "ocspResponder": {
+        "redis": {
+            "username": "ocsp-responder",
+            "passwordFile": "test/secrets/ocsp_responder_redis_password",
+            "shardAddrs": {
+                "shard1": "10.33.33.2:4218",
+                "shard2": "10.33.33.3:4218"
+            },
+            "timeout": "5s",
+            "poolSize": 100,
+            "routeRandomly": true,
+            "tls": {
+                "caCertFile": "test/redis-tls/minica.pem",
+                "certFile": "test/redis-tls/boulder/cert.pem",
+                "keyFile": "test/redis-tls/boulder/key.pem"
+            }
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
+        },
+        "raService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ra",
+                "domain": "service.consul"
+            },
+            "hostOverride": "ra.boulder",
+            "timeout": "15s"
+        },
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "logSampleRate": 1,
+        "path": "/",
+        "listenAddress": "0.0.0.0:4002",
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "liveSigningPeriod": "60h",
+        "timeout": "4.9s",
+        "maxInflightSignings": 2,
+        "maxSigningWaiters": 1,
+        "shutdownStopTimeout": "10s",
+        "debugAddr": ":8005",
+        "requiredSerialPrefixes": [
+            "ff"
+        ],
+        "features": {}
     },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
-    },
-    "raService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ra",
-        "domain": "service.consul"
-      },
-      "hostOverride": "ra.boulder",
-      "timeout": "15s"
-    },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "logSampleRate": 1,
-    "path": "/",
-    "listenAddress": "0.0.0.0:4002",
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "liveSigningPeriod": "60h",
-    "timeout": "4.9s",
-    "maxInflightSignings": 2,
-    "maxSigningWaiters": 1,
-    "shutdownStopTimeout": "10s",
-    "debugAddr": ":8005",
-    "requiredSerialPrefixes": ["ff"],
-    "features": {}
-  },
-
-  "syslog": {
-   "stdoutlevel": 6,
-   "sysloglevel": -1
- }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -1,40 +1,39 @@
 {
-  "ocspUpdater": {
-    "db": {
-      "dbConnectFile": "test/secrets/ocsp_updater_dburl",
-      "maxOpenConns": 10
+    "ocspUpdater": {
+        "db": {
+            "dbConnectFile": "test/secrets/ocsp_updater_dburl",
+            "maxOpenConns": 10
+        },
+        "readOnlyDB": {
+            "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
+            "maxOpenConns": 100
+        },
+        "oldOCSPWindow": "2s",
+        "oldOCSPBatchSize": 5000,
+        "parallelGenerateOCSPRequests": 10,
+        "ocspMinTimeToExpiry": "72h",
+        "signFailureBackoffFactor": 1.2,
+        "signFailureBackoffMax": "30m",
+        "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
+        "debugAddr": ":8006",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
+        },
+        "ocspGeneratorService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ca",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "features": {}
     },
-    "readOnlyDB": {
-      "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
-      "maxOpenConns": 100
-    },
-    "oldOCSPWindow": "2s",
-    "oldOCSPBatchSize": 5000,
-    "parallelGenerateOCSPRequests": 10,
-    "ocspMinTimeToExpiry": "72h",
-    "signFailureBackoffFactor": 1.2,
-    "signFailureBackoffMax": "30m",
-    "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
-    "debugAddr": ":8006",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
-    },
-    "ocspGeneratorService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ca",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "features": {}
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/ocsp-updater.json
+++ b/test/config-next/ocsp-updater.json
@@ -1,39 +1,39 @@
 {
-    "ocspUpdater": {
-        "db": {
-            "dbConnectFile": "test/secrets/ocsp_updater_dburl",
-            "maxOpenConns": 10
-        },
-        "readOnlyDB": {
-            "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
-            "maxOpenConns": 100
-        },
-        "oldOCSPWindow": "2s",
-        "oldOCSPBatchSize": 5000,
-        "parallelGenerateOCSPRequests": 10,
-        "ocspMinTimeToExpiry": "72h",
-        "signFailureBackoffFactor": 1.2,
-        "signFailureBackoffMax": "30m",
-        "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
-        "debugAddr": ":8006",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
-        },
-        "ocspGeneratorService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ca",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"ocspUpdater": {
+		"db": {
+			"dbConnectFile": "test/secrets/ocsp_updater_dburl",
+			"maxOpenConns": 10
+		},
+		"readOnlyDB": {
+			"dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
+			"maxOpenConns": 100
+		},
+		"oldOCSPWindow": "2s",
+		"oldOCSPBatchSize": 5000,
+		"parallelGenerateOCSPRequests": 10,
+		"ocspMinTimeToExpiry": "72h",
+		"signFailureBackoffFactor": 1.2,
+		"signFailureBackoffMax": "30m",
+		"serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
+		"debugAddr": ":8006",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
+		},
+		"ocspGeneratorService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ca",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -1,38 +1,38 @@
 {
-    "backdate": "1h",
-    "issuerCerts": [
-        "/hierarchy/intermediate-cert-rsa-a.pem",
-        "/hierarchy/intermediate-cert-rsa-b.pem",
-        "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "syslog": {
-        "stdoutlevel": 7,
-        "sysloglevel": -1
-    },
-    "tls": {
-        "caCertFile": "test/grpc-creds/minica.pem",
-        "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
-        "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
-    },
-    "ocspGeneratorService": {
-        "dnsAuthority": "10.55.55.10",
-        "srvLookup": {
-            "service": "ca",
-            "domain": "service.consul"
-        },
-        "timeout": "15s",
-        "hostOverride": "ca.boulder"
-    },
-    "saService": {
-        "dnsAuthority": "10.55.55.10",
-        "srvLookup": {
-            "service": "sa",
-            "domain": "service.consul"
-        },
-        "timeout": "15s",
-        "hostOverride": "sa.boulder"
-    },
-    "features": {
-        "ROCSPStage7": true
-    }
+	"backdate": "1h",
+	"issuerCerts": [
+		"/hierarchy/intermediate-cert-rsa-a.pem",
+		"/hierarchy/intermediate-cert-rsa-b.pem",
+		"/hierarchy/intermediate-cert-ecdsa-a.pem"
+	],
+	"syslog": {
+		"stdoutlevel": 7,
+		"sysloglevel": -1
+	},
+	"tls": {
+		"caCertFile": "test/grpc-creds/minica.pem",
+		"certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
+		"keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
+	},
+	"ocspGeneratorService": {
+		"dnsAuthority": "10.55.55.10",
+		"srvLookup": {
+			"service": "ca",
+			"domain": "service.consul"
+		},
+		"timeout": "15s",
+		"hostOverride": "ca.boulder"
+	},
+	"saService": {
+		"dnsAuthority": "10.55.55.10",
+		"srvLookup": {
+			"service": "sa",
+			"domain": "service.consul"
+		},
+		"timeout": "15s",
+		"hostOverride": "sa.boulder"
+	},
+	"features": {
+		"ROCSPStage7": true
+	}
 }

--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -1,42 +1,38 @@
 {
-  "backdate": "1h",
-  "issuerCerts": [
-    "/hierarchy/intermediate-cert-rsa-a.pem",
-    "/hierarchy/intermediate-cert-rsa-b.pem",
-    "/hierarchy/intermediate-cert-ecdsa-a.pem"
-  ],
-
-  "syslog": {
-    "stdoutlevel": 7,
-    "sysloglevel": -1
-  },
-
-  "tls": {
-    "caCertFile": "test/grpc-creds/minica.pem",
-    "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
-    "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
-  },
-
-  "ocspGeneratorService": {
-    "dnsAuthority": "10.55.55.10",
-    "srvLookup": {
-      "service": "ca",
-      "domain": "service.consul"
+    "backdate": "1h",
+    "issuerCerts": [
+        "/hierarchy/intermediate-cert-rsa-a.pem",
+        "/hierarchy/intermediate-cert-rsa-b.pem",
+        "/hierarchy/intermediate-cert-ecdsa-a.pem"
+    ],
+    "syslog": {
+        "stdoutlevel": 7,
+        "sysloglevel": -1
     },
-    "timeout": "15s",
-    "hostOverride": "ca.boulder"
-  },
-  "saService": {
-    "dnsAuthority": "10.55.55.10",
-    "srvLookup": {
-      "service": "sa",
-      "domain": "service.consul"
+    "tls": {
+        "caCertFile": "test/grpc-creds/minica.pem",
+        "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
+        "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
     },
-    "timeout": "15s",
-    "hostOverride": "sa.boulder"
-  },
-
-  "features": {
-    "ROCSPStage7": true
-  }
+    "ocspGeneratorService": {
+        "dnsAuthority": "10.55.55.10",
+        "srvLookup": {
+            "service": "ca",
+            "domain": "service.consul"
+        },
+        "timeout": "15s",
+        "hostOverride": "ca.boulder"
+    },
+    "saService": {
+        "dnsAuthority": "10.55.55.10",
+        "srvLookup": {
+            "service": "sa",
+            "domain": "service.consul"
+        },
+        "timeout": "15s",
+        "hostOverride": "sa.boulder"
+    },
+    "features": {
+        "ROCSPStage7": true
+    }
 }

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -1,54 +1,52 @@
 {
-  "publisher": {
-    "userAgent": "boulder/1.0",
-    "blockProfileRate": 1000000000,
-    "chains": [
-      [
-        "/hierarchy/intermediate-cert-rsa-a.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-rsa-b.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-a.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-b.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ]
-    ],
-    "debugAddr": ":8009",
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9091",
-      "services": {
-        "Publisher": {
-          "clientNames": [
-            "ocsp-updater.boulder",
-            "ra.boulder"
-          ]
+    "publisher": {
+        "userAgent": "boulder/1.0",
+        "blockProfileRate": 1000000000,
+        "chains": [
+            [
+                "/hierarchy/intermediate-cert-rsa-a.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-rsa-b.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-b.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ]
+        ],
+        "debugAddr": ":8009",
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9091",
+            "services": {
+                "Publisher": {
+                    "clientNames": [
+                        "ocsp-updater.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
+        },
+        "features": {}
     },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
-    },
-    "features": {
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
 }

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -1,52 +1,52 @@
 {
-    "publisher": {
-        "userAgent": "boulder/1.0",
-        "blockProfileRate": 1000000000,
-        "chains": [
-            [
-                "/hierarchy/intermediate-cert-rsa-a.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-rsa-b.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-b.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ]
-        ],
-        "debugAddr": ":8009",
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9091",
-            "services": {
-                "Publisher": {
-                    "clientNames": [
-                        "ocsp-updater.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
-        },
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"publisher": {
+		"userAgent": "boulder/1.0",
+		"blockProfileRate": 1000000000,
+		"chains": [
+			[
+				"/hierarchy/intermediate-cert-rsa-a.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-rsa-b.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-a.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-b.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			]
+		],
+		"debugAddr": ":8009",
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9091",
+			"services": {
+				"Publisher": {
+					"clientNames": [
+						"ocsp-updater.boulder",
+						"ra.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/publisher.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/publisher.boulder/key.pem"
+		},
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -1,141 +1,141 @@
 {
-    "ra": {
-        "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
-        "maxContactsPerRegistration": 3,
-        "debugAddr": ":8002",
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "maxNames": 100,
-        "authorizationLifetimeDays": 30,
-        "pendingAuthorizationLifetimeDays": 7,
-        "goodkey": {
-            "weakKeyFile": "test/example-weak-keys.json",
-            "blockedKeyFile": "test/example-blocked-keys.yaml",
-            "fermatRounds": 100
-        },
-        "orderLifetime": "168h",
-        "finalizeTimeout": "30s",
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ra.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ra.boulder/key.pem"
-        },
-        "vaService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "va",
-                "domain": "service.consul"
-            },
-            "timeout": "20s",
-            "hostOverride": "va.boulder"
-        },
-        "caService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ca",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "ocspService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ca",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "publisherService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "publisher",
-                "domain": "service.consul"
-            },
-            "timeout": "300s",
-            "hostOverride": "publisher.boulder"
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "akamaiPurgerService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "akamai-purger",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "akamai-purger.boulder"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9094",
-            "services": {
-                "ra.RegistrationAuthority": {
-                    "clientNames": [
-                        "admin-revoker.boulder",
-                        "bad-key-revoker.boulder",
-                        "ocsp-responder.boulder",
-                        "wfe.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "features": {
-            "StoreRevokerInfo": true,
-            "ROCSPStage7": true,
-            "AsyncFinalize": true
-        },
-        "ctLogs": {
-            "stagger": "500ms",
-            "logListFile": "test/ct-test-srv/log_list.json",
-            "sctLogs": [
-                "A1 Current",
-                "A1 Future",
-                "A2 Past",
-                "A2 Current",
-                "B1",
-                "B2",
-                "C1",
-                "D1",
-                "E1"
-            ],
-            "infoLogs": [
-                "F1"
-            ],
-            "finalLogs": [
-                "A1 Current",
-                "A1 Future",
-                "C1",
-                "F1"
-            ]
-        }
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    }
+	"ra": {
+		"rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
+		"maxContactsPerRegistration": 3,
+		"debugAddr": ":8002",
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"maxNames": 100,
+		"authorizationLifetimeDays": 30,
+		"pendingAuthorizationLifetimeDays": 7,
+		"goodkey": {
+			"weakKeyFile": "test/example-weak-keys.json",
+			"blockedKeyFile": "test/example-blocked-keys.yaml",
+			"fermatRounds": 100
+		},
+		"orderLifetime": "168h",
+		"finalizeTimeout": "30s",
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ra.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ra.boulder/key.pem"
+		},
+		"vaService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "va",
+				"domain": "service.consul"
+			},
+			"timeout": "20s",
+			"hostOverride": "va.boulder"
+		},
+		"caService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ca",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"ocspService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ca",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"publisherService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "publisher",
+				"domain": "service.consul"
+			},
+			"timeout": "300s",
+			"hostOverride": "publisher.boulder"
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"akamaiPurgerService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "akamai-purger",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "akamai-purger.boulder"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9094",
+			"services": {
+				"ra.RegistrationAuthority": {
+					"clientNames": [
+						"admin-revoker.boulder",
+						"bad-key-revoker.boulder",
+						"ocsp-responder.boulder",
+						"wfe.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"features": {
+			"StoreRevokerInfo": true,
+			"ROCSPStage7": true,
+			"AsyncFinalize": true
+		},
+		"ctLogs": {
+			"stagger": "500ms",
+			"logListFile": "test/ct-test-srv/log_list.json",
+			"sctLogs": [
+				"A1 Current",
+				"A1 Future",
+				"A2 Past",
+				"A2 Current",
+				"B1",
+				"B2",
+				"C1",
+				"D1",
+				"E1"
+			],
+			"infoLogs": [
+				"F1"
+			],
+			"finalLogs": [
+				"A1 Current",
+				"A1 Future",
+				"C1",
+				"F1"
+			]
+		}
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	}
 }

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -1,143 +1,141 @@
 {
-  "ra": {
-    "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
-    "maxContactsPerRegistration": 3,
-    "debugAddr": ":8002",
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "maxNames": 100,
-    "authorizationLifetimeDays": 30,
-    "pendingAuthorizationLifetimeDays": 7,
-    "goodkey": {
-      "weakKeyFile": "test/example-weak-keys.json",
-      "blockedKeyFile": "test/example-blocked-keys.yaml",
-      "fermatRounds": 100
-    },
-    "orderLifetime": "168h",
-    "finalizeTimeout": "30s",
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ra.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ra.boulder/key.pem"
-    },
-    "vaService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "va",
-        "domain": "service.consul"
-      },
-      "timeout": "20s",
-      "hostOverride": "va.boulder"
-    },
-    "caService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ca",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "ocspService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ca",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "publisherService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "publisher",
-        "domain": "service.consul"
-      },
-      "timeout": "300s",
-      "hostOverride": "publisher.boulder"
-    },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "akamaiPurgerService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "akamai-purger",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "akamai-purger.boulder"
-    },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9094",
-      "services": {
-        "ra.RegistrationAuthority": {
-          "clientNames": [
-            "admin-revoker.boulder",
-            "bad-key-revoker.boulder",
-            "ocsp-responder.boulder",
-            "wfe.boulder"
-          ]
+    "ra": {
+        "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
+        "maxContactsPerRegistration": 3,
+        "debugAddr": ":8002",
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "maxNames": 100,
+        "authorizationLifetimeDays": 30,
+        "pendingAuthorizationLifetimeDays": 7,
+        "goodkey": {
+            "weakKeyFile": "test/example-weak-keys.json",
+            "blockedKeyFile": "test/example-blocked-keys.yaml",
+            "fermatRounds": 100
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
+        "orderLifetime": "168h",
+        "finalizeTimeout": "30s",
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ra.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ra.boulder/key.pem"
+        },
+        "vaService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "va",
+                "domain": "service.consul"
+            },
+            "timeout": "20s",
+            "hostOverride": "va.boulder"
+        },
+        "caService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ca",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "ocspService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ca",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "publisherService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "publisher",
+                "domain": "service.consul"
+            },
+            "timeout": "300s",
+            "hostOverride": "publisher.boulder"
+        },
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "akamaiPurgerService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "akamai-purger",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "akamai-purger.boulder"
+        },
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9094",
+            "services": {
+                "ra.RegistrationAuthority": {
+                    "clientNames": [
+                        "admin-revoker.boulder",
+                        "bad-key-revoker.boulder",
+                        "ocsp-responder.boulder",
+                        "wfe.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "features": {
+            "StoreRevokerInfo": true,
+            "ROCSPStage7": true,
+            "AsyncFinalize": true
+        },
+        "ctLogs": {
+            "stagger": "500ms",
+            "logListFile": "test/ct-test-srv/log_list.json",
+            "sctLogs": [
+                "A1 Current",
+                "A1 Future",
+                "A2 Past",
+                "A2 Current",
+                "B1",
+                "B2",
+                "C1",
+                "D1",
+                "E1"
+            ],
+            "infoLogs": [
+                "F1"
+            ],
+            "finalLogs": [
+                "A1 Current",
+                "A1 Future",
+                "C1",
+                "F1"
+            ]
         }
-      }
     },
-    "features": {
-      "StoreRevokerInfo": true,
-      "ROCSPStage7": true,
-      "AsyncFinalize": true
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
+        }
     },
-    "ctLogs": {
-      "stagger": "500ms",
-      "logListFile": "test/ct-test-srv/log_list.json",
-      "sctLogs": [
-        "A1 Current",
-        "A1 Future",
-        "A2 Past",
-        "A2 Current",
-        "B1",
-        "B2",
-        "C1",
-        "D1",
-        "E1"
-      ],
-      "infoLogs": [
-        "F1"
-      ],
-      "finalLogs": [
-        "A1 Current",
-        "A1 Future",
-        "C1",
-        "F1"
-      ]
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     }
-  },
-
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
-    }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  }
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -1,65 +1,65 @@
 {
-    "sa": {
-        "db": {
-            "dbConnectFile": "test/secrets/sa_dburl",
-            "maxOpenConns": 100
-        },
-        "readOnlyDB": {
-            "dbConnectFile": "test/secrets/sa_ro_dburl",
-            "maxOpenConns": 100
-        },
-        "incidentsDB": {
-            "dbConnectFile": "test/secrets/incidents_dburl",
-            "maxOpenConns": 100
-        },
-        "ParallelismPerRPC": 20,
-        "lagFactor": "200ms",
-        "debugAddr": ":8003",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/sa.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/sa.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9095",
-            "services": {
-                "sa.StorageAuthority": {
-                    "clientNames": [
-                        "admin-revoker.boulder",
-                        "ca.boulder",
-                        "expiration-mailer.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "sa.StorageAuthorityReadOnly": {
-                    "clientNames": [
-                        "crl-updater.boulder",
-                        "ocsp-responder.boulder",
-                        "wfe.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "issuers": {
-            ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
-            ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
-            ".hierarchy/intermediate-cert-rsa-a.pem": 3,
-            ".hierarchy/intermediate-cert-rsa-b.pem": 4
-        },
-        "features": {
-            "StoreRevokerInfo": true,
-            "ROCSPStage6": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"sa": {
+		"db": {
+			"dbConnectFile": "test/secrets/sa_dburl",
+			"maxOpenConns": 100
+		},
+		"readOnlyDB": {
+			"dbConnectFile": "test/secrets/sa_ro_dburl",
+			"maxOpenConns": 100
+		},
+		"incidentsDB": {
+			"dbConnectFile": "test/secrets/incidents_dburl",
+			"maxOpenConns": 100
+		},
+		"ParallelismPerRPC": 20,
+		"lagFactor": "200ms",
+		"debugAddr": ":8003",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/sa.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/sa.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9095",
+			"services": {
+				"sa.StorageAuthority": {
+					"clientNames": [
+						"admin-revoker.boulder",
+						"ca.boulder",
+						"expiration-mailer.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder"
+					]
+				},
+				"sa.StorageAuthorityReadOnly": {
+					"clientNames": [
+						"crl-updater.boulder",
+						"ocsp-responder.boulder",
+						"wfe.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"issuers": {
+			".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
+			".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
+			".hierarchy/intermediate-cert-rsa-a.pem": 3,
+			".hierarchy/intermediate-cert-rsa-b.pem": 4
+		},
+		"features": {
+			"StoreRevokerInfo": true,
+			"ROCSPStage6": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -1,66 +1,65 @@
 {
-  "sa": {
-    "db": {
-      "dbConnectFile": "test/secrets/sa_dburl",
-      "maxOpenConns": 100
-    },
-    "readOnlyDB": {
-      "dbConnectFile": "test/secrets/sa_ro_dburl",
-      "maxOpenConns": 100
-    },
-    "incidentsDB": {
-      "dbConnectFile": "test/secrets/incidents_dburl",
-      "maxOpenConns": 100
-    },
-    "ParallelismPerRPC": 20,
-    "lagFactor": "200ms",
-    "debugAddr": ":8003",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/sa.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/sa.boulder/key.pem"
-    },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9095",
-      "services": {
-        "sa.StorageAuthority": {
-          "clientNames": [
-            "admin-revoker.boulder",
-            "ca.boulder",
-            "expiration-mailer.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder"
-          ]
+    "sa": {
+        "db": {
+            "dbConnectFile": "test/secrets/sa_dburl",
+            "maxOpenConns": 100
         },
-        "sa.StorageAuthorityReadOnly": {
-          "clientNames": [
-            "crl-updater.boulder",
-            "ocsp-responder.boulder",
-            "wfe.boulder"
-          ]
+        "readOnlyDB": {
+            "dbConnectFile": "test/secrets/sa_ro_dburl",
+            "maxOpenConns": 100
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
+        "incidentsDB": {
+            "dbConnectFile": "test/secrets/incidents_dburl",
+            "maxOpenConns": 100
+        },
+        "ParallelismPerRPC": 20,
+        "lagFactor": "200ms",
+        "debugAddr": ":8003",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/sa.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/sa.boulder/key.pem"
+        },
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9095",
+            "services": {
+                "sa.StorageAuthority": {
+                    "clientNames": [
+                        "admin-revoker.boulder",
+                        "ca.boulder",
+                        "expiration-mailer.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "sa.StorageAuthorityReadOnly": {
+                    "clientNames": [
+                        "crl-updater.boulder",
+                        "ocsp-responder.boulder",
+                        "wfe.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "issuers": {
+            ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
+            ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
+            ".hierarchy/intermediate-cert-rsa-a.pem": 3,
+            ".hierarchy/intermediate-cert-rsa-b.pem": 4
+        },
+        "features": {
+            "StoreRevokerInfo": true,
+            "ROCSPStage6": true
         }
-      }
     },
-    "issuers": {
-      ".hierarchy/intermediate-cert-ecdsa-a.pem": 1,
-      ".hierarchy/intermediate-cert-ecdsa-b.pem": 2,
-      ".hierarchy/intermediate-cert-rsa-a.pem": 3,
-      ".hierarchy/intermediate-cert-rsa-b.pem": 4
-    },
-    "features": {
-      "StoreRevokerInfo": true,
-      "ROCSPStage6": true
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
 }

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -1,45 +1,44 @@
 {
-  "va": {
-    "userAgent": "boulder-remote-a",
-    "debugAddr": ":8011",
-    "dnsTries": 3,
-    "dnsResolver": "service.consul",
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true,
-    "issuerDomain": "happy-hacker-ca.invalid",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/rva.boulder/key.pem"
-    },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9097",
-      "services": {
-        "va.VA": {
-          "clientNames": [
-            "va.boulder"
-          ]
+    "va": {
+        "userAgent": "boulder-remote-a",
+        "debugAddr": ":8011",
+        "dnsTries": 3,
+        "dnsResolver": "service.consul",
+        "dnsTimeout": "1s",
+        "dnsAllowLoopbackAddresses": true,
+        "issuerDomain": "happy-hacker-ca.invalid",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9097",
+            "services": {
+                "va.VA": {
+                    "clientNames": [
+                        "va.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "features": {
+            "CAAValidationMethods": true,
+            "CAAAccountURI": true
+        },
+        "accountURIPrefixes": [
+            "http://boulder.service.consul:4000/acme/reg/",
+            "http://boulder.service.consul:4001/acme/acct/"
+        ]
     },
-    "features": {
-      "CAAValidationMethods": true,
-      "CAAAccountURI": true
-    },
-    "accountURIPrefixes": [
-      "http://boulder.service.consul:4000/acme/reg/",
-      "http://boulder.service.consul:4001/acme/acct/"
-    ]
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -1,44 +1,44 @@
 {
-    "va": {
-        "userAgent": "boulder-remote-a",
-        "debugAddr": ":8011",
-        "dnsTries": 3,
-        "dnsResolver": "service.consul",
-        "dnsTimeout": "1s",
-        "dnsAllowLoopbackAddresses": true,
-        "issuerDomain": "happy-hacker-ca.invalid",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9097",
-            "services": {
-                "va.VA": {
-                    "clientNames": [
-                        "va.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "features": {
-            "CAAValidationMethods": true,
-            "CAAAccountURI": true
-        },
-        "accountURIPrefixes": [
-            "http://boulder.service.consul:4000/acme/reg/",
-            "http://boulder.service.consul:4001/acme/acct/"
-        ]
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"va": {
+		"userAgent": "boulder-remote-a",
+		"debugAddr": ":8011",
+		"dnsTries": 3,
+		"dnsResolver": "service.consul",
+		"dnsTimeout": "1s",
+		"dnsAllowLoopbackAddresses": true,
+		"issuerDomain": "happy-hacker-ca.invalid",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/rva.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/rva.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9097",
+			"services": {
+				"va.VA": {
+					"clientNames": [
+						"va.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"features": {
+			"CAAValidationMethods": true,
+			"CAAAccountURI": true
+		},
+		"accountURIPrefixes": [
+			"http://boulder.service.consul:4000/acme/reg/",
+			"http://boulder.service.consul:4001/acme/acct/"
+		]
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -1,44 +1,44 @@
 {
-    "va": {
-        "userAgent": "boulder-remote-b",
-        "debugAddr": ":8012",
-        "dnsTries": 3,
-        "dnsResolver": "service.consul",
-        "dnsTimeout": "1s",
-        "dnsAllowLoopbackAddresses": true,
-        "issuerDomain": "happy-hacker-ca.invalid",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9098",
-            "services": {
-                "va.VA": {
-                    "clientNames": [
-                        "va.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "features": {
-            "CAAValidationMethods": true,
-            "CAAAccountURI": true
-        },
-        "accountURIPrefixes": [
-            "http://boulder.service.consul:4000/acme/reg/",
-            "http://boulder.service.consul:4001/acme/acct/"
-        ]
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    }
+	"va": {
+		"userAgent": "boulder-remote-b",
+		"debugAddr": ":8012",
+		"dnsTries": 3,
+		"dnsResolver": "service.consul",
+		"dnsTimeout": "1s",
+		"dnsAllowLoopbackAddresses": true,
+		"issuerDomain": "happy-hacker-ca.invalid",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/rva.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/rva.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9098",
+			"services": {
+				"va.VA": {
+					"clientNames": [
+						"va.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"features": {
+			"CAAValidationMethods": true,
+			"CAAAccountURI": true
+		},
+		"accountURIPrefixes": [
+			"http://boulder.service.consul:4000/acme/reg/",
+			"http://boulder.service.consul:4001/acme/acct/"
+		]
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -1,45 +1,44 @@
 {
-  "va": {
-    "userAgent": "boulder-remote-b",
-    "debugAddr": ":8012",
-    "dnsTries": 3,
-    "dnsResolver": "service.consul",
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true,
-    "issuerDomain": "happy-hacker-ca.invalid",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/rva.boulder/key.pem"
-    },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9098",
-      "services": {
-        "va.VA": {
-          "clientNames": [
-            "va.boulder"
-          ]
+    "va": {
+        "userAgent": "boulder-remote-b",
+        "debugAddr": ":8012",
+        "dnsTries": 3,
+        "dnsResolver": "service.consul",
+        "dnsTimeout": "1s",
+        "dnsAllowLoopbackAddresses": true,
+        "issuerDomain": "happy-hacker-ca.invalid",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9098",
+            "services": {
+                "va.VA": {
+                    "clientNames": [
+                        "va.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "features": {
+            "CAAValidationMethods": true,
+            "CAAAccountURI": true
+        },
+        "accountURIPrefixes": [
+            "http://boulder.service.consul:4000/acme/reg/",
+            "http://boulder.service.consul:4001/acme/acct/"
+        ]
     },
-    "features": {
-      "CAAValidationMethods": true,
-      "CAAAccountURI": true
-    },
-    "accountURIPrefixes": [
-      "http://boulder.service.consul:4000/acme/reg/",
-      "http://boulder.service.consul:4001/acme/acct/"
-    ]
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": -1
-  }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
+    }
 }

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -1,65 +1,64 @@
 {
-  "va": {
-    "userAgent": "boulder",
-    "debugAddr": ":8004",
-    "dnsTries": 3,
-    "dnsResolver": "service.consul",
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true,
-    "issuerDomain": "happy-hacker-ca.invalid",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/va.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/va.boulder/key.pem"
-    },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9092",
-      "services": {
-        "va.VA": {
-          "clientNames": [
-            "ra.boulder"
-          ]
+    "va": {
+        "userAgent": "boulder",
+        "debugAddr": ":8004",
+        "dnsTries": 3,
+        "dnsResolver": "service.consul",
+        "dnsTimeout": "1s",
+        "dnsAllowLoopbackAddresses": true,
+        "issuerDomain": "happy-hacker-ca.invalid",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/va.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/va.boulder/key.pem"
         },
-        "va.CAA": {
-          "clientNames": [
-            "ra.boulder"
-          ]
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9092",
+            "services": {
+                "va.VA": {
+                    "clientNames": [
+                        "ra.boulder"
+                    ]
+                },
+                "va.CAA": {
+                    "clientNames": [
+                        "ra.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
+        "features": {
+            "CAAValidationMethods": true,
+            "CAAAccountURI": true,
+            "EnforceMultiVA": true,
+            "MultiVAFullResults": true
+        },
+        "remoteVAs": [
+            {
+                "serverAddress": "rva1.service.consul:9097",
+                "timeout": "15s",
+                "hostOverride": "rva1.boulder"
+            },
+            {
+                "serverAddress": "rva1.service.consul:9098",
+                "timeout": "15s",
+                "hostOverride": "rva1.boulder"
+            }
+        ],
+        "maxRemoteValidationFailures": 1,
+        "accountURIPrefixes": [
+            "http://boulder.service.consul:4000/acme/reg/",
+            "http://boulder.service.consul:4001/acme/acct/"
+        ]
     },
-    "features": {
-      "CAAValidationMethods": true,
-      "CAAAccountURI": true,
-      "EnforceMultiVA": true,
-      "MultiVAFullResults": true
-    },
-    "remoteVAs": [
-      {
-        "serverAddress": "rva1.service.consul:9097",
-        "timeout": "15s",
-        "hostOverride": "rva1.boulder"
-      },
-      {
-        "serverAddress": "rva1.service.consul:9098",
-        "timeout": "15s",
-        "hostOverride": "rva1.boulder"
-      }
-    ],
-    "maxRemoteValidationFailures": 1,
-    "accountURIPrefixes": [
-      "http://boulder.service.consul:4000/acme/reg/",
-      "http://boulder.service.consul:4001/acme/acct/"
-    ]
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
+    }
 }

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -1,64 +1,64 @@
 {
-    "va": {
-        "userAgent": "boulder",
-        "debugAddr": ":8004",
-        "dnsTries": 3,
-        "dnsResolver": "service.consul",
-        "dnsTimeout": "1s",
-        "dnsAllowLoopbackAddresses": true,
-        "issuerDomain": "happy-hacker-ca.invalid",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/va.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/va.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9092",
-            "services": {
-                "va.VA": {
-                    "clientNames": [
-                        "ra.boulder"
-                    ]
-                },
-                "va.CAA": {
-                    "clientNames": [
-                        "ra.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "features": {
-            "CAAValidationMethods": true,
-            "CAAAccountURI": true,
-            "EnforceMultiVA": true,
-            "MultiVAFullResults": true
-        },
-        "remoteVAs": [
-            {
-                "serverAddress": "rva1.service.consul:9097",
-                "timeout": "15s",
-                "hostOverride": "rva1.boulder"
-            },
-            {
-                "serverAddress": "rva1.service.consul:9098",
-                "timeout": "15s",
-                "hostOverride": "rva1.boulder"
-            }
-        ],
-        "maxRemoteValidationFailures": 1,
-        "accountURIPrefixes": [
-            "http://boulder.service.consul:4000/acme/reg/",
-            "http://boulder.service.consul:4001/acme/acct/"
-        ]
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    }
+	"va": {
+		"userAgent": "boulder",
+		"debugAddr": ":8004",
+		"dnsTries": 3,
+		"dnsResolver": "service.consul",
+		"dnsTimeout": "1s",
+		"dnsAllowLoopbackAddresses": true,
+		"issuerDomain": "happy-hacker-ca.invalid",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/va.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/va.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9092",
+			"services": {
+				"va.VA": {
+					"clientNames": [
+						"ra.boulder"
+					]
+				},
+				"va.CAA": {
+					"clientNames": [
+						"ra.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"features": {
+			"CAAValidationMethods": true,
+			"CAAAccountURI": true,
+			"EnforceMultiVA": true,
+			"MultiVAFullResults": true
+		},
+		"remoteVAs": [
+			{
+				"serverAddress": "rva1.service.consul:9097",
+				"timeout": "15s",
+				"hostOverride": "rva1.boulder"
+			},
+			{
+				"serverAddress": "rva1.service.consul:9098",
+				"timeout": "15s",
+				"hostOverride": "rva1.boulder"
+			}
+		],
+		"maxRemoteValidationFailures": 1,
+		"accountURIPrefixes": [
+			"http://boulder.service.consul:4000/acme/reg/",
+			"http://boulder.service.consul:4001/acme/acct/"
+		]
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	}
 }

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -1,104 +1,104 @@
 {
-    "wfe": {
-        "listenAddress": "0.0.0.0:4001",
-        "TLSListenAddress": "0.0.0.0:4431",
-        "timeout": "30s",
-        "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
-        "serverKeyPath": "test/wfe-tls/boulder/key.pem",
-        "allowOrigins": [
-            "*"
-        ],
-        "shutdownStopTimeout": "10s",
-        "subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
-        "debugAddr": ":8013",
-        "directoryCAAIdentity": "happy-hacker-ca.invalid",
-        "directoryWebsite": "https://github.com/letsencrypt/boulder",
-        "legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
-        "goodkey": {
-            "blockedKeyFile": "test/example-blocked-keys.yaml"
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
-        },
-        "raService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "ra",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "ra.boulder"
-        },
-        "saService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "sa",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "accountCache": {
-            "size": 9000,
-            "ttl": "5s"
-        },
-        "getNonceService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookup": {
-                "service": "nonce",
-                "domain": "service.consul"
-            },
-            "timeout": "15s",
-            "hostOverride": "nonce.boulder"
-        },
-        "redeemNonceService": {
-            "dnsAuthority": "10.55.55.10",
-            "srvLookups": [
-                {
-                    "service": "nonce1",
-                    "domain": "service.consul"
-                },
-                {
-                    "service": "nonce2",
-                    "domain": "service.consul"
-                }
-            ],
-            "srvResolver": "nonce-srv",
-            "timeout": "15s",
-            "hostOverride": "nonce.boulder"
-        },
-        "noncePrefixKey": {
-            "passwordFile": "test/secrets/nonce_prefix_key"
-        },
-        "chains": [
-            [
-                "/hierarchy/intermediate-cert-rsa-a.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-rsa-b.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-b.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ]
-        ],
-        "staleTimeout": "5m",
-        "authorizationLifetimeDays": 30,
-        "pendingAuthorizationLifetimeDays": 7,
-        "features": {
-            "ServeRenewalInfo": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 4,
-        "sysloglevel": -1
-    }
+	"wfe": {
+		"listenAddress": "0.0.0.0:4001",
+		"TLSListenAddress": "0.0.0.0:4431",
+		"timeout": "30s",
+		"serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
+		"serverKeyPath": "test/wfe-tls/boulder/key.pem",
+		"allowOrigins": [
+			"*"
+		],
+		"shutdownStopTimeout": "10s",
+		"subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
+		"debugAddr": ":8013",
+		"directoryCAAIdentity": "happy-hacker-ca.invalid",
+		"directoryWebsite": "https://github.com/letsencrypt/boulder",
+		"legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
+		"goodkey": {
+			"blockedKeyFile": "test/example-blocked-keys.yaml"
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/wfe.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/wfe.boulder/key.pem"
+		},
+		"raService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "ra.boulder"
+		},
+		"saService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"accountCache": {
+			"size": 9000,
+			"ttl": "5s"
+		},
+		"getNonceService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookup": {
+				"service": "nonce",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"hostOverride": "nonce.boulder"
+		},
+		"redeemNonceService": {
+			"dnsAuthority": "10.55.55.10",
+			"srvLookups": [
+				{
+					"service": "nonce1",
+					"domain": "service.consul"
+				},
+				{
+					"service": "nonce2",
+					"domain": "service.consul"
+				}
+			],
+			"srvResolver": "nonce-srv",
+			"timeout": "15s",
+			"hostOverride": "nonce.boulder"
+		},
+		"noncePrefixKey": {
+			"passwordFile": "test/secrets/nonce_prefix_key"
+		},
+		"chains": [
+			[
+				"/hierarchy/intermediate-cert-rsa-a.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-rsa-b.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-a.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-b.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			]
+		],
+		"staleTimeout": "5m",
+		"authorizationLifetimeDays": 30,
+		"pendingAuthorizationLifetimeDays": 7,
+		"features": {
+			"ServeRenewalInfo": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 4,
+		"sysloglevel": -1
+	}
 }

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -1,101 +1,104 @@
 {
-  "wfe": {
-    "listenAddress": "0.0.0.0:4001",
-    "TLSListenAddress": "0.0.0.0:4431",
-    "timeout": "30s",
-    "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
-    "serverKeyPath": "test/wfe-tls/boulder/key.pem",
-    "allowOrigins": ["*"],
-    "shutdownStopTimeout": "10s",
-    "subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
-    "debugAddr": ":8013",
-    "directoryCAAIdentity": "happy-hacker-ca.invalid",
-    "directoryWebsite": "https://github.com/letsencrypt/boulder",
-    "legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
-    "goodkey": {
-      "blockedKeyFile": "test/example-blocked-keys.yaml"
-    },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
-    },
-    "raService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "ra",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "ra.boulder"
-    },
-    "saService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "sa",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "accountCache": {
-      "size": 9000,
-      "ttl": "5s"
-    },
-    "getNonceService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookup": {
-        "service": "nonce",
-        "domain": "service.consul"
-      },
-      "timeout": "15s",
-      "hostOverride": "nonce.boulder"
-    },
-    "redeemNonceService": {
-      "dnsAuthority": "10.55.55.10",
-      "srvLookups": [
-        {
-          "service": "nonce1",
-          "domain": "service.consul"
+    "wfe": {
+        "listenAddress": "0.0.0.0:4001",
+        "TLSListenAddress": "0.0.0.0:4431",
+        "timeout": "30s",
+        "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
+        "serverKeyPath": "test/wfe-tls/boulder/key.pem",
+        "allowOrigins": [
+            "*"
+        ],
+        "shutdownStopTimeout": "10s",
+        "subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
+        "debugAddr": ":8013",
+        "directoryCAAIdentity": "happy-hacker-ca.invalid",
+        "directoryWebsite": "https://github.com/letsencrypt/boulder",
+        "legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
+        "goodkey": {
+            "blockedKeyFile": "test/example-blocked-keys.yaml"
         },
-        {
-          "service": "nonce2",
-          "domain": "service.consul"
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
+        },
+        "raService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "ra",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "ra.boulder"
+        },
+        "saService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "sa",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "accountCache": {
+            "size": 9000,
+            "ttl": "5s"
+        },
+        "getNonceService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookup": {
+                "service": "nonce",
+                "domain": "service.consul"
+            },
+            "timeout": "15s",
+            "hostOverride": "nonce.boulder"
+        },
+        "redeemNonceService": {
+            "dnsAuthority": "10.55.55.10",
+            "srvLookups": [
+                {
+                    "service": "nonce1",
+                    "domain": "service.consul"
+                },
+                {
+                    "service": "nonce2",
+                    "domain": "service.consul"
+                }
+            ],
+            "srvResolver": "nonce-srv",
+            "timeout": "15s",
+            "hostOverride": "nonce.boulder"
+        },
+        "noncePrefixKey": {
+            "passwordFile": "test/secrets/nonce_prefix_key"
+        },
+        "chains": [
+            [
+                "/hierarchy/intermediate-cert-rsa-a.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-rsa-b.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-b.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ]
+        ],
+        "staleTimeout": "5m",
+        "authorizationLifetimeDays": 30,
+        "pendingAuthorizationLifetimeDays": 7,
+        "features": {
+            "ServeRenewalInfo": true
         }
-      ],
-      "srvResolver": "nonce-srv",
-      "timeout": "15s",
-      "hostOverride": "nonce.boulder"
     },
-    "noncePrefixKey": {"passwordFile": "test/secrets/nonce_prefix_key"},
-    "chains": [
-      [
-        "/hierarchy/intermediate-cert-rsa-a.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-rsa-b.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-a.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-b.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ]
-    ],
-    "staleTimeout": "5m",
-    "authorizationLifetimeDays": 30,
-    "pendingAuthorizationLifetimeDays": 7,
-    "features": {
-      "ServeRenewalInfo": true
+    "syslog": {
+        "stdoutlevel": 4,
+        "sysloglevel": -1
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 4,
-    "sysloglevel": -1
-  }
 }

--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -1,28 +1,28 @@
 {
-    "revoker": {
-        "db": {
-            "dbConnectFile": "test/secrets/revoker_dburl",
-            "maxOpenConns": 1
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
-        },
-        "raService": {
-            "serverAddress": "ra.service.consul:9094",
-            "timeout": "15s",
-            "hostOverride": "ra.boulder"
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    }
+	"revoker": {
+		"db": {
+			"dbConnectFile": "test/secrets/revoker_dburl",
+			"maxOpenConns": 1
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
+		},
+		"raService": {
+			"serverAddress": "ra.service.consul:9094",
+			"timeout": "15s",
+			"hostOverride": "ra.boulder"
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	}
 }

--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -1,30 +1,28 @@
 {
-  "revoker": {
-    "db": {
-      "dbConnectFile": "test/secrets/revoker_dburl",
-      "maxOpenConns": 1
+    "revoker": {
+        "db": {
+            "dbConnectFile": "test/secrets/revoker_dburl",
+            "maxOpenConns": 1
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
+        },
+        "raService": {
+            "serverAddress": "ra.service.consul:9094",
+            "timeout": "15s",
+            "hostOverride": "ra.boulder"
+        },
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "features": {}
     },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/admin-revoker.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
-    },
-    "raService": {
-      "serverAddress": "ra.service.consul:9094",
-      "timeout": "15s",
-      "hostOverride": "ra.boulder"
-    },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "features": {
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  }
 }

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -1,36 +1,36 @@
 {
-    "akamaiPurger": {
-        "debugAddr": ":9666",
-        "purgeRetries": 10,
-        "purgeRetryBackoff": "50ms",
-        "baseURL": "http://localhost:6789",
-        "clientToken": "its-a-token",
-        "clientSecret": "its-a-secret",
-        "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
-        "v3Network": "staging",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
-        },
-        "grpc": {
-            "address": ":9099",
-            "maxConnectionAge": "30s",
-            "clientNames": [
-                "health-checker.boulder",
-                "ra.boulder"
-            ]
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"akamaiPurger": {
+		"debugAddr": ":9666",
+		"purgeRetries": 10,
+		"purgeRetryBackoff": "50ms",
+		"baseURL": "http://localhost:6789",
+		"clientToken": "its-a-token",
+		"clientSecret": "its-a-secret",
+		"accessToken": "idk-how-this-is-different-from-client-token-but-okay",
+		"v3Network": "staging",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
+		},
+		"grpc": {
+			"address": ":9099",
+			"maxConnectionAge": "30s",
+			"clientNames": [
+				"health-checker.boulder",
+				"ra.boulder"
+			]
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/akamai-purger.json
+++ b/test/config/akamai-purger.json
@@ -1,35 +1,36 @@
 {
-  "akamaiPurger": {
-    "debugAddr": ":9666",
-    "purgeRetries": 10,
-    "purgeRetryBackoff": "50ms",
-    "baseURL": "http://localhost:6789",
-    "clientToken": "its-a-token",
-    "clientSecret": "its-a-secret",
-    "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
-    "v3Network": "staging",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
+    "akamaiPurger": {
+        "debugAddr": ":9666",
+        "purgeRetries": 10,
+        "purgeRetryBackoff": "50ms",
+        "baseURL": "http://localhost:6789",
+        "clientToken": "its-a-token",
+        "clientSecret": "its-a-secret",
+        "accessToken": "idk-how-this-is-different-from-client-token-but-okay",
+        "v3Network": "staging",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/akamai-purger.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/akamai-purger.boulder/key.pem"
+        },
+        "grpc": {
+            "address": ":9099",
+            "maxConnectionAge": "30s",
+            "clientNames": [
+                "health-checker.boulder",
+                "ra.boulder"
+            ]
+        }
     },
-    "grpc": {
-      "address": ":9099",
-      "maxConnectionAge": "30s",
-      "clientNames": [
-        "health-checker.boulder",
-        "ra.boulder"
-      ]
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
+    },
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
 }

--- a/test/config/bad-key-revoker.json
+++ b/test/config/bad-key-revoker.json
@@ -1,44 +1,44 @@
 {
-    "BadKeyRevoker": {
-        "db": {
-            "dbConnectFile": "test/secrets/badkeyrevoker_dburl",
-            "maxOpenConns": 10
-        },
-        "debugAddr": ":8020",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
-        },
-        "raService": {
-            "serverAddress": "ra.service.consul:9094",
-            "timeout": "15s",
-            "hostOverride": "ra.boulder"
-        },
-        "mailer": {
-            "server": "localhost",
-            "port": "9380",
-            "username": "cert-manager@example.com",
-            "from": "bad key revoker <bad-key-revoker@test.org>",
-            "passwordFile": "test/secrets/smtp_password",
-            "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-            "emailSubject": "Certificates you've issued have been revoked due to key compromise",
-            "emailTemplate": "test/example-bad-key-revoker-template"
-        },
-        "maximumRevocations": 15,
-        "findCertificatesBatchSize": 10,
-        "interval": "1s",
-        "backoffIntervalMax": "2s"
-    },
-    "syslog": {
-        "stdoutlevel": 4,
-        "sysloglevel": 4
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"BadKeyRevoker": {
+		"db": {
+			"dbConnectFile": "test/secrets/badkeyrevoker_dburl",
+			"maxOpenConns": 10
+		},
+		"debugAddr": ":8020",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
+		},
+		"raService": {
+			"serverAddress": "ra.service.consul:9094",
+			"timeout": "15s",
+			"hostOverride": "ra.boulder"
+		},
+		"mailer": {
+			"server": "localhost",
+			"port": "9380",
+			"username": "cert-manager@example.com",
+			"from": "bad key revoker <bad-key-revoker@test.org>",
+			"passwordFile": "test/secrets/smtp_password",
+			"SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+			"emailSubject": "Certificates you've issued have been revoked due to key compromise",
+			"emailTemplate": "test/example-bad-key-revoker-template"
+		},
+		"maximumRevocations": 15,
+		"findCertificatesBatchSize": 10,
+		"interval": "1s",
+		"backoffIntervalMax": "2s"
+	},
+	"syslog": {
+		"stdoutlevel": 4,
+		"sysloglevel": 4
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/bad-key-revoker.json
+++ b/test/config/bad-key-revoker.json
@@ -1,44 +1,44 @@
 {
-  "BadKeyRevoker": {
-    "db": {
-      "dbConnectFile": "test/secrets/badkeyrevoker_dburl",
-      "maxOpenConns": 10
+    "BadKeyRevoker": {
+        "db": {
+            "dbConnectFile": "test/secrets/badkeyrevoker_dburl",
+            "maxOpenConns": 10
+        },
+        "debugAddr": ":8020",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
+        },
+        "raService": {
+            "serverAddress": "ra.service.consul:9094",
+            "timeout": "15s",
+            "hostOverride": "ra.boulder"
+        },
+        "mailer": {
+            "server": "localhost",
+            "port": "9380",
+            "username": "cert-manager@example.com",
+            "from": "bad key revoker <bad-key-revoker@test.org>",
+            "passwordFile": "test/secrets/smtp_password",
+            "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+            "emailSubject": "Certificates you've issued have been revoked due to key compromise",
+            "emailTemplate": "test/example-bad-key-revoker-template"
+        },
+        "maximumRevocations": 15,
+        "findCertificatesBatchSize": 10,
+        "interval": "1s",
+        "backoffIntervalMax": "2s"
     },
-    "debugAddr": ":8020",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/bad-key-revoker.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
+    "syslog": {
+        "stdoutlevel": 4,
+        "sysloglevel": 4
     },
-    "raService": {
-      "serverAddress": "ra.service.consul:9094",
-      "timeout": "15s",
-      "hostOverride": "ra.boulder"
-    },
-    "mailer": {
-      "server": "localhost",
-      "port": "9380",
-      "username": "cert-manager@example.com",
-      "from": "bad key revoker <bad-key-revoker@test.org>",
-      "passwordFile": "test/secrets/smtp_password",
-      "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-      "emailSubject": "Certificates you've issued have been revoked due to key compromise",
-      "emailTemplate": "test/example-bad-key-revoker-template"
-    },
-    "maximumRevocations": 15,
-    "findCertificatesBatchSize": 10,
-    "interval": "1s",
-    "backoffIntervalMax": "2s"
-  },
-  "syslog": {
-    "stdoutlevel": 4,
-    "sysloglevel": 4
-  },
-  "beeline": {
-    "mute": true,
-    "serviceName": "Test",
-    "writeKey": {
-      "passwordFile": "test/secrets/honeycomb_fake_password"
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     }
-  }
 }

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -1,177 +1,177 @@
 {
-    "ca": {
-        "debugAddr": ":8001",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-        },
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "grpcCA": {
-            "maxConnectionAge": "30s",
-            "address": ":9093",
-            "services": {
-                "ca.CertificateAuthority": {
-                    "clientNames": [
-                        "ra.boulder"
-                    ]
-                },
-                "ca.OCSPGenerator": {
-                    "clientNames": [
-                        "ocsp-updater.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "ca.CRLGenerator": {
-                    "clientNames": [
-                        "crl-updater.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "grpcOCSPGenerator": {
-            "maxConnectionAge": "30s",
-            "address": ":9096",
-            "services": {
-                "ca.OCSPGenerator": {
-                    "clientNames": [
-                        "ocsp-updater.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "grpcCRLGenerator": {
-            "maxConnectionAge": "30s",
-            "address": ":9106",
-            "services": {
-                "ca.CRLGenerator": {
-                    "clientNames": [
-                        "crl-updater.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "issuance": {
-            "profile": {
-                "allowMustStaple": true,
-                "allowCTPoison": true,
-                "allowSCTList": true,
-                "allowCommonName": true,
-                "policies": [
-                    {
-                        "oid": "2.23.140.1.2.1"
-                    },
-                    {
-                        "oid": "1.2.3.4",
-                        "qualifiers": [
-                            {
-                                "type": "id-qt-cps",
-                                "value": "http://example.com/cps"
-                            }
-                        ]
-                    }
-                ],
-                "maxValidityPeriod": "7776000s",
-                "maxValidityBackdate": "1h5m"
-            },
-            "issuers": [
-                {
-                    "useForRSALeaves": true,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "test/test-ca.key-pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": false,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "test/test-ca.key-pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-                        "numSessions": 2
-                    }
-                }
-            ],
-            "ignoredLints": [
-                "n_subject_common_name_included"
-            ]
-        },
-        "expiry": "7776000s",
-        "backdate": "1h",
-        "serialPrefix": 255,
-        "maxNames": 100,
-        "lifespanOCSP": "96h",
-        "lifespanCRL": "216h",
-        "crldpBase": "http://c.boulder.test",
-        "goodkey": {
-            "weakKeyFile": "test/example-weak-keys.json",
-            "blockedKeyFile": "test/example-blocked-keys.yaml",
-            "fermatRounds": 100
-        },
-        "orphanQueueDir": "/tmp/orphaned-certificates-a",
-        "ocspLogMaxLength": 4000,
-        "ocspLogPeriod": "500ms",
-        "ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
-        "features": {}
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"ca": {
+		"debugAddr": ":8001",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ca.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ca.boulder/key.pem"
+		},
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"grpcCA": {
+			"maxConnectionAge": "30s",
+			"address": ":9093",
+			"services": {
+				"ca.CertificateAuthority": {
+					"clientNames": [
+						"ra.boulder"
+					]
+				},
+				"ca.OCSPGenerator": {
+					"clientNames": [
+						"ocsp-updater.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder"
+					]
+				},
+				"ca.CRLGenerator": {
+					"clientNames": [
+						"crl-updater.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"grpcOCSPGenerator": {
+			"maxConnectionAge": "30s",
+			"address": ":9096",
+			"services": {
+				"ca.OCSPGenerator": {
+					"clientNames": [
+						"ocsp-updater.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"grpcCRLGenerator": {
+			"maxConnectionAge": "30s",
+			"address": ":9106",
+			"services": {
+				"ca.CRLGenerator": {
+					"clientNames": [
+						"crl-updater.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"issuance": {
+			"profile": {
+				"allowMustStaple": true,
+				"allowCTPoison": true,
+				"allowSCTList": true,
+				"allowCommonName": true,
+				"policies": [
+					{
+						"oid": "2.23.140.1.2.1"
+					},
+					{
+						"oid": "1.2.3.4",
+						"qualifiers": [
+							{
+								"type": "id-qt-cps",
+								"value": "http://example.com/cps"
+							}
+						]
+					}
+				],
+				"maxValidityPeriod": "7776000s",
+				"maxValidityBackdate": "1h5m"
+			},
+			"issuers": [
+				{
+					"useForRSALeaves": true,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "test/test-ca.key-pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": false,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "test/test-ca.key-pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+						"numSessions": 2
+					}
+				}
+			],
+			"ignoredLints": [
+				"n_subject_common_name_included"
+			]
+		},
+		"expiry": "7776000s",
+		"backdate": "1h",
+		"serialPrefix": 255,
+		"maxNames": 100,
+		"lifespanOCSP": "96h",
+		"lifespanCRL": "216h",
+		"crldpBase": "http://c.boulder.test",
+		"goodkey": {
+			"weakKeyFile": "test/example-weak-keys.json",
+			"blockedKeyFile": "test/example-blocked-keys.yaml",
+			"fermatRounds": 100
+		},
+		"orphanQueueDir": "/tmp/orphaned-certificates-a",
+		"ocspLogMaxLength": 4000,
+		"ocspLogPeriod": "500ms",
+		"ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
+		"features": {}
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -1,175 +1,177 @@
 {
-  "ca": {
-    "debugAddr": ":8001",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-    },
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "grpcCA": {
-      "maxConnectionAge": "30s",
-      "address": ":9093",
-      "services": {
-        "ca.CertificateAuthority": {
-          "clientNames": [
-            "ra.boulder"
-          ]
+    "ca": {
+        "debugAddr": ":8001",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
         },
-        "ca.OCSPGenerator": {
-          "clientNames": [
-            "ocsp-updater.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder"
-          ]
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "grpcCA": {
+            "maxConnectionAge": "30s",
+            "address": ":9093",
+            "services": {
+                "ca.CertificateAuthority": {
+                    "clientNames": [
+                        "ra.boulder"
+                    ]
+                },
+                "ca.OCSPGenerator": {
+                    "clientNames": [
+                        "ocsp-updater.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "ca.CRLGenerator": {
+                    "clientNames": [
+                        "crl-updater.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "ca.CRLGenerator": {
-          "clientNames": [
-            "crl-updater.boulder"
-          ]
+        "grpcOCSPGenerator": {
+            "maxConnectionAge": "30s",
+            "address": ":9096",
+            "services": {
+                "ca.OCSPGenerator": {
+                    "clientNames": [
+                        "ocsp-updater.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "grpcOCSPGenerator": {
-      "maxConnectionAge": "30s",
-      "address": ":9096",
-      "services": {
-        "ca.OCSPGenerator": {
-          "clientNames": [
-            "ocsp-updater.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder"
-          ]
+        "grpcCRLGenerator": {
+            "maxConnectionAge": "30s",
+            "address": ":9106",
+            "services": {
+                "ca.CRLGenerator": {
+                    "clientNames": [
+                        "crl-updater.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "grpcCRLGenerator": {
-      "maxConnectionAge": "30s",
-      "address": ":9106",
-      "services": {
-        "ca.CRLGenerator": {
-          "clientNames": [
-            "crl-updater.boulder"
-          ]
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "issuance": {
-      "profile": {
-        "allowMustStaple": true,
-        "allowCTPoison": true,
-        "allowSCTList": true,
-        "allowCommonName": true,
-        "policies": [
-          {
-            "oid": "2.23.140.1.2.1"
-          },
-          {
-            "oid": "1.2.3.4",
-            "qualifiers": [
-              {
-                "type": "id-qt-cps",
-                "value": "http://example.com/cps"
-              }
+        "issuance": {
+            "profile": {
+                "allowMustStaple": true,
+                "allowCTPoison": true,
+                "allowSCTList": true,
+                "allowCommonName": true,
+                "policies": [
+                    {
+                        "oid": "2.23.140.1.2.1"
+                    },
+                    {
+                        "oid": "1.2.3.4",
+                        "qualifiers": [
+                            {
+                                "type": "id-qt-cps",
+                                "value": "http://example.com/cps"
+                            }
+                        ]
+                    }
+                ],
+                "maxValidityPeriod": "7776000s",
+                "maxValidityBackdate": "1h5m"
+            },
+            "issuers": [
+                {
+                    "useForRSALeaves": true,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "test/test-ca.key-pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": false,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "test/test-ca.key-pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+                        "numSessions": 2
+                    }
+                }
+            ],
+            "ignoredLints": [
+                "n_subject_common_name_included"
             ]
-          }
-        ],
-        "maxValidityPeriod": "7776000s",
-        "maxValidityBackdate": "1h5m"
-      },
-      "issuers": [
-        {
-          "useForRSALeaves": true,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "test/test-ca.key-pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-            "numSessions": 2
-          }
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-            "numSessions": 2
-          }
+        "expiry": "7776000s",
+        "backdate": "1h",
+        "serialPrefix": 255,
+        "maxNames": 100,
+        "lifespanOCSP": "96h",
+        "lifespanCRL": "216h",
+        "crldpBase": "http://c.boulder.test",
+        "goodkey": {
+            "weakKeyFile": "test/example-weak-keys.json",
+            "blockedKeyFile": "test/example-blocked-keys.yaml",
+            "fermatRounds": 100
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": false,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "test/test-ca.key-pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-            "numSessions": 2
-          }
+        "orphanQueueDir": "/tmp/orphaned-certificates-a",
+        "ocspLogMaxLength": 4000,
+        "ocspLogPeriod": "500ms",
+        "ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
+        "features": {}
+    },
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
         }
-      ],
-      "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "7776000s",
-    "backdate": "1h",
-    "serialPrefix": 255,
-    "maxNames": 100,
-    "lifespanOCSP": "96h",
-    "lifespanCRL": "216h",
-    "crldpBase": "http://c.boulder.test",
-    "goodkey": {
-      "weakKeyFile": "test/example-weak-keys.json",
-      "blockedKeyFile": "test/example-blocked-keys.yaml",
-      "fermatRounds": 100
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "orphanQueueDir": "/tmp/orphaned-certificates-a",
-    "ocspLogMaxLength": 4000,
-    "ocspLogPeriod": "500ms",
-    "ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
-    "features": {}
-  },
-
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
 }

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -1,175 +1,177 @@
 {
-  "ca": {
-    "debugAddr": ":8001",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-    },
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "grpcCA": {
-      "maxConnectionAge": "30s",
-      "address": ":9093",
-      "services": {
-        "ca.CertificateAuthority": {
-          "clientNames": [
-            "ra.boulder"
-          ]
+    "ca": {
+        "debugAddr": ":8001",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
         },
-        "ca.OCSPGenerator": {
-          "clientNames": [
-            "ocsp-updater.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder"
-          ]
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "grpcCA": {
+            "maxConnectionAge": "30s",
+            "address": ":9093",
+            "services": {
+                "ca.CertificateAuthority": {
+                    "clientNames": [
+                        "ra.boulder"
+                    ]
+                },
+                "ca.OCSPGenerator": {
+                    "clientNames": [
+                        "ocsp-updater.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "ca.CRLGenerator": {
+                    "clientNames": [
+                        "crl-updater.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "ca.CRLGenerator": {
-          "clientNames": [
-            "crl-updater.boulder"
-          ]
+        "grpcOCSPGenerator": {
+            "maxConnectionAge": "30s",
+            "address": ":9096",
+            "services": {
+                "ca.OCSPGenerator": {
+                    "clientNames": [
+                        "ocsp-updater.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "grpcOCSPGenerator": {
-      "maxConnectionAge": "30s",
-      "address": ":9096",
-      "services": {
-        "ca.OCSPGenerator": {
-          "clientNames": [
-            "ocsp-updater.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder"
-          ]
+        "grpcCRLGenerator": {
+            "maxConnectionAge": "30s",
+            "address": ":9106",
+            "services": {
+                "ca.CRLGenerator": {
+                    "clientNames": [
+                        "crl-updater.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "grpcCRLGenerator": {
-      "maxConnectionAge": "30s",
-      "address": ":9106",
-      "services": {
-        "ca.CRLGenerator": {
-          "clientNames": [
-            "crl-updater.boulder"
-          ]
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
-        }
-      }
-    },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "issuance": {
-      "profile": {
-        "allowMustStaple": true,
-        "allowCTPoison": true,
-        "allowSCTList": true,
-        "allowCommonName": true,
-        "policies": [
-          {
-            "oid": "2.23.140.1.2.1"
-          },
-          {
-            "oid": "1.2.3.4",
-            "qualifiers": [
-              {
-                "type": "id-qt-cps",
-                "value": "http://example.com/cps"
-              }
+        "issuance": {
+            "profile": {
+                "allowMustStaple": true,
+                "allowCTPoison": true,
+                "allowSCTList": true,
+                "allowCommonName": true,
+                "policies": [
+                    {
+                        "oid": "2.23.140.1.2.1"
+                    },
+                    {
+                        "oid": "1.2.3.4",
+                        "qualifiers": [
+                            {
+                                "type": "id-qt-cps",
+                                "value": "http://example.com/cps"
+                            }
+                        ]
+                    }
+                ],
+                "maxValidityPeriod": "7776000s",
+                "maxValidityBackdate": "1h5m"
+            },
+            "issuers": [
+                {
+                    "useForRSALeaves": true,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "test/test-ca.key-pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": true,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "location": {
+                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                        "numSessions": 2
+                    }
+                },
+                {
+                    "useForRSALeaves": false,
+                    "useForECDSALeaves": false,
+                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+                    "ocspURL": "http://127.0.0.1:4002/",
+                    "crlURL": "http://example.com/crl",
+                    "location": {
+                        "configFile": "test/test-ca.key-pkcs11.json",
+                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+                        "numSessions": 2
+                    }
+                }
+            ],
+            "ignoredLints": [
+                "n_subject_common_name_included"
             ]
-          }
-        ],
-        "maxValidityPeriod": "7776000s",
-        "maxValidityBackdate": "1h5m"
-      },
-      "issuers": [
-        {
-          "useForRSALeaves": true,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "test/test-ca.key-pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-            "numSessions": 2
-          }
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": true,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "location": {
-            "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-            "numSessions": 2
-          }
+        "expiry": "7776000s",
+        "backdate": "1h",
+        "serialPrefix": 255,
+        "maxNames": 100,
+        "lifespanOCSP": "96h",
+        "lifespanCRL": "216h",
+        "crldpBase": "http://c.boulder.test",
+        "goodkey": {
+            "weakKeyFile": "test/example-weak-keys.json",
+            "blockedKeyFile": "test/example-blocked-keys.yaml",
+            "fermatRounds": 100
         },
-        {
-          "useForRSALeaves": false,
-          "useForECDSALeaves": false,
-          "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-          "ocspURL": "http://127.0.0.1:4002/",
-          "crlURL": "http://example.com/crl",
-          "location": {
-            "configFile": "test/test-ca.key-pkcs11.json",
-            "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-            "numSessions": 2
-          }
+        "orphanQueueDir": "/tmp/orphaned-certificates-b",
+        "ocspLogMaxLength": 4000,
+        "ocspLogPeriod": "500ms",
+        "ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
+        "features": {}
+    },
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
         }
-      ],
-      "ignoredLints": ["n_subject_common_name_included"]
     },
-    "expiry": "7776000s",
-    "backdate": "1h",
-    "serialPrefix": 255,
-    "maxNames": 100,
-    "lifespanOCSP": "96h",
-    "lifespanCRL": "216h",
-    "crldpBase": "http://c.boulder.test",
-    "goodkey": {
-      "weakKeyFile": "test/example-weak-keys.json",
-      "blockedKeyFile": "test/example-blocked-keys.yaml",
-      "fermatRounds": 100
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "orphanQueueDir": "/tmp/orphaned-certificates-b",
-    "ocspLogMaxLength": 4000,
-    "ocspLogPeriod": "500ms",
-    "ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
-    "features": {}
-  },
-
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
 }

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -1,177 +1,177 @@
 {
-    "ca": {
-        "debugAddr": ":8001",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ca.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ca.boulder/key.pem"
-        },
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "grpcCA": {
-            "maxConnectionAge": "30s",
-            "address": ":9093",
-            "services": {
-                "ca.CertificateAuthority": {
-                    "clientNames": [
-                        "ra.boulder"
-                    ]
-                },
-                "ca.OCSPGenerator": {
-                    "clientNames": [
-                        "ocsp-updater.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "ca.CRLGenerator": {
-                    "clientNames": [
-                        "crl-updater.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "grpcOCSPGenerator": {
-            "maxConnectionAge": "30s",
-            "address": ":9096",
-            "services": {
-                "ca.OCSPGenerator": {
-                    "clientNames": [
-                        "ocsp-updater.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "grpcCRLGenerator": {
-            "maxConnectionAge": "30s",
-            "address": ":9106",
-            "services": {
-                "ca.CRLGenerator": {
-                    "clientNames": [
-                        "crl-updater.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "issuance": {
-            "profile": {
-                "allowMustStaple": true,
-                "allowCTPoison": true,
-                "allowSCTList": true,
-                "allowCommonName": true,
-                "policies": [
-                    {
-                        "oid": "2.23.140.1.2.1"
-                    },
-                    {
-                        "oid": "1.2.3.4",
-                        "qualifiers": [
-                            {
-                                "type": "id-qt-cps",
-                                "value": "http://example.com/cps"
-                            }
-                        ]
-                    }
-                ],
-                "maxValidityPeriod": "7776000s",
-                "maxValidityBackdate": "1h5m"
-            },
-            "issuers": [
-                {
-                    "useForRSALeaves": true,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "test/test-ca.key-pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": true,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "location": {
-                        "configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                        "numSessions": 2
-                    }
-                },
-                {
-                    "useForRSALeaves": false,
-                    "useForECDSALeaves": false,
-                    "issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
-                    "ocspURL": "http://127.0.0.1:4002/",
-                    "crlURL": "http://example.com/crl",
-                    "location": {
-                        "configFile": "test/test-ca.key-pkcs11.json",
-                        "certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
-                        "numSessions": 2
-                    }
-                }
-            ],
-            "ignoredLints": [
-                "n_subject_common_name_included"
-            ]
-        },
-        "expiry": "7776000s",
-        "backdate": "1h",
-        "serialPrefix": 255,
-        "maxNames": 100,
-        "lifespanOCSP": "96h",
-        "lifespanCRL": "216h",
-        "crldpBase": "http://c.boulder.test",
-        "goodkey": {
-            "weakKeyFile": "test/example-weak-keys.json",
-            "blockedKeyFile": "test/example-blocked-keys.yaml",
-            "fermatRounds": 100
-        },
-        "orphanQueueDir": "/tmp/orphaned-certificates-b",
-        "ocspLogMaxLength": 4000,
-        "ocspLogPeriod": "500ms",
-        "ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
-        "features": {}
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"ca": {
+		"debugAddr": ":8001",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ca.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ca.boulder/key.pem"
+		},
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"grpcCA": {
+			"maxConnectionAge": "30s",
+			"address": ":9093",
+			"services": {
+				"ca.CertificateAuthority": {
+					"clientNames": [
+						"ra.boulder"
+					]
+				},
+				"ca.OCSPGenerator": {
+					"clientNames": [
+						"ocsp-updater.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder"
+					]
+				},
+				"ca.CRLGenerator": {
+					"clientNames": [
+						"crl-updater.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"grpcOCSPGenerator": {
+			"maxConnectionAge": "30s",
+			"address": ":9096",
+			"services": {
+				"ca.OCSPGenerator": {
+					"clientNames": [
+						"ocsp-updater.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"grpcCRLGenerator": {
+			"maxConnectionAge": "30s",
+			"address": ":9106",
+			"services": {
+				"ca.CRLGenerator": {
+					"clientNames": [
+						"crl-updater.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"issuance": {
+			"profile": {
+				"allowMustStaple": true,
+				"allowCTPoison": true,
+				"allowSCTList": true,
+				"allowCommonName": true,
+				"policies": [
+					{
+						"oid": "2.23.140.1.2.1"
+					},
+					{
+						"oid": "1.2.3.4",
+						"qualifiers": [
+							{
+								"type": "id-qt-cps",
+								"value": "http://example.com/cps"
+							}
+						]
+					}
+				],
+				"maxValidityPeriod": "7776000s",
+				"maxValidityBackdate": "1h5m"
+			},
+			"issuers": [
+				{
+					"useForRSALeaves": true,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "test/test-ca.key-pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": true,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/5214744660557630",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"location": {
+						"configFile": "/hierarchy/intermediate-signing-key-ecdsa.pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-ecdsa-a.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"useForRSALeaves": false,
+					"useForECDSALeaves": false,
+					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
+					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURL": "http://example.com/crl",
+					"location": {
+						"configFile": "test/test-ca.key-pkcs11.json",
+						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",
+						"numSessions": 2
+					}
+				}
+			],
+			"ignoredLints": [
+				"n_subject_common_name_included"
+			]
+		},
+		"expiry": "7776000s",
+		"backdate": "1h",
+		"serialPrefix": 255,
+		"maxNames": 100,
+		"lifespanOCSP": "96h",
+		"lifespanCRL": "216h",
+		"crldpBase": "http://c.boulder.test",
+		"goodkey": {
+			"weakKeyFile": "test/example-weak-keys.json",
+			"blockedKeyFile": "test/example-blocked-keys.yaml",
+			"fermatRounds": 100
+		},
+		"orphanQueueDir": "/tmp/orphaned-certificates-b",
+		"ocspLogMaxLength": 4000,
+		"ocspLogPeriod": "500ms",
+		"ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
+		"features": {}
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -1,33 +1,33 @@
 {
-    "certChecker": {
-        "db": {
-            "dbConnectFile": "test/secrets/cert_checker_dburl",
-            "maxOpenConns": 10
-        },
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "goodkey": {
-            "fermatRounds": 100
-        },
-        "workers": 16,
-        "unexpiredOnly": true,
-        "badResultsOnly": true,
-        "checkPeriod": "72h",
-        "acceptableValidityDurations": [
-            "7776000s"
-        ],
-        "ignoredLints": [
-            "n_subject_common_name_included"
-        ]
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    }
+	"certChecker": {
+		"db": {
+			"dbConnectFile": "test/secrets/cert_checker_dburl",
+			"maxOpenConns": 10
+		},
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"goodkey": {
+			"fermatRounds": 100
+		},
+		"workers": 16,
+		"unexpiredOnly": true,
+		"badResultsOnly": true,
+		"checkPeriod": "72h",
+		"acceptableValidityDurations": [
+			"7776000s"
+		],
+		"ignoredLints": [
+			"n_subject_common_name_included"
+		]
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	}
 }

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -1,33 +1,33 @@
 {
-  "certChecker": {
-    "db": {
-      "dbConnectFile": "test/secrets/cert_checker_dburl",
-      "maxOpenConns": 10
+    "certChecker": {
+        "db": {
+            "dbConnectFile": "test/secrets/cert_checker_dburl",
+            "maxOpenConns": 10
+        },
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "goodkey": {
+            "fermatRounds": 100
+        },
+        "workers": 16,
+        "unexpiredOnly": true,
+        "badResultsOnly": true,
+        "checkPeriod": "72h",
+        "acceptableValidityDurations": [
+            "7776000s"
+        ],
+        "ignoredLints": [
+            "n_subject_common_name_included"
+        ]
     },
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "goodkey": {
-      "fermatRounds": 100
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
+        }
     },
-    "workers": 16,
-    "unexpiredOnly": true,
-    "badResultsOnly": true,
-    "checkPeriod": "72h",
-    "acceptableValidityDurations": ["7776000s"],
-    "ignoredLints": [
-      "n_subject_common_name_included"
-    ]
-  },
-
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  }
 }

--- a/test/config/contact-auditor.json
+++ b/test/config/contact-auditor.json
@@ -1,8 +1,8 @@
 {
-    "contactAuditor": {
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        }
-    }
+	"contactAuditor": {
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		}
+	}
 }

--- a/test/config/contact-auditor.json
+++ b/test/config/contact-auditor.json
@@ -1,8 +1,8 @@
 {
-  "contactAuditor": {
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "contactAuditor": {
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        }
     }
-  }
 }

--- a/test/config/contact-exporter.json
+++ b/test/config/contact-exporter.json
@@ -1,9 +1,9 @@
 {
-    "contactExporter": {
-        "passwordFile": "test/secrets/smtp_password",
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        }
-    }
+	"contactExporter": {
+		"passwordFile": "test/secrets/smtp_password",
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		}
+	}
 }

--- a/test/config/contact-exporter.json
+++ b/test/config/contact-exporter.json
@@ -1,9 +1,9 @@
 {
-  "contactExporter": {
-    "passwordFile": "test/secrets/smtp_password",
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "contactExporter": {
+        "passwordFile": "test/secrets/smtp_password",
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        }
     }
-  }
 }

--- a/test/config/crl-storer.json
+++ b/test/config/crl-storer.json
@@ -1,37 +1,38 @@
 {
-  "crlStorer": {
-    "debugAddr": ":9667",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
+    "crlStorer": {
+        "debugAddr": ":9667",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
+        },
+        "grpc": {
+            "address": ":9109",
+            "maxConnectionAge": "30s",
+            "clientNames": [
+                "health-checker.boulder",
+                "crl-updater.boulder"
+            ]
+        },
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "s3Endpoint": "http://localhost:7890",
+        "s3Bucket": "lets-encrypt-crls",
+        "awsConfigFile": "test/config/crl-storer.ini",
+        "awsCredsFile": "test/secrets/aws_creds.ini"
     },
-    "grpc": {
-      "address": ":9109",
-      "maxConnectionAge": "30s",
-      "clientNames": [
-        "health-checker.boulder",
-        "crl-updater.boulder"
-      ]
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "s3Endpoint": "http://localhost:7890",
-    "s3Bucket": "lets-encrypt-crls",
-    "awsConfigFile": "test/config/crl-storer.ini",
-    "awsCredsFile": "test/secrets/aws_creds.ini"
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    }
 }

--- a/test/config/crl-storer.json
+++ b/test/config/crl-storer.json
@@ -1,38 +1,38 @@
 {
-    "crlStorer": {
-        "debugAddr": ":9667",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
-        },
-        "grpc": {
-            "address": ":9109",
-            "maxConnectionAge": "30s",
-            "clientNames": [
-                "health-checker.boulder",
-                "crl-updater.boulder"
-            ]
-        },
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "s3Endpoint": "http://localhost:7890",
-        "s3Bucket": "lets-encrypt-crls",
-        "awsConfigFile": "test/config/crl-storer.ini",
-        "awsCredsFile": "test/secrets/aws_creds.ini"
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"crlStorer": {
+		"debugAddr": ":9667",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/crl-storer.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/crl-storer.boulder/key.pem"
+		},
+		"grpc": {
+			"address": ":9109",
+			"maxConnectionAge": "30s",
+			"clientNames": [
+				"health-checker.boulder",
+				"crl-updater.boulder"
+			]
+		},
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"s3Endpoint": "http://localhost:7890",
+		"s3Bucket": "lets-encrypt-crls",
+		"awsConfigFile": "test/config/crl-storer.ini",
+		"awsCredsFile": "test/secrets/aws_creds.ini"
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/crl-updater.json
+++ b/test/config/crl-updater.json
@@ -1,45 +1,46 @@
 {
-  "crlUpdater": {
-    "debugAddr": ":8021",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
+    "crlUpdater": {
+        "debugAddr": ":8021",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
+        },
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "crlGeneratorService": {
+            "serverAddress": "ca.service.consul:9093",
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "crlStorerService": {
+            "serverAddress": "crl-storer.service.consul:9109",
+            "timeout": "15s",
+            "hostOverride": "crl-storer.boulder"
+        },
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "numShards": 10,
+        "certificateLifetime": "2160h",
+        "updatePeriod": "6h",
+        "updateOffset": "9120s",
+        "maxParallelism": 10
     },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "crlGeneratorService": {
-      "serverAddress": "ca.service.consul:9093",
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "crlStorerService": {
-      "serverAddress": "crl-storer.service.consul:9109",
-      "timeout": "15s",
-      "hostOverride": "crl-storer.boulder"
-    },
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "numShards": 10,
-    "certificateLifetime": "2160h",
-    "updatePeriod": "6h",
-    "updateOffset": "9120s",
-    "maxParallelism": 10
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-    "mute": true,
-    "serviceName": "Test",
-    "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    }
 }

--- a/test/config/crl-updater.json
+++ b/test/config/crl-updater.json
@@ -1,46 +1,46 @@
 {
-    "crlUpdater": {
-        "debugAddr": ":8021",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "crlGeneratorService": {
-            "serverAddress": "ca.service.consul:9093",
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "crlStorerService": {
-            "serverAddress": "crl-storer.service.consul:9109",
-            "timeout": "15s",
-            "hostOverride": "crl-storer.boulder"
-        },
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "numShards": 10,
-        "certificateLifetime": "2160h",
-        "updatePeriod": "6h",
-        "updateOffset": "9120s",
-        "maxParallelism": 10
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"crlUpdater": {
+		"debugAddr": ":8021",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"crlGeneratorService": {
+			"serverAddress": "ca.service.consul:9093",
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"crlStorerService": {
+			"serverAddress": "crl-storer.service.consul:9109",
+			"timeout": "15s",
+			"hostOverride": "crl-storer.boulder"
+		},
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"numShards": 10,
+		"certificateLifetime": "2160h",
+		"updatePeriod": "6h",
+		"updateOffset": "9120s",
+		"maxParallelism": 10
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -1,39 +1,43 @@
 {
-  "mailer": {
-    "server": "localhost",
-    "port": "9380",
-    "username": "cert-manager@example.com",
-    "from": "Expiry bot <expiration-mailer@test.org>",
-    "passwordFile": "test/secrets/smtp_password",
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "mailer": {
+        "server": "localhost",
+        "port": "9380",
+        "username": "cert-manager@example.com",
+        "from": "Expiry bot <expiration-mailer@test.org>",
+        "passwordFile": "test/secrets/smtp_password",
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        },
+        "certLimit": 100000,
+        "nagTimes": [
+            "480h",
+            "240h"
+        ],
+        "emailTemplate": "test/config/expiration-mailer.gotmpl",
+        "debugAddr": ":8008",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
+        },
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+        "frequency": "1h"
     },
-    "certLimit": 100000,
-    "nagTimes": ["480h", "240h"],
-    "emailTemplate": "test/config/expiration-mailer.gotmpl",
-    "debugAddr": ":8008",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-    "frequency": "1h"
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    }
 }

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -1,43 +1,43 @@
 {
-    "mailer": {
-        "server": "localhost",
-        "port": "9380",
-        "username": "cert-manager@example.com",
-        "from": "Expiry bot <expiration-mailer@test.org>",
-        "passwordFile": "test/secrets/smtp_password",
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        },
-        "certLimit": 100000,
-        "nagTimes": [
-            "480h",
-            "240h"
-        ],
-        "emailTemplate": "test/config/expiration-mailer.gotmpl",
-        "debugAddr": ":8008",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
-        "frequency": "1h"
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"mailer": {
+		"server": "localhost",
+		"port": "9380",
+		"username": "cert-manager@example.com",
+		"from": "Expiry bot <expiration-mailer@test.org>",
+		"passwordFile": "test/secrets/smtp_password",
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		},
+		"certLimit": 100000,
+		"nagTimes": [
+			"480h",
+			"240h"
+		],
+		"emailTemplate": "test/config/expiration-mailer.gotmpl",
+		"debugAddr": ":8008",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/expiration-mailer.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",
+		"frequency": "1h"
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/health-checker.json
+++ b/test/config/health-checker.json
@@ -1,10 +1,10 @@
 {
-  "grpc": {
-    "timeout": "1s"
-  },
-  "tls": {
-    "caCertFile": "test/grpc-creds/minica.pem",
-    "certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
-    "keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
-  }
+    "grpc": {
+        "timeout": "1s"
+    },
+    "tls": {
+        "caCertFile": "test/grpc-creds/minica.pem",
+        "certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
+        "keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
+    }
 }

--- a/test/config/health-checker.json
+++ b/test/config/health-checker.json
@@ -1,10 +1,10 @@
 {
-    "grpc": {
-        "timeout": "1s"
-    },
-    "tls": {
-        "caCertFile": "test/grpc-creds/minica.pem",
-        "certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
-        "keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
-    }
+	"grpc": {
+		"timeout": "1s"
+	},
+	"tls": {
+		"caCertFile": "test/grpc-creds/minica.pem",
+		"certFile": "test/grpc-creds/health-checker.boulder/cert.pem",
+		"keyFile": "test/grpc-creds/health-checker.boulder/key.pem"
+	}
 }

--- a/test/config/log-validator.json
+++ b/test/config/log-validator.json
@@ -1,30 +1,30 @@
 {
-    "syslog": {
-        "stdoutLevel": 7
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    },
-    "debugAddr": ":8016",
-    "files": [
-        "/var/log/akamai-purger.log",
-        "/var/log/bad-key-revoker.log",
-        "/var/log/boulder-ca.log",
-        "/var/log/boulder-observer.log",
-        "/var/log/boulder-publisher.log",
-        "/var/log/boulder-ra.log",
-        "/var/log/boulder-remoteva.log",
-        "/var/log/boulder-sa.log",
-        "/var/log/boulder-va.log",
-        "/var/log/boulder-wfe2.log",
-        "/var/log/crl-storer.log",
-        "/var/log/crl-updater.log",
-        "/var/log/nonce-service.log",
-        "/var/log/ocsp-responder.log",
-        "/var/log/ocsp-updater.log"
-    ]
+	"syslog": {
+		"stdoutLevel": 7
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	},
+	"debugAddr": ":8016",
+	"files": [
+		"/var/log/akamai-purger.log",
+		"/var/log/bad-key-revoker.log",
+		"/var/log/boulder-ca.log",
+		"/var/log/boulder-observer.log",
+		"/var/log/boulder-publisher.log",
+		"/var/log/boulder-ra.log",
+		"/var/log/boulder-remoteva.log",
+		"/var/log/boulder-sa.log",
+		"/var/log/boulder-va.log",
+		"/var/log/boulder-wfe2.log",
+		"/var/log/crl-storer.log",
+		"/var/log/crl-updater.log",
+		"/var/log/nonce-service.log",
+		"/var/log/ocsp-responder.log",
+		"/var/log/ocsp-updater.log"
+	]
 }

--- a/test/config/log-validator.json
+++ b/test/config/log-validator.json
@@ -1,28 +1,30 @@
 {
-  "syslog": {
-    "stdoutLevel": 7
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  },
-  "debugAddr": ":8016",
-  "files": [
-    "/var/log/akamai-purger.log",
-    "/var/log/bad-key-revoker.log",
-    "/var/log/boulder-ca.log",
-    "/var/log/boulder-observer.log",
-    "/var/log/boulder-publisher.log",
-    "/var/log/boulder-ra.log",
-    "/var/log/boulder-remoteva.log",
-    "/var/log/boulder-sa.log",
-    "/var/log/boulder-va.log",
-    "/var/log/boulder-wfe2.log",
-    "/var/log/crl-storer.log",
-    "/var/log/crl-updater.log",
-    "/var/log/nonce-service.log",
-    "/var/log/ocsp-responder.log",
-    "/var/log/ocsp-updater.log"
-  ]
+    "syslog": {
+        "stdoutLevel": 7
+    },
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    },
+    "debugAddr": ":8016",
+    "files": [
+        "/var/log/akamai-purger.log",
+        "/var/log/bad-key-revoker.log",
+        "/var/log/boulder-ca.log",
+        "/var/log/boulder-observer.log",
+        "/var/log/boulder-publisher.log",
+        "/var/log/boulder-ra.log",
+        "/var/log/boulder-remoteva.log",
+        "/var/log/boulder-sa.log",
+        "/var/log/boulder-va.log",
+        "/var/log/boulder-wfe2.log",
+        "/var/log/crl-storer.log",
+        "/var/log/crl-updater.log",
+        "/var/log/nonce-service.log",
+        "/var/log/ocsp-responder.log",
+        "/var/log/ocsp-updater.log"
+    ]
 }

--- a/test/config/nonce-a.json
+++ b/test/config/nonce-a.json
@@ -9,7 +9,9 @@
         "beeline": {
             "mute": true,
             "serviceName": "Test",
-            "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
+            "writeKey": {
+                "passwordFile": "test/secrets/honeycomb_fake_password"
+            }
         },
         "debugAddr": ":8111",
         "grpc": {

--- a/test/config/nonce-a.json
+++ b/test/config/nonce-a.json
@@ -1,31 +1,31 @@
 {
-    "NonceService": {
-        "maxUsed": 131072,
-        "noncePrefix": "taro",
-        "syslog": {
-            "stdoutLevel": 6,
-            "syslogLevel": 6
-        },
-        "beeline": {
-            "mute": true,
-            "serviceName": "Test",
-            "writeKey": {
-                "passwordFile": "test/secrets/honeycomb_fake_password"
-            }
-        },
-        "debugAddr": ":8111",
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9101",
-            "clientNames": [
-                "health-checker.boulder",
-                "wfe.boulder"
-            ]
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
-        }
-    }
+	"NonceService": {
+		"maxUsed": 131072,
+		"noncePrefix": "taro",
+		"syslog": {
+			"stdoutLevel": 6,
+			"syslogLevel": 6
+		},
+		"beeline": {
+			"mute": true,
+			"serviceName": "Test",
+			"writeKey": {
+				"passwordFile": "test/secrets/honeycomb_fake_password"
+			}
+		},
+		"debugAddr": ":8111",
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9101",
+			"clientNames": [
+				"health-checker.boulder",
+				"wfe.boulder"
+			]
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/nonce.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/nonce.boulder/key.pem"
+		}
+	}
 }

--- a/test/config/nonce-b.json
+++ b/test/config/nonce-b.json
@@ -9,7 +9,9 @@
         "beeline": {
             "mute": true,
             "serviceName": "Test",
-            "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
+            "writeKey": {
+                "passwordFile": "test/secrets/honeycomb_fake_password"
+            }
         },
         "debugAddr": ":8111",
         "grpc": {

--- a/test/config/nonce-b.json
+++ b/test/config/nonce-b.json
@@ -1,31 +1,31 @@
 {
-    "NonceService": {
-        "maxUsed": 131072,
-        "noncePrefix": "zinc",
-        "syslog": {
-            "stdoutLevel": 6,
-            "syslogLevel": 6
-        },
-        "beeline": {
-            "mute": true,
-            "serviceName": "Test",
-            "writeKey": {
-                "passwordFile": "test/secrets/honeycomb_fake_password"
-            }
-        },
-        "debugAddr": ":8111",
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9101",
-            "clientNames": [
-                "health-checker.boulder",
-                "wfe.boulder"
-            ]
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/nonce.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/nonce.boulder/key.pem"
-        }
-    }
+	"NonceService": {
+		"maxUsed": 131072,
+		"noncePrefix": "zinc",
+		"syslog": {
+			"stdoutLevel": 6,
+			"syslogLevel": 6
+		},
+		"beeline": {
+			"mute": true,
+			"serviceName": "Test",
+			"writeKey": {
+				"passwordFile": "test/secrets/honeycomb_fake_password"
+			}
+		},
+		"debugAddr": ":8111",
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9101",
+			"clientNames": [
+				"health-checker.boulder",
+				"wfe.boulder"
+			]
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/nonce.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/nonce.boulder/key.pem"
+		}
+	}
 }

--- a/test/config/notify-mailer.json
+++ b/test/config/notify-mailer.json
@@ -1,16 +1,16 @@
 {
-    "notifyMailer": {
-        "server": "localhost",
-        "port": "9380",
-        "username": "cert-manager@example.com",
-        "passwordFile": "test/secrets/smtp_password",
-        "db": {
-            "dbConnectFile": "test/secrets/mailer_dburl",
-            "maxOpenConns": 10
-        }
-    },
-    "syslog": {
-        "stdoutLevel": 7,
-        "syslogLevel": 7
-    }
+	"notifyMailer": {
+		"server": "localhost",
+		"port": "9380",
+		"username": "cert-manager@example.com",
+		"passwordFile": "test/secrets/smtp_password",
+		"db": {
+			"dbConnectFile": "test/secrets/mailer_dburl",
+			"maxOpenConns": 10
+		}
+	},
+	"syslog": {
+		"stdoutLevel": 7,
+		"syslogLevel": 7
+	}
 }

--- a/test/config/notify-mailer.json
+++ b/test/config/notify-mailer.json
@@ -1,16 +1,16 @@
 {
-  "notifyMailer": {
-    "server": "localhost",
-    "port": "9380",
-    "username": "cert-manager@example.com",
-    "passwordFile": "test/secrets/smtp_password",
-    "db": {
-      "dbConnectFile": "test/secrets/mailer_dburl",
-      "maxOpenConns": 10
+    "notifyMailer": {
+        "server": "localhost",
+        "port": "9380",
+        "username": "cert-manager@example.com",
+        "passwordFile": "test/secrets/smtp_password",
+        "db": {
+            "dbConnectFile": "test/secrets/mailer_dburl",
+            "maxOpenConns": 10
+        }
+    },
+    "syslog": {
+        "stdoutLevel": 7,
+        "syslogLevel": 7
     }
-  },
-  "syslog": {
-    "stdoutLevel": 7,
-    "syslogLevel": 7
-  }
 }

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -1,63 +1,66 @@
 {
-  "ocspResponder": {
-    "db": {
-      "dbConnectFile": "test/secrets/ocsp_responder_dburl",
-      "maxOpenConns": 10
+    "ocspResponder": {
+        "db": {
+            "dbConnectFile": "test/secrets/ocsp_responder_dburl",
+            "maxOpenConns": 10
+        },
+        "redis": {
+            "username": "ocsp-responder",
+            "passwordFile": "test/secrets/ocsp_responder_redis_password",
+            "shardAddrs": {
+                "shard1": "10.33.33.2:4218",
+                "shard2": "10.33.33.3:4218"
+            },
+            "timeout": "5s",
+            "poolSize": 100,
+            "routeRandomly": true,
+            "tls": {
+                "caCertFile": "test/redis-tls/minica.pem",
+                "certFile": "test/redis-tls/boulder/cert.pem",
+                "keyFile": "test/redis-tls/boulder/key.pem"
+            }
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
+        },
+        "raService": {
+            "serverAddress": "ra.service.consul:9094",
+            "hostOverride": "ra.boulder",
+            "timeout": "15s"
+        },
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "logSampleRate": 1,
+        "path": "/",
+        "listenAddress": "0.0.0.0:4002",
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "liveSigningPeriod": "60h",
+        "timeout": "4.9s",
+        "shutdownStopTimeout": "10s",
+        "debugAddr": ":8005",
+        "requiredSerialPrefixes": [
+            "ff"
+        ],
+        "features": {}
     },
-    "redis": {
-      "username": "ocsp-responder",
-      "passwordFile": "test/secrets/ocsp_responder_redis_password",
-      "shardAddrs": {
-        "shard1": "10.33.33.2:4218",
-        "shard2": "10.33.33.3:4218"
-      },
-      "timeout": "5s",
-      "poolSize": 100,
-      "routeRandomly": true,
-      "tls": {
-        "caCertFile": "test/redis-tls/minica.pem",
-        "certFile": "test/redis-tls/boulder/cert.pem",
-        "keyFile": "test/redis-tls/boulder/key.pem"
-      }
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": -1
     },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
-    },
-    "raService": {
-      "serverAddress": "ra.service.consul:9094",
-      "hostOverride": "ra.boulder",
-      "timeout": "15s"
-    },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "logSampleRate": 1,
-    "path": "/",
-    "listenAddress": "0.0.0.0:4002",
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "liveSigningPeriod": "60h",
-    "timeout": "4.9s",
-    "shutdownStopTimeout": "10s",
-    "debugAddr": ":8005",
-    "requiredSerialPrefixes": ["ff"],
-    "features": {}
-  },
-
-  "syslog": {
-   "stdoutlevel": 6,
-   "sysloglevel": -1
- },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
- }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    }
 }

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -1,66 +1,66 @@
 {
-    "ocspResponder": {
-        "db": {
-            "dbConnectFile": "test/secrets/ocsp_responder_dburl",
-            "maxOpenConns": 10
-        },
-        "redis": {
-            "username": "ocsp-responder",
-            "passwordFile": "test/secrets/ocsp_responder_redis_password",
-            "shardAddrs": {
-                "shard1": "10.33.33.2:4218",
-                "shard2": "10.33.33.3:4218"
-            },
-            "timeout": "5s",
-            "poolSize": 100,
-            "routeRandomly": true,
-            "tls": {
-                "caCertFile": "test/redis-tls/minica.pem",
-                "certFile": "test/redis-tls/boulder/cert.pem",
-                "keyFile": "test/redis-tls/boulder/key.pem"
-            }
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
-        },
-        "raService": {
-            "serverAddress": "ra.service.consul:9094",
-            "hostOverride": "ra.boulder",
-            "timeout": "15s"
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "logSampleRate": 1,
-        "path": "/",
-        "listenAddress": "0.0.0.0:4002",
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "liveSigningPeriod": "60h",
-        "timeout": "4.9s",
-        "shutdownStopTimeout": "10s",
-        "debugAddr": ":8005",
-        "requiredSerialPrefixes": [
-            "ff"
-        ],
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": -1
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"ocspResponder": {
+		"db": {
+			"dbConnectFile": "test/secrets/ocsp_responder_dburl",
+			"maxOpenConns": 10
+		},
+		"redis": {
+			"username": "ocsp-responder",
+			"passwordFile": "test/secrets/ocsp_responder_redis_password",
+			"shardAddrs": {
+				"shard1": "10.33.33.2:4218",
+				"shard2": "10.33.33.3:4218"
+			},
+			"timeout": "5s",
+			"poolSize": 100,
+			"routeRandomly": true,
+			"tls": {
+				"caCertFile": "test/redis-tls/minica.pem",
+				"certFile": "test/redis-tls/boulder/cert.pem",
+				"keyFile": "test/redis-tls/boulder/key.pem"
+			}
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ocsp-responder.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
+		},
+		"raService": {
+			"serverAddress": "ra.service.consul:9094",
+			"hostOverride": "ra.boulder",
+			"timeout": "15s"
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"logSampleRate": 1,
+		"path": "/",
+		"listenAddress": "0.0.0.0:4002",
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"liveSigningPeriod": "60h",
+		"timeout": "4.9s",
+		"shutdownStopTimeout": "10s",
+		"debugAddr": ":8005",
+		"requiredSerialPrefixes": [
+			"ff"
+		],
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": -1
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -1,41 +1,42 @@
 {
-  "ocspUpdater": {
-    "db": {
-      "dbConnectFile": "test/secrets/ocsp_updater_dburl",
-      "maxOpenConns": 10
+    "ocspUpdater": {
+        "db": {
+            "dbConnectFile": "test/secrets/ocsp_updater_dburl",
+            "maxOpenConns": 10
+        },
+        "readOnlyDB": {
+            "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
+            "maxOpenConns": 100
+        },
+        "oldOCSPWindow": "2s",
+        "oldOCSPBatchSize": 5000,
+        "parallelGenerateOCSPRequests": 10,
+        "ocspMinTimeToExpiry": "72h",
+        "signFailureBackoffFactor": 1.2,
+        "signFailureBackoffMax": "30m",
+        "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
+        "debugAddr": ":8006",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
+        },
+        "ocspGeneratorService": {
+            "serverAddress": "ca.service.consul:9093",
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "features": {}
     },
-    "readOnlyDB": {
-      "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
-      "maxOpenConns": 100
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "oldOCSPWindow": "2s",
-    "oldOCSPBatchSize": 5000,
-    "parallelGenerateOCSPRequests": 10,
-    "ocspMinTimeToExpiry": "72h",
-    "signFailureBackoffFactor": 1.2,
-    "signFailureBackoffMax": "30m",
-    "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
-    "debugAddr": ":8006",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
-    },
-    "ocspGeneratorService": {
-      "serverAddress": "ca.service.consul:9093",
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "features": {}
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    }
 }

--- a/test/config/ocsp-updater.json
+++ b/test/config/ocsp-updater.json
@@ -1,42 +1,42 @@
 {
-    "ocspUpdater": {
-        "db": {
-            "dbConnectFile": "test/secrets/ocsp_updater_dburl",
-            "maxOpenConns": 10
-        },
-        "readOnlyDB": {
-            "dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
-            "maxOpenConns": 100
-        },
-        "oldOCSPWindow": "2s",
-        "oldOCSPBatchSize": 5000,
-        "parallelGenerateOCSPRequests": 10,
-        "ocspMinTimeToExpiry": "72h",
-        "signFailureBackoffFactor": 1.2,
-        "signFailureBackoffMax": "30m",
-        "serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
-        "debugAddr": ":8006",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
-        },
-        "ocspGeneratorService": {
-            "serverAddress": "ca.service.consul:9093",
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"ocspUpdater": {
+		"db": {
+			"dbConnectFile": "test/secrets/ocsp_updater_dburl",
+			"maxOpenConns": 10
+		},
+		"readOnlyDB": {
+			"dbConnectFile": "test/secrets/ocsp_updater_ro_dburl",
+			"maxOpenConns": 100
+		},
+		"oldOCSPWindow": "2s",
+		"oldOCSPBatchSize": 5000,
+		"parallelGenerateOCSPRequests": 10,
+		"ocspMinTimeToExpiry": "72h",
+		"signFailureBackoffFactor": 1.2,
+		"signFailureBackoffMax": "30m",
+		"serialSuffixShards": "0 1 2 3 4 5 6 7 8 9 a b c d e f",
+		"debugAddr": ":8006",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ocsp-updater.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ocsp-updater.boulder/key.pem"
+		},
+		"ocspGeneratorService": {
+			"serverAddress": "ca.service.consul:9093",
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -1,30 +1,27 @@
 {
-  "backdate": "1h",
-  "issuerCerts": [
-    "/hierarchy/intermediate-cert-rsa-a.pem",
-    "/hierarchy/intermediate-cert-rsa-b.pem",
-    "/hierarchy/intermediate-cert-ecdsa-a.pem"
-  ],
-
-  "syslog": {
-    "stdoutlevel": 7,
-    "sysloglevel": 7
-  },
-
-  "tls": {
-    "caCertFile": "test/grpc-creds/minica.pem",
-    "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
-    "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
-  },
-
-  "ocspGeneratorService": {
-    "serverAddress": "ca.service.consul:9093",
-    "timeout": "15s",
-    "hostOverride": "ca.boulder"
-  },
-  "saService": {
-    "serverAddress": "sa.service.consul:9095",
-    "timeout": "15s",
-    "hostOverride": "sa.boulder"
-  }
+    "backdate": "1h",
+    "issuerCerts": [
+        "/hierarchy/intermediate-cert-rsa-a.pem",
+        "/hierarchy/intermediate-cert-rsa-b.pem",
+        "/hierarchy/intermediate-cert-ecdsa-a.pem"
+    ],
+    "syslog": {
+        "stdoutlevel": 7,
+        "sysloglevel": 7
+    },
+    "tls": {
+        "caCertFile": "test/grpc-creds/minica.pem",
+        "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
+        "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
+    },
+    "ocspGeneratorService": {
+        "serverAddress": "ca.service.consul:9093",
+        "timeout": "15s",
+        "hostOverride": "ca.boulder"
+    },
+    "saService": {
+        "serverAddress": "sa.service.consul:9095",
+        "timeout": "15s",
+        "hostOverride": "sa.boulder"
+    }
 }

--- a/test/config/orphan-finder.json
+++ b/test/config/orphan-finder.json
@@ -1,27 +1,27 @@
 {
-    "backdate": "1h",
-    "issuerCerts": [
-        "/hierarchy/intermediate-cert-rsa-a.pem",
-        "/hierarchy/intermediate-cert-rsa-b.pem",
-        "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "syslog": {
-        "stdoutlevel": 7,
-        "sysloglevel": 7
-    },
-    "tls": {
-        "caCertFile": "test/grpc-creds/minica.pem",
-        "certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
-        "keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
-    },
-    "ocspGeneratorService": {
-        "serverAddress": "ca.service.consul:9093",
-        "timeout": "15s",
-        "hostOverride": "ca.boulder"
-    },
-    "saService": {
-        "serverAddress": "sa.service.consul:9095",
-        "timeout": "15s",
-        "hostOverride": "sa.boulder"
-    }
+	"backdate": "1h",
+	"issuerCerts": [
+		"/hierarchy/intermediate-cert-rsa-a.pem",
+		"/hierarchy/intermediate-cert-rsa-b.pem",
+		"/hierarchy/intermediate-cert-ecdsa-a.pem"
+	],
+	"syslog": {
+		"stdoutlevel": 7,
+		"sysloglevel": 7
+	},
+	"tls": {
+		"caCertFile": "test/grpc-creds/minica.pem",
+		"certFile": "test/grpc-creds/orphan-finder.boulder/cert.pem",
+		"keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
+	},
+	"ocspGeneratorService": {
+		"serverAddress": "ca.service.consul:9093",
+		"timeout": "15s",
+		"hostOverride": "ca.boulder"
+	},
+	"saService": {
+		"serverAddress": "sa.service.consul:9095",
+		"timeout": "15s",
+		"hostOverride": "sa.boulder"
+	}
 }

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -1,51 +1,51 @@
 {
-  "publisher": {
-    "userAgent": "boulder/1.0",
-    "blockProfileRate": 1000000000,
-    "chains": [
-      [
-        "/hierarchy/intermediate-cert-rsa-a.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-rsa-b.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-a.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-b.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ]
-    ],
-    "debugAddr": ":8009",
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9091",
-      "clientNames": [
-        "health-checker.boulder",
-        "ocsp-updater.boulder",
-        "ra.boulder"
-      ]
+    "publisher": {
+        "userAgent": "boulder/1.0",
+        "blockProfileRate": 1000000000,
+        "chains": [
+            [
+                "/hierarchy/intermediate-cert-rsa-a.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-rsa-b.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-b.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ]
+        ],
+        "debugAddr": ":8009",
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9091",
+            "clientNames": [
+                "health-checker.boulder",
+                "ocsp-updater.boulder",
+                "ra.boulder"
+            ]
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
+        },
+        "features": {}
     },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "features": {
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
 }

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -1,51 +1,51 @@
 {
-    "publisher": {
-        "userAgent": "boulder/1.0",
-        "blockProfileRate": 1000000000,
-        "chains": [
-            [
-                "/hierarchy/intermediate-cert-rsa-a.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-rsa-b.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-b.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ]
-        ],
-        "debugAddr": ":8009",
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9091",
-            "clientNames": [
-                "health-checker.boulder",
-                "ocsp-updater.boulder",
-                "ra.boulder"
-            ]
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/publisher.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/publisher.boulder/key.pem"
-        },
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"publisher": {
+		"userAgent": "boulder/1.0",
+		"blockProfileRate": 1000000000,
+		"chains": [
+			[
+				"/hierarchy/intermediate-cert-rsa-a.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-rsa-b.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-a.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-b.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			]
+		],
+		"debugAddr": ":8009",
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9091",
+			"clientNames": [
+				"health-checker.boulder",
+				"ocsp-updater.boulder",
+				"ra.boulder"
+			]
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/publisher.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/publisher.boulder/key.pem"
+		},
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -1,112 +1,113 @@
 {
-  "ra": {
-    "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
-    "maxContactsPerRegistration": 3,
-    "debugAddr": ":8002",
-    "hostnamePolicyFile": "test/hostname-policy.yaml",
-    "maxNames": 100,
-    "authorizationLifetimeDays": 30,
-    "pendingAuthorizationLifetimeDays": 7,
-    "goodkey": {
-      "weakKeyFile": "test/example-weak-keys.json",
-      "blockedKeyFile": "test/example-blocked-keys.yaml",
-      "fermatRounds": 100
+    "ra": {
+        "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
+        "maxContactsPerRegistration": 3,
+        "debugAddr": ":8002",
+        "hostnamePolicyFile": "test/hostname-policy.yaml",
+        "maxNames": 100,
+        "authorizationLifetimeDays": 30,
+        "pendingAuthorizationLifetimeDays": 7,
+        "goodkey": {
+            "weakKeyFile": "test/example-weak-keys.json",
+            "blockedKeyFile": "test/example-blocked-keys.yaml",
+            "fermatRounds": 100
+        },
+        "orderLifetime": "168h",
+        "issuerCerts": [
+            "/hierarchy/intermediate-cert-rsa-a.pem",
+            "/hierarchy/intermediate-cert-rsa-b.pem",
+            "/hierarchy/intermediate-cert-ecdsa-a.pem"
+        ],
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/ra.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/ra.boulder/key.pem"
+        },
+        "vaService": {
+            "serverAddress": "va.service.consul:9092",
+            "timeout": "20s",
+            "hostOverride": "va.boulder"
+        },
+        "caService": {
+            "serverAddress": "ca.service.consul:9093",
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "ocspService": {
+            "serverAddress": "ca.service.consul:9093",
+            "timeout": "15s",
+            "hostOverride": "ca.boulder"
+        },
+        "publisherService": {
+            "serverAddress": "publisher.service.consul:9091",
+            "timeout": "300s",
+            "hostOverride": "publisher.boulder"
+        },
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "akamaiPurgerService": {
+            "serverAddress": "akamai-purger.service.consul:9099",
+            "timeout": "15s",
+            "hostOverride": "akamai-purger.boulder"
+        },
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9094",
+            "clientNames": [
+                "admin-revoker.boulder",
+                "bad-key-revoker.boulder",
+                "health-checker.boulder",
+                "ocsp-responder.boulder",
+                "wfe.boulder"
+            ]
+        },
+        "features": {
+            "StoreRevokerInfo": true
+        },
+        "ctLogs": {
+            "stagger": "500ms",
+            "logListFile": "test/ct-test-srv/log_list.json",
+            "sctLogs": [
+                "A1 Current",
+                "A1 Future",
+                "A2 Past",
+                "A2 Current",
+                "B1",
+                "B2",
+                "C1",
+                "D1",
+                "E1"
+            ],
+            "infoLogs": [
+                "F1"
+            ],
+            "finalLogs": [
+                "A1 Current",
+                "A1 Future",
+                "C1",
+                "F1"
+            ]
+        }
     },
-    "orderLifetime": "168h",
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem",
-      "/hierarchy/intermediate-cert-rsa-b.pem",
-      "/hierarchy/intermediate-cert-ecdsa-a.pem"
-    ],
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/ra.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/ra.boulder/key.pem"
+    "pa": {
+        "challenges": {
+            "http-01": true,
+            "dns-01": true,
+            "tls-alpn-01": true
+        }
     },
-    "vaService": {
-      "serverAddress": "va.service.consul:9092",
-      "timeout": "20s",
-      "hostOverride": "va.boulder"
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "caService": {
-      "serverAddress": "ca.service.consul:9093",
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "ocspService": {
-      "serverAddress": "ca.service.consul:9093",
-      "timeout": "15s",
-      "hostOverride": "ca.boulder"
-    },
-    "publisherService": {
-      "serverAddress": "publisher.service.consul:9091",
-      "timeout": "300s",
-      "hostOverride": "publisher.boulder"
-    },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "akamaiPurgerService": {
-      "serverAddress": "akamai-purger.service.consul:9099",
-      "timeout": "15s",
-      "hostOverride": "akamai-purger.boulder"
-    },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9094",
-      "clientNames": [
-        "admin-revoker.boulder",
-        "bad-key-revoker.boulder",
-        "health-checker.boulder",
-        "ocsp-responder.boulder",
-        "wfe.boulder"
-      ]
-    },
-    "features": {
-      "StoreRevokerInfo": true
-    },
-    "ctLogs": {
-      "stagger": "500ms",
-      "logListFile": "test/ct-test-srv/log_list.json",
-      "sctLogs": [
-        "A1 Current",
-        "A1 Future",
-        "A2 Past",
-        "A2 Current",
-        "B1",
-        "B2",
-        "C1",
-        "D1",
-        "E1"
-      ],
-      "infoLogs": [
-        "F1"
-      ],
-      "finalLogs": [
-        "A1 Current",
-        "A1 Future",
-        "C1",
-        "F1"
-      ]
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     }
-  },
-  "pa": {
-    "challenges": {
-      "http-01": true,
-      "dns-01": true,
-      "tls-alpn-01": true
-    }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
 }

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -1,113 +1,113 @@
 {
-    "ra": {
-        "rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
-        "maxContactsPerRegistration": 3,
-        "debugAddr": ":8002",
-        "hostnamePolicyFile": "test/hostname-policy.yaml",
-        "maxNames": 100,
-        "authorizationLifetimeDays": 30,
-        "pendingAuthorizationLifetimeDays": 7,
-        "goodkey": {
-            "weakKeyFile": "test/example-weak-keys.json",
-            "blockedKeyFile": "test/example-blocked-keys.yaml",
-            "fermatRounds": 100
-        },
-        "orderLifetime": "168h",
-        "issuerCerts": [
-            "/hierarchy/intermediate-cert-rsa-a.pem",
-            "/hierarchy/intermediate-cert-rsa-b.pem",
-            "/hierarchy/intermediate-cert-ecdsa-a.pem"
-        ],
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/ra.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/ra.boulder/key.pem"
-        },
-        "vaService": {
-            "serverAddress": "va.service.consul:9092",
-            "timeout": "20s",
-            "hostOverride": "va.boulder"
-        },
-        "caService": {
-            "serverAddress": "ca.service.consul:9093",
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "ocspService": {
-            "serverAddress": "ca.service.consul:9093",
-            "timeout": "15s",
-            "hostOverride": "ca.boulder"
-        },
-        "publisherService": {
-            "serverAddress": "publisher.service.consul:9091",
-            "timeout": "300s",
-            "hostOverride": "publisher.boulder"
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "akamaiPurgerService": {
-            "serverAddress": "akamai-purger.service.consul:9099",
-            "timeout": "15s",
-            "hostOverride": "akamai-purger.boulder"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9094",
-            "clientNames": [
-                "admin-revoker.boulder",
-                "bad-key-revoker.boulder",
-                "health-checker.boulder",
-                "ocsp-responder.boulder",
-                "wfe.boulder"
-            ]
-        },
-        "features": {
-            "StoreRevokerInfo": true
-        },
-        "ctLogs": {
-            "stagger": "500ms",
-            "logListFile": "test/ct-test-srv/log_list.json",
-            "sctLogs": [
-                "A1 Current",
-                "A1 Future",
-                "A2 Past",
-                "A2 Current",
-                "B1",
-                "B2",
-                "C1",
-                "D1",
-                "E1"
-            ],
-            "infoLogs": [
-                "F1"
-            ],
-            "finalLogs": [
-                "A1 Current",
-                "A1 Future",
-                "C1",
-                "F1"
-            ]
-        }
-    },
-    "pa": {
-        "challenges": {
-            "http-01": true,
-            "dns-01": true,
-            "tls-alpn-01": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"ra": {
+		"rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
+		"maxContactsPerRegistration": 3,
+		"debugAddr": ":8002",
+		"hostnamePolicyFile": "test/hostname-policy.yaml",
+		"maxNames": 100,
+		"authorizationLifetimeDays": 30,
+		"pendingAuthorizationLifetimeDays": 7,
+		"goodkey": {
+			"weakKeyFile": "test/example-weak-keys.json",
+			"blockedKeyFile": "test/example-blocked-keys.yaml",
+			"fermatRounds": 100
+		},
+		"orderLifetime": "168h",
+		"issuerCerts": [
+			"/hierarchy/intermediate-cert-rsa-a.pem",
+			"/hierarchy/intermediate-cert-rsa-b.pem",
+			"/hierarchy/intermediate-cert-ecdsa-a.pem"
+		],
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/ra.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/ra.boulder/key.pem"
+		},
+		"vaService": {
+			"serverAddress": "va.service.consul:9092",
+			"timeout": "20s",
+			"hostOverride": "va.boulder"
+		},
+		"caService": {
+			"serverAddress": "ca.service.consul:9093",
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"ocspService": {
+			"serverAddress": "ca.service.consul:9093",
+			"timeout": "15s",
+			"hostOverride": "ca.boulder"
+		},
+		"publisherService": {
+			"serverAddress": "publisher.service.consul:9091",
+			"timeout": "300s",
+			"hostOverride": "publisher.boulder"
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"akamaiPurgerService": {
+			"serverAddress": "akamai-purger.service.consul:9099",
+			"timeout": "15s",
+			"hostOverride": "akamai-purger.boulder"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9094",
+			"clientNames": [
+				"admin-revoker.boulder",
+				"bad-key-revoker.boulder",
+				"health-checker.boulder",
+				"ocsp-responder.boulder",
+				"wfe.boulder"
+			]
+		},
+		"features": {
+			"StoreRevokerInfo": true
+		},
+		"ctLogs": {
+			"stagger": "500ms",
+			"logListFile": "test/ct-test-srv/log_list.json",
+			"sctLogs": [
+				"A1 Current",
+				"A1 Future",
+				"A2 Past",
+				"A2 Current",
+				"B1",
+				"B2",
+				"C1",
+				"D1",
+				"E1"
+			],
+			"infoLogs": [
+				"F1"
+			],
+			"finalLogs": [
+				"A1 Current",
+				"A1 Future",
+				"C1",
+				"F1"
+			]
+		}
+	},
+	"pa": {
+		"challenges": {
+			"http-01": true,
+			"dns-01": true,
+			"tls-alpn-01": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -1,23 +1,23 @@
 {
-  "rocspTool": {
-    "debugAddr": ":9101",
-    "redis": {
-      "username": "ocsp-updater",
-      "passwordFile": "test/secrets/rocsp_tool_password",
-      "shardAddrs": {
-        "shard1": "10.33.33.2:4218",
-        "shard2": "10.33.33.3:4218"
-      },
-      "timeout": "5s",
-      "tls": {
-        "caCertFile": "test/redis-tls/minica.pem",
-        "certFile": "test/redis-tls/boulder/cert.pem",
-        "keyFile": "test/redis-tls/boulder/key.pem"
-      }
+    "rocspTool": {
+        "debugAddr": ":9101",
+        "redis": {
+            "username": "ocsp-updater",
+            "passwordFile": "test/secrets/rocsp_tool_password",
+            "shardAddrs": {
+                "shard1": "10.33.33.2:4218",
+                "shard2": "10.33.33.3:4218"
+            },
+            "timeout": "5s",
+            "tls": {
+                "caCertFile": "test/redis-tls/minica.pem",
+                "certFile": "test/redis-tls/boulder/cert.pem",
+                "keyFile": "test/redis-tls/boulder/key.pem"
+            }
+        }
+    },
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     }
-  },
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  }
 }

--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -1,23 +1,23 @@
 {
-    "rocspTool": {
-        "debugAddr": ":9101",
-        "redis": {
-            "username": "ocsp-updater",
-            "passwordFile": "test/secrets/rocsp_tool_password",
-            "shardAddrs": {
-                "shard1": "10.33.33.2:4218",
-                "shard2": "10.33.33.3:4218"
-            },
-            "timeout": "5s",
-            "tls": {
-                "caCertFile": "test/redis-tls/minica.pem",
-                "certFile": "test/redis-tls/boulder/cert.pem",
-                "keyFile": "test/redis-tls/boulder/key.pem"
-            }
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    }
+	"rocspTool": {
+		"debugAddr": ":9101",
+		"redis": {
+			"username": "ocsp-updater",
+			"passwordFile": "test/secrets/rocsp_tool_password",
+			"shardAddrs": {
+				"shard1": "10.33.33.2:4218",
+				"shard2": "10.33.33.3:4218"
+			},
+			"timeout": "5s",
+			"tls": {
+				"caCertFile": "test/redis-tls/minica.pem",
+				"certFile": "test/redis-tls/boulder/cert.pem",
+				"keyFile": "test/redis-tls/boulder/key.pem"
+			}
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	}
 }

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -1,63 +1,63 @@
 {
-    "sa": {
-        "db": {
-            "dbConnectFile": "test/secrets/sa_dburl",
-            "maxOpenConns": 100
-        },
-        "readOnlyDB": {
-            "dbConnectFile": "test/secrets/sa_ro_dburl",
-            "maxOpenConns": 100
-        },
-        "ParallelismPerRPC": 20,
-        "debugAddr": ":8003",
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/sa.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/sa.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9095",
-            "services": {
-                "sa.StorageAuthority": {
-                    "clientNames": [
-                        "admin-revoker.boulder",
-                        "ca.boulder",
-                        "crl-updater.boulder",
-                        "expiration-mailer.boulder",
-                        "ocsp-responder.boulder",
-                        "orphan-finder.boulder",
-                        "ra.boulder",
-                        "wfe.boulder"
-                    ]
-                },
-                "sa.StorageAuthorityReadOnly": {
-                    "clientNames": [
-                        "crl-updater.boulder",
-                        "ocsp-responder.boulder",
-                        "wfe.boulder"
-                    ]
-                },
-                "grpc.health.v1.Health": {
-                    "clientNames": [
-                        "health-checker.boulder"
-                    ]
-                }
-            }
-        },
-        "features": {
-            "StoreRevokerInfo": true
-        }
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"sa": {
+		"db": {
+			"dbConnectFile": "test/secrets/sa_dburl",
+			"maxOpenConns": 100
+		},
+		"readOnlyDB": {
+			"dbConnectFile": "test/secrets/sa_ro_dburl",
+			"maxOpenConns": 100
+		},
+		"ParallelismPerRPC": 20,
+		"debugAddr": ":8003",
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/sa.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/sa.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9095",
+			"services": {
+				"sa.StorageAuthority": {
+					"clientNames": [
+						"admin-revoker.boulder",
+						"ca.boulder",
+						"crl-updater.boulder",
+						"expiration-mailer.boulder",
+						"ocsp-responder.boulder",
+						"orphan-finder.boulder",
+						"ra.boulder",
+						"wfe.boulder"
+					]
+				},
+				"sa.StorageAuthorityReadOnly": {
+					"clientNames": [
+						"crl-updater.boulder",
+						"ocsp-responder.boulder",
+						"wfe.boulder"
+					]
+				},
+				"grpc.health.v1.Health": {
+					"clientNames": [
+						"health-checker.boulder"
+					]
+				}
+			}
+		},
+		"features": {
+			"StoreRevokerInfo": true
+		}
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -1,62 +1,63 @@
 {
-  "sa": {
-    "db": {
-      "dbConnectFile": "test/secrets/sa_dburl",
-      "maxOpenConns": 100
-    },
-    "readOnlyDB": {
-      "dbConnectFile": "test/secrets/sa_ro_dburl",
-      "maxOpenConns": 100
-    },
-    "ParallelismPerRPC": 20,
-    "debugAddr": ":8003",
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/sa.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/sa.boulder/key.pem"
-    },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9095",
-      "services": {
-        "sa.StorageAuthority": {
-          "clientNames": [
-            "admin-revoker.boulder",
-            "ca.boulder",
-            "crl-updater.boulder",
-            "expiration-mailer.boulder",
-            "ocsp-responder.boulder",
-            "orphan-finder.boulder",
-            "ra.boulder",
-            "wfe.boulder"
-          ]
+    "sa": {
+        "db": {
+            "dbConnectFile": "test/secrets/sa_dburl",
+            "maxOpenConns": 100
         },
-        "sa.StorageAuthorityReadOnly": {
-          "clientNames": [
-            "crl-updater.boulder",
-            "ocsp-responder.boulder",
-            "wfe.boulder"
-          ]
+        "readOnlyDB": {
+            "dbConnectFile": "test/secrets/sa_ro_dburl",
+            "maxOpenConns": 100
         },
-        "grpc.health.v1.Health": {
-          "clientNames": [
-            "health-checker.boulder"
-          ]
+        "ParallelismPerRPC": 20,
+        "debugAddr": ":8003",
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/sa.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/sa.boulder/key.pem"
+        },
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9095",
+            "services": {
+                "sa.StorageAuthority": {
+                    "clientNames": [
+                        "admin-revoker.boulder",
+                        "ca.boulder",
+                        "crl-updater.boulder",
+                        "expiration-mailer.boulder",
+                        "ocsp-responder.boulder",
+                        "orphan-finder.boulder",
+                        "ra.boulder",
+                        "wfe.boulder"
+                    ]
+                },
+                "sa.StorageAuthorityReadOnly": {
+                    "clientNames": [
+                        "crl-updater.boulder",
+                        "ocsp-responder.boulder",
+                        "wfe.boulder"
+                    ]
+                },
+                "grpc.health.v1.Health": {
+                    "clientNames": [
+                        "health-checker.boulder"
+                    ]
+                }
+            }
+        },
+        "features": {
+            "StoreRevokerInfo": true
         }
-      }
     },
-    "features": {
-      "StoreRevokerInfo": true
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
+    },
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     }
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
 }

--- a/test/config/va-remote-a.json
+++ b/test/config/va-remote-a.json
@@ -1,42 +1,42 @@
 {
-    "va": {
-        "userAgent": "boulder-remote-a",
-        "debugAddr": ":8011",
-        "dnsTries": 3,
-        "dnsResolver": "service.consul",
-        "issuerDomain": "happy-hacker-ca.invalid",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9097",
-            "clientNames": [
-                "health-checker.boulder",
-                "va.boulder"
-            ]
-        },
-        "features": {},
-        "accountURIPrefixes": [
-            "http://boulder.service.consul:4000/acme/reg/",
-            "http://boulder.service.consul:4001/acme/acct/"
-        ]
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 4
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    },
-    "common": {
-        "dnsTimeout": "1s",
-        "dnsAllowLoopbackAddresses": true
-    }
+	"va": {
+		"userAgent": "boulder-remote-a",
+		"debugAddr": ":8011",
+		"dnsTries": 3,
+		"dnsResolver": "service.consul",
+		"issuerDomain": "happy-hacker-ca.invalid",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/rva.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/rva.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9097",
+			"clientNames": [
+				"health-checker.boulder",
+				"va.boulder"
+			]
+		},
+		"features": {},
+		"accountURIPrefixes": [
+			"http://boulder.service.consul:4000/acme/reg/",
+			"http://boulder.service.consul:4001/acme/acct/"
+		]
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 4
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	},
+	"common": {
+		"dnsTimeout": "1s",
+		"dnsAllowLoopbackAddresses": true
+	}
 }

--- a/test/config/va-remote-a.json
+++ b/test/config/va-remote-a.json
@@ -1,42 +1,42 @@
 {
-  "va": {
-    "userAgent": "boulder-remote-a",
-    "debugAddr": ":8011",
-    "dnsTries": 3,
-    "dnsResolver": "service.consul",
-    "issuerDomain": "happy-hacker-ca.invalid",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/rva.boulder/key.pem"
+    "va": {
+        "userAgent": "boulder-remote-a",
+        "debugAddr": ":8011",
+        "dnsTries": 3,
+        "dnsResolver": "service.consul",
+        "issuerDomain": "happy-hacker-ca.invalid",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
+        },
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9097",
+            "clientNames": [
+                "health-checker.boulder",
+                "va.boulder"
+            ]
+        },
+        "features": {},
+        "accountURIPrefixes": [
+            "http://boulder.service.consul:4000/acme/reg/",
+            "http://boulder.service.consul:4001/acme/acct/"
+        ]
     },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9097",
-      "clientNames": [
-        "health-checker.boulder",
-        "va.boulder"
-      ]
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 4
     },
-    "features": {},
-    "accountURIPrefixes": [
-      "http://boulder.service.consul:4000/acme/reg/",
-      "http://boulder.service.consul:4001/acme/acct/"
-    ]
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 4
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  },
-
-  "common": {
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true
-  }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    },
+    "common": {
+        "dnsTimeout": "1s",
+        "dnsAllowLoopbackAddresses": true
+    }
 }

--- a/test/config/va-remote-b.json
+++ b/test/config/va-remote-b.json
@@ -1,42 +1,42 @@
 {
-  "va": {
-    "userAgent": "boulder-remote-b",
-    "debugAddr": ":8012",
-    "dnsTries": 3,
-    "dnsResolver": "service.consul",
-    "issuerDomain": "happy-hacker-ca.invalid",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/rva.boulder/key.pem"
+    "va": {
+        "userAgent": "boulder-remote-b",
+        "debugAddr": ":8012",
+        "dnsTries": 3,
+        "dnsResolver": "service.consul",
+        "issuerDomain": "happy-hacker-ca.invalid",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
+        },
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9098",
+            "clientNames": [
+                "health-checker.boulder",
+                "va.boulder"
+            ]
+        },
+        "features": {},
+        "accountURIPrefixes": [
+            "http://boulder.service.consul:4000/acme/reg/",
+            "http://boulder.service.consul:4001/acme/acct/"
+        ]
     },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9098",
-      "clientNames": [
-        "health-checker.boulder",
-        "va.boulder"
-      ]
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 4
     },
-    "features": {},
-    "accountURIPrefixes": [
-      "http://boulder.service.consul:4000/acme/reg/",
-      "http://boulder.service.consul:4001/acme/acct/"
-    ]
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 4
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  },
-
-  "common": {
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true
-  }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    },
+    "common": {
+        "dnsTimeout": "1s",
+        "dnsAllowLoopbackAddresses": true
+    }
 }

--- a/test/config/va-remote-b.json
+++ b/test/config/va-remote-b.json
@@ -1,42 +1,42 @@
 {
-    "va": {
-        "userAgent": "boulder-remote-b",
-        "debugAddr": ":8012",
-        "dnsTries": 3,
-        "dnsResolver": "service.consul",
-        "issuerDomain": "happy-hacker-ca.invalid",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/rva.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/rva.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9098",
-            "clientNames": [
-                "health-checker.boulder",
-                "va.boulder"
-            ]
-        },
-        "features": {},
-        "accountURIPrefixes": [
-            "http://boulder.service.consul:4000/acme/reg/",
-            "http://boulder.service.consul:4001/acme/acct/"
-        ]
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 4
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    },
-    "common": {
-        "dnsTimeout": "1s",
-        "dnsAllowLoopbackAddresses": true
-    }
+	"va": {
+		"userAgent": "boulder-remote-b",
+		"debugAddr": ":8012",
+		"dnsTries": 3,
+		"dnsResolver": "service.consul",
+		"issuerDomain": "happy-hacker-ca.invalid",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/rva.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/rva.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9098",
+			"clientNames": [
+				"health-checker.boulder",
+				"va.boulder"
+			]
+		},
+		"features": {},
+		"accountURIPrefixes": [
+			"http://boulder.service.consul:4000/acme/reg/",
+			"http://boulder.service.consul:4001/acme/acct/"
+		]
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 4
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	},
+	"common": {
+		"dnsTimeout": "1s",
+		"dnsAllowLoopbackAddresses": true
+	}
 }

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -1,58 +1,58 @@
 {
-  "va": {
-    "userAgent": "boulder",
-    "debugAddr": ":8004",
-    "dnsTries": 3,
-    "dnsResolver": "service.consul",
-    "issuerDomain": "happy-hacker-ca.invalid",
-    "tls": {
-      "caCertfile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/va.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/va.boulder/key.pem"
+    "va": {
+        "userAgent": "boulder",
+        "debugAddr": ":8004",
+        "dnsTries": 3,
+        "dnsResolver": "service.consul",
+        "issuerDomain": "happy-hacker-ca.invalid",
+        "tls": {
+            "caCertfile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/va.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/va.boulder/key.pem"
+        },
+        "grpc": {
+            "maxConnectionAge": "30s",
+            "address": ":9092",
+            "clientNames": [
+                "health-checker.boulder",
+                "ra.boulder"
+            ]
+        },
+        "features": {
+            "EnforceMultiVA": true,
+            "MultiVAFullResults": true
+        },
+        "remoteVAs": [
+            {
+                "serverAddress": "rva1.service.consul:9097",
+                "timeout": "15s",
+                "hostOverride": "rva1.boulder"
+            },
+            {
+                "serverAddress": "rva1.service.consul:9098",
+                "timeout": "15s",
+                "hostOverride": "rva1.boulder"
+            }
+        ],
+        "maxRemoteValidationFailures": 1,
+        "accountURIPrefixes": [
+            "http://boulder.service.consul:4000/acme/reg/",
+            "http://boulder.service.consul:4001/acme/acct/"
+        ]
     },
-    "grpc": {
-      "maxConnectionAge": "30s",
-      "address": ":9092",
-      "clientNames": [
-        "health-checker.boulder",
-        "ra.boulder"
-      ]
+    "syslog": {
+        "stdoutlevel": 6,
+        "sysloglevel": 6
     },
-    "features": {
-      "EnforceMultiVA": true,
-      "MultiVAFullResults": true
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
     },
-    "remoteVAs": [
-      {
-        "serverAddress": "rva1.service.consul:9097",
-        "timeout": "15s",
-        "hostOverride": "rva1.boulder"
-      },
-      {
-        "serverAddress": "rva1.service.consul:9098",
-        "timeout": "15s",
-        "hostOverride": "rva1.boulder"
-      }
-    ],
-    "maxRemoteValidationFailures": 1,
-    "accountURIPrefixes": [
-      "http://boulder.service.consul:4000/acme/reg/",
-      "http://boulder.service.consul:4001/acme/acct/"
-    ]
-  },
-
-  "syslog": {
-    "stdoutlevel": 6,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  },
-
-  "common": {
-    "dnsTimeout": "1s",
-    "dnsAllowLoopbackAddresses": true
-  }
+    "common": {
+        "dnsTimeout": "1s",
+        "dnsAllowLoopbackAddresses": true
+    }
 }

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -1,58 +1,58 @@
 {
-    "va": {
-        "userAgent": "boulder",
-        "debugAddr": ":8004",
-        "dnsTries": 3,
-        "dnsResolver": "service.consul",
-        "issuerDomain": "happy-hacker-ca.invalid",
-        "tls": {
-            "caCertfile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/va.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/va.boulder/key.pem"
-        },
-        "grpc": {
-            "maxConnectionAge": "30s",
-            "address": ":9092",
-            "clientNames": [
-                "health-checker.boulder",
-                "ra.boulder"
-            ]
-        },
-        "features": {
-            "EnforceMultiVA": true,
-            "MultiVAFullResults": true
-        },
-        "remoteVAs": [
-            {
-                "serverAddress": "rva1.service.consul:9097",
-                "timeout": "15s",
-                "hostOverride": "rva1.boulder"
-            },
-            {
-                "serverAddress": "rva1.service.consul:9098",
-                "timeout": "15s",
-                "hostOverride": "rva1.boulder"
-            }
-        ],
-        "maxRemoteValidationFailures": 1,
-        "accountURIPrefixes": [
-            "http://boulder.service.consul:4000/acme/reg/",
-            "http://boulder.service.consul:4001/acme/acct/"
-        ]
-    },
-    "syslog": {
-        "stdoutlevel": 6,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    },
-    "common": {
-        "dnsTimeout": "1s",
-        "dnsAllowLoopbackAddresses": true
-    }
+	"va": {
+		"userAgent": "boulder",
+		"debugAddr": ":8004",
+		"dnsTries": 3,
+		"dnsResolver": "service.consul",
+		"issuerDomain": "happy-hacker-ca.invalid",
+		"tls": {
+			"caCertfile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/va.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/va.boulder/key.pem"
+		},
+		"grpc": {
+			"maxConnectionAge": "30s",
+			"address": ":9092",
+			"clientNames": [
+				"health-checker.boulder",
+				"ra.boulder"
+			]
+		},
+		"features": {
+			"EnforceMultiVA": true,
+			"MultiVAFullResults": true
+		},
+		"remoteVAs": [
+			{
+				"serverAddress": "rva1.service.consul:9097",
+				"timeout": "15s",
+				"hostOverride": "rva1.boulder"
+			},
+			{
+				"serverAddress": "rva1.service.consul:9098",
+				"timeout": "15s",
+				"hostOverride": "rva1.boulder"
+			}
+		],
+		"maxRemoteValidationFailures": 1,
+		"accountURIPrefixes": [
+			"http://boulder.service.consul:4000/acme/reg/",
+			"http://boulder.service.consul:4001/acme/acct/"
+		]
+	},
+	"syslog": {
+		"stdoutlevel": 6,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	},
+	"common": {
+		"dnsTimeout": "1s",
+		"dnsAllowLoopbackAddresses": true
+	}
 }

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -1,89 +1,89 @@
 {
-    "wfe": {
-        "listenAddress": "0.0.0.0:4001",
-        "TLSListenAddress": "0.0.0.0:4431",
-        "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
-        "serverKeyPath": "test/wfe-tls/boulder/key.pem",
-        "allowOrigins": [
-            "*"
-        ],
-        "shutdownStopTimeout": "10s",
-        "subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
-        "debugAddr": ":8013",
-        "directoryCAAIdentity": "happy-hacker-ca.invalid",
-        "directoryWebsite": "https://github.com/letsencrypt/boulder",
-        "legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
-        "goodkey": {
-            "blockedKeyFile": "test/example-blocked-keys.yaml"
-        },
-        "tls": {
-            "caCertFile": "test/grpc-creds/minica.pem",
-            "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
-            "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
-        },
-        "raService": {
-            "serverAddress": "ra.service.consul:9094",
-            "timeout": "15s",
-            "hostOverride": "ra.boulder"
-        },
-        "saService": {
-            "serverAddress": "sa.service.consul:9095",
-            "timeout": "15s",
-            "hostOverride": "sa.boulder"
-        },
-        "accountCache": {
-            "size": 9000,
-            "ttl": "5s"
-        },
-        "getNonceService": {
-            "serverAddress": "nonce.service.consul:9101",
-            "timeout": "15s",
-            "hostOverride": "nonce.boulder"
-        },
-        "redeemNonceServices": {
-            "taro": {
-                "serverAddress": "nonce1.service.consul:9101",
-                "timeout": "15s",
-                "hostOverride": "nonce1.boulder"
-            },
-            "zinc": {
-                "serverAddress": "nonce2.service.consul:9101",
-                "timeout": "15s",
-                "hostOverride": "nonce2.boulder"
-            }
-        },
-        "chains": [
-            [
-                "/hierarchy/intermediate-cert-rsa-a.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-rsa-b.pem",
-                "/hierarchy/root-cert-rsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-a.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ],
-            [
-                "/hierarchy/intermediate-cert-ecdsa-b.pem",
-                "/hierarchy/root-cert-ecdsa.pem"
-            ]
-        ],
-        "staleTimeout": "5m",
-        "authorizationLifetimeDays": 30,
-        "pendingAuthorizationLifetimeDays": 7,
-        "features": {}
-    },
-    "syslog": {
-        "stdoutlevel": 4,
-        "sysloglevel": 6
-    },
-    "beeline": {
-        "mute": true,
-        "serviceName": "Test",
-        "writeKey": {
-            "passwordFile": "test/secrets/honeycomb_fake_password"
-        }
-    }
+	"wfe": {
+		"listenAddress": "0.0.0.0:4001",
+		"TLSListenAddress": "0.0.0.0:4431",
+		"serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
+		"serverKeyPath": "test/wfe-tls/boulder/key.pem",
+		"allowOrigins": [
+			"*"
+		],
+		"shutdownStopTimeout": "10s",
+		"subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
+		"debugAddr": ":8013",
+		"directoryCAAIdentity": "happy-hacker-ca.invalid",
+		"directoryWebsite": "https://github.com/letsencrypt/boulder",
+		"legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
+		"goodkey": {
+			"blockedKeyFile": "test/example-blocked-keys.yaml"
+		},
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/wfe.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/wfe.boulder/key.pem"
+		},
+		"raService": {
+			"serverAddress": "ra.service.consul:9094",
+			"timeout": "15s",
+			"hostOverride": "ra.boulder"
+		},
+		"saService": {
+			"serverAddress": "sa.service.consul:9095",
+			"timeout": "15s",
+			"hostOverride": "sa.boulder"
+		},
+		"accountCache": {
+			"size": 9000,
+			"ttl": "5s"
+		},
+		"getNonceService": {
+			"serverAddress": "nonce.service.consul:9101",
+			"timeout": "15s",
+			"hostOverride": "nonce.boulder"
+		},
+		"redeemNonceServices": {
+			"taro": {
+				"serverAddress": "nonce1.service.consul:9101",
+				"timeout": "15s",
+				"hostOverride": "nonce1.boulder"
+			},
+			"zinc": {
+				"serverAddress": "nonce2.service.consul:9101",
+				"timeout": "15s",
+				"hostOverride": "nonce2.boulder"
+			}
+		},
+		"chains": [
+			[
+				"/hierarchy/intermediate-cert-rsa-a.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-rsa-b.pem",
+				"/hierarchy/root-cert-rsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-a.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			],
+			[
+				"/hierarchy/intermediate-cert-ecdsa-b.pem",
+				"/hierarchy/root-cert-ecdsa.pem"
+			]
+		],
+		"staleTimeout": "5m",
+		"authorizationLifetimeDays": 30,
+		"pendingAuthorizationLifetimeDays": 7,
+		"features": {}
+	},
+	"syslog": {
+		"stdoutlevel": 4,
+		"sysloglevel": 6
+	},
+	"beeline": {
+		"mute": true,
+		"serviceName": "Test",
+		"writeKey": {
+			"passwordFile": "test/secrets/honeycomb_fake_password"
+		}
+	}
 }

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -1,86 +1,89 @@
 {
-  "wfe": {
-    "listenAddress": "0.0.0.0:4001",
-    "TLSListenAddress": "0.0.0.0:4431",
-    "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
-    "serverKeyPath": "test/wfe-tls/boulder/key.pem",
-    "allowOrigins": ["*"],
-    "shutdownStopTimeout": "10s",
-    "subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
-    "debugAddr": ":8013",
-    "directoryCAAIdentity": "happy-hacker-ca.invalid",
-    "directoryWebsite": "https://github.com/letsencrypt/boulder",
-    "legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
-    "goodkey": {
-      "blockedKeyFile": "test/example-blocked-keys.yaml"
+    "wfe": {
+        "listenAddress": "0.0.0.0:4001",
+        "TLSListenAddress": "0.0.0.0:4431",
+        "serverCertificatePath": "test/wfe-tls/boulder/cert.pem",
+        "serverKeyPath": "test/wfe-tls/boulder/key.pem",
+        "allowOrigins": [
+            "*"
+        ],
+        "shutdownStopTimeout": "10s",
+        "subscriberAgreementURL": "https://boulder.service.consul:4431/terms/v7",
+        "debugAddr": ":8013",
+        "directoryCAAIdentity": "happy-hacker-ca.invalid",
+        "directoryWebsite": "https://github.com/letsencrypt/boulder",
+        "legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
+        "goodkey": {
+            "blockedKeyFile": "test/example-blocked-keys.yaml"
+        },
+        "tls": {
+            "caCertFile": "test/grpc-creds/minica.pem",
+            "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
+            "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
+        },
+        "raService": {
+            "serverAddress": "ra.service.consul:9094",
+            "timeout": "15s",
+            "hostOverride": "ra.boulder"
+        },
+        "saService": {
+            "serverAddress": "sa.service.consul:9095",
+            "timeout": "15s",
+            "hostOverride": "sa.boulder"
+        },
+        "accountCache": {
+            "size": 9000,
+            "ttl": "5s"
+        },
+        "getNonceService": {
+            "serverAddress": "nonce.service.consul:9101",
+            "timeout": "15s",
+            "hostOverride": "nonce.boulder"
+        },
+        "redeemNonceServices": {
+            "taro": {
+                "serverAddress": "nonce1.service.consul:9101",
+                "timeout": "15s",
+                "hostOverride": "nonce1.boulder"
+            },
+            "zinc": {
+                "serverAddress": "nonce2.service.consul:9101",
+                "timeout": "15s",
+                "hostOverride": "nonce2.boulder"
+            }
+        },
+        "chains": [
+            [
+                "/hierarchy/intermediate-cert-rsa-a.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-rsa-b.pem",
+                "/hierarchy/root-cert-rsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-a.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ],
+            [
+                "/hierarchy/intermediate-cert-ecdsa-b.pem",
+                "/hierarchy/root-cert-ecdsa.pem"
+            ]
+        ],
+        "staleTimeout": "5m",
+        "authorizationLifetimeDays": 30,
+        "pendingAuthorizationLifetimeDays": 7,
+        "features": {}
     },
-    "tls": {
-      "caCertFile": "test/grpc-creds/minica.pem",
-      "certFile": "test/grpc-creds/wfe.boulder/cert.pem",
-      "keyFile": "test/grpc-creds/wfe.boulder/key.pem"
+    "syslog": {
+        "stdoutlevel": 4,
+        "sysloglevel": 6
     },
-    "raService": {
-      "serverAddress": "ra.service.consul:9094",
-      "timeout": "15s",
-      "hostOverride": "ra.boulder"
-    },
-    "saService": {
-      "serverAddress": "sa.service.consul:9095",
-      "timeout": "15s",
-      "hostOverride": "sa.boulder"
-    },
-    "accountCache": {
-      "size": 9000,
-      "ttl": "5s"
-    },
-    "getNonceService": {
-      "serverAddress": "nonce.service.consul:9101",
-      "timeout": "15s",
-      "hostOverride": "nonce.boulder"
-    },
-    "redeemNonceServices": {
-      "taro": {
-        "serverAddress": "nonce1.service.consul:9101",
-        "timeout": "15s",
-        "hostOverride": "nonce1.boulder"
-      },
-      "zinc": {
-        "serverAddress": "nonce2.service.consul:9101",
-        "timeout": "15s",
-        "hostOverride": "nonce2.boulder"
-      }
-    },
-    "chains": [
-      [
-        "/hierarchy/intermediate-cert-rsa-a.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-rsa-b.pem",
-        "/hierarchy/root-cert-rsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-a.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ],
-      [
-        "/hierarchy/intermediate-cert-ecdsa-b.pem",
-        "/hierarchy/root-cert-ecdsa.pem"
-      ]
-    ],
-    "staleTimeout": "5m",
-    "authorizationLifetimeDays": 30,
-    "pendingAuthorizationLifetimeDays": 7,
-    "features": {}
-  },
-
-  "syslog": {
-    "stdoutlevel": 4,
-    "sysloglevel": 6
-  },
-  "beeline": {
-      "mute": true,
-      "serviceName": "Test",
-      "writeKey": {"passwordFile": "test/secrets/honeycomb_fake_password"}
-  }
+    "beeline": {
+        "mute": true,
+        "serviceName": "Test",
+        "writeKey": {
+            "passwordFile": "test/secrets/honeycomb_fake_password"
+        }
+    }
 }

--- a/test/format-configs.py
+++ b/test/format-configs.py
@@ -2,9 +2,12 @@
 
 import glob
 import json
+import sys
 
-for cfg in glob.glob("test/config*/*json"):
-    print(cfg)
+if len(sys.argv) != 2:
+  print("This program reformats JSON.  It takes a glob pattern as input")
+else:
+  for cfg in glob.glob(sys.argv[1]):
     with open(cfg, "r") as fr:
       j = json.load(fr)
     with open(cfg, "w") as fw:

--- a/test/format-configs.py
+++ b/test/format-configs.py
@@ -5,7 +5,7 @@ import json
 import sys
 
 if len(sys.argv) != 2:
-  print("This program reformats JSON.  It takes a glob pattern as input")
+  print("This program reformats JSON files in-place. You must provide a glob pattern of files to process as its argument.")
 else:
   for cfg in glob.glob(sys.argv[1]):
     with open(cfg, "r") as fr:

--- a/test/format-configs.py
+++ b/test/format-configs.py
@@ -11,5 +11,5 @@ else:
     with open(cfg, "r") as fr:
       j = json.load(fr)
     with open(cfg, "w") as fw:
-      json.dump(j, fw, indent=4)
+      json.dump(j, fw, indent="\t")
       fw.write("\n")

--- a/test/format-configs.py
+++ b/test/format-configs.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import glob
+import json
+
+for cfg in glob.glob("test/config*/*json"):
+    print(cfg)
+    with open(cfg, "r") as fr:
+      j = json.load(fr)
+    with open(cfg, "w") as fw:
+      json.dump(j, fw, indent=4)
+      fw.write("\n")


### PR DESCRIPTION
Use python's json.tool to add a new lint for ensuring JSON configurations are consistently formatted.  Right now there's some indentation inconsistenty that I'd like to clean up.

This adds a small python script that loads and dumps JSON files, and runs it on configurations as a CI lint. 

There should be no functional changes to the configurations in this PR.
