### PR TITLE
Profiles: allow for omission of KU, EKU, and SKID

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -184,8 +184,8 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]issuance
 		return certProfilesMaps{}, fmt.Errorf("defaultCertificateProfileName:\"%s\" was configured, but a profile object was not found for that name", defaultName)
 	}
 
-	profileByName := make(map[string]*certProfileWithID, len(profiles))
-	profileByHash := make(map[[32]byte]*certProfileWithID, len(profiles))
+	profilesByName := make(map[string]*certProfileWithID, len(profiles))
+	profilesByHash := make(map[[32]byte]*certProfileWithID, len(profiles))
 
 	for name, profileConfig := range profiles {
 		profile, err := issuance.NewProfile(profileConfig, lints)
@@ -208,30 +208,22 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]issuance
 		}
 		hash := sha256.Sum256(encodedProfile.Bytes())
 
-		_, ok := profileByName[name]
-		if !ok {
-			profileByName[name] = &certProfileWithID{
-				name:    name,
-				hash:    hash,
-				profile: profile,
-			}
-		} else {
-			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile name %s", name)
+		cpwid := certProfileWithID{
+			name:    name,
+			hash:    hash,
+			profile: profile,
 		}
 
-		_, ok = profileByHash[hash]
-		if !ok {
-			profileByHash[hash] = &certProfileWithID{
-				name:    name,
-				hash:    hash,
-				profile: profile,
-			}
-		} else {
+		profilesByName[name] = &cpwid
+
+		_, found := profilesByHash[hash]
+		if found {
 			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", hash)
 		}
+		profilesByHash[hash] = &cpwid
 	}
 
-	return certProfilesMaps{defaultName, profileByHash, profileByName}, nil
+	return certProfilesMaps{defaultName, profilesByHash, profilesByName}, nil
 }
 
 // NewCertificateAuthorityImpl creates a CA instance that can sign certificates

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -208,19 +208,19 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]issuance
 		}
 		hash := sha256.Sum256(encodedProfile.Bytes())
 
