### PR TITLE
fix: fix slice init length

### DIFF
--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -217,7 +217,7 @@ func (ll List) subset(names []string) (List, error) {
 	}
 
 	if len(remaining) > 0 {
-		missed := make([]string, len(remaining))
+		missed := make([]string, 0, len(remaining))
 		for name := range remaining {
 			missed = append(missed, fmt.Sprintf("%q", name))
 		}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(remaining) rather than initializing the length of this slice.