### PR TITLE
observer: disable IPv6-to-IPv4 fallback

### DIFF
--- a/observer/obsdialer/obsdialer.go
+++ b/observer/obsdialer/obsdialer.go
@@ -1,0 +1,10 @@
+// package obsdialer contains a custom dialer for use in observers.
+package obsdialer
+
+import "net"
+
+// Dialer is a custom dialer for use in observers. It disables IPv6-to-IPv4
+// fallback so we don't mask failures of IPv6 connectivity.
+var Dialer = net.Dialer{
+	FallbackDelay: -1, // Disable IPv6-to-IPv4 fallback
+}

--- a/observer/probers/tcp/tcp.go
+++ b/observer/probers/tcp/tcp.go
@@ -1,8 +1,10 @@
 package tcp
 
 import (
-	"net"
+	"context"
 	"time"
+
+	"github.com/letsencrypt/boulder/observer/obsdialer"
 )
 
 type TCPProbe struct {
@@ -22,12 +24,10 @@ func (p TCPProbe) Kind() string {
 
 // Probe performs the configured TCP dial.
 func (p TCPProbe) Probe(timeout time.Duration) (bool, time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	start := time.Now()
-	dialer := &net.Dialer{
-		Timeout:       timeout,
-		FallbackDelay: -1,
-	}
-	c, err := dialer.Dial("tcp", p.hostport)
+	c, err := obsdialer.Dialer.DialContext(ctx, "tcp", p.hostport)
 	if err != nil {
 		return false, time.Since(start)
 	}


### PR DESCRIPTION
We had this disabled in one of our probes, but not all. Add a common dialer that disables the fallback and use it in each applicable prober. This avoids masking failures of IPv6 connectivity.

Also change to use contexts instead of timeout parameters consistently.

The shared dialer is in the new `obsdialer` package because putting it in `observer` results in import cycles.