### PR TITLE
ra, wfe: use TimestampsForWindow to check renewal

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3698,8 +3698,12 @@ func (sa *mockSAWithFinalize) FinalizeOrder(ctx context.Context, req *sapb.Final
 	return &emptypb.Empty{}, nil
 }
 
-func (sa *mockSAWithFinalize) FQDNSetExists(ctx context.Context, in *sapb.FQDNSetExistsRequest, opts ...grpc.CallOption) (*sapb.Exists, error) {
-	return &sapb.Exists{}, nil
+func (sa *mockSAWithFinalize) FQDNSetTimestampsForWindow(ctx context.Context, in *sapb.CountFQDNSetsRequest, opts ...grpc.CallOption) (*sapb.Timestamps, error) {
+	return &sapb.Timestamps{
+		Timestamps: []*timestamppb.Timestamp{
+			timestamppb.Now(),
+		},
+	}, nil
 }
 
 func TestIssueCertificateInnerWithProfile(t *testing.T) {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -3655,7 +3655,7 @@ func TestIssueCertificateInnerErrs(t *testing.T) {
 			// Mock the CA
 			ra.CA = tc.Mock
 			// Attempt issuance
-			_, _, err = ra.issueCertificateInner(ctx, csrOb, order.CertificateProfileName, accountID(Registration.Id), orderID(order.Id))
+			_, _, err = ra.issueCertificateInner(ctx, csrOb, false, order.CertificateProfileName, accountID(Registration.Id), orderID(order.Id))
 			// We expect all of the testcases to fail because all use mocked CAs that deliberately error
 			test.AssertError(t, err, "issueCertificateInner with failing mock CA did not fail")
 			// If there is an expected `error` then match the error message
@@ -3736,7 +3736,7 @@ func TestIssueCertificateInnerWithProfile(t *testing.T) {
 
 	// Call issueCertificateInner with the CSR generated above and the profile
 	// name "default", which will cause the mockCA to return a specific hash.
-	_, cpId, err := ra.issueCertificateInner(context.Background(), csr, "default", 1, 1)
+	_, cpId, err := ra.issueCertificateInner(context.Background(), csr, false, "default", 1, 1)
 	test.AssertNotError(t, err, "issuing cert with profile name")
 	test.AssertEquals(t, mockCA.profileName, cpId.name)
 	test.AssertByteEquals(t, mockCA.profileHash, cpId.hash)

--- a/sa/db/boulder_sa/20230419000000_CombinedSchema.sql
+++ b/sa/db/boulder_sa/20230419000000_CombinedSchema.sql
@@ -86,6 +86,8 @@ CREATE TABLE `fqdnSets` (
   `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
   `setHash` binary(32) NOT NULL,
   `serial` varchar(255) NOT NULL,
+  -- Note: This should actually be called "notBefore" since it is set
+  -- based on the certificate's notBefore field, not the issuance time.
   `issued` datetime NOT NULL,
   `expires` datetime NOT NULL,
   PRIMARY KEY (`id`),

--- a/test/inmem/sa/sa.go
+++ b/test/inmem/sa/sa.go
@@ -121,6 +121,10 @@ func (sa SA) FQDNSetExists(ctx context.Context, req *sapb.FQDNSetExistsRequest, 
 	return sa.Impl.FQDNSetExists(ctx, req)
 }
 
+func (sa SA) FQDNSetTimestampsForWindow(ctx context.Context, req *sapb.CountFQDNSetsRequest, _ ...grpc.CallOption) (*sapb.Timestamps, error) {
+	return sa.Impl.FQDNSetTimestampsForWindow(ctx, req)
+}
+
 func (sa SA) PauseIdentifiers(ctx context.Context, req *sapb.PauseRequest, _ ...grpc.CallOption) (*sapb.PauseIdentifiersResponse, error) {
 	return sa.Impl.PauseIdentifiers(ctx, req)
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3863,13 +3863,17 @@ func Test_sendErrorInternalServerError(t *testing.T) {
 
 // mockSAForARI provides a mock SA with the methods required for an issuance and
 // a renewal with the ARI `Replaces` field.
+//
+// Note that FQDNSetTimestampsForWindow always return an empty list, which allows us to act
+// as if a certificate is not getting the renewal exemption, even when we are repeatedly
+// issuing for the same names.
 type mockSAForARI struct {
 	sapb.StorageAuthorityReadOnlyClient
 	cert *corepb.Certificate
 }
 
-func (sa *mockSAForARI) FQDNSetExists(ctx context.Context, in *sapb.FQDNSetExistsRequest, opts ...grpc.CallOption) (*sapb.Exists, error) {
-	return &sapb.Exists{Exists: false}, nil
+func (sa *mockSAForARI) FQDNSetTimestampsForWindow(ctx context.Context, in *sapb.CountFQDNSetsRequest, opts ...grpc.CallOption) (*sapb.Timestamps, error) {
+	return &sapb.Timestamps{Timestamps: nil}, nil
 }
 
 // GetCertificate returns the inner certificate if it matches the given serial.
@@ -4170,6 +4174,9 @@ func TestNewOrderRateLimits(t *testing.T) {
 		`{"Identifiers": [{"type": "dns", "value": "example.com"}]}`)
 	responseWriter = httptest.NewRecorder()
 	mux.ServeHTTP(responseWriter, r)
+	features.Set(features.Config{
+		UseKvLimitsForNewOrder: true,
+	})
 	test.AssertEquals(t, responseWriter.Code, http.StatusTooManyRequests)
 
 	// Make a request with the "Replaces" field, which should satisfy ARI checks


### PR DESCRIPTION
And in the RA, log the notBefore of the previous issuance.

To make this happen, I had to hoist the "check for previous certificate" up a level into `issueCertificateOuter`. That meant I also had to hoist the "split off a WithoutCancel context" logic all the way up to `FinalizeOrder`.
