### PR TITLE
Introduce SerialPrefixHex field in CA

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -126,7 +126,7 @@ type certificateAuthorityImpl struct {
 	issuers      issuerMaps
 	certProfiles certProfilesMaps
 
-	prefix    uint8 // Prepended to the serial number
+	prefix    byte // Prepended to the serial number
 	maxNames  int
 	keyPolicy goodkey.KeyPolicy
 	clk       clock.Clock
@@ -233,7 +233,7 @@ func NewCertificateAuthorityImpl(
 	boulderIssuers []*issuance.Issuer,
 	defaultCertProfileName string,
 	certificateProfiles map[string]*issuance.ProfileConfig,
-	serialPrefix uint8,
+	serialPrefix byte,
 	maxNames int,
 	keyPolicy goodkey.KeyPolicy,
 	logger blog.Logger,
@@ -243,8 +243,8 @@ func NewCertificateAuthorityImpl(
 	var ca *certificateAuthorityImpl
 	var err error
 
-	if serialPrefix < 1 || serialPrefix > 127 {
-		err = errors.New("serial prefix must be between 1 (0x01) and 127 (0x7f)")
+	if serialPrefix < 0x01 || serialPrefix > 0x7f {
+		err = errors.New("serial prefix must be between 0x01 (1) and 0x7f (127)")
 		return nil, err
 	}
 

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -130,7 +130,8 @@ type certificateAuthorityImpl struct {
 	issuers      issuerMaps
 	certProfiles certProfilesMaps
 
-	prefix    byte // Prepended to the serial number
+	// The prefix is prepended to the serial number.
+	prefix    byte
 	maxNames  int
 	keyPolicy goodkey.KeyPolicy
 	clk       clock.Clock

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -476,7 +476,7 @@ func (ca *certificateAuthorityImpl) generateSerialNumber() (*big.Int, error) {
 	// We want 136 bits of random number, plus an 8-bit instance id prefix.
 	const randBits = 136
 	serialBytes := make([]byte, randBits/8+1)
-	serialBytes[0] = byte(ca.prefix)
+	serialBytes[0] = ca.prefix
 	_, err := rand.Read(serialBytes[1:])
 	if err != nil {
 		err = berrors.InternalServerError("failed to generate serial: %s", err)

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -126,7 +126,7 @@ type certificateAuthorityImpl struct {
 	issuers      issuerMaps
 	certProfiles certProfilesMaps
 
-	prefix    int // Prepended to the serial number
+	prefix    uint8 // Prepended to the serial number
 	maxNames  int
 	keyPolicy goodkey.KeyPolicy
 	clk       clock.Clock
@@ -233,7 +233,7 @@ func NewCertificateAuthorityImpl(
 	boulderIssuers []*issuance.Issuer,
 	defaultCertProfileName string,
 	certificateProfiles map[string]*issuance.ProfileConfig,
-	serialPrefix int,
+	serialPrefix uint8,
 	maxNames int,
 	keyPolicy goodkey.KeyPolicy,
 	logger blog.Logger,
@@ -244,7 +244,7 @@ func NewCertificateAuthorityImpl(
 	var err error
 
 	if serialPrefix < 1 || serialPrefix > 127 {
-		err = errors.New("serial prefix must be between 1 and 127")
+		err = errors.New("serial prefix must be between 1 (0x01) and 127 (0x7f)")
 		return nil, err
 	}
 

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -103,7 +103,7 @@ type testCtx struct {
 	crl                    *crlImpl
 	defaultCertProfileName string
 	certProfiles           map[string]*issuance.ProfileConfig
-	serialPrefix           int
+	serialPrefix           uint8
 	maxNames               int
 	boulderIssuers         []*issuance.Issuer
 	keyPolicy              goodkey.KeyPolicy
@@ -237,7 +237,7 @@ func setup(t *testing.T) *testCtx {
 		crl:                    crl,
 		defaultCertProfileName: "legacy",
 		certProfiles:           certProfiles,
-		serialPrefix:           17,
+		serialPrefix:           0x11,
 		maxNames:               2,
 		boulderIssuers:         boulderIssuers,
 		keyPolicy:              keyPolicy,
@@ -257,7 +257,7 @@ func TestSerialPrefix(t *testing.T) {
 		nil,
 		"",
 		nil,
-		0,
+		0x00,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
 		testCtx.logger,
@@ -271,7 +271,7 @@ func TestSerialPrefix(t *testing.T) {
 		nil,
 		"",
 		nil,
-		128,
+		0x80,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
 		testCtx.logger,

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -103,7 +103,7 @@ type testCtx struct {
 	crl                    *crlImpl
 	defaultCertProfileName string
 	certProfiles           map[string]*issuance.ProfileConfig
-	serialPrefix           uint8
+	serialPrefix           byte
 	maxNames               int
 	boulderIssuers         []*issuance.Issuer
 	keyPolicy              goodkey.KeyPolicy

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -164,11 +164,11 @@ func main() {
 		c.CA.DebugAddr = *debugAddr
 	}
 
-	serialPrefix := uint8(c.CA.SerialPrefix)
+	serialPrefix := byte(c.CA.SerialPrefix)
 	if c.CA.SerialPrefixHex != "" {
 		parsedSerialPrefix, err := strconv.ParseUint(c.CA.SerialPrefixHex, 16, 8)
 		cmd.FailOnError(err, "Couldn't convert SerialPrefixHex to int")
-		serialPrefix = uint8(parsedSerialPrefix)
+		serialPrefix = byte(parsedSerialPrefix)
 	}
 
 	if c.CA.MaxNames == 0 {

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -73,7 +73,7 @@ type Config struct {
 		// Deprecated: Use SerialPrefixHex instead.
 		SerialPrefix int `validate:"required_without=SerialPrefixHex,omitempty,min=1,max=127"`
 
-		// What hex string we should prepend to serials after randomly
+		// SerialPrefixHex is the hex string to prepend to serials after randomly
 		// generating them. The minimum value is "01" to ensure that at least
 		// one bit in the prefix byte is set. The maximum value is "7f" to
 		// ensure that the first bit in the prefix byte is not set. The validate

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -142,7 +142,7 @@
 				}
 			]
 		},
-		"serialPrefix": 127,
+		"serialPrefixHex": "7f",
 		"maxNames": 100,
 		"lifespanOCSP": "96h",
 		"goodkey": {


### PR DESCRIPTION
Add a new SerialPrefixHex field to the CA's config, which takes a two-character hexadecimal string to use as the serial prefix. This matches the way that the OCSP Responder's acceptable serial prefixes are configured, and is easier for human operators to configure than raw integers.

At the same time, change the type of the CA's internal serial prefix from `int` to `byte`, using the type system to enforce its 8-bit length.

Fixes #7213 