### PR TITLE
VA: properly initialize slowRemoteTimeout

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -261,6 +261,7 @@ func NewValidationAuthorityImpl(
 		// used for the DialContext operations that take place during an
 		// HTTP-01 challenge validation.
 		singleDialTimeout:    10 * time.Second,
+		slowRemoteTimeout:    slowRemoteTimeout,
 		perspective:          perspective,
 		rir:                  rir,
 		isReservedIPFunc:     reservedIPChecker,


### PR DESCRIPTION
This may have been the cause of the issues we observed with high remote VA latency -- we believed we had enabled the new slowRemoteTimeout feature, but in fact we had not. It is surprising to me that none of the go tooling warned about this unused function parameter.