### PR TITLE
config: Update minimum TLS version from 1.2 to 1.3

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -205,11 +205,8 @@ func (t *TLSConfig) Load(scope prometheus.Registerer) (*tls.Config, error) {
 		ClientCAs:    rootCAs,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{cert},
-		// Set the only acceptable TLS to v1.2 and v1.3.
-		MinVersion: tls.VersionTLS12,
-		MaxVersion: tls.VersionTLS13,
-		// CipherSuites will be ignored for TLS v1.3.
-		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
+		// Set the only acceptable TLS to v1.3.
+		MinVersion: tls.VersionTLS13,
 	}, nil
 }
 

--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -86,10 +86,7 @@ func (tc *clientTransportCredentials) ServerHandshake(rawConn net.Conn) (net.Con
 
 // Info returns information about the transport protocol used
 func (tc *clientTransportCredentials) Info() credentials.ProtocolInfo {
-	return credentials.ProtocolInfo{
-		SecurityProtocol: "tls",
-		SecurityVersion:  "1.2", // We *only* support TLS 1.2
-	}
+	return credentials.ProtocolInfo{SecurityProtocol: "tls"}
 }
 
 // GetRequestMetadata returns nil, nil since TLS credentials do not have metadata.
@@ -217,10 +214,7 @@ func (tc *serverTransportCredentials) ClientHandshake(ctx context.Context, addr 
 
 // Info provides the ProtocolInfo of this TransportCredentials.
 func (tc *serverTransportCredentials) Info() credentials.ProtocolInfo {
-	return credentials.ProtocolInfo{
-		SecurityProtocol: "tls",
-		SecurityVersion:  "1.2", // We *only* support TLS 1.2
-	}
+	return credentials.ProtocolInfo{SecurityProtocol: "tls"}
 }
 
 // GetRequestMetadata returns nil, nil since TLS credentials do not have metadata.


### PR DESCRIPTION
- Set the minimum TLS version used for communication with gRPC, Redis, and Unbound to 1.3.
- Remove deprecated `SecurityVersion` setting in `clientTransportCredentials` and `serverTransportCredentials`, as grpc-go now depends on the settings provided by the `tls.Config`.

The [http-01](https://github.com/letsencrypt/boulder/blob/939ac1be8f291aea5b9e2b862caf38e73c4428d2/va/http.go#L140-L157) and [tls-alpn-01](https://github.com/letsencrypt/boulder/blob/939ac1be8f291aea5b9e2b862caf38e73c4428d2/va/tlsalpn.go#L213-L217) challenges are not affected.