### PR TITLE
Add additional service resolution strategy to consul doc

### DIFF
--- a/test/consul/README.md
+++ b/test/consul/README.md
@@ -6,7 +6,8 @@ in-memory server and client with persistence disabled for ease of use.
 
 - Open `./test/consul/config.hcl`
 - Add a `services` stanza for each IP address and (optional) port combination
-  you wish to have returned as an DNS record.
+  you wish to have returned as an DNS record. The following stanza will return
+  two records when resolving `foo-purger`.
   ([docs](https://www.consul.io/docs/discovery/services)).
   
   ```hcl
@@ -20,6 +21,24 @@ in-memory server and client with persistence disabled for ease of use.
   services {
     id      = "foo-purger-b"
     name    = "foo-purger"
+    address = "10.88.88.88"
+    port    = 1338
+  }
+  ```
+- To target individual `foo-purger`'s, add these additional `service` sections
+  which allow resolving `foo-purger-1` and `foo-purger-2` respectively.
+
+  ```hcl
+  services {
+    id      = "foo-purger-1"
+    name    = "foo-purger-1"
+    address = "10.77.77.77"
+    port    = 1338
+  }
+
+  services {
+    id      = "foo-purger-2"
+    name    = "foo-purger-2"
     address = "10.88.88.88"
     port    = 1338
   }


### PR DESCRIPTION
While working on https://github.com/letsencrypt/boulder/pull/7238, I dug into why the consul services config has, for example, `[ca-a, ca-b]` in addition to `[ca1, ca2]`. Boulder test configs use `ca.service.consul` which will return both CAs (`[ca-a, ca-b]`). For `[ca1, ca2]` though, a grpc load balancing [integration test](https://github.com/letsencrypt/boulder/blob/a55bf19ea062febc94b5054a004e447aa5b3a6bd/test/integration-test.py#L121-L143) individually targets services such as to verify that each backend is working correctly.