### PR TITLE
issuance: add CRLDistributionPoints to certs

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -225,7 +225,7 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]*issuanc
 		profilesByName[name] = &withID
 		_, found := profilesByHash[hash]
 		if found {
-			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", profile.Hash())
+			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", hash)
 		}
 		profilesByHash[hash] = &withID
 	}

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -227,7 +227,7 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]*issuanc
 		if found {
 			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", profile.Hash())
 		}
-		profilesByHash[profile.Hash()] = &withID
+		profilesByHash[hash] = &withID
 	}
 
 	return certProfilesMaps{defaultName, profilesByHash, profilesByName}, nil

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -225,9 +225,9 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]*issuanc
 		profilesByName[name] = &withID
 		_, found := profilesByHash[hash]
 		if found {
-			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", hash)
+			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", profile.Hash())
 		}
-		profilesByHash[hash] = &withID
+		profilesByHash[profile.Hash()] = &withID
 	}
 
 	return certProfilesMaps{defaultName, profilesByHash, profilesByName}, nil

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -67,6 +68,18 @@ func TestGenerateValidity(t *testing.T) {
 			test.AssertEquals(t, notBefore, tc.notBefore)
 			test.AssertEquals(t, notAfter, tc.notAfter)
 		})
+	}
+}
+
+func TestCRLURL(t *testing.T) {
+	issuer, err := newIssuer(defaultIssuerConfig(), issuerCert, issuerSigner, clock.NewFake())
+	if err != nil {
+		t.Fatalf("newIssuer: %s", err)
+	}
+	url := issuer.crlURL(4928)
+	want := "http://crl-url.example.org/4928.crl"
+	if url != want {
+		t.Errorf("crlURL(4928)=%s, want %s", url, want)
 	}
 }
 
@@ -380,7 +393,50 @@ func TestIssue(t *testing.T) {
 			test.AssertDeepEquals(t, cert.PublicKey, pk.Public())
 			test.AssertEquals(t, len(cert.Extensions), 9) // Constraints, KU, EKU, SKID, AKID, AIA, SAN, Policies, Poison
 			test.AssertEquals(t, cert.KeyUsage, tc.ku)
+			if len(cert.CRLDistributionPoints) > 0 {
+				t.Errorf("want CRLDistributionPoints=[], got %v", cert.CRLDistributionPoints)
+			}
 		})
+	}
+}
+
+func TestIssueWithCRLDP(t *testing.T) {
+	fc := clock.NewFake()
+	issuerConfig := defaultIssuerConfig()
+	issuerConfig.CRLURLBase = "http://crls.example.net/"
+	issuerConfig.CRLShards = 999
+	signer, err := newIssuer(issuerConfig, issuerCert, issuerSigner, fc)
+	if err != nil {
+		t.Fatalf("newIssuer: %s", err)
+	}
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %s", err)
+	}
+	_, issuanceToken, err := signer.Prepare(defaultProfile(), &IssuanceRequest{
+		PublicKey:       MarshalablePublicKey{pk.Public()},
+		SubjectKeyId:    goodSKID,
+		Serial:          []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		DNSNames:        []string{"example.com"},
+		NotBefore:       fc.Now(),
+		NotAfter:        fc.Now().Add(time.Hour - time.Second),
+		IncludeCTPoison: true,
+	})
+	if err != nil {
+		t.Fatalf("signer.Prepare: %s", err)
+	}
+	certBytes, err := signer.Issue(issuanceToken)
+	if err != nil {
+		t.Fatalf("signer.Issue: %s", err)
+	}
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate: %s", err)
+	}
+	// Because CRL shard is calculated deterministically from serial, we know which shard will be chosen.
+	expectedCRLDP := []string{"http://crls.example.net/919.crl"}
+	if !reflect.DeepEqual(cert.CRLDistributionPoints, expectedCRLDP) {
+		t.Errorf("CRLDP=%+v, want %+v", cert.CRLDistributionPoints, expectedCRLDP)
 	}
 }
 

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -413,7 +413,9 @@ func TestIssueWithCRLDP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ecdsa.GenerateKey: %s", err)
 	}
