### PR TITLE
Invoke consul via /bin/consul

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
         ipv4_address: 10.77.77.10
       rednet:
         ipv4_address: 10.88.88.10
-    command: "consul agent -dev -config-format=hcl -config-file=/test/consul/config.hcl"
+    command: "/bin/consul agent -dev -config-format=hcl -config-file=/test/consul/config.hcl"
 
   bjaeger:
     image: jaegertracing/all-in-one:1.50


### PR DESCRIPTION
On my system, this fixes a problem where consul fails to start up because it gets permission denied accessing its TLS certificates. I have no idea why changing the invocation path would make a difference.