### PR TITLE
CertsPerName limit: only check renewal exemption once

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1419,18 +1419,6 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerNameLimit(ctx context.C
 	}
 
 	if len(namesOutOfLimit) > 0 {
-		// check if there is already an existing certificate for
-		// the exact name set we are issuing for. If so bypass the
-		// the certificatesPerName limit.
-		exists, err := ra.SA.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{Domains: names})
-		if err != nil {
-			return fmt.Errorf("checking renewal exemption for %q: %s", names, err)
-		}
-		if exists.Exists {
-			ra.rateLimitCounter.WithLabelValues("certificates_for_domain", "FQDN set bypass").Inc()
-			return nil
-		}
-
 		// Determine the amount of time until the earliest event would fall out
 		// of the window.
 		retryAfter := earliest.Add(limit.Window.Duration).Sub(ra.clk.Now())


### PR DESCRIPTION
We used to check the CertificatesPerName "renewal exemption" after checking to see if the rate limit was going to kick in at all. But checking the rate limit is rather expensive, so #4174 introduced a feature flag and a new block of code so that we'd check the renewal exemption first, and short-circuit out of the whole function if it was met. But when #4771 deprecated the feature flag, it left both blocks of code in, instead of deleting the old location.

Remove the redundant exemption check.