### PR TITLE
sfe: Render optional checkboxes as valid

### DIFF
--- a/sfe/static/overriderequest.js
+++ b/sfe/static/overriderequest.js
@@ -58,7 +58,7 @@ const updateSubmitButtonState = () => {
 const validateFieldContents = async (field) => {
     const val = field.type === "checkbox" ? String(field.checked) : field.value.trim();
 
-    if (field.type === "checkbox" && !field.required && !field.checked) {
+    if (field.type === "checkbox" && !field.required) {  
         markFieldValid(field);
         return;
     }


### PR DESCRIPTION
Render optional checkbox fields as valid so leaving them unchecked no longer blocks form submissions. Also, skip validation calls when an optional checkbox is validated.

Fixes #8573