### PR TITLE
grpc: Read timestamps from timestamppb fields instead of int64 fields

### DIFF
--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -116,8 +116,8 @@ func PBToChallenge(in *corepb.Challenge) (challenge core.Challenge, err error) {
 		return core.Challenge{}, err
 	}
 	var validated *time.Time
-	if in.ValidatedNS != 0 {
-		val := time.Unix(0, in.ValidatedNS).UTC()
+	if !in.Validated.AsTime().IsZero() {
+		val := in.Validated.AsTime()
 		validated = &val
 	}
 	ch := core.Challenge{
@@ -275,8 +275,8 @@ func PbToRegistration(pb *corepb.Registration) (core.Registration, error) {
 		return core.Registration{}, err
 	}
 	var createdAt *time.Time
-	if pb.CreatedAtNS != 0 {
-		c := time.Unix(0, pb.CreatedAtNS).UTC()
+	if !pb.CreatedAt.AsTime().IsZero() {
+		c := pb.CreatedAt.AsTime()
 		createdAt = &c
 	}
 	var contacts *[]string
@@ -344,8 +344,8 @@ func PBToAuthz(pb *corepb.Authorization) (core.Authorization, error) {
 		challs[i] = chall
 	}
 	var expires *time.Time
-	if pb.ExpiresNS != 0 {
-		c := time.Unix(0, pb.ExpiresNS).UTC()
+	if !pb.Expires.AsTime().IsZero() {
+		c := pb.Expires.AsTime()
 		expires = &c
 	}
 	authz := core.Authorization{
@@ -396,8 +396,8 @@ func PBToCert(pb *corepb.Certificate) core.Certificate {
 		Serial:         pb.Serial,
 		Digest:         pb.Digest,
 		DER:            pb.Der,
-		Issued:         time.Unix(0, pb.IssuedNS),
-		Expires:        time.Unix(0, pb.ExpiresNS),
+		Issued:         pb.Issued.AsTime(),
+		Expires:        pb.Expires.AsTime(),
 	}
 }
 
@@ -423,11 +423,11 @@ func PBToCertStatus(pb *corepb.CertificateStatus) core.CertificateStatus {
 	return core.CertificateStatus{
 		Serial:                pb.Serial,
 		Status:                core.OCSPStatus(pb.Status),
-		OCSPLastUpdated:       time.Unix(0, pb.OcspLastUpdatedNS),
-		RevokedDate:           time.Unix(0, pb.RevokedDateNS),
+		OCSPLastUpdated:       pb.OcspLastUpdated.AsTime(),
+		RevokedDate:           pb.RevokedDate.AsTime(),
 		RevokedReason:         revocation.Reason(pb.RevokedReason),
-		LastExpirationNagSent: time.Unix(0, pb.LastExpirationNagSentNS),
-		NotAfter:              time.Unix(0, pb.NotAfterNS),
+		LastExpirationNagSent: pb.LastExpirationNagSent.AsTime(),
+		NotAfter:              pb.NotAfter.AsTime(),
 		IsExpired:             pb.IsExpired,
 		IssuerNameID:          pb.IssuerID,
 	}

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -116,7 +116,7 @@ func PBToChallenge(in *corepb.Challenge) (challenge core.Challenge, err error) {
 		return core.Challenge{}, err
 	}
 	var validated *time.Time
-	if !in.Validated.AsTime().IsZero() {
+	if in.Validated != nil && !in.Validated.AsTime().IsZero() {
 		val := in.Validated.AsTime()
 		validated = &val
 	}
@@ -275,7 +275,7 @@ func PbToRegistration(pb *corepb.Registration) (core.Registration, error) {
 		return core.Registration{}, err
 	}
 	var createdAt *time.Time
-	if !pb.CreatedAt.AsTime().IsZero() {
+	if pb.CreatedAt != nil && !pb.CreatedAt.AsTime().IsZero() {
 		c := pb.CreatedAt.AsTime()
 		createdAt = &c
 	}
@@ -344,7 +344,7 @@ func PBToAuthz(pb *corepb.Authorization) (core.Authorization, error) {
 		challs[i] = chall
 	}
 	var expires *time.Time
-	if !pb.Expires.AsTime().IsZero() {
+	if pb.Expires != nil && !pb.Expires.AsTime().IsZero() {
 		c := pb.Expires.AsTime()
 		expires = &c
 	}

--- a/grpc/pb-marshalling_test.go
+++ b/grpc/pb-marshalling_test.go
@@ -267,7 +267,7 @@ func TestAuthz(t *testing.T) {
 }
 
 func TestCert(t *testing.T) {
-	now := time.Now().Round(0)
+	now := time.Now().Round(0).UTC()
 	cert := core.Certificate{
 		RegistrationID: 1,
 		Serial:         "serial",


### PR DESCRIPTION
Switch to reading grpc timestamp values from the new timestamppb protofbuf fields, completely ignoring the old int64 fields.

Part 3 of 4 for https://github.com/letsencrypt/boulder/issues/7060