### PR TITLE
ra: remove MaxNames config field

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -81,15 +81,6 @@ type Config struct {
 			OverridesFromDB bool
 		}
 
-		// MaxNames is the maximum number of subjectAltNames in a single cert.
-		// The value supplied MUST be greater than 0 and no more than 100. These
-		// limits are per section 7.1 of our combined CP/CPS, under "DV-SSL
-		// Subscriber Certificate". The value must match the CA and WFE
-		// configurations.
-		//
-		// Deprecated: Set ValidationProfiles[*].MaxNames instead.
-		MaxNames int `validate:"omitempty,min=1,max=100"`
-
 		// ValidationProfiles is a map of validation profiles to their
 		// respective issuance allow lists. If a profile is not included in this
 		// mapping, it cannot be used by any account. If this field is left
@@ -241,16 +232,6 @@ func main() {
 		cmd.Fail("At least one profile must be configured")
 	}
 
-	// TODO(#7993): Remove this fallback and make ValidationProfile.MaxNames a
-	// required config field. We don't do any validation on the value of this
-	// top-level MaxNames because that happens inside the call to
-	// NewValidationProfiles below.
-	for _, pc := range c.RA.ValidationProfiles {
-		if pc.MaxNames == 0 {
-			pc.MaxNames = c.RA.MaxNames
-		}
-	}
-
 	validationProfiles, err := ra.NewValidationProfiles(c.RA.DefaultProfileName, c.RA.ValidationProfiles)
 	cmd.FailOnError(err, "Failed to load validation profiles")
 
@@ -297,7 +278,6 @@ func main() {
 		kp,
 		limiter,
 		txnBuilder,
-		c.RA.MaxNames,
 		validationProfiles,
 		pubc,
 		c.RA.FinalizeTimeout.Duration,

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -121,7 +121,6 @@ func NewRegistrationAuthorityImpl(
 	keyPolicy goodkey.KeyPolicy,
 	limiter *ratelimits.Limiter,
 	txnBuilder *ratelimits.TransactionBuilder,
-	maxNames int,
 	profiles *validationProfiles,
 	pubc pubpb.PublisherClient,
 	finalizeTimeout time.Duration,
@@ -257,7 +256,7 @@ type ValidationProfileConfig struct {
 	// limits are per section 7.1 of our combined CP/CPS, under "DV-SSL
 	// Subscriber Certificate". The value must be less than or equal to the
 	// global (i.e. not per-profile) value configured in the CA.
-	MaxNames int `validate:"omitempty,min=1,max=100"`
+	MaxNames int `validate:"required,min=1,max=100"`
 	// AllowList specifies the path to a YAML file containing a list of
 	// account IDs permitted to use this profile. If no path is
 	// specified, the profile is open to all accounts. If the file

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -381,7 +381,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 
 	ra := NewRegistrationAuthorityImpl(
 		fc, log, stats,
-		1, testKeyPolicy, limiter, txnBuilder, 100,
+		1, testKeyPolicy, limiter, txnBuilder,
 		profiles, nil, 5*time.Minute, ctp, nil)
 	ra.SA = sa
 	ra.VA = va


### PR DESCRIPTION
This has been moved to a per-profile config, and the change has been made in prod.

Followup to #7993 