### PR TITLE
startserver: check for DNS before starting

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -3,6 +3,7 @@ import collections
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -183,6 +184,14 @@ def start(fakeclock):
     """
     signal.signal(signal.SIGTERM, lambda _, __: stop())
     signal.signal(signal.SIGINT, lambda _, __: stop())
+
+    # Check that we can resolve the service names before we try to start any
+    # services. This prevents a confusing error (timed out health check).
+    try:
+        socket.getaddrinfo('publisher1.service.consul', None)
+    except Exception as e:
+        print("Error querying DNS. Is consul running? `docker compose ps bconsul`. %s" % (e))
+        return False
 
     # Start the pebble-challtestsrv first so it can be used to resolve DNS for
     # gRPC.


### PR DESCRIPTION
The servers are invoked such that they have to look up their service names in DNS in order to bind a port. This means that when consul is down, they take a long time to start up- they are timing out the query.

In the meantime there are a number of messages about timed out health checks. This winds up obscuring the real error, so let's do a quick DNS check at startup and give a more meaningful error.