### PR TITLE
va: make http keyAuthz mismatch problem wording less ambiguous

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -664,7 +664,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, ident ide
 	payload := strings.TrimRightFunc(string(body), unicode.IsSpace)
 
 	if payload != challenge.ProvidedKeyAuthorization {
-		problem := probs.Unauthorized(fmt.Sprintf("The key authorization file from the server did not match this challenge %q != %q",
+		problem := probs.Unauthorized(fmt.Sprintf("The key authorization file from the server did not match this challenge: %q (expected %q)",
 			challenge.ProvidedKeyAuthorization, payload))
 		va.log.Infof("%s for %s", problem.Detail, ident)
 		return validationRecords, problem

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -1209,7 +1209,7 @@ func TestHTTPKeyAuthorizationFileMismatch(t *testing.T) {
 	if prob == nil {
 		t.Fatalf("Expected validation to fail when file mismatched.")
 	}
-	expected := `The key authorization file from the server did not match this challenge "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0.9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI" != "\xef\xffAABBCC"`
+	expected := `The key authorization file from the server did not match this challenge: "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0.9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI" (expected "\xef\xffAABBCC")`
 	if prob.Detail != expected {
 		t.Errorf("validation failed with %s, expected %s", prob.Detail, expected)
 	}

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -353,7 +353,7 @@ func TestMultiVA(t *testing.T) {
 	}
 
 	unauthorized := probs.Unauthorized(fmt.Sprintf(
-		`The key authorization file from the server did not match this challenge %q != "???"`,
+		`The key authorization file from the server did not match this challenge: %q (expected "???")`,
 		expectedKeyAuthorization))
 
 	expectedInternalErrLine := fmt.Sprintf(
@@ -441,7 +441,7 @@ func TestMultiVA(t *testing.T) {
 			AllowedUAs: map[string]bool{localUA: true, remoteUA2: true},
 			Features:   enforceMultiVA,
 			ExpectedProb: probs.Unauthorized(fmt.Sprintf(
-				`During secondary validation: The key authorization file from the server did not match this challenge %q != "???"`,
+				`During secondary validation: The key authorization file from the server did not match this challenge: %q (expected "???")`,
 				expectedKeyAuthorization)),
 		},
 		{
@@ -483,7 +483,7 @@ func TestMultiVA(t *testing.T) {
 			AllowedUAs: map[string]bool{localUA: true},
 			Features:   enforceMultiVAFullResults,
 			ExpectedProb: probs.Unauthorized(fmt.Sprintf(
-				`During secondary validation: The key authorization file from the server did not match this challenge %q != "???"`,
+				`During secondary validation: The key authorization file from the server did not match this challenge: %q (expected "???")`,
 				expectedKeyAuthorization)),
 		},
 	}


### PR DESCRIPTION
Occasionally (and just now) I've responded to an issue or thread that involves this error message:

> The key authorization file from the server did not match this challenge "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0.9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI" != "\xef\xffAABBCC

and I've found myself looking at Boulder's source code, to check which way around the values are. I suspect that users are not understanding it either.

Happy for the wording to be something else, but it would be nice for this to be less ambiguous, one way or another.

