### PR TITLE
CI: Run staticcheck standalone

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -220,6 +220,7 @@ jobs:
           # Ignores the following checks:
           # SA1019: Using a deprecated function, variable, constant or field
           # SA6003: Converting a string to a slice of runes before ranging over it
+          # ST1000: Incorrect or missing package comment
           # ST1003: Poorly chosen identifier
           # ST1005: Incorrectly formatted error string
           checks: "all, -ST1003, -ST1005, -SA1019, -SA6003"

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -207,11 +207,6 @@ jobs:
       # Pre-pull the docker containers before running the tests.
       - name: docker compose pull netaccess
         run: docker compose pull netaccess
-
-      # Enable https://github.com/golang/go/wiki/LoopvarExperiment if we're on
-      # go1.21rc2 or higher. This experiment value is unknown in lower versions.
-      - if: startsWith(matrix.BOULDER_TOOLS_TAG, 'go1.21')
-        run: echo "GOEXPERIMENT=loopvar" >> "$GITHUB_ENV"
       
       - uses: dominikh/staticcheck-action@v1.3.0
         with:

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -205,8 +205,8 @@ jobs:
         run: echo "Using BOULDER_TOOLS_TAG ${BOULDER_TOOLS_TAG}"
 
       # Pre-pull the docker containers before running the tests.
-      - name: docker compose pull boulder
-        run: docker compose pull boulder
+      - name: docker compose pull netaccess
+        run: docker compose pull netaccess
 
       # Enable https://github.com/golang/go/wiki/LoopvarExperiment if we're on
       # go1.21rc2 or higher. This experiment value is unknown in lower versions.
@@ -216,10 +216,13 @@ jobs:
       # Unset the GOFLAGS environment variable because, by default, it will be
       # set to "GOFLAGS='-mod=vendor'" which all go subcommands will utilize. In
       # this instance, we want to run a package that isn't vendored in our
-      # repository because 1) we don't need this package for CA operations and
-      # 2) we want the benefits of vulnerability checking.
+      # repository because we don't need this package for CA operations.
+      #
+      # This lint tool is running specifically in the netaccess container
+      # because it will only run a container containing boulder source code, not
+      # the entire boulder stack.
       - name: Run staticcheck
-        run: docker compose run -e GOFLAGS= boulder staticcheck ./...
+        run: docker compose run -e GOFLAGS= netaccess staticcheck ./...
 
   # This is a utility build job to detect if the status of any of the
   # above jobs have failed and fail if so. It is needed so there can be

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -223,7 +223,7 @@ jobs:
           # ST1000: Incorrect or missing package comment
           # ST1003: Poorly chosen identifier
           # ST1005: Incorrectly formatted error string
-          checks: "all, -SA1019, -SA6003, ST1000, -ST1003, -ST1005,"
+          checks: "all, -SA1019, -SA6003, -ST1000, -ST1003, -ST1005,"
 
   # This is a utility build job to detect if the status of any of the
   # above jobs have failed and fail if so. It is needed so there can be

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -163,67 +163,6 @@ jobs:
       - name: Run govulncheck
         run: docker compose run -e GOFLAGS= netaccess go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
