### PR TITLE
WFE: Include profile name in returned Order json

### DIFF
--- a/mocks/sa.go
+++ b/mocks/sa.go
@@ -399,7 +399,7 @@ func (sa *StorageAuthorityReadOnly) GetOrder(_ context.Context, req *sapb.OrderR
 		V2Authorizations:       []int64{1},
 		CertificateSerial:      "serial",
 		Error:                  nil,
-		CertificateProfileName: "defaultBoulderCertificateProfile",
+		CertificateProfileName: "default",
 	}
 
 	// Order ID doesn't have a certificate serial yet

--- a/test/asserts.go
+++ b/test/asserts.go
@@ -147,7 +147,7 @@ func AssertUnmarshaledEquals(t *testing.T, got, expected string) {
 	err = json.Unmarshal([]byte(expected), &expectedMap)
 	AssertNotError(t, err, "Could not unmarshal 'expected'")
 	if len(gotMap) != len(expectedMap) {
-		t.Errorf("Expected had %d keys, got had %d", len(gotMap), len(expectedMap))
+		t.Errorf("Expected %d keys, but got %d", len(expectedMap), len(gotMap))
 	}
 	for k, v := range expectedMap {
 		if !reflect.DeepEqual(v, gotMap[k]) {

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -132,7 +132,8 @@
 			"CheckRenewalExemptionAtWFE": true
 		},
 		"certProfiles": {
-			"defaultBoulderCertificateProfile": "The normal profile you know and love"
+			"legacy": "The normal profile you know and love",
+			"modern": "Profile 2: Electric Boogaloo"
 		}
 	},
 	"syslog": {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1990,6 +1990,7 @@ func (wfe *WebFrontEndImpl) orderToOrderJSON(request *http.Request, order *corep
 		Expires:     order.Expires.AsTime(),
 		Identifiers: idents,
 		Finalize:    finalizeURL,
+		Profile:     order.CertificateProfileName,
 	}
 	// If there is an order error, prefix its type with the V2 namespace
 	if order.Error != nil {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2768,6 +2768,7 @@ func TestFinalizeOrder(t *testing.T) {
   "identifiers": [
     {"type":"dns","value":"example.com"}
   ],
+	"profile": "default",
   "authorizations": [
     "http://localhost/acme/authz-v3/1"
   ],
@@ -2786,8 +2787,7 @@ func TestFinalizeOrder(t *testing.T) {
 					t.Errorf("Header %q: Expected %q, got %q", k, v, got)
 				}
 			}
-			test.AssertUnmarshaledEquals(t, responseWriter.Body.String(),
-				tc.ExpectedBody)
+			test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), tc.ExpectedBody)
 		})
 	}
 
@@ -2939,7 +2939,7 @@ func TestGetOrder(t *testing.T) {
 		{
 			Name:     "Good request",
 			Request:  makeGet("1/1"),
-			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/1","certificate":"http://localhost/acme/cert/serial"}`,
+			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "profile": "default", "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/1","certificate":"http://localhost/acme/cert/serial"}`,
 		},
 		{
 			Name:     "404 request",
@@ -2984,7 +2984,7 @@ func TestGetOrder(t *testing.T) {
 		{
 			Name:     "Valid POST-as-GET",
 			Request:  makePost(1, "1/1", ""),
-			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/1","certificate":"http://localhost/acme/cert/serial"}`,
+			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "profile": "default", "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/1","certificate":"http://localhost/acme/cert/serial"}`,
 		},
 		{
 			Name:     "GET new order",
@@ -2995,17 +2995,17 @@ func TestGetOrder(t *testing.T) {
 		{
 			Name:     "GET new order from old endpoint",
 			Request:  makeGet("1/9"),
-			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/9","certificate":"http://localhost/acme/cert/serial"}`,
+			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "profile": "default", "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/9","certificate":"http://localhost/acme/cert/serial"}`,
 		},
 		{
 			Name:     "POST-as-GET new order",
 			Request:  makePost(1, "1/9", ""),
-			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/9","certificate":"http://localhost/acme/cert/serial"}`,
+			Response: `{"status": "valid","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "profile": "default", "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/9","certificate":"http://localhost/acme/cert/serial"}`,
 		},
 		{
 			Name:     "POST-as-GET processing order",
 			Request:  makePost(1, "1/10", ""),
-			Response: `{"status": "processing","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/10"}`,
+			Response: `{"status": "processing","expires": "2000-01-01T00:00:00Z","identifiers":[{"type":"dns", "value":"example.com"}], "profile": "default", "authorizations":["http://localhost/acme/authz-v3/1"],"finalize":"http://localhost/acme/finalize/1/10"}`,
 			Headers:  map[string]string{"Retry-After": "3"},
 		},
 	}
@@ -3018,6 +3018,9 @@ func TestGetOrder(t *testing.T) {
 			} else {
 				wfe.GetOrder(ctx, newRequestEvent(), responseWriter, tc.Request)
 			}
+			t.Log(tc.Name)
+			t.Log("actual:", responseWriter.Body.String())
+			t.Log("expect:", tc.Response)
 			test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), tc.Response)
 			for k, v := range tc.Headers {
 				test.AssertEquals(t, responseWriter.Header().Get(k), v)


### PR DESCRIPTION
Integration testing revealed that the WFE was not rendering the profile name in the Order JSON object. Fix the one spot where it was missed.

Part of https://github.com/letsencrypt/boulder/issues/7332
No config changes necessary; they will be made as part of https://github.com/letsencrypt/boulder/issues/7309