### PR TITLE
crl-updater: UpdatePeriod safety check

### DIFF
--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -57,10 +57,9 @@ type Config struct {
 		LookbackPeriod config.Duration `validate:"-"`
 
 		// UpdatePeriod controls how frequently the crl-updater runs and publishes
-		// new versions of every CRL shard. The Baseline Requirements, Section 4.9.7
-		// state that this MUST NOT be more than 7 days. We believe that future
-		// updates may require that this not be more than 24 hours, and currently
-		// recommend an UpdatePeriod of 6 hours.
+		// new versions of every CRL shard. The Baseline Requirements, Section 4.9.7:
+		// "MUST update and publish a new CRL within twenty‐four (24) hours after
+		// recording a Certificate as revoked."
 		UpdatePeriod config.Duration
 
 		// UpdateTimeout controls how long a single CRL shard is allowed to attempt

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -80,8 +80,8 @@ func NewUpdater(
 		return nil, fmt.Errorf("must have positive number of shards, got: %d", numShards)
 	}
 
-	if updatePeriod >= 7*24*time.Hour {
-		return nil, fmt.Errorf("must update CRLs at least every 7 days, got: %s", updatePeriod)
+	if updatePeriod >= 24*time.Hour {
+		return nil, fmt.Errorf("must update CRLs at least every 24 hours, got: %s", updatePeriod)
 	}
 
 	if updateTimeout >= updatePeriod {


### PR DESCRIPTION
The current requirement is that CRLs must be published within 24 hours after revoking a certificate.

Fixes #8110 