### PR TITLE
Add must.Do utility function

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/letsencrypt/boulder/linter"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/must"
 	"github.com/letsencrypt/boulder/policy"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
@@ -107,11 +108,7 @@ const caCertFile = "../test/test-ca.pem"
 const caCertFile2 = "../test/test-ca2.pem"
 
 func mustRead(path string) []byte {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		panic(fmt.Sprintf("unable to read %#v: %s", path, err))
-	}
-	return b
+	return must.Do(os.ReadFile(path))
 }
 
 type testCtx struct {

--- a/must/must.go
+++ b/must/must.go
@@ -1,0 +1,11 @@
+package must
+
+// Do panics if err is not nil, otherwise returns t.
+// It is useful in wrapping a two-value function call
+// where you know statically that the call will succeed.
+func Do[T any](t T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/must/must.go
+++ b/must/must.go
@@ -3,6 +3,10 @@ package must
 // Do panics if err is not nil, otherwise returns t.
 // It is useful in wrapping a two-value function call
 // where you know statically that the call will succeed.
+//
+// Example:
+//
+// url := must.Do(url.Parse("http://example.com"))
 func Do[T any](t T, err error) T {
 	if err != nil {
 		panic(err)

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -1,0 +1,13 @@
+package must
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestDo(t *testing.T) {
+	url := Do(url.Parse("http://example.com"))
+	if url.Host != "example.com" {
+		t.Errorf("expected host to be example.com, got %s", url.Host)
+	}
+}

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/must"
 	"github.com/letsencrypt/boulder/test"
 	"gopkg.in/yaml.v3"
 )
@@ -394,19 +395,13 @@ func TestChallengesForWildcard(t *testing.T) {
 		Value: "*.zombo.com",
 	}
 
-	mustConstructPA := func(t *testing.T, enabledChallenges map[core.AcmeChallenge]bool) *AuthorityImpl {
-		pa, err := New(enabledChallenges, blog.NewMock())
-		test.AssertNotError(t, err, "Couldn't create policy implementation")
-		return pa
-	}
-
 	// First try to get a challenge for the wildcard ident without the
 	// DNS-01 challenge type enabled. This should produce an error
 	var enabledChallenges = map[core.AcmeChallenge]bool{
 		core.ChallengeTypeHTTP01: true,
 		core.ChallengeTypeDNS01:  false,
 	}
-	pa := mustConstructPA(t, enabledChallenges)
+	pa := must.Do(New(enabledChallenges, blog.NewMock()))
 	_, err := pa.ChallengesFor(wildcardIdent)
 	test.AssertError(t, err, "ChallengesFor did not error for a wildcard ident "+
 		"when DNS-01 was disabled")
@@ -416,7 +411,7 @@ func TestChallengesForWildcard(t *testing.T) {
 	// Try again with DNS-01 enabled. It should not error and
 	// should return only one DNS-01 type challenge
 	enabledChallenges[core.ChallengeTypeDNS01] = true
-	pa = mustConstructPA(t, enabledChallenges)
+	pa = must.Do(New(enabledChallenges, blog.NewMock()))
 	challenges, err := pa.ChallengesFor(wildcardIdent)
 	test.AssertNotError(t, err, "ChallengesFor errored for a wildcard ident "+
 		"unexpectedly")

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -47,6 +47,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/mocks"
+	"github.com/letsencrypt/boulder/must"
 	"github.com/letsencrypt/boulder/nonce"
 	noncepb "github.com/letsencrypt/boulder/nonce/proto"
 	"github.com/letsencrypt/boulder/probs"
@@ -400,11 +401,7 @@ func signAndPost(signer requestSigner, path, signedURL, payload string) *http.Re
 }
 
 func mustParseURL(s string) *url.URL {
-	if u, err := url.Parse(s); err != nil {
-		panic("Cannot parse URL " + s)
-	} else {
-		return u
-	}
+	return must.Do(url.Parse(s))
 }
 
 func sortHeader(s string) string {


### PR DESCRIPTION
This can take two values (typically the return values of a two-value function) and panic if the error is non-nil, returning the interesting value. This is particularly useful for cases where we statically know the call will succeed.

Thanks to @mcpherrinm for the idea!