### PR TITLE
ratelimits: Fix loading of override limits from the database

### DIFF
--- a/ratelimits/transaction_test.go
+++ b/ratelimits/transaction_test.go
@@ -281,32 +281,32 @@ func TestNewTransactionBuilderFromDatabase(t *testing.T) {
 			name: "2 valid overrides",
 			overrides: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (grpc.ServerStreamingClient[sapb.RateLimitOverrideResponse], error) {
 				return &mocks.ServerStreamClient[sapb.RateLimitOverrideResponse]{Results: []*sapb.RateLimitOverrideResponse{
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "example.com", Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "example.net", Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "example.com"), Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "example.net"), Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
 				}}, nil
 			},
 			expectOverrides: map[string]Limit{
-				"example.com": {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, Comment: "Last Updated: 1970-01-01 - ", emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
-				"example.net": {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, Comment: "Last Updated: 1970-01-01 - ", emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
+				joinWithColon(CertificatesPerDomain.EnumString(), "example.com"): {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
+				joinWithColon(CertificatesPerDomain.EnumString(), "example.net"): {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
 			},
 		},
 		{
 			name: "2 valid & 4 incomplete overrides",
 			overrides: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (grpc.ServerStreamingClient[sapb.RateLimitOverrideResponse], error) {
 				return &mocks.ServerStreamClient[sapb.RateLimitOverrideResponse]{Results: []*sapb.RateLimitOverrideResponse{
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "example.com", Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "example.net", Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "bad-example.com"}},
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "bad-example.net"}},
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "worse-example.com"}},
-					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: "even-worse-example.xyz"}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "example.com"), Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "example.net"), Period: &durationpb.Duration{Seconds: 1}, Count: 1, Burst: 1}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "bad-example.com")}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "bad-example.net")}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "worse-example.com")}},
+					{Override: &sapb.RateLimitOverride{LimitEnum: int64(StringToName["CertificatesPerDomain"]), BucketKey: joinWithColon(CertificatesPerDomain.EnumString(), "even-worse-example.xyz")}},
 				}}, nil
 			},
 			expectOverrides: map[string]Limit{
-				"example.com": {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, Comment: "Last Updated: 1970-01-01 - ", emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
-				"example.net": {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, Comment: "Last Updated: 1970-01-01 - ", emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
+				joinWithColon(CertificatesPerDomain.EnumString(), "example.com"): {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
+				joinWithColon(CertificatesPerDomain.EnumString(), "example.net"): {Burst: 1, Count: 1, Period: config.Duration{Duration: time.Second}, Name: CertificatesPerDomain, emissionInterval: 1000000000, burstOffset: 1000000000, isOverride: true},
 			},
-			expectLog:            "ERR: hydrating CertificatesPerDomain override with key \"bad-example.com\": invalid burst '0', must be > 0",
+			expectLog:            fmt.Sprintf("ERR: hydrating CertificatesPerDomain override with key %q: invalid burst '0', must be > 0", joinWithColon(CertificatesPerDomain.EnumString(), "bad-example.com")),
 			expectOverrideErrors: 4,
 		},
 	}


### PR DESCRIPTION
NewTransactionBuilderFromDatabase called hydrateOverrideLimit(), which should only be used to hydrate overrides from YAML, where they’re stored as limits and corresponding raw IDs (example.com, 8.8.8.8, 12345, etc.) that must be normalized and combined with the limit enum to form a bucketKey. However, the database stores bucketKeys that have already been validated and normalized before being written. As a result, every override entry was treated as invalid.

Instead, we now skip hydrateOverrideLimit() and use the bucketKey exactly as stored by SA, with no additional normalization when loading overrides from the database.

Also dropped rehydration of the comment field. It’s never referenced at runtime and consumes unnecessary memory.

Important: this change makes the overrides table the source of truth.

Fixes #8590