### PR TITLE
bdns: fix handling of NXDOMAIN

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -529,6 +529,16 @@ func (dnsClient *impl) LookupHost(ctx context.Context, hostname string) ([]net.I
 func (dnsClient *impl) LookupCAA(ctx context.Context, hostname string) ([]*dns.CAA, string, error) {
 	dnsType := dns.TypeCAA
 	r, err := dnsClient.exchangeOne(ctx, hostname, dnsType)
+
+	// Special case: for CAA, treat NXDOMAIN as a successful response
+	// containing an empty set of records. This can come up in
+	// situations where records were provisioned for validation (e.g.
+	// TXT records for DNS-01 challenge) and then removed after
+	// validation but before CAA rechecking.
+	if err == nil && r.Rcode == dns.RcodeNameError {
+		return nil, "", nil
+	}
+
 	errWrap := wrapErr(dnsType, hostname, r, err)
 	if errWrap != nil {
 		return nil, "", errWrap

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -425,6 +425,12 @@ bracewel.net.	0	IN	CAA	1 issue "letsencrypt.org"
 	expectedResp = ""
 	test.AssertEquals(t, resp, expectedResp)
 
+	caas, resp, err = obj.LookupCAA(context.Background(), "nxdomain.letsencrypt.org")
+	test.AssertNotError(t, err, "CAA lookup failed")
+	test.Assert(t, len(caas) == 0, "Shouldn't have CAA records")
+	expectedResp = ""
+	test.AssertEquals(t, resp, expectedResp)
+
 	caas, resp, err = obj.LookupCAA(context.Background(), "cname.example.com")
 	test.AssertNotError(t, err, "CAA lookup failed")
 	test.Assert(t, len(caas) > 0, "Should follow CNAME to find CAA")


### PR DESCRIPTION
A [recent refactoring](https://github.com/letsencrypt/boulder/pull/6906) started treating NXDOMAIN for a CAA lookup as a hard error, when it should be treated (from Boulder's point of view) as meaning there is an empty list of resource records.