### PR TITLE
Add linting, and fix the lints, in Python

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,11 @@
+name: python-lint
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rickstaa/action-black@v1
+        with:
+          black_args: ". --check"
+      - uses: chartboost/ruff-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+
+ignore = ["E501","F405"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.ruff]
 
-ignore = ["E501","F405"]
+ignore = ["E501"]

--- a/start.py
+++ b/start.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 sys.path.append("./test")
-import startservers
+import startservers  # noqa: E402
 
 if not startservers.install(race_detection=False):
     raise (Exception("failed to build"))

--- a/start.py
+++ b/start.py
@@ -12,13 +12,12 @@ start, or die before ^C.
 import errno
 import os
 import sys
-import time
 
-sys.path.append('./test')
+sys.path.append("./test")
 import startservers
 
 if not startservers.install(race_detection=False):
-    raise(Exception("failed to build"))
+    raise (Exception("failed to build"))
 
 # Setup issuance hierarchy
 startservers.setupHierarchy()

--- a/test/challtestsrv.py
+++ b/test/challtestsrv.py
@@ -1,6 +1,7 @@
 import json
 import requests
 
+
 class ChallTestServer:
     """
     ChallTestServer is a wrapper around pebble-challtestsrv's HTTP management
@@ -9,53 +10,52 @@ class ChallTestServer:
     can instantiate the ChallTestServer using the -management address in use. If
     no custom address is provided the default is assumed.
     """
+
     _baseURL = "http://10.77.77.77:8055"
 
     _paths = {
-            "set-ipv4": "/set-default-ipv4",
-            "set-ipv6": "/set-default-ipv6",
-            "del-history": "/clear-request-history",
-            "get-http-history": "/http-request-history",
-            "get-dns-history": "/dns-request-history",
-            "get-alpn-history": "/tlsalpn01-request-history",
-            "add-a": "/add-a",
-            "del-a": "/clear-a",
-            "add-aaaa": "/add-aaaa",
-            "del-aaaa": "/clear-aaaa",
-            "add-caa": "/add-caa",
-            "del-caa": "/clear-caa",
-            "add-redirect": "/add-redirect",
-            "del-redirect": "/del-redirect",
-            "add-http": "/add-http01",
-            "del-http": "/del-http01",
-            "add-txt": "/set-txt",
-            "del-txt": "/clear-txt",
-            "add-alpn": "/add-tlsalpn01",
-            "del-alpn": "/del-tlsalpn01",
-            "add-servfail": "/set-servfail",
-            "del-servfail": "/clear-servfail",
-            }
+        "set-ipv4": "/set-default-ipv4",
+        "set-ipv6": "/set-default-ipv6",
+        "del-history": "/clear-request-history",
+        "get-http-history": "/http-request-history",
+        "get-dns-history": "/dns-request-history",
+        "get-alpn-history": "/tlsalpn01-request-history",
+        "add-a": "/add-a",
+        "del-a": "/clear-a",
+        "add-aaaa": "/add-aaaa",
+        "del-aaaa": "/clear-aaaa",
+        "add-caa": "/add-caa",
+        "del-caa": "/clear-caa",
+        "add-redirect": "/add-redirect",
+        "del-redirect": "/del-redirect",
+        "add-http": "/add-http01",
+        "del-http": "/del-http01",
+        "add-txt": "/set-txt",
+        "del-txt": "/clear-txt",
+        "add-alpn": "/add-tlsalpn01",
+        "del-alpn": "/del-tlsalpn01",
+        "add-servfail": "/set-servfail",
+        "del-servfail": "/clear-servfail",
+    }
 
     def __init__(self, url=None):
         if url is not None:
             self._baseURL = url
 
     def _postURL(self, url, body):
-        response = requests.post(
-                url,
-                data=json.dumps(body))
+        response = requests.post(url, data=json.dumps(body))
         return response.text
 
     def _URL(self, path):
         urlPath = self._paths.get(path, None)
         if urlPath is None:
-            raise Exception("No challenge test server URL path known for {0}".format(path))
+            raise Exception(
+                "No challenge test server URL path known for {0}".format(path)
+            )
         return self._baseURL + urlPath
 
     def _clear_request_history(self, host, typ):
-        return self._postURL(
-                self._URL("del-history"),
-                { "host": host, "type": typ })
+        return self._postURL(self._URL("del-history"), {"host": host, "type": typ})
 
     def set_default_ipv4(self, address):
         """
@@ -65,9 +65,7 @@ class ChallTestServer:
         address to disable answering A queries except for hosts that have mock
         A addresses added.
         """
-        return self._postURL(
-                self._URL("set-ipv4"),
-                { "ip": address })
+        return self._postURL(self._URL("set-ipv4"), {"ip": address})
 
     def set_default_ipv6(self, address):
         """
@@ -77,27 +75,21 @@ class ChallTestServer:
         default address to disable answering AAAA queries except for hosts that
         have mock AAAA addresses added.
         """
-        return self._postURL(
-                self._URL("set-ipv6"),
-                { "ip": address })
+        return self._postURL(self._URL("set-ipv6"), {"ip": address})
 
     def add_a_record(self, host, addresses):
         """
         add_a_record adds a mock A response to the challenge server's DNS
         interface for the given host and IPv4 addresses.
         """
-        return self._postURL(
-                self._URL("add-a"),
-                { "host": host, "addresses": addresses })
+        return self._postURL(self._URL("add-a"), {"host": host, "addresses": addresses})
 
     def remove_a_record(self, host):
         """
         remove_a_record removes a mock A response from the challenge server's DNS
         interface for the given host.
         """
-        return self._postURL(
-                self._URL("del-a"),
-                { "host": host })
+        return self._postURL(self._URL("del-a"), {"host": host})
 
     def add_aaaa_record(self, host, addresses):
         """
@@ -105,17 +97,15 @@ class ChallTestServer:
         interface for the given host and IPv6 addresses.
         """
         return self._postURL(
-                self._URL("add-aaaa"),
-                { "host": host, "addresses": addresses })
+            self._URL("add-aaaa"), {"host": host, "addresses": addresses}
+        )
 
     def remove_aaaa_record(self, host):
         """
         remove_aaaa_record removes mock AAAA response from the challenge server's DNS
         interface for the given host.
         """
-        return self._postURL(
-                self._URL("del-aaaa"),
-                { "host": host })
+        return self._postURL(self._URL("del-aaaa"), {"host": host})
 
     def add_caa_issue(self, host, value):
         """
@@ -124,28 +114,25 @@ class ChallTestServer:
         tag specifying the provided value.
         """
         return self._postURL(
-                self._URL("add-caa"),
-                {
-                    "host": host,
-                    "policies": [{ "tag": "issue", "value": value}],
-                })
+            self._URL("add-caa"),
+            {
+                "host": host,
+                "policies": [{"tag": "issue", "value": value}],
+            },
+        )
 
     def remove_caa_issue(self, host):
         """
         remove_caa_issue removes a mock CAA response from the challenge server's
         DNS interface for the given host.
         """
-        return self._postURL(
-                self._URL("del-caa"),
-                { "host": host })
+        return self._postURL(self._URL("del-caa"), {"host": host})
 
     def http_request_history(self, host):
         """
         http_request_history fetches the challenge server's HTTP request history for the given host.
         """
-        return json.loads(self._postURL(
-                self._URL("get-http-history"),
-                { "host": host }))
+        return json.loads(self._postURL(self._URL("get-http-history"), {"host": host}))
 
     def clear_http_request_history(self, host):
         """
@@ -160,17 +147,15 @@ class ChallTestServer:
         the targetURL. Redirects are not served for HTTPS requests.
         """
         return self._postURL(
-                self._URL("add-redirect"),
-                { "path": path, "targetURL": targetURL })
+            self._URL("add-redirect"), {"path": path, "targetURL": targetURL}
+        )
 
     def remove_http_redirect(self, path):
         """
         remove_http_redirect removes a redirect from the challenge server's HTTP
         interfaces for the given path.
         """
-        return self._postURL(
-                self._URL("del-redirect"),
-                { "path": path })
+        return self._postURL(self._URL("del-redirect"), {"path": path})
 
     def add_http01_response(self, token, keyauth):
         """
@@ -180,17 +165,15 @@ class ChallTestServer:
         returned as the HTTP response body for requests to the challenge token.
         """
         return self._postURL(
-                self._URL("add-http"),
-                { "token": token, "content": keyauth })
+            self._URL("add-http"), {"token": token, "content": keyauth}
+        )
 
     def remove_http01_response(self, token):
         """
         remove_http01_response removes an ACME HTTP-01 challenge response for
         the provided token from the challenge test server.
         """
-        return self._postURL(
-                self._URL("del-http"),
-                { "token": token })
+        return self._postURL(self._URL("del-http"), {"token": token})
 
     def add_servfail_response(self, host):
         """
@@ -198,18 +181,14 @@ class ChallTestServer:
         SERVFAIL for all queries made for the provided host. This will override
         any other mocks for the host until removed with remove_servfail_response.
         """
-        return self._postURL(
-                self._URL("add-servfail"),
-                { "host": host})
+        return self._postURL(self._URL("add-servfail"), {"host": host})
 
     def remove_servfail_response(self, host):
         """
         remove_servfail_response undoes the work of add_servfail_response,
         removing the SERVFAIL configuration for the given host.
         """