-  staticcheck:
-    runs-on: ubuntu-20.04
-    strategy:
-      # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
-      fail-fast: false
-      matrix:
-        # Add additional docker image tags here and all tests will be run with the additional image.
-        BOULDER_TOOLS_TAG:
-          - go1.20.7_2023-08-28
-          - go1.21rc4_2023-08-28
-
-    env:
-      # This sets the docker image tag for the boulder-tools repository to
-      # use in tests. It will be set appropriately for each tag in the list
-      # defined in the matrix.
-      BOULDER_TOOLS_TAG: ${{ matrix.BOULDER_TOOLS_TAG }}
-
-    steps:
-      # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-
-      - name: Docker Login
-        # You may pin to the exact commit or the version.
-        # uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
-        uses: docker/login-action@v2.2.0
-        with:
-          # Username used to log against the Docker registry
-          username: ${{ secrets.DOCKER_USERNAME}}
-          # Password or personal access token used to log against the Docker registry
-          password: ${{ secrets.DOCKER_PASSWORD}}
-          # Log out from the Docker registry at the end of a job
-          logout: true
-        continue-on-error: true
-
-      # Print the env variable being used to pull the docker image. For
-      # informational use.
-      - name: Print BOULDER_TOOLS_TAG
-        run: echo "Using BOULDER_TOOLS_TAG ${BOULDER_TOOLS_TAG}"
-
-      # Pre-pull the docker containers before running the tests.
-      - name: docker compose pull netaccess
-        run: docker compose pull netaccess
-
-      # Enable https://github.com/golang/go/wiki/LoopvarExperiment if we're on
-      # go1.21rc2 or higher. This experiment value is unknown in lower versions.
-      - if: startsWith(matrix.BOULDER_TOOLS_TAG, 'go1.21')
-        run: echo "GOEXPERIMENT=loopvar" >> "$GITHUB_ENV"
-
-      # Unset the GOFLAGS environment variable because, by default, it will be
-      # set to "GOFLAGS='-mod=vendor'" which all go subcommands will utilize. In
-      # this instance, we want to run a package that isn't vendored in our
-      # repository because we don't need this package for CA operations.
-      #
-      # This lint tool is running specifically in the netaccess container
-      # because it will only run a container containing boulder source code, not
-      # the entire boulder stack.
-      - name: Run staticcheck
-        run: docker compose run -e GOFLAGS= netaccess staticcheck ./...
-
   # This is a utility build job to detect if the status of any of the
   # above jobs have failed and fail if so. It is needed so there can be
   # one static job name that can be used to determine success of the job
@@ -237,8 +176,7 @@ jobs:
     needs:
       - b
       - govulncheck
-      - staticcheck
     steps:
       - name: Check boulder ci test matrix status
-        if: ${{ needs.b.result != 'success' || needs.govulncheck.result != 'success' || needs.staticcheck.result != 'success'  }}
+        if: ${{ needs.b.result != 'success' || needs.govulncheck.result != 'success' }}
         run: exit 1

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -205,20 +205,21 @@ jobs:
         run: echo "Using BOULDER_TOOLS_TAG ${BOULDER_TOOLS_TAG}"
 
       # Pre-pull the docker containers before running the tests.
-      - name: docker compose pull netaccess
-        run: docker compose pull netaccess
+      - name: docker compose pull boulder
+        run: docker compose pull boulder
       
-      - uses: dominikh/staticcheck-action@v1.3.0
-        with:
-          version: "2023.1.5"
-          install-go: false
-          # Ignores the following checks:
-          # SA1019: Using a deprecated function, variable, constant or field
-          # SA6003: Converting a string to a slice of runes before ranging over it
-          # ST1000: Incorrect or missing package comment
-          # ST1003: Poorly chosen identifier
-          # ST1005: Incorrectly formatted error string
-          checks: "all, -SA1019, -SA6003, -ST1000, -ST1003, -ST1005,"
+      # Enable https://github.com/golang/go/wiki/LoopvarExperiment if we're on
+      # go1.21rc2 or higher. This experiment value is unknown in lower versions.
+      - if: startsWith(matrix.BOULDER_TOOLS_TAG, 'go1.21')
+        run: echo "GOEXPERIMENT=loopvar" >> "$GITHUB_ENV"
+
+      # Unset the GOFLAGS environment variable because, by default, it will be
+      # set to "GOFLAGS='-mod=vendor'" which all go subcommands will utilize. In
+      # this instance, we want to run a package that isn't vendored in our
+      # repository because 1) we don't need this package for CA operations and
+      # 2) we want the benefits of vulnerability checking.
+      - name: Run staticcheck
+        run: docker compose run -e GOFLAGS= boulder staticcheck ./...
 
   # This is a utility build job to detect if the status of any of the
   # above jobs have failed and fail if so. It is needed so there can be
@@ -233,6 +234,7 @@ jobs:
     needs:
       - b
       - govulncheck
+      - staticcheck
     steps:
       - name: Check boulder ci test matrix status
         if: ${{ needs.b.result != 'success' || needs.govulncheck.result != 'success' || needs.staticcheck.result != 'success'  }}

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -223,7 +223,7 @@ jobs:
           # ST1000: Incorrect or missing package comment
           # ST1003: Poorly chosen identifier
           # ST1005: Incorrectly formatted error string
-          checks: "all, -ST1003, -ST1005, -SA1019, -SA6003"
+          checks: "all, -SA1019, -SA6003, ST1000, -ST1003, -ST1005,"
 
   # This is a utility build job to detect if the status of any of the
   # above jobs have failed and fail if so. It is needed so there can be

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -163,6 +163,67 @@ jobs:
       - name: Run govulncheck
         run: docker compose run -e GOFLAGS= netaccess go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
