### PR TITLE
tests: increase wfe log level

### DIFF
--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -142,7 +142,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 7,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -141,7 +141,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 7,
 		"sysloglevel": 6
 	}
 }


### PR DESCRIPTION
We've been seeing some flaky integration tests where issuance fails. The integration test only has access to the generic user-facing error. The real error is available as `InternalError` in the WFE logs, but we need a higher log level to see it.