### PR TITLE
Add sqlclosecheck to golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - sqlclosecheck
     # TODO(#6202): Re-enable 'wastedassign' linter
 linters-settings:
   errcheck:


### PR DESCRIPTION
This linter helps identify failure to close sql rows, which can lead to connection pool issues.

This PR is a "WIP" because there's some failures, but they don't look immediately important.