### PR TITLE
Run more go vet checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,11 @@ linters-settings:
     checks: ["all", "-S1029"]
   govet:
     enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
+      - nilness
+      - unusedwrite
     settings:
       printf:
         funcs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters-settings:
     # S1029: Range over the string directly
     checks: ["all", "-S1029"]
   govet:
+    enable-all: true
     settings:
       printf:
         funcs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,6 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
-      - nilness
     settings:
       printf:
         funcs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters-settings:
       - fieldalignment
       - shadow
       - nilness
-      - unusedwrite
     settings:
       printf:
         funcs:

--- a/cmd/admin-revoker/main.go
+++ b/cmd/admin-revoker/main.go
@@ -185,9 +185,6 @@ func (r *revoker) revokeSerialBatchFile(ctx context.Context, serialPath string, 
 	}
 
 	scanner := bufio.NewScanner(file)
-	if err != nil {
-		return err
-	}
 
 	wg := new(sync.WaitGroup)
 	work := make(chan string, parallelism)

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -256,7 +256,7 @@ func TestFailExit(t *testing.T) {
 
 func testPanicStackTraceHelper() {
 	var x *int
-	*x = 1
+	*x = 1 //nolint:govet
 }
 
 func TestPanicStackTrace(t *testing.T) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3265,11 +3265,11 @@ func TestUpdateMissingAuthorization(t *testing.T) {
 	test.AssertNotError(t, err, "failed to deserialize authz")
 
 	// Twiddle the authz to pretend its been validated by the VA
-	authz.Status = "valid"
 	authz.Challenges[0].Status = "valid"
 	err = ra.recordValidation(ctx, authz.ID, authz.Expires, &authz.Challenges[0])
 	test.AssertNotError(t, err, "ra.recordValidation failed")
 
+	// Try to record the same validation a second time.
 	err = ra.recordValidation(ctx, authz.ID, authz.Expires, &authz.Challenges[0])
 	test.AssertError(t, err, "ra.recordValidation didn't fail")
 	test.AssertErrorIs(t, err, berrors.NotFound)

--- a/test/load-generator/acme/challenge_test.go
+++ b/test/load-generator/acme/challenge_test.go
@@ -50,12 +50,12 @@ func TestNewChallengeStrategy(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			strategy, err := NewChallengeStrategy(tc.InputName)
-			if err == nil && tc.ExpectedError != "" {
+			if err == nil && tc.ExpectedError == "" {
+				test.AssertEquals(t, fmt.Sprintf("%T", strategy), tc.ExpectedStratType)
+			} else if err == nil && tc.ExpectedError != "" {
 				t.Errorf("Expected %q got no error\n", tc.ExpectedError)
 			} else if err != nil {
 				test.AssertEquals(t, err.Error(), tc.ExpectedError)
-			} else if err == nil && tc.ExpectedError == "" {
-				test.AssertEquals(t, fmt.Sprintf("%T", strategy), tc.ExpectedStratType)
 			}
 		})
 	}
@@ -126,12 +126,12 @@ func TestPickChallenge(t *testing.T) {
 			strategy, err := NewChallengeStrategy(tc.StratName)
 			test.AssertNotError(t, err, "Failed to create challenge strategy")
 			chall, err := strategy.PickChallenge(tc.InputAuthz)
-			if err == nil && tc.ExpectedError != "" {
+			if err == nil && tc.ExpectedError == "" {
+				test.AssertDeepEquals(t, chall, tc.ExpectedChallenge)
+			} else if err == nil && tc.ExpectedError != "" {
 				t.Errorf("Expected %q got no error\n", tc.ExpectedError)
 			} else if err != nil {
 				test.AssertEquals(t, err.Error(), tc.ExpectedError)
-			} else if err == nil && tc.ExpectedError == "" {
-				test.AssertDeepEquals(t, chall, tc.ExpectedChallenge)
 			}
 		})
 	}

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -260,9 +260,6 @@ func (s *State) Restore(filename string) error {
 		if err != nil {
 			continue
 		}
-		if err != nil {
-			continue
-		}
 		s.accts = append(s.accts, &account{
 			key:             key,
 			id:              a.ID,

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -90,7 +90,7 @@ func (va *ValidationAuthorityImpl) tryGetChallengeCert(ctx context.Context,
 		cert, cs, prob := va.getChallengeCert(ctx, address, identifier, challenge, tlsConfig)
 
 		// If there is no problem, return immediately
-		if err == nil {
+		if prob == nil {
 			return cert, cs, validationRecords, prob
 		}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3009,9 +3009,6 @@ func makeRevokeRequestJSON(reason *revocation.Reason) ([]byte, error) {
 		return nil, err
 	}
 	certBlock, _ := pem.Decode(certPemBytes)
-	if err != nil {
-		return nil, err
-	}
 	return makeRevokeRequestJSONForCert(certBlock.Bytes, reason)
 }
 


### PR DESCRIPTION
Enable the atomicalign, deepequalerrors, findcall, nilness, reflectvaluecompare, sortslice, timeformat, and unusedwrite go vet analyzers, which golangci-lint does not enable by default. Additionally, enable new go vet analyzers by default as they become available.

The fieldalignment and shadow analyzers remain disabled because they report so many errors that they should be fixed in a separate PR.

Note that the nilness analyzer appears to have found one very real bug in tlsalpn.go.