-        return self._postURL(
-                self._URL("del-servfail"),
-                { "host": host})
+        return self._postURL(self._URL("del-servfail"), {"host": host})
 
     def add_dns01_response(self, host, value):
         """
@@ -220,27 +199,21 @@ class ChallTestServer:
         """
         if host.endswith(".") is False:
             host = host + "."
-        return self._postURL(
-                self._URL("add-txt"),
-                { "host": host, "value": value})
+        return self._postURL(self._URL("add-txt"), {"host": host, "value": value})
 
     def remove_dns01_response(self, host):
         """
         remove_dns01_response removes an ACME DNS-01 challenge response for the
         provided host from the challenge test server's DNS interfaces.
         """
-        return self._postURL(
-                self._URL("del-txt"),
-                { "host": host })
+        return self._postURL(self._URL("del-txt"), {"host": host})
 
     def dns_request_history(self, host):
         """
         dns_request_history returns the history of DNS requests made to the
         challenge test server's DNS interfaces for the given host.
         """
-        return json.loads(self._postURL(
-                self._URL("get-dns-history"),
-                { "host": host }))
+        return json.loads(self._postURL(self._URL("get-dns-history"), {"host": host}))
 
     def clear_dns_request_history(self, host):
         """
@@ -258,9 +231,7 @@ class ChallTestServer:
         challenge validation with the challenge test server for the provided
         host.
         """
-        return self._postURL(
-                self._URL("add-alpn"),
-                { "host": host, "content": value})
+        return self._postURL(self._URL("add-alpn"), {"host": host, "content": value})
 
     def remove_tlsalpn01_response(self, host):
         """
@@ -268,9 +239,7 @@ class ChallTestServer:
         certificate from the challenge test server's TLS-ALPN-01 interface for
         the given host.
         """
-        return self._postURL(
-                self._URL("del-alpn"),
-                { "host": host })
+        return self._postURL(self._URL("del-alpn"), {"host": host})
 
     def tlsalpn01_request_history(self, host):
         """
@@ -278,9 +247,7 @@ class ChallTestServer:
         made to the challenge test server's TLS-ALPN-01 interface for the given
         host.
         """
-        return json.loads(self._postURL(
-                self._URL("get-alpn-history"),
-                { "host": host }))
+        return json.loads(self._postURL(self._URL("get-alpn-history"), {"host": host}))
 
     def clear_tlsalpn01_request_history(self, host):
         """

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -8,18 +8,13 @@ $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ python chisel2.py foo.com bar.com
 """
-import json
 import logging
 import os
 import sys
 import signal
-import threading
-import time
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes
 
 import OpenSSL
 import josepy

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -26,6 +26,8 @@ from acme import errors as acme_errors
 from acme import messages
 from acme import standalone
 
+import challtestsrv
+
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(int(os.getenv("LOGLEVEL", 20)))
@@ -37,8 +39,6 @@ ACCEPTABLE_TOS = os.getenv(
 PORT = os.getenv("PORT", "80")
 
 os.environ.setdefault("REQUESTS_CA_BUNDLE", "test/wfe-tls/minica.pem")
-
-import challtestsrv
 
 challSrv = challtestsrv.ChallTestServer()
 

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -33,46 +33,60 @@ from acme import standalone
 
 logging.basicConfig()
 logger = logging.getLogger()
-logger.setLevel(int(os.getenv('LOGLEVEL', 20)))
+logger.setLevel(int(os.getenv("LOGLEVEL", 20)))
 
-DIRECTORY_V2 = os.getenv('DIRECTORY_V2', 'http://boulder.service.consul:4001/directory')
-ACCEPTABLE_TOS = os.getenv('ACCEPTABLE_TOS',"https://boulder.service.consul:4431/terms/v7")
-PORT = os.getenv('PORT', '80')
+DIRECTORY_V2 = os.getenv("DIRECTORY_V2", "http://boulder.service.consul:4001/directory")
+ACCEPTABLE_TOS = os.getenv(
+    "ACCEPTABLE_TOS", "https://boulder.service.consul:4431/terms/v7"
+)
+PORT = os.getenv("PORT", "80")
 
-os.environ.setdefault('REQUESTS_CA_BUNDLE', 'test/wfe-tls/minica.pem')
+os.environ.setdefault("REQUESTS_CA_BUNDLE", "test/wfe-tls/minica.pem")
 
 import challtestsrv
+
 challSrv = challtestsrv.ChallTestServer()
+
 
 def uninitialized_client(key=None):
     if key is None:
-        key = josepy.JWKRSA(key=rsa.generate_private_key(65537, 2048, default_backend()))
+        key = josepy.JWKRSA(
+            key=rsa.generate_private_key(65537, 2048, default_backend())
+        )
     net = acme_client.ClientNetwork(key, user_agent="Boulder integration tester")
     directory = messages.Directory.from_json(net.get(DIRECTORY_V2).json())
     return acme_client.ClientV2(directory, net)
+
 
 def make_client(email=None):
     """Build an acme.Client and register a new account with a random key."""
     client = uninitialized_client()
     tos = client.directory.meta.terms_of_service
     if tos == ACCEPTABLE_TOS:
-        client.net.account = client.new_account(messages.NewRegistration.from_data(email=email,
-            terms_of_service_agreed=True))
+        client.net.account = client.new_account(
+            messages.NewRegistration.from_data(
+                email=email, terms_of_service_agreed=True
+            )
+        )
     else:
         raise Exception("Unrecognized terms of service URL %s" % tos)
     return client
+
 
 class NoClientError(ValueError):
     """
     An error that occurs when no acme.Client is provided to a function that
     requires one.
     """
+
     pass
+
 
 class EmailRequiredError(ValueError):
     """
     An error that occurs when a None email is provided to update_email.
     """
+
 
 def update_email(client, email):
     """
@@ -80,11 +94,11 @@ def update_email(client, email):
     email.
     """
     if client is None:
-        raise(NoClientError("update_email requires a valid acme.Client argument"))
+        raise (NoClientError("update_email requires a valid acme.Client argument"))
     if email is None:
-        raise(EmailRequiredError("update_email requires an email argument"))
+        raise (EmailRequiredError("update_email requires an email argument"))
     if not email.startswith("mailto:"):
-        email = "mailto:"+ email
+        email = "mailto:" + email
     acct = client.net.account
     updatedAcct = acct.update(body=acct.body.update(contact=(email,)))
     return client.update_registration(updatedAcct)
@@ -96,23 +110,28 @@ def get_chall(authz, typ):
             return chall_body
     raise Exception("No %s challenge found" % typ.typ)
 
+
 def make_csr(domains):
     key = OpenSSL.crypto.PKey()
     key.generate_key(OpenSSL.crypto.TYPE_RSA, 2048)
     pem = OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
     return acme_crypto_util.make_csr(pem, domains, False)
 
+
 def http_01_answer(client, chall_body):
     """Return an HTTP01Resource to server in response to the given challenge."""
     response, validation = chall_body.response_and_validation(client.net.key)
     return standalone.HTTP01RequestHandler.HTTP01Resource(
-          chall=chall_body.chall, response=response,
-          validation=validation)
+        chall=chall_body.chall, response=response, validation=validation
+    )
 
-def auth_and_issue(domains, chall_type="dns-01", email=None, cert_output=None, client=None):
+
+def auth_and_issue(
+    domains, chall_type="dns-01", email=None, cert_output=None, client=None
+):
     """Make authzs for each of the given domains, set up a server to answer the
-       challenges in those authzs, tell the ACME server to validate the challenges,
-       then poll for the authzs to be ready and issue a cert."""
+    challenges in those authzs, tell the ACME server to validate the challenges,
+    then poll for the authzs to be ready and issue a cert."""
     if client is None:
         client = make_client(email)
 
@@ -139,19 +158,25 @@ def auth_and_issue(domains, chall_type="dns-01", email=None, cert_output=None, c
 
     return order
 
+
 def do_dns_challenges(client, authzs):
     cleanup_hosts = []
     for a in authzs:
         c = get_chall(a, challenges.DNS01)
-        name, value = (c.validation_domain_name(a.body.identifier.value),
-            c.validation(client.net.key))
+        name, value = (
+            c.validation_domain_name(a.body.identifier.value),
+            c.validation(client.net.key),
+        )
         cleanup_hosts.append(name)
         challSrv.add_dns01_response(name, value)
         client.answer_challenge(c, c.response(client.net.key))
+
     def cleanup():
         for host in cleanup_hosts:
             challSrv.remove_dns01_response(host)
+
     return cleanup
+
 
 def do_http_challenges(client, authzs):
     cleanup_tokens = []
@@ -176,7 +201,9 @@ def do_http_challenges(client, authzs):
         # the tokens we added.
         for token in cleanup_tokens:
             challSrv.remove_http01_response(token)
+
     return cleanup
+
 
 def do_tlsalpn_challenges(client, authzs):
     cleanup_hosts = []
@@ -186,15 +213,18 @@ def do_tlsalpn_challenges(client, authzs):
         cleanup_hosts.append(name)
         challSrv.add_tlsalpn01_response(name, value)
         client.answer_challenge(c, c.response(client.net.key))
+
     def cleanup():
         for host in cleanup_hosts:
             challSrv.remove_tlsalpn01_response(host)
+
     return cleanup
+
 
 def expect_problem(problem_type, func):
     """Run a function. If it raises an acme_errors.ValidationError or messages.Error that
