### PR TITLE
Don't ignore unrecognized CAA parameters

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -369,6 +369,16 @@ func (va *ValidationAuthorityImpl) validateCAA(caaSet *caaResult, wildcard bool,
 			continue
 		}
 
+		for _, param := range parsedParams {
+			// The existence of any parameters other than the ones we recognize means
+			// that this user wants something we don't understand. Don't interpret
+			// this record as allowing issuance. We're case-sensitive here to be
+			// strict in what we accept.
+			if param.tag != "accounturi" && param.tag != "validationmethods" {
+				continue
+			}
+		}
+
 		if !caaAccountURIMatches(parsedParams, va.accountURIPrefixes, params.accountURIID) {
 			continue
 		}


### PR DESCRIPTION
> [!NOTE]
> This is a simpler alternative to https://github.com/letsencrypt/boulder/pull/8616. Creating this PR as a draft for the sake of discussion.

If a CAA record contains any parameters which we don't recognize, we shouldn't simply ignore them. The parameters are likely there because the user wants some particular protection, and we might be violating their security expectations by ignoring that parameter.

This includes simply mis-capitalized versions of recognized parameters, such as "AccountURI" or "validationMethods". We do not see these mis-capitalizations in practice, so we do not expect this to be a breaking change for any existing users. By putting this in place now, we will prevent any future proliferation of accidentally-miscapitalized parameters.

Fixes https://github.com/letsencrypt/boulder/issues/8614