### PR TITLE
Prevent serial prefixes from beginning with a 1

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -46,7 +46,7 @@ type Config struct {
 		Backdate config.Duration
 
 		// What digits we should prepend to serials after randomly generating them.
-		SerialPrefix int `validate:"required,min=1,max=255"`
+		SerialPrefix int `validate:"required,min=1,max=127"`
 
 		// The maximum number of subjectAltNames in a single certificate
 		MaxNames int `validate:"required,min=1,max=100"`


### PR DESCRIPTION
Change the max value of the CA's `SerialPrefix` config value from 255 (a byte of all 1s) to 127 (a byte of one 0 followed by seven 1s). This prevents the serial prefix from ever beginning with a 1. This is important because serials are interpreted as signed (twos-complement) integers, and are required to be positive -- a serial whose first bit is 1 is considered to be negative and therefore in violation of RFC 5280. The go stdlib fixes this for us by prepending a zero byte to any serial that begins with a 1 bit, but we'd prefer all our serials to be the same length. Restricting the prefix to be maximum 127 means we'll never accidentally use a prefix which begins with a 1.