### PR TITLE
CI: run release job on all tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
-# Build the Boulder Debian package on every PR, push to main, and tag push. On
-# tag pushes, additionally create a GitHub release and with the resulting Debian
-# package.
-# Keep in sync with try-release.yml, with the exception that try-release.yml
-# can have multiple entries in its matrix but this should only have one.
+# Build the Boulder Debian package on tag push, and attach it to a GitHub
+# release.
+#
+# Keep in sync with try-release.yml, with the exception that try-release.yml can
+# have multiple entries in its matrix but this should only have one.
 name: Build release
 on:
   push:
     tags:
-      - release-*
+      - *
 
 jobs:
   push-release:


### PR DESCRIPTION
We don't use tags for anything other than tagging releases, so this should run for all tags.