### PR TITLE
sfe: Fix broken unpause form

### DIFF
--- a/sfe/pages/unpause-form.html
+++ b/sfe/pages/unpause-form.html
@@ -9,7 +9,7 @@
         following:
     </p>
     <ul>
-        {{ range $identifier := .Identifiers }}<li>{{ $identifier}}</li>{{ end }}
+        {{ range $identifier := .Idents }}<li>{{ $identifier}}</li>{{ end }}
     </ul>
     <p>
         These identifiers were paused after consistently failing validation

--- a/sfe/sfe.go
+++ b/sfe/sfe.go
@@ -169,6 +169,8 @@ func (sfe *SelfServiceFrontEndImpl) UnpauseForm(response http.ResponseWriter, re
 		return
 	}
 
+	// If any of these values change, ensure any relevant pages in //sfe/pages/
+	// are also updated.
 	type tmplData struct {
 		PostPath  string
 		JWT       string

--- a/sfe/sfe.go
+++ b/sfe/sfe.go
@@ -124,6 +124,7 @@ func (sfe *SelfServiceFrontEndImpl) renderTemplate(w http.ResponseWriter, filena
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	err := sfe.templatePages.ExecuteTemplate(w, filename, dynamicData)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Fix incorrect struct member name cause broken unpause form caused by https://github.com/letsencrypt/boulder/pull/8066
Adds the `text/html` header to all rendered templates.

Initial error report:
```
template: unpause-form.html:12:32: executing "unpause-form.html" at <.Identifiers>: can't evaluate field Identifiers in type sfe.tmplData
```