### PR TITLE
WIP: Allow issuers to configure specific profiles

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -67,20 +67,140 @@ type issuanceEvent struct {
 	}
 }
 
-// Two maps of keys to Issuers. Lookup by PublicKeyAlgorithm is useful for
-// determining the set of issuers which can sign a given (pre)cert, based on its
-// PublicKeyAlgorithm. Lookup by NameID is useful for looking up a specific
-// issuer based on the issuer of a given (pre)certificate.
+// issuerMaps provides easy lookup of valid issuers for precertificates and
+// certificates. Users should not access its internal data directly, and should
+// use the forPrecert and forFinalCert methods instead.
 type issuerMaps struct {
-	byAlg     map[x509.PublicKeyAlgorithm][]*issuance.Issuer
-	byNameID  map[issuance.NameID]*issuance.Issuer
-	byProfile map[string]*issuance.Issuer
+	// Lookup by issuer unique ID is useful for finding the specific issuer to use
+	// for a final cert, based on extracting that same unique ID from the precert.
+	byNameID map[issuance.NameID]*issuance.Issuer
+	// Lookup by profile and algorithm is useful for determining the set of
+	// issuers which can sign a potential precert, based on the requested profile
+	// and the CSR's pubkey.
+	byProfileAndAlg map[string]map[x509.PublicKeyAlgorithm][]*issuance.Issuer
 }
 
+// forPrecert returns a random issuer from among the pool of issuers that are
+// configured to issue for the given profile and csr's public key algorithm.
+func (im *issuerMaps) forPrecert(prof *certProfileWithID, csr *x509.CertificateRequest) (*issuance.Issuer, error) {
+	byAlg, ok := im.byProfileAndAlg[prof.name]
+	if !ok {
+		return nil, berrors.InternalServerError("no issuers found for profile %q", prof.name)
+	}
+
+	pool, ok := byAlg[csr.PublicKeyAlgorithm]
+	if !ok {
+		return nil, berrors.InternalServerError("no issuers found for profile %q and public key algorithm %q", csr.PublicKeyAlgorithm)
+	}
+
+	return pool[mrand.IntN(len(pool))], nil
+}
+
+// forFinalCert returns the exact issuer which was used to issue the given precert.
+func (im *issuerMaps) forFinalCert(precert *x509.Certificate) (*issuance.Issuer, error) {
+	issuer, ok := im.byNameID[issuance.IssuerNameID(precert)]
+	if !ok {
+		return nil, berrors.InternalServerError("no issuer found for Issuer Name %q", precert.Issuer)
+	}
+
+	return issuer, nil
+}
+
+func (im *issuerMaps) forCRL(id issuance.NameID) (*issuance.Issuer, error) {
+	issuer, ok := im.byNameID[id]
+	if !ok {
+		return nil, berrors.InternalServerError("no issuer found for nameID %d", id)
+	}
+
+	return issuer, nil
+}
+
+// certProfileWithID is a simple wrapper around issuance.Profile which adds
+// the profile's unique human-readable name, so that the name can be retrieved
+// from a profile object instead of only associated with it via a map.
 type certProfileWithID struct {
 	// name is a human readable name used to refer to the certificate profile.
 	name    string
 	profile *issuance.Profile
+}
+
+// LoadIssuersAndProfiles takes in all of the issuer and profile configs and
+// returns fully-loaded and cross-referenced in-memory issuers and profiles. The
+// return values are intended to be arguments to the NewCertificateAuthorityImpl
+// constructor. This function is exported so that it can be used in
+// cmd/boulder-ca/main.go, so that the real constructor can continue to take
+// in-memory structs as arguments for ease of testing.
+//
+// This loader ensures that there is at least one issuer for each key type, at
+// least one issuer for each profile, and no issuers which list profiles that
+// don't actually exist.
+func LoadIssuersAndProfiles(issuers []issuance.IssuerConfig, profiles map[string]issuance.ProfileConfig, clk clock.Clock) (*issuerMaps, map[string]*certProfileWithID, error) {
+	if len(issuers) < 1 {
+		return nil, nil, fmt.Errorf("must configure at least one issuer")
+	}
+
+	if len(profiles) <= 0 {
+		return nil, nil, fmt.Errorf("must configure at least one certificate profile")
+	}
+
+	// Load all of the profiles first, so we can cross-reference them when loading
+	// the issuers.
+	profilesByName := make(map[string]*certProfileWithID, len(profiles))
+	for name, profileConfig := range profiles {
+		profile, err := issuance.NewProfile(profileConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		profilesByName[name] = &certProfileWithID{name, profile}
+	}
+
+	// Because we're using a nested map, initialization is a little more complex
+	// than usual.
+	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer)
+	issuersByProfileAndAlg := make(map[string]map[x509.PublicKeyAlgorithm][]*issuance.Issuer)
+	for profile, _ := range profilesByName {
+		issuersByProfileAndAlg[profile] = make(map[x509.PublicKeyAlgorithm][]*issuance.Issuer)
+	}
+
+	// Load all of the issuers, ensuring that each one gets associated with the
+	// correct key algorithm and profile(s).
+	for _, issuerConfig := range issuers {
+		issuer, err := issuance.LoadIssuer(issuerConfig, clk)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		nameID := issuer.NameID()
+		_, duplicate := issuersByNameID[nameID]
+		if duplicate {
+			return nil, nil, fmt.Errorf("two issuers with same NameID %d (%q) configured", nameID, issuer.Name())
+		}
+		issuersByNameID[nameID] = issuer
+
+		for _, profile := range issuerConfig.Profiles {
+			_, ok := profilesByName[profile]
+			if !ok {
+				return nil, nil, fmt.Errorf("issuer %q configured with unrecognized profile %q", issuer.Name(), profile)
+			}
+
+			if issuer.IsActive() {
+				issuersByProfileAndAlg[profile][issuer.KeyType()] = append(issuersByProfileAndAlg[profile][issuer.KeyType()], issuer)
+			}
+		}
+	}
+
+	// Ensure that every profile has at least one issuer for each key type.
+	for profile, issuersByAlg := range issuersByProfileAndAlg {
+		if len(issuersByAlg[x509.ECDSA]) == 0 {
+			return nil, nil, fmt.Errorf("no ECDSA issuers configured for profile %q", profile)
+		}
+		if len(issuersByAlg[x509.RSA]) == 0 {
+			return nil, nil, fmt.Errorf("no RSA issuers configured for profile %q", profile)
+		}
+	}
+
+	return &issuerMaps{issuersByNameID, issuersByProfileAndAlg}, profilesByName, nil
 }
 
 // caMetrics holds various metrics which are shared between caImpl and crlImpl.
