### PR TITLE
Set MaxIdleConnsPerHost to MaxIdleConns

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -123,6 +123,7 @@ func NewLog(uri, b64PK, userAgent string, logger blog.Logger) (*Log, error) {
 		// "unlimited," which would be bad.
 		Transport: &http.Transport{
 			MaxIdleConns:        http.DefaultTransport.(*http.Transport).MaxIdleConns,
+			MaxIdleConnsPerHost: http.DefaultTransport.(*http.Transport).MaxIdleConns,
 			IdleConnTimeout:     http.DefaultTransport.(*http.Transport).IdleConnTimeout,
 			TLSHandshakeTimeout: http.DefaultTransport.(*http.Transport).TLSHandshakeTimeout,
 			// In Boulder Issue 3821[0] we found that HTTP/2 support was causing hard


### PR DESCRIPTION
MaxIdleConns defaults to 100, but MaxIdleConnsPerHost is only 2. Because there's a new Transport per client, we should allow a single host to use all the idle connections.

A CT Log operator has notified us we're churning a lot of connections. This should significantly help.

We might want to make the value configurable, instead of just using the default value, but that can always come later if needed.
