### PR TITLE
Simplify custom lint directory structure

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -16,10 +16,8 @@ import (
 	"github.com/letsencrypt/boulder/crl/crl_x509"
 	crllints "github.com/letsencrypt/boulder/linter/lints/crl"
 
-	_ "github.com/letsencrypt/boulder/linter/lints/all"
-	_ "github.com/letsencrypt/boulder/linter/lints/intermediate"
-	_ "github.com/letsencrypt/boulder/linter/lints/root"
-	_ "github.com/letsencrypt/boulder/linter/lints/subscriber"
+	_ "github.com/letsencrypt/boulder/linter/lints/chrome"
+	_ "github.com/letsencrypt/boulder/linter/lints/cpcps"
 )
 
 var ErrLinting = fmt.Errorf("failed lint(s)")

--- a/linter/lints/chrome/e_scts_from_same_operator.go
+++ b/linter/lints/chrome/e_scts_from_same_operator.go
@@ -1,4 +1,4 @@
-package subscriber
+package chrome
 
 import (
 	"time"

--- a/linter/lints/common.go
+++ b/linter/lints/common.go
@@ -14,11 +14,8 @@ const (
 	BRDay time.Duration = 86400 * time.Second
 
 	// Declare our own Sources for use in zlint registry filtering.
-	LetsEncryptCPSAll          lint.LintSource = "LECPSAll"
-	LetsEncryptCPSIntermediate lint.LintSource = "LECPSIntermediate"
-	LetsEncryptCPSRoot         lint.LintSource = "LECPSRoot"
-	LetsEncryptCPSSubscriber   lint.LintSource = "LECPSSubscriber"
-	ChromeCTPolicy             lint.LintSource = "ChromeCT"
+	LetsEncryptCPS lint.LintSource = "LECPS"
+	ChromeCTPolicy lint.LintSource = "ChromeCT"
 )
 
 var (

--- a/linter/lints/cpcps/lint_root_ca_cert_validity_period_greater_than_25_years.go
+++ b/linter/lints/cpcps/lint_root_ca_cert_validity_period_greater_than_25_years.go
@@ -1,4 +1,4 @@
-package subscriber
+package cpcps
 
 import (
 	"time"
@@ -10,28 +10,28 @@ import (
 	"github.com/letsencrypt/boulder/linter/lints"
 )
 
-type certValidityTooLong struct{}
+type rootCACertValidityTooLong struct{}
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "e_validity_period_greater_than_25_years",
+		Name:          "e_root_ca_cert_validity_period_greater_than_25_years",
 		Description:   "Let's Encrypt Root CA Certificates have Validity Periods of up to 25 years",
 		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPSRoot,
+		Source:        lints.LetsEncryptCPS,
 		EffectiveDate: lints.CPSV33Date,
-		Lint:          NewCertValidityTooLong,
+		Lint:          NewRootCACertValidityTooLong,
 	})
 }
 
