### PR TITLE
Install v2.20.0 of docker-compose-plugin

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -73,6 +73,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      
+      - name: Update docker compose plugin
+        run: mkdir -p ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins && curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose
 
       - name: Docker Login
         # You may pin to the exact commit or the version.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           persist-credentials: false
       
+      # TODO(#6998): Remove this step.
       - name: Update docker compose plugin
         run: mkdir -p ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins && curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose && chmod +x ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose
 

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -75,7 +75,7 @@ jobs:
           persist-credentials: false
       
       - name: Update docker compose plugin
-        run: mkdir -p ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins && curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose
+        run: mkdir -p ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins && curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose && chmod +x ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose
 
       - name: Docker Login
         # You may pin to the exact commit or the version.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -74,7 +74,8 @@ jobs:
         with:
           persist-credentials: false
       
-      # TODO(#6998): Remove this step.
+      # TODO(#6998): Remove this step when the ubuntu-20.04 image has v2.20.0+.
+      # Install instructions copied from https://docs.docker.com/compose/install/linux/#install-the-plugin-manually
       - name: Update docker compose plugin
         run: mkdir -p ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins && curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose && chmod +x ${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose
 


### PR DESCRIPTION
Work around the bug[1] in docker-compose-plugin v2.19.1, which is included in the current github actions ubuntu 20.04 runner image[2].

[1] https://github.com/docker/compose/issues/10777
[2] https://github.com/actions/runner-images/issues/7916

Part of https://github.com/letsencrypt/boulder/issues/6998