### PR TITLE
cmd: use the built-in maps library

### DIFF
--- a/cmd/admin/cert.go
+++ b/cmd/admin/cert.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/user"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"unicode"
 
 	"golang.org/x/crypto/ocsp"
-	"golang.org/x/exp/maps"
 
 	core "github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"

--- a/cmd/admin/key.go
+++ b/cmd/admin/key.go
@@ -8,11 +8,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/user"
 	"sync"
 
-	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/letsencrypt/boulder/core"


### PR DESCRIPTION
In the current go 1.21 version used in the project, maps are no longer an experimental feature and have entered the standard library