### PR TITLE
Deprecated goodkey.BlockedKeyFile

### DIFF
--- a/goodkey/good_key.go
+++ b/goodkey/good_key.go
@@ -49,6 +49,9 @@ type Config struct {
 	// BlockedKeyFile is the path to a YAML file containing base64-encoded SHA256
 	// hashes of PKIX Subject Public Keys that should be blocked. If this config
 	// value is empty, then blocked key checking will be disabled.
+	//
+	// Deprecated: This functionality is better performed by the blockedKeys database
+	// table, and will be removed in a future release.
 	BlockedKeyFile string
 	// FermatRounds is an integer number of rounds of Fermat's factorization
 	// method that should be performed to attempt to detect keys whose modulus can


### PR DESCRIPTION
This config field duplicates functionality that is better provided by the blockedKeys database table. We should only have one mechanism for blocking keys, so this one should be removed.

Mark it deprecated as a warning to any downstream consumers of Boulder.

Part of https://github.com/letsencrypt/boulder/issues/7748