### PR TITLE
Deprecate AllowCTPoison and AllowSCTList profile settings

### DIFF
--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -27,9 +27,21 @@ import (
 
 // ProfileConfig describes the certificate issuance constraints for all issuers.
 type ProfileConfig struct {
+	// AllowMustStaple, when false, causes all IssuanceRequests which specify the
+	// OCSP Must Staple extension to be rejected.
 	AllowMustStaple bool
-	AllowCTPoison   bool
-	AllowSCTList    bool
+	// AllowCTPoison, when false, causes all IssuanceRequests which want the
+	// CT Poison extension to be rejected.
+	// Deprecated: We will always allow the CT Poison extension because it is
+	// mandated for Precertificates. This boolean has no effect.
+	AllowCTPoison bool
+	// AllowSCTList, when false, causes all IssuanceRequests which include SCTs
+	// to be rejected.
+	// Deprecated: We intend to include SCTs in all final Certificates for the
+	// foreseeable future. This boolean has no effect.
+	AllowSCTList bool
+	// AllowCommonName, when false, causes all IssuanceRequests which specify a CN
+	// to be rejected.
 	AllowCommonName bool
 
 	MaxValidityPeriod   config.Duration
@@ -47,8 +59,6 @@ type PolicyConfig struct {
 // Profile is the validated structure created by reading in ProfileConfigs and IssuerConfigs
 type Profile struct {
 	allowMustStaple bool
-	allowCTPoison   bool
-	allowSCTList    bool
 	allowCommonName bool
 
 	maxBackdate time.Duration
@@ -61,8 +71,6 @@ type Profile struct {
 func NewProfile(profileConfig ProfileConfig, lints lint.Registry) (*Profile, error) {
 	sp := &Profile{
 		allowMustStaple: profileConfig.AllowMustStaple,
-		allowCTPoison:   profileConfig.AllowCTPoison,
-		allowSCTList:    profileConfig.AllowSCTList,
 		allowCommonName: profileConfig.AllowCommonName,
 		maxBackdate:     profileConfig.MaxValidityBackdate.Duration,
 		maxValidity:     profileConfig.MaxValidityPeriod.Duration,
@@ -91,14 +99,6 @@ func (i *Issuer) requestValid(clk clock.Clock, prof *Profile, req *IssuanceReque
 
 	if !prof.allowMustStaple && req.IncludeMustStaple {
 		return errors.New("must-staple extension cannot be included")
-	}
-
-	if !prof.allowCTPoison && req.IncludeCTPoison {
-		return errors.New("ct poison extension cannot be included")
-	}
-
-	if !prof.allowSCTList && req.sctList != nil {
-		return errors.New("sct list extension cannot be included")
 	}
 
 	if req.IncludeCTPoison && req.sctList != nil {

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -30,15 +30,13 @@ type ProfileConfig struct {
 	// AllowMustStaple, when false, causes all IssuanceRequests which specify the
 	// OCSP Must Staple extension to be rejected.
 	AllowMustStaple bool
-	// AllowCTPoison, when false, causes all IssuanceRequests which want the
-	// CT Poison extension to be rejected.
+	// AllowCTPoison has no effect.
 	// Deprecated: We will always allow the CT Poison extension because it is
-	// mandated for Precertificates. This boolean has no effect.
+	// mandated for Precertificates.
 	AllowCTPoison bool
-	// AllowSCTList, when false, causes all IssuanceRequests which include SCTs
-	// to be rejected.
+	// AllowSCTList has no effect.
 	// Deprecated: We intend to include SCTs in all final Certificates for the
-	// foreseeable future. This boolean has no effect.
+	// foreseeable future.
 	AllowSCTList bool
 	// AllowCommonName, when false, causes all IssuanceRequests which specify a CN
 	// to be rejected.

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -93,40 +93,11 @@ func TestRequestValid(t *testing.T) {
 			expectedError: "must-staple extension cannot be included",
 		},
 		{
-			name: "ct poison not allowed",
+			name: "both sct list and ct poison provided",
 			issuer: &Issuer{
 				active: true,
 			},
 			profile: &Profile{},
-			request: &IssuanceRequest{
-				PublicKey:       &ecdsa.PublicKey{},
-				SubjectKeyId:    goodSKID,
-				IncludeCTPoison: true,
-			},
-			expectedError: "ct poison extension cannot be included",
-		},
-		{
-			name: "sct list not allowed",
-			issuer: &Issuer{
-				active: true,
-			},
-			profile: &Profile{},
-			request: &IssuanceRequest{
-				PublicKey:    &ecdsa.PublicKey{},
-				SubjectKeyId: goodSKID,
-				sctList:      []ct.SignedCertificateTimestamp{},
-			},
-			expectedError: "sct list extension cannot be included",
-		},
-		{
-			name: "sct list and ct poison not allowed",
-			issuer: &Issuer{
-				active: true,
-			},
-			profile: &Profile{
-				allowCTPoison: true,
-				allowSCTList:  true,
-			},
 			request: &IssuanceRequest{
 				PublicKey:       &ecdsa.PublicKey{},
 				SubjectKeyId:    goodSKID,
@@ -263,7 +234,24 @@ func TestRequestValid(t *testing.T) {
 			expectedError: "serial must be between 9 and 19 bytes",
 		},
 		{
-			name: "good",
+			name: "good with poison",
+			issuer: &Issuer{
+				active: true,
+			},
+			profile: &Profile{
+				maxValidity: time.Hour * 2,
+			},
+			request: &IssuanceRequest{
+				PublicKey:       &ecdsa.PublicKey{},
+				SubjectKeyId:    goodSKID,
+				NotBefore:       fc.Now(),
+				NotAfter:        fc.Now().Add(time.Hour),
+				Serial:          []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				IncludeCTPoison: true,
+			},
+		},
+		{
+			name: "good with scts",
 			issuer: &Issuer{
 				active: true,
 			},
@@ -276,6 +264,7 @@ func TestRequestValid(t *testing.T) {
 				NotBefore:    fc.Now(),
 				NotAfter:     fc.Now().Add(time.Hour),
 				Serial:       []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				sctList:      []ct.SignedCertificateTimestamp{},
 			},
 		},
 	}

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -46,8 +46,6 @@
 			"certProfiles": {
 				"defaultBoulderCertificateProfile": {
 					"allowMustStaple": true,
-					"allowCTPoison": true,
-					"allowSCTList": true,
 					"allowCommonName": true,
 					"policies": [
 						{


### PR DESCRIPTION
These profile variables are set to "true" everywhere, and we have no intention of ever setting them to "false" anywhere. Deprecate them so that they can be removed in the future, and to reduce the chances of confusion when new profile variables are introduced in the near future.

Part of https://github.com/letsencrypt/boulder/issues/7610

IN-10497 tracks the corresponding production config changes