### PR TITLE
Fix typos in documentation and error messages

### DIFF
--- a/docs/acme-divergences.md
+++ b/docs/acme-divergences.md
@@ -18,7 +18,7 @@ support this non-essential feature in the future. Please follow Boulder Issue
 ## [Section 7.4](https://tools.ietf.org/html/rfc8555#section-7.4)
 
 Boulder does not accept the optional `notBefore` and `notAfter` fields of a
-`newOrder` request paylod.
+`newOrder` request payload.
 
 ## [Section 7.4.1](https://tools.ietf.org/html/rfc8555#section-7.4.1)
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -49,7 +49,7 @@ const (
 	AlreadyRevoked
 	BadRevocationReason
 	UnsupportedContact
-	// The requesteed serial number does not exist in the `serials` table.
+	// The requested serial number does not exist in the `serials` table.
 	UnknownSerial
 	// The certificate being indicated for replacement already has a replacement
 	// order.


### PR DESCRIPTION
- Fix 'requesteed' -> 'requested' in errors/errors.go
- Fix 'paylod' -> 'payload' in docs/acme-divergences.md

These changes address typos identified by the linter.
