### PR TITLE
CA: Only increment lintErrorCount for true lint violations

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -27,6 +27,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/issuance"
+	"github.com/letsencrypt/boulder/linter"
 	blog "github.com/letsencrypt/boulder/log"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
@@ -446,7 +447,7 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 	if err != nil {
 		ca.log.AuditErrf("Preparing precert failed: serial=[%s] regID=[%d] names=[%s] err=[%v]",
 			serialHex, issueReq.RegistrationID, strings.Join(csr.DNSNames, ", "), err)
-		if errors.Is(err, issuance.ErrLinting) {
+		if errors.Is(err, linter.ErrLinting) {
 			ca.lintErrorCount.Inc()
 		}
 		return nil, nil, berrors.InternalServerError("failed to prepare precertificate signing: %s", err)

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -36,8 +36,6 @@ import (
 	"github.com/letsencrypt/pkcs11key/v4"
 )
 
-var ErrLinting = errors.New("tbsCertificate linting failed")
-
 // ProfileConfig describes the certificate issuance constraints for all issuers.
 type ProfileConfig struct {
 	AllowMustStaple bool
@@ -668,7 +666,7 @@ func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 	// with a throwaway key and then linting it using zlint
 	lintCertBytes, err := i.Linter.Check(template, req.PublicKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w: %w", ErrLinting, err)
+		return nil, nil, fmt.Errorf("tbsCertificate linting failed: %w", err)
 	}
 
 	token := &issuanceToken{sync.Mutex{}, template, req.PublicKey, i}

--- a/issuance/issuance_test.go
+++ b/issuance/issuance_test.go
@@ -800,9 +800,9 @@ func TestIssueMustStaple(t *testing.T) {
 func TestIssueBadLint(t *testing.T) {
 	fc := clock.NewFake()
 	fc.Set(time.Now())
-	linter, err := linter.New(issuerCert.Certificate, issuerSigner, []string{})
+	lint, err := linter.New(issuerCert.Certificate, issuerSigner, []string{})
 	test.AssertNotError(t, err, "failed to create linter")
-	signer, err := NewIssuer(issuerCert, issuerSigner, defaultProfile(), linter, fc)
+	signer, err := NewIssuer(issuerCert, issuerSigner, defaultProfile(), lint, fc)
 	test.AssertNotError(t, err, "NewIssuer failed")
 	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	test.AssertNotError(t, err, "failed to generate test key")
@@ -814,8 +814,8 @@ func TestIssueBadLint(t *testing.T) {
 		NotAfter:  fc.Now().Add(time.Hour - time.Second),
 	})
 	test.AssertError(t, err, "Prepare didn't fail")
-	test.AssertErrorIs(t, err, ErrLinting)
-	test.AssertContains(t, err.Error(), "tbsCertificate linting failed: failed lints")
+	test.AssertErrorIs(t, err, linter.ErrLinting)
+	test.AssertContains(t, err.Error(), "tbsCertificate linting failed: failed lint(s)")
 }
 
 func TestLoadChain_Valid(t *testing.T) {

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -22,7 +22,7 @@ import (
 	_ "github.com/letsencrypt/boulder/linter/lints/subscriber"
 )
 
-var ErrLinting = fmt.Errorf("failed lint(s): ")
+var ErrLinting = fmt.Errorf("failed lint(s)")
 
 // Check accomplishes the entire process of linting: it generates a throwaway
 // signing key, uses that to create a throwaway cert, and runs a default set

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -22,6 +22,8 @@ import (
 	_ "github.com/letsencrypt/boulder/linter/lints/subscriber"
 )
 
+var ErrLinting = fmt.Errorf("failed lint(s): ")
+
 // Check accomplishes the entire process of linting: it generates a throwaway
 // signing key, uses that to create a throwaway cert, and runs a default set
 // of lints (everything except for the ETSI and EV lints) against it. This is
@@ -204,7 +206,7 @@ func ProcessResultSet(lintRes *zlint.ResultSet) error {
 				failedLints = append(failedLints, fmt.Sprintf("%s (%s)", lintName, result.Details))
 			}
 		}
-		return fmt.Errorf("failed lints: %s", strings.Join(failedLints, ", "))
+		return fmt.Errorf("%w: %s", ErrLinting, strings.Join(failedLints, ", "))
 	}
 	return nil
 }


### PR DESCRIPTION
Return the sentinel error indicative of lint violation from `linter.ProcessResultSet()` instead of `issuance`. This removes a potential source of false-positives.