### PR TITLE
test: move "make build" for webpki into generate.sh

### DIFF
--- a/test/certs/generate.sh
+++ b/test/certs/generate.sh
@@ -63,6 +63,7 @@ webpki() (
   # This function executes in a subshell, so this cd does not affect the parent
   # script.
   cd ../..
+  make build
   mkdir ./test/certs/webpki
   go run ./test/certs/webpki.go
 )

--- a/test/certs/webpki.go
+++ b/test/certs/webpki.go
@@ -81,10 +81,6 @@ func main() {
 	_ = blog.Set(blog.StdoutLogger(6))
 	defer cmd.AuditPanic()
 
-	// Compile the ceremony binary for easy re-use.
-	_, err := exec.Command("make", "build").CombinedOutput()
-	cmd.FailOnError(err, "compiling ceremony tool")
-
 	// Create SoftHSM slots for the root signing keys
 	rsaRootKeySlot, err := createSlot("Root RSA")
 	cmd.FailOnError(err, "failed creating softhsm2 slot for RSA root key")


### PR DESCRIPTION
webpki.go was discarding stdout when "make build" failed. We can make it print stdout in that context, but it's more straightforward to run "make build" from the shell script that calls webpki.go, where its stdout will naturally be emitted.

Inspired by a recent CI run where there was a straightforward build failure in some of Boulder's code, but it was masked by an error running webpki.go in the `bsetup` container.