### PR TITLE
RA: Control MaxNames via profile

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -78,6 +78,7 @@ type Config struct {
 		// limits are per section 7.1 of our combined CP/CPS, under "DV-SSL
 		// Subscriber Certificate". The value must match the CA and WFE
 		// configurations.
+		//
 		// Deprecated: Set ValidationProfiles[*].MaxNames instead.
 		MaxNames int `validate:"omitempty,min=1,max=100"`
 

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -149,13 +149,6 @@ type Config struct {
 			Overrides string
 		}
 
-		// MaxNames is the maximum number of subjectAltNames in a single cert.
-		// The value supplied SHOULD be greater than 0 and no more than 100,
-		// defaults to 100. These limits are per section 7.1 of our combined
-		// CP/CPS, under "DV-SSL Subscriber Certificate". The value must match
-		// the CA and RA configurations.
-		MaxNames int `validate:"min=0,max=100"`
-
 		// CertProfiles is a map of acceptable certificate profile names to
 		// descriptions (perhaps including URLs) of those profiles. NewOrder
 		// Requests with a profile name not present in this map will be rejected.
@@ -240,11 +233,6 @@ func main() {
 	}
 	if *debugAddr != "" {
 		c.WFE.DebugAddr = *debugAddr
-	}
-	maxNames := c.WFE.MaxNames
-	if maxNames == 0 {
-		// Default to 100 names per cert.
-		maxNames = 100
 	}
 
 	certChains := map[issuance.NameID][][]byte{}
@@ -357,7 +345,6 @@ func main() {
 		accountGetter,
 		limiter,
 		txnBuilder,
-		maxNames,
 		c.WFE.CertProfiles,
 		unpauseSigner,
 		c.WFE.Unpause.JWTLifetime.Duration,

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -354,6 +354,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 			pendingAuthzLifetime: 7 * 24 * time.Hour,
 			validAuthzLifetime:   300 * 24 * time.Hour,
 			orderLifetime:        7 * 24 * time.Hour,
+			maxNames:             100,
 		}},
 	}
 
@@ -1702,11 +1703,13 @@ func TestNewOrder_ValidationProfiles(t *testing.T) {
 				pendingAuthzLifetime: 1 * 24 * time.Hour,
 				validAuthzLifetime:   1 * 24 * time.Hour,
 				orderLifetime:        1 * 24 * time.Hour,
+				maxNames:             10,
 			},
 			"two": {
 				pendingAuthzLifetime: 2 * 24 * time.Hour,
 				validAuthzLifetime:   2 * 24 * time.Hour,
 				orderLifetime:        2 * 24 * time.Hour,
+				maxNames:             10,
 			},
 		},
 	}
