### PR TITLE
OTel Integration test using jaeger

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -181,7 +181,7 @@ func (l logOutput) Output(calldepth int, logline string) error {
 func StatsAndLogging(logConf SyslogConfig, otConf OpenTelemetryConfig, addr string) (prometheus.Registerer, blog.Logger, func(context.Context)) {
 	logger := NewLogger(logConf)
 
-	shutdown := newOpenTelemetry(otConf, logger)
+	shutdown := NewOpenTelemetry(otConf, logger)
 
 	return newStatsRegistry(addr, logger), logger, shutdown
 }
@@ -295,9 +295,9 @@ func newStatsRegistry(addr string, logger blog.Logger) prometheus.Registerer {
 	return registry
 }
 
-// newOpenTelemetry sets up our OpenTelemetry tracing
+// NewOpenTelemetry sets up our OpenTelemetry tracing
 // It returns a graceful shutdown function to be deferred.
-func newOpenTelemetry(config OpenTelemetryConfig, logger blog.Logger) func(ctx context.Context) {
+func NewOpenTelemetry(config OpenTelemetryConfig, logger blog.Logger) func(ctx context.Context) {
 	otel.SetLogger(stdr.New(logOutput{logger}))
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) { logger.Errf("OpenTelemetry error: %v", err) }))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - bredis_1
       - bredis_2
       - bconsul
+      - jaeger
     entrypoint: test/entrypoint.sh
     working_dir: &boulder_working_dir /boulder
 
@@ -117,6 +118,17 @@ services:
       - .:/boulder
     working_dir: *boulder_working_dir
     entrypoint: test/entrypoint-netaccess.sh
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    networks:
+      bluenet:
+        ipv4_address: 10.77.77.17
+    ports:
+      - "16686:16686" # Jaegar API and UI
+      - "4317:4317"  # OTLP grpc trace submission
 
 networks:
   bluenet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - bredis_1
       - bredis_2
       - bconsul
-      - jaeger
+      - bjaeger
     entrypoint: test/entrypoint.sh
     working_dir: &boulder_working_dir /boulder
 
@@ -119,7 +119,7 @@ services:
     working_dir: *boulder_working_dir
     entrypoint: test/entrypoint-netaccess.sh
 
-  jaeger:
+  bjaeger:
     image: jaegertracing/all-in-one:1.44
     environment:
       COLLECTOR_OTLP_ENABLED: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
     entrypoint: test/entrypoint-netaccess.sh
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:1.44
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
     networks:

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ocsp"
 
 	"github.com/letsencrypt/boulder/core"
@@ -185,7 +186,9 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	// to not be able to cancel our operations in arbitrary places. Instead we
 	// start a new context, and apply timeouts in our various RPCs.
 	// TODO(go1.22?): Use context.Detach()
-	ctx := context.Background()
+	span := trace.SpanFromContext(request.Context())
+	ctx := trace.ContextWithSpan(context.Background(), span)
+	request = request.WithContext(ctx)
 
 	if rs.timeout != 0 {
 		var cancel func()

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -20,9 +20,10 @@ import (
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ocsp"
 	"golang.org/x/exp/slices"
-	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"gopkg.in/go-jose/go-jose.v2"
@@ -1255,8 +1256,9 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 	if features.Enabled(features.AsyncFinalize) {
 		// If we're in async mode, use a context with a much longer timeout.
 		// TODO(go1.22?): use context.Detach to preserve tracing metadata.
+		span := trace.SpanFromContext(ctx)
 		var cancel func()
-		ctx, cancel = context.WithTimeout(context.Background(), ra.finalizeTimeout)
+		ctx, cancel = context.WithTimeout(trace.ContextWithSpan(context.Background(), span), ra.finalizeTimeout)
 		defer cancel()
 	}
 

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -37,5 +37,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -39,7 +39,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -37,5 +37,9 @@
 	"syslog": {
 		"stdoutlevel": 4,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -39,7 +39,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -140,7 +140,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -138,5 +138,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -140,7 +140,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -138,5 +138,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/crl-storer.json
+++ b/test/config-next/crl-storer.json
@@ -37,7 +37,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/crl-storer.json
+++ b/test/config-next/crl-storer.json
@@ -35,5 +35,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -48,5 +48,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -50,7 +50,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -44,7 +44,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -42,5 +42,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -3,7 +3,7 @@
 		"stdoutLevel": 7
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	},
 	"debugAddr": ":8016",

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -2,6 +2,10 @@
 	"syslog": {
 		"stdoutLevel": 7
 	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
+	},
 	"debugAddr": ":8016",
 	"files": [
 		"/var/log/akamai-purger.log",

--- a/test/config-next/nonce-a.json
+++ b/test/config-next/nonce-a.json
@@ -10,7 +10,7 @@
 			"syslogLevel": -1
 		},
 		"opentelemetry": {
-			"endpoint": "jaeger:4317",
+			"endpoint": "bjaeger:4317",
 			"sampleratio": 1
 		},
 		"debugAddr": ":8111",

--- a/test/config-next/nonce-a.json
+++ b/test/config-next/nonce-a.json
@@ -9,6 +9,10 @@
 			"stdoutLevel": 6,
 			"syslogLevel": -1
 		},
+		"opentelemetry": {
+			"endpoint": "jaeger:4317",
+			"sampleratio": 1
+		},
 		"debugAddr": ":8111",
 		"grpc": {
 			"maxConnectionAge": "30s",

--- a/test/config-next/nonce-b.json
+++ b/test/config-next/nonce-b.json
@@ -10,7 +10,7 @@
 			"syslogLevel": -1
 		},
 		"opentelemetry": {
-			"endpoint": "jaeger:4317",
+			"endpoint": "bjaeger:4317",
 			"sampleratio": 1
 		},
 		"debugAddr": ":8111",

--- a/test/config-next/nonce-b.json
+++ b/test/config-next/nonce-b.json
@@ -9,6 +9,10 @@
 			"stdoutLevel": 6,
 			"syslogLevel": -1
 		},
