### PR TITLE
Log the time hourly

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -222,7 +222,7 @@ func NewLogger(logConf SyslogConfig) blog.Logger {
 	// Boulder's conception of time.
 	go func() {
 		for {
-			time.Sleep(time.Minute)
+			time.Sleep(time.Hour)
 			logger.Info(fmt.Sprintf("time=%s", time.Now().Format(time.RFC3339Nano)))
 		}
 	}()


### PR DESCRIPTION
Logging it every minute is just a bit too much log volume and adds a fair
amount of clutter, especially for 'quieter' services.
