### PR TITLE
cert-checker: check for precertificate correspondence

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -23,14 +23,15 @@ func _() {
 	_ = x[ExpirationMailerUsesJoin-12]
 	_ = x[CertCheckerChecksValidations-13]
 	_ = x[CertCheckerRequiresValidations-14]
-	_ = x[AsyncFinalize-15]
-	_ = x[RequireCommonName-16]
-	_ = x[LeaseCRLShards-17]
+	_ = x[CertCheckerRequiresCorrespondence-15]
+	_ = x[AsyncFinalize-16]
+	_ = x[RequireCommonName-17]
+	_ = x[LeaseCRLShards-18]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoROCSPStage6ROCSPStage7StoreLintingCertificateInsteadOfPrecertificateCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsAsyncFinalizeRequireCommonNameLeaseCRLShards"
+const _FeatureFlag_name = "unusedStoreRevokerInfoROCSPStage6ROCSPStage7StoreLintingCertificateInsteadOfPrecertificateCAAValidationMethodsCAAAccountURIEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsCertCheckerRequiresCorrespondenceAsyncFinalizeRequireCommonNameLeaseCRLShards"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 22, 33, 44, 90, 110, 123, 137, 155, 166, 182, 207, 231, 259, 289, 302, 319, 333}
+var _FeatureFlag_index = [...]uint16{0, 6, 22, 33, 44, 90, 110, 123, 137, 155, 166, 182, 207, 231, 259, 289, 322, 335, 352, 366}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -52,6 +52,12 @@ const (
 	// authorizations.
 	CertCheckerRequiresValidations
 
+	// CertCheckerRequiresCorrespondence enables an extra query for each certificate
+	// checked, to find the linting precertificate in the `precertificates` table.
+	// It then checks that the final certificate "corresponds" to the precertificate
+	// using `precert.Correspond`.
+	CertCheckerRequiresCorrespondence
+
 	// AsyncFinalize enables the RA to return approximately immediately from
 	// requests to finalize orders. This allows us to take longer getting SCTs,
 	// issuing certs, and updating the database; it indirectly reduces the number
@@ -75,23 +81,24 @@ const (
 
 // List of features and their default value, protected by fMu
 var features = map[FeatureFlag]bool{
-	unused:                         false,
-	CAAValidationMethods:           false,
-	CAAAccountURI:                  false,
-	EnforceMultiVA:                 false,
-	MultiVAFullResults:             false,
-	StoreRevokerInfo:               false,
-	ECDSAForAll:                    false,
-	ServeRenewalInfo:               false,
-	AllowUnrecognizedFeatures:      false,
-	ROCSPStage6:                    false,
-	ROCSPStage7:                    false,
-	ExpirationMailerUsesJoin:       false,
-	CertCheckerChecksValidations:   false,
-	CertCheckerRequiresValidations: false,
-	AsyncFinalize:                  false,
-	RequireCommonName:              true,
-	LeaseCRLShards:                 false,
+	unused:                            false,
+	CAAValidationMethods:              false,
+	CAAAccountURI:                     false,
+	EnforceMultiVA:                    false,
+	MultiVAFullResults:                false,
+	StoreRevokerInfo:                  false,
+	ECDSAForAll:                       false,
+	ServeRenewalInfo:                  false,
+	AllowUnrecognizedFeatures:         false,
+	ROCSPStage6:                       false,
+	ROCSPStage7:                       false,
+	ExpirationMailerUsesJoin:          false,
+	CertCheckerChecksValidations:      false,
+	CertCheckerRequiresValidations:    false,
+	CertCheckerRequiresCorrespondence: false,
+	AsyncFinalize:                     false,
+	RequireCommonName:                 true,
+	LeaseCRLShards:                    false,
 
 	StoreLintingCertificateInsteadOfPrecertificate: false,
 }

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -20,6 +20,7 @@
 		],
 		"ctLogListFile": "test/ct-test-srv/log_list.json",
 		"features": {
+			"CertCheckerRequiresCorrespondence": true,
 			"CertCheckerChecksValidations": true,
 			"CertCheckerRequiresValidations": true
 		}


### PR DESCRIPTION
This adds a lookup in cert-checker to find the linting precertificate with the same serial number as a given final certificate, and checks precertificate correspondence between the two.

Fixes #6959