### PR TITLE
ratelimits: Replace *Decision merging with always returning most restrictive

### DIFF
--- a/ratelimits/limiter.go
+++ b/ratelimits/limiter.go
@@ -236,9 +236,6 @@ func prepareBatch(txns []Transaction) ([]Transaction, []string, error) {
 }
 
 func stricter(existing *Decision, incoming *Decision) *Decision {
-	if existing == nil {
-		return incoming
-	}
 	if existing.retryIn == incoming.retryIn {
 		if existing.remaining < incoming.remaining {
 			return existing
@@ -275,8 +272,7 @@ func (l *Limiter) BatchSpend(ctx context.Context, txns []Transaction) (*Decision
 	if err != nil {
 		return nil, err
 	}
-
-	batchDecision := &Decision{}
+	batchDecision := allowedDecision
 	newTATs := make(map[string]time.Time)
 	txnOutcomes := make(map[Transaction]string)
 
@@ -367,7 +363,7 @@ func (l *Limiter) BatchRefund(ctx context.Context, txns []Transaction) (*Decisio
 		return nil, err
 	}
 
-	batchDecision := &Decision{}
+	batchDecision := allowedDecision
 	newTATs := make(map[string]time.Time)
 
 	for _, txn := range batch {

--- a/ratelimits/limiter.go
+++ b/ratelimits/limiter.go
@@ -276,7 +276,7 @@ func (l *Limiter) BatchSpend(ctx context.Context, txns []Transaction) (*Decision
 		return nil, err
 	}
 
-	var batchDecision *Decision
+	batchDecision := &Decision{}
 	newTATs := make(map[string]time.Time)
 	txnOutcomes := make(map[Transaction]string)
 
@@ -300,6 +300,8 @@ func (l *Limiter) BatchSpend(ctx context.Context, txns []Transaction) (*Decision
 		}
 
 		if !txn.spendOnly() {
+			// Spend-only Transactions are best-effort and do not contribute to
+			// the batchDecision.
 			batchDecision = stricter(batchDecision, d)
 		}
 
@@ -365,7 +367,7 @@ func (l *Limiter) BatchRefund(ctx context.Context, txns []Transaction) (*Decisio
 		return nil, err
 	}
 
-	var batchDecision *Decision
+	batchDecision := &Decision{}
 	newTATs := make(map[string]time.Time)
 
 	for _, txn := range batch {


### PR DESCRIPTION
Fix a bug added in #7653 which sometimes attributed an "Allowed" `Transaction` to the amalgamated "Denied" `*Decision`. Instead, always return the most restrictive `*Decision` in the batch.

Remove a debug `fmt.Printf()` call added in #7653