### PR TITLE
ceremony: Remove unnecessary fmt.Print

### DIFF
--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -90,7 +90,6 @@ func postIssuanceLinting(fc *x509.Certificate, skipLints []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Print()
 
 	return nil
 }


### PR DESCRIPTION
I accidentally left this print line in while working on https://github.com/letsencrypt/boulder/pull/7364 and forgot to clean it up.