-       contains the given problem_type, return. If it raises no error or the wrong
-       error, raise an exception."""
+    contains the given problem_type, return. If it raises no error or the wrong
+    error, raise an exception."""
     ok = False
     try:
         func()
@@ -210,9 +240,12 @@ def expect_problem(problem_type, func):
                 if error and error.typ == problem_type:
                     ok = True
                 elif error:
-                    raise Exception("Expected %s, got %s" % (problem_type, error.__str__()))
+                    raise Exception(
+                        "Expected %s, got %s" % (problem_type, error.__str__())
+                    )
     if not ok:
-        raise Exception('Expected %s, got no error' % problem_type)
+        raise Exception("Expected %s, got no error" % problem_type)
+
 
 if __name__ == "__main__":
     # Die on SIGINT

--- a/test/format-configs.py
+++ b/test/format-configs.py
@@ -5,11 +5,13 @@ import json
 import sys
 
 if len(sys.argv) != 2:
-  print("This program reformats JSON files in-place. You must provide a glob pattern of files to process as its argument.")
+    print(
+        "This program reformats JSON files in-place. You must provide a glob pattern of files to process as its argument."
+    )
 else:
-  for cfg in glob.glob(sys.argv[1]):
-    with open(cfg, "r") as fr:
-      j = json.load(fr)
-    with open(cfg, "w") as fw:
-      json.dump(j, fw, indent="\t")
-      fw.write("\n")
+    for cfg in glob.glob(sys.argv[1]):
+        with open(cfg, "r") as fr:
+            j = json.load(fr)
+        with open(cfg, "w") as fw:
+            json.dump(j, fw, indent="\t")
+            fw.write("\n")

--- a/test/grafana/lint.py
+++ b/test/grafana/lint.py
@@ -2,8 +2,10 @@
 # datasource.
 import json
 import os
-with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-    "boulderdash.json")) as f:
+
+with open(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "boulderdash.json")
+) as f:
     dashboard = json.load(f)
 
 # When exporting, the current value of templated variables is saved. We don't
@@ -12,15 +14,15 @@ with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
 # datasource template variable set to "Default."
 for li in dashboard["templating"]["list"]:
     if li["type"] == "datasource":
-        assert(li["current"]["value"] == "default")
+        assert li["current"]["value"] == "default"
 
 # Additionally, ensure each panel's datasource is using the template variable
 # rather than a hardcoded datasource. Grafana will choose a hardcoded
 # datasource on new panels by default, so this is an easy mistake to make.
 for ro in dashboard["rows"]:
     for pa in ro["panels"]:
-        assert(pa["datasource"] == "$datasource")
+        assert pa["datasource"] == "$datasource"
 
 # It seems that __inputs is non-empty when template variables at the top of the
 # dashboard have been modified from the defaults; check for that.
-assert(len(dashboard["__inputs"]) == 0)
+assert len(dashboard["__inputs"]) == 0

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -4,7 +4,6 @@ import urllib
 import time
 import re
 import random
-import json
 import requests
 import socket
 import tempfile

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -18,39 +18,45 @@ import challtestsrv
 challSrv = challtestsrv.ChallTestServer()
 tempdir = tempfile.mkdtemp()
 
+
 @atexit.register
 def stop():
     shutil.rmtree(tempdir)
 
-config_dir = os.environ.get('BOULDER_CONFIG_DIR', '')
-if config_dir == '':
+
+config_dir = os.environ.get("BOULDER_CONFIG_DIR", "")
+if config_dir == "":
     raise Exception("BOULDER_CONFIG_DIR was not set")
 CONFIG_NEXT = config_dir.startswith("test/config-next")
+
 
 def temppath(name):
     """Creates and returns a closed file inside the tempdir."""
     f = tempfile.NamedTemporaryFile(
-        dir=tempdir,
-        suffix='.{0}'.format(name),
-        mode='w+',
-        delete=False
+        dir=tempdir, suffix=".{0}".format(name), mode="w+", delete=False
     )
     f.close()
     return f
 
+
 def fakeclock(date):
     return date.strftime("%a %b %d %H:%M:%S UTC %Y")
 
+
 def get_future_output(cmd, date):
-    return subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-        env={'FAKECLOCK': fakeclock(date)}).decode()
+    return subprocess.check_output(
+        cmd, stderr=subprocess.STDOUT, env={"FAKECLOCK": fakeclock(date)}
+    ).decode()
+
 
 def random_domain():
     """Generate a random domain for testing (to avoid rate limiting)."""
     return "rand.%x.xyz" % random.randrange(2**32)
 
+
 def run(cmd, **kwargs):
     return subprocess.check_call(cmd, stderr=subprocess.STDOUT, **kwargs)
+
 
 def fetch_ocsp(request_bytes, url):
     """Fetch an OCSP response using POST, GET, and GET with URL encoding.
@@ -62,39 +68,64 @@ def fetch_ocsp(request_bytes, url):
     # Make the OCSP request three different ways: by POST, by GET, and by GET with
     # URL-encoded parameters. All three should have an identical response.
     get_response = requests.get("%s/%s" % (url, ocsp_req_b64)).content
-    get_encoded_response = requests.get("%s/%s" % (url, urllib.parse.quote(ocsp_req_b64, safe = ""))).content
+    get_encoded_response = requests.get(
+        "%s/%s" % (url, urllib.parse.quote(ocsp_req_b64, safe=""))
+    ).content
     post_response = requests.post("%s/" % (url), data=request_bytes).content
 
     return (post_response, get_response, get_encoded_response)
 
+
 def make_ocsp_req(cert_file, issuer_file):
     """Return the bytes of an OCSP request for the given certificate file."""
     with tempfile.NamedTemporaryFile(dir=tempdir) as f:
-        run(["openssl", "ocsp", "-no_nonce",
-            "-issuer", issuer_file,
-            "-cert", cert_file,
-            "-reqout", f.name])
+        run(
+            [
+                "openssl",
+                "ocsp",
+                "-no_nonce",
+                "-issuer",
+                issuer_file,
+                "-cert",
+                cert_file,
+                "-reqout",
+                f.name,
+            ]
+        )
         ocsp_req = f.read()
     return ocsp_req
+
 
 def ocsp_verify(cert_file, issuer_file, ocsp_response):
     with tempfile.NamedTemporaryFile(dir=tempdir, delete=False) as f:
         f.write(ocsp_response)
         f.close()
-        output = subprocess.check_output([
-            'openssl', 'ocsp', '-no_nonce',
-            '-issuer', issuer_file,
-            '-cert', cert_file,
-            '-verify_other', issuer_file,
-            '-CAfile', '/hierarchy/root-cert-rsa.pem',
-            '-respin', f.name], stderr=subprocess.STDOUT).decode()
+        output = subprocess.check_output(
+            [
+                "openssl",
+                "ocsp",
+                "-no_nonce",
+                "-issuer",
+                issuer_file,
+                "-cert",
+                cert_file,
+                "-verify_other",
+                issuer_file,
+                "-CAfile",
+                "/hierarchy/root-cert-rsa.pem",
+                "-respin",
+                f.name,
+            ],
+            stderr=subprocess.STDOUT,
+        ).decode()
     # OpenSSL doesn't always return non-zero when response verify fails, so we
     # also look for the string "Response Verify Failure"
     verify_failure = "Response Verify Failure"
     if re.search(verify_failure, output):
         print(output)
-        raise(Exception("OCSP verify failure"))
+        raise (Exception("OCSP verify failure"))
     return output
+
 
 def verify_ocsp(cert_file, issuer_file, url, status="revoked", reason=None):
     ocsp_request = make_ocsp_req(cert_file, issuer_file)
@@ -103,8 +134,12 @@ def verify_ocsp(cert_file, issuer_file, url, status="revoked", reason=None):
     # Verify all responses are the same
     for resp in responses:
         if resp != responses[0]:
-            raise(Exception("OCSP responses differed: %s vs %s" %(
-                base64.b64encode(responses[0]), base64.b64encode(resp))))
+            raise (
+                Exception(
+                    "OCSP responses differed: %s vs %s"
+                    % (base64.b64encode(responses[0]), base64.b64encode(resp))
+                )
+            )
 
     # Check response is for the correct certificate and is correct
     # status
@@ -113,22 +148,24 @@ def verify_ocsp(cert_file, issuer_file, url, status="revoked", reason=None):
     if status is not None:
         if not re.search("%s: %s" % (cert_file, status), verify_output):
             print(verify_output)
-            raise(Exception("OCSP response wasn't '%s'" % status))
+            raise (Exception("OCSP response wasn't '%s'" % status))
     if reason is not None:
         if not re.search("Reason: %s" % reason, verify_output):
             print(verify_output)
-            raise(Exception("OCSP response wasn't '%s'" % reason))
+            raise (Exception("OCSP response wasn't '%s'" % reason))
     return verify_output
+
 
 def reset_akamai_purges():
     requests.post("http://localhost:6789/debug/reset-purges", data="{}")
 
+
 def verify_akamai_purge():
-    deadline = time.time() + .4
+    deadline = time.time() + 0.4
     while True:
         time.sleep(0.05)
         if time.time() > deadline:
-            raise(Exception("Timed out waiting for Akamai purge"))
+            raise (Exception("Timed out waiting for Akamai purge"))
         response = requests.get("http://localhost:6789/debug/get-purges")
         purgeData = response.json()
         if len(purgeData["V3"]) == 0:
@@ -136,28 +173,35 @@ def verify_akamai_purge():
         break
     reset_akamai_purges()
 
-twenty_days_ago_functions = [ ]
+
+twenty_days_ago_functions = []
+
 
 def register_twenty_days_ago(f):
     """Register a function to be run during "setup_twenty_days_ago." This allows
