### PR TITLE
WFE: Correct Error Handling for Nonce Redemption RPCs with Unknown Prefixes

### DIFF
--- a/grpc/noncebalancer/noncebalancer.go
+++ b/grpc/noncebalancer/noncebalancer.go
@@ -32,7 +32,7 @@ const (
 // In any case, the client should retry with a new nonce. The balancer will be
 // rebuilt and DNS re-resolved at regular intervals as backends terminate client
 // connections which have reached a set maximum age.
-var ErrNoBackendsMatchPrefix = status.Errorf(codes.NotFound, "no backends match the nonce prefix")
+var ErrNoBackendsMatchPrefix = status.New(codes.Unavailable, "no backends match the nonce prefix")
 var errMissingPrefixCtxKey = errors.New("nonce.PrefixCtxKey value required in RPC context")
 var errMissingHMACKeyCtxKey = errors.New("nonce.HMACKeyCtxKey value required in RPC context")
 var errInvalidPrefixCtxKeyType = errors.New("nonce.PrefixCtxKey value in RPC context must be a string")
@@ -122,7 +122,7 @@ func (p *Picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	if !ok {
 		// No backend SubConn was found for the destination prefix. Return an
 		// error so the client can retry with a new nonce.
-		return balancer.PickResult{}, ErrNoBackendsMatchPrefix
+		return balancer.PickResult{}, ErrNoBackendsMatchPrefix.Err()
 	}
 	return balancer.PickResult{SubConn: sc}, nil
 }

--- a/grpc/noncebalancer/noncebalancer_test.go
+++ b/grpc/noncebalancer/noncebalancer_test.go
@@ -80,7 +80,7 @@ func TestPickerNoMatchingSubConnAvailable(t *testing.T) {
 	info := balancer.PickInfo{Ctx: testCtx}
 
 	gotPick, err := p.Pick(info)
-	test.AssertErrorIs(t, err, balancer.ErrNoSubConnAvailable)
+	test.AssertErrorIs(t, err, ErrNoBackendsMatchPrefix.Err())
 	test.AssertNil(t, gotPick.SubConn, "subConn should be nil")
 }
 

--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -38,13 +38,16 @@ import (
 const (
 	// PrefixLen is the character length of a nonce prefix.
 	PrefixLen = 8
+
 	// DeprecatedPrefixLen is the character length of a nonce prefix.
 	//
 	// DEPRECATED: Use PrefixLen instead.
 	// TODO(#6610): Remove once we've moved to derivable prefixes by default.
 	DeprecatedPrefixLen = 4
-	defaultMaxUsed      = 65536
-	nonceLen            = 32
+
+	// NonceLen is the character length of a nonce, excluding the prefix.
+	NonceLen       = 32
+	defaultMaxUsed = 65536
 )
 
 var errInvalidNonceLength = errors.New("invalid nonce length")
@@ -203,7 +206,7 @@ func (ns *NonceService) encrypt(counter int64) (string, error) {
 	copy(pt[pad:], ctr.Bytes())
 
 	// Encrypt
-	ret := make([]byte, nonceLen)
+	ret := make([]byte, NonceLen)
 	ct := ns.gcm.Seal(nil, nonce, pt, nil)
 	copy(ret, nonce[4:])
 	copy(ret[8:], ct)
@@ -228,7 +231,7 @@ func (ns *NonceService) decrypt(nonce string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if len(decoded) != nonceLen {
+	if len(decoded) != NonceLen {
 		return 0, errInvalidNonceLength
 	}
 

--- a/test/integration/nonce_test.go
+++ b/test/integration/nonce_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
-	"github.com/letsencrypt/boulder/grpc/noncebalancer"
+	nb "github.com/letsencrypt/boulder/grpc/noncebalancer"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/nonce"
 	noncepb "github.com/letsencrypt/boulder/nonce/proto"
@@ -64,7 +64,5 @@ func TestNonceBalancer_NoBackendMatchingPrefix(t *testing.T) {
 	// We expect to get a specific gRPC status error with code NotFound.
 	gotRPCStatus, ok := status.FromError(err)
 	test.Assert(t, ok, "Failed to convert error to status")
-	expectRPCStatus, ok := status.FromError(noncebalancer.ErrNoBackendsMatchPrefix)
-	test.Assert(t, ok, "Failed to convert expected error to status")
-	test.AssertEquals(t, gotRPCStatus, expectRPCStatus)
+	test.AssertEquals(t, gotRPCStatus, nb.ErrNoBackendsMatchPrefix)
 }

--- a/test/integration/nonce_test.go
+++ b/test/integration/nonce_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jmhodges/clock"
+
+	"github.com/letsencrypt/boulder/cmd"
+	bgrpc "github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/grpc/noncebalancer"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/nonce"
+	noncepb "github.com/letsencrypt/boulder/nonce/proto"
+	"github.com/letsencrypt/boulder/test"
+	"google.golang.org/grpc/status"
+)
+
+type Config struct {
+	NotWFE struct {
+		TLS                cmd.TLSConfig
+		GetNonceService    *cmd.GRPCClientConfig
+		RedeemNonceService *cmd.GRPCClientConfig
+		NoncePrefixKey     cmd.PasswordConfig
+	}
+}
+
+func TestNonceBalancer_NoBackendMatchingPrefix(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
+		t.Skip("Derived nonce prefixes are only configured in config-next")
+	}
+
+	// We're going to use a minimal nonce service client called "notwfe" which
+	// masquerades as a wfe for the purpose of redeeming nonces.
+
+	// Load the test config.
+	var c Config
+	err := cmd.ReadConfigFile("test/integration/testdata/nonce-client.json", &c)
+	test.AssertNotError(t, err, "Could not read config file")
+
+	tlsConfig, err := c.NotWFE.TLS.Load(metrics.NoopRegisterer)
+	test.AssertNotError(t, err, "Could not load TLS config")
+
+	rncKey, err := c.NotWFE.NoncePrefixKey.Pass()
+	test.AssertNotError(t, err, "Failed to load noncePrefixKey")
+
+	clk := clock.New()
+
+	redeemNonceConn, err := bgrpc.ClientSetup(c.NotWFE.RedeemNonceService, tlsConfig, metrics.NoopRegisterer, clk)
+	test.AssertNotError(t, err, "Failed to load credentials and create gRPC connection to redeem nonce service")
+	rnc := nonce.NewRedeemer(redeemNonceConn)
+
+	// Attempt to redeem a nonce with a prefix that doesn't match any backends.
+	ctx := context.WithValue(context.Background(), nonce.PrefixCtxKey{}, "12345678")
+	ctx = context.WithValue(ctx, nonce.HMACKeyCtxKey{}, rncKey)
+	_, err = rnc.Redeem(ctx, &noncepb.NonceMessage{Nonce: "0123456789"})
+
+	// We expect to get a specific gRPC status error with code NotFound.
+	gotRPCStatus, ok := status.FromError(err)
+	test.Assert(t, ok, "Failed to convert error to status")
+	expectRPCStatus, ok := status.FromError(noncebalancer.ErrNoBackendsMatchPrefix)
+	test.Assert(t, ok, "Failed to convert expected error to status")
+	test.AssertEquals(t, gotRPCStatus, expectRPCStatus)
+}

--- a/test/integration/testdata/nonce-client.json
+++ b/test/integration/testdata/nonce-client.json
@@ -1,0 +1,39 @@
+{
+	"notwfe": {
+		"tls": {
+			"caCertFile": "test/grpc-creds/minica.pem",
+			"certFile": "test/grpc-creds/wfe.boulder/cert.pem",
+			"keyFile": "test/grpc-creds/wfe.boulder/key.pem"
+		},
+		"getNonceService": {
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "nonce",
+				"domain": "service.consul"
+			},
+			"timeout": "15s",
+			"noWaitForReady": true,
+			"hostOverride": "nonce.boulder"
+		},
+		"redeemNonceService": {
+			"dnsAuthority": "consul.service.consul",
+			"srvLookups": [
+				{
+					"service": "nonce1",
+					"domain": "service.consul"
+				},
+				{
+					"service": "nonce2",
+					"domain": "service.consul"
+				}
+			],
+			"srvResolver": "nonce-srv",
+			"timeout": "15s",
+			"noWaitForReady": true,
+			"hostOverride": "nonce.boulder"
+		},
+		"noncePrefixKey": {
+			"passwordFile": "test/secrets/nonce_prefix_key"
+		}
+    }
+}

--- a/wfe2/stats.go
+++ b/wfe2/stats.go
@@ -17,9 +17,9 @@ type wfe2Stats struct {
 	// improperECFieldLengths counts the number of ACME account EC JWKs we see
 	// with improper X and Y lengths for their curve
 	improperECFieldLengths prometheus.Counter
-	// nonceNoBackendCount counts the number of times we've received a nonce
+	// nonceNoMatchingBackendCount counts the number of times we've received a nonce
 	// with a prefix that doesn't match a known backend.
-	nonceNoBackendCount prometheus.Counter
+	nonceNoMatchingBackendCount prometheus.Counter
 }
 
 func initStats(stats prometheus.Registerer) wfe2Stats {
@@ -65,9 +65,10 @@ func initStats(stats prometheus.Registerer) wfe2Stats {
 	stats.MustRegister(nonceNoBackendCount)
 
 	return wfe2Stats{
-		httpErrorCount:         httpErrorCount,
-		joseErrorCount:         joseErrorCount,
-		csrSignatureAlgs:       csrSignatureAlgs,
-		improperECFieldLengths: improperECFieldLengths,
+		httpErrorCount:              httpErrorCount,
+		joseErrorCount:              joseErrorCount,
+		csrSignatureAlgs:            csrSignatureAlgs,
+		improperECFieldLengths:      improperECFieldLengths,
+		nonceNoMatchingBackendCount: nonceNoBackendCount,
 	}
 }

--- a/wfe2/stats.go
+++ b/wfe2/stats.go
@@ -17,6 +17,9 @@ type wfe2Stats struct {
 	// improperECFieldLengths counts the number of ACME account EC JWKs we see
 	// with improper X and Y lengths for their curve
 	improperECFieldLengths prometheus.Counter
+	// nonceNoBackendCount counts the number of times we've received a nonce
+	// with a prefix that doesn't match a known backend.
+	nonceNoBackendCount prometheus.Counter
 }
 
 func initStats(stats prometheus.Registerer) wfe2Stats {
@@ -52,6 +55,14 @@ func initStats(stats prometheus.Registerer) wfe2Stats {
 		},
 	)
 	stats.MustRegister(improperECFieldLengths)
+
+	nonceNoBackendCount := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nonce_no_backend_found",
+			Help: "Number of times we've received a nonce with a prefix that doesn't match a known backend",
+		},
+	)
+	stats.MustRegister(nonceNoBackendCount)
 
 	return wfe2Stats{
 		httpErrorCount:         httpErrorCount,

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -240,7 +240,7 @@ func (wfe *WebFrontEndImpl) validNonce(ctx context.Context, header jose.Header) 
 			// this WFE. As this is a transient failure, the client should retry
 			// their request with a fresh nonce.
 			resp = &noncepb.ValidMessage{Valid: false}
-			wfe.stats.nonceNoBackendCount.Inc()
+			wfe.stats.nonceNoMatchingBackendCount.Inc()
 		}
 		valid = resp.Valid
 	} else {

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -745,10 +745,8 @@ func TestValidNonce(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// TODO(#6610): Remove this.
-			if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-				if tc.SkipConfigNext {
-					t.Skip("Skipping test in config-next")
-				}
+			if (os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next") && tc.SkipConfigNext {
+				t.Skip("Skipping test in config-next")
 			} else if tc.SkipConfig {
 				t.Skip("Skipping test in config")
 			}
@@ -1391,10 +1389,8 @@ func TestValidJWSForKey(t *testing.T) {
 		// TODO(#6610): Remove this.
 		t.Run(tc.Name, func(t *testing.T) {
 			// TODO(#6610): Remove this.
-			if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-				if tc.SkipConfigNext {
-					t.Skip("Skipping test in config-next")
-				}
+			if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" && tc.SkipConfigNext {
+				t.Skip("Skipping test in config-next")
 			} else if tc.SkipConfig {
 				t.Skip("Skipping test in config")
 			}

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1307,8 +1307,10 @@ func TestValidJWSForKey(t *testing.T) {
 		Body            string
 		ExpectedProblem *probs.ProblemDetails
 		ErrorStatType   string
-		SkipConfig      bool
-		SkipConfigNext  bool
+		// TODO(#6610): Remove this.
+		SkipConfig bool
+		// TODO(#6610): Remove this.
+		SkipConfigNext bool
 	}{
 		{
 			Name: "JWS with an invalid algorithm",

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -745,8 +745,10 @@ func TestValidNonce(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// TODO(#6610): Remove this.
-			if (os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next") && tc.SkipConfigNext {
-				t.Skip("Skipping test in config-next")
+			if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
+				if tc.SkipConfigNext {
+					t.Skip("Skipping test in config-next")
+				}
 			} else if tc.SkipConfig {
 				t.Skip("Skipping test in config")
 			}
@@ -1389,8 +1391,10 @@ func TestValidJWSForKey(t *testing.T) {
 		// TODO(#6610): Remove this.
 		t.Run(tc.Name, func(t *testing.T) {
 			// TODO(#6610): Remove this.
-			if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" && tc.SkipConfigNext {
-				t.Skip("Skipping test in config-next")
+			if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
+				if tc.SkipConfigNext {
+					t.Skip("Skipping test in config-next")
+				}
 			} else if tc.SkipConfig {
 				t.Skip("Skipping test in config")
 			}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -339,11 +339,31 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 	}
 
 	mockSA := mocks.NewStorageAuthorityReadOnly(fc)
-	noncePrefix := "mlem"
-	nonceService, err := nonce.NewNonceService(metrics.NoopRegisterer, 100, noncePrefix)
-	test.AssertNotError(t, err, "making nonceService")
-	nonceGRPCService := &inmemnonce.Service{
-		NonceService: nonceService,
+
+	var gnc nonce.Getter
+	var noncePrefixMap map[string]nonce.Redeemer
+	var rnc nonce.Redeemer
+	var rncKey string
+	var inmemNonceService *inmemnonce.Service
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
+		// Use derived nonces.
+		noncePrefix := nonce.DerivePrefix("192.168.1.1:8080", "b8c758dd85e113ea340ce0b3a99f389d40a308548af94d1730a7692c1874f1f")
+		nonceService, err := nonce.NewNonceService(metrics.NoopRegisterer, 100, noncePrefix)
+		test.AssertNotError(t, err, "making nonceService")
+
+		inmemNonceService = &inmemnonce.Service{NonceService: nonceService}
+		gnc = inmemNonceService
+		rnc = inmemNonceService
+	} else {
+		// TODO(#6610): Remove this once we've moved to derived to prefixes.
+		noncePrefix := "mlem"
+		nonceService, err := nonce.NewNonceService(metrics.NoopRegisterer, 100, noncePrefix)
+		test.AssertNotError(t, err, "making nonceService")
+
+		inmemNonceService = &inmemnonce.Service{NonceService: nonceService}
+		gnc = inmemNonceService
+		noncePrefixMap = map[string]nonce.Redeemer{noncePrefix: inmemNonceService}
+		rnc = inmemNonceService
 	}
 
 	wfe, err := NewWebFrontEndImpl(
@@ -359,16 +379,16 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 		7*24*time.Hour,
 		&MockRegistrationAuthority{},
 		mockSA,
-		nonceGRPCService,
-		map[string]nonce.Redeemer{noncePrefix: nonceGRPCService},
-		nonceGRPCService,
-		"",
+		gnc,
+		noncePrefixMap,
+		rnc,
+		rncKey,
 		mockSA)
 	test.AssertNotError(t, err, "Unable to create WFE")
 
 	wfe.SubscriberAgreementURL = agreementURL
 
-	return wfe, fc, requestSigner{t, nonceGRPCService.AsSource()}
+	return wfe, fc, requestSigner{t, inmemNonceService.AsSource()}
 }
 
 // makePostRequestWithPath creates an http.Request for localhost with method


### PR DESCRIPTION
Fix an issue related to the custom gRPC Picker implementation introduced in #6618. When a nonce contained a prefix not associated with a known backend, the Picker would continuously rebuild, re-resolve DNS, and eventually throw a 500 "Server Error" at RPC timeout. The Picker now promptly returns a 400 "Bad Nonce" error as expected, in response the requesting client should retry their request with a fresh nonce.

Additionally:
- WFE unit tests use derived nonces when `"BOULDER_CONFIG_DIR" == "test/config-next"`.
- `Balancer.Build()` in "noncebalancer" forces a rebuild until non-zero backends are available. This matches the [balancer/roundrobin](https://github.com/grpc/grpc-go/blob/d524b409462c601ef3f05a7e1fba19755a337c77/balancer/roundrobin/roundrobin.go#L49-L53) implementation.
- Nonces with no matching backend increment "jose_errors" with label `"type": "JWSInvalidNonce"` and "nonce_no_backend_found".
- Nonces of incorrect length are now rejected at the WFE and increment "jose_errors" with label `"type": "JWSMalformedNonce"` instead of `"type": "JWSInvalidNonce"`.
- Nonces not encoded as base64url are now rejected at the WFE and increment "jose_errors" with label `"type": "JWSMalformedNonce"` instead of `"type": "JWSInvalidNonce"`.

Fixes #6969
Part of #6974