### PR TITLE
Add an index on serials to the revokedCertificates table

### DIFF
--- a/sa/db-next/boulder_sa/20251002000000_AddRevokedSerialsIndex.sql
+++ b/sa/db-next/boulder_sa/20251002000000_AddRevokedSerialsIndex.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `revokedCertificates` ADD KEY `serial` (`serial`);
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `revokedCertificates` DROP KEY `serial`;


### PR DESCRIPTION
Give the `revokedCertificates` table a non-unique index on the `serial` column. This exactly matches the existing index on the `certificateStatus` table.

We did not include this index initially because we were optimizing this table for the crl-updater's crawl-by-shard-and-expiration behavior, but this index is necessary to look up if a certificate has already been revoked when computing ARI windows and when processing revocation requests.

Part of https://github.com/letsencrypt/boulder/issues/8322

IN-11835 tracks the corresponding production schema changes