### PR TITLE
test: Remove queries containing DDL from unit tests

### DIFF
--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -247,7 +247,7 @@ func TestFindUnrevoked(t *testing.T) {
 	test.AssertNotError(t, err, "findUnrevoked failed")
 	test.AssertEquals(t, len(rows), 1)
 	test.AssertEquals(t, rows[0].Serial, "ff")
-	test.AssertEquals(t, rows[0].RegistrationID, int64(1))
+	test.AssertEquals(t, rows[0].RegistrationID, regID)
 	test.AssertByteEquals(t, rows[0].DER, []byte{1, 2, 3})
 
 	bkr.maxRevocations = 0

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -99,21 +99,21 @@ func randomIPv6() netip.Addr {
 	return ip
 }
 
-func createPendingAuthorization(t *testing.T, sa sapb.StorageAuthorityClient, ident identifier.ACMEIdentifier, exp time.Time) *corepb.Authorization {
+func createPendingAuthorization(t *testing.T, sa sapb.StorageAuthorityClient, regID int64, ident identifier.ACMEIdentifier, exp time.Time) *corepb.Authorization {
 	t.Helper()
 
 	res, err := sa.NewOrderAndAuthzs(
 		context.Background(),
 		&sapb.NewOrderAndAuthzsRequest{
 			NewOrder: &sapb.NewOrderRequest{
-				RegistrationID: Registration.Id,
+				RegistrationID: regID,
 				Expires:        timestamppb.New(exp),
 				Identifiers:    []*corepb.Identifier{ident.ToProto()},
 			},
 			NewAuthzs: []*sapb.NewAuthzRequest{
 				{
 					Identifier:     ident.ToProto(),
-					RegistrationID: Registration.Id,
+					RegistrationID: regID,
 					Expires:        timestamppb.New(exp),
 					ChallengeTypes: []string{
 						string(core.ChallengeTypeHTTP01),
@@ -129,12 +129,12 @@ func createPendingAuthorization(t *testing.T, sa sapb.StorageAuthorityClient, id
 	return getAuthorization(t, fmt.Sprint(res.V2Authorizations[0]), sa)
 }
 
-func createFinalizedAuthorization(t *testing.T, sa sapb.StorageAuthorityClient, ident identifier.ACMEIdentifier, exp time.Time, chall core.AcmeChallenge, attemptedAt time.Time) int64 {
+func createFinalizedAuthorization(t *testing.T, saClient sapb.StorageAuthorityClient, regID int64, ident identifier.ACMEIdentifier, exp time.Time, chall core.AcmeChallenge, attemptedAt time.Time) int64 {
 	t.Helper()
-	pending := createPendingAuthorization(t, sa, ident, exp)
+	pending := createPendingAuthorization(t, saClient, regID, ident, exp)
 	pendingID, err := strconv.ParseInt(pending.Id, 10, 64)
 	test.AssertNotError(t, err, "strconv.ParseInt failed")
-	_, err = sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
+	_, err = saClient.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id:          pendingID,
 		Status:      "valid",
 		Expires:     timestamppb.New(exp),
@@ -278,8 +278,6 @@ var (
 
 	ExampleCSR = &x509.CertificateRequest{}
 
-	Registration = &corepb.Registration{Id: 1}
-
 	Identifier = "not-example.com"
 
 	log = blog.UseMock()
@@ -287,7 +285,7 @@ var (
 
 var ctx = context.Background()
 
-func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAuthorityClient, *RegistrationAuthorityImpl, ratelimits.Source, clock.FakeClock, func()) {
+func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAuthorityClient, *RegistrationAuthorityImpl, ratelimits.Source, clock.FakeClock, *corepb.Registration, func()) {
 	err := json.Unmarshal(AccountKeyJSONA, &AccountKeyA)
 	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
 	err = json.Unmarshal(AccountKeyJSONB, &AccountKeyB)
@@ -350,10 +348,11 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	ExampleCSR, _ = x509.ParseCertificateRequest(block.Bytes)
 
 	test.AssertNotError(t, err, "Couldn't create initial IP")
-	Registration, _ = ssa.NewRegistration(ctx, &corepb.Registration{
+	registration, err := sa.NewRegistration(ctx, &corepb.Registration{
 		Key:    AccountKeyJSONA,
 		Status: string(core.StatusValid),
 	})
+	test.AssertNotError(t, err, "Failed to create initial registration")
 
 	ctp := ctpolicy.New(&mocks.PublisherClient{}, loglist.List{
 		{Name: "LogA1", Operator: "OperA", Url: "UrlA1", Key: []byte("KeyA1")},
@@ -388,11 +387,11 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	ra.VA = va
 	ra.CA = ca
 	ra.PA = pa
-	return dummyVA, sa, ra, rlSource, fc, cleanUp
+	return dummyVA, sa, ra, rlSource, fc, registration, cleanUp
 }
 
 func TestValidateContacts(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	ansible := "ansible:earth.sol.milkyway.laniakea/letsencrypt"
@@ -469,7 +468,7 @@ func TestValidateContacts(t *testing.T) {
 }
 
 func TestNewRegistration(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	acctKeyB, err := AccountKeyB.MarshalJSON()
 	test.AssertNotError(t, err, "failed to marshal account key")
@@ -498,7 +497,7 @@ func (sa *mockSAFailsNewRegistration) NewRegistration(_ context.Context, _ *core
 }
 
 func TestNewRegistrationSAFailure(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ra.SA = &mockSAFailsNewRegistration{}
 	acctKeyB, err := AccountKeyB.MarshalJSON()
@@ -513,7 +512,7 @@ func TestNewRegistrationSAFailure(t *testing.T) {
 }
 
 func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	acctKeyC, err := AccountKeyC.MarshalJSON()
 	test.AssertNotError(t, err, "failed to marshal account key")
@@ -531,7 +530,7 @@ func TestNewRegistrationNoFieldOverwrite(t *testing.T) {
 }
 
 func TestNewRegistrationBadKey(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	shortKey, err := ShortKey.MarshalJSON()
 	test.AssertNotError(t, err, "failed to marshal account key")
@@ -543,10 +542,10 @@ func TestNewRegistrationBadKey(t *testing.T) {
 }
 
 func TestPerformValidationExpired(t *testing.T) {
-	_, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	_, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	authz := createPendingAuthorization(t, sa, identifier.NewDNS("example.com"), fc.Now().Add(-2*time.Hour))
+	authz := createPendingAuthorization(t, sa, registration.Id, identifier.NewDNS("example.com"), fc.Now().Add(-2*time.Hour))
 
 	_, err := ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 		Authz:          authz,
@@ -556,7 +555,7 @@ func TestPerformValidationExpired(t *testing.T) {
 }
 
 func TestPerformValidationAlreadyValid(t *testing.T) {
-	va, _, ra, _, _, cleanUp := initAuthorities(t)
+	va, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Create a finalized authorization
@@ -564,7 +563,7 @@ func TestPerformValidationAlreadyValid(t *testing.T) {
 	authz := core.Authorization{
 		ID:             "1337",
 		Identifier:     identifier.NewDNS("not-example.com"),
-		RegistrationID: 1,
+		RegistrationID: registration.Id,
 		Status:         "valid",
 		Expires:        &exp,
 		Challenges: []core.Challenge{
@@ -602,7 +601,7 @@ func TestPerformValidationAlreadyValid(t *testing.T) {
 }
 
 func TestPerformValidationSuccess(t *testing.T) {
-	va, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	va, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	idents := identifier.ACMEIdentifiers{
@@ -612,7 +611,7 @@ func TestPerformValidationSuccess(t *testing.T) {
 
 	for _, ident := range idents {
 		// We know this is OK because of TestNewAuthorization
-		authzPB := createPendingAuthorization(t, sa, ident, fc.Now().Add(12*time.Hour))
+		authzPB := createPendingAuthorization(t, sa, registration.Id, ident, fc.Now().Add(12*time.Hour))
 
 		va.doDCVResult = &vapb.ValidationResult{
 			Records: []*corepb.ValidationRecord{
@@ -687,7 +686,7 @@ func (msa mockSAWithSyncPause) PauseIdentifiers(ctx context.Context, req *sapb.P
 }
 
 func TestPerformValidation_FailedValidationsTriggerPauseIdentifiersRatelimit(t *testing.T) {
-	va, sa, ra, rl, fc, cleanUp := initAuthorities(t)
+	va, sa, ra, rl, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	features.Set(features.Config{AutomaticallyPauseZombieClients: true})
@@ -715,7 +714,7 @@ func TestPerformValidation_FailedValidationsTriggerPauseIdentifiersRatelimit(t *
 	// Set up a fake domain, authz, and bucket key to care about.
 	domain := randomDomain()
 	ident := identifier.NewDNS(domain)
-	authzPB := createPendingAuthorization(t, sa, ident, fc.Now().Add(12*time.Hour))
+	authzPB := createPendingAuthorization(t, sa, registration.Id, ident, fc.Now().Add(12*time.Hour))
 	bucketKey := ratelimits.NewRegIdIdentValueBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, authzPB.RegistrationID, ident.Value)
 
 	// Set the stored TAT to indicate that this bucket has exhausted its quota.
@@ -772,7 +771,7 @@ func (rl mockRLSourceWithSyncDelete) Delete(ctx context.Context, bucketKey strin
 }
 
 func TestPerformValidation_FailedThenSuccessfulValidationResetsPauseIdentifiersRatelimit(t *testing.T) {
-	va, sa, ra, rl, fc, cleanUp := initAuthorities(t)
+	va, sa, ra, rl, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	features.Set(features.Config{AutomaticallyPauseZombieClients: true})
@@ -791,7 +790,7 @@ func TestPerformValidation_FailedThenSuccessfulValidationResetsPauseIdentifiersR
 	// Set up a fake domain, authz, and bucket key to care about.
 	domain := randomDomain()
 	ident := identifier.NewDNS(domain)
-	authzPB := createPendingAuthorization(t, sa, ident, fc.Now().Add(12*time.Hour))
+	authzPB := createPendingAuthorization(t, sa, registration.Id, ident, fc.Now().Add(12*time.Hour))
 	bucketKey := ratelimits.NewRegIdIdentValueBucketKey(ratelimits.FailedAuthorizationsForPausingPerDomainPerAccount, authzPB.RegistrationID, ident.Value)
 
 	// Set a stored TAT so that we can tell when it's been reset.
@@ -833,10 +832,10 @@ func TestPerformValidation_FailedThenSuccessfulValidationResetsPauseIdentifiersR
 }
 
 func TestPerformValidationVAError(t *testing.T) {
-	va, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	va, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
-	authzPB := createPendingAuthorization(t, sa, identifier.NewDNS("example.com"), fc.Now().Add(12*time.Hour))
+	authzPB := createPendingAuthorization(t, sa, registration.Id, identifier.NewDNS("example.com"), fc.Now().Add(12*time.Hour))
 
 	va.doDCVError = fmt.Errorf("Something went wrong")
 
@@ -880,16 +879,16 @@ func TestPerformValidationVAError(t *testing.T) {
 }
 
 func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
 
-	authzID := createFinalizedAuthorization(t, sa, identifier.NewDNS("www.example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
+	authzID := createFinalizedAuthorization(t, sa, registration.Id, identifier.NewDNS("www.example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
 
 	order, err := sa.NewOrderAndAuthzs(context.Background(), &sapb.NewOrderAndAuthzsRequest{
 		NewOrder: &sapb.NewOrderRequest{
-			RegistrationID:   Registration.Id,
+			RegistrationID:   registration.Id,
 			Expires:          timestamppb.New(exp),
 			Identifiers:      []*corepb.Identifier{identifier.NewDNS("www.example.com").ToProto()},
 			V2Authorizations: []int64{authzID},
@@ -910,7 +909,7 @@ func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 			Status:         string(core.StatusReady),
 			Identifiers:    []*corepb.Identifier{identifier.NewDNS("www.example.com").ToProto()},
 			Id:             order.Id,
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 		},
 		Csr: csrBytes,
 	})
@@ -919,11 +918,11 @@ func TestCertificateKeyNotEqualAccountKey(t *testing.T) {
 }
 
 func TestDeactivateAuthorization(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	exp := ra.clk.Now().Add(365 * 24 * time.Hour)
-	authzID := createFinalizedAuthorization(t, sa, identifier.NewDNS("not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
+	authzID := createFinalizedAuthorization(t, sa, registration.Id, identifier.NewDNS("not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
 	dbAuthzPB := getAuthorization(t, fmt.Sprint(authzID), sa)
 	_, err := ra.DeactivateAuthorization(ctx, dbAuthzPB)
 	test.AssertNotError(t, err, "Could not deactivate authorization")
@@ -947,7 +946,7 @@ func (sa *mockSARecordingPauses) DeactivateAuthorization2(_ context.Context, _ *
 }
 
 func TestDeactivateAuthorization_Pausing(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	if ra.limiter == nil {
@@ -975,7 +974,7 @@ func TestDeactivateAuthorization_Pausing(t *testing.T) {
 	// get paused.
 	_, err = ra.DeactivateAuthorization(ctx, &corepb.Authorization{
 		Id:             "1",
-		RegistrationID: 1,
+		RegistrationID: registration.Id,
 		Identifier:     identifier.NewDNS("example.com").ToProto(),
 		Status:         string(core.StatusPending),
 	})
@@ -985,7 +984,7 @@ func TestDeactivateAuthorization_Pausing(t *testing.T) {
 	// Deactivating a valid authz shouldn't increment any limits or pause anything.
 	_, err = ra.DeactivateAuthorization(ctx, &corepb.Authorization{
 		Id:             "2",
-		RegistrationID: 1,
+		RegistrationID: registration.Id,
 		Identifier:     identifier.NewDNS("example.com").ToProto(),
 		Status:         string(core.StatusValid),
 	})
@@ -996,18 +995,18 @@ func TestDeactivateAuthorization_Pausing(t *testing.T) {
 	// in a pause request.
 	_, err = ra.DeactivateAuthorization(ctx, &corepb.Authorization{
 		Id:             "3",
-		RegistrationID: 1,
+		RegistrationID: registration.Id,
 		Identifier:     identifier.NewDNS("example.com").ToProto(),
 		Status:         string(core.StatusPending),
 	})
 	test.AssertNotError(t, err, "mock deactivation should work")
 	test.AssertNotNil(t, msa.recv, "should have recorded a pause request")
-	test.AssertEquals(t, msa.recv.RegistrationID, int64(1))
+	test.AssertEquals(t, msa.recv.RegistrationID, registration.Id)
 	test.AssertEquals(t, msa.recv.Identifiers[0].Value, "example.com")
 }
 
 func TestDeactivateRegistration(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Deactivate failure because incomplete registration provided
@@ -1015,12 +1014,12 @@ func TestDeactivateRegistration(t *testing.T) {
 	test.AssertDeepEquals(t, err, fmt.Errorf("incomplete gRPC request message"))
 
 	// Deactivate success with valid registration
-	got, err := ra.DeactivateRegistration(context.Background(), &rapb.DeactivateRegistrationRequest{RegistrationID: 1})
+	got, err := ra.DeactivateRegistration(context.Background(), &rapb.DeactivateRegistrationRequest{RegistrationID: registration.Id})
 	test.AssertNotError(t, err, "DeactivateRegistration failed")
 	test.AssertEquals(t, got.Status, string(core.StatusDeactivated))
 
 	// Check db to make sure account is deactivated
-	dbReg, err := ra.SA.GetRegistration(context.Background(), &sapb.RegistrationID{Id: 1})
+	dbReg, err := ra.SA.GetRegistration(context.Background(), &sapb.RegistrationID{Id: registration.Id})
 	test.AssertNotError(t, err, "GetRegistration failed")
 	test.AssertEquals(t, dbReg.Status, string(core.StatusDeactivated))
 }
@@ -1076,7 +1075,7 @@ func (cr *caaRecorder) DoCAA(
 // Test that the right set of domain names have their CAA rechecked, based on
 // their `Validated` (attemptedAt in the database) timestamp.
 func TestRecheckCAADates(t *testing.T) {
-	_, _, ra, _, fc, cleanUp := initAuthorities(t)
+	_, _, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	recorder := &caaRecorder{names: make(map[string]bool)}
 	ra.VA = va.RemoteClients{CAAClient: recorder}
@@ -1196,22 +1195,22 @@ func TestRecheckCAADates(t *testing.T) {
 
 	// NOTE: The names provided here correspond to authorizations in the
 	// `mockSAWithRecentAndOlder`
-	err := ra.checkAuthorizationsCAA(context.Background(), Registration.Id, authzs, fc.Now())
+	err := ra.checkAuthorizationsCAA(context.Background(), registration.Id, authzs, fc.Now())
 	// We expect that there is no error rechecking authorizations for these names
 	if err != nil {
 		t.Errorf("expected nil err, got %s", err)
 	}
 
 	// Should error if a authorization has `!= 1` challenge
-	err = ra.checkAuthorizationsCAA(context.Background(), Registration.Id, twoChallenges, fc.Now())
+	err = ra.checkAuthorizationsCAA(context.Background(), registration.Id, twoChallenges, fc.Now())
 	test.AssertEquals(t, err.Error(), "authorization has incorrect number of challenges. 1 expected, 2 found for: id twochal")
 
 	// Should error if a authorization has `!= 1` challenge
-	err = ra.checkAuthorizationsCAA(context.Background(), Registration.Id, noChallenges, fc.Now())
+	err = ra.checkAuthorizationsCAA(context.Background(), registration.Id, noChallenges, fc.Now())
 	test.AssertEquals(t, err.Error(), "authorization has incorrect number of challenges. 1 expected, 0 found for: id nochal")
 
 	// Should error if authorization's challenge has no validated timestamp
-	err = ra.checkAuthorizationsCAA(context.Background(), Registration.Id, noValidationTime, fc.Now())
+	err = ra.checkAuthorizationsCAA(context.Background(), registration.Id, noValidationTime, fc.Now())
 	test.AssertEquals(t, err.Error(), "authorization's challenge has no validated timestamp for: id noval")
 
 	// We expect that "recent.com" is not checked because its mock authorization
@@ -1293,7 +1292,7 @@ func (cf *caaFailer) DoCAA(
 }
 
 func TestRecheckCAAEmpty(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	err := ra.recheckCAA(context.Background(), nil)
 	test.AssertNotError(t, err, "expected nil")
@@ -1307,7 +1306,7 @@ func makeHTTP01Authorization(ident identifier.ACMEIdentifier) *core.Authorizatio
 }
 
 func TestRecheckCAASuccess(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ra.VA = va.RemoteClients{CAAClient: &noopCAA{}}
 	authzs := []*core.Authorization{
@@ -1320,7 +1319,7 @@ func TestRecheckCAASuccess(t *testing.T) {
 }
 
 func TestRecheckCAAFail(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ra.VA = va.RemoteClients{CAAClient: &caaFailer{}}
 	authzs := []*core.Authorization{
@@ -1371,7 +1370,7 @@ func TestRecheckCAAFail(t *testing.T) {
 }
 
 func TestRecheckCAAInternalServerError(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ra.VA = va.RemoteClients{CAAClient: &caaFailer{}}
 	authzs := []*core.Authorization{
@@ -1385,7 +1384,7 @@ func TestRecheckCAAInternalServerError(t *testing.T) {
 }
 
 func TestRecheckSkipIPAddress(t *testing.T) {
-	_, _, ra, _, fc, cleanUp := initAuthorities(t)
+	_, _, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ra.VA = va.RemoteClients{CAAClient: &caaFailer{}}
 	ident := identifier.NewIP(netip.MustParseAddr("127.0.0.1"))
@@ -1405,12 +1404,12 @@ func TestRecheckSkipIPAddress(t *testing.T) {
 			},
 		},
 	}
-	err := ra.checkAuthorizationsCAA(context.Background(), 1, authzs, fc.Now())
+	err := ra.checkAuthorizationsCAA(context.Background(), registration.Id, authzs, fc.Now())
 	test.AssertNotError(t, err, "rechecking CAA for IP address, should have skipped")
 }
 
 func TestRecheckInvalidIdentifierType(t *testing.T) {
-	_, _, ra, _, fc, cleanUp := initAuthorities(t)
+	_, _, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ident := identifier.ACMEIdentifier{
 		Type:  "fnord",
@@ -1432,19 +1431,19 @@ func TestRecheckInvalidIdentifierType(t *testing.T) {
 			},
 		},
 	}
-	err := ra.checkAuthorizationsCAA(context.Background(), 1, authzs, fc.Now())
+	err := ra.checkAuthorizationsCAA(context.Background(), registration.Id, authzs, fc.Now())
 	test.AssertError(t, err, "expected err, got nil")
 	test.AssertErrorIs(t, err, berrors.Malformed)
 	test.AssertContains(t, err.Error(), "invalid identifier type")
 }
 
 func TestNewOrder(t *testing.T) {
-	_, _, ra, _, fc, cleanUp := initAuthorities(t)
+	_, _, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	now := fc.Now()
 	orderA, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID:         Registration.Id,
+		RegistrationID:         registration.Id,
 		CertificateProfileName: "test",
 		Identifiers: []*corepb.Identifier{
 			identifier.NewDNS("b.com").ToProto(),
@@ -1454,7 +1453,7 @@ func TestNewOrder(t *testing.T) {
 		},
 	})
 	test.AssertNotError(t, err, "ra.NewOrder failed")
-	test.AssertEquals(t, orderA.RegistrationID, int64(1))
+	test.AssertEquals(t, orderA.RegistrationID, registration.Id)
 	test.AssertEquals(t, orderA.Expires.AsTime(), now.Add(ra.profiles.def().orderLifetime))
 	test.AssertEquals(t, len(orderA.Identifiers), 3)
 	test.AssertEquals(t, orderA.CertificateProfileName, "test")
@@ -1466,11 +1465,11 @@ func TestNewOrder(t *testing.T) {
 		identifier.NewDNS("c.com").ToProto(),
 	})
 
-	test.AssertEquals(t, orderA.Id, int64(1))
+	test.Assert(t, orderA.Id != 0, "order ID should not be zero")
 	test.AssertEquals(t, numAuthorizations(orderA), 3)
 
 	_, err = ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    []*corepb.Identifier{identifier.NewDNS("a").ToProto()},
 	})
 	test.AssertError(t, err, "NewOrder with invalid names did not error")
@@ -1481,7 +1480,7 @@ func TestNewOrder(t *testing.T) {
 // an identical order results in only one order being created & subsequently
 // reused.
 func TestNewOrder_OrderReuse(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Create an initial order with regA and names
@@ -1491,7 +1490,7 @@ func TestNewOrder_OrderReuse(t *testing.T) {
 	}
 
 	orderReq := &rapb.NewOrderRequest{
-		RegistrationID:         Registration.Id,
+		RegistrationID:         registration.Id,
 		Identifiers:            idents.ToProtoSlice(),
 		CertificateProfileName: "test",
 	}
@@ -1517,7 +1516,7 @@ func TestNewOrder_OrderReuse(t *testing.T) {
 	}{
 		{
 			Name:           "Duplicate order, same regID",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifiers:    idents,
 			Profile:        "test",
 			// We expect reuse since the order matches firstOrder
@@ -1525,7 +1524,7 @@ func TestNewOrder_OrderReuse(t *testing.T) {
 		},
 		{
 			Name:           "Subset of order names, same regID",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifiers:    idents[:1],
 			Profile:        "test",
 			// We do not expect reuse because the order names don't match firstOrder
@@ -1533,7 +1532,7 @@ func TestNewOrder_OrderReuse(t *testing.T) {
 		},
 		{
 			Name:           "Superset of order names, same regID",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifiers:    append(idents, identifier.NewDNS("blog.zombo.com")),
 			Profile:        "test",
 			// We do not expect reuse because the order names don't match firstOrder
@@ -1541,14 +1540,14 @@ func TestNewOrder_OrderReuse(t *testing.T) {
 		},
 		{
 			Name:           "Missing profile, same regID",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifiers:    append(idents, identifier.NewDNS("blog.zombo.com")),
 			// We do not expect reuse because the profile is missing
 			ExpectReuse: false,
 		},
 		{
 			Name:           "Missing profile, same regID",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifiers:    append(idents, identifier.NewDNS("blog.zombo.com")),
 			Profile:        "different",
 			// We do not expect reuse because a different profile is specified
@@ -1593,7 +1592,7 @@ func TestNewOrder_OrderReuse(t *testing.T) {
 // This is not simply a test case in TestNewOrder_OrderReuse because it has
 // side effects.
 func TestNewOrder_OrderReuse_Expired(t *testing.T) {
-	_, _, ra, _, fc, cleanUp := initAuthorities(t)
+	_, _, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Set the order lifetime to something short and known.
@@ -1601,7 +1600,7 @@ func TestNewOrder_OrderReuse_Expired(t *testing.T) {
 
 	// Create an initial order.
 	extant, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers: []*corepb.Identifier{
 			identifier.NewDNS("a.com").ToProto(),
 			identifier.NewDNS("b.com").ToProto(),
@@ -1615,7 +1614,7 @@ func TestNewOrder_OrderReuse_Expired(t *testing.T) {
 
 	// Now a new order for the same names should not reuse the first one.
 	new, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers: []*corepb.Identifier{
 			identifier.NewDNS("a.com").ToProto(),
 			identifier.NewDNS("b.com").ToProto(),
@@ -1629,12 +1628,12 @@ func TestNewOrder_OrderReuse_Expired(t *testing.T) {
 // This is not simply a test case in TestNewOrder_OrderReuse because it has
 // side effects.
 func TestNewOrder_OrderReuse_Invalid(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Create an initial order.
 	extant, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers: []*corepb.Identifier{
 			identifier.NewDNS("a.com").ToProto(),
 			identifier.NewDNS("b.com").ToProto(),
@@ -1651,7 +1650,7 @@ func TestNewOrder_OrderReuse_Invalid(t *testing.T) {
 
 	// Now a new order for the same names should not reuse the first one.
 	new, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers: []*corepb.Identifier{
 			identifier.NewDNS("a.com").ToProto(),
 			identifier.NewDNS("b.com").ToProto(),
@@ -1662,7 +1661,7 @@ func TestNewOrder_OrderReuse_Invalid(t *testing.T) {
 }
 
 func TestNewOrder_AuthzReuse(t *testing.T) {
-	_, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	_, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Create three initial authzs by creating an initial order, then updating
@@ -1673,7 +1672,7 @@ func TestNewOrder_AuthzReuse(t *testing.T) {
 		invalid = "c-invalid.com"
 	)
 	extant, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers: []*corepb.Identifier{
 			identifier.NewDNS(pending).ToProto(),
 			identifier.NewDNS(valid).ToProto(),
@@ -1716,25 +1715,25 @@ func TestNewOrder_AuthzReuse(t *testing.T) {
 	}{
 		{
 			Name:           "Reuse pending authz",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifier:     identifier.NewDNS(pending),
 			ExpectReuse:    false,
 		},
 		{
 			Name:           "Reuse valid authz",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifier:     identifier.NewDNS(valid),
 			ExpectReuse:    true,
 		},
 		{
 			Name:           "Don't reuse invalid authz",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifier:     identifier.NewDNS(invalid),
 			ExpectReuse:    false,
 		},
 		{
 			Name:           "Don't reuse valid authz with wrong profile",
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Identifier:     identifier.NewDNS(valid),
 			Profile:        "test",
 			ExpectReuse:    false,
@@ -1767,7 +1766,7 @@ func TestNewOrder_AuthzReuse(t *testing.T) {
 }
 
 func TestNewOrder_ValidationProfiles(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	ra.profiles = &validationProfiles{
@@ -1816,7 +1815,7 @@ func TestNewOrder_ValidationProfiles(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			order, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-				RegistrationID:         Registration.Id,
+				RegistrationID:         registration.Id,
 				Identifiers:            []*corepb.Identifier{identifier.NewDNS(randomDomain()).ToProto()},
 				CertificateProfileName: tc.profile,
 			})
@@ -1843,7 +1842,7 @@ func TestNewOrder_ValidationProfiles(t *testing.T) {
 }
 
 func TestNewOrder_ProfileSelectionAllowList(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	testCases := []struct {
@@ -1870,8 +1869,8 @@ func TestNewOrder_ProfileSelectionAllowList(t *testing.T) {
 			expectErrContains: "not permitted to use certificate profile",
 		},
 		{
-			name:      "Allow Registration.Id",
-			profile:   validationProfile{allowList: allowlist.NewList([]int64{Registration.Id})},
+			name:      "Allow registration ID",
+			profile:   validationProfile{allowList: allowlist.NewList([]int64{registration.Id})},
 			expectErr: false,
 		},
 	}
@@ -1885,7 +1884,7 @@ func TestNewOrder_ProfileSelectionAllowList(t *testing.T) {
 			}
 
 			orderReq := &rapb.NewOrderRequest{
-				RegistrationID:         Registration.Id,
+				RegistrationID:         registration.Id,
 				Identifiers:            []*corepb.Identifier{identifier.NewDNS(randomDomain()).ToProto()},
 				CertificateProfileName: "test",
 			}
@@ -1902,7 +1901,7 @@ func TestNewOrder_ProfileSelectionAllowList(t *testing.T) {
 }
 
 func TestNewOrder_ProfileIdentifierTypes(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	testCases := []struct {
@@ -1962,7 +1961,7 @@ func TestNewOrder_ProfileIdentifierTypes(t *testing.T) {
 			}
 
 			orderReq := &rapb.NewOrderRequest{
-				RegistrationID:         Registration.Id,
+				RegistrationID:         registration.Id,
 				Identifiers:            tc.idents,
 				CertificateProfileName: "test",
 			}
@@ -2048,7 +2047,7 @@ func (msa *mockSAWithAuthzs) NewOrderAndAuthzs(ctx context.Context, req *sapb.Ne
 // for background - this safety check was previously broken!
 // https://github.com/letsencrypt/boulder/issues/3420
 func TestNewOrderAuthzReuseSafety(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	ctx := context.Background()
@@ -2063,7 +2062,7 @@ func TestNewOrderAuthzReuseSafety(t *testing.T) {
 				// A static fake ID we can check for in a unit test
 				ID:             "1",
 				Identifier:     identifier.NewDNS("*.zombo.com"),
-				RegistrationID: Registration.Id,
+				RegistrationID: registration.Id,
 				// Authz is valid
 				Status:  "valid",
 				Expires: &expires,
@@ -2086,7 +2085,7 @@ func TestNewOrderAuthzReuseSafety(t *testing.T) {
 				// A static fake ID we can check for in a unit test
 				ID:             "2",
 				Identifier:     identifier.NewDNS("zombo.com"),
-				RegistrationID: Registration.Id,
+				RegistrationID: registration.Id,
 				// Authz is valid
 				Status:  "valid",
 				Expires: &expires,
@@ -2110,7 +2109,7 @@ func TestNewOrderAuthzReuseSafety(t *testing.T) {
 
 	// Create an initial request with regA and names
 	orderReq := &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    idents.ToProtoSlice(),
 	}
 
@@ -2122,7 +2121,7 @@ func TestNewOrderAuthzReuseSafety(t *testing.T) {
 }
 
 func TestNewOrderWildcard(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	orderIdents := identifier.ACMEIdentifiers{
@@ -2130,7 +2129,7 @@ func TestNewOrderWildcard(t *testing.T) {
 		identifier.NewDNS("*.welcome.zombo.com"),
 	}
 	wildcardOrderRequest := &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    orderIdents.ToProtoSlice(),
 	}
 
@@ -2183,7 +2182,7 @@ func TestNewOrderWildcard(t *testing.T) {
 		identifier.NewDNS("*.zombo.com"),
 	}
 	wildcardOrderRequest = &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    orderIdents.ToProtoSlice(),
 	}
 	order, err = ra.NewOrder(context.Background(), wildcardOrderRequest)
@@ -2226,7 +2225,7 @@ func TestNewOrderWildcard(t *testing.T) {
 	// Make an order for a single domain, no wildcards. This will create a new
 	// pending authz for the domain
 	normalOrderReq := &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    []*corepb.Identifier{identifier.NewDNS("everything.is.possible.zombo.com").ToProto()},
 	}
 	normalOrder, err := ra.NewOrder(context.Background(), normalOrderReq)
@@ -2252,7 +2251,7 @@ func TestNewOrderWildcard(t *testing.T) {
 	// order since we now require a DNS-01 challenge for the `*.` prefixed name.
 	orderIdents = identifier.ACMEIdentifiers{identifier.NewDNS("*.everything.is.possible.zombo.com")}
 	wildcardOrderRequest = &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    orderIdents.ToProtoSlice(),
 	}
 	order, err = ra.NewOrder(context.Background(), wildcardOrderRequest)
@@ -2291,7 +2290,7 @@ func TestNewOrderWildcard(t *testing.T) {
 }
 
 func TestNewOrderExpiry(t *testing.T) {
-	_, _, ra, _, clk, cleanUp := initAuthorities(t)
+	_, _, ra, _, clk, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	ctx := context.Background()
@@ -2312,7 +2311,7 @@ func TestNewOrderExpiry(t *testing.T) {
 				// A static fake ID we can check for in a unit test
 				ID:             "1",
 				Identifier:     identifier.NewDNS("zombo.com"),
-				RegistrationID: Registration.Id,
+				RegistrationID: registration.Id,
 				Expires:        &fakeAuthzExpires,
 				Status:         "valid",
 				Challenges: []core.Challenge{
@@ -2328,7 +2327,7 @@ func TestNewOrderExpiry(t *testing.T) {
 
 	// Create an initial request with regA and names
 	orderReq := &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    idents.ToProtoSlice(),
 	}
 
@@ -2359,15 +2358,15 @@ func TestNewOrderExpiry(t *testing.T) {
 }
 
 func TestFinalizeOrder(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Create one finalized authorization for not-example.com and one finalized
 	// authorization for www.not-example.org
 	now := ra.clk.Now()
 	exp := now.Add(365 * 24 * time.Hour)
-	authzIDA := createFinalizedAuthorization(t, sa, identifier.NewDNS("not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
-	authzIDB := createFinalizedAuthorization(t, sa, identifier.NewDNS("www.not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
+	authzIDA := createFinalizedAuthorization(t, sa, registration.Id, identifier.NewDNS("not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
+	authzIDB := createFinalizedAuthorization(t, sa, registration.Id, identifier.NewDNS("www.not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	test.AssertNotError(t, err, "error generating test key")
@@ -2422,20 +2421,20 @@ func TestFinalizeOrder(t *testing.T) {
 	// processed.
 	// Add a new order for the fake reg ID
 	fakeRegOrder, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    []*corepb.Identifier{identifier.NewDNS("001.example.com").ToProto()},
 	})
 	test.AssertNotError(t, err, "Could not add test order for fake reg ID order ID")
 
 	missingAuthzOrder, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    []*corepb.Identifier{identifier.NewDNS("002.example.com").ToProto()},
 	})
 	test.AssertNotError(t, err, "Could not add test order for missing authz order ID")
 
 	validatedOrder, err := sa.NewOrderAndAuthzs(context.Background(), &sapb.NewOrderAndAuthzsRequest{
 		NewOrder: &sapb.NewOrderRequest{
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Expires:        timestamppb.New(exp),
 			Identifiers: []*corepb.Identifier{
 				identifier.NewDNS("not-example.com").ToProto(),
@@ -2608,7 +2607,7 @@ func TestFinalizeOrder(t *testing.T) {
 						identifier.NewDNS("b.com").ToProto(),
 					},
 					Id:                missingAuthzOrder.Id,
-					RegistrationID:    Registration.Id,
+					RegistrationID:    registration.Id,
 					Expires:           timestamppb.New(exp),
 					CertificateSerial: "",
 					BeganProcessing:   false,
@@ -2653,22 +2652,22 @@ func TestFinalizeOrder(t *testing.T) {
 }
 
 func TestFinalizeOrderWithMixedSANAndCN(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Pick an expiry in the future
 	now := ra.clk.Now()
 	exp := now.Add(365 * 24 * time.Hour)
 
-	// Create one finalized authorization for Registration.Id for not-example.com and
-	// one finalized authorization for Registration.Id for www.not-example.org
-	authzIDA := createFinalizedAuthorization(t, sa, identifier.NewDNS("not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
-	authzIDB := createFinalizedAuthorization(t, sa, identifier.NewDNS("www.not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
+	// Create one finalized authorization for the registration for not-example.com and
+	// one finalized authorization for www.not-example.org
+	authzIDA := createFinalizedAuthorization(t, sa, registration.Id, identifier.NewDNS("not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
+	authzIDB := createFinalizedAuthorization(t, sa, registration.Id, identifier.NewDNS("www.not-example.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
 
 	// Create a new order to finalize with names in SAN and CN
 	mixedOrder, err := sa.NewOrderAndAuthzs(context.Background(), &sapb.NewOrderAndAuthzsRequest{
 		NewOrder: &sapb.NewOrderRequest{
-			RegistrationID: Registration.Id,
+			RegistrationID: registration.Id,
 			Expires:        timestamppb.New(exp),
 			Identifiers: []*corepb.Identifier{
 				identifier.NewDNS("not-example.com").ToProto(),
@@ -2717,7 +2716,7 @@ func TestFinalizeOrderWithMixedSANAndCN(t *testing.T) {
 }
 
 func TestFinalizeOrderWildcard(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Pick an expiry in the future
@@ -2762,14 +2761,14 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 	orderIdents := identifier.ACMEIdentifiers{identifier.NewDNS("*.zombo.com")}
 	test.AssertNotError(t, err, "Converting identifiers to DNS names")
 	wildcardOrderRequest := &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    orderIdents.ToProtoSlice(),
 	}
 	order, err := ra.NewOrder(context.Background(), wildcardOrderRequest)
 	test.AssertNotError(t, err, "NewOrder failed for wildcard domain order")
 
-	// Create one standard finalized authorization for Registration.Id for zombo.com
-	_ = createFinalizedAuthorization(t, sa, identifier.NewDNS("zombo.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
+	// Create one standard finalized authorization for the registration for zombo.com
+	_ = createFinalizedAuthorization(t, sa, registration.Id, identifier.NewDNS("zombo.com"), exp, core.ChallengeTypeHTTP01, ra.clk.Now())
 
 	// Finalizing the order should *not* work since the existing validated authz
 	// is not a special DNS-01-Wildcard challenge authz, so the order will be
@@ -2820,7 +2819,7 @@ func TestFinalizeOrderWildcard(t *testing.T) {
 }
 
 func TestFinalizeOrderDisabledChallenge(t *testing.T) {
-	_, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	_, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	domain := randomDomain()
@@ -2828,11 +2827,11 @@ func TestFinalizeOrderDisabledChallenge(t *testing.T) {
 
 	// Create a finalized authorization for that domain
 	authzID := createFinalizedAuthorization(
-		t, sa, ident, fc.Now().Add(24*time.Hour), core.ChallengeTypeHTTP01, fc.Now().Add(-1*time.Hour))
+		t, sa, registration.Id, ident, fc.Now().Add(24*time.Hour), core.ChallengeTypeHTTP01, fc.Now().Add(-1*time.Hour))
 
 	// Create an order that reuses that authorization
 	order, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    []*corepb.Identifier{ident.ToProto()},
 	})
 	test.AssertNotError(t, err, "creating test order")
@@ -2878,7 +2877,7 @@ func TestFinalizeOrderDisabledChallenge(t *testing.T) {
 }
 
 func TestFinalizeWithMustStaple(t *testing.T) {
-	_, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	_, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	ocspMustStapleExt := pkix.Extension{
@@ -2894,10 +2893,10 @@ func TestFinalizeWithMustStaple(t *testing.T) {
 	domain := randomDomain()
 
 	authzID := createFinalizedAuthorization(
-		t, sa, identifier.NewDNS(domain), fc.Now().Add(24*time.Hour), core.ChallengeTypeHTTP01, fc.Now().Add(-1*time.Hour))
+		t, sa, registration.Id, identifier.NewDNS(domain), fc.Now().Add(24*time.Hour), core.ChallengeTypeHTTP01, fc.Now().Add(-1*time.Hour))
 
 	order, err := ra.NewOrder(context.Background(), &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    []*corepb.Identifier{identifier.NewDNS(domain).ToProto()},
 	})
 	test.AssertNotError(t, err, "creating test order")
@@ -2943,7 +2942,7 @@ func TestFinalizeWithMustStaple(t *testing.T) {
 }
 
 func TestIssueCertificateAuditLog(t *testing.T) {
-	_, sa, ra, _, _, cleanUp := initAuthorities(t)
+	_, sa, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Make some valid authorizations for some names using different challenge types
@@ -2958,13 +2957,13 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 	challs := []core.AcmeChallenge{core.ChallengeTypeHTTP01, core.ChallengeTypeDNS01, core.ChallengeTypeHTTP01, core.ChallengeTypeDNS01}
 	var authzIDs []int64
 	for i, ident := range idents {
-		authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, ident, exp, challs[i], ra.clk.Now()))
+		authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, registration.Id, ident, exp, challs[i], ra.clk.Now()))
 	}
 
 	// Create a pending order for all of the names
 	order, err := sa.NewOrderAndAuthzs(context.Background(), &sapb.NewOrderAndAuthzsRequest{
 		NewOrder: &sapb.NewOrderRequest{
-			RegistrationID:   Registration.Id,
+			RegistrationID:   registration.Id,
 			Expires:          timestamppb.New(exp),
 			Identifiers:      idents.ToProtoSlice(),
 			V2Authorizations: authzIDs,
@@ -3040,7 +3039,7 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 	// The event should have no error
 	test.AssertEquals(t, event.Error, "")
 	// The event requester should be the expected reg ID
-	test.AssertEquals(t, event.Requester, Registration.Id)
+	test.AssertEquals(t, event.Requester, registration.Id)
 	// The event order ID should be the expected order ID
 	test.AssertEquals(t, event.OrderID, order.Id)
 	// The event serial number should be the expected serial number
@@ -3069,7 +3068,7 @@ func TestIssueCertificateAuditLog(t *testing.T) {
 }
 
 func TestIssueCertificateCAACheckLog(t *testing.T) {
-	_, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	_, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ra.VA = va.RemoteClients{CAAClient: &noopCAA{}}
 
@@ -3092,13 +3091,13 @@ func TestIssueCertificateCAACheckLog(t *testing.T) {
 		if i%2 == 0 {
 			attemptedAt = recent
 		}
-		authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, ident, exp, core.ChallengeTypeHTTP01, attemptedAt))
+		authzIDs = append(authzIDs, createFinalizedAuthorization(t, sa, registration.Id, ident, exp, core.ChallengeTypeHTTP01, attemptedAt))
 	}
 
 	// Create a pending order for all of the names.
 	order, err := sa.NewOrderAndAuthzs(context.Background(), &sapb.NewOrderAndAuthzsRequest{
 		NewOrder: &sapb.NewOrderRequest{
-			RegistrationID:   Registration.Id,
+			RegistrationID:   registration.Id,
 			Expires:          timestamppb.New(exp),
 			Identifiers:      idents.ToProtoSlice(),
 			V2Authorizations: authzIDs,
@@ -3166,7 +3165,7 @@ func TestIssueCertificateCAACheckLog(t *testing.T) {
 	// The JSON should unmarshal without error.
 	test.AssertNotError(t, err, "Error unmarshalling logged JSON issuance event.")
 	// The event requester should be the expected registration ID.
-	test.AssertEquals(t, event.Requester, Registration.Id)
+	test.AssertEquals(t, event.Requester, registration.Id)
 	// The event should have the expected number of Authzs where CAA was reused.
 	test.AssertEquals(t, event.Reused, 2)
 	// The event should have the expected number of Authzs where CAA was
@@ -3183,11 +3182,11 @@ func TestIssueCertificateCAACheckLog(t *testing.T) {
 //
 // See https://github.com/letsencrypt/boulder/issues/3201
 func TestUpdateMissingAuthorization(t *testing.T) {
-	_, sa, ra, _, fc, cleanUp := initAuthorities(t)
+	_, sa, ra, _, fc, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	ctx := context.Background()
 
-	authzPB := createPendingAuthorization(t, sa, identifier.NewDNS("example.com"), fc.Now().Add(12*time.Hour))
+	authzPB := createPendingAuthorization(t, sa, registration.Id, identifier.NewDNS("example.com"), fc.Now().Add(12*time.Hour))
 	authz, err := bgrpc.PBToAuthz(authzPB)
 	test.AssertNotError(t, err, "failed to deserialize authz")
 
@@ -3203,7 +3202,7 @@ func TestUpdateMissingAuthorization(t *testing.T) {
 }
 
 func TestPerformValidationBadChallengeType(t *testing.T) {
-	_, _, ra, _, fc, cleanUp := initAuthorities(t)
+	_, _, ra, _, fc, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 	pa, err := policy.New(map[identifier.IdentifierType]bool{}, map[core.AcmeChallenge]bool{}, blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
@@ -3243,7 +3242,7 @@ func (mp *timeoutPub) SubmitToSingleCTWithResult(_ context.Context, _ *pubpb.Req
 }
 
 func TestCTPolicyMeasurements(t *testing.T) {
-	_, _, ra, _, _, cleanup := initAuthorities(t)
+	_, _, ra, _, _, _, cleanup := initAuthorities(t)
 	defer cleanup()
 
 	ra.ctpolicy = ctpolicy.New(&timeoutPub{}, loglist.List{
@@ -3315,7 +3314,7 @@ func (sa *mockSAWithFinalize) FQDNSetTimestampsForWindow(ctx context.Context, in
 }
 
 func TestIssueCertificateOuter(t *testing.T) {
-	_, _, ra, _, fc, cleanup := initAuthorities(t)
+	_, _, ra, _, fc, registration, cleanup := initAuthorities(t)
 	defer cleanup()
 	ra.SA = &mockSAWithFinalize{}
 
@@ -3363,7 +3362,7 @@ func TestIssueCertificateOuter(t *testing.T) {
 			ra.CA = &mockCA
 
 			order := &corepb.Order{
-				RegistrationID:         Registration.Id,
+				RegistrationID:         registration.Id,
 				Expires:                timestamppb.New(fc.Now().Add(24 * time.Hour)),
 				Identifiers:            []*corepb.Identifier{identifier.NewDNS("example.com").ToProto()},
 				CertificateProfileName: tc.profile,
@@ -3388,7 +3387,7 @@ func TestIssueCertificateOuter(t *testing.T) {
 }
 
 func TestNewOrderMaxNames(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	ra.profiles.def().maxNames = 2
@@ -3584,7 +3583,7 @@ func (msar *mockSARevocation) UpdateRevokedCertificate(_ context.Context, req *s
 }
 
 func TestRevokeCertByApplicant_Subscriber(t *testing.T) {
-	_, _, ra, _, clk, cleanUp := initAuthorities(t)
+	_, _, ra, _, clk, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Use the same self-signed cert as both issuer and issuee for revocation.
@@ -3656,7 +3655,7 @@ func (msa *mockSARevocationWithAuthzs) GetValidAuthorizations2(ctx context.Conte
 }
 
 func TestRevokeCertByApplicant_Controller(t *testing.T) {
-	_, _, ra, _, clk, cleanUp := initAuthorities(t)
+	_, _, ra, _, clk, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Use the same self-signed cert as both issuer and issuee for revocation.
@@ -3694,7 +3693,7 @@ func TestRevokeCertByApplicant_Controller(t *testing.T) {
 }
 
 func TestRevokeCertByKey(t *testing.T) {
-	_, _, ra, _, clk, cleanUp := initAuthorities(t)
+	_, _, ra, _, clk, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Use the same self-signed cert as both issuer and issuee for revocation.
@@ -3743,7 +3742,7 @@ func TestRevokeCertByKey(t *testing.T) {
 }
 
 func TestAdministrativelyRevokeCertificate(t *testing.T) {
-	_, _, ra, _, clk, cleanUp := initAuthorities(t)
+	_, _, ra, _, clk, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	// Use the same self-signed cert as both issuer and issuee for revocation.
@@ -3880,11 +3879,11 @@ func (sa *mockNewOrderMustBeReplacementAuthority) NewOrderAndAuthzs(ctx context.
 }
 
 func TestNewOrderReplacesSerialCarriesThroughToSA(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, registration, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	exampleOrder := &rapb.NewOrderRequest{
-		RegistrationID: Registration.Id,
+		RegistrationID: registration.Id,
 		Identifiers:    []*corepb.Identifier{identifier.NewDNS("example.com").ToProto()},
 		ReplacesSerial: "1234",
 	}
@@ -3916,7 +3915,7 @@ func (sa *mockSAUnpauseAccount) UnpauseAccount(_ context.Context, req *sapb.Regi
 // the requested RegID to the SA, and correctly passes the SA's count back to
 // the caller.
 func TestUnpauseAccount(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	mockSA := mockSAUnpauseAccount{identsToUnpause: 0}
@@ -3938,7 +3937,7 @@ func TestUnpauseAccount(t *testing.T) {
 }
 
 func TestGetAuthorization(t *testing.T) {
-	_, _, ra, _, _, cleanup := initAuthorities(t)
+	_, _, ra, _, _, _, cleanup := initAuthorities(t)
 	defer cleanup()
 
 	ra.SA = &mockSAWithAuthzs{
@@ -4022,7 +4021,7 @@ func (sa *mockSARecordingRegistration) UpdateRegistrationKey(ctx context.Context
 // correctly requires a registration ID and key, passes them to the SA, and
 // passes the updated Registration back to the caller.
 func TestUpdateRegistrationKey(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	expectRegID := int64(1)
@@ -4132,7 +4131,7 @@ func (sa *mockSAWithOverrides) AddRateLimitOverride(ctx context.Context, req *sa
 }
 
 func TestAddRateLimitOverride(t *testing.T) {
-	_, _, ra, _, _, cleanUp := initAuthorities(t)
+	_, _, ra, _, _, _, cleanUp := initAuthorities(t)
 	defer cleanUp()
 
 	mockSA := mockSAWithOverrides{}

--- a/sa/db-users/boulder_sa.sql
+++ b/sa/db-users/boulder_sa.sql
@@ -32,8 +32,8 @@ GRANT SELECT,INSERT,UPDATE ON crlShards TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON revokedCertificates TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON replacementOrders TO 'sa'@'localhost';
 GRANT SELECT,INSERT,UPDATE ON overrides TO 'sa'@'localhost';
--- Tests need to be able to TRUNCATE this table, so DROP is necessary.
-GRANT SELECT,INSERT,UPDATE,DROP ON paused TO 'sa'@'localhost';
+-- Tests need to be able to remove rows from this table, so DELETE,DROP is necessary.
+GRANT SELECT,INSERT,UPDATE,DELETE,DROP ON paused TO 'sa'@'localhost';
 
 GRANT SELECT ON certificates TO 'sa_ro'@'localhost';
 GRANT SELECT ON certificateStatus TO 'sa_ro'@'localhost';

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -134,7 +134,7 @@ func createWorkingRegistration(t testing.TB, sa *SQLStorageAuthority) *corepb.Re
 	return reg
 }
 
-func createPendingAuthorization(t *testing.T, sa *SQLStorageAuthority, ident identifier.ACMEIdentifier, exp time.Time) int64 {
+func createPendingAuthorization(t *testing.T, sa *SQLStorageAuthority, regID int64, ident identifier.ACMEIdentifier, exp time.Time) int64 {
 	t.Helper()
 
 	tokenStr := core.NewToken()
@@ -144,7 +144,7 @@ func createPendingAuthorization(t *testing.T, sa *SQLStorageAuthority, ident ide
 	am := authzModel{
 		IdentifierType:  identifierTypeToUint[string(ident.Type)],
 		IdentifierValue: ident.Value,
-		RegistrationID:  1,
+		RegistrationID:  regID,
 		Status:          statusToUint[core.StatusPending],
 		Expires:         exp,
 		Challenges:      1 << challTypeToUint[string(core.ChallengeTypeHTTP01)],
@@ -157,10 +157,10 @@ func createPendingAuthorization(t *testing.T, sa *SQLStorageAuthority, ident ide
 	return am.ID
 }
 
-func createFinalizedAuthorization(t *testing.T, sa *SQLStorageAuthority, ident identifier.ACMEIdentifier, exp time.Time,
+func createFinalizedAuthorization(t *testing.T, sa *SQLStorageAuthority, regID int64, ident identifier.ACMEIdentifier, exp time.Time,
 	status string, attemptedAt time.Time) int64 {
 	t.Helper()
-	pendingID := createPendingAuthorization(t, sa, ident, exp)
+	pendingID := createPendingAuthorization(t, sa, regID, ident, exp)
 	attempted := string(core.ChallengeTypeHTTP01)
 	_, err := sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id:          pendingID,
@@ -848,15 +848,17 @@ func TestDeactivateAuthorization2(t *testing.T) {
 	sa, fc, cleanUp := initSA(t)
 	defer cleanUp()
 
+	reg := createWorkingRegistration(t, sa)
+
 	// deactivate a pending authorization
 	expires := fc.Now().Add(time.Hour).UTC()
 	attemptedAt := fc.Now()
-	authzID := createPendingAuthorization(t, sa, identifier.NewDNS("example.com"), expires)
+	authzID := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expires)
 	_, err := sa.DeactivateAuthorization2(context.Background(), &sapb.AuthorizationID2{Id: authzID})
 	test.AssertNotError(t, err, "sa.DeactivateAuthorization2 failed")
 
 	// deactivate a valid authorization
-	authzID = createFinalizedAuthorization(t, sa, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
+	authzID = createFinalizedAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
 	_, err = sa.DeactivateAuthorization2(context.Background(), &sapb.AuthorizationID2{Id: authzID})
 	test.AssertNotError(t, err, "sa.DeactivateAuthorization2 failed")
 }
@@ -956,10 +958,8 @@ func TestNewOrderAndAuthzs(t *testing.T) {
 	reg := createWorkingRegistration(t, sa)
 
 	// Insert two pre-existing authorizations to reference
-	idA := createPendingAuthorization(t, sa, identifier.NewDNS("a.com"), sa.clk.Now().Add(time.Hour))
-	idB := createPendingAuthorization(t, sa, identifier.NewDNS("b.com"), sa.clk.Now().Add(time.Hour))
-	test.AssertEquals(t, idA, int64(1))
-	test.AssertEquals(t, idB, int64(2))
+	idA := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("a.com"), sa.clk.Now().Add(time.Hour))
+	idB := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("b.com"), sa.clk.Now().Add(time.Hour))
 
 	nowC := sa.clk.Now().Add(time.Hour)
 	nowD := sa.clk.Now().Add(time.Hour)
@@ -975,7 +975,7 @@ func TestNewOrderAndAuthzs(t *testing.T) {
 				identifier.NewDNS("c.com").ToProto(),
 				identifier.NewDNS("d.com").ToProto(),
 			},
-			V2Authorizations: []int64{1, 2},
+			V2Authorizations: []int64{idA, idB},
 		},
 		// And add new authorizations for the other two names.
 		NewAuthzs: []*sapb.NewAuthzRequest{
@@ -997,14 +997,28 @@ func TestNewOrderAndAuthzs(t *testing.T) {
 	}
 	order, err := sa.NewOrderAndAuthzs(context.Background(), req)
 	test.AssertNotError(t, err, "sa.NewOrderAndAuthzs failed")
-	test.AssertEquals(t, order.Id, int64(1))
-	test.AssertDeepEquals(t, order.V2Authorizations, []int64{1, 2, 3, 4})
+	test.Assert(t, order.Id != 0, "order ID should be non-zero")
+	test.AssertEquals(t, len(order.V2Authorizations), 4)
+	test.AssertSliceContains(t, order.V2Authorizations, idA)
+	test.AssertSliceContains(t, order.V2Authorizations, idB)
+	// Ensure that two new authzs were created.
+	var newAuthzIDs []int64
+	for _, id := range order.V2Authorizations {
+		if id != idA && id != idB {
+			newAuthzIDs = append(newAuthzIDs, id)
+		}
+	}
+	test.AssertEquals(t, len(newAuthzIDs), 2)
+	test.Assert(t, newAuthzIDs[0] != newAuthzIDs[1], "expected distinct new authz IDs")
 
 	var authzIDs []int64
 	_, err = sa.dbMap.Select(ctx, &authzIDs, "SELECT authzID FROM orderToAuthz2 WHERE orderID = ?;", order.Id)
 	test.AssertNotError(t, err, "Failed to count orderToAuthz entries")
 	test.AssertEquals(t, len(authzIDs), 4)
-	test.AssertDeepEquals(t, authzIDs, []int64{1, 2, 3, 4})
+	slices.Sort(authzIDs)
+	expectedIDs := append([]int64{idA, idB}, newAuthzIDs...)
+	slices.Sort(expectedIDs)
+	test.AssertDeepEquals(t, authzIDs, expectedIDs)
 }
 
 func TestNewOrderAndAuthzs_ReuseOnly(t *testing.T) {
@@ -1015,10 +1029,8 @@ func TestNewOrderAndAuthzs_ReuseOnly(t *testing.T) {
 	expires := fc.Now().Add(2 * time.Hour)
 
 	// Insert two pre-existing authorizations to reference
-	idA := createPendingAuthorization(t, sa, identifier.NewDNS("a.com"), sa.clk.Now().Add(time.Hour))
-	idB := createPendingAuthorization(t, sa, identifier.NewDNS("b.com"), sa.clk.Now().Add(time.Hour))
-	test.AssertEquals(t, idA, int64(1))
-	test.AssertEquals(t, idB, int64(2))
+	idA := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("a.com"), sa.clk.Now().Add(time.Hour))
+	idB := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("b.com"), sa.clk.Now().Add(time.Hour))
 	req := &sapb.NewOrderAndAuthzsRequest{
 		// Insert an order for four names, two of which already have authzs
 		NewOrder: &sapb.NewOrderRequest{
@@ -1028,15 +1040,15 @@ func TestNewOrderAndAuthzs_ReuseOnly(t *testing.T) {
 				identifier.NewDNS("a.com").ToProto(),
 				identifier.NewDNS("b.com").ToProto(),
 			},
-			V2Authorizations: []int64{1, 2},
+			V2Authorizations: []int64{idA, idB},
 		},
 	}
 	order, err := sa.NewOrderAndAuthzs(context.Background(), req)
 	if err != nil {
 		t.Fatal("sa.NewOrderAndAuthzs:", err)
 	}
-	if !reflect.DeepEqual(order.V2Authorizations, []int64{1, 2}) {
-		t.Errorf("sa.NewOrderAndAuthzs().V2Authorizations: want [1, 2], got %v", order.V2Authorizations)
+	if !reflect.DeepEqual(order.V2Authorizations, []int64{idA, idB}) {
+		t.Errorf("sa.NewOrderAndAuthzs().V2Authorizations: want [%d, %d], got %v", idA, idB, order.V2Authorizations)
 	}
 }
 
@@ -1048,10 +1060,8 @@ func TestNewOrderAndAuthzs_CreateOnly(t *testing.T) {
 	expires := fc.Now().Add(2 * time.Hour)
 
 	// Insert two pre-existing authorizations to reference
-	idA := createPendingAuthorization(t, sa, identifier.NewDNS("a.com"), sa.clk.Now().Add(time.Hour))
-	idB := createPendingAuthorization(t, sa, identifier.NewDNS("b.com"), sa.clk.Now().Add(time.Hour))
-	test.AssertEquals(t, idA, int64(1))
-	test.AssertEquals(t, idB, int64(2))
+	_ = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("a.com"), sa.clk.Now().Add(time.Hour))
+	_ = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("b.com"), sa.clk.Now().Add(time.Hour))
 	req := &sapb.NewOrderAndAuthzsRequest{
 		// Insert an order for four names, two of which already have authzs
 		NewOrder: &sapb.NewOrderRequest{
@@ -1262,7 +1272,7 @@ func TestSetOrderProcessing(t *testing.T) {
 	// Add one valid authz
 	expires := fc.Now().Add(time.Hour)
 	attemptedAt := fc.Now()
-	authzID := createFinalizedAuthorization(t, sa, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
+	authzID := createFinalizedAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
 
 	// Add a new order in pending status with no certificate serial
 	expires1Year := sa.clk.Now().Add(365 * 24 * time.Hour)
@@ -1302,7 +1312,7 @@ func TestFinalizeOrder(t *testing.T) {
 	reg := createWorkingRegistration(t, sa)
 	expires := fc.Now().Add(time.Hour)
 	attemptedAt := fc.Now()
-	authzID := createFinalizedAuthorization(t, sa, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
+	authzID := createFinalizedAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
 
 	// Add a new order in pending status with no certificate serial
 	expires1Year := sa.clk.Now().Add(365 * 24 * time.Hour)
@@ -1344,7 +1354,7 @@ func TestGetOrder(t *testing.T) {
 	reg := createWorkingRegistration(t, sa)
 	ident := identifier.NewDNS("example.com")
 	authzExpires := fc.Now().Add(time.Hour)
-	authzID := createPendingAuthorization(t, sa, ident, authzExpires)
+	authzID := createPendingAuthorization(t, sa, reg.Id, ident, authzExpires)
 
 	// Set the order to expire in two hours
 	expires := fc.Now().Add(2 * time.Hour)
@@ -1367,9 +1377,11 @@ func TestGetOrder(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "sa.NewOrderAndAuthzs failed")
 
-	// The Order from GetOrder should match the following expected order
+	// Fetch the order by its ID and make sure it matches the expected
+	storedOrder, err := sa.GetOrder(context.Background(), &sapb.OrderRequest{Id: order.Id})
+	test.AssertNotError(t, err, "sa.GetOrder failed")
 	created := sa.clk.Now()
-	expectedOrder := &corepb.Order{
+	test.AssertDeepEquals(t, storedOrder, &corepb.Order{
 		// The registration ID, authorizations, expiry, and identifiers should match the
 		// input to NewOrderAndAuthzs
 		RegistrationID:   inputOrder.RegistrationID,
@@ -1377,7 +1389,7 @@ func TestGetOrder(t *testing.T) {
 		Identifiers:      inputOrder.Identifiers,
 		Expires:          inputOrder.Expires,
 		// The ID should have been set to 1 by the SA
-		Id: 1,
+		Id: storedOrder.Id,
 		// The status should be pending
 		Status: string(core.StatusPending),
 		// The serial should be empty since this is a pending order
@@ -1386,12 +1398,7 @@ func TestGetOrder(t *testing.T) {
 		BeganProcessing: false,
 		// The created timestamp should have been set to the current time
 		Created: timestamppb.New(created),
-	}
-
-	// Fetch the order by its ID and make sure it matches the expected
-	storedOrder, err := sa.GetOrder(context.Background(), &sapb.OrderRequest{Id: order.Id})
-	test.AssertNotError(t, err, "sa.GetOrder failed")
-	test.AssertDeepEquals(t, storedOrder, expectedOrder)
+	})
 }
 
 // TestGetOrderWithProfile tests that round-tripping a simple order through
@@ -1403,7 +1410,7 @@ func TestGetOrderWithProfile(t *testing.T) {
 	reg := createWorkingRegistration(t, sa)
 	ident := identifier.NewDNS("example.com")
 	authzExpires := fc.Now().Add(time.Hour)
-	authzID := createPendingAuthorization(t, sa, ident, authzExpires)
+	authzID := createPendingAuthorization(t, sa, reg.Id, ident, authzExpires)
 
 	// Set the order to expire in two hours
 	expires := fc.Now().Add(2 * time.Hour)
@@ -1428,9 +1435,11 @@ func TestGetOrderWithProfile(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "sa.NewOrderAndAuthzs failed")
 
-	// The Order from GetOrder should match the following expected order
+	// Fetch the order by its ID and make sure it matches the expected
+	storedOrder, err := sa.GetOrder(context.Background(), &sapb.OrderRequest{Id: order.Id})
+	test.AssertNotError(t, err, "sa.GetOrder failed")
 	created := sa.clk.Now()
-	expectedOrder := &corepb.Order{
+	test.AssertDeepEquals(t, storedOrder, &corepb.Order{
 		// The registration ID, authorizations, expiry, and names should match the
 		// input to NewOrderAndAuthzs
 		RegistrationID:   inputOrder.RegistrationID,
@@ -1438,7 +1447,7 @@ func TestGetOrderWithProfile(t *testing.T) {
 		Identifiers:      inputOrder.Identifiers,
 		Expires:          inputOrder.Expires,
 		// The ID should have been set to 1 by the SA
-		Id: 1,
+		Id: storedOrder.Id,
 		// The status should be pending
 		Status: string(core.StatusPending),
 		// The serial should be empty since this is a pending order
@@ -1448,12 +1457,7 @@ func TestGetOrderWithProfile(t *testing.T) {
 		// The created timestamp should have been set to the current time
 		Created:                timestamppb.New(created),
 		CertificateProfileName: "tbiapb",
-	}
-
-	// Fetch the order by its ID and make sure it matches the expected
-	storedOrder, err := sa.GetOrder(context.Background(), &sapb.OrderRequest{Id: order.Id})
-	test.AssertNotError(t, err, "sa.GetOrder failed")
-	test.AssertDeepEquals(t, storedOrder, expectedOrder)
+	})
 }
 
 // TestGetAuthorization2NoRows ensures that the GetAuthorization2 function returns
@@ -1482,7 +1486,7 @@ func TestFasterGetOrderForNames(t *testing.T) {
 	})
 	test.AssertNotError(t, err, "Couldn't create test registration")
 
-	authzIDs := createPendingAuthorization(t, sa, ident, expires)
+	authzIDs := createPendingAuthorization(t, sa, reg.Id, ident, expires)
 
 	_, err = sa.NewOrderAndAuthzs(ctx, &sapb.NewOrderAndAuthzsRequest{
 		NewOrder: &sapb.NewOrderRequest{
@@ -1529,8 +1533,8 @@ func TestGetOrderForNames(t *testing.T) {
 	// Add one pending authz for the first name for regA and one
 	// pending authz for the second name for regA
 	authzExpires := fc.Now().Add(time.Hour)
-	authzIDA := createPendingAuthorization(t, sa, identifier.NewDNS("example.com"), authzExpires)
-	authzIDB := createPendingAuthorization(t, sa, identifier.NewDNS("just.another.example.com"), authzExpires)
+	authzIDA := createPendingAuthorization(t, sa, regA.Id, identifier.NewDNS("example.com"), authzExpires)
+	authzIDB := createPendingAuthorization(t, sa, regA.Id, identifier.NewDNS("just.another.example.com"), authzExpires)
 
 	ctx := context.Background()
 	idents := identifier.ACMEIdentifiers{
@@ -1610,8 +1614,8 @@ func TestGetOrderForNames(t *testing.T) {
 	// Create two valid authorizations
 	authzExpires = fc.Now().Add(time.Hour)
 	attemptedAt := fc.Now()
-	authzIDC := createFinalizedAuthorization(t, sa, identifier.NewDNS("zombo.com"), authzExpires, "valid", attemptedAt)
-	authzIDD := createFinalizedAuthorization(t, sa, identifier.NewDNS("welcome.to.zombo.com"), authzExpires, "valid", attemptedAt)
+	authzIDC := createFinalizedAuthorization(t, sa, regA.Id, identifier.NewDNS("zombo.com"), authzExpires, "valid", attemptedAt)
+	authzIDD := createFinalizedAuthorization(t, sa, regA.Id, identifier.NewDNS("welcome.to.zombo.com"), authzExpires, "valid", attemptedAt)
 
 	// Add a fresh order that uses the authorizations created above
 	expires = fc.Now().Add(orderLifetime)
@@ -1678,11 +1682,11 @@ func TestStatusForOrder(t *testing.T) {
 
 	// Create a pending authz, an expired authz, an invalid authz, a deactivated authz,
 	// and a valid authz
-	pendingID := createPendingAuthorization(t, sa, identifier.NewDNS("pending.your.order.is.up"), expires)
-	expiredID := createPendingAuthorization(t, sa, identifier.NewDNS("expired.your.order.is.up"), alreadyExpired)
-	invalidID := createFinalizedAuthorization(t, sa, identifier.NewDNS("invalid.your.order.is.up"), expires, "invalid", attemptedAt)
-	validID := createFinalizedAuthorization(t, sa, identifier.NewDNS("valid.your.order.is.up"), expires, "valid", attemptedAt)
-	deactivatedID := createPendingAuthorization(t, sa, identifier.NewDNS("deactivated.your.order.is.up"), expires)
+	pendingID := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("pending.your.order.is.up"), expires)
+	expiredID := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("expired.your.order.is.up"), alreadyExpired)
+	invalidID := createFinalizedAuthorization(t, sa, reg.Id, identifier.NewDNS("invalid.your.order.is.up"), expires, "invalid", attemptedAt)
+	validID := createFinalizedAuthorization(t, sa, reg.Id, identifier.NewDNS("valid.your.order.is.up"), expires, "valid", attemptedAt)
+	deactivatedID := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("deactivated.your.order.is.up"), expires)
 	_, err := sa.DeactivateAuthorization2(context.Background(), &sapb.AuthorizationID2{Id: deactivatedID})
 	test.AssertNotError(t, err, "sa.DeactivateAuthorization2 failed")
 
@@ -1822,7 +1826,8 @@ func TestUpdateChallengesDeleteUnused(t *testing.T) {
 	attemptedAt := fc.Now()
 
 	// Create a valid authz
-	authzID := createFinalizedAuthorization(t, sa, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
+	reg := createWorkingRegistration(t, sa)
+	authzID := createFinalizedAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
 
 	result, err := sa.GetAuthorization2(ctx, &sapb.AuthorizationID2{Id: authzID})
 	test.AssertNotError(t, err, "sa.GetAuthorization2 failed")
@@ -2163,7 +2168,8 @@ func TestFinalizeAuthorization2(t *testing.T) {
 
 	fc.Set(mustTime("2021-01-01 00:00"))
 
-	authzID := createPendingAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
+	reg := createWorkingRegistration(t, sa)
+	authzID := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
 	expires := fc.Now().Add(time.Hour * 2).UTC()
 	attemptedAt := fc.Now()
 	ip, _ := netip.MustParseAddr("1.1.1.1").MarshalText()
@@ -2197,7 +2203,7 @@ func TestFinalizeAuthorization2(t *testing.T) {
 	test.AssertEquals(t, dbVer.Challenges[0].Validationrecords[0].ResolverAddrs[0], "resolver:5353")
 	test.AssertEquals(t, dbVer.Challenges[0].Validated.AsTime(), attemptedAt)
 
-	authzID = createPendingAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
+	authzID = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
 	prob, _ := bgrpc.ProblemDetailsToPB(probs.Connection("it went bad captain"))
 
 	_, err = sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
@@ -2235,12 +2241,13 @@ func TestRehydrateHostPort(t *testing.T) {
 
 	fc.Set(mustTime("2021-01-01 00:00"))
 
+	reg := createWorkingRegistration(t, sa)
 	expires := fc.Now().Add(time.Hour * 2).UTC()
 	attemptedAt := fc.Now()
 	ip, _ := netip.MustParseAddr("1.1.1.1").MarshalText()
 
 	// Implicit good port with good scheme
-	authzID := createPendingAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
+	authzID := createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
 	_, err := sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id: authzID,
 		ValidationRecords: []*corepb.ValidationRecord{
@@ -2261,7 +2268,7 @@ func TestRehydrateHostPort(t *testing.T) {
 	test.AssertNotError(t, err, "rehydration failed in some fun and interesting way")
 
 	// Explicit good port with good scheme
-	authzID = createPendingAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
+	authzID = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
 	_, err = sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id: authzID,
 		ValidationRecords: []*corepb.ValidationRecord{
@@ -2282,7 +2289,7 @@ func TestRehydrateHostPort(t *testing.T) {
 	test.AssertNotError(t, err, "rehydration failed in some fun and interesting way")
 
 	// Explicit bad port with good scheme
-	authzID = createPendingAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
+	authzID = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
 	_, err = sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id: authzID,
 		ValidationRecords: []*corepb.ValidationRecord{
@@ -2303,7 +2310,7 @@ func TestRehydrateHostPort(t *testing.T) {
 	test.AssertError(t, err, "only ports 80/tcp and 443/tcp are allowed in URL \"http://example.com:444\"")
 
 	// Explicit bad port with bad scheme
-	authzID = createPendingAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
+	authzID = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
 	_, err = sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id: authzID,
 		ValidationRecords: []*corepb.ValidationRecord{
@@ -2324,7 +2331,7 @@ func TestRehydrateHostPort(t *testing.T) {
 	test.AssertError(t, err, "unknown scheme \"httpx\" in URL \"httpx://example.com\"")
 
 	// Missing URL field
-	authzID = createPendingAuthorization(t, sa, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
+	authzID = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("aaa"), fc.Now().Add(time.Hour))
 	_, err = sa.FinalizeAuthorization2(context.Background(), &sapb.FinalizeAuthorizationRequest{
 		Id: authzID,
 		ValidationRecords: []*corepb.ValidationRecord{
@@ -2348,13 +2355,14 @@ func TestCountPendingAuthorizations2(t *testing.T) {
 	sa, fc, cleanUp := initSA(t)
 	defer cleanUp()
 
+	reg := createWorkingRegistration(t, sa)
 	expiresA := fc.Now().Add(time.Hour).UTC()
 	expiresB := fc.Now().Add(time.Hour * 3).UTC()
-	_ = createPendingAuthorization(t, sa, identifier.NewDNS("example.com"), expiresA)
-	_ = createPendingAuthorization(t, sa, identifier.NewDNS("example.com"), expiresB)
+	_ = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expiresA)
+	_ = createPendingAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expiresB)
 
 	// Registration has two new style pending authorizations
-	regID := int64(1)
+	regID := reg.Id
 	count, err := sa.CountPendingAuthorizations2(context.Background(), &sapb.RegistrationID{
 		Id: regID,
 	})
@@ -2370,7 +2378,7 @@ func TestCountPendingAuthorizations2(t *testing.T) {
 	test.AssertEquals(t, count.Count, int64(1))
 
 	// Registration with no authorizations should be 0
-	noReg := int64(20)
+	noReg := reg.Id + 100
 	count, err = sa.CountPendingAuthorizations2(context.Background(), &sapb.RegistrationID{
 		Id: noReg,
 	})
@@ -2472,9 +2480,9 @@ func TestGetValidOrderAuthorizations2(t *testing.T) {
 	expires := fc.Now().Add(time.Hour * 24 * 7).UTC()
 	attemptedAt := fc.Now()
 
-	authzIDA := createFinalizedAuthorization(t, sa, identA, expires, "valid", attemptedAt)
-	authzIDB := createFinalizedAuthorization(t, sa, identB, expires, "valid", attemptedAt)
-	authzIDC := createFinalizedAuthorization(t, sa, identC, expires, "valid", attemptedAt)
+	authzIDA := createFinalizedAuthorization(t, sa, reg.Id, identA, expires, "valid", attemptedAt)
+	authzIDB := createFinalizedAuthorization(t, sa, reg.Id, identB, expires, "valid", attemptedAt)
+	authzIDC := createFinalizedAuthorization(t, sa, reg.Id, identC, expires, "valid", attemptedAt)
 
 	orderExpr := fc.Now().Truncate(time.Second)
 	order, err := sa.NewOrderAndAuthzs(context.Background(), &sapb.NewOrderAndAuthzsRequest{
@@ -2542,8 +2550,8 @@ func TestCountInvalidAuthorizations2(t *testing.T) {
 		expiresA := fc.Now().Add(time.Hour).UTC()
 		expiresB := fc.Now().Add(time.Hour * 3).UTC()
 		attemptedAt := fc.Now()
-		_ = createFinalizedAuthorization(t, sa, ident, expiresA, "invalid", attemptedAt)
-		_ = createPendingAuthorization(t, sa, ident, expiresB)
+		_ = createFinalizedAuthorization(t, sa, reg.Id, ident, expiresA, "invalid", attemptedAt)
+		_ = createPendingAuthorization(t, sa, reg.Id, ident, expiresB)
 
 		earliest := fc.Now().Add(-time.Hour).UTC()
 		latest := fc.Now().Add(time.Hour * 5).UTC()
@@ -3526,7 +3534,7 @@ func TestReplacementOrderExists(t *testing.T) {
 	// Add one valid authz.
 	expires := fc.Now().Add(time.Hour)
 	attemptedAt := fc.Now()
-	authzID := createFinalizedAuthorization(t, sa, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
+	authzID := createFinalizedAuthorization(t, sa, reg.Id, identifier.NewDNS("example.com"), expires, "valid", attemptedAt)
 
 	// Add a new order in pending status with no certificate serial.
 	expires1Year := sa.clk.Now().Add(365 * 24 * time.Hour)
@@ -3736,6 +3744,8 @@ func TestUnpauseAccount(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
+	reg := createWorkingRegistration(t, sa)
+
 	tests := []struct {
 		name  string
 		state []pausedModel
@@ -3744,13 +3754,13 @@ func TestUnpauseAccount(t *testing.T) {
 		{
 			name:  "UnpauseAccount with no paused identifiers",
 			state: nil,
-			req:   &sapb.RegistrationID{Id: 1},
+			req:   &sapb.RegistrationID{Id: reg.Id},
 		},
 		{
 			name: "UnpauseAccount with one paused identifier",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -3758,13 +3768,13 @@ func TestUnpauseAccount(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 			},
-			req: &sapb.RegistrationID{Id: 1},
+			req: &sapb.RegistrationID{Id: reg.Id},
 		},
 		{
 			name: "UnpauseAccount with multiple paused identifiers",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -3772,7 +3782,7 @@ func TestUnpauseAccount(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.net",
@@ -3780,7 +3790,7 @@ func TestUnpauseAccount(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.org",
@@ -3788,15 +3798,14 @@ func TestUnpauseAccount(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 			},
-			req: &sapb.RegistrationID{Id: 1},
+			req: &sapb.RegistrationID{Id: reg.Id},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				// Drop all rows from the paused table.
-				_, err := sa.dbMap.ExecContext(ctx, "TRUNCATE TABLE paused")
-				test.AssertNotError(t, err, "truncating paused table")
+				_, err := sa.dbMap.ExecContext(ctx, "DELETE FROM paused WHERE 1 = 1")
+				test.AssertNotError(t, err, "cleaning up paused table")
 			}()
 
 			// Setup table state.
@@ -3822,7 +3831,7 @@ func TestUnpauseAccount(t *testing.T) {
 	}
 }
 
-func bulkInsertPausedIdentifiers(ctx context.Context, sa *SQLStorageAuthority, count int) error {
+func bulkInsertPausedIdentifiers(ctx context.Context, sa *SQLStorageAuthority, regID int64, count int) error {
 	const batchSize = 1000
 
 	values := make([]any, 0, batchSize*4)
@@ -3842,7 +3851,7 @@ func bulkInsertPausedIdentifiers(ctx context.Context, sa *SQLStorageAuthority, c
 				query += ","
 			}
 			query += "(?, ?, ?, ?)"
-			values = append(values, 1, identifierTypeToUint[string(identifier.TypeDNS)], fmt.Sprintf("example%d.com", i), now)
+			values = append(values, regID, identifierTypeToUint[string(identifier.TypeDNS)], fmt.Sprintf("example%d.com", i), now)
 		}
 
 		_, err := sa.dbMap.ExecContext(ctx, query, values...)
@@ -3859,10 +3868,12 @@ func TestUnpauseAccountWithTwoLoops(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
-	err := bulkInsertPausedIdentifiers(ctx, sa, 12000)
+	reg := createWorkingRegistration(t, sa)
+
+	err := bulkInsertPausedIdentifiers(ctx, sa, reg.Id, 12000)
 	test.AssertNotError(t, err, "bulk inserting paused identifiers")
 
-	result, err := sa.UnpauseAccount(ctx, &sapb.RegistrationID{Id: 1})
+	result, err := sa.UnpauseAccount(ctx, &sapb.RegistrationID{Id: reg.Id})
 	test.AssertNotError(t, err, "Unexpected error for UnpauseAccount()")
 	test.AssertEquals(t, result.Count, int64(12000))
 }
@@ -3871,10 +3882,11 @@ func TestUnpauseAccountWithMaxLoops(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
-	err := bulkInsertPausedIdentifiers(ctx, sa, 50001)
+	reg := createWorkingRegistration(t, sa)
+	err := bulkInsertPausedIdentifiers(ctx, sa, reg.Id, 50001)
 	test.AssertNotError(t, err, "bulk inserting paused identifiers")
 
-	result, err := sa.UnpauseAccount(ctx, &sapb.RegistrationID{Id: 1})
+	result, err := sa.UnpauseAccount(ctx, &sapb.RegistrationID{Id: reg.Id})
 	test.AssertNotError(t, err, "Unexpected error for UnpauseAccount()")
 	test.AssertEquals(t, result.Count, int64(50000))
 }
@@ -3883,6 +3895,7 @@ func TestPauseIdentifiers(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
+	reg := createWorkingRegistration(t, sa)
 	ptrTime := func(t time.Time) *time.Time {
 		return &t
 	}
@@ -3900,7 +3913,7 @@ func TestPauseIdentifiers(t *testing.T) {
 			name:  "An identifier which is not now or previously paused",
 			state: nil,
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -3917,7 +3930,7 @@ func TestPauseIdentifiers(t *testing.T) {
 			name: "One unpaused entry which was previously paused",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -3927,7 +3940,7 @@ func TestPauseIdentifiers(t *testing.T) {
 				},
 			},
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -3944,7 +3957,7 @@ func TestPauseIdentifiers(t *testing.T) {
 			name: "One unpaused entry which was previously paused and unpaused less than 2 weeks ago",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -3954,7 +3967,7 @@ func TestPauseIdentifiers(t *testing.T) {
 				},
 			},
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -3971,7 +3984,7 @@ func TestPauseIdentifiers(t *testing.T) {
 			name: "An identifier which is currently paused",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -3980,7 +3993,7 @@ func TestPauseIdentifiers(t *testing.T) {
 				},
 			},
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -3997,7 +4010,7 @@ func TestPauseIdentifiers(t *testing.T) {
 			name: "Two previously paused entries and one new entry",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -4006,7 +4019,7 @@ func TestPauseIdentifiers(t *testing.T) {
 					UnpausedAt: ptrTime(threeWeeksAgo),
 				},
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.net",
@@ -4016,7 +4029,7 @@ func TestPauseIdentifiers(t *testing.T) {
 				},
 			},
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -4041,9 +4054,8 @@ func TestPauseIdentifiers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				// Drop all rows from the paused table.
-				_, err := sa.dbMap.ExecContext(ctx, "TRUNCATE TABLE paused")
-				test.AssertNotError(t, err, "Truncate table paused failed")
+				_, err := sa.dbMap.ExecContext(ctx, "DELETE FROM paused WHERE 1 = 1")
+				test.AssertNotError(t, err, "cleaning up paused table")
 			}()
 
 			// Setup table state.
@@ -4068,6 +4080,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 		return &t
 	}
 
+	reg := createWorkingRegistration(t, sa)
 	tests := []struct {
 		name  string
 		state []pausedModel
@@ -4078,7 +4091,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 			name:  "No paused identifiers",
 			state: nil,
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -4094,7 +4107,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 			name: "One paused identifier",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -4103,7 +4116,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 				},
 			},
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -4124,7 +4137,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 			name: "Two paused identifiers, one unpaused",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -4132,7 +4145,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.net",
@@ -4140,7 +4153,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.org",
@@ -4150,7 +4163,7 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 				},
 			},
 			req: &sapb.PauseRequest{
-				RegistrationID: 1,
+				RegistrationID: reg.Id,
 				Identifiers: []*corepb.Identifier{
 					{
 						Type:  string(identifier.TypeDNS),
@@ -4183,9 +4196,8 @@ func TestCheckIdentifiersPaused(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				// Drop all rows from the paused table.
-				_, err := sa.dbMap.ExecContext(ctx, "TRUNCATE TABLE paused")
-				test.AssertNotError(t, err, "Truncate table paused failed")
+				_, err := sa.dbMap.ExecContext(ctx, "DELETE FROM paused WHERE 1 = 1")
+				test.AssertNotError(t, err, "cleaning up paused table")
 			}()
 
 			// Setup table state.
@@ -4209,6 +4221,8 @@ func TestGetPausedIdentifiers(t *testing.T) {
 		return &t
 	}
 
+	reg := createWorkingRegistration(t, sa)
+
 	tests := []struct {
 		name  string
 		state []pausedModel
@@ -4218,7 +4232,7 @@ func TestGetPausedIdentifiers(t *testing.T) {
 		{
 			name:  "No paused identifiers",
 			state: nil,
-			req:   &sapb.RegistrationID{Id: 1},
+			req:   &sapb.RegistrationID{Id: reg.Id},
 			want: &sapb.Identifiers{
 				Identifiers: []*corepb.Identifier{},
 			},
@@ -4227,7 +4241,7 @@ func TestGetPausedIdentifiers(t *testing.T) {
 			name: "One paused identifier",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -4235,7 +4249,7 @@ func TestGetPausedIdentifiers(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 			},
-			req: &sapb.RegistrationID{Id: 1},
+			req: &sapb.RegistrationID{Id: reg.Id},
 			want: &sapb.Identifiers{
 				Identifiers: []*corepb.Identifier{
 					{
@@ -4249,7 +4263,7 @@ func TestGetPausedIdentifiers(t *testing.T) {
 			name: "Two paused identifiers, one unpaused",
 			state: []pausedModel{
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.com",
@@ -4257,7 +4271,7 @@ func TestGetPausedIdentifiers(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.net",
@@ -4265,7 +4279,7 @@ func TestGetPausedIdentifiers(t *testing.T) {
 					PausedAt: sa.clk.Now().Add(-time.Hour),
 				},
 				{
-					RegistrationID: 1,
+					RegistrationID: reg.Id,
 					identifierModel: identifierModel{
 						Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 						Value: "example.org",
@@ -4274,7 +4288,7 @@ func TestGetPausedIdentifiers(t *testing.T) {
 					UnpausedAt: ptrTime(sa.clk.Now().Add(-time.Minute)),
 				},
 			},
-			req: &sapb.RegistrationID{Id: 1},
+			req: &sapb.RegistrationID{Id: reg.Id},
 			want: &sapb.Identifiers{
 				Identifiers: []*corepb.Identifier{
 					{
@@ -4292,9 +4306,8 @@ func TestGetPausedIdentifiers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				// Drop all rows from the paused table.
-				_, err := sa.dbMap.ExecContext(ctx, "TRUNCATE TABLE paused")
-				test.AssertNotError(t, err, "Truncate table paused failed")
+				_, err := sa.dbMap.ExecContext(ctx, "DELETE FROM paused WHERE 1 = 1")
+				test.AssertNotError(t, err, "cleaning up paused table")
 			}()
 
 			// Setup table state.
@@ -4314,9 +4327,17 @@ func TestGetPausedIdentifiersOnlyUnpausesOneAccount(t *testing.T) {
 	sa, _, cleanUp := initSA(t)
 	defer cleanUp()
 
+	reg1 := createWorkingRegistration(t, sa)
+	reg2, err := sa.NewRegistration(ctx, &corepb.Registration{
+		Key:       newAcctKey(t),
+		CreatedAt: mustTimestamp("2018-04-01 07:00"),
+		Status:    string(core.StatusValid),
+	})
+	test.AssertNotError(t, err, "creating second registration")
+
 	// Insert two paused identifiers for two different accounts.
-	err := sa.dbMap.Insert(ctx, &pausedModel{
-		RegistrationID: 1,
+	err = sa.dbMap.Insert(ctx, &pausedModel{
+		RegistrationID: reg1.Id,
 		identifierModel: identifierModel{
 			Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 			Value: "example.com",
@@ -4326,7 +4347,7 @@ func TestGetPausedIdentifiersOnlyUnpausesOneAccount(t *testing.T) {
 	test.AssertNotError(t, err, "inserting test identifier")
 
 	err = sa.dbMap.Insert(ctx, &pausedModel{
-		RegistrationID: 2,
+		RegistrationID: reg2.Id,
 		identifierModel: identifierModel{
 			Type:  identifierTypeToUint[string(identifier.TypeDNS)],
 			Value: "example.net",
@@ -4336,11 +4357,11 @@ func TestGetPausedIdentifiersOnlyUnpausesOneAccount(t *testing.T) {
 	test.AssertNotError(t, err, "inserting test identifier")
 
 	// Unpause the first account.
-	_, err = sa.UnpauseAccount(ctx, &sapb.RegistrationID{Id: 1})
+	_, err = sa.UnpauseAccount(ctx, &sapb.RegistrationID{Id: reg1.Id})
 	test.AssertNotError(t, err, "UnpauseAccount failed")
 
 	// Check that the second account's identifier is still paused.
-	idents, err := sa.GetPausedIdentifiers(ctx, &sapb.RegistrationID{Id: 2})
+	idents, err := sa.GetPausedIdentifiers(ctx, &sapb.RegistrationID{Id: reg2.Id})
 	test.AssertNotError(t, err, "GetPausedIdentifiers failed")
 	test.AssertEquals(t, len(idents.Identifiers), 1)
 	test.AssertEquals(t, idents.Identifiers[0].Value, "example.net")


### PR DESCRIPTION
DDL (Data Definition Language) operations such as `ALTER` and `TRUNCATE` are extremely expensive in Vitess. Each time Vitess detects a DDL statement, it triggers a full schema reload, rebuilding the in-memory schema models that are used for query planning and routing.

Our Storage Authority, Registration Authority, bad-key-revoker (cmd), and cert-checker (cmd) unit tests repeatedly execute `ALTER` (and some `TRUNCATE`) statements during routine cleanup of every table in the Boulder database at the end of each test case. This has the effect of dramatically worse performance when running on Vitess.

The good news is that we can omit these executions entirely by fixing our unit tests so they no longer make implicit assumptions about the Registration ID of the account under test.

- Remove `ALTER TABLE ... AUTO_INCREMENT = 1` from cleanup to avoid unnecessary DDL
- Replace per-table `SET FOREIGN_KEY_CHECKS` toggles with toggles at the beginning and end of the transaction. Replacing tables (20) x 2 statements with just 2.
- Replace `TRUNCATE TABLE` with `DELETE FROM ... WHERE 1 = 1` to avoid unnecessary DDL
- Remove implicit dependencies on `RegID = 1 (or 2 or 3 or 4)` in `ra`, `sa`, and `cmd/bad-key-revoker` unit tests

The results on both MariaDB and Vitess are extremely good.

Local unit test times with ProxySQL + MariaDB:
SA: 7.1s to  2.5s
RA: 4.5s to 1.1s

Local unit test times with Vitess + MySQL 8.0:
SA: 43s to 2.7s
RA: 28s to 1.5s

Part of #7736