### PR TITLE
DB: Truncate timestamps to microseconds

### DIFF
--- a/sa/type-converter.go
+++ b/sa/type-converter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/letsencrypt/borp"
 	"gopkg.in/go-jose/go-jose.v2"
@@ -34,6 +35,8 @@ func (tc BoulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
 		return string(t), nil
 	case core.OCSPStatus:
 		return string(t), nil
+	case time.Time:
+		return t.Truncate(time.Microsecond), nil
 	default:
 		return val, nil
 	}

--- a/sa/type-converter.go
+++ b/sa/type-converter.go
@@ -36,7 +36,9 @@ func (tc BoulderTypeConverter) ToDb(val interface{}) (interface{}, error) {
 	case core.OCSPStatus:
 		return string(t), nil
 	case time.Time:
-		return t.Truncate(time.Microsecond), nil
+		// All of our MySQL DATETIME columns have only Second-level precision, so
+		// don't bother sending more precision than the database will use.
+		return t.Truncate(time.Second), nil
 	default:
 		return val, nil
 	}


### PR DESCRIPTION
Historically, go-mysql-driver rounded all timestamps to the nearest microsecond before forwarding them to the database connector. This is because MySQL only supports microsecond accuracy for timestamps, so the driver did the rounding first, to avoid sending unnecessary bits on the wire.

However, this led to a bug regarding double-rounding, detailed in https://github.com/go-sql-driver/mysql/issues/1121. The fix for this bug was for go-mysql-driver to stop rounding timestamps entirely, favoring correctness over optimization, and allowing the database itself to handle rounding and truncation however it is configured to do so. This fix was landed in https://github.com/go-sql-driver/mysql/pull/1172, which was included in the v1.6.0 release of that package (https://github.com/go-sql-driver/mysql/releases/tag/v1.6.0).

When we attempted to upgrade our version of go-mysql-driver to v1.6.0, we ran into significant performance problems which we failed to diagnose. The same happened over a year later, when we attempted to upgrade to v1.7.1. In the course of these investigations we found and fixed numerous other bugs, including upstreaming fixes to ProxySQL, but none of those seemed to alleviate the original issue. See the following bugs and PRs for the full timeline and context:
- https://github.com/letsencrypt/boulder/pull/5411
- https://github.com/letsencrypt/boulder/pull/5428
- https://github.com/letsencrypt/boulder/issues/5437
- https://github.com/letsencrypt/boulder/pull/5539
- https://github.com/letsencrypt/boulder/pull/5540
- https://github.com/letsencrypt/boulder/pull/6625
- https://github.com/letsencrypt/boulder/pull/6660
- https://github.com/letsencrypt/boulder/pull/6662
- https://github.com/letsencrypt/boulder/pull/6709
- https://github.com/sysown/proxysql/pull/4155
- https://github.com/sysown/proxysql/pull/4191
- https://github.com/go-sql-driver/mysql/pull/1402
- https://github.com/letsencrypt/boulder/pull/6976
- https://github.com/letsencrypt/boulder/pull/7006

Finally, with the help of new deployment infrastructure, we bisected the whole set of go-mysql-driver commits between v1.5.0 and v1.7.1 to try to find the culprit. This revealed the timestamp-rounding commit described above as the first commit to cause performance issues, and finally made the explanation clear.

Our database has a significant quantity of timestamp data, all of which has been written to the database with truncated timestamps, thanks to go-sql-driver's historical behavior. When switching to a newer version, all of our SELECT queries which used time ranges were now querying for those time ranges with untruncated precision, and were therefore *not using our existing indexes*.

This obviously led to significant query performance issues, particularly on the `fqdnSets`, `orderFqdnSets`, and `authz2` tables. These tables are very heavily queried with time ranges both for order and authorization reuse, and for rate limits. The fact that this issue only arises in the presence of significant historical data also explains why we could never reproduce it in the development environment or integration tests.

This change causes Boulder to do the time truncation that go-sql-driver used to do. This should allow our queries to continue using the existing indexes, and prevent performance regressions.