### PR TITLE
Fix location of release.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -359,7 +359,7 @@ truncation, and performs it for SELECT queries as well as INSERT and UPDATE.
 # Release Process
 
 The current Boulder release process is described in
-[release.md](https://github.com/letsencrypt/boulder/docs/release.md). New
+[release.md](https://github.com/letsencrypt/boulder/blob/main/docs/release.md). New
 releases are tagged weekly, and artifacts are automatically produced for each
 release by GitHub Actions.
 


### PR DESCRIPTION
I noticed that the release.md file location in the condtributing docs had an incorrect filepath. Now it doesn't.