### PR TITLE
va: remove arg from processRemoteCAAResults

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -215,6 +215,7 @@ func (va *ValidationAuthorityImpl) processRemoteCAAResults(
 	} else if bad > va.maxRemoteFailures {
 		modifiedProblem := *firstProb
 		modifiedProblem.Detail = "During secondary CAA checking: " + firstProb.Detail
+		va.metrics.prospectiveRemoteCAACheckFailures.Inc()
 		return &modifiedProblem
 	}
 

--- a/va/caa.go
+++ b/va/caa.go
@@ -81,7 +81,6 @@ func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsC
 					req.Domain,
 					req.AccountURIID,
 					string(validationMethod),
-					prob,
 					remoteCAAResults)
 			}()
 		} else if features.Get().EnforceMultiCAA {
@@ -89,7 +88,6 @@ func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsC
 				req.Domain,
 				req.AccountURIID,
 				string(validationMethod),
-				prob,
 				remoteCAAResults)
 
 			// If the remote result was a non-nil problem then fail the CAA check
@@ -146,7 +144,6 @@ func (va *ValidationAuthorityImpl) processRemoteCAAResults(
 	domain string,
 	acctID int64,
 	challengeType string,
-	primaryResult *probs.ProblemDetails,
 	remoteResultsChan <-chan *remoteVAResult) *probs.ProblemDetails {
 
 	state := "failure"
@@ -208,7 +205,7 @@ func (va *ValidationAuthorityImpl) processRemoteCAAResults(
 		domain,
 		acctID,
 		challengeType,
-		primaryResult,
+		nil,
 		remoteResults)
 
 	// Based on the threshold of good/bad return nil or a problem.
@@ -218,12 +215,6 @@ func (va *ValidationAuthorityImpl) processRemoteCAAResults(
 	} else if bad > va.maxRemoteFailures {
 		modifiedProblem := *firstProb
 		modifiedProblem.Detail = "During secondary CAA checking: " + firstProb.Detail
-		// If the primary result was OK and there were more failures than the allowed
-		// threshold increment a stat that indicates this overall validation will have
-		// failed.
-		if primaryResult == nil {
-			va.metrics.prospectiveRemoteCAACheckFailures.Inc()
-		}
 		return &modifiedProblem
 	}
 

--- a/va/caa.go
+++ b/va/caa.go
@@ -205,7 +205,6 @@ func (va *ValidationAuthorityImpl) processRemoteCAAResults(
 		domain,
 		acctID,
 		challengeType,
-		nil,
 		remoteResults)
 
 	// Based on the threshold of good/bad return nil or a problem.

--- a/va/va.go
+++ b/va/va.go
@@ -649,18 +649,14 @@ func (va *ValidationAuthorityImpl) logRemoteDifferentials(
 
 	var successes, failures []*remoteVAResult
 
-	allNil := true
 	for _, result := range remoteResults {
 		if result.Problem != nil {
-			allNil = false
-		}
-		if result.Problem == nil {
-			successes = append(successes, result)
-		} else {
 			failures = append(failures, result)
+		} else {
+			successes = append(successes, result)
 		}
 	}
-	if allNil {
+	if len(failures) == 0 {
 		// There's no point logging a differential line if everything succeeded.
 		return
 	}
@@ -669,7 +665,6 @@ func (va *ValidationAuthorityImpl) logRemoteDifferentials(
 		Domain          string
 		AccountID       int64
 		ChallengeType   string
-		PrimaryResult   *probs.ProblemDetails
 		RemoteSuccesses int
 		RemoteFailures  []*remoteVAResult
 	}{

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -832,7 +832,7 @@ func TestLogRemoteDifferentials(t *testing.T) {
 			mockLog.Clear()
 
 			localVA.logRemoteDifferentials(
-				"example.com", 1999, "blorpus-01", tc.primaryResult, tc.remoteProbs)
+				"example.com", 1999, "blorpus-01", tc.remoteProbs)
 
 			lines := mockLog.GetAllMatching("remoteVADifferentials JSON=.*")
 			if tc.expectedLog != "" {

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -782,14 +782,12 @@ func TestLogRemoteDifferentials(t *testing.T) {
 	egProbB := probs.OrderNotReady("please take a number")
 
 	testCases := []struct {
-		name          string
-		primaryResult *probs.ProblemDetails
-		remoteProbs   []*remoteVAResult
-		expectedLog   string
+		name        string
+		remoteProbs []*remoteVAResult
+		expectedLog string
 	}{
 		{
-			name:          "remote and primary results equal (all nil)",
-			primaryResult: nil,
+			name: "all results equal (nil)",
 			remoteProbs: []*remoteVAResult{
 				{Problem: nil, VAHostname: "remoteA"},
 				{Problem: nil, VAHostname: "remoteB"},
@@ -797,33 +795,22 @@ func TestLogRemoteDifferentials(t *testing.T) {
 			},
 		},
 		{
-			name:          "remote and primary results equal (not nil)",
-			primaryResult: egProbA,
+			name: "all results equal (not nil)",
 			remoteProbs: []*remoteVAResult{
 				{Problem: egProbA, VAHostname: "remoteA"},
 				{Problem: egProbA, VAHostname: "remoteB"},
 				{Problem: egProbA, VAHostname: "remoteC"},
 			},
+			expectedLog: `INFO: remoteVADifferentials JSON={"Domain":"example.com","AccountID":1999,"ChallengeType":"blorpus-01","RemoteSuccesses":0,"RemoteFailures":[{"VAHostname":"remoteA","Problem":{"type":"dns","detail":"root DNS servers closed at 4:30pm","status":400}},{"VAHostname":"remoteB","Problem":{"type":"dns","detail":"root DNS servers closed at 4:30pm","status":400}},{"VAHostname":"remoteC","Problem":{"type":"dns","detail":"root DNS servers closed at 4:30pm","status":400}}]}`,
 		},
 		{
-			name:          "remote and primary differ (primary nil)",
-			primaryResult: nil,
-			remoteProbs: []*remoteVAResult{
-				{Problem: egProbA, VAHostname: "remoteA"},
-				{Problem: nil, VAHostname: "remoteB"},
-				{Problem: egProbB, VAHostname: "remoteC"},
-			},
-			expectedLog: `INFO: remoteVADifferentials JSON={"Domain":"example.com","AccountID":1999,"ChallengeType":"blorpus-01","PrimaryResult":null,"RemoteSuccesses":1,"RemoteFailures":[{"VAHostname":"remoteA","Problem":{"type":"dns","detail":"root DNS servers closed at 4:30pm","status":400}},{"VAHostname":"remoteC","Problem":{"type":"orderNotReady","detail":"please take a number","status":403}}]}`,
-		},
-		{
-			name:          "remote and primary differ (primary not nil)",
-			primaryResult: egProbA,
+			name: "differing results, some non-nil",
 			remoteProbs: []*remoteVAResult{
 				{Problem: nil, VAHostname: "remoteA"},
 				{Problem: egProbB, VAHostname: "remoteB"},
 				{Problem: nil, VAHostname: "remoteC"},
 			},
-			expectedLog: `INFO: remoteVADifferentials JSON={"Domain":"example.com","AccountID":1999,"ChallengeType":"blorpus-01","PrimaryResult":{"type":"dns","detail":"root DNS servers closed at 4:30pm","status":400},"RemoteSuccesses":2,"RemoteFailures":[{"VAHostname":"remoteB","Problem":{"type":"orderNotReady","detail":"please take a number","status":403}}]}`,
+			expectedLog: `INFO: remoteVADifferentials JSON={"Domain":"example.com","AccountID":1999,"ChallengeType":"blorpus-01","RemoteSuccesses":2,"RemoteFailures":[{"VAHostname":"remoteB","Problem":{"type":"orderNotReady","detail":"please take a number","status":403}}]}`,
 		},
 	}
 


### PR DESCRIPTION
In the current code, when `processRemoteCAAResults` is called, its `primaryResult` parameter is always set to `nil`. So we can simplify by removing that parameter.

Follow-up from https://github.com/letsencrypt/boulder/pull/7313#discussion_r1480665727