### PR TITLE
RA: Purge OCSP cache on duplicate revocations

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2120,7 +2120,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 	// Perform an Akamai cache purge to handle occurrences of a client
 	// successfully revoking a certificate, but the initial cache purge failing.
 	if errors.Is(revokeErr, berrors.AlreadyRevoked) {
-		err := ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+		err = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
 		if err != nil {
 			return nil, err
 		}
@@ -2146,6 +2146,11 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 	if err != nil {
 		return nil, err
 	}
+
+	return &emptypb.Empty{}, nil
+}
+
+func (ra *RegistrationAuthorityImpl) revokeCertByKeyInner(ctx context.Context, req *rapb.RevokeCertByKeyRequest) (*emptypb.Empty, error) {
 
 	return &emptypb.Empty{}, nil
 }
@@ -2227,7 +2232,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	// successfully revoking a certificate, but the initial cache purge failing.
 	if errors.Is(err, berrors.AlreadyRevoked) {
 		if cert != nil {
-			err := ra.purgeOCSPCache(ctx, cert, issuerID)
+			err = ra.purgeOCSPCache(ctx, cert, issuerID)
 			if err != nil {
 				return nil, err
 			}
@@ -2264,7 +2269,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	}
 
 	if cert != nil {
-		err := ra.purgeOCSPCache(ctx, cert, issuerID)
+		err = ra.purgeOCSPCache(ctx, cert, issuerID)
 		if err != nil {
 			return nil, err
 		}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2050,8 +2050,8 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 	return &emptypb.Empty{}, nil
 }
 
-// addToBlockedKey initiates a GRPC call to have the hash of a specified public
-// key added to the blockedKeys table.
+// addToBlockedKeys initiates a GRPC call to have the Base64-encoded SHA256
+// digest of a provided public key added to the blockedKeys table.
 func (ra *RegistrationAuthorityImpl) addToBlockedKeys(ctx context.Context, key crypto.PublicKey, src string, comment string) (*emptypb.Empty, error) {
 	var digest core.Sha256Digest
 	digest, err := core.KeyDigest(key)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2043,8 +2043,10 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 		return nil, err
 	}
 
-	// TODO(#5979): Check this error when it can't simply be due to a full queue.
-	_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+	err = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+	if err != nil {
+		return nil, err
+	}
 
 	return &emptypb.Empty{}, nil
 }
@@ -2118,8 +2120,10 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 	// Perform an Akamai cache purge to handle occurrences of a client
 	// successfully revoking a certificate, but the initial cache purge failing.
 	if errors.Is(revokeErr, berrors.AlreadyRevoked) {
-		// TODO(#5979): Check this error when it can't simply be due to a full queue.
-		_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+		err := ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Finally check the error from revocation itself. If it was an AlreadyRevoked
@@ -2138,8 +2142,10 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 		}
 	}
 
-	// TODO(#5979): Check this error when it can't simply be due to a full queue.
-	_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+	err = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+	if err != nil {
+		return nil, err
+	}
 
 	return &emptypb.Empty{}, nil
 }
