### PR TITLE
Use profile to determine backdate and validity

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -127,14 +127,12 @@ type certificateAuthorityImpl struct {
 	issuers      issuerMaps
 	certProfiles certProfilesMaps
 
-	prefix         int // Prepended to the serial number
-	validityPeriod time.Duration
-	backdate       time.Duration
-	maxNames       int
-	keyPolicy      goodkey.KeyPolicy
-	clk            clock.Clock
-	log            blog.Logger
-	metrics        *caMetrics
+	prefix    int // Prepended to the serial number
+	maxNames  int
+	keyPolicy goodkey.KeyPolicy
+	clk       clock.Clock
+	log       blog.Logger
+	metrics   *caMetrics
 }
 
 var _ capb.CertificateAuthorityServer = (*certificateAuthorityImpl)(nil)
@@ -246,8 +244,6 @@ func NewCertificateAuthorityImpl(
 	defaultCertProfileName string,
 	certificateProfiles map[string]issuance.ProfileConfig,
 	lints lint.Registry,
-	certExpiry time.Duration,
-	certBackdate time.Duration,
 	serialPrefix int,
 	maxNames int,
 	keyPolicy goodkey.KeyPolicy,
@@ -257,13 +253,6 @@ func NewCertificateAuthorityImpl(
 ) (*certificateAuthorityImpl, error) {
 	var ca *certificateAuthorityImpl
 	var err error
-
-	// TODO(briansmith): Make the backdate setting mandatory after the
-	// production ca.json has been updated to include it. Until then, manually
-	// default to 1h, which is the backdating duration we currently use.
-	if certBackdate == 0 {
-		certBackdate = time.Hour
-	}
 
 	if serialPrefix < 1 || serialPrefix > 127 {
 		err = errors.New("serial prefix must be between 1 and 127")
@@ -285,18 +274,16 @@ func NewCertificateAuthorityImpl(
 	}
 
 	ca = &certificateAuthorityImpl{
-		sa:             sa,
-		pa:             pa,
-		issuers:        issuers,
-		certProfiles:   certProfiles,
-		validityPeriod: certExpiry,
-		backdate:       certBackdate,
-		prefix:         serialPrefix,
-		maxNames:       maxNames,
-		keyPolicy:      keyPolicy,
-		log:            logger,
-		metrics:        metrics,
-		clk:            clk,
+		sa:           sa,
+		pa:           pa,
+		issuers:      issuers,
+		certProfiles: certProfiles,
+		prefix:       serialPrefix,
+		maxNames:     maxNames,
+		keyPolicy:    keyPolicy,
+		log:          logger,
+		metrics:      metrics,
+		clk:          clk,
 	}
 
 	return ca, nil

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -106,8 +106,6 @@ type testCtx struct {
 	defaultCertProfileName string
 	lints                  lint.Registry
 	certProfiles           map[string]issuance.ProfileConfig
-	certExpiry             time.Duration
-	certBackdate           time.Duration
 	serialPrefix           int
 	maxNames               int
 	boulderIssuers         []*issuance.Issuer
@@ -164,7 +162,7 @@ func setup(t *testing.T) *testCtx {
 		Policies: []issuance.PolicyConfig{
 			{OID: "2.23.140.1.2.1"},
 		},
-		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 365},
+		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 90},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},
 	}
 	certProfiles["modern"] = issuance.ProfileConfig{
@@ -173,7 +171,7 @@ func setup(t *testing.T) *testCtx {
 		Policies: []issuance.PolicyConfig{
 			{OID: "2.23.140.1.2.1"},
 		},
-		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 90},
+		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 6},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},
 	}
 	test.AssertEquals(t, len(certProfiles), 2)
