### PR TITLE
linter: Remove SignatureAlgorithm field from makeIssuer

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -163,7 +163,6 @@ func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.C
 		// intermediate or cross-signed intermediate, the SignatureAlgorithm of
 		// that certificate may differ from the root certificate that had signed
 		// it.
-		//
 		AuthorityKeyId:              realIssuer.AuthorityKeyId,
 		BasicConstraintsValid:       realIssuer.BasicConstraintsValid,
 		CRLDistributionPoints:       realIssuer.CRLDistributionPoints,

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -159,10 +159,10 @@ func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.C
 		// get, without sharing a public key.
 		//
 		// We do not copy the SignatureAlgorithm field while constructing the
-		// lint issuer. Depending on the realIssuer, which could be either an
-		// intermediate or cross-signed intermediate, the SignatureAlgorithm of
-		// that certificate may differ from the root certificate that had signed
-		// it.
+		// lintIssuer because the lintIssuer is self-signed. Depending on the
+		// realIssuer, which could be either an intermediate or cross-signed
+		// intermediate, the SignatureAlgorithm of that certificate may differ
+		// from the root certificate that had signed it.
 		AuthorityKeyId:              realIssuer.AuthorityKeyId,
 		BasicConstraintsValid:       realIssuer.BasicConstraintsValid,
 		CRLDistributionPoints:       realIssuer.CRLDistributionPoints,

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -152,10 +152,18 @@ func makeSigner(realSigner crypto.Signer) (crypto.Signer, error) {
 
 func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.Certificate, error) {
 	lintIssuerTBS := &x509.Certificate{
-		// This is the full list of attributes that x509.CreateCertificate() says it
-		// carries over from the template. Constructing this TBS certificate in
-		// this way ensures that the resulting lint issuer is as identical to the
-		// real issuer as we can get, without sharing a public key.
+		// This is nearly the full list of attributes that
+		// x509.CreateCertificate() says it carries over from the template.
+		// Constructing this TBS certificate in this way ensures that the
+		// resulting lint issuer is as identical to the real issuer as we can
+		// get, without sharing a public key.
+		//
+		// We do not copy the SignatureAlgorithm field while constructing the
+		// lint issuer. Depending on the realIssuer, which could be either an
+		// intermediate or cross-signed intermediate, the SignatureAlgorithm of
+		// that certificate may differ from the root certificate that had signed
+		// it.
+		//
 		AuthorityKeyId:              realIssuer.AuthorityKeyId,
 		BasicConstraintsValid:       realIssuer.BasicConstraintsValid,
 		CRLDistributionPoints:       realIssuer.CRLDistributionPoints,
@@ -183,7 +191,6 @@ func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.C
 		PermittedURIDomains:         realIssuer.PermittedURIDomains,
 		PolicyIdentifiers:           realIssuer.PolicyIdentifiers,
 		SerialNumber:                realIssuer.SerialNumber,
-		SignatureAlgorithm:          realIssuer.SignatureAlgorithm,
 		Subject:                     realIssuer.Subject,
 		SubjectKeyId:                realIssuer.SubjectKeyId,
 		URIs:                        realIssuer.URIs,


### PR DESCRIPTION
Removes the SignatureAlgorithm field while constructing the lint issuer. Depending on the realIssuer, which could be either an intermediate or cross-signed intermediate, the SignatureAlgorithm of that certificate may differ from the root certificate that had signed it causing the following error during CA startup.

```
Starting service boulder-ca-a
16:49:29.437776 3 boulder-ca qM-tDQA [AUDIT] Couldn't load issuers: failed to create lint issuer: x509: requested SignatureAlgorithm does not match private key type
```

Related to work done in https://github.com/letsencrypt/boulder/pull/7005.