### PR TITLE
ratelimits: Fix docs urls for two rate limits

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -253,7 +253,7 @@ func CertificatesPerFQDNSetError(retryAfter time.Duration, msg string, args ...a
 func FailedAuthorizationsPerDomainPerAccountError(retryAfter time.Duration, msg string, args ...any) error {
 	return &BoulderError{
 		Type:       RateLimit,
-		Detail:     fmt.Sprintf(msg+": see https://letsencrypt.org/docs/rate-limits/#authorization-failures-per-hostname-per-account", args...),
+		Detail:     fmt.Sprintf(msg+": see https://letsencrypt.org/docs/rate-limits/#authorization-failures-per-identifier-per-account", args...),
 		RetryAfter: retryAfter,
 	}
 }
@@ -261,7 +261,7 @@ func FailedAuthorizationsPerDomainPerAccountError(retryAfter time.Duration, msg 
 func LimitOverrideRequestsPerIPAddressError(retryAfter time.Duration, msg string, args ...any) error {
 	return &BoulderError{
 		Type:       RateLimit,
-		Detail:     fmt.Sprintf(msg+": see https://letsencrypt.org/docs/rate-limits/#limit-override-requests-per-ip-address", args...),
+		Detail:     fmt.Sprintf(msg+": see https://letsencrypt.org/docs/rate-limits/#new-registrations-per-ip-address", args...),
 		RetryAfter: retryAfter,
 	}
 }

--- a/ratelimits/limiter_test.go
+++ b/ratelimits/limiter_test.go
@@ -527,7 +527,7 @@ func TestRateLimitError(t *testing.T) {
 					bucketKey: "4:12345:example.com",
 				},
 			},
-			expectedErr:     "too many failed authorizations (7) for \"example.com\" in the last 1h0m0s, retry after 1970-01-01 00:00:15 UTC: see https://letsencrypt.org/docs/rate-limits/#authorization-failures-per-hostname-per-account",
+			expectedErr:     "too many failed authorizations (7) for \"example.com\" in the last 1h0m0s, retry after 1970-01-01 00:00:15 UTC: see https://letsencrypt.org/docs/rate-limits/#authorization-failures-per-identifier-per-account",
 			expectedErrType: berrors.RateLimit,
 		},
 		{
@@ -577,7 +577,7 @@ func TestRateLimitError(t *testing.T) {
 					},
 				},
 			},
-			expectedErr:     "too many override request form submissions (3) from this IP address in the last 1h0m0s, retry after 1970-01-01 00:00:20 UTC: see https://letsencrypt.org/docs/rate-limits/#limit-override-requests-per-ip-address",
+			expectedErr:     "too many override request form submissions (3) from this IP address in the last 1h0m0s, retry after 1970-01-01 00:00:20 UTC: see https://letsencrypt.org/docs/rate-limits/#new-registrations-per-ip-address",
 			expectedErrType: berrors.RateLimit,
 		},
 		{


### PR DESCRIPTION
A previous website pull request (https://github.com/letsencrypt/website/pull/1933) modified documentation anchor links so they no longer align with those referenced in Boulder error messages.

Update documentation hyperlinks in Boulder errors to match the website changes:
- https://letsencrypt.org/docs/rate-limits/#authorization-failures-per-identifier-per-account
- https://letsencrypt.org/docs/rate-limits/#new-registrations-per-ip-address