### PR TITLE
test: copy some config-next settings to config

### DIFF
--- a/test/config-next/observer.yml
+++ b/test/config-next/observer.yml
@@ -1,4 +1,4 @@
---- 
+---
 buckets: [.001, .002, .005, .01, .02, .05, .1, .2, .5, 1, 2, 5, 10]
 syslog:
   stdoutlevel: 6
@@ -31,10 +31,10 @@ monitors:
       recurse: true
       query_name: google.com
       query_type: A
-  - 
+  -
     period: 2s
     kind: HTTP
-    settings: 
+    settings:
       url: https://letsencrypt.org
       rcodes: [200]
       useragent: "letsencrypt/boulder-observer-http-client"
@@ -83,10 +83,15 @@ monitors:
       recurse: true
       query_name: google.com
       query_type: A
-  - 
+  -
     period: 2s
     kind: HTTP
-    settings: 
+    settings:
       url: http://letsencrypt.org/foo
       rcodes: [200, 404]
       useragent: "letsencrypt/boulder-observer-http-client"
+  -
+    period: 10s
+    kind: TCP
+    settings:
+      hostport: acme-v02.api.letsencrypt.org:443

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -1,6 +1,5 @@
 {
 	"ca": {
-		"debugAddr": ":8001",
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/ca.boulder/cert.pem",
@@ -54,7 +53,6 @@
 			"hostOverride": "sa.boulder"
 		},
 		"issuance": {
-			"defaultCertificateProfileName": "legacy",
 			"certProfiles": {
 				"legacy": {
 					"allowMustStaple": true,
@@ -179,11 +177,10 @@
 		"serialPrefixHex": "6e",
 		"maxNames": 100,
 		"lifespanOCSP": "96h",
-		"goodkey": {
-			"fermatRounds": 100
-		},
+		"goodkey": {},
 		"ocspLogMaxLength": 4000,
 		"ocspLogPeriod": "500ms",
+		"ctLogListFile": "test/ct-test-srv/log_list.json",
 		"features": {}
 	},
 	"pa": {

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -5,9 +5,6 @@
 			"maxOpenConns": 10
 		},
 		"hostnamePolicyFile": "test/hostname-policy.yaml",
-		"goodkey": {
-			"fermatRounds": 100
-		},
 		"workers": 16,
 		"unexpiredOnly": true,
 		"badResultsOnly": true,
@@ -17,8 +14,10 @@
 		],
 		"ignoredLints": [
 			"w_subject_common_name_included",
+			"w_ext_subject_key_identifier_missing_sub_cert",
 			"w_ext_subject_key_identifier_not_recommended_subscriber"
-		]
+		],
+		"ctLogListFile": "test/ct-test-srv/log_list.json"
 	},
 	"pa": {
 		"challenges": {

--- a/test/config/log-validator.json
+++ b/test/config/log-validator.json
@@ -2,21 +2,15 @@
 	"syslog": {
 		"stdoutLevel": 7
 	},
-	"debugAddr": ":8016",
+	"openTelemetry": {
+		"endpoint": "bjaeger:4317",
+		"sampleratio": 1
+	},
 	"files": [
 		"/var/log/akamai-purger.log",
 		"/var/log/bad-key-revoker.log",
-		"/var/log/boulder-ca.log",
-		"/var/log/boulder-observer.log",
-		"/var/log/boulder-publisher.log",
-		"/var/log/boulder-ra.log",
-		"/var/log/boulder-remoteva.log",
-		"/var/log/boulder-sa.log",
-		"/var/log/boulder-va.log",
-		"/var/log/boulder-wfe2.log",
-		"/var/log/sfe.log",
-		"/var/log/crl-storer.log",
-		"/var/log/crl-updater.log",
+		"/var/log/boulder-*.log",
+		"/var/log/crl-*.log",
 		"/var/log/nonce-service.log",
 		"/var/log/ocsp-responder.log"
 	]

--- a/test/config/observer.yml
+++ b/test/config/observer.yml
@@ -1,5 +1,4 @@
 --- 
-debugaddr: :8040
 buckets: [.001, .002, .005, .01, .02, .05, .1, .2, .5, 1, 2, 5, 10]
 syslog:
   stdoutlevel: 6
@@ -38,6 +37,7 @@ monitors:
     settings: 
       url: https://letsencrypt.org
       rcodes: [200]
+      useragent: "letsencrypt/boulder-observer-http-client"
   -
     period: 5s
     kind: DNS
@@ -83,12 +83,13 @@ monitors:
       recurse: true
       query_name: google.com
       query_type: A
-  -
+  - 
     period: 2s
     kind: HTTP
-    settings:
+    settings: 
       url: http://letsencrypt.org/foo
       rcodes: [200, 404]
+      useragent: "letsencrypt/boulder-observer-http-client"
   -
     period: 10s
     kind: TCP

--- a/test/config/publisher.json
+++ b/test/config/publisher.json
@@ -20,10 +20,8 @@
 				"test/certs/webpki/root-ecdsa.cert.pem"
 			]
 		],
