### PR TITLE
ca: Create "OmitOCSP" profile config option

### DIFF
--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -335,7 +335,7 @@ func TestGenerateTemplate(t *testing.T) {
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		IssuingCertificateURL: []string{"http://issuer"},
 		Policies:              []x509.OID{domainValidatedOID},
-		// These fields are only included if the profile wants them.
+		// These fields are only included if specified in the profile.
 		OCSPServer:            nil,
 		CRLDistributionPoints: nil,
 	}

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -333,9 +334,10 @@ func TestGenerateTemplate(t *testing.T) {
 		BasicConstraintsValid: true,
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		IssuingCertificateURL: []string{"http://issuer"},
-		OCSPServer:            []string{"http://ocsp"},
-		CRLDistributionPoints: nil,
 		Policies:              []x509.OID{domainValidatedOID},
+		// These fields are only included if the profile wants them.
+		OCSPServer:            nil,
+		CRLDistributionPoints: nil,
 	}
 
 	test.AssertDeepEquals(t, actual, expected)
@@ -867,6 +869,73 @@ func TestMismatchedProfiles(t *testing.T) {
 	_, _, err = issuer2.Prepare(noCNProfile, request2)
 	test.AssertError(t, err, "preparing final cert issuance")
 	test.AssertContains(t, err.Error(), "precert does not correspond to linted final cert")
+}
+
+func TestNewProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		config  ProfileConfig
+		wantErr string
+	}{
+		{
+			name: "happy path",
+			config: ProfileConfig{
+				MaxValidityBackdate: config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:   config.Duration{Duration: 90 * 24 * time.Hour},
+			},
+		},
+		{
+			name: "crl but no ocsp",
+			config: ProfileConfig{
+				MaxValidityBackdate:          config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:            config.Duration{Duration: 90 * 24 * time.Hour},
+				OmitOCSP:                     false,
+				IncludeCRLDistributionPoints: true,
+			},
+		},
+		{
+			name: "large backdate",
+			config: ProfileConfig{
+				MaxValidityBackdate: config.Duration{Duration: 24 * time.Hour},
+				MaxValidityPeriod:   config.Duration{Duration: 90 * 24 * time.Hour},
+			},
+			wantErr: "backdate \"24h0m0s\" is too large",
+		},
+		{
+			name: "large validity",
+			config: ProfileConfig{
+				MaxValidityBackdate: config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:   config.Duration{Duration: 397 * 24 * time.Hour},
+			},
+			wantErr: "validity period \"9528h0m0s\" is too large",
+		},
+		{
+			name: "no revocation info",
+			config: ProfileConfig{
+				MaxValidityBackdate:          config.Duration{Duration: 1 * time.Hour},
+				MaxValidityPeriod:            config.Duration{Duration: 90 * 24 * time.Hour},
+				OmitOCSP:                     true,
+				IncludeCRLDistributionPoints: false,
+			},
+			wantErr: "revocation mechanism must be included",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProfile, gotErr := NewProfile(&tc.config)
+			if tc.wantErr != "" {
+				if gotErr == nil {
+					t.Errorf("NewProfile(%#v) = %#v, but want err %q", tc.config, gotProfile, tc.wantErr)
+				}
+				if !strings.Contains(gotErr.Error(), tc.wantErr) {
+					t.Errorf("NewProfile(%#v) = %q, but want %q", tc.config, gotErr, tc.wantErr)
+				}
+			} else {
+				if gotErr != nil {
+					t.Errorf("NewProfile(%#v) = %q, but want no error", tc.config, gotErr)
+				}
+			}
+		})
+	}
 }
 
 func TestProfileHash(t *testing.T) {

--- a/linter/lints/rfc/lint_cert_via_pkimetal.go
+++ b/linter/lints/rfc/lint_cert_via_pkimetal.go
@@ -89,14 +89,16 @@ func (pkim *PKIMetalConfig) execute(endpoint string, der []byte) (*lint.LintResu
 
 	var findings []string
 	for _, finding := range res {
-		id := fmt.Sprintf("%s:%s", finding.Linter, finding.Code)
+		var id string
+		if finding.Code != "" {
+			id = fmt.Sprintf("%s:%s", finding.Linter, finding.Code)
+		} else {
+			id = fmt.Sprintf("%s:%s", finding.Linter, strings.ReplaceAll(strings.ToLower(finding.Finding), " ", "_"))
+		}
 		if slices.Contains(pkim.IgnoreLints, id) {
 			continue
 		}
-		desc := fmt.Sprintf("%s from %s at %s", finding.Severity, id, finding.Field)
-		if finding.Finding != "" {
-			desc = fmt.Sprintf("%s: %s", desc, finding.Finding)
-		}
+		desc := fmt.Sprintf("%s from %s: %s", finding.Severity, id, finding.Finding)
 		findings = append(findings, desc)
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1787,6 +1787,12 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 // purgeOCSPCache makes a request to akamai-purger to purge the cache entries
 // for the given certificate.
 func (ra *RegistrationAuthorityImpl) purgeOCSPCache(ctx context.Context, cert *x509.Certificate, issuerID issuance.NameID) error {
+	if len(cert.OCSPServer) == 0 {
+		// We can't purge the cache (and there should be no responses in the cache)
+		// for certs that have no AIA OCSP URI.
+		return nil
+	}
+
 	issuer, ok := ra.issuersByNameID[issuerID]
 	if !ok {
 		return fmt.Errorf("unable to identify issuer of cert with serial %q", core.SerialToString(cert.SerialNumber))

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -55,6 +55,7 @@
 			"certProfiles": {
 				"legacy": {
 					"allowMustStaple": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m",
@@ -70,6 +71,7 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "583200s",
 					"maxValidityBackdate": "1h5m",
@@ -84,6 +86,7 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "160h",
 					"maxValidityBackdate": "1h5m",

--- a/test/config-next/zlint.toml
+++ b/test/config-next/zlint.toml
@@ -15,6 +15,10 @@ ignore_lints = [
   # issued under the "classic" profile, but have removed it from our "tlsserver"
   # and "shortlived" profiles.
   "pkilint:cabf.serverauth.subscriber_rsa_digitalsignature_and_keyencipherment_present",
+  # Some linters continue to complain about the lack of an AIA OCSP URI, even
+  # when a CRLDP is present.
+  "certlint:br_certificates_must_include_an_http_url_of_the_ocsp_responder",
+  "x509lint:no_ocsp_over_http"
 ]
 
 [e_pkimetal_lint_cabf_serverauth_crl]

--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -65,7 +65,7 @@ func getPrecertByName(db *sql.DB, name string) (*x509.Certificate, error) {
 // expectOCSP500 queries OCSP for the given certificate and expects a 500 error.
 func expectOCSP500(cert *x509.Certificate) error {
 	// Provide a fallback, so even when the AIA OCSP URI is not present, we can test this behavior.
-	_, err := ocsp_helper.Req(cert, ocsp_helper.DefaultConfig.WithURLFallback("http://ca.example.org:4002/"))
+	_, err := ocsp_helper.Req(cert, ocspConf())
 	if err == nil {
 		return errors.New("Expected error getting OCSP for certificate that failed status storage")
 	}
@@ -94,7 +94,6 @@ func expectOCSP500(cert *x509.Certificate) error {
 // that a final certificate exists for any precertificate, though it is
 // similar in spirit).
 func TestIssuanceCertStorageFailed(t *testing.T) {
-	t.Parallel()
 	os.Setenv("DIRECTORY", "http://boulder.service.consul:4001/directory")
 
 	ctx := context.Background()
@@ -198,7 +197,7 @@ func TestIssuanceCertStorageFailed(t *testing.T) {
 
 	for range 300 {
 		_, err = ocsp_helper.Req(successfulCert,
-			ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise).WithURLFallback("http://ca.example.org:4002/"))
+			ocspConf().WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise))
 		if err == nil {
 			break
 		}

--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -64,7 +64,6 @@ func getPrecertByName(db *sql.DB, name string) (*x509.Certificate, error) {
 
 // expectOCSP500 queries OCSP for the given certificate and expects a 500 error.
 func expectOCSP500(cert *x509.Certificate) error {
-	// Provide a fallback, so even when the AIA OCSP URI is not present, we can test this behavior.
 	_, err := ocsp_helper.Req(cert, ocspConf())
 	if err == nil {
 		return errors.New("Expected error getting OCSP for certificate that failed status storage")

--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -184,6 +184,7 @@ func TestIssuanceCertStorageFailed(t *testing.T) {
 	test.AssertNotError(t, err, "issuing second cert")
 
 	successfulCert := res.certs[0]
+	successfulCertIssuer := res.certs[1]
 	err = revokeClient.RevokeCertificate(
 		revokeClient.Account,
 		successfulCert,
@@ -193,7 +194,7 @@ func TestIssuanceCertStorageFailed(t *testing.T) {
 	test.AssertNotError(t, err, "revoking second certificate")
 
 	runUpdater(t, path.Join(os.Getenv("BOULDER_CONFIG_DIR"), "crl-updater.json"))
-	fetchAndCheckRevoked(t, successfulCert, ocsp.KeyCompromise)
+	fetchAndCheckRevoked(t, successfulCert, successfulCertIssuer, ocsp.KeyCompromise)
 
 	for range 300 {
 		_, err = ocsp_helper.Req(successfulCert,

--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -16,6 +17,12 @@ import (
 
 func TestOCSPHappyPath(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
+		// We no longer include AIA OCSP URIs in certificates issued by the
+		// config-next integration test environment.
+		t.Skip()
+	}
+
 	cert, err := authAndIssue(nil, nil, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
 	if err != nil || len(cert.certs) < 1 {
 		t.Fatal("failed to issue cert for OCSP testing")
@@ -31,6 +38,12 @@ func TestOCSPHappyPath(t *testing.T) {
 
 func TestOCSPBadSerialPrefix(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
+		// We no longer include AIA OCSP URIs in certificates issued by the
+		// config-next integration test environment.
+		t.Skip()
+	}
+
 	res, err := authAndIssue(nil, nil, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
 	if err != nil || len(res.certs) < 1 {
 		t.Fatal("Failed to issue dummy cert for OCSP testing")
@@ -50,6 +63,12 @@ func TestOCSPBadSerialPrefix(t *testing.T) {
 
 func TestOCSPRejectedPrecertificate(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
+		// We no longer include AIA OCSP URIs in certificates issued by the
+		// config-next integration test environment.
+		t.Skip()
+	}
+
 	domain := random_domain()
 	err := ctAddRejectHost(domain)
 	if err != nil {

--- a/test/integration/ocsp_test.go
+++ b/test/integration/ocsp_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -17,17 +16,11 @@ import (
 
 func TestOCSPHappyPath(t *testing.T) {
 	t.Parallel()
-	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
-		// We no longer include AIA OCSP URIs in certificates issued by the
-		// config-next integration test environment.
-		t.Skip()
-	}
-
 	cert, err := authAndIssue(nil, nil, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
 	if err != nil || len(cert.certs) < 1 {
 		t.Fatal("failed to issue cert for OCSP testing")
 	}
-	resp, err := ocsp_helper.Req(cert.certs[0], ocsp_helper.DefaultConfig)
+	resp, err := ocsp_helper.Req(cert.certs[0], ocspConf())
 	if err != nil {
 		t.Fatalf("want ocsp response, but got error: %s", err)
 	}
@@ -38,12 +31,6 @@ func TestOCSPHappyPath(t *testing.T) {
 
 func TestOCSPBadSerialPrefix(t *testing.T) {
 	t.Parallel()
-	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
-		// We no longer include AIA OCSP URIs in certificates issued by the
-		// config-next integration test environment.
-		t.Skip()
-	}
-
 	res, err := authAndIssue(nil, nil, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
 	if err != nil || len(res.certs) < 1 {
 		t.Fatal("Failed to issue dummy cert for OCSP testing")
@@ -55,7 +42,7 @@ func TestOCSPBadSerialPrefix(t *testing.T) {
 	serialStr := []byte(core.SerialToString(cert.SerialNumber))
 	serialStr[0] = serialStr[0] + 1
 	cert.SerialNumber.SetString(string(serialStr), 16)
-	_, err = ocsp_helper.Req(cert, ocsp_helper.DefaultConfig)
+	_, err = ocsp_helper.Req(cert, ocspConf())
 	if err == nil {
 		t.Fatal("Expected error getting OCSP for request with invalid serial")
 	}
@@ -63,12 +50,6 @@ func TestOCSPBadSerialPrefix(t *testing.T) {
 
 func TestOCSPRejectedPrecertificate(t *testing.T) {
 	t.Parallel()
-	if strings.Contains(os.Getenv("BOULDER_CONFIG_DIR"), "config-next") {
-		// We no longer include AIA OCSP URIs in certificates issued by the
-		// config-next integration test environment.
-		t.Skip()
-	}
-
 	domain := random_domain()
 	err := ctAddRejectHost(domain)
 	if err != nil {
@@ -93,7 +74,7 @@ func TestOCSPRejectedPrecertificate(t *testing.T) {
 		t.Fatalf("couldn't find rejected precert for %q", domain)
 	}
 
-	ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
+	ocspConfig := ocspConf().WithExpectStatus(ocsp.Good)
 	_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 	if err != nil {
 		t.Errorf("requesting OCSP for rejected precertificate: %s", err)

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/eggsampler/acme/v3"
 	"golang.org/x/crypto/ocsp"
@@ -643,6 +644,10 @@ func TestBadKeyRevoker(t *testing.T) {
 			err = revokerClient.RevokeCertificate(revokerClient.Account, badCert, revokerClient.PrivateKey, ocsp.KeyCompromise)
 			test.AssertNotError(t, err, "failed to revoke certificate")
 		}
+
+		// Give the bad-key-revoker daemon a moment to catch up. Note: sleeping in tests
+		// is bad practice, but we're giving this one a pass because we'll delete these email-based checks soon.
+		time.Sleep(time.Second)
 
 		for _, email := range []string{revokerEmail, revokeeEmail, sharedEmail} {
 			count, err := http.Get(fmt.Sprintf("http://boulder.service.consul:9381/count?to=%s&from=bad-key-revoker@test.org", email))

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -654,7 +654,7 @@ func TestBadKeyRevoker(t *testing.T) {
 	for _, bundle := range bundles {
 		cert := bundle.certs[0]
 		for i := range 5 {
-			t.Logf("TestBadKeyRevoker: Requesting OCSP for cert with serial %x (attempt %d)", bundle.SerialNumber, i)
+			t.Logf("TestBadKeyRevoker: Requesting OCSP for cert with serial %x (attempt %d)", cert.SerialNumber, i)
 			_, err := ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 			if err != nil {
 				t.Logf("TestBadKeyRevoker: Got bad response: %s", err.Error())
@@ -720,7 +720,7 @@ func TestBadKeyRevokerByAccount(t *testing.T) {
 	bundles := []*issuanceResult{}
 	for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
 		bundle, err := authAndIssue(c, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
-		t.Logf("TestBadKeyRevokerByAccount: Issued cert with serial %x", cert.certs[0].SerialNumber)
+		t.Logf("TestBadKeyRevokerByAccount: Issued cert with serial %x", bundle.certs[0].SerialNumber)
 		test.AssertNotError(t, err, "authAndIssue failed")
 		bundles = append(bundles, bundle)
 	}

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -288,7 +288,7 @@ func TestRevocation(t *testing.T) {
 		}
 
 		// Initially, the cert should have a Good OCSP response (only via OCSP; the CRL is unchanged by issuance).
-		ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
+		ocspConfig := ocspConf().WithExpectStatus(ocsp.Good)
 		_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 		test.AssertNotError(t, err, "requesting OCSP for precert")
 

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/eggsampler/acme/v3"
 	"golang.org/x/crypto/ocsp"
@@ -95,6 +94,11 @@ func getAllCRLs(t *testing.T) map[string][]*x509.RevocationList {
 		}
 	}
 	return ret
+}
+
+type revocationCheck struct {
+	cert       *x509.Certificate
+	wantReason int
 }
 
 // getCRL fetches a CRL, parses it, and checks the signature.
@@ -179,6 +183,10 @@ func checkRevoked(t *testing.T, revocations map[string][]*x509.RevocationList, c
 		}
 	}
 	if len(matchingCRLs) == 0 {
+		if expectedReason == ocsp.Good {
+			// If the cert is supposed to be valid, not finding it is a good thing.
+			return
+		}
 		t.Errorf("searching for %x in CRLs: no entry on combined CRLs of length %d", cert.SerialNumber, count)
 	}
 
@@ -266,11 +274,6 @@ func TestRevocation(t *testing.T) {
 			t.Fatalf("unrecognized cert kind %q", tc.kind)
 		}
 
-		// Initially, the cert should have a Good OCSP response.
-		ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
-		_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
-		test.AssertNotError(t, err, "requesting OCSP for precert")
-
 		// Set up the account and key that we'll use to revoke the cert.
 		switch tc.method {
 		case byAccount:
@@ -336,11 +339,9 @@ func TestRevocation(t *testing.T) {
 		return cert
 	}
 
-	// revocationCheck represents a deferred that a specific certificate is revoked.
-	//
-	// We defer these checks for performance reasons: we want to run crl-updater once,
-	// after all certificates have been revoked.
-	type revocationCheck func(t *testing.T, allCRLs map[string][]*x509.RevocationList)
+	// We collect all the revocation checks that we want to do until the end for
+	// performance reasons: we want to run crl-updater once, after all
+	// certificates have been revoked.
 	var revocationChecks []revocationCheck
 	var rcMu sync.Mutex
 	var wg sync.WaitGroup
@@ -377,15 +378,8 @@ func TestRevocation(t *testing.T) {
 					default:
 					}
 
-					check := func(t *testing.T, allCRLs map[string][]*x509.RevocationList) {
-						_, err := ocsp_helper.ReqDER(cert.Raw, ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked).WithExpectReason(expectedReason))
-						test.AssertNotError(t, err, "requesting OCSP for revoked cert")
-
-						checkRevoked(t, allCRLs, cert, expectedReason)
-					}
-
 					rcMu.Lock()
-					revocationChecks = append(revocationChecks, check)
+					revocationChecks = append(revocationChecks, revocationCheck{cert, expectedReason})
 					rcMu.Unlock()
 				}()
 			}
@@ -396,9 +390,8 @@ func TestRevocation(t *testing.T) {
 
 	runUpdater(t, path.Join(os.Getenv("BOULDER_CONFIG_DIR"), "crl-updater.json"))
 	allCRLs := getAllCRLs(t)
-
 	for _, check := range revocationChecks {
-		check(t, allCRLs)
+		checkRevoked(t, allCRLs, check.cert, check.wantReason)
 	}
 }
 
@@ -596,159 +589,85 @@ func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 }
 
 func TestBadKeyRevoker(t *testing.T) {
-	// Both accounts have two email addresses, one of which is shared between
-	// them. All three addresses should receive mail, because the revocation
-	// request is signed by the certificate key, not an account key, so we don't
-	// know who requested the revocation. Finally, a third account with no address
-	// to ensure the bad-key-revoker handles that gracefully.
-	revokerClient, err := makeClient("mailto:revoker@letsencrypt.org", "mailto:shared@letsencrypt.org")
-	test.AssertNotError(t, err, "creating acme client")
-	revokeeClient, err := makeClient("mailto:shared@letsencrypt.org", "mailto:revokee@letsencrypt.org")
-	test.AssertNotError(t, err, "creating acme client")
-	noContactClient, err := makeClient()
-	test.AssertNotError(t, err, "creating acme client")
+	var revocationChecks []revocationCheck
+	for _, kind := range []string{"byKey", "byAccount"} {
+		revokerEmail := fmt.Sprintf("revoker-%s@letsencrypt.org", kind)
+		revokeeEmail := fmt.Sprintf("revoker-%s@letsencrypt.org", kind)
+		sharedEmail := fmt.Sprintf("shared-%s@letsencrypt.org", kind)
 
-	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	test.AssertNotError(t, err, "failed to generate cert key")
+		// Two accounts have two email addresses, one of which is shared between them;
+		// a third account has no address to ensure bad-key-revoker handles that.
+		revokerClient, err := makeClient("mailto:"+revokerEmail, "mailto:"+sharedEmail)
+		test.AssertNotError(t, err, "creating acme client")
+		revokeeClient, err := makeClient("mailto:"+revokeeEmail, "mailto:"+sharedEmail)
+		test.AssertNotError(t, err, "creating acme client")
+		noContactClient, err := makeClient()
+		test.AssertNotError(t, err, "creating acme client")
 
-	res, err := authAndIssue(revokerClient, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
-	test.AssertNotError(t, err, "authAndIssue failed")
-	badCert := res.certs[0]
-	t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
+		certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		test.AssertNotError(t, err, "failed to generate cert key")
 
-	certs := []*x509.Certificate{}
-	for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
-		cert, err := authAndIssue(c, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
-		t.Logf("TestBadKeyRevoker: Issued cert with serial %x", cert.certs[0].SerialNumber)
+		res, err := authAndIssue(revokerClient, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
 		test.AssertNotError(t, err, "authAndIssue failed")
-		certs = append(certs, cert.certs[0])
-	}
+		badCert := res.certs[0]
+		t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
+		revocationChecks = append(revocationChecks, revocationCheck{cert: badCert, wantReason: ocsp.KeyCompromise})
 
-	err = revokerClient.RevokeCertificate(
-		acme.Account{},
-		badCert,
-		certKey,
-		ocsp.KeyCompromise,
-	)
-	test.AssertNotError(t, err, "failed to revoke certificate")
+		certs := []*x509.Certificate{}
+		for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
+			cert, err := authAndIssue(c, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
+			t.Logf("TestBadKeyRevoker: Issued cert with serial %x", cert.certs[0].SerialNumber)
+			test.AssertNotError(t, err, "authAndIssue failed")
+			certs = append(certs, cert.certs[0])
 
-	ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise)
-	_, err = ocsp_helper.ReqDER(badCert.Raw, ocspConfig)
-	test.AssertNotError(t, err, "ReqDER failed")
-
-	for _, cert := range certs {
-		for i := range 5 {
-			t.Logf("TestBadKeyRevoker: Requesting OCSP for cert with serial %x (attempt %d)", cert.SerialNumber, i)
-			_, err := ocsp_helper.ReqDER(cert.Raw, ocspConfig)
-			if err != nil {
-				t.Logf("TestBadKeyRevoker: Got bad response: %s", err.Error())
-				if i >= 4 {
-					t.Fatal("timed out waiting for correct OCSP status")
-				}
-				time.Sleep(time.Second)
-				continue
+			switch kind {
+			case "byKey":
+				// When the first cert is revoked with *proof* of key compromise, all
+				// other certs which share that key should also be revoked by the bad
+				// key revoker.
+				revocationChecks = append(revocationChecks, revocationCheck{cert: cert.certs[0], wantReason: ocsp.KeyCompromise})
+			case "byAccount":
+				// When the subscriber merely *asserts* that the cert's key was
+				// compromised, other certs sharing that key should be untouched.
+				revocationChecks = append(revocationChecks, revocationCheck{cert: cert.certs[0], wantReason: ocsp.Good})
 			}
-			break
+		}
+
+		switch kind {
+		case "byKey":
+			// Revoke the certificate using the cert's own key and a dummy account.
+			err = revokerClient.RevokeCertificate(acme.Account{}, badCert, certKey, ocsp.KeyCompromise)
+			test.AssertNotError(t, err, "failed to revoke certificate")
+		case "byAccount":
+			// Revoke the certificate using the account key as normal.
+			err = revokerClient.RevokeCertificate(revokerClient.Account, badCert, revokerClient.PrivateKey, ocsp.KeyCompromise)
+			test.AssertNotError(t, err, "failed to revoke certificate")
+		}
+
+		for _, email := range []string{revokerEmail, revokeeEmail, sharedEmail} {
+			count, err := http.Get(fmt.Sprintf("http://boulder.service.consul:9381/count?to=%s&from=bad-key-revoker@test.org", email))
+			test.AssertNotError(t, err, "mail-test-srv GET /count failed")
+			defer count.Body.Close()
+			body, err := io.ReadAll(count.Body)
+			test.AssertNotError(t, err, "failed to read body")
+
+			switch kind {
+			case "byKey":
+				// Each recipient should have been notified by bad key revoker, but
+				// only once each to prevent spamminess.
+				test.AssertEquals(t, string(body), "1\n")
+			case "byAccount":
+				// No one should have been notified by bad key revoker, because it
+				// didn't revoke any certs.
+				test.AssertEquals(t, string(body), "0\n")
+			}
 		}
 	}
 
-	revokeeCount, err := http.Get("http://boulder.service.consul:9381/count?to=revokee@letsencrypt.org&from=bad-key-revoker@test.org")
-	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
-	defer func() { _ = revokeeCount.Body.Close() }()
-	body, err := io.ReadAll(revokeeCount.Body)
-	test.AssertNotError(t, err, "failed to read body")
-	test.AssertEquals(t, string(body), "1\n")
-
-	revokerCount, err := http.Get("http://boulder.service.consul:9381/count?to=revoker@letsencrypt.org&from=bad-key-revoker@test.org")
-	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
-	defer func() { _ = revokerCount.Body.Close() }()
-	body, err = io.ReadAll(revokerCount.Body)
-	test.AssertNotError(t, err, "failed to read body")
-	test.AssertEquals(t, string(body), "1\n")
-
-	sharedCount, err := http.Get("http://boulder.service.consul:9381/count?to=shared@letsencrypt.org&from=bad-key-revoker@test.org")
-	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
-	defer func() { _ = sharedCount.Body.Close() }()
-	body, err = io.ReadAll(sharedCount.Body)
-	test.AssertNotError(t, err, "failed to read body")
-	test.AssertEquals(t, string(body), "1\n")
-}
-
-func TestBadKeyRevokerByAccount(t *testing.T) {
-	// Both accounts have two email addresses, one of which is shared between
-	// them. No accounts should receive any mail, because the revocation request
-	// is signed by the account key (not the cert key) and so will not be
-	// propagated to other certs sharing the same key.
-	revokerClient, err := makeClient("mailto:revoker-moz@letsencrypt.org", "mailto:shared-moz@letsencrypt.org")
-	test.AssertNotError(t, err, "creating acme client")
-	revokeeClient, err := makeClient("mailto:shared-moz@letsencrypt.org", "mailto:revokee-moz@letsencrypt.org")
-	test.AssertNotError(t, err, "creating acme client")
-	noContactClient, err := makeClient()
-	test.AssertNotError(t, err, "creating acme client")
-
-	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	test.AssertNotError(t, err, "failed to generate cert key")
-
-	res, err := authAndIssue(revokerClient, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
-	test.AssertNotError(t, err, "authAndIssue failed")
-	badCert := res.certs[0]
-	t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
-
-	certs := []*x509.Certificate{}
-	for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
-		cert, err := authAndIssue(c, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
-		t.Logf("TestBadKeyRevokerByAccount: Issued cert with serial %x", cert.certs[0].SerialNumber)
-		test.AssertNotError(t, err, "authAndIssue failed")
-		certs = append(certs, cert.certs[0])
+	// Finally check that all of the revocations actually happened as expected.
+	runUpdater(t, path.Join(os.Getenv("BOULDER_CONFIG_DIR"), "crl-updater.json"))
+	allCRLs := getAllCRLs(t)
+	for _, check := range revocationChecks {
+		checkRevoked(t, allCRLs, check.cert, check.wantReason)
 	}
-
-	err = revokerClient.RevokeCertificate(
-		revokerClient.Account,
-		badCert,
-		revokerClient.PrivateKey,
-		ocsp.KeyCompromise,
-	)
-	test.AssertNotError(t, err, "failed to revoke certificate")
-
-	ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise)
-	_, err = ocsp_helper.ReqDER(badCert.Raw, ocspConfig)
-	test.AssertNotError(t, err, "ReqDER failed")
-
-	ocspConfig = ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
-	for _, cert := range certs {
-		for i := range 5 {
-			t.Logf("TestBadKeyRevoker: Requesting OCSP for cert with serial %x (attempt %d)", cert.SerialNumber, i)
-			_, err := ocsp_helper.ReqDER(cert.Raw, ocspConfig)
-			if err != nil {
-				t.Logf("TestBadKeyRevoker: Got bad response: %s", err.Error())
-				if i >= 4 {
-					t.Fatal("timed out waiting for correct OCSP status")
-				}
-				time.Sleep(time.Second)
-				continue
-			}
-			break
-		}
-	}
-
-	revokeeCount, err := http.Get("http://boulder.service.consul:9381/count?to=revokee-moz@letsencrypt.org&from=bad-key-revoker@test.org")
-	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
-	defer func() { _ = revokeeCount.Body.Close() }()
-	body, err := io.ReadAll(revokeeCount.Body)
-	test.AssertNotError(t, err, "failed to read body")
-	test.AssertEquals(t, string(body), "0\n")
-
-	revokerCount, err := http.Get("http://boulder.service.consul:9381/count?to=revoker-moz@letsencrypt.org&from=bad-key-revoker@test.org")
-	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
-	defer func() { _ = revokerCount.Body.Close() }()
-	body, err = io.ReadAll(revokerCount.Body)
-	test.AssertNotError(t, err, "failed to read body")
-	test.AssertEquals(t, string(body), "0\n")
-
-	sharedCount, err := http.Get("http://boulder.service.consul:9381/count?to=shared-moz@letsencrypt.org&from=bad-key-revoker@test.org")
-	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
-	defer func() { _ = sharedCount.Body.Close() }()
-	body, err = io.ReadAll(sharedCount.Body)
-	test.AssertNotError(t, err, "failed to read body")
-	test.AssertEquals(t, string(body), "0\n")
 }

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -441,11 +441,6 @@ func TestReRevocation(t *testing.T) {
 			cert := res.certs[0]
 			issuer := res.certs[1]
 
-			// Initially, the cert should have a Good OCSP response.
-			ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good)
-			_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
-			test.AssertNotError(t, err, "requesting OCSP for precert")
-
 			// Set up the account and key that we'll use to revoke the cert.
 			var revokeClient *client
 			var revokeKey crypto.Signer
@@ -647,7 +642,7 @@ func TestBadKeyRevoker(t *testing.T) {
 
 		// Give the bad-key-revoker daemon a moment to catch up. Note: sleeping in tests
 		// is bad practice, but we're giving this one a pass because we'll delete these email-based checks soon.
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 
 		for _, email := range []string{revokerEmail, revokeeEmail, sharedEmail} {
 			count, err := http.Get(fmt.Sprintf("http://boulder.service.consul:9381/count?to=%s&from=bad-key-revoker@test.org", email))

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -43,6 +43,13 @@ func isPrecert(cert *x509.Certificate) bool {
 	return false
 }
 
+// ocspConf returns an OCSP helper config with a fallback URL that matches what is
+// configured for our CA / OCSP responder. This allows continuing to test OCSP
+// service even after we stop including OCSP URLs in certificates.
+func ocspConf() ocsp_helper.Config {
+	return ocsp_helper.DefaultConfig.WithURLFallback("http://ca.example.org:4002/")
+}
+
 // getALLCRLs fetches and parses each certificate for each configured CA.
 // Returns a map from issuer SKID (hex) to a list of that issuer's CRLs.
 func getAllCRLs(t *testing.T) map[string][]*x509.RevocationList {
@@ -160,6 +167,18 @@ func fetchAndCheckRevoked(t *testing.T, cert, issuer *x509.Certificate, expected
 	t.Errorf("serial %x not found on CRL %s, expected it to be revoked with reason %d", cert.SerialNumber, crlURL, expectedReason)
 }
 
+func checkUnrevoked(t *testing.T, revocations map[string][]*x509.RevocationList, cert *x509.Certificate) {
+	for _, singleIssuerCRLs := range revocations {
+		for _, crl := range singleIssuerCRLs {
+			for _, entry := range crl.RevokedCertificateEntries {
+				if entry.SerialNumber == cert.SerialNumber {
+					t.Errorf("expected %x to be unrevoked, but found it on a CRL", cert.SerialNumber)
+				}
+			}
+		}
+	}
+}
+
 func checkRevoked(t *testing.T, revocations map[string][]*x509.RevocationList, cert *x509.Certificate, expectedReason int) {
 	t.Helper()
 	akid := hex.EncodeToString(cert.AuthorityKeyId)
@@ -185,10 +204,6 @@ func checkRevoked(t *testing.T, revocations map[string][]*x509.RevocationList, c
 		}
 	}
 	if len(matchingCRLs) == 0 {
-		if expectedReason == ocsp.Good {
-			// If the cert is supposed to be valid, not finding it is a good thing.
-			return
-		}
 		t.Errorf("searching for %x in CRLs: no entry on combined CRLs of length %d", cert.SerialNumber, count)
 	}
 
@@ -341,9 +356,11 @@ func TestRevocation(t *testing.T) {
 		return cert
 	}
 
-	// We collect all the revocation checks that we want to do until the end for
-	// performance reasons: we want to run crl-updater once, after all
-	// certificates have been revoked.
+	// revocationCheck represents a deferred that a specific certificate is revoked.
+	//
+	// We defer these checks for performance reasons: we want to run crl-updater once,
+	// after all certificates have been revoked.
+	type revocationCheck func(t *testing.T, allCRLs map[string][]*x509.RevocationList)
 	var revocationChecks []revocationCheck
 	var rcMu sync.Mutex
 	var wg sync.WaitGroup
@@ -380,8 +397,16 @@ func TestRevocation(t *testing.T) {
 					default:
 					}
 
+					check := func(t *testing.T, allCRLs map[string][]*x509.RevocationList) {
+						ocsp_config := ocspConf().WithExpectStatus(ocsp.Revoked).WithExpectReason(expectedReason)
+						_, err := ocsp_helper.ReqDER(cert.Raw, ocsp_config)
+						test.AssertNotError(t, err, "requesting OCSP for revoked cert")
+
+						checkRevoked(t, allCRLs, cert, expectedReason)
+					}
+
 					rcMu.Lock()
-					revocationChecks = append(revocationChecks, revocationCheck{cert, expectedReason})
+					revocationChecks = append(revocationChecks, check)
 					rcMu.Unlock()
 				}()
 			}
@@ -392,8 +417,9 @@ func TestRevocation(t *testing.T) {
 
 	runUpdater(t, path.Join(os.Getenv("BOULDER_CONFIG_DIR"), "crl-updater.json"))
 	allCRLs := getAllCRLs(t)
+
 	for _, check := range revocationChecks {
-		checkRevoked(t, allCRLs, check.cert, check.wantReason)
+		check(t, allCRLs)
 	}
 }
 
@@ -510,7 +536,7 @@ func TestReRevocation(t *testing.T) {
 
 				// Check the OCSP response for the certificate again. It should still be
 				// revoked, with the same reason.
-				ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked).WithExpectReason(tc.reason1).WithURLFallback("http://ca.example.org:4002/")
+				ocspConfig := ocspConf().WithExpectStatus(ocsp.Revoked).WithExpectReason(tc.reason1)
 				_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 				// Check the CRL for the certificate again. It should still be
 				// revoked, with the same reason.
@@ -522,7 +548,7 @@ func TestReRevocation(t *testing.T) {
 
 				// Check the OCSP response for the certificate again. It should now be
 				// revoked with reason keyCompromise.
-				ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked).WithExpectReason(tc.reason2).WithURLFallback("http://ca.example.org:4002/")
+				ocspConfig := ocspConf().WithExpectStatus(ocsp.Revoked).WithExpectReason(tc.reason2)
 				_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 				// Check the CRL for the certificate again. It should now be
 				// revoked with reason keyCompromise.
@@ -557,7 +583,7 @@ func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 		cert := res.certs[0]
 		issuer := res.certs[1]
 
-		ocspConfig := ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Good).WithURLFallback("http://ca.example.org:4002/")
+		ocspConfig := ocspConf().WithExpectStatus(ocsp.Good)
 		_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 		test.AssertNotError(t, err, "requesting OCSP for not yet revoked cert")
 
@@ -572,7 +598,7 @@ func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 		test.AssertNotError(t, err, "failed to revoke certificate")
 
 		// Check the OCSP response. It should be revoked with reason = 1 (keyCompromise).
-		ocspConfig = ocsp_helper.DefaultConfig.WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise).WithURLFallback("http://ca.example.org:4002/")
+		ocspConfig = ocspConf().WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise)
 		_, err = ocsp_helper.ReqDER(cert.Raw, ocspConfig)
 		test.AssertNotError(t, err, "requesting OCSP for revoked cert")
 
@@ -594,89 +620,159 @@ func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
 }
 
 func TestBadKeyRevoker(t *testing.T) {
-	var revocationChecks []revocationCheck
-	for _, kind := range []string{"byKey", "byAccount"} {
-		revokerEmail := fmt.Sprintf("revoker-%s@letsencrypt.org", kind)
-		revokeeEmail := fmt.Sprintf("revoker-%s@letsencrypt.org", kind)
-		sharedEmail := fmt.Sprintf("shared-%s@letsencrypt.org", kind)
+	// Both accounts have two email addresses, one of which is shared between
+	// them. All three addresses should receive mail, because the revocation
+	// request is signed by the certificate key, not an account key, so we don't
+	// know who requested the revocation. Finally, a third account with no address
+	// to ensure the bad-key-revoker handles that gracefully.
+	revokerClient, err := makeClient("mailto:revoker@letsencrypt.org", "mailto:shared@letsencrypt.org")
+	test.AssertNotError(t, err, "creating acme client")
+	revokeeClient, err := makeClient("mailto:shared@letsencrypt.org", "mailto:revokee@letsencrypt.org")
+	test.AssertNotError(t, err, "creating acme client")
+	noContactClient, err := makeClient()
+	test.AssertNotError(t, err, "creating acme client")
 
-		// Two accounts have two email addresses, one of which is shared between them;
-		// a third account has no address to ensure bad-key-revoker handles that.
-		revokerClient, err := makeClient("mailto:"+revokerEmail, "mailto:"+sharedEmail)
-		test.AssertNotError(t, err, "creating acme client")
-		revokeeClient, err := makeClient("mailto:"+revokeeEmail, "mailto:"+sharedEmail)
-		test.AssertNotError(t, err, "creating acme client")
-		noContactClient, err := makeClient()
-		test.AssertNotError(t, err, "creating acme client")
+	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "failed to generate cert key")
 
-		certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		test.AssertNotError(t, err, "failed to generate cert key")
+	res, err := authAndIssue(revokerClient, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
+	test.AssertNotError(t, err, "authAndIssue failed")
+	badCert := res.certs[0]
+	t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
 
-		res, err := authAndIssue(revokerClient, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
+	certs := []*x509.Certificate{}
+	for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
+		cert, err := authAndIssue(c, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
+		t.Logf("TestBadKeyRevoker: Issued cert with serial %x", cert.certs[0].SerialNumber)
 		test.AssertNotError(t, err, "authAndIssue failed")
-		badCert := res.certs[0]
-		t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
-		revocationChecks = append(revocationChecks, revocationCheck{cert: badCert, wantReason: ocsp.KeyCompromise})
+		certs = append(certs, cert.certs[0])
+	}
 
-		certs := []*x509.Certificate{}
-		for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
-			cert, err := authAndIssue(c, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
-			t.Logf("TestBadKeyRevoker: Issued cert with serial %x", cert.certs[0].SerialNumber)
-			test.AssertNotError(t, err, "authAndIssue failed")
-			certs = append(certs, cert.certs[0])
+	err = revokerClient.RevokeCertificate(
+		acme.Account{},
+		badCert,
+		certKey,
+		ocsp.KeyCompromise,
+	)
+	test.AssertNotError(t, err, "failed to revoke certificate")
 
-			switch kind {
-			case "byKey":
-				// When the first cert is revoked with *proof* of key compromise, all
-				// other certs which share that key should also be revoked by the bad
-				// key revoker.
-				revocationChecks = append(revocationChecks, revocationCheck{cert: cert.certs[0], wantReason: ocsp.KeyCompromise})
-			case "byAccount":
-				// When the subscriber merely *asserts* that the cert's key was
-				// compromised, other certs sharing that key should be untouched.
-				revocationChecks = append(revocationChecks, revocationCheck{cert: cert.certs[0], wantReason: ocsp.Good})
+	ocspConfig := ocspConf().WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise)
+	_, err = ocsp_helper.ReqDER(badCert.Raw, ocspConfig)
+	test.AssertNotError(t, err, "ReqDER failed")
+
+	for _, cert := range certs {
+		for i := range 5 {
+			t.Logf("TestBadKeyRevoker: Requesting OCSP for cert with serial %x (attempt %d)", cert.SerialNumber, i)
+			_, err := ocsp_helper.ReqDER(cert.Raw, ocspConfig)
+			if err != nil {
+				t.Logf("TestBadKeyRevoker: Got bad response: %s", err.Error())
+				if i >= 4 {
+					t.Fatal("timed out waiting for correct OCSP status")
+				}
+				time.Sleep(time.Second)
+				continue
 			}
-		}
-
-		switch kind {
-		case "byKey":
-			// Revoke the certificate using the cert's own key and a dummy account.
-			err = revokerClient.RevokeCertificate(acme.Account{}, badCert, certKey, ocsp.KeyCompromise)
-			test.AssertNotError(t, err, "failed to revoke certificate")
-		case "byAccount":
-			// Revoke the certificate using the account key as normal.
-			err = revokerClient.RevokeCertificate(revokerClient.Account, badCert, revokerClient.PrivateKey, ocsp.KeyCompromise)
-			test.AssertNotError(t, err, "failed to revoke certificate")
-		}
-
-		// Give the bad-key-revoker daemon a moment to catch up. Note: sleeping in tests
-		// is bad practice, but we're giving this one a pass because we'll delete these email-based checks soon.
-		time.Sleep(2 * time.Second)
-
-		for _, email := range []string{revokerEmail, revokeeEmail, sharedEmail} {
-			count, err := http.Get(fmt.Sprintf("http://boulder.service.consul:9381/count?to=%s&from=bad-key-revoker@test.org", email))
-			test.AssertNotError(t, err, "mail-test-srv GET /count failed")
-			defer count.Body.Close()
-			body, err := io.ReadAll(count.Body)
-			test.AssertNotError(t, err, "failed to read body")
-
-			switch kind {
-			case "byKey":
-				// Each recipient should have been notified by bad key revoker, but
-				// only once each to prevent spamminess.
-				test.AssertEquals(t, string(body), "1\n")
-			case "byAccount":
-				// No one should have been notified by bad key revoker, because it
-				// didn't revoke any certs.
-				test.AssertEquals(t, string(body), "0\n")
-			}
+			break
 		}
 	}
 
-	// Finally check that all of the revocations actually happened as expected.
-	runUpdater(t, path.Join(os.Getenv("BOULDER_CONFIG_DIR"), "crl-updater.json"))
-	allCRLs := getAllCRLs(t)
-	for _, check := range revocationChecks {
-		checkRevoked(t, allCRLs, check.cert, check.wantReason)
+	revokeeCount, err := http.Get("http://boulder.service.consul:9381/count?to=revokee@letsencrypt.org&from=bad-key-revoker@test.org")
+	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
+	defer func() { _ = revokeeCount.Body.Close() }()
+	body, err := io.ReadAll(revokeeCount.Body)
+	test.AssertNotError(t, err, "failed to read body")
+	test.AssertEquals(t, string(body), "1\n")
+
+	revokerCount, err := http.Get("http://boulder.service.consul:9381/count?to=revoker@letsencrypt.org&from=bad-key-revoker@test.org")
+	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
+	defer func() { _ = revokerCount.Body.Close() }()
+	body, err = io.ReadAll(revokerCount.Body)
+	test.AssertNotError(t, err, "failed to read body")
+	test.AssertEquals(t, string(body), "1\n")
+
+	sharedCount, err := http.Get("http://boulder.service.consul:9381/count?to=shared@letsencrypt.org&from=bad-key-revoker@test.org")
+	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
+	defer func() { _ = sharedCount.Body.Close() }()
+	body, err = io.ReadAll(sharedCount.Body)
+	test.AssertNotError(t, err, "failed to read body")
+	test.AssertEquals(t, string(body), "1\n")
+}
+
+func TestBadKeyRevokerByAccount(t *testing.T) {
+	// Both accounts have two email addresses, one of which is shared between
+	// them. No accounts should receive any mail, because the revocation request
+	// is signed by the account key (not the cert key) and so will not be
+	// propagated to other certs sharing the same key.
+	revokerClient, err := makeClient("mailto:revoker-moz@letsencrypt.org", "mailto:shared-moz@letsencrypt.org")
+	test.AssertNotError(t, err, "creating acme client")
+	revokeeClient, err := makeClient("mailto:shared-moz@letsencrypt.org", "mailto:revokee-moz@letsencrypt.org")
+	test.AssertNotError(t, err, "creating acme client")
+	noContactClient, err := makeClient()
+	test.AssertNotError(t, err, "creating acme client")
+
+	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.AssertNotError(t, err, "failed to generate cert key")
+
+	res, err := authAndIssue(revokerClient, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
+	test.AssertNotError(t, err, "authAndIssue failed")
+	badCert := res.certs[0]
+	t.Logf("Generated to-be-revoked cert with serial %x", badCert.SerialNumber)
+
+	certs := []*x509.Certificate{}
+	for _, c := range []*client{revokerClient, revokeeClient, noContactClient} {
+		cert, err := authAndIssue(c, certKey, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "")
+		t.Logf("TestBadKeyRevokerByAccount: Issued cert with serial %x", cert.certs[0].SerialNumber)
+		test.AssertNotError(t, err, "authAndIssue failed")
+		certs = append(certs, cert.certs[0])
 	}
+
+	err = revokerClient.RevokeCertificate(
+		revokerClient.Account,
+		badCert,
+		revokerClient.PrivateKey,
+		ocsp.KeyCompromise,
+	)
+	test.AssertNotError(t, err, "failed to revoke certificate")
+
+	ocspConfig := ocspConf().WithExpectStatus(ocsp.Revoked).WithExpectReason(ocsp.KeyCompromise)
+	_, err = ocsp_helper.ReqDER(badCert.Raw, ocspConfig)
+	test.AssertNotError(t, err, "ReqDER failed")
+
+	ocspConfig = ocspConf().WithExpectStatus(ocsp.Good)
+	for _, cert := range certs {
+		for i := range 5 {
+			t.Logf("TestBadKeyRevoker: Requesting OCSP for cert with serial %x (attempt %d)", cert.SerialNumber, i)
+			_, err := ocsp_helper.ReqDER(cert.Raw, ocspConfig)
+			if err != nil {
+				t.Logf("TestBadKeyRevoker: Got bad response: %s", err.Error())
+				if i >= 4 {
+					t.Fatal("timed out waiting for correct OCSP status")
+				}
+				time.Sleep(time.Second)
+				continue
+			}
+			break
+		}
+	}
+
+	revokeeCount, err := http.Get("http://boulder.service.consul:9381/count?to=revokee-moz@letsencrypt.org&from=bad-key-revoker@test.org")
+	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
+	defer func() { _ = revokeeCount.Body.Close() }()
+	body, err := io.ReadAll(revokeeCount.Body)
+	test.AssertNotError(t, err, "failed to read body")
+	test.AssertEquals(t, string(body), "0\n")
+
+	revokerCount, err := http.Get("http://boulder.service.consul:9381/count?to=revoker-moz@letsencrypt.org&from=bad-key-revoker@test.org")
+	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
+	defer func() { _ = revokerCount.Body.Close() }()
+	body, err = io.ReadAll(revokerCount.Body)
+	test.AssertNotError(t, err, "failed to read body")
+	test.AssertEquals(t, string(body), "0\n")
+
+	sharedCount, err := http.Get("http://boulder.service.consul:9381/count?to=shared-moz@letsencrypt.org&from=bad-key-revoker@test.org")
+	test.AssertNotError(t, err, "mail-test-srv GET /count failed")
+	defer func() { _ = sharedCount.Body.Close() }()
+	body, err = io.ReadAll(sharedCount.Body)
+	test.AssertNotError(t, err, "failed to read body")
+	test.AssertEquals(t, string(body), "0\n")
 }

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -430,8 +430,6 @@ func TestRevocation(t *testing.T) {
 // In which case the revocation reason (but not revocation date) will be
 // updated to be keyCompromise.
 func TestReRevocation(t *testing.T) {
-	t.Parallel()
-
 	type authMethod string
 	var (
 		byAccount authMethod = "byAccount"
@@ -560,8 +558,6 @@ func TestReRevocation(t *testing.T) {
 }
 
 func TestRevokeWithKeyCompromiseBlocksKey(t *testing.T) {
-	t.Parallel()
-
 	type authMethod string
 	var (
 		byAccount authMethod = "byAccount"


### PR DESCRIPTION
Add a new config field for profiles which causes the profile to omit the AIA OCSP URI. It can only be omitted if the CRLDP extension is configured to be included instead. Enable this flag in config-next.

When a certificate is revoked, if it does not have an AIA OCSP URI, don't bother with an Akamai OCSP purge.

Builds on #8089

Most of the changes in this PR relate to tests. Different from #8089, I chose to keep testing of OCSP in the config-next world. This is because we intend to keep operating OCSP even after we have stopped including it in new certificates. So we should test it in as many environments as possible.

Adds a WithURLFallback option to ocsp_helper. When `ocsp_helper.ReqDer()` is called for a certificate with no OCSP URI, it will query the fallback URL instead. As before, if the certificate has an OCSP URI ocsp_helper will use that. Use that for all places in the integration tests that call ocsp_helper. Note for reviewers: This PR is also acting as a forcing function to _add_ equivalent CRL-based checks to everything that currently uses OCSP. You should be checking that each place that has calls `ocspConf()` (i.e. sets a fallback OCSP URL) has a corresponding runUpdater / fetchAndCheckRevoked or checkUnrevoked call corresponding. A couple of places already call runUpdater and check the CRLs for revocation:

 - TestRevocation has an existing check on revocation_test.go lines 419-425.
 - TestReRevocation has an existing check on revocation_test.go line 519.
 
And two places don't need a call to runUpdater / fetchAndCheckRevoked: In both TestRevocation and TestReRevocation, we have calls starting with the comment "Initially, ...". These verify that OCSP has a "good" status right after issuance. There's no corresponding behavior for CRLs: issuing a certificate does not change the CRLs because unrevoked certificates are simply not listed. These "Initially, ..." calls will simply go away once we fully deprecate OCSP service.