### PR TITLE
wfe: use wildcard patterns in HTTP handlers

### DIFF
--- a/cmd/ocsp-responder/main.go
+++ b/cmd/ocsp-responder/main.go
@@ -276,6 +276,10 @@ func (om *ocspMux) Handler(_ *http.Request) (http.Handler, string) {
 	return om.handler, "/"
 }
 
+func (om *ocspMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	om.handler.ServeHTTP(w, r)
+}
+
 func mux(responderPath string, source responder.Source, timeout time.Duration, stats prometheus.Registerer, oTelHTTPOptions []otelhttp.Option, logger blog.Logger, sampleRate int) http.Handler {
 	stripPrefix := http.StripPrefix(responderPath, responder.NewResponder(source, timeout, stats, logger, sampleRate))
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Previously, we manually parsed path components. As of Go 1.22, we can include wildcards in ServeMux patterns: https://pkg.go.dev/net/http#hdr-Patterns-ServeMux. This simplifies our parsing code a little bit.

To get the values of such wildcards, we use `request.PathValue`. Our `metrics/measured_http` code interfered with setting those values, so I modified it. Instead of retrieving the handler for a given request, then calling it, we retrieve only the pattern matched by that request. Then we call `.ServeHTTP()` on the inner `ServeMux`.

(Needs unittest updates)
