### PR TITLE
noncebalancer: integration test reconnects

### DIFF
--- a/test/config-next/nonce-a.json
+++ b/test/config-next/nonce-a.json
@@ -13,7 +13,7 @@
 			"sampleratio": 1
 		},
 		"grpc": {
-			"maxConnectionAge": "30m",
+			"maxConnectionAge": "1s",
 			"services": {
 				"nonce.NonceService": {
 					"clientNames": [

--- a/test/config-next/nonce-b.json
+++ b/test/config-next/nonce-b.json
@@ -13,7 +13,7 @@
 			"sampleratio": 1
 		},
 		"grpc": {
-			"maxConnectionAge": "30m",
+			"maxConnectionAge": "1s",
 			"services": {
 				"nonce.NonceService": {
 					"clientNames": [

--- a/test/config/nonce-a.json
+++ b/test/config/nonce-a.json
@@ -10,7 +10,7 @@
 		},
 		"debugAddr": ":8111",
 		"grpc": {
-			"maxConnectionAge": "30m",
+			"maxConnectionAge": "1s",
 			"address": ":9101",
 			"services": {
 				"nonce.NonceService": {

--- a/test/config/nonce-b.json
+++ b/test/config/nonce-b.json
@@ -10,7 +10,7 @@
 		},
 		"debugAddr": ":8111",
 		"grpc": {
-			"maxConnectionAge": "30m",
+			"maxConnectionAge": "1s",
 			"address": ":9101",
 			"services": {
 				"nonce.NonceService": {

--- a/test/integration/nonce_test.go
+++ b/test/integration/nonce_test.go
@@ -4,7 +4,9 @@ package integration
 
 import (
 	"context"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"testing"
+	"time"
 
 	"github.com/jmhodges/clock"
 	"google.golang.org/grpc/status"
@@ -46,6 +48,11 @@ func TestNonceBalancer_NoBackendMatchingPrefix(t *testing.T) {
 
 	clk := clock.New()
 
+	getNonceConn, err := bgrpc.ClientSetup(c.NotWFE.GetNonceService, tlsConfig, metrics.NoopRegisterer, clk)
+	test.AssertNotError(t, err, "Failed to load credentials and create gRPC connection to get nonce service")
+
+	gnc := nonce.NewGetter(getNonceConn)
+
 	redeemNonceConn, err := bgrpc.ClientSetup(c.NotWFE.RedeemNonceService, tlsConfig, metrics.NoopRegisterer, clk)
 	test.AssertNotError(t, err, "Failed to load credentials and create gRPC connection to redeem nonce service")
 	rnc := nonce.NewRedeemer(redeemNonceConn)
@@ -59,4 +66,21 @@ func TestNonceBalancer_NoBackendMatchingPrefix(t *testing.T) {
 	gotRPCStatus, ok := status.FromError(err)
 	test.Assert(t, ok, "Failed to convert error to status")
 	test.AssertEquals(t, gotRPCStatus, nb.ErrNoBackendsMatchPrefix)
+
+	var nonces []*noncepb.NonceMessage
+	for i := 0; i < 300; i++ {
+		nonceMsg, err := gnc.Nonce(ctx, &emptypb.Empty{})
+		test.AssertNotError(t, err, "getting nonce")
+
+		nonces = append(nonces, nonceMsg)
+	}
+
+	for _, nonceMsg := range nonces {
+		ctx := context.WithValue(ctx, nonce.PrefixCtxKey{}, nonceMsg.Nonce[:nonce.PrefixLen])
+		ctx = context.WithValue(ctx, nonce.HMACKeyCtxKey{}, rncKey)
+
+		_, err = rnc.Redeem(ctx, &noncepb.NonceMessage{Nonce: nonceMsg.Nonce})
+		test.AssertNotError(t, err, "redeeming nonce")
+		time.Sleep(10 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
Set maxConnectionAge to 1s, and make nonce_test.go collect 300 nonces, then redeem them one at a time, separated by 10ms. This creates a high likelihood of a redemption request occuring during a reconnect.

This should fail fairly reliably with `redeeming nonce: rpc error: code = Unavailable desc = no backends match the nonce prefix` until #8662 is fixed. We should merge this after a fix is merged.