### PR TITLE
ca: rand.Read is infallible

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -269,7 +269,7 @@ func (ca *certificateAuthorityImpl) IssueCertificate(ctx context.Context, req *c
 		ipStrings = append(ipStrings, ip.String())
 	}
 
-	serialBigInt, err := ca.generateSerialNumber()
+	serialBigInt := ca.generateSerialNumber()
 	if err != nil {
 		return nil, err
 	}
@@ -483,21 +483,19 @@ func (ca *certificateAuthorityImpl) pickIssuer(profileName string, keyAlg x509.P
 
 // generateSerialNumber produces a big.Int which has more than 64 bits of
 // entropy and has the CA's configured one-byte prefix.
-func (ca *certificateAuthorityImpl) generateSerialNumber() (*big.Int, error) {
+func (ca *certificateAuthorityImpl) generateSerialNumber() *big.Int {
 	// We want 136 bits of random number, plus an 8-bit instance id prefix.
 	const randBits = 136
 	serialBytes := make([]byte, randBits/8+1)
 	serialBytes[0] = ca.prefix
-	_, err := rand.Read(serialBytes[1:])
-	if err != nil {
-		err = berrors.InternalServerError("failed to generate serial: %s", err)
-		ca.log.AuditErr("Serial randomness failed", err, nil)
-		return nil, err
-	}
+	// rand.Read is guaranteed since Go 1.24 not to return error (it crashes the program instead)
+	// https://tip.golang.org/doc/go1.24#cryptorandpkgcryptorand
+	// https://pkg.go.dev/crypto/rand@master#Read
+	rand.Read(serialBytes[1:])
 	serialBigInt := big.NewInt(0)
 	serialBigInt = serialBigInt.SetBytes(serialBytes)
 
-	return serialBigInt, nil
+	return serialBigInt
 }
 
 // generateSKID computes the Subject Key Identifier using one of the methods in

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -270,9 +270,6 @@ func (ca *certificateAuthorityImpl) IssueCertificate(ctx context.Context, req *c
 	}
 
 	serialBigInt := ca.generateSerialNumber()
-	if err != nil {
-		return nil, err
-	}
 	serialHex := core.SerialToString(serialBigInt)
 
 	// Step 2: Persist the serial and minimal metadata, to ensure that we never
@@ -491,7 +488,7 @@ func (ca *certificateAuthorityImpl) generateSerialNumber() *big.Int {
 	// rand.Read is guaranteed since Go 1.24 not to return error (it crashes the program instead)
 	// https://tip.golang.org/doc/go1.24#cryptorandpkgcryptorand
 	// https://pkg.go.dev/crypto/rand@master#Read
-	rand.Read(serialBytes[1:])
+	rand.Read(serialBytes[1:]) //nolint:errcheck //rand.Read is infallible
 	serialBigInt := big.NewInt(0)
 	serialBigInt = serialBigInt.SetBytes(serialBytes)
 


### PR DESCRIPTION
We can remove an error return and log message from generateSerialNumber().