### PR TITLE
ci: install specific gem versions in make-assets.sh

### DIFF
--- a/tools/make-assets.sh
+++ b/tools/make-assets.sh
@@ -24,7 +24,12 @@ $(dirname -- "${0}")/fetch-and-verify-go.sh "${GO_VERSION}"
 sudo tar -C /usr/local -xzf go.tar.gz
 export PATH=/usr/local/go/bin:$PATH
 
-# Install fpm, this is used in our Makefile to package Boulder as a deb.
+# Install fpm. This is used in our Makefile to package Boulder as a deb.
+# We install specific versions of some dependencies because these are the last versions
+# supported by the Ruby / RubyGems that ships on ubuntu-20.04, which this script runs on in CI.
+sudo gem install --no-document -v 1.8.0 rchardet
+sudo gem install --no-document -v 5.1.1 public_suffix
+sudo gem install --no-document -v 2.8.1 dotenv
 sudo gem install --no-document -v 1.14.0 fpm
 
 #


### PR DESCRIPTION
We recently started getting these errors in CI:

```
ERROR:  Error installing fpm:
	The last version of rchardet (~> 1.8) to support your Ruby & RubyGems was 1.8.0. Try installing it with `gem install rchardet -v 1.8.0` and then running the current command again
	rchardet requires Ruby version >= 3.0.0. The current ruby version is 2.7.0.0.
```

Installing specific versions of dependencies fixes it.