### PR TITLE
Fix typos

### DIFF
--- a/cmd/admin-revoker/main_test.go
+++ b/cmd/admin-revoker/main_test.go
@@ -379,7 +379,7 @@ type testCtx struct {
 	log     *blog.Mock
 }
 
-func (c testCtx) addRegistation(t *testing.T, names []string, jwk string) int64 {
+func (c testCtx) addRegistration(t *testing.T, names []string, jwk string) int64 {
 	t.Helper()
 	initialIP, err := net.ParseIP("127.0.0.1").MarshalText()
 	test.AssertNotError(t, err, "Failed to create initialIP")
@@ -433,7 +433,7 @@ func (c testCtx) createAndRegisterEntries(t *testing.T, entries []*entry) {
 
 func (c testCtx) createAndRegisterEntry(t *testing.T, e *entry) {
 	t.Helper()
-	e.regId = c.addRegistation(t, e.names, e.jwk)
+	e.regId = c.addRegistration(t, e.names, e.jwk)
 	cert := c.addCertificate(t, e.serial, e.names, e.testKey.PublicKey, e.regId)
 	var err error
 	e.spkiHash, err = core.KeyDigest(cert.PublicKey)

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -32,7 +32,7 @@ func TestExpectedKeyAuthorization(t *testing.T) {
 	}
 }
 
-func TestRecordSanityCheckOnUnsupportChallengeType(t *testing.T) {
+func TestRecordSanityCheckOnUnsupportedChallengeType(t *testing.T) {
 	rec := []ValidationRecord{
 		{
 			URL:               "http://localhost/test",

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1570,7 +1570,7 @@ func TestExactPublicSuffixCertLimit(t *testing.T) {
 	test.AssertNotError(t, err, "certificate per name rate limit not applied correctly")
 
 	// Trying to issue for "test3.dedyn.io" and "dynv6.net" should fail because
-	// "dynv6.net" is an exact public suffic match with 2 certificates issued for
+	// "dynv6.net" is an exact public suffix match with 2 certificates issued for
 	// it.
 	err = ra.checkCertificatesPerNameLimit(ctx, []string{"test3.dedyn.io", "dynv6.net"}, certsPerNamePolicy, 99)
 	test.AssertError(t, err, "certificate per name rate limit not applied correctly")

--- a/rocsp/mocks.go
+++ b/rocsp/mocks.go
@@ -9,13 +9,13 @@ import (
 
 // MockWriteClient is a mock
 type MockWriteClient struct {
-	StoreReponseReturnError error
+	StoreResponseReturnError error
 }
 
 // StoreResponse mocks a rocsp.StoreResponse method and returns nil or an
 // error depending on the desired state.
 func (r MockWriteClient) StoreResponse(ctx context.Context, resp *ocsp.Response) error {
-	return r.StoreReponseReturnError
+	return r.StoreResponseReturnError
 }
 
 // NewMockWriteSucceedClient returns a mock MockWriteClient with a
@@ -27,5 +27,5 @@ func NewMockWriteSucceedClient() MockWriteClient {
 // NewMockWriteFailClient returns a mock MockWriteClient with a
 // StoreResponse method that will always fail.
 func NewMockWriteFailClient() MockWriteClient {
-	return MockWriteClient{StoreReponseReturnError: fmt.Errorf("could not store response")}
+	return MockWriteClient{StoreResponseReturnError: fmt.Errorf("could not store response")}
 }

--- a/test/load-generator/acme/directory.go
+++ b/test/load-generator/acme/directory.go
@@ -41,7 +41,7 @@ var (
 	// ErrInvalidDirectoryMeta is returned if NewDirectory is provided a directory
 	// URL that returns a directory resource with an invalid or  missing "meta" key.
 	ErrInvalidDirectoryMeta = errors.New(`server's directory resource had invalid or missing "meta" key`)
-	// ErrInvalidTermsOfSerivce is returned if NewDirectory is provided
+	// ErrInvalidTermsOfService is returned if NewDirectory is provided
 	// a directory URL that returns a directory resource with an invalid or
 	// missing "termsOfService" key in the "meta" map.
 	ErrInvalidTermsOfService = errors.New(`server's directory resource had invalid or missing "meta.termsOfService" key`)

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -142,7 +142,7 @@ def test_tls_alpn_challenge_dns_err():
 def test_http_challenge_broken_redirect():
     """
     test_http_challenge_broken_redirect tests that a common webserver
-    mis-configuration receives the correct specialized error message when attempting
+    misconfiguration receives the correct specialized error message when attempting
     an HTTP-01 challenge.
     """
     client = chisel2.make_client()
@@ -598,7 +598,7 @@ def test_order_reuse_failed_authz():
     """
     Test that creating an order for a domain name, failing an authorization in
     that order, and submitting another new order request for the same name
-    doesn't reuse a failed authorizaton in the new order.
+    doesn't reuse a failed authorization in the new order.
     """
 
     client = chisel2.make_client(None)

--- a/va/http.go
+++ b/va/http.go
@@ -402,7 +402,7 @@ func (va *ValidationAuthorityImpl) fetchHTTP(
 // fallbackErr returns true only for net.OpError instances where the op is equal
 // to "dial", or url.Error instances wrapping such an error. fallbackErr returns
 // false for all other errors. By policy, only dial errors (not read or write
-// errors) are eligble for fallback from an IPv6 to an IPv4 address.
+// errors) are eligible for fallback from an IPv6 to an IPv4 address.
 func fallbackErr(err error) bool {
 	// Err shouldn't ever be nil if we're considering it for fallback
 	if err == nil {


### PR DESCRIPTION
Found new misspellings.

`typos` is a better tool than the current spell checker.