+  staticcheck:
+    runs-on: ubuntu-20.04
+    strategy:
+      # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
+      fail-fast: false
+      matrix:
+        # Add additional docker image tags here and all tests will be run with the additional image.
+        BOULDER_TOOLS_TAG:
+          - go1.20.7_2023-08-02
+          - go1.21rc4_2023-08-02
+
+    env:
+      # This sets the docker image tag for the boulder-tools repository to
+      # use in tests. It will be set appropriately for each tag in the list
+      # defined in the matrix.
+      BOULDER_TOOLS_TAG: ${{ matrix.BOULDER_TOOLS_TAG }}
+
+    steps:
+      # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Docker Login
+        # You may pin to the exact commit or the version.
+        # uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+        uses: docker/login-action@v2.2.0
+        with:
+          # Username used to log against the Docker registry
+          username: ${{ secrets.DOCKER_USERNAME}}
+          # Password or personal access token used to log against the Docker registry
+          password: ${{ secrets.DOCKER_PASSWORD}}
+          # Log out from the Docker registry at the end of a job
+          logout: true
+        continue-on-error: true
+
+      # Print the env variable being used to pull the docker image. For
+      # informational use.
+      - name: Print BOULDER_TOOLS_TAG
+        run: echo "Using BOULDER_TOOLS_TAG ${BOULDER_TOOLS_TAG}"
+
+      # Pre-pull the docker containers before running the tests.
+      - name: docker compose pull netaccess
+        run: docker compose pull netaccess
+
+      # Enable https://github.com/golang/go/wiki/LoopvarExperiment if we're on
+      # go1.21rc2 or higher. This experiment value is unknown in lower versions.
+      - if: startsWith(matrix.BOULDER_TOOLS_TAG, 'go1.21')
+        run: echo "GOEXPERIMENT=loopvar" >> "$GITHUB_ENV"
+      
+      - uses: dominikh/staticcheck-action@v1.3.0
+        with:
+          version: "2023.1.5"
+          install-go: false
+          # Ignores the following checks:
+          # SA1019: Using a deprecated function, variable, constant or field
+          # SA6003: Converting a string to a slice of runes before ranging over it
+          # ST1003: Poorly chosen identifier
+          # ST1005: Incorrectly formatted error string
+          checks: "all, -ST1003, -ST1005, -SA1019, -SA6003"
+
   # This is a utility build job to detect if the status of any of the
   # above jobs have failed and fail if so. It is needed so there can be
   # one static job name that can be used to determine success of the job
@@ -178,5 +239,5 @@ jobs:
       - govulncheck
     steps:
       - name: Check boulder ci test matrix status
-        if: ${{ needs.b.result != 'success' || needs.govulncheck.result != 'success' }}
+        if: ${{ needs.b.result != 'success' || needs.govulncheck.result != 'success' || needs.staticcheck.result != 'success'  }}
         run: exit 1

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.7_2023-08-02
-          - go1.21rc4_2023-08-02
+          - go1.20.7_2023-08-28
+          - go1.21rc4_2023-08-28
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -113,8 +113,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.7_2023-08-02
-          - go1.21rc4_2023-08-02
+          - go1.20.7_2023-08-28
+          - go1.21rc4_2023-08-28
 
     env:
       # This sets the docker image tag for the boulder-tools repository to
@@ -171,8 +171,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.20.7_2023-08-02
-          - go1.21rc4_2023-08-02
+          - go1.20.7_2023-08-28
+          - go1.21rc4_2023-08-28
 
     env:
       # This sets the docker image tag for the boulder-tools repository to
@@ -207,7 +207,7 @@ jobs:
       # Pre-pull the docker containers before running the tests.
       - name: docker compose pull boulder
         run: docker compose pull boulder
-      
+
       # Enable https://github.com/golang/go/wiki/LoopvarExperiment if we're on
       # go1.21rc2 or higher. This experiment value is unknown in lower versions.
       - if: startsWith(matrix.BOULDER_TOOLS_TAG, 'go1.21')

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,8 +8,6 @@ linters:
     - govet
     - ineffassign
     - misspell
-    - staticcheck
-    - stylecheck
     - typecheck
     - unconvert
     - unparam
