### PR TITLE
WFE: Return errors from JWS-verification functions

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -31,7 +31,7 @@ const (
 	// InternalServer is deprecated. Instead, pass a plain Go error. That will get
 	// turned into a probs.InternalServerError by the WFE.
 	InternalServer ErrorType = iota
-	_
+	_                        // Reserved, previously NotSupported
 	Malformed
 	Unauthorized
 	NotFound
@@ -58,6 +58,9 @@ const (
 	// The certificate being indicated for replacement already has a replacement
 	// order.
 	AlreadyReplaced
+	BadSignatureAlgorithm
+	AccountDoesNotExist
+	BadNonce
 )
 
 func (ErrorType) Error() string {
@@ -302,4 +305,16 @@ func UnknownSerialError() error {
 
 func InvalidProfileError(msg string, args ...interface{}) error {
 	return newf(InvalidProfile, msg, args...)
+}
+
+func BadSignatureAlgorithmError(msg string, args ...interface{}) error {
+	return newf(BadSignatureAlgorithm, msg, args...)
+}
+
+func AccountDoesNotExistError(msg string, args ...interface{}) error {
+	return newf(AccountDoesNotExist, msg, args...)
+}
+
+func BadNonceError(msg string, args ...interface{}) error {
+	return newf(BadNonce, msg, args...)
 }

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -537,7 +537,7 @@ func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 			test.AssertNotError(t, err, "NewAccount failed with a non-blocklisted key")
 		case byKey:
 			test.AssertError(t, err, "NewAccount didn't fail with a blocklisted key")
-			test.AssertEquals(t, err.Error(), `acme: error code 400 "urn:ietf:params:acme:error:badPublicKey": public key is forbidden`)
+			test.AssertEquals(t, err.Error(), `acme: error code 400 "urn:ietf:params:acme:error:badPublicKey": Unable to validate JWS :: invalid request signing key: public key is forbidden`)
 		}
 	}
 }

--- a/web/probs.go
+++ b/web/probs.go
@@ -52,6 +52,12 @@ func problemDetailsForBoulderError(err *berrors.BoulderError, msg string) *probs
 		outProb = probs.Conflict(fmt.Sprintf("%s :: %s", msg, err))
 	case berrors.InvalidProfile:
 		outProb = probs.InvalidProfile(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.BadSignatureAlgorithm:
+		outProb = probs.BadSignatureAlgorithm(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.AccountDoesNotExist:
+		outProb = probs.AccountDoesNotExist(fmt.Sprintf("%s :: %s", msg, err))
+	case berrors.BadNonce:
+		outProb = probs.BadNonce(fmt.Sprintf("%s :: %s", msg, err))
 	default:
 		// Internal server error messages may include sensitive data, so we do
 		// not include it.

--- a/wfe2/verify.go
+++ b/wfe2/verify.go
@@ -26,7 +26,6 @@ import (
 	nb "github.com/letsencrypt/boulder/grpc/noncebalancer"
 	"github.com/letsencrypt/boulder/nonce"
 	noncepb "github.com/letsencrypt/boulder/nonce/proto"
-	"github.com/letsencrypt/boulder/probs"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/web"
 )
@@ -52,7 +51,7 @@ func sigAlgorithmForKey(key *jose.JSONWebKey) (jose.SignatureAlgorithm, error) {
 			return jose.ES512, nil
 		}
 	}
-	return "", errors.New("JWK contains unsupported key type (expected RSA, or ECDSA P-256, P-384, or P-521)")
+	return "", berrors.BadPublicKeyError("JWK contains unsupported key type (expected RSA, or ECDSA P-256, P-384, or P-521)")
 }
 
 // getSupportedAlgs returns a sorted slice of joseSignatureAlgorithm's from a
