### PR TITLE
SA: Use IgnoreAccountContacts flag to shortcut UpdateRegistrationContact

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -21,6 +21,7 @@ import (
 	corepb "github.com/letsencrypt/boulder/core/proto"
 	"github.com/letsencrypt/boulder/db"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
@@ -130,6 +131,10 @@ func (ssa *SQLStorageAuthority) NewRegistration(ctx context.Context, req *corepb
 func (ssa *SQLStorageAuthority) UpdateRegistrationContact(ctx context.Context, req *sapb.UpdateRegistrationContactRequest) (*corepb.Registration, error) {
 	if core.IsAnyNilOrZero(req.RegistrationID) {
 		return nil, errIncompleteRequest
+	}
+
+	if features.Get().IgnoreAccountContacts {
+		return ssa.GetRegistration(ctx, &sapb.RegistrationID{Id: req.RegistrationID})
 	}
 
 	// We don't want to write literal JSON "null" strings into the database if the


### PR DESCRIPTION
If the IgnoreAccountContacts flag is set, don't bother writing the new contacts to the database and instead just return the account object as it stands. This does not require any test changes because https://github.com/letsencrypt/boulder/pull/8198 already changed registrationModelToPb to omit whatever contacts were retrieved from the database before responding to the RA.

Part of https://github.com/letsencrypt/boulder/issues/8176