### PR TITLE
Fix flaky integration test failures

### DIFF
--- a/test/config-next/health-checker.json
+++ b/test/config-next/health-checker.json
@@ -1,7 +1,6 @@
 {
 	"grpc": {
-		"timeout": "1s",
-		"noWaitForReady": true
+		"timeout": "1s"
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config-next/health-checker.json
+++ b/test/config-next/health-checker.json
@@ -1,6 +1,7 @@
 {
 	"grpc": {
-		"timeout": "1s"
+		"timeout": "1s",
+		"noWaitForReady": true
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config/health-checker.json
+++ b/test/config/health-checker.json
@@ -1,7 +1,6 @@
 {
 	"grpc": {
-		"timeout": "1s",
-		"noWaitForReady": true
+		"timeout": "1s"
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config/health-checker.json
+++ b/test/config/health-checker.json
@@ -1,6 +1,7 @@
 {
 	"grpc": {
-		"timeout": "1s"
+		"timeout": "1s",
+		"noWaitForReady": true
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/health-checker/main.go
+++ b/test/health-checker/main.go
@@ -78,6 +78,9 @@ func main() {
 			}
 			resp, err := client.Check(ctx2, req)
 			if err != nil {
+				if strings.Contains(err.Error(), "authentication handshake failed") {
+					cmd.Fail(fmt.Sprintf("error connecting to health service %s: %s\n", *serverAddr, err))
+				}
 				fmt.Fprintf(os.Stderr, "got error connecting to health service %s: %s\n", *serverAddr, err)
 			} else if resp.Status == healthpb.HealthCheckResponse_SERVING {
 				return

--- a/test/health-checker/main.go
+++ b/test/health-checker/main.go
@@ -78,9 +78,6 @@ func main() {
 			}
 			resp, err := client.Check(ctx2, req)
 			if err != nil {
-				if strings.Contains(err.Error(), "authentication handshake failed") {
-					cmd.Fail(fmt.Sprintf("error connecting to health service %s: %s\n", *serverAddr, err))
-				}
 				fmt.Fprintf(os.Stderr, "got error connecting to health service %s: %s\n", *serverAddr, err)
 			} else if resp.Status == healthpb.HealthCheckResponse_SERVING {
 				return


### PR DESCRIPTION
This partially reverts commit 20b121138cd30a86a32cce86d7266bd71d1da5b5, which was landed in https://github.com/letsencrypt/boulder/pull/7254. Specifically, it reverts the addition of "noWaitForReady" to the health-checker's gRPC config. This appears to stop the flaky `last resolver error: produced zero addresses` failures we've been seeing in the CI integration tests.