### PR TITLE
Check if JSON configs are properly formatted instead of relying on git --diff

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -220,8 +220,7 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
     # Update .typos.toml if you find false positives
     run_and_expect_silence typos
     # Check test JSON configs are formatted consistently
-    ./test/format-configs.py 'test/config*/*.json'
-    run_and_expect_silence git diff --exit-code .
+    run_and_expect_silence ./test/format-configs.py 'test/config*/*.json'
   fi
 fi
 

--- a/test/format-configs.py
+++ b/test/format-configs.py
@@ -19,11 +19,11 @@ for pattern in args.globs:
         j = json.loads(existing)
         new = json.dumps(j, indent="\t")
         new += "\n"
-        if args.write:
-            with open(cfg, "w") as fw:
-                fw.write(new)
-        else:
-            if new != existing:
+        if new != existing:
+            if args.write:
+                with open(cfg, "w") as fw:
+                    fw.write(new)
+            else:
                 needs_format.append(cfg)
 
 if len(needs_format) > 0:

--- a/test/format-configs.py
+++ b/test/format-configs.py
@@ -1,15 +1,34 @@
 #!/usr/bin/env python3
 
+import argparse
 import glob
 import json
 import sys
 
-if len(sys.argv) != 2:
-  print("This program reformats JSON files in-place. You must provide a glob pattern of files to process as its argument.")
-else:
-  for cfg in glob.glob(sys.argv[1]):
-    with open(cfg, "r") as fr:
-      j = json.load(fr)
-    with open(cfg, "w") as fw:
-      json.dump(j, fw, indent="\t")
-      fw.write("\n")
+parser = argparse.ArgumentParser()
+parser.add_argument('globs', nargs='+', help='List of JSON file globs')
+parser.add_argument('--write', action='store_true', help='Write out formatted files')
+args = parser.parse_args()
+
+needs_format = []
+
+for pattern in args.globs:
+    for cfg in glob.glob(pattern):
+        with open(cfg, "r") as fr:
+            existing = fr.read()
+        j = json.loads(existing)
+        new = json.dumps(j, indent="\t")
+        new += "\n"
+        if args.write:
+            with open(cfg, "w") as fw:
+                fw.write(new)
+        else:
+            if new != existing:
+                needs_format.append(cfg)
+
+if len(needs_format) > 0:
+    print("Files need reformatting:")
+    for file in needs_format:
+        print(f"\t{file}")
+    print("Run ./test/format-configs.py --write 'test/config*/*.json'")
+    sys.exit(1)


### PR DESCRIPTION
This adds a new --write flag which will write out the formatted JSON files.

By default this command now checks if the files are properly formatted and prints a list of unformatted files.

This avoids the problem of lints failing if there are uncommited changes, and decouples this check from git.

By using a proper argument parsing library, we also get a good --help flag.
