### PR TITLE
admin: Remove deprecated debugAddr

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -31,9 +31,6 @@ type Config struct {
 		RAService *cmd.GRPCClientConfig
 		SAService *cmd.GRPCClientConfig
 
-		// Deprecated: DebugAddr is no longer used.
-		DebugAddr string
-
 		Features features.Config
 	}
 

--- a/test/config/admin.json
+++ b/test/config/admin.json
@@ -4,7 +4,6 @@
 			"dbConnectFile": "test/secrets/revoker_dburl",
 			"maxOpenConns": 1
 		},
-		"debugAddr": ":8014",
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/admin.boulder/cert.pem",


### PR DESCRIPTION
The parameter was removed in production in IN-10874.

Followup to #7838, #7840