### PR TITLE
Remove usage of subtle.ConstantTimeCompare in validation

### DIFF
--- a/va/dns.go
+++ b/va/dns.go
@@ -3,7 +3,6 @@ package va
 import (
 	"context"
 	"crypto/sha256"
-	"crypto/subtle"
 	"encoding/base32"
 	"encoding/base64"
 	"errors"
@@ -122,7 +121,7 @@ func (va *ValidationAuthorityImpl) validateDNS(ctx context.Context, ident identi
 	}
 
 	for _, element := range txts {
-		if subtle.ConstantTimeCompare([]byte(element), []byte(authorizedKeysDigest)) == 1 {
+		if element == authorizedKeysDigest {
 			// Successful challenge validation
 			return []core.ValidationRecord{{Hostname: ident.Value, ResolverAddrs: resolvers}}, nil
 		}

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -367,7 +366,7 @@ func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, ident 
 				return validationRecords, badCertErr(
 					"Received certificate with malformed acmeValidationV1 extension value.")
 			}
-			if subtle.ConstantTimeCompare(h[:], extValue) != 1 {
+			if !bytes.Equal(h[:], extValue) {
 				return validationRecords, badCertErr(fmt.Sprintf(
 					"Received certificate with acmeValidationV1 extension value %s but expected %s.",
 					hex.EncodeToString(extValue),


### PR DESCRIPTION
While constant-time comparison is important in cryptographic algorithms, that's not what we're doing here. The validation random token is not intended to be secret in the same way as (say) a private key is: it's just meant to be random enough that it's unlikely to exist in DNS or on a webserver by chance. Possession of the random token does not give an attacker any advantages; they still need to control the domain itself, at which point they could get a random token of their own. Using subtle.ConstantTimeCompare is overkill and sets a bad example for places that truly do need to use it.