### PR TITLE
sfe: Add per IP rate limits to the overrides request form submissions

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -258,6 +258,14 @@ func FailedAuthorizationsPerDomainPerAccountError(retryAfter time.Duration, msg 
 	}
 }
 
+func LimitOverrideRequestsPerIPAddressError(retryAfter time.Duration, msg string, args ...any) error {
+	return &BoulderError{
+		Type:       RateLimit,
+		Detail:     fmt.Sprintf(msg+": see https://letsencrypt.org/docs/rate-limits/#limit-override-requests-per-ip-address", args...),
+		RetryAfter: retryAfter,
+	}
+}
+
 func RejectedIdentifierError(msg string, args ...any) error {
 	return newf(RejectedIdentifier, msg, args...)
 }

--- a/ratelimits/limiter.go
+++ b/ratelimits/limiter.go
@@ -172,6 +172,15 @@ func (d *Decision) Result(now time.Time) error {
 			retryAfterTs,
 		)
 
+	case LimitOverrideRequestsPerIPAddress:
+		return berrors.LimitOverrideRequestsPerIPAddressError(
+			retryAfter,
+			"too many override request form submissions (%d) from this IP address in the last %s, retry after %s",
+			d.transaction.limit.Burst,
+			d.transaction.limit.Period.Duration,
+			retryAfterTs,
+		)
+
 	default:
 		return berrors.InternalServerError("cannot generate error for unknown rate limit")
 	}

--- a/ratelimits/limiter_test.go
+++ b/ratelimits/limiter_test.go
@@ -558,6 +558,22 @@ func TestRateLimitError(t *testing.T) {
 			expectedErrType: berrors.RateLimit,
 		},
 		{
+			name: "LimitOverrideRequestsPerIPAddress limit reached",
+			decision: &Decision{
+				allowed: false,
+				retryIn: 20 * time.Second,
+				transaction: Transaction{
+					limit: &Limit{
+						Name:   LimitOverrideRequestsPerIPAddress,
+						Burst:  3,
+						Period: config.Duration{Duration: time.Hour},
+					},
+				},
+			},
+			expectedErr:     "too many override request form submissions (3) from this IP address in the last 1h0m0s, retry after 1970-01-01 00:00:20 UTC: see https://letsencrypt.org/docs/rate-limits/#limit-override-requests-per-ip-address",
+			expectedErrType: berrors.RateLimit,
+		},
+		{
 			name: "Unknown rate limit name",
 			decision: &Decision{
 				allowed: false,

--- a/ratelimits/transaction.go
+++ b/ratelimits/transaction.go
@@ -572,3 +572,18 @@ func (builder *TransactionBuilder) NewAccountLimitTransactions(ip netip.Addr) ([
 	}
 	return append(transactions, txn), nil
 }
+
+// LimitOverrideRequestsPerIPAddressTransaction returns a Transaction for the
+// LimitOverrideRequestsPerIPAddress limit for the provided IP address. This
+// limit is used to rate limit requests to the SFE override request endpoint.
+func (builder *TransactionBuilder) LimitOverrideRequestsPerIPAddressTransaction(ip netip.Addr) (Transaction, error) {
+	bucketKey := newIPAddressBucketKey(LimitOverrideRequestsPerIPAddress, ip)
+	limit, err := builder.getLimit(LimitOverrideRequestsPerIPAddress, bucketKey)
+	if err != nil {
+		if errors.Is(err, errLimitDisabled) {
+			return newAllowOnlyTransaction(), nil
+		}
+		return Transaction{}, err
+	}
+	return newTransaction(limit, bucketKey, 1)
+}

--- a/sfe/sfe.go
+++ b/sfe/sfe.go
@@ -67,6 +67,9 @@ type SelfServiceFrontEndImpl struct {
 
 	templatePages *template.Template
 	cop           *http.CrossOriginProtection
+
+	limiter    *rl.Limiter
+	txnBuilder *rl.TransactionBuilder
 }
 
 // NewSelfServiceFrontEndImpl constructs a web service for Boulder
@@ -79,6 +82,8 @@ func NewSelfServiceFrontEndImpl(
 	sac sapb.StorageAuthorityReadOnlyClient,
 	unpauseHMACKey []byte,
 	zendeskClient *zendesk.Client,
+	limiter *rl.Limiter,
+	txnBuilder *rl.TransactionBuilder,
 ) (SelfServiceFrontEndImpl, error) {
 
 	// Parse the files once at startup to avoid each request causing the server
@@ -99,6 +104,8 @@ func NewSelfServiceFrontEndImpl(
 		zendeskClient:  zendeskClient,
 		templatePages:  tmplPages,
 		cop:            http.NewCrossOriginProtection(),
+		limiter:        limiter,
+		txnBuilder:     txnBuilder,
 	}
 
 	return sfe, nil

--- a/test/config-next/sfe-ratelimit-defaults.yml
+++ b/test/config-next/sfe-ratelimit-defaults.yml
@@ -1,0 +1,4 @@
+LimitOverrideRequestsPerIPAddress:
+  count: 100
+  burst: 100
+  period: 168h

--- a/web/extract.go
+++ b/web/extract.go
@@ -1,0 +1,23 @@
+package web
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+)
+
+// ExtractRequesterIP extracts the IP address of the requester from the HTTP
+// request. It first checks the "X-Real-IP" header, and if that is not set, it
+// falls back to the RemoteAddr field of the request. An error is returned if
+// the IP address cannot be determined.
+func ExtractRequesterIP(req *http.Request) (netip.Addr, error) {
+	ip, err := netip.ParseAddr(req.Header.Get("X-Real-IP"))
+	if err == nil {
+		return ip, nil
+	}
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	return netip.ParseAddr(host)
+}

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand/v2"
-	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -817,7 +816,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 		return
 	}
 
-	ip, err := extractRequesterIP(request)
+	ip, err := web.ExtractRequesterIP(request)
 	if err != nil {
 		wfe.sendError(
 			response,
@@ -2729,18 +2728,6 @@ func (wfe *WebFrontEndImpl) RenewalInfo(ctx context.Context, logEvent *web.Reque
 		wfe.sendError(response, logEvent, probs.ServerInternal("Error marshalling renewalInfo"), err)
 		return
 	}
-}
-
-func extractRequesterIP(req *http.Request) (netip.Addr, error) {
-	ip, err := netip.ParseAddr(req.Header.Get("X-Real-IP"))
-	if err == nil {
-		return ip, nil
-	}
-	host, _, err := net.SplitHostPort(req.RemoteAddr)
-	if err != nil {
-		return netip.Addr{}, err
-	}
-	return netip.ParseAddr(host)
 }
 
 func urlForAuthz(authz core.Authorization, request *http.Request) string {


### PR DESCRIPTION
Prevent callers from blasting our Zendesk with junk requests and (eventually) our database with automatically approved overrides.

Closes #8359