### PR TITLE
Restore TestAccountEmailError

### DIFF
--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -12,7 +12,7 @@
 		"directoryWebsite": "https://github.com/letsencrypt/boulder",
 		"legacyKeyIDPrefix": "http://boulder.service.consul:4000/reg/",
 		"goodkey": {},
-		"maxContactsPerRegistration": 10,
+		"maxContactsPerRegistration": 3,
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/wfe.boulder/cert.pem",

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -813,7 +813,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	// does not contain valid contacts before we actually create the account.
 	emails, err := wfe.contactsToEmails(accountCreateRequest.Contact)
 	if err != nil {
-		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "invalid contact"), nil)
+		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Error validating contact(s)"), nil)
 		return
 	}
 


### PR DESCRIPTION
This integration test was removed in the early versions of https://github.com/letsencrypt/boulder/pull/8245, because that PR had removed all validation of contact addresses. However, later iterations of that PR restored (most) contact validation, so this PR restores (most of) the TestAccountEmailError integration test.

Config change is test-only, no need for a corresponding production change.