### PR TITLE
test: allow empty $DB_ADDR for most tests

### DIFF
--- a/test/vars/vars.go
+++ b/test/vars/vars.go
@@ -2,24 +2,15 @@ package vars
 
 import (
 	"fmt"
-	"net"
 	"os"
 )
 
-var dbAddr = func() string {
+func dsn(user, database string) string {
 	addr := os.Getenv("DB_ADDR")
 	if addr == "" {
-		panic("environment variable DB_ADDR  must be set")
+		addr = "unset DB_ADDR"
 	}
-	_, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		panic(fmt.Sprintf("environment variable DB_ADDR (%s) is not a valid address with host and port: %s", addr, err))
-	}
-	return addr
-}()
-
-func dsn(user, database string) string {
-	return fmt.Sprintf("%s@tcp(%s)/%s", user, dbAddr, database)
+	return fmt.Sprintf("%s@tcp(%s)/%s", user, addr, database)
 }
 
 var (


### PR DESCRIPTION
In vars.go we were doing some string validation at init time on the $DB_ADDR variable, and panicking if it was unset or invalid. This meant that running unittests panicked for those tests that depended on `vars`, even if they didn't actually do any DB work. For instance:

    go test ./policy

Fix this by removing the init-time validation and inserting a placeholder string if DB_ADDR is empty. This results in most tests passing without $DB_ADDR set. For those tests that do rely on $DB_ADDR, we get an error message like this:

    go test ./sa
    ...
    --- FAIL: TestSerialsForIncident (0.00s)
    sa_test.go:2924: Failed to create dbMap: dial tcp: lookup unset DB_ADDR: no such host