### PR TITLE
Fix doc comment on core.KeyDigest

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -94,8 +94,7 @@ func Fingerprint256(data []byte) string {
 
 type Sha256Digest [sha256.Size]byte
 
-// KeyDigest produces a Base64-encoded SHA256 digest of a
-// provided public key.
+// KeyDigest produces the SHA256 digest of a provided public key.
 func KeyDigest(key crypto.PublicKey) (Sha256Digest, error) {
 	switch t := key.(type) {
 	case *jose.JSONWebKey:


### PR DESCRIPTION
This functionality changed in https://github.com/letsencrypt/boulder/pull/4745
but the doc wasn't updated. This confused me while reviewing another PR.
