### PR TITLE
Remove registrations.LockCol

### DIFF
--- a/sa/db/01-boulder_sa.sql
+++ b/sa/db/01-boulder_sa.sql
@@ -198,7 +198,6 @@ CREATE TABLE `registrations` (
   `jwk` mediumblob NOT NULL,
   `jwk_sha256` varchar(255) NOT NULL,
   `agreement` varchar(255) NOT NULL,
-  `LockCol` bigint(20) NOT NULL DEFAULT 0,
   `createdAt` datetime NOT NULL,
   `status` varchar(255) NOT NULL DEFAULT 'valid',
   PRIMARY KEY (`id`),

--- a/sa/db/01-boulder_sa_next.sql
+++ b/sa/db/01-boulder_sa_next.sql
@@ -202,7 +202,6 @@ CREATE TABLE `registrations` (
   `jwk` mediumblob NOT NULL,
   `jwk_sha256` varchar(255) NOT NULL,
   `agreement` varchar(255) NOT NULL,
-  `LockCol` bigint(20) NOT NULL DEFAULT 0,
   `createdAt` datetime NOT NULL,
   `status` varchar(255) NOT NULL DEFAULT 'valid',
   PRIMARY KEY (`id`),
@@ -245,5 +244,4 @@ CREATE TABLE `serials` (
 
 ALTER TABLE `certificateStatus` DROP COLUMN `subscriberApproved`;
 ALTER TABLE `certificateStatus` DROP COLUMN `LockCol`;
-ALTER TABLE `registrations` DROP COLUMN `LockCol`;
 ALTER TABLE `revokedCertificates` ADD KEY `serial` (`serial`);


### PR DESCRIPTION
This column has been dropped in prod, so we can remove it from db, and remove the ALTER TABLE statement from db-next.

Fixes https://github.com/letsencrypt/boulder/issues/7934

The corresponding production changes were made in IN-11527