### PR TITLE
docker-compose: Update ProxySQL container to v2.5.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     logging:
       driver: none
   bproxysql:
-    image: proxysql/proxysql:2.5.2
+    image: proxysql/proxysql:2.5.3
     # The --initial flag force resets the ProxySQL database on startup. By
     # default, ProxySQL ignores new configuration if the database already
     # exists. Without this flag, new configuration wouldn't be applied until you


### PR DESCRIPTION
Updates ProxySQL container from v2.5.2 -> v2.5.3 to match production.