### PR TITLE
ct-test-srv: remove logging at startup

### DIFF
--- a/test/ct-test-srv/main.go
+++ b/test/ct-test-srv/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"crypto/ecdsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -211,10 +210,6 @@ func runPersonality(p Personality) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
-	if err != nil {
-		log.Fatal(err)
-	}
 	is := integrationSrv{
 		key:           key,
 		flakinessRate: p.FlakinessRate,
@@ -232,9 +227,6 @@ func runPersonality(p Personality) {
 		Addr:    p.Addr,
 		Handler: m,
 	}
-	logID := sha256.Sum256(pubKeyBytes)
-	log.Printf("ct-test-srv on %s with pubkey: %s, log ID: %s, flakiness: %d%%", p.Addr,
-		base64.StdEncoding.EncodeToString(pubKeyBytes), base64.StdEncoding.EncodeToString(logID[:]), p.FlakinessRate)
 	log.Fatal(srv.ListenAndServe())
 }
 


### PR DESCRIPTION
A small effort to slightly denoise our integration test startup.