### PR TITLE
Replace Python test_recheck_caa with Go TestCAARechecking

### DIFF
--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -90,6 +90,23 @@ func delHTTP01Response(token string) error {
 	return nil
 }
 
+func addCAAIssueRecord(host string, issue string) error {
+	resp, err := http.Post("http://boulder.service.consul:8055/add-caa", "",
+		bytes.NewBufferString(fmt.Sprintf(`{
+			"host": "%s",
+			"policies": [{"tag": "issue", "value": "%s"}]
+		}`, host, issue)))
+	if err != nil {
+		return fmt.Errorf("adding CAA record: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("adding CAA record: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
 func makeClientAndOrder(c *client, csrKey *ecdsa.PrivateKey, idents []acme.Identifier, cn bool, profile string, certToReplace *x509.Certificate) (*client, *acme.Order, error) {
 	var err error
 	if c == nil {

--- a/test/integration/validation_test.go
+++ b/test/integration/validation_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package integration
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eggsampler/acme/v3"
+	"github.com/letsencrypt/boulder/test/vars"
+)
+
+func TestCAARechecking(t *testing.T) {
+	t.Parallel()
+
+	domain := randomDomain(t)
+	idents := []acme.Identifier{{Type: "dns", Value: domain}}
+
+	// Create an order and authorization, and fulfill the associated challenge.
+	// This should put the authz into the "valid" state, since CAA checks passed.
+	client, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating acme client: %s", err)
+	}
+
+	order, err := client.Client.NewOrder(client.Account, idents)
+	if err != nil {
+		t.Fatalf("creating order: %s", err)
+	}
+
+	authz, err := client.Client.FetchAuthorization(client.Account, order.Authorizations[0])
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := authz.ChallengeMap[acme.ChallengeTypeHTTP01]
+	if !ok {
+		t.Fatalf("no HTTP challenge found in %#v", authz)
+	}
+
+	err = addHTTP01Response(chal.Token, chal.KeyAuthorization)
+	if err != nil {
+		t.Fatalf("setting HTTP-01 challenge token: %s", err)
+	}
+	defer delHTTP01Response(chal.Token)
+
+	chal, err = client.Client.UpdateChallenge(client.Account, chal)
+	if err != nil {
+		t.Fatalf("completing HTTP-01 validation: %s", err)
+	}
+
+	// Manipulate the database so that it looks like the authz was validated
+	// more than 8 hours ago.
+	db, err := sql.Open("mysql", vars.DBConnSAIntegrationFullPerms)
+	if err != nil {
+		t.Fatalf("sql.Open: %s", err)
+	}
+
+	_, err = db.Exec(`UPDATE authz2 SET attemptedAt = ? WHERE identifierValue = ?`, time.Now().Add(-24*time.Hour).Format(time.DateTime), domain)
+	if err != nil {
+		t.Fatalf("updating authz attemptedAt timestamp: %s", err)
+	}
+
+	// Change the CAA record to now forbid issuance.
+	err = addCAAIssueRecord(domain, ";")
+	if err != nil {
+		t.Fatalf("updating CAA record: %s", err)
+	}
+
+	// Try to finalize the order created above. Due to our db manipulation, this
+	// should trigger a CAA recheck. And due to our challtestsrv manipulation,
+	// that CAA recheck should fail. Therefore the whole finalize should fail.
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating cert key: %s", err)
+	}
+
+	csr, err := makeCSR(key, idents, false)
+	if err != nil {
+		t.Fatalf("generating finalize csr: %s", err)
+	}
+
+	_, err = client.Client.FinalizeOrder(client.Account, order, csr)
+	if err == nil {
+		t.Errorf("expected finalize to fail, but got success")
+	}
+	if !strings.Contains(err.Error(), "CAA") {
+		t.Errorf("expected finalize to fail due to CAA, but got: %s", err)
+	}
+}


### PR DESCRIPTION
Replace a python integration test which relies on our "setup_twenty_days_ago" scaffolding with a Go test that uses direct database statements to avoid any need to do clock manipulation. The resulting test is much more verbose, but also (in my opinion) much clearer and significantly faster.