### PR TITLE
admin: add clear-email subcommand

### DIFF
--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -50,7 +50,7 @@ descriptions:
   malformed-revoke       Revoke a single certificate by the hex serial number. Works even
                          if the certificate cannot be parsed from the database.
                          Note: This does not purge the Akamai cache.
-			 Note: This cannot be used to revoke for key compromise.
+                         Note: This cannot be used to revoke for key compromise.
   batched-serial-revoke  Revoke all certificates contained in a file of hex serial numbers.
   incident-table-revoke  Revoke all certificates in the provided incident table.
   reg-revoke             Revoke all certificates associated with a registration ID.
@@ -61,7 +61,7 @@ descriptions:
                          provided private key. Then adds the hash to the blocked keys
                          table. <priv-key-path> is expected to be the path to a PEM
                          formatted file containing an RSA or ECDSA private key.
-  clear-email			 Delete all instances of a given email from all accounts (slow).
+  clear-email            Delete all instances of a given email from all accounts (slow).
 
 flags:
   all:

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -229,8 +229,9 @@ func (r *revoker) clearEmailAddress(ctx context.Context, email string) error {
 		return err
 	}
 
-	failures := 0
 	r.log.Infof("Found %d registration IDs matching email %q.", len(regIDs), email)
+
+	failures := 0
 	for _, regID := range regIDs {
 		err := sa.ClearEmail(r.dbMap, ctx, regID, email)
 		if err != nil {
@@ -239,7 +240,7 @@ func (r *revoker) clearEmailAddress(ctx context.Context, email string) error {
 			r.log.AuditErrf("failed to clear email %q for registration ID %d: %s", email, regID, err)
 			failures++
 		} else {
-			r.log.AuditErrf("cleared email %q for registration ID %d: %s", email, regID, err)
+			r.log.AuditInfof("cleared email %q for registration ID %d: %s", email, regID, err)
 		}
 	}
 	if failures > 0 {

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -230,7 +230,7 @@ func (r *revoker) clearEmailAddress(ctx context.Context, email string) error {
 	}
 
 	failures := 0
-	r.log.Infof("Found %d registration IDs matching email %q.", len(regIDs), email, regIDs)
+	r.log.Infof("Found %d registration IDs matching email %q.", len(regIDs), email)
 	for _, regID := range regIDs {
 		err := sa.ClearEmail(r.dbMap, ctx, regID, email)
 		if err != nil {

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -41,6 +41,7 @@ usage:
   reg-revoke             -config <path> <registration-id>  <reason-code>
   private-key-block      -config <path> -comment="<string>" -dry-run=<bool>    <priv-key-path>
   private-key-revoke     -config <path> -comment="<string>" -dry-run=<bool>    <priv-key-path>
+  clear-email            -config <path> <email-address>
 
 
 descriptions:
@@ -60,6 +61,7 @@ descriptions:
                          provided private key. Then adds the hash to the blocked keys
                          table. <priv-key-path> is expected to be the path to a PEM
                          formatted file containing an RSA or ECDSA private key.
+  email-clear			 Delete all instances of a given email from all accounts (slow).
 
 flags:
   all:
@@ -215,6 +217,32 @@ func (r *revoker) revokeSerialBatchFile(ctx context.Context, serialPath string, 
 	close(work)
 	wg.Wait()
 
+	return nil
+}
+
+// clearEmailAddress clears the given email address from all accounts that have it.
+// Because it does not use an index to find the relevant accounts, it is very slow.
+func (r *revoker) clearEmailAddress(ctx context.Context, email string) error {
+	r.log.AuditInfof("Searching database for accounts with email addresses matching %q in order to clear the email addresses", email)
+	regIDs, err := r.getRegIDsMatchingEmail(email)
+	if err != nil {
+		return err
+	}
+
+	failures := 0
+	r.log.Debugf("Found %d registration IDs matching email %q: %v", len(regIDs), email, regIDs)
+	for _, regID := range regIDs {
+		err := sa.ClearEmail(r.dbMap, ctx, regID, email)
+		if err != nil {
+			// Log, but don't fail, because it took a long time to find the relevant registration IDs
+			// and we don't want to have to redo that work.
+			r.log.AuditErrf("failed to clear email %q for registration %d: %s", email, regID, err)
+			failures++
+		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("failed to clear email for %d out of %d registrations", failures, len(regIDs))
+	}
 	return nil
 }
 
@@ -397,6 +425,21 @@ func (r *revoker) countCertsMatchingSPKIHash(spkiHash []byte) (int, error) {
 		return 0, err
 	}
 	return count, nil
+}
+
+// getRegIDsMatchingEmail returns a list of registration IDs where the contacts list
+// contains the given email address. Since this uses a substring match, it is important
+// to subsequently parse the JSON list of addresses and look for exact matches.
+// Note: Since this does not use an index, it is very slow.
+func (r *revoker) getRegIDsMatchingEmail(email string) ([]int64, error) {
+	// We use SQL `CONCAT` rather than interpolating with `+` or `%s` because we want to
+	// use a `?` placeholder for the email, which prevents SQL injection.
+	var regIDs []int64
+	_, err := r.dbMap.Select(&regIDs, "SELECT id FROM registrations WHERE contact LIKE CONCAT('%\"mailto:', ?, '\"%')", email)
+	if err != nil {
+		return nil, err
+	}
+	return regIDs, nil
 }
 
 // TODO(#5899) Use an non-wrapped sql.Db client to iterate over results and
@@ -624,11 +667,20 @@ func main() {
 		err = r.revokeIncidentTableSerials(ctx, tableName, revocation.Reason(reasonCode), parallelism)
 		cmd.FailOnError(err, "Couldn't revoke serials in incident table")
 
+	case command == "clear-email" && len(args) == 1:
+		email := args[0]
+		err := r.clearEmailAddress(ctx, email)
+		cmd.FailOnError(err, "Clearing email address")
+
 	default:
+		fmt.Fprintf(os.Stderr, "unrecognized subcommand %q\n\n", command)
 		usage()
 	}
 }
 
 func init() {
+	// admin-revoker is the old name. Now that this can also clear email addresses,
+	// admin is the new name
 	cmd.RegisterCommand("admin-revoker", main, &cmd.ConfigValidator{Config: &Config{}})
+	cmd.RegisterCommand("admin", main, &cmd.ConfigValidator{Config: &Config{}})
 }

--- a/sa/db-users/boulder_sa.sql
+++ b/sa/db-users/boulder_sa.sql
@@ -55,7 +55,7 @@ GRANT SELECT ON incidents TO 'sa_ro'@'localhost';
 GRANT SELECT ON certificateStatus TO 'ocsp_resp'@'localhost';
 
 -- Revoker Tool
-GRANT SELECT ON registrations TO 'revoker'@'localhost';
+GRANT SELECT,UPDATE ON registrations TO 'revoker'@'localhost';
 GRANT SELECT ON certificates TO 'revoker'@'localhost';
 GRANT SELECT ON precertificates TO 'revoker'@'localhost';
 GRANT SELECT ON keyHashToSerial TO 'revoker'@'localhost';

--- a/sa/model.go
+++ b/sa/model.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"net"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -77,12 +76,10 @@ func ClearEmail(dbMap db.DatabaseMap, ctx context.Context, regID int64, email st
 			return nil, err
 		}
 
-		// newContacts will be a copy of currPb.Contact with the email address removed.
+		// newContacts will be a copy of all emails in currPb.Contact _except_ the oneto be removed
 		var newContacts []string
 		for _, contact := range currPb.Contact {
-			if contact == "mailto:"+email {
-				fmt.Fprintf(os.Stderr, "Skipping %s\n", contact)
-			} else {
+			if contact != "mailto:"+email {
 				newContacts = append(newContacts, contact)
 			}
 		}

--- a/test/config-next/admin.json
+++ b/test/config-next/admin.json
@@ -1,0 +1,1 @@
+admin-revoker.json

--- a/test/config/admin.json
+++ b/test/config/admin.json
@@ -1,0 +1,1 @@
+admin-revoker.json

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/eggsampler/acme/v3"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestAdminClearEmail(t *testing.T) {
+	t.Parallel()
+	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
+
+	// Note that `example@mail.example.letsencrypt.org` is a substring of `long-example@mail.example.letsencrypt.org`.
+	// We specifically want to test that the superstring does not get removed, even though we use substring matching
+	// as an initial filter.
+	client1, err := makeClient("mailto:example@mail.example.letsencrypt.org", "mailto:long-example@mail.example.letsencrypt.org", "mailto:third-example@mail.example.letsencrypt.org")
+	test.AssertNotError(t, err, "creating first acme client")
+	
+	client2, err := makeClient("mailto:example@mail.example.letsencrypt.org")
+	test.AssertNotError(t, err, "creating second acme client")
+	
+	client3, err := makeClient("mailto:other@mail.example.letsencrypt.org")
+	test.AssertNotError(t, err, "creating second acme client")
+	
+	deleteMe := "example@mail.example.letsencrypt.org"
+	config := fmt.Sprintf("%s/%s", os.Getenv("BOULDER_CONFIG_DIR"), "admin-revoker.json")
+	cmd := exec.Command("./bin/admin", "clear-email", 
+		"-config", config,
+		deleteMe)
+	output, err := cmd.CombinedOutput()
+	test.AssertNotError(t, err, fmt.Sprintf("clearing email via admin tool (%s): %s", cmd, string(output)))
+	t.Logf("clear-email output: %s\n", string(output))
+	
+	updatedAccount1, err := client1.NewAccountOptions(client1.PrivateKey, acme.NewAcctOptOnlyReturnExisting())
+	test.AssertNotError(t, err, "fetching updated account for first client")
+
+	t.Log(updatedAccount1.Contact)
+	test.AssertDeepEquals(t, updatedAccount1.Contact,
+		[]string{"mailto:long-example@mail.example.letsencrypt.org", "mailto:third-example@mail.example.letsencrypt.org"})
+
+	updatedAccount2, err := client2.NewAccountOptions(client2.PrivateKey, acme.NewAcctOptOnlyReturnExisting())
+	test.AssertNotError(t, err, "fetching updated account for second client")
+	test.AssertDeepEquals(t, updatedAccount2.Contact, []string(nil))
+
+	updatedAccount3, err := client3.NewAccountOptions(client3.PrivateKey, acme.NewAcctOptOnlyReturnExisting())
+	test.AssertNotError(t, err, "fetching updated account for third client")
+	test.AssertDeepEquals(t, updatedAccount3.Contact, []string{"mailto:other@mail.example.letsencrypt.org"})
+}


### PR DESCRIPTION
When a user wants their email address deleted from the database but no longer has access to their account, this allows an administrator to clear it.

This adds `admin` as an alias for `admin-revoker`, because we'd like the clear-email sub-command to be a part of that overall tool, but it's not really revocation related.

Part of #6864 