### PR TITLE
wfe: return proper error for goodkey timeout

### DIFF
--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1521,7 +1521,7 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 	kp, err = goodkey.NewKeyPolicy(&goodkey.Config{}, badKeyCheckFunc)
 	test.AssertNotError(t, err, "making key policy")
 
-	wfe.keyPolicy =  kp
+	wfe.keyPolicy = kp
 
 	_, _, validJWSBody = signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
 	request = makePostRequestWithPath("test", validJWSBody)

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1499,9 +1499,6 @@ func TestValidPOSTForAccountSwappedKey(t *testing.T) {
 func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 	wfe, _, signer := setupWFE(t)
 
-	_, _, validJWSBody := signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
-	request := makePostRequestWithPath("test", validJWSBody)
-
 	timeoutErrCheckFunc := func(ctx context.Context, keyHash []byte) (bool, error) {
 		return false, context.DeadlineExceeded
 	}
@@ -1510,6 +1507,9 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 	test.AssertNotError(t, err, "making key policy")
 
 	wfe.keyPolicy = kp
+
+	_, _, validJWSBody := signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
+	request := makePostRequestWithPath("test", validJWSBody)
 
 	_, _, prob := wfe.validSelfAuthenticatedPOST(context.Background(), request)
 	test.AssertEquals(t, prob.Type, probs.ServerInternalProblem)
@@ -1521,9 +1521,11 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 	kp, err = goodkey.NewKeyPolicy(&goodkey.Config{}, badKeyCheckFunc)
 	test.AssertNotError(t, err, "making key policy")
 
-	wfe.keyPolicy = kp
+	wfe.keyPolicy =  kp
+
 	_, _, validJWSBody = signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
 	request = makePostRequestWithPath("test", validJWSBody)
+
 	_, _, prob = wfe.validSelfAuthenticatedPOST(context.Background(), request)
 	test.AssertEquals(t, prob.Type, probs.BadPublicKeyProblem)
 }

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
+	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/mocks"
 	"github.com/letsencrypt/boulder/probs"
@@ -1493,6 +1494,38 @@ func TestValidPOSTForAccountSwappedKey(t *testing.T) {
 	test.Assert(t, prob != nil, "No error returned for request signed by wrong key")
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
 	test.AssertEquals(t, prob.Detail, "JWS verification error")
+}
+
+func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
+	wfe, _, signer := setupWFE(t)
+
+	_, _, validJWSBody := signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
+	request := makePostRequestWithPath("test", validJWSBody)
+
+	timeoutErrCheckFunc := func(ctx context.Context, keyHash []byte) (bool, error) {
+		return false, context.DeadlineExceeded
+	}
+
+	kp, err := goodkey.NewKeyPolicy(&goodkey.Config{}, timeoutErrCheckFunc)
+	test.AssertNotError(t, err, "making key policy")
+
+	wfe.keyPolicy = kp
+
+	_, _, prob := wfe.validSelfAuthenticatedPOST(context.Background(), request)
+	test.AssertEquals(t, prob.Type, probs.ServerInternalProblem)
+
+	badKeyCheckFunc := func(ctx context.Context, keyHash []byte) (bool, error) {
+		return false, fmt.Errorf("oh no: %w", goodkey.ErrBadKey)
+	}
+
+	kp, err = goodkey.NewKeyPolicy(&goodkey.Config{}, badKeyCheckFunc)
+	test.AssertNotError(t, err, "making key policy")
+
+	wfe.keyPolicy = kp
+	_, _, validJWSBody = signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
+	request = makePostRequestWithPath("test", validJWSBody)
+	_, _, prob = wfe.validSelfAuthenticatedPOST(context.Background(), request)
+	test.AssertEquals(t, prob.Type, probs.BadPublicKeyProblem)
 }
 
 func TestValidSelfAuthenticatedPOST(t *testing.T) {


### PR DESCRIPTION
In WFE, we do a goodkey check when validating a self-authenticated POST (i.e. when creating an account). For a while, that was a purely local check, looking at a list of bad keys or bad moduluses, or checking for factorability. At some point we also added a backend check, querying the SA to see if a key was blocked. However, we did not update this one code path to distinguish "bad key" from "timeout querying SA." That meant that sometimes we would give a badPublicKey Problem Document when we should have given an internalServerError.

Related: https://github.com/letsencrypt/boulder/issues/6795#issuecomment-1574217398