+		"opentelemetry": {
+			"endpoint": "jaeger:4317",
+			"sampleratio": 1
+		},
 		"debugAddr": ":8111",
 		"grpc": {
 			"maxConnectionAge": "30s",

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -61,5 +61,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -63,7 +63,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -49,7 +49,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -47,5 +47,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -139,7 +139,7 @@
 		"sysloglevel": 6
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -137,5 +137,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": 6
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/rocsp-tool.json
+++ b/test/config-next/rocsp-tool.json
@@ -19,5 +19,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": 6
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/rocsp-tool.json
+++ b/test/config-next/rocsp-tool.json
@@ -21,7 +21,7 @@
 		"sysloglevel": 6
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -56,7 +56,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -54,5 +54,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -40,5 +40,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -42,7 +42,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -40,5 +40,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -42,7 +42,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -62,7 +62,7 @@
 		"sysloglevel": 6
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -60,5 +60,9 @@
 	"syslog": {
 		"stdoutlevel": 6,
 		"sysloglevel": 6
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -101,5 +101,9 @@
 	"syslog": {
 		"stdoutlevel": 4,
 		"sysloglevel": -1
+	},
+	"opentelemetry": {
+		"endpoint": "jaeger:4317",
+		"sampleratio": 1
 	}
 }

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -103,7 +103,7 @@
 		"sysloglevel": -1
 	},
 	"opentelemetry": {
-		"endpoint": "jaeger:4317",
+		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}
 }

--- a/test/integration/otel_test.go
+++ b/test/integration/otel_test.go
@@ -120,10 +120,10 @@ func findSpans(trace Trace, parentSpan string, expectedSpan expectedSpans) bool 
 		if !isParent(parentSpan, span) {
 			continue
 		}