-	_, issuanceToken, err := signer.Prepare(defaultProfile(), &IssuanceRequest{
+	profile := defaultProfile()
+	profile.includeCRLDistributionPoints = true
+	_, issuanceToken, err := signer.Prepare(profile, &IssuanceRequest{
 		PublicKey:       MarshalablePublicKey{pk.Public()},
 		SubjectKeyId:    goodSKID,
 		Serial:          []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},

--- a/issuance/crl.go
+++ b/issuance/crl.go
@@ -59,6 +59,11 @@ type CRLRequest struct {
 	Entries []x509.RevocationListEntry
 }
 
+// crlURL combines the CRL URL base with a shard, and adds a suffix.
+func (i *Issuer) crlURL(shard int) string {
+	return fmt.Sprintf("%s%d.crl", i.crlURLBase, shard)
+}
+
 func (i *Issuer) IssueCRL(prof *CRLProfile, req *CRLRequest) ([]byte, error) {
 	backdatedBy := i.clk.Now().Sub(req.ThisUpdate)
 	if backdatedBy > prof.maxBackdate {
@@ -82,7 +87,7 @@ func (i *Issuer) IssueCRL(prof *CRLProfile, req *CRLRequest) ([]byte, error) {
 	// Concat the base with the shard directly, since we require that the base
 	// end with a single trailing slash.
 	idp, err := idp.MakeUserCertsExt([]string{
-		fmt.Sprintf("%s%d.crl", i.crlURLBase, req.Shard),
+		i.crlURL(int(req.Shard)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating IDP extension: %w", err)

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -162,7 +162,7 @@ type IssuerConfig struct {
 
 	IssuerURL  string `validate:"required,url"`
 	OCSPURL    string `validate:"required,url"`
-	CRLURLBase string `validate:"omitempty,url,startswith=http://,endswith=/"`
+	CRLURLBase string `validate:"required,url,startswith=http://,endswith=/"`
 
 	// Number of CRL shards.
 	// If this is zero, no CRLDP will be added to issued certs.

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -165,13 +165,8 @@ type IssuerConfig struct {
 	CRLURLBase string `validate:"required,url,startswith=http://,endswith=/"`
 
 	// Number of CRL shards.
-	// If this is zero, no CRLDP will be added to issued certs.
-	// If this is nonzero, enable explicit sharding: a CRLDP based on CRLURLBase
-	// will be added to all issued certs.
-	// A shard will be selected between 1 and CRLShards, inclusive.
-	// Enabling explicit sharding enables writing to the `revokedCertificates`
-	// table at revocation time, which in turn allows the the crl-updater to
-	// find certificates by their explicit shard.
+	// This must be nonzero if adding CRLDistributionPoints to certificates
+	// (that is, if profile.IncludeCRLDistributionPoints is true).
 	CRLShards int
 
 	Location IssuerLoc

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -48,6 +48,17 @@
 					"allowMustStaple": true,
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m",
+					"includeCRLDistributionPoints": true,
+					"lintConfig": "test/config-next/zlint.toml",
+					"ignoredLints": [
+						"w_subject_common_name_included",
+						"w_ext_subject_key_identifier_not_recommended_subscriber"
+					]
+				},
+				"legacyRenamedPriorToDeletion": {
+					"allowMustStaple": true,
+					"maxValidityPeriod": "7776000s",
+					"maxValidityBackdate": "1h5m",
 					"lintConfig": "test/config-next/zlint.toml",
 					"ignoredLints": [
 						"w_subject_common_name_included",
@@ -55,6 +66,20 @@
 					]
 				},
 				"modern": {
+					"allowMustStaple": true,
+					"omitCommonName": true,
+					"omitKeyEncipherment": true,
+					"omitClientAuth": true,
+					"omitSKID": true,
+					"includeCRLDistributionPoints": true,
+					"maxValidityPeriod": "583200s",
+					"maxValidityBackdate": "1h5m",
+					"lintConfig": "test/config-next/zlint.toml",
+					"ignoredLints": [
+						"w_ext_subject_key_identifier_missing_sub_cert"
+					]
+				},
+				"modernRenamedPriorToDeletion": {
 					"allowMustStaple": true,
 					"omitCommonName": true,
 					"omitKeyEncipherment": true,
@@ -75,6 +100,7 @@
 			"issuers": [
 				{
 					"active": true,
+					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-a",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/43104258997432926/",
@@ -86,6 +112,7 @@
 				},
 				{
 					"active": true,
+					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-b",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/17302365692836921/",
@@ -97,6 +124,7 @@
 				},
 				{
 					"active": false,
+					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-c",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/56560759852043581/",
@@ -108,6 +136,7 @@
 				},
 				{
 					"active": true,
+					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-a",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/29947985078257530/",
@@ -119,6 +148,7 @@
 				},
 				{
 					"active": true,
+					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-b",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/6762885421992935/",
@@ -130,6 +160,7 @@
 				},
 				{
 					"active": false,
+					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-c",
 					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/56183656833365902/",


### PR DESCRIPTION
The CRLDP is included only when the profile's IncludeCRLDistributionPoints field is true.

Introduce a new config field for issuers, CRLShards. If IncludeCRLDistributionPoints is true and this is zero, issuance will error.

The CRL shard is assigned at issuance time based on the (random) low bits of the serial number.

Part of #7094.