### PR TITLE
ra: remove special case for empty DNSNames

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1328,16 +1328,11 @@ func (ra *RegistrationAuthorityImpl) issueCertificateInner(
 		return nil, nil, wrapError(err, "getting SCTs")
 	}
 
-	var isRenewal bool
-	if len(parsedPrecert.DNSNames) > 0 {
-		// This should never happen under normal operation, but it sometimes
-		// occurs under test.
-		exists, err := ra.SA.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{DnsNames: parsedPrecert.DNSNames})
-		if err != nil {
-			return nil, nil, wrapError(err, "checking if certificate is a renewal")
-		}
-		isRenewal = exists.Exists
+	exists, err := ra.SA.FQDNSetExists(ctx, &sapb.FQDNSetExistsRequest{DnsNames: parsedPrecert.DNSNames})
+	if err != nil {
+		return nil, nil, wrapError(err, "checking if certificate is a renewal")
 	}
+	isRenewal := exists.Exists
 
 	cert, err := ra.CA.IssueCertificateForPrecertificate(ctx, &capb.IssueCertificateForPrecertificateRequest{
 		DER:             precert.DER,

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3442,15 +3442,20 @@ type mockCAFailCertForPrecert struct {
 
 // IssuePrecertificate needs to be mocked for mockCAFailCertForPrecert's `IssueCertificateForPrecertificate` to get called.
 func (ca *mockCAFailCertForPrecert) IssuePrecertificate(
-	context.Context,
-	*capb.IssueCertificateRequest,
-	...grpc.CallOption) (*capb.IssuePrecertificateResponse, error) {
+	ctx context.Context,
+	req *capb.IssueCertificateRequest,
+	opts ...grpc.CallOption) (*capb.IssuePrecertificateResponse, error) {
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	parsedCSR, err := x509.ParseCertificateRequest(req.Csr)
 	if err != nil {
 		return nil, err
 	}
 	tmpl := &ctx509.Certificate{
 		SerialNumber: big.NewInt(1),
+		DNSNames:     parsedCSR.DNSNames,
 		ExtraExtensions: []ctpkix.Extension{
 			{
 				Id:       ctx509.OIDExtensionCTPoison,


### PR DESCRIPTION
This case was added to work around a test case that didn't fill it out; instead, fill DNSNames for that test case.