### PR TITLE
Add hotfix tag functionality to release tool

### DIFF
--- a/tools/release/branch/main.go
+++ b/tools/release/branch/main.go
@@ -89,9 +89,6 @@ func branch(args []string) error {
 	// Confirm the reasonableness of the given tag name by inspecting each of its
 	// components.
 	parts := strings.SplitN(tag, ".", 3)
-	if len(parts) != 3 {
-		return fmt.Errorf("failed to parse patch version from release tag %q", tag)
-	}
 
 	major := parts[0]
 	if major != "v0" {
@@ -101,7 +98,7 @@ func branch(args []string) error {
 	minor := parts[1]
 	t, err := time.Parse("20060102", minor)
 	if err != nil {
-		return fmt.Errorf("expected minor portion of release tag to be a ")
+		return fmt.Errorf("expected minor portion of release tag to be a date: %w", err)
 	}
 	if t.Year() < 2015 {
 		return fmt.Errorf("minor portion of release tag appears to be an unrealistic date: %q", t.String())


### PR DESCRIPTION
If given the name of a pre-existing release branch (created with //tools/release/branch), it will:
- fetch all commits on that branch;
- compute the next release tag by incrementing the highest extant patch version; and
- create (and optionally push) the new tag.

Most of the logic is contained in the new `nextTagOnBranch` function. The rest of the diff is slight rearrangement to accommodate that new function elegantly.

Sample output from using this tool to create a series of tags along a release branch is in the expando:
<details>

Each of the `git push origin HEAD...:release-branch-v0.20250630` commands below represents the process of cherrypicking a commit from `main` over to the release branch, getting it reviewed, and merging it.

```
$ ../../letsencrypt/boulder/branch v0.20250630.0
Running: /usr/bin/git fetch origin
Running: /usr/bin/git merge-base --is-ancestor v0.20250630.0 origin/main
Running: /usr/bin/git branch release-branch-v0.20250630 v0.20250630.0
Running: /usr/bin/git show -s release-branch-v0.20250630
   commit 5493682a1948d2a8677db32d053ac6648e5eb84d
   Author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
   Date:   Mon Jun 30 12:05:25 2025 -0700

       Update IANA special-purpose address registries (#8277)
Running: /usr/bin/git push origin release-branch-v0.20250630:release-branch-v0.20250630

$ git push origin HEAD~~:release-branch-v0.20250630
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:aarongable/boulder
   5493682a1..a1a7a7f7e  HEAD~~ -> release-branch-v0.20250630

$ ../../letsencrypt/boulder/tag -push release-branch-v0.20250630
Running: /usr/bin/git fetch origin release-branch-v0.20250630
Running: /usr/bin/git tag --list --no-column v0.20250630.*
Running: /usr/bin/git tag -m Release v0.20250630.1 v0.20250630.1 origin/release-branch-v0.20250630
Running: /usr/bin/git show -s v0.20250630.1
   tag v0.20250630.1
   Tagger: Aaron Gable <aaron@letsencrypt.org>
   Date:   Wed Jul 2 19:31:09 2025 -0700
    
   Release v0.20250630.1
    
   commit a1a7a7f7e650ebf4d99d6df295ea3d0d0f85d86a
   Author: Aaron Gable <aaron@letsencrypt.org>
   Date:   Mon Jun 30 16:07:11 2025 -0700
    
       Reject all CSRs with an IP in the CN (#8282)
        
       Although https://github.com/letsencrypt/boulder/pull/8231 fixed
       csr.CNFromCSR to ignore Common Names that are valid IPs, that didn't
       fully solve our issue: identifier.FromCSR still extracts the CN and
       assumes that it is a dnsName, leading to a mismatch between the CSR's
       identifiers and the Order's identifiers.
        
       Instead, let's outright reject all CSRs which carry an IP in their
       Subject Common Name. Although this doesn't have the elegance of
       rejecting such CNs on a profile-by-profile basis, it matches our ongoing
       effort to do away with CNs entirely.
Running: /usr/bin/git push origin v0.20250630.1

$ git push origin HEAD~:release-branch-v0.20250630 
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:aarongable/boulder
   a1a7a7f7e..7d5adcdf3  HEAD~ -> release-branch-v0.20250630

$ ../../letsencrypt/boulder/tag -push release-branch-v0.20250630
Running: /usr/bin/git fetch origin release-branch-v0.20250630
Running: /usr/bin/git tag --list --no-column v0.20250630.*
Running: /usr/bin/git tag -m Release v0.20250630.2 v0.20250630.2 origin/release-branch-v0.20250630
Running: /usr/bin/git show -s v0.20250630.2
   tag v0.20250630.2
   Tagger: Aaron Gable <aaron@letsencrypt.org>
   Date:   Wed Jul 2 19:31:52 2025 -0700
    
   Release v0.20250630.2
    
   commit 7d5adcdf31c80b9aa1104b174a47a99768849f36
   Author: Aaron Gable <aaron@letsencrypt.org>
   Date:   Mon Jun 30 16:24:59 2025 -0700
    
       CI: run release job on all tag pushes (#8283)
        
       We don't use tags for anything other than tagging releases, so this
       should run for all tags.
Running: /usr/bin/git push origin v0.20250630.2

$ git push origin HEAD:release-branch-v0.20250630              
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:aarongable/boulder
   7d5adcdf3..b4675dbae  HEAD -> release-branch-v0.20250630

$ ../../letsencrypt/boulder/tag -push release-branch-v0.20250630
Running: /usr/bin/git fetch origin release-branch-v0.20250630
Running: /usr/bin/git tag --list --no-column v0.20250630.*
Running: /usr/bin/git tag -m Release v0.20250630.3 v0.20250630.3 origin/release-branch-v0.20250630
Running: /usr/bin/git show -s v0.20250630.3
   tag v0.20250630.3
   Tagger: Aaron Gable <aaron@letsencrypt.org>
   Date:   Wed Jul 2 19:32:12 2025 -0700
    
   Release v0.20250630.3
    
   commit b4675dbae612c24d681241a34ef5d6be569b591e
   Author: Aaron Gable <aaron@letsencrypt.org>
   Date:   Tue Jul 1 09:48:35 2025 -0700
    
       Properly quote workflow tag push filter in yaml (#8284)
        
       For some reason it's necessary to quote `*`, but not necessary to quote
       `release-*`.
        
       Also, switch from a single `*` to a double `**` to catch tag names that
       contain `/`.
Running: /usr/bin/git push origin v0.20250630.3
```
</details>