### PR TITLE
Fix miscellaneous value/pointer receiver mismatches

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -100,7 +100,7 @@ func New(realIssuer *x509.Certificate, realSigner crypto.Signer) (*Linter, error
 // replaced with the linter's pubkey so that it appears self-signed. It returns
 // an error if any lint fails. On success it also returns the DER bytes of the
 // linting certificate.
-func (l Linter) Check(tbs *x509.Certificate, subjectPubKey crypto.PublicKey, reg lint.Registry) ([]byte, error) {
+func (l *Linter) Check(tbs *x509.Certificate, subjectPubKey crypto.PublicKey, reg lint.Registry) ([]byte, error) {
 	lintPubKey := subjectPubKey
 	selfSigned, err := core.PublicKeysEqual(subjectPubKey, l.realPubKey)
 	if err != nil {
@@ -127,7 +127,7 @@ func (l Linter) Check(tbs *x509.Certificate, subjectPubKey crypto.PublicKey, reg
 // CheckCRL signs the given RevocationList template using the Linter's fake
 // issuer cert and private key, then runs the resulting CRL through all CRL
 // lints in the registry. It returns an error if any check fails.
-func (l Linter) CheckCRL(tbs *x509.RevocationList, reg lint.Registry) error {
+func (l *Linter) CheckCRL(tbs *x509.RevocationList, reg lint.Registry) error {
 	crl, err := makeLintCRL(tbs, l.issuer, l.signer)
 	if err != nil {
 		return err

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -20,7 +20,7 @@ type Observer struct {
 }
 
 // Start spins off a goroutine for each monitor, and waits for a signal to exit
-func (o Observer) Start() {
+func (o *Observer) Start() {
 	for _, mon := range o.monitors {
 		go mon.start(o.logger)
 	}

--- a/pkcs11helpers/helpers.go
+++ b/pkcs11helpers/helpers.go
@@ -388,34 +388,34 @@ type MockCtx struct {
 	FindObjectsFinalFunc  func(sh pkcs11.SessionHandle) error
 }
 
-func (mc MockCtx) GenerateKeyPair(s pkcs11.SessionHandle, m []*pkcs11.Mechanism, a1 []*pkcs11.Attribute, a2 []*pkcs11.Attribute) (pkcs11.ObjectHandle, pkcs11.ObjectHandle, error) {
+func (mc *MockCtx) GenerateKeyPair(s pkcs11.SessionHandle, m []*pkcs11.Mechanism, a1 []*pkcs11.Attribute, a2 []*pkcs11.Attribute) (pkcs11.ObjectHandle, pkcs11.ObjectHandle, error) {
 	return mc.GenerateKeyPairFunc(s, m, a1, a2)
 }
 
-func (mc MockCtx) GetAttributeValue(s pkcs11.SessionHandle, o pkcs11.ObjectHandle, a []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
+func (mc *MockCtx) GetAttributeValue(s pkcs11.SessionHandle, o pkcs11.ObjectHandle, a []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
 	return mc.GetAttributeValueFunc(s, o, a)
 }
 
-func (mc MockCtx) SignInit(s pkcs11.SessionHandle, m []*pkcs11.Mechanism, o pkcs11.ObjectHandle) error {
+func (mc *MockCtx) SignInit(s pkcs11.SessionHandle, m []*pkcs11.Mechanism, o pkcs11.ObjectHandle) error {
 	return mc.SignInitFunc(s, m, o)
 }
 
-func (mc MockCtx) Sign(s pkcs11.SessionHandle, m []byte) ([]byte, error) {
+func (mc *MockCtx) Sign(s pkcs11.SessionHandle, m []byte) ([]byte, error) {
 	return mc.SignFunc(s, m)
 }
 
-func (mc MockCtx) GenerateRandom(s pkcs11.SessionHandle, c int) ([]byte, error) {
+func (mc *MockCtx) GenerateRandom(s pkcs11.SessionHandle, c int) ([]byte, error) {
 	return mc.GenerateRandomFunc(s, c)
 }
 
-func (mc MockCtx) FindObjectsInit(sh pkcs11.SessionHandle, temp []*pkcs11.Attribute) error {
+func (mc *MockCtx) FindObjectsInit(sh pkcs11.SessionHandle, temp []*pkcs11.Attribute) error {
 	return mc.FindObjectsInitFunc(sh, temp)
 }
 
-func (mc MockCtx) FindObjects(sh pkcs11.SessionHandle, max int) ([]pkcs11.ObjectHandle, bool, error) {
+func (mc *MockCtx) FindObjects(sh pkcs11.SessionHandle, max int) ([]pkcs11.ObjectHandle, bool, error) {
 	return mc.FindObjectsFunc(sh, max)
 }
 
-func (mc MockCtx) FindObjectsFinal(sh pkcs11.SessionHandle) error {
+func (mc *MockCtx) FindObjectsFinal(sh pkcs11.SessionHandle) error {
 	return mc.FindObjectsFinalFunc(sh)
 }

--- a/pkcs11helpers/helpers_test.go
+++ b/pkcs11helpers/helpers_test.go
@@ -14,8 +14,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/letsencrypt/boulder/test"
 	"github.com/miekg/pkcs11"
+
+	"github.com/letsencrypt/boulder/test"
 )
 
 func TestGetECDSAPublicKey(t *testing.T) {
@@ -151,7 +152,7 @@ func newSessionWithMock() (*Session, *MockCtx) {
 }
 
 func TestFindObjectFailsOnFailedInit(t *testing.T) {
-	ctx := MockCtx{}
+	ctx := &MockCtx{}
 	ctx.FindObjectsFinalFunc = findObjectsFinalOK
 	ctx.FindObjectsFunc = func(pkcs11.SessionHandle, int) ([]pkcs11.ObjectHandle, bool, error) {
 		return []pkcs11.ObjectHandle{1}, false, nil
@@ -167,7 +168,7 @@ func TestFindObjectFailsOnFailedInit(t *testing.T) {
 }
 
 func TestFindObjectFailsOnFailedFindObjects(t *testing.T) {
-	ctx := MockCtx{}
+	ctx := &MockCtx{}
 	ctx.FindObjectsInitFunc = findObjectsInitOK
 	ctx.FindObjectsFinalFunc = findObjectsFinalOK
 
@@ -181,7 +182,7 @@ func TestFindObjectFailsOnFailedFindObjects(t *testing.T) {
 }
 
 func TestFindObjectFailsOnNoHandles(t *testing.T) {
-	ctx := MockCtx{}
+	ctx := &MockCtx{}
 	ctx.FindObjectsInitFunc = findObjectsInitOK
 	ctx.FindObjectsFinalFunc = findObjectsFinalOK
 
@@ -195,7 +196,7 @@ func TestFindObjectFailsOnNoHandles(t *testing.T) {
 }
 
 func TestFindObjectFailsOnMultipleHandles(t *testing.T) {
-	ctx := MockCtx{}
+	ctx := &MockCtx{}
 	ctx.FindObjectsInitFunc = findObjectsInitOK
 	ctx.FindObjectsFinalFunc = findObjectsFinalOK
 
@@ -210,7 +211,7 @@ func TestFindObjectFailsOnMultipleHandles(t *testing.T) {
 }
 
 func TestFindObjectFailsOnFinalizeFailure(t *testing.T) {
-	ctx := MockCtx{}
+	ctx := &MockCtx{}
 	ctx.FindObjectsInitFunc = findObjectsInitOK
 
 	// test FindObject fails when FindObjectsFinal fails
@@ -226,7 +227,7 @@ func TestFindObjectFailsOnFinalizeFailure(t *testing.T) {
 }
 
 func TestFindObjectSucceeds(t *testing.T) {
-	ctx := MockCtx{}
+	ctx := &MockCtx{}
 	ctx.FindObjectsInitFunc = findObjectsInitOK
 	ctx.FindObjectsFinalFunc = findObjectsFinalOK
 	ctx.FindObjectsFunc = func(pkcs11.SessionHandle, int) ([]pkcs11.ObjectHandle, bool, error) {
@@ -241,7 +242,7 @@ func TestFindObjectSucceeds(t *testing.T) {
 }
 
 func TestX509Signer(t *testing.T) {
-	ctx := MockCtx{}
+	ctx := &MockCtx{}
 
 	// test that x509Signer.Sign properly converts the PKCS#11 format signature to
 	// the RFC 5480 format signature

--- a/va/dns.go
+++ b/va/dns.go
@@ -26,7 +26,7 @@ import (
 // there is an error resolving the hostname, or if no usable IP addresses are
 // available then a berrors.DNSError instance is returned with a nil netip.Addr
 // slice.
-func (va ValidationAuthorityImpl) getAddrs(ctx context.Context, hostname string) ([]netip.Addr, []string, error) {
+func (va *ValidationAuthorityImpl) getAddrs(ctx context.Context, hostname string) ([]netip.Addr, []string, error) {
 	// Kick off both the A and AAAA lookups in parallel.
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
Update the Linter's Check and CheckCRL methods to use a pointer receiver, to match the fact that New returns a pointer to a Linter, and that the linter itself contains various large pointer/interface fields.

Update Observer's Start() method to use a pointer receiver, to match the fact that obs_conf.MakeObserver returns a pointer.

Update pcks11helper's MockCtx methods to use pointer receivers, to match the fact that NewMock returns a pointer.

Update the VA's getAddrs method to use a pointer receiver, to match every other method on the VA.

Do not update various MarshalJSON and UnmarshalJSON methods to match each other, since the expectation there is that all UnmarshalJSON methods use pointer receivers while all MarshalJSON methods use value receivers.