### PR TITLE
Give registrations.contact column a default value

### DIFF
--- a/sa/db-next/boulder_sa/20250519000000_NullRegistrationsContact.sql
+++ b/sa/db-next/boulder_sa/20250519000000_NullRegistrationsContact.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `registrations` ALTER COLUMN `contact` SET DEFAULT '[]';
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `registrations` ALTER COLUMN `LockCol` DROP DEFAULT;


### PR DESCRIPTION
Alter the "registrations" table so that the "contact" column has a default value of the JSON empty list "[]". This, once deployed to all production environments, will allow Boulder to stop writing to and reading from this column, in turn allowing it to be eventually wholly dropped from the database.

IN-11365 tracks the corresponding production database changes
Part of https://github.com/letsencrypt/boulder/issues/8176