### PR TITLE
bdns, va: Remove DNSAllowLoopbackAddresses

### DIFF
--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -252,7 +252,7 @@ func TestDNSNoServers(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Hour, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Hour, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 
 	_, resolvers, err := obj.LookupHost(context.Background(), "letsencrypt.org")
 	test.AssertEquals(t, len(resolvers), 0)
@@ -269,7 +269,7 @@ func TestDNSOneServer(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 
 	_, resolvers, err := obj.LookupHost(context.Background(), "cps.letsencrypt.org")
 	test.AssertEquals(t, len(resolvers), 2)
@@ -282,7 +282,7 @@ func TestDNSDuplicateServers(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr, dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 
 	_, resolvers, err := obj.LookupHost(context.Background(), "cps.letsencrypt.org")
 	test.AssertEquals(t, len(resolvers), 2)
@@ -295,7 +295,7 @@ func TestDNSServFail(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 	bad := "servfail.com"
 
 	_, _, err = obj.LookupTXT(context.Background(), bad)
@@ -313,7 +313,7 @@ func TestDNSLookupTXT(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 
 	a, _, err := obj.LookupTXT(context.Background(), "letsencrypt.org")
 	t.Logf("A: %v", a)
@@ -330,7 +330,7 @@ func TestDNSLookupHost(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 
 	ip, resolvers, err := obj.LookupHost(context.Background(), "servfail.com")
 	t.Logf("servfail.com - IP: %s, Err: %s", ip, err)
@@ -416,7 +416,7 @@ func TestDNSNXDOMAIN(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 
 	hostname := "nxdomain.letsencrypt.org"
 	_, _, err = obj.LookupHost(context.Background(), hostname)
@@ -432,7 +432,7 @@ func TestDNSLookupCAA(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	obj := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
+	obj := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 1, "", blog.UseMock(), nil)
 	removeIDExp := regexp.MustCompile(" id: [[:digit:]]+")
 
 	caas, resp, resolvers, err := obj.LookupCAA(context.Background(), "bracewel.net")
@@ -673,7 +673,7 @@ func TestRetry(t *testing.T) {
 			staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 			test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-			testClient := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), tc.maxTries, "", blog.UseMock(), nil)
+			testClient := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), tc.maxTries, "", blog.UseMock(), nil)
 			dr := testClient.(*impl)
 			dr.dnsClient = tc.te
 			_, _, err = dr.LookupTXT(context.Background(), "example.com")
@@ -704,7 +704,7 @@ func TestRetry(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	testClient := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 3, "", blog.UseMock(), nil)
+	testClient := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 3, "", blog.UseMock(), nil)
 	dr := testClient.(*impl)
 	dr.dnsClient = &testExchanger{errs: []error{isTempErr, isTempErr, nil}}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -808,7 +808,7 @@ func TestRotateServerOnErr(t *testing.T) {
 	fmt.Println(staticProvider.servers)
 
 	maxTries := 5
-	client := NewTest(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), maxTries, "", blog.UseMock(), nil)
+	client := New(time.Second*10, staticProvider, metrics.NoopRegisterer, clock.NewFake(), maxTries, "", blog.UseMock(), nil)
 
 	// Configure a mock exchanger that will always return a retryable error for
 	// servers A and B. This will force server "[2606:4700:4700::1111]:53" to do
@@ -878,7 +878,7 @@ func TestDOHMetric(t *testing.T) {
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 
-	testClient := NewTest(time.Second*11, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 0, "", blog.UseMock(), nil)
+	testClient := New(time.Second*11, staticProvider, metrics.NoopRegisterer, clock.NewFake(), 0, "", blog.UseMock(), nil)
 	resolver := testClient.(*impl)
 	resolver.dnsClient = &dohAlwaysRetryExchanger{err: &url.Error{Op: "read", Err: tempError(true)}}
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -98,28 +98,15 @@ func main() {
 	tlsConfig, err := c.VA.TLS.Load(scope)
 	cmd.FailOnError(err, "tlsConfig config")
 
-	var resolver bdns.Client
-	if !c.VA.DNSAllowLoopbackAddresses {
-		resolver = bdns.New(
-			c.VA.DNSTimeout.Duration,
-			servers,
-			scope,
-			clk,
-			c.VA.DNSTries,
-			c.VA.UserAgent,
-			logger,
-			tlsConfig)
-	} else {
-		resolver = bdns.NewTest(
-			c.VA.DNSTimeout.Duration,
-			servers,
-			scope,
-			clk,
-			c.VA.DNSTries,
-			c.VA.UserAgent,
-			logger,
-			tlsConfig)
-	}
+	resolver := bdns.New(
+		c.VA.DNSTimeout.Duration,
+		servers,
+		scope,
+		clk,
+		c.VA.DNSTries,
+		c.VA.UserAgent,
+		logger,
+		tlsConfig)
 	var remotes []va.RemoteVA
 	if len(c.VA.RemoteVAs) > 0 {
 		for _, rva := range c.VA.RemoteVAs {

--- a/cmd/remoteva/main.go
+++ b/cmd/remoteva/main.go
@@ -107,28 +107,15 @@ func main() {
 		tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
 	}
 
-	var resolver bdns.Client
-	if !c.RVA.DNSAllowLoopbackAddresses {
-		resolver = bdns.New(
-			c.RVA.DNSTimeout.Duration,
-			servers,
-			scope,
-			clk,
-			c.RVA.DNSTries,
-			c.RVA.UserAgent,
-			logger,
-			tlsConfig)
-	} else {
-		resolver = bdns.NewTest(
-			c.RVA.DNSTimeout.Duration,
-			servers,
-			scope,
-			clk,
-			c.RVA.DNSTries,
-			c.RVA.UserAgent,
-			logger,
-			tlsConfig)
-	}
+	resolver := bdns.New(
+		c.RVA.DNSTimeout.Duration,
+		servers,
+		scope,
+		clk,
+		c.RVA.DNSTries,
+		c.RVA.UserAgent,
+		logger,
+		tlsConfig)
 
 	vai, err := va.NewValidationAuthorityImpl(
 		resolver,

--- a/test/config-next/remoteva-a.json
+++ b/test/config-next/remoteva-a.json
@@ -7,7 +7,6 @@
 			"10.77.77.77:8443"
 		],
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/test/config-next/remoteva-b.json
+++ b/test/config-next/remoteva-b.json
@@ -7,7 +7,6 @@
 			"10.77.77.77:8443"
 		],
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/test/config-next/remoteva-c.json
+++ b/test/config-next/remoteva-c.json
@@ -7,7 +7,6 @@
 			"10.77.77.77:8443"
 		],
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -10,7 +10,6 @@
 			}
 		},
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/test/config/remoteva-a.json
+++ b/test/config/remoteva-a.json
@@ -11,7 +11,6 @@
 			}
 		},
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/test/config/remoteva-b.json
+++ b/test/config/remoteva-b.json
@@ -11,7 +11,6 @@
 			}
 		},
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/test/config/remoteva-c.json
+++ b/test/config/remoteva-c.json
@@ -11,7 +11,6 @@
 			}
 		},
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/test/config/va.json
+++ b/test/config/va.json
@@ -11,7 +11,6 @@
 			}
 		},
 		"dnsTimeout": "1s",
