### PR TITLE
Remove '-tags "integration"' from build

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -185,7 +185,7 @@ def install(race_detection, coverage=False):
     # Pass empty BUILD_TIME and BUILD_ID flags to avoid constantly invalidating the
     # build cache with new BUILD_TIMEs, or invalidating it on merges with a new
     # BUILD_ID.
-    go_build_flags='-tags "integration"'
+    go_build_flags=''
     if race_detection:
         go_build_flags += ' -race'
 


### PR DESCRIPTION
This was used to gate support for FAKECLOCK, which is now removed.

Note this is distinct from `go test -tags integration`.

Followup to #8356