### PR TITLE
RA: Make ProfileSelectionAllowList test clearer

### DIFF
--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1678,13 +1678,13 @@ func TestNewOrder_ProfileSelectionAllowList(t *testing.T) {
 			name:               "Allow all account IDs regardless of profile",
 			validationProfiles: nil,
 			expectErr:          false,
-		}
+		},
 		{
-			name:               "Allow all account IDs for this specific profile",
+			name: "Allow all account IDs for this specific profile",
 			validationProfiles: map[string]*ValidationProfile{
 				"test": NewValidationProfile(nil),
 			},
-			expectErr:          false,
+			expectErr: false,
 		},
 		{
 			name: "Deny all but account Id 1337",

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -1675,8 +1675,15 @@ func TestNewOrder_ProfileSelectionAllowList(t *testing.T) {
 		expectErrContains  string
 	}{
 		{
-			name:               "Allow all account IDs",
+			name:               "Allow all account IDs regardless of profile",
 			validationProfiles: nil,
+			expectErr:          false,
+		}
+		{
+			name:               "Allow all account IDs for this specific profile",
+			validationProfiles: map[string]*ValidationProfile{
+				"test": NewValidationProfile(nil),
+			},
 			expectErr:          false,
 		},
 		{


### PR DESCRIPTION
Improve the test of the `ra.validationProfiles` field by providing a constructed `map[string]*ValidationProfile` instead of constructing one inside the test. Much like how this data is provided, or `nil`, in calls to `ra.NewRegistrationAuthorityImpl()`.