### PR TITLE
Ratelimits: don't validate our own constructed bucket keys

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1546,11 +1546,8 @@ func (ra *RegistrationAuthorityImpl) countFailedValidations(ctx context.Context,
 // TODO(#7311): Handle IP address identifiers properly; don't just trust that
 // the value will always make sense in context.
 func (ra *RegistrationAuthorityImpl) resetAccountPausingLimit(ctx context.Context, regId int64, ident identifier.ACMEIdentifier) {
-	bucketKey, err := ratelimits.NewRegIdDomainBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, regId, ident.Value)
-	if err != nil {
-		ra.log.Warningf("creating bucket key for regID=[%d] identifier=[%s]: %s", regId, ident.Value, err)
-	}
-	err = ra.limiter.Reset(ctx, bucketKey)
+	bucketKey := ratelimits.NewRegIdDomainBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, regId, ident.Value)
+	err := ra.limiter.Reset(ctx, bucketKey)
 	if err != nil {
 		ra.log.Warningf("resetting bucket for regID=[%d] identifier=[%s]: %s", regId, ident.Value, err)
 	}

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -727,8 +727,7 @@ func TestPerformValidation_FailedValidationsTriggerPauseIdentifiersRatelimit(t *
 	domain := randomDomain()
 	ident := identifier.NewDNS(domain)
 	authzPB := createPendingAuthorization(t, sa, ident, fc.Now().Add(12*time.Hour))
-	bucketKey, err := ratelimits.NewRegIdDomainBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, authzPB.RegistrationID, domain)
-	test.AssertNotError(t, err, "constructing test bucket key")
+	bucketKey := ratelimits.NewRegIdDomainBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, authzPB.RegistrationID, domain)
 
 	// Set the stored TAT to indicate that this bucket has exhausted its quota.
 	err = rl.BatchSet(context.Background(), map[string]time.Time{
@@ -804,8 +803,7 @@ func TestPerformValidation_FailedThenSuccessfulValidationResetsPauseIdentifiersR
 	domain := randomDomain()
 	ident := identifier.NewDNS(domain)
 	authzPB := createPendingAuthorization(t, sa, ident, fc.Now().Add(12*time.Hour))
-	bucketKey, err := ratelimits.NewRegIdDomainBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, authzPB.RegistrationID, domain)
-	test.AssertNotError(t, err, "constructing test bucket key")
+	bucketKey := ratelimits.NewRegIdDomainBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, authzPB.RegistrationID, domain)
 
 	// Set a stored TAT so that we can tell when it's been reset.
 	err = rl.BatchSet(context.Background(), map[string]time.Time{

--- a/ratelimits/limit_test.go
+++ b/ratelimits/limit_test.go
@@ -115,12 +115,9 @@ func TestLoadAndParseOverrideLimits(t *testing.T) {
 	//   - CertificatesPerFQDNSet:example.com
 	//   - CertificatesPerFQDNSet:example.com,example.net
 	//   - CertificatesPerFQDNSet:example.com,example.net,example.org
-	firstEntryKey, err := newFQDNSetBucketKey(CertificatesPerFQDNSet, []string{"example.com"})
-	test.AssertNotError(t, err, "valid fqdnSet with one domain should not fail")
-	secondEntryKey, err := newFQDNSetBucketKey(CertificatesPerFQDNSet, []string{"example.com", "example.net"})
-	test.AssertNotError(t, err, "valid fqdnSet with two domains should not fail")
-	thirdEntryKey, err := newFQDNSetBucketKey(CertificatesPerFQDNSet, []string{"example.com", "example.net", "example.org"})
-	test.AssertNotError(t, err, "valid fqdnSet with three domains should not fail")
+	firstEntryKey := newFQDNSetBucketKey(CertificatesPerFQDNSet, []string{"example.com"})
+	secondEntryKey := newFQDNSetBucketKey(CertificatesPerFQDNSet, []string{"example.com", "example.net"})
+	thirdEntryKey := newFQDNSetBucketKey(CertificatesPerFQDNSet, []string{"example.com", "example.net", "example.org"})
 	l, err = loadAndParseOverrideLimits("testdata/working_overrides_regid_fqdnset.yml")
 	test.AssertNotError(t, err, "multiple valid override limits with 'fqdnSet' Ids")
 	test.AssertEquals(t, l[firstEntryKey].burst, int64(40))

--- a/ratelimits/limiter_test.go
+++ b/ratelimits/limiter_test.go
@@ -60,8 +60,7 @@ func TestLimiter_CheckWithLimitOverrides(t *testing.T) {
 	testCtx, limiters, txnBuilder, clk, testIP := setup(t)
 	for name, l := range limiters {
 		t.Run(name, func(t *testing.T) {
-			overriddenBucketKey, err := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(tenZeroZeroTwo))
-			test.AssertNotError(t, err, "should not error")
+			overriddenBucketKey := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(tenZeroZeroTwo))
 			overriddenLimit, err := txnBuilder.getLimit(NewRegistrationsPerIPAddress, overriddenBucketKey)
 			test.AssertNotError(t, err, "should not error")
 
@@ -116,8 +115,7 @@ func TestLimiter_CheckWithLimitOverrides(t *testing.T) {
 			// Wait 1 second for a full bucket reset.
 			clk.Add(d.resetIn)
 
-			normalBucketKey, err := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
-			test.AssertNotError(t, err, "should not error")
+			normalBucketKey := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
 			normalLimit, err := txnBuilder.getLimit(NewRegistrationsPerIPAddress, normalBucketKey)
 			test.AssertNotError(t, err, "should not error")
 
@@ -247,8 +245,7 @@ func TestLimiter_InitializationViaCheckAndSpend(t *testing.T) {
 	testCtx, limiters, txnBuilder, _, testIP := setup(t)
 	for name, l := range limiters {
 		t.Run(name, func(t *testing.T) {
-			bucketKey, err := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
-			test.AssertNotError(t, err, "should not error")
+			bucketKey := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
 			limit, err := txnBuilder.getLimit(NewRegistrationsPerIPAddress, bucketKey)
 			test.AssertNotError(t, err, "should not error")
 
@@ -310,8 +307,7 @@ func TestLimiter_DefaultLimits(t *testing.T) {
 	testCtx, limiters, txnBuilder, clk, testIP := setup(t)
 	for name, l := range limiters {
 		t.Run(name, func(t *testing.T) {
-			bucketKey, err := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
-			test.AssertNotError(t, err, "should not error")
+			bucketKey := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
 			limit, err := txnBuilder.getLimit(NewRegistrationsPerIPAddress, bucketKey)
 			test.AssertNotError(t, err, "should not error")
 
@@ -373,8 +369,7 @@ func TestLimiter_RefundAndReset(t *testing.T) {
 	testCtx, limiters, txnBuilder, clk, testIP := setup(t)
 	for name, l := range limiters {
 		t.Run(name, func(t *testing.T) {
-			bucketKey, err := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
-			test.AssertNotError(t, err, "should not error")
+			bucketKey := newIPAddressBucketKey(NewRegistrationsPerIPAddress, netip.MustParseAddr(testIP))
 			limit, err := txnBuilder.getLimit(NewRegistrationsPerIPAddress, bucketKey)
 			test.AssertNotError(t, err, "should not error")
 

--- a/ratelimits/transaction.go
+++ b/ratelimits/transaction.go
@@ -15,8 +15,8 @@ var ErrInvalidCostOverLimit = fmt.Errorf("invalid cost, must be <= limit.Burst")
 
 // newIPAddressBucketKey validates and returns a bucketKey for limits that use
 // the 'enum:ipAddress' bucket key format.
-func newIPAddressBucketKey(name Name, ip netip.Addr) (string, error) { //nolint:unparam // Only one named rate limit uses this helper
-	return joinWithColon(name.EnumString(), ip.String()), nil
+func newIPAddressBucketKey(name Name, ip netip.Addr) string { //nolint:unparam // Only one named rate limit uses this helper
+	return joinWithColon(name.EnumString(), ip.String())
 }
 
 // newIPv6RangeCIDRBucketKey validates and returns a bucketKey for limits that
@@ -34,28 +34,27 @@ func newIPv6RangeCIDRBucketKey(name Name, ip netip.Addr) (string, error) {
 
 // newRegIdBucketKey validates and returns a bucketKey for limits that use the
 // 'enum:regId' bucket key format.
-func newRegIdBucketKey(name Name, regId int64) (string, error) {
-	return joinWithColon(name.EnumString(), strconv.FormatInt(regId, 10)), nil
+func newRegIdBucketKey(name Name, regId int64) string {
+	return joinWithColon(name.EnumString(), strconv.FormatInt(regId, 10))
 }
 
 // newDomainBucketKey validates and returns a bucketKey for limits that use the
 // 'enum:domain' bucket key format.
-func newDomainBucketKey(name Name, orderName string) (string, error) {
-	return joinWithColon(name.EnumString(), orderName), nil
+func newDomainBucketKey(name Name, orderName string) string {
+	return joinWithColon(name.EnumString(), orderName)
 }
 
 // NewRegIdDomainBucketKey validates and returns a bucketKey for limits that use
 // the 'enum:regId:domain' bucket key format. This function is exported for use
 // in ra.resetAccountPausingLimit.
-func NewRegIdDomainBucketKey(name Name, regId int64, orderName string) (string, error) {
-	return joinWithColon(name.EnumString(), strconv.FormatInt(regId, 10), orderName), nil
+func NewRegIdDomainBucketKey(name Name, regId int64, orderName string) string {
+	return joinWithColon(name.EnumString(), strconv.FormatInt(regId, 10), orderName)
 }
 
 // newFQDNSetBucketKey validates and returns a bucketKey for limits that use the
 // 'enum:fqdnSet' bucket key format.
-func newFQDNSetBucketKey(name Name, orderNames []string) (string, error) { //nolint: unparam // Only one named rate limit uses this helper
-	id := fmt.Sprintf("%x", hashNames(orderNames))
-	return joinWithColon(name.EnumString(), id), nil
+func newFQDNSetBucketKey(name Name, orderNames []string) string { //nolint: unparam // Only one named rate limit uses this helper
+	return joinWithColon(name.EnumString(), fmt.Sprintf("%x", hashNames(orderNames)))
 }
 
 // Transaction represents a single rate limit operation. It includes a
@@ -180,10 +179,7 @@ func NewTransactionBuilder(defaults LimitConfigs) (*TransactionBuilder, error) {
 // registrationsPerIPAddressTransaction returns a Transaction for the
 // NewRegistrationsPerIPAddress limit for the provided IP address.
 func (builder *TransactionBuilder) registrationsPerIPAddressTransaction(ip netip.Addr) (Transaction, error) {
-	bucketKey, err := newIPAddressBucketKey(NewRegistrationsPerIPAddress, ip)
-	if err != nil {
-		return Transaction{}, err
-	}
+	bucketKey := newIPAddressBucketKey(NewRegistrationsPerIPAddress, ip)
 	limit, err := builder.getLimit(NewRegistrationsPerIPAddress, bucketKey)
 	if err != nil {
 		if errors.Is(err, errLimitDisabled) {
@@ -215,10 +211,7 @@ func (builder *TransactionBuilder) registrationsPerIPv6RangeTransaction(ip netip
 // ordersPerAccountTransaction returns a Transaction for the NewOrdersPerAccount
 // limit for the provided ACME registration Id.
 func (builder *TransactionBuilder) ordersPerAccountTransaction(regId int64) (Transaction, error) {
-	bucketKey, err := newRegIdBucketKey(NewOrdersPerAccount, regId)
-	if err != nil {
-		return Transaction{}, err
-	}
+	bucketKey := newRegIdBucketKey(NewOrdersPerAccount, regId)
 	limit, err := builder.getLimit(NewOrdersPerAccount, bucketKey)
 	if err != nil {
 		if errors.Is(err, errLimitDisabled) {
@@ -238,10 +231,7 @@ func (builder *TransactionBuilder) ordersPerAccountTransaction(regId int64) (Tra
 func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountCheckOnlyTransactions(regId int64, orderDomains []string) ([]Transaction, error) {
 	// FailedAuthorizationsPerDomainPerAccount limit uses the 'enum:regId'
 	// bucket key format for overrides.
-	perAccountBucketKey, err := newRegIdBucketKey(FailedAuthorizationsPerDomainPerAccount, regId)
-	if err != nil {
-		return nil, err
-	}
+	perAccountBucketKey := newRegIdBucketKey(FailedAuthorizationsPerDomainPerAccount, regId)
 	limit, err := builder.getLimit(FailedAuthorizationsPerDomainPerAccount, perAccountBucketKey)
 	if err != nil {
 		if errors.Is(err, errLimitDisabled) {
@@ -254,10 +244,7 @@ func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountCheckO
 	for _, name := range orderDomains {
 		// FailedAuthorizationsPerDomainPerAccount limit uses the
 		// 'enum:regId:domain' bucket key format for transactions.
-		perDomainPerAccountBucketKey, err := NewRegIdDomainBucketKey(FailedAuthorizationsPerDomainPerAccount, regId, name)
-		if err != nil {
-			return nil, err
-		}
+		perDomainPerAccountBucketKey := NewRegIdDomainBucketKey(FailedAuthorizationsPerDomainPerAccount, regId, name)
 
 		// Add a check-only transaction for each per domain per account bucket.
 		// The cost is 0, as we are only checking that the account and domain
@@ -278,10 +265,7 @@ func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountCheckO
 func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountSpendOnlyTransaction(regId int64, orderDomain string) (Transaction, error) {
 	// FailedAuthorizationsPerDomainPerAccount limit uses the 'enum:regId'
 	// bucket key format for overrides.
-	perAccountBucketKey, err := newRegIdBucketKey(FailedAuthorizationsPerDomainPerAccount, regId)
-	if err != nil {
-		return Transaction{}, err
-	}
+	perAccountBucketKey := newRegIdBucketKey(FailedAuthorizationsPerDomainPerAccount, regId)
 	limit, err := builder.getLimit(FailedAuthorizationsPerDomainPerAccount, perAccountBucketKey)
 	if err != nil {
 		if errors.Is(err, errLimitDisabled) {
@@ -292,10 +276,7 @@ func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountSpendO
 
 	// FailedAuthorizationsPerDomainPerAccount limit uses the
 	// 'enum:regId:domain' bucket key format for transactions.
-	perDomainPerAccountBucketKey, err := NewRegIdDomainBucketKey(FailedAuthorizationsPerDomainPerAccount, regId, orderDomain)
-	if err != nil {
-		return Transaction{}, err
-	}
+	perDomainPerAccountBucketKey := NewRegIdDomainBucketKey(FailedAuthorizationsPerDomainPerAccount, regId, orderDomain)
 	txn, err := newSpendOnlyTransaction(limit, perDomainPerAccountBucketKey, 1)
 	if err != nil {
 		return Transaction{}, err
@@ -311,10 +292,7 @@ func (builder *TransactionBuilder) FailedAuthorizationsPerDomainPerAccountSpendO
 func (builder *TransactionBuilder) FailedAuthorizationsForPausingPerDomainPerAccountTransaction(regId int64, orderDomain string) (Transaction, error) {
 	// FailedAuthorizationsForPausingPerDomainPerAccount limit uses the 'enum:regId'
 	// bucket key format for overrides.
-	perAccountBucketKey, err := newRegIdBucketKey(FailedAuthorizationsForPausingPerDomainPerAccount, regId)
-	if err != nil {
-		return Transaction{}, err
-	}
+	perAccountBucketKey := newRegIdBucketKey(FailedAuthorizationsForPausingPerDomainPerAccount, regId)
 	limit, err := builder.getLimit(FailedAuthorizationsForPausingPerDomainPerAccount, perAccountBucketKey)
 	if err != nil {
 		if errors.Is(err, errLimitDisabled) {
@@ -325,11 +303,7 @@ func (builder *TransactionBuilder) FailedAuthorizationsForPausingPerDomainPerAcc
 
 	// FailedAuthorizationsForPausingPerDomainPerAccount limit uses the
 	// 'enum:regId:domain' bucket key format for transactions.
-	perDomainPerAccountBucketKey, err := NewRegIdDomainBucketKey(FailedAuthorizationsForPausingPerDomainPerAccount, regId, orderDomain)
-	if err != nil {
-		return Transaction{}, err
-	}
-
+	perDomainPerAccountBucketKey := NewRegIdDomainBucketKey(FailedAuthorizationsForPausingPerDomainPerAccount, regId, orderDomain)
 	txn, err := newTransaction(limit, perDomainPerAccountBucketKey, 1)
 	if err != nil {
 		return Transaction{}, err
@@ -353,10 +327,7 @@ func (builder *TransactionBuilder) certificatesPerDomainCheckOnlyTransactions(re
 		return nil, fmt.Errorf("unwilling to process more than 100 rate limit transactions, got %d", len(orderDomains))
 	}
 
-	perAccountLimitBucketKey, err := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)
-	if err != nil {
-		return nil, err
-	}
+	perAccountLimitBucketKey := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)
 	accountOverride := true
 	perAccountLimit, err := builder.getLimit(CertificatesPerDomainPerAccount, perAccountLimitBucketKey)
 	if err != nil {
@@ -373,18 +344,12 @@ func (builder *TransactionBuilder) certificatesPerDomainCheckOnlyTransactions(re
 
 	var txns []Transaction
 	for _, name := range FQDNsToETLDsPlusOne(orderDomains) {
-		perDomainBucketKey, err := newDomainBucketKey(CertificatesPerDomain, name)
-		if err != nil {
-			return nil, err
-		}
+		perDomainBucketKey := newDomainBucketKey(CertificatesPerDomain, name)
 		if accountOverride {
 			if !perAccountLimit.isOverride {
 				return nil, fmt.Errorf("shouldn't happen: CertificatesPerDomainPerAccount limit is not an override")
 			}
-			perAccountPerDomainKey, err := NewRegIdDomainBucketKey(CertificatesPerDomainPerAccount, regId, name)
-			if err != nil {
-				return nil, err
-			}
+			perAccountPerDomainKey := NewRegIdDomainBucketKey(CertificatesPerDomainPerAccount, regId, name)
 			// Add a check-only transaction for each per account per domain
 			// bucket.
 			txn, err := newCheckOnlyTransaction(perAccountLimit, perAccountPerDomainKey, 1)
@@ -435,10 +400,7 @@ func (builder *TransactionBuilder) CertificatesPerDomainSpendOnlyTransactions(re
 		return nil, fmt.Errorf("unwilling to process more than 100 rate limit transactions, got %d", len(orderDomains))
 	}
 
-	perAccountLimitBucketKey, err := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)
-	if err != nil {
-		return nil, err
-	}
+	perAccountLimitBucketKey := newRegIdBucketKey(CertificatesPerDomainPerAccount, regId)
 	accountOverride := true
 	perAccountLimit, err := builder.getLimit(CertificatesPerDomainPerAccount, perAccountLimitBucketKey)
 	if err != nil {
@@ -455,18 +417,12 @@ func (builder *TransactionBuilder) CertificatesPerDomainSpendOnlyTransactions(re
 
 	var txns []Transaction
 	for _, name := range FQDNsToETLDsPlusOne(orderDomains) {
-		perDomainBucketKey, err := newDomainBucketKey(CertificatesPerDomain, name)
-		if err != nil {
-			return nil, err
-		}
+		perDomainBucketKey := newDomainBucketKey(CertificatesPerDomain, name)
 		if accountOverride {
 			if !perAccountLimit.isOverride {
 				return nil, fmt.Errorf("shouldn't happen: CertificatesPerDomainPerAccount limit is not an override")
 			}
-			perAccountPerDomainKey, err := NewRegIdDomainBucketKey(CertificatesPerDomainPerAccount, regId, name)
-			if err != nil {
-				return nil, err
-			}
+			perAccountPerDomainKey := NewRegIdDomainBucketKey(CertificatesPerDomainPerAccount, regId, name)
 			// Add a spend-only transaction for each per account per domain
 			// bucket.
 			txn, err := newSpendOnlyTransaction(perAccountLimit, perAccountPerDomainKey, 1)
@@ -514,10 +470,7 @@ func (builder *TransactionBuilder) CertificatesPerDomainSpendOnlyTransactions(re
 // for the provided order domain names. This method should only be used for
 // checking capacity, before allowing more orders to be created.
 func (builder *TransactionBuilder) certificatesPerFQDNSetCheckOnlyTransaction(orderNames []string) (Transaction, error) {
-	bucketKey, err := newFQDNSetBucketKey(CertificatesPerFQDNSet, orderNames)
-	if err != nil {
-		return Transaction{}, err
-	}
+	bucketKey := newFQDNSetBucketKey(CertificatesPerFQDNSet, orderNames)
 	limit, err := builder.getLimit(CertificatesPerFQDNSet, bucketKey)
 	if err != nil {
 		if errors.Is(err, errLimitDisabled) {
@@ -532,10 +485,7 @@ func (builder *TransactionBuilder) certificatesPerFQDNSetCheckOnlyTransaction(or
 // for the provided order domain names. This method should only be used for
 // spending capacity, when a certificate is issued.
 func (builder *TransactionBuilder) CertificatesPerFQDNSetSpendOnlyTransaction(orderNames []string) (Transaction, error) {
-	bucketKey, err := newFQDNSetBucketKey(CertificatesPerFQDNSet, orderNames)
-	if err != nil {
-		return Transaction{}, err
-	}
+	bucketKey := newFQDNSetBucketKey(CertificatesPerFQDNSet, orderNames)
 	limit, err := builder.getLimit(CertificatesPerFQDNSet, bucketKey)
 	if err != nil {
 		if errors.Is(err, errLimitDisabled) {

--- a/ratelimits/transaction.go
+++ b/ratelimits/transaction.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/netip"
 	"strconv"
-	"strings"
 )
 
 // ErrInvalidCost indicates that the cost specified was < 0.
@@ -17,12 +16,7 @@ var ErrInvalidCostOverLimit = fmt.Errorf("invalid cost, must be <= limit.Burst")
 // newIPAddressBucketKey validates and returns a bucketKey for limits that use
 // the 'enum:ipAddress' bucket key format.
 func newIPAddressBucketKey(name Name, ip netip.Addr) (string, error) { //nolint:unparam // Only one named rate limit uses this helper
-	id := ip.String()
-	err := validateIdForName(name, id)
-	if err != nil {
-		return "", err
-	}
-	return joinWithColon(name.EnumString(), id), nil
+	return joinWithColon(name.EnumString(), ip.String()), nil
 }
 
 // newIPv6RangeCIDRBucketKey validates and returns a bucketKey for limits that
@@ -35,32 +29,18 @@ func newIPv6RangeCIDRBucketKey(name Name, ip netip.Addr) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid IPv6 address, can't calculate prefix of %q: %s", ip.String(), err)
 	}
-	id := prefix.String()
-	err = validateIdForName(name, id)
-	if err != nil {
-		return "", err
-	}
-	return joinWithColon(name.EnumString(), id), nil
+	return joinWithColon(name.EnumString(), prefix.String()), nil
 }
 
 // newRegIdBucketKey validates and returns a bucketKey for limits that use the
 // 'enum:regId' bucket key format.
 func newRegIdBucketKey(name Name, regId int64) (string, error) {
-	id := strconv.FormatInt(regId, 10)
-	err := validateIdForName(name, id)
-	if err != nil {
-		return "", err
-	}
-	return joinWithColon(name.EnumString(), id), nil
+	return joinWithColon(name.EnumString(), strconv.FormatInt(regId, 10)), nil
 }
 
 // newDomainBucketKey validates and returns a bucketKey for limits that use the
 // 'enum:domain' bucket key format.
 func newDomainBucketKey(name Name, orderName string) (string, error) {
-	err := validateIdForName(name, orderName)
-	if err != nil {
-		return "", err
-	}
 	return joinWithColon(name.EnumString(), orderName), nil
 }
 
@@ -68,21 +48,12 @@ func newDomainBucketKey(name Name, orderName string) (string, error) {
 // the 'enum:regId:domain' bucket key format. This function is exported for use
 // in ra.resetAccountPausingLimit.
 func NewRegIdDomainBucketKey(name Name, regId int64, orderName string) (string, error) {
-	regIdStr := strconv.FormatInt(regId, 10)
-	err := validateIdForName(name, joinWithColon(regIdStr, orderName))
-	if err != nil {
-		return "", err
-	}
-	return joinWithColon(name.EnumString(), regIdStr, orderName), nil
+	return joinWithColon(name.EnumString(), strconv.FormatInt(regId, 10), orderName), nil
 }
 
 // newFQDNSetBucketKey validates and returns a bucketKey for limits that use the
 // 'enum:fqdnSet' bucket key format.
 func newFQDNSetBucketKey(name Name, orderNames []string) (string, error) { //nolint: unparam // Only one named rate limit uses this helper
-	err := validateIdForName(name, strings.Join(orderNames, ","))
-	if err != nil {
-		return "", err
-	}
 	id := fmt.Sprintf("%x", hashNames(orderNames))
 	return joinWithColon(name.EnumString(), id), nil
 }


### PR DESCRIPTION
All of the identifiers being passed into the bucket construction helpers have already passed through policy.WellFormedIdentifiers in the WFE. We can trust that function, and  our own ability to construct bucket keys, to reduce the amount of revalidation we do before sending bucket keys to redis.

The validateIdForName function is still used to validate override bucket keys loaded from yaml.