### PR TITLE
Remove boulder invocation via symlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ VERSION ?= 1.0.0
 EPOCH ?= 1
 MAINTAINER ?= "Community"
 
-CMDS = $(shell find ./cmd -maxdepth 1 -mindepth 1 -type d | grep -v testdata)
-CMD_BASENAMES = $(shell echo $(CMDS) | xargs -n1 basename)
-CMD_BINS = $(addprefix bin/, $(CMD_BASENAMES) )
+CMDS = admin boulder ceremony ct-test-srv
+CMD_BINS = $(addprefix bin/, $(CMDS) )
 OBJECTS = $(CMD_BINS)
 
 # Build environment variables (referencing core/util.go)
@@ -38,7 +37,7 @@ $(CMD_BINS): build_cmds
 build_cmds: | $(OBJDIR)
 	echo $(OBJECTS)
 	GOBIN=$(OBJDIR) GO111MODULE=on go install -mod=vendor $(GO_BUILD_FLAGS) ./...
-	./link.sh
+
 
 # Building an RPM requires `fpm` from https://github.com/jordansissel/fpm
 # which you can install with `gem install fpm`.
@@ -64,10 +63,10 @@ deb: build
 		--package "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).x86_64.deb" \
 		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
 		--maintainer "$(MAINTAINER)" \
-		test/config/ sa/db data/ $(OBJECTS) bin/ct-test-srv
+		test/config/ sa/db data/ $(OBJECTS)
 
 tar: build
 	fpm -f -s dir -t tar --name "boulder" --prefix=/opt/boulder \
 		--package "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).amd64.tar" \
-		test/config/ sa/db data/ $(OBJECTS) bin/ct-test-srv
+		test/config/ sa/db data/ $(OBJECTS)
 	gzip -f "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).amd64.tar"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILD_TIME_VAR = github.com/letsencrypt/boulder/core.BuildTime
 
 GO_BUILD_FLAGS = -ldflags "-X \"$(BUILD_ID_VAR)=$(BUILD_ID)\" -X \"$(BUILD_TIME_VAR)=$(BUILD_TIME)\" -X \"$(BUILD_HOST_VAR)=$(BUILD_HOST)\""
 
-.PHONY: all build build_cmds rpm deb tar
+.PHONY: all build build_cmds deb tar
 all: build
 
 build: $(OBJECTS)
@@ -39,22 +39,12 @@ build_cmds: | $(OBJDIR)
 	GOBIN=$(OBJDIR) GO111MODULE=on go install -mod=vendor $(GO_BUILD_FLAGS) ./...
 
 
-# Building an RPM requires `fpm` from https://github.com/jordansissel/fpm
+# Building a .deb requires `fpm` from https://github.com/jordansissel/fpm
 # which you can install with `gem install fpm`.
 # It is recommended that maintainers use environment overrides to specify
 # Version and Epoch, such as:
 #
-# VERSION=0.1.9 EPOCH=52 MAINTAINER="$(whoami)" ARCHIVEDIR=/tmp make build rpm
-rpm: build
-	fpm -f -s dir -t rpm --rpm-digest sha256 --name "boulder" \
-		--license "Mozilla Public License v2.0" --vendor "ISRG" \
-		--url "https://github.com/letsencrypt/boulder" --prefix=/opt/boulder \
-		--version "$(VERSION)" --iteration "$(COMMIT_ID)" --epoch "$(EPOCH)" \
-		--package "$(ARCHIVEDIR)/boulder-$(VERSION)-$(COMMIT_ID).x86_64.rpm" \
-		--description "Boulder is an ACME-compatible X.509 Certificate Authority" \
-		--maintainer "$(MAINTAINER)" \
-		test/config/ sa/db data/ $(OBJECTS)
-
+# VERSION=0.1.9 EPOCH=52 MAINTAINER="$(whoami)" ARCHIVEDIR=/tmp make build deb
 deb: build
 	fpm -f -s dir -t deb --name "boulder" \
 		--license "Mozilla Public License v2.0" --vendor "ISRG" \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ build_cmds: | $(OBJDIR)
 	echo $(OBJECTS)
 	GOBIN=$(OBJDIR) GO111MODULE=on go install -mod=vendor $(GO_BUILD_FLAGS) ./...
 
