### PR TITLE
Add current datetime column to orderFqdnSets and authz2 tables

### DIFF
--- a/sa/db-next/boulder_sa/20251203000000_CreatedDatetimes.sql
+++ b/sa/db-next/boulder_sa/20251203000000_CreatedDatetimes.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE `authz2` ADD COLUMN `created` datetime DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `orderFqdnSets` ADD COLUMN `created` datetime DEFAULT CURRENT_TIMESTAMP;
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE `authz2` DROP COLUMN `created`;
+ALTER TABLE `orderFqdnSets` DROP COLUMN `created`;


### PR DESCRIPTION
The new "created" column is always populated by the current time, indicating when the row was created. We do this directly inside the database, rather than in the Go data model, because Boulder doesn't actually care when these rows were created. Instead, we care about the creation timestamp for the purpose of creating and dropping partitions to manage our total data size.

Previously we've been partitioning these tables based on their `expires` column. But that column is no longer a good proxy for when the row was created, because not all certificates/orders/authzs have the same lifetime anymore.

Example after an integration test run:
```mysql
MariaDB [boulder_sa_integration]> select id,created,expires from orderFqdnSets limit 5;
+----+---------------------+---------------------+
| id | created             | expires             |
+----+---------------------+---------------------+
|  1 | 2025-12-04 00:49:10 | 2025-12-11 00:49:10 |
|  3 | 2025-12-04 00:49:12 | 2025-12-11 00:49:12 |
|  6 | 2025-12-04 00:49:17 | 2025-12-11 00:49:17 |
|  9 | 2025-12-04 00:49:23 | 2025-12-11 00:49:23 |
| 10 | 2025-12-04 00:49:24 | 2025-12-11 00:49:24 |
+----+---------------------+---------------------+
5 rows in set (0.000 sec)
```

IN-12028 tracks the corresponding SRE-side changes