### PR TITLE
RA/loglist: Allow submissions to test logs from all_log_list.json

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -230,13 +230,13 @@ func main() {
 	allLogs, err := loglist.New(c.RA.CTLogs.LogListFile)
 	cmd.FailOnError(err, "Failed to parse log list")
 
-	sctLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.SCTLogs, loglist.Issuance, c.RA.CTLogs.AllowedSCTTypes)
+	sctLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.SCTLogs, loglist.Issuance, c.RA.CTLogs.SubmitToTestLogs)
 	cmd.FailOnError(err, "Failed to load SCT logs")
 
-	infoLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.InfoLogs, loglist.Informational, nil)
+	infoLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.InfoLogs, loglist.Informational, true)
 	cmd.FailOnError(err, "Failed to load informational logs")
 
-	finalLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.FinalLogs, loglist.Informational, nil)
+	finalLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.FinalLogs, loglist.Informational, true)
 	cmd.FailOnError(err, "Failed to load final logs")
 
 	ctp = ctpolicy.New(pubc, sctLogs, infoLogs, finalLogs, c.RA.CTLogs.Stagger.Duration, logger, scope)

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -230,13 +230,13 @@ func main() {
 	allLogs, err := loglist.New(c.RA.CTLogs.LogListFile)
 	cmd.FailOnError(err, "Failed to parse log list")
 
-	sctLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.SCTLogs, loglist.Issuance)
+	sctLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.SCTLogs, loglist.Issuance, c.RA.CTLogs.AllowedSCTTypes)
 	cmd.FailOnError(err, "Failed to load SCT logs")
 
-	infoLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.InfoLogs, loglist.Informational)
+	infoLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.InfoLogs, loglist.Informational, nil)
 	cmd.FailOnError(err, "Failed to load informational logs")
 
-	finalLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.FinalLogs, loglist.Informational)
+	finalLogs, err := allLogs.SubsetForPurpose(c.RA.CTLogs.FinalLogs, loglist.Informational, nil)
 	cmd.FailOnError(err, "Failed to load final logs")
 
 	ctp = ctpolicy.New(pubc, sctLogs, infoLogs, finalLogs, c.RA.CTLogs.Stagger.Duration, logger, scope)

--- a/ctpolicy/ctconfig/ctconfig.go
+++ b/ctpolicy/ctconfig/ctconfig.go
@@ -108,6 +108,9 @@ type CTConfig struct {
 	// This may include duplicates from the lists above, to submit both precerts
 	// and final certs to the same log.
 	FinalLogs []string
+	// AllowedSCTTypes allows non-empty log types (typically "test") to be used for
+	// SCTs. This should only be used in test environments.
+	AllowedSCTTypes []string
 }
 
 // LogID holds enough information to uniquely identify a CT Log: its log_id

--- a/ctpolicy/ctconfig/ctconfig.go
+++ b/ctpolicy/ctconfig/ctconfig.go
@@ -108,9 +108,9 @@ type CTConfig struct {
 	// This may include duplicates from the lists above, to submit both precerts
 	// and final certs to the same log.
 	FinalLogs []string
-	// AllowedSCTTypes allows non-empty log types (typically "test") to be used for
-	// SCTs. This should only be used in test environments.
-	AllowedSCTTypes []string
+	// SubmitToTestLogs enables inclusion of "test" logs when obtaining SCTs.
+	// This should only be used in test environments.
+	SubmitToTestLogs bool
 }
 
 // LogID holds enough information to uniquely identify a CT Log: its log_id

--- a/ctpolicy/loglist/lintlist.go
+++ b/ctpolicy/loglist/lintlist.go
@@ -22,7 +22,7 @@ func InitLintList(path string) error {
 			return
 		}
 
