### PR TITLE
Test against go1.20.6

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.5_2023-06-20
-          - go1.21rc2_2023-06-21
+          - go1.20.6_2023-07-11
+          - go1.21rc2_2023-07-11
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -113,8 +113,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.5_2023-06-20
-          - go1.21rc2_2023-06-21
+          - go1.20.6_2023-07-11
+          - go1.21rc2_2023-07-11
 
     env:
       # This sets the docker image tag for the boulder-tools repository to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.20.5"
+          - "1.20.6"
           - "1.21rc2"
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.20.5"
+          - "1.20.6"
           - "1.21rc2"
     runs-on: ubuntu-20.04
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.5_2023-06-20}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.5_2023-07-11}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2063,7 +2063,7 @@ func TestNewOrderReuse(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			// If the testcase specifies, advance the clock before adding the order
 			if tc.AdvanceClock != nil {
-				fc.Now().Add(*tc.AdvanceClock)
+				_ = fc.Now().Add(*tc.AdvanceClock)
 			}
 			// Add the order for the test request
 			order, err := ra.NewOrder(ctx, tc.OrderReq)

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,11 +12,11 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.20.5" "1.21rc2" )
+GO_CI_VERSIONS=( "1.20.6" "1.21rc2" )
 # These versions are built for both platforms that boulder devs use.
 # When updating GO_DEV_VERSIONS, please also update
 # ../../docker-compose.yml's default Go version.
-GO_DEV_VERSIONS=( "1.20.5" )
+GO_DEV_VERSIONS=( "1.20.6" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
This version includes a fix that seems relevant to us:

> The HTTP/1 client did not fully validate the contents of the Host header. A maliciously crafted Host header could inject additional headers or entire requests. The HTTP/1 client now refuses to send requests containing an invalid Request.Host or Request.URL.Host value.
> 
> Thanks to Bartek Nowotarski for reporting this issue.
> 
> Includes security fixes for CVE-2023-29406 and Go issue https://go.dev/issue/60374