### PR TITLE
Invert RequireCommonName into AllowNoCommonName

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -75,7 +75,7 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 	if len(names.SANs) == 0 && names.CN == "" {
 		return invalidNoDNS
 	}
-	if names.CN == "" && features.Enabled(features.RequireCommonName) {
+	if names.CN == "" && !features.Enabled(features.AllowNoCommonName) {
 		return invalidAllSANTooLong
 	}
 	if len(names.CN) > maxCNLength {

--- a/features/featureflag_string.go
+++ b/features/featureflag_string.go
@@ -26,11 +26,11 @@ func _() {
 	_ = x[CertCheckerRequiresValidations-15]
 	_ = x[CertCheckerRequiresCorrespondence-16]
 	_ = x[AsyncFinalize-17]
-	_ = x[RequireCommonName-18]
+	_ = x[AllowNoCommonName-18]
 	_ = x[CAAAfterValidation-19]
 }
 
-const _FeatureFlag_name = "unusedStoreRevokerInfoROCSPStage6ROCSPStage7StoreLintingCertificateInsteadOfPrecertificateCAAValidationMethodsCAAAccountURILeaseCRLShardsEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsCertCheckerRequiresCorrespondenceAsyncFinalizeRequireCommonNameCAAAfterValidation"
+const _FeatureFlag_name = "unusedStoreRevokerInfoROCSPStage6ROCSPStage7StoreLintingCertificateInsteadOfPrecertificateCAAValidationMethodsCAAAccountURILeaseCRLShardsEnforceMultiVAMultiVAFullResultsECDSAForAllServeRenewalInfoAllowUnrecognizedFeaturesExpirationMailerUsesJoinCertCheckerChecksValidationsCertCheckerRequiresValidationsCertCheckerRequiresCorrespondenceAsyncFinalizeAllowNoCommonNameCAAAfterValidation"
 
 var _FeatureFlag_index = [...]uint16{0, 6, 22, 33, 44, 90, 110, 123, 137, 151, 169, 180, 196, 221, 245, 273, 303, 336, 349, 366, 384}
 

--- a/features/features.go
+++ b/features/features.go
@@ -67,13 +67,14 @@ const (
 	// for the cert URL to appear.
 	AsyncFinalize
 
-	// RequireCommonName defaults to true, and causes the CA to fail to issue a
-	// certificate if there is no CommonName in the certificate. When false, the
-	// CA will be willing to issue certificates with no CN.
+	// AllowNoCommonName defaults to false, and causes the CA to fail to issue a
+	// certificate if we can't put a CommonName in it. When true, the
+	// CA will be willing to issue certificates with no CN if and only if there
+	// is no SAN short enough to be hoisted into the CN.
 	//
 	// According to the BRs Section 7.1.4.2.2(a), the commonName field is
 	// Deprecated, and its inclusion is discouraged but not (yet) prohibited.
-	RequireCommonName
+	AllowNoCommonName
 
 	// CAAAfterValidation causes the VA to only kick off CAA checks after the base
 	// domain control validation has completed and succeeded. This makes
@@ -100,7 +101,7 @@ var features = map[FeatureFlag]bool{
 	CertCheckerRequiresValidations:    false,
 	CertCheckerRequiresCorrespondence: false,
 	AsyncFinalize:                     false,
-	RequireCommonName:                 true,
+	AllowNoCommonName:                 false,
 	LeaseCRLShards:                    false,
 	CAAAfterValidation:                false,
 

--- a/test/config-next/ca-a.json
+++ b/test/config-next/ca-a.json
@@ -113,7 +113,7 @@
 		"ctLogListFile": "test/ct-test-srv/log_list.json",
 		"features": {
 			"ECDSAForAll": true,
-			"RequireCommonName": false
+			"AllowNoCommonName": true
 		}
 	},
 	"pa": {

--- a/test/config-next/ca-b.json
+++ b/test/config-next/ca-b.json
@@ -113,7 +113,7 @@
 		"ctLogListFile": "test/ct-test-srv/log_list.json",
 		"features": {
 			"ECDSAForAll": true,
-			"RequireCommonName": false
+			"AllowNoCommonName": true
 		}
 	},
 	"pa": {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -106,7 +106,7 @@
 		"features": {
 			"StoreRevokerInfo": true,
 			"AsyncFinalize": true,
-			"RequireCommonName": false
+			"AllowNoCommonName": true
 		},
 		"ctLogs": {
 			"stagger": "500ms",

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -131,7 +131,7 @@
 		},
 		"features": {
 			"ServeRenewalInfo": true,
-			"RequireCommonName": false
+			"AllowNoCommonName": true
 		}
 	},
 	"syslog": {

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -78,7 +78,7 @@ func TestFirstCSRSANHoistedToCN(t *testing.T) {
 
 // TestCommonNameSANsTooLong tests that, when the names in an order and CSR are
 // too long to be hoisted into the CN, the correct behavior results (depending
-// on the state of the RequireCommonName feature flag).
+// on the state of the AllowNoCommonName feature flag).
 func TestCommonNameSANsTooLong(t *testing.T) {
 	t.Parallel()
 
@@ -97,13 +97,13 @@ func TestCommonNameSANsTooLong(t *testing.T) {
 	// Issue a cert using a CSR with no CN set.
 	ir, err := authAndIssue(client, key, []string{san1, san2}, false)
 
-	// By default, the RequireCommonName flag is true, so issuance should have failed.
+	// By default, the AllowNoCommonName flag is false, so issuance should have failed.
 	if !strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
 		test.AssertError(t, err, "issuing cert with no CN")
 		return
 	}
 
-	// But in config-next, the RequireCommonName flag is false, so issuance should
+	// But in config-next, the AllowNoCommonName flag is true, so issuance should
 	// have succeeded.
 	test.AssertNotError(t, err, "failed to issue test cert")
 	cert := ir.certs[0]

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2098,7 +2098,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 			hasValidCNLen = true
 		}
 	}
-	if !hasValidCNLen && features.Enabled(features.RequireCommonName) {
+	if !hasValidCNLen && !features.Enabled(features.AllowNoCommonName) {
 		wfe.sendError(response, logEvent,
 			probs.RejectedIdentifier("NewOrder request did not include a SAN short enough to fit in CN"),
 			nil)


### PR DESCRIPTION
The RequireCommonName feature flag was our only "inverted" feature flag, which defaulted to true and had to be explicitly set to false. This inversion can lead to confusion, especially to readers who expect all Go default values to be zero values. We plan to remove the ability for our feature flag system to support default-true flags, which the existence of this flag blocked. Since this flag has not been set in any real configs, inverting it is easy.

Part of https://github.com/letsencrypt/boulder/issues/6802