### PR TITLE
va: Add experimental VA for testing Hickory

### DIFF
--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -59,7 +59,7 @@ type Config struct {
 		// Leaving this value zero means the VA won't early-cancel slow remotes.
 		SlowRemoteTimeout config.Duration
 
-		// ExperimentalVA configures an optional parallel VA that shadows the
+		// ExperimentalVA configures an optional parallel VA that repeats the
 		// primary VA's DCV and CAA checks using an alternative DNS resolver,
 		// emitting comparison metrics without affecting the real validation
 		// decision.
@@ -70,9 +70,13 @@ type Config struct {
 			// DNSTimeout is the timeout for DNS queries. Defaults to the
 			// primary VA's DNSTimeout if unset.
 			DNSTimeout config.Duration `validate:"omitempty"`
-			// SampleRate controls the rate of validations that are shadowed
-			// (0.0 to 1.0). A value of 0 disables shadowing.
+			// SampleRate controls the rate of validations that are repeated
+			// (0.0 to 1.0). A value of 0 disables it entirely, while 1 repeats
+			// all validations.
 			SampleRate float64 `validate:"min=0,max=1"`
+			// Timeout is the timeout for experimental validation operations.
+			// This should be configured to match the RA->VA timeout.
+			Timeout config.Duration `validate:"required"`
 		}
 		Features features.Config
 	}
@@ -149,6 +153,7 @@ func main() {
 
 	var experimentalVA *va.ValidationAuthorityImpl
 	var experimentalVASampleRate float64
+	var experimentalVATimeout time.Duration
 	if c.VA.ExperimentalVA != nil {
 		servers, err := bdns.StartDynamicProvider(c.VA.ExperimentalVA.DNSProvider, 60*time.Second, "tcp")
 		cmd.FailOnError(err, "Couldn't start experimental dynamic DNS server resolver")
@@ -190,9 +195,11 @@ func main() {
 			c.VA.DNSAllowLoopbackAddresses,
 			nil,
 			0,
+			0,
 		)
 		cmd.FailOnError(err, "Unable to create experimental VA")
 		experimentalVASampleRate = c.VA.ExperimentalVA.SampleRate
+		experimentalVATimeout = c.VA.ExperimentalVA.Timeout.Duration
 	}
 
 	vai, err := va.NewValidationAuthorityImpl(
@@ -211,6 +218,7 @@ func main() {
 		c.VA.DNSAllowLoopbackAddresses,
 		experimentalVA,
 		experimentalVASampleRate,
+		experimentalVATimeout,
 	)
 	cmd.FailOnError(err, "Unable to create VA server")
 

--- a/cmd/remoteva/main.go
+++ b/cmd/remoteva/main.go
@@ -132,6 +132,7 @@ func main() {
 		c.RVA.DNSAllowLoopbackAddresses,
 		nil,
 		0,
+		0,
 	)
 	cmd.FailOnError(err, "Unable to create Remote-VA server")
 

--- a/va/caa.go
+++ b/va/caa.go
@@ -105,23 +105,25 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 		prob.Detail = fmt.Sprintf("While processing CAA for %s: %s", ident.Value, prob.Detail)
 	}
 
-	var localResult remoteResult
-	if va.shouldDispatchExperiment() {
-		defer func() {
-			va.dispatchExperiment(opCAA, localResult, func(ctx context.Context) (remoteResult, error) {
-				return va.experimentalVA.DoCAA(ctx, req)
-			})
-		}()
-	}
-
 	// Capture the local validation result for experimental resolver comparison
 	// before MPIC can influence the outcome.
-	localResult, err = bgrpc.CAAResultToPB(filterProblemDetails(prob), va.perspective, va.rir)
+	localResult, err := bgrpc.CAAResultToPB(filterProblemDetails(prob), va.perspective, va.rir)
 	if err != nil {
 		return nil, err
 	}
+
+	if va.shouldRunExperiment() {
+		go va.runExperiment(
+			ctx,
+			opCAA,
+			proto.Clone(localResult).(*vapb.IsCAAValidResponse),
+			func(ctx context.Context) (remoteResult, error) {
+				return va.experimentalVA.DoCAA(ctx, req)
+			})
+	}
+
 	if prob != nil {
-		return localResult.(*vapb.IsCAAValidResponse), nil
+		return localResult, nil
 	}
 
 	if va.isPrimaryVA() {

--- a/va/va.go
+++ b/va/va.go
@@ -217,6 +217,7 @@ type ValidationAuthorityImpl struct {
 	allowRestrictedAddrs     bool
 	experimentalVA           *ValidationAuthorityImpl
 	experimentalVASampleRate float64
+	experimentalVATimeout    time.Duration
 
 	metrics *vaMetrics
 }
@@ -241,6 +242,7 @@ func NewValidationAuthorityImpl(
 	allowRestrictedAddrs bool,
 	experimentalVA *ValidationAuthorityImpl,
 	experimentalVASampleRate float64,
+	experimentalVATimeout time.Duration,
 ) (*ValidationAuthorityImpl, error) {
 
 	if len(accountURIPrefixes) == 0 {
@@ -290,43 +292,46 @@ func NewValidationAuthorityImpl(
 		allowRestrictedAddrs:     allowRestrictedAddrs,
 		experimentalVA:           experimentalVA,
 		experimentalVASampleRate: experimentalVASampleRate,
+		experimentalVATimeout:    experimentalVATimeout,
 	}
 
 	return va, nil
 }
 
-func (va *ValidationAuthorityImpl) shouldDispatchExperiment() bool {
+func (va *ValidationAuthorityImpl) shouldRunExperiment() bool {
 	return va.experimentalVA != nil && rand.Float64() < va.experimentalVASampleRate
 }
 
-func (va *ValidationAuthorityImpl) dispatchExperiment(operation string, primary remoteResult, experimentFunc func(context.Context) (remoteResult, error)) {
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), va.slowRemoteTimeout)
-		defer cancel()
+// runExperiment compares the primary VA's local result against the experimental
+// VA's result and records a concurrence metric. On disagreement, it logs a
+// structured event with both results. The primary argument must be non-nil.
+// Callers should invoke this in a goroutine.
+func (va *ValidationAuthorityImpl) runExperiment(ctx context.Context, operation string, primary remoteResult, experimentFunc func(context.Context) (remoteResult, error)) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), va.experimentalVATimeout)
+	defer cancel()
 
-		experimentResult, err := experimentFunc(ctx)
+	experimentResult, err := experimentFunc(ctx)
 
-		primaryPassed := primary.GetProblem() == nil
-		experimentPassed := (err == nil) && (experimentResult.GetProblem() == nil)
+	primaryPassed := primary.GetProblem() == nil
+	experimentPassed := (err == nil) && (experimentResult.GetProblem() == nil)
 
-		if primaryPassed == experimentPassed {
-			va.metrics.experimentConcurrence.WithLabelValues(operation, "true").Inc()
-			return
-		}
-		va.metrics.experimentConcurrence.WithLabelValues(operation, "false").Inc()
+	if primaryPassed == experimentPassed {
+		va.metrics.experimentConcurrence.WithLabelValues(operation, "true").Inc()
+		return
+	}
+	va.metrics.experimentConcurrence.WithLabelValues(operation, "false").Inc()
 
-		logArgs := map[string]any{
-			"operation":        operation,
-			"primaryPassed":    primaryPassed,
-			"primaryResult":    primary,
-			"experimentPassed": experimentPassed,
-			"experimentResult": experimentResult,
-		}
-		if err != nil {
-			logArgs["experimentErr"] = err.Error()
-		}
-		va.log.AuditInfo("Primary VA disagreed with experimental VA", logArgs)
-	}()
+	logArgs := map[string]any{
+		"operation":        operation,
+		"primaryPassed":    primaryPassed,
+		"primaryResult":    primary,
+		"experimentPassed": experimentPassed,
+		"experimentResult": experimentResult,
+	}
+	if err != nil {
+		logArgs["experimentErr"] = err.Error()
+	}
+	va.log.AuditInfo("Primary VA disagreed with experimental VA", logArgs)
 }
 
 // maxAllowedFailures returns the maximum number of allowed failures
