### PR TITLE
CI: don't block on govulncheck, do block on vendorcheck

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -150,6 +150,8 @@ jobs:
   # above jobs have failed and fail if so. It is needed so there can be
   # one static job name that can be used to determine success of the job
   # in GitHub branch protection.
+  # It does not block on the result of govulncheck so that a new vulnerability
+  # disclosure does not prevent any other PRs from being merged.
   boulder_ci_test_matrix_status:
     permissions:
       contents: none
@@ -158,8 +160,8 @@ jobs:
     name: Boulder CI Test Matrix
     needs:
       - b
-      - govulncheck
+      - vendorcheck
     steps:
       - name: Check boulder ci test matrix status
-        if: ${{ needs.b.result != 'success' || needs.govulncheck.result != 'success' }}
+        if: ${{ needs.b.result != 'success' || needs.vendorcheck.result != 'success' }}
         run: exit 1


### PR DESCRIPTION
Having govulncheck prevent a PR from merging means that circumstances entirely outside our control can grind Boulder development to a halt until they are addressed. When the vulnerability is within Go itself, it prevents PRs from being merged until we do a production deploy, because we want our CI to always match what is in production. This is too strict.

This PR removes govulncheck from the set of jobs depended upon by our Boulder CI Test Matrix meta-job. It also adds vendorcheck, which was accidentally omitted in #7123.