### PR TITLE
Reduce logging from inflight validation collisions

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -784,7 +784,7 @@ func (ssa *SQLStorageAuthority) FinalizeAuthorization2(ctx context.Context, req 
 		return nil, err
 	}
 	if rows == 0 {
-		return nil, berrors.NotFoundError("authorization with id %d not found", req.Id)
+		return nil, berrors.NotFoundError("no pending authorization with id %d", req.Id)
 	} else if rows > 1 {
 		return nil, berrors.InternalServerError("multiple rows updated for authorization id %d", req.Id)
 	}


### PR DESCRIPTION
If a client attempts to validate a challenge twice in rapid succession, we'll kick off two background validation routines. One of these will complete first, updating the database with success or failure. The other will fail when it attempts to update the database and finds that there are no longer any authorizations with that ID in the "pending" state. Reduce the level at which we log such events, since we don't particularly care about them.

Fixes https://github.com/letsencrypt/boulder/issues/3995