### PR TITLE
Read from durationpb instead of int64 durations

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -25,6 +25,7 @@ import (
 	"time"
 	"unicode"
 
+	"google.golang.org/protobuf/types/known/durationpb"
 	"gopkg.in/go-jose/go-jose.v2"
 )
 
@@ -214,6 +215,10 @@ func IsAnyNilOrZero(vals ...interface{}) bool {
 			return true
 		case []byte:
 			if len(v) == 0 {
+				return true
+			}
+		case *durationpb.Duration:
+			if v == nil || v.AsDuration() == time.Duration(0) {
 				return true
 			}
 		default:

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/types/known/durationpb"
 	"gopkg.in/go-jose/go-jose.v2"
 
 	"github.com/letsencrypt/boulder/test"
@@ -135,6 +136,12 @@ func TestIsAnyNilOrZero(t *testing.T) {
 
 	test.Assert(t, IsAnyNilOrZero(1, ""), "Mixed values seen as non-zero")
 	test.Assert(t, IsAnyNilOrZero("", 1), "Mixed values seen as non-zero")
+
+	var d *durationpb.Duration
+	var zeroDuration time.Duration
+	test.Assert(t, IsAnyNilOrZero(d), "Pointer to uninitialized durationpb.Duration seen as non-zero")
+	test.Assert(t, IsAnyNilOrZero(durationpb.New(zeroDuration)), "*durationpb.Duration containing an zero value time.Duration is seen as non-zero")
+	test.Assert(t, !IsAnyNilOrZero(durationpb.New(666)), "A *durationpb.Duration with valid inner duration is seen as zero")
 }
 
 func TestUniqueLowerNames(t *testing.T) {

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -918,8 +918,17 @@ func TestFQDNSets(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to add name set")
 	test.AssertNotError(t, tx.Commit(), "Failed to commit transaction")
 
-	threeHours := time.Hour * 3
+	// Invalid Window
 	req := &sapb.CountFQDNSetsRequest{
+		Domains:  names,
+		WindowNS: 0,
+		Window:   nil,
+	}
+	_, err = sa.CountFQDNSets(ctx, req)
+	test.AssertErrorIs(t, err, errIncompleteRequest)
+
+	threeHours := time.Hour * 3
+	req = &sapb.CountFQDNSetsRequest{
 		Domains:  names,
 		WindowNS: threeHours.Nanoseconds(),
 		Window:   durationpb.New(threeHours),
@@ -977,8 +986,18 @@ func TestFQDNSetTimestampsForWindow(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to open transaction")
 
 	names := []string{"a.example.com", "B.example.com"}
-	window := time.Hour * 3
+
+	// Invalid Window
 	req := &sapb.CountFQDNSetsRequest{
+		Domains:  names,
+		WindowNS: 0,
+		Window:   nil,
+	}
+	_, err = sa.FQDNSetTimestampsForWindow(ctx, req)
+	test.AssertErrorIs(t, err, errIncompleteRequest)
+
+	window := time.Hour * 3
+	req = &sapb.CountFQDNSetsRequest{
 		Domains:  names,
 		WindowNS: window.Nanoseconds(),
 		Window:   durationpb.New(window),

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -507,7 +507,7 @@ func (ssa *SQLStorageAuthority) CountOrders(ctx context.Context, req *sapb.Count
 // CountFQDNSets counts the total number of issuances, for a set of domains,
 // that occurred during a given window of time.
 func (ssa *SQLStorageAuthorityRO) CountFQDNSets(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Count, error) {
-	if req.WindowNS == 0 || len(req.Domains) == 0 {
+	if req.Window == nil || len(req.Domains) == 0 {
 		return nil, errIncompleteRequest
 	}
 
@@ -519,7 +519,7 @@ func (ssa *SQLStorageAuthorityRO) CountFQDNSets(ctx context.Context, req *sapb.C
 		WHERE setHash = ?
 		AND issued > ?`,
 		core.HashNames(req.Domains),
-		ssa.clk.Now().Add(-time.Duration(req.WindowNS)),
+		ssa.clk.Now().Add(-req.Window.AsDuration()),
 	)
 	return &sapb.Count{Count: count}, err
 }
@@ -532,7 +532,7 @@ func (ssa *SQLStorageAuthority) CountFQDNSets(ctx context.Context, req *sapb.Cou
 // certificate, issued for a set of domains, during a given window of time,
 // starting from the most recent issuance.
 func (ssa *SQLStorageAuthorityRO) FQDNSetTimestampsForWindow(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Timestamps, error) {
-	if req.WindowNS == 0 || len(req.Domains) == 0 {
+	if req.Window == nil || len(req.Domains) == 0 {
 		return nil, errIncompleteRequest
 	}
 	type row struct {
@@ -547,7 +547,7 @@ func (ssa *SQLStorageAuthorityRO) FQDNSetTimestampsForWindow(ctx context.Context
 		AND issued > ?
 		ORDER BY issued DESC`,
 		core.HashNames(req.Domains),
-		ssa.clk.Now().Add(-time.Duration(req.WindowNS)),
+		ssa.clk.Now().Add(-req.Window.AsDuration()),
 	)
 	if err != nil {
 		return nil, err

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -507,7 +507,7 @@ func (ssa *SQLStorageAuthority) CountOrders(ctx context.Context, req *sapb.Count
 // CountFQDNSets counts the total number of issuances, for a set of domains,
 // that occurred during a given window of time.
 func (ssa *SQLStorageAuthorityRO) CountFQDNSets(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Count, error) {
-	if req.Window == nil || len(req.Domains) == 0 {
+	if core.IsAnyNilOrZero(req.Window) || len(req.Domains) == 0 {
 		return nil, errIncompleteRequest
 	}
 

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -532,7 +532,7 @@ func (ssa *SQLStorageAuthority) CountFQDNSets(ctx context.Context, req *sapb.Cou
 // certificate, issued for a set of domains, during a given window of time,
 // starting from the most recent issuance.
 func (ssa *SQLStorageAuthorityRO) FQDNSetTimestampsForWindow(ctx context.Context, req *sapb.CountFQDNSetsRequest) (*sapb.Timestamps, error) {
-	if req.Window == nil || len(req.Domains) == 0 {
+	if core.IsAnyNilOrZero(req.Window) || len(req.Domains) == 0 {
 		return nil, errIncompleteRequest
 	}
 	type row struct {


### PR DESCRIPTION
Switch to reading grpc duration values from the new durationpb protofbuf fields, completely ignoring the old int64 fields.

Part 2 of 3 for https://github.com/letsencrypt/boulder/issues/7097