### PR TITLE
ra: send UnknownSerial error from GenerateOCSP

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2353,7 +2353,14 @@ func (ra *RegistrationAuthorityImpl) checkOrderNames(names []string) error {
 // or the certificate is expired, it returns berrors.NotFoundError.
 func (ra *RegistrationAuthorityImpl) GenerateOCSP(ctx context.Context, req *rapb.GenerateOCSPRequest) (*capb.OCSPResponse, error) {
 	status, err := ra.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: req.Serial})
-	if err != nil {
+	if errors.Is(err, berrors.NotFound) {
+		_, err := ra.SA.GetSerialMetadata(ctx, &sapb.Serial{Serial: req.Serial})
+		if errors.Is(err, berrors.NotFound) {
+			return nil, berrors.UnknownSerialError()
+		} else {
+			return nil, berrors.NotFoundError("certificate not found")
+		}
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3732,6 +3732,7 @@ func (mp *mockPurger) Purge(context.Context, *akamaipb.PurgeRequest, ...grpc.Cal
 	return &emptypb.Empty{}, nil
 }
 
+// mockSAGenerateOCSP is a mock SA that always returns a good OCSP response, with a constant NotAfter.
 type mockSAGenerateOCSP struct {
 	mocks.StorageAuthority
 	expiration time.Time
@@ -3764,6 +3765,70 @@ func TestGenerateOCSP(t *testing.T) {
 	_, err = ra.GenerateOCSP(context.Background(), req)
 	if !errors.Is(err, berrors.NotFound) {
 		t.Errorf("expected NotFound error, got %s", err)
+	}
+}
+
+// mockSALongExpiredSerial is a mock SA that treats every serial as if it expired a long time ago.
+// Specifically, it returns NotFound to GetCertificateStatus (simulating the serial having been
+// removed from the certificateStatus table), but returns success to GetSerialMetadata (simulating
+// a serial number staying in the `serials` table indefinitely).
+type mockSALongExpiredSerial struct {
+	mocks.StorageAuthority
+}
+
+func (msgo *mockSALongExpiredSerial) GetCertificateStatus(_ context.Context, req *sapb.Serial, _ ...grpc.CallOption) (*corepb.CertificateStatus, error) {
+	return nil, berrors.NotFoundError("not found")
+}
+
+func (msgo *mockSALongExpiredSerial) GetSerialMetadata(_ context.Context, req *sapb.Serial, _ ...grpc.CallOption) (*sapb.SerialMetadata, error) {
+	return &sapb.SerialMetadata{
+		Serial: req.Serial,
+	}, nil
+}
+
+func TestGenerateOCSPLongExpiredSerial(t *testing.T) {
+	_, _, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+
+	ra.OCSP = &mockOCSPA{}
+	ra.SA = &mockSALongExpiredSerial{}
+
+	req := &rapb.GenerateOCSPRequest{
+		Serial: core.SerialToString(big.NewInt(1)),
+	}
+
+	_, err := ra.GenerateOCSP(context.Background(), req)
+	test.AssertError(t, err, "generating OCSP")
+	if !errors.Is(err, berrors.NotFound) {
+		t.Errorf("expected NotFound error, got %#v", err)
+	}
+}
+
+// mockSAUnknownSerial is a mock SA that always returns NotFound to certificate status and serial lookups.
+// It emulates an SA that has never issued a certificate.
+type mockSAUnknownSerial struct {
+	mockSALongExpiredSerial
+}
+
+func (msgo *mockSAUnknownSerial) GetSerialMetadata(_ context.Context, req *sapb.Serial, _ ...grpc.CallOption) (*sapb.SerialMetadata, error) {
+	return nil, berrors.NotFoundError("not found")
+}
+
+func TestGenerateOCSPUnknownSerial(t *testing.T) {
+	_, _, ra, _, cleanUp := initAuthorities(t)
+	defer cleanUp()
+
+	ra.OCSP = &mockOCSPA{}
+	ra.SA = &mockSAUnknownSerial{}
+
+	req := &rapb.GenerateOCSPRequest{
+		Serial: core.SerialToString(big.NewInt(1)),
+	}
+
+	_, err := ra.GenerateOCSP(context.Background(), req)
+	test.AssertError(t, err, "generating OCSP")
+	if !errors.Is(err, berrors.UnknownSerial) {
+		t.Errorf("expected UnknownSerial error, got %#v", err)
 	}
 }
 


### PR DESCRIPTION
The allows the ocsp-responder to log unknown serial numbers (vs just expired ones).

Follow-up of #7108
Updates #7091