### PR TITLE
Change ClearEmail to use a direct UPDATE query

### DIFF
--- a/sa/model.go
+++ b/sa/model.go
@@ -116,7 +116,6 @@ func ClearEmail(ctx context.Context, dbMap db.DatabaseMap, regID int64, email st
 
 		return nil, nil
 	})
-
 	if overallError != nil {
 		return overallError
 	}

--- a/sa/model.go
+++ b/sa/model.go
@@ -88,16 +88,33 @@ func ClearEmail(ctx context.Context, dbMap db.DatabaseMap, regID int64, email st
 			return nil, nil
 		}
 
+		// We don't want to write literal JSON "null" strings into the database if the
+		// list of contact addresses is empty. Replace any possibly-`nil` slice with
+		// an empty JSON array. We don't need to check reg.ContactPresent, because
+		// we're going to write the whole object to the database anyway.
+		jsonContact := []byte("[]")
+		if len(newContacts) != 0 {
+			jsonContact, err = json.Marshal(newContacts)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		// UPDATE the row with a direct database query, in order to avoid LockCol issues.
-		//
-		// TODO(#7716): Revert to use tx.Update() once LockCol has been removed.
-		_, err = dbMap.ExecContext(ctx,
+		result, err := tx.ExecContext(ctx,
 			"UPDATE registrations SET contact = ? WHERE id = ? LIMIT 1",
-			newContacts,
+			jsonContact,
 			regID,
 		)
+		if err != nil {
+			return nil, err
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil || rowsAffected != 1 {
+			return nil, berrors.InternalServerError("no registration updated with new contact field")
+		}
 
-		return nil, err
+		return nil, nil
 	})
 
 	if overallError != nil {


### PR DESCRIPTION
Change ClearEmail to use a direct `UPDATE` query instead of `tx.Update()`, in order to avoid `LockCol` issues.

Part of https://github.com/letsencrypt/boulder/issues/7716