### PR TITLE
Remove outdated integration test limitations

### DIFF
--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -96,12 +96,6 @@ func TestIssuanceCertStorageFailed(t *testing.T) {
 
 	ctx := context.Background()
 
-	// This test is gated on the StoreLintingCertificateInsteadOfPrecertificate
-	// feature flag.
-	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
-		t.Skip("Skipping test because it requires the StoreLintingCertificateInsteadOfPrecertificate feature flag")
-	}
-
 	db, err := sql.Open("mysql", vars.DBConnSAIntegrationFullPerms)
 	test.AssertNotError(t, err, "failed to open db connection")
 

--- a/test/integration/subordinate_ca_chains_test.go
+++ b/test/integration/subordinate_ca_chains_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"os"
 	"strings"
 	"testing"
 
@@ -15,10 +14,6 @@ import (
 
 func TestSubordinateCAChainsServedByWFE(t *testing.T) {
 	t.Parallel()
-
-	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
-		t.Skip("Skipping test in config")
-	}
 
 	client, err := makeClient("mailto:example@letsencrypt.org")
 	test.AssertNotError(t, err, "creating acme client")


### PR DESCRIPTION
Remove outdated limitations in TestIssuanceCertStorageFailed & TestSubordinateCAChainsServedByWFE

Fixes https://github.com/letsencrypt/boulder/issues/7696