### PR TITLE
Include Location header in get-order responses

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2102,6 +2102,10 @@ func (wfe *WebFrontEndImpl) GetOrder(ctx context.Context, logEvent *web.RequestE
 
 	respObj := wfe.orderToOrderJSON(request, order)
 
+	orderURL := web.RelativeEndpoint(request,
+		fmt.Sprintf("%s%d/%d", orderPath, acctID, order.Id))
+	response.Header().Set("Location", orderURL)
+
 	if respObj.Status == core.StatusProcessing {
 		response.Header().Set(headerRetryAfter, strconv.Itoa(orderRetryAfter))
 	}


### PR DESCRIPTION
We already include a Location header in responses to New Order and Finalize requests. The former is required by RFC 8555; the latter is not required but is included in the RFC's issuance flow example. We do not currently include a matching Location header on Get Order responses. This makes sense: the client already had the relevant URL in order to request this resource, and Location headers "only provide meaning when served with a 3XX (redirection) or 201 (created) status code" (MDN).

However, it turns out that at least one client has been relying on this Location header, and with asynchronous finalization, is failing to get a Location header from the polled Get Order responses. Add a matching Location header to Get Order responses for the sake of consistency.