### PR TITLE
RA tests: Fix pseudo-merge-conflict

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -4600,8 +4600,8 @@ func TestGetAuthorization(t *testing.T) {
 	defer cleanup()
 
 	ra.SA = &mockSAWithAuthzs{
-		authzs: map[string]*core.Authorization{
-			"example.com": {
+		authzs: []*core.Authorization{
+			{
 				ID:         "1",
 				Identifier: identifier.DNSIdentifier("example.com"),
 				Status:     "valid",


### PR DESCRIPTION
This compile error was introduced by the combination of https://github.com/letsencrypt/boulder/pull/7650 (which changed the type of mockSAWithAuthzs.authzs) and https://github.com/letsencrypt/boulder/pull/7652 (which introduced a new usage of mockSAWithAuthzs.authzs). Because the latter PR introduced a new usage, rather than modifying an existing usage, it didn't create a merge conflict and wasn't caught by GitHub's mergeability checker.