### PR TITLE
va: Make the primary VA aware of the Perspective and RIR of each remote

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -15,10 +15,44 @@ import (
 	vapb "github.com/letsencrypt/boulder/va/proto"
 )
 
+// RemoteVAGRPCClientConfig  contains the information necessary to setup a gRPC
+// client connection. The following GRPC client configuration field combinations
+// are allowed:
+//
+// ServerIPAddresses, [Timeout]
+// ServerAddress, DNSAuthority, [Timeout], [HostOverride]
+// SRVLookup, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
+// SRVLookups, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
+type RemoteVAGRPCClientConfig struct {
+	cmd.GRPCClientConfig
+	// Perspective uniquely identifies the Network Perspective used to
+	// perform the validation, as specified in BRs Section 5.4.1,
+	// Requirement 2.7 ("Multi-Perspective Issuance Corroboration attempts
+	// from each Network Perspective"). It should uniquely identify a group
+	// of RVAs deployed in the same datacenter.
+	//
+	// TODO(#7615): Make mandatory.
+	Perspective string `validate:"omitempty"`
+
+	// RIR indicates the Regional Internet Registry where this RVA is
+	// located. This field is used to identify the RIR region from which a
+	// given validation was performed, as specified in the "Phased
+	// Implementation Timeline" in BRs Section 3.2.2.9. It must be one of
+	// the following values:
+	//   - ARIN
+	//   - RIPE
+	//   - APNIC
+	//   - LACNIC
+	//   - AfriNIC
+	//
+	// TODO(#7615): Make mandatory.
+	RIR string `validate:"omitempty,oneof=ARIN RIPE APNIC LACNIC AfriNIC"`
+}
+
 type Config struct {
 	VA struct {
 		vaConfig.Common
-		RemoteVAs []cmd.RemoteVAGRPCClientConfig `validate:"omitempty,dive"`
+		RemoteVAs []RemoteVAGRPCClientConfig `validate:"omitempty,dive"`
 		// Deprecated and ignored
 		MaxRemoteValidationFailures int `validate:"omitempty,min=0,required_with=RemoteVAs"`
 		Features                    features.Config

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -18,7 +18,7 @@ import (
 type Config struct {
 	VA struct {
 		vaConfig.Common
-		RemoteVAs []cmd.GRPCClientConfig `validate:"omitempty,dive"`
+		RemoteVAs []cmd.RemoteVAGRPCClientConfig `validate:"omitempty,dive"`
 		// Deprecated and ignored
 		MaxRemoteValidationFailures int `validate:"omitempty,min=0,required_with=RemoteVAs"`
 		Features                    features.Config
@@ -92,7 +92,7 @@ func main() {
 	if len(c.VA.RemoteVAs) > 0 {
 		for _, rva := range c.VA.RemoteVAs {
 			rva := rva
-			vaConn, err := bgrpc.ClientSetup(&rva, tlsConfig, scope, clk)
+			vaConn, err := bgrpc.ClientSetup(&rva.GRPCClientConfig, tlsConfig, scope, clk)
 			cmd.FailOnError(err, "Unable to create remote VA client")
 			remotes = append(
 				remotes,
@@ -101,7 +101,9 @@ func main() {
 						VAClient:  vapb.NewVAClient(vaConn),
 						CAAClient: vapb.NewCAAClient(vaConn),
 					},
-					Address: rva.ServerAddress,
+					Address:     rva.ServerAddress,
+					Perspective: rva.Perspective,
+					RIR:         rva.RIR,
 				},
 			)
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -442,40 +442,6 @@ func (c *GRPCClientConfig) makeSRVScheme() (string, error) {
 	return c.SRVResolver, nil
 }
 
-// RemoteVAGRPCClientConfig  contains the information necessary to setup a gRPC
-// client connection. The following GRPC client configuration field combinations
-// are allowed:
-//
-// ServerIPAddresses, [Timeout]
-// ServerAddress, DNSAuthority, [Timeout], [HostOverride]
-// SRVLookup, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
-// SRVLookups, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
-type RemoteVAGRPCClientConfig struct {
-	GRPCClientConfig
-	// Perspective uniquely identifies the Network Perspective used to
-	// perform the validation, as specified in BRs Section 5.4.1,
-	// Requirement 2.7 ("Multi-Perspective Issuance Corroboration attempts
-	// from each Network Perspective"). It should uniquely identify a group
-	// of RVAs deployed in the same datacenter.
-	//
-	// TODO(#7615): Make mandatory.
-	Perspective string `validate:"omitempty"`
-
-	// RIR indicates the Regional Internet Registry where this RVA is
-	// located. This field is used to identify the RIR region from which a
-	// given validation was performed, as specified in the "Phased
-	// Implementation Timeline" in BRs Section 3.2.2.9. It must be one of
-	// the following values:
-	//   - ARIN
-	//   - RIPE
-	//   - APNIC
-	//   - LACNIC
-	//   - AfriNIC
-	//
-	// TODO(#7615): Make mandatory.
-	RIR string `validate:"omitempty,oneof=ARIN RIPE APNIC LACNIC AfriNIC"`
-}
-
 // GRPCServerConfig contains the information needed to start a gRPC server.
 type GRPCServerConfig struct {
 	Address string `json:"address" validate:"omitempty,hostname_port"`

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -442,6 +442,40 @@ func (c *GRPCClientConfig) makeSRVScheme() (string, error) {
 	return c.SRVResolver, nil
 }
 
+// RemoteVAGRPCClientConfig  contains the information necessary to setup a gRPC
+// client connection. The following GRPC client configuration field combinations
+// are allowed:
+//
+// ServerIPAddresses, [Timeout]
+// ServerAddress, DNSAuthority, [Timeout], [HostOverride]
+// SRVLookup, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
+// SRVLookups, DNSAuthority, [Timeout], [HostOverride], [SRVResolver]
+type RemoteVAGRPCClientConfig struct {
+	GRPCClientConfig
+	// Perspective uniquely identifies the Network Perspective used to
+	// perform the validation, as specified in BRs Section 5.4.1,
+	// Requirement 2.7 ("Multi-Perspective Issuance Corroboration attempts
+	// from each Network Perspective"). It should uniquely identify a group
+	// of RVAs deployed in the same datacenter.
+	//
+	// TODO(#7615): Make mandatory.
+	Perspective string `validate:"omitempty"`
+
+	// RIR indicates the Regional Internet Registry where this RVA is
+	// located. This field is used to identify the RIR region from which a
+	// given validation was performed, as specified in the "Phased
+	// Implementation Timeline" in BRs Section 3.2.2.9. It must be one of
+	// the following values:
+	//   - ARIN
+	//   - RIPE
+	//   - APNIC
+	//   - LACNIC
+	//   - AfriNIC
+	//
+	// TODO(#7615): Make mandatory.
+	RIR string `validate:"omitempty,oneof=ARIN RIPE APNIC LACNIC AfriNIC"`
+}
+
 // GRPCServerConfig contains the information needed to start a gRPC server.
 type GRPCServerConfig struct {
 	Address string `json:"address" validate:"omitempty,hostname_port"`

--- a/test/config-next/remoteva-a.json
+++ b/test/config-next/remoteva-a.json
@@ -37,7 +37,7 @@
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"
 		],
-		"perspective": "development",
+		"perspective": "dadaist",
 		"rir": "ARIN"
 	},
 	"syslog": {

--- a/test/config-next/remoteva-b.json
+++ b/test/config-next/remoteva-b.json
@@ -37,7 +37,7 @@
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"
 		],
-		"perspective": "development",
+		"perspective": "surrealist",
 		"rir": "RIPE"
 	},
 	"syslog": {

--- a/test/config-next/remoteva-c.json
+++ b/test/config-next/remoteva-c.json
@@ -37,7 +37,7 @@
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"
 		],
-		"perspective": "development",
+		"perspective": "cubist",
 		"rir": "ARIN"
 	},
 	"syslog": {

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -46,17 +46,23 @@
 			{
 				"serverAddress": "rva1.service.consul:9397",
 				"timeout": "15s",
-				"hostOverride": "rva1.boulder"
+				"hostOverride": "rva1.boulder",
+				"perspective": "dadaist",
+				"rir": "ARIN"
 			},
 			{
 				"serverAddress": "rva1.service.consul:9498",
 				"timeout": "15s",
-				"hostOverride": "rva1.boulder"
+				"hostOverride": "rva1.boulder",
+				"perspective": "surrealist",
+				"rir": "RIPE"
 			},
 			{
 				"serverAddress": "rva1.service.consul:9499",
 				"timeout": "15s",
-				"hostOverride": "rva1.boulder"
+				"hostOverride": "rva1.boulder",
+				"perspective": "cubist",
+				"rir": "ARIN"
 			}
 		],
 		"accountURIPrefixes": [

--- a/va/va.go
+++ b/va/va.go
@@ -481,16 +481,6 @@ func (va *ValidationAuthorityImpl) performRemoteValidation(
 	for _, i := range rand.Perm(remoteVACount) {
 		go func(rva RemoteVA) {
 			res, err := rva.PerformValidation(subCtx, req)
-			if res == nil {
-				responses <- &response{rva.Address, rva.Perspective, rva.RIR, res, err}
-				return
-			}
-			if rva.Perspective != res.Perspective || rva.RIR != res.Rir {
-				err = fmt.Errorf(
-					"Remote VA %q.PerformValidation result included mismatched Perspective result=[%q] configured=[%q] and/or RIR result=[%q] configured=[%q]",
-					rva.Perspective, res.Perspective, rva.Perspective, res.Rir, rva.RIR,
-				)
-			}
 			responses <- &response{rva.Address, rva.Perspective, rva.RIR, res, err}
 		}(va.remoteVAs[i])
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -239,7 +239,7 @@ func NewValidationAuthorityImpl(
 
 	for i, va1 := range remoteVAs {
 		for j, va2 := range remoteVAs {
-			// TODO(#7615): Remove the != "" check once perspective is required.
+			// TODO(#7819): Remove the != "" check once perspective is required.
 			if i != j && va1.Perspective == va2.Perspective && va1.Perspective != "" {
 				return nil, fmt.Errorf("duplicate remote VA perspective %q", va1.Perspective)
 			}

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -332,48 +332,6 @@ func TestNewValidationAuthorityImplWithDuplicateRemotes(t *testing.T) {
 	test.AssertContains(t, err.Error(), "duplicate remote VA perspective \"dadaist\"")
 }
 
-func TestPerformValidationWithMismatchedRemoteVAPerspectives(t *testing.T) {
-	mismatched1 := RemoteVA{
-		RemoteClients: setupRemote(nil, "", nil, "dadaist", arin),
-		Perspective:   "baroque",
-		RIR:           arin,
-	}
-	mismatched2 := RemoteVA{
-		RemoteClients: setupRemote(nil, "", nil, "impressionist", ripe),
-		Perspective:   "minimalist",
-		RIR:           ripe,
-	}
-	remoteVAs := setupRemotes([]remoteConf{{rir: ripe}}, nil)
-	remoteVAs = append(remoteVAs, mismatched1, mismatched2)
-	va, mockLog := setup(nil, "", remoteVAs, nil)
-
-	req := createValidationRequest("good-dns01.com", core.ChallengeTypeDNS01)
-	res, _ := va.PerformValidation(context.Background(), req)
-	test.AssertNotNil(t, res.Problems, "validation succeeded with mismatched remote VA perspectives")
-	test.AssertEquals(t, len(mockLog.GetAllMatching("result included mismatched")), 2)
-}
-
-func TestPerformValidationWithMismatchedRemoteVARIRs(t *testing.T) {
-	mismatched1 := RemoteVA{
-		RemoteClients: setupRemote(nil, "", nil, "dadaist", arin),
-		Perspective:   "dadaist",
-		RIR:           ripe,
-	}
-	mismatched2 := RemoteVA{
-		RemoteClients: setupRemote(nil, "", nil, "impressionist", ripe),
-		Perspective:   "impressionist",
-		RIR:           arin,
-	}
-	remoteVAs := setupRemotes([]remoteConf{{rir: ripe}}, nil)
-	remoteVAs = append(remoteVAs, mismatched1, mismatched2)
-	va, mockLog := setup(nil, "", remoteVAs, nil)
-
-	req := createValidationRequest("good-dns01.com", core.ChallengeTypeDNS01)
-	res, _ := va.PerformValidation(context.Background(), req)
-	test.AssertNotNil(t, res.Problems, "validation succeeded with mismatched remote VA perspectives")
-	test.AssertEquals(t, len(mockLog.GetAllMatching("result included mismatched")), 2)
-}
-
 func TestValidateMalformedChallenge(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -231,7 +231,7 @@ type multiSrv struct {
 }
 
 const (
-	slow                  = "slow remote"
+	slowUA                = "slow remote"
 	slowRemoteSleepMillis = 1000
 )
 
@@ -243,7 +243,7 @@ func httpMultiSrv(t *testing.T, token string, allowedUAs map[string]bool) *multi
 	ms := &multiSrv{server, sync.Mutex{}, allowedUAs}
 
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.UserAgent() == slow {
+		if r.UserAgent() == slowUA {
 			time.Sleep(slowRemoteSleepMillis)
 		}
 		ms.mu.Lock()
@@ -659,15 +659,15 @@ func TestMultiVAEarlyReturn(t *testing.T) {
 	}{
 		{
 			remoteConfs: []remoteConf{
-				{ua: slow, rir: arin},
+				{ua: slowUA, rir: arin},
 				{ua: pass, rir: ripe},
 				{ua: fail, rir: apnic},
 			},
 		},
 		{
 			remoteConfs: []remoteConf{
-				{ua: slow, rir: arin},
-				{ua: slow, rir: ripe},
+				{ua: slowUA, rir: arin},
+				{ua: slowUA, rir: ripe},
 				{ua: pass, rir: apnic},
 				{ua: pass, rir: arin},
 				{ua: fail, rir: ripe},
@@ -675,8 +675,8 @@ func TestMultiVAEarlyReturn(t *testing.T) {
 		},
 		{
 			remoteConfs: []remoteConf{
-				{ua: slow, rir: arin},
-				{ua: slow, rir: ripe},
+				{ua: slowUA, rir: arin},
+				{ua: slowUA, rir: ripe},
 				{ua: pass, rir: apnic},
 				{ua: pass, rir: arin},
 				{ua: fail, rir: ripe},

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -162,6 +162,67 @@ func setupRemote(srv *httptest.Server, userAgent string, mockDNSClientOverride b
 	return RemoteClients{VAClient: &inMemVA{*rva}, CAAClient: &inMemVA{*rva}}
 }
 
+// RIRs
+const (
+	arin    = "ARIN"
+	ripe    = "RIPE"
+	apnic   = "APNIC"
+	lacnic  = "LACNIC"
+	afrinic = "AFRINIC"
+)
+
+// remoteConf is used in conjunction with setupRemotes/withRemotes to configure
+// a remote VA.
+type remoteConf struct {
+	// ua is optional, will default to "user agent 1.0". When set to "broken" or
+	// "hijacked", the Address field of the resulting RemoteVA will be set to
+	// match. This is a bit hacky, but it's the easiest way to satisfy some of
+	// our existing TestMultiCAARechecking tests.
+	ua string
+	// rir is required.
+	rir string
+	// dns is optional.
+	dns bdns.Client
+	// impl is optional.
+	impl RemoteClients
+}
+
+func setupRemotes(confs []remoteConf, srv *httptest.Server) []RemoteVA {
+	remoteVAs := make([]RemoteVA, 0, len(confs))
+	for i, c := range confs {
+		if c.rir == "" {
+			panic("rir is required")
+		}
+		// perspective MUST be unique for each remote VA, otherwise the VA will
+		// fail to start.
+		perspective := fmt.Sprintf("dc-%d-%s", i, c.rir)
+		clients := setupRemote(srv, c.ua, c.dns, perspective, c.rir)
+		if c.impl != (RemoteClients{}) {
+			clients = c.impl
+		}
+		var address string
+		if c.ua == "broken" {
+			address = "broken"
+		}
+		if c.ua == "hijacked" {
+			address = "hijacked"
+		}
+		remoteVAs = append(remoteVAs, RemoteVA{
+			Address:       address,
+			RemoteClients: clients,
+			Perspective:   perspective,
+			RIR:           c.rir,
+		})
+	}
+
+	return remoteVAs
+}
+
+func setupWithRemotes(srv *httptest.Server, userAgent string, remotes []remoteConf, mockDNSClientOverride bdns.Client) (*ValidationAuthorityImpl, *blog.Mock) {
+	remoteVAs := setupRemotes(remotes, srv)
+	return setup(srv, userAgent, remoteVAs, mockDNSClientOverride)
+}
+
 type multiSrv struct {
 	*httptest.Server
 
@@ -169,13 +230,10 @@ type multiSrv struct {
 	allowedUAs map[string]bool
 }
 
-func (s *multiSrv) setAllowedUAs(allowedUAs map[string]bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.allowedUAs = allowedUAs
-}
-
-const slowRemoteSleepMillis = 1000
+const (
+	slow                  = "slow remote"
+	slowRemoteSleepMillis = 1000
+)
 
 func httpMultiSrv(t *testing.T, token string, allowedUAs map[string]bool) *multiSrv {
 	t.Helper()
@@ -185,7 +243,7 @@ func httpMultiSrv(t *testing.T, token string, allowedUAs map[string]bool) *multi
 	ms := &multiSrv{server, sync.Mutex{}, allowedUAs}
 
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.UserAgent() == "slow remote" {
+		if r.UserAgent() == slow {
 			time.Sleep(slowRemoteSleepMillis)
 		}
 		ms.mu.Lock()
@@ -246,6 +304,74 @@ func (inmem inMemVA) PerformValidation(ctx context.Context, req *vapb.PerformVal
 
 func (inmem inMemVA) IsCAAValid(ctx context.Context, req *vapb.IsCAAValidRequest, _ ...grpc.CallOption) (*vapb.IsCAAValidResponse, error) {
 	return inmem.rva.IsCAAValid(ctx, req)
+}
+
+func TestNewValidationAuthorityImplWithDuplicateRemotes(t *testing.T) {
+	var remoteVAs []RemoteVA
+	for i := 0; i < 3; i++ {
+		remoteVAs = append(remoteVAs, RemoteVA{
+			RemoteClients: setupRemote(nil, "", nil, "dadaist", arin),
+			Perspective:   "dadaist",
+			RIR:           arin,
+		})
+	}
+
+	_, err := NewValidationAuthorityImpl(
+		&bdns.MockClient{Log: blog.NewMock()},
+		remoteVAs,
+		"user agent 1.0",
+		"letsencrypt.org",
+		metrics.NoopRegisterer,
+		clock.NewFake(),
+		blog.NewMock(),
+		accountURIPrefixes,
+		"example perspective",
+		"",
+	)
+	test.AssertError(t, err, "NewValidationAuthorityImpl allowed duplicate remote perspectives")
+	test.AssertContains(t, err.Error(), "duplicate remote VA perspective \"dadaist\"")
+}
+
+func TestPerformValidationWithMismatchedRemoteVAPerspectives(t *testing.T) {
+	mismatched1 := RemoteVA{
+		RemoteClients: setupRemote(nil, "", nil, "dadaist", arin),
+		Perspective:   "baroque",
+		RIR:           arin,
+	}
+	mismatched2 := RemoteVA{
+		RemoteClients: setupRemote(nil, "", nil, "impressionist", ripe),
+		Perspective:   "minimalist",
+		RIR:           ripe,
+	}
+	remoteVAs := setupRemotes([]remoteConf{{rir: ripe}}, nil)
+	remoteVAs = append(remoteVAs, mismatched1, mismatched2)
+	va, mockLog := setup(nil, "", remoteVAs, nil)
+
+	req := createValidationRequest("good-dns01.com", core.ChallengeTypeDNS01)
+	res, _ := va.PerformValidation(context.Background(), req)
+	test.AssertNotNil(t, res.Problems, "validation succeeded with mismatched remote VA perspectives")
+	test.AssertEquals(t, len(mockLog.GetAllMatching("result included mismatched")), 2)
+}
+
+func TestPerformValidationWithMismatchedRemoteVARIRs(t *testing.T) {
+	mismatched1 := RemoteVA{
+		RemoteClients: setupRemote(nil, "", nil, "dadaist", arin),
+		Perspective:   "dadaist",
+		RIR:           ripe,
+	}
+	mismatched2 := RemoteVA{
+		RemoteClients: setupRemote(nil, "", nil, "impressionist", ripe),
+		Perspective:   "impressionist",
+		RIR:           arin,
+	}
+	remoteVAs := setupRemotes([]remoteConf{{rir: ripe}}, nil)
+	remoteVAs = append(remoteVAs, mismatched1, mismatched2)
+	va, mockLog := setup(nil, "", remoteVAs, nil)
+
+	req := createValidationRequest("good-dns01.com", core.ChallengeTypeDNS01)
+	res, _ := va.PerformValidation(context.Background(), req)
+	test.AssertNotNil(t, res.Problems, "validation succeeded with mismatched remote VA perspectives")
+	test.AssertEquals(t, len(mockLog.GetAllMatching("result included mismatched")), 2)
 }
 
 func TestValidateMalformedChallenge(t *testing.T) {
@@ -366,37 +492,11 @@ func TestDCVAndCAASequencing(t *testing.T) {
 }
 
 func TestMultiVA(t *testing.T) {
+	t.Parallel()
+
 	// Create a new challenge to use for the httpSrv
 	req := createValidationRequest("localhost", core.ChallengeTypeHTTP01)
 
-	const (
-		remoteUA1 = "remote 1"
-		remoteUA2 = "remote 2"
-		remoteUA3 = "remote 3"
-		remoteUA4 = "remote 4"
-		localUA   = "local 1"
-	)
-	allowedUAs := map[string]bool{
-		localUA:   true,
-		remoteUA1: true,
-		remoteUA2: true,
-		remoteUA3: true,
-		remoteUA4: true,
-	}
-
-	// Create an IPv4 test server
-	ms := httpMultiSrv(t, expectedToken, allowedUAs)
-	defer ms.Close()
-
-	remoteVA1 := setupRemote(ms.Server, remoteUA1, nil, "", "")
-	remoteVA2 := setupRemote(ms.Server, remoteUA2, nil, "", "")
-	remoteVA3 := setupRemote(ms.Server, remoteUA3, nil, "", "")
-	remoteVA4 := setupRemote(ms.Server, remoteUA4, nil, "", "")
-	remoteVAs := []RemoteVA{
-		{remoteVA1, remoteUA1},
-		{remoteVA2, remoteUA2},
-		{remoteVA3, remoteUA3},
-	}
 	brokenVA := RemoteClients{
 		VAClient:  brokenRemoteVA{},
 		CAAClient: brokenRemoteVA{},
@@ -406,176 +506,187 @@ func TestMultiVA(t *testing.T) {
 		CAAClient: cancelledVA{},
 	}
 
-	unauthorized := probs.Unauthorized(fmt.Sprintf(
-		`The key authorization file from the server did not match this challenge. Expected %q (got "???")`,
-		expectedKeyAuthorization))
-	expectedInternalErrLine := fmt.Sprintf(
-		`ERR: \[AUDIT\] Remote VA "broken".PerformValidation failed: %s`,
-		errBrokenRemoteVA.Error())
 	testCases := []struct {
-		Name         string
-		RemoteVAs    []RemoteVA
-		AllowedUAs   map[string]bool
-		ExpectedProb *probs.ProblemDetails
-		ExpectedLog  string
+		Name                string
+		Remotes             []remoteConf
+		PrimaryUA           string
+		ExpectedProbType    string
+		ExpectedLogContains string
 	}{
 		{
 			// With local and all remote VAs working there should be no problem.
-			Name:       "Local and remote VAs OK",
-			RemoteVAs:  remoteVAs,
-			AllowedUAs: allowedUAs,
+			Name: "Local and remote VAs OK",
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: pass, rir: apnic},
+			},
+			PrimaryUA: pass,
 		},
 		{
 			// If the local VA fails everything should fail
-			Name:         "Local VA bad, remote VAs OK",
-			RemoteVAs:    remoteVAs,
-			AllowedUAs:   map[string]bool{remoteUA1: true, remoteUA2: true},
-			ExpectedProb: unauthorized,
+			Name: "Local VA bad, remote VAs OK",
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: pass, rir: apnic},
+			},
+			PrimaryUA:        fail,
+			ExpectedProbType: string(probs.UnauthorizedProblem),
 		},
 		{
 			// If one out of three remote VAs fails with an internal err it should succeed
 			Name: "Local VA ok, 1/3 remote VA internal err",
-			RemoteVAs: []RemoteVA{
-				{remoteVA1, remoteUA1},
-				{remoteVA2, remoteUA2},
-				{brokenVA, "broken"},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: pass, rir: apnic, impl: brokenVA},
 			},
-			AllowedUAs: allowedUAs,
+			PrimaryUA: pass,
 		},
 		{
 			// If two out of three remote VAs fail with an internal err it should fail
 			Name: "Local VA ok, 2/3 remote VAs internal err",
-			RemoteVAs: []RemoteVA{
-				{remoteVA1, remoteUA1},
-				{brokenVA, "broken"},
-				{brokenVA, "broken"},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe, impl: brokenVA},
+				{ua: pass, rir: apnic, impl: brokenVA},
 			},
-			AllowedUAs:   allowedUAs,
-			ExpectedProb: probs.ServerInternal("During secondary domain validation: Secondary domain validation RPC failed"),
+			PrimaryUA:        pass,
+			ExpectedProbType: string(probs.ServerInternalProblem),
 			// The real failure cause should be logged
-			ExpectedLog: expectedInternalErrLine,
+			ExpectedLogContains: errBrokenRemoteVA.Error(),
 		},
 		{
 			// If one out of five remote VAs fail with an internal err it should succeed
 			Name: "Local VA ok, 1/5 remote VAs internal err",
-			RemoteVAs: []RemoteVA{
-				{remoteVA1, remoteUA1},
-				{remoteVA2, remoteUA2},
-				{remoteVA3, remoteUA3},
-				{remoteVA4, remoteUA4},
-				{brokenVA, "broken"},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: pass, rir: apnic},
+				{ua: pass, rir: lacnic},
+				{ua: pass, rir: afrinic, impl: brokenVA},
 			},
-			AllowedUAs: allowedUAs,
+			PrimaryUA: pass,
 		},
 		{
 			// If two out of five remote VAs fail with an internal err it should fail
 			Name: "Local VA ok, 2/5 remote VAs internal err",
-			RemoteVAs: []RemoteVA{
-				{remoteVA1, remoteUA1},
-				{remoteVA2, remoteUA2},
-				{remoteVA3, remoteUA3},
-				{brokenVA, "broken"},
-				{brokenVA, "broken"},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: pass, rir: apnic},
+				{ua: pass, rir: arin, impl: brokenVA},
+				{ua: pass, rir: ripe, impl: brokenVA},
 			},
-			AllowedUAs:   allowedUAs,
-			ExpectedProb: probs.ServerInternal("During secondary domain validation: Secondary domain validation RPC failed"),
+			PrimaryUA:        pass,
+			ExpectedProbType: string(probs.ServerInternalProblem),
 			// The real failure cause should be logged
-			ExpectedLog: expectedInternalErrLine,
+			ExpectedLogContains: errBrokenRemoteVA.Error(),
 		},
 		{
 			// If two out of six remote VAs fail with an internal err it should succeed
 			Name: "Local VA ok, 2/6 remote VAs internal err",
-			RemoteVAs: []RemoteVA{
-				{remoteVA1, remoteUA1},
-				{remoteVA2, remoteUA2},
-				{remoteVA3, remoteUA3},
-				{remoteVA4, remoteUA4},
-				{brokenVA, "broken"},
-				{brokenVA, "broken"},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: pass, rir: apnic},
+				{ua: pass, rir: lacnic},
+				{ua: pass, rir: afrinic, impl: brokenVA},
+				{ua: pass, rir: arin, impl: brokenVA},
 			},
-			AllowedUAs: allowedUAs,
+			PrimaryUA: pass,
 		},
 		{
 			// If three out of six remote VAs fail with an internal err it should fail
 			Name: "Local VA ok, 4/6 remote VAs internal err",
-			RemoteVAs: []RemoteVA{
-				{remoteVA1, remoteUA1},
-				{remoteVA2, remoteUA2},
-				{remoteVA3, remoteUA3},
-				{brokenVA, "broken"},
-				{brokenVA, "broken"},
-				{brokenVA, "broken"},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: pass, rir: apnic},
+				{ua: pass, rir: lacnic, impl: brokenVA},
+				{ua: pass, rir: afrinic, impl: brokenVA},
+				{ua: pass, rir: arin, impl: brokenVA},
 			},
-			AllowedUAs:   allowedUAs,
-			ExpectedProb: probs.ServerInternal("During secondary domain validation: Secondary domain validation RPC failed"),
+			PrimaryUA:        pass,
+			ExpectedProbType: string(probs.ServerInternalProblem),
 			// The real failure cause should be logged
-			ExpectedLog: expectedInternalErrLine,
+			ExpectedLogContains: errBrokenRemoteVA.Error(),
 		},
 		{
 			// With only one working remote VA there should be a validation failure
-			Name:       "Local VA and one remote VA OK",
-			RemoteVAs:  remoteVAs,
-			AllowedUAs: map[string]bool{localUA: true, remoteUA2: true},
-			ExpectedProb: probs.Unauthorized(fmt.Sprintf(
-				`During secondary domain validation: The key authorization file from the server did not match this challenge. Expected %q (got "???")`,
-				expectedKeyAuthorization)),
+			Name: "Local VA and one remote VA OK",
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: fail, rir: ripe},
+				{ua: fail, rir: apnic},
+			},
+			PrimaryUA:           pass,
+			ExpectedProbType:    string(probs.UnauthorizedProblem),
+			ExpectedLogContains: "During secondary domain validation: The key authorization file from the server",
 		},
 		{
 			// If one remote VA cancels, it should succeed
 			Name: "Local VA and one remote VA OK, one cancelled VA",
-			RemoteVAs: []RemoteVA{
-				{remoteVA1, remoteUA1},
-				{cancelledVA, remoteUA2},
-				{remoteVA3, remoteUA3},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin},
+				{ua: pass, rir: ripe, impl: cancelledVA},
+				{ua: pass, rir: apnic},
 			},
-			AllowedUAs: allowedUAs,
+			PrimaryUA: pass,
 		},
 		{
 			// If all remote VAs cancel, it should fail
 			Name: "Local VA OK, three cancelled remote VAs",
-			RemoteVAs: []RemoteVA{
-				{cancelledVA, remoteUA1},
-				{cancelledVA, remoteUA2},
-				{cancelledVA, remoteUA3},
+			Remotes: []remoteConf{
+				{ua: pass, rir: arin, impl: cancelledVA},
+				{ua: pass, rir: ripe, impl: cancelledVA},
+				{ua: pass, rir: apnic, impl: cancelledVA},
 			},
-			AllowedUAs:   allowedUAs,
-			ExpectedProb: probs.ServerInternal("During secondary domain validation: Secondary domain validation RPC canceled"),
+			PrimaryUA:           pass,
+			ExpectedProbType:    string(probs.ServerInternalProblem),
+			ExpectedLogContains: "During secondary domain validation: Secondary domain validation RPC canceled",
 		},
 		{
 			// With the local and remote VAs seeing diff problems, we expect a problem.
-			Name:       "Local and remote VA differential, full results, enforce multi VA",
-			RemoteVAs:  remoteVAs,
-			AllowedUAs: map[string]bool{localUA: true},
-			ExpectedProb: probs.Unauthorized(fmt.Sprintf(
-				`During secondary domain validation: The key authorization file from the server did not match this challenge. Expected %q (got "???")`,
-				expectedKeyAuthorization)),
+			Name: "Local and remote VA differential, full results, enforce multi VA",
+			Remotes: []remoteConf{
+				{ua: fail, rir: arin},
+				{ua: fail, rir: ripe},
+				{ua: fail, rir: apnic},
+			},
+			PrimaryUA:           pass,
+			ExpectedProbType:    string(probs.UnauthorizedProblem),
+			ExpectedLogContains: "During secondary domain validation: The key authorization file from the server",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			// Configure the test server with the testcase allowed UAs.
-			ms.setAllowedUAs(tc.AllowedUAs)
+			t.Parallel()
+
+			// Configure one test server per test case so that all tests can run in parallel.
+			ms := httpMultiSrv(t, expectedToken, map[string]bool{pass: true, fail: false})
+			defer ms.Close()
 
 			// Configure a primary VA with testcase remote VAs.
-			localVA, mockLog := setup(ms.Server, localUA, tc.RemoteVAs, nil)
+			localVA, mockLog := setupWithRemotes(ms.Server, tc.PrimaryUA, tc.Remotes, nil)
 
 			// Perform all validations
 			res, _ := localVA.PerformValidation(ctx, req)
-			if res.Problems == nil && tc.ExpectedProb != nil {
-				t.Errorf("expected prob %v, got nil", tc.ExpectedProb)
-			} else if res.Problems != nil && tc.ExpectedProb == nil {
+			if res.Problems == nil && tc.ExpectedProbType != "" {
+				t.Errorf("expected prob %v, got nil", tc.ExpectedProbType)
+			} else if res.Problems != nil && tc.ExpectedProbType == "" {
 				t.Errorf("expected no prob, got %v", res.Problems)
-			} else if res.Problems != nil && tc.ExpectedProb != nil {
+			} else if res.Problems != nil && tc.ExpectedProbType != "" {
 				// That result should match expected.
-				test.AssertEquals(t, res.Problems.ProblemType, string(tc.ExpectedProb.Type))
-				test.AssertEquals(t, res.Problems.Detail, tc.ExpectedProb.Detail)
+				test.AssertEquals(t, res.Problems.ProblemType, tc.ExpectedProbType)
 			}
 
-			if tc.ExpectedLog != "" {
-				lines := mockLog.GetAllMatching(tc.ExpectedLog)
+			if tc.ExpectedLogContains != "" {
+				lines := mockLog.GetAllMatching(tc.ExpectedLogContains)
 				if len(lines) == 0 {
-					t.Fatalf("Got log %v; expected %q", mockLog.GetAll(), tc.ExpectedLog)
+					t.Fatalf("Got log %v; expected %q", mockLog.GetAll(), tc.ExpectedLogContains)
 				}
 			}
 		})
@@ -583,39 +694,48 @@ func TestMultiVA(t *testing.T) {
 }
 
 func TestMultiVAEarlyReturn(t *testing.T) {
-	const passUA = "pass"
-	const failUA = "fail"
-	// httpMultiSrv handles this specially by being slow
-	const slowRemoteUA = "slow remote"
-	allowedUAs := map[string]bool{
-		passUA: true,
-	}
-
-	ms := httpMultiSrv(t, expectedToken, allowedUAs)
-	defer ms.Close()
-
-	makeRemotes := func(userAgent ...string) []RemoteVA {
-		var rvas []RemoteVA
-		for i, ua := range userAgent {
-			clients := setupRemote(ms.Server, ua, nil, "", "")
-			rva := RemoteVA{clients, fmt.Sprintf("remote VA %d hostname", i)}
-			rvas = append(rvas, rva)
-		}
-		return rvas
-	}
+	t.Parallel()
 
 	testCases := []struct {
-		remoteUserAgents []string
+		remoteConfs []remoteConf
 	}{
-		{remoteUserAgents: []string{slowRemoteUA, passUA, failUA}},
-		{remoteUserAgents: []string{slowRemoteUA, slowRemoteUA, passUA, passUA, failUA}},
-		{remoteUserAgents: []string{slowRemoteUA, slowRemoteUA, passUA, passUA, failUA, failUA}},
+		{
+			remoteConfs: []remoteConf{
+				{ua: slow, rir: arin},
+				{ua: pass, rir: ripe},
+				{ua: fail, rir: apnic},
+			},
+		},
+		{
+			remoteConfs: []remoteConf{
+				{ua: slow, rir: arin},
+				{ua: slow, rir: ripe},
+				{ua: pass, rir: apnic},
+				{ua: pass, rir: arin},
+				{ua: fail, rir: ripe},
+			},
+		},
+		{
+			remoteConfs: []remoteConf{
+				{ua: slow, rir: arin},
+				{ua: slow, rir: ripe},
+				{ua: pass, rir: apnic},
+				{ua: pass, rir: arin},
+				{ua: fail, rir: ripe},
+				{ua: fail, rir: apnic},
+			},
+		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			rvas := makeRemotes(tc.remoteUserAgents...)
-			localVA, _ := setup(ms.Server, pass, rvas, nil)
+			t.Parallel()
+
+			// Configure one test server per test case so that all tests can run in parallel.
+			ms := httpMultiSrv(t, expectedToken, map[string]bool{pass: true, fail: false})
+			defer ms.Close()
+
+			localVA, _ := setupWithRemotes(ms.Server, pass, tc.remoteConfs, nil)
 
 			// Perform all validations
 			start := time.Now()
@@ -643,35 +763,19 @@ func TestMultiVAEarlyReturn(t *testing.T) {
 }
 
 func TestMultiVAPolicy(t *testing.T) {
-	const (
-		remoteUA1 = "remote 1"
-		remoteUA2 = "remote 2"
-		remoteUA3 = "remote 3"
-		localUA   = "local 1"
-	)
-	// Forbid all remote UAs to ensure that multi-va fails
-	allowedUAs := map[string]bool{
-		localUA:   true,
-		remoteUA1: false,
-		remoteUA2: false,
-		remoteUA3: false,
-	}
+	t.Parallel()
 
-	ms := httpMultiSrv(t, expectedToken, allowedUAs)
+	ms := httpMultiSrv(t, expectedToken, map[string]bool{pass: true, fail: false})
 	defer ms.Close()
 
-	remoteVA1 := setupRemote(ms.Server, remoteUA1, nil, "", "")
-	remoteVA2 := setupRemote(ms.Server, remoteUA2, nil, "", "")
-	remoteVA3 := setupRemote(ms.Server, remoteUA3, nil, "", "")
-
-	remoteVAs := []RemoteVA{
-		{remoteVA1, remoteUA1},
-		{remoteVA2, remoteUA2},
-		{remoteVA3, remoteUA3},
+	remoteConfs := []remoteConf{
+		{ua: fail, rir: arin},
+		{ua: fail, rir: ripe},
+		{ua: fail, rir: apnic},
 	}
 
-	// Create a local test VA with the two remote VAs
-	localVA, _ := setup(ms.Server, localUA, remoteVAs, nil)
+	// Create a local test VA with the remote VAs
+	localVA, _ := setupWithRemotes(ms.Server, pass, remoteConfs, nil)
 
 	// Perform validation for a domain not in the disabledDomains list
 	req := createValidationRequest("letsencrypt.org", core.ChallengeTypeHTTP01)
@@ -681,28 +785,19 @@ func TestMultiVAPolicy(t *testing.T) {
 		t.Error("expected prob from PerformValidation, got nil")
 	}
 }
-
 func TestMultiVALogging(t *testing.T) {
-	const (
-		rva1UA  = "remote 1"
-		rva2UA  = "remote 2"
-		rva3UA  = "remote 3"
-		localUA = "local 1"
-	)
+	t.Parallel()
 
-	ms := httpMultiSrv(t, expectedToken, map[string]bool{localUA: true, rva1UA: true, rva2UA: true})
+	ms := httpMultiSrv(t, expectedToken, map[string]bool{pass: true, fail: false})
 	defer ms.Close()
 
-	rva1 := setupRemote(ms.Server, rva1UA, nil, "dev-arin", "ARIN")
-	rva2 := setupRemote(ms.Server, rva2UA, nil, "dev-ripe", "RIPE")
-	rva3 := setupRemote(ms.Server, rva3UA, nil, "dev-ripe", "RIPE")
-
-	remoteVAs := []RemoteVA{
-		{rva1, rva1UA},
-		{rva2, rva2UA},
-		{rva3, rva3UA},
+	remoteConfs := []remoteConf{
+		{ua: pass, rir: arin},
+		{ua: pass, rir: ripe},
+		{ua: pass, rir: apnic},
 	}
-	va, _ := setup(ms.Server, localUA, remoteVAs, nil)
+
+	va, _ := setupWithRemotes(ms.Server, pass, remoteConfs, nil)
 	req := createValidationRequest("letsencrypt.org", core.ChallengeTypeHTTP01)
 	res, err := va.PerformValidation(ctx, req)
 	test.Assert(t, res.Problems == nil, fmt.Sprintf("validation failed with: %#v", res.Problems))
@@ -762,18 +857,11 @@ func TestDetailedError(t *testing.T) {
 }
 
 func TestLogRemoteDifferentials(t *testing.T) {
-	// Create some remote VAs
-	remoteVA1 := setupRemote(nil, "remote 1", nil, "", "")
-	remoteVA2 := setupRemote(nil, "remote 2", nil, "", "")
-	remoteVA3 := setupRemote(nil, "remote 3", nil, "", "")
-	// The VA will allow a max of 1 remote failure based on MPIC.
-	remoteVAs := []RemoteVA{
-		{remoteVA1, "remote 1"},
-		{remoteVA2, "remote 2"},
-		{remoteVA3, "remote 3"},
+	remoteConfs := []remoteConf{
+		{ua: pass, rir: arin},
+		{ua: pass, rir: ripe},
+		{ua: pass, rir: apnic},
 	}
-
-	localVA, mockLog := setup(nil, "local 1", remoteVAs, nil)
 
 	egProbA := probs.DNS("root DNS servers closed at 4:30pm")
 	egProbB := probs.OrderNotReady("please take a number")
@@ -813,7 +901,13 @@ func TestLogRemoteDifferentials(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockLog.Clear()
+			t.Parallel()
+
+			// Configure one test server per test case so that all tests can run in parallel.
+			ms := httpMultiSrv(t, expectedToken, map[string]bool{pass: true, fail: false})
+			defer ms.Close()
+
+			localVA, mockLog := setupWithRemotes(ms.Server, pass, remoteConfs, nil)
 
 			localVA.logRemoteResults(
 				"example.com", 1999, "blorpus-01", tc.remoteProbs)


### PR DESCRIPTION
- Make the primary VA aware of the expected Perspective and RIR of each remote VA.
- All Perspectives should be unique, have the primary VA check for duplicate Perspectives at startup.
- Update test setup functions to ensure that each remote VA client and corresponding inmem impl have a matching perspective and RIR.

Part of #7819

---

Updated IN-10231 and created IN-10840. 