### PR TITLE
Make upgrading OpenTelemetry easier

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -314,20 +314,14 @@ func NewOpenTelemetry(config OpenTelemetryConfig, logger blog.Logger) func(ctx c
 	otel.SetLogger(stdr.New(logOutput{logger}))
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) { logger.Errf("OpenTelemetry error: %v", err) }))
 
-	r, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(core.Command()),
-			semconv.ServiceVersionKey.String(core.GetBuildID()),
-		),
+	resources := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceNameKey.String(core.Command()),
+		semconv.ServiceVersionKey.String(core.GetBuildID()),
 	)
-	if err != nil {
-		FailOnError(err, "Could not create OpenTelemetry resource")
-	}
 
 	opts := []trace.TracerProviderOption{
-		trace.WithResource(r),
+		trace.WithResource(resources),
 		// Use a ParentBased sampler to respect the sample decisions on incoming
 		// traces, and TraceIDRatioBased to randomly sample new traces.
 		trace.WithSampler(trace.ParentBased(trace.TraceIDRatioBased(config.SampleRatio))),

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -318,6 +318,7 @@ func NewOpenTelemetry(config OpenTelemetryConfig, logger blog.Logger) func(ctx c
 		semconv.SchemaURL,
 		semconv.ServiceName(core.Command()),
 		semconv.ServiceVersion(core.GetBuildID()),
+		semconv.ProcessPID(os.Getpid()),
 	)
 
 	opts := []trace.TracerProviderOption{

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -316,8 +316,8 @@ func NewOpenTelemetry(config OpenTelemetryConfig, logger blog.Logger) func(ctx c
 
 	resources := resource.NewWithAttributes(
 		semconv.SchemaURL,
-		semconv.ServiceNameKey.String(core.Command()),
-		semconv.ServiceVersionKey.String(core.GetBuildID()),
+		semconv.ServiceName(core.Command()),
+		semconv.ServiceVersion(core.GetBuildID()),
 	)
 
 	opts := []trace.TracerProviderOption{


### PR DESCRIPTION
OpenTelemetry has "semantic conventions" which are versioned independently of the software package, as it describes the semantics of the resources being produced.  Previously, we'd combined `resource.Default()` using the `Merge` function with our own resources.

Merge, however, doesn't handle merging resources with different semantic conventions.  This means that every dependabot PR that bumps otel will break when the `resources.Default` has a new version.

That doesn't seem worth it for the default resources, so just provide our own resources which have everything we care about. I've added the PID  which we didn't have before but will be interesting. We will lose the SDK's version, but I don't think that matters.

For more discussion on this topic, see https://github.com/open-telemetry/opentelemetry-go/issues/3769