### PR TITLE
Simplify docker-compose network setup

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -297,7 +297,7 @@ type GRPCClientConfig struct {
 	// If you've added the above to your Consul configuration file (and reloaded
 	// Consul) then you should be able to resolve the following dig query:
 	//
-	// $ dig @10.55.55.10 -t SRV _foo._tcp.service.consul +short
+	// $ dig @10.77.77.10 -t SRV _foo._tcp.service.consul +short
 	// 1 1 8080 0a585858.addr.dc1.consul.
 	// 1 1 8080 0a4d4d4d.addr.dc1.consul.
 	SRVLookup *ServiceDomain `validate:"required_without_all=SRVLookups ServerAddress ServerIPAddresses"`
@@ -337,7 +337,7 @@ type GRPCClientConfig struct {
 	// If you've added the above to your Consul configuration file (and reloaded
 	// Consul) then you should be able to resolve the following dig query:
 	//
-	// $ dig A @10.55.55.10 foo.service.consul +short
+	// $ dig A @10.77.77.10 foo.service.consul +short
 	// 10.77.77.77
 	// 10.88.88.88
 	ServerAddress string `validate:"required_without_all=ServerIPAddresses SRVLookup SRVLookups,omitempty,hostname_port"`
@@ -562,7 +562,7 @@ type DNSProvider struct {
 	// If you've added the above to your Consul configuration file (and reloaded
 	// Consul) then you should be able to resolve the following dig query:
 	//
-	// $ dig @10.55.55.10 -t SRV _unbound._udp.service.consul +short
+	// $ dig @10.77.77.10 -t SRV _unbound._udp.service.consul +short
 	// 1 1 8053 0a4d4d4d.addr.dc1.consul.
 	// 1 1 8153 0a4d4d4d.addr.dc1.consul.
 	SRVLookup ServiceDomain `validate:"required"`

--- a/cmd/rocsp-tool/client_test.go
+++ b/cmd/rocsp-tool/client_test.go
@@ -40,8 +40,8 @@ func makeClient() (*rocsp.RWClient, clock.Clock) {
 
 	rdb := redis.NewRing(&redis.RingOptions{
 		Addrs: map[string]string{
-			"shard1": "10.33.33.2:4218",
-			"shard2": "10.33.33.3:4218",
+			"shard1": "10.77.77.2:4218",
+			"shard2": "10.77.77.3:4218",
 		},
 		Username:  "unittest-rw",
 		Password:  "824968fa490f4ecec1e52d5e34916bdb60d45f8d",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,6 @@ services:
         ipv4_address: 10.77.77.77
       integrationtestnet:
         ipv4_address: 10.88.88.88
-      redisnet:
-        ipv4_address: 10.33.33.33
-      consulnet:
-        ipv4_address: 10.55.55.55
       publicnet:
         ipv4_address: 64.112.117.122
     # Use consul as a backup to Docker's embedded DNS server. If there's a name
@@ -40,7 +36,7 @@ services:
     # are configured via the ServerAddress field of cmd.GRPCClientConfig.
     # TODO: Remove this when ServerAddress is deprecated in favor of SRV records
     # and DNSAuthority.
-    dns: 10.55.55.10
+    dns: 10.77.77.10
     extra_hosts:
       # Allow the boulder container to be reached as "ca.example.org", so that
       # we can put that name inside our integration test certs (e.g. as a crl
@@ -118,8 +114,8 @@ services:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ocsp.config
     networks:
-      redisnet:
-        ipv4_address: 10.33.33.2
+      bouldernet:
+        ipv4_address: 10.77.77.2
 
   bredis_2:
     image: redis:6.2.7
@@ -127,8 +123,8 @@ services:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ocsp.config
     networks:
-      redisnet:
-        ipv4_address: 10.33.33.3
+      bouldernet:
+        ipv4_address: 10.77.77.3
 
   bredis_3:
     image: redis:6.2.7
@@ -136,8 +132,8 @@ services:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ratelimits.config
     networks:
-      redisnet:
-        ipv4_address: 10.33.33.4
+      bouldernet:
+        ipv4_address: 10.77.77.4
 
   bredis_4:
     image: redis:6.2.7
@@ -145,16 +141,14 @@ services:
       - ./test/:/test/:cached
     command: redis-server /test/redis-ratelimits.config
     networks:
-      redisnet:
-        ipv4_address: 10.33.33.5
+      bouldernet:
+        ipv4_address: 10.77.77.5
 
   bconsul:
     image: hashicorp/consul:1.15.4
     volumes:
      - ./test/:/test/:cached
     networks:
-      consulnet:
-        ipv4_address: 10.55.55.10
       bouldernet:
         ipv4_address: 10.77.77.10
     command: "consul agent -dev -config-format=hcl -config-file=/test/consul/config.hcl"
@@ -197,20 +191,6 @@ networks:
       driver: default
       config:
         - subnet: 10.88.88.0/24
-
-  redisnet:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 10.33.33.0/24
-
-  consulnet:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 10.55.55.0/24
 
   publicnet:
     driver: bridge

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -23,13 +23,13 @@ docker compose up boulder
 Then, in a different window, run the following to connect to `bredis_1`:
 
 ```shell
-./test/redis-cli.sh -h 10.33.33.2
+./test/redis-cli.sh -h 10.77.77.2
 ```
 
 Similarly, to connect to `bredis_2`:
 
 ```shell
-./test/redis-cli.sh -h 10.33.33.3
+./test/redis-cli.sh -h 10.77.77.3
 ```
 
 You can pass any IP address for the -h (host) parameter. The full list of IP
@@ -40,7 +40,7 @@ You may want to go a level deeper and communicate with a Redis node using the
 Redis protocol. Here's the command to do that (run from the Boulder root):
 
 ```shell
-openssl s_client -connect 10.33.33.2:4218 \
+openssl s_client -connect 10.77.77.2:4218 \
   -CAfile test/certs/ipki/minica.pem \
   -cert test/certs/ipki/localhost/cert.pem \
   -key test/certs/ipki/localhost/key.pem

--- a/ratelimits/source_redis_test.go
+++ b/ratelimits/source_redis_test.go
@@ -38,32 +38,32 @@ func newTestRedisSource(clk clock.FakeClock, addrs map[string]string) *RedisSour
 
 func newRedisTestLimiter(t *testing.T, clk clock.FakeClock) *Limiter {
 	return newTestLimiter(t, newTestRedisSource(clk, map[string]string{
-		"shard1": "10.33.33.4:4218",
-		"shard2": "10.33.33.5:4218",
+		"shard1": "10.77.77.4:4218",
+		"shard2": "10.77.77.5:4218",
 	}), clk)
 }
 
 func TestRedisSource_Ping(t *testing.T) {
 	clk := clock.NewFake()
 	workingSource := newTestRedisSource(clk, map[string]string{
-		"shard1": "10.33.33.4:4218",
-		"shard2": "10.33.33.5:4218",
+		"shard1": "10.77.77.4:4218",
+		"shard2": "10.77.77.5:4218",
 	})
 
 	err := workingSource.Ping(context.Background())
 	test.AssertNotError(t, err, "Ping should not error")
 
 	missingFirstShardSource := newTestRedisSource(clk, map[string]string{
-		"shard1": "10.33.33.4:1337",
-		"shard2": "10.33.33.5:4218",
+		"shard1": "10.77.77.4:1337",
+		"shard2": "10.77.77.5:4218",
 	})
 
 	err = missingFirstShardSource.Ping(context.Background())
 	test.AssertError(t, err, "Ping should not error")
 
 	missingSecondShardSource := newTestRedisSource(clk, map[string]string{
-		"shard1": "10.33.33.4:4218",
-		"shard2": "10.33.33.5:1337",
+		"shard1": "10.77.77.4:4218",
+		"shard2": "10.77.77.5:1337",
 	})
 
 	err = missingSecondShardSource.Ping(context.Background())
@@ -73,8 +73,8 @@ func TestRedisSource_Ping(t *testing.T) {
 func TestRedisSource_BatchSetAndGet(t *testing.T) {
 	clk := clock.NewFake()
 	s := newTestRedisSource(clk, map[string]string{
-		"shard1": "10.33.33.4:4218",
-		"shard2": "10.33.33.5:4218",
+		"shard1": "10.77.77.4:4218",
+		"shard2": "10.77.77.5:4218",
 	})
 
 	set := map[string]time.Time{

--- a/rocsp/rocsp_test.go
+++ b/rocsp/rocsp_test.go
@@ -32,8 +32,8 @@ func makeClient() (*RWClient, clock.Clock) {
 
 	rdb := redis.NewRing(&redis.RingOptions{
 		Addrs: map[string]string{
-			"shard1": "10.33.33.2:4218",
-			"shard2": "10.33.33.3:4218",
+			"shard1": "10.77.77.2:4218",
+			"shard2": "10.77.77.3:4218",
 		},
 		Username:  "unittest-rw",
 		Password:  "824968fa490f4ecec1e52d5e34916bdb60d45f8d",

--- a/test/certs/generate.sh
+++ b/test/certs/generate.sh
@@ -37,7 +37,7 @@ ipki() (
 
   # Presented by the test redis cluster. Contains IP addresses because Boulder
   # components find individual redis servers via SRV records.
-  minica -domains redis -ip-addresses 10.33.33.2,10.33.33.3,10.33.33.4,10.33.33.5,10.33.33.6,10.33.33.7,10.33.33.8,10.33.33.9
+  minica -domains redis -ip-addresses 10.77.77.2,10.77.77.3,10.77.77.4,10.77.77.5
 
   # Used by Boulder gRPC services as both server and client mTLS certificates.
   for SERVICE in admin expiration-mailer ocsp-responder consul \

--- a/test/config-next/ocsp-responder.json
+++ b/test/config-next/ocsp-responder.json
@@ -4,8 +4,8 @@
 			"username": "ocsp-responder",
 			"passwordFile": "test/secrets/ocsp_responder_redis_password",
 			"shardAddrs": {
-				"shard1": "10.33.33.2:4218",
-				"shard2": "10.33.33.3:4218"
+				"shard1": "10.77.77.2:4218",
+				"shard2": "10.77.77.3:4218"
 			},
 			"timeout": "5s",
 			"poolSize": 100,

--- a/test/config-next/rocsp-tool.json
+++ b/test/config-next/rocsp-tool.json
@@ -4,8 +4,8 @@
 			"username": "rocsp-tool",
 			"passwordFile": "test/secrets/rocsp_tool_password",
 			"shardAddrs": {
-				"shard1": "10.33.33.2:4218",
-				"shard2": "10.33.33.3:4218"
+				"shard1": "10.77.77.2:4218",
+				"shard2": "10.77.77.3:4218"
 			},
 			"timeout": "5s",
 			"tls": {

--- a/test/config/ocsp-responder.json
+++ b/test/config/ocsp-responder.json
@@ -8,8 +8,8 @@
 			"username": "ocsp-responder",
 			"passwordFile": "test/secrets/ocsp_responder_redis_password",
 			"shardAddrs": {
-				"shard1": "10.33.33.2:4218",
-				"shard2": "10.33.33.3:4218"
+				"shard1": "10.77.77.2:4218",
+				"shard2": "10.77.77.3:4218"
 			},
 			"timeout": "5s",
 			"poolSize": 100,

--- a/test/config/rocsp-tool.json
+++ b/test/config/rocsp-tool.json
@@ -5,8 +5,8 @@
 			"username": "rocsp-tool",
 			"passwordFile": "test/secrets/rocsp_tool_password",
 			"shardAddrs": {
-				"shard1": "10.33.33.2:4218",
-				"shard2": "10.33.33.3:4218"
+				"shard1": "10.77.77.2:4218",
+				"shard2": "10.77.77.3:4218"
 			},
 			"timeout": "5s",
 			"tls": {

--- a/test/consul/README.md
+++ b/test/consul/README.md
@@ -66,7 +66,7 @@ in-memory server and client with persistence disabled for ease of use.
 
 ### Linux
 
-Consul should be accessible at http://10.55.55.10:8500.
+Consul should be accessible at http://10.77.77.10:8500.
 
 ### Mac
 
@@ -76,14 +76,14 @@ to add the following port lines (temporarily) to `docker-compose.yml`:
 ```yaml
   bconsul:
     ports:
-      - 8500:8500 # forwards 127.0.0.1:8500 -> 10.55.55.10:8500
+      - 8500:8500 # forwards 127.0.0.1:8500 -> 10.77.77.10:8500
 ```
 
 For testing DNS resolution locally using `dig` you'll need to add the following:
 ```yaml
   bconsul:
     ports:
-      - 53:53/udp # forwards 127.0.0.1:53 -> 10.55.55.10:53
+      - 53:53/udp # forwards 127.0.0.1:53 -> 10.77.77.10:53
 ```
 
 The next time you bring the container up you should be able to access the web UI

--- a/test/consul/config.hcl
+++ b/test/consul/config.hcl
@@ -1,7 +1,7 @@
 # Keep this file in sync with the ports bound in test/startservers.py
 
 client_addr = "0.0.0.0"
-bind_addr   = "10.55.55.10"
+bind_addr   = "10.77.77.10"
 log_level   = "ERROR"
 // When set, uses a subset of the agent's TLS configuration (key_file,
 // cert_file, ca_file, ca_path, and server_name) to set up the client for HTTP
@@ -318,7 +318,7 @@ services {
 services {
   id      = "bredis3"
   name    = "redisratelimits"
-  address = "10.33.33.4"
+  address = "10.77.77.4"
   port    = 4218
   tags    = ["tcp"] // Required for SRV RR support in DNS resolution.
 }
@@ -326,7 +326,7 @@ services {
 services {
   id      = "bredis4"
   name    = "redisratelimits"
-  address = "10.33.33.5"
+  address = "10.77.77.5"
   port    = 4218
   tags    = ["tcp"] // Required for SRV RR support in DNS resolution.
 }


### PR DESCRIPTION
This will require devs to regenerate their //test/certs/ipki directory, as the redis IP addresses are changing.