### PR TITLE
crl/va/test: Let the bodies hit the Close()

### DIFF
--- a/cmd/crl-checker/main.go
+++ b/cmd/crl-checker/main.go
@@ -22,6 +22,8 @@ func downloadShard(url string) (*x509.RevocationList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("downloading crl: %w", err)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("downloading crl: http status %d", resp.StatusCode)
 	}

--- a/crl/storer/storer.go
+++ b/crl/storer/storer.go
@@ -182,6 +182,7 @@ func (cs *crlStorer) UploadCRL(stream grpc.ClientStreamingServer[cspb.UploadCRLR
 		}
 		cs.log.Infof("No previous CRL found for %s, proceeding", crlId)
 	} else {
+		defer prevObj.Body.Close()
 		prevBytes, err := io.ReadAll(prevObj.Body)
 		if err != nil {
 			return fmt.Errorf("downloading previous CRL for %s: %w", crlId, err)

--- a/test/integration/common_mock.go
+++ b/test/integration/common_mock.go
@@ -25,10 +25,10 @@ func ctAddRejectHost(domain string) error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("adding reject host: %d", resp.StatusCode)
 		}
-		resp.Body.Close()
 	}
 	return nil
 }

--- a/test/integration/crl_test.go
+++ b/test/integration/crl_test.go
@@ -43,6 +43,7 @@ func runUpdater(t *testing.T, configFile string) {
 	// this new batch of CRLs.
 	resp, err := http.Post("http://localhost:4501/reset", "", bytes.NewReader([]byte{}))
 	test.AssertNotError(t, err, "opening database connection")
+	defer resp.Body.Close()
 	test.AssertEquals(t, resp.StatusCode, http.StatusOK)
 
 	// Reset the "leasedUntil" column so this can be done alongside other

--- a/test/integration/otel_test.go
+++ b/test/integration/otel_test.go
@@ -65,6 +65,8 @@ func getTraceFromJaeger(t *testing.T, traceID trace.TraceID) Trace {
 	traceURL := "http://bjaeger:16686/api/traces/" + traceID.String()
 	resp, err := http.Get(traceURL)
 	test.AssertNotError(t, err, "failed to trace from jaeger: "+traceID.String())
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
 		t.Fatalf("jaeger returned 404 for trace %s", traceID)
 	}

--- a/test/integration/revocation_test.go
+++ b/test/integration/revocation_test.go
@@ -103,6 +103,8 @@ func getCRL(t *testing.T, crlURL string, issuerCert *x509.Certificate) *x509.Rev
 	if err != nil {
 		t.Fatalf("getting CRL from %s: %s", crlURL, err)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("fetching %s: status code %d", crlURL, resp.StatusCode)
 	}
@@ -110,7 +112,6 @@ func getCRL(t *testing.T, crlURL string, issuerCert *x509.Certificate) *x509.Rev
 	if err != nil {
 		t.Fatalf("reading CRL from %s: %s", crlURL, err)
 	}
-	resp.Body.Close()
 
 	list, err := x509.ParseRevocationList(body)
 	if err != nil {

--- a/test/integration/wfe_test.go
+++ b/test/integration/wfe_test.go
@@ -25,6 +25,8 @@ func TestWFECORS(t *testing.T) {
 	client := &http.Client{}
 	resp, err := client.Do(getReq)
 	test.AssertNotError(t, err, "GET directory")
+	defer resp.Body.Close()
+
 	test.AssertEquals(t, resp.StatusCode, http.StatusOK)
 
 	// We expect that the response has the correct Access-Control-Allow-Origin

--- a/test/load-generator/state.go
+++ b/test/load-generator/state.go
@@ -513,6 +513,7 @@ func (s *State) post(
 		ns.addNonce(newNonce)
 	}
 	if resp.StatusCode != expectedCode {
+		defer resp.Body.Close()
 		return nil, fmt.Errorf("POST %q returned HTTP status %d, expected %d",
 			url, resp.StatusCode, expectedCode)
 	}

--- a/test/ocsp/checkari/main.go
+++ b/test/ocsp/checkari/main.go
@@ -79,6 +79,7 @@ func checkARI(baseURL string, certPath string) (*core.RenewalInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	ri, err := parseResponse(resp)
 	if err != nil {
@@ -93,6 +94,7 @@ func getARIURL(directory string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/tools/crldps/main.go
+++ b/tools/crldps/main.go
@@ -81,7 +81,9 @@ func main() {
 		resp, err := client.Get(crldp)
 		if err != nil {
 			log.Fatalf("Error checking for existence of zero shard %q: %s", crldp, err)
-		} else if resp.StatusCode != http.StatusNotFound {
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
 			log.Fatalf("Was unexpectedly able to fetch zero shard %q; please verify that the generated shards are one-indexed", crldp)
 		}
 	}
@@ -90,7 +92,9 @@ func main() {
 		resp, err := client.Get(crldp)
 		if err != nil {
 			log.Fatalf("Error checking for existence of higher-numbered shard %q: %s", crldp, err)
-		} else if resp.StatusCode != http.StatusNotFound {
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
 			log.Fatalf("Was unexpectedly able to fetch higher-numbered shard %q; please verify that the -shards flag is correct", crldp)
 		}
 	}
@@ -115,10 +119,12 @@ func fetchAndCheck(crldp string, client http.Client, issuer *x509.Certificate) e
 	resp, err := client.Get(crldp)
 	if err != nil {
 		return fmt.Errorf("error downloading crl: %s", err)
-	} else if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code while downloading crl: %s", http.StatusText(resp.StatusCode))
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code while downloading crl: %s", http.StatusText(resp.StatusCode))
+	}
 
 	crlDer, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/va/http.go
+++ b/va/http.go
@@ -640,6 +640,8 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 		return nil, records, newIPError(records[len(records)-1].AddressUsed, err)
 	}
 
+	defer httpResponse.Body.Close()
+
 	if httpResponse.StatusCode != 200 {
 		return nil, records, newIPError(records[len(records)-1].AddressUsed, berrors.UnauthorizedError("Invalid response from %s: %d",
 			records[len(records)-1].URL, httpResponse.StatusCode))
@@ -648,10 +650,6 @@ func (va *ValidationAuthorityImpl) processHTTPValidation(
 	// At this point we've made a successful request (be it from a retry or
 	// otherwise) and can read and process the response body.
 	body, err := io.ReadAll(&io.LimitedReader{R: httpResponse.Body, N: maxResponseSize})
-	closeErr := httpResponse.Body.Close()
-	if err == nil {
-		err = closeErr
-	}
 	if err != nil {
 		return nil, records, newIPError(records[len(records)-1].AddressUsed, berrors.UnauthorizedError("Error reading HTTP response body: %v", err))
 	}


### PR DESCRIPTION
Ensure we're closing all of our HTTP response bodies.