### PR TITLE
Clearer error message when goodkey fails unexpectedly

### DIFF
--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -722,7 +722,7 @@ func (wfe *WebFrontEndImpl) validSelfAuthenticatedPOST(
 			wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWKRejectedByGoodKey"}).Inc()
 			return nil, nil, probs.BadPublicKey(err.Error())
 		}
-		return nil, nil, probs.ServerInternal("error checking key quality")
+		return nil, nil, probs.ServerInternal("internal error while checking JWK")
 	}
 
 	return payload, pubKey, nil


### PR DESCRIPTION
This will prevent users from believing their key is at fault when the actual error is between Boulder and the database.

Fixes https://github.com/letsencrypt/boulder/issues/7624