### PR TITLE
In config-next/, opentelemetry -> openTelemetry for consistency

### DIFF
--- a/test/config-next/akamai-purger.json
+++ b/test/config-next/akamai-purger.json
@@ -38,7 +38,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -39,7 +39,7 @@
 		"stdoutlevel": 4,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -132,7 +132,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -132,7 +132,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/crl-storer.json
+++ b/test/config-next/crl-storer.json
@@ -36,7 +36,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -52,7 +52,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/expiration-mailer.json
+++ b/test/config-next/expiration-mailer.json
@@ -44,7 +44,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -2,7 +2,7 @@
 	"syslog": {
 		"stdoutLevel": 7
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	},

--- a/test/config-next/nonce-a.json
+++ b/test/config-next/nonce-a.json
@@ -9,7 +9,7 @@
 			"stdoutLevel": 6,
 			"syslogLevel": -1
 		},
-		"opentelemetry": {
+		"openTelemetry": {
 			"endpoint": "bjaeger:4317",
 			"sampleratio": 1
 		},

--- a/test/config-next/nonce-b.json
+++ b/test/config-next/nonce-b.json
@@ -9,7 +9,7 @@
 			"stdoutLevel": 6,
 			"syslogLevel": -1
 		},
-		"opentelemetry": {
+		"openTelemetry": {
 			"endpoint": "bjaeger:4317",
 			"sampleratio": 1
 		},

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -64,7 +64,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	},

--- a/test/config-next/publisher.json
+++ b/test/config-next/publisher.json
@@ -48,7 +48,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -144,7 +144,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": 6
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/rocsp-tool.json
+++ b/test/config-next/rocsp-tool.json
@@ -20,7 +20,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": 6
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -55,7 +55,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -47,7 +47,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -47,7 +47,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -67,7 +67,7 @@
 		"stdoutlevel": 6,
 		"sysloglevel": 6
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	}

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -106,7 +106,7 @@
 		"stdoutlevel": 4,
 		"sysloglevel": -1
 	},
-	"opentelemetry": {
+	"openTelemetry": {
 		"endpoint": "bjaeger:4317",
 		"sampleratio": 1
 	},


### PR DESCRIPTION
In configs, opentelemetry -> openTelemetry

As pointed out in review of #6867, these should match the case of their
corresponding Go identifiers for consistency.

JSON keys are case-insensitive in Go (part of why we've got a fork in go-jose),
so this change should have no functional impact.
