### PR TITLE
db: remove IsNoRows

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -2,6 +2,8 @@ package notmain
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -222,7 +224,7 @@ func (bkr *badKeyRevoker) invoke(ctx context.Context) (work bool, err error) {
 	// select a row to process
 	unchecked, err := bkr.selectUncheckedKey(ctx)
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return true, nil
 		}
 		return false, err

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -3,6 +3,8 @@ package notmain
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -76,7 +78,7 @@ func TestSelectUncheckedRows(t *testing.T) {
 	test.AssertEquals(t, count, 0)
 	_, err = bkr.selectUncheckedKey(ctx)
 	test.AssertError(t, err, "selectUncheckedKey didn't fail with no rows to process")
-	test.Assert(t, db.IsNoRows(err), "returned error is not sql.ErrNoRows")
+	test.Assert(t, errors.Is(err, sql.ErrNoRows), "returned error is not sql.ErrNoRows")
 
 	// insert a blocked key that's due to be checked
 	insertBlockedRow(t, dbMap, fcBeforeRepLag(fc, bkr), hashB, 1, false)
@@ -211,7 +213,7 @@ func TestFindUnrevokedNoRows(t *testing.T) {
 		maxExpectedReplicationLag: time.Second * 22,
 	}
 	_, err = bkr.findUnrevoked(ctx, uncheckedBlockedKey{KeyHash: hashA})
-	test.Assert(t, db.IsNoRows(err), "expected NoRows error")
+	test.Assert(t, errors.Is(err, sql.ErrNoRows), "expected NoRows error")
 }
 
 func TestFindUnrevoked(t *testing.T) {

--- a/db/map.go
+++ b/db/map.go
@@ -43,13 +43,6 @@ func (e ErrDatabaseOp) Unwrap() error {
 	return e.Err
 }
 
-// IsNoRows is a utility function for determining if an error wraps the go sql
-// package's ErrNoRows, which is returned when a Scan operation has no more
-// results to return, and as such is returned by many borp methods.
-func IsNoRows(err error) bool {
-	return errors.Is(err, sql.ErrNoRows)
-}
-
 // IsDuplicate is a utility function for determining if an error wrap MySQL's
 // Error 1062: Duplicate entry. This error is returned when inserting a row
 // would violate a unique key constraint.

--- a/db/map_test.go
+++ b/db/map_test.go
@@ -49,39 +49,6 @@ func TestErrDatabaseOpError(t *testing.T) {
 	}
 }
 
