### PR TITLE
identifier: Add identifiers package; rename NewDNS & NewIP

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -412,7 +412,7 @@ func (c *certChecker) checkCert(ctx context.Context, cert core.Certificate) ([]s
 		//
 		// TODO(#7311): We'll need to iterate over IP address identifiers too.
 		for _, name := range parsedCert.DNSNames {
-			err = c.pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(name)})
+			err = c.pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS(name)})
 			if err != nil {
 				problems = append(problems, fmt.Sprintf("Policy Authority isn't willing to issue for '%s': %s", name, err))
 			} else {

--- a/cmd/reversed-hostname-checker/main.go
+++ b/cmd/reversed-hostname-checker/main.go
@@ -51,7 +51,7 @@ func main() {
 	var errors bool
 	for scanner.Scan() {
 		n := sa.ReverseName(scanner.Text())
-		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(n)})
+		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS(n)})
 		if err != nil {
 			errors = true
 			fmt.Printf("%s: %s\n", n, err)

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -10,7 +10,7 @@ import (
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/goodkey"
-	"github.com/letsencrypt/boulder/identifier"
+	"github.com/letsencrypt/boulder/identifiers"
 )
 
 // maxCNLength is the maximum length allowed for the common name as specified in RFC 5280
@@ -82,7 +82,7 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 		return berrors.BadCSRError("CSR contains more than %d DNS names", maxNames)
 	}
 
-	err = pa.WillingToIssue(identifier.FromDNSNames(names.SANs))
+	err = pa.WillingToIssue(identifiers.FromDNS(names.SANs))
 	if err != nil {
 		return err
 	}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -17,14 +17,14 @@ func TestWithSubErrors(t *testing.T) {
 
 	subErrs := []SubBoulderError{
 		{
-			Identifier: identifier.NewDNS("example.com"),
+			Identifier: identifier.FromDNS("example.com"),
 			BoulderError: &BoulderError{
 				Type:   RateLimit,
 				Detail: "everyone uses this example domain",
 			},
 		},
 		{
-			Identifier: identifier.NewDNS("what about example.com"),
+			Identifier: identifier.FromDNS("what about example.com"),
 			BoulderError: &BoulderError{
 				Type:   RateLimit,
 				Detail: "try a real identifier value next time",
@@ -39,7 +39,7 @@ func TestWithSubErrors(t *testing.T) {
 	test.AssertDeepEquals(t, outResult.SubErrors, subErrs)
 	// Adding another suberr shouldn't squash the original sub errors
 	anotherSubErr := SubBoulderError{
-		Identifier: identifier.NewDNS("another ident"),
+		Identifier: identifier.FromDNS("another ident"),
 		BoulderError: &BoulderError{
 			Type:   RateLimit,
 			Detail: "another rate limit err",

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -97,7 +97,7 @@ func TestSubErrorWrapping(t *testing.T) {
 
 	subErrors := []berrors.SubBoulderError{
 		{
-			Identifier: identifier.NewDNS("chillserver.com"),
+			Identifier: identifier.FromDNS("chillserver.com"),
 			BoulderError: &berrors.BoulderError{
 				Type:   berrors.RejectedIdentifier,
 				Detail: "2 ill 2 chill",

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -315,7 +315,7 @@ func PBToAuthz(pb *corepb.Authorization) (core.Authorization, error) {
 	}
 	authz := core.Authorization{
 		ID:                     pb.Id,
-		Identifier:             identifier.NewDNS(pb.DnsName),
+		Identifier:             identifier.FromDNS(pb.DnsName),
 		RegistrationID:         pb.RegistrationID,
 		Status:                 core.AcmeStatus(pb.Status),
 		Expires:                expires,

--- a/grpc/pb-marshalling_test.go
+++ b/grpc/pb-marshalling_test.go
@@ -227,7 +227,7 @@ func TestRegistration(t *testing.T) {
 
 func TestAuthz(t *testing.T) {
 	exp := time.Now().AddDate(0, 0, 1).UTC()
-	ident := identifier.NewDNS("example.com")
+	ident := identifier.FromDNS("example.com")
 	challA := core.Challenge{
 		Type:   core.ChallengeTypeDNS01,
 		Status: core.StatusPending,

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -1,6 +1,6 @@
-// The identifier package defines types for RFC 8555 ACME identifiers.
-// It exists as a separate package to prevent an import loop between the core
-// and probs packages.
+// The identifier package defines types and functions for handling singular RFC
+// 8555 ACME identifiers. It exists as a separate package to prevent an import
+// loop between the core and probs packages.
 package identifier
 
 import (
@@ -50,33 +50,23 @@ func FromProto(ident *corepb.Identifier) ACMEIdentifier {
 // RPCs. TODO(#8023)
 func FromProtoWithDefault(ident *corepb.Identifier, name string) ACMEIdentifier {
 	if ident == nil {
-		return NewDNS(name)
+		return FromDNS(name)
 	}
 	return FromProto(ident)
 }
 
-// NewDNS is a convenience function for creating an ACMEIdentifier with Type
+// FromDNS is a convenience function for creating an ACMEIdentifier with Type
 // "dns" for a given domain name.
-func NewDNS(domain string) ACMEIdentifier {
+func FromDNS(domain string) ACMEIdentifier {
 	return ACMEIdentifier{
 		Type:  TypeDNS,
 		Value: domain,
 	}
 }
 
-// FromDNSNames is a convenience function for creating a slice of ACMEIdentifier
-// with Type "dns" for a given slice of domain names.
-func FromDNSNames(input []string) []ACMEIdentifier {
-	var out []ACMEIdentifier
-	for _, in := range input {
-		out = append(out, NewDNS(in))
-	}
-	return out
-}
-
-// NewIP is a convenience function for creating an ACMEIdentifier with Type "ip"
+// FromIP is a convenience function for creating an ACMEIdentifier with Type "ip"
 // for a given IP address.
-func NewIP(ip netip.Addr) ACMEIdentifier {
+func FromIP(ip netip.Addr) ACMEIdentifier {
 	return ACMEIdentifier{
 		Type: TypeIP,
 		// RFC 8738, Sec. 3: The identifier value MUST contain the textual form

--- a/identifiers/identifiers.go
+++ b/identifiers/identifiers.go
@@ -1,0 +1,25 @@
+// The identifier package defines types and functions for handling plural RFC
+// 8555 ACME identifiers. It exists as a separate package to prevent an import
+// loop between the core and probs packages, and to improve code readability so
+// that it's clear when you're calling a function to handle/return a slice of
+// identifiers, as opposed to a single identifier.
+package identifiers
+
+import (
+	//	corepb "github.com/letsencrypt/boulder/core/proto"
+	"github.com/letsencrypt/boulder/identifier"
+)
+
+// ACMEIdentifiers is a named type for a slice of ACME identifiers, so that
+// methods can be applied to these slices.
+type ACMEIdentifiers []identifier.ACMEIdentifier
+
+// FromDNS is a convenience function for creating a slice of ACMEIdentifier with
+// Type "dns" for a given slice of domain names.
+func FromDNS(input []string) ACMEIdentifiers {
+	var out ACMEIdentifiers
+	for _, in := range input {
+		out = append(out, identifier.FromDNS(in))
+	}
+	return out
+}

--- a/mocks/sa.go
+++ b/mocks/sa.go
@@ -450,7 +450,7 @@ func (sa *StorageAuthorityReadOnly) GetValidAuthorizations2(ctx context.Context,
 			Status:         core.StatusValid,
 			RegistrationID: req.RegistrationID,
 			Expires:        &exp,
-			Identifier:     identifier.NewDNS(name),
+			Identifier:     identifier.FromDNS(name),
 			Challenges: []core.Challenge{
 				{
 					Status:    core.StatusValid,

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -110,7 +110,7 @@ func TestWellFormedIdentifiers(t *testing.T) {
 
 	// Test syntax errors
 	for _, tc := range testCases {
-		err := WellFormedIdentifiers([]identifier.ACMEIdentifier{identifier.NewDNS(tc.domain)})
+		err := WellFormedIdentifiers([]identifier.ACMEIdentifier{identifier.FromDNS(tc.domain)})
 		if tc.err == nil {
 			test.AssertNil(t, err, fmt.Sprintf("Unexpected error for domain %q, got %s", tc.domain, err))
 		} else {
@@ -121,7 +121,7 @@ func TestWellFormedIdentifiers(t *testing.T) {
 		}
 	}
 
-	err := WellFormedIdentifiers([]identifier.ACMEIdentifier{identifier.NewIP(netip.MustParseAddr("9.9.9.9"))})
+	err := WellFormedIdentifiers([]identifier.ACMEIdentifier{identifier.FromIP(netip.MustParseAddr("9.9.9.9"))})
 	test.AssertError(t, err, "Expected error for IP, but got none")
 	var berr *berrors.BoulderError
 	test.AssertErrorWraps(t, err, &berr)
@@ -183,22 +183,22 @@ func TestWillingToIssue(t *testing.T) {
 	test.AssertNotError(t, err, "Couldn't load rules")
 
 	// Invalid encoding
-	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("www.xn--m.com")})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS("www.xn--m.com")})
 	test.AssertError(t, err, "WillingToIssue didn't fail on a malformed IDN")
 	// Invalid identifier type
-	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewIP(netip.MustParseAddr("1.1.1.1"))})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromIP(netip.MustParseAddr("1.1.1.1"))})
 	test.AssertError(t, err, "WillingToIssue didn't fail on an IP address")
 	// Valid encoding
-	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("www.xn--mnich-kva.com")})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS("www.xn--mnich-kva.com")})
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed IDN")
 	// IDN TLD
-	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("xn--example--3bhk5a.xn--p1ai")})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS("xn--example--3bhk5a.xn--p1ai")})
 	test.AssertNotError(t, err, "WillingToIssue failed on a properly formed domain with IDN TLD")
 	features.Reset()
 
 	// Test expected blocked domains
 	for _, domain := range shouldBeBlocked {
-		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(domain)})
+		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS(domain)})
 		test.AssertError(t, err, "domain was not correctly forbidden")
 		var berr *berrors.BoulderError
 		test.AssertErrorWraps(t, err, &berr)
@@ -207,7 +207,7 @@ func TestWillingToIssue(t *testing.T) {
 
 	// Test acceptance of good names
 	for _, domain := range shouldBeAccepted {
-		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(domain)})
+		err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS(domain)})
 		test.AssertNotError(t, err, "domain was incorrectly forbidden")
 	}
 }
@@ -293,7 +293,7 @@ func TestWillingToIssue_Wildcards(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS(tc.Domain)})
+			err := pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS(tc.Domain)})
 			if tc.ExpectedErr == nil {
 				test.AssertNil(t, err, fmt.Sprintf("Unexpected error for domain %q, got %s", tc.Domain, err))
 			} else {
@@ -329,11 +329,11 @@ func TestWillingToIssue_SubErrors(t *testing.T) {
 
 	// Test multiple malformed domains and one banned domain; only the malformed ones will generate errors
 	err = pa.WillingToIssue([]identifier.ACMEIdentifier{
-		identifier.NewDNS("perfectly-fine.com"),      // fine
-		identifier.NewDNS("letsdecrypt_org"),         // malformed
-		identifier.NewDNS("example.comm"),            // malformed
-		identifier.NewDNS("letsdecrypt.org"),         // banned
-		identifier.NewDNS("also-perfectly-fine.com"), // fine
+		identifier.FromDNS("perfectly-fine.com"),      // fine
+		identifier.FromDNS("letsdecrypt_org"),         // malformed
+		identifier.FromDNS("example.comm"),            // malformed
+		identifier.FromDNS("letsdecrypt.org"),         // banned
+		identifier.FromDNS("also-perfectly-fine.com"), // fine
 	})
 	test.AssertDeepEquals(t, err,
 		&berrors.BoulderError{
@@ -345,24 +345,24 @@ func TestWillingToIssue_SubErrors(t *testing.T) {
 						Type:   berrors.Malformed,
 						Detail: "Domain name contains an invalid character",
 					},
-					Identifier: identifier.NewDNS("letsdecrypt_org"),
+					Identifier: identifier.FromDNS("letsdecrypt_org"),
 				},
 				{
 					BoulderError: &berrors.BoulderError{
 						Type:   berrors.Malformed,
 						Detail: "Domain name does not end with a valid public suffix (TLD)",
 					},
-					Identifier: identifier.NewDNS("example.comm"),
+					Identifier: identifier.FromDNS("example.comm"),
 				},
 			},
 		})
 
 	// Test multiple banned domains.
 	err = pa.WillingToIssue([]identifier.ACMEIdentifier{
-		identifier.NewDNS("perfectly-fine.com"),      // fine
-		identifier.NewDNS("letsdecrypt.org"),         // banned
-		identifier.NewDNS("example.com"),             // banned
-		identifier.NewDNS("also-perfectly-fine.com"), // fine
+		identifier.FromDNS("perfectly-fine.com"),      // fine
+		identifier.FromDNS("letsdecrypt.org"),         // banned
+		identifier.FromDNS("example.com"),             // banned
+		identifier.FromDNS("also-perfectly-fine.com"), // fine
 	})
 	test.AssertError(t, err, "Expected err from WillingToIssueWildcards")
 
@@ -376,20 +376,20 @@ func TestWillingToIssue_SubErrors(t *testing.T) {
 						Type:   berrors.RejectedIdentifier,
 						Detail: "The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy",
 					},
-					Identifier: identifier.NewDNS("letsdecrypt.org"),
+					Identifier: identifier.FromDNS("letsdecrypt.org"),
 				},
 				{
 					BoulderError: &berrors.BoulderError{
 						Type:   berrors.RejectedIdentifier,
 						Detail: "The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy",
 					},
-					Identifier: identifier.NewDNS("example.com"),
+					Identifier: identifier.FromDNS("example.com"),
 				},
 			},
 		})
 
 	// Test willing to issue with only *one* bad identifier.
