### PR TITLE
CA: Stop using OCSP status NotReady

### DIFF
--- a/test/integration/cert_storage_failed_test.go
+++ b/test/integration/cert_storage_failed_test.go
@@ -60,9 +60,8 @@ func getPrecertByName(db *sql.DB, reversedName string) (*x509.Certificate, error
 
 // TestIssuanceCertStorageFailed tests what happens when a storage RPC fails
 // during issuance. Specifically, it tests that case where we successfully
-// prepared and stored a linting certificate plus metadata, but after
-// issuing the precertificate we failed to mark the certificate as "ready"
-// to serve an OCSP "good" response.
+// prepared and stored a linting certificate plus metadata, but failed to store
+// the corresponding final certificate after issuance completed.
 //
 // To do this, we need to mess with the database, because we want to cause
 // a failure in one specific query, without control ever returning to the


### PR DESCRIPTION
Stop setting "OcspNotReady: true" when asking the SA to store a linting precertificate, and stop calling SetCertificateStatusReady after precertificate issuance has succeeded. Because these two calls are always made in sequence by the same CA instance, this change will not leave any database entries permanently hanging in the "NotReady" state (unless an error occurs between the two calls, as is the case today).

A follow-up change will remove the corresponding support on the SA side.

Part of https://github.com/letsencrypt/boulder/issues/8343