### PR TITLE
ra: do not emit UnknownSerial yet

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2349,22 +2349,11 @@ func (ra *RegistrationAuthorityImpl) checkOrderNames(names []string) error {
 }
 
 // GenerateOCSP looks up a certificate's status, then requests a signed OCSP
-// response for it from the CA. If the certificate is expired, it returns
-// berrors.NotFoundError. If the serial is in the `serials` table but not
-// `certificateStatus` (i.e. its partition in the certificateStatus table has
-// been cleaned up), it returns berrors.NotFoundError. If the serial is in
-// neither the `serials` table nor `certificateStatus`, it returns
-// berrors.UnknownSerialError.
-// This does not write back the result to the SA or any other storage.
+// response for it from the CA. If the certificate status is not available
+// or the certificate is expired, it returns berrors.NotFoundError.
 func (ra *RegistrationAuthorityImpl) GenerateOCSP(ctx context.Context, req *rapb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	status, err := ra.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: req.Serial})
-	if errors.Is(err, berrors.NotFound) {
-		_, err := ra.SA.GetSerialMetadata(ctx, &sapb.Serial{Serial: req.Serial})
-		if errors.Is(err, berrors.NotFound) {
-			return nil, berrors.UnknownSerialError()
-		}
-		return nil, err
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This is a partial revert of #7103. Because that PR introduces a new Boulder error code that ocsp-responder needs to be specially aware of, it has a deployability issue: ocsp-responder needs to be made aware of the new error code before the RA can start emitting it.

The simple fix is to not emit that error code in the RA until the ocsp-responder is ready to receive it.