### PR TITLE
Properly quote workflow tag push filter in yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Build release
 on:
   push:
     tags:
-      - *
+      - '**'
 
 jobs:
   push-release:


### PR DESCRIPTION
For some reason it's necessary to quote `*`, but not necessary to quote `release-*`.

Also, switch from a single `*` to a double `**` to catch tag names that contain `/`.