### PR TITLE
Fix incorrect ARI error message

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2767,7 +2767,7 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 	renewalInfo, err := wfe.determineARIWindow(ctx, decodedSerial)
 	if err != nil {
 		if errors.Is(err, berrors.NotFound) {
-			wfe.sendError(response, logEvent, probs.NotFound("Certificate replaced by this order was not found"), nil)
+			wfe.sendError(response, logEvent, probs.NotFound("Requested certificate was not found"), nil)
 			return
 		}
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error determining renewal window"), err)


### PR DESCRIPTION
This confusing error message was an accidental carry-over from sharing some code with the NewOrder "replaces" ARI codepath.

Fixes https://github.com/letsencrypt/boulder/issues/7889