### PR TITLE
ratelimits: Set a TTL each time we store bucket data in Redis

### DIFF
--- a/ratelimits/source_redis.go
+++ b/ratelimits/source_redis.go
@@ -89,7 +89,9 @@ func (r *RedisSource) BatchSet(ctx context.Context, buckets map[string]time.Time
 
 	pipeline := r.client.Pipeline()
 	for bucketKey, tat := range buckets {
-		pipeline.Set(ctx, bucketKey, tat.UTC().UnixNano(), 0)
+		// Set a TTL of TAT + 10 minutes to account for clock skew.
+		ttl := tat.UTC().Sub(r.clk.Now()) + time.Minute*10
+		pipeline.Set(ctx, bucketKey, tat.UTC().UnixNano(), ttl)
 	}
 	_, err := pipeline.Exec(ctx)
 	if err != nil {

--- a/ratelimits/source_redis.go
+++ b/ratelimits/source_redis.go
@@ -90,7 +90,7 @@ func (r *RedisSource) BatchSet(ctx context.Context, buckets map[string]time.Time
 	pipeline := r.client.Pipeline()
 	for bucketKey, tat := range buckets {
 		// Set a TTL of TAT + 10 minutes to account for clock skew.
-		ttl := tat.UTC().Sub(r.clk.Now()) + time.Minute*10
+		ttl := tat.UTC().Sub(r.clk.Now()) + 10*time.Minute
 		pipeline.Set(ctx, bucketKey, tat.UTC().UnixNano(), ttl)
 	}
 	_, err := pipeline.Exec(ctx)


### PR DESCRIPTION
Set the Redis TTL to TAT (theoretical arrival time) plus a 10-minute buffer to account for possible clock skew.