### PR TITLE
sa: refactor db initialization

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -84,7 +84,7 @@ func TestRevokeIncidentTableSerials(t *testing.T) {
 	entries, _ := setupUniqueTestEntries(t)
 	testCtx.createAndRegisterEntries(t, entries)
 
-	testIncidentsDbMap, err := sa.NewDbMap(vars.DBConnIncidentsFullPerms, sa.DbSettings{})
+	testIncidentsDbMap, err := sa.DBMapForTest(vars.DBConnIncidentsFullPerms)
 	test.AssertNotError(t, err, "Couldn't create test dbMap")
 
 	// Ensure that an empty incident table results in the expected log output.
@@ -440,11 +440,11 @@ func setup(t *testing.T) testCtx {
 	// Set some non-zero time for GRPC requests to be non-nil.
 	fc.Set(time.Now())
 
-	dbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
-	incidentsDbMap, err := sa.NewDbMap(vars.DBConnIncidents, sa.DbSettings{})
+	incidentsDbMap, err := sa.DBMapForTest(vars.DBConnIncidents)
 	test.AssertNotError(t, err, "Couldn't create test dbMap")
 
 	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, incidentsDbMap, 1, 0, fc, log, metrics.NoopRegisterer)

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -48,7 +48,7 @@ func insertBlockedRow(t *testing.T, dbMap *db.WrappedMap, fc clock.Clock, hash [
 }
 
 func TestSelectUncheckedRows(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 
@@ -178,7 +178,7 @@ func insertCert(t *testing.T, dbMap *db.WrappedMap, fc clock.Clock, keyHash []by
 // does not have a corresponding entry in the certificateStatus and
 // precertificates table.
 func TestFindUnrevokedNoRows(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 
@@ -199,7 +199,7 @@ func TestFindUnrevokedNoRows(t *testing.T) {
 }
 
 func TestFindUnrevoked(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 
@@ -233,7 +233,7 @@ func TestFindUnrevoked(t *testing.T) {
 }
 
 func TestResolveContacts(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 
@@ -286,7 +286,7 @@ func (mr *mockRevoker) AdministrativelyRevokeCertificate(ctx context.Context, in
 }
 
 func TestRevokeCerts(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 
@@ -308,7 +308,7 @@ func TestRevokeCerts(t *testing.T) {
 }
 
 func TestCertificateAbsent(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 
@@ -345,7 +345,7 @@ func TestCertificateAbsent(t *testing.T) {
 }
 
 func TestInvoke(t *testing.T) {
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 
@@ -417,7 +417,7 @@ func TestInvokeRevokerHasNoExtantCerts(t *testing.T) {
 	// extant certificates themselves their contact email is still
 	// resolved and we avoid sending any emails to accounts that
 	// share the same email.
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -91,7 +91,7 @@ func BenchmarkCheckCert(b *testing.B) {
 }
 
 func TestCheckWildcardCert(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	saCleanup := test.ResetBoulderTestDatabase(t)
 	defer func() {
@@ -137,7 +137,7 @@ func TestCheckWildcardCert(t *testing.T) {
 }
 
 func TestCheckCertReturnsDNSNames(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	saCleanup := test.ResetBoulderTestDatabase(t)
 	defer func() {
@@ -186,7 +186,7 @@ func (*rsa2048Generator) genKey() (crypto.Signer, error) {
 }
 
 func TestCheckCert(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	saCleanup := test.ResetBoulderTestDatabase(t)
 	defer func() {
@@ -326,7 +326,7 @@ func TestCheckCert(t *testing.T) {
 }
 
 func TestGetAndProcessCerts(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	fc := clock.NewFake()
 	fc.Set(fc.Now().Add(time.Hour))
@@ -419,7 +419,7 @@ func (db mismatchedCountDB) Select(output interface{}, _ string, _ ...interface{
  * 0: https://github.com/letsencrypt/boulder/issues/2004
  */
 func TestGetCertsEmptyResults(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations, blog.NewMock())
 	checker.dbMap = mismatchedCountDB{}
@@ -447,7 +447,7 @@ func (db emptyDB) SelectNullInt(_ string, _ ...interface{}) (sql.NullInt64, erro
 // expected if the DB finds no certificates to match the SELECT query and
 // should return an error.
 func TestGetCertsNullResults(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations, blog.NewMock())
 	checker.dbMap = emptyDB{}
@@ -521,7 +521,7 @@ func TestIsForbiddenDomain(t *testing.T) {
 }
 
 func TestIgnoredLint(t *testing.T) {
-	saDbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	test.AssertNotError(t, err, "Couldn't connect to database")
 	saCleanup := test.ResetBoulderTestDatabase(t)
 	defer func() {

--- a/cmd/contact-auditor/main_test.go
+++ b/cmd/contact-auditor/main_test.go
@@ -179,7 +179,7 @@ func setup(t *testing.T) testCtx {
 
 	// Using DBConnSAFullPerms to be able to insert registrations and
 	// certificates
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	if err != nil {
 		t.Fatalf("Couldn't connect to the database: %s", err)
 	}
@@ -196,7 +196,7 @@ func setup(t *testing.T) testCtx {
 		os.Remove(file.Name())
 	}
 
-	db, err := sa.NewDbMap(vars.DBConnSAMailer, sa.DbSettings{})
+	db, err := sa.DBMapForTest(vars.DBConnSAMailer)
 	if err != nil {
 		t.Fatalf("Couldn't connect to the database: %s", err)
 	}

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -348,7 +348,7 @@ func TestNoContactCertIsRenewed(t *testing.T) {
 	err = insertCertificate(cert, time.Time{})
 	test.AssertNotError(t, err, "inserting certificate")
 
-	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	setupDBMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "setting up DB")
 	err = setupDBMap.Insert(&core.FQDNSet{
 		SetHash: sa.HashNames(names),
@@ -503,7 +503,7 @@ func insertCertificate(cert certDERWithRegID, lastNagSent time.Time) error {
 		return err
 	}
 
-	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	setupDBMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	if err != nil {
 		return err
 	}
@@ -597,7 +597,7 @@ func addExpiringCerts(t *testing.T, ctx *testCtx) []certDERWithRegID {
 	err = insertCertificate(certD, ctx.fc.Now().Add(-36*time.Hour))
 	test.AssertNotError(t, err, "inserting certD")
 
-	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	setupDBMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "setting up DB")
 	err = setupDBMap.Insert(fqdnStatusD)
 	test.AssertNotError(t, err, "Couldn't add fqdnStatusD")
@@ -723,7 +723,7 @@ func TestCertIsRenewed(t *testing.T) {
 		},
 	}
 
-	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	setupDBMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -858,7 +858,7 @@ func TestDontFindRevokedCert(t *testing.T) {
 	err = insertCertificate(certA, time.Time{})
 	test.AssertNotError(t, err, "inserting certificate")
 
-	setupDBMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	setupDBMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "sa.NewDbMap failed")
 	_, err = setupDBMap.Exec("UPDATE certificateStatus SET status = ? WHERE serial = ?",
 		string(core.OCSPStatusRevoked), core.SerialToString(serial1))
@@ -933,7 +933,7 @@ type testCtx struct {
 func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
 	// We use the test_setup user (which has full permissions to everything)
 	// because the SA we return is used for inserting data to set up the test.
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	if err != nil {
 		t.Fatalf("Couldn't connect the database: %s", err)
 	}

--- a/cmd/id-exporter/main_test.go
+++ b/cmd/id-exporter/main_test.go
@@ -442,7 +442,7 @@ func setup(t *testing.T) testCtx {
 	fc := clock.NewFake()
 
 	// Using DBConnSAFullPerms to be able to insert registrations and certificates
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	if err != nil {
 		t.Fatalf("Couldn't connect the database: %s", err)
 	}

--- a/cmd/rocsp-tool/client_test.go
+++ b/cmd/rocsp-tool/client_test.go
@@ -51,7 +51,7 @@ func makeClient() (*rocsp.RWClient, clock.Clock) {
 
 func TestGetStartingID(t *testing.T) {
 	clk := clock.NewFake()
-	dbMap, err := sa.NewDbMap(vars.DBConnSAFullPerms, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
 	sa.SetSQLDebug(dbMap, blog.Get())
@@ -121,7 +121,7 @@ func (mog mockOCSPGenerator) GenerateOCSP(ctx context.Context, in *capb.Generate
 func TestLoadFromDB(t *testing.T) {
 	redisClient, clk := makeClient()
 
-	dbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -315,7 +315,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	// Set to some non-zero time.
 	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
 
-	dbMap, err := sa.NewDbMap(vars.DBConnSA, sa.DbSettings{})
+	dbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}

--- a/sa/database.go
+++ b/sa/database.go
@@ -145,9 +145,9 @@ var setConnMaxIdleTime = func(db *sql.DB, connMaxIdleTime time.Duration) {
 // is usually provided from JSON config.
 //
 // This function also:
-//  - pings the database (and errors if it's unreachable)
-//  - wraps the connection in a gorp.DbMap so we can use the handy Get/Insert methods gorp provides
-//  - wraps that in a db.WrappedMap to get more useful error messages
+//   - pings the database (and errors if it's unreachable)
+//   - wraps the connection in a gorp.DbMap so we can use the handy Get/Insert methods gorp provides
+//   - wraps that in a db.WrappedMap to get more useful error messages
 func newDbMapFromMysqlConfig(config *mysql.Config, settings DbSettings) (*boulderDB.WrappedMap, error) {
 	err := adjustMySQLConfig(config)
 	if err != nil {

--- a/sa/database.go
+++ b/sa/database.go
@@ -46,8 +46,8 @@ type DbSettings struct {
 }
 
 // InitWrappedDb constructs a wrapped gorp mapping object with the provided
-// settings. If scope is non-Nil database metrics will be initialized. If logger
-// is non-Nil (gorp) SQL debugging will be enabled. The only required parameter
+// settings. If scope is non-nil, Prometheus metrics will be exported. If logger
+// is non-nil, SQL debug-level logging will be enabled. The only required parameter
 // is config.
 func InitWrappedDb(config cmd.DBConfig, scope prometheus.Registerer, logger blog.Logger) (*boulderDB.WrappedMap, error) {
 	url, err := config.URL()
@@ -62,9 +62,14 @@ func InitWrappedDb(config cmd.DBConfig, scope prometheus.Registerer, logger blog
 		ConnMaxIdleTime: config.ConnMaxIdleTime.Duration,
 	}
 
-	dbMap, err := NewDbMap(url, settings)
+	mysqlConfig, err := mysql.ParseDSN(url)
 	if err != nil {
-		return nil, fmt.Errorf("while initializing database connection: %s", err)
+		return nil, err
+	}
+
+	dbMap, err := newDbMapFromMysqlConfig(mysqlConfig, settings)
+	if err != nil {
+		return nil, err
 	}
 
 	if logger != nil {
@@ -77,7 +82,7 @@ func InitWrappedDb(config cmd.DBConfig, scope prometheus.Registerer, logger blog
 	}
 
 	if scope != nil {
-		err = InitDBMetrics(dbMap.Db, scope, settings, addr, user)
+		err = initDBMetrics(dbMap.Db, scope, settings, addr, user)
 		if err != nil {
 			return nil, fmt.Errorf("while initializing metrics: %w", err)
 		}
@@ -85,11 +90,11 @@ func InitWrappedDb(config cmd.DBConfig, scope prometheus.Registerer, logger blog
 	return dbMap, nil
 }
 
-// NewDbMap creates a wrapped root gorp mapping object. Create one of these for
+// DBMapForTest creates a wrapped root gorp mapping object. Create one of these for
 // each database schema you wish to map. Each DbMap contains a list of mapped
 // tables. It automatically maps the tables for the primary parts of Boulder
 // around the Storage Authority.
-func NewDbMap(dbConnect string, settings DbSettings) (*boulderDB.WrappedMap, error) {
+func DBMapForTest(dbConnect string) (*boulderDB.WrappedMap, error) {
 	var err error
 	var config *mysql.Config
 
@@ -98,7 +103,7 @@ func NewDbMap(dbConnect string, settings DbSettings) (*boulderDB.WrappedMap, err
 		return nil, err
 	}
 
-	return NewDbMapFromConfig(config, settings)
+	return newDbMapFromMysqlConfig(config, DbSettings{})
 }
 
 // sqlOpen is used in the tests to check that the arguments are properly
@@ -135,9 +140,15 @@ var setConnMaxIdleTime = func(db *sql.DB, connMaxIdleTime time.Duration) {
 	}
 }
 
-// NewDbMapFromConfig functions similarly to NewDbMap, but it takes the
-// decomposed form of the connection string, a *mysql.Config.
-func NewDbMapFromConfig(config *mysql.Config, settings DbSettings) (*boulderDB.WrappedMap, error) {
+// newDbMapFromMysqlConfig opens a database connection given the provided *mysql.Config, plus some Boulder-specific
+// required and default settings, plus some additional config in the sa.DbSettings object. The sa.DbSettings object
+// is usually provided from JSON config.
+//
+// This function also:
+//  - pings the database (and errors if it's unreachable)
+//  - wraps the connection in a gorp.DbMap so we can use the handy Get/Insert methods gorp provides
+//  - wraps that in a db.WrappedMap to get more useful error messages
+func newDbMapFromMysqlConfig(config *mysql.Config, settings DbSettings) (*boulderDB.WrappedMap, error) {
 	err := adjustMySQLConfig(config)
 	if err != nil {
 		return nil, err

--- a/sa/database.go
+++ b/sa/database.go
@@ -67,7 +67,7 @@ func InitWrappedDb(config cmd.DBConfig, scope prometheus.Registerer, logger blog
 		return nil, err
 	}
 
-	dbMap, err := newDbMapFromMysqlConfig(mysqlConfig, settings)
+	dbMap, err := newDbMapFromMySQLConfig(mysqlConfig, settings)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func DBMapForTest(dbConnect string) (*boulderDB.WrappedMap, error) {
 		return nil, err
 	}
 
-	return newDbMapFromMysqlConfig(config, DbSettings{})
+	return newDbMapFromMySQLConfig(config, DbSettings{})
 }
 
 // sqlOpen is used in the tests to check that the arguments are properly
@@ -140,7 +140,7 @@ var setConnMaxIdleTime = func(db *sql.DB, connMaxIdleTime time.Duration) {
 	}
 }
 
-// newDbMapFromMysqlConfig opens a database connection given the provided *mysql.Config, plus some Boulder-specific
+// newDbMapFromMySQLConfig opens a database connection given the provided *mysql.Config, plus some Boulder-specific
 // required and default settings, plus some additional config in the sa.DbSettings object. The sa.DbSettings object
 // is usually provided from JSON config.
 //
@@ -148,7 +148,7 @@ var setConnMaxIdleTime = func(db *sql.DB, connMaxIdleTime time.Duration) {
 //   - pings the database (and errors if it's unreachable)
 //   - wraps the connection in a gorp.DbMap so we can use the handy Get/Insert methods gorp provides
 //   - wraps that in a db.WrappedMap to get more useful error messages
-func newDbMapFromMysqlConfig(config *mysql.Config, settings DbSettings) (*boulderDB.WrappedMap, error) {
+func newDbMapFromMySQLConfig(config *mysql.Config, settings DbSettings) (*boulderDB.WrappedMap, error) {
 	err := adjustMySQLConfig(config)
 	if err != nil {
 		return nil, err

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -77,6 +77,7 @@ func TestDbSettings(t *testing.T) {
 	err := os.WriteFile(dsnFile,
 		[]byte("sa@tcp(boulder-proxysql:6033)/boulder_sa_integration"),
 		os.ModeAppend)
+	test.AssertNotError(t, err, "writing dbconnect file")
 
 	config := cmd.DBConfig{
 		DBConnectFile:   dsnFile,

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -75,11 +75,11 @@ func TestDbSettings(t *testing.T) {
 	}
 	dsnFile := path.Join(t.TempDir(), "dbconnect")
 	err := os.WriteFile(dsnFile,
-	    []byte("sa@tcp(boulder-proxysql:6033)/boulder_sa_integration"),
-	    os.ModeAppend)
+		[]byte("sa@tcp(boulder-proxysql:6033)/boulder_sa_integration"),
+		os.ModeAppend)
 
-	config := cmd.DBConfig {
-		DBConnectFile: dsnFile,
+	config := cmd.DBConfig{
+		DBConnectFile:   dsnFile,
 		MaxOpenConns:    100,
 		MaxIdleConns:    100,
 		ConnMaxLifetime: config.Duration{Duration: 100 * time.Second},
@@ -95,10 +95,10 @@ func TestDbSettings(t *testing.T) {
 	if maxIdleConns != 100 {
 		t.Errorf("maxIdleConns was not set: expected 100, got %d", maxIdleConns)
 	}
-	if connMaxLifetime != 100 * time.Second {
+	if connMaxLifetime != 100*time.Second {
 		t.Errorf("connMaxLifetime was not set: expected 100s, got %s", connMaxLifetime)
 	}
-	if connMaxIdleTime != 100 * time.Second {
+	if connMaxIdleTime != 100*time.Second {
 		t.Errorf("connMaxIdleTime was not set: expected 100s, got %s", connMaxIdleTime)
 	}
 }
@@ -145,7 +145,7 @@ func TestStrictness(t *testing.T) {
 }
 
 func TestTimeouts(t *testing.T) {
-	dbMap, err := DBMapForTest(vars.DBConnSA+"?max_statement_time=1")
+	dbMap, err := DBMapForTest(vars.DBConnSA + "?max_statement_time=1")
 	if err != nil {
 		t.Fatal("Error setting up DB:", err)
 	}

--- a/sa/database_test.go
+++ b/sa/database_test.go
@@ -3,33 +3,37 @@ package sa
 import (
 	"database/sql"
 	"errors"
+	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
 )
 
 func TestInvalidDSN(t *testing.T) {
-	_, err := NewDbMap("invalid", DbSettings{})
+	_, err := DBMapForTest("invalid")
 	test.AssertError(t, err, "DB connect string missing the slash separating the database name")
 
 	DSN := "policy:password@tcp(boulder-proxysql:6033)/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms&stringVarThatDoesntExist=%27whoopsidaisies"
-	_, err = NewDbMap(DSN, DbSettings{})
+	_, err = DBMapForTest(DSN)
 	test.AssertError(t, err, "Variable does not exist in curated system var list, but didn't return an error and should have")
 
 	DSN = "policy:password@tcp(boulder-proxysql:6033)/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms&concurrent_insert=2"
-	_, err = NewDbMap(DSN, DbSettings{})
+	_, err = DBMapForTest(DSN)
 	test.AssertError(t, err, "Variable is unable to be set in the SESSION scope, but was declared")
 
 	DSN = "policy:password@tcp(boulder-proxysql:6033)/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms&optimizer_switch=incorrect-quoted-string"
-	_, err = NewDbMap(DSN, DbSettings{})
+	_, err = DBMapForTest(DSN)
 	test.AssertError(t, err, "Variable declared with incorrect quoting")
 
 	DSN = "policy:password@tcp(boulder-proxysql:6033)/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms&concurrent_insert=%272%27"
-	_, err = NewDbMap(DSN, DbSettings{})
+	_, err = DBMapForTest(DSN)
 	test.AssertError(t, err, "Integer enum declared, but should not have been quoted")
 }
 
@@ -69,30 +73,37 @@ func TestDbSettings(t *testing.T) {
 		connMaxIdleTime = c
 		oldSetConnMaxIdleTime(db, connMaxIdleTime)
 	}
-	dbSettings := DbSettings{
+	dsnFile := path.Join(t.TempDir(), "dbconnect")
+	err := os.WriteFile(dsnFile,
+	    []byte("sa@tcp(boulder-proxysql:6033)/boulder_sa_integration"),
+	    os.ModeAppend)
+
+	config := cmd.DBConfig {
+		DBConnectFile: dsnFile,
 		MaxOpenConns:    100,
 		MaxIdleConns:    100,
-		ConnMaxLifetime: 100,
-		ConnMaxIdleTime: 100,
+		ConnMaxLifetime: config.Duration{Duration: 100 * time.Second},
+		ConnMaxIdleTime: config.Duration{Duration: 100 * time.Second},
 	}
-	_, err := NewDbMap("sa@tcp(boulder-proxysql:6033)/boulder_sa_integration", dbSettings)
+	_, err = InitWrappedDb(config, nil, nil)
 	if err != nil {
 		t.Errorf("connecting to DB: %s", err)
 	}
 	if maxOpenConns != 100 {
-		t.Errorf("maxOpenConns was not set: expected %d, got %d", 100, maxOpenConns)
+		t.Errorf("maxOpenConns was not set: expected 100, got %d", maxOpenConns)
 	}
 	if maxIdleConns != 100 {
-		t.Errorf("maxIdleConns was not set: expected %d, got %d", 100, maxIdleConns)
+		t.Errorf("maxIdleConns was not set: expected 100, got %d", maxIdleConns)
 	}
-	if connMaxLifetime != 100 {
-		t.Errorf("connMaxLifetime was not set: expected %d, got %d", 100, connMaxLifetime)
+	if connMaxLifetime != 100 * time.Second {
+		t.Errorf("connMaxLifetime was not set: expected 100s, got %s", connMaxLifetime)
 	}
-	if connMaxIdleTime != 100 {
-		t.Errorf("connMaxIdleTime was not set: expected %d, got %d", 100, connMaxIdleTime)
+	if connMaxIdleTime != 100 * time.Second {
+		t.Errorf("connMaxIdleTime was not set: expected 100s, got %s", connMaxIdleTime)
 	}
 }
 
+// TODO: Change this to test `newDbMapFromMySQLConfig` instead?
 func TestNewDbMap(t *testing.T) {
 	const mysqlConnectURL = "policy:password@tcp(boulder-proxysql:6033)/boulder_policy_integration?readTimeout=800ms&writeTimeout=800ms"
 	const expected = "policy:password@tcp(boulder-proxysql:6033)/boulder_policy_integration?clientFoundRows=true&parseTime=true&readTimeout=800ms&writeTimeout=800ms&long_query_time=0.6400000000000001&max_statement_time=0.76&sql_mode=%27STRICT_ALL_TABLES%27"
@@ -107,7 +118,7 @@ func TestNewDbMap(t *testing.T) {
 		return nil, errExpected
 	}
 
-	dbMap, err := NewDbMap(mysqlConnectURL, DbSettings{})
+	dbMap, err := DBMapForTest(mysqlConnectURL)
 	if err != errExpected {
 		t.Errorf("got incorrect error. Got %v, expected %v", err, errExpected)
 	}
@@ -118,7 +129,7 @@ func TestNewDbMap(t *testing.T) {
 }
 
 func TestStrictness(t *testing.T) {
-	dbMap, err := NewDbMap(vars.DBConnSA, DbSettings{1, 0, 0, 0})
+	dbMap, err := DBMapForTest(vars.DBConnSA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +145,7 @@ func TestStrictness(t *testing.T) {
 }
 
 func TestTimeouts(t *testing.T) {
-	dbMap, err := NewDbMap(vars.DBConnSA+"?max_statement_time=1", DbSettings{1, 0, 0, 0})
+	dbMap, err := DBMapForTest(vars.DBConnSA+"?max_statement_time=1")
 	if err != nil {
 		t.Fatal("Error setting up DB:", err)
 	}
@@ -158,7 +169,7 @@ func TestTimeouts(t *testing.T) {
 // databases that have auto_increment columns use BIGINT for the data type. Our
 // data is too big for INT.
 func TestAutoIncrementSchema(t *testing.T) {
-	dbMap, err := NewDbMap(vars.DBInfoSchemaRoot, DbSettings{1, 0, 0, 0})
+	dbMap, err := DBMapForTest(vars.DBInfoSchemaRoot)
 	test.AssertNotError(t, err, "unexpected err making NewDbMap")
 
 	var count int64

--- a/sa/metrics.go
+++ b/sa/metrics.go
@@ -61,10 +61,11 @@ func (dbc dbMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	writeCounter(dbc.maxLifetimeClosed, float64(dbMapStats.MaxLifetimeClosed))
 }
 
-// InitDBMetrics will register a Collector that translates the provided dbMap's
-// stats and DbSettings into Prometheus metrics on the fly. The stat values will
-// be translated from the gorp dbMap's inner sql.DBMap's DBStats structure values
-func InitDBMetrics(db *sql.DB, stats prometheus.Registerer, dbSettings DbSettings, address string, user string) error {
+// initDBMetrics will register a Collector that translates the provided dbMap's
+// stats and DbSettings into Prometheus metrics on the fly. The exported metrics
+// all start with `db_`. The underlying data comes from sql.DBStats:
+// https://pkg.go.dev/database/sql#DBStats
+func initDBMetrics(db *sql.DB, stats prometheus.Registerer, dbSettings DbSettings, address string, user string) error {
 	// Create a dbMetricsCollector and register it
 	dbc := dbMetricsCollector{db: db, dbSettings: dbSettings}
 

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -66,12 +66,12 @@ func initSA(t *testing.T) (*SQLStorageAuthority, clock.FakeClock, func()) {
 	t.Helper()
 	features.Reset()
 
-	dbMap, err := NewDbMap(vars.DBConnSA, DbSettings{})
+	dbMap, err := DBMapForTest(vars.DBConnSA)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
 
-	dbIncidentsMap, err := NewDbMap(vars.DBConnIncidents, DbSettings{})
+	dbIncidentsMap, err := DBMapForTest(vars.DBConnIncidents)
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
@@ -2918,10 +2918,10 @@ func TestIncidentsForSerial(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
-	testSADbMap, err := NewDbMap(vars.DBConnSAFullPerms, DbSettings{})
+	testSADbMap, err := DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "Couldn't create test dbMap")
 
-	testIncidentsDbMap, err := NewDbMap(vars.DBConnIncidentsFullPerms, DbSettings{})
+	testIncidentsDbMap, err := DBMapForTest(vars.DBConnIncidentsFullPerms)
 	test.AssertNotError(t, err, "Couldn't create test dbMap")
 	defer test.ResetIncidentsTestDatabase(t)
 
@@ -3013,7 +3013,7 @@ func TestSerialsForIncident(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
-	testIncidentsDbMap, err := NewDbMap(vars.DBConnIncidentsFullPerms, DbSettings{})
+	testIncidentsDbMap, err := DBMapForTest(vars.DBConnIncidentsFullPerms)
 	test.AssertNotError(t, err, "Couldn't create test dbMap")
 	defer test.ResetIncidentsTestDatabase(t)
 


### PR DESCRIPTION
Previously, we had three chained calls initializing a database:

 - InitWrappedDb calls NewDbMap
 - NewDbMap calls NewDbMapFromConfig

Since all three are exporetd, this left me wondering when to call one vs the others.

It turns out that NewDbMap is only called from tests, so I renamed it to DBMapForTest to make that clear.

NewDbMapFromConfig is only called internally to the SA, so I made it unexported it as newDbMapFromMysqlConfig.

Also, I copied the ParseDSN call into InitWrappedDb, so it doesn't need to call DBMapForTest. Now InitWrappedDb and DBMapForTest both independently call newDbMapFromMysqlConfig.

I also noticed that InitDBMetrics was only called internally so I unexported it.