### PR TITLE
Add multi-architecture (amd64 & arm64) builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,13 +6,19 @@ FROM docker.io/ubuntu:24.04 AS builder
 ARG COMMIT_ID
 ARG GO_VERSION
 ARG VERSION
+ARG TARGETPLATFORM
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get --assume-yes --no-install-recommends --update install \
     ca-certificates curl gcc git gnupg2 libc6-dev
 
 COPY tools/fetch-and-verify-go.sh /tmp
-RUN /tmp/fetch-and-verify-go.sh ${GO_VERSION}
+RUN case "${TARGETPLATFORM}" in \
+        "linux/amd64") PLATFORM="linux-amd64" ;; \
+        "linux/arm64") PLATFORM="linux-arm64" ;; \
+        *) echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac && \
+    /tmp/fetch-and-verify-go.sh ${GO_VERSION} ${PLATFORM}
 RUN tar -C /opt -xzf go.tar.gz
 ENV PATH="/opt/go/bin:${PATH}"
 

--- a/tools/container-build.sh
+++ b/tools/container-build.sh
@@ -7,36 +7,53 @@
 
 set -ex
 
-# Without this, `go install` produces:
-# # runtime/cgo
-# gcc: error: unrecognized command-line option '-m64'
-if [ "$(uname -m)" = "arm64" ]; then
-  export DOCKER_DEFAULT_PLATFORM=linux/amd64
-fi
-
 if [ -z "${GO_VERSION}" ] ; then
   echo "GO_VERSION not set"
   exit 1
 fi
 
-ARCH="$(uname -m)"
 COMMIT_ID="$(git rev-parse --short=8 HEAD)"
 VERSION="${GO_VERSION}.$(date +%s)"
 
+# Detect architecture to build for (allow override via DOCKER_DEFAULT_PLATFORM)
+if [ -n "${DOCKER_DEFAULT_PLATFORM}" ]; then
+    PLATFORM="${DOCKER_DEFAULT_PLATFORM}"
+else
+    case "$(uname -m)" in
+        "x86_64") PLATFORM="linux/amd64" ;;
+        "aarch64"|"arm64") PLATFORM="linux/arm64" ;;
+        *) echo "Unsupported architecture: $(uname -m)" && exit 1 ;;
+    esac
+fi
+
+# Extract architecture from platform
+case "$PLATFORM" in
+    "linux/amd64") ARCH="amd64" ;;
+    "linux/arm64") ARCH="arm64" ;;
+    *) echo "Unsupported platform: ${PLATFORM}" && exit 1 ;;
+esac
+
+# Create platform-specific image
 docker buildx build \
     --file Containerfile \
+    --platform "$PLATFORM" \
     --build-arg "COMMIT_ID=${COMMIT_ID}" \
     --build-arg "GO_VERSION=${GO_VERSION}" \
     --build-arg "VERSION=${VERSION}" \
+    --tag "boulder:${VERSION}-${ARCH}" \
     --tag "boulder:${VERSION}" \
     --tag "boulder:${COMMIT_ID}" \
     --tag boulder \
+    --load \
     .
 
-docker run boulder tar -C /opt/boulder -cpz . > "./boulder-${VERSION}-${COMMIT_ID}.${ARCH}.tar.gz" .
-# Produces e.g. boulder-1.25.0.1754519595-591c0545.x86_64.deb
+# Create tarball
+docker run "boulder:${VERSION}-${ARCH}" tar -C /opt/boulder -cpz . > "./boulder-${VERSION}-${COMMIT_ID}.${ARCH}.tar.gz"
+
+# Create .deb package
 docker run -v .:/boulderrepo \
-  -e "COMMIT_ID=$(git rev-parse --short=8 HEAD)" \
-  -e "VERSION=${VERSION}" \
-  boulder \
-  /boulderrepo/tools/make-deb.sh
+    -e "COMMIT_ID=${COMMIT_ID}" \
+    -e "VERSION=${VERSION}" \
+    -e "ARCH=${ARCH}" \
+    "boulder:${VERSION}-${ARCH}" \
+    /boulderrepo/tools/make-deb.sh


### PR DESCRIPTION
### Summary

This PR modifies the Boulder build system to support both amd64 and arm64 architectures while defaulting to building only the current host architecture. This enables efficient local development and lays the foundation for future parallel multi-architecture CI builds.

### Changes Made

#### `tools/container-build.sh`

- __Architecture detection__: Automatically detects host architecture using `uname -m`
- __Single-arch builds__: Builds only for the detected architecture by default
- __Override support__: `DOCKER_DEFAULT_PLATFORM` environment variable for manual overrides

#### `Containerfile`

- __Platform-aware Go downloads__: Uses `TARGETPLATFORM` build arg to pass correct platform to `fetch-and-verify-go.sh`
- __Cross-platform compatibility__: Supports both `linux/amd64` and `linux/arm64` platforms

#### `tools/make-deb.sh`

- __Dynamic architecture detection__: Uses `ARCH` environment variable or falls back to `uname -m`
- __Proper Debian architecture mapping__: Correctly maps to `amd64`/`arm64` for .deb packages

### Testing

- ARM64 build on Apple Silicon: `GO_VERSION=1.24.6 ./tools/container-build.sh`
- AMD64 override on ARM host: `DOCKER_DEFAULT_PLATFORM=linux/amd64 GO_VERSION=1.24.6 ./tools/container-build.sh`
- Artifact generation: Produces properly named `.amd64.tar.gz`/`.arm64.tar.gz` and `.amd64.deb`/`.arm64.deb` files
- Docker image tagging: Creates both architecture-specific and generic tags

### Usage Examples

```bash
# Default: Build current architecture
GO_VERSION=1.24.6 ./tools/container-build.sh

# Override: Build specific architecture 
DOCKER_DEFAULT_PLATFORM=linux/amd64 GO_VERSION=1.24.6 ./tools/container-build.sh
```

This change prepares the build system for future GitHub Actions matrix builds with different runners for each architecture, while immediately improving local development efficiency.

Fixes https://github.com/letsencrypt/boulder/issues/8388