@@ -819,23 +824,25 @@ func (va *ValidationAuthorityImpl) DoDCV(ctx context.Context, req *vapb.PerformV
 		prob = detailedError(err)
 	}
 
-	var localResult remoteResult
-	if va.shouldDispatchExperiment() {
-		defer func() {
-			va.dispatchExperiment(opDCV, localResult, func(ctx context.Context) (remoteResult, error) {
-				return va.experimentalVA.DoDCV(ctx, req)
-			})
-		}()
-	}
-
 	// Capture the local validation result for experimental resolver comparison
 	// before MPIC can influence the outcome.
-	localResult, err = bgrpc.ValidationResultToPB(records, filterProblemDetails(prob), va.perspective, va.rir)
+	localResult, err := bgrpc.ValidationResultToPB(records, filterProblemDetails(prob), va.perspective, va.rir)
 	if err != nil {
 		return nil, err
 	}
+
+	if va.shouldRunExperiment() {
+		go va.runExperiment(
+			ctx,
+			opDCV,
+			proto.Clone(localResult).(*vapb.ValidationResult),
+			func(ctx context.Context) (remoteResult, error) {
+				return va.experimentalVA.DoDCV(ctx, req)
+			})
+	}
+
 	if prob != nil {
-		return localResult.(*vapb.ValidationResult), nil
+		return localResult, nil
 	}
 
 	if va.isPrimaryVA() {

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -154,6 +154,7 @@ func setup(srv *httptest.Server, userAgent string, remoteVAs []RemoteVA, fakeDNS
 		true,
 		nil,
 		0,
+		0,
 	)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create validation authority: %v", err))
@@ -331,6 +332,7 @@ func TestNewValidationAuthorityImplWithDuplicateRemotes(t *testing.T) {
 		time.Second,
 		true,
 		nil,
+		0,
 		0,
 	)
 	test.AssertError(t, err, "NewValidationAuthorityImpl allowed duplicate remote perspectives")


### PR DESCRIPTION
Introduce an optional parallel VA instance that repeats the primary VA's DCV and CAA checks using an alternative DNS resolver. This enables side-by-side comparison of DNS resolution behavior (e.g. Unbound vs Hickory) without affecting validation decisions.

Validation shadowing is performed according to a configurable sampling rate (0.0 to 1.0), giving us the ability to control what percentage of our traffic will also hit experimental resolvers and keep our log volumes reasonable.

Fixes #8677