### PR TITLE
Make "CRLDPBase" config item optional

### DIFF
--- a/ca/crl.go
+++ b/ca/crl.go
@@ -47,15 +47,6 @@ func NewCRLImpl(
 		return nil, fmt.Errorf("loading CRL profile: %w", err)
 	}
 
-	// TODO(#7094): Remove this once all CRLs have IDPs built from their
-	// issuer.crlURLBase instead.
-	if !strings.HasPrefix(idpBase, "http://") {
-		return nil, fmt.Errorf("issuingDistributionPoint base URI must use http:// scheme, got %q", idpBase)
-	}
-	if strings.HasSuffix(idpBase, "/") {
-		return nil, fmt.Errorf("issuingDistributionPoint base URI must not end with a slash, got %q", idpBase)
-	}
-
 	return &crlImpl{
 		issuers:   issuersByNameID,
 		profile:   profile,

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -111,7 +111,7 @@ type Config struct {
 		// across all issuers and shards. It must use the http:// scheme, and must
 		// not end with a slash. Example: "http://prod.c.lencr.org".
 		// TODO(#7296): Remove this fallback once all configs have issuer.CRLBaseURL
-		CRLDPBase string `validate:"required,url,startswith=http://,endsnotwith=/"`
+		CRLDPBase string `validate:"omitempty,url,startswith=http://,endsnotwith=/"`
 
 		// DisableCertService causes the CertificateAuthority gRPC service to not
 		// start, preventing any certificates or precertificates from being issued.

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -110,7 +110,6 @@
 		"serialPrefix": 127,
 		"maxNames": 100,
 		"lifespanOCSP": "96h",
-		"crldpBase": "http://c.boulder.test",
 		"goodkey": {
 			"weakKeyFile": "test/example-weak-keys.json",
 			"blockedKeyFile": "test/example-blocked-keys.yaml",

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -92,6 +92,7 @@
 					"useForECDSALeaves": false,
 					"issuerURL": "http://127.0.0.1:4502/int rsa b",
 					"ocspURL": "http://127.0.0.1:4002/",
+					"crlURLBase": "http://127.0.0.1:4501/rsa-b/",
 					"location": {
 						"configFile": "/hierarchy/int-rsa-b.pkcs11.json",
 						"certFile": "/hierarchy/int-rsa-b.cert.pem",


### PR DESCRIPTION
This was missed in https://github.com/letsencrypt/boulder/pull/7300

Part of https://github.com/letsencrypt/boulder/issues/7296
IN-10046 tracks the corresponding production config change.