### PR TITLE
test: remove use of 10.88.88.88 in most places

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -274,8 +274,8 @@ type GRPCClientConfig struct {
 	// services {
 	//   id      = "some-unique-id-2"
 	//   name    = "foo"
-	//   address = "10.88.88.88"
-	//   port    = 8080
+	//   address = "10.77.77.77"
+	//   port    = 8180
 	//   tags    = ["tcp"]
 	// }
 	//
@@ -532,15 +532,15 @@ type DNSProvider struct {
 	//   id      = "unbound-1" // Must be unique
 	//   name    = "unbound"
 	//   address = "10.77.77.77"
-	//   port    = 53
+	//   port    = 8053
 	//   tags    = ["udp"]
 	// }
 	//
 	// services {
 	//   id      = "unbound-2" // Must be unique
 	//   name    = "unbound"
-	//   address = "10.88.88.88"
-	//   port    = 53
+	//   address = "10.77.77.77"
+	//   port    = 8153
 	//   tags    = ["udp"]
 	// }
 	//
@@ -548,7 +548,7 @@ type DNSProvider struct {
 	// Consul) then you should be able to resolve the following dig query:
 	//
 	// $ dig @10.55.55.10 -t SRV _unbound._udp.service.consul +short
-	// 1 1 53 0a585858.addr.dc1.consul.
-	// 1 1 53 0a4d4d4d.addr.dc1.consul.
+	// 1 1 8053 0a4d4d4d.addr.dc1.consul.
+	// 1 1 8153 0a4d4d4d.addr.dc1.consul.
 	SRVLookup ServiceDomain `validate:"required"`
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,8 +136,6 @@ services:
         ipv4_address: 10.55.55.10
       bluenet:
         ipv4_address: 10.77.77.10
-      rednet:
-        ipv4_address: 10.88.88.10
     command: "consul agent -dev -config-format=hcl -config-file=/test/consul/config.hcl"
 
   bjaeger:

--- a/test/config/health-checker.json
+++ b/test/config/health-checker.json
@@ -1,7 +1,6 @@
 {
 	"grpc": {
-		"timeout": "1s",
-		"noWaitForReady": true
+		"timeout": "1s"
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/config/health-checker.json
+++ b/test/config/health-checker.json
@@ -1,6 +1,7 @@
 {
 	"grpc": {
-		"timeout": "1s"
+		"timeout": "1s",
+		"noWaitForReady": true
 	},
 	"tls": {
 		"caCertFile": "test/grpc-creds/minica.pem",

--- a/test/consul/README.md
+++ b/test/consul/README.md
@@ -21,8 +21,8 @@ in-memory server and client with persistence disabled for ease of use.
   services {
     id      = "foo-purger-b"
     name    = "foo-purger"
-    address = "10.88.88.88"
-    port    = 1338
+    address = "10.77.77.77"
+    port    = 1438
   }
   ```
 - To target individual `foo-purger`'s, add these additional `service` sections
@@ -39,8 +39,8 @@ in-memory server and client with persistence disabled for ease of use.
   services {
     id      = "foo-purger-2"
     name    = "foo-purger-2"
-    address = "10.88.88.88"
-    port    = 1338
+    address = "10.77.77.77"
+    port    = 1438
   }
   ```
 - For RFC 2782 (SRV RR) lookups to work ensure you that you add a tag for the

--- a/test/consul/config.hcl
+++ b/test/consul/config.hcl
@@ -42,7 +42,7 @@ services {
 services {
   id      = "boulder-a"
   name    = "boulder"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
 }
 
 services {
@@ -56,7 +56,7 @@ services {
 services {
   id      = "ca-b"
   name    = "ca"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
   port    = 9493
   tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
 }
@@ -80,7 +80,7 @@ services {
 services {
   id      = "dns-b"
   name    = "dns"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
   port    = 8054
   tags    = ["udp"] // Required for SRV RR support in VA RVA.
 }
@@ -96,7 +96,7 @@ services {
 services {
   id      = "doh-b"
   name    = "doh"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
   port    = 8443
   tags    = ["tcp"]
 }
@@ -139,7 +139,7 @@ services {
 services {
   id      = "publisher-b"
   name    = "publisher"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
   port    = 9491
   tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
 }
@@ -155,7 +155,7 @@ services {
 services {
   id      = "ra-b"
   name    = "ra"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
   port    = 9494
   tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
 }
@@ -216,14 +216,14 @@ services {
 services {
   id      = "sa-b"
   name    = "sa"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
   port    = 9495
   tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
   checks = [
     {
       id              = "sa-b-grpc"
       name            = "sa-b-grpc"
-      grpc            = "10.88.88.88:9495"
+      grpc            = "10.77.77.77:9495"
       grpc_use_tls    = true
       tls_server_name = "sa.boulder"
       tls_skip_verify = false
@@ -232,7 +232,7 @@ services {
     {
       id              = "sa-b-grpc-sa"
       name            = "sa-b-grpc-sa"
-      grpc            = "10.88.88.88:9495/sa.StorageAuthority"
+      grpc            = "10.77.77.77:9495/sa.StorageAuthority"
       grpc_use_tls    = true
       tls_server_name = "sa.boulder"
       tls_skip_verify = false
@@ -241,7 +241,7 @@ services {
     {
       id              = "sa-b-grpc-saro"
       name            = "sa-b-grpc-saro"
-      grpc            = "10.88.88.88:9495/sa.StorageAuthorityReadOnly"
+      grpc            = "10.77.77.77:9495/sa.StorageAuthorityReadOnly"
       grpc_use_tls    = true
       tls_server_name = "sa.boulder"
       tls_skip_verify = false
@@ -261,7 +261,7 @@ services {
 services {
   id      = "va-b"
   name    = "va"
-  address = "10.88.88.88"
+  address = "10.77.77.77"
   port    = 9492
   tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
 }

--- a/test/consul/config.hcl
+++ b/test/consul/config.hcl
@@ -116,6 +116,11 @@ services {
   id      = "nonce-taro-b"
   name    = "nonce-taro"
   address = "10.77.77.77"
+  port    = 9401
+  tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
+}
+
+  address = "10.77.77.77"
   port    = 9501
   tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
 }

--- a/test/consul/config.hcl
+++ b/test/consul/config.hcl
@@ -116,11 +116,6 @@ services {
   id      = "nonce-taro-b"
   name    = "nonce-taro"
   address = "10.77.77.77"
-  port    = 9401
-  tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
-}
-
-  address = "10.77.77.77"
   port    = 9501
   tags    = ["tcp"] // Required for SRV RR support in gRPC DNS resolution.
 }


### PR DESCRIPTION
Part of #7245.

There are still a few places that use 10.88.88.88 that will be harder to remove. In particular, some of the Python integration tests start up their own HTTP servers that differ from challtestsrv in some important way (like timing out requests). Because challtestsrv already binds to 10.77.77.77:80, those test servers need a different IP address to bind to. We can probably solve that but I'll leave it for another PR.