### PR TITLE
ca: Enable ECDSAForAll in config

### DIFF
--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -144,8 +144,9 @@
 		},
 		"ocspLogMaxLength": 4000,
 		"ocspLogPeriod": "500ms",
-		"ecdsaAllowListFilename": "test/config/ecdsaAllowList.yml",
-		"features": {}
+		"features": {
+			"ECDSAForAll": true
+		}
 	},
 	"pa": {
 		"challenges": {


### PR DESCRIPTION
This change removes the ECDSAAllowList entry and enables ECDSAForAll for the `test/config/ca.json` to match the configuration in `test/config-next/ca.json`. A future change will remove ECDSAAllowList and ECDSAForAll permanently.

Related to https://github.com/letsencrypt/boulder/issues/7535