### PR TITLE
Make release workflow compatible with immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 # Build the Boulder Debian package on tag push, and attach it to a GitHub
 # release.
 #
-# Keep in sync with try-release.yml, with the exception that try-release.yml can
-# have multiple entries in its matrix but this should only have one.
+# Keep the GO_VERSION matrix and the container-building steps in sync with
+# try-release.yml.
 name: Build release
 on:
   push:
@@ -10,12 +10,33 @@ on:
       - '**'
 
 jobs:
+  draft-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
+
+      - name: Verify release ancestry
+        run: ./tools/verify-release-ancestry.sh "$GITHUB_SHA"
+
+      - name: Create draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://cli.github.com/manual/gh_release_create
+        run: gh release create --draft --generate-notes "${GITHUB_REF_NAME}"
+
   push-release:
+    needs: draft-release
     strategy:
       fail-fast: false
       matrix:
         GO_VERSION:
           - "1.25.2"
+          - "1.25.3"
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -26,9 +47,6 @@ jobs:
           persist-credentials: false
           fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
 
-      - name: Verify release ancestry
-        run: ./tools/verify-release-ancestry.sh "$GITHUB_SHA"
-
       - name: Build Boulder container and .deb
         id: build
         env:
@@ -36,20 +54,13 @@ jobs:
         run: ./tools/container-build.sh
 
       - name: Tag Boulder container
-        run: docker tag boulder "ghcr.io/letsencrypt/boulder:${{ github.ref_name }}-go${{ matrix.GO_VERSION }}"
+        run: docker tag boulder "ghcr.io/letsencrypt/boulder:${GITHUB_REF_NAME}-go${{ matrix.GO_VERSION }}"
 
       - name: Compute checksums
         id: checksums
         # The files listed on this line must be identical to the files uploaded
         # in the last step.
         run: sha256sum boulder*.deb boulder*.tar.gz >| boulder-${{ matrix.GO_VERSION }}.$(date +%s)-$(git rev-parse --short=8 HEAD).checksums.txt
-
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # https://cli.github.com/manual/gh_release_create
-        run: gh release create --generate-notes "${GITHUB_REF_NAME}"
-        continue-on-error: true
 
       - name: Upload release files
         env:
@@ -58,15 +69,33 @@ jobs:
         run: gh release upload "${GITHUB_REF_NAME}" boulder*.deb boulder*.tar.gz boulder*.checksums.txt
 
       - name: Build ct-test-srv container
-        run: docker buildx build . --build-arg "GO_VERSION=${{ matrix.GO_VERSION }}" -f test/ct-test-srv/Dockerfile -t "ghcr.io/letsencrypt/ct-test-srv:${{ github.ref_name }}-go${{ matrix.GO_VERSION }}"
+        run: docker buildx build . --build-arg "GO_VERSION=${{ matrix.GO_VERSION }}" -f test/ct-test-srv/Dockerfile -t "ghcr.io/letsencrypt/ct-test-srv:${GITHUB_REF_NAME}-go${{ matrix.GO_VERSION }}"
 
-      - name: Login to ghcr.io
-        run: printenv GITHUB_TOKEN | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Boulder container
-        run: docker push "ghcr.io/letsencrypt/boulder:${{ github.ref_name }}-go${{ matrix.GO_VERSION }}"
+        run: docker push "ghcr.io/letsencrypt/boulder:${GITHUB_REF_NAME}-go${{ matrix.GO_VERSION }}"
 
       - name: Push ct-test-srv container
-        run: docker push "ghcr.io/letsencrypt/ct-test-srv:${{ github.ref_name }}-go${{ matrix.GO_VERSION }}"
+        run: docker push "ghcr.io/letsencrypt/ct-test-srv:${GITHUB_REF_NAME}-go${{ matrix.GO_VERSION }}"
+
+  publish-release:
+    needs: push-release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://cli.github.com/manual/gh_release_edit
+        run: gh release edit --draft=false "${GITHUB_REF_NAME}"

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -1,7 +1,8 @@
-# Try building the Boulder Debian package on every PR and push to main.
-# This is to make sure the actual release job will succeed when we tag a
-# release.
-# Keep in sync with release.yml
+# Try building the Boulder Debian package on every PR and push to main. This is
+# to make sure the actual release job will succeed when we tag a release.
+#
+# Keep the GO_VERSION matrix and the container-building steps in sync with
+# release.yml.
 name: Try release
 on:
   push:
@@ -20,6 +21,7 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.25.2"
+          - "1.25.3"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Separate the release workflow into three sequential jobs. The first simply creates a draft release, the second (which can be multiple parallel jobs, if there's a matrix of go versions) builds all the relevant release artifacts and uploads them to container registries and to the release itself, and the third takes the release out of draft mode if and only if the previous jobs succeeded.

This separation allows us to adopt Immutable Releases, which can provide attestations that release artifacts are not modified after they're created. This is because the release only becomes immutable once it is taken out of draft mode, so as long as it's just a draft, multiple different jobs can upload artifacts to it.

Along the way, make a few other small improvements to the release workflow, such as avoiding directly interpolating ${{ github.ref_name }} and using a pinned version of the docker/login-action to authenticate to ghcr.

Fixes https://github.com/letsencrypt/boulder/issues/8380