### PR TITLE
Minor fix to gRPC interceptor deadline computation

### DIFF
--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -99,10 +99,10 @@ func (smi *serverMetadataInterceptor) Unary(
 	deadline, ok := ctx.Deadline()
 	// Should never happen: there was no deadline.
 	if !ok {
-		deadline = time.Now().Add(100 * time.Second)
+		deadline = smi.clk.Now().Add(100 * time.Second)
 	}
 	deadline = deadline.Add(-returnOverhead)
-	remaining := time.Until(deadline)
+	remaining := deadline.Sub(smi.clk.Now())
 	if remaining < meaningfulWorkOverhead {
 		return nil, status.Errorf(codes.DeadlineExceeded, "not enough time left on clock: %s", remaining)
 	}
@@ -158,10 +158,10 @@ func (smi *serverMetadataInterceptor) Stream(
 	deadline, ok := ctx.Deadline()
 	// Should never happen: there was no deadline.
 	if !ok {
-		deadline = time.Now().Add(100 * time.Second)
+		deadline = smi.clk.Now().Add(100 * time.Second)
 	}
 	deadline = deadline.Add(-returnOverhead)
-	remaining := time.Until(deadline)
+	remaining := deadline.Sub(smi.clk.Now())
 	if remaining < meaningfulWorkOverhead {
 		return status.Errorf(codes.DeadlineExceeded, "not enough time left on clock: %s", remaining)
 	}

--- a/grpc/interceptors_test.go
+++ b/grpc/interceptors_test.go
@@ -184,7 +184,7 @@ func TestTimeouts(t *testing.T) {
 
 	serverMetrics, err := newServerMetrics(metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "creating server metrics")
-	si := newServerMetadataInterceptor(serverMetrics, clock.NewFake())
+	si := newServerMetadataInterceptor(serverMetrics, clock.New())
 	s := grpc.NewServer(grpc.UnaryInterceptor(si.Unary))
 	test_proto.RegisterChillerServer(s, &testServer{})
 	go func() {
@@ -202,7 +202,7 @@ func TestTimeouts(t *testing.T) {
 	ci := &clientMetadataInterceptor{
 		timeout: 30 * time.Second,
 		metrics: clientMetrics,
-		clk:     clock.NewFake(),
+		clk:     clock.New(),
 	}
 	conn, err := grpc.Dial(net.JoinHostPort("localhost", strconv.Itoa(port)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),


### PR DESCRIPTION
Our gRPC server interceptor ensures that a deadline is set even if none was specified by the client, and bails out immediately if the amount of time to complete the request is too low. However, it was using the global clock to perform these computations, instead of using the instance-specific clock like it uses for other operations. This was causing some problems debugging unit tests.