### PR TITLE
grpc: Advertise h2 support in ALPN

### DIFF
--- a/grpc/creds/creds.go
+++ b/grpc/creds/creds.go
@@ -69,7 +69,6 @@ func (tc *clientTransportCredentials) ClientHandshake(ctx context.Context, addr 
 		ServerName:   host,
 		RootCAs:      tc.roots,
 		Certificates: tc.clients,
-		NextProtos:   []string{"h2"},
 	})
 	err = conn.HandshakeContext(ctx)
 	if err != nil {

--- a/grpc/creds/creds_test.go
+++ b/grpc/creds/creds_test.go
@@ -106,9 +106,9 @@ func TestClientTransportCredentials(t *testing.T) {
 	roots.AddCert(certB)
 
 	serverA := httptest.NewUnstartedServer(nil)
-	serverA.TLS = &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{derA}, PrivateKey: priv}}, NextProtos: []string{"h2"}}
+	serverA.TLS = &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{derA}, PrivateKey: priv}}}
 	serverB := httptest.NewUnstartedServer(nil)
-	serverB.TLS = &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{derB}, PrivateKey: priv}}, NextProtos: []string{"h2"}}
+	serverB.TLS = &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{derB}, PrivateKey: priv}}}
 
 	tc := NewClientCredentials(roots, []tls.Certificate{}, "")
 


### PR DESCRIPTION
A compliant HTTP/2 server advertises support for h2 in the TLS ALPN
field. See https://datatracker.ietf.org/doc/html/rfc7540#section-3.1.

grpc-go did not always check for the presence and validity of this
extension. It did so in a relatively recent version.

This didn't affect boulder, because neither a boulder client nor boulder
server was advertising the ALPN.

However, now that we're trying to update Consul, we run into a problem
with failing healthchecks. Consul now uses an upgraded grpc-go with ALPN
enforcement. When Consul makes a gRPC healthcheck against boulder, it
rejects the healthcheck due to the missing ALPN.

Fix this problem by appropriately advertising the h2 ALPN.

Normally, grpc-go would handle this for us, but because we're handling
a raw tls.Config struct, we have to do it ourselves.
