### PR TITLE
sfe/zendesk: Add a Zendesk API client implementation

### DIFF
--- a/cmd/sfe/main.go
+++ b/cmd/sfe/main.go
@@ -11,8 +11,10 @@ import (
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
+	rlo "github.com/letsencrypt/boulder/ratelimits/overriderequests"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	"github.com/letsencrypt/boulder/sfe"
+	"github.com/letsencrypt/boulder/sfe/zendesk"
 	"github.com/letsencrypt/boulder/web"
 )
 
@@ -43,6 +45,21 @@ type Config struct {
 		// WFEs. This field is required to enable the pausing feature.
 		UnpauseHMACKey cmd.HMACKeyConfig
 
+		Zendesk *struct {
+			BaseURL      string             `validate:"required,url"`
+			TokenEmail   string             `validate:"required,email"`
+			Token        cmd.PasswordConfig `validate:"required,dive"`
+			CustomFields struct {
+				Organization     int64 `validate:"required"`
+				Tier             int64 `validate:"required"`
+				RateLimit        int64 `validate:"required"`
+				ReviewStatus     int64 `validate:"required"`
+				Fundraising      int64 `validate:"required"`
+				AccountID        int64 `validate:"required"`
+				RegisteredDomain int64 `validate:"required"`
+				IPAddress        int64 `validate:"required"`
+			} `validate:"required,dive"`
+		} `validate:"omitempty,dive"`
 		Features features.Config
 	}
 
