### PR TITLE
admin: Implement missing dryRunRAC methods

### DIFF
--- a/cmd/admin/dryrun.go
+++ b/cmd/admin/dryrun.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -11,6 +12,8 @@ import (
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 )
+
+var _ rapb.RegistrationAuthorityClient = (*dryRunRAC)(nil)
 
 type dryRunRAC struct {
 	rapb.RegistrationAuthorityClient
@@ -26,6 +29,8 @@ func (d dryRunRAC) AdministrativelyRevokeCertificate(_ context.Context, req *rap
 	return &emptypb.Empty{}, nil
 }
 
+var _ rapb.RegistrationAuthorityClient = (*dryRunRAC)(nil)
+
 type dryRunSAC struct {
 	sapb.StorageAuthorityClient
 	log blog.Logger
@@ -34,4 +39,39 @@ type dryRunSAC struct {
 func (d dryRunSAC) AddBlockedKey(_ context.Context, req *sapb.AddBlockedKeyRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
 	d.log.Infof("dry-run: Block SPKI hash %x by %s %s", req.KeyHash, req.Comment, req.Source)
 	return &emptypb.Empty{}, nil
+}
+
+func (d dryRunSAC) AddRateLimitOverride(_ context.Context, req *sapb.AddRateLimitOverrideRequest, _ ...grpc.CallOption) (*sapb.AddRateLimitOverrideResponse, error) {
+	b, err := prototext.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	d.log.Infof("dry-run: %#v", string(b))
+	return &sapb.AddRateLimitOverrideResponse{
+		Inserted: true,
+		Enabled:  true,
+	}, nil
+}
+
+func (d dryRunSAC) DisableRateLimitOverride(_ context.Context, req *sapb.DisableRateLimitOverrideRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+	b, err := prototext.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	d.log.Infof("dry-run: %#v", string(b))
+	return &emptypb.Empty{}, nil
+}
+
+func (d dryRunSAC) EnableRateLimitOverride(_ context.Context, req *sapb.EnableRateLimitOverrideRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+	b, err := prototext.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	d.log.Infof("dry-run: %#v", string(b))
+	return &emptypb.Empty{}, nil
+}
+
+func (d dryRunSAC) GetEnabledRateLimitOverrides(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (grpc.ServerStreamingClient[sapb.RateLimitOverrideResponse], error) {
+	d.log.Info("dry-run: GetEnabledRateLimitOverrides")
+	return nil, errors.New("dry-run mode is not enabled for dump-limit-overrides")
 }


### PR DESCRIPTION
Implement dryRunSAC methods AddRateLimitOverride, DisableRateLimitOverride, EnableRateLimitOverride, and GetEnabledRateLimitOverrides. This avoids a panic when running the admin tool subcommands import-limit-overrides, dump-limit-overrides, add-limit-override, and toggle-limit-override.

Fixes #8588