### PR TITLE
Remove port bindings from bjaeger container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,9 +126,6 @@ services:
     networks:
       bluenet:
         ipv4_address: 10.77.77.17
-    ports:
-      - "16686:16686" # Jaegar API and UI
-      - "4317:4317"  # OTLP grpc trace submission
 
 networks:
   bluenet:


### PR DESCRIPTION
These external port bindings are not necessary, as the integration test configs resolve the bjaeger container directly. In addition, these external port bindings cause problems for rootless docker, so let's remove them.