### PR TITLE
config: Add SFE as RPC client of SARO and RA in test/config

### DIFF
--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -95,8 +95,8 @@
 						"admin-revoker.boulder",
 						"bad-key-revoker.boulder",
 						"ocsp-responder.boulder",
-						"wfe.boulder",
-						"sfe.boulder"
+						"sfe.boulder",
+						"wfe.boulder"
 					]
 				},
 				"grpc.health.v1.Health": {

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -95,7 +95,8 @@
 						"admin-revoker.boulder",
 						"bad-key-revoker.boulder",
 						"ocsp-responder.boulder",
-						"wfe.boulder"
+						"wfe.boulder",
+						"sfe.boulder"
 					]
 				},
 				"grpc.health.v1.Health": {

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -35,7 +35,8 @@
 						"admin-revoker.boulder",
 						"crl-updater.boulder",
 						"ocsp-responder.boulder",
-						"wfe.boulder"
+						"wfe.boulder",
+						"sfe.boulder"
 					]
 				},
 				"grpc.health.v1.Health": {

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -35,8 +35,8 @@
 						"admin-revoker.boulder",
 						"crl-updater.boulder",
 						"ocsp-responder.boulder",
-						"wfe.boulder",
-						"sfe.boulder"
+						"sfe.boulder",
+						"wfe.boulder"
 					]
 				},
 				"grpc.health.v1.Health": {


### PR DESCRIPTION
Add SFE as an RPC client of SARO and RA in `test/config`. #7500 added same in `test/config-next`.