### PR TITLE
Remove CAA-rechecking dead code

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1896,10 +1896,6 @@ func TestRecheckCAADates(t *testing.T) {
 	err = ra.checkAuthorizationsCAA(context.Background(), Registration.Id, []string{"novalidationtime.com"}, authzs, fc.Now())
 	test.AssertEquals(t, err.Error(), "authorization's challenge has no validated timestamp for: id noval")
 
-	// Test to make sure the authorization lifetime codepath was not used
-	// to determine if CAA needed recheck.
-	test.AssertMetricWithLabelsEquals(t, ra.recheckCAAUsedAuthzLifetime, prometheus.Labels{}, 0)
-
 	// We expect that "recent.com" is not checked because its mock authorization
 	// isn't expired
 	if _, present := recorder.names["recent.com"]; present {


### PR DESCRIPTION
This code path was a safety net to ensure that CAA got rechecked if the authorization was going to expire less than 30d+7h from now, i.e. if the authorization had originally been checked more than 7h ago. The metrics show that, as expected, this code path has not been executed in living memory, because all situations in which it might be hit instead hit the preceding `if staleCAA` clause.