### PR TITLE
va: Fix deployability of CAA change in #8153

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -108,7 +108,7 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 	if internalErr != nil {
 		logEvent.InternalError = internalErr.Error()
 		prob = detailedError(internalErr)
-		prob.Detail = fmt.Sprintf("While processing CAA for %s: %s", req.Identifier.Value, prob.Detail)
+		prob.Detail = fmt.Sprintf("While processing CAA for %s: %s", ident.Value, prob.Detail)
 	}
 
 	if va.isPrimaryVA() {
@@ -125,7 +125,7 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 		if remoteProb != nil {
 			prob = remoteProb
 			va.log.Infof("CAA check failed due to remote failures: identifier=%v err=%s",
-				req.Identifier.Value, remoteProb)
+				ident.Value, remoteProb)
 		}
 	}
 


### PR DESCRIPTION
In #8153, we started using identifiers in `vapb.IsCAAValidRequest`, and added logic at the top of `va.DoCAA` to populate the `ident` variable from the deprecated `Domain` value, in order to accommodate clients that don't yet populate the `Identifier`.

Unfortunately, we didn't use the `ident` variable throughout the entire function. Two places refer directly to `req.Identifier` and can't handle it being nil.

Fixes #8189 