### PR TITLE
database: Remove Partitions from our tables

### DIFF
--- a/sa/db-next/boulder_sa/20230419000003_OrderToAuthzID.sql
+++ b/sa/db-next/boulder_sa/20230419000003_OrderToAuthzID.sql
@@ -9,9 +9,7 @@ CREATE TABLE `orderToAuthz2` (
   PRIMARY KEY (`id`),
   KEY `orderID_idx` (`orderID`),
   KEY `authzID_idx` (`authzID`)
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE (`id`)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4;
 
 -- +migrate Down
 -- SQL section 'Down' is executed when this migration is rolled back
@@ -22,6 +20,4 @@ CREATE TABLE `orderToAuthz2` (
   `authzID` bigint(20) NOT NULL,
   PRIMARY KEY (`orderID`,`authzID`),
   KEY `authzID` (`authzID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE COLUMNS(orderID, authzID)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE, MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sa/db-next/boulder_sa/20240503000000_RemoveRequestedNames.sql
+++ b/sa/db-next/boulder_sa/20240503000000_RemoveRequestedNames.sql
@@ -13,6 +13,4 @@ CREATE TABLE `requestedNames` (
   PRIMARY KEY (`id`),
   KEY `orderID_idx` (`orderID`),
   KEY `reversedName_idx` (`reversedName`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sa/db/boulder_sa/20230419000000_CombinedSchema.sql
+++ b/sa/db/boulder_sa/20230419000000_CombinedSchema.sql
@@ -18,9 +18,7 @@ CREATE TABLE `authz2` (
   KEY `regID_expires_idx` (`registrationID`,`status`,`expires`),
   KEY `regID_identifier_status_expires_idx` (`registrationID`,`identifierType`,`identifierValue`,`status`,`expires`),
   KEY `expires_idx` (`expires`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `blockedKeys` (
   `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -53,9 +51,7 @@ CREATE TABLE `certificateStatus` (
   KEY `serial` (`serial`),
   KEY `isExpired_ocspLastUpdated_idx` (`isExpired`,`ocspLastUpdated`),
   KEY `notAfter_idx` (`notAfter`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `certificates` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -69,9 +65,7 @@ CREATE TABLE `certificates` (
   KEY `serial` (`serial`),
   KEY `regId_certificates_idx` (`registrationID`) COMMENT 'Common lookup',
   KEY `issued_idx` (`issued`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `certificatesPerName` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -93,9 +87,7 @@ CREATE TABLE `fqdnSets` (
   PRIMARY KEY (`id`),
   KEY `serial` (`serial`),
   KEY `setHash_issued_idx` (`setHash`,`issued`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `incidents` (
   `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -104,7 +96,7 @@ CREATE TABLE `incidents` (
   `renewBy` datetime NOT NULL,
   `enabled` boolean DEFAULT false,
   PRIMARY KEY (`id`)
-) CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `issuedNames` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -114,9 +106,7 @@ CREATE TABLE `issuedNames` (
   `renewal` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `reversedName_notBefore_Idx` (`reversedName`,`notBefore`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `keyHashToSerial` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -147,18 +137,14 @@ CREATE TABLE `orderFqdnSets` (
   KEY `setHash_expires_idx` (`setHash`,`expires`),
   KEY `orderID_idx` (`orderID`),
   KEY `orderFqdnSets_registrationID_registrations` (`registrationID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `orderToAuthz2` (
   `orderID` bigint(20) NOT NULL,
   `authzID` bigint(20) NOT NULL,
   PRIMARY KEY (`orderID`,`authzID`),
   KEY `authzID` (`authzID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE COLUMNS(orderID, authzID)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE, MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `orders` (
   `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -171,9 +157,7 @@ CREATE TABLE `orders` (
   PRIMARY KEY (`id`),
   KEY `reg_status_expires` (`registrationID`,`expires`),
   KEY `regID_created_idx` (`registrationID`,`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Note: This table's name is a historical artifact and it is now
 -- used to store linting certificates, not precertificates.
@@ -189,9 +173,7 @@ CREATE TABLE `precertificates` (
   KEY `serial` (`serial`),
   KEY `regId_precertificates_idx` (`registrationID`),
   KEY `issued_precertificates_idx` (`issued`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `registrations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -215,9 +197,7 @@ CREATE TABLE `requestedNames` (
   PRIMARY KEY (`id`),
   KEY `orderID_idx` (`orderID`),
   KEY `reversedName_idx` (`reversedName`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Tables below have foreign key constraints, so are created after all other tables.
 
@@ -245,6 +225,7 @@ DROP TABLE `certificateStatus`;
 DROP TABLE `certificatesPerName`;
 DROP TABLE `certificates`;
 DROP TABLE `fqdnSets`;
+DROP TABLE `incidents`;
 DROP TABLE `issuedNames`;
 DROP TABLE `keyHashToSerial`;
 DROP TABLE `newOrdersRL`;

--- a/sa/db/boulder_sa/20230519000000_CrlShards.sql
+++ b/sa/db/boulder_sa/20230519000000_CrlShards.sql
@@ -5,8 +5,8 @@ CREATE TABLE `crlShards` (
   `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
   `issuerID` bigint(20) NOT NULL,
   `idx` int UNSIGNED NOT NULL,
-  `thisUpdate` datetime,
-  `nextUpdate` datetime,
+  `thisUpdate` datetime DEFAULT NULL,
+  `nextUpdate` datetime DEFAULT NULL,
   `leasedUntil` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `shardID` (`issuerID`, `idx`)

--- a/sa/db/boulder_sa/20230919000000_RevokedCertificates.sql
+++ b/sa/db/boulder_sa/20230919000000_RevokedCertificates.sql
@@ -11,9 +11,7 @@ CREATE TABLE `revokedCertificates` (
   `revokedReason` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `issuerID_shardIdx_notAfterHour_idx` (`issuerID`, `shardIdx`, `notAfterHour`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- +migrate Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/sa/db/boulder_sa/20240119000000_ReplacementOrders.sql
+++ b/sa/db/boulder_sa/20240119000000_ReplacementOrders.sql
@@ -10,9 +10,7 @@ CREATE TABLE `replacementOrders` (
   PRIMARY KEY (`id`),
   KEY `serial_idx` (`serial`),
   KEY `orderID_idx` (`orderID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
- PARTITION BY RANGE(id)
-(PARTITION p_start VALUES LESS THAN (MAXVALUE));
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- +migrate Down
 -- SQL section 'Down' is executed when this migration is rolled back


### PR DESCRIPTION
Ahead of the move from ProxySQL + MariaDB to Vitess + MySQL 8 in #8468. Vitess blocks partition related DDL, so partitions need to be removed from all schemas under `sa/db*`. The team has agreed that this drift from Production is acceptable because it lets us begin testing on Vitess and MySQL sooner.

Separately, `thisUpdate` and `nextUpdate` were relying on an implicit `DEFAULT NULL`. We now make that explicit, matching how we define other DATETIME columns. Also, add a missing `DROP TABLE `incidents`;` to our combined schema migration.

Part of https://github.com/letsencrypt/boulder/issues/7736