### PR TITLE
Clean up usage of non-formatter log methods

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -251,7 +251,6 @@ func (ca *certificateAuthorityImpl) IssueCertificate(ctx context.Context, req *c
 
 	if issuer.Cert.NotAfter.Before(notAfter) {
 		err = berrors.InternalServerError("cannot issue a certificate that expires after the issuer certificate")
-		ca.log.AuditErr(err.Error())
 		return nil, err
 	}
 

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -219,17 +219,16 @@ func (bkr *badKeyRevoker) invoke(ctx context.Context) (bool, error) {
 		}
 		return false, err
 	}
-	bkr.logger.AuditInfo(fmt.Sprintf("found unchecked block key to work on: %s", unchecked))
+	bkr.logger.AuditInfof("found unchecked block key to work on: %s", unchecked)
 
 	// select all unrevoked, unexpired serials associated with the blocked key hash
 	unrevokedCerts, err := bkr.findUnrevoked(ctx, unchecked)
 	if err != nil {
-		bkr.logger.AuditInfo(fmt.Sprintf("finding unrevoked certificates related to %s: %s",
-			unchecked, err))
+		bkr.logger.AuditInfof("finding unrevoked certificates related to %s: %s", unchecked, err)
 		return false, err
 	}
 	if len(unrevokedCerts) == 0 {
-		bkr.logger.AuditInfo(fmt.Sprintf("found no certificates that need revoking related to %s, marking row as checked", unchecked))
+		bkr.logger.AuditInfof("found no certificates that need revoking related to %s, marking row as checked", unchecked)
 		// mark row as checked
 		err = bkr.markRowChecked(ctx, unchecked)
 		if err != nil {
@@ -242,7 +241,7 @@ func (bkr *badKeyRevoker) invoke(ctx context.Context) (bool, error) {
 	for _, cert := range unrevokedCerts {
 		serials = append(serials, cert.Serial)
 	}
-	bkr.logger.AuditInfo(fmt.Sprintf("revoking serials %v for key with hash %x", serials, unchecked.KeyHash))
+	bkr.logger.AuditInfof("revoking serials %v for key with hash %x", serials, unchecked.KeyHash)
 
 	// revoke each certificate
 	err = bkr.revokeCerts(unrevokedCerts)

--- a/cmd/boulder-publisher/main.go
+++ b/cmd/boulder-publisher/main.go
@@ -70,8 +70,7 @@ func main() {
 	cmd.LogStartup(logger)
 
 	if c.Publisher.Chains == nil {
-		logger.AuditErr("No chain files provided")
-		os.Exit(1)
+		cmd.Fail("No chain files provided")
 	}
 
 	bundles := make(map[issuance.NameID][]ct.ASN1Cert)

--- a/cmd/nonce-service/main.go
+++ b/cmd/nonce-service/main.go
@@ -97,7 +97,7 @@ func main() {
 		&noncepb.NonceService_ServiceDesc, ns).Build(tlsConfig, scope, clock.New())
 	cmd.FailOnError(err, "Unable to setup nonce service gRPC server")
 
-	logger.Info(fmt.Sprintf("Nonce server listening on %s with prefix %q", c.NonceService.GRPC.Address, noncePrefix))
+	logger.Infof("Nonce server listening on %s with prefix %q", c.NonceService.GRPC.Address, noncePrefix)
 
 	cmd.FailOnError(start(), "Nonce service gRPC server failed")
 }

--- a/va/http.go
+++ b/va/http.go
@@ -671,7 +671,7 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 
 func (va *ValidationAuthorityImpl) validateHTTP01(ctx context.Context, ident identifier.ACMEIdentifier, token string, keyAuthorization string) ([]core.ValidationRecord, error) {
 	if ident.Type != identifier.TypeDNS && ident.Type != identifier.TypeIP {
-		va.log.Info(fmt.Sprintf("Identifier type for HTTP-01 challenge was not DNS or IP: %s", ident))
+		va.log.Infof("Identifier type for HTTP-01 challenge was not DNS or IP: %s", ident)
 		return nil, berrors.MalformedError("Identifier type for HTTP-01 challenge was not DNS or IP")
 	}
 

--- a/va/tlsalpn.go
+++ b/va/tlsalpn.go
@@ -161,7 +161,7 @@ func (va *ValidationAuthorityImpl) getChallengeCert(
 		return nil, nil, fmt.Errorf("unknown identifier type: %s", ident.Type)
 	}
 
-	va.log.Info(fmt.Sprintf("%s [%s] Attempting to validate for %s %s", core.ChallengeTypeTLSALPN01, ident, hostPort, serverName))
+	va.log.Infof("%s [%s] Attempting to validate for %s %s", core.ChallengeTypeTLSALPN01, ident, hostPort, serverName)
 
 	dialCtx, cancel := context.WithTimeout(ctx, va.singleDialTimeout)
 	defer cancel()
@@ -295,7 +295,7 @@ func checkAcceptableExtensions(exts []pkix.Extension, requiredOIDs []asn1.Object
 
 func (va *ValidationAuthorityImpl) validateTLSALPN01(ctx context.Context, ident identifier.ACMEIdentifier, keyAuthorization string) ([]core.ValidationRecord, error) {
 	if ident.Type != identifier.TypeDNS && ident.Type != identifier.TypeIP {
-		va.log.Info(fmt.Sprintf("Identifier type for TLS-ALPN-01 challenge was not DNS or IP: %s", ident))
+		va.log.Infof("Identifier type for TLS-ALPN-01 challenge was not DNS or IP: %s", ident)
 		return nil, berrors.MalformedError("Identifier type for TLS-ALPN-01 challenge was not DNS or IP")
 	}
 

--- a/web/server.go
+++ b/web/server.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -22,7 +21,7 @@ func (ew errorWriter) Write(p []byte) (n int, err error) {
 	// logged from inside net/http.Server we strip the newline before
 	// we get to the checksum generator.
 	p = bytes.TrimRight(p, "\n")
-	ew.Logger.Err(fmt.Sprintf("net/http.Server: %s", string(p)))
+	ew.Logger.Errf("net/http.Server: %s", p)
 	return
 }
 


### PR DESCRIPTION
Just some small cleanups I found while doing other work on the logging system.