### PR TITLE
grpc: log health check failures

### DIFF
--- a/grpc/server.go
+++ b/grpc/server.go
@@ -252,7 +252,7 @@ func (sb *serverBuilder) initLongRunningCheck(shutdownCtx context.Context, servi
 		var next healthpb.HealthCheckResponse_ServingStatus
 		err := checkImpl(checkImplCtx)
 		if err != nil {
-			sb.logger.Infof("health check of %q failed: %s", service, err)
+			sb.logger.Infof("health check of gRPC service %q failed: %s", service, err)
 			next = healthpb.HealthCheckResponse_NOT_SERVING
 		} else {
 			next = healthpb.HealthCheckResponse_SERVING


### PR DESCRIPTION
This makes errors during integration tests easier to debug, and will almost certainly be useful in debugging prod / staging issues in the future.

This came up working on #8545: there was a permissions problem that manifested as the SA failing its health check, but the actual error was not logged anywhere.