### PR TITLE
Probs: simplifications and cleanup

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -2,7 +2,6 @@
 
 While Boulder attempts to implement the ACME specification ([RFC 8555]) as strictly as possible there are places at which we will diverge from the letter of the specification for various reasons. This document describes the difference between [RFC 8555] and Boulder's implementation of ACME, informally called ACMEv2 and available at https://acme-v02.api.letsencrypt.org/directory. A listing of RFC conformant design decisions that may differ from other ACME servers is listed in [implementation_details](https://github.com/letsencrypt/boulder/blob/main/docs/acme-implementation_details.md).
 
-
 Presently, Boulder diverges from the [RFC 8555] ACME spec in the following ways:
 
 ## [Section 6.3](https://tools.ietf.org/html/rfc8555#section-6.3)
@@ -17,8 +16,6 @@ For all rate-limits, Boulder includes a `Link` header to additional documentatio
 ## [Section 6.7](https://tools.ietf.org/html/rfc8555#section-6.7)
 
 Boulder uses `invalidEmail` in place of the error `invalidContact`.
-
-Boulder does not implement the `unsupportedContact` and `dnssec` errors.
 
 ## [Section 7.1.2](https://tools.ietf.org/html/rfc8555#section-7.1.2)
 

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -7,29 +7,34 @@ import (
 	"github.com/letsencrypt/boulder/identifier"
 )
 
-// Error types that can be used in ACME payloads
 const (
+	// Error types that can be used in ACME payloads. These are sorted in the
+	// same order as they are defined in RFC8555 Section 6.7. We do not implement
+	// the `compound`, `externalAccountRequired`, or `userActionRequired` errors,
+	// because we have no path that would return them.
+	AccountDoesNotExistProblem   = ProblemType("accountDoesNotExist")
+	AlreadyRevokedProblem        = ProblemType("alreadyRevoked")
+	BadCSRProblem                = ProblemType("badCSR")
+	BadNonceProblem              = ProblemType("badNonce")
+	BadPublicKeyProblem          = ProblemType("badPublicKey")
+	BadRevocationReasonProblem   = ProblemType("badRevocationReason")
+	BadSignatureAlgorithmProblem = ProblemType("badSignatureAlgorithm")
+	CAAProblem                   = ProblemType("caa")
 	ConnectionProblem            = ProblemType("connection")
+	DNSProblem                   = ProblemType("dns")
+	// TODO: Change this to InvalidContactProblem and "invalidContact".
+	InvalidEmailProblem          = ProblemType("invalidEmail")
 	MalformedProblem             = ProblemType("malformed")
+	OrderNotReadyProblem         = ProblemType("orderNotReady")
+	RateLimitedProblem           = ProblemType("rateLimited")
+	RejectedIdentifierProblem    = ProblemType("rejectedIdentifier")
 	ServerInternalProblem        = ProblemType("serverInternal")
 	TLSProblem                   = ProblemType("tls")
 	UnauthorizedProblem          = ProblemType("unauthorized")
-	RateLimitedProblem           = ProblemType("rateLimited")
-	BadNonceProblem              = ProblemType("badNonce")
-	InvalidEmailProblem          = ProblemType("invalidEmail")
-	RejectedIdentifierProblem    = ProblemType("rejectedIdentifier")
-	AccountDoesNotExistProblem   = ProblemType("accountDoesNotExist")
-	CAAProblem                   = ProblemType("caa")
-	DNSProblem                   = ProblemType("dns")
-	AlreadyRevokedProblem        = ProblemType("alreadyRevoked")
-	OrderNotReadyProblem         = ProblemType("orderNotReady")
-	BadSignatureAlgorithmProblem = ProblemType("badSignatureAlgorithm")
-	BadPublicKeyProblem          = ProblemType("badPublicKey")
-	BadRevocationReasonProblem   = ProblemType("badRevocationReason")
-	BadCSRProblem                = ProblemType("badCSR")
+	UnsupportedContactProblem    = ProblemType("unsupportedContact")
+	UnsupportedIdentifierProblem = ProblemType("unsupportedIdentifier")
 
-	V1ErrorNS = "urn:acme:error:"
-	V2ErrorNS = "urn:ietf:params:acme:error:"
+	ErrorNS = "urn:ietf:params:acme:error:"
 )
 
 // ProblemType defines the error types in the ACME protocol
@@ -71,40 +76,35 @@ func (pd *ProblemDetails) WithSubProblems(subProbs []SubProblemDetails) *Problem
 	}
 }
 
-// statusTooManyRequests is the HTTP status code meant for rate limiting
-// errors. It's not currently in the net/http library so we add it here.
-const statusTooManyRequests = 429
+// Helper functions which construct the basic RFC8555 Problem Documents, with
+// the Type already set and the Details supplied by the caller.
 
