### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.24.1_2025-04-30
+          - go1.24.1_2025-06-03
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,16 +30,20 @@ linters:
     gosec:
       excludes:
         # TODO: Identify, fix, and remove violations of most of these rules
-        - G101  # Potential hardcoded credentials
-        - G102  # Binds to all network interfaces
-        - G107  # Potential HTTP request made with variable url
-        - G201  # SQL string formatting
-        - G202  # SQL string concatenation
-        - G306  # Expect WriteFile permissions to be 0600 or less
-        - G401  # Use of weak cryptographic primitive
-        - G402  # TLS InsecureSkipVerify set true.
-        - G403  # RSA keys should be at least 2048 bits
-        - G404  # Use of weak random number generator
+        - G101 # Potential hardcoded credentials
+        - G102 # Binds to all network interfaces
+        - G104 # Errors unhandled
+        - G107 # Potential HTTP request made with variable url
+        - G201 # SQL string formatting
+        - G202 # SQL string concatenation
+        - G204 # Subprocess launched with variable
+        - G302 # Expect file permissions to be 0600 or less
+        - G306 # Expect WriteFile permissions to be 0600 or less
+        - G304 # Potential file inclusion via variable
+        - G401 # Use of weak cryptographic primitive
+        - G402 # TLS InsecureSkipVerify set true.
+        - G403 # RSA keys should be at least 2048 bits
+        - G404 # Use of weak random number generator
     govet:
       disable:
         - fieldalignment
@@ -63,6 +67,7 @@ linters:
     staticcheck:
       checks:
         - all
+        # TODO: Identify, fix, and remove violations of most of these rules
         - -S1029  # Range over the string directly
         - -SA1019 # Using a deprecated function, variable, constant or field
         - -SA6003 # Converting a string to a slice of runes before ranging over it
@@ -77,16 +82,8 @@ linters:
         - -QF1009 # Probably want to use time.Time.Equal
         - -QF1012 # Use fmt.Fprintf(...) instead of Write(fmt.Sprintf(...))
   exclusions:
-    generated: lax
     presets:
-      - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,22 @@ linters:
         - net/http.Write
         - os.Remove
         - github.com/miekg/dns.WriteMsg
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+      settings:
+        printf:
+          funcs:
+            - (github.com/letsencrypt/boulder/log.Logger).Errf
+            - (github.com/letsencrypt/boulder/log.Logger).Warningf
+            - (github.com/letsencrypt/boulder/log.Logger).Infof
+            - (github.com/letsencrypt/boulder/log.Logger).Debugf
+            - (github.com/letsencrypt/boulder/log.Logger).AuditInfof
+            - (github.com/letsencrypt/boulder/log.Logger).AuditErrf
+            - (github.com/letsencrypt/boulder/ocsp/responder).SampledError
+            - (github.com/letsencrypt/boulder/web.RequestEvent).AddError
     gosec:
       excludes:
         # TODO: Identify, fix, and remove violations of most of these rules
@@ -44,22 +60,6 @@ linters:
         - G402 # TLS InsecureSkipVerify set true.
         - G403 # RSA keys should be at least 2048 bits
         - G404 # Use of weak random number generator
-    govet:
-      disable:
-        - fieldalignment
-        - shadow
-      enable-all: true
-      settings:
-        printf:
-          funcs:
-            - (github.com/letsencrypt/boulder/log.Logger).Errf
-            - (github.com/letsencrypt/boulder/log.Logger).Warningf
-            - (github.com/letsencrypt/boulder/log.Logger).Infof
-            - (github.com/letsencrypt/boulder/log.Logger).Debugf
-            - (github.com/letsencrypt/boulder/log.Logger).AuditInfof
-            - (github.com/letsencrypt/boulder/log.Logger).AuditErrf
-            - (github.com/letsencrypt/boulder/ocsp/responder).SampledError
-            - (github.com/letsencrypt/boulder/web.RequestEvent).AddError
     nolintlint:
       require-explanation: true
       require-specific: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,66 +1,92 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bidichk
     - errcheck
-    - gofmt
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nolintlint
     - spancheck
     - sqlclosecheck
