### PR TITLE
Re-enable errcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,8 @@ linters:
 linters-settings:
   errcheck:
     exclude-functions:
+      - (net/http.ResponseWriter).Write
+      - (net.Conn).Write
       - encoding/binary.Write
       - io.Write
       - net/http.Write

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   disable-all: true
   enable:
+    - errcheck
     - gofmt
     - gosec
     - gosimple
@@ -16,7 +17,12 @@ linters:
     # TODO(#6202): Re-enable 'wastedassign' linter
 linters-settings:
   errcheck:
-    ignore: fmt:[FS]?[Pp]rint*,io:Write,os:Remove,net/http:Write,github.com/miekg/dns:WriteMsg,net:Write,encoding/binary:Write
+    exclude-functions:
+      - encoding/binary.Write
+      - io.Write
+      - net/http.Write
+      - os.Remove
+      - github.com/miekg/dns.WriteMsg
   gosimple:
     # S1029: Range over the string directly
     checks: ["all", "-S1029"]

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -617,7 +617,8 @@ func main() {
 		if parallelism < 1 {
 			cmd.Fail("parallelism argument must be >= 1")
 		}
-		r.revokeIncidentTableSerials(ctx, tableName, revocation.Reason(reasonCode), parallelism)
+		err = r.revokeIncidentTableSerials(ctx, tableName, revocation.Reason(reasonCode), parallelism)
+		cmd.FailOnError(err, "Couldn't revoke serials in incident table")
 
 	default:
 		usage()

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -274,7 +274,8 @@ func TestProcessCerts(t *testing.T) {
 	testCtx := setup(t, []time.Duration{expiresIn})
 
 	certs := addExpiringCerts(t, testCtx)
-	testCtx.m.processCerts(context.Background(), certs, expiresIn)
+	err := testCtx.m.processCerts(context.Background(), certs, expiresIn)
+	test.AssertNotError(t, err, "processing certs")
 	// Test that the lastExpirationNagSent was updated for the certificate
 	// corresponding to serial4, which is set up as "already renewed" by
 	// addExpiringCerts.
@@ -381,7 +382,8 @@ func TestProcessCertsParallel(t *testing.T) {
 
 	testCtx.m.parallelSends = 2
 	certs := addExpiringCerts(t, testCtx)
-	testCtx.m.processCerts(context.Background(), certs, expiresIn)
+	err := testCtx.m.processCerts(context.Background(), certs, expiresIn)
+	test.AssertNotError(t, err, "processing certs")
 	// Test that the lastExpirationNagSent was updated for the certificate
 	// corresponding to serial4, which is set up as "already renewed" by
 	// addExpiringCerts.
@@ -404,7 +406,8 @@ func TestProcessCertsConnectError(t *testing.T) {
 	testCtx.m.mailer = erroringMailClient{}
 	certs := addExpiringCerts(t, testCtx)
 	// Checking that this terminates rather than deadlocks
-	testCtx.m.processCerts(context.Background(), certs, expiresIn)
+	err := testCtx.m.processCerts(context.Background(), certs, expiresIn)
+	test.AssertError(t, err, "processing certs")
 }
 
 func TestFindExpiringCertificates(t *testing.T) {

--- a/cmd/rocsp-tool/main.go
+++ b/cmd/rocsp-tool/main.go
@@ -192,7 +192,10 @@ var (
 					Bytes: resp,
 					Type:  "OCSP RESPONSE",
 				}
-				pem.Encode(os.Stdout, &block)
+				err = pem.Encode(os.Stdout, &block)
+				if err != nil {
+					return err
+				}
 			}
 			return nil
 		},

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -336,7 +336,10 @@ func ValidateJSONConfig(cv *ConfigValidator, in io.Reader) error {
 	validate := validator.New()
 	if cv.Validators != nil {
 		for tag, v := range cv.Validators {
-			validate.RegisterValidation(tag, v)
+			err := validate.RegisterValidation(tag, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -377,7 +380,10 @@ func ValidateYAMLConfig(cv *ConfigValidator, in io.Reader) error {
 	validate := validator.New()
 	if cv.Validators != nil {
 		for tag, v := range cv.Validators {
-			validate.RegisterValidation(tag, v)
+			err := validate.RegisterValidation(tag, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/db/qmarks_test.go
+++ b/db/qmarks_test.go
@@ -13,7 +13,7 @@ func TestQuestionMarks(t *testing.T) {
 }
 
 func TestQuestionMarksPanic(t *testing.T) {
-	defer func() { recover() }()
+	defer func() { _ = recover() }()
 	QuestionMarks(0)
 	t.Errorf("calling QuestionMarks(0) did not panic as expected")
 }

--- a/grpc/resolver.go
+++ b/grpc/resolver.go
@@ -30,7 +30,11 @@ func (sb *staticBuilder) Build(target resolver.Target, cc resolver.ClientConn, _
 		}
 		resolverAddrs = append(resolverAddrs, *parsedAddress)
 	}
-	return newStaticResolver(cc, resolverAddrs), nil
+	r, err := newStaticResolver(cc, resolverAddrs)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
 // Scheme returns the scheme that `staticBuilder` will be registered for, for
@@ -49,9 +53,12 @@ type staticResolver struct {
 // `resolver.Addresses`. It updates the state of the `resolver.ClientConn` with
 // the provided addresses and returns a `staticResolver` which wraps the
 // `resolver.ClientConn` and implements the `resolver.Resolver` interface.
-func newStaticResolver(cc resolver.ClientConn, resolverAddrs []resolver.Address) resolver.Resolver {
-	cc.UpdateState(resolver.State{Addresses: resolverAddrs})
-	return &staticResolver{cc: cc}
+func newStaticResolver(cc resolver.ClientConn, resolverAddrs []resolver.Address) (resolver.Resolver, error) {
+	err := cc.UpdateState(resolver.State{Addresses: resolverAddrs})
+	if err != nil {
+		return nil, err
+	}
+	return &staticResolver{cc: cc}, nil
 }
 
 // ResolveNow is a no-op necessary for `staticResolver` to implement the

--- a/ocsp/responder/redis/redis_source.go
+++ b/ocsp/responder/redis/redis_source.go
@@ -163,6 +163,10 @@ func (src *redisSource) signAndSave(ctx context.Context, req *ocsp.Request, caus
 		return nil, err
 	}
 	src.signAndSaveCounter.WithLabelValues(string(cause), "signing_success").Inc()
-	go src.client.StoreResponse(context.Background(), resp.Response)
+	go func() {
+		// We don't care about the error here, because if storing the response
+		// fails, we'll just generate a new one on the next request.
+		_ = src.client.StoreResponse(context.Background(), resp.Response)
+	}()
 	return resp, nil
 }

--- a/semaphore/semaphore_bench_test.go
+++ b/semaphore/semaphore_bench_test.go
@@ -60,7 +60,7 @@ func acquireN(b *testing.B, sem weighted, size int64, N int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < N; j++ {
-			sem.Acquire(context.Background(), size)
+			_ = sem.Acquire(context.Background(), size)
 		}
 		for j := 0; j < N; j++ {
 			sem.Release(size)

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -20,7 +20,7 @@ const maxSleep = 1 * time.Millisecond
 
 func HammerWeighted(sem *semaphore.Weighted, n int64, loops int) {
 	for i := 0; i < loops; i++ {
-		sem.Acquire(context.Background(), n)
+		_ = sem.Acquire(context.Background(), n)
 		time.Sleep(time.Duration(rand.Int63n(int64(maxSleep/time.Nanosecond))) * time.Nanosecond)
 		sem.Release(n)
 	}
@@ -62,14 +62,14 @@ func TestWeightedTryAcquire(t *testing.T) {
 	ctx := context.Background()
 	sem := semaphore.NewWeighted(2, 0)
 	tries := []bool{}
-	sem.Acquire(ctx, 1)
+	_ = sem.Acquire(ctx, 1)
 	tries = append(tries, sem.TryAcquire(1))
 	tries = append(tries, sem.TryAcquire(1))
 
 	sem.Release(2)
 
 	tries = append(tries, sem.TryAcquire(1))
-	sem.Acquire(ctx, 1)
+	_ = sem.Acquire(ctx, 1)
 	tries = append(tries, sem.TryAcquire(1))
 
 	want := []bool{true, false, true, false}
@@ -92,14 +92,14 @@ func TestWeightedAcquire(t *testing.T) {
 	}
 
 	tries := []bool{}
-	sem.Acquire(ctx, 1)
+	_ = sem.Acquire(ctx, 1)
 	tries = append(tries, tryAcquire(1))
 	tries = append(tries, tryAcquire(1))
 
 	sem.Release(2)
 
 	tries = append(tries, tryAcquire(1))
-	sem.Acquire(ctx, 1)
+	_ = sem.Acquire(ctx, 1)
 	tries = append(tries, tryAcquire(1))
 
 	want := []bool{true, false, true, false}
@@ -118,7 +118,9 @@ func TestWeightedDoesntBlockIfTooBig(t *testing.T) {
 	{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		go sem.Acquire(ctx, n+1)
+		go func() {
+			_ = sem.Acquire(ctx, n+1)
+		}()
 	}
 
 	g, ctx := errgroup.WithContext(context.Background())
@@ -150,7 +152,7 @@ func TestLargeAcquireDoesntStarve(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(int(n))
 	for i := n; i > 0; i-- {
-		sem.Acquire(ctx, 1)
+		_ = sem.Acquire(ctx, 1)
 		go func() {
 			defer func() {
 				sem.Release(1)
@@ -159,12 +161,12 @@ func TestLargeAcquireDoesntStarve(t *testing.T) {
 			for running {
 				time.Sleep(1 * time.Millisecond)
 				sem.Release(1)
-				sem.Acquire(ctx, 1)
+				_ = sem.Acquire(ctx, 1)
 			}
 		}()
 	}
 
-	sem.Acquire(ctx, n)
+	_ = sem.Acquire(ctx, n)
 	running = false
 	sem.Release(n)
 	wg.Wait()
@@ -175,13 +177,13 @@ func TestAllocCancelDoesntStarve(t *testing.T) {
 	sem := semaphore.NewWeighted(10, 0)
 
 	// Block off a portion of the semaphore so that Acquire(_, 10) can eventually succeed.
-	sem.Acquire(context.Background(), 1)
+	_ = sem.Acquire(context.Background(), 1)
 
 	// In the background, Acquire(_, 10).
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		sem.Acquire(ctx, 10)
+		_ = sem.Acquire(ctx, 10)
 	}()
 
 	// Wait until the Acquire(_, 10) call blocks.
@@ -205,11 +207,11 @@ func TestMaxWaiters(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sem := semaphore.NewWeighted(1, 10)
-	sem.Acquire(ctx, 1)
+	_ = sem.Acquire(ctx, 1)
 
 	for i := 0; i < 10; i++ {
 		go func() {
-			sem.Acquire(ctx, 1)
+			_ = sem.Acquire(ctx, 1)
 			<-ctx.Done()
 		}()
 	}

--- a/test/cert-ceremonies/generate.go
+++ b/test/cert-ceremonies/generate.go
@@ -74,7 +74,7 @@ func genCert(path string) error {
 }
 
 func main() {
-	blog.Set(blog.StdoutLogger(6))
+	_ = blog.Set(blog.StdoutLogger(6))
 
 	// If one of the output files already exists, assume this ran once
 	// already for the container and don't re-run.


### PR DESCRIPTION
Enable the errcheck linter. Update the way we express exclusions to use the new, non-deprecated, non-regex-based format. Fix all places where we began accidentally violating errcheck while it was disabled.