### PR TITLE
KeyPolicy: add custom constructor and make all fields private

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -198,11 +198,9 @@ func setup(t *testing.T) *testCtx {
 		test.AssertNotError(t, err, "Couldn't load test issuer")
 	}
 
-	keyPolicy := goodkey.KeyPolicy{
-		AllowRSA:           true,
-		AllowECDSANISTP256: true,
-		AllowECDSANISTP384: true,
-	}
+	keyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	test.AssertNotError(t, err, "Failed to create test keypolicy")
+
 	signatureCount := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "signatures",

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -198,7 +198,7 @@ func setup(t *testing.T) *testCtx {
 		test.AssertNotError(t, err, "Couldn't load test issuer")
 	}
 
-	keyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	keyPolicy, err := goodkey.NewPolicy(nil, nil)
 	test.AssertNotError(t, err, "Failed to create test keypolicy")
 
 	signatureCount := prometheus.NewCounterVec(

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -233,7 +233,7 @@ func main() {
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sa := sapb.NewStorageAuthorityClient(conn)
 
-	kp, err := sagoodkey.NewKeyPolicy(&c.CA.GoodKey, sa.KeyBlocked)
+	kp, err := sagoodkey.NewPolicy(&c.CA.GoodKey, sa.KeyBlocked)
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	var ecdsaAllowList *ca.ECDSAAllowList

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -254,7 +254,7 @@ func main() {
 		cmd.Fail("finalizeTimeout must be supplied when AsyncFinalize feature is enabled")
 	}
 
-	kp, err := sagoodkey.NewKeyPolicy(&c.RA.GoodKey, sac.KeyBlocked)
+	kp, err := sagoodkey.NewPolicy(&c.RA.GoodKey, sac.KeyBlocked)
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	if c.RA.MaxNames == 0 {

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -311,7 +311,7 @@ func main() {
 
 	rac, sac, gnc, rnc, npKey := setupWFE(c, stats, clk)
 
-	kp, err := sagoodkey.NewKeyPolicy(&c.WFE.GoodKey, sac.KeyBlocked)
+	kp, err := sagoodkey.NewPolicy(&c.WFE.GoodKey, sac.KeyBlocked)
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	if c.WFE.StaleTimeout.Duration == 0 {

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -34,7 +34,7 @@ var kp goodkey.KeyPolicy
 
 func init() {
 	var err error
-	kp, err = goodkey.NewDefaultKeyPolicy(&goodkey.Config{FermatRounds: 100}, nil)
+	kp, err = goodkey.NewPolicy(&goodkey.Config{FermatRounds: 100}, nil)
 	if err != nil {
 		log.Fatal("Could not create goodkey.KeyPolicy")
 	}

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -34,7 +34,7 @@ var kp goodkey.KeyPolicy
 
 func init() {
 	var err error
-	kp, err = goodkey.NewKeyPolicy(&goodkey.Config{FermatRounds: 100}, nil)
+	kp, err = goodkey.NewDefaultKeyPolicy(&goodkey.Config{FermatRounds: 100}, nil)
 	if err != nil {
 		log.Fatal("Could not create goodkey.KeyPolicy")
 	}

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -555,7 +555,7 @@ func main() {
 	if config.CertChecker.GoodKey.BlockedKeyFile != "" {
 		cmd.Fail("cert-checker does not support checking against blocked key files")
 	}
-	kp, err := sagoodkey.NewKeyPolicy(&config.CertChecker.GoodKey, nil)
+	kp, err := sagoodkey.NewPolicy(&config.CertChecker.GoodKey, nil)
 	cmd.FailOnError(err, "Unable to create key policy")
 
 	saDbMap, err := sa.InitWrappedDb(config.CertChecker.DB, prometheus.DefaultRegisterer, logger)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -60,7 +60,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	kp, err = sagoodkey.NewKeyPolicy(&goodkey.Config{FermatRounds: 100}, nil)
+	kp, err = sagoodkey.NewPolicy(&goodkey.Config{FermatRounds: 100}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -20,12 +20,6 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-var testingPolicy = &goodkey.KeyPolicy{
-	AllowRSA:           true,
-	AllowECDSANISTP256: true,
-	AllowECDSANISTP384: true,
-}
-
 type mockPA struct{}
 
 func (pa *mockPA) ChallengesFor(identifier identifier.ACMEIdentifier) (challenges []core.Challenge, err error) {
@@ -78,87 +72,79 @@ func TestVerifyCSR(t *testing.T) {
 	*signedReqWithAllLongSANs = *signedReq
 	signedReqWithAllLongSANs.DNSNames = []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com"}
 
+	keyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	test.AssertNotError(t, err, "creating test keypolicy")
+
 	cases := []struct {
 		csr           *x509.CertificateRequest
 		maxNames      int
-		keyPolicy     *goodkey.KeyPolicy
 		pa            core.PolicyAuthority
 		expectedError error
 	}{
 		{
 			&x509.CertificateRequest{},
 			100,
-			testingPolicy,
 			&mockPA{},
 			invalidPubKey,
 		},
 		{
 			&x509.CertificateRequest{PublicKey: &private.PublicKey},
 			100,
-			testingPolicy,
 			&mockPA{},
 			unsupportedSigAlg,
 		},
 		{
 			brokenSignedReq,
 			100,
-			testingPolicy,
 			&mockPA{},
 			invalidSig,
 		},
 		{
 			signedReq,
 			100,
-			testingPolicy,
 			&mockPA{},
 			invalidNoDNS,
 		},
 		{
 			signedReqWithLongCN,
 			100,
-			testingPolicy,
 			&mockPA{},
 			berrors.BadCSRError("CN was longer than %d bytes", maxCNLength),
 		},
 		{
 			signedReqWithHosts,
 			1,
-			testingPolicy,
 			&mockPA{},
 			berrors.BadCSRError("CSR contains more than 1 DNS names"),
 		},
 		{
 			signedReqWithBadNames,
 			100,
-			testingPolicy,
 			&mockPA{},
 			errors.New("policy forbids issuing for identifier"),
 		},
 		{
 			signedReqWithEmailAddress,
 			100,
-			testingPolicy,
 			&mockPA{},
 			invalidEmailPresent,
 		},
 		{
 			signedReqWithIPAddress,
 			100,
-			testingPolicy,
 			&mockPA{},
 			invalidIPPresent,
 		},
 		{
 			signedReqWithAllLongSANs,
 			100,
-			testingPolicy,
 			&mockPA{},
 			nil,
 		},
 	}
 
 	for _, c := range cases {
-		err := VerifyCSR(context.Background(), c.csr, c.maxNames, c.keyPolicy, c.pa)
+		err := VerifyCSR(context.Background(), c.csr, c.maxNames, &keyPolicy, c.pa)
 		test.AssertDeepEquals(t, c.expectedError, err)
 	}
 }
@@ -239,6 +225,9 @@ func TestNamesFromCSR(t *testing.T) {
 func TestSHA1Deprecation(t *testing.T) {
 	features.Reset()
 
+	keyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	test.AssertNotError(t, err, "creating test keypolicy")
+
 	private, err := rsa.GenerateKey(rand.Reader, 2048)
 	test.AssertNotError(t, err, "error generating test key")
 
@@ -254,7 +243,7 @@ func TestSHA1Deprecation(t *testing.T) {
 		csr, err := x509.ParseCertificateRequest(csrBytes)
 		test.AssertNotError(t, err, "parsing test CSR")
 
-		return VerifyCSR(context.Background(), csr, 100, testingPolicy, &mockPA{})
+		return VerifyCSR(context.Background(), csr, 100, &keyPolicy, &mockPA{})
 	}
 
 	err = makeAndVerifyCsr(x509.SHA256WithRSA)

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -72,7 +72,7 @@ func TestVerifyCSR(t *testing.T) {
 	*signedReqWithAllLongSANs = *signedReq
 	signedReqWithAllLongSANs.DNSNames = []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com"}
 
-	keyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	keyPolicy, err := goodkey.NewPolicy(nil, nil)
 	test.AssertNotError(t, err, "creating test keypolicy")
 
 	cases := []struct {
@@ -225,7 +225,7 @@ func TestNamesFromCSR(t *testing.T) {
 func TestSHA1Deprecation(t *testing.T) {
 	features.Reset()
 
-	keyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	keyPolicy, err := goodkey.NewPolicy(nil, nil)
 	test.AssertNotError(t, err, "creating test keypolicy")
 
 	private, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/goodkey/blocked_test.go
+++ b/goodkey/blocked_test.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"testing"
 
+	yaml "gopkg.in/yaml.v3"
+
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/web"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func TestBlockedKeys(t *testing.T) {
@@ -76,11 +77,9 @@ func TestBlockedKeys(t *testing.T) {
 	test.AssertNotError(t, err, "unexpected error loading empty blockedKeys yaml file")
 
 	// Create a test policy that doesn't reference the blocked list
-	testingPolicy := &KeyPolicy{
-		AllowRSA:           true,
-		AllowECDSANISTP256: true,
-		AllowECDSANISTP384: true,
-	}
+	testingPolicy := &KeyPolicy{allowedKeys: AllowedKeys{
+		RSA2048: true, RSA3072: true, RSA4096: true, ECDSAP256: true, ECDSAP384: true,
+	}}
 
 	// All of the test keys should not be considered blocked
 	for _, k := range blockedKeys {

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -264,7 +264,7 @@ func TestDBBlocklistAccept(t *testing.T) {
 			return false, nil
 		},
 	} {
-		policy, err := NewDefaultKeyPolicy(&Config{}, testCheck)
+		policy, err := NewPolicy(nil, testCheck)
 		test.AssertNotError(t, err, "NewKeyPolicy failed")
 
 		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -279,7 +279,7 @@ func TestDBBlocklistReject(t *testing.T) {
 		return true, nil
 	}
 
-	policy, err := NewDefaultKeyPolicy(&Config{}, testCheck)
+	policy, err := NewPolicy(nil, testCheck)
 	test.AssertNotError(t, err, "NewKeyPolicy failed")
 
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -291,8 +291,17 @@ func TestDBBlocklistReject(t *testing.T) {
 }
 
 func TestDefaultAllowedKeys(t *testing.T) {
-	policy, err := NewDefaultKeyPolicy(&Config{}, nil)
-	test.AssertNotError(t, err, "NewDefaultKeyPolicy failed")
+	policy, err := NewPolicy(nil, nil)
+	test.AssertNotError(t, err, "NewPolicy with nil config failed")
+	test.Assert(t, policy.allowedKeys.RSA2048, "RSA 2048 should be allowed")
+	test.Assert(t, policy.allowedKeys.RSA3072, "RSA 3072 should be allowed")
+	test.Assert(t, policy.allowedKeys.RSA4096, "RSA 4096 should be allowed")
+	test.Assert(t, policy.allowedKeys.ECDSAP256, "NIST P256 should be allowed")
+	test.Assert(t, policy.allowedKeys.ECDSAP384, "NIST P384 should be allowed")
+	test.Assert(t, !policy.allowedKeys.ECDSAP521, "NIST P521 should not be allowed")
+
+	policy, err = NewPolicy(&Config{FermatRounds: 100}, nil)
+	test.AssertNotError(t, err, "NewPolicy with nil config.AllowedKeys failed")
 	test.Assert(t, policy.allowedKeys.RSA2048, "RSA 2048 should be allowed")
 	test.Assert(t, policy.allowedKeys.RSA3072, "RSA 3072 should be allowed")
 	test.Assert(t, policy.allowedKeys.RSA4096, "RSA 4096 should be allowed")

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -290,9 +290,9 @@ func TestDBBlocklistReject(t *testing.T) {
 	test.AssertEquals(t, err.Error(), "public key is forbidden")
 }
 
-func TestDefaultECDSAKeys(t *testing.T) {
+func TestDefaultAllowedKeys(t *testing.T) {
 	policy, err := NewDefaultKeyPolicy(&Config{}, nil)
-	test.AssertNotError(t, err, "NewKeyPolicy failed")
+	test.AssertNotError(t, err, "NewDefaultKeyPolicy failed")
 	test.Assert(t, policy.allowedKeys.RSA2048, "RSA 2048 should be allowed")
 	test.Assert(t, policy.allowedKeys.RSA3072, "RSA 3072 should be allowed")
 	test.Assert(t, policy.allowedKeys.RSA4096, "RSA 4096 should be allowed")

--- a/goodkey/good_key_test.go
+++ b/goodkey/good_key_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-var testingPolicy = &KeyPolicy{
-	AllowRSA:           true,
-	AllowECDSANISTP256: true,
-	AllowECDSANISTP384: true,
-	AllowECDSANISTP521: true,
-}
+// testingPolicy is a simple policy which allows all of the key types, so that
+// the unit tests can exercise checks against all key types.
+var testingPolicy = &KeyPolicy{allowedKeys: AllowedKeys{
+	RSA2048: true, RSA3072: true, RSA4096: true,
+	ECDSAP256: true, ECDSAP384: true, ECDSAP521: true,
+}}
 
 func TestUnknownKeyType(t *testing.T) {
 	notAKey := struct{}{}
@@ -264,7 +264,7 @@ func TestDBBlocklistAccept(t *testing.T) {
 			return false, nil
 		},
 	} {
-		policy, err := NewKeyPolicy(&Config{}, testCheck)
+		policy, err := NewDefaultKeyPolicy(&Config{}, testCheck)
 		test.AssertNotError(t, err, "NewKeyPolicy failed")
 
 		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -279,7 +279,7 @@ func TestDBBlocklistReject(t *testing.T) {
 		return true, nil
 	}
 
-	policy, err := NewKeyPolicy(&Config{}, testCheck)
+	policy, err := NewDefaultKeyPolicy(&Config{}, testCheck)
 	test.AssertNotError(t, err, "NewKeyPolicy failed")
 
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -291,12 +291,14 @@ func TestDBBlocklistReject(t *testing.T) {
 }
 
 func TestDefaultECDSAKeys(t *testing.T) {
-	policy, err := NewKeyPolicy(&Config{}, nil)
+	policy, err := NewDefaultKeyPolicy(&Config{}, nil)
 	test.AssertNotError(t, err, "NewKeyPolicy failed")
-	test.Assert(t, policy.AllowRSA, "RSA should be allowed")
-	test.Assert(t, policy.AllowECDSANISTP256, "NIST P256 should be allowed")
-	test.Assert(t, policy.AllowECDSANISTP384, "NIST P384 should be allowed")
-	test.Assert(t, !policy.AllowECDSANISTP521, "NIST P521 should not be allowed")
+	test.Assert(t, policy.allowedKeys.RSA2048, "RSA 2048 should be allowed")
+	test.Assert(t, policy.allowedKeys.RSA3072, "RSA 3072 should be allowed")
+	test.Assert(t, policy.allowedKeys.RSA4096, "RSA 4096 should be allowed")
+	test.Assert(t, policy.allowedKeys.ECDSAP256, "NIST P256 should be allowed")
+	test.Assert(t, policy.allowedKeys.ECDSAP384, "NIST P384 should be allowed")
+	test.Assert(t, !policy.allowedKeys.ECDSAP521, "NIST P521 should not be allowed")
 }
 
 func TestRSAStrangeSize(t *testing.T) {

--- a/goodkey/sagoodkey/good_key.go
+++ b/goodkey/sagoodkey/good_key.go
@@ -14,9 +14,9 @@ import (
 // significantly simpler.
 type BlockedKeyCheckFunc func(context.Context, *sapb.SPKIHash, ...grpc.CallOption) (*sapb.Exists, error)
 
-// NewKeyPolicy returns a KeyPolicy that uses a sa.BlockedKey method.
-// See goodkey.NewKeyPolicy for more details about the policy itself.
-func NewKeyPolicy(config *goodkey.Config, bkc BlockedKeyCheckFunc) (goodkey.KeyPolicy, error) {
+// NewPolicy returns a KeyPolicy that uses a sa.BlockedKey method.
+// See goodkey.NewPolicy for more details about the policy itself.
+func NewPolicy(config *goodkey.Config, bkc BlockedKeyCheckFunc) (goodkey.KeyPolicy, error) {
 	var genericCheck goodkey.BlockedKeyCheckFunc
 	if bkc != nil {
 		genericCheck = func(ctx context.Context, keyHash []byte) (bool, error) {
@@ -28,5 +28,5 @@ func NewKeyPolicy(config *goodkey.Config, bkc BlockedKeyCheckFunc) (goodkey.KeyP
 		}
 	}
 
-	return goodkey.NewDefaultKeyPolicy(config, genericCheck)
+	return goodkey.NewPolicy(config, genericCheck)
 }

--- a/goodkey/sagoodkey/good_key.go
+++ b/goodkey/sagoodkey/good_key.go
@@ -28,5 +28,5 @@ func NewKeyPolicy(config *goodkey.Config, bkc BlockedKeyCheckFunc) (goodkey.KeyP
 		}
 	}
 
-	return goodkey.NewKeyPolicy(config, genericCheck)
+	return goodkey.NewDefaultKeyPolicy(config, genericCheck)
 }

--- a/goodkey/sagoodkey/good_key_test.go
+++ b/goodkey/sagoodkey/good_key_test.go
@@ -21,7 +21,7 @@ func TestDBBlocklistAccept(t *testing.T) {
 			return &sapb.Exists{Exists: false}, nil
 		},
 	} {
-		policy, err := NewKeyPolicy(&goodkey.Config{}, testCheck)
+		policy, err := NewPolicy(&goodkey.Config{}, testCheck)
 		test.AssertNotError(t, err, "NewKeyPolicy failed")
 
 		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -36,7 +36,7 @@ func TestDBBlocklistReject(t *testing.T) {
 		return &sapb.Exists{Exists: true}, nil
 	}
 
-	policy, err := NewKeyPolicy(&goodkey.Config{}, testCheck)
+	policy, err := NewPolicy(&goodkey.Config{}, testCheck)
 	test.AssertNotError(t, err, "NewKeyPolicy failed")
 
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -224,12 +224,6 @@ var (
 	log = blog.UseMock()
 )
 
-var testKeyPolicy = goodkey.KeyPolicy{
-	AllowRSA:           true,
-	AllowECDSANISTP256: true,
-	AllowECDSANISTP384: true,
-}
-
 var ctx = context.Background()
 
 // dummyRateLimitConfig satisfies the rl.RateLimitConfig interface while
@@ -396,6 +390,9 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 		txnBuilder, err = ratelimits.NewTransactionBuilder("../test/config-next/wfe2-ratelimit-defaults.yml", "")
 		test.AssertNotError(t, err, "making transaction composer")
 	}
+
+	testKeyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	test.AssertNotError(t, err, "making keypolicy")
 
 	ra := NewRegistrationAuthorityImpl(
 		fc, log, stats,

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -391,7 +391,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 		test.AssertNotError(t, err, "making transaction composer")
 	}
 
-	testKeyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	testKeyPolicy, err := goodkey.NewPolicy(nil, nil)
 	test.AssertNotError(t, err, "making keypolicy")
 
 	ra := NewRegistrationAuthorityImpl(

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1599,7 +1599,7 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 		return false, context.DeadlineExceeded
 	}
 
-	kp, err := goodkey.NewKeyPolicy(&goodkey.Config{}, timeoutErrCheckFunc)
+	kp, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, timeoutErrCheckFunc)
 	test.AssertNotError(t, err, "making key policy")
 
 	wfe.keyPolicy = kp
@@ -1614,7 +1614,7 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 		return false, fmt.Errorf("oh no: %w", goodkey.ErrBadKey)
 	}
 
-	kp, err = goodkey.NewKeyPolicy(&goodkey.Config{}, badKeyCheckFunc)
+	kp, err = goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, badKeyCheckFunc)
 	test.AssertNotError(t, err, "making key policy")
 
 	wfe.keyPolicy = kp

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -1599,7 +1599,7 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 		return false, context.DeadlineExceeded
 	}
 
-	kp, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, timeoutErrCheckFunc)
+	kp, err := goodkey.NewPolicy(nil, timeoutErrCheckFunc)
 	test.AssertNotError(t, err, "making key policy")
 
 	wfe.keyPolicy = kp
@@ -1614,7 +1614,7 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 		return false, fmt.Errorf("oh no: %w", goodkey.ErrBadKey)
 	}
 
-	kp, err = goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, badKeyCheckFunc)
+	kp, err = goodkey.NewPolicy(nil, badKeyCheckFunc)
 	test.AssertNotError(t, err, "making key policy")
 
 	wfe.keyPolicy = kp

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -297,12 +297,6 @@ func loadKey(t *testing.T, keyBytes []byte) crypto.Signer {
 	return nil
 }
 
-var testKeyPolicy = goodkey.KeyPolicy{
-	AllowRSA:           true,
-	AllowECDSANISTP256: true,
-	AllowECDSANISTP384: true,
-}
-
 var ctx = context.Background()
 
 func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
@@ -310,6 +304,9 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 
 	fc := clock.NewFake()
 	stats := metrics.NoopRegisterer
+
+	testKeyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	test.AssertNotError(t, err, "creating test keypolicy")
 
 	certChains := map[issuance.NameID][][]byte{}
 	issuerCertificates := map[issuance.NameID]*issuance.Certificate{}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -305,7 +305,7 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 	fc := clock.NewFake()
 	stats := metrics.NoopRegisterer
 
-	testKeyPolicy, err := goodkey.NewDefaultKeyPolicy(&goodkey.Config{}, nil)
+	testKeyPolicy, err := goodkey.NewPolicy(nil, nil)
 	test.AssertNotError(t, err, "creating test keypolicy")
 
 	certChains := map[issuance.NameID][][]byte{}


### PR DESCRIPTION
Change how goodkey.KeyPolicy keeps track of allowed RSA and ECDSA key sizes, to make it slightly more flexible while still retaining the very locked-down allowlist of only 6 acceptable key sizes (RSA 2048, 3076, and 4092, and ECDSA P256, P384, and P521). Add a new constructor which takes in a collection of allowed key sizes, so that users of the goodkey package can customize which keys they accept. Rename the existing constructor to make it clear that it uses hardcoded default values.

With these new constructors available, make all of the goodkey.KeyPolicy member fields private, so that a KeyPolicy can only be built via these constructors.

~~NOTE: This PR is based on top of https://github.com/letsencrypt/boulder/pull/7541. DO NOT MERGE until that PR has landed.~~