### PR TITLE
Add integration test for when CRL entries are removed

### DIFF
--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -130,8 +130,6 @@ func TestCRLUpdaterStartup(t *testing.T) {
 // that the correct number of properly-formed and validly-signed CRLs are sent
 // to our fake S3 service.
 func TestCRLPipeline(t *testing.T) {
-	t.Parallel()
-
 	// Basic setup.
 	configDir, ok := os.LookupEnv("BOULDER_CONFIG_DIR")
 	t.Log(configDir)
@@ -209,8 +207,6 @@ func TestCRLPipeline(t *testing.T) {
 }
 
 func TestCRLTemporalAndExplicitShardingCoexist(t *testing.T) {
-	t.Parallel()
-
 	db, err := sql.Open("mysql", vars.DBConnSAIntegrationFullPerms)
 	if err != nil {
 		t.Fatalf("sql.Open: %s", err)

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -175,8 +175,6 @@ func checkRevoked(t *testing.T, revocations map[string][]*x509.RevocationList, c
 // precerts (with no corresponding final cert), and for both the Unspecified and
 // keyCompromise revocation reasons.
 func TestRevocation(t *testing.T) {
-	t.Parallel()
-
 	type authMethod string
 	var (
 		byAccount authMethod = "byAccount"

--- a/test/s3-test-srv/main.go
+++ b/test/s3-test-srv/main.go
@@ -27,21 +27,21 @@ func (srv *s3TestSrv) handleS3(w http.ResponseWriter, r *http.Request) {
 	} else if r.Method == "GET" {
 		srv.handleDownload(w, r)
 	} else {
-		w.WriteHeader(405)
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
 }
 
 func (srv *s3TestSrv) handleUpload(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("failed to read request body"))
 		return
 	}
 
 	crl, err := x509.ParseRevocationList(body)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(fmt.Sprintf("failed to parse body: %s", err)))
 		return
 	}
@@ -53,7 +53,7 @@ func (srv *s3TestSrv) handleUpload(w http.ResponseWriter, r *http.Request) {
 		srv.allSerials[core.SerialToString(rc.SerialNumber)] = revocation.Reason(rc.ReasonCode)
 	}
 
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("{}"))
 }
 
@@ -62,22 +62,22 @@ func (srv *s3TestSrv) handleDownload(w http.ResponseWriter, r *http.Request) {
 	defer srv.RUnlock()
 	body, ok := srv.allShards[r.URL.Path]
 	if !ok {
-		w.WriteHeader(404)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }
 
 func (srv *s3TestSrv) handleQuery(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
-		w.WriteHeader(405)
+		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
 
 	serial := r.URL.Query().Get("serial")
 	if serial == "" {
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -85,17 +85,17 @@ func (srv *s3TestSrv) handleQuery(w http.ResponseWriter, r *http.Request) {
 	defer srv.RUnlock()
 	reason, ok := srv.allSerials[serial]
 	if !ok {
-		w.WriteHeader(404)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(fmt.Sprintf("%d", reason)))
 }
 
 func (srv *s3TestSrv) handleReset(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		w.WriteHeader(405)
+		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
 
@@ -104,8 +104,7 @@ func (srv *s3TestSrv) handleReset(w http.ResponseWriter, r *http.Request) {
 	srv.allSerials = make(map[string]revocation.Reason)
 	srv.allShards = make(map[string][]byte)
 
-	w.WriteHeader(200)
-	return
+	w.WriteHeader(http.StatusOK)
 }
 
 func main() {

--- a/test/s3-test-srv/main.go
+++ b/test/s3-test-srv/main.go
@@ -93,6 +93,21 @@ func (srv *s3TestSrv) handleQuery(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(fmt.Sprintf("%d", reason)))
 }
 
+func (srv *s3TestSrv) handleReset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		w.WriteHeader(405)
+		return
+	}
+
+	srv.Lock()
+	defer srv.Unlock()
+	srv.allSerials = make(map[string]revocation.Reason)
+	srv.allShards = make(map[string][]byte)
+
+	w.WriteHeader(200)
+	return
+}
+
 func main() {
 	listenAddr := flag.String("listen", "0.0.0.0:4501", "Address to listen on")
 	flag.Parse()
@@ -104,6 +119,7 @@ func main() {
 
 	http.HandleFunc("/", srv.handleS3)
 	http.HandleFunc("/query", srv.handleQuery)
+	http.HandleFunc("/reset", srv.handleReset)
 
 	s := http.Server{
 		ReadTimeout: 30 * time.Second,


### PR DESCRIPTION
We already have an integration test showing that a serial does not show up on any CRL before its certificate has been revoked, and does show up afterwards. Extend that test to cover three new times:
- shortly before the certificate expires, when the entry must still appear;
- shortly after the certificate expires, when the entry must still appear; and
- significantly after the certificate expires, when the entry may be removed.

To facilitate this, augment the s3-test-srv with a new reset endpoint, so that the integration test can query the contents of only the most-recently-generated set of CRLs.

I have confirmed that the new integration test fails with https://github.com/letsencrypt/boulder/pull/8072 reverted.

Fixes https://github.com/letsencrypt/boulder/issues/8083