### PR TITLE
bump pkimetal to v1.41.0 and ignore new ctlint warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       - bouldernet
 
   bpkimetal:
-    image: ghcr.io/pkimetal/pkimetal:v1.20.0
+    image: ghcr.io/pkimetal/pkimetal:v1.41.0
     networks:
       - bouldernet
 

--- a/test/config-next/zlint.toml
+++ b/test/config-next/zlint.toml
@@ -18,7 +18,10 @@ ignore_lints = [
   # Some linters continue to complain about the lack of an AIA OCSP URI, even
   # when a CRLDP is present.
   "certlint:br_certificates_must_include_an_http_url_of_the_ocsp_responder",
-  "x509lint:no_ocsp_over_http"
+  "x509lint:no_ocsp_over_http",
+  # ctlint requires CCADB data to verify SCT signatures; our test issuers are
+  # not in CCADB so this warning fires for every issued certificate.
+  "ctlint:cannot_verify_sct_signature_without_issuer_spki,_which_could_not_be_found_in_the_available_ccadb_data",
 ]
 
 [e_pkimetal_lint_cabf_serverauth_crl]

--- a/test/config/zlint.toml
+++ b/test/config/zlint.toml
@@ -15,6 +15,9 @@ ignore_lints = [
   # issued under the "classic" profile, but have removed it from our "tlsserver"
   # and "shortlived" profiles.
   "pkilint:cabf.serverauth.subscriber_rsa_digitalsignature_and_keyencipherment_present",
+  # ctlint requires CCADB data to verify SCT signatures; our test issuers are
+  # not in CCADB so this warning fires for every issued certificate.
+  "ctlint:cannot_verify_sct_signature_without_issuer_spki,_which_could_not_be_found_in_the_available_ccadb_data",
 ]
 
 [e_pkimetal_lint_cabf_serverauth_crl]


### PR DESCRIPTION
Updates the integration-test pkimetal sidecar from v1.20.0 to v1.41.0. 

The upgraded ctlint throws a new warning, "Cannot verify SCT signature without issuer SPKI, which could not be found in the available CCADB data", because our test PKI is of course not in its CCADB data, so ignore it.