### PR TITLE
Fix CI failures related to akamai-test-srv

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -131,7 +131,7 @@ def verify_akamai_purge():
             raise(Exception("Timed out waiting for Akamai purge"))
         response = requests.get("http://localhost:6789/debug/get-purges")
         purgeData = response.json()
-        if len(purgeData["V3"]) != 1:
+        if len(purgeData["V3"]) == 0:
             continue
         break
     reset_akamai_purges()


### PR DESCRIPTION
Fixes a CI problem introduced by https://github.com/letsencrypt/boulder/pull/6758 where we could send two purge requests which caused sporadic CI failures due to an infinite loop.

Fixes https://github.com/letsencrypt/boulder/issues/6806