### PR TITLE
ctpolicy: Remove init function from loglist.go

### DIFF
--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -317,7 +317,3 @@ func (ll List) PickOne(operator string, expiry time.Time) (string, string, error
 	log := candidates[rand.Intn(len(candidates))]
 	return log.Url, log.Key, nil
 }
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}


### PR DESCRIPTION
Removes the `//ctpolicy/loglist.go` init function which previously seeded the math/rand global random generator in favor of Go 1.20 math/rand now doing this automatically. See release notes [here.](https://tip.golang.org/doc/go1.20)

> The [math/rand](https://tip.golang.org/pkg/math/rand/) package now automatically seeds the global random number generator (used by top-level functions like Float64 and Int) with a random value, and the top-level [Seed](https://tip.golang.org/pkg/math/rand/#Seed) function has been deprecated. Programs that need a reproducible sequence of random numbers should prefer to allocate their own random source, using rand.New(rand.NewSource(seed)).