### PR TITLE
policy: Add initial Identifier support

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/goodkey/sagoodkey"
+	"github.com/letsencrypt/boulder/identifier"
 	_ "github.com/letsencrypt/boulder/linter"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/policy"
@@ -406,7 +407,7 @@ func (c *certChecker) checkCert(ctx context.Context, cert core.Certificate, igno
 		// We do not check the CommonName here, as (if it exists) we already checked
 		// that it is identical to one of the DNSNames in the SAN.
 		for _, name := range parsedCert.DNSNames {
-			err = c.pa.WillingToIssue([]string{name})
+			err = c.pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(name)})
 			if err != nil {
 				problems = append(problems, fmt.Sprintf("Policy Authority isn't willing to issue for '%s': %s", name, err))
 			} else {

--- a/cmd/reversed-hostname-checker/main.go
+++ b/cmd/reversed-hostname-checker/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/letsencrypt/boulder/cmd"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/policy"
 	"github.com/letsencrypt/boulder/sa"
 )
@@ -50,7 +51,7 @@ func main() {
 	var errors bool
 	for scanner.Scan() {
 		n := sa.ReverseName(scanner.Text())
-		err := pa.WillingToIssue([]string{n})
+		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(n)})
 		if err != nil {
 			errors = true
 			fmt.Printf("%s: %s\n", n, err)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -7,7 +7,7 @@ import (
 // PolicyAuthority defines the public interface for the Boulder PA
 // TODO(#5891): Move this interface to a more appropriate location.
 type PolicyAuthority interface {
-	WillingToIssue([]string) error
+	WillingToIssue([]identifier.ACMEIdentifier) error
 	ChallengeTypesFor(identifier.ACMEIdentifier) ([]AcmeChallenge, error)
 	ChallengeTypeEnabled(AcmeChallenge) bool
 	CheckAuthzChallenges(*Authorization) error

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -26,9 +26,9 @@ func (pa *mockPA) ChallengeTypesFor(identifier identifier.ACMEIdentifier) ([]cor
 	return []core.AcmeChallenge{}, nil
 }
 
-func (pa *mockPA) WillingToIssue(domains []string) error {
-	for _, domain := range domains {
-		if domain == "bad-name.com" || domain == "other-bad-name.com" {
+func (pa *mockPA) WillingToIssue(idents []identifier.ACMEIdentifier) error {
+	for _, ident := range idents {
+		if ident.Value == "bad-name.com" || ident.Value == "other-bad-name.com" {
 			return errors.New("policy forbids issuing for identifier")
 		}
 	}
@@ -103,7 +103,7 @@ func TestVerifyCSR(t *testing.T) {
 			signedReq,
 			100,
 			&mockPA{},
-			invalidNoDNS,
+			invalidNoIdentifier,
 		},
 		{
 			signedReqWithLongCN,

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -64,6 +64,16 @@ func NewDNS(domain string) ACMEIdentifier {
 	}
 }
 
+// FromDNSNames is a convenience function for creating a slice of ACMEIdentifier
+// with Type "dns" for a given slice of domain names.
+func FromDNSNames(input []string) []ACMEIdentifier {
+	var out []ACMEIdentifier
+	for _, in := range input {
+		out = append(out, NewDNS(in))
+	}
+	return out
+}
+
 // NewIP is a convenience function for creating an ACMEIdentifier with Type "ip"
 // for a given IP address.
 func NewIP(ip netip.Addr) ACMEIdentifier {

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -30,7 +30,7 @@ func paImpl(t *testing.T) *AuthorityImpl {
 	return pa
 }
 
-func TestWellFormedDomainNames(t *testing.T) {
+func TestWellFormedIdentifiers(t *testing.T) {
 	testCases := []struct {
 		domain string
 		err    error
@@ -110,7 +110,7 @@ func TestWellFormedDomainNames(t *testing.T) {
 
 	// Test syntax errors
 	for _, tc := range testCases {
-		err := WellFormedDomainNames([]string{tc.domain})
+		err := WellFormedIdentifiers([]identifier.ACMEIdentifier{identifier.NewDNS(tc.domain)})
 		if tc.err == nil {
 			test.AssertNil(t, err, fmt.Sprintf("Unexpected error for domain %q, got %s", tc.domain, err))
 		} else {
@@ -120,6 +120,12 @@ func TestWellFormedDomainNames(t *testing.T) {
 			test.AssertContains(t, berr.Error(), tc.err.Error())
 		}
 	}
+
+	err := WellFormedIdentifiers([]identifier.ACMEIdentifier{identifier.NewIP(netip.MustParseAddr("9.9.9.9"))})
+	test.AssertError(t, err, "Expected error for IP, but got none")
+	var berr *berrors.BoulderError
+	test.AssertErrorWraps(t, err, &berr)
+	test.AssertContains(t, berr.Error(), errUnsupportedIdentifier.Error())
 }
 
 func TestWillingToIssue(t *testing.T) {
@@ -177,19 +183,22 @@ func TestWillingToIssue(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't load rules")
 
 	// Invalid encoding
-	err = pa.WillingToIssue([]string{"www.xn--m.com"})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("www.xn--m.com")})
 	test.AssertError(t, err, "WillingToIssue didn't fail on a malformed IDN")
+	// Invalid identifier type
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewIP(netip.MustParseAddr("1.1.1.1"))})
+	test.AssertError(t, err, "WillingToIssue didn't fail on an IP address")
 	// Valid encoding
-	err = pa.WillingToIssue([]string{"www.xn--mnich-kva.com"})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("www.xn--mnich-kva.com")})
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed IDN")
 	// IDN TLD
-	err = pa.WillingToIssue([]string{"xn--example--3bhk5a.xn--p1ai"})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("xn--example--3bhk5a.xn--p1ai")})
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed domain with IDN TLD")
 	features.Reset()
 
 	// Test expected blocked domains
 	for _, domain := range shouldBeBlocked {
-		err := pa.WillingToIssue([]string{domain})
+		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(domain)})
 		test.AssertError(t, err, "domain was not correctly forbidden")
 		var berr *berrors.BoulderError
 		test.AssertErrorWraps(t, err, &berr)
@@ -198,7 +207,7 @@ func TestWillingToIssue(t *testing.T) {
 
 	// Test acceptance of good names
 	for _, domain := range shouldBeAccepted {
-		err := pa.WillingToIssue([]string{domain})
+		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(domain)})
 		test.AssertNotError(t, err, "domain was incorrectly forbidden")
 	}
 }
@@ -284,7 +293,7 @@ func TestWillingToIssue_Wildcards(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			err := pa.WillingToIssue([]string{tc.Domain})
+			err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(tc.Domain)})
 			if tc.ExpectedErr == nil {
 				test.AssertNil(t, err, fmt.Sprintf("Unexpected error for domain %q, got %s", tc.Domain, err))
 			} else {
@@ -319,12 +328,12 @@ func TestWillingToIssue_SubErrors(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't load policy contents from file")
 
 	// Test multiple malformed domains and one banned domain; only the malformed ones will generate errors
-	err = pa.WillingToIssue([]string{
-		"perfectly-fine.com",      // fine
-		"letsdecrypt_org",         // malformed
-		"example.comm",            // malformed
-		"letsdecrypt.org",         // banned
-		"also-perfectly-fine.com", // fine
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{
+		identifier.NewDNS("perfectly-fine.com"),      // fine
+		identifier.NewDNS("letsdecrypt_org"),         // malformed
+		identifier.NewDNS("example.comm"),            // malformed
+		identifier.NewDNS("letsdecrypt.org"),         // banned
+		identifier.NewDNS("also-perfectly-fine.com"), // fine
 	})
 	test.AssertDeepEquals(t, err,
 		&berrors.BoulderError{
@@ -349,11 +358,11 @@ func TestWillingToIssue_SubErrors(t *testing.T) {
 		})
 
 	// Test multiple banned domains.
-	err = pa.WillingToIssue([]string{
-		"perfectly-fine.com",      // fine
-		"letsdecrypt.org",         // banned
-		"example.com",             // banned
-		"also-perfectly-fine.com", // fine
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{
+		identifier.NewDNS("perfectly-fine.com"),      // fine
+		identifier.NewDNS("letsdecrypt.org"),         // banned
+		identifier.NewDNS("example.com"),             // banned
+		identifier.NewDNS("also-perfectly-fine.com"), // fine
 	})
 	test.AssertError(t, err, "Expected err from WillingToIssueWildcards")
 
@@ -380,7 +389,7 @@ func TestWillingToIssue_SubErrors(t *testing.T) {
 		})
 
 	// Test willing to issue with only *one* bad identifier.
-	err = pa.WillingToIssue([]string{"letsdecrypt.org"})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("letsdecrypt.org")})
 	test.AssertDeepEquals(t, err,
 		&berrors.BoulderError{
 			Type:   berrors.RejectedIdentifier,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2287,7 +2287,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	}
 
 	// Validate that our policy allows issuing for each of the names in the order
-	err = ra.PA.WillingToIssue(newOrder.DnsNames)
+	err = ra.PA.WillingToIssue(identifier.FromDNSNames(newOrder.DnsNames))
 	if err != nil {
 		return nil, err
 	}

--- a/ratelimits/names.go
+++ b/ratelimits/names.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/policy"
 )
 
@@ -199,7 +200,7 @@ func validateFQDNSet(id string) error {
 		return fmt.Errorf(
 			"invalid fqdnSet, %q must be formatted 'fqdnSet'", id)
 	}
-	return policy.WellFormedDomainNames(domains)
+	return policy.WellFormedIdentifiers(identifier.FromDNSNames(domains))
 }
 
 func validateIdForName(name Name, id string) error {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2287,7 +2287,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	}
 
 	names = core.UniqueLowerNames(names)
-	err = policy.WellFormedDomainNames(names)
+	err = policy.WellFormedIdentifiers(identifier.FromDNSNames(names))
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
 		return


### PR DESCRIPTION
Change WillingToIssue and WellFormedDomainNames to use Identifiers, and (for now) reject non-DNS identifiers.