### PR TITLE
docker: simplify bmariadb container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,14 +84,6 @@ services:
           - boulder-mariadb
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    # Send slow queries to a table so we can check for them in the
-    # integration tests. For now we ignore queries not using indexes,
-    # because that seems to trigger based on the optimizer's choice to not
-    # use an index for certain queries, particularly when tables are still
-    # small.
-    command: mysqld --bind-address=0.0.0.0 --slow-query-log --log-output=TABLE --log-queries-not-using-indexes=ON
-    logging:
-      driver: none
 
   bproxysql:
     image: proxysql/proxysql:2.7.2


### PR DESCRIPTION
We don't need to specify the slow query / not-using-indexes parameters because we removed the corresponding test. We don't need to specify the bind address because 0.0.0.0 is the default.

The logging: driver: none part dates back to our very first use of docker and I can't find any explanation for it. It simply avoids storing logs, but does not affect whether logs go to stdout, AFAICT.