### PR TITLE
identifier: Rename FromDNSNames & AsProto; add ACMEIdentifiers named type

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -82,7 +82,7 @@ func VerifyCSR(ctx context.Context, csr *x509.CertificateRequest, maxNames int, 
 		return berrors.BadCSRError("CSR contains more than %d DNS names", maxNames)
 	}
 
-	err = pa.WillingToIssue(identifier.FromDNSNames(names.SANs))
+	err = pa.WillingToIssue(identifier.NewDNSSlice(names.SANs))
 	if err != nil {
 		return err
 	}

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -1,6 +1,11 @@
 // The identifier package defines types for RFC 8555 ACME identifiers.
+//
 // It exists as a separate package to prevent an import loop between the core
 // and probs packages.
+//
+// Function naming conventions:
+// - "New" creates a new instance from one or more simple base type inputs.
+// - "From" and "To" extract information from, or compose, a more complex object.
 package identifier
 
 import (
@@ -32,7 +37,11 @@ type ACMEIdentifier struct {
 	Value string `json:"value"`
 }
 
-func (i ACMEIdentifier) AsProto() *corepb.Identifier {
+// ACMEIdentifiers is a named type for a slice of ACME identifiers, so that
+// methods can be applied to these slices.
+type ACMEIdentifiers []ACMEIdentifier
+
+func (i ACMEIdentifier) ToProto() *corepb.Identifier {
 	return &corepb.Identifier{
 		Type:  string(i.Type),
 		Value: i.Value,
@@ -64,9 +73,9 @@ func NewDNS(domain string) ACMEIdentifier {
 	}
 }
 
-// FromDNSNames is a convenience function for creating a slice of ACMEIdentifier
+// NewDNSSlice is a convenience function for creating a slice of ACMEIdentifier
 // with Type "dns" for a given slice of domain names.
-func FromDNSNames(input []string) []ACMEIdentifier {
+func NewDNSSlice(input []string) ACMEIdentifiers {
 	var out []ACMEIdentifier
 	for _, in := range input {
 		out = append(out, NewDNS(in))

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2281,7 +2281,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 	}
 
 	// Validate that our policy allows issuing for each of the names in the order
-	err = ra.PA.WillingToIssue(identifier.FromDNSNames(newOrder.DnsNames))
+	err = ra.PA.WillingToIssue(identifier.NewDNSSlice(newOrder.DnsNames))
 	if err != nil {
 		return nil, err
 	}
@@ -2435,7 +2435,7 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		}
 
 		newAuthzs = append(newAuthzs, &sapb.NewAuthzRequest{
-			Identifier:     ident.AsProto(),
+			Identifier:     ident.ToProto(),
 			RegistrationID: newOrder.RegistrationID,
 			Expires:        timestamppb.New(ra.clk.Now().Add(profile.pendingAuthzLifetime).Truncate(time.Second)),
 			ChallengeTypes: challStrs,

--- a/ratelimits/names.go
+++ b/ratelimits/names.go
@@ -200,7 +200,7 @@ func validateFQDNSet(id string) error {
 		return fmt.Errorf(
 			"invalid fqdnSet, %q must be formatted 'fqdnSet'", id)
 	}
-	return policy.WellFormedIdentifiers(identifier.FromDNSNames(domains))
+	return policy.WellFormedIdentifiers(identifier.NewDNSSlice(domains))
 }
 
 func validateIdForName(name Name, id string) error {

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -85,7 +85,7 @@ var accountURIPrefixes = []string{"http://boulder.service.consul:4000/acme/reg/"
 
 func createValidationRequest(ident identifier.ACMEIdentifier, challengeType core.AcmeChallenge) *vapb.PerformValidationRequest {
 	return &vapb.PerformValidationRequest{
-		Identifier: ident.AsProto(),
+		Identifier: ident.ToProto(),
 		Challenge: &corepb.Challenge{
 			Type:              string(challengeType),
 			Status:            string(core.StatusPending),

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2298,7 +2298,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	}
 
 	names = core.UniqueLowerNames(names)
-	err = policy.WellFormedIdentifiers(identifier.FromDNSNames(names))
+	err = policy.WellFormedIdentifiers(identifier.NewDNSSlice(names))
 	if err != nil {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Invalid identifiers requested"), nil)
 		return


### PR DESCRIPTION
Rename `FromDNSNames` to `NewDNSSlice`, since it's exactly `NewDNS` except for slices.

Rename `AsProto` to use the "To" prefix, since it's the opposite of "From".

Add a named type `ACMEIdentifiers` so that we can add methods to slices. We will have a lot of slice handling code coming up, which this will make more elegant and readable.

Add a comment to explain naming conventions in the `identifier` package.

Part of #7311
Alternative to #8068