### PR TITLE
Correct Comments on Challenge Construction in `core/challenges.go`

### DIFF
--- a/core/challenges.go
+++ b/core/challenges.go
@@ -10,27 +10,23 @@ func newChallenge(challengeType AcmeChallenge, token string) Challenge {
 	}
 }
 
-// HTTPChallenge01 constructs a random http-01 challenge. If token is empty a random token
-// will be generated, otherwise the provided token is used.
+// HTTPChallenge01 constructs a http-01 challenge.
 func HTTPChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeHTTP01, token)
 }
 
-// DNSChallenge01 constructs a random dns-01 challenge. If token is empty a random token
-// will be generated, otherwise the provided token is used.
+// DNSChallenge01 constructs a dns-01 challenge.
 func DNSChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeDNS01, token)
 }
 
-// TLSALPNChallenge01 constructs a random tls-alpn-01 challenge. If token is empty a random token
-// will be generated, otherwise the provided token is used.
+// TLSALPNChallenge01 constructs a tls-alpn-01 challenge.
 func TLSALPNChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeTLSALPN01, token)
 }
 
-// NewChallenge constructs a random challenge of the given kind. It returns an
-// error if the challenge type is unrecognized. If token is empty a random token
-// will be generated, otherwise the provided token is used.
+// NewChallenge constructs a challenge of the given kind. It returns an
+// error if the challenge type is unrecognized.
 func NewChallenge(kind AcmeChallenge, token string) (Challenge, error) {
 	switch kind {
 	case ChallengeTypeHTTP01:


### PR DESCRIPTION
This PR addresses a discrepancy between the code comments and the actual behavior in the challenge construction functions within `core/challenges.go`. The existing comments suggest that these functions generate a random token if the supplied token is empty. However, upon reviewing the relevant code, it's evident that these functions do not generate a random token; they simply use the token that is passed to them.

The [only calling code](https://github.com/fastly/boulder/blob/a3afce5f75c34c781ba4095587eb96d6899e538d/policy/pa.go#L561-L571) in `policy/pa.go` demonstrates this behavior:

```go
token := core.NewToken()

for i, t := range challTypes {
	c, err := core.NewChallenge(t, token)
	// ... additional code ...
}
```

This change corrects the comments to reflect actual behavior.