### PR TITLE
Allow block-a-key to process private key files

### DIFF
--- a/test/block-a-key/main.go
+++ b/test/block-a-key/main.go
@@ -30,9 +30,9 @@ installation:
   go install github.com/letsencrypt/boulder/test/block-a-key/...
 
 usage:
-  block-a-key -cert <PEM encoded x509 certificate file>
+  block-a-key -cert <PEM formatted x509 certificate file>
   block-a-key -jwk <JSON encoded JWK file>
-  block-a-key -privateKey <PEM encoded private key file>
+  block-a-key -privateKey <PEM formatted private key file>
 
 output format:
   # <filepath>
@@ -46,7 +46,7 @@ examples:
   $> block-a-key -privateKey private.key
 `
 
-// keyFromPrivateKeyFile returns the public key from a PEM encoded private key
+// keyFromPrivateKeyFile returns the public key from a PEM formatted private key
 // located in pemFile or returns an error.
 func keyFromPrivateKeyFile(pemFile string) (crypto.PublicKey, error) {
 	_, pubKey, err := privatekey.Load(pemFile)
@@ -56,8 +56,8 @@ func keyFromPrivateKeyFile(pemFile string) (crypto.PublicKey, error) {
 	return pubKey, nil
 }
 
-// keyFromCert returns the public key from a PEM encoded certificate located in
-// pemFile or returns an error.
+// keyFromCert returns the public key from a PEM formatted certificate located
+// in pemFile or returns an error.
 func keyFromCert(pemFile string) (crypto.PublicKey, error) {
 	c, err := core.LoadCert(pemFile)
 	if err != nil {
@@ -77,9 +77,9 @@ func keyFromJWK(jsonFile string) (crypto.PublicKey, error) {
 }
 
 func main() {
-	certFileArg := flag.String("cert", "", "path to a PEM encoded X509 certificate file")
+	certFileArg := flag.String("cert", "", "path to a PEM formatted X509 certificate file")
 	jwkFileArg := flag.String("jwk", "", "path to a JSON encoded JWK file")
-	privKeyFileArg := flag.String("privateKey", "", "path to a PEM encoded private key file")
+	privKeyFileArg := flag.String("privateKey", "", "path to a PEM formatted private key file")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "%s\n\n", usageHelp)

--- a/test/block-a-key/main_test.go
+++ b/test/block-a-key/main_test.go
@@ -10,10 +10,11 @@ import (
 
 func TestKeyBlocking(t *testing.T) {
 	testCases := []struct {
-		name     string
-		certPath string
-		jwkPath  string
-		expected string
+		name        string
+		certPath    string
+		jwkPath     string
+		privKeyPath string
+		expected    string
 	}{
 		// NOTE(@cpu): The JWKs and certificates were generated with the same
 		// keypair within an algorithm/parameter family. E.g. the RSA JWK public key
@@ -39,16 +40,28 @@ func TestKeyBlocking(t *testing.T) {
 			certPath: "test/test.rsa.cert.pem",
 			expected: "Qebc1V3SkX3izkYRGNJilm9Bcuvf0oox4U2Rn+b4JOE=",
 		},
+		{
+			name:        "P-256 ECDSA Private Key",
+			privKeyPath: "../hierarchy/ee-e1.key.pem",
+			expected:    "ysCgov5oH7fsFs+ry0ODIx7runcINcS8V/0a0NWNQSY=",
+		},
+		{
+			name:        "2048 RSA Private Key",
+			privKeyPath: "../hierarchy/ee-r4.key.pem",
+			expected:    "ClG5+g8ypi7kMF6mxMT+gszQbwLjPsIv9mHNVjOv4FU=",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var key crypto.PublicKey
 			var err error
-			if tc.jwkPath != "" {
+			if tc.certPath != "" {
+				key, err = keyFromCert(tc.certPath)
+			} else if tc.jwkPath != "" {
 				key, err = keyFromJWK(tc.jwkPath)
 			} else {
-				key, err = keyFromCert(tc.certPath)
+				key, err = keyFromPrivateKeyFile(tc.privKeyPath)
 			}
 			test.AssertNotError(t, err, "error getting key from input file")
 			spkiHash, err := core.KeyDigestB64(key)


### PR DESCRIPTION
The CAB/F [Debian weak keys](https://github.com/cabforum/Debian-weak-keys) repository contains a bunch of DER encoded private keys that we should ensure are blocked. I hacked up the block-a-key tool to output a base64 encoded SPKI hash from an arbitrary PEM formatted private key file.

openssl output for comparison
```
$ openssl pkey -in ./test/hierarchy/ee-e1.key.pem -outform der -pubout | openssl dgst -sha256 -binary | openssl enc -base64
ysCgov5oH7fsFs+ry0ODIx7runcINcS8V/0a0NWNQSY=

$ openssl pkey -in ./test/hierarchy/ee-r4.key.pem -outform der -pubout | openssl dgst -sha256 -binary | openssl enc -base64
ClG5+g8ypi7kMF6mxMT+gszQbwLjPsIv9mHNVjOv4FU=
```