### PR TITLE
RA: Pass requested new-order profile through to SA

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2521,8 +2521,9 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 			return nil, errIncompleteGRPCResponse
 		}
 
-		// Only re-use the order if the profile matches.
-		if newOrder.CertificateProfileName == "" || existingOrder.CertificateProfileName == newOrder.CertificateProfileName {
+		// Only re-use the order if the profile (even if it is just the empty
+		// string, leaving us to choose a default profile) matches.
+		if existingOrder.CertificateProfileName == newOrder.CertificateProfileName {
 			// Track how often we reuse an existing order and how old that order is.
 			ra.orderAges.WithLabelValues("NewOrder").Observe(ra.clk.Since(existingOrder.Created.AsTime()).Seconds())
 			return existingOrder, nil

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2049,13 +2049,15 @@ func TestNewOrder(t *testing.T) {
 
 	now := fc.Now()
 	orderA, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
-		Names:          []string{"b.com", "a.com", "a.com", "C.COM"},
+		RegistrationID:         Registration.Id,
+		CertificateProfileName: "test",
+		Names:                  []string{"b.com", "a.com", "a.com", "C.COM"},
 	})
 	test.AssertNotError(t, err, "ra.NewOrder failed")
 	test.AssertEquals(t, orderA.RegistrationID, int64(1))
 	test.AssertEquals(t, orderA.Expires.AsTime(), now.Add(time.Hour))
 	test.AssertEquals(t, len(orderA.Names), 3)
+	test.AssertEquals(t, orderA.CertificateProfileName, "test")
 	// We expect the order names to have been sorted, deduped, and lowercased
 	test.AssertDeepEquals(t, orderA.Names, []string{"a.com", "b.com", "c.com"})
 	test.AssertEquals(t, orderA.Id, int64(1))
@@ -2171,6 +2173,16 @@ func TestNewOrderReuse(t *testing.T) {
 				Names:          names,
 			},
 			// We do not expect reuse because the order regID differs from firstOrder
+			ExpectReuse: false,
+		},
+		{
+			Name: "Duplicate order, different profile",
+			OrderReq: &rapb.NewOrderRequest{
+				RegistrationID:         Registration.Id,
+				CertificateProfileName: "different",
+				Names:                  names,
+			},
+			// We do not expect reuse because the profile name differs from firstOrder
 			ExpectReuse: false,
 		},
 		{


### PR DESCRIPTION
When receiving a NewOrder request from the WFE, pass the specified profile name (if any) through to the SA for storage. Also, when retrieving previous orders for potential re-use, don't reuse them unless they have the same profile name (including the empty/default profile name).

Fixes https://github.com/letsencrypt/boulder/issues/7607