### PR TITLE
admin: fail if any error is encountered during parallel processing

### DIFF
--- a/cmd/admin/cert_test.go
+++ b/cmd/admin/cert_test.go
@@ -249,7 +249,7 @@ func TestRevokeSerials(t *testing.T) {
 	log.Clear()
 	mra.alreadyRevoked = []string{"048c3f6388afb7695dd4d6bbe3d264f1e5e5"}
 	err = a.revokeSerials(context.Background(), serials, 0, false, false, 1)
-	test.AssertNotError(t, err, "")
+	test.AssertError(t, err, "already-revoked should result in error")
 	test.AssertEquals(t, len(log.GetAllMatching("not revoking")), 1)
 	test.AssertEquals(t, len(mra.revocationRequests), 3)
 	assertRequestsContain(mra.revocationRequests, 0, false, false)
@@ -259,7 +259,7 @@ func TestRevokeSerials(t *testing.T) {
 	log.Clear()
 	mra.doomedToFail = []string{"048c3f6388afb7695dd4d6bbe3d264f1e5e5"}
 	err = a.revokeSerials(context.Background(), serials, 0, false, false, 1)
-	test.AssertNotError(t, err, "")
+	test.AssertError(t, err, "gRPC error should result in error")
 	test.AssertEquals(t, len(log.GetAllMatching("failed to revoke")), 1)
 	test.AssertEquals(t, len(mra.revocationRequests), 3)
 	assertRequestsContain(mra.revocationRequests, 0, false, false)

--- a/cmd/admin/key.go
+++ b/cmd/admin/key.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/user"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -151,7 +152,7 @@ func (a *admin) blockSPKIHashes(ctx context.Context, spkiHashes [][]byte, commen
 		return fmt.Errorf("getting admin username: %w", err)
 	}
 
-	anyErr := false
+	var errCount atomic.Uint64
 	wg := new(sync.WaitGroup)
 	work := make(chan []byte, parallelism)
 	for i := uint(0); i < parallelism; i++ {
@@ -161,7 +162,7 @@ func (a *admin) blockSPKIHashes(ctx context.Context, spkiHashes [][]byte, commen
 			for spkiHash := range work {
 				err = a.blockSPKIHash(ctx, spkiHash, u, comment)
 				if err != nil {
-					anyErr = true
+					errCount.Add(1)
 					if errors.Is(err, berrors.AlreadyRevoked) {
 						a.log.Errf("not blocking %x: already blocked", spkiHash)
 					} else {
@@ -178,8 +179,8 @@ func (a *admin) blockSPKIHashes(ctx context.Context, spkiHashes [][]byte, commen
 	close(work)
 	wg.Wait()
 
-	if anyErr {
-		return errors.New("one or more errors encountered while blocking keys; see logs above for details")
+	if errCount.Load() > 0 {
+		return fmt.Errorf("encountered %d errors while revoking certs; see logs above for details", errCount.Load())
 	}
 
 	return nil

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -464,7 +464,7 @@ func (ssa *SQLStorageAuthorityRO) GetLintPrecertificate(ctx context.Context, req
 }
 
 func (ssa *SQLStorageAuthority) GetLintPrecertificate(ctx context.Context, req *sapb.Serial) (*corepb.Certificate, error) {
-	return ssa.SQLStorageAuthorityRO.GetCertificate(ctx, req)
+	return ssa.SQLStorageAuthorityRO.GetLintPrecertificate(ctx, req)
 }
 
 // GetCertificateStatus takes a hexadecimal string representing the full 128-bit serial

--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -161,7 +161,6 @@ func TestIssuanceCertStorageFailed(t *testing.T) {
 		"revoke-cert",
 		"-serial", core.SerialToString(cert.SerialNumber),
 		"-reason", "unspecified",
-		"-malformed", "true",
 	).CombinedOutput()
 	test.AssertNotError(t, err, fmt.Sprintf("revoking via admin-revoker: %s", string(output)))
 

--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -161,6 +161,7 @@ func TestIssuanceCertStorageFailed(t *testing.T) {
 		"revoke-cert",
 		"-serial", core.SerialToString(cert.SerialNumber),
 		"-reason", "unspecified",
+		"-malformed", "true",
 	).CombinedOutput()
 	test.AssertNotError(t, err, fmt.Sprintf("revoking via admin-revoker: %s", string(output)))
 


### PR DESCRIPTION
While we don't want to halt the admin tool in the midst of its parallel processing, we can keep track of whether it has encountered any errors and raise one meta-error at the end of its execution. This will prevent the top-level admin code from claiming that execution succeeded, and ensure operators notice any previously-logged errors.

As part of this, fix the SA's GetLintPrecertificate wrapper to actually call the SARO's GetLintPrecertificate, instead of incorrectly calling the SARO's GetCertificate.

Fixes https://github.com/letsencrypt/boulder/issues/7460