### PR TITLE
grpc: add NoWaitForReady config field

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -343,6 +343,13 @@ type GRPCClientConfig struct {
 	// verify in the certificate presented by the server.
 	HostOverride string `validate:"excluded_with=ServerIPAddresses,omitempty,hostname"`
 	Timeout      config.Duration
+
+	// NoWaitForReady turns off our (current) default of setting grpc.WaitForReady(true).
+	// This means if all of a GRPC client's backends are down, it will error immediately.
+	// The current default, grpc.WaitForReady(true), means that if all of a GRPC client's
+	// backends are down, it will wait until either one becomes available or the RPC
+	// times out.
+	NoWaitForReady bool
 }
 
 // MakeTargetAndHostOverride constructs the target URI that the gRPC client will

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -39,7 +39,7 @@ func ClientSetup(c *cmd.GRPCClientConfig, tlsConfig *tls.Config, statsRegistry p
 		return nil, err
 	}
 
-	cmi := clientMetadataInterceptor{c.Timeout.Duration, metrics, clk}
+	cmi := clientMetadataInterceptor{c.Timeout.Duration, metrics, clk, !c.NoWaitForReady}
 
 	unaryInterceptors := []grpc.UnaryClientInterceptor{
 		cmi.Unary,

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -34,7 +34,7 @@ func TestErrorWrapping(t *testing.T) {
 	smi := newServerMetadataInterceptor(serverMetrics, clock.NewFake())
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	cmi := clientMetadataInterceptor{time.Second, clientMetrics, clock.NewFake()}
+	cmi := clientMetadataInterceptor{time.Second, clientMetrics, clock.NewFake(), true}
 	srv := grpc.NewServer(grpc.UnaryInterceptor(smi.Unary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)
@@ -77,7 +77,7 @@ func TestSubErrorWrapping(t *testing.T) {
 	smi := newServerMetadataInterceptor(serverMetrics, clock.NewFake())
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
-	cmi := clientMetadataInterceptor{time.Second, clientMetrics, clock.NewFake()}
+	cmi := clientMetadataInterceptor{time.Second, clientMetrics, clock.NewFake(), true}
 	srv := grpc.NewServer(grpc.UnaryInterceptor(smi.Unary))
 	es := &errorServer{}
 	test_proto.RegisterChillerServer(srv, es)

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -224,6 +224,8 @@ type clientMetadataInterceptor struct {
 	timeout time.Duration
 	metrics clientMetrics
 	clk     clock.Clock
+
+	waitForReady bool
 }
 
 // Unary implements the grpc.UnaryClientInterceptor interface.
@@ -255,7 +257,7 @@ func (cmi *clientMetadataInterceptor) Unary(
 
 	// Disable fail-fast so RPCs will retry until deadline, even if all backends
 	// are down.
-	opts = append(opts, grpc.WaitForReady(true))
+	opts = append(opts, grpc.WaitForReady(cmi.waitForReady))
 
 	// Create a grpc/metadata.Metadata instance for a grpc.Trailer.
 	respMD := metadata.New(nil)
@@ -364,7 +366,7 @@ func (cmi *clientMetadataInterceptor) Stream(
 
 	// Disable fail-fast so RPCs will retry until deadline, even if all backends
 	// are down.
-	opts = append(opts, grpc.WaitForReady(true))
+	opts = append(opts, grpc.WaitForReady(cmi.waitForReady))
 
 	// Create a grpc/metadata.Metadata instance for a grpc.Trailer.
 	respMD := metadata.New(nil)

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -87,17 +87,19 @@ func TestClientInterceptor(t *testing.T) {
 	test.AssertError(t, err, "ci.intercept didn't fail when handler returned a error")
 }
 
-// TestFailFastFalse sends a gRPC request to a backend that is
-// unavailable, and ensures that the request doesn't error out until the
-// timeout is reached, i.e. that FailFast is set to false.
+// TestWaitForReadyTrue configures a gRPC client with waitForReady: true and
+// sends a request to a backend that is unavailable. It ensures that the
+// request doesn't error out until the timeout is reached, i.e. that
+// FailFast is set to false.
 // https://github.com/grpc/grpc/blob/main/doc/wait-for-ready.md
-func TestFailFastFalse(t *testing.T) {
+func TestWaitForReadyTrue(t *testing.T) {
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
 	ci := &clientMetadataInterceptor{
 		timeout: 100 * time.Millisecond,
 		metrics: clientMetrics,
 		clk:     clock.NewFake(),
+		waitForReady: true,
 	}
 	conn, err := grpc.Dial("localhost:19876", // random, probably unused port
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, roundrobin.Name)),
@@ -114,7 +116,38 @@ func TestFailFastFalse(t *testing.T) {
 		t.Errorf("Successful Chill when we expected failure.")
 	}
 	if time.Since(start) < 90*time.Millisecond {
-		t.Errorf("Chill failed fast, when FailFast should be disabled.")
+		t.Errorf("Chill failed fast, when WaitForReady should be enabled.")
+	}
+	_ = conn.Close()
+}
+
+// TestWaitForReadyFalse configures a gRPC client with waitForReady: false and
+// unavailable, and ensures that the request errors out promptly.
+func TestWaitForReadyFalse(t *testing.T) {
+	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "creating client metrics")
+	ci := &clientMetadataInterceptor{
+		timeout: time.Second,
+		metrics: clientMetrics,
+		clk:     clock.NewFake(),
+		waitForReady: false,
+	}
+	conn, err := grpc.Dial("localhost:19876", // random, probably unused port
+		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, roundrobin.Name)),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(ci.Unary))
+	if err != nil {
+		t.Fatalf("did not connect: %v", err)
+	}
+	c := test_proto.NewChillerClient(conn)
+
+	start := time.Now()
+	_, err = c.Chill(context.Background(), &test_proto.Time{Time: time.Second.Nanoseconds()})
+	if err == nil {
+		t.Errorf("Successful Chill when we expected failure.")
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Errorf("Chill failed slow, when WaitForReady should be disabled.")
 	}
 	_ = conn.Close()
 }

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -96,9 +96,9 @@ func TestWaitForReadyTrue(t *testing.T) {
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
 	ci := &clientMetadataInterceptor{
-		timeout: 100 * time.Millisecond,
-		metrics: clientMetrics,
-		clk:     clock.NewFake(),
+		timeout:      100 * time.Millisecond,
+		metrics:      clientMetrics,
+		clk:          clock.NewFake(),
 		waitForReady: true,
 	}
 	conn, err := grpc.Dial("localhost:19876", // random, probably unused port
@@ -127,9 +127,9 @@ func TestWaitForReadyFalse(t *testing.T) {
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
 	ci := &clientMetadataInterceptor{
-		timeout: time.Second,
-		metrics: clientMetrics,
-		clk:     clock.NewFake(),
+		timeout:      time.Second,
+		metrics:      clientMetrics,
+		clk:          clock.NewFake(),
 		waitForReady: false,
 	}
 	conn, err := grpc.Dial("localhost:19876", // random, probably unused port

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -108,6 +108,7 @@ func TestWaitForReadyTrue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
+	defer conn.Close()
 	c := test_proto.NewChillerClient(conn)
 
 	start := time.Now()
@@ -118,11 +119,11 @@ func TestWaitForReadyTrue(t *testing.T) {
 	if time.Since(start) < 90*time.Millisecond {
 		t.Errorf("Chill failed fast, when WaitForReady should be enabled.")
 	}
-	_ = conn.Close()
 }
 
 // TestWaitForReadyFalse configures a gRPC client with waitForReady: false and
-// unavailable, and ensures that the request errors out promptly.
+// sends a request to a backend that is unavailable, and ensures that the request
+// errors out promptly.
 func TestWaitForReadyFalse(t *testing.T) {
 	clientMetrics, err := newClientMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating client metrics")
@@ -139,6 +140,7 @@ func TestWaitForReadyFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
+	defer conn.Close()
 	c := test_proto.NewChillerClient(conn)
 
 	start := time.Now()
@@ -149,7 +151,6 @@ func TestWaitForReadyFalse(t *testing.T) {
 	if time.Since(start) > 200*time.Millisecond {
 		t.Errorf("Chill failed slow, when WaitForReady should be disabled.")
 	}
-	_ = conn.Close()
 }
 
 // testServer is used to implement TestTimeouts, and will attempt to sleep for

--- a/test/config-next/admin-revoker.json
+++ b/test/config-next/admin-revoker.json
@@ -16,6 +16,7 @@
 				"domain": "service.consul"
 			},
 			"hostOverride": "ra.boulder",
+			"noWaitForReady": true,
 			"timeout": "15s"
 		},
 		"saService": {
@@ -25,6 +26,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"features": {}

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -17,6 +17,7 @@
 				"domain": "service.consul"
 			},
 			"hostOverride": "ra.boulder",
+			"noWaitForReady": true,
 			"timeout": "15s"
 		},
 		"mailer": {

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -41,6 +41,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"issuance": {

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -41,6 +41,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"issuance": {

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -13,6 +13,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"crlGeneratorService": {
@@ -22,6 +23,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ca.boulder"
 		},
 		"crlStorerService": {
@@ -31,6 +33,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "crl-storer.boulder"
 		},
 		"issuerCerts": [

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -31,6 +31,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -28,6 +28,7 @@
 				"domain": "service.consul"
 			},
 			"hostOverride": "ra.boulder",
+			"noWaitForReady": true,
 			"timeout": "15s"
 		},
 		"saService": {
@@ -37,6 +38,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"logSampleRate": 1,

--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -21,6 +21,7 @@
 			"domain": "service.consul"
 		},
 		"timeout": "15s",
+		"noWaitForReady": true,
 		"hostOverride": "ca.boulder"
 	},
 	"saService": {
@@ -30,6 +31,7 @@
 			"domain": "service.consul"
 		},
 		"timeout": "15s",
+		"noWaitForReady": true,
 		"hostOverride": "sa.boulder"
 	},
 	"features": {}

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -31,6 +31,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "20s",
+			"noWaitForReady": true,
 			"hostOverride": "va.boulder"
 		},
 		"caService": {
@@ -40,6 +41,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ca.boulder"
 		},
 		"ocspService": {
@@ -49,6 +51,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ca.boulder"
 		},
 		"publisherService": {
@@ -58,6 +61,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "300s",
+			"noWaitForReady": true,
 			"hostOverride": "publisher.boulder"
 		},
 		"saService": {
@@ -67,6 +71,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"akamaiPurgerService": {
@@ -76,6 +81,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "akamai-purger.boulder"
 		},
 		"grpc": {

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -29,6 +29,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ra.boulder"
 		},
 		"saService": {
@@ -38,6 +39,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"accountCache": {
@@ -51,6 +53,7 @@
 				"domain": "service.consul"
 			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "nonce.boulder"
 		},
 		"redeemNonceService": {
@@ -67,6 +70,7 @@
 			],
 			"srvResolver": "nonce-srv",
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "nonce.boulder"
 		},
 		"noncePrefixKey": {


### PR DESCRIPTION
Currently we set WaitForReady(true), which causes gRPC requests to not fail immediately if no backends are available, but instead wait until the timeout in case a backend does become available. The downside is that this behavior masks true connection errors. We'd like to turn it off.

Fixes #6834