### PR TITLE
WFE: Use JSON tags to omit the Authorization ID and RegistrationID fields

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -297,13 +297,13 @@ func (ch Challenge) StringID() string {
 type Authorization struct {
 	// An identifier for this authorization, unique across
 	// authorizations and certificates within this instance.
-	ID string `json:"id,omitempty" db:"id"`
+	ID string `json:"-" db:"id"`
 
 	// The identifier for which authorization is being given
 	Identifier identifier.ACMEIdentifier `json:"identifier,omitempty" db:"identifier"`
 
 	// The registration ID associated with the authorization
-	RegistrationID int64 `json:"regId,omitempty" db:"registrationID"`
+	RegistrationID int64 `json:"-" db:"registrationID"`
 
 	// The status of the validation of this authorization
 	Status AcmeStatus `json:"status,omitempty" db:"status"`

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1207,8 +1207,7 @@ func (wfe *WebFrontEndImpl) prepChallengeForDisplay(request *http.Request, authz
 }
 
 // prepAuthorizationForDisplay takes a core.Authorization and prepares it for
-// display to the client by clearing its ID and RegistrationID fields, and
-// preparing all its challenges.
+// display to the client by preparing all its challenges.
 func (wfe *WebFrontEndImpl) prepAuthorizationForDisplay(request *http.Request, authz *core.Authorization) {
 	for i := range authz.Challenges {
 		wfe.prepChallengeForDisplay(request, *authz, &authz.Challenges[i])
@@ -1218,9 +1217,6 @@ func (wfe *WebFrontEndImpl) prepAuthorizationForDisplay(request *http.Request, a
 	rand.Shuffle(len(authz.Challenges), func(i, j int) {
 		authz.Challenges[i], authz.Challenges[j] = authz.Challenges[j], authz.Challenges[i]
 	})
-
-	authz.ID = ""
-	authz.RegistrationID = 0
 
 	// The ACME spec forbids allowing "*" in authorization identifiers. Boulder
 	// allows this internally as a means of tracking when an authorization

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3387,9 +3387,9 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	wfe, _, _ := setupWFE(t)
 
 	authz := &core.Authorization{
-		ID:             "12345",
+		ID:             "12345678",
 		Status:         core.StatusPending,
-		RegistrationID: 1,
+		RegistrationID: 87654321,
 		Identifier:     identifier.NewDNS("example.com"),
 		Challenges: []core.Challenge{
 			{Type: core.ChallengeTypeDNS01, Status: core.StatusPending, Token: "token"},
@@ -3401,9 +3401,11 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	// This modifies the authz in-place.
 	wfe.prepAuthorizationForDisplay(&http.Request{Host: "localhost"}, authz)
 
-	// The ID and RegID should be empty, since they're not part of the ACME API object.
-	test.AssertEquals(t, authz.ID, "")
-	test.AssertEquals(t, authz.RegistrationID, int64(0))
+	// Ensure ID and RegID are omitted.
+	authzJSON, err := json.Marshal(authz)
+	test.AssertNotError(t, err, "Failed to marshal authz")
+	test.AssertNotContains(t, string(authzJSON), "\"id\":12345678")
+	test.AssertNotContains(t, string(authzJSON), "\"registrationID\":87654321")
 }
 
 func TestPrepRevokedAuthzForDisplay(t *testing.T) {

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3387,9 +3387,9 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	wfe, _, _ := setupWFE(t)
 
 	authz := &core.Authorization{
-		ID:             "12345678",
+		ID:             "12345",
 		Status:         core.StatusPending,
-		RegistrationID: 87654321,
+		RegistrationID: 1,
 		Identifier:     identifier.NewDNS("example.com"),
 		Challenges: []core.Challenge{
 			{Type: core.ChallengeTypeDNS01, Status: core.StatusPending, Token: "token"},
@@ -3404,8 +3404,8 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	// Ensure ID and RegID are omitted.
 	authzJSON, err := json.Marshal(authz)
 	test.AssertNotError(t, err, "Failed to marshal authz")
-	test.AssertNotContains(t, string(authzJSON), "\"id\":12345678")
-	test.AssertNotContains(t, string(authzJSON), "\"registrationID\":87654321")
+	test.AssertNotContains(t, string(authzJSON), "\"id\":\"12345\"")
+	test.AssertNotContains(t, string(authzJSON), "\"registrationID\":\"1\"")
 }
 
 func TestPrepRevokedAuthzForDisplay(t *testing.T) {


### PR DESCRIPTION
Use the `-` JSON tag to omit `ID` and `RegistrationID` fields instead of mutating the core.Authorization object.