### PR TITLE
docker: Update consul container to match production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
         ipv4_address: 10.33.33.3
 
   bconsul:
-    image: hashicorp/consul:1.13.1
+    image: hashicorp/consul:1.14.2
     volumes:
      - ./test/:/test/:cached
     networks:

--- a/test/consul/config.hcl
+++ b/test/consul/config.hcl
@@ -19,7 +19,8 @@ ui_config {
   enabled = true
 }
 ports {
-  dns = 53
+  dns      = 53
+  grpc_tls = 8503
 }
 
 services {


### PR DESCRIPTION
- Update consul container from `1.13.1` to `1.14.2` to match production.
- Specify `grpc_tls`, now required instead of defaulted to `8503` when `enable_agent_tls_for_checks` is specified.

Part of #6911 