### PR TITLE
ratelimits: Correctly handle stale and concurrently initialized buckets

### DIFF
--- a/ratelimits/limiter.go
+++ b/ratelimits/limiter.go
@@ -326,14 +326,14 @@ func (l *Limiter) BatchSpend(ctx context.Context, txns []Transaction) (*Decision
 			// if concurrent requests have created this bucket at the same time,
 			// which would result in overwriting if we used a plain "SET"
 			// command. If that happens, fall back to incrementing.
-			created, err := l.source.BatchSetNotExisting(ctx, newBuckets)
+			alreadyExists, err := l.source.BatchSetNotExisting(ctx, newBuckets)
 			if err != nil {
 				return nil, fmt.Errorf("batch set for %d keys: %w", len(newBuckets), err)
 			}
 			// Find the original transaction in order to compute the increment
 			// and set the TTL.
 			for _, txn := range batch {
-				if !created[txn.bucketKey] {
+				if alreadyExists[txn.bucketKey] {
 					incrBuckets[txn.bucketKey] = increment{
 						cost: time.Duration(txn.cost * txn.limit.emissionInterval),
 						ttl:  time.Duration(txn.limit.burstOffset),

--- a/ratelimits/source.go
+++ b/ratelimits/source.go
@@ -20,6 +20,11 @@ type Source interface {
 	//    the underlying storage client implementation).
 	BatchSet(ctx context.Context, bucketKeys map[string]time.Time) error
 
+	// BatchSetNotExisting attempts to set TATs for the specified bucketKeys if
+	// they do not already exist. Returns a map indicating which keys were set
+	// successfully.
+	BatchSetNotExisting(ctx context.Context, buckets map[string]time.Time) (map[string]bool, error)
+
 	// BatchIncrement updates the TATs for the specified bucketKeys, similar to
 	// BatchSet. Implementations MUST ensure non-blocking operations by either:
 	//   a) applying a deadline or timeout to the context WITHIN the method, or
@@ -77,6 +82,20 @@ func (in *inmem) BatchSet(_ context.Context, bucketKeys map[string]time.Time) er
 		in.m[k] = v
 	}
 	return nil
+}
+
+func (in *inmem) BatchSetNotExisting(_ context.Context, bucketKeys map[string]time.Time) (map[string]bool, error) {
+	in.Lock()
+	defer in.Unlock()
+	results := make(map[string]bool, len(bucketKeys))
+	for k, v := range bucketKeys {
+		_, ok := in.m[k]
+		if !ok {
+			in.m[k] = v
+			results[k] = true
+		}
+	}
+	return results, nil
 }
 
 func (in *inmem) BatchIncrement(_ context.Context, bucketKeys map[string]increment) error {

--- a/ratelimits/source_redis.go
+++ b/ratelimits/source_redis.go
@@ -108,6 +108,38 @@ func (r *RedisSource) BatchSet(ctx context.Context, buckets map[string]time.Time
 	return nil
 }
 
+// BatchSetNotExisting attempts to set TATs for the specified bucketKeys if they
+// do not already exist. Returns a map indicating which keys were set successfully.
+func (r *RedisSource) BatchSetNotExisting(ctx context.Context, buckets map[string]time.Time) (map[string]bool, error) {
+	start := r.clk.Now()
+
+	pipeline := r.client.Pipeline()
+	cmds := make(map[string]*redis.BoolCmd, len(buckets))
+	for bucketKey, tat := range buckets {
+		// Set a TTL of TAT + 10 minutes to account for clock skew.
+		ttl := tat.UTC().Sub(r.clk.Now()) + 10*time.Minute
+		cmds[bucketKey] = pipeline.SetNX(ctx, bucketKey, tat.UTC().UnixNano(), ttl)
+	}
+
+	_, err := pipeline.Exec(ctx)
+	totalLatency := r.clk.Since(start)
+	perSetLatency := totalLatency / time.Duration(len(buckets))
+	if err != nil {
+		r.observeLatency("batchsetnotexisting", totalLatency, err)
+		return nil, err
+	}
+
+	results := make(map[string]bool, len(buckets))
+	for bucketKey, cmd := range cmds {
+		success, _ := cmd.Result()
+		results[bucketKey] = success
+		r.observeLatency("batchsetnotexisting_entry", perSetLatency, nil)
+	}
+
+	r.observeLatency("batchsetnotexisting", totalLatency, nil)
+	return results, nil
+}
+
 // BatchIncrement updates TATs for the specified bucketKeys using a pipelined
 // Redis Transaction in order to reduce the number of round-trips to each Redis
 // shard.


### PR DESCRIPTION
#7782 fixed an issue where concurrent requests to the same existing bucket ignored all but one rate limit spend. However, concurrent requests to the same empty bucket can still cause multiple initializations that skip all but one spend. Use BatchSetNotExisting (SETNX in Redis) to detect this scenario and then fall back to BatchIncrement (INCRBY in Redis).

#7782 sets the TTL (Time-To-Live) of incremented buckets to the maximum possible burst for the applied limit. Because this TTL doesn’t match the TAT, these buckets can become "stale," holding a TAT in the past. Incrementing these stale buckets by cost * emissionInterval leaves the new TAT behind the current time, allowing clients who are sometimes idle to gain extra burst capacity. Instead, use BatchSet (SET in Redis) to overwrite the TAT to now + cost * emissionInterval. Though this introduces a similar race condition as empty buckets, it’s less harmful than granting extra burst capacity.