### PR TITLE
test: No longer accumulate orphans on each test run

### DIFF
--- a/t.sh
+++ b/t.sh
@@ -10,9 +10,8 @@ if type realpath >/dev/null 2>&1 ; then
 fi
 
 # Generate the test keys and certs necessary for the integration tests.
-docker compose run bsetup
+docker compose run --rm bsetup
 
 # Use a predictable name for the container so we can grab the logs later
 # for use when testing logs analysis tools.
-docker rm boulder_tests || true
-exec docker compose run --name boulder_tests boulder ./test.sh "$@"
+exec docker compose run --rm --name boulder_tests boulder ./test.sh "$@"

--- a/t.sh
+++ b/t.sh
@@ -12,6 +12,4 @@ fi
 # Generate the test keys and certs necessary for the integration tests.
 docker compose run --rm bsetup
 
-# Use a predictable name for the container so we can grab the logs later
-# for use when testing logs analysis tools.
 exec docker compose run --rm --name boulder_tests boulder ./test.sh "$@"

--- a/tn.sh
+++ b/tn.sh
@@ -12,6 +12,4 @@ fi
 # Generate the test keys and certs necessary for the integration tests.
 docker compose run --rm bsetup
 
-# Use a predictable name for the container so we can grab the logs later
-# for use when testing logs analysis tools.
 exec docker compose -f docker-compose.yml -f docker-compose.next.yml run --rm --name boulder_tests boulder ./test.sh "$@"

--- a/tn.sh
+++ b/tn.sh
@@ -10,9 +10,8 @@ if type realpath >/dev/null 2>&1 ; then
 fi
 
 # Generate the test keys and certs necessary for the integration tests.
-docker compose run bsetup
+docker compose run --rm bsetup
 
 # Use a predictable name for the container so we can grab the logs later
 # for use when testing logs analysis tools.
-docker rm boulder_tests || true
-exec docker compose -f docker-compose.yml -f docker-compose.next.yml run boulder ./test.sh "$@"
+exec docker compose -f docker-compose.yml -f docker-compose.next.yml run --rm --name boulder_tests boulder ./test.sh "$@"


### PR DESCRIPTION
Stop producing orphans and `No such container: boulder_tests` on each test invocation.

---

>[!Note]
>No more:
>`$ ./tn.sh -uvw`
>`WARN[0000] Found orphan containers ([boulder-bsetup-run-e1f829a31082 boulder-boulder-run-46a3dfe373bc boulder-bsetup-run-12fff21f4cf3 boulder-boulder-run-f42253a0e5d4 boulder-bsetup-run-2e3aa384e16f boulder-boulder-run-f099848f9d4c boulder-bsetup-run-c34f6931196c boulder-boulder-run-e10238f0f513 boulder-bsetup-run-3eca5f83e3c5 boulder-boulder-run-336e028210ce boulder-bsetup-run-56c85a9e03ea boulder-boulder-run-29c7ee095d16 boulder-bsetup-run-635603efffa9 boulder-boulder-run-9f5a859edb4d boulder-bsetup-run-4c0f6774b9a4 boulder-boulder-run-97f7575db781 boulder-bsetup-run-79735134cda5 boulder-boulder-run-3a8d5cb917bb boulder-bsetup-run-00537abe7e00 boulder-boulder-run-05af85f0bb6e boulder-bsetup-run-d1604e7c822e boulder-boulder-run-8bac2b5d6c53 boulder-bsetup-run-fb7f2eabb6c1 boulder-boulder-run-2063c1e2969e boulder-bsetup-run-5046ab5ad729 boulder-boulder-run-467e9767fb35 boulder-bsetup-run-ba53209a3782 boulder-boulder-run-5750eb012e2c boulder-bsetup-run-33cb73238481 boulder-boulder-run-2f8d9671cc8b boulder-bsetup-run-1f6839a8fd41 boulder-boulder-run-7696bfe0e112 boulder-bsetup-run-8ec3b7363ec6 boulder-boulder-run-e2d122934054 boulder-bsetup-run-e9e1d9d6ae44 boulder-boulder-run-ca980bf12c5c boulder-bsetup-run-b0fa4882ced3 boulder-boulder-run-0ac6ffaec102 boulder-bsetup-run-f6fd7403be5e boulder-boulder-run-cdb1e7ed894a boulder-bsetup-run-4a12c3313d50 boulder-boulder-run-2d20da0716c8 boulder-bsetup-run-cfd64f05e4a2 boulder-boulder-run-a4ebe93e405d boulder-bsetup-run-2d240b943535 boulder-boulder-run-360147415f74 boulder-bsetup-run-7c119400e195 boulder-boulder-run-50e428e3f5f1 boulder-bsetup-run-bd4f0c8b28f3 boulder-boulder-run-63e195f82802 boulder-bsetup-run-ee6ef6ac98f0]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.`