### PR TITLE
cert-checker: improve querying

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -154,7 +154,7 @@ func (c *certChecker) getCerts(ctx context.Context) error {
 					  issued < :end`,
 			map[string]interface{}{
 				"begin": c.issuedReport.begin,
-				"end":   c.issuedReport.end,
+				"end":   c.issuedReport.begin.Add(time.Hour),
 			},
 		)
 		if err != nil {

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -147,7 +147,7 @@ func (c *certChecker) findStartingID(ctx context.Context, begin, end time.Time) 
 	var retries int
 
 	// Rather than querying `MIN(id)` across that whole window, we query it across the first
-	// hour of the window. Thisallows the query planner to use the index on `issued` more
+	// hour of the window. This allows the query planner to use the index on `issued` more
 	// effectively. For a busy, actively issuing CA, that will always return results in the
 	// first query. For a less busy CA, or during integration tests, there may only exist
 	// certificates towards the end of the window, so we try querying later hourly chunks until

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -140,7 +140,9 @@ func newChecker(saDbMap certDB,
 }
 
 func (c *certChecker) getCerts(ctx context.Context) error {
+	// The end of the report is the current time, rounded up to the nearest second.
 	c.issuedReport.end = c.clock.Now().Truncate(time.Second).Add(time.Second)
+	// The beginning of the report is the end minus the check period, rounded down to the nearest second.
 	c.issuedReport.begin = c.issuedReport.end.Add(-c.checkPeriod).Truncate(time.Second)
 
 	var sni sql.NullInt64

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -453,13 +453,58 @@ func (db emptyDB) SelectNullInt(_ context.Context, _ string, _ ...interface{}) (
 // expected if the DB finds no certificates to match the SELECT query and
 // should return an error.
 func TestGetCertsNullResults(t *testing.T) {
-	saDbMap, err := sa.DBMapForTest(vars.DBConnSA)
-	test.AssertNotError(t, err, "Couldn't connect to database")
-	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations, blog.NewMock())
-	checker.dbMap = emptyDB{}
+	checker := newChecker(emptyDB{}, clock.NewFake(), pa, kp, time.Hour, testValidityDurations, blog.NewMock())
 
-	err = checker.getCerts(context.Background())
+	err := checker.getCerts(context.Background())
 	test.AssertError(t, err, "Should have gotten error from empty DB")
+	if !strings.Contains(err.Error(), "no rows found for certificates issued between") {
+		t.Errorf("expected error to contain 'no rows found for certificates issued between', got '%s'", err.Error())
+	}
+}
+
+// lateDB is a certDB object that helps with TestGetCertsLate.
+// It pretends to contain a single cert issued at the given time.
+type lateDB struct {
+	issuedTime    time.Time
+	selectedACert bool
+}
+
+// SelectNullInt is a method that returns a false sql.NullInt64 struct to
+// mock a null DB response
+func (db *lateDB) SelectNullInt(_ context.Context, _ string, args ...interface{}) (sql.NullInt64, error) {
+	args2 := args[0].(map[string]interface{})
+	begin := args2["begin"].(time.Time)
+	end := args2["end"].(time.Time)
+	if begin.Compare(db.issuedTime) < 0 && end.Compare(db.issuedTime) > 0 {
+		return sql.NullInt64{Int64: 23, Valid: true}, nil
+	}
+	return sql.NullInt64{Valid: false}, nil
+}
+
+func (db *lateDB) Select(_ context.Context, output interface{}, _ string, args ...interface{}) ([]interface{}, error) {
+	db.selectedACert = true
+	// For expediency we respond with an empty list of certificates; the checker will treat this as if it's
+	// reached the end of the list of certificates to process.
+	return nil, nil
+}
+
+func (db *lateDB) SelectOne(_ context.Context, _ interface{}, _ string, _ ...interface{}) error {
+	return nil
+}
+
+// TestGetCertsLate checks for correct behavior when certificates exist only late in the provided window.
+func TestGetCertsLate(t *testing.T) {
+	clk := clock.NewFake()
+	db := &lateDB{issuedTime: clk.Now().Add(-time.Hour)}
+	checkPeriod := 24 * time.Hour
+	checker := newChecker(db, clk, pa, kp, checkPeriod, testValidityDurations, blog.NewMock())
+
+	err := checker.getCerts(context.Background())
+	test.AssertNotError(t, err, "getting certs")
+
+	if !db.selectedACert {
+		t.Errorf("checker never selected a certificate after getting a MIN(id)")
+	}
 }
 
 func TestSaveReport(t *testing.T) {

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -367,7 +367,7 @@ func TestGetAndProcessCerts(t *testing.T) {
 	}
 
 	batchSize = 2
-	err = checker.getCerts(context.Background(), false)
+	err = checker.getCerts(context.Background())
 	test.AssertNotError(t, err, "Failed to retrieve certificates")
 	test.AssertEquals(t, len(checker.certs), 5)
 	wg := new(sync.WaitGroup)
@@ -431,7 +431,7 @@ func TestGetCertsEmptyResults(t *testing.T) {
 	checker.dbMap = mismatchedCountDB{}
 
 	batchSize = 3
-	err = checker.getCerts(context.Background(), false)
+	err = checker.getCerts(context.Background())
 	test.AssertNotError(t, err, "Failed to retrieve certificates")
 }
 
@@ -458,7 +458,7 @@ func TestGetCertsNullResults(t *testing.T) {
 	checker := newChecker(saDbMap, clock.NewFake(), pa, kp, time.Hour, testValidityDurations, blog.NewMock())
 	checker.dbMap = emptyDB{}
 
-	err = checker.getCerts(context.Background(), false)
+	err = checker.getCerts(context.Background())
 	test.AssertError(t, err, "Should have gotten error from empty DB")
 }
 


### PR DESCRIPTION
The certificates table has no index on expires, so including expires in the query was causing unnecessarily slow queries.

Expires was part of the query in order to support the "UnexpiredOnly" feature. This feature isn't really necessary; if we tell cert-checker to check certain certificates, we want to know about problems even if the certificates are expired. Deprecate the feature and always include all certificates in the time range. Remove "expires" from the queries.

This allows simplifying the query structure a bit and inlining query arguments in each site where they are used.

Update the error message returned when no rows are returned for the MIN(id) query.

The precursor to UnexpiredOnly was introduced in https://github.com/letsencrypt/boulder/pull/1644, but I can't find any reference to a requirement for the flag.

Fixes #7085