### PR TITLE
Fix IsReservedAddr to handle IPv6 zone, add/verify tests

### DIFF
--- a/iana/ip.go
+++ b/iana/ip.go
@@ -157,6 +157,8 @@ func parseReservedPrefixFile(registryData []byte, addressFamily string) ([]reser
 
 // IsReservedAddr returns an error if an IP address is part of a reserved range.
 func IsReservedAddr(ip netip.Addr) error {
+	// Strip zone from IPv6 addresses before checking
+	ip = ip.WithZone("")
 	for _, rpx := range reservedPrefixes {
 		if rpx.addressBlock.Contains(ip) {
 			return fmt.Errorf("IP address is in a reserved address block: %s: %s", rpx.rfc, rpx.name)

--- a/iana/ip_test.go
+++ b/iana/ip_test.go
@@ -26,6 +26,9 @@ func TestIsReservedAddr(t *testing.T) {
 		{"febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "Link-Local Unicast"}, // highest IP in a reserved /10
 		{"fec0::1", ""}, // second-lowest IP just above a reserved /10
 
+		{"fe80::1%eth0", "Link-Local Unicast"}, // IPv6 link-local with zone
+		{"::1%lo", "Loopback Address"},         // IPv6 loopback with zone
+
 		{"192.0.0.170", "NAT64/DNS64 Discovery"},            // first of two reserved IPs that are comma-split in IANA's CSV; also a more-specific of a larger reserved block that comes first
 		{"192.0.0.171", "NAT64/DNS64 Discovery"},            // second of two reserved IPs that are comma-split in IANA's CSV; also a more-specific of a larger reserved block that comes first
 		{"2001:1::1", "Port Control Protocol Anycast"},      // reserved IP that comes after a line with a line break in IANA's CSV; also a more-specific of a larger reserved block that comes first


### PR DESCRIPTION
- Fixes a bug where IsReservedAddr did not properly handle IPv6 addresses with a zone (scope), due to `netip.Prefix.Contains` returning false for zoned addresses.
- Now strips the zone before checking.
- Added tests covering IPv6 addresses with zones.

Related to #8196
Related to #8020
Part of https://github.com/letsencrypt/boulder/pull/8292