### PR TITLE
Add tool to generate, verify, and output a list of CRLDPs

### DIFF
--- a/tools/crldps/main.go
+++ b/tools/crldps/main.go
@@ -1,6 +1,6 @@
 // crldps generates the list of CRL Distribution Point URIs for a given issuing
 // CA and number of shards. It fetches and validates all of those shards. If
-// it doesn't encouter any errors, it pretty-prints the list of all CRLDPs for
+// it doesn't encounter any errors, it pretty-prints the list of all CRLDPs for
 // disclosure in CCADB.
 package main
 

--- a/tools/crldps/main.go
+++ b/tools/crldps/main.go
@@ -27,7 +27,7 @@ func main() {
 	caPath := fs.String("ca", "", "path to an issuing intermediate CA certificate (required)")
 	numShards := fs.Int("shards", 128, "number of CRL shards issued by the CA")
 	err := fs.Parse(os.Args[1:])
-	if err != nil || len(fs.Args()) != 0 {
+	if err != nil || len(fs.Args()) != 0 || len(*caPath) == 0 {
 		log.Println("Incorrect command line flags; usage:")
 		fs.PrintDefaults()
 		os.Exit(1)

--- a/tools/crldps/main.go
+++ b/tools/crldps/main.go
@@ -1,7 +1,9 @@
 // crldps generates the list of CRL Distribution Point URIs for a given issuing
-// CA and number of shards. It fetches and validates all of those shards. If
-// it doesn't encounter any errors, it pretty-prints the list of all CRLDPs for
-// disclosure in CCADB.
+// CA and number of shards. The CRLDPs look like "http://x.c.lencr.org/n.crl",
+// where "x" is the lowercased Subject Common Name of the issuing CA (e.g. "r3")
+// and "n" is the one-indexed number of the shard. It fetches and validates all
+// of those shards. If it doesn't encounter any errors, it pretty-prints the
+// list of all CRLDPs for disclosure in CCADB.
 package main
 
 import (
@@ -14,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -22,14 +25,16 @@ import (
 	"github.com/letsencrypt/boulder/crl/idp"
 )
 
-func main() {
-	log.SetOutput(os.Stderr)
+// Matches the ABNF definition of a <label> per RFC 1035's Preferred Name Syntax
+// https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1
+var rfc1035label = regexp.MustCompile("^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$")
 
+func main() {
 	fs := flag.NewFlagSet("crldps", flag.ContinueOnError)
 	caPath := fs.String("ca", "", "path to an issuing intermediate CA certificate (required)")
-	numShards := fs.Int("shards", 128, "number of CRL shards issued by the CA")
+	numShards := fs.Int("shards", 0, "number of CRL shards issued by the CA (required)")
 	err := fs.Parse(os.Args[1:])
-	if err != nil || len(fs.Args()) != 0 || len(*caPath) == 0 {
+	if err != nil || len(fs.Args()) != 0 || len(*caPath) == 0 || *numShards == 0 {
 		log.Println("Incorrect command line flags; usage:")
 		fs.PrintDefaults()
 		os.Exit(1)
@@ -40,6 +45,10 @@ func main() {
 		log.Fatalf("Failed to load issuer certificate from %q: %s", os.Args[1], err)
 	}
 
+	if len(issuer.Subject.CommonName) > 63 || !rfc1035label.MatchString(issuer.Subject.CommonName) {
+		log.Fatalf("Cannot construct CRLDP because issuer CN %q is not a valid domain label", issuer.Subject.CommonName)
+	}
+
 	client := http.Client{Timeout: 10 * time.Second}
 
 	var (
@@ -47,52 +56,13 @@ func main() {
 		crldps []string
 	)
 	for shard := range *numShards {
-		crldp := (&url.URL{
-			Scheme: "http",
-			Host:   fmt.Sprintf("%s.c.lencr.org", strings.ToLower(issuer.Subject.CommonName)),
-			// We 1-index our CRL shards.
-			Path: fmt.Sprintf("%d.crl", shard+1),
-		}).String()
+		// We 1-index our CRL shards.
+		crldp := crldpString(issuer, shard+1)
 
-		resp, err := client.Get(crldp)
+		err := fetchAndCheck(crldp, client, issuer)
 		if err != nil {
 			anyErr = true
-			log.Printf("Error downloading crl %q: %s", crldp, err)
-			continue
-		}
-
-		crlDer, err := io.ReadAll(resp.Body)
-		if err != nil {
-			anyErr = true
-			log.Printf("Error reading crl %q: %s", crldp, err)
-			continue
-		}
-		resp.Body.Close()
-
-		crl, err := x509.ParseRevocationList(crlDer)
-		if err != nil {
-			anyErr = true
-			log.Printf("Error parsing crl %q: %s", crldp, err)
-			continue
-		}
-
-		err = crl.CheckSignatureFrom(issuer)
-		if err != nil {
-			anyErr = true
-			log.Printf("Error validating signature on crl %q: %s", crldp, err)
-			continue
-		}
-
-		idps, err := idp.GetIDPURIs(crl.Extensions)
-		if err != nil {
-			anyErr = true
-			log.Printf("Error extracting IDPs from crl %q: %s", crldp, err)
-			continue
-		}
-
-		if !slices.Contains(idps, crldp) {
-			anyErr = true
-			log.Printf("Failed to find matching IDP in crl %q", crldp)
+			log.Printf("Error processing crl %q: %x", crldp, err)
 			continue
 		}
 
@@ -103,16 +73,24 @@ func main() {
 		log.Fatalf("Encountered one or more errors above; exiting")
 	}
 
-	// Do a final check of the one-past-the-end shard, to ensure the operator
-	// gave the correct number of shards.
+	// Do two final checks of the zeroth and one-past-the-end shards, to ensure
+	// the operator gave the correct number of shards and that the shard
+	// generation is configured correctly.
 	{
-		crldp := (&url.URL{
-			Scheme: "http",
-			Host:   fmt.Sprintf("%s.c.lencr.org", strings.ToLower(issuer.Subject.CommonName)),
-			Path:   fmt.Sprintf("%d.crl", *numShards+1),
-		}).String()
+		crldp := crldpString(issuer, 0)
 		resp, err := client.Get(crldp)
-		if err == nil && resp.StatusCode != http.StatusNotFound {
+		if err != nil {
+			log.Fatalf("Error checking for existence of zero shard %q: %s", crldp, err)
+		} else if resp.StatusCode != http.StatusNotFound {
+			log.Fatalf("Was unexpectedly able to fetch zero shard %q; please verify that the generated shards are one-indexed", crldp)
+		}
+	}
+	{
+		crldp := crldpString(issuer, *numShards+1)
+		resp, err := client.Get(crldp)
+		if err != nil {
+			log.Fatalf("Error checking for existence of higher-nunbered shard %q: %s", crldp, err)
+		} else if resp.StatusCode != http.StatusNotFound {
 			log.Fatalf("Was unexpectedly able to fetch higher-numbered shard %q; please verify that the -shards flag is correct", crldp)
 		}
 	}
@@ -123,4 +101,48 @@ func main() {
 	}
 
 	fmt.Println(string(out))
+}
+
+func crldpString(issuer *x509.Certificate, shard int) string {
+	return (&url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s.c.lencr.org", strings.ToLower(issuer.Subject.CommonName)),
+		Path:   fmt.Sprintf("%d.crl", shard),
+	}).String()
+}
+
+func fetchAndCheck(crldp string, client http.Client, issuer *x509.Certificate) error {
+	resp, err := client.Get(crldp)
+	if err != nil {
+		return fmt.Errorf("error downloading crl: %s", err)
+	} else if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code while downloading crl: %s", http.StatusText(resp.StatusCode))
+	}
+	defer resp.Body.Close()
+
+	crlDer, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading crl: %s", err)
+	}
+
+	crl, err := x509.ParseRevocationList(crlDer)
+	if err != nil {
+		return fmt.Errorf("error parsing crl: %s", err)
+	}
+
+	err = crl.CheckSignatureFrom(issuer)
+	if err != nil {
+		return fmt.Errorf("error validating crl signature: %s", err)
+	}
+
+	idps, err := idp.GetIDPURIs(crl.Extensions)
+	if err != nil {
+		return fmt.Errorf("error extracting IDPs: %s", err)
+	}
+
+	if !slices.Contains(idps, crldp) {
+		return fmt.Errorf("crl does not contain matching IDP")
+	}
+
+	return nil
 }

--- a/tools/crldps/main.go
+++ b/tools/crldps/main.go
@@ -1,0 +1,116 @@
+// crldps generates the list of CRL Distribution Point URIs for a given issuing
+// CA and number of shards. It fetches and validates all of those shards. If
+// it doesn't encouter any errors, it pretty-prints the list of all CRLDPs for
+// disclosure in CCADB.
+package main
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/letsencrypt/boulder/core"
+	"github.com/letsencrypt/boulder/crl/idp"
+)
+
+func main() {
+	log.SetOutput(os.Stderr)
+
+	fs := flag.NewFlagSet("crldps", flag.ContinueOnError)
+	caPath := fs.String("ca", "", "path to an issuing intermediate CA certificate (required)")
+	numShards := fs.Int("shards", 128, "number of CRL shards issued by the CA")
+	err := fs.Parse(os.Args[1:])
+	if err != nil || len(fs.Args()) != 0 {
+		log.Println("Incorrect command line flags; usage:")
+		fs.PrintDefaults()
+		os.Exit(1)
+	}
+
+	issuer, err := core.LoadCert(*caPath)
+	if err != nil {
+		log.Fatalf("Failed to load issuer certificate from %q: %s", os.Args[1], err)
+	}
+
+	crldpBase := fmt.Sprintf("http://%s.c.lencr.org", strings.ToLower(issuer.Subject.CommonName))
+
+	var (
+		anyErr bool
+		crldps []string
+	)
+	for shard := range *numShards {
+		// We 1-index our CRL shards.
+		crldp := fmt.Sprintf("%s/%d.crl", crldpBase, shard+1)
+
+		resp, err := http.Get(crldp)
+		if err != nil {
+			anyErr = true
+			log.Printf("Error downloading crl %q: %s", crldp, err)
+			continue
+		}
+
+		crlDer, err := io.ReadAll(resp.Body)
+		if err != nil {
+			anyErr = true
+			log.Printf("Error reading crl %q: %s", crldp, err)
+			continue
+		}
+		resp.Body.Close()
+
+		crl, err := x509.ParseRevocationList(crlDer)
+		if err != nil {
+			anyErr = true
+			log.Printf("Error parsing crl %q: %s", crldp, err)
+			continue
+		}
+
+		err = crl.CheckSignatureFrom(issuer)
+		if err != nil {
+			anyErr = true
+			log.Printf("Error validating signature on crl %q: %s", crldp, err)
+			continue
+		}
+
+		idps, err := idp.GetIDPURIs(crl.Extensions)
+		if err != nil {
+			anyErr = true
+			log.Printf("Error extracting IDPs from crl %q: %s", crldp, err)
+			continue
+		}
+
+		if !slices.Contains(idps, crldp) {
+			anyErr = true
+			log.Printf("Failed to find matching IDP in crl %q", crldp)
+			continue
+		}
+
+		crldps = append(crldps, crldp)
+	}
+
+	if anyErr {
+		log.Fatalf("Encountered one or more errors above; exiting")
+	}
+
+	// Do a final check of the one-past-the-end shard, to ensure the operator
+	// gave the correct number of shards.
+	{
+		crldp := fmt.Sprintf("%s/%d.crl", crldpBase, *numShards+1)
+		resp, err := http.Get(crldp)
+		if err == nil && resp.StatusCode != http.StatusNotFound {
+			log.Fatalf("Was unexpectedly able to fetch higher-numbered shard %q; please verify that the -shards flag is correct", crldp)
+		}
+	}
+
+	out, err := json.MarshalIndent(crldps, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal list of CRLDPs: %s", err)
+	}
+
+	fmt.Println(string(out))
+}


### PR DESCRIPTION
Add a new tool which generates, validates, and outputs a list of CRLDPs for the given issuer and number of shards. The output is intended for disclosure in CCADB.

Usage:
```
  -ca string
        path to an issuing intermediate CA certificate (required)
  -shards int
        number of CRL shards issued by the CA (default 128)
```

Sample output:
```
$ go run ./tools/crldps -ca ../website/static/certs/2024/e7.pem -shards 128
[
  "http://e7.c.lencr.org/1.crl",
  "http://e7.c.lencr.org/2.crl",
  "http://e7.c.lencr.org/3.crl",
  <...>
  "http://e7.c.lencr.org/127.crl",
  "http://e7.c.lencr.org/128.crl"
]
```