### PR TITLE
Remove issuerCerts stanza from test root ocsp responder

### DIFF
--- a/test/issuer-ocsp-responder.json
+++ b/test/issuer-ocsp-responder.json
@@ -3,9 +3,6 @@
     "source": "file:///hierarchy/intermediate-ocsp-rsa.b64",
     "path": "/",
     "listenAddress": "0.0.0.0:4003",
-    "issuerCerts": [
-      "/hierarchy/intermediate-cert-rsa-a.pem"
-    ],
     "timeout": "4.9s",
     "shutdownStopTimeout": "10s",
     "debugAddr": "localhost:8010"


### PR DESCRIPTION
This config stanza is not set in prod, because the IssuerCerts config field is only used by the FilterSource, which is only initialized for the DB+Redis path, not for the static file source path.