### PR TITLE
sfe: Periodically import approved rate limit override tickets

### DIFF
--- a/cmd/sfe/main.go
+++ b/cmd/sfe/main.go
@@ -178,7 +178,7 @@ func main() {
 				mode = sfe.ProcessAll
 			}
 
-			importer, ierr := sfe.NewOverridesImporter(
+			importer, err := sfe.NewOverridesImporter(
 				mode,
 				c.SFE.OverridesImporter.Interval.Duration,
 				zendeskClient,
@@ -186,7 +186,7 @@ func main() {
 				clk,
 				logger,
 			)
-			cmd.FailOnError(ierr, "Creating overrides importer")
+			cmd.FailOnError(err, "Creating overrides importer")
 
 			var ctx context.Context
 			ctx, overridesImporterShutdown = context.WithCancel(context.Background())

--- a/sfe/overrides.go
+++ b/sfe/overrides.go
@@ -46,6 +46,9 @@ const (
 	// reviewStatusDefault is the initial status of a ticket when created.
 	reviewStatusDefault = "review-status-pending"
 
+	// reviewStatusApproved is the status of a ticket when it has been approved.
+	reviewStatusApproved = "review-status-approved"
+
 	// validateOverrideFieldBodyLimit is the maximum size of request body
 	// accepted by validateOverrideFieldHandler. It should be large enough to
 	// accommodate the JSON encoded validationRequest struct, but small enough

--- a/sfe/overridesimporter.go
+++ b/sfe/overridesimporter.go
@@ -244,7 +244,7 @@ func (im *OverridesImporter) makeAddOverrideRequest(fields map[string]string) (*
 func (im *OverridesImporter) processTicket(ctx context.Context, ticketID int64, fields map[string]string) error {
 	req, accountDomainOrIP, err := im.makeAddOverrideRequest(fields)
 	if err != nil {
-		// This will recur until the operator corrects the ticket.
+		// Move to "pending" so the next tick won't comment again.
 		im.transitionToPendingWithComment(ticketID, err.Error())
 		return fmt.Errorf("preparing override request: %w", err)
 	}
@@ -257,7 +257,7 @@ func (im *OverridesImporter) processTicket(ctx context.Context, ticketID int64, 
 
 	rateLimit := rl.Name(req.LimitEnum).String()
 	if !resp.Enabled {
-		// This will recur until the existing override is re-enabled.
+		// Move to "pending" so the next tick won't comment again.
 		im.transitionToPendingWithComment(ticketID, "An existing override for this limit and requester is currently administratively disabled.")
 		return fmt.Errorf("override for rate limit %s and account/domain/IP: %s is administratively disabled", rateLimit, accountDomainOrIP)
 	}

--- a/sfe/overridesimporter.go
+++ b/sfe/overridesimporter.go
@@ -160,15 +160,15 @@ func (im *OverridesImporter) makeAddOverrideRequest(fields map[string]string) (*
 	}
 	tierStr, err := im.getValidatedFieldValue(fields, TierFieldName, rateLimit)
 	if err != nil {
-		return nil, "", fmt.Errorf("getting/validating tier field: %s", err)
+		return nil, "", fmt.Errorf("getting/validating tier field: %w", err)
 	}
 	tier, err := strconv.ParseInt(tierStr, 10, 64)
 	if err != nil {
-		return nil, "", fmt.Errorf("parsing tier: %s", err)
+		return nil, "", fmt.Errorf("parsing tier: %w", err)
 	}
 	organization, err := im.getValidatedFieldValue(fields, OrganizationFieldName, "")
 	if err != nil {
-		return nil, "", fmt.Errorf("getting/validating organization: %s", err)
+		return nil, "", fmt.Errorf("getting/validating organization: %w", err)
 	}
 
 	var req *rapb.AddRateLimitOverrideRequest
@@ -178,15 +178,15 @@ func (im *OverridesImporter) makeAddOverrideRequest(fields map[string]string) (*
 	case rl.NewOrdersPerAccount.String():
 		accountURI, err := im.getValidatedFieldValue(fields, AccountURIFieldName, "")
 		if err != nil {
-			return nil, "", fmt.Errorf("getting/validating accountURI: %s", err)
+			return nil, "", fmt.Errorf("getting/validating accountURI: %w", err)
 		}
 		accountID, err := accountURIToID(accountURI)
 		if err != nil {
-			return nil, "", fmt.Errorf("parsing accountURI to accountID: %s", err)
+			return nil, "", fmt.Errorf("parsing accountURI to accountID: %w", err)
 		}
 		bucketKey, err := rl.BuildBucketKey(rl.NewOrdersPerAccount, accountID, identifier.ACMEIdentifier{}, identifier.ACMEIdentifiers{}, netip.Addr{})
 		if err != nil {
-			return nil, "", fmt.Errorf("building bucket key: %s", err)
+			return nil, "", fmt.Errorf("building bucket key: %w", err)
 		}
 		req = makeReq(rl.NewOrdersPerAccount, bucketKey, organization, tier)
 		accountDomainOrIP = accountURI
@@ -194,15 +194,15 @@ func (im *OverridesImporter) makeAddOverrideRequest(fields map[string]string) (*
 	case rl.CertificatesPerDomainPerAccount.String():
 		accountURI, err := im.getValidatedFieldValue(fields, AccountURIFieldName, "")
 		if err != nil {
-			return nil, "", fmt.Errorf("getting/validating accountURI: %s", err)
+			return nil, "", fmt.Errorf("getting/validating accountURI: %w", err)
 		}
 		accountID, err := accountURIToID(accountURI)
 		if err != nil {
-			return nil, "", fmt.Errorf("parsing accountURI to accountID: %s", err)
+			return nil, "", fmt.Errorf("parsing accountURI to accountID: %w", err)
 		}
 		bucketKey, err := rl.BuildBucketKey(rl.CertificatesPerDomainPerAccount, accountID, identifier.ACMEIdentifier{}, identifier.ACMEIdentifiers{}, netip.Addr{})
 		if err != nil {
-			return nil, "", fmt.Errorf("building bucket key: %s", err)
+			return nil, "", fmt.Errorf("building bucket key: %w", err)
 		}
 		req = makeReq(rl.CertificatesPerDomainPerAccount, bucketKey, organization, tier)
 		accountDomainOrIP = accountURI
@@ -210,11 +210,11 @@ func (im *OverridesImporter) makeAddOverrideRequest(fields map[string]string) (*
 	case rl.CertificatesPerDomain.String() + perDNSNameSuffix:
 		dnsName, err := im.getValidatedFieldValue(fields, RegisteredDomainFieldName, rateLimit)
 		if err != nil {
-			return nil, "", fmt.Errorf("getting/validating registeredDomain: %s", err)
+			return nil, "", fmt.Errorf("getting/validating registeredDomain: %w", err)
 		}
 		bucketKey, err := rl.BuildBucketKey(rl.CertificatesPerDomain, 0, identifier.NewDNS(dnsName), identifier.ACMEIdentifiers{}, netip.Addr{})
 		if err != nil {
-			return nil, "", fmt.Errorf("building bucket key: %s", err)
+			return nil, "", fmt.Errorf("building bucket key: %w", err)
 		}
 		accountDomainOrIP = dnsName
 		req = makeReq(rl.CertificatesPerDomain, bucketKey, organization, tier)
@@ -222,15 +222,15 @@ func (im *OverridesImporter) makeAddOverrideRequest(fields map[string]string) (*
 	case rl.CertificatesPerDomain.String() + perIPSuffix:
 		ipAddrStr, err := im.getValidatedFieldValue(fields, IPAddressFieldName, rateLimit)
 		if err != nil {
-			return nil, "", fmt.Errorf("getting/validating ipAddress: %s", err)
+			return nil, "", fmt.Errorf("getting/validating ipAddress: %w", err)
 		}
 		ipAddr, err := netip.ParseAddr(ipAddrStr)
 		if err != nil {
-			return nil, "", fmt.Errorf("parsing ipAddress: %s", err)
+			return nil, "", fmt.Errorf("parsing ipAddress: %w", err)
 		}
 		bucketKey, err := rl.BuildBucketKey(rl.CertificatesPerDomain, 0, identifier.NewIP(ipAddr), identifier.ACMEIdentifiers{}, netip.Addr{})
 		if err != nil {
-			return nil, "", fmt.Errorf("building bucket key: %s", err)
+			return nil, "", fmt.Errorf("building bucket key: %w", err)
 		}
 		req = makeReq(rl.CertificatesPerDomain, bucketKey, organization, tier)
 		accountDomainOrIP = ipAddrStr

--- a/sfe/overridesimporter.go
+++ b/sfe/overridesimporter.go
@@ -1,0 +1,302 @@
+package sfe
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/letsencrypt/boulder/identifier"
+	blog "github.com/letsencrypt/boulder/log"
+	rapb "github.com/letsencrypt/boulder/ra/proto"
+	rl "github.com/letsencrypt/boulder/ratelimits"
+	"github.com/letsencrypt/boulder/sfe/zendesk"
+)
+
+// ProcessMode determines which ticket IDs the importer will process.
+type ProcessMode string
+
+const (
+	// ProcessAll indicates that all tickets should be processed, as opposed to
+	// just even or odd numbered tickets.
+	ProcessAll  ProcessMode = "all"
+	processEven ProcessMode = "even"
+	processOdd  ProcessMode = "odd"
+)
+
+type OverridesImporter struct {
+	mode     ProcessMode
+	interval time.Duration
+
+	zendesk *zendesk.Client
+	ra      rapb.RegistrationAuthorityClient
+
+	clk clock.Clock
+	log blog.Logger
+}
+
+// NewOverridesImporter creates a new OverridesImporter that will process
+// tickets in the given mode at the given interval. An error is returned if the
+// interval is left unspecified.
+func NewOverridesImporter(mode ProcessMode, interval time.Duration, client *zendesk.Client, sa rapb.RegistrationAuthorityClient, clk clock.Clock, log blog.Logger) (*OverridesImporter, error) {
+	if interval <= 0 {
+		return nil, fmt.Errorf("interval cannot be 0")
+	}
+	return &OverridesImporter{
+		mode:     mode,
+		interval: interval,
+		zendesk:  client,
+		ra:       sa,
+		clk:      clk,
+		log:      log,
+	}, nil
+}
+
+// Start begins the periodic import of approved override requests from Zendesk.
+// This method blocks until the provided context is cancelled.
+func (im *OverridesImporter) Start(ctx context.Context) {
+	ticker := time.NewTicker(im.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			im.tick(ctx)
+		}
+	}
+}
+
+// tick performs a single import pass, serially processing all tickets in the
+// configured mode that have been marked "open" and "approved".
+func (im *OverridesImporter) tick(ctx context.Context) {
+	tickets, err := im.zendesk.FindTickets(map[string]string{ReviewStatusFieldName: reviewStatusApproved}, "open")
+	if err != nil {
+		im.log.Errf("while searching zendesk for solved and approved tickets: %s", err)
+		return
+	}
+
+	processed := 0
+	failures := 0
+	for id, fields := range tickets {
+		switch im.mode {
+		case processEven:
+			if id%2 != 0 {
+				continue
+			}
+		case processOdd:
+			if id%2 == 0 {
+				continue
+			}
+		}
+
+		err = im.processTicket(ctx, id, fields)
+		if err != nil {
+			im.log.Errf("while processing ticket %d: %s", id, err)
+			failures++
+			continue
+		}
+		processed++
+	}
+	im.log.Infof("overrides importer processed %d tickets with %d failures", processed, failures)
+}
+
+func accountURIToID(s string) (int64, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return 0, err
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 3 {
+		return 0, fmt.Errorf("unexpected path %q", u.Path)
+	}
+	id, convErr := strconv.ParseInt(parts[len(parts)-1], 10, 64)
+	if convErr != nil {
+		return 0, convErr
+	}
+	return id, nil
+}
+
+// transitionToPendingWithComment sets the status of the given ticket to
+// "pending" and adds a private comment with the given cause. If updating the
+// ticket fails, the error is logged.
+func (im *OverridesImporter) transitionToPendingWithComment(ticketID int64, cause string) {
+	privateBody := fmt.Sprintf(
+		"A failure occurred while importing this override:\n\n%s\n\n"+
+			"This ticket's status has been set to pending.\n\n"+
+			"Once the error has been corrected, change the status back to \"solved\" to retry.\n",
+		cause,
+	)
+	err := im.zendesk.UpdateTicketStatus(ticketID, "pending", privateBody, false)
+	if err != nil {
+		im.log.Errf("failed to update ticket %d: %s", ticketID, err)
+	}
+}
+
+func makeAddOverrideRequest(limit rl.Name, bucket, organization string, tier int64) *rapb.AddRateLimitOverrideRequest {
+	return &rapb.AddRateLimitOverrideRequest{
+		LimitEnum: int64(limit),
+		BucketKey: bucket,
+		Count:     tier,
+		Burst:     tier,
+		Period:    durationpb.New(7 * 24 * time.Hour),
+		Comment:   organization,
+	}
+}
+
+func (im *OverridesImporter) getValidatedFieldValue(fields map[string]string, fieldName, rateLimit string) (string, error) {
+	val := fields[fieldName]
+	err := validateOverrideRequestField(fieldName, val, rateLimit)
+	if err != nil {
+		return "", err
+	}
+	return val, nil
+}
+
+func (im *OverridesImporter) processTicket(ctx context.Context, ticketID int64, fields map[string]string) error {
+	var pendingComment string
+	defer func() {
+		if pendingComment != "" {
+			im.transitionToPendingWithComment(ticketID, pendingComment)
+		}
+	}()
+
+	rateLimit, ok := fields[RateLimitFieldName]
+	if !ok {
+		pendingComment = "missing rate limit field"
+		return fmt.Errorf("missing rate limit field")
+	}
+	tierStr, err := im.getValidatedFieldValue(fields, TierFieldName, rateLimit)
+	if err != nil {
+		pendingComment = fmt.Sprintf("getting/validating tier field: %s", err)
+		return err
+	}
+	tier, err := strconv.ParseInt(tierStr, 10, 64)
+	if err != nil {
+		pendingComment = fmt.Sprintf("parsing tier: %s", err)
+		return err
+	}
+	organization, err := im.getValidatedFieldValue(fields, OrganizationFieldName, "")
+	if err != nil {
+		pendingComment = fmt.Sprintf("getting/validating organization: %s", err)
+		return err
+	}
+
+	var req *rapb.AddRateLimitOverrideRequest
+	var accountDomainOrIP string
+
+	switch rateLimit {
+	case rl.NewOrdersPerAccount.String():
+		accountURI, err := im.getValidatedFieldValue(fields, AccountURIFieldName, "")
+		if err != nil {
+			pendingComment = fmt.Sprintf("getting/validating accountURI: %s", err)
+			return err
+		}
+		accountID, err := accountURIToID(accountURI)
+		if err != nil {
+			pendingComment = fmt.Sprintf("parsing accountURI to accountID: %s", err)
+			return err
+		}
+		bucketKey, err := rl.BuildBucketKey(rl.NewOrdersPerAccount, accountID, identifier.ACMEIdentifier{}, identifier.ACMEIdentifiers{}, netip.Addr{})
+		if err != nil {
+			pendingComment = fmt.Sprintf("building bucket key: %s", err)
+			return err
+		}
+		req = makeAddOverrideRequest(rl.NewOrdersPerAccount, bucketKey, organization, tier)
+		accountDomainOrIP = accountURI
+
+	case rl.CertificatesPerDomainPerAccount.String():
+		accountURI, err := im.getValidatedFieldValue(fields, AccountURIFieldName, "")
+		if err != nil {
+			pendingComment = fmt.Sprintf("getting/validating accountURI: %s", err)
+			return err
+		}
+		accountID, err := accountURIToID(accountURI)
+		if err != nil {
+			pendingComment = fmt.Sprintf("parsing accountURI to accountID: %s", err)
+			return err
+		}
+		bucketKey, err := rl.BuildBucketKey(rl.CertificatesPerDomainPerAccount, accountID, identifier.ACMEIdentifier{}, identifier.ACMEIdentifiers{}, netip.Addr{})
+		if err != nil {
+			pendingComment = fmt.Sprintf("building bucket key: %s", err)
+			return err
+		}
+		req = makeAddOverrideRequest(rl.CertificatesPerDomainPerAccount, bucketKey, organization, tier)
+		accountDomainOrIP = accountURI
+
+	case rl.CertificatesPerDomain.String() + perDNSNameSuffix:
+		dnsName, err := im.getValidatedFieldValue(fields, RegisteredDomainFieldName, rateLimit)
+		if err != nil {
+			pendingComment = fmt.Sprintf("getting/validating registeredDomain: %s", err)
+			return err
+		}
+		bucketKey, err := rl.BuildBucketKey(rl.CertificatesPerDomain, 0, identifier.NewDNS(dnsName), identifier.ACMEIdentifiers{}, netip.Addr{})
+		if err != nil {
+			pendingComment = fmt.Sprintf("building bucket key: %s", err)
+			return err
+		}
+		req = makeAddOverrideRequest(rl.CertificatesPerDomain, bucketKey, organization, tier)
+		accountDomainOrIP = dnsName
+
+	case rl.CertificatesPerDomain.String() + perIPSuffix:
+		ipAddrStr, err := im.getValidatedFieldValue(fields, IPAddressFieldName, rateLimit)
+		if err != nil {
+			pendingComment = fmt.Sprintf("getting/validating ipAddress: %s", err)
+			return err
+		}
+		ipAddr, err := netip.ParseAddr(ipAddrStr)
+		if err != nil {
+			pendingComment = fmt.Sprintf("parsing ipAddress: %s", err)
+			return err
+		}
+		bucketKey, err := rl.BuildBucketKey(rl.CertificatesPerDomain, 0, identifier.NewIP(ipAddr), identifier.ACMEIdentifiers{}, netip.Addr{})
+		if err != nil {
+			pendingComment = fmt.Sprintf("building bucket key: %s", err)
+			return err
+		}
+		req = makeAddOverrideRequest(rl.CertificatesPerDomain, bucketKey, organization, tier)
+		accountDomainOrIP = ipAddrStr
+
+	default:
+		err = fmt.Errorf("unknown rate limit %q", rateLimit)
+		pendingComment = "unknown rate limit"
+		return err
+	}
+
+	if accountDomainOrIP == "" {
+		// If this has occurred we have failed to set the accountDNSNameOrIP in
+		// one of the above cases, which is a bug.
+		return fmt.Errorf("no account/domain/IP specified for rate limit %s", rateLimit)
+	}
+
+	resp, err := im.ra.AddRateLimitOverride(ctx, req)
+	if err != nil {
+		// This is likely a transient error, so we leave the ticket as "solved"
+		// so that it will be retried on the next pass.
+		return fmt.Errorf("calling ra.AddRateLimitOverride: %w", err)
+	}
+
+	if !resp.Enabled {
+		pendingComment = "An existing override for this limit and requester is currently administratively disabled."
+		return fmt.Errorf("override for rate limit %s and account/domain/IP: %s is administratively disabled", rateLimit, accountDomainOrIP)
+	}
+
+	successCommentBody := fmt.Sprintf(
+		"Your override request for rate limit %s and account/domain/IP: %s "+
+			"has been approved. Your new limit is %d per week. Please allow up to 30 minutes for this change to take effect.",
+		rateLimit, accountDomainOrIP, tier,
+	)
+
+	err = im.zendesk.UpdateTicketStatus(ticketID, "solved", successCommentBody, true)
+	if err != nil {
+		return fmt.Errorf("transitioning ticket %d to solved with a comment: %w", ticketID, err)
+	}
+	return nil
+}

--- a/sfe/overridesimporter_test.go
+++ b/sfe/overridesimporter_test.go
@@ -1,0 +1,515 @@
+package sfe
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	blog "github.com/letsencrypt/boulder/log"
+	rapb "github.com/letsencrypt/boulder/ra/proto"
+	rl "github.com/letsencrypt/boulder/ratelimits"
+	"github.com/letsencrypt/boulder/sfe/zendesk"
+
+	"github.com/jmhodges/clock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+type raBehavior int
+
+const (
+	ok raBehavior = iota
+	alwaysError
+	alwaysAdministrativelyDisabled
+)
+
+type raFakeServer struct {
+	rapb.UnimplementedRegistrationAuthorityServer
+	behavior raBehavior
+
+	mu          sync.Mutex
+	lastRequest *rapb.AddRateLimitOverrideRequest
+	allRequests []*rapb.AddRateLimitOverrideRequest
+}
+
+func (s *raFakeServer) AddRateLimitOverride(ctx context.Context, r *rapb.AddRateLimitOverrideRequest) (*rapb.AddRateLimitOverrideResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.lastRequest = r
+	s.allRequests = append(s.allRequests, r)
+
+	switch s.behavior {
+	case ok:
+		return &rapb.AddRateLimitOverrideResponse{Enabled: true}, nil
+	case alwaysAdministrativelyDisabled:
+		return &rapb.AddRateLimitOverrideResponse{Enabled: false}, nil
+	case alwaysError:
+		return nil, status.Error(codes.Internal, "oh no, something has gone terriby awry!")
+	default:
+		return &rapb.AddRateLimitOverrideResponse{Enabled: true}, nil
+	}
+}
+
+func (s *raFakeServer) calls() []*rapb.AddRateLimitOverrideRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]*rapb.AddRateLimitOverrideRequest, len(s.allRequests))
+	copy(out, s.allRequests)
+	return out
+}
+
+func startRAFakeSrv(t *testing.T, behavior raBehavior) (*raFakeServer, rapb.RegistrationAuthorityClient, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Errorf("while creating listener: %s", err)
+	}
+
+	srv := grpc.NewServer()
+	fake := &raFakeServer{behavior: behavior}
+	rapb.RegisterRegistrationAuthorityServer(srv, fake)
+
+	done := make(chan struct{})
+	go func() {
+		_ = srv.Serve(lis)
+		close(done)
+	}()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Errorf("while creating grpc client: %s", err)
+	}
+	return fake, rapb.NewRegistrationAuthorityClient(conn), func() {
+		srv.GracefulStop()
+		<-done
+		_ = conn.Close()
+		_ = lis.Close()
+	}
+}
+
+func newImporter(t *testing.T, ra rapb.RegistrationAuthorityClient, zd *zendesk.Client, p ProcessMode) *OverridesImporter {
+	t.Helper()
+
+	var lg blog.Logger = blog.NewMock()
+	im, err := NewOverridesImporter(p, time.Minute, zd, ra, clock.New(), lg)
+	if err != nil {
+		t.Errorf("while creating OverridesImporter: %s", err)
+	}
+	return im
+}
+
+func createApprovedTicket(t *testing.T, c *zendesk.Client) int64 {
+	t.Helper()
+
+	fields := map[string]string{
+		RateLimitFieldName:    rl.NewOrdersPerAccount.String(),
+		TierFieldName:         "1000",
+		OrganizationFieldName: "Acme Corp",
+		AccountURIFieldName:   "https://acme-v02.api.letsencrypt.org/acme/acct/999",
+		ReviewStatusFieldName: reviewStatusApproved,
+	}
+
+	id, err := c.CreateTicket("foo@bar.biz", "Test Ticket", "Test Body", fields)
+	if err != nil {
+		t.Errorf("while creating test ticket: %s", err)
+	}
+	err = c.UpdateTicketStatus(id, "open", "", false)
+	if err != nil {
+		t.Errorf("while updating ticket %d to open: %s", id, err)
+	}
+	return id
+}
+
+func TestOverridesImporterProcessTicketHappyPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                       string
+		fields                     map[string]string
+		expectLimit                rl.Name
+		expectBucketKey            string
+		expectTier                 int64
+		expectBurst                int64
+		expectCount                int64
+		expectPeriod               time.Duration
+		expectOrgComment           string
+		expectLastCommentSubstring string
+	}{
+		{
+			name: "NewOrdersPerAccount with valid Account URI",
+			fields: map[string]string{
+				RateLimitFieldName:    rl.NewOrdersPerAccount.String(),
+				TierFieldName:         "1000",
+				OrganizationFieldName: "Acme Corp",
+				AccountURIFieldName:   "https://acme-v02.api.letsencrypt.org/acme/acct/12345",
+			},
+			expectLimit:                rl.NewOrdersPerAccount,
+			expectBucketKey:            "3:12345",
+			expectTier:                 1000,
+			expectBurst:                1000,
+			expectCount:                1000,
+			expectPeriod:               7 * 24 * time.Hour,
+			expectOrgComment:           "Acme Corp",
+			expectLastCommentSubstring: "has been approved. Your new limit is 1000 per week",
+		},
+		{
+			name: "CertificatesPerDomain with valid Registered Domain",
+			fields: map[string]string{
+				RateLimitFieldName:        rl.CertificatesPerDomain.String() + perDNSNameSuffix,
+				TierFieldName:             "300",
+				OrganizationFieldName:     "Acme Corp",
+				RegisteredDomainFieldName: "example.com",
+			},
+			expectLimit:                rl.CertificatesPerDomain,
+			expectBucketKey:            "5:example.com",
+			expectTier:                 300,
+			expectBurst:                300,
+			expectCount:                300,
+			expectPeriod:               7 * 24 * time.Hour,
+			expectOrgComment:           "Acme Corp",
+			expectLastCommentSubstring: "has been approved. Your new limit is 300 per week",
+		},
+		{
+			name: "CertificatesPerDomain with valid IPv4 Address",
+			fields: map[string]string{
+				RateLimitFieldName:    rl.CertificatesPerDomain.String() + perIPSuffix,
+				TierFieldName:         "300",
+				OrganizationFieldName: "Acme Corp",
+				IPAddressFieldName:    "64.112.11.11",
+			},
+			expectLimit:                rl.CertificatesPerDomain,
+			expectBucketKey:            "5:64.112.11.11/32",
+			expectTier:                 300,
+			expectBurst:                300,
+			expectCount:                300,
+			expectPeriod:               7 * 24 * time.Hour,
+			expectOrgComment:           "Acme Corp",
+			expectLastCommentSubstring: "has been approved. Your new limit is 300 per week",
+		},
+		{
+			name: "CertificatesPerDomain with valid IPv6",
+			fields: map[string]string{
+				RateLimitFieldName:    rl.CertificatesPerDomain.String() + perIPSuffix,
+				TierFieldName:         "300",
+				OrganizationFieldName: "Acme Corp",
+				IPAddressFieldName:    "2606:4700:4700::1111",
+			},
+			expectLimit:     rl.CertificatesPerDomain,
+			expectBucketKey: "5:2606:4700:4700::/64",
+			expectTier:      300, expectBurst: 300, expectCount: 300,
+			expectPeriod:               7 * 24 * time.Hour,
+			expectOrgComment:           "Acme Corp",
+			expectLastCommentSubstring: "has been approved. Your new limit is 300 per week",
+		},
+		{
+			name: "CertificatesPerDomainPerAccount with valid Account URI",
+			fields: map[string]string{
+				RateLimitFieldName:    rl.CertificatesPerDomainPerAccount.String(),
+				TierFieldName:         "300",
+				OrganizationFieldName: "Acme Corp",
+				AccountURIFieldName:   "https://acme-v02.api.letsencrypt.org/acme/acct/12345",
+			},
+			expectLimit:                rl.CertificatesPerDomainPerAccount,
+			expectBucketKey:            "6:12345",
+			expectTier:                 300,
+			expectBurst:                300,
+			expectCount:                300,
+			expectPeriod:               7 * 24 * time.Hour,
+			expectOrgComment:           "Acme Corp",
+			expectLastCommentSubstring: "has been approved. Your new limit is 300 per week",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			zdServer, zdClient := createFakeZendeskClientServer(t)
+			raSrv, raClient, stopRA := startRAFakeSrv(t, ok)
+			defer stopRA()
+
+			ticketID := createApprovedTicket(t, zdClient)
+
+			im := newImporter(t, raClient, zdClient, ProcessAll)
+			err := im.processTicket(context.Background(), ticketID, tc.fields)
+			if err != nil {
+				t.Errorf("processTicket got an unexpected error: %s", err)
+			}
+
+			req := raSrv.lastRequest
+			if req == nil {
+				t.Errorf("RA AddRateLimitOverride was not called")
+				return
+			}
+			if req.LimitEnum != int64(tc.expectLimit) {
+				t.Errorf("got rapb.AddRateLimitOverrideRequest.LimitEnum=%d, expected %d", req.LimitEnum, tc.expectLimit)
+			}
+			if req.Comment != tc.expectOrgComment {
+				t.Errorf("got rapb.AddRateLimitOverrideRequest.Comment=%q, expected %q", req.Comment, tc.expectOrgComment)
+			}
+			if req.Count != tc.expectCount {
+				t.Errorf("got rapb.AddRateLimitOverrideRequest.Count=%d, expected %d", req.Count, tc.expectCount)
+			}
+			if req.Burst != tc.expectBurst {
+				t.Errorf("got rapb.AddRateLimitOverrideRequest.Burst=%d, expected %d", req.Burst, tc.expectBurst)
+			}
+			gotPeriod := req.Period.AsDuration()
+			if gotPeriod != tc.expectPeriod {
+				t.Errorf("got rapb.AddRateLimitOverrideRequest.Period=%s, expected %s", gotPeriod, tc.expectPeriod)
+			}
+			if req.BucketKey != tc.expectBucketKey {
+				t.Errorf("got rapb.AddRateLimitOverrideRequest.BucketKey=%q, expected %q", req.BucketKey, tc.expectBucketKey)
+			}
+
+			got, ok := zdServer.GetTicket(ticketID)
+			if !ok {
+				t.Errorf("ticket %d not found in zendesk store", ticketID)
+			}
+			if got.Status != "solved" {
+				// Ticket should remain "solved" after successful processing.
+				t.Errorf("unexpected ticket status=%q, expected solved", got.Status)
+			}
+
+			if tc.expectLastCommentSubstring == "" {
+				if len(got.Comments) != 1 {
+					t.Errorf("unexpected comments count: got %d, expected 1", len(got.Comments))
+				}
+			} else {
+				if len(got.Comments) < 2 {
+					t.Errorf("expected an additional comment, got %d comments (%#v)", len(got.Comments), got.Comments)
+				}
+				last := got.Comments[len(got.Comments)-1]
+				if !last.Public {
+					t.Errorf("expected last comment to be public but it was private")
+				}
+				if !strings.Contains(last.Body, tc.expectLastCommentSubstring) {
+					t.Errorf("last comment body %q does not contain %q", last.Body, tc.expectLastCommentSubstring)
+				}
+			}
+		})
+	}
+}
+
+func TestOverridesImporterProcessTicketSadPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                       string
+		tickerFields               map[string]string
+		raFakeBehavior             raBehavior
+		expectErrSubstring         string
+		expectStatus               string
+		expectLastCommentSubstring string
+	}{
+		{
+			name:                       "missing rate limit field",
+			tickerFields:               map[string]string{OrganizationFieldName: "Acme Corp"},
+			raFakeBehavior:             ok,
+			expectErrSubstring:         "missing rate limit field",
+			expectStatus:               "pending",
+			expectLastCommentSubstring: "missing rate limit field",
+		},
+		{
+			name: "invalid tier option (validation error)",
+			tickerFields: map[string]string{
+				RateLimitFieldName:    rl.NewOrdersPerAccount.String(),
+				TierFieldName:         "999",
+				OrganizationFieldName: "Acme Corp",
+				AccountURIFieldName:   "https://acme-v02.api.letsencrypt.org/acme/acct/12345",
+			},
+			raFakeBehavior:             ok,
+			expectErrSubstring:         "invalid request override quantity",
+			expectStatus:               "pending",
+			expectLastCommentSubstring: "getting/validating tier field",
+		},
+		{
+			name: "invalid account URI (validation error)",
+			tickerFields: map[string]string{
+				RateLimitFieldName:    rl.NewOrdersPerAccount.String(),
+				TierFieldName:         "1000",
+				OrganizationFieldName: "Acme Corp",
+				AccountURIFieldName:   "https://acme-v02.ap1.letsencrypt.org/acme/acct/1",
+			},
+			raFakeBehavior:             ok,
+			expectErrSubstring:         "account URI is invalid",
+			expectStatus:               "pending",
+			expectLastCommentSubstring: "getting/validating accountURI",
+		},
+		{
+			name: "invalid IP (validation error)",
+			tickerFields: map[string]string{
+				RateLimitFieldName:    rl.CertificatesPerDomain.String() + perIPSuffix,
+				TierFieldName:         "300",
+				OrganizationFieldName: "Acme Corp",
+				IPAddressFieldName:    "2606:4700:4700::1111:12345",
+			},
+			raFakeBehavior: ok,
+
+			expectErrSubstring:         "IP address is invalid",
+			expectStatus:               "pending",
+			expectLastCommentSubstring: "getting/validating ipAddress",
+		},
+		{
+			name: "RA administratively disabled",
+			tickerFields: map[string]string{
+				RateLimitFieldName:    rl.NewOrdersPerAccount.String(),
+				TierFieldName:         "1000",
+				OrganizationFieldName: "Acme Corp",
+				AccountURIFieldName:   "https://acme-v02.api.letsencrypt.org/acme/acct/12345",
+			},
+			raFakeBehavior:             alwaysAdministrativelyDisabled,
+			expectErrSubstring:         "administratively disabled",
+			expectStatus:               "pending",
+			expectLastCommentSubstring: "administratively disabled",
+		},
+		{
+			name: "RA internal error (no ticket update)",
+			tickerFields: map[string]string{
+				RateLimitFieldName:    rl.NewOrdersPerAccount.String(),
+				TierFieldName:         "1000",
+				OrganizationFieldName: "Acme Corp",
+				AccountURIFieldName:   "https://acme-v02.api.letsencrypt.org/acme/acct/12345",
+			},
+			raFakeBehavior:     alwaysError,
+			expectErrSubstring: "calling ra.AddRateLimitOverride",
+			expectStatus:       "open",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zdServer, zdClient := createFakeZendeskClientServer(t)
+
+			_, raClient, stopRA := startRAFakeSrv(t, tc.raFakeBehavior)
+			defer stopRA()
+
+			ticketID := createApprovedTicket(t, zdClient)
+
+			im := newImporter(t, raClient, zdClient, ProcessAll)
+
+			err := im.processTicket(context.Background(), ticketID, tc.tickerFields)
+			if err == nil {
+				t.Errorf("processTicket error = nil, expected error containing %q", tc.expectErrSubstring)
+			}
+			if tc.expectErrSubstring != "" && !strings.Contains(err.Error(), tc.expectErrSubstring) {
+				t.Errorf("error=%q does not contain %q", err.Error(), tc.expectErrSubstring)
+			}
+
+			got, ok := zdServer.GetTicket(ticketID)
+			if !ok {
+				t.Errorf("ticket %d not found in zendesk store", ticketID)
+			}
+			if got.Status != tc.expectStatus {
+				t.Errorf("unexpected ticket status=%q, expected %q", got.Status, tc.expectStatus)
+			}
+
+			if tc.expectLastCommentSubstring == "" {
+				if len(got.Comments) != 1 {
+					t.Errorf("unexpected comments count: got %d; expected 1", len(got.Comments))
+				}
+			} else {
+				if len(got.Comments) < 2 {
+					t.Errorf("expected an additional comment, got %d comments (%#v)", len(got.Comments), got.Comments)
+				}
+				last := got.Comments[len(got.Comments)-1]
+				if last.Public != false {
+					t.Errorf("last comment Public=%t, expected false; errors should not be shown to end users", last.Public)
+				}
+				if !strings.Contains(last.Body, tc.expectLastCommentSubstring) {
+					t.Errorf("last comment body %q does not contain %q", last.Body, tc.expectLastCommentSubstring)
+				}
+
+			}
+		})
+	}
+}
+
+func TestTickProcessModes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		mode                 ProcessMode
+		expectTicketIDs      []int64
+		expectRARequestCount int
+	}{
+		{
+			name:                 "importer.tick() with Mode=ProcessAll",
+			mode:                 ProcessAll,
+			expectTicketIDs:      []int64{1, 2, 3},
+			expectRARequestCount: 3,
+		},
+		{
+			name:                 "importer.tick() with Mode=ProcessEven",
+			mode:                 processEven,
+			expectTicketIDs:      []int64{2},
+			expectRARequestCount: 1,
+		},
+		{
+			name:                 "importer.tick() with Mode=ProcessOdd",
+			mode:                 processOdd,
+			expectTicketIDs:      []int64{1, 3},
+			expectRARequestCount: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			zdServer, zdClient := createFakeZendeskClientServer(t)
+			raSrv, raClient, stopRA := startRAFakeSrv(t, ok)
+			defer stopRA()
+
+			var initialTicketIDs []int64
+			initialTicketIDToCommentsCount := make(map[int64]int)
+			for range 3 {
+				ticketID := createApprovedTicket(t, zdClient)
+				initialTicketIDs = append(initialTicketIDs, ticketID)
+
+				initialTicket, ok := zdServer.GetTicket(ticketID)
+				if !ok {
+					t.Errorf("ticket %d not found in zendesk store", ticketID)
+				}
+				initialTicketIDToCommentsCount[ticketID] = len(initialTicket.Comments)
+			}
+
+			im := newImporter(t, raClient, zdClient, tc.mode)
+			im.tick(context.Background())
+
+			AddRateLimitOverrideCalls := raSrv.calls()
+			if len(AddRateLimitOverrideCalls) != tc.expectRARequestCount {
+				t.Errorf("got %d RA AddRateLimitOverride calls, expected %d", len(AddRateLimitOverrideCalls), tc.expectRARequestCount)
+			}
+
+			processedTickets := make(map[int64]bool)
+			for _, id := range initialTicketIDs {
+				resultingTicket, ok := zdServer.GetTicket(id)
+				if !ok {
+					t.Errorf("ticket %d not found after tick", id)
+				}
+				if len(resultingTicket.Comments) > initialTicketIDToCommentsCount[id] {
+					// We know that a ticket was processed if it has more comments than it started with.
+					processedTickets[id] = true
+				}
+			}
+
+			if len(processedTickets) != len(tc.expectTicketIDs) {
+				t.Errorf("got %d processed tickets, expected %d", len(processedTickets), len(tc.expectTicketIDs))
+			}
+			for _, id := range tc.expectTicketIDs {
+				if !processedTickets[id] {
+					t.Errorf("expected ticket %d to be processed, but it was not", id)
+				}
+			}
+		})
+	}
+}

