### PR TITLE
SA: Improve concurrency robustness of CRL leasing transactions

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1082,8 +1082,7 @@ func (ssa *SQLStorageAuthority) leaseOldestCRLShard(ctx context.Context, req *sa
 			`SELECT id, issuerID, idx, thisUpdate, nextUpdate, leasedUntil
 				FROM crlShards
 				WHERE issuerID = ?
-				AND idx BETWEEN ? AND ?
-				FOR UPDATE`,
+				AND idx BETWEEN ? AND ?`,
 			req.IssuerNameID, req.MinShardIdx, req.MaxShardIdx,
 		)
 		if err != nil {
@@ -1185,8 +1184,7 @@ func (ssa *SQLStorageAuthority) leaseSpecificCRLShard(ctx context.Context, req *
 			  FROM crlShards
 				WHERE issuerID = ?
 				AND idx = ?
-				LIMIT 1
-				FOR UPDATE`,
+				LIMIT 1`,
 			req.IssuerNameID,
 			req.MinShardIdx,
 		)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1135,7 +1135,7 @@ func (ssa *SQLStorageAuthority) leaseOldestCRLShard(ctx context.Context, req *sa
 			}
 			shardIdx = oldest.Idx
 
-			_, err = tx.ExecContext(ctx,
+			res, err := tx.ExecContext(ctx,
 				`UPDATE crlShards
 					SET leasedUntil = ?
 					WHERE issuerID = ?
@@ -1149,6 +1149,13 @@ func (ssa *SQLStorageAuthority) leaseOldestCRLShard(ctx context.Context, req *sa
 			)
 			if err != nil {
 				return -1, fmt.Errorf("updating selected shard: %w", err)
+			}
+			rowsAffected, err := res.RowsAffected()
+			if err != nil {
+				return -1, fmt.Errorf("confirming update of selected shard: %w", err)
+			}
+			if rowsAffected != 1 {
+				return -1, errors.New("failed to lease shard")
 			}
 		}
 
