### PR TITLE
issuance: Remove last vestiges of OCSP support

### DIFF
--- a/crl/checker/checker_test.go
+++ b/crl/checker/checker_test.go
@@ -61,8 +61,8 @@ func TestDiff(t *testing.T) {
 				CertFile: "../../test/hierarchy/int-e1.cert.pem",
 			},
 			IssuerURL:  "http://not-example.com/issuer-url",
-			OCSPURL:    "http://not-example.com/ocsp",
 			CRLURLBase: "http://not-example.com/crl/",
+			CRLShards:  1,
 		}, clock.NewFake())
 	test.AssertNotError(t, err, "loading test issuer")
 

--- a/crl/storer/storer_test.go
+++ b/crl/storer/storer_test.go
@@ -62,8 +62,8 @@ func setupTestUploadCRL(t *testing.T) (*crlStorer, *issuance.Issuer) {
 				CertFile: "../../test/hierarchy/int-e1.cert.pem",
 			},
 			IssuerURL:  "http://not-example.com/issuer-url",
-			OCSPURL:    "http://not-example.com/ocsp",
 			CRLURLBase: "http://not-example.com/crl/",
+			CRLShards:  1,
 		}, clock.NewFake())
 	test.AssertNotError(t, err, "loading fake ECDSA issuer cert")
 

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -321,8 +321,7 @@ func TestGenerateTemplate(t *testing.T) {
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		IssuingCertificateURL: []string{"http://issuer"},
 		Policies:              []x509.OID{domainValidatedOID},
-		// These fields are only included if specified in the profile.
-		OCSPServer:            nil,
+		// This field is computed based on the serial, so is not included in the template.
 		CRLDistributionPoints: nil,
 	}
 
@@ -488,7 +487,6 @@ func TestIssueWithCRLDP(t *testing.T) {
 		t.Fatalf("ecdsa.GenerateKey: %s", err)
 	}
 	profile := defaultProfile()
-	profile.includeCRLDistributionPoints = true
 	_, issuanceToken, err := signer.Prepare(profile, &IssuanceRequest{
 		PublicKey:       MarshalablePublicKey{pk.Public()},
 		SubjectKeyId:    goodSKID,


### PR DESCRIPTION
The AIA OCSP URI is always omitted, and therefore the CRLDistributionPoint URL is always included. This implicitly drops support for "temporal sharding" (mapping certs to CRLs by their notAfter, rather than by their baked-in CRLDP) but that had in fact already become unsupported when OmitOCSP was made non-functional.

Fixes https://github.com/letsencrypt/boulder/issues/8177