### PR TITLE
Retry single selects against the primary

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -124,7 +124,7 @@ func (ssa *SQLStorageAuthority) UpdateRegistration(ctx context.Context, req *cor
 		return nil, errIncompleteRequest
 	}
 
-	curr, err := selectRegistration(ctx, ssa.dbMap, "id", req.Id)
+	curr, err := selectRegistration(ctx, ssa.dbMap, false, "id", req.Id)
 	if err != nil {
 		if db.IsNoRows(err) {
 			return nil, berrors.NotFoundError("registration with ID '%d' not found", req.Id)

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -252,12 +252,14 @@ func TestSelectRegistration(t *testing.T) {
 	test.AssertNotError(t, err, fmt.Sprintf("couldn't create new registration: %s", err))
 	test.Assert(t, reg.Id != 0, "ID shouldn't be 0")
 
-	_, err = selectRegistration(ctx, sa.dbMap, "id", reg.Id)
+	_, err = selectRegistration(ctx, sa.dbMap, false, "id", reg.Id)
 	test.AssertNotError(t, err, "selecting by id should work")
-	_, err = selectRegistration(ctx, sa.dbMap, "jwk_sha256", sha)
+	_, err = selectRegistration(ctx, sa.dbMap, false, "jwk_sha256", sha)
 	test.AssertNotError(t, err, "selecting by jwk_sha256 should work")
-	_, err = selectRegistration(ctx, sa.dbMap, "initialIP", reg.Id)
+	_, err = selectRegistration(ctx, sa.dbMap, false, "initialIP", reg.Id)
 	test.AssertError(t, err, "selecting by any other column should not work")
+	_, err = selectRegistration(ctx, sa.dbMap, true, "id", reg.Id)
+	test.AssertNotError(t, err, "selecting with the extra primary token should work")
 }
 
 func TestReplicationLagRetries(t *testing.T) {


### PR DESCRIPTION
DO NOT SUBMIT

Here's a draft implementing the "send the retry to the primary" scheme we discussed earlier this week. If we like this approach, we can attempt to extend it to the other SA methods which currently have lagfactor retries, although it will be considerably more complex in those cases due to additional layers of abstraction above the query itself.