### PR TITLE
Update overrideForm data values to match sfe/overrides.go

### DIFF
--- a/sfe/static/overriderequest.js
+++ b/sfe/static/overriderequest.js
@@ -3,7 +3,7 @@ const RATE_LIMIT = form.dataset.rateLimit;
 const VALIDATE_FIELD_PATH = form.dataset.validateFieldPath;
 const SUBMIT_REQUEST_PATH = form.dataset.submitRequestPath;
 const AUTO_APPROVED_SUCCESS_PATH = form.dataset.autoApprovedSuccessPath;
-const REQUEST_SUBMITTED_SUCCESS_PATH = form.dataset.RequestSubmittedSuccessPath;
+const REQUEST_SUBMITTED_SUCCESS_PATH = form.dataset.requestSubmittedSuccessPath;
 
 const ERR_REQUIRED = "This field is required.";
 const ERR_VALIDATE = "Unable to validate this field due to timeout, please try again.";

--- a/sfe/templates/overrideForm.html
+++ b/sfe/templates/overrideForm.html
@@ -6,7 +6,8 @@
     <div id="form-error-banner"></div>
     <form id="override-form" referrerpolicy="no-referrer" data-rate-limit="{{.RateLimit}}"
         data-validate-field-path="{{.ValidateFieldPath}}" data-submit-request-path="{{.SubmitRequestPath}}"
-        data-submit-success-path="{{.SubmitSuccessPath}}">
+        data-auto-approved-success-path="{{.AutoApprovedSuccessPath}}"
+        data-request-submitted-success-path="{{.RequestSubmittedSuccessPath}}">
         {{ .FormHTML }}
         <button type="submit" class="primary btn-disabled" id="submit-button">Submit</button>
     </form>


### PR DESCRIPTION
While testing submissions of override requests, I was consistently returned to an "Invalid Portal URL" whose address ended in `/undefined`. It looks to me like the overrideForm data fields just needed to be normalized with the correct fields from sfe/overrides.go.