### PR TITLE
wfe: Remove ResolverAddrs field from being displayed to the client

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1233,8 +1233,8 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 	}
 
 	// This field is not useful for the client, only internal debugging,
-	for _, vr := range challenge.ValidationRecord {
-		vr.ResolverAddrs = nil
+	for idx := range challenge.ValidationRecord {
+		challenge.ValidationRecord[idx].ResolverAddrs = nil
 	}
 }
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1206,7 +1206,8 @@ func prepAccountForDisplay(acct *core.Registration) {
 }
 
 // prepChallengeForDisplay takes a core.Challenge and prepares it for display to
-// the client by filling in its URL field and clearing its ID and URI fields.
+// the client by filling in its URL field and clearing several unnecessary
+// fields.
 func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz core.Authorization, challenge *core.Challenge) {
 	// Update the challenge URL to be relative to the HTTP request Host
 	challenge.URL = web.RelativeEndpoint(request, fmt.Sprintf("%s%s/%s", challengePath, authz.ID, challenge.StringID()))
@@ -1229,6 +1230,11 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 	// to be invalid as well.
 	if authz.Status == core.StatusInvalid {
 		challenge.Status = authz.Status
+	}
+
+	// This field is not useful for the client, only internal debugging,
+	for _, vr := range challenge.ValidationRecord {
+		vr.ResolverAddrs = nil
 	}
 }
 


### PR DESCRIPTION
The ResolverAddrs field is only useful for internal debugging and shouldn't be displayed to clients.

Fixes https://github.com/letsencrypt/boulder/issues/7462