### PR TITLE
 bad-key-revoker: Reduce probability of hash collision during testing

### DIFF
--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -81,7 +81,7 @@ func TestSelectUncheckedRows(t *testing.T) {
 
 func insertRegistration(t *testing.T, dbMap *db.WrappedMap, fc clock.Clock, addrs ...string) int64 {
 	t.Helper()
-	jwkHash := make([]byte, 2)
+	jwkHash := make([]byte, 32)
 	_, err := rand.Read(jwkHash)
 	test.AssertNotError(t, err, "failed to read rand")
 	contactStr := "[]"


### PR DESCRIPTION
Create a jwkHash of 32 bytes rather than 2 bytes to reduce the probability of a hash collision in the `TestInvoke` function.

Fixes https://github.com/letsencrypt/boulder/issues/6789