### PR TITLE
RA: Clean up deprecated validation configuration

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -275,12 +275,6 @@ func NewRegistrationAuthorityImpl(
 	return ra
 }
 
-// UnconfiguredDefaultProfileName is a unique string which the RA can use to
-// identify a profile, but also detect that no profiles were explicitly
-// configured, and therefore should not be assumed to exist outside the RA.
-// TODO(#7986): Remove this when the defaultProfileName config is required.
-const UnconfiguredDefaultProfileName = "unconfiguredDefaultProfileName"
-
 // ValidationProfileConfig is a config struct which can be used to create a
 // ValidationProfile.
 type ValidationProfileConfig struct {
@@ -340,6 +334,10 @@ type validationProfiles struct {
 // configs and default name. It enforces that the given authorization lifetimes
 // are within the bounds mandated by the Baseline Requirements.
 func NewValidationProfiles(defaultName string, configs map[string]ValidationProfileConfig) (*validationProfiles, error) {
+	if defaultName == "" {
+		return nil, errors.New("default profile name must be configured")
+	}
+
 	profiles := make(map[string]*validationProfile, len(configs))
 
 	for name, config := range configs {
@@ -1188,12 +1186,8 @@ func (ra *RegistrationAuthorityImpl) issueCertificateOuter(
 		logEvent.PreviousCertificateIssued = timestamps.Timestamps[0].AsTime()
 	}
 
-	// If the order didn't request a specific profile and we have a default
-	// configured, provide it to the CA so we can stop relying on the CA's
-	// configured default.
-	// TODO(#7309): Make this unconditional.
 	profileName := order.CertificateProfileName
-	if profileName == "" && ra.profiles.defaultName != UnconfiguredDefaultProfileName {
+	if profileName == "" {
 		profileName = ra.profiles.defaultName
 	}
 

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -29,12 +29,9 @@
 		"debugAddr": ":8002",
 		"hostnamePolicyFile": "test/hostname-policy.yaml",
 		"maxNames": 100,
-		"authorizationLifetimeDays": 30,
-		"pendingAuthorizationLifetimeDays": 7,
 		"goodkey": {
 			"fermatRounds": 100
 		},
-		"orderLifetime": "168h",
 		"issuerCerts": [
 			"test/certs/webpki/int-rsa-a.cert.pem",
 			"test/certs/webpki/int-rsa-b.cert.pem",
@@ -43,6 +40,19 @@
 			"test/certs/webpki/int-ecdsa-b.cert.pem",
 			"test/certs/webpki/int-ecdsa-c.cert.pem"
 		],
+		"validationProfiles": {
+			"legacy": {
+				"pendingAuthzLifetime": "168h",
+				"validAuthzLifetime": "720h",
+				"orderLifetime": "168h"
+			},
+			"modern": {
+				"pendingAuthzLifetime": "7h",
+				"validAuthzLifetime": "7h",
+				"orderLifetime": "7h"
+			}
+		},
+		"defaultProfileName": "legacy",
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/ra.boulder/cert.pem",


### PR DESCRIPTION
Remove the RA's deprecated top-level config keys which used to control order and authz lifetimes. Make the new profile-based config keys which replaced them required.

Since configuring a profile and default profile name is now mandatory, always supply a profile name to the CA when requesting issuance.

Part of https://github.com/letsencrypt/boulder/issues/7986

---

> [!WARNING]
> ~~Do not merge before https://github.com/letsencrypt/boulder/pull/7989 has been deployed.~~
> ~~Do not merge before IN-11006 has been completed.~~