--- a/sfe/overridesimporter_test.go
+++ b/sfe/overridesimporter_test.go
@@ -50,7 +50,7 @@ func (s *raFakeServer) AddRateLimitOverride(ctx context.Context, r *rapb.AddRate
 	case alwaysAdministrativelyDisabled:
 		return &rapb.AddRateLimitOverrideResponse{Enabled: false}, nil
 	case alwaysError:
-		return nil, status.Error(codes.Internal, "oh no, something has gone terriby awry!")
+		return nil, status.Error(codes.Internal, "oh no, something has gone terribly awry!")
 	default:
 		return &rapb.AddRateLimitOverrideResponse{Enabled: true}, nil
 	}

--- a/test/config-next/sfe.json
+++ b/test/config-next/sfe.json
@@ -47,6 +47,10 @@
 				"IPAddress": 67890123
 			}
 		},
+		"overridesImporter": {
+			"mode": "all",
+			"interval": "20m"
+		},
 		"features": {}
 	},
 	"syslog": {


### PR DESCRIPTION
Add a periodic background job to the SFE with the following responsibilities:

- Search for Zendesk tickets that have a status of "open" and an reviewStatus of "approved"
- Process even numbered, odd numbered, or all Zendesk tickets depending on JSON configuration; this allows us to process tickets simultaneously in both DCs without the two SFEs having to coordinate locks
- Re-validate fields from Zendesk tickets, perform any transformations as necessary (e.g. Account URI to ID)
- If any ticket fields fail validation transition to Zendesk ticket to "pending" and leave a private comment concerning the issue
- Write each approved and valid override request to the overrides table, in the enabled state
- If any requested override is already administratively disabled, notify SFE via a private comment and transition the ticket to "pending"
- Finally, close the ticket with a public comment that contains the relevant information

Closes #8166