### PR TITLE
CA: Remove deprecated crldpBase config

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -241,7 +241,6 @@ func setup(t *testing.T) *testCtx {
 			ValidityInterval: config.Duration{Duration: 216 * time.Hour},
 			MaxBackdate:      config.Duration{Duration: time.Hour},
 		},
-		"http://c.boulder.test",
 		100,
 		blog.NewMock(),
 	)

--- a/ca/crl.go
+++ b/ca/crl.go
@@ -18,10 +18,8 @@ import (
 
 type crlImpl struct {
 	capb.UnimplementedCRLGeneratorServer
-	issuers map[issuance.NameID]*issuance.Issuer
-	profile *issuance.CRLProfile
-	// TODO(#7094): Remove this once all CRLs have IDPs built from issuer.crlURLBase.
-	idpBase   string
+	issuers   map[issuance.NameID]*issuance.Issuer
+	profile   *issuance.CRLProfile
 	maxLogLen int
 	log       blog.Logger
 }
@@ -29,12 +27,10 @@ type crlImpl struct {
 // NewCRLImpl returns a new object which fulfils the ca.proto CRLGenerator
 // interface. It uses the list of issuers to determine what issuers it can
 // issue CRLs from. lifetime sets the validity period (inclusive) of the
-// resulting CRLs. idpBase is the base URL from which IssuingDistributionPoint
-// URIs will constructed; it must use the http:// scheme.
+// resulting CRLs.
 func NewCRLImpl(
 	issuers []*issuance.Issuer,
 	profileConfig issuance.CRLProfileConfig,
-	idpBase string,
 	maxLogLen int,
 	logger blog.Logger) (*crlImpl, error) {
 	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer, len(issuers))
@@ -50,7 +46,6 @@ func NewCRLImpl(
 	return &crlImpl{
 		issuers:   issuersByNameID,
 		profile:   profile,
-		idpBase:   idpBase,
 		maxLogLen: maxLogLen,
 		log:       logger,
 	}, nil
@@ -102,13 +97,6 @@ func (ci *crlImpl) GenerateCRL(stream capb.CRLGenerator_GenerateCRLServer) error
 
 	if req == nil {
 		return errors.New("no crl metadata received")
-	}
-
-	// Add the Issuing Distribution Point extension.
-	// TODO(#7296): Remove this fallback once all configs have issuer.CRLBaseURL
-	// set and our CRL URLs disclosed in CCADB have been updated.
-	if ci.idpBase != "" {
-		req.DeprecatedIDPBaseURL = ci.idpBase
 	}
 
 	// Compute a unique ID for this issuer-number-shard combo, to tie together all

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -110,12 +110,6 @@ type Config struct {
 		// https://www.gstatic.com/ct/log_list/v3/log_list_schema.json
 		CTLogListFile string
 
-		// CRLDPBase is the piece of the CRL Distribution Point URI which is common
-		// across all issuers and shards. It must use the http:// scheme, and must
-		// not end with a slash. Example: "http://prod.c.lencr.org".
-		// TODO(#7296): Remove this fallback once all configs have issuer.CRLBaseURL
-		CRLDPBase string `validate:"omitempty,url,startswith=http://,endsnotwith=/"`
-
 		// DisableCertService causes the CertificateAuthority gRPC service to not
 		// start, preventing any certificates or precertificates from being issued.
 		DisableCertService bool
@@ -291,7 +285,6 @@ func main() {
 		crli, err := ca.NewCRLImpl(
 			issuers,
 			c.CA.Issuance.CRLProfile,
-			c.CA.CRLDPBase,
 			c.CA.OCSPLogMaxLength,
 			logger,
 		)

--- a/issuance/crl.go
+++ b/issuance/crl.go
@@ -57,9 +57,6 @@ type CRLRequest struct {
 	ThisUpdate time.Time
 
 	Entries []x509.RevocationListEntry
-
-	// TODO(#7296): Remove this and instead compute it from Issuer.CRLBaseURL
-	DeprecatedIDPBaseURL string
 }
 
 func (i *Issuer) IssueCRL(prof *CRLProfile, req *CRLRequest) ([]byte, error) {
@@ -78,22 +75,15 @@ func (i *Issuer) IssueCRL(prof *CRLProfile, req *CRLRequest) ([]byte, error) {
 		NextUpdate:                req.ThisUpdate.Add(-time.Second).Add(prof.validityInterval),
 	}
 
-	if i.crlURLBase == "" && req.DeprecatedIDPBaseURL == "" {
+	if i.crlURLBase == "" {
 		return nil, fmt.Errorf("CRL must contain an issuingDistributionPoint")
 	}
 
-	var idps []string
-	if i.crlURLBase != "" {
-		// Concat the base with the shard directly, since we require that the base
-		// end with a single trailing slash.
-		idps = append(idps, fmt.Sprintf("%s%d.crl", i.crlURLBase, req.Shard))
-	}
-	if req.DeprecatedIDPBaseURL != "" {
-		// TODO(#7296): Remove this fallback once CCADB and all non-expired certs
-		// contain the new-style CRLDP URL instead.
-		idps = append(idps, fmt.Sprintf("%s/%d/%d.crl", req.DeprecatedIDPBaseURL, i.NameID(), req.Shard))
-	}
-	idp, err := idp.MakeUserCertsExt(idps)
+	// Concat the base with the shard directly, since we require that the base
+	// end with a single trailing slash.
+	idp, err := idp.MakeUserCertsExt([]string{
+		fmt.Sprintf("%s%d.crl", i.crlURLBase, req.Shard),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("creating IDP extension: %w", err)
 	}

--- a/issuance/crl_test.go
+++ b/issuance/crl_test.go
@@ -107,7 +107,6 @@ func TestIssueCRL(t *testing.T) {
 				ReasonCode:     1,
 			},
 		},
-		DeprecatedIDPBaseURL: "http://old.crl.url",
 	}
 
 	req := defaultRequest
@@ -148,15 +147,16 @@ func TestIssueCRL(t *testing.T) {
 
 	idps, err := idp.GetIDPURIs(parsedRes.Extensions)
 	test.AssertNotError(t, err, "getting IDP URIs from test CRL")
+	test.AssertEquals(t, len(idps), 1)
 	test.AssertEquals(t, idps[0], "http://crl-url.example.org/100.crl")
-	test.AssertEquals(t, idps[1], "http://old.crl.url/0/100.crl")
 
 	req = defaultRequest
-	req.DeprecatedIDPBaseURL = ""
+	crlURLBase := issuer.crlURLBase
 	issuer.crlURLBase = ""
 	_, err = issuer.IssueCRL(&defaultProfile, &req)
 	test.AssertError(t, err, "crl issuance with no IDP should fail")
 	test.AssertContains(t, err.Error(), "must contain an issuingDistributionPoint")
+	issuer.crlURLBase = crlURLBase
 
 	// A CRL with no entries must not have the revokedCertificates field
 	req = defaultRequest

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -255,13 +255,14 @@ func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk
 	if config.OCSPURL == "" {
 		return nil, errors.New("OCSP URL is required")
 	}
-	if config.CRLURLBase != "" {
-		if !strings.HasPrefix(config.CRLURLBase, "http://") {
-			return nil, fmt.Errorf("crlURLBase must use HTTP scheme, got %q", config.CRLURLBase)
-		}
-		if !strings.HasSuffix(config.CRLURLBase, "/") {
-			return nil, fmt.Errorf("crlURLBase must end with exactly one forward slash, got %q", config.CRLURLBase)
-		}
+	if config.CRLURLBase == "" {
+		return nil, errors.New("CRL URL base is required")
+	}
+	if !strings.HasPrefix(config.CRLURLBase, "http://") {
+		return nil, fmt.Errorf("crlURLBase must use HTTP scheme, got %q", config.CRLURLBase)
+	}
+	if !strings.HasSuffix(config.CRLURLBase, "/") {
+		return nil, fmt.Errorf("crlURLBase must end with exactly one forward slash, got %q", config.CRLURLBase)
 	}
 
 	// We require that all of our issuers be capable of both issuing certs and

--- a/linter/lints/cpcps/lint_crl_has_idp.go
+++ b/linter/lints/cpcps/lint_crl_has_idp.go
@@ -192,9 +192,12 @@ func parseDistributionPointName(distributionPointName *cryptobyte.String, idp *l
 			Status:  lint.Error,
 			Details: "IssuingDistributionPoint FullName URI MUST be present",
 		}
+	} else if len(idp.DistributionPointURIs) > 1 {
+		return &lint.LintResult{
+			Status:  lint.Notice,
+			Details: "IssuingDistributionPoint unexpectedly has more than one FullName",
+		}
 	}
-	// TODO(#7296): When we're back to only including one GeneralName within the
-	// distributionPoint's FullName, re-add a check that len(uris) == 1.
 
 	return nil
 }

--- a/linter/lints/cpcps/lint_crl_has_idp_test.go
+++ b/linter/lints/cpcps/lint_crl_has_idp_test.go
@@ -47,10 +47,9 @@ func TestCrlHasIDP(t *testing.T) {
 			wantSubStr: "IssuingDistributionPoint FullName URI MUST be present",
 		},
 		{
-			// TODO(#7296): When we're back to only including one GeneralName within
-			// the distributionPoint's FullName, change this to expect a lint.Notice.
-			name: "idp_two_uris",
-			want: lint.Pass,
+			name:       "idp_two_uris",
+			want:       lint.Notice,
+			wantSubStr: "IssuingDistributionPoint unexpectedly has more than one FullName",
 		},
 		{
 			name:       "idp_https",

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -63,6 +63,7 @@
 					"useForECDSALeaves": true,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-a",
 					"ocspURL": "http://ca.example.org:4002/",
+					"crlURLBase": "http://ca.example.org:4501/ecdsa-a/",
 					"location": {
 						"configFile": "/hierarchy/int-ecdsa-a.pkcs11.json",
 						"certFile": "/hierarchy/int-ecdsa-a.cert.pem",
@@ -74,6 +75,7 @@
 					"useForECDSALeaves": true,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-a",
 					"ocspURL": "http://ca.example.org:4002/",
+					"crlURLBase": "http://ca.example.org:4501/rsa-a/",
 					"location": {
 						"configFile": "/hierarchy/int-rsa-a.pkcs11.json",
 						"certFile": "/hierarchy/int-rsa-a.cert.pem",
@@ -85,6 +87,7 @@
 					"useForECDSALeaves": false,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-b",
 					"ocspURL": "http://ca.example.org:4003/",
+					"crlURLBase": "http://ca.example.org:4501/rsa-b/",
 					"location": {
 						"configFile": "/hierarchy/int-rsa-b.pkcs11.json",
 						"certFile": "/hierarchy/int-rsa-b.cert.pem",
@@ -103,7 +106,6 @@
 		"maxNames": 100,
 		"lifespanOCSP": "96h",
 		"lifespanCRL": "216h",
-		"crldpBase": "http://c.boulder.test",
 		"goodkey": {
 			"weakKeyFile": "test/example-weak-keys.json",
 			"blockedKeyFile": "test/example-blocked-keys.yaml",


### PR DESCRIPTION
Remove the CA's global "crldpBase" config item, and the code which used it to produce a IDP URI in our CRLs if it was configured.

This config item has been replaced by per-issuer crlURLBase configs instead, because we have switched our CRL URL format from "commonURL/issuerID/shard.crl" to "issuerURL/shard.crl" in anticipation of including these URLs directly in our end-entity certs.

IN-10046 tracked the corresponding change in prod