### PR TITLE
release: tag based on `refs/remotes/origin/main`.

### DIFF
--- a/tools/release/tag/main.go
+++ b/tools/release/tag/main.go
@@ -121,7 +121,7 @@ func tag(args []string) error {
 	// Produce the tag, using -s to PGP sign it. This will fail if a tag with
 	// that name already exists.
 	message := fmt.Sprintf("Release %s", tag)
-	_, err = git("tag", "-s", "-m", message, tag, "origin/"+branch)
+	_, err = git("tag", "-s", "-m", message, tag, "refs/remotes/origin/"+branch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prevent locally created branches from shadowing `origin/main`, for instance via the `git switch -c origin/main` mistake that originally motivated this script.