### PR TITLE
WFE: Don't remove contacts on empty update-account request

### DIFF
--- a/test/integration/account_test.go
+++ b/test/integration/account_test.go
@@ -76,9 +76,4 @@ func TestAccountUpdate_UnspecifiedContacts(t *testing.T) {
 	if len(acct.Contact) != 1 {
 		t.Errorf("unexpected number of contacts: want 1, got %d", len(acct.Contact))
 	}
-
-	// TODO: Figure out a way to test that we don't update contacts even when the
-	// rest of the request is non-empty. We can't do this today because eggsampler
-	// makes it impossible to include the `status` field in an UpdateAccount
-	// request (it exposes DeactivateAccount for that instead).
 }

--- a/test/integration/account_test.go
+++ b/test/integration/account_test.go
@@ -48,3 +48,37 @@ func TestAccountDeactivate(t *testing.T) {
 	// account object as it used to make the request, and a wholly missing
 	// contacts field doesn't overwrite whatever eggsampler was holding in memory.
 }
+
+func TestAccountUpdate_UnspecifiedContacts(t *testing.T) {
+	t.Parallel()
+
+	c, err := acme.NewClient("http://boulder.service.consul:4001/directory")
+	if err != nil {
+		t.Fatalf("failed to connect to acme directory: %s", err)
+	}
+
+	acctKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate account key: %s", err)
+	}
+
+	acct, err := c.NewAccount(acctKey, false, true, "mailto:example@"+random_domain())
+	if err != nil {
+		t.Fatalf("failed to create initial account: %s", err)
+	}
+
+	// This request does not include the Contact field, meaning that the contacts
+	// should remain unchanged (i.e. not be removed).
+	acct, err = c.UpdateAccount(acct)
+	if err != nil {
+		t.Errorf("failed to no-op update account: %s", err)
+	}
+	if len(acct.Contact) != 1 {
+		t.Errorf("unexpected number of contacts: want 1, got %d", len(acct.Contact))
+	}
+
+	// TODO: Figure out a way to test that we don't update contacts even when the
+	// rest of the request is non-empty. We can't do this today because eggsampler
+	// makes it impossible to include the `status` field in an UpdateAccount
+	// request (it exposes DeactivateAccount for that instead).
+}

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1441,12 +1441,16 @@ func (wfe *WebFrontEndImpl) updateAccount(
 		return nil, probs.Malformed("Invalid value provided for status field")
 	}
 
-	var contacts []string
-	if accountUpdateRequest.Contact != nil {
-		contacts = *accountUpdateRequest.Contact
+	if accountUpdateRequest.Contact == nil {
+		// We use a pointer-to-slice for the contacts field so that we can tell the
+		// difference between the request not including the contact field, and the
+		// request including an empty contact list. If the field was omitted
+		// entirely, they don't want us to update it, so there's no work to do here.
+		return currAcct, nil
 	}
 
-	updatedAcct, err := wfe.ra.UpdateRegistrationContact(ctx, &rapb.UpdateRegistrationContactRequest{RegistrationID: currAcct.ID, Contacts: contacts})
+	updatedAcct, err := wfe.ra.UpdateRegistrationContact(ctx, &rapb.UpdateRegistrationContactRequest{
+		RegistrationID: currAcct.ID, Contacts: *accountUpdateRequest.Contact})
 	if err != nil {
 		return nil, web.ProblemDetailsForError(err, "Unable to update account")
 	}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -2987,7 +2987,7 @@ func TestKeyRollover(t *testing.T) {
 			Payload: `{"oldKey":` + test1KeyPublicJSON + `,"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
 		     "key": ` + string(newJWKJSON) + `,
-		     "status": ""
+		     "status": "valid"
 		   }`,
 			NewKey: newKeyPriv,
 		},


### PR DESCRIPTION
When we receive an update-account request which is not empty, but doesn't contain the "contact" field, don't assume that they want to remove their contacts. Only remove contacts if the "contact" field is present, but empty.

Add a unit test and an integration test which will catch regressions in this behavior.