### PR TITLE
build: Specify go 1.23.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/letsencrypt/boulder
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.2


### PR DESCRIPTION
We're using `.Keys()` a  method of the maps package added in 1.23 (https://pkg.go.dev/maps@master#Keys) but our go.mod states 1.22.0. This causes some in-IDE linting errors in VSCode.