### PR TITLE
log: don't emit excess zeroes in stack traces

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -278,7 +278,7 @@ func (log *impl) auditAtLevel(level syslog.Priority, msg string, a ...interface{
 func (log *impl) AuditPanic() {
 	err := recover()
 	if err != nil {
-		buf := make([]byte, 8192)
+		var buf []byte
 		log.AuditErrf("Panic caused by err: %s", err)
 
 		runtime.Stack(buf, false)


### PR DESCRIPTION
Previously, we allocated a buffer of 8192 bytes to write the stack trace into. Presumably the intent was to set the _capacity_ to 8192 bytes but leave the length at 0:

    make([]byte, 0, 8192)

However, the code as written set the length to 8192 as well. This meant that any time we logged a stack trace from a panic, if the stack trace was less than 8192 bytes, we'd additionally log a bunch of zero bytes.

Setting the capacity was premature optimization anyhow.

Fixes #6931