### PR TITLE
WFE/ARI: Add method for tracking certificate replacement

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -493,6 +493,12 @@ type SuggestedWindow struct {
 	End   time.Time `json:"end"`
 }
 
+// IsWithin returns true if the given time is within the suggested window,
+// inclusive of the start and end times.
+func (window SuggestedWindow) IsWithin(now time.Time) bool {
+	return !now.Before(window.Start) && !now.After(window.End)
+}
+
 // RenewalInfo is a type which is exposed to clients which query the renewalInfo
 // endpoint specified in draft-aaron-ari.
 type RenewalInfo struct {

--- a/core/objects.go
+++ b/core/objects.go
@@ -494,9 +494,9 @@ type SuggestedWindow struct {
 }
 
 // IsWithin returns true if the given time is within the suggested window,
-// inclusive of the start and end times.
+// inclusive of the start time and exclusive of the end time.
 func (window SuggestedWindow) IsWithin(now time.Time) bool {
-	return !now.Before(window.Start) && !now.After(window.End)
+	return !now.Before(window.Start) && now.Before(window.End)
 }
 
 // RenewalInfo is a type which is exposed to clients which query the renewalInfo

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -190,7 +190,7 @@ func TestRenewalInfoSuggestedWindowIsWithin(t *testing.T) {
 	test.Assert(t, window.IsWithin(now.Add(time.Minute*30)), "Middle of window should be within the window")
 
 	// Exactly the end, inclusive of the last nanosecond.
-	test.Assert(t, window.IsWithin(now.Add(time.Hour)), "End of window should be within the window")
+	test.Assert(t, !window.IsWithin(now.Add(time.Hour)), "End of window should be outside the window")
 
 	// Just before the first nanosecond.
 	test.Assert(t, !window.IsWithin(now.Add(-time.Nanosecond)), "Before the window should not be within the window")

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -189,12 +189,12 @@ func TestRenewalInfoSuggestedWindowIsWithin(t *testing.T) {
 	// Exactly the middle.
 	test.Assert(t, window.IsWithin(now.Add(time.Minute*30)), "Middle of window should be within the window")
 
-	// Exactly the end, inclusive of the last nanosecond.
+	// Exactly the end time.
 	test.Assert(t, !window.IsWithin(now.Add(time.Hour)), "End of window should be outside the window")
+
+	// Exactly the end of the window.
+	test.Assert(t, window.IsWithin(now.Add(time.Hour-time.Nanosecond)), "Should be just inside the window")
 
 	// Just before the first nanosecond.
 	test.Assert(t, !window.IsWithin(now.Add(-time.Nanosecond)), "Before the window should not be within the window")
-
-	// Just after the last nanosecond.
-	test.Assert(t, !window.IsWithin(now.Add(time.Hour+time.Nanosecond)), "After the window should not be within the window")
 }

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net"
 	"testing"
+	"time"
 
 	"gopkg.in/go-jose/go-jose.v2"
 
@@ -173,4 +174,27 @@ func TestFindChallengeByType(t *testing.T) {
 	test.AssertEquals(t, 0, authz.FindChallengeByStringID(authz.Challenges[0].StringID()))
 	test.AssertEquals(t, 1, authz.FindChallengeByStringID(authz.Challenges[1].StringID()))
 	test.AssertEquals(t, -1, authz.FindChallengeByStringID("hello"))
+}
+
+func TestRenewalInfoSuggestedWindowIsWithin(t *testing.T) {
+	now := time.Now().UTC()
+	window := SuggestedWindow{
+		Start: now,
+		End:   now.Add(time.Hour),
+	}
+
+	// Exactly the beginning, inclusive of the first nanosecond.
+	test.Assert(t, window.IsWithin(now), "Start of window should be within the window")
+
+	// Exactly the middle.
+	test.Assert(t, window.IsWithin(now.Add(time.Minute*30)), "Middle of window should be within the window")
+
+	// Exactly the end, inclusive of the last nanosecond.
+	test.Assert(t, window.IsWithin(now.Add(time.Hour)), "End of window should be within the window")
+
+	// Just before the first nanosecond.
+	test.Assert(t, !window.IsWithin(now.Add(-time.Nanosecond)), "Before the window should not be within the window")
+
+	// Just after the last nanosecond.
+	test.Assert(t, !window.IsWithin(now.Add(time.Hour+time.Nanosecond)), "After the window should not be within the window")
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2324,7 +2324,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 
 	replaces, limitsExempt, err := wfe.validateReplacementOrder(ctx, acct, names, newOrderRequest.Replaces)
 	if err != nil {
-		wfe.sendError(response, logEvent, probs.Malformed("Error validating replaces field"), err)
+		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "While validating order as a replacement and error occurred"), err)
 		return
 	}
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2204,9 +2204,16 @@ func (wfe *WebFrontEndImpl) determineARIWindow(ctx context.Context, serial strin
 //  2. MUST be associated with the same ACME account as this request, and
 //  3. MUST have at least one identifier in common with this request.
 //
-// When a replacement order does not meet these criteria, an error is returned.
-// If it meets the criteria, but the request is not within the suggested renewal
-// window, the limitsExempt bool returned is set to false.
+// There are three values returned by this function:
+//   - The first return value is the serial number of the certificate being
+//     replaced. If the order is not a replacement, this value is an empty
+//     string.
+//   - The second return value is a boolean indicating whether the order is
+//     exempt from rate limits. If the order is a replacement and the request
+//     is made within the suggested renewal window, this value is true.
+//     Otherwise, this value is false.
+//   - The last value is an error, this is non-nil unless the order is not a
+//     replacement or there was an error while validating the replacement.
 func (wfe *WebFrontEndImpl) validateReplacementOrder(ctx context.Context, acct *core.Registration, names []string, replaces string) (string, bool, error) {
 	if replaces == "" {
 		// No replacement indicated.

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2204,7 +2204,7 @@ func (wfe *WebFrontEndImpl) determineARIWindow(ctx context.Context, serial strin
 //  2. MUST be associated with the same ACME account as this request, and
 //  3. MUST have at least one identifier in common with this request.
 //
-// When a replacment order does not meet these criteria, an error is returned.
+// When a replacement order does not meet these criteria, an error is returned.
 // If it meets the criteria, but the request is not within the suggested renewal
 // window, the limitsExempt bool returned is set to false.
 func (wfe *WebFrontEndImpl) validateReplacementOrder(ctx context.Context, acct *core.Registration, names []string, replaces string) (string, bool, error) {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3986,3 +3986,67 @@ func Test_sendError(t *testing.T) {
 	// Ensure the Link header isn't populatsed.
 	test.AssertEquals(t, testResponse.Header().Get("Link"), "")
 }
+
+type mockSA struct {
+	sapb.StorageAuthorityReadOnlyClient
+	cert *corepb.Certificate
+}
+
+// GetCertificate returns the inner certificate if it matches the given serial.
+func (sa *mockSA) GetCertificate(ctx context.Context, req *sapb.Serial, _ ...grpc.CallOption) (*corepb.Certificate, error) {
+	if req.Serial == sa.cert.Serial {
+		return sa.cert, nil
+	}
+	return nil, berrors.NotFoundError("certificate with serial %q not found", req.Serial)
+}
+
+func TestOrderMatchesReplacement(t *testing.T) {
+	wfe, _, _ := setupWFE(t)
+
+	expectExpiry := time.Now().AddDate(0, 0, 1)
+	expectSerial := big.NewInt(1337)
+	testKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	rawCert := x509.Certificate{
+		NotAfter:     expectExpiry,
+		DNSNames:     []string{"example.com", "example-a.com"},
+		SerialNumber: expectSerial,
+	}
+	mockDer, err := x509.CreateCertificate(rand.Reader, &rawCert, &rawCert, &testKey.PublicKey, testKey)
+	test.AssertNotError(t, err, "failed to create test certificate")
+
+	wfe.sa = &mockSA{
+		cert: &corepb.Certificate{
+			RegistrationID: 1,
+			Serial:         expectSerial.String(),
+			Der:            mockDer,
+		},
+	}
+
+	// Working with a single matching identifier.
+	prob, err := wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example.com"}, expectSerial.String())
+	test.Assert(t, prob == nil, "expected no problem")
+	test.AssertNotError(t, err, "failed to check order replacement")
+
+	// Working with a different matching identifier.
+	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example-a.com"}, expectSerial.String())
+	test.Assert(t, prob == nil, "expected no problem")
+	test.AssertNotError(t, err, "failed to check order replacement")
+
+	// No matching identifiers.
+	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example-b.com"}, expectSerial.String())
+	test.Assert(t, prob != nil, "expected a problem")
+	test.AssertNotError(t, err, "failed to check order replacement")
+	test.AssertEquals(t, prob.Detail, "Certificate replaced by this order does not have matching identifiers")
+
+	// RegID for predecessor order does not match.
+	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 2}, []string{"example.com"}, expectSerial.String())
+	test.Assert(t, prob != nil, "expected a problem")
+	test.AssertNotError(t, err, "failed to check order replacement")
+	test.AssertEquals(t, prob.Detail, "Requester account did request the certificate being replaced by this order")
+
+	// Predecessor certificate not found.
+	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example.com"}, "1")
+	test.Assert(t, prob != nil, "expected a problem")
+	test.AssertErrorIs(t, err, berrors.NotFound)
+	test.AssertEquals(t, prob.Detail, "Existing certificate could not be found")
+}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -4023,30 +4023,22 @@ func TestOrderMatchesReplacement(t *testing.T) {
 	}
 
 	// Working with a single matching identifier.
-	prob, err := wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example.com"}, expectSerial.String())
-	test.Assert(t, prob == nil, "expected no problem")
-	test.AssertNotError(t, err, "failed to check order replacement")
+	err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example.com"}, expectSerial.String())
+	test.AssertNotError(t, err, "failed to check order is replacement")
 
 	// Working with a different matching identifier.
-	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example-a.com"}, expectSerial.String())
-	test.Assert(t, prob == nil, "expected no problem")
-	test.AssertNotError(t, err, "failed to check order replacement")
+	err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example-a.com"}, expectSerial.String())
+	test.AssertNotError(t, err, "failed to check order is replacement")
 
 	// No matching identifiers.
-	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example-b.com"}, expectSerial.String())
-	test.Assert(t, prob != nil, "expected a problem")
-	test.AssertNotError(t, err, "failed to check order replacement")
-	test.AssertEquals(t, prob.Detail, "Certificate replaced by this order does not have matching identifiers")
+	err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example-b.com"}, expectSerial.String())
+	test.AssertErrorIs(t, err, berrors.Malformed)
 
 	// RegID for predecessor order does not match.
-	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 2}, []string{"example.com"}, expectSerial.String())
-	test.Assert(t, prob != nil, "expected a problem")
-	test.AssertNotError(t, err, "failed to check order replacement")
-	test.AssertEquals(t, prob.Detail, "Requester account did request the certificate being replaced by this order")
+	err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 2}, []string{"example.com"}, expectSerial.String())
+	test.AssertErrorIs(t, err, berrors.Unauthorized)
 
 	// Predecessor certificate not found.
-	prob, err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example.com"}, "1")
-	test.Assert(t, prob != nil, "expected a problem")
+	err = wfe.orderMatchesReplacement(context.Background(), &core.Registration{ID: 1}, []string{"example.com"}, "1")
 	test.AssertErrorIs(t, err, berrors.NotFound)
-	test.AssertEquals(t, prob.Detail, "Existing certificate could not be found")
 }


### PR DESCRIPTION
Implement draft-ietf-acme-ari-02 changes in WFE newOrder:
- Add a `replaces` field to the newOrder request object
- Ensure that `replaces` values provided by subscribers are vetted according to the requirements set out in the draft specification
- When a NewOrder request falls inside the suggested RenewalWindow, exempt from rate limits in the WFE and indicate exemption in the RA NewOrder request

Part of #7038