### PR TITLE
sa: Drop LockCol from registrations table in db-next

### DIFF
--- a/sa/db-next/boulder_sa/20250708000000_DropRegistrationsLockCol.sql
+++ b/sa/db-next/boulder_sa/20250708000000_DropRegistrationsLockCol.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `registrations` DROP COLUMN `LockCol`;
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `registrations` ADD COLUMN `LockCol` BIGINT(20) NOT NULL DEFAULT 0;


### PR DESCRIPTION
`LockCol` in the `registrations` table is no longer used or needed, as of #8296.

**Do not merge** until #8296 is deployed to production.