### PR TITLE
crl-updater: retry failed shards

### DIFF
--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -87,6 +87,12 @@ type Config struct {
 		// by this updater.
 		MaxParallelism int `validate:"min=0"`
 
+		// MaxAttempts control how many times the updater will attempt to generate
+		// a single CRL shard. A higher number increases the likelihood of a fully
+		// successful run, but also increases the worst-case runtime and db/network
+		// load of said run. The default is 1.
+		MaxAttempts int `validate:"omitempty,min=1"`
+
 		Features map[string]bool
 	}
 
@@ -158,6 +164,7 @@ func main() {
 		c.CRLUpdater.UpdatePeriod.Duration,
 		c.CRLUpdater.UpdateOffset.Duration,
 		c.CRLUpdater.MaxParallelism,
+		c.CRLUpdater.MaxAttempts,
 		sac,
 		cac,
 		csc,

--- a/crl/updater/updater_test.go
+++ b/crl/updater/updater_test.go
@@ -146,7 +146,7 @@ func TestTickShard(t *testing.T) {
 	cu, err := NewUpdater(
 		[]*issuance.Certificate{e1, r3},
 		2, 18*time.Hour, 24*time.Hour,
-		6*time.Hour, 1*time.Minute, 1,
+		6*time.Hour, 1*time.Minute, 1, 1,
 		&fakeSAC{grcc: fakeGRCC{}, maxNotAfter: clk.Now().Add(90 * 24 * time.Hour)},
 		&fakeCGC{gcc: fakeGCC{}},
 		&fakeCSC{ucc: fakeUCC{}},
@@ -234,7 +234,7 @@ func TestTickIssuer(t *testing.T) {
 	cu, err := NewUpdater(
 		[]*issuance.Certificate{e1, r3},
 		2, 18*time.Hour, 24*time.Hour,
-		6*time.Hour, 1*time.Minute, 1,
+		6*time.Hour, 1*time.Minute, 1, 1,
 		&fakeSAC{grcc: fakeGRCC{err: errors.New("db no worky")}, maxNotAfter: clk.Now().Add(90 * 24 * time.Hour)},
 		&fakeCGC{gcc: fakeGCC{}},
 		&fakeCSC{ucc: fakeUCC{}},
@@ -270,7 +270,7 @@ func TestTick(t *testing.T) {
 	cu, err := NewUpdater(
 		[]*issuance.Certificate{e1, r3},
 		2, 18*time.Hour, 24*time.Hour,
-		6*time.Hour, 1*time.Minute, 1,
+		6*time.Hour, 1*time.Minute, 1, 1,
 		&fakeSAC{grcc: fakeGRCC{err: errors.New("db no worky")}, maxNotAfter: clk.Now().Add(90 * 24 * time.Hour)},
 		&fakeCGC{gcc: fakeGCC{}},
 		&fakeCSC{ucc: fakeUCC{}},

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -46,7 +46,8 @@
 		"lookbackPeriod": "24h",
 		"updatePeriod": "6h",
 		"updateOffset": "9120s",
-		"maxParallelism": 10
+		"maxParallelism": 10,
+		"maxAttempts": 5
 	},
 	"syslog": {
 		"stdoutlevel": 6,


### PR DESCRIPTION
Add per-shard exponential backoff and retry to crl-updater. Each individual CRL shard will be retried up to MaxAttempts (default 1) times, with exponential backoff starting at 1 second and maxing out at 1 minute between each attempt.

This can effectively reduce the parallelism of crl-updater: while a goroutine is sleeping between attempts of a failing shard, it is not doing work on another shard. This is a desirable feature, since it means that crl-updater gently reduces the total load it places on the network and database when shards start to fail.

Fixes https://github.com/letsencrypt/boulder/issues/6895