@@ -74,7 +73,7 @@ func getSupportedAlgs() []jose.SignatureAlgorithm {
 func checkAlgorithm(key *jose.JSONWebKey, header jose.Header) error {
 	sigHeaderAlg := jose.SignatureAlgorithm(header.Algorithm)
 	if !slices.Contains(getSupportedAlgs(), sigHeaderAlg) {
-		return fmt.Errorf(
+		return berrors.BadSignatureAlgorithmError(
 			"JWS signature header contains unsupported algorithm %q, expected one of %s",
 			header.Algorithm, getSupportedAlgs(),
 		)
@@ -85,10 +84,10 @@ func checkAlgorithm(key *jose.JSONWebKey, header jose.Header) error {
 		return err
 	}
 	if sigHeaderAlg != expectedAlg {
-		return fmt.Errorf("JWS signature header algorithm %q does not match expected algorithm %q for JWK", sigHeaderAlg, string(expectedAlg))
+		return berrors.MalformedError("JWS signature header algorithm %q does not match expected algorithm %q for JWK", sigHeaderAlg, string(expectedAlg))
 	}
 	if key.Algorithm != "" && key.Algorithm != string(expectedAlg) {
-		return fmt.Errorf("JWK key header algorithm %q does not match expected algorithm %q for JWK", key.Algorithm, string(expectedAlg))
+		return berrors.MalformedError("JWK key header algorithm %q does not match expected algorithm %q for JWK", key.Algorithm, string(expectedAlg))
 	}
 	return nil
 }
@@ -108,15 +107,14 @@ const (
 // determine if the request being authenticated by the JWS is identified using
 // an embedded JWK or an embedded key ID. If no signatures are present, or
 // mutually exclusive authentication types are specified at the same time, a
-// problem is returned. checkJWSAuthType is separate from enforceJWSAuthType so
+// error is returned. checkJWSAuthType is separate from enforceJWSAuthType so
 // that endpoints that need to handle both embedded JWK and embedded key ID
 // requests can determine which type of request they have and act accordingly
 // (e.g. acme v2 cert revocation).
-func checkJWSAuthType(header jose.Header) (jwsAuthType, *probs.ProblemDetails) {
+func checkJWSAuthType(header jose.Header) (jwsAuthType, error) {
 	// There must not be a Key ID *and* an embedded JWK
 	if header.KeyID != "" && header.JSONWebKey != nil {
-		return invalidAuthType, probs.Malformed(
-			"jwk and kid header fields are mutually exclusive")
+		return invalidAuthType, berrors.MalformedError("jwk and kid header fields are mutually exclusive")
 	} else if header.KeyID != "" {
 		return embeddedKeyID, nil
 	} else if header.JSONWebKey != nil {
@@ -129,25 +127,25 @@ func checkJWSAuthType(header jose.Header) (jwsAuthType, *probs.ProblemDetails) {
 // enforceJWSAuthType enforces that the protected headers from a
 // bJSONWebSignature have the provided auth type. If there is an error
 // determining the auth type or if it is not the expected auth type then a
-// problem is returned.
+// error is returned.
 func (wfe *WebFrontEndImpl) enforceJWSAuthType(
 	header jose.Header,
-	expectedAuthType jwsAuthType) *probs.ProblemDetails {
+	expectedAuthType jwsAuthType) error {
 	// Check the auth type for the provided JWS
-	authType, prob := checkJWSAuthType(header)
-	if prob != nil {
+	authType, err := checkJWSAuthType(header)
+	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSAuthTypeInvalid"}).Inc()
-		return prob
+		return err
 	}
-	// If the auth type isn't the one expected return a sensible problem based on
+	// If the auth type isn't the one expected return a sensible error based on
 	// what was expected
 	if authType != expectedAuthType {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSAuthTypeWrong"}).Inc()
 		switch expectedAuthType {
 		case embeddedKeyID:
-			return probs.Malformed("No Key ID in JWS header")
+			return berrors.MalformedError("No Key ID in JWS header")
 		case embeddedJWK:
-			return probs.Malformed("No embedded JWK in JWS header")
+			return berrors.MalformedError("No embedded JWK in JWS header")
 		}
 	}
 	return nil
@@ -156,47 +154,45 @@ func (wfe *WebFrontEndImpl) enforceJWSAuthType(
 // validPOSTRequest checks a *http.Request to ensure it has the headers
 // a well-formed ACME POST request has, and to ensure there is a body to
 // process.
-func (wfe *WebFrontEndImpl) validPOSTRequest(request *http.Request) *probs.ProblemDetails {
+func (wfe *WebFrontEndImpl) validPOSTRequest(request *http.Request) error {
 	// All POSTs should have an accompanying Content-Length header
 	if _, present := request.Header["Content-Length"]; !present {
 		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "ContentLengthRequired"}).Inc()
-		return probs.ContentLengthRequired()
+		return berrors.MalformedError("missing Content-Length header")
 	}
 
 	// Per 6.2 ALL POSTs should have the correct JWS Content-Type for flattened
 	// JSON serialization.
 	if _, present := request.Header["Content-Type"]; !present {
 		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "NoContentType"}).Inc()
-		return probs.InvalidContentType(fmt.Sprintf("No Content-Type header on POST. Content-Type must be %q",
-			expectedJWSContentType))
+		return berrors.MalformedError("No Content-Type header on POST. Content-Type must be %q", expectedJWSContentType)
 	}
 	if contentType := request.Header.Get("Content-Type"); contentType != expectedJWSContentType {
 		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "WrongContentType"}).Inc()
-		return probs.InvalidContentType(fmt.Sprintf("Invalid Content-Type header on POST. Content-Type must be %q",
-			expectedJWSContentType))
+		return berrors.MalformedError("Invalid Content-Type header on POST. Content-Type must be %q", expectedJWSContentType)
 	}
 
 	// Per 6.4.1 "Replay-Nonce" clients should not send a Replay-Nonce header in
 	// the HTTP request, it needs to be part of the signed JWS request body
 	if _, present := request.Header["Replay-Nonce"]; present {
 		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "ReplayNonceOutsideJWS"}).Inc()
-		return probs.Malformed("HTTP requests should NOT contain Replay-Nonce header. Use JWS nonce field")
+		return berrors.MalformedError("HTTP requests should NOT contain Replay-Nonce header. Use JWS nonce field")
 	}
 
 	// All POSTs should have a non-nil body
 	if request.Body == nil {
 		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "NoPOSTBody"}).Inc()
-		return probs.Malformed("No body on POST")
+		return berrors.MalformedError("No body on POST")
 	}
 
 	return nil
 }
 
 // nonceWellFormed checks a JWS' Nonce header to ensure it is well-formed,
-// otherwise a bad nonce problem is returned. This avoids unnecessary RPCs to
+// otherwise a bad nonce error is returned. This avoids unnecessary RPCs to
 // the nonce redemption service.
-func nonceWellFormed(nonceHeader string, prefixLen int) *probs.ProblemDetails {
-	errBadNonce := probs.BadNonce(fmt.Sprintf("JWS has an invalid anti-replay nonce: %q", nonceHeader))
+func nonceWellFormed(nonceHeader string, prefixLen int) error {
+	errBadNonce := berrors.BadNonceError("JWS has an invalid anti-replay nonce: %q", nonceHeader)
 	if len(nonceHeader) <= prefixLen {
 		// Nonce header was an unexpected length because there is either:
 		// 1) no nonce, or
@@ -216,19 +212,19 @@ func nonceWellFormed(nonceHeader string, prefixLen int) *probs.ProblemDetails {
 }
 
 // validNonce checks a JWS' Nonce header to ensure it is one that the
-// nonceService knows about, otherwise a bad nonce problem is returned.
+// nonceService knows about, otherwise a bad nonce error is returned.
 // NOTE: this function assumes the JWS has already been verified with the
 // correct public key.
-func (wfe *WebFrontEndImpl) validNonce(ctx context.Context, header jose.Header) *probs.ProblemDetails {
+func (wfe *WebFrontEndImpl) validNonce(ctx context.Context, header jose.Header) error {
 	if len(header.Nonce) == 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSMissingNonce"}).Inc()
-		return probs.BadNonce("JWS has no anti-replay nonce")
+		return berrors.BadNonceError("JWS has no anti-replay nonce")
 	}
 
-	prob := nonceWellFormed(header.Nonce, nonce.PrefixLen)
-	if prob != nil {
+	err := nonceWellFormed(header.Nonce, nonce.PrefixLen)
+	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSMalformedNonce"}).Inc()
-		return prob
+		return err
 	}
 
 	// Populate the context with the nonce prefix and HMAC key. These are
@@ -241,7 +237,7 @@ func (wfe *WebFrontEndImpl) validNonce(ctx context.Context, header jose.Header) 
 	if err != nil {
 		rpcStatus, ok := status.FromError(err)
 		if !ok || rpcStatus != nb.ErrNoBackendsMatchPrefix {
-			return web.ProblemDetailsForError(err, "failed to redeem nonce")
+			return fmt.Errorf("failed to redeem nonce: %w", err)
 		}
 
 		// ErrNoBackendsMatchPrefix suggests that the nonce backend, which
@@ -254,7 +250,7 @@ func (wfe *WebFrontEndImpl) validNonce(ctx context.Context, header jose.Header) 
 
 	if !resp.Valid {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSInvalidNonce"}).Inc()
-		return probs.BadNonce(fmt.Sprintf("JWS has an invalid anti-replay nonce: %q", header.Nonce))
+		return berrors.BadNonceError("JWS has an invalid anti-replay nonce: %q", header.Nonce)
 	}
 	return nil
 }
@@ -262,21 +258,21 @@ func (wfe *WebFrontEndImpl) validNonce(ctx context.Context, header jose.Header) 
 // validPOSTURL checks the JWS' URL header against the expected URL based on the
 // HTTP request. This prevents a JWS intended for one endpoint being replayed
 // against a different endpoint. If the URL isn't present, is invalid, or
-// doesn't match the HTTP request a problem is returned.
+// doesn't match the HTTP request a error is returned.
 func (wfe *WebFrontEndImpl) validPOSTURL(
 	request *http.Request,
-	header jose.Header) *probs.ProblemDetails {
+	header jose.Header) error {
 	extraHeaders := header.ExtraHeaders
 	// Check that there is at least one Extra Header
 	if len(extraHeaders) == 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSNoExtraHeaders"}).Inc()
-		return probs.Malformed("JWS header parameter 'url' required")
+		return berrors.MalformedError("JWS header parameter 'url' required")
 	}
 	// Try to read a 'url' Extra Header as a string
 	headerURL, ok := extraHeaders[jose.HeaderKey("url")].(string)
 	if !ok || len(headerURL) == 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSMissingURL"}).Inc()
-		return probs.Malformed("JWS header parameter 'url' required")
+		return berrors.MalformedError("JWS header parameter 'url' required")
 	}
 	// Compute the URL we expect to be in the JWS based on the HTTP request
 	expectedURL := url.URL{
@@ -288,17 +284,15 @@ func (wfe *WebFrontEndImpl) validPOSTURL(
 	// header
 	if expectedURL.String() != headerURL {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSMismatchedURL"}).Inc()
-		return probs.Malformed(fmt.Sprintf(
-			"JWS header parameter 'url' incorrect. Expected %q got %q",
-			expectedURL.String(), headerURL))
+		return berrors.MalformedError("JWS header parameter 'url' incorrect. Expected %q got %q", expectedURL.String(), headerURL)
 	}
 	return nil
 }
 
 // matchJWSURLs checks two JWS' URL headers are equal. This is used during key
 // rollover to check that the inner JWS URL matches the outer JWS URL. If the
-// JWS URLs do not match a problem is returned.
-func (wfe *WebFrontEndImpl) matchJWSURLs(outer, inner jose.Header) *probs.ProblemDetails {
+// JWS URLs do not match a error is returned.
+func (wfe *WebFrontEndImpl) matchJWSURLs(outer, inner jose.Header) error {
 	// Verify that the outer JWS has a non-empty URL header. This is strictly
 	// defensive since the expectation is that endpoints using `matchJWSURLs`
 	// have received at least one of their JWS from calling validPOSTForAccount(),
@@ -307,22 +301,20 @@ func (wfe *WebFrontEndImpl) matchJWSURLs(outer, inner jose.Header) *probs.Proble
 	outerURL, ok := outer.ExtraHeaders[jose.HeaderKey("url")].(string)
 	if !ok || len(outerURL) == 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverOuterJWSNoURL"}).Inc()
-		return probs.Malformed("Outer JWS header parameter 'url' required")
+		return berrors.MalformedError("Outer JWS header parameter 'url' required")
 	}
 
 	// Verify the inner JWS has a non-empty URL header.
 	innerURL, ok := inner.ExtraHeaders[jose.HeaderKey("url")].(string)
 	if !ok || len(innerURL) == 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverInnerJWSNoURL"}).Inc()
-		return probs.Malformed("Inner JWS header parameter 'url' required")
+		return berrors.MalformedError("Inner JWS header parameter 'url' required")
 	}
 
 	// Verify that the outer URL matches the inner URL
 	if outerURL != innerURL {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverMismatchedURLs"}).Inc()
-		return probs.Malformed(fmt.Sprintf(
-			"Outer JWS 'url' value %q does not match inner JWS 'url' value %q",
-			outerURL, innerURL))
+		return berrors.MalformedError("Outer JWS 'url' value %q does not match inner JWS 'url' value %q", outerURL, innerURL)
 	}
 
 	return nil
@@ -337,9 +329,9 @@ type bJSONWebSignature struct {
 
 // parseJWS extracts a JSONWebSignature from a byte slice. If there is an error
 // reading the JWS or it is unacceptable (e.g. too many/too few signatures,
-// presence of unprotected headers) a problem is returned, otherwise a
+// presence of unprotected headers) a error is returned, otherwise a
 // *bJSONWebSignature is returned.
-func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*bJSONWebSignature, *probs.ProblemDetails) {
+func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*bJSONWebSignature, error) {
 	// Parse the raw JWS JSON to check that:
 	// * the unprotected Header field is not being used.
 	// * the "signatures" member isn't present, just "signature".
@@ -353,14 +345,14 @@ func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*bJSONWebSignature, *probs.Pr
 	err := json.Unmarshal(body, &unprotected)
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSUnmarshalFailed"}).Inc()
-		return nil, probs.Malformed("Parse error reading JWS")
+		return nil, berrors.MalformedError("Parse error reading JWS")
 	}
 
 	// ACME v2 never uses values from the unprotected JWS header. Reject JWS that
 	// include unprotected headers.
 	if unprotected.Header != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSUnprotectedHeaders"}).Inc()
-		return nil, probs.Malformed(
+		return nil, berrors.MalformedError(
 			"JWS \"header\" field not allowed. All headers must be in \"protected\" field")
 	}
 
@@ -368,7 +360,7 @@ func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*bJSONWebSignature, *probs.Pr
 	// mandatory "signature" field. Reject JWS that include the "signatures" array.
 	if len(unprotected.Signatures) > 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSMultiSig"}).Inc()
-		return nil, probs.Malformed(
+		return nil, berrors.MalformedError(
 			"JWS \"signatures\" field not allowed. Only the \"signature\" field should contain a signature")
 	}
 
@@ -378,29 +370,29 @@ func (wfe *WebFrontEndImpl) parseJWS(body []byte) (*bJSONWebSignature, *probs.Pr
 	parsedJWS, err := jose.ParseSigned(bodyStr, getSupportedAlgs())
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSParseError"}).Inc()
-		return nil, probs.Malformed("Parse error reading JWS")
+		return nil, berrors.MalformedError("Parse error reading JWS")
 	}
 	if len(parsedJWS.Signatures) > 1 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSTooManySignatures"}).Inc()
-		return nil, probs.Malformed("Too many signatures in POST body")
+		return nil, berrors.MalformedError("Too many signatures in POST body")
 	}
 	if len(parsedJWS.Signatures) == 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSNoSignatures"}).Inc()
-		return nil, probs.Malformed("POST JWS not signed")
+		return nil, berrors.MalformedError("POST JWS not signed")
 	}
 	if len(parsedJWS.Signatures) == 1 && len(parsedJWS.Signatures[0].Signature) == 0 {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSEmptySignature"}).Inc()
-		return nil, probs.Malformed("POST JWS not signed")
+		return nil, berrors.MalformedError("POST JWS not signed")
 	}
 
 	return &bJSONWebSignature{parsedJWS}, nil
 }
 
 // parseJWSRequest extracts a bJSONWebSignature from an HTTP POST request's body using parseJWS.
-func (wfe *WebFrontEndImpl) parseJWSRequest(request *http.Request) (*bJSONWebSignature, *probs.ProblemDetails) {
+func (wfe *WebFrontEndImpl) parseJWSRequest(request *http.Request) (*bJSONWebSignature, error) {
 	// Verify that the POST request has the expected headers
-	if prob := wfe.validPOSTRequest(request); prob != nil {
-		return nil, prob
+	if err := wfe.validPOSTRequest(request); err != nil {
+		return nil, err
 	}
 
 	// Read the POST request body's bytes. validPOSTRequest has already checked
@@ -408,40 +400,40 @@ func (wfe *WebFrontEndImpl) parseJWSRequest(request *http.Request) (*bJSONWebSig
 	bodyBytes, err := io.ReadAll(http.MaxBytesReader(nil, request.Body, maxRequestSize))
 	if err != nil {
 		if err.Error() == "http: request body too large" {
-			return nil, probs.Unauthorized("request body too large")
+			return nil, berrors.UnauthorizedError("request body too large")
 		}
 		wfe.stats.httpErrorCount.With(prometheus.Labels{"type": "UnableToReadReqBody"}).Inc()
-		return nil, probs.ServerInternal("unable to read request body")
+		return nil, errors.New("unable to read request body")
 	}
 
-	jws, prob := wfe.parseJWS(bodyBytes)
-	if prob != nil {
-		return nil, prob
+	jws, err := wfe.parseJWS(bodyBytes)
+	if err != nil {
+		return nil, err
 	}
 
 	return jws, nil
 }
 
 // extractJWK extracts a JWK from the protected headers of a bJSONWebSignature
-// or returns a problem. It expects that the JWS is using the embedded JWK style
+// or returns a error. It expects that the JWS is using the embedded JWK style
 // of authentication and does not contain an embedded Key ID. Callers should
 // have acquired the headers from a bJSONWebSignature returned by parseJWS to
 // ensure it has the correct number of signatures present.
-func (wfe *WebFrontEndImpl) extractJWK(header jose.Header) (*jose.JSONWebKey, *probs.ProblemDetails) {
+func (wfe *WebFrontEndImpl) extractJWK(header jose.Header) (*jose.JSONWebKey, error) {
 	// extractJWK expects the request to be using an embedded JWK auth type and
 	// to not contain the mutually exclusive KeyID.
-	if prob := wfe.enforceJWSAuthType(header, embeddedJWK); prob != nil {
-		return nil, prob
+	if err := wfe.enforceJWSAuthType(header, embeddedJWK); err != nil {
+		return nil, err
 	}
 
 	// We can be sure that JSONWebKey is != nil because we have already called
 	// enforceJWSAuthType()
 	key := header.JSONWebKey
 
-	// If the key isn't considered valid by go-jose return a problem immediately
+	// If the key isn't considered valid by go-jose return a error immediately
 	if !key.Valid() {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWKInvalid"}).Inc()
-		return nil, probs.Malformed("Invalid JWK in JWS header")
+		return nil, berrors.MalformedError("Invalid JWK in JWS header")
 	}
 
 	return key, nil
@@ -449,8 +441,8 @@ func (wfe *WebFrontEndImpl) extractJWK(header jose.Header) (*jose.JSONWebKey, *p
 
 // acctIDFromURL extracts the numeric int64 account ID from a ACMEv1 or ACMEv2
 // account URL. If the acctURL has an invalid URL or the account ID in the
-// acctURL is non-numeric a MalformedProblem is returned.
-func (wfe *WebFrontEndImpl) acctIDFromURL(acctURL string, request *http.Request) (int64, *probs.ProblemDetails) {
+// acctURL is non-numeric a MalformedError is returned.
+func (wfe *WebFrontEndImpl) acctIDFromURL(acctURL string, request *http.Request) (int64, error) {
 	// For normal ACME v2 accounts we expect the account URL has a prefix composed
 	// of the Host header and the acctPath.
 	expectedURLPrefix := web.RelativeEndpoint(request, acctPath)
@@ -465,65 +457,62 @@ func (wfe *WebFrontEndImpl) acctIDFromURL(acctURL string, request *http.Request)
 	} else if strings.HasPrefix(acctURL, wfe.LegacyKeyIDPrefix) {
 		accountIDStr = strings.TrimPrefix(acctURL, wfe.LegacyKeyIDPrefix)
 	} else {
-		return 0, probs.Malformed(
-			fmt.Sprintf("KeyID header contained an invalid account URL: %q", acctURL))
+		return 0, berrors.MalformedError("KeyID header contained an invalid account URL: %q", acctURL)
 	}
 
 	// Convert the raw account ID string to an int64 for use with the SA's
 	// GetRegistration RPC
 	accountID, err := strconv.ParseInt(accountIDStr, 10, 64)
 	if err != nil {
-		return 0, probs.Malformed("Malformed account ID in KeyID header URL: %q", acctURL)
+		return 0, berrors.MalformedError("Malformed account ID in KeyID header URL: %q", acctURL)
 	}
 	return accountID, nil
 }
 
 // lookupJWK finds a JWK associated with the Key ID present in the provided
 // headers, returning the JWK and a pointer to the associated account, or a
-// problem. It expects that the JWS header is using the embedded Key ID style of
+// error. It expects that the JWS header is using the embedded Key ID style of
 // authentication and does not contain an embedded JWK. Callers should have
 // acquired headers from a bJSONWebSignature.
 func (wfe *WebFrontEndImpl) lookupJWK(
 	header jose.Header,
 	ctx context.Context,
 	request *http.Request,
-	logEvent *web.RequestEvent) (*jose.JSONWebKey, *core.Registration, *probs.ProblemDetails) {
+	logEvent *web.RequestEvent) (*jose.JSONWebKey, *core.Registration, error) {
 	// We expect the request to be using an embedded Key ID auth type and to not
 	// contain the mutually exclusive embedded JWK.
-	if prob := wfe.enforceJWSAuthType(header, embeddedKeyID); prob != nil {
-		return nil, nil, prob
+	if err := wfe.enforceJWSAuthType(header, embeddedKeyID); err != nil {
+		return nil, nil, err
 	}
 
 	accountURL := header.KeyID
-	accountID, prob := wfe.acctIDFromURL(accountURL, request)
-	if prob != nil {
+	accountID, err := wfe.acctIDFromURL(accountURL, request)
+	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSInvalidKeyID"}).Inc()
-		return nil, nil, prob
+		return nil, nil, err
 	}
 
 	// Try to find the account for this account ID
 	account, err := wfe.accountGetter.GetRegistration(ctx, &sapb.RegistrationID{Id: accountID})
 	if err != nil {
-		// If the account isn't found, return a suitable problem
+		// If the account isn't found, return a suitable error
 		if errors.Is(err, berrors.NotFound) {
 			wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDNotFound"}).Inc()
-			return nil, nil, probs.AccountDoesNotExist(fmt.Sprintf(
-				"Account %q not found", accountURL))
+			return nil, nil, berrors.AccountDoesNotExistError("Account %q not found", accountURL)
 		}
 
 		// If there was an error and it isn't a "Not Found" error, return
-		// a ServerInternal problem since this is unexpected.
+		// a ServerInternal error since this is unexpected.
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDLookupFailed"}).Inc()
 		// Add an error to the log event with the internal error message
 		logEvent.AddError("calling SA.GetRegistration: %s", err)
-		return nil, nil, web.ProblemDetailsForError(err, fmt.Sprintf("Error retrieving account %q", accountURL))
+		return nil, nil, berrors.InternalServerError("Error retrieving account %q: %s", accountURL, err)
 	}
 
 	// Verify the account is not deactivated
 	if core.AcmeStatus(account.Status) != core.StatusValid {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSKeyIDAccountInvalid"}).Inc()
-		return nil, nil, probs.Unauthorized(
-			fmt.Sprintf("Account is not valid, has status %q", account.Status))
+		return nil, nil, berrors.UnauthorizedError("Account is not valid, has status %q", account.Status)
 	}
 
 	// Update the logEvent with the account information and return the JWK
@@ -531,8 +520,7 @@ func (wfe *WebFrontEndImpl) lookupJWK(
 
 	acct, err := grpc.PbToRegistration(account)
 	if err != nil {
-		return nil, nil, probs.ServerInternal(fmt.Sprintf(
-			"Error unmarshalling account %q", accountURL))
+		return nil, nil, fmt.Errorf("error unmarshalling account %q: %w", accountURL, err)
 	}
 	return acct.Key, &acct, nil
 }
@@ -547,11 +535,11 @@ func (wfe *WebFrontEndImpl) validJWSForKey(
 	ctx context.Context,
 	jws *bJSONWebSignature,
 	jwk *jose.JSONWebKey,
-	request *http.Request) ([]byte, *probs.ProblemDetails) {
+	request *http.Request) ([]byte, error) {
 	err := checkAlgorithm(jwk, jws.Signatures[0].Header)
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSAlgorithmCheckFailed"}).Inc()
-		return nil, probs.BadSignatureAlgorithm(err.Error())
+		return nil, err
 	}
 
 	// Verify the JWS signature with the public key.
@@ -563,17 +551,17 @@ func (wfe *WebFrontEndImpl) validJWSForKey(
 	payload, err := jws.Verify(jwk)
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSVerifyFailed"}).Inc()
-		return nil, probs.Malformed("JWS verification error")
+		return nil, berrors.MalformedError("JWS verification error")
 	}
 
 	// Check that the JWS contains a correct Nonce header
-	if prob := wfe.validNonce(ctx, jws.Signatures[0].Header); prob != nil {
-		return nil, prob
+	if err := wfe.validNonce(ctx, jws.Signatures[0].Header); err != nil {
+		return nil, err
 	}
 
 	// Check that the HTTP request URL matches the URL in the signed JWS
-	if prob := wfe.validPOSTURL(request, jws.Signatures[0].Header); prob != nil {
-		return nil, prob
+	if err := wfe.validPOSTURL(request, jws.Signatures[0].Header); err != nil {
+		return nil, err
 	}
 
 	// In the WFE1 package the check for the request URL required unmarshalling
@@ -585,7 +573,7 @@ func (wfe *WebFrontEndImpl) validJWSForKey(
 	err = json.Unmarshal(payload, &parsedBody)
 	if string(payload) != "" && err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWSBodyUnmarshalFailed"}).Inc()
-		return nil, probs.Malformed("Request payload did not parse as JSON")
+		return nil, berrors.MalformedError("Request payload did not parse as JSON")
 	}
 
 	return payload, nil
@@ -597,22 +585,22 @@ func (wfe *WebFrontEndImpl) validJWSForKey(
 // specified key ID, specifies the correct URL, and has a valid nonce) then
 // `validJWSForAccount` returns the validated JWS body, the parsed
 // JSONWebSignature, and a pointer to the JWK's associated account. If any of
-// these conditions are not met or an error occurs only a problem is returned.
+// these conditions are not met or an error occurs only a error is returned.
 func (wfe *WebFrontEndImpl) validJWSForAccount(
 	jws *bJSONWebSignature,
 	request *http.Request,
 	ctx context.Context,
-	logEvent *web.RequestEvent) ([]byte, *bJSONWebSignature, *core.Registration, *probs.ProblemDetails) {
+	logEvent *web.RequestEvent) ([]byte, *bJSONWebSignature, *core.Registration, error) {
 	// Lookup the account and JWK for the key ID that authenticated the JWS
-	pubKey, account, prob := wfe.lookupJWK(jws.Signatures[0].Header, ctx, request, logEvent)
-	if prob != nil {
-		return nil, nil, nil, prob
+	pubKey, account, err := wfe.lookupJWK(jws.Signatures[0].Header, ctx, request, logEvent)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	// Verify the JWS with the JWK from the SA
-	payload, prob := wfe.validJWSForKey(ctx, jws, pubKey, request)
-	if prob != nil {
-		return nil, nil, nil, prob
+	payload, err := wfe.validJWSForKey(ctx, jws, pubKey, request)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	return payload, jws, account, nil
@@ -620,17 +608,17 @@ func (wfe *WebFrontEndImpl) validJWSForAccount(
 
 // validPOSTForAccount checks that a given POST request has a valid JWS
 // using `validJWSForAccount`. If valid, the authenticated JWS body and the
-// registration that authenticated the body are returned. Otherwise a problem is
+// registration that authenticated the body are returned. Otherwise a error is
 // returned. The returned JWS body may be empty if the request is a POST-as-GET
 // request.
 func (wfe *WebFrontEndImpl) validPOSTForAccount(
 	request *http.Request,
 	ctx context.Context,
-	logEvent *web.RequestEvent) ([]byte, *bJSONWebSignature, *core.Registration, *probs.ProblemDetails) {
+	logEvent *web.RequestEvent) ([]byte, *bJSONWebSignature, *core.Registration, error) {
 	// Parse the JWS from the POST request
-	jws, prob := wfe.parseJWSRequest(request)
-	if prob != nil {
-		return nil, nil, nil, prob
+	jws, err := wfe.parseJWSRequest(request)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	return wfe.validJWSForAccount(jws, request, ctx, logEvent)
 }
@@ -639,27 +627,27 @@ func (wfe *WebFrontEndImpl) validPOSTForAccount(
 // `validPOSTForAccount`. It additionally validates that the JWS request payload
 // is empty, indicating that it is a POST-as-GET request per ACME draft 15+
 // section 6.3 "GET and POST-as-GET requests". If a non empty payload is
-// provided in the JWS the invalidPOSTAsGETErr problem is returned. This
+// provided in the JWS the invalidPOSTAsGETErr error is returned. This
 // function is useful only for endpoints that do not need to handle both POSTs
 // with a body and POST-as-GET requests (e.g. Order, Certificate).
 func (wfe *WebFrontEndImpl) validPOSTAsGETForAccount(
 	request *http.Request,
 	ctx context.Context,
-	logEvent *web.RequestEvent) (*core.Registration, *probs.ProblemDetails) {
+	logEvent *web.RequestEvent) (*core.Registration, error) {
 	// Call validPOSTForAccount to verify the JWS and extract the body.
-	body, _, reg, prob := wfe.validPOSTForAccount(request, ctx, logEvent)
-	if prob != nil {
-		return nil, prob
+	body, _, reg, err := wfe.validPOSTForAccount(request, ctx, logEvent)
+	if err != nil {
+		return nil, err
 	}
 	// Verify the POST-as-GET payload is empty
 	if string(body) != "" {
-		return nil, probs.Malformed("POST-as-GET requests must have an empty payload")
+		return nil, berrors.MalformedError("POST-as-GET requests must have an empty payload")
 	}
 	// To make log analysis easier we choose to elevate the pseudo ACME HTTP
 	// method "POST-as-GET" to the logEvent's Method, replacing the
 	// http.MethodPost value.
 	logEvent.Method = "POST-as-GET"
-	return reg, prob
+	return reg, err
 }
 
 // validSelfAuthenticatedJWS checks that a given JWS verifies with the JWK
@@ -672,7 +660,7 @@ func (wfe *WebFrontEndImpl) validPOSTAsGETForAccount(
 // embedded in it, has the correct URL, and includes a valid nonce) then
 // `validSelfAuthenticatedJWS` returns the validated JWS body and the JWK that
 // was embedded in the JWS. Otherwise if the valid JWS conditions are not met or
-// an error occurs only a problem is returned.
+// an error occurs only a error is returned.
 // Note that this function does *not* enforce that the JWK abides by our goodkey
 // policies. This is because this method is used by the RevokeCertificate path,
 // which must allow JWKs which are signed by blocklisted (i.e. already revoked
@@ -681,17 +669,17 @@ func (wfe *WebFrontEndImpl) validPOSTAsGETForAccount(
 func (wfe *WebFrontEndImpl) validSelfAuthenticatedJWS(
 	ctx context.Context,
 	jws *bJSONWebSignature,
-	request *http.Request) ([]byte, *jose.JSONWebKey, *probs.ProblemDetails) {
+	request *http.Request) ([]byte, *jose.JSONWebKey, error) {
 	// Extract the embedded JWK from the parsed protected JWS' headers
-	pubKey, prob := wfe.extractJWK(jws.Signatures[0].Header)
-	if prob != nil {
-		return nil, nil, prob
+	pubKey, err := wfe.extractJWK(jws.Signatures[0].Header)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Verify the JWS with the embedded JWK
-	payload, prob := wfe.validJWSForKey(ctx, jws, pubKey, request)
-	if prob != nil {
-		return nil, nil, prob
+	payload, err := wfe.validJWSForKey(ctx, jws, pubKey, request)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return payload, pubKey, nil
@@ -702,27 +690,27 @@ func (wfe *WebFrontEndImpl) validSelfAuthenticatedJWS(
 // goodkey policies (key algorithm, length, blocklist, etc).
 func (wfe *WebFrontEndImpl) validSelfAuthenticatedPOST(
 	ctx context.Context,
-	request *http.Request) ([]byte, *jose.JSONWebKey, *probs.ProblemDetails) {
+	request *http.Request) ([]byte, *jose.JSONWebKey, error) {
 	// Parse the JWS from the POST request
-	jws, prob := wfe.parseJWSRequest(request)
-	if prob != nil {
-		return nil, nil, prob
+	jws, err := wfe.parseJWSRequest(request)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Extract and validate the embedded JWK from the parsed JWS
-	payload, pubKey, prob := wfe.validSelfAuthenticatedJWS(ctx, jws, request)
-	if prob != nil {
-		return nil, nil, prob
+	payload, pubKey, err := wfe.validSelfAuthenticatedJWS(ctx, jws, request)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// If the key doesn't meet the GoodKey policy return a problem
-	err := wfe.keyPolicy.GoodKey(ctx, pubKey.Key)
+	// If the key doesn't meet the GoodKey policy return a error
+	err = wfe.keyPolicy.GoodKey(ctx, pubKey.Key)
 	if err != nil {
 		if errors.Is(err, goodkey.ErrBadKey) {
 			wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "JWKRejectedByGoodKey"}).Inc()
-			return nil, nil, probs.BadPublicKey(err.Error())
+			return nil, nil, berrors.BadPublicKeyError("invalid request signing key: %s", err.Error())
 		}
-		return nil, nil, probs.ServerInternal("internal error while checking JWK")
+		return nil, nil, berrors.InternalServerError("internal error while checking JWK: %s", err)
 	}
 
 	return payload, pubKey, nil
@@ -757,7 +745,7 @@ type rolloverOperation struct {
 // field will be set to the JWK from the inner JWS.
 //
 // If the request is valid a *rolloverOperation object is returned,
-// otherwise a problem is returned. The caller is left to verify
+// otherwise a error is returned. The caller is left to verify
 // whether the new key is appropriate (e.g. isn't being used by another existing
 // account) and that the account field of the rollover object matches the
 // account that verified the outer JWS.
@@ -765,25 +753,25 @@ func (wfe *WebFrontEndImpl) validKeyRollover(
 	ctx context.Context,
 	outerJWS *bJSONWebSignature,
 	innerJWS *bJSONWebSignature,
-	oldKey *jose.JSONWebKey) (*rolloverOperation, *probs.ProblemDetails) {
+	oldKey *jose.JSONWebKey) (*rolloverOperation, error) {
 
 	// Extract the embedded JWK from the inner JWS' protected headers
-	innerJWK, prob := wfe.extractJWK(innerJWS.Signatures[0].Header)
-	if prob != nil {
-		return nil, prob
+	innerJWK, err := wfe.extractJWK(innerJWS.Signatures[0].Header)
+	if err != nil {
+		return nil, err
 	}
 
-	// If the key doesn't meet the GoodKey policy return a problem immediately
-	err := wfe.keyPolicy.GoodKey(ctx, innerJWK.Key)
+	// If the key doesn't meet the GoodKey policy return a error immediately
+	err = wfe.keyPolicy.GoodKey(ctx, innerJWK.Key)
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverJWKRejectedByGoodKey"}).Inc()
-		return nil, probs.BadPublicKey(err.Error())
+		return nil, berrors.BadPublicKeyError("invalid request signing key: %s", err.Error())
 	}
 
 	// Check that the public key and JWS algorithms match expected
 	err = checkAlgorithm(innerJWK, innerJWS.Signatures[0].Header)
 	if err != nil {
-		return nil, probs.Malformed(err.Error())
+		return nil, err
 	}
 
 	// Verify the inner JWS signature with the public key from the embedded JWK.
@@ -793,38 +781,39 @@ func (wfe *WebFrontEndImpl) validKeyRollover(
 	innerPayload, err := innerJWS.Verify(innerJWK)
 	if err != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverJWSVerifyFailed"}).Inc()
-		return nil, probs.Malformed("Inner JWS does not verify with embedded JWK")
+		return nil, berrors.MalformedError("Inner JWS does not verify with embedded JWK")
 	}
 	// NOTE(@cpu): we do not stomp the web.RequestEvent's payload here since that is set
 	// from the outerJWS in validPOSTForAccount and contains the inner JWS and inner
 	// payload already.
 
 	// Verify that the outer and inner JWS protected URL headers match
-	if prob := wfe.matchJWSURLs(outerJWS.Signatures[0].Header, innerJWS.Signatures[0].Header); prob != nil {
-		return nil, prob
+	if err := wfe.matchJWSURLs(outerJWS.Signatures[0].Header, innerJWS.Signatures[0].Header); err != nil {
+		return nil, err
 	}
 
 	var req rolloverRequest
 	if json.Unmarshal(innerPayload, &req) != nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverUnmarshalFailed"}).Inc()
-		return nil, probs.Malformed(
-			"Inner JWS payload did not parse as JSON key rollover object")
+		return nil, berrors.MalformedError("Inner JWS payload did not parse as JSON key rollover object")
 	}
 
 	// If there's no oldkey specified fail before trying to use
 	// core.PublicKeyEqual on a nil argument.
 	if req.OldKey.Key == nil {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverWrongOldKey"}).Inc()
-		return nil, probs.Malformed("Inner JWS does not contain old key field matching current account key")
+		return nil, berrors.MalformedError("Inner JWS does not contain old key field matching current account key")
 	}
 
 	// We must validate that the inner JWS' rollover request specifies the correct
 	// oldKey.
-	if keysEqual, err := core.PublicKeysEqual(req.OldKey.Key, oldKey.Key); err != nil {
-		return nil, probs.Malformed("Unable to compare new and old keys: %s", err.Error())
-	} else if !keysEqual {
+	keysEqual, err := core.PublicKeysEqual(req.OldKey.Key, oldKey.Key)
+	if err != nil {
+		return nil, berrors.MalformedError("Unable to compare new and old keys: %s", err.Error())
+	}
+	if !keysEqual {
 		wfe.stats.joseErrorCount.With(prometheus.Labels{"type": "KeyRolloverWrongOldKey"}).Inc()
-		return nil, probs.Malformed("Inner JWS does not contain old key field matching current account key")
+		return nil, berrors.MalformedError("Inner JWS does not contain old key field matching current account key")
 	}
 
 	// Return a rolloverOperation populated with the validated old JWK, the

--- a/wfe2/verify_test.go
+++ b/wfe2/verify_test.go
@@ -7,8 +7,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -16,11 +18,11 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
+	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/goodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/grpc/noncebalancer"
 	noncepb "github.com/letsencrypt/boulder/nonce/proto"
-	"github.com/letsencrypt/boulder/probs"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/web"
@@ -496,7 +498,7 @@ func TestValidPOSTRequest(t *testing.T) {
 		Headers            map[string][]string
 		Body               *string
 		HTTPStatus         int
-		ProblemDetail      string
+		ErrorDetail        string
 		ErrorStatType      string
 		EnforceContentType bool
 	}{
@@ -505,7 +507,7 @@ func TestValidPOSTRequest(t *testing.T) {
 			Name:          "POST without a Content-Length header",
 			Headers:       nil,
 			HTTPStatus:    http.StatusLengthRequired,
-			ProblemDetail: "missing Content-Length header",
+			ErrorDetail:   "missing Content-Length header",
 			ErrorStatType: "ContentLengthRequired",
 		},
 		// POST requests with a Replay-Nonce header should produce a problem
@@ -517,7 +519,7 @@ func TestValidPOSTRequest(t *testing.T) {
 				"Content-Type":   {expectedJWSContentType},
 			},
 			HTTPStatus:    http.StatusBadRequest,
-			ProblemDetail: "HTTP requests should NOT contain Replay-Nonce header. Use JWS nonce field",
+			ErrorDetail:   "HTTP requests should NOT contain Replay-Nonce header. Use JWS nonce field",
 			ErrorStatType: "ReplayNonceOutsideJWS",
 		},
 		// POST requests without a body should produce a problem
@@ -528,7 +530,7 @@ func TestValidPOSTRequest(t *testing.T) {
 				"Content-Type":   {expectedJWSContentType},
 			},
 			HTTPStatus:    http.StatusBadRequest,
-			ProblemDetail: "No body on POST",
+			ErrorDetail:   "No body on POST",
 			ErrorStatType: "NoPOSTBody",
 		},
 		{
@@ -537,7 +539,7 @@ func TestValidPOSTRequest(t *testing.T) {
 				"Content-Length": dummyContentLength,
 			},
 			HTTPStatus: http.StatusUnsupportedMediaType,
-			ProblemDetail: fmt.Sprintf(
+			ErrorDetail: fmt.Sprintf(
 				"No Content-Type header on POST. Content-Type must be %q",
 				expectedJWSContentType),
 			ErrorStatType:      "NoContentType",
@@ -550,7 +552,7 @@ func TestValidPOSTRequest(t *testing.T) {
 				"Content-Type":   {"fresh.and.rare"},
 			},
 			HTTPStatus: http.StatusUnsupportedMediaType,
-			ProblemDetail: fmt.Sprintf(
+			ErrorDetail: fmt.Sprintf(
 				"Invalid Content-Type header on POST. Content-Type must be %q",
 				expectedJWSContentType),
 			ErrorStatType:      "WrongContentType",
@@ -565,11 +567,10 @@ func TestValidPOSTRequest(t *testing.T) {
 			Header: tc.Headers,
 		}
 		t.Run(tc.Name, func(t *testing.T) {
-			prob := wfe.validPOSTRequest(input)
-			test.Assert(t, prob != nil, "No error returned for invalid POST")
-			test.AssertEquals(t, prob.Type, probs.MalformedProblem)
-			test.AssertEquals(t, prob.HTTPStatus, tc.HTTPStatus)
-			test.AssertEquals(t, prob.Detail, tc.ProblemDetail)
+			err := wfe.validPOSTRequest(input)
+			test.AssertError(t, err, "No error returned for invalid POST")
+			test.AssertErrorIs(t, err, berrors.Malformed)
+			test.AssertContains(t, err.Error(), tc.ErrorDetail)
 			test.AssertMetricWithLabelsEquals(
 				t, wfe.stats.httpErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
 		})
@@ -605,71 +606,72 @@ func TestEnforceJWSAuthType(t *testing.T) {
 	}
 
 	testCases := []struct {
-		Name             string
-		JWS              *jose.JSONWebSignature
-		ExpectedAuthType jwsAuthType
-		ExpectedResult   *probs.ProblemDetails
-		ErrorStatType    string
+		Name          string
+		JWS           *jose.JSONWebSignature
+		AuthType      jwsAuthType
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name:             "Key ID and embedded JWS",
-			JWS:              conflictJWS,
-			ExpectedAuthType: invalidAuthType,
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "jwk and kid header fields are mutually exclusive",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSAuthTypeInvalid",
+			Name:          "Key ID and embedded JWS",
+			JWS:           conflictJWS,
+			AuthType:      invalidAuthType,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "jwk and kid header fields are mutually exclusive",
+			WantStatType:  "JWSAuthTypeInvalid",
 		},
 		{
-			Name:             "Key ID when expected is embedded JWK",
-			JWS:              testKeyIDJWS,
-			ExpectedAuthType: embeddedJWK,
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "No embedded JWK in JWS header",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSAuthTypeWrong",
+			Name:          "Key ID when expected is embedded JWK",
+			JWS:           testKeyIDJWS,
+			AuthType:      embeddedJWK,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "No embedded JWK in JWS header",
+			WantStatType:  "JWSAuthTypeWrong",
 		},
 		{
-			Name:             "Embedded JWK when expected is Key ID",
-			JWS:              testEmbeddedJWS,
-			ExpectedAuthType: embeddedKeyID,
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "No Key ID in JWS header",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSAuthTypeWrong",
+			Name:          "Embedded JWK when expected is Key ID",
+			JWS:           testEmbeddedJWS,
+			AuthType:      embeddedKeyID,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "No Key ID in JWS header",
+			WantStatType:  "JWSAuthTypeWrong",
 		},
 		{
-			Name:             "Key ID when expected is KeyID",
-			JWS:              testKeyIDJWS,
-			ExpectedAuthType: embeddedKeyID,
-			ExpectedResult:   nil,
+			Name:     "Key ID when expected is KeyID",
+			JWS:      testKeyIDJWS,
+			AuthType: embeddedKeyID,
 		},
 		{
-			Name:             "Embedded JWK when expected is embedded JWK",
-			JWS:              testEmbeddedJWS,
-			ExpectedAuthType: embeddedJWK,
-			ExpectedResult:   nil,
+			Name:     "Embedded JWK when expected is embedded JWK",
+			JWS:      testEmbeddedJWS,
+			AuthType: embeddedJWK,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
-			prob := wfe.enforceJWSAuthType(tc.JWS.Signatures[0].Header, tc.ExpectedAuthType)
-			if tc.ExpectedResult == nil && prob != nil {
-				t.Fatalf("Expected nil result, got %#v", prob)
+			in := tc.JWS.Signatures[0].Header
+
+			gotErr := wfe.enforceJWSAuthType(in, tc.AuthType)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("enforceJWSAuthType(%#v, %#v) = %#v, want nil", in, tc.AuthType, gotErr)
+				}
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedResult)
-			}
-			if tc.ErrorStatType != "" {
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("enforceJWSAuthType(%#v, %#v) returned %T, want BoulderError", in, tc.AuthType, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("enforceJWSAuthType(%#v, %#v) = %#v, want %#v", in, tc.AuthType, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("enforceJWSAuthType(%#v, %#v) = %q, want %q", in, tc.AuthType, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}
@@ -699,70 +701,69 @@ func TestValidNonce(t *testing.T) {
 	goodJWS, _, _ := signer.embeddedJWK(nil, "", "")
 
 	testCases := []struct {
-		Name           string
-		JWS            *jose.JSONWebSignature
-		ExpectedResult *probs.ProblemDetails
-		ErrorStatType  string
+		Name          string
+		JWS           *jose.JSONWebSignature
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name: "No nonce in JWS",
-			JWS:  signer.missingNonce(),
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.BadNonceProblem,
-				Detail:     "JWS has no anti-replay nonce",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMissingNonce",
+			Name:          "No nonce in JWS",
+			JWS:           signer.missingNonce(),
+			WantErrType:   berrors.BadNonce,
+			WantErrDetail: "JWS has no anti-replay nonce",
+			WantStatType:  "JWSMissingNonce",
 		},
 		{
-			Name: "Malformed nonce in JWS",
-			JWS:  signer.malformedNonce(),
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.BadNonceProblem,
-				Detail:     "JWS has an invalid anti-replay nonce: \"im-a-nonce\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMalformedNonce",
+			Name:          "Malformed nonce in JWS",
+			JWS:           signer.malformedNonce(),
+			WantErrType:   berrors.BadNonce,
+			WantErrDetail: "JWS has an invalid anti-replay nonce: \"im-a-nonce\"",
+			WantStatType:  "JWSMalformedNonce",
 		},
 		{
-			Name: "Canned nonce shorter than prefixLength in JWS",
-			JWS:  signer.shortNonce(),
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.BadNonceProblem,
-				Detail:     "JWS has an invalid anti-replay nonce: \"woww\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMalformedNonce",
+			Name:          "Canned nonce shorter than prefixLength in JWS",
+			JWS:           signer.shortNonce(),
+			WantErrType:   berrors.BadNonce,
+			WantErrDetail: "JWS has an invalid anti-replay nonce: \"woww\"",
+			WantStatType:  "JWSMalformedNonce",
 		},
 		{
-			Name: "Invalid nonce in JWS (test/config-next)",
-			JWS:  signer.invalidNonce(),
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.BadNonceProblem,
-				Detail:     "JWS has an invalid anti-replay nonce: \"mlolmlol3ov77I5Ui-cdaY_k8IcjK58FvbG0y_BCRrx5rGQ8rjA\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSInvalidNonce",
+			Name:          "Invalid nonce in JWS (test/config-next)",
+			JWS:           signer.invalidNonce(),
+			WantErrType:   berrors.BadNonce,
+			WantErrDetail: "JWS has an invalid anti-replay nonce: \"mlolmlol3ov77I5Ui-cdaY_k8IcjK58FvbG0y_BCRrx5rGQ8rjA\"",
+			WantStatType:  "JWSInvalidNonce",
 		},
 		{
-			Name:           "Valid nonce in JWS",
-			JWS:            goodJWS,
-			ExpectedResult: nil,
+			Name: "Valid nonce in JWS",
+			JWS:  goodJWS,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
+			in := tc.JWS.Signatures[0].Header
 			wfe.stats.joseErrorCount.Reset()
-			prob := wfe.validNonce(context.Background(), tc.JWS.Signatures[0].Header)
-			if tc.ExpectedResult == nil && prob != nil {
-				t.Fatalf("Expected nil result, got %#v", prob)
+
+			gotErr := wfe.validNonce(context.Background(), in)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("validNonce(%#v) = %#v, want nil", in, gotErr)
+				}
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedResult)
-			}
-			if tc.ErrorStatType != "" {
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("validNonce(%#v) returned %T, want BoulderError", in, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("validNonce(%#v) = %#v, want %#v", in, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("validNonce(%#v) = %q, want %q", in, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}
@@ -783,11 +784,10 @@ func TestValidNonce_NoMatchingBackendFound(t *testing.T) {
 
 	// A valid JWS with a nonce whose prefix matches no known nonce provider should
 	// result in a BadNonceProblem.
-	prob := wfe.validNonce(context.Background(), goodJWS.Signatures[0].Header)
-	test.Assert(t, prob != nil, "Expected error for valid nonce with no backend")
-	test.AssertEquals(t, prob.Type, probs.BadNonceProblem)
-	test.AssertEquals(t, prob.HTTPStatus, http.StatusBadRequest)
-	test.AssertContains(t, prob.Detail, "JWS has an invalid anti-replay nonce")
+	err := wfe.validNonce(context.Background(), goodJWS.Signatures[0].Header)
+	test.AssertError(t, err, "Expected error for valid nonce with no backend")
+	test.AssertErrorIs(t, err, berrors.BadNonce)
+	test.AssertContains(t, err.Error(), "JWS has an invalid anti-replay nonce")
 	test.AssertMetricWithLabelsEquals(t, wfe.stats.nonceNoMatchingBackendCount, prometheus.Labels{}, 1)
 }
 
@@ -844,66 +844,68 @@ func TestValidPOSTURL(t *testing.T) {
 	correctURLHeaderRequest := makePostRequestWithPath("test-path", correctURLHeaderJWSBody)
 
 	testCases := []struct {
-		Name           string
-		JWS            *jose.JSONWebSignature
-		Request        *http.Request
-		ExpectedResult *probs.ProblemDetails
-		ErrorStatType  string
+		Name          string
+		JWS           *jose.JSONWebSignature
+		Request       *http.Request
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name:    "No extra headers in JWS",
-			JWS:     noHeadersJWS,
-			Request: noHeadersRequest,
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS header parameter 'url' required",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSNoExtraHeaders",
+			Name:          "No extra headers in JWS",
+			JWS:           noHeadersJWS,
+			Request:       noHeadersRequest,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS header parameter 'url' required",
+			WantStatType:  "JWSNoExtraHeaders",
 		},
 		{
-			Name:    "No URL header in JWS",
-			JWS:     noURLHeaderJWS,
-			Request: noURLHeaderRequest,
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS header parameter 'url' required",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMissingURL",
+			Name:          "No URL header in JWS",
+			JWS:           noURLHeaderJWS,
+			Request:       noURLHeaderRequest,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS header parameter 'url' required",
+			WantStatType:  "JWSMissingURL",
 		},
 		{
-			Name:    "Wrong URL header in JWS",
-			JWS:     wrongURLHeaderJWS,
-			Request: wrongURLHeaderRequest,
-			ExpectedResult: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS header parameter 'url' incorrect. Expected \"http://localhost/test-path\" got \"foobar\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMismatchedURL",
+			Name:          "Wrong URL header in JWS",
+			JWS:           wrongURLHeaderJWS,
+			Request:       wrongURLHeaderRequest,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS header parameter 'url' incorrect. Expected \"http://localhost/test-path\" got \"foobar\"",
+			WantStatType:  "JWSMismatchedURL",
 		},
 		{
-			Name:           "Correct URL header in JWS",
-			JWS:            correctURLHeaderJWS,
-			Request:        correctURLHeaderRequest,
-			ExpectedResult: nil,
+			Name:    "Correct URL header in JWS",
+			JWS:     correctURLHeaderJWS,
+			Request: correctURLHeaderRequest,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
+			in := tc.JWS.Signatures[0].Header
 			tc.Request.Header.Add("Content-Type", expectedJWSContentType)
 			wfe.stats.joseErrorCount.Reset()
-			prob := wfe.validPOSTURL(tc.Request, tc.JWS.Signatures[0].Header)
-			if tc.ExpectedResult == nil && prob != nil {
-				t.Fatalf("Expected nil result, got %#v", prob)
+
+			got := wfe.validPOSTURL(tc.Request, in)
+			if tc.WantErrDetail == "" {
+				if got != nil {
+					t.Fatalf("validPOSTURL(%#v) = %#v, want nil", in, got)
+				}
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedResult)
-			}
-			if tc.ErrorStatType != "" {
+				berr, ok := got.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("validPOSTURL(%#v) returned %T, want BoulderError", in, got)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("validPOSTURL(%#v) = %#v, want %#v", in, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("validPOSTURL(%#v) = %q, want %q", in, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}
@@ -973,10 +975,11 @@ func TestParseJWSRequest(t *testing.T) {
 `
 
 	testCases := []struct {
-		Name            string
-		Request         *http.Request
-		ExpectedProblem *probs.ProblemDetails
-		ErrorStatType   string
+		Name          string
+		Request       *http.Request
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
 			Name: "Invalid POST request",
@@ -985,91 +988,80 @@ func TestParseJWSRequest(t *testing.T) {
 				Method: "POST",
 				URL:    mustParseURL("/"),
 			},
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "missing Content-Length header",
-				HTTPStatus: http.StatusLengthRequired,
-			},
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "missing Content-Length header",
 		},
 		{
-			Name:    "Invalid JWS in POST body",
-			Request: makePostRequestWithPath("test-path", `{`),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Parse error reading JWS",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSUnmarshalFailed",
+			Name:          "Invalid JWS in POST body",
+			Request:       makePostRequestWithPath("test-path", `{`),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Parse error reading JWS",
+			WantStatType:  "JWSUnmarshalFailed",
 		},
 		{
-			Name:    "Too few signatures in JWS",
-			Request: missingSigsJWSRequest,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "POST JWS not signed",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSEmptySignature",
+			Name:          "Too few signatures in JWS",
+			Request:       missingSigsJWSRequest,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "POST JWS not signed",
+			WantStatType:  "JWSEmptySignature",
 		},
 		{
-			Name:    "Too many signatures in JWS",
-			Request: makePostRequestWithPath("test-path", tooManySigsJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS \"signatures\" field not allowed. Only the \"signature\" field should contain a signature",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMultiSig",
+			Name:          "Too many signatures in JWS",
+			Request:       makePostRequestWithPath("test-path", tooManySigsJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS \"signatures\" field not allowed. Only the \"signature\" field should contain a signature",
+			WantStatType:  "JWSMultiSig",
 		},
 		{
-			Name:    "Unprotected JWS headers",
-			Request: makePostRequestWithPath("test-path", unprotectedHeadersJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS \"header\" field not allowed. All headers must be in \"protected\" field",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSUnprotectedHeaders",
+			Name:          "Unprotected JWS headers",
+			Request:       makePostRequestWithPath("test-path", unprotectedHeadersJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS \"header\" field not allowed. All headers must be in \"protected\" field",
+			WantStatType:  "JWSUnprotectedHeaders",
 		},
 		{
-			Name:    "Unsupported signatures field in JWS",
-			Request: makePostRequestWithPath("test-path", wrongSignaturesFieldJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS \"signatures\" field not allowed. Only the \"signature\" field should contain a signature",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMultiSig",
+			Name:          "Unsupported signatures field in JWS",
+			Request:       makePostRequestWithPath("test-path", wrongSignaturesFieldJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS \"signatures\" field not allowed. Only the \"signature\" field should contain a signature",
+			WantStatType:  "JWSMultiSig",
 		},
 		{
-			Name:            "Valid JWS in POST request",
-			Request:         validJWSRequest,
-			ExpectedProblem: nil,
+			Name:    "Valid JWS in POST request",
+			Request: validJWSRequest,
 		},
 		{
-			Name: "POST body too large",
-			Request: makePostRequestWithPath("test-path",
-				fmt.Sprintf(`{"a":"%s"}`, strings.Repeat("a", 50000))),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.UnauthorizedProblem,
-				Detail:     "request body too large",
-				HTTPStatus: http.StatusForbidden,
-			},
+			Name:          "POST body too large",
+			Request:       makePostRequestWithPath("test-path", fmt.Sprintf(`{"a":"%s"}`, strings.Repeat("a", 50000))),
+			WantErrType:   berrors.Unauthorized,
+			WantErrDetail: "request body too large",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
-			_, prob := wfe.parseJWSRequest(tc.Request)
-			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatalf("Expected nil problem, got %#v\n", prob)
+
+			_, gotErr := wfe.parseJWSRequest(tc.Request)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("parseJWSRequest(%#v) = %#v, want nil", tc.Request, gotErr)
+				}
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-			}
-			if tc.ErrorStatType != "" {
-				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("parseJWSRequest(%#v) returned %T, want BoulderError", tc.Request, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("parseJWSRequest(%#v) = %#v, want %#v", tc.Request, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("parseJWSRequest(%#v) = %q, want %q", tc.Request, berr.Detail, tc.WantErrDetail)
+				}
+				if tc.WantStatType != "" {
+					test.AssertMetricWithLabelsEquals(
+						t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
+				}
 			}
 		})
 	}
@@ -1082,36 +1074,46 @@ func TestExtractJWK(t *testing.T) {
 	goodJWS, goodJWK, _ := signer.embeddedJWK(nil, "", "")
 
 	testCases := []struct {
-		Name            string
-		JWS             *jose.JSONWebSignature
-		ExpectedKey     *jose.JSONWebKey
-		ExpectedProblem *probs.ProblemDetails
+		Name          string
+		JWS           *jose.JSONWebSignature
+		WantKey       *jose.JSONWebKey
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
 	}{
 		{
-			Name: "JWS with wrong auth type (Key ID vs embedded JWK)",
-			JWS:  keyIDJWS,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "No embedded JWK in JWS header",
-				HTTPStatus: http.StatusBadRequest,
-			},
+			Name:          "JWS with wrong auth type (Key ID vs embedded JWK)",
+			JWS:           keyIDJWS,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "No embedded JWK in JWS header",
 		},
 		{
-			Name:        "Valid JWS with embedded JWK",
-			JWS:         goodJWS,
-			ExpectedKey: goodJWK,
+			Name:    "Valid JWS with embedded JWK",
+			JWS:     goodJWS,
+			WantKey: goodJWK,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			jwkHeader, prob := wfe.extractJWK(tc.JWS.Signatures[0].Header)
-			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatalf("Expected nil problem, got %#v\n", prob)
-			} else if tc.ExpectedProblem == nil {
-				test.AssertMarshaledEquals(t, jwkHeader, tc.ExpectedKey)
+			in := tc.JWS.Signatures[0].Header
+
+			gotKey, gotErr := wfe.extractJWK(in)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("extractJWK(%#v) = %#v, want nil", in, gotKey)
+				}
+				test.AssertMarshaledEquals(t, gotKey, tc.WantKey)
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("extractJWK(%#v) returned %T, want BoulderError", in, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("extractJWK(%#v) = %#v, want %#v", in, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("extractJWK(%#v) = %q, want %q", in, berr.Detail, tc.WantErrDetail)
+				}
 			}
 		})
 	}
@@ -1179,114 +1181,110 @@ func TestLookupJWK(t *testing.T) {
 	// good key, log event requester is set
 
 	testCases := []struct {
-		Name            string
-		JWS             *jose.JSONWebSignature
-		Request         *http.Request
-		ExpectedProblem *probs.ProblemDetails
-		ExpectedKey     *jose.JSONWebKey
-		ExpectedAccount *core.Registration
-		ErrorStatType   string
+		Name          string
+		JWS           *jose.JSONWebSignature
+		Request       *http.Request
+		WantJWK       *jose.JSONWebKey
+		WantAccount   *core.Registration
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name:    "JWS with wrong auth type (embedded JWK vs Key ID)",
-			JWS:     embeddedJWS,
-			Request: makePostRequestWithPath("test-path", embeddedJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "No Key ID in JWS header",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSAuthTypeWrong",
+			Name:          "JWS with wrong auth type (embedded JWK vs Key ID)",
+			JWS:           embeddedJWS,
+			Request:       makePostRequestWithPath("test-path", embeddedJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "No Key ID in JWS header",
+			WantStatType:  "JWSAuthTypeWrong",
 		},
 		{
-			Name:    "JWS with invalid key ID URL",
-			JWS:     invalidKeyIDJWS,
-			Request: makePostRequestWithPath("test-path", invalidKeyIDJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "KeyID header contained an invalid account URL: \"https://acme-99.lettuceencrypt.org/acme/reg/1\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSInvalidKeyID",
+			Name:          "JWS with invalid key ID URL",
+			JWS:           invalidKeyIDJWS,
+			Request:       makePostRequestWithPath("test-path", invalidKeyIDJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "KeyID header contained an invalid account URL: \"https://acme-99.lettuceencrypt.org/acme/reg/1\"",
+			WantStatType:  "JWSInvalidKeyID",
 		},
 		{
-			Name:    "JWS with non-numeric account ID in key ID URL",
-			JWS:     nonNumericKeyIDJWS,
-			Request: makePostRequestWithPath("test-path", nonNumericKeyIDJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Malformed account ID in KeyID header URL: \"https://acme-v00.lettuceencrypt.org/acme/reg/abcd\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSInvalidKeyID",
+			Name:          "JWS with non-numeric account ID in key ID URL",
+			JWS:           nonNumericKeyIDJWS,
+			Request:       makePostRequestWithPath("test-path", nonNumericKeyIDJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Malformed account ID in KeyID header URL: \"https://acme-v00.lettuceencrypt.org/acme/reg/abcd\"",
+			WantStatType:  "JWSInvalidKeyID",
 		},
 		{
-			Name:    "JWS with account ID that causes GetRegistration error",
-			JWS:     errorIDJWS,
-			Request: makePostRequestWithPath("test-path", errorIDJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.ServerInternalProblem,
-				Detail:     "Error retrieving account \"http://localhost/acme/acct/100\"",
-				HTTPStatus: http.StatusInternalServerError,
-			},
-			ErrorStatType: "JWSKeyIDLookupFailed",
+			Name:          "JWS with account ID that causes GetRegistration error",
+			JWS:           errorIDJWS,
+			Request:       makePostRequestWithPath("test-path", errorIDJWSBody),
+			WantErrType:   berrors.InternalServer,
+			WantErrDetail: "Error retrieving account \"http://localhost/acme/acct/100\"",
+			WantStatType:  "JWSKeyIDLookupFailed",
 		},
 		{
-			Name:    "JWS with account ID that doesn't exist",
-			JWS:     missingIDJWS,
-			Request: makePostRequestWithPath("test-path", missingIDJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.AccountDoesNotExistProblem,
-				Detail:     "Account \"http://localhost/acme/acct/102\" not found",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSKeyIDNotFound",
+			Name:          "JWS with account ID that doesn't exist",
+			JWS:           missingIDJWS,
+			Request:       makePostRequestWithPath("test-path", missingIDJWSBody),
+			WantErrType:   berrors.AccountDoesNotExist,
+			WantErrDetail: "Account \"http://localhost/acme/acct/102\" not found",
+			WantStatType:  "JWSKeyIDNotFound",
 		},
 		{
-			Name:    "JWS with account ID that is deactivated",
-			JWS:     deactivatedIDJWS,
-			Request: makePostRequestWithPath("test-path", deactivatedIDJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.UnauthorizedProblem,
-				Detail:     "Account is not valid, has status \"deactivated\"",
-				HTTPStatus: http.StatusForbidden,
-			},
-			ErrorStatType: "JWSKeyIDAccountInvalid",
+			Name:          "JWS with account ID that is deactivated",
+			JWS:           deactivatedIDJWS,
+			Request:       makePostRequestWithPath("test-path", deactivatedIDJWSBody),
+			WantErrType:   berrors.Unauthorized,
+			WantErrDetail: "Account is not valid, has status \"deactivated\"",
+			WantStatType:  "JWSKeyIDAccountInvalid",
 		},
 		{
-			Name:            "Valid JWS with legacy account ID",
-			JWS:             legacyKeyIDJWS,
-			Request:         makePostRequestWithPath("test-path", legacyKeyIDJWSBody),
-			ExpectedKey:     validKey,
-			ExpectedAccount: &validAccount,
+			Name:        "Valid JWS with legacy account ID",
+			JWS:         legacyKeyIDJWS,
+			Request:     makePostRequestWithPath("test-path", legacyKeyIDJWSBody),
+			WantJWK:     validKey,
+			WantAccount: &validAccount,
 		},
 		{
-			Name:            "Valid JWS with valid account ID",
-			JWS:             validJWS,
-			Request:         makePostRequestWithPath("test-path", validJWSBody),
-			ExpectedKey:     validKey,
-			ExpectedAccount: &validAccount,
+			Name:        "Valid JWS with valid account ID",
+			JWS:         validJWS,
+			Request:     makePostRequestWithPath("test-path", validJWSBody),
+			WantJWK:     validKey,
+			WantAccount: &validAccount,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
+			in := tc.JWS.Signatures[0].Header
 			inputLogEvent := newRequestEvent()
-			jwkHeader, acct, prob := wfe.lookupJWK(tc.JWS.Signatures[0].Header, context.Background(), tc.Request, inputLogEvent)
-			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatalf("Expected nil problem, got %#v\n", prob)
-			} else if tc.ExpectedProblem == nil {
-				inThumb, _ := tc.ExpectedKey.Thumbprint(crypto.SHA256)
-				outThumb, _ := jwkHeader.Thumbprint(crypto.SHA256)
-				test.AssertDeepEquals(t, inThumb, outThumb)
-				test.AssertMarshaledEquals(t, acct, tc.ExpectedAccount)
-				test.AssertEquals(t, inputLogEvent.Requester, acct.ID)
+
+			gotJWK, gotAcct, gotErr := wfe.lookupJWK(in, context.Background(), tc.Request, inputLogEvent)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("lookupJWK(%#v) = %#v, want nil", in, gotErr)
+				}
+				gotThumb, _ := gotJWK.Thumbprint(crypto.SHA256)
+				wantThumb, _ := tc.WantJWK.Thumbprint(crypto.SHA256)
+				if !slices.Equal(gotThumb, wantThumb) {
+					t.Fatalf("lookupJWK(%#v) = %#v, want %#v", tc.Request, gotThumb, wantThumb)
+				}
+				test.AssertMarshaledEquals(t, gotAcct, tc.WantAccount)
+				test.AssertEquals(t, inputLogEvent.Requester, gotAcct.ID)
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-			}
-			if tc.ErrorStatType != "" {
+				var berr *berrors.BoulderError
+				ok := errors.As(gotErr, &berr)
+				if !ok {
+					t.Fatalf("lookupJWK(%#v) returned %T, want BoulderError", in, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("lookupJWK(%#v) = %#v, want %#v", in, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("lookupJWK(%#v) = %q, want %q", in, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}
@@ -1325,67 +1323,53 @@ func TestValidJWSForKey(t *testing.T) {
 	badJSONJWS, _, _ := signer.embeddedJWK(nil, testURL, `{`)
 
 	testCases := []struct {
-		Name            string
-		JWS             bJSONWebSignature
-		JWK             *jose.JSONWebKey
-		Body            string
-		ExpectedProblem *probs.ProblemDetails
-		ErrorStatType   string
+		Name          string
+		JWS           bJSONWebSignature
+		JWK           *jose.JSONWebKey
+		Body          string
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name: "JWS with an invalid algorithm",
-			JWS:  bJSONWebSignature{wrongAlgJWS},
-			JWK:  goodJWK,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.BadSignatureAlgorithmProblem,
-				Detail:     "JWS signature header contains unsupported algorithm \"HS256\", expected one of [RS256 ES256 ES384 ES512]",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSAlgorithmCheckFailed",
+			Name:          "JWS with an invalid algorithm",
+			JWS:           bJSONWebSignature{wrongAlgJWS},
+			JWK:           goodJWK,
+			WantErrType:   berrors.BadSignatureAlgorithm,
+			WantErrDetail: "JWS signature header contains unsupported algorithm \"HS256\", expected one of [RS256 ES256 ES384 ES512]",
+			WantStatType:  "JWSAlgorithmCheckFailed",
 		},
 		{
-			Name: "JWS with an invalid nonce (test/config-next)",
-			JWS:  bJSONWebSignature{signer.invalidNonce()},
-			JWK:  goodJWK,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.BadNonceProblem,
-				Detail:     "JWS has an invalid anti-replay nonce: \"mlolmlol3ov77I5Ui-cdaY_k8IcjK58FvbG0y_BCRrx5rGQ8rjA\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSInvalidNonce",
+			Name:          "JWS with an invalid nonce (test/config-next)",
+			JWS:           bJSONWebSignature{signer.invalidNonce()},
+			JWK:           goodJWK,
+			WantErrType:   berrors.BadNonce,
+			WantErrDetail: "JWS has an invalid anti-replay nonce: \"mlolmlol3ov77I5Ui-cdaY_k8IcjK58FvbG0y_BCRrx5rGQ8rjA\"",
+			WantStatType:  "JWSInvalidNonce",
 		},
 		{
-			Name: "JWS with broken signature",
-			JWS:  bJSONWebSignature{badJWS},
-			JWK:  badJWS.Signatures[0].Header.JSONWebKey,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS verification error",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSVerifyFailed",
+			Name:          "JWS with broken signature",
+			JWS:           bJSONWebSignature{badJWS},
+			JWK:           badJWS.Signatures[0].Header.JSONWebKey,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS verification error",
+			WantStatType:  "JWSVerifyFailed",
 		},
 		{
-			Name: "JWS with incorrect URL",
-			JWS:  bJSONWebSignature{wrongURLHeaderJWS},
-			JWK:  wrongURLHeaderJWS.Signatures[0].Header.JSONWebKey,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "JWS header parameter 'url' incorrect. Expected \"http://localhost/test\" got \"foobar\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSMismatchedURL",
+			Name:          "JWS with incorrect URL",
+			JWS:           bJSONWebSignature{wrongURLHeaderJWS},
+			JWK:           wrongURLHeaderJWS.Signatures[0].Header.JSONWebKey,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "JWS header parameter 'url' incorrect. Expected \"http://localhost/test\" got \"foobar\"",
+			WantStatType:  "JWSMismatchedURL",
 		},
 		{
-			Name: "Valid JWS with invalid JSON in the protected body",
-			JWS:  bJSONWebSignature{badJSONJWS},
-			JWK:  goodJWK,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Request payload did not parse as JSON",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSBodyUnmarshalFailed",
+			Name:          "Valid JWS with invalid JSON in the protected body",
+			JWS:           bJSONWebSignature{badJSONJWS},
+			JWK:           goodJWK,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Request payload did not parse as JSON",
+			WantStatType:  "JWSBodyUnmarshalFailed",
 		},
 		{
 			Name: "Good JWS and JWK",
@@ -1398,17 +1382,28 @@ func TestValidJWSForKey(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
 			request := makePostRequestWithPath("test", tc.Body)
-			outPayload, prob := wfe.validJWSForKey(context.Background(), &tc.JWS, tc.JWK, request)
-			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatalf("Expected nil problem, got %#v\n", prob)
-			} else if tc.ExpectedProblem == nil {
-				test.AssertEquals(t, string(outPayload), payload)
+
+			gotPayload, gotErr := wfe.validJWSForKey(context.Background(), &tc.JWS, tc.JWK, request)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("validJWSForKey(%#v, %#v, %#v) = %#v, want nil", tc.JWS, tc.JWK, request, gotErr)
+				}
+				if string(gotPayload) != payload {
+					t.Fatalf("validJWSForKey(%#v, %#v, %#v) = %q, want %q", tc.JWS, tc.JWK, request, string(gotPayload), payload)
+				}
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-			}
-			if tc.ErrorStatType != "" {
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("validJWSForKey(%#v, %#v, %#v) returned %T, want BoulderError", tc.JWS, tc.JWK, request, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("validJWSForKey(%#v, %#v, %#v) = %#v, want %#v", tc.JWS, tc.JWK, request, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("validJWSForKey(%#v, %#v, %#v) = %q, want %q", tc.JWS, tc.JWK, request, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}
@@ -1431,60 +1426,49 @@ func TestValidPOSTForAccount(t *testing.T) {
 	_, _, embeddedJWSBody := signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
 
 	testCases := []struct {
-		Name            string
-		Request         *http.Request
-		ExpectedProblem *probs.ProblemDetails
-		ExpectedPayload string
-		ExpectedAcct    *core.Registration
-		ExpectedJWS     *jose.JSONWebSignature
-		ErrorStatType   string
+		Name          string
+		Request       *http.Request
+		WantPayload   string
+		WantAcct      *core.Registration
+		WantJWS       *jose.JSONWebSignature
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name:    "Invalid JWS",
-			Request: makePostRequestWithPath("test", "foo"),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Parse error reading JWS",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSUnmarshalFailed",
+			Name:          "Invalid JWS",
+			Request:       makePostRequestWithPath("test", "foo"),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Parse error reading JWS",
+			WantStatType:  "JWSUnmarshalFailed",
 		},
 		{
-			Name:    "Embedded Key JWS",
-			Request: makePostRequestWithPath("test", embeddedJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "No Key ID in JWS header",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSAuthTypeWrong",
+			Name:          "Embedded Key JWS",
+			Request:       makePostRequestWithPath("test", embeddedJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "No Key ID in JWS header",
+			WantStatType:  "JWSAuthTypeWrong",
 		},
 		{
-			Name:    "JWS signed by account that doesn't exist",
-			Request: makePostRequestWithPath("test", missingJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.AccountDoesNotExistProblem,
-				Detail:     "Account \"http://localhost/acme/acct/102\" not found",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSKeyIDNotFound",
+			Name:          "JWS signed by account that doesn't exist",
+			Request:       makePostRequestWithPath("test", missingJWSBody),
+			WantErrType:   berrors.AccountDoesNotExist,
+			WantErrDetail: "Account \"http://localhost/acme/acct/102\" not found",
+			WantStatType:  "JWSKeyIDNotFound",
 		},
 		{
-			Name:    "JWS signed by account that's deactivated",
-			Request: makePostRequestWithPath("test", deactivatedJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.UnauthorizedProblem,
-				Detail:     "Account is not valid, has status \"deactivated\"",
-				HTTPStatus: http.StatusForbidden,
-			},
-			ErrorStatType: "JWSKeyIDAccountInvalid",
+			Name:          "JWS signed by account that's deactivated",
+			Request:       makePostRequestWithPath("test", deactivatedJWSBody),
+			WantErrType:   berrors.Unauthorized,
+			WantErrDetail: "Account is not valid, has status \"deactivated\"",
+			WantStatType:  "JWSKeyIDAccountInvalid",
 		},
 		{
-			Name:            "Valid JWS for account",
-			Request:         makePostRequestWithPath("test", validJWSBody),
-			ExpectedPayload: `{"test":"passed"}`,
-			ExpectedAcct:    &validAccount,
-			ExpectedJWS:     validJWS,
+			Name:        "Valid JWS for account",
+			Request:     makePostRequestWithPath("test", validJWSBody),
+			WantPayload: `{"test":"passed"}`,
+			WantAcct:    &validAccount,
+			WantJWS:     validJWS,
 		},
 	}
 
@@ -1492,19 +1476,30 @@ func TestValidPOSTForAccount(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
 			inputLogEvent := newRequestEvent()
-			outPayload, jws, acct, prob := wfe.validPOSTForAccount(tc.Request, context.Background(), inputLogEvent)
-			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatalf("Expected nil problem, got %#v\n", prob)
-			} else if tc.ExpectedProblem == nil {
-				test.AssertEquals(t, string(outPayload), tc.ExpectedPayload)
-				test.AssertMarshaledEquals(t, acct, tc.ExpectedAcct)
-				test.AssertMarshaledEquals(t, jws, tc.ExpectedJWS)
+
+			gotPayload, gotJWS, gotAcct, gotErr := wfe.validPOSTForAccount(tc.Request, context.Background(), inputLogEvent)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("validPOSTForAccount(%#v) = %#v, want nil", tc.Request, gotErr)
+				}
+				if string(gotPayload) != tc.WantPayload {
+					t.Fatalf("validPOSTForAccount(%#v) = %q, want %q", tc.Request, string(gotPayload), tc.WantPayload)
+				}
+				test.AssertMarshaledEquals(t, gotJWS, tc.WantJWS)
+				test.AssertMarshaledEquals(t, gotAcct, tc.WantAcct)
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-			}
-			if tc.ErrorStatType != "" {
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("validPOSTForAccount(%#v) returned %T, want BoulderError", tc.Request, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("validPOSTForAccount(%#v) = %#v, want %#v", tc.Request, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("validPOSTForAccount(%#v) = %q, want %q", tc.Request, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}
@@ -1524,38 +1519,50 @@ func TestValidPOSTAsGETForAccount(t *testing.T) {
 	_, _, validRequest := signer.byKeyID(1, nil, "http://localhost/test", "")
 
 	testCases := []struct {
-		Name             string
-		Request          *http.Request
-		ExpectedProblem  *probs.ProblemDetails
-		ExpectedLogEvent web.RequestEvent
+		Name          string
+		Request       *http.Request
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantLogEvent  web.RequestEvent
 	}{
 		{
-			Name:             "Non-empty JWS payload",
-			Request:          makePostRequestWithPath("test", invalidPayloadRequest),
-			ExpectedProblem:  probs.Malformed("POST-as-GET requests must have an empty payload"),
-			ExpectedLogEvent: web.RequestEvent{},
+			Name:          "Non-empty JWS payload",
+			Request:       makePostRequestWithPath("test", invalidPayloadRequest),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "POST-as-GET requests must have an empty payload",
+			WantLogEvent:  web.RequestEvent{},
 		},
 		{
 			Name:    "Valid POST-as-GET",
 			Request: makePostRequestWithPath("test", validRequest),
-			ExpectedLogEvent: web.RequestEvent{
+			WantLogEvent: web.RequestEvent{
 				Method: "POST-as-GET",
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		ev := newRequestEvent()
-		_, prob := wfe.validPOSTAsGETForAccount(
-			tc.Request,
-			context.Background(),
-			ev)
-		if tc.ExpectedProblem == nil && prob != nil {
-			t.Fatalf("Expected nil problem, got %#v\n", prob)
-		} else if tc.ExpectedProblem != nil {
-			test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-		}
-		test.AssertMarshaledEquals(t, *ev, tc.ExpectedLogEvent)
+		t.Run(tc.Name, func(t *testing.T) {
+			ev := newRequestEvent()
+			_, gotErr := wfe.validPOSTAsGETForAccount(tc.Request, context.Background(), ev)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("validPOSTAsGETForAccount(%#v) = %#v, want nil", tc.Request, gotErr)
+				}
+			} else {
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("validPOSTAsGETForAccount(%#v) returned %T, want BoulderError", tc.Request, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("validPOSTAsGETForAccount(%#v) = %#v, want %#v", tc.Request, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("validPOSTAsGETForAccount(%#v) = %q, want %q", tc.Request, berr.Detail, tc.WantErrDetail)
+				}
+			}
+			test.AssertMarshaledEquals(t, *ev, tc.WantLogEvent)
+		})
 	}
 }
 
@@ -1586,10 +1593,10 @@ func TestValidPOSTForAccountSwappedKey(t *testing.T) {
 	// Ensure that ValidPOSTForAccount produces an error since the
 	// mockSADifferentStoredKey will return a different key than the one we used to
 	// sign the request
-	_, _, _, prob := wfe.validPOSTForAccount(request, ctx, event)
-	test.Assert(t, prob != nil, "No error returned for request signed by wrong key")
-	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
-	test.AssertEquals(t, prob.Detail, "JWS verification error")
+	_, _, _, err := wfe.validPOSTForAccount(request, ctx, event)
+	test.AssertError(t, err, "No error returned for request signed by wrong key")
+	test.AssertErrorIs(t, err, berrors.Malformed)
+	test.AssertContains(t, err.Error(), "JWS verification error")
 }
 
 func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
@@ -1607,8 +1614,8 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 	_, _, validJWSBody := signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
 	request := makePostRequestWithPath("test", validJWSBody)
 
-	_, _, prob := wfe.validSelfAuthenticatedPOST(context.Background(), request)
-	test.AssertEquals(t, prob.Type, probs.ServerInternalProblem)
+	_, _, err = wfe.validSelfAuthenticatedPOST(context.Background(), request)
+	test.AssertErrorIs(t, err, berrors.InternalServer)
 
 	badKeyCheckFunc := func(ctx context.Context, keyHash []byte) (bool, error) {
 		return false, fmt.Errorf("oh no: %w", goodkey.ErrBadKey)
@@ -1622,8 +1629,8 @@ func TestValidSelfAuthenticatedPOSTGoodKeyErrors(t *testing.T) {
 	_, _, validJWSBody = signer.embeddedJWK(nil, "http://localhost/test", `{"test":"passed"}`)
 	request = makePostRequestWithPath("test", validJWSBody)
 
-	_, _, prob = wfe.validSelfAuthenticatedPOST(context.Background(), request)
-	test.AssertEquals(t, prob.Type, probs.BadPublicKeyProblem)
+	_, _, err = wfe.validSelfAuthenticatedPOST(context.Background(), request)
+	test.AssertErrorIs(t, err, berrors.BadPublicKey)
 }
 
 func TestValidSelfAuthenticatedPOST(t *testing.T) {
@@ -1634,58 +1641,65 @@ func TestValidSelfAuthenticatedPOST(t *testing.T) {
 	_, _, keyIDJWSBody := signer.byKeyID(1, nil, "http://localhost/test", `{"test":"passed"}`)
 
 	testCases := []struct {
-		Name            string
-		Request         *http.Request
-		ExpectedProblem *probs.ProblemDetails
-		ExpectedPayload string
-		ExpectedJWK     *jose.JSONWebKey
-		ErrorStatType   string
+		Name          string
+		Request       *http.Request
+		WantPayload   string
+		WantJWK       *jose.JSONWebKey
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name:    "Invalid JWS",
-			Request: makePostRequestWithPath("test", "foo"),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Parse error reading JWS",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSUnmarshalFailed",
+			Name:          "Invalid JWS",
+			Request:       makePostRequestWithPath("test", "foo"),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Parse error reading JWS",
+			WantStatType:  "JWSUnmarshalFailed",
 		},
 		{
-			Name:    "JWS with key ID",
-			Request: makePostRequestWithPath("test", keyIDJWSBody),
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "No embedded JWK in JWS header",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "JWSAuthTypeWrong",
+			Name:          "JWS with key ID",
+			Request:       makePostRequestWithPath("test", keyIDJWSBody),
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "No embedded JWK in JWS header",
+			WantStatType:  "JWSAuthTypeWrong",
 		},
 		{
-			Name:            "Valid JWS",
-			Request:         makePostRequestWithPath("test", validJWSBody),
-			ExpectedPayload: `{"test":"passed"}`,
-			ExpectedJWK:     validKey,
+			Name:        "Valid JWS",
+			Request:     makePostRequestWithPath("test", validJWSBody),
+			WantPayload: `{"test":"passed"}`,
+			WantJWK:     validKey,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
-			outPayload, jwk, prob := wfe.validSelfAuthenticatedPOST(context.Background(), tc.Request)
-			if tc.ExpectedProblem == nil && prob != nil {
-				t.Fatalf("Expected nil problem, got %#v\n", prob)
-			} else if tc.ExpectedProblem == nil {
-				inThumb, _ := tc.ExpectedJWK.Thumbprint(crypto.SHA256)
-				outThumb, _ := jwk.Thumbprint(crypto.SHA256)
-				test.AssertDeepEquals(t, inThumb, outThumb)
-				test.AssertEquals(t, string(outPayload), tc.ExpectedPayload)
+			gotPayload, gotJWK, gotErr := wfe.validSelfAuthenticatedPOST(context.Background(), tc.Request)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("validSelfAuthenticatedPOST(%#v) = %#v, want nil", tc.Request, gotErr)
+				}
+				if string(gotPayload) != tc.WantPayload {
+					t.Fatalf("validSelfAuthenticatedPOST(%#v) = %q, want %q", tc.Request, string(gotPayload), tc.WantPayload)
+				}
+				gotThumb, _ := gotJWK.Thumbprint(crypto.SHA256)
+				wantThumb, _ := tc.WantJWK.Thumbprint(crypto.SHA256)
+				if !slices.Equal(gotThumb, wantThumb) {
+					t.Fatalf("validSelfAuthenticatedPOST(%#v) = %#v, want %#v", tc.Request, gotThumb, wantThumb)
+				}
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-			}
-			if tc.ErrorStatType != "" {
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("validSelfAuthenticatedPOST(%#v) returned %T, want BoulderError", tc.Request, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("validSelfAuthenticatedPOST(%#v) = %#v, want %#v", tc.Request, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("validSelfAuthenticatedPOST(%#v) = %q, want %q", tc.Request, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}
@@ -1699,56 +1713,44 @@ func TestMatchJWSURLs(t *testing.T) {
 	urlBJWS, _, _ := signer.embeddedJWK(nil, "example.org", "")
 
 	testCases := []struct {
-		Name            string
-		Outer           *jose.JSONWebSignature
-		Inner           *jose.JSONWebSignature
-		ExpectedProblem *probs.ProblemDetails
-		ErrorStatType   string
+		Name          string
+		Outer         *jose.JSONWebSignature
+		Inner         *jose.JSONWebSignature
+		WantErrType   berrors.ErrorType
+		WantErrDetail string
+		WantStatType  string
 	}{
 		{
-			Name:  "Outer JWS without URL",
-			Outer: noURLJWS,
-			Inner: urlAJWS,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Outer JWS header parameter 'url' required",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "KeyRolloverOuterJWSNoURL",
+			Name:          "Outer JWS without URL",
+			Outer:         noURLJWS,
+			Inner:         urlAJWS,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Outer JWS header parameter 'url' required",
+			WantStatType:  "KeyRolloverOuterJWSNoURL",
 		},
 		{
-			Name:  "Inner JWS without URL",
-			Outer: urlAJWS,
-			Inner: noURLJWS,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Inner JWS header parameter 'url' required",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "KeyRolloverInnerJWSNoURL",
+			Name:          "Inner JWS without URL",
+			Outer:         urlAJWS,
+			Inner:         noURLJWS,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Inner JWS header parameter 'url' required",
+			WantStatType:  "KeyRolloverInnerJWSNoURL",
 		},
 		{
-			Name:  "Inner and outer JWS without URL",
-			Outer: noURLJWS,
-			Inner: noURLJWS,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type: probs.MalformedProblem,
-				// The Outer JWS is validated first
-				Detail:     "Outer JWS header parameter 'url' required",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "KeyRolloverOuterJWSNoURL",
+			Name:          "Inner and outer JWS without URL",
+			Outer:         noURLJWS,
+			Inner:         noURLJWS,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Outer JWS header parameter 'url' required",
+			WantStatType:  "KeyRolloverOuterJWSNoURL",
 		},
 		{
-			Name:  "Mismatched inner and outer JWS URLs",
-			Outer: urlAJWS,
-			Inner: urlBJWS,
-			ExpectedProblem: &probs.ProblemDetails{
-				Type:       probs.MalformedProblem,
-				Detail:     "Outer JWS 'url' value \"example.com\" does not match inner JWS 'url' value \"example.org\"",
-				HTTPStatus: http.StatusBadRequest,
-			},
-			ErrorStatType: "KeyRolloverMismatchedURLs",
+			Name:          "Mismatched inner and outer JWS URLs",
+			Outer:         urlAJWS,
+			Inner:         urlBJWS,
+			WantErrType:   berrors.Malformed,
+			WantErrDetail: "Outer JWS 'url' value \"example.com\" does not match inner JWS 'url' value \"example.org\"",
+			WantStatType:  "KeyRolloverMismatchedURLs",
 		},
 		{
 			Name:  "Matching inner and outer JWS URLs",
@@ -1760,15 +1762,27 @@ func TestMatchJWSURLs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			wfe.stats.joseErrorCount.Reset()
-			prob := wfe.matchJWSURLs(tc.Outer.Signatures[0].Header, tc.Inner.Signatures[0].Header)
-			if prob != nil && tc.ExpectedProblem == nil {
-				t.Errorf("matchJWSURLs failed. Expected no problem, got %#v", prob)
+			outer := tc.Outer.Signatures[0].Header
+			inner := tc.Inner.Signatures[0].Header
+
+			gotErr := wfe.matchJWSURLs(outer, inner)
+			if tc.WantErrDetail == "" {
+				if gotErr != nil {
+					t.Fatalf("matchJWSURLs(%#v, %#v) = %#v, want nil", outer, inner, gotErr)
+				}
 			} else {
-				test.AssertMarshaledEquals(t, prob, tc.ExpectedProblem)
-			}
-			if tc.ErrorStatType != "" {
+				berr, ok := gotErr.(*berrors.BoulderError)
+				if !ok {
+					t.Fatalf("matchJWSURLs(%#v, %#v) returned %T, want BoulderError", outer, inner, gotErr)
+				}
+				if berr.Type != tc.WantErrType {
+					t.Errorf("matchJWSURLs(%#v, %#v) = %#v, want %#v", outer, inner, berr.Type, tc.WantErrType)
+				}
+				if !strings.Contains(berr.Detail, tc.WantErrDetail) {
+					t.Errorf("matchJWSURLs(%#v, %#v) = %q, want %q", outer, inner, berr.Detail, tc.WantErrDetail)
+				}
 				test.AssertMetricWithLabelsEquals(
-					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.ErrorStatType}, 1)
+					t, wfe.stats.joseErrorCount, prometheus.Labels{"type": tc.WantStatType}, 1)
 			}
 		})
 	}

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -871,7 +871,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 // or revocation reason don't pass simple static checks. Also populates some
 // metadata fields on the given logEvent.
 func (wfe *WebFrontEndImpl) parseRevocation(
-	jwsBody []byte, logEvent *web.RequestEvent) (*x509.Certificate, revocation.Reason, *probs.ProblemDetails) {
+	jwsBody []byte, logEvent *web.RequestEvent) (*x509.Certificate, revocation.Reason, error) {
 	// Read the revoke request from the JWS payload
 	var revokeRequest struct {
 		CertificateDER core.JSONBuffer    `json:"certificate"`
@@ -879,13 +879,13 @@ func (wfe *WebFrontEndImpl) parseRevocation(
 	}
 	err := json.Unmarshal(jwsBody, &revokeRequest)
 	if err != nil {
-		return nil, 0, probs.Malformed("Unable to JSON parse revoke request")
+		return nil, 0, berrors.MalformedError("Unable to JSON parse revoke request")
 	}
 
 	// Parse the provided certificate
 	parsedCertificate, err := x509.ParseCertificate(revokeRequest.CertificateDER)
 	if err != nil {
-		return nil, 0, probs.Malformed("Unable to parse certificate DER")
+		return nil, 0, berrors.MalformedError("Unable to parse certificate DER")
 	}
 
 	// Compute and record the serial number of the provided certificate
@@ -899,31 +899,23 @@ func (wfe *WebFrontEndImpl) parseRevocation(
 	// issuer certificate.
 	issuerCert, ok := wfe.issuerCertificates[issuance.IssuerNameID(parsedCertificate)]
 	if !ok || issuerCert == nil {
-		return nil, 0, probs.NotFound("Certificate from unrecognized issuer")
+		return nil, 0, berrors.NotFoundError("Certificate from unrecognized issuer")
 	}
 	err = parsedCertificate.CheckSignatureFrom(issuerCert.Certificate)
 	if err != nil {
-		return nil, 0, probs.NotFound("No such certificate")
+		return nil, 0, berrors.NotFoundError("No such certificate")
 	}
 	logEvent.DNSNames = parsedCertificate.DNSNames
 
 	if parsedCertificate.NotAfter.Before(wfe.clk.Now()) {
-		return nil, 0, probs.Unauthorized("Certificate is expired")
+		return nil, 0, berrors.UnauthorizedError("Certificate is expired")
 	}
 
 	// Verify the revocation reason supplied is allowed
 	reason := revocation.Reason(0)
 	if revokeRequest.Reason != nil {
 		if _, present := revocation.UserAllowedReasons[*revokeRequest.Reason]; !present {
-			reasonStr, ok := revocation.ReasonToString[*revokeRequest.Reason]
-			if !ok {
-				reasonStr = "unknown"
-			}
-			return nil, 0, probs.BadRevocationReason(fmt.Sprintf(
-				"unsupported revocation reason code provided: %s (%d). Supported reasons: %s",
-				reasonStr,
-				*revokeRequest.Reason,
-				revocation.UserAllowedReasonsMessage))
+			return nil, 0, berrors.BadRevocationReasonError(int64(*revokeRequest.Reason))
 		}
 		reason = *revokeRequest.Reason
 	}
@@ -952,9 +944,9 @@ func (wfe *WebFrontEndImpl) revokeCertBySubscriberKey(
 		return prob
 	}
 
-	cert, reason, prob := wfe.parseRevocation(jwsBody, logEvent)
-	if prob != nil {
-		return prob
+	cert, reason, err := wfe.parseRevocation(jwsBody, logEvent)
+	if err != nil {
+		return err
 	}
 
 	wfe.log.AuditObject("Authenticated revocation", revocationEvidence{
@@ -967,7 +959,7 @@ func (wfe *WebFrontEndImpl) revokeCertBySubscriberKey(
 	// The RA will confirm that the authenticated account either originally
 	// issued the certificate, or has demonstrated control over all identifiers
 	// in the certificate.
-	_, err := wfe.ra.RevokeCertByApplicant(ctx, &rapb.RevokeCertByApplicantRequest{
+	_, err = wfe.ra.RevokeCertByApplicant(ctx, &rapb.RevokeCertByApplicantRequest{
 		Cert:  cert.Raw,
 		Code:  int64(reason),
 		RegID: acct.ID,
@@ -997,9 +989,9 @@ func (wfe *WebFrontEndImpl) revokeCertByCertKey(
 		return prob
 	}
 
-	cert, reason, prob := wfe.parseRevocation(jwsBody, logEvent)
-	if prob != nil {
-		return prob
+	cert, reason, err := wfe.parseRevocation(jwsBody, logEvent)
+	if err != nil {
+		return err
 	}
 
 	// For embedded JWK revocations we decide if a requester is able to revoke a specific
@@ -1019,7 +1011,7 @@ func (wfe *WebFrontEndImpl) revokeCertByCertKey(
 
 	// The RA assumes here that the WFE2 has validated the JWS as proving
 	// control of the private key corresponding to this certificate.
-	_, err := wfe.ra.RevokeCertByKey(ctx, &rapb.RevokeCertByKeyRequest{
+	_, err = wfe.ra.RevokeCertByKey(ctx, &rapb.RevokeCertByKeyRequest{
 		Cert: cert.Raw,
 	})
 	if err != nil {
@@ -1071,7 +1063,7 @@ func (wfe *WebFrontEndImpl) RevokeCertificate(
 		err = berrors.MalformedError("Malformed JWS, no KeyID or embedded JWK")
 	}
 	if err != nil {
-		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "unable to revoke"), nil)
+		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to revoke"), nil)
 		return
 	}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3246,7 +3246,7 @@ func TestRevokeCertificateNotIssued(t *testing.T) {
 		makePostRequestWithPath("revoke-cert", jwsBody))
 	// It should result in a 404 response with a problem body
 	test.AssertEquals(t, responseWriter.Code, 404)
-	test.AssertEquals(t, responseWriter.Body.String(), "{\n  \"type\": \"urn:ietf:params:acme:error:malformed\",\n  \"detail\": \"Certificate from unrecognized issuer\",\n  \"status\": 404\n}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\n  \"type\": \"urn:ietf:params:acme:error:malformed\",\n  \"detail\": \"Unable to revoke :: Certificate from unrecognized issuer\",\n  \"status\": 404\n}")
 }
 
 func TestRevokeCertificateExpired(t *testing.T) {
@@ -3271,7 +3271,7 @@ func TestRevokeCertificateExpired(t *testing.T) {
 	wfe.RevokeCertificate(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath("revoke-cert", jwsBody))
 	test.AssertEquals(t, responseWriter.Code, 403)
-	test.AssertEquals(t, responseWriter.Body.String(), "{\n  \"type\": \"urn:ietf:params:acme:error:unauthorized\",\n  \"detail\": \"Certificate is expired\",\n  \"status\": 403\n}")
+	test.AssertEquals(t, responseWriter.Body.String(), "{\n  \"type\": \"urn:ietf:params:acme:error:unauthorized\",\n  \"detail\": \"Unable to revoke :: Certificate is expired\",\n  \"status\": 403\n}")
 }
 
 func TestRevokeCertificateReasons(t *testing.T) {
@@ -3306,13 +3306,13 @@ func TestRevokeCertificateReasons(t *testing.T) {
 			Name:             "Unsupported reason",
 			Reason:           &reason2,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: cACompromise (2). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.ErrorNS + `badRevocationReason","detail":"Unable to revoke :: disallowed revocation reason: 2","status":400}`,
 		},
 		{
 			Name:             "Non-existent reason",
 			Reason:           &reason100,
 			ExpectedHTTPCode: http.StatusBadRequest,
-			ExpectedBody:     `{"type":"` + probs.ErrorNS + `badRevocationReason","detail":"unsupported revocation reason code provided: unknown (100). Supported reasons: unspecified (0), keyCompromise (1), superseded (4), cessationOfOperation (5)","status":400}`,
+			ExpectedBody:     `{"type":"` + probs.ErrorNS + `badRevocationReason","detail":"Unable to revoke :: disallowed revocation reason: 100","status":400}`,
 		},
 	}
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -1349,7 +1349,7 @@ func TestBadNonce(t *testing.T) {
 	test.AssertNotError(t, err, "Failed to sign body")
 	wfe.NewAccount(ctx, newRequestEvent(), responseWriter,
 		makePostRequestWithPath("nonce", result.FullSerialize()))
-	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.ErrorNS+`badNonce","detail":"JWS has no anti-replay nonce","status":400}`)
+	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `{"type":"`+probs.ErrorNS+`badNonce","detail":"Unable to validate JWS :: JWS has no anti-replay nonce","status":400}`)
 }
 
 func TestNewECDSAAccount(t *testing.T) {
@@ -1530,19 +1530,19 @@ func TestNewAccount(t *testing.T) {
 					"Content-Type":   {expectedJWSContentType},
 				},
 			},
-			`{"type":"` + probs.ErrorNS + `malformed","detail":"No body on POST","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: No body on POST","status":400}`,
 		},
 
 		// POST, but body that isn't valid JWS
 		{
 			makePostRequestWithPath(newAcctPath, "hi"),
-			`{"type":"` + probs.ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: Parse error reading JWS","status":400}`,
 		},
 
 		// POST, Properly JWS-signed, but payload is "foo", not base64-encoded JSON.
 		{
 			makePostRequestWithPath(newAcctPath, fooBody),
-			`{"type":"` + probs.ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: Request payload did not parse as JSON","status":400}`,
 		},
 
 		// Same signed body, but payload modified by one byte, breaking signature.
@@ -1550,7 +1550,7 @@ func TestNewAccount(t *testing.T) {
 		{
 			makePostRequestWithPath(newAcctPath,
 				`{"payload":"Zm9x","protected":"eyJhbGciOiJSUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoicW5BUkxyVDdYejRnUmNLeUxkeWRtQ3ItZXk5T3VQSW1YNFg0MHRoazNvbjI2RmtNem5SM2ZSanM2NmVMSzdtbVBjQlo2dU9Kc2VVUlU2d0FhWk5tZW1vWXgxZE12cXZXV0l5aVFsZUhTRDdROHZCcmhSNnVJb080akF6SlpSLUNoelp1U0R0N2lITi0zeFVWc3B1NVhHd1hVX01WSlpzaFR3cDRUYUZ4NWVsSElUX09iblR2VE9VM1hoaXNoMDdBYmdaS21Xc1ZiWGg1cy1DcklpY1U0T2V4SlBndW5XWl9ZSkp1ZU9LbVR2bkxsVFY0TXpLUjJvWmxCS1oyN1MwLVNmZFZfUUR4X3lkbGU1b01BeUtWdGxBVjM1Y3lQTUlzWU53Z1VHQkNkWV8yVXppNWVYMGxUYzdNUFJ3ejZxUjFraXAtaTU5VmNHY1VRZ3FIVjZGeXF3IiwiZSI6IkFRQUIifSwia2lkIjoiIiwibm9uY2UiOiJyNHpuenZQQUVwMDlDN1JwZUtYVHhvNkx3SGwxZVBVdmpGeXhOSE1hQnVvIiwidXJsIjoiaHR0cDovL2xvY2FsaG9zdC9hY21lL25ldy1yZWcifQ","signature":"jcTdxSygm_cvD7KbXqsxgnoPApCTSkV4jolToSOd2ciRkg5W7Yl0ZKEEKwOc-dYIbQiwGiDzisyPCicwWsOUA1WSqHylKvZ3nxSMc6KtwJCW2DaOqcf0EEjy5VjiZJUrOt2c-r6b07tbn8sfOJKwlF2lsOeGi4s-rtvvkeQpAU-AWauzl9G4bv2nDUeCviAZjHx_PoUC-f9GmZhYrbDzAvXZ859ktM6RmMeD0OqPN7bhAeju2j9Gl0lnryZMtq2m0J2m1ucenQBL1g4ZkP1JiJvzd2cAz5G7Ftl2YeJJyWhqNd3qq0GVOt1P11s8PTGNaSoM0iR9QfUxT9A6jxARtg"}`),
-			`{"type":"` + probs.ErrorNS + `malformed","detail":"JWS verification error","status":400}`,
+			`{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: JWS verification error","status":400}`,
 		},
 		{
 			makePostRequestWithPath(newAcctPath, wrongAgreementBody),
@@ -1801,7 +1801,7 @@ func TestAccount(t *testing.T) {
 	wfe.Account(ctx, newRequestEvent(), responseWriter, makePostRequestWithPath("2", "invalid"))
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"`+probs.ErrorNS+`malformed","detail":"Parse error reading JWS","status":400}`)
+		`{"type":"`+probs.ErrorNS+`malformed","detail":"Unable to validate JWS :: Parse error reading JWS","status":400}`)
 	responseWriter.Body.Reset()
 
 	key := loadKey(t, []byte(test2KeyPrivatePEM))
@@ -1819,7 +1819,7 @@ func TestAccount(t *testing.T) {
 	wfe.Account(ctx, newRequestEvent(), responseWriter, request)
 	test.AssertUnmarshaledEquals(t,
 		responseWriter.Body.String(),
-		`{"type":"`+probs.ErrorNS+`accountDoesNotExist","detail":"Account \"http://localhost/acme/acct/102\" not found","status":400}`)
+		`{"type":"`+probs.ErrorNS+`accountDoesNotExist","detail":"Unable to validate JWS :: Account \"http://localhost/acme/acct/102\" not found","status":400}`)
 	responseWriter.Body.Reset()
 
 	key = loadKey(t, []byte(test1KeyPrivatePEM))
@@ -2080,7 +2080,7 @@ func TestGetCertificate(t *testing.T) {
 			ExpectedBody: `{
 				"type": "urn:ietf:params:acme:error:malformed",
 				"status": 400,
-				"detail": "POST-as-GET requests must have an empty payload"
+				"detail": "Unable to validate JWS :: POST-as-GET requests must have an empty payload"
 			}`,
 		},
 		{
@@ -2573,7 +2573,7 @@ func TestDeactivateAccount(t *testing.T) {
 		responseWriter.Body.String(),
 		`{
 		  "type": "`+probs.ErrorNS+`unauthorized",
-		  "detail": "Account is not valid, has status \"deactivated\"",
+		  "detail": "Unable to validate JWS :: Account is not valid, has status \"deactivated\"",
 		  "status": 403
 		}`)
 }
@@ -2652,17 +2652,17 @@ func TestNewOrder(t *testing.T) {
 					"Content-Type":   {expectedJWSContentType},
 				},
 			},
-			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"No body on POST","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: No body on POST","status":400}`,
 		},
 		{
 			Name:         "POST, with an invalid JWS body",
 			Request:      makePostRequestWithPath("hi", "hi"),
-			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: Parse error reading JWS","status":400}`,
 		},
 		{
 			Name:         "POST, properly signed JWS, payload isn't valid",
 			Request:      signAndPost(signer, targetPath, signedURL, "foo"),
-			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: Request payload did not parse as JSON","status":400}`,
 		},
 		{
 			Name:         "POST, empty domain name identifier",
@@ -2815,17 +2815,17 @@ func TestFinalizeOrder(t *testing.T) {
 					"Content-Type":   {expectedJWSContentType},
 				},
 			},
-			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"No body on POST","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: No body on POST","status":400}`,
 		},
 		{
 			Name:         "POST, with an invalid JWS body",
 			Request:      makePostRequestWithPath(targetPath, "hi"),
-			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Parse error reading JWS","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: Parse error reading JWS","status":400}`,
 		},
 		{
 			Name:         "POST, properly signed JWS, payload isn't valid",
 			Request:      signAndPost(signer, targetPath, signedURL, "foo"),
-			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Request payload did not parse as JSON","status":400}`,
+			ExpectedBody: `{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: Request payload did not parse as JSON","status":400}`,
 		},
 		{
 			Name:         "Invalid path",
@@ -2942,7 +2942,7 @@ func TestKeyRollover(t *testing.T) {
 		responseWriter.Body.String(),
 		`{
 		  "type": "`+probs.ErrorNS+`malformed",
-		  "detail": "Parse error reading JWS",
+		  "detail": "Unable to validate JWS :: Parse error reading JWS",
 		  "status": 400
 		}`)
 
@@ -2969,7 +2969,7 @@ func TestKeyRollover(t *testing.T) {
 			Payload: `{"oldKey":` + string(newJWKJSON) + `,"account":"http://localhost/acme/acct/1"}`,
 			ExpectedResponse: `{
 		     "type": "` + probs.ErrorNS + `malformed",
-		     "detail": "Inner JWS does not contain old key field matching current account key",
+		     "detail": "Unable to validate JWS :: Inner JWS does not contain old key field matching current account key",
 		     "status": 400
 		   }`,
 			NewKey:        newKeyPriv,
@@ -3029,7 +3029,7 @@ func TestKeyRolloverMismatchedJWSURLs(t *testing.T) {
 	test.AssertUnmarshaledEquals(t, responseWriter.Body.String(), `
 		{
 			"type": "urn:ietf:params:acme:error:malformed",
-			"detail": "Outer JWS 'url' value \"http://localhost/key-change\" does not match inner JWS 'url' value \"http://localhost/wrong-url\"",
+			"detail": "Unable to validate JWS :: Outer JWS 'url' value \"http://localhost/key-change\" does not match inner JWS 'url' value \"http://localhost/wrong-url\"",
 			"status": 400
 		}`)
 }
@@ -3090,7 +3090,7 @@ func TestGetOrder(t *testing.T) {
 		{
 			Name:     "Invalid POST-as-GET",
 			Request:  makePost(1, "1/1", "{}"),
-			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"POST-as-GET requests must have an empty payload", "status":400}`,
+			Response: `{"type":"` + probs.ErrorNS + `malformed","detail":"Unable to validate JWS :: POST-as-GET requests must have an empty payload", "status":400}`,
 		},
 		{
 			Name:     "Valid POST-as-GET, wrong account",


### PR DESCRIPTION
Change all of the helper methods and functions in verify.go to return an `error` instead of a `probs.ProblemDetails`. Add a few new types to our errors package, and support for those types in ProblemDetailsForError, to maintain the same public-facing error types. Update the tests to check for specific errors instead of specific problems.

This is a building block towards making the probs.ProblemDetails type not implement the Error interface, and only be used when rendering errors to the user (i.e. not within Boulder logic itself).

Part of https://github.com/letsencrypt/boulder/issues/4980

---

> [!WARNING]
> ~~Do not merge before https://github.com/letsencrypt/boulder/pull/8076, as doing so will create a nil-pointer exception due to ProblemDetails/error type confusion.~~