### PR TITLE
cmd: remove redundant nil check

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -442,12 +442,10 @@ func ValidateJSONConfig(cv *ConfigValidator, in io.Reader) error {
 
 	// Initialize the validator and load any custom tags.
 	validate := validator.New()
-	if cv.Validators != nil {
-		for tag, v := range cv.Validators {
-			err := validate.RegisterValidation(tag, v)
-			if err != nil {
-				return err
-			}
+	for tag, v := range cv.Validators {
+		err := validate.RegisterValidation(tag, v)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -486,12 +484,10 @@ func ValidateYAMLConfig(cv *ConfigValidator, in io.Reader) error {
 
 	// Initialize the validator and load any custom tags.
 	validate := validator.New()
-	if cv.Validators != nil {
-		for tag, v := range cv.Validators {
-			err := validate.RegisterValidation(tag, v)
-			if err != nil {
-				return err
-			}
+	for tag, v := range cv.Validators {
+		err := validate.RegisterValidation(tag, v)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
From the Go specification:

> "3. If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary.