### PR TITLE
Remove RSA KEX tracking from validation

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -148,13 +148,6 @@ type ValidationRecord struct {
 	// lookup for AddressUsed. During recursive A and AAAA lookups, a record may
 	// instead look like A:host:port or AAAA:host:port
 	ResolverAddrs []string `json:"resolverAddrs,omitempty"`
-	// UsedRSAKEX is a *temporary* addition to the validation record, so we can
-	// see how many servers that we reach out to during HTTP-01 and TLS-ALPN-01
-	// validation are only willing to negotiate RSA key exchange mechanisms. The
-	// field is not included in the serialized json to avoid cluttering the
-	// database and log lines.
-	// TODO(#7321): Remove this when we have collected sufficient data.
-	UsedRSAKEX bool `json:"-"`
 }
 
 // Challenge is an aggregate of all data needed for any challenges.

--- a/va/http.go
+++ b/va/http.go
@@ -494,13 +494,6 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		numRedirects++
 		va.metrics.http01Redirects.Inc()
 
-		// If TLS was used, record the negotiated key exchange mechanism in the most
-		// recent validationRecord.
-		// TODO(#7321): Remove this when we have collected enough data.
-		if req.Response.TLS != nil {
-			records[len(records)-1].UsedRSAKEX = usedRSAKEX(req.Response.TLS.CipherSuite)
-		}
-
 		if req.Response.TLS != nil && req.Response.TLS.Version < tls.VersionTLS12 {
 			return berrors.ConnectionFailureError(
 				"validation attempt was redirected to an HTTPS server that doesn't " +
@@ -641,13 +634,6 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 	if len(body) >= maxResponseSize {
 		return nil, records, newIPError(records[len(records)-1].AddressUsed, berrors.UnauthorizedError("Invalid response from %s: %q",
 			records[len(records)-1].URL, body))
-	}
-
-	// We were successful, so record the negotiated key exchange mechanism in the
-	// last validationRecord.
-	// TODO(#7321): Remove this when we have collected enough data.
-	if httpResponse.TLS != nil {
-		records[len(records)-1].UsedRSAKEX = usedRSAKEX(httpResponse.TLS.CipherSuite)
 	}
 
 	return body, records, nil

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -289,10 +289,6 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, identi
 					hex.EncodeToString(h[:]),
 				))
 			}
-			// We were successful, so record the negotiated key exchange mechanism in
-			// the validationRecord.
-			// TODO(#7321): Remove this when we have collected enough data.
-			validationRecord.UsedRSAKEX = usedRSAKEX(cs.CipherSuite)
 			return validationRecords, nil
 		}
 	}


### PR DESCRIPTION
We used this data to inform our decision making, and have now fully turned off support for RSA KEX during validation. This log event field will now never be set, so it can be removed.

Part of https://github.com/letsencrypt/boulder/issues/7321
Fixes https://github.com/letsencrypt/boulder/issues/7628