### PR TITLE
Remove OCSP and MustStaple support from issuance

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -549,16 +549,15 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 	}
 
 	req := &issuance.IssuanceRequest{
-		PublicKey:         issuance.MarshalablePublicKey{PublicKey: csr.PublicKey},
-		SubjectKeyId:      subjectKeyId,
-		Serial:            serialBigInt.Bytes(),
-		DNSNames:          dnsNames,
-		IPAddresses:       ipAddresses,
-		CommonName:        csrlib.NamesFromCSR(csr).CN,
-		IncludeCTPoison:   true,
-		IncludeMustStaple: issuance.ContainsMustStaple(csr.Extensions),
-		NotBefore:         notBefore,
-		NotAfter:          notAfter,
+		PublicKey:       issuance.MarshalablePublicKey{PublicKey: csr.PublicKey},
+		SubjectKeyId:    subjectKeyId,
+		Serial:          serialBigInt.Bytes(),
+		DNSNames:        dnsNames,
+		IPAddresses:     ipAddresses,
+		CommonName:      csrlib.NamesFromCSR(csr).CN,
+		IncludeCTPoison: true,
+		NotBefore:       notBefore,
+		NotAfter:        notAfter,
 	}
 
 	lintCertBytes, issuanceToken, err := issuer.Prepare(certProfile.profile, req)

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -161,8 +161,10 @@ type IssuerConfig struct {
 	Active bool
 
 	IssuerURL  string `validate:"required,url"`
-	OCSPURL    string `validate:"required,url"`
 	CRLURLBase string `validate:"required,url,startswith=http://,endswith=/"`
+
+	// TODO(#8177): Remove this.
+	OCSPURL string `validate:"omitempty,url"`
 
 	// Number of CRL shards.
 	// This must be nonzero if adding CRLDistributionPoints to certificates
@@ -205,9 +207,6 @@ type Issuer struct {
 	// Used to set the Authority Information Access caIssuers URL in issued
 	// certificates.
 	issuerURL string
-	// Used to set the Authority Information Access ocsp URL in issued
-	// certificates.
-	ocspURL string
 	// Used to set the Issuing Distribution Point extension in issued CRLs
 	// and the CRL Distribution Point extension in issued certs.
 	crlURLBase string
@@ -242,9 +241,6 @@ func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk
 
 	if config.IssuerURL == "" {
 		return nil, errors.New("Issuer URL is required")
-	}
-	if config.OCSPURL == "" {
-		return nil, errors.New("OCSP URL is required")
 	}
 	if config.CRLURLBase == "" {
 		return nil, errors.New("CRL URL base is required")
@@ -281,7 +277,6 @@ func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk
 		sigAlg:     sigAlg,
 		active:     config.Active,
 		issuerURL:  config.IssuerURL,
-		ocspURL:    config.OCSPURL,
 		crlURLBase: config.CRLURLBase,
 		crlShards:  config.CRLShards,
 		clk:        clk,

--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -24,9 +24,10 @@ import (
 
 func defaultProfileConfig() *ProfileConfig {
 	return &ProfileConfig{
-		AllowMustStaple:     true,
-		MaxValidityPeriod:   config.Duration{Duration: time.Hour},
-		MaxValidityBackdate: config.Duration{Duration: time.Hour},
+		AllowMustStaple:              true,
+		IncludeCRLDistributionPoints: true,
+		MaxValidityPeriod:            config.Duration{Duration: time.Hour},
+		MaxValidityBackdate:          config.Duration{Duration: time.Hour},
 		IgnoredLints: []string{
 			// Ignore the two SCT lints because these tests don't get SCTs.
 			"w_ct_sct_policy_count_unsatisfied",
@@ -42,8 +43,8 @@ func defaultIssuerConfig() IssuerConfig {
 	return IssuerConfig{
 		Active:     true,
 		IssuerURL:  "http://issuer-url.example.org",
-		OCSPURL:    "http://ocsp-url.example.org",
 		CRLURLBase: "http://crl-url.example.org/",
+		CRLShards:  10,
 	}
 }
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1,9 +1,12 @@
 package ra
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1046,6 +1049,26 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 	}
 }
 
+// containsMustStaple returns true if the provided set of extensions includes
+// an entry whose OID and value both match the expected values for the OCSP
+// Must-Staple (a.k.a. id-pe-tlsFeature) extension.
+func containsMustStaple(extensions []pkix.Extension) bool {
+	// RFC 7633: id-pe-tlsfeature OBJECT IDENTIFIER ::=  { id-pe 24 }
+	var mustStapleExtId = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+	// ASN.1 encoding of:
+	// SEQUENCE
+	//   INTEGER 5
+	// where "5" is the status_request feature (RFC 6066)
+	var mustStapleExtValue = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
+
+	for _, ext := range extensions {
+		if ext.Id.Equal(mustStapleExtId) && bytes.Equal(ext.Value, mustStapleExtValue) {
+			return true
+		}
+	}
+	return false
+}
+
 // validateFinalizeRequest checks that a FinalizeOrder request is fully correct
 // and ready for issuance.
 func (ra *RegistrationAuthorityImpl) validateFinalizeRequest(
@@ -1086,7 +1109,7 @@ func (ra *RegistrationAuthorityImpl) validateFinalizeRequest(
 		return nil, berrors.BadCSRError("unable to parse CSR: %s", err.Error())
 	}
 
-	if ra.mustStapleAllowList != nil && issuance.ContainsMustStaple(csr.Extensions) {
+	if ra.mustStapleAllowList != nil && containsMustStaple(csr.Extensions) {
 		if !ra.mustStapleAllowList.Contains(req.Order.RegistrationID) {
 			ra.mustStapleRequestsCounter.WithLabelValues("denied").Inc()
 			return nil, berrors.UnauthorizedError(

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -54,8 +54,6 @@
 		"issuance": {
 			"certProfiles": {
 				"legacy": {
-					"allowMustStaple": true,
-					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m",
@@ -66,12 +64,10 @@
 					]
 				},
 				"modern": {
-					"allowMustStaple": true,
 					"omitCommonName": true,
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
-					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "583200s",
 					"maxValidityBackdate": "1h5m",
@@ -81,12 +77,10 @@
 					]
 				},
 				"shortlived": {
-					"allowMustStaple": true,
 					"omitCommonName": true,
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
-					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "160h",
 					"maxValidityBackdate": "1h5m",
@@ -106,7 +100,6 @@
 					"active": true,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-a",
-					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/43104258997432926/",
 					"location": {
 						"configFile": "test/certs/webpki/int-ecdsa-a.pkcs11.json",
@@ -118,7 +111,6 @@
 					"active": true,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-b",
-					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/17302365692836921/",
 					"location": {
 						"configFile": "test/certs/webpki/int-ecdsa-b.pkcs11.json",
@@ -130,7 +122,6 @@
 					"active": false,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-c",
-					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/56560759852043581/",
 					"location": {
 						"configFile": "test/certs/webpki/int-ecdsa-c.pkcs11.json",
@@ -142,7 +133,6 @@
 					"active": true,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-a",
-					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/29947985078257530/",
 					"location": {
 						"configFile": "test/certs/webpki/int-rsa-a.pkcs11.json",
@@ -154,7 +144,6 @@
 					"active": true,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-b",
-					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/6762885421992935/",
 					"location": {
 						"configFile": "test/certs/webpki/int-rsa-b.pkcs11.json",
@@ -166,7 +155,6 @@
 					"active": false,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-c",
-					"ocspURL": "http://ca.example.org:4002/",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/56183656833365902/",
 					"location": {
 						"configFile": "test/certs/webpki/int-rsa-c.pkcs11.json",

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -56,6 +56,7 @@
 			"certProfiles": {
 				"legacy": {
 					"allowMustStaple": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m",
@@ -71,6 +72,7 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "583200s",
 					"maxValidityBackdate": "1h5m",
@@ -85,6 +87,7 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
+					"omitOCSP": true,
 					"includeCRLDistributionPoints": true,
 					"maxValidityPeriod": "160h",
 					"maxValidityBackdate": "1h5m",


### PR DESCRIPTION
Remove the ability for the issuance package to include the AIA OCSP URI and the Must Staple (more properly known as the tlsRequest) extension in certificates. Deprecate the "OmitOCSP" and "AllowMustStaple" profile config keys, as they no longer have any effect. Similarly deprecate the "OCSPURL" issuer config key, as it is no longer included in certificates.

Update the tests to always include to CRLDP extension instead, and remove some OCSP- or Stapling-specific test cases.

Fixes https://github.com/letsencrypt/boulder/issues/8179