### PR TITLE
Make sure all services are logging at level 6

### DIFF
--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -198,7 +198,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config-next/crl-updater.json
+++ b/test/config-next/crl-updater.json
@@ -55,7 +55,7 @@
 		"features": {}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -180,7 +180,7 @@
 	},
 	"syslog": {
 		"stdoutlevel": 6,
-		"sysloglevel": 6
+		"sysloglevel": -1
 	},
 	"openTelemetry": {
 		"endpoint": "bjaeger:4317",

--- a/test/config-next/remoteva-a.json
+++ b/test/config-next/remoteva-a.json
@@ -45,7 +45,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config-next/remoteva-b.json
+++ b/test/config-next/remoteva-b.json
@@ -45,7 +45,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config-next/remoteva-c.json
+++ b/test/config-next/remoteva-c.json
@@ -45,7 +45,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config-next/sfe.json
+++ b/test/config-next/sfe.json
@@ -88,7 +88,7 @@
 		"features": {}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
+		"stdoutlevel": 6,
 		"sysloglevel": -1
 	},
 	"openTelemetry": {

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -70,7 +70,7 @@
 	},
 	"syslog": {
 		"stdoutlevel": 6,
-		"sysloglevel": 6
+		"sysloglevel": -1
 	},
 	"openTelemetry": {
 		"endpoint": "bjaeger:4317",

--- a/test/config/bad-key-revoker.json
+++ b/test/config/bad-key-revoker.json
@@ -27,7 +27,7 @@
 		"maxExpectedReplicationLag": "100ms"
 	},
 	"syslog": {
-		"stdoutlevel": 4,
-		"sysloglevel": 4
+		"stdoutlevel": 6,
+		"sysloglevel": 6
 	}
 }

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -199,7 +199,7 @@
 		}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
-		"sysloglevel": 4
+		"stdoutlevel": 6,
+		"sysloglevel": 6
 	}
 }

--- a/test/config/crl-updater.json
+++ b/test/config/crl-updater.json
@@ -55,7 +55,7 @@
 		"features": {}
 	},
 	"syslog": {
-		"stdoutlevel": 4,
-		"sysloglevel": 4
+		"stdoutlevel": 6,
+		"sysloglevel": 6
 	}
 }

--- a/test/config/email-exporter.json
+++ b/test/config/email-exporter.json
@@ -36,6 +36,6 @@
 	},
 	"syslog": {
 		"stdoutlevel": 6,
-		"sysloglevel": -1
+		"sysloglevel": 6
 	}
 }

--- a/test/config/remoteva-a.json
+++ b/test/config/remoteva-a.json
@@ -49,7 +49,7 @@
 		"rir": "ARIN"
 	},
 	"syslog": {
-		"stdoutlevel": 4,
-		"sysloglevel": 4
+		"stdoutlevel": 6,
+		"sysloglevel": 6
 	}
 }

--- a/test/config/remoteva-b.json
+++ b/test/config/remoteva-b.json
@@ -49,7 +49,7 @@
 		"rir": "RIPE"
 	},
 	"syslog": {
-		"stdoutlevel": 4,
-		"sysloglevel": 4
+		"stdoutlevel": 6,
+		"sysloglevel": 6
 	}
 }

--- a/test/config/remoteva-c.json
+++ b/test/config/remoteva-c.json
@@ -49,7 +49,7 @@
 		"rir": "ARIN"
 	},
 	"syslog": {
-		"stdoutlevel": 4,
-		"sysloglevel": 4
+		"stdoutlevel": 6,
+		"sysloglevel": 6
 	}
 }

--- a/test/config/sfe.json
+++ b/test/config/sfe.json
@@ -36,7 +36,7 @@
 	},
 	"syslog": {
 		"stdoutlevel": 6,
-		"sysloglevel": -1
+		"sysloglevel": 6
 	},
 	"openTelemetry": {
 		"endpoint": "bjaeger:4317",

--- a/test/config/wfe2.json
+++ b/test/config/wfe2.json
@@ -144,6 +144,6 @@
 	},
 	"syslog": {
 		"stdoutlevel": 7,
-		"sysloglevel": 6
+		"sysloglevel": 7
 	}
 }


### PR DESCRIPTION
This updates services logging at a level lower than 6 to be 6.

For configs in config/, keep the stdout and syslog levels the same
For configs in config-next/, set syslog to -1

Syslog level 6 is "Info", 4 is "Warning".

In particular, boulder-ca audit logs weren't getting logged with this configuration.
