### PR TITLE
Write release checksums to per-release files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         id: checksums
         # The files listed on this line must be identical to the files uploaded
         # in the last step.
-        run: sha256sum boulder*.deb boulder*.tar.gz >| checksums.txt
+        run: sha256sum boulder*.deb boulder*.tar.gz >| boulder-${{ matrix.GO_VERSION }}.$(date +%s)-$(git rev-parse --short=8 HEAD).checksums.txt
 
       - name: Create release
         env:
@@ -48,4 +48,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://cli.github.com/manual/gh_release_upload
-        run: gh release upload "${GITHUB_REF_NAME}" boulder*.deb boulder*.tar.gz checksums.txt
+        run: gh release upload "${GITHUB_REF_NAME}" boulder*.deb boulder*.tar.gz boulder*.checksums.txt

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   try-release:
@@ -33,4 +34,12 @@ jobs:
         id: checksums
         # The files listed on this line must be identical to the files uploaded
         # in the last step of the real release action.
-        run: sha256sum boulder*.deb boulder*.tar.gz
+        run: sha256sum boulder*.deb boulder*.tar.gz >| boulder-${{ matrix.GO_VERSION }}.$(date +%s)-$(git rev-parse --short=8 HEAD).checksums.txt
+
+      - name: List files
+        id: files
+        run: ls boulder*.deb boulder*.tar.gz boulder*.checksums.txt
+
+      - name: Show checksums
+        id: check
+        run: cat boulder*.checksums.txt


### PR DESCRIPTION
Have the release action write the checksums to a file whose name matches the name of the boulder deb and rpm files whose checksums it contains. This prevents name-collision errors when we are running multiple Go versions side-by-side in CI.

To demonstrate this, augment the try-release action to write the checksums to the same file, print the list of files it would upload, and print the contents of the checksums file. Also allow the try-release workflow to be triggered manually.