### PR TITLE
nonce: Add space after value in nonce used error message

### DIFF
--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -290,7 +290,7 @@ func (ns *NonceService) valid(nonce string) error {
 	if ns.used[c] {
 		ns.nonceRedeems.WithLabelValues("invalid", "already used").Inc()
 		ns.nonceAges.WithLabelValues("invalid").Observe(age)
-		return berrors.BadNonceError("nonce already marked as used: %d in [%d]used", c, len(ns.used))
+		return berrors.BadNonceError("nonce already marked as used: %d in [%d] used", c, len(ns.used))
 	}
 
 	ns.used[c] = true


### PR DESCRIPTION
Changes 
```
nonce already marked as used: 380081064 in [2000000]used
``` 
to 
```
nonce already marked as used: 380081064 in [2000000] used
```