### PR TITLE
test: Add integration tests for MPIC validation

### DIFF
--- a/test/chall-test-srv-client/client.go
+++ b/test/chall-test-srv-client/client.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/eggsampler/acme/v3"
-	"github.com/miekg/dns"
 )
 
 // Client is an HTTP client for https://github.com/letsencrypt/challtestsrv's
@@ -405,23 +404,13 @@ func (c *Client) RemoveDNS01Response(host string) ([]byte, error) {
 	return resp, nil
 }
 
-type dnsQuestion struct {
-	Name   string `json:"Name"`
-	Qtype  uint16 `json:"Qtype"`
-	Qclass uint16 `json:"Qclass"`
-}
-
-func (d *dnsQuestion) QtypeString() string {
-	return dns.TypeToString[d.Qtype]
-}
-
-func (d *dnsQuestion) QclassString() string {
-	return dns.ClassToString[d.Qclass]
-}
-
 // DNSRequest is a single DNS request in the request history.
 type DNSRequest struct {
-	Question dnsQuestion `json:"Question"`
+	Question struct {
+		Name   string `json:"Name"`
+		Qtype  uint16 `json:"Qtype"`
+		Qclass uint16 `json:"Qclass"`
+	} `json:"Question"`
 }
 
 // DNSRequestHistory returns the history of DNS requests made to the challenge