@@ -247,8 +245,6 @@ func setup(t *testing.T) *testCtx {
 		defaultCertProfileName: "legacy",
 		lints:                  lints,
 		certProfiles:           certProfiles,
-		certExpiry:             8760 * time.Hour,
-		certBackdate:           time.Hour,
 		serialPrefix:           17,
 		maxNames:               2,
 		boulderIssuers:         boulderIssuers,
@@ -270,8 +266,6 @@ func TestSerialPrefix(t *testing.T) {
 		"",
 		nil,
 		nil,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		0,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -287,8 +281,6 @@ func TestSerialPrefix(t *testing.T) {
 		"",
 		nil,
 		nil,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		128,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -387,8 +379,6 @@ func issueCertificateSubTestSetup(t *testing.T) (*certificateAuthorityImpl, *moc
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -429,8 +419,6 @@ func TestNoIssuers(t *testing.T) {
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -453,8 +441,6 @@ func TestMultipleIssuers(t *testing.T) {
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -530,8 +516,6 @@ func TestUnpredictableIssuance(t *testing.T) {
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -606,7 +590,7 @@ func TestProfiles(t *testing.T) {
 		Policies: []issuance.PolicyConfig{
 			{OID: "2.23.140.1.2.1"},
 		},
-		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 399},
+		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 90},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},
 	}
 	test.AssertEquals(t, len(badProfiles), 1)
@@ -645,11 +629,11 @@ func TestProfiles(t *testing.T) {
 			expectedProfiles: []nameToHash{
 				{
 					name: "legacy",
-					hash: [32]byte{0xf7, 0x53, 0xef, 0xcd, 0x5a, 0x17, 0x22, 0x2, 0x79, 0xc8, 0xcb, 0x7a, 0x3d, 0x60, 0x46, 0x8b, 0xa0, 0x3b, 0x8b, 0x1a, 0x81, 0x19, 0x7e, 0x84, 0x19, 0x7f, 0x16, 0xd7, 0x95, 0x39, 0xef, 0x8e},
+					hash: [32]byte{0x41, 0xda, 0xe6, 0x97, 0xec, 0x2, 0x4c, 0x68, 0x7, 0x45, 0x57, 0xa2, 0x25, 0x86, 0xbb, 0xbe, 0x5, 0x8a, 0x40, 0x5, 0x72, 0xf5, 0x3f, 0x9f, 0x89, 0x2b, 0x1a, 0x24, 0x10, 0xab, 0xfc, 0x95},
 				},
 				{
 					name: "modern",
-					hash: [32]byte{0x44, 0x1d, 0x9d, 0xbc, 0x4c, 0xfc, 0xf, 0x95, 0xa4, 0x32, 0xc0, 0xcb, 0x76, 0xd1, 0x1b, 0xcb, 0xbe, 0xf1, 0x14, 0xe7, 0xa3, 0xf6, 0xfd, 0x7, 0x14, 0xb5, 0xfa, 0x2f, 0xb6, 0x1, 0x22, 0xc},
+					hash: [32]byte{0x85, 0xfb, 0x36, 0xdc, 0xef, 0x1b, 0x77, 0xc9, 0x50, 0x29, 0x36, 0xe7, 0xf2, 0xf8, 0xc, 0xed, 0xc, 0x14, 0xa8, 0x11, 0x18, 0xe9, 0x9f, 0xb3, 0xc1, 0xc7, 0x78, 0x81, 0xa2, 0x6, 0x2d, 0x12},
 				},
 			},
 		},
@@ -667,7 +651,7 @@ func TestProfiles(t *testing.T) {
 					// We'll change the mapped hash key under the hood during
 					// the test.
 					name: "ruhroh",
-					hash: [32]byte{0x4f, 0x23, 0x87, 0xe0, 0xc3, 0x1, 0xac, 0x3d, 0x40, 0x94, 0xa8, 0x5c, 0x71, 0xef, 0x40, 0xb5, 0xa, 0xfd, 0xb0, 0xb2, 0xb0, 0x6b, 0x2c, 0x2a, 0xf9, 0xb1, 0x5, 0xf, 0x37, 0x42, 0xf4, 0x23},
+					hash: [32]byte{0x12, 0x20, 0xb4, 0x5e, 0xf5, 0x9, 0x68, 0x37, 0x71, 0xb8, 0x2b, 0x2d, 0x1, 0xf6, 0xd5, 0x8c, 0xae, 0x9c, 0x6d, 0xc, 0x81, 0xb8, 0x60, 0xad, 0xfe, 0x31, 0x7, 0x60, 0x7e, 0x58, 0xed, 0xa4},
 				},
 			},
 		},
@@ -687,8 +671,6 @@ func TestProfiles(t *testing.T) {
 				tc.defaultName,
 				tc.profileConfigs,
 				testCtx.lints,
-				testCtx.certExpiry,
-				testCtx.certBackdate,
 				testCtx.serialPrefix,
 				testCtx.maxNames,
 				testCtx.keyPolicy,
@@ -793,8 +775,6 @@ func TestInvalidCSRs(t *testing.T) {
 			testCtx.defaultCertProfileName,
 			testCtx.certProfiles,
 			testCtx.lints,
-			testCtx.certExpiry,
-			testCtx.certBackdate,
 			testCtx.serialPrefix,
 			testCtx.maxNames,
 			testCtx.keyPolicy,
@@ -823,16 +803,18 @@ func TestInvalidCSRs(t *testing.T) {
 func TestRejectValidityTooLong(t *testing.T) {
 	t.Parallel()
 	testCtx := setup(t)
-	sa := &mockSA{}
+
+	// Jump to a time just moments before the test issuers expire.
+	future := testCtx.boulderIssuers[0].Cert.Certificate.NotAfter.Add(-1 * time.Hour)
+	testCtx.fc.Set(future)
+
 	ca, err := NewCertificateAuthorityImpl(
-		sa,
+		&mockSA{},
 		testCtx.pa,
 		testCtx.boulderIssuers,
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -841,10 +823,6 @@ func TestRejectValidityTooLong(t *testing.T) {
 		testCtx.fc)
 	test.AssertNotError(t, err, "Failed to create CA")
 
-	future, err := time.Parse(time.RFC3339, "2025-02-10T00:30:00Z")
-
-	test.AssertNotError(t, err, "Failed to parse time")
-	testCtx.fc.Set(future)
 	// Test that the CA rejects CSRs that would expire after the intermediate cert
 	_, err = ca.IssuePrecertificate(ctx, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID})
 	test.AssertError(t, err, "Cannot issue a certificate that expires after the intermediate certificate")
@@ -931,8 +909,6 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -999,8 +975,6 @@ func TestIssueCertificateForPrecertificateWithSpecificCertificateProfile(t *test
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -1118,8 +1092,6 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -1168,8 +1140,6 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -327,7 +327,6 @@ func TestIssuePrecertificate(t *testing.T) {
 		subTest func(t *testing.T, i *TestCertificateIssuance)
 	}{
 		{"IssuePrecertificate", CNandSANCSR, issueCertificateSubTestIssuePrecertificate},
-		{"ValidityUsesCAClock", CNandSANCSR, issueCertificateSubTestValidityUsesCAClock},
 		{"ProfileSelectionRSA", CNandSANCSR, issueCertificateSubTestProfileSelectionRSA},
 		{"ProfileSelectionECDSA", ECDSACSR, issueCertificateSubTestProfileSelectionECDSA},
 		{"MustStaple", MustStapleCSR, issueCertificateSubTestMustStaple},
@@ -416,11 +415,6 @@ func issueCertificateSubTestIssuePrecertificate(t *testing.T, i *TestCertificate
 	if len(cert.Subject.Country) > 0 {
 		t.Errorf("Subject contained unauthorized values: %v", cert.Subject)
 	}
-}
-
-func issueCertificateSubTestValidityUsesCAClock(t *testing.T, i *TestCertificateIssuance) {
-	test.AssertEquals(t, i.cert.NotBefore, i.ca.clk.Now().Add(-1*i.ca.backdate))
-	test.AssertEquals(t, i.cert.NotAfter.Add(time.Second).Sub(i.cert.NotBefore), i.ca.validityPeriod)
 }
 
 // Test failure mode when no issuers are present.

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -36,8 +36,6 @@ func TestOCSP(t *testing.T) {
 		testCtx.defaultCertProfileName,
 		testCtx.certProfiles,
 		testCtx.lints,
-		testCtx.certExpiry,
-		testCtx.certBackdate,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -58,9 +58,11 @@ type Config struct {
 		}
 
 		// How long issued certificates are valid for.
+		// Deprecated: Use Issuace.CertProfiles.MaxValidityPeriod instead.
 		Expiry config.Duration
 
 		// How far back certificates should be backdated.
+		// Deprecated: Use Issuace.CertProfiles.MaxValidityBackdate instead.
 		Backdate config.Duration
 
 		// What digits we should prepend to serials after randomly generating them.
@@ -273,8 +275,6 @@ func main() {
 			c.CA.Issuance.DefaultCertificateProfileName,
 			c.CA.Issuance.CertProfiles,
 			lints,
-			c.CA.Expiry.Duration,
-			c.CA.Backdate.Duration,
 			c.CA.SerialPrefix,
 			c.CA.MaxNames,
 			kp,

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -27,9 +27,21 @@ import (
 
 // ProfileConfig describes the certificate issuance constraints for all issuers.
 type ProfileConfig struct {
+	// AllowMustStaple, when false, causes all IssuanceRequests which specify the
+	// OCSP Must Staple extension to be rejected.
 	AllowMustStaple bool
-	AllowCTPoison   bool
-	AllowSCTList    bool
+	// AllowCTPoison, when false, causes all IssuanceRequests which want the
+	// CT Poison extension to be rejected.
+	// Deprecated: We will always allow the CT Poison extension because it is
+	// mandated for Precertificates. This boolean has no effect.
+	AllowCTPoison bool
+	// AllowSCTList, when false, causes all IssuanceRequests which include SCTs
+	// to be rejected.
+	// Deprecated: We intend to include SCTs in all final Certificates for the
+	// foreseeable future. This boolean has no effect.
+	AllowSCTList bool
+	// AllowCommonName, when false, causes all IssuanceRequests which specify a CN
+	// to be rejected.
 	AllowCommonName bool
 
 	MaxValidityPeriod   config.Duration
@@ -47,8 +59,6 @@ type PolicyConfig struct {
 // Profile is the validated structure created by reading in ProfileConfigs and IssuerConfigs
 type Profile struct {
 	allowMustStaple bool
-	allowCTPoison   bool
-	allowSCTList    bool
 	allowCommonName bool
 
 	maxBackdate time.Duration
@@ -61,8 +71,6 @@ type Profile struct {
 func NewProfile(profileConfig ProfileConfig, lints lint.Registry) (*Profile, error) {
 	sp := &Profile{
 		allowMustStaple: profileConfig.AllowMustStaple,
-		allowCTPoison:   profileConfig.AllowCTPoison,
-		allowSCTList:    profileConfig.AllowSCTList,
 		allowCommonName: profileConfig.AllowCommonName,
 		maxBackdate:     profileConfig.MaxValidityBackdate.Duration,
 		maxValidity:     profileConfig.MaxValidityPeriod.Duration,
@@ -91,14 +99,6 @@ func (i *Issuer) requestValid(clk clock.Clock, prof *Profile, req *IssuanceReque
 
 	if !prof.allowMustStaple && req.IncludeMustStaple {
 		return errors.New("must-staple extension cannot be included")
-	}
-
-	if !prof.allowCTPoison && req.IncludeCTPoison {
-		return errors.New("ct poison extension cannot be included")
-	}
-
-	if !prof.allowSCTList && req.sctList != nil {
-		return errors.New("sct list extension cannot be included")
 	}
 
 	if req.IncludeCTPoison && req.sctList != nil {

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -30,15 +30,13 @@ type ProfileConfig struct {
 	// AllowMustStaple, when false, causes all IssuanceRequests which specify the
 	// OCSP Must Staple extension to be rejected.
 	AllowMustStaple bool
-	// AllowCTPoison, when false, causes all IssuanceRequests which want the
-	// CT Poison extension to be rejected.
+	// AllowCTPoison has no effect.
 	// Deprecated: We will always allow the CT Poison extension because it is
-	// mandated for Precertificates. This boolean has no effect.
+	// mandated for Precertificates.
 	AllowCTPoison bool
-	// AllowSCTList, when false, causes all IssuanceRequests which include SCTs
-	// to be rejected.
+	// AllowSCTList has no effect.
 	// Deprecated: We intend to include SCTs in all final Certificates for the
-	// foreseeable future. This boolean has no effect.
+	// foreseeable future.
 	AllowSCTList bool
 	// AllowCommonName, when false, causes all IssuanceRequests which specify a CN
 	// to be rejected.

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -72,6 +72,18 @@ type Profile struct {
 
 // NewProfile converts the profile config and lint registry into a usable profile.
 func NewProfile(profileConfig ProfileConfig, lints lint.Registry) (*Profile, error) {
+	// The Baseline Requirements, Section 7.1.2.7, says that the notBefore time
+	// must be "within 48 hours of the time of signing". We can be even stricter.
+	if profileConfig.MaxValidityBackdate.Duration >= 24*time.Hour {
+		return nil, fmt.Errorf("backdate %q is too large", profileConfig.MaxValidityBackdate.Duration)
+	}
+
+	// Our CP/CPS, Section 7.1, says that our Subscriber Certificates have a
+	// validity period of "up to 100 days".
+	if profileConfig.MaxValidityPeriod.Duration >= 100*24*time.Hour {
+		return nil, fmt.Errorf("validity period %q is too large", profileConfig.MaxValidityPeriod.Duration)
+	}
+
 	sp := &Profile{
 		allowMustStaple: profileConfig.AllowMustStaple,
 		omitCommonName:  profileConfig.OmitCommonName,

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -103,7 +103,7 @@ func (p *Profile) GenerateValidity(now time.Time) (time.Time, time.Time) {
 	backdate := time.Duration(float64(p.maxBackdate.Nanoseconds()) * 0.9)
 	notBefore := now.Add(-1 * backdate)
 	// Subtract one second, because certificate validity periods are *inclusive*
-	// of their final second.
+	// of their final second (Baseline Requirements, Section 1.6.1).
 	notAfter := notBefore.Add(p.maxValidity).Add(-1 * time.Second)
 	return notBefore, notAfter
 }

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -93,40 +93,11 @@ func TestRequestValid(t *testing.T) {
 			expectedError: "must-staple extension cannot be included",
 		},
 		{
-			name: "ct poison not allowed",
+			name: "both sct list and ct poison provided",
 			issuer: &Issuer{
 				active: true,
 			},
 			profile: &Profile{},
-			request: &IssuanceRequest{
-				PublicKey:       &ecdsa.PublicKey{},
-				SubjectKeyId:    goodSKID,
-				IncludeCTPoison: true,
-			},
-			expectedError: "ct poison extension cannot be included",
-		},
-		{
-			name: "sct list not allowed",
-			issuer: &Issuer{
-				active: true,
-			},
-			profile: &Profile{},
-			request: &IssuanceRequest{
-				PublicKey:    &ecdsa.PublicKey{},
-				SubjectKeyId: goodSKID,
-				sctList:      []ct.SignedCertificateTimestamp{},
-			},
-			expectedError: "sct list extension cannot be included",
-		},
-		{
-			name: "sct list and ct poison not allowed",
-			issuer: &Issuer{
-				active: true,
-			},
-			profile: &Profile{
-				allowCTPoison: true,
-				allowSCTList:  true,
-			},
 			request: &IssuanceRequest{
 				PublicKey:       &ecdsa.PublicKey{},
 				SubjectKeyId:    goodSKID,
@@ -263,7 +234,24 @@ func TestRequestValid(t *testing.T) {
 			expectedError: "serial must be between 9 and 19 bytes",
 		},
 		{
-			name: "good",
+			name: "good with poison",
+			issuer: &Issuer{
+				active: true,
+			},
+			profile: &Profile{
+				maxValidity: time.Hour * 2,
+			},
+			request: &IssuanceRequest{
+				PublicKey:       &ecdsa.PublicKey{},
+				SubjectKeyId:    goodSKID,
+				NotBefore:       fc.Now(),
+				NotAfter:        fc.Now().Add(time.Hour),
+				Serial:          []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				IncludeCTPoison: true,
+			},
+		},
+		{
+			name: "good with scts",
 			issuer: &Issuer{
 				active: true,
 			},
@@ -276,6 +264,7 @@ func TestRequestValid(t *testing.T) {
 				NotBefore:    fc.Now(),
 				NotAfter:     fc.Now().Add(time.Hour),
 				Serial:       []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				sctList:      []ct.SignedCertificateTimestamp{},
 			},
 		},
 	}

--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -24,9 +24,6 @@ import (
 
 func defaultProfileConfig() ProfileConfig {
 	return ProfileConfig{
-		AllowCommonName:     true,
-		AllowCTPoison:       true,
-		AllowSCTList:        true,
 		AllowMustStaple:     true,
 		MaxValidityPeriod:   config.Duration{Duration: time.Hour},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -46,8 +46,6 @@
 			"certProfiles": {
 				"defaultBoulderCertificateProfile": {
 					"allowMustStaple": true,
-					"allowCTPoison": true,
-					"allowSCTList": true,
 					"allowCommonName": true,
 					"policies": [
 						{

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -62,7 +62,7 @@
 							"oid": "2.23.140.1.2.1"
 						}
 					],
-					"maxValidityPeriod": "7776000s",
+					"maxValidityPeriod": "583200s",
 					"maxValidityBackdate": "1h5m"
 				}
 			},

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -144,8 +144,6 @@
 				"w_sub_cert_aia_contains_internal_names"
 			]
 		},
-		"expiry": "7776000s",
-		"backdate": "1h",
 		"serialPrefix": 127,
 		"maxNames": 100,
 		"lifespanOCSP": "96h",

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -44,9 +44,19 @@
 		"issuance": {
 			"defaultCertificateProfileName": "defaultBoulderCertificateProfile",
 			"certProfiles": {
-				"defaultBoulderCertificateProfile": {
+				"legacy": {
 					"allowMustStaple": true,
-					"allowCommonName": true,
+					"policies": [
+						{
+							"oid": "2.23.140.1.2.1"
+						}
+					],
+					"maxValidityPeriod": "7776000s",
+					"maxValidityBackdate": "1h5m"
+				},
+				"modern": {
+					"allowMustStaple": true,
+					"omitCommonName": true,
 					"policies": [
 						{
 							"oid": "2.23.140.1.2.1"

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -42,7 +42,7 @@
 			"hostOverride": "sa.boulder"
 		},
 		"issuance": {
-			"defaultCertificateProfileName": "defaultBoulderCertificateProfile",
+			"defaultCertificateProfileName": "legacy",
 			"certProfiles": {
 				"legacy": {
 					"allowMustStaple": true,


### PR DESCRIPTION
One of our goals with profiles is to allow different profiles to have different validity periods. While the profiles already had the ability to enforce different maximum backdates and validities, the CA still had separate global configuration for what the backdate and validity period should actually be.

Move the computation of the notBefore and notAfter timestamps into the issuance package, so that it can be based on the profile's configured backdate and validity durations. Deprecate the global "backdate" and "expiry" config fields, as they are no longer used. Finally, add more validation for the profile's backdate and validity.

Part of https://github.com/letsencrypt/boulder/issues/7610

~~DO NOT MERGE before https://github.com/letsencrypt/boulder/pull/7620~~
IN-10506 tracks the corresponding production config changes