### PR TITLE
web: add feature flag PropagateCancels

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -103,6 +103,15 @@ type Config struct {
 	// This flag should only be used in conjunction with UseKvLimitsForNewOrder.
 	DisableLegacyLimitWrites bool
 
+	// PropagateCancels controls whether the WFE and ocsp-responder allows cancellation
+	// of an inbound request to cancel downstream gRPC and other queries. In practice,
+	// cancellation of an inbound request is achieved by Nginx closing the connection
+	// on which the request was happening. This may help shed load in overcapacity
+	// situations. However, not that in-progress database queries (for instance, in the
+	// SA) are not cancelled. Database queries waiting for an available connection may
+	// be cancelled.
+	PropagateCancels bool
+
 	// InsertAuthzsIndividually causes the SA's NewOrderAndAuthzs method to
 	// create each new authz one at a time, rather than using MultiInserter.
 	// Although this is expected to be a performance penalty, it is necessary to

--- a/features/features.go
+++ b/features/features.go
@@ -103,13 +103,13 @@ type Config struct {
 	// This flag should only be used in conjunction with UseKvLimitsForNewOrder.
 	DisableLegacyLimitWrites bool
 
-	// PropagateCancels controls whether the WFE and ocsp-responder allows cancellation
-	// of an inbound request to cancel downstream gRPC and other queries. In practice,
-	// cancellation of an inbound request is achieved by Nginx closing the connection
-	// on which the request was happening. This may help shed load in overcapacity
-	// situations. However, not that in-progress database queries (for instance, in the
-	// SA) are not cancelled. Database queries waiting for an available connection may
-	// be cancelled.
+	// PropagateCancels controls whether the WFE and ocsp-responder allows
+	// cancellation of an inbound request to cancel downstream gRPC and other
+	// queries. In practice, cancellation of an inbound request is achieved by
+	// Nginx closing the connection on which the request was happening. This may
+	// help shed load in overcapacity situations. However, note that in-progress
+	// database queries (for instance, in the SA) are not cancelled. Database
+	// queries waiting for an available connection may be cancelled.
 	PropagateCancels bool
 
 	// InsertAuthzsIndividually causes the SA's NewOrderAndAuthzs method to

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -127,6 +127,7 @@
 			"Overrides": "test/config-next/wfe2-ratelimit-overrides.yml"
 		},
 		"features": {
+      "PropagateCancels": true,
 			"ServeRenewalInfo": true,
 			"CheckIdentifiersPaused": true,
 			"UseKvLimitsForNewOrder": true

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -127,7 +127,7 @@
 			"Overrides": "test/config-next/wfe2-ratelimit-overrides.yml"
 		},
 		"features": {
-      "PropagateCancels": true,
+			"PropagateCancels": true,
 			"ServeRenewalInfo": true,
 			"CheckIdentifiersPaused": true,
 			"UseKvLimitsForNewOrder": true

--- a/web/context.go
+++ b/web/context.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 )
 
@@ -127,11 +128,13 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Origin:    r.Header.Get("Origin"),
 		Extra:     make(map[string]interface{}),
 	}
-	// We specifically override the default r.Context() because we would prefer
-	// for clients to not be able to cancel our operations in arbitrary places.
-	// Instead we start a new context, and apply timeouts in our various RPCs.
-	ctx := context.WithoutCancel(r.Context())
-	r = r.WithContext(ctx)
+	if !features.Get().PropagateCancels {
+		// We specifically override the default r.Context() because we would prefer
+		// for clients to not be able to cancel our operations in arbitrary places.
+		// Instead we start a new context, and apply timeouts in our various RPCs.
+		ctx := context.WithoutCancel(r.Context())
+		r = r.WithContext(ctx)
+	}
 
 	// Some clients will send a HTTP Host header that includes the default port
 	// for the scheme that they are using. Previously when we were fronted by


### PR DESCRIPTION
This allow client-initiated cancels to propagate through gRPC.

CPS Compliance Review: this flag does not impact any compliance obligations found in our CPS.
IN-10803 tracks the SRE-side changes to enable this flag.