-       test cases to define their own custom setup.
+    test cases to define their own custom setup.
     """
     twenty_days_ago_functions.append(f)
 
+
 def setup_twenty_days_ago():
     """Do any setup that needs to happen 20 day in the past, for tests that
-       will run in the 'present'.
+    will run in the 'present'.
     """
     for f in twenty_days_ago_functions:
         f()
 
+
 six_months_ago_functions = []
+
 
 def register_six_months_ago(f):
     six_months_ago_functions.append(f)
 
+
 def setup_six_months_ago():
     [f() for f in six_months_ago_functions]
+
 
 def waitport(port, prog, perTickCheck=None):
     """Wait until a port on localhost is open."""
@@ -167,7 +211,7 @@ def waitport(port, prog, perTickCheck=None):
             if perTickCheck is not None and not perTickCheck():
                 return False
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect(('localhost', port))
+            s.connect(("localhost", port))
             s.close()
             return True
         except socket.error as e:
@@ -175,10 +219,16 @@ def waitport(port, prog, perTickCheck=None):
                 print("Waiting for debug port %d (%s)" % (port, prog))
             else:
                 raise
-    raise(Exception("timed out waiting for debug port %d (%s)" % (port, prog)))
+    raise (Exception("timed out waiting for debug port %d (%s)" % (port, prog)))
+
 
 def waithealth(prog, addr):
-    subprocess.check_call([
-        './bin/health-checker',
-        '-addr', addr,
-        '-config', os.path.join(config_dir, 'health-checker.json')])
+    subprocess.check_call(
+        [
+            "./bin/health-checker",
+            "-addr",
+            addr,
+            "-config",
+            os.path.join(config_dir, "health-checker.json"),
+        ]
+    )

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -19,7 +19,17 @@ import signal
 import startservers
 
 import v2_integration
-from helpers import *
+
+from helpers import (
+    waitport,
+    verify_ocsp,
+    fakeclock,
+    setup_six_months_ago,
+    setup_twenty_days_ago,
+    run,
+    tempdir,
+    config_dir,
+)
 
 
 # Set the environment variable RACE to anything other than 'true' to disable

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -10,22 +10,17 @@ are also in this file.
 import argparse
 import datetime
 import inspect
-import json
 import os
-import random
 import re
 import requests
 import subprocess
-import shlex
 import signal
-import time
 
 import startservers
 
 import v2_integration
 from helpers import *
 
-from acme import challenges
 
 # Set the environment variable RACE to anything other than 'true' to disable
 # race detection. This significantly speeds up integration testing cycles
@@ -265,7 +260,7 @@ def check_balance():
     ]
     for address in addresses:
         metrics = requests.get("http://%s/metrics" % address)
-        if not "grpc_server_handled_total" in metrics.text:
+        if "grpc_server_handled_total" not in metrics.text:
             raise (
                 Exception("no gRPC traffic processed by %s; load balancing problem?")
                 % address

--- a/test/load-generator/latency-charter.py
+++ b/test/load-generator/latency-charter.py
@@ -3,13 +3,11 @@
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
-import numpy as np
 import datetime
 import json
 import pandas
 import matplotlib
 import argparse
-import os
 
 matplotlib.style.use("ggplot")
 

--- a/test/load-generator/latency-charter.py
+++ b/test/load-generator/latency-charter.py
@@ -22,6 +22,7 @@ randAx.plot(0, 0, color="orange", label="90th quantile")
 randAx.plot(0, 0, color="red", label="99th quantile")
 handles, labels = randAx.get_legend_handles_labels()
 
+
 # big ol' plotting method
 def plot_section(all_data, title, outputPath):
     # group calls by the endpoint/method

--- a/test/load-generator/latency-charter.py
+++ b/test/load-generator/latency-charter.py
@@ -158,8 +158,8 @@ args = parser.parse_args()
 
 with open(args.chartData) as data_file:
     stuff = []
-    for l in data_file.readlines():
-        stuff.append(json.loads(l))
+    for line in data_file.readlines():
+        stuff.append(json.loads(line))
 
 df = pandas.DataFrame(stuff)
 df["finished"] = pandas.to_datetime(df["finished"]).astype(datetime.datetime)

--- a/test/load-generator/latency-charter.py
+++ b/test/load-generator/latency-charter.py
@@ -10,36 +10,37 @@ import pandas
 import matplotlib
 import argparse
 import os
-matplotlib.style.use('ggplot')
+
+matplotlib.style.use("ggplot")
 
 # sacrificial plot for single legend
-matplotlib.rcParams['figure.figsize'] = 1, 1
+matplotlib.rcParams["figure.figsize"] = 1, 1
 randFig = plt.figure()
 randAx = plt.subplot()
-randAx.plot(0, 0, color='green', label='good', marker='+')
-randAx.plot(0, 0, color='red', label='failed', marker='x')
-randAx.plot(0, 0, color='black', label='sent', linestyle='--')
-randAx.plot(0, 0, color='green', label='50th quantile')
-randAx.plot(0, 0, color='orange', label='90th quantile')
-randAx.plot(0, 0, color='red', label='99th quantile')
+randAx.plot(0, 0, color="green", label="good", marker="+")
+randAx.plot(0, 0, color="red", label="failed", marker="x")
+randAx.plot(0, 0, color="black", label="sent", linestyle="--")
+randAx.plot(0, 0, color="green", label="50th quantile")
+randAx.plot(0, 0, color="orange", label="90th quantile")
+randAx.plot(0, 0, color="red", label="99th quantile")
 handles, labels = randAx.get_legend_handles_labels()
 
 # big ol' plotting method
 def plot_section(all_data, title, outputPath):
     # group calls by the endpoint/method
-    actions = all_data.groupby('action')
+    actions = all_data.groupby("action")
     h = len(actions.groups.keys())
-    matplotlib.rcParams['figure.figsize'] = 20, 3 * h
+    matplotlib.rcParams["figure.figsize"] = 20, 3 * h
 
     fig = plt.figure()
-    fig.legend(handles, labels, ncol=6, fontsize=16, framealpha=0, loc='upper center')
+    fig.legend(handles, labels, ncol=6, fontsize=16, framealpha=0, loc="upper center")
     if title is not None:
         fig.suptitle(title, fontsize=20, y=0.93)
     gs = gridspec.GridSpec(h, 3)
 
     # figure out left and right datetime bounds
-    started = all_data['sent'].min()
-    stopped = all_data['finished'].max()
+    started = all_data["sent"].min()
+    stopped = all_data["finished"].max()
 
     i = 0
     # plot one row of charts for each endpoint/method combination
@@ -55,74 +56,106 @@ def plot_section(all_data, title, outputPath):
 
         # find the maximum y value and set it across all three charts
         calls = actions.get_group(section)
-        tookMax = calls['took'].max()
-        ax.set_ylim(0, tookMax+tookMax*0.1)
-        ax2.set_ylim(0, tookMax+tookMax*0.1)
-        ax3.set_ylim(0, tookMax+tookMax*0.1)
+        tookMax = calls["took"].max()
+        ax.set_ylim(0, tookMax + tookMax * 0.1)
+        ax2.set_ylim(0, tookMax + tookMax * 0.1)
+        ax3.set_ylim(0, tookMax + tookMax * 0.1)
 
-        groups = calls.groupby('type')
-        if groups.groups.get('error', False) is not False:
-            bad = groups.get_group('error')
-            ax.plot_date(bad['finished'], bad['took'], color='red', marker='x', label='error')
+        groups = calls.groupby("type")
+        if groups.groups.get("error", False) is not False:
+            bad = groups.get_group("error")
+            ax.plot_date(
+                bad["finished"], bad["took"], color="red", marker="x", label="error"
+            )
 
-            bad_rate = bad.set_index('finished')
-            bad_rate['rate'] = [0] * len(bad_rate.index)
-            bad_rate = bad_rate.resample('5S').count()
-            bad_rate['rate'] = bad_rate['rate'].divide(5)
-            rateMax = bad_rate['rate'].max()
-            ax2.plot_date(bad_rate.index, bad_rate['rate'], linestyle='-', marker='', color='red', label='error')
-        if groups.groups.get('good', False) is not False:
-            good = groups.get_group('good')
-            ax.plot_date(good['finished'], good['took'], color='green', marker='+', label='good')
+            bad_rate = bad.set_index("finished")
+            bad_rate["rate"] = [0] * len(bad_rate.index)
+            bad_rate = bad_rate.resample("5S").count()
+            bad_rate["rate"] = bad_rate["rate"].divide(5)
+            rateMax = bad_rate["rate"].max()
+            ax2.plot_date(
+                bad_rate.index,
+                bad_rate["rate"],
+                linestyle="-",
+                marker="",
+                color="red",
+                label="error",
+            )
+        if groups.groups.get("good", False) is not False:
+            good = groups.get_group("good")
+            ax.plot_date(
+                good["finished"], good["took"], color="green", marker="+", label="good"
+            )
 
-            good_rate = good.set_index('finished')
-            good_rate['rate'] = [0] * len(good_rate.index)
-            good_rate = good_rate.resample('5S').count()
-            good_rate['rate'] = good_rate['rate'].divide(5)
-            rateMax = good_rate['rate'].max()
-            ax2.plot_date(good_rate.index, good_rate['rate'], linestyle='-', marker='', color='green', label='good')
-        ax.set_ylabel('Latency (ms)')
+            good_rate = good.set_index("finished")
+            good_rate["rate"] = [0] * len(good_rate.index)
+            good_rate = good_rate.resample("5S").count()
+            good_rate["rate"] = good_rate["rate"].divide(5)
+            rateMax = good_rate["rate"].max()
+            ax2.plot_date(
+                good_rate.index,
+                good_rate["rate"],
+                linestyle="-",
+                marker="",
+                color="green",
+                label="good",
+            )
+        ax.set_ylabel("Latency (ms)")
 
         # calculate the request rate
-        sent_rate = pandas.DataFrame(calls['sent'])
-        sent_rate = sent_rate.set_index('sent')
-        sent_rate['rate'] = [0] * len(sent_rate.index)
-        sent_rate = sent_rate.resample('5S').count()
-        sent_rate['rate'] = sent_rate['rate'].divide(5)
-        if sent_rate['rate'].max() > rateMax:
-            rateMax = sent_rate['rate'].max()
-        ax2.plot_date(sent_rate.index, sent_rate['rate'], linestyle='--', marker='', color='black', label='sent')
-        ax2.set_ylim(0, rateMax+rateMax*0.1)
-        ax2.set_ylabel('Rate (per second)')
+        sent_rate = pandas.DataFrame(calls["sent"])
+        sent_rate = sent_rate.set_index("sent")
+        sent_rate["rate"] = [0] * len(sent_rate.index)
+        sent_rate = sent_rate.resample("5S").count()
+        sent_rate["rate"] = sent_rate["rate"].divide(5)
+        if sent_rate["rate"].max() > rateMax:
+            rateMax = sent_rate["rate"].max()
+        ax2.plot_date(
+            sent_rate.index,
+            sent_rate["rate"],
+            linestyle="--",
+            marker="",
+            color="black",
+            label="sent",
+        )
+        ax2.set_ylim(0, rateMax + rateMax * 0.1)
+        ax2.set_ylabel("Rate (per second)")
 
         # calculate and plot latency quantiles
-        calls = calls.set_index('finished')
+        calls = calls.set_index("finished")
         calls = calls.sort_index()
-        quan = pandas.DataFrame(calls['took'])
-        for q, c in [[.5, 'green'], [.9, 'orange'], [.99, 'red']]:
+        quan = pandas.DataFrame(calls["took"])
+        for q, c in [[0.5, "green"], [0.9, "orange"], [0.99, "red"]]:
             quanN = quan.rolling(500, center=True).quantile(q)
-            ax3.plot(quanN['took'].index, quanN['took'], color=c)
+            ax3.plot(quanN["took"].index, quanN["took"], color=c)
 
-        ax3.set_ylabel('Latency quantiles (ms)')
+        ax3.set_ylabel("Latency quantiles (ms)")
 
         i += 1
 
     # format x axes
     for ax in fig.axes:
         matplotlib.pyplot.sca(ax)
-        plt.xticks(rotation=30, ha='right')
-        majorFormatter = matplotlib.dates.DateFormatter('%H:%M:%S')
+        plt.xticks(rotation=30, ha="right")
+        majorFormatter = matplotlib.dates.DateFormatter("%H:%M:%S")
         ax.xaxis.set_major_formatter(majorFormatter)
 
     # save image
     gs.update(wspace=0.275, hspace=0.5)
-    fig.savefig(outputPath, bbox_inches='tight')
+    fig.savefig(outputPath, bbox_inches="tight")
+
 
 # and the main event
 parser = argparse.ArgumentParser()
-parser.add_argument('chartData', type=str, help='Path to file containing JSON chart output from load-generator')
-parser.add_argument('--output', type=str, help='Path to save output to', default='latency-chart.png')
-parser.add_argument('--title', type=str, help='Chart title')
+parser.add_argument(
+    "chartData",
+    type=str,
+    help="Path to file containing JSON chart output from load-generator",
+)
+parser.add_argument(
+    "--output", type=str, help="Path to save output to", default="latency-chart.png"
+)
+parser.add_argument("--title", type=str, help="Chart title")
 args = parser.parse_args()
 
 with open(args.chartData) as data_file:
@@ -131,8 +164,8 @@ with open(args.chartData) as data_file:
         stuff.append(json.loads(l))
 
 df = pandas.DataFrame(stuff)
-df['finished'] = pandas.to_datetime(df['finished']).astype(datetime.datetime)
-df['sent'] = pandas.to_datetime(df['sent']).astype(datetime.datetime)
-df['took'] = df['took'].divide(1000000)
+df["finished"] = pandas.to_datetime(df["finished"]).astype(datetime.datetime)
+df["sent"] = pandas.to_datetime(df["sent"]).astype(datetime.datetime)
+df["took"] = df["took"].divide(1000000)
 
 plot_section(df, args.title, args.output)

--- a/test/load-generator/latency-charter.py
+++ b/test/load-generator/latency-charter.py
@@ -6,7 +6,6 @@ from matplotlib import gridspec
 import datetime
 import json
 import pandas
-import matplotlib
 import argparse
 
 matplotlib.style.use("ggplot")

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -1,15 +1,10 @@
 import atexit
 import collections
 import os
-import shutil
 import signal
 import subprocess
-import sys
-import tempfile
-import threading
-import time
 
-from helpers import waithealth, waitport, config_dir, CONFIG_NEXT
+from helpers import waithealth, waitport, config_dir
 
 Service = collections.namedtuple(
     "Service", ("name", "debug_port", "grpc_addr", "cmd", "deps")

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -11,109 +11,382 @@ import time
 
 from helpers import waithealth, waitport, config_dir, CONFIG_NEXT
 
-Service = collections.namedtuple('Service', ('name', 'debug_port', 'grpc_addr', 'cmd', 'deps'))
+Service = collections.namedtuple(
+    "Service", ("name", "debug_port", "grpc_addr", "cmd", "deps")
+)
 
 SERVICES = (
-    Service('boulder-remoteva-a',
-        8011, 'rva1.service.consul:9097',
-        ('./bin/boulder', 'boulder-remoteva', '--config', os.path.join(config_dir, 'va-remote-a.json')),
-        None),
-    Service('boulder-remoteva-b',
-        8012, 'rva1.service.consul:9098',
-        ('./bin/boulder', 'boulder-remoteva', '--config', os.path.join(config_dir, 'va-remote-b.json')),
-        None),
-    Service('boulder-sa-1',
-        8003, 'sa1.service.consul:9095',
-        ('./bin/boulder', 'boulder-sa', '--config', os.path.join(config_dir, 'sa.json'), '--addr', 'sa1.service.consul:9095', '--debug-addr', ':8003'),
-        None),
-    Service('boulder-sa-2',
-        8103, 'sa2.service.consul:9095',
-        ('./bin/boulder', 'boulder-sa', '--config', os.path.join(config_dir, 'sa.json'), '--addr', 'sa2.service.consul:9095', '--debug-addr', ':8103'),
-        None),
-    Service('ct-test-srv',
-        4500, None,
-        ('./bin/ct-test-srv', '--config', 'test/ct-test-srv/ct-test-srv.json'), None),
-    Service('boulder-publisher-1',
-        8009, 'publisher1.service.consul:9091',
-        ('./bin/boulder', 'boulder-publisher', '--config', os.path.join(config_dir, 'publisher.json'), '--addr', 'publisher1.service.consul:9091', '--debug-addr', ':8009'),
-        None),
-    Service('boulder-publisher-2',
-        8109, 'publisher2.service.consul:9091',
-        ('./bin/boulder', 'boulder-publisher', '--config', os.path.join(config_dir, 'publisher.json'), '--addr', 'publisher2.service.consul:9091', '--debug-addr', ':8109'),
-        None),
-    Service('mail-test-srv',
-        9380, None,
-        ('./bin/mail-test-srv', '--closeFirst', '5', '--cert', 'test/mail-test-srv/localhost/cert.pem', '--key', 'test/mail-test-srv/localhost/key.pem'),
-        None),
-    Service('ocsp-responder',
-        8005, None,
-        ('./bin/boulder', 'ocsp-responder', '--config', os.path.join(config_dir, 'ocsp-responder.json')),
-        ('boulder-ra-1', 'boulder-ra-2')),
-    Service('boulder-va-1',
-        8004, 'va1.service.consul:9092',
-        ('./bin/boulder', 'boulder-va', '--config', os.path.join(config_dir, 'va.json'), '--addr', 'va1.service.consul:9092', '--debug-addr', ':8004'),
-        ('boulder-remoteva-a', 'boulder-remoteva-b')),
-    Service('boulder-va-2',
-        8104, 'va2.service.consul:9092',
-        ('./bin/boulder', 'boulder-va', '--config', os.path.join(config_dir, 'va.json'), '--addr', 'va2.service.consul:9092', '--debug-addr', ':8104'),
-        ('boulder-remoteva-a', 'boulder-remoteva-b')),
-    Service('boulder-ca-a',
-        8001, 'ca1.service.consul:9093',
-        ('./bin/boulder', 'boulder-ca', '--config', os.path.join(config_dir, 'ca-a.json'), '--ca-addr', 'ca1.service.consul:9093', '--debug-addr', ':8001'),
-        ('boulder-sa-1', 'boulder-sa-2')),
-    Service('boulder-ca-b',
-        8101, 'ca2.service.consul:9093',
-        ('./bin/boulder', 'boulder-ca', '--config', os.path.join(config_dir, 'ca-b.json'), '--ca-addr', 'ca2.service.consul:9093', '--debug-addr', ':8101'),
-        ('boulder-sa-1', 'boulder-sa-2')),
-    Service('akamai-test-srv',
-        6789, None,
-        ('./bin/akamai-test-srv', '--listen', 'localhost:6789', '--secret', 'its-a-secret'),
-        None),
-    Service('akamai-purger',
-        9666, None,
-        ('./bin/boulder', 'akamai-purger', '--config', os.path.join(config_dir, 'akamai-purger.json')),
-        ('akamai-test-srv',)),
-    Service('s3-test-srv',
-        7890, None,
-        ('./bin/s3-test-srv', '--listen', 'localhost:7890'),
-        None),
-    Service('crl-storer',
-        9667, None,
-        ('./bin/boulder', 'crl-storer', '--config', os.path.join(config_dir, 'crl-storer.json')),
-        ('s3-test-srv',)),
-    Service('crl-updater',
-        8021, None,
-        ('./bin/boulder', 'crl-updater', '--config', os.path.join(config_dir, 'crl-updater.json')),
-        ('boulder-ca-a', 'boulder-ca-b', 'boulder-sa-1', 'boulder-sa-2', 'crl-storer')),
-    Service('boulder-ra-1',
-        8002, 'ra1.service.consul:9094',
-        ('./bin/boulder', 'boulder-ra', '--config', os.path.join(config_dir, 'ra.json'), '--addr', 'ra1.service.consul:9094', '--debug-addr', ':8002'),
-        ('boulder-sa-1', 'boulder-sa-2', 'boulder-ca-a', 'boulder-ca-b', 'boulder-va-1', 'boulder-va-2', 'akamai-purger', 'boulder-publisher-1', 'boulder-publisher-2')),
-    Service('boulder-ra-2',
-        8102, 'ra2.service.consul:9094',
-        ('./bin/boulder', 'boulder-ra', '--config', os.path.join(config_dir, 'ra.json'), '--addr', 'ra2.service.consul:9094', '--debug-addr', ':8102'),
-        ('boulder-sa-1', 'boulder-sa-2', 'boulder-ca-a', 'boulder-ca-b', 'boulder-va-1', 'boulder-va-2', 'akamai-purger', 'boulder-publisher-1', 'boulder-publisher-2')),
-    Service('bad-key-revoker',
-        8020, None,
-        ('./bin/boulder', 'bad-key-revoker', '--config', os.path.join(config_dir, 'bad-key-revoker.json')),
-        ('boulder-ra-1', 'boulder-ra-2', 'mail-test-srv')),
-    Service('nonce-service-taro',
-        8111, 'nonce1.service.consul:9101',
-        ('./bin/boulder', 'nonce-service', '--config', os.path.join(config_dir, 'nonce-a.json'), '--addr', '10.77.77.77:9101', '--debug-addr', ':8111',),
-        None),
-    Service('nonce-service-zinc',
-        8112, 'nonce2.service.consul:9101',
-        ('./bin/boulder', 'nonce-service', '--config', os.path.join(config_dir, 'nonce-b.json'), '--addr', '10.88.88.88:9101', '--debug-addr', ':8112',),
-        None),
-    Service('boulder-wfe2',
-        4001, None,
-        ('./bin/boulder', 'boulder-wfe2', '--config', os.path.join(config_dir, 'wfe2.json')),
-        ('boulder-ra-1', 'boulder-ra-2', 'boulder-sa-1', 'boulder-sa-2', 'nonce-service-taro', 'nonce-service-zinc')),
-    Service('log-validator',
-        8016, None,
-        ('./bin/boulder', 'log-validator', '--config', os.path.join(config_dir, 'log-validator.json')),
-        None),
+    Service(
+        "boulder-remoteva-a",
+        8011,
+        "rva1.service.consul:9097",
+        (
+            "./bin/boulder",
+            "boulder-remoteva",
+            "--config",
+            os.path.join(config_dir, "va-remote-a.json"),
+        ),
+        None,
+    ),
+    Service(
+        "boulder-remoteva-b",
+        8012,
+        "rva1.service.consul:9098",
+        (
+            "./bin/boulder",
+            "boulder-remoteva",
+            "--config",
+            os.path.join(config_dir, "va-remote-b.json"),
+        ),
+        None,
+    ),
+    Service(
+        "boulder-sa-1",
+        8003,
+        "sa1.service.consul:9095",
+        (
+            "./bin/boulder",
+            "boulder-sa",
+            "--config",
+            os.path.join(config_dir, "sa.json"),
+            "--addr",
+            "sa1.service.consul:9095",
+            "--debug-addr",
+            ":8003",
+        ),
+        None,
+    ),
+    Service(
+        "boulder-sa-2",
+        8103,
+        "sa2.service.consul:9095",
+        (
+            "./bin/boulder",
+            "boulder-sa",
+            "--config",
+            os.path.join(config_dir, "sa.json"),
+            "--addr",
+            "sa2.service.consul:9095",
+            "--debug-addr",
+            ":8103",
+        ),
+        None,
+    ),
+    Service(
+        "ct-test-srv",
+        4500,
+        None,
+        ("./bin/ct-test-srv", "--config", "test/ct-test-srv/ct-test-srv.json"),
+        None,
+    ),
+    Service(
+        "boulder-publisher-1",
+        8009,
+        "publisher1.service.consul:9091",
+        (
+            "./bin/boulder",
+            "boulder-publisher",
+            "--config",
+            os.path.join(config_dir, "publisher.json"),
+            "--addr",
+            "publisher1.service.consul:9091",
+            "--debug-addr",
+            ":8009",
+        ),
+        None,
+    ),
+    Service(
+        "boulder-publisher-2",
+        8109,
+        "publisher2.service.consul:9091",
+        (
+            "./bin/boulder",
+            "boulder-publisher",
+            "--config",
+            os.path.join(config_dir, "publisher.json"),
+            "--addr",
+            "publisher2.service.consul:9091",
+            "--debug-addr",
+            ":8109",
+        ),
+        None,
+    ),
+    Service(
+        "mail-test-srv",
+        9380,
+        None,
+        (
+            "./bin/mail-test-srv",
+            "--closeFirst",
+            "5",
+            "--cert",
+            "test/mail-test-srv/localhost/cert.pem",
+            "--key",
+            "test/mail-test-srv/localhost/key.pem",
+        ),
+        None,
+    ),
+    Service(
+        "ocsp-responder",
+        8005,
+        None,
+        (
+            "./bin/boulder",
+            "ocsp-responder",
+            "--config",
+            os.path.join(config_dir, "ocsp-responder.json"),
+        ),
+        ("boulder-ra-1", "boulder-ra-2"),
+    ),
+    Service(
+        "boulder-va-1",
+        8004,
+        "va1.service.consul:9092",
+        (
+            "./bin/boulder",
+            "boulder-va",
+            "--config",
+            os.path.join(config_dir, "va.json"),
+            "--addr",
+            "va1.service.consul:9092",
+            "--debug-addr",
+            ":8004",
+        ),
+        ("boulder-remoteva-a", "boulder-remoteva-b"),
+    ),
+    Service(
+        "boulder-va-2",
+        8104,
+        "va2.service.consul:9092",
+        (
+            "./bin/boulder",
+            "boulder-va",
+            "--config",
+            os.path.join(config_dir, "va.json"),
+            "--addr",
+            "va2.service.consul:9092",
+            "--debug-addr",
+            ":8104",
+        ),
+        ("boulder-remoteva-a", "boulder-remoteva-b"),
+    ),
+    Service(
+        "boulder-ca-a",
+        8001,
+        "ca1.service.consul:9093",
+        (
+            "./bin/boulder",
+            "boulder-ca",
+            "--config",
+            os.path.join(config_dir, "ca-a.json"),
+            "--ca-addr",
+            "ca1.service.consul:9093",
+            "--debug-addr",
+            ":8001",
+        ),
+        ("boulder-sa-1", "boulder-sa-2"),
+    ),
+    Service(
+        "boulder-ca-b",
+        8101,
+        "ca2.service.consul:9093",
+        (
+            "./bin/boulder",
+            "boulder-ca",
+            "--config",
+            os.path.join(config_dir, "ca-b.json"),
+            "--ca-addr",
+            "ca2.service.consul:9093",
+            "--debug-addr",
+            ":8101",
+        ),
+        ("boulder-sa-1", "boulder-sa-2"),
+    ),
+    Service(
+        "akamai-test-srv",
+        6789,
+        None,
+        (
+            "./bin/akamai-test-srv",
+            "--listen",
+            "localhost:6789",
+            "--secret",
+            "its-a-secret",
+        ),
+        None,
+    ),
+    Service(
+        "akamai-purger",
+        9666,
+        None,
+        (
+            "./bin/boulder",
+            "akamai-purger",
+            "--config",
+            os.path.join(config_dir, "akamai-purger.json"),
+        ),
+        ("akamai-test-srv",),
+    ),
+    Service(
+        "s3-test-srv",
+        7890,
+        None,
+        ("./bin/s3-test-srv", "--listen", "localhost:7890"),
+        None,
+    ),
+    Service(
+        "crl-storer",
+        9667,
+        None,
+        (
+            "./bin/boulder",
+            "crl-storer",
+            "--config",
+            os.path.join(config_dir, "crl-storer.json"),
+        ),
+        ("s3-test-srv",),
+    ),
+    Service(
+        "crl-updater",
+        8021,
+        None,
+        (
+            "./bin/boulder",
+            "crl-updater",
+            "--config",
+            os.path.join(config_dir, "crl-updater.json"),
+        ),
+        ("boulder-ca-a", "boulder-ca-b", "boulder-sa-1", "boulder-sa-2", "crl-storer"),
+    ),
+    Service(
+        "boulder-ra-1",
+        8002,
+        "ra1.service.consul:9094",
+        (
+            "./bin/boulder",
+            "boulder-ra",
+            "--config",
+            os.path.join(config_dir, "ra.json"),
+            "--addr",
+            "ra1.service.consul:9094",
+            "--debug-addr",
+            ":8002",
+        ),
+        (
+            "boulder-sa-1",
+            "boulder-sa-2",
+            "boulder-ca-a",
+            "boulder-ca-b",
+            "boulder-va-1",
+            "boulder-va-2",
+            "akamai-purger",
+            "boulder-publisher-1",
+            "boulder-publisher-2",
+        ),
+    ),
+    Service(
+        "boulder-ra-2",
+        8102,
+        "ra2.service.consul:9094",
+        (
+            "./bin/boulder",
+            "boulder-ra",
+            "--config",
+            os.path.join(config_dir, "ra.json"),
+            "--addr",
+            "ra2.service.consul:9094",
+            "--debug-addr",
+            ":8102",
+        ),
+        (
+            "boulder-sa-1",
+            "boulder-sa-2",
+            "boulder-ca-a",
+            "boulder-ca-b",
+            "boulder-va-1",
+            "boulder-va-2",
+            "akamai-purger",
+            "boulder-publisher-1",
+            "boulder-publisher-2",
+        ),
+    ),
+    Service(
+        "bad-key-revoker",
+        8020,
+        None,
+        (
+            "./bin/boulder",
+            "bad-key-revoker",
+            "--config",
+            os.path.join(config_dir, "bad-key-revoker.json"),
+        ),
+        ("boulder-ra-1", "boulder-ra-2", "mail-test-srv"),
+    ),
+    Service(
+        "nonce-service-taro",
+        8111,
+        "nonce1.service.consul:9101",
+        (
+            "./bin/boulder",
+            "nonce-service",
+            "--config",
+            os.path.join(config_dir, "nonce-a.json"),
+            "--addr",
+            "10.77.77.77:9101",
+            "--debug-addr",
+            ":8111",
+        ),
+        None,
+    ),
+    Service(
+        "nonce-service-zinc",
+        8112,
+        "nonce2.service.consul:9101",
+        (
+            "./bin/boulder",
+            "nonce-service",
+            "--config",
+            os.path.join(config_dir, "nonce-b.json"),
+            "--addr",
+            "10.88.88.88:9101",
+            "--debug-addr",
+            ":8112",
+        ),
+        None,
+    ),
+    Service(
+        "boulder-wfe2",
+        4001,
+        None,
+        (
+            "./bin/boulder",
+            "boulder-wfe2",
+            "--config",
+            os.path.join(config_dir, "wfe2.json"),
+        ),
+        (
+            "boulder-ra-1",
+            "boulder-ra-2",
+            "boulder-sa-1",
+            "boulder-sa-2",
+            "nonce-service-taro",
+            "nonce-service-zinc",
+        ),
+    ),
+    Service(
+        "log-validator",
+        8016,
+        None,
+        (
+            "./bin/boulder",
+            "log-validator",
+            "--config",
+            os.path.join(config_dir, "log-validator.json"),
+        ),
+        None,
+    ),
 )
+
 
 def _service_toposort(services):
     """Yields Service objects in topologically sorted order.
