### PR TITLE
wfe: check well-formedness of requested names early

### DIFF
--- a/policy/pa.go
+++ b/policy/pa.go
@@ -412,13 +412,14 @@ func (pa *AuthorityImpl) WillingToIssue(domains []string) error {
 				subErrors = append(subErrors, subError(domain, err))
 				continue
 			}
-		} else {
-			// Require no match against hostname block lists
-			err := pa.checkHostLists(domain)
-			if err != nil {
-				subErrors = append(subErrors, subError(domain, err))
-				continue
-			}
+		}
+
+		// For both wildcard and non-wildcard domains, check whether any parent domain
+		// name is on the regular blocklist.
+		err := pa.checkHostLists(domain)
+		if err != nil {
+			subErrors = append(subErrors, subError(domain, err))
+			continue
 		}
 	}
 	return combineSubErrors(subErrors)

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -395,7 +395,7 @@ func subError(name string, err error) berrors.SubBoulderError {
 //
 // Precondition: all input domain names must be in lowercase.
 func (pa *AuthorityImpl) WillingToIssue(domains []string) error {
-	err := WellFormed(domains)
+	err := WellFormedDomainNames(domains)
 	if err != nil {
 		return err
 	}
@@ -424,7 +424,7 @@ func (pa *AuthorityImpl) WillingToIssue(domains []string) error {
 	return combineSubErrors(subErrors)
 }
 
-// WellFormed returns an error if any of the provided domains do not meet these criteria:
+// WellFormedDomainNames returns an error if any of the provided domains do not meet these criteria:
 //
 //   - MUST contains only lowercase characters, numbers, hyphens, and dots
 //   - MUST NOT have more than maxLabels labels
@@ -446,7 +446,7 @@ func (pa *AuthorityImpl) WillingToIssue(domains []string) error {
 //
 // If multiple domains are invalid, the error will contain suberrors specific to
 // each domain.
-func WellFormed(domains []string) error {
+func WellFormedDomainNames(domains []string) error {
 	var subErrors []berrors.SubBoulderError
 	for _, domain := range domains {
 		if strings.Count(domain, "*") > 0 {

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -387,8 +387,8 @@ func subError(name string, err error) berrors.SubBoulderError {
 // WillingToIssue determines whether the CA is willing to issue for the provided
 // domain names.
 //
-// It checks the criteria checked by `WellFormed`, and additionally checks whether
-// any domain is on a blocklist.
+// It checks the criteria checked by `WellFormedDomainNames`, and additionally checks
+// whether any domain is on a blocklist.
 //
 // If multiple domains are invalid, the error will contain suberrors specific to
 // each domain.

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -300,6 +300,7 @@ func TestWillingToIssue_Wildcards(t *testing.T) {
 func TestWillingToIssue_Wildcard(t *testing.T) {
 	banned := []string{
 		"letsdecrypt.org",
+		"example.com",
 	}
 	pa := paImpl(t)
 
@@ -316,10 +317,10 @@ func TestWillingToIssue_Wildcard(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't load policy contents from file")
 
 	domains := []string{
-		"perfectly-fine.com",             // fine
-		"letsdecrypt.org",                // banned
-		"ok.*.this.is.a.*.weird.one.com", // malformed
-		"also-perfectly-fine.com",        // fine
+		"perfectly-fine.com",      // fine
+		"letsdecrypt.org",         // banned
+		"example.com",             // banned
+		"also-perfectly-fine.com", // fine
 	}
 
 	err = pa.WillingToIssue(domains)
@@ -330,6 +331,7 @@ func TestWillingToIssue_Wildcard(t *testing.T) {
 	for _, err := range berr.SubErrors {
 		fmt.Println(err)
 	}
+	fmt.Println(berr)
 	test.AssertEquals(t, len(berr.SubErrors), 2)
 	test.AssertEquals(t, berr.Error(), "Cannot issue for \"letsdecrypt.org\": The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy (and 1 more problems. Refer to sub-problems for more information.)")
 
@@ -340,12 +342,12 @@ func TestWillingToIssue_Wildcard(t *testing.T) {
 	}
 
 	subErrA, foundA := subErrMap["letsdecrypt.org"]
-	subErrB, foundB := subErrMap["ok.*.this.is.a.*.weird.one.com"]
+	subErrB, foundB := subErrMap["example.com"]
 	test.AssertEquals(t, foundA, true)
 	test.AssertEquals(t, foundB, true)
 
 	test.AssertEquals(t, subErrA.Type, berrors.RejectedIdentifier)
-	test.AssertEquals(t, subErrB.Type, berrors.Malformed)
+	test.AssertEquals(t, subErrB.Type, berrors.RejectedIdentifier)
 
 	// Test willing to issue with only *one* bad identifier.
 	err = pa.WillingToIssue([]string{"letsdecrypt.org"})

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -331,7 +331,6 @@ func TestWillingToIssue_Wildcard(t *testing.T) {
 	for _, err := range berr.SubErrors {
 		fmt.Println(err)
 	}
-	fmt.Println(berr)
 	test.AssertEquals(t, len(berr.SubErrors), 2)
 	test.AssertEquals(t, berr.Error(), "Cannot issue for \"letsdecrypt.org\": The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy (and 1 more problems. Refer to sub-problems for more information.)")
 

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -295,9 +295,9 @@ func TestWillingToIssue_Wildcards(t *testing.T) {
 	}
 }
 
-// TestWillingToIssue_Wildcard tests that more than one rejected identifier
+// TestWillingToIssue_SubErrors tests that more than one rejected identifier
 // results in an error with suberrors.
-func TestWillingToIssue_Wildcard(t *testing.T) {
+func TestWillingToIssue_SubErrors(t *testing.T) {
 	banned := []string{
 		"letsdecrypt.org",
 		"example.com",

--- a/ratelimits/bucket.go
+++ b/ratelimits/bucket.go
@@ -239,6 +239,9 @@ func (builder *TransactionBuilder) OrdersPerAccountTransaction(regId int64) (Tra
 // of Transactions for the provided order domain names. An error is returned if
 // any of the order domain names are invalid. This method should be used for
 // checking capacity, before allowing more authorizations to be created.
+//
+// Precondition: orderDomains must all pass policy.WellFormedDomainNames.
+// Precondition: len(orderDomains) < maxNames.
 func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountCheckOnlyTransactions(regId int64, orderDomains []string, maxNames int) ([]Transaction, error) {
 	if len(orderDomains) > maxNames {
 		return nil, fmt.Errorf("order contains more than %d DNS names", maxNames)
@@ -318,6 +321,9 @@ func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountSpendO
 //
 // When a CertificatesPerDomainPerAccount override is not configured, a check-
 // and-spend Transaction is returned for each per domain bucket.
+//
+// Precondition: orderDomains must all pass policy.WellFormedDomainNames.
+// Precondition: len(orderDomains) < maxNames.
 func (builder *TransactionBuilder) CertificatesPerDomainTransactions(regId int64, orderDomains []string, maxNames int) ([]Transaction, error) {
 	if len(orderDomains) > maxNames {
 		return nil, fmt.Errorf("order contains more than %d DNS names", maxNames)

--- a/ratelimits/names.go
+++ b/ratelimits/names.go
@@ -187,14 +187,7 @@ func validateFQDNSet(id string) error {
 		return fmt.Errorf(
 			"invalid fqdnSet, %q must be formatted 'fqdnSet'", id)
 	}
-	for _, domain := range domains {
-		err := policy.ValidDomain(domain)
-		if err != nil {
-			return fmt.Errorf(
-				"invalid domain, %q must be formatted 'fqdnSet': %w", id, err)
-		}
-	}
-	return nil
+	return policy.WellFormedDomainNames(domains)
 }
 
 func validateIdForName(name Name, id string) error {

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -28,7 +28,7 @@ func TestTooBigOrderError(t *testing.T) {
 	var prob acme.Problem
 	test.AssertErrorWraps(t, err, &prob)
 	test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:malformed")
-	test.AssertEquals(t, prob.Detail, "Error creating new order :: Order cannot contain more than 100 DNS names")
+	test.AssertEquals(t, prob.Detail, "Order cannot contain more than 100 DNS names")
 }
 
 // TestAccountEmailError tests that registering a new account, or updating an

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2342,6 +2342,10 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
 		return
 	}
+	if len(names) > wfe.maxNames {
+		wfe.sendError(response, logEvent, probs.Malformed("Order cannot contain more than %d DNS names", wfe.maxNames), nil)
+		return
+	}
 
 	logEvent.DNSNames = names
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -29,6 +29,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
+	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/ratelimits"
 
 	// 'grpc/noncebalancer' is imported for its init function.
@@ -2044,6 +2045,11 @@ func (wfe *WebFrontEndImpl) orderToOrderJSON(request *http.Request, order *corep
 	return respObj
 }
 
+// newNewOrderLimitTransactions constructs a set of rate limit transactions to
+// evaluate for a new-order request.
+//
+// Precondition: names must be a list of DNS names that all pass
+// policy.WellFormedDomainNames.
 func (wfe *WebFrontEndImpl) newNewOrderLimitTransactions(regId int64, names []string) []ratelimits.Transaction {
 	if wfe.limiter == nil && wfe.txnBuilder == nil {
 		// Limiter is disabled.
@@ -2329,6 +2335,12 @@ func (wfe *WebFrontEndImpl) NewOrder(
 			return
 		}
 		names[i] = ident.Value
+	}
+
+	err = policy.WellFormedDomainNames(names)
+	if err != nil {
+		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
+		return
 	}
 
 	logEvent.DNSNames = names

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2540,6 +2540,11 @@ func TestNewOrder(t *testing.T) {
 			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"NewOrder request included empty domain name","status":400}`,
 		},
 		{
+			Name:         "POST, invalid domain name identifier",
+			Request:      signAndPost(signer, targetPath, signedURL, `{"identifiers":[{"type":"dns","value":"example.invalid"}]}`),
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `rejectedIdentifier","detail":"Invalid identifiers requested :: Cannot issue for \"example.invalid\": Domain name does not end with a valid public suffix (TLD)","status":400}`,
+		},
+		{
 			Name:         "POST, no identifiers in payload",
 			Request:      signAndPost(signer, targetPath, signedURL, "{}"),
 			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"NewOrder request did not specify any identifiers","status":400}`,


### PR DESCRIPTION
This allows us to give a user-meaningful error about malformed names early on, instead of propagating internal errors from the new rate limiting system.

This moves the well-formedness logic from `WillingToIssue` into a new function `WellFormedDomainNames`, which calls `ValidDomain` on each name and combines the errors into suberrors if there is more than one. `WillingToIssue` now calls `WellFormedDomainNames` to keep the existing behavior. Additionally, WFE calls `WellFormedDomainNames` before checking rate limits.

This creates a slight behavior change: If an order contains both malformed domain names and wellformed but blocked domain names, suberrors will only be generated for the malformed domain names. This is reflected in the changes to `TestWillingToIssue_Wildcard`.

Adds a WFE test case for receiving malformed identifiers in a new-order request.

Follows up on #3323 and #7218

Fixes #7526

Some small incidental fixes:

 - checkWildcardHostList was checking `pa.blocklist` for `nil` before accessing `pa.wildcardExactBlocklist`. Fix that.
 - move table test for WillingToIssue into a new test case for WellFormedDomainNames
 - move two standalone test cases into the big table test