-	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.NewDNS("letsdecrypt.org")})
+	err = pa.WillingToIssue([]identifier.ACMEIdentifier{identifier.FromDNS("letsdecrypt.org")})
 	test.AssertDeepEquals(t, err,
 		&berrors.BoulderError{
 			Type:   berrors.RejectedIdentifier,
@@ -409,21 +409,21 @@ func TestChallengeTypesFor(t *testing.T) {
 	}{
 		{
 			name:  "dns",
-			ident: identifier.NewDNS("example.com"),
+			ident: identifier.FromDNS("example.com"),
 			wantChalls: []core.AcmeChallenge{
 				core.ChallengeTypeHTTP01, core.ChallengeTypeDNS01, core.ChallengeTypeTLSALPN01,
 			},
 		},
 		{
 			name:  "wildcard",
-			ident: identifier.NewDNS("*.example.com"),
+			ident: identifier.FromDNS("*.example.com"),
 			wantChalls: []core.AcmeChallenge{
 				core.ChallengeTypeDNS01,
 			},
 		},
 		{
 			name:    "other",
-			ident:   identifier.NewIP(netip.MustParseAddr("1.2.3.4")),
+			ident:   identifier.FromIP(netip.MustParseAddr("1.2.3.4")),
 			wantErr: "unrecognized identifier type",
 		},
 	}
@@ -514,7 +514,7 @@ func TestCheckAuthzChallenges(t *testing.T) {
 		{
 			name: "no challenges",
 			authz: core.Authorization{
-				Identifier: identifier.NewDNS("example.com"),
+				Identifier: identifier.FromDNS("example.com"),
 				Challenges: []core.Challenge{},
 			},
 			wantErr: "has no challenges",
@@ -522,7 +522,7 @@ func TestCheckAuthzChallenges(t *testing.T) {
 		{
 			name: "no valid challenges",
 			authz: core.Authorization{
-				Identifier: identifier.NewDNS("example.com"),
+				Identifier: identifier.FromDNS("example.com"),
 				Challenges: []core.Challenge{{Type: core.ChallengeTypeDNS01, Status: core.StatusPending}},
 			},
 			wantErr: "not solved by any challenge",
@@ -530,7 +530,7 @@ func TestCheckAuthzChallenges(t *testing.T) {
 		{
 			name: "solved by disabled challenge",
 			authz: core.Authorization{
-				Identifier: identifier.NewDNS("example.com"),
+				Identifier: identifier.FromDNS("example.com"),
 				Challenges: []core.Challenge{{Type: core.ChallengeTypeDNS01, Status: core.StatusValid}},
 			},
 			enabled: map[core.AcmeChallenge]bool{core.ChallengeTypeHTTP01: true},
@@ -539,7 +539,7 @@ func TestCheckAuthzChallenges(t *testing.T) {
 		{
 			name: "solved by wrong kind of challenge",
 			authz: core.Authorization{
-				Identifier: identifier.NewDNS("*.example.com"),
+				Identifier: identifier.FromDNS("*.example.com"),
 				Challenges: []core.Challenge{{Type: core.ChallengeTypeHTTP01, Status: core.StatusValid}},
 			},
 			wantErr: "inapplicable challenge type",
@@ -547,7 +547,7 @@ func TestCheckAuthzChallenges(t *testing.T) {
 		{
 			name: "valid authz",
 			authz: core.Authorization{
-				Identifier: identifier.NewDNS("example.com"),
+				Identifier: identifier.FromDNS("example.com"),
 				Challenges: []core.Challenge{{Type: core.ChallengeTypeTLSALPN01, Status: core.StatusValid}},
 			},
 		},

--- a/probs/probs_test.go
+++ b/probs/probs_test.go
@@ -67,7 +67,7 @@ func TestWithSubProblems(t *testing.T) {
 	}
 	subProbs := []SubProblemDetails{
 		{
-			Identifier: identifier.NewDNS("example.com"),
+			Identifier: identifier.FromDNS("example.com"),
 			ProblemDetails: ProblemDetails{
 				Type:       RateLimitedProblem,
 				Detail:     "don't you think you have enough certificates already?",
@@ -75,7 +75,7 @@ func TestWithSubProblems(t *testing.T) {
 			},
 		},
 		{
-			Identifier: identifier.NewDNS("what about example.com"),
+			Identifier: identifier.FromDNS("what about example.com"),
 			ProblemDetails: ProblemDetails{
 				Type:       MalformedProblem,
 				Detail:     "try a real identifier value next time",
@@ -92,7 +92,7 @@ func TestWithSubProblems(t *testing.T) {
 	test.AssertDeepEquals(t, outResult.SubProblems, subProbs)
 	// Adding another sub problem shouldn't squash the original sub problems
 	anotherSubProb := SubProblemDetails{
-		Identifier: identifier.NewDNS("another ident"),
+		Identifier: identifier.FromDNS("another ident"),
 		ProblemDetails: ProblemDetails{
 			Type:       RateLimitedProblem,
 			Detail:     "yet another rate limit err",

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -547,7 +547,7 @@ func TestPerformValidationAlreadyValid(t *testing.T) {
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
 	authz := core.Authorization{
 		ID:             "1337",
-		Identifier:     identifier.NewDNS("not-example.com"),
+		Identifier:     identifier.FromDNS("not-example.com"),
 		RegistrationID: 1,
 		Status:         "valid",
 		Expires:        &exp,
@@ -1065,8 +1065,8 @@ func TestRecheckCAADates(t *testing.T) {
 	olderExpires := fc.Now().Add(5 * time.Hour)
 
 	authzs := map[identifier.ACMEIdentifier]*core.Authorization{
-		identifier.NewDNS("recent.com"): {
-			Identifier: identifier.NewDNS("recent.com"),
+		identifier.FromDNS("recent.com"): {
+			Identifier: identifier.FromDNS("recent.com"),
 			Expires:    &recentExpires,
 			Challenges: []core.Challenge{
 				{
@@ -1077,8 +1077,8 @@ func TestRecheckCAADates(t *testing.T) {
 				},
 			},
 		},
-		identifier.NewDNS("older.com"): {
-			Identifier: identifier.NewDNS("older.com"),
+		identifier.FromDNS("older.com"): {
+			Identifier: identifier.FromDNS("older.com"),
 			Expires:    &olderExpires,
 			Challenges: []core.Challenge{
 				{
@@ -1089,8 +1089,8 @@ func TestRecheckCAADates(t *testing.T) {
 				},
 			},
 		},
-		identifier.NewDNS("older2.com"): {
-			Identifier: identifier.NewDNS("older2.com"),
+		identifier.FromDNS("older2.com"): {
+			Identifier: identifier.FromDNS("older2.com"),
 			Expires:    &olderExpires,
 			Challenges: []core.Challenge{
 				{
@@ -1101,8 +1101,8 @@ func TestRecheckCAADates(t *testing.T) {
 				},
 			},
 		},
-		identifier.NewDNS("wildcard.com"): {
-			Identifier: identifier.NewDNS("wildcard.com"),
+		identifier.FromDNS("wildcard.com"): {
+			Identifier: identifier.FromDNS("wildcard.com"),
 			Expires:    &olderExpires,
 			Challenges: []core.Challenge{
 				{
@@ -1113,8 +1113,8 @@ func TestRecheckCAADates(t *testing.T) {
 				},
 			},
 		},
-		identifier.NewDNS("*.wildcard.com"): {
-			Identifier: identifier.NewDNS("*.wildcard.com"),
+		identifier.FromDNS("*.wildcard.com"): {
+			Identifier: identifier.FromDNS("*.wildcard.com"),
 			Expires:    &olderExpires,
 			Challenges: []core.Challenge{
 				{
@@ -1127,9 +1127,9 @@ func TestRecheckCAADates(t *testing.T) {
 		},
 	}
 	twoChallenges := map[identifier.ACMEIdentifier]*core.Authorization{
-		identifier.NewDNS("twochallenges.com"): {
+		identifier.FromDNS("twochallenges.com"): {
 			ID:         "twochal",
-			Identifier: identifier.NewDNS("twochallenges.com"),
+			Identifier: identifier.FromDNS("twochallenges.com"),
 			Expires:    &recentExpires,
 			Challenges: []core.Challenge{
 				{
@@ -1148,17 +1148,17 @@ func TestRecheckCAADates(t *testing.T) {
 		},
 	}
 	noChallenges := map[identifier.ACMEIdentifier]*core.Authorization{
-		identifier.NewDNS("nochallenges.com"): {
+		identifier.FromDNS("nochallenges.com"): {
 			ID:         "nochal",
-			Identifier: identifier.NewDNS("nochallenges.com"),
+			Identifier: identifier.FromDNS("nochallenges.com"),
 			Expires:    &recentExpires,
 			Challenges: []core.Challenge{},
 		},
 	}
 	noValidationTime := map[identifier.ACMEIdentifier]*core.Authorization{
-		identifier.NewDNS("novalidationtime.com"): {
+		identifier.FromDNS("novalidationtime.com"): {
 			ID:         "noval",
-			Identifier: identifier.NewDNS("novalidationtime.com"),
+			Identifier: identifier.FromDNS("novalidationtime.com"),
 			Expires:    &recentExpires,
 			Challenges: []core.Challenge{
 				{
@@ -1272,7 +1272,7 @@ func TestRecheckCAAEmpty(t *testing.T) {
 
 func makeHTTP01Authorization(domain string) *core.Authorization {
 	return &core.Authorization{
-		Identifier: identifier.NewDNS(domain),
+		Identifier: identifier.FromDNS(domain),
 		Challenges: []core.Challenge{{Status: core.StatusValid, Type: core.ChallengeTypeHTTP01}},
 	}
 }
@@ -1907,7 +1907,7 @@ func TestNewOrderAuthzReuseSafety(t *testing.T) {
 			{
 				// A static fake ID we can check for in a unit test
 				ID:             "1",
-				Identifier:     identifier.NewDNS("*.zombo.com"),
+				Identifier:     identifier.FromDNS("*.zombo.com"),
 				RegistrationID: Registration.Id,
 				// Authz is valid
 				Status:  "valid",
@@ -1930,7 +1930,7 @@ func TestNewOrderAuthzReuseSafety(t *testing.T) {
 			{
 				// A static fake ID we can check for in a unit test
 				ID:             "2",
-				Identifier:     identifier.NewDNS("zombo.com"),
+				Identifier:     identifier.FromDNS("zombo.com"),
 				RegistrationID: Registration.Id,
 				// Authz is valid
 				Status:  "valid",
@@ -2153,7 +2153,7 @@ func TestNewOrderExpiry(t *testing.T) {
 			{
 				// A static fake ID we can check for in a unit test
 				ID:             "1",
-				Identifier:     identifier.NewDNS("zombo.com"),
+				Identifier:     identifier.FromDNS("zombo.com"),
 				RegistrationID: Registration.Id,
 				Expires:        &fakeAuthzExpires,
 				Status:         "valid",
@@ -3074,7 +3074,7 @@ func TestPerformValidationBadChallengeType(t *testing.T) {
 	exp := fc.Now().Add(10 * time.Hour)
 	authz := core.Authorization{
 		ID:             "1337",
-		Identifier:     identifier.NewDNS("not-example.com"),
+		Identifier:     identifier.FromDNS("not-example.com"),
 		RegistrationID: 1,
 		Status:         "valid",
 		Challenges: []core.Challenge{
@@ -3929,7 +3929,7 @@ func TestGetAuthorization(t *testing.T) {
 		authzs: []*core.Authorization{
 			{
 				ID:         "1",
-				Identifier: identifier.NewDNS("example.com"),
+				Identifier: identifier.FromDNS("example.com"),
 				Status:     "valid",
 				Challenges: []core.Challenge{
 					{

--- a/ratelimits/names.go
+++ b/ratelimits/names.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/letsencrypt/boulder/identifier"
+	"github.com/letsencrypt/boulder/identifiers"
 	"github.com/letsencrypt/boulder/policy"
 )
 
@@ -200,7 +200,7 @@ func validateFQDNSet(id string) error {
 		return fmt.Errorf(
 			"invalid fqdnSet, %q must be formatted 'fqdnSet'", id)
 	}
-	return policy.WellFormedIdentifiers(identifier.FromDNSNames(domains))
+	return policy.WellFormedIdentifiers(identifiers.FromDNS(domains))
 }
 
 func validateIdForName(name Name, id string) error {

--- a/test/load-generator/boulder-calls.go
+++ b/test/load-generator/boulder-calls.go
@@ -166,7 +166,7 @@ func newOrder(s *State, c *acmeCache) error {
 	// don't care. The ACME server will collapse those down for us, how handy!
 	dnsNames := []identifier.ACMEIdentifier{}
 	for range orderSize {
-		dnsNames = append(dnsNames, identifier.NewDNS(randDomain(s.domainBase)))
+		dnsNames = append(dnsNames, identifier.FromDNS(randDomain(s.domainBase)))
 	}
 
 	// create the new order request object

--- a/va/caa.go
+++ b/va/caa.go
@@ -41,7 +41,7 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 	logEvent := validationLogEvent{
 		AuthzID:    req.AuthzID,
 		Requester:  req.AccountURIID,
-		Identifier: identifier.NewDNS(req.Domain),
+		Identifier: identifier.FromDNS(req.Domain),
 	}
 
 	challType := core.AcmeChallenge(req.ValidationMethod)
@@ -49,7 +49,7 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 		return nil, berrors.InternalServerError("unrecognized validation method %q", req.ValidationMethod)
 	}
 
-	acmeID := identifier.NewDNS(req.Domain)
+	acmeID := identifier.FromDNS(req.Domain)
 	params := &caaParams{
 		accountURIID:     req.AccountURIID,
 		validationMethod: challType,

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -201,7 +201,7 @@ func TestCAATimeout(t *testing.T) {
 		validationMethod: core.ChallengeTypeHTTP01,
 	}
 
-	err := va.checkCAA(ctx, identifier.NewDNS("caa-timeout.com"), params)
+	err := va.checkCAA(ctx, identifier.FromDNS("caa-timeout.com"), params)
 	test.AssertErrorIs(t, err, berrors.DNS)
 	test.AssertContains(t, err.Error(), "error")
 }
@@ -424,7 +424,7 @@ func TestCAAChecking(t *testing.T) {
 		mockLog := va.log.(*blog.Mock)
 		defer mockLog.Clear()
 		t.Run(caaTest.Name, func(t *testing.T) {
-			ident := identifier.NewDNS(caaTest.Domain)
+			ident := identifier.FromDNS(caaTest.Domain)
 			foundAt, valid, _, err := va.checkCAARecords(ctx, ident, params)
 			if err != nil {
 				t.Errorf("checkCAARecords error for %s: %s", caaTest.Domain, err)
@@ -514,7 +514,7 @@ func TestCAALogging(t *testing.T) {
 				accountURIID:     tc.AccountURIID,
 				validationMethod: tc.ChallengeType,
 			}
-			_ = va.checkCAA(ctx, identifier.NewDNS(tc.Domain), params)
+			_ = va.checkCAA(ctx, identifier.FromDNS(tc.Domain), params)
 
 			caaLogLines := mockLog.GetAllMatching(`Checked CAA records for`)
 			if len(caaLogLines) != 1 {
@@ -1127,13 +1127,13 @@ func TestCAAFailure(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, caaMockDNS{})
 
-	err := va.checkCAA(ctx, identifier.NewDNS("reserved.com"), &caaParams{1, core.ChallengeTypeHTTP01})
+	err := va.checkCAA(ctx, identifier.FromDNS("reserved.com"), &caaParams{1, core.ChallengeTypeHTTP01})
 	if err == nil {
 		t.Fatalf("Expected CAA rejection for reserved.com, got success")
 	}
 	test.AssertErrorIs(t, err, berrors.CAA)
 
-	err = va.checkCAA(ctx, identifier.NewDNS("example.gonetld"), &caaParams{1, core.ChallengeTypeHTTP01})
+	err = va.checkCAA(ctx, identifier.FromDNS("example.gonetld"), &caaParams{1, core.ChallengeTypeHTTP01})
 	if err == nil {
 		t.Fatalf("Expected CAA rejection for gonetld, got success")
 	}

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestDNSValidationWrong(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
-	_, err := va.validateDNS01(context.Background(), identifier.NewDNS("wrong-dns01.com"), expectedKeyAuthorization)
+	_, err := va.validateDNS01(context.Background(), identifier.FromDNS("wrong-dns01.com"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("Successful DNS validation with wrong TXT record")
 	}
@@ -30,7 +30,7 @@ func TestDNSValidationWrong(t *testing.T) {
 func TestDNSValidationWrongMany(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNS01(context.Background(), identifier.NewDNS("wrong-many-dns01.com"), expectedKeyAuthorization)
+	_, err := va.validateDNS01(context.Background(), identifier.FromDNS("wrong-many-dns01.com"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("Successful DNS validation with wrong TXT record")
 	}
@@ -41,7 +41,7 @@ func TestDNSValidationWrongMany(t *testing.T) {
 func TestDNSValidationWrongLong(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNS01(context.Background(), identifier.NewDNS("long-dns01.com"), expectedKeyAuthorization)
+	_, err := va.validateDNS01(context.Background(), identifier.FromDNS("long-dns01.com"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("Successful DNS validation with wrong TXT record")
 	}
@@ -52,7 +52,7 @@ func TestDNSValidationWrongLong(t *testing.T) {
 func TestDNSValidationFailure(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNS01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization)
+	_, err := va.validateDNS01(ctx, identifier.FromDNS("localhost"), expectedKeyAuthorization)
 	prob := detailedError(err)
 
 	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)
@@ -61,7 +61,7 @@ func TestDNSValidationFailure(t *testing.T) {
 func TestDNSValidationIP(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNS01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
+	_, err := va.validateDNS01(ctx, identifier.FromIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
 	prob := detailedError(err)
 
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
@@ -84,7 +84,7 @@ func TestDNSValidationInvalid(t *testing.T) {
 func TestDNSValidationServFail(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNS01(ctx, identifier.NewDNS("servfail.com"), expectedKeyAuthorization)
+	_, err := va.validateDNS01(ctx, identifier.FromDNS("servfail.com"), expectedKeyAuthorization)
 
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.DNSProblem)
@@ -104,7 +104,7 @@ func TestDNSValidationNoServer(t *testing.T) {
 		log,
 		nil)
 
-	_, err = va.validateDNS01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization)
+	_, err = va.validateDNS01(ctx, identifier.FromDNS("localhost"), expectedKeyAuthorization)
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.DNSProblem)
 }
@@ -112,7 +112,7 @@ func TestDNSValidationNoServer(t *testing.T) {
 func TestDNSValidationOK(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, prob := va.validateDNS01(ctx, identifier.NewDNS("good-dns01.com"), expectedKeyAuthorization)
+	_, prob := va.validateDNS01(ctx, identifier.FromDNS("good-dns01.com"), expectedKeyAuthorization)
 
 	test.Assert(t, prob == nil, "Should be valid.")
 }
@@ -120,7 +120,7 @@ func TestDNSValidationOK(t *testing.T) {
 func TestDNSValidationNoAuthorityOK(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, prob := va.validateDNS01(ctx, identifier.NewDNS("no-authority-dns01.com"), expectedKeyAuthorization)
+	_, prob := va.validateDNS01(ctx, identifier.FromDNS("no-authority-dns01.com"), expectedKeyAuthorization)
 
 	test.Assert(t, prob == nil, "Should be valid.")
 }

--- a/va/http.go
+++ b/va/http.go
@@ -334,14 +334,14 @@ func (va *ValidationAuthorityImpl) extractRequestTarget(req *http.Request) (iden
 		if va.isReservedIPFunc(reqIP.AsSlice()) {
 			return identifier.ACMEIdentifier{}, 0, berrors.ConnectionFailureError("Invalid host in redirect target, must not be a reserved IP address")
 		}
-		return identifier.NewIP(reqIP), reqPort, nil
+		return identifier.FromIP(reqIP), reqPort, nil
 	}
 
 	if _, err := iana.ExtractSuffix(reqHost); err != nil {
 		return identifier.ACMEIdentifier{}, 0, berrors.ConnectionFailureError("Invalid host in redirect target, must end in IANA registered TLD")
 	}
 
-	return identifier.NewDNS(reqHost), reqPort, nil
+	return identifier.FromDNS(reqHost), reqPort, nil
 }
 
 // setupHTTPValidation sets up a preresolvedDialer and a validation record for

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -89,7 +89,7 @@ func TestDialerTimeout(t *testing.T) {
 	var took time.Duration
 	for range 20 {
 		started := time.Now()
-		_, _, err = va.processHTTPValidation(ctx, identifier.NewDNS("unroutable.invalid"), "/.well-known/acme-challenge/whatever")
+		_, _, err = va.processHTTPValidation(ctx, identifier.FromDNS("unroutable.invalid"), "/.well-known/acme-challenge/whatever")
 		took = time.Since(started)
 		if err != nil && strings.Contains(err.Error(), "network is unreachable") {
 			continue
@@ -140,33 +140,33 @@ func TestHTTPValidationTarget(t *testing.T) {
 	}{
 		{
 			Name:          "No IPs for DNS identifier",
-			Ident:         identifier.NewDNS("always.invalid"),
+			Ident:         identifier.FromDNS("always.invalid"),
 			ExpectedError: berrors.DNSError("No valid IP addresses found for always.invalid"),
 		},
 		{
 			Name:        "Only IPv4 addrs for DNS identifier",
-			Ident:       identifier.NewDNS("some.example.com"),
+			Ident:       identifier.FromDNS("some.example.com"),
 			ExpectedIPs: []string{"127.0.0.1"},
 		},
 		{
 			Name:        "Only IPv6 addrs for DNS identifier",
-			Ident:       identifier.NewDNS("ipv6.localhost"),
+			Ident:       identifier.FromDNS("ipv6.localhost"),
 			ExpectedIPs: []string{"::1"},
 		},
 		{
 			Name:  "Both IPv6 and IPv4 addrs for DNS identifier",
-			Ident: identifier.NewDNS("ipv4.and.ipv6.localhost"),
+			Ident: identifier.FromDNS("ipv4.and.ipv6.localhost"),
 			// In this case we expect 1 IPv6 address first, and then 1 IPv4 address
 			ExpectedIPs: []string{"::1", "127.0.0.1"},
 		},
 		{
 			Name:        "IPv4 IP address identifier",
-			Ident:       identifier.NewIP(netip.MustParseAddr("127.0.0.1")),
+			Ident:       identifier.FromIP(netip.MustParseAddr("127.0.0.1")),
 			ExpectedIPs: []string{"127.0.0.1"},
 		},
 		{
 			Name:        "IPv6 IP address identifier",
-			Ident:       identifier.NewIP(netip.MustParseAddr("::1")),
+			Ident:       identifier.FromIP(netip.MustParseAddr("::1")),
 			ExpectedIPs: []string{"::1"},
 		},
 	}
@@ -285,7 +285,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("http://127.0.0.1"),
 			},
-			ExpectedIdent: identifier.NewIP(netip.MustParseAddr("127.0.0.1")),
+			ExpectedIdent: identifier.FromIP(netip.MustParseAddr("127.0.0.1")),
 			ExpectedPort:  80,
 		},
 		{
@@ -293,7 +293,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("http://127.0.0.1:80"),
 			},
-			ExpectedIdent: identifier.NewIP(netip.MustParseAddr("127.0.0.1")),
+			ExpectedIdent: identifier.FromIP(netip.MustParseAddr("127.0.0.1")),
 			ExpectedPort:  80,
 		},
 		{
@@ -309,7 +309,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("https://127.0.0.1"),
 			},
-			ExpectedIdent: identifier.NewIP(netip.MustParseAddr("127.0.0.1")),
+			ExpectedIdent: identifier.FromIP(netip.MustParseAddr("127.0.0.1")),
 			ExpectedPort:  443,
 		},
 		{
@@ -325,7 +325,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("http://[::1]"),
 			},
-			ExpectedIdent: identifier.NewIP(netip.MustParseAddr("::1")),
+			ExpectedIdent: identifier.FromIP(netip.MustParseAddr("::1")),
 			ExpectedPort:  80,
 		},
 		{
@@ -333,7 +333,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("http://[::1]:80"),
 			},
-			ExpectedIdent: identifier.NewIP(netip.MustParseAddr("::1")),
+			ExpectedIdent: identifier.FromIP(netip.MustParseAddr("::1")),
 			ExpectedPort:  80,
 		},
 		{
@@ -349,7 +349,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("https://[::1]"),
 			},
-			ExpectedIdent: identifier.NewIP(netip.MustParseAddr("::1")),
+			ExpectedIdent: identifier.FromIP(netip.MustParseAddr("::1")),
 			ExpectedPort:  443,
 		},
 		{
@@ -365,7 +365,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("http://cpu.letsencrypt.org:80"),
 			},
-			ExpectedIdent: identifier.NewDNS("cpu.letsencrypt.org"),
+			ExpectedIdent: identifier.FromDNS("cpu.letsencrypt.org"),
 			ExpectedPort:  80,
 		},
 		{
@@ -373,7 +373,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("http://cpu.letsencrypt.org"),
 			},
-			ExpectedIdent: identifier.NewDNS("cpu.letsencrypt.org"),
+			ExpectedIdent: identifier.FromDNS("cpu.letsencrypt.org"),
 			ExpectedPort:  80,
 		},
 		{
@@ -381,7 +381,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("https://cpu.letsencrypt.org:443/hello.world"),
 			},
-			ExpectedIdent: identifier.NewDNS("cpu.letsencrypt.org"),
+			ExpectedIdent: identifier.FromDNS("cpu.letsencrypt.org"),
 			ExpectedPort:  443,
 		},
 		{
@@ -389,7 +389,7 @@ func TestExtractRequestTarget(t *testing.T) {
 			Req: &http.Request{
 				URL: mustURL("https://cpu.letsencrypt.org/hello.world"),
 			},
-			ExpectedIdent: identifier.NewDNS("cpu.letsencrypt.org"),
+			ExpectedIdent: identifier.FromDNS("cpu.letsencrypt.org"),
 			ExpectedPort:  443,
 		},
 	}
@@ -418,7 +418,7 @@ func TestExtractRequestTarget(t *testing.T) {
 func TestHTTPValidationDNSError(t *testing.T) {
 	va, mockLog := setup(nil, "", nil, nil)
 
-	_, _, prob := va.processHTTPValidation(ctx, identifier.NewDNS("always.error"), "/.well-known/acme-challenge/whatever")
+	_, _, prob := va.processHTTPValidation(ctx, identifier.FromDNS("always.error"), "/.well-known/acme-challenge/whatever")
 	test.AssertError(t, prob, "Expected validation fetch to fail")
 	matchingLines := mockLog.GetAllMatching(`read udp: some net error`)
 	if len(matchingLines) != 1 {
@@ -434,7 +434,7 @@ func TestHTTPValidationDNSError(t *testing.T) {
 func TestHTTPValidationDNSIdMismatchError(t *testing.T) {
 	va, mockLog := setup(nil, "", nil, nil)
 
-	_, _, prob := va.processHTTPValidation(ctx, identifier.NewDNS("id.mismatch"), "/.well-known/acme-challenge/whatever")
+	_, _, prob := va.processHTTPValidation(ctx, identifier.FromDNS("id.mismatch"), "/.well-known/acme-challenge/whatever")
 	test.AssertError(t, prob, "Expected validation fetch to fail")
 	matchingLines := mockLog.GetAllMatching(`logDNSError ID mismatch`)
 	if len(matchingLines) != 1 {
@@ -476,7 +476,7 @@ func TestSetupHTTPValidation(t *testing.T) {
 	mustTarget := func(t *testing.T, host string, port int, path string) *httpValidationTarget {
 		target, err := va.newHTTPValidationTarget(
 			context.Background(),
-			identifier.NewDNS(host),
+			identifier.FromDNS(host),
 			port,
 			path,
 			"")
@@ -929,7 +929,7 @@ func TestFetchHTTP(t *testing.T) {
 	}{
 		{
 			Name:  "No IPs for host",
-			Ident: identifier.NewDNS("always.invalid"),
+			Ident: identifier.FromDNS("always.invalid"),
 			Path:  "/.well-known/whatever",
 			ExpectedProblem: probs.DNS(
 				"No valid IP addresses found for always.invalid"),
@@ -939,7 +939,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Timeout for host with standard ACME allowed port",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/timeout",
 			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching http://example.com/timeout: " +
@@ -957,7 +957,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Redirect loop",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/loop",
 			ExpectedProblem: probs.Connection(fmt.Sprintf(
 				"127.0.0.1: Fetching http://example.com:%d/loop: Redirect loop detected", httpPortIPv4)),
@@ -965,7 +965,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Too many redirects",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/max-redirect/0",
 			ExpectedProblem: probs.Connection(fmt.Sprintf(
 				"127.0.0.1: Fetching http://example.com:%d/max-redirect/12: Too many redirects", httpPortIPv4)),
@@ -973,7 +973,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Redirect to bad protocol",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/redir-bad-proto",
 			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching gopher://example.com: Invalid protocol scheme in " +
@@ -992,7 +992,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Redirect to bad port",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/redir-bad-port",
 			ExpectedProblem: probs.Connection(fmt.Sprintf(
 				"127.0.0.1: Fetching https://example.com:1987: Invalid port in redirect target. "+
@@ -1010,7 +1010,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:         "Redirect to bare IPv4 address",
-			Ident:        identifier.NewDNS("example.com"),
+			Ident:        identifier.FromDNS("example.com"),
 			Path:         "/redir-bare-ipv4",
 			ExpectedBody: "ok",
 			ExpectedRecords: []core.ValidationRecord{
@@ -1033,7 +1033,7 @@ func TestFetchHTTP(t *testing.T) {
 		}, {
 			Name:         "Redirect to bare IPv6 address",
 			IPv6:         true,
-			Ident:        identifier.NewDNS("ipv6.localhost"),
+			Ident:        identifier.FromDNS("ipv6.localhost"),
 			Path:         "/redir-bare-ipv6",
 			ExpectedBody: "ok",
 			ExpectedRecords: []core.ValidationRecord{
@@ -1056,7 +1056,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Redirect to long path",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/redir-path-too-long",
 			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching https://example.com/this-is-too-long-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789: Redirect target too long"),
@@ -1073,7 +1073,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Wrong HTTP status code",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/bad-status-code",
 			ExpectedProblem: probs.Unauthorized(
 				"127.0.0.1: Invalid response from http://example.com/bad-status-code: 410"),
@@ -1090,7 +1090,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "HTTP status code 303 redirect",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/303-see-other",
 			ExpectedProblem: probs.Connection(
 				"127.0.0.1: Fetching http://example.org/303-see-other: received disallowed redirect status code"),
@@ -1107,7 +1107,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Response too large",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/resp-too-big",
 			ExpectedProblem: probs.Unauthorized(fmt.Sprintf(
 				"127.0.0.1: Invalid response from http://example.com/resp-too-big: %q", expectedTruncatedResp.String(),
@@ -1125,7 +1125,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Broken IPv6 only",
-			Ident: identifier.NewDNS("ipv6.localhost"),
+			Ident: identifier.FromDNS("ipv6.localhost"),
 			Path:  "/ok",
 			ExpectedProblem: probs.Connection(
 				"::1: Fetching http://ipv6.localhost/ok: Connection refused"),
@@ -1142,7 +1142,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:         "Dual homed w/ broken IPv6, working IPv4",
-			Ident:        identifier.NewDNS("ipv4.and.ipv6.localhost"),
+			Ident:        identifier.FromDNS("ipv4.and.ipv6.localhost"),
 			Path:         "/ok",
 			ExpectedBody: "ok",
 			ExpectedRecords: []core.ValidationRecord{
@@ -1168,7 +1168,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:         "Working IPv4 only",
-			Ident:        identifier.NewDNS("example.com"),
+			Ident:        identifier.FromDNS("example.com"),
 			Path:         "/ok",
 			ExpectedBody: "ok",
 			ExpectedRecords: []core.ValidationRecord{
@@ -1184,7 +1184,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:         "Redirect to uppercase Public Suffix",
-			Ident:        identifier.NewDNS("example.com"),
+			Ident:        identifier.FromDNS("example.com"),
 			Path:         "/redir-uppercase-publicsuffix",
 			ExpectedBody: "ok",
 			ExpectedRecords: []core.ValidationRecord{
@@ -1208,7 +1208,7 @@ func TestFetchHTTP(t *testing.T) {
 		},
 		{
 			Name:  "Reflected response body containing printf verbs",
-			Ident: identifier.NewDNS("example.com"),
+			Ident: identifier.FromDNS("example.com"),
 			Path:  "/printf-verbs",
 			ExpectedProblem: &probs.ProblemDetails{
 				Type: probs.UnauthorizedProblem,
@@ -1367,7 +1367,7 @@ func TestHTTPBadPort(t *testing.T) {
 	badPort := 40000 + mrand.IntN(25000)
 	va.httpPort = badPort
 
-	_, err := va.validateHTTP01(ctx, identifier.NewDNS("localhost"), expectedToken, expectedKeyAuthorization)
+	_, err := va.validateHTTP01(ctx, identifier.FromDNS("localhost"), expectedToken, expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("Server's down; expected refusal. Where did we connect?")
 	}
@@ -1404,7 +1404,7 @@ func TestHTTPKeyAuthorizationFileMismatch(t *testing.T) {
 	hs.Start()
 
 	va, _ := setup(hs, "", nil, nil)
-	_, err := va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), expectedToken, expectedKeyAuthorization)
+	_, err := va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), expectedToken, expectedKeyAuthorization)
 
 	if err == nil {
 		t.Fatalf("Expected validation to fail when file mismatched.")
@@ -1421,21 +1421,21 @@ func TestHTTP(t *testing.T) {
 
 	va, log := setup(hs, "", nil, nil)
 
-	_, err := va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), expectedToken, expectedKeyAuthorization)
+	_, err := va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), expectedToken, expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Unexpected failure in HTTP validation for DNS: %s", err)
 	}
 	test.AssertEquals(t, len(log.GetAllMatching(`\[AUDIT\] `)), 1)
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedToken, expectedKeyAuthorization)
+	_, err = va.validateHTTP01(ctx, identifier.FromIP(netip.MustParseAddr("127.0.0.1")), expectedToken, expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Unexpected failure in HTTP validation for IPv4: %s", err)
 	}
 	test.AssertEquals(t, len(log.GetAllMatching(`\[AUDIT\] `)), 1)
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), path404, ka(path404))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), path404, ka(path404))
 	if err == nil {
 		t.Fatalf("Should have found a 404 for the challenge.")
 	}
@@ -1445,7 +1445,7 @@ func TestHTTP(t *testing.T) {
 	log.Clear()
 	// The "wrong token" will actually be the expectedToken.  It's wrong
 	// because it doesn't match pathWrongToken.
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathWrongToken, ka(pathWrongToken))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathWrongToken, ka(pathWrongToken))
 	if err == nil {
 		t.Fatalf("Should have found the wrong token value.")
 	}
@@ -1454,7 +1454,7 @@ func TestHTTP(t *testing.T) {
 	test.AssertEquals(t, len(log.GetAllMatching(`\[AUDIT\] `)), 1)
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathMoved, ka(pathMoved))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathMoved, ka(pathMoved))
 	if err != nil {
 		t.Fatalf("Failed to follow http.StatusMovedPermanently redirect")
 	}
@@ -1463,7 +1463,7 @@ func TestHTTP(t *testing.T) {
 	test.AssertEquals(t, len(matchedValidRedirect), 1)
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathFound, ka(pathFound))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathFound, ka(pathFound))
 	if err != nil {
 		t.Fatalf("Failed to follow http.StatusFound redirect")
 	}
@@ -1472,7 +1472,7 @@ func TestHTTP(t *testing.T) {
 	test.AssertEquals(t, len(matchedValidRedirect), 1)
 	test.AssertEquals(t, len(matchedMovedRedirect), 1)
 
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("always.invalid"), pathFound, ka(pathFound))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("always.invalid"), pathFound, ka(pathFound))
 	if err == nil {
 		t.Fatalf("Domain name is invalid.")
 	}
@@ -1486,7 +1486,7 @@ func TestHTTPIPv6(t *testing.T) {
 
 	va, log := setup(hs, "", nil, nil)
 
-	_, err := va.validateHTTP01(ctx, identifier.NewIP(netip.MustParseAddr("::1")), expectedToken, expectedKeyAuthorization)
+	_, err := va.validateHTTP01(ctx, identifier.FromIP(netip.MustParseAddr("::1")), expectedToken, expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Unexpected failure in HTTP validation for IPv6: %s", err)
 	}
@@ -1503,7 +1503,7 @@ func TestHTTPTimeout(t *testing.T) {
 	timeout := 250 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	_, err := va.validateHTTP01(ctx, identifier.NewDNS("localhost"), pathWaitLong, ka(pathWaitLong))
+	_, err := va.validateHTTP01(ctx, identifier.FromDNS("localhost"), pathWaitLong, ka(pathWaitLong))
 	if err == nil {
 		t.Fatalf("Connection should've timed out")
 	}
@@ -1527,7 +1527,7 @@ func TestHTTPRedirectLookup(t *testing.T) {
 	defer hs.Close()
 	va, log := setup(hs, "", nil, nil)
 
-	_, err := va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathMoved, ka(pathMoved))
+	_, err := va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathMoved, ka(pathMoved))
 	if err != nil {
 		t.Fatalf("Unexpected failure in redirect (%s): %s", pathMoved, err)
 	}
@@ -1537,7 +1537,7 @@ func TestHTTPRedirectLookup(t *testing.T) {
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost.com: \[127.0.0.1\]`)), 2)
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathFound, ka(pathFound))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathFound, ka(pathFound))
 	if err != nil {
 		t.Fatalf("Unexpected failure in redirect (%s): %s", pathFound, err)
 	}
@@ -1547,14 +1547,14 @@ func TestHTTPRedirectLookup(t *testing.T) {
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost.com: \[127.0.0.1\]`)), 3)
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathReLookupInvalid, ka(pathReLookupInvalid))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathReLookupInvalid, ka(pathReLookupInvalid))
 	test.AssertError(t, err, "error for pathReLookupInvalid should not be nil")
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for localhost.com: \[127.0.0.1\]`)), 1)
 	prob := detailedError(err)
 	test.AssertDeepEquals(t, prob, probs.Connection(`127.0.0.1: Fetching http://invalid.invalid/path: Invalid host in redirect target, must end in IANA registered TLD`))
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathReLookup, ka(pathReLookup))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathReLookup, ka(pathReLookup))
 	if err != nil {
 		t.Fatalf("Unexpected error in redirect (%s): %s", pathReLookup, err)
 	}
@@ -1564,7 +1564,7 @@ func TestHTTPRedirectLookup(t *testing.T) {
 	test.AssertEquals(t, len(log.GetAllMatching(`Resolved addresses for other.valid.com: \[127.0.0.1\]`)), 1)
 
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathRedirectInvalidPort, ka(pathRedirectInvalidPort))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathRedirectInvalidPort, ka(pathRedirectInvalidPort))
 	test.AssertNotNil(t, err, "error for pathRedirectInvalidPort should not be nil")
 	prob = detailedError(err)
 	test.AssertEquals(t, prob.Detail, fmt.Sprintf(
@@ -1575,7 +1575,7 @@ func TestHTTPRedirectLookup(t *testing.T) {
 	// HTTP 500 errors. The test case is ensuring that the connection error
 	// is referencing the redirected to host, instead of the original host.
 	log.Clear()
-	_, err = va.validateHTTP01(ctx, identifier.NewDNS("localhost.com"), pathRedirectToFailingURL, ka(pathRedirectToFailingURL))
+	_, err = va.validateHTTP01(ctx, identifier.FromDNS("localhost.com"), pathRedirectToFailingURL, ka(pathRedirectToFailingURL))
 	test.AssertNotNil(t, err, "err should not be nil")
 	prob = detailedError(err)
 	test.AssertDeepEquals(t, prob,
@@ -1589,7 +1589,7 @@ func TestHTTPRedirectLoop(t *testing.T) {
 	defer hs.Close()
 	va, _ := setup(hs, "", nil, nil)
 
-	_, prob := va.validateHTTP01(ctx, identifier.NewDNS("localhost"), "looper", ka("looper"))
+	_, prob := va.validateHTTP01(ctx, identifier.FromDNS("localhost"), "looper", ka("looper"))
 	if prob == nil {
 		t.Fatalf("Challenge should have failed for looper")
 	}
@@ -1601,12 +1601,12 @@ func TestHTTPRedirectUserAgent(t *testing.T) {
 	va, _ := setup(hs, "", nil, nil)
 	va.userAgent = rejectUserAgent
 
-	_, prob := va.validateHTTP01(ctx, identifier.NewDNS("localhost"), pathMoved, ka(pathMoved))
+	_, prob := va.validateHTTP01(ctx, identifier.FromDNS("localhost"), pathMoved, ka(pathMoved))
 	if prob == nil {
 		t.Fatalf("Challenge with rejectUserAgent should have failed (%s).", pathMoved)
 	}
 
-	_, prob = va.validateHTTP01(ctx, identifier.NewDNS("localhost"), pathFound, ka(pathFound))
+	_, prob = va.validateHTTP01(ctx, identifier.FromDNS("localhost"), pathFound, ka(pathFound))
 	if prob == nil {
 		t.Fatalf("Challenge with rejectUserAgent should have failed (%s).", pathFound)
 	}
@@ -1636,7 +1636,7 @@ func TestValidateHTTP(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, prob := va.validateHTTP01(ctx, identifier.NewDNS("localhost"), token, ka(token))
+	_, prob := va.validateHTTP01(ctx, identifier.FromDNS("localhost"), token, ka(token))
 	test.Assert(t, prob == nil, "validation failed")
 }
 
@@ -1647,7 +1647,7 @@ func TestLimitedReader(t *testing.T) {
 	va, _ := setup(hs, "", nil, nil)
 	defer hs.Close()
 
-	_, err := va.validateHTTP01(ctx, identifier.NewDNS("localhost"), token, ka(token))
+	_, err := va.validateHTTP01(ctx, identifier.FromDNS("localhost"), token, ka(token))
 
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -152,7 +152,7 @@ func TestTLSALPNTimeoutAfterConnect(t *testing.T) {
 	defer cancel()
 
 	started := time.Now()
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("slow.server"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("slow.server"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("Validation should've failed")
 	}
@@ -195,7 +195,7 @@ func TestTLSALPN01DialTimeout(t *testing.T) {
 	// that, just retry until we get something other than "Network unreachable".
 	var err error
 	for range 20 {
-		_, err = va.validateTLSALPN01(ctx, identifier.NewDNS("unroutable.invalid"), expectedKeyAuthorization)
+		_, err = va.validateTLSALPN01(ctx, identifier.FromDNS("unroutable.invalid"), expectedKeyAuthorization)
 		if err != nil && strings.Contains(err.Error(), "Network unreachable") {
 			continue
 		} else {
@@ -235,7 +235,7 @@ func TestTLSALPN01Refused(t *testing.T) {
 
 	// Take down validation server and check that validation fails.
 	hs.Close()
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("Server's down; expected refusal. Where did we connect?")
 	}
@@ -256,7 +256,7 @@ func TestTLSALPN01TalkingToHTTP(t *testing.T) {
 	httpOnly := httpSrv(t, "", false)
 	va.tlsPort = getPort(httpOnly)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "TLS-SNI-01 validation passed when talking to a HTTP-only server")
 	prob := detailedError(err)
 	expected := "Server only speaks HTTP, not TLS"
@@ -281,7 +281,7 @@ func TestTLSError(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("TLS validation should have failed: What cert was used?")
 	}
@@ -297,7 +297,7 @@ func TestDNSError(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("always.invalid"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("always.invalid"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("TLS validation should have failed: what IP was used?")
 	}
@@ -374,7 +374,7 @@ func TestTLSALPN01SuccessDNS(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Validation failed: %v", err)
 	}
@@ -390,7 +390,7 @@ func TestTLSALPN01SuccessIPv4(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Validation failed: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestTLSALPN01SuccessIPv6(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("::1")), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromIP(netip.MustParseAddr("::1")), expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Validation failed: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestTLSALPN01ObsoleteFailure(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertNotNil(t, err, "expected validation to fail")
 	test.AssertContains(t, err.Error(), "Required extension OID 1.3.6.1.5.5.7.1.31 is not present")
 }
@@ -444,7 +444,7 @@ func TestValidateTLSALPN01BadChallenge(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("TLS ALPN validation should have failed.")
 	}
@@ -465,7 +465,7 @@ func TestValidateTLSALPN01BrokenSrv(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("TLS ALPN validation should have failed.")
 	}
@@ -488,7 +488,7 @@ func TestValidateTLSALPN01UnawareSrv(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	if err == nil {
 		t.Fatalf("TLS ALPN validation should have failed.")
 	}
@@ -521,7 +521,7 @@ func TestValidateTLSALPN01MalformedExtnValue(t *testing.T) {
 		hs := tlsalpn01SrvWithCert(t, acmeCert, 0, false)
 		va, _ := setup(hs, "", nil, nil)
 
-		_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+		_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 		hs.Close()
 
 		if err == nil {
@@ -561,7 +561,7 @@ func TestTLSALPN01TLSVersion(t *testing.T) {
 
 		va, _ := setup(hs, "", nil, nil)
 
-		_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+		_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 		if !tc.expectError {
 			if err != nil {
 				t.Errorf("expected success, got: %v", err)
@@ -586,7 +586,7 @@ func TestTLSALPN01WrongName(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "identifier does not match expected identifier")
 }
@@ -598,7 +598,7 @@ func TestTLSALPN01WrongIPv4(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "identifier does not match expected identifier")
 }
@@ -610,7 +610,7 @@ func TestTLSALPN01WrongIPv6(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("::1")), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromIP(netip.MustParseAddr("::1")), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "identifier does not match expected identifier")
 }
@@ -621,7 +621,7 @@ func TestTLSALPN01ExtraNames(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "wrong number of identifiers")
 }
@@ -632,7 +632,7 @@ func TestTLSALPN01WrongIdentType(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "wrong number of identifiers")
 }
@@ -643,11 +643,11 @@ func TestTLSALPN01TooManyIdentTypes(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "wrong number of identifiers")
 
-	_, err = va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
+	_, err = va.validateTLSALPN01(ctx, identifier.FromIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "wrong number of identifiers")
 }
@@ -701,7 +701,7 @@ func TestTLSALPN01NotSelfSigned(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err = va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err = va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "not self-signed")
 
@@ -719,7 +719,7 @@ func TestTLSALPN01NotSelfSigned(t *testing.T) {
 
 	va, _ = setup(hs, "", nil, nil)
 
-	_, err = va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err = va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "not self-signed")
 }
@@ -758,7 +758,7 @@ func TestTLSALPN01ExtraIdentifiers(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err = va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err = va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	test.AssertContains(t, err.Error(), "Received certificate with unexpected identifiers")
 }
@@ -781,7 +781,7 @@ func TestTLSALPN01ExtraSANs(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err = va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err = va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	// In go >= 1.19, the TLS client library detects that the certificate has
 	// a duplicate extension and terminates the connection itself.
@@ -796,7 +796,7 @@ func TestTLSALPN01ExtraAcmeExtensions(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	_, err := va.validateTLSALPN01(ctx, identifier.FromDNS("expected"), expectedKeyAuthorization)
 	test.AssertError(t, err, "validation should have failed")
 	// In go >= 1.19, the TLS client library detects that the certificate has
 	// a duplicate extension and terminates the connection itself.

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -357,7 +357,7 @@ func TestPerformValidationWithMismatchedRemoteVAPerspectives(t *testing.T) {
 	remoteVAs = append(remoteVAs, mismatched1, mismatched2)
 
 	va, mockLog := setup(nil, "", remoteVAs, nil)
-	req := createValidationRequest(identifier.NewDNS("good-dns01.com"), core.ChallengeTypeDNS01)
+	req := createValidationRequest(identifier.FromDNS("good-dns01.com"), core.ChallengeTypeDNS01)
 	res, _ := va.DoDCV(context.Background(), req)
 	test.AssertNotNil(t, res.GetProblem(), "validation succeeded with mismatched remote VA perspectives")
 	test.AssertEquals(t, len(mockLog.GetAllMatching("Expected perspective")), 2)
@@ -380,7 +380,7 @@ func TestPerformValidationWithMismatchedRemoteVARIRs(t *testing.T) {
 	remoteVAs = append(remoteVAs, mismatched1, mismatched2)
 
 	va, mockLog := setup(nil, "", remoteVAs, nil)
-	req := createValidationRequest(identifier.NewDNS("good-dns01.com"), core.ChallengeTypeDNS01)
+	req := createValidationRequest(identifier.FromDNS("good-dns01.com"), core.ChallengeTypeDNS01)
 	res, _ := va.DoDCV(context.Background(), req)
 	test.AssertNotNil(t, res.GetProblem(), "validation succeeded with mismatched remote VA perspectives")
 	test.AssertEquals(t, len(mockLog.GetAllMatching("Expected perspective")), 2)
@@ -389,7 +389,7 @@ func TestPerformValidationWithMismatchedRemoteVARIRs(t *testing.T) {
 func TestValidateMalformedChallenge(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateChallenge(ctx, identifier.NewDNS("example.com"), "fake-type-01", expectedToken, expectedKeyAuthorization)
+	_, err := va.validateChallenge(ctx, identifier.FromDNS("example.com"), "fake-type-01", expectedToken, expectedKeyAuthorization)
 
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
@@ -399,7 +399,7 @@ func TestPerformValidationInvalid(t *testing.T) {
 	t.Parallel()
 	va, _ := setup(nil, "", nil, nil)
 
-	req := createValidationRequest(identifier.NewDNS("foo.com"), core.ChallengeTypeDNS01)
+	req := createValidationRequest(identifier.FromDNS("foo.com"), core.ChallengeTypeDNS01)
 	res, _ := va.DoDCV(context.Background(), req)
 	test.Assert(t, res.Problem != nil, "validation succeeded")
 	test.AssertMetricWithLabelsEquals(t, va.metrics.validationLatency, prometheus.Labels{
@@ -418,7 +418,7 @@ func TestInternalErrorLogged(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
-	req := createValidationRequest(identifier.NewDNS("nonexistent.com"), core.ChallengeTypeHTTP01)
+	req := createValidationRequest(identifier.FromDNS("nonexistent.com"), core.ChallengeTypeHTTP01)
 	_, err := va.DoDCV(ctx, req)
 	test.AssertNotError(t, err, "failed validation should not be an error")
 	matchingLogs := mockLog.GetAllMatching(
@@ -432,7 +432,7 @@ func TestPerformValidationValid(t *testing.T) {
 	va, mockLog := setup(nil, "", nil, nil)
 
 	// create a challenge with well known token
-	req := createValidationRequest(identifier.NewDNS("good-dns01.com"), core.ChallengeTypeDNS01)
+	req := createValidationRequest(identifier.FromDNS("good-dns01.com"), core.ChallengeTypeDNS01)
 	res, _ := va.DoDCV(context.Background(), req)
 	test.Assert(t, res.Problem == nil, fmt.Sprintf("validation failed: %#v", res.Problem))
 	test.AssertMetricWithLabelsEquals(t, va.metrics.validationLatency, prometheus.Labels{
@@ -460,7 +460,7 @@ func TestPerformValidationWildcard(t *testing.T) {
 	va, mockLog := setup(nil, "", nil, nil)
 
 	// create a challenge with well known token
-	req := createValidationRequest(identifier.NewDNS("*.good-dns01.com"), core.ChallengeTypeDNS01)
+	req := createValidationRequest(identifier.FromDNS("*.good-dns01.com"), core.ChallengeTypeDNS01)
 	// perform a validation for a wildcard name
 	res, _ := va.DoDCV(context.Background(), req)
 	test.Assert(t, res.Problem == nil, fmt.Sprintf("validation failed: %#v", res.Problem))
@@ -491,7 +491,7 @@ func TestMultiVA(t *testing.T) {
 	t.Parallel()
 
 	// Create a new challenge to use for the httpSrv
-	req := createValidationRequest(identifier.NewDNS("localhost"), core.ChallengeTypeHTTP01)
+	req := createValidationRequest(identifier.FromDNS("localhost"), core.ChallengeTypeHTTP01)
 
 	brokenVA := RemoteClients{
 		VAClient:  brokenRemoteVA{},
@@ -787,7 +787,7 @@ func TestMultiVAEarlyReturn(t *testing.T) {
 
 				// Perform all validations
 				start := time.Now()
-				req := createValidationRequest(identifier.NewDNS("localhost"), core.ChallengeTypeHTTP01)
+				req := createValidationRequest(identifier.FromDNS("localhost"), core.ChallengeTypeHTTP01)
 				res, _ := localVA.DoDCV(ctx, req)
 
 				if tc.wantCorroboration {
@@ -842,7 +842,7 @@ func TestMultiVAPolicy(t *testing.T) {
 	localVA, _ := setupWithRemotes(ms.Server, pass, remoteConfs, nil)
 
 	// Perform validation for a domain not in the disabledDomains list
-	req := createValidationRequest(identifier.NewDNS("letsencrypt.org"), core.ChallengeTypeHTTP01)
+	req := createValidationRequest(identifier.FromDNS("letsencrypt.org"), core.ChallengeTypeHTTP01)
 	res, _ := localVA.DoDCV(ctx, req)
 	// It should fail
 	if res.Problem == nil {
@@ -863,7 +863,7 @@ func TestMultiVALogging(t *testing.T) {
 	defer ms.Close()
 
 	va, _ := setupWithRemotes(ms.Server, pass, remoteConfs, nil)
-	req := createValidationRequest(identifier.NewDNS("letsencrypt.org"), core.ChallengeTypeHTTP01)
+	req := createValidationRequest(identifier.FromDNS("letsencrypt.org"), core.ChallengeTypeHTTP01)
 	res, err := va.DoDCV(ctx, req)
 	test.Assert(t, res.Problem == nil, fmt.Sprintf("validation failed with: %#v", res.Problem))
 	test.AssertNotError(t, err, "performing validation")
@@ -965,7 +965,7 @@ func TestPerformValidationDnsName(t *testing.T) {
 			va, _ := setup(nil, "", nil, nil)
 
 			// create a challenge with well known token
-			req := createValidationRequest(identifier.NewDNS(tc.identDomain), core.ChallengeTypeDNS01)
+			req := createValidationRequest(identifier.FromDNS(tc.identDomain), core.ChallengeTypeDNS01)
 			tc.transmogrifier(req)
 			res, err := va.DoDCV(context.Background(), req)
 			if tc.expectErr {

--- a/web/probs_test.go
+++ b/web/probs_test.go
@@ -67,14 +67,14 @@ func TestSubProblems(t *testing.T) {
 	}).WithSubErrors(
 		[]berrors.SubBoulderError{
 			{
-				Identifier: identifier.NewDNS("threeletter.agency"),
+				Identifier: identifier.FromDNS("threeletter.agency"),
 				BoulderError: &berrors.BoulderError{
 					Type:   berrors.CAA,
 					Detail: "Forbidden by ■■■■■■■■■■■ and directive ■■■■",
 				},
 			},
 			{
-				Identifier: identifier.NewDNS("area51.threeletter.agency"),
+				Identifier: identifier.FromDNS("area51.threeletter.agency"),
 				BoulderError: &berrors.BoulderError{
 					Type:   berrors.NotFound,
 					Detail: "No Such Area...",

--- a/web/send_error_test.go
+++ b/web/send_error_test.go
@@ -20,14 +20,14 @@ func TestSendErrorSubProblemNamespace(t *testing.T) {
 	}).WithSubErrors(
 		[]berrors.SubBoulderError{
 			{
-				Identifier: identifier.NewDNS("example.com"),
+				Identifier: identifier.FromDNS("example.com"),
 				BoulderError: &berrors.BoulderError{
 					Type:   berrors.Malformed,
 					Detail: "nop",
 				},
 			},
 			{
-				Identifier: identifier.NewDNS("what about example.com"),
+				Identifier: identifier.FromDNS("what about example.com"),
 				BoulderError: &berrors.BoulderError{
 					Type:   berrors.Malformed,
 					Detail: "nah",
@@ -74,14 +74,14 @@ func TestSendErrorSubProbLogging(t *testing.T) {
 	}).WithSubErrors(
 		[]berrors.SubBoulderError{
 			{
-				Identifier: identifier.NewDNS("example.com"),
+				Identifier: identifier.FromDNS("example.com"),
 				BoulderError: &berrors.BoulderError{
 					Type:   berrors.Malformed,
 					Detail: "nop",
 				},
 			},
 			{
-				Identifier: identifier.NewDNS("what about example.com"),
+				Identifier: identifier.FromDNS("what about example.com"),
 				BoulderError: &berrors.BoulderError{
 					Type:   berrors.Malformed,
 					Detail: "nah",

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -33,6 +33,7 @@ import (
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	_ "github.com/letsencrypt/boulder/grpc/noncebalancer" // imported for its init function.
 	"github.com/letsencrypt/boulder/identifier"
+	"github.com/letsencrypt/boulder/identifiers"
 	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics/measured_http"
@@ -1985,7 +1986,7 @@ type orderJSON struct {
 func (wfe *WebFrontEndImpl) orderToOrderJSON(request *http.Request, order *corepb.Order) orderJSON {
 	idents := make([]identifier.ACMEIdentifier, len(order.DnsNames))
 	for i, name := range order.DnsNames {
-		idents[i] = identifier.NewDNS(name)
+		idents[i] = identifier.FromDNS(name)
 	}
 	finalizeURL := web.RelativeEndpoint(request,
 		fmt.Sprintf("%s%d/%d", finalizeOrderPath, order.RegistrationID, order.Id))
@@ -2298,7 +2299,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	}
 
 	names = core.UniqueLowerNames(names)
-	err = policy.WellFormedIdentifiers(identifier.FromDNSNames(names))
+	err = policy.WellFormedIdentifiers(identifiers.FromDNS(names))
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
 		return

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3441,7 +3441,7 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 		ID:             "12345",
 		Status:         core.StatusPending,
 		RegistrationID: 1,
-		Identifier:     identifier.NewDNS("example.com"),
+		Identifier:     identifier.FromDNS("example.com"),
 		Challenges: []core.Challenge{
 			{Type: core.ChallengeTypeDNS01, Status: core.StatusPending, Token: "token"},
 			{Type: core.ChallengeTypeHTTP01, Status: core.StatusPending, Token: "token"},
@@ -3467,7 +3467,7 @@ func TestPrepRevokedAuthzForDisplay(t *testing.T) {
 		ID:             "12345",
 		Status:         core.StatusInvalid,
 		RegistrationID: 1,
-		Identifier:     identifier.NewDNS("example.com"),
+		Identifier:     identifier.FromDNS("example.com"),
 		Challenges: []core.Challenge{
 			{Type: core.ChallengeTypeDNS01, Status: core.StatusPending, Token: "token"},
 			{Type: core.ChallengeTypeHTTP01, Status: core.StatusPending, Token: "token"},
@@ -3492,7 +3492,7 @@ func TestPrepWildcardAuthzForDisplay(t *testing.T) {
 		ID:             "12345",
 		Status:         core.StatusPending,
 		RegistrationID: 1,
-		Identifier:     identifier.NewDNS("*.example.com"),
+		Identifier:     identifier.FromDNS("*.example.com"),
 		Challenges: []core.Challenge{
 			{Type: core.ChallengeTypeDNS01, Status: core.StatusPending, Token: "token"},
 		},
@@ -3515,7 +3515,7 @@ func TestPrepAuthzForDisplayShuffle(t *testing.T) {
 		ID:             "12345",
 		Status:         core.StatusPending,
 		RegistrationID: 1,
-		Identifier:     identifier.NewDNS("example.com"),
+		Identifier:     identifier.FromDNS("example.com"),
 		Challenges: []core.Challenge{
 			{Type: core.ChallengeTypeDNS01, Status: core.StatusPending, Token: "token"},
 			{Type: core.ChallengeTypeHTTP01, Status: core.StatusPending, Token: "token"},


### PR DESCRIPTION
Add a new `identifiers` package for functions that handle slices of `ACMEIdentifier`. We plan to add several such functions (e.g. in #7961). Without this change, they'd need a clumsy prefix/suffix to differentiate them from their sibling functions that handle single idents. The current `NewDNS` / `FromDNSNames` are the first example of this.

Rename `NewDNS` and `NewIP` to use a more standardized `From` prefix, since they're doing conversions. Move and rename `FromDNSNames`, standardizing `identifier.FromDNS` as the singular and `identifiers.FromDNS` as the plural (i.e. slice).

Add a named type `ACMEIdentifiers` so that we can add methods to slices. We will have a lot of slice handling code coming up, which this will make more elegant and readable.

Part of #7311