### PR TITLE
Perform remote validation after primary validation

### DIFF
--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -959,19 +959,18 @@ func TestMultiCAARechecking(t *testing.T) {
 }
 
 func TestCAAFailure(t *testing.T) {
-	chall := createChallenge(core.ChallengeTypeHTTP01)
-	hs := httpSrv(t, chall.Token)
+	hs := httpSrv(t, expectedToken)
 	defer hs.Close()
 
 	va, _ := setup(hs, 0, "", nil, caaMockDNS{})
 
-	_, err := va.validate(ctx, dnsi("reserved.com"), 1, chall, expectedKeyAuthorization)
+	err := va.checkCAA(ctx, dnsi("reserved.com"), &caaParams{1, core.ChallengeTypeHTTP01})
 	if err == nil {
 		t.Fatalf("Expected CAA rejection for reserved.com, got success")
 	}
 	test.AssertErrorIs(t, err, berrors.CAA)
 
-	_, err = va.validate(ctx, dnsi("example.gonetld"), 1, chall, expectedKeyAuthorization)
+	err = va.checkCAA(ctx, dnsi("example.gonetld"), &caaParams{1, core.ChallengeTypeHTTP01})
 	if err == nil {
 		t.Fatalf("Expected CAA rejection for gonetld, got success")
 	}

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -89,44 +88,6 @@ func TestDNSValidationInvalid(t *testing.T) {
 	prob := detailedError(err)
 
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
-}
-
-func TestDNSValidationNotSane(t *testing.T) {
-	va, _ := setup(nil, 0, "", nil, nil)
-
-	chall := createChallenge(core.ChallengeTypeDNS01)
-	chall.Token = ""
-	_, err := va.validateChallenge(ctx, dnsi("localhost"), chall, expectedKeyAuthorization)
-	prob := detailedError(err)
-	if prob.Type != probs.MalformedProblem {
-		t.Errorf("Got wrong error type: expected %s, got %s",
-			prob.Type, probs.MalformedProblem)
-	}
-	if !strings.Contains(prob.Error(), "Challenge failed consistency check:") {
-		t.Errorf("Got wrong error: %s", prob.Error())
-	}
-
-	chall.Token = "yfCBb-bRTLz8Wd1C0lTUQK3qlKj3-t2tYGwx5Hj7r_"
-	_, err = va.validateChallenge(ctx, dnsi("localhost"), chall, expectedKeyAuthorization)
-	prob = detailedError(err)
-	if prob.Type != probs.MalformedProblem {
-		t.Errorf("Got wrong error type: expected %s, got %s",
-			prob.Type, probs.MalformedProblem)
-	}
-	if !strings.Contains(prob.Error(), "Challenge failed consistency check:") {
-		t.Errorf("Got wrong error: %s", prob.Error())
-	}
-
-	_, err = va.validateChallenge(ctx, dnsi("localhost"), chall, "a")
-	prob = detailedError(err)
-	if prob.Type != probs.MalformedProblem {
-		t.Errorf("Got wrong error type: expected %s, got %s",
-			prob.Type, probs.MalformedProblem)
-	}
-	if !strings.Contains(prob.Error(), "Challenge failed consistency check:") {
-		t.Errorf("Got wrong error: %s", prob.Error())
-	}
-
 }
 
 func TestDNSValidationServFail(t *testing.T) {

--- a/va/va.go
+++ b/va/va.go
@@ -444,10 +444,9 @@ func (va *ValidationAuthorityImpl) validateChallenge(
 
 // performRemoteValidation coordinates the whole process of kicking off and
 // collecting results from calls to remote VAs' PerformValidation function. It
-// returns either a problem (if too many of the RVAs observed validation
-// failures), or an error (if too many of the remote validation requests
-// encountered non-validation errors), or neither if the number of successful
-// remote validations surpassed our corroboration threshold.
+// returns a problem if too many remote perspectives failed to corroborate
+// domain control, or nil if enough succeeded to surpass our corroboration
+// threshold.
 func (va *ValidationAuthorityImpl) performRemoteValidation(
 	ctx context.Context,
 	req *vapb.PerformValidationRequest,
@@ -621,9 +620,9 @@ func (va *ValidationAuthorityImpl) performLocalValidation(
 		return records, err
 	}
 
-	// Do primary CAA checks. Any kind of error returned by this counts as a
-	// not receiving permission to issue, and will be converted into an
-	// appropriate ACME Problem by the calling function.
+	// Do primary CAA checks. Any kind of error returned by this counts as not
+	// receiving permission to issue, and will be converted into an appropriate
+	// ACME Problem by the calling function.
 	err = va.checkCAA(ctx, ident, &caaParams{
 		accountURIID:     regid,
 		validationMethod: kind,

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -101,16 +101,6 @@ func createValidationRequest(domain string, challengeType core.AcmeChallenge) *v
 	}
 }
 
-func createChallenge(challengeType core.AcmeChallenge) core.Challenge {
-	return core.Challenge{
-		Type:                     challengeType,
-		Status:                   core.StatusPending,
-		Token:                    expectedToken,
-		ValidationRecord:         []core.ValidationRecord{},
-		ProvidedKeyAuthorization: expectedKeyAuthorization,
-	}
-}
-
 // setup returns an in-memory VA and a mock logger. The default resolver client
 // is MockClient{}, but can be overridden.
 func setup(srv *httptest.Server, maxRemoteFailures int, userAgent string, remoteVAs []RemoteVA, mockDNSClientOverride bdns.Client) (*ValidationAuthorityImpl, *blog.Mock) {
@@ -251,7 +241,7 @@ func (inmem inMemVA) IsCAAValid(ctx context.Context, req *vapb.IsCAAValidRequest
 func TestValidateMalformedChallenge(t *testing.T) {
 	va, _ := setup(nil, 0, "", nil, nil)
 
-	_, err := va.validateChallenge(ctx, dnsi("example.com"), createChallenge("fake-type-01"), expectedKeyAuthorization)
+	_, err := va.validateChallenge(ctx, dnsi("example.com"), "fake-type-01", expectedToken, expectedKeyAuthorization)
 
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)


### PR DESCRIPTION
Change the VA to perform remote validation wholly after local validation and CAA checks, and to do so only if those local checks pass. This will likely increase the latency of our successful validations, by making them less parallel. However, it will reduce the amount of work we do on unsuccessful validations, and reduce their latency, by not kicking off and waiting for remote results.

Note to reviewers: I suggest reviewing this PR one commit at a time: each commit is small and self-contained, only editing one function.

Fixes https://github.com/letsencrypt/boulder/issues/7509