@@ -135,7 +408,8 @@ def _service_toposort(services):
         print("WARNING: services with unsatisfied dependencies:")
         for s in blocked:
             print(s.name, ":", s.deps)
-        raise(Exception("Unable to satisfy service dependencies"))
+        raise (Exception("Unable to satisfy service dependencies"))
+
 
 processes = []
 
@@ -144,12 +418,15 @@ processes = []
 # to run the load-generator).
 challSrvProcess = None
 
+
 def setupHierarchy():
     """Set up the issuance hierarchy. Must have called install() before this."""
     e = os.environ.copy()
     e.setdefault("GOBIN", "%s/bin" % os.getcwd())
     try:
-        subprocess.check_output(["go", "run", "test/cert-ceremonies/generate.go"], env=e)
+        subprocess.check_output(
+            ["go", "run", "test/cert-ceremonies/generate.go"], env=e
+        )
     except subprocess.CalledProcessError as e:
         print(e.output)
         raise
@@ -159,11 +436,12 @@ def install(race_detection):
     # Pass empty BUILD_TIME and BUILD_ID flags to avoid constantly invalidating the
     # build cache with new BUILD_TIMEs, or invalidating it on merges with a new
     # BUILD_ID.
-    go_build_flags='-tags "integration"'
+    go_build_flags = '-tags "integration"'
     if race_detection:
