### PR TITLE
ratelimits: More compact overrides format

### DIFF
--- a/ratelimits/testdata/busted_override_burst_0.yml
+++ b/ratelimits/testdata/busted_override_burst_0.yml
@@ -1,4 +1,5 @@
-NewRegistrationsPerIPAddress:10.0.0.2:
-  burst: 0
-  count: 40
-  period: 1s
+- NewRegistrationsPerIPAddress:
+    burst: 0
+    count: 40
+    period: 1s
+    ids: [10.0.0.2]

--- a/ratelimits/testdata/busted_override_burst_0_deprecated.yml
+++ b/ratelimits/testdata/busted_override_burst_0_deprecated.yml
@@ -1,0 +1,4 @@
+NewRegistrationsPerIPAddress:10.0.0.2:
+  burst: 0
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/busted_override_empty_id.yml
+++ b/ratelimits/testdata/busted_override_empty_id.yml
@@ -1,4 +1,5 @@
-"UsageRequestsPerIPv10Address:":
-  burst: 40
-  count: 40
-  period: 1s
+- UsageRequestsPerIPv10Address:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: []

--- a/ratelimits/testdata/busted_override_empty_id_deprecated.yml
+++ b/ratelimits/testdata/busted_override_empty_id_deprecated.yml
@@ -1,0 +1,4 @@
+"UsageRequestsPerIPv10Address:":
+  burst: 40
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/busted_override_empty_name.yml
+++ b/ratelimits/testdata/busted_override_empty_name.yml
@@ -1,4 +1,5 @@
-":10.0.0.2":
-  burst: 40
-  count: 40
-  period: 1s
+- "":
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [10.0.0.2]

--- a/ratelimits/testdata/busted_override_empty_name_deprecated.yml
+++ b/ratelimits/testdata/busted_override_empty_name_deprecated.yml
@@ -1,0 +1,4 @@
+":10.0.0.2":
+  burst: 40
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/busted_override_invalid_name.yml
+++ b/ratelimits/testdata/busted_override_invalid_name.yml
@@ -1,4 +1,5 @@
-UsageRequestsPerIPv10Address:10.0.0.2:
-  burst: 40
-  count: 40
-  period: 1s
+- UsageRequestsPerIPv10Address:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [10.0.0.2]

--- a/ratelimits/testdata/busted_override_invalid_name_deprecated.yml
+++ b/ratelimits/testdata/busted_override_invalid_name_deprecated.yml
@@ -1,0 +1,4 @@
+UsageRequestsPerIPv10Address:10.0.0.2:
+  burst: 40
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/busted_overrides_second_entry_bad_name.yml
+++ b/ratelimits/testdata/busted_overrides_second_entry_bad_name.yml
@@ -1,8 +1,10 @@
-NewRegistrationsPerIPAddress:10.0.0.2:
-  burst: 40
-  count: 40
-  period: 1s
-UsageRequestsPerIPv10Address:10.0.0.5:
-  burst: 40
-  count: 40
-  period: 1s
+- NewRegistrationsPerIPAddress:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [10.0.0.2]
+- UsageRequestsPerIPv10Address:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [10.0.0.5]

--- a/ratelimits/testdata/busted_overrides_second_entry_bad_name_deprecated.yml
+++ b/ratelimits/testdata/busted_overrides_second_entry_bad_name_deprecated.yml
@@ -1,0 +1,8 @@
+NewRegistrationsPerIPAddress:10.0.0.2:
+  burst: 40
+  count: 40
+  period: 1s
+UsageRequestsPerIPv10Address:10.0.0.5:
+  burst: 40
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/busted_overrides_third_entry_bad_id.yml
+++ b/ratelimits/testdata/busted_overrides_third_entry_bad_id.yml
@@ -1,12 +1,5 @@
-NewRegistrationsPerIPAddress:10.0.0.2:
-  burst: 40
-  count: 40
-  period: 1s
-NewRegistrationsPerIPAddress:10.0.0.5:
-  burst: 40
-  count: 40
-  period: 1s
-NewRegistrationsPerIPAddress:lol:
-  burst: 40
-  count: 40
-  period: 1s
+- NewRegistrationsPerIPAddress:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [10.0.0.5, 10.0.0.2, lol]

