### PR TITLE
Export prometheus client_golang's Go build_info metric

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
@@ -271,6 +272,7 @@ func newStatsRegistry(addr string, logger blog.Logger) prometheus.Registerer {
 	registry.MustRegister(collectors.NewProcessCollector(
 		collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(newVersionCollector())
+	registry.MustRegister(version.NewCollector("boulder"))
 
 	mux := http.NewServeMux()
 	// Register the available pprof handlers. These are all registered on

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/version/version.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/version/version.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/version"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// NewCollector returns a collector that exports metrics about current version
+// information.
+func NewCollector(program string) prometheus.Collector {
+	return prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: program,
+			Name:      "build_info",
+			Help: fmt.Sprintf(
+				"A metric with a constant '1' value labeled by version, revision, branch, goversion from which %s was built, and the goos and goarch for the build.",
+				program,
+			),
+			ConstLabels: prometheus.Labels{
+				"version":   version.Version,
+				"revision":  version.GetRevision(),
+				"branch":    version.Branch,
+				"goversion": version.GoVersion,
+				"goos":      version.GoOS,
+				"goarch":    version.GoArch,
+				"tags":      version.GetTags(),
+			},
+		},
+		func() float64 { return 1 },
+	)
+}

--- a/vendor/github.com/prometheus/common/version/info.go
+++ b/vendor/github.com/prometheus/common/version/info.go
@@ -1,0 +1,133 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"text/template"
+)
+
+// Build information. Populated at build-time.
+var (
+	Version   string
+	Revision  string
+	Branch    string
+	BuildUser string
+	BuildDate string
+	GoVersion = runtime.Version()
+	GoOS      = runtime.GOOS
+	GoArch    = runtime.GOARCH
+
+	computedRevision string
+	computedTags     string
+)
+
+// versionInfoTmpl contains the template used by Info.
+var versionInfoTmpl = `
+{{.program}}, version {{.version}} (branch: {{.branch}}, revision: {{.revision}})
+  build user:       {{.buildUser}}
+  build date:       {{.buildDate}}
+  go version:       {{.goVersion}}
+  platform:         {{.platform}}
+  tags:             {{.tags}}
+`
+
+// Print returns version information.
+func Print(program string) string {
+	m := map[string]string{
+		"program":   program,
+		"version":   Version,
+		"revision":  GetRevision(),
+		"branch":    Branch,
+		"buildUser": BuildUser,
+		"buildDate": BuildDate,
+		"goVersion": GoVersion,
+		"platform":  GoOS + "/" + GoArch,
+		"tags":      GetTags(),
+	}
+	t := template.Must(template.New("version").Parse(versionInfoTmpl))
+
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "version", m); err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+// Info returns version, branch and revision information.
+func Info() string {
+	return fmt.Sprintf("(version=%s, branch=%s, revision=%s)", Version, Branch, GetRevision())
+}
+
+// BuildContext returns goVersion, platform, buildUser and buildDate information.
+func BuildContext() string {
+	return fmt.Sprintf("(go=%s, platform=%s, user=%s, date=%s, tags=%s)", GoVersion, GoOS+"/"+GoArch, BuildUser, BuildDate, GetTags())
+}
+
+func GetRevision() string {
+	if Revision != "" {
+		return Revision
+	}
+	return computedRevision
+}
+
+func GetTags() string {
+	return computedTags
+}
+
+func PrometheusUserAgent() string {
+	return ComponentUserAgent("Prometheus")
+}
+
+func ComponentUserAgent(component string) string {
+	return component + "/" + Version
+}
+
+func init() {
+	computedRevision, computedTags = computeRevision()
+}
+
+func computeRevision() (string, string) {
+	var (
+		rev      = "unknown"
+		tags     = "unknown"
+		modified bool
+	)
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return rev, tags
+	}
+	for _, v := range buildInfo.Settings {
+		if v.Key == "vcs.revision" {
+			rev = v.Value
+		}
+		if v.Key == "vcs.modified" {
+			if v.Value == "true" {
+				modified = true
+			}
+		}
+		if v.Key == "-tags" {
+			tags = v.Value
+		}
+	}
+	if modified {
+		return rev + "-modified", tags
+	}
+	return rev, tags
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -244,6 +244,7 @@ github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil/header
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
+github.com/prometheus/client_golang/prometheus/collectors/version
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/promhttp/internal
@@ -254,6 +255,7 @@ github.com/prometheus/client_model/go
 ## explicit; go 1.21
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/model
+github.com/prometheus/common/version
 # github.com/prometheus/procfs v0.15.1
 ## explicit; go 1.20
 github.com/prometheus/procfs


### PR DESCRIPTION
We have our own version metric already, but supporting client_golang's build_info means we can be more compatible with other Golang programs we run which export this metric.

We can consider deprecating and removing our own metric in the future, but we have dashboards and alerts using it, so there's no rush to do that.
