### PR TITLE
WFE: Implement CertID format as per draft-ietf-acme-ari-02

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2388,7 +2388,7 @@ func (c deprecatedCertID) Serial() string {
 func parseDeprecatedCertID(path string) (ariCertID, error) {
 	der, err := base64.RawURLEncoding.DecodeString(path)
 	if err != nil {
-		return deprecatedCertID{}, err
+		return nil, err
 	}
 
 	var id deprecatedCertID

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1,6 +1,7 @@
 package wfe2
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -73,7 +74,7 @@ const (
 	getCertPath      = getAPIPrefix + "cert/"
 
 	// Draft or likely-to-change paths
-	renewalInfoPath = "/draft-ietf-acme-ari-01/renewalInfo/"
+	renewalInfoPath = "/draft-ietf-acme-ari-02/renewalInfo/"
 
 	// Non-ACME paths
 	aiaIssuerPath = "/aia/issuer/"
@@ -2353,12 +2354,109 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(ctx context.Context, logEvent *web.Req
 	}
 }
 
-// certID matches the ASN.1 structure of the CertID sequence defined by RFC6960.
-type certID struct {
+// ariCertID is an interface that represents a unique identifier for a
+// certificate. It is implemented by both the deprecatedCertID and certID
+// structs.
+//
+// TODO(#7183): Remove this.
+type ariCertID interface {
+	Serial() string
+}
+
+// deprecatedCertID matches the ASN.1 structure of the CertID sequence defined
+// by RFC6960. Its fields are exported so that they can be unmarshaled using the
+// asn1 package.
+//
+// TODO(#7183): Remove this.
+type deprecatedCertID struct {
 	HashAlgorithm  pkix.AlgorithmIdentifier
 	IssuerNameHash []byte
 	IssuerKeyHash  []byte
 	SerialNumber   *big.Int
+}
+
+func (c deprecatedCertID) Serial() string {
+	return core.SerialToString(c.SerialNumber)
+}
+
+// newDeprecatedCertID parses a unique identifier (certID) for a certificate as
+// per the ACME protocol's "renewalInfo" resource, as specified in draft-ietf-
+// acme-ari-02. For more details see:
+// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-01#section-4.1.
+//
+// TODO(#7183): Remove this.
+func newDeprecatedCertID(path string) (ariCertID, error) {
+	der, err := base64.RawURLEncoding.DecodeString(path)
+	if err != nil {
+		return deprecatedCertID{}, err
+	}
+
+	var id deprecatedCertID
+	rest, err := asn1.Unmarshal(der, &id)
+	if err != nil || len(rest) != 0 {
+		return deprecatedCertID{}, err
+	}
+
+	// Verify that the hash algorithm is SHA-256, so people don't use SHA-1 here.
+	if !id.HashAlgorithm.Algorithm.Equal(asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}) {
+		// wfe.sendError(response, logEvent, probs.Malformed("Request used hash algorithm other than SHA-256"), err)
+		return deprecatedCertID{}, errors.New("Request used hash algorithm other than SHA-256")
+	}
+	return id, nil
+}
+
+// certID represents a unique identifier (certID) for a certificate as per the
+// ACME protocol's "renewalInfo" resource, as specified in draft-ietf-acme-ari-
+// 02. The certID is a composite string derived from the base64url-encoded
+// keyIdentifier of the certificate's Authority Key Identifier (AKI) and the
+// base64url-encoded serial number of the certificate, separated by a period.
+// For more details see:
+// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-02#section-4.1.
+type certID struct {
+	keyIdentifier []byte
+	serialNumber  *big.Int
+}
+
+func (c certID) Serial() string {
+	return core.SerialToString(c.serialNumber)
+}
+
+// newCertID parses a unique identifier (certID) as specified in
+// draft-ietf-acme-ari-02. It takes the composite string as input returns a
+// certID struct with the keyIdentifier and serialNumber extracted and decoded.
+// For more details see:
+// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-02#section-4.1.
+func newCertID(path string, issuerCertificates map[issuance.IssuerNameID]*issuance.Certificate) (ariCertID, *probs.ProblemDetails, error) {
+	parts := strings.Split(path, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return certID{}, probs.Malformed("Path was not a composite CertID"), nil
+	}
+
+	akid, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return certID{}, probs.Malformed("Path did not contain a base64url-encoded Authority Key Identifier"), err
+	}
+
+	var found bool
+	for _, issuer := range issuerCertificates {
+		if bytes.Equal(issuer.SubjectKeyId, akid) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return certID{}, probs.Malformed("Path contained an Authority Key Identifier that did not match a known issuer"), nil
+	}
+
+	serialNumber, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return certID{}, probs.Malformed("Path did not contain a base64url-encoded serial number"), err
+	}
+
+	return certID{
+		keyIdentifier: akid,
+		serialNumber:  new(big.Int).SetBytes(serialNumber),
+	}, nil, nil
 }
 
 // RenewalInfo is used to get information about the suggested renewal window
