### PR TITLE
publisher: Errf -> InfoObject

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -243,13 +243,7 @@ func (pub *Impl) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Requ
 	issuerBundle, ok := pub.issuerBundles[id]
 	if !ok {
 		err := fmt.Errorf("No issuerBundle matching issuerNameID: %d", int64(id))
-		pub.log.InfoObject("No configured issuer matches cert", struct {
-			IssuerNameID int64
-			Issuer       string
-		}{
-			IssuerNameID: int64(id),
-			Issuer:       cert.Issuer.CommonName,
-		})
+		pub.log.Errf("Failed to submit certificate to CT log: %s", err)
 		return nil, err
 	}
 	chain = append(chain, issuerBundle...)


### PR DESCRIPTION
Err logs wind up in audit log, Info doesn't. At the same time, move the relevant lines to InfoObject.

Also, take the existing info-level logs about error backoffs and move them to no-ops.

Fixes #8431