-        go_build_flags += ' -race'
+        go_build_flags += " -race"
 
     return subprocess.call(["/usr/bin/make", "GO_BUILD_FLAGS=%s" % go_build_flags]) == 0
+
 
 def run(cmd, fakeclock):
     e = os.environ.copy()
@@ -173,6 +451,7 @@ def run(cmd, fakeclock):
     p = subprocess.Popen(cmd, env=e)
     p.cmd = cmd
     return p
+
 
 def start(fakeclock):
     """Return True if everything builds and starts.
@@ -198,9 +477,11 @@ def start(fakeclock):
             p = run(service.cmd, fakeclock)
             processes.append(p)
             if service.grpc_addr is not None:
-                waithealth(' '.join(p.args), service.grpc_addr)
+                waithealth(" ".join(p.args), service.grpc_addr)
             else:
-                if not waitport(service.debug_port, ' '.join(p.args), perTickCheck=check):
+                if not waitport(
+                    service.debug_port, " ".join(p.args), perTickCheck=check
+                ):
                     return False
         except Exception as e:
             print("Error starting service %s: %s" % (service.name, e))
@@ -208,6 +489,7 @@ def start(fakeclock):
 
     print("All servers running. Hit ^C to kill.")
     return True
+
 
 def check():
     """Return true if all started processes are still alive.
