### PR TITLE
Update CI to go1.25.2

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.25.0_2025-08-15
+          - go1.25.2_2025-10-07
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -122,7 +122,7 @@ jobs:
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
       fail-fast: false
       matrix:
-        go-version: [ '1.25.0' ]
+        go-version: [ '1.25.2' ]
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.25.0"
+          - "1.25.2"
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.25.0"
+          - "1.25.2"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: test/boulder-tools/
       # Should match one of the GO_CI_VERSIONS in test/boulder-tools/tag_and_upload.sh.
       args:
-        GO_VERSION: 1.25.0
+        GO_VERSION: 1.25.2
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening. This is

--- a/precert/corr.go
+++ b/precert/corr.go
@@ -148,7 +148,7 @@ func (e *extensionParser) Next() (cryptobyte.String, error) {
 
 // unwrapExtensions takes a given a sequence of bytes representing the `extensions` field
 // of a TBSCertificate and parses away the outermost two layers, returning the inner bytes
-// of the Extensions SEQUENCE.
+// of the Extensions sequence.
 //
 // https://datatracker.ietf.org/doc/html/rfc5280#page-117
 //
@@ -193,7 +193,7 @@ func readIdenticalElement(a, b *cryptobyte.String) error {
 }
 
 // tbsDERFromCertDER takes a Certificate object encoded as DER, and parses
-// away the outermost two SEQUENCEs to get the inner bytes of the TBSCertificate.
+// away the outermost two sequences to get the inner bytes of the TBSCertificate.
 //
 // https://datatracker.ietf.org/doc/html/rfc5280#page-116
 //

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.25.0" )
+GO_CI_VERSIONS=( "1.25.2" )
 
 echo "Please login to allow push to DockerHub"
 docker login

--- a/va/http_test.go
+++ b/va/http_test.go
@@ -274,13 +274,6 @@ func TestExtractRequestTarget(t *testing.T) {
 			ExpectedError: errors.New("Invalid host in redirect target, must end in IANA registered TLD"),
 		},
 		{
-			Name: "malformed too-long IPv6 address",
-			Req: &http.Request{
-				URL: mustURL("https://[a:b:c:d:e:f:b:a:d]"),
-			},
-			ExpectedError: errors.New("Invalid host in redirect target, must end in IANA registered TLD"),
-		},
-		{
 			Name: "bare IPv4, implicit port",
 			Req: &http.Request{
 				URL: mustURL("http://127.0.0.1"),


### PR DESCRIPTION
The go1.25.2 security release addresses a number of CVEs, including ones affecting crypto/x509, crypto/tls, encoding/asn1, and other packages we rely on. See the full details here:
- https://go.dev/doc/devel/release#go1.25.2
- https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI

Also make two small updates to accommodate the new version of `typos` pulled in by the new boulder-tools image, and the new version of net/url which closes off a corner case we were testing.