### PR TITLE
boulder-tools: plumb TARGETPLATFORM into build.sh

### DIFF
--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -31,6 +31,9 @@ RUN /tmp/build-rust-deps.sh
 #
 # Run this command in each container: dpkg -l libc6
 FROM buildpack-deps:focal-scm
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ENV TARGETPLATFORM=${TARGETPLATFORM:-$BUILDPLATFORM}
 COPY requirements.txt /tmp/requirements.txt
 COPY boulder.rsyslog.conf /etc/rsyslog.d/
 COPY build.sh /tmp/build.sh


### PR DESCRIPTION
This is necessary in order for build.sh to download the correct version of protoc.