### PR TITLE
Fix profile comparison when looking for authzs to reuse

### DIFF
--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -2573,7 +2573,37 @@ func TestGetValidAuthorizations2(t *testing.T) {
 	sa, fc, cleanUp := initSA(t)
 	defer cleanUp()
 
-	aaa := createFinalizedAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(24*time.Hour), "valid", fc.Now())
+	var aaa int64
+	{
+		tokenStr := core.NewToken()
+		token, err := base64.RawURLEncoding.DecodeString(tokenStr)
+		test.AssertNotError(t, err, "computing test authorization challenge token")
+
+		profile := "test"
+		attempted := challTypeToUint[string(core.ChallengeTypeHTTP01)]
+		attemptedAt := fc.Now()
+		vr, _ := json.Marshal([]core.ValidationRecord{})
+
+		am := authzModel{
+			IdentifierType:         identifierTypeToUint[string(identifier.TypeDNS)],
+			IdentifierValue:        "aaa",
+			RegistrationID:         1,
+			CertificateProfileName: &profile,
+			Status:                 statusToUint[core.StatusValid],
+			Expires:                fc.Now().Add(24 * time.Hour),
+			Challenges:             1 << challTypeToUint[string(core.ChallengeTypeHTTP01)],
+			Attempted:              &attempted,
+			AttemptedAt:            &attemptedAt,
+			Token:                  token,
+			ValidationError:        nil,
+			ValidationRecord:       vr,
+		}
+
+		err = sa.dbMap.Insert(context.Background(), &am)
+		test.AssertNotError(t, err, "failed to insert valid authz")
+
+		aaa = am.ID
+	}
 
 	for _, tc := range []struct {
 		name        string
@@ -2587,15 +2617,15 @@ func TestGetValidAuthorizations2(t *testing.T) {
 			name:        "happy path, DNS identifier",
 			regID:       1,
 			identifiers: []*corepb.Identifier{identifier.NewDNS("aaa").ToProto()},
-			profile:     "",
+			profile:     "test",
 			validUntil:  fc.Now().Add(time.Hour),
 			wantIDs:     []int64{aaa},
 		},
 		{
-			name:        "happy path, IP identifier",
+			name:        "different identifier type",
 			regID:       1,
 			identifiers: []*corepb.Identifier{identifier.NewIP(netip.MustParseAddr("10.10.10.10")).ToProto()},
-			profile:     "",
+			profile:     "test",
 			validUntil:  fc.Now().Add(time.Hour),
 			wantIDs:     []int64{},
 		},
@@ -2603,7 +2633,7 @@ func TestGetValidAuthorizations2(t *testing.T) {
 			name:        "different regID",
 			regID:       2,
 			identifiers: []*corepb.Identifier{identifier.NewDNS("aaa").ToProto()},
-			profile:     "",
+			profile:     "test",
 			validUntil:  fc.Now().Add(time.Hour),
 			wantIDs:     []int64{},
 		},
@@ -2611,15 +2641,7 @@ func TestGetValidAuthorizations2(t *testing.T) {
 			name:        "different DNS identifier",
 			regID:       1,
 			identifiers: []*corepb.Identifier{identifier.NewDNS("bbb").ToProto()},
-			profile:     "",
-			validUntil:  fc.Now().Add(time.Hour),
-			wantIDs:     []int64{},
-		},
-		{
-			name:        "different IP identifier",
-			regID:       1,
-			identifiers: []*corepb.Identifier{identifier.NewIP(netip.MustParseAddr("3fff:aaa:aaaa:aaaa:abad:0ff1:cec0:ffee")).ToProto()},
-			profile:     "",
+			profile:     "test",
 			validUntil:  fc.Now().Add(time.Hour),
 			wantIDs:     []int64{},
 		},
@@ -2627,7 +2649,7 @@ func TestGetValidAuthorizations2(t *testing.T) {
 			name:        "different profile",
 			regID:       1,
 			identifiers: []*corepb.Identifier{identifier.NewDNS("aaa").ToProto()},
-			profile:     "test",
+			profile:     "other",
 			validUntil:  fc.Now().Add(time.Hour),
 			wantIDs:     []int64{},
 		},
@@ -2635,7 +2657,7 @@ func TestGetValidAuthorizations2(t *testing.T) {
 			name:        "too-far-out validUntil",
 			regID:       2,
 			identifiers: []*corepb.Identifier{identifier.NewDNS("aaa").ToProto()},
-			profile:     "",
+			profile:     "test",
 			validUntil:  fc.Now().Add(25 * time.Hour),
 			wantIDs:     []int64{},
 		},

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -604,9 +604,11 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorizations2(ctx context.Context, req *s
 	// TODO(#8111): Consider reducing the volume of data in this map.
 	authzModelMap := make(map[identifier.ACMEIdentifier]authzModel, len(authzModels))
 	for _, am := range authzModels {
-		if req.Profile != "" && am.CertificateProfileName != &req.Profile {
+		if req.Profile != "" {
 			// Don't return authzs whose profile doesn't match that requested.
-			continue
+			if am.CertificateProfileName == nil || *am.CertificateProfileName != req.Profile {
+				continue
+			}
 		}
 		// If there is an existing authorization in the map, only replace it with
 		// one which has a "better" validation state (valid instead of pending).
@@ -798,9 +800,11 @@ func (ssa *SQLStorageAuthorityRO) GetValidAuthorizations2(ctx context.Context, r
 	// TODO(#8111): Consider reducing the volume of data in this map.
 	authzMap := make(map[identifier.ACMEIdentifier]authzModel, len(authzModels))
 	for _, am := range authzModels {
-		if req.Profile != "" && am.CertificateProfileName != &req.Profile {
+		if req.Profile != "" {
 			// Don't return authzs whose profile doesn't match that requested.
-			continue
+			if am.CertificateProfileName == nil || *am.CertificateProfileName != req.Profile {
+				continue
+			}
 		}
 		// If there is an existing authorization in the map only replace it with one
 		// which has a later expiry.


### PR DESCRIPTION
Previously, if the request asked for a profile, we were comparing the address of that requested profile to the address of the profile field of the found authz. Obviously these addresses were never the same. Instead, compare the actual values, with an added nil check for safety.

This fixes a bug reported on the community forum. The updated test fails without the accompanying code change.