### PR TITLE
wfe: remove special "multiple certificates" error

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1583,9 +1583,7 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 
 	cert, err := wfe.sa.GetCertificate(ctx, &sapb.Serial{Serial: serial})
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "gorp: multiple rows returned") {
-			wfe.sendError(response, logEvent, probs.Conflict("Multiple certificates with same serial"), nil)
-		} else if errors.Is(err, berrors.NotFound) {
+		if errors.Is(err, berrors.NotFound) {
 			wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
 		} else {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Failed to retrieve certificate"), err)


### PR DESCRIPTION
This was introduced early in Boulder development when we had the concept of a "short serial" (monotonically increasing) which would be prepended to random bytes to form the full serial. We wanted to specially report the case that there were duplicates of a given short serial since it meant a problem with our monotonicity.

We've long since abandoned that idea, and also this code can't be exercised because sa.SelectCertificate does a LIMIT 1 anyhow.