### PR TITLE
Upgrade to jaeger 1.50

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,9 +146,7 @@ services:
     entrypoint: test/entrypoint-netaccess.sh
 
   bjaeger:
-    image: jaegertracing/all-in-one:1.44
-    environment:
-      COLLECTOR_OTLP_ENABLED: "true"
+    image: jaegertracing/all-in-one:1.50
     networks:
       bluenet:
         ipv4_address: 10.77.77.17


### PR DESCRIPTION
This has the OTLP collector enabled by default, so we don't need a flag
for that anymore.
