### PR TITLE
ARI: Return alreadyReplaced error instead of conflict

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -52,11 +52,12 @@ const (
 	UnsupportedContact
 	// The requested serial number does not exist in the `serials` table.
 	UnknownSerial
-	// The certificate being indicated for replacement already has a replacement
-	// order.
 	Conflict
 	// Defined in https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/00/
 	InvalidProfile
+	// The certificate being indicated for replacement already has a replacement
+	// order.
+	AlreadyReplaced
 )
 
 func (ErrorType) Error() string {
@@ -283,6 +284,10 @@ func BadCSRError(msg string, args ...interface{}) error {
 	return newf(BadCSR, msg, args...)
 }
 
+func AlreadyReplacedError(msg string, args ...interface{}) error {
+	return newf(AlreadyReplaced, msg, args...)
+}
+
 func AlreadyRevokedError(msg string, args ...interface{}) error {
 	return newf(AlreadyRevoked, msg, args...)
 }
@@ -293,10 +298,6 @@ func BadRevocationReasonError(reason int64) error {
 
 func UnknownSerialError() error {
 	return newf(UnknownSerial, "unknown serial")
-}
-
-func ConflictError(msg string, args ...interface{}) error {
-	return newf(Conflict, msg, args...)
 }
 
 func InvalidProfileError(msg string, args ...interface{}) error {

--- a/probs/probs.go
+++ b/probs/probs.go
@@ -12,7 +12,11 @@ const (
 	// same order as they are defined in RFC8555 Section 6.7. We do not implement
 	// the `compound`, `externalAccountRequired`, or `userActionRequired` errors,
 	// because we have no path that would return them.
-	AccountDoesNotExistProblem   = ProblemType("accountDoesNotExist")
+	AccountDoesNotExistProblem = ProblemType("accountDoesNotExist")
+	// AlreadyReplacedProblem is a problem type that is defined in Section 7.4
+	// of draft-ietf-acme-ari-08, for more information see:
+	// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-08#section-7.4
+	AlreadyReplacedProblem       = ProblemType("alreadyReplaced")
 	AlreadyRevokedProblem        = ProblemType("alreadyRevoked")
 	BadCSRProblem                = ProblemType("badCSR")
 	BadNonceProblem              = ProblemType("badNonce")
@@ -91,6 +95,16 @@ func AccountDoesNotExist(detail string) *ProblemDetails {
 		Type:       AccountDoesNotExistProblem,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// AlreadyReplaced returns a ProblemDetails with a AlreadyReplacedProblem and a
+// 409 Conflict status code.
+func AlreadyReplaced(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       AlreadyReplacedProblem,
+		Detail:     detail,
+		HTTPStatus: http.StatusConflict,
 	}
 }
 

--- a/test/integration/ari_test.go
+++ b/test/integration/ari_test.go
@@ -59,6 +59,9 @@ func TestARIAndReplacement(t *testing.T) {
 	// Try another replacement order and verify that it fails.
 	_, order, err = makeClientAndOrder(client, key, []string{name}, true, "", cert)
 	test.AssertError(t, err, "subsequent ARI replacements for a replaced cert should fail, but didn't")
+	test.AssertContains(t, err.Error(), "urn:ietf:params:acme:error:alreadyReplaced")
+	test.AssertContains(t, err.Error(), "already has a replacement order")
+	test.AssertContains(t, err.Error(), "error code 409")
 }
 
 func TestARIShortLived(t *testing.T) {

--- a/web/probs.go
+++ b/web/probs.go
@@ -40,6 +40,8 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		outProb = probs.BadPublicKey(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.BadCSR:
 		outProb = probs.BadCSR(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.AlreadyReplaced:
+		outProb = probs.AlreadyReplaced(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.AlreadyRevoked:
 		outProb = probs.AlreadyRevoked(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.BadRevocationReason:

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2152,7 +2152,7 @@ func (wfe *WebFrontEndImpl) validateReplacementOrder(ctx context.Context, acct *
 		return "", false, fmt.Errorf("checking replacement status of existing certificate: %w", err)
 	}
 	if exists.Exists {
-		return "", false, berrors.ConflictError(
+		return "", false, berrors.AlreadyReplacedError(
 			"cannot indicate an order replaces certificate with serial %q, which already has a replacement order",
 			decodedSerial,
 		)


### PR DESCRIPTION
Return "alreadyReplaced" in addition to HTTP 409 Conflict to signal that an order indicates that it replaces a certificate which already has a replacement order.