### PR TITLE
VA: ensure wildcard hostname is lowercased

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -297,7 +297,7 @@ func (va *ValidationAuthorityImpl) checkCAARecords(
 	// If this is a wildcard name, remove the prefix
 	var wildcard bool
 	if strings.HasPrefix(hostname, `*.`) {
-		hostname = strings.TrimPrefix(ident.Value, `*.`)
+		hostname = strings.TrimPrefix(hostname, `*.`)
 		wildcard = true
 	}
 	caaSet, err := va.getCAA(ctx, hostname)


### PR DESCRIPTION
If a hostname were a wildcard, the asterisk prefix would be trimmed from the pre-lowercase ident.Value, rather than the already-lowercased hostname. This would have no real impact, as the hostname here is being plumbed into DNS requests which randomize the capitalization of the hostname anyway, but is a good cleanliness fix.