-		l, err = l.forPurpose(Validation, nil)
+		l, err = l.forPurpose(Validation, false)
 		if err != nil {
 			lintlist.err = err
 			return

--- a/ctpolicy/loglist/lintlist.go
+++ b/ctpolicy/loglist/lintlist.go
@@ -22,7 +22,7 @@ func InitLintList(path string) error {
 			return
 		}
 
-		l, err = l.forPurpose(Validation)
+		l, err = l.forPurpose(Validation, nil)
 		if err != nil {
 			lintlist.err = err
 			return

--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -185,7 +185,7 @@ func (ll List) forPurpose(p purpose, allowedTypes []string) (List, error) {
 			continue
 		}
 		// For the Issuance purpose, if the log has a non-standard type,
-		// require it to be explicitally allowed
+		// require it to be explicitly allowed
 		if p == Issuance && len(log.Type) > 0 {
 			if !slices.Contains(allowedTypes, log.Type) {
 				continue

--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -182,7 +182,7 @@ func (ll List) forPurpose(p purpose, allowedTypes []string) (List, error) {
 	operators := make(map[string]struct{})
 	for _, log := range ll {
 		// For the Issuance purpose, if the log has a non-standard type,
-		// require that log type to be explicitally allowed instead of
+		// require that log type to be explicitly allowed instead of
 		// checking the log state
 		if p == Issuance && len(log.Type) > 0 {
 			if !slices.Contains(allowedTypes, log.Type) {

--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -181,13 +181,15 @@ func (ll List) forPurpose(p purpose, allowedTypes []string) (List, error) {
 	res := make(List, 0)
 	operators := make(map[string]struct{})
 	for _, log := range ll {
-		if !usableForPurpose(log.State, p) {
-			continue
-		}
 		// For the Issuance purpose, if the log has a non-standard type,
-		// require it to be explicitly allowed
+		// require that log type to be explicitally allowed instead of
+		// checking the log state
 		if p == Issuance && len(log.Type) > 0 {
 			if !slices.Contains(allowedTypes, log.Type) {
+				continue
+			}
+		} else {
+			if !usableForPurpose(log.State, p) {
 				continue
 			}
 		}

--- a/ctpolicy/loglist/loglist.go
+++ b/ctpolicy/loglist/loglist.go
@@ -136,13 +136,13 @@ func newHelper(file []byte) (List, error) {
 // given purpose. It returns an error if any of the given names are not found
 // in the starting list, or if the resulting list is too small to satisfy the
 // Chrome "two operators" policy.
-func (ll List) SubsetForPurpose(names []string, p purpose, allowedTypes []string) (List, error) {
+func (ll List) SubsetForPurpose(names []string, p purpose, submitToTestLogs bool) (List, error) {
 	sub, err := ll.subset(names)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := sub.forPurpose(p, allowedTypes)
+	res, err := sub.forPurpose(p, submitToTestLogs)
 	if err != nil {
 		return nil, err
 	}
@@ -174,24 +174,23 @@ func (ll List) subset(names []string) (List, error) {
 }
 
 // forPurpose returns a new log list containing only those logs whose states are
-// acceptable for the given purpose. It returns an error if the purpose is
-// Issuance or Validation and the set of remaining logs is too small to satisfy
-// the Google "two operators" log policy.
-func (ll List) forPurpose(p purpose, allowedTypes []string) (List, error) {
+// acceptable for the given purpose. Test logs are included only when
+// submitToTestLogs is true. It returns an error if the purpose is Issuance or
+// Validation and the set of remaining logs is too small to satisfy the Google
+// "two operators" log policy.
+func (ll List) forPurpose(p purpose, submitToTestLogs bool) (List, error) {
 	res := make(List, 0)
 	operators := make(map[string]struct{})
+
+	// Test logs in Chrome's all_logs_list.json omit the "state" field. loglist3
+	// interprets this as "UndefinedLogStatus", which causes usableForPurpose()
+	// to return false. To account for this, we skip this check for test logs.
 	for _, log := range ll {
-		// For the Issuance purpose, if the log has a non-standard type,
-		// require that log type to be explicitly allowed instead of
-		// checking the log state
-		if p == Issuance && len(log.Type) > 0 {
-			if !slices.Contains(allowedTypes, log.Type) {
-				continue
-			}
-		} else {
-			if !usableForPurpose(log.State, p) {
-				continue
-			}
+		if log.Type == "test" && !submitToTestLogs {
+			continue
+		}
+		if log.Type != "test" && !usableForPurpose(log.State, p) {
+			continue
 		}
 		res = append(res, log)
 		operators[log.Operator] = struct{}{}

--- a/ctpolicy/loglist/loglist_test.go
+++ b/ctpolicy/loglist/loglist_test.go
@@ -59,7 +59,7 @@ func TestForPurpose(t *testing.T) {
 		Log{Name: "Log A1", Operator: "A", State: loglist3.UsableLogStatus},
 		Log{Name: "Log B1", Operator: "B", State: loglist3.UsableLogStatus},
 	}
-	actual, err := input.forPurpose(Issuance, nil)
+	actual, err := input.forPurpose(Issuance, false)
 	test.AssertNotError(t, err, "should have two acceptable logs")
 	test.AssertDeepEquals(t, actual, expected)
 
@@ -71,14 +71,14 @@ func TestForPurpose(t *testing.T) {
 		Log{Name: "Log C1", Operator: "C", State: loglist3.PendingLogStatus},
 		Log{Name: "Log C2", Operator: "C", State: loglist3.ReadOnlyLogStatus},
 	}
-	_, err = input.forPurpose(Issuance, nil)
+	_, err = input.forPurpose(Issuance, false)
 	test.AssertError(t, err, "should only have one acceptable log")
 
 	expected = List{
 		Log{Name: "Log A1", Operator: "A", State: loglist3.UsableLogStatus},
 		Log{Name: "Log C2", Operator: "C", State: loglist3.ReadOnlyLogStatus},
 	}
-	actual, err = input.forPurpose(Validation, nil)
+	actual, err = input.forPurpose(Validation, false)
 	test.AssertNotError(t, err, "should have two acceptable logs")
 	test.AssertDeepEquals(t, actual, expected)
 
@@ -87,8 +87,30 @@ func TestForPurpose(t *testing.T) {
 		Log{Name: "Log B1", Operator: "B", State: loglist3.QualifiedLogStatus},
 		Log{Name: "Log C1", Operator: "C", State: loglist3.PendingLogStatus},
 	}
-	actual, err = input.forPurpose(Informational, nil)
+	actual, err = input.forPurpose(Informational, false)
 	test.AssertNotError(t, err, "should have three acceptable logs")
+	test.AssertDeepEquals(t, actual, expected)
+
+	input = List{
+		Log{Name: "Log A1", Operator: "A", State: loglist3.UsableLogStatus},
+		Log{Name: "Log B1", Operator: "B", State: loglist3.UsableLogStatus},
+		Log{Name: "Log T1", Operator: "T", Type: "test", State: loglist3.UndefinedLogStatus},
+	}
+	expected = List{
+		Log{Name: "Log A1", Operator: "A", State: loglist3.UsableLogStatus},
+		Log{Name: "Log B1", Operator: "B", State: loglist3.UsableLogStatus},
+	}
+	actual, err = input.forPurpose(Issuance, false)
+	test.AssertNotError(t, err, "should have two acceptable logs with submitToTestLogs=[false]")
+	test.AssertDeepEquals(t, actual, expected)
+
+	expected = List{
+		Log{Name: "Log A1", Operator: "A", State: loglist3.UsableLogStatus},
+		Log{Name: "Log B1", Operator: "B", State: loglist3.UsableLogStatus},
+		Log{Name: "Log T1", Operator: "T", Type: "test", State: loglist3.UndefinedLogStatus},
+	}
+	actual, err = input.forPurpose(Issuance, true)
+	test.AssertNotError(t, err, "should have two acceptable logs with submitToTestLogs=[true]")
 	test.AssertDeepEquals(t, actual, expected)
 }
 

--- a/ctpolicy/loglist/loglist_test.go
+++ b/ctpolicy/loglist/loglist_test.go
@@ -59,7 +59,7 @@ func TestForPurpose(t *testing.T) {
 		Log{Name: "Log A1", Operator: "A", State: loglist3.UsableLogStatus},
 		Log{Name: "Log B1", Operator: "B", State: loglist3.UsableLogStatus},
 	}
-	actual, err := input.forPurpose(Issuance)
+	actual, err := input.forPurpose(Issuance, nil)
 	test.AssertNotError(t, err, "should have two acceptable logs")
 	test.AssertDeepEquals(t, actual, expected)
 
@@ -71,14 +71,14 @@ func TestForPurpose(t *testing.T) {
 		Log{Name: "Log C1", Operator: "C", State: loglist3.PendingLogStatus},
 		Log{Name: "Log C2", Operator: "C", State: loglist3.ReadOnlyLogStatus},
 	}
-	_, err = input.forPurpose(Issuance)
+	_, err = input.forPurpose(Issuance, nil)
 	test.AssertError(t, err, "should only have one acceptable log")
 
 	expected = List{
 		Log{Name: "Log A1", Operator: "A", State: loglist3.UsableLogStatus},
 		Log{Name: "Log C2", Operator: "C", State: loglist3.ReadOnlyLogStatus},
 	}
-	actual, err = input.forPurpose(Validation)
+	actual, err = input.forPurpose(Validation, nil)
 	test.AssertNotError(t, err, "should have two acceptable logs")
 	test.AssertDeepEquals(t, actual, expected)
 
@@ -87,7 +87,7 @@ func TestForPurpose(t *testing.T) {
 		Log{Name: "Log B1", Operator: "B", State: loglist3.QualifiedLogStatus},
 		Log{Name: "Log C1", Operator: "C", State: loglist3.PendingLogStatus},
 	}
-	actual, err = input.forPurpose(Informational)
+	actual, err = input.forPurpose(Informational, nil)
 	test.AssertNotError(t, err, "should have three acceptable logs")
 	test.AssertDeepEquals(t, actual, expected)
 }


### PR DESCRIPTION
Allow use of test ("type": "test") CT logs for Informational and Final submissions.

Add new RA configuration field "SubmitToTestLogs" to optionally include test CT logs for SCT submissions.

Co-authored-by: beautifulentropy <hello@entropy.cat> 