### PR TITLE
Ip alpn records sane

### DIFF
--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -84,6 +84,10 @@ func (va *ValidationAuthorityImpl) tryGetChallengeCert(
 			return nil, nil, validationRecord, fmt.Errorf("can't parse IP address %q: %s", ident.Value, err)
 		}
 		addrs = []netip.Addr{netIP}
+		// This field shouldn't be necessary: it's redundant with the Hostname
+		// field. But Challenge.RecordsSane expects it, and there's no easy way to
+		// special-case IP identifiers within that function.
+		validationRecord.AddressesResolved = addrs
 	default:
 		// This should never happen. The calling function should check the
 		// identifier type.

--- a/va/tlsalpn_test.go
+++ b/va/tlsalpn_test.go
@@ -368,9 +368,12 @@ func TestTLSALPN01SuccessDNS(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
+	res, err := va.validateTLSALPN01(ctx, identifier.NewDNS("expected"), expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Validation failed: %v", err)
+	}
+	if !(core.Challenge{Type: core.ChallengeTypeTLSALPN01, ValidationRecord: res}).RecordsSane() {
+		t.Errorf("got validation record %#v, but want something sane", res)
 	}
 	test.AssertMetricWithLabelsEquals(
 		t, va.metrics.tlsALPNOIDCounter, prometheus.Labels{"oid": IdPeAcmeIdentifier.String()}, 1)
@@ -384,9 +387,12 @@ func TestTLSALPN01SuccessIPv4(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
+	res, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Validation failed: %v", err)
+	}
+	if !(core.Challenge{Type: core.ChallengeTypeTLSALPN01, ValidationRecord: res}).RecordsSane() {
+		t.Errorf("got validation record %#v, but want something sane", res)
 	}
 	test.AssertMetricWithLabelsEquals(
 		t, va.metrics.tlsALPNOIDCounter, prometheus.Labels{"oid": IdPeAcmeIdentifier.String()}, 1)
@@ -400,9 +406,12 @@ func TestTLSALPN01SuccessIPv6(t *testing.T) {
 
 	va, _ := setup(hs, "", nil, nil)
 
-	_, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("::1")), expectedKeyAuthorization)
+	res, err := va.validateTLSALPN01(ctx, identifier.NewIP(netip.MustParseAddr("::1")), expectedKeyAuthorization)
 	if err != nil {
 		t.Errorf("Validation failed: %v", err)
+	}
+	if !(core.Challenge{Type: core.ChallengeTypeTLSALPN01, ValidationRecord: res}).RecordsSane() {
+		t.Errorf("got validation record %#v, but want something sane", res)
 	}
 	test.AssertMetricWithLabelsEquals(
 		t, va.metrics.tlsALPNOIDCounter, prometheus.Labels{"oid": IdPeAcmeIdentifier.String()}, 1)


### PR DESCRIPTION
Set the ValidationRecord.AddressesResolved field when performing tls-alpn-01 validation on an IP address. This field is redundant with ValidationRecord.Hostname, because we don't perform any resolution of DNS names to IP addresses when conducting validation of an IP address. But populating it anyway appeases the safety checks within the Challenge.RecordsSane() method, and matches the fact that we populate it for http-01 validation of IP addresses.

Add a check to several unit tests which fails on main but passes with this change applied.

Fixes https://github.com/letsencrypt/boulder/issues/8286