### PR TITLE
WFE: Normalize SANs in NewOrder request

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2343,20 +2343,17 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
 		return
 	}
-	// TODO(#7555) Replace names with normalizedNames
-	if len(names) > wfe.maxNames {
+	if len(normalizedNames) > wfe.maxNames {
 		wfe.sendError(response, logEvent, probs.Malformed("Order cannot contain more than %d DNS names", wfe.maxNames), nil)
 		return
 	}
 
-	// TODO(#7555) Replace names with normalizedNames
-	logEvent.DNSNames = names
+	logEvent.DNSNames = normalizedNames
 
 	var replaces string
 	var limitsExempt bool
 	if features.Get().TrackReplacementCertificatesARI {
-		// TODO(#7555) Replace names with normalizedNames
-		replaces, limitsExempt, err = wfe.validateReplacementOrder(ctx, acct, names, newOrderRequest.Replaces)
+		replaces, limitsExempt, err = wfe.validateReplacementOrder(ctx, acct, normalizedNames, newOrderRequest.Replaces)
 		if err != nil {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "While validating order as a replacement an error occurred"), err)
 			return
@@ -2399,9 +2396,8 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	}()
 
 	order, err := wfe.ra.NewOrder(ctx, &rapb.NewOrderRequest{
-		RegistrationID: acct.ID,
-		// TODO(#7555) Replace names with normalizedNames
-		Names:                  names,
+		RegistrationID:         acct.ID,
+		Names:                  normalizedNames,
 		ReplacesSerial:         replaces,
 		LimitsExempt:           limitsExempt,
 		CertificateProfileName: newOrderRequest.Profile,

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2337,8 +2337,6 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		names[i] = ident.Value
 	}
 
-	// Ensure that all names are normalized to meet the precondition for
-	// policy.WellFormedDomainNames
 	err = policy.WellFormedDomainNames(core.UniqueLowerNames(names))
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2337,7 +2337,9 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		names[i] = ident.Value
 	}
 
-	err = policy.WellFormedDomainNames(names)
+	// Ensure that all names are normalized to meet the precondition for
+	// policy.WellFormedDomainNames
+	err = policy.WellFormedDomainNames(core.UniqueLowerNames(names))
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
 		return

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2482,8 +2482,8 @@ func TestNewOrder(t *testing.T) {
 	validOrderBodyWithMixedCaseIdentifiers := `
 	{
 		"Identifiers": [
-		  {"type": "dns", "value": "not-ExAmPlE.com"},
-		  {"type": "dns", "value": "WWW.nOt-example.coM"}
+		  {"type": "dns", "value": "Not-Example.com"},
+			{"type": "dns", "value": "WWW.Not-example.com"}
 		]
 	}`
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2464,7 +2464,7 @@ func TestNewOrder(t *testing.T) {
 	nonDNSIdentifierBody := `
 	{
 		"Identifiers": [
-		  {"type": "dns",    "value": "not-example.com"},
+			{"type": "dns",    "value": "not-example.com"},
 			{"type": "dns",    "value": "www.not-example.com"},
 			{"type": "fakeID", "value": "www.i-am-21.com"}
 		]
@@ -2474,7 +2474,7 @@ func TestNewOrder(t *testing.T) {
 	validOrderBody := `
 	{
 		"Identifiers": [
-		  {"type": "dns", "value": "not-example.com"},
+			{"type": "dns", "value": "not-example.com"},
 			{"type": "dns", "value": "www.not-example.com"}
 		]
 	}`
@@ -2482,7 +2482,7 @@ func TestNewOrder(t *testing.T) {
 	validOrderBodyWithMixedCaseIdentifiers := `
 	{
 		"Identifiers": [
-		  {"type": "dns", "value": "Not-Example.com"},
+			{"type": "dns", "value": "Not-Example.com"},
 			{"type": "dns", "value": "WWW.Not-example.com"}
 		]
 	}`

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -244,7 +244,7 @@ func (ra *MockRegistrationAuthority) NewOrder(ctx context.Context, in *rapb.NewO
 		RegistrationID:   in.RegistrationID,
 		Created:          timestamppb.New(created),
 		Expires:          timestamppb.New(expires),
-		Names:            core.UniqueLowerNames(in.Names),
+		Names:            in.Names,
 		Status:           string(core.StatusPending),
 		V2Authorizations: []int64{1},
 	}, nil

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2483,7 +2483,7 @@ func TestNewOrder(t *testing.T) {
 	{
 		"Identifiers": [
 		  {"type": "dns", "value": "not-ExAmPlE.com"},
-			{"type": "dns", "value": "WWW.nOt-example.coM"}
+		  {"type": "dns", "value": "WWW.nOt-example.coM"}
 		]
 	}`
 


### PR DESCRIPTION
In #7530, `wfe.NewOrder` [began constructing a rate limit transaction](https://github.com/letsencrypt/boulder/pull/7530/files#diff-3f950e720c205ce9fa8dea12c6fd7fd44272c2671f19d0e06962abfbea00d491R2340-R2344) with a precondition that all names must be lower-cased, however the actual implementation of the precondition was accidentally overlooked. This fix corrects that and adds a unit test to prevent a future regression.

Other changes:
- Only normalized names count towards max names limit
- Only normalized names will be logged in the web.RequestEvent