### PR TITLE
test: Use consul hostname instead of IP for dnsAuthority

### DIFF
--- a/test/config-next/admin-revoker.json
+++ b/test/config-next/admin-revoker.json
@@ -10,7 +10,7 @@
 			"keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"
@@ -20,7 +20,7 @@
 			"timeout": "15s"
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/admin-revoker.json
+++ b/test/config-next/admin-revoker.json
@@ -10,7 +10,7 @@
 			"keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"
@@ -20,7 +20,7 @@
 			"timeout": "15s"
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -11,7 +11,7 @@
 			"keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -11,7 +11,7 @@
 			"keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -35,7 +35,7 @@
 			}
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -35,7 +35,7 @@
 			}
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -35,7 +35,7 @@
 			}
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -35,7 +35,7 @@
 			}
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -7,7 +7,7 @@
 			"keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"
@@ -17,7 +17,7 @@
 			"hostOverride": "sa.boulder"
 		},
 		"crlGeneratorService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "ca",
 				"domain": "service.consul"
@@ -27,7 +27,7 @@
 			"hostOverride": "ca.boulder"
 		},
 		"crlStorerService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "crl-storer",
 				"domain": "service.consul"

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -7,7 +7,7 @@
 			"keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"
@@ -17,7 +17,7 @@
 			"hostOverride": "sa.boulder"
 		},
 		"crlGeneratorService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "ca",
 				"domain": "service.consul"
@@ -27,7 +27,7 @@
 			"hostOverride": "ca.boulder"
 		},
 		"crlStorerService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "crl-storer",
 				"domain": "service.consul"

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -25,7 +25,7 @@
 			"keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -25,7 +25,7 @@
 			"keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -22,7 +22,7 @@
 			"keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"
@@ -32,7 +32,7 @@
 			"timeout": "15s"
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -22,7 +22,7 @@
 			"keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"
@@ -32,7 +32,7 @@
 			"timeout": "15s"
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"

--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -15,7 +15,7 @@
 		"keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
 	},
 	"ocspGeneratorService": {
-		"dnsAuthority": "service.consul.service",
+		"dnsAuthority": "consul.service.consul",
 		"srvLookup": {
 			"service": "ca",
 			"domain": "service.consul"
@@ -25,7 +25,7 @@
 		"hostOverride": "ca.boulder"
 	},
 	"saService": {
-		"dnsAuthority": "service.consul.service",
+		"dnsAuthority": "consul.service.consul",
 		"srvLookup": {
 			"service": "sa",
 			"domain": "service.consul"

--- a/test/config-next/orphan-finder.json
+++ b/test/config-next/orphan-finder.json
@@ -15,7 +15,7 @@
 		"keyFile": "test/grpc-creds/orphan-finder.boulder/key.pem"
 	},
 	"ocspGeneratorService": {
-		"dnsAuthority": "10.55.55.10",
+		"dnsAuthority": "service.consul.service",
 		"srvLookup": {
 			"service": "ca",
 			"domain": "service.consul"
@@ -25,7 +25,7 @@
 		"hostOverride": "ca.boulder"
 	},
 	"saService": {
-		"dnsAuthority": "10.55.55.10",
+		"dnsAuthority": "service.consul.service",
 		"srvLookup": {
 			"service": "sa",
 			"domain": "service.consul"

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -25,7 +25,7 @@
 			"keyFile": "test/grpc-creds/ra.boulder/key.pem"
 		},
 		"vaService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "va",
 				"domain": "service.consul"
@@ -35,7 +35,7 @@
 			"hostOverride": "va.boulder"
 		},
 		"caService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "ca",
 				"domain": "service.consul"
@@ -45,7 +45,7 @@
 			"hostOverride": "ca.boulder"
 		},
 		"ocspService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "ca",
 				"domain": "service.consul"
@@ -55,7 +55,7 @@
 			"hostOverride": "ca.boulder"
 		},
 		"publisherService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "publisher",
 				"domain": "service.consul"
@@ -65,7 +65,7 @@
 			"hostOverride": "publisher.boulder"
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"
@@ -75,7 +75,7 @@
 			"hostOverride": "sa.boulder"
 		},
 		"akamaiPurgerService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "akamai-purger",
 				"domain": "service.consul"

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -25,7 +25,7 @@
 			"keyFile": "test/grpc-creds/ra.boulder/key.pem"
 		},
 		"vaService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "va",
 				"domain": "service.consul"
@@ -35,7 +35,7 @@
 			"hostOverride": "va.boulder"
 		},
 		"caService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "ca",
 				"domain": "service.consul"
@@ -45,7 +45,7 @@
 			"hostOverride": "ca.boulder"
 		},
 		"ocspService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "ca",
 				"domain": "service.consul"
@@ -55,7 +55,7 @@
 			"hostOverride": "ca.boulder"
 		},
 		"publisherService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "publisher",
 				"domain": "service.consul"
@@ -65,7 +65,7 @@
 			"hostOverride": "publisher.boulder"
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"
@@ -75,7 +75,7 @@
 			"hostOverride": "sa.boulder"
 		},
 		"akamaiPurgerService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "akamai-purger",
 				"domain": "service.consul"

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -23,7 +23,7 @@
 			"keyFile": "test/grpc-creds/wfe.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"
@@ -33,7 +33,7 @@
 			"hostOverride": "ra.boulder"
 		},
 		"saService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"
@@ -47,7 +47,7 @@
 			"ttl": "5s"
 		},
 		"getNonceService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookup": {
 				"service": "nonce",
 				"domain": "service.consul"
@@ -57,7 +57,7 @@
 			"hostOverride": "nonce.boulder"
 		},
 		"redeemNonceService": {
-			"dnsAuthority": "10.55.55.10",
+			"dnsAuthority": "service.consul.service",
 			"srvLookups": [
 				{
 					"service": "nonce1",

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -23,7 +23,7 @@
 			"keyFile": "test/grpc-creds/wfe.boulder/key.pem"
 		},
 		"raService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "ra",
 				"domain": "service.consul"
@@ -33,7 +33,7 @@
 			"hostOverride": "ra.boulder"
 		},
 		"saService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "sa",
 				"domain": "service.consul"
@@ -47,7 +47,7 @@
 			"ttl": "5s"
 		},
 		"getNonceService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
 				"service": "nonce",
 				"domain": "service.consul"
@@ -57,7 +57,7 @@
 			"hostOverride": "nonce.boulder"
 		},
 		"redeemNonceService": {
-			"dnsAuthority": "service.consul.service",
+			"dnsAuthority": "consul.service.consul",
 			"srvLookups": [
 				{
 					"service": "nonce1",


### PR DESCRIPTION
Standardize on hostnames for dnsAuthority to match production. 

Related to #6869