### PR TITLE
Re-enable lints on go1.22

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.22.2_2024-04-03
+          - go1.22.2_2024-04-04
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -122,7 +122,7 @@ jobs:
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
       fail-fast: false
       matrix:
-        go-version: [ '1.22.2' ]
+        go-version: [ '1.22.1' ]
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -122,7 +122,7 @@ jobs:
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
       fail-fast: false
       matrix:
-        go-version: [ '1.22.1' ]
+        go-version: [ '1.22.2' ]
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,3 +57,4 @@ linters-settings:
       - G404  # Use of weak random number generator (math/rand instead of crypto/rand)
       - G501  # Blacklisted import `crypto/md5`: weak cryptographic primitive
       - G505  # Blacklisted import `crypto/sha1`: weak cryptographic primitive
+      - G601  # Implicit memory aliasing in for loop (this is fixed by go1.22)

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,11 +9,9 @@ ignore-hidden = false
 
 [default]
 extend-ignore-re = [
-    # PEM
-    "\\s*[+/0-9=A-Za-z]{64}\\s*",
-    ' := `\{"[0-9A-Z_a-z-]{36,}"\}`',
-    '"(csr|d|dp|n|protected|qi|signature|y)": ?"[0-9=A-Z_a-z-]{36,}"',
-    'bigIntFromB64\("[0-9=A-Z_a-z-]{36,}"\)',
+    # Anything base64 or base64url longer than 36 chars is probably encoded.
+    '\b[0-9A-Za-z+/]{36,}\b',
+    '\b[0-9A-Za-z_-]{36,}\b',
     "0002a4ba3cf408927759",
     "65CuDAA",
     '"sql_warnings", "TrUe"',

--- a/crl/idp/idp.go
+++ b/crl/idp/idp.go
@@ -23,7 +23,7 @@ type issuingDistributionPoint struct {
 // others are omitted.
 type distributionPointName struct {
 	// Technically, FullName is of type GeneralNames, which is of type SEQUENCE OF
-	// GeneralName. But GeneralName itself is of type CHOICE, and the ans1.Marhsal
+	// GeneralName. But GeneralName itself is of type CHOICE, and the asn1.Marhsal
 	// function doesn't support marshalling structs to CHOICEs, so we have to use
 	// asn1.RawValue and encode the GeneralName ourselves.
 	FullName []asn1.RawValue `asn1:"optional,tag:0"`

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -402,7 +402,7 @@ func CreateTestingSignedSCT(req []string, k *ecdsa.PrivateKey, precert bool, tim
 
 // GetCTBundleForChain takes a slice of *issuance.Certificate(s)
 // representing a certificate chain and returns a slice of
-// ct.ANS1Cert(s) in the same order
+// ct.ASN1Cert(s) in the same order
 func GetCTBundleForChain(chain []*issuance.Certificate) []ct.ASN1Cert {
 	var ctBundle []ct.ASN1Cert
 	for _, cert := range chain {

--- a/ratelimits/bucket.go
+++ b/ratelimits/bucket.go
@@ -43,7 +43,7 @@ func newIPv6RangeCIDRBucketKey(name Name, ip net.IP) (string, error) {
 	return joinWithColon(name.EnumString(), id), nil
 }
 
-// newRegIdBucketKey validates ands returns a bucketKey for limits that use the
+// newRegIdBucketKey validates and returns a bucketKey for limits that use the
 // 'enum:regId' bucket key format.
 func newRegIdBucketKey(name Name, regId int64) (string, error) {
 	id := strconv.FormatInt(regId, 10)

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -3737,7 +3737,7 @@ func TestGetRevokedCertsByShard(t *testing.T) {
 	test.AssertNotError(t, err, "zero rows shouldn't result in error")
 	test.AssertEquals(t, count, 0)
 
-	// Asking for revoked certs from a different shard should return zero reults.
+	// Asking for revoked certs from a different shard should return zero results.
 	expiresAfter = time.Date(2023, time.March, 1, 0, 0, 0, 0, time.UTC)
 	revokedBefore = time.Date(2023, time.April, 1, 0, 0, 0, 0, time.UTC)
 	count, err = countRevokedCerts(&sapb.GetRevokedCertsRequest{

--- a/test.sh
+++ b/test.sh
@@ -207,21 +207,16 @@ print_heading "Starting..."
 #
 STAGE="lints"
 if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
-  # TODO(#7229): Remove this conditional and globally re-enable this test.
-  if [[ $(go version) == *go1.22* ]] ; then
-    print_heading "Skipping Lints"
-  else
-    print_heading "Running Lints"
-    golangci-lint run --timeout 9m ./...
-    # Implicitly loads staticcheck.conf from the root of the boulder repository
-    staticcheck ./...
-    python3 test/grafana/lint.py
-    # Check for common spelling errors using typos.
-    # Update .typos.toml if you find false positives
-    run_and_expect_silence typos
-    # Check test JSON configs are formatted consistently
-    run_and_expect_silence ./test/format-configs.py 'test/config*/*.json'
-  fi
+  print_heading "Running Lints"
+  golangci-lint run --timeout 9m ./...
+  # Implicitly loads staticcheck.conf from the root of the boulder repository
+  staticcheck ./...
+  python3 test/grafana/lint.py
+  # Check for common spelling errors using typos.
+  # Update .typos.toml if you find false positives
+  run_and_expect_silence typos
+  # Check test JSON configs are formatted consistently
+  run_and_expect_silence ./test/format-configs.py 'test/config*/*.json'
 fi
 
 #

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -13,8 +13,8 @@ RUN go install github.com/rubenv/sql-migrate/sql-migrate@v1.1.2
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 RUN go install github.com/letsencrypt/pebble/v2/cmd/pebble-challtestsrv@66511d8
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
-RUN go install honnef.co/go/tools/cmd/staticcheck@2023.1.5
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+RUN go install honnef.co/go/tools/cmd/staticcheck@2023.1.7
 
 FROM rust:bullseye as rustdeps
 # Provided automatically by docker build.


### PR DESCRIPTION
We had disabled our lints on go1.22 because golangci-lint and staticcheck didn't work with some of its updates. Re-enable them, and fix the things which the updated linters catch now.

Fixes https://github.com/letsencrypt/boulder/issues/7229