### PR TITLE
expiry mailer : typo fix

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -730,7 +730,7 @@ func initStats(stats prometheus.Registerer) mailerStats {
 	nagsAtCapacity := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "nags_at_capacity",
-			Help: "Count of nag groups at capcacity",
+			Help: "Count of nag groups at capacity",
 		},
 		[]string{"nag_group"})
 	stats.MustRegister(nagsAtCapacity)


### PR DESCRIPTION
makes linter happy: not sure why 7 year old typo starts to hit by linter nowdays though
not sure why github CI can't catch this but running t.sh locally marks this as typo: (and it is)