### PR TITLE
CAA: Handle non-empty RRSets correctly during wildcard checking

### DIFF
--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -286,8 +286,14 @@ func TestCAAChecking(t *testing.T) {
 			Valid:   false,
 		},
 		{
-			Name:    "Good (unknown non-critical, no issue/issuewild)",
+			Name:    "Good (unknown non-critical, no issue)",
 			Domain:  "unknown-noncritical.com",
+			FoundAt: "unknown-noncritical.com",
+			Valid:   true,
+		},
+		{
+			Name:    "Good (unknown non-critical, no issuewild)",
+			Domain:  "*.unknown-noncritical.com",
 			FoundAt: "unknown-noncritical.com",
 			Valid:   true,
 		},


### PR DESCRIPTION
When checking CAA, issuance is allowed if the relevant RRSet (as defined in RFC 8659, Section 3) does not contain any records of the right Property kind (issue or issuewild) for the kind of checking being attempted. Previously, we correctly detected that a non-wildcard issuance attempt could short-circuit our validation logic if no issue records are present. However, we did not do a similar short-circuit for wildcard issuance attempts when no issue records and no issuewild records are present.

Add a test which demonstrates that a nearly-empty RRSet accidentally forbade issuance of wildcard certs. Update our logic to perform the "no relevant records" check slightly later, so that it catches both the wildcard and non-wildcard cases, causing the new test to pass.

Fixes https://github.com/letsencrypt/boulder/issues/8032