-    - typecheck
+    - staticcheck
     - unconvert
     - unparam
     - unused
     - wastedassign
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - (net/http.ResponseWriter).Write
-      - (net.Conn).Write
-      - encoding/binary.Write
-      - io.Write
-      - net/http.Write
-      - os.Remove
-      - github.com/miekg/dns.WriteMsg
-  gosimple:
-    # S1029: Range over the string directly
-    checks: ["all", "-S1029"]
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-    settings:
-      printf:
-        funcs:
-          - (github.com/letsencrypt/boulder/log.Logger).Errf
-          - (github.com/letsencrypt/boulder/log.Logger).Warningf
-          - (github.com/letsencrypt/boulder/log.Logger).Infof
-          - (github.com/letsencrypt/boulder/log.Logger).Debugf
-          - (github.com/letsencrypt/boulder/log.Logger).AuditInfof
-          - (github.com/letsencrypt/boulder/log.Logger).AuditErrf
-          - (github.com/letsencrypt/boulder/ocsp/responder).SampledError
-          - (github.com/letsencrypt/boulder/web.RequestEvent).AddError
-  gosec:
-    excludes:
-      # TODO: Identify, fix, and remove violations of most of these rules
-      - G101  # Potential hardcoded credentials
-      - G102  # Binds to all network interfaces
-      - G107  # Potential HTTP request made with variable url
-      - G201  # SQL string formatting
-      - G202  # SQL string concatenation
-      - G306  # Expect WriteFile permissions to be 0600 or less
-      - G401  # Use of weak cryptographic primitive
-      - G402  # TLS InsecureSkipVerify set true.
-      - G403  # RSA keys should be at least 2048 bits
-      - G404  # Use of weak random number generator (math/rand instead of crypto/rand)
-  nolintlint:
-    allow-unused: false
-    require-explanation: true
-    require-specific: true
+  settings:
+    errcheck:
+      exclude-functions:
+        - (net/http.ResponseWriter).Write
+        - (net.Conn).Write
+        - encoding/binary.Write
+        - io.Write
+        - net/http.Write
+        - os.Remove
+        - github.com/miekg/dns.WriteMsg
+    gosec:
+      excludes:
+        # TODO: Identify, fix, and remove violations of most of these rules
+        - G101  # Potential hardcoded credentials
+        - G102  # Binds to all network interfaces
+        - G107  # Potential HTTP request made with variable url
+        - G201  # SQL string formatting
+        - G202  # SQL string concatenation
+        - G306  # Expect WriteFile permissions to be 0600 or less
+        - G401  # Use of weak cryptographic primitive
+        - G402  # TLS InsecureSkipVerify set true.
+        - G403  # RSA keys should be at least 2048 bits
+        - G404  # Use of weak random number generator
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+      settings:
+        printf:
+          funcs:
+            - (github.com/letsencrypt/boulder/log.Logger).Errf
+            - (github.com/letsencrypt/boulder/log.Logger).Warningf
+            - (github.com/letsencrypt/boulder/log.Logger).Infof
+            - (github.com/letsencrypt/boulder/log.Logger).Debugf
+            - (github.com/letsencrypt/boulder/log.Logger).AuditInfof
+            - (github.com/letsencrypt/boulder/log.Logger).AuditErrf
+            - (github.com/letsencrypt/boulder/ocsp/responder).SampledError
+            - (github.com/letsencrypt/boulder/web.RequestEvent).AddError
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
+    staticcheck:
+      checks:
+        - all
+        - -S1029  # Range over the string directly
+        - -SA1019 # Using a deprecated function, variable, constant or field
+        - -SA6003 # Converting a string to a slice of runes before ranging over it
+        - -ST1000 # Incorrect or missing package comment
+        - -ST1003 # Poorly chosen identifier
+        - -ST1005 # Incorrectly formatted error string
+        - -QF1001 # Could apply De Morgan's law
+        - -QF1003 # Could use tagged switch
+        - -QF1004 # Could use strings.Split instead
+        - -QF1007 # Could merge conditional assignment into variable declaration
+        - -QF1008 # Could remove embedded field from selector
+        - -QF1009 # Probably want to use time.Time.Equal
+        - -QF1012 # Use fmt.Fprintf(...) instead of Write(fmt.Sprintf(...))
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -279,7 +279,6 @@ func TestFailExit(t *testing.T) {
 		return
 	}
 
-	//nolint: gosec // Test-only code is not concerned about untrusted values in os.Args[0]
 	cmd := exec.Command(os.Args[0], "-test.run=TestFailExit")
 	cmd.Env = append(os.Environ(), "TIME_TO_DIE=1")
 	output, err := cmd.CombinedOutput()
