### PR TITLE
allowlist: Provide a generic implementation of an allow list

### DIFF
--- a/allowlist/main.go
+++ b/allowlist/main.go
@@ -1,0 +1,38 @@
+package allowlist
+
+import (
+	"github.com/letsencrypt/boulder/strictyaml"
+)
+
+// List holds a unique collection of items of type T. Membership can be checked
+// by calling the Contains method.
+type List[T comparable] struct {
+	members map[T]struct{}
+}
+
+// NewList returns a *List[T] populated with the provided members of type T. All
+// duplicate entries are ignored, ensuring uniqueness.
+func NewList[T comparable](members []T) *List[T] {
+	l := &List[T]{members: make(map[T]struct{})}
+	for _, m := range members {
+		l.members[m] = struct{}{}
+	}
+	return l
+}
+
+// NewFromYAML reads a YAML sequence of values of type T and returns a *List[T]
+// containing those values. If the data cannot be parsed, an error is returned.
+func NewFromYAML[T comparable](data []byte) (*List[T], error) {
+	var entries []T
+	err := strictyaml.Unmarshal(data, &entries)
+	if err != nil {
+		return nil, err
+	}
+	return NewList(entries), nil
+}
+
+// Contains reports whether the provided entry is a member of the list.
+func (l *List[T]) Contains(entry T) bool {
+	_, ok := l.members[entry]
+	return ok
+}

--- a/allowlist/main_test.go
+++ b/allowlist/main_test.go
@@ -1,0 +1,55 @@
+package allowlist
+
+import (
+	"testing"
+)
+
+func TestNewFromYAML(t *testing.T) {
+	tests := []struct {
+		name          string
+		yamlData      string
+		check         []string
+		expectAnswers []bool
+		expectErr     bool
+	}{
+		{
+			name:          "valid YAML",
+			yamlData:      "- oak\n- maple\n- cherry",
+			check:         []string{"oak", "walnut", "maple", "cherry"},
+			expectAnswers: []bool{true, false, true, true},
+			expectErr:     false,
+		},
+		{
+			name:          "empty YAML",
+			yamlData:      "",
+			check:         nil,
+			expectAnswers: nil,
+			expectErr:     true,
+		},
+		{
+			name:          "invalid YAML",
+			yamlData:      "{ invalid_yaml",
+			check:         []string{},
+			expectAnswers: []bool{},
+			expectErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := NewFromYAML[string]([]byte(tt.yamlData))
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("NewFromYAML() error = %v, expectErr = %v", err, tt.expectErr)
+			}
+
+			if err == nil {
+				for i, item := range tt.check {
+					got := list.Contains(item)
+					if got != tt.expectAnswers[i] {
+						t.Errorf("Contains(%q) got %v, want %v", item, got, tt.expectAnswers[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow lists are a common pattern in Boulder, provide a generic implementation in its own package.

Part of #7604