-
 # Building a .deb requires `fpm` from https://github.com/jordansissel/fpm
 # which you can install with `gem install fpm`.
 # It is recommended that maintainers use environment overrides to specify

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -85,36 +85,30 @@ var boulderUsage = fmt.Sprintf(`Usage: %s <subcommand> [flags]
 
 func main() {
 	defer cmd.AuditPanic()
-	var command string
-	if core.Command() == "boulder" {
-		// Operator passed the boulder component as a subcommand.
-		if len(os.Args) <= 1 {
-			// No arguments passed.
-			fmt.Fprint(os.Stderr, boulderUsage)
-			return
-		}
 
-		if os.Args[1] == "--help" || os.Args[1] == "-help" {
-			// Help flag passed.
-			fmt.Fprint(os.Stderr, boulderUsage)
-			return
-		}
-
-		if os.Args[1] == "--list" || os.Args[1] == "-list" {
-			// List flag passed.
-			for _, c := range cmd.AvailableCommands() {
-				fmt.Println(c)
-			}
-			return
-		}
-		command = os.Args[1]
-
-		// Remove the subcommand from the arguments.
-		os.Args = os.Args[1:]
-	} else {
-		// Operator ran a boulder component using a symlink.
-		command = core.Command()
+	if len(os.Args) <= 1 {
+		// No arguments passed.
+		fmt.Fprint(os.Stderr, boulderUsage)
+		return
 	}
+
+	if os.Args[1] == "--help" || os.Args[1] == "-help" {
+		// Help flag passed.
+		fmt.Fprint(os.Stderr, boulderUsage)
+		return
+	}
+
+	if os.Args[1] == "--list" || os.Args[1] == "-list" {
+		// List flag passed.
+		for _, c := range cmd.AvailableCommands() {
+			fmt.Println(c)
+		}
+		return
+	}
+
+	// Remove the subcommand from the arguments.
+	command := os.Args[1]
+	os.Args = os.Args[1:]
 
 	config := getConfigPath()
 	if config != "" {

--- a/link.sh
+++ b/link.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-#
-# Symlink the various boulder subcommands into place.
-#
-BINDIR="$PWD/bin"
-for n in `"${BINDIR}/boulder" --list` ; do
-  ln -sf boulder "${BINDIR}/$n"
-done

--- a/tools/make-assets.sh
+++ b/tools/make-assets.sh
@@ -24,7 +24,7 @@ $(dirname -- "${0}")/fetch-and-verify-go.sh "${GO_VERSION}"
 sudo tar -C /usr/local -xzf go.tar.gz
 export PATH=/usr/local/go/bin:$PATH
 
-# Install fpm, this is used in our Makefile to package Boulder as a deb or rpm.
+# Install fpm, this is used in our Makefile to package Boulder as a deb.
 sudo gem install --no-document -v 1.14.0 fpm
 
 #
@@ -38,5 +38,5 @@ export ARCHIVEDIR="${PWD}"
 # Set $VERSION to be a simulacrum of what is set in other build environments.
 export VERSION="${GO_VERSION}.$(date +%s)"
 
-# Build Boulder and produce an RPM, a .deb, and a tar.gz file in $PWD.
-make rpm deb tar
+# Build Boulder and produce a .deb and a tar.gz file in $PWD.
+make deb tar


### PR DESCRIPTION
Boulder switched from multiple binaries to one by having symlinks for the old binaries, but we invoke boulder via subcommands now. This drops support for running via symlinks in Boulder, and drops them from the build process.

This does explicitly list out the four binaries in the makefile, which I think explicitly listing them is fine given that we rarely add them. This also avoids needing to duplicate mentioning the special ct-test-srv in the deb/tar rules. We could probably just look at what's in `bin/` after `go install ./...`, but I didn't want to get too into makefile changes.

We haven't used the symlinked versions of commands for a while, and can drop them from builds.

This also drops the .rpm builds, which we also haven't used in a long time.