### PR TITLE
PA: Improve wildcard exact blocklist implementation

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/goodkey/sagoodkey"
-	"github.com/letsencrypt/boulder/identifier"
 	_ "github.com/letsencrypt/boulder/linter"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/policy"
@@ -408,8 +407,7 @@ func (c *certChecker) checkCert(ctx context.Context, cert core.Certificate, igno
 		// We do not check the CommonName here, as (if it exists) we already checked
 		// that it is identical to one of the DNSNames in the SAN.
 		for _, name := range parsedCert.DNSNames {
-			id := identifier.ACMEIdentifier{Type: identifier.DNS, Value: name}
-			err = c.pa.WillingToIssueWildcards([]identifier.ACMEIdentifier{id})
+			err = c.pa.WillingToIssue([]string{name})
 			if err != nil {
 				problems = append(problems, fmt.Sprintf("Policy Authority isn't willing to issue for '%s': %s", name, err))
 			} else {

--- a/cmd/reversed-hostname-checker/main.go
+++ b/cmd/reversed-hostname-checker/main.go
@@ -12,7 +12,6 @@ import (
 	"os"
 
 	"github.com/letsencrypt/boulder/cmd"
-	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
 )
@@ -51,7 +50,7 @@ func main() {
 	var errors bool
 	for scanner.Scan() {
 		n := sa.ReverseName(scanner.Text())
-		err := pa.WillingToIssueWildcards([]identifier.ACMEIdentifier{identifier.DNSIdentifier(n)})
+		err := pa.WillingToIssue([]string{n})
 		if err != nil {
 			errors = true
 			fmt.Printf("%s: %s\n", n, err)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -7,7 +7,7 @@ import (
 // PolicyAuthority defines the public interface for the Boulder PA
 // TODO(#5891): Move this interface to a more appropriate location.
 type PolicyAuthority interface {
-	WillingToIssueWildcards([]identifier.ACMEIdentifier) error
+	WillingToIssue([]string) error
 	ChallengesFor(identifier.ACMEIdentifier) ([]Challenge, error)
 	ChallengeTypeEnabled(AcmeChallenge) bool
 	CheckAuthz(*Authorization) error

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -11,7 +11,6 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
-	"github.com/letsencrypt/boulder/identifier"
 )
 
 // maxCNLength is the maximum length allowed for the common name as specified in RFC 5280
@@ -85,11 +84,7 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 		return berrors.BadCSRError("CSR contains more than %d DNS names", maxNames)
 	}
 
-	idents := make([]identifier.ACMEIdentifier, len(names.SANs))
-	for i, name := range names.SANs {
-		idents[i] = identifier.DNSIdentifier(name)
-	}
-	err = pa.WillingToIssueWildcards(idents)
+	err = pa.WillingToIssue(names.SANs)
 	if err != nil {
 		return err
 	}

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -32,9 +32,9 @@ func (pa *mockPA) ChallengesFor(identifier identifier.ACMEIdentifier) (challenge
 	return
 }
 
-func (pa *mockPA) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
-	for _, ident := range idents {
-		if ident.Value == "bad-name.com" || ident.Value == "other-bad-name.com" {
+func (pa *mockPA) WillingToIssue(domains []string) error {
+	for _, domain := range domains {
+		if domain == "bad-name.com" || domain == "other-bad-name.com" {
 			return errors.New("policy forbids issuing for identifier")
 		}
 	}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -170,7 +170,6 @@ func isDNSCharacter(ch byte) bool {
 // If these values change, the related error messages should be updated.
 
 var (
-	errInvalidIdentifier    = berrors.MalformedError("Invalid identifier type")
 	errNonPublic            = berrors.MalformedError("Domain name does not end with a valid public suffix (TLD)")
 	errICANNTLD             = berrors.MalformedError("Domain name is an ICANN TLD")
 	errPolicyForbidden      = berrors.RejectedIdentifierError("The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy")
@@ -192,19 +191,18 @@ var (
 )
 
 // ValidDomain checks that a domain isn't:
+//   - empty
+//   - prefixed with the wildcard label `*.`
+//   - made of invalid DNS characters
+//   - longer than the maxDNSIdentifierLength
+//   - an IPv4 or IPv6 address
+//   - suffixed with just "."
+//   - made of too many DNS labels
+//   - made of any invalid DNS labels
+//   - suffixed with something other than an IANA registered TLD
+//   - exactly equal to an IANA registered TLD
 //
-// * empty
-// * prefixed with the wildcard label `*.`
-// * made of invalid DNS characters
-// * longer than the maxDNSIdentifierLength
-// * an IPv4 or IPv6 address
-// * suffixed with just "."
-// * made of too many DNS labels
-// * made of any invalid DNS labels
-// * suffixed with something other than an IANA registered TLD
-// * exactly equal to an IANA registered TLD
-//
-// It does _not_ check that the domain isn't on any PA blocked lists.
+// It does NOT ensure that the domain is absent from any PA blocked lists.
 func ValidDomain(domain string) error {
 	if domain == "" {
 		return errEmptyName
@@ -293,6 +291,48 @@ func ValidDomain(domain string) error {
 	return nil
 }
 
+// ValidWildcardDomain is like ValidDomain but it supports properly formatted
+// wildcard domains. It checks that a domain isn't:
+//   - empty
+//   - made of invalid DNS characters
+//   - longer than the maxDNSIdentifierLength
+//   - an IPv4 or IPv6 address
+//   - suffixed with just "."
+//   - made of too many DNS labels
+//   - made of any invalid DNS labels
+//   - suffixed with something other than an IANA registered TLD
+//   - exactly equal to an IANA registered TLD
+//
+// It does NOT ensure that the domain is absent from any PA blocked lists.
+func ValidWildcardDomain(domain string) error {
+	// Names containing more than one wildcard are invalid.
+	if strings.Count(domain, "*") > 1 {
+		return errTooManyWildcards
+	}
+
+	// If the domain has a wildcard character, but it isn't the first most
+	// label of the domain name then the wildcard domain is malformed
+	if !strings.HasPrefix(domain, "*.") {
+		return errMalformedWildcard
+	}
+
+	// The base domain is the wildcard request with the `*.` prefix removed
+	baseDomain := strings.TrimPrefix(domain, "*.")
+
+	// Names must end in an ICANN TLD, but they must not be equal to an ICANN TLD.
+	icannTLD, err := iana.ExtractSuffix(baseDomain)
+	if err != nil {
+		return errNonPublic
+	}
+	// Names must have a non-wildcard label immediately adjacent to the ICANN
+	// TLD. No `*.com`!
+	if baseDomain == icannTLD {
+		return errICANNTLDWildcard
+	}
+
+	return ValidDomain(baseDomain)
+}
+
 // forbiddenMailDomains is a map of domain names we do not allow after the
 // @ symbol in contact mailto addresses. These are frequently used when
 // copy-pasting example configurations and would not result in expiration
@@ -332,12 +372,11 @@ func ValidEmail(address string) error {
 	return nil
 }
 
-// willingToIssue determines whether the CA is willing to issue for the provided
-// identifier. It expects domains in id to be lowercase to prevent mismatched
-// cases breaking queries. It is a helper method for WillingToIssueWildcards.
+// WillingToIssue determines whether the CA is willing to issue for the provided
+// domains. It expects each domain to be lowercase to prevent mismatched cases
+// breaking queries.
 //
-// We place several criteria on identifiers we are willing to issue for:
-//   - MUST self-identify as DNS identifiers
+// We place several criteria on domains we are willing to issue for:
 //   - MUST contain only bytes in the DNS hostname character set
 //   - MUST NOT have more than maxLabels labels
 //   - MUST follow the DNS hostname syntax rules in RFC 1035 and RFC 2181
@@ -350,36 +389,11 @@ func ValidEmail(address string) error {
 //   - MUST NOT be a label-wise suffix match for a name on the block list,
 //     where comparison is case-independent (normalized to lower case)
 //
-// If willingToIssue returns an error, it will be of type MalformedRequestError
+// If this function returns an error, it will be of type MalformedRequestError
 // or RejectedIdentifierError
-func (pa *AuthorityImpl) willingToIssue(id identifier.ACMEIdentifier) error {
-	if id.Type != identifier.DNS {
-		return errInvalidIdentifier
-	}
-	domain := id.Value
-
-	err := ValidDomain(domain)
-	if err != nil {
-		return err
-	}
-
-	// Require no match against hostname block lists
-	err = pa.checkHostLists(domain)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// WillingToIssueWildcards is an extension of WillingToIssue that accepts DNS
-// identifiers for well formed wildcard domains in addition to regular
-// identifiers.
 //
-// All provided identifiers are run through WillingToIssue and any errors are
-// returned. In addition to the regular WillingToIssue checks this function
-// also checks each wildcard identifier to enforce that:
-//   - The identifier is a DNS type identifier
+// In addition to the aformention checks this function also checks each wildcard
+// domain to enforce that:
 //   - There is at most one `*` wildcard character
 //   - That the wildcard character is the leftmost label
 //   - That the wildcard label is not immediately adjacent to a top level ICANN
@@ -388,26 +402,59 @@ func (pa *AuthorityImpl) willingToIssue(id identifier.ACMEIdentifier) error {
 //     blocklist entry for "foo.example.com" should prevent issuance for
 //     "*.example.com")
 //
-// If any of the identifiers are not valid then an error with suberrors specific
-// to the rejected identifiers will be returned.
-func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentifier) error {
+// If any of the domains are not valid then an error with suberrors specific
+// to the rejected domains will be returned.
+func (pa *AuthorityImpl) WillingToIssue(domains []string) error {
 	var subErrors []berrors.SubBoulderError
-	for _, ident := range idents {
-		err := pa.willingToIssueWildcard(ident)
-		if err != nil {
-			var bErr *berrors.BoulderError
-			if errors.As(err, &bErr) {
-				subErrors = append(subErrors, berrors.SubBoulderError{
-					Identifier:   ident,
-					BoulderError: bErr})
-			} else {
-				subErrors = append(subErrors, berrors.SubBoulderError{
-					Identifier: ident,
-					BoulderError: &berrors.BoulderError{
-						Type:   berrors.RejectedIdentifier,
-						Detail: err.Error(),
-					}})
+	appendSubError := func(name string, err error) {
+		var bErr *berrors.BoulderError
+		if errors.As(err, &bErr) {
+			subErrors = append(subErrors, berrors.SubBoulderError{
+				Identifier:   identifier.DNSIdentifier(name),
+				BoulderError: bErr,
+			})
+		} else {
+			subErrors = append(subErrors, berrors.SubBoulderError{
+				Identifier: identifier.DNSIdentifier(name),
+				BoulderError: &berrors.BoulderError{
+					Type:   berrors.RejectedIdentifier,
+					Detail: err.Error(),
+				},
+			})
+		}
+	}
+
+	for _, domain := range domains {
+		if strings.Count(domain, "*") > 0 {
+			// Domain contains a wildcard, check that it is valid.
+			err := ValidWildcardDomain(domain)
+			if err != nil {
+				appendSubError(domain, err)
+				continue
 			}
+
+			// The base domain is the wildcard request with the `*.` prefix removed
+			baseDomain := strings.TrimPrefix(domain, "*.")
+
+			// The base domain can't be in the wildcard exact blocklist
+			err = pa.checkWildcardHostList(baseDomain)
+			if err != nil {
+				appendSubError(domain, err)
+				continue
+			}
+		} else {
+			// Validate that the domain is well-formed.
+			err := ValidDomain(domain)
+			if err != nil {
+				appendSubError(domain, err)
+				continue
+			}
+		}
+		// Require no exact match against hostname block lists
+		err := pa.checkHostLists(domain)
+		if err != nil {
+			appendSubError(domain, err)
+			continue
 		}
 	}
 	if len(subErrors) > 0 {
@@ -433,64 +480,6 @@ func (pa *AuthorityImpl) WillingToIssueWildcards(idents []identifier.ACMEIdentif
 		}).WithSubErrors(subErrors)
 	}
 	return nil
-}
-
-// willingToIssueWildcard vets a single identifier. It is used by
-// the plural WillingToIssueWildcards when evaluating a list of identifiers.
-func (pa *AuthorityImpl) willingToIssueWildcard(ident identifier.ACMEIdentifier) error {
-	// We're only willing to process DNS identifiers
-	if ident.Type != identifier.DNS {
-		return errInvalidIdentifier
-	}
-	rawDomain := ident.Value
-
-	// If there is more than one wildcard in the domain the ident is invalid
-	if strings.Count(rawDomain, "*") > 1 {
-		return errTooManyWildcards
-	}
-
-	// If there is exactly one wildcard in the domain we need to do some special
-	// processing to ensure that it is a well formed wildcard request and to
-	// translate the identifier to its base domain for use with WillingToIssue
-	if strings.Count(rawDomain, "*") == 1 {
-		// If the rawDomain has a wildcard character, but it isn't the first most
-		// label of the domain name then the wildcard domain is malformed
-		if !strings.HasPrefix(rawDomain, "*.") {
-			return errMalformedWildcard
-		}
-		// The base domain is the wildcard request with the `*.` prefix removed
-		baseDomain := strings.TrimPrefix(rawDomain, "*.")
-		// Names must end in an ICANN TLD, but they must not be equal to an ICANN TLD.
-		icannTLD, err := iana.ExtractSuffix(baseDomain)
-		if err != nil {
-			return errNonPublic
-		}
-		// Names must have a non-wildcard label immediately adjacent to the ICANN
-		// TLD. No `*.com`!
-		if baseDomain == icannTLD {
-			return errICANNTLDWildcard
-		}
-		// The base domain can't be in the wildcard exact blocklist
-		err = pa.checkWildcardHostList(baseDomain)
-		if err != nil {
-			return err
-		}
-		// Check that the PA is willing to issue for the base domain
-		// Since the base domain without the "*." may trip the exact hostname policy
-		// blocklist when the "*." is removed we replace it with a single "x"
-		// character to differentiate "*.example.com" from "example.com" for the
-		// exact hostname check.
-		//
-		// NOTE(@cpu): This is pretty hackish! Boulder issue #3323[0] describes
-		// a better follow-up that we should land to replace this code.
-		// [0] https://github.com/letsencrypt/boulder/issues/3323
-		return pa.willingToIssue(identifier.ACMEIdentifier{
-			Type:  identifier.DNS,
-			Value: "x." + baseDomain,
-		})
-	}
-
-	return pa.willingToIssue(ident)
 }
 
 // checkWildcardHostList checks the wildcardExactBlocklist for a given domain.

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -351,7 +351,7 @@ func ValidEmail(address string) error {
 	}
 	splitEmail := strings.SplitN(email.Address, "@", -1)
 	domain := strings.ToLower(splitEmail[len(splitEmail)-1])
-	err = ValidDomain(domain)
+	err = ValidNonWildcardDomain(domain)
 	if err != nil {
 		return berrors.InvalidEmailError(
 			"contact email %q has invalid domain : %s",

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -59,12 +60,11 @@ func TestWillingToIssue(t *testing.T) {
 		{`---.net`, errInvalidDNSCharacter},       // First label is only hyphens
 		{`0`, errTooFewLabels},
 		{`1`, errTooFewLabels},
-		{`*`, errInvalidDNSCharacter},
-		{`**`, errInvalidDNSCharacter},
-		{`*.*`, errWildcardNotSupported},
-		{`zombo*com`, errInvalidDNSCharacter},
-		{`*.com`, errWildcardNotSupported},
-		{`*.zombo.com`, errWildcardNotSupported},
+		{`*`, errMalformedWildcard},
+		{`**`, errTooManyWildcards},
+		{`*.*`, errTooManyWildcards},
+		{`zombo*com`, errMalformedWildcard},
+		{`*.com`, errICANNTLDWildcard},
 		{`..a`, errLabelTooShort},
 		{`a..a`, errLabelTooShort},
 		{`.a..a`, errLabelTooShort},
@@ -162,60 +162,56 @@ func TestWillingToIssue(t *testing.T) {
 	err = pa.LoadHostnamePolicyFile(yamlPolicyFile.Name())
 	test.AssertNotError(t, err, "Couldn't load rules")
 
-	// Test for invalid identifier type
-	ident := identifier.ACMEIdentifier{Type: "ip", Value: "example.com"}
-	err = pa.willingToIssue(ident)
-	if err != errInvalidIdentifier {
-		t.Error("Identifier was not correctly forbidden: ", ident)
-	}
-
 	// Test syntax errors
 	for _, tc := range testCases {
-		ident := identifier.DNSIdentifier(tc.domain)
-		err := pa.willingToIssue(ident)
-		if err != tc.err {
-			t.Errorf("WillingToIssue(%q) = %q, expected %q", tc.domain, err, tc.err)
+		err := pa.WillingToIssue([]string{tc.domain})
+		if tc.err == nil {
+			test.AssertNil(t, err, fmt.Sprintf("Unexpected error for domain %q, got %s", tc.domain, err))
+		} else {
+			test.AssertError(t, err, fmt.Sprintf("Expected error for domain %q, but got none", tc.domain))
+			var berr *berrors.BoulderError
+			test.AssertErrorWraps(t, err, &berr)
+			test.AssertContains(t, berr.Error(), tc.err.Error())
 		}
 	}
 
 	// Invalid encoding
-	err = pa.willingToIssue(identifier.DNSIdentifier("www.xn--m.com"))
+	err = pa.WillingToIssue([]string{"www.xn--m.com"})
 	test.AssertError(t, err, "WillingToIssue didn't fail on a malformed IDN")
 	// Valid encoding
-	err = pa.willingToIssue(identifier.DNSIdentifier("www.xn--mnich-kva.com"))
+	err = pa.WillingToIssue([]string{"www.xn--mnich-kva.com"})
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed IDN")
 	// IDN TLD
-	err = pa.willingToIssue(identifier.DNSIdentifier("xn--example--3bhk5a.xn--p1ai"))
+	err = pa.WillingToIssue([]string{"xn--example--3bhk5a.xn--p1ai"})
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed domain with IDN TLD")
 	features.Reset()
 
 	// Test domains that are equal to public suffixes
 	for _, domain := range shouldBeTLDError {
-		ident := identifier.DNSIdentifier(domain)
-		err := pa.willingToIssue(ident)
-		if err != errICANNTLD {
-			t.Error("Identifier was not correctly forbidden: ", ident, err)
-		}
+		err := pa.WillingToIssue([]string{domain})
+		test.AssertError(t, err, "domain was not correctly forbidden")
+		var berr *berrors.BoulderError
+		test.AssertErrorWraps(t, err, &berr)
+		test.AssertContains(t, berr.Detail, errICANNTLD.Error())
 	}
 
 	// Test expected blocked domains
 	for _, domain := range shouldBeBlocked {
-		ident := identifier.DNSIdentifier(domain)
-		err := pa.willingToIssue(ident)
-		if err != errPolicyForbidden {
-			t.Error("Identifier was not correctly forbidden: ", ident, err)
-		}
+		err := pa.WillingToIssue([]string{domain})
+		test.AssertError(t, err, "domain was not correctly forbidden")
+		var berr *berrors.BoulderError
+		test.AssertErrorWraps(t, err, &berr)
+		test.AssertContains(t, berr.Detail, errPolicyForbidden.Error())
 	}
 
 	// Test acceptance of good names
 	for _, domain := range shouldBeAccepted {
-		ident := identifier.DNSIdentifier(domain)
-		err := pa.willingToIssue(ident)
-		test.AssertNotError(t, err, "identiier was incorrectly forbidden")
+		err := pa.WillingToIssue([]string{domain})
+		test.AssertNotError(t, err, "domain was incorrectly forbidden")
 	}
 }
 
-func TestWillingToIssueWildcard(t *testing.T) {
+func TestWillingToIssue_Wildcards(t *testing.T) {
 	bannedDomains := []string{
 		"zombo.gov.us",
 	}
@@ -238,78 +234,80 @@ func TestWillingToIssueWildcard(t *testing.T) {
 
 	testCases := []struct {
 		Name        string
-		Ident       identifier.ACMEIdentifier
+		Domain      string
 		ExpectedErr error
 	}{
 		{
-			Name:        "Non-DNS identifier",
-			Ident:       identifier.ACMEIdentifier{Type: "nickname", Value: "cpu"},
-			ExpectedErr: errInvalidIdentifier,
-		},
-		{
 			Name:        "Too many wildcards",
-			Ident:       identifier.DNSIdentifier("ok.*.whatever.*.example.com"),
+			Domain:      "ok.*.whatever.*.example.com",
 			ExpectedErr: errTooManyWildcards,
 		},
 		{
 			Name:        "Misplaced wildcard",
-			Ident:       identifier.DNSIdentifier("ok.*.whatever.example.com"),
+			Domain:      "ok.*.whatever.example.com",
 			ExpectedErr: errMalformedWildcard,
 		},
 		{
 			Name:        "Missing ICANN TLD",
-			Ident:       identifier.DNSIdentifier("*.ok.madeup"),
+			Domain:      "*.ok.madeup",
 			ExpectedErr: errNonPublic,
 		},
 		{
 			Name:        "Wildcard for ICANN TLD",
-			Ident:       identifier.DNSIdentifier("*.com"),
+			Domain:      "*.com",
 			ExpectedErr: errICANNTLDWildcard,
 		},
 		{
 			Name:        "Forbidden base domain",
-			Ident:       identifier.DNSIdentifier("*.zombo.gov.us"),
+			Domain:      "*.zombo.gov.us",
 			ExpectedErr: errPolicyForbidden,
 		},
 		// We should not allow getting a wildcard for that would cover an exact
 		// blocklist domain
 		{
 			Name:        "Wildcard for ExactBlocklist base domain",
-			Ident:       identifier.DNSIdentifier("*.letsdecrypt.org"),
+			Domain:      "*.letsdecrypt.org",
 			ExpectedErr: errPolicyForbidden,
 		},
 		// We should allow a wildcard for a domain that doesn't match the exact
 		// blocklist domain
 		{
 			Name:        "Wildcard for non-matching subdomain of ExactBlocklist domain",
-			Ident:       identifier.DNSIdentifier("*.lowvalue.letsdecrypt.org"),
+			Domain:      "*.lowvalue.letsdecrypt.org",
 			ExpectedErr: nil,
 		},
 		// We should allow getting a wildcard for an exact blocklist domain since it
 		// only covers subdomains, not the exact name.
 		{
 			Name:        "Wildcard for ExactBlocklist domain",
-			Ident:       identifier.DNSIdentifier("*.highvalue.letsdecrypt.org"),
+			Domain:      "*.highvalue.letsdecrypt.org",
 			ExpectedErr: nil,
 		},
 		{
 			Name:        "Valid wildcard domain",
-			Ident:       identifier.DNSIdentifier("*.everything.is.possible.at.zombo.com"),
+			Domain:      "*.everything.is.possible.at.zombo.com",
 			ExpectedErr: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			result := pa.willingToIssueWildcard(tc.Ident)
-			test.AssertEquals(t, result, tc.ExpectedErr)
+			err := pa.WillingToIssue([]string{tc.Domain})
+			if tc.ExpectedErr == nil {
+				test.AssertNil(t, err, fmt.Sprintf("Unexpected error for domain %q, got %s", tc.Domain, err))
+			} else {
+				test.AssertError(t, err, fmt.Sprintf("Expected error for domain %q, but got none", tc.Domain))
+				var berr *berrors.BoulderError
+				test.AssertErrorWraps(t, err, &berr)
+				test.AssertContains(t, berr.Error(), tc.ExpectedErr.Error())
+			}
 		})
 	}
 }
 
 // TestWillingToIssueWildcards tests that more than one rejected identifier
 // results in an error with suberrors.
-func TestWillingToIssueWildcards(t *testing.T) {
+func TestWillingToIssue_Wildcard(t *testing.T) {
 	banned := []string{
 		"letsdecrypt.org",
 	}
@@ -327,18 +325,21 @@ func TestWillingToIssueWildcards(t *testing.T) {
 	err = pa.LoadHostnamePolicyFile(f.Name())
 	test.AssertNotError(t, err, "Couldn't load policy contents from file")
 
-	idents := []identifier.ACMEIdentifier{
-		identifier.DNSIdentifier("perfectly-fine.com"),
-		identifier.DNSIdentifier("letsdecrypt.org"),
-		identifier.DNSIdentifier("ok.*.this.is.a.*.weird.one.com"),
-		identifier.DNSIdentifier("also-perfectly-fine.com"),
+	domains := []string{
+		"perfectly-fine.com",             // fine
+		"letsdecrypt.org",                // banned
+		"ok.*.this.is.a.*.weird.one.com", // malformed
+		"also-perfectly-fine.com",        // fine
 	}
 
-	err = pa.WillingToIssueWildcards(idents)
+	err = pa.WillingToIssue(domains)
 	test.AssertError(t, err, "Expected err from WillingToIssueWildcards")
 
 	var berr *berrors.BoulderError
 	test.AssertErrorWraps(t, err, &berr)
+	for _, err := range berr.SubErrors {
+		fmt.Println(err)
+	}
 	test.AssertEquals(t, len(berr.SubErrors), 2)
 	test.AssertEquals(t, berr.Error(), "Cannot issue for \"letsdecrypt.org\": The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy (and 1 more problems. Refer to sub-problems for more information.)")
 
@@ -357,9 +358,7 @@ func TestWillingToIssueWildcards(t *testing.T) {
 	test.AssertEquals(t, subErrB.Type, berrors.Malformed)
 
 	// Test willing to issue with only *one* bad identifier.
-	err = pa.WillingToIssueWildcards([]identifier.ACMEIdentifier{
-		identifier.DNSIdentifier("letsdecrypt.org"),
-	})
+	err = pa.WillingToIssue([]string{"letsdecrypt.org"})
 	// It should error
 	test.AssertError(t, err, "Expected err from WillingToIssueWildcards")
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2335,22 +2335,6 @@ func (ra *RegistrationAuthorityImpl) DeactivateAuthorization(ctx context.Context
 	return &emptypb.Empty{}, nil
 }
 
-// checkOrderNames validates that the RA's policy authority allows issuing for
-// each of the names in an order. If any of the names are unacceptable a
-// malformed or rejectedIdentifier error with suberrors for each rejected
-// identifier is returned.
-func (ra *RegistrationAuthorityImpl) checkOrderNames(names []string) error {
-	idents := make([]identifier.ACMEIdentifier, len(names))
-	for i, name := range names {
-		idents[i] = identifier.DNSIdentifier(name)
-	}
-	err := ra.PA.WillingToIssueWildcards(idents)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // GenerateOCSP looks up a certificate's status, then requests a signed OCSP
 // response for it from the CA. If the certificate status is not available
 // or the certificate is expired, it returns berrors.NotFoundError.
@@ -2407,7 +2391,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	}
 
 	// Validate that our policy allows issuing for each of the names in the order
-	err := ra.checkOrderNames(newOrder.Names)
+	err := ra.PA.WillingToIssue(newOrder.Names)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Revamp WillingToIssueWildcards to WillingToIssue. Remove the need for identifier.ACMEIdentifiers in the WillingToIssue(Wildcards) method. Previously, before invoking this method, a slice of identifiers was created by looping over each dnsName. However, these identifiers were solely used in error messages.

Segment the validation process into distinct parts for domain validation, wildcard validation, and exact blocklist checks. This approach eliminates the necessity of substituting *. with x. in wildcard domains.

Introduce a new helper, ValidDomain. It checks that a domain is valid and that it doesn't contain any invalid wildcard characters. Functionality from the previous ValidDomain is preserved in ValidNonWildcardDomain.

Fixes #3323