### PR TITLE
WFE: Count NewOrders which indicate replacement

### DIFF
--- a/wfe2/stats.go
+++ b/wfe2/stats.go
@@ -20,6 +20,11 @@ type wfe2Stats struct {
 	// nonceNoMatchingBackendCount counts the number of times we've received a nonce
 	// with a prefix that doesn't match a known backend.
 	nonceNoMatchingBackendCount prometheus.Counter
+	// ariReplacementOrders counts the number of new order requests that replace
+	// an existing order, labeled by:
+	//   - isReplacement=[true|false]
+	//   - limitsExempt=[true|false]
+	ariReplacementOrders *prometheus.CounterVec
 }
 
 func initStats(stats prometheus.Registerer) wfe2Stats {
@@ -64,11 +69,21 @@ func initStats(stats prometheus.Registerer) wfe2Stats {
 	)
 	stats.MustRegister(nonceNoBackendCount)
 
+	ariReplacementOrders := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ari_replacements",
+			Help: "Number of new order requests that replace an existing order, labeled isReplacement=[true|false], limitsExempt=[true|false]",
+		},
+		[]string{"isReplacement", "limitsExempt"},
+	)
+	stats.MustRegister(ariReplacementOrders)
+
 	return wfe2Stats{
 		httpErrorCount:              httpErrorCount,
 		joseErrorCount:              joseErrorCount,
 		csrSignatureAlgs:            csrSignatureAlgs,
 		improperECFieldLengths:      improperECFieldLengths,
 		nonceNoMatchingBackendCount: nonceNoBackendCount,
+		ariReplacementOrders:        ariReplacementOrders,
 	}
 }

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2372,6 +2372,13 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	var newOrderSuccessful bool
 	var errIsRateLimit bool
 	defer func() {
+		if features.Get().TrackReplacementCertificatesARI {
+			wfe.stats.ariReplacementOrders.With(prometheus.Labels{
+				"isReplacement": fmt.Sprintf("%t", replaces != ""),
+				"limitsExempt":  fmt.Sprintf("%t", limitsExempt),
+			}).Inc()
+		}
+
 		if !newOrderSuccessful && !errIsRateLimit {
 			// This can be a little racy, but we're not going to worry about it
 			// for now. If the check hasn't completed yet, we can pretty safely


### PR DESCRIPTION
Add support for counting new orders which indicate replacement according to draft-ietf-acme-ari.

Fixes #7405