### PR TITLE
va: Avoid creating multiple slow remote timers in doRemoteOperation

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -571,6 +571,7 @@ func (va *ValidationAuthorityImpl) doRemoteOperation(ctx context.Context, op rem
 	var failed []string
 	var passedRIRs = map[string]struct{}{}
 	var firstProb *probs.ProblemDetails
+	var slowTimerSet bool
 
 	for resp := range responses {
 		var currProb *probs.ProblemDetails
@@ -606,13 +607,14 @@ func (va *ValidationAuthorityImpl) doRemoteOperation(ctx context.Context, op rem
 			firstProb = currProb
 		}
 
-		if va.slowRemoteTimeout != 0 {
+		if va.slowRemoteTimeout != 0 && !slowTimerSet {
 			// If enough perspectives have passed, or enough perspectives have
 			// failed, set a tighter deadline for the remaining perspectives.
 			if (len(passed) >= required && len(passedRIRs) >= requiredRIRs) ||
 				(len(failed) > remoteVACount-required) {
 				timer := time.AfterFunc(va.slowRemoteTimeout, cancel)
 				defer timer.Stop()
+				slowTimerSet = true
 			}
 		}
 


### PR DESCRIPTION
The code that sets a tighter deadline for slow remote VAs was inside a loop, causing a new timer (and goroutine) to be created on every iteration after quorum was reached. While not incorrect (only the first timer's cancel matters), this was wasteful.

Add a slowTimerSet flag to ensure only one timer is created.

Benchmark results show the fix is ~6.7x faster with ~7x less memory:

```
  BenchmarkSlowRemoteTimerMultiple  1907 ns/op  1464 B/op  17 allocs/op
  BenchmarkSlowRemoteTimerSingle     284 ns/op   208 B/op   3 allocs/op
```

(I didn't add these benchmarks in the PR because I just wanted to validate it's a big enough improvement)