### PR TITLE
Update default docker compose BOULDER_TOOLS_TAG

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.5_2023-07-11}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.6_2023-07-11}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.


### PR DESCRIPTION
This is a follow-up fix to https://github.com/letsencrypt/boulder/pull/6987 which mistakenly did not update the docker compose default BOULDER_TOOLS_TAG variable from go1.20.5 to go1.20.6. This would only manifest on developer machines manually running unit/integration tests rather than CI which explicitly tests against a matrix of BOULDER_TOOLS_TAG versions.
```
Error response from daemon: manifest for letsencrypt/boulder-tools:go1.20.5_2023-07-11 not found: manifest unknown: manifest unknown
```