### PR TITLE
Restrict permissions of merged-to-main workflow

### DIFF
--- a/.github/workflows/merged-to-main-or-release-branch.yml
+++ b/.github/workflows/merged-to-main-or-release-branch.yml
@@ -2,6 +2,8 @@
 # be used by tag protection rules to ensure that tags may only be pushed if
 # their corresponding commit was first pushed to one of those branches.
 name: Merged to main (or hotfix)
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Set the workflow's permissions to just `content: read`.

---

> [!NOTE]
> Suggested fix generated by Copilot Autofix. Review carefully before merging.