@@ -98,6 +115,31 @@ func main() {
 	cmd.FailOnError(err, "Failed to load credentials and create gRPC connection to SA")
 	sac := sapb.NewStorageAuthorityReadOnlyClient(saConn)
 
+	var zendeskClient *zendesk.Client
+	if c.SFE.Zendesk != nil {
+		zendeskToken, err := c.SFE.Zendesk.Token.Pass()
+		cmd.FailOnError(err, "Failed to load Zendesk token")
+
+		zendeskClient, err = zendesk.NewClient(
+			c.SFE.Zendesk.BaseURL,
+			c.SFE.Zendesk.TokenEmail,
+			zendeskToken,
+			map[string]int64{
+				rlo.OrganizationFieldName:     c.SFE.Zendesk.CustomFields.Organization,
+				rlo.TierFieldName:             c.SFE.Zendesk.CustomFields.Tier,
+				rlo.RateLimitFieldName:        c.SFE.Zendesk.CustomFields.RateLimit,
+				rlo.ReviewStatusFieldName:     c.SFE.Zendesk.CustomFields.ReviewStatus,
+				rlo.FundraisingFieldName:      c.SFE.Zendesk.CustomFields.Fundraising,
+				rlo.AccountURIFieldName:       c.SFE.Zendesk.CustomFields.AccountID,
+				rlo.RegisteredDomainFieldName: c.SFE.Zendesk.CustomFields.RegisteredDomain,
+				rlo.IPAddressFieldName:        c.SFE.Zendesk.CustomFields.IPAddress,
+			},
+		)
+		if err != nil {
+			cmd.FailOnError(err, "Failed to create Zendesk client")
+		}
+	}
+
 	sfei, err := sfe.NewSelfServiceFrontEndImpl(
 		stats,
 		clk,
@@ -106,6 +148,7 @@ func main() {
 		rac,
 		sac,
 		unpauseHMACKey,
+		zendeskClient,
 	)
 	cmd.FailOnError(err, "Unable to create SFE")
 

--- a/ratelimits/overriderequests/overriderequests.go
+++ b/ratelimits/overriderequests/overriderequests.go
@@ -38,7 +38,7 @@ func makeInitialComment(organization, useCase, tier string) string {
 	)
 }
 
-func NewOrdersPerAccountOverrideTicket(client *zendesk.Client, requesterEmail, useCase, fundraising, organization, tier, accountID string) (int64, error) {
+func CreateNewOrdersPerAccountOverrideTicket(client *zendesk.Client, requesterEmail, useCase, fundraising, organization, tier, accountID string) (int64, error) {
 	return client.CreateTicket(
 		requesterEmail,
 		makeSubject(rl.NewOrdersPerAccount, organization),

--- a/ratelimits/overriderequests/overriderequests.go
+++ b/ratelimits/overriderequests/overriderequests.go
@@ -54,7 +54,7 @@ func NewOrdersPerAccountOverrideTicket(client *zendesk.Client, requesterEmail, u
 	)
 }
 
-func CreateCertificatesPerDomainOverrideTicket(client *zendesk.Client, requesterEmail, useCase, fundraising, organization, tier, registeredDomainOrIP string) (int64, error) {
+func CreateCertificatesPerDomainOverrideTicket(client *zendesk.Client, requesterEmail, useCase, fundraising, organization, tier, registeredDomain, ipAddress string) (int64, error) {
 	return client.CreateTicket(
 		requesterEmail,
 		makeSubject(rl.NewOrdersPerAccount, organization),
@@ -65,7 +65,8 @@ func CreateCertificatesPerDomainOverrideTicket(client *zendesk.Client, requester
 			OrganizationFieldName:     organization,
 			FundraisingFieldName:      fundraising,
 			TierFieldName:             tier,
-			RegisteredDomainFieldName: registeredDomainOrIP,
+			RegisteredDomainFieldName: registeredDomain,
+			IPAddressFieldName:        ipAddress,
 		},
 	)
 }

--- a/ratelimits/overriderequests/overriderequests.go
+++ b/ratelimits/overriderequests/overriderequests.go
@@ -1,0 +1,87 @@
+package overriderequests
+
+import (
+	"fmt"
+
+	rl "github.com/letsencrypt/boulder/ratelimits"
+	"github.com/letsencrypt/boulder/sfe/zendesk"
+)
+
+const (
+	// Used for the request form Web UI and in the Zendesk tickets.
+	OrganizationFieldName     = "organization"
+	TierFieldName             = "tier"
+	RateLimitFieldName        = "rateLimit"
+	ReviewStatusFieldName     = "reviewStatus"
+	FundraisingFieldName      = "fundraising"
+	AccountURIFieldName       = "accountURI"
+	RegisteredDomainFieldName = "registeredDomain"
+	IPAddressFieldName        = "ipAddress"
+
+	// Only used for the request form Web UI.
+	PrivacyPolicyFieldName = "privacyPolicy"
+	EmailAddressFieldName  = "emailAddress"
+	UseCase                = "useCase"
+
+	// reviewStatusDefault is the initial status of a ticket when created.
+	reviewStatusDefault = "review-status-pending"
+)
+
+func makeSubject(rateLimit rl.Name, organization string) string {
+	return fmt.Sprintf("%s rate limit override request for %s", rateLimit.String(), organization)
+}
+
+func makeInitialComment(organization, useCase, tier string) string {
+	return fmt.Sprintf(
+		"Use case: %s\n\nRequested Override Tier: %s\n\nOrganization: %s",
+		useCase, tier, organization,
+	)
+}
+
+func NewOrdersPerAccountOverrideTicket(client *zendesk.Client, requesterEmail, useCase, fundraising, organization, tier, accountID string) (int64, error) {
+	return client.CreateTicket(
+		requesterEmail,
+		makeSubject(rl.NewOrdersPerAccount, organization),
+		makeInitialComment(organization, useCase, tier),
+		map[string]string{
+			RateLimitFieldName:    rl.NewOrdersPerAccount.String(),
+			ReviewStatusFieldName: reviewStatusDefault,
+			OrganizationFieldName: organization,
+			FundraisingFieldName:  fundraising,
+			TierFieldName:         tier,
+			AccountURIFieldName:   accountID,
+		},
+	)
+}
+
+func CreateCertificatesPerDomainOverrideTicket(client *zendesk.Client, requesterEmail, useCase, fundraising, organization, tier, registeredDomainOrIP string) (int64, error) {
+	return client.CreateTicket(
+		requesterEmail,
+		makeSubject(rl.NewOrdersPerAccount, organization),
+		makeInitialComment(organization, useCase, tier),
+		map[string]string{
+			RateLimitFieldName:        rl.CertificatesPerDomain.String(),
+			ReviewStatusFieldName:     reviewStatusDefault,
+			OrganizationFieldName:     organization,
+			FundraisingFieldName:      fundraising,
+			TierFieldName:             tier,
+			RegisteredDomainFieldName: registeredDomainOrIP,
+		},
+	)
+}
+
+func CreateCertificatesPerDomainPerAccountOverrideTicket(client *zendesk.Client, requesterEmail, useCase, fundraising, organization, tier, accountID string) (int64, error) {
+	return client.CreateTicket(
+		requesterEmail,
+		makeSubject(rl.NewOrdersPerAccount, organization),
+		makeInitialComment(organization, useCase, tier),
+		map[string]string{
+			RateLimitFieldName:    rl.CertificatesPerDomainPerAccount.String(),
+			ReviewStatusFieldName: reviewStatusDefault,
+			OrganizationFieldName: organization,
+			FundraisingFieldName:  fundraising,
+			TierFieldName:         tier,
+			AccountURIFieldName:   accountID,
+		},
+	)
+}

--- a/sfe/sfe.go
+++ b/sfe/sfe.go
@@ -22,6 +22,7 @@ import (
 	"github.com/letsencrypt/boulder/metrics/measured_http"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
+	"github.com/letsencrypt/boulder/sfe/zendesk"
 	"github.com/letsencrypt/boulder/unpause"
 )
 
@@ -53,7 +54,9 @@ type SelfServiceFrontEndImpl struct {
 	requestTimeout time.Duration
 
 	unpauseHMACKey []byte
-	templatePages  *template.Template
+	zendeskClient  *zendesk.Client //nolint:unused // TODO(#8166): For periodic Zendesk sync.
+
+	templatePages *template.Template
 }
 
 // NewSelfServiceFrontEndImpl constructs a web service for Boulder
@@ -65,6 +68,7 @@ func NewSelfServiceFrontEndImpl(
 	rac rapb.RegistrationAuthorityClient,
 	sac sapb.StorageAuthorityReadOnlyClient,
 	unpauseHMACKey []byte,
+	zendeskClient *zendesk.Client,
 ) (SelfServiceFrontEndImpl, error) {
 
 	// Parse the files once at startup to avoid each request causing the server

--- a/sfe/sfe_test.go
+++ b/sfe/sfe_test.go
@@ -59,6 +59,7 @@ func setupSFE(t *testing.T) (SelfServiceFrontEndImpl, clock.FakeClock) {
 		&MockRegistrationAuthority{},
 		mockSA,
 		key,
+		nil,
 	)
 	test.AssertNotError(t, err, "Unable to create SFE")
 

--- a/sfe/zendesk/zendesk.go
+++ b/sfe/zendesk/zendesk.go
@@ -1,0 +1,327 @@
+package zendesk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	apiPath         = "api/v2/"
+	ticketsJSONPath = apiPath + "tickets.json"
+	searchJSONPath  = apiPath + "search.json"
+)
+
+type Client struct {
+	httpClient *http.Client
+	tokenEmail string
+	token      string
+
+	ticketsURL string
+	searchURL  string
+	commentURL string
+
+	nameToFieldID map[string]int64
+	fieldIDToName map[int64]string
+}
+
+// NewClient creates a new Zendesk client with the provided baseURL, token, and
+// tokenEmail, and a name to field id mapping. baseURL is your Zendesk URL with
+// the scheme included, e.g. "https://yourdomain.zendesk.com". Token is an API
+// token generated from the Zendesk Admin UI. The tokenEmail is the email
+// address of the Zendesk user that created the token. The nameToFieldID must
+// contain the display names and corresponding IDs of the custom fields you want
+// to use in your tickets, this allows you to refer to custom fields by string
+// names instead of numeric IDs when working with tickets.
+func NewClient(baseURL, tokenEmail, token string, nameToFieldID map[string]int64) (*Client, error) {
+	ticketsURL, err := url.JoinPath(baseURL, ticketsJSONPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to join tickets path: %w", err)
+	}
+	searchURL, err := url.JoinPath(baseURL, searchJSONPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to join search path: %w", err)
+	}
+	commentURL, err := url.JoinPath(baseURL, apiPath, "tickets")
+	if err != nil {
+		return nil, fmt.Errorf("failed to join comment path: %w", err)
+	}
+	fieldIDToName := make(map[int64]string, len(nameToFieldID))
+	for name, id := range nameToFieldID {
+		_, ok := fieldIDToName[id]
+		if ok {
+			return nil, fmt.Errorf("duplicate field ID %d for field %q", id, name)
+		}
+		fieldIDToName[id] = name
+	}
+	return &Client{
+		httpClient:    &http.Client{Timeout: 15 * time.Second},
+		tokenEmail:    tokenEmail,
+		token:         token,
+		ticketsURL:    ticketsURL,
+		searchURL:     searchURL,
+		commentURL:    commentURL,
+		nameToFieldID: nameToFieldID,
+		fieldIDToName: fieldIDToName,
+	}, nil
+}
+
+type requester struct {
+	// Name is the name of the requester, it is a required field.
+	Name string `json:"name"`
+
+	// Email is the email address of the requester, it is a required field.
+	Email string `json:"email"`
+}
+
+type comment struct {
+	// Body is the content of the comment, it is a required field.
+	Body string `json:"body"`
+
+	// Public indicates whether the comment is public or private.
+	Public bool `json:"public"`
+}
+
+type customField struct {
+	// ID is the ID of the custom field in Zendesk. It is a required field.
+	ID int64 `json:"id"`
+
+	// Value is the value of the custom field.
+	Value string `json:"value"`
+}
+
+type ticket struct {
+	// Requester is the requester of the ticket, it is a required field.
+	Requester requester `json:"requester"`
+
+	// Subject is the subject of the ticket, it is a required field.
+	Subject string `json:"subject"`
+
+	// Comment is the initial comment on the ticket. It is a required field. If
+	// you want to add additional comments later, use the AddComment method.
+	Comment comment `json:"comment"`
+
+	// CustomFields is a list of custom fields and their corresponding values.
+	// It is optional, but if you want to set custom fields you must provide
+	// them here.
+	CustomFields []customField `json:"custom_fields,omitempty"`
+}
+
+func (c *Client) newJSONRequest(method, reqURL string, body []byte) (*http.Request, error) {
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, reqURL, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.tokenEmail+"/token", c.token)
+	req.Header.Set("Accept", "application/json")
+	if reader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
+}
+
+// CreateTicket creates a new Zendesk ticket with the provided requester email,
+// subject, initial comment body, and custom fields. It returns the ID of the
+// created ticket or an error if the request fails. The custom fields should be
+// provided as a map where the keys are the display names of the custom fields
+// and the values are the desired values for those fields. The method will
+// convert the display names to their corresponding field IDs using the
+// nameToFieldID map provided when creating the Client. If a custom field name
+// is unknown, an error will be returned.
+func (c *Client) CreateTicket(requesterEmail, subject, commentBody string, fields map[string]string) (int64, error) {
+	ticketContents := ticket{
+		Requester: requester{
+			Email: requesterEmail,
+			Name:  requesterEmail,
+		},
+		Subject: subject,
+		Comment: comment{
+			Body:   commentBody,
+			Public: true,
+		},
+	}
+	for name, value := range fields {
+		id, ok := c.nameToFieldID[name]
+		if !ok {
+			return 0, fmt.Errorf("unknown custom field %q", name)
+		}
+		ticketContents.CustomFields = append(ticketContents.CustomFields, customField{
+			ID:    id,
+			Value: value,
+		})
+	}
+
+	body, err := json.Marshal(struct {
+		Ticket ticket `json:"ticket"`
+	}{Ticket: ticketContents})
+	if err != nil {
+		return 0, err
+	}
+
+	req, err := c.newJSONRequest(http.MethodPost, c.ticketsURL, body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create zendesk request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return 0, fmt.Errorf("zendesk status %d: failed to read response body: %w", resp.StatusCode, err)
+		}
+		return 0, fmt.Errorf("zendesk returned status %d: %s", resp.StatusCode, respBody)
+	}
+
+	var result struct {
+		Ticket struct {
+			ID int64 `json:"id"`
+		} `json:"ticket"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return 0, err
+	}
+	if result.Ticket.ID == 0 {
+		return 0, fmt.Errorf("zendesk did not return a valid ticket ID")
+	}
+	return result.Ticket.ID, nil
+}
+
+// FindTickets returns all tickets whose custom fields match the supplied
+// matchFields. The matchFields map should contain the display names of the
+// custom fields as keys and the desired values as values. The method returns a
+// map where the keys are ticket IDs and the values are maps of custom field
+// names to their values. If no matchFields are supplied, an error is returned.
+// If a custom field name is unknown, an error is returned.
+func (c *Client) FindTickets(matchFields map[string]string) (map[int64]map[string]string, error) {
+	if len(matchFields) == 0 {
+		return nil, fmt.Errorf("no match fields supplied")
+	}
+
+	var query strings.Builder
+	query.WriteString("type:ticket")
+
+	for name, want := range matchFields {
+		id, ok := c.nameToFieldID[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown custom field %q", name)
+		}
+		val := want
+		if strings.ContainsRune(val, ' ') {
+			val = `"` + val + `"`
+		}
+		fmt.Fprintf(&query, " custom_field_%d:%s", id, val)
+	}
+
+	searchURL := c.searchURL + "?query=" + url.QueryEscape(query.String())
+	out := make(map[int64]map[string]string)
+
+	for searchURL != "" {
+		req, err := c.newJSONRequest(http.MethodGet, searchURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create zendesk request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode >= 300 {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("zendesk status %d: failed to read response body: %w", resp.StatusCode, err)
+			}
+			resp.Body.Close()
+			return nil, fmt.Errorf("zendesk status %d: %s", resp.StatusCode, body)
+		}
+
+		var results struct {
+			Results []struct {
+				ID           int64 `json:"id"`
+				CustomFields []struct {
+					ID    int64 `json:"id"`
+					Value any   `json:"value"`
+				} `json:"custom_fields"`
+			} `json:"results"`
+			Next *string `json:"next_page"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&results)
+		if err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("failed to decode zendesk response: %w", err)
+		}
+		resp.Body.Close()
+
+		for _, result := range results.Results {
+			fieldMap := make(map[string]string)
+			for _, cf := range result.CustomFields {
+				name, ok := c.fieldIDToName[cf.ID]
+				if ok {
+					fieldMap[name] = fmt.Sprint(cf.Value)
+				}
+			}
+			out[result.ID] = fieldMap
+		}
+		if results.Next != nil {
+			searchURL = *results.Next
+			continue
+		}
+		searchURL = ""
+	}
+	return out, nil
+}
+
+// AddComment posts the comment body to the specified ticket. The comment is
+// added as a public or private comment based on the provided boolean value. An
+// error is returned if the request fails.
+func (c *Client) AddComment(ticketID int64, commentBody string, public bool) error {
+	endpoint, err := url.JoinPath(c.commentURL, fmt.Sprintf("%d.json", ticketID))
+	if err != nil {
+		return fmt.Errorf("failed to join ticket path: %w", err)
+	}
+
+	payload := struct {
+		Ticket struct {
+			Comment comment `json:"comment"`
+		} `json:"ticket"`
+	}{}
+	payload.Ticket.Comment = comment{Body: commentBody, Public: public}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal zendesk comment: %w", err)
+	}
+
+	req, err := c.newJSONRequest(http.MethodPut, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("failed to create zendesk request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("zendesk request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("zendesk status %d: failed to read response body: %w", resp.StatusCode, err)
+		}
+		return fmt.Errorf("zendesk status %d: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}

--- a/sfe/zendesk/zendesk_test.go
+++ b/sfe/zendesk/zendesk_test.go
@@ -1,0 +1,389 @@
+package zendesk
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/letsencrypt/boulder/test/zendeskfake"
+)
+
+const (
+	apiTokenEmail = "tester@example.com"
+	apiToken      = "someToken"
+)
+
+func startMockClient(t *testing.T) (*Client, *zendeskfake.Server) {
+	t.Helper()
+
+	st := zendeskfake.NewStore(0)
+	srv := zendeskfake.NewServer(apiTokenEmail, apiToken, st)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	nameToID := map[string]int64{
+		"reviewStatus": 111,
+		"organization": 222,
+		"kind":         333,
+	}
+
+	c, err := NewClient(ts.URL, apiTokenEmail, apiToken, nameToID)
+	if err != nil {
+		t.Errorf("NewClient(%q) returned error: %s", ts.URL, err)
+	}
+
+	return c, srv
+}
+
+func TestCreateTicketOK(t *testing.T) {
+	t.Parallel()
+
+	c, srv := startMockClient(t)
+
+	id, err := c.CreateTicket("alice@example.com", "Subject", "Body text", map[string]string{
+		"reviewStatus": "pending",
+		"organization": "Acme",
+	})
+	if err != nil {
+		t.Errorf("CreateTicket(alice@example.com, Subject) error: %s", err)
+	}
+	if id == 0 {
+		t.Errorf("CreateTicket returned id=0; want non-zero")
+	}
+
+	got, ok := srv.GetTicket(id)
+	if !ok {
+		t.Errorf("ticket id %d not stored in mock server", id)
+	}
+	if got.Subject != "Subject" {
+		t.Errorf("subject mismatch: got %q, want %q", got.Subject, "Subject")
+	}
+	if len(got.Comments) != 1 || got.Comments[0].Body != "Body text" || !got.Comments[0].Public {
+		t.Errorf("comments stored incorrectly: %#v (want one public comment with body %q)", got.Comments, "Body text")
+	}
+	if got.CustomFields[111] != "pending" || got.CustomFields[222] != "Acme" {
+		t.Errorf("custom fields mismatch: %#v (want 111=%q, 222=%q)", got.CustomFields, "pending", "Acme")
+	}
+}
+
+func TestCreateTicketHTTPError(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/tickets.json", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL, apiTokenEmail, apiToken, map[string]int64{})
+	if err != nil {
+		t.Errorf("NewClient(%q): %s", ts.URL, err)
+	}
+
+	_, err = c.CreateTicket("bob@example.com", "cause500", "x", nil)
+	if err == nil || !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("expected HTTP 500 error creating ticket, got: %s", err)
+	}
+}
+
+func TestCreateTicketUnknownField(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	_, err := c.CreateTicket("x@example.com", "s", "b", map[string]string{"nope": "v"})
+	if err == nil || !strings.Contains(err.Error(), "unknown custom field") {
+		t.Errorf("expected unknown custom field error, got: %s", err)
+	}
+}
+
+func TestAddCommentOK(t *testing.T) {
+	t.Parallel()
+
+	c, srv := startMockClient(t)
+
+	id, err := c.CreateTicket("a@example.com", "s", "first", nil)
+	if err != nil {
+		t.Errorf("CreateTicket(a@example.com): %s", err)
+	}
+
+	err = c.AddComment(id, "second-private", false)
+	if err != nil {
+		t.Errorf("AddComment(id=%d): %s", id, err)
+	}
+
+	got, ok := srv.GetTicket(id)
+	if !ok {
+		t.Errorf("ticket id %d not stored after AddComment", id)
+	}
+	if len(got.Comments) != 2 {
+		t.Errorf("want 2 comments after AddComment, got %d: %#v", len(got.Comments), got.Comments)
+	}
+	if got.Comments[1].Body != "second-private" || got.Comments[1].Public {
+		t.Errorf("second comment incorrect: %#v (want body=%q, public=false)", got.Comments[1], "second-private")
+	}
+}
+
+func TestAddComment404(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	err := c.AddComment(99999, "x", true)
+	if err == nil || !strings.Contains(err.Error(), "status 404") {
+		t.Errorf("expected HTTP 404 when adding comment to unknown ticket, got: %s", err)
+	}
+}
+
+func TestFindTicketsSimple(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	_, err := c.CreateTicket("u1@example.com", "s1", "b", map[string]string{"reviewStatus": "pending", "organization": "Acme"})
+	if err != nil {
+		t.Errorf("creating ticket 1: %s", err)
+	}
+	_, err = c.CreateTicket("u2@example.com", "s2", "b", map[string]string{"reviewStatus": "approved", "organization": "Acme"})
+	if err != nil {
+		t.Errorf("creating ticket 2: %s", err)
+	}
+	id3, err := c.CreateTicket("u3@example.com", "s3", "b", map[string]string{"reviewStatus": "pending", "organization": "Beta"})
+	if err != nil {
+		t.Errorf("creating ticket 3: %s", err)
+	}
+
+	got, err := c.FindTickets(map[string]string{"reviewStatus": "pending"})
+	if err != nil {
+		t.Errorf("FindTickets(reviewStatus=pending): %s", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 results for reviewStatus=pending, got %d: %#v", len(got), got)
+	}
+	fields, ok := got[id3]
+	if ok {
+		if fields["reviewStatus"] != "pending" || fields["organization"] != "Beta" {
+			t.Errorf("field name/value mapping wrong for ticket %d: %#v (want reviewStatus=%q, organization=%q)", id3, fields, "pending", "Beta")
+		}
+	}
+}
+
+func TestFindTicketsQuotedValueReturnsAll(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	for i := range 5 {
+		_, err := c.CreateTicket("x@example.com", fmt.Sprintf("s%d", i), "b",
+			map[string]string{"reviewStatus": "needs review"})
+		if err != nil {
+			t.Errorf("create ticket %d: %s", i, err)
+		}
+	}
+
+	got, err := c.FindTickets(map[string]string{"reviewStatus": "needs review"})
+	if err != nil {
+		t.Errorf("FindTickets(needs review): %s", err)
+	}
+	if len(got) != 5 {
+		t.Errorf("expected 5 results for quoted value search, got %d: %#v", len(got), got)
+	}
+}
+
+func TestFindTicketsNoMatchFieldsError(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	_, err := c.FindTickets(map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "no match fields") {
+		t.Errorf("expected error for empty match fields, got: %s", err)
+	}
+}
+
+func TestFindTicketsUnknownFieldName(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	_, err := c.FindTickets(map[string]string{"unknown": "v"})
+	if err == nil || !strings.Contains(err.Error(), "unknown custom field") {
+		t.Errorf("expected unknown custom field error, got: %s", err)
+	}
+}
+
+func TestNewClientWithDuplicateFieldID(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.NewServeMux())
+	defer ts.Close()
+	nameToID := map[string]int64{
+		"a": 1,
+		"b": 1,
+	}
+	_, err := NewClient(ts.URL, apiTokenEmail, apiToken, nameToID)
+	if err == nil || !strings.Contains(err.Error(), "duplicate field ID") {
+		t.Errorf("expected duplicate field ID error, got: %s", err)
+	}
+}
+
+func TestNewClientBaseURLJoin(t *testing.T) {
+	t.Parallel()
+
+	base := "http://example.test"
+	_, err := NewClient(base+"/", apiTokenEmail, apiToken, map[string]int64{})
+	if err != nil {
+		t.Errorf("NewClient with trailing slash failed: %s", err)
+	}
+	_, err = NewClient(base, apiTokenEmail, apiToken, map[string]int64{})
+	if err != nil {
+		t.Errorf("NewClient without trailing slash failed: %s", err)
+	}
+}
+
+func TestCreateTicketSetsRequesterNameToEmail(t *testing.T) {
+	t.Parallel()
+
+	c, srv := startMockClient(t)
+
+	id, err := c.CreateTicket("alice@example.com", "S", "B", nil)
+	if err != nil {
+		t.Errorf("CreateTicket(alice@example.com): %s", err)
+	}
+
+	got, ok := srv.GetTicket(id)
+	if !ok {
+		t.Errorf("ticket id %d not found in server", id)
+		return
+	}
+	if got.Requester.Email != "alice@example.com" || got.Requester.Name != "alice@example.com" {
+		t.Errorf("requester mismatch for ticket %d: %#v (want Email=%q Name=%q)", id, got.Requester, "alice@example.com", "alice@example.com")
+	}
+}
+
+func TestAddCommentEmptyBody422(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	id, err := c.CreateTicket("a@example.com", "s", "init", nil)
+	if err != nil {
+		t.Errorf("CreateTicket(a@example.com): %s", err)
+	}
+
+	err = c.AddComment(id, "", true)
+	if err == nil || !strings.Contains(err.Error(), "status 422") {
+		t.Errorf("expected HTTP 422 for empty comment body on ticket %d, got: %s", id, err)
+	}
+}
+
+func TestFindTicketsNoResults(t *testing.T) {
+	t.Parallel()
+
+	c, _ := startMockClient(t)
+
+	_, err := c.CreateTicket("u@example.com", "s", "b", map[string]string{"reviewStatus": "approved"})
+	if err != nil {
+		t.Errorf("creating ticket with reviewStatus=approved: %s", err)
+	}
+	got, err := c.FindTickets(map[string]string{"reviewStatus": "pending"})
+	if err != nil {
+		t.Errorf("FindTickets(reviewStatus=pending): %s", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 results, got %d: %#v", len(got), got)
+	}
+}
+
+func TestFindTicketsPaginationFollowed(t *testing.T) {
+	t.Parallel()
+
+	store := zendeskfake.NewStore(0)
+	fake := zendeskfake.NewServer(apiTokenEmail, apiToken, store)
+
+	inner := fake.Handler()
+	var searchHits int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(zendeskfake.SearchJSONPath, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&searchHits, 1)
+		inner.ServeHTTP(w, r)
+	})
+	mux.Handle(zendeskfake.TicketsJSONPath, inner)
+	mux.Handle(zendeskfake.TicketsPath, inner)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL, apiTokenEmail, apiToken, map[string]int64{"reviewStatus": 111})
+	if err != nil {
+		t.Errorf("NewClient(%q): %s", ts.URL, err)
+	}
+
+	for i := range 5 {
+		if _, err := c.CreateTicket(
+			fmt.Sprintf("u%d@example.com", i),
+			fmt.Sprintf("s%d", i),
+			"body",
+			map[string]string{"reviewStatus": "needs review"},
+		); err != nil {
+			t.Errorf("create ticket %d: %s", i, err)
+		}
+	}
+
+	got, err := c.FindTickets(map[string]string{"reviewStatus": "needs review"})
+	if err != nil {
+		t.Errorf("FindTickets(needs review): %s", err)
+	}
+	if len(got) != 5 {
+		t.Errorf("expected 5 merged results from paginated search, got %d: %#v", len(got), got)
+	}
+
+	if atomic.LoadInt32(&searchHits) < 3 {
+		t.Errorf("expected >= 3 /search.json requests due to pagination, got %d", searchHits)
+	}
+}
+
+func TestFindTicketsHTTP400(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/search.json", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad query", http.StatusBadRequest)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL, apiTokenEmail, apiToken, map[string]int64{"reviewStatus": 111})
+	if err != nil {
+		t.Errorf("NewClient(%q): %s", ts.URL, err)
+	}
+	_, err = c.FindTickets(map[string]string{"reviewStatus": "needs review"})
+	if err == nil || !strings.Contains(err.Error(), "status 400") {
+		t.Errorf("expected HTTP 400 from search, got: %s", err)
+	}
+}
+
+func TestFindTicketsHTTP500(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/search.json", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL, apiTokenEmail, apiToken, map[string]int64{"reviewStatus": 111})
+	if err != nil {
+		t.Errorf("NewClient(%q): %s", ts.URL, err)
+	}
+	_, err = c.FindTickets(map[string]string{"reviewStatus": "needs review"})
+	if err == nil || !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("expected HTTP 500 from search, got: %s", err)
+	}
+}

