### PR TITLE
akamai-purger: Check the correct pointer for manual mode configuration file

### DIFF
--- a/cmd/akamai-purger/main.go
+++ b/cmd/akamai-purger/main.go
@@ -257,7 +257,7 @@ func main() {
 	if os.Args[1] == "manual" {
 		manualMode = true
 		_ = manualFlags.Parse(os.Args[2:])
-		if *configFile == "" {
+		if *manualConfigFile == "" {
 			manualFlags.Usage()
 			os.Exit(1)
 		}


### PR DESCRIPTION
When running in manual mode, the `configFile` variable will take the zero value of `""` while `manualConfigFile` will be provided on the CLI by the operator. A startup check incorrectly dereferences `configFile`; but correctly determines that it is the zero value `""`, outputs the help text, and exits.

Fixes https://github.com/letsencrypt/boulder/issues/7176