### PR TITLE
Fix flaky unittest failures

### DIFF
--- a/test/load-generator/acme/directory_test.go
+++ b/test/load-generator/acme/directory_test.go
@@ -132,7 +132,7 @@ func TestNew(t *testing.T) {
 		{
 			Name:          "unreachable directory URL",
 			DirectoryURL:  "http://localhost:1987",
-			ExpectedError: "Get \"http://localhost:1987\": dial tcp 127.0.0.1:1987: connect: connection refused",
+			ExpectedError: "connect: connection refused",
 		},
 		{
 			Name:          "wrong directory HTTP status code",
@@ -179,7 +179,7 @@ func TestNew(t *testing.T) {
 			if err == nil && tc.ExpectedError != "" {
 				t.Errorf("expected error %q got nil", tc.ExpectedError)
 			} else if err != nil {
-				test.AssertEquals(t, err.Error(), tc.ExpectedError)
+				test.AssertContains(t, err.Error(), tc.ExpectedError)
 			}
 		})
 	}

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -1378,7 +1378,7 @@ func TestHTTPDialTimeout(t *testing.T) {
 	var err error
 	for range 20 {
 		_, err = va.validateHTTP01(ctx, dnsi("unroutable.invalid"), expectedToken, expectedKeyAuthorization)
-		if err != nil && strings.Contains(err.Error(), "Network unreachable") {
+		if err != nil && strings.Contains(err.Error(), "network is unreachable") {
 			continue
 		} else {
 			break

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -992,7 +992,7 @@ func TestFetchHTTP(t *testing.T) {
 			Host: "ipv6.localhost",
 			Path: "/ok",
 			ExpectedProblem: probs.Connection(
-				"::1: Fetching http://ipv6.localhost/ok: Error getting validation data"),
+				"::1: Fetching http://ipv6.localhost/ok: Connection refused"),
 			ExpectedRecords: []core.ValidationRecord{
 				{
 					Hostname:          "ipv6.localhost",
@@ -1098,14 +1098,14 @@ func TestFetchHTTP(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
 			defer cancel()
 			body, records, err := va.fetchHTTP(ctx, tc.Host, tc.Path)
-			if err != nil && tc.ExpectedProblem == nil {
-				t.Errorf("expected nil prob, got %#v\n", err)
-			} else if err == nil && tc.ExpectedProblem != nil {
-				t.Errorf("expected %#v prob, got nil", tc.ExpectedProblem)
-			} else if err != nil && tc.ExpectedProblem != nil {
+			if tc.ExpectedProblem == nil {
+				test.AssertNotError(t, err, "expected nil prob")
+			} else {
+				test.AssertError(t, err, "expected non-nil prob")
 				prob := detailedError(err)
 				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-			} else {
+			}
+			if tc.ExpectedBody != "" {
 				test.AssertEquals(t, string(body), tc.ExpectedBody)
 			}
 			// in all cases we expect validation records to be present and matching expected


### PR DESCRIPTION
Fix three unit tests which have been flakily failing for the last several weeks:

- [x] //test/load-generator/acme: TestNew/unreachable_directory_URL
      `directory_test.go:182: "Get \"http://localhost:1987/\": dial tcp [::1]:1987: connect: connection refused" != "Get \"http://localhost:1987/\": dial tcp 127.0.0.1:1987: connect: connection refused"`
      Fixed by changing the error checking code to care only about the underlying "connection refused" message, and not the IP address from which it was receieved.
- [x]  //va: TestHTTPDialTimeout
      `http_test.go:1394: HTTP returned before 250ms (3.860444ms) with "198.51.100.1: Get \"http://unroutable.invalid/.well-known/acme-challenge/LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0\": dial tcp 198.51.100.1:80: connect: network is unreachable"`
      Fixed by correcting the error checking code to look for "network is unreachable" instead of "Network unreachable"
- [x] //va: TestFetchHTTP/Broken_IPv6_only
      `http_test.go:1107: [{"type":"connection","detail":"::1: Fetching http://ipv6.localhost/ok: Connection refused","status":400}] !(json)= [{"type":"connection","detail":"::1: Fetching http://ipv6.localhost/ok: Error getting validation data","status":400}]`
      Fixed by making the expected error message more specific -- it was previously looking for "Error getting validation data", which is the message that `detailedError` gives for errors it doesn't recognize. An underlying library has changed to provide an error type that `detailedError` now recognizes as a connection error.