### PR TITLE
ca/linter: Port safety checks from ceremony tool

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -684,10 +684,6 @@ func tbsCertIsDeterministic(lintCertBytes []byte, leafCertBytes []byte) error {
 		return fmt.Errorf("while extracting leaf TBS cert: %w", err)
 	}
 
-	if lintRawTBSCert == nil || leafRawTBSCert == nil {
-		return fmt.Errorf("while extracting TBS cert: %w", err)
-	}
-
 	if !bytes.Equal(lintRawTBSCert, leafRawTBSCert) {
 		return fmt.Errorf("mismatch between lintCert and leafCert RawTBSCertificate DER bytes: \"%x\" != \"%x\"", lintRawTBSCert, leafRawTBSCert)
 	}

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -640,9 +640,9 @@ func tbsCertIsDeterministic(lintCertBytes []byte, leafCertBytes []byte) error {
 	}
 
 	// parseTBSCert is a partial copy of //crypto/x509/parser.go to extract the
-	// RawTBSCertificate field from given DER bytes. It the RawTBSCertficate field
-	// bytes or an error if the given bytes cannot be parsed. This is far more
-	// performant than parsing the entire *Certificate structure with
+	// RawTBSCertificate field from given DER bytes. It the RawTBSCertificate
+	// field bytes or an error if the given bytes cannot be parsed. This is far
+	// more performant than parsing the entire *Certificate structure with
 	// x509.ParseCertificate().
 	parseTBSCert := func(inputDERBytes *[]byte) ([]byte, error) {
 		if inputDERBytes == nil {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -656,14 +656,14 @@ func tbsCertIsDeterministic(lintCertBytes []byte, leafCertBytes []byte) error {
 	extractTBSCertBytes := func(inputDERBytes *[]byte) ([]byte, error) {
 		input := cryptobyte.String(*inputDERBytes)
 
-		// Get the Certificate bytes
-		if !input.ReadASN1Element(&input, cryptobyte_asn1.SEQUENCE) {
+		// Extract the Certificate bytes
+		if !input.ReadASN1(&input, cryptobyte_asn1.SEQUENCE) {
 			return nil, errors.New("malformed certificate")
 		}
 
 		var tbs cryptobyte.String
-		// Get the TBSCertificate bytes from the Certificate bytes
-		if !input.ReadASN1Element(&tbs, cryptobyte_asn1.SEQUENCE) {
+		// Extract the TBSCertificate bytes from the Certificate bytes
+		if !input.ReadASN1(&tbs, cryptobyte_asn1.SEQUENCE) {
 			return nil, errors.New("malformed tbs certificate")
 		}
 

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1392,8 +1392,8 @@ func TestVerifyTBSCertIsDeterministic(t *testing.T) {
 			t.Parallel()
 			err := tbsCertIsDeterministic(testCase.lintCertBytes, testCase.leafCertBytes)
 			if testCase.errorSubstr != "" {
-				test.AssertContains(t, fmt.Sprint(err), testCase.errorSubstr)
 				test.AssertError(t, err, "your lack of errors is disturbing")
+				test.AssertContains(t, err.Error(), testCase.errorSubstr)
 			} else {
 				test.AssertNotError(t, err, "unexpected error")
 			}

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1331,35 +1331,36 @@ func TestVerifyTBSCertIsDeterministic(t *testing.T) {
 		name          string
 		lintCertBytes []byte
 		leafCertBytes []byte
-		errorExpected bool
 		errorSubstr   string
 	}{
 		{
 			name:          "Both nil",
 			lintCertBytes: nil,
 			leafCertBytes: nil,
-			errorExpected: true,
 			errorSubstr:   "were nil",
 		},
 		{
 			name:          "Missing a value, invalid input",
 			lintCertBytes: nil,
 			leafCertBytes: []byte{0x6, 0x6, 0x6},
-			errorExpected: true,
 			errorSubstr:   "were nil",
 		},
 		{
 			name:          "Missing a value, valid input",
 			lintCertBytes: nil,
 			leafCertBytes: certDer1,
-			errorExpected: true,
 			errorSubstr:   "were nil",
 		},
 		{
 			name:          "Mismatched bytes, invalid input",
 			lintCertBytes: []byte{0x6, 0x6, 0x6},
 			leafCertBytes: []byte{0x1, 0x2, 0x3},
-			errorExpected: true,
+			errorSubstr:   "malformed certificate",
+		},
+		{
+			name:          "Mismatched bytes, invalider input",
+			lintCertBytes: certDer1,
+			leafCertBytes: []byte{0x1, 0x2, 0x3},
 			errorSubstr:   "malformed certificate",
 		},
 		{
@@ -1369,7 +1370,6 @@ func TestVerifyTBSCertIsDeterministic(t *testing.T) {
 			name:          "Mismatched bytes, valid input",
 			lintCertBytes: certDer1,
 			leafCertBytes: certDer2,
-			errorExpected: true,
 			errorSubstr:   "mismatch between",
 		},
 		{
@@ -1391,11 +1391,9 @@ func TestVerifyTBSCertIsDeterministic(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			err := tbsCertIsDeterministic(testCase.lintCertBytes, testCase.leafCertBytes)
-			if testCase.errorExpected {
+			if testCase.errorSubstr != "" {
+				test.AssertContains(t, fmt.Sprint(err), testCase.errorSubstr)
 				test.AssertError(t, err, "your lack of errors is disturbing")
-				if testCase.errorSubstr != "" {
-					test.AssertContains(t, fmt.Sprint(err), testCase.errorSubstr)
-				}
 			} else {
 				test.AssertNotError(t, err, "unexpected error")
 			}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -645,10 +645,6 @@ func rootCeremony(configBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	// Verify that the lintCert is self-signed.
-	if !bytes.Equal(lintCert.RawSubject, lintCert.RawIssuer) {
-		return fmt.Errorf("mismatch between self-signed lintCert RawSubject and RawIssuer DER bytes: \"%x\" != \"%x\"", lintCert.RawSubject, lintCert.RawIssuer)
-	}
 	finalCert, err := signAndWriteCert(template, template, lintCert, keyInfo.key, signer, config.Outputs.CertificatePath)
 	if err != nil {
 		return err
@@ -696,10 +692,6 @@ func intermediateCeremony(configBytes []byte, ct certType) error {
 	lintCert, err := issueLintCertAndPerformLinting(template, issuer, pub, signer, config.SkipLints)
 	if err != nil {
 		return err
-	}
-	// Verify that the lintCert (and therefore the eventual finalCert) corresponds to the specified issuer certificate.
-	if !bytes.Equal(issuer.RawSubject, lintCert.RawIssuer) {
-		return fmt.Errorf("mismatch between issuer RawSubject and lintCert RawIssuer DER bytes: \"%x\" != \"%x\"", issuer.RawSubject, lintCert.RawIssuer)
 	}
 	finalCert, err := signAndWriteCert(template, issuer, lintCert, pub, signer, config.Outputs.CertificatePath)
 	if err != nil {
@@ -779,9 +771,6 @@ func crossCertCeremony(configBytes []byte, ct certType) error {
 	// notBefore date of the existing CA Certificate(s).
 	if lintCert.NotBefore.Before(toBeCrossSigned.NotBefore) {
 		return fmt.Errorf("cross-signed subordinate CA's NotBefore predates the existing CA's NotBefore")
-	}
-	if !bytes.Equal(issuer.RawSubject, lintCert.RawIssuer) {
-		return fmt.Errorf("mismatch between issuer RawSubject and lintCert RawIssuer DER bytes: \"%x\" != \"%x\"", issuer.RawSubject, lintCert.RawIssuer)
 	}
 	// BR 7.1.2.2.3 Cross-Certified Subordinate CA Extensions
 	if !slices.Equal(lintCert.ExtKeyUsage, toBeCrossSigned.ExtKeyUsage) {


### PR DESCRIPTION
In https://github.com/letsencrypt/boulder/pull/7005 several safety checks were added to the `ceremony` tool:

This change extracts the `RawSubject` to `RawIssuer` DER byte comparison into the `//linter` package proper so that it can serve both `//ca` and `//cmd/ceremony`.

Adds a helper function `verifyTBSCertificateDeterminism` to `//ca` similar to an existing check in `//cmd/ceremony`. This code is not shared because we want `//cmd/ceremony` to largely stand alone from boulder proper.  The helper performs a byte comparison on the `RawTBSCertificate` DER bytes for a given linting certificate and leaf certificate. The goal is to verify that `x509.CreateCertificate` was deterministic and produced identical DER bytes after each signing operation.

Fixes https://github.com/letsencrypt/boulder/issues/6965