### PR TITLE
Truncate ocsp thisUpdate to the minute, not the hour

### DIFF
--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -127,7 +127,7 @@ func (oi *ocspImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequ
 		}
 	}
 
-	now := oi.clk.Now().Truncate(time.Hour)
+	now := oi.clk.Now().Truncate(time.Minute)
 	tbsResponse := ocsp.Response{
 		Status:       ocspStatusToCode[req.Status],
 		SerialNumber: serial,


### PR DESCRIPTION
Truncating to the hour does not provide any meaningful protection against signature preimage attacks, and can cause the thisUpdate and producedAt fields to differ by up to 59 minutes from each other. Instead, truncate to the minute, to match how x/crypto/ocsp sets the producedAt field.

Fixes https://github.com/letsencrypt/boulder/issues/7190