### PR TITLE
iana: Fix GitHub Action

### DIFF
--- a/.github/workflows/check-iana-registries.yml
+++ b/.github/workflows/check-iana-registries.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout iana/data from main branch
         uses: actions/checkout@v6
         with:
-          persist-credentials: false
           sparse-checkout: iana/data
 
       # If the branch already exists, this will fail, which will remind us about


### PR DESCRIPTION
The GitHub Action to update IANA special-purpose address registries depends on persisting credentials in order to create a PR; this was disabled in #8537.