### PR TITLE
Remove fallbacks from IssuerNameID to IssuerID

### DIFF
--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -49,7 +49,7 @@ func TestOCSP(t *testing.T) {
 	ocspi := testCtx.ocsp
 
 	// Issue a certificate from the RSA issuer caCert, then check OCSP comes from the same issuer.
-	rsaIssuerID := ca.issuers.byAlg[x509.RSA].ID()
+	rsaIssuerID := ca.issuers.byAlg[x509.RSA].Cert.NameID()
 	rsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	rsaCert, err := x509.ParseCertificate(rsaCertPB.DER)
@@ -67,7 +67,7 @@ func TestOCSP(t *testing.T) {
 	test.AssertEquals(t, rsaOCSP.SerialNumber.Cmp(rsaCert.SerialNumber), 0)
 
 	// Issue a certificate from the ECDSA issuer caCert2, then check OCSP comes from the same issuer.
-	ecdsaIssuerID := ca.issuers.byAlg[x509.ECDSA].ID()
+	ecdsaIssuerID := ca.issuers.byAlg[x509.ECDSA].Cert.NameID()
 	ecdsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	ecdsaCert, err := x509.ParseCertificate(ecdsaCertPB.DER)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3805,9 +3805,6 @@ func TestRevokeCertByApplicant_Subscriber(t *testing.T) {
 	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
 		ic.NameID(): ic,
 	}
-	ra.issuersByID = map[issuance.IssuerID]*issuance.Certificate{
-		ic.ID(): ic,
-	}
 	ra.SA = newMockSARevocation(cert, clk)
 
 	// Revoking without a regID should fail.
@@ -3859,9 +3856,6 @@ func TestRevokeCertByApplicant_Controller(t *testing.T) {
 	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
 		ic.NameID(): ic,
 	}
-	ra.issuersByID = map[issuance.IssuerID]*issuance.Certificate{
-		ic.ID(): ic,
-	}
 	mockSA := newMockSARevocation(cert, clk)
 	ra.SA = mockSA
 
@@ -3899,9 +3893,6 @@ func TestRevokeCertByKey(t *testing.T) {
 	test.AssertNotError(t, err, "failed to create issuer cert")
 	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
 		ic.NameID(): ic,
-	}
-	ra.issuersByID = map[issuance.IssuerID]*issuance.Certificate{
-		ic.ID(): ic,
 	}
 	mockSA := newMockSARevocation(cert, clk)
 	ra.SA = mockSA
@@ -3952,9 +3943,6 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	test.AssertNotError(t, err, "failed to create issuer cert")
 	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
 		ic.NameID(): ic,
-	}
-	ra.issuersByID = map[issuance.IssuerID]*issuance.Certificate{
-		ic.ID(): ic,
 	}
 	mockSA := newMockSARevocation(cert, clk)
 	ra.SA = mockSA

--- a/rocsp/config/issuers_test.go
+++ b/rocsp/config/issuers_test.go
@@ -96,22 +96,8 @@ func TestFindIssuerByID(t *testing.T) {
 	}
 	test.AssertEquals(t, issuer.shortID, uint8(23))
 
-	// an IssuerID
-	issuer, err = FindIssuerByID(2823400738, issuers)
-	if err != nil {
-		t.Fatalf("couldn't find issuer: %s", err)
-	}
-	test.AssertEquals(t, issuer.shortID, uint8(23))
-
 	// an IssuerNameID
 	issuer, err = FindIssuerByID(58923463773186183, issuers)
-	if err != nil {
-		t.Fatalf("couldn't find issuer: %s", err)
-	}
-	test.AssertEquals(t, issuer.shortID, uint8(99))
-
-	// an IssuerID
-	issuer, err = FindIssuerByID(2890189813, issuers)
 	if err != nil {
 		t.Fatalf("couldn't find issuer: %s", err)
 	}

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -227,7 +227,7 @@ func (si *ShortIDIssuer) ShortID() byte {
 // FindIssuerByID returns the issuer that matches the given IssuerID or IssuerNameID.
 func FindIssuerByID(longID int64, issuers []ShortIDIssuer) (*ShortIDIssuer, error) {
 	for _, iss := range issuers {
-		if iss.NameID() == issuance.IssuerNameID(longID) || iss.ID() == issuance.IssuerID(longID) {
+		if iss.NameID() == issuance.IssuerNameID(longID) {
 			return &iss, nil
 		}
 	}

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -224,7 +224,7 @@ func (si *ShortIDIssuer) ShortID() byte {
 	return si.shortID
 }
 
-// FindIssuerByID returns the issuer that matches the given IssuerID or IssuerNameID.
+// FindIssuerByID returns the issuer that matches the given IssuerNameID.
 func FindIssuerByID(longID int64, issuers []ShortIDIssuer) (*ShortIDIssuer, error) {
 	for _, iss := range issuers {
 		if iss.NameID() == issuance.IssuerNameID(longID) {


### PR DESCRIPTION
The last rows using the old-style IssuerID were written to the database in late 2021. Those rows have long since aged out -- we no longer serve certificates or revocation information for them -- so we can remove the code which handles those old-style IDs. This allows for some nice simplifications in the CA's ocspImpl and in the Issuance package, which will be useful for further reorganization of the CA and issuance packages.

Fixes https://github.com/letsencrypt/boulder/issues/5152