### PR TITLE
CA: Run all CA package tests in parallel

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 func TestImplementation(t *testing.T) {
+	t.Parallel()
 	test.AssertImplementsGRPCServer(t, &certificateAuthorityImpl{}, capb.UnimplementedCertificateAuthorityServer{})
 }
 
@@ -277,6 +278,7 @@ func setup(t *testing.T) *testCtx {
 }
 
 func TestSerialPrefix(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 
 	_, err := NewCertificateAuthorityImpl(
@@ -329,6 +331,7 @@ type TestCertificateIssuance struct {
 }
 
 func TestIssuePrecertificate(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name    string
 		csr     []byte
@@ -439,6 +442,7 @@ func issueCertificateSubTestValidityUsesCAClock(t *testing.T, i *TestCertificate
 
 // Test failure mode when no issuers are present.
 func TestNoIssuers(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	sa := &mockSA{}
 	_, err := NewCertificateAuthorityImpl(
@@ -465,6 +469,7 @@ func TestNoIssuers(t *testing.T) {
 
 // Test issuing when multiple issuers are present.
 func TestMultipleIssuers(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	sa := &mockSA{}
 	ca, err := NewCertificateAuthorityImpl(
@@ -511,6 +516,7 @@ func TestMultipleIssuers(t *testing.T) {
 }
 
 func TestProfiles(t *testing.T) {
+	t.Parallel()
 	ctx := setup(t)
 	test.AssertEquals(t, len(ctx.certProfiles), 2)
 
@@ -679,6 +685,7 @@ func TestProfiles(t *testing.T) {
 }
 
 func TestECDSAAllowList(t *testing.T) {
+	t.Parallel()
 	req := &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID}
 
 	// With allowlist containing arbitraryRegID, issuance should come from ECDSA issuer.
@@ -711,6 +718,7 @@ func TestECDSAAllowList(t *testing.T) {
 }
 
 func TestInvalidCSRs(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name         string
 		csrPath      string
@@ -802,6 +810,7 @@ func TestInvalidCSRs(t *testing.T) {
 }
 
 func TestRejectValidityTooLong(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	sa := &mockSA{}
 	ca, err := NewCertificateAuthorityImpl(
@@ -905,6 +914,7 @@ func makeSCTs() ([][]byte, error) {
 }
 
 func TestIssueCertificateForPrecertificate(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	sa := &mockSA{}
 	ca, err := NewCertificateAuthorityImpl(
@@ -975,6 +985,7 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 }
 
 func TestIssueCertificateForPrecertificateWithSpecificCertificateProfile(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	sa := &mockSA{}
 	ca, err := NewCertificateAuthorityImpl(
@@ -1096,6 +1107,7 @@ func (m *getCertErrorSA) GetCertificate(ctx context.Context, req *sapb.Serial, _
 }
 
 func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	sa := &dupeSA{}
 	ca, err := NewCertificateAuthorityImpl(
@@ -1190,6 +1202,7 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 }
 
 func TestGenerateSKID(t *testing.T) {
+	t.Parallel()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	test.AssertNotError(t, err, "Error generating key")
 

--- a/ca/crl_test.go
+++ b/ca/crl_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestImplementationCRL(t *testing.T) {
+	t.Parallel()
 	test.AssertImplementsGRPCServer(t, &crlImpl{}, capb.UnimplementedCRLGeneratorServer{})
 }
 
@@ -38,6 +39,7 @@ func (s mockGenerateCRLBidiStream) Send(entry *capb.GenerateCRLResponse) error {
 }
 
 func TestGenerateCRL(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	crli := testCtx.crl
 	errs := make(chan error, 1)

--- a/ca/ecdsa_allow_list_test.go
+++ b/ca/ecdsa_allow_list_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestNewECDSAAllowListFromFile(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		filename string
 	}
@@ -46,9 +47,13 @@ func TestNewECDSAAllowListFromFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		// TODO(Remove this >= go1.22.3) This shouldn't be necessary due to
+		// go1.22 changing loopvars.
+		// https://github.com/golang/go/issues/65612#issuecomment-1943342030
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			allowList, gotEntries, err := NewECDSAAllowListFromFile(tt.args.filename)
-
 			if (err != nil) != tt.wantErrBool {
 				t.Errorf("NewECDSAAllowListFromFile() error = %v, wantErr %v", err, tt.wantErrBool)
 				t.Error(allowList, gotEntries, err)

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestImplementationOCSP(t *testing.T) {
+	t.Parallel()
 	test.AssertImplementsGRPCServer(t, &ocspImpl{}, capb.UnimplementedOCSPGeneratorServer{})
 }
 
@@ -30,6 +31,7 @@ func serial(t *testing.T) []byte {
 }
 
 func TestOCSP(t *testing.T) {
+	t.Parallel()
 	testCtx := setup(t)
 	ca, err := NewCertificateAuthorityImpl(
 		&mockSA{},


### PR DESCRIPTION
The CA tests don't share any state and create their own individual CA implementations. We can safely run these tests in parallel within the CA package to shave at least a second off of unit test runs at the expense of additional CPU and memory usage.

Before:
```
$ ./t.sh -u -p ./ca -w
Running Unit Tests
ok      github.com/letsencrypt/boulder/ca       3.538s
SUCCESS
```

After:
```
$ ./t.sh -u -p ./ca -w
Running Unit Tests
ok      github.com/letsencrypt/boulder/ca       2.033s
SUCCESS
```