### PR TITLE
ci: update govulncheck

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -99,12 +99,9 @@ jobs:
         run: ${{ matrix.tests }}
 
   govulncheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
-      # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
       fail-fast: false
-      matrix:
-        go-version: [ '1.21.8' ]
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -114,8 +111,11 @@ jobs:
 
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
+        # When Go produces a security release, we want govulncheck to run
+        # against the most recently released Go version.
+        check-latest: true
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "latest"
 
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
Always run on the latest Go version. This reduces busywork / failed CI builds when Go publishes a security release, since we have other processes for making sure we get notice of those security releases.

This may still fail for a little while after the Go release is published, while we wait for GitHub to update the Go version used in CI as "latest", but it will be a little faster and require less manual work.