### PR TITLE
integration: Move test_order_finalize_early to the Go tests

### DIFF
--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -316,8 +316,7 @@ func TestOrderFinalizeEarly(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error to be of type acme.Problem, got: %T", err)
 	}
-	orderNotReadyProblem := probs.OrderNotReadyProblem
-	if prob.Type != "urn:ietf:params:acme:error:"+string(orderNotReadyProblem) {
+	if prob.Type != "urn:ietf:params:acme:error:"+string(probs.OrderNotReadyProblem) {
 		t.Errorf("expected problem type 'urn:ietf:params:acme:error:orderNotReady', got: %s", prob.Type)
 	}
 }

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/eggsampler/acme/v3"
 	"github.com/go-jose/go-jose/v4"
 
-	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -307,7 +306,7 @@ func TestOrderFinalizeEarly(t *testing.T) {
 		t.Fatalf("generating CSR: %s", err)
 	}
 
-	_, err = client.Client.FinalizeOrder(client.Account, order, csr)
+	order, err = client.Client.FinalizeOrder(client.Account, order, csr)
 	if err == nil {
 		t.Fatal("expected finalize to fail, but got success")
 	}
@@ -316,7 +315,10 @@ func TestOrderFinalizeEarly(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error to be of type acme.Problem, got: %T", err)
 	}
-	if prob.Type != "urn:ietf:params:acme:error:"+string(probs.OrderNotReadyProblem) {
+	if prob.Type != "urn:ietf:params:acme:error:orderNotReady" {
 		t.Errorf("expected problem type 'urn:ietf:params:acme:error:orderNotReady', got: %s", prob.Type)
+	}
+	if order.Status != "pending" {
+		t.Errorf("expected order status to be pending, got: %s", order.Status)
 	}
 }

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -292,8 +292,7 @@ func TestOrderFinalizeEarly(t *testing.T) {
 		t.Fatalf("creating acme client: %s", err)
 	}
 
-	domain := randomDomain(t)
-	idents := []acme.Identifier{{Type: "dns", Value: domain}}
+	idents := []acme.Identifier{{Type: "dns", Value: randomDomain(t)}}
 
 	order, err := client.Client.NewOrder(client.Account, idents)
 	if err != nil {

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -647,27 +647,6 @@ def test_order_reuse_failed_authz():
     finally:
         cleanup()
 
-def test_order_finalize_early():
-    """
-    Test that finalizing an order before its fully authorized results in the
-    order having an error set and the status being invalid.
-    """
-    # Create a client
-    client = chisel2.make_client(None)
-
-    # Create a random domain and a csr
-    domains = [ random_domain() ]
-    csr_pem = chisel2.make_csr(domains)
-
-    # Create an order for the domain
-    order = client.new_order(csr_pem)
-
-    deadline = datetime.datetime.now() + datetime.timedelta(seconds=5)
-
-    # Finalizing an order early should generate an orderNotReady error.
-    chisel2.expect_problem("urn:ietf:params:acme:error:orderNotReady",
-        lambda: client.finalize_order(order, deadline))
-
 def test_only_return_existing_reg():
     client = chisel2.uninitialized_client()
     email = "test@not-example.com"


### PR DESCRIPTION
Hyrum’s Law strikes again: our Python integration tests were implicitly relying on behavior that was changed upstream in Certbot’s ACME client (see https://github.com/certbot/certbot/pull/10239). To ensure continued coverage, replicate this test in our Go integration test suite.