### PR TITLE
Simplify issuance.NameID and how it is used

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -307,7 +307,7 @@ func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 	})
 	if err != nil {
 		ca.log.AuditErrf("Failed RPC to store at SA: serial=[%s], cert=[%s], issuerID=[%d], regID=[%d], orderID=[%d], err=[%v]",
-			serialHex, hex.EncodeToString(certDER), int64(issuer.NameID()), req.RegistrationID, req.OrderID, err)
+			serialHex, hex.EncodeToString(certDER), issuer.NameID(), req.RegistrationID, req.OrderID, err)
 		return nil, err
 	}
 

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -50,7 +50,7 @@ const (
 // issuer based on the issuer of a given (pre)certificate.
 type issuerMaps struct {
 	byAlg    map[x509.PublicKeyAlgorithm]*issuance.Issuer
-	byNameID map[issuance.IssuerNameID]*issuance.Issuer
+	byNameID map[issuance.NameID]*issuance.Issuer
 }
 
 // certificateAuthorityImpl represents a CA that signs certificates.
@@ -82,7 +82,7 @@ type certificateAuthorityImpl struct {
 // the input list "wins".
 func makeIssuerMaps(issuers []*issuance.Issuer) issuerMaps {
 	issuersByAlg := make(map[x509.PublicKeyAlgorithm]*issuance.Issuer, 2)
-	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Issuer, len(issuers))
+	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer, len(issuers))
 	for _, issuer := range issuers {
 		for _, alg := range issuer.Algs() {
 			// TODO(#5259): Enforce that there is only one issuer for each algorithm,
@@ -91,7 +91,7 @@ func makeIssuerMaps(issuers []*issuance.Issuer) issuerMaps {
 				issuersByAlg[alg] = issuer
 			}
 		}
-		issuersByNameID[issuer.Cert.NameID()] = issuer
+		issuersByNameID[issuer.NameID()] = issuer
 	}
 	return issuerMaps{issuersByAlg, issuersByNameID}
 }
@@ -266,7 +266,7 @@ func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 		scts = append(scts, sct)
 	}
 
-	issuer, ok := ca.issuers.byNameID[issuance.GetIssuerNameID(precert)]
+	issuer, ok := ca.issuers.byNameID[issuance.IssuerNameID(precert)]
 	if !ok {
 		return nil, berrors.InternalServerError("no issuer found for Issuer Name %s", precert.Issuer)
 	}
@@ -307,7 +307,7 @@ func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 	})
 	if err != nil {
 		ca.log.AuditErrf("Failed RPC to store at SA: serial=[%s], cert=[%s], issuerID=[%d], regID=[%d], orderID=[%d], err=[%v]",
-			serialHex, hex.EncodeToString(certDER), int64(issuer.Cert.NameID()), req.RegistrationID, req.OrderID, err)
+			serialHex, hex.EncodeToString(certDER), int64(issuer.NameID()), req.RegistrationID, req.OrderID, err)
 		return nil, err
 	}
 
@@ -404,7 +404,7 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 			return nil, nil, berrors.InternalServerError("no issuer found for public key algorithm %s", csr.PublicKeyAlgorithm)
 		}
 	} else {
-		issuer, ok = ca.issuers.byNameID[issuance.IssuerNameID(issueReq.IssuerNameID)]
+		issuer, ok = ca.issuers.byNameID[issuance.NameID(issueReq.IssuerNameID)]
 		if !ok {
 			return nil, nil, berrors.InternalServerError("no issuer found for IssuerNameID %d", issueReq.IssuerNameID)
 		}
@@ -453,7 +453,7 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		Der:          lintCertBytes,
 		RegID:        issueReq.RegistrationID,
 		Issued:       timestamppb.New(ca.clk.Now()),
-		IssuerNameID: int64(issuer.Cert.NameID()),
+		IssuerNameID: int64(issuer.NameID()),
 		OcspNotReady: true,
 	})
 	if err != nil {

--- a/ca/crl_test.go
+++ b/ca/crl_test.go
@@ -96,7 +96,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].Cert.NameID()),
+				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 			},
 		},
@@ -104,7 +104,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].Cert.NameID()),
+				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 			},
 		},
@@ -174,7 +174,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].Cert.NameID()),
+				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 			},
 		},
@@ -210,7 +210,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].Cert.NameID()),
+				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 			},
 		},

