### PR TITLE
Improve how we disable challenge types

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -10,5 +10,5 @@ type PolicyAuthority interface {
 	WillingToIssue([]string) error
 	ChallengeTypesFor(identifier.ACMEIdentifier) ([]AcmeChallenge, error)
 	ChallengeTypeEnabled(AcmeChallenge) bool
-	CheckAuthz(*Authorization) error
+	CheckAuthzChallenges(*Authorization) error
 }

--- a/core/objects.go
+++ b/core/objects.go
@@ -337,14 +337,14 @@ func (authz *Authorization) FindChallengeByStringID(id string) int {
 // challenge is valid.
 func (authz *Authorization) SolvedBy() (AcmeChallenge, error) {
 	if len(authz.Challenges) == 0 {
-		return "", fmt.Errorf("Authorization has no challenges")
+		return "", fmt.Errorf("authorization has no challenges")
 	}
 	for _, chal := range authz.Challenges {
 		if chal.Status == StatusValid {
 			return chal.Type, nil
 		}
 	}
-	return "", fmt.Errorf("Authorization not solved by any challenge")
+	return "", fmt.Errorf("authorization not solved by any challenge")
 }
 
 // JSONBuffer fields get encoded and decoded JOSE-style, in base64url encoding

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -100,7 +100,7 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 		{
 			Name:          "No challenges",
 			Authz:         Authorization{},
-			ExpectedError: "Authorization has no challenges",
+			ExpectedError: "authorization has no challenges",
 		},
 		// An authz with all non-valid challenges should return nil
 		{
@@ -108,7 +108,7 @@ func TestAuthorizationSolvedBy(t *testing.T) {
 			Authz: Authorization{
 				Challenges: []Challenge{HTTPChallenge01(""), DNSChallenge01("")},
 			},
-			ExpectedError: "Authorization not solved by any challenge",
+			ExpectedError: "authorization not solved by any challenge",
 		},
 		// An authz with one valid HTTP01 challenge amongst other challenges should
 		// return the HTTP01 challenge

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -39,7 +39,7 @@ func (pa *mockPA) ChallengeTypeEnabled(t core.AcmeChallenge) bool {
 	return true
 }
 
-func (pa *mockPA) CheckAuthz(a *core.Authorization) error {
+func (pa *mockPA) CheckAuthzChallenges(a *core.Authorization) error {
 	return nil
 }
 

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -551,10 +551,10 @@ func (pa *AuthorityImpl) ChallengeTypeEnabled(t core.AcmeChallenge) bool {
 	return pa.enabledChallenges[t]
 }
 
-// CheckAuthz determines that an authorization was fulfilled by a challenge that
-// is currently enabled and was appropriate for the kind of identifier in the
-// authorization.
-func (pa *AuthorityImpl) CheckAuthz(authz *core.Authorization) error {
+// CheckAuthzChallenges determines that an authorization was fulfilled by a
+// challenge that is currently enabled and was appropriate for the kind of
+// identifier in the authorization.
+func (pa *AuthorityImpl) CheckAuthzChallenges(authz *core.Authorization) error {
 	chall, err := authz.SolvedBy()
 	if err != nil {
 		return err
@@ -570,7 +570,7 @@ func (pa *AuthorityImpl) CheckAuthz(authz *core.Authorization) error {
 	}
 
 	if !slices.Contains(challTypes, chall) {
-		return errors.New("authorization fulfilled by invalid challenge")
+		return errors.New("authorization fulfilled by inapplicable challenge type")
 	}
 
 	return nil

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -558,12 +558,17 @@ func (pa *AuthorityImpl) ChallengeTypeEnabled(t core.AcmeChallenge) bool {
 	return pa.enabledChallenges[t]
 }
 
-// CheckAuthz determines that an authorization was fulfilled by a challenge
-// that was appropriate for the kind of identifier in the authorization.
+// CheckAuthz determines that an authorization was fulfilled by a challenge that
+// is currently enabled and was appropriate for the kind of identifier in the
+// authorization.
 func (pa *AuthorityImpl) CheckAuthz(authz *core.Authorization) error {
 	chall, err := authz.SolvedBy()
 	if err != nil {
 		return err
+	}
+
+	if !pa.ChallengeTypeEnabled(chall) {
+		return errors.New("authorization fulfilled by disabled challenge type")
 	}
 
 	challTypes, err := pa.ChallengeTypesFor(authz.Identifier)

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -484,7 +484,7 @@ func TestValidEmailError(t *testing.T) {
 	test.AssertEquals(t, err.Error(), "contact email \"example@-foobar.com\" has invalid domain : Domain name contains an invalid character")
 }
 
-func TestCheckAuthz(t *testing.T) {
+func TestCheckAuthzChallenges(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -532,7 +532,7 @@ func TestCheckAuthz(t *testing.T) {
 				Identifier: identifier.ACMEIdentifier{Type: identifier.DNS, Value: "*.example.com"},
 				Challenges: []core.Challenge{{Type: core.ChallengeTypeHTTP01, Status: core.StatusValid}},
 			},
-			wantErr: "invalid challenge",
+			wantErr: "inapplicable challenge type",
 		},
 		{
 			name: "valid authz",
@@ -552,7 +552,7 @@ func TestCheckAuthz(t *testing.T) {
 				pa.enabledChallenges = tc.enabled
 			}
 
-			err := pa.CheckAuthz(&tc.authz)
+			err := pa.CheckAuthzChallenges(&tc.authz)
 
 			if tc.wantErr == "" {
 				test.AssertNotError(t, err, "should have succeeded")

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -826,7 +826,7 @@ func (ra *RegistrationAuthorityImpl) checkOrderAuthorizations(
 			expired = append(expired, ident.Value)
 			continue
 		}
-		err = ra.PA.CheckAuthz(authz)
+		err = ra.PA.CheckAuthzChallenges(authz)
 		if err != nil {
 			invalid = append(invalid, ident.Value)
 			continue

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -2516,7 +2516,7 @@ func TestNewOrderWildcard(t *testing.T) {
 			test.AssertEquals(t, authz.Challenges[0].Type, core.ChallengeTypeDNS01)
 		case "example.com":
 			// If the authz is for example.com, we expect it has normal challenges
-			test.AssertEquals(t, len(authz.Challenges), 2)
+			test.AssertEquals(t, len(authz.Challenges), 3)
 		default:
 			t.Fatalf("Received an authorization for a name not requested: %q", name)
 		}
@@ -2556,7 +2556,7 @@ func TestNewOrderWildcard(t *testing.T) {
 		case "zombo.com":
 			// We expect that the base domain identifier auth has the normal number of
 			// challenges
-			test.AssertEquals(t, len(authz.Challenges), 2)
+			test.AssertEquals(t, len(authz.Challenges), 3)
 		case "*.zombo.com":
 			// We expect that the wildcard identifier auth has only a pending
 			// DNS-01 type challenge
@@ -2590,7 +2590,7 @@ func TestNewOrderWildcard(t *testing.T) {
 	// We expect the authz is for the identifier the correct domain
 	test.AssertEquals(t, authz.Identifier.Value, "everything.is.possible.zombo.com")
 	// We expect the authz has the normal # of challenges
-	test.AssertEquals(t, len(authz.Challenges), 2)
+	test.AssertEquals(t, len(authz.Challenges), 3)
 
 	// Now submit an order request for a wildcard of the domain we just created an
 	// order for. We should **NOT** reuse the authorization from the previous

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3153,6 +3153,61 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 		"wildcard order")
 }
 
+func TestFinalizeOrderDisabledChallenge(t *testing.T) {
+	_, sa, ra, fc, cleanUp := initAuthorities(t)
+	defer cleanUp()
+
+	// Create a random domain
+	var bytes [3]byte
+	_, err := rand.Read(bytes[:])
+	test.AssertNotError(t, err, "creating test domain name")
+	domain := fmt.Sprintf("%x.example.com", bytes[:])
+
+	// Create a finalized authorization for that domain
+	authzID := createFinalizedAuthorization(
+		t, sa, domain, fc.Now().Add(24*time.Hour), core.ChallengeTypeHTTP01, fc.Now().Add(-1*time.Hour))
+
+	// Create an order that reuses that authorization
+	order, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
+		RegistrationID: Registration.Id,
+		DnsNames:       []string{domain},
+	})
+	test.AssertNotError(t, err, "creating test order")
+	test.AssertEquals(t, order.V2Authorizations[0], authzID)
+
+	// Create a CSR for this order
+	testKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "generating test key")
+	csr, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		PublicKey: testKey.PublicKey,
+		DNSNames:  []string{domain},
+	}, testKey)
+	test.AssertNotError(t, err, "Error creating policy forbid CSR")
+
+	// Replace the Policy Authority with one which has this challenge type disabled
+	pa, err := policy.New(map[core.AcmeChallenge]bool{
+		core.ChallengeTypeDNS01:     true,
+		core.ChallengeTypeTLSALPN01: true,
+	}, ra.log)
+	test.AssertNotError(t, err, "creating test PA")
+	err = pa.LoadHostnamePolicyFile("../test/hostname-policy.yaml")
+	test.AssertNotError(t, err, "loading test hostname policy")
+	ra.PA = pa
+
+	// Now finalizing this order should fail
+	_, err = ra.FinalizeOrder(context.Background(), &rapb.FinalizeOrderRequest{
+		Order: order,
+		Csr:   csr,
+	})
+	test.AssertError(t, err, "finalization should fail")
+
+	// Unfortunately we can't test for the PA's "which is now disabled" error
+	// message directly, because the RA discards it and collects all invalid names
+	// into a single more generic error message. But it does at least distinguish
+	// between missing, expired, and invalid, so we can test for "invalid".
+	test.AssertContains(t, err.Error(), "authorizations for these identifiers not valid")
+}
+
 func TestIssueCertificateAuditLog(t *testing.T) {
 	_, sa, ra, _, cleanUp := initAuthorities(t)
 	defer cleanUp()


### PR DESCRIPTION
When creating an authorization, populate it with all challenges appropriate for that identifier, regardless of whether those challenge types are currently "enabled" in the config. This ensures that authorizations created during a incident for which we can temporarily disabled a single challenge type can still be validated via that challenge type after the incident is over.

Also, when finalizing an order, check that the challenge type used to validation each authorization is not currently disabled. This ensures that, if we temporarily disable a single challenge due to an incident, we don't issue any more certificates using authorizations which were fulfilled using that disabled challenge.

Note that standard rolling deployment of this change is not safe if any challenges are disabled at the same time, due to the possibility of an updated RA not filtering a challenge when writing it to the database, and then a non-updated RA not filtering it when reading from the database. But if all challenges are enabled then this change is safe for normal deploy.

Fixes https://github.com/letsencrypt/boulder/issues/5913

DO NOT MERGE until https://github.com/letsencrypt/boulder/pull/7659 has been deployed