### PR TITLE
Make it possible to enable NIST P521 curve to verify a public key.

### DIFF
--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -77,6 +77,7 @@ type KeyPolicy struct {
 	AllowRSA           bool // Whether RSA keys should be allowed.
 	AllowECDSANISTP256 bool // Whether ECDSA NISTP256 keys should be allowed.
 	AllowECDSANISTP384 bool // Whether ECDSA NISTP384 keys should be allowed.
+	AllowECDSANISTP521 bool // Whether ECDSA NISTP521 keys should be allowed.
 	weakRSAList        *WeakRSAKeys
 	blockedList        *blockedKeys
 	fermatRounds       int
@@ -267,6 +268,8 @@ func (policy *KeyPolicy) goodCurve(c elliptic.Curve) (err error) {
 	case policy.AllowECDSANISTP256 && params == elliptic.P256().Params():
 		return nil
 	case policy.AllowECDSANISTP384 && params == elliptic.P384().Params():
+		return nil
+	case policy.AllowECDSANISTP521 && params == elliptic.P521().Params():
 		return nil
 	default:
 		return badKey("ECDSA curve %v not allowed", params.Name)

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -17,6 +17,7 @@ var testingPolicy = &KeyPolicy{
 	AllowRSA:           true,
 	AllowECDSANISTP256: true,
 	AllowECDSANISTP384: true,
+	AllowECDSANISTP521: true,
 }
 
 func TestUnknownKeyType(t *testing.T) {
@@ -146,12 +147,12 @@ func TestECDSABadCurve(t *testing.T) {
 
 var invalidCurves = []elliptic.Curve{
 	elliptic.P224(),
-	elliptic.P521(),
 }
 
 var validCurves = []elliptic.Curve{
 	elliptic.P256(),
 	elliptic.P384(),
+	elliptic.P521(),
 }
 
 func TestECDSAGoodKey(t *testing.T) {
@@ -287,6 +288,15 @@ func TestDBBlocklistReject(t *testing.T) {
 	test.AssertError(t, err, "GoodKey didn't fail with a blocked key")
 	test.AssertErrorIs(t, err, ErrBadKey)
 	test.AssertEquals(t, err.Error(), "public key is forbidden")
+}
+
+func TestDefaultECDSAKeys(t *testing.T) {
+	policy, err := NewKeyPolicy(&Config{}, nil)
+	test.AssertNotError(t, err, "NewKeyPolicy failed")
+	test.Assert(t, policy.AllowRSA, "RSA should be allowed")
+	test.Assert(t, policy.AllowECDSANISTP256, "NIST P256 should be allowed")
+	test.Assert(t, policy.AllowECDSANISTP384, "NIST P384 should be allowed")
+	test.Assert(t, !policy.AllowECDSANISTP521, "NIST P521 should not be allowed")
 }
 
 func TestRSAStrangeSize(t *testing.T) {


### PR DESCRIPTION
👋 from the Sigstore project. 

This PR enables optional verification of NIST P521 keys. 
Default key policy is not changed, which means that default only P256 and P384 is supported, so no changes are made to the current behaviour.

We are currently using `goodkeys` to verify public keys (see [here](https://github.com/sigstore/sigstore/blob/2e3ca7405eeff2eb489a337486172f748bd3d537/pkg/cryptoutils/publickey.go#L157)), but we don't use it to verify EC keys due to the lack of P521 support, which we do allow in our public key policy. By getting this change merged upstream, we could use `goodkeys` to verify all EC keys as well.