### PR TITLE
iana: Remove hardcoded multicast prefixes

### DIFF
--- a/iana/ip.go
+++ b/iana/ip.go
@@ -54,26 +54,7 @@ func init() {
 		panic(err)
 	}
 
-	// Add multicast addresses, which aren't in the IANA registries.
-	//
-	// TODO(#8237): Move these entries to IP address blocklists once they're
-	// implemented.
-	additionalPrefixes := []reservedPrefix{
-		{
-			addressFamily: "IPv4",
-			addressBlock:  netip.MustParsePrefix("224.0.0.0/4"),
-			name:          "Multicast Addresses",
-			rfc:           "[RFC3171]",
-		},
-		{
-			addressFamily: "IPv6",
-			addressBlock:  netip.MustParsePrefix("ff00::/8"),
-			name:          "Multicast Addresses",
-			rfc:           "[RFC4291]",
-		},
-	}
-
-	reservedPrefixes = slices.Concat(ipv4Prefixes, ipv6Prefixes, additionalPrefixes)
+	reservedPrefixes = slices.Concat(ipv4Prefixes, ipv6Prefixes)
 
 	// Sort the list of reserved prefixes in descending order of prefix size, so
 	// that checks will match the most-specific reserved prefix first.

--- a/iana/ip_test.go
+++ b/iana/ip_test.go
@@ -38,12 +38,6 @@ func TestIsReservedAddr(t *testing.T) {
 		{"0100::", "Discard-Only Address Block"},                         // part of a reserved block in a non-canonical IPv6 format
 		{"0100::0000:ffff:ffff:ffff:ffff", "Discard-Only Address Block"}, // part of a reserved block in a non-canonical IPv6 format
 		{"0100::0002:0000:0000:0000:0000", ""},                           // non-reserved but in a non-canonical IPv6 format
-
-		// TODO(#8237): Move these entries to IP address blocklists once they're
-		// implemented.
-		{"ff00::1", "Multicast Addresses"},                                 // second-lowest IP in a reserved /8 we hardcode
-		{"ff10::1", "Multicast Addresses"},                                 // in the middle of a reserved /8 we hardcode
-		{"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "Multicast Addresses"}, // highest IP in a reserved /8 we hardcode
 	}
 
 	for _, tc := range cases {

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -184,6 +184,9 @@ func TestWillingToIssue(t *testing.T) {
 		identifier.NewIP(netip.MustParseAddr(`64.112.117.66`)),
 		identifier.NewIP(netip.MustParseAddr(`2602:80a:6000:666::1`)),
 		identifier.NewIP(netip.MustParseAddr(`2602:80a:6000:666::1%lo`)),
+		identifier.NewIP(netip.MustParseAddr(`ff00::1`)),
+		identifier.NewIP(netip.MustParseAddr(`ff10::1`)),
+		identifier.NewIP(netip.MustParseAddr(`ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff`)),
 	}
 	blocklistContents := []string{
 		`website2.com`,
@@ -202,7 +205,9 @@ func TestWillingToIssue(t *testing.T) {
 	}
 	adminBlockedPrefixesContents := []string{
 		`64.112.117.66/32`,
+		`224.0.0.0/4`,
 		`2602:80a:6000:666::/64`,
+		`ff00::/8`,
 	}
 
 	shouldBeAccepted := identifier.ACMEIdentifiers{

--- a/test/ident-policy.yaml
+++ b/test/ident-policy.yaml
@@ -39,5 +39,7 @@ AdminBlockedNames:
 AdminBlockedPrefixes:
   - "64.112.117.66/32"
   - "64.112.117.68/30"
+  - "224.0.0.0/4"
   - "2602:80a:6000:baa:ffff:ffff:ffff:ffff/128"
   - "2602:80a:6000:bad::/64"
+  - "ff00::/8"


### PR DESCRIPTION
Remove multicast IP prefixes (RFCs 3171 & 4291) from the hardcoded list of reserved addresses in the `iana` package.

These prefixes are not listed in IANA's Special-Purpose Address Registries or otherwise forbidden by the Baseline Requirements, so hardcoding them in Boulder probably isn't appropriate.

Instead, operators can configure them in `AdminBlockedPrefixes` to prevent their use as identifiers. For Let's Encrypt, this has been done in IN-11854. They can also use their resolvers' configuration (e.g. Unbound's `private-address` and `do-not-query-address` directives) to exclude them from DNS query results. For Let's Encrypt, this has been done for a long time (since before the current config's first blame).

Part of #8237