### PR TITLE
Replace docker/login-action with inline docker login

### DIFF
--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -76,10 +76,10 @@ jobs:
           persist-credentials: false
 
       - name: Docker Login
-        run: printenv $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
+        run: printenv $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin docker.io
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME}}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD}}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       # Print the env variable being used to pull the docker image. For
       # informational use.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -75,11 +75,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # Log into dockerhub to avoid rate limits.
       - name: Docker Login
         run: printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin docker.io
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        # This task is best-effort, if it fails, e.g. due to running from a fork, it's no big deal.
+        continue-on-error: true
 
       # Print the env variable being used to pull the docker image. For
       # informational use.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -76,7 +76,7 @@ jobs:
           persist-credentials: false
 
       - name: Docker Login
-        run: printenv $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin docker.io
+        run: printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin docker.io
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -75,18 +75,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Docker Login
-        # You may pin to the exact commit or the version.
-        # uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
-        uses: docker/login-action@v3.6.0
-        with:
-          # Username used to log against the Docker registry
-          username: ${{ secrets.DOCKER_USERNAME}}
-          # Password or personal access token used to log against the Docker registry
-          password: ${{ secrets.DOCKER_PASSWORD}}
-          # Log out from the Docker registry at the end of a job
-          logout: true
-        continue-on-error: true
+      - name: Login to GitHub Container Registry
+        run: printenv GITHUB_TOKEN | docker login -u "$GITHUB_ACTOR" --password-stdin ghcr.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Print the env variable being used to pull the docker image. For
       # informational use.

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -75,10 +75,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Login to GitHub Container Registry
-        run: printenv GITHUB_TOKEN | docker login -u "$GITHUB_ACTOR" --password-stdin ghcr.io
+      - name: Docker Login
+        run: printenv $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME}}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD}}
 
       # Print the env variable being used to pull the docker image. For
       # informational use.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,9 @@ jobs:
         run: docker buildx build . --build-arg "GO_VERSION=${{ matrix.GO_VERSION }}" -f test/ct-test-srv/Dockerfile -t "ghcr.io/letsencrypt/ct-test-srv:${GITHUB_REF_NAME}-go${{ matrix.GO_VERSION }}"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: printenv GITHUB_TOKEN | docker login -u "$GITHUB_ACTOR" --password-stdin ghcr.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Boulder container
         run: docker push "ghcr.io/letsencrypt/boulder:${GITHUB_REF_NAME}-go${{ matrix.GO_VERSION }}"


### PR DESCRIPTION
Drop dependency on docker/login-action by replacing it with a simple `docker login` command. Just reduces our supply chain exposure a bit.

This is done in a way consistent with GitHub's suggestions https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#using-secrets-in-a-workflow, in particular: the secret is passed to the inner step as an environment variable; `printenv` prevents the secret from being visible in the process list, and is piped over stdin to `docker login`.