### PR TITLE
WFE: Suppress logging of probs.PausedProblem

### DIFF
--- a/probs/probs.go
+++ b/probs/probs.go
@@ -27,6 +27,7 @@ const (
 	InvalidContactProblem        = ProblemType("invalidContact")
 	MalformedProblem             = ProblemType("malformed")
 	OrderNotReadyProblem         = ProblemType("orderNotReady")
+	PausedProblem                = ProblemType("rateLimited")
 	RateLimitedProblem           = ProblemType("rateLimited")
 	RejectedIdentifierProblem    = ProblemType("rejectedIdentifier")
 	ServerInternalProblem        = ProblemType("serverInternal")
@@ -220,7 +221,7 @@ func RateLimited(detail string) *ProblemDetails {
 // Paused returns a ProblemDetails representing a RateLimitedProblem error
 func Paused(detail string) *ProblemDetails {
 	return &ProblemDetails{
-		Type:       RateLimitedProblem,
+		Type:       PausedProblem,
 		Detail:     detail,
 		HTTPStatus: http.StatusTooManyRequests,
 	}

--- a/web/send_error.go
+++ b/web/send_error.go
@@ -39,9 +39,9 @@ func SendError(
 
 	// Suppress logging of the "Your account is temporarily prevented from
 	// requesting certificates" error.
-	var primaryDetail string
+	var primaryDetail = prob.Detail
 	if prob.Type == probs.PausedProblem {
-		primaryDetail = "caller is paused"
+		primaryDetail = "account is paused"
 	}
 
 	// Record details to the log event

--- a/web/send_error.go
+++ b/web/send_error.go
@@ -37,8 +37,15 @@ func SendError(
 		response.WriteHeader(http.StatusInternalServerError)
 	}
 
+	// Suppress logging of the "Your account is temporarily prevented from
+	// requesting certificates" error.
+	var primaryDetail string
+	if prob.Type == probs.PausedProblem {
+		primaryDetail = "caller is paused"
+	}
+
 	// Record details to the log event
-	logEvent.Error = fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, prob.Detail)
+	logEvent.Error = fmt.Sprintf("%d :: %s :: %s", prob.HTTPStatus, prob.Type, primaryDetail)
 	if len(prob.SubProblems) > 0 {
 		subDetails := make([]string, len(prob.SubProblems))
 		for i, sub := range prob.SubProblems {

--- a/web/send_error.go
+++ b/web/send_error.go
@@ -41,7 +41,7 @@ func SendError(
 	// requesting certificates" error.
 	var primaryDetail = prob.Detail
 	if prob.Type == probs.PausedProblem {
-		primaryDetail = "account is paused"
+		primaryDetail = "account/ident pair is paused"
 	}
 
 	// Record details to the log event

--- a/web/send_error_test.go
+++ b/web/send_error_test.go
@@ -8,6 +8,7 @@ import (
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -93,4 +94,12 @@ func TestSendErrorSubProbLogging(t *testing.T) {
 	SendError(log.NewMock(), rw, &logEvent, prob, errors.New("it bad"))
 
 	test.AssertEquals(t, logEvent.Error, `400 :: malformed :: dfoop :: bad ["example.com :: malformed :: dfoop :: nop", "what about example.com :: malformed :: dfoop :: nah"]`)
+}
+
+func TestSendErrorPausedProblemLoggingSuppression(t *testing.T) {
+	rw := httptest.NewRecorder()
+	logEvent := RequestEvent{}
+	SendError(log.NewMock(), rw, &logEvent, probs.Paused("I better not see any of this"), nil)
+
+	test.AssertEquals(t, logEvent.Error, "429 :: rateLimited :: account/ident pair is paused")
 }


### PR DESCRIPTION
Instead of logging the message shown to the caller, log "429 :: rateLimited :: account/ident pair is paused"