### PR TITLE
Update admin-revoker certs to be admin

### DIFF
--- a/test/certs/generate.sh
+++ b/test/certs/generate.sh
@@ -40,7 +40,7 @@ ipki() (
   minica -domains redis -ip-addresses 10.33.33.2,10.33.33.3,10.33.33.4,10.33.33.5,10.33.33.6,10.33.33.7,10.33.33.8,10.33.33.9
 
   # Used by Boulder gRPC services as both server and client mTLS certificates.
-  for SERVICE in admin-revoker expiration-mailer ocsp-responder consul \
+  for SERVICE in admin expiration-mailer ocsp-responder consul \
     wfe akamai-purger bad-key-revoker crl-updater crl-storer \
     health-checker rocsp-tool sfe; do
     minica -domains "${SERVICE}.boulder" &

--- a/test/config-next/admin.json
+++ b/test/config-next/admin.json
@@ -6,8 +6,8 @@
 		},
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
-			"certFile": "test/certs/ipki/admin-revoker.boulder/cert.pem",
-			"keyFile": "test/certs/ipki/admin-revoker.boulder/key.pem"
+			"certFile": "test/certs/ipki/admin.boulder/cert.pem",
+			"keyFile": "test/certs/ipki/admin.boulder/key.pem"
 		},
 		"raService": {
 			"dnsAuthority": "consul.service.consul",

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -110,7 +110,7 @@
 			"services": {
 				"ra.RegistrationAuthority": {
 					"clientNames": [
-						"admin-revoker.boulder",
+						"admin.boulder",
 						"bad-key-revoker.boulder",
 						"ocsp-responder.boulder",
 						"wfe.boulder",

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -24,7 +24,7 @@
 			"services": {
 				"sa.StorageAuthority": {
 					"clientNames": [
-						"admin-revoker.boulder",
+						"admin.boulder",
 						"ca.boulder",
 						"crl-updater.boulder",
 						"expiration-mailer.boulder",
@@ -33,7 +33,7 @@
 				},
 				"sa.StorageAuthorityReadOnly": {
 					"clientNames": [
-						"admin-revoker.boulder",
+						"admin.boulder",
 						"ocsp-responder.boulder",
 						"wfe.boulder",
 						"sfe.boulder"

--- a/test/config/admin.json
+++ b/test/config/admin.json
@@ -7,8 +7,8 @@
 		"debugAddr": ":8014",
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
-			"certFile": "test/certs/ipki/admin-revoker.boulder/cert.pem",
-			"keyFile": "test/certs/ipki/admin-revoker.boulder/key.pem"
+			"certFile": "test/certs/ipki/admin.boulder/cert.pem",
+			"keyFile": "test/certs/ipki/admin.boulder/key.pem"
 		},
 		"raService": {
 			"dnsAuthority": "consul.service.consul",

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -114,7 +114,7 @@
 			"services": {
 				"ra.RegistrationAuthority": {
 					"clientNames": [
-						"admin-revoker.boulder",
+						"admin.boulder",
 						"bad-key-revoker.boulder",
 						"ocsp-responder.boulder",
 						"sfe.boulder",

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -21,7 +21,7 @@
 			"services": {
 				"sa.StorageAuthority": {
 					"clientNames": [
-						"admin-revoker.boulder",
+						"admin.boulder",
 						"ca.boulder",
 						"crl-updater.boulder",
 						"expiration-mailer.boulder",
@@ -32,7 +32,7 @@
 				},
 				"sa.StorageAuthorityReadOnly": {
 					"clientNames": [
-						"admin-revoker.boulder",
+						"admin.boulder",
 						"crl-updater.boulder",
 						"ocsp-responder.boulder",
 						"sfe.boulder",


### PR DESCRIPTION
The admin and admin-revoker tools shared certs. admin-revoker is gone, so
update the certs to use the admin name only.