@@ -2379,35 +2477,26 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 		return
 	}
 
-	// The path prefix has already been stripped, so request.URL.Path here is just
-	// the base64url-encoded DER CertID sequence.
-	der, err := base64.RawURLEncoding.DecodeString(request.URL.Path)
+	// Try parsing certID param using the draft-ietf-acme-ari-01 format.
+	// TODO(#7183): Remove this.
+	certID, err := newDeprecatedCertID(request.URL.Path)
 	if err != nil {
-		wfe.sendError(response, logEvent, probs.Malformed("Path was not base64url-encoded or had padding"), err)
-		return
+		// Try parsing certID param using the draft-ietf-acme-ari-02 format.
+		var prob *probs.ProblemDetails
+		certID, prob, err = newCertID(request.URL.Path, wfe.issuerCertificates)
+		if prob != nil {
+			wfe.sendError(response, logEvent, prob, err)
+			return
+		}
 	}
-
-	var id certID
-	rest, err := asn1.Unmarshal(der, &id)
-	if err != nil || len(rest) != 0 {
-		wfe.sendError(response, logEvent, probs.Malformed("Path was not a DER-encoded CertID sequence"), err)
-		return
-	}
-
-	// Verify that the hash algorithm is SHA-256, so people don't use SHA-1 here.
-	if !id.HashAlgorithm.Algorithm.Equal(asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}) {
-		wfe.sendError(response, logEvent, probs.Malformed("Request used hash algorithm other than SHA-256"), err)
-		return
-	}
-
 	// We can do all of our processing based just on the serial, because Boulder
 	// does not re-use the same serial across multiple issuers.
-	serial := core.SerialToString(id.SerialNumber)
+	serial := certID.Serial()
 	logEvent.Extra["RequestedSerial"] = serial
 
 	sendRI := func(ri core.RenewalInfo) {
 		response.Header().Set(headerRetryAfter, fmt.Sprintf("%d", int(6*time.Hour/time.Second)))
-		err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, ri)
+		err := wfe.writeJsonResponse(response, logEvent, http.StatusOK, ri)
 		if err != nil {
 			wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling renewalInfo"), err)
 			return
@@ -2492,27 +2581,21 @@ func (wfe *WebFrontEndImpl) UpdateRenewal(ctx context.Context, logEvent *web.Req
 		return
 	}
 
-	der, err := base64.RawURLEncoding.DecodeString(updateRenewalRequest.CertID)
+	// Try parsing certID param using the draft-ietf-acme-ari-01 format.
+	// TODO(#7183): Remove this.
+	certID, err := newDeprecatedCertID(updateRenewalRequest.CertID)
 	if err != nil {
-		wfe.sendError(response, logEvent, probs.Malformed("certID was not base64url-encoded or contained padding"), err)
-		return
+		// Try parsing certID param using the draft-ietf-acme-ari-02 format.
+		var prob *probs.ProblemDetails
+		certID, prob, err = newCertID(updateRenewalRequest.CertID, wfe.issuerCertificates)
+		if prob != nil {
+			wfe.sendError(response, logEvent, prob, err)
+			return
+		}
 	}
-
-	var id certID
-	rest, err := asn1.Unmarshal(der, &id)
-	if err != nil || len(rest) != 0 {
-		wfe.sendError(response, logEvent, probs.Malformed("certID was not a DER-encoded CertID ASN.1 sequence"), err)
-		return
-	}
-
-	if !id.HashAlgorithm.Algorithm.Equal(asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}) {
-		wfe.sendError(response, logEvent, probs.Malformed("Decoded CertID used a hashAlgorithm other than SHA-256"), err)
-		return
-	}
-
 	// We can do all of our processing based just on the serial, because Boulder
 	// does not re-use the same serial across multiple issuers.
