### PR TITLE
ca: remove simulated ISRG OID from config

### DIFF
--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -52,15 +52,6 @@
 				"policies": [
 					{
 						"oid": "2.23.140.1.2.1"
-					},
-					{
-						"oid": "1.2.3.4",
-						"qualifiers": [
-							{
-								"type": "id-qt-cps",
-								"value": "http://example.com/cps"
-							}
-						]
 					}
 				],
 				"maxValidityPeriod": "7776000s",

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -52,15 +52,6 @@
 				"policies": [
 					{
 						"oid": "2.23.140.1.2.1"
-					},
-					{
-						"oid": "1.2.3.4",
-						"qualifiers": [
-							{
-								"type": "id-qt-cps",
-								"value": "http://example.com/cps"
-							}
-						]
 					}
 				],
 				"maxValidityPeriod": "7776000s",


### PR DESCRIPTION
We intend to issue in the future with only the CA/Browser Forum Domain Validated OID.