### PR TITLE
VA: Remove unnecessary wrapper function

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -382,20 +382,6 @@ func (va *ValidationAuthorityImpl) setupHTTPValidation(
 	return dialer, record, nil
 }
 
-// fetchHTTP invokes processHTTPValidation and if an error result is
-// returned, converts it to a problem. Otherwise the results from
-// processHTTPValidation are returned.
-func (va *ValidationAuthorityImpl) fetchHTTP(
-	ctx context.Context,
-	host string,
-	path string) ([]byte, []core.ValidationRecord, error) {
-	body, records, err := va.processHTTPValidation(ctx, host, path)
-	if err != nil {
-		return body, records, err
-	}
-	return body, records, nil
-}
-
 // fallbackErr returns true only for net.OpError instances where the op is equal
 // to "dial", or url.Error instances wrapping such an error. fallbackErr returns
 // false for all other errors. By policy, only dial errors (not read or write
@@ -647,7 +633,7 @@ func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, ident ide
 
 	// Perform the fetch
 	path := fmt.Sprintf(".well-known/acme-challenge/%s", token)
-	body, validationRecords, err := va.fetchHTTP(ctx, ident.Value, "/"+path)
+	body, validationRecords, err := va.processHTTPValidation(ctx, ident.Value, "/"+path)
 	if err != nil {
 		return validationRecords, err
 	}

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -89,7 +89,7 @@ func TestDialerTimeout(t *testing.T) {
 	var took time.Duration
 	for range 20 {
 		started := time.Now()
-		_, _, err = va.fetchHTTP(ctx, "unroutable.invalid", "/.well-known/acme-challenge/whatever")
+		_, _, err = va.processHTTPValidation(ctx, "unroutable.invalid", "/.well-known/acme-challenge/whatever")
 		took = time.Since(started)
 		if err != nil && strings.Contains(err.Error(), "network is unreachable") {
 			continue
@@ -322,7 +322,7 @@ func TestExtractRequestTarget(t *testing.T) {
 func TestHTTPValidationDNSError(t *testing.T) {
 	va, mockLog := setup(nil, "", nil, nil)
 
-	_, _, prob := va.fetchHTTP(ctx, "always.error", "/.well-known/acme-challenge/whatever")
+	_, _, prob := va.processHTTPValidation(ctx, "always.error", "/.well-known/acme-challenge/whatever")
 	test.AssertError(t, prob, "Expected validation fetch to fail")
 	matchingLines := mockLog.GetAllMatching(`read udp: some net error`)
 	if len(matchingLines) != 1 {
@@ -338,7 +338,7 @@ func TestHTTPValidationDNSError(t *testing.T) {
 func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 	va, mockLog := setup(nil, "", nil, nil)
 
-	_, _, prob := va.fetchHTTP(ctx, "id.mismatch", "/.well-known/acme-challenge/whatever")
+	_, _, prob := va.processHTTPValidation(ctx, "id.mismatch", "/.well-known/acme-challenge/whatever")
 	test.AssertError(t, prob, "Expected validation fetch to fail")
 	matchingLines := mockLog.GetAllMatching(`logDNSError ID mismatch`)
 	if len(matchingLines) != 1 {
@@ -1105,7 +1105,7 @@ func TestFetchHTTP(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
 			defer cancel()
-			body, records, err := va.fetchHTTP(ctx, tc.Host, tc.Path)
+			body, records, err := va.processHTTPValidation(ctx, tc.Host, tc.Path)
 			if tc.ExpectedProblem == nil {
 				test.AssertNotError(t, err, "expected nil prob")
 			} else {


### PR DESCRIPTION
This function lost its purpose when we made it so all VA functions return errors instead of problems in https://github.com/letsencrypt/boulder/pull/7313.