### PR TITLE
Make log-validator take glob patterns to monitor for log files

### DIFF
--- a/cmd/log-validator/main.go
+++ b/cmd/log-validator/main.go
@@ -38,13 +38,8 @@ func main() {
 	defer oTelShutdown(context.Background())
 	logger.Info(cmd.VersionString())
 
-	v := validator.New(logger, stats)
+	v := validator.New(config.Files, logger, stats)
 	defer v.Shutdown()
-
-	for _, filename := range config.Files {
-		err := v.TailValidateFile(filename)
-		cmd.FailOnError(err, "failed to tail file")
-	}
 
 	cmd.WaitForSignal()
 }

--- a/log/validator/tail_logger.go
+++ b/log/validator/tail_logger.go
@@ -6,7 +6,7 @@ import (
 	"github.com/letsencrypt/boulder/log"
 )
 
-// tailLogger is an adapter to the hpcloud/tail module's logging interface.
+// tailLogger is an adapter to the nxadm/tail module's logging interface.
 type tailLogger struct {
 	log.Logger
 }

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -8,19 +8,6 @@
 	},
 	"debugAddr": ":8016",
 	"files": [
-		"/var/log/akamai-purger.log",
-		"/var/log/bad-key-revoker.log",
-		"/var/log/boulder-ca.log",
-		"/var/log/boulder-observer.log",
-		"/var/log/boulder-publisher.log",
-		"/var/log/boulder-ra.log",
-		"/var/log/boulder-remoteva.log",
-		"/var/log/boulder-sa.log",
-		"/var/log/boulder-va.log",
-		"/var/log/boulder-wfe2.log",
-		"/var/log/crl-storer.log",
-		"/var/log/crl-updater.log",
-		"/var/log/nonce-service.log",
-		"/var/log/ocsp-responder.log"
+		"/var/log/*.log"
 	]
 }

--- a/test/config-next/log-validator.json
+++ b/test/config-next/log-validator.json
@@ -8,6 +8,11 @@
 	},
 	"debugAddr": ":8016",
 	"files": [
-		"/var/log/*.log"
+		"/var/log/akamai-purger.log",
+		"/var/log/bad-key-revoker.log",
+		"/var/log/boulder-*.log",
+		"/var/log/crl-*.log",
+		"/var/log/nonce-service.log",
+		"/var/log/ocsp-responder.log"
 	]
 }


### PR DESCRIPTION
To simplify deployment of the log validator, this allows wildcards (using go's filepath.Glob) to be included in the file paths.

In order to detect new files, a new background goroutine polls the glob patterns every minute for matches.

Because the "monitor" function is running in its own goroutine, a lock is needed to ensure it's not trying to add new tailers while shutdown is happening.