### PR TITLE
Omit revocation information for short-lived certificates

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -117,6 +117,13 @@ type Config struct {
 	// to be the authoritative source of rate limiting information for
 	// new-account callers and disables the legacy rate limiting checks.
 	UseKvLimitsForNewAccount bool
+
+	// OmitShortLivedRevocation causes the AIA OCSP URL and/or the CRLDP URL to be
+	// omitted from certificates whose validity period is less than or equal to 7
+	// days. This validity period is the threshold to qualify as a "Short-Lived
+	// Certificate" per the BRs Section 1.6.1, and therefore to not require
+	// revocation information per the BRs Sections 4.9.1.1 and 7.1.2.11.2.
+	OmitShortLivedRevocation bool
 }
 
 var fMu = new(sync.RWMutex)

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -152,7 +152,9 @@
 		"ocspLogMaxLength": 4000,
 		"ocspLogPeriod": "500ms",
 		"ctLogListFile": "test/ct-test-srv/log_list.json",
-		"features": {}
+		"features": {
+			"OmitShortLivedRevocation": true
+		}
 	},
 	"pa": {
 		"challenges": {


### PR DESCRIPTION
Add a new "OmitShortLivedRevocation" feature flag. When this flag is enabled in the CA, reset the AIA OCSP URL to be nil.

Fixes https://github.com/letsencrypt/boulder/issues/7673

DO NOT MERGE: we're not yet at the point where enabling this makes sense, since we don't have integration tests for short-lived certs, we don't have clients that can request short-lived profiles, and the Microsoft root program requirements still mandate OCSP for all certs regardless of lifetime. I'm just uploading this as a draft now so we have it on hand when the time comes.