### PR TITLE
Check via zlint if a domain's TLD is valid

### DIFF
--- a/iana/iana.go
+++ b/iana/iana.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 
 	"github.com/weppos/publicsuffix-go/publicsuffix"
+	zlintutil "github.com/zmap/zlint/v3/util"
 )
 
 // ExtractSuffix returns the public suffix of the domain using only the "ICANN"
 // section of the Public Suffix List database.
 // If the domain does not end in a suffix that belongs to an IANA-assigned
 // domain, ExtractSuffix returns an error.
+// It confirms with zlint's TLD list.
 func ExtractSuffix(name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("Blank name argument passed to ExtractSuffix")
@@ -21,6 +23,10 @@ func ExtractSuffix(name string) (string, error) {
 	}
 
 	suffix := rule.Decompose(name)[1]
+
+	if !zlintutil.IsInTLDMap(suffix) {
+		return "", fmt.Errorf("Domain %s has an invalid TLD %s", name, suffix)
+	}
 
 	// If the TLD is empty, it means name is actually a suffix.
 	// In fact, decompose returns an array of empty strings in this case.


### PR DESCRIPTION
If there's discrepencies between the PSL and Zlint TLD list, this will take the
most conservative option of rejecting if either list doesn't have a TLD.
