### PR TITLE
test: bump consul to 1.19.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
         ipv4_address: 10.77.77.5
 
   bconsul:
-    image: hashicorp/consul:1.19.1
+    image: hashicorp/consul:1.19.2
     volumes:
      - ./test/:/test/:cached
     networks:


### PR DESCRIPTION
This fixes a slightly annoying log line that repeats as long as consul is running:

     error serializing DNS results: error="no data"

This is triggered by Boulder's DNS resolution code querying for

     AAAA consul.service.consul

Which doesn't exist. In 1.19.2 and above this log message is not generated.