### PR TITLE
Improve how cert-checker runs lints

### DIFF
--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -12,6 +12,7 @@
 		"acceptableValidityDurations": [
 			"7776000s"
 		],
+		"lintConfig": "test/config-next/zlint.toml",
 		"ignoredLints": [
 			"w_subject_common_name_included",
 			"w_ext_subject_key_identifier_missing_sub_cert",


### PR DESCRIPTION
Give cert-checker the ability to load zlint configs, so that it can be configured to talk to PKIMetal in CI and hopefully in staging/production in the future.

Also update how cert-checker executes lints, so that it uses a real lint registry instead of using the global registry and passing around a dictionary of lints to filter out of the results.

IN-11113 discusses making the corresponding staging/production changes.

Fixes https://github.com/letsencrypt/boulder/issues/7786