### PR TITLE
Stop using DIRECTORY env var

### DIFF
--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -9,11 +9,11 @@ import (
 	"crypto/rand"
 	"crypto/x509/pkix"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/eggsampler/acme/v3"
+
 	"github.com/letsencrypt/boulder/test"
 	ocsp_helper "github.com/letsencrypt/boulder/test/ocsp/helper"
 )
@@ -30,7 +30,6 @@ func TestARI(t *testing.T) {
 	t.Parallel()
 
 	// Create an account.
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	client, err := makeClient("mailto:example@letsencrypt.org")
 	test.AssertNotError(t, err, "creating acme client")
 

--- a/test/integration/authz_test.go
+++ b/test/integration/authz_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -21,7 +20,6 @@ const (
 // expires time.
 func TestValidAuthzExpires(t *testing.T) {
 	t.Parallel()
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	c, err := makeClient()
 	test.AssertNotError(t, err, "makeClient failed")
 

--- a/test/integration/bad_key_test.go
+++ b/test/integration/bad_key_test.go
@@ -8,10 +8,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/eggsampler/acme/v3"
+
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -19,8 +19,6 @@ import (
 // less than 100 rounds of Fermat's Algorithm is rejected.
 func TestFermat(t *testing.T) {
 	t.Parallel()
-
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
 	type testCase struct {
 		name string

--- a/test/integration/caa_test.go
+++ b/test/integration/caa_test.go
@@ -14,7 +14,6 @@ import (
 func TestCAALogChecker(t *testing.T) {
 	t.Parallel()
 
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	c, err := makeClient()
 	test.AssertNotError(t, err, "makeClient failed")
 

--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -42,7 +42,7 @@ type client struct {
 }
 
 func makeClient(contacts ...string) (*client, error) {
-	c, err := acme.NewClient(os.Getenv("DIRECTORY"))
+	c, err := acme.NewClient("http://boulder.service.consul:4001/directory")
 	if err != nil {
 		return nil, fmt.Errorf("Error connecting to acme directory: %v", err)
 	}

--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -37,7 +37,6 @@ func TestCRLPipeline(t *testing.T) {
 	test.Assert(t, ok, "failed to look up test config directory")
 
 	// Basic setup.
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	client, err := makeClient()
 	test.AssertNotError(t, err, "creating acme client")
 	configFile := path.Join(configDir, "crl-updater.json")

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -17,7 +16,6 @@ import (
 // produces the expected problem result.
 func TestTooBigOrderError(t *testing.T) {
 	t.Parallel()
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
 	var domains []string
 	for i := 0; i < 101; i++ {
@@ -38,7 +36,6 @@ func TestTooBigOrderError(t *testing.T) {
 // result to ACME clients.
 func TestAccountEmailError(t *testing.T) {
 	t.Parallel()
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
 	// The registrations.contact field is VARCHAR(191). 175 'a' characters plus
 	// the prefix "mailto:" and the suffix "@a.com" makes exactly 191 bytes of

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -20,7 +20,6 @@ func TestCommonNameInCSR(t *testing.T) {
 	t.Parallel()
 
 	// Create an account.
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	client, err := makeClient("mailto:example@letsencrypt.org")
 	test.AssertNotError(t, err, "creating acme client")
 
@@ -53,7 +52,6 @@ func TestFirstCSRSANHoistedToCN(t *testing.T) {
 	t.Parallel()
 
 	// Create an account.
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	client, err := makeClient("mailto:example@letsencrypt.org")
 	test.AssertNotError(t, err, "creating acme client")
 
@@ -85,7 +83,6 @@ func TestCommonNameSANsTooLong(t *testing.T) {
 	t.Parallel()
 
 	// Create an account.
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	client, err := makeClient("mailto:example@letsencrypt.org")
 	test.AssertNotError(t, err, "creating acme client")
 

--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -3,13 +3,13 @@
 package integration
 
 import (
-	"os"
 	"strings"
 	"testing"
 
+	"golang.org/x/crypto/ocsp"
+
 	"github.com/letsencrypt/boulder/core"
 	ocsp_helper "github.com/letsencrypt/boulder/test/ocsp/helper"
-	"golang.org/x/crypto/ocsp"
 )
 
 // TODO(#5172): Fill out these test stubs.
@@ -40,7 +40,6 @@ func TestOCSPBadIssuerCert(t *testing.T) {
 func TestOCSPBadSerialPrefix(t *testing.T) {
 	t.Parallel()
 	domain := random_domain()
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	res, err := authAndIssue(nil, nil, []string{domain}, true)
 	if err != nil || len(res.certs) < 1 {
 		t.Fatal("Failed to issue dummy cert for OCSP testing")
@@ -74,7 +73,6 @@ func TestOCSPRejectedPrecertificate(t *testing.T) {
 		t.Fatalf("adding ct-test-srv reject host: %s", err)
 	}
 
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 	_, err = authAndIssue(nil, nil, []string{domain}, true)
 	if err != nil {
 		if !strings.Contains(err.Error(), "urn:ietf:params:acme:error:serverInternal") ||

--- a/test/integration/ratelimit_test.go
+++ b/test/integration/ratelimit_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/letsencrypt/boulder/test"
@@ -12,7 +11,6 @@ import (
 func TestDuplicateFQDNRateLimit(t *testing.T) {
 	t.Parallel()
 	domain := random_domain()
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
 	_, err := authAndIssue(nil, nil, []string{domain}, true)
 	test.AssertNotError(t, err, "Failed to issue first certificate")

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -11,15 +11,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/eggsampler/acme/v3"
+	"golang.org/x/crypto/ocsp"
+
 	"github.com/letsencrypt/boulder/test"
 	ocsp_helper "github.com/letsencrypt/boulder/test/ocsp/helper"
-	"golang.org/x/crypto/ocsp"
 )
 
 // isPrecert returns true if the provided cert has an extension with the OID
@@ -39,9 +39,6 @@ func isPrecert(cert *x509.Certificate) bool {
 // keyCompromise revocation reasons.
 func TestRevocation(t *testing.T) {
 	t.Parallel()
-
-	// Create a base account to use for revocation tests.
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
 	type authMethod string
 	var (
@@ -203,9 +200,6 @@ func TestRevocation(t *testing.T) {
 func TestReRevocation(t *testing.T) {
 	t.Parallel()
 
-	// Create a base account to use for revocation tests.
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
-
 	type authMethod string
 	var (
 		byAccount authMethod = "byAccount"
@@ -335,7 +329,6 @@ func TestReRevocation(t *testing.T) {
 
 func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 	t.Parallel()
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
 	type authMethod string
 	var (
@@ -387,8 +380,6 @@ func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 }
 
 func TestBadKeyRevoker(t *testing.T) {
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
-
 	// Both accounts have two email addresses, one of which is shared between
 	// them. All three addresses should receive mail, because the revocation
 	// request is signed by the certificate key, not an account key, so we don't
@@ -468,8 +459,6 @@ func TestBadKeyRevoker(t *testing.T) {
 }
 
 func TestBadKeyRevokerByAccount(t *testing.T) {
-	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
-
 	// Both accounts have two email addresses, one of which is shared between
 	// them. No accounts should receive any mail, because the revocation request
 	// is signed by the account key (not the cert key) and so will not be


### PR DESCRIPTION
We only ever set it to the same value, and then read it back in make_client.
It's a bit spooky-action-at-a-distance and is process-wide with no
synchronization, which means we can't safely use different values anyway.
