### PR TITLE
ca: make orderID mandatory

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -307,11 +307,6 @@ var ocspStatusToCode = map[string]int{
 //
 // [issuance cycle]: https://github.com/letsencrypt/boulder/blob/main/docs/ISSUANCE-CYCLE.md
 func (ca *certificateAuthorityImpl) issuePrecertificate(ctx context.Context, certProfile *certProfileWithID, issueReq *capb.IssueCertificateRequest) ([]byte, error) {
-	// issueReq.orderID may be zero, for ACMEv1 requests.
-	if core.IsAnyNilOrZero(issueReq, issueReq.Csr, issueReq.RegistrationID) {
-		return nil, berrors.InternalServerError("Incomplete issue certificate request")
-	}
-
 	serialBigInt, err := ca.generateSerialNumber()
 	if err != nil {
 		return nil, err
@@ -345,6 +340,10 @@ func (ca *certificateAuthorityImpl) issuePrecertificate(ctx context.Context, cer
 }
 
 func (ca *certificateAuthorityImpl) IssueCertificate(ctx context.Context, issueReq *capb.IssueCertificateRequest) (*capb.IssueCertificateResponse, error) {
+	if core.IsAnyNilOrZero(issueReq, issueReq.Csr, issueReq.RegistrationID, issueReq.OrderID) {
+		return nil, berrors.InternalServerError("Incomplete issue certificate request")
+	}
+
 	if ca.sctClient == nil {
 		return nil, errors.New("IssueCertificate called with a nil SCT service")
 	}
@@ -398,13 +397,9 @@ func (ca *certificateAuthorityImpl) issueCertificateForPrecertificate(ctx contex
 	certProfile *certProfileWithID,
 	precertDER []byte,
 	sctBytes [][]byte,
-	regID int64, //nolint: unparam // unparam says "regID` always receives `arbitraryRegID` (`1001`)", which is wrong; that's just what happens in the unittests.
-	orderID int64, //nolint: unparam // same as above
+	regID int64,
+	orderID int64,
 ) ([]byte, error) {
-	if core.IsAnyNilOrZero(certProfile, precertDER, sctBytes, regID) {
-		return nil, berrors.InternalServerError("Incomplete cert for precertificate request")
-	}
-
 	precert, err := x509.ParseCertificate(precertDER)
 	if err != nil {
 		return nil, err

--- a/ca/ocsp_test.go
+++ b/ca/ocsp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/hex"
+	mrand "math/rand"
 	"testing"
 	"time"
 
@@ -47,7 +48,7 @@ func TestOCSP(t *testing.T) {
 	profile := ca.certProfiles.profileByName["legacy"]
 	// Issue a certificate from an RSA issuer, request OCSP from the same issuer,
 	// and make sure it works.
-	rsaCertDER, err := ca.issuePrecertificate(ctx, profile, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: arbitraryRegID, CertProfileName: "legacy"})
+	rsaCertDER, err := ca.issuePrecertificate(ctx, profile, &capb.IssueCertificateRequest{Csr: CNandSANCSR, RegistrationID: mrand.Int63(), OrderID: mrand.Int63(), CertProfileName: "legacy"})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	rsaCert, err := x509.ParseCertificate(rsaCertDER)
 	test.AssertNotError(t, err, "Failed to parse rsaCert")
@@ -70,7 +71,7 @@ func TestOCSP(t *testing.T) {
 
 	// Issue a certificate from an ECDSA issuer, request OCSP from the same issuer,
 	// and make sure it works.
-	ecdsaCertDER, err := ca.issuePrecertificate(ctx, profile, &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: arbitraryRegID, CertProfileName: "legacy"})
+	ecdsaCertDER, err := ca.issuePrecertificate(ctx, profile, &capb.IssueCertificateRequest{Csr: ECDSACSR, RegistrationID: mrand.Int63(), OrderID: mrand.Int63(), CertProfileName: "legacy"})
 	test.AssertNotError(t, err, "Failed to issue certificate")
 	ecdsaCert, err := x509.ParseCertificate(ecdsaCertDER)
 	test.AssertNotError(t, err, "Failed to parse ecdsaCert")


### PR DESCRIPTION
It was allowed to be empty for ACMEv1 requests, but those are long gone.

Also, move the IsAnyNilOrZero checks up to the RPC entry point.