@@ -1205,7 +1212,7 @@ func (ssa *SQLStorageAuthority) leaseSpecificCRLShard(ctx context.Context, req *
 				return nil, fmt.Errorf("inserting selected shard: %w", err)
 			}
 		} else {
-			_, err = tx.ExecContext(ctx,
+			res, err := tx.ExecContext(ctx,
 				`UPDATE crlShards
 					SET leasedUntil = ?
 					WHERE issuerID = ?
@@ -1219,6 +1226,13 @@ func (ssa *SQLStorageAuthority) leaseSpecificCRLShard(ctx context.Context, req *
 			)
 			if err != nil {
 				return nil, fmt.Errorf("updating selected shard: %w", err)
+			}
+			rowsAffected, err := res.RowsAffected()
+			if err != nil {
+				return -1, fmt.Errorf("confirming update of selected shard: %w", err)
+			}
+			if rowsAffected != 1 {
+				return -1, errors.New("failed to lease shard")
 			}
 		}
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -311,7 +311,7 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 		var row struct {
 			Count int64
 		}
-		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM precertificates WHERE serial=?", serialHex)
+		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM precertificates WHERE serial=? FOR UPDATE", serialHex)
 		if err != nil {
 			return nil, err
 		}
@@ -404,7 +404,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(ctx context.Context, req *sapb.Ad
 		var row struct {
 			Count int64
 		}
-		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM certificates WHERE serial=?", serial)
+		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM certificates WHERE serial=? FOR UPDATE", serial)
 		if err != nil {
 			return nil, err
 		}
@@ -1082,7 +1082,8 @@ func (ssa *SQLStorageAuthority) leaseOldestCRLShard(ctx context.Context, req *sa
 			`SELECT id, issuerID, idx, thisUpdate, nextUpdate, leasedUntil
 				FROM crlShards
 				WHERE issuerID = ?
-				AND idx BETWEEN ? AND ?`,
+				AND idx BETWEEN ? AND ?
+				FOR UPDATE`,
 			req.IssuerNameID, req.MinShardIdx, req.MaxShardIdx,
 		)
 		if err != nil {
@@ -1184,7 +1185,8 @@ func (ssa *SQLStorageAuthority) leaseSpecificCRLShard(ctx context.Context, req *
 			  FROM crlShards
 				WHERE issuerID = ?
 				AND idx = ?
-				LIMIT 1`,
+				LIMIT 1
+				FOR UPDATE`,
 			req.IssuerNameID,
 			req.MinShardIdx,
 		)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1091,7 +1091,6 @@ func (ssa *SQLStorageAuthority) leaseOldestCRLShard(ctx context.Context, req *sa
 
 		// Determine which shard index we want to lease.
 		var shardIdx int
-		var needToInsert bool
 		if len(shards) < (int(req.MaxShardIdx + 1 - req.MinShardIdx)) {
 			// Some expected shards are missing (i.e. never-before-produced), so we
 			// pick one at random.
@@ -1107,7 +1106,17 @@ func (ssa *SQLStorageAuthority) leaseOldestCRLShard(ctx context.Context, req *sa
 				shardIdx = idx
 				break
 			}
-			needToInsert = true
+
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO crlShards (issuerID, idx, leasedUntil)
+					VALUES (?, ?, ?)`,
+				req.IssuerNameID,
+				shardIdx,
+				req.Until.AsTime(),
+			)
+			if err != nil {
+				return -1, fmt.Errorf("inserting selected shard: %w", err)
+			}
 		} else {
 			// We got all the shards we expect, so we pick the oldest unleased shard.
 			var oldest *crlShardModel
@@ -1125,30 +1134,18 @@ func (ssa *SQLStorageAuthority) leaseOldestCRLShard(ctx context.Context, req *sa
 				return -1, fmt.Errorf("issuer %d has no unleased shards in range %d-%d", req.IssuerNameID, req.MinShardIdx, req.MaxShardIdx)
 			}
 			shardIdx = oldest.Idx
-			needToInsert = false
-		}
 
-		if needToInsert {
-			_, err = tx.ExecContext(ctx,
-				`INSERT INTO crlShards (issuerID, idx, leasedUntil)
-					VALUES (?, ?, ?)`,
-				req.IssuerNameID,
-				shardIdx,
-				req.Until.AsTime(),
-			)
-			if err != nil {
-				return -1, fmt.Errorf("inserting selected shard: %w", err)
-			}
-		} else {
 			_, err = tx.ExecContext(ctx,
 				`UPDATE crlShards
 					SET leasedUntil = ?
 					WHERE issuerID = ?
 					AND idx = ?
+					AND leasedUntil = ?
 					LIMIT 1`,
 				req.Until.AsTime(),
 				req.IssuerNameID,
 				shardIdx,
+				oldest.LeasedUntil,
 			)
 			if err != nil {
 				return -1, fmt.Errorf("updating selected shard: %w", err)
@@ -1213,10 +1210,12 @@ func (ssa *SQLStorageAuthority) leaseSpecificCRLShard(ctx context.Context, req *
 					SET leasedUntil = ?
 					WHERE issuerID = ?
 					AND idx = ?
+					AND leasedUntil = ?
 					LIMIT 1`,
 				req.Until.AsTime(),
 				req.IssuerNameID,
 				req.MinShardIdx,
+				shardModel.LeasedUntil,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("updating selected shard: %w", err)

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -311,7 +311,7 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 		var row struct {
 			Count int64
 		}
-		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM precertificates WHERE serial=? FOR UPDATE", serialHex)
+		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM precertificates WHERE serial=?", serialHex)
 		if err != nil {
 			return nil, err
 		}
@@ -404,7 +404,7 @@ func (ssa *SQLStorageAuthority) AddCertificate(ctx context.Context, req *sapb.Ad
 		var row struct {
 			Count int64
 		}
-		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM certificates WHERE serial=? FOR UPDATE", serial)
+		err := tx.SelectOne(ctx, &row, "SELECT COUNT(*) as count FROM certificates WHERE serial=?", serial)
 		if err != nil {
 			return nil, err
 		}

--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -102,7 +102,7 @@ func TestCRLPipeline(t *testing.T) {
 	resp.Body.Close()
 }
 
-func TestTemporalAndExplicitShardingCoexist(t *testing.T) {
+func TestCRLTemporalAndExplicitShardingCoexist(t *testing.T) {
 	db, err := sql.Open("mysql", vars.DBConnSAIntegrationFullPerms)
 	if err != nil {
 		t.Fatalf("sql.Open: %s", err)


### PR DESCRIPTION
In a few places within the SA, we use explicit transactions to wrap read-then-update style operations. Because we set the transaction isolation level on a per-session basis, these transactions do not in fact change their isolation level, and therefore generally remain at the default isolation level of REPEATABLE READ.

Unfortunately, we cannot resolve this simply by converting the SELECT statements into SELECT...FOR UPDATE statements: although this would fix the issue by making those queries into locking statements, it also triggers what appears to be an InnoDB bug when many transactions all attempt to select-then-insert into a table with both a primary key and a separate unique key, as the crlShards table has. This causes the integration tests in GitHub Actions, which run with an empty database and therefore use the needToInsert codepath instead of the update codepath, to consistently flake.

Instead, resolve the issue by having the UPDATE statements specify that the value of the leasedUntil column is still the same as was read by the initial SELECT. Although two crl-updaters may still attempt these transactions concurrently, the UPDATE statements will still be fully sequenced, and the latter one will fail.

Part of https://github.com/letsencrypt/boulder/issues/8031