### PR TITLE
test: better message for different empty slices

### DIFF
--- a/test/asserts.go
+++ b/test/asserts.go
@@ -118,7 +118,7 @@ func AssertEquals(t *testing.T, one interface{}, two interface{}) {
 func AssertDeepEquals(t *testing.T, one interface{}, two interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(one, two) {
-		t.Fatalf("[%+v] !(deep)= [%+v]", one, two)
+		t.Fatalf("[%#v] !(deep)= [%#v]", one, two)
 	}
 }
 


### PR DESCRIPTION
Given two empty slices, one that is equal to nil and one that is not, AssertDeepEquals used to produce this confusing output:

    [[]] !(deep)= [[]]

After this change, it produces:

    [[]string(nil)] !(deep)= [[]string{}]