### PR TITLE
Remove deprecated UseFor[RSA|ECDSA]Leaves configs

### DIFF
--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -161,21 +161,6 @@ type IssuerConfig struct {
 	// the ECDSAForAll feature flag, and the ECDSAAllowListFilename config field.
 	Active bool
 
-	// UseForRSALeaves is a synonym for Active. Note that, despite the name,
-	// setting this field to true cannot add an issuer to a pool different than
-	// its key type. An active issuer will always be part of a pool based on its
-	// key type.
-	//
-	// Deprecated: use Active instead.
-	UseForRSALeaves bool
-	// UseForECDSALeaves is a synonym for Active. Note that, despite the name,
-	// setting this field to true cannot add an issuer to a pool different than
-	// its key type. An active issuer will always be part of a pool based on its
-	// key type.
-	//
-	// Deprecated: use Active instead.
-	UseForECDSALeaves bool
-
 	IssuerURL  string `validate:"required,url"`
 	OCSPURL    string `validate:"required,url"`
 	CRLURLBase string `validate:"omitempty,url,startswith=http://,endswith=/"`
@@ -288,7 +273,7 @@ func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk
 		Linter:     lintSigner,
 		keyAlg:     keyAlg,
 		sigAlg:     sigAlg,
-		active:     config.Active || config.UseForRSALeaves || config.UseForECDSALeaves,
+		active:     config.Active,
 		issuerURL:  config.IssuerURL,
 		ocspURL:    config.OCSPURL,
 		crlURLBase: config.CRLURLBase,

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -59,8 +59,7 @@
 			},
 			"issuers": [
 				{
-					"useForRSALeaves": false,
-					"useForECDSALeaves": true,
+					"active": true,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-a",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/ecdsa-a/",
@@ -71,8 +70,29 @@
 					}
 				},
 				{
-					"useForRSALeaves": true,
-					"useForECDSALeaves": true,
+					"active": true,
+					"issuerURL": "http://ca.example.org:4502/int-ecdsa-b",
+					"ocspURL": "http://ca.example.org:4002/",
+					"crlURLBase": "http://ca.example.org:4501/ecdsa-b/",
+					"location": {
+						"configFile": "test/certs/webpki/int-ecdsa-b.pkcs11.json",
+						"certFile": "test/certs/webpki/int-ecdsa-b.cert.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"active": false,
+					"issuerURL": "http://ca.example.org:4502/int-ecdsa-c",
+					"ocspURL": "http://ca.example.org:4002/",
+					"crlURLBase": "http://ca.example.org:4501/ecdsa-c/",
+					"location": {
+						"configFile": "test/certs/webpki/int-ecdsa-c.pkcs11.json",
+						"certFile": "test/certs/webpki/int-ecdsa-c.cert.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"active": true,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-a",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/rsa-a/",
@@ -83,14 +103,24 @@
 					}
 				},
 				{
-					"useForRSALeaves": false,
-					"useForECDSALeaves": false,
+					"active": true,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-b",
-					"ocspURL": "http://ca.example.org:4003/",
+					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/rsa-b/",
 					"location": {
 						"configFile": "test/certs/webpki/int-rsa-b.pkcs11.json",
 						"certFile": "test/certs/webpki/int-rsa-b.cert.pem",
+						"numSessions": 2
+					}
+				},
+				{
+					"active": false,
+					"issuerURL": "http://ca.example.org:4502/int-rsa-c",
+					"ocspURL": "http://ca.example.org:4002/",
+					"crlURLBase": "http://ca.example.org:4501/rsa-c/",
+					"location": {
+						"configFile": "test/certs/webpki/int-rsa-c.pkcs11.json",
+						"certFile": "test/certs/webpki/int-rsa-c.cert.pem",
 						"numSessions": 2
 					}
 				}


### PR DESCRIPTION
These were removed from production configs in IN-10212.