### PR TITLE
WIP - just for CI test - Valkey 8.0.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,37 +108,37 @@ services:
           - boulder-proxysql
 
   bredis_1:
-    image: valkey:7.2.8-bookworm
+    image: valkey/valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
-    command: redis-server /test/redis-ocsp.config
+    command: valkey-server /test/redis-ocsp.config
     networks:
       redisnet:
         ipv4_address: 10.33.33.2
 
   bredis_2:
-    image: valkey:7.2.8-bookworm
+    image: valkey/valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
-    command: redis-server /test/redis-ocsp.config
+    command: valkey-server /test/redis-ocsp.config
     networks:
       redisnet:
         ipv4_address: 10.33.33.3
 
   bredis_3:
-    image: valkey:7.2.8-bookworm
+    image: valkey/valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
-    command: redis-server /test/redis-ratelimits.config
+    command: valkey-server /test/redis-ratelimits.config
     networks:
       redisnet:
         ipv4_address: 10.33.33.4
 
   bredis_4:
-    image: valkey:7.2.8-bookworm
+    image: valkey/valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
-    command: redis-server /test/redis-ratelimits.config
+    command: valkey-server /test/redis-ratelimits.config
     networks:
       redisnet:
         ipv4_address: 10.33.33.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
           - boulder-proxysql
 
   bredis_1:
-    image: redis:7.2.7-bookworm
+    image: valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ocsp.config
@@ -117,7 +117,7 @@ services:
         ipv4_address: 10.33.33.2
 
   bredis_2:
-    image: redis:7.2.7-bookworm
+    image: valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ocsp.config
@@ -126,7 +126,7 @@ services:
         ipv4_address: 10.33.33.3
 
   bredis_3:
-    image: redis:7.2.7-bookworm
+    image: valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ratelimits.config
@@ -135,7 +135,7 @@ services:
         ipv4_address: 10.33.33.4
 
   bredis_4:
-    image: redis:7.2.7-bookworm
+    image: valkey:7.2.8-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ratelimits.config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
           - boulder-proxysql
 
   bredis_1:
-    image: valkey/valkey:7.2.8-bookworm
+    image: valkey/valkey:8.0.2-bookworm
     volumes:
       - ./test/:/test/:cached
     command: valkey-server /test/redis-ocsp.config
@@ -117,7 +117,7 @@ services:
         ipv4_address: 10.33.33.2
 
   bredis_2:
-    image: valkey/valkey:7.2.8-bookworm
+    image: valkey/valkey:8.0.2-bookworm
     volumes:
       - ./test/:/test/:cached
     command: valkey-server /test/redis-ocsp.config
@@ -126,7 +126,7 @@ services:
         ipv4_address: 10.33.33.3
 
   bredis_3:
-    image: valkey/valkey:7.2.8-bookworm
+    image: valkey/valkey:8.0.2-bookworm
     volumes:
       - ./test/:/test/:cached
     command: valkey-server /test/redis-ratelimits.config
@@ -135,7 +135,7 @@ services:
         ipv4_address: 10.33.33.4
 
   bredis_4:
-    image: valkey/valkey:7.2.8-bookworm
+    image: valkey/valkey:8.0.2-bookworm
     volumes:
       - ./test/:/test/:cached
     command: valkey-server /test/redis-ratelimits.config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
           - boulder-proxysql
 
   bredis_1:
-    image: redis:6.2.7
+    image: redis:7.2.7-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ocsp.config
@@ -117,7 +117,7 @@ services:
         ipv4_address: 10.33.33.2
 
   bredis_2:
-    image: redis:6.2.7
+    image: redis:7.2.7-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ocsp.config
@@ -126,7 +126,7 @@ services:
         ipv4_address: 10.33.33.3
 
   bredis_3:
-    image: redis:6.2.7
+    image: redis:7.2.7-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ratelimits.config
@@ -135,7 +135,7 @@ services:
         ipv4_address: 10.33.33.4
 
   bredis_4:
-    image: redis:6.2.7
+    image: redis:7.2.7-bookworm
     volumes:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ratelimits.config


### PR DESCRIPTION
Just using GHA to verify a few different versions work, to check for potential incompatibilities across a bit of a wide slice of options.

Good:
- Redis 7.2.7
- Valkey 7.2.8
- Valkey 8.0.2