### PR TITLE
email-exporter: Add an LRU cache of seen hashed email addresses

### DIFF
--- a/cmd/email-exporter/main.go
+++ b/cmd/email-exporter/main.go
@@ -50,10 +50,10 @@ type Config struct {
 		// "https://pi.pardot.com")
 		PardotBaseURL string `validate:"required"`
 
-		// EmailCache is the configuration for the LRU email cache. It is used
-		// to deduplicate contacts dispatched to the Pardot API. The approximate
-		// size of a single cached email address is ~120 bytes, so a cache size
-		// of 100,000 would consume about 12 MB of memory.
+		// EmailCacheSize controls how many hashed email addresses are retained
+		// in memory to prevent duplicates from being sent to the Pardot API.
+		// Each entry consumes ~120 bytes, so 100,000 entries uses around 12 MB
+		// of memory. If left unset, no caching is performed.
 		EmailCacheSize int `validate:"omitempty,min=1"`
 	}
 	Syslog        cmd.SyslogConfig

--- a/cmd/email-exporter/main.go
+++ b/cmd/email-exporter/main.go
@@ -108,7 +108,7 @@ func main() {
 		cache,
 	)
 	cmd.FailOnError(err, "Creating Pardot API client")
-	exporterServer := email.NewExporterImpl(pardotClient, c.EmailExporter.PerDayLimit, c.EmailExporter.MaxConcurrentRequests, cache, scope, logger)
+	exporterServer := email.NewExporterImpl(pardotClient, c.EmailExporter.PerDayLimit, c.EmailExporter.MaxConcurrentRequests, scope, logger)
 
 	tlsConfig, err := c.EmailExporter.TLS.Load(scope)
 	cmd.FailOnError(err, "Loading email-exporter TLS config")

--- a/email/cache.go
+++ b/email/cache.go
@@ -1,0 +1,68 @@
+package email
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type EmailCache struct {
+	sync.Mutex
+	cache    *lru.Cache
+	requests *prometheus.CounterVec
+}
+
+func NewHashedEmailCache(maxEntries int, stats prometheus.Registerer) *EmailCache {
+	requests := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "email_cache_requests",
+	}, []string{"status"})
+	stats.MustRegister(requests)
+
+	return &EmailCache{
+		cache:    lru.New(maxEntries),
+		requests: requests,
+	}
+}
+
+func hashEmail(email string) string {
+	sum := sha256.Sum256([]byte(email))
+	return hex.EncodeToString(sum[:])
+}
+
+func (c *EmailCache) Seen(email string) bool {
+	if c == nil {
+		// If the cache is nil we assume it was not configured.
+		return false
+	}
+
+	hash := hashEmail(email)
+
+	c.Lock()
+	defer c.Unlock()
+
+	_, ok := c.cache.Get(hash)
+	if !ok {
+		c.requests.WithLabelValues("miss").Inc()
+		return false
+	}
+
+	c.requests.WithLabelValues("hit").Inc()
+	return true
+}
+
+func (c *EmailCache) Store(email string) {
+	if c == nil {
+		// If the cache is nil we assume it was not configured.
+		return
+	}
+
+	hash := hashEmail(email)
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.cache.Add(hash, nil)
+}

