### PR TITLE
Add schema for profile column in authz2 table

### DIFF
--- a/sa/db-next/boulder_sa/20250115000000_AuthzProfiles.sql
+++ b/sa/db-next/boulder_sa/20250115000000_AuthzProfiles.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `authz2` ADD COLUMN `certificateProfileName` varchar(32) DEFAULT NULL;
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `authz2` DROP COLUMN `certificateProfileName`;


### PR DESCRIPTION
Use MariaDB's "instant add column" feature to add a new certificateProfileName column to the existing authz2 table. This column is nullable to reflect the fact that profiles are optional, and to mirror the similarly-added column on the orders table.

This change is standalone, with no code reading or writing this field, so that it can be deployed to production and a follow-up change can begin reading and writing the field all at once with no deployability concerns.

IN-10973 tracks creating this column in Staging and Prod.

~~DO NOT MERGE until https://github.com/letsencrypt/boulder/pull/7953 has been merged~~

Part of https://github.com/letsencrypt/boulder/issues/7955