--- a/ca/ocsp.go
+++ b/ca/ocsp.go
@@ -23,7 +23,7 @@ import (
 // ocspImpl provides a backing implementation for the OCSP gRPC service.
 type ocspImpl struct {
 	capb.UnimplementedOCSPGeneratorServer
-	issuers        map[issuance.IssuerNameID]*issuance.Issuer
+	issuers        map[issuance.NameID]*issuance.Issuer
 	ocspLifetime   time.Duration
 	ocspLogQueue   *ocspLogQueue
 	log            blog.Logger
@@ -43,9 +43,9 @@ func NewOCSPImpl(
 	signErrorCount *prometheus.CounterVec,
 	clk clock.Clock,
 ) (*ocspImpl, error) {
-	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Issuer, len(issuers))
+	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer, len(issuers))
 	for _, issuer := range issuers {
-		issuersByNameID[issuer.Cert.NameID()] = issuer
+		issuersByNameID[issuer.NameID()] = issuer
 	}
 
 	if ocspLifetime < 8*time.Hour || ocspLifetime > 7*24*time.Hour {
@@ -100,7 +100,7 @@ func (oi *ocspImpl) GenerateOCSP(ctx context.Context, req *capb.GenerateOCSPRequ
 	}
 	serial := serialInt
 
-	issuer, ok := oi.issuers[issuance.IssuerNameID(req.IssuerID)]
+	issuer, ok := oi.issuers[issuance.NameID(req.IssuerID)]
 	if !ok {
 		return nil, fmt.Errorf("unrecognized issuer ID %d", req.IssuerID)
 	}

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -49,7 +49,7 @@ func TestOCSP(t *testing.T) {
 	ocspi := testCtx.ocsp
 
 	// Issue a certificate from the RSA issuer caCert, then check OCSP comes from the same issuer.
-	rsaIssuerID := ca.issuers.byAlg[x509.RSA].Cert.NameID()
+	rsaIssuerID := ca.issuers.byAlg[x509.RSA].NameID()
 	rsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	rsaCert, err := x509.ParseCertificate(rsaCertPB.DER)
@@ -67,7 +67,7 @@ func TestOCSP(t *testing.T) {
 	test.AssertEquals(t, rsaOCSP.SerialNumber.Cmp(rsaCert.SerialNumber), 0)
 
 	// Issue a certificate from the ECDSA issuer caCert2, then check OCSP comes from the same issuer.
-	ecdsaIssuerID := ca.issuers.byAlg[x509.ECDSA].Cert.NameID()
+	ecdsaIssuerID := ca.issuers.byAlg[x509.ECDSA].NameID()
 	ecdsaCertPB, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	ecdsaCert, err := x509.ParseCertificate(ecdsaCertPB.DER)

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -73,7 +73,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	bundles := make(map[issuance.IssuerNameID][]ct.ASN1Cert)
+	bundles := make(map[issuance.NameID][]ct.ASN1Cert)
 	for _, files := range c.Publisher.Chains {
 		chain, err := issuance.LoadChain(files)
 		cmd.FailOnError(err, "failed to load chain.")

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -300,8 +300,8 @@ func main() {
 		c.WFE.DebugAddr = *debugAddr
 	}
 
-	certChains := map[issuance.IssuerNameID][][]byte{}
-	issuerCerts := map[issuance.IssuerNameID]*issuance.Certificate{}
+	certChains := map[issuance.NameID][][]byte{}
+	issuerCerts := map[issuance.NameID]*issuance.Certificate{}
 	if c.WFE.Chains == nil {
 		cmd.Fail("'chains' must be configured")
 	}

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -302,9 +302,6 @@ func main() {
 
 	certChains := map[issuance.NameID][][]byte{}
 	issuerCerts := map[issuance.NameID]*issuance.Certificate{}
-	if c.WFE.Chains == nil {
-		cmd.Fail("'chains' must be configured")
-	}
 	for _, files := range c.WFE.Chains {
 		issuer, chain, err := loadChain(files)
 		cmd.FailOnError(err, "Failed to load chain")

--- a/crl/crl.go
+++ b/crl/crl.go
@@ -30,11 +30,11 @@ func Number(thisUpdate time.Time) number {
 type id string
 
 // Id is a utility function which constructs a new `id`.
-func Id(issuerID issuance.IssuerNameID, shardIdx int, crlNumber number) id {
+func Id(issuerID issuance.NameID, shardIdx int, crlNumber number) id {
 	type info struct {
-		IssuerID  issuance.IssuerNameID `json:"issuerID"`
-		ShardIdx  int                   `json:"shardIdx"`
-		CRLNumber number                `json:"crlNumber"`
+		IssuerID  issuance.NameID `json:"issuerID"`
+		ShardIdx  int             `json:"shardIdx"`
+		CRLNumber number          `json:"crlNumber"`
 	}
 	jsonBytes, err := json.Marshal(info{issuerID, shardIdx, crlNumber})
 	if err != nil {

--- a/crl/storer/storer.go
+++ b/crl/storer/storer.go
@@ -38,7 +38,7 @@ type crlStorer struct {
 	cspb.UnimplementedCRLStorerServer
 	s3Client         simpleS3
 	s3Bucket         string
-	issuers          map[issuance.IssuerNameID]*issuance.Certificate
+	issuers          map[issuance.NameID]*issuance.Certificate
 	uploadCount      *prometheus.CounterVec
 	sizeHistogram    *prometheus.HistogramVec
 	latencyHistogram *prometheus.HistogramVec
@@ -54,7 +54,7 @@ func New(
 	log blog.Logger,
 	clk clock.Clock,
 ) (*crlStorer, error) {
-	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Certificate, len(issuers))
+	issuersByNameID := make(map[issuance.NameID]*issuance.Certificate, len(issuers))
 	for _, issuer := range issuers {
 		issuersByNameID[issuer.NameID()] = issuer
 	}
@@ -126,7 +126,7 @@ func (cs *crlStorer) UploadCRL(stream cspb.CRLStorer_UploadCRLServer) error {
 			crlNumber = crl.Number(time.Unix(0, payload.Metadata.Number))
 
 			var ok bool
-			issuer, ok = cs.issuers[issuance.IssuerNameID(payload.Metadata.IssuerNameID)]
+			issuer, ok = cs.issuers[issuance.NameID(payload.Metadata.IssuerNameID)]
 			if !ok {
 				return fmt.Errorf("got unrecognized IssuerID: %d", payload.Metadata.IssuerNameID)
 			}

--- a/crl/updater/batch.go
+++ b/crl/updater/batch.go
@@ -16,7 +16,7 @@ func (cu *crlUpdater) RunOnce(ctx context.Context) error {
 	atTime := cu.clk.Now()
 
 	type workItem struct {
-		issuerNameID issuance.IssuerNameID
+		issuerNameID issuance.NameID
 		shardIdx     int
 	}
 

--- a/crl/updater/continuous.go
+++ b/crl/updater/continuous.go
@@ -16,7 +16,7 @@ import (
 func (cu *crlUpdater) Run(ctx context.Context) error {
 	var wg sync.WaitGroup
 
-	shardWorker := func(issuerNameID issuance.IssuerNameID, shardIdx int) {
+	shardWorker := func(issuerNameID issuance.NameID, shardIdx int) {
 		defer wg.Done()
 
 		// Wait for a random number of nanoseconds less than the updatePeriod, so

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -25,7 +25,7 @@ import (
 )
 
 type crlUpdater struct {
-	issuers        map[issuance.IssuerNameID]*issuance.Certificate
+	issuers        map[issuance.NameID]*issuance.Certificate
 	numShards      int
 	shardWidth     time.Duration
 	lookbackPeriod time.Duration
@@ -61,7 +61,7 @@ func NewUpdater(
 	log blog.Logger,
 	clk clock.Clock,
 ) (*crlUpdater, error) {
-	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Certificate, len(issuers))
+	issuersByNameID := make(map[issuance.NameID]*issuance.Certificate, len(issuers))
 	for _, issuer := range issuers {
 		issuersByNameID[issuer.NameID()] = issuer
 	}
@@ -124,7 +124,7 @@ func NewUpdater(
 
 // updateShardWithRetry calls updateShard repeatedly (with exponential backoff
 // between attempts) until it succeeds or the max number of attempts is reached.
-func (cu *crlUpdater) updateShardWithRetry(ctx context.Context, atTime time.Time, issuerNameID issuance.IssuerNameID, shardIdx int, chunks []chunk) error {
+func (cu *crlUpdater) updateShardWithRetry(ctx context.Context, atTime time.Time, issuerNameID issuance.NameID, shardIdx int, chunks []chunk) error {
 	ctx, cancel := context.WithTimeout(ctx, cu.updateTimeout)
 	defer cancel()
 	deadline, _ := ctx.Deadline()
@@ -187,7 +187,7 @@ func (cu *crlUpdater) updateShardWithRetry(ctx context.Context, atTime time.Time
 // the list of revoked certs in that shard from the SA, gets the CA to sign the
 // resulting CRL, and gets the crl-storer to upload it. It returns an error if
 // any of these operations fail.
-func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerNameID issuance.IssuerNameID, shardIdx int, chunks []chunk) (err error) {
+func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerNameID issuance.NameID, shardIdx int, chunks []chunk) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -20,8 +20,28 @@ import (
 	ctx509 "github.com/google/certificate-transparency-go/x509"
 	"github.com/jmhodges/clock"
 
+	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/precert"
 )
+
+// ProfileConfig describes the certificate issuance constraints for all issuers.
+type ProfileConfig struct {
+	AllowMustStaple bool
+	AllowCTPoison   bool
+	AllowSCTList    bool
+	AllowCommonName bool
+
+	MaxValidityPeriod   config.Duration
+	MaxValidityBackdate config.Duration
+
+	// Deprecated: we do not respect this field.
+	Policies []PolicyConfig `validate:"-"`
+}
+
+// PolicyConfig describes a policy
+type PolicyConfig struct {
+	OID string `validate:"required"`
+}
 
 // Profile is the validated structure created by reading in ProfileConfigs and IssuerConfigs
 type Profile struct {

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -15,31 +15,139 @@ import (
 	"github.com/jmhodges/clock"
 	"golang.org/x/crypto/ocsp"
 
-	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/linter"
 	"github.com/letsencrypt/boulder/privatekey"
 	"github.com/letsencrypt/pkcs11key/v4"
 )
 
-// ProfileConfig describes the certificate issuance constraints for all issuers.
-type ProfileConfig struct {
-	AllowMustStaple bool
-	AllowCTPoison   bool
-	AllowSCTList    bool
-	AllowCommonName bool
+// ----- Name ID -----
 
-	MaxValidityPeriod   config.Duration
-	MaxValidityBackdate config.Duration
+// NameID is a statistically-unique small ID which can be computed from
+// both CA and end-entity certs to link them together into a validation chain.
+// It is computed as a truncated hash over the issuer Subject Name bytes, or
+// over the end-entity's Issuer Name bytes, which are required to be equal.
+type NameID int64
 
-	// Deprecated: we do not respect this field.
-	Policies []PolicyConfig `validate:"-"`
+// SubjectNameID returns the NameID (a truncated hash over the raw bytes of a
+// Distinguished Name) of this issuer certificate's Subject. Useful for storing
+// as a lookup key in contexts that don't expect hash collisions.
+func SubjectNameID(ic *Certificate) NameID {
+	return truncatedHash(ic.RawSubject)
 }
 
-// PolicyConfig describes a policy
-type PolicyConfig struct {
-	OID string `validate:"required"`
+// IssuerNameID returns the IssuerNameID (a truncated hash over the raw bytes
+// of the Issuer Distinguished Name) of the given end-entity certificate.
+// Useful for performing lookups in contexts that don't expect hash collisions.
+func IssuerNameID(ee *x509.Certificate) NameID {
+	return truncatedHash(ee.RawIssuer)
 }
+
+// ResponderNameID returns the NameID (a truncated hash over the raw
+// bytes of the Responder Distinguished Name) of the given OCSP Response.
+// As per the OCSP spec, it is technically possible for this field to not be
+// populated: the OCSP Response can instead contain a SHA-1 hash of the Issuer
+// Public Key as the Responder ID. However, all OCSP responses that we produce
+// contain it, because the Go stdlib always includes it.
+func ResponderNameID(resp *ocsp.Response) NameID {
+	return truncatedHash(resp.RawResponderName)
+}
+
+// truncatedHash computes a truncated SHA1 hash across arbitrary bytes. Uses
+// SHA1 because that is the algorithm most commonly used in OCSP requests.
+// PURPOSEFULLY NOT EXPORTED. Exists only to ensure that the implementations of
+// SubjectNameID(), IssuerNameID(), and ResponderNameID never diverge. Use those
+// instead.
+func truncatedHash(name []byte) NameID {
+	h := crypto.SHA1.New()
+	h.Write(name)
+	s := h.Sum(nil)
+	return NameID(big.NewInt(0).SetBytes(s[:7]).Int64())
+}
+
+// ----- Issuer Certificates -----
+
+// Certificate embeds an *x509.Certificate and represents the added semantics
+// that this certificate is a CA certificate.
+type Certificate struct {
+	*x509.Certificate
+	// nameID is stored here simply for the sake of precomputation.
+	nameID NameID
+}
+
+// NameID is equivalent to SubjectNameID(ic), but faster because it is
+// precomputed.
+func (ic *Certificate) NameID() NameID {
+	return ic.nameID
+}
+
+// NewCertificate wraps an in-memory cert in an issuance.Certificate, marking it
+// as an issuer cert. It may fail if the certificate does not contain the
+// attributes expected of an issuer certificate.
+func NewCertificate(ic *x509.Certificate) (*Certificate, error) {
+	if !ic.IsCA {
+		return nil, errors.New("certificate is not a CA certificate")
+	}
+
+	res := Certificate{ic, 0}
+	res.nameID = SubjectNameID(&res)
+	return &res, nil
+}
+
+func LoadCertificate(path string) (*Certificate, error) {
+	cert, err := core.LoadCert(path)
+	if err != nil {
+		return nil, err
+	}
+	return NewCertificate(cert)
+}
+
+// LoadChain takes a list of filenames containing pem-formatted certificates,
+// and returns a chain representing all of those certificates in order. It
+// ensures that the resulting chain is valid. The final file is expected to be
+// a root certificate, which the chain will be verified against, but which will
+// not be included in the resulting chain.
+func LoadChain(certFiles []string) ([]*Certificate, error) {
+	if len(certFiles) < 2 {
+		return nil, errors.New(
+			"each chain must have at least two certificates: an intermediate and a root")
+	}
+
+	// Pre-load all the certificates to make validation easier.
+	certs := make([]*Certificate, len(certFiles))
+	var err error
+	for i := 0; i < len(certFiles); i++ {
+		certs[i], err = LoadCertificate(certFiles[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to load certificate %q: %w", certFiles[i], err)
+		}
+	}
+
+	// Iterate over all certs except for the last, checking that their signature
+	// comes from the next cert in the list.
+	chain := make([]*Certificate, len(certFiles)-1)
+	for i := 0; i < len(certs)-1; i++ {
+		err = certs[i].CheckSignatureFrom(certs[i+1].Certificate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to verify signature from %q to %q (%q to %q): %w",
+				certs[i+1].Subject, certs[i].Subject, certFiles[i+1], certFiles[i], err)
+		}
+		chain[i] = certs[i]
+	}
+
+	// Verify that the last cert is self-signed.
+	lastCert := certs[len(certs)-1]
+	err = lastCert.CheckSignatureFrom(lastCert.Certificate)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"final cert in chain (%q; %q) must be self-signed (used only for validation): %w",
+			lastCert.Subject, certFiles[len(certFiles)-1], err)
+	}
+
+	return chain, nil
+}
+
+// ----- Issuers with Signers -----
 
 // IssuerConfig describes the constraints on and URLs used by a single issuer.
 type IssuerConfig struct {
@@ -68,130 +176,6 @@ type IssuerLoc struct {
 	// Number of sessions to open with the HSM. For maximum performance,
 	// this should be equal to the number of cores in the HSM. Defaults to 1.
 	NumSessions int
-}
-
-// LoadIssuer loads a signer (private key) and certificate from the locations specified.
-func LoadIssuer(location IssuerLoc) (*Certificate, crypto.Signer, error) {
-	issuerCert, err := LoadCertificate(location.CertFile)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	signer, err := loadSigner(location, issuerCert)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if !core.KeyDigestEquals(signer.Public(), issuerCert.PublicKey) {
-		return nil, nil, fmt.Errorf("Issuer key did not match issuer cert %s", location.CertFile)
-	}
-	return issuerCert, signer, err
-}
-
-func LoadCertificate(path string) (*Certificate, error) {
-	cert, err := core.LoadCert(path)
-	if err != nil {
-		return nil, err
-	}
-	return NewCertificate(cert)
-}
-
-func loadSigner(location IssuerLoc, cert *Certificate) (crypto.Signer, error) {
-	if location.File != "" {
-		signer, _, err := privatekey.Load(location.File)
-		if err != nil {
-			return nil, err
-		}
-		return signer, nil
-	}
-
-	var pkcs11Config *pkcs11key.Config
-	if location.ConfigFile != "" {
-		contents, err := os.ReadFile(location.ConfigFile)
-		if err != nil {
-			return nil, err
-		}
-		pkcs11Config = new(pkcs11key.Config)
-		err = json.Unmarshal(contents, pkcs11Config)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		pkcs11Config = location.PKCS11
-	}
-
-	if pkcs11Config.Module == "" ||
-		pkcs11Config.TokenLabel == "" ||
-		pkcs11Config.PIN == "" {
-		return nil, fmt.Errorf("missing a field in pkcs11Config %#v", pkcs11Config)
-	}
-
-	numSessions := location.NumSessions
-	if numSessions <= 0 {
-		numSessions = 1
-	}
-
-	return pkcs11key.NewPool(numSessions, pkcs11Config.Module,
-		pkcs11Config.TokenLabel, pkcs11Config.PIN, cert.PublicKey)
-}
-
-// IssuerNameID is a statistically-unique small ID which can be computed from
-// both CA and end-entity certs to link them together into a validation chain.
-// It is computed as a truncated hash over the issuer Subject Name bytes, or
-// over the end-entity's Issuer Name bytes, which are required to be equal.
-type IssuerNameID int64
-
-// Certificate embeds an *x509.Certificate and represents the added semantics
-// that this certificate can be used for issuance.
-type Certificate struct {
-	*x509.Certificate
-	nameID IssuerNameID
-}
-
-// NewCertificate wraps an in-memory cert in an issuance.Certificate, marking it
-// as an issuer cert. It may fail if the certificate does not contain the
-// attributes expected of an issuer certificate.
-func NewCertificate(ic *x509.Certificate) (*Certificate, error) {
-	res := Certificate{Certificate: ic}
-
-	// Compute ic.NameID()
-	res.nameID = truncatedHash(ic.RawSubject)
-
-	return &res, nil
-}
-
-// NameID returns the IssuerNameID (a truncated hash over the raw bytes of the
-// Subject Distinguished Name) of this issuer certificate. Useful for storing as
-// a lookup key in contexts that don't expect hash collisions.
-func (ic *Certificate) NameID() IssuerNameID {
-	return ic.nameID
-}
-
-// GetIssuerNameID returns the IssuerNameID (a truncated hash over the raw bytes
-// of the Issuer Distinguished Name) of the given end-entity certificate.
-// Useful for performing lookups in contexts that don't expect hash collisions.
-func GetIssuerNameID(ee *x509.Certificate) IssuerNameID {
-	return truncatedHash(ee.RawIssuer)
-}
-
-// GetOCSPIssuerNameID returns the IssuerNameID (a truncated hash over the raw
-// bytes of the Responder Distinguished Name) of the given OCSP Response.
-// As per the OCSP spec, it is technically possible for this field to not be
-// populated: the OCSP Response can instead contain a SHA-1 hash of the Issuer
-// Public Key as the Responder ID. The Go stdlib always uses the DN, though.
-func GetOCSPIssuerNameID(resp *ocsp.Response) IssuerNameID {
-	return truncatedHash(resp.RawResponderName)
-}
-
-// truncatedHash computes a truncated SHA1 hash across arbitrary bytes. Uses
-// SHA1 because that is the algorithm most commonly used in OCSP requests.
-// PURPOSEFULLY NOT EXPORTED. Exists only to ensure that the implementations of
-// Certificate.NameID() and GetIssuerNameID() never diverge. Use those instead.
-func truncatedHash(name []byte) IssuerNameID {
-	h := crypto.SHA1.New()
-	h.Write(name)
-	s := h.Sum(nil)
-	return IssuerNameID(big.NewInt(0).SetBytes(s[:7]).Int64())
 }
 
 // Issuer is capable of issuing new certificates
@@ -262,47 +246,64 @@ func (i *Issuer) Name() string {
 	return i.Cert.Subject.CommonName
 }
 
-// LoadChain takes a list of filenames containing pem-formatted certificates,
-// and returns a chain representing all of those certificates in order. It
-// ensures that the resulting chain is valid. The final file is expected to be
-// a root certificate, which the chain will be verified against, but which will
-// not be included in the resulting chain.
-func LoadChain(certFiles []string) ([]*Certificate, error) {
-	if len(certFiles) < 2 {
-		return nil, errors.New(
-			"each chain must have at least two certificates: an intermediate and a root")
-	}
+// NameID provides the NameID of the issuer's certificate.
+func (i *Issuer) NameID() NameID {
+	return i.Cert.NameID()
+}
 
-	// Pre-load all the certificates to make validation easier.
-	certs := make([]*Certificate, len(certFiles))
-	var err error
-	for i := 0; i < len(certFiles); i++ {
-		certs[i], err = LoadCertificate(certFiles[i])
-		if err != nil {
-			return nil, fmt.Errorf("failed to load certificate %q: %w", certFiles[i], err)
-		}
-	}
-
-	// Iterate over all certs except for the last, checking that their signature
-	// comes from the next cert in the list.
-	chain := make([]*Certificate, len(certFiles)-1)
-	for i := 0; i < len(certs)-1; i++ {
-		err = certs[i].CheckSignatureFrom(certs[i+1].Certificate)
-		if err != nil {
-			return nil, fmt.Errorf("failed to verify signature from %q to %q (%q to %q): %w",
-				certs[i+1].Subject, certs[i].Subject, certFiles[i+1], certFiles[i], err)
-		}
-		chain[i] = certs[i]
-	}
-
-	// Verify that the last cert is self-signed.
-	lastCert := certs[len(certs)-1]
-	err = lastCert.CheckSignatureFrom(lastCert.Certificate)
+// LoadIssuer loads a signer (private key) and certificate from the locations specified.
+func LoadIssuer(location IssuerLoc) (*Certificate, crypto.Signer, error) {
+	issuerCert, err := LoadCertificate(location.CertFile)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"final cert in chain (%q; %q) must be self-signed (used only for validation): %w",
-			lastCert.Subject, certFiles[len(certFiles)-1], err)
+		return nil, nil, err
 	}
 
-	return chain, nil
+	signer, err := loadSigner(location, issuerCert)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !core.KeyDigestEquals(signer.Public(), issuerCert.PublicKey) {
+		return nil, nil, fmt.Errorf("Issuer key did not match issuer cert %s", location.CertFile)
+	}
+	return issuerCert, signer, err
+}
+
+func loadSigner(location IssuerLoc, cert *Certificate) (crypto.Signer, error) {
+	if location.File != "" {
+		signer, _, err := privatekey.Load(location.File)
+		if err != nil {
+			return nil, err
+		}
+		return signer, nil
+	}
+
+	var pkcs11Config *pkcs11key.Config
+	if location.ConfigFile != "" {
+		contents, err := os.ReadFile(location.ConfigFile)
+		if err != nil {
+			return nil, err
+		}
+		pkcs11Config = new(pkcs11key.Config)
+		err = json.Unmarshal(contents, pkcs11Config)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		pkcs11Config = location.PKCS11
+	}
+
+	if pkcs11Config.Module == "" ||
+		pkcs11Config.TokenLabel == "" ||
+		pkcs11Config.PIN == "" {
+		return nil, fmt.Errorf("missing a field in pkcs11Config %#v", pkcs11Config)
+	}
+
+	numSessions := location.NumSessions
+	if numSessions <= 0 {
+		numSessions = 1
+	}
+
+	return pkcs11key.NewPool(numSessions, pkcs11Config.Module,
+		pkcs11Config.TokenLabel, pkcs11Config.PIN, cert.PublicKey)
 }

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -196,7 +196,7 @@ type Impl struct {
 	pubpb.UnimplementedPublisherServer
 	log           blog.Logger
 	userAgent     string
-	issuerBundles map[issuance.IssuerNameID][]ct.ASN1Cert
+	issuerBundles map[issuance.NameID][]ct.ASN1Cert
 	ctLogsCache   logCache
 	metrics       *pubMetrics
 }
@@ -204,7 +204,7 @@ type Impl struct {
 // New creates a Publisher that will submit certificates
 // to requested CT logs
 func New(
-	bundles map[issuance.IssuerNameID][]ct.ASN1Cert,
+	bundles map[issuance.NameID][]ct.ASN1Cert,
 	userAgent string,
 	logger blog.Logger,
 	stats prometheus.Registerer,
@@ -235,7 +235,7 @@ func (pub *Impl) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Requ
 	}
 
 	chain := []ct.ASN1Cert{{Data: req.Der}}
-	id := issuance.GetIssuerNameID(cert)
+	id := issuance.IssuerNameID(cert)
 	issuerBundle, ok := pub.issuerBundles[id]
 	if !ok {
 		err := fmt.Errorf("No issuerBundle matching issuerNameID: %d", int64(id))

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -145,7 +145,7 @@ func setup(t *testing.T) (*Impl, *x509.Certificate, *ecdsa.PrivateKey) {
 	test.AssertNotError(t, err, "failed to load chain3.")
 
 	// Create an example issuerNameID to CT bundle mapping
-	issuerBundles := map[issuance.IssuerNameID][]ct.ASN1Cert{
+	issuerBundles := map[issuance.NameID][]ct.ASN1Cert{
 		chain1[0].NameID(): GetCTBundleForChain(chain1),
 		chain2[0].NameID(): GetCTBundleForChain(chain2),
 		chain3[0].NameID(): GetCTBundleForChain(chain3),
@@ -176,7 +176,7 @@ func addLog(t *testing.T, port int, pubKey *ecdsa.PublicKey) *Log {
 	return newLog
 }
 
-func makePrecert(k *ecdsa.PrivateKey) (map[issuance.IssuerNameID][]ct.ASN1Cert, []byte, error) {
+func makePrecert(k *ecdsa.PrivateKey) (map[issuance.NameID][]ct.ASN1Cert, []byte, error) {
 	rootTmpl := x509.Certificate{
 		SerialNumber:          big.NewInt(0),
 		Subject:               pkix.Name{CommonName: "root"},
@@ -205,8 +205,8 @@ func makePrecert(k *ecdsa.PrivateKey) (map[issuance.IssuerNameID][]ct.ASN1Cert, 
 	if err != nil {
 		return nil, nil, err
 	}
-	precertIssuerNameID := issuance.GetIssuerNameID(precertX509)
-	bundles := map[issuance.IssuerNameID][]ct.ASN1Cert{
+	precertIssuerNameID := issuance.IssuerNameID(precertX509)
+	bundles := map[issuance.NameID][]ct.ASN1Cert{
 		precertIssuerNameID: {
 			ct.ASN1Cert{Data: rootBytes},
 		},

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1896,15 +1896,14 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 
 // revokeCertificate updates the database to mark the certificate as revoked,
 // with the given reason and current timestamp.
-// TODO(#5152) make the issuerID argument an issuance.IssuerNameID
-func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, serial *big.Int, issuerID int64, reason revocation.Reason) error {
+func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, serial *big.Int, issuerID issuance.NameID, reason revocation.Reason) error {
 	serialString := core.SerialToString(serial)
 
 	_, err := ra.SA.RevokeCertificate(ctx, &sapb.RevokeCertificateRequest{
 		Serial:   serialString,
 		Reason:   int64(reason),
 		Date:     timestamppb.New(ra.clk.Now()),
-		IssuerID: issuerID,
+		IssuerID: int64(issuerID),
 	})
 	if err != nil {
 		return err
@@ -1918,8 +1917,7 @@ func (ra *RegistrationAuthorityImpl) revokeCertificate(ctx context.Context, seri
 // as revoked, with the given reason and current timestamp. This only works for
 // certificates that were previously revoked for a reason other than
 // keyCompromise, and which are now being updated to keyCompromise instead.
-// TODO(#5152) make the issuerID argument an issuance.IssuerNameID
-func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx context.Context, serial *big.Int, issuerID int64) error {
+func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx context.Context, serial *big.Int, issuerID issuance.NameID) error {
 	serialString := core.SerialToString(serial)
 
 	status, err := ra.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: serialString})
@@ -1941,7 +1939,7 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 		Reason:   int64(ocsp.KeyCompromise),
 		Date:     timestamppb.New(ra.clk.Now()),
 		Backdate: status.RevokedDate,
-		IssuerID: issuerID,
+		IssuerID: int64(issuerID),
 	})
 	if err != nil {
 		return err
@@ -1953,9 +1951,8 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 
 // purgeOCSPCache makes a request to akamai-purger to purge the cache entries
 // for the given certificate.
-// TODO(#5152) make the issuerID argument an issuance.IssuerNameID
-func (ra *RegistrationAuthorityImpl) purgeOCSPCache(ctx context.Context, cert *x509.Certificate, issuerID int64) error {
-	issuer, ok := ra.issuersByNameID[issuance.NameID(issuerID)]
+func (ra *RegistrationAuthorityImpl) purgeOCSPCache(ctx context.Context, cert *x509.Certificate, issuerID issuance.NameID) error {
+	issuer, ok := ra.issuersByNameID[issuerID]
 	if !ok {
 		return fmt.Errorf("unable to identify issuer of cert with serial %q", core.SerialToString(cert.SerialNumber))
 	}
@@ -2064,7 +2061,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 	err = ra.revokeCertificate(
 		ctx,
 		cert.SerialNumber,
-		int64(issuerID),
+		issuerID,
 		revocation.Reason(req.Code),
 	)
 	if err != nil {
@@ -2072,7 +2069,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 	}
 
 	// Don't propagate purger errors to the client.
-	_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+	_ = ra.purgeOCSPCache(ctx, cert, issuerID)
 
 	return &emptypb.Empty{}, nil
 }
@@ -2143,7 +2140,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 	revokeErr := ra.revokeCertificate(
 		ctx,
 		cert.SerialNumber,
-		int64(issuerID),
+		issuerID,
 		revocation.Reason(ocsp.KeyCompromise),
 	)
 
@@ -2161,18 +2158,18 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 		// If the revocation and blocked keys list addition were successful, then
 		// just purge and return.
 		// Don't propagate purger errors to the client.
-		_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+		_ = ra.purgeOCSPCache(ctx, cert, issuerID)
 		return &emptypb.Empty{}, nil
 	} else if errors.Is(err, berrors.AlreadyRevoked) {
 		// If it was an AlreadyRevoked error, try to re-revoke the cert in case
 		// it was revoked for a reason other than keyCompromise.
-		err = ra.updateRevocationForKeyCompromise(ctx, cert.SerialNumber, int64(issuerID))
+		err = ra.updateRevocationForKeyCompromise(ctx, cert.SerialNumber, issuerID)
 
 		// Perform an Akamai cache purge to handle occurrences of a client
 		// previously successfully revoking a certificate, but the cache purge had
 		// unexpectedly failed. Allows clients to re-attempt revocation and purge the
 		// Akamai cache.
-		_ = ra.purgeOCSPCache(ctx, cert, int64(issuerID))
+		_ = ra.purgeOCSPCache(ctx, cert, issuerID)
 		if err != nil {
 			return nil, err
 		}
@@ -2216,20 +2213,20 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	// that in case we are administratively revoking the certificate because it is
 	// so badly malformed that it can't be parsed.
 	var cert *x509.Certificate
-	var issuerID int64 // TODO(#5152) make this an issuance.IssuerNameID
+	var issuerID issuance.NameID
 	var err error
 	if req.Cert == nil {
 		status, err := ra.SA.GetCertificateStatus(ctx, &sapb.Serial{Serial: req.Serial})
 		if err != nil {
 			return nil, fmt.Errorf("unable to confirm that serial %q was ever issued: %w", req.Serial, err)
 		}
-		issuerID = status.IssuerID
+		issuerID = issuance.NameID(status.IssuerID)
 	} else {
 		cert, err = x509.ParseCertificate(req.Cert)
 		if err != nil {
 			return nil, err
 		}
-		issuerID = int64(issuance.IssuerNameID(cert))
+		issuerID = issuance.IssuerNameID(cert)
 	}
 
 	logEvent := certificateRevocationEvent{

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -101,7 +101,7 @@ type RegistrationAuthorityImpl struct {
 	finalizeTimeout              time.Duration
 	finalizeWG                   sync.WaitGroup
 
-	issuersByNameID map[issuance.IssuerNameID]*issuance.Certificate
+	issuersByNameID map[issuance.NameID]*issuance.Certificate
 	purger          akamaipb.AkamaiPurgerClient
 
 	ctpolicy *ctpolicy.CTPolicy
@@ -233,7 +233,7 @@ func NewRegistrationAuthorityImpl(
 	})
 	stats.MustRegister(inflightFinalizes)
 
-	issuersByNameID := make(map[issuance.IssuerNameID]*issuance.Certificate)
+	issuersByNameID := make(map[issuance.NameID]*issuance.Certificate)
 	for _, issuer := range issuers {
 		issuersByNameID[issuer.NameID()] = issuer
 	}
@@ -1955,7 +1955,7 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 // for the given certificate.
 // TODO(#5152) make the issuerID argument an issuance.IssuerNameID
 func (ra *RegistrationAuthorityImpl) purgeOCSPCache(ctx context.Context, cert *x509.Certificate, issuerID int64) error {
-	issuer, ok := ra.issuersByNameID[issuance.IssuerNameID(issuerID)]
+	issuer, ok := ra.issuersByNameID[issuance.NameID(issuerID)]
 	if !ok {
 		return fmt.Errorf("unable to identify issuer of cert with serial %q", core.SerialToString(cert.SerialNumber))
 	}
@@ -2060,7 +2060,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 		logEvent.Reason = req.Code
 	}
 
-	issuerID := issuance.GetIssuerNameID(cert)
+	issuerID := issuance.IssuerNameID(cert)
 	err = ra.revokeCertificate(
 		ctx,
 		cert.SerialNumber,
@@ -2116,7 +2116,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 		return nil, err
 	}
 
-	issuerID := issuance.GetIssuerNameID(cert)
+	issuerID := issuance.IssuerNameID(cert)
 
 	logEvent := certificateRevocationEvent{
 		ID:           core.NewToken(),
@@ -2229,7 +2229,7 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 		if err != nil {
 			return nil, err
 		}
-		issuerID = int64(issuance.GetIssuerNameID(cert))
+		issuerID = int64(issuance.IssuerNameID(cert))
 	}
 
 	logEvent := certificateRevocationEvent{

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3638,7 +3638,7 @@ func newMockSARevocation(known *x509.Certificate, clk clock.Clock) *mockSARevoca
 		StorageAuthority: *mocks.NewStorageAuthority(clk),
 		known: &corepb.CertificateStatus{
 			Serial:   core.SerialToString(known.SerialNumber),
-			IssuerID: int64(issuance.GetIssuerNameID(known)),
+			IssuerID: int64(issuance.IssuerNameID(known)),
 		},
 		blocked: make([]*sapb.AddBlockedKeyRequest, 0),
 		revoked: make(map[string]int64),
@@ -3799,10 +3799,12 @@ func TestRevokeCertByApplicant_Subscriber(t *testing.T) {
 	ra.OCSP = &mockOCSPA{}
 	ra.purger = &mockPurger{}
 
+	// Use the same self-signed cert as both issuer and issuee for revocation.
 	_, cert := test.ThrowAwayCert(t, clk)
+	cert.IsCA = true
 	ic, err := issuance.NewCertificate(cert)
 	test.AssertNotError(t, err, "failed to create issuer cert")
-	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
+	ra.issuersByNameID = map[issuance.NameID]*issuance.Certificate{
 		ic.NameID(): ic,
 	}
 	ra.SA = newMockSARevocation(cert, clk)
@@ -3850,10 +3852,12 @@ func TestRevokeCertByApplicant_Controller(t *testing.T) {
 	ra.OCSP = &mockOCSPA{}
 	ra.purger = &mockPurger{}
 
+	// Use the same self-signed cert as both issuer and issuee for revocation.
 	_, cert := test.ThrowAwayCert(t, clk)
+	cert.IsCA = true
 	ic, err := issuance.NewCertificate(cert)
 	test.AssertNotError(t, err, "failed to create issuer cert")
-	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
+	ra.issuersByNameID = map[issuance.NameID]*issuance.Certificate{
 		ic.NameID(): ic,
 	}
 	mockSA := newMockSARevocation(cert, clk)
@@ -3886,12 +3890,14 @@ func TestRevokeCertByKey(t *testing.T) {
 	ra.OCSP = &mockOCSPA{}
 	ra.purger = &mockPurger{}
 
+	// Use the same self-signed cert as both issuer and issuee for revocation.
 	_, cert := test.ThrowAwayCert(t, clk)
 	digest, err := core.KeyDigest(cert.PublicKey)
 	test.AssertNotError(t, err, "core.KeyDigest failed")
+	cert.IsCA = true
 	ic, err := issuance.NewCertificate(cert)
 	test.AssertNotError(t, err, "failed to create issuer cert")
-	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
+	ra.issuersByNameID = map[issuance.NameID]*issuance.Certificate{
 		ic.NameID(): ic,
 	}
 	mockSA := newMockSARevocation(cert, clk)
@@ -3936,12 +3942,14 @@ func TestAdministrativelyRevokeCertificate(t *testing.T) {
 	ra.OCSP = &mockOCSPA{}
 	ra.purger = &mockPurger{}
 
+	// Use the same self-signed cert as both issuer and issuee for revocation.
 	serial, cert := test.ThrowAwayCert(t, clk)
 	digest, err := core.KeyDigest(cert.PublicKey)
 	test.AssertNotError(t, err, "core.KeyDigest failed")
+	cert.IsCA = true
 	ic, err := issuance.NewCertificate(cert)
 	test.AssertNotError(t, err, "failed to create issuer cert")
-	ra.issuersByNameID = map[issuance.IssuerNameID]*issuance.Certificate{
+	ra.issuersByNameID = map[issuance.NameID]*issuance.Certificate{
 		ic.NameID(): ic,
 	}
 	mockSA := newMockSARevocation(cert, clk)

--- a/rocsp/config/rocsp_config.go
+++ b/rocsp/config/rocsp_config.go
@@ -227,7 +227,7 @@ func (si *ShortIDIssuer) ShortID() byte {
 // FindIssuerByID returns the issuer that matches the given IssuerNameID.
 func FindIssuerByID(longID int64, issuers []ShortIDIssuer) (*ShortIDIssuer, error) {
 	for _, iss := range issuers {
-		if iss.NameID() == issuance.IssuerNameID(longID) {
+		if iss.NameID() == issuance.NameID(longID) {
 			return &iss, nil
 		}
 	}

--- a/wfe2/test_aia.go
+++ b/wfe2/test_aia.go
@@ -22,7 +22,7 @@ func (wfe *WebFrontEndImpl) Issuer(ctx context.Context, logEvent *web.RequestEve
 		return
 	}
 
-	issuer, ok := wfe.issuerCertificates[issuance.IssuerNameID(id)]
+	issuer, ok := wfe.issuerCertificates[issuance.NameID(id)]
 	if !ok {
 		wfe.sendError(response, logEvent, probs.NotFound("Issuer ID did not match any known issuer"), nil)
 		return

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -123,12 +123,12 @@ type WebFrontEndImpl struct {
 	// newline and one or more PEM encoded certificates separated by a newline,
 	// sorted from leaf to root. The first []byte is the default certificate chain,
 	// and any subsequent []byte is an alternate certificate chain.
-	certificateChains map[issuance.IssuerNameID][][]byte
+	certificateChains map[issuance.NameID][][]byte
 
 	// issuerCertificates is a map of IssuerNameIDs to issuer certificates built with the
 	// first entry from each of the certificateChains. These certificates are used
 	// to verify the signature of certificates provided in revocation requests.
-	issuerCertificates map[issuance.IssuerNameID]*issuance.Certificate
+	issuerCertificates map[issuance.NameID]*issuance.Certificate
 
 	// URL to the current subscriber agreement (should contain some version identifier)
 	SubscriberAgreementURL string
@@ -177,8 +177,8 @@ func NewWebFrontEndImpl(
 	stats prometheus.Registerer,
 	clk clock.Clock,
 	keyPolicy goodkey.KeyPolicy,
-	certificateChains map[issuance.IssuerNameID][][]byte,
-	issuerCertificates map[issuance.IssuerNameID]*issuance.Certificate,
+	certificateChains map[issuance.NameID][][]byte,
+	issuerCertificates map[issuance.NameID]*issuance.Certificate,
 	logger blog.Logger,
 	requestTimeout time.Duration,
 	staleTimeout time.Duration,
@@ -938,7 +938,7 @@ func (wfe *WebFrontEndImpl) parseRevocation(
 
 	// Try to validate the signature on the provided cert using its corresponding
 	// issuer certificate.
-	issuerNameID := issuance.GetIssuerNameID(parsedCertificate)
+	issuerNameID := issuance.IssuerNameID(parsedCertificate)
 	issuerCert, ok := wfe.issuerCertificates[issuerNameID]
 	if !ok || issuerCert == nil {
 		return nil, 0, probs.NotFound("Certificate from unrecognized issuer")
@@ -1744,7 +1744,7 @@ func (wfe *WebFrontEndImpl) Certificate(ctx context.Context, logEvent *web.Reque
 			)
 		}
 
-		issuerNameID := issuance.GetIssuerNameID(parsedCert)
+		issuerNameID := issuance.IssuerNameID(parsedCert)
 		availableChains, ok := wfe.certificateChains[issuerNameID]
 		if !ok || len(availableChains) == 0 {
 			// If there is no wfe.certificateChains entry for the IssuerNameID then
@@ -2435,7 +2435,7 @@ func (c certID) Serial() string {
 // certID struct with the keyIdentifier and serialNumber extracted and decoded.
 // For more details see:
 // https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-02#section-4.1.
-func parseCertID(path string, issuerCertificates map[issuance.IssuerNameID]*issuance.Certificate) (ariCertID, *probs.ProblemDetails, error) {
+func parseCertID(path string, issuerCertificates map[issuance.NameID]*issuance.Certificate) (ariCertID, *probs.ProblemDetails, error) {
 	parts := strings.Split(path, ".")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return certID{}, probs.Malformed("Invalid path"), nil

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -938,8 +938,7 @@ func (wfe *WebFrontEndImpl) parseRevocation(
 
 	// Try to validate the signature on the provided cert using its corresponding
 	// issuer certificate.
-	issuerNameID := issuance.IssuerNameID(parsedCertificate)
-	issuerCert, ok := wfe.issuerCertificates[issuerNameID]
+	issuerCert, ok := wfe.issuerCertificates[issuance.IssuerNameID(parsedCertificate)]
 	if !ok || issuerCert == nil {
 		return nil, 0, probs.NotFound("Certificate from unrecognized issuer")
 	}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -312,8 +312,8 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 	fc := clock.NewFake()
 	stats := metrics.NoopRegisterer
 
-	certChains := map[issuance.IssuerNameID][][]byte{}
-	issuerCertificates := map[issuance.IssuerNameID]*issuance.Certificate{}
+	certChains := map[issuance.NameID][][]byte{}
+	issuerCertificates := map[issuance.NameID]*issuance.Certificate{}
 	for _, files := range [][]string{
 		{
 			"../test/hierarchy/int-r3.cert.pem",
@@ -3713,7 +3713,7 @@ func TestIncidentARI(t *testing.T) {
 
 	// draft-ietf-acme-ari02
 	test.AssertNotError(t, err, "failed to load test certificate")
-	var issuer issuance.IssuerNameID
+	var issuer issuance.NameID
 	for k := range wfe.issuerCertificates {
 		// Grab the first known issuer.
 		issuer = k


### PR DESCRIPTION
Rename "IssuerNameID" to just "NameID". Similarly rename the standalone functions which compute it to better describe their function. Add a .NameID() directly to issuance.Issuer, so that callers in other packages don't have to directly access the .Cert member of an Issuer. Finally, rearrange the code in issuance.go to be sensibly grouped as concerning NameIDs, Certificates, or Issuers, rather than all mixed up between the three.

Fixes https://github.com/letsencrypt/boulder/issues/5152

~DO NOT SUBMIT before https://github.com/letsencrypt/boulder/pull/7259~