### PR TITLE
Advertise available profiles in directory resource

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -155,11 +155,11 @@ type Config struct {
 		// the CA and RA configurations.
 		MaxNames int `validate:"min=0,max=100"`
 
-		// CertificateProfileNames is the list of acceptable certificate profile
-		// names for newOrder requests. Requests with a profile name not in this
-		// list will be rejected. This field is optional; if unset, no profile
-		// names are accepted.
-		CertificateProfileNames []string `validate:"omitempty,dive,alphanum,min=1,max=32"`
+		// CertProfiles is a map of acceptable certificate profile names to
+		// descriptions (perhaps including URLs) of those profiles. NewOrder
+		// Requests with a profile name not present in this map will be rejected.
+		// This field is optional; if unset, no profile names are accepted.
+		CertProfiles map[string]string `validate:"omitempty,dive,keys,alphanum,min=1,max=32,endkeys"`
 	}
 
 	Syslog        cmd.SyslogConfig
@@ -355,7 +355,7 @@ func main() {
 		limiter,
 		txnBuilder,
 		maxNames,
-		c.WFE.CertificateProfileNames,
+		c.WFE.CertProfiles,
 	)
 	cmd.FailOnError(err, "Unable to create WFE")
 

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -131,9 +131,9 @@
 			"TrackReplacementCertificatesARI": true,
 			"CheckRenewalExemptionAtWFE": true
 		},
-		"certificateProfileNames": [
-			"defaultBoulderCertificateProfile"
-		]
+		"certProfiles": {
+			"defaultBoulderCertificateProfile": "The normal profile you know and love"
+		}
 	},
 	"syslog": {
 		"stdoutlevel": 4,

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -407,7 +407,7 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 		limiter,
 		txnBuilder,
 		100,
-		[]string{""},
+		nil,
 	)
 	test.AssertNotError(t, err, "Unable to create WFE")
 
@@ -3816,7 +3816,7 @@ func TestNewOrderWithProfile(t *testing.T) {
 	expectProfileName := "test-profile"
 	wfe.ra = &mockRA{expectProfileName: expectProfileName}
 	mux := wfe.Handler(metrics.NoopRegisterer)
-	wfe.certificateProfileNames = []string{expectProfileName}
+	wfe.certProfiles = map[string]string{expectProfileName: "description"}
 
 	// Test that the newOrder endpoint returns the proper error if an invalid
 	// profile is specified.
@@ -3855,8 +3855,8 @@ func TestNewOrderWithProfile(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to unmarshal order response")
 	test.AssertEquals(t, errorResp1["status"], "valid")
 
-	// Set the acceptable profiles to an empty list, the WFE should no longer accept any profiles.
-	wfe.certificateProfileNames = []string{}
+	// Set the acceptable profiles to the empty set, the WFE should no longer accept any profiles.
+	wfe.certProfiles = map[string]string{}
 	responseWriter = httptest.NewRecorder()
 	r = signAndPost(signer, newOrderPath, "http://localhost"+newOrderPath, validOrderBody)
 	mux.ServeHTTP(responseWriter, r)


### PR DESCRIPTION
Change the way profiles are configured at the WFE to allow them to be accompanied by descriptive strings. Augment the construction of the directory resource's "meta" sub-object to include these profile names and descriptions.

This config swap is safe, since no Boulder WFE instance is configured with `CertificateProfileNames` yet.

Fixes https://github.com/letsencrypt/boulder/issues/7602