@@ -306,7 +305,6 @@ func TestPanicStackTrace(t *testing.T) {
 		return
 	}
 
-	//nolint: gosec // Test-only code is not concerned about untrusted values in os.Args[0]
 	cmd := exec.Command(os.Args[0], "-test.run=TestPanicStackTrace")
 	cmd.Env = append(os.Environ(), "AT_THE_DISCO=1")
 	output, err := cmd.CombinedOutput()

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,8 +1,0 @@
-# Ignores the following:
-#   SA1019: Using a deprecated function, variable, constant or field
-#   SA6003: Converting a string to a slice of runes before ranging over it
-#   ST1000: Incorrect or missing package comment
-#   ST1003: Poorly chosen identifier
-#   ST1005: Incorrectly formatted error string
-
-checks = ["all", "-SA1019", "-SA6003", "-ST1000", "-ST1003", "-ST1005"]

--- a/test.sh
+++ b/test.sh
@@ -211,8 +211,6 @@ STAGE="lints"
 if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   print_heading "Running Lints"
   golangci-lint run --timeout 9m ./...
-  # Implicitly loads staticcheck.conf from the root of the boulder repository
-  staticcheck ./...
   python3 test/grafana/lint.py
   # Check for common spelling errors using typos.
   # Update .typos.toml if you find false positives

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1
-FROM buildpack-deps:noble-scm as godeps
+FROM buildpack-deps:noble-scm AS godeps
 ARG GO_VERSION
 # Provided automatically by docker build.
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-$BUILDPLATFORM}
 ENV GO_VERSION=$GO_VERSION
-ENV PATH /usr/local/go/bin:/usr/local/protoc/bin:$PATH
-ENV GOBIN /usr/local/bin/
+ENV PATH=/usr/local/go/bin:/usr/local/protoc/bin:$PATH
+ENV GOBIN=/usr/local/bin/
 RUN curl "https://dl.google.com/go/go${GO_VERSION}.$(echo $TARGETPLATFORM | sed 's|\/|-|').tar.gz" |\
     tar -C /usr/local -xz
 RUN go install github.com/rubenv/sql-migrate/sql-migrate@v1.1.2
@@ -16,7 +16,7 @@ RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 RUN go install github.com/jsha/minica@v1.1.0
 
-FROM rust:latest as rustdeps
+FROM rust:latest AS rustdeps
 # Provided automatically by docker build.
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -48,4 +48,4 @@ COPY --from=godeps /usr/local/bin/* /usr/local/bin/
 COPY --from=godeps /usr/local/go/ /usr/local/go/
 COPY --from=rustdeps /usr/local/cargo/bin/typos /usr/local/bin/typos
 
-ENV PATH /usr/local/go/bin:/usr/local/protoc/bin:$PATH
+ENV PATH=/usr/local/go/bin:/usr/local/protoc/bin:$PATH

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -13,7 +13,7 @@ RUN curl "https://dl.google.com/go/go${GO_VERSION}.$(echo $TARGETPLATFORM | sed 
 RUN go install github.com/rubenv/sql-migrate/sql-migrate@v1.1.2
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.5
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.0
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 RUN go install honnef.co/go/tools/cmd/staticcheck@2025.1
 RUN go install github.com/jsha/minica@v1.1.0
 
@@ -28,7 +28,7 @@ RUN /tmp/build-rust-deps.sh
 # When the version of Ubuntu (focal, jammy, etc) changes, ensure that the
 # version of libc6 is compatible with the rustdeps container above. See
 # https://github.com/letsencrypt/boulder/pull/7248#issuecomment-1896612920 for
-# more information. 
+# more information.
 #
 # Run this command in each container: dpkg -l libc6
 FROM buildpack-deps:noble-scm

--- a/test/boulder-tools/Dockerfile
+++ b/test/boulder-tools/Dockerfile
@@ -14,7 +14,6 @@ RUN go install github.com/rubenv/sql-migrate/sql-migrate@v1.1.2
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.5
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
-RUN go install honnef.co/go/tools/cmd/staticcheck@2025.1
 RUN go install github.com/jsha/minica@v1.1.0
 
 FROM rust:latest as rustdeps


### PR DESCRIPTION
The golangci-lint project has released a v2, which is noticeably faster, splits linters and formatters into separate categories, has greatly improved support for staticcheck, and has an incompatible config file format. Update our boulder-tools version of golangci-lint to v2, remove our standalone staticcheck, and update our config file to match.