### PR TITLE
Remove expectation of contacts from id-exporter

### DIFF
--- a/cmd/id-exporter/main.go
+++ b/cmd/id-exporter/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
+
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/db"
 	"github.com/letsencrypt/boulder/features"
@@ -77,8 +78,7 @@ func (c idExporter) findIDs(ctx context.Context) (idExporterResults, error) {
 		`SELECT DISTINCT r.id
 		FROM registrations AS r
 			INNER JOIN certificates AS c on c.registrationID = r.id
-		WHERE r.contact NOT IN ('[]', 'null')
-			AND c.expires >= :expireCutoff;`,
+		WHERE c.expires >= :expireCutoff;`,
 		map[string]interface{}{
 			"expireCutoff": c.clk.Now().Add(-c.grace),
 		})


### PR DESCRIPTION
It appears that, in the past, we wanted id-exporter's "tell me all the accounts with unexpired certificates" functionality to limit itself to account that have contact info. The reasons for this limitation are unclear, and are quickly becoming obsolete as we remove contact info from the registrations table.

Remove this layer of filtering, so that id-exporter will retrieve all accounts with active certificates, and not care whether the contact column exists or not.

Part of https://github.com/letsencrypt/boulder/issues/8199