### PR TITLE
expiration-mailer: Don't audit log "no usable contact address"

### DIFF
--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -384,7 +384,10 @@ func (m *mailer) processCerts(
 			for w := range ch {
 				err := m.sendToOneRegID(ctx, conn, w.regID, w.certDERs, expiresIn)
 				if err != nil {
-					m.log.AuditErr(err.Error())
+					// Don't audit log when there is no email address on file.
+					if !errors.Is(err, errNoValidEmail) {
+						m.log.AuditErr(err.Error())
+					}
 				}
 			}
 			conn.Close()

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -456,8 +456,8 @@ func (m *mailer) sendToOneRegID(ctx context.Context, conn bmail.Conn, regID int6
 		var badAddrErr *bmail.BadAddressSMTPError
 		if errors.Is(err, errNoValidEmail) || errors.As(err, &badAddrErr) {
 			m.updateLastNagTimestamps(ctx, parsedCerts)
-			// Some accounts have no email; some accounts have a nonexistent
-			// email. Treat those as non-error cases.
+			// Some accounts have no email; some accounts have an invalid email.
+			// Treat those as non-error cases.
 			return nil
 		}
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -456,9 +456,8 @@ func (m *mailer) sendToOneRegID(ctx context.Context, conn bmail.Conn, regID int6
 		var badAddrErr *bmail.BadAddressSMTPError
 		if errors.Is(err, errNoValidEmail) || errors.As(err, &badAddrErr) {
 			m.updateLastNagTimestamps(ctx, parsedCerts)
-			// Though these are technically an error, we don't consider them
-			// failures to send because these (lack of) addresses were not even
-			// attempted to be sent to.
+			// Some accounts have no email; some accounts have a nonexistent
+			// email. Treat those as non-error cases.
 			return nil
 		}
 

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -383,11 +383,12 @@ func (m *mailer) processCerts(
 			defer wg.Done()
 			for w := range ch {
 				err := m.sendToOneRegID(ctx, conn, w.regID, w.certDERs, expiresIn)
-				if err != nil {
-					// Don't audit log when there is no email address on file.
-					if !errors.Is(err, errNoValidEmail) {
-						m.log.AuditErr(err.Error())
-					}
+				// Don't audit log when there is no email address on file
+				// because it's a waste of space. This decision should be
+				// revisited if we ever decide to output the accountID in the
+				// log line.
+				if err != nil && !errors.Is(err, errNoValidEmail) {
+					m.log.AuditErr(err.Error())
 				}
 			}
 			conn.Close()


### PR DESCRIPTION
Fixes #7528 