### PR TITLE
ocsp-responder: reduce spamminess of "not found"

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -49,6 +49,8 @@ const (
 	AlreadyRevoked
 	BadRevocationReason
 	UnsupportedContact
+	// The requesteed serial number does not exist in the `serials` table.
+	UnknownSerial
 )
 
 func (ErrorType) Error() string {
@@ -248,4 +250,8 @@ func AlreadyRevokedError(msg string, args ...interface{}) error {
 
 func BadRevocationReasonError(reason int64) error {
 	return New(BadRevocationReason, "disallowed revocation reason: %d", reason)
+}
+
+func UnknownSerialError() error {
+	return New(UnknownSerial, "unknown serial")
 }

--- a/ocsp/responder/responder.go
+++ b/ocsp/responder/responder.go
@@ -299,8 +299,6 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	ocspResponse, err := rs.Source.Response(ctx, ocspRequest)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			rs.sampledError("No response found for request: serial %x, request body %s",
-				ocspRequest.SerialNumber, b64Body)
 			response.Write(ocsp.UnauthorizedErrorResponse)
 			rs.responseTypes.With(prometheus.Labels{"type": responseTypeToString[ocsp.Unauthorized]}).Inc()
 			return

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2349,12 +2349,22 @@ func (ra *RegistrationAuthorityImpl) checkOrderNames(names []string) error {
 }
 
 // GenerateOCSP looks up a certificate's status, then requests a signed OCSP
-// response for it from the CA. If the certificate status is not available
-// or the certificate is expired, it returns berrors.NotFoundError.
+// response for it from the CA. If the certificate is expired, it returns
+// berrors.NotFoundError. If the serial is in the `serials` table but not
+// `certificateStatus` (i.e. its partition in the certificateStatus table has
+// been cleaned up), it returns berrors.NotFoundError. If the serial is in
+// neither the `serials` table nor `certificateStatus`, it returns
+// berrors.UnknownSerial.
 // This does not write back the result to the SA or any other storage.
 func (ra *RegistrationAuthorityImpl) GenerateOCSP(ctx context.Context, req *rapb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	status, err := ra.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: req.Serial})
-	if err != nil {
+	if errors.Is(err, berrors.NotFound) {
+		_, err := ra.SA.GetSerialMetadata(ctx, &sapb.Serial{Serial: req.Serial})
+		if errors.Is(err, berrors.NotFound) {
+			return nil, berrors.UnknownSerialError()
+		}
+		return nil, err
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2354,7 +2354,7 @@ func (ra *RegistrationAuthorityImpl) checkOrderNames(names []string) error {
 // `certificateStatus` (i.e. its partition in the certificateStatus table has
 // been cleaned up), it returns berrors.NotFoundError. If the serial is in
 // neither the `serials` table nor `certificateStatus`, it returns
-// berrors.UnknownSerial.
+// berrors.UnknownSerialError.
 // This does not write back the result to the SA or any other storage.
 func (ra *RegistrationAuthorityImpl) GenerateOCSP(ctx context.Context, req *rapb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	status, err := ra.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: req.Serial})


### PR DESCRIPTION
The "no response found for request" log message is pretty useless. There are a lot of reasons why we might have no response for an OCSP request; the most common being that someone is requesting OCSP status for a certificate even after it has expired.

Instead of logging all "not found" cases, log only a narrower set of cases: those where the serial doesn't exist in the `serials` table. Since we keep the serials table long term, even expired certificates will be in it (so long as those certificates were issued after we started writing to the `serials` table, in late 2019).

Part of #7091