### PR TITLE
Only run issue-for-sre-handoff when review requested

### DIFF
--- a/.github/workflows/issue-for-sre-handoff.yml
+++ b/.github/workflows/issue-for-sre-handoff.yml
@@ -2,7 +2,7 @@ name: Check PR for configuration and SQL changes
 
 on:
   pull_request:
-    types: [ready_for_review, review_requested]
+    types: [review_requested]
     paths:
     - 'test/config-next/*.json'
     - 'test/config-next/*.yaml'


### PR DESCRIPTION
Running this workflow on both `ready_for_review` and `review_requested` was causing duplicate comments to show up when PRs were moved out of draft mode. This is because moving out of draft mode would both trigger a workflow run and automatically request review, which in turn would trigger a second workflow run, and the two runs were triggered in such quick succession that our commentMarker detection wouldn't work.