### PR TITLE
RA: relax CN matchesCSR check

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
 	"golang.org/x/crypto/ocsp"
+	"golang.org/x/exp/slices"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -679,11 +680,11 @@ func (ra *RegistrationAuthorityImpl) matchesCSR(parsedCertificate *x509.Certific
 
 	csrNames := csrlib.NamesFromCSR(csr)
 	if parsedCertificate.Subject.CommonName != "" {
-		// Only check that the issued common name matches the requested CN if there
+		// Only check that the issued common name matches one of the SANs if there
 		// is an issued CN at all: this allows flexibility on whether we include
 		// the CN.
-		if parsedCertificate.Subject.CommonName != csrNames.CN {
-			return berrors.InternalServerError("generated certificate CommonName doesn't match CSR CommonName")
+		if !slices.Contains(csrNames.SANs, parsedCertificate.Subject.CommonName) {
+			return berrors.InternalServerError("generated certificate CommonName doesn't match any CSR name")
 		}
 	}
 


### PR DESCRIPTION
The RA's matchesCSR function checks to make sure that various aspects of the final issued certificate match the CSR provided by the client. One of these checks is that the CommonName matches the CN specified in the CSR, or matches a specific one of the SANs if no CN was specified in the CSR. However, if the logic to select which of the SANs gets promoted into the CN ever differs between the RA and the CA (for example, in the midst of an incremental deploy that updates the version of one service before the other) this causes conflicts and results in Finalize requests failing with 500s.

Relax the check, so that the RA simply guarantees that the final certificate's CN matches any of the names in the CSR, not a specific one of the names. This fixes a deployability bug introduced in #6706.

Part of #5112