### PR TITLE
test: rewrite CAA integration test in Go 

### DIFF
--- a/test/config-next/wfe2-ratelimit-overrides.yml
+++ b/test/config-next/wfe2-ratelimit-overrides.yml
@@ -27,8 +27,6 @@
         comment: Let's Encrypt Test Domain 3
       - id: nginx.wtf
         comment: Nginx Test Domain
-      - id: good-caa-reserved.com
-        comment: Good CAA Reserved Domain
       - id: bad-caa-reserved.com
         comment: Bad CAA Reserved Domain
       - id: ecdsa.le.wtf
@@ -50,8 +48,6 @@
         comment: Let's Encrypt Test Domain 3
       - id: le.wtf,le1.wtf
         comment: Let's Encrypt Test Domain, Let's Encrypt Test Domain 1
-      - id: good-caa-reserved.com
-        comment: Good CAA Reserved Domain
       - id: nginx.wtf
         comment: Nginx Test Domain
       - id: ecdsa.le.wtf

--- a/test/config/wfe2-ratelimit-overrides.yml
+++ b/test/config/wfe2-ratelimit-overrides.yml
@@ -27,8 +27,6 @@
         comment: Let's Encrypt Test Domain 3
       - id: nginx.wtf
         comment: Nginx Test Domain
-      - id: good-caa-reserved.com
-        comment: Good CAA Reserved Domain
       - id: bad-caa-reserved.com
         comment: Bad CAA Reserved Domain
       - id: ecdsa.le.wtf
@@ -50,8 +48,6 @@
         comment: Let's Encrypt Test Domain 3
       - id: le.wtf,le1.wtf
         comment: Let's Encrypt Test Domain, Let's Encrypt Test Domain 1
-      - id: good-caa-reserved.com
-        comment: Good CAA Reserved Domain
       - id: nginx.wtf
         comment: Nginx Test Domain
       - id: ecdsa.le.wtf

--- a/test/integration/validation_test.go
+++ b/test/integration/validation_test.go
@@ -359,7 +359,6 @@ func TestCAAAccountURI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("domain %s\n", domain)
 	_, err = authAndIssue(client, nil, idents, true, "")
 	if err != nil {
 		t.Fatalf("authAndIssue: %s", err)

--- a/test/rate-limit-policies.yml
+++ b/test/rate-limit-policies.yml
@@ -11,7 +11,6 @@ certificatesPerName:
     le2.wtf: 10000
     le3.wtf: 10000
     nginx.wtf: 10000
-    good-caa-reserved.com: 10000
     bad-caa-reserved.com: 10000
     ecdsa.le.wtf: 10000
     must-staple.le.wtf: 10000
@@ -45,7 +44,6 @@ certificatesPerFQDNSet:
     le2.wtf: 10000
     le3.wtf: 10000
     le.wtf,le1.wtf: 10000
-    good-caa-reserved.com: 10000
     nginx.wtf: 10000
     ecdsa.le.wtf: 10000
     must-staple.le.wtf: 10000

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -1136,36 +1136,6 @@ def test_caa_reject():
     chisel2.expect_problem("urn:ietf:params:acme:error:caa",
         lambda: chisel2.auth_and_issue([domain]))
 
-def test_caa_extensions():
-    goodCAA = "happy-hacker-ca.invalid"
-
-    client = chisel2.make_client()
-    caa_account_uri = client.net.account.uri
-    caa_records = [
-        {"domain": "accounturi.good-caa-reserved.com", "value":"{0}; accounturi={1}".format(goodCAA, caa_account_uri)},
-        {"domain": "dns-01-only.good-caa-reserved.com", "value": "{0}; validationmethods=dns-01".format(goodCAA)},
-        {"domain": "http-01-only.good-caa-reserved.com", "value": "{0}; validationmethods=http-01".format(goodCAA)},
-        {"domain": "dns-01-or-http01.good-caa-reserved.com", "value": "{0}; validationmethods=dns-01,http-01".format(goodCAA)},
-    ]
-    for policy in caa_records:
-        challSrv.add_caa_issue(policy["domain"], policy["value"])
-
-    chisel2.expect_problem("urn:ietf:params:acme:error:caa",
-        lambda: chisel2.auth_and_issue(["dns-01-only.good-caa-reserved.com"], chall_type="http-01"))
-
-    chisel2.expect_problem("urn:ietf:params:acme:error:caa",
-        lambda: chisel2.auth_and_issue(["http-01-only.good-caa-reserved.com"], chall_type="dns-01"))
-
-    ## Note: the additional names are to avoid rate limiting...
-    chisel2.auth_and_issue(["dns-01-only.good-caa-reserved.com", "www.dns-01-only.good-caa-reserved.com"], chall_type="dns-01")
-    chisel2.auth_and_issue(["http-01-only.good-caa-reserved.com", "www.http-01-only.good-caa-reserved.com"], chall_type="http-01")
-    chisel2.auth_and_issue(["dns-01-or-http-01.good-caa-reserved.com", "dns-01-only.good-caa-reserved.com"], chall_type="dns-01")
-    chisel2.auth_and_issue(["dns-01-or-http-01.good-caa-reserved.com", "http-01-only.good-caa-reserved.com"], chall_type="http-01")
-
-    ## CAA should fail with an arbitrary account, but succeed with the CAA client.
-    chisel2.expect_problem("urn:ietf:params:acme:error:caa", lambda: chisel2.auth_and_issue(["accounturi.good-caa-reserved.com"]))
-    chisel2.auth_and_issue(["accounturi.good-caa-reserved.com"], client=client)
-
 def test_renewal_exemption():
     """
     Under a single domain, issue two certificates for different subdomains of


### PR DESCRIPTION
The existing test case tested accounturi and validationmethods. Replace it with two test cases, one for validationmethods and one for accounturi. Use a random base domain to avoid rate limit issues.

Fixes #8332 