### PR TITLE
health-checker: reduce log noise

### DIFF
--- a/test/health-checker/main.go
+++ b/test/health-checker/main.go
@@ -22,8 +22,6 @@ type config struct {
 }
 
 func main() {
-	defer cmd.AuditPanic()
-
 	// Flag and config parsing and validation.
 	configFile := flag.String("config", "", "Path to the TLS configuration file")
 	serverAddr := flag.String("addr", "", "Address of the gRPC server to check")
@@ -69,7 +67,6 @@ func main() {
 
 			// Set the hostOverride to match the dNSName in the server certificate.
 			c.GRPC.HostOverride = strings.Replace(hostOverride, ".service.consul", ".boulder", 1)
-			fmt.Fprintf(os.Stderr, "health checking %s (%s)\n", c.GRPC.HostOverride, *serverAddr)
 
 			// Set up the GRPC connection.
 			conn, err := bgrpc.ClientSetup(c.GRPC, tlsConfig, metrics.NoopRegisterer, clk)


### PR DESCRIPTION
We don't need an exit log each time the health-checker runs. We can also slightly reduce how often it runs, and remove the "checking %s" log. We'll still get log lines when it errors.