### PR TITLE
Generate self-signed lint certs when linting roots

### DIFF
--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -677,7 +677,7 @@ func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 
 	// check that the tbsCertificate is properly formed by signing it
 	// with a throwaway key and then linting it using zlint
-	lintCertBytes, err := i.Linter.Check(template, req.PublicKey)
+	lintCertBytes, err := i.Linter.Check(template, req.PublicKey, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("tbsCertificate linting failed: %w", err)
 	}

--- a/issuance/issuance.go
+++ b/issuance/issuance.go
@@ -677,7 +677,7 @@ func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 
 	// check that the tbsCertificate is properly formed by signing it
 	// with a throwaway key and then linting it using zlint
-	lintCertBytes, err := i.Linter.Check(template, req.PublicKey, false)
+	lintCertBytes, err := i.Linter.Check(template, req.PublicKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("tbsCertificate linting failed: %w", err)
 	}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -25,26 +25,29 @@ var ErrLinting = fmt.Errorf("failed lint(s)")
 
 // Check accomplishes the entire process of linting: it generates a throwaway
 // signing key, uses that to create a throwaway cert, and runs a default set
-// of lints (everything except for the ETSI and EV lints) against it. This is
+// of lints (everything except for the ETSI and EV lints) against it. If the
+// subjectPubKey and realSigner indicate that this is a self-signed cert, the
+// throwaway cert will have its pubkey replaced to also be self-signed. This is
 // the primary public interface of this package, but it can be inefficient;
 // creating a new signer and a new lint registry are expensive operations which
-// performance-sensitive clients may want to cache.
+// performance-sensitive clients may want to cache via linter.New().
 func Check(tbs *x509.Certificate, subjectPubKey crypto.PublicKey, realIssuer *x509.Certificate, realSigner crypto.Signer, skipLints []string) error {
 	linter, err := New(realIssuer, realSigner, skipLints)
 	if err != nil {
 		return err
 	}
 
-	// If the provided pubkey is identical to the public half of the provided
-	// signing key, then we're being asked to lint a self-signed cert. Replace the
-	// pubkey with the fake lint issuer's pubkey, so that the resulting lint cert
-	// is also self-signed.
-	lintSubjectPubKey := subjectPubKey
-	if realSigner.Public() == subjectPubKey {
-		lintSubjectPubKey = linter.signer.Public()
+	selfSigned := false
+	switch k := subjectPubKey.(type) {
+	case *rsa.PublicKey:
+		selfSigned = k.Equal(realSigner.Public())
+	case *ecdsa.PublicKey:
+		selfSigned = k.Equal(realSigner.Public())
+	default:
+		return fmt.Errorf("unsupported lint signer type: %T", k)
 	}
 
-	_, err = linter.Check(tbs, lintSubjectPubKey)
+	_, err = linter.Check(tbs, subjectPubKey, selfSigned)
 	return err
 }
 
@@ -90,10 +93,17 @@ func New(realIssuer *x509.Certificate, realSigner crypto.Signer, skipLints []str
 
 // Check signs the given TBS certificate using the Linter's fake issuer cert and
 // private key, then runs the resulting certificate through all non-filtered
-// lints. It returns an error if any lint fails. On success it also returns the
-// DER bytes of the linting certificate.
-func (l Linter) Check(tbs *x509.Certificate, subjectPubKey crypto.PublicKey) ([]byte, error) {
-	lintCertBytes, cert, err := makeLintCert(tbs, subjectPubKey, l.issuer, l.signer)
+// lints. If selfSigned is true, the throwaway cert will have its pubkey
+// replaced with the linter's pubkey so that it appears self-signed. It returns
+// an error if any lint fails. On success it also returns the DER bytes of the
+// linting certificate.
+func (l Linter) Check(tbs *x509.Certificate, subjectPubKey crypto.PublicKey, selfSigned bool) ([]byte, error) {
+	lintPubKey := subjectPubKey
+	if selfSigned {
+		lintPubKey = l.signer.Public()
+	}
+
+	lintCertBytes, cert, err := makeLintCert(tbs, lintPubKey, l.issuer, l.signer)
 	if err != nil {
 		return nil, err
 	}

--- a/test/cert-ceremonies/root-ceremony-ecdsa.yaml
+++ b/test/cert-ceremonies/root-ceremony-ecdsa.yaml
@@ -21,12 +21,5 @@ certificate-profile:
         - Cert Sign
         - CRL Sign
 skip-lints:
-   - e_ext_authority_key_identifier_missing
-   - e_ext_authority_key_identifier_no_key_identifier
-   - e_sub_ca_aia_missing
-   - e_sub_ca_certificate_policies_missing
-   - e_sub_ca_crl_distribution_points_missing
+   # Our roots don't sign OCSP, so they don't need the Digital Signature KU.
    - n_ca_digital_signature_not_set
-   - n_mp_allowed_eku
-   - n_sub_ca_eku_missing
-   - w_sub_ca_aia_does_not_contain_issuing_ca_url

--- a/test/cert-ceremonies/root-ceremony-rsa.yaml
+++ b/test/cert-ceremonies/root-ceremony-rsa.yaml
@@ -21,12 +21,5 @@ certificate-profile:
         - Cert Sign
         - CRL Sign
 skip-lints:
-   - e_ext_authority_key_identifier_missing
-   - e_ext_authority_key_identifier_no_key_identifier
-   - e_sub_ca_aia_missing
-   - e_sub_ca_certificate_policies_missing
-   - e_sub_ca_crl_distribution_points_missing
+   # Our roots don't sign OCSP, so they don't need the Digital Signature KU.
    - n_ca_digital_signature_not_set
-   - n_mp_allowed_eku
-   - n_sub_ca_eku_missing
-   - w_sub_ca_aia_does_not_contain_issuing_ca_url


### PR DESCRIPTION
Our linting system uses a throwaway key to sign an untrusted version of the to-be-signed cert, then runs the lints over that. But this means that, when linting a self-signed cert, the signature no longer matches the embedded public key. This in turn causes a bunch of zlint's checks to think they're linting a Subordinate CA cert, rather than a Root CA cert.

Change our linting system to make the lint cert appear self-signed when the input cert is intended to be self-signed.