### PR TITLE
Remove extraneous top-level struct args to IsAnyNilOrZero

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -219,7 +219,7 @@ func (ca *certificateAuthorityImpl) IssueCertificate(ctx context.Context, req *c
 	// Step 1: Locally process the gRPC request and its embedded CSR to extract
 	// the relevant information, like the pubkey and SANs. Also generate
 	// some metadata from scratch, such as the serial and validity period.
-	if core.IsAnyNilOrZero(req, req.RegistrationID, req.OrderID, req.CertProfileName, req.Csr) {
+	if core.IsAnyNilOrZero(req.RegistrationID, req.OrderID, req.CertProfileName, req.Csr) {
 		return nil, berrors.InternalServerError("Incomplete issue certificate request")
 	}
 

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2096,7 +2096,7 @@ func (ra *RegistrationAuthorityImpl) DeactivateRegistration(ctx context.Context,
 func (ra *RegistrationAuthorityImpl) DeactivateAuthorization(ctx context.Context, req *corepb.Authorization) (*emptypb.Empty, error) {
 	ident := identifier.FromProto(req.Identifier)
 
-	if core.IsAnyNilOrZero(req, req.Id, ident, req.Status, req.RegistrationID) {
+	if core.IsAnyNilOrZero(req.Id, ident, req.Status, req.RegistrationID) {
 		return nil, errIncompleteGRPCRequest
 	}
 	authzID, err := strconv.ParseInt(req.Id, 10, 64)
@@ -2413,7 +2413,7 @@ func (ra *RegistrationAuthorityImpl) UnpauseAccount(ctx context.Context, request
 }
 
 func (ra *RegistrationAuthorityImpl) GetAuthorization(ctx context.Context, req *rapb.GetAuthorizationRequest) (*corepb.Authorization, error) {
-	if core.IsAnyNilOrZero(req, req.Id) {
+	if core.IsAnyNilOrZero(req.Id) {
 		return nil, errIncompleteGRPCRequest
 	}
 
@@ -2437,7 +2437,7 @@ func (ra *RegistrationAuthorityImpl) GetAuthorization(ctx context.Context, req *
 
 // AddRateLimitOverride is a pass-through to the SA's AddRateLimitOverride method.
 func (ra *RegistrationAuthorityImpl) AddRateLimitOverride(ctx context.Context, req *rapb.AddRateLimitOverrideRequest) (*rapb.AddRateLimitOverrideResponse, error) {
-	if core.IsAnyNilOrZero(req, req.Override, req.Override.LimitEnum, req.Override.BucketKey, req.Override.Count, req.Override.Burst, req.Override.Period, req.Override.Comment) {
+	if core.IsAnyNilOrZero(req.Override, req.Override.LimitEnum, req.Override.BucketKey, req.Override.Count, req.Override.Burst, req.Override.Period, req.Override.Comment) {
 		return nil, errIncompleteGRPCRequest
 	}
 

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -1428,7 +1428,7 @@ func overrideLowerThanExisting(new *sapb.RateLimitOverride, existing overrideMod
 // re-enabled. The current status is returned in the Enabled field of the
 // response. To re-enable an override, use EnableRateLimitOverride.
 func (ssa *SQLStorageAuthority) AddRateLimitOverride(ctx context.Context, req *sapb.AddRateLimitOverrideRequest) (*sapb.AddRateLimitOverrideResponse, error) {
-	if core.IsAnyNilOrZero(req, req.Override, req.Override.LimitEnum, req.Override.BucketKey, req.Override.Count, req.Override.Burst, req.Override.Period, req.Override.Comment) {
+	if core.IsAnyNilOrZero(req.Override, req.Override.LimitEnum, req.Override.BucketKey, req.Override.Count, req.Override.Burst, req.Override.Period, req.Override.Comment) {
 		return nil, errIncompleteRequest
 	}
 
@@ -1615,7 +1615,7 @@ func (ssa *SQLStorageAuthority) updateRateLimitOverride(
 // not exist, a NotFoundError is returned. If the override exists but is already
 // disabled, this is a no-op.
 func (ssa *SQLStorageAuthority) DisableRateLimitOverride(ctx context.Context, req *sapb.DisableRateLimitOverrideRequest) (*emptypb.Empty, error) {
-	if core.IsAnyNilOrZero(req, req.LimitEnum, req.BucketKey) {
+	if core.IsAnyNilOrZero(req.LimitEnum, req.BucketKey) {
 		return nil, errIncompleteRequest
 	}
 	return ssa.setRateLimitOverride(ctx, req.LimitEnum, req.BucketKey, false)
@@ -1625,7 +1625,7 @@ func (ssa *SQLStorageAuthority) DisableRateLimitOverride(ctx context.Context, re
 // not exist, a NotFoundError is returned. If the override exists but is already
 // enabled, this is a no-op.
 func (ssa *SQLStorageAuthority) EnableRateLimitOverride(ctx context.Context, req *sapb.EnableRateLimitOverrideRequest) (*emptypb.Empty, error) {
-	if core.IsAnyNilOrZero(req, req.LimitEnum, req.BucketKey) {
+	if core.IsAnyNilOrZero(req.LimitEnum, req.BucketKey) {
 		return nil, errIncompleteRequest
 	}
 	return ssa.setRateLimitOverride(ctx, req.LimitEnum, req.BucketKey, true)

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -685,7 +685,7 @@ func (ssa *SQLStorageAuthorityRO) CountInvalidAuthorizations2(ctx context.Contex
 func (ssa *SQLStorageAuthorityRO) GetValidAuthorizations2(ctx context.Context, req *sapb.GetValidAuthorizationsRequest) (*sapb.Authorizations, error) {
 	idents := identifier.FromProtoSlice(req.Identifiers)
 
-	if core.IsAnyNilOrZero(req, req.RegistrationID, idents, req.ValidUntil) {
+	if core.IsAnyNilOrZero(req.RegistrationID, idents, req.ValidUntil) {
 		return nil, errIncompleteRequest
 	}
 
@@ -1128,7 +1128,7 @@ func (ssa *SQLStorageAuthorityRO) GetPausedIdentifiers(ctx context.Context, req 
 // GetRateLimitOverride retrieves a rate limit override for the given bucket key
 // and limit. If no override is found, a NotFound error is returned.
 func (ssa *SQLStorageAuthorityRO) GetRateLimitOverride(ctx context.Context, req *sapb.GetRateLimitOverrideRequest) (*sapb.RateLimitOverrideResponse, error) {
-	if core.IsAnyNilOrZero(req, req.LimitEnum, req.BucketKey) {
+	if core.IsAnyNilOrZero(req.LimitEnum, req.BucketKey) {
 		return nil, errIncompleteRequest
 	}
 

--- a/salesforce/exporter.go
+++ b/salesforce/exporter.go
@@ -105,7 +105,7 @@ func NewExporterImpl(client SalesforceClient, cache *EmailCache, perDayLimit flo
 // SendContacts enqueues the provided email addresses. If the queue cannot
 // accommodate the new emails, an ErrQueueFull is returned.
 func (impl *ExporterImpl) SendContacts(ctx context.Context, req *salesforcepb.SendContactsRequest) (*emptypb.Empty, error) {
-	if core.IsAnyNilOrZero(req, req.Emails) {
+	if core.IsAnyNilOrZero(req.Emails) {
 		return nil, berrors.InternalServerError("Incomplete gRPC request message")
 	}
 
@@ -127,7 +127,7 @@ func (impl *ExporterImpl) SendContacts(ctx context.Context, req *salesforcepb.Se
 // provided details. Any retries are handled internally by the SalesforceClient.
 // The following fields are required: Origin, Subject, ContactEmail.
 func (impl *ExporterImpl) SendCase(ctx context.Context, req *salesforcepb.SendCaseRequest) (*emptypb.Empty, error) {
-	if core.IsAnyNilOrZero(req, req.Origin, req.Subject, req.ContactEmail) {
+	if core.IsAnyNilOrZero(req.Origin, req.Subject, req.ContactEmail) {
 		return nil, berrors.InternalServerError("incomplete gRPC request message")
 	}
 

--- a/va/caa.go
+++ b/va/caa.go
@@ -126,7 +126,7 @@ func (va *ValidationAuthorityImpl) checkCAA(
 	ctx context.Context,
 	ident identifier.ACMEIdentifier,
 	params *caaParams) error {
-	if core.IsAnyNilOrZero(params, params.validationMethod, params.accountURIID) {
+	if core.IsAnyNilOrZero(params.validationMethod, params.accountURIID) {
 		return errors.New("expected validationMethod or accountURIID not provided to checkCAA")
 	}
 

--- a/va/va.go
+++ b/va/va.go
@@ -664,7 +664,7 @@ type validationLogEvent struct {
 // implements the DCV portion of Multi-Perspective Issuance Corroboration as
 // defined in BRs Sections 3.2.2.9 and 5.4.1.
 func (va *ValidationAuthorityImpl) DoDCV(ctx context.Context, req *vapb.PerformValidationRequest) (*vapb.ValidationResult, error) {
-	if core.IsAnyNilOrZero(req, req.Identifier, req.Challenge, req.Authz, req.Authz.RegID, req.ExpectedKeyAuthorization) {
+	if core.IsAnyNilOrZero(req.Identifier, req.Challenge, req.Authz, req.Authz.RegID, req.ExpectedKeyAuthorization) {
 		return nil, berrors.InternalServerError("Incomplete validation request")
 	}
 

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1348,7 +1348,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			Authz:          authzPB,
 			ChallengeIndex: int64(challengeIndex),
 		})
-		if err != nil || core.IsAnyNilOrZero(authzPB, authzPB.Id, authzPB.Identifier, authzPB.Status, authzPB.Expires) {
+		if err != nil || core.IsAnyNilOrZero(authzPB.Id, authzPB.Identifier, authzPB.Status, authzPB.Expires) {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
 			return
 		}
@@ -2450,7 +2450,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		ReplacesSerial:         replacesSerial,
 	})
 
-	if err != nil || core.IsAnyNilOrZero(order, order.Id, order.RegistrationID, order.Identifiers, order.Created, order.Expires) {
+	if err != nil || core.IsAnyNilOrZero(order.Id, order.RegistrationID, order.Identifiers, order.Created, order.Expires) {
 		wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Error creating new order"), err)
 		return
 	}


### PR DESCRIPTION
We frequently call `core.IsAnyNilOrZero(obj, obj.field)`, to check both that the object (usually a gRPC request) is not nil, and that the required field on the object is not nil. This is pointless for two reasons:

1) gRPC guarantees that the request object will never be nil, so checking the top-level object is wasted effort.
2) If the object were nil, then attempting to pass `obj.field` as the second argument to IsAnyNilOrZero will result in a nil pointer dereference panic before that function even gets to evaluate its first argument. This can be seen here: https://go.dev/play/p/duQK2ZbnxqK

Remove these extraneous first arguments, and operate under the assumption that the request object itself is never nil.