### PR TITLE
chore: add `syntax` parser directive to Dockerfile

### DIFF
--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM buildpack-deps:focal-scm as godeps
 ARG GO_VERSION
 # Provided automatically by docker build.

--- a/test/ct-test-srv/Dockerfile
+++ b/test/ct-test-srv/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG GO_VERSION
 
 FROM golang:${GO_VERSION} AS build


### PR DESCRIPTION
## What?

Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).

## Why?

To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend.

## How?

Append `# syntax=docker/dockerfile:1` to the top of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).