### PR TITLE
[WIP] Support file glob paths in log-validator

### DIFF
--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -225,6 +225,12 @@ func main() {
 		}
 	}
 
+	if len(tailers) == 0 {
+		cmd.Fail("No log files to monitor")
+	} else {
+		logger.Infof("Tailing %d files", len(tailers))
+	}
+
 	defer func() {
 		for _, t := range tailers {
 			// The tail module seems to have a race condition that will generate

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -7,20 +7,7 @@
 		"sampleratio": 1
 	},
 	"debugAddr": ":8016",
-	"files": [
-		"/var/log/akamai-purger.log",
-		"/var/log/bad-key-revoker.log",
-		"/var/log/boulder-ca.log",
-		"/var/log/boulder-observer.log",
-		"/var/log/boulder-publisher.log",
-		"/var/log/boulder-ra.log",
-		"/var/log/boulder-remoteva.log",
-		"/var/log/boulder-sa.log",
-		"/var/log/boulder-va.log",
-		"/var/log/boulder-wfe2.log",
-		"/var/log/crl-storer.log",
-		"/var/log/crl-updater.log",
-		"/var/log/nonce-service.log",
-		"/var/log/ocsp-responder.log"
+	"fileGlobs": [
+		"/var/log/*.log"
 	]
 }


### PR DESCRIPTION
Our configuration for log-validator has a bunch of hardcoded paths, which is harder to manage than it should be, and could miss new paths, for example if we add more nodes.

This uses filepath.Glob to load a collection of files.

[WIP] This isn't really ready yet, and has a number of shortcomings:
1. Glob won't notice new files.  Does this matter?  Should we re-glob on a timer or inotify?
2. Config validation needed.
3. Some test coverage.
