### PR TITLE
RA: Always output revocation reason field in cert revocation event

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -350,7 +350,7 @@ type certificateRevocationEvent struct {
 	// serial number.
 	SerialNumber string `json:",omitempty"`
 	// Reason is the integer representing the revocation reason used.
-	Reason int64 `json:",omitempty"`
+	Reason int64 `json:"reason"`
 	// Method is the way in which revocation was requested.
 	// It will be one of the strings: "applicant", "subscriber", "control", "key", or "admin".
 	Method string `json:",omitempty"`


### PR DESCRIPTION
In the event of pruned MariaDB partitions and having to go back to audit logs to search for certificate revocation audit logs, it would be nice to always have the revocation reason listed even if it's the zero-value for the field which would be revocation reason `unspecified`. This would help engineers unfamiliar with golang struct tags and `omitempty`.