### PR TITLE
Re-remove never-used crls table

### DIFF
--- a/sa/db/boulder_sa/20210223140000_CombinedSchema.sql
+++ b/sa/db/boulder_sa/20210223140000_CombinedSchema.sql
@@ -63,13 +63,6 @@ CREATE TABLE `certificatesPerName` (
   UNIQUE KEY `eTLDPlusOne_time_idx` (`eTLDPlusOne`,`time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `crls` (
-  `serial` varchar(255) NOT NULL,
-  `createdAt` datetime NOT NULL,
-  `crl` varchar(255) NOT NULL,
-  PRIMARY KEY (`serial`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
 CREATE TABLE `fqdnSets` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `setHash` binary(32) NOT NULL,


### PR DESCRIPTION
Relands #5303, which was accidentally reverted in #5305.

Fixes https://github.com/letsencrypt/boulder/issues/6816