### PR TITLE
Remove SKID from end-entity certificates

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -3,12 +3,9 @@ package ca
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/gob"
 	"encoding/hex"
 	"errors"
@@ -509,29 +506,6 @@ func (ca *certificateAuthorityImpl) generateSerialNumberAndValidity() (*big.Int,
 	return serialBigInt, validity, nil
 }
 
-// generateSKID computes the Subject Key Identifier using one of the methods in
-// RFC 7093 Section 2 Additional Methods for Generating Key Identifiers:
-// The keyIdentifier [may be] composed of the leftmost 160-bits of the
-// SHA-256 hash of the value of the BIT STRING subjectPublicKey
-// (excluding the tag, length, and number of unused bits).
-func generateSKID(pk crypto.PublicKey) ([]byte, error) {
-	pkBytes, err := x509.MarshalPKIXPublicKey(pk)
-	if err != nil {
-		return nil, err
-	}
-
-	var pkixPublicKey struct {
-		Algo      pkix.AlgorithmIdentifier
-		BitString asn1.BitString
-	}
-	if _, err := asn1.Unmarshal(pkBytes, &pkixPublicKey); err != nil {
-		return nil, err
-	}
-
-	skid := sha256.Sum256(pkixPublicKey.BitString.Bytes)
-	return skid[0:20:20], nil
-}
-
 func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, serialBigInt *big.Int, validity validity) ([]byte, *certProfileWithID, error) {
 	// The CA must check if it is capable of issuing for the given certificate
 	// profile name. The name is checked here instead of the hash because the RA
@@ -576,11 +550,6 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		return nil, nil, err
 	}
 
-	subjectKeyId, err := generateSKID(csr.PublicKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("computing subject key ID: %w", err)
-	}
-
 	serialHex := core.SerialToString(serialBigInt)
 
 	ca.log.AuditInfof("Signing precert: serial=[%s] regID=[%d] names=[%s] csr=[%s]",
@@ -589,7 +558,6 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 	names := csrlib.NamesFromCSR(csr)
 	req := &issuance.IssuanceRequest{
 		PublicKey:         csr.PublicKey,
-		SubjectKeyId:      subjectKeyId,
 		Serial:            serialBigInt.Bytes(),
 		DNSNames:          names.SANs,
 		CommonName:        names.CN,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1216,18 +1216,6 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 	test.AssertMetricWithLabelsEquals(t, ca.metrics.signatureCount, prometheus.Labels{"purpose": "certificate", "status": "success"}, 0)
 }
 
-func TestGenerateSKID(t *testing.T) {
-	t.Parallel()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	test.AssertNotError(t, err, "Error generating key")
-
-	sha256skid, err := generateSKID(key.Public())
-	test.AssertNotError(t, err, "Error generating SKID")
-	test.AssertEquals(t, len(sha256skid), 20)
-	test.AssertEquals(t, cap(sha256skid), 20)
-	features.Reset()
-}
-
 func TestVerifyTBSCertIsDeterministic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The Subject Key Identifier extension is NOT RECOMMENDED by the Baseline Requirements because it serves no purpose in Subscriber Certificates. It is required in CA Certificates to facilitate chain-building, but no one builds chains up to end-entity certs, so it is just extra bytes.

This change only removes the SKID from precertificate issuance requests. It still allows the SKID to appear in final certificates whose precertificate contained a SKID, to ensure safe deployability. It will be followed by another change which finishes the clean-up.

Fixes https://github.com/letsencrypt/boulder/issues/7446

DO NOT MERGE until we have a comms plan in place