--- a/test/zendeskfake/zendeskfake.go
+++ b/test/zendeskfake/zendeskfake.go
@@ -1,0 +1,433 @@
+package zendeskfake
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"maps"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	defaultTicketCapacity = 200
+	searchPageSize        = 2
+	apiPrefix             = "/api/v2"
+	TicketsJSONPath       = apiPrefix + "/tickets.json"
+	SearchJSONPath        = apiPrefix + "/search.json"
+	TicketsPath           = apiPrefix + "/tickets/"
+)
+
+var (
+	// ticketPathRegexp matches the tickets path with an ID at the end, e.g.
+	// /api/v2/tickets/123.json. It captures the ID as the first group.
+	ticketPathRegexp = regexp.MustCompile("^" + regexp.QuoteMeta(TicketsPath) + `(\d+)\.json$`)
+
+	// customFieldRegexp matches custom fields in the format
+	// custom_field_<id>:"value" or custom_field_<id>:value where <id> is the
+	// field ID and "value" is the field value, allowing for both quoted and
+	// unquoted values. It captures the field ID as the first group and the
+	// value as the second group.
+	customFieldRegexp = regexp.MustCompile(`custom_field_(\d+):("[^"]+"|\S+)`)
+)
+
+// Requester represents a requester in a Zendesk ticket.
+type Requester struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// Comment represents a comment in a Zendesk ticket.
+type Comment struct {
+	Body   string `json:"body"`
+	Public bool   `json:"public"`
+}
+
+// Ticket represents all the fields of a Zendesk ticket.
+type Ticket struct {
+	ID           int64            `json:"id"`
+	Requester    Requester        `json:"requester"`
+	Subject      string           `json:"subject"`
+	Comments     []Comment        `json:"comments"`
+	CustomFields map[int64]string `json:"custom_fields"`
+}
+
+// Store is a thread-safe in-memory store for tickets. It uses a stack to store
+// the tickets and a map to quickly access them by ID. The stack has a fixed
+// capacity, and when it is full, the oldest ticket is removed to make room.
+type Store struct {
+	sync.Mutex
+	nextID int64
+	cap    int
+	stack  []*Ticket
+	byID   map[int64]*Ticket
+}
+
+func newStore() *Store {
+	return &Store{
+		nextID: 1,
+		cap:    defaultTicketCapacity,
+		stack:  make([]*Ticket, 0, defaultTicketCapacity),
+		byID:   make(map[int64]*Ticket, defaultTicketCapacity),
+	}
+}
+
+// NewStore creates a new Store with the specified capacity. If no capacity is
+// specified, it defaults to 200 tickets.
+func NewStore(capacity int) *Store {
+	s := newStore()
+	if capacity > 0 {
+		s.cap = capacity
+	}
+	return s
+}
+
+func (s *Store) push(t *Ticket) int64 {
+	s.Lock()
+	defer s.Unlock()
+
+	if len(s.stack) >= s.cap {
+		oldest := s.stack[0]
+		delete(s.byID, oldest.ID)
+		s.stack = s.stack[1:]
+	}
+
+	t.ID = s.nextID
+	s.nextID++
+
+	s.stack = append(s.stack, t)
+	s.byID[t.ID] = t
+	return t.ID
+}
+
+func (s *Store) addComment(id int64, c Comment) error {
+	s.Lock()
+	defer s.Unlock()
+
+	current, ok := s.byID[id]
+	if !ok {
+		return errors.New("ticket not found")
+	}
+
+	current.Comments = append(current.Comments, c)
+	return nil
+}
+
+func checkBasicAuth(r *http.Request, wantEmail, wantToken string) bool {
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Basic ") {
+		return false
+	}
+	decodedBytes, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+	if err != nil {
+		return false
+	}
+	decoded := string(decodedBytes)
+	expected := fmt.Sprintf("%s/token:%s", wantEmail, wantToken)
+	return decoded == expected
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("failed to marshal response: %s", err)
+		http.Error(w, "marshal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, err = w.Write(bytes)
+	if err != nil {
+		log.Printf("failed to write response: %s", err)
+		http.Error(w, "write error", http.StatusInternalServerError)
+		return
+	}
+}
+
+type Server struct {
+	tokenUser string
+	token     string
+	store     *Store
+}
+
+// NewServer creates a new Server with the specified user and token. If no store
+// is provided, it creates a new Store with the default capacity.
+func NewServer(tokenEmail, apiToken string, s *Store) *Server {
+	if s == nil {
+		s = newStore()
+	}
+	return &Server{
+		tokenUser: tokenEmail,
+		token:     apiToken,
+		store:     s,
+	}
+}
+
+func (s *Server) auth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ok := checkBasicAuth(r, s.tokenUser, s.token)
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// POST /api/v2/tickets.json
+func (s *Server) createTicket(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Ticket struct {
+			Requester Requester `json:"requester"`
+			Subject   string    `json:"subject"`
+			Comment   Comment   `json:"comment"`
+			Custom    []struct {
+				ID    int64 `json:"id"`
+				Value any   `json:"value"`
+			} `json:"custom_fields"`
+		} `json:"ticket"`
+	}
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+
+	if req.Ticket.Subject == "" || req.Ticket.Comment.Body == "" || req.Ticket.Requester.Email == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"error":       "RecordInvalid",
+			"description": "Record validation errors",
+		})
+		return
+	}
+
+	newTicket := &Ticket{
+		Requester:    req.Ticket.Requester,
+		Subject:      req.Ticket.Subject,
+		Comments:     []Comment{req.Ticket.Comment},
+		CustomFields: make(map[int64]string),
+	}
+
+	for _, cf := range req.Ticket.Custom {
+		newTicket.CustomFields[cf.ID] = fmt.Sprint(cf.Value)
+	}
+
+	ticketID := s.store.push(newTicket)
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"ticket": map[string]int64{"id": ticketID},
+	})
+}
+
+// PUT /api/v2/tickets/{id}.json
+func (s *Server) updateTicket(w http.ResponseWriter, r *http.Request) {
+	match := ticketPathRegexp.FindStringSubmatch(r.URL.Path)
+	if len(match) != 2 {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error":       "RecordNotFound",
+			"description": "Not found",
+		})
+		return
+	}
+
+	id, err := strconv.ParseInt(match[1], 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error":       "RecordNotFound",
+			"description": "Not found",
+		})
+		return
+	}
+
+	var req struct {
+		Ticket struct {
+			Comment Comment `json:"comment"`
+		} `json:"ticket"`
+	}
+
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+
+	if req.Ticket.Comment.Body == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"error":       "RecordInvalid",
+			"description": "Record validation errors",
+			"details": map[string]any{
+				"comment": []map[string]string{
+					{"description": "Comment body can't be blank"},
+				},
+			},
+		})
+		return
+	}
+
+	err = s.store.addComment(id, req.Ticket.Comment)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error":       "RecordNotFound",
+			"description": "Not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ticket": map[string]int64{"id": id},
+	})
+}
+
+// GET /api/v2/search.json?query=...&page=...
+func (s *Server) search(w http.ResponseWriter, r *http.Request) {
+	queryParam := r.URL.Query().Get("query")
+
+	if !strings.Contains(queryParam, "type:ticket") {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"results":   []any{},
+			"next_page": nil,
+			"count":     0,
+		})
+		return
+	}
+
+	type criterion struct {
+		fieldID int64
+		value   string
+	}
+
+	if strings.Contains(queryParam, "custom_field_") && !customFieldRegexp.MatchString(queryParam) {
+		http.Error(w, "invalid custom field id", http.StatusBadRequest)
+		return
+	}
+
+	var criteria []criterion
+	matches := customFieldRegexp.FindAllStringSubmatch(queryParam, -1)
+	for _, match := range matches {
+		fieldID, err := strconv.ParseInt(match[1], 10, 64)
+		if err != nil {
+			http.Error(w, "invalid custom field id", http.StatusBadRequest)
+			return
+		}
+		criteria = append(criteria, criterion{
+			fieldID: fieldID,
+			value:   strings.Trim(match[2], `"`),
+		})
+	}
+
+	s.store.Lock()
+	defer s.store.Unlock()
+
+	type resultRow struct {
+		id     int64
+		fields []map[string]any
+	}
+
+	var resultRows []resultRow
+	resultRows = make([]resultRow, 0, len(s.store.stack))
+
+	for _, ticket := range s.store.stack {
+		allMatch := true
+		for _, c := range criteria {
+			curr, ok := ticket.CustomFields[c.fieldID]
+			if !ok || curr != c.value {
+				allMatch = false
+				break
+			}
+		}
+		if !allMatch {
+			continue
+		}
+
+		var cf []map[string]any
+		for id, v := range ticket.CustomFields {
+			cf = append(cf, map[string]any{"id": id, "value": v})
+		}
+		resultRows = append(resultRows, resultRow{id: ticket.ID, fields: cf})
+	}
+
+	sort.Slice(resultRows, func(i, j int) bool {
+		return resultRows[i].id > resultRows[j].id
+	})
+
+	const pageSize = 2
+
+	page := 1
+	pageStr := r.URL.Query().Get("page")
+	if pageStr != "" {
+		pageNum, err := strconv.Atoi(pageStr)
+		if err == nil && pageNum > 0 {
+			page = pageNum
+		}
+	}
+
+	total := len(resultRows)
+	start := min((page-1)*pageSize, total)
+	end := min(start+pageSize, total)
+
+	buildNextPageURL := func(currPage int) *string {
+		nextPage := currPage + 1
+		if (nextPage-1)*pageSize >= total {
+			return nil
+		}
+		u := url.URL{
+			Scheme: "http",
+			Host:   r.Host,
+			Path:   r.URL.Path,
+		}
+		q := url.Values{}
+		q.Set("query", queryParam)
+		q.Set("page", strconv.Itoa(nextPage))
+		u.RawQuery = q.Encode()
+		s := u.String()
+		return &s
+	}
+
+	encodedResults := make([]any, 0, end-start)
+	for _, row := range resultRows[start:end] {
+		encodedResults = append(encodedResults, map[string]any{
+			"id":            row.id,
+			"custom_fields": row.fields,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"results":   encodedResults,
+		"next_page": buildNextPageURL(page),
+		"count":     total,
+	})
+}
+
+// Handler returns an HTTP handler that serves the Zendesk fake API.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle(TicketsJSONPath, s.auth(http.HandlerFunc(s.createTicket)))
+	mux.Handle(SearchJSONPath, s.auth(http.HandlerFunc(s.search)))
+	mux.Handle(TicketsPath, s.auth(http.HandlerFunc(s.updateTicket)))
+	return mux
+}
+
+// GetTicket retrieves a ticket by its ID directly from the inner store. It
+// returns a copy of the ticket to ensure that the original ticket in the store
+// is never modified. If the ticket does not exist, it returns false.
+func (s *Server) GetTicket(id int64) (Ticket, bool) {
+	s.store.Lock()
+	defer s.store.Unlock()
+	t, ok := s.store.byID[id]
+	if !ok {
+		return Ticket{}, false
+	}
+	cp := *t
+	cp.CustomFields = make(map[int64]string, len(t.CustomFields))
+	maps.Copy(cp.CustomFields, t.CustomFields)
+	cp.Comments = append([]Comment(nil), t.Comments...)
+	return cp, true
+}

