### PR TITLE
Use a separate GOCACHE for config and config-next

### DIFF
--- a/docker-compose.next.yml
+++ b/docker-compose.next.yml
@@ -5,3 +5,4 @@ services:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: &boulder_config_dir test/config-next
       GOFLAGS: -mod=vendor
+      GOCACHE: "/root/.cache/go-build/tn"

--- a/docker-compose.next.yml
+++ b/docker-compose.next.yml
@@ -5,4 +5,4 @@ services:
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: &boulder_config_dir test/config-next
       GOFLAGS: -mod=vendor
-      GOCACHE: "/root/.cache/go-build/tn"
+      GOCACHE: /boulder/.gocache/go-build-next

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       # FAKE_DNS: 172.17.0.1
       FAKE_DNS: 10.77.77.77
       BOULDER_CONFIG_DIR: test/config
+      GOCACHE: /boulder/.gocache/go-build
       GOFLAGS: -mod=vendor
       # Forward the parent env's GOEXPERIMENT value into the container.
       GOEXPERIMENT: ${GOEXPERIMENT}

--- a/test.sh
+++ b/test.sh
@@ -191,7 +191,7 @@ trap "print_outcome" EXIT
 settings="$(cat -- <<-EOM
     RUN:                ${RUN[@]}
     BOULDER_CONFIG_DIR: $BOULDER_CONFIG_DIR
-    GOCACHE:            $(go env | awk -F'=' '/^GOCACHE/ {print $2}' | sed "s/'//g")
+    GOCACHE:            $(go env GOCACHE)
     UNIT_PACKAGES:      ${UNIT_PACKAGES[@]}
     UNIT_FLAGS:         ${UNIT_FLAGS[@]}
     FILTER:             ${FILTER[@]}

--- a/test.sh
+++ b/test.sh
@@ -191,6 +191,7 @@ trap "print_outcome" EXIT
 settings="$(cat -- <<-EOM
     RUN:                ${RUN[@]}
     BOULDER_CONFIG_DIR: $BOULDER_CONFIG_DIR
+    GOCACHE:            $(go env | awk -F'=' '/^GOCACHE/ {print $2}' | sed "s/'//g")
     UNIT_PACKAGES:      ${UNIT_PACKAGES[@]}
     UNIT_FLAGS:         ${UNIT_FLAGS[@]}
     FILTER:             ${FILTER[@]}


### PR DESCRIPTION
`t.sh` and `tn.sh` now each use a distinct GOCACHE.
Changes `test.sh` to output which GOCACHE is being used.