### PR TITLE
Remove deprecated and unused feature flags

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -17,12 +17,7 @@ import (
 type Config struct {
 	// Deprecated features. Safe for removal once all references to them have
 	// been removed from deployed configuration.
-	StoreRevokerInfo                               bool
-	ROCSPStage6                                    bool
-	ROCSPStage7                                    bool
 	StoreLintingCertificateInsteadOfPrecertificate bool
-	CAAValidationMethods                           bool
-	CAAAccountURI                                  bool
 	LeaseCRLShards                                 bool
 	AllowUnrecognizedFeatures                      bool
 

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -102,7 +102,6 @@
 			}
 		},
 		"features": {
-			"StoreRevokerInfo": true,
 			"AsyncFinalize": true,
 			"AllowNoCommonName": true
 		},

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -46,9 +46,7 @@
 			}
 		},
 		"healthCheckInterval": "4s",
-		"features": {
-			"StoreRevokerInfo": true
-		}
+		"features": {}
 	},
 	"syslog": {
 		"stdoutlevel": 6,

--- a/test/config/ca-a.json
+++ b/test/config/ca-a.json
@@ -106,9 +106,7 @@
 		"ocspLogMaxLength": 4000,
 		"ocspLogPeriod": "500ms",
 		"ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
-		"features": {
-			"ROCSPStage7": true
-		}
+		"features": {}
 	},
 	"pa": {
 		"challenges": {

--- a/test/config/ca-b.json
+++ b/test/config/ca-b.json
@@ -106,9 +106,7 @@
 		"ocspLogMaxLength": 4000,
 		"ocspLogPeriod": "500ms",
 		"ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
-		"features": {
-			"ROCSPStage7": true
-		}
+		"features": {}
 	},
 	"pa": {
 		"challenges": {

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -72,10 +72,7 @@
 				}
 			}
 		},
-		"features": {
-			"StoreRevokerInfo": true,
-			"ROCSPStage7": true
-		},
+		"features": {},
 		"ctLogs": {
 			"stagger": "500ms",
 			"logListFile": "test/ct-test-srv/log_list.json",

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -45,10 +45,7 @@
 				}
 			}
 		},
-		"features": {
-			"StoreRevokerInfo": true,
-			"ROCSPStage6": true
-		}
+		"features": {}
 	},
 	"syslog": {
 		"stdoutlevel": 6,


### PR DESCRIPTION
These feature flags are no longer referenced in any test, staging, or production configuration. They were removed in:
- StoreRevokerInfo: IN-8546
- ROCSPStage6 and ROCSPStage7: IN-8886
- CAAValidationMethods and CAAAccountURI: IN-9301