### PR TITLE
Update eggsampler/acme to v3.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.24
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
 	github.com/aws/smithy-go v1.20.3
-	github.com/eggsampler/acme/v3 v3.6.0
+	github.com/eggsampler/acme/v3 v3.6.1
 	github.com/go-jose/go-jose/v4 v4.0.1
 	github.com/go-logr/stdr v1.2.2
 	github.com/go-sql-driver/mysql v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/eggsampler/acme/v3 v3.6.0 h1:TbQYoWlpl62fTdJq5i2LHBDY6h3LDU3pPAdyoUSQMOc=
-github.com/eggsampler/acme/v3 v3.6.0/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/eggsampler/acme/v3 v3.6.1 h1:MPGfIpvSSnsS318quL+25m5dDpV0xyd6cZ98TZvHCM0=
 github.com/eggsampler/acme/v3 v3.6.1/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/eggsampler/acme/v3 v3.6.0 h1:TbQYoWlpl62fTdJq5i2LHBDY6h3LDU3pPAdyoUSQMOc=
 github.com/eggsampler/acme/v3 v3.6.0/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
+github.com/eggsampler/acme/v3 v3.6.1 h1:MPGfIpvSSnsS318quL+25m5dDpV0xyd6cZ98TZvHCM0=
+github.com/eggsampler/acme/v3 v3.6.1/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/vendor/github.com/eggsampler/acme/v3/acme.go
+++ b/vendor/github.com/eggsampler/acme/v3/acme.go
@@ -74,8 +74,9 @@ func (c Client) getPollingDurations() (time.Duration, time.Duration) {
 	return pollInterval, pollTimeout
 }
 
-// Helper function to have a central point for performing http requests.
-// Stores any returned nonces in the stack.
+// Helper function to have a central point for performing http requests. Stores
+// any returned nonces in the stack. The caller is responsible for closing the
+// body so they can read the response.
 func (c Client) do(req *http.Request, addNonce bool) (*http.Response, error) {
 	// identifier for this client, as well as the default go user agent
 	if c.userAgentSuffix != "" {
@@ -100,7 +101,8 @@ func (c Client) do(req *http.Request, addNonce bool) (*http.Response, error) {
 	return resp, nil
 }
 
-// Helper function to perform an HTTP get request and read the body.
+// Helper function to perform an HTTP get request and read the body. The caller
+// is responsible for closing the body so they can read the response.
 func (c Client) getRaw(url string, expectedStatus ...int) (*http.Response, []byte, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -125,7 +127,8 @@ func (c Client) getRaw(url string, expectedStatus ...int) (*http.Response, []byt
 	return resp, body, nil
 }
 
-// Helper function for performing a http get on an acme resource.
+// Helper function for performing a http get on an acme resource. The caller is
+// responsible for closing the body so they can read the response.
 func (c Client) get(url string, out interface{}, expectedStatus ...int) (*http.Response, error) {
 	resp, body, err := c.getRaw(url, expectedStatus...)
 	if err != nil {
@@ -165,8 +168,9 @@ func (c Client) nonce() (string, error) {
 	return nonce, nil
 }
 
-// Helper function to perform an HTTP post request and read the body.
-// Will attempt to retry if error is badNonce
+// Helper function to perform an HTTP post request and read the body. Will
+// attempt to retry if error is badNonce. The caller is responsible for closing
+// the body so they can read the response.
 func (c Client) postRaw(retryCount int, requestURL, kid string, privateKey crypto.Signer, payload interface{}, expectedStatus []int) (*http.Response, []byte, error) {
 	nonce, err := c.nonce()
 	if err != nil {
@@ -215,7 +219,8 @@ func (c Client) postRaw(retryCount int, requestURL, kid string, privateKey crypt
 	return resp, body, nil
 }
 
-// Helper function for performing a http post to an acme resource.
+// Helper function for performing a http post to an acme resource. The caller is
+// responsible for closing the body so they can read the response.
 func (c Client) post(requestURL, keyID string, privateKey crypto.Signer, payload interface{}, out interface{}, expectedStatus ...int) (*http.Response, error) {
 	resp, body, err := c.postRaw(0, requestURL, keyID, privateKey, payload, expectedStatus)
 	if err != nil {
@@ -240,7 +245,7 @@ func (c Client) post(requestURL, keyID string, privateKey crypto.Signer, payload
 
 var regLink = regexp.MustCompile(`<(.+?)>;\s*rel="(.+?)"`)
 
-// Fetches a http Link header from a http response
+// Fetches a http Link header from an http response and closes the body.
 func fetchLink(resp *http.Response, wantedLink string) string {
 	if resp == nil {
 		return ""

--- a/vendor/github.com/eggsampler/acme/v3/ari.go
+++ b/vendor/github.com/eggsampler/acme/v3/ari.go
@@ -39,6 +39,7 @@ func (c Client) GetRenewalInfo(cert *x509.Certificate) (RenewalInfo, error) {
 	if err != nil {
 		return ri, err
 	}
+	defer resp.Body.Close()
 
 	ri.RetryAfter, err = parseRetryAfter(resp.Header.Get("Retry-After"))
 	return ri, err

--- a/vendor/github.com/eggsampler/acme/v3/order.go
+++ b/vendor/github.com/eggsampler/acme/v3/order.go
@@ -65,6 +65,8 @@ func (c Client) ReplacementOrder(account Account, oldCert *x509.Certificate, ide
 	if err != nil {
 		return newOrderResp, err
 	}
+	defer resp.Body.Close()
+
 	newOrderResp.URL = resp.Header.Get("Location")
 	return newOrderResp, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -135,7 +135,7 @@ github.com/cespare/xxhash/v2
 # github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 ## explicit
 github.com/dgryski/go-rendezvous
-# github.com/eggsampler/acme/v3 v3.6.0
+# github.com/eggsampler/acme/v3 v3.6.1
 ## explicit; go 1.11
 github.com/eggsampler/acme/v3
 # github.com/felixge/httpsnoop v1.0.4


### PR DESCRIPTION
This change has negligible benefits, but [v3.6.1](https://github.com/eggsampler/acme/releases/tag/v3.6.1) does contain my ARI support for Pebble which I think is pretty rad.