### PR TITLE
health-checker: bail early on handshake failure

### DIFF
--- a/test/config-next/health-checker.json
+++ b/test/config-next/health-checker.json
@@ -1,6 +1,7 @@
 {
 	"grpc": {
-		"timeout": "1s"
+		"timeout": "1s",
+		"noWaitForReady": true
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config/health-checker.json
+++ b/test/config/health-checker.json
@@ -1,6 +1,7 @@
 {
 	"grpc": {
-		"timeout": "1s"
+		"timeout": "1s",
+		"noWaitForReady": true
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/health-checker/main.go
+++ b/test/health-checker/main.go
@@ -78,6 +78,9 @@ func main() {
 			}
 			resp, err := client.Check(ctx2, req)
 			if err != nil {
+				if strings.Contains(err.Error(), "authentication handshake failed") {
+					cmd.Fail(fmt.Sprintf("error connecting to health service %s: %s\n", *serverAddr, err))
+				}
 				fmt.Fprintf(os.Stderr, "got error connecting to health service %s: %s\n", *serverAddr, err)
 			} else if resp.Status == healthpb.HealthCheckResponse_SERVING {
 				return


### PR DESCRIPTION
When we have a problem with our authentication certificates, it's better to get a clear error early than to wait for health checker to time out.

Also, set noWaitForReady in the config, which prevents detailed errors from being obscured by "timed out" errors.