### PR TITLE
CAA: Fix reference to req.Identifier

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -108,7 +108,7 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 	if internalErr != nil {
 		logEvent.InternalError = internalErr.Error()
 		prob = detailedError(internalErr)
-		prob.Detail = fmt.Sprintf("While processing CAA for %s: %s", req.Identifier.Value, prob.Detail)
+		prob.Detail = fmt.Sprintf("While processing CAA for %s: %s", ident.Value, prob.Detail)
 	}
 
 	if va.isPrimaryVA() {
@@ -125,7 +125,7 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 		if remoteProb != nil {
 			prob = remoteProb
 			va.log.Infof("CAA check failed due to remote failures: identifier=%v err=%s",
-				req.Identifier.Value, remoteProb)
+				ident.Value, remoteProb)
 		}
 	}
 


### PR DESCRIPTION
During the transition from dnsNames to Identifiers, all references to req.Identifier should have been replaced by references to `ident`, a temporary variable which could be derived either from the incoming request's dnsName or identifier.

Fixes https://github.com/letsencrypt/boulder/issues/8189