@@ -137,7 +257,7 @@ type certificateAuthorityImpl struct {
 	sa           sapb.StorageAuthorityCertificateClient
 	sctClient    rapb.SCTProviderClient
 	pa           core.PolicyAuthority
-	issuers      issuerMaps
+	issuers      *issuerMaps
 	certProfiles map[string]*certProfileWithID
 
 	// The prefix is prepended to the serial number.
@@ -152,64 +272,14 @@ type certificateAuthorityImpl struct {
 
 var _ capb.CertificateAuthorityServer = (*certificateAuthorityImpl)(nil)
 
-// makeIssuerMaps processes a list of issuers into a set of maps for easy
-// lookup either by key algorithm (useful for picking an issuer for a precert)
-// or by unique ID (useful for final certs and CRLs). If two issuers with
-// the same unique ID are encountered, an error is returned.
-func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
-	issuersByAlg := make(map[x509.PublicKeyAlgorithm][]*issuance.Issuer)
-	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer)
-	issuersByProfile := make(map[string]*issuance.Issuer)
-	for _, issuer := range issuers {
-		if _, found := issuersByNameID[issuer.NameID()]; found {
-			return issuerMaps{}, fmt.Errorf("two issuers with same NameID %d (%s) configured", issuer.NameID(), issuer.Name())
-		}
-		issuersByNameID[issuer.NameID()] = issuer
-		if issuer.IsActive() {
-			issuersByAlg[issuer.KeyType()] = append(issuersByAlg[issuer.KeyType()], issuer)
-		}
-	}
-	if i, ok := issuersByAlg[x509.ECDSA]; !ok || len(i) == 0 {
-		return issuerMaps{}, errors.New("no ECDSA issuers configured")
-	}
-	if i, ok := issuersByAlg[x509.RSA]; !ok || len(i) == 0 {
-		return issuerMaps{}, errors.New("no RSA issuers configured")
-	}
-	return issuerMaps{issuersByAlg, issuersByNameID, issuersByProfile}, nil
-}
-
-// makeCertificateProfilesMap processes a set of named certificate issuance
-// profile configs into a map from name to profile.
-func makeCertificateProfilesMap(profiles map[string]*issuance.ProfileConfig) (map[string]*certProfileWithID, error) {
-	if len(profiles) <= 0 {
-		return nil, fmt.Errorf("must pass at least one certificate profile")
-	}
-
-	profilesByName := make(map[string]*certProfileWithID, len(profiles))
-
-	for name, profileConfig := range profiles {
-		profile, err := issuance.NewProfile(profileConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		profilesByName[name] = &certProfileWithID{
-			name:    name,
-			profile: profile,
-		}
-	}
-
-	return profilesByName, nil
-}
-
 // NewCertificateAuthorityImpl creates a CA instance that can sign certificates
 // from any number of issuance.Issuers and for any number of profiles.
 func NewCertificateAuthorityImpl(
 	sa sapb.StorageAuthorityCertificateClient,
 	sctService rapb.SCTProviderClient,
 	pa core.PolicyAuthority,
-	boulderIssuers []*issuance.Issuer,
-	certificateProfiles map[string]*issuance.ProfileConfig,
+	issuers *issuerMaps,
+	profiles map[string]*certProfileWithID,
 	serialPrefix byte,
 	maxNames int,
 	keyPolicy goodkey.KeyPolicy,
@@ -217,34 +287,24 @@ func NewCertificateAuthorityImpl(
 	metrics *caMetrics,
 	clk clock.Clock,
 ) (*certificateAuthorityImpl, error) {
-	var ca *certificateAuthorityImpl
-	var err error
-
 	if serialPrefix < 0x01 || serialPrefix > 0x7f {
-		err = errors.New("serial prefix must be between 0x01 (1) and 0x7f (127)")
-		return nil, err
+		return nil, errors.New("serial prefix must be between 0x01 (1) and 0x7f (127)")
 	}
 
-	if len(boulderIssuers) == 0 {
+	if issuers == nil || len(issuers.byNameID) == 0 {
 		return nil, errors.New("must have at least one issuer")
 	}
 
-	certProfiles, err := makeCertificateProfilesMap(certificateProfiles)
-	if err != nil {
-		return nil, err
+	if len(profiles) == 0 {
+		return nil, errors.New("must have at least one profile")
 	}
 
-	issuers, err := makeIssuerMaps(boulderIssuers)
-	if err != nil {
-		return nil, err
-	}
-
-	ca = &certificateAuthorityImpl{
+	return &certificateAuthorityImpl{
 		sa:           sa,
 		sctClient:    sctService,
 		pa:           pa,
 		issuers:      issuers,
-		certProfiles: certProfiles,
+		certProfiles: profiles,
 		prefix:       serialPrefix,
 		maxNames:     maxNames,
 		keyPolicy:    keyPolicy,
@@ -252,9 +312,7 @@ func NewCertificateAuthorityImpl(
 		metrics:      metrics,
 		tracer:       otel.GetTracerProvider().Tracer("github.com/letsencrypt/boulder/ca"),
 		clk:          clk,
-	}
-
-	return ca, nil
+	}, nil
 }
 
 // issuePrecertificate is the first step in the [issuance cycle]. It allocates and stores a serial number,
@@ -380,9 +438,9 @@ func (ca *certificateAuthorityImpl) issueCertificateForPrecertificate(ctx contex
 		scts = append(scts, sct)
 	}
 
-	issuer, ok := ca.issuers.byNameID[issuance.IssuerNameID(precert)]
-	if !ok {
-		return nil, berrors.InternalServerError("no issuer found for Issuer Name %s", precert.Issuer)
+	issuer, err := ca.issuers.forFinalCert(precert)
+	if err != nil {
+		return nil, err
 	}
 
 	issuanceReq, err := issuance.RequestFromPrecert(precert, scts)
@@ -492,7 +550,7 @@ func generateSKID(pk crypto.PublicKey) ([]byte, error) {
 	return skid[0:20:20], nil
 }
 
-func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, certProfile certProfileWithID, serialBigInt *big.Int, notBefore time.Time, notAfter time.Time) ([]byte, *certProfileWithID, error) {
+func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, certProfile *certProfileWithID, serialBigInt *big.Int, notBefore time.Time, notAfter time.Time) ([]byte, *certProfileWithID, error) {
 	csr, err := x509.ParseCertificateRequest(issueReq.Csr)
 	if err != nil {
 		return nil, nil, err
@@ -506,16 +564,10 @@ func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context
 		return nil, nil, err
 	}
 
-	// Select which pool of issuers to use, based on the to-be-issued cert's key
-	// type.
-	alg := csr.PublicKeyAlgorithm
-
-	// Select a random issuer from among the active issuers of this key type.
-	issuerPool, ok := ca.issuers.byAlg[alg]
-	if !ok || len(issuerPool) == 0 {
-		return nil, nil, berrors.InternalServerError("no issuers found for public key algorithm %s", csr.PublicKeyAlgorithm)
+	issuer, err := ca.issuers.forPrecert(certProfile, csr)
+	if err != nil {
+		return nil, nil, err
 	}
-	issuer := issuerPool[mrand.IntN(len(issuerPool))]
 
 	if issuer.Cert.NotAfter.Before(notAfter) {
 		err = berrors.InternalServerError("cannot issue a certificate that expires after the issuer certificate")

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -72,8 +72,9 @@ type issuanceEvent struct {
 // PublicKeyAlgorithm. Lookup by NameID is useful for looking up a specific
 // issuer based on the issuer of a given (pre)certificate.
 type issuerMaps struct {
-	byAlg    map[x509.PublicKeyAlgorithm][]*issuance.Issuer
-	byNameID map[issuance.NameID]*issuance.Issuer
+	byAlg     map[x509.PublicKeyAlgorithm][]*issuance.Issuer
+	byNameID  map[issuance.NameID]*issuance.Issuer
+	byProfile map[string]*issuance.Issuer
 }
 
 type certProfileWithID struct {
@@ -156,8 +157,9 @@ var _ capb.CertificateAuthorityServer = (*certificateAuthorityImpl)(nil)
 // or by unique ID (useful for final certs and CRLs). If two issuers with
 // the same unique ID are encountered, an error is returned.
 func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
-	issuersByAlg := make(map[x509.PublicKeyAlgorithm][]*issuance.Issuer, 2)
-	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer, len(issuers))
+	issuersByAlg := make(map[x509.PublicKeyAlgorithm][]*issuance.Issuer)
+	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer)
+	issuersByProfile := make(map[string]*issuance.Issuer)
 	for _, issuer := range issuers {
 		if _, found := issuersByNameID[issuer.NameID()]; found {
 			return issuerMaps{}, fmt.Errorf("two issuers with same NameID %d (%s) configured", issuer.NameID(), issuer.Name())
@@ -173,7 +175,7 @@ func makeIssuerMaps(issuers []*issuance.Issuer) (issuerMaps, error) {
 	if i, ok := issuersByAlg[x509.RSA]; !ok || len(i) == 0 {
 		return issuerMaps{}, errors.New("no RSA issuers configured")
 	}
-	return issuerMaps{issuersByAlg, issuersByNameID}, nil
+	return issuerMaps{issuersByAlg, issuersByNameID, issuersByProfile}, nil
 }
 
 // makeCertificateProfilesMap processes a set of named certificate issuance
@@ -490,7 +492,7 @@ func generateSKID(pk crypto.PublicKey) ([]byte, error) {
 	return skid[0:20:20], nil
 }
 
-func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, certProfile *certProfileWithID, serialBigInt *big.Int, notBefore time.Time, notAfter time.Time) ([]byte, *certProfileWithID, error) {
+func (ca *certificateAuthorityImpl) issuePrecertificateInner(ctx context.Context, issueReq *capb.IssueCertificateRequest, certProfile certProfileWithID, serialBigInt *big.Int, notBefore time.Time, notAfter time.Time) ([]byte, *certProfileWithID, error) {
 	csr, err := x509.ParseCertificateRequest(issueReq.Csr)
 	if err != nil {
 		return nil, nil, err

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -98,16 +98,16 @@ func mustRead(path string) []byte {
 }
 
 type testCtx struct {
-	pa             core.PolicyAuthority
-	crl            *crlImpl
-	certProfiles   map[string]*issuance.ProfileConfig
-	serialPrefix   byte
-	maxNames       int
-	boulderIssuers []*issuance.Issuer
-	keyPolicy      goodkey.KeyPolicy
-	fc             clock.FakeClock
-	metrics        *caMetrics
-	logger         *blog.Mock
+	pa           core.PolicyAuthority
+	crl          *crlImpl
+	issuers      *issuerMaps
+	profiles     map[string]*certProfileWithID
+	serialPrefix byte
+	maxNames     int
+	keyPolicy    goodkey.KeyPolicy
+	fc           clock.FakeClock
+	metrics      *caMetrics
+	logger       *blog.Mock
 }
 
 type mockSA struct {
@@ -151,14 +151,14 @@ func setup(t *testing.T) *testCtx {
 	err = pa.LoadIdentPolicyFile("../test/ident-policy.yaml")
 	test.AssertNotError(t, err, "Couldn't set identifier policy")
 
-	certProfiles := make(map[string]*issuance.ProfileConfig, 0)
-	certProfiles["legacy"] = &issuance.ProfileConfig{
+	certProfiles := make(map[string]issuance.ProfileConfig, 0)
+	certProfiles["legacy"] = issuance.ProfileConfig{
 		IncludeCRLDistributionPoints: true,
 		MaxValidityPeriod:            config.Duration{Duration: time.Hour * 24 * 90},
 		MaxValidityBackdate:          config.Duration{Duration: time.Hour},
 		IgnoredLints:                 []string{"w_subject_common_name_included"},
 	}
-	certProfiles["modern"] = &issuance.ProfileConfig{
+	certProfiles["modern"] = issuance.ProfileConfig{
 		OmitCommonName:               true,
 		OmitKeyEncipherment:          true,
 		OmitClientAuth:               true,
@@ -168,23 +168,24 @@ func setup(t *testing.T) *testCtx {
 		MaxValidityBackdate:          config.Duration{Duration: time.Hour},
 		IgnoredLints:                 []string{"w_ext_subject_key_identifier_missing_sub_cert"},
 	}
-	test.AssertEquals(t, len(certProfiles), 2)
 
-	boulderIssuers := make([]*issuance.Issuer, 4)
-	for i, name := range []string{"int-r3", "int-r4", "int-e1", "int-e2"} {
-		boulderIssuers[i], err = issuance.LoadIssuer(issuance.IssuerConfig{
+	issuerConfigs := make([]issuance.IssuerConfig, 0)
+	for _, name := range []string{"int-r3", "int-r4", "int-e1", "int-e2"} {
+		issuerConfigs = append(issuerConfigs, issuance.IssuerConfig{
 			Active:     true,
+			Profiles:   []string{"legacy", "modern"},
 			IssuerURL:  fmt.Sprintf("http://not-example.com/i/%s", name),
-			OCSPURL:    "http://not-example.com/o",
 			CRLURLBase: fmt.Sprintf("http://not-example.com/c/%s/", name),
 			CRLShards:  10,
 			Location: issuance.IssuerLoc{
 				File:     fmt.Sprintf("../test/hierarchy/%s.key.pem", name),
 				CertFile: fmt.Sprintf("../test/hierarchy/%s.cert.pem", name),
 			},
-		}, fc)
-		test.AssertNotError(t, err, "Couldn't load test issuer")
+		})
 	}
+
+	issuers, profiles, err := LoadIssuersAndProfiles(issuerConfigs, certProfiles, fc)
+	test.AssertNotError(t, err, "Failed to load test issuers and configs")
 
 	keyPolicy, err := goodkey.NewPolicy(nil, nil)
 	test.AssertNotError(t, err, "Failed to create test keypolicy")
@@ -212,7 +213,7 @@ func setup(t *testing.T) *testCtx {
 	cametrics := &caMetrics{signatureCount, signErrorCount, lintErrorCount, certificatesCount}
 
 	crl, err := NewCRLImpl(
-		boulderIssuers,
+		issuers,
 		issuance.CRLProfileConfig{
 			ValidityInterval: config.Duration{Duration: 216 * time.Hour},
 			MaxBackdate:      config.Duration{Duration: time.Hour},
@@ -224,16 +225,16 @@ func setup(t *testing.T) *testCtx {
 	test.AssertNotError(t, err, "Failed to create crl impl")
 
 	return &testCtx{
-		pa:             pa,
-		crl:            crl,
-		certProfiles:   certProfiles,
-		serialPrefix:   0x11,
-		maxNames:       2,
-		boulderIssuers: boulderIssuers,
-		keyPolicy:      keyPolicy,
-		fc:             fc,
-		metrics:        cametrics,
-		logger:         blog.NewMock(),
+		pa:           pa,
+		crl:          crl,
+		profiles:     profiles,
+		serialPrefix: 0x11,
+		maxNames:     2,
+		issuers:      issuers,
+		keyPolicy:    keyPolicy,
+		fc:           fc,
+		metrics:      cametrics,
+		logger:       blog.NewMock(),
 	}
 }
 
@@ -359,8 +360,8 @@ func issueCertificateSubTestSetup(t *testing.T) (*certificateAuthorityImpl, *moc
 		sa,
 		mockSCTService{},
 		testCtx.pa,
-		testCtx.boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.issuers,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -399,7 +400,7 @@ func TestNoIssuers(t *testing.T) {
 		mockSCTService{},
 		testCtx.pa,
 		nil, // No issuers
-		testCtx.certProfiles,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -419,8 +420,8 @@ func TestMultipleIssuers(t *testing.T) {
 		sa,
 		mockSCTService{},
 		testCtx.pa,
-		testCtx.boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.issuers,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -492,7 +493,7 @@ func TestUnpredictableIssuance(t *testing.T) {
 		mockSCTService{},
 		testCtx.pa,
 		boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -534,10 +535,11 @@ func TestUnpredictableIssuance(t *testing.T) {
 	test.Assert(t, seenR3, "Expected at least one issuance from active issuer")
 }
 
+// TKTK change this to TestLoadIssuersAndProfiles
 func TestMakeCertificateProfilesMap(t *testing.T) {
 	t.Parallel()
 	testCtx := setup(t)
-	test.AssertEquals(t, len(testCtx.certProfiles), 2)
+	test.AssertEquals(t, len(testCtx.profiles), 2)
 
 	testCases := []struct {
 		name              string
@@ -571,7 +573,7 @@ func TestMakeCertificateProfilesMap(t *testing.T) {
 		},
 		{
 			name:             "default profiles from setup func",
-			profileConfigs:   testCtx.certProfiles,
+			profileConfigs:   testCtx.profiles,
 			expectedProfiles: []string{"legacy", "modern"},
 		},
 	}
@@ -656,8 +658,8 @@ func TestInvalidCSRs(t *testing.T) {
 			sa,
 			mockSCTService{},
 			testCtx.pa,
-			testCtx.boulderIssuers,
-			testCtx.certProfiles,
+			testCtx.issuers,
+			testCtx.profiles,
 			testCtx.serialPrefix,
 			testCtx.maxNames,
 			testCtx.keyPolicy,
@@ -689,15 +691,15 @@ func TestRejectValidityTooLong(t *testing.T) {
 	testCtx := setup(t)
 
 	// Jump to a time just moments before the test issuers expire.
-	future := testCtx.boulderIssuers[0].Cert.Certificate.NotAfter.Add(-1 * time.Hour)
+	future := testCtx.issuers[0].Cert.Certificate.NotAfter.Add(-1 * time.Hour)
 	testCtx.fc.Set(future)
 
 	ca, err := NewCertificateAuthorityImpl(
 		&mockSA{},
 		mockSCTService{},
 		testCtx.pa,
-		testCtx.boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.issuers,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -772,8 +774,8 @@ func TestIssueCertificateForPrecertificate(t *testing.T) {
 		sa,
 		mockSCTService{},
 		testCtx.pa,
-		testCtx.boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.issuers,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -834,8 +836,8 @@ func TestIssueCertificateForPrecertificateWithSpecificCertificateProfile(t *test
 		sa,
 		mockSCTService{},
 		testCtx.pa,
-		testCtx.boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.issuers,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -949,8 +951,8 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		sa,
 		mockSCTService{},
 		testCtx.pa,
-		testCtx.boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.issuers,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,
@@ -992,8 +994,8 @@ func TestIssueCertificateForPrecertificateDuplicateSerial(t *testing.T) {
 		errorsa,
 		mockSCTService{},
 		testCtx.pa,
-		testCtx.boulderIssuers,
-		testCtx.certProfiles,
+		testCtx.issuers,
+		testCtx.profiles,
 		testCtx.serialPrefix,
 		testCtx.maxNames,
 		testCtx.keyPolicy,

--- a/ca/crl.go
+++ b/ca/crl.go
@@ -22,7 +22,7 @@ import (
 
 type crlImpl struct {
 	capb.UnsafeCRLGeneratorServer
-	issuers   map[issuance.NameID]*issuance.Issuer
+	issuers   *issuerMaps
 	profile   *issuance.CRLProfile
 	maxLogLen int
 	log       blog.Logger
@@ -36,24 +36,19 @@ var _ capb.CRLGeneratorServer = (*crlImpl)(nil)
 // issue CRLs from. lifetime sets the validity period (inclusive) of the
 // resulting CRLs.
 func NewCRLImpl(
-	issuers []*issuance.Issuer,
+	issuers *issuerMaps,
 	profileConfig issuance.CRLProfileConfig,
 	maxLogLen int,
 	logger blog.Logger,
 	metrics *caMetrics,
 ) (*crlImpl, error) {
-	issuersByNameID := make(map[issuance.NameID]*issuance.Issuer, len(issuers))
-	for _, issuer := range issuers {
-		issuersByNameID[issuer.NameID()] = issuer
-	}
-
 	profile, err := issuance.NewCRLProfile(profileConfig)
 	if err != nil {
 		return nil, fmt.Errorf("loading CRL profile: %w", err)
 	}
 
 	return &crlImpl{
-		issuers:   issuersByNameID,
+		issuers:   issuers,
 		profile:   profile,
 		maxLogLen: maxLogLen,
 		log:       logger,
@@ -86,10 +81,9 @@ func (ci *crlImpl) GenerateCRL(stream grpc.BidiStreamingServer[capb.GenerateCRLR
 				return err
 			}
 
-			var ok bool
-			issuer, ok = ci.issuers[issuance.NameID(payload.Metadata.IssuerNameID)]
-			if !ok {
-				return fmt.Errorf("got unrecognized IssuerNameID: %d", payload.Metadata.IssuerNameID)
+			issuer, err = ci.issuers.forCRL(issuance.NameID(payload.Metadata.IssuerNameID))
+			if err != nil {
+				return err
 			}
 
 		case *capb.GenerateCRLRequest_Entry:

--- a/ca/crl_test.go
+++ b/ca/crl_test.go
@@ -92,7 +92,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
+				IssuerNameID: int64(testCtx.issuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 				ShardIdx:     1,
 			},
@@ -101,7 +101,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
+				IssuerNameID: int64(testCtx.issuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 				ShardIdx:     1,
 			},
@@ -170,7 +170,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
+				IssuerNameID: int64(testCtx.issuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 				ShardIdx:     1,
 			},
@@ -184,7 +184,7 @@ func TestGenerateCRL(t *testing.T) {
 	crl, err := x509.ParseRevocationList(crlBytes)
 	test.AssertNotError(t, err, "should be able to parse empty CRL")
 	test.AssertEquals(t, len(crl.RevokedCertificateEntries), 0)
-	err = crl.CheckSignatureFrom(testCtx.boulderIssuers[0].Cert.Certificate)
+	err = crl.CheckSignatureFrom(testCtx.issuers[0].Cert.Certificate)
 	test.AssertEquals(t, crl.ThisUpdate, now)
 	test.AssertEquals(t, crl.ThisUpdate, timestamppb.New(now).AsTime())
 	test.AssertNotError(t, err, "CRL signature should validate")
@@ -207,7 +207,7 @@ func TestGenerateCRL(t *testing.T) {
 	ins <- &capb.GenerateCRLRequest{
 		Payload: &capb.GenerateCRLRequest_Metadata{
 			Metadata: &capb.CRLMetadata{
-				IssuerNameID: int64(testCtx.boulderIssuers[0].NameID()),
+				IssuerNameID: int64(testCtx.issuers[0].NameID()),
 				ThisUpdate:   timestamppb.New(now),
 				ShardIdx:     1,
 			},
@@ -266,6 +266,6 @@ func TestGenerateCRL(t *testing.T) {
 	crl, err = x509.ParseRevocationList(crlBytes)
 	test.AssertNotError(t, err, "should be able to parse empty CRL")
 	test.AssertEquals(t, len(crl.RevokedCertificateEntries), 5)
-	err = crl.CheckSignatureFrom(testCtx.boulderIssuers[0].Cert.Certificate)
+	err = crl.CheckSignatureFrom(testCtx.issuers[0].Cert.Certificate)
 	test.AssertNotError(t, err, "CRL signature should validate")
 }

--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -47,7 +47,7 @@ type Config struct {
 
 			// One of the profile names must match the value of ra.defaultProfileName
 			// or large amounts of issuance will fail.
-			CertProfiles map[string]*issuance.ProfileConfig `validate:"dive,keys,alphanum,min=1,max=32,endkeys,required_without=Profile,structonly"`
+			CertProfiles map[string]issuance.ProfileConfig `validate:"required,dive,keys,alphanum,min=1,max=32,endkeys"`
 
 			// TODO(#7159): Make this required once all live configs are using it.
 			CRLProfile issuance.CRLProfileConfig `validate:"-"`
@@ -185,23 +185,20 @@ func main() {
 		cmd.FailOnError(err, "Failed to load CT Log List")
 	}
 
-	clk := clock.New()
+	// Double check that all issuers have the same number of CRL shards, because
+	// crl-updater relies upon that invariant.
 	var crlShards int
-	issuers := make([]*issuance.Issuer, 0, len(c.CA.Issuance.Issuers))
 	for i, issuerConfig := range c.CA.Issuance.Issuers {
-		issuer, err := issuance.LoadIssuer(issuerConfig, clk)
-		cmd.FailOnError(err, "Loading issuer")
-		// All issuers should have the same number of CRL shards, because
-		// crl-updater assumes they all have the same number.
 		if issuerConfig.CRLShards != 0 && crlShards == 0 {
 			crlShards = issuerConfig.CRLShards
 		}
 		if issuerConfig.CRLShards != crlShards {
 			cmd.Fail(fmt.Sprintf("issuer %d has %d shards, want %d", i, issuerConfig.CRLShards, crlShards))
 		}
-		issuers = append(issuers, issuer)
-		logger.Infof("Loaded issuer: name=[%s] keytype=[%s] nameID=[%v] isActive=[%t]", issuer.Name(), issuer.KeyType(), issuer.NameID(), issuer.IsActive())
 	}
+
+	clk := clock.New()
+	issuers, profiles, err := ca.LoadIssuersAndProfiles(c.CA.Issuance.Issuers, c.CA.Issuance.CertProfiles, clk)
 
 	if len(c.CA.Issuance.CertProfiles) == 0 {
 		cmd.Fail("At least one profile must be configured")
@@ -245,7 +242,7 @@ func main() {
 			sctService,
 			pa,
 			issuers,
-			c.CA.Issuance.CertProfiles,
+			profiles,
 			serialPrefix,
 			c.CA.MaxNames,
 			kp,

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -89,7 +89,7 @@ type Profile struct {
 }
 
 // NewProfile converts the profile config into a usable profile.
-func NewProfile(profileConfig *ProfileConfig) (*Profile, error) {
+func NewProfile(profileConfig ProfileConfig) (*Profile, error) {
 	// The Baseline Requirements, Section 7.1.2.7, says that the notBefore time
 	// must be "within 48 hours of the time of signing". We can be even stricter.
 	if profileConfig.MaxValidityBackdate.Duration >= 24*time.Hour {

--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -75,12 +75,7 @@ type ProfileConfig struct {
 	IgnoredLints []string
 }
 
-// PolicyConfig describes a policy
-type PolicyConfig struct {
-	OID string `validate:"required"`
-}
-
-// Profile is the validated structure created by reading in ProfileConfigs and IssuerConfigs
+// Profile is the validated structure created by reading in a ProfileConfig
 type Profile struct {
 	omitCommonName      bool
 	omitKeyEncipherment bool

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -149,9 +149,10 @@ type IssuerConfig struct {
 	Active bool
 
 	// Profiles is the list of profiles for which this issuer is willing to issue.
-	// For the moment, this does nothing, and exists only for deployability.
-	// TODO(#8390): Make this field required once it is configured in prod.
-	Profiles []string `validate:"omitempty,dive,alphanum,min=1,max=32"`
+	// The names listed here must match the names of configured profiles (see
+	// cmd/ca/main.go's Config.Issuance.CertProfiles and issuance/cert.go's
+	// ProfileConfig).
+	Profiles []string `validate:"required,dive,alphanum,min=1,max=32"`
 
 	IssuerURL  string `validate:"required,url"`
 	CRLURLBase string `validate:"required,url,startswith=http://,endswith=/"`

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -148,6 +148,11 @@ type IssuerConfig struct {
 	// The selection of which pool depends on the precertificate's key algorithm.
 	Active bool
 
+	// Profiles is the list of profiles for which this issuer is willing to issue.
+	// For the moment, this does nothing, and exists only for deployability.
+	// TODO(#8390): Make this field required once it is configured in prod.
+	Profiles []string `validate:"omitempty,dive,alphanum,min=1,max=32"`
+
 	IssuerURL  string `validate:"required,url"`
 	CRLURLBase string `validate:"required,url,startswith=http://,endswith=/"`
 


### PR DESCRIPTION
WIP WIP WIP

Add a "Profiles" field to the CA's Issuer Config.

Create a whole new helper function which loads both issuers and profiles at the same time, replacing the previously-separate `makeIssuerMaps`, `makeCertificateProfileMap`, and some code in ca/main.go. Make the `issuerMaps` type smarter, so we can change its internal storage later without having to touch as much of the calling code.

TODO:
* Make the new Profiles field _optional_, probably by populating it with the list of all profiles if none are specified.
* Update all of the tests, several of which extensively inspect the guts of `issuerMaps` and will be annoying to fix.

WIP WIP WIP