### PR TITLE
Log the flakinessrate at ct-test-srv startup

### DIFF
--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -236,8 +236,8 @@ func runPersonality(p Personality) {
 		Handler: m,
 	}
 	logID := sha256.Sum256(pubKeyBytes)
-	log.Printf("ct-test-srv on %s with pubkey %s and log ID %s", p.Addr,
-		base64.StdEncoding.EncodeToString(pubKeyBytes), base64.StdEncoding.EncodeToString(logID[:]))
+	log.Printf("ct-test-srv on %s with pubkey: %s, log ID: %s, flakiness: %d%%", p.Addr,
+		base64.StdEncoding.EncodeToString(pubKeyBytes), base64.StdEncoding.EncodeToString(logID[:]), p.FlakinessRate)
 	log.Fatal(srv.ListenAndServe())
 }
 


### PR DESCRIPTION
This is useful for checking configurations via logs