### PR TITLE
admin: Fix race in revokeSerials

### DIFF
--- a/cmd/admin/cert.go
+++ b/cmd/admin/cert.go
@@ -323,7 +323,7 @@ func (a *admin) revokeSerials(ctx context.Context, serials []string, reason revo
 		go func() {
 			defer wg.Done()
 			for serial := range work {
-				_, err = a.rac.AdministrativelyRevokeCertificate(
+				_, err := a.rac.AdministrativelyRevokeCertificate(
 					ctx,
 					&rapb.AdministrativelyRevokeCertificateRequest{
 						Serial:       serial,


### PR DESCRIPTION
Redeclare `err` rather than assigning to the parent function's `err`, as there are multiple goroutines running. Thanks to @jsha for the diagnosis.