### PR TITLE
SARO: Add sa_lag_factor metric to assess usage of the lagFactor codepath

### DIFF
--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -87,7 +87,7 @@ func main() {
 	cmd.FailOnError(err, "TLS config")
 
 	saroi, err := sa.NewSQLStorageAuthorityRO(
-		dbReadOnlyMap, dbIncidentsMap, parallel, c.SA.LagFactor.Duration, clk, logger)
+		dbReadOnlyMap, dbIncidentsMap, scope, parallel, c.SA.LagFactor.Duration, clk, logger)
 	cmd.FailOnError(err, "Failed to create read-only SA impl")
 
 	sai, err := sa.NewSQLStorageAuthorityWrapping(saroi, dbMap, scope)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -87,7 +87,7 @@ func NewSQLStorageAuthority(
 	stats prometheus.Registerer,
 ) (*SQLStorageAuthority, error) {
 	ssaro, err := NewSQLStorageAuthorityRO(
-		dbReadOnlyMap, dbIncidentsMap, parallelismPerRPC, lagFactor, clk, logger)
+		dbReadOnlyMap, dbIncidentsMap, stats, parallelismPerRPC, lagFactor, clk, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -36,6 +36,7 @@ import (
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/ocsp"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -72,7 +73,7 @@ func initSA(t *testing.T) (*SQLStorageAuthority, clock.FakeClock, func()) {
 	fc := clock.NewFake()
 	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
 
-	saro, err := NewSQLStorageAuthorityRO(dbMap, dbIncidentsMap, 1, 0, fc, log)
+	saro, err := NewSQLStorageAuthorityRO(dbMap, dbIncidentsMap, metrics.NoopRegisterer, 1, 0, fc, log)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}
@@ -240,10 +241,14 @@ func TestReplicationLagRetries(t *testing.T) {
 	_, err := sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id})
 	test.AssertNotError(t, err, "selecting extant registration")
 	test.AssertEquals(t, clk.Now(), start)
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 0)
 
 	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
 	test.AssertError(t, err, "selecting nonexistent registration")
 	test.AssertEquals(t, clk.Now(), start)
+	// If lagFactor is turned off i.e. "0", then we should never enter the retry
+	// codepath and as a result the metric should not increment.
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 0)
 
 	// Now, set the lagFactor to 1. Trying to select a nonexistent registration
 	// should cause the clock to advance when GetRegistration sleeps and retries.
@@ -253,10 +258,16 @@ func TestReplicationLagRetries(t *testing.T) {
 	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id})
 	test.AssertNotError(t, err, "selecting extant registration")
 	test.AssertEquals(t, clk.Now(), start)
+	// lagFactor is enabled, but the registration exists.
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 0)
 
 	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
 	test.AssertError(t, err, "selecting nonexistent registration")
 	test.AssertEquals(t, clk.Now(), start.Add(1))
+	// With lagFactor is enabled i.e. "time > 0 ", then we should enter the
+	// retry codepath for a nonexistent and as a result the metric should
+	// increment.
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 1)
 }
 
 func TestAddCertificate(t *testing.T) {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -246,8 +246,8 @@ func TestReplicationLagRetries(t *testing.T) {
 	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
 	test.AssertError(t, err, "selecting nonexistent registration")
 	test.AssertEquals(t, clk.Now(), start)
-	// If lagFactor is turned off i.e. "0", then we should never enter the retry
-	// codepath and as a result the metric should not increment.
+	// With lagFactor disabled, we should never enter the retry codepath, as a
+	// result the metric should not increment.
 	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 0)
 
 	// Now, set the lagFactor to 1. Trying to select a nonexistent registration

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -241,14 +241,14 @@ func TestReplicationLagRetries(t *testing.T) {
 	_, err := sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id})
 	test.AssertNotError(t, err, "selecting extant registration")
 	test.AssertEquals(t, clk.Now(), start)
-	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 0)
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "notfound"}, 0)
 
 	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
 	test.AssertError(t, err, "selecting nonexistent registration")
 	test.AssertEquals(t, clk.Now(), start)
 	// With lagFactor disabled, we should never enter the retry codepath, as a
 	// result the metric should not increment.
-	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 0)
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "notfound"}, 0)
 
 	// Now, set the lagFactor to 1. Trying to select a nonexistent registration
 	// should cause the clock to advance when GetRegistration sleeps and retries.
@@ -259,14 +259,14 @@ func TestReplicationLagRetries(t *testing.T) {
 	test.AssertNotError(t, err, "selecting extant registration")
 	test.AssertEquals(t, clk.Now(), start)
 	// lagFactor is enabled, but the registration exists.
-	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 0)
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "notfound"}, 0)
 
 	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
 	test.AssertError(t, err, "selecting nonexistent registration")
 	test.AssertEquals(t, clk.Now(), start.Add(1))
 	// With lagFactor enabled, we should enter the retry codepath and as a result
 	// the metric should increment.
