### PR TITLE
cmd/ceremony: lint CRLs before issuance

### DIFF
--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -336,7 +336,7 @@ func makeTemplate(randReader io.Reader, profile *certProfile, pubKey []byte, ct 
 type failReader struct{}
 
 func (fr *failReader) Read([]byte) (int, error) {
-	return 0, errors.New("Empty reader used by x509.CreateCertificate")
+	return 0, errors.New("empty reader used by x509.CreateCertificate")
 }
 
 func generateCSR(profile *certProfile, signer crypto.Signer) ([]byte, error) {

--- a/cmd/ceremony/crl.go
+++ b/cmd/ceremony/crl.go
@@ -3,15 +3,18 @@ package notmain
 import (
 	"crypto"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
+
+	"github.com/letsencrypt/boulder/crl/crl_x509"
+	"github.com/letsencrypt/boulder/linter"
 )
 
-func generateCRL(signer crypto.Signer, issuer *x509.Certificate, thisUpdate, nextUpdate time.Time, number int64, revokedCertificates []pkix.RevokedCertificate) ([]byte, error) {
-	template := &x509.RevocationList{
+func generateCRL(signer crypto.Signer, issuer *x509.Certificate, thisUpdate, nextUpdate time.Time, number int64, revokedCertificates []crl_x509.RevokedCertificate) ([]byte, error) {
+	template := &crl_x509.RevocationList{
 		RevokedCertificates: revokedCertificates,
 		Number:              big.NewInt(number),
 		ThisUpdate:          thisUpdate,
@@ -33,12 +36,26 @@ func generateCRL(signer crypto.Signer, issuer *x509.Certificate, thisUpdate, nex
 		return nil, errors.New("nextUpdate must be less than 12 months after thisUpdate")
 	}
 
+	err := linter.CheckCRL(template, issuer, signer, []string{
+		// We skip this lint because our ceremony tooling issues CRLs with validity
+		// periods up to 12 months, but the lint only allows up to 10 days (which
+		// is the limit for CRLs containing Subscriber Certificates).
+		"e_crl_validity_period",
+		// We skip this lint because it is only applicable for sharded/partitioned
+		// CRLs, which our Subscriber CRLs are, but our higher-level CRLs issued by
+		// this tool are not.
+		"e_crl_has_idp",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("crl failed pre-issuance lint: %w", err)
+	}
+
 	// x509.CreateRevocationList uses an io.Reader here for signing methods that require
 	// a source of randomness. Since PKCS#11 based signing generates needed randomness
 	// at the HSM we don't need to pass a real reader. Instead of passing a nil reader
 	// we use one that always returns errors in case the internal usage of this reader
 	// changes.
-	crlBytes, err := x509.CreateRevocationList(&failReader{}, template, issuer, signer)
+	crlBytes, err := crl_x509.CreateRevocationList(&failReader{}, template, issuer, signer)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/crl/crl_x509"
 	"github.com/letsencrypt/boulder/linter"
 	"github.com/letsencrypt/boulder/pkcs11helpers"
 	"github.com/letsencrypt/boulder/strictyaml"
@@ -721,7 +722,7 @@ func crlCeremony(configBytes []byte) error {
 		return fmt.Errorf("unable to parse crl-profile.next-update: %s", err)
 	}
 
-	var revokedCertificates []pkix.RevokedCertificate
+	var revokedCertificates []crl_x509.RevokedCertificate
 	for _, rc := range config.CRLProfile.RevokedCertificates {
 		cert, err := loadCert(rc.CertificatePath)
 		if err != nil {
@@ -731,7 +732,7 @@ func crlCeremony(configBytes []byte) error {
 		if err != nil {
 			return fmt.Errorf("unable to parse crl-profile.revoked-certificates.revocation-date")
 		}
-		revokedCert := pkix.RevokedCertificate{
+		revokedCert := crl_x509.RevokedCertificate{
 			SerialNumber:   cert.SerialNumber,
 			RevocationTime: revokedAt,
 		}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -38,6 +38,15 @@ func Check(tbs *x509.Certificate, subjectPubKey crypto.PublicKey, realIssuer *x5
 	return err
 }
 
+// CheckCRL is like Check, but for CRLs.
+func CheckCRL(tbs *crl_x509.RevocationList, realIssuer *x509.Certificate, realSigner crypto.Signer, skipLints []string) error {
+	linter, err := New(realIssuer, realSigner, skipLints)
+	if err != nil {
+		return err
+	}
+	return linter.CheckCRL(tbs)
+}
+
 // Linter is capable of linting a to-be-signed (TBS) certificate. It does so by
 // signing that certificate with a throwaway private key and a fake issuer whose
 // public key matches the throwaway private key, and then running the resulting


### PR DESCRIPTION
Add a step to lint CRLs prior to issuance inside the ceremony tool. To prevent all such CRLs from failing lints, disable two of our custom lints which only apply to Subscriber CRLs, but don't have any way to tell whether they're linting a Subscriber or Subordinate CA CRL. Add a test to verify that the lints are run properly, and update the thisUpdate/nextUpdate dates in all CRL test cases to ensure that the linting system believes they were issued after various requirements came into effect.

Fixes https://github.com/letsencrypt/boulder/issues/6979