### PR TITLE
cert-checker: allow for empty common name

### DIFF
--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -241,13 +241,12 @@ func TestCheckCert(t *testing.T) {
 				NotBefore: issued,
 				NotAfter:  goodExpiry.AddDate(0, 0, 1), // Period too long
 				DNSNames: []string{
-					// longName should be flagged along with the long CN
-					longName,
 					"example-a.com",
 					"foodnotbombs.mil",
 					// `dev-myqnapcloud.com` is included because it is an exact private
 					// entry on the public suffix list
 					"dev-myqnapcloud.com",
+					// don't include longName in the SANs, so the unique CN gets flagged
 				},
 				SerialNumber:          serial,
 				BasicConstraintsValid: false,
@@ -283,6 +282,7 @@ func TestCheckCert(t *testing.T) {
 				"Certificate has incorrect key usage extensions":                            1,
 				"Certificate has common name >64 characters long (65)":                      1,
 				"Certificate contains an unexpected extension: 1.3.3.7":                     1,
+				"Certificate Common Name does not appear in Subject Alternative Names: \"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeexample.com\" !< [example-a.com foodnotbombs.mil dev-myqnapcloud.com]": 1,
 			}
 			for _, p := range problems {
 				_, ok := problemsMap[p]


### PR DESCRIPTION
Update cert-checker's logic to only ask the Policy Authority if we are willing to issue for the Subject Alternative Names in a cert, to avoid asking the PA about the Common Name when that CN is just the empty string.

Add a new check to cert-checker to ensure that the Common Name is exactly equal to one of the SANs, to fill a theoretical gap created by loosening the check above.

Fixes https://github.com/letsencrypt/boulder/issues/7156