### PR TITLE
VA: put most recent, not original, IP in error messages

### DIFF
--- a/va/http_test.go
+++ b/va/http_test.go
@@ -94,7 +94,7 @@ func TestPreresolvedDialerTimeout(t *testing.T) {
 	// Check that the HTTP connection doesn't return too fast, and times
 	// out after the expected time
 	if took < va.singleDialTimeout {
-		t.Fatalf("fetch returned before %s (took: %s) with %#v", va.singleDialTimeout, took, err)
+		t.Fatalf("fetch returned before %s (took: %s) with %q", va.singleDialTimeout, took, err.Error())
 	}
 	if took > 2*va.singleDialTimeout {
 		t.Fatalf("fetch didn't timeout after %s (took: %s)", va.singleDialTimeout, took)
@@ -184,7 +184,7 @@ func TestHTTPValidationTarget(t *testing.T) {
 				// Calling ip() on the target should give the expected IPs in the right
 				// order.
 				for i, expectedIP := range tc.ExpectedIPs {
-					gotIP := target.ip()
+					gotIP := target.cur
 					if gotIP == nil {
 						t.Errorf("Expected IP %d to be %s got nil", i, expectedIP)
 					} else {
@@ -1404,7 +1404,7 @@ func TestHTTPDialTimeout(t *testing.T) {
 	// Check that the HTTP connection doesn't return too fast, and times
 	// out after the expected time
 	if took < (timeout-200*time.Millisecond)/2 {
-		t.Fatalf("HTTP returned before %s (%s) with %#v", timeout, took, err)
+		t.Fatalf("HTTP returned before %s (%s) with %q", timeout, took, err.Error())
 	}
 	if took > 2*timeout {
 		t.Fatalf("HTTP connection didn't timeout after %s seconds", timeout)

--- a/va/va.go
+++ b/va/va.go
@@ -330,6 +330,12 @@ type ipError struct {
 	err error
 }
 
+// newIPError wraps an error and the IP of the remote host in an ipError so we
+// can display the IP in the problem details returned to the client.
+func newIPError(ip net.IP, err error) error {
+	return ipError{ip: ip, err: err}
+}
+
 // Unwrap returns the underlying error.
 func (i ipError) Unwrap() error {
 	return i.err


### PR DESCRIPTION
When we present error messages containing IP addresses to end users, sometimes we're presenting the IP at which we began a chain of redirects, but not presenting the IP at which the final redirect was located. This can make it difficult for client operators to identify exactly which server in their infrastructure is misbehaving.

Change our IP error messages to reference the most-recently-tried address from the set of all validation records, rather than the address which started the current (potential) redirect chain.

Fixes https://github.com/letsencrypt/boulder/issues/7347