### PR TITLE
ratelimits: Fix transaction building for Failed Authorizations Limit

### DIFF
--- a/ratelimits/bucket.go
+++ b/ratelimits/bucket.go
@@ -265,7 +265,9 @@ func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountCheckO
 		}
 
 		// Add a check-only transaction for each per domain per account bucket.
-		txn, err := newCheckOnlyTransaction(limit, perDomainPerAccountBucketKey, 1)
+		// The cost is 0, as we are only checking that the account and domain
+		// pair aren't already over the limit.
+		txn, err := newCheckOnlyTransaction(limit, perDomainPerAccountBucketKey, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/ratelimits/bucket.go
+++ b/ratelimits/bucket.go
@@ -235,39 +235,82 @@ func (builder *TransactionBuilder) OrdersPerAccountTransaction(regId int64) (Tra
 	return newTransaction(limit, bucketKey, 1)
 }
 
-// FailedAuthorizationsPerAccountCheckOnlyTransaction returns a check-only
-// Transaction for the provided ACME registration Id for the
-// FailedAuthorizationsPerAccount limit.
-func (builder *TransactionBuilder) FailedAuthorizationsPerAccountCheckOnlyTransaction(regId int64) (Transaction, error) {
-	bucketKey, err := newRegIdBucketKey(FailedAuthorizationsPerAccount, regId)
-	if err != nil {
-		return Transaction{}, err
+// FailedAuthorizationsPerDomainPerAccountCheckOnlyTransactions returns a slice
+// of Transactions for the provided order domain names. An error is returned if
+// any of the order domain names are invalid. This method should be used for
+// checking capacity, before allowing more authorizations to be created.
+func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountCheckOnlyTransactions(regId int64, orderDomains []string, maxNames int) ([]Transaction, error) {
+	if len(orderDomains) > maxNames {
+		return nil, fmt.Errorf("order contains more than %d DNS names", maxNames)
 	}
-	limit, err := builder.getLimit(FailedAuthorizationsPerAccount, bucketKey)
+
+	// FailedAuthorizationsPerDomainPerAccount limit uses the 'enum:regId'
+	// bucket key format for overrides.
+	perAccountBucketKey, err := newRegIdBucketKey(FailedAuthorizationsPerDomainPerAccount, regId)
 	if err != nil {
-		if errors.Is(err, errLimitDisabled) {
-			return newAllowOnlyTransaction()
+		return nil, err
+	}
+	limit, err := builder.getLimit(FailedAuthorizationsPerDomainPerAccount, perAccountBucketKey)
+	if err != nil && !errors.Is(err, errLimitDisabled) {
+		return nil, err
+	}
+
+	var txns []Transaction
+	for _, name := range DomainsForRateLimiting(orderDomains) {
+		// FailedAuthorizationsPerDomainPerAccount limit uses the
+		// 'enum:regId:domain' bucket key format for transactions.
+		perDomainPerAccountBucketKey, err := newRegIdDomainBucketKey(FailedAuthorizationsPerDomainPerAccount, regId, name)
+		if err != nil {
+			return nil, err
 		}
-		return Transaction{}, err
+
+		// Add a check-only transaction for each per domain per account bucket.
+		txn, err := newCheckOnlyTransaction(limit, perDomainPerAccountBucketKey, 1)
+		if err != nil {
+			return nil, err
+		}
+		txns = append(txns, txn)
 	}
-	return newCheckOnlyTransaction(limit, bucketKey, 1)
+	return txns, nil
 }
 
-// FailedAuthorizationsPerAccountTransaction returns a Transaction for the
-// FailedAuthorizationsPerAccount limit for the provided ACME registration Id.
-func (builder *TransactionBuilder) FailedAuthorizationsPerAccountTransaction(regId int64) (Transaction, error) {
-	bucketKey, err := newRegIdBucketKey(FailedAuthorizationsPerAccount, regId)
-	if err != nil {
-		return Transaction{}, err
+// FailedAuthorizationsPerDomainPerAccountSpendOnlyTransactions returns a slice
+// of Transactions for the provided order domain names. An error is returned if
+// any of the order domain names are invalid. This method should be used for
+// spending capacity, as a result of a failed authorization.
+func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountSpendOnlyTransactions(regId int64, orderDomains []string, maxNames int) ([]Transaction, error) {
+	if len(orderDomains) > maxNames {
+		return nil, fmt.Errorf("order contains more than %d DNS names", maxNames)
 	}
-	limit, err := builder.getLimit(FailedAuthorizationsPerAccount, bucketKey)
+
+	// FailedAuthorizationsPerDomainPerAccount limit uses the 'enum:regId'
+	// bucket key format for overrides.
+	perAccountBucketKey, err := newRegIdBucketKey(FailedAuthorizationsPerDomainPerAccount, regId)
 	if err != nil {
-		if errors.Is(err, errLimitDisabled) {
-			return newAllowOnlyTransaction()
+		return nil, err
+	}
+	limit, err := builder.getLimit(FailedAuthorizationsPerDomainPerAccount, perAccountBucketKey)
+	if err != nil && !errors.Is(err, errLimitDisabled) {
+		return nil, err
+	}
+
+	var txns []Transaction
+	for _, name := range DomainsForRateLimiting(orderDomains) {
+		// FailedAuthorizationsPerDomainPerAccount limit uses the
+		// 'enum:regId:domain' bucket key format for transactions.
+		perDomainPerAccountBucketKey, err := newRegIdDomainBucketKey(FailedAuthorizationsPerDomainPerAccount, regId, name)
+		if err != nil {
+			return nil, err
 		}
-		return Transaction{}, err
+
+		// Add an allow-only transaction for each per domain per account bucket.
+		txn, err := newSpendOnlyTransaction(limit, perDomainPerAccountBucketKey, 1)
+		if err != nil {
+			return nil, err
+		}
+		txns = append(txns, txn)
 	}
-	return newTransaction(limit, bucketKey, 1)
+	return txns, nil
 }
 
 // CertificatesPerDomainTransactions returns a slice of Transactions for the

--- a/ratelimits/testdata/working_overrides.yml
+++ b/ratelimits/testdata/working_overrides.yml
@@ -8,3 +8,9 @@
     count: 50
     period: 2s
     ids: [2001:0db8:0000::/48]
+- FailedAuthorizationsPerDomainPerAccount:
+    burst: 60
+    count: 60
+    period: 3s
+    ids: [1234, 5678]
+

--- a/test/config-next/wfe2-ratelimit-defaults.yml
+++ b/test/config-next/wfe2-ratelimit-defaults.yml
@@ -10,7 +10,7 @@ CertificatesPerDomain:
   count: 2
   burst: 2
   period: 2160h
-FailedAuthorizationsPerAccount:
+FailedAuthorizationsPerDomainPerAccount:
   count: 3
   burst: 3
   period: 5m

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2064,19 +2064,19 @@ func (wfe *WebFrontEndImpl) newNewOrderLimitTransactions(regId int64, names []st
 	}
 	transactions = append(transactions, txn)
 
-	txn, err = wfe.txnBuilder.FailedAuthorizationsPerAccountCheckOnlyTransaction(regId)
+	failedAuthzTxns, err := wfe.txnBuilder.FailedAuthorizationsPerDomainPerAccountCheckOnlyTransactions(regId, names, wfe.maxNames)
 	if err != nil {
-		logTxnErr(err, ratelimits.FailedAuthorizationsPerAccount)
+		logTxnErr(err, ratelimits.FailedAuthorizationsPerDomainPerAccount)
 		return nil
 	}
-	transactions = append(transactions, txn)
+	transactions = append(transactions, failedAuthzTxns...)
 
-	txns, err := wfe.txnBuilder.CertificatesPerDomainTransactions(regId, names, wfe.maxNames)
+	certsPerDomainTxns, err := wfe.txnBuilder.CertificatesPerDomainTransactions(regId, names, wfe.maxNames)
 	if err != nil {
 		logTxnErr(err, ratelimits.CertificatesPerDomain)
 		return nil
 	}
-	transactions = append(transactions, txns...)
+	transactions = append(transactions, certsPerDomainTxns...)
 
 	txn, err = wfe.txnBuilder.CertificatesPerFQDNSetTransaction(names)
 	if err != nil {


### PR DESCRIPTION
- Update the failed authorizations limit to use 'enum:regId:domain' for transactions while maintaining 'enum:regId' for overrides.
- Modify the failed authorizations transaction builder to generate a transaction for each order name.
- Rename the `FailedAuthorizationsPerAccount` enum to `FailedAuthorizationsPerDomainPerAccount` to align with its corrected implementation. This change is possible because the limit isn't yet deployed in staging or production.

Blocks #7346
Part of #5545