-	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 1)
+	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "notfound"}, 1)
 }
 
 func TestAddCertificate(t *testing.T) {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -54,8 +54,8 @@ var (
 }`
 )
 
-// initSA constructs a SQLStorageAuthority and a clean up function
-// that should be defer'ed to the end of the test.
+// initSA constructs a SQLStorageAuthority and a clean up function that should
+// be defer'ed to the end of the test.
 func initSA(t *testing.T) (*SQLStorageAuthority, clock.FakeClock, func()) {
 	t.Helper()
 	features.Reset()
@@ -265,8 +265,8 @@ func TestReplicationLagRetries(t *testing.T) {
 	test.AssertError(t, err, "selecting nonexistent registration")
 	test.AssertEquals(t, clk.Now(), start.Add(1))
 	// With lagFactor is enabled i.e. "time > 0 ", then we should enter the
-	// retry codepath for a nonexistent and as a result the metric should
-	// increment.
+	// retry codepath for a nonexistent registration ID and as a result the
+	// metric should increment.
 	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 1)
 }
 

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -264,9 +264,8 @@ func TestReplicationLagRetries(t *testing.T) {
 	_, err = sa.GetRegistration(ctx, &sapb.RegistrationID{Id: reg.Id + 1})
 	test.AssertError(t, err, "selecting nonexistent registration")
 	test.AssertEquals(t, clk.Now(), start.Add(1))
-	// With lagFactor is enabled i.e. "time > 0 ", then we should enter the
-	// retry codepath for a nonexistent registration ID and as a result the
-	// metric should increment.
+	// With lagFactor enabled, we should enter the retry codepath and as a result
+	// the metric should increment.
 	test.AssertMetricWithLabelsEquals(t, sa.lagFactorCounter, prometheus.Labels{"method": "GetRegistration", "result": "fail"}, 1)
 }
 

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -61,9 +61,10 @@ type SQLStorageAuthorityRO struct {
 	clk clock.Clock
 	log blog.Logger
 
-	// lagFactorCounter is a CounterVec for the number of times a database
-	// connection retry happens in the GetRegistration, GetOrder, and
-	// GetAuthorization2 methods.
+	// lagFactorCounter is a Prometheus counter that tracks the number of times
+	// we've retried a query inside of GetRegistration, GetOrder, and
+	// GetAuthorization2 due to replication lag. It is labeled by method name
+	// and whether the retry succeeded or failed.
 	lagFactorCounter *prometheus.CounterVec
 }
 

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -120,7 +120,6 @@ func (ssa *SQLStorageAuthorityRO) GetRegistration(ctx context.Context, req *sapb
 	if err != nil {
 		if db.IsNoRows(err) {
 			if ssa.lagFactor != 0 {
-				fmt.Println("got here 1")
 				ssa.lagFactorCounter.WithLabelValues("GetRegistration", "fail").Inc()
 			}
 			return nil, berrors.NotFoundError("registration with ID '%d' not found", req.Id)
@@ -128,7 +127,6 @@ func (ssa *SQLStorageAuthorityRO) GetRegistration(ctx context.Context, req *sapb
 		return nil, err
 	}
 	if lagRetry {
-		fmt.Println("got here 2")
 		ssa.lagFactorCounter.WithLabelValues("GetRegistration", "pass").Inc()
 	}
 

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -779,7 +779,7 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorization2(ctx context.Context, req *sa
 		// read replica yet. If we get a NoRows, wait a little bit and retry, once.
 		ssa.clk.Sleep(ssa.lagFactor)
 		obj, err = ssa.dbReadOnlyMap.Get(authzModel{}, req.Id)
-		if err != nil {
+		if obj == nil || err != nil {
 			if db.IsNoRows(err) {
 				ssa.lagFactorCounter.WithLabelValues("GetAuthorization2", "fail").Inc()
 			}

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -772,7 +772,6 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorization2(ctx context.Context, req *sa
 	if req.Id == 0 {
 		return nil, errIncompleteRequest
 	}
-
 	obj, err := ssa.dbReadOnlyMap.Get(authzModel{}, req.Id)
 	if db.IsNoRows(err) && ssa.lagFactor != 0 {
 		// GetAuthorization2 is often called shortly after a new order is created,

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -117,7 +117,6 @@ func (ssa *SQLStorageAuthorityRO) GetRegistration(ctx context.Context, req *sapb
 		model, err = selectRegistration(ssa.dbReadOnlyMap.WithContext(ctx), query, req.Id)
 		lagRetry = true
 	}
-
 	if err != nil {
 		if db.IsNoRows(err) {
 			if ssa.lagFactor != 0 {

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -779,7 +779,7 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorization2(ctx context.Context, req *sa
 		// read replica yet. If we get a NoRows, wait a little bit and retry, once.
 		ssa.clk.Sleep(ssa.lagFactor)
 		obj, err = ssa.dbReadOnlyMap.Get(authzModel{}, req.Id)
-		if obj == nil || err != nil {
+		if err != nil {
 			if db.IsNoRows(err) {
 				ssa.lagFactorCounter.WithLabelValues("GetAuthorization2", "fail").Inc()
 			}


### PR DESCRIPTION
Add `sa_lag_retry` prometheus countervec metric with pass/fail dimensions for `GetOrder`, `GetAuthorization2`, and `GetRegistration` methods.

The new metrics will appear as follows:
```
sa_lag_retry{method="GetOrder",result="found"} 0
sa_lag_retry{method="GetOrder",result="notfound"} 0
sa_lag_retry{method="GetOrder",result="other"} 0
sa_lag_retry{method="GetAuthorization2",result="found"} 0
sa_lag_retry{method="GetAuthorization2",result="notfound"} 0
sa_lag_retry{method="GetAuthorization2",result="other"} 0
sa_lag_retry{method="GetRegistration",result="found"} 0
sa_lag_retry{method="GetRegistration",result="notfound"} 0
sa_lag_retry{method="GetRegistration",result="other"} 0
```

Fixes https://github.com/letsencrypt/boulder/issues/6773