### PR TITLE
Remove go1.20.3 from CI

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,6 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.3_2023-05-02
           - go1.20.4_2023-05-02
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.20.3"
           - "1.20.4"
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.20.3"
           - "1.20.4"
     runs-on: ubuntu-20.04
     steps:

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.20.3" "1.20.4" )
+GO_CI_VERSIONS=( "1.20.4" )
 # These versions are built for both platforms that boulder devs use.
 # When updating GO_DEV_VERSIONS, please also update
 # ../../docker-compose.yml's default Go version.


### PR DESCRIPTION
Once IN-9126 is complete, we will no longer be using go1.20.3 in prod.