### PR TITLE
Ensure gRPC suberror metadata is ascii-only

### DIFF
--- a/grpc/errors.go
+++ b/grpc/errors.go
@@ -111,7 +111,7 @@ func unwrapError(err error, md metadata.MD) error {
 			)
 		}
 
-		utf8SubErrors, unquoteErr := strconv.Unquote(subErrorsVal[0])
+		unquotedSubErrors, unquoteErr := strconv.Unquote(subErrorsVal[0])
 		if unquoteErr != nil {
 			return fmt.Errorf(
 				"unquoting 'suberrors' %q, wrapped error %q: %w",
@@ -121,7 +121,7 @@ func unwrapError(err error, md metadata.MD) error {
 			)
 		}
 
-		unmarshalErr := json.Unmarshal([]byte(utf8SubErrors), &outErr.SubErrors)
+		unmarshalErr := json.Unmarshal([]byte(unquotedSubErrors), &outErr.SubErrors)
 		if unmarshalErr != nil {
 			return berrors.InternalServerError(
 				"JSON unmarshaling 'suberrors' %q, wrapped error %q: %s",

--- a/grpc/errors.go
+++ b/grpc/errors.go
@@ -41,7 +41,8 @@ func wrapError(ctx context.Context, appErr error) error {
 				return berrors.InternalServerError(
 					"error marshaling json SubErrors, orig error %q", err)
 			}
-			pairs = append(pairs, "suberrors", string(jsonSubErrs))
+			headerSafeSubErrs := strconv.QuoteToASCII(string(jsonSubErrs))
+			pairs = append(pairs, "suberrors", headerSafeSubErrs)
 		}
 
 		// If there is a RetryAfter value then extend the metadata pairs to
@@ -110,7 +111,17 @@ func unwrapError(err error, md metadata.MD) error {
 			)
 		}
 
-		unmarshalErr := json.Unmarshal([]byte(subErrorsVal[0]), &outErr.SubErrors)
+		utf8SubErrors, unquoteErr := strconv.Unquote(subErrorsVal[0])
+		if unquoteErr != nil {
+			return fmt.Errorf(
+				"unquoting 'suberrors' %q, wrapped error %q: %w",
+				subErrorsVal[0],
+				inErrMsg,
+				unquoteErr,
+			)
+		}
+
+		unmarshalErr := json.Unmarshal([]byte(utf8SubErrors), &outErr.SubErrors)
 		if unmarshalErr != nil {
 			return berrors.InternalServerError(
 				"JSON unmarshaling 'suberrors' %q, wrapped error %q: %s",

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -156,18 +156,17 @@ func TestRejectedIdentifier(t *testing.T) {
 	domains := []string{
 		"яџ–Х6яяdь}",
 	}
-
 	_, err := authAndIssue(nil, nil, domains, true)
-	test.AssertError(t, err, "authAndIssue failed")
-
+	test.AssertError(t, err, "issuance should fail for one malformed name")
 	var prob acme.Problem
 	test.AssertErrorWraps(t, err, &prob)
-	t.Logf("%#v", prob)
 	test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:rejectedIdentifier")
 	test.AssertContains(t, prob.Detail, "Domain name contains an invalid character")
 
 	// When multiple malformed names are provided, we correctly reject all of
-	// them and reflect this in suberrors.
+	// them and reflect this in suberrors. This test ensures that the way we
+	// encode these errors across the gRPC boundary is resilient to non-ascii
+	// characters.
 	domains = []string{
 		"o-",
 		"ш№Ў",
@@ -176,7 +175,7 @@ func TestRejectedIdentifier(t *testing.T) {
 		"яџ–Х6яя`ь",
 	}
 	_, err = authAndIssue(nil, nil, domains, true)
-	test.AssertError(t, err, "authAndIssue failed")
+	test.AssertError(t, err, "issuance should fail for multiple malformed names")
 	test.AssertErrorWraps(t, err, &prob)
 	test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:rejectedIdentifier")
 	test.AssertContains(t, prob.Detail, "Domain name contains an invalid character")


### PR DESCRIPTION
When passing detailed error information between services as gRPC metadata, ensure that the suberrors being sent contain only ascii characters, because gRPC metadata is sent as HTTP headers which only allow visible ascii characters.

Also add a regression test.