### PR TITLE
Remove GO111MODULE and GOFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(CMD_BINS): build_cmds
 
 build_cmds: | $(OBJDIR)
 	echo $(OBJECTS)
-	GOBIN=$(OBJDIR) GO111MODULE=on go install -mod=vendor $(GO_BUILD_FLAGS) ./...
+	GOBIN=$(OBJDIR) go install -mod=vendor $(GO_BUILD_FLAGS) ./...
 
 # Building a .deb requires `fpm` from https://github.com/jordansissel/fpm
 # which you can install with `gem install fpm`.

--- a/docker-compose.next.yml
+++ b/docker-compose.next.yml
@@ -3,5 +3,4 @@ services:
     environment:
       FAKE_DNS: 64.112.117.122
       BOULDER_CONFIG_DIR: test/config-next
-      GOFLAGS: -mod=vendor
       GOCACHE: /boulder/.gocache/go-build-next

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       FAKE_DNS: 64.112.117.122
       BOULDER_CONFIG_DIR: test/config
       GOCACHE: /boulder/.gocache/go-build
-      GOFLAGS: -mod=vendor
     volumes:
       - .:/boulder:cached
       - ./.gocache:/root/.cache/go-build:cached

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -365,11 +365,7 @@ release by GitHub Actions.
 
 # Dependencies
 
-We use [go modules](https://github.com/golang/go/wiki/Modules) and vendor our
-dependencies. As of Go 1.12, this may require setting the `GO111MODULE=on` and
-`GOFLAGS=-mod=vendor` environment variables. Inside the Docker containers for
-Boulder tests, these variables are set for you, but if you ever work outside
-those containers you will want to set them yourself.
+We use [go modules](https://github.com/golang/go/wiki/Modules) and vendor our dependencies.
 
 To add a dependency, add the import statement to your .go file, then run
 `go build` on it. This will automatically add the dependency to go.mod. Next,


### PR DESCRIPTION
These are no longer needed.

https://go.dev/ref/mod#build-commands

> -mod=vendor tells the go command to use the vendor directory. In
> this mode, the go command will not use the network or the module
> cache.  By default, if the go version in go.mod is 1.14 or higher
> and a vendor directory is present, the go command acts as if
> -mod=vendor were used.

https://go.dev/ref/mod#environment-variables

> GO111MODULE
> Controls whether the go command runs in module-aware mode or GOPATH
> mode.
> on (or unset): the go command runs in module-aware mode, even when
> no go.mod file is present.