@@ -230,6 +512,7 @@ def check():
     processes = stillok
     return not busted
 
+
 def startChallSrv():
     """
     Start the pebble-challtestsrv and wait for it to become available. See also
@@ -237,26 +520,37 @@ def startChallSrv():
     """
     global challSrvProcess
     if challSrvProcess is not None:
-        raise(Exception("startChallSrv called more than once"))
+        raise (Exception("startChallSrv called more than once"))
 
     # NOTE(@cpu): We specify explicit bind addresses for -https01 and
     # --tlsalpn01 here to allow HTTPS HTTP-01 responses on 443 for on interface
     # and TLS-ALPN-01 responses on 443 for another interface. The choice of
     # which is used is controlled by mock DNS data added by the relevant
     # integration tests.
-    challSrvProcess = run([
-        'pebble-challtestsrv',
-        '--defaultIPv4', os.environ.get("FAKE_DNS"),
-        '-defaultIPv6', '',
-        '--dns01', ':8053,:8054',
-        '--management', ':8055',
-        '--http01', '10.77.77.77:80',
-        '-https01', '10.77.77.77:443',
-        '--tlsalpn01', '10.88.88.88:443'],
-        None)
+    challSrvProcess = run(
+        [
+            "pebble-challtestsrv",
+            "--defaultIPv4",
+            os.environ.get("FAKE_DNS"),
+            "-defaultIPv6",
+            "",
+            "--dns01",
+            ":8053,:8054",
+            "--management",
+            ":8055",
+            "--http01",
+            "10.77.77.77:80",
+            "-https01",
+            "10.77.77.77:443",
+            "--tlsalpn01",
+            "10.88.88.88:443",
+        ],
+        None,
+    )
     # Wait for the pebble-challtestsrv management port.
-    if not waitport(8055, ' '.join(challSrvProcess.args)):
+    if not waitport(8055, " ".join(challSrvProcess.args)):
         return False
