### PR TITLE
Deprecate EnforceMultiVA and MultiVAFullResults feature flags

### DIFF
--- a/docs/multi-va.md
+++ b/docs/multi-va.md
@@ -37,19 +37,12 @@ and
 [`test/config-next/remoteva-b.json`](https://github.com/letsencrypt/boulder/blob/5c27eadb1db0605f380e41c8bd444a7f4ffe3c08/test/config-next/remoteva-b.json)
 as their config files.
 
-There are two feature flags that control whether multi-VA takes effect:
-MultiVAFullResults and EnforceMultiVA. If MultiVAFullResults is enabled
-then each primary validation will also send out remote validation requests, and
-wait for all the results to come in, so we can log the results for analysis. If
-EnforceMultiVA is enabled, we require that almost all remote validation requests
-succeed. The primary VA's "maxRemoteValidationFailures" config field specifies
-how many remote VAs can fail before the primary VA considers overall validation
-a failure. It should be strictly less than the number of remote VAs.
-
-Validation is also controlled by the "multiVAPolicyFile" config field on the
-primary VA. This specifies a file that can contain temporary overrides for
-domains or accounts that fail under multi-va. Over time those temporary
-overrides will be removed.
+We require that almost all remote validation requests succeed; the exact number
+is controlled by the VA's `maxRemoteFailures` config variable. If the number of
+failing remote VAs exceeds that threshold, validation is terminated. If the
+number of successful remote VAs is high enough that it would be impossible for
+the outstanding remote VAs to exceed that threshold, validation immediately
+succeeds.
 
 There are some integration tests that test this end to end. The most relevant is
 probably

--- a/features/features.go
+++ b/features/features.go
@@ -20,13 +20,8 @@ type Config struct {
 	CAAAfterValidation         bool
 	AllowNoCommonName          bool
 	SHA256SubjectKeyIdentifier bool
-
-	// EnforceMultiVA causes the VA to block on remote VA PerformValidation
-	// requests in order to make a valid/invalid decision with the results.
-	EnforceMultiVA bool
-	// MultiVAFullResults will cause the main VA to wait for all of the remote VA
-	// results, not just the threshold required to make a decision.
-	MultiVAFullResults bool
+	EnforceMultiVA             bool
+	MultiVAFullResults         bool
 
 	// ECDSAForAll enables all accounts, regardless of their presence in the CA's
 	// ecdsaAllowedAccounts config value, to get issuance from ECDSA issuers.

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -38,8 +38,6 @@
 			}
 		},
 		"features": {
-			"EnforceMultiVA": true,
-			"MultiVAFullResults": true,
 			"EnforceMultiCAA": true,
 			"MultiCAAFullResults": true,
 			"DOH": true

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -38,10 +38,7 @@
 				}
 			}
 		},
-		"features": {
-			"EnforceMultiVA": true,
-			"MultiVAFullResults": true
-		},
+		"features": {},
 		"remoteVAs": [
 			{
 				"serverAddress": "rva1.service.consul:9397",

--- a/va/caa.go
+++ b/va/caa.go
@@ -212,7 +212,7 @@ func (va *ValidationAuthorityImpl) processRemoteCAAResults(
 	// If we are using `features.MultiCAAFullResults` then we haven't returned
 	// early and can now log the differential between what the primary VA saw and
 	// what all of the remote VAs saw.
-	va.logRemoteDifferentials(
+	va.logRemoteResults(
 		domain,
 		acctID,
 		challengeType,


### PR DESCRIPTION
These flags have been true and false, respectively, for years. We do not expect to change them at any time in the future, and their continued existence makes certain parts of the VA code significantly more complex.

Remove all references to them, preserving behavior in the "enforce, but not full results" configuration.

IN-10358 tracks the corresponding config changes