### PR TITLE
Include Location: header in GET Order responses

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2479,6 +2479,10 @@ func (wfe *WebFrontEndImpl) GetOrder(ctx context.Context, logEvent *web.RequestE
 		response.Header().Set(headerRetryAfter, strconv.Itoa(orderRetryAfter))
 	}
 
+	orderURL := web.RelativeEndpoint(request,
+		fmt.Sprintf("%s%d/%d", orderPath, acctID, order.Id))
+	response.Header().Set("Location", orderURL)
+
 	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, respObj)
 	if err != nil {
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshaling order"), err)


### PR DESCRIPTION
This causes the GET Order polling response to match the NewOrder and FinalizeOrder responses.

Fixes https://github.com/letsencrypt/boulder/issues/8197