### PR TITLE
sa: GetRevokedCerts returns explicit shards too

### DIFF
--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -3386,7 +3386,7 @@ func TestGetRevokedCertsWithShard(t *testing.T) {
 			Der:          cert.Raw,
 			RegID:        reg.Id,
 			Issued:       timestamppb.New(cert.NotBefore),
-			IssuerNameID: int64(issuerNameID),
+			IssuerNameID: issuerNameID,
 		})
 		if err != nil {
 			t.Fatalf("adding cert: %s", err)
@@ -3475,7 +3475,7 @@ func TestGetRevokedCertsWithShard(t *testing.T) {
 	revoke(eeCert3, 97)
 
 	// expectSerials registers an error if the provided serials don't match the serials
-	// of the provded certs (after sorting).
+	// of the provided certs (after sorting).
 	expectSerials := func(message string, serials []string, certs ...*x509.Certificate) {
 		t.Helper()
 		var expectedSerials []string

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -1084,6 +1084,9 @@ func (cd crlDeduper) Send(crl *corepb.CRLEntry) error {
 // notAfter date are included), but the ending timestamp is exclusive (certs
 // with exactly that notAfter date are *not* included).
 func (ssa *SQLStorageAuthorityRO) GetRevokedCerts(req *sapb.GetRevokedCertsRequest, stream grpc.ServerStreamingServer[corepb.CRLEntry]) error {
+	if core.IsAnyNilOrZero(req.IssuerNameID, req.ExpiresAfter, req.ExpiresBefore, req.RevokedBefore) {
+		return errors.New("incomplete request for GetRevokedCerts")
+	}
 	crlDeduper := crlDeduper{
 		ServerStreamingServer: stream,
 		seen:                  make(map[string]bool),

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -1057,7 +1057,9 @@ func (ssa *SQLStorageAuthorityRO) SerialsForIncident(req *sapb.SerialsForInciden
 //
 // If ShardIdx is nonzero, GetRevokedCerts calculates shard membership based
 // on temporal sharding _and_ explicit sharding (that is, sharding based on
-// the shardIdx field of the revokedCertificates table).
+// the shardIdx field of the revokedCertificates table). Most revoked certificates
+// will be present in two shards: one based on explicit sharding and one based
+// on temporal sharding (a few will have the same shard for both).
 //
 // The starting timestamp is treated as inclusive (certs with exactly that
 // notAfter date are included), but the ending timestamp is exclusive (certs

--- a/test/certs.go
+++ b/test/certs.go
@@ -64,14 +64,18 @@ func LoadSigner(filename string) (crypto.Signer, error) {
 // ThrowAwayCert is a small test helper function that creates a self-signed
 // certificate with one SAN. It returns the parsed certificate and its serial
 // in string form for convenience.
+//
 // The certificate returned from this function is the bare minimum needed for
 // most tests and isn't a robust example of a complete end entity certificate.
+//
+// Returned certificates have NotBefore == clk.Now(), and NotBefore 6 days in the
+// future.
 func ThrowAwayCert(t *testing.T, clk clock.Clock) (string, *x509.Certificate) {
 	var nameBytes [3]byte
 	_, _ = rand.Read(nameBytes[:])
 	name := fmt.Sprintf("%s.example.com", hex.EncodeToString(nameBytes[:]))
 
-	var serialBytes [16]byte
+	var serialBytes [18]byte
 	_, _ = rand.Read(serialBytes[:])
 	serial := big.NewInt(0).SetBytes(serialBytes[:])
 


### PR DESCRIPTION
Change GetRevokedCerts to return a combined list of certs for a given shard, calculating shard membership temporally _and_ by explicit assignment to a shard in the revokedCertificates table.

This functionality is gated on the ShardIdx field of GetRevokedCertsRequest. If it is zero, revoked certs will only be returned from a given temporal shard (and we assume that no certs have been assigned to any explicit shard yet).

After we start sending the ShardIdx field, and also start writing entries to the revokedCertificates table, this will result in CRL sizes doubling for several months until we retire the temporal sharding code, since most revoked certificates will be included in one shard based on their entry in revokedCertificates, and a different shard based on their issuance time.

Update the tests to cover more cases, and reduce duplication somewhat.

Update `test.ThrowAwayCert` to document the lifetime it uses, and to generate serial numbers that are the same length as used in the rest of boulder (which makes debug output using serials easier to read).

Part of #7094 