### PR TITLE
sa: Update paused table schema

### DIFF
--- a/sa/db-next/boulder_sa/20240514000000_Paused.sql
+++ b/sa/db-next/boulder_sa/20240514000000_Paused.sql
@@ -6,12 +6,12 @@
 -- rate of ~18% per year.
 
 CREATE TABLE `paused` (
-  `registrationID` bigint(20) NOT NULL,
+  `registrationID` bigint(20) UNSIGNED NOT NULL,
   `identifierType` tinyint(4) NOT NULL,
   `identifierValue` varchar(255) NOT NULL,
   `pausedAt` datetime NOT NULL,
   `unpausedAt` datetime DEFAULT NULL,
-  PRIMARY KEY (`registrationID`, `identifierType`, `identifierValue`)
+  PRIMARY KEY (`registrationID`, `identifierValue`, `identifierType`)
 );
 
 -- +migrate Down


### PR DESCRIPTION
* Make `registrationID` unsigned to match staging/production so that we have a large pool of autoincrement IDs
* Change the primary key line to perform better filtering to appease the query planner