### PR TITLE
cert-checker: remove use of SelectNullInt

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
-	"database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -90,7 +89,6 @@ type reportEntry struct {
 type certDB interface {
 	Select(ctx context.Context, i any, query string, args ...any) ([]any, error)
 	SelectOne(ctx context.Context, i any, query string, args ...any) error
-	SelectNullInt(ctx context.Context, query string, args ...any) (sql.NullInt64, error)
 }
 
 // A function that looks up a precertificate by serial and returns its DER bytes. Used for
@@ -147,8 +145,6 @@ func newChecker(saDbMap certDB,
 // findStartingID returns the lowest `id` in the certificates table within the
 // time window specified. The time window is a half-open interval [begin, end).
 func (c *certChecker) findStartingID(ctx context.Context, begin, end time.Time) (int64, error) {
-	var output sql.NullInt64
-	var err error
 	var retries int
 
 	// Rather than querying `MIN(id)` across that whole window, we query it across the first
@@ -161,8 +157,10 @@ func (c *certChecker) findStartingID(ctx context.Context, begin, end time.Time) 
 	queryEnd := begin.Add(time.Hour)
 
 	for queryBegin.Compare(end) < 0 {
-		output, err = c.dbMap.SelectNullInt(
+		var output *int64
+		err := c.dbMap.SelectOne(
 			ctx,
+			&output,
 			`SELECT MIN(id) FROM certificates
 				WHERE issued >= :begin AND
 					  issued < :end`,
@@ -185,7 +183,7 @@ func (c *certChecker) findStartingID(ctx context.Context, begin, end time.Time) 
 		// MIN() returns NULL if there were no matching rows
 		// https://pkg.go.dev/database/sql#NullInt64
 		// Valid is true if Int64 is not NULL
-		if !output.Valid {
+		if output == nil {
 			// No matching rows, try the next hour
 			queryBegin = queryBegin.Add(time.Hour)
 			queryEnd = queryEnd.Add(time.Hour)
@@ -195,7 +193,7 @@ func (c *certChecker) findStartingID(ctx context.Context, begin, end time.Time) 
 			continue
 		}
 
-		return output.Int64, nil
+		return *output, nil
 	}
 
 	// Fell through the loop without finding a valid ID

--- a/cmd/cert-checker/main_test.go
+++ b/cmd/cert-checker/main_test.go
@@ -9,10 +9,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"database/sql"
 	"encoding/asn1"
 	"encoding/pem"
-	"errors"
 	"log"
 	"math/big"
 	mrand "math/rand/v2"
@@ -389,25 +387,20 @@ func TestGetAndProcessCerts(t *testing.T) {
 // asked for the actual rows.
 type mismatchedCountDB struct{}
 
-// `getCerts` calls `SelectInt` first to determine how many rows there are
-// matching the `getCertsCountQuery` criteria. For this mock we return
-// a non-zero number
-func (db mismatchedCountDB) SelectNullInt(_ context.Context, _ string, _ ...any) (sql.NullInt64, error) {
-	return sql.NullInt64{
-			Int64: 99999,
-			Valid: true,
-		},
-		nil
-}
-
 // `getCerts` then calls `Select` to retrieve the Certificate rows. We pull
 // a dastardly switch-a-roo here and return an empty set
 func (db mismatchedCountDB) Select(_ context.Context, output any, _ string, _ ...any) ([]any, error) {
 	return nil, nil
 }
 
-func (db mismatchedCountDB) SelectOne(_ context.Context, _ any, _ string, _ ...any) error {
-	return errors.New("unimplemented")
+// `getCerts` calls `SelectOne` first to determine how many rows there are
+// matching the `getCertsCountQuery` criteria. For this mock we return
+// a non-zero number
+func (db mismatchedCountDB) SelectOne(_ context.Context, holder any, _ string, _ ...any) error {
+	h := holder.(**int64)
+	var nines int64 = 99999
+	*h = &nines
+	return nil
 }
 
 /*
@@ -445,11 +438,12 @@ type emptyDB struct {
 	certDB
 }
 
-// SelectNullInt is a method that returns a false sql.NullInt64 struct to
-// mock a null DB response
-func (db emptyDB) SelectNullInt(_ context.Context, _ string, _ ...any) (sql.NullInt64, error) {
-	return sql.NullInt64{Valid: false},
-		nil
+// SelectOne is a method that stores `nil` in the passed int64 holder.
+// It's used to mock a null DB response (i.e. MIN across now rows).
+func (db emptyDB) SelectOne(_ context.Context, holder any, _ string, _ ...any) error {
+	h := holder.(**int64)
+	*h = nil
+	return nil
 }
 
 // TestGetCertsNullResults tests that a null response from the database will
@@ -473,16 +467,22 @@ type lateDB struct {
 	selectedACert bool
 }
 
-// SelectNullInt is a method that returns a false sql.NullInt64 struct to
-// mock a null DB response
-func (db *lateDB) SelectNullInt(_ context.Context, _ string, args ...any) (sql.NullInt64, error) {
+// SelectOne is a method that stores `nil` in the passed int64 holder.
+// It's used to mock a null DB response (i.e. MIN across now rows).
+func (db lateDB) SelectOne(_ context.Context, holder any, _ string, args ...any) error {
+	h := holder.(**int64)
+
 	args2 := args[0].(map[string]any)
 	begin := args2["begin"].(time.Time)
 	end := args2["end"].(time.Time)
 	if begin.Compare(db.issuedTime) < 0 && end.Compare(db.issuedTime) > 0 {
-		return sql.NullInt64{Int64: 23, Valid: true}, nil
+		var twentythree int64 = 23
+		*h = &twentythree
+		return nil
 	}
-	return sql.NullInt64{Valid: false}, nil
+
+	*h = nil
+	return nil
 }
 
 func (db *lateDB) Select(_ context.Context, output any, _ string, args ...any) ([]any, error) {
@@ -490,10 +490,6 @@ func (db *lateDB) Select(_ context.Context, output any, _ string, args ...any) (
 	// For expediency we respond with an empty list of certificates; the checker will treat this as if it's
 	// reached the end of the list of certificates to process.
 	return nil, nil
-}
-
-func (db *lateDB) SelectOne(_ context.Context, _ any, _ string, _ ...any) error {
-	return nil
 }
 
 // TestGetCertsLate checks for correct behavior when certificates exist only late in the provided window.


### PR DESCRIPTION
In its place, use SelectOne. This will allow us to remove SelectNullInt from `borp`, since we don't use it elsewhere in Boulder.

Additional context: https://github.com/letsencrypt/borp/pull/13