--- a/test/integration/validation_test.go
+++ b/test/integration/validation_test.go
@@ -69,15 +69,8 @@ func TestMPICTLSALPN01(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	validationCount := 0
-	for _, event := range validationEvents {
-		if event.ServerName == domain {
-			validationCount++
-		}
-	}
-	if validationCount != 4 {
-		t.Fatalf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
+	if len(validationEvents) != 4 {
+		t.Errorf("expected 4 validation events (VA=1 RVAs=3), got %d", len(validationEvents))
 	}
 
 	dnsEvents, err := testSrvClient.DNSRequestHistory(domain)
@@ -144,12 +137,12 @@ func TestMPICDNS01(t *testing.T) {
 
 	validationCount := 0
 	for _, event := range challDomainDNSEvents {
-		if event.Question.Qtype == dns.TypeTXT && strings.Contains(event.Question.Name, "_acme-challenge."+domain) {
+		if event.Question.Qtype == dns.TypeTXT && event.Question.Name == "_acme-challenge."+domain+"." {
 			validationCount++
 		}
 	}
 	if validationCount != 4 {
-		t.Fatalf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
+		t.Errorf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
 	}
 
 	domainDNSEvents, err := testSrvClient.DNSRequestHistory(domain)
@@ -216,12 +209,12 @@ func TestMPICHTTP01(t *testing.T) {
 
 	validationCount := 0
 	for _, event := range validationEvents {
-		if strings.Contains(event.Host, domain) && strings.Contains(event.URL, chal.Token) {
+		if event.URL == "/.well-known/acme-challenge/"+chal.Token {
 			validationCount++
 		}
 	}
 	if validationCount != 4 {
-		t.Fatalf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
+		t.Errorf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
 	}
 
 	dnsEvents, err := testSrvClient.DNSRequestHistory(domain)

--- a/test/integration/validation_test.go
+++ b/test/integration/validation_test.go
@@ -15,6 +15,230 @@ import (
 	"github.com/letsencrypt/boulder/test/vars"
 )
 
+func TestMPICTLSALPN01(t *testing.T) {
+	t.Parallel()
+
+	client, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating acme client: %s", err)
+	}
+
+	domain := randomDomain(t)
+
+	order, err := client.Client.NewOrder(client.Account, []acme.Identifier{{Type: "dns", Value: domain}})
+	if err != nil {
+		t.Fatalf("creating order: %s", err)
+	}
+
+	authz, err := client.Client.FetchAuthorization(client.Account, order.Authorizations[0])
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := authz.ChallengeMap[acme.ChallengeTypeTLSALPN01]
+	if !ok {
+		t.Fatalf("no TLS-ALPN-01 challenge found in %#v", authz)
+	}
+
+	_, err = testSrvClient.AddARecord(domain, []string{"10.88.88.88"})
+	if err != nil {
+		t.Fatalf("adding A record: %s", err)
+	}
+	defer func() {
+		testSrvClient.RemoveARecord(domain)
+	}()
+
+	_, err = testSrvClient.AddTLSALPN01Response(domain, chal.KeyAuthorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, err = testSrvClient.RemoveTLSALPN01Response(domain)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	chal, err = client.Client.UpdateChallenge(client.Account, chal)
+	if err != nil {
+		t.Fatalf("completing TLS-ALPN-01 validation: %s", err)
+	}
+
+	validationEvents, err := testSrvClient.TLSALPN01RequestHistory(domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validationCount := 0
+	for _, event := range validationEvents {
+		if event.ServerName == domain {
+			validationCount++
+		}
+	}
+	if validationCount != 4 {
+		t.Fatalf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
+	}
+
+	dnsEvents, err := testSrvClient.DNSRequestHistory(domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caaCount := 0
+	for _, event := range dnsEvents {
+		if event.Question.QtypeString() == "CAA" {
+			caaCount++
+		}
+	}
+	if caaCount != 4 {
+		t.Fatalf("expected 4 CAA validation events (VA=1 RVAs=3), got %d", caaCount)
+	}
+}
+
+func TestMPICDNS01(t *testing.T) {
+	t.Parallel()
+
+	client, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating acme client: %s", err)
+	}
+
+	domain := randomDomain(t)
+
+	order, err := client.Client.NewOrder(client.Account, []acme.Identifier{{Type: "dns", Value: domain}})
+	if err != nil {
+		t.Fatalf("creating order: %s", err)
+	}
+
+	authz, err := client.Client.FetchAuthorization(client.Account, order.Authorizations[0])
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := authz.ChallengeMap[acme.ChallengeTypeDNS01]
+	if !ok {
+		t.Fatalf("no DNS challenge found in %#v", authz)
+	}
+
+	_, err = testSrvClient.AddDNS01Response(domain, chal.KeyAuthorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, err = testSrvClient.RemoveDNS01Response(domain)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	chal, err = client.Client.UpdateChallenge(client.Account, chal)
+	if err != nil {
+		t.Fatalf("completing DNS-01 validation: %s", err)
+	}
+
+	challDomainDNSEvents, err := testSrvClient.DNSRequestHistory("_acme-challenge." + domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validationCount := 0
+	for _, event := range challDomainDNSEvents {
+		if event.Question.QtypeString() == "TXT" && strings.Contains(event.Question.Name, "_acme-challenge."+domain) {
+			validationCount++
+		}
+	}
+	if validationCount != 4 {
+		t.Fatalf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
+	}
+
+	domainDNSEvents, err := testSrvClient.DNSRequestHistory(domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caaCount := 0
+	for _, event := range domainDNSEvents {
+		if event.Question.QtypeString() == "CAA" {
+			caaCount++
+		}
+	}
+	if caaCount != 4 {
+		t.Fatalf("expected 4 CAA validation events (VA=1 RVAs=3), got %d", caaCount)
+	}
+}
+
+func TestMPICHTTP01(t *testing.T) {
+	t.Parallel()
+
+	client, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating acme client: %s", err)
+	}
+
+	domain := randomDomain(t)
+
+	order, err := client.Client.NewOrder(client.Account, []acme.Identifier{{Type: "dns", Value: domain}})
+	if err != nil {
+		t.Fatalf("creating order: %s", err)
+	}
+
+	authz, err := client.Client.FetchAuthorization(client.Account, order.Authorizations[0])
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := authz.ChallengeMap[acme.ChallengeTypeHTTP01]
+	if !ok {
+		t.Fatalf("no HTTP challenge found in %#v", authz)
+	}
+
+	_, err = testSrvClient.AddHTTP01Response(chal.Token, chal.KeyAuthorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, err = testSrvClient.RemoveHTTP01Response(chal.Token)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	chal, err = client.Client.UpdateChallenge(client.Account, chal)
+	if err != nil {
+		t.Fatalf("completing HTTP-01 validation: %s", err)
+	}
+
+	validationEvents, err := testSrvClient.HTTPRequestHistory(domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validationCount := 0
+	for _, event := range validationEvents {
+		if strings.Contains(event.Host, domain) && strings.Contains(event.URL, chal.Token) {
+			validationCount++
+		}
+	}
+	if validationCount != 4 {
+		t.Fatalf("expected 4 validation events (VA=1 RVAs=3), got %d", validationCount)
+	}
+
+	dnsEvents, err := testSrvClient.DNSRequestHistory(domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caaCount := 0
+	for _, event := range dnsEvents {
+		if event.Question.QtypeString() == "CAA" {
+			caaCount++
+		}
+	}
+	if caaCount != 4 {
+		t.Fatalf("expected 4 CAA validation events (VA=1 RVAs=3), got %d", caaCount)
+	}
+}
+
 func TestCAARechecking(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration/validation_test.go
+++ b/test/integration/validation_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/eggsampler/acme/v3"
 	"github.com/letsencrypt/boulder/test/vars"
+	"github.com/miekg/dns"
 )
 
 func TestMPICTLSALPN01(t *testing.T) {
@@ -86,7 +87,7 @@ func TestMPICTLSALPN01(t *testing.T) {
 
 	caaCount := 0
 	for _, event := range dnsEvents {
-		if event.Question.QtypeString() == "CAA" {
+		if event.Question.Qtype == dns.TypeCAA {
 			caaCount++
 		}
 	}
@@ -143,7 +144,7 @@ func TestMPICDNS01(t *testing.T) {
 
 	validationCount := 0
 	for _, event := range challDomainDNSEvents {
-		if event.Question.QtypeString() == "TXT" && strings.Contains(event.Question.Name, "_acme-challenge."+domain) {
+		if event.Question.Qtype == dns.TypeTXT && strings.Contains(event.Question.Name, "_acme-challenge."+domain) {
 			validationCount++
 		}
 	}
@@ -158,7 +159,7 @@ func TestMPICDNS01(t *testing.T) {
 
 	caaCount := 0
 	for _, event := range domainDNSEvents {
-		if event.Question.QtypeString() == "CAA" {
+		if event.Question.Qtype == dns.TypeCAA {
 			caaCount++
 		}
 	}
@@ -230,7 +231,7 @@ func TestMPICHTTP01(t *testing.T) {
 
 	caaCount := 0
 	for _, event := range dnsEvents {
-		if event.Question.QtypeString() == "CAA" {
+		if event.Question.Qtype == dns.TypeCAA {
 			caaCount++
 		}
 	}


### PR DESCRIPTION
- Update the chall-test-srv-client to make DNS events and DNS01 methods more convenient
- Add an integration test that counts DCV and CAA checks for each validation method

Part of #7963