### PR TITLE
RA and WFE tests: use inmem rate limit source

### DIFF
--- a/ratelimits/limiter.go
+++ b/ratelimits/limiter.go
@@ -34,7 +34,7 @@ var allowedDecision = &Decision{allowed: true, remaining: math.MaxInt64}
 // utilizing a leaky bucket-style approach.
 type Limiter struct {
 	// source is used to store buckets. It must be safe for concurrent use.
-	source source
+	source Source
 	clk    clock.Clock
 
 	spendLatency       *prometheus.HistogramVec
@@ -43,7 +43,7 @@ type Limiter struct {
 
 // NewLimiter returns a new *Limiter. The provided source must be safe for
 // concurrent use.
-func NewLimiter(clk clock.Clock, source source, stats prometheus.Registerer) (*Limiter, error) {
+func NewLimiter(clk clock.Clock, source Source, stats prometheus.Registerer) (*Limiter, error) {
 	spendLatency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "ratelimits_spend_latency",
 		Help: fmt.Sprintf("Latency of ratelimit checks labeled by limit=[name] and decision=[%s|%s], in seconds", Allowed, Denied),

--- a/ratelimits/limiter_test.go
+++ b/ratelimits/limiter_test.go
@@ -21,7 +21,7 @@ import (
 const tenZeroZeroTwo = "10.0.0.2"
 
 // newTestLimiter constructs a new limiter.
-func newTestLimiter(t *testing.T, s source, clk clock.FakeClock) *Limiter {
+func newTestLimiter(t *testing.T, s Source, clk clock.FakeClock) *Limiter {
 	l, err := NewLimiter(clk, s, metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "should not error")
 	return l

--- a/ratelimits/source.go
+++ b/ratelimits/source.go
@@ -10,8 +10,8 @@ import (
 // ErrBucketNotFound indicates that the bucket was not found.
 var ErrBucketNotFound = fmt.Errorf("bucket not found")
 
-// source is an interface for creating and modifying TATs.
-type source interface {
+// Source is an interface for creating and modifying TATs.
+type Source interface {
 	// BatchSet stores the TATs at the specified bucketKeys (formatted as
 	// 'name:id'). Implementations MUST ensure non-blocking operations by
 	// either:
@@ -64,9 +64,9 @@ type inmem struct {
 	m map[string]time.Time
 }
 
-var _ source = (*inmem)(nil)
+var _ Source = (*inmem)(nil)
 
-func newInmem() *inmem {
+func NewInmemSource() *inmem {
 	return &inmem{m: make(map[string]time.Time)}
 }
 

--- a/ratelimits/source_redis.go
+++ b/ratelimits/source_redis.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Compile-time check that RedisSource implements the source interface.
-var _ source = (*RedisSource)(nil)
+var _ Source = (*RedisSource)(nil)
 
 // RedisSource is a ratelimits source backed by sharded Redis.
 type RedisSource struct {

--- a/ratelimits/source_test.go
+++ b/ratelimits/source_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func newInmemTestLimiter(t *testing.T, clk clock.FakeClock) *Limiter {
-	return newTestLimiter(t, newInmem(), clk)
+	return newTestLimiter(t, NewInmemSource(), clk)
 }


### PR DESCRIPTION
The purpose of these RA and WFE unit tests is to test how they deal with certain rate limit conditions, not to test talking to an actual redis instance. Streamline the tests by having them talk to an in-memory rate limits store, rather than a redis-backed one.