### PR TITLE
Use json tags to suppress Account fields in API responses

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -94,7 +94,7 @@ type RawCertificateRequest struct {
 // to account keys.
 type Registration struct {
 	// Unique identifier
-	ID int64 `json:"id,omitempty"`
+	ID int64 `json:"-"`
 
 	// Account key to which the details are attached
 	Key *jose.JSONWebKey `json:"key"`
@@ -103,7 +103,7 @@ type Registration struct {
 	Contact *[]string `json:"contact,omitempty"`
 
 	// Agreement with terms of service
-	Agreement string `json:"agreement,omitempty"`
+	Agreement string `json:"-"`
 
 	// CreatedAt is the time the registration was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3779,19 +3779,30 @@ func TestOrderToOrderJSONV2Authorizations(t *testing.T) {
 	})
 }
 
-func TestPrepAccountForDisplay(t *testing.T) {
+func TestAccountMarshaling(t *testing.T) {
 	acct := &core.Registration{
 		ID:        1987,
 		Agreement: "disagreement",
+		Status:    core.StatusValid,
 	}
 
-	// Prep the account for display.
-	prepAccountForDisplay(acct)
+	marshaled, err := json.Marshal(acct)
+	if err != nil {
+		t.Fatalf("marshalling account object: %s", err)
+	}
+
+	var got core.Registration
+	err = json.Unmarshal(marshaled, &got)
+	if err != nil {
+		t.Fatalf("unmarshaling account object: %s", err)
+	}
 
 	// The Agreement should always be cleared.
-	test.AssertEquals(t, acct.Agreement, "")
+	test.AssertEquals(t, got.Agreement, "")
 	// The ID field should be zeroed.
-	test.AssertEquals(t, acct.ID, int64(0))
+	test.AssertEquals(t, got.ID, int64(0))
+	// The Status field should be preserved.
+	test.AssertEquals(t, got.Status, core.StatusValid)
 }
 
 // TestGet404 tests that a 404 is served and that the expected endpoint of


### PR DESCRIPTION
Fixes https://github.com/letsencrypt/boulder/issues/7774