### PR TITLE
VA: Add metrics to measure key exchange cipher suites

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -148,6 +148,13 @@ type ValidationRecord struct {
 	// lookup for AddressUsed. During recursive A and AAAA lookups, a record may
 	// instead look like A:host:port or AAAA:host:port
 	ResolverAddrs []string `json:"resolverAddrs,omitempty"`
+	// UsedRSAKEX is a *temporary* addition to the validation record, so we can
+	// see how many servers that we reach out to during HTTP-01 and TLS-ALPN-01
+	// validation are only willing to negotiate RSA key exchange mechanisms. The
+	// field is not included in the serialized json to avoid cluttering the
+	// database and log lines.
+	// TODO(#7321): Remove this when we have collected sufficient data.
+	UsedRSAKEX bool `json:"-"`
 }
 
 func looksLikeKeyAuthorization(str string) error {

--- a/va/http.go
+++ b/va/http.go
@@ -508,6 +508,13 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		numRedirects++
 		va.metrics.http01Redirects.Inc()
 
+		// If TLS was used, record the negotiated key exchange mechanism in the most
+		// recent validationRecord.
+		// TODO(#7321): Remove this when we have collected enough data.
+		if req.Response.TLS != nil {
+			records[len(records)-1].UsedRSAKEX = usedRSAKEX(req.Response.TLS.CipherSuite)
+		}
+
 		if req.Response.TLS != nil && req.Response.TLS.Version < tls.VersionTLS12 {
 			return berrors.ConnectionFailureError(
 				"validation attempt was redirected to an HTTPS server that doesn't " +

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -3,6 +3,7 @@ package va
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -114,7 +115,8 @@ func TestHTTPTransport(t *testing.T) {
 	dummyDialerFunc := func(_ context.Context, _, _ string) (net.Conn, error) {
 		return nil, nil
 	}
-	transport := httpTransport(dummyDialerFunc)
+	dummyVerifyFunc := func(_ tls.ConnectionState) error { return nil }
+	transport := httpTransport(dummyDialerFunc, dummyVerifyFunc)
 	// The HTTP Transport should have a TLS config that skips verifying
 	// certificates.
 	test.AssertEquals(t, transport.TLSClientConfig.InsecureSkipVerify, true)

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -3,7 +3,6 @@ package va
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -115,8 +114,7 @@ func TestHTTPTransport(t *testing.T) {
 	dummyDialerFunc := func(_ context.Context, _, _ string) (net.Conn, error) {
 		return nil, nil
 	}
-	dummyVerifyFunc := func(_ tls.ConnectionState) error { return nil }
-	transport := httpTransport(dummyDialerFunc, dummyVerifyFunc)
+	transport := httpTransport(dummyDialerFunc)
 	// The HTTP Transport should have a TLS config that skips verifying
 	// certificates.
 	test.AssertEquals(t, transport.TLSClientConfig.InsecureSkipVerify, true)

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -160,8 +160,6 @@ func (va *ValidationAuthorityImpl) getChallengeCert(
 			challenge.Type, identifier.Value, i+1, len(certs), hex.EncodeToString(cert.Raw))
 	}
 
-	va.metrics.outboundKexTypes.WithLabelValues("tls-alpn-01", tls.CipherSuiteName(cs.CipherSuite)).Inc()
-
 	return certs[0], &cs, nil
 }
 
@@ -290,6 +288,10 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 					hex.EncodeToString(h[:]),
 				))
 			}
+			// We were successful, so record the negotiated key exchange mechanism in
+			// the last validationRecord.
+			// TODO(#7321): Remove this when we have collected enough data.
+			validationRecords[len(validationRecords)-1].UsedRSAKEX = usedRSAKEX(cs.CipherSuite)
 			return validationRecords, nil
 		}
 	}

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -159,6 +159,9 @@ func (va *ValidationAuthorityImpl) getChallengeCert(
 		va.log.AuditInfof("%s challenge for %s received certificate (%d of %d): cert=[%s]",
 			challenge.Type, identifier.Value, i+1, len(certs), hex.EncodeToString(cert.Raw))
 	}
