### PR TITLE
sa: refactor how metrics and logging are set up

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"google.golang.org/grpc/resolver"
@@ -86,20 +85,6 @@ type DBConfig struct {
 func (d *DBConfig) URL() (string, error) {
 	url, err := os.ReadFile(d.DBConnectFile)
 	return strings.TrimSpace(string(url)), err
-}
-
-// DSNAddressAndUser returns the Address and User of the DBConnect DSN from
-// this object.
-func (d *DBConfig) DSNAddressAndUser() (string, string, error) {
-	dsnStr, err := d.URL()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to load DBConnect URL: %s", err)
-	}
-	config, err := mysql.ParseDSN(dsnStr)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to parse DSN from the DBConnect URL: %s", err)
-	}
-	return config.Addr, config.User, nil
 }
 
 type SMTPConfig struct {

--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -937,15 +937,16 @@ type testCtx struct {
 }
 
 func setup(t *testing.T, nagTimes []time.Duration) *testCtx {
+	log := blog.NewMock()
+
 	// We use the test_setup user (which has full permissions to everything)
 	// because the SA we return is used for inserting data to set up the test.
-	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
+	dbMap, err := sa.DBMapForTestWithLog(vars.DBConnSAFullPerms, log)
 	if err != nil {
 		t.Fatalf("Couldn't connect the database: %s", err)
 	}
 
 	fc := clock.NewFake()
-	log := blog.NewMock()
 	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, fc, log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("unable to create SQLStorageAuthority: %s", err)

--- a/cmd/rocsp-tool/client_test.go
+++ b/cmd/rocsp-tool/client_test.go
@@ -56,7 +56,6 @@ func TestGetStartingID(t *testing.T) {
 	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
 	test.AssertNotError(t, err, "failed setting up db client")
 	defer test.ResetBoulderTestDatabase(t)()
-	sa.SetSQLDebug(dbMap, blog.Get())
 
 	cs := core.CertificateStatus{
 		Serial:   "1337",

--- a/db/map.go
+++ b/db/map.go
@@ -68,10 +68,6 @@ func NewWrappedMap(dbMap *borp.DbMap) *WrappedMap {
 	return &WrappedMap{dbMap: dbMap}
 }
 
-func (m *WrappedMap) SQLDb() *sql.DB {
-	return m.dbMap.Db
-}
-
 func (m *WrappedMap) TableFor(t reflect.Type, checkPK bool) (*borp.TableMap, error) {
 	return m.dbMap.TableFor(t, checkPK)
 }

--- a/db/map.go
+++ b/db/map.go
@@ -72,10 +72,6 @@ func (m *WrappedMap) SQLDb() *sql.DB {
 	return m.dbMap.Db
 }
 
-func (m *WrappedMap) BorpDB() *borp.DbMap {
-	return m.dbMap
-}
-
 func (m *WrappedMap) TableFor(t reflect.Type, checkPK bool) (*borp.TableMap, error) {
 	return m.dbMap.TableFor(t, checkPK)
 }

--- a/sa/database.go
+++ b/sa/database.go
@@ -83,7 +83,7 @@ func DBMapForTest(dbConnect string) (*boulderDB.WrappedMap, error) {
 	return DBMapForTestWithLog(dbConnect, nil)
 }
 
-// DBMapForTestWithLog does the same as DBMapFortest but also routes the debug logs
+// DBMapForTestWithLog does the same as DBMapForTest but also routes the debug logs
 // from the database driver to the given log (usually a `blog.NewMock`).
 func DBMapForTestWithLog(dbConnect string, log blog.Logger) (*boulderDB.WrappedMap, error) {
 	var err error
@@ -141,8 +141,8 @@ var setConnMaxIdleTime = func(db *sql.DB, connMaxIdleTime time.Duration) {
 //   - wraps the connection in a borp.DbMap so we can use the handy Get/Insert methods borp provides
 //   - wraps that in a db.WrappedMap to get more useful error messages
 //
-// If logger is non-nil, debug log messages from borp will be sent to it.
-// If scope is non-nil, stats will be sent to it.
+// If logger is non-nil, it will receive debug log messages from borp.
+// If scope is non-nil, it will be used to register Prometheus metrics.
 func newDbMapFromMySQLConfig(config *mysql.Config, settings DbSettings, scope prometheus.Registerer, logger blog.Logger) (*boulderDB.WrappedMap, error) {
 	err := adjustMySQLConfig(config)
 	if err != nil {

--- a/sa/database.go
+++ b/sa/database.go
@@ -94,7 +94,6 @@ func DBMapForTestWithLog(dbConnect string, log blog.Logger) (*boulderDB.WrappedM
 		return nil, err
 	}
 
-	blog.NewMock()
 	return newDbMapFromMySQLConfig(config, DbSettings{}, nil, log)
 }
 

--- a/sa/database.go
+++ b/sa/database.go
@@ -80,6 +80,12 @@ func InitWrappedDb(config cmd.DBConfig, scope prometheus.Registerer, logger blog
 // tables. It automatically maps the tables for the primary parts of Boulder
 // around the Storage Authority.
 func DBMapForTest(dbConnect string) (*boulderDB.WrappedMap, error) {
+	return DBMapForTestWithLog(dbConnect, nil)
+}
+
+// DBMapForTestWithLog does the same as DBMapFortest but also routes the debug logs
+// from the database driver to the given log (usually a `blog.NewMock`).
+func DBMapForTestWithLog(dbConnect string, log blog.Logger) (*boulderDB.WrappedMap, error) {
 	var err error
 	var config *mysql.Config
 
@@ -88,7 +94,8 @@ func DBMapForTest(dbConnect string) (*boulderDB.WrappedMap, error) {
 		return nil, err
 	}
 
-	return newDbMapFromMySQLConfig(config, DbSettings{}, nil, nil)
+	blog.NewMock()
+	return newDbMapFromMySQLConfig(config, DbSettings{}, nil, log)
 }
 
 // sqlOpen is used in the tests to check that the arguments are properly

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -56,8 +56,6 @@ func NewSQLStorageAuthorityWrapping(
 	dbMap *db.WrappedMap,
 	stats prometheus.Registerer,
 ) (*SQLStorageAuthority, error) {
-	SetSQLDebug(dbMap, ssaro.log)
-
 	rateLimitWriteErrors := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "rate_limit_write_errors",
 		Help: "number of failed ratelimit update transactions during AddCertificate",


### PR DESCRIPTION
This eliminates the need for a pair of accessors on `db.WrappedMap` that expose the underlying `*sql.DB` and `*borp.DbMap`.

Fixes #6991