-// ProblemDetailsToStatusCode inspects the given ProblemDetails to figure out
-// what HTTP status code it should represent. It should only be used by the WFE
-// but is included in this package because of its reliance on ProblemTypes.
-func ProblemDetailsToStatusCode(prob *ProblemDetails) int {
-	if prob.HTTPStatus != 0 {
-		return prob.HTTPStatus
+// AccountDoesNotExist returns a ProblemDetails representing an
+// AccountDoesNotExistProblem error
+func AccountDoesNotExist(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       AccountDoesNotExistProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
 	}
-	switch prob.Type {
-	case
-		ConnectionProblem,
-		MalformedProblem,
-		BadSignatureAlgorithmProblem,
-		BadPublicKeyProblem,
-		TLSProblem,
-		BadNonceProblem,
-		InvalidEmailProblem,
-		RejectedIdentifierProblem,
-		AccountDoesNotExistProblem,
-		BadRevocationReasonProblem:
-		return http.StatusBadRequest
-	case ServerInternalProblem:
-		return http.StatusInternalServerError
-	case
-		UnauthorizedProblem,
-		CAAProblem:
-		return http.StatusForbidden
-	case RateLimitedProblem:
-		return statusTooManyRequests
-	default:
-		return http.StatusInternalServerError
+}
+
+// AlreadyRevoked returns a ProblemDetails with a AlreadyRevokedProblem and a 400 Bad
+// Request status code.
+func AlreadyRevoked(detail string, a ...any) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       AlreadyRevokedProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// BadCSR returns a ProblemDetails representing a BadCSRProblem.
+func BadCSR(detail string, a ...any) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       BadCSRProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
@@ -118,75 +118,9 @@ func BadNonce(detail string) *ProblemDetails {
 	}
 }
 
-// RejectedIdentifier returns a ProblemDetails with a RejectedIdentifierProblem and a 400 Bad
-// Request status code.
-func RejectedIdentifier(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       RejectedIdentifierProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// Conflict returns a ProblemDetails with a MalformedProblem and a 409 Conflict
-// status code.
-func Conflict(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       MalformedProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusConflict,
-	}
-}
-
-// AlreadyRevoked returns a ProblemDetails with a AlreadyRevokedProblem and a 400 Bad
-// Request status code.
-func AlreadyRevoked(detail string, a ...interface{}) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       AlreadyRevokedProblem,
-		Detail:     fmt.Sprintf(detail, a...),
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// Malformed returns a ProblemDetails with a MalformedProblem and a 400 Bad
-// Request status code.
-func Malformed(detail string, args ...interface{}) *ProblemDetails {
-	if len(args) > 0 {
-		detail = fmt.Sprintf(detail, args...)
-	}
-	return &ProblemDetails{
-		Type:       MalformedProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// Canceled returns a ProblemDetails with a MalformedProblem and a 408 Request
-// Timeout status code.
-func Canceled(detail string, args ...interface{}) *ProblemDetails {
-	if len(args) > 0 {
-		detail = fmt.Sprintf(detail, args...)
-	}
-	return &ProblemDetails{
-		Type:       MalformedProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusRequestTimeout,
-	}
-}
-
-// BadSignatureAlgorithm returns a ProblemDetails with a BadSignatureAlgorithmProblem
-// and a 400 Bad Request status code.
-func BadSignatureAlgorithm(detail string, a ...interface{}) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       BadSignatureAlgorithmProblem,
-		Detail:     fmt.Sprintf(detail, a...),
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
 // BadPublicKey returns a ProblemDetails with a BadPublicKeyProblem and a 400 Bad
 // Request status code.
-func BadPublicKey(detail string, a ...interface{}) *ProblemDetails {
+func BadPublicKey(detail string, a ...any) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       BadPublicKeyProblem,
 		Detail:     fmt.Sprintf(detail, a...),
@@ -194,13 +128,102 @@ func BadPublicKey(detail string, a ...interface{}) *ProblemDetails {
 	}
 }
 
-// NotFound returns a ProblemDetails with a MalformedProblem and a 404 Not Found
-// status code.
-func NotFound(detail string) *ProblemDetails {
+// BadRevocationReason returns a ProblemDetails representing
+// a BadRevocationReasonProblem
+func BadRevocationReason(detail string, a ...any) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       BadRevocationReasonProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// BadSignatureAlgorithm returns a ProblemDetails with a BadSignatureAlgorithmProblem
+// and a 400 Bad Request status code.
+func BadSignatureAlgorithm(detail string, a ...any) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       BadSignatureAlgorithmProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// CAA returns a ProblemDetails representing a CAAProblem
+func CAA(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       CAAProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+// Connection returns a ProblemDetails representing a ConnectionProblem
+// error
+func Connection(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       ConnectionProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// DNS returns a ProblemDetails representing a DNSProblem
+func DNS(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       DNSProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// InvalidEmail returns a ProblemDetails representing an InvalidEmailProblem.
+// TODO: Change this to InvalidContact.
+func InvalidEmail(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       InvalidEmailProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// Malformed returns a ProblemDetails with a MalformedProblem and a 400 Bad
+// Request status code.
+func Malformed(detail string, a ...any) *ProblemDetails {
+	if len(a) > 0 {
+		detail = fmt.Sprintf(detail, a...)
+	}
 	return &ProblemDetails{
 		Type:       MalformedProblem,
 		Detail:     detail,
-		HTTPStatus: http.StatusNotFound,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// OrderNotReady returns a ProblemDetails representing a OrderNotReadyProblem
+func OrderNotReady(detail string, a ...any) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       OrderNotReadyProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+// RateLimited returns a ProblemDetails representing a RateLimitedProblem error
+func RateLimited(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       RateLimitedProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusTooManyRequests,
+	}
+}
+
+// RejectedIdentifier returns a ProblemDetails with a RejectedIdentifierProblem and a 400 Bad
+// Request status code.
+func RejectedIdentifier(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       RejectedIdentifierProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
 	}
 }
 
@@ -214,6 +237,15 @@ func ServerInternal(detail string) *ProblemDetails {
 	}
 }
 
+// TLS returns a ProblemDetails representing a TLSProblem error
+func TLS(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       TLSProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
 // Unauthorized returns a ProblemDetails with an UnauthorizedProblem and a 403
 // Forbidden status code.
 func Unauthorized(detail string) *ProblemDetails {
@@ -224,13 +256,49 @@ func Unauthorized(detail string) *ProblemDetails {
 	}
 }
 
-// MethodNotAllowed returns a ProblemDetails representing a disallowed HTTP
-// method error.
-func MethodNotAllowed() *ProblemDetails {
+// UnsupportedContact returns a ProblemDetails representing an
+// UnsupportedContactProblem
+func UnsupportedContact(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       UnsupportedContactProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// UnsupportedIdentifier returns a ProblemDetails representing an
+// UnsupportedIdentifierProblem
+func UnsupportedIdentifier(detail string, a ...any) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       UnsupportedIdentifierProblem,
+		Detail:     fmt.Sprintf(detail, a...),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// Additional helper functions that return variations on MalformedProblem with
+// different HTTP status codes set.
+
+// Canceled returns a ProblemDetails with a MalformedProblem and a 408 Request
+// Timeout status code.
+func Canceled(detail string, a ...any) *ProblemDetails {
+	if len(a) > 0 {
+		detail = fmt.Sprintf(detail, a...)
+	}
 	return &ProblemDetails{
 		Type:       MalformedProblem,
-		Detail:     "Method not allowed",
-		HTTPStatus: http.StatusMethodNotAllowed,
+		Detail:     detail,
+		HTTPStatus: http.StatusRequestTimeout,
+	}
+}
+
+// Conflict returns a ProblemDetails with a MalformedProblem and a 409 Conflict
+// status code.
+func Conflict(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       MalformedProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusConflict,
 	}
 }
 
@@ -254,96 +322,22 @@ func InvalidContentType(detail string) *ProblemDetails {
 	}
 }
 
-// InvalidEmail returns a ProblemDetails representing an invalid email address
-// error
-func InvalidEmail(detail string) *ProblemDetails {
+// MethodNotAllowed returns a ProblemDetails representing a disallowed HTTP
+// method error.
+func MethodNotAllowed() *ProblemDetails {
 	return &ProblemDetails{
-		Type:       InvalidEmailProblem,
+		Type:       MalformedProblem,
+		Detail:     "Method not allowed",
+		HTTPStatus: http.StatusMethodNotAllowed,
+	}
+}
+
+// NotFound returns a ProblemDetails with a MalformedProblem and a 404 Not Found
+// status code.
+func NotFound(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       MalformedProblem,
 		Detail:     detail,
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// ConnectionFailure returns a ProblemDetails representing a ConnectionProblem
-// error
-func ConnectionFailure(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       ConnectionProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// RateLimited returns a ProblemDetails representing a RateLimitedProblem error
-func RateLimited(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       RateLimitedProblem,
-		Detail:     detail,
-		HTTPStatus: statusTooManyRequests,
-	}
-}
-
-// TLSError returns a ProblemDetails representing a TLSProblem error
-func TLSError(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       TLSProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// AccountDoesNotExist returns a ProblemDetails representing an
-// AccountDoesNotExistProblem error
-func AccountDoesNotExist(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       AccountDoesNotExistProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// CAA returns a ProblemDetails representing a CAAProblem
-func CAA(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       CAAProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusForbidden,
-	}
-}
-
-// DNS returns a ProblemDetails representing a DNSProblem
-func DNS(detail string) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       DNSProblem,
-		Detail:     detail,
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// OrderNotReady returns a ProblemDetails representing a OrderNotReadyProblem
-func OrderNotReady(detail string, a ...interface{}) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       OrderNotReadyProblem,
-		Detail:     fmt.Sprintf(detail, a...),
-		HTTPStatus: http.StatusForbidden,
-	}
-}
-
-// BadRevocationReason returns a ProblemDetails representing
-// a BadRevocationReasonProblem
-func BadRevocationReason(detail string, a ...interface{}) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       BadRevocationReasonProblem,
-		Detail:     fmt.Sprintf(detail, a...),
-		HTTPStatus: http.StatusBadRequest,
-	}
-}
-
-// BadCSR returns a ProblemDetails representing a BadCSRProblem.
-func BadCSR(detail string, a ...interface{}) *ProblemDetails {
-	return &ProblemDetails{
-		Type:       BadCSRProblem,
-		Detail:     fmt.Sprintf(detail, a...),
-		HTTPStatus: http.StatusBadRequest,
+		HTTPStatus: http.StatusNotFound,
 	}
 }

--- a/probs/probs_test.go
+++ b/probs/probs_test.go
@@ -18,34 +18,6 @@ func TestProblemDetails(t *testing.T) {
 	test.AssertEquals(t, pd.Error(), "malformed :: Wat? o.O")
 }
 
-func TestProblemDetailsToStatusCode(t *testing.T) {
-	testCases := []struct {
-		pb         *ProblemDetails
-		statusCode int
-	}{
-		{&ProblemDetails{Type: ConnectionProblem}, http.StatusBadRequest},
-		{&ProblemDetails{Type: MalformedProblem}, http.StatusBadRequest},
-		{&ProblemDetails{Type: ServerInternalProblem}, http.StatusInternalServerError},
-		{&ProblemDetails{Type: TLSProblem}, http.StatusBadRequest},
-		{&ProblemDetails{Type: UnauthorizedProblem}, http.StatusForbidden},
-		{&ProblemDetails{Type: RateLimitedProblem}, statusTooManyRequests},
-		{&ProblemDetails{Type: BadNonceProblem}, http.StatusBadRequest},
-		{&ProblemDetails{Type: InvalidEmailProblem}, http.StatusBadRequest},
-		{&ProblemDetails{Type: "foo"}, http.StatusInternalServerError},
-		{&ProblemDetails{Type: "foo", HTTPStatus: 200}, 200},
-		{&ProblemDetails{Type: ConnectionProblem, HTTPStatus: 200}, 200},
-		{&ProblemDetails{Type: AccountDoesNotExistProblem}, http.StatusBadRequest},
-		{&ProblemDetails{Type: BadRevocationReasonProblem}, http.StatusBadRequest},
-	}
-
-	for _, c := range testCases {
-		p := ProblemDetailsToStatusCode(c.pb)
-		if c.statusCode != p {
-			t.Errorf("Incorrect status code for %s. Expected %d, got %d", c.pb.Type, c.statusCode, p)
-		}
-	}
-}
-
 func TestProblemDetailsConvenience(t *testing.T) {
 	testCases := []struct {
 		pb           *ProblemDetails
@@ -54,13 +26,13 @@ func TestProblemDetailsConvenience(t *testing.T) {
 		detail       string
 	}{
 		{InvalidEmail("invalid email detail"), InvalidEmailProblem, http.StatusBadRequest, "invalid email detail"},
-		{ConnectionFailure("connection failure detail"), ConnectionProblem, http.StatusBadRequest, "connection failure detail"},
+		{Connection("connection failure detail"), ConnectionProblem, http.StatusBadRequest, "connection failure detail"},
 		{Malformed("malformed detail"), MalformedProblem, http.StatusBadRequest, "malformed detail"},
 		{ServerInternal("internal error detail"), ServerInternalProblem, http.StatusInternalServerError, "internal error detail"},
 		{Unauthorized("unauthorized detail"), UnauthorizedProblem, http.StatusForbidden, "unauthorized detail"},
-		{RateLimited("rate limited detail"), RateLimitedProblem, statusTooManyRequests, "rate limited detail"},
+		{RateLimited("rate limited detail"), RateLimitedProblem, http.StatusTooManyRequests, "rate limited detail"},
 		{BadNonce("bad nonce detail"), BadNonceProblem, http.StatusBadRequest, "bad nonce detail"},
-		{TLSError("TLS error detail"), TLSProblem, http.StatusBadRequest, "TLS error detail"},
+		{TLS("TLS error detail"), TLSProblem, http.StatusBadRequest, "TLS error detail"},
 		{RejectedIdentifier("rejected identifier detail"), RejectedIdentifierProblem, http.StatusBadRequest, "rejected identifier detail"},
 		{AccountDoesNotExist("no account detail"), AccountDoesNotExistProblem, http.StatusBadRequest, "no account detail"},
 		{BadRevocationReason("only reason xxx is supported"), BadRevocationReasonProblem, http.StatusBadRequest, "only reason xxx is supported"},
@@ -91,7 +63,7 @@ func TestWithSubProblems(t *testing.T) {
 	topProb := &ProblemDetails{
 		Type:       RateLimitedProblem,
 		Detail:     "don't you think you have enough certificates already?",
-		HTTPStatus: statusTooManyRequests,
+		HTTPStatus: http.StatusTooManyRequests,
 	}
 	subProbs := []SubProblemDetails{
 		{
@@ -99,7 +71,7 @@ func TestWithSubProblems(t *testing.T) {
 			ProblemDetails: ProblemDetails{
 				Type:       RateLimitedProblem,
 				Detail:     "don't you think you have enough certificates already?",
-				HTTPStatus: statusTooManyRequests,
+				HTTPStatus: http.StatusTooManyRequests,
 			},
 		},
 		{
@@ -124,7 +96,7 @@ func TestWithSubProblems(t *testing.T) {
 		ProblemDetails: ProblemDetails{
 			Type:       RateLimitedProblem,
 			Detail:     "yet another rate limit err",
-			HTTPStatus: statusTooManyRequests,
+			HTTPStatus: http.StatusTooManyRequests,
 		},
 	}
 	outResult = outResult.WithSubProblems([]SubProblemDetails{anotherSubProb})

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -92,7 +92,7 @@ func TestAuthzModel(t *testing.T) {
 	test.AssertNotError(t, err, "modelToAuthzPB failed")
 	test.AssertDeepEquals(t, authzPB.Challenges, authzPBOut.Challenges)
 
-	validationErr := probs.ConnectionFailure("weewoo")
+	validationErr := probs.Connection("weewoo")
 	authzPB.Challenges[0].Status = string(core.StatusInvalid)
 	authzPB.Challenges[0].Error, err = grpc.ProblemDetailsToPB(validationErr)
 	test.AssertNotError(t, err, "grpc.ProblemDetailsToPB failed")

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2349,7 +2349,7 @@ func TestFinalizeAuthorization2(t *testing.T) {
 	test.AssertEquals(t, time.Unix(0, dbVer.Challenges[0].Validated).UTC(), fc.Now().UTC())
 
 	authzID = createPendingAuthorization(t, sa, "aaa", fc.Now().Add(time.Hour))
-	prob, _ := bgrpc.ProblemDetailsToPB(probs.ConnectionFailure("it went bad captain"))
+	prob, _ := bgrpc.ProblemDetailsToPB(probs.Connection("it went bad captain"))
 
 	_, err = sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id: authzID,

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -818,7 +818,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Timeout for host",
 			Host: "example.com",
 			Path: "/timeout",
-			ExpectedProblem: probs.ConnectionFailure(
+			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching http://example.com/timeout: " +
 					"Timeout after connect (your server may be slow or overloaded)"),
 			ExpectedRecords: []core.ValidationRecord{
@@ -835,7 +835,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Redirect loop",
 			Host: "example.com",
 			Path: "/loop",
-			ExpectedProblem: probs.ConnectionFailure(fmt.Sprintf(
+			ExpectedProblem: probs.Connection(fmt.Sprintf(
 				"127.0.0.1: Fetching http://example.com:%d/loop: Redirect loop detected", httpPort)),
 			ExpectedRecords: expectedLoopRecords,
 		},
@@ -843,7 +843,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Too many redirects",
 			Host: "example.com",
 			Path: "/max-redirect/0",
-			ExpectedProblem: probs.ConnectionFailure(fmt.Sprintf(
+			ExpectedProblem: probs.Connection(fmt.Sprintf(
 				"127.0.0.1: Fetching http://example.com:%d/max-redirect/12: Too many redirects", httpPort)),
 			ExpectedRecords: expectedTooManyRedirRecords,
 		},
@@ -851,7 +851,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Redirect to bad protocol",
 			Host: "example.com",
 			Path: "/redir-bad-proto",
-			ExpectedProblem: probs.ConnectionFailure(
+			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching gopher://example.com: Invalid protocol scheme in " +
 					`redirect target. Only "http" and "https" protocol schemes ` +
 					`are supported, not "gopher"`),
@@ -869,7 +869,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Redirect to bad port",
 			Host: "example.com",
 			Path: "/redir-bad-port",
-			ExpectedProblem: probs.ConnectionFailure(fmt.Sprintf(
+			ExpectedProblem: probs.Connection(fmt.Sprintf(
 				"127.0.0.1: Fetching https://example.com:1987: Invalid port in redirect target. "+
 					"Only ports %d and 443 are supported, not 1987", httpPort)),
 			ExpectedRecords: []core.ValidationRecord{
@@ -886,7 +886,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Redirect to bad host (bare IP address)",
 			Host: "example.com",
 			Path: "/redir-bad-host",
-			ExpectedProblem: probs.ConnectionFailure(
+			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching https://127.0.0.1: Invalid host in redirect target " +
 					`"127.0.0.1". Only domain names are supported, not IP addresses`),
 			ExpectedRecords: []core.ValidationRecord{
@@ -903,7 +903,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Redirect to long path",
 			Host: "example.com",
 			Path: "/redir-path-too-long",
-			ExpectedProblem: probs.ConnectionFailure(
+			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching https://example.com/this-is-too-long-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789: Redirect target too long"),
 			ExpectedRecords: []core.ValidationRecord{
 				{
@@ -935,7 +935,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "HTTP status code 303 redirect",
 			Host: "example.com",
 			Path: "/303-see-other",
-			ExpectedProblem: probs.ConnectionFailure(
+			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching http://example.org/303-see-other: received disallowed redirect status code"),
 			ExpectedRecords: []core.ValidationRecord{
 				{
@@ -968,7 +968,7 @@ func TestFetchHTTP(t *testing.T) {
 			Name: "Broken IPv6 only",
 			Host: "ipv6.localhost",
 			Path: "/ok",
-			ExpectedProblem: probs.ConnectionFailure(
+			ExpectedProblem: probs.Connection(
 				"::1: Fetching http://ipv6.localhost/ok: Error getting validation data"),
 			ExpectedRecords: []core.ValidationRecord{
 				{
@@ -1411,7 +1411,7 @@ func TestHTTPRedirectLookup(t *testing.T) {
 	_, err := va.validateHTTP01(ctx, dnsi("localhost.com"), chall)
 	test.AssertError(t, err, chall.Token)
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost.com: \[127.0.0.1\]`)), 1)
-	test.AssertDeepEquals(t, err, probs.ConnectionFailure(`127.0.0.1: Fetching http://invalid.invalid/path: Invalid hostname in redirect target, must end in IANA registered TLD`))
+	test.AssertDeepEquals(t, err, probs.Connection(`127.0.0.1: Fetching http://invalid.invalid/path: Invalid hostname in redirect target, must end in IANA registered TLD`))
 
 	log.Clear()
 	setChallengeToken(&chall, pathReLookup)

--- a/va/va.go
+++ b/va/va.go
@@ -320,30 +320,30 @@ func detailedError(err error) *probs.ProblemDetails {
 		if fmt.Sprintf("%T", netOpErr.Err) == "tls.alert" {
 			// All the tls.alert error strings are reasonable to hand back to a
 			// user. Confirmed against Go 1.8.
-			return probs.TLSError(netOpErr.Error())
+			return probs.TLS(netOpErr.Error())
 		} else if netOpErr.Timeout() && netOpErr.Op == "dial" {
-			return probs.ConnectionFailure("Timeout during connect (likely firewall problem)")
+			return probs.Connection("Timeout during connect (likely firewall problem)")
 		} else if netOpErr.Timeout() {
-			return probs.ConnectionFailure(fmt.Sprintf("Timeout during %s (your server may be slow or overloaded)", netOpErr.Op))
+			return probs.Connection(fmt.Sprintf("Timeout during %s (your server may be slow or overloaded)", netOpErr.Op))
 		}
 	}
 	var syscallErr *os.SyscallError
 	if errors.As(err, &syscallErr) {
 		switch syscallErr.Err {
 		case syscall.ECONNREFUSED:
-			return probs.ConnectionFailure("Connection refused")
+			return probs.Connection("Connection refused")
 		case syscall.ENETUNREACH:
-			return probs.ConnectionFailure("Network unreachable")
+			return probs.Connection("Network unreachable")
 		case syscall.ECONNRESET:
-			return probs.ConnectionFailure("Connection reset by peer")
+			return probs.Connection("Connection reset by peer")
 		}
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
-		return probs.ConnectionFailure("Timeout after connect (your server may be slow or overloaded)")
+		return probs.Connection("Timeout after connect (your server may be slow or overloaded)")
 	}
 	if errors.Is(err, berrors.ConnectionFailure) {
-		return probs.ConnectionFailure(err.Error())
+		return probs.Connection(err.Error())
 	}
 	if errors.Is(err, berrors.Unauthorized) {
 		return probs.Unauthorized(err.Error())
@@ -353,9 +353,9 @@ func detailedError(err error) *probs.ProblemDetails {
 	}
 
 	if h2SettingsFrameErrRegex.MatchString(err.Error()) {
-		return probs.ConnectionFailure("Server is speaking HTTP/2 over HTTP")
+		return probs.Connection("Server is speaking HTTP/2 over HTTP")
 	}
-	return probs.ConnectionFailure("Error getting validation data")
+	return probs.Connection("Error getting validation data")
 }
 
 // validate performs a challenge validation and, in parallel,

--- a/web/send_error.go
+++ b/web/send_error.go
@@ -14,21 +14,28 @@ import (
 //   - Adds both the external and the internal error to a RequestEvent.
 //   - If the ProblemDetails provided is a ServerInternalProblem, audit logs the
 //     internal error.
-//   - Prefixes the Type field of the ProblemDetails with a namespace.
+//   - Prefixes the Type field of the ProblemDetails with the RFC8555 namespace.
 //   - Sends an HTTP response containing the error and an error code to the user.
 //
 // The internal error (ierr) may be nil if no information beyond the
 // ProblemDetails is needed for internal debugging.
 func SendError(
 	log blog.Logger,
-	namespace string,
 	response http.ResponseWriter,
 	logEvent *RequestEvent,
 	prob *probs.ProblemDetails,
 	ierr error,
 ) {
-	// Determine the HTTP status code to use for this problem
-	code := probs.ProblemDetailsToStatusCode(prob)
+	// Write the JSON problem response
+	response.Header().Set("Content-Type", "application/problem+json")
+	if prob.HTTPStatus != 0 {
+		response.WriteHeader(prob.HTTPStatus)
+	} else {
+		// All problems should have an HTTPStatus set, because all of the functions
+		// in the probs package which construct a problem set one. A problem details
+		// object getting to this point without a status set is an error.
+		response.WriteHeader(http.StatusInternalServerError)
+	}
 
 	// Record details to the log event
 	logEvent.Error = fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, prob.Detail)
@@ -43,20 +50,17 @@ func SendError(
 		logEvent.AddError(fmt.Sprintf("%s", ierr))
 	}
 
-	// Set the proper namespace for the problem and any
-	// sub-problems
-	prob.Type = probs.ProblemType(namespace) + prob.Type
+	// Set the proper namespace for the problem and any sub-problems.
+	prob.Type = probs.ProblemType(probs.ErrorNS) + prob.Type
 	for i := range prob.SubProblems {
-		prob.SubProblems[i].Type = prob.Type
+		prob.SubProblems[i].Type = probs.ProblemType(probs.ErrorNS) + prob.SubProblems[i].Type
 	}
+
 	problemDoc, err := json.MarshalIndent(prob, "", "  ")
 	if err != nil {
 		log.AuditErrf("Could not marshal error message: %s - %+v", err, prob)
 		problemDoc = []byte("{\"detail\": \"Problem marshalling error message.\"}")
 	}
 
-	// Write the JSON problem response
-	response.Header().Set("Content-Type", "application/problem+json")
-	response.WriteHeader(code)
 	response.Write(problemDoc)
 }

--- a/web/send_error_test.go
+++ b/web/send_error_test.go
@@ -35,16 +35,16 @@ func TestSendErrorSubProblemNamespace(t *testing.T) {
 		}),
 		"dfoop",
 	)
-	SendError(log.NewMock(), "namespace:test:", rw, &RequestEvent{}, prob, errors.New("it bad"))
+	SendError(log.NewMock(), rw, &RequestEvent{}, prob, errors.New("it bad"))
 
 	body := rw.Body.String()
 	test.AssertUnmarshaledEquals(t, body, `{
-		"type": "namespace:test:malformed",
+		"type": "urn:ietf:params:acme:error:malformed",
 		"detail": "dfoop :: bad",
 		"status": 400,
 		"subproblems": [
 		  {
-			"type": "namespace:test:malformed",
+			"type": "urn:ietf:params:acme:error:malformed",
 			"detail": "dfoop :: nop",
 			"status": 400,
 			"identifier": {
@@ -53,7 +53,7 @@ func TestSendErrorSubProblemNamespace(t *testing.T) {
 			}
 		  },
 		  {
-			"type": "namespace:test:malformed",
+			"type": "urn:ietf:params:acme:error:malformed",
 			"detail": "dfoop :: nah",
 			"status": 400,
 			"identifier": {
@@ -90,7 +90,7 @@ func TestSendErrorSubProbLogging(t *testing.T) {
 		"dfoop",
 	)
 	logEvent := RequestEvent{}
-	SendError(log.NewMock(), "namespace:test:", rw, &logEvent, prob, errors.New("it bad"))
+	SendError(log.NewMock(), rw, &logEvent, prob, errors.New("it bad"))
 
 	test.AssertEquals(t, logEvent.Error, `400 :: malformed :: dfoop :: bad ["example.com :: malformed :: dfoop :: nop", "what about example.com :: malformed :: dfoop :: nah"]`)
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -605,7 +605,7 @@ func (wfe *WebFrontEndImpl) sendError(response http.ResponseWriter, logEvent *we
 		}
 	}
 	wfe.stats.httpErrorCount.With(prometheus.Labels{"type": string(prob.Type)}).Inc()
-	web.SendError(wfe.log, probs.V2ErrorNS, response, logEvent, prob, ierr)
+	web.SendError(wfe.log, response, logEvent, prob, ierr)
 }
 
 func link(url, relation string) string {
@@ -1113,13 +1113,11 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 	// ACMEv2 never sends the KeyAuthorization back in a challenge object.
 	challenge.ProvidedKeyAuthorization = ""
 
-	// Historically the Type field of a problem was always prefixed with a static
-	// error namespace. To support the V2 API and migrating to the correct IETF
-	// namespace we now prefix the Type with the correct namespace at runtime when
-	// we write the problem JSON to the user. We skip this process if the
-	// challenge error type has already been prefixed with the V1ErrorNS.
-	if challenge.Error != nil && !strings.HasPrefix(string(challenge.Error.Type), probs.V1ErrorNS) {
-		challenge.Error.Type = probs.V2ErrorNS + challenge.Error.Type
+	// Internally, we store challege error problems with just the short form (e.g.
+	// "CAA") of the problem type. But for external display, we need to prefix
+	// the error type with the RFC8555 ACME Error namespace.
+	if challenge.Error != nil {
+		challenge.Error.Type = probs.ErrorNS + challenge.Error.Type
 	}
 
 	// If the authz has been marked invalid, consider all challenges on that authz
@@ -1930,7 +1928,7 @@ func (wfe *WebFrontEndImpl) orderToOrderJSON(request *http.Request, order *corep
 				"proto buf prob to problem details: %q", order.Id, err)
 		}
 		respObj.Error = prob
-		respObj.Error.Type = probs.V2ErrorNS + respObj.Error.Type
+		respObj.Error.Type = probs.ErrorNS + respObj.Error.Type
 	}
 	for _, v2ID := range order.V2Authorizations {
 		respObj.Authorizations = append(respObj.Authorizations, web.RelativeEndpoint(request, fmt.Sprintf("%s%d", authzPath, v2ID)))

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -41,6 +41,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
+	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
@@ -465,7 +466,7 @@ func TestHandleFunc(t *testing.T) {
 			test.AssertEquals(t, sortHeader(rw.Header().Get("Allow")), sortHeader(strings.Join(addHeadIfGet(c.allowed), ", ")))
 			test.AssertUnmarshaledEquals(t,
 				rw.Body.String(),
-				`{"type":"`+probs.V2ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
+				`{"type":"`+probs.ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
 		}
 		if c.reqMethod == "GET" && c.pattern != newNoncePath {
 			nonce := rw.Header().Get("Replay-Nonce")
@@ -489,7 +490,7 @@ func TestHandleFunc(t *testing.T) {
 	// Disallowed method returns error JSON in body
 	runWrappedHandler(&http.Request{Method: "PUT"}, "/test", "GET", "POST")
 	test.AssertEquals(t, rw.Header().Get("Content-Type"), "application/problem+json")
-	test.AssertUnmarshaledEquals(t, rw.Body.String(), `{"type":"`+probs.V2ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
+	test.AssertUnmarshaledEquals(t, rw.Body.String(), `{"type":"`+probs.ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
 	test.AssertEquals(t, sortHeader(rw.Header().Get("Allow")), "GET, HEAD, POST")
 
 	// Disallowed method special case: response to HEAD has got no body
@@ -503,7 +504,7 @@ func TestHandleFunc(t *testing.T) {
 	test.AssertEquals(t, rw.Code, http.StatusMethodNotAllowed)
 	test.AssertEquals(t, rw.Header().Get("Content-Type"), "application/problem+json")
 	test.AssertEquals(t, rw.Header().Get("Allow"), "POST")
-	test.AssertUnmarshaledEquals(t, rw.Body.String(), `{"type":"`+probs.V2ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
+	test.AssertUnmarshaledEquals(t, rw.Body.String(), `{"type":"`+probs.ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
 
 	wfe.AllowOrigins = []string{"*"}
 	testOrigin := "https://example.com"
@@ -1132,25 +1133,25 @@ func TestChallenge(t *testing.T) {
 			Name:           "Expired challenge",
 			Request:        post("3/-ZfxEw"),
 			ExpectedStatus: http.StatusNotFound,
-			ExpectedBody:   `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Expired authorization","status":404}`,
+			ExpectedBody:   `{"type":"` + probs.ErrorNS + `malformed","detail":"Expired authorization","status":404}`,
 		},
 		{
 			Name:           "Missing challenge",
 			Request:        post("1/"),
 			ExpectedStatus: http.StatusNotFound,
-			ExpectedBody:   `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No such challenge","status":404}`,
+			ExpectedBody:   `{"type":"` + probs.ErrorNS + `malformed","detail":"No such challenge","status":404}`,
 		},
 		{
 			Name:           "Unspecified database error",
 			Request:        post("4/-ZfxEw"),
 			ExpectedStatus: http.StatusInternalServerError,
-			ExpectedBody:   `{"type":"` + probs.V2ErrorNS + `serverInternal","detail":"Problem getting authorization","status":500}`,
+			ExpectedBody:   `{"type":"` + probs.ErrorNS + `serverInternal","detail":"Problem getting authorization","status":500}`,
 		},
 		{
 			Name:           "POST-as-GET, wrong owner",
 			Request:        postAsGet(1, "5/-ZfxEw", ""),
 			ExpectedStatus: http.StatusForbidden,
-			ExpectedBody:   `{"type":"` + probs.V2ErrorNS + `unauthorized","detail":"User account ID doesn't match account ID in authorization","status":403}`,
+			ExpectedBody:   `{"type":"` + probs.ErrorNS + `unauthorized","detail":"User account ID doesn't match account ID in authorization","status":403}`,
 		},
 		{
 			Name:           "Valid POST-as-GET",
@@ -1254,7 +1255,7 @@ func TestBadNonce(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to sign body")
 	wfe.NewAccount(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath("nonce", result.FullSerialize()))
-	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.V2ErrorNS+`badNonce","detail":"JWS has no anti-replay nonce","status":400}`)
+	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.ErrorNS+`badNonce","detail":"JWS has no anti-replay nonce","status":400}`)
 }
 
 func TestNewECDSAAccount(t *testing.T) {
@@ -1358,7 +1359,7 @@ func TestEmptyAccount(t *testing.T) {
 
 	responseBody := responseWriter.Body.String()
 	// There should be no error
-	test.AssertNotContains(t, responseBody, probs.V2ErrorNS)
+	test.AssertNotContains(t, responseBody, probs.ErrorNS)
 
 	// We should get back a populated Account
 	var acct core.Registration
@@ -1403,19 +1404,19 @@ func TestNewAccount(t *testing.T) {
 					"Content-Type":   {expectedJWSContentType},
 				},
 			},
-			`{"type":"` + probs.V2ErrorNS + `malformed","detail":"No body on POST","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"No body on POST","status":400}`,
 		},
 
 		// POST, but body that isn't valid JWS
 		{
 			makePostRequestWithPath(newAcctPath, "hi"),
-			`{"type":"` + probs.V2ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
 		},
 
 		// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 		{
 			makePostRequestWithPath(newAcctPath, fooBody),
-			`{"type":"` + probs.V2ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 
 		// Same signed body, but payload modified by one byte, breaking signature.
@@ -1423,11 +1424,11 @@ func TestNewAccount(t *testing.T) {
 		{
 			makePostRequestWithPath(newAcctPath,
 				`{"payload":"Zm9x","protected":"eyJhbGciOiJSUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoicW5BUkxyVDdYejRnUmNLeUxkeWRtQ3ItZXk5T3VQSW1YNFg0MHRoazNvbjI2RmtNem5SM2ZSanM2NmVMSzdtbVBjQlo2dU9Kc2VVUlU2d0FhWk5tZW1vWXgxZE12cXZXV0l5aVFsZUhTRDdROHZCcmhSNnVJb080akF6SlpSLUNoelp1U0R0N2lITi0zeFVWc3B1NVhHd1hVX01WSlpzaFR3cDRUYUZ4NWVsSElUX09iblR2VE9VM1hoaXNoMDdBYmdaS21Xc1ZiWGg1cy1DcklpY1U0T2V4SlBndW5XWl9ZSkp1ZU9LbVR2bkxsVFY0TXpLUjJvWmxCS1oyN1MwLVNmZFZfUUR4X3lkbGU1b01BeUtWdGxBVjM1Y3lQTUlzWU53Z1VHQkNkWV8yVXppNWVYMGxUYzdNUFJ3ejZxUjFraXAtaTU5VmNHY1VRZ3FIVjZGeXF3IiwiZSI6IkFRQUIifSwia2lkIjoiIiwibm9uY2UiOiJyNHpuenZQQUVwMDlDN1JwZUtYVHhvNkx3SGwxZVBVdmpGeXhOSE1hQnVvIiwidXJsIjoiaHR0cDovL2xvY2FsaG9zdC9hY21lL25ldy1yZWcifQ","signature":"jcTdxSygm_cvD7KbXqsxgnoPApCTSkV4jolToSOd2ciRkg5W7Yl0ZKEEKwOc-dYIbQiwGiDzisyPCicwWsOUA1WSqHylKvZ3nxSMc6KtwJCW2DaOqcf0EEjy5VjiZJUrOt2c-r6b07tbn8sfOJKwlF2lsOeGi4s-rtvvkeQpAU-AWauzl9G4bv2nDUeCviAZjHx_PoUC-f9GmZhYrbDzAvXZ859ktM6RmMeD0OqPN7bhAeju2j9Gl0lnryZMtq2m0J2m1ucenQBL1g4ZkP1JiJvzd2cAz5G7Ftl2YeJJyWhqNd3qq0GVOt1P11s8PTGNaSoM0iR9QfUxT9A6jxARtg"}`),
-			`{"type":"` + probs.V2ErrorNS + `malformed","detail":"JWS verification error","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"JWS verification error","status":400}`,
 		},
 		{
 			makePostRequestWithPath(newAcctPath, wrongAgreementBody),
-			`{"type":"` + probs.V2ErrorNS + `malformed","detail":"must agree to terms of service","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"must agree to terms of service","status":400}`,
 		},
 	}
 	for _, rt := range acctErrTests {
@@ -1551,7 +1552,7 @@ func TestGetAuthorization(t *testing.T) {
 	})
 	test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`malformed","detail":"Expired authorization","status":404}`)
+		`{"type":"`+probs.ErrorNS+`malformed","detail":"Expired authorization","status":404}`)
 	responseWriter.Body.Reset()
 
 	// Ensure that a valid authorization can't be reached with an invalid URL
@@ -1560,7 +1561,7 @@ func TestGetAuthorization(t *testing.T) {
 		Method: "GET",
 	})
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`malformed","detail":"Invalid authorization ID","status":400}`)
+		`{"type":"`+probs.ErrorNS+`malformed","detail":"Invalid authorization ID","status":400}`)
 
 	_, _, jwsBody := signer.byKeyID(1, nil, "http://localhost/1", "")
 	postAsGet := makePostRequestWithPath("1", jwsBody)
@@ -1607,16 +1608,45 @@ func TestAuthorization500(t *testing.T) {
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), expected)
 }
 
+// SAWithFailedChallenges is a mocks.StorageAuthority that has
+// a `GetAuthorization` implementation that can return authorizations with
+// failed challenges.
+type SAWithFailedChallenges struct {
+	mocks.StorageAuthorityReadOnly
+	Clk clock.FakeClock
+}
+
+func (sa *SAWithFailedChallenges) GetAuthorization2(ctx context.Context, id *sapb.AuthorizationID2, _ ...grpc.CallOption) (*corepb.Authorization, error) {
+	authz := core.Authorization{
+		ID:             "55",
+		Status:         core.StatusValid,
+		RegistrationID: 1,
+		Identifier:     identifier.DNSIdentifier("not-an-example.com"),
+		Challenges: []core.Challenge{
+			{
+				Status: core.StatusInvalid,
+				Type:   "dns",
+				Token:  "exampleToken",
+				Error: &probs.ProblemDetails{
+					Type:       "things:are:whack",
+					Detail:     "whack attack",
+					HTTPStatus: 555,
+				},
+			},
+		},
+	}
+	exp := sa.Clk.Now().AddDate(100, 0, 0)
+	authz.Expires = &exp
+	return bgrpc.AuthzToPB(authz)
+}
+
 // TestAuthorizationChallengeNamespace tests that the runtime prefixing of
 // Challenge Problem Types works as expected
 func TestAuthorizationChallengeNamespace(t *testing.T) {
 	wfe, clk, _ := setupWFE(t)
 
-	mockSA := &mocks.SAWithFailedChallenges{Clk: clk}
-	wfe.sa = mockSA
+	wfe.sa = &SAWithFailedChallenges{Clk: clk}
 
-	// For "oldNS" the SA mock returns an authorization with a failed challenge
-	// that has an error with the type already prefixed by the v1 error NS
 	responseWriter := httptest.NewRecorder()
 	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
 		Method: "GET",
@@ -1627,22 +1657,8 @@ func TestAuthorizationChallengeNamespace(t *testing.T) {
 	err := json.Unmarshal(responseWriter.Body.Bytes(), &authz)
 	test.AssertNotError(t, err, "Couldn't unmarshal returned authorization object")
 	test.AssertEquals(t, len(authz.Challenges), 1)
-	// The Challenge Error Type should have its prefix unmodified
-	test.AssertEquals(t, string(authz.Challenges[0].Error.Type), probs.V1ErrorNS+"things:are:whack")
-
-	// For "failed" the SA mock returns an authorization with a failed challenge
-	// that has an error with the type not prefixed by an error namespace.
-	responseWriter = httptest.NewRecorder()
-	wfe.Authorization(ctx, newRequestEvent(), responseWriter, &http.Request{
-		Method: "GET",
-		URL:    mustParseURL("56"),
-	})
-
-	err = json.Unmarshal(responseWriter.Body.Bytes(), &authz)
-	test.AssertNotError(t, err, "Couldn't unmarshal returned authorization object")
-	test.AssertEquals(t, len(authz.Challenges), 1)
 	// The Challenge Error Type should have had the probs.V2ErrorNS prefix added
-	test.AssertEquals(t, string(authz.Challenges[0].Error.Type), probs.V2ErrorNS+"things:are:whack")
+	test.AssertEquals(t, string(authz.Challenges[0].Error.Type), probs.ErrorNS+"things:are:whack")
 	responseWriter.Body.Reset()
 }
 
@@ -1667,14 +1683,14 @@ func TestAccount(t *testing.T) {
 	})
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
+		`{"type":"`+probs.ErrorNS+`malformed","detail":"Method not allowed","status":405}`)
 	responseWriter.Body.Reset()
 
 	// Test POST invalid JSON
 	wfe.Account(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("2", "invalid"))
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`malformed","detail":"Parse error reading JWS","status":400}`)
+		`{"type":"`+probs.ErrorNS+`malformed","detail":"Parse error reading JWS","status":400}`)
 	responseWriter.Body.Reset()
 
 	key := loadKey(t, []byte(test2KeyPrivatePEM))
@@ -1692,7 +1708,7 @@ func TestAccount(t *testing.T) {
 	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`accountDoesNotExist","detail":"Account \"http://localhost/acme/acct/102\" not found","status":400}`)
+		`{"type":"`+probs.ErrorNS+`accountDoesNotExist","detail":"Account \"http://localhost/acme/acct/102\" not found","status":400}`)
 	responseWriter.Body.Reset()
 
 	key = loadKey(t, []byte(test1KeyPrivatePEM))
@@ -1707,7 +1723,7 @@ func TestAccount(t *testing.T) {
 	request = makePostRequestWithPath(path, body)
 
 	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
-	test.AssertNotContains(t, responseWriter.Body.String(), probs.V2ErrorNS)
+	test.AssertNotContains(t, responseWriter.Body.String(), probs.ErrorNS)
 	links := responseWriter.Header()["Link"]
 	test.AssertEquals(t, contains(links, "<"+agreementURL+">;rel=\"terms-of-service\""), true)
 	responseWriter.Body.Reset()
@@ -1720,7 +1736,7 @@ func TestAccount(t *testing.T) {
 
 	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertContains(t, responseWriter.Body.String(), "400")
-	test.AssertContains(t, responseWriter.Body.String(), probs.V2ErrorNS+"malformed")
+	test.AssertContains(t, responseWriter.Body.String(), probs.ErrorNS+"malformed")
 	responseWriter.Body.Reset()
 
 	// Test valid POST-as-GET request
@@ -1729,7 +1745,7 @@ func TestAccount(t *testing.T) {
 	request = makePostRequestWithPath("1", body)
 	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	// It should not error
-	test.AssertNotContains(t, responseWriter.Body.String(), probs.V2ErrorNS)
+	test.AssertNotContains(t, responseWriter.Body.String(), probs.ErrorNS)
 	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
 
 	altKey := loadKey(t, []byte(test2KeyPrivatePEM))
@@ -1855,7 +1871,7 @@ func TestGetCertificate(t *testing.T) {
 	reqPath := fmt.Sprintf("/acme/cert/%s", core.SerialToString(cert.SerialNumber))
 	pkixContent := "application/pem-certificate-chain"
 	noCache := "public, max-age=0, no-cache"
-	notFound := `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Certificate not found","status":404}`
+	notFound := `{"type":"` + probs.ErrorNS + `malformed","detail":"Certificate not found","status":404}`
 
 	testCases := []struct {
 		Name            string
@@ -1948,13 +1964,13 @@ func TestGetCertificate(t *testing.T) {
 			Name:           "Valid serial (explicit non-existent alternate chain)",
 			Request:        makeGet(reqPath + "/2"),
 			ExpectedStatus: http.StatusNotFound,
-			ExpectedBody:   `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Unknown issuance chain","status":404}`,
+			ExpectedBody:   `{"type":"` + probs.ErrorNS + `malformed","detail":"Unknown issuance chain","status":404}`,
 		},
 		{
 			Name:           "Valid serial (explicit negative alternate chain)",
 			Request:        makeGet(reqPath + "/-1"),
 			ExpectedStatus: http.StatusBadRequest,
-			ExpectedBody:   `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Chain ID must be a non-negative integer","status":400}`,
+			ExpectedBody:   `{"type":"` + probs.ErrorNS + `malformed","detail":"Chain ID must be a non-negative integer","status":400}`,
 		},
 	}
 
@@ -2111,7 +2127,7 @@ func TestGetCertificateNew(t *testing.T) {
 			Request:        makeGet("/get/cert/000000000000000000000000000000000001"),
 			ExpectedStatus: http.StatusForbidden,
 			ExpectedBody: `{
-				"type": "` + probs.V2ErrorNS + `unauthorized",
+				"type": "` + probs.ErrorNS + `unauthorized",
 				"detail": "Certificate is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago",
 				"status": 403
 			}`,
@@ -2292,7 +2308,7 @@ func TestDeactivateAuthorization(t *testing.T) {
 	wfe.Authorization(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type": "`+probs.V2ErrorNS+`malformed","detail": "Invalid status value","status": 400}`)
+		`{"type": "`+probs.ErrorNS+`malformed","detail": "Invalid status value","status": 400}`)
 
 	responseWriter.Body.Reset()
 	payload = `{"status":"deactivated"}`
@@ -2334,7 +2350,7 @@ func TestDeactivateAccount(t *testing.T) {
 	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type": "`+probs.V2ErrorNS+`malformed","detail": "Invalid value provided for status field","status": 400}`)
+		`{"type": "`+probs.ErrorNS+`malformed","detail": "Invalid value provided for status field","status": 400}`)
 
 	responseWriter.Body.Reset()
 	payload = `{"status":"deactivated"}`
@@ -2393,7 +2409,7 @@ func TestDeactivateAccount(t *testing.T) {
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{
-		  "type": "`+probs.V2ErrorNS+`unauthorized",
+		  "type": "`+probs.ErrorNS+`unauthorized",
 		  "detail": "Account is not valid, has status \"deactivated\"",
 		  "status": 403
 		}`)
@@ -2465,42 +2481,42 @@ func TestNewOrder(t *testing.T) {
 					"Content-Type":   {expectedJWSContentType},
 				},
 			},
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No body on POST","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"No body on POST","status":400}`,
 		},
 		{
 			Name:         "POST, with an invalid JWS body",
 			Request:      makePostRequestWithPath("hi", "hi"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
 		},
 		{
 			Name:         "POST, properly signed JWS, payload isn't valid",
 			Request:      signAndPost(signer, targetPath, signedURL, "foo"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 		{
 			Name:         "POST, empty domain name identifier",
 			Request:      signAndPost(signer, targetPath, signedURL, `{"identifiers":[{"type":"dns","value":""}]}`),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request included empty domain name","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"NewOrder request included empty domain name","status":400}`,
 		},
 		{
 			Name:         "POST, no identifiers in payload",
 			Request:      signAndPost(signer, targetPath, signedURL, "{}"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request did not specify any identifiers","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"NewOrder request did not specify any identifiers","status":400}`,
 		},
 		{
 			Name:         "POST, invalid identifier in payload",
 			Request:      signAndPost(signer, targetPath, signedURL, nonDNSIdentifierBody),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NewOrder request included invalid non-DNS type identifier: type \"fakeID\", value \"www.i-am-21.com\"","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"NewOrder request included invalid non-DNS type identifier: type \"fakeID\", value \"www.i-am-21.com\"","status":400}`,
 		},
 		{
 			Name:         "POST, notAfter and notBefore in payload",
 			Request:      signAndPost(signer, targetPath, signedURL, `{"identifiers":[{"type": "dns", "value": "not-example.com"}], "notBefore":"now", "notAfter": "later"}`),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"NotBefore and NotAfter are not supported","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"NotBefore and NotAfter are not supported","status":400}`,
 		},
 		{
 			Name:         "POST, no potential CNs 64 bytes or smaller",
 			Request:      signAndPost(signer, targetPath, signedURL, tooLongCNBody),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `rejectedIdentifier","detail":"NewOrder request did not include a SAN short enough to fit in CN","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `rejectedIdentifier","detail":"NewOrder request did not include a SAN short enough to fit in CN","status":400}`,
 		},
 		{
 			Name:    "POST, good payload, one potential CNs less than 64 bytes and one longer",
@@ -2596,27 +2612,27 @@ func TestFinalizeOrder(t *testing.T) {
 					"Content-Type":   {expectedJWSContentType},
 				},
 			},
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No body on POST","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"No body on POST","status":400}`,
 		},
 		{
 			Name:         "POST, with an invalid JWS body",
 			Request:      makePostRequestWithPath(targetPath, "hi"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
 		},
 		{
 			Name:         "POST, properly signed JWS, payload isn't valid",
 			Request:      signAndPost(signer, targetPath, signedURL, "foo"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
 		},
 		{
 			Name:         "Invalid path",
 			Request:      signAndPost(signer, "1", "http://localhost/1", "{}"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid request path","status":404}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Invalid request path","status":404}`,
 		},
 		{
 			Name:         "Bad acct ID in path",
 			Request:      signAndPost(signer, "a/1", "http://localhost/a/1", "{}"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid account ID","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Invalid account ID","status":400}`,
 		},
 		{
 			Name: "Mismatched acct ID in path/JWS",
@@ -2626,35 +2642,35 @@ func TestFinalizeOrder(t *testing.T) {
 			// stripped by the global WFE2 handler. We need the JWS URL to match the request
 			// URL so we fudge both such that the finalize-order prefix has been removed.
 			Request:      signAndPost(signer, "2/1", "http://localhost/2/1", "{}"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order found for account ID 2","status":404}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"No order found for account ID 2","status":404}`,
 		},
 		{
 			Name:         "Order ID is invalid",
 			Request:      signAndPost(signer, "1/okwhatever/finalize-order", "http://localhost/1/okwhatever/finalize-order", "{}"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid order ID","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Invalid order ID","status":400}`,
 		},
 		{
 			Name: "Order doesn't exist",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 2 as missing
 			Request:      signAndPost(signer, "1/2", "http://localhost/1/2", "{}"),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order for ID 2","status":404}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"No order for ID 2","status":404}`,
 		},
 		{
 			Name: "Order is already finalized",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 1 as an Order with a Serial
 			Request:      signAndPost(signer, "1/1", "http://localhost/1/1", goodCertCSRPayload),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `orderNotReady","detail":"Order's status (\"valid\") is not acceptable for finalization","status":403}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `orderNotReady","detail":"Order's status (\"valid\") is not acceptable for finalization","status":403}`,
 		},
 		{
 			Name: "Order is expired",
 			// mocks/mocks.go's StorageAuthority's GetOrder mock treats ID 7 as an Order that has already expired
 			Request:      signAndPost(signer, "1/7", "http://localhost/1/7", goodCertCSRPayload),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Order 7 is expired","status":404}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Order 7 is expired","status":404}`,
 		},
 		{
 			Name:         "Good CSR, Pending Order",
 			Request:      signAndPost(signer, "1/4", "http://localhost/1/4", goodCertCSRPayload),
-			ExpectedBody: `{"type":"` + probs.V2ErrorNS + `orderNotReady","detail":"Order's status (\"pending\") is not acceptable for finalization","status":403}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `orderNotReady","detail":"Order's status (\"pending\") is not acceptable for finalization","status":403}`,
 		},
 		{
 			Name:    "Good CSR, Ready Order",
@@ -2722,7 +2738,7 @@ func TestKeyRollover(t *testing.T) {
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
 		`{
-		  "type": "`+probs.V2ErrorNS+`malformed",
+		  "type": "`+probs.ErrorNS+`malformed",
 		  "detail": "Parse error reading JWS",
 		  "status": 400
 		}`)
@@ -2738,7 +2754,7 @@ func TestKeyRollover(t *testing.T) {
 			Name:    "Missing account URL",
 			Payload: `{"oldKey":` + test1KeyPublicJSON + `}`,
 			ExpectedResponse: `{
-		     "type": "` + probs.V2ErrorNS + `malformed",
+		     "type": "` + probs.ErrorNS + `malformed",
 		     "detail": "Inner key rollover request specified Account \"\", but outer JWS has Key ID \"http://localhost/acme/acct/1\"",
 		     "status": 400
 		   }`,
@@ -2749,7 +2765,7 @@ func TestKeyRollover(t *testing.T) {
 			Name:    "incorrect old key",
 			Payload: `{"oldKey":` + string(newJWKJSON) + `,"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
-		     "type": "` + probs.V2ErrorNS + `malformed",
+		     "type": "` + probs.ErrorNS + `malformed",
 		     "detail": "Inner JWS does not contain old key field matching current account key",
 		     "status": 400
 		   }`,
@@ -2844,42 +2860,42 @@ func TestGetOrder(t *testing.T) {
 		{
 			Name:     "404 request",
 			Request:  makeGet("1/2"),
-			Response: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order for ID 2", "status":404}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"No order for ID 2", "status":404}`,
 		},
 		{
 			Name:     "Invalid request path",
 			Request:  makeGet("asd"),
-			Response: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid request path","status":404}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"Invalid request path","status":404}`,
 		},
 		{
 			Name:     "Invalid account ID",
 			Request:  makeGet("asd/asd"),
-			Response: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid account ID","status":400}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"Invalid account ID","status":400}`,
 		},
 		{
 			Name:     "Invalid order ID",
 			Request:  makeGet("1/asd"),
-			Response: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"Invalid order ID","status":400}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"Invalid order ID","status":400}`,
 		},
 		{
 			Name:     "Real request, wrong account",
 			Request:  makeGet("2/1"),
-			Response: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order found for account ID 2", "status":404}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"No order found for account ID 2", "status":404}`,
 		},
 		{
 			Name:     "Internal error request",
 			Request:  makeGet("1/3"),
-			Response: `{"type":"` + probs.V2ErrorNS + `serverInternal","detail":"Failed to retrieve order for ID 3","status":500}`,
+			Response: `{"type":"` + probs.ErrorNS + `serverInternal","detail":"Failed to retrieve order for ID 3","status":500}`,
 		},
 		{
 			Name:     "Invalid POST-as-GET",
 			Request:  makePost(1, "1/1", "{}"),
-			Response: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"POST-as-GET requests must have an empty payload", "status":400}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"POST-as-GET requests must have an empty payload", "status":400}`,
 		},
 		{
 			Name:     "Valid POST-as-GET, wrong account",
 			Request:  makePost(1, "2/1", ""),
-			Response: `{"type":"` + probs.V2ErrorNS + `malformed","detail":"No order found for account ID 2", "status":404}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"No order found for account ID 2", "status":404}`,
 		},
 		{
 			Name:     "Valid POST-as-GET",
@@ -2889,7 +2905,7 @@ func TestGetOrder(t *testing.T) {
 		{
 			Name:     "GET new order",
 			Request:  makeGet("1/9"),
-			Response: `{"type":"` + probs.V2ErrorNS + `unauthorized","detail":"Order is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`,
+			Response: `{"type":"` + probs.ErrorNS + `unauthorized","detail":"Order is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`,
 			Endpoint: "/get/order/",
 		},
 		{
@@ -3100,13 +3116,13 @@ func TestRevokeCertificateReasons(t *testing.T) {
 			Name:             "Unsupported reason",
 			Reason:           &reason2,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
 		},
 		{
 			Name:             "Non-existent reason",
 			Reason:           &reason100,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.V2ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: unknown (100). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: unknown (100). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
 		},
 	}
 
@@ -3152,7 +3168,7 @@ func TestRevokeCertificateWrongCertificateKey(t *testing.T) {
 		makePostRequestWithPath("revoke-cert", jwsBody))
 	test.AssertEquals(t, responseWriter.Code, 403)
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`unauthorized","detail":"JWK embedded in revocation request must be the same public key as the cert to be revoked","status":403}`)
+		`{"type":"`+probs.ErrorNS+`unauthorized","detail":"JWK embedded in revocation request must be the same public key as the cert to be revoked","status":403}`)
 }
 
 type mockSAGetRegByKeyFails struct {
@@ -3181,7 +3197,7 @@ func TestNewAccountWhenGetRegByKeyFails(t *testing.T) {
 	var prob probs.ProblemDetails
 	err := json.Unmarshal(responseWriter.Body.Bytes(), &prob)
 	test.AssertNotError(t, err, "unmarshalling response")
-	if prob.Type != probs.V2ErrorNS+probs.ServerInternalProblem {
+	if prob.Type != probs.ErrorNS+probs.ServerInternalProblem {
 		t.Errorf("Wrong type for returned problem: %#v", prob.Type)
 	}
 }
@@ -3297,7 +3313,7 @@ func TestFinalizeSCTError(t *testing.T) {
 	// a serverInternal error with the right message.
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"`+probs.V2ErrorNS+`serverInternal","detail":"Error finalizing order :: Unable to meet CA SCT embedding requirements","status":500}`)
+		`{"type":"`+probs.ErrorNS+`serverInternal","detail":"Error finalizing order :: Unable to meet CA SCT embedding requirements","status":500}`)
 }
 
 func TestOrderToOrderJSONV2Authorizations(t *testing.T) {
@@ -3375,7 +3391,7 @@ func TestGETAPIAuthz(t *testing.T) {
 		},
 	}
 
-	tooFreshErr := `{"type":"` + probs.V2ErrorNS + `unauthorized","detail":"Authorization is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`
+	tooFreshErr := `{"type":"` + probs.ErrorNS + `unauthorized","detail":"Authorization is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`
 	for _, tc := range testCases {
 		responseWriter := httptest.NewRecorder()
 		req, logEvent := makeGet(tc.path, getAuthzPath)
@@ -3414,7 +3430,7 @@ func TestGETAPIChallenge(t *testing.T) {
 		},
 	}
 
-	tooFreshErr := `{"type":"` + probs.V2ErrorNS + `unauthorized","detail":"Authorization is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`
+	tooFreshErr := `{"type":"` + probs.ErrorNS + `unauthorized","detail":"Authorization is too new for GET API. You should only use this non-standard API to access resources created more than 10s ago","status":403}`
 	for _, tc := range testCases {
 		responseWriter := httptest.NewRecorder()
 		req, logEvent := makeGet(tc.path, getAuthzPath)


### PR DESCRIPTION
Make minor, non-user-visible changes to how we structure the probs package. Notably:
- Add new problem types for UnsupportedContact and UnsupportedIdentifier, which are specified by RFC8555 and which we will use in the future, but haven't been using historically.
- Sort the problem types and constructor functions to match the (alphabetical) order given in RFC8555.
- Rename some of the constructor functions to better match their underlying problem types (e.g. "TLSError" to just "TLS").
- Replace the redundant ProblemDetailsToStatusCode function with simply always returning a 500 if we haven't properly set the problem's HTTPStatus.
- Remove the ability to use either the V1 or V2 error namespace prefix; always use the proper RFC namespace prefix.