### PR TITLE
Add/clean up admin tool audit lines

### DIFF
--- a/cmd/admin/dryrun.go
+++ b/cmd/admin/dryrun.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	blog "github.com/letsencrypt/boulder/log"
@@ -17,7 +18,11 @@ type dryRunRAC struct {
 }
 
 func (d dryRunRAC) AdministrativelyRevokeCertificate(_ context.Context, req *rapb.AdministrativelyRevokeCertificateRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-	d.log.Infof("dry-run: %#v", req)
+	b, err := prototext.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	d.log.Infof("dry-run: %#v", string(b))
 	return &emptypb.Empty{}, nil
 }
 
@@ -27,6 +32,10 @@ type dryRunSAC struct {
 }
 
 func (d dryRunSAC) AddBlockedKey(_ context.Context, req *sapb.AddBlockedKeyRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-	d.log.Infof("dry-run: %#v", req)
+	b, err := prototext.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	d.log.Infof("dry-run: %#v", string(b))
 	return &emptypb.Empty{}, nil
 }

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -120,12 +120,19 @@ func main() {
 		cmd.FailOnError(errors.New("no recognized subcommand name provided"), "")
 	}
 
-	a.log.AuditInfof("Running admin tool with the following arguments: %s", strings.Join(unparsedArgs, " "))
+	if a.dryRun {
+		a.log.AuditInfof("admin tool executing a dry-run with the following arguments: %s", strings.Join(unparsedArgs, " "))
+	} else {
+		a.log.AuditInfof("admin tool executing with the following arguments: %s", strings.Join(unparsedArgs, " "))
+	}
+
 	err = subcommand.run(a, context.Background(), unparsedArgs[1:])
 	cmd.FailOnError(err, "executing subcommand")
-	a.log.AuditInfof("Admin tool has successfully completed running with the following arguments: %s", strings.Join(unparsedArgs, " "))
 
 	if a.dryRun {
+		a.log.AuditInfof("admin tool has successfully completed executing a dry-run with the following arguments: %s", strings.Join(unparsedArgs, " "))
 		a.log.Info("Dry run complete. Pass -dry-run=false to mutate the database.")
+	} else {
+		a.log.AuditInfof("admin tool has successfully completed executing with the following arguments: %s", strings.Join(unparsedArgs, " "))
 	}
 }

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/features"
@@ -119,8 +120,10 @@ func main() {
 		cmd.FailOnError(errors.New("no recognized subcommand name provided"), "")
 	}
 
+	a.log.AuditInfof("Running admin tool with the following arguments: %s", strings.Join(unparsedArgs, " "))
 	err = subcommand.run(a, context.Background(), unparsedArgs[1:])
 	cmd.FailOnError(err, "executing subcommand")
+	a.log.AuditInfof("Admin tool has successfully completed running with the following arguments: %s", strings.Join(unparsedArgs, " "))
 
 	if a.dryRun {
 		a.log.Info("Dry run complete. Pass -dry-run=false to mutate the database.")


### PR DESCRIPTION
Before this PR, this is what example output of using the admin tool would look like for an example command (in this case, certificate revocation):
```
$ sudo /vagrant/admin -config /etc/boulder/config/admin.json revoke-cert -serial 2a13699017c283dea4d6ac5ac6d40caa3321
20:22:05.682795 6 admin qK_A7gU Debug server listening on :8000
20:22:05.682908 6 admin ts7-5Ag Versions: admin=(Unspecified Unspecified) Golang=(go1.21.8) BuildHost=(Unspecified)
20:22:05.689743 6 admin 6MX16g0 Found 1 certificates to revoke
20:22:05.691842 6 admin 1b3FsgU dry-run: &proto.AdministrativelyRevokeCertificateRequest{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(nil)}, sizeCache:0, unknownFields:[]uint8(nil), Cert:[]uint8(nil), Serial:"2a13699017c283dea4d6ac5ac6d40caa3321", Code:0, AdminName:"root", SkipBlockKey:false, Malformed:false}
20:22:05.691901 6 admin 7tT7rAY Dry run complete. Pass -dry-run=false to mutate the database.
```
after this change the output looks like this:
```
$ sudo /vagrant/admin -config /etc/boulder/config/admin.json revoke-cert -serial 2a13699017c283dea4d6ac5ac6d40caa3321
21:22:13.769728 6 admin qK_A7gU Debug server listening on :8000
21:22:13.770156 6 admin ts7-5Ag Versions: admin=(Unspecified Unspecified) Golang=(go1.21.8) BuildHost=(Unspecified)
21:22:13.779291 6 admin xNuU_gY [AUDIT] admin tool executing a dry-run with the following arguments: revoke-cert -serial 2a13699017c283dea4d6ac5ac6d40caa3321
21:22:13.779534 6 admin 6MX16g0 Found 1 certificates to revoke
21:22:13.784524 6 admin yvHv9AM dry-run: "serial:\"2a13699017c283dea4d6ac5ac6d40caa3321\" adminName:\"root\""
21:22:13.786379 6 admin nKfNswk [AUDIT] admin tool has successfully completed executing a dry-run with the following arguments: revoke-cert -serial 2a13699017c283dea4d6ac5ac6d40caa3321
21:22:13.786951 6 admin 7tT7rAY Dry run complete. Pass -dry-run=false to mutate the database.
```
and with `-dry-run=false`:
```
$ sudo /vagrant/admin -config /etc/boulder/config/admin.json -dry-run=false revoke-cert -serial 2a13699017c283dea4d6ac5ac6d40caa3321
21:23:19.080073 6 admin qK_A7gU Debug server listening on :8000
21:23:19.080510 6 admin ts7-5Ag Versions: admin=(Unspecified Unspecified) Golang=(go1.21.8) BuildHost=(Unspecified)
21:23:19.089588 6 admin iKnckQ0 [AUDIT] admin tool executing with the following arguments: revoke-cert -serial 2a13699017c283dea4d6ac5ac6d40caa3321
21:23:19.089625 6 admin 6MX16g0 Found 1 certificates to revoke
21:23:19.169317 6 admin 9oyv3QY [AUDIT] admin tool has successfully completed executing with the following arguments: revoke-cert -serial 2a13699017c283dea4d6ac5ac6d40caa3321
```

Fixes #7358