### PR TITLE
Allow admin command to block key from a CSR file

### DIFF
--- a/cmd/admin/key.go
+++ b/cmd/admin/key.go
@@ -88,7 +88,7 @@ func (s *subcommandBlockKey) Run(ctx context.Context, a *admin) error {
 	case "-cert-file":
 		spkiHashes, err = a.spkiHashesFromCertPEM(s.certFile)
 	case "-csr-file":
-		spkiHashes, err = spkiHashFromCSRPEM(s.csrFile, s.checkSignature, s.csrFileExpectedCN)
+		spkiHashes, err = a.spkiHashFromCSRPEM(s.csrFile, s.checkSignature, s.csrFileExpectedCN)
 	default:
 		return errors.New("no recognized input method flag set (this shouldn't happen)")
 	}
@@ -160,7 +160,7 @@ func (a *admin) spkiHashesFromCertPEM(filename string) ([][]byte, error) {
 	return [][]byte{spkiHash[:]}, nil
 }
 
-func spkiHashFromCSRPEM(filename string, checkSignature bool, expectedCN string) ([][]byte, error) {
+func (a *admin) spkiHashFromCSRPEM(filename string, checkSignature bool, expectedCN string) ([][]byte, error) {
 	csrFile, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("reading CSR file %q: %w", filename, err)
@@ -170,6 +170,8 @@ func spkiHashFromCSRPEM(filename string, checkSignature bool, expectedCN string)
 	if data == nil {
 		return nil, fmt.Errorf("no PEM data found in %q", filename)
 	}
+
+	a.log.AuditInfof("Parsing key to block from CSR PEM: %x", data)
 
 	csr, err := x509.ParseCertificateRequest(data.Bytes)
 	if err != nil {

--- a/cmd/admin/key_test.go
+++ b/cmd/admin/key_test.go
@@ -86,7 +86,7 @@ func TestCSR(t *testing.T) {
 	err := os.WriteFile(goodCSRFile, []byte(goodCSR), 0600)
 	test.AssertNotError(t, err, "writing good csr")
 
-	goodHash, err := spkiHashFromCSRPEM(goodCSRFile, true)
+	goodHash, err := spkiHashFromCSRPEM(goodCSRFile, true, "")
 	test.AssertNotError(t, err, "expected to read CSR")
 
 	if len(goodHash) != 1 {
@@ -101,10 +101,10 @@ func TestCSR(t *testing.T) {
 	err = os.WriteFile(csrFile, []byte(badCSR), 0600)
 	test.AssertNotError(t, err, "writing bad csr")
 
-	_, err = spkiHashFromCSRPEM(csrFile, true)
+	_, err = spkiHashFromCSRPEM(csrFile, true, "")
 	test.AssertError(t, err, "expected invalid signature")
 
-	badHash, err := spkiHashFromCSRPEM(csrFile, false)
+	badHash, err := spkiHashFromCSRPEM(csrFile, false, "")
 	test.AssertNotError(t, err, "expected to read CSR with bad signature")
 
 	if len(badHash) != 1 {

--- a/cmd/admin/key_test.go
+++ b/cmd/admin/key_test.go
@@ -68,19 +68,35 @@ func TestSPKIHashesFromFile(t *testing.T) {
 	}
 }
 
-// This CSR has had its final bit flipped in the signature
 // The key is the p256 test key from RFC9500
-const badCSR = `
+const goodCSR = `
 -----BEGIN CERTIFICATE REQUEST-----
 MIG6MGICAQAwADBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEIlSPiPt4L/teyj
 dERSxyoeVY+9b3O+XkjpMjLMRcWxbEzRDEy41bihcTnpSILImSVymTQl9BQZq36Q
 pCpJQnKgADAKBggqhkjOPQQDAgNIADBFAiBadw3gvL9IjUfASUTa7MvmkbC4ZCvl
-21m1KMwkIx/+CQIhAKvuyfCcdZ0cWJYOXCOb1OavolWHIUzgEpNGUWul6O0t
+21m1KMwkIx/+CQIhAKvuyfCcdZ0cWJYOXCOb1OavolWHIUzgEpNGUWul6O0s
 -----END CERTIFICATE REQUEST-----
 `
 
 // TestCSR checks that we get the correct SPKI from a CSR, even if its signature is invalid
 func TestCSR(t *testing.T) {
+	expectedSPKIHash := "b2b04340cfaee616ec9c2c62d261b208e54bb197498df52e8cadede23ac0ba5e"
+
+	goodCSRFile := path.Join(t.TempDir(), "good.csr")
+	err := os.WriteFile(goodCSRFile, []byte(goodCSR), 0600)
+	test.AssertNotError(t, err, "writing good csr")
+
+	goodHash, err := spkiHashFromCSRPEM(goodCSRFile, true)
+	test.AssertNotError(t, err, "expected to read CSR")
+
+	if len(goodHash) != 1 {
+		t.Fatalf("expected to read 1 SPKI from CSR, read %d", len(goodHash))
+	}
+	test.AssertEquals(t, hex.EncodeToString(goodHash[0]), expectedSPKIHash)
+
+	// Flip a bit, in the signature, to make a bad CSR:
+	badCSR := strings.Replace(goodCSR, "Wul6", "Wul7", 1)
+
 	csrFile := path.Join(t.TempDir(), "bad.csr")
 	err := os.WriteFile(csrFile, []byte(badCSR), 0600)
 	test.AssertNotError(t, err, "writing bad csr")
@@ -88,14 +104,13 @@ func TestCSR(t *testing.T) {
 	_, err = spkiHashFromCSRPEM(csrFile, true)
 	test.AssertError(t, err, "expected invalid signature")
 
-	hashes, err := spkiHashFromCSRPEM(csrFile, false)
+	badHash, err := spkiHashFromCSRPEM(csrFile, false)
 	test.AssertNotError(t, err, "expected to read CSR with bad signature")
 
-	if len(hashes) != 1 {
-		t.Fatalf("expected to read 1 SPKI from CSR, read %d", len(hashes))
+	if len(badHash) != 1 {
+		t.Fatalf("expected to read 1 SPKI from CSR, read %d", len(badHash))
 	}
-	expected := "b2b04340cfaee616ec9c2c62d261b208e54bb197498df52e8cadede23ac0ba5e"
-	test.AssertEquals(t, hex.EncodeToString(hashes[0]), expected)
+	test.AssertEquals(t, hex.EncodeToString(badHash[0]), expectedSPKIHash)
 }
 
 // mockSARecordingBlocks is a mock which only implements the AddBlockedKey gRPC

--- a/cmd/admin/key_test.go
+++ b/cmd/admin/key_test.go
@@ -98,7 +98,7 @@ func TestCSR(t *testing.T) {
 	badCSR := strings.Replace(goodCSR, "Wul6", "Wul7", 1)
 
 	csrFile := path.Join(t.TempDir(), "bad.csr")
-	err := os.WriteFile(csrFile, []byte(badCSR), 0600)
+	err = os.WriteFile(csrFile, []byte(badCSR), 0600)
 	test.AssertNotError(t, err, "writing bad csr")
 
 	_, err = spkiHashFromCSRPEM(csrFile, true)

--- a/cmd/admin/key_test.go
+++ b/cmd/admin/key_test.go
@@ -86,7 +86,9 @@ func TestCSR(t *testing.T) {
 	err := os.WriteFile(goodCSRFile, []byte(goodCSR), 0600)
 	test.AssertNotError(t, err, "writing good csr")
 
-	goodHash, err := spkiHashFromCSRPEM(goodCSRFile, true, "")
+	a := admin{log: blog.NewMock()}
+
+	goodHash, err := a.spkiHashFromCSRPEM(goodCSRFile, true, "")
 	test.AssertNotError(t, err, "expected to read CSR")
 
 	if len(goodHash) != 1 {
@@ -101,10 +103,10 @@ func TestCSR(t *testing.T) {
 	err = os.WriteFile(csrFile, []byte(badCSR), 0600)
 	test.AssertNotError(t, err, "writing bad csr")
 
-	_, err = spkiHashFromCSRPEM(csrFile, true, "")
+	_, err = a.spkiHashFromCSRPEM(csrFile, true, "")
 	test.AssertError(t, err, "expected invalid signature")
 
-	badHash, err := spkiHashFromCSRPEM(csrFile, false, "")
+	badHash, err := a.spkiHashFromCSRPEM(csrFile, false, "")
 	test.AssertNotError(t, err, "expected to read CSR with bad signature")
 
 	if len(badHash) != 1 {


### PR DESCRIPTION
One format we receive key compromise reports is as a CSR file. For example, from https://pwnedkeys.com/revokinator

This allows the admin command to block a key from a CSR directly, instead of needing to validate it manually and get the SPKI or key from it.

I've added a flag (default true) to check the signature on the CSR, in case we ever decide we want to block a key from a CSR with a bad signature for whatever reason.