### PR TITLE
Rely on crypto/x509 to set AuthorityKeyID

### DIFF
--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -275,12 +275,13 @@ func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 		template.Subject.CommonName = req.CommonName
 	}
 	template.DNSNames = req.DNSNames
-	template.AuthorityKeyId = i.Cert.SubjectKeyId
+
 	skid, err := generateSKID(req.PublicKey)
 	if err != nil {
 		return nil, nil, err
 	}
 	template.SubjectKeyId = skid
+	
 	switch req.PublicKey.(type) {
 	case *rsa.PublicKey:
 		template.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -281,7 +281,7 @@ func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 		return nil, nil, err
 	}
 	template.SubjectKeyId = skid
-	
+
 	switch req.PublicKey.(type) {
 	case *rsa.PublicKey:
 		template.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment


### PR DESCRIPTION
The go crypto/x509 library correctly sets the AuthorityKeyID from the issuer's SubjectKeyID, overriding any value provided in the template:

https://pkg.go.dev/crypto/x509@go1.21.4#CreateCertificate:
> The AuthorityKeyId will be taken from the SubjectKeyId of parent, if any, unless the resulting certificate is self-signed. Otherwise the value from template will be used.

https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/crypto/x509/x509.go;l=1584-1587;drc=82c713feb05da594567631972082af2fcba0ee4f

We shouldn't attempt to second-guess this functionality by setting the AKID ourselves.