### PR TITLE
crl-updater: Fix lookback period for GetRevokedCertsByShard

### DIFF
--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -314,7 +314,7 @@ func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerN
 
 	// Query for unexpired certificates, with padding to ensure that revoked certificates show
 	// up in at least one CRL, even if they expire between revocation and CRL generation.
-	expiresAfter := cu.clk.Now().Add(cu.lookbackPeriod)
+	expiresAfter := cu.clk.Now().Add(-1 * cu.lookbackPeriod)
 
 	saStream, err := cu.sa.GetRevokedCertsByShard(ctx, &sapb.GetRevokedCertsByShardRequest{
 		IssuerNameID:  int64(issuerNameID),


### PR DESCRIPTION
The purpose of the lookback period is so that entries are not removed from a CRL until well after they have expired, to ensure we comply with RFC 5280, Section 3.3, which says "An entry MUST NOT be removed from the CRL until it appears on one regularly scheduled CRL issued beyond the revoked certificate's validity period."

Setting the expiresAfter time to be in the future means that certificates will be omitted from the query before they expire, rather than after. Change the sign of the lookbackPeriod so that the expiresAfter timestamp is in the past.