### PR TITLE
test: dont overlap ca2 and va2 debug ports

### DIFF
--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -130,9 +130,9 @@ def check_balance():
         "publisher1.service.consul:8009",
         "publisher2.service.consul:8109",
         "va1.service.consul:8004",
-        "va2.service.consul:8104",
+        "va2.service.consul:8101",
         "ca1.service.consul:8001",
-        "ca2.service.consul:8104",
+        "ca2.service.consul:8105",
         "ra1.service.consul:8002",
         "ra2.service.consul:8102",
     ]


### PR DESCRIPTION
[PR 7246](https://github.com/letsencrypt/boulder/pull/7246) introduced using different ports for instances of the same service. CA2 and VA2 accidentally configured the same debug port and caused random CI flakes.