### PR TITLE
test: Allow IP address issuance in config

### DIFF
--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -193,7 +193,8 @@
 			"tls-alpn-01": true
 		},
 		"identifiers": {
-			"dns": true
+			"dns": true,
+			"ip": true
 		}
 	},
 	"syslog": {

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -26,7 +26,8 @@
 			"tls-alpn-01": true
 		},
 		"identifiers": {
-			"dns": true
+			"dns": true,
+			"ip": true
 		}
 	},
 	"syslog": {

--- a/test/config/ra.json
+++ b/test/config/ra.json
@@ -61,7 +61,8 @@
 				"orderLifetime": "7h",
 				"maxNames": 10,
 				"identifierTypes": [
-					"dns"
+					"dns",
+					"ip"
 				]
 			}
 		},
@@ -193,7 +194,8 @@
 			"tls-alpn-01": true
 		},
 		"identifiers": {
-			"dns": true
+			"dns": true,
+			"ip": true
 		}
 	},
 	"syslog": {

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -212,22 +212,16 @@ func TestIPShortLived(t *testing.T) {
 
 	// Get one cert for the shortlived profile.
 	res, err := authAndIssue(client, key, idents, false, "shortlived")
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		if err != nil {
-			t.Errorf("issuing under shortlived profile: %s", err)
-		}
-		if res.Order.Profile != "shortlived" {
-			t.Errorf("got '%s' profile, wanted 'shortlived'", res.Order.Profile)
-		}
-		cert := res.certs[0]
+	if err != nil {
+		t.Errorf("issuing under shortlived profile: %s", err)
+	}
+	if res.Order.Profile != "shortlived" {
+		t.Errorf("got '%s' profile, wanted 'shortlived'", res.Order.Profile)
+	}
+	cert := res.certs[0]
 
-		// Check that the shortlived profile worked as expected.
-		if cert.IPAddresses[0].String() != ip {
-			t.Errorf("got cert with first IP SAN '%s', wanted '%s'", cert.IPAddresses[0], ip)
-		}
-	} else {
-		if !strings.Contains(err.Error(), "Profile \"shortlived\" does not permit ip type identifiers") {
-			t.Errorf("issuing under shortlived profile failed for the wrong reason: %s", err)
-		}
+	// Check that the shortlived profile worked as expected.
+	if cert.IPAddresses[0].String() != ip {
+		t.Errorf("got cert with first IP SAN '%s', wanted '%s'", cert.IPAddresses[0], ip)
 	}
 }

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 

--- a/test/integration/ratelimit_test.go
+++ b/test/integration/ratelimit_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/eggsampler/acme/v3"

--- a/test/integration/ratelimit_test.go
+++ b/test/integration/ratelimit_test.go
@@ -15,8 +15,10 @@ import (
 
 func TestDuplicateFQDNRateLimit(t *testing.T) {
 	t.Parallel()
-	idents := []acme.Identifier{{Type: "dns", Value: random_domain()}}
-	idents = append(idents, acme.Identifier{Type: "ip", Value: "64.112.117.122"})
+	idents := []acme.Identifier{
+		{Type: "dns", Value: random_domain()},
+		{Type: "ip", Value: "64.112.117.122"},
+	}
 
 	// The global rate limit for a duplicate certificates is 2 per 3 hours.
 	_, err := authAndIssue(nil, nil, idents, true, "shortlived")

--- a/test/integration/ratelimit_test.go
+++ b/test/integration/ratelimit_test.go
@@ -17,12 +17,7 @@ import (
 func TestDuplicateFQDNRateLimit(t *testing.T) {
 	t.Parallel()
 	idents := []acme.Identifier{{Type: "dns", Value: random_domain()}}
-
-	// TODO(#8235): Remove this conditional once IP address identifiers are
-	// enabled in test/config.
-	if os.Getenv("BOULDER_CONFIG_DIR") == "test/config-next" {
-		idents = append(idents, acme.Identifier{Type: "ip", Value: "64.112.117.122"})
-	}
+	idents = append(idents, acme.Identifier{Type: "ip", Value: "64.112.117.122"})
 
 	// The global rate limit for a duplicate certificates is 2 per 3 hours.
 	_, err := authAndIssue(nil, nil, idents, true, "shortlived")


### PR DESCRIPTION
Issuance for IP address identifiers is now enabled in production.

Fixes #8235