+
 
 def stopChallSrv():
     """
@@ -270,6 +564,7 @@ def stopChallSrv():
         challSrvProcess.send_signal(signal.SIGTERM)
         challSrvProcess.wait()
     challSrvProcess = None
+
 
 @atexit.register
 def stop():

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -362,8 +362,7 @@ def test_http_challenge_http_redirect():
     if len(history) < 2:
         raise (
             Exception(
-                "Expected at least 2 HTTP request events on challtestsrv, found {0}".format(
-                    )
+                "Expected at least 2 HTTP request events on challtestsrv, found {0}".format()
             )
         )
 
@@ -1628,9 +1627,7 @@ def ocsp_exp_unauth_setup():
     order = chisel2.auth_and_issue(
         [random_domain()], client=client, cert_output=cert_file.name
     )
-    OpenSSL.crypto.load_certificate(
-        OpenSSL.crypto.FILETYPE_PEM, order.fullchain_pem
-    )
+    OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, order.fullchain_pem)
 
     # Since our servers are pretending to be in the past, but the openssl cli
     # isn't, we'll get an expired OCSP response. Just check that it exists;

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -532,7 +532,7 @@ class SlowHTTPRequestHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b"this is not an ACME key authorization")
-        except:
+        except Exception:
             pass
 
 

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -128,7 +128,7 @@ def check_challenge_dns_err(chalType):
                 c = chisel2.get_chall(authzr, challenges.TLSALPN01)
             else:
                 raise (
-                    Exception("Invalid challenge type requested: {0}".format(challType))
+                    Exception("Invalid challenge type requested: {0}".format(chalType))
                 )
 
             # The failed challenge's error should match expected
@@ -413,8 +413,8 @@ def test_http_challenge_http_redirect():
     if len(initialRequests) < 1:
         raise (
             Exception(
-                "Expected {0} initial HTTP-01 request events on challtestsrv, found {1}".format(
-                    validation_attempts, len(initialRequests)
+                "Expected an initial HTTP-01 request events on challtestsrv, found {0}".format(
+                    len(initialRequests)
                 )
             )
         )
@@ -423,8 +423,8 @@ def test_http_challenge_http_redirect():
     if len(redirectedRequests) < 1:
         raise (
             Exception(
-                "Expected {0} redirected HTTP-01 request events on challtestsrv, found {1}".format(
-                    validation_attempts, len(redirectedRequests)
+                "Expected a redirected HTTP-01 request events on challtestsrv, found {0}".format(
+                    len(redirectedRequests)
                 )
             )
         )
@@ -505,8 +505,8 @@ def test_http_challenge_https_redirect():
     if len(initialRequests) < 1:
         raise (
             Exception(
-                "Expected {0} initial HTTP-01 request events on challtestsrv, found {1}".format(
-                    validation_attempts, len(initialRequests)
+                "Expected an initial HTTP-01 request events on challtestsrv, found {0}".format(
+                    len(initialRequests)
                 )
             )
         )
@@ -519,8 +519,8 @@ def test_http_challenge_https_redirect():
     if len(redirectedRequests) < 1:
         raise (
             Exception(
-                "Expected {0} redirected HTTP-01 request events on challtestsrv, found {1}".format(
-                    validation_attempts, len(redirectedRequests)
+                "Expected an redirected HTTP-01 request events on challtestsrv, found {0}".format(
+                    len(redirectedRequests)
                 )
             )
         )
@@ -1649,7 +1649,7 @@ def test_ocsp_exp_unauth():
             last_error = cpe.output
             if cpe.output == b"Responder Error: unauthorized (6)\n":
                 break
-        except e:
+        except Exception as e:
             last_error = e
             pass
         tries += 1

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1030,37 +1030,6 @@ def test_double_revocation():
         raise (Exception("Re-revoked already keyCompromise'd cert"))
 
 
-def test_sct_embedding():
-    order = chisel2.auth_and_issue([random_domain()])
-    print(order.fullchain_pem.encode())
-    cert = parse_cert(order)
-
-    # make sure there is no poison extension
-    try:
-        cert.extensions.get_extension_for_oid(
-            x509.ObjectIdentifier("1.3.6.1.4.1.11129.2.4.3")
-        )
-        raise (Exception("certificate contains CT poison extension"))
-    except x509.ExtensionNotFound:
-        # do nothing
-        pass
-
-    # make sure there is a SCT list extension
-    try:
-        sctList = cert.extensions.get_extension_for_oid(
-            x509.ObjectIdentifier("1.3.6.1.4.1.11129.2.4.2")
-        )
-    except x509.ExtensionNotFound:
-        raise (Exception("certificate doesn't contain SCT list extension"))
-    if len(sctList.value) != 2:
-        raise (Exception("SCT list contains wrong number of SCTs"))
-    for sct in sctList.value:
-        if sct.version != x509.certificate_transparency.Version.v1:
-            raise (Exception("SCT contains wrong version"))
-        if sct.entry_type != x509.certificate_transparency.LogEntryType.PRE_CERTIFICATE:
-            raise (Exception("SCT contains wrong entry type"))
-
-
 def test_only_return_existing_reg():
     client = chisel2.uninitialized_client()
     email = "test@not-example.com"

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -17,7 +17,25 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 
 import chisel2
-from helpers import *
+
+# from helpers import *
+from helpers import (
+    random_domain,
+    temppath,
+    reset_akamai_purges,
+    verify_ocsp,
+    verify_akamai_purge,
+    tempdir,
+    base64,
+    CONFIG_NEXT,
+    register_twenty_days_ago,
+    register_six_months_ago,
+    run,
+    make_ocsp_req,
+    get_future_output,
+    config_dir,
+    fetch_ocsp,
+)
 
 from acme import errors as acme_errors
 

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -6,7 +6,6 @@ import subprocess
 import requests
 import datetime
 import time
-import os
 import json
 import re
 
@@ -22,9 +21,8 @@ from helpers import *
 
 from acme import errors as acme_errors
 
-from acme.messages import Status, CertificateRequest, Directory, NewRegistration
+from acme.messages import Status
 from acme import crypto_util as acme_crypto_util
-from acme import client as acme_client
 from acme import messages
 from acme import challenges
 from acme import errors
@@ -32,8 +30,6 @@ from acme import errors
 import josepy
 
 import tempfile
-import shutil
-import atexit
 import random
 import string
 
@@ -232,7 +228,7 @@ def test_failed_validation_limit():
         client.answer_challenge(chall, chall.response(client.net.key))
         try:
             client.poll_and_finalize(order)
-        except errors.ValidationError as e:
+        except errors.ValidationError:
             pass
     chisel2.expect_problem(
         "urn:ietf:params:acme:error:rateLimited",
@@ -366,9 +362,8 @@ def test_http_challenge_http_redirect():
     if len(history) < 2:
         raise (
             Exception(
-                "Expected at least 2 HTTP request events on challtestsrv, found {1}".format(
-                    len(history)
-                )
+                "Expected at least 2 HTTP request events on challtestsrv, found {0}".format(
+                    )
             )
         )
 
@@ -754,7 +749,7 @@ def test_order_reuse_failed_authz():
         # Poll the order's authorizations until they are non-pending, a timeout
         # occurs, or there is an invalid authorization status.
         client.poll_authorizations(order, deadline)
-    except acme_errors.ValidationError as e:
+    except acme_errors.ValidationError:
         # We expect there to be a ValidationError from one of the authorizations
         # being invalid.
         authzFailed = True
@@ -1438,7 +1433,7 @@ def test_new_order_policy_errs():
     # subproblems are properly represented.
     ok = False
     try:
-        order = client.new_order(csr_pem)
+        client.new_order(csr_pem)
     except messages.Error as e:
         ok = True
         if e.typ != "urn:ietf:params:acme:error:rejectedIdentifier":
@@ -1614,7 +1609,7 @@ def check_ocsp_basic_oid(cert_file, issuer_file, url):
     # successful response.
     expected = bytearray.fromhex("06 09 2B 06 01 05 05 07 30 01 01")
     for resp in responses:
-        if not expected in bytearray(resp):
+        if expected not in bytearray(resp):
             raise (
                 Exception(
                     "Did not receive successful OCSP response: %s doesn't contain %s"
@@ -1633,7 +1628,7 @@ def ocsp_exp_unauth_setup():
     order = chisel2.auth_and_issue(
         [random_domain()], client=client, cert_output=cert_file.name
     )
-    cert = OpenSSL.crypto.load_certificate(
+    OpenSSL.crypto.load_certificate(
         OpenSSL.crypto.FILETYPE_PEM, order.fullchain_pem
     )
 
@@ -1747,7 +1742,7 @@ def test_blocked_key_cert():
     authzs = order.authorizations
 
     testPass = False
-    cleanup = chisel2.do_http_challenges(client, authzs)
+    chisel2.do_http_challenges(client, authzs)
     try:
         order = client.poll_and_finalize(order)
     except acme_errors.Error as e:

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1783,7 +1783,7 @@ def test_expiration_mailer():
     last_reminder = expiry + datetime.timedelta(days=-2)
 
     requests.post("http://localhost:9381/clear", data="")
-    for time in (no_reminder, first_reminder, last_reminder):
+    for reminder_time in (no_reminder, first_reminder, last_reminder):
         print(
             get_future_output(
                 [
@@ -1792,7 +1792,7 @@ def test_expiration_mailer():
                     "--config",
                     "%s/expiration-mailer.json" % config_dir,
                 ],
-                time,
+                reminder_time,
             )
         )
     resp = requests.get("http://localhost:9381/count?to=%s" % email_addr)

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -362,7 +362,9 @@ def test_http_challenge_http_redirect():
     if len(history) < 2:
         raise (
             Exception(
-                "Expected at least 2 HTTP request events on challtestsrv, found {0}".format()
+                "Expected at least 2 HTTP request events on challtestsrv, found {0}".format(
+                    history
+                )
             )
         )
 


### PR DESCRIPTION
When reviewing python integration tests, I noticed a number of mistakes that would be instantly caught by a linter.  So this adds the ruff linter, along with black for formatting.

You probably want to read the individual commits, as there's a mix of big automatic ones and small real fixes:

- Run `black` to reformat files
- ruff --fix
- duplicate import
- Add black and ruff linting of python files
- reformat with newer black
- Ignore ruff E501 (line length), F405
- Ignore imports not at start
- move import to top of file
- Missing argument to .format
- E722: Do not use bare except
- F402: Shadowing import
- Duplicated test
- E741: Ambiguous variable name
- Explicitly import from helpers
- Fix references to unknown names
