### PR TITLE
Partially revert "bdns, va: Remove DNSAllowLoopbackAddresses"

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -42,11 +42,12 @@ type Client interface {
 
 // impl represents a client that talks to an external resolver
 type impl struct {
-	dnsClient exchanger
-	servers   ServerProvider
-	maxTries  int
-	clk       clock.Clock
-	log       blog.Logger
+	dnsClient                exchanger
+	servers                  ServerProvider
+	allowRestrictedAddresses bool
+	maxTries                 int
+	clk                      clock.Clock
+	log                      blog.Logger
 
 	queryTime         *prometheus.HistogramVec
 	totalLookupTime   *prometheus.HistogramVec
@@ -134,16 +135,35 @@ func New(
 	)
 	stats.MustRegister(queryTime, totalLookupTime, timeoutCounter, idMismatchCounter)
 	return &impl{
-		dnsClient:         client,
-		servers:           servers,
-		maxTries:          maxTries,
-		clk:               clk,
-		queryTime:         queryTime,
-		totalLookupTime:   totalLookupTime,
-		timeoutCounter:    timeoutCounter,
-		idMismatchCounter: idMismatchCounter,
-		log:               log,
+		dnsClient:                client,
+		servers:                  servers,
+		allowRestrictedAddresses: false,
+		maxTries:                 maxTries,
+		clk:                      clk,
+		queryTime:                queryTime,
+		totalLookupTime:          totalLookupTime,
+		timeoutCounter:           timeoutCounter,
+		idMismatchCounter:        idMismatchCounter,
+		log:                      log,
 	}
+}
+
+// NewTest constructs a new DNS resolver object that utilizes the
+// provided list of DNS servers for resolution and will allow loopback addresses.
+// This constructor should *only* be called from tests (unit or integration).
+func NewTest(
+	readTimeout time.Duration,
+	servers ServerProvider,
+	stats prometheus.Registerer,
+	clk clock.Clock,
+	maxTries int,
+	userAgent string,
+	log blog.Logger,
+	tlsConfig *tls.Config,
+) Client {
+	resolver := New(readTimeout, servers, stats, clk, maxTries, userAgent, log, tlsConfig)
+	resolver.(*impl).allowRestrictedAddresses = true
+	return resolver
 }
 
 // exchangeOne performs a single DNS exchange with a randomly chosen server
@@ -391,7 +411,7 @@ func (dnsClient *impl) LookupHost(ctx context.Context, hostname string) ([]netip
 				a, ok := answer.(*dns.A)
 				if ok && a.A.To4() != nil {
 					netIP, ok := netip.AddrFromSlice(a.A)
-					if ok && policy.IsReservedIP(netIP) == nil {
+					if ok && (policy.IsReservedIP(netIP) == nil || dnsClient.allowRestrictedAddresses) {
 						addrsA = append(addrsA, netIP)
 					}
 				}
@@ -409,7 +429,7 @@ func (dnsClient *impl) LookupHost(ctx context.Context, hostname string) ([]netip
 				aaaa, ok := answer.(*dns.AAAA)
 				if ok && aaaa.AAAA.To16() != nil {
 					netIP, ok := netip.AddrFromSlice(aaaa.AAAA)
-					if ok && policy.IsReservedIP(netIP) == nil {
+					if ok && (policy.IsReservedIP(netIP) == nil || dnsClient.allowRestrictedAddresses) {
 						addrsAAAA = append(addrsAAAA, netIP)
 					}
 				}

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -99,15 +99,28 @@ func main() {
 	tlsConfig, err := c.VA.TLS.Load(scope)
 	cmd.FailOnError(err, "tlsConfig config")
 
-	resolver := bdns.New(
-		c.VA.DNSTimeout.Duration,
-		servers,
-		scope,
-		clk,
-		c.VA.DNSTries,
-		c.VA.UserAgent,
-		logger,
-		tlsConfig)
+	var resolver bdns.Client
+	if !c.VA.DNSAllowLoopbackAddresses {
+		resolver = bdns.New(
+			c.VA.DNSTimeout.Duration,
+			servers,
+			scope,
+			clk,
+			c.VA.DNSTries,
+			c.VA.UserAgent,
+			logger,
+			tlsConfig)
+	} else {
+		resolver = bdns.NewTest(
+			c.VA.DNSTimeout.Duration,
+			servers,
+			scope,
+			clk,
+			c.VA.DNSTries,
+			c.VA.UserAgent,
+			logger,
+			tlsConfig)
+	}
 	var remotes []va.RemoteVA
 	if len(c.VA.RemoteVAs) > 0 {
 		for _, rva := range c.VA.RemoteVAs {

--- a/cmd/remoteva/main.go
+++ b/cmd/remoteva/main.go
@@ -108,15 +108,28 @@ func main() {
 		tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
 	}
 
-	resolver := bdns.New(
-		c.RVA.DNSTimeout.Duration,
-		servers,
-		scope,
-		clk,
-		c.RVA.DNSTries,
-		c.RVA.UserAgent,
-		logger,
-		tlsConfig)
+	var resolver bdns.Client
+	if !c.RVA.DNSAllowLoopbackAddresses {
+		resolver = bdns.New(
+			c.RVA.DNSTimeout.Duration,
+			servers,
+			scope,
+			clk,
+			c.RVA.DNSTries,
+			c.RVA.UserAgent,
+			logger,
+			tlsConfig)
+	} else {
+		resolver = bdns.NewTest(
+			c.RVA.DNSTimeout.Duration,
+			servers,
+			scope,
+			clk,
+			c.RVA.DNSTries,
+			c.RVA.UserAgent,
+			logger,
+			tlsConfig)
+	}
 
 	vai, err := va.NewValidationAuthorityImpl(
 		resolver,

--- a/va/config/config.go
+++ b/va/config/config.go
@@ -24,8 +24,9 @@ type Common struct {
 	// DNSStaticResolvers is a list of DNS resolvers. Each entry must
 	// be a host or IP and port separated by a colon. IPv6 addresses
 	// must be enclosed in square brackets.
-	DNSStaticResolvers []string        `validate:"required_without=DNSProvider,dive,hostname_port"`
-	DNSTimeout         config.Duration `validate:"required"`
+	DNSStaticResolvers        []string        `validate:"required_without=DNSProvider,dive,hostname_port"`
+	DNSTimeout                config.Duration `validate:"required"`
+	DNSAllowLoopbackAddresses bool
 
 	AccountURIPrefixes []string `validate:"min=1,dive,required,url"`
 }


### PR DESCRIPTION
This partially reverts https://github.com/letsencrypt/boulder/pull/8203, which was landed as commit dea81c7381f135ab2cc99e647b98ba7d5bed55bc.

It leaves all of the boulder integration test environment changes in place, while restoring the DNSAllowLoopbackAddresses config key and its ability to influence the VA's behavior.