### PR TITLE
Update CI to go1.23.7 and go1.24.1

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.23.6_2025-02-11
-          - go1.24.0_2025-02-11
+          - go1.23.7_2025-03-10
+          - go1.24.1_2025-03-10
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.23.6"
-          - "1.24.0"
+          - "1.23.7"
+          - "1.24.1"
     runs-on: ubuntu-20.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.23.6"
-          - "1.24.0"
+          - "1.23.7"
+          - "1.24.1"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: test/boulder-tools/
       # Should match one of the GO_CI_VERSIONS in test/boulder-tools/tag_and_upload.sh.
       args:
-        GO_VERSION: 1.23.6
+        GO_VERSION: 1.24.1
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening.

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.23.6" "1.24.0" )
+GO_CI_VERSIONS=( "1.23.7" "1.24.1" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
These versions contain security fixes to the net/http package, but not to the parts of it which we use.