### PR TITLE
email-exporter: Don't waste limited attempts on cached entries

### DIFF
--- a/cmd/email-exporter/main.go
+++ b/cmd/email-exporter/main.go
@@ -105,10 +105,9 @@ func main() {
 		clientSecret,
 		c.EmailExporter.SalesforceBaseURL,
 		c.EmailExporter.PardotBaseURL,
-		cache,
 	)
 	cmd.FailOnError(err, "Creating Pardot API client")
-	exporterServer := email.NewExporterImpl(pardotClient, c.EmailExporter.PerDayLimit, c.EmailExporter.MaxConcurrentRequests, scope, logger)
+	exporterServer := email.NewExporterImpl(pardotClient, cache, c.EmailExporter.PerDayLimit, c.EmailExporter.MaxConcurrentRequests, scope, logger)
 
 	tlsConfig, err := c.EmailExporter.TLS.Load(scope)
 	cmd.FailOnError(err, "Loading email-exporter TLS config")

--- a/email/cache.go
+++ b/email/cache.go
@@ -67,12 +67,13 @@ func (c *EmailCache) Remove(email string) {
 	c.cache.Remove(hash)
 }
 
-// StoreIfAbsent stores the email in the cache if it is not already present in a
-// single atomic operation. True is returned if the email was stored and thus
-// not already present, false if it was already present in the cache.
+// StoreIfAbsent stores the email in the cache if it is not already present, as
+// a single atomic operation. It returns true if the email was stored and false
+// if it was already in the cache. If the cache is nil, true is always returned.
 func (c *EmailCache) StoreIfAbsent(email string) bool {
 	if c == nil {
-		return false
+		// If the cache is nil we assume it was not configured.
+		return true
 	}
 
 	hash := hashEmail(email)
@@ -83,9 +84,9 @@ func (c *EmailCache) StoreIfAbsent(email string) bool {
 	_, ok := c.cache.Get(hash)
 	if ok {
 		c.requests.WithLabelValues("hit").Inc()
-		return true
+		return false
 	}
 	c.cache.Add(hash, nil)
 	c.requests.WithLabelValues("miss").Inc()
-	return false
+	return true
 }

--- a/email/exporter.go
+++ b/email/exporter.go
@@ -147,7 +147,7 @@ func (impl *ExporterImpl) Start(daemonCtx context.Context) {
 			impl.toSend = impl.toSend[:last]
 			impl.Unlock()
 
-			if impl.emailCache.StoreIfAbsent(email) {
+			if !impl.emailCache.StoreIfAbsent(email) {
 				// Another worker has already processed this email.
 				continue
 			}

--- a/email/pardot.go
+++ b/email/pardot.go
@@ -63,14 +63,13 @@ type PardotClientImpl struct {
 	contactsURL  string
 	tokenURL     string
 	token        *oAuthToken
-	emailCache   *EmailCache
 	clk          clock.Clock
 }
 
 var _ PardotClient = &PardotClientImpl{}
 
 // NewPardotClientImpl creates a new PardotClientImpl.
-func NewPardotClientImpl(clk clock.Clock, businessUnit, clientId, clientSecret, oauthbaseURL, pardotBaseURL string, cache *EmailCache) (*PardotClientImpl, error) {
+func NewPardotClientImpl(clk clock.Clock, businessUnit, clientId, clientSecret, oauthbaseURL, pardotBaseURL string) (*PardotClientImpl, error) {
 	contactsURL, err := url.JoinPath(pardotBaseURL, contactsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to join contacts path: %w", err)
@@ -87,7 +86,6 @@ func NewPardotClientImpl(clk clock.Clock, businessUnit, clientId, clientSecret, 
 		contactsURL:  contactsURL,
 		tokenURL:     tokenURL,
 		token:        &oAuthToken{},
-		emailCache:   cache,
 		clk:          clk,
 	}, nil
 }
@@ -145,15 +143,6 @@ func redactEmail(body []byte, email string) string {
 // SendContact submits an email to the Pardot Contacts endpoint, retrying up
 // to 3 times with exponential backoff.
 func (pc *PardotClientImpl) SendContact(email string) error {
-	if pc.emailCache.Seen(email) {
-		// Another goroutine has already sent this email address.
-		return nil
-	}
-	// There is a possible race here where two goroutines could enqueue and send
-	// the same email address between this check and the actual HTTP request.
-	// However, at an average rate of ~1 email every 2 seconds, this is unlikely
-	// to happen in practice.
-
 	var err error
 	for attempt := range maxAttempts {
 		time.Sleep(core.RetryBackoff(attempt, retryBackoffMin, retryBackoffMax, retryBackoffBase))
@@ -193,7 +182,6 @@ func (pc *PardotClientImpl) SendContact(email string) error {
 
 		defer resp.Body.Close()
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			pc.emailCache.Store(email)
 			return nil
 		}
 

--- a/email/pardot_test.go
+++ b/email/pardot_test.go
@@ -6,14 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/jmhodges/clock"
-	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/test"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func defaultTokenHandler(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +44,7 @@ func TestSendContactSuccess(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
 	test.AssertNotError(t, err, "failed to create client")
 
 	err = client.SendContact("test@example.com")
@@ -73,7 +70,7 @@ func TestSendContactUpdateTokenFails(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
 	test.AssertNotError(t, err, "Failed to create client")
 
 	err = client.SendContact("test@example.com")
@@ -97,7 +94,7 @@ func TestSendContact4xx(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
 	test.AssertNotError(t, err, "Failed to create client")
 
 	err = client.SendContact("test@example.com")
@@ -145,7 +142,7 @@ func TestSendContactTokenExpiry(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
 	test.AssertNotError(t, err, "Failed to create client")
 
 	// First call uses the initial token ("old_token").
@@ -175,7 +172,7 @@ func TestSendContactServerErrorsAfterMaxAttempts(t *testing.T) {
 	contactSrv := httptest.NewServer(http.HandlerFunc(contactHandler))
 	defer contactSrv.Close()
 
-	client, _ := NewPardotClientImpl(clock.NewFake(), "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
+	client, _ := NewPardotClientImpl(clock.NewFake(), "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
 
 	err := client.SendContact("test@example.com")
 	test.AssertError(t, err, "Should fail after retrying all attempts")
@@ -203,38 +200,11 @@ func TestSendContactRedactsEmail(t *testing.T) {
 	defer contactSrv.Close()
 
 	clk := clock.NewFake()
-	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL, nil)
+	client, err := NewPardotClientImpl(clk, "biz-unit", "cid", "csec", tokenSrv.URL, contactSrv.URL)
 	test.AssertNotError(t, err, "failed to create client")
 
 	err = client.SendContact(emailToTest)
 	test.AssertError(t, err, "SendContact should fail")
 	test.AssertNotContains(t, err.Error(), emailToTest)
 	test.AssertContains(t, err.Error(), "[REDACTED]")
-}
-
-func TestSendContactDeduplication(t *testing.T) {
-	t.Parallel()
-
-	tokenSrv := httptest.NewServer(http.HandlerFunc(defaultTokenHandler))
-	defer tokenSrv.Close()
-
-	var contactHits int32
-	contactSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&contactHits, 1)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer contactSrv.Close()
-
-	cache := NewHashedEmailCache(1000, metrics.NoopRegisterer)
-	client, _ := NewPardotClientImpl(clock.New(), "biz", "cid", "csec", tokenSrv.URL, contactSrv.URL, cache)
-
-	err := client.SendContact("test@example.com")
-	test.AssertNotError(t, err, "SendContact should succeed on first call")
-	test.AssertMetricWithLabelsEquals(t, client.emailCache.requests, prometheus.Labels{"status": "miss"}, 1)
-
-	err = client.SendContact("test@example.com")
-	test.AssertNotError(t, err, "SendContact should succeed on second call")
-
-	test.AssertEquals(t, int32(1), atomic.LoadInt32(&contactHits))
-	test.AssertMetricWithLabelsEquals(t, client.emailCache.requests, prometheus.Labels{"status": "hit"}, 1)
 }


### PR DESCRIPTION
Currently, we check the cache only immediately before attempting to send an email address. However, we only reach that point if the rate limiter (used to respect the daily API quota) permits it. As a result, around 40% of sends are wasted on email addresses that are ultimately skipped due to cache hits.

Replace the pre-send cache `Seen` check with an atomic `StoreIfAbsent` executed before the `limiter.Wait()` so that limiter tokens are consumed only for email addresses that actually need sending. Skip the `limiter.Wait()` on cache hits, remove cache entries only when a send fails, and increment metrics only on successful sends.