### PR TITLE
database: Add composite index on paused

### DIFF
--- a/sa/db-next/boulder_sa/20251022000000_AddPausedIndex.sql
+++ b/sa/db-next/boulder_sa/20251022000000_AddPausedIndex.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE paused
+  ADD INDEX paused_regID_unpausedAt_identifierType_identifierValue_idx
+    (registrationID, unpausedAt, identifierType, identifierValue);
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE paused
+  DROP INDEX paused_regID_unpausedAt_identifierType_identifierValue_idx;


### PR DESCRIPTION
Add a composite index on the paused table to speed up CheckIdentifiersPaused() and GetPausedIdentifiers(). Use (registrationID, unpausedAt, identifierType, identifierValue) so the planner can apply an index condition on registrationID and unpausedAt IS NULL and return identifierType and identifierValue from the same covering index. For a table with a few hundred thousand rows, the size of this new index is projected to be ~50 MB.

> [!NOTE]
> I am not a DBA; the following change is based on my best understanding of how the query planner is behaving. It is intended to address queries [observed in CI runs](https://github.com/letsencrypt/boulder/pull/8447) with `log_queries_not_using_indexes` enabled. I cannot guarantee that this change is strictly optimal but I have provided some rationale, the relevant EXPLAINS, and directions for reproducing these results yourself. I would greatly appreciate feedback from someone with deeper database expertise.
>
> I have injected fake data on the order of 100s of 1000s of rows, with pretty poor cardinality. This means that the provided results may not be reflective of how the query planner will behave on a larger machine with a larger and more varied dataset.

```shell
docker compose exec -it bmysql mysql -uroot
```

```sql
use boulder_sa_integration;
```

Add 300,000 rows to the `paused` table for testing purposes:

```sql
SET max_recursive_iterations = 1000000;

INSERT INTO paused (registrationID, identifierType, identifierValue, pausedAt, unpausedAt)
WITH RECURSIVE seq(n) AS (
  SELECT 0
  UNION ALL
  SELECT n+1 FROM seq WHERE n < 299999
)
SELECT
  CASE WHEN n < 200000 THEN 12345 ELSE 20000 + (n % 1000) END AS registrationID,
  (n % 2) AS identifierType,
  CONCAT('foo-', n, '.bar') AS identifierValue,
  NOW() - INTERVAL (n % 86400) SECOND AS pausedAt,
  CASE
    WHEN n < 200000 AND (n % 20) = 0 THEN NULL
    ELSE NOW() - INTERVAL (n % 86400) SECOND
  END AS unpausedAt
FROM seq;
```

Run an EXPLAIN on our query before adding the index:

```sql
EXPLAIN FORMAT=JSON
SELECT identifierType, identifierValue
FROM paused
WHERE registrationID = 12345
  AND unpausedAt IS NULL
LIMIT 15;
```

```json
{
  "query_block": {
    "select_id": 1,
    "nested_loop": [
      {
        "table": {
          "table_name": "paused",
          "access_type": "ref",
          "possible_keys": ["PRIMARY"],
          "key": "PRIMARY",
          "key_length": "8",
          "used_key_parts": ["registrationID"],
          "ref": ["const"],
          "rows": 144626,
          "filtered": 100,
          "attached_condition": "paused.unpausedAt is null"
        }
      }
    ]
  }
}
```

Add the new composite index:

```sql
ALTER TABLE paused
  ADD INDEX paused_regID_unpausedAt_identifierType_identifierValue_idx
    (registrationID, unpausedAt, identifierType, identifierValue);
```

Running a new EXPLAIN shows the query using the new index:

```json
{
  "query_block": {
    "select_id": 1,
    "nested_loop": [
      {
        "table": {
          "table_name": "paused",
          "access_type": "ref",
          "possible_keys": [
            "PRIMARY",
            "paused_regID_unpausedAt_identifierType_identifierValue_idx"
          ],
          "key": "paused_regID_unpausedAt_identifierType_identifierValue_idx",
          "key_length": "14",
          "used_key_parts": ["registrationID", "unpausedAt"],
          "ref": ["const", "const"],
          "rows": 20688,
          "filtered": 100,
          "attached_condition": "paused.unpausedAt is null",
          "using_index": true
        }
      }
    ]
  }
}
```