### PR TITLE
Improve core.PublicKeysEqual

### DIFF
--- a/ca/crl_test.go
+++ b/ca/crl_test.go
@@ -127,7 +127,7 @@ func TestGenerateCRL(t *testing.T) {
 	close(ins)
 	err = <-errs
 	test.AssertError(t, err, "can't generate CRL with bad serials")
-	test.AssertContains(t, err.Error(), "Invalid serial number")
+	test.AssertContains(t, err.Error(), "invalid serial number")
 
 	// Test that we get an error when an entry has a bad revocation time.
 	ins = make(chan *capb.GenerateCRLRequest)

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -52,7 +52,7 @@ func TestSerialUtils(t *testing.T) {
 	}
 
 	badSerial, err := StringToSerial("doop!!!!000")
-	test.AssertEquals(t, fmt.Sprintf("%v", err), "Invalid serial number")
+	test.AssertContains(t, err.Error(), "invalid serial number")
 	fmt.Println(badSerial)
 }
 
@@ -166,7 +166,7 @@ func TestLoadCert(t *testing.T) {
 
 	_, err = LoadCert("../test/test-ca.der")
 	test.AssertError(t, err, "Loading non-PEM file did not error")
-	test.AssertEquals(t, err.Error(), "No data in cert PEM file ../test/test-ca.der")
+	test.AssertEquals(t, err.Error(), "no data in cert PEM file \"../test/test-ca.der\"")
 
 	_, err = LoadCert("../test/test-ca.key")
 	test.AssertError(t, err, "Loading non-cert file did not error")


### PR DESCRIPTION
Rather than marshalling and comparing the bytes of each key, simply use the .Equal() method provided by all go stdlib types that implement the crypto.PublicKey interface.