### PR TITLE
CA: Stop gRPC service before helper goroutines

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -323,11 +323,11 @@ func main() {
 	cmd.FailOnError(err, "Unable to setup CA gRPC server")
 
 	go cmd.CatchSignals(logger, func() {
+		stop()
 		ecdsaAllowList.Stop()
 		if ocspi != nil {
 			ocspi.Stop()
 		}
-		stop()
 	})
 	cmd.FailOnError(start(), "CA gRPC service failed")
 }


### PR DESCRIPTION
When shutting down the CA, we should stop the primary gRPC service (which waits for any outstanding requests to complete) before shutting down the other helper goroutines. This prevents panics when an ongoing gRPC request attempts to write to the OCSPLogQueue, but the queue's channel has already been closed by the call to ocspi.Stop().

Fixes #6760