### PR TITLE
crl-updater: duplicate shard 0 as shard NumShards

### DIFF
--- a/crl/updater/updater_test.go
+++ b/crl/updater/updater_test.go
@@ -316,15 +316,15 @@ func TestTickIssuer(t *testing.T) {
 	test.AssertNotError(t, err, "building test crlUpdater")
 
 	// An error that affects all shards should have every shard reflected in the
-	// combined error message.
+	// combined error message, including the bonus shard with index=numShards.
 	err = cu.tickIssuer(context.Background(), cu.clk.Now(), e1.NameID())
 	test.AssertError(t, err, "database error")
-	test.AssertContains(t, err.Error(), "2 shards failed")
-	test.AssertContains(t, err.Error(), "[0 1]")
-	test.AssertEquals(t, len(mockLog.GetAllMatching("Generating CRL failed:")), 2)
+	test.AssertContains(t, err.Error(), "3 shards failed")
+	test.AssertContains(t, err.Error(), "[0 1 2]")
+	test.AssertEquals(t, len(mockLog.GetAllMatching("Generating CRL failed:")), 3)
 	test.AssertMetricWithLabelsEquals(t, cu.tickHistogram, prometheus.Labels{
 		"issuer": "(TEST) Elegant Elephant E1", "result": "failed",
-	}, 2)
+	}, 3)
 	test.AssertMetricWithLabelsEquals(t, cu.tickHistogram, prometheus.Labels{
 		"issuer": "(TEST) Elegant Elephant E1 (Overall)", "result": "failed",
 	}, 1)
@@ -359,7 +359,7 @@ func TestTick(t *testing.T) {
 	test.AssertContains(t, err.Error(), "2 issuers failed")
 	test.AssertContains(t, err.Error(), "(TEST) Elegant Elephant E1")
 	test.AssertContains(t, err.Error(), "(TEST) Radical Rhino R3")
-	test.AssertEquals(t, len(mockLog.GetAllMatching("Generating CRL failed:")), 4)
+	test.AssertEquals(t, len(mockLog.GetAllMatching("Generating CRL failed:")), 6)
 	test.AssertEquals(t, len(mockLog.GetAllMatching("Generating CRLs for issuer failed:")), 2)
 	test.AssertMetricWithLabelsEquals(t, cu.tickHistogram, prometheus.Labels{
 		"issuer": "(TEST) Elegant Elephant E1 (Overall)", "result": "failed",


### PR DESCRIPTION
When crl-updater produces a CRL with shard index 0, have it also produce an identical CRL with shard index NumShards (e.g. 128). This is the first step towards having it only produce shards numbered 1 through NumShards, i.e. transition from using 0-indexing to 1-indexing.

We want to do this because various aspects of Golang and gRPC cannot tell the difference between "this struct/message has no shard index set" and "this struct/message has shard index 0 set".

Part of https://github.com/letsencrypt/boulder/issues/7007