### PR TITLE
set permissions for generated certs and keys

### DIFF
--- a/test/grpc-creds/generate.sh
+++ b/test/grpc-creds/generate.sh
@@ -2,6 +2,8 @@
 set -e
 set -o xtrace
 
+cd "$(realpath -- $(dirname -- "$0"))"
+
 # Check that `minica` is installed
 command -v minica >/dev/null 2>&1 || {
   echo >&2 "No 'minica' command available.";
@@ -18,3 +20,6 @@ done
 for SERVICE in publisher nonce ra ca sa va rva ; do
   minica -domains "${SERVICE}.boulder,${SERVICE}1.boulder,${SERVICE}2.boulder"
 done
+
+# minica sets restrictive directory permissions, but we don't want that
+chmod -R go+rX .

--- a/test/redis-tls/generate.sh
+++ b/test/redis-tls/generate.sh
@@ -2,6 +2,8 @@
 set -e
 set -o xtrace
 
+cd "$(realpath -- $(dirname -- "$0"))"
+
 # Check that `minica` is installed
 command -v minica >/dev/null 2>&1 || {
   echo >&2 "No 'minica' command available.";
@@ -12,3 +14,6 @@ command -v minica >/dev/null 2>&1 || {
 minica -domains boulder
 minica -domains boulder-redis
 minica -domains redis -ip-addresses 10.33.33.2,10.33.33.3,10.33.33.4,10.33.33.5,10.33.33.6,10.33.33.7,10.33.33.8,10.33.33.9
+
+# minica sets restrictive directory permissions, but we don't want that
+chmod -R go+rX .


### PR DESCRIPTION
minica by default sets restrictive permissions on the directories it makes. This produced confusing behavior after regenerating keys: the `bconsul` container failed to start up because it couldn't access its TLS keys, which led to other errors during startservers.