### PR TITLE
doc: replace "leaky" with "token" bucket

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1471,7 +1471,7 @@ func (ra *RegistrationAuthorityImpl) checkCertificatesPerFQDNSetLimit(ctx contex
 		}
 		return nil
 	} else {
-		// Evaluate the rate limit using a leaky bucket algorithm. The bucket
+		// Evaluate the rate limit using a token bucket algorithm. The bucket
 		// has a capacity of threshold and is refilled at a rate of 1 token per
 		// limit.Window/threshold from the time of each issuance timestamp. The
 		// timestamps start from the most recent issuance and go back in time.

--- a/ratelimits/limiter.go
+++ b/ratelimits/limiter.go
@@ -31,7 +31,7 @@ const (
 var allowedDecision = &Decision{allowed: true, remaining: math.MaxInt64}
 
 // Limiter provides a high-level interface for rate limiting requests by
-// utilizing a leaky bucket-style approach.
+// utilizing a token bucket-style approach.
 type Limiter struct {
 	// source is used to store buckets. It must be safe for concurrent use.
 	source Source


### PR DESCRIPTION
Mostly we refer consistently to token bucket, but these two places (one of which is soon to be removed) still had the "leaky" terminology, which is potentially confusing.