### PR TITLE
database: Add composite index on blockedKeys

### DIFF
--- a/sa/db-next/boulder_sa/20251022000000_AddBlockedKeysIndex.sql
+++ b/sa/db-next/boulder_sa/20251022000000_AddBlockedKeysIndex.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE blockedKeys
+  ADD INDEX blockedKeys_extantCertificatesChecked_added_idx
+    (extantCertificatesChecked, added);
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE blockedKeys
+  DROP INDEX blockedKeys_extantCertificatesChecked_added_idx;


### PR DESCRIPTION
Add a composite index on blockedKeys to speed up countUncheckedKeys(), which uses a derived subquery with a LIMIT. The index on (extantCertificatesChecked, added) lets the planner apply equality on extantCertificatesChecked = 0 and a range on added, so the inner subquery is satisfied via a covering index range scan with early termination at LIMIT 1000, avoiding a full table scan. For a table with low single digit million rows, the size of this new index is projected to be ~130 MB.


> [!NOTE]
> I am not a DBA; the following change is based on my best understanding of how the query planner is behaving. It is intended to address queries [observed in CI runs](https://github.com/letsencrypt/boulder/pull/8447) with `log_queries_not_using_indexes` enabled. I cannot guarantee that this change is strictly optimal but I have provided some rationale, the relevant EXPLAINS, and directions for reproducing these results yourself. I would greatly appreciate feedback from someone with deeper database expertise.
>
> I have injected fake data on the order of 100s of 1000s of rows, with pretty poor cardinality. This means that the provided results may not be reflective of how the query planner will behave on a larger machine with a larger and more varied dataset.

```shell
docker compose exec -it bmysql mysql -uroot
```

```sql
use boulder_sa_integration;
```

Add 500,000 rows to the `blockedKeys` table for testing purposes:

```sql
SET max_recursive_iterations = 500000;

INSERT INTO blockedKeys (keyHash, added, source, comment, revokedBy, extantCertificatesChecked)
WITH RECURSIVE seq(n) AS (
  SELECT 0
  UNION ALL
  SELECT n+1 FROM seq WHERE n < 499999
)
SELECT
  UNHEX(SHA2(CONCAT(UUID(), n), 256)),
  NOW() - INTERVAL (n % 172800) SECOND,
  0, NULL, 0,
  CASE WHEN (n % 10) < 7 THEN 0 ELSE 1 END
FROM seq;
```

Run an EXPLAIN on the query before adding the index:

```sql
EXPLAIN FORMAT=JSON
SELECT COUNT(*)
FROM (
  SELECT 1 FROM blockedKeys
   WHERE extantCertificatesChecked = 0
     AND added < NOW() - INTERVAL 0.1 SECOND
   LIMIT 1000
) AS a;
```

```json
{
  "query_block": {
    "select_id": 1,
    "nested_loop": [
      {
        "table": {
          "table_name": "<derived2>",
          "access_type": "ALL",
          "rows": 1000,
          "filtered": 100,
          "materialized": {
            "query_block": {
              "select_id": 2,
              "nested_loop": [
                {
                  "table": {
                    "table_name": "blockedKeys",
                    "access_type": "ref",
                    "possible_keys": ["extantCertificatesChecked_idx"],
                    "key": "extantCertificatesChecked_idx",
                    "key_length": "2",
                    "used_key_parts": ["extantCertificatesChecked"],
                    "ref": ["const"],
                    "rows": 248878,
                    "filtered": 100,
                    "attached_condition": "blockedKeys.added < <cache>(current_timestamp() - interval 0.1 second)"
                  }
                }
              ]
            }
          }
        }
      }
    ]
  }
}
```

Add the new composite index:

```sql
ALTER TABLE blockedKeys
  ADD INDEX blockedKeys_extantCertificatesChecked_added_idx
    (extantCertificatesChecked, added);
```
Running a new EXPLAIN shows the query using the new index:

```json
{
  "query_block": {
    "select_id": 1,
    "nested_loop": [
      {
        "table": {
          "table_name": "<derived2>",
          "access_type": "ALL",
          "rows": 1000,
          "filtered": 100,
          "materialized": {
            "query_block": {
              "select_id": 2,
              "nested_loop": [
                {
                  "table": {
                    "table_name": "blockedKeys",
                    "access_type": "range",
                    "possible_keys": [
                      "extantCertificatesChecked_idx",
                      "blockedKeys_extantCertificatesChecked_added_idx"
                    ],
                    "key": "blockedKeys_extantCertificatesChecked_added_idx",
                    "key_length": "7",
                    "used_key_parts": ["extantCertificatesChecked", "added"],
                    "rows": 248878,
                    "filtered": 50,
                    "attached_condition": "blockedKeys.extantCertificatesChecked = 0 and blockedKeys.added < <cache>(current_timestamp() - interval 0.1 second)",
                    "using_index": true
                  }
                }
              ]
            }
          }
        }
      }
    ]
  }
}
```
