### PR TITLE
Separate issuance.Profile out from issuance.Issuer

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -136,6 +136,10 @@ func NewCertificateAuthorityImpl(
 		return nil, errors.New("must have at least one issuer")
 	}
 
+	if certificateProfile == nil {
+		return nil, errors.New("must have at least one certificate profile")
+	}
+
 	issuers := makeIssuerMaps(boulderIssuers)
 
 	lintErrorCount := prometheus.NewCounter(

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -60,6 +60,7 @@ type certificateAuthorityImpl struct {
 	sa      sapb.StorageAuthorityCertificateClient
 	pa      core.PolicyAuthority
 	issuers issuerMaps
+	profile *issuance.Profile
 
 	// This is temporary, and will be used for testing and slow roll-out
 	// of ECDSA issuance, but will then be removed.
@@ -103,6 +104,7 @@ func NewCertificateAuthorityImpl(
 	sa sapb.StorageAuthorityCertificateClient,
 	pa core.PolicyAuthority,
 	boulderIssuers []*issuance.Issuer,
+	certificateProfile *issuance.Profile,
 	ecdsaAllowList *ECDSAAllowList,
 	certExpiry time.Duration,
 	certBackdate time.Duration,
@@ -147,6 +149,7 @@ func NewCertificateAuthorityImpl(
 		sa:             sa,
 		pa:             pa,
 		issuers:        issuers,
+		profile:        certificateProfile,
 		validityPeriod: certExpiry,
 		backdate:       certBackdate,
 		prefix:         serialPrefix,
@@ -281,7 +284,7 @@ func (ca *certificateAuthorityImpl) IssueCertificateForPrecertificate(ctx contex
 	ca.log.AuditInfof("Signing cert: serial=[%s] regID=[%d] names=[%s] precert=[%s]",
 		serialHex, req.RegistrationID, names, hex.EncodeToString(precert.Raw))
 
-	_, issuanceToken, err := issuer.Prepare(issuanceReq)
+	_, issuanceToken, err := issuer.Prepare(ca.profile, issuanceReq)
 	if err != nil {
 		ca.log.AuditErrf("Preparing cert failed: serial=[%s] regID=[%d] names=[%s] err=[%v]",
 			serialHex, req.RegistrationID, names, err)
@@ -439,7 +442,7 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		NotAfter:          validity.NotAfter,
 	}
 
-	lintCertBytes, issuanceToken, err := issuer.Prepare(req)
+	lintCertBytes, issuanceToken, err := issuer.Prepare(ca.profile, req)
 	if err != nil {
 		ca.log.AuditErrf("Preparing precert failed: serial=[%s] regID=[%d] names=[%s] err=[%v]",
 			serialHex, issueReq.RegistrationID, strings.Join(csr.DNSNames, ", "), err)

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -2,7 +2,6 @@ package ca
 
 import (
 	"context"
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -32,7 +31,6 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/issuance"
-	"github.com/letsencrypt/boulder/linter"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/must"
@@ -110,6 +108,7 @@ type testCtx struct {
 	pa             core.PolicyAuthority
 	ocsp           *ocspImpl
 	crl            *crlImpl
+	profile        *issuance.Profile
 	certExpiry     time.Duration
 	certBackdate   time.Duration
 	serialPrefix   int
@@ -148,29 +147,7 @@ func (m *mockSA) SetCertificateStatusReady(ctx context.Context, req *sapb.Serial
 	return &emptypb.Empty{}, nil
 }
 
-var caKey crypto.Signer
-var caCert *issuance.Certificate
-var caCert2 *issuance.Certificate
-var caLinter *linter.Linter
-var caLinter2 *linter.Linter
 var ctx = context.Background()
-
-func init() {
-	var err error
-	caCert, caKey, err = issuance.LoadIssuer(issuance.IssuerLoc{
-		File:     caKeyFile,
-		CertFile: caCertFile,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("Unable to load %q and %q: %s", caKeyFile, caCertFile, err))
-	}
-	caCert2, err = issuance.LoadCertificate(caCertFile2)
-	if err != nil {
-		panic(fmt.Sprintf("Unable to parse %q: %s", caCertFile2, err))
-	}
-	caLinter, _ = linter.New(caCert.Certificate, caKey, []string{"w_subject_common_name_included"})
-	caLinter2, _ = linter.New(caCert2.Certificate, caKey, []string{"w_subject_common_name_included"})
-}
 
 func setup(t *testing.T) *testCtx {
 	features.Reset()
@@ -182,46 +159,44 @@ func setup(t *testing.T) *testCtx {
 	err = pa.LoadHostnamePolicyFile("../test/hostname-policy.yaml")
 	test.AssertNotError(t, err, "Couldn't set hostname policy")
 
-	boulderProfile := func(rsa, ecdsa bool) *issuance.Profile {
-		res, _ := issuance.NewProfile(
-			issuance.ProfileConfig{
-				AllowMustStaple: true,
-				AllowCTPoison:   true,
-				AllowSCTList:    true,
-				AllowCommonName: true,
-				Policies: []issuance.PolicyConfig{
-					{OID: "2.23.140.1.2.1"},
-				},
-				MaxValidityPeriod:   config.Duration{Duration: time.Hour * 8760},
-				MaxValidityBackdate: config.Duration{Duration: time.Hour},
+	boulderProfile, err := issuance.NewProfile(
+		issuance.ProfileConfig{
+			AllowMustStaple: true,
+			AllowCTPoison:   true,
+			AllowSCTList:    true,
+			AllowCommonName: true,
+			Policies: []issuance.PolicyConfig{
+				{OID: "2.23.140.1.2.1"},
 			},
-			issuance.IssuerConfig{
-				UseForECDSALeaves: ecdsa,
-				UseForRSALeaves:   rsa,
-				IssuerURL:         "http://not-example.com/issuer-url",
-				OCSPURL:           "http://not-example.com/ocsp",
-				CRLURL:            "http://not-example.com/crl",
-			},
-		)
-		return res
-	}
-	boulderIssuers := []*issuance.Issuer{
-		// Must list ECDSA-only issuer first, so it is the default for ECDSA.
-		{
-			Cert:    caCert2,
-			Signer:  caKey,
-			Profile: boulderProfile(false, true),
-			Linter:  caLinter2,
-			Clk:     fc,
+			MaxValidityPeriod:   config.Duration{Duration: time.Hour * 8760},
+			MaxValidityBackdate: config.Duration{Duration: time.Hour},
 		},
-		{
-			Cert:    caCert,
-			Signer:  caKey,
-			Profile: boulderProfile(true, true),
-			Linter:  caLinter,
-			Clk:     fc,
-		},
-	}
+		[]string{"w_subject_common_name_included"},
+	)
+	test.AssertNotError(t, err, "Couldn't create test profile")
+
+	ecdsaOnlyIssuer, err := issuance.LoadIssuer(issuance.IssuerConfig{
+		UseForRSALeaves:   false,
+		UseForECDSALeaves: true,
+		IssuerURL:         "http://not-example.com/issuer-url",
+		OCSPURL:           "http://not-example.com/ocsp",
+		CRLURL:            "http://not-example.com/crl",
+		Location:          issuance.IssuerLoc{File: caKeyFile, CertFile: caCertFile2},
+	}, fc)
+	test.AssertNotError(t, err, "Couldn't load test issuer")
+
+	ecdsaAndRSAIssuer, err := issuance.LoadIssuer(issuance.IssuerConfig{
+		UseForRSALeaves:   true,
+		UseForECDSALeaves: true,
+		IssuerURL:         "http://not-example.com/issuer-url",
+		OCSPURL:           "http://not-example.com/ocsp",
+		CRLURL:            "http://not-example.com/crl",
+		Location:          issuance.IssuerLoc{File: caKeyFile, CertFile: caCertFile},
+	}, fc)
+	test.AssertNotError(t, err, "Couldn't load test issuer")
+
+	// Must list ECDSA-only issuer first, so it is the default for ECDSA.
+	boulderIssuers := []*issuance.Issuer{ecdsaOnlyIssuer, ecdsaAndRSAIssuer}
 
 	keyPolicy := goodkey.KeyPolicy{
 		AllowRSA:           true,
@@ -254,6 +229,7 @@ func setup(t *testing.T) *testCtx {
 
 	crl, err := NewCRLImpl(
 		boulderIssuers,
+		boulderProfile.Lints,
 		time.Hour,
 		"http://c.boulder.test",
 		100,
@@ -265,6 +241,7 @@ func setup(t *testing.T) *testCtx {
 		pa:             pa,
 		ocsp:           ocsp,
 		crl:            crl,
+		profile:        boulderProfile,
 		certExpiry:     8760 * time.Hour,
 		certBackdate:   time.Hour,
 		serialPrefix:   17,
@@ -287,6 +264,7 @@ func TestSerialPrefix(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
 		0,
@@ -300,6 +278,7 @@ func TestSerialPrefix(t *testing.T) {
 	test.AssertError(t, err, "CA should have failed with no SerialPrefix")
 
 	_, err = NewCertificateAuthorityImpl(
+		nil,
 		nil,
 		nil,
 		nil,
@@ -396,6 +375,7 @@ func issueCertificateSubTestSetup(t *testing.T, e *ECDSAAllowList) (*certificate
 		sa,
 		testCtx.pa,
 		testCtx.boulderIssuers,
+		testCtx.profile,
 		e,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
@@ -441,6 +421,7 @@ func TestNoIssuers(t *testing.T) {
 		sa,
 		testCtx.pa,
 		nil, // No issuers
+		testCtx.profile,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
@@ -464,6 +445,7 @@ func TestMultipleIssuers(t *testing.T) {
 		sa,
 		testCtx.pa,
 		testCtx.boulderIssuers,
+		testCtx.profile,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
@@ -477,20 +459,20 @@ func TestMultipleIssuers(t *testing.T) {
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to remake CA")
 
-	// Test that an RSA CSR gets issuance from the RSA issuer, caCert.
+	// Test that an RSA CSR gets issuance from the RSA issuer.
 	issuedCert, err := ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	cert, err := x509.ParseCertificate(issuedCert.DER)
 	test.AssertNotError(t, err, "Certificate failed to parse")
-	err = cert.CheckSignatureFrom(caCert2.Certificate)
+	err = cert.CheckSignatureFrom(testCtx.boulderIssuers[1].Cert.Certificate)
 	test.AssertNotError(t, err, "Certificate failed signature validation")
 
-	// Test that an ECDSA CSR gets issuance from the ECDSA issuer, caCert2.
+	// Test that an ECDSA CSR gets issuance from the ECDSA issuer.
 	issuedCert, err = ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	cert, err = x509.ParseCertificate(issuedCert.DER)
 	test.AssertNotError(t, err, "Certificate failed to parse")
-	err = cert.CheckSignatureFrom(caCert2.Certificate)
+	err = cert.CheckSignatureFrom(testCtx.boulderIssuers[0].Cert.Certificate)
 	test.AssertNotError(t, err, "Certificate failed signature validation")
 }
 
@@ -504,7 +486,7 @@ func TestECDSAAllowList(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	cert, err := x509.ParseCertificate(result.DER)
 	test.AssertNotError(t, err, "Certificate failed to parse")
-	test.AssertByteEquals(t, cert.RawIssuer, caCert2.RawSubject)
+	test.AssertByteEquals(t, cert.RawIssuer, ca.issuers.byAlg[x509.ECDSA].Cert.RawSubject)
 
 	// With allowlist not containing arbitraryRegID, issuance should fall back to RSA issuer.
 	regIDMap = makeRegIDsMap([]int64{2002})
@@ -513,7 +495,7 @@ func TestECDSAAllowList(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	cert, err = x509.ParseCertificate(result.DER)
 	test.AssertNotError(t, err, "Certificate failed to parse")
-	test.AssertByteEquals(t, cert.RawIssuer, caCert.RawSubject)
+	test.AssertByteEquals(t, cert.RawIssuer, ca.issuers.byAlg[x509.RSA].Cert.RawSubject)
 
 	// With empty allowlist but ECDSAForAll enabled, issuance should come from ECDSA issuer.
 	ca, _ = issueCertificateSubTestSetup(t, nil)
@@ -523,7 +505,7 @@ func TestECDSAAllowList(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	cert, err = x509.ParseCertificate(result.DER)
 	test.AssertNotError(t, err, "Certificate failed to parse")
-	test.AssertByteEquals(t, cert.RawIssuer, caCert2.RawSubject)
+	test.AssertByteEquals(t, cert.RawIssuer, ca.issuers.byAlg[x509.ECDSA].Cert.RawSubject)
 }
 
 func TestInvalidCSRs(t *testing.T) {
@@ -585,6 +567,7 @@ func TestInvalidCSRs(t *testing.T) {
 			sa,
 			testCtx.pa,
 			testCtx.boulderIssuers,
+			testCtx.profile,
 			nil,
 			testCtx.certExpiry,
 			testCtx.certBackdate,
@@ -621,6 +604,7 @@ func TestRejectValidityTooLong(t *testing.T) {
 		sa,
 		testCtx.pa,
 		testCtx.boulderIssuers,
+		testCtx.profile,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
@@ -721,6 +705,7 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 		sa,
 		testCtx.pa,
 		testCtx.boulderIssuers,
+		testCtx.profile,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
@@ -826,6 +811,7 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		sa,
 		testCtx.pa,
 		testCtx.boulderIssuers,
+		testCtx.profile,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
@@ -867,6 +853,7 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		errorsa,
 		testCtx.pa,
 		testCtx.boulderIssuers,
+		testCtx.profile,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -476,6 +476,29 @@ func TestMultipleIssuers(t *testing.T) {
 	test.AssertNotError(t, err, "Certificate failed signature validation")
 }
 
+func TestNoProfile(t *testing.T) {
+	testCtx := setup(t)
+	sa := &mockSA{}
+	_, err := NewCertificateAuthorityImpl(
+		sa,
+		testCtx.pa,
+		testCtx.boulderIssuers,
+		nil, // no profile
+		nil,
+		testCtx.certExpiry,
+		testCtx.certBackdate,
+		testCtx.serialPrefix,
+		testCtx.maxNames,
+		testCtx.keyPolicy,
+		testCtx.logger,
+		testCtx.stats,
+		testCtx.signatureCount,
+		testCtx.signErrorCount,
+		testCtx.fc)
+	test.AssertError(t, err, "No profile found during CA construction.")
+	test.AssertEquals(t, err.Error(), "must have at least one certificate profile")
+}
+
 func TestECDSAAllowList(t *testing.T) {
 	req := &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID}
 

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/crypto/ocsp"
+
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/core"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
-	"golang.org/x/crypto/ocsp"
 )
 
 func TestImplementationOCSP(t *testing.T) {
@@ -34,6 +35,7 @@ func TestOCSP(t *testing.T) {
 		&mockSA{},
 		testCtx.pa,
 		testCtx.boulderIssuers,
+		testCtx.profile,
 		nil,
 		testCtx.certExpiry,
 		testCtx.certBackdate,
@@ -60,7 +62,7 @@ func TestOCSP(t *testing.T) {
 		Status:   string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "Failed to generate OCSP")
-	rsaOCSP, err := ocsp.ParseResponse(rsaOCSPPB.Response, caCert.Certificate)
+	rsaOCSP, err := ocsp.ParseResponse(rsaOCSPPB.Response, testCtx.boulderIssuers[1].Cert.Certificate)
 	test.AssertNotError(t, err, "Failed to parse / validate OCSP for rsaCert")
 	test.AssertEquals(t, rsaOCSP.Status, 0)
 	test.AssertEquals(t, rsaOCSP.RevocationReason, 0)
@@ -78,7 +80,7 @@ func TestOCSP(t *testing.T) {
 		Status:   string(core.OCSPStatusGood),
 	})
 	test.AssertNotError(t, err, "Failed to generate OCSP")
-	ecdsaOCSP, err := ocsp.ParseResponse(ecdsaOCSPPB.Response, caCert2.Certificate)
+	ecdsaOCSP, err := ocsp.ParseResponse(ecdsaOCSPPB.Response, testCtx.boulderIssuers[0].Cert.Certificate)
 	test.AssertNotError(t, err, "Failed to parse / validate OCSP for ecdsaCert")
 	test.AssertEquals(t, ecdsaOCSP.Status, 0)
 	test.AssertEquals(t, ecdsaOCSP.RevocationReason, 0)

--- a/crl/storer/storer_test.go
+++ b/crl/storer/storer_test.go
@@ -57,20 +57,26 @@ func setupTestUploadCRL(t *testing.T) (*crlStorer, *issuance.Issuer) {
 
 	r3, err := issuance.LoadCertificate("../../test/hierarchy/int-r3.cert.pem")
 	test.AssertNotError(t, err, "loading fake RSA issuer cert")
-	e1, e1Signer, err := issuance.LoadIssuer(issuance.IssuerLoc{
-		File:     "../../test/hierarchy/int-e1.key.pem",
-		CertFile: "../../test/hierarchy/int-e1.cert.pem",
-	})
+	issuerE1, err := issuance.LoadIssuer(
+		issuance.IssuerConfig{
+			Location: issuance.IssuerLoc{
+				File:     "../../test/hierarchy/int-e1.key.pem",
+				CertFile: "../../test/hierarchy/int-e1.cert.pem",
+			},
+			IssuerURL: "http://not-example.com/issuer-url",
+			OCSPURL:   "http://not-example.com/ocsp",
+			CRLURL:    "http://not-example.com/crl",
+		}, clock.NewFake())
 	test.AssertNotError(t, err, "loading fake ECDSA issuer cert")
 
 	storer, err := New(
-		[]*issuance.Certificate{r3, e1},
+		[]*issuance.Certificate{r3, issuerE1.Cert},
 		nil, "le-crl.s3.us-west.amazonaws.com",
 		metrics.NoopRegisterer, blog.NewMock(), clock.NewFake(),
 	)
 	test.AssertNotError(t, err, "creating test crl-storer")
 
-	return storer, &issuance.Issuer{Cert: e1, Signer: e1Signer}
+	return storer, issuerE1
 }
 
 // Test that we get an error when no metadata is sent.

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -353,7 +353,7 @@ func ContainsMustStaple(extensions []pkix.Extension) bool {
 	return false
 }
 
-// containtsCTPoison returns true if the provided set of extensions includes
+// containsCTPoison returns true if the provided set of extensions includes
 // an entry whose OID and value both match the expected values for the CT
 // Poison extension.
 func containsCTPoison(extensions []pkix.Extension) bool {

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -250,11 +250,12 @@ type issuanceToken struct {
 	issuer *Issuer
 }
 
-// Prepare applies this Issuer's profile to create a template certificate. It
-// then generates a linting certificate from that template and runs the linter
-// over it. If successful, returns both the linting certificate (which can be
-// stored) and an issuanceToken. The issuanceToken can be used to sign a
-// matching certificate with this Issuer's private key.
+// Prepare combines the given profile and request with the Issuer's information
+// to create a template certificate. It then generates a linting certificate
+// from that template and runs the linter over it. If successful, returns both
+// the linting certificate (which can be stored) and an issuanceToken. The
+// issuanceToken can be used to sign a matching certificate with this Issuer's
+// private key.
 func (i *Issuer) Prepare(prof *Profile, req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 	// check request is valid according to the issuance profile
 	err := i.requestValid(i.Clk, prof, req)

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -19,8 +19,10 @@ import (
 	cttls "github.com/google/certificate-transparency-go/tls"
 	ctx509 "github.com/google/certificate-transparency-go/x509"
 	"github.com/jmhodges/clock"
+	"github.com/zmap/zlint/v3/lint"
 
 	"github.com/letsencrypt/boulder/config"
+	"github.com/letsencrypt/boulder/linter"
 	"github.com/letsencrypt/boulder/precert"
 )
 
@@ -45,45 +47,34 @@ type PolicyConfig struct {
 
 // Profile is the validated structure created by reading in ProfileConfigs and IssuerConfigs
 type Profile struct {
-	useForRSALeaves   bool
-	useForECDSALeaves bool
-
 	allowMustStaple bool
 	allowCTPoison   bool
 	allowSCTList    bool
 	allowCommonName bool
 
-	sigAlg    x509.SignatureAlgorithm
-	ocspURL   string
-	crlURL    string
-	issuerURL string
-
 	maxBackdate time.Duration
 	maxValidity time.Duration
+
+	// TODO(#7159): Make this private when CRLs have their own profile.
+	Lints lint.Registry
 }
 
 // NewProfile synthesizes the profile config and issuer config into a single
 // object, and checks various aspects for correctness.
-func NewProfile(profileConfig ProfileConfig, issuerConfig IssuerConfig) (*Profile, error) {
-	if issuerConfig.IssuerURL == "" {
-		return nil, errors.New("Issuer URL is required")
-	}
-	if issuerConfig.OCSPURL == "" {
-		return nil, errors.New("OCSP URL is required")
+func NewProfile(profileConfig ProfileConfig, skipLints []string) (*Profile, error) {
+	reg, err := linter.NewRegistry(skipLints)
+	if err != nil {
+		return nil, fmt.Errorf("creating lint registry: %w", err)
 	}
 
 	sp := &Profile{
-		useForRSALeaves:   issuerConfig.UseForRSALeaves,
-		useForECDSALeaves: issuerConfig.UseForECDSALeaves,
-		allowMustStaple:   profileConfig.AllowMustStaple,
-		allowCTPoison:     profileConfig.AllowCTPoison,
-		allowSCTList:      profileConfig.AllowSCTList,
-		allowCommonName:   profileConfig.AllowCommonName,
-		issuerURL:         issuerConfig.IssuerURL,
-		crlURL:            issuerConfig.CRLURL,
-		ocspURL:           issuerConfig.OCSPURL,
-		maxBackdate:       profileConfig.MaxValidityBackdate.Duration,
-		maxValidity:       profileConfig.MaxValidityPeriod.Duration,
+		allowMustStaple: profileConfig.AllowMustStaple,
+		allowCTPoison:   profileConfig.AllowCTPoison,
+		allowSCTList:    profileConfig.AllowSCTList,
+		allowCommonName: profileConfig.AllowCommonName,
+		maxBackdate:     profileConfig.MaxValidityBackdate.Duration,
+		maxValidity:     profileConfig.MaxValidityPeriod.Duration,
+		Lints:           reg,
 	}
 
 	return sp, nil
@@ -91,14 +82,14 @@ func NewProfile(profileConfig ProfileConfig, issuerConfig IssuerConfig) (*Profil
 
 // requestValid verifies the passed IssuanceRequest against the profile. If the
 // request doesn't match the signing profile an error is returned.
-func (p *Profile) requestValid(clk clock.Clock, req *IssuanceRequest) error {
+func (i *Issuer) requestValid(clk clock.Clock, prof *Profile, req *IssuanceRequest) error {
 	switch req.PublicKey.(type) {
 	case *rsa.PublicKey:
-		if !p.useForRSALeaves {
+		if !i.useForRSALeaves {
 			return errors.New("cannot sign RSA public keys")
 		}
 	case *ecdsa.PublicKey:
-		if !p.useForECDSALeaves {
+		if !i.useForECDSALeaves {
 			return errors.New("cannot sign ECDSA public keys")
 		}
 	default:
@@ -109,15 +100,15 @@ func (p *Profile) requestValid(clk clock.Clock, req *IssuanceRequest) error {
 		return errors.New("unexpected subject key ID length")
 	}
 
-	if !p.allowMustStaple && req.IncludeMustStaple {
+	if !prof.allowMustStaple && req.IncludeMustStaple {
 		return errors.New("must-staple extension cannot be included")
 	}
 
-	if !p.allowCTPoison && req.IncludeCTPoison {
+	if !prof.allowCTPoison && req.IncludeCTPoison {
 		return errors.New("ct poison extension cannot be included")
 	}
 
-	if !p.allowSCTList && req.sctList != nil {
+	if !prof.allowSCTList && req.sctList != nil {
 		return errors.New("sct list extension cannot be included")
 	}
 
@@ -125,7 +116,7 @@ func (p *Profile) requestValid(clk clock.Clock, req *IssuanceRequest) error {
 		return errors.New("cannot include both ct poison and sct list extensions")
 	}
 
-	if !p.allowCommonName && req.CommonName != "" {
+	if !prof.allowCommonName && req.CommonName != "" {
 		return errors.New("common name cannot be included")
 	}
 
@@ -135,12 +126,12 @@ func (p *Profile) requestValid(clk clock.Clock, req *IssuanceRequest) error {
 	if validity <= 0 {
 		return errors.New("NotAfter must be after NotBefore")
 	}
-	if validity > p.maxValidity {
-		return fmt.Errorf("validity period is more than the maximum allowed period (%s>%s)", validity, p.maxValidity)
+	if validity > prof.maxValidity {
+		return fmt.Errorf("validity period is more than the maximum allowed period (%s>%s)", validity, prof.maxValidity)
 	}
 	backdatedBy := clk.Now().Sub(req.NotBefore)
-	if backdatedBy > p.maxBackdate {
-		return fmt.Errorf("NotBefore is backdated more than the maximum allowed period (%s>%s)", backdatedBy, p.maxBackdate)
+	if backdatedBy > prof.maxBackdate {
+		return fmt.Errorf("NotBefore is backdated more than the maximum allowed period (%s>%s)", backdatedBy, prof.maxBackdate)
 	}
 	if backdatedBy < 0 {
 		return errors.New("NotBefore is in the future")
@@ -156,24 +147,22 @@ func (p *Profile) requestValid(clk clock.Clock, req *IssuanceRequest) error {
 	return nil
 }
 
-var defaultEKU = []x509.ExtKeyUsage{
-	x509.ExtKeyUsageServerAuth,
-	x509.ExtKeyUsageClientAuth,
-}
-
-func (p *Profile) generateTemplate() *x509.Certificate {
+func (i *Issuer) generateTemplate() *x509.Certificate {
 	template := &x509.Certificate{
-		SignatureAlgorithm:    p.sigAlg,
-		ExtKeyUsage:           defaultEKU,
-		OCSPServer:            []string{p.ocspURL},
-		IssuingCertificateURL: []string{p.issuerURL},
+		SignatureAlgorithm: i.sigAlg,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		OCSPServer:            []string{i.ocspURL},
+		IssuingCertificateURL: []string{i.issuerURL},
 		BasicConstraintsValid: true,
 		// Baseline Requirements, Section 7.1.6.1: domain-validated
 		PolicyIdentifiers: []asn1.ObjectIdentifier{{2, 23, 140, 1, 2, 1}},
 	}
 
-	if p.crlURL != "" {
-		template.CRLDistributionPoints = []string{p.crlURL}
+	if i.crlURL != "" {
+		template.CRLDistributionPoints = []string{i.crlURL}
 	}
 
 	return template
@@ -266,15 +255,15 @@ type issuanceToken struct {
 // over it. If successful, returns both the linting certificate (which can be
 // stored) and an issuanceToken. The issuanceToken can be used to sign a
 // matching certificate with this Issuer's private key.
-func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
+func (i *Issuer) Prepare(prof *Profile, req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 	// check request is valid according to the issuance profile
-	err := i.Profile.requestValid(i.Clk, req)
+	err := i.requestValid(i.Clk, prof, req)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// generate template from the issuance profile
-	template := i.Profile.generateTemplate()
+	// generate template from the issuer's data
+	template := i.generateTemplate()
 
 	// populate template from the issuance request
 	template.NotBefore, template.NotAfter = req.NotBefore, req.NotAfter
@@ -314,7 +303,7 @@ func (i *Issuer) Prepare(req *IssuanceRequest) ([]byte, *issuanceToken, error) {
 
 	// check that the tbsCertificate is properly formed by signing it
 	// with a throwaway key and then linting it using zlint
-	lintCertBytes, err := i.Linter.Check(template, req.PublicKey)
+	lintCertBytes, err := i.Linter.Check(template, req.PublicKey, prof.Lints)
 	if err != nil {
 		return nil, nil, fmt.Errorf("tbsCertificate linting failed: %w", err)
 	}
@@ -352,6 +341,9 @@ func (i *Issuer) Issue(token *issuanceToken) ([]byte, error) {
 	return x509.CreateCertificate(rand.Reader, template, i.Cert.Certificate, token.pubKey, i.Signer)
 }
 
+// ContainsMustStaple returns true if the provided set of extensions includes
+// an entry whose OID and value both match the expected values for the OCSP
+// Must-Staple (a.k.a. id-pe-tlsFeature) extension.
 func ContainsMustStaple(extensions []pkix.Extension) bool {
 	for _, ext := range extensions {
 		if ext.Id.Equal(mustStapleExt.Id) && bytes.Equal(ext.Value, mustStapleExt.Value) {
@@ -361,6 +353,9 @@ func ContainsMustStaple(extensions []pkix.Extension) bool {
 	return false
 }
 
+// containtsCTPoison returns true if the provided set of extensions includes
+// an entry whose OID and value both match the expected values for the CT
+// Poison extension.
 func containsCTPoison(extensions []pkix.Extension) bool {
 	for _, ext := range extensions {
 		if ext.Id.Equal(ctPoisonExt.Id) && bytes.Equal(ext.Value, asn1.NullBytes) {

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -97,7 +97,7 @@ func NewCertificate(ic *x509.Certificate) (*Certificate, error) {
 func LoadCertificate(path string) (*Certificate, error) {
 	cert, err := core.LoadCert(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading issuer certificate: %w", err)
 	}
 	return NewCertificate(cert)
 }
@@ -178,51 +178,83 @@ type IssuerLoc struct {
 	NumSessions int
 }
 
-// Issuer is capable of issuing new certificates
-// TODO(#5086): make Cert and Signer private when they're no longer needed by ca.internalIssuer
+// Issuer is capable of issuing new certificates.
 type Issuer struct {
-	Cert    *Certificate
-	Signer  crypto.Signer
-	Profile *Profile
-	Linter  *linter.Linter
-	Clk     clock.Clock
+	// TODO(#7159): make Cert, Signer, and Linter private when all signing ops
+	// are handled through this package (e.g. the CA doesn't need direct access
+	// while signing CRLs anymore).
+	Cert   *Certificate
+	Signer crypto.Signer
+	Linter *linter.Linter
+
+	sigAlg            x509.SignatureAlgorithm
+	useForRSALeaves   bool
+	useForECDSALeaves bool
+
+	issuerURL string
+	ocspURL   string
+	crlURL    string
+
+	// TODO(#7159): Make Clk private by giving ca_test.go a better way to build
+	// in-memory Issuers.
+	Clk clock.Clock
 }
 
-// NewIssuer constructs an Issuer on the heap, verifying that the profile
-// is well-formed.
-func NewIssuer(cert *Certificate, signer crypto.Signer, profile *Profile, linter *linter.Linter, clk clock.Clock) (*Issuer, error) {
+// newIssuer constructs a new Issuer from the in-memory certificate and signer.
+// It exists as a helper for LoadIssuer to make testing simpler.
+func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk clock.Clock) (*Issuer, error) {
+	var sigAlg x509.SignatureAlgorithm
 	switch k := cert.PublicKey.(type) {
 	case *rsa.PublicKey:
-		profile.sigAlg = x509.SHA256WithRSA
+		sigAlg = x509.SHA256WithRSA
 	case *ecdsa.PublicKey:
 		switch k.Curve {
 		case elliptic.P256():
-			profile.sigAlg = x509.ECDSAWithSHA256
+			sigAlg = x509.ECDSAWithSHA256
 		case elliptic.P384():
-			profile.sigAlg = x509.ECDSAWithSHA384
+			sigAlg = x509.ECDSAWithSHA384
 		default:
-			return nil, fmt.Errorf("unsupported ECDSA curve: %s", k.Curve.Params().Name)
+			return nil, fmt.Errorf("unsupported ECDSA curve: %q", k.Curve.Params().Name)
 		}
 	default:
 		return nil, errors.New("unsupported issuer key type")
 	}
 
-	if profile.useForRSALeaves || profile.useForECDSALeaves {
-		if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
-			return nil, errors.New("end-entity signing cert does not have keyUsage certSign")
-		}
+	if config.IssuerURL == "" {
+		return nil, errors.New("Issuer URL is required")
 	}
-	// TODO(#5086): Only do this check for ocsp-issuing issuers.
+	if config.OCSPURL == "" {
+		return nil, errors.New("OCSP URL is required")
+	}
+
+	// We require that all of our issuers be capable of both issuing certs and
+	// providing revocation information.
+	if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return nil, errors.New("end-entity signing cert does not have keyUsage certSign")
+	}
+	if cert.KeyUsage&x509.KeyUsageCRLSign == 0 {
+		return nil, errors.New("end-entity signing cert does not have keyUsage crlSign")
+	}
 	if cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
-		return nil, errors.New("end-entity ocsp signing cert does not have keyUsage digitalSignature")
+		return nil, errors.New("end-entity signing cert does not have keyUsage digitalSignature")
+	}
+
+	lintSigner, err := linter.New(cert.Certificate, signer)
+	if err != nil {
+		return nil, fmt.Errorf("creating fake lint signer: %w", err)
 	}
 
 	i := &Issuer{
-		Cert:    cert,
-		Signer:  signer,
-		Profile: profile,
-		Linter:  linter,
-		Clk:     clk,
+		Cert:              cert,
+		Signer:            signer,
+		Linter:            lintSigner,
+		sigAlg:            sigAlg,
+		useForRSALeaves:   config.UseForRSALeaves,
+		useForECDSALeaves: config.UseForECDSALeaves,
+		issuerURL:         config.IssuerURL,
+		ocspURL:           config.OCSPURL,
+		crlURL:            config.CRLURL,
+		Clk:               clk,
 	}
 	return i, nil
 }
@@ -232,10 +264,10 @@ func NewIssuer(cert *Certificate, signer crypto.Signer, profile *Profile, linter
 // public key algorithm or signature algorithm in this issuer's own cert.
 func (i *Issuer) Algs() []x509.PublicKeyAlgorithm {
 	var algs []x509.PublicKeyAlgorithm
-	if i.Profile.useForRSALeaves {
+	if i.useForRSALeaves {
 		algs = append(algs, x509.RSA)
 	}
-	if i.Profile.useForECDSALeaves {
+	if i.useForECDSALeaves {
 		algs = append(algs, x509.ECDSA)
 	}
 	return algs
@@ -251,25 +283,32 @@ func (i *Issuer) NameID() NameID {
 	return i.Cert.NameID()
 }
 
-// LoadIssuer loads a signer (private key) and certificate from the locations specified.
-func LoadIssuer(location IssuerLoc) (*Certificate, crypto.Signer, error) {
-	issuerCert, err := LoadCertificate(location.CertFile)
+// LoadIssuer constructs a new Issuer, loading its certificate from disk and its
+// private key material from the indicated location. It also verifies that the
+// issuer metadata (such a AIA URLs) is well-formed.
+func LoadIssuer(config IssuerConfig, clk clock.Clock) (*Issuer, error) {
+	issuerCert, err := LoadCertificate(config.Location.CertFile)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	signer, err := loadSigner(location, issuerCert)
+	signer, err := loadSigner(config.Location, issuerCert.PublicKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if !core.KeyDigestEquals(signer.Public(), issuerCert.PublicKey) {
-		return nil, nil, fmt.Errorf("Issuer key did not match issuer cert %s", location.CertFile)
+		return nil, fmt.Errorf("issuer key did not match issuer cert %q", config.Location.CertFile)
 	}
-	return issuerCert, signer, err
+
+	return newIssuer(config, issuerCert, signer, clk)
 }
 
-func loadSigner(location IssuerLoc, cert *Certificate) (crypto.Signer, error) {
+func loadSigner(location IssuerLoc, pubkey crypto.PublicKey) (crypto.Signer, error) {
+	if location.File == "" && location.ConfigFile == "" && location.PKCS11 == nil {
+		return nil, errors.New("must supply File, ConfigFile, or PKCS11")
+	}
+
 	if location.File != "" {
 		signer, _, err := privatekey.Load(location.File)
 		if err != nil {
@@ -305,5 +344,5 @@ func loadSigner(location IssuerLoc, cert *Certificate) (crypto.Signer, error) {
 	}
 
 	return pkcs11key.NewPool(numSessions, pkcs11Config.Module,
-		pkcs11Config.TokenLabel, pkcs11Config.PIN, cert.PublicKey)
+		pkcs11Config.TokenLabel, pkcs11Config.PIN, pubkey)
 }

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -285,7 +285,7 @@ func (i *Issuer) NameID() NameID {
 
 // LoadIssuer constructs a new Issuer, loading its certificate from disk and its
 // private key material from the indicated location. It also verifies that the
-// issuer metadata (such a AIA URLs) is well-formed.
+// issuer metadata (such as AIA URLs) is well-formed.
 func LoadIssuer(config IssuerConfig, clk clock.Clock) (*Issuer, error) {
 	issuerCert, err := LoadCertificate(config.Location.CertFile)
 	if err != nil {

--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -116,11 +116,10 @@ func TestLoadSigner(t *testing.T) {
 		{"ECDSA key file", IssuerLoc{File: "../test/hierarchy/int-e1.key.pem"}, ""},
 		{"RSA key file", IssuerLoc{File: "../test/hierarchy/int-r3.key.pem"}, ""},
 		{"invalid config file", IssuerLoc{ConfigFile: "../test/example-weak-keys.json"}, "json: cannot unmarshal"},
-		// Note that this valid config file still results in an error, because we
-		// don't supply the correct public key so pkcs11key can't look up the
-		// corresponding private key in the softhsm (which we only want to use in
-		// integration tests anyway).
-		{"valid config file", IssuerLoc{ConfigFile: "../test/test-ca.key-pkcs11.json"}, "looking up public key: no objects found"},
+		// Note that we don't have a test for "valid config file" because it would
+		// always fail -- in CI, the softhsm hasn't been initialized, so there's no
+		// key to look up; locally even if the softhsm has been initialized, the
+		// keys in it don't match the fakeKey we generated above.
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
-	"github.com/letsencrypt/boulder/linter"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -57,7 +56,7 @@ func TestMain(m *testing.M) {
 		Subject: pkix.Name{
 			CommonName: "big ca",
 		},
-		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		KeyUsage: x509.KeyUsageCRLSign | x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
 	}
 	issuer, err := x509.CreateCertificate(rand.Reader, template, template, tk.Public(), tk)
 	cmd.FailOnError(err, "failed to generate test issuer")
@@ -67,90 +66,151 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestNewIssuer(t *testing.T) {
-	_, err := NewIssuer(
+func TestLoadCertificate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{"invalid cert file", "../test/hierarchy/int-e1.crl.pem", "loading issuer certificate"},
+		{"non-CA cert file", "../test/hierarchy/ee-e1.cert.pem", "not a CA certificate"},
+		{"happy path", "../test/hierarchy/int-e1.cert.pem", ""},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadCertificate(tc.path)
+			if err != nil {
+				if tc.wantErr != "" {
+					test.AssertContains(t, err.Error(), tc.wantErr)
+				} else {
+					t.Errorf("expected no error but got %v", err)
+				}
+			} else {
+				if tc.wantErr != "" {
+					t.Errorf("expected error %q but got none", tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadSigner(t *testing.T) {
+	t.Parallel()
+
+	// We're using this for its pubkey. This definitely doesn't match the private
+	// key loaded in any of the tests below, but that's okay because it still gets
+	// us through all the logic in loadSigner.
+	fakeKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	test.AssertNotError(t, err, "generating test key")
+
+	tests := []struct {
+		name    string
+		loc     IssuerLoc
+		wantErr string
+	}{
+		{"empty IssuerLoc", IssuerLoc{}, "must supply"},
+		{"invalid key file", IssuerLoc{File: "../test/hierarchy/int-e1.crl.pem"}, "unable to parse"},
+		{"ECDSA key file", IssuerLoc{File: "../test/hierarchy/int-e1.key.pem"}, ""},
+		{"RSA key file", IssuerLoc{File: "../test/hierarchy/int-r3.key.pem"}, ""},
+		{"invalid config file", IssuerLoc{ConfigFile: "../test/example-weak-keys.json"}, "json: cannot unmarshal"},
+		// Note that this valid config file still results in an error, because we
+		// don't supply the correct public key so pkcs11key can't look up the
+		// corresponding private key in the softhsm (which we only want to use in
+		// integration tests anyway).
+		{"valid config file", IssuerLoc{ConfigFile: "../test/test-ca.key-pkcs11.json"}, "looking up public key: no objects found"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := loadSigner(tc.loc, fakeKey.Public())
+			if err != nil {
+				if tc.wantErr != "" {
+					test.AssertContains(t, err.Error(), tc.wantErr)
+				} else {
+					t.Errorf("expected no error but got %v", err)
+				}
+			} else {
+				if tc.wantErr != "" {
+					t.Errorf("expected error %q but got none", tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadIssuer(t *testing.T) {
+	_, err := newIssuer(
+		defaultIssuerConfig(),
 		issuerCert,
 		issuerSigner,
-		defaultProfile(),
-		&linter.Linter{},
 		clock.NewFake(),
 	)
-	test.AssertNotError(t, err, "NewIssuer failed")
+	test.AssertNotError(t, err, "newIssuer failed")
 }
 
 func TestNewIssuerUnsupportedKeyType(t *testing.T) {
-	_, err := NewIssuer(
+	_, err := newIssuer(
+		defaultIssuerConfig(),
 		&Certificate{
 			Certificate: &x509.Certificate{
 				PublicKey: &ed25519.PublicKey{},
 			},
 		},
 		&ed25519.PrivateKey{},
-		defaultProfile(),
-		&linter.Linter{},
 		clock.NewFake(),
 	)
-	test.AssertError(t, err, "NewIssuer didn't fail")
+	test.AssertError(t, err, "newIssuer didn't fail")
 	test.AssertEquals(t, err.Error(), "unsupported issuer key type")
 }
 
-func TestNewIssuerNoCertSign(t *testing.T) {
-	_, err := NewIssuer(
-		&Certificate{
-			Certificate: &x509.Certificate{
-				PublicKey: &ecdsa.PublicKey{
-					Curve: elliptic.P256(),
-				},
-				KeyUsage: 0,
-			},
-		},
-		issuerSigner,
-		defaultProfile(),
-		&linter.Linter{},
-		clock.NewFake(),
-	)
-	test.AssertError(t, err, "NewIssuer didn't fail")
-	test.AssertEquals(t, err.Error(), "end-entity signing cert does not have keyUsage certSign")
-}
+func TestNewIssuerKeyUsage(t *testing.T) {
+	t.Parallel()
 
-func TestNewIssuerNoDigitalSignature(t *testing.T) {
-	_, err := NewIssuer(
-		&Certificate{
-			Certificate: &x509.Certificate{
-				PublicKey: &ecdsa.PublicKey{
-					Curve: elliptic.P256(),
+	tests := []struct {
+		name    string
+		ku      x509.KeyUsage
+		wantErr string
+	}{
+		{"missing certSign", x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature, "does not have keyUsage certSign"},
+		{"missing crlSign", x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature, "does not have keyUsage crlSign"},
+		{"missing digitalSignature", x509.KeyUsageCertSign | x509.KeyUsageCRLSign, "does not have keyUsage digitalSignature"},
+		{"all three", x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature, ""},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := newIssuer(
+				defaultIssuerConfig(),
+				&Certificate{
+					Certificate: &x509.Certificate{
+						SerialNumber: big.NewInt(123),
+						PublicKey: &ecdsa.PublicKey{
+							Curve: elliptic.P256(),
+						},
+						KeyUsage: tc.ku,
+					},
 				},
-				KeyUsage: x509.KeyUsageCertSign,
-			},
-		},
-		issuerSigner,
-		defaultProfile(),
-		&linter.Linter{},
-		clock.NewFake(),
-	)
-	test.AssertError(t, err, "NewIssuer didn't fail")
-	test.AssertEquals(t, err.Error(), "end-entity ocsp signing cert does not have keyUsage digitalSignature")
-}
-
-func TestNewIssuerOCSPOnly(t *testing.T) {
-	p := defaultProfile()
-	p.useForRSALeaves = false
-	p.useForECDSALeaves = false
-	_, err := NewIssuer(
-		&Certificate{
-			Certificate: &x509.Certificate{
-				PublicKey: &ecdsa.PublicKey{
-					Curve: elliptic.P256(),
-				},
-				KeyUsage: x509.KeyUsageDigitalSignature,
-			},
-		},
-		issuerSigner,
-		p,
-		&linter.Linter{},
-		clock.NewFake(),
-	)
-	test.AssertNotError(t, err, "NewIssuer failed")
+				issuerSigner,
+				clock.NewFake(),
+			)
+			if err != nil {
+				if tc.wantErr != "" {
+					test.AssertContains(t, err.Error(), tc.wantErr)
+				} else {
+					t.Errorf("expected no error but got %v", err)
+				}
+			} else {
+				if tc.wantErr != "" {
+					t.Errorf("expected error %q but got none", tc.wantErr)
+				}
+			}
+		})
+	}
 }
 
 func TestLoadChain_Valid(t *testing.T) {


### PR DESCRIPTION
Remove the Profile field from issuance.Issuer, to reflect the fact that profiles are in fact independent pieces of configuration which can be shared across (and are configured independently of) multiple issuers.

Move the IssuerURL, OCSPUrl, and CRLURL fields from issuance.Profile to issuance.Issuer, since they reflect fundamental attributes of the issuer, rather than attributes of a particular profile. This also reflects the location at which those values are configured, in issuance.IssuerConfig.

All other changes are fallout from the above: adding a Profile argument to various methods in the issuance and linting packages, adding a profile field to the caImpl struct, etc. This change paves the way for two future changes: moving OCSP and CRL creation into the issuance package, and supporting multiple simultaneous profiles that the CA can select between.

Part of https://github.com/letsencrypt/boulder/issues/7159
Part of https://github.com/letsencrypt/boulder/issues/6316
Part of https://github.com/letsencrypt/boulder/issues/6966