--- a/email/exporter.go
+++ b/email/exporter.go
@@ -17,8 +17,8 @@ import (
 
 // contactsQueueCap limits the queue size to prevent unbounded growth. This
 // value is adjustable as needed. Each RFC 5321 email address, encoded in UTF-8,
-// is at most 320 bytes. Storing 10,000 emails requires ~3.44 MB of memory.
-const contactsQueueCap = 10000
+// is at most 320 bytes. Storing 100,000 emails requires ~34.4 MB of memory.
+const contactsQueueCap = 100000
 
 var ErrQueueFull = errors.New("email-exporter queue is full")
 
@@ -40,6 +40,7 @@ type ExporterImpl struct {
 	maxConcurrentRequests int
 	limiter               *rate.Limiter
 	client                PardotClient
+	emailCache            *EmailCache
 	emailsHandledCounter  prometheus.Counter
 	pardotErrorCounter    prometheus.Counter
 	log                   blog.Logger
@@ -54,7 +55,7 @@ var _ emailpb.ExporterServer = (*ExporterImpl)(nil)
 // is assigned 40% (20,000 requests), it should also receive 40% of the max
 // concurrent requests (e.g., 2 out of 5). For more details, see:
 // https://developer.salesforce.com/docs/marketing/pardot/guide/overview.html?q=rate%20limits
-func NewExporterImpl(client PardotClient, perDayLimit float64, maxConcurrentRequests int, scope prometheus.Registerer, logger blog.Logger) *ExporterImpl {
+func NewExporterImpl(client PardotClient, perDayLimit float64, maxConcurrentRequests int, cache *EmailCache, scope prometheus.Registerer, logger blog.Logger) *ExporterImpl {
 	limiter := rate.NewLimiter(rate.Limit(perDayLimit/86400.0), maxConcurrentRequests)
 
 	emailsHandledCounter := prometheus.NewCounter(prometheus.CounterOpts{
@@ -74,6 +75,7 @@ func NewExporterImpl(client PardotClient, perDayLimit float64, maxConcurrentRequ
 		limiter:               limiter,
 		toSend:                make([]string, 0, contactsQueueCap),
 		client:                client,
+		emailCache:            cache,
 		emailsHandledCounter:  emailsHandledCounter,
 		pardotErrorCounter:    pardotErrorCounter,
 		log:                   logger,
@@ -100,14 +102,24 @@ func (impl *ExporterImpl) SendContacts(ctx context.Context, req *emailpb.SendCon
 		return nil, berrors.InternalServerError("Incomplete gRPC request message")
 	}
 
+	var unseen []string
+	for _, email := range req.Emails {
+		// We check the cache here to avoid enqueuing an email that has already
+		// been seen, but we do not add it to the cache until the Pardot client
+		// has successfully sent it.
+		if !impl.emailCache.Seen(email) {
+			unseen = append(unseen, email)
+		}
+	}
+
 	impl.Lock()
 	defer impl.Unlock()
 
 	spotsLeft := contactsQueueCap - len(impl.toSend)
-	if spotsLeft < len(req.Emails) {
+	if spotsLeft < len(unseen) {
 		return nil, ErrQueueFull
 	}
-	impl.toSend = append(impl.toSend, req.Emails...)
+	impl.toSend = append(impl.toSend, unseen...)
 	// Wake waiting workers to process the new emails.
 	impl.wake.Broadcast()
 

--- a/email/pardot_test.go
+++ b/email/pardot_test.go
@@ -226,8 +226,7 @@ func TestSendContactDeduplication(t *testing.T) {
 	defer contactSrv.Close()
 
 	cache := NewHashedEmailCache(1000, metrics.NoopRegisterer)
-	client, _ := NewPardotClientImpl(clock.New(), "biz", "cid", "csec",
-		tokenSrv.URL, contactSrv.URL, cache)
+	client, _ := NewPardotClientImpl(clock.New(), "biz", "cid", "csec", tokenSrv.URL, contactSrv.URL, cache)
 
 	err := client.SendContact("test@example.com")
 	test.AssertNotError(t, err, "SendContact should succeed on first call")

--- a/email/pardot_test.go
+++ b/email/pardot_test.go
@@ -6,11 +6,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func defaultTokenHandler(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +47,7 @@ func TestSendContactSuccess(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
 	test.AssertNotError(t, err, "failed to create client")
 
 	err = client.SendContact("test@example.com")
@@ -70,7 +73,7 @@ func TestSendContactUpdateTokenFails(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
 	test.AssertNotError(t, err, "Failed to create client")
 
 	err = client.SendContact("test@example.com")
@@ -94,7 +97,7 @@ func TestSendContact4xx(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
 	test.AssertNotError(t, err, "Failed to create client")
 
 	err = client.SendContact("test@example.com")
@@ -142,7 +145,7 @@ func TestSendContactTokenExpiry(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
 	test.AssertNotError(t, err, "Failed to create client")
 
 	// First call uses the initial token ("old_token").
@@ -172,7 +175,7 @@ func TestSendContactServerErrorsAfterMaxAttempts(t *testing.T) {
 	contactSrv := httptest.NewServer(http.HandlerFunc(contactHandler))
 	defer contactSrv.Close()
 
-	client, _ := NewPardotClientImpl(clock.NewFake(), "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
+	client, _ := NewPardotClientImpl(clock.NewFake(), "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
 
 	err := client.SendContact("test@example.com")
 	test.AssertError(t, err, "Should fail after retrying all attempts")
@@ -200,11 +203,39 @@ func TestSendContactRedactsEmail(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
 	test.AssertNotError(t, err, "failed to create client")
 
 	err = client.SendContact(emailToTest)
 	test.AssertError(t, err, "SendContact should fail")
 	test.AssertNotContains(t, err.Error(), emailToTest)
 	test.AssertContains(t, err.Error(), "[REDACTED]")
+}
+
+func TestSendContactDeduplication(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(defaultTokenHandler))
+	defer tokenSrv.Close()
+
+	var contactHits int32
+	contactSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&contactHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer contactSrv.Close()
+
+	cache := NewHashedEmailCache(1000, metrics.NoopRegisterer)
+	client, _ := NewPardotClientImpl(clock.New(), "biz", "cid", "csec",
+		tokenSrv.URL, contactSrv.URL, cache)
+
+	err := client.SendContact("test@example.com")
+	test.AssertNotError(t, err, "SendContact should succeed on first call")
+	test.AssertMetricWithLabelsEquals(t, client.emailCache.requests, prometheus.Labels{"status": "miss"}, 1)
+
+	err = client.SendContact("test@example.com")
+	test.AssertNotError(t, err, "SendContact should succeed on second call")
+
+	test.AssertEquals(t, int32(1), atomic.LoadInt32(&contactHits))
+	test.AssertMetricWithLabelsEquals(t, client.emailCache.requests, prometheus.Labels{"status": "hit"}, 1)
 }

--- a/test/config-next/email-exporter.json
+++ b/test/config-next/email-exporter.json
@@ -32,7 +32,8 @@
 			"passwordFile": "test/secrets/salesforce_client_secret"
 		},
 		"salesforceBaseURL": "http://localhost:9601",
-		"pardotBaseURL": "http://localhost:9602"
+		"pardotBaseURL": "http://localhost:9602",
+		"emailCacheSize": 100000
 	},
 	"syslog": {
 		"stdoutlevel": 6,


### PR DESCRIPTION
Also increase the queue cap from 10,000 to 100,000.

Fixes #8211