@@ -2220,10 +2226,11 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	// Perform an Akamai cache purge to handle occurrences of a client
 	// successfully revoking a certificate, but the initial cache purge failing.
 	if errors.Is(err, berrors.AlreadyRevoked) {
-		// TODO(#5979): Check this error when it can't simply be due to a full
-		// queue.
 		if cert != nil {
-			_ = ra.purgeOCSPCache(ctx, cert, issuerID)
+			err := ra.purgeOCSPCache(ctx, cert, issuerID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if err != nil {
@@ -2257,7 +2264,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	}
 
 	if cert != nil {
-		err = ra.purgeOCSPCache(ctx, cert, issuerID)
+		err := ra.purgeOCSPCache(ctx, cert, issuerID)
 		if err != nil {
 			return nil, err
 		}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2243,6 +2243,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 			// An administrator will most likely want to know why a purge failed.
 			err = ra.purgeOCSPCache(ctx, cert, issuerID)
 			if err != nil {
+				err = fmt.Errorf("OCSP cache purge for already revoked serial %v failed: %w", serialInt, err)
 				return nil, err
 			}
 		}
@@ -2271,6 +2272,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 		// An administrator will most likely want to know why a purge failed.
 		err = ra.purgeOCSPCache(ctx, cert, issuerID)
 		if err != nil {
+			err = fmt.Errorf("OCSP cache purge for serial %v failed: %w", serialInt, err)
 			return nil, err
 		}
 	}

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2220,8 +2220,11 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	// Perform an Akamai cache purge to handle occurrences of a client
 	// successfully revoking a certificate, but the initial cache purge failing.
 	if errors.Is(err, berrors.AlreadyRevoked) {
-		// TODO(#5979): Check this error when it can't simply be due to a full queue.
-		_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+		// TODO(#5979): Check this error when it can't simply be due to a full
+		// queue.
+		if cert != nil {
+			_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+		}
 	}
 	if err != nil {
 		if req.Code == ocsp.KeyCompromise && errors.Is(err, berrors.AlreadyRevoked) {

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2226,8 +2226,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	// successfully revoking a certificate, but the initial cache purge failing.
 	if errors.Is(err, berrors.AlreadyRevoked) {
 		if cert != nil {
-			// An administrator will most likely want to know why a purge error
-			// failed so keep it in this scenario.
+			// An administrator will most likely want to know why a purge failed.
 			err = ra.purgeOCSPCache(ctx, cert, issuerID)
 			if err != nil {
 				return nil, err
@@ -2265,8 +2264,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	}
 
 	if cert != nil {
-		// An administrator will most likely want to know why a purge error
-		// failed so keep it in this scenario.
+		// An administrator will most likely want to know why a purge failed.
 		err = ra.purgeOCSPCache(ctx, cert, issuerID)
 		if err != nil {
 			return nil, err

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2123,6 +2123,8 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 		// Error out if the error was anything other than AlreadyRevoked. Otherwise
 		// try re-revocation.
 		if !errors.Is(err, berrors.AlreadyRevoked) {
+			// TODO(#5979): Check this error when it can't simply be due to a full queue.
+			_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
 			return nil, err
 		}
 		err = ra.updateRevocationForKeyCompromise(ctx, cert.SerialNumber, int64(issuerID))
@@ -2212,6 +2214,11 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	}
 
 	err = ra.revokeCertificate(ctx, serialInt, issuerID, revocation.Reason(req.Code))
+	// TODO(#5979): Check this error when it can't simply be due to
+	// a full queue.
+	if cert != nil {
+		_ = ra.purgeOCSPCache(ctx, cert, issuerID)
+	}
 	if err != nil {
 		if req.Code == ocsp.KeyCompromise && errors.Is(err, berrors.AlreadyRevoked) {
 			err = ra.updateRevocationForKeyCompromise(ctx, serialInt, issuerID)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2052,11 +2052,11 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 
 // addToBlockedKeys initiates a GRPC call to have the Base64-encoded SHA256
 // digest of a provided public key added to the blockedKeys table.
-func (ra *RegistrationAuthorityImpl) addToBlockedKeys(ctx context.Context, key crypto.PublicKey, src string, comment string) (*emptypb.Empty, error) {
+func (ra *RegistrationAuthorityImpl) addToBlockedKeys(ctx context.Context, key crypto.PublicKey, src string, comment string) error {
 	var digest core.Sha256Digest
 	digest, err := core.KeyDigest(key)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	_, err = ra.SA.AddBlockedKey(ctx, &sapb.AddBlockedKeyRequest{
@@ -2066,10 +2066,10 @@ func (ra *RegistrationAuthorityImpl) addToBlockedKeys(ctx context.Context, key c
 		Comment: comment,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &emptypb.Empty{}, nil
+	return nil
 }
 
 // RevokeCertByKey revokes the certificate in question. It always uses

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3957,7 +3957,8 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 		Code:      ocsp.Unspecified,
 		AdminName: "root",
 	})
-	test.AssertError(t, err, "already revoked")
+	test.AssertError(t, err, "Should be revoked")
+	test.AssertContains(t, err.Error(), "already revoked")
 	test.AssertEquals(t, len(mockSA.blocked), 0)
 	test.AssertMetricWithLabelsEquals(
 		t, ra.revocationReasonCounter, prometheus.Labels{"reason": "unspecified"}, 2)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3950,6 +3950,18 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	test.AssertMetricWithLabelsEquals(
 		t, ra.revocationReasonCounter, prometheus.Labels{"reason": "unspecified"}, 2)
 
+	// Duplicate administrative revocation of a serial for an unspecified reason
+	// should fail and not block the key
+	_, err = ra.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
+		Serial:    core.SerialToString(cert.SerialNumber),
+		Code:      ocsp.Unspecified,
+		AdminName: "root",
+	})
+	test.AssertError(t, err, "already revoked")
+	test.AssertEquals(t, len(mockSA.blocked), 0)
+	test.AssertMetricWithLabelsEquals(
+		t, ra.revocationReasonCounter, prometheus.Labels{"reason": "unspecified"}, 2)
+
 	// Revoking a cert for key compromise should work and block the key.
 	mockSA.revoked = make(map[string]int64)
 	_, err = ra.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{


### PR DESCRIPTION
* Perform Akamai OCSP cache purges on already revoked certificates in `ra.RevokeCertByKey` and `ra.AdministrativelyRevokeCertificate` for subsequent client calls to `/acme/revoke-cert`.

* Add `addToBlockedKeys` helper function used by `ra.AdministrativelyRevokeCertificate` and `ra.RevokeCertByKey` to de-duplicate code adding subject public key info hash to the `blockedKeys` table.

* Add a duplicate revocation test to `ra.TestAdministrativelyRevokeCertificate` 

* Fix some grammar in an RA comment.

* Fixes https://github.com/letsencrypt/boulder/issues/4862