### PR TITLE
sa: get order names from authorizations

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -600,7 +600,7 @@ func (ssa *SQLStorageAuthority) NewOrderAndAuthzs(ctx context.Context, req *sapb
 		authzValidityInfo, err := getAuthorizationStatuses(ctx, tx, res.V2Authorizations)
 		// If there was an error getting the authorizations, return it immediately
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		// Calculate the order status before returning it. Since it may have reused

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -546,6 +546,7 @@ func (ssa *SQLStorageAuthority) NewOrderAndAuthzs(ctx context.Context, req *sapb
 		}
 
 		// Fourth, insert all of the requestedNames.
+		// TODO(#7432): Remove this
 		inserter, err = db.NewMultiInserter("requestedNames", []string{"orderID", "reversedName"}, "")
 		if err != nil {
 			return nil, err
@@ -595,9 +596,16 @@ func (ssa *SQLStorageAuthority) NewOrderAndAuthzs(ctx context.Context, req *sapb
 			}
 		}
 
+		// Get the partial Authorization objects for the order
+		authzValidityInfo, err := getAuthorizationStatuses(ctx, tx, res.V2Authorizations)
+		// If there was an error getting the authorizations, return it immediately
+		if err != nil {
+			return "", err
+		}
+
 		// Calculate the order status before returning it. Since it may have reused
 		// all valid authorizations the order may be "born" in a ready status.
-		status, err := statusForOrder(ctx, tx, res, ssa.clk.Now())
+		status, err := statusForOrder(res, authzValidityInfo, ssa.clk.Now())
 		if err != nil {
 			return nil, err
 		}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -1321,11 +1321,6 @@ func TestNewOrderAndAuthzs(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to count orderToAuthz entries")
 	test.AssertEquals(t, len(authzIDs), 4)
 	test.AssertDeepEquals(t, authzIDs, []int64{1, 2, 3, 4})
-
-	names, err := namesForOrder(ctx, sa.dbReadOnlyMap, order.Id)
-	test.AssertNotError(t, err, "namesForOrder errored")
-	test.AssertEquals(t, len(names), 4)
-	test.AssertDeepEquals(t, names, []string{"com.a", "com.b", "com.c", "com.d"})
 }
 
 // TestNewOrderAndAuthzs_NonNilInnerOrder verifies that a nil

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -740,7 +740,7 @@ func (ssa *SQLStorageAuthorityRO) GetOrder(ctx context.Context, req *sapb.OrderR
 		authzValidityInfo, err := getAuthorizationStatuses(ctx, tx, order.V2Authorizations)
 		// If there was an error getting the authorizations, return it immediately
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		names := make([]string, 0, len(authzValidityInfo))

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -736,21 +736,21 @@ func (ssa *SQLStorageAuthorityRO) GetOrder(ctx context.Context, req *sapb.OrderR
 		}
 		order.V2Authorizations = v2AuthzIDs
 
-		names, err := namesForOrder(ctx, tx, order.Id)
+		// Get the partial Authorization objects for the order
+		authzValidityInfo, err := getAuthorizationStatuses(ctx, tx, order.V2Authorizations)
+		// If there was an error getting the authorizations, return it immediately
 		if err != nil {
-			return nil, err
+			return "", err
 		}
-		// The requested names are stored reversed to improve indexing performance. We
-		// need to reverse the reversed names here before giving them back to the
-		// caller.
-		reversedNames := make([]string, len(names))
-		for i, n := range names {
-			reversedNames[i] = ReverseName(n)
+
+		names := make([]string, 0, len(authzValidityInfo))
+		for _, a := range authzValidityInfo {
+			names = append(names, a.IdentifierValue)
 		}
-		order.Names = reversedNames
+		order.Names = names
 
 		// Calculate the status for the order
-		status, err := statusForOrder(ctx, tx, order, ssa.clk.Now())
+		status, err := statusForOrder(order, authzValidityInfo, ssa.clk.Now())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This removes the only place we query the requestedNames table, which allows us to get rid of it in a subsequent PR (once this one is merged and deployed).

Part of #7432