### PR TITLE
Give throwaway test certs reasonable validity intervals

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -312,7 +312,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 
 	fc := clock.NewFake()
 	// Set to some non-zero time.
-	fc.Set(time.Date(2015, 3, 4, 5, 0, 0, 0, time.UTC))
+	fc.Set(time.Date(2020, 3, 4, 5, 0, 0, 0, time.UTC))
 
 	dbMap, err := sa.DBMapForTest(vars.DBConnSA)
 	if err != nil {
@@ -1086,7 +1086,7 @@ func TestEarlyOrderRateLimiting(t *testing.T) {
 	test.AssertEquals(t, bErr.RetryAfter, rateLimitDuration)
 
 	// The err should be the expected rate limit error
-	expected := "too many certificates already issued for \"early-ratelimit-example.com\". Retry after 2015-03-04T05:05:00Z: see https://letsencrypt.org/docs/rate-limits/"
+	expected := "too many certificates already issued for \"early-ratelimit-example.com\". Retry after 2020-03-04T05:05:00Z: see https://letsencrypt.org/docs/rate-limits/"
 	test.AssertEquals(t, bErr.Error(), expected)
 }
 
@@ -3785,7 +3785,7 @@ func TestRevokeCertByApplicant_Subscriber(t *testing.T) {
 	ra.OCSP = &mockOCSPA{}
 	ra.purger = &mockPurger{}
 
-	_, cert := test.ThrowAwayCert(t, 1)
+	_, cert := test.ThrowAwayCert(t, clk, 1)
 	ic, err := issuance.NewCertificate(cert)
 	test.AssertNotError(t, err, "failed to create issuer cert")
 	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
@@ -3839,7 +3839,7 @@ func TestRevokeCertByApplicant_Controller(t *testing.T) {
 	ra.OCSP = &mockOCSPA{}
 	ra.purger = &mockPurger{}
 
-	_, cert := test.ThrowAwayCert(t, 1)
+	_, cert := test.ThrowAwayCert(t, clk, 1)
 	ic, err := issuance.NewCertificate(cert)
 	test.AssertNotError(t, err, "failed to create issuer cert")
 	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
@@ -3883,7 +3883,11 @@ func TestRevokeCertByKey(t *testing.T) {
 	digest, err := core.KeyDigest(k.Public())
 	test.AssertNotError(t, err, "core.KeyDigest failed")
 
-	template := x509.Certificate{SerialNumber: big.NewInt(257)}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(257),
+		NotBefore:    clk.Now(),
+		NotAfter:     clk.Now().Add(6 * 24 * time.Hour),
+	}
 	der, err := x509.CreateCertificate(rand.Reader, &template, &template, k.Public(), k)
 	test.AssertNotError(t, err, "x509.CreateCertificate failed")
 	cert, err := x509.ParseCertificate(der)

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -322,11 +322,11 @@ func findIssuedName(ctx context.Context, dbMap db.OneSelector, name string) (str
 }
 
 func TestAddSerial(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
+	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()
 
 	reg := createWorkingRegistration(t, sa)
-	serial, testCert := test.ThrowAwayCert(t, 1)
+	serial, testCert := test.ThrowAwayCert(t, clk, 1)
 
 	_, err := sa.AddSerial(context.Background(), &sapb.AddSerialRequest{
 		RegID:     reg.Id,
@@ -378,7 +378,7 @@ func TestGetSerialMetadata(t *testing.T) {
 	defer cleanUp()
 
 	reg := createWorkingRegistration(t, sa)
-	serial, _ := test.ThrowAwayCert(t, 1)
+	serial, _ := test.ThrowAwayCert(t, clk, 1)
 
 	_, err := sa.GetSerialMetadata(context.Background(), &sapb.Serial{Serial: serial})
 	test.AssertError(t, err, "getting nonexistent serial should have failed")
@@ -415,7 +415,7 @@ func TestAddPrecertificate(t *testing.T) {
 
 	// Create a throw-away self signed certificate with a random name and
 	// serial number
-	serial, testCert := test.ThrowAwayCert(t, 1)
+	serial, testCert := test.ThrowAwayCert(t, clk, 1)
 
 	// Add the cert as a precertificate
 	regID := reg.Id
@@ -455,11 +455,11 @@ func TestAddPrecertificate(t *testing.T) {
 }
 
 func TestAddPrecertificateNoOCSP(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
+	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()
 
 	reg := createWorkingRegistration(t, sa)
-	_, testCert := test.ThrowAwayCert(t, 1)
+	_, testCert := test.ThrowAwayCert(t, clk, 1)
 
 	regID := reg.Id
 	issuedTime := time.Date(2018, 4, 1, 7, 0, 0, 0, time.UTC)
@@ -479,8 +479,9 @@ func TestAddPreCertificateDuplicate(t *testing.T) {
 
 	reg := createWorkingRegistration(t, sa)
 
-	_, testCert := test.ThrowAwayCert(t, 1)
+	_, testCert := test.ThrowAwayCert(t, clk, 1)
 	issuedTime := clk.Now()
+
 	_, err := sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
 		Der:          testCert.Raw,
 		IssuedNS:     issuedTime.UnixNano(),
@@ -501,14 +502,14 @@ func TestAddPreCertificateDuplicate(t *testing.T) {
 }
 
 func TestAddPrecertificateIncomplete(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
+	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()
 
 	reg := createWorkingRegistration(t, sa)
 
 	// Create a throw-away self signed certificate with a random name and
 	// serial number
-	_, testCert := test.ThrowAwayCert(t, 1)
+	_, testCert := test.ThrowAwayCert(t, clk, 1)
 
 	// Add the cert as a precertificate
 	regID := reg.Id
@@ -525,11 +526,11 @@ func TestAddPrecertificateIncomplete(t *testing.T) {
 }
 
 func TestAddPrecertificateKeyHash(t *testing.T) {
-	sa, _, cleanUp := initSA(t)
+	sa, clk, cleanUp := initSA(t)
 	defer cleanUp()
 	reg := createWorkingRegistration(t, sa)
 
-	serial, testCert := test.ThrowAwayCert(t, 1)
+	serial, testCert := test.ThrowAwayCert(t, clk, 1)
 	_, err := sa.AddPrecertificate(ctx, &sapb.AddCertificateRequest{
 		Der:          testCert.Raw,
 		RegID:        reg.Id,
@@ -609,7 +610,7 @@ func TestAddCertificateDuplicate(t *testing.T) {
 
 	reg := createWorkingRegistration(t, sa)
 
-	_, testCert := test.ThrowAwayCert(t, 1)
+	_, testCert := test.ThrowAwayCert(t, clk, 1)
 
 	issuedTime := clk.Now()
 	_, err := sa.AddCertificate(ctx, &sapb.AddCertificateRequest{


### PR DESCRIPTION
Add a new clock argument to the test-only ThrowAwayCert function, and use that clock to generate reasonable notBefore and notAfter timestamps in the resulting throwaway test cert. This is necessary to easily test functions which rely on the expiration timestamp of the certificate, such as upcoming work about computing CRL shards.

Part of https://github.com/letsencrypt/boulder/issues/7094