@@ -1768,46 +1771,41 @@ func TestNewOrder_ProfileSelectionAllowList(t *testing.T) {
 	defer cleanUp()
 
 	testCases := []struct {
-		name               string
-		validationProfiles map[string]*validationProfile
-		expectErr          bool
-		expectErrContains  string
+		name              string
+		profile           validationProfile
+		expectErr         bool
+		expectErrContains string
 	}{
 		{
-			name: "Allow all account IDs",
-			validationProfiles: map[string]*validationProfile{
-				"test": {allowList: nil},
-			},
+			name:      "Allow all account IDs",
+			profile:   validationProfile{allowList: nil},
 			expectErr: false,
 		},
 		{
-			name: "Deny all but account Id 1337",
-			validationProfiles: map[string]*validationProfile{
-				"test": {allowList: allowlist.NewList([]int64{1337})},
-			},
+			name:              "Deny all but account Id 1337",
+			profile:           validationProfile{allowList: allowlist.NewList([]int64{1337})},
 			expectErr:         true,
 			expectErrContains: "not permitted to use certificate profile",
 		},
 		{
-			name: "Deny all",
-			validationProfiles: map[string]*validationProfile{
-				"test": {allowList: allowlist.NewList([]int64{})},
-			},
+			name:              "Deny all",
+			profile:           validationProfile{allowList: allowlist.NewList([]int64{})},
 			expectErr:         true,
 			expectErrContains: "not permitted to use certificate profile",
 		},
 		{
-			name: "Allow Registration.Id",
-			validationProfiles: map[string]*validationProfile{
-				"test": {allowList: allowlist.NewList([]int64{Registration.Id})},
-			},
+			name:      "Allow Registration.Id",
+			profile:   validationProfile{allowList: allowlist.NewList([]int64{Registration.Id})},
 			expectErr: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ra.profiles.byName = tc.validationProfiles
+			tc.profile.maxNames = 1
+			ra.profiles.byName = map[string]*validationProfile{
+				"test": &tc.profile,
+			}
 
 			orderReq := &rapb.NewOrderRequest{
 				RegistrationID:         Registration.Id,
@@ -3478,7 +3476,7 @@ func TestNewOrderMaxNames(t *testing.T) {
 	_, _, ra, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	ra.maxNames = 2
+	ra.profiles.def().maxNames = 2
 	_, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
 		RegistrationID: 1,
 		DnsNames: []string{

--- a/ratelimits/transaction.go
+++ b/ratelimits/transaction.go
@@ -378,6 +378,10 @@ func (builder *TransactionBuilder) FailedAuthorizationsForPausingPerDomainPerAcc
 //
 // Precondition: All orderDomains must comply with policy.WellFormedDomainNames.
 func (builder *TransactionBuilder) certificatesPerDomainCheckOnlyTransactions(regId int64, orderDomains []string) ([]Transaction, error) {
+	if len(orderDomains) > 100 {
+		return nil, fmt.Errorf("unwilling to process >100 rate limit transactions, got %d", len(orderDomains))
+	}
+
 	perAccountLimitBucketKey, err := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)
 	if err != nil {
 		return nil, err
@@ -456,6 +460,10 @@ func (builder *TransactionBuilder) certificatesPerDomainCheckOnlyTransactions(re
 //
 // Precondition: orderDomains must all pass policy.WellFormedDomainNames.
 func (builder *TransactionBuilder) CertificatesPerDomainSpendOnlyTransactions(regId int64, orderDomains []string) ([]Transaction, error) {
+	if len(orderDomains) > 100 {
+		return nil, fmt.Errorf("unwilling to process >100 rate limit transactions, got %d", len(orderDomains))
+	}
+
 	perAccountLimitBucketKey, err := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)
 	if err != nil {
 		return nil, err

--- a/ratelimits/transaction.go
+++ b/ratelimits/transaction.go
@@ -379,7 +379,7 @@ func (builder *TransactionBuilder) FailedAuthorizationsForPausingPerDomainPerAcc
 // Precondition: All orderDomains must comply with policy.WellFormedDomainNames.
 func (builder *TransactionBuilder) certificatesPerDomainCheckOnlyTransactions(regId int64, orderDomains []string) ([]Transaction, error) {
 	if len(orderDomains) > 100 {
-		return nil, fmt.Errorf("unwilling to process >100 rate limit transactions, got %d", len(orderDomains))
+		return nil, fmt.Errorf("unwilling to process more than 100 rate limit transactions, got %d", len(orderDomains))
 	}
 
 	perAccountLimitBucketKey, err := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)
@@ -461,7 +461,7 @@ func (builder *TransactionBuilder) certificatesPerDomainCheckOnlyTransactions(re
 // Precondition: orderDomains must all pass policy.WellFormedDomainNames.
 func (builder *TransactionBuilder) CertificatesPerDomainSpendOnlyTransactions(regId int64, orderDomains []string) ([]Transaction, error) {
 	if len(orderDomains) > 100 {
-		return nil, fmt.Errorf("unwilling to process >100 rate limit transactions, got %d", len(orderDomains))
+		return nil, fmt.Errorf("unwilling to process more than 100 rate limit transactions, got %d", len(orderDomains))
 	}
 
 	perAccountLimitBucketKey, err := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -26,7 +26,6 @@
 		},
 		"maxContactsPerRegistration": 3,
 		"hostnamePolicyFile": "test/hostname-policy.yaml",
-		"maxNames": 100,
 		"goodkey": {},
 		"finalizeTimeout": "30s",
 		"issuerCerts": [
@@ -41,12 +40,14 @@
 			"legacy": {
 				"pendingAuthzLifetime": "168h",
 				"validAuthzLifetime": "720h",
-				"orderLifetime": "168h"
+				"orderLifetime": "168h",
+				"maxNames": 100
 			},
 			"modern": {
 				"pendingAuthzLifetime": "7h",
 				"validAuthzLifetime": "7h",
-				"orderLifetime": "7h"
+				"orderLifetime": "7h",
+				"maxNames": 10
 			}
 		},
 		"defaultProfileName": "legacy",

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -28,7 +28,7 @@ func TestTooBigOrderError(t *testing.T) {
 	var prob acme.Problem
 	test.AssertErrorWraps(t, err, &prob)
 	test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:malformed")
-	test.AssertEquals(t, prob.Detail, "Order cannot contain more than 100 DNS names")
+	test.AssertContains(t, prob.Detail, "Order cannot contain more than 100 DNS names")
 }
 
 // TestAccountEmailError tests that registering a new account, or updating an

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -152,7 +152,6 @@ type WebFrontEndImpl struct {
 
 	limiter    *ratelimits.Limiter
 	txnBuilder *ratelimits.TransactionBuilder
-	maxNames   int
 
 	unpauseSigner      unpause.JWTSigner
 	unpauseJWTLifetime time.Duration
@@ -182,7 +181,6 @@ func NewWebFrontEndImpl(
 	accountGetter AccountGetter,
 	limiter *ratelimits.Limiter,
 	txnBuilder *ratelimits.TransactionBuilder,
-	maxNames int,
 	certProfiles map[string]string,
 	unpauseSigner unpause.JWTSigner,
 	unpauseJWTLifetime time.Duration,
@@ -221,7 +219,6 @@ func NewWebFrontEndImpl(
 		accountGetter:      accountGetter,
 		limiter:            limiter,
 		txnBuilder:         txnBuilder,
-		maxNames:           maxNames,
 		certProfiles:       certProfiles,
 		unpauseSigner:      unpauseSigner,
 		unpauseJWTLifetime: unpauseJWTLifetime,
@@ -2246,10 +2243,6 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	err = policy.WellFormedDomainNames(names)
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
-		return
-	}
-	if len(names) > wfe.maxNames {
-		wfe.sendError(response, logEvent, probs.Malformed("Order cannot contain more than %d DNS names", wfe.maxNames), nil)
 		return
 	}
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -757,6 +757,8 @@ func (wfe *WebFrontEndImpl) NewAccount(
 			wfe.sendError(response, logEvent, probs.RateLimited(err.Error()), err)
 			return
 		} else {
+			// Proceed, since we don't want internal rate limit system failures to
+			// block all account creation.
 			logEvent.IgnoredRateLimitError = err.Error()
 		}
 	}
@@ -2301,7 +2303,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		return
 	}
 
-	refundLimits := func() {}
+	var refundLimits func()
 	if !isARIRenewal {
 		refundLimits, err = wfe.checkNewOrderLimits(ctx, acct.ID, names, isRenewal || isARIRenewal)
 		if err != nil {
@@ -2309,8 +2311,9 @@ func (wfe *WebFrontEndImpl) NewOrder(
 				wfe.sendError(response, logEvent, probs.RateLimited(err.Error()), err)
 				return
 			} else {
+				// Proceed, since we don't want internal rate limit system failures to
+				// block all issuance.
 				logEvent.IgnoredRateLimitError = err.Error()
-				return
 			}
 		}
 	}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -435,7 +435,6 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 		mockSA,
 		limiter,
 		txnBuilder,
-		100,
 		map[string]string{"default": "a test profile"},
 		unpauseSigner,
 		unpauseLifetime,


### PR DESCRIPTION
Add MaxNames to the set of things that can be configured on a per-profile basis. Remove all references to the RA's global maxNames, replacing them with reference's to the current profile's maxNames. Add code to the RA's main() to copy a globally-configured MaxNames into each profile, for deployability.

Also remove any understanding of MaxNames from the WFE, as it is redundant with the RA and is not configured in staging or prod. Instead, hardcode the upper limit of 100 into the ratelimit package itself.

IN-11055 tracks the corresponding prod config changes.

Fixes https://github.com/letsencrypt/boulder/issues/7993