### PR TITLE
ca: log cert signing using JSON objects

### DIFF
--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -162,7 +162,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -154,7 +154,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
-		"sysloglevel": 4
+		"stdoutlevel": 6,
+		"sysloglevel": 6
 	}
 }


### PR DESCRIPTION
(Note: this PR is mainly for discussion of what direction we want to go)

This makes the log events easier to parse, and makes it easier to consistently use the correct fields from the issuance request.

Also, reduce the number of fields that are logged on error events. Logging just the serial and the error in most cases should suffice to cross-reference the error with the item that we attempted to sign.

Some example log output from an integration test run:

```
17:21:40.821440 6 boulder-ca qJ-v5w0 [AUDIT] Signing precert JSON={"csr":"3081f930819f0201003015311330110603550403130a3638613662382e636f6d3059301306072a8648ce3d020106082a8648ce3d030107034200040f643ac212536a7ce507cb46c89cf793b9ee6651e092fe21b6dcb664de893ea04674f4e4b078496fa033437ae2ea4fadb389ec28adb413ac968e36f5f97fe382a028302606092a864886f70d01090e3119301730150603551d11040e300c820a3638613662382e636f6d300a06082a8648ce3d0403020349003046022100d8337cb3bb6638401139129b29cad1f3557e15733aa66645ed32b4fe55047370022100eda2acd351063a5de0f7253a68aa42191a6e136b464fe7a8565eec9fedabd857","issuanceRequest":{"commonName":"68a6b8.com","dnsNames":["68a6b8.com"],"includeCTPoison":true,"includeMustStaple":false,"notAfter":"2025-01-01T16:23:09.81845777Z","notBefore":"2024-10-03T16:23:10.81845777Z","publicKey":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED2Q6whJTanzlB8tGyJz3k7nuZlHgkv4htty2ZN6JPqBGdPTksHhJb6AzQ3ri6k+ts4nsKK20E6yWjjb1+X/jgg==","serial":"7f00966e93c8fa6837272989ca851be4240f","subjectKeyId":"b3e1e8e471e2b292964aedca53d0a51f3c1bcfac"},"issuer":"int ecdsa b","orderID":242,"profile":"defaultBoulderCertificateProfile","profileHash":"7dc66848654f3d4c26562883ad2979ccb427afbf0684ea175f1a5c9073a039fa","regID":307}
17:21:40.839502 6 boulder-ca zdKrywQ [AUDIT] Signing precert success JSON={"issuanceRequest":{"commonName":"68a6b8.com","dnsNames":["68a6b8.com"],"includeCTPoison":true,"includeMustStaple":false,"notAfter":"2025-01-01T16:23:09.81845777Z","notBefore":"2024-10-03T16:23:10.81845777Z","publicKey":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED2Q6whJTanzlB8tGyJz3k7nuZlHgkv4htty2ZN6JPqBGdPTksHhJb6AzQ3ri6k+ts4nsKK20E6yWjjb1+X/jgg==","serial":"7f00966e93c8fa6837272989ca851be4240f","subjectKeyId":"b3e1e8e471e2b292964aedca53d0a51f3c1bcfac"},"issuer":"int ecdsa b","orderID":242,"precert":"3082029e30820223a00302010202127f00966e93c8fa6837272989ca851be4240f300a06082a8648ce3d0403033037310b300906035504061302555331123010060355040a1309676f6f642067757973311430120603550403130b696e742065636473612062301e170d3234313030333136323331305a170d3235303130313136323330395a3015311330110603550403130a3638613662382e636f6d3059301306072a8648ce3d020106082a8648ce3d030107034200040f643ac212536a7ce507cb46c89cf793b9ee6651e092fe21b6dcb664de893ea04674f4e4b078496fa033437ae2ea4fadb389ec28adb413ac968e36f5f97fe382a382012f3082012b300e0603551d0f0101ff040403020780301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff04023000301d0603551d0e04160414b3e1e8e471e2b292964aedca53d0a51f3c1bcfac301f0603551d2304183016801466ae9f98f0f6a012272faead4acb3ade07bfd7d0306b06082b06010505070101045f305d302706082b06010505073001861b687474703a2f2f63612e6578616d706c652e6f72673a343030322f303206082b060105050730028626687474703a2f2f63612e6578616d706c652e6f72673a343530322f696e742d65636473612d6230150603551d11040e300c820a3638613662382e636f6d30130603551d20040c300a3008060667810c0102013013060a2b06010401d6790204030101ff04020500300a06082a8648ce3d0403030369003066023100f5feb72985626a4e7e1efb31a1faeba97dce50e13ea2788820fcf01dd2bac58dc2ffb8d390ba1951e11df2cc1f1c3c26023100bdee79b2b389d2959136d7088b7c735abe96b3879163ac18a61e65cd93fa9f840830c52fb224b845e6c9d8ee6fba0eec","profile":"defaultBoulderCertificateProfile","profileHash":"7dc66848654f3d4c26562883ad2979ccb427afbf0684ea175f1a5c9073a039fa","regID":307}
17:21:40.844849 6 boulder-ca uOXBmAg [AUDIT] Signing cert JSON={"issuanceRequest":{"commonName":"68a6b8.com","dnsNames":["68a6b8.com"],"includeCTPoison":false,"includeMustStaple":false,"notAfter":"2025-01-01T16:23:09Z","notBefore":"2024-10-03T16:23:10Z","precertDER":"3082029e30820223a00302010202127f00966e93c8fa6837272989ca851be4240f300a06082a8648ce3d0403033037310b300906035504061302555331123010060355040a1309676f6f642067757973311430120603550403130b696e742065636473612062301e170d3234313030333136323331305a170d3235303130313136323330395a3015311330110603550403130a3638613662382e636f6d3059301306072a8648ce3d020106082a8648ce3d030107034200040f643ac212536a7ce507cb46c89cf793b9ee6651e092fe21b6dcb664de893ea04674f4e4b078496fa033437ae2ea4fadb389ec28adb413ac968e36f5f97fe382a382012f3082012b300e0603551d0f0101ff040403020780301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff04023000301d0603551d0e04160414b3e1e8e471e2b292964aedca53d0a51f3c1bcfac301f0603551d2304183016801466ae9f98f0f6a012272faead4acb3ade07bfd7d0306b06082b06010505070101045f305d302706082b06010505073001861b687474703a2f2f63612e6578616d706c652e6f72673a343030322f303206082b060105050730028626687474703a2f2f63612e6578616d706c652e6f72673a343530322f696e742d65636473612d6230150603551d11040e300c820a3638613662382e636f6d30130603551d20040c300a3008060667810c0102013013060a2b06010401d6790204030101ff04020500300a06082a8648ce3d0403030369003066023100f5feb72985626a4e7e1efb31a1faeba97dce50e13ea2788820fcf01dd2bac58dc2ffb8d390ba1951e11df2cc1f1c3c26023100bdee79b2b389d2959136d7088b7c735abe96b3879163ac18a61e65cd93fa9f840830c52fb224b845e6c9d8ee6fba0eec","publicKey":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED2Q6whJTanzlB8tGyJz3k7nuZlHgkv4htty2ZN6JPqBGdPTksHhJb6AzQ3ri6k+ts4nsKK20E6yWjjb1+X/jgg==","sctList":[{"SCTVersion":0,"LogID":{"KeyID":[58,169,63,78,253,28,81,41,196,39,134,217,107,71,169,174,109,200,65,14,23,128,215,47,219,79,219,94,44,101,198,116]},"Timestamp":1727976100841,"Extensions":"","Signature":"BAMARjBEAiB4uFoWEdrdFYQnSlqcNlRJvArc3mxSwn1SvD/CIKqXqwIgOj4o4wHnsWj4jt3JBMKui4oSMRRfLHhOWBVxUWccocM="},{"SCTVersion":0,"LogID":{"KeyID":[56,152,140,148,208,53,152,195,147,45,223,233,35,186,186,242,122,66,14,185,108,65,225,90,168,12,26,176,252,4,189,3]},"Timestamp":1727976100841,"Extensions":"","Signature":"BAMARzBFAiEAkTYhJU/tlqRTTsrmJIO5JCPdLSYSpoS7OqijHfQPDdwCIDAoYJHvXrcIYwzHTn/GlyaXcEdoNgj4V48uqKEqUR4Y"}],"serial":"7f00966e93c8fa6837272989ca851be4240f","subjectKeyId":"b3e1e8e471e2b292964aedca53d0a51f3c1bcfac"},"issuer":"int ecdsa b","orderID":242,"profile":"defaultBoulderCertificateProfile","profileHash":"7dc66848654f3d4c26562883ad2979ccb427afbf0684ea175f1a5c9073a039fa","regID":307}
17:21:40.859069 6 boulder-ca 4rmomA4 [AUDIT] Signing cert success JSON={"certificate":"3082038e30820315a00302010202127f00966e93c8fa6837272989ca851be4240f300a06082a8648ce3d0403033037310b300906035504061302555331123010060355040a1309676f6f642067757973311430120603550403130b696e742065636473612062301e170d3234313030333136323331305a170d3235303130313136323330395a3015311330110603550403130a3638613662382e636f6d3059301306072a8648ce3d020106082a8648ce3d030107034200040f643ac212536a7ce507cb46c89cf793b9ee6651e092fe21b6dcb664de893ea04674f4e4b078496fa033437ae2ea4fadb389ec28adb413ac968e36f5f97fe382a38202213082021d300e0603551d0f0101ff040403020780301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff04023000301d0603551d0e04160414b3e1e8e471e2b292964aedca53d0a51f3c1bcfac301f0603551d2304183016801466ae9f98f0f6a012272faead4acb3ade07bfd7d0306b06082b06010505070101045f305d302706082b06010505073001861b687474703a2f2f63612e6578616d706c652e6f72673a343030322f303206082b060105050730028626687474703a2f2f63612e6578616d706c652e6f72673a343530322f696e742d65636473612d6230150603551d11040e300c820a3638613662382e636f6d30130603551d20040c300a3008060667810c01020130820103060a2b06010401d6790204020481f40481f100ef0075003aa93f4efd1c5129c42786d96b47a9ae6dc8410e1780d72fdb4fdb5e2c65c674000001925366d3e90000040300463044022078b85a1611dadd1584274a5a9c365449bc0adcde6c52c27d52bc3fc220aa97ab02203a3e28e301e7b168f88eddc904c2ae8b8a1231145f2c784e58157151671ca1c300760038988c94d03598c3932ddfe923babaf27a420eb96c41e15aa80c1ab0fc04bd03000001925366d3e90000040300473045022100913621254fed96a4534ecae62483b92423dd2d2612a684bb3aa8a31df40f0ddc022030286091ef5eb708630cc74e7fc69726977047683608f8578f2ea8a12a511e18300a06082a8648ce3d04030303670030640230668862e1e6ace3995d1a211a77faafcc7f65dbbd4804f493184ce84bae2827960a931fefd1ad759f3769e0ba302af345023047031b81997d7bc3529e31fc6802a542c374342e7120e10b2b5c699bf6202864a77d91d7ad18edaf5fc6579f0b2dce2d","issuanceRequest":{"commonName":"68a6b8.com","dnsNames":["68a6b8.com"],"includeCTPoison":false,"includeMustStaple":false,"notAfter":"2025-01-01T16:23:09Z","notBefore":"2024-10-03T16:23:10Z","precertDER":"3082029e30820223a00302010202127f00966e93c8fa6837272989ca851be4240f300a06082a8648ce3d0403033037310b300906035504061302555331123010060355040a1309676f6f642067757973311430120603550403130b696e742065636473612062301e170d3234313030333136323331305a170d3235303130313136323330395a3015311330110603550403130a3638613662382e636f6d3059301306072a8648ce3d020106082a8648ce3d030107034200040f643ac212536a7ce507cb46c89cf793b9ee6651e092fe21b6dcb664de893ea04674f4e4b078496fa033437ae2ea4fadb389ec28adb413ac968e36f5f97fe382a382012f3082012b300e0603551d0f0101ff040403020780301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff04023000301d0603551d0e04160414b3e1e8e471e2b292964aedca53d0a51f3c1bcfac301f0603551d2304183016801466ae9f98f0f6a012272faead4acb3ade07bfd7d0306b06082b06010505070101045f305d302706082b06010505073001861b687474703a2f2f63612e6578616d706c652e6f72673a343030322f303206082b060105050730028626687474703a2f2f63612e6578616d706c652e6f72673a343530322f696e742d65636473612d6230150603551d11040e300c820a3638613662382e636f6d30130603551d20040c300a3008060667810c0102013013060a2b06010401d6790204030101ff04020500300a06082a8648ce3d0403030369003066023100f5feb72985626a4e7e1efb31a1faeba97dce50e13ea2788820fcf01dd2bac58dc2ffb8d390ba1951e11df2cc1f1c3c26023100bdee79b2b389d2959136d7088b7c735abe96b3879163ac18a61e65cd93fa9f840830c52fb224b845e6c9d8ee6fba0eec","publicKey":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED2Q6whJTanzlB8tGyJz3k7nuZlHgkv4htty2ZN6JPqBGdPTksHhJb6AzQ3ri6k+ts4nsKK20E6yWjjb1+X/jgg==","sctList":[{"SCTVersion":0,"LogID":{"KeyID":[58,169,63,78,253,28,81,41,196,39,134,217,107,71,169,174,109,200,65,14,23,128,215,47,219,79,219,94,44,101,198,116]},"Timestamp":1727976100841,"Extensions":"","Signature":"BAMARjBEAiB4uFoWEdrdFYQnSlqcNlRJvArc3mxSwn1SvD/CIKqXqwIgOj4o4wHnsWj4jt3JBMKui4oSMRRfLHhOWBVxUWccocM="},{"SCTVersion":0,"LogID":{"KeyID":[56,152,140,148,208,53,152,195,147,45,223,233,35,186,186,242,122,66,14,185,108,65,225,90,168,12,26,176,252,4,189,3]},"Timestamp":1727976100841,"Extensions":"","Signature":"BAMARzBFAiEAkTYhJU/tlqRTTsrmJIO5JCPdLSYSpoS7OqijHfQPDdwCIDAoYJHvXrcIYwzHTn/GlyaXcEdoNgj4V48uqKEqUR4Y"}],"serial":"7f00966e93c8fa6837272989ca851be4240f","subjectKeyId":"b3e1e8e471e2b292964aedca53d0a51f3c1bcfac"},"issuer":"int ecdsa b","orderID":242,"profile":"defaultBoulderCertificateProfile","profileHash":"7dc66848654f3d4c26562883ad2979ccb427afbf0684ea175f1a5c9073a039fa","regID":307}
```

One downside is that this increases the total log size (10kB above, vs 7kB from a similar production issuance) due in part to more repetition. For example, both the "signing cert" and "signing cert success" log lines include the full precert DER.

Note that our long-term plan for more structured logs is to have a unique event id to join logs on, which can avoid this repetition. But since we don't currently have convenient ways to do that join, some duplication (as we currently have in the logs) seems reasonable.