### PR TITLE
Promote the first SAN from the CSR

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -114,19 +114,18 @@ func NamesFromCSR(csr *x509.CertificateRequest) names {
 	if csr.Subject.CommonName != "" {
 		sans = append(sans, csr.Subject.CommonName)
 	}
-	sans = core.UniqueLowerNames(sans)
 
 	if csr.Subject.CommonName != "" {
-		return names{SANs: sans, CN: strings.ToLower(csr.Subject.CommonName)}
+		return names{SANs: core.UniqueLowerNames(sans), CN: strings.ToLower(csr.Subject.CommonName)}
 	}
 
 	// If there's no CN already, but we want to set one, promote the first SAN
 	// which is shorter than the the maximum acceptable CN length (if any).
 	for _, name := range sans {
 		if len(name) <= maxCNLength {
-			return names{SANs: sans, CN: name}
+			return names{SANs: core.UniqueLowerNames(sans), CN: name}
 		}
 	}
-
-	return names{SANs: sans}
+	
+	return names{SANs: core.UniqueLowerNames(sans)}
 }

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -126,6 +126,6 @@ func NamesFromCSR(csr *x509.CertificateRequest) names {
 			return names{SANs: core.UniqueLowerNames(sans), CN: name}
 		}
 	}
-	
+
 	return names{SANs: core.UniqueLowerNames(sans)}
 }

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -47,9 +47,9 @@ func TestCommonNameInCSR(t *testing.T) {
 	test.AssertEquals(t, cert.Subject.CommonName, cn)
 }
 
-// TestCommonNameHoisted ensures that CSRs which have no CN set result in certs
-// with one of their SANs hoisted into the CN field.
-func TestCommonNameHoisted(t *testing.T) {
+// TestFirstCSRSANHoistedToCN ensures that CSRs which have no CN set result in
+// certs with the first CSR SAN hoisted into the CN field.
+func TestFirstCSRSANHoistedToCN(t *testing.T) {
 	t.Parallel()
 
 	// Create an account.
@@ -75,7 +75,7 @@ func TestCommonNameHoisted(t *testing.T) {
 	test.AssertSliceContains(t, cert.DNSNames, san2)
 
 	// Ensure that one of the SANs is the CN.
-	test.Assert(t, cert.Subject.CommonName == san1 || cert.Subject.CommonName == san2, "SAN should have been hoisted")
+	test.Assert(t, cert.Subject.CommonName == san1, "SAN should have been hoisted")
 }
 
 // TestCommonNameSANsTooLong tests that, when the names in an order and CSR are

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -61,21 +61,21 @@ func TestFirstCSRSANHoistedToCN(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	test.AssertNotError(t, err, "creating random cert key")
 
-	// Put together some names.
-	san1 := random_domain()
-	san2 := random_domain()
+	// Create some names that we can sort.
+	san1 := "a" + random_domain()
+	san2 := "b" + random_domain()
 
-	// Issue a cert using a CSR with no CN set.
-	ir, err := authAndIssue(client, key, []string{san1, san2}, false)
+	// Issue a cert using a CSR with no CN set, and the SANs in *non*-alpha order.
+	ir, err := authAndIssue(client, key, []string{san2, san1}, false)
 	test.AssertNotError(t, err, "failed to issue test cert")
 	cert := ir.certs[0]
 
-	// Ensure that the SANs are correct.
-	test.AssertSliceContains(t, cert.DNSNames, san1)
-	test.AssertSliceContains(t, cert.DNSNames, san2)
+	// Ensure that the SANs are correct, and sorted alphabetically.
+	test.AssertEquals(t, cert.DNSNames[0], san1)
+	test.AssertEquals(t, cert.DNSNames[1], san2)
 
-	// Ensure that one of the SANs is the CN.
-	test.Assert(t, cert.Subject.CommonName == san1, "SAN should have been hoisted")
+	// Ensure that the first SAN from the CSR is the CN.
+	test.Assert(t, cert.Subject.CommonName == san2, "first SAN should have been hoisted")
 }
 
 // TestCommonNameSANsTooLong tests that, when the names in an order and CSR are


### PR DESCRIPTION
Rather than promoting the alphabetically-first SAN to be the CN, promote the SAN which came first in the CSR. This is a reversion to previous behavior that was changed as a side-effect of changes:
- https://github.com/letsencrypt/boulder/pull/6706;
- https://github.com/letsencrypt/boulder/pull/6749; and
- https://github.com/letsencrypt/boulder/pull/6757

Fixes https://github.com/letsencrypt/boulder/issues/6801