@@ -40,14 +38,6 @@ linters-settings:
           - (github.com/letsencrypt/boulder/log.Logger).AuditErrf
           - (github.com/letsencrypt/boulder/ocsp/responder).SampledError
           - (github.com/letsencrypt/boulder/web.RequestEvent).AddError
-  staticcheck:
-    # SA1019: Using a deprecated function, variable, constant or field
-    # SA6003: Converting a string to a slice of runes before ranging over it
-    checks: ["all", "-SA1019", "-SA6003"]
-  stylecheck:
-    # ST1003: Poorly chosen identifier
-    # ST1005: Incorrectly formatted error string
-    checks: ["all", "-ST1003", "-ST1005"]
   gosec:
     excludes:
       # TODO: Identify, fix, and remove violations of most of these rules

--- a/bdns/servers.go
+++ b/bdns/servers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// serverProvider represents a type which can provide a list of addresses for
+// ServerProvider represents a type which can provide a list of addresses for
 // the bdns to use as DNS resolvers. Different implementations may provide
 // different strategies for providing addresses, and may provide different kinds
 // of addresses (e.g. host:port combos vs IP addresses).

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -926,7 +926,6 @@ func main() {
 
 	if *daemon {
 		t := time.NewTicker(c.Mailer.Frequency.Duration)
-	daemonLoop:
 		for {
 			select {
 			case <-t.C:
@@ -935,7 +934,7 @@ func main() {
 					cmd.FailOnError(err, "expiration-mailer has failed")
 				}
 			case <-ctx.Done():
-				continue daemonLoop
+				return
 			}
 		}
 	} else {

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -926,6 +926,7 @@ func main() {
 
 	if *daemon {
 		t := time.NewTicker(c.Mailer.Frequency.Duration)
+	daemonLoop:
 		for {
 			select {
 			case <-t.C:
@@ -934,7 +935,7 @@ func main() {
 					cmd.FailOnError(err, "expiration-mailer has failed")
 				}
 			case <-ctx.Done():
-				break
+				continue daemonLoop
 			}
 		}
 	} else {

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -101,7 +101,7 @@ type Rows[T any] interface {
 	Close() error
 }
 
-// MockSqlExecuter implement SqlExecutor by returning errors from every call.
+// MockSqlExecutor implement SqlExecutor by returning errors from every call.
 //
 // TODO: To mock out WithContext, we needed to be able to return objects that satisfy
 // borp.SqlExecutor. That's a pretty big interface, so we specify one no-op mock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.7_2023-08-02}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.20.7_2023-08-28}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -171,8 +171,8 @@ func New(
 	}
 }
 
-// New constructs a Mailer suitable for doing a dry run. It simply logs each
-// command that would have been run, at debug level.
+// NewDryRun constructs a Mailer suitable for doing a dry run. It simply logs
+// each command that would have been run, at debug level.
 func NewDryRun(from mail.Address, logger blog.Logger) *mailerImpl {
 	return &mailerImpl{
 		config: config{

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -572,7 +572,7 @@ func (sa *StorageAuthority) RevokeCertificate(ctx context.Context, req *sapb.Rev
 	return nil, nil
 }
 
-// RevokeCertificate is a mock
+// UpdateRevokedCertificate is a mock
 func (sa *StorageAuthority) UpdateRevokedCertificate(ctx context.Context, req *sapb.RevokeCertificateRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
 	return nil, nil
 }
@@ -602,7 +602,7 @@ func (sa *StorageAuthority) UpdateCRLShard(ctx context.Context, req *sapb.Update
 	return nil, errors.New("unimplemented")
 }
 
-// Publisher is a mock
+// PublisherClient is a mock
 type PublisherClient struct {
 	// empty
 }

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -167,7 +167,7 @@ func (rs Responder) sampledError(format string, a ...interface{}) {
 // mapping from an OCSP request to an OCSP response is done by the Source; the
 // Responder simply decodes the request, and passes back whatever response is
 // provided by the source.
-// The Responder will set these headers:ServeHTTP
+// The Responder will set these headers:
 //
 //	Cache-Control: "max-age=(response.NextUpdate-now), public, no-transform, must-revalidate",
 //	Last-Modified: response.ThisUpdate,

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -163,11 +163,11 @@ func (rs Responder) sampledError(format string, a ...interface{}) {
 	SampledError(rs.log, rs.sampleRate, format, a...)
 }
 
-// A Responder can process both GET and POST requests. The mapping from an OCSP
-// request to an OCSP response is done by the Source; the Responder simply
-// decodes the request, and passes back whatever response is provided by the
-// source.
-// The Responder will set these headers:
+// ServeHTTP is a Responder that can process both GET and POST requests. The
+// mapping from an OCSP request to an OCSP response is done by the Source; the
+// Responder simply decodes the request, and passes back whatever response is
+// provided by the source.
+// The Responder will set these headers:ServeHTTP
 //
 //	Cache-Control: "max-age=(response.NextUpdate-now), public, no-transform, must-revalidate",
 //	Last-Modified: response.ThisUpdate,

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,8 @@
+# Ignores the following:
+#   SA1019: Using a deprecated function, variable, constant or field
+#   SA6003: Converting a string to a slice of runes before ranging over it
+#   ST1000: Incorrect or missing package comment
+#   ST1003: Poorly chosen identifier
+#   ST1005: Incorrectly formatted error string
+
+checks = ["all", "-SA1019", "-SA6003", "-ST1000", "-ST1003", "-ST1005"]

--- a/test.sh
+++ b/test.sh
@@ -212,6 +212,8 @@ STAGE="lints"
 if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   print_heading "Running Lints"
   golangci-lint run --timeout 9m ./...
+  # Implicitly loads staticcheck.conf from the root of the boulder repository
+  staticcheck ./...
   python3 test/grafana/lint.py
   # Check for common spelling errors using codespell.
   # Update .codespell.ignore.txt if you find false positives (NOTE: ignored

--- a/test/boulder-tools/install-go.sh
+++ b/test/boulder-tools/install-go.sh
@@ -19,6 +19,7 @@ go install github.com/rubenv/sql-migrate/...@v1.1.2
 go install golang.org/x/tools/cmd/stringer@latest
 go install github.com/letsencrypt/pebble/cmd/pebble-challtestsrv@master
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
+go install honnef.co/go/tools/cmd/staticcheck@2023.1.5
 
 go clean -cache
 go clean -modcache

--- a/test/ocsp/helper/helper.go
+++ b/test/ocsp/helper/helper.go
@@ -107,7 +107,7 @@ func (template Config) WithExpectStatus(status int) Config {
 	return ret
 }
 
-// WithExpectStatus returns a new Config with the given expectReason,
+// WithExpectReason returns a new Config with the given expectReason,
 // and all other fields the same as the receiver.
 func (template Config) WithExpectReason(reason int) Config {
 	ret := template
@@ -208,7 +208,7 @@ func parseCMS(body []byte) (*x509.Certificate, error) {
 	return cert, nil
 }
 
-// ReqFle makes an OCSP request using the given config for the PEM-encoded
+// ReqFile makes an OCSP request using the given config for the PEM-encoded
 // certificate in fileName, and returns the response.
 func ReqFile(fileName string, config Config) (*ocsp.Response, error) {
 	contents, err := os.ReadFile(fileName)

--- a/web/context.go
+++ b/web/context.go
@@ -183,10 +183,9 @@ func (th *TopHandler) logEvent(logEvent *RequestEvent) {
 		int(logEvent.Latency*1000), logEvent.RealIP, jsonEvent)
 }
 
-// Comma-separated list of HTTP clients involved in making this
-// request, starting with the original requester and ending with the
-// remote end of our TCP connection (which is typically our own
-// proxy).
+// GetClientAddr returns a comma-separated list of HTTP clients involved in
+// making this request, starting with the original requester and ending with the
+// remote end of our TCP connection (which is typically our own proxy).
 func GetClientAddr(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		return xff + "," + r.RemoteAddr

--- a/web/probs.go
+++ b/web/probs.go
@@ -63,7 +63,7 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 	return outProb
 }
 
-// problemDetailsForError turns an error into a ProblemDetails with the special
+// ProblemDetailsForError turns an error into a ProblemDetails with the special
 // case of returning the same error back if its already a ProblemDetails. If the
 // error is of an type unknown to ProblemDetailsForError, it will return a
 // ServerInternal ProblemDetails.


### PR DESCRIPTION
Run staticcheck as a standalone binary rather than as a library via golangci-lint. From the golangci-lint help out,
> staticcheck (megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.

We decided to disable ST1000 which warns about incorrect or missing package comments.

For SA4011, I chose to change the semantics[1] of the for loop rather than ignoring the SA4011 lint for that line.

Fixes https://github.com/letsencrypt/boulder/issues/6988

1. https://go.dev/ref/spec#Continue_statements