### PR TITLE
Remove ECDSA P-224 curve support from the ceremony tool

### DIFF
--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -40,7 +40,7 @@ This tool always generates key pairs such that the public and private key are bo
     | Field | Description |
     | --- | --- |
     | `type` | Specifies the type of key to be generated, either `rsa` or `ecdsa`. If `rsa` the generated key will have an exponent of 65537 and a modulus length specified by `rsa-mod-length`. If `ecdsa` the curve is specified by `ecdsa-curve`. |
-    | `ecdsa-curve` | Specifies the ECDSA curve to use when generating key, either `P-224`, `P-256`, `P-384`, or `P-521`. |
+    | `ecdsa-curve` | Specifies the ECDSA curve to use when generating key, either `P-256`, `P-384`, or `P-521`. |
     | `rsa-mod-length` | Specifies the length of the RSA modulus, either `2048` or `4096`. |
 
 - `outputs`: object containing paths to write outputs.
@@ -267,7 +267,7 @@ This config generates a CSR signed by a key in the HSM, identified by the object
     | Field | Description |
     | --- | --- |
     | `type` | Specifies the type of key to be generated, either `rsa` or `ecdsa`. If `rsa` the generated key will have an exponent of 65537 and a modulus length specified by `rsa-mod-length`. If `ecdsa` the curve is specified by `ecdsa-curve`. |
-    | `ecdsa-curve` | Specifies the ECDSA curve to use when generating key, either `P-224`, `P-256`, `P-384`, or `P-521`. |
+    | `ecdsa-curve` | Specifies the ECDSA curve to use when generating key, either `P-256`, `P-384`, or `P-521`. |
     | `rsa-mod-length` | Specifies the length of the RSA modulus, either `2048` or `4096`. |
 
 - `outputs`: object containing paths to write outputs.

--- a/cmd/ceremony/ecdsa.go
+++ b/cmd/ceremony/ecdsa.go
@@ -13,7 +13,6 @@ import (
 )
 
 var stringToCurve = map[string]elliptic.Curve{
-	elliptic.P224().Params().Name: elliptic.P224(),
 	elliptic.P256().Params().Name: elliptic.P256(),
 	elliptic.P384().Params().Name: elliptic.P384(),
 	elliptic.P521().Params().Name: elliptic.P521(),
@@ -21,7 +20,6 @@ var stringToCurve = map[string]elliptic.Curve{
 
 // curveToOIDDER maps the name of the curves to their DER encoded OIDs
 var curveToOIDDER = map[string][]byte{
-	elliptic.P224().Params().Name: {6, 5, 43, 129, 4, 0, 33},
 	elliptic.P256().Params().Name: {6, 8, 42, 134, 72, 206, 61, 3, 1, 7},
 	elliptic.P384().Params().Name: {6, 5, 43, 129, 4, 0, 34},
 	elliptic.P521().Params().Name: {6, 5, 43, 129, 4, 0, 35},

--- a/cmd/ceremony/main.go
+++ b/cmd/ceremony/main.go
@@ -101,7 +101,6 @@ type keyGenConfig struct {
 }
 
 var allowedCurves = map[string]bool{
-	"P-224": true,
 	"P-256": true,
 	"P-384": true,
 	"P-521": true,
@@ -121,7 +120,7 @@ func (kgc keyGenConfig) validate() error {
 		return errors.New("if key.type = 'rsa' then key.ecdsa-curve is not used")
 	}
 	if kgc.Type == "ecdsa" && !allowedCurves[kgc.ECDSACurve] {
-		return errors.New("key.ecdsa-curve can only be 'P-224', 'P-256', 'P-384', or 'P-521'")
+		return errors.New("key.ecdsa-curve can only be 'P-256', 'P-384', or 'P-521'")
 	}
 	if kgc.Type == "ecdsa" && kgc.RSAModLength != 0 {
 		return errors.New("if key.type = 'ecdsa' then key.rsa-mod-length is not used")

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -117,7 +117,7 @@ func TestKeyGenConfigValidate(t *testing.T) {
 				Type:       "ecdsa",
 				ECDSACurve: "bad",
 			},
-			expectedError: "key.ecdsa-curve can only be 'P-224', 'P-256', 'P-384', or 'P-521'",
+			expectedError: "key.ecdsa-curve can only be 'P-256', 'P-384', or 'P-521'",
 		},
 		{
 			name: "key.type is ecdsa but key.rsa-mod-length is present",


### PR DESCRIPTION
[BR 7.1.3.2.2](https://github.com/cabforum/servercert/blob/main/docs/BR.md#71322-ecdsa) states that only ECDSA curves P-256, P-384, and P-512 are allowed. This should prevent a silly footgun.