### PR TITLE
Don't update the notAfter Gauge with zeros

### DIFF
--- a/observer/probers/tls/tls.go
+++ b/observer/probers/tls/tls.go
@@ -98,7 +98,9 @@ func (p TLSProbe) checkRoot(rootOrg, rootCN string) error {
 
 // Export expiration timestamp and reason to Prometheus.
 func (p TLSProbe) exportMetrics(notAfter time.Time, reason reason) {
-	p.notAfter.WithLabelValues(p.hostname).Set(float64(notAfter.Unix()))
+	if !notAfter.IsZero() {
+		p.notAfter.WithLabelValues(p.hostname).Set(float64(notAfter.Unix()))
+	}
 	p.reason.WithLabelValues(p.hostname, reasonToString[reason]).Inc()
 }
 


### PR DESCRIPTION
This is a bit jank:  I think ideally we'd only ever call exportMetrics with a valid time, but that's a bit bigger of a refactor of this code.

This was the fix we lightly decided on in the discussion of #6635

Fixes #6635
