### PR TITLE
CA: Fix CRL chunking loop

### DIFF
--- a/ca/crl.go
+++ b/ca/crl.go
@@ -151,7 +151,7 @@ func (ci *crlImpl) GenerateCRL(stream capb.CRLGenerator_GenerateCRLServer) error
 		logID, len(crlBytes), hash,
 	)
 
-	for i := range len(crlBytes) {
+	for i := 0; i < len(crlBytes); i += 1000 {
 		j := i + 1000
 		if j > len(crlBytes) {
 			j = len(crlBytes)


### PR DESCRIPTION
Partial revert of https://github.com/letsencrypt/boulder/pull/7434

The purpose of this loop is to chunk the CRL into thousand-byte pieces. To that end, it iterated across the bytes of the CRL in steps of size 1000. When this loop was replaced with a range loop, that step size was not preserved.

Our tests do not usually produce any CRLs that exceed 1k bytes, so the test CRLs fit within a single chunk, and this bug was not detected.

A search of the diff in the previous change does not show any other instances where a step size other than 1 was being used.