### PR TITLE
Remove direct db connection from admin tool

### DIFF
--- a/cmd/admin/admin.go
+++ b/cmd/admin/admin.go
@@ -8,12 +8,10 @@ import (
 	"github.com/jmhodges/clock"
 
 	"github.com/letsencrypt/boulder/cmd"
-	"github.com/letsencrypt/boulder/db"
 	"github.com/letsencrypt/boulder/features"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	blog "github.com/letsencrypt/boulder/log"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
-	"github.com/letsencrypt/boulder/sa"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
 
@@ -23,13 +21,6 @@ type admin struct {
 	rac   rapb.RegistrationAuthorityClient
 	sac   sapb.StorageAuthorityClient
 	saroc sapb.StorageAuthorityReadOnlyClient
-	// TODO: Remove this and only use sac and saroc to interact with the db.
-	// We cannot have true dry-run safety as long as we have a direct dbMap.
-	dbMap *db.WrappedMap
-
-	// TODO: Remove this when the dbMap is removed and the dryRunSAC and dryRunRAC
-	// handle all dry-run safety.
-	dryRun bool
 
 	clk clock.Clock
 	log blog.Logger
@@ -80,19 +71,12 @@ func newAdmin(configFile string, dryRun bool) (*admin, error) {
 		sac = sapb.NewStorageAuthorityClient(saConn)
 	}
 
-	dbMap, err := sa.InitWrappedDb(c.Admin.DB, nil, logger)
-	if err != nil {
-		return nil, fmt.Errorf("creating database connection: %w", err)
-	}
-
 	return &admin{
-		rac:    rac,
-		sac:    sac,
-		saroc:  saroc,
-		dbMap:  dbMap,
-		dryRun: dryRun,
-		clk:    clk,
-		log:    logger,
+		rac:   rac,
+		sac:   sac,
+		saroc: saroc,
+		clk:   clk,
+		log:   logger,
 	}, nil
 }
 

--- a/cmd/admin/cert_test.go
+++ b/cmd/admin/cert_test.go
@@ -219,7 +219,6 @@ func TestRevokeSerials(t *testing.T) {
 	// Revoking should result in 3 gRPC requests and quiet execution.
 	mra.reset()
 	log.Clear()
-	a.dryRun = false
 	err := a.revokeSerials(context.Background(), serials, 0, false, 1)
 	test.AssertEquals(t, len(log.GetAllMatching("invalid serial format")), 0)
 	test.AssertNotError(t, err, "")
@@ -260,7 +259,6 @@ func TestRevokeSerials(t *testing.T) {
 	// Revoking in dry-run mode should result in no gRPC requests and three logs.
 	mra.reset()
 	log.Clear()
-	a.dryRun = true
 	a.rac = dryRunRAC{log: log}
 	err = a.revokeSerials(context.Background(), serials, 0, false, 1)
 	test.AssertNotError(t, err, "")
@@ -274,9 +272,8 @@ func TestRevokeMalformed(t *testing.T) {
 	mra := mockRARecordingRevocations{}
 	log := blog.NewMock()
 	a := &admin{
-		rac:    &mra,
-		log:    log,
-		dryRun: false,
+		rac: &mra,
+		log: log,
 	}
 
 	s := subcommandRevokeCert{

--- a/cmd/admin/key_test.go
+++ b/cmd/admin/key_test.go
@@ -162,7 +162,6 @@ func TestBlockSPKIHash(t *testing.T) {
 	// A full run should result in one request with the right fields.
 	msa.reset()
 	log.Clear()
-	a.dryRun = false
 	err = a.blockSPKIHash(context.Background(), keyHash[:], u, "hello world")
 	test.AssertNotError(t, err, "")
 	test.AssertEquals(t, len(log.GetAllMatching("Found 0 unexpired certificates")), 1)
@@ -173,7 +172,6 @@ func TestBlockSPKIHash(t *testing.T) {
 	// A dry-run should result in zero requests and two log lines.
 	msa.reset()
 	log.Clear()
-	a.dryRun = true
 	a.sac = dryRunSAC{log: log}
 	err = a.blockSPKIHash(context.Background(), keyHash[:], u, "")
 	test.AssertNotError(t, err, "")

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -23,7 +23,7 @@ import (
 
 type Config struct {
 	Admin struct {
-		// DB controls the admin tool's direct connection to the database.
+		// TODO(#7350): Remove this once removed from production configs.
 		DB cmd.DBConfig
 		// TLS controls the TLS client the admin tool uses for gRPC connections.
 		TLS cmd.TLSConfig
@@ -132,7 +132,7 @@ func main() {
 	cmd.FailOnError(err, "creating admin object")
 
 	// Finally, run the selected subcommand.
-	if a.dryRun {
+	if *dryRun {
 		a.log.AuditInfof("admin tool executing a dry-run with the following arguments: %q", strings.Join(os.Args, " "))
 	} else {
 		a.log.AuditInfof("admin tool executing with the following arguments: %q", strings.Join(os.Args, " "))
@@ -141,7 +141,7 @@ func main() {
 	err = subcommand.Run(context.Background(), a)
 	cmd.FailOnError(err, "executing subcommand")
 
-	if a.dryRun {
+	if *dryRun {
 		a.log.AuditInfof("admin tool has successfully completed executing a dry-run with the following arguments: %q", strings.Join(os.Args, " "))
 		a.log.Info("Dry run complete. Pass -dry-run=false to mutate the database.")
 	} else {

--- a/test/config-next/admin.json
+++ b/test/config-next/admin.json
@@ -1,9 +1,5 @@
 {
 	"admin": {
-		"db": {
-			"dbConnectFile": "test/secrets/revoker_dburl",
-			"maxOpenConns": 1
-		},
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/admin.boulder/cert.pem",


### PR DESCRIPTION
Turns out we'd removed the last subcommands that relied on this dbconn when we removed all code for handling contact email addresses. This removes the last vestiges of the dbconn scaffolding, so that SRE can stop configuring it.

Part of https://github.com/letsencrypt/boulder/issues/7350
IN-12126 tracks the corresponding prod config changes