### PR TITLE
Add signature count and error metrics to crlImpl

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -239,6 +239,8 @@ func setup(t *testing.T) *testCtx {
 		},
 		100,
 		blog.NewMock(),
+		signatureCount,
+		signErrorCount,
 	)
 	test.AssertNotError(t, err, "Failed to create crl impl")
 

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -287,6 +287,8 @@ func main() {
 			c.CA.Issuance.CRLProfile,
 			c.CA.OCSPLogMaxLength,
 			logger,
+			signatureCount,
+			signErrorCount,
 		)
 		cmd.FailOnError(err, "Failed to create CRL impl")
 


### PR DESCRIPTION
Add the "signatureCount" and "signErrorCount" metrics, which are already incremented by the certificateAuthorityImpl and ocspImpl after all signing operations, to the crlImpl.

Note that in the process of writing this PR I discovered that the method for determining whether to increment the signErrorCount metric is broken. Rather than diverge the crlImpl's version of that code from the identical code in the other two files, I have duplicated the broken code and will fix it in all three places in a follow-up.

Fixes https://github.com/letsencrypt/boulder/issues/7532