### PR TITLE
VA: Support discovery of DNS resolvers via Consul

### DIFF
--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -102,9 +102,8 @@ func (sp *staticProvider) Stop() {}
 type dynamicProvider struct {
 	// dnsAuthority is the single <hostname|IPv4|[IPv6]>:<port> of the DNS
 	// server to be used for resolution of DNS backends. If the address contains
-	// a hostname the BDNS will resolve it via the system DNS. If the address
-	// contains a port, the client will use it directly, otherwise port 53 is
-	// used.
+	// a hostname it will be resolved via the system DNS. If the port is left
+	// unspecified it will default to '53'.
 	dnsAuthority string
 	// service is the service name to look up SRV records for within the domain.
 	service string

--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -106,12 +106,9 @@ type dynamicProvider struct {
 	// contains a port, the client will use it directly, otherwise port 53 is
 	// used.
 	dnsAuthority string
-	// service is the name of the service to look up SRV records for. This will
-	// be used as the basis of a SRV query to locate DNS services on the domain.
-	// If not specified, "dns" will be used.
+	// service is the service name to look up SRV records for within the domain.
 	service string
-	// domain is the domain to look up SRV records for. This will be used as the
-	// basis of a SRV query to locate DNS services on the domain.
+	// domain is the name to look up SRV records within.
 	domain string
 	// A map of IP addresses (results of A record lookups for SRV Targets) to
 	// ports (Port fields in SRV records) associated with those addresses.
@@ -123,8 +120,8 @@ type dynamicProvider struct {
 	updateCounter *prometheus.CounterVec
 }
 
-// resolveDNSAuthority resolves the DNS authority to use for resolution of DNS
-// backends. The DNS authority can be specified as a hostname or IP address,
+// resolveDNSAuthority resolves the DNS authority to use for resolution of other
+// DNS backends. The DNS authority can be specified as a hostname or IP address,
 // with or without a port. If the authority is specified as a hostname it will
 // be resolved via the system DNS. If the authority is specified as an IP
 // address it will be used directly, defaulting to port 53 if no port is

--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -128,29 +128,14 @@ type dynamicProvider struct {
 func resolveDNSAuthority(d string) (string, error) {
 	host, port, err := net.SplitHostPort(d)
 	if err != nil {
-		// No port specified.
-		if net.ParseIP(d) != nil {
-			// IP without port, use it directly, defaulting to port 53.
-			return net.JoinHostPort(d, "53"), nil
-		}
-		// Assume hostname without port, resolve it via the system DNS.
-		ips, err := net.LookupIP(d)
-		if err != nil {
-			return "", fmt.Errorf("during A/AAAA lookup of %q: %s", d, err)
-		}
-		if len(ips) <= 0 {
-			return "", fmt.Errorf("A/AAAA lookup of %q returned 0 results", d)
-		}
-		// Use the first IP returned, defaulting to port 53.
-		return net.JoinHostPort(ips[0].String(), "53"), nil
+		// Assume host with no port specified, default port to 53.
+		host = d
+		port = "53"
 
 	}
-	// Port specified.
 	if net.ParseIP(host) != nil {
-		// IP with port, use it directly.
 		return net.JoinHostPort(host, port), nil
 	}
-	// Assume hostname with port, resolve it via the system DNS.
 	ips, err := net.LookupIP(host)
 	if err != nil {
 		return "", fmt.Errorf("during A/AAAA lookup of %q: %s", d, err)
@@ -158,7 +143,6 @@ func resolveDNSAuthority(d string) (string, error) {
 	if len(ips) <= 0 {
 		return "", fmt.Errorf("A/AAAA lookup for %q returned 0 results", d)
 	}
-	// Use the first IP returned.
 	return net.JoinHostPort(ips[0].String(), port), nil
 }
 

--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/letsencrypt/boulder/cmd"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -99,10 +100,19 @@ func (sp *staticProvider) Stop() {}
 // addresses, and refreshes it regularly using a goroutine started by its
 // constructor.
 type dynamicProvider struct {
-	// The domain name which should be used for DNS. Will be used as the basis of
-	// a SRV query to locate DNS services on this domain, which will in turn be
-	// used as the basis for A queries to cache IP addrs for those services.
-	name string
+	// dnsAuthority is the single <hostname|IPv4|[IPv6]>:<port> of the DNS
+	// server to be used for resolution of DNS backends. If the address contains
+	// a hostname the BDNS will resolve it via the system DNS. If the address
+	// contains a port, the client will use it directly, otherwise port 53 is
+	// used.
+	dnsAuthority string
+	// service is the name of the service to look up SRV records for. This will
+	// be used as the basis of a SRV query to locate DNS services on the domain.
+	// If not specified, "dns" will be used.
+	service string
+	// domain is the domain to look up SRV records for. This will be used as the
+	// basis of a SRV query to locate DNS services on the domain.
+	domain string
 	// A map of IP addresses (results of A record lookups for SRV Targets) to
 	// ports (Port fields in SRV records) associated with those addresses.
 	addrs map[string][]uint16
@@ -113,23 +123,84 @@ type dynamicProvider struct {
 	updateCounter *prometheus.CounterVec
 }
 
+// resolveDNSAuthority resolves the DNS authority to use for resolution of DNS
+// backends. The DNS authority can be specified as a hostname or IP address,
+// with or without a port. If the authority is specified as a hostname it will
+// be resolved via the system DNS. If the authority is specified as an IP
+// address it will be used directly, defaulting to port 53 if no port is
+// specified.
+func resolveDNSAuthority(d string) (string, error) {
+	host, port, err := net.SplitHostPort(d)
+	if err != nil {
+		// No port specified.
+		if net.ParseIP(d) != nil {
+			// IP without port, use it directly, defaulting to port 53.
+			return net.JoinHostPort(d, "53"), nil
+		}
+		// Assume hostname without port, resolve it via the system DNS.
+		ips, err := net.LookupIP(d)
+		if err != nil {
+			return "", fmt.Errorf("during A/AAAA lookup of %q: %s", d, err)
+		}
+		if len(ips) <= 0 {
+			return "", fmt.Errorf("A/AAAA lookup of %q returned 0 results", d)
+		}
+		// Use the first IP returned, defaulting to port 53.
+		return net.JoinHostPort(ips[0].String(), "53"), nil
+
+	}
+	// Port specified.
+	if net.ParseIP(host) != nil {
+		// IP with port, use it directly.
+		return net.JoinHostPort(host, port), nil
+	}
+	// Assume hostname with port, resolve it via the system DNS.
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return "", fmt.Errorf("during A/AAAA lookup of %q: %s", d, err)
+	}
+	if len(ips) <= 0 {
+		return "", fmt.Errorf("A/AAAA lookup for %q returned 0 results", d)
+	}
+	// Use the first IP returned.
+	return net.JoinHostPort(ips[0].String(), port), nil
+}
+
 var _ ServerProvider = &dynamicProvider{}
 
 // StartDynamicProvider constructs a new dynamicProvider and starts its
 // auto-update goroutine. The auto-update process queries DNS for SRV records
 // at refresh intervals and uses the resulting IP/port combos to populate the
 // list returned by Addrs. The update process ignores the Priority and Weight
-// attributes of the SRV records. The given server name should be a full domain
-// name like `example.com`, which will result in SRV queries for `_dns._udp.example.com`.
-func StartDynamicProvider(server string, refresh time.Duration) (*dynamicProvider, error) {
-	if server == "" {
-		return nil, fmt.Errorf("no DNS domain name provided")
+// attributes of the SRV records.
+func StartDynamicProvider(c *cmd.DNSProvider, refresh time.Duration) (*dynamicProvider, error) {
+	if c.SRVLookup.Domain == "" {
+		return nil, fmt.Errorf("'domain' cannot be empty")
 	}
+
+	service := c.SRVLookup.Service
+	if service == "" {
+		// Default to "dns" if no service is specified. This is the default
+		// service name for DNS servers.
+		service = "dns"
+	}
+
+	dnsAuthority := c.DNSAuthority
+	if dnsAuthority != "" {
+		var err error
+		dnsAuthority, err = resolveDNSAuthority(dnsAuthority)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	dp := dynamicProvider{
-		name:    server,
-		addrs:   make(map[string][]uint16),
-		cancel:  make(chan interface{}),
-		refresh: refresh,
+		dnsAuthority: dnsAuthority,
+		service:      service,
+		domain:       c.SRVLookup.Domain,
+		addrs:        make(map[string][]uint16),
+		cancel:       make(chan interface{}),
+		refresh:      refresh,
 		updateCounter: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "dns_update",
@@ -180,25 +251,41 @@ func (dp *dynamicProvider) update() error {
 	ctx, cancel := context.WithTimeout(context.Background(), dp.refresh/2)
 	defer cancel()
 
-	_, srvs, err := net.DefaultResolver.LookupSRV(ctx, "dns", "udp", dp.name)
+	// If dnsAuthority is specified, setup a custom resolver to use it
+	// otherwise use a default system resolver.
+	resolver := net.DefaultResolver
+	if dp.dnsAuthority != "" {
+		resolver = &net.Resolver{
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				// Same as the default resolver, but with a custom IP/port.
+				d := &net.Dialer{}
+				return d.DialContext(ctx, network, dp.dnsAuthority)
+			},
+		}
+	}
+
+	// RFC 2782 formatted SRV record being queried e.g. "_service._proto.name."
+	record := fmt.Sprintf("_%s._udp.%s.", dp.service, dp.domain)
+
+	_, srvs, err := resolver.LookupSRV(ctx, dp.service, "udp", dp.domain)
 	if err != nil {
-		return fmt.Errorf("failed to lookup SRV records for %q: %w", dp.name, err)
+		return fmt.Errorf("during SRV lookup of %q: %w", record, err)
 	}
 	if len(srvs) == 0 {
-		return fmt.Errorf("no SRV records found for %q", dp.name)
+		return fmt.Errorf("SRV lookup of %q returned 0 results", record)
 	}
 
 	addrPorts := make(map[string][]uint16)
 	for _, srv := range srvs {
-		addrs, err := net.DefaultResolver.LookupHost(ctx, srv.Target)
+		addrs, err := resolver.LookupHost(ctx, srv.Target)
 		if err != nil {
-			return fmt.Errorf("failed to resolve SRV Target %q: %w", srv.Target, err)
+			return fmt.Errorf("during A/AAAA lookup of target %q from SRV record %q: %w", srv.Target, record, err)
 		}
 		for _, addr := range addrs {
 			joinedHostPort := net.JoinHostPort(addr, fmt.Sprint(srv.Port))
 			err := validateServerAddress(joinedHostPort)
 			if err != nil {
-				return fmt.Errorf("invalid SRV addr %q: %w", joinedHostPort, err)
+				return fmt.Errorf("invalid addr %q from SRV record %q: %w", joinedHostPort, record, err)
 			}
 			addrPorts[addr] = append(addrPorts[addr], srv.Port)
 		}

--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -131,7 +131,17 @@ func resolveDNSAuthority(d string) (string, error) {
 		// Assume host with no port specified, default port to 53.
 		host = d
 		port = "53"
+	} else {
+		// Ensure the `port` portion of `address` is a valid port.
+		portNum, err := strconv.Atoi(port)
+		if err != nil {
+			return "", errors.New("port must be an integer: %s")
+		}
+		if portNum <= 0 || portNum > 65535 {
+			return "", errors.New("port must be an integer between 0 - 65535")
+		}
 	}
+
 	if net.ParseIP(host) != nil {
 		return net.JoinHostPort(host, port), nil
 	}

--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -131,7 +131,6 @@ func resolveDNSAuthority(d string) (string, error) {
 		// Assume host with no port specified, default port to 53.
 		host = d
 		port = "53"
-
 	}
 	if net.ParseIP(host) != nil {
 		return net.JoinHostPort(host, port), nil

--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -166,11 +166,11 @@ func StartDynamicProvider(c *cmd.DNSProvider, refresh time.Duration) (*dynamicPr
 
 	dnsAuthority := c.DNSAuthority
 	if dnsAuthority != "" {
-		var err error
-		dnsAuthority, err = resolveDNSAuthority(dnsAuthority)
+		resolved, err := resolveDNSAuthority(dnsAuthority)
 		if err != nil {
 			return nil, err
 		}
+		dnsAuthority = resolved
 	}
 
 	dp := dynamicProvider{

--- a/bdns/servers_test.go
+++ b/bdns/servers_test.go
@@ -2,8 +2,6 @@ package bdns
 
 import (
 	"testing"
-
-	"github.com/letsencrypt/boulder/test"
 )
 
 func Test_validateServerAddress(t *testing.T) {
@@ -85,12 +83,12 @@ func Test_resolveDNSAuthority(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := resolveDNSAuthority(tt.args.d)
-			if (err != nil) != tt.wantErr {
-				test.AssertNotError(t, err, "returned unexpected error")
+			if err != nil && !tt.wantErr {
+				t.Errorf("resolveDNSAuthority() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				test.AssertEquals(t, got, tt.want)
+				t.Errorf("resolveDNSAuthority() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/bdns/servers_test.go
+++ b/bdns/servers_test.go
@@ -85,9 +85,10 @@ func Test_resolveDNSAuthority(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := resolveDNSAuthority(tt.args.d)
-			if err != nil && !tt.wantErr {
-				t.Errorf("resolveDNSAuthority() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				test.AssertError(t, err, "expected error")
+			} else {
+				test.AssertNotError(t, err, "unexpected error")
 			}
 			test.AssertEquals(t, got, tt.want)
 		})

--- a/bdns/servers_test.go
+++ b/bdns/servers_test.go
@@ -2,6 +2,8 @@ package bdns
 
 import (
 	"testing"
+
+	"github.com/letsencrypt/boulder/test"
 )
 
 func Test_validateServerAddress(t *testing.T) {
@@ -87,9 +89,7 @@ func Test_resolveDNSAuthority(t *testing.T) {
 				t.Errorf("resolveDNSAuthority() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("resolveDNSAuthority() = %v, want %v", got, tt.want)
-			}
+			test.AssertEquals(t, got, tt.want)
 		})
 	}
 }

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -26,8 +26,8 @@ type Config struct {
 		// before giving up. May be short-circuited by deadlines. A zero value
 		// will be turned into 1.
 		DNSTries                  int
-		DNSResolver               string           `validate:"required_without=DNSProvider"`
-		DNSProvider               *cmd.DNSProvider `validate:"required_without=DNSResolver"`
+		DNSResolver               string           `validate:"required_without=DNSProvider,excluded_with=DNSProvider,omitempty,hostname|hostname_port"`
+		DNSProvider               *cmd.DNSProvider `validate:"required_without=DNSResolver,excluded_with=DNSResolver,omitempty"`
 		DNSTimeout                string
 		DNSAllowLoopbackAddresses bool
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -26,8 +26,8 @@ type Config struct {
 		// before giving up. May be short-circuited by deadlines. A zero value
 		// will be turned into 1.
 		DNSTries                  int
-		DNSResolver               string `validate:"required"`
-		DNSProvider               *cmd.DNSProvider
+		DNSResolver               string           `validate:"required_without=DNSProvider"`
+		DNSProvider               *cmd.DNSProvider `validate:"required_without=DNSResolver"`
 		DNSTimeout                string
 		DNSAllowLoopbackAddresses bool
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -97,11 +97,11 @@ func main() {
 	// TODO(#6868) Remove this once all instances of VA.DNSResolver have been
 	// removed from production config files.
 	if c.VA.DNSResolver != "" && c.VA.DNSProvider != nil {
-		cmd.Fail("Cannot specify both 'dnsResolver' and dnsDynamicResolver")
+		cmd.Fail("Cannot specify both 'dnsResolver' and dnsProvider")
 	}
 
 	if c.VA.DNSResolver == "" && c.VA.DNSProvider == nil {
-		cmd.Fail("Must specify either 'dnsResolver' or dnsDynamicResolver")
+		cmd.Fail("Must specify either 'dnsResolver' or dnsProvider")
 	}
 
 	if c.VA.DNSProvider == nil && c.VA.DNSResolver != "" {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -500,9 +500,8 @@ type OpenTelemetryConfig struct {
 type DNSProvider struct {
 	// DNSAuthority is a single <hostname|IPv4|[IPv6]>:<port> of the DNS server
 	// to be used for resolution of DNS backends. If the address contains a
-	// hostname the BDNS will resolve it via the system DNS. If the address
-	// contains a port, the client will use it directly, otherwise port 53 is
-	// used.
+	// hostname it will be resolved via the system DNS. If the address contains
+	// a port, the client will use it directly, otherwise port 53 is assumed.
 	DNSAuthority string `validate:"required,ip|hostname|hostname_port"`
 
 	// SRVLookup contains the service and domain name used to construct a SRV
@@ -534,8 +533,8 @@ type DNSProvider struct {
 	// If you've added the above to your Consul configuration file (and reloaded
 	// Consul) then you should be able to resolve the following dig query:
 	//
-	// $ dig @10.55.55.10 -t SRV _foo._tcp.service.consul +short
-	// 1 1 8080 0a585858.addr.dc1.consul.
-	// 1 1 8080 0a4d4d4d.addr.dc1.consul.
+	// $ dig @10.55.55.10 -t SRV _unbound._udp.service.consul +short
+	// 1 1 53 0a585858.addr.dc1.consul.
+	// 1 1 53 0a4d4d4d.addr.dc1.consul.
 	SRVLookup ServiceDomain `validate:"required"`
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -502,7 +502,7 @@ type DNSProvider struct {
 	// to be used for resolution of DNS backends. If the address contains a
 	// hostname it will be resolved via the system DNS. If the address contains
 	// a port, the client will use it directly, otherwise port 53 is assumed.
-	DNSAuthority string `validate:"required,ip|hostname|hostname_port"`
+	DNSAuthority string `validate:"omitempty,ip|hostname|hostname_port"`
 
 	// SRVLookup contains the service and domain name used to construct a SRV
 	// DNS query to lookup DNS backends. For example: if the resource record is

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -498,21 +498,26 @@ type OpenTelemetryConfig struct {
 // DNSProvider contains the configuration for a DNS provider in the bdns package
 // which supports dynamic reloading of its backends.
 type DNSProvider struct {
-	// DNSAuthority is a single <hostname|IPv4|[IPv6]>:<port> of the DNS server
-	// to be used for resolution of DNS backends. If the address contains a
-	// hostname it will be resolved via the system DNS. If the address contains
-	// a port, the client will use it directly, otherwise port 53 is assumed.
+	// DNSAuthority is the single <hostname|IPv4|[IPv6]>:<port> of the DNS
+	// server to be used for resolution of DNS backends. If the address contains
+	// a hostname it will be resolved via the system DNS. If the port is left
+	// unspecified it will default to '53'. If this field is left unspecified
+	// the system DNS will be used for resolution of DNS backends.
+	//
+	// TODO(#6868): Make this field required once 'dnsResolver' is removed from
+	// the boulder-va JSON config in favor of 'dnsProvider'.
 	DNSAuthority string `validate:"omitempty,ip|hostname|hostname_port"`
 
 	// SRVLookup contains the service and domain name used to construct a SRV
-	// DNS query to lookup DNS backends. For example: if the resource record is
-	// 'unbound.service.consul', then the 'Service' is 'unbound' and the
-	// 'Domain' is 'service.consul'. The expected dNSName to be authenticated in
-	// the server certificate would be 'unbound.service.consul'.
+	// DNS query to lookup DNS backends. 'Domain' is required. 'Service' is
+	// optional and will be defaulted to 'dns' if left unspecified.
 	//
-	// Note: The 'proto' field of the SRV record MUST contain 'udp' and the
-	// 'port' field MUST be a valid port. In a Consul configuration file you
-	// would specify 'unbound.service.consul' as:
+	// Usage: If the resource record is 'unbound.service.consul', then the
+	// 'Service' is 'unbound' and the 'Domain' is 'service.consul'. The expected
+	// dNSName to be authenticated in the server certificate would be
+	// 'unbound.service.consul'. The 'proto' field of the SRV record MUST
+	// contain 'udp' and the 'port' field MUST be a valid port. In a Consul
+	// configuration file you would specify 'unbound.service.consul' as:
 	//
 	// services {
 	//   id      = "unbound-1" // Must be unique

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -237,7 +237,7 @@ type SyslogConfig struct {
 	SyslogLevel int `validate:"min=-1,max=7"`
 }
 
-// ServiceDomain contains the service and domain name the gRPC or BDNS client
+// ServiceDomain contains the service and domain name the gRPC or bdns provider
 // will use to construct a SRV DNS query to lookup backends.
 type ServiceDomain struct {
 	Service string `validate:"required"`

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -3,7 +3,7 @@
 		"userAgent": "boulder-remote-a",
 		"debugAddr": ":8011",
 		"dnsTries": 3,
-		"DNSProvider": {
+		"dnsProvider": {
 			"srvLookup": {
 				"service": "dns",
 				"domain": "service.consul"

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -3,7 +3,12 @@
 		"userAgent": "boulder-remote-a",
 		"debugAddr": ":8011",
 		"dnsTries": 3,
-		"dnsResolver": "service.consul",
+		"dnsDynamicResolver": {
+			"srvLookup": {
+				"service": "dns",
+				"domain": "service.consul"
+			}
+		},
 		"dnsTimeout": "1s",
 		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -4,6 +4,7 @@
 		"debugAddr": ":8011",
 		"dnsTries": 3,
 		"dnsProvider": {
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "dns",
 				"domain": "service.consul"

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -3,7 +3,7 @@
 		"userAgent": "boulder-remote-a",
 		"debugAddr": ":8011",
 		"dnsTries": 3,
-		"dnsDynamicResolver": {
+		"DNSProvider": {
 			"srvLookup": {
 				"service": "dns",
 				"domain": "service.consul"

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -3,7 +3,7 @@
 		"userAgent": "boulder-remote-b",
 		"debugAddr": ":8012",
 		"dnsTries": 3,
-		"dnsDynamicResolver": {
+		"DNSProvider": {
 			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "dns",

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -3,7 +3,7 @@
 		"userAgent": "boulder-remote-b",
 		"debugAddr": ":8012",
 		"dnsTries": 3,
-		"DNSProvider": {
+		"dnsProvider": {
 			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "dns",

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -3,7 +3,13 @@
 		"userAgent": "boulder-remote-b",
 		"debugAddr": ":8012",
 		"dnsTries": 3,
-		"dnsResolver": "service.consul",
+		"dnsDynamicResolver": {
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "dns",
+				"domain": "service.consul"
+			}
+		},
 		"dnsTimeout": "1s",
 		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -3,7 +3,7 @@
 		"userAgent": "boulder",
 		"debugAddr": ":8004",
 		"dnsTries": 3,
-		"DNSProvider": {
+		"dnsProvider": {
 			"dnsAuthority": "consul.service.consul:53",
 			"srvLookup": {
 				"service": "dns",

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -4,7 +4,7 @@
 		"debugAddr": ":8004",
 		"dnsTries": 3,
 		"dnsProvider": {
-			"dnsAuthority": "consul.service.consul:53",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "dns",
 				"domain": "service.consul"

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -3,7 +3,7 @@
 		"userAgent": "boulder",
 		"debugAddr": ":8004",
 		"dnsTries": 3,
-		"dnsDynamicResolver": {
+		"DNSProvider": {
 			"dnsAuthority": "consul.service.consul:53",
 			"srvLookup": {
 				"service": "dns",

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -3,7 +3,13 @@
 		"userAgent": "boulder",
 		"debugAddr": ":8004",
 		"dnsTries": 3,
-		"dnsResolver": "service.consul",
+		"dnsDynamicResolver": {
+			"dnsAuthority": "consul.service.consul:53",
+			"srvLookup": {
+				"service": "dns",
+				"domain": "service.consul"
+			}
+		},
 		"dnsTimeout": "1s",
 		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",


### PR DESCRIPTION
Deprecate `va.DNSResolver` in favor of backwards compatible `va.DNSProvider`.

Fixes #6852