### PR TITLE
VA: Check that maxRemoteValidationFailures is non-negative

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -32,7 +32,7 @@ type Config struct {
 		DNSAllowLoopbackAddresses bool
 
 		RemoteVAs                   []cmd.GRPCClientConfig `validate:"omitempty,dive"`
-		MaxRemoteValidationFailures int
+		MaxRemoteValidationFailures int                    `validate:"omitempty,min=0,required_with=RemoteVAs"`
 
 		Features map[string]bool
 

--- a/va/va.go
+++ b/va/va.go
@@ -233,6 +233,10 @@ func NewValidationAuthorityImpl(
 		return nil, errors.New("no account URI prefixes configured")
 	}
 
+	if maxRemoteFailures < 0 {
+		return nil, errors.New("MaxRemoteValidationFailures must not be a negative number")
+	}
+
 	pc := newDefaultPortConfig()
 
 	va := &ValidationAuthorityImpl{

--- a/va/va.go
+++ b/va/va.go
@@ -233,10 +233,6 @@ func NewValidationAuthorityImpl(
 		return nil, errors.New("no account URI prefixes configured")
 	}
 
-	if maxRemoteFailures < 0 {
-		return nil, errors.New("MaxRemoteValidationFailures must not be a negative number")
-	}
-
 	pc := newDefaultPortConfig()
 
 	va := &ValidationAuthorityImpl{


### PR DESCRIPTION
Prevents a panic when the VA config field `maxRemoteValidationFailures` is set to a negative number by adding validation tags
 
Fixes https://github.com/letsencrypt/boulder/issues/7149