### PR TITLE
Remove support for temporally-sharded CRLs

### DIFF
--- a/cmd/crl-updater/main.go
+++ b/cmd/crl-updater/main.go
@@ -82,6 +82,9 @@ type Config struct {
 		// When deploying explicit sharding (i.e. the CRLDistributionPoints extension),
 		// the CAs should be configured with a new set of serial prefixes that haven't
 		// been used before.
+		//
+		// Deprecated: The updater no longer supports temporal sharding.
+		// TODO(#8345): Remove this.
 		TemporallyShardedSerialPrefixes []string
 
 		// MaxParallelism controls how many workers may be running in parallel.
@@ -202,7 +205,6 @@ func main() {
 		c.CRLUpdater.MaxAttempts,
 		c.CRLUpdater.CacheControl,
 		c.CRLUpdater.ExpiresMargin.Duration,
-		c.CRLUpdater.TemporallyShardedSerialPrefixes,
 		sac,
 		cac,
 		csc,

--- a/crl/updater/batch.go
+++ b/crl/updater/batch.go
@@ -34,7 +34,7 @@ func (cu *crlUpdater) RunOnce(ctx context.Context) error {
 				if !ok {
 					return
 				}
-				err := cu.updateShardWithRetry(ctx, atTime, work.issuerNameID, work.shardIdx, nil)
+				err := cu.updateShardWithRetry(ctx, atTime, work.issuerNameID, work.shardIdx)
 				if err != nil {
 					cu.log.AuditErrf(
 						"Generating CRL failed: id=[%s] err=[%s]",

--- a/crl/updater/batch_test.go
+++ b/crl/updater/batch_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
+
 	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
@@ -28,7 +29,6 @@ func TestRunOnce(t *testing.T) {
 		6*time.Hour, time.Minute, 1, 1,
 		"stale-if-error=60",
 		5*time.Minute,
-		nil,
 		&fakeSAC{revokedCerts: revokedCertsStream{err: errors.New("db no worky")}, maxNotAfter: clk.Now().Add(90 * 24 * time.Hour)},
 		&fakeCA{gcc: generateCRLStream{}},
 		&fakeStorer{uploaderStream: &noopUploader{}},

--- a/crl/updater/continuous.go
+++ b/crl/updater/continuous.go
@@ -41,7 +41,7 @@ func (cu *crlUpdater) Run(ctx context.Context) error {
 			}
 
 			atTime := cu.clk.Now()
-			err := cu.updateShardWithRetry(ctx, atTime, issuerNameID, shardIdx, nil)
+			err := cu.updateShardWithRetry(ctx, atTime, issuerNameID, shardIdx)
 			if err != nil {
 				// We only log, rather than return, so that the long-lived process can
 				// continue and try again at the next tick.

--- a/crl/updater/updater.go
+++ b/crl/updater/updater.go
@@ -3,16 +3,12 @@ package updater
 import (
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
-	"math"
-	"slices"
 	"time"
 
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	capb "github.com/letsencrypt/boulder/ca/proto"
@@ -22,7 +18,6 @@ import (
 	cspb "github.com/letsencrypt/boulder/crl/storer/proto"
 	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
-	"github.com/letsencrypt/boulder/revocation"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
 
@@ -38,8 +33,6 @@ type crlUpdater struct {
 
 	cacheControl  string
 	expiresMargin time.Duration
-
-	temporallyShardedPrefixes []string
 
 	sa sapb.StorageAuthorityClient
 	ca capb.CRLGeneratorClient
@@ -63,7 +56,6 @@ func NewUpdater(
 	maxAttempts int,
 	cacheControl string,
 	expiresMargin time.Duration,
-	temporallyShardedPrefixes []string,
 	sa sapb.StorageAuthorityClient,
 	ca capb.CRLGeneratorClient,
 	cs cspb.CRLStorerClient,
@@ -124,7 +116,6 @@ func NewUpdater(
 		maxAttempts,
 		cacheControl,
 		expiresMargin,
-		temporallyShardedPrefixes,
 		sa,
 		ca,
 		cs,
@@ -137,20 +128,10 @@ func NewUpdater(
 
 // updateShardWithRetry calls updateShard repeatedly (with exponential backoff
 // between attempts) until it succeeds or the max number of attempts is reached.
-func (cu *crlUpdater) updateShardWithRetry(ctx context.Context, atTime time.Time, issuerNameID issuance.NameID, shardIdx int, chunks []chunk) error {
+func (cu *crlUpdater) updateShardWithRetry(ctx context.Context, atTime time.Time, issuerNameID issuance.NameID, shardIdx int) error {
 	deadline := cu.clk.Now().Add(cu.updateTimeout)
 	ctx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
-
-	if chunks == nil {
-		// Compute the shard map and relevant chunk boundaries, if not supplied.
-		// Batch mode supplies this to avoid duplicate computation.
-		shardMap, err := cu.getShardMappings(ctx, atTime)
-		if err != nil {
-			return fmt.Errorf("computing shardmap: %w", err)
-		}
-		chunks = shardMap[shardIdx%cu.numShards]
-	}
 
 	_, err := cu.sa.LeaseCRLShard(ctx, &sapb.LeaseCRLShardRequest{
 		IssuerNameID: int64(issuerNameID),
@@ -174,7 +155,7 @@ func (cu *crlUpdater) updateShardWithRetry(ctx context.Context, atTime time.Time
 		}
 		cu.clk.Sleep(sleepTime)
 
-		err = cu.updateShard(ctx, atTime, issuerNameID, shardIdx, chunks)
+		err = cu.updateShard(ctx, atTime, issuerNameID, shardIdx)
 		if err == nil {
 			break
 		}
@@ -196,75 +177,11 @@ func (cu *crlUpdater) updateShardWithRetry(ctx context.Context, atTime time.Time
 	return nil
 }
 
-type crlStream interface {
-	Recv() (*proto.CRLEntry, error)
-}
-
-// reRevoked returns the later of the two entries, only if the latter represents a valid
-// re-revocation of the former (reason == KeyCompromise).
-func reRevoked(a *proto.CRLEntry, b *proto.CRLEntry) (*proto.CRLEntry, error) {
-	first, second := a, b
-	if b.RevokedAt.AsTime().Before(a.RevokedAt.AsTime()) {
-		first, second = b, a
-	}
-	if revocation.Reason(first.Reason) != revocation.KeyCompromise && revocation.Reason(second.Reason) == revocation.KeyCompromise {
-		return second, nil
-	}
-	// The RA has logic to prevent re-revocation for any reason other than KeyCompromise,
-	// so this should be impossible. The best we can do is error out.
-	return nil, fmt.Errorf("certificate %s was revoked with reason %d at %s and re-revoked with invalid reason %d at %s",
-		first.Serial, first.Reason, first.RevokedAt.AsTime(), second.Reason, second.RevokedAt.AsTime())
-}
-
-// addFromStream pulls `proto.CRLEntry` objects from a stream, adding them to the crlEntries map.
-//
-// Consolidates duplicates and checks for internal consistency of the results.
-// If allowedSerialPrefixes is non-empty, only serials with that one-byte prefix (two hex-encoded
-// bytes) will be accepted.
-//
-// Returns the number of entries received from the stream, regardless of whether they were accepted.
-func addFromStream(crlEntries map[string]*proto.CRLEntry, stream crlStream, allowedSerialPrefixes []string) (int, error) {
-	var count int
-	for {
-		entry, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return 0, fmt.Errorf("retrieving entry from SA: %w", err)
-		}
-		count++
-		serialPrefix := entry.Serial[0:2]
-		if len(allowedSerialPrefixes) > 0 && !slices.Contains(allowedSerialPrefixes, serialPrefix) {
-			continue
-		}
-		previousEntry := crlEntries[entry.Serial]
-		if previousEntry == nil {
-			crlEntries[entry.Serial] = entry
-			continue
-		}
-		if previousEntry.Reason == entry.Reason &&
-			previousEntry.RevokedAt.AsTime().Equal(entry.RevokedAt.AsTime()) {
-			continue
-		}
-
-		// There's a tiny possibility a certificate was re-revoked for KeyCompromise and
-		// we got a different view of it from temporal sharding vs explicit sharding.
-		// Prefer the re-revoked CRL entry, which must be the one with KeyCompromise.
-		second, err := reRevoked(entry, previousEntry)
-		if err != nil {
-			return 0, err
-		}
-		crlEntries[entry.Serial] = second
-	}
-	return count, nil
-}
-
 // updateShard processes a single shard. It computes the shard's boundaries, gets
 // the list of revoked certs in that shard from the SA, gets the CA to sign the
 // resulting CRL, and gets the crl-storer to upload it. It returns an error if
 // any of these operations fail.
-func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerNameID issuance.NameID, shardIdx int, chunks []chunk) (err error) {
+func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerNameID issuance.NameID, shardIdx int) (err error) {
 	if shardIdx <= 0 {
 		return fmt.Errorf("invalid shard %d", shardIdx)
 	}
@@ -284,33 +201,7 @@ func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerN
 		cu.updatedCounter.WithLabelValues(cu.issuers[issuerNameID].Subject.CommonName, result).Inc()
 	}()
 
-	cu.log.Infof(
-		"Generating CRL shard: id=[%s] numChunks=[%d]", crlID, len(chunks))
-
-	// Deduplicate the CRL entries by serial number, since we can get the same certificate via
-	// both temporal sharding (GetRevokedCerts) and explicit sharding (GetRevokedCertsByShard).
-	crlEntries := make(map[string]*proto.CRLEntry)
-
-	for _, chunk := range chunks {
-		saStream, err := cu.sa.GetRevokedCerts(ctx, &sapb.GetRevokedCertsRequest{
-			IssuerNameID:  int64(issuerNameID),
-			ExpiresAfter:  timestamppb.New(chunk.start),
-			ExpiresBefore: timestamppb.New(chunk.end),
-			RevokedBefore: timestamppb.New(atTime),
-		})
-		if err != nil {
-			return fmt.Errorf("GetRevokedCerts: %w", err)
-		}
-
-		n, err := addFromStream(crlEntries, saStream, cu.temporallyShardedPrefixes)
-		if err != nil {
-			return fmt.Errorf("streaming GetRevokedCerts: %w", err)
-		}
-
-		cu.log.Infof(
-			"Queried SA for CRL shard: id=[%s] expiresAfter=[%s] expiresBefore=[%s] numEntries=[%d]",
-			crlID, chunk.start, chunk.end, n)
-	}
+	cu.log.Infof("Generating CRL shard: id=[%s]", crlID)
 
 	// Query for unexpired certificates, with padding to ensure that revoked certificates show
 	// up in at least one CRL, even if they expire between revocation and CRL generation.
@@ -326,13 +217,19 @@ func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerN
 		return fmt.Errorf("GetRevokedCertsByShard: %w", err)
 	}
 
-	n, err := addFromStream(crlEntries, saStream, nil)
-	if err != nil {
-		return fmt.Errorf("streaming GetRevokedCertsByShard: %w", err)
+	var crlEntries []*proto.CRLEntry
+	for {
+		entry, err := saStream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("retrieving entry from SA: %w", err)
+		}
+		crlEntries = append(crlEntries, entry)
 	}
 
-	cu.log.Infof(
-		"Queried SA by CRL shard number: id=[%s] shardIdx=[%d] numEntries=[%d]", crlID, shardIdx, n)
+	cu.log.Infof("Queried SA for CRL shard: id=[%s] shardIdx=[%d] numEntries=[%d]", crlID, shardIdx, len(crlEntries))
 
 	// Send the full list of CRL Entries to the CA.
 	caStream, err := cu.ca.GenerateCRL(ctx)
@@ -429,128 +326,4 @@ func (cu *crlUpdater) updateShard(ctx context.Context, atTime time.Time, issuerN
 		crlID, crlLen, crlHash.Sum(nil))
 
 	return nil
-}
-
-// anchorTime is used as a universal starting point against which other times
-// can be compared. This time must be less than 290 years (2^63-1 nanoseconds)
-// in the past, to ensure that Go's time.Duration can represent that difference.
-// The significance of 2015-06-04 11:04:38 UTC is left as an exercise to the
-// reader.
-func anchorTime() time.Time {
-	return time.Date(2015, time.June, 04, 11, 04, 38, 0, time.UTC)
-}
-
-// chunk represents a fixed slice of time during which some certificates
-// presumably expired or will expire. Its non-unique index indicates which shard
-// it will be mapped to. The start boundary is inclusive, the end boundary is
-// exclusive.
-type chunk struct {
-	start time.Time
-	end   time.Time
-	Idx   int
-}
-
-// shardMap is a mapping of shard indices to the set of chunks which should be
-// included in that shard. Under most circumstances there is a one-to-one
-// mapping, but certain configuration (such as having very narrow shards, or
-// having a very long lookback period) can result in more than one chunk being
-// mapped to a single shard.
-type shardMap [][]chunk
-
-// getShardMappings determines which chunks are currently relevant, based on
-// the current time, the configured lookbackPeriod, and the farthest-future
-// certificate expiration in the database. It then maps all of those chunks to
-// their corresponding shards, and returns that mapping.
-//
-// The idea here is that shards should be stable. Picture a timeline, divided
-// into chunks. Number those chunks from 0 (starting at the anchor time) up to
-// numShards, then repeat the cycle when you run out of numbers:
-//
-//	chunk:  0     1     2     3     4     0     1     2     3     4     0
-//	     |-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----...
-//	     ^-anchorTime
-//
-// The total time window we care about goes from atTime-lookbackPeriod, forward
-// through the time of the farthest-future notAfter date found in the database.
-// The lookbackPeriod must be larger than the updatePeriod, to ensure that any
-// certificates which were both revoked *and* expired since the last time we
-// issued CRLs get included in this generation. Because these times are likely
-// to fall in the middle of chunks, we include the whole chunks surrounding
-// those times in our output CRLs:
-//
-//	included chunk:     4     0     1     2     3     4     0     1
-//	      ...--|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----...
-//	atTime-lookbackPeriod-^   ^-atTime                lastExpiry-^
-//
-// Because this total period of time may include multiple chunks with the same
-// number, we then coalesce these chunks into a single shard. Ideally, this
-// will never happen: it should only happen if the lookbackPeriod is very
-// large, or if the shardWidth is small compared to the lastExpiry (such that
-// numShards * shardWidth is less than lastExpiry - atTime). In this example,
-// shards 0, 1, and 4 all get the contents of two chunks mapped to them, while
-// shards 2 and 3 get only one chunk each.
-//
-//	included chunk:     4     0     1     2     3     4     0     1
-//	      ...--|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----...
-//	                    │     │     │     │     │     │     │     │
-//	shard 0: <────────────────┘─────────────────────────────┘     │
-//	shard 1: <──────────────────────┘─────────────────────────────┘
-//	shard 2: <────────────────────────────┘     │     │
-//	shard 3: <──────────────────────────────────┘     │
-//	shard 4: <──────────┘─────────────────────────────┘
-//
-// Under this scheme, the shard to which any given certificate will be mapped is
-// a function of only three things: that certificate's notAfter timestamp, the
-// chunk width, and the number of shards.
-func (cu *crlUpdater) getShardMappings(ctx context.Context, atTime time.Time) (shardMap, error) {
-	res := make(shardMap, cu.numShards)
-
-	// Get the farthest-future expiration timestamp to ensure we cover everything.
-	lastExpiry, err := cu.sa.GetMaxExpiration(ctx, &emptypb.Empty{})
-	if err != nil {
-		return nil, err
-	}
-
-	// Find the id number and boundaries of the earliest chunk we care about.
-	first := atTime.Add(-cu.lookbackPeriod)
-	c, err := GetChunkAtTime(cu.shardWidth, cu.numShards, first)
-	if err != nil {
-		return nil, err
-	}
-
-	// Iterate over chunks until we get completely beyond the farthest-future
-	// expiration.
-	for c.start.Before(lastExpiry.AsTime()) {
-		res[c.Idx] = append(res[c.Idx], c)
-		c = chunk{
-			start: c.end,
-			end:   c.end.Add(cu.shardWidth),
-			Idx:   (c.Idx + 1) % cu.numShards,
-		}
-	}
-
-	return res, nil
-}
-
-// GetChunkAtTime returns the chunk whose boundaries contain the given time.
-// It is exported so that it can be used by both the crl-updater and the RA
-// as we transition from dynamic to static shard mappings.
-func GetChunkAtTime(shardWidth time.Duration, numShards int, atTime time.Time) (chunk, error) {
-	// Compute the amount of time between the current time and the anchor time.
-	timeSinceAnchor := atTime.Sub(anchorTime())
-	if timeSinceAnchor == time.Duration(math.MaxInt64) || timeSinceAnchor < 0 {
-		return chunk{}, errors.New("shard boundary math broken: anchor time too far away")
-	}
-
-	// Determine how many full chunks fit within that time, and from that the
-	// index number of the desired chunk.
-	chunksSinceAnchor := timeSinceAnchor.Nanoseconds() / shardWidth.Nanoseconds()
-	chunkIdx := int(chunksSinceAnchor) % numShards
-
-	// Determine the boundaries of the chunk.
-	timeSinceChunk := time.Duration(timeSinceAnchor.Nanoseconds() % shardWidth.Nanoseconds())
-	left := atTime.Add(-timeSinceChunk)
-	right := left.Add(shardWidth)
-
-	return chunk{left, right, chunkIdx}, nil
 }

--- a/crl/updater/updater_test.go
+++ b/crl/updater/updater_test.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
-	"reflect"
 	"testing"
 	"time"
 
@@ -31,7 +29,7 @@ import (
 
 // revokedCertsStream is a fake grpc.ClientStreamingClient which can be
 // populated with some CRL entries or an error for use as the return value of
-// a faked GetRevokedCerts call.
+// a faked GetRevokedCertsByShard call.
 type revokedCertsStream struct {
 	grpc.ClientStream
 	entries []*corepb.CRLEntry
@@ -52,35 +50,18 @@ func (f *revokedCertsStream) Recv() (*corepb.CRLEntry, error) {
 }
 
 // fakeSAC is a fake sapb.StorageAuthorityClient which can be populated with a
-// fakeGRCC to be used as the return value for calls to GetRevokedCerts, and a
-// fake timestamp to serve as the database's maximum notAfter value.
+// fakeGRCC to be used as the return value for calls to GetRevokedCertsByShard,
+// and a fake timestamp to serve as the database's maximum notAfter value.
 type fakeSAC struct {
 	sapb.StorageAuthorityClient
-	revokedCerts        revokedCertsStream
-	revokedCertsByShard revokedCertsStream
-	maxNotAfter         time.Time
-	leaseError          error
+	revokedCerts revokedCertsStream
+	maxNotAfter  time.Time
+	leaseError   error
 }
 
-func (f *fakeSAC) GetRevokedCerts(ctx context.Context, _ *sapb.GetRevokedCertsRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[corepb.CRLEntry], error) {
-	return &f.revokedCerts, nil
-}
-
-// Return some configured contents, but only for shard 2.
+// Return the configured stream.
 func (f *fakeSAC) GetRevokedCertsByShard(ctx context.Context, req *sapb.GetRevokedCertsByShardRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[corepb.CRLEntry], error) {
-	// This time is based on the setting of `clk` in TestUpdateShard,
-	// minus the setting of `lookbackPeriod` in that same function (24h).
-	want := time.Date(2020, time.January, 17, 0, 0, 0, 0, time.UTC)
-	got := req.ExpiresAfter.AsTime().UTC()
-	if !got.Equal(want) {
-		return nil, fmt.Errorf("fakeSAC.GetRevokedCertsByShard called with ExpiresAfter=%s, want %s",
-			got, want)
-	}
-
-	if req.ShardIdx == 2 {
-		return &f.revokedCertsByShard, nil
-	}
-	return &revokedCertsStream{}, nil
+	return &f.revokedCerts, nil
 }
 
 func (f *fakeSAC) GetMaxExpiration(_ context.Context, req *emptypb.Empty, _ ...grpc.CallOption) (*timestamppb.Timestamp, error) {
@@ -241,7 +222,6 @@ func TestUpdateShard(t *testing.T) {
 		1, 1,
 		"stale-if-error=60",
 		5*time.Minute,
-		nil,
 		&fakeSAC{
 			revokedCerts: revokedCertsStream{},
 			maxNotAfter:  clk.Now().Add(90 * 24 * time.Hour),
@@ -252,12 +232,8 @@ func TestUpdateShard(t *testing.T) {
 	)
 	test.AssertNotError(t, err, "building test crlUpdater")
 
-	testChunks := []chunk{
-		{clk.Now(), clk.Now().Add(18 * time.Hour), 0},
-	}
-
 	// Ensure that getting no results from the SA still works.
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertNotError(t, err, "empty CRL")
 	test.AssertMetricWithLabelsEquals(t, cu.updatedCounter, prometheus.Labels{
 		"issuer": "(TEST) Elegant Elephant E1", "result": "success",
@@ -281,15 +257,6 @@ func TestUpdateShard(t *testing.T) {
 					Reason:    int32(revocation.KeyCompromise),
 					RevokedAt: now,
 				},
-			},
-		},
-		revokedCertsByShard: revokedCertsStream{
-			entries: []*corepb.CRLEntry{
-				{
-					Serial:    "0311b5d430823cfa25b0fc85d14c54ee35",
-					Reason:    int32(revocation.KeyCompromise),
-					RevokedAt: now,
-				},
 				{
 					Serial:    "037d6a05a0f6a975380456ae605cee9889",
 					Reason:    int32(revocation.AffiliationChanged),
@@ -306,7 +273,7 @@ func TestUpdateShard(t *testing.T) {
 	}
 	// We ask for shard 2 specifically because GetRevokedCertsByShard only returns our
 	// certificate for that shard.
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 2, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 2)
 	test.AssertNotError(t, err, "updateShard")
 
 	expectedEntries := map[string]int32{
@@ -341,7 +308,7 @@ func TestUpdateShard(t *testing.T) {
 	cu.updatedCounter.Reset()
 
 	// Ensure that getting no results from the SA still works.
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertNotError(t, err, "empty CRL")
 	test.AssertMetricWithLabelsEquals(t, cu.updatedCounter, prometheus.Labels{
 		"issuer": "(TEST) Elegant Elephant E1", "result": "success",
@@ -350,7 +317,7 @@ func TestUpdateShard(t *testing.T) {
 
 	// Errors closing the Storer upload stream should bubble up.
 	cu.cs = &fakeStorer{uploaderStream: &noopUploader{recvErr: sentinelErr}}
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertError(t, err, "storer error")
 	test.AssertContains(t, err.Error(), "closing CRLStorer upload stream")
 	test.AssertErrorIs(t, err, sentinelErr)
@@ -361,7 +328,7 @@ func TestUpdateShard(t *testing.T) {
 
 	// Errors sending to the Storer should bubble up sooner.
 	cu.cs = &fakeStorer{uploaderStream: &noopUploader{sendErr: sentinelErr}}
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertError(t, err, "storer error")
 	test.AssertContains(t, err.Error(), "sending CRLStorer metadata")
 	test.AssertErrorIs(t, err, sentinelErr)
@@ -372,7 +339,7 @@ func TestUpdateShard(t *testing.T) {
 
 	// Errors reading from the CA should bubble up sooner.
 	cu.ca = &fakeCA{gcc: generateCRLStream{recvErr: sentinelErr}}
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertError(t, err, "CA error")
 	test.AssertContains(t, err.Error(), "receiving CRL bytes")
 	test.AssertErrorIs(t, err, sentinelErr)
@@ -383,7 +350,7 @@ func TestUpdateShard(t *testing.T) {
 
 	// Errors sending to the CA should bubble up sooner.
 	cu.ca = &fakeCA{gcc: generateCRLStream{sendErr: sentinelErr}}
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertError(t, err, "CA error")
 	test.AssertContains(t, err.Error(), "sending CA metadata")
 	test.AssertErrorIs(t, err, sentinelErr)
@@ -394,7 +361,7 @@ func TestUpdateShard(t *testing.T) {
 
 	// Errors reading from the SA should bubble up soonest.
 	cu.sa = &fakeSAC{revokedCerts: revokedCertsStream{err: sentinelErr}, maxNotAfter: clk.Now().Add(90 * 24 * time.Hour)}
-	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShard(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertError(t, err, "database error")
 	test.AssertContains(t, err.Error(), "retrieving entry from SA")
 	test.AssertErrorIs(t, err, sentinelErr)
@@ -424,7 +391,6 @@ func TestUpdateShardWithRetry(t *testing.T) {
 		6*time.Hour, time.Minute, 1, 1,
 		"stale-if-error=60",
 		5*time.Minute,
-		nil,
 		&fakeSAC{revokedCerts: revokedCertsStream{err: sentinelErr}, maxNotAfter: clk.Now().Add(90 * 24 * time.Hour)},
 		&fakeCA{gcc: generateCRLStream{}},
 		&fakeStorer{uploaderStream: &noopUploader{}},
@@ -432,14 +398,10 @@ func TestUpdateShardWithRetry(t *testing.T) {
 	)
 	test.AssertNotError(t, err, "building test crlUpdater")
 
-	testChunks := []chunk{
-		{clk.Now(), clk.Now().Add(18 * time.Hour), 0},
-	}
-
 	// Ensure that having MaxAttempts set to 1 results in the clock not moving
 	// forward at all.
 	startTime := cu.clk.Now()
-	err = cu.updateShardWithRetry(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShardWithRetry(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertError(t, err, "database error")
 	test.AssertErrorIs(t, err, sentinelErr)
 	test.AssertEquals(t, cu.clk.Now(), startTime)
@@ -449,272 +411,11 @@ func TestUpdateShardWithRetry(t *testing.T) {
 	// in, so we have to be approximate.
 	cu.maxAttempts = 5
 	startTime = cu.clk.Now()
-	err = cu.updateShardWithRetry(ctx, cu.clk.Now(), e1.NameID(), 1, testChunks)
+	err = cu.updateShardWithRetry(ctx, cu.clk.Now(), e1.NameID(), 1)
 	test.AssertError(t, err, "database error")
 	test.AssertErrorIs(t, err, sentinelErr)
 	t.Logf("start: %v", startTime)
 	t.Logf("now: %v", cu.clk.Now())
 	test.Assert(t, startTime.Add(15*0.8*time.Second).Before(cu.clk.Now()), "retries didn't sleep enough")
 	test.Assert(t, startTime.Add(15*1.2*time.Second).After(cu.clk.Now()), "retries slept too much")
-}
-
-func TestGetShardMappings(t *testing.T) {
-	// We set atTime to be exactly one day (numShards * shardWidth) after the
-	// anchorTime for these tests, so that we know that the index of the first
-	// chunk we would normally (i.e. not taking lookback or overshoot into
-	// account) care about is 0.
-	atTime := anchorTime().Add(24 * time.Hour)
-
-	// When there is no lookback, and the maxNotAfter is exactly as far in the
-	// future as the numShards * shardWidth looks, every shard should be mapped to
-	// exactly one chunk.
-	tcu := crlUpdater{
-		numShards:      24,
-		shardWidth:     1 * time.Hour,
-		sa:             &fakeSAC{maxNotAfter: atTime.Add(23*time.Hour + 30*time.Minute)},
-		lookbackPeriod: 0,
-	}
-	m, err := tcu.getShardMappings(context.Background(), atTime)
-	test.AssertNotError(t, err, "getting aligned shards")
-	test.AssertEquals(t, len(m), 24)
-	for _, s := range m {
-		test.AssertEquals(t, len(s), 1)
-	}
-
-	// When there is 1.5 hours each of lookback and maxNotAfter overshoot, then
-	// there should be four shards which each get two chunks mapped to them.
-	tcu = crlUpdater{
-		numShards:      24,
-		shardWidth:     1 * time.Hour,
-		sa:             &fakeSAC{maxNotAfter: atTime.Add(24*time.Hour + 90*time.Minute)},
-		lookbackPeriod: 90 * time.Minute,
-	}
-	m, err = tcu.getShardMappings(context.Background(), atTime)
-	test.AssertNotError(t, err, "getting overshoot shards")
-	test.AssertEquals(t, len(m), 24)
-	for i, s := range m {
-		if i == 0 || i == 1 || i == 22 || i == 23 {
-			test.AssertEquals(t, len(s), 2)
-		} else {
-			test.AssertEquals(t, len(s), 1)
-		}
-	}
-
-	// When there is a massive amount of overshoot, many chunks should be mapped
-	// to each shard.
-	tcu = crlUpdater{
-		numShards:      24,
-		shardWidth:     1 * time.Hour,
-		sa:             &fakeSAC{maxNotAfter: atTime.Add(90 * 24 * time.Hour)},
-		lookbackPeriod: time.Minute,
-	}
-	m, err = tcu.getShardMappings(context.Background(), atTime)
-	test.AssertNotError(t, err, "getting overshoot shards")
-	test.AssertEquals(t, len(m), 24)
-	for i, s := range m {
-		if i == 23 {
-			test.AssertEquals(t, len(s), 91)
-		} else {
-			test.AssertEquals(t, len(s), 90)
-		}
-	}
-
-	// An arbitrarily-chosen chunk should always end up in the same shard no
-	// matter what the current time, lookback, and overshoot are, as long as the
-	// number of shards and the shard width remains constant.
-	tcu = crlUpdater{
-		numShards:      24,
-		shardWidth:     1 * time.Hour,
-		sa:             &fakeSAC{maxNotAfter: atTime.Add(24 * time.Hour)},
-		lookbackPeriod: time.Hour,
-	}
-	m, err = tcu.getShardMappings(context.Background(), atTime)
-	test.AssertNotError(t, err, "getting consistency shards")
-	test.AssertEquals(t, m[10][0].start, anchorTime().Add(34*time.Hour))
-	tcu.lookbackPeriod = 4 * time.Hour
-	m, err = tcu.getShardMappings(context.Background(), atTime)
-	test.AssertNotError(t, err, "getting consistency shards")
-	test.AssertEquals(t, m[10][0].start, anchorTime().Add(34*time.Hour))
-	tcu.sa = &fakeSAC{maxNotAfter: atTime.Add(300 * 24 * time.Hour)}
-	m, err = tcu.getShardMappings(context.Background(), atTime)
-	test.AssertNotError(t, err, "getting consistency shards")
-	test.AssertEquals(t, m[10][0].start, anchorTime().Add(34*time.Hour))
-	atTime = atTime.Add(6 * time.Hour)
-	m, err = tcu.getShardMappings(context.Background(), atTime)
-	test.AssertNotError(t, err, "getting consistency shards")
-	test.AssertEquals(t, m[10][0].start, anchorTime().Add(34*time.Hour))
-}
-
-func TestGetChunkAtTime(t *testing.T) {
-	// Our test updater divides time into chunks 1 day wide, numbered 0 through 9.
-	numShards := 10
-	shardWidth := 24 * time.Hour
-
-	// The chunk right at the anchor time should have index 0 and start at the
-	// anchor time. This also tests behavior when atTime is on a chunk boundary.
-	atTime := anchorTime()
-	c, err := GetChunkAtTime(shardWidth, numShards, atTime)
-	test.AssertNotError(t, err, "getting chunk at anchor")
-	test.AssertEquals(t, c.Idx, 0)
-	test.Assert(t, c.start.Equal(atTime), "getting chunk at anchor")
-	test.Assert(t, c.end.Equal(atTime.Add(24*time.Hour)), "getting chunk at anchor")
-
-	// The chunk a bit over a year in the future should have index 5.
-	atTime = anchorTime().Add(365 * 24 * time.Hour)
-	c, err = GetChunkAtTime(shardWidth, numShards, atTime.Add(time.Minute))
-	test.AssertNotError(t, err, "getting chunk")
-	test.AssertEquals(t, c.Idx, 5)
-	test.Assert(t, c.start.Equal(atTime), "getting chunk")
-	test.Assert(t, c.end.Equal(atTime.Add(24*time.Hour)), "getting chunk")
-
-	// A chunk very far in the future should break the math. We have to add to
-	// the time twice, since the whole point of "very far in the future" is that
-	// it isn't representable by a time.Duration.
-	atTime = anchorTime().Add(200 * 365 * 24 * time.Hour).Add(200 * 365 * 24 * time.Hour)
-	_, err = GetChunkAtTime(shardWidth, numShards, atTime)
-	test.AssertError(t, err, "getting far-future chunk")
-}
-
-func TestAddFromStream(t *testing.T) {
-	now := time.Now()
-	yesterday := now.Add(-24 * time.Hour)
-	simpleEntry := &corepb.CRLEntry{
-		Serial:    "abcdefg",
-		Reason:    int32(revocation.CessationOfOperation),
-		RevokedAt: timestamppb.New(yesterday),
-	}
-
-	reRevokedEntry := &corepb.CRLEntry{
-		Serial:    "abcdefg",
-		Reason:    int32(revocation.KeyCompromise),
-		RevokedAt: timestamppb.New(now),
-	}
-
-	reRevokedEntryOld := &corepb.CRLEntry{
-		Serial:    "abcdefg",
-		Reason:    int32(revocation.KeyCompromise),
-		RevokedAt: timestamppb.New(now.Add(-48 * time.Hour)),
-	}
-
-	reRevokedEntryBadReason := &corepb.CRLEntry{
-		Serial:    "abcdefg",
-		Reason:    int32(revocation.AffiliationChanged),
-		RevokedAt: timestamppb.New(now),
-	}
-
-	type testCase struct {
-		name      string
-		inputs    [][]*corepb.CRLEntry
-		expected  map[string]*corepb.CRLEntry
-		expectErr bool
-	}
-
-	testCases := []testCase{
-		{
-			name: "two streams with same entry",
-			inputs: [][]*corepb.CRLEntry{
-				{simpleEntry},
-				{simpleEntry},
-			},
-			expected: map[string]*corepb.CRLEntry{
-				simpleEntry.Serial: simpleEntry,
-			},
-		},
-		{
-			name: "re-revoked",
-			inputs: [][]*corepb.CRLEntry{
-				{simpleEntry},
-				{simpleEntry, reRevokedEntry},
-			},
-			expected: map[string]*corepb.CRLEntry{
-				simpleEntry.Serial: reRevokedEntry,
-			},
-		},
-		{
-			name: "re-revoked (newer shows up first)",
-			inputs: [][]*corepb.CRLEntry{
-				{reRevokedEntry, simpleEntry},
-				{simpleEntry},
-			},
-			expected: map[string]*corepb.CRLEntry{
-				simpleEntry.Serial: reRevokedEntry,
-			},
-		},
-		{
-			name: "re-revoked (wrong date)",
-			inputs: [][]*corepb.CRLEntry{
-				{simpleEntry},
-				{simpleEntry, reRevokedEntryOld},
-			},
-			expectErr: true,
-		},
-		{
-			name: "re-revoked (wrong reason)",
-			inputs: [][]*corepb.CRLEntry{
-				{simpleEntry},
-				{simpleEntry, reRevokedEntryBadReason},
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			crlEntries := make(map[string]*corepb.CRLEntry)
-			var err error
-			for _, input := range tc.inputs {
-				_, err = addFromStream(crlEntries, &revokedCertsStream{entries: input}, nil)
-				if err != nil {
-					break
-				}
-			}
-			if tc.expectErr {
-				if err == nil {
-					t.Errorf("addFromStream=%+v, want error", crlEntries)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("addFromStream=%s, want no error", err)
-				}
-
-				if !reflect.DeepEqual(crlEntries, tc.expected) {
-					t.Errorf("addFromStream=%+v, want %+v", crlEntries, tc.expected)
-				}
-			}
-		})
-	}
-}
-
-func TestAddFromStreamDisallowedSerialPrefix(t *testing.T) {
-	now := time.Now()
-	yesterday := now.Add(-24 * time.Hour)
-	input := []*corepb.CRLEntry{
-		{
-			Serial:    "abcdefg",
-			Reason:    int32(revocation.CessationOfOperation),
-			RevokedAt: timestamppb.New(yesterday),
-		},
-		{
-			Serial:    "01020304",
-			Reason:    int32(revocation.CessationOfOperation),
-			RevokedAt: timestamppb.New(yesterday),
-		},
-	}
-	crlEntries := make(map[string]*corepb.CRLEntry)
-	var err error
-	_, err = addFromStream(
-		crlEntries,
-		&revokedCertsStream{entries: input},
-		[]string{"ab"},
-	)
-	if err != nil {
-		t.Fatalf("addFromStream: %s", err)
-	}
-	expected := map[string]*corepb.CRLEntry{
-		"abcdefg": input[0],
-	}
-
-	if !reflect.DeepEqual(crlEntries, expected) {
-		t.Errorf("addFromStream=%+v, want %+v", crlEntries, expected)
-	}
 }

--- a/docs/CRLS.md
+++ b/docs/CRLS.md
@@ -3,10 +3,10 @@
 For each issuer certificate, Boulder generates several sharded CRLs.
 The responsibility is shared across these components:
 
- - crl-updater
- - sa
- - ca
- - crl-storer
+- crl-updater
+- sa
+- ca
+- crl-storer
 
 The crl-updater starts the process: for each shard of each issuer,
 it requests revoked certificate information from the SA. It sends
@@ -26,63 +26,21 @@ where that issuer's CRLs will be served.
 
 ## Shard assignment
 
-Certificates are assigned to shards one of two ways: temporally or explicitly.
-Temporal shard assignment places certificates into shards based on their
-notAfter. Explicit shard assignment places certificates into shards based
-on the (random) low bytes of their serial numbers.
-
-Boulder distinguishes the two types of sharding by the one-byte (two hex
-encoded bytes) prefix on the serial number, configured at the CA.
-When enabling explicit sharding at the CA, operators should at the same
-time change the CA's configured serial prefix. Also, the crl-updater should
-be configured with `temporallyShardedPrefixes` set to the _old_ serial prefix.
-
-An explicitly sharded certificate will always have the CRLDistributionPoints
-extension, containing a URL that points to its CRL shard. A temporally sharded
-certificate will never have that extension.
-
-As of Jan 2025, we are planning to turn on explicit sharding for new
-certificates soon. Once all temporally sharded certificates have expired, we
-will remove the code for temporal sharding.
+Certificates are assigned to shards explicitly at issuance time, with the
+selected shard baked into the certificate as part of its CRLDistributionPoints
+extension. The shard is selected based on taking the (random) low bytes of the
+serial number modulo the number of shards produced by that certificate's issuer.
 
 ## Storage
 
-When a certificate is revoked, its status in the `certificateStatus` table is
-always updated. If that certificate has an explicit shard, an entry in the
-`revokedCertificates` table is also added or updated. Note: the certificateStatus
-table has an entry for every certificate, even unrevoked ones. The
-`revokedCertificates` table only has entries for revoked certificates.
+When a certificate is revoked, the new status is written to both the
+`certificateStatus` table and the `revokedCertificates` table. The former
+contains an entry for every certificate, explicitly recording that newly-issued
+certificates are not revoked. The latter is less explicit but more scalable,
+containing rows only for certificates which have been revoked.
 
 The SA exposes the two different types of recordkeeping in two different ways:
-`GetRevokedCerts` returns revoked certificates whose NotAfter dates fall
-within a requested range. This is used for temporal sharding.
-`GetRevokedCertsByShard` returns revoked certificates whose `shardIdx` matches
-the requested shard.
-
-For each shard, the crl-storer queries both methods. Typically a certificate
-will have a different temporal shard than its explicit shard, so for a
-transition period, revoked certs may show up in two different CRL shards.
-A fraction of certificates will have the same temporal shard as their explicit
-shard. To avoid including the same serial twice in the same sharded CRL, the
-crl-updater de-duplicates by serial number.
-
-## Enabling explicit sharding
-
-Explicit sharding is enabled at the CA by configuring each issuer with a number
-of CRL shards. This number must be the same across all issuers and must match
-the number of shards configured on the crl-updater. As part of the same config
-deploy, the CA must be updated to issue using a new serial prefix.
-
-The crl-updater must also be updated to add the `temporallyShardedPrefixes`
-field, listing the _old_ serial prefixes (i.e., those that were issued by a CA
-that did not include the CRLDistributionPoints extension).
-
-Once we've turned on explicit sharding, we can turn it back off. However, for
-the certificates we've already issued, we are still committed to serving their
-revocations in the CRL hosted at the URL embedded in those certificates.
-Fortunately, all of the revocation and storage elements that rely on explicit
-sharding are gated by the contents of the certificate being revoked (specifically,
-the presence of CRLDistributionPoints). So even if we turn off explicit sharding
-for new certificates, we will still do the right thing at revocation time and
-CRL generation time for any already existing certificates that have a
-CRLDistributionPoints extension.
+`GetRevokedCerts` returns revoked certificates whose NotAfter dates fall within
+a requested range. `GetRevokedCertsByShard` returns revoked certificates whose
+`shardIdx` matches the requested shard. The crl-updater uses only the latter
+method, and the former will be removed in the future.

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1838,7 +1838,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 // on this certificate comes from one of our issuers.
 func crlShard(cert *x509.Certificate) (int64, error) {
 	if len(cert.CRLDistributionPoints) == 0 {
-		return 0, nil
+		return 0, errors.New("no crlDistributionPoints in certificate")
 	}
 	if len(cert.CRLDistributionPoints) > 1 {
 		return 0, errors.New("too many crlDistributionPoints in certificate")
@@ -1969,6 +1969,9 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 	}
 	if req.CrlShard != 0 && !req.Malformed {
 		return nil, errors.New("non-zero CRLShard is only allowed for malformed certificates (shard is automatic for well formed certificates)")
+	}
+	if req.Malformed && req.CrlShard == 0 {
+		return nil, errors.New("CRLShard is required for malformed certificates")
 	}
 
 	reasonCode := revocation.Reason(req.Code)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -4110,8 +4110,8 @@ func TestUpdateRegistrationKey(t *testing.T) {
 func TestCRLShard(t *testing.T) {
 	var cdp []string
 	n, err := crlShard(&x509.Certificate{CRLDistributionPoints: cdp})
-	if err != nil || n != 0 {
-		t.Errorf("crlShard(%+v) = %d, %s, want 0, nil", cdp, n, err)
+	if err == nil {
+		t.Errorf("crlShard(%+v) = %d, %s, want 0, some error", cdp, n, err)
 	}
 
 	cdp = []string{

--- a/test/certs.go
+++ b/test/certs.go
@@ -93,7 +93,8 @@ func ThrowAwayCert(t *testing.T, clk clock.Clock) (string, *x509.Certificate) {
 		IPAddresses:           []net.IP{ip},
 		NotBefore:             clk.Now(),
 		NotAfter:              clk.Now().Add(6 * 24 * time.Hour),
-		IssuingCertificateURL: []string{"http://localhost:4001/acme/issuer-cert/1234"},
+		IssuingCertificateURL: []string{"http://localhost:4001/issuer/1234/cert"},
+		CRLDistributionPoints: []string{"http://localhost:4002/issuer/1234/crl/1"},
 	}
 
 	testCertDER, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -50,9 +50,6 @@
 		"updateTimeout": "1m",
 		"expiresMargin": "5m",
 		"cacheControl": "stale-if-error=60",
-		"temporallyShardedSerialPrefixes": [
-			"7f"
-		],
 		"maxParallelism": 10,
 		"maxAttempts": 2,
 		"features": {}


### PR DESCRIPTION
In crl-updater, delete the code which computes the set of temporal chunks that belong to a shard, which queries the database for revoked certs falling into those chunks, and which combines and deduplicates those results against the revoked certs from explicit shards.

In the SA, make the ShardIdx argument to RevokeCertificate and UpdateRevokedCertificate fully mandatory, and make updating the revokedCertificates table unconditional.

This paves the way for deleting the sa.GetMaxExpiration and sa.GetRevokedCerts methods, which were only called from code deleted by this change.

IN-11747 tracks the corresponding config change in prod.

Part of https://github.com/letsencrypt/boulder/issues/8399
Part of https://github.com/letsencrypt/boulder/issues/8322