### PR TITLE
VA: Fix two IsCAAValid bugs

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -90,7 +90,12 @@ func (va *ValidationAuthorityImpl) IsCAAValid(ctx context.Context, req *vapb.IsC
 	}
 
 	internalErr = va.checkCAA(ctx, acmeID, params)
+
+	// Stop the clock for local check latency.
+	localLatency = va.clk.Since(start)
+
 	if internalErr != nil {
+		logEvent.InternalError = internalErr.Error()
 		prob = detailedError(internalErr)
 		prob.Detail = fmt.Sprintf("While processing CAA for %s: %s", req.Domain, prob.Detail)
 	} else if remoteCAAResults != nil {


### PR DESCRIPTION
Fix two bugs introduced in #7816:
- Fix localLatency time for CAA rechecking is always 0
- Fix logEvent.InternalError is no longer being written to log