-		if expectedSpan.Service != trace.Processes[span.ProcessID].ServiceName {
+		if trace.Processes[span.ProcessID].ServiceName != expectedSpan.Service {
 			continue
 		}
-		if expectedSpan.Operation != span.OperationName {
+		if span.OperationName != expectedSpan.Operation {
 			continue
 		}
 		if missingChildren(trace, span.SpanID, expectedSpan.Children) {

--- a/test/integration/otel_test.go
+++ b/test/integration/otel_test.go
@@ -61,6 +61,7 @@ type Span struct {
 }
 
 func getTraceFromJaeger(t *testing.T, traceID trace.TraceID) Trace {
+	t.Helper()
 	traceURL := "http://bjaeger:16686/api/traces/" + traceID.String()
 	resp, err := http.Get(traceURL)
 	test.AssertNotError(t, err, "failed to trace from jaeger: "+traceID.String())
@@ -77,7 +78,7 @@ func getTraceFromJaeger(t *testing.T, traceID trace.TraceID) Trace {
 	test.AssertNotError(t, err, "failed to decode traces body")
 
 	if len(parsed.Data) != 1 {
-		t.Fatalf("expected to get exactly one trace for %s: %v", traceID, parsed)
+		t.Fatalf("expected to get exactly one trace from jaeger for %s: %v", traceID, parsed)
 	}
 
 	return parsed.Data[0]

--- a/test/integration/otel_test.go
+++ b/test/integration/otel_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eggsampler/acme/v3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/letsencrypt/boulder/cmd"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/test"
+)
+
+// TraceResponse is just the minimal fields we care about from the Jaeger traces API
+type TraceData struct {
+	Spans []struct {
+		SpanID        string
+		OperationName string
+		Warnings      []string
+		ProcessID     string
+		References    []struct {
+			RefType string
+			TraceID string
+			SpanID  string
+		}
+	}
+}
+
+// TraceResponse is what we get from the traces API.
+// We always search for a single trace by ID, so this should be length 1.
+type TraceResponse struct {
+	Data []TraceData
+}
+
+func getTraceFromJaeger(t *testing.T, traceID trace.TraceID) TraceData {
+	traceURL := "http://jaeger:16686/api/traces/" + traceID.String()
+	resp, err := http.Get(traceURL)
+	test.AssertNotError(t, err, "failed to trace from jaeger: "+traceID.String())
+	if resp.StatusCode == http.StatusNotFound {
+		t.Fatalf("jaeger returned 404 for trace %s", traceID)
+	}
+	test.AssertEquals(t, resp.StatusCode, http.StatusOK)
+
+	body, err := io.ReadAll(resp.Body)
+	test.AssertNotError(t, err, "failed to read trace body")
+
+	var parsed TraceResponse
+	err = json.Unmarshal(body, &parsed)
+	test.AssertNotError(t, err, "failed to decode traces body")
+
+	if len(parsed.Data) != 1 {
+		t.Fatalf("expected to get exactly one trace for %s: %v", traceID, parsed)
+	}
+
+	return parsed.Data[0]
+}
+
+// assertSpans checks the trace contains all the expected spans.
+func assertSpans(t *testing.T, traceData TraceData, expectedSpans []string) {
+	for _, expectedSpan := range expectedSpans {
+		found := false
+		for _, span := range traceData.Spans {
+			if expectedSpan == span.OperationName {
+				found = true
+				break
+			}
+		}
+		test.Assert(t, found, fmt.Sprintf("Didn't find expected span: %s in %v", expectedSpan, traceData))
+	}
+}
+
+type ContextInjectingRoundTripper struct {
+	ctx context.Context
+}
+
+func (c *ContextInjectingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	otel.GetTextMapPropagator().Inject(c.ctx, propagation.HeaderCarrier(request.Header))
+	return http.DefaultTransport.RoundTrip(request.WithContext(c.ctx))
+}
+
+// TestTraces tests that all the expected spans are present and properly connected
+func TestTraces(t *testing.T) {
+	t.Parallel()
+	if !strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
+		t.Skip("OpenTelemetry is only configured in config-next")
+	}
+
+	traceID := traceIssuingTestCert(t)
+
+	// Sleep to allow traces to flush
+	// TODO: We could retry with backoff instead, allowing this test to complete faster.
+	// TODO: We could also configure a lower batch delay in CI
+	time.Sleep(1.2 * sdktrace.DefaultScheduleDelay * time.Millisecond)
+
+	// TODO: We really want to assert more structure of the trace here
+	assertSpans(t, getTraceFromJaeger(t, traceID), []string{
+		"/directory",
+		"/acme/new-acct",
+		"sa.StorageAuthority/GetOrderForNames",
+		"/acme/chall-v3/",
+		"nonce.NonceService/Nonce",
+	})
+}
+
+func traceIssuingTestCert(t *testing.T) trace.TraceID {
+	domains := []string{random_domain()}
+
+	// Configure this integration test to trace to jaeger:4317 like Boulder will
+	shutdown := cmd.NewOpenTelemetry(cmd.OpenTelemetryConfig{
+		Endpoint:    "jaeger:4317",
+		SampleRatio: 1,
+	}, blog.Get())
+	defer shutdown(context.Background())
+
+	tracer := otel.GetTracerProvider().Tracer("TraceTest")
+	ctx, span := tracer.Start(context.Background(), "TraceTest")
+	defer span.End()
+
+	// Provide an HTTP client with otel spans.
+	// The acme client doesn't pass contexts through, so we inject one.
+	option := acme.WithHTTPClient(&http.Client{
+		Timeout:   60 * time.Second,
+		Transport: &ContextInjectingRoundTripper{ctx},
+	})
+
+	c, err := acme.NewClient("http://boulder.service.consul:4001/directory", option)
+	test.AssertNotError(t, err, "newAccount failed")
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "newAccount failed")
+
+	account, err := c.NewAccount(privKey, false, true)
+	test.AssertNotError(t, err, "newAccount failed")
+
+	_, err = authAndIssue(&client{account, c}, nil, domains, true)
+	test.AssertNotError(t, err, "authAndIssue failed")
+
+	return span.SpanContext().TraceID()
+}

--- a/test/integration/otel_test.go
+++ b/test/integration/otel_test.go
@@ -55,7 +55,7 @@ type TraceResponse struct {
 }
 
 func getTraceFromJaeger(t *testing.T, traceID trace.TraceID) TraceData {
-	traceURL := "http://jaeger:16686/api/traces/" + traceID.String()
+	traceURL := "http://bjaeger:16686/api/traces/" + traceID.String()
 	resp, err := http.Get(traceURL)
 	test.AssertNotError(t, err, "failed to trace from jaeger: "+traceID.String())
 	if resp.StatusCode == http.StatusNotFound {
@@ -263,7 +263,7 @@ func traceIssuingTestCert(t *testing.T) trace.TraceID {
 
 	// Configure this integration test to trace to jaeger:4317 like Boulder will
 	shutdown := cmd.NewOpenTelemetry(cmd.OpenTelemetryConfig{
-		Endpoint:    "jaeger:4317",
+		Endpoint:    "bjaeger:4317",
 		SampleRatio: 1,
 	}, blog.Get())
 	defer shutdown(context.Background())


### PR DESCRIPTION
This adds Jaeger's all-in-one dev container (with no persistent storage) to boulder's dev docker-compose.  It configures config-next/ to send all traces there.
A new integration test creates an account and issues a cert, then verifies the trace contains some set of expected spans.

This test found that async finalize broke spans, so I fixed that and a few related spots where we make a new context.