### PR TITLE
ci: bump versions for release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.23.1"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.23.1"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tools/make-assets.sh
+++ b/tools/make-assets.sh
@@ -16,6 +16,8 @@ set -eu
 sudo apt-get install -y --no-install-recommends \
   ruby \
   ruby-dev \
+  gnupg2 \
+  curl \
   gcc
 
 # Download and unpack our production go version. Ensure that $GO_VERSION is
@@ -25,7 +27,7 @@ sudo tar -C /usr/local -xzf go.tar.gz
 export PATH=/usr/local/go/bin:$PATH
 
 # Install fpm, this is used in our Makefile to package Boulder as a deb.
-sudo gem install --no-document -v 1.14.0 fpm
+sudo gem install --no-document -v 1.15.1 fpm
 
 #
 # Build


### PR DESCRIPTION
Run the jobs on ubuntu-24.04, and update fpm 1.15.1.

This fixes a problem installing `fpm` on ubuntu-20.04:

```
ERROR:  Error installing fpm:
	The last version of rchardet (~> 1.8) to support your Ruby & RubyGems was 1.8.0. Try installing it with `gem install rchardet -v 1.8.0` and then running the current command again
	rchardet requires Ruby version >= 3.0.0. The current ruby version is 2.7.0.0.
```