### PR TITLE
Remove key policy log line.

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -380,8 +380,6 @@ func main() {
 	wfe.DirectoryWebsite = c.WFE.DirectoryWebsite
 	wfe.LegacyKeyIDPrefix = c.WFE.LegacyKeyIDPrefix
 
-	logger.Infof("WFE using key policy: %#v", kp)
-
 	if c.WFE.ListenAddress == "" {
 		cmd.Fail("HTTP listen address is not configured")
 	}


### PR DESCRIPTION
This log line was somewhat malformed (printing a pointer instead of contents, for the blockedKeyFunc), but more importantly we don't need it.

Fixes #8406.