### PR TITLE
tests: add explicit versions to Python dependencies

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.6_2023-07-12
-          - go1.21rc2_2023-07-12
+          - go1.20.6_2023-07-19
+          - go1.21rc2_2023-07-19
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -113,8 +113,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.6_2023-07-12
-          - go1.21rc2_2023-07-12
+          - go1.20.6_2023-07-19
+          - go1.21rc2_2023-07-19
 
     env:
       # This sets the docker image tag for the boulder-tools repository to

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.6_2023-07-11
-          - go1.21rc2_2023-07-11
+          - go1.20.6_2023-07-12
+          - go1.21rc2_2023-07-12
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -113,8 +113,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.6_2023-07-11
-          - go1.21rc2_2023-07-11
+          - go1.20.6_2023-07-12
+          - go1.21rc2_2023-07-12
 
     env:
       # This sets the docker image tag for the boulder-tools repository to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.6_2023-07-11}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.6_2023-07-12}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.6_2023-07-12}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.6_2023-07-13}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.6_2023-07-13}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.6_2023-07-19}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/test/boulder-tools/requirements.txt
+++ b/test/boulder-tools/requirements.txt
@@ -1,5 +1,5 @@
-acme==2.6.0
-cryptography==3.4.8
-PyOpenSSL==21.0.0
-requests==2.27.1
+acme>=2.0
+cryptography>=0.7
+PyOpenSSL
+requests
 codespell==2.2.5

--- a/test/boulder-tools/requirements.txt
+++ b/test/boulder-tools/requirements.txt
@@ -1,5 +1,5 @@
-acme>=2.0
-cryptography>=0.7
-PyOpenSSL
-requests
-codespell
+acme==2.6.0
+cryptography==3.4.8
+PyOpenSSL==21.0.0
+requests==2.27.1
+codespell==2.2.5

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -50,5 +50,5 @@ done
 
 # This needs to work with both GNU sed and BSD sed
 echo "Updating container build timestamp in docker-compose.yml"
-sed -i.bak -E "s|BOULDER_TOOLS_TAG:-go([0-9.]+)_([0-9-]+)}$|BOULDER_TOOLS_TAG:-go\1_${DATESTAMP}}|" ../../docker-compose.yml
+sed -i.bak -E "s|BOULDER_TOOLS_TAG:-go([0-9.]+)_([0-9-]+)}$|BOULDER_TOOLS_TAG:-go${GO_DEV_VERSIONS[0]}_${DATESTAMP}}|g" ../../docker-compose.yml
 rm -f ../../docker-compose.yml.bak


### PR DESCRIPTION
This avoids a situation where building a fresh boulder-tools image accidentally brings in a new version of codespell, which flags new misspellings.