### PR TITLE
Build boulder-tools locally for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,15 @@
 version: '3'
 services:
   boulder:
-    # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
-    image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-go1.21.5_2023-12-05}
+    # The `letsencrypt/boulder-tools:latest` tag is automatically built in local
+    # dev environments. In CI a specific BOULDER_TOOLS_TAG is passed, and it is
+    # pulled with `docker compose pull`.
+    image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-latest}
+    build:
+      context: test/boulder-tools/
+      # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
+      args:
+        GO_VERSION: 1.21.5
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -4,7 +4,7 @@ FROM buildpack-deps:focal-scm
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-ENV TARGETPLATFORM=$TARGETPLATFORM
+ENV TARGETPLATFORM=${TARGETPLATFORM:-$BUILDPLATFORM}
 ENV PATH /usr/local/go/bin:/usr/local/protoc/bin:$PATH
 
 COPY requirements.txt /tmp/requirements.txt

--- a/test/boulder-tools/install-go.sh
+++ b/test/boulder-tools/install-go.sh
@@ -1,7 +1,8 @@
-#!/bin/bash -ex
+#!/bin/bash
 #
 # Install a specific version of Go (provided by the $GO_VERSION variable)
 # and then install some dev dependencies using that version of Go.
+set -feuxo pipefail
 
 arch=$(echo $TARGETPLATFORM | sed 's|\/|-|')
 curl "https://dl.google.com/go/go${GO_VERSION}.${arch}.tar.gz" | tar -C /usr/local -xz
@@ -12,10 +13,11 @@ export GOBIN=/usr/local/bin GOCACHE=/tmp/gocache
 # Install protobuf and testing/dev tools.
 # Note: The version of golang/protobuf is partially tied to the version of grpc
 # used by Boulder overall. Updating it may require updating the grpc version
+
 # and vice versa.
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
-go install github.com/rubenv/sql-migrate/...@v1.1.2
+go install github.com/rubenv/sql-migrate/sql-migrate@v1.1.2
 go install golang.org/x/tools/cmd/stringer@latest
 go install github.com/letsencrypt/pebble/cmd/pebble-challtestsrv@master
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3


### PR DESCRIPTION
This solves a few problems:

 - When producing a new revision of boulder-tools, it often requires multiple iterations to get it right. This provides a straightforward path to build those iterations without trying to upload them to a Docker repository each time.
 - It's no longer necessary to produce dev container images in addition to CI container images. Dev images are built on-demand and cached.
 - Cross builds are no longer needed unless building the CI images on non-amd64.
 
For third-party integration tests that do `docker compose up`, this may result in longer build times if they are rebuilding from scratch each time. That can be improved by keeping docker cache around.