### PR TITLE
test: use SIGKILL instead of SIGTERM

### DIFF
--- a/test/startservers.py
+++ b/test/startservers.py
@@ -307,13 +307,12 @@ def stopChallSrv():
 
 @atexit.register
 def stop():
-    # When we are about to exit, send SIGTERM to each subprocess and wait for
-    # them to nicely die. This reflects the restart process in prod and allows
-    # us to exercise the graceful shutdown code paths.
+    # When we are about to exit, send SIGKILL to each subprocess and wait for
+    # them to die.
     global processes
     for p in reversed(processes):
         if p.poll() is None:
-            p.send_signal(signal.SIGTERM)
+            p.send_signal(signal.SIGKILL)
             p.wait()
     processes = []
 


### PR DESCRIPTION
Now that we audit log clean shutdowns, it's very hard to find error messages among the logspam during shutdown. SIGKILL prevents the processes from logging anything on their way down.