### PR TITLE
Truncate ARI timestamps to 1-second resolution

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -489,8 +489,8 @@ func RenewalInfoSimple(issued time.Time, expires time.Time) RenewalInfo {
 	idealRenewal := expires.Add(-renewalOffset)
 	return RenewalInfo{
 		SuggestedWindow: SuggestedWindow{
-			Start: idealRenewal.Add(-24 * time.Hour),
-			End:   idealRenewal.Add(24 * time.Hour),
+			Start: idealRenewal.Add(-24 * time.Hour).Truncate(time.Second),
+			End:   idealRenewal.Add(24 * time.Hour).Truncate(time.Second),
 		},
 	}
 }
@@ -505,8 +505,8 @@ func RenewalInfoImmediate(now time.Time, explanationURL string) RenewalInfo {
 	oneHourAgo := now.Add(-1 * time.Hour)
 	return RenewalInfo{
 		SuggestedWindow: SuggestedWindow{
-			Start: oneHourAgo,
-			End:   oneHourAgo.Add(time.Minute * 30),
+			Start: oneHourAgo.Truncate(time.Second),
+			End:   oneHourAgo.Add(time.Minute * 30).Truncate(time.Second),
 		},
 		ExplanationURL: explanationURL,
 	}


### PR DESCRIPTION
There's no reason for us to be providing nanosecond precision on ARI timestamps, and apparently it messes up some JSON date-parsing libraries.

Fixes https://github.com/letsencrypt/boulder/issues/7779