### PR TITLE
Update CI to go1.21.8 and go1.22.1

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.21.5_2024-02-14
-          - go1.22.0_2024-02-14
+          - go1.21.8_2024-03-05
+          - go1.22.1_2024-03-05
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.21.5"
-          - "1.22.0"
+          - "1.21.8"
+          - "1.22.1"
     runs-on: ubuntu-20.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.21.5"
-          - "1.22.0"
+          - "1.21.8"
+          - "1.22.1"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     image: letsencrypt/boulder-tools:${BOULDER_TOOLS_TAG:-latest}
     build:
       context: test/boulder-tools/
-      # Should match one of the GO_DEV_VERSIONS in test/boulder-tools/tag_and_upload.sh.
+      # Should match one of the GO_CI_VERSIONS in test/boulder-tools/tag_and_upload.sh.
       args:
-        GO_VERSION: 1.21.5
+        GO_VERSION: 1.21.8
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.21.5" "1.22.0" )
+GO_CI_VERSIONS=( "1.21.8" "1.22.1" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
Security releases announced here: https://groups.google.com/g/golang-announce/c/5pwGVUPoMbg