### PR TITLE
issuerCerts match counterparts in config-next

### DIFF
--- a/test/config/crl-storer.json
+++ b/test/config/crl-storer.json
@@ -25,7 +25,10 @@
 		"issuerCerts": [
 			"test/certs/webpki/int-rsa-a.cert.pem",
 			"test/certs/webpki/int-rsa-b.cert.pem",
-			"test/certs/webpki/int-ecdsa-a.cert.pem"
+			"test/certs/webpki/int-rsa-c.cert.pem",
+			"test/certs/webpki/int-ecdsa-a.cert.pem",
+			"test/certs/webpki/int-ecdsa-b.cert.pem",
+			"test/certs/webpki/int-ecdsa-c.cert.pem"
 		],
 		"s3Endpoint": "http://localhost:4501",
 		"s3Bucket": "lets-encrypt-crls",

--- a/test/config/crl-updater.json
+++ b/test/config/crl-updater.json
@@ -38,7 +38,10 @@
 		"issuerCerts": [
 			"test/certs/webpki/int-rsa-a.cert.pem",
 			"test/certs/webpki/int-rsa-b.cert.pem",
-			"test/certs/webpki/int-ecdsa-a.cert.pem"
+			"test/certs/webpki/int-rsa-c.cert.pem",
+			"test/certs/webpki/int-ecdsa-a.cert.pem",
+			"test/certs/webpki/int-ecdsa-b.cert.pem",
+			"test/certs/webpki/int-ecdsa-c.cert.pem"
 		],
 		"numShards": 10,
 		"shardWidth": "240h",

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -51,7 +51,10 @@
 		"issuerCerts": [
 			"test/certs/webpki/int-rsa-a.cert.pem",
 			"test/certs/webpki/int-rsa-b.cert.pem",
-			"test/certs/webpki/int-ecdsa-a.cert.pem"
+			"test/certs/webpki/int-rsa-c.cert.pem",
+			"test/certs/webpki/int-ecdsa-a.cert.pem",
+			"test/certs/webpki/int-ecdsa-b.cert.pem",
+			"test/certs/webpki/int-ecdsa-c.cert.pem"
 		],
 		"liveSigningPeriod": "60h",
 		"timeout": "4.9s",

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -16,7 +16,10 @@
 		"issuerCerts": [
 			"test/certs/webpki/int-rsa-a.cert.pem",
 			"test/certs/webpki/int-rsa-b.cert.pem",
-			"test/certs/webpki/int-ecdsa-a.cert.pem"
+			"test/certs/webpki/int-rsa-c.cert.pem",
+			"test/certs/webpki/int-ecdsa-a.cert.pem",
+			"test/certs/webpki/int-ecdsa-b.cert.pem",
+			"test/certs/webpki/int-ecdsa-c.cert.pem"
 		],
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",


### PR DESCRIPTION
Makes the `issuerCerts` list in `test/config` match the corresponding list in `test/config-next`. As a result, fixes an issue encountered with `config` integration testing in https://github.com/letsencrypt/boulder/pull/7560 and https://github.com/letsencrypt/boulder/pull/7561.