-		"debugAddr": ":8009",
 		"grpc": {
 			"maxConnectionAge": "30s",
-			"address": ":9091",
 			"services": {
 				"Publisher": {
 					"clientNames": [

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -1,6 +1,5 @@
 {
 	"ra": {
-		"rateLimitPoliciesFilename": "test/rate-limit-policies.yml",
 		"limiter": {
 			"redis": {
 				"username": "boulder-wfe",
@@ -28,10 +27,7 @@
 		"maxContactsPerRegistration": 3,
 		"debugAddr": ":8002",
 		"hostnamePolicyFile": "test/hostname-policy.yaml",
-		"maxNames": 100,
-		"goodkey": {
-			"fermatRounds": 100
-		},
+		"goodkey": {},
 		"issuerCerts": [
 			"test/certs/webpki/int-rsa-a.cert.pem",
 			"test/certs/webpki/int-rsa-b.cert.pem",
@@ -44,17 +40,20 @@
 			"legacy": {
 				"pendingAuthzLifetime": "168h",
 				"validAuthzLifetime": "720h",
-				"orderLifetime": "168h"
+				"orderLifetime": "168h",
+				"maxNames": 100
 			},
 			"modern": {
 				"pendingAuthzLifetime": "7h",
 				"validAuthzLifetime": "7h",
-				"orderLifetime": "7h"
+				"orderLifetime": "7h",
+				"maxNames": 10
 			},
 			"shortlived": {
 				"pendingAuthzLifetime": "7h",
 				"validAuthzLifetime": "7h",
-				"orderLifetime": "7h"
+				"orderLifetime": "7h",
+				"maxNames": 10
 			}
 		},
 		"defaultProfileName": "legacy",
@@ -125,15 +124,14 @@
 		},
 		"grpc": {
 			"maxConnectionAge": "30s",
-			"address": ":9094",
 			"services": {
 				"ra.RegistrationAuthority": {
 					"clientNames": [
 						"admin.boulder",
 						"bad-key-revoker.boulder",
 						"ocsp-responder.boulder",
-						"sfe.boulder",
-						"wfe.boulder"
+						"wfe.boulder",
+						"sfe.boulder"
 					]
 				},
 				"ra.SCTProvider": {
@@ -149,8 +147,10 @@
 			}
 		},
 		"features": {
-			"UseKvLimitsForNewOrder": true,
-			"IncrementRateLimits": true
+			"AutomaticallyPauseZombieClients": true,
+			"NoPendingAuthzReuse": true,
+			"EnforceMPIC": true,
+			"UnsplitIssuance": true
 		},
 		"ctLogs": {
 			"stagger": "500ms",

--- a/test/config/remoteva-a.json
+++ b/test/config/remoteva-a.json
@@ -39,7 +39,9 @@
 				}
 			}
 		},
-		"features": {},
+		"features": {
+			"DOH": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config/remoteva-a.json
+++ b/test/config/remoteva-a.json
@@ -6,7 +6,7 @@
 		"dnsProvider": {
 			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
-				"service": "dns",
+				"service": "doh",
 				"domain": "service.consul"
 			}
 		},

--- a/test/config/remoteva-b.json
+++ b/test/config/remoteva-b.json
@@ -39,7 +39,9 @@
 				}
 			}
 		},
-		"features": {},
+		"features": {
+			"DOH": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config/remoteva-b.json
+++ b/test/config/remoteva-b.json
@@ -6,7 +6,7 @@
 		"dnsProvider": {
 			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
-				"service": "dns",
+				"service": "doh",
 				"domain": "service.consul"
 			}
 		},

--- a/test/config/remoteva-c.json
+++ b/test/config/remoteva-c.json
@@ -39,7 +39,9 @@
 				}
 			}
 		},
