### PR TITLE
Remove the TLS-ALPN-01 tlsDial helper

### DIFF
--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -69,7 +69,7 @@ func (va *ValidationAuthorityImpl) tryGetChallengeCert(ctx context.Context,
 		},
 	}
 	if err != nil {
-		return nil, nil, validationRecords, detailedError(fmt.Errorf("getting IP addrs: %w", err))
+		return nil, nil, validationRecords, detailedError(err)
 	}
 	thisRecord := &validationRecords[0]
 

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -196,7 +196,7 @@ func TestTLSALPNTimeoutAfterConnect(t *testing.T) {
 		t.Fatalf("Connection should've timed out")
 	}
 	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
-	expected := "127.0.0.1: Timeout during read (your server may be slow or overloaded)"
+	expected := "127.0.0.1: Timeout after connect (your server may be slow or overloaded)"
 	if prob.Detail != expected {
 		t.Errorf("Wrong error detail. Expected %q, got %q", expected, prob.Detail)
 	}


### PR DESCRIPTION
This minor cleanup was found in the process of fixing tests in https://github.com/letsencrypt/boulder/pull/6952, and resolves a TODO from 2018.