### PR TITLE
test: Remove loop variable rebinding

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -342,9 +342,6 @@ func TestIssuePrecertificate(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		// TODO(#7454) Remove this rebinding
-		testCase := testCase
-
 		// The loop through the issuance modes must be inside the loop through
 		// |testCases| because the "certificate-for-precertificate" tests use
 		// the precertificates previously generated from the preceding
@@ -697,8 +694,6 @@ func TestProfiles(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		// TODO(#7454) Remove this rebinding
-		tc := tc
 		// This is handled by boulder-ca, not the CA package.
 		if tc.defaultName == "" {
 			tc.defaultName = testCtx.defaultCertProfileName
@@ -809,8 +804,6 @@ func TestInvalidCSRs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		// TODO(#7454) Remove this rebinding
-		testCase := testCase
 		testCtx := setup(t)
 		sa := &mockSA{}
 		ca, err := NewCertificateAuthorityImpl(
@@ -1319,8 +1312,6 @@ func TestVerifyTBSCertIsDeterministic(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		// TODO(#7454) Remove this rebinding
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			err := tbsCertIsDeterministic(testCase.lintCertBytes, testCase.leafCertBytes)

--- a/crl/idp/idp_test.go
+++ b/crl/idp/idp_test.go
@@ -27,7 +27,6 @@ func TestMakeUserCertsExt(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := MakeUserCertsExt(tc.urls)

--- a/issuance/crl_test.go
+++ b/issuance/crl_test.go
@@ -60,7 +60,6 @@ func TestNewCRLProfile(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			actual, err := NewCRLProfile(tc.config)

--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -78,7 +78,6 @@ func TestLoadCertificate(t *testing.T) {
 		{"happy path", "../test/hierarchy/int-e1.cert.pem", ""},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := LoadCertificate(tc.path)
@@ -122,7 +121,6 @@ func TestLoadSigner(t *testing.T) {
 		// keys in it don't match the fakeKey we generated above.
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := loadSigner(tc.loc, fakeKey.Public())
@@ -180,7 +178,6 @@ func TestNewIssuerKeyUsage(t *testing.T) {
 		{"all three", x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature, ""},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := newIssuer(

--- a/linter/lints/common_test.go
+++ b/linter/lints/common_test.go
@@ -3,9 +3,10 @@ package lints
 import (
 	"testing"
 
-	"github.com/letsencrypt/boulder/test"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
+
+	"github.com/letsencrypt/boulder/test"
 )
 
 var onlyContainsUserCertsTag = asn1.Tag(1).ContextSpecific()
@@ -78,7 +79,6 @@ func TestReadOptionalASN1BooleanWithTag(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/ratelimits/names_test.go
+++ b/ratelimits/names_test.go
@@ -192,7 +192,6 @@ func TestValidateIdForName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s/%s", tc.limit, tc.desc), func(t *testing.T) {
 			t.Parallel()
 			err := validateIdForName(tc.limit, tc.id)

--- a/test/integration/bad_key_test.go
+++ b/test/integration/bad_key_test.go
@@ -43,7 +43,6 @@ func TestFermat(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -1270,8 +1270,6 @@ func TestAccountURIMatches(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		// TODO(#7454) Remove this rebinding
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := caaAccountURIMatches(tc.params, tc.prefixes, tc.id)
@@ -1387,8 +1385,6 @@ func TestValidationMethodMatches(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		// TODO(#7454) Remove this rebinding
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := caaValidationMethodMatches(tc.params, tc.method)
@@ -1539,8 +1535,6 @@ func TestExtractIssuerDomainAndParameters(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		// TODO(#7454) Remove this rebinding
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			gotDomain, gotParameters, gotErr := parseCAARecord(&dns.CAA{Value: tc.value})


### PR DESCRIPTION
[Gopls](https://github.com/golang/go/issues/66876) had a recent update which fixed my text editor from complaining about the "loop variable being captured by func literal".

Fixes https://github.com/letsencrypt/boulder/issues/7454