### PR TITLE
sa: Provide a grace period for recently unpaused identifiers

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1359,7 +1359,7 @@ func (ssa *SQLStorageAuthority) PauseIdentifiers(ctx context.Context, req *sapb.
 				// Identifier is already paused.
 				continue
 
-			case entry.UnpausedAt != nil && entry.UnpausedAt.After(ssa.clk.Now().Add(-14*24*time.Hour)):
+			case entry.UnpausedAt.After(ssa.clk.Now().Add(-14*24*time.Hour)):
 				// Previously unpaused less than two weeks ago, skip this identifier.
 				continue
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1295,8 +1295,10 @@ func (ssa *SQLStorageAuthority) UpdateCRLShard(ctx context.Context, req *sapb.Up
 
 // PauseIdentifiers pauses a set of identifiers for the provided account. If an
 // identifier is currently paused, this is a no-op. If an identifier was
-// previously paused and unpaused, it will be repaused. All work is accomplished
-// in a transaction to limit possible race conditions.
+// previously paused and unpaused, it will be repaused unless it was unpaused
+// less than two weeks ago. The response will indicate how many identifiers were
+// paused and how many were repaused. All work is accomplished in a transaction
+// to limit possible race conditions.
 func (ssa *SQLStorageAuthority) PauseIdentifiers(ctx context.Context, req *sapb.PauseRequest) (*sapb.PauseIdentifiersResponse, error) {
 	if core.IsAnyNilOrZero(req.RegistrationID, req.Identifiers) {
 		return nil, errIncompleteRequest
@@ -1355,6 +1357,10 @@ func (ssa *SQLStorageAuthority) PauseIdentifiers(ctx context.Context, req *sapb.
 
 			case entry.UnpausedAt == nil || entry.PausedAt.After(*entry.UnpausedAt):
 				// Identifier is already paused.
+				continue
+
+			case entry.UnpausedAt != nil && entry.UnpausedAt.After(ssa.clk.Now().Add(-14*24*time.Hour)):
+				// Previously unpaused less than two weeks ago, skip this identifier.
 				continue
 
 			case entry.UnpausedAt.After(entry.PausedAt):

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1359,7 +1359,7 @@ func (ssa *SQLStorageAuthority) PauseIdentifiers(ctx context.Context, req *sapb.
 				// Identifier is already paused.
 				continue
 
-			case entry.UnpausedAt.After(ssa.clk.Now().Add(-14*24*time.Hour)):
+			case entry.UnpausedAt.After(ssa.clk.Now().Add(-14 * 24 * time.Hour)):
 				// Previously unpaused less than two weeks ago, skip this identifier.
 				continue
 

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -4414,6 +4414,9 @@ func TestPauseIdentifiers(t *testing.T) {
 		return &t
 	}
 
+	fourWeeksAgo := sa.clk.Now().Add(-4 * 7 * 24 * time.Hour)
+	threeWeeksAgo := sa.clk.Now().Add(-3 * 7 * 24 * time.Hour)
+
 	tests := []struct {
 		name  string
 		state []pausedModel
@@ -4446,8 +4449,8 @@ func TestPauseIdentifiers(t *testing.T) {
 						Type:  identifierTypeToUint[string(identifier.DNS)],
 						Value: "example.com",
 					},
-					PausedAt:   sa.clk.Now().Add(-time.Hour),
-					UnpausedAt: ptrTime(sa.clk.Now().Add(-time.Minute)),
+					PausedAt:   fourWeeksAgo,
+					UnpausedAt: ptrTime(threeWeeksAgo),
 				},
 			},
 			req: &sapb.PauseRequest{
@@ -4465,6 +4468,33 @@ func TestPauseIdentifiers(t *testing.T) {
 			},
 		},
 		{
+			name: "One unpaused entry which was previously paused and unpaused less than 2 weeks ago",
+			state: []pausedModel{
+				{
+					RegistrationID: 1,
+					identifierModel: identifierModel{
+						Type:  identifierTypeToUint[string(identifier.DNS)],
+						Value: "example.com",
+					},
+					PausedAt:   fourWeeksAgo,
+					UnpausedAt: ptrTime(sa.clk.Now().Add(-13 * 24 * time.Hour)),
+				},
+			},
+			req: &sapb.PauseRequest{
+				RegistrationID: 1,
+				Identifiers: []*sapb.Identifier{
+					{
+						Type:  string(identifier.DNS),
+						Value: "example.com",
+					},
+				},
+			},
+			want: &sapb.PauseIdentifiersResponse{
+				Paused:   0,
+				Repaused: 0,
+			},
+		},
+		{
 			name: "An identifier which is currently paused",
 			state: []pausedModel{
 				{
@@ -4473,7 +4503,7 @@ func TestPauseIdentifiers(t *testing.T) {
 						Type:  identifierTypeToUint[string(identifier.DNS)],
 						Value: "example.com",
 					},
-					PausedAt: sa.clk.Now().Add(-time.Hour),
+					PausedAt: fourWeeksAgo,
 				},
 			},
 			req: &sapb.PauseRequest{
@@ -4499,8 +4529,8 @@ func TestPauseIdentifiers(t *testing.T) {
 						Type:  identifierTypeToUint[string(identifier.DNS)],
 						Value: "example.com",
 					},
-					PausedAt:   sa.clk.Now().Add(-time.Hour),
-					UnpausedAt: ptrTime(sa.clk.Now().Add(-time.Minute)),
+					PausedAt:   fourWeeksAgo,
+					UnpausedAt: ptrTime(threeWeeksAgo),
 				},
 				{
 					RegistrationID: 1,
@@ -4508,8 +4538,8 @@ func TestPauseIdentifiers(t *testing.T) {
 						Type:  identifierTypeToUint[string(identifier.DNS)],
 						Value: "example.net",
 					},
-					PausedAt:   sa.clk.Now().Add(-time.Hour),
-					UnpausedAt: ptrTime(sa.clk.Now().Add(-time.Minute)),
+					PausedAt:   fourWeeksAgo,
+					UnpausedAt: ptrTime(threeWeeksAgo),
 				},
 			},
 			req: &sapb.PauseRequest{


### PR DESCRIPTION
SA method PauseIdentifiers skips identifiers unpaused within the last 2 weeks, providing a grace period for operators to fix configuration issues resulting in numerous contiguous validation failures.

Part of #7475