### PR TITLE
Simplify and fix CRL observer IDP check

### DIFF
--- a/observer/probers/crl/crl.go
+++ b/observer/probers/crl/crl.go
@@ -59,7 +59,7 @@ func (p CRLProbe) Probe(timeout time.Duration) (bool, time.Duration) {
 		if err != nil {
 			return false, dur
 		}
-		if len(idps) != 0 && !slices.Contains(idps, p.url) {
+		if !slices.Contains(idps, p.url) {
 			return false, dur
 		}
 	}


### PR DESCRIPTION
The conditional introduced in https://github.com/letsencrypt/boulder/pull/8067 contained a bug left over from an earlier draft of the PR. Remove the zero-length check to ensure the code matches the documented intent.