### PR TITLE
ARI: Return HTTP 409 "Conflict" when the certificate identified by 'replaces' has already been replaced

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -51,6 +51,9 @@ const (
 	UnsupportedContact
 	// The requesteed serial number does not exist in the `serials` table.
 	UnknownSerial
+	// The certificate being indicated for replacement already has a replacement
+	// order.
+	Conflict
 )
 
 func (ErrorType) Error() string {
@@ -254,4 +257,8 @@ func BadRevocationReasonError(reason int64) error {
 
 func UnknownSerialError() error {
 	return New(UnknownSerial, "unknown serial")
+}
+
+func ConflictError(msg string, args ...interface{}) error {
+	return New(Conflict, msg, args...)
 }

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -32,6 +32,7 @@ const (
 	UnauthorizedProblem          = ProblemType("unauthorized")
 	UnsupportedContactProblem    = ProblemType("unsupportedContact")
 	UnsupportedIdentifierProblem = ProblemType("unsupportedIdentifier")
+	ConflictProblem              = ProblemType("conflict")
 
 	ErrorNS = "urn:ietf:params:acme:error:"
 )

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -20,6 +20,8 @@ const (
 	BadRevocationReasonProblem   = ProblemType("badRevocationReason")
 	BadSignatureAlgorithmProblem = ProblemType("badSignatureAlgorithm")
 	CAAProblem                   = ProblemType("caa")
+	// ConflictProblem is a problem type that is not defined in RFC8555.
+	ConflictProblem              = ProblemType("conflict")
 	ConnectionProblem            = ProblemType("connection")
 	DNSProblem                   = ProblemType("dns")
 	InvalidContactProblem        = ProblemType("invalidContact")
@@ -32,7 +34,6 @@ const (
 	UnauthorizedProblem          = ProblemType("unauthorized")
 	UnsupportedContactProblem    = ProblemType("unsupportedContact")
 	UnsupportedIdentifierProblem = ProblemType("unsupportedIdentifier")
-	ConflictProblem              = ProblemType("conflict")
 
 	ErrorNS = "urn:ietf:params:acme:error:"
 )
@@ -291,11 +292,11 @@ func Canceled(detail string, a ...any) *ProblemDetails {
 	}
 }
 
-// Conflict returns a ProblemDetails with a MalformedProblem and a 409 Conflict
+// Conflict returns a ProblemDetails with a ConflictProblem and a 409 Conflict
 // status code.
 func Conflict(detail string) *ProblemDetails {
 	return &ProblemDetails{
-		Type:       MalformedProblem,
+		Type:       ConflictProblem,
 		Detail:     detail,
 		HTTPStatus: http.StatusConflict,
 	}

--- a/web/probs.go
+++ b/web/probs.go
@@ -46,6 +46,8 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		outProb = probs.BadRevocationReason(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.UnsupportedContact:
 		outProb = probs.UnsupportedContact(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.Conflict:
+		outProb = probs.Conflict(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2230,7 +2230,10 @@ func (wfe *WebFrontEndImpl) validateReplacementOrder(ctx context.Context, acct *
 		return "", false, fmt.Errorf("checking replacement status of existing certificate: %w", err)
 	}
 	if exists.Exists {
-		return "", false, berrors.MalformedError("cannot indicate an order replaces a certificate which already has a replacement order")
+		return "", false, berrors.ConflictError(
+			"cannot indicate an order replaces certificate with serial %q, which already has a replacement order",
+			certID.Serial(),
+		)
 	}
 
 	err = wfe.orderMatchesReplacement(ctx, acct, names, certID.Serial())

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2848,7 +2848,7 @@ func TestKeyRollover(t *testing.T) {
 			Name:    "Valid key rollover request, key exists",
 			Payload: `{"oldKey":` + test1KeyPublicJSON + `,"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
-                          "type": "urn:ietf:params:acme:error:malformed",
+                          "type": "urn:ietf:params:acme:error:conflict",
                           "detail": "New key is already in use for a different account",
                           "status": 409
                         }`,


### PR DESCRIPTION
Fixes #7338