### PR TITLE
latency-charter.py: import matplotlib once, not twice

### DIFF
--- a/test/load-generator/latency-charter.py
+++ b/test/load-generator/latency-charter.py
@@ -7,7 +7,6 @@ import numpy as np
 import datetime
 import json
 import pandas
-import matplotlib
 import argparse
 import os
 matplotlib.style.use('ggplot')


### PR DESCRIPTION
`matplotlib` is already imported on line 3.

% `pipx run ruff --select=F811 .`
```
test/load-generator/latency-charter.py:10:8: F811 Redefinition of unused `matplotlib` from line 3
```