### PR TITLE
Update path to ARI endpoint

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -499,7 +499,7 @@ func RenewalInfoSimple(issued time.Time, expires time.Time) RenewalInfo {
 }
 
 // RenewalInfoImmediate constructs a `RenewalInfo` object with a suggested
-// window in the past. Per the draft-ietf-acme-ari-00 spec, clients should
+// window in the past. Per the draft-ietf-acme-ari-01 spec, clients should
 // attempt to renew immediately if the suggested window is in the past. The
 // passed `now` is assumed to be a timestamp representing the current moment in
 // time.

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -73,7 +73,7 @@ const (
 	getCertPath      = getAPIPrefix + "cert/"
 
 	// Draft or likely-to-change paths
-	renewalInfoPath = getAPIPrefix + "draft-ietf-acme-ari-00/renewalInfo/"
+	renewalInfoPath = "/draft-ietf-acme-ari-01/renewalInfo/"
 
 	// Non-ACME paths
 	aiaIssuerPath = "/aia/issuer/"


### PR DESCRIPTION
Update the document number to the latest version, and remove the /get/ prefix since it now supports both the GET and POST portions of the spec.

Also update one piece of tooling to properly get the ARI URL from the directory, rather than hard-coding it.