### PR TITLE
Allow ICANN TLDs as registration email domains

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -281,15 +281,6 @@ func ValidDomain(domain string) error {
 		}
 	}
 
-	// Names must end in an ICANN TLD, but they must not be equal to an ICANN TLD.
-	icannTLD, err := iana.ExtractSuffix(domain)
-	if err != nil {
-		return errNonPublic
-	}
-	if icannTLD == domain {
-		return errICANNTLD
-	}
-
 	return nil
 }
 
@@ -324,6 +315,13 @@ func ValidEmail(address string) error {
 			"contact email %q has invalid domain : %s",
 			email.Address, err)
 	}
+
+	// Names must end in an ICANN TLD, but they can be equal to an ICANN TLD.
+	icannTLD, err := iana.ExtractSuffix(domain)
+	if err != nil {
+		return errNonPublic
+	}
+	
 	if forbiddenMailDomains[domain] {
 		return berrors.InvalidEmailError(
 			"invalid contact domain. Contact emails @%s are forbidden",
@@ -361,6 +359,15 @@ func (pa *AuthorityImpl) willingToIssue(id identifier.ACMEIdentifier) error {
 	err := ValidDomain(domain)
 	if err != nil {
 		return err
+	}
+
+	// Names must end in an ICANN TLD, but they must not be equal to an ICANN TLD.
+	icannTLD, err := iana.ExtractSuffix(domain)
+	if err != nil {
+		return errNonPublic
+	}
+	if icannTLD == domain {
+		return errICANNTLD
 	}
 
 	// Require no match against hostname block lists

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -317,11 +317,11 @@ func ValidEmail(address string) error {
 	}
 
 	// Names must end in an ICANN TLD, but they can be equal to an ICANN TLD.
-	icannTLD, err := iana.ExtractSuffix(domain)
+	_, err = iana.ExtractSuffix(domain)
 	if err != nil {
 		return errNonPublic
 	}
-	
+
 	if forbiddenMailDomains[domain] {
 		return berrors.InvalidEmailError(
 			"invalid contact domain. Contact emails @%s are forbidden",

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -319,7 +319,9 @@ func ValidEmail(address string) error {
 	// Names must end in an ICANN TLD, but they can be equal to an ICANN TLD.
 	_, err = iana.ExtractSuffix(domain)
 	if err != nil {
-		return errNonPublic
+		return berrors.InvalidEmailError(
+			"contact email %q has invalid domain : Domain name does not end with a valid public suffix (TLD)",
+			email.Address)
 	}
 
 	if forbiddenMailDomains[domain] {


### PR DESCRIPTION
We currently use the same logic to ensure that domain names are valid for certificate issuance and are valid for being the domain component of a subscriber's contact email address. However, we do not need to be as strict for email addresses: namely, it is possible for a subscriber to have an email whose domain component is exactly an ICANN TLD, while it is forbidden for us to issue a certificate to a name that is exactly an ICANN TLD.

Move the TLD logic out of ValidDomain and into its two callers: willingToIssue and ValidEmail. Slightly modify the logic in ValidEmail to not reject ICANN TLDs.

Fixes https://github.com/letsencrypt/boulder/issues/5372
Fixes https://github.com/letsencrypt/boulder/issues/4736