### PR TITLE
bdns: restore stats.MustRegister call

### DIFF
--- a/bdns/dns.go
+++ b/bdns/dns.go
@@ -115,6 +115,7 @@ func New(
 		},
 		[]string{"qtype", "type", "resolver", "isTLD"},
 	)
+	stats.MustRegister(queryTime, totalLookupTime, timeoutCounter)
 	return &impl{
 		dnsClient:                client,
 		servers:                  servers,


### PR DESCRIPTION
This was accidentally deleted along with the idMismatchCounter in #8445.