### PR TITLE
Make CAA checking more like DCV checking

### DIFF
--- a/grpc/pb-marshalling.go
+++ b/grpc/pb-marshalling.go
@@ -227,6 +227,18 @@ func pbToValidationResult(in *vapb.ValidationResult) ([]core.ValidationRecord, *
 	return recordAry, prob, nil
 }
 
+func CAAResultToPB(prob *probs.ProblemDetails, perspective, rir string) (*vapb.IsCAAValidResponse, error) {
+	marshalledProb, err := ProblemDetailsToPB(prob)
+	if err != nil {
+		return nil, err
+	}
+	return &vapb.IsCAAValidResponse{
+		Problem:     marshalledProb,
+		Perspective: perspective,
+		Rir:         rir,
+	}, nil
+}
+
 func RegistrationToPB(reg core.Registration) (*corepb.Registration, error) {
 	keyBytes, err := reg.Key.MarshalJSON()
 	if err != nil {

--- a/va/va.go
+++ b/va/va.go
@@ -700,6 +700,7 @@ func (va *ValidationAuthorityImpl) DoDCV(ctx context.Context, req *vapb.PerformV
 			logEvent.Challenge.Status = core.StatusValid
 			outcome = pass
 		}
+
 		// Observe local validation latency (primary|remote).
 		va.observeLatency(opDCV, va.perspective, string(chall.Type), probType, outcome, localLatency)
 		if va.isPrimaryVA() {
@@ -762,5 +763,6 @@ func (va *ValidationAuthorityImpl) DoDCV(ctx context.Context, req *vapb.PerformV
 		}
 		summary, prob = va.doRemoteOperation(ctx, op, req)
 	}
+
 	return bgrpc.ValidationResultToPB(records, filterProblemDetails(prob), va.perspective, va.rir)
 }


### PR DESCRIPTION
If the primary perspective CAA check returns an error, return early rather than always kicking off the remote checks anyway.

As part of this change, rearrange the code in DoCAA to more closely mirror the code in DoDCV. In particular, move the creation of the result protobuf into a helper function which can be called at both the early-return and late-return locations.