### PR TITLE
dns: add ForceAttemptHTTP2

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -198,7 +198,8 @@ func New(
 			hc: http.Client{
 				Timeout: readTimeout,
 				Transport: &http.Transport{
-					TLSClientConfig: tlsConfig,
+					ForceAttemptHTTP2: true,
+					TLSClientConfig:   tlsConfig.Clone(),
 				},
 			},
 		}


### PR DESCRIPTION
Per https://pkg.go.dev/net/http#hdr-HTTP_2:

> The http package's Transport and Server both automatically enable HTTP/2 support for simple configurations.

and https://pkg.go.dev/net/http#Transport:

> // If non-nil, HTTP/2 support may not be enabled by default.
>	TLSClientConfig *tls.Config

Since we were setting a non-default TLSClientConfig to trust custom roots, we accidentally turned off HTTP/2 support. And Unbound requires HTTP/2 to serve DoH queries.

Also, clone the TLS config just to be safe against possible mutation in other packages.