### PR TITLE
ca: Output issuer configuration details at startup

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -188,16 +188,12 @@ func main() {
 		cmd.FailOnError(err, "Failed to load CT Log List")
 	}
 
+	clk := cmd.Clock()
 	issuers := make([]*issuance.Issuer, 0, len(c.CA.Issuance.Issuers))
 	for _, issuerConfig := range c.CA.Issuance.Issuers {
-		issuer, err := issuance.LoadIssuer(issuerConfig, cmd.Clock())
+		issuer, err := issuance.LoadIssuer(issuerConfig, clk)
 		cmd.FailOnError(err, "Loading issuer")
 		issuers = append(issuers, issuer)
-	}
-
-	// Output issuer details here rather than in Issuers loop above to avoid
-	// interleaving with clock logs.
-	for _, issuer := range issuers {
 		logger.Infof("Loaded issuer: name=[%s] keytype=[%s] nameID=[%v] isActive=[%t]", issuer.Name(), issuer.KeyType(), issuer.NameID(), issuer.IsActive())
 	}
 
@@ -228,8 +224,6 @@ func main() {
 
 	tlsConfig, err := c.CA.TLS.Load(scope)
 	cmd.FailOnError(err, "TLS config")
-
-	clk := cmd.Clock()
 
 	conn, err := bgrpc.ClientSetup(c.CA.SAService, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -195,6 +195,12 @@ func main() {
 		issuers = append(issuers, issuer)
 	}
 
+	// Output issuer details here rather than in Issuers loop above to avoid
+	// interleaving with clock logs.
+	for _, issuer := range issuers {
+		logger.Infof("Loaded issuer: name=[%s] keytype=[%s] nameID=[%v] isActive=[%t]", issuer.Name(), issuer.KeyType(), issuer.NameID(), issuer.IsActive())
+	}
+
 	if c.CA.Issuance.DefaultCertificateProfileName == "" {
 		c.CA.Issuance.DefaultCertificateProfileName = "defaultBoulderCertificateProfile"
 	}


### PR DESCRIPTION
As an operator, it's helpful to know what issuers a given CA has at startup time. We already log the default issuer profile for instance. 

Here's a truncated example of what appears in the logs.
```
boulder-ca vJq3lww Loaded issuer: name=[int ecdsa a] keytype=[ECDSA] nameID=[43104258997432926] isActive=[true]
boulder-ca tJGB2wE Loaded issuer: name=[int rsa c] keytype=[RSA] nameID=[56183656833365902] isActive=[false]
```

Related to https://github.com/letsencrypt/boulder/issues/7469