### PR TITLE
database: Do not skip replacementOrders tests for config

### DIFF
--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -10,7 +10,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -419,10 +418,6 @@ func TestIncidentSerialModel(t *testing.T) {
 }
 
 func TestAddReplacementOrder(t *testing.T) {
-	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
-		t.Skip("Test requires replacementOrders database table")
-	}
-
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
@@ -468,10 +463,6 @@ func TestAddReplacementOrder(t *testing.T) {
 }
 
 func TestSetReplacementOrderFinalized(t *testing.T) {
-	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
-		t.Skip("Test requires replacementOrders database table")
-	}
-
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 


### PR DESCRIPTION
The replacementOrders table was moved from db-next to db back in #7639.