-func TestIsNoRows(t *testing.T) {
-	testCases := []struct {
-		name           string
-		err            ErrDatabaseOp
-		expectedNoRows bool
-	}{
-		{
-			name: "underlying err is sql.ErrNoRows",
-			err: ErrDatabaseOp{
-				Op:    "test",
-				Table: "testTable",
-				Err:   fmt.Errorf("some wrapper around %w", sql.ErrNoRows),
-			},
-			expectedNoRows: true,
-		},
-		{
-			name: "underlying err is not sql.ErrNoRows",
-			err: ErrDatabaseOp{
-				Op:    "test",
-				Table: "testTable",
-				Err:   fmt.Errorf("some wrapper around %w", errors.New("lots of rows. too many rows.")),
-			},
-			expectedNoRows: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			test.AssertEquals(t, IsNoRows(tc.err), tc.expectedNoRows)
-		})
-	}
-}
-
 func TestIsDuplicate(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/sa/sa.go
+++ b/sa/sa.go
@@ -167,7 +167,7 @@ func (ssa *SQLStorageAuthority) UpdateRegistrationKey(ctx context.Context, req *
 
 		updatedRegistrationModel, err := selectRegistration(ctx, tx, "id", req.RegistrationID)
 		if err != nil {
-			if db.IsNoRows(err) {
+			if errors.Is(err, sql.ErrNoRows) {
 				return nil, berrors.NotFoundError("registration with ID '%d' not found", req.RegistrationID)
 			}
 			return nil, err
@@ -405,7 +405,7 @@ func (ssa *SQLStorageAuthority) DeactivateRegistration(ctx context.Context, req 
 
 		updatedRegistrationModel, err := selectRegistration(ctx, tx, "id", req.Id)
 		if err != nil {
-			if db.IsNoRows(err) {
+			if errors.Is(err, sql.ErrNoRows) {
 				return nil, berrors.NotFoundError("fetching account %d: no rows found", req.Id)
 			}
 			return nil, fmt.Errorf("fetching account %d: %w", req.Id, err)
@@ -1138,7 +1138,7 @@ func (ssa *SQLStorageAuthority) leaseSpecificCRLShard(ctx context.Context, req *
 			req.IssuerNameID,
 			req.MinShardIdx,
 		)
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			needToInsert = true
 		} else if err != nil {
 			return nil, fmt.Errorf("selecting requested shard: %w", err)
@@ -1455,7 +1455,7 @@ func (ssa *SQLStorageAuthority) AddRateLimitOverride(ctx context.Context, req *s
 		)
 
 		switch {
-		case err != nil && !db.IsNoRows(err):
+		case err != nil && !errors.Is(err, sql.ErrNoRows):
 			// Error querying the database.
 			return nil, fmt.Errorf("querying override for rate limit %d and bucket key %s: %w",
 				req.Override.LimitEnum,
@@ -1463,7 +1463,7 @@ func (ssa *SQLStorageAuthority) AddRateLimitOverride(ctx context.Context, req *s
 				err,
 			)
 
-		case db.IsNoRows(err):
+		case errors.Is(err, sql.ErrNoRows):
 			// Insert a new overrides row.
 			new := overrideModelForPB(req.Override, now, true)
 			err = tx.Insert(ctx, &new)
@@ -1532,7 +1532,7 @@ func (ssa *SQLStorageAuthority) setRateLimitOverride(ctx context.Context, limitE
 			bucketKey,
 		)
 		if err != nil {
-			if db.IsNoRows(err) {
+			if errors.Is(err, sql.ErrNoRows) {
 				return nil, berrors.NotFoundError(
 					"no rate limit override found for limit %d and bucket key %s",
 					limitEnum,

--- a/sa/saro.go
+++ b/sa/saro.go
@@ -2,6 +2,7 @@ package sa
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"math"
@@ -100,14 +101,14 @@ func (ssa *SQLStorageAuthorityRO) GetRegistration(ctx context.Context, req *sapb
 	}
 
 	model, err := selectRegistration(ctx, ssa.dbReadOnlyMap, "id", req.Id)
-	if db.IsNoRows(err) && ssa.lagFactor != 0 {
+	if errors.Is(err, sql.ErrNoRows) && ssa.lagFactor != 0 {
 		// GetRegistration is often called to validate a JWK belonging to a brand
 		// new account whose registrations table row hasn't propagated to the read
 		// replica yet. If we get a NoRows, wait a little bit and retry, once.
 		ssa.clk.Sleep(ssa.lagFactor)
 		model, err = selectRegistration(ctx, ssa.dbReadOnlyMap, "id", req.Id)
 		if err != nil {
-			if db.IsNoRows(err) {
+			if errors.Is(err, sql.ErrNoRows) {
 				ssa.lagFactorCounter.WithLabelValues("GetRegistration", "notfound").Inc()
 			} else {
 				ssa.lagFactorCounter.WithLabelValues("GetRegistration", "other").Inc()
@@ -117,7 +118,7 @@ func (ssa *SQLStorageAuthorityRO) GetRegistration(ctx context.Context, req *sapb
 		}
 	}
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, berrors.NotFoundError("registration with ID '%d' not found", req.Id)
 		}
 		return nil, err
@@ -144,7 +145,7 @@ func (ssa *SQLStorageAuthorityRO) GetRegistrationByKey(ctx context.Context, req 
 	}
 	model, err := selectRegistration(ctx, ssa.dbReadOnlyMap, "jwk_sha256", sha)
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, berrors.NotFoundError("no registrations with public key sha256 %q", sha)
 		}
 		return nil, err
@@ -173,7 +174,7 @@ func (ssa *SQLStorageAuthorityRO) GetSerialMetadata(ctx context.Context, req *sa
 		req.Serial,
 	)
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, berrors.NotFoundError("serial %q not found", req.Serial)
 		}
 		return nil, err
@@ -198,7 +199,7 @@ func (ssa *SQLStorageAuthorityRO) GetCertificate(ctx context.Context, req *sapb.
 	}
 
 	cert, err := SelectCertificate(ctx, ssa.dbReadOnlyMap, req.Serial)
-	if db.IsNoRows(err) {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, berrors.NotFoundError("certificate with serial %q not found", req.Serial)
 	}
 	if err != nil {
@@ -220,7 +221,7 @@ func (ssa *SQLStorageAuthorityRO) GetLintPrecertificate(ctx context.Context, req
 	}
 
 	cert, err := SelectPrecertificate(ctx, ssa.dbReadOnlyMap, req.Serial)
-	if db.IsNoRows(err) {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, berrors.NotFoundError("precertificate with serial %q not found", req.Serial)
 	}
 	if err != nil {
@@ -242,7 +243,7 @@ func (ssa *SQLStorageAuthorityRO) GetCertificateStatus(ctx context.Context, req 
 	}
 
 	certStatus, err := SelectCertificateStatus(ctx, ssa.dbReadOnlyMap, req.Serial)
-	if db.IsNoRows(err) {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, berrors.NotFoundError("certificate status with serial %q not found", req.Serial)
 	}
 	if err != nil {
@@ -265,7 +266,7 @@ func (ssa *SQLStorageAuthorityRO) GetRevocationStatus(ctx context.Context, req *
 
 	status, err := SelectRevocationStatus(ctx, ssa.dbReadOnlyMap, req.Serial)
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, berrors.NotFoundError("certificate status with serial %q not found", req.Serial)
 		}
 		return nil, err
@@ -397,14 +398,14 @@ func (ssa *SQLStorageAuthorityRO) GetOrder(ctx context.Context, req *sapb.OrderR
 	}
 
 	output, err := db.WithTransaction(ctx, ssa.dbReadOnlyMap, txn)
-	if (db.IsNoRows(err) || errors.Is(err, berrors.NotFound)) && ssa.lagFactor != 0 {
+	if (errors.Is(err, sql.ErrNoRows) || errors.Is(err, berrors.NotFound)) && ssa.lagFactor != 0 {
 		// GetOrder is often called shortly after a new order is created, sometimes
 		// before the order or its associated rows have propagated to the read
 		// replica yet. If we get a NoRows, wait a little bit and retry, once.
 		ssa.clk.Sleep(ssa.lagFactor)
 		output, err = db.WithTransaction(ctx, ssa.dbReadOnlyMap, txn)
 		if err != nil {
-			if db.IsNoRows(err) || errors.Is(err, berrors.NotFound) {
+			if errors.Is(err, sql.ErrNoRows) || errors.Is(err, berrors.NotFound) {
 				ssa.lagFactorCounter.WithLabelValues("GetOrder", "notfound").Inc()
 			} else {
 				ssa.lagFactorCounter.WithLabelValues("GetOrder", "other").Inc()
@@ -465,7 +466,7 @@ func (ssa *SQLStorageAuthorityRO) GetOrderForNames(ctx context.Context, req *sap
 					LIMIT 1`,
 		fqdnHash, ssa.clk.Now())
 
-	if db.IsNoRows(err) {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, berrors.NotFoundError("no order matching request found")
 	} else if err != nil {
 		return nil, err
@@ -527,14 +528,14 @@ func (ssa *SQLStorageAuthorityRO) GetAuthorization2(ctx context.Context, req *sa
 		return nil, errIncompleteRequest
 	}
 	obj, err := ssa.dbReadOnlyMap.Get(ctx, authzModel{}, req.Id)
-	if db.IsNoRows(err) && ssa.lagFactor != 0 {
+	if errors.Is(err, sql.ErrNoRows) && ssa.lagFactor != 0 {
 		// GetAuthorization2 is often called shortly after a new order is created,
 		// sometimes before the order's associated authz rows have propagated to the
 		// read replica yet. If we get a NoRows, wait a little bit and retry, once.
 		ssa.clk.Sleep(ssa.lagFactor)
 		obj, err = ssa.dbReadOnlyMap.Get(ctx, authzModel{}, req.Id)
 		if err != nil {
-			if db.IsNoRows(err) {
+			if errors.Is(err, sql.ErrNoRows) {
 				ssa.lagFactorCounter.WithLabelValues("GetAuthorization2", "notfound").Inc()
 			} else {
 				ssa.lagFactorCounter.WithLabelValues("GetAuthorization2", "other").Inc()
@@ -696,7 +697,7 @@ func (ssa *SQLStorageAuthorityRO) KeyBlocked(ctx context.Context, req *sapb.SPKI
 	var id int64
 	err := ssa.dbReadOnlyMap.SelectOne(ctx, &id, `SELECT ID FROM blockedKeys WHERE keyHash = ?`, req.KeyHash)
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return &sapb.Exists{Exists: false}, nil
 		}
 		return nil, err
@@ -715,7 +716,7 @@ func (ssa *SQLStorageAuthorityRO) IncidentsForSerial(ctx context.Context, req *s
 	var activeIncidents []incidentModel
 	_, err := ssa.dbReadOnlyMap.Select(ctx, &activeIncidents, `SELECT * FROM incidents WHERE enabled = 1`)
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return &sapb.Incidents{}, nil
 		}
 		return nil, err
@@ -727,7 +728,7 @@ func (ssa *SQLStorageAuthorityRO) IncidentsForSerial(ctx context.Context, req *s
 		err := ssa.dbIncidentsMap.SelectOne(ctx, &count, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE serial = ?",
 			i.SerialTable), req.Serial)
 		if err != nil {
-			if db.IsNoRows(err) {
+			if errors.Is(err, sql.ErrNoRows) {
 				continue
 			}
 			return nil, err
@@ -870,7 +871,7 @@ func (ssa *SQLStorageAuthorityRO) ReplacementOrderExists(ctx context.Context, re
 		req.Serial,
 	)
 	if err != nil {
-		if db.IsNoRows(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			// No replacement order exists.
 			return &sapb.Exists{Exists: false}, nil
 		}
@@ -1027,7 +1028,7 @@ func (ssa *SQLStorageAuthorityRO) CheckIdentifiersPaused(ctx context.Context, re
 
 	var matches []identifierModel
 	_, err = ssa.dbReadOnlyMap.Select(ctx, &matches, query, args...)
-	if err != nil && !db.IsNoRows(err) {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		// Error querying the database.
 		return nil, err
 	}
@@ -1053,7 +1054,7 @@ func (ssa *SQLStorageAuthorityRO) GetPausedIdentifiers(ctx context.Context, req 
 		LIMIT 15`,
 		req.Id,
 	)
-	if err != nil && !db.IsNoRows(err) {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
 
@@ -1068,7 +1069,7 @@ func (ssa *SQLStorageAuthorityRO) GetRateLimitOverride(ctx context.Context, req 
 	}
 
 	obj, err := ssa.dbReadOnlyMap.Get(ctx, overrideModel{}, req.LimitEnum, req.BucketKey)
-	if db.IsNoRows(err) {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, berrors.NotFoundError(
 			"no rate limit override found for limit %d and bucket key %s",
 			req.LimitEnum,


### PR DESCRIPTION
Its original purpose was to unwrap an ErrDatabaseOp, but we can now do that easily with `errors.Is`. Eliminating the trivial wrapper makes things clearer.

It was originally added in #4585. 