### PR TITLE
issuance: add new IncludeCRLDistributionPoints bool

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -225,7 +225,7 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]*issuanc
 		profilesByName[name] = &withID
 		_, found := profilesByHash[hash]
 		if found {
-			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", profile.Hash())
+			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", hash)
 		}
 		profilesByHash[hash] = &withID
 	}

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -214,10 +214,7 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]*issuanc
 			return certProfilesMaps{}, err
 		}
 
-		hash, err := profileConfig.Hash()
-		if err != nil {
-			return certProfilesMaps{}, err
-		}
+		hash := profile.Hash()
 
 		withID := certProfileWithID{
 			name:    name,
@@ -226,12 +223,11 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]*issuanc
 		}
 
 		profilesByName[name] = &withID
-
-		_, found := profilesByHash[hash]
+		_, found := profilesByHash[profile.Hash()]
 		if found {
-			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", hash)
+			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", profile.Hash())
 		}
-		profilesByHash[hash] = &withID
+		profilesByHash[profile.Hash()] = &withID
 	}
 
 	return certProfilesMaps{defaultName, profilesByHash, profilesByName}, nil

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -223,11 +223,11 @@ func makeCertificateProfilesMap(defaultName string, profiles map[string]*issuanc
 		}
 
 		profilesByName[name] = &withID
-		_, found := profilesByHash[profile.Hash()]
+		_, found := profilesByHash[hash]
 		if found {
 			return certProfilesMaps{}, fmt.Errorf("duplicate certificate profile hash %d", profile.Hash())
 		}
