### PR TITLE
grpc: server-side health check default: 5s->500ms

### DIFF
--- a/grpc/server.go
+++ b/grpc/server.go
@@ -209,7 +209,7 @@ func (sb *serverBuilder) Build(tlsConfig *tls.Config, statsRegistry prometheus.R
 	// Initialize long-running health checks of all services which implement the
 	// checker interface.
 	if sb.checkInterval <= 0 {
-		sb.checkInterval = 5 * time.Second
+		sb.checkInterval = 500 * time.Millisecond
 	}
 	healthCtx, stopHealthChecks := context.WithCancel(context.Background())
 	for _, s := range sb.services {


### PR DESCRIPTION
Since the RA always starts unhealthy (it needs to load overrides), this allows it to become healthy sooner.

This speeds up integration test startup by about 20s, because we start four instances of RA, and they were all waiting on their second internal health check before they could become healthy.

Note that our `health-checker` binary (used from `startservers.py`) checks health every 100ms, but no requests are actually sent over the wire because the server side has not sent the client a streaming reply to the `HealthClient.Watch()` RPC. We do have the option of plumbing things up so that RA can call `serverBuilder.healthSrv.SetServingStatus()` as soon as its overrides are loaded, which would speed things up a bit more, but this seems good enough for now.