### PR TITLE
sa: Encode IP identifiers for issuedNames

### DIFF
--- a/cmd/reversed-hostname-checker/main.go
+++ b/cmd/reversed-hostname-checker/main.go
@@ -1,5 +1,14 @@
-// Read a list of reversed hostnames, separated by newlines. Print only those
-// that are rejected by the current policy.
+// Read a list of reversed hostnames and/or IP addresses, separated by newlines.
+// Print only those that are rejected by the current policy.
+//
+// IP addresses must be represented in their reverse DNS hostname forms, which
+// are then reversed. For example:
+//
+// 192.168.1.1 -> 1.1.168.192.in-addr.arpa -> arpa.in-addr.192.168.1.1
+//
+// 3fff:aaa:a:c0ff:ee:a:bad:deed ->
+// d.e.e.d.d.a.b.0.a.0.0.0.e.e.0.0.f.f.0.c.a.0.0.0.a.a.a.0.f.f.f.3.ip6.arpa ->
+// arpa.ip6.3.f.f.f.0.a.a.a.0.0.0.a.c.0.f.f.0.0.e.e.0.0.0.a.0.b.a.d.d.e.e.d
 
 package notmain
 
@@ -9,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/netip"
 	"os"
 
 	"github.com/letsencrypt/boulder/cmd"
@@ -50,8 +60,19 @@ func main() {
 	}
 	var errors bool
 	for scanner.Scan() {
-		n := sa.ReverseName(scanner.Text())
-		err := pa.WillingToIssue(identifier.ACMEIdentifiers{identifier.NewDNS(n)})
+		n, err := sa.DecodeIssuedName(scanner.Text())
+		if err != nil {
+			errors = true
+			fmt.Printf("%s: %s\n", n, err)
+		}
+		var ident identifier.ACMEIdentifier
+		ip, err := netip.ParseAddr(n)
+		if err != nil {
+			ident = identifier.NewIP(ip)
+		} else {
+			ident = identifier.NewDNS(n)
+		}
+		err = pa.WillingToIssue(identifier.ACMEIdentifiers{ident})
 		if err != nil {
 			errors = true
 			fmt.Printf("%s: %s\n", n, err)

--- a/test/hostname-policy.yaml
+++ b/test/hostname-policy.yaml
@@ -14,7 +14,7 @@ ExactBlockedNames:
 # all subdomains/wildcards.
 HighRiskBlockedNames:
   # See RFC 3152
-  - "ipv6.arpa"
+  - "ip6.arpa"
   # See RFC 2317
   - "in-addr.arpa"
   # Etc etc etc


### PR DESCRIPTION
Add `sa.EncodeIssuedIP` as the IP equivalent to `ReverseName`, which converts the IP to its reverse DNS hostname format (`in-addr.arpa` or `ip6.arpa`), then reverses that. This preserves most existing semantics of searching the `issuedNames` table, and makes use of existing encoding/decoding logic (which is relatively complex for IPv6).

Migrate `ReverseName`'s use for decoding to the new `DecodeIssuedName`, which detects whether the `issuedNames` entry is an IP address based on the `arpa` domains, and returns the IP address' normal string representation.

Update `id-exporter` and `reversed-hostname-checker` to use these new functions and handle IP addresses.

Part of #7311