### PR TITLE
test: Update eggsampler/acme to support draft-ietf-acme-ari-03

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,3 +98,5 @@ exclude github.com/go-sql-driver/mysql v1.6.0
 
 // This version is required by borp
 exclude github.com/go-sql-driver/mysql v1.7.1
+
+replace github.com/eggsampler/acme/v3 v3.5.0 => /home/phil/work/eggsampler-acme-client

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.26.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.50.2
 	github.com/aws/smithy-go v1.20.0
-	github.com/eggsampler/acme/v3 v3.5.0
+	github.com/eggsampler/acme/v3 v3.6.0
 	github.com/go-jose/go-jose/v4 v4.0.1
 	github.com/go-logr/stdr v1.2.2
 	github.com/go-sql-driver/mysql v1.5.0
@@ -98,5 +98,3 @@ exclude github.com/go-sql-driver/mysql v1.6.0
 
 // This version is required by borp
 exclude github.com/go-sql-driver/mysql v1.7.1
-
-replace github.com/eggsampler/acme/v3 v3.5.0 => /home/phil/work/eggsampler-acme-client

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/eggsampler/acme/v3 v3.6.0 h1:TbQYoWlpl62fTdJq5i2LHBDY6h3LDU3pPAdyoUSQMOc=
+github.com/eggsampler/acme/v3 v3.6.0/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/eggsampler/acme/v3 v3.5.0 h1:tM8IXhS95HLm2LGxRDI3yzQrs7iZ9mKep1JjQhTIsUo=
-github.com/eggsampler/acme/v3 v3.5.0/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -53,12 +53,15 @@ func TestARI(t *testing.T) {
 	// TODO(@pgporada): Clean this up when 'test/config/{sa,wfe2}.json' sets
 	// TrackReplacementCertificatesARI=true.
 	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		ir, err = authAndIssueReplacement(client, key, []string{name}, true, cert)
+		_, order, err := makeClientAndOrder(client, key, []string{name}, true, cert)
 		test.AssertNotError(t, err, "failed to issue test cert")
-		test.AssertNotEquals(t, ir.Replaces, "")
+		replaceID, err := acme.GenerateARICertID(cert)
+		test.AssertNotError(t, err, "failed to generate ARI certID")
+		test.AssertEquals(t, order.Replaces, replaceID)
+		test.AssertNotEquals(t, order.Replaces, "")
 
 		// Try it again and verify it fails
-		_, err = authAndIssueReplacement(client, key, []string{name}, true, cert)
+		_, order, err = makeClientAndOrder(client, key, []string{name}, true, cert)
 		test.AssertError(t, err, "subsequent ARI replacements for a replaced cert should fail, but didn't")
 	} else {
 		// ARI is disabled so we only use the client to POST the replacement

--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -3,19 +3,18 @@
 package integration
 
 import (
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509/pkix"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/eggsampler/acme/v3"
 
 	"github.com/letsencrypt/boulder/test"
-	ocsp_helper "github.com/letsencrypt/boulder/test/ocsp/helper"
 )
 
 // certID matches the ASN.1 structure of the CertID sequence defined by RFC6960.
@@ -45,28 +44,38 @@ func TestARI(t *testing.T) {
 	test.AssertNotError(t, err, "failed to issue test cert")
 
 	cert := ir.certs[0]
-	issuer, err := ocsp_helper.GetIssuer(cert)
-	test.AssertNotError(t, err, "failed to get issuer cert")
-
-	eri, err := client.GetRenewalInfo(cert, issuer, crypto.SHA256)
+	ari, err := client.GetRenewalInfo(cert)
 	test.AssertNotError(t, err, "ARI request should have succeeded")
-	test.AssertEquals(t, eri.SuggestedWindow.Start.Sub(time.Now()).Round(time.Hour), 1415*time.Hour)
-	test.AssertEquals(t, eri.SuggestedWindow.End.Sub(time.Now()).Round(time.Hour), 1463*time.Hour)
-	test.AssertEquals(t, eri.RetryAfter.Sub(time.Now()).Round(time.Hour), 6*time.Hour)
+	test.AssertEquals(t, ari.SuggestedWindow.Start.Sub(time.Now()).Round(time.Hour), 1415*time.Hour)
+	test.AssertEquals(t, ari.SuggestedWindow.End.Sub(time.Now()).Round(time.Hour), 1463*time.Hour)
+	test.AssertEquals(t, ari.RetryAfter.Sub(time.Now()).Round(time.Hour), 6*time.Hour)
+
+	// TODO(@pgporada): Clean this up when 'test/config/{sa,wfe2}.json' sets
+	// TrackReplacementCertificatesARI=true.
+	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
+		ir, err = authAndIssueReplacement(client, key, []string{name}, true, cert)
+		test.AssertNotError(t, err, "failed to issue test cert")
+		test.AssertNotEquals(t, ir.Replaces, "")
+
+		// Try it again and verify it fails
+		_, err = authAndIssueReplacement(client, key, []string{name}, true, cert)
+		test.AssertError(t, err, "subsequent ARI replacements for a replaced cert should fail, but didn't")
+	} else {
+		// ARI is disabled so we only use the client to POST the replacement
+		// order, but we never finalize it.
+		replacementOrder, err := client.NewOrderRenewal(client.Account, cert, name)
+		test.AssertNotError(t, err, "ARI replacement request should have succeeded")
+		test.AssertNotEquals(t, replacementOrder.Replaces, "")
+	}
 
 	// Revoke the cert, re-request ARI, and the window should now be in the past.
 	err = client.RevokeCertificate(client.Account, cert, client.PrivateKey, 0)
 	test.AssertNotError(t, err, "failed to revoke cert")
 
-	eri, err = client.GetRenewalInfo(cert, issuer, crypto.SHA256)
+	ari, err = client.GetRenewalInfo(cert)
 	test.AssertNotError(t, err, "ARI request should have succeeded")
-	test.Assert(t, eri.SuggestedWindow.End.Before(time.Now()), "suggested window should end in the past")
-	test.Assert(t, eri.SuggestedWindow.Start.Before(eri.SuggestedWindow.End), "suggested window should start before it ends")
-
-	// Check that marking the cert as replaced succeeds, but don't check that
-	// any server state has been updated (because that doesn't happen, yet).
-	err = client.UpdateRenewalInfo(client.Account, cert, issuer, crypto.SHA256, true)
-	test.AssertNotError(t, err, "ARI request should have succeeded")
+	test.Assert(t, ari.SuggestedWindow.End.Before(time.Now()), "suggested window should end in the past")
+	test.Assert(t, ari.SuggestedWindow.Start.Before(ari.SuggestedWindow.End), "suggested window should start before it ends")
 
 	// Try to make a new cert for a new domain, but sabotage the CT logs so
 	// issuance fails. Recover the precert from CT, then request ARI and check
@@ -79,10 +88,8 @@ func TestARI(t *testing.T) {
 
 	cert, err = ctFindRejection([]string{name})
 	test.AssertNotError(t, err, "failed to find rejected precert")
-	issuer, err = ocsp_helper.GetIssuer(cert)
-	test.AssertNotError(t, err, "failed to get issuer cert")
 
-	eri, err = client.GetRenewalInfo(cert, issuer, crypto.SHA256)
+	ari, err = client.GetRenewalInfo(cert)
 	test.AssertError(t, err, "ARI request should have failed")
 	test.AssertEquals(t, err.(acme.Problem).Status, 404)
 }

--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -53,6 +53,7 @@ func TestARI(t *testing.T) {
 	// TODO(@pgporada): Clean this up when 'test/config/{sa,wfe2}.json' sets
 	// TrackReplacementCertificatesARI=true.
 	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
+		// Make a new order which indicates that it replaces the cert issued above.
 		_, order, err := makeClientAndOrder(client, key, []string{name}, true, cert)
 		test.AssertNotError(t, err, "failed to issue test cert")
 		replaceID, err := acme.GenerateARICertID(cert)

--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -66,12 +66,14 @@ func TestARI(t *testing.T) {
 	} else {
 		// ARI is disabled so we only use the client to POST the replacement
 		// order, but we never finalize it.
-		replacementOrder, err := client.NewOrderRenewal(client.Account, cert, name)
+		replacementOrder, err := client.ReplacementOrder(client.Account, cert, []acme.Identifier{{Type: "dns", Value: name}})
 		test.AssertNotError(t, err, "ARI replacement request should have succeeded")
 		test.AssertNotEquals(t, replacementOrder.Replaces, "")
 	}
 
-	// Revoke the cert, re-request ARI, and the window should now be in the past.
+	// Revoke the cert and re-request ARI. The renewal window should now be in
+	// the past indicating to the client that a renewal should happen
+	// immediately.
 	err = client.RevokeCertificate(client.Account, cert, client.PrivateKey, 0)
 	test.AssertNotError(t, err, "failed to revoke cert")
 

--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -102,9 +102,9 @@ func makeClientAndOrder(c *client, csrKey *ecdsa.PrivateKey, domains []string, c
 	for _, domain := range domains {
 		ids = append(ids, acme.Identifier{Type: "dns", Value: domain})
 	}
-	var order *acme.Order
+	var order acme.Order
 	if certToReplace != nil {
-		order, err = c.Client.NewOrderRenewal(c.Account, certToReplace, domains...)
+		order, err = c.Client.ReplacementOrder(c.Account, certToReplace, ids)
 	} else {
 		order, err = c.Client.NewOrder(c.Account, ids)
 	}
@@ -145,7 +145,7 @@ func makeClientAndOrder(c *client, csrKey *ecdsa.PrivateKey, domains []string, c
 		return nil, nil, fmt.Errorf("finalizing order: %s", err)
 	}
 
-	return c, order, nil
+	return c, &order, nil
 }
 
 type issuanceResult struct {

--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -168,26 +168,6 @@ func authAndIssue(c *client, csrKey *ecdsa.PrivateKey, domains []string, cn bool
 	return &issuanceResult{*order, certs}, nil
 }
 
-// authAndIssueReplacement takes an existing certificate and attempts to use
-// ACME Renewal Info (ARI) to replace it.
-func authAndIssueReplacement(c *client, csrKey *ecdsa.PrivateKey, domains []string, cn bool, oldCert *x509.Certificate) (*issuanceResult, error) {
-	if oldCert == nil {
-		return nil, fmt.Errorf("old certificate was not provided")
-	}
-	var err error
-
-	c, order, err := makeClientAndOrder(c, csrKey, domains, cn, oldCert)
-	if err != nil {
-		return nil, err
-	}
-
-	certs, err := c.Client.FetchCertificates(c.Account, order.Certificate)
-	if err != nil {
-		return nil, fmt.Errorf("fetching certificates: %s", err)
-	}
-	return &issuanceResult{*order, certs}, nil
-}
-
 type issuanceResultAllChains struct {
 	acme.Order
 	certs map[string][]*x509.Certificate

--- a/vendor/github.com/eggsampler/acme/v3/Makefile
+++ b/vendor/github.com/eggsampler/acme/v3/Makefile
@@ -3,7 +3,7 @@
 
 # some variables for path injection, if already set will not override
 GOPATH ?= $(HOME)/go
-BOULDER_PATH ?= /home/phil/work/boulder
+BOULDER_PATH ?= $(GOPATH)/src/github.com/letsencrypt/boulder
 PEBBLE_PATH ?= $(GOPATH)/src/github.com/letsencrypt/pebble
 TEST_PATH ?= github.com/eggsampler/acme/v3
 CLIENT ?= unknown
@@ -63,7 +63,7 @@ boulder_setup:
 
 # runs an instance of boulder
 boulder_start:
-	docker compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml up -d
+	docker-compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml up -d
 
 # waits until boulder responds
 boulder_wait:
@@ -71,4 +71,4 @@ boulder_wait:
 
 # stops the running docker instance
 boulder_stop:
-	docker compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml down
+	docker-compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml down

--- a/vendor/github.com/eggsampler/acme/v3/Makefile
+++ b/vendor/github.com/eggsampler/acme/v3/Makefile
@@ -3,7 +3,7 @@
 
 # some variables for path injection, if already set will not override
 GOPATH ?= $(HOME)/go
-BOULDER_PATH ?= $(GOPATH)/src/github.com/letsencrypt/boulder
+BOULDER_PATH ?= /home/phil/work/boulder
 PEBBLE_PATH ?= $(GOPATH)/src/github.com/letsencrypt/pebble
 TEST_PATH ?= github.com/eggsampler/acme/v3
 CLIENT ?= unknown
@@ -63,7 +63,7 @@ boulder_setup:
 
 # runs an instance of boulder
 boulder_start:
-	docker-compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml up -d
+	docker compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml up -d
 
 # waits until boulder responds
 boulder_wait:
@@ -71,4 +71,4 @@ boulder_wait:
 
 # stops the running docker instance
 boulder_stop:
-	docker-compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml down
+	docker compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml down

--- a/vendor/github.com/eggsampler/acme/v3/account.go
+++ b/vendor/github.com/eggsampler/acme/v3/account.go
@@ -20,7 +20,7 @@ func (c Client) NewAccount(privateKey crypto.Signer, onlyReturnExisting, termsOf
 	if termsOfServiceAgreed {
 		opts = append(opts, NewAcctOptAgreeTOS())
 	}
-	if contact != nil && len(contact) > 0 {
+	if len(contact) > 0 {
 		opts = append(opts, NewAcctOptWithContacts(contact...))
 	}
 

--- a/vendor/github.com/eggsampler/acme/v3/acme.go
+++ b/vendor/github.com/eggsampler/acme/v3/acme.go
@@ -224,6 +224,7 @@ func (c Client) post(requestURL, keyID string, privateKey crypto.Signer, payload
 
 	if _, b := os.LookupEnv("ACME_DEBUG_POST"); b {
 		fmt.Println()
+		fmt.Println("========= " + requestURL)
 		fmt.Println(string(body))
 		fmt.Println()
 	}

--- a/vendor/github.com/eggsampler/acme/v3/ari.go
+++ b/vendor/github.com/eggsampler/acme/v3/ari.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -15,23 +14,6 @@ import (
 	"strings"
 	"time"
 )
-
-// RenewalInfo stores the server-provided suggestions on when to renew
-// certificates.
-type RenewalInfo struct {
-	SuggestedWindow struct {
-		Start time.Time `json:"start"`
-		End   time.Time `json:"end"`
-	} `json:"suggestedWindow"`
-	ExplanationURL string `json:"explanationURL"`
-
-	RetryAfter time.Time `json:"-"`
-}
-
-// ErrRenewalInfoNotSupported is returned by Client.GetRenewalInfo if the
-// renewal info entry isn't present on the acme directory (ie, it's not
-// supported by the acme server)
-var ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not")
 
 // GetRenewalInfo returns the renewal information (if present and supported by
 // the ACME server), and a Retry-After time if indicated in the http response

--- a/vendor/github.com/eggsampler/acme/v3/ari.go
+++ b/vendor/github.com/eggsampler/acme/v3/ari.go
@@ -1,69 +1,49 @@
 package acme
 
 import (
-	"crypto"
 	_ "crypto/sha1"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"math/big"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 )
 
-type (
-	// RenewalInfo is returned by Client.GetRenewalInfo
-	RenewalInfo struct {
-		SuggestedWindow struct {
-			Start time.Time `json:"start"`
-			End   time.Time `json:"end"`
-		} `json:"suggestedWindow"`
-		ExplanationURL string `json:"explanationURL"`
+// RenewalInfo stores the server-provided suggestions on when to renew
+// certificates.
+type RenewalInfo struct {
+	SuggestedWindow struct {
+		Start time.Time `json:"start"`
+		End   time.Time `json:"end"`
+	} `json:"suggestedWindow"`
+	ExplanationURL string `json:"explanationURL"`
 
-		RetryAfter time.Time `json:"-"`
-	}
-)
+	RetryAfter time.Time `json:"-"`
+}
 
-var (
-	// ErrRenewalInfoNotSupported is returned by Client.GetRenewalInfo and Client.UpdateRenewalInfo if the renewal info
-	// entry isn't present on the acme directory (ie, it's not supported by the acme server)
-	ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not")
+// ErrRenewalInfoNotSupported is returned by Client.GetRenewalInfo if the
+// renewal info entry isn't present on the acme directory (ie, it's not
+// supported by the acme server)
+var ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not")
 
-	// from https://cs.opensource.google/go/x/crypto/+/refs/tags/v0.8.0:ocsp/ocsp.go;l=156
-	hashOIDs = map[crypto.Hash]asn1.ObjectIdentifier{
-		crypto.SHA1:   asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26}),
-		crypto.SHA256: asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 1}),
-		crypto.SHA384: asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 2}),
-		crypto.SHA512: asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 3}),
-	}
-
-	// hashNames exists because go 1.11 doesn't have crypto.Hash.String()
-	hashNames = map[crypto.Hash]string{
-		crypto.SHA1:   "SHA1",
-		crypto.SHA256: "SHA256",
-		crypto.SHA384: "SHA384",
-		crypto.SHA512: "SHA512",
-	}
-)
-
-// GetRenewalInfo returns the renewal information (if present and supported by the ACME server), and
-// a Retry-After time if indicated in the http response header.
-func (c Client) GetRenewalInfo(cert, issuer *x509.Certificate, hash crypto.Hash) (RenewalInfo, error) {
-
-	if len(c.dir.RenewalInfo) == 0 {
+// GetRenewalInfo returns the renewal information (if present and supported by
+// the ACME server), and a Retry-After time if indicated in the http response
+// header.
+func (c Client) GetRenewalInfo(cert *x509.Certificate) (RenewalInfo, error) {
+	if c.dir.RenewalInfo == "" {
 		return RenewalInfo{}, ErrRenewalInfoNotSupported
 	}
 
-	certID, err := generateCertID(cert, issuer, hash)
+	certID, err := generateARICertID(cert)
 	if err != nil {
-		return RenewalInfo{}, fmt.Errorf("error generating certificate id: %v", err)
+		return RenewalInfo{}, fmt.Errorf("acme: error generating certificate id: %v", err)
 	}
 
 	renewalURL := c.dir.RenewalInfo
@@ -82,79 +62,59 @@ func (c Client) GetRenewalInfo(cert, issuer *x509.Certificate, hash crypto.Hash)
 	return ri, err
 }
 
-// UpdateRenewalInfo sends a request to the acme server to indicate the renewal info is updated.
-// replaced should always be true.
-func (c Client) UpdateRenewalInfo(account Account, cert, issuer *x509.Certificate, hash crypto.Hash, replaced bool) error {
-
-	if len(c.dir.RenewalInfo) == 0 {
-		return ErrRenewalInfoNotSupported
+// generateARICertID constructs a certificate identifier as described in
+// draft-ietf-acme-ari-03, section 4.1.
+func generateARICertID(cert *x509.Certificate) (string, error) {
+	if cert == nil {
+		return "", fmt.Errorf("certificate not found")
 	}
 
-	certID, err := generateCertID(cert, issuer, hash)
+	derBytes, err := asn1.Marshal(cert.SerialNumber)
 	if err != nil {
-		return fmt.Errorf("error generating certificate id: %v", err)
+		return "", nil
 	}
 
-	updateReq := struct {
-		CertID   string `json:"certID"`
-		Replaced bool   `json:"replaced"`
-	}{
-		CertID:   certID,
-		Replaced: replaced,
+	if len(derBytes) < 3 {
+		return "", fmt.Errorf("invalid DER encoding of serial number")
 	}
 
-	_, err = c.post(c.dir.RenewalInfo, account.URL, account.PrivateKey, updateReq, nil, http.StatusOK)
+	// Extract only the integer bytes from the DER encoded Serial Number
+	// Skipping the first 2 bytes (tag and length). The result is base64url
+	// encoded without padding.
+	serial := base64.RawURLEncoding.EncodeToString(derBytes[2:])
 
-	return err
+	// Convert the Authority Key Identifier to base64url encoding without
+	// padding.
+	aki := base64.RawURLEncoding.EncodeToString(cert.AuthorityKeyId)
+
+	// Construct the final identifier by concatenating AKI and Serial Number.
+	return fmt.Sprintf("%s.%s", aki, serial), nil
 }
 
-// generateCertID creates a CertID as per RFC6960
-func generateCertID(cert, issuer *x509.Certificate, hashFunc crypto.Hash) (string, error) {
-	oid, ok := hashOIDs[hashFunc]
-	if !ok {
-		var s []string
-		for k := range hashOIDs {
-			s = append(s, hashNames[k])
-		}
-		return "", fmt.Errorf("unsupported hash algorithm %q, currently available: %q", hashNames[hashFunc], strings.Join(s, ","))
+func (r RenewalInfo) ShouldRenewAt(now time.Time, willingToSleep time.Duration) *time.Time {
+	// Explicitly convert all times to UTC.
+	now = now.UTC()
+	start := r.SuggestedWindow.Start.UTC()
+	end := r.SuggestedWindow.End.UTC()
+
+	// Select a uniform random time within the suggested window.
+	window := end.Sub(start)
+	randomDuration := time.Duration(rand.Int63n(int64(window)))
+	randomTime := start.Add(randomDuration)
+
+	// If the selected time is in the past, attempt renewal immediately.
+	if randomTime.Before(now) {
+		return &now
 	}
 
-	if !hashFunc.Available() {
-		return "", x509.ErrUnsupportedAlgorithm
+	// Otherwise, if the client can schedule itself to attempt renewal at
+	// exactly the selected time, do so.
+	willingToSleepUntil := now.Add(willingToSleep)
+	if willingToSleepUntil.After(randomTime) || willingToSleepUntil.Equal(randomTime) {
+		return &randomTime
 	}
 
-	var publicKeyInfo struct {
-		Algorithm pkix.AlgorithmIdentifier
-		PublicKey asn1.BitString
-	}
-	if _, err := asn1.Unmarshal(issuer.RawSubjectPublicKeyInfo, &publicKeyInfo); err != nil {
-		return "", err
-	}
-
-	h := hashFunc.New()
-	h.Write(issuer.RawSubject)
-	issuerNameHash := h.Sum(nil)
-
-	h.Reset()
-	h.Write(publicKeyInfo.PublicKey.RightAlign())
-	issuerKeyHash := h.Sum(nil)
-
-	s := struct {
-		HashAlgorithm  pkix.AlgorithmIdentifier
-		IssuerNameHash []byte
-		IssuerKeyHash  []byte
-		SerialNumber   *big.Int
-	}{
-		HashAlgorithm: pkix.AlgorithmIdentifier{
-			Algorithm: oid,
-			// Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
-		},
-		IssuerNameHash: issuerNameHash,
-		IssuerKeyHash:  issuerKeyHash,
-		SerialNumber:   cert.SerialNumber,
-	}
-	b, err := asn1.Marshal(s)
-	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "="), err
+	return nil
 }
 
 // timeNow and implementations support testing

--- a/vendor/github.com/eggsampler/acme/v3/ari.go
+++ b/vendor/github.com/eggsampler/acme/v3/ari.go
@@ -41,7 +41,7 @@ func (c Client) GetRenewalInfo(cert *x509.Certificate) (RenewalInfo, error) {
 		return RenewalInfo{}, ErrRenewalInfoNotSupported
 	}
 
-	certID, err := generateARICertID(cert)
+	certID, err := GenerateARICertID(cert)
 	if err != nil {
 		return RenewalInfo{}, fmt.Errorf("acme: error generating certificate id: %v", err)
 	}
@@ -62,16 +62,16 @@ func (c Client) GetRenewalInfo(cert *x509.Certificate) (RenewalInfo, error) {
 	return ri, err
 }
 
-// generateARICertID constructs a certificate identifier as described in
+// GenerateARICertID constructs a certificate identifier as described in
 // draft-ietf-acme-ari-03, section 4.1.
-func generateARICertID(cert *x509.Certificate) (string, error) {
+func GenerateARICertID(cert *x509.Certificate) (string, error) {
 	if cert == nil {
 		return "", fmt.Errorf("certificate not found")
 	}
 
 	derBytes, err := asn1.Marshal(cert.SerialNumber)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	if len(derBytes) < 3 {

--- a/vendor/github.com/eggsampler/acme/v3/challenge.go
+++ b/vendor/github.com/eggsampler/acme/v3/challenge.go
@@ -15,7 +15,7 @@ func EncodeDNS01KeyAuthorization(keyAuth string) string {
 	return base64.RawURLEncoding.EncodeToString(h[:])
 }
 
-// Helper function to determine whether a challenge is "finished" by it's status.
+// Helper function to determine whether a challenge is "finished" by its status.
 func checkUpdatedChallengeStatus(challenge Challenge) (bool, error) {
 	switch challenge.Status {
 	case "pending":

--- a/vendor/github.com/eggsampler/acme/v3/order.go
+++ b/vendor/github.com/eggsampler/acme/v3/order.go
@@ -23,10 +23,13 @@ func (c Client) NewOrderDomains(account Account, domains ...string) (Order, erro
 	return c.ReplacementOrder(account, nil, identifiers)
 }
 
-// ReplacementOrder takes an existing *x509.Certificate and initiates a new order for a new certificate, but with the
-// order being marked as a replacement. Replacement orders are exempt from Let's Encrypt NewOrder rate limits.
-// At least one identifier must match the list of identifiers from the parent order to be considered as a valid
-// replacement order.
+// ReplacementOrder takes an existing *x509.Certificate and initiates a new
+// order for a new certificate, but with the order being marked as a
+// replacement. Replacement orders which are valid replacements are (currently)
+// exempt from Let's Encrypt NewOrder rate limits, but may not be exempt from
+// other ACME CAs ACME Renewal Info implementations. At least one identifier
+// must match the list of identifiers from the parent order to be considered as
+// a valid replacement order.
 // See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
 func (c Client) ReplacementOrder(account Account, oldCert *x509.Certificate, identifiers []Identifier) (Order, error) {
 	// If an old cert being replaced is present and the acme directory doesn't list a RenewalInfo endpoint,

--- a/vendor/github.com/eggsampler/acme/v3/order.go
+++ b/vendor/github.com/eggsampler/acme/v3/order.go
@@ -52,7 +52,7 @@ func (c Client) NewOrderRenewal(account Account, oldCert *x509.Certificate, doma
 		return nil, fmt.Errorf("certificate not found")
 	}
 
-	certID, err := generateARICertID(oldCert)
+	certID, err := GenerateARICertID(oldCert)
 	if err != nil {
 		return nil, fmt.Errorf("acme: error generating certificate id: %v", err)
 	}

--- a/vendor/github.com/eggsampler/acme/v3/order.go
+++ b/vendor/github.com/eggsampler/acme/v3/order.go
@@ -47,6 +47,8 @@ func (c Client) ReplacementOrder(account Account, oldCert *x509.Certificate, ide
 		Identifiers: identifiers,
 	}
 
+	newOrderResp := Order{}
+
 	// If present, add the ari cert ID from the original/old certificate
 	if oldCert != nil {
 		replacesCertID, err := GenerateARICertID(oldCert)
@@ -55,10 +57,10 @@ func (c Client) ReplacementOrder(account Account, oldCert *x509.Certificate, ide
 		}
 
 		newOrderReq.Replaces = replacesCertID
+		newOrderResp.Replaces = replacesCertID // server does not appear to set this currently?
 	}
 
 	// Submit the order
-	newOrderResp := Order{}
 	resp, err := c.post(c.dir.NewOrder, account.URL, account.PrivateKey, newOrderReq, &newOrderResp, http.StatusCreated)
 	if err != nil {
 		return newOrderResp, err

--- a/vendor/github.com/eggsampler/acme/v3/order.go
+++ b/vendor/github.com/eggsampler/acme/v3/order.go
@@ -9,124 +9,64 @@ import (
 	"time"
 )
 
-// NewOrder initiates a new order for a new certificate. This method does not
-// use ACME Renewal Info.
-func (c Client) NewOrder(account Account, identifiers []Identifier) (*Order, error) {
-	newOrderResp, err := c.postNewOrder(account, identifiers, nil)
-	if err != nil {
-		return newOrderResp, err
+// NewOrder initiates a new order for a new certificate. This method does not use ACME Renewal Info.
+func (c Client) NewOrder(account Account, identifiers []Identifier) (Order, error) {
+	return c.ReplacementOrder(account, nil, identifiers)
+}
+
+// NewOrderDomains takes a list of domain dns identifiers for a new certificate. Essentially a helper function.
+func (c Client) NewOrderDomains(account Account, domains ...string) (Order, error) {
+	var identifiers []Identifier
+	for _, d := range domains {
+		identifiers = append(identifiers, Identifier{Type: "dns", Value: d})
 	}
-
-	return newOrderResp, nil
+	return c.ReplacementOrder(account, nil, identifiers)
 }
 
-// NewOrderDomains is a wrapper for NewOrder(AcmeAccount, []AcmeIdentifiers). It
-// creates a dns identifier for each provided domain. This method does not use
-// ACME Renewal Info.
-func (c Client) NewOrderDomains(account Account, domains ...string) (*Order, error) {
-	ids, err := domainsToIds(domains)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.NewOrder(account, ids)
-}
-
-type ariRequest struct {
-	certID string
-}
-
-// NewOrderRenewal takes an existing *x509.Certificate and initiates a new order
-// for a new certificate, but with the order being marked as a replacement.
-// Replacement orders are exempt from Let's Encrypt NewOrder rate limits. It
-// creates a dns identifier for each provided domain. At least one identifier
-// must match the list of identifiers from the parent order to be considered as
-// a valid replacment order.
+// ReplacementOrder takes an existing *x509.Certificate and initiates a new order for a new certificate, but with the
+// order being marked as a replacement. Replacement orders are exempt from Let's Encrypt NewOrder rate limits.
+// At least one identifier must match the list of identifiers from the parent order to be considered as a valid
+// replacement order.
 // See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
-func (c Client) NewOrderRenewal(account Account, oldCert *x509.Certificate, domains ...string) (*Order, error) {
-	if c.dir.RenewalInfo == "" {
-		return nil, ErrRenewalInfoNotSupported
+func (c Client) ReplacementOrder(account Account, oldCert *x509.Certificate, identifiers []Identifier) (Order, error) {
+	// If an old cert being replaced is present and the acme directory doesn't list a RenewalInfo endpoint,
+	// throw an error. This endpoint being present indicates support for ARI.
+	if oldCert != nil && c.dir.RenewalInfo == "" {
+		return Order{}, ErrRenewalInfoNotSupported
 	}
 
-	if oldCert == nil {
-		return nil, fmt.Errorf("certificate not found")
+	// 'replaces' is specifically listed as 'omitempty' so the json encoder doesn't include this key
+	// if the ari oldCert is nil
+	newOrderReq := struct {
+		Identifiers []Identifier `json:"identifiers"`
+		Replaces    string       `json:"replaces,omitempty"`
+	}{
+		Identifiers: identifiers,
 	}
 
-	certID, err := GenerateARICertID(oldCert)
-	if err != nil {
-		return nil, fmt.Errorf("acme: error generating certificate id: %v", err)
-	}
-
-	ids, err := domainsToIds(domains)
-	if err != nil {
-		return nil, err
-	}
-
-	ari := &ariRequest{certID: certID}
-	newOrderResp, err := c.postNewOrder(account, ids, ari)
-	if err != nil {
-		return nil, err
-	}
-
-	return newOrderResp, nil
-}
-
-// postNewOrder handles the logic of POSTing either 1) an ACME Renewal Info (ARI)
-// replacement order or 2) a standard RFC 8555 order to the ACME server and returns an
-// error.
-func (c Client) postNewOrder(account Account, ids []Identifier, ari *ariRequest) (*Order, error) {
-	type newOrderRequest interface{}
-	var newOrderReq newOrderRequest
-
-	// This order object will be returned to the client.
-	order := Order{}
-	if ari != nil {
-		order.Replaces = ari.certID
-		ariNewOrderReq := struct {
-			Identifiers []Identifier `json:"identifiers"`
-			Replaces    string
-		}{
-			Identifiers: ids,
-			Replaces:    ari.certID,
+	// If present, add the ari cert ID from the original/old certificate
+	if oldCert != nil {
+		replacesCertID, err := GenerateARICertID(oldCert)
+		if err != nil {
+			return Order{}, fmt.Errorf("acme: error generating replacement certificate id: %v", err)
 		}
-		newOrderReq = ariNewOrderReq
-	} else {
-		nonARINewOrderReq := struct {
-			Identifiers []Identifier `json:"identifiers"`
-		}{
-			Identifiers: ids,
-		}
-		newOrderReq = nonARINewOrderReq
+
+		newOrderReq.Replaces = replacesCertID
 	}
 
 	// Submit the order
-	resp, err := c.post(c.dir.NewOrder, account.URL, account.PrivateKey, newOrderReq, &order, http.StatusCreated)
+	newOrderResp := Order{}
+	resp, err := c.post(c.dir.NewOrder, account.URL, account.PrivateKey, newOrderReq, &newOrderResp, http.StatusCreated)
 	if err != nil {
-		return nil, err
+		return newOrderResp, err
 	}
-	order.URL = resp.Header.Get("Location")
-
-	return &order, nil
-}
-
-// domainsToIds takes a slice of strings representing domain names and returns a
-// slice of Identifiers or an error.
-func domainsToIds(domains []string) ([]Identifier, error) {
-	if len(domains) == 0 {
-		return nil, errors.New("acme: no domains provided")
-	}
-
-	var ids []Identifier
-	for _, d := range domains {
-		ids = append(ids, Identifier{Type: "dns", Value: d})
-	}
-
-	return ids, nil
+	newOrderResp.URL = resp.Header.Get("Location")
+	return newOrderResp, nil
 }
 
 // FetchOrder fetches an existing order given an order url.
-func (c Client) FetchOrder(account Account, orderURL string) (*Order, error) {
-	orderResp := &Order{
+func (c Client) FetchOrder(account Account, orderURL string) (Order, error) {
+	orderResp := Order{
 		URL: orderURL, // boulder response doesn't seem to contain location header for this request
 	}
 	_, err := c.post(orderURL, account.URL, account.PrivateKey, "", &orderResp, http.StatusOK)
@@ -134,12 +74,8 @@ func (c Client) FetchOrder(account Account, orderURL string) (*Order, error) {
 	return orderResp, err
 }
 
-// Helper function to determine whether an order is "finished" by it's status.
-func checkFinalizedOrderStatus(order *Order) (bool, error) {
-	if order == nil {
-		return false, errors.New("acme: nil order")
-	}
-
+// Helper function to determine whether an order is "finished" by its status.
+func checkFinalizedOrderStatus(order Order) (bool, error) {
 	switch order.Status {
 	case "invalid":
 		// "invalid": The certificate will not be issued.  Consider this
@@ -181,7 +117,7 @@ func checkFinalizedOrderStatus(order *Order) (bool, error) {
 // FinalizeOrder indicates to the acme server that the client considers an order complete and "finalizes" it.
 // If the server believes the authorizations have been filled successfully, a certificate should then be available.
 // This function assumes that the order status is "ready".
-func (c Client) FinalizeOrder(account Account, order *Order, csr *x509.CertificateRequest) (*Order, error) {
+func (c Client) FinalizeOrder(account Account, order Order, csr *x509.CertificateRequest) (Order, error) {
 	finaliseReq := struct {
 		Csr string `json:"csr"`
 	}{

--- a/vendor/github.com/eggsampler/acme/v3/types.go
+++ b/vendor/github.com/eggsampler/acme/v3/types.go
@@ -43,12 +43,14 @@ const (
 // Directory object as returned from the client's directory url upon creation of client.
 // See https://tools.ietf.org/html/rfc8555#section-7.1.1
 type Directory struct {
-	NewNonce    string `json:"newNonce"`    // url to new nonce endpoint
-	NewAccount  string `json:"newAccount"`  // url to new account endpoint
-	NewOrder    string `json:"newOrder"`    // url to new order endpoint
-	NewAuthz    string `json:"newAuthz"`    // url to new authz endpoint
-	RevokeCert  string `json:"revokeCert"`  // url to revoke cert endpoint
-	KeyChange   string `json:"keyChange"`   // url to key change endpoint
+	NewNonce   string `json:"newNonce"`   // url to new nonce endpoint
+	NewAccount string `json:"newAccount"` // url to new account endpoint
+	NewOrder   string `json:"newOrder"`   // url to new order endpoint
+	NewAuthz   string `json:"newAuthz"`   // url to new authz endpoint
+	RevokeCert string `json:"revokeCert"` // url to revoke cert endpoint
+	KeyChange  string `json:"keyChange"`  // url to key change endpoint
+
+	// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03
 	RenewalInfo string `json:"renewalInfo"` // url to renewal info endpoint
 
 	// meta object containing directory metadata
@@ -154,6 +156,11 @@ type Order struct {
 
 	// RetryAfter is the http Retry-After header from the order response
 	RetryAfter time.Time `json:"-"`
+
+	// Replaces (optional, string): A string uniquely identifying a
+	// previously-issued certificate which this order is intended to replace.
+	// See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
+	Replaces string `json:"replaces,omitempty"`
 }
 
 // Authorization object returned when fetching an authorization in an order.

--- a/vendor/github.com/eggsampler/acme/v3/types.go
+++ b/vendor/github.com/eggsampler/acme/v3/types.go
@@ -228,7 +228,7 @@ type RenewalInfo struct {
 		Start time.Time `json:"start"`
 		End   time.Time `json:"end"`
 	} `json:"suggestedWindow"`
-	ExplanationURL string `json:"explanationURL"`
+	ExplanationURL string `json:"explanationURL,omitempty"`
 
 	RetryAfter time.Time `json:"-"`
 }

--- a/vendor/github.com/eggsampler/acme/v3/types.go
+++ b/vendor/github.com/eggsampler/acme/v3/types.go
@@ -8,8 +8,15 @@ import (
 	"time"
 )
 
-// ErrUnsupportedKey is returned when an unsupported key type is encountered.
-var ErrUnsupportedKey = errors.New("acme: unknown key type; only RSA and ECDSA are supported")
+var (
+	// ErrUnsupportedKey is returned when an unsupported key type is encountered.
+	ErrUnsupportedKey = errors.New("acme: unknown key type; only RSA and ECDSA are supported")
+
+	// ErrRenewalInfoNotSupported is returned by Client.GetRenewalInfo if the
+	// renewal info entry isn't present on the acme directory (ie, it's not
+	// supported by the acme server)
+	ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not supported")
+)
 
 // Different possible challenge types provided by an ACME server.
 // See https://tools.ietf.org/html/rfc8555#section-9.7.8
@@ -122,7 +129,7 @@ type Account struct {
 //   - "HS384" for HashFunc: crypto.SHA384
 //   - "HS512" for HashFunc: crypto.SHA512
 //
-// However this is dependant on the acme server in question and is provided here to give more options for future compatibility.
+// However this is dependent on the acme server in question and is provided here to give more options for future compatibility.
 type ExternalAccountBinding struct {
 	KeyIdentifier string      `json:"-"`
 	MacKey        string      `json:"-"`
@@ -212,4 +219,16 @@ type NewAccountRequest struct {
 	TermsOfServiceAgreed   bool            `json:"termsOfServiceAgreed"`
 	Contact                []string        `json:"contact,omitempty"`
 	ExternalAccountBinding json.RawMessage `json:"externalAccountBinding"`
+}
+
+// RenewalInfo stores the server-provided suggestions on when to renew
+// certificates.
+type RenewalInfo struct {
+	SuggestedWindow struct {
+		Start time.Time `json:"start"`
+		End   time.Time `json:"end"`
+	} `json:"suggestedWindow"`
+	ExplanationURL string `json:"explanationURL"`
+
+	RetryAfter time.Time `json:"-"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,7 +136,7 @@ github.com/cespare/xxhash/v2
 # github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 ## explicit
 github.com/dgryski/go-rendezvous
-# github.com/eggsampler/acme/v3 v3.5.0 => /home/phil/work/eggsampler-acme-client
+# github.com/eggsampler/acme/v3 v3.6.0
 ## explicit; go 1.11
 github.com/eggsampler/acme/v3
 # github.com/felixge/httpsnoop v1.0.4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,7 +136,7 @@ github.com/cespare/xxhash/v2
 # github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 ## explicit
 github.com/dgryski/go-rendezvous
-# github.com/eggsampler/acme/v3 v3.5.0
+# github.com/eggsampler/acme/v3 v3.5.0 => /home/phil/work/eggsampler-acme-client
 ## explicit; go 1.11
 github.com/eggsampler/acme/v3
 # github.com/felixge/httpsnoop v1.0.4


### PR DESCRIPTION
`Eggsampler/acme` v3.6.0 has been [released](https://github.com/eggsampler/acme/releases/tag/v3.6.0). I've updated the ARI integration tests to issue replacement orders.

Fixes https://github.com/letsencrypt/boulder/issues/7463