### PR TITLE
CA: Check system time synchronized upon startup

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -199,10 +199,11 @@ func main() {
 	// server. This is important for the CA because it selects our notBefore and
 	// notAfter values, which MUST NOT be more than 48 hours from the actual time
 	// of the signing operation per BRs Section 7.1.2.7.
+	// See https://man7.org/linux/man-pages/man2/adjtimex.2.html
 	var timex = new(unix.Timex)
-	status, err := unix.Adjtimex(timex)
+	clockState, err := unix.Adjtimex(timex)
 	cmd.FailOnError(err, "Failed to check system time")
-	if status == unix.TIME_ERROR {
+	if clockState == unix.TIME_ERROR {
 		cmd.Fail("System time not synchronized to a reliable server")
 	}
 

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/letsencrypt/boulder/ca"
 	capb "github.com/letsencrypt/boulder/ca/proto"
 	"github.com/letsencrypt/boulder/cmd"
@@ -191,6 +193,17 @@ func main() {
 	if c.CA.CTLogListFile != "" {
 		err = loglist.InitLintList(c.CA.CTLogListFile)
 		cmd.FailOnError(err, "Failed to load CT Log List")
+	}
+
+	// Check that the system clock believes it is synced with a reliable time
+	// server. This is important for the CA because it selects our notBefore and
+	// notAfter values, which MUST NOT be more than 48 hours from the actual time
+	// of the signing operation per BRs Section 7.1.2.7.
+	var timex = new(unix.Timex)
+	status, err := unix.Adjtimex(timex)
+	cmd.FailOnError(err, "Failed to check system time")
+	if status == unix.TIME_ERROR {
+		cmd.Fail("System time not synchronized to a reliable server")
 	}
 
 	clk := cmd.Clock()

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3
 	golang.org/x/net v0.28.0
 	golang.org/x/sync v0.8.0
+	golang.org/x/sys v0.23.0
 	golang.org/x/term v0.23.0
 	golang.org/x/text v0.17.0
 	google.golang.org/grpc v1.64.1
@@ -84,7 +85,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
 	golang.org/x/mod v0.18.0 // indirect
-	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240520151616-dc85e6b867a5 // indirect


### PR DESCRIPTION
Use the `adjtimex` unix syscall[1] to check that the system clock is synchronized with a reliable time server during CA startup. This helps ensure that the CA's system clock doesn't cause us to accidentally violate the requirement that the notBefore date be within 48 hours of the signing operation.

[1] https://man7.org/linux/man-pages/man2/adjtimex.2.html