### PR TITLE
log: use `Requester` in revocation logs

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -450,10 +450,10 @@ type certificateRevocationEvent struct {
 	// Method is the way in which revocation was requested.
 	// It will be one of the strings: "applicant", "subscriber", "control", "key", or "admin".
 	Method string `json:",omitempty"`
-	// RequesterID is the account ID of the requester.
+	// Requester is the account ID of the requester.
 	// Will be zero for admin revocations.
-	RequesterID int64 `json:",omitempty"`
-	CRLShard    int64
+	Requester int64 `json:",omitempty"`
+	CRLShard  int64
 	// AdminName is the name of the admin requester.
 	// Will be zero for subscriber revocations.
 	AdminName string `json:",omitempty"`
@@ -1718,8 +1718,8 @@ func (ra *RegistrationAuthorityImpl) updateRevocationForKeyCompromise(ctx contex
 // RevokeCertByApplicant revokes the certificate in question. It allows any
 // revocation reason from (0, 1, 3, 4, 5, 9), because Subscribers are allowed to
 // request any revocation reason for their own certificates. However, if the
-// requesting RegID is an account which has authorizations for all names in the
-// cert but is *not* the original subscriber, it overrides the revocation reason
+// requesting account has authorizations for all names in the cert but
+// is *not* the original subscriber, it overrides the revocation reason
 // to be 5 (cessationOfOperation), because that code is used to cover instances
 // where "the certificate subscriber no longer owns the domain names in the
 // certificate". It does not add the key to the blocked keys list, even if
@@ -1747,7 +1747,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByApplicant(ctx context.Context, 
 		SerialNumber: serialString,
 		Reason:       reasonCode,
 		Method:       "applicant",
-		RequesterID:  req.RegID,
+		Requester:    req.RegID,
 	}
 
 	// Below this point, do not re-declare `err` (i.e. type `err :=`) in a
@@ -1891,7 +1891,7 @@ func (ra *RegistrationAuthorityImpl) RevokeCertByKey(ctx context.Context, req *r
 		SerialNumber: core.SerialToString(cert.SerialNumber),
 		Reason:       revocation.KeyCompromise,
 		Method:       "key",
-		RequesterID:  0,
+		Requester:    0,
 	}
 
 	// Below this point, do not re-declare `err` (i.e. type `err :=`) in a

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -977,10 +977,10 @@ func (wfe *WebFrontEndImpl) parseRevocation(
 }
 
 type revocationEvidence struct {
-	Serial string
-	Reason revocation.Reason
-	RegID  int64
-	Method string
+	Serial    string
+	Reason    revocation.Reason
+	Requester int64
+	Method    string
 }
 
 // revokeCertBySubscriberKey processes an outer JWS as a revocation request that
@@ -1003,10 +1003,10 @@ func (wfe *WebFrontEndImpl) revokeCertBySubscriberKey(
 	}
 
 	wfe.log.AuditObject("Authenticated revocation", revocationEvidence{
-		Serial: core.SerialToString(cert.SerialNumber),
-		Reason: reason,
-		RegID:  acct.ID,
-		Method: "applicant",
+		Serial:    core.SerialToString(cert.SerialNumber),
+		Reason:    reason,
+		Requester: acct.ID,
+		Method:    "applicant",
 	})
 
 	// The RA will confirm that the authenticated account either originally
@@ -1056,10 +1056,10 @@ func (wfe *WebFrontEndImpl) revokeCertByCertKey(
 	}
 
 	wfe.log.AuditObject("Authenticated revocation", revocationEvidence{
-		Serial: core.SerialToString(cert.SerialNumber),
-		Reason: reason,
-		RegID:  0,
-		Method: "privkey",
+		Serial:    core.SerialToString(cert.SerialNumber),
+		Reason:    reason,
+		Requester: 0,
+		Method:    "privkey",
 	})
 
 	// The RA assumes here that the WFE2 has validated the JWS as proving

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -3361,7 +3361,7 @@ func TestRevokeCertificateByApplicantValid(t *testing.T) {
 	test.AssertEquals(t, responseWriter.Code, 200)
 	test.AssertEquals(t, responseWriter.Body.String(), "")
 	test.AssertDeepEquals(t, mockLog.GetAllMatching("Authenticated revocation"), []string{
-		`INFO: [AUDIT] Authenticated revocation JSON={"Serial":"000000000000000000001d72443db5189821","Reason":0,"RegID":1,"Method":"applicant"}`,
+		`INFO: [AUDIT] Authenticated revocation JSON={"Serial":"000000000000000000001d72443db5189821","Reason":0,"Requester":1,"Method":"applicant"}`,
 	})
 }
 
@@ -3390,7 +3390,7 @@ func TestRevokeCertificateByKeyValid(t *testing.T) {
 	test.AssertEquals(t, responseWriter.Code, 200)
 	test.AssertEquals(t, responseWriter.Body.String(), "")
 	test.AssertDeepEquals(t, mockLog.GetAllMatching("Authenticated revocation"), []string{
-		`INFO: [AUDIT] Authenticated revocation JSON={"Serial":"000000000000000000001d72443db5189821","Reason":1,"RegID":0,"Method":"privkey"}`,
+		`INFO: [AUDIT] Authenticated revocation JSON={"Serial":"000000000000000000001d72443db5189821","Reason":1,"Requester":0,"Method":"privkey"}`,
 	})
 }
 
@@ -3638,7 +3638,7 @@ func TestPrepAuthzForDisplay(t *testing.T) {
 	authzJSON, err := json.Marshal(authz)
 	test.AssertNotError(t, err, "Failed to marshal authz")
 	test.AssertNotContains(t, string(authzJSON), "\"id\":\"12345\"")
-	test.AssertNotContains(t, string(authzJSON), "\"registrationID\":\"1\"")
+	test.AssertNotContains(t, string(authzJSON), "\"requester\":\"1\"")
 }
 
 func TestPrepRevokedAuthzForDisplay(t *testing.T) {


### PR DESCRIPTION
Part of #8559.

I didn't touch the `checkCAA` ""Checked CAA records for %s" log line yet because I know @aarongable is working on a PR to update that log line and didn't want to generate unnecessary conflicts.