### PR TITLE
Print key hash as hex in admin tool.

### DIFF
--- a/cmd/admin/dryrun.go
+++ b/cmd/admin/dryrun.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/prototext"

--- a/cmd/admin/dryrun.go
+++ b/cmd/admin/dryrun.go
@@ -33,6 +33,6 @@ type dryRunSAC struct {
 }
 
 func (d dryRunSAC) AddBlockedKey(_ context.Context, req *sapb.AddBlockedKeyRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-	d.log.Infof("dry-run: Block SPKI hash %s by %s %s", hex.EncodeToString(req.KeyHash), req.Comment, req.Source)
+	d.log.Infof("dry-run: Block SPKI hash %x by %s %s", req.KeyHash, req.Comment, req.Source)
 	return &emptypb.Empty{}, nil
 }

--- a/cmd/admin/dryrun.go
+++ b/cmd/admin/dryrun.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -32,10 +33,6 @@ type dryRunSAC struct {
 }
 
 func (d dryRunSAC) AddBlockedKey(_ context.Context, req *sapb.AddBlockedKeyRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-	b, err := prototext.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	d.log.Infof("dry-run: %#v", string(b))
+	d.log.Infof("dry-run: Block SPKI hash %s by %s %s", hex.EncodeToString(req.KeyHash), req.Comment, req.Source)
 	return &emptypb.Empty{}, nil
 }

--- a/cmd/admin/key_test.go
+++ b/cmd/admin/key_test.go
@@ -178,6 +178,6 @@ func TestBlockSPKIHash(t *testing.T) {
 	err = a.blockSPKIHash(context.Background(), keyHash[:], u, "")
 	test.AssertNotError(t, err, "")
 	test.AssertEquals(t, len(log.GetAllMatching("Found 0 unexpired certificates")), 1)
-	test.AssertEquals(t, len(log.GetAllMatching("dry-run:")), 1)
+	test.AssertEquals(t, len(log.GetAllMatching("dry-run: Block SPKI hash "+hex.EncodeToString(keyHash[:]))), 1)
 	test.AssertEquals(t, len(msa.blockRequests), 0)
 }


### PR DESCRIPTION
The ProtoText printing of this structure prints the binary string as escaped
utf8 text, which is essentially gibberish for my processes.
