### PR TITLE
Issuance: carry SKID forward from precert

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -2,8 +2,13 @@ package ca
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -344,6 +349,32 @@ func (ca *certificateAuthorityImpl) generateSerialNumberAndValidity() (*big.Int,
 	return serialBigInt, validity, nil
 }
 
+func generateSKID(pk crypto.PublicKey) ([]byte, error) {
+	pkBytes, err := x509.MarshalPKIXPublicKey(pk)
+	if err != nil {
+		return nil, err
+	}
+	var pkixPublicKey struct {
+		Algo      pkix.AlgorithmIdentifier
+		BitString asn1.BitString
+	}
+	if _, err := asn1.Unmarshal(pkBytes, &pkixPublicKey); err != nil {
+		return nil, err
+	}
+
+	if features.Get().SHA256SubjectKeyIdentifier {
+		// RFC 7093 Section 2 Additional Methods for Generating Key Identifiers:
+		// The keyIdentifier [may be] composed of the leftmost 160-bits of the
+		// SHA-256 hash of the value of the BIT STRING subjectPublicKey
+		// (excluding the tag, length, and number of unused bits).
+		skid := sha256.Sum256(pkixPublicKey.BitString.Bytes)
+		return skid[0:20:20], nil
+	} else {
+		skid := sha1.Sum(pkixPublicKey.BitString.Bytes)
+		return skid[:], nil
+	}
+}
+
 func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, serialBigInt *big.Int, validity validity) ([]byte, *issuance.Issuer, error) {
 	csr, err := x509.ParseCertificateRequest(issueReq.Csr)
 	if err != nil {
@@ -385,6 +416,11 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		return nil, nil, err
 	}
 
+	subjectKeyId, err := generateSKID(csr.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("computing subject key ID: %w", err)
+	}
+
 	serialHex := core.SerialToString(serialBigInt)
 
 	ca.log.AuditInfof("Signing precert: serial=[%s] regID=[%d] names=[%s] csr=[%s]",
@@ -393,6 +429,7 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 	names := csrlib.NamesFromCSR(csr)
 	req := &issuance.IssuanceRequest{
 		PublicKey:         csr.PublicKey,
+		SubjectKeyId:      subjectKeyId,
 		Serial:            serialBigInt.Bytes(),
 		DNSNames:          names.SANs,
 		CommonName:        names.CN,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -3,6 +3,9 @@ package ca
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -889,4 +892,26 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 	if !strings.Contains(err.Error(), "error checking for duplicate") {
 		t.Fatalf("Wrong type of error issuing duplicate serial. Expected 'error checking for duplicate', got '%s'", err)
 	}
+}
+
+func TestGenerateSKID(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "Error generating key")
+
+	features.Set(features.Config{SHA256SubjectKeyIdentifier: true})
+	defer features.Reset()
+	// RFC 7093 section 2 method 1 allows us to use 160 of the leftmost bits for
+	// the Subject Key Identifier. This is the same amount of bits as the
+	// related SHA1 hash.
+	sha256skid, err := generateSKID(key.Public())
+	test.AssertNotError(t, err, "Error generating SKID")
+	test.AssertEquals(t, len(sha256skid), 20)
+	test.AssertEquals(t, cap(sha256skid), 20)
+	features.Reset()
+
+	features.Set(features.Config{SHA256SubjectKeyIdentifier: false})
+	sha1skid, err := generateSKID(key.Public())
+	test.AssertNotError(t, err, "Error generating SKID")
+	test.AssertEquals(t, len(sha1skid), 20)
+	test.AssertEquals(t, cap(sha1skid), 20)
 }

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -88,7 +88,7 @@ func (p *Profile) requestValid(clk clock.Clock, req *IssuanceRequest) error {
 		return errors.New("unsupported public key type")
 	}
 
-	if req.SubjectKeyID != nil && len(req.SubjectKeyID) != 20 {
+	if req.SubjectKeyId != nil && len(req.SubjectKeyId) != 20 {
 		return errors.New("unexpected subject key ID length")
 	}
 
@@ -234,7 +234,7 @@ func generateSKID(pk crypto.PublicKey) ([]byte, error) {
 // IssuanceRequest describes a certificate issuance request
 type IssuanceRequest struct {
 	PublicKey    crypto.PublicKey
-	SubjectKeyID []byte
+	SubjectKeyId []byte
 
 	Serial []byte
 
@@ -293,8 +293,8 @@ func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 	}
 	template.DNSNames = req.DNSNames
 
-	if req.SubjectKeyID != nil {
-		template.SubjectKeyId = req.SubjectKeyID
+	if req.SubjectKeyId != nil {
+		template.SubjectKeyId = req.SubjectKeyId
 	} else {
 		skid, err := generateSKID(req.PublicKey)
 		if err != nil {
@@ -396,7 +396,7 @@ func RequestFromPrecert(precert *x509.Certificate, scts []ct.SignedCertificateTi
 	}
 	return &IssuanceRequest{
 		PublicKey:         precert.PublicKey,
-		SubjectKeyID:      precert.SubjectKeyId,
+		SubjectKeyId:      precert.SubjectKeyId,
 		Serial:            precert.SerialNumber.Bytes(),
 		NotBefore:         precert.NotBefore,
 		NotAfter:          precert.NotAfter,

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -220,6 +220,21 @@ func TestRequestValid(t *testing.T) {
 			expectedError: "serial must be between 9 and 19 bytes",
 		},
 		{
+			name: "skid too short",
+			profile: &Profile{
+				useForECDSALeaves: true,
+				maxValidity:       time.Hour * 2,
+			},
+			request: &IssuanceRequest{
+				PublicKey:    &ecdsa.PublicKey{},
+				SubjectKeyID: []byte{0, 1, 2, 3, 4},
+				NotBefore:    fc.Now(),
+				NotAfter:     fc.Now().Add(time.Hour),
+				Serial:       []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			},
+			expectedError: "unexpected subject key ID length",
+		},
+		{
 			name: "good",
 			profile: &Profile{
 				useForECDSALeaves: true,
@@ -230,6 +245,20 @@ func TestRequestValid(t *testing.T) {
 				NotBefore: fc.Now(),
 				NotAfter:  fc.Now().Add(time.Hour),
 				Serial:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			},
+		},
+		{
+			name: "good with skid",
+			profile: &Profile{
+				useForECDSALeaves: true,
+				maxValidity:       time.Hour * 2,
+			},
+			request: &IssuanceRequest{
+				PublicKey:    &ecdsa.PublicKey{},
+				SubjectKeyID: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+				NotBefore:    fc.Now(),
+				NotAfter:     fc.Now().Add(time.Hour),
+				Serial:       []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 			},
 		},
 	}

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -227,7 +227,7 @@ func TestRequestValid(t *testing.T) {
 			},
 			request: &IssuanceRequest{
 				PublicKey:    &ecdsa.PublicKey{},
-				SubjectKeyID: []byte{0, 1, 2, 3, 4},
+				SubjectKeyId: []byte{0, 1, 2, 3, 4},
 				NotBefore:    fc.Now(),
 				NotAfter:     fc.Now().Add(time.Hour),
 				Serial:       []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
@@ -255,7 +255,7 @@ func TestRequestValid(t *testing.T) {
 			},
 			request: &IssuanceRequest{
 				PublicKey:    &ecdsa.PublicKey{},
-				SubjectKeyID: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+				SubjectKeyId: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				NotBefore:    fc.Now(),
 				NotAfter:     fc.Now().Add(time.Hour),
 				Serial:       []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},


### PR DESCRIPTION
Rather than regenerating the Subject Key ID during both precertificate and final certificate issuance, carry the SKID forward from the precert to the final cert. This ensures that the SKID remains stable between the precert and final cert, even when the method for computing the SKID is updated in the middle of certificate finalization.

Additionally, to ensure that the IssuanceRequest -> Certificate conversion process is nearly identical for both precerts and final certs, move SKID computation out of the issuance package and into the CA, so that the SKID is always supplied as part of the issuance request and the issuance package itself doesn't have conditionals or feature flags regarding this behavior.