### PR TITLE
RA: Replace IsCAAValid call with DoCAA

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1392,7 +1392,7 @@ func (ra *RegistrationAuthorityImpl) checkDCVAndCAA(ctx context.Context, dcvReq 
 			return doDCVRes.Problem, doDCVRes.Records, nil
 		}
 
-		doCAAResp, err := ra.VA.IsCAAValid(ctx, caaReq)
+		doCAAResp, err := ra.VA.DoCAA(ctx, caaReq)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Replace the non-MPIC-compliant IsCAAValid VA method with the correct MPIC-compliant DoCAA VA method when the EnforceMPIC feature is enabled. This fixes the mistake introduced in #7870.