### PR TITLE
Remove mail functionality from bad-key-revoker

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -181,11 +181,7 @@ func (bkr *badKeyRevoker) markRowChecked(ctx context.Context, unchecked unchecke
 // keyCompromise and includes note indicating that they were revoked by
 // bad-key-revoker.
 func (bkr *badKeyRevoker) revokeCerts(certs []unrevokedCertificate) error {
-	alreadyRevoked := map[int]bool{}
 	for _, cert := range certs {
-		if alreadyRevoked[cert.ID] {
-			continue
-		}
 		_, err := bkr.raClient.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
 			Cert:      cert.DER,
 			Serial:    cert.Serial,
@@ -196,7 +192,6 @@ func (bkr *badKeyRevoker) revokeCerts(certs []unrevokedCertificate) error {
 			return err
 		}
 		certsRevoked.Inc()
-		alreadyRevoked[cert.ID] = true
 	}
 	return nil
 }

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -1,15 +1,10 @@
 package notmain
 
 import (
-	"bytes"
 	"context"
-	"crypto/x509"
 	"flag"
 	"fmt"
-	"html/template"
-	netmail "net/mail"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/jmhodges/clock"
@@ -24,7 +19,6 @@ import (
 	"github.com/letsencrypt/boulder/db"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
-	"github.com/letsencrypt/boulder/mail"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/sa"
 )
@@ -43,10 +37,6 @@ var certsRevoked = prometheus.NewCounter(prometheus.CounterOpts{
 	Name: "bad_keys_certs_revoked",
 	Help: "A counter of certificates associated with rows in blockedKeys that have been revoked",
 })
-var mailErrors = prometheus.NewCounter(prometheus.CounterOpts{
-	Name: "bad_keys_mail_errors",
-	Help: "A counter of email send errors",
-})
 
 // revoker is an interface used to reduce the scope of a RA gRPC client
 // to only the single method we need to use, this makes testing significantly
@@ -60,9 +50,6 @@ type badKeyRevoker struct {
 	maxRevocations      int
 	serialBatchSize     int
 	raClient            revoker
-	mailer              mail.Mailer
-	emailSubject        string
-	emailTemplate       *template.Template
 	logger              blog.Logger
 	clk                 clock.Clock
 	backoffIntervalBase time.Duration
@@ -190,109 +177,32 @@ func (bkr *badKeyRevoker) markRowChecked(ctx context.Context, unchecked unchecke
 	return err
 }
 
-// resolveContacts builds a map of id -> email addresses
-func (bkr *badKeyRevoker) resolveContacts(ctx context.Context, ids []int64) (map[int64][]string, error) {
-	idToEmail := map[int64][]string{}
-	for _, id := range ids {
-		var emails struct {
-			Contact []string
-		}
-		err := bkr.dbMap.SelectOne(ctx, &emails, "SELECT contact FROM registrations WHERE id = ?", id)
-		if err != nil {
-			// ErrNoRows is not acceptable here since there should always be a
-			// row for the registration, even if there are no contacts
-			return nil, err
-		}
-		if len(emails.Contact) != 0 {
-			for _, email := range emails.Contact {
-				idToEmail[id] = append(idToEmail[id], strings.TrimPrefix(email, "mailto:"))
-			}
-		} else {
-			// if the account has no contacts add a placeholder empty contact
-			// so that we don't skip any certificates
-			idToEmail[id] = append(idToEmail[id], "")
-			continue
-		}
-	}
-	return idToEmail, nil
-}
-
-var maxSerials = 100
-
-// sendMessage sends a single email to the provided address with the revoked
-// serials
-func (bkr *badKeyRevoker) sendMessage(addr string, serials []string) error {
-	conn, err := bkr.mailer.Connect()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = conn.Close()
-	}()
-	mutSerials := make([]string, len(serials))
-	copy(mutSerials, serials)
-	if len(mutSerials) > maxSerials {
-		more := len(mutSerials) - maxSerials
-		mutSerials = mutSerials[:maxSerials]
-		mutSerials = append(mutSerials, fmt.Sprintf("and %d more certificates.", more))
-	}
-	message := bytes.NewBuffer(nil)
-	err = bkr.emailTemplate.Execute(message, mutSerials)
-	if err != nil {
-		return err
-	}
-	err = conn.SendMail([]string{addr}, bkr.emailSubject, message.String())
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// revokeCerts revokes all the certificates associated with a particular key hash and sends
-// emails to the users that issued the certificates. Emails are not sent to the user which
-// requested revocation of the original certificate which marked the key as compromised.
-func (bkr *badKeyRevoker) revokeCerts(revokerEmails []string, emailToCerts map[string][]unrevokedCertificate) error {
-	revokerEmailsMap := map[string]bool{}
-	for _, email := range revokerEmails {
-		revokerEmailsMap[email] = true
-	}
-
+// revokeCerts revokes all the provided certificates. It uses reason
+// keyCompromise and includes note indicating that they were revoked by
+// bad-key-revoker.
+func (bkr *badKeyRevoker) revokeCerts(certs []unrevokedCertificate) error {
 	alreadyRevoked := map[int]bool{}
-	for email, certs := range emailToCerts {
-		var revokedSerials []string
-		for _, cert := range certs {
-			revokedSerials = append(revokedSerials, cert.Serial)
-			if alreadyRevoked[cert.ID] {
-				continue
-			}
-			_, err := bkr.raClient.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
-				Cert:      cert.DER,
-				Serial:    cert.Serial,
-				Code:      int64(ocsp.KeyCompromise),
-				AdminName: "bad-key-revoker",
-			})
-			if err != nil {
-				return err
-			}
-			certsRevoked.Inc()
-			alreadyRevoked[cert.ID] = true
-		}
-		// don't send emails to the person who revoked the certificate
-		if revokerEmailsMap[email] || email == "" {
+	for _, cert := range certs {
+		if alreadyRevoked[cert.ID] {
 			continue
 		}
-		err := bkr.sendMessage(email, revokedSerials)
+		_, err := bkr.raClient.AdministrativelyRevokeCertificate(context.Background(), &rapb.AdministrativelyRevokeCertificateRequest{
+			Cert:      cert.DER,
+			Serial:    cert.Serial,
+			Code:      int64(ocsp.KeyCompromise),
+			AdminName: "bad-key-revoker",
+		})
 		if err != nil {
-			mailErrors.Inc()
-			bkr.logger.Errf("failed to send message: %s", err)
-			continue
+			return err
 		}
+		certsRevoked.Inc()
+		alreadyRevoked[cert.ID] = true
 	}
 	return nil
 }
 
-// invoke processes a single key in the blockedKeys table and returns whether
-// there were any rows to process or not.
+// invoke exits early and returns true if there is no work to be done.
+// Otherwise, it processes a single key in the blockedKeys table and returns false.
 func (bkr *badKeyRevoker) invoke(ctx context.Context) (bool, error) {
 	// Gather a count of rows to be processed.
 	uncheckedCount, err := bkr.countUncheckedKeys(ctx)
@@ -337,47 +247,14 @@ func (bkr *badKeyRevoker) invoke(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	// build a map of registration ID -> certificates, and collect a
-	// list of unique registration IDs
-	ownedBy := map[int64][]unrevokedCertificate{}
-	var ids []int64
-	for _, cert := range unrevokedCerts {
-		if ownedBy[cert.RegistrationID] == nil {
-			ids = append(ids, cert.RegistrationID)
-		}
-		ownedBy[cert.RegistrationID] = append(ownedBy[cert.RegistrationID], cert)
-	}
-	// if the account that revoked the original certificate isn't an owner of any
-	// extant certificates, still add them to ids so that we can resolve their
-	// email and avoid sending emails later. If RevokedBy == 0 it was a row
-	// inserted by admin-revoker with a dummy ID, since there won't be a registration
-	// to look up, don't bother adding it to ids.
-	if _, present := ownedBy[unchecked.RevokedBy]; !present && unchecked.RevokedBy != 0 {
-		ids = append(ids, unchecked.RevokedBy)
-	}
-	// get contact addresses for the list of IDs
-	idToEmails, err := bkr.resolveContacts(ctx, ids)
-	if err != nil {
-		return false, err
-	}
-
-	// build a map of email -> certificates, this de-duplicates accounts with
-	// the same email addresses
-	emailsToCerts := map[string][]unrevokedCertificate{}
-	for id, emails := range idToEmails {
-		for _, email := range emails {
-			emailsToCerts[email] = append(emailsToCerts[email], ownedBy[id]...)
-		}
-	}
-
 	var serials []string
 	for _, cert := range unrevokedCerts {
 		serials = append(serials, cert.Serial)
 	}
 	bkr.logger.AuditInfo(fmt.Sprintf("revoking serials %v for key with hash %s", serials, unchecked.KeyHash))
 
-	// revoke each certificate and send emails to their owners
-	err = bkr.revokeCerts(idToEmails[unchecked.RevokedBy], emailsToCerts)
+	// revoke each certificate
+	err = bkr.revokeCerts(unrevokedCerts)
 	if err != nil {
 		return false, err
 	}
@@ -417,15 +294,14 @@ type Config struct {
 		// or no work to do.
 		BackoffIntervalMax config.Duration `validate:"-"`
 
+		// Deprecated: the bad-key-revoker no longer sends emails; we use ARI.
+		// TODO(#8199): Remove this config stanza entirely.
 		Mailer struct {
-			cmd.SMTPConfig
-			// Path to a file containing a list of trusted root certificates for use
-			// during the SMTP connection (as opposed to the gRPC connections).
+			cmd.SMTPConfig      `validate:"-"`
 			SMTPTrustedRootFile string
-
-			From          string `validate:"required"`
-			EmailSubject  string `validate:"required"`
-			EmailTemplate string `validate:"required"`
+			From                string
+			EmailSubject        string
+			EmailTemplate       string
 		}
 	}
 
@@ -457,7 +333,6 @@ func main() {
 
 	scope.MustRegister(keysProcessed)
 	scope.MustRegister(certsRevoked)
-	scope.MustRegister(mailErrors)
 
 	dbMap, err := sa.InitWrappedDb(config.BadKeyRevoker.DB, scope, logger)
 	cmd.FailOnError(err, "While initializing dbMap")
@@ -469,50 +344,11 @@ func main() {
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to RA")
 	rac := rapb.NewRegistrationAuthorityClient(conn)
 
-	var smtpRoots *x509.CertPool
-	if config.BadKeyRevoker.Mailer.SMTPTrustedRootFile != "" {
-		pem, err := os.ReadFile(config.BadKeyRevoker.Mailer.SMTPTrustedRootFile)
-		cmd.FailOnError(err, "Loading trusted roots file")
-		smtpRoots = x509.NewCertPool()
-		if !smtpRoots.AppendCertsFromPEM(pem) {
-			cmd.FailOnError(nil, "Failed to parse root certs PEM")
-		}
-	}
-
-	fromAddress, err := netmail.ParseAddress(config.BadKeyRevoker.Mailer.From)
-	cmd.FailOnError(err, fmt.Sprintf("Could not parse from address: %s", config.BadKeyRevoker.Mailer.From))
-
-	smtpPassword, err := config.BadKeyRevoker.Mailer.PasswordConfig.Pass()
-	cmd.FailOnError(err, "Failed to load SMTP password")
-	mailClient := mail.New(
-		config.BadKeyRevoker.Mailer.Server,
-		config.BadKeyRevoker.Mailer.Port,
-		config.BadKeyRevoker.Mailer.Username,
-		smtpPassword,
-		smtpRoots,
-		*fromAddress,
-		logger,
-		scope,
-		1*time.Second,    // reconnection base backoff
-		5*60*time.Second, // reconnection maximum backoff
-	)
-
-	if config.BadKeyRevoker.Mailer.EmailSubject == "" {
-		cmd.Fail("BadKeyRevoker.Mailer.EmailSubject must be populated")
-	}
-	templateBytes, err := os.ReadFile(config.BadKeyRevoker.Mailer.EmailTemplate)
-	cmd.FailOnError(err, fmt.Sprintf("failed to read email template %q: %s", config.BadKeyRevoker.Mailer.EmailTemplate, err))
-	emailTemplate, err := template.New("email").Parse(string(templateBytes))
-	cmd.FailOnError(err, fmt.Sprintf("failed to parse email template %q: %s", config.BadKeyRevoker.Mailer.EmailTemplate, err))
-
 	bkr := &badKeyRevoker{
 		dbMap:               dbMap,
 		maxRevocations:      config.BadKeyRevoker.MaximumRevocations,
 		serialBatchSize:     config.BadKeyRevoker.FindCertificatesBatchSize,
 		raClient:            rac,
-		mailer:              mailClient,
-		emailSubject:        config.BadKeyRevoker.Mailer.EmailSubject,
-		emailTemplate:       emailTemplate,
 		logger:              logger,
 		clk:                 clk,
 		backoffIntervalMax:  config.BadKeyRevoker.BackoffIntervalMax.Duration,

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -266,7 +266,6 @@ func TestRevokeCerts(t *testing.T) {
 
 	err = bkr.revokeCerts([]unrevokedCertificate{
 		{ID: 0, Serial: "ff"},
-		{ID: 0, Serial: "ff"}, // duplicate
 		{ID: 1, Serial: "ee"},
 	})
 	test.AssertNotError(t, err, "revokeCerts failed")

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -4,24 +4,23 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"html/template"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/jmhodges/clock"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
-	"github.com/letsencrypt/boulder/mocks"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test"
 	"github.com/letsencrypt/boulder/test/vars"
-	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func randHash(t *testing.T) []byte {
@@ -244,47 +243,6 @@ func TestFindUnrevoked(t *testing.T) {
 	test.AssertEquals(t, err.Error(), fmt.Sprintf("too many certificates to revoke associated with %x: got 1, max 0", hashA))
 }
 
-func TestResolveContacts(t *testing.T) {
-	dbMap, err := sa.DBMapForTest(vars.DBConnSAFullPerms)
-	test.AssertNotError(t, err, "failed setting up db client")
-	defer test.ResetBoulderTestDatabase(t)()
-
-	fc := clock.NewFake()
-
-	bkr := &badKeyRevoker{dbMap: dbMap, clk: fc}
-
-	regIDA := insertRegistration(t, dbMap, fc)
-	regIDB := insertRegistration(t, dbMap, fc, "example.com", "example-2.com")
-	regIDC := insertRegistration(t, dbMap, fc, "example.com")
-	regIDD := insertRegistration(t, dbMap, fc, "example-2.com")
-
-	idToEmail, err := bkr.resolveContacts(context.Background(), []int64{regIDA, regIDB, regIDC, regIDD})
-	test.AssertNotError(t, err, "resolveContacts failed")
-	test.AssertDeepEquals(t, idToEmail, map[int64][]string{
-		regIDA: {""},
-		regIDB: {"example.com", "example-2.com"},
-		regIDC: {"example.com"},
-		regIDD: {"example-2.com"},
-	})
-}
-
-var testTemplate = template.Must(template.New("testing").Parse("{{range .}}{{.}}\n{{end}}"))
-
-func TestSendMessage(t *testing.T) {
-	mm := &mocks.Mailer{}
-	fc := clock.NewFake()
-	bkr := &badKeyRevoker{mailer: mm, emailSubject: "testing", emailTemplate: testTemplate, clk: fc}
-
-	maxSerials = 2
-	err := bkr.sendMessage("example.com", []string{"a", "b", "c"})
-	test.AssertNotError(t, err, "sendMessages failed")
-	test.AssertEquals(t, len(mm.Messages), 1)
-	test.AssertEquals(t, mm.Messages[0].To, "example.com")
-	test.AssertEquals(t, mm.Messages[0].Subject, bkr.emailSubject)
-	test.AssertEquals(t, mm.Messages[0].Body, "a\nb\nand 1 more certificates.\n")
-
-}
-
 type mockRevoker struct {
 	revoked int
 	mu      sync.Mutex
@@ -303,20 +261,16 @@ func TestRevokeCerts(t *testing.T) {
 	defer test.ResetBoulderTestDatabase(t)()
 
 	fc := clock.NewFake()
-	mm := &mocks.Mailer{}
 	mr := &mockRevoker{}
-	bkr := &badKeyRevoker{dbMap: dbMap, raClient: mr, mailer: mm, emailSubject: "testing", emailTemplate: testTemplate, clk: fc}
+	bkr := &badKeyRevoker{dbMap: dbMap, raClient: mr, clk: fc}
 
-	err = bkr.revokeCerts([]string{"revoker@example.com", "revoker-b@example.com"}, map[string][]unrevokedCertificate{
-		"revoker@example.com":   {{ID: 0, Serial: "ff"}},
-		"revoker-b@example.com": {{ID: 0, Serial: "ff"}},
-		"other@example.com":     {{ID: 1, Serial: "ee"}},
+	err = bkr.revokeCerts([]unrevokedCertificate{
+		{ID: 0, Serial: "ff"},
+		{ID: 0, Serial: "ff"}, // duplicate
+		{ID: 1, Serial: "ee"},
 	})
 	test.AssertNotError(t, err, "revokeCerts failed")
-	test.AssertEquals(t, len(mm.Messages), 1)
-	test.AssertEquals(t, mm.Messages[0].To, "other@example.com")
-	test.AssertEquals(t, mm.Messages[0].Subject, bkr.emailSubject)
-	test.AssertEquals(t, mm.Messages[0].Body, "ee\n")
+	test.AssertEquals(t, mr.revoked, 2)
 }
 
 func TestCertificateAbsent(t *testing.T) {
@@ -349,9 +303,6 @@ func TestCertificateAbsent(t *testing.T) {
 		maxRevocations:  1,
 		serialBatchSize: 1,
 		raClient:        &mockRevoker{},
-		mailer:          &mocks.Mailer{},
-		emailSubject:    "testing",
-		emailTemplate:   testTemplate,
 		logger:          blog.NewMock(),
 		clk:             fc,
 	}
@@ -368,16 +319,12 @@ func TestInvoke(t *testing.T) {
 
 	fc := clock.NewFake()
 
-	mm := &mocks.Mailer{}
 	mr := &mockRevoker{}
 	bkr := &badKeyRevoker{
 		dbMap:           dbMap,
 		maxRevocations:  10,
 		serialBatchSize: 1,
 		raClient:        mr,
-		mailer:          mm,
-		emailSubject:    "testing",
-		emailTemplate:   testTemplate,
 		logger:          blog.NewMock(),
 		clk:             fc,
 	}
@@ -398,8 +345,6 @@ func TestInvoke(t *testing.T) {
 	test.AssertNotError(t, err, "invoke failed")
 	test.AssertEquals(t, noWork, false)
 	test.AssertEquals(t, mr.revoked, 4)
-	test.AssertEquals(t, len(mm.Messages), 1)
-	test.AssertEquals(t, mm.Messages[0].To, "example.com")
 	test.AssertMetricWithLabelsEquals(t, keysToProcess, prometheus.Labels{}, 1)
 
 	var checked struct {
@@ -440,15 +385,11 @@ func TestInvokeRevokerHasNoExtantCerts(t *testing.T) {
 
 	fc := clock.NewFake()
 
-	mm := &mocks.Mailer{}
 	mr := &mockRevoker{}
 	bkr := &badKeyRevoker{dbMap: dbMap,
 		maxRevocations:  10,
 		serialBatchSize: 1,
 		raClient:        mr,
-		mailer:          mm,
-		emailSubject:    "testing",
-		emailTemplate:   testTemplate,
 		logger:          blog.NewMock(),
 		clk:             fc,
 	}
@@ -471,8 +412,6 @@ func TestInvokeRevokerHasNoExtantCerts(t *testing.T) {
 	test.AssertNotError(t, err, "invoke failed")
 	test.AssertEquals(t, noWork, false)
 	test.AssertEquals(t, mr.revoked, 4)
-	test.AssertEquals(t, len(mm.Messages), 1)
-	test.AssertEquals(t, mm.Messages[0].To, "b@example.com")
 }
 
 func TestBackoffPolicy(t *testing.T) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -89,6 +89,8 @@ func (d *DBConfig) URL() (string, error) {
 	return strings.TrimSpace(string(url)), err
 }
 
+// SMTPConfig is deprecated.
+// TODO(#8199): Delete this when it is removed from bad-key-revoker's config.
 type SMTPConfig struct {
 	PasswordConfig
 	Server   string `validate:"required"`

--- a/test/config-next/bad-key-revoker.json
+++ b/test/config-next/bad-key-revoker.json
@@ -19,16 +19,6 @@
 			"noWaitForReady": true,
 			"timeout": "15s"
 		},
-		"mailer": {
-			"server": "localhost",
-			"port": "9380",
-			"username": "cert-manager@example.com",
-			"from": "bad key revoker <bad-key-revoker@test.org>",
-			"passwordFile": "test/secrets/smtp_password",
-			"SMTPTrustedRootFile": "test/certs/ipki/minica.pem",
-			"emailSubject": "Certificates you've issued have been revoked due to key compromise",
-			"emailTemplate": "test/example-bad-key-revoker-template"
-		},
 		"maximumRevocations": 15,
 		"findCertificatesBatchSize": 10,
 		"interval": "50ms",


### PR DESCRIPTION
Simplify the main logic loop to simply revoke certs as soon as they're identified, rather than jumping through hoops to identify and deduplicate the associated accounts and emails. Make the Mailer portion of the config optional for deployability.

Part of https://github.com/letsencrypt/boulder/issues/8199
IN-11428 tracks the corresponding production config changes