### PR TITLE
 Golang 1.20.3 security release upgrade

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.2_2023-03-07
+          - go1.20.2_2023-04-04
+          - go1.20.3_2023-04-04
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.20.2"
+          - "1.20.3"
     runs-on: ubuntu-20.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.20.2"
+          - "1.20.3"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.2_2023-03-07}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.3_2023-04-04}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.
@@ -62,7 +62,7 @@ services:
     command: mysqld --bind-address=0.0.0.0 --slow-query-log --log-output=TABLE --log-queries-not-using-indexes=ON
     logging:
       driver: none
-  
+
   bproxysql:
     image: proxysql/proxysql:2.4.4
     # The --initial flag force resets the ProxySQL database on startup. By

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,6 @@ services:
     command: mysqld --bind-address=0.0.0.0 --slow-query-log --log-output=TABLE --log-queries-not-using-indexes=ON
     logging:
       driver: none
-
   bproxysql:
     image: proxysql/proxysql:2.4.4
     # The --initial flag force resets the ProxySQL database on startup. By

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,11 +12,11 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.20.2" )
+GO_CI_VERSIONS=( "1.20.2" "1.20.3" )
 # These versions are built for both platforms that boulder devs use.
 # When updating GO_DEV_VERSIONS, please also update
 # ../../docker-compose.yml's default Go version.
-GO_DEV_VERSIONS=( "1.20.2" )
+GO_DEV_VERSIONS=( "1.20.3" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
Release notes: https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8

This update includes fixes for excessive memory usage when parsing headers in the net/http package,