### PR TITLE
sa: deprecate parallelismPerRPC

### DIFF
--- a/cmd/boulder-sa/main.go
+++ b/cmd/boulder-sa/main.go
@@ -24,7 +24,7 @@ type Config struct {
 
 		Features features.Config
 
-		// Max simultaneous SQL queries caused by a single RPC.
+		// Deprecated and unused.
 		ParallelismPerRPC int `validate:"omitempty,min=1"`
 		// LagFactor is how long to sleep before retrying a read request that may
 		// have failed solely due to replication lag.
@@ -79,13 +79,11 @@ func main() {
 
 	clk := clock.New()
 
-	parallel := max(c.SA.ParallelismPerRPC, 1)
-
 	tls, err := c.SA.TLS.Load(scope)
 	cmd.FailOnError(err, "TLS config")
 
 	saroi, err := sa.NewSQLStorageAuthorityRO(
-		dbReadOnlyMap, dbIncidentsMap, scope, parallel, c.SA.LagFactor.Duration, clk, logger)
+		dbReadOnlyMap, dbIncidentsMap, scope, c.SA.LagFactor.Duration, clk, logger)
 	cmd.FailOnError(err, "Failed to create read-only SA impl")
 
 	sai, err := sa.NewSQLStorageAuthorityWrapping(saroi, dbMap, scope)

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -339,7 +339,7 @@ func TestGetAndProcessCerts(t *testing.T) {
 	fc.Set(fc.Now().Add(time.Hour))
 
 	checker := newChecker(saDbMap, fc, pa, kp, time.Hour, testValidityDurations, nil, blog.NewMock())
-	sa, err := sa.NewSQLStorageAuthority(saDbMap, saDbMap, nil, 1, 0, fc, blog.NewMock(), metrics.NoopRegisterer)
+	sa, err := sa.NewSQLStorageAuthority(saDbMap, saDbMap, nil, 0, fc, blog.NewMock(), metrics.NoopRegisterer)
 	test.AssertNotError(t, err, "Couldn't create SA to insert certificates")
 	saCleanUp := test.ResetBoulderTestDatabase(t)
 	defer func() {

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -307,7 +307,7 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	if err != nil {
 		t.Fatalf("Failed to create dbMap: %s", err)
 	}
-	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 1, 0, fc, log, metrics.NoopRegisterer)
+	ssa, err := sa.NewSQLStorageAuthority(dbMap, dbMap, nil, 0, fc, log, metrics.NoopRegisterer)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -86,14 +86,13 @@ func NewSQLStorageAuthority(
 	dbMap *db.WrappedMap,
 	dbReadOnlyMap *db.WrappedMap,
 	dbIncidentsMap *db.WrappedMap,
-	parallelismPerRPC int,
 	lagFactor time.Duration,
 	clk clock.Clock,
 	logger blog.Logger,
 	stats prometheus.Registerer,
 ) (*SQLStorageAuthority, error) {
 	ssaro, err := NewSQLStorageAuthorityRO(
-		dbReadOnlyMap, dbIncidentsMap, stats, parallelismPerRPC, lagFactor, clk, logger)
+		dbReadOnlyMap, dbIncidentsMap, stats, lagFactor, clk, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/sa/sa_test.go
+++ b/sa/sa_test.go
@@ -107,7 +107,7 @@ func initSA(t testing.TB) (*SQLStorageAuthority, clock.FakeClock) {
 	fc := clock.NewFake()
 	fc.Set(mustTime("2015-03-04 05:00"))
 
-	saro, err := NewSQLStorageAuthorityRO(dbMap, dbIncidentsMap, metrics.NoopRegisterer, 1, 0, fc, log)
+	saro, err := NewSQLStorageAuthorityRO(dbMap, dbIncidentsMap, metrics.NoopRegisterer, 0, fc, log)
 	if err != nil {
 		t.Fatalf("Failed to create SA: %s", err)
 	}

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -37,11 +37,6 @@ type SQLStorageAuthorityRO struct {
 	dbReadOnlyMap  *db.WrappedMap
 	dbIncidentsMap *db.WrappedMap
 
-	// For RPCs that generate multiple, parallelizable SQL queries, this is the
-	// max parallelism they will use (to avoid consuming too many MariaDB
-	// threads).
-	parallelismPerRPC int
-
 	// lagFactor is the amount of time we're willing to delay before retrying a
 	// request that may have failed due to replication lag. For example, a user
 	// might create a new account and then immediately create a new order, but
@@ -70,7 +65,6 @@ func NewSQLStorageAuthorityRO(
 	dbReadOnlyMap *db.WrappedMap,
 	dbIncidentsMap *db.WrappedMap,
 	stats prometheus.Registerer,
-	parallelismPerRPC int,
 	lagFactor time.Duration,
 	clk clock.Clock,
 	logger blog.Logger,
@@ -81,13 +75,12 @@ func NewSQLStorageAuthorityRO(
 	}, []string{"method", "result"})
 
 	ssaro := &SQLStorageAuthorityRO{
-		dbReadOnlyMap:     dbReadOnlyMap,
-		dbIncidentsMap:    dbIncidentsMap,
-		parallelismPerRPC: parallelismPerRPC,
-		lagFactor:         lagFactor,
-		clk:               clk,
-		log:               logger,
-		lagFactorCounter:  lagFactorCounter,
+		dbReadOnlyMap:    dbReadOnlyMap,
+		dbIncidentsMap:   dbIncidentsMap,
+		lagFactor:        lagFactor,
+		clk:              clk,
+		log:              logger,
+		lagFactorCounter: lagFactorCounter,
 	}
 
 	return ssaro, nil

--- a/test/config-next/sa.json
+++ b/test/config-next/sa.json
@@ -12,7 +12,6 @@
 			"dbConnectFile": "test/secrets/incidents_dburl",
 			"maxOpenConns": 100
 		},
-		"ParallelismPerRPC": 20,
 		"lagFactor": "200ms",
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",


### PR DESCRIPTION
This was used when querying for rate limit calculations from the database. Last usage was removed in #7858