### PR TITLE
cmd: Use non-deprecated clock.New

### DIFF
--- a/cmd/clock_integration.go
+++ b/cmd/clock_integration.go
@@ -8,10 +8,11 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
+
 	blog "github.com/letsencrypt/boulder/log"
 )
 
-// Clock functions similarly to clock.Default(), but the returned value can be
+// Clock functions similarly to clock.New(), but the returned value can be
 // changed using the FAKECLOCK environment variable if the 'integration' build
 // flag is set.
 //
@@ -26,5 +27,6 @@ func Clock() clock.Clock {
 		blog.Get().Infof("Time was set to %v via FAKECLOCK", targetTime)
 		return cl
 	}
-	return clock.Default()
+
+	return clock.New()
 }


### PR DESCRIPTION
Switch from using the deprecated `clock.Default()` to `clock.New()`. Both return the same value of `systemClock`. This fixes a code deprecation warning in my editor.

For more details, see [jmhodges/clock](https://github.com/jmhodges/clock/blob/8a401d017099427a3a22abf2b14a49d9a069f433/clock.go#L31-L42).