### PR TITLE
Add CAAAfterValidation feature flag

### DIFF
--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -27,11 +27,12 @@ func _() {
 	_ = x[CertCheckerRequiresCorrespondence-16]
 	_ = x[AsyncFinalize-17]
 	_ = x[RequireCommonName-18]
+	_ = x[CAAAfterValidation-19]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoROCSPStage6ROCSPStage7StoreLintingCertificateInsteadOfPrecertificateCAAValidationMethodsCAAAccountURILeaseCRLShardsEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsCertCheckerRequiresCorrespondenceAsyncFinalizeRequireCommonName"
+const _FeatureFlag_name = "unusedStoreRevokerInfoROCSPStage6ROCSPStage7StoreLintingCertificateInsteadOfPrecertificateCAAValidationMethodsCAAAccountURILeaseCRLShardsEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsCertCheckerRequiresCorrespondenceAsyncFinalizeRequireCommonNameCAAAfterValidation"
 
-var _FeatureFlag_index = [...]uint16{0, 6, 22, 33, 44, 90, 110, 123, 137, 151, 169, 180, 196, 221, 245, 273, 303, 336, 349, 366}
+var _FeatureFlag_index = [...]uint16{0, 6, 22, 33, 44, 90, 110, 123, 137, 151, 169, 180, 196, 221, 245, 273, 303, 336, 349, 366, 384}
 
 func (i FeatureFlag) String() string {
 	if i < 0 || i >= FeatureFlag(len(_FeatureFlag_index)-1) {

--- a/features/features.go
+++ b/features/features.go
@@ -74,6 +74,12 @@ const (
 	// According to the BRs Section 7.1.4.2.2(a), the commonName field is
 	// Deprecated, and its inclusion is discouraged but not (yet) prohibited.
 	RequireCommonName
+
+	// CAAAfterValidation causes the VA to only kick off CAA checks after the base
+	// domain control validation has completed and succeeded. This makes
+	// successful validations slower by serializing the DCV and CAA work, but
+	// makes unsuccessful validations easier by not doing CAA work at all.
+	CAAAfterValidation
 )
 
 // List of features and their default value, protected by fMu
@@ -96,6 +102,7 @@ var features = map[FeatureFlag]bool{
 	AsyncFinalize:                     false,
 	RequireCommonName:                 true,
 	LeaseCRLShards:                    false,
+	CAAAfterValidation:                false,
 
 	StoreLintingCertificateInsteadOfPrecertificate: false,
 }

--- a/test/config-next/va-remote-a.json
+++ b/test/config-next/va-remote-a.json
@@ -34,7 +34,9 @@
 				}
 			}
 		},
-		"features": {},
+		"features": {
+			"CAAAfterValidation": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/va-remote-b.json
+++ b/test/config-next/va-remote-b.json
@@ -34,7 +34,9 @@
 				}
 			}
 		},
-		"features": {},
+		"features": {
+			"CAAAfterValidation": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -41,7 +41,8 @@
 		},
 		"features": {
 			"EnforceMultiVA": true,
-			"MultiVAFullResults": true
+			"MultiVAFullResults": true,
+			"CAAAfterValidation": true
 		},
 		"remoteVAs": [
 			{

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -310,6 +310,42 @@ func TestPerformValidationWildcard(t *testing.T) {
 	}
 }
 
+func TestDCVAndCAASequencing(t *testing.T) {
+	va, mockLog := setup(nil, 0, "", nil)
+
+	// When performing validation without the CAAAfterValidation flag, CAA should
+	// be checked.
+	req := createValidationRequest("good-dns01.com", core.ChallengeTypeDNS01)
+	res, err := va.PerformValidation(context.Background(), req)
+	test.AssertNotError(t, err, "performing validation")
+	test.Assert(t, res.Problems == nil, fmt.Sprintf("validation failed: %#v", res.Problems))
+	caaLog := mockLog.GetAllMatching(`Checked CAA records for`)
+	test.AssertEquals(t, len(caaLog), 1)
+
+	features.Set(map[string]bool{features.CAAAfterValidation.String(): true})
+	defer features.Reset()
+
+	// When performing successful validation with the CAAAfterValidation flag,
+	// CAA should be checked.
+	mockLog.Clear()
+	req = createValidationRequest("good-dns01.com", core.ChallengeTypeDNS01)
+	res, err = va.PerformValidation(context.Background(), req)
+	test.AssertNotError(t, err, "performing validation")
+	test.Assert(t, res.Problems == nil, fmt.Sprintf("validation failed: %#v", res.Problems))
+	caaLog = mockLog.GetAllMatching(`Checked CAA records for`)
+	test.AssertEquals(t, len(caaLog), 1)
+
+	// When performing failed validation with the CAAAfterValidation flag,
+	// CAA should be skipped
+	mockLog.Clear()
+	req = createValidationRequest("bad-dns01.com", core.ChallengeTypeDNS01)
+	res, err = va.PerformValidation(context.Background(), req)
+	test.AssertNotError(t, err, "performing validation")
+	test.Assert(t, res.Problems != nil, "validation succeeded")
+	caaLog = mockLog.GetAllMatching(`Checked CAA records for`)
+	test.AssertEquals(t, len(caaLog), 0)
+}
+
 func TestMultiVA(t *testing.T) {
 	// Create a new challenge to use for the httpSrv
 	req := createValidationRequest("localhost", core.ChallengeTypeHTTP01)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -322,7 +322,7 @@ func TestDCVAndCAASequencing(t *testing.T) {
 	caaLog := mockLog.GetAllMatching(`Checked CAA records for`)
 	test.AssertEquals(t, len(caaLog), 1)
 
-	features.Set(map[string]bool{features.CAAAfterValidation.String(): true})
+	_ = features.Set(map[string]bool{features.CAAAfterValidation.String(): true})
 	defer features.Reset()
 
 	// When performing successful validation with the CAAAfterValidation flag,


### PR DESCRIPTION
Add a new feature flag "CAAAfterValidation" which, when set to true in the VA, causes the VA to only begin CAA checks after basic domain control validation has completed successfully. This will make successful validations take longer, since the DCV and CAA checks are performed serially instead of in parallel. However, it will also reduce the number of CAA checks we perform by up to 80%, since such a high percentage of validations also fail.

IN-9575 tracks enabling this feature flag in staging and prod
Fixes https://github.com/letsencrypt/boulder/issues/7058