### PR TITLE
Run config/sql change action when ready for review

### DIFF
--- a/.github/workflows/issue-for-sre-handoff.yml
+++ b/.github/workflows/issue-for-sre-handoff.yml
@@ -2,7 +2,7 @@ name: Check PR for configuration and SQL changes
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ready_for_review, review_requested]
     paths:
     - 'test/config-next/*.json'
     - 'test/config-next/*.yaml'


### PR DESCRIPTION
Rather than running the "check-changes" action immediately when a PR is opened, wait for the PR to be ready for review (either by being taken out of draft mode, or by having reviewers added). This way it's possible to create a draft PR, then create a corresponding deployment ticket which references the PR, add that ticket to the PR description, and mark the PR ready for review, thereby pre-empting the bot so it doesn't have to leave a comment.