### PR TITLE
test: Enable optional coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tags
 
 # ProxySQL log files
 test/proxysql/*.log*
+
+# Coverage files
+test/coverage

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ To run all integration tests:
 docker compose run --use-aliases boulder ./test.sh --integration
 ```
 
+To run unit tests and integration tests with coverage:
+
+```shell
+docker compose run --use-aliases boulder ./test.sh --unit --integration --coverage --coverage-dir=./test/coverage/mytestrun
+```
+
 To run specific integration tests (example runs TestAkamaiPurgerDrainQueueFails and TestWFECORS):
 
 ```shell

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -10,22 +10,14 @@ are also in this file.
 import argparse
 import datetime
 import inspect
-import json
 import os
-import random
 import re
-import requests
 import subprocess
-import shlex
-import signal
-import time
 
+import requests
 import startservers
-
 import v2_integration
 from helpers import *
-
-from acme import challenges
 
 # Set the environment variable RACE to anything other than 'true' to disable
 # race detection. This significantly speeds up integration testing cycles
@@ -55,6 +47,11 @@ def main():
     parser = argparse.ArgumentParser(description='Run integration tests')
     parser.add_argument('--chisel', dest="run_chisel", action="store_true",
                         help="run integration tests using chisel")
+    parser.add_argument('--coverage', dest="coverage", action="store_true",
+                        help="run integration tests with coverage")
+    parser.add_argument('--coverage-dir', dest="coverage_dir", action="store",
+                        default=f"test/coverage/{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}",
+                        help="directory to store coverage data")
     parser.add_argument('--gotest', dest="run_go", action="store_true",
                         help="run Go integration tests")
     parser.add_argument('--gotestverbose', dest="run_go_verbose", action="store_true",
@@ -64,16 +61,22 @@ def main():
     # allow any ACME client to run custom command for integration
     # testing (without having to implement its own busy-wait loop)
     parser.add_argument('--custom', metavar="CMD", help="run custom command")
-    parser.set_defaults(run_chisel=False, test_case_filter="", skip_setup=False)
+    parser.set_defaults(run_chisel=False, test_case_filter="", skip_setup=False, coverage=False, coverage_dir=None)
     args = parser.parse_args()
+
+    if args.coverage and args.coverage_dir:
+        if not os.path.exists(args.coverage_dir):
+            os.makedirs(args.coverage_dir)
+        if not os.path.isdir(args.coverage_dir):
+            raise(Exception("coverage-dir must be a directory"))
 
     if not (args.run_chisel or args.custom  or args.run_go is not None):
         raise(Exception("must run at least one of the letsencrypt or chisel tests with --chisel, --gotest, or --custom"))
 
-    if not startservers.install(race_detection=race_detection):
+    if not startservers.install(race_detection=race_detection, coverage=args.coverage):
         raise(Exception("failed to build"))
 
-    if not startservers.start():
+    if not startservers.start(coverage_dir=args.coverage_dir):
         raise(Exception("startservers failed"))
 
     if args.run_chisel:
@@ -81,7 +84,7 @@ def main():
 
     if args.run_go:
         run_go_tests(args.test_case_filter, False)
-    
+
     if args.run_go_verbose:
         run_go_tests(args.test_case_filter, True)
 
@@ -93,6 +96,10 @@ def main():
     if not args.test_case_filter:
         run_cert_checker()
         check_balance()
+
+    # If coverage is enabled, process the coverage data
+    if args.coverage:
+        process_covdata(args.coverage_dir)
 
     if not startservers.check():
         raise(Exception("startservers.check failed"))
@@ -128,12 +135,24 @@ def check_balance():
     ]
     for address in addresses:
         metrics = requests.get("http://%s/metrics" % address)
-        if not "grpc_server_handled_total" in metrics.text:
+        if "grpc_server_handled_total" not in metrics.text:
             raise(Exception("no gRPC traffic processed by %s; load balancing problem?")
                 % address)
 
 def run_cert_checker():
     run(["./bin/boulder", "cert-checker", "-config", "%s/cert-checker.json" % config_dir])
+
+def process_covdata(coverage_dir):
+    """Process coverage data and generate reports."""
+    if not os.path.exists(coverage_dir):
+        raise(Exception("Coverage directory does not exist: %s" % coverage_dir))
+
+    # Generate text report
+    coverage_dir = os.path.abspath(coverage_dir)
+    cov_text = os.path.join(coverage_dir, "integration.coverprofile")
+    # this works, but if it takes a long time consider merging with `go tool covdata merge` first
+    # https://go.dev/blog/integration-test-coverage#merging-raw-profiles-with-go-tool-covdata-merge
+    run(["go", "tool", "covdata", "textfmt", "-i", coverage_dir, "-o", cov_text])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add new flag `-c` / `--coverage` to enable optional coverage reporting for all the test types.
- Use `GOFLAGS="-cover -covermode=atomic -coverprofile=...` for go unit tests
- Use the build flag `-cover`, as described in https://go.dev/blog/integration-test-coverage, for the end-to-end go integration tests