### PR TITLE
integration: shorten log output

### DIFF
--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -129,7 +129,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 6,
+		"stdoutlevel": 4,
 		"sysloglevel": -1
 	},
 	"opentelemetry": {

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -129,7 +129,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 6,
+		"stdoutlevel": 4,
 		"sysloglevel": -1
 	},
 	"opentelemetry": {

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -44,7 +44,7 @@
 		]
 	},
 	"syslog": {
-		"stdoutlevel": 6,
+		"stdoutlevel": 4,
 		"sysloglevel": -1
 	},
 	"opentelemetry": {

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -44,7 +44,7 @@
 		]
 	},
 	"syslog": {
-		"stdoutlevel": 6,
+		"stdoutlevel": 4,
 		"sysloglevel": -1
 	},
 	"opentelemetry": {

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -131,7 +131,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 6,
-		"sysloglevel": 6
+		"stdoutlevel": 4,
+		"sysloglevel": 4
 	}
 }

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -131,7 +131,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 6,
-		"sysloglevel": 6
+		"stdoutlevel": 4,
+		"sysloglevel": 4
 	}
 }

--- a/test/config/va-remote-a.json
+++ b/test/config/va-remote-a.json
@@ -35,7 +35,7 @@
 		]
 	},
 	"syslog": {
-		"stdoutlevel": 6,
+		"stdoutlevel": 4,
 		"sysloglevel": 4
 	}
 }

--- a/test/config/va-remote-b.json
+++ b/test/config/va-remote-b.json
@@ -35,7 +35,7 @@
 		]
 	},
 	"syslog": {
-		"stdoutlevel": 6,
+		"stdoutlevel": 4,
 		"sysloglevel": 4
 	}
 }

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -122,11 +122,6 @@ def main():
         run_cert_checker()
         check_balance()
 
-        # Run the load-generator last. run_loadtest will stop the
-        # pebble-challtestsrv before running the load-generator and will not restart
-        # it.
-        run_loadtest()
-
     if not startservers.check():
         raise(Exception("startservers.check failed"))
 
@@ -178,20 +173,6 @@ def run_chisel(test_case_filter):
     for key, value in globals().items():
       if callable(value) and key.startswith('test_') and re.search(test_case_filter, key):
         value()
-
-def run_loadtest():
-    """Run the ACME v2 load generator."""
-    latency_data_file = "%s/integration-test-latency.json" % tempdir
-
-    # Stop the global pebble-challtestsrv - it will conflict with the
-    # load-generator's internal challtestsrv. We don't restart it because
-    # run_loadtest() is called last and there are no remaining tests to run that
-    # might benefit from the pebble-challtestsrv being restarted.
-    startservers.stopChallSrv()
-
-    run(["./bin/load-generator",
-        "-config", "test/load-generator/config/integration-test-config.json",
-        "-results", latency_data_file])
 
 def check_balance():
     """Verify that gRPC load balancing across backends is working correctly.


### PR DESCRIPTION
Remove the load test stage of the integration test, which generates superfluous amounts of log.

Turn down logging on the CA and VA from info to error-only.

Part of https://github.com/letsencrypt/boulder/issues/6890