--- a/ratelimits/testdata/busted_overrides_third_entry_bad_id_deprecated.yml
+++ b/ratelimits/testdata/busted_overrides_third_entry_bad_id_deprecated.yml
@@ -1,0 +1,12 @@
+NewRegistrationsPerIPAddress:10.0.0.2:
+  burst: 40
+  count: 40
+  period: 1s
+NewRegistrationsPerIPAddress:10.0.0.5:
+  burst: 40
+  count: 40
+  period: 1s
+NewRegistrationsPerIPAddress:lol:
+  burst: 40
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/working_override.yml
+++ b/ratelimits/testdata/working_override.yml
@@ -1,4 +1,5 @@
-NewRegistrationsPerIPAddress:10.0.0.2:
-  burst: 40
-  count: 40
-  period: 1s
+- NewRegistrationsPerIPAddress:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [10.0.0.2]

--- a/ratelimits/testdata/working_override_deprecated.yml
+++ b/ratelimits/testdata/working_override_deprecated.yml
@@ -1,0 +1,4 @@
+NewRegistrationsPerIPAddress:10.0.0.2:
+  burst: 40
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/working_override_regid_domain.yml
+++ b/ratelimits/testdata/working_override_regid_domain.yml
@@ -1,4 +1,5 @@
-CertificatesPerDomain:example.com:
-  burst: 40
-  count: 40
-  period: 1s
+- CertificatesPerDomain:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [example.com]

--- a/ratelimits/testdata/working_override_regid_domain_deprecated.yml
+++ b/ratelimits/testdata/working_override_regid_domain_deprecated.yml
@@ -1,0 +1,4 @@
+CertificatesPerDomain:example.com:
+  burst: 40
+  count: 40
+  period: 1s

--- a/ratelimits/testdata/working_overrides.yml
+++ b/ratelimits/testdata/working_overrides.yml
@@ -1,8 +1,10 @@
-NewRegistrationsPerIPAddress:10.0.0.2:
-  burst: 40
-  count: 40
-  period: 1s
-NewRegistrationsPerIPv6Range:2001:0db8:0000::/48:
-  burst: 50
-  count: 50
-  period: 2s
+- NewRegistrationsPerIPAddress:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [10.0.0.2]
+- NewRegistrationsPerIPv6Range:
+    burst: 50
+    count: 50
+    period: 2s
+    ids: [2001:0db8:0000::/48]

--- a/ratelimits/testdata/working_overrides_deprecated.yml
+++ b/ratelimits/testdata/working_overrides_deprecated.yml
@@ -1,0 +1,8 @@
+NewRegistrationsPerIPAddress:10.0.0.2:
+  burst: 40
+  count: 40
+  period: 1s
+NewRegistrationsPerIPv6Range:2001:0db8:0000::/48:
+  burst: 50
+  count: 50
+  period: 2s

--- a/ratelimits/testdata/working_overrides_regid_fqdnset.yml
+++ b/ratelimits/testdata/working_overrides_regid_fqdnset.yml
@@ -1,12 +1,15 @@
-CertificatesPerFQDNSet:example.com:
-  burst: 40
-  count: 40
-  period: 1s
-CertificatesPerFQDNSet:example.com,example.net:
-  burst: 50
-  count: 50
-  period: 2s
-CertificatesPerFQDNSet:example.com,example.net,example.org:
-  burst: 60
-  count: 60
-  period: 3s
+- CertificatesPerFQDNSet:
+    burst: 40
+    count: 40
+    period: 1s
+    ids: [example.com]
+- CertificatesPerFQDNSet:
+    burst: 50
+    count: 50
+    period: 2s
+    ids: ["example.com,example.net"]
+- CertificatesPerFQDNSet:
+    burst: 60
+    count: 60
+    period: 3s
+    ids: ["example.com,example.net,example.org"]

--- a/ratelimits/testdata/working_overrides_regid_fqdnset_deprecated.yml
+++ b/ratelimits/testdata/working_overrides_regid_fqdnset_deprecated.yml
@@ -1,0 +1,12 @@
+CertificatesPerFQDNSet:example.com:
+  burst: 40
+  count: 40
+  period: 1s
+CertificatesPerFQDNSet:example.com,example.net:
+  burst: 50
+  count: 50
+  period: 2s
+CertificatesPerFQDNSet:example.com,example.net,example.org:
+  burst: 60
+  count: 60
+  period: 3s

--- a/test/config-next/wfe2-ratelimit-overrides.yml
+++ b/test/config-next/wfe2-ratelimit-overrides.yml
@@ -1,1 +1,5 @@
-NewRegistrationsPerIPAddress:127.0.0.1: { burst: 1000000, count: 1000000, period: 168h }
+- NewRegistrationsPerIPAddress:
+    burst: 1000000
+    count: 1000000
+    period: 168h
+    ids: [127.0.0.1]


### PR DESCRIPTION
Support a more compact format for supplying overrides to default rate limits.



Fixes #7197