### PR TITLE
CAA: Don't fail on critical iodef property tags

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -105,9 +105,10 @@ func filterCAA(rrs []*dns.CAA) ([]*dns.CAA, []*dns.CAA, bool) {
 		case "issuewild":
 			issuewild = append(issuewild, caaRecord)
 		case "iodef":
-			// We "know about" but do not "support" the iodef property tag. Therefore
-			// we don't keep track of it, but do avoid setting the criticalUnknown bit
-			// if there are critical iodef records.
+			// We support the iodef property tag inasumch as we recognize it, but we
+			// never choose to send notifications to the specified addresses. So we
+			// do not store the contents of the property tag, but also avoid setting
+			// the criticalUnknown bit if there are critical iodef tags.
 			continue
 		default:
 			// The critical flag is the bit with significance 128. However, many CAA

--- a/va/caa.go
+++ b/va/caa.go
@@ -105,7 +105,7 @@ func filterCAA(rrs []*dns.CAA) ([]*dns.CAA, []*dns.CAA, bool) {
 		case "issuewild":
 			issuewild = append(issuewild, caaRecord)
 		case "iodef":
-			// We support the iodef property tag inasumch as we recognize it, but we
+			// We support the iodef property tag insofar as we recognize it, but we
 			// never choose to send notifications to the specified addresses. So we
 			// do not store the contents of the property tag, but also avoid setting
 			// the criticalUnknown bit if there are critical iodef tags.

--- a/va/caa.go
+++ b/va/caa.go
@@ -104,6 +104,11 @@ func filterCAA(rrs []*dns.CAA) ([]*dns.CAA, []*dns.CAA, bool) {
 			issue = append(issue, caaRecord)
 		case "issuewild":
 			issuewild = append(issuewild, caaRecord)
+		case "iodef":
+			// We "know about" but do not "support" the iodef property tag. Therefore
+			// we don't keep track of it, but do avoid setting the criticalUnknown bit
+			// if there are critical iodef records.
+			continue
 		default:
 			// The critical flag is the bit with significance 128. However, many CAA
 			// record users have misinterpreted the RFC and concluded that the bit

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -646,16 +646,17 @@ func TestFilterCAA(t *testing.T) {
 		expectedCU        bool
 	}{
 		{
-			name: "happy path",
+			name: "recognized non-critical",
 			input: []*dns.CAA{
 				{Tag: "issue", Value: "a"},
 				{Tag: "issuewild", Value: "b"},
+				{Tag: "iodef", Value: "c"},
 			},
 			expectedIssueVals: []string{"a"},
 			expectedWildVals:  []string{"b"},
 		},
 		{
-			name: "recognized criticals",
+			name: "recognized critical",
 			input: []*dns.CAA{
 				{Tag: "issue", Value: "a", Flag: 128},
 				{Tag: "issuewild", Value: "b", Flag: 128},
@@ -665,15 +666,29 @@ func TestFilterCAA(t *testing.T) {
 			expectedWildVals:  []string{"b"},
 		},
 		{
-			name: "uncritical unknown",
+			name: "unrecognized non-critical",
 			input: []*dns.CAA{
 				{Tag: "unknown", Flag: 2},
 			},
 		},
 		{
-			name: "critical unknown",
+			name: "unrecognized critical",
 			input: []*dns.CAA{
 				{Tag: "unknown", Flag: 128},
+			},
+			expectedCU: true,
+		},
+		{
+			name: "unrecognized improper critical",
+			input: []*dns.CAA{
+				{Tag: "unknown", Flag: 1},
+			},
+			expectedCU: true,
+		},
+		{
+			name: "unrecognized very improper critical",
+			input: []*dns.CAA{
+				{Tag: "unknown", Flag: 9},
 			},
 			expectedCU: true,
 		},


### PR DESCRIPTION
RFC 8659 (CAA; https://www.rfc-editor.org/rfc/rfc8659) says that "A CA MUST NOT issue certificates for any FQDN if the Relevant RRset for that FQDN contains a CAA critical Property for an unknown or unsupported Property Tag."

Let's Encrypt does technically support the iodef property tag: we recognize it, but then ignore it and never choose to send notifications to the given contact address. Historically, we have carried around the iodef property tags in our internal structures as though we might use them, but all code referencing them was essentially dead code.

As part of a set of simplifications, https://github.com/letsencrypt/boulder/pull/6886 made it so that we completely ignore iodef property tags. However, this had the unintended side-effect of causing iodef property tags with the Critical bit set to be counted as "unknown critical" tags, which prevent issuance.

This change causes our property tag parsing code to recognize iodef tags again, so that critical iodef tags don't prevent issuance.