--- a/test/zendeskfake/zendeskfake_test.go
+++ b/test/zendeskfake/zendeskfake_test.go
@@ -1,0 +1,732 @@
+package zendeskfake
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	apiTokenEmail = "tester@example.com"
+	apiToken      = "someToken"
+)
+
+func basicAuthHeader(email, token string) string {
+	raw := email + "/token:" + token
+	enc := base64.StdEncoding.EncodeToString([]byte(raw))
+	return "Basic " + enc
+}
+
+func startTestServer(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+
+	srv := NewServer(apiTokenEmail, apiToken, nil)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return srv, ts
+}
+
+func startTestServerWithStore(t *testing.T, store *Store) (*Server, *httptest.Server) {
+	t.Helper()
+
+	srv := NewServer(apiTokenEmail, apiToken, store)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return srv, ts
+}
+
+func doJSON(t *testing.T, method, urlStr, authHeader string, body []byte, setContentType bool) (*http.Response, []byte) {
+	t.Helper()
+
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, urlStr, reader)
+	if err != nil {
+		t.Errorf("creating request %s %s failed: %s", method, urlStr, err)
+		return nil, nil
+	}
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	req.Header.Set("Accept", "application/json")
+	if setContentType {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Errorf("performing %s %s failed: %s", method, urlStr, err)
+		return nil, nil
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("reading response body for %s %s failed: %s", method, urlStr, err)
+		err = resp.Body.Close()
+		if err != nil {
+			t.Errorf("closing response body for %s %s failed: %s", method, urlStr, err)
+		}
+		return resp, nil
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		t.Errorf("closing response body for %s %s failed: %s", method, urlStr, err)
+	}
+	return resp, respBody
+}
+
+func postTicket(t *testing.T, baseURL string, body []byte) (*http.Response, []byte) {
+	t.Helper()
+
+	return doJSON(t, http.MethodPost, baseURL+TicketsJSONPath, basicAuthHeader(apiTokenEmail, apiToken), body, true)
+}
+
+func putComment(t *testing.T, baseURL string, id int64, body []byte) (*http.Response, []byte) {
+	t.Helper()
+
+	endpoint := fmt.Sprintf("%s%s%d.json", baseURL, TicketsPath, id)
+	return doJSON(t, http.MethodPut, endpoint, basicAuthHeader(apiTokenEmail, apiToken), body, true)
+}
+
+func getSearch(t *testing.T, baseURL, query string) (*http.Response, []byte) {
+	t.Helper()
+
+	v := url.Values{}
+	v.Set("query", query)
+	urlStr := baseURL + SearchJSONPath + "?" + v.Encode()
+	return doJSON(t, http.MethodGet, urlStr, basicAuthHeader(apiTokenEmail, apiToken), nil, false)
+}
+
+func createTicketAndReturnID(t *testing.T, baseURL string) int64 {
+	t.Helper()
+
+	payload := []byte(`{
+		"ticket": {
+			"requester": {"name":"R","email":"r@example.com"},
+			"subject": "S",
+			"comment": {"body":"B","public":true},
+			"custom_fields": []
+		}
+	}`)
+	resp, body := postTicket(t, baseURL, payload)
+	if resp == nil {
+		t.Errorf("unexpected nil response while creating ticket")
+		return 0
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("create ticket: expected HTTP %d, got HTTP %d body=%s", http.StatusCreated, resp.StatusCode, string(body))
+	}
+
+	var out struct {
+		Ticket struct {
+			ID int64 `json:"id"`
+		} `json:"ticket"`
+	}
+	err := json.Unmarshal(body, &out)
+	if err != nil {
+		t.Errorf("unmarshalling create ticket response failed: %s", err)
+		return 0
+	}
+	return out.Ticket.ID
+}
+
+func TestAuthRequired(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	resp, _ := doJSON(t, http.MethodGet, ts.URL+SearchJSONPath+"?query=type:ticket", "", nil, false)
+	if resp == nil {
+		t.Errorf("unexpected nil response for unauthorized request")
+		return
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthorized request: expected HTTP %d, got HTTP %d", http.StatusUnauthorized, resp.StatusCode)
+	}
+}
+
+func TestAuthWrongCredentialsAllEndpoints(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	validCreate := []byte(`{"ticket":{"requester":{"name":"n","email":"e@example.com"},"subject":"s","comment":{"body":"b","public":true},"custom_fields":[]}}`)
+	validUpdate := []byte(`{"ticket":{"comment":{"body":"x","public":false}}}`)
+
+	id := createTicketAndReturnID(t, ts.URL)
+
+	type ep struct {
+		name   string
+		method string
+		url    string
+		body   []byte
+	}
+	endpoints := []ep{
+		{"POST /tickets.json", http.MethodPost, ts.URL + TicketsJSONPath, validCreate},
+		{"GET  /search.json", http.MethodGet, ts.URL + SearchJSONPath + "?query=type:ticket", nil},
+		{"PUT  /tickets/{id}.json", http.MethodPut, ts.URL + TicketsPath + strconv.FormatInt(id, 10) + ".json", validUpdate},
+	}
+
+	for _, e := range endpoints {
+		t.Run(e.name+"/wrong-credentials", func(t *testing.T) {
+			resp, _ := doJSON(t, e.method, e.url, basicAuthHeader("wrong@example.com", "wrong"), e.body, true)
+			if resp == nil {
+				t.Errorf("%s wrong-credentials: unexpected nil response", e.name)
+				return
+			}
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("%s wrong-credentials: expected HTTP %d, got HTTP %d", e.name, http.StatusUnauthorized, resp.StatusCode)
+			}
+		})
+		t.Run(e.name+"/malformed-header", func(t *testing.T) {
+			resp, _ := doJSON(t, e.method, e.url, "Basic malformed-header", e.body, true)
+			if resp == nil {
+				t.Errorf("%s malformed-header: unexpected nil response", e.name)
+				return
+			}
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("%s malformed-header: expected HTTP %d, got HTTP %d", e.name, http.StatusUnauthorized, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestCreateTicketSuccessAndStored(t *testing.T) {
+	t.Parallel()
+
+	srv, ts := startTestServer(t)
+
+	payload := []byte(`{
+		"ticket": {
+			"requester": {"name":"Alice","email":"alice@example.com"},
+			"subject": "Subject A",
+			"comment": {"body":"Hello world","public":true},
+			"custom_fields": [
+				{"id": 111, "value":"pending"},
+				{"id": 222, "value":"Acme"}
+			]
+		}
+	}`)
+
+	resp, body := postTicket(t, ts.URL, payload)
+	if resp == nil {
+		t.Errorf("create ticket: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("create ticket: expected HTTP %d, got HTTP %d body=%s", http.StatusCreated, resp.StatusCode, string(body))
+	}
+
+	var res struct {
+		Ticket struct {
+			ID int64 `json:"id"`
+		} `json:"ticket"`
+	}
+	err := json.Unmarshal(body, &res)
+	if err != nil {
+		t.Errorf("unmarshal create response failed: %s", err)
+		return
+	}
+	if res.Ticket.ID == 0 {
+		t.Errorf("create ticket: expected non-zero id")
+		return
+	}
+
+	got, ok := srv.GetTicket(res.Ticket.ID)
+	if !ok {
+		t.Errorf("ticket id %d not found in store", res.Ticket.ID)
+		return
+	}
+	if got.Subject != "Subject A" {
+		t.Errorf("ticket subject mismatch: got %q, want %q", got.Subject, "Subject A")
+	}
+	if len(got.Comments) != 1 || got.Comments[0].Body != "Hello world" || !got.Comments[0].Public {
+		t.Errorf("ticket comment stored incorrectly: %#v (want one public 'Hello world' comment)", got.Comments)
+	}
+	if got.CustomFields[111] != "pending" || got.CustomFields[222] != "Acme" {
+		t.Errorf("ticket custom fields stored incorrectly: %#v (want 111=%q 222=%q)", got.CustomFields, "pending", "Acme")
+	}
+}
+
+func TestCreateTicketUnhappyPaths(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	cases := []struct {
+		name       string
+		body       []byte
+		wantStatus int
+	}{
+		{
+			name:       "bad json",
+			body:       []byte(`{"ticket": { "requester": {"name":"A","email":"a@example.com"},`),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing subject",
+			body: []byte(`{
+				"ticket": {
+					"requester": {"name":"Bob","email":"bob@example.com"},
+					"comment": {"body":"Hi","public":true}
+				}
+			}`),
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "missing email",
+			body: []byte(`{
+				"ticket": {
+					"requester": {"name":"NoEmail"},
+					"subject": "S",
+					"comment": {"body":"B","public":true}
+				}
+			}`),
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "missing comment body",
+			body: []byte(`{
+				"ticket": {
+					"requester": {"name":"N","email":"n@example.com"},
+					"subject": "S",
+					"comment": {"public":true}
+				}
+			}`),
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name:       "empty body",
+			body:       nil,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp, body := postTicket(t, ts.URL, tc.body)
+			if resp == nil {
+				t.Errorf("create ticket (%s): unexpected nil response", tc.name)
+				return
+			}
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("create ticket (%s): expected HTTP %d, got HTTP %d body=%s", tc.name, tc.wantStatus, resp.StatusCode, string(body))
+			}
+		})
+	}
+}
+
+func TestUpdateTicketAddsComment(t *testing.T) {
+	t.Parallel()
+
+	srv, ts := startTestServer(t)
+
+	id := createTicketAndReturnID(t, ts.URL)
+
+	updatePayload := []byte(`{
+		"ticket": {
+			"comment": {"body":"Follow-up","public":false}
+		}
+	}`)
+	resp, body := putComment(t, ts.URL, id, updatePayload)
+	if resp == nil {
+		t.Errorf("update ticket: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("update ticket: expected HTTP %d, got HTTP %d body=%s", http.StatusOK, resp.StatusCode, string(body))
+	}
+
+	got, ok := srv.GetTicket(id)
+	if !ok {
+		t.Errorf("update ticket: id %d not found in store", id)
+		return
+	}
+	if len(got.Comments) != 2 {
+		t.Errorf("update ticket: expected 2 comments, got %d", len(got.Comments))
+	} else {
+		if got.Comments[1].Body != "Follow-up" || got.Comments[1].Public {
+			t.Errorf("update ticket: second comment incorrect: %#v (want body=%q, public=false)", got.Comments[1], "Follow-up")
+		}
+	}
+}
+
+func TestUpdateTicketUnhappyPaths(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	validID := createTicketAndReturnID(t, ts.URL)
+
+	type tc struct {
+		name       string
+		method     string
+		path       string
+		body       []byte
+		wantStatus int
+	}
+	tests := []tc{
+		{
+			name:       "bad id path (non-numeric)",
+			method:     http.MethodPut,
+			path:       TicketsPath + "abc.json",
+			body:       []byte(`{"ticket":{"comment":{"body":"x","public":false}}}`),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "missing id segment",
+			method:     http.MethodPut,
+			path:       TicketsPath + ".json",
+			body:       []byte(`{"ticket":{"comment":{"body":"x","public":true}}}`),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "unknown id",
+			method:     http.MethodPut,
+			path:       TicketsPath + "999999.json",
+			body:       []byte(`{"ticket":{"comment":{"body":"x","public":true}}}`),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "bad json",
+			method:     http.MethodPut,
+			path:       TicketsPath + strconv.FormatInt(validID, 10) + ".json",
+			body:       []byte(`{"ticket": {"comment":`),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing comment body",
+			method:     http.MethodPut,
+			path:       TicketsPath + strconv.FormatInt(validID, 10) + ".json",
+			body:       []byte(`{"ticket":{"comment":{"public":true}}}`),
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp, body := doJSON(t, tt.method, ts.URL+tt.path, basicAuthHeader(apiTokenEmail, apiToken), tt.body, true)
+			if resp == nil {
+				t.Errorf("%s: unexpected nil response", tt.name)
+				return
+			}
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("%s: expected HTTP %d, got HTTP %d body=%s", tt.name, tt.wantStatus, resp.StatusCode, string(body))
+			}
+
+			if tt.wantStatus == http.StatusNotFound && (strings.Contains(tt.name, "bad id path") || strings.Contains(tt.name, "missing id")) {
+				ct := resp.Header.Get("Content-Type")
+				if !strings.HasPrefix(ct, "application/json") {
+					t.Errorf("%s: expected Content-Type application/json, got %q", tt.name, ct)
+				}
+				var payload struct {
+					Error       string `json:"error"`
+					Description string `json:"description"`
+				}
+				err := json.Unmarshal(body, &payload)
+				if err != nil {
+					t.Errorf("%s: unmarshal 404 payload failed: %s (body=%q)", tt.name, err, string(body))
+				}
+				if payload.Error != "RecordNotFound" || payload.Description != "Not found" {
+					t.Errorf("%s: unexpected 404 payload: %#v", tt.name, payload)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchNoTypeTicketReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	resp, body := getSearch(t, ts.URL, "custom_field_1:foo")
+	if resp == nil {
+		t.Errorf("search without type: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("search without type: expected HTTP %d, got HTTP %d", http.StatusOK, resp.StatusCode)
+	}
+
+	var out struct {
+		Results []any `json:"results"`
+		Next    any   `json:"next_page"`
+	}
+	err := json.Unmarshal(body, &out)
+	if err != nil {
+		t.Errorf("search without type: unmarshal response failed: %s", err)
+	}
+	if len(out.Results) != 0 {
+		t.Errorf("search without type: expected 0 results, got %d", len(out.Results))
+	}
+}
+
+func TestSearchByCustomFieldsQuotedAndUnquoted(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	payload1 := []byte(`{
+		"ticket": {
+			"requester": {"name":"A","email":"a@example.com"},
+			"subject": "S1",
+			"comment": {"body":"B1","public":true},
+			"custom_fields": [
+				{"id": 111, "value": "pending"},
+				{"id": 222, "value": "Acme"}
+			]
+		}
+	}`)
+	resp, body := postTicket(t, ts.URL, payload1)
+	if resp == nil {
+		t.Errorf("create ticket 1: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("create ticket 1: expected HTTP %d, got HTTP %d body=%s", http.StatusCreated, resp.StatusCode, string(body))
+	}
+
+	payload2 := []byte(`{
+		"ticket": {
+			"requester": {"name":"B","email":"b@example.com"},
+			"subject": "S2",
+			"comment": {"body":"B2","public":true},
+			"custom_fields": [
+				{"id": 111, "value": "pending review"},
+				{"id": 222, "value": "Acme"}
+			]
+		}
+	}`)
+	resp, body = postTicket(t, ts.URL, payload2)
+	if resp == nil {
+		t.Errorf("create ticket 2: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("create ticket 2: expected HTTP %d, got HTTP %d body=%s", http.StatusCreated, resp.StatusCode, string(body))
+	}
+
+	resp, body = getSearch(t, ts.URL, `type:ticket custom_field_111:pending`)
+	if resp == nil {
+		t.Errorf("search unquoted: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("search unquoted: expected HTTP %d, got HTTP %d", http.StatusOK, resp.StatusCode)
+	}
+	var res1 struct{ Results []any }
+	err := json.Unmarshal(body, &res1)
+	if err != nil {
+		t.Errorf("search unquoted: unmarshal failed: %s", err)
+	}
+	if len(res1.Results) != 1 {
+		t.Errorf("search unquoted: expected 1 result, got %d", len(res1.Results))
+	}
+
+	resp, body = getSearch(t, ts.URL, `type:ticket custom_field_111:"pending review"`)
+	if resp == nil {
+		t.Errorf("search quoted: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("search quoted: expected HTTP %d, got HTTP %d", http.StatusOK, resp.StatusCode)
+	}
+	var res2 struct{ Results []any }
+	err = json.Unmarshal(body, &res2)
+	if err != nil {
+		t.Errorf("search quoted: unmarshal failed: %s", err)
+	}
+	if len(res2.Results) != 1 {
+		t.Errorf("search quoted: expected 1 result, got %d", len(res2.Results))
+	}
+}
+
+func TestSearchNewestFirstOrder(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	for i := 1; i <= 3; i++ {
+		payload := fmt.Sprintf(`{
+			"ticket": {
+				"requester": {"name":"U%d","email":"u%d@example.com"},
+				"subject": "S%d",
+				"comment": {"body":"B%d","public":true},
+				"custom_fields": [
+					{"id": 999, "value": "x"}
+				]
+			}
+		}`, i, i, i, i)
+
+		resp, body := postTicket(t, ts.URL, []byte(payload))
+		if resp == nil {
+			t.Errorf("create ticket %d: unexpected nil response", i)
+			return
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("create ticket %d: expected HTTP %d, got HTTP %d body=%s", i, http.StatusCreated, resp.StatusCode, string(body))
+			return
+		}
+	}
+
+	type item struct {
+		ID int64 `json:"id"`
+	}
+	type page struct {
+		Results []item  `json:"results"`
+		Next    *string `json:"next_page"`
+	}
+
+	var all []item
+
+	resp, body := getSearch(t, ts.URL, `type:ticket custom_field_999:x`)
+	if resp == nil {
+		t.Errorf("initial search: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("initial search: expected HTTP %d, got HTTP %d", http.StatusOK, resp.StatusCode)
+		return
+	}
+	var pg page
+	err := json.Unmarshal(body, &pg)
+	if err != nil {
+		t.Errorf("initial search: unmarshal failed: %s", err)
+		return
+	}
+	all = append(all, pg.Results...)
+
+	next := pg.Next
+	for next != nil && *next != "" {
+		nextURL := *next
+		if strings.HasPrefix(nextURL, "/") {
+			nextURL = ts.URL + nextURL
+		}
+		resp, body = doJSON(t, http.MethodGet, nextURL, basicAuthHeader(apiTokenEmail, apiToken), nil, false)
+		if resp == nil {
+			t.Errorf("paginated search: unexpected nil response on next_page")
+			return
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("paginated search: expected HTTP %d on next_page, got HTTP %d", http.StatusOK, resp.StatusCode)
+			return
+		}
+		var np page
+		err = json.Unmarshal(body, &np)
+		if err != nil {
+			t.Errorf("paginated search: unmarshal next_page failed: %s", err)
+			return
+		}
+		all = append(all, np.Results...)
+		next = np.Next
+	}
+
+	if len(all) != 3 {
+		t.Errorf("expected 3 results, got %d", len(all))
+		return
+	}
+	if !(all[0].ID > all[1].ID && all[1].ID > all[2].ID) {
+		t.Errorf("order incorrect (want strictly descending IDs): %#v", all)
+	}
+}
+
+func TestCapacityEviction(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(2)
+	srv, ts := startTestServerWithStore(t, store)
+
+	for i := 1; i <= 3; i++ {
+		payload := fmt.Sprintf(`{
+			"ticket": {
+				"requester": {"name":"E%d","email":"e%d@example.com"},
+				"subject": "Sub%d",
+				"comment": {"body":"C%d","public":true},
+				"custom_fields": [
+					{"id": 111, "value": "v%d"}
+				]
+			}
+		}`, i, i, i, i, i)
+
+		resp, body := postTicket(t, ts.URL, []byte(payload))
+		if resp == nil {
+			t.Errorf("unexpected nil response creating ticket %d", i)
+			return
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("create ticket %d expected HTTP %d, got HTTP %d body=%s", i, http.StatusCreated, resp.StatusCode, string(body))
+		}
+	}
+
+	_, ok := srv.GetTicket(1)
+	if ok {
+		t.Errorf("expected ticket 1 to be evicted")
+	}
+	_, ok = srv.GetTicket(2)
+	if !ok {
+		t.Errorf("expected ticket 2 to remain")
+	}
+	_, ok = srv.GetTicket(3)
+	if !ok {
+		t.Errorf("expected ticket 3 to remain")
+	}
+}
+
+func TestSearchInvalidCustomFieldID(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+	_ = createTicketAndReturnID(t, ts.URL)
+
+	resp, body := getSearch(t, ts.URL, `type:ticket custom_field_abc:foo`)
+	if resp == nil {
+		t.Errorf("invalid custom field id search: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("invalid custom field id search: expected HTTP %d, got HTTP %d body=%s", http.StatusBadRequest, resp.StatusCode, string(body))
+	}
+}
+
+func TestSearchMissingQueryParam(t *testing.T) {
+	t.Parallel()
+
+	_, ts := startTestServer(t)
+
+	resp, body := doJSON(t, http.MethodGet, ts.URL+SearchJSONPath, basicAuthHeader(apiTokenEmail, apiToken), nil, false)
+	if resp == nil {
+		t.Errorf("missing query param search: unexpected nil response")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("missing query param search: expected HTTP %d, got HTTP %d", http.StatusOK, resp.StatusCode)
+	}
+
+	var out struct {
+		Results []any `json:"results"`
+		Next    any   `json:"next_page"`
+	}
+	err := json.Unmarshal(body, &out)
+	if err != nil {
+		t.Errorf("missing query param search: unmarshal failed: %s", err)
+	}
+	if len(out.Results) != 0 {
+		t.Errorf("missing query param search: expected 0 results, got %d", len(out.Results))
+	}
+}


### PR DESCRIPTION
**sfe/zendesk:** Add a Zendesk client implementation that supports all functionality required for storing and loading rate limit override requests.

**test/zendeskfake:** Add a fake Zendesk server implementation supporting all behavior expected by the sfe/zendesk client.

**cmd/sfe:** Add configuration to support an optional Zendesk client in the SFE.

**sfe:** Add the optional Zendesk client to SelfServiceFrontEndImpl and its constructor, NewSelfServiceFrontEndImpl.

**ratelimits/overriderequests:** Add helpers for creating Zendesk tickets for supported rate limit override requests. Include expected display names for Zendesk custom fields related to override request storage. These match the documentation I've drafted for our SRE team.

Closes #8164