### PR TITLE
Expose the earliest nonce value accepted as a metric, using atomics

### DIFF
--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -149,7 +149,7 @@ func NewNonceService(stats prometheus.Registerer, maxUsed int, prefix string) (*
 
 	stats.MustRegister(prometheus.NewCounterFunc(prometheus.CounterOpts{
 		Name: "nonce_earliest",
-		Help: "A count of the earliest nonce currently accepted",
+		Help: "A counter with the earliest nonce currently accepted",
 	}, func() float64 { return float64(earliest.Load()) }))
 	stats.MustRegister(prometheus.NewCounterFunc(prometheus.CounterOpts{
 		Name: "nonce_creates",

--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -264,13 +264,13 @@ func (ns *NonceService) Valid(nonce string) bool {
 		return false
 	}
 
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+
 	if c <= ns.earliest.Load() {
 		ns.nonceRedeems.WithLabelValues("invalid", "too low").Inc()
 		return false
 	}
-
-	ns.mu.Lock()
-	defer ns.mu.Unlock()
 
 	if ns.used[c] {
 		ns.nonceRedeems.WithLabelValues("invalid", "already used").Inc()

--- a/nonce/nonce_test.go
+++ b/nonce/nonce_test.go
@@ -62,10 +62,10 @@ func TestRejectTooLate(t *testing.T) {
 	ns, err := NewNonceService(metrics.NoopRegisterer, 0, "")
 	test.AssertNotError(t, err, "Could not create nonce service")
 
-	ns.latest = 2
+	ns.latest.Store(2)
 	n, err := ns.Nonce()
 	test.AssertNotError(t, err, "Could not create nonce")
-	ns.latest = 1
+	ns.latest.Store(1)
 	test.Assert(t, !ns.Valid(n), "Accepted a nonce with a too-high counter")
 }
 


### PR DESCRIPTION
This avoids obtaining a lock when generating nonces, and exposes the values of the earliest and latest nonces in metrics.

With both the earliest and latest nonce values, we can get much better visibility into how long nonces are valid for, which is currently pretty difficult to figure out.