### PR TITLE
Suppress boring nonce log events

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -598,6 +598,9 @@ func (wfe *WebFrontEndImpl) Nonce(
 	// field with the "no-store" directive in responses for the newNonce resource,
 	// in order to prevent caching of this resource.
 	response.Header().Set("Cache-Control", "no-store")
+
+	// No need to log succesful nonce GETs, they're boring.
+	logEvent.Suppress()
 }
 
 // sendError wraps web.SendError

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -599,7 +599,7 @@ func (wfe *WebFrontEndImpl) Nonce(
 	// in order to prevent caching of this resource.
 	response.Header().Set("Cache-Control", "no-store")
 
-	// No need to log succesful nonce GETs, they're boring.
+	// No need to log successful nonce requests, they're boring.
 	logEvent.Suppress()
 }
 


### PR DESCRIPTION
Requests to the new-nonce endpoint make up about 20% of our WFE log lines, but they're uninteresting and largely useless for debugging. Suppress the log event for successful requests to reduce our log volume.