### PR TITLE
ratelimits: Fix test function prefixes

### DIFF
--- a/ratelimits/gcra_test.go
+++ b/ratelimits/gcra_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func Test_decide(t *testing.T) {
+func TestDecide(t *testing.T) {
 	clk := clock.NewFake()
 	limit := precomputeLimit(
 		limit{Burst: 10, Count: 1, Period: config.Duration{Duration: time.Second}},
@@ -133,7 +133,7 @@ func Test_decide(t *testing.T) {
 	test.AssertEquals(t, d.ResetIn, time.Second*5)
 }
 
-func Test_maybeRefund(t *testing.T) {
+func TestMaybeRefund(t *testing.T) {
 	clk := clock.NewFake()
 	limit := precomputeLimit(
 		limit{Burst: 10, Count: 1, Period: config.Duration{Duration: time.Second}},

--- a/ratelimits/limit_test.go
+++ b/ratelimits/limit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func Test_parseOverrideNameId(t *testing.T) {
+func TestParseOverrideNameId(t *testing.T) {
 	// 'enum:ipv4'
 	// Valid IPv4 address.
 	name, id, err := parseOverrideNameId(NewRegistrationsPerIPAddress.String() + ":10.0.0.1")
@@ -42,7 +42,7 @@ func Test_parseOverrideNameId(t *testing.T) {
 	test.AssertError(t, err, "invalid enum")
 }
 
-func Test_validateLimit(t *testing.T) {
+func TestValidateLimit(t *testing.T) {
 	err := validateLimit(limit{Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}})
 	test.AssertNotError(t, err, "valid limit")
 
@@ -57,7 +57,7 @@ func Test_validateLimit(t *testing.T) {
 	}
 }
 
-func Test_validateIdForName(t *testing.T) {
+func TestValidateIdForName(t *testing.T) {
 	// 'enum:ipAddress'
 	// Valid IPv4 address.
 	err := validateIdForName(NewRegistrationsPerIPAddress, "10.0.0.1")
@@ -134,7 +134,7 @@ func Test_validateIdForName(t *testing.T) {
 	test.AssertError(t, err, "valid regId with empty domain")
 }
 
-func Test_loadAndParseOverrideLimits(t *testing.T) {
+func TestLoadAndParseOverrideLimits(t *testing.T) {
 	// Load a single valid override limit with Id formatted as 'enum:RegId'.
 	l, err := loadAndParseOverrideLimits("testdata/working_override.yml")
 	test.AssertNotError(t, err, "valid single override limit")
@@ -226,7 +226,7 @@ func Test_loadAndParseOverrideLimits(t *testing.T) {
 	test.Assert(t, !os.IsNotExist(err), "test file should exist")
 }
 
-func Test_loadAndParseDefaultLimits(t *testing.T) {
+func TestLoadAndParseDefaultLimits(t *testing.T) {
 	// Load a single valid default limit.
 	l, err := loadAndParseDefaultLimits("testdata/working_default.yml")
 	test.AssertNotError(t, err, "valid single default limit")

--- a/ratelimits/limiter_test.go
+++ b/ratelimits/limiter_test.go
@@ -52,7 +52,7 @@ func setup(t *testing.T) (context.Context, map[string]*Limiter, *TransactionBuil
 	}, newTestTransactionBuilder(t), clk, randIP.String()
 }
 
-func Test_Limiter_CheckWithLimitOverrides(t *testing.T) {
+func TestLimiter_CheckWithLimitOverrides(t *testing.T) {
 	t.Parallel()
 	testCtx, limiters, txnBuilder, clk, testIP := setup(t)
 	for name, l := range limiters {
@@ -252,7 +252,7 @@ func Test_Limiter_CheckWithLimitOverrides(t *testing.T) {
 	}
 }
 
-func Test_Limiter_InitializationViaCheckAndSpend(t *testing.T) {
+func TestLimiter_InitializationViaCheckAndSpend(t *testing.T) {
 	t.Parallel()
 	testCtx, limiters, txnBuilder, _, testIP := setup(t)
 	for name, l := range limiters {
@@ -315,7 +315,7 @@ func Test_Limiter_InitializationViaCheckAndSpend(t *testing.T) {
 	}
 }
 
-func Test_Limiter_DefaultLimits(t *testing.T) {
+func TestLimiter_DefaultLimits(t *testing.T) {
 	t.Parallel()
 	testCtx, limiters, txnBuilder, clk, testIP := setup(t)
 	for name, l := range limiters {
@@ -378,7 +378,7 @@ func Test_Limiter_DefaultLimits(t *testing.T) {
 	}
 }
 
-func Test_Limiter_RefundAndReset(t *testing.T) {
+func TestLimiter_RefundAndReset(t *testing.T) {
 	t.Parallel()
 	testCtx, limiters, txnBuilder, clk, testIP := setup(t)
 	for name, l := range limiters {

--- a/ratelimits/source_redis_test.go
+++ b/ratelimits/source_redis_test.go
@@ -43,7 +43,7 @@ func newRedisTestLimiter(t *testing.T, clk clock.FakeClock) *Limiter {
 	}), clk)
 }
 
-func Test_RedisSource_Ping(t *testing.T) {
+func TestRedisSource_Ping(t *testing.T) {
 	clk := clock.NewFake()
 	workingSource := newTestRedisSource(clk, map[string]string{
 		"shard1": "10.33.33.4:4218",
@@ -70,7 +70,7 @@ func Test_RedisSource_Ping(t *testing.T) {
 	test.AssertError(t, err, "Ping should not error")
 }
 
-func Test_RedisSource_BatchSetAndGet(t *testing.T) {
+func TestRedisSource_BatchSetAndGet(t *testing.T) {
 	clk := clock.NewFake()
 	s := newTestRedisSource(clk, map[string]string{
 		"shard1": "10.33.33.4:4218",


### PR DESCRIPTION
Small fix to match the style of our other tests.