### PR TITLE
Confine contact addresses to the WFE

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -528,6 +528,7 @@ func (ra *RegistrationAuthorityImpl) NewRegistration(ctx context.Context, reques
 	}
 
 	// Check that contacts conform to our expectations.
+	// TODO(#8199): Remove this when no contacts are included in any requests.
 	err = ra.validateContacts(request.Contact)
 	if err != nil {
 		return nil, err
@@ -1399,8 +1400,11 @@ func (ra *RegistrationAuthorityImpl) getSCTs(ctx context.Context, precertDER []b
 	return scts, nil
 }
 
-// UpdateRegistrationContact updates an existing Registration's contact.
-// The updated contacts field may be empty.
+// UpdateRegistrationContact updates an existing Registration's contact. The
+// updated contacts field may be empty.
+//
+// Deprecated: This method has no callers. See
+// https://github.com/letsencrypt/boulder/issues/8199 for removal.
 func (ra *RegistrationAuthorityImpl) UpdateRegistrationContact(ctx context.Context, req *rapb.UpdateRegistrationContactRequest) (*corepb.Registration, error) {
 	if core.IsAnyNilOrZero(req.RegistrationID) {
 		return nil, errIncompleteGRPCRequest

--- a/test/integration/account_test.go
+++ b/test/integration/account_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 // TestNewAccount tests that various new-account requests are handled correctly.
-// It does not test malform account contacts, as those are covered by
-// TestAccountEmailError in errors_test.go.
+// It does not test malformed account contacts, as we no longer care about
+// how well-formed the contact string is, since we no longer store them.
 func TestNewAccount(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/eggsampler/acme/v3"
@@ -37,126 +36,6 @@ func TestTooBigOrderError(t *testing.T) {
 	test.AssertErrorWraps(t, err, &prob)
 	test.AssertEquals(t, prob.Type, "urn:ietf:params:acme:error:malformed")
 	test.AssertContains(t, prob.Detail, "Order cannot contain more than 100 identifiers")
-}
-
-// TestAccountEmailError tests that registering a new account, or updating an
-// account, with invalid contact information produces the expected problem
-// result to ACME clients.
-func TestAccountEmailError(t *testing.T) {
-	t.Parallel()
-
-	// The registrations.contact field is VARCHAR(191). 175 'a' characters plus
-	// the prefix "mailto:" and the suffix "@a.com" makes exactly 191 bytes of
-	// encoded JSON. The correct size to hit our maximum DB field length.
-	var longStringBuf strings.Builder
-	longStringBuf.WriteString("mailto:")
-	for range 175 {
-		longStringBuf.WriteRune('a')
-	}
-	longStringBuf.WriteString("@a.com")
-
-	createErrorPrefix := "Error creating new account :: "
-	updateErrorPrefix := "Unable to update account :: invalid contact: "
-
-	testCases := []struct {
-		name               string
-		contacts           []string
-		expectedProbType   string
-		expectedProbDetail string
-	}{
-		{
-			name:               "empty contact",
-			contacts:           []string{"mailto:valid@valid.com", ""},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: `empty contact`,
-		},
-		{
-			name:               "empty proto",
-			contacts:           []string{"mailto:valid@valid.com", " "},
-			expectedProbType:   "urn:ietf:params:acme:error:unsupportedContact",
-			expectedProbDetail: `only contact scheme 'mailto:' is supported`,
-		},
-		{
-			name:               "empty mailto",
-			contacts:           []string{"mailto:valid@valid.com", "mailto:"},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: `unable to parse email address`,
-		},
-		{
-			name:               "non-ascii mailto",
-			contacts:           []string{"mailto:valid@valid.com", "mailto:cpu@l̴etsencrypt.org"},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: `contact email contains non-ASCII characters`,
-		},
-		{
-			name:               "too many contacts",
-			contacts:           []string{"a", "b", "c", "d"},
-			expectedProbType:   "urn:ietf:params:acme:error:malformed",
-			expectedProbDetail: `too many contacts provided: 4 > 3`,
-		},
-		{
-			name:               "invalid contact",
-			contacts:           []string{"mailto:valid@valid.com", "mailto:a@"},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: `unable to parse email address`,
-		},
-		{
-			name:               "forbidden contact domain",
-			contacts:           []string{"mailto:valid@valid.com", "mailto:a@example.com"},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: "contact email has forbidden domain \"example.com\"",
-		},
-		{
-			name:               "contact domain invalid TLD",
-			contacts:           []string{"mailto:valid@valid.com", "mailto:a@example.cpu"},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: `contact email has invalid domain: Domain name does not end with a valid public suffix (TLD)`,
-		},
-		{
-			name:               "contact domain invalid",
-			contacts:           []string{"mailto:valid@valid.com", "mailto:a@example./.com"},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: "contact email has invalid domain: Domain name contains an invalid character",
-		},
-		{
-			name: "too long contact",
-			contacts: []string{
-				longStringBuf.String(),
-			},
-			expectedProbType:   "urn:ietf:params:acme:error:invalidContact",
-			expectedProbDetail: `too many/too long contact(s). Please use shorter or fewer email addresses`,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// First try registering a new account and ensuring the expected problem occurs
-			var prob acme.Problem
-			_, err := makeClient(tc.contacts...)
-			if err != nil {
-				test.AssertErrorWraps(t, err, &prob)
-				test.AssertEquals(t, prob.Type, tc.expectedProbType)
-				test.AssertEquals(t, prob.Detail, createErrorPrefix+tc.expectedProbDetail)
-			} else {
-				t.Errorf("expected %s type problem for %q, got nil",
-					tc.expectedProbType, strings.Join(tc.contacts, ","))
-			}
-
-			// Next try making a client with a good contact and updating with the test
-			// case contact info. The same problem should occur.
-			c, err := makeClient("mailto:valid@valid.com")
-			test.AssertNotError(t, err, "failed to create account with valid contact")
-			_, err = c.UpdateAccount(c.Account, tc.contacts...)
-			if err != nil {
-				test.AssertErrorWraps(t, err, &prob)
-				test.AssertEquals(t, prob.Type, tc.expectedProbType)
-				test.AssertEquals(t, prob.Detail, updateErrorPrefix+tc.expectedProbDetail)
-			} else {
-				t.Errorf("expected %s type problem after updating account to %q, got nil",
-					tc.expectedProbType, strings.Join(tc.contacts, ","))
-			}
-		})
-	}
 }
 
 func TestRejectedIdentifier(t *testing.T) {

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -784,14 +784,8 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		return
 	}
 
-	var contacts []string
-	if accountCreateRequest.Contact != nil {
-		contacts = *accountCreateRequest.Contact
-	}
-
 	// Create corepb.Registration from provided account information
 	reg := corepb.Registration{
-		Contact:   contacts,
 		Agreement: wfe.SubscriberAgreementURL,
 		Key:       keyBytes,
 	}


### PR DESCRIPTION
Change the WFE to stop populating the Contact field of the NewRegistration requests it sends to the RA. Similarly change the WFE to ignore the Contact field of any update-account requests it receives, thereby removing all calls to the RA's UpdateRegistrationContact method.

Note that this does mean that we're no longer performing any validation of contact addresses, since that happened in the RA. But that's fine, because we're not storing them anymore, either.

A follow-up change (after a deploy cycle) will remove the deprecated RA and SA methods.