### PR TITLE
test: Fix Cryptography deprecation warning

### DIFF
--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1402,7 +1402,7 @@ def test_expiration_mailer():
     order = chisel2.auth_and_issue([random_domain()], email=email_addr)
     cert = parse_cert(order)
     # Check that the expiration mailer sends a reminder
-    expiry = cert.not_valid_after
+    expiry = cert.not_valid_after_utc
     no_reminder = expiry + datetime.timedelta(days=-31)
     first_reminder = expiry + datetime.timedelta(days=-13)
     last_reminder = expiry + datetime.timedelta(days=-2)


### PR DESCRIPTION
The `not_valid_after` property was deprecated in favor of `not_valid_after_utc`. Both return a timestamp in UTC time so this seems like a safe lateral move. See [here](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Certificate.not_valid_after) for more information.

```
/boulder/test/v2_integration.py:1405: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.
```