### PR TITLE
docker: Update image to Ubuntu 24.04

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.24.1_2025-04-02
+          - go1.24.1_2025-04-17
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/test/boulder-tools/build.sh
+++ b/test/boulder-tools/build.sh
@@ -4,7 +4,7 @@ apt-get update
 
 # Install system deps
 apt-get install -y --no-install-recommends \
-  mariadb-client-core-10.3 \
+  mariadb-client-core \
   rsyslog \
   build-essential \
   opensc \
@@ -23,7 +23,7 @@ fi
 curl -L https://github.com/google/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-"${PROTO_ARCH}".zip -o /tmp/protoc.zip
 unzip /tmp/protoc.zip -d /usr/local/protoc
 
-pip3 install -r /tmp/requirements.txt
+pip3 install --break-system-packages -r /tmp/requirements.txt
 
 apt-get clean -y
 

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -8,7 +8,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # already present, which prevents the whole container from starting. We remove
 # it just in case it's there.
 rm -f /var/run/rsyslogd.pid
-service rsyslog start
+rsyslogd
 
 # make sure we can reach the mysqldb.
 ./test/wait-for-it.sh boulder-mysql 3306

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -10,8 +10,6 @@ import os
 import json
 import re
 
-import OpenSSL
-
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -1328,7 +1326,7 @@ def test_auth_deactivation():
 def get_ocsp_response_and_reason(cert_file, issuer_glob, url):
     """Returns the ocsp response output and revocation reason."""
     output = verify_ocsp(cert_file, issuer_glob, url, None)
-    m = re.search('Reason: (\w+)', output)
+    m = re.search(r'Reason: (\w+)', output)
     reason = m.group(1) if m is not None else ""
     return output, reason
 
@@ -1345,10 +1343,9 @@ def ocsp_resigning_setup():
     cert_file = temppath('ocsp_resigning_setup.pem')
     order = chisel2.auth_and_issue([random_domain()], client=client, cert_output=cert_file.name)
 
-    cert = OpenSSL.crypto.load_certificate(
-        OpenSSL.crypto.FILETYPE_PEM, order.fullchain_pem)
+    cert = x509.load_pem_x509_certificate(order.fullchain_pem.encode(), default_backend())
     # Revoke for reason 5: cessationOfOperation
-    client.revoke(josepy.ComparableX509(cert), 5)
+    client.revoke(cert, 5)
 
     ocsp_response, reason = get_ocsp_response_and_reason(
         cert_file.name, "test/certs/webpki/int-rsa-*.cert.pem", "http://localhost:4002")


### PR DESCRIPTION
#8109 updated CI to use 24.04 runners, now update the Docker image to build 24.04 and CI to use it.

Build fixes:
- Unpin mariadb-client-core, 10.3 is no longer provided in 24.04 apt repositories
- Use new pip flag --break-system-packages to comply with PEP 668, which is now enforced in Python 3.12+

Runtime fixes:
- Start rsyslogd directly due to missing symlink (see: https://github.com/rsyslog/rsyslog/issues/5611)
- Fix SyntaxWarning: invalid escape sequence '\w' error.
- Replace OpenSSL.crypto.load_certificate with x509.load_pem_x509_certificate due to https://github.com/certbot/josepy/commit/d73d0ed417d266bb5792503683e7afd82dfe397d