### PR TITLE
Update to go1.21.3

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,6 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
+          - go1.21.1_2023-09-07
           - go1.21.3_2023-10-12
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
@@ -110,6 +111,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
+          - go1.21.1_2023-09-07
           - go1.21.3_2023-10-12
 
     env:

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -111,7 +111,6 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.21.1_2023-09-07
           - go1.21.3_2023-10-12
 
     env:

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.21.1_2023-09-07
+          - go1.21.3_2023-10-12
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -110,7 +110,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.21.1_2023-09-07
+          - go1.21.3_2023-10-12
 
     env:
       # This sets the docker image tag for the boulder-tools repository to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.21.1"
+          - "1.21.3"
     runs-on: ubuntu-20.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -16,13 +16,14 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.21.1"
+          - "1.21.3"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      # Enable https://github.com/golang/go/wiki/LoopvarExperiment 
+      # Enable https://github.com/golang/go/wiki/LoopvarExperiment
       - run: echo "GOEXPERIMENT=loopvar" >> "$GITHUB_ENV"
 
       - name: Build .deb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   boulder:
     # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.21.1_2023-09-07}
+    image: &boulder_image letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.21.3_2023-10-12}
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,11 +12,11 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.21.1" )
+GO_CI_VERSIONS=( "1.21.1" "1.21.3" )
 # These versions are built for both platforms that boulder devs use.
 # When updating GO_DEV_VERSIONS, please also update
 # ../../docker-compose.yml's default Go version.
-GO_DEV_VERSIONS=( "1.21.1" )
+GO_DEV_VERSIONS=( "1.21.3" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
The [go1.21.3 release](https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo) contains updates to the `net/http` package for the [HTTP/2 rapid reset bug](https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack). The fixes in `x/net/http2` will be handled by [another PR](https://github.com/letsencrypt/boulder/pull/7113).

The following CVEs are fixed in this release:
- [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325)
- [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)