### PR TITLE
test: increase pkilint timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
         ipv4_address: 10.77.77.17
 
   bpkilint:
-    image: ghcr.io/digicert/pkilint:v0.10.1
+    image: ghcr.io/digicert/pkilint:v0.12.6
     networks:
       bouldernet:
         ipv4_address: 10.77.77.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       BOULDER_CONFIG_DIR: test/config
       GOCACHE: /boulder/.gocache/go-build
       GOFLAGS: -mod=vendor
+      GOMAXPROCS: 2
     volumes:
       - .:/boulder:cached
       - ./.gocache:/root/.cache/go-build:cached
@@ -161,7 +162,7 @@ services:
         ipv4_address: 10.77.77.17
 
   bpkilint:
-    image: ghcr.io/digicert/pkilint:v0.12.6
+    image: ghcr.io/digicert/pkilint:v0.10.1
     networks:
       bouldernet:
         ipv4_address: 10.77.77.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       BOULDER_CONFIG_DIR: test/config
       GOCACHE: /boulder/.gocache/go-build
       GOFLAGS: -mod=vendor
-      GOMAXPROCS: 2
     volumes:
       - .:/boulder:cached
       - ./.gocache:/root/.cache/go-build:cached

--- a/linter/lints/rfc/lint_cert_via_pkilint.go
+++ b/linter/lints/rfc/lint_cert_via_pkilint.go
@@ -99,7 +99,7 @@ func (l *certViaPKILint) Execute(c *x509.Certificate) *lint.LintResult {
 	if err != nil {
 		return &lint.LintResult{
 			Status:  lint.Error,
-			Details: fmt.Sprintf("making POST request to pkilint API: %s", err),
+			Details: fmt.Sprintf("making POST request to pkilint API: %s (timeout %s)", err, timeout),
 		}
 	}
 	defer resp.Body.Close()

--- a/test/config-next/zlint.toml
+++ b/test/config-next/zlint.toml
@@ -1,6 +1,6 @@
 [e_pkilint_lint_cabf_serverauth_cert]
 pkilint_addr = "http://10.77.77.9"
-pkilint_timeout = 200000000 # 200 milliseconds
+pkilint_timeout = 2000000000 # 2 seconds
 ignore_lints = [
   # We include the CN in (almost) all of our certificates, on purpose.
   # See https://github.com/letsencrypt/boulder/issues/5112 for details.

--- a/test/config/zlint.toml
+++ b/test/config/zlint.toml
@@ -1,6 +1,6 @@
 [e_pkilint_lint_cabf_serverauth_cert]
 pkilint_addr = "http://10.77.77.9"
-pkilint_timeout = 200000000 # 200 milliseconds
+pkilint_timeout = 2000000000 # 2 seconds
 ignore_lints = [
   # We include the CN in (almost) all of our certificates, on purpose.
   # See https://github.com/letsencrypt/boulder/issues/5112 for details.


### PR DESCRIPTION
Increase pkilint timeout from 200ms to 2s. In #8006 I found that errors were stemming from timeouts talking to the bpkilint container. These probably showed up in TestRevocation particularly because that integration test now issues for many certificates in parallel. Pkilint's slowness, combined with the relatively small number of cores in CI, probably resulted in some requests taking too long.