### PR TITLE
Add "deprecate doh" commit to release-branch-2025-06-09

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -21,7 +21,6 @@ import (
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/policy"
@@ -77,30 +76,23 @@ func New(
 	tlsConfig *tls.Config,
 ) Client {
 	var client exchanger
-	if features.Get().DOH {
-		// Clone the default transport because it comes with various settings
-		// that we like, which are different from the zero value of an
-		// `http.Transport`.
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.TLSClientConfig = tlsConfig
-		// The default transport already sets this field, but it isn't
-		// documented that it will always be set. Set it again to be sure,
-		// because Unbound will reject non-HTTP/2 DoH requests.
-		transport.ForceAttemptHTTP2 = true
-		client = &dohExchanger{
-			clk: clk,
-			hc: http.Client{
-				Timeout:   readTimeout,
-				Transport: transport,
-			},
-			userAgent: userAgent,
-		}
-	} else {
-		client = &dns.Client{
-			// Set timeout for underlying net.Conn
-			ReadTimeout: readTimeout,
-			Net:         "udp",
-		}
+
+	// Clone the default transport because it comes with various settings
+	// that we like, which are different from the zero value of an
+	// `http.Transport`.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	// The default transport already sets this field, but it isn't
+	// documented that it will always be set. Set it again to be sure,
+	// because Unbound will reject non-HTTP/2 DoH requests.
+	transport.ForceAttemptHTTP2 = true
+	client = &dohExchanger{
+		clk: clk,
+		hc: http.Client{
+			Timeout:   readTimeout,
+			Transport: transport,
+		},
+		userAgent: userAgent,
 	}
 
 	queryTime := prometheus.NewHistogramVec(
@@ -281,17 +273,10 @@ func (dnsClient *impl) exchangeOne(ctx context.Context, hostname string, qtype u
 		case r := <-ch:
 			if r.err != nil {
 				var isRetryable bool
-				if features.Get().DOH {
-					// According to the http package documentation, retryable
-					// errors emitted by the http package are of type *url.Error.
-					var urlErr *url.Error
-					isRetryable = errors.As(r.err, &urlErr) && urlErr.Temporary()
-				} else {
-					// According to the net package documentation, retryable
-					// errors emitted by the net package are of type *net.OpError.
-					var opErr *net.OpError
-					isRetryable = errors.As(r.err, &opErr) && opErr.Temporary()
-				}
+				// According to the http package documentation, retryable
+				// errors emitted by the http package are of type *url.Error.
+				var urlErr *url.Error
+				isRetryable = errors.As(r.err, &urlErr) && urlErr.Temporary()
 				hasRetriesLeft := tries < dnsClient.maxTries
 				if isRetryable && hasRetriesLeft {
 					tries++

--- a/bdns/dns_test.go
+++ b/bdns/dns_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/letsencrypt/boulder/features"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
@@ -843,9 +842,6 @@ func (dohE *dohAlwaysRetryExchanger) Exchange(m *dns.Msg, a string) (*dns.Msg, t
 }
 
 func TestDOHMetric(t *testing.T) {
-	features.Set(features.Config{DOH: true})
-	defer features.Reset()
-
 	staticProvider, err := NewStaticProvider([]string{dnsLoopbackAddr})
 	test.AssertNotError(t, err, "Got error creating StaticProvider")
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -82,16 +82,12 @@ func main() {
 	clk := cmd.Clock()
 
 	var servers bdns.ServerProvider
-	proto := "udp"
-	if features.Get().DOH {
-		proto = "tcp"
-	}
 
 	if len(c.VA.DNSStaticResolvers) != 0 {
 		servers, err = bdns.NewStaticProvider(c.VA.DNSStaticResolvers)
 		cmd.FailOnError(err, "Couldn't start static DNS server resolver")
 	} else {
-		servers, err = bdns.StartDynamicProvider(c.VA.DNSProvider, 60*time.Second, proto)
+		servers, err = bdns.StartDynamicProvider(c.VA.DNSProvider, 60*time.Second, "tcp")
 		cmd.FailOnError(err, "Couldn't start dynamic DNS server resolver")
 	}
 	defer servers.Stop()

--- a/cmd/remoteva/main.go
+++ b/cmd/remoteva/main.go
@@ -87,16 +87,12 @@ func main() {
 	clk := cmd.Clock()
 
 	var servers bdns.ServerProvider
-	proto := "udp"
-	if features.Get().DOH {
-		proto = "tcp"
-	}
 
 	if len(c.RVA.DNSStaticResolvers) != 0 {
 		servers, err = bdns.NewStaticProvider(c.RVA.DNSStaticResolvers)
 		cmd.FailOnError(err, "Couldn't start static DNS server resolver")
 	} else {
-		servers, err = bdns.StartDynamicProvider(c.RVA.DNSProvider, 60*time.Second, proto)
+		servers, err = bdns.StartDynamicProvider(c.RVA.DNSProvider, 60*time.Second, "tcp")
 		cmd.FailOnError(err, "Couldn't start dynamic DNS server resolver")
 	}
 	defer servers.Stop()

--- a/features/features.go
+++ b/features/features.go
@@ -25,6 +25,7 @@ type Config struct {
 	EnforceMPIC                 bool
 	MPICFullResults             bool
 	UnsplitIssuance             bool
+	DOH                         bool
 
 	// ServeRenewalInfo exposes the renewalInfo endpoint in the directory and for
 	// GET requests. WARNING: This feature is a draft and highly unstable.
@@ -52,9 +53,6 @@ type Config struct {
 	// requires clients to properly implement polling the Order object to wait
 	// for the cert URL to appear.
 	AsyncFinalize bool
-
-	// DOH enables DNS-over-HTTPS queries for validation
-	DOH bool
 
 	// CheckIdentifiersPaused checks if any of the identifiers in the order are
 	// currently paused at NewOrder time. If any are paused, an error is

--- a/test/config-next/remoteva-a.json
+++ b/test/config-next/remoteva-a.json
@@ -34,9 +34,6 @@
 				}
 			}
 		},
-		"features": {
-			"DOH": true
-		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/remoteva-b.json
+++ b/test/config-next/remoteva-b.json
@@ -34,9 +34,6 @@
 				}
 			}
 		},
-		"features": {
-			"DOH": true
-		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/remoteva-c.json
+++ b/test/config-next/remoteva-c.json
@@ -34,9 +34,6 @@
 				}
 			}
 		},
-		"features": {
-			"DOH": true
-		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -36,9 +36,6 @@
 				}
 			}
 		},
-		"features": {
-			"DOH": true
-		},
 		"remoteVAs": [
 			{
 				"serverAddress": "rva1.service.consul:9397",

--- a/test/integration/common_test.go
+++ b/test/integration/common_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -49,7 +50,7 @@ func makeClient(contacts ...string) (*client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error connecting to acme directory: %v", err)
 	}
-	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privKey, err := rsa.GenerateKey(rand.Reader, 4090)
 	if err != nil {
 		return nil, fmt.Errorf("error creating private key: %v", err)
 	}

--- a/test/integration/validation_test.go
+++ b/test/integration/validation_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"database/sql"
-	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -117,14 +116,7 @@ func TestMPICTLSALPN01(t *testing.T) {
 		}
 	}
 	assertUserAgentsLength(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		// We can only check the user-agent for DNS requests if the DOH
-		// feature-flag is enabled.
-		//
-		// TODO(#8120): Remove this conditional once the DoH feature flag has
-		// been defaulted to true.
-		assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
-	}
+	assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
 }
 
 func TestMPICDNS01(t *testing.T) {
@@ -180,14 +172,7 @@ func TestMPICDNS01(t *testing.T) {
 		}
 	}
 	assertUserAgentsLength(t, collectUserAgentsFromDNSRequests(validationEvents), "DNS-01 validation")
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		// We can only check the user-agent for DNS requests if the DOH
-		// feature-flag is enabled.
-		//
-		// TODO(#8120): Remove this once the DoH feature flag has been defaulted
-		// to true.
-		assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(validationEvents), "DNS-01 validation")
-	}
+	assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(validationEvents), "DNS-01 validation")
 
 	domainDNSEvents, err := testSrvClient.DNSRequestHistory(domain)
 	if err != nil {
@@ -201,14 +186,7 @@ func TestMPICDNS01(t *testing.T) {
 		}
 	}
 	assertUserAgentsLength(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		// We can only check the user-agent for DNS requests if the DOH
-		// feature-flag is enabled.
-		//
-		// TODO(#8120): Remove this once the DoH feature flag has been defaulted
-		// to true.
-		assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
-	}
+	assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
 }
 
 func TestMPICHTTP01(t *testing.T) {
@@ -279,14 +257,7 @@ func TestMPICHTTP01(t *testing.T) {
 	}
 
 	assertUserAgentsLength(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		// We can only check the user-agent for DNS requests if the DOH
-		// feature-flag is enabled.
-		//
-		// TODO(#8120): Remove this once the DoH feature flag has been defaulted
-		// to true.
-		assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
-	}
+	assertExpectedUserAgents(t, collectUserAgentsFromDNSRequests(caaEvents), "CAA check")
 }
 
 func TestCAARechecking(t *testing.T) {


### PR DESCRIPTION
The commit 63310a34163e59c70447cc1ab3bad2ad2c100a11 was mistakenly included in the `release-2025-06-09` tag even though the corresponding pull request (https://github.com/letsencrypt/boulder/pull/8234) had not yet been merged.

To ensure the corresponding code is properly reviewed, we've created a release branch (`release-branch-2025-06-09`) off of the parent commit (1d713ed8eb250d8b1da0f254d775f765e5a7a2f9), using the pattern established in https://github.com/letsencrypt/boulder/blob/main/docs/release.md#dirty-hotfix-release, so we can review in this PR and merge to `release-branch-2025-06-09`.