### PR TITLE
Reduce redis rate limit construction logs from audit to info

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2057,7 +2057,7 @@ func (wfe *WebFrontEndImpl) newNewOrderLimitTransactions(regId int64, names []st
 	logTxnErr := func(err error, limit ratelimits.Name) {
 		// TODO(#5545): Once key-value rate limits are authoritative this log
 		// line should be removed in favor of returning the error.
-		wfe.log.Infof("constructing rate limit transaction for %s rate limit: %s", limit, err)
+		wfe.log.Infof("error constructing rate limit transaction for %s rate limit: %s", limit, err)
 	}
 
 	var transactions []ratelimits.Transaction

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2057,7 +2057,7 @@ func (wfe *WebFrontEndImpl) newNewOrderLimitTransactions(regId int64, names []st
 	logTxnErr := func(err error, limit ratelimits.Name) {
 		// TODO(#5545): Once key-value rate limits are authoritative this log
 		// line should be removed in favor of returning the error.
-		wfe.log.Errf("constructing rate limit transaction for %s rate limit: %s", limit, err)
+		wfe.log.Infof("constructing rate limit transaction for %s rate limit: %s", limit, err)
 	}
 
 	var transactions []ratelimits.Transaction


### PR DESCRIPTION
Everything logged at the error level is implicitly given the audit tag as well. That's not merited in this case, so downgrade these error logs to be info logs instead.