-	serial := core.SerialToString(id.SerialNumber)
+	serial := certID.Serial()
 	logEvent.Extra["RequestedSerial"] = serial
 
 	metadata, err := wfe.sa.GetSerialMetadata(ctx, &sapb.Serial{Serial: serial})

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3664,7 +3664,7 @@ func TestARI(t *testing.T) {
 	resp = httptest.NewRecorder()
 	wfe.RenewalInfo(context.Background(), event, resp, req)
 	test.AssertEquals(t, resp.Code, http.StatusBadRequest)
-	test.AssertContains(t, resp.Body.String(), "Path was not a composite CertID")
+	test.AssertContains(t, resp.Body.String(), "Invalid path")
 
 	// Ensure that a query with no path slug at all bails out early.
 	req, event = makeGet("", renewalInfoPath)

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3557,14 +3557,15 @@ func TestARI(t *testing.T) {
 	issuer, err := core.LoadCert("../test/hierarchy/int-r3.cert.pem")
 	test.AssertNotError(t, err, "failed to load test issuer")
 
-	// Take advantage of OCSP to build the issuer hashes.
+	// Take advantage of OCSP to build the issuer hashes used for
+	// draft-ietf-acme-ari01.
 	ocspReqBytes, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{Hash: crypto.SHA256})
 	test.AssertNotError(t, err, "failed to create ocsp request")
 	ocspReq, err := ocsp.ParseRequest(ocspReqBytes)
 	test.AssertNotError(t, err, "failed to parse ocsp request")
 
-	// Ensure that a correct query results in a 200.
-	idBytes, err := asn1.Marshal(certID{
+	// Ensure that a correct draft-ietf-acme-ari01 query results in a 200.
+	idBytes, err := asn1.Marshal(deprecatedCertID{
 		pkix.AlgorithmIdentifier{ // SHA256
 			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1},
 			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
@@ -3585,8 +3586,23 @@ func TestARI(t *testing.T) {
 	test.Assert(t, ri.SuggestedWindow.Start.After(cert.NotBefore), "suggested window begins before cert issuance")
 	test.Assert(t, ri.SuggestedWindow.End.Before(cert.NotAfter), "suggested window ends after cert expiry")
 
-	// Ensure that a correct query for a revoked cert results in a renewal window
-	// in the past.
+	// Ensure that a correct draft-ietf-acme-ari02 query results in a 200.
+	certID := fmt.Sprintf("%s.%s",
+		base64.RawURLEncoding.EncodeToString(cert.AuthorityKeyId),
+		base64.RawURLEncoding.EncodeToString(cert.SerialNumber.Bytes()),
+	)
+	req, event = makeGet(certID, renewalInfoPath)
+	resp = httptest.NewRecorder()
+	wfe.RenewalInfo(context.Background(), event, resp, req)
+	test.AssertEquals(t, resp.Code, http.StatusOK)
+	test.AssertEquals(t, resp.Header().Get("Retry-After"), "21600")
+	err = json.Unmarshal(resp.Body.Bytes(), &ri)
+	test.AssertNotError(t, err, "unmarshalling renewal info")
+	test.Assert(t, ri.SuggestedWindow.Start.After(cert.NotBefore), "suggested window begins before cert issuance")
+	test.Assert(t, ri.SuggestedWindow.End.Before(cert.NotAfter), "suggested window ends after cert expiry")
+
+	// Ensure that a correct draft-ietf-acme-ari01 query for a revoked cert
+	// results in a renewal window in the past.
 	msa.status = core.OCSPStatusRevoked
 	req, event = makeGet(base64.RawURLEncoding.EncodeToString(idBytes), renewalInfoPath)
 	resp = httptest.NewRecorder()
@@ -3598,8 +3614,22 @@ func TestARI(t *testing.T) {
 	test.Assert(t, ri.SuggestedWindow.End.Before(wfe.clk.Now()), "suggested window should end in the past")
 	test.Assert(t, ri.SuggestedWindow.Start.Before(ri.SuggestedWindow.End), "suggested window should start before it ends")
 
-	// Ensure that a query for a non-existent serial results in a 404.
-	idBytes, err = asn1.Marshal(certID{
+	// Ensure that a correct draft-ietf-acme-ari02 query for a revoked cert
+	// results in a renewal window in the past.
+	msa.status = core.OCSPStatusRevoked
+	req, event = makeGet(certID, renewalInfoPath)
+	resp = httptest.NewRecorder()
+	wfe.RenewalInfo(context.Background(), event, resp, req)
+	test.AssertEquals(t, resp.Code, http.StatusOK)
+	test.AssertEquals(t, resp.Header().Get("Retry-After"), "21600")
+	err = json.Unmarshal(resp.Body.Bytes(), &ri)
+	test.AssertNotError(t, err, "unmarshalling renewal info")
+	test.Assert(t, ri.SuggestedWindow.End.Before(wfe.clk.Now()), "suggested window should end in the past")
+	test.Assert(t, ri.SuggestedWindow.Start.Before(ri.SuggestedWindow.End), "suggested window should start before it ends")
+
+	// Ensure that a draft-ietf-acme-ari01 query for a non-existent serial
+	// results in a 404.
+	idBytes, err = asn1.Marshal(deprecatedCertID{
 		pkix.AlgorithmIdentifier{ // SHA256
 			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1},
 			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
@@ -3615,44 +3645,26 @@ func TestARI(t *testing.T) {
 	test.AssertEquals(t, resp.Code, http.StatusNotFound)
 	test.AssertEquals(t, resp.Header().Get("Retry-After"), "")
 
-	// Ensure that a query with a bad hash algorithm fails.
-	idBytes, err = asn1.Marshal(certID{
-		pkix.AlgorithmIdentifier{ // SHA-1
-			Algorithm:  asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26},
-			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
-		},
-		ocspReq.IssuerNameHash,
-		ocspReq.IssuerKeyHash,
-		big.NewInt(0).Add(cert.SerialNumber, big.NewInt(1)),
-	})
-	test.AssertNotError(t, err, "failed to marshal certID")
-	req, event = makeGet(base64.RawURLEncoding.EncodeToString(idBytes), renewalInfoPath)
+	// Ensure that a draft-ietf-acme-ari02 query for a non-existent serial
+	// results in a 404.
+	certID = fmt.Sprintf("%s.%s",
+		base64.RawURLEncoding.EncodeToString(cert.AuthorityKeyId),
+		base64.RawURLEncoding.EncodeToString(
+			big.NewInt(0).Add(cert.SerialNumber, big.NewInt(1)).Bytes(),
+		),
+	)
+	req, event = makeGet(certID, renewalInfoPath)
 	resp = httptest.NewRecorder()
 	wfe.RenewalInfo(context.Background(), event, resp, req)
-	test.AssertEquals(t, resp.Code, http.StatusBadRequest)
-	test.AssertContains(t, resp.Body.String(), "Request used hash algorithm other than SHA-256")
+	test.AssertEquals(t, resp.Code, http.StatusNotFound)
+	test.AssertEquals(t, resp.Header().Get("Retry-After"), "")
 
 	// Ensure that a query with a non-CertID path fails.
 	req, event = makeGet(base64.RawURLEncoding.EncodeToString(ocspReqBytes), renewalInfoPath)
 	resp = httptest.NewRecorder()
 	wfe.RenewalInfo(context.Background(), event, resp, req)
 	test.AssertEquals(t, resp.Code, http.StatusBadRequest)
-	test.AssertContains(t, resp.Body.String(), "Path was not a DER-encoded CertID sequence")
-
-	// Ensure that a query with a non-Base64URL path (including one in the old
-	// request path style, which included slashes) fails.
-	req, event = makeGet(
-		fmt.Sprintf(
-			"%s/%s/%s",
-			base64.RawURLEncoding.EncodeToString(ocspReq.IssuerNameHash),
-			base64.RawURLEncoding.EncodeToString(ocspReq.IssuerKeyHash),
-			base64.RawURLEncoding.EncodeToString(cert.SerialNumber.Bytes()),
-		),
-		renewalInfoPath)
-	resp = httptest.NewRecorder()
-	wfe.RenewalInfo(context.Background(), event, resp, req)
-	test.AssertEquals(t, resp.Code, http.StatusBadRequest)
-	test.AssertContains(t, resp.Body.String(), "Path was not base64url-encoded")
+	test.AssertContains(t, resp.Body.String(), "Path was not a composite CertID")
 
 	// Ensure that a query with no path slug at all bails out early.
 	req, event = makeGet("", renewalInfoPath)
@@ -3680,7 +3692,8 @@ func TestIncidentARI(t *testing.T) {
 			&web.RequestEvent{Endpoint: endpoint, Extra: map[string]interface{}{}}
 	}
 
-	idBytes, err := asn1.Marshal(certID{
+	// draft-ietf-acme-ari01
+	idBytes, err := asn1.Marshal(deprecatedCertID{
 		pkix.AlgorithmIdentifier{ // SHA256
 			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1},
 			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
@@ -3697,6 +3710,32 @@ func TestIncidentARI(t *testing.T) {
 	test.AssertEquals(t, resp.Code, 200)
 	test.AssertEquals(t, resp.Header().Get("Retry-After"), "21600")
 	var ri core.RenewalInfo
+	err = json.Unmarshal(resp.Body.Bytes(), &ri)
+	test.AssertNotError(t, err, "unmarshalling renewal info")
+	// The start of the window should be in the past.
+	test.AssertEquals(t, ri.SuggestedWindow.Start.Before(wfe.clk.Now()), true)
+	// The end of the window should be after the start.
+	test.AssertEquals(t, ri.SuggestedWindow.End.After(ri.SuggestedWindow.Start), true)
+	// The end of the window should also be in the past.
+	test.AssertEquals(t, ri.SuggestedWindow.End.Before(wfe.clk.Now()), true)
+
+	// draft-ietf-acme-ari02
+	test.AssertNotError(t, err, "failed to load test certificate")
+	var issuer issuance.IssuerNameID
+	for k := range wfe.issuerCertificates {
+		// Grab the first known issuer.
+		issuer = k
+		break
+	}
+	certID := fmt.Sprintf("%s.%s",
+		base64.RawURLEncoding.EncodeToString(wfe.issuerCertificates[issuer].SubjectKeyId),
+		base64.RawURLEncoding.EncodeToString(expectSerial.Bytes()),
+	)
+	req, event = makeGet(certID, renewalInfoPath)
+	resp = httptest.NewRecorder()
+	wfe.RenewalInfo(context.Background(), event, resp, req)
+	test.AssertEquals(t, resp.Code, 200)
+	test.AssertEquals(t, resp.Header().Get("Retry-After"), "21600")
 	err = json.Unmarshal(resp.Body.Bytes(), &ri)
 	test.AssertNotError(t, err, "unmarshalling renewal info")
 	// The start of the window should be in the past.
@@ -3771,8 +3810,9 @@ func TestUpdateARI(t *testing.T) {
 	wfe.UpdateRenewal(ctx, newRequestEvent(), responseWriter, req)
 	test.AssertEquals(t, responseWriter.Code, http.StatusBadRequest)
 
+	// draft-ietf-acme-ari01
 	// Non-sha256 hash algorithm should result in an error.
-	idBytes, err := asn1.Marshal(certID{
+	idBytes, err := asn1.Marshal(deprecatedCertID{
 		pkix.AlgorithmIdentifier{ // definitely not SHA256
 			Algorithm:  asn1.ObjectIdentifier{1, 2, 3, 4, 5},
 			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
@@ -3792,8 +3832,9 @@ func TestUpdateARI(t *testing.T) {
 	wfe.UpdateRenewal(ctx, newRequestEvent(), responseWriter, req)
 	test.AssertEquals(t, responseWriter.Code, http.StatusBadRequest)
 
+	// draft-ietf-acme-ari01
 	// Unrecognized serial should result in an error.
-	idBytes, err = asn1.Marshal(certID{
+	idBytes, err = asn1.Marshal(deprecatedCertID{
 		pkix.AlgorithmIdentifier{ // SHA256
 			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1},
 			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
@@ -3813,9 +3854,26 @@ func TestUpdateARI(t *testing.T) {
 	wfe.UpdateRenewal(ctx, newRequestEvent(), responseWriter, req)
 	test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
 
+	// draft-ietf-acme-ari02
+	// Unrecognized serial should result in an error.
+	certID := fmt.Sprintf("%s.%s",
+		base64.RawURLEncoding.EncodeToString(cert.AuthorityKeyId),
+		base64.RawURLEncoding.EncodeToString(big.NewInt(12345).Bytes()),
+	)
+	body, err = json.Marshal(jsonReq{
+		CertID:   certID,
+		Replaced: true,
+	})
+	test.AssertNotError(t, err, "failed to marshal request body")
+	req = makePost(1, string(body))
+	responseWriter = httptest.NewRecorder()
+	wfe.UpdateRenewal(ctx, newRequestEvent(), responseWriter, req)
+	test.AssertEquals(t, responseWriter.Code, http.StatusNotFound)
+
+	// draft-ietf-acme-ari01
 	// Recognized serial but owned by the wrong account should result in an error.
 	msa.regID = 2
-	idBytes, err = asn1.Marshal(certID{
+	idBytes, err = asn1.Marshal(deprecatedCertID{
 		pkix.AlgorithmIdentifier{ // SHA256
 			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1},
 			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
@@ -3835,9 +3893,27 @@ func TestUpdateARI(t *testing.T) {
 	wfe.UpdateRenewal(ctx, newRequestEvent(), responseWriter, req)
 	test.AssertEquals(t, responseWriter.Code, http.StatusForbidden)
 
+	// draft-ietf-acme-ari02
+	// Recognized serial but owned by the wrong account should result in an error.
+	msa.regID = 2
+	certID = fmt.Sprintf("%s.%s",
+		base64.RawURLEncoding.EncodeToString(cert.AuthorityKeyId),
+		base64.RawURLEncoding.EncodeToString(cert.SerialNumber.Bytes()),
+	)
+	body, err = json.Marshal(jsonReq{
+		CertID:   certID,
+		Replaced: true,
+	})
+	test.AssertNotError(t, err, "failed to marshal request body")
+	req = makePost(1, string(body))
+	responseWriter = httptest.NewRecorder()
+	wfe.UpdateRenewal(ctx, newRequestEvent(), responseWriter, req)
+	test.AssertEquals(t, responseWriter.Code, http.StatusForbidden)
+
+	// draft-ietf-acme-ari01
 	// Recognized serial and owned by the right account should work.
 	msa.regID = 1
-	idBytes, err = asn1.Marshal(certID{
+	idBytes, err = asn1.Marshal(deprecatedCertID{
 		pkix.AlgorithmIdentifier{ // SHA256
 			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1},
 			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
@@ -3849,6 +3925,23 @@ func TestUpdateARI(t *testing.T) {
 	test.AssertNotError(t, err, "failed to marshal certID")
 	body, err = json.Marshal(jsonReq{
 		CertID:   base64.RawURLEncoding.EncodeToString(idBytes),
+		Replaced: true,
+	})
+	test.AssertNotError(t, err, "failed to marshal request body")
+	req = makePost(1, string(body))
+	responseWriter = httptest.NewRecorder()
+	wfe.UpdateRenewal(ctx, newRequestEvent(), responseWriter, req)
+	test.AssertEquals(t, responseWriter.Code, http.StatusOK)
+
+	// draft-ietf-acme-ari02
+	// Recognized serial and owned by the right account should work.
+	msa.regID = 1
+	certID = fmt.Sprintf("%s.%s",
+		base64.RawURLEncoding.EncodeToString(cert.AuthorityKeyId),
+		base64.RawURLEncoding.EncodeToString(cert.SerialNumber.Bytes()),
+	)
+	body, err = json.Marshal(jsonReq{
+		CertID:   certID,
 		Replaced: true,
 	})
 	test.AssertNotError(t, err, "failed to marshal request body")


### PR DESCRIPTION
Add support for draft-ietf-acme-ari-02 format alongside the existing draft-ietf-acme-ari-01 implementation. Both formats are interchangeable.

Fixes #7037 