-		"features": {},
+		"features": {
+			"DOH": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config/remoteva-c.json
+++ b/test/config/remoteva-c.json
@@ -6,7 +6,7 @@
 		"dnsProvider": {
 			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
-				"service": "dns",
+				"service": "doh",
 				"domain": "service.consul"
 			}
 		},

--- a/test/config/sa.json
+++ b/test/config/sa.json
@@ -8,8 +8,13 @@
 			"dbConnectFile": "test/secrets/sa_ro_dburl",
 			"maxOpenConns": 100
 		},
+		"incidentsDB": {
+			"dbConnectFile": "test/secrets/incidents_dburl",
+			"maxOpenConns": 100
+		},
 		"ParallelismPerRPC": 20,
 		"debugAddr": ":8003",
+		"lagFactor": "200ms",
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/sa.boulder/cert.pem",
@@ -25,18 +30,15 @@
 						"ca.boulder",
 						"crl-updater.boulder",
 						"expiration-mailer.boulder",
-						"ocsp-responder.boulder",
-						"ra.boulder",
-						"wfe.boulder"
+						"ra.boulder"
 					]
 				},
 				"sa.StorageAuthorityReadOnly": {
 					"clientNames": [
 						"admin.boulder",
-						"crl-updater.boulder",
 						"ocsp-responder.boulder",
-						"sfe.boulder",
-						"wfe.boulder"
+						"wfe.boulder",
+						"sfe.boulder"
 					]
 				},
 				"grpc.health.v1.Health": {
@@ -48,7 +50,6 @@
 			}
 		},
 		"features": {
-			"UseKvLimitsForNewOrder": true,
 			"MultipleCertificateProfiles": true,
 			"InsertAuthzsIndividually": true
 		}

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -6,7 +6,7 @@
 		"dnsProvider": {
 			"dnsAuthority": "consul.service.consul",
 			"srvLookup": {
-				"service": "dns",
+				"service": "doh",
 				"domain": "service.consul"
 			}
 		},
@@ -38,7 +38,9 @@
 				}
 			}
 		},
-		"features": {},
+		"features": {
+			"DOH": true
+		},
 		"remoteVAs": [
 			{
 				"serverAddress": "rva1.service.consul:9397",
@@ -62,7 +64,6 @@
 				"rir": "ARIN"
 			}
 		],
-		"maxRemoteValidationFailures": 1,
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -1,5 +1,6 @@
 {
 	"wfe": {
+		"timeout": "30s",
 		"listenAddress": "0.0.0.0:4001",
 		"TLSListenAddress": "0.0.0.0:4431",
 		"serverCertificatePath": "test/certs/ipki/boulder/cert.pem",
@@ -100,8 +101,6 @@
 			]
 		],
 		"staleTimeout": "5m",
-		"authorizationLifetimeDays": 30,
-		"pendingAuthorizationLifetimeDays": 7,
 		"limiter": {
 			"redis": {
 				"username": "boulder-wfe",
@@ -127,9 +126,7 @@
 			"Overrides": "test/config/wfe2-ratelimit-overrides.yml"
 		},
 		"features": {
-			"UseKvLimitsForNewOrder": true,
 			"ServeRenewalInfo": true,
-			"IncrementRateLimits": true,
 			"CheckIdentifiersPaused": true
 		},
 		"certProfiles": {


### PR DESCRIPTION
Methodology:

 - Copy test/config-next/* to test/config/.
 - Review the diff, reverting things that should stay `next`-only.
 - When in doubt, check against prod configs (e.g. for feature flags).

In the process I noticed that config for the TCP prober in `observer` had been added to test/config but not test/config-next, so I ported it forward (and my IDE stripped some trailing spaces in both versions).