### PR TITLE
admin: revoke certs or block keys based on cert PEM

### DIFF
--- a/cmd/admin/cert.go
+++ b/cmd/admin/cert.go
@@ -43,6 +43,7 @@ type subcommandRevokeCert struct {
 	serialsFile   string
 	privKey       string
 	regID         uint
+	certFile      string
 }
 
 var _ subcommand = (*subcommandRevokeCert)(nil)
@@ -64,10 +65,7 @@ func (s *subcommandRevokeCert) Flags(flag *flag.FlagSet) {
 	flag.StringVar(&s.serialsFile, "serials-file", "", "Revoke all certificates whose hex serials are in this file")
 	flag.StringVar(&s.privKey, "private-key", "", "Revoke all certificates whose pubkey matches this private key")
 	flag.UintVar(&s.regID, "reg-id", 0, "Revoke all certificates issued to this account")
-
-	// TODO: add these, because they would have been useful in the most recent revocation.
-	// certFile := subflags.String("cert-file", "", "Revoke all certificates whose PEM is in this file")
-	// pubKey := subflags.String("public-key", "", "Revoke all certificates whose pubkey matches this public key")
+	flag.StringVar(&s.certFile, "cert-file", "", "Revoke the PEM-formatted certificate in this file")
 }
 
 func (s *subcommandRevokeCert) Run(ctx context.Context, a *admin) error {
@@ -108,6 +106,7 @@ func (s *subcommandRevokeCert) Run(ctx context.Context, a *admin) error {
 		"-serials-file":   s.serialsFile != "",
 		"-private-key":    s.privKey != "",
 		"-reg-id":         s.regID != 0,
+		"-cert-file":      s.certFile != "",
 	}
 	maps.DeleteFunc(setInputs, func(_ string, v bool) bool { return !v })
 	if len(setInputs) == 0 {
@@ -129,6 +128,8 @@ func (s *subcommandRevokeCert) Run(ctx context.Context, a *admin) error {
 		serials, err = a.serialsFromPrivateKey(ctx, s.privKey)
 	case "-reg-id":
 		serials, err = a.serialsFromRegID(ctx, int64(s.regID))
+	case "-cert-file":
+		serials, err = a.serialsFromCertPEM(ctx, s.certFile)
 	default:
 		return errors.New("no recognized input method flag set (this shouldn't happen)")
 	}
@@ -239,6 +240,15 @@ func (a *admin) serialsFromRegID(ctx context.Context, regID int64) ([]string, er
 	}
 
 	return serials, nil
+}
+
+func (a *admin) serialsFromCertPEM(_ context.Context, filename string) ([]string, error) {
+	cert, err := core.LoadCert(filename)
+	if err != nil {
+		return nil, fmt.Errorf("loading certificate pem: %w", err)
+	}
+
+	return []string{core.SerialToString(cert.SerialNumber)}, nil
 }
 
 func cleanSerial(serial string) (string, error) {

--- a/cmd/admin/cert.go
+++ b/cmd/admin/cert.go
@@ -65,7 +65,7 @@ func (s *subcommandRevokeCert) Flags(flag *flag.FlagSet) {
 	flag.StringVar(&s.serialsFile, "serials-file", "", "Revoke all certificates whose hex serials are in this file")
 	flag.StringVar(&s.privKey, "private-key", "", "Revoke all certificates whose pubkey matches this private key")
 	flag.UintVar(&s.regID, "reg-id", 0, "Revoke all certificates issued to this account")
-	flag.StringVar(&s.certFile, "cert-file", "", "Revoke the PEM-formatted certificate in this file")
+	flag.StringVar(&s.certFile, "cert-file", "", "Revoke the single PEM-formatted certificate in this file")
 }
 
 func (s *subcommandRevokeCert) Run(ctx context.Context, a *admin) error {

--- a/cmd/admin/key.go
+++ b/cmd/admin/key.go
@@ -27,6 +27,7 @@ type subcommandBlockKey struct {
 	comment     string
 	privKey     string
 	spkiFile    string
+	certFile    string
 }
 
 var _ subcommand = (*subcommandBlockKey)(nil)
@@ -43,6 +44,7 @@ func (s *subcommandBlockKey) Flags(flag *flag.FlagSet) {
 	// Flags specifying the input method for the keys to be blocked.
 	flag.StringVar(&s.privKey, "private-key", "", "Block issuance for the pubkey corresponding to this private key")
 	flag.StringVar(&s.spkiFile, "spki-file", "", "Block issuance for all keys listed in this file as SHA256 hashes of SPKI, hex encoded, one per line")
+	flag.StringVar(&s.certFile, "cert-file", "", "Block issuance for the public key of the PEM-formatted certificate in this file")
 }
 
 func (s *subcommandBlockKey) Run(ctx context.Context, a *admin) error {
@@ -52,6 +54,7 @@ func (s *subcommandBlockKey) Run(ctx context.Context, a *admin) error {
 	setInputs := map[string]bool{
 		"-private-key": s.privKey != "",
 		"-spki-file":   s.spkiFile != "",
+		"-cert-file":   s.certFile != "",
 	}
 	maps.DeleteFunc(setInputs, func(_ string, v bool) bool { return !v })
 	if len(setInputs) == 0 {
@@ -69,6 +72,8 @@ func (s *subcommandBlockKey) Run(ctx context.Context, a *admin) error {
 		spkiHashes = [][]byte{spkiHash}
 	case "-spki-file":
 		spkiHashes, err = a.spkiHashesFromFile(s.spkiFile)
+	case "-cert-file":
+		spkiHashes, err = a.spkiHashesFromCertPEM(s.certFile)
 	default:
 		return errors.New("no recognized input method flag set (this shouldn't happen)")
 	}
@@ -124,6 +129,20 @@ func (a *admin) spkiHashesFromFile(filePath string) ([][]byte, error) {
 	}
 
 	return spkiHashes, nil
+}
+
+func (a *admin) spkiHashesFromCertPEM(filename string) ([][]byte, error) {
+	cert, err := core.LoadCert(filename)
+	if err != nil {
+		return nil, fmt.Errorf("loading certificate pem: %w", err)
+	}
+
+	spkiHash, err := core.KeyDigest(cert.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("computing SPKI hash: %w", err)
+	}
+
+	return [][]byte{spkiHash[:]}, nil
 }
 
 func (a *admin) blockSPKIHashes(ctx context.Context, spkiHashes [][]byte, comment string, parallelism uint) error {

--- a/cmd/admin/key.go
+++ b/cmd/admin/key.go
@@ -44,7 +44,7 @@ func (s *subcommandBlockKey) Flags(flag *flag.FlagSet) {
 	// Flags specifying the input method for the keys to be blocked.
 	flag.StringVar(&s.privKey, "private-key", "", "Block issuance for the pubkey corresponding to this private key")
 	flag.StringVar(&s.spkiFile, "spki-file", "", "Block issuance for all keys listed in this file as SHA256 hashes of SPKI, hex encoded, one per line")
-	flag.StringVar(&s.certFile, "cert-file", "", "Block issuance for the public key of the PEM-formatted certificate in this file")
+	flag.StringVar(&s.certFile, "cert-file", "", "Block issuance for the public key of the single PEM-formatted certificate in this file")
 }
 
 func (s *subcommandBlockKey) Run(ctx context.Context, a *admin) error {


### PR DESCRIPTION
Add a new "-cert-file" input mode to both `admin revoke-cert` and `admin block-key` which operates on the serial or pubkey found in the PEM-encoded certificate in the supplied file.

Fixes https://github.com/letsencrypt/boulder/issues/7267