### PR TITLE
Ignore IP CNs in CSRs

### DIFF
--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/asn1"
 	"errors"
 	"net"
+	"net/netip"
 	"net/url"
 	"strings"
 	"testing"
@@ -237,6 +238,22 @@ func TestCNFromCSR(t *testing.T) {
 				DNSNames: []string{
 					"b.com",
 				}},
+			"",
+		},
+		{
+			"explicit CN that's an IP",
+			&x509.CertificateRequest{
+				Subject: pkix.Name{CommonName: "127.0.0.1"},
+			},
+			"",
+		},
+		{
+			"no CN, only IP SANs",
+			&x509.CertificateRequest{
+				IPAddresses: []net.IP{
+					netip.MustParseAddr("127.0.0.1").AsSlice(),
+				},
+			},
 			"",
 		},
 	}


### PR DESCRIPTION
If a finalize CSR contains a SAN which looks like an IP address, don't actually include that CN in our IssuanceRequest, and don't promote any other SAN to be the CN either. This is similar to how we ignore the CSR's CN when it is too long.