### PR TITLE
t.sh: rebuild local boulder-tools docker container

### DIFF
--- a/t.sh
+++ b/t.sh
@@ -10,4 +10,4 @@ fi
 # Use a predictable name for the container so we can grab the logs later
 # for use when testing logs analysis tools.
 docker rm boulder_tests
-exec docker compose run --name boulder_tests boulder ./test.sh "$@"
+exec docker compose run --build --name boulder_tests boulder ./test.sh "$@"

--- a/t.sh
+++ b/t.sh
@@ -7,7 +7,14 @@ if type realpath >/dev/null 2>&1 ; then
   cd "$(realpath -- $(dirname -- "$0"))"
 fi
 
+lastBuild=$(date -d $(docker inspect letsencrypt/boulder-tools:latest | jq -r ".[0].Created") +%s)
+lastMod=$(date -d $(git log -1 --pretty="format:%cI" test/boulder-tools/) +%s)
+if [ $lastBuild -le $lastMod ]
+then
+  docker compose build
+fi
+
 # Use a predictable name for the container so we can grab the logs later
 # for use when testing logs analysis tools.
 docker rm boulder_tests
-exec docker compose run --build --name boulder_tests boulder ./test.sh "$@"
+exec docker compose run --name boulder_tests boulder ./test.sh "$@"

--- a/tn.sh
+++ b/tn.sh
@@ -7,4 +7,4 @@ if type realpath >/dev/null 2>&1 ; then
   cd "$(realpath -- $(dirname -- "$0"))"
 fi
 
-exec docker compose -f docker-compose.yml -f docker-compose.next.yml run boulder ./test.sh "$@"
+exec docker compose -f docker-compose.yml -f docker-compose.next.yml run --build boulder ./test.sh "$@"

--- a/tn.sh
+++ b/tn.sh
@@ -7,4 +7,11 @@ if type realpath >/dev/null 2>&1 ; then
   cd "$(realpath -- $(dirname -- "$0"))"
 fi
 
-exec docker compose -f docker-compose.yml -f docker-compose.next.yml run --build boulder ./test.sh "$@"
+lastBuild=$(date -d $(docker inspect letsencrypt/boulder-tools:latest | jq -r ".[0].Created") +%s)
+lastMod=$(date -d $(git log -1 --pretty="format:%cI" test/boulder-tools/) +%s)
+if [ $lastBuild -le $lastMod ]
+then
+  docker compose build
+fi
+
+exec docker compose -f docker-compose.yml -f docker-compose.next.yml run boulder ./test.sh "$@"


### PR DESCRIPTION
It turns out that, even with a "build:" stanza in docker-compose.yml, the various docker compose commands won't automatically rebuild the container image unless no such image exists in the local cache. To encourage docker compose to rebuild the image when there are changes to the dockerfile, add the --build flag to our docker compose run command.