### PR TITLE
Update CI to go1.24.4

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.24.1_2025-06-03
+          - go1.24.4_2025-06-06
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.24.1"
+          - "1.24.4"
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.24.1"
+          - "1.24.4"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.24.1" )
+GO_CI_VERSIONS=( "1.24.4" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
Go 1.24.4 is a security release containing fixes to net/http, os.OpenFile, and x509.Certificate.Verify, all of which we use. We appear to be unaffected by the specific vulnerabilities described, however. See the announcement here: https://groups.google.com/g/golang-announce/c/ufZ8WpEsA3A