-func NewCertValidityTooLong() lint.LintInterface {
-	return &certValidityTooLong{}
+func NewRootCACertValidityTooLong() lint.LintInterface {
+	return &rootCACertValidityTooLong{}
 }
 
-func (l *certValidityTooLong) CheckApplies(c *x509.Certificate) bool {
+func (l *rootCACertValidityTooLong) CheckApplies(c *x509.Certificate) bool {
 	return util.IsRootCA(c)
 }
 
-func (l *certValidityTooLong) Execute(c *x509.Certificate) *lint.LintResult {
+func (l *rootCACertValidityTooLong) Execute(c *x509.Certificate) *lint.LintResult {
 	// CPS 7.1: "Root CA Certificate Validity Period: Up to 25 years."
 	maxValidity := 25 * 365 * lints.BRDay
 

--- a/linter/lints/cpcps/lint_subordinate_ca_cert_validity_period_greater_than_8_years.go
+++ b/linter/lints/cpcps/lint_subordinate_ca_cert_validity_period_greater_than_8_years.go
@@ -1,4 +1,4 @@
-package subscriber
+package cpcps
 
 import (
 	"time"
@@ -10,28 +10,28 @@ import (
 	"github.com/letsencrypt/boulder/linter/lints"
 )
 
-type certValidityTooLong struct{}
+type subordinateCACertValidityTooLong struct{}
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_validity_period_greater_than_8_years",
 		Description:   "Let's Encrypt Intermediate CA Certificates have Validity Periods of up to 8 years",
 		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPSIntermediate,
+		Source:        lints.LetsEncryptCPS,
 		EffectiveDate: lints.CPSV33Date,
-		Lint:          NewCertValidityTooLong,
+		Lint:          NewSubordinateCACertValidityTooLong,
 	})
 }
 
-func NewCertValidityTooLong() lint.LintInterface {
-	return &certValidityTooLong{}
+func NewSubordinateCACertValidityTooLong() lint.LintInterface {
+	return &subordinateCACertValidityTooLong{}
 }
 
-func (l *certValidityTooLong) CheckApplies(c *x509.Certificate) bool {
+func (l *subordinateCACertValidityTooLong) CheckApplies(c *x509.Certificate) bool {
 	return util.IsSubCA(c)
 }
 
-func (l *certValidityTooLong) Execute(c *x509.Certificate) *lint.LintResult {
+func (l *subordinateCACertValidityTooLong) Execute(c *x509.Certificate) *lint.LintResult {
 	// CPS 7.1: "Intermediate CA Certificate Validity Period: Up to 8 years."
 	maxValidity := 8 * 365 * lints.BRDay
 

--- a/linter/lints/cpcps/lint_subscriber_cert_validity_greater_than_100_days.go
+++ b/linter/lints/cpcps/lint_subscriber_cert_validity_greater_than_100_days.go
@@ -1,4 +1,4 @@
-package subscriber
+package cpcps
 
 import (
 	"time"
@@ -10,28 +10,28 @@ import (
 	"github.com/letsencrypt/boulder/linter/lints"
 )
 
-type certValidityTooLong struct{}
+type subscriberCertValidityTooLong struct{}
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "e_validity_period_greater_than_100_days",
+		Name:          "e_subscriber_cert_validity_period_greater_than_100_days",
 		Description:   "Let's Encrypt Subscriber Certificates have Validity Periods of up to 100 days",
 		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPSSubscriber,
+		Source:        lints.LetsEncryptCPS,
 		EffectiveDate: lints.CPSV33Date,
-		Lint:          NewCertValidityTooLong,
+		Lint:          NewSubscriberCertValidityTooLong,
 	})
 }
 
-func NewCertValidityTooLong() lint.LintInterface {
-	return &certValidityTooLong{}
+func NewSubscriberCertValidityTooLong() lint.LintInterface {
+	return &subscriberCertValidityTooLong{}
 }
 
-func (l *certValidityTooLong) CheckApplies(c *x509.Certificate) bool {
+func (l *subscriberCertValidityTooLong) CheckApplies(c *x509.Certificate) bool {
 	return util.IsServerAuthCert(c) && !c.IsCA
 }
 
-func (l *certValidityTooLong) Execute(c *x509.Certificate) *lint.LintResult {
+func (l *subscriberCertValidityTooLong) Execute(c *x509.Certificate) *lint.LintResult {
 	// CPS 7.1: "DV SSL End Entity Certificate Validity Period: Up to 100 days."
 	maxValidity := 100 * lints.BRDay
 

--- a/linter/lints/cpcps/lint_validity_period_has_extra_second.go
+++ b/linter/lints/cpcps/lint_validity_period_has_extra_second.go
@@ -1,4 +1,4 @@
-package subscriber
+package cpcps
 
 import (
 	"time"
@@ -16,7 +16,7 @@ func init() {
 		Name:          "w_validity_period_has_extra_second",
 		Description:   "Let's Encrypt Certificates have Validity Periods that are a round number of seconds",
 		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPSAll,
+		Source:        lints.LetsEncryptCPS,
 		EffectiveDate: lints.CPSV33Date,
 		Lint:          NewCertValidityNotRound,
 	})


### PR DESCRIPTION
The upstream zlint lints are organized not by what kind of certificate they apply to, but what source they are from. This change rearranges (and slightly renames) our custom lints to match the same structure. This will make it easier for us to temporarily add lints (e.g. for our CRLs) which we intend to upstream to zlint later.

Part of https://github.com/letsencrypt/boulder/issues/6934