### PR TITLE
ratelimits: add detail to error messages

### DIFF
--- a/ratelimits/limiter.go
+++ b/ratelimits/limiter.go
@@ -272,7 +272,7 @@ func (l *Limiter) BatchSpend(ctx context.Context, txns []Transaction) (*Decision
 	ctx = context.WithoutCancel(ctx)
 	tats, err := l.source.BatchGet(ctx, bucketKeys)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("batch get for %d keys: %w", len(bucketKeys), err)
 	}
 	batchDecision := allowedDecision
 	newBuckets := make(map[string]time.Time)
@@ -321,14 +321,14 @@ func (l *Limiter) BatchSpend(ctx context.Context, txns []Transaction) (*Decision
 		if len(newBuckets) > 0 {
 			err = l.source.BatchSet(ctx, newBuckets)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("batch set for %d keys: %w", len(newBuckets), err)
 			}
 		}
 
 		if len(incrBuckets) > 0 {
 			err = l.source.BatchIncrement(ctx, incrBuckets)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("batch increment for %d keys: %w", len(incrBuckets), err)
 			}
 		}
 	}
@@ -379,7 +379,7 @@ func (l *Limiter) BatchRefund(ctx context.Context, txns []Transaction) (*Decisio
 	ctx = context.WithoutCancel(ctx)
 	tats, err := l.source.BatchGet(ctx, bucketKeys)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("batch get for %d keys: %w", len(bucketKeys), err)
 	}
 
 	batchDecision := allowedDecision
@@ -410,7 +410,7 @@ func (l *Limiter) BatchRefund(ctx context.Context, txns []Transaction) (*Decisio
 	if len(incrBuckets) > 0 {
 		err = l.source.BatchIncrement(ctx, incrBuckets)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("batch increment for %d keys: %w", len(incrBuckets), err)
 		}
 	}
 	return batchDecision, nil

--- a/web/context.go
+++ b/web/context.go
@@ -35,7 +35,12 @@ type RequestEvent struct {
 	Slug           string   `json:",omitempty"`
 	InternalErrors []string `json:",omitempty"`
 	Error          string   `json:",omitempty"`
-	UserAgent      string   `json:"ua,omitempty"`
+	// If there is an error checking the data store for our rate limits
+	// we ignore it, but attach the error to the log event for analysis.
+	// TODO(#7796): Treat errors from the rate limit system as normal
+	// errors and put them into InternalErrors.
+	IgnoredRateLimitError string `json:",omitempty"`
+	UserAgent             string `json:"ua,omitempty"`
 	// Origin is sent by the browser from XHR-based clients.
 	Origin string                 `json:",omitempty"`
 	Extra  map[string]interface{} `json:",omitempty"`

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -800,7 +800,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 			wfe.sendError(response, logEvent, probs.RateLimited(err.Error()), err)
 			return
 		} else {
-			wfe.log.Warning(err.Error())
+			logEvent.IgnoredRateLimitError = err.Error()
 		}
 	}
 
@@ -2444,7 +2444,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 				return
 			}
 		} else {
-			wfe.log.Warning(err.Error())
+			logEvent.IgnoredRateLimitError = err.Error()
 		}
 	}
 


### PR DESCRIPTION
For batch operations, include the operation and the number of keys in the error message. This should help diagnose whether we are getting `i/o timeout` errors disproportionately for larger requests, or for certain operations.

Also, make the ignored errors part of the overall WFE request logs, which allows us to get additional context, like whether certain requesters or domain names are getting disproportionately many errors.

Related to #7846.