### PR TITLE
Group some dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,13 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    groups:
+      aws:
+        patterns:
+          - "github.com/aws/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
     open-pull-requests-limit: 1
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This will cause dependabot to open one PR that updates dependencies matching these patterns in a single PR.  For both AWS and otel, we depend on multiple packages from them, which generally are good to bump together.