-		cpwid := certProfileWithID{
+		withID := certProfileWithID{
 			name:    name,
 			hash:    hash,
 			profile: profile,
 		}
 
-		profilesByName[name] = &cpwid
+		profilesByName[name] = &withID
 
 		_, found := profilesByHash[hash]
 		if found {
 			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", hash)
 		}
-		profilesByHash[hash] = &cpwid
+		profilesByHash[hash] = &withID
 	}
 
 	return certProfilesMaps{defaultName, profilesByHash, profilesByName}, nil

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -49,7 +49,7 @@ type ProfileConfig struct {
 	// OmitKeyEncipherment causes the keyEncipherment bit to be omitted from the
 	// Key Usage field of all certificates (instead of only from ECDSA certs).
 	OmitKeyEncipherment bool
-	// OmitClientAuth causes the id-kp-clientAuth OID (TLS CLient Authentication)
+	// OmitClientAuth causes the id-kp-clientAuth OID (TLS Client Authentication)
 	// to be omitted from the EKU extension.
 	OmitClientAuth bool
 	// OmitSKID causes the Subject Key Identifier extension to be omitted.

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -46,6 +46,14 @@ type ProfileConfig struct {
 	// OmitCommonName causes the CN field to be excluded from the resulting
 	// certificate, regardless of its inclusion in the IssuanceRequest.
 	OmitCommonName bool
+	// OmitKeyEncipherment causes the keyEncipherment bit to be omitted from the
+	// Key Usage field of all certificates (instead of only from ECDSA certs).
+	OmitKeyEncipherment bool
+	// OmitClientAuth causes the id-kp-clientAuth OID (TLS CLient Authentication)
+	// to be omitted from the EKU extension.
+	OmitClientAuth bool
+	// OmitSKID causes the Subject Key Identifier extension to be omitted.
+	OmitSKID bool
 
 	MaxValidityPeriod   config.Duration
 	MaxValidityBackdate config.Duration
@@ -61,8 +69,11 @@ type PolicyConfig struct {
 
 // Profile is the validated structure created by reading in ProfileConfigs and IssuerConfigs
 type Profile struct {
-	allowMustStaple bool
-	omitCommonName  bool
+	allowMustStaple     bool
+	omitCommonName      bool
+	omitKeyEncipherment bool
+	omitClientAuth      bool
+	omitSKID            bool
 
 	maxBackdate time.Duration
 	maxValidity time.Duration
@@ -85,11 +96,14 @@ func NewProfile(profileConfig ProfileConfig, lints lint.Registry) (*Profile, err
 	}
 
 	sp := &Profile{
-		allowMustStaple: profileConfig.AllowMustStaple,
-		omitCommonName:  profileConfig.OmitCommonName,
-		maxBackdate:     profileConfig.MaxValidityBackdate.Duration,
-		maxValidity:     profileConfig.MaxValidityPeriod.Duration,
-		lints:           lints,
+		allowMustStaple:     profileConfig.AllowMustStaple,
+		omitCommonName:      profileConfig.OmitCommonName,
+		omitKeyEncipherment: profileConfig.OmitKeyEncipherment,
+		omitClientAuth:      profileConfig.OmitClientAuth,
+		omitSKID:            profileConfig.OmitSKID,
+		maxBackdate:         profileConfig.MaxValidityBackdate.Duration,
+		maxValidity:         profileConfig.MaxValidityPeriod.Duration,
+		lints:               lints,
 	}
 
 	return sp, nil
@@ -121,7 +135,7 @@ func (i *Issuer) requestValid(clk clock.Clock, prof *Profile, req *IssuanceReque
 		return errors.New("inactive issuer cannot issue precert")
 	}
 
-	if len(req.SubjectKeyId) != 20 {
+	if len(req.SubjectKeyId) != 0 && len(req.SubjectKeyId) != 20 {
 		return errors.New("unexpected subject key ID length")
 	}
 
@@ -162,11 +176,7 @@ func (i *Issuer) requestValid(clk clock.Clock, prof *Profile, req *IssuanceReque
 
 func (i *Issuer) generateTemplate() *x509.Certificate {
 	template := &x509.Certificate{
-		SignatureAlgorithm: i.sigAlg,
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageServerAuth,
-			x509.ExtKeyUsageClientAuth,
-		},
+		SignatureAlgorithm:    i.sigAlg,
 		OCSPServer:            []string{i.ocspURL},
 		IssuingCertificateURL: []string{i.issuerURL},
 		BasicConstraintsValid: true,
@@ -278,6 +288,17 @@ func (i *Issuer) Prepare(prof *Profile, req *IssuanceRequest) ([]byte, *issuance
 	// generate template from the issuer's data
 	template := i.generateTemplate()
 
+	ekus := []x509.ExtKeyUsage{
+		x509.ExtKeyUsageServerAuth,
+		x509.ExtKeyUsageClientAuth,
+	}
+	if prof.omitClientAuth {
+		ekus = []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+		}
+	}
+	template.ExtKeyUsage = ekus
+
 	// populate template from the issuance request
 	template.NotBefore, template.NotAfter = req.NotBefore, req.NotAfter
 	template.SerialNumber = big.NewInt(0).SetBytes(req.Serial)
@@ -288,12 +309,18 @@ func (i *Issuer) Prepare(prof *Profile, req *IssuanceRequest) ([]byte, *issuance
 
 	switch req.PublicKey.(type) {
 	case *rsa.PublicKey:
-		template.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+		if prof.omitKeyEncipherment {
+			template.KeyUsage = x509.KeyUsageDigitalSignature
+		} else {
+			template.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+		}
 	case *ecdsa.PublicKey:
 		template.KeyUsage = x509.KeyUsageDigitalSignature
 	}
 
-	template.SubjectKeyId = req.SubjectKeyId
+	if !prof.omitSKID {
+		template.SubjectKeyId = req.SubjectKeyId
+	}
 
 	if req.IncludeCTPoison {
 		template.ExtraExtensions = append(template.ExtraExtensions, ctPoisonExt)

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -764,7 +764,12 @@ func (ra *RegistrationAuthorityImpl) matchesCSR(parsedCertificate *x509.Certific
 	if parsedCertificate.IsCA {
 		return berrors.InternalServerError("generated certificate can sign other certificates")
 	}
-	if !slices.Equal(parsedCertificate.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}) {
+	for _, eku := range parsedCertificate.ExtKeyUsage {
+		if eku != x509.ExtKeyUsageServerAuth && eku != x509.ExtKeyUsageClientAuth {
+			return berrors.InternalServerError("generated certificate doesn't have correct key usage extensions")
+		}
+	}
+	if !slices.Contains(parsedCertificate.ExtKeyUsage, x509.ExtKeyUsageServerAuth) {
 		return berrors.InternalServerError("generated certificate doesn't have correct key usage extensions")
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -766,11 +766,11 @@ func (ra *RegistrationAuthorityImpl) matchesCSR(parsedCertificate *x509.Certific
 	}
 	for _, eku := range parsedCertificate.ExtKeyUsage {
 		if eku != x509.ExtKeyUsageServerAuth && eku != x509.ExtKeyUsageClientAuth {
-			return berrors.InternalServerError("generated certificate doesn't have correct key usage extensions")
+			return berrors.InternalServerError("generated certificate has unacceptable EKU")
 		}
 	}
 	if !slices.Contains(parsedCertificate.ExtKeyUsage, x509.ExtKeyUsageServerAuth) {
-		return berrors.InternalServerError("generated certificate doesn't have correct key usage extensions")
+		return berrors.InternalServerError("generated certificate doesn't have serverAuth EKU")
 	}
 
 	return nil

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -46,11 +46,6 @@
 			"certProfiles": {
 				"legacy": {
 					"allowMustStaple": true,
-					"policies": [
-						{
-							"oid": "2.23.140.1.2.1"
-						}
-					],
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m"
 				},
@@ -60,11 +55,6 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
-					"policies": [
-						{
-							"oid": "2.23.140.1.2.1"
-						}
-					],
 					"maxValidityPeriod": "583200s",
 					"maxValidityBackdate": "1h5m"
 				}

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -57,6 +57,9 @@
 				"modern": {
 					"allowMustStaple": true,
 					"omitCommonName": true,
+					"omitKeyEncipherment": true,
+					"omitClientAuth": true,
+					"omitSKID": true,
 					"policies": [
 						{
 							"oid": "2.23.140.1.2.1"


### PR DESCRIPTION
Add three new keys to the CA's ProfileConfig:
- OmitKeyEncipherment causes the keyEncipherment Key Usage to be omitted from certificates with RSA public keys. We currently include it for backwards compatibility with TLS 1.1 servers that don't support modern cipher suites, but this KU is completely useless as of TLS 1.3.
- OmitClientAuth causes the tlsClientAuthentication Extended Key Usage to be omitted from all certificates. We currently include it to support any subscribers who may be relying on it, but Root Programs are moving towards single-purpose hierarchies and its inclusion is being discouraged.
- OmitSKID causes the Subject Key Identifier extension to be omitted from all certificates. We currently include this extension because it is recommended by RFC 5280, but it serves little to no practical purpose and consumes a large number of bytes, so it is now NOT RECOMMENDED by the Baseline Requirements.

Make substantive changes to issuer.requestValid and issuer.Prepare to implement the desired behavior for each of these options. Make a very slight change to ra.matchesCSR to generally allow for serverAuth-only EKUs. Improve the unit tests of both the //ca and //issuance packages to cover the new behavior.

Part of https://github.com/letsencrypt/boulder/issues/7610
No config changes at this time; they will be made as part of https://github.com/letsencrypt/boulder/issues/7309