### PR TITLE
admin/test: Fix data race in admin tests

### DIFF
--- a/cmd/admin/pause_identifier_test.go
+++ b/cmd/admin/pause_identifier_test.go
@@ -91,8 +91,8 @@ type mockSAPaused struct {
 
 func (msa *mockSAPaused) PauseIdentifiers(ctx context.Context, in *sapb.PauseRequest, _ ...grpc.CallOption) (*sapb.PauseIdentifiersResponse, error) {
 	msa.mu.Lock()
+	defer msa.mu.Unlock()
 	msa.calls = append(msa.calls, in)
-	msa.mu.Unlock()
 	return &sapb.PauseIdentifiersResponse{Paused: int64(len(in.Identifiers))}, nil
 }
 


### PR DESCRIPTION
The mockSAPaused test mock records each PauseIdentifiers request by appending to a shared slice. Because pauseIdentifiers() launches multiple goroutines that call this mock concurrently, unsynchronized access to the slice can result in a data race. Introduce a mutex to protect access to this shared slice.

```
WARNING: DATA RACE
Read at 0x00c00045e548 by goroutine 60:
  runtime.growslice()
      /usr/local/go/src/runtime/slice.go:155 +0x0
  github.com/letsencrypt/boulder/cmd/admin.(*mockSAPaused).PauseIdentifiers()
      /boulder/cmd/admin/pause_identifier_test.go:91 +0x7b
  github.com/letsencrypt/boulder/cmd/admin.(*admin).pauseIdentifiers.func1()
      /boulder/cmd/admin/pause_identifier.go:84 +0x289

Previous write at 0x00c00045e548 by goroutine 53:
  github.com/letsencrypt/boulder/cmd/admin.(*mockSAPaused).PauseIdentifiers()
      /boulder/cmd/admin/pause_identifier_test.go:91 +0xa4
  github.com/letsencrypt/boulder/cmd/admin.(*admin).pauseIdentifiers.func1()
      /boulder/cmd/admin/pause_identifier.go:84 +0x289
```

Fixes #7697