### PR TITLE
Deprecate CAA AccountURI and ValidationMethods feature flags

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -37,7 +37,7 @@ type Config struct {
 
 		Features map[string]bool
 
-		AccountURIPrefixes []string
+		AccountURIPrefixes []string `validate:"min=1,dive,required,url"`
 	}
 
 	Syslog        cmd.SyslogConfig

--- a/features/features.go
+++ b/features/features.go
@@ -17,12 +17,10 @@ const (
 	ROCSPStage6
 	ROCSPStage7
 	StoreLintingCertificateInsteadOfPrecertificate
+	CAAValidationMethods
+	CAAAccountURI
 
 	//   Currently in-use features
-	// Check CAA and respect validationmethods parameter.
-	CAAValidationMethods
-	// Check CAA and respect accounturi parameter.
-	CAAAccountURI
 	// EnforceMultiVA causes the VA to block on remote VA PerformValidation
 	// requests in order to make a valid/invalid decision with the results.
 	EnforceMultiVA

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -34,10 +34,7 @@
 				}
 			}
 		},
-		"features": {
-			"CAAValidationMethods": true,
-			"CAAAccountURI": true
-		},
+		"features": {},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -34,10 +34,7 @@
 				}
 			}
 		},
-		"features": {
-			"CAAValidationMethods": true,
-			"CAAAccountURI": true
-		},
+		"features": {},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -40,8 +40,6 @@
 			}
 		},
 		"features": {
-			"CAAValidationMethods": true,
-			"CAAAccountURI": true,
 			"EnforceMultiVA": true,
 			"MultiVAFullResults": true
 		},

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1491,11 +1491,6 @@ def test_caa_extensions():
     for policy in caa_records:
         challSrv.add_caa_issue(policy["domain"], policy["value"])
 
-    # TODO(@4a6f656c): Once the `CAAValidationMethods` feature flag is enabled by
-    # default, remove this early return.
-    if not CONFIG_NEXT:
-        return
-
     chisel2.expect_problem("urn:ietf:params:acme:error:caa",
         lambda: chisel2.auth_and_issue(["dns-01-only.good-caa-reserved.com"], chall_type="http-01"))
 

--- a/va/caa.go
+++ b/va/caa.go
@@ -11,7 +11,6 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	berrors "github.com/letsencrypt/boulder/errors"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/probs"
 	vapb "github.com/letsencrypt/boulder/va/proto"
@@ -284,15 +283,12 @@ func (va *ValidationAuthorityImpl) validateCAA(caaSet *caaResult, wildcard bool,
 			continue
 		}
 
-		if features.Enabled(features.CAAAccountURI) {
-			if !caaAccountURIMatches(parsedParams, va.accountURIPrefixes, params.accountURIID) {
-				continue
-			}
+		if !caaAccountURIMatches(parsedParams, va.accountURIPrefixes, params.accountURIID) {
+			continue
 		}
-		if features.Enabled(features.CAAValidationMethods) {
-			if !caaValidationMethodMatches(parsedParams, params.validationMethod) {
-				continue
-			}
+
+		if !caaValidationMethodMatches(parsedParams, params.validationMethod) {
+			continue
 		}
 
 		va.metrics.caaCounter.WithLabelValues("authorized").Inc()

--- a/va/va.go
+++ b/va/va.go
@@ -229,7 +229,7 @@ func NewValidationAuthorityImpl(
 	accountURIPrefixes []string,
 ) (*ValidationAuthorityImpl, error) {
 
-	if features.Enabled(features.CAAAccountURI) && len(accountURIPrefixes) == 0 {
+	if len(accountURIPrefixes) == 0 {
 		return nil, errors.New("no account URI prefixes configured")
 	}
 


### PR DESCRIPTION
These flags are set to true in all environments.