### PR TITLE
wfe2, integration: Test account pausing in current config

### DIFF
--- a/test/integration/pausing_test.go
+++ b/test/integration/pausing_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -24,10 +23,6 @@ import (
 
 func TestIdentifiersPausedForAccount(t *testing.T) {
 	t.Parallel()
-
-	if !strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "test/config-next") {
-		t.Skip("Skipping test as it requires the next configuration")
-	}
 
 	tlsCerts := &cmd.TLSConfig{
 		CACertFile: "test/certs/ipki/minica.pem",

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -412,12 +412,10 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 	var unpauseSigner unpause.JWTSigner
 	var unpauseLifetime time.Duration
 	var unpauseURL string
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		unpauseSigner, err = unpause.NewJWTSigner(cmd.HMACKeyConfig{KeyFile: "../test/secrets/sfe_unpause_key"})
-		test.AssertNotError(t, err, "making unpause signer")
-		unpauseLifetime = time.Hour * 24 * 14
-		unpauseURL = "https://boulder.service.consul:4003"
-	}
+	unpauseSigner, err = unpause.NewJWTSigner(cmd.HMACKeyConfig{KeyFile: "../test/secrets/sfe_unpause_key"})
+	test.AssertNotError(t, err, "making unpause signer")
+	unpauseLifetime = time.Hour * 24 * 14
+	unpauseURL = "https://boulder.service.consul:4003"
 
 	wfe, err := NewWebFrontEndImpl(
 		stats,


### PR DESCRIPTION
Remove conditionals on `test/config-next` for account (un)pausing, which is now in prod and enabled in `test/config`.