-		"dnsAllowLoopbackAddresses": true,
 		"issuerDomain": "happy-hacker-ca.invalid",
 		"tls": {
 			"caCertfile": "test/certs/ipki/minica.pem",

--- a/va/config/config.go
+++ b/va/config/config.go
@@ -24,9 +24,8 @@ type Common struct {
 	// DNSStaticResolvers is a list of DNS resolvers. Each entry must
 	// be a host or IP and port separated by a colon. IPv6 addresses
 	// must be enclosed in square brackets.
-	DNSStaticResolvers        []string        `validate:"required_without=DNSProvider,dive,hostname_port"`
-	DNSTimeout                config.Duration `validate:"required"`
-	DNSAllowLoopbackAddresses bool
+	DNSStaticResolvers []string        `validate:"required_without=DNSProvider,dive,hostname_port"`
+	DNSTimeout         config.Duration `validate:"required"`
 
 	AccountURIPrefixes []string `validate:"min=1,dive,required,url"`
 }

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -95,7 +95,7 @@ func TestDNSValidationNoServer(t *testing.T) {
 	staticProvider, err := bdns.NewStaticProvider([]string{})
 	test.AssertNotError(t, err, "Couldn't make new static provider")
 
-	va.dnsClient = bdns.NewTest(
+	va.dnsClient = bdns.New(
 		time.Second*5,
 		staticProvider,
 		metrics.NoopRegisterer,


### PR DESCRIPTION
We no longer need a code path to resolve reserved IP addresses during integration tests, since we started using a public IP for tests in #8187.

Depends on #8187