-		profilesByHash[profile.Hash()] = &withID
+		profilesByHash[hash] = &withID
 	}
 
 	return certProfilesMaps{defaultName, profilesByHash, profilesByName}, nil

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -102,7 +102,7 @@ type testCtx struct {
 	ocsp                   *ocspImpl
 	crl                    *crlImpl
 	defaultCertProfileName string
-	certProfiles           map[string]*issuance.ProfileConfig
+	certProfiles           map[string]*issuance.ProfileConfigNew
 	serialPrefix           byte
 	maxNames               int
 	boulderIssuers         []*issuance.Issuer
@@ -153,14 +153,14 @@ func setup(t *testing.T) *testCtx {
 	err = pa.LoadHostnamePolicyFile("../test/hostname-policy.yaml")
 	test.AssertNotError(t, err, "Couldn't set hostname policy")
 
-	certProfiles := make(map[string]*issuance.ProfileConfig, 0)
-	certProfiles["legacy"] = &issuance.ProfileConfig{
+	certProfiles := make(map[string]*issuance.ProfileConfigNew, 0)
+	certProfiles["legacy"] = &issuance.ProfileConfigNew{
 		AllowMustStaple:     true,
 		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 90},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},
 		IgnoredLints:        []string{"w_subject_common_name_included"},
 	}
-	certProfiles["modern"] = &issuance.ProfileConfig{
+	certProfiles["modern"] = &issuance.ProfileConfigNew{
 		AllowMustStaple:     true,
 		OmitCommonName:      true,
 		OmitKeyEncipherment: true,
@@ -546,7 +546,7 @@ func TestMakeCertificateProfilesMap(t *testing.T) {
 	testCtx := setup(t)
 	test.AssertEquals(t, len(testCtx.certProfiles), 2)
 
-	testProfile := issuance.ProfileConfig{
+	testProfile := issuance.ProfileConfigNew{
 		AllowMustStaple:     false,
 		MaxValidityPeriod:   config.Duration{Duration: time.Hour * 24 * 90},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},
@@ -560,7 +560,7 @@ func TestMakeCertificateProfilesMap(t *testing.T) {
 	testCases := []struct {
 		name              string
 		defaultName       string
-		profileConfigs    map[string]*issuance.ProfileConfig
+		profileConfigs    map[string]*issuance.ProfileConfigNew
 		expectedErrSubstr string
 		expectedProfiles  []nameToHash
 	}{
@@ -571,13 +571,13 @@ func TestMakeCertificateProfilesMap(t *testing.T) {
 		},
 		{
 			name:              "no profiles",
-			profileConfigs:    map[string]*issuance.ProfileConfig{},
+			profileConfigs:    map[string]*issuance.ProfileConfigNew{},
 			expectedErrSubstr: "at least one certificate profile",
 		},
 		{
 			name:        "no profile matching default name",
 			defaultName: "default",
-			profileConfigs: map[string]*issuance.ProfileConfig{
+			profileConfigs: map[string]*issuance.ProfileConfigNew{
 				"notDefault": &testProfile,
 			},
 			expectedErrSubstr: "profile object was not found for that name",
@@ -585,7 +585,7 @@ func TestMakeCertificateProfilesMap(t *testing.T) {
 		{
 			name:        "duplicate hash",
 			defaultName: "default",
-			profileConfigs: map[string]*issuance.ProfileConfig{
+			profileConfigs: map[string]*issuance.ProfileConfigNew{
 				"default":  &testProfile,
 				"default2": &testProfile,
 			},
@@ -594,7 +594,7 @@ func TestMakeCertificateProfilesMap(t *testing.T) {
 		{
 			name:        "empty profile config",
 			defaultName: "empty",
-			profileConfigs: map[string]*issuance.ProfileConfig{
+			profileConfigs: map[string]*issuance.ProfileConfigNew{
 				"empty": {},
 			},
 			expectedProfiles: []nameToHash{

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -40,7 +40,7 @@ type Config struct {
 
 			// One of the profile names must match the value of
 			// DefaultCertificateProfileName or boulder-ca will fail to start.
-			CertProfiles map[string]*issuance.ProfileConfig `validate:"dive,keys,alphanum,min=1,max=32,endkeys,required_without=Profile,structonly"`
+			CertProfiles map[string]*issuance.ProfileConfigNew `validate:"dive,keys,alphanum,min=1,max=32,endkeys,required_without=Profile,structonly"`
 
 			// TODO(#7159): Make this required once all live configs are using it.
 			CRLProfile issuance.CRLProfileConfig `validate:"-"`

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -103,6 +103,9 @@ type ProfileConfig struct {
 // allows for gracefully adding new fields without changing the hash of existing
 // profile configs). This struct does not get embedded into any certs, CRLs, or
 // other objects, and does not get signed; it's only used internally.
+//
+// Note: even though these fields have encoding instructions (tag:N), they will
+// be encoded in the order they appear in the struct, so do not reorder them.
 type ProfileConfigNew struct {
 	// AllowMustStaple, when false, causes all IssuanceRequests which specify the
 	// OCSP Must Staple extension to be rejected.
@@ -121,10 +124,10 @@ type ProfileConfigNew struct {
 	OmitSKID bool `asn1:"tag:5,optional"`
 	// IncludeCRLDistributionPoints causes the CRLDistributionPoints extension to
 	// be added to all certificates issued by this profile.
-	IncludeCRLDistributionPoints bool `asn1:"tag:8,optional"`
+	IncludeCRLDistributionPoints bool `asn1:"tag:6,optional"`
 
-	MaxValidityPeriod   config.Duration `asn1:"tag:6,optional"`
-	MaxValidityBackdate config.Duration `asn1:"tag:7,optional"`
+	MaxValidityPeriod   config.Duration `asn1:"tag:7,optional"`
+	MaxValidityBackdate config.Duration `asn1:"tag:8,optional"`
 
 	// LintConfig is a path to a zlint config file, which can be used to control
 	// the behavior of zlint's "customizable lints".

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -182,6 +182,8 @@ type Profile struct {
 	maxValidity time.Duration
 
 	lints lint.Registry
+
+	hash [32]byte
 }
 
 // NewProfile converts the profile config into a usable profile.
@@ -206,6 +208,11 @@ func NewProfile(profileConfig *ProfileConfigNew) (*Profile, error) {
 		lints.SetConfiguration(lintconfig)
 	}
 
+	hash, err := profileConfig.Hash()
+	if err != nil {
+		return nil, err
+	}
+
 	sp := &Profile{
 		allowMustStaple:     profileConfig.AllowMustStaple,
 		omitCommonName:      profileConfig.OmitCommonName,
@@ -215,9 +222,14 @@ func NewProfile(profileConfig *ProfileConfigNew) (*Profile, error) {
 		maxBackdate:         profileConfig.MaxValidityBackdate.Duration,
 		maxValidity:         profileConfig.MaxValidityPeriod.Duration,
 		lints:               lints,
+		hash:                hash,
 	}
 
 	return sp, nil
+}
+
+func (p *Profile) Hash() [32]byte {
+	return p.hash
 }
 
 // GenerateValidity returns a notBefore/notAfter pair bracketing the input time,

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -40,7 +40,7 @@ import (
 // The CA uses a hash of the gob encoding of ProfileConfig to ensure precert
 // and final cert issuance use the exact same profile settings. Gob encodes all
 // fields, including zero values, which means adding fields immediately changes all
-// hashes, causing a deployability problem.
+// hashes, causing a deployability problem. It also encodes the struct name.
 //
 // To solve the deployability problem, we're switching to ASN.1 encoding. However,
 // while deploying that we still need the ability to hash old configs the same way
@@ -119,11 +119,12 @@ type ProfileConfigNew struct {
 	OmitClientAuth bool `asn1:"tag:4,optional"`
 	// OmitSKID causes the Subject Key Identifier extension to be omitted.
 	OmitSKID bool `asn1:"tag:5,optional"`
+	// IncludeCRLDistributionPoints causes the CRLDistributionPoints extension to
+	// be added to all certificates issued by this profile.
+	IncludeCRLDistributionPoints bool `asn1:"tag:8,optional"`
 
 	MaxValidityPeriod   config.Duration `asn1:"tag:6,optional"`
 	MaxValidityBackdate config.Duration `asn1:"tag:7,optional"`
-
-	IncludeCRLDistributionPoints bool `asn1:"tag:8,optional"`
 
 	// LintConfig is a path to a zlint config file, which can be used to control
 	// the behavior of zlint's "customizable lints".

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -854,7 +854,7 @@ func TestProfileHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hashing %+v: %s", profile, err)
 	}
-	expectedHash = "a7d2ee3ede97124e66265cebfb59dccc55c1c67dc267b361324400f89e577afe"
+	expectedHash = "d2a6c9f0aa37d2ac0b15476cb6e0ae9b98ba59b1321d8d6da26efc620581c53d"
 	if expectedHash != fmt.Sprintf("%x", hash) {
 		t.Errorf("%+v.Hash()=%x, want %s", profile, hash, expectedHash)
 	}

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -854,7 +854,7 @@ func TestProfileHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hashing %+v: %s", profile, err)
 	}
-	expectedHash = "5939ea199deb3327d1b529da08d6fb07eb8de4c4cca9f6bf499d76da4b67d1e8"
+	expectedHash = "a7d2ee3ede97124e66265cebfb59dccc55c1c67dc267b361324400f89e577afe"
 	if expectedHash != fmt.Sprintf("%x", hash) {
 		t.Errorf("%+v.Hash()=%x, want %s", profile, hash, expectedHash)
 	}

--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func defaultProfileConfig() *ProfileConfig {
-	return &ProfileConfig{
+func defaultProfileConfig() *ProfileConfigNew {
+	return &ProfileConfigNew{
 		AllowMustStaple:     true,
 		MaxValidityPeriod:   config.Duration{Duration: time.Hour},
 		MaxValidityBackdate: config.Duration{Duration: time.Hour},


### PR DESCRIPTION
To achieve this without breaking hashes of deployed configs, create a ProfileConfigNew containing the new field (and removing some deprecated fields).

Move the CA's profile-hashing logic into the `issuance` package, and gate it on the presence of IncludeCRLDistributionPoints. If that field is false (the default), create an instance of the old `ProfileConfig` with the appropriate values and encode/hash that instead.

Note: the IncludeCRLDistributionPoints field does not yet control any behavior. That will be part of #7974.

Part of #7094