### PR TITLE
Force a new allocation for sans in NamesFromCSR

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -105,7 +105,10 @@ type names struct {
 // Alternative Names from the CSR. It guarantees that the SANs include the CN.
 // It also enforces various conditions on the CN, based on feature flags.
 func NamesFromCSR(csr *x509.CertificateRequest) names {
-	sans := csr.DNSNames
+	// Produce a new "sans" slice with the same memory address as csr.DNSNames
+	// but force a new allocation so that we don't accidently mutate the
+	// underlying csr.DNSNames array.
+	sans := csr.DNSNames[0:len(csr.DNSNames):len(csr.DNSNames)]
 	if csr.Subject.CommonName != "" {
 		sans = append(sans, csr.Subject.CommonName)
 	}

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -106,8 +106,8 @@ type names struct {
 // It also enforces various conditions on the CN, based on feature flags.
 func NamesFromCSR(csr *x509.CertificateRequest) names {
 	// Produce a new "sans" slice with the same memory address as csr.DNSNames
-	// but force a new allocation so that we don't accidently mutate the
-	// underlying csr.DNSNames array.
+	// but force a new allocation IFF an append happens so that we don't
+	// accidently mutate the underlying csr.DNSNames array.
 	sans := csr.DNSNames[0:len(csr.DNSNames):len(csr.DNSNames)]
 	if csr.Subject.CommonName != "" {
 		sans = append(sans, csr.Subject.CommonName)

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -106,8 +106,8 @@ type names struct {
 // It also enforces various conditions on the CN, based on feature flags.
 func NamesFromCSR(csr *x509.CertificateRequest) names {
 	// Produce a new "sans" slice with the same memory address as csr.DNSNames
-	// but force a new allocation IFF an append happens so that we don't
-	// accidently mutate the underlying csr.DNSNames array.
+	// but force a new allocation if an append happens so that we don't
+	// accidentally mutate the underlying csr.DNSNames array.
 	sans := csr.DNSNames[0:len(csr.DNSNames):len(csr.DNSNames)]
 	if csr.Subject.CommonName != "" {
 		sans = append(sans, csr.Subject.CommonName)


### PR DESCRIPTION
In `csr.NamesFromCSR`, there's a subtle trap when appending to a slice. We set `sans := csr.DNSNames` and then depending on the existence of a CommonName, we append to sans which could mutate the backing array in `csr.DNSNames`. Instead, we will force a new allocation meaning that `sans` has its own pointer to a distinct memory unrelated to the pointer of `csr.DNSNames`.

See this [cool blog post](https://build-your-own.org/blog/20230316_go_full_slice/) too.