### PR TITLE
policy: Support IP address identifiers

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -147,7 +147,7 @@ func setup(t *testing.T) *testCtx {
 	fc := clock.NewFake()
 	fc.Add(1 * time.Hour)
 
-	pa, err := policy.New(nil, blog.NewMock())
+	pa, err := policy.New(nil, nil, blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
 	err = pa.LoadHostnamePolicyFile("../test/hostname-policy.yaml")
 	test.AssertNotError(t, err, "Couldn't set hostname policy")

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -164,8 +164,9 @@ func main() {
 	metrics := ca.NewCAMetrics(scope)
 
 	cmd.FailOnError(c.PA.CheckChallenges(), "Invalid PA configuration")
+	cmd.FailOnError(c.PA.CheckIdentifiers(), "Invalid PA configuration")
 
-	pa, err := policy.New(c.PA.Challenges, logger)
+	pa, err := policy.New(c.PA.Challenges, c.PA.Identifiers, logger)
 	cmd.FailOnError(err, "Couldn't create PA")
 
 	if c.CA.HostnamePolicyFile == "" {

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -166,7 +166,7 @@ func main() {
 	cmd.FailOnError(c.PA.CheckChallenges(), "Invalid PA configuration")
 	cmd.FailOnError(c.PA.CheckIdentifiers(), "Invalid PA configuration")
 
-	pa, err := policy.New(c.PA.Challenges, c.PA.Identifiers, logger)
+	pa, err := policy.New(c.PA.Identifiers, c.PA.Challenges, logger)
 	cmd.FailOnError(err, "Couldn't create PA")
 
 	if c.CA.HostnamePolicyFile == "" {

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -168,7 +168,7 @@ func main() {
 	cmd.FailOnError(c.PA.CheckChallenges(), "Invalid PA configuration")
 	cmd.FailOnError(c.PA.CheckIdentifiers(), "Invalid PA configuration")
 
-	pa, err := policy.New(c.PA.Challenges, c.PA.Identifiers, logger)
+	pa, err := policy.New(c.PA.Identifiers, c.PA.Challenges, logger)
 	cmd.FailOnError(err, "Couldn't create PA")
 
 	if c.RA.HostnamePolicyFile == "" {

--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -166,8 +166,9 @@ func main() {
 
 	// Validate PA config and set defaults if needed
 	cmd.FailOnError(c.PA.CheckChallenges(), "Invalid PA configuration")
+	cmd.FailOnError(c.PA.CheckIdentifiers(), "Invalid PA configuration")
 
-	pa, err := policy.New(c.PA.Challenges, logger)
+	pa, err := policy.New(c.PA.Challenges, c.PA.Identifiers, logger)
 	cmd.FailOnError(err, "Couldn't create PA")
 
 	if c.RA.HostnamePolicyFile == "" {

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -562,6 +562,7 @@ func main() {
 
 	// Validate PA config and set defaults if needed.
 	cmd.FailOnError(config.PA.CheckChallenges(), "Invalid PA configuration")
+	cmd.FailOnError(config.PA.CheckIdentifiers(), "Invalid PA configuration")
 
 	kp, err := sagoodkey.NewPolicy(&config.CertChecker.GoodKey, nil)
 	cmd.FailOnError(err, "Unable to create key policy")
@@ -575,7 +576,7 @@ func main() {
 	})
 	prometheus.DefaultRegisterer.MustRegister(checkerLatency)
 
-	pa, err := policy.New(config.PA.Challenges, logger)
+	pa, err := policy.New(config.PA.Challenges, config.PA.Identifiers, logger)
 	cmd.FailOnError(err, "Failed to create PA")
 
 	err = pa.LoadHostnamePolicyFile(config.CertChecker.HostnamePolicyFile)

--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -576,7 +576,7 @@ func main() {
 	})
 	prometheus.DefaultRegisterer.MustRegister(checkerLatency)
 
-	pa, err := policy.New(config.PA.Challenges, config.PA.Identifiers, logger)
+	pa, err := policy.New(config.PA.Identifiers, config.PA.Challenges, logger)
 	cmd.FailOnError(err, "Failed to create PA")
 
 	err = pa.LoadHostnamePolicyFile(config.CertChecker.HostnamePolicyFile)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -54,8 +54,8 @@ var (
 func init() {
 	var err error
 	pa, err = policy.New(
-		map[core.AcmeChallenge]bool{},
 		map[identifier.IdentifierType]bool{identifier.TypeDNS: true, identifier.TypeIP: true},
+		map[core.AcmeChallenge]bool{},
 		blog.NewMock())
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/letsencrypt/boulder/ctpolicy/loglist"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/goodkey/sagoodkey"
+	"github.com/letsencrypt/boulder/identifier"
 	"github.com/letsencrypt/boulder/linter"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -52,7 +53,10 @@ var (
 
 func init() {
 	var err error
-	pa, err = policy.New(map[core.AcmeChallenge]bool{}, blog.NewMock())
+	pa, err = policy.New(
+		map[core.AcmeChallenge]bool{},
+		map[identifier.IdentifierType]bool{identifier.TypeDNS: true, identifier.TypeIP: true},
+		blog.NewMock())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/identifier"
 )
 
 // PasswordConfig contains a path to a file containing a password.
@@ -99,8 +100,9 @@ type SMTPConfig struct {
 // database, what policies it should enforce, and what challenges
 // it should offer.
 type PAConfig struct {
-	DBConfig   `validate:"-"`
-	Challenges map[core.AcmeChallenge]bool `validate:"omitempty,dive,keys,oneof=http-01 dns-01 tls-alpn-01,endkeys"`
+	DBConfig    `validate:"-"`
+	Challenges  map[core.AcmeChallenge]bool        `validate:"omitempty,dive,keys,oneof=http-01 dns-01 tls-alpn-01,endkeys"`
+	Identifiers map[identifier.IdentifierType]bool `validate:"omitempty,dive,keys,oneof=dns ip,endkeys"`
 }
 
 // CheckChallenges checks whether the list of challenges in the PA config
@@ -112,6 +114,17 @@ func (pc PAConfig) CheckChallenges() error {
 	for c := range pc.Challenges {
 		if !c.IsValid() {
 			return fmt.Errorf("invalid challenge in PA config: %s", c)
+		}
+	}
+	return nil
+}
+
+// CheckIdentifiers checks whether the list of identifiers in the PA config
+// actually contains valid identifier type names
+func (pc PAConfig) CheckIdentifiers() error {
+	for i := range pc.Identifiers {
+		if !i.IsValid() {
+			return fmt.Errorf("invalid identifier type in PA config: %s", i)
 		}
 	}
 	return nil

--- a/cmd/reversed-hostname-checker/main.go
+++ b/cmd/reversed-hostname-checker/main.go
@@ -40,7 +40,7 @@ func main() {
 	scanner := bufio.NewScanner(input)
 	logger := cmd.NewLogger(cmd.SyslogConfig{StdoutLevel: 7})
 	logger.Info(cmd.VersionString())
-	pa, err := policy.New(nil, logger)
+	pa, err := policy.New(nil, nil, logger)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -23,22 +23,24 @@ var (
 	validPAConfig = []byte(`{
   "dbConnect": "dummyDBConnect",
   "enforcePolicyWhitelist": false,
-  "challenges": { "http-01": true }
+  "challenges": { "http-01": true },
+  "identifiers": { "dns": true, "ip": true }
 }`)
 	invalidPAConfig = []byte(`{
   "dbConnect": "dummyDBConnect",
   "enforcePolicyWhitelist": false,
-  "challenges": { "nonsense": true }
+  "challenges": { "nonsense": true },
+  "identifiers": { "openpgp": true }
 }`)
-	noChallengesPAConfig = []byte(`{
+	noChallengesIdentsPAConfig = []byte(`{
   "dbConnect": "dummyDBConnect",
   "enforcePolicyWhitelist": false
 }`)
-
-	emptyChallengesPAConfig = []byte(`{
+	emptyChallengesIdentsPAConfig = []byte(`{
   "dbConnect": "dummyDBConnect",
   "enforcePolicyWhitelist": false,
-  "challenges": {}
+  "challenges": {},
+  "identifiers": {}
 }`)
 )
 
@@ -47,21 +49,25 @@ func TestPAConfigUnmarshal(t *testing.T) {
 	err := json.Unmarshal(validPAConfig, &pc1)
 	test.AssertNotError(t, err, "Failed to unmarshal PAConfig")
 	test.AssertNotError(t, pc1.CheckChallenges(), "Flagged valid challenges as bad")
+	test.AssertNotError(t, pc1.CheckIdentifiers(), "Flagged valid identifiers as bad")
 
 	var pc2 PAConfig
 	err = json.Unmarshal(invalidPAConfig, &pc2)
 	test.AssertNotError(t, err, "Failed to unmarshal PAConfig")
 	test.AssertError(t, pc2.CheckChallenges(), "Considered invalid challenges as good")
+	test.AssertError(t, pc2.CheckIdentifiers(), "Considered invalid identifiers as good")
 
 	var pc3 PAConfig
-	err = json.Unmarshal(noChallengesPAConfig, &pc3)
+	err = json.Unmarshal(noChallengesIdentsPAConfig, &pc3)
 	test.AssertNotError(t, err, "Failed to unmarshal PAConfig")
 	test.AssertError(t, pc3.CheckChallenges(), "Disallow empty challenges map")
+	test.AssertNotError(t, pc3.CheckIdentifiers(), "Disallowed empty identifiers map")
 
 	var pc4 PAConfig
-	err = json.Unmarshal(emptyChallengesPAConfig, &pc4)
+	err = json.Unmarshal(emptyChallengesIdentsPAConfig, &pc4)
 	test.AssertNotError(t, err, "Failed to unmarshal PAConfig")
 	test.AssertError(t, pc4.CheckChallenges(), "Disallow empty challenges map")
+	test.AssertNotError(t, pc4.CheckIdentifiers(), "Disallowed empty identifiers map")
 }
 
 func TestMysqlLogger(t *testing.T) {

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -30,6 +30,16 @@ const (
 	TypeIP = IdentifierType("ip")
 )
 
+// IsValid tests whether the identifier type is known
+func (i IdentifierType) IsValid() bool {
+	switch i {
+	case TypeDNS, TypeIP:
+		return true
+	default:
+		return false
+	}
+}
+
 // ACMEIdentifier is a struct encoding an identifier that can be validated. The
 // protocol allows for different types of identifier to be supported (DNS
 // names, IP addresses, etc.), but currently we only support RFC 8555 DNS type

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -39,7 +39,11 @@ type AuthorityImpl struct {
 }
 
 // New constructs a Policy Authority.
-func New(challengeTypes map[core.AcmeChallenge]bool, identifierTypes map[identifier.IdentifierType]bool, log blog.Logger) (*AuthorityImpl, error) {
+func New(identifierTypes map[identifier.IdentifierType]bool, challengeTypes map[core.AcmeChallenge]bool, log blog.Logger) (*AuthorityImpl, error) {
+	// If identifierTypes are not configured (i.e. nil), default to allowing DNS
+	// identifiers. This default is temporary, to improve deployability.
+	//
+	// TODO(#8184): Remove this default.
 	if identifierTypes == nil {
 		identifierTypes = map[identifier.IdentifierType]bool{identifier.TypeDNS: true}
 	}

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -333,8 +333,13 @@ func validIP(ip string) error {
 		return errEmptyIdentifier
 	}
 
+	// Check the output of net.IP.String(), to ensure the input complied with
+	// RFC 8738, Sec. 3. ("The identifier value MUST contain the textual form of
+	// the address as defined in RFC 1123, Sec. 2.1 for IPv4 and in RFC 5952,
+	// Sec. 4 for IPv6.") ParseIP() will accept a non-compliant but otherwise
+	// valid string; String() will output a compliant string.
 	parsedIP := net.ParseIP(ip)
-	if parsedIP == nil {
+	if parsedIP == nil || parsedIP.String() != ip {
 		return errIPInvalid
 	}
 

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -29,7 +29,7 @@ func paImpl(t *testing.T) *AuthorityImpl {
 		identifier.TypeIP:  true,
 	}
 
-	pa, err := New(enabledChallenges, enabledIdentifiers, blog.NewMock())
+	pa, err := New(enabledIdentifiers, enabledChallenges, blog.NewMock())
 	if err != nil {
 		t.Fatalf("Couldn't create policy implementation: %s", err)
 	}

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -120,10 +120,30 @@ func TestWellFormedIdentifiers(t *testing.T) {
 
 		{identifier.ACMEIdentifier{Type: "ip", Value: `zombo.com`}, errIPInvalid}, // That's DNS!
 
+		// Unexpected IPv4 variants
+		{identifier.ACMEIdentifier{Type: "ip", Value: `192.168.1.1.1`}, errIPInvalid},            // extra octet
+		{identifier.ACMEIdentifier{Type: "ip", Value: `192.168.1.256`}, errIPInvalid},            // octet out of range
+		{identifier.ACMEIdentifier{Type: "ip", Value: `192.168.1.a1`}, errIPInvalid},             // character out of range
+		{identifier.ACMEIdentifier{Type: "ip", Value: `192.168.1.0/24`}, errIPInvalid},           // with CIDR
+		{identifier.ACMEIdentifier{Type: "ip", Value: `192.168.1.1:443`}, errIPInvalid},          // with port
+		{identifier.ACMEIdentifier{Type: "ip", Value: `0xc0a80101`}, errIPInvalid},               // as hex
+		{identifier.ACMEIdentifier{Type: "ip", Value: `1.1.168.192.in-addr.arpa`}, errIPInvalid}, // reverse DNS
+
 		// Unexpected IPv6 variants
-		{identifier.ACMEIdentifier{Type: "ip", Value: `[2001:db8:85a3:8d3:1319:8a2e:370:7348]`}, errIPInvalid},
-		{identifier.ACMEIdentifier{Type: "ip", Value: `[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443`}, errIPInvalid},
-		{identifier.ACMEIdentifier{Type: "ip", Value: `2001:db8::/32`}, errIPInvalid},
+		{identifier.ACMEIdentifier{Type: "ip", Value: `3fff:aaa:a:c0ff:ee:a:bad:deed:ffff`}, errIPInvalid},                                       // extra octet
+		{identifier.ACMEIdentifier{Type: "ip", Value: `3fff:aaa:a:c0ff:ee:a:bad:mead`}, errIPInvalid},                                            // character out of range
+		{identifier.ACMEIdentifier{Type: "ip", Value: `2001:db8::/32`}, errIPInvalid},                                                            // with CIDR
+		{identifier.ACMEIdentifier{Type: "ip", Value: `[3fff:aaa:a:c0ff:ee:a:bad:deed]`}, errIPInvalid},                                          // in brackets
+		{identifier.ACMEIdentifier{Type: "ip", Value: `[3fff:aaa:a:c0ff:ee:a:bad:deed]:443`}, errIPInvalid},                                      // in brackets, with port
+		{identifier.ACMEIdentifier{Type: "ip", Value: `0x3fff0aaa000ac0ff00ee000a0baddeed`}, errIPInvalid},                                       // as hex
+		{identifier.ACMEIdentifier{Type: "ip", Value: `d.e.e.d.d.a.b.0.a.0.0.0.e.e.0.0.f.f.0.c.a.0.0.0.a.a.a.0.f.f.f.3.ip6.arpa`}, errIPInvalid}, // reverse DNS
+		{identifier.ACMEIdentifier{Type: "ip", Value: `3fff:0aaa:a:c0ff:ee:a:bad:deed`}, errIPInvalid},                                           // leading 0 in 2nd octet (RFC 5952, Sec. 4.1)
+		{identifier.ACMEIdentifier{Type: "ip", Value: `3fff:aaa:0:0:0:a:bad:deed`}, errIPInvalid},                                                // lone 0s in 3rd-5th octets, :: not used (RFC 5952, Sec. 4.2.1)
+		{identifier.ACMEIdentifier{Type: "ip", Value: `3fff:aaa::c0ff:ee:a:bad:deed`}, errIPInvalid},                                             // :: used for just one empty octet (RFC 5952, Sec. 4.2.2)
+		{identifier.ACMEIdentifier{Type: "ip", Value: `3fff:aaa::ee:0:0:0`}, errIPInvalid},                                                       // :: used for the shorter of two possible collapses (RFC 5952, Sec. 4.2.3)
+		{identifier.ACMEIdentifier{Type: "ip", Value: `fe80:0:0:0:a::`}, errIPInvalid},                                                           // :: used for the last of two possible equal-length collapses (RFC 5952, Sec. 4.2.3)
+		{identifier.ACMEIdentifier{Type: "ip", Value: `3fff:aaa:a:C0FF:EE:a:bad:deed`}, errIPInvalid},                                            // alpha characters capitalized (RFC 5952, Sec. 4.3)
+		{identifier.ACMEIdentifier{Type: "ip", Value: `::ffff:192.168.1.1`}, errIPInvalid},                                                       // IPv6-encapsulated IPv4
 
 		// IANA special-purpose address blocks
 		{identifier.NewIP(netip.MustParseAddr("192.0.2.129")), errIPSpecialPurpose},                        // Documentation (TEST-NET-1)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -302,13 +302,13 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	va := va.RemoteClients{VAClient: dummyVA, CAAClient: dummyVA}
 
 	pa, err := policy.New(
-		map[core.AcmeChallenge]bool{
-			core.ChallengeTypeHTTP01: true,
-			core.ChallengeTypeDNS01:  true,
-		},
 		map[identifier.IdentifierType]bool{
 			identifier.TypeDNS: true,
 			identifier.TypeIP:  true,
+		},
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeHTTP01: true,
+			core.ChallengeTypeDNS01:  true,
 		},
 		blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
@@ -2802,13 +2802,13 @@ func TestFinalizeOrderDisabledChallenge(t *testing.T) {
 
 	// Replace the Policy Authority with one which has this challenge type disabled
 	pa, err := policy.New(
-		map[core.AcmeChallenge]bool{
-			core.ChallengeTypeDNS01:     true,
-			core.ChallengeTypeTLSALPN01: true,
-		},
 		map[identifier.IdentifierType]bool{
 			identifier.TypeDNS: true,
 			identifier.TypeIP:  true,
+		},
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeDNS01:     true,
+			core.ChallengeTypeTLSALPN01: true,
 		},
 		ra.log)
 	test.AssertNotError(t, err, "creating test PA")
@@ -3211,7 +3211,7 @@ func TestUpdateMissingAuthorization(t *testing.T) {
 func TestPerformValidationBadChallengeType(t *testing.T) {
 	_, _, ra, _, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
-	pa, err := policy.New(map[core.AcmeChallenge]bool{}, map[identifier.IdentifierType]bool{}, blog.NewMock())
+	pa, err := policy.New(map[identifier.IdentifierType]bool{}, map[core.AcmeChallenge]bool{}, blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
 	ra.PA = pa
 
@@ -4104,13 +4104,13 @@ func TestGetAuthorization(t *testing.T) {
 
 	// With HTTP01 enabled, GetAuthorization should pass the mock challenge through.
 	pa, err := policy.New(
-		map[core.AcmeChallenge]bool{
-			core.ChallengeTypeHTTP01: true,
-			core.ChallengeTypeDNS01:  true,
-		},
 		map[identifier.IdentifierType]bool{
 			identifier.TypeDNS: true,
 			identifier.TypeIP:  true,
+		},
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeHTTP01: true,
+			core.ChallengeTypeDNS01:  true,
 		},
 		blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
@@ -4122,12 +4122,12 @@ func TestGetAuthorization(t *testing.T) {
 
 	// With HTTP01 disabled, GetAuthorization should filter out the mock challenge.
 	pa, err = policy.New(
-		map[core.AcmeChallenge]bool{
-			core.ChallengeTypeDNS01: true,
-		},
 		map[identifier.IdentifierType]bool{
 			identifier.TypeDNS: true,
 			identifier.TypeIP:  true,
+		},
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeDNS01: true,
 		},
 		blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -301,10 +301,16 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	}
 	va := va.RemoteClients{VAClient: dummyVA, CAAClient: dummyVA}
 
-	pa, err := policy.New(map[core.AcmeChallenge]bool{
-		core.ChallengeTypeHTTP01: true,
-		core.ChallengeTypeDNS01:  true,
-	}, blog.NewMock())
+	pa, err := policy.New(
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeHTTP01: true,
+			core.ChallengeTypeDNS01:  true,
+		},
+		map[identifier.IdentifierType]bool{
+			identifier.TypeDNS: true,
+			identifier.TypeIP:  true,
+		},
+		blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
 	err = pa.LoadHostnamePolicyFile("../test/hostname-policy.yaml")
 	test.AssertNotError(t, err, "Couldn't set hostname policy")
@@ -2795,10 +2801,16 @@ func TestFinalizeOrderDisabledChallenge(t *testing.T) {
 	test.AssertNotError(t, err, "Error creating policy forbid CSR")
 
 	// Replace the Policy Authority with one which has this challenge type disabled
-	pa, err := policy.New(map[core.AcmeChallenge]bool{
-		core.ChallengeTypeDNS01:     true,
-		core.ChallengeTypeTLSALPN01: true,
-	}, ra.log)
+	pa, err := policy.New(
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeDNS01:     true,
+			core.ChallengeTypeTLSALPN01: true,
+		},
+		map[identifier.IdentifierType]bool{
+			identifier.TypeDNS: true,
+			identifier.TypeIP:  true,
+		},
+		ra.log)
 	test.AssertNotError(t, err, "creating test PA")
 	err = pa.LoadHostnamePolicyFile("../test/hostname-policy.yaml")
 	test.AssertNotError(t, err, "loading test hostname policy")
@@ -3199,7 +3211,7 @@ func TestUpdateMissingAuthorization(t *testing.T) {
 func TestPerformValidationBadChallengeType(t *testing.T) {
 	_, _, ra, _, fc, cleanUp := initAuthorities(t)
 	defer cleanUp()
-	pa, err := policy.New(map[core.AcmeChallenge]bool{}, blog.NewMock())
+	pa, err := policy.New(map[core.AcmeChallenge]bool{}, map[identifier.IdentifierType]bool{}, blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
 	ra.PA = pa
 
@@ -4091,10 +4103,16 @@ func TestGetAuthorization(t *testing.T) {
 	}
 
 	// With HTTP01 enabled, GetAuthorization should pass the mock challenge through.
-	pa, err := policy.New(map[core.AcmeChallenge]bool{
-		core.ChallengeTypeHTTP01: true,
-		core.ChallengeTypeDNS01:  true,
-	}, blog.NewMock())
+	pa, err := policy.New(
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeHTTP01: true,
+			core.ChallengeTypeDNS01:  true,
+		},
+		map[identifier.IdentifierType]bool{
+			identifier.TypeDNS: true,
+			identifier.TypeIP:  true,
+		},
+		blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
 	ra.PA = pa
 	authz, err := ra.GetAuthorization(context.Background(), &rapb.GetAuthorizationRequest{Id: 1})
@@ -4103,9 +4121,15 @@ func TestGetAuthorization(t *testing.T) {
 	test.AssertEquals(t, authz.Challenges[0].Type, string(core.ChallengeTypeHTTP01))
 
 	// With HTTP01 disabled, GetAuthorization should filter out the mock challenge.
-	pa, err = policy.New(map[core.AcmeChallenge]bool{
-		core.ChallengeTypeDNS01: true,
-	}, blog.NewMock())
+	pa, err = policy.New(
+		map[core.AcmeChallenge]bool{
+			core.ChallengeTypeDNS01: true,
+		},
+		map[identifier.IdentifierType]bool{
+			identifier.TypeDNS: true,
+			identifier.TypeIP:  true,
+		},
+		blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
 	ra.PA = pa
 	authz, err = ra.GetAuthorization(context.Background(), &rapb.GetAuthorizationRequest{Id: 1})

--- a/ratelimits/names_test.go
+++ b/ratelimits/names_test.go
@@ -205,7 +205,7 @@ func TestValidateIdForName(t *testing.T) {
 			limit: CertificatesPerDomain,
 			desc:  "empty domain",
 			id:    "",
-			err:   "name is empty",
+			err:   "Identifier value (name) is empty",
 		},
 		{
 			limit: CertificatesPerFQDNSet,

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -190,6 +190,10 @@
 			"http-01": true,
 			"dns-01": true,
 			"tls-alpn-01": true
+		},
+		"identifiers": {
+			"dns": true,
+			"ip": true
 		}
 	},
 	"syslog": {

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -29,6 +29,10 @@
 			"http-01": true,
 			"dns-01": true,
 			"tls-alpn-01": true
+		},
+		"identifiers": {
+			"dns": true,
+			"ip": true
 		}
 	},
 	"syslog": {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -181,6 +181,10 @@
 			"http-01": true,
 			"dns-01": true,
 			"tls-alpn-01": true
+		},
+		"identifiers": {
+			"dns": true,
+			"ip": true
 		}
 	},
 	"syslog": {


### PR DESCRIPTION
Add `pa.validIP` to test IP address validity & absence from IANA reservations.

Modify `pa.WillingToIssue` and `pa.WellFormedIdentifiers` to support IP address identifiers.

Add a map of allowed identifier types to the `pa` config.

Part of #8137