### PR TITLE
Update CI to go1.25.8

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -38,6 +38,7 @@ jobs:
         BOULDER_TOOLS_TAG:
           - go1.25.5_2025-12-03
           - go1.25.7_2026-02-04
+          - go1.25.8_2026-03-05
         # Tests command definitions. Use the entire "docker compose" command you want to run.
         tests:
           # Run ./test.sh --help for a description of each of the flags.
@@ -130,7 +131,7 @@ jobs:
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
       fail-fast: false
       matrix:
-        go-version: [ '1.25.7' ]
+        go-version: [ '1.25.8' ]
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.25.5"
+          - "1.25.8"
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.25.5"
+          - "1.25.8"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: test/boulder-tools/
       # Should match one of the GO_CI_VERSIONS in test/boulder-tools/tag_and_upload.sh.
       args:
-        GO_VERSION: 1.25.7
+        GO_VERSION: 1.25.8
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening. This is

--- a/test/boulder-tools/tag_and_upload.sh
+++ b/test/boulder-tools/tag_and_upload.sh
@@ -12,7 +12,7 @@ DOCKER_REPO="letsencrypt/boulder-tools"
 # .github/workflows/release.yml,
 # .github/workflows/try-release.yml if appropriate,
 # and .github/workflows/boulder-ci.yml with the new container tag.
-GO_CI_VERSIONS=( "1.25.5" "1.25.7" )
+GO_CI_VERSIONS=( "1.25.5" "1.25.7" "1.25.8" )
 
 echo "Please login to allow push to DockerHub"
 docker login


### PR DESCRIPTION
The go1.25.8 security release addresses a CVE affecting net/url:
- https://groups.google.com/g/golang-announce/c/EdhZqrQ98hk