### PR TITLE
Lowercase CN in all code paths

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -123,7 +123,7 @@ func NamesFromCSR(csr *x509.CertificateRequest) names {
 	// which is shorter than the the maximum acceptable CN length (if any).
 	for _, name := range sans {
 		if len(name) <= maxCNLength {
-			return names{SANs: core.UniqueLowerNames(sans), CN: name}
+			return names{SANs: core.UniqueLowerNames(sans), CN: strings.ToLower(name)}
 		}
 	}
 

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -185,6 +185,14 @@ func TestNamesFromCSR(t *testing.T) {
 			[]string{"a.com"},
 		},
 		{
+			"no explicit CN, uppercase SAN",
+			&x509.CertificateRequest{DNSNames: []string{
+				"A.com",
+			}},
+			"a.com",
+			[]string{"a.com"},
+		},
+		{
 			"no explicit CN, too long leading SANs",
 			&x509.CertificateRequest{DNSNames: []string{
 				tooLongString + ".a.com",


### PR DESCRIPTION
When returning a CN from csr.NamesFromCSR, ensure that we call strings.ToLower on that name in all return paths. This prevents us from running into lint failures (and therefore refusing to issue) when an applicant submits a CSR containing uppercase SANs and no explicit CN.