### PR TITLE
WFE/nonce: Remove deprecated NoncePrefixKey field

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -79,17 +79,6 @@ type Config struct {
 		// boulder-wfe and nonce-service instances.
 		NonceHMACKey cmd.HMACKeyConfig `validate:"-"`
 
-		// NoncePrefixKey is a secret used for deriving the prefix of each nonce
-		// instance. It should contain 256 bits of random data to be suitable as
-		// an HMAC-SHA256 key (e.g. the output of `openssl rand -hex 32`). In a
-		// multi-DC deployment this value should be the same across all
-		// boulder-wfe and nonce-service instances.
-		//
-		// TODO(#7632): Remove this.
-		//
-		// Deprecated: Use NonceHMACKey instead.
-		NoncePrefixKey cmd.PasswordConfig `validate:"-"`
-
 		// Chains is a list of lists of certificate filenames. Each inner list is
 		// a chain (starting with the issuing intermediate, followed by one or
 		// more additional certificates, up to and including a root) which we are
@@ -308,12 +297,8 @@ func main() {
 	if c.WFE.NonceHMACKey.KeyFile != "" {
 		noncePrefixKey, err = c.WFE.NonceHMACKey.Load()
 		cmd.FailOnError(err, "Failed to load nonceHMACKey file")
-	} else if c.WFE.NoncePrefixKey.PasswordFile != "" {
-		keyString, err := c.WFE.NoncePrefixKey.Pass()
-		cmd.FailOnError(err, "Failed to load noncePrefixKey file")
-		noncePrefixKey = []byte(keyString)
 	} else {
-		cmd.Fail("NonceHMACKey KeyFile or NoncePrefixKey PasswordFile must be set")
+		cmd.Fail("NonceHMACKey KeyFile must be set")
 	}
 
 	getNonceConn, err := bgrpc.ClientSetup(c.WFE.GetNonceService, tlsConfig, stats, clk)

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -293,13 +293,8 @@ func main() {
 		cmd.Fail("'getNonceService' must be configured")
 	}
 
-	var noncePrefixKey []byte
-	if c.WFE.NonceHMACKey.KeyFile != "" {
-		noncePrefixKey, err = c.WFE.NonceHMACKey.Load()
-		cmd.FailOnError(err, "Failed to load nonceHMACKey file")
-	} else {
-		cmd.Fail("NonceHMACKey KeyFile must be set")
-	}
+	noncePrefixKey, err := c.WFE.NonceHMACKey.Load()
+	cmd.FailOnError(err, "Failed to load nonceHMACKey file")
 
 	getNonceConn, err := bgrpc.ClientSetup(c.WFE.GetNonceService, tlsConfig, stats, clk)
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to get nonce service")

--- a/cmd/nonce-service/main.go
+++ b/cmd/nonce-service/main.go
@@ -74,13 +74,8 @@ func main() {
 		c.NonceService.DebugAddr = *debugAddr
 	}
 
-	var key []byte
-	if c.NonceService.NonceHMACKey.KeyFile != "" {
-		key, err = c.NonceService.NonceHMACKey.Load()
-		cmd.FailOnError(err, "Failed to load nonceHMACKey file.")
-	} else {
-		cmd.Fail("NonceHMACKey KeyFile must be set")
-	}
+	key, err := c.NonceService.NonceHMACKey.Load()
+	cmd.FailOnError(err, "Failed to load nonceHMACKey file.")
 
 	noncePrefix, err := derivePrefix(key, c.NonceService.GRPC.Address)
 	cmd.FailOnError(err, "Failed to derive nonce prefix")

--- a/test/config/nonce-a.json
+++ b/test/config/nonce-a.json
@@ -1,8 +1,8 @@
 {
 	"NonceService": {
 		"maxUsed": 131072,
-		"noncePrefixKey": {
-			"passwordFile": "test/secrets/nonce_prefix_key"
+		"nonceHMACKey": {
+			"keyFile": "test/secrets/nonce_prefix_key"
 		},
 		"syslog": {
 			"stdoutLevel": 6,

--- a/test/config/nonce-b.json
+++ b/test/config/nonce-b.json
@@ -1,8 +1,8 @@
 {
 	"NonceService": {
 		"maxUsed": 131072,
-		"noncePrefixKey": {
-			"passwordFile": "test/secrets/nonce_prefix_key"
+		"nonceHMACKey": {
+			"keyFile": "test/secrets/nonce_prefix_key"
 		},
 		"syslog": {
 			"stdoutLevel": 6,

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -70,8 +70,8 @@
 			"noWaitForReady": true,
 			"hostOverride": "nonce.boulder"
 		},
-		"noncePrefixKey": {
-			"passwordFile": "test/secrets/nonce_prefix_key"
+		"nonceHMACKey": {
+			"keyFile": "test/secrets/nonce_prefix_key"
 		},
 		"chains": [
 			[


### PR DESCRIPTION
Remove the deprecated WFE & nonce config field `NoncePrefixKey`, which has been replaced by `NonceHMACKey`.

<del>DO NOT MERGE until:</del>
- <del>#7793 (in `release-2024-11-18`) has been deployed, AND:</del>
- <del>`NoncePrefixKey` has been removed from all running configs.</del>

Fixes #7632