### PR TITLE
CA: Log error instead of cert upon storage failure

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -450,7 +450,7 @@ func (ca *certificateAuthorityImpl) IssueCertificate(ctx context.Context, req *c
 		Issued: timestamppb.New(ca.clk.Now()),
 	})
 	if err != nil {
-		ca.log.AuditErrf("Failed RPC to store at SA: serial=[%s] cert=[%v] err=[%v]", serialHex, hex.EncodeToString(certDER), err)
+		ca.log.AuditErrf("Failed RPC to store at SA: serial=[%s] err=[%v]", serialHex, err)
 		return nil, fmt.Errorf("persisting cert to database: %w", err)
 	}
 


### PR DESCRIPTION
This seems to be a simple copy-paste error. The cert has already been audit-logged by the time we reach this point, so just log the error.