### PR TITLE
Fix cert-checker in config-next integration tests

### DIFF
--- a/sa/db-users/boulder_sa.sql
+++ b/sa/db-users/boulder_sa.sql
@@ -76,6 +76,7 @@ GRANT SELECT ON fqdnSets TO 'mailer'@'localhost';
 -- Cert checker
 GRANT SELECT ON certificates TO 'cert_checker'@'localhost';
 GRANT SELECT ON authz2 TO 'cert_checker'@'localhost';
+GRANT SELECT ON precertificates TO 'cert_checker'@'localhost';
 
 -- Bad Key Revoker
 GRANT SELECT,UPDATE ON blockedKeys TO 'badkeyrevoker'@'localhost';


### PR DESCRIPTION
Cert checker has been failing in config-next because the "CertCheckerRequiresCorrespondence" flag is enabled, but no permissions were granted on the precertificates table. While this did cause it to log profusively, this did not cause the tests to fail because integration-test.py simply executes cert-checker without caring about its exit code.