### PR TITLE
Always use INCRBY for redis rate limits

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -15,6 +15,9 @@ import (
 // then call features.Set(parsedConfig) to load the parsed struct into this
 // package's global Config.
 type Config struct {
+	// Deprecated flags.
+	IncrementRateLimits bool
+
 	// ServeRenewalInfo exposes the renewalInfo endpoint in the directory and for
 	// GET requests. WARNING: This feature is a draft and highly unstable.
 	ServeRenewalInfo bool
@@ -106,11 +109,6 @@ type Config struct {
 	// and pause issuance for each (account, hostname) pair that repeatedly
 	// fails validation.
 	AutomaticallyPauseZombieClients bool
-
-	// IncrementRateLimits uses Redis' IncrBy, instead of Set, for rate limit
-	// accounting. This catches and denies spikes of requests much more
-	// reliably.
-	IncrementRateLimits bool
 }
 
 var fMu = new(sync.RWMutex)

--- a/ratelimits/limiter_test.go
+++ b/ratelimits/limiter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/rand/v2"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 
 	"github.com/letsencrypt/boulder/config"
 	berrors "github.com/letsencrypt/boulder/errors"
-	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
 )
@@ -40,19 +38,6 @@ func newTestTransactionBuilder(t *testing.T) *TransactionBuilder {
 }
 
 func setup(t *testing.T) (context.Context, map[string]*Limiter, *TransactionBuilder, clock.FakeClock, string) {
-	// Because all test cases in this file are affected by this feature flag, we
-	// want to run them all both with and without the feature flag. This way, we
-	// get one set of runs with and one set without. It's difficult to defer
-	// features.Reset() from the setup func (these tests are parallel); as long
-	// as this code doesn't test any other features, we don't need to.
-	//
-	// N.b. This is fragile. If a test case does call features.Reset(), it will
-	// not be testing the intended code path. But we expect to clean this up
-	// quickly.
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		features.Set(features.Config{IncrementRateLimits: true})
-	}
-
 	testCtx := context.Background()
 	clk := clock.NewFake()
 

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -128,8 +128,7 @@
 		"features": {
 			"AsyncFinalize": true,
 			"UseKvLimitsForNewOrder": true,
-			"AutomaticallyPauseZombieClients": true,
-			"IncrementRateLimits": true
+			"AutomaticallyPauseZombieClients": true
 		},
 		"ctLogs": {
 			"stagger": "500ms",

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -128,8 +128,7 @@
 			"PropagateCancels": true,
 			"ServeRenewalInfo": true,
 			"CheckIdentifiersPaused": true,
-			"UseKvLimitsForNewOrder": true,
-			"IncrementRateLimits": true
+			"UseKvLimitsForNewOrder": true
 		},
 		"certProfiles": {
 			"legacy": "The normal profile you know and love",

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -104,6 +104,9 @@
 				}
 			}
 		},
+		"features": {
+			"IncrementRateLimits": true
+		},
 		"ctLogs": {
 			"stagger": "500ms",
 			"logListFile": "test/ct-test-srv/log_list.json",

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -103,7 +103,8 @@
 		"authorizationLifetimeDays": 30,
 		"pendingAuthorizationLifetimeDays": 7,
 		"features": {
-			"ServeRenewalInfo": true
+			"ServeRenewalInfo": true,
+			"IncrementRateLimits": true
 		}
 	},
 	"syslog": {


### PR DESCRIPTION
Deprecate the IncrementRateLimits feature flag, and always use the redis INCRBY instruction to update rate limit TATs.

Fixes https://github.com/letsencrypt/boulder/issues/7855
IN-10858 tracks the SRE-side changes