### PR TITLE
issuance: Use RFC 7093 truncated SHA256 hash for Subject Key Identifier

### DIFF
--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -6,7 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -211,8 +211,16 @@ func generateSKID(pk crypto.PublicKey) ([]byte, error) {
 	if _, err := asn1.Unmarshal(pkBytes, &pkixPublicKey); err != nil {
 		return nil, err
 	}
-	skid := sha1.Sum(pkixPublicKey.BitString.Bytes)
-	return skid[:], nil
+
+	// RFC 7093 section 2. Additional Methods for Generating Key Identifiers
+	// 		[RFC5280] specifies two examples for generating key identifiers
+	//	    from public keys. Four additional mechanisms are as follows:
+	//
+	//	    1) The keyIdentifier is composed of the leftmost 160-bits of the SHA-256
+	//	       hash of the value of the BIT STRING subjectPublicKey (excluding the
+	//	       tag, length, and number of unused bits).
+	skid := sha256.Sum256(pkixPublicKey.BitString.Bytes)
+	return skid[0:20:20], nil
 }
 
 // IssuanceRequest describes a certificate issuance request

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -764,3 +764,13 @@ func TestMismatchedProfiles(t *testing.T) {
 	test.AssertError(t, err, "preparing final cert issuance")
 	test.AssertContains(t, err.Error(), "precert does not correspond to linted final cert")
 }
+
+func TestGenerateSKID(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "Error genering key")
+
+	skid, err := generateSKID(key.Public())
+	test.AssertNotError(t, err, "Error generating SKID")
+	test.AssertEquals(t, len(skid), 20)
+	test.AssertEquals(t, cap(skid), 20)
+}


### PR DESCRIPTION
[RFC 7093 section 2 sub 1](https://datatracker.ietf.org/doc/html/rfc7093#section-2) provides a methods for generating a truncated SHA256 sum for the Subject Key Identifier field in accordance with Baseline Requirement [section 7.1.2.11.4 Subject Key Identifier](https://github.com/cabforum/servercert/blob/90a98dc7c1131eaab01af411968aa7330d315b9b/docs/BR.md#712114-subject-key-identifier). 

>    [RFC5280] specifies two examples for generating key identifiers from
>    public keys.  Four additional mechanisms are as follows:
> 
>    1) The keyIdentifier is composed of the leftmost 160-bits of the
>       SHA-256 hash of the value of the BIT STRING subjectPublicKey
>       (excluding the tag, length, and number of unused bits).

The related [RFC 5280 section 4.2.1.2](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) states:
>   For CA certificates, subject key identifiers SHOULD be derived from
>   the public key or a method that generates unique values.  Two common
>   methods for generating key identifiers from the public key are:
>   ...
>   Other methods of generating unique numbers are also acceptable.