### PR TITLE
Remove contact addresses from WFE logs

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -44,10 +44,6 @@ type RequestEvent struct {
 	// For endpoints that create objects, the ID of the newly created object.
 	Created string `json:",omitempty"`
 
-	// For endpoints that return or update accounts, the pre-existing (at the time
-	// of the request) contact addresses for that account.
-	Contacts []string `json:",omitempty"`
-
 	// For challenge and authorization GETs and POSTs:
 	// the status of the authorization at the time the request began.
 	Status string `json:",omitempty"`

--- a/web/context.go
+++ b/web/context.go
@@ -36,7 +36,6 @@ type RequestEvent struct {
 	Slug           string   `json:",omitempty"`
 	InternalErrors []string `json:",omitempty"`
 	Error          string   `json:",omitempty"`
-	Contacts       []string `json:",omitempty"`
 	UserAgent      string   `json:"ua,omitempty"`
 	// Origin is sent by the browser from XHR-based clients.
 	Origin string                 `json:",omitempty"`
@@ -44,6 +43,10 @@ type RequestEvent struct {
 
 	// For endpoints that create objects, the ID of the newly created object.
 	Created string `json:",omitempty"`
+
+	// For endpoints that return or update accounts, the pre-existing (at the time
+	// of the request) contact addresses for that account.
+	Contacts []string `json:",omitempty"`
 
 	// For challenge and authorization GETs and POSTs:
 	// the status of the authorization at the time the request began.

--- a/web/context.go
+++ b/web/context.go
@@ -33,7 +33,6 @@ type RequestEvent struct {
 	Latency   float64 `json:"-"`
 	RealIP    string  `json:"-"`
 
-	TLS            string   `json:",omitempty"`
 	Slug           string   `json:",omitempty"`
 	InternalErrors []string `json:",omitempty"`
 	Error          string   `json:",omitempty"`

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -487,9 +487,6 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 
 	// Update the logEvent with the account information and return the JWK
 	logEvent.Requester = account.Id
-	if account.Contact != nil {
-		logEvent.Contacts = account.Contact
-	}
 
 	acct, err := grpc.PbToRegistration(account)
 	if err != nil {

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1429,19 +1429,16 @@ func TestValidPOSTAsGETForAccount(t *testing.T) {
 		ExpectedLogEvent web.RequestEvent
 	}{
 		{
-			Name:            "Non-empty JWS payload",
-			Request:         makePostRequestWithPath("test", invalidPayloadRequest),
-			ExpectedProblem: probs.Malformed("POST-as-GET requests must have an empty payload"),
-			ExpectedLogEvent: web.RequestEvent{
-				Contacts: []string{"mailto:person@mail.com"},
-			},
+			Name:             "Non-empty JWS payload",
+			Request:          makePostRequestWithPath("test", invalidPayloadRequest),
+			ExpectedProblem:  probs.Malformed("POST-as-GET requests must have an empty payload"),
+			ExpectedLogEvent: web.RequestEvent{},
 		},
 		{
 			Name:    "Valid POST-as-GET",
 			Request: makePostRequestWithPath("test", validRequest),
 			ExpectedLogEvent: web.RequestEvent{
-				Contacts: []string{"mailto:person@mail.com"},
-				Method:   "POST-as-GET",
+				Method: "POST-as-GET",
 			},
 		},
 	}

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1180,7 +1180,6 @@ func TestLookupJWK(t *testing.T) {
 				test.AssertDeepEquals(t, inThumb, outThumb)
 				test.AssertMarshaledEquals(t, acct, tc.ExpectedAccount)
 				test.AssertEquals(t, inputLogEvent.Requester, acct.ID)
-				test.AssertEquals(t, fmt.Sprint(inputLogEvent.Contacts), fmt.Sprint(*acct.Contact))
 			} else {
 				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
 			}

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -660,9 +660,6 @@ func (wfe *WebFrontEndImpl) NewAccount(
 			return
 		}
 		prepAccountForDisplay(&acct)
-		if acct.Contact != nil {
-			logEvent.Contacts = *acct.Contact
-		}
 
 		err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, acct)
 		if err != nil {
@@ -772,9 +769,6 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	}
 	logEvent.Requester = acct.ID
 	addRequesterHeader(response, acct.ID)
-	if acct.Contact != nil {
-		logEvent.Contacts = *acct.Contact
-	}
 
 	acctURL := web.RelativeEndpoint(request, fmt.Sprintf("%s%d", acctPath, acct.ID))
 
@@ -1296,10 +1290,6 @@ func (wfe *WebFrontEndImpl) Account(
 		wfe.sendError(response, logEvent,
 			probs.Unauthorized("Request signing key did not match account key"), nil)
 		return
-	}
-
-	if currAcct.Contact != nil {
-		logEvent.Contacts = *currAcct.Contact
 	}
 
 	// If the body was not empty, then this is an account update request.

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -660,6 +660,9 @@ func (wfe *WebFrontEndImpl) NewAccount(
 			return
 		}
 		prepAccountForDisplay(&acct)
+		if acct.Contact != nil {
+			logEvent.Contacts = *acct.Contact
+		}
 
 		err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, acct)
 		if err != nil {
@@ -1293,6 +1296,10 @@ func (wfe *WebFrontEndImpl) Account(
 		wfe.sendError(response, logEvent,
 			probs.Unauthorized("Request signing key did not match account key"), nil)
 		return
+	}
+
+	if currAcct.Contact != nil {
+		logEvent.Contacts = *currAcct.Contact
 	}
 
 	// If the body was not empty, then this is an account update request.


### PR DESCRIPTION
The contacts field of an account can be very verbose, and is irrelevant to the vast majority -- e.g. creating orders, validating challenges, and downloading certificates -- of requests made by an account. To reduce the length of our WFE log lines, remove the Contacts field from all logs. When we actually need it, we can get it from the database.

Also remove the RequestEvent.TLS field, which is unused.