### PR TITLE
Add nameid tool

### DIFF
--- a/tools/nameid/README.md
+++ b/tools/nameid/README.md
@@ -2,8 +2,10 @@
 
 The `nameid` tool displays a statistically-unique small ID which can be computed
 from both CA and end-entity certs to link them together into a validation chain.
-It is computed as a truncated hash over the issuer Subject Name bytes, or over
-the end-entity's Issuer Name bytes, which are required to be equal.
+It is computed as a truncated hash over the issuer Subject Name bytes. It should
+only be used on issuer certificates e.g. [when the CA boolean is
+asserted](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9) which in the
+`//crypto/x509` `Certificate` struct is `IsCA: true`.
 
 For implementation details, please see the `//issuance` package
 [here](https://github.com/letsencrypt/boulder/blob/30c6e592f7f6825c2782b6a7d5da566979445674/issuance/issuer.go#L79-L83).

--- a/tools/nameid/README.md
+++ b/tools/nameid/README.md
@@ -1,0 +1,22 @@
+# Overview
+
+The `nameid` tool displays a statistically-unique small ID which can be computed
+from both CA and end-entity certs to link them together into a validation chain.
+It is computed as a truncated hash over the issuer Subject Name bytes, or over
+the end-entity's Issuer Name bytes, which are required to be equal.
+
+For implementation details, please see the `//issuance` package
+[here](https://github.com/letsencrypt/boulder/blob/30c6e592f7f6825c2782b6a7d5da566979445674/issuance/issuer.go#L79-L83).
+
+# Usage
+
+```
+# Display help
+go run ./tools/nameid/nameid.go -h
+
+# Output the certificate path and nameid, one per line
+go run ./tools/nameid/nameid.go /path/to/cert1.pem /path/to/cert2.pem ...
+
+# Output just the nameid, one per line
+go run ./tools/nameid/nameid.go -s /path/to/cert1.pem /path/to/cert2.pem ...
+```

--- a/tools/nameid/nameid.go
+++ b/tools/nameid/nameid.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/letsencrypt/boulder/issuance"
+)
+
+func usage() {
+	fmt.Printf("Usage: %s [OPTIONS] cert1.pem certN.pem certN+1.pem\n", os.Args[0])
+}
+
+func main() {
+	var shorthandFlag = flag.Bool("s", false, "Display only the nameid for each given certificate")
+	flag.Parse()
+
+	if len(os.Args) <= 1 {
+		usage()
+		os.Exit(1)
+	}
+
+	for _, cert := range flag.Args() {
+		issuer, err := issuance.LoadCertificate(cert)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if *shorthandFlag {
+			fmt.Printf("%d\n", issuer.NameID())
+		} else {
+			fmt.Printf("%s - %d\n", cert, issuer.NameID())
+		}
+	}
+}

--- a/tools/nameid/nameid.go
+++ b/tools/nameid/nameid.go
@@ -13,7 +13,7 @@ func usage() {
 }
 
 func main() {
-	var shorthandFlag = flag.Bool("s", false, "Display only the nameid for each given certificate")
+	var shorthandFlag = flag.Bool("s", false, "Display only the nameid for each given issuer certificate")
 	flag.Parse()
 
 	if len(os.Args) <= 1 {
@@ -24,18 +24,14 @@ func main() {
 	for _, certFile := range flag.Args() {
 		issuer, err := issuance.LoadCertificate(certFile)
 		if err != nil {
-			if *shorthandFlag {
-				fmt.Println(err)
-			} else {
-				fmt.Printf("%s\t- %v", certFile, err)
-			}
+			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
 
 		if *shorthandFlag {
-			fmt.Printf("%d\n", issuer.NameID())
+			fmt.Println(issuer.NameID())
 		} else {
-			fmt.Printf("%s\t- %d\n", certFile, issuer.NameID())
+			fmt.Printf("%s: %d\n", certFile, issuer.NameID())
 		}
 	}
 }

--- a/tools/nameid/nameid.go
+++ b/tools/nameid/nameid.go
@@ -9,7 +9,7 @@ import (
 )
 
 func usage() {
-	fmt.Printf("Usage: %s [OPTIONS] cert1.pem certN.pem certN+1.pem\n", os.Args[0])
+	fmt.Printf("Usage: %s [OPTIONS] [CERTIFICATE(S)]\n", os.Args[0])
 }
 
 func main() {
@@ -21,17 +21,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	for _, cert := range flag.Args() {
-		issuer, err := issuance.LoadCertificate(cert)
+	for _, certFile := range flag.Args() {
+		issuer, err := issuance.LoadCertificate(certFile)
 		if err != nil {
-			fmt.Println(err)
+			if *shorthandFlag {
+				fmt.Println(err)
+			} else {
+				fmt.Printf("%s\t- %v", certFile, err)
+			}
 			os.Exit(1)
 		}
 
 		if *shorthandFlag {
 			fmt.Printf("%d\n", issuer.NameID())
 		} else {
-			fmt.Printf("%s\t- %d\n", cert, issuer.NameID())
+			fmt.Printf("%s\t- %d\n", certFile, issuer.NameID())
 		}
 	}
 }

--- a/tools/nameid/nameid.go
+++ b/tools/nameid/nameid.go
@@ -9,7 +9,7 @@ import (
 )
 
 func usage() {
-	fmt.Printf("Usage: %s [OPTIONS] [CERTIFICATE(S)]\n", os.Args[0])
+	fmt.Printf("Usage: %s [OPTIONS] [ISSUER CERTIFICATE(S)]\n", os.Args[0])
 }
 
 func main() {

--- a/tools/nameid/nameid.go
+++ b/tools/nameid/nameid.go
@@ -31,7 +31,7 @@ func main() {
 		if *shorthandFlag {
 			fmt.Printf("%d\n", issuer.NameID())
 		} else {
-			fmt.Printf("%s - %d\n", cert, issuer.NameID())
+			fmt.Printf("%s\t- %d\n", cert, issuer.NameID())
 		}
 	}
 }


### PR DESCRIPTION
Adds a nameid tool to the boulder tools directory for SRE use. The existing local and github CI framework correctly catches build failures of this directory.

Examples of usage:
```
$ go run ./tools/nameid/nameid.go test/certs/webpki/int-ecdsa-c.cert.pem test/certs/webpki/int-rsa-a.cert.pem 
test/certs/webpki/int-ecdsa-c.cert.pem: 56560759852043581
test/certs/webpki/int-rsa-a.cert.pem: 29947985078257530

$ go run ./tools/nameid/nameid.go -s test/certs/webpki/int-ecdsa-c.cert.pem test/certs/webpki/int-rsa-a.cert.pem 
56560759852043581
29947985078257530
```

Fixes https://github.com/letsencrypt/boulder/issues/7469