### PR TITLE
docker: Update proxysql container to match production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     logging:
       driver: none
   bproxysql:
-    image: proxysql/proxysql:2.4.4
+    image: proxysql/proxysql:2.5.2
     # The --initial flag force resets the ProxySQL database on startup. By
     # default, ProxySQL ignores new configuration if the database already
     # exists. Without this flag, new configuration wouldn't be applied until you

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -134,7 +134,7 @@ func TestStrictness(t *testing.T) {
 }
 
 func TestTimeouts(t *testing.T) {
-	dbMap, err := NewDbMap(vars.DBConnSA+"?readTimeout=1300ms", DbSettings{1, 0, 0, 0})
+	dbMap, err := NewDbMap(vars.DBConnSA+"?max_statement_time=1", DbSettings{1, 0, 0, 0})
 	if err != nil {
 		t.Fatal("Error setting up DB:", err)
 	}

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -134,7 +134,7 @@ func TestStrictness(t *testing.T) {
 }
 
 func TestTimeouts(t *testing.T) {
-	dbMap, err := NewDbMap(vars.DBConnSA+"?readTimeout=1s", DbSettings{1, 0, 0, 0})
+	dbMap, err := NewDbMap(vars.DBConnSA+"?readTimeout=1300ms", DbSettings{1, 0, 0, 0})
 	if err != nil {
 		t.Fatal("Error setting up DB:", err)
 	}


### PR DESCRIPTION
Update proxysql container from `2.4.2` to `2.5.2` to match production. Changes in this version add `max_statement_time` to proxysql's set of session variables, we should no longer see warning messages indicating that `max_statement_time` is unrecognized.

Part of #6911 