### PR TITLE
va: Put most recent, not original, IP in error messages (add'l case)

### DIFF
--- a/va/http.go
+++ b/va/http.go
@@ -592,7 +592,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		// If the retry still failed there isn't anything more to do, return the
 		// error immediately.
 		if err != nil {
-			return nil, records, newIPError(retryRecord.AddressUsed, err)
+			return nil, records, newIPError(records[len(records)-1].AddressUsed, err)
 		}
 	} else if err != nil {
 		// if the error was not a fallbackErr then return immediately.


### PR DESCRIPTION
Fix a remaining edge case after #7468: one call to `newIPError` did not account for when we retry *successfully,* but then are served a redirect which errors. In those cases, our `client.Do` call results in our redirect handler `processRedirect` appending yet another validation record to `records`, which was missed.

Fixes #7347