### PR TITLE
expiration-mailer: check address validity before sending

### DIFF
--- a/cmd/expiration-mailer/main_test.go
+++ b/cmd/expiration-mailer/main_test.go
@@ -177,7 +177,7 @@ func TestSendNags(t *testing.T) {
 	conn, err = m.mailer.Connect()
 	test.AssertNotError(t, err, "connecting SMTP")
 	err = m.sendNags(conn, []string{}, []*x509.Certificate{cert})
-	test.AssertNotError(t, err, "Not an error to pass no email contacts")
+	test.AssertErrorIs(t, err, errNoValidEmail)
 	test.AssertEquals(t, len(mc.Messages), 0)
 
 	sendLogs := log.GetAllMatching("INFO: attempting send JSON=.*")
@@ -231,7 +231,7 @@ func TestSendNagsAddressLimited(t *testing.T) {
 
 	// Try sending a message to an over-the-limit address
 	err = m.sendNags(conn, []string{emailA}, []*x509.Certificate{cert})
-	test.AssertNotError(t, err, "sending warning messages")
+	test.AssertErrorIs(t, err, errNoValidEmail)
 	// Expect that no messages were sent because this address was over the limit
 	test.AssertEquals(t, len(mc.Messages), 0)
 

--- a/cmd/expiration-mailer/send_test.go
+++ b/cmd/expiration-mailer/send_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	email1 = "mailto:one@example.com"
-	email2 = "mailto:two@example.com"
+	email1 = "mailto:one@shared-example.com"
+	email2 = "mailto:two@shared-example.com"
 )
 
 func TestSendEarliestCertInfo(t *testing.T) {
@@ -52,9 +52,9 @@ func TestSendEarliestCertInfo(t *testing.T) {
 			domains,
 			rawCertB.NotAfter.Format(time.DateOnly)),
 	}
-	expected.To = "one@example.com"
+	expected.To = "one@shared-example.com"
 	test.AssertEquals(t, expected, ctx.mc.Messages[0])
-	expected.To = "two@example.com"
+	expected.To = "two@shared-example.com"
 	test.AssertEquals(t, expected, ctx.mc.Messages[1])
 }
 


### PR DESCRIPTION
Use policy.ValidEmail to vet email addresses before sending expiration notifications to them. This same check is performed by notify-mailer, and it helps reduce the number of invalid addresses we attempt to send to and the number of email bounces we generate.

Additionally, mark certificates as having had a nag email sent if there are no valid addresses for us to send to, so that we don't constantly retry them.

Fixes https://github.com/letsencrypt/boulder/issues/5372