### PR TITLE
Remove support for the old log line checksum format

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -160,11 +160,9 @@ type stdoutWriter struct {
 	isatty    bool
 }
 
-// NewLineChecksum computes a CRC32 over the log line, which can be checked by
+// LogLineChecksum computes a CRC32 over the log line, which can be checked by
 // log-validator to ensure no unexpected log corruption has occurred.
-// It is currently only accepted for Validation, and will be switched in for
-// LogLineChecksum in an upcoming release.
-func NewLineChecksum(line string) string {
+func LogLineChecksum(line string) string {
 	crc := crc32.ChecksumIEEE([]byte(line))
 	buf := make([]byte, crc32.Size)
 	// Error is unreachable because we provide a supported type and buffer size
@@ -172,8 +170,8 @@ func NewLineChecksum(line string) string {
 	return base64.RawURLEncoding.EncodeToString(buf)
 }
 
-// LogLineChecksum is the current checksum algorithm, emitted in every log line.
-func LogLineChecksum(line string) string {
+// OldLineChecksum was previously used, and is still accepted for validation.
+func OldLineChecksum(line string) string {
 	crc := crc32.ChecksumIEEE([]byte(line))
 	// Using the hash.Hash32 doesn't make this any easier
 	// as it also returns a uint32 rather than []byte

--- a/log/log.go
+++ b/log/log.go
@@ -162,8 +162,8 @@ type stdoutWriter struct {
 
 // NewLineChecksum computes a CRC32 over the log line, which can be checked by
 // log-validator to ensure no unexpected log corruption has occurred.
-// It is currently ony accepted for Validation, and will be switched in for LogLineChecksum
-// in an upcoming release.
+// It is currently only accepted for Validation, and will be switched in for
+// LogLineChecksum in an upcoming release.
 func NewLineChecksum(line string) string {
 	crc := crc32.ChecksumIEEE([]byte(line))
 	buf := make([]byte, crc32.Size)

--- a/log/log.go
+++ b/log/log.go
@@ -167,7 +167,8 @@ type stdoutWriter struct {
 func NewLineChecksum(line string) string {
 	crc := crc32.ChecksumIEEE([]byte(line))
 	buf := make([]byte, crc32.Size)
-	binary.Encode(buf, binary.LittleEndian, crc)
+	// Error is unreachable because we provide a supported type and buffer size
+	_, _ = binary.Encode(buf, binary.LittleEndian, crc)
 	return base64.RawURLEncoding.EncodeToString(buf)
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -160,6 +160,18 @@ type stdoutWriter struct {
 	isatty    bool
 }
 
+// NewLineChecksum computes a CRC32 over the log line, which can be checked by
+// log-validator to ensure no unexpected log corruption has occurred.
+// It is currently ony accepted for Validation, and will be switched in for LogLineChecksum
+// in an upcoming release.
+func NewLineChecksum(line string) string {
+	crc := crc32.ChecksumIEEE([]byte(line))
+	buf := make([]byte, crc32.Size)
+	binary.Encode(buf, binary.LittleEndian, crc)
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// LogLineChecksum is the current checksum algorithm, emitted in every log line.
 func LogLineChecksum(line string) string {
 	crc := crc32.ChecksumIEEE([]byte(line))
 	// Using the hash.Hash32 doesn't make this any easier

--- a/log/log.go
+++ b/log/log.go
@@ -170,16 +170,6 @@ func LogLineChecksum(line string) string {
 	return base64.RawURLEncoding.EncodeToString(buf)
 }
 
-// OldLineChecksum was previously used, and is still accepted for validation.
-func OldLineChecksum(line string) string {
-	crc := crc32.ChecksumIEEE([]byte(line))
-	// Using the hash.Hash32 doesn't make this any easier
-	// as it also returns a uint32 rather than []byte
-	buf := make([]byte, binary.MaxVarintLen32)
-	binary.PutUvarint(buf, uint64(crc))
-	return base64.RawURLEncoding.EncodeToString(buf)
-}
-
 func checkSummed(msg string) string {
 	return fmt.Sprintf("%s %s", LogLineChecksum(msg), msg)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -102,8 +102,8 @@ func TestStdoutLogger(t *testing.T) {
 	logger.Warning("Warning log")
 	logger.Info("Info log")
 
-	test.AssertEquals(t, stdout.String(), "1970-01-01 prefix 6 log.test pcbo7wk Info log\n")
-	test.AssertEquals(t, stderr.String(), "1970-01-01 prefix 3 log.test 46_ghQg [AUDIT] Error Audit\n1970-01-01 prefix 4 log.test 97r2xAw Warning log\n")
+	test.AssertEquals(t, stdout.String(), "1970-01-01 prefix 6 log.test JSP6nQ Info log\n")
+	test.AssertEquals(t, stderr.String(), "1970-01-01 prefix 3 log.test 4xe4gA [AUDIT] Error Audit\n1970-01-01 prefix 4 log.test d52dyA Warning log\n")
 }
 
 func TestSyslogMethods(t *testing.T) {
@@ -352,14 +352,14 @@ func TestLogLineChecksum(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "NewLineChecksum with Hello, World!",
-			function: NewLineChecksum,
+			name:     "LogLineChecksum with Hello, World!",
+			function: LogLineChecksum,
 			input:    "Hello, World!",
 			expected: "0MNK7A",
 		},
 		{
-			name:     "LogLineChecksum with Info log",
-			function: LogLineChecksum,
+			name:     "OldLineChecksum with Info log",
+			function: OldLineChecksum,
 			input:    "Info log",
 			expected: "pcbo7wk",
 		},

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jmhodges/clock"
+
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -341,4 +342,35 @@ func TestLogAtLevelEscapesNewlines(t *testing.T) {
 	w.logAtLevel(6, "foo\nbar")
 
 	test.Assert(t, strings.Contains(buf.String(), "foo\\nbar"), "failed to escape newline")
+}
+
+func TestLogLineChecksum(t *testing.T) {
+	testCases := []struct {
+		name     string
+		function func(string) string
+		input    string
+		expected string
+	}{
+		{
+			name:     "NewLineChecksum with Hello, World!",
+			function: NewLineChecksum,
+			input:    "Hello, World!",
+			expected: "0MNK7A",
+		},
+		{
+			name:     "LogLineChecksum with Info log",
+			function: LogLineChecksum,
+			input:    "Info log",
+			expected: "pcbo7wk",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			checksum := tc.function(tc.input)
+			if checksum != tc.expected {
+				t.Fatalf("got %q, want %q", checksum, tc.expected)
+			}
+		})
+	}
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -357,12 +357,6 @@ func TestLogLineChecksum(t *testing.T) {
 			input:    "Hello, World!",
 			expected: "0MNK7A",
 		},
-		{
-			name:     "OldLineChecksum with Info log",
-			function: OldLineChecksum,
-			input:    "Info log",
-			expected: "pcbo7wk",
-		},
 	}
 
 	for _, tc := range testCases {

--- a/log/validator/validator.go
+++ b/log/validator/validator.go
@@ -208,9 +208,9 @@ func lineValid(text string) error {
 	// TODO(#8414): Accept both the old and new checksum format, distinguished by length
 	var computedChecksum string
 	if len(checksum) == 6 {
-		computedChecksum = log.NewLineChecksum(line)
-	} else {
 		computedChecksum = log.LogLineChecksum(line)
+	} else {
+		computedChecksum = log.OldLineChecksum(line)
 	}
 	if checksum != computedChecksum {
 		return fmt.Errorf("%s invalid checksum (expected %q, got %q)", errorPrefix, computedChecksum, checksum)

--- a/log/validator/validator.go
+++ b/log/validator/validator.go
@@ -186,10 +186,9 @@ func lineValid(text string) error {
 	}
 	checksum := fields[5]
 	_, err := base64.RawURLEncoding.DecodeString(checksum)
-	// TODO(#8414): Temporarily accept length 6 or 7 checksums
-	if err != nil || (len(checksum) != 6 && len(checksum) != 7) {
+	if err != nil || len(checksum) != 6 {
 		return fmt.Errorf(
-			"%s expected a 6 or 7 character base64 raw URL decodable string, got %q: %w",
+			"%s expected a 6 character base64 raw URL decodable string, got %q: %w",
 			errorPrefix,
 			checksum,
 			errInvalidChecksum,
@@ -205,13 +204,7 @@ func lineValid(text string) error {
 		return nil
 	}
 	// Check the extracted checksum against the computed checksum
-	// TODO(#8414): Accept both the old and new checksum format, distinguished by length
-	var computedChecksum string
-	if len(checksum) == 6 {
-		computedChecksum = log.LogLineChecksum(line)
-	} else {
-		computedChecksum = log.OldLineChecksum(line)
-	}
+	computedChecksum := log.LogLineChecksum(line)
 	if checksum != computedChecksum {
 		return fmt.Errorf("%s invalid checksum (expected %q, got %q)", errorPrefix, computedChecksum, checksum)
 	}

--- a/log/validator/validator.go
+++ b/log/validator/validator.go
@@ -186,9 +186,10 @@ func lineValid(text string) error {
 	}
 	checksum := fields[5]
 	_, err := base64.RawURLEncoding.DecodeString(checksum)
-	if err != nil || len(checksum) != 7 {
+	// Temporarily accept length 6 or 7 checksums
+	if err != nil || (len(checksum) != 6 && len(checksum) != 7) {
 		return fmt.Errorf(
-			"%s expected a 7 character base64 raw URL decodable string, got %q: %w",
+			"%s expected a 6 or 7 character base64 raw URL decodable string, got %q: %w",
 			errorPrefix,
 			checksum,
 			errInvalidChecksum,
@@ -204,7 +205,13 @@ func lineValid(text string) error {
 		return nil
 	}
 	// Check the extracted checksum against the computed checksum
-	if computedChecksum := log.LogLineChecksum(line); checksum != computedChecksum {
+	var computedChecksum string
+	if len(checksum) == 6 {
+		computedChecksum = log.NewLineChecksum(line)
+	} else {
+		computedChecksum = log.LogLineChecksum(line)
+	}
+	if checksum != computedChecksum {
 		return fmt.Errorf("%s invalid checksum (expected %q, got %q)", errorPrefix, computedChecksum, checksum)
 	}
 	return nil

--- a/log/validator/validator.go
+++ b/log/validator/validator.go
@@ -186,7 +186,7 @@ func lineValid(text string) error {
 	}
 	checksum := fields[5]
 	_, err := base64.RawURLEncoding.DecodeString(checksum)
-	// Temporarily accept length 6 or 7 checksums
+	// TODO(#8414): Temporarily accept length 6 or 7 checksums
 	if err != nil || (len(checksum) != 6 && len(checksum) != 7) {
 		return fmt.Errorf(
 			"%s expected a 6 or 7 character base64 raw URL decodable string, got %q: %w",
@@ -205,6 +205,7 @@ func lineValid(text string) error {
 		return nil
 	}
 	// Check the extracted checksum against the computed checksum
+	// TODO(#8414): Accept both the old and new checksum format, distinguished by length
 	var computedChecksum string
 	if len(checksum) == 6 {
 		computedChecksum = log.NewLineChecksum(line)

--- a/log/validator/validator_test.go
+++ b/log/validator/validator_test.go
@@ -6,9 +6,14 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestLineValidAccepts(t *testing.T) {
-	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: kKG6cwA Caught SIGTERM")
+func TestLineValidAcceptsNew(t *testing.T) {
+	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: -bEKHQ Welcome to the world of the future!")
 	test.AssertNotError(t, err, "errored on valid checksum")
+}
+
+func TestLineValidAcceptsOld(t *testing.T) {
+	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: kKG6cwA Caught SIGTERM")
+	test.AssertNotError(t, err, "errored on valid old checksum")
 }
 
 func TestLineValidRejects(t *testing.T) {

--- a/log/validator/validator_test.go
+++ b/log/validator/validator_test.go
@@ -11,13 +11,13 @@ func TestLineValidAcceptsNew(t *testing.T) {
 	test.AssertNotError(t, err, "errored on valid checksum")
 }
 
-func TestLineValidAcceptsOld(t *testing.T) {
+func TestLineValidRejectsOld(t *testing.T) {
 	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: kKG6cwA Caught SIGTERM")
-	test.AssertNotError(t, err, "errored on valid old checksum")
+	test.AssertError(t, err, "didn't error on old checksum format")
 }
 
 func TestLineValidRejects(t *testing.T) {
-	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: xxxxxxx Caught SIGTERM")
+	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: xxxxxx Caught SIGTERM")
 	test.AssertError(t, err, "didn't error on invalid checksum")
 }
 
@@ -28,10 +28,10 @@ func TestLineValidRejectsNotAChecksum(t *testing.T) {
 }
 
 func TestLineValidNonOurobouros(t *testing.T) {
-	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: xxxxxxx Caught SIGTERM")
+	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: xxxxxx Caught SIGTERM")
 	test.AssertError(t, err, "didn't error on invalid checksum")
 
-	selfOutput := "2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 log-validator[1337]: xxxxxxx " + err.Error()
+	selfOutput := "2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 log-validator[1337]: xxxxxx " + err.Error()
 	err2 := lineValid(selfOutput)
 	test.AssertNotError(t, err2, "expected no error when feeding lineValid's error output into itself")
 }

--- a/log/validator/validator_test.go
+++ b/log/validator/validator_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLineValidAcceptsNew(t *testing.T) {
-	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: -bEKHQ Welcome to the world of the future!")
+	err := lineValid("2020-07-06T18:07:43.109389+00:00 70877f679c72 datacenter 6 boulder-wfe[1595]: kJBuDg Caught SIGTERM")
 	test.AssertNotError(t, err, "errored on valid checksum")
 }
 


### PR DESCRIPTION
- Start accepting a new log checksum format
- Explicitally ignore error from binary.Encode with explanation
- Fix checksum and rewrap comment
- Review feedback: Add TODOs with bug reference
- Fix checksum and rewrap comment
- Switch to new log checksum
- Remove support for old line checksum format
