### PR TITLE
Remove crlURL from test CA issuer configs

### DIFF
--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -74,7 +74,6 @@
 					"useForECDSALeaves": true,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
@@ -86,7 +85,6 @@
 					"useForECDSALeaves": false,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -74,7 +74,6 @@
 					"useForECDSALeaves": true,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
@@ -86,7 +85,6 @@
 					"useForECDSALeaves": false,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "/hierarchy/intermediate-signing-key-rsa.pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -69,7 +69,6 @@
 					"useForECDSALeaves": true,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "test/test-ca.key-pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
@@ -81,7 +80,6 @@
 					"useForECDSALeaves": false,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "test/test-ca.key-pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -69,7 +69,6 @@
 					"useForECDSALeaves": true,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/6605440498369741",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "test/test-ca.key-pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-a.pem",
@@ -81,7 +80,6 @@
 					"useForECDSALeaves": false,
 					"issuerURL": "http://127.0.0.1:4001/aia/issuer/41127673797486028",
 					"ocspURL": "http://127.0.0.1:4002/",
-					"crlURL": "http://example.com/crl",
 					"location": {
 						"configFile": "test/test-ca.key-pkcs11.json",
 						"certFile": "/hierarchy/intermediate-cert-rsa-b.pem",


### PR DESCRIPTION
This value is always set to the empty string in prod, which (correctly) results in the issued certificates not having a CRLDP at all. It turns out our integration test environment has been including CRLDPs in all of our test certs because we set crlURL to a non-empty value! This change updates our test configs to match reality.

I'll remove the code which supports this config value as part of my upcoming CA CRLDP changes.