### PR TITLE
Update CI to go1.25.5

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Add additional docker image tags here and all tests will be run with the additional image.
         BOULDER_TOOLS_TAG:
-          - go1.25.2_2025-10-07
+          - go1.25.5_2025-12-03
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -122,7 +122,7 @@ jobs:
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
       fail-fast: false
       matrix:
-        go-version: [ '1.25.2' ]
+        go-version: [ '1.25.5' ]
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.25.2"
-          - "1.25.3"
+          - "1.25.5"
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -20,8 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.25.2"
-          - "1.25.3"
+          - "1.25.5"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: test/boulder-tools/
       # Should match one of the GO_CI_VERSIONS in test/boulder-tools/tag_and_upload.sh.
       args:
-        GO_VERSION: 1.25.2
+        GO_VERSION: 1.25.5
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening. This is

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.25.2" )
+GO_CI_VERSIONS=( "1.25.5" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
This picks up fixes to the crypto/x509 standard library package, as described here: https://go.dev/doc/devel/release#go1.25.5

These security fixes do not affect our usage of the crypto/x509 package, but govulncheck isn't aware of that, so let's update anyway.