### PR TITLE
Profiles: replace AllowCommonName with OmitCommonName

### DIFF
--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -24,9 +24,6 @@ import (
 
 func defaultProfileConfig() ProfileConfig {
 	return ProfileConfig{
-		AllowCommonName:     true,
-		AllowCTPoison:       true,
-		AllowSCTList:        true,
 		AllowMustStaple:     true,
 		MaxValidityPeriod:   config.Duration{Duration: time.Hour},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -44,9 +44,19 @@
 		"issuance": {
 			"defaultCertificateProfileName": "defaultBoulderCertificateProfile",
 			"certProfiles": {
-				"defaultBoulderCertificateProfile": {
+				"legacy": {
 					"allowMustStaple": true,
-					"allowCommonName": true,
+					"policies": [
+						{
+							"oid": "2.23.140.1.2.1"
+						}
+					],
+					"maxValidityPeriod": "7776000s",
+					"maxValidityBackdate": "1h5m"
+				},
+				"modern": {
+					"allowMustStaple": true,
+					"omitCommonName": true,
 					"policies": [
 						{
 							"oid": "2.23.140.1.2.1"

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -42,7 +42,7 @@
 			"hostOverride": "sa.boulder"
 		},
 		"issuance": {
-			"defaultCertificateProfileName": "defaultBoulderCertificateProfile",
+			"defaultCertificateProfileName": "legacy",
 			"certProfiles": {
 				"legacy": {
 					"allowMustStaple": true,


### PR DESCRIPTION
Add a new profile config key named "OmitCommonName" which, if set to `true`, causes the issuance package to exclude the CN from the resulting certificate even if the initiating IssuanceRequest specified one. Deprecate the old "AllowCommonName" config key, so that it no longer has any effect, rather than causing the issuance package to fully reject IssuanceRequests containing a CN.

This allows for more graceful variation between profiles, since we know that excluding the Common Name is always safe.

Part of https://github.com/letsencrypt/boulder/issues/7610

DO NOT MERGE before https://github.com/letsencrypt/boulder/pull/7611