### PR TITLE
Create "OmitOCSP" profile config option

### DIFF
--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -333,9 +334,10 @@ func TestGenerateTemplate(t *testing.T) {
 		BasicConstraintsValid: true,
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		IssuingCertificateURL: []string{"http://issuer"},
-		OCSPServer:            []string{"http://ocsp"},
-		CRLDistributionPoints: nil,
 		Policies:              []x509.OID{domainValidatedOID},
+		// These fields are only included if the profile wants them.
+		OCSPServer:            nil,
+		CRLDistributionPoints: nil,
 	}
 
 	test.AssertDeepEquals(t, actual, expected)
@@ -867,6 +869,73 @@ func TestMismatchedProfiles(t *testing.T) {
 	_, _, err = issuer2.Prepare(noCNProfile, request2)
 	test.AssertError(t, err, "preparing final cert issuance")
 	test.AssertContains(t, err.Error(), "precert does not correspond to linted final cert")
+}
+
+func TestNewProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		config  ProfileConfig
+		wantErr string
+	}{
+		{
+			name: "happy path",
+			config: ProfileConfig{
+				MaxValidityBackdate: config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:   config.Duration{Duration: 90 * 24 * time.Hour},
+			},
+		},
+		{
+			name: "crl but no ocsp",
+			config: ProfileConfig{
+				MaxValidityBackdate:          config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:            config.Duration{Duration: 90 * 24 * time.Hour},
+				OmitOCSP:                     false,
+				IncludeCRLDistributionPoints: true,
+			},
+		},
+		{
+			name: "large backdate",
+			config: ProfileConfig{
+				MaxValidityBackdate: config.Duration{Duration: 24 * time.Hour},
+				MaxValidityPeriod:   config.Duration{Duration: 90 * 24 * time.Hour},
+			},
+			wantErr: "backdate \"24h0m0s\" is too large",
+		},
+		{
+			name: "large validity",
+			config: ProfileConfig{
+				MaxValidityBackdate: config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:   config.Duration{Duration: 397 * 24 * time.Hour},
+			},
+			wantErr: "validity period \"9528h0m0s\" is too large",
+		},
+		{
+			name: "no revocation info",
+			config: ProfileConfig{
+				MaxValidityBackdate:          config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:            config.Duration{Duration: 90 * 24 * time.Hour},
+				OmitOCSP:                     true,
+				IncludeCRLDistributionPoints: false,
+			},
+			wantErr: "revocation mechanism must be included",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProfile, gotErr := NewProfile(&tc.config)
+			if tc.wantErr != "" {
+				if gotErr == nil {
+					t.Errorf("NewProfile(%#v) = %#v, but want err %q", tc.config, gotProfile, tc.wantErr)
+				}
+				if !strings.Contains(gotErr.Error(), tc.wantErr) {
+					t.Errorf("NewProfile(%#v) = %q, but want %q", tc.config, gotErr, tc.wantErr)
+				}
+			} else {
+				if gotErr != nil {
+					t.Errorf("NewProfile(%#v) = %q, but want no error", tc.config, gotErr)
+				}
+			}
+		})
+	}
 }
 
 func TestProfileHash(t *testing.T) {

--- a/linter/lints/rfc/lint_cert_via_pkimetal.go
+++ b/linter/lints/rfc/lint_cert_via_pkimetal.go
@@ -89,14 +89,16 @@ func (pkim *PKIMetalConfig) execute(endpoint string, der []byte) (*lint.LintResu
 
 	var findings []string
 	for _, finding := range res {
-		id := fmt.Sprintf("%s:%s", finding.Linter, finding.Code)
+		var id string
+		if finding.Code != "" {
+			id = fmt.Sprintf("%s:%s", finding.Linter, finding.Code)
+		} else {
+			id = fmt.Sprintf("%s:%s", finding.Linter, strings.ReplaceAll(strings.ToLower(finding.Finding), " ", "_"))
+		}
 		if slices.Contains(pkim.IgnoreLints, id) {
 			continue
 		}
-		desc := fmt.Sprintf("%s from %s at %s", finding.Severity, id, finding.Field)
-		if finding.Finding != "" {
-			desc = fmt.Sprintf("%s: %s", desc, finding.Finding)
-		}
+		desc := fmt.Sprintf("%s from %s: %s", finding.Severity, id, finding.Finding)
 		findings = append(findings, desc)
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1772,6 +1772,12 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 // purgeOCSPCache makes a request to akamai-purger to purge the cache entries
 // for the given certificate.
 func (ra *RegistrationAuthorityImpl) purgeOCSPCache(ctx context.Context, cert *x509.Certificate, issuerID issuance.NameID) error {
+	if len(cert.OCSPServer) == 0 {
+		// We can't purge the cache (and there should be no responses in the cache)
+		// for certs that have no AIA OCSP URI.
+		return nil
+	}
+
 	issuer, ok := ra.issuersByNameID[issuerID]
 	if !ok {
 		return fmt.Errorf("unable to identify issuer of cert with serial %q", core.SerialToString(cert.SerialNumber))

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -55,6 +55,7 @@
 			"certProfiles": {
 				"legacy": {
 					"allowMustStaple": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m",
@@ -70,6 +71,7 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "583200s",
 					"maxValidityBackdate": "1h5m",
@@ -84,6 +86,7 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "160h",
 					"maxValidityBackdate": "1h5m",

--- a/test/config-next/zlint.toml
+++ b/test/config-next/zlint.toml
@@ -15,6 +15,10 @@ ignore_lints = [
   # issued under the "classic" profile, but have removed it from our "tlsserver"
   # and "shortlived" profiles.
   "pkilint:cabf.serverauth.subscriber_rsa_digitalsignature_and_keyencipherment_present",
+  # Some linters continue to complain about the lack of an AIA OCSP URI, even
+  # when a CRLDP is present.
+  "certlint:br_certificates_must_include_an_http_url_of_the_ocsp_responder",
+  "x509lint:no_ocsp_over_http"
 ]
 
 [e_pkimetal_lint_cabf_serverauth_crl]

--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -16,6 +17,12 @@ import (
 
 func TestOCSPHappyPath(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
+		// We no longer include AIA OCSP URIs in certificates issued by the
+		// config-next integration test environment.
+		t.Skip()
+	}
+
 	cert, err := authAndIssue(nil, nil, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
 	if err != nil || len(cert.certs) < 1 {
 		t.Fatal("failed to issue cert for OCSP testing")
@@ -31,6 +38,12 @@ func TestOCSPHappyPath(t *testing.T) {
 
 func TestOCSPBadSerialPrefix(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
+		// We no longer include AIA OCSP URIs in certificates issued by the
+		// config-next integration test environment.
+		t.Skip()
+	}
+
 	res, err := authAndIssue(nil, nil, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
 	if err != nil || len(res.certs) < 1 {
 		t.Fatal("Failed to issue dummy cert for OCSP testing")
@@ -50,6 +63,12 @@ func TestOCSPBadSerialPrefix(t *testing.T) {
 
 func TestOCSPRejectedPrecertificate(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
+		// We no longer include AIA OCSP URIs in certificates issued by the
+		// config-next integration test environment.
+		t.Skip()
+	}
+
 	domain := random_domain()
 	err := ctAddRejectHost(domain)
 	if err != nil {


### PR DESCRIPTION
Add a new control to profiles which causes the profile to omit the AIA OCSP URI. It can only be omitted if the CRLDP extension is configured to be included instead. Enable this flag in config-next.

When a certificate is revoked, if it does not have an AIA OCSP URI, don't bother with an akamai purge. Although it is possible for akamai to have cached OCSP responses for certs that don't contain an AIA OCSP URI (e.g. because someone manually constructed the correct URL to query), any such certs have their canonical revocation information distributed via CRLs within 24 hours, so we don't need to worry about OCSP propagation time.

Update several tests to use CRLs instead of OCSP to get the revocation status of certs issued during the test. Disable some tests which are explicitly testing OCSP behavior in config-next.

Fixes https://github.com/letsencrypt/boulder/issues/8059

---

> [!NOTE]
> This PR is incomplete. Not all of the integration tests have been updated to use CRLs. Please continue development on this PR while I'm on vacation.