### PR TITLE
test: move SRV stanzas from config-next to config

### DIFF
--- a/test/config/admin-revoker.json
+++ b/test/config/admin-revoker.json
@@ -10,13 +10,23 @@
 			"keyFile": "test/grpc-creds/admin-revoker.boulder/key.pem"
 		},
 		"raService": {
-			"serverAddress": "ra.service.consul:9094",
-			"timeout": "15s",
-			"hostOverride": "ra.boulder"
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
+			"hostOverride": "ra.boulder",
+			"noWaitForReady": true,
+			"timeout": "15s"
 		},
 		"saService": {
-			"serverAddress": "sa.service.consul:9095",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"features": {}

--- a/test/config/bad-key-revoker.json
+++ b/test/config/bad-key-revoker.json
@@ -11,9 +11,14 @@
 			"keyFile": "test/grpc-creds/bad-key-revoker.boulder/key.pem"
 		},
 		"raService": {
-			"serverAddress": "ra.service.consul:9094",
-			"timeout": "15s",
-			"hostOverride": "ra.boulder"
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
+			"hostOverride": "ra.boulder",
+			"noWaitForReady": true,
+			"timeout": "15s"
 		},
 		"mailer": {
 			"server": "localhost",

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -34,8 +34,13 @@
 			}
 		},
 		"saService": {
-			"serverAddress": "sa.service.consul:9095",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"issuance": {

--- a/test/config/crl-updater.json
+++ b/test/config/crl-updater.json
@@ -1,24 +1,38 @@
 {
 	"crlUpdater": {
-		"debugAddr": ":8021",
 		"tls": {
 			"caCertFile": "test/grpc-creds/minica.pem",
 			"certFile": "test/grpc-creds/crl-updater.boulder/cert.pem",
 			"keyFile": "test/grpc-creds/crl-updater.boulder/key.pem"
 		},
 		"saService": {
-			"serverAddress": "sa.service.consul:9095",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"crlGeneratorService": {
-			"serverAddress": "ca.service.consul:9093",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "ca",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ca.boulder"
 		},
 		"crlStorerService": {
-			"serverAddress": "crl-storer.service.consul:9109",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "crl-storer",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "crl-storer.boulder"
 		},
 		"issuerCerts": [

--- a/test/config/expiration-mailer.json
+++ b/test/config/expiration-mailer.json
@@ -22,8 +22,13 @@
 			"keyFile": "test/grpc-creds/expiration-mailer.boulder/key.pem"
 		},
 		"saService": {
-			"serverAddress": "sa.service.consul:9095",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"SMTPTrustedRootFile": "test/mail-test-srv/minica.pem",

--- a/test/config/nonce-a.json
+++ b/test/config/nonce-a.json
@@ -1,7 +1,10 @@
 {
 	"NonceService": {
 		"maxUsed": 131072,
-		"noncePrefix": "taro",
+		"useDerivablePrefix": true,
+		"noncePrefixKey": {
+			"passwordFile": "test/secrets/nonce_prefix_key"
+		},
 		"syslog": {
 			"stdoutLevel": 6,
 			"syslogLevel": 6

--- a/test/config/nonce-b.json
+++ b/test/config/nonce-b.json
@@ -1,7 +1,10 @@
 {
 	"NonceService": {
 		"maxUsed": 131072,
-		"noncePrefix": "zinc",
+		"useDerivablePrefix": true,
+		"noncePrefixKey": {
+			"passwordFile": "test/secrets/nonce_prefix_key"
+		},
 		"syslog": {
 			"stdoutLevel": 6,
 			"syslogLevel": 6

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -26,13 +26,23 @@
 			"keyFile": "test/grpc-creds/ocsp-responder.boulder/key.pem"
 		},
 		"raService": {
-			"serverAddress": "ra.service.consul:9094",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
 			"hostOverride": "ra.boulder",
+			"noWaitForReady": true,
 			"timeout": "15s"
 		},
 		"saService": {
-			"serverAddress": "sa.service.consul:9095",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"logSampleRate": 1,

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -24,33 +24,63 @@
 			"keyFile": "test/grpc-creds/ra.boulder/key.pem"
 		},
 		"vaService": {
-			"serverAddress": "va.service.consul:9092",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "va",
+				"domain": "service.consul"
+			},
 			"timeout": "20s",
+			"noWaitForReady": true,
 			"hostOverride": "va.boulder"
 		},
 		"caService": {
-			"serverAddress": "ca.service.consul:9093",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "ca",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ca.boulder"
 		},
 		"ocspService": {
-			"serverAddress": "ca.service.consul:9093",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "ca",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ca.boulder"
 		},
 		"publisherService": {
-			"serverAddress": "publisher.service.consul:9091",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "publisher",
+				"domain": "service.consul"
+			},
 			"timeout": "300s",
+			"noWaitForReady": true,
 			"hostOverride": "publisher.boulder"
 		},
 		"saService": {
-			"serverAddress": "sa.service.consul:9095",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"akamaiPurgerService": {
-			"serverAddress": "akamai-purger.service.consul:9099",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "akamai-purger",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "akamai-purger.boulder"
 		},
 		"grpc": {

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -22,13 +22,23 @@
 			"keyFile": "test/grpc-creds/wfe.boulder/key.pem"
 		},
 		"raService": {
-			"serverAddress": "ra.service.consul:9094",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "ra",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "ra.boulder"
 		},
 		"saService": {
-			"serverAddress": "sa.service.consul:9095",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "sa",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "sa.boulder"
 		},
 		"accountCache": {
@@ -36,21 +46,34 @@
 			"ttl": "5s"
 		},
 		"getNonceService": {
-			"serverAddress": "nonce.service.consul:9101",
+			"dnsAuthority": "consul.service.consul",
+			"srvLookup": {
+				"service": "nonce",
+				"domain": "service.consul"
+			},
 			"timeout": "15s",
+			"noWaitForReady": true,
 			"hostOverride": "nonce.boulder"
 		},
-		"redeemNonceServices": {
-			"taro": {
-				"serverAddress": "nonce1.service.consul:9101",
-				"timeout": "15s",
-				"hostOverride": "nonce1.boulder"
-			},
-			"zinc": {
-				"serverAddress": "nonce2.service.consul:9101",
-				"timeout": "15s",
-				"hostOverride": "nonce2.boulder"
-			}
+		"redeemNonceService": {
+			"dnsAuthority": "consul.service.consul",
+			"srvLookups": [
+				{
+					"service": "nonce1",
+					"domain": "service.consul"
+				},
+				{
+					"service": "nonce2",
+					"domain": "service.consul"
+				}
+			],
+			"srvResolver": "nonce-srv",
+			"timeout": "15s",
+			"noWaitForReady": true,
+			"hostOverride": "nonce.boulder"
+		},
+		"noncePrefixKey": {
+			"passwordFile": "test/secrets/nonce_prefix_key"
 		},
 		"chains": [
 			[


### PR DESCRIPTION
Service discovery via SRV records is now deployed in prod.