### PR TITLE
sa: use internal certificateModel

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -245,10 +245,10 @@ func (c *certChecker) getCerts(ctx context.Context) error {
 			break
 		}
 		lastCert := certs[len(certs)-1]
-		batchStartID = highestID
 		if lastCert.Issued.AsTime().After(c.issuedReport.end) {
 			break
 		}
+		batchStartID = highestID
 	}
 
 	// Close channel so range operations won't block once the channel empties out

--- a/cmd/expiration-mailer/main.go
+++ b/cmd/expiration-mailer/main.go
@@ -608,7 +608,6 @@ func (m *mailer) getCerts(ctx context.Context, left, right time.Time, expiresIn 
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		var cert core.Certificate
 		cert, err := sa.SelectCertificate(ctx, m.dbMap, serial)
 		if err != nil {
 			// We can get a NoRowsErr when processing a serial number corresponding
@@ -623,13 +622,13 @@ func (m *mailer) getCerts(ctx context.Context, left, right time.Time, expiresIn 
 			continue
 		}
 		certs = append(certs, certDERWithRegID{
-			DER:   cert.DER,
+			DER:   cert.Der,
 			RegID: cert.RegistrationID,
 		})
 		if i == 0 {
 			// Report the send delay metric. Note: this is the worst-case send delay
 			// of any certificate in this batch because it's based on the first (oldest).
-			sendDelay := expiresIn - cert.Expires.Sub(m.clk.Now())
+			sendDelay := expiresIn - cert.Expires.AsTime().Sub(m.clk.Now())
 			m.stats.sendDelay.With(prometheus.Labels{"nag_group": expiresIn.String()}).Set(
 				sendDelay.Truncate(time.Second).Seconds())
 		}

--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -343,28 +343,6 @@ func newOrderValid(order *corepb.Order) bool {
 	return !(order.RegistrationID == 0 || order.Expires == nil || len(order.Identifiers) == 0)
 }
 
-func CertToPB(cert core.Certificate) *corepb.Certificate {
-	return &corepb.Certificate{
-		RegistrationID: cert.RegistrationID,
-		Serial:         cert.Serial,
-		Digest:         cert.Digest,
-		Der:            cert.DER,
-		Issued:         timestamppb.New(cert.Issued),
-		Expires:        timestamppb.New(cert.Expires),
-	}
-}
-
-func PBToCert(pb *corepb.Certificate) core.Certificate {
-	return core.Certificate{
-		RegistrationID: pb.RegistrationID,
-		Serial:         pb.Serial,
-		Digest:         pb.Digest,
-		DER:            pb.Der,
-		Issued:         pb.Issued.AsTime(),
-		Expires:        pb.Expires.AsTime(),
-	}
-}
-
 func CertStatusToPB(certStatus core.CertificateStatus) *corepb.CertificateStatus {
 	return &corepb.CertificateStatus{
 		Serial:                certStatus.Serial,

--- a/grpc/pb-marshalling_test.go
+++ b/grpc/pb-marshalling_test.go
@@ -267,23 +267,6 @@ func TestAuthz(t *testing.T) {
 	test.AssertDeepEquals(t, inAuthzNilExpires, outAuthz2)
 }
 
-func TestCert(t *testing.T) {
-	now := time.Now().Round(0).UTC()
-	cert := core.Certificate{
-		RegistrationID: 1,
-		Serial:         "serial",
-		Digest:         "digest",
-		DER:            []byte{255},
-		Issued:         now,
-		Expires:        now.Add(time.Hour),
-	}
-
-	certPB := CertToPB(cert)
-	outCert := PBToCert(certPB)
-
-	test.AssertDeepEquals(t, cert, outCert)
-}
-
 func TestOrderValid(t *testing.T) {
 	created := time.Now()
 	expires := created.Add(1 * time.Hour)

--- a/sa/model.go
+++ b/sa/model.go
@@ -139,65 +139,81 @@ func selectRegistration(ctx context.Context, s db.OneSelector, whereCol string, 
 	return &model, err
 }
 
-const certFields = "registrationID, serial, digest, der, issued, expires"
+const certFields = "id, registrationID, serial, digest, der, issued, expires"
 
 // SelectCertificate selects all fields of one certificate object identified by
 // a serial. If more than one row contains the same serial only the first is
 // returned.
-func SelectCertificate(ctx context.Context, s db.OneSelector, serial string) (core.Certificate, error) {
-	var model core.Certificate
+func SelectCertificate(ctx context.Context, s db.OneSelector, serial string) (*corepb.Certificate, error) {
+	var model certificateModel
 	err := s.SelectOne(
 		ctx,
 		&model,
 		"SELECT "+certFields+" FROM certificates WHERE serial = ? LIMIT 1",
 		serial,
 	)
-	return model, err
+	return certificateModelToPb(model), err
+}
+
+func certificateModelToPb(model certificateModel) *corepb.Certificate {
+	return &corepb.Certificate{
+		RegistrationID: model.RegistrationID,
+		Serial:         model.Serial,
+		Digest:         model.Digest,
+		Der:            model.DER,
+		Issued:         timestamppb.New(model.Issued),
+		Expires:        timestamppb.New(model.Expires),
+	}
+}
+
+func lintingCertModelToPb(model lintingCertModel) *corepb.Certificate {
+	return &corepb.Certificate{
+		RegistrationID: model.RegistrationID,
+		Serial:         model.Serial,
+		Digest:         "",
+		Der:            model.DER,
+		Issued:         timestamppb.New(model.Issued),
+		Expires:        timestamppb.New(model.Expires),
+	}
 }
 
 const precertFields = "registrationID, serial, der, issued, expires"
 
 // SelectPrecertificate selects all fields of one precertificate object
 // identified by serial.
-func SelectPrecertificate(ctx context.Context, s db.OneSelector, serial string) (core.Certificate, error) {
+func SelectPrecertificate(ctx context.Context, s db.OneSelector, serial string) (*corepb.Certificate, error) {
 	var model lintingCertModel
 	err := s.SelectOne(
 		ctx,
 		&model,
 		"SELECT "+precertFields+" FROM precertificates WHERE serial = ? LIMIT 1",
 		serial)
-	return core.Certificate{
-		RegistrationID: model.RegistrationID,
-		Serial:         model.Serial,
-		DER:            model.DER,
-		Issued:         model.Issued,
-		Expires:        model.Expires,
-	}, err
-}
-
-type CertWithID struct {
-	ID int64
-	core.Certificate
+	if err != nil {
+		return nil, err
+	}
+	return lintingCertModelToPb(model), nil
 }
 
 // SelectCertificates selects all fields of multiple certificate objects
-func SelectCertificates(ctx context.Context, s db.Selector, q string, args map[string]interface{}) ([]CertWithID, error) {
-	var models []CertWithID
+//
+// Returns a slice of *corepb.Certificate along with the highest ID field seen
+// (which can be used as input to a subsequent query when iterating in primary
+// key order).
+func SelectCertificates(ctx context.Context, s db.Selector, q string, args map[string]interface{}) ([]*corepb.Certificate, int64, error) {
+	var models []certificateModel
 	_, err := s.Select(
 		ctx,
 		&models,
-		"SELECT id, "+certFields+" FROM certificates "+q, args)
-	return models, err
-}
-
-// SelectPrecertificates selects all fields of multiple precertificate objects.
-func SelectPrecertificates(ctx context.Context, s db.Selector, q string, args map[string]interface{}) ([]CertWithID, error) {
-	var models []CertWithID
-	_, err := s.Select(
-		ctx,
-		&models,
-		"SELECT id, "+precertFields+" FROM precertificates "+q, args)
-	return models, err
+		"SELECT "+certFields+" FROM certificates "+q, args)
+	var pbs []*corepb.Certificate
+	var highestID int64
+	for _, m := range models {
+		pbs = append(pbs, certificateModelToPb(m))
+		if m.ID > highestID {
+			highestID = m.ID
+		}
+	}
+	return pbs, highestID, err
 }
 
 type CertStatusMetadata struct {
@@ -282,6 +298,17 @@ type regModel struct {
 	CreatedAt time.Time `db:"createdAt"`
 	LockCol   int64
 	Status    string `db:"status"`
+}
+
+type certificateModel struct {
+	ID             int64 `db:"id"`
+	RegistrationID int64 `db:"registrationID"`
+
+	Serial  string    `db:"serial"`
+	Digest  string    `db:"digest"`
+	DER     []byte    `db:"der"`
+	Issued  time.Time `db:"issued"`
+	Expires time.Time `db:"expires"`
 }
 
 func registrationPbToModel(reg *corepb.Registration) (*regModel, error) {

--- a/sa/model_test.go
+++ b/sa/model_test.go
@@ -305,7 +305,7 @@ func TestCertificatesTableContainsDuplicateSerials(t *testing.T) {
 	test.AssertNotError(t, err, "received an error for a valid query")
 
 	// Ensure that `certA` and `certB` are the same.
-	test.AssertByteEquals(t, certA.DER, certB.DER)
+	test.AssertByteEquals(t, certA.Der, certB.Der)
 }
 
 func insertCertificate(ctx context.Context, dbMap *db.WrappedMap, fc clock.FakeClock, hostname, cn string, serial, regID int64) error {

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -213,7 +213,7 @@ func (ssa *SQLStorageAuthorityRO) GetCertificate(ctx context.Context, req *sapb.
 	if err != nil {
 		return nil, err
 	}
-	return bgrpc.CertToPB(cert), nil
+	return cert, nil
 }
 
 // GetLintPrecertificate takes a serial number and returns the corresponding
@@ -235,7 +235,7 @@ func (ssa *SQLStorageAuthorityRO) GetLintPrecertificate(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	return bgrpc.CertToPB(cert), nil
+	return cert, nil
 }
 
 // GetCertificateStatus takes a hexadecimal string representing the full 128-bit serial
@@ -305,7 +305,7 @@ func (ssa *SQLStorageAuthorityRO) FQDNSetTimestampsForWindow(ctx context.Context
 	_, err := ssa.dbReadOnlyMap.Select(
 		ctx,
 		&rows,
-		`SELECT issued FROM fqdnSets 
+		`SELECT issued FROM fqdnSets
 		WHERE setHash = ?
 		AND issued > ?
 		ORDER BY issued DESC
@@ -1254,7 +1254,7 @@ func (ssa *SQLStorageAuthorityRO) GetPausedIdentifiers(ctx context.Context, req 
 	_, err := ssa.dbReadOnlyMap.Select(ctx, &matches, `
 		SELECT identifierType, identifierValue
 		FROM paused
-		WHERE 
+		WHERE
 			registrationID = ? AND
 			unpausedAt IS NULL
 		LIMIT 15`,


### PR DESCRIPTION
This follows the system we've used for other types, where the SA has a model type that is converted to a proto message for use outside the SA.

Part of #8112.