### PR TITLE
wfe: Don't serve renewalInfoPath with trailing slash in the directory

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -73,7 +73,8 @@ const (
 	getCertPath      = getAPIPrefix + "cert/"
 
 	// Draft or likely-to-change paths
-	renewalInfoPath = "/draft-ietf-acme-ari-03/renewalInfo/"
+	// ARI-capable clients are expected to add the trailing slash per the draft.
+	renewalInfoPath = "/draft-ietf-acme-ari-03/renewalInfo"
 )
 
 const (

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -73,8 +73,7 @@ const (
 	getCertPath      = getAPIPrefix + "cert/"
 
 	// Draft or likely-to-change paths
-	// ARI-capable clients are expected to add the trailing slash per the draft.
-	renewalInfoPath = "/draft-ietf-acme-ari-03/renewalInfo"
+	renewalInfoPath = "/draft-ietf-acme-ari-03/renewalInfo/"
 )
 
 const (
@@ -442,7 +441,7 @@ func (wfe *WebFrontEndImpl) Handler(stats prometheus.Registerer, oTelHTTPOptions
 	wfe.HandleFunc(m, getChallengePath, wfe.Challenge, "GET")
 	wfe.HandleFunc(m, getCertPath, wfe.Certificate, "GET")
 
-	// Endpoint for draft-aaron-ari
+	// Endpoint for draft-ietf-acme-ari
 	if features.Get().ServeRenewalInfo {
 		wfe.HandleFunc(m, renewalInfoPath, wfe.RenewalInfo, "GET", "POST")
 	}
@@ -520,7 +519,11 @@ func (wfe *WebFrontEndImpl) Directory(
 	}
 
 	if features.Get().ServeRenewalInfo {
-		directoryEndpoints["renewalInfo"] = renewalInfoPath
+		// ARI-capable clients are expected to add the trailing slash per the
+		// draft. We explicitly strip the trailing slash here so that clients
+		// don't need to add trailing slash handling in their own code, saving
+		// them minimal amounts of complexity.
+		directoryEndpoints["renewalInfo"] = strings.TrimRight(renewalInfoPath, "/")
 	}
 
 	if request.Method == http.MethodPost {


### PR DESCRIPTION
[draft-ietf-acme-ari-03 section 4.1](https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#section-4.1) states the following indicating that it's the clients responsibility to add a `/` after the `renewalInfoPath`, not the server.
> Thus the full request url is constructed as follows, where the "||" operator indicates string concatenation and the renewalInfo url is taken from the Directory object:
```
url = renewalInfo || '/' || base64url(AKI) || '.' || base64url(Serial)
```
Fixes https://github.com/letsencrypt/boulder/issues/7481