### PR TITLE
admin: Add debug-addr CLI flag

### DIFF
--- a/cmd/admin/admin.go
+++ b/cmd/admin/admin.go
@@ -36,7 +36,7 @@ type admin struct {
 
 // newAdmin constructs a new admin object on the heap and returns a pointer to
 // it.
-func newAdmin(configFile string, dryRun bool) (*admin, error) {
+func newAdmin(configFile string, dryRun bool, debugAddr string) (*admin, error) {
 	// Unlike most boulder service constructors, this does all of its own config
 	// parsing and dependency setup. If this is broken out into its own package
 	// (outside the //cmd/ directory) those pieces of setup should stay behind
@@ -47,7 +47,11 @@ func newAdmin(configFile string, dryRun bool) (*admin, error) {
 		return nil, fmt.Errorf("parsing config file: %w", err)
 	}
 
-	scope, logger, oTelShutdown := cmd.StatsAndLogging(c.Syslog, c.OpenTelemetry, c.Admin.DebugAddr)
+	if debugAddr == "" {
+		debugAddr = c.Admin.DebugAddr
+	}
+
+	scope, logger, oTelShutdown := cmd.StatsAndLogging(c.Syslog, c.OpenTelemetry, debugAddr)
 	defer oTelShutdown(context.Background())
 	logger.Info(cmd.VersionString())
 

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -92,6 +92,7 @@ func main() {
 	// they're present.
 	configFile := flag.String("config", "", "Path to the configuration file for this service (required)")
 	dryRun := flag.Bool("dry-run", true, "Print actions instead of mutating the database")
+	debugAddr := flag.String("debug-addr", "", "Debug server address override")
 	flag.Parse()
 
 	// Figure out which subcommand they want us to run.
@@ -127,7 +128,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	a, err := newAdmin(*configFile, *dryRun)
+	a, err := newAdmin(*configFile, *dryRun, *debugAddr)
 	cmd.FailOnError(err, "creating admin object")
 
 	// Finally, run the selected subcommand.

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -38,7 +38,9 @@ func TestAdminClearEmail(t *testing.T) {
 		"-dry-run=false",
 		"update-email",
 		"-address", deleteMe,
-		"-clear")
+		"-clear",
+		"-debug-addr", ":8014",
+	)
 	output, err := cmd.CombinedOutput()
 	test.AssertNotError(t, err, fmt.Sprintf("clearing email via admin tool (%s): %s", cmd, string(output)))
 	t.Logf("clear-email output: %s\n", string(output))

--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -155,6 +155,7 @@ func TestIssuanceCertStorageFailed(t *testing.T) {
 		"revoke-cert",
 		"-serial", core.SerialToString(cert.SerialNumber),
 		"-reason", "unspecified",
+		"-debug-addr", ":18014",
 	).CombinedOutput()
 	test.AssertNotError(t, err, fmt.Sprintf("revoking via admin-revoker: %s", string(output)))
 


### PR DESCRIPTION
If provided, the CLI flag will override the value in the config file.

Use the CLI flag to de-conflict parallel integration tests.

Fixes #7838