### PR TITLE
Remove deprecated Active bool config

### DIFF
--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -141,9 +141,6 @@ func LoadChain(certFiles []string) ([]*Certificate, error) {
 
 // IssuerConfig describes the constraints on and URLs used by a single issuer.
 type IssuerConfig struct {
-	// Deprecated: Populate IssuerConfig.Profiles to ensure "Active"
-	Active bool
-
 	// Profiles is the list of profiles for which this issuer is willing to issue.
 	// The names listed here must match the names of configured profiles (see
 	// cmd/ca/main.go's Config.Issuance.CertProfiles and issuance/cert.go's

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -97,7 +97,6 @@
 			},
 			"issuers": [
 				{
-					"active": true,
 					"profiles": [
 						"legacy"
 					],
@@ -111,7 +110,6 @@
 					}
 				},
 				{
-					"active": true,
 					"profiles": [
 						"legacy",
 						"modern",
@@ -127,7 +125,6 @@
 					}
 				},
 				{
-					"active": false,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-ecdsa-c",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/56560759852043581/",
@@ -138,7 +135,6 @@
 					}
 				},
 				{
-					"active": true,
 					"profiles": [
 						"legacy"
 					],
@@ -152,7 +148,6 @@
 					}
 				},
 				{
-					"active": true,
 					"profiles": [
 						"legacy",
 						"modern",
@@ -168,7 +163,6 @@
 					}
 				},
 				{
-					"active": false,
 					"crlShards": 10,
 					"issuerURL": "http://ca.example.org:4502/int-rsa-c",
 					"crlURLBase": "http://ca.example.org:4501/lets-encrypt-crls/56183656833365902/",


### PR DESCRIPTION
This is the final step in the three-stage change - it has been removed from prod configs.

Follows #8597