### PR TITLE
Switch from lint.Lint to lint.CertificateLint

### DIFF
--- a/linter/lints/chrome/e_scts_from_same_operator.go
+++ b/linter/lints/chrome/e_scts_from_same_operator.go
@@ -17,13 +17,15 @@ type sctsFromSameOperator struct {
 }
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_scts_from_same_operator",
-		Description:   "Let's Encrypt Subscriber Certificates have two SCTs from logs run by different operators",
-		Citation:      "Chrome CT Policy",
-		Source:        lints.ChromeCTPolicy,
-		EffectiveDate: time.Date(2022, time.April, 15, 0, 0, 0, 0, time.UTC),
-		Lint:          NewSCTsFromSameOperator,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_scts_from_same_operator",
+			Description:   "Let's Encrypt Subscriber Certificates have two SCTs from logs run by different operators",
+			Citation:      "Chrome CT Policy",
+			Source:        lints.ChromeCTPolicy,
+			EffectiveDate: time.Date(2022, time.April, 15, 0, 0, 0, 0, time.UTC),
+		},
+		Lint: NewSCTsFromSameOperator,
 	})
 }
 

--- a/linter/lints/chrome/e_scts_from_same_operator.go
+++ b/linter/lints/chrome/e_scts_from_same_operator.go
@@ -29,7 +29,7 @@ func init() {
 	})
 }
 
-func NewSCTsFromSameOperator() lint.LintInterface {
+func NewSCTsFromSameOperator() lint.CertificateLintInterface {
 	return &sctsFromSameOperator{logList: loglist.GetLintList()}
 }
 

--- a/linter/lints/cpcps/lint_root_ca_cert_validity_period_greater_than_25_years.go
+++ b/linter/lints/cpcps/lint_root_ca_cert_validity_period_greater_than_25_years.go
@@ -13,13 +13,15 @@ import (
 type rootCACertValidityTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_root_ca_cert_validity_period_greater_than_25_years",
-		Description:   "Let's Encrypt Root CA Certificates have Validity Periods of up to 25 years",
-		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPS,
-		EffectiveDate: lints.CPSV33Date,
-		Lint:          NewRootCACertValidityTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_root_ca_cert_validity_period_greater_than_25_years",
+			Description:   "Let's Encrypt Root CA Certificates have Validity Periods of up to 25 years",
+			Citation:      "CPS: 7.1",
+			Source:        lints.LetsEncryptCPS,
+			EffectiveDate: lints.CPSV33Date,
+		},
+		Lint: NewRootCACertValidityTooLong,
 	})
 }
 

--- a/linter/lints/cpcps/lint_root_ca_cert_validity_period_greater_than_25_years.go
+++ b/linter/lints/cpcps/lint_root_ca_cert_validity_period_greater_than_25_years.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func NewRootCACertValidityTooLong() lint.LintInterface {
+func NewRootCACertValidityTooLong() lint.CertificateLintInterface {
 	return &rootCACertValidityTooLong{}
 }
 

--- a/linter/lints/cpcps/lint_subordinate_ca_cert_validity_period_greater_than_8_years.go
+++ b/linter/lints/cpcps/lint_subordinate_ca_cert_validity_period_greater_than_8_years.go
@@ -13,13 +13,15 @@ import (
 type subordinateCACertValidityTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_validity_period_greater_than_8_years",
-		Description:   "Let's Encrypt Intermediate CA Certificates have Validity Periods of up to 8 years",
-		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPS,
-		EffectiveDate: lints.CPSV33Date,
-		Lint:          NewSubordinateCACertValidityTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_validity_period_greater_than_8_years",
+			Description:   "Let's Encrypt Intermediate CA Certificates have Validity Periods of up to 8 years",
+			Citation:      "CPS: 7.1",
+			Source:        lints.LetsEncryptCPS,
+			EffectiveDate: lints.CPSV33Date,
+		},
+		Lint: NewSubordinateCACertValidityTooLong,
 	})
 }
 

--- a/linter/lints/cpcps/lint_subordinate_ca_cert_validity_period_greater_than_8_years.go
+++ b/linter/lints/cpcps/lint_subordinate_ca_cert_validity_period_greater_than_8_years.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func NewSubordinateCACertValidityTooLong() lint.LintInterface {
+func NewSubordinateCACertValidityTooLong() lint.CertificateLintInterface {
 	return &subordinateCACertValidityTooLong{}
 }
 

--- a/linter/lints/cpcps/lint_subscriber_cert_validity_greater_than_100_days.go
+++ b/linter/lints/cpcps/lint_subscriber_cert_validity_greater_than_100_days.go
@@ -13,13 +13,15 @@ import (
 type subscriberCertValidityTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subscriber_cert_validity_period_greater_than_100_days",
-		Description:   "Let's Encrypt Subscriber Certificates have Validity Periods of up to 100 days",
-		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPS,
-		EffectiveDate: lints.CPSV33Date,
-		Lint:          NewSubscriberCertValidityTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subscriber_cert_validity_period_greater_than_100_days",
+			Description:   "Let's Encrypt Subscriber Certificates have Validity Periods of up to 100 days",
+			Citation:      "CPS: 7.1",
+			Source:        lints.LetsEncryptCPS,
+			EffectiveDate: lints.CPSV33Date,
+		},
+		Lint: NewSubscriberCertValidityTooLong,
 	})
 }
 

--- a/linter/lints/cpcps/lint_subscriber_cert_validity_greater_than_100_days.go
+++ b/linter/lints/cpcps/lint_subscriber_cert_validity_greater_than_100_days.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func NewSubscriberCertValidityTooLong() lint.LintInterface {
+func NewSubscriberCertValidityTooLong() lint.CertificateLintInterface {
 	return &subscriberCertValidityTooLong{}
 }
 

--- a/linter/lints/cpcps/lint_validity_period_has_extra_second.go
+++ b/linter/lints/cpcps/lint_validity_period_has_extra_second.go
@@ -12,13 +12,15 @@ import (
 type certValidityNotRound struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_validity_period_has_extra_second",
-		Description:   "Let's Encrypt Certificates have Validity Periods that are a round number of seconds",
-		Citation:      "CPS: 7.1",
-		Source:        lints.LetsEncryptCPS,
-		EffectiveDate: lints.CPSV33Date,
-		Lint:          NewCertValidityNotRound,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_validity_period_has_extra_second",
+			Description:   "Let's Encrypt Certificates have Validity Periods that are a round number of seconds",
+			Citation:      "CPS: 7.1",
+			Source:        lints.LetsEncryptCPS,
+			EffectiveDate: lints.CPSV33Date,
+		},
+		Lint: NewCertValidityNotRound,
 	})
 }
 

--- a/linter/lints/cpcps/lint_validity_period_has_extra_second.go
+++ b/linter/lints/cpcps/lint_validity_period_has_extra_second.go
@@ -24,7 +24,7 @@ func init() {
 	})
 }
 
-func NewCertValidityNotRound() lint.LintInterface {
+func NewCertValidityNotRound() lint.CertificateLintInterface {
 	return &certValidityNotRound{}
 }
 


### PR DESCRIPTION
Zlint is deprecating lint.Lint in favour of lint.CertificateLint.

The main difference is that metadata is now its own struct, shared with lint.RevocationListLint and presumably future lint types.