### PR TITLE
crl-updater: split temporal/explicit sharding by serial

### DIFF
--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -91,6 +91,19 @@ type Config struct {
 		// of magnitude greater than our p99 update latency.
 		UpdateTimeout config.Duration `validate:"-"`
 
+		// TemporallyShardedSerialPrefixes is a list of prefixes that were used to
+		// issue certificates with no CRLDistributionPoints extension, and which are
+		// therefore temporally sharded. If it's non-empty, the CRL Updater will
+		// require matching serials when querying by temporal shard. When querying
+		// by explicit shard, any prefix is allowed.
+		//
+		// This should be set to the current set of serial prefixes in production.
+		// When deploying explicit sharding (i.e. the CRLDistributionPoints extension),
+		// the CAs should be configured with a new set of serial prefixes that haven't
+		// been used before (and the OCSP Responder config should be updated to
+		// recognize the new prefixes as well as the old ones).
+		TemporallyShardedSerialPrefixes []string
+
 		// MaxParallelism controls how many workers may be running in parallel.
 		// A higher value reduces the total time necessary to update all CRL shards
 		// that this updater is responsible for, but also increases the memory used
@@ -176,6 +189,7 @@ func main() {
 		c.CRLUpdater.UpdateTimeout.Duration,
 		c.CRLUpdater.MaxParallelism,
 		c.CRLUpdater.MaxAttempts,
+		c.CRLUpdater.TemporallyShardedSerialPrefixes,
 		sac,
 		cac,
 		csc,

--- a/crl/updater/batch_test.go
+++ b/crl/updater/batch_test.go
@@ -26,6 +26,7 @@ func TestRunOnce(t *testing.T) {
 		[]*issuance.Certificate{e1, r3},
 		2, 18*time.Hour, 24*time.Hour,
 		6*time.Hour, time.Minute, 1, 1,
+		nil,
 		&fakeSAC{revokedCerts: revokedCertsStream{err: errors.New("db no worky")}, maxNotAfter: clk.Now().Add(90 * 24 * time.Hour)},
 		&fakeCA{gcc: generateCRLStream{}},
 		&fakeStorer{uploaderStream: &noopUploader{}},

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -172,7 +172,7 @@
 				}
 			]
 		},
-		"serialPrefixHex": "7f",
+		"serialPrefixHex": "6e",
 		"maxNames": 100,
 		"lifespanOCSP": "96h",
 		"goodkey": {},

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -48,6 +48,9 @@
 		"lookbackPeriod": "24h",
 		"updatePeriod": "10m",
 		"updateTimeout": "1m",
+		"temporallyShardedSerialPrefixes": [
+			"7f"
+		],
 		"maxParallelism": 10,
 		"maxAttempts": 2,
 		"features": {}

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -57,7 +57,8 @@
 		"maxInflightSignings": 20,
 		"maxSigningWaiters": 100,
 		"requiredSerialPrefixes": [
-			"7f"
+			"7f",
+			"6e"
 		],
 		"features": {}
 	},


### PR DESCRIPTION
When we turn on explicit sharding, we'll change the CA serial prefix, so we can know that all issuance from the new prefixes uses explicit sharding, and all issuance from the old prefixes uses temporal sharding. This lets us avoid putting a revoked cert in two different CRL shards (the temporal one and the explicit one).

To achieve this, the crl-updater gets a list of temporally sharded serial prefixes. When it queries the `certificateStatus` table by date (`GetRevokedCerts`), it will filter out explicitly sharded certificates: those that don't have their prefix on the list.

Part of #7094