### PR TITLE
ra: wait for validations on clean shutdown

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -295,7 +295,7 @@ func main() {
 		apc,
 		issuerCerts,
 	)
-	defer rai.DrainFinalize()
+	defer rai.Drain()
 
 	policyErr := rai.LoadRateLimitPoliciesFile(c.RA.RateLimitPoliciesFilename)
 	cmd.FailOnError(policyErr, "Couldn't load rate limit policies file")


### PR DESCRIPTION
This reduces the number of validations that get left indefinitely in "pending" state.

Rename `DrainFinalize()` to `Drain()` to indicate that it now covers more cases than just finalize.