### PR TITLE
RA: Fix special error case when finalizing authz

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2013,8 +2013,12 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 
 		err = ra.recordValidation(vaCtx, authz.ID, authz.Expires, challenge)
 		if err != nil {
-			if errors.Is(err, berrors.AlreadyRevoked) {
-				ra.log.Infof("Didn't record already-finalized validation: regID=[%d] authzID=[%s] err=[%s]",
+			if errors.Is(err, berrors.NotFound) {
+				// We log NotFound at a lower level because this is largely due to a
+				// parallel-validation race: a different validation attempt has already
+				// updated this authz, so we failed to find a *pending* authz with the
+				// given ID to update.
+				ra.log.Infof("Failed to record validation: regID=[%d] authzID=[%s] err=[%s]",
 					authz.RegistrationID, authz.ID, err)
 			} else {
 				ra.log.AuditErrf("Failed to record validation: regID=[%d] authzID=[%s] err=[%s]",

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2018,7 +2018,7 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 				// parallel-validation race: a different validation attempt has already
 				// updated this authz, so we failed to find a *pending* authz with the
 				// given ID to update.
-				ra.log.Infof("Failed to record validation: regID=[%d] authzID=[%s] err=[%s]",
+				ra.log.Infof("Failed to record validation (likely parallel validation race): regID=[%d] authzID=[%s] err=[%s]",
 					authz.RegistrationID, authz.ID, err)
 			} else {
 				ra.log.AuditErrf("Failed to record validation: regID=[%d] authzID=[%s] err=[%s]",


### PR DESCRIPTION
Replace looking for AlreadyRevoked (which is never returned by the underlying SA method) with the correct NotFound. Also add a comment documenting why this behavior exists.

Fixes https://github.com/letsencrypt/boulder/issues/3995