### PR TITLE
admin-revoker: fix help output

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -510,7 +510,10 @@ func main() {
 	)
 	comment := flagSet.String("comment", "", "Comment to include in the blocked key database entry ")
 	err := flagSet.Parse(os.Args[2:])
-	cmd.FailOnError(err, "Error parsing flagset")
+	if err == flag.ErrHelp {
+		os.Exit(1)
+	}
+	cmd.FailOnError(err, "parsing flagset")
 
 	if *configFile == "" {
 		usage()


### PR DESCRIPTION
Previously if you passed `-h` or `-help` to a sub-sub-command of admin-revoker it would error out with a red message and a stack trace (in addition to printing help).

Now, it will print help and exit 1.