+
+	va.metrics.outboundKexTypes.WithLabelValues("tls-alpn-01", tls.CipherSuiteName(cs.CipherSuite)).Inc()
+
 	return certs[0], &cs, nil
 }
 

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -58,21 +58,18 @@ func certAltNames(cert *x509.Certificate) []string {
 
 func (va *ValidationAuthorityImpl) tryGetChallengeCert(ctx context.Context,
 	identifier identifier.ACMEIdentifier, challenge core.Challenge,
-	tlsConfig *tls.Config) (*x509.Certificate, *tls.ConnectionState, []core.ValidationRecord, error) {
+	tlsConfig *tls.Config) (*x509.Certificate, *tls.ConnectionState, core.ValidationRecord, error) {
 
 	allAddrs, resolvers, err := va.getAddrs(ctx, identifier.Value)
-	validationRecords := []core.ValidationRecord{
-		{
-			Hostname:          identifier.Value,
-			AddressesResolved: allAddrs,
-			Port:              strconv.Itoa(va.tlsPort),
-			ResolverAddrs:     resolvers,
-		},
+	validationRecord := core.ValidationRecord{
+		Hostname:          identifier.Value,
+		AddressesResolved: allAddrs,
+		Port:              strconv.Itoa(va.tlsPort),
+		ResolverAddrs:     resolvers,
 	}
 	if err != nil {
-		return nil, nil, validationRecords, err
+		return nil, nil, validationRecord, err
 	}
-	thisRecord := &validationRecords[0]
 
 	// Split the available addresses into v4 and v6 addresses
 	v4, v6 := availableAddresses(allAddrs)
@@ -80,43 +77,43 @@ func (va *ValidationAuthorityImpl) tryGetChallengeCert(ctx context.Context,
 
 	// This shouldn't happen, but be defensive about it anyway
 	if len(addresses) < 1 {
-		return nil, nil, validationRecords, berrors.MalformedError("no IP addresses found for %q", identifier.Value)
+		return nil, nil, validationRecord, berrors.MalformedError("no IP addresses found for %q", identifier.Value)
 	}
 
 	// If there is at least one IPv6 address then try it first
 	if len(v6) > 0 {
-		address := net.JoinHostPort(v6[0].String(), thisRecord.Port)
-		thisRecord.AddressUsed = v6[0]
+		address := net.JoinHostPort(v6[0].String(), validationRecord.Port)
+		validationRecord.AddressUsed = v6[0]
 
 		cert, cs, err := va.getChallengeCert(ctx, address, identifier, challenge, tlsConfig)
 
 		// If there is no problem, return immediately
 		if err == nil {
-			return cert, cs, validationRecords, nil
+			return cert, cs, validationRecord, nil
 		}
 
 		// Otherwise, we note that we tried an address and fall back to trying IPv4
-		thisRecord.AddressesTried = append(thisRecord.AddressesTried, thisRecord.AddressUsed)
+		validationRecord.AddressesTried = append(validationRecord.AddressesTried, validationRecord.AddressUsed)
 		va.metrics.ipv4FallbackCounter.Inc()
 	}
 
 	// If there are no IPv4 addresses and we tried an IPv6 address return
 	// an error - there's nothing left to try
-	if len(v4) == 0 && len(thisRecord.AddressesTried) > 0 {
-		return nil, nil, validationRecords, berrors.MalformedError("Unable to contact %q at %q, no IPv4 addresses to try as fallback",
-			thisRecord.Hostname, thisRecord.AddressesTried[0])
-	} else if len(v4) == 0 && len(thisRecord.AddressesTried) == 0 {
+	if len(v4) == 0 && len(validationRecord.AddressesTried) > 0 {
+		return nil, nil, validationRecord, berrors.MalformedError("Unable to contact %q at %q, no IPv4 addresses to try as fallback",
+			validationRecord.Hostname, validationRecord.AddressesTried[0])
+	} else if len(v4) == 0 && len(validationRecord.AddressesTried) == 0 {
 		// It shouldn't be possible that there are no IPv4 addresses and no previous
 		// attempts at an IPv6 address connection but be defensive about it anyway
-		return nil, nil, validationRecords, berrors.MalformedError("No IP addresses found for %q", thisRecord.Hostname)
+		return nil, nil, validationRecord, berrors.MalformedError("No IP addresses found for %q", validationRecord.Hostname)
 	}
 
 	// Otherwise if there are no IPv6 addresses, or there was an error
 	// talking to the first IPv6 address, try the first IPv4 address
-	thisRecord.AddressUsed = v4[0]
-	cert, cs, err := va.getChallengeCert(ctx, net.JoinHostPort(v4[0].String(), thisRecord.Port),
+	validationRecord.AddressUsed = v4[0]
+	cert, cs, err := va.getChallengeCert(ctx, net.JoinHostPort(v4[0].String(), validationRecord.Port),
 		identifier, challenge, tlsConfig)
-	return cert, cs, validationRecords, err
+	return cert, cs, validationRecord, err
 }
 
 func (va *ValidationAuthorityImpl) getChallengeCert(
@@ -159,7 +156,6 @@ func (va *ValidationAuthorityImpl) getChallengeCert(
 		va.log.AuditInfof("%s challenge for %s received certificate (%d of %d): cert=[%s]",
 			challenge.Type, identifier.Value, i+1, len(certs), hex.EncodeToString(cert.Raw))
 	}
-
 	return certs[0], &cs, nil
 }
 
@@ -214,11 +210,15 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 		return nil, berrors.MalformedError("Identifier type for TLS-ALPN-01 was not DNS")
 	}
 
-	cert, cs, validationRecords, problem := va.tryGetChallengeCert(ctx, identifier, challenge, &tls.Config{
+	cert, cs, tvr, problem := va.tryGetChallengeCert(ctx, identifier, challenge, &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		NextProtos: []string{ACMETLS1Protocol},
 		ServerName: identifier.Value,
 	})
+	// Copy the single validationRecord into the slice that we have to return, and
+	// get a reference to it so we can modify it if we have to.
+	validationRecords := []core.ValidationRecord{tvr}
+	validationRecord := &validationRecords[0]
 	if problem != nil {
 		return validationRecords, problem
 	}
@@ -231,7 +231,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 	}
 
 	badCertErr := func(msg string) error {
-		hostPort := net.JoinHostPort(validationRecords[0].AddressUsed.String(), validationRecords[0].Port)
+		hostPort := net.JoinHostPort(validationRecord.AddressUsed.String(), validationRecord.Port)
 
 		return berrors.UnauthorizedError(
 			"Incorrect validation certificate for %s challenge. "+
@@ -289,9 +289,9 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 				))
 			}
 			// We were successful, so record the negotiated key exchange mechanism in
-			// the last validationRecord.
+			// the validationRecord.
 			// TODO(#7321): Remove this when we have collected enough data.
-			validationRecords[len(validationRecords)-1].UsedRSAKEX = usedRSAKEX(cs.CipherSuite)
+			validationRecord.UsedRSAKEX = usedRSAKEX(cs.CipherSuite)
 			return validationRecords, nil
 		}
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -783,13 +783,11 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, req *v
 	validationLatency := time.Since(vStart)
 	logEvent.ValidationLatency = validationLatency.Round(time.Millisecond).Seconds()
 
+	// Copy the "UsedRSAKEX" value from the last validationRecord into the log
+	// event. Only the last record will have this bool set, because we only
+	// record it if/when validation is finally successful.
 	// TODO(#7321): Remove this when we have collected enough data.
-	for _, record := range records {
-		if record.UsedRSAKEX {
-			logEvent.UsedRSAKEX = true
-			break
-		}
-	}
+	logEvent.UsedRSAKEX = records[len(records)-1].UsedRSAKEX
 
 	va.metrics.localValidationTime.With(prometheus.Labels{
 		"type":   string(challenge.Type),

--- a/va/va.go
+++ b/va/va.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/canceled"
 	"github.com/letsencrypt/boulder/core"
@@ -28,7 +30,6 @@ import (
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
 	vapb "github.com/letsencrypt/boulder/va/proto"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -96,6 +97,7 @@ type vaMetrics struct {
 	http01Redirects                     prometheus.Counter
 	caaCounter                          *prometheus.CounterVec
 	ipv4FallbackCounter                 prometheus.Counter
+	outboundKexTypes                    *prometheus.CounterVec
 }
 
 func initMetrics(stats prometheus.Registerer) *vaMetrics {
@@ -201,6 +203,11 @@ func initMetrics(stats prometheus.Registerer) *vaMetrics {
 		Help: "A counter of IPv4 fallbacks during TLS ALPN validation",
 	})
 	stats.MustRegister(ipv4FallbackCounter)
+	outboundKexTypes := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "va_kex_types",
+		Help: "Count of key exchange algorithms negotiated during HTTP-01 and TLS-ALPN-01",
+	}, []string{"method", "kex"})
+	stats.MustRegister(outboundKexTypes)
 
 	return &vaMetrics{
 		validationTime:                      validationTime,
@@ -218,6 +225,7 @@ func initMetrics(stats prometheus.Registerer) *vaMetrics {
 		http01Redirects:                     http01Redirects,
 		caaCounter:                          caaCounter,
 		ipv4FallbackCounter:                 ipv4FallbackCounter,
+		outboundKexTypes:                    outboundKexTypes,
 	}
 }
 

--- a/va/va.go
+++ b/va/va.go
@@ -784,10 +784,13 @@ func (va *ValidationAuthorityImpl) PerformValidation(ctx context.Context, req *v
 	logEvent.ValidationLatency = validationLatency.Round(time.Millisecond).Seconds()
 
 	// Copy the "UsedRSAKEX" value from the last validationRecord into the log
-	// event. Only the last record will have this bool set, because we only
-	// record it if/when validation is finally successful.
+	// event. Only the last record should have this bool set, because we only
+	// record it if/when validation is finally successful, but we use the loop
+	// just in case that assumption changes.
 	// TODO(#7321): Remove this when we have collected enough data.
-	logEvent.UsedRSAKEX = records[len(records)-1].UsedRSAKEX
+	for _, record := range records {
+		logEvent.UsedRSAKEX = record.UsedRSAKEX || logEvent.UsedRSAKEX
+	}
 
 	va.metrics.localValidationTime.With(prometheus.Labels{
 		"type":   string(challenge.Type),


### PR DESCRIPTION
Add a new field to the structured JSON object logged by the VA indicating whether the HTTP-01 or TLS-ALPN-01 requests ended up negotiating a TLS cipher suite which uses RSA key exchange. This is useful for measuring how many servers we reach out to are RSA-only, so we can determine the deprecation timeline for RSA key exchange (which has been removed from go1.22).

The go TLS library always prefers ECDHE key exchange over RSA, so we should only be negotiating RSA key exchange if the server we're reaching out to doesn't support ECDHE at all.

Part of https://github.com/letsencrypt/boulder/issues/7321

