### PR TITLE
wfe: add /get/certinfo

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1636,11 +1636,12 @@ func (wfe *WebFrontEndImpl) Authorization(
 func (wfe *WebFrontEndImpl) CertificateInfo(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
 	serial := request.URL.Path
 	if !core.ValidSerial(serial) {
+		fmt.Println("oh no ", serial, "x")
 		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
+		return
 	}
 	metadata, err := wfe.sa.GetSerialMetadata(ctx, &sapb.Serial{Serial: serial})
 	if err != nil {
-		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
 		if err != nil {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Error getting certificate metadata"), err)
 			return
@@ -1651,7 +1652,7 @@ func (wfe *WebFrontEndImpl) CertificateInfo(ctx context.Context, logEvent *web.R
 	}{
 		NotAfter: metadata.Expires.AsTime(),
 	}
-	wfe.writeJsonResponse(response, logEvent, http.StatusOK, certInfoStruct)
+	err = wfe.writeJsonResponse(response, logEvent, http.StatusOK, certInfoStruct)
 	if err != nil {
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling certInfoStruct"), err)
 		return

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -69,8 +69,9 @@ const (
 	renewalInfoPath   = "/acme/renewal-info/"
 
 	// Non-ACME paths.
-	getCertPath = "/get/cert/"
-	buildIDPath = "/build"
+	getCertPath     = "/get/cert/"
+	getCertInfoPath = "/get/certinfo/"
+	buildIDPath     = "/build"
 )
 
 const (
@@ -423,6 +424,7 @@ func (wfe *WebFrontEndImpl) Handler(stats prometheus.Registerer, oTelHTTPOptions
 
 	// Boulder specific endpoints
 	wfe.HandleFunc(m, getCertPath, wfe.Certificate, "GET")
+	wfe.HandleFunc(m, getCertInfoPath, wfe.CertificateInfo, "GET")
 	wfe.HandleFunc(m, buildIDPath, wfe.BuildID, "GET")
 
 	// Endpoint for draft-ietf-acme-ari
@@ -1623,6 +1625,35 @@ func (wfe *WebFrontEndImpl) Authorization(
 	if err != nil {
 		// InternalServerError because this is a failure to decode from our DB.
 		wfe.sendError(response, logEvent, probs.ServerInternal("Failed to JSON marshal authz"), err)
+		return
+	}
+}
+
+// CertificateInfo is a Boulder-specific endpoint to return notAfter.
+//
+// This is used by our CRL monitoring infrastructure to determine when it is acceptable
+// for a serial to be removed from a CRL.
+func (wfe *WebFrontEndImpl) CertificateInfo(ctx context.Context, logEvent *web.RequestEvent, response http.ResponseWriter, request *http.Request) {
+	serial := request.URL.Path
+	if !core.ValidSerial(serial) {
+		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
+	}
+	metadata, err := wfe.sa.GetSerialMetadata(ctx, &sapb.Serial{Serial: serial})
+	if err != nil {
+		wfe.sendError(response, logEvent, probs.NotFound("Certificate not found"), nil)
+		if err != nil {
+			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Error getting certificate metadata"), err)
+			return
+		}
+	}
+	certInfoStruct := struct {
+		NotAfter time.Time `json:"notAfter"`
+	}{
+		NotAfter: metadata.Expires.AsTime(),
+	}
+	wfe.writeJsonResponse(response, logEvent, http.StatusOK, certInfoStruct)
+	if err != nil {
+		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling certInfoStruct"), err)
 		return
 	}
 }


### PR DESCRIPTION
This provides NotAfter for any serial number allocated, which includes precertificates that did not have a corresponding final certificate issued.

Fixes #8287