### PR TITLE
all: use proper deprecation comment

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -73,7 +73,7 @@ type Config struct {
 		// this should contain all nonce-services from all DCs as we want to be
 		// able to redeem nonces generated at any DC.
 		//
-		// DEPRECATED: See RedeemNonceService, below.
+		// Deprecated: See RedeemNonceService, below.
 		// TODO (#6610) Remove this after all configs have migrated to
 		// `RedeemNonceService`.
 		RedeemNonceServices map[string]cmd.GRPCClientConfig `validate:"required_without=RedeemNonceService,omitempty,min=1,dive"`

--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -63,7 +63,7 @@ type Config struct {
 		// immediately; if the validity period of the issued certificates ever
 		// changes downwards, the value must not change until after all certificates with
 		// the old validity period have expired.
-		// DEPRECATED: This config value is no longer used.
+		// Deprecated: This config value is no longer used.
 		// TODO(#6438): Remove this value.
 		CertificateLifetime config.Duration `validate:"-"`
 
@@ -79,7 +79,7 @@ type Config struct {
 		// UpdatePeriod, starting from the Unix Epoch plus UpdateOffset, and
 		// continuing forward into the future forever. This value must be strictly
 		// less than the UpdatePeriod.
-		// DEPRECATED: This config value is not relevant with continuous updating.
+		// Deprecated: This config value is not relevant with continuous updating.
 		// TODO(#7023): Remove this value.
 		UpdateOffset config.Duration `validate:"-"`
 

--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -41,7 +41,7 @@ const (
 
 	// DeprecatedPrefixLen is the character length of a nonce prefix.
 	//
-	// DEPRECATED: Use PrefixLen instead.
+	// Deprecated: Use PrefixLen instead.
 	// TODO(#6610): Remove once we've moved to derivable prefixes by default.
 	DeprecatedPrefixLen = 4
 


### PR DESCRIPTION
Silents `go-critic` linter.