### PR TITLE
when GOMEMLIMIT is set, write profiles

### DIFF
--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -81,6 +81,8 @@ var boulderUsage = fmt.Sprintf(`Usage: %s <subcommand> [flags]
 func main() {
 	defer cmd.AuditPanic()
 
+	go memoryMonitor()
+
 	if len(os.Args) <= 1 {
 		// No arguments passed.
 		fmt.Fprint(os.Stderr, boulderUsage)

--- a/cmd/boulder/main.go
+++ b/cmd/boulder/main.go
@@ -81,7 +81,7 @@ var boulderUsage = fmt.Sprintf(`Usage: %s <subcommand> [flags]
 func main() {
 	defer cmd.AuditPanic()
 
-	go memoryMonitor()
+	go cmd.MemoryMonitor()
 
 	if len(os.Args) <= 1 {
 		// No arguments passed.

--- a/cmd/boulder/memorymonitor.go
+++ b/cmd/boulder/memorymonitor.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"time"
+
+	blog "github.com/letsencrypt/boulder/log"
+)
+
+// memoryCheckPeriod indicates how frequently we'll check for high-memory-usage conditions.
+const memoryCheckPeriod = 10 * time.Second
+
+// profileDumpPeriod limits how frequently we will dump profiles to disk.
+const profileDumpPeriod = 1 * time.Hour
+
+// memoryMonitor runs in a loop, checking every 10 seconds if memory use is greater
+// than GOMEMLIMIT. If so, it dumps memory and goroutine profiles to temporary files
+// created by os.CreateTemp, at most once per hour.
+//
+// If GOMEMLIMIT is unset, returns immediately.
+func memoryMonitor() {
+	logger := blog.Get()
+	memLimit := debug.SetMemoryLimit(-1)
+	if memLimit == math.MaxInt64 {
+		return
+	}
+	memLimitU64 := uint64(memLimit) //nolint:gosec // G115: memLimit is not negative
+
+	var lastDump time.Time
+	var memStats runtime.MemStats
+	ticker := time.NewTicker(memoryCheckPeriod)
+	for {
+		<-ticker.C
+
+		if time.Since(lastDump) < profileDumpPeriod {
+			continue
+		}
+
+		runtime.ReadMemStats(&memStats)
+
+		if memStats.Sys-memStats.HeapReleased > memLimitU64 {
+			lastDump = time.Now()
+
+			err := writeProfile(logger, "heap")
+			if err != nil {
+				logger.Errf("writing heap profile: %s", err)
+			}
+			err = writeProfile(logger, "goroutine")
+			if err != nil {
+				logger.Errf("writing goroutine profile: %s", err)
+			}
+		}
+	}
+}
+
+func writeProfile(logger blog.Logger, typ string) error {
+	datestamp := time.Now().Format("20060102T150405")
+	profileFile, err := os.CreateTemp("", fmt.Sprintf("boulder-profile-%s-%s", typ, datestamp))
+	if err != nil {
+		return fmt.Errorf("creating profile file: %s", err)
+	}
+	defer profileFile.Close()
+	logger.Infof("Writing %s profile to %s", typ, profileFile.Name())
+	err = pprof.Lookup(typ).WriteTo(profileFile, 0)
+	if err != nil {
+		return fmt.Errorf("writing profile: %s", err)
+	}
+	return nil
+}

--- a/cmd/memorymonitor.go
+++ b/cmd/memorymonitor.go
@@ -30,21 +30,14 @@ func MemoryMonitor() {
 	}
 	memLimitU64 := uint64(memLimit) //nolint:gosec // G115: memLimit is not negative
 
-	var lastDump time.Time
 	var memStats runtime.MemStats
 	ticker := time.NewTicker(memoryCheckPeriod)
 	for {
 		<-ticker.C
 
-		if time.Since(lastDump) < profileDumpPeriod {
-			continue
-		}
-
 		runtime.ReadMemStats(&memStats)
 
 		if memStats.Sys-memStats.HeapReleased > memLimitU64 {
-			lastDump = time.Now()
-
 			logger := blog.Get()
 			err := writeProfile(logger, "heap")
 			if err != nil {
@@ -54,6 +47,8 @@ func MemoryMonitor() {
 			if err != nil {
 				logger.Errf("writing goroutine profile: %s", err)
 			}
+
+			time.Sleep(profileDumpPeriod)
 		}
 	}
 }

--- a/cmd/memorymonitor.go
+++ b/cmd/memorymonitor.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"
@@ -18,13 +18,12 @@ const memoryCheckPeriod = 10 * time.Second
 // profileDumpPeriod limits how frequently we will dump profiles to disk.
 const profileDumpPeriod = 1 * time.Hour
 
-// memoryMonitor runs in a loop, checking every 10 seconds if memory use is greater
+// MemoryMonitor runs a loop, checking every 10 seconds if memory use is greater
 // than GOMEMLIMIT. If so, it dumps memory and goroutine profiles to temporary files
 // created by os.CreateTemp, at most once per hour.
 //
 // If GOMEMLIMIT is unset, returns immediately.
-func memoryMonitor() {
-	logger := blog.Get()
+func MemoryMonitor() {
 	memLimit := debug.SetMemoryLimit(-1)
 	if memLimit == math.MaxInt64 {
 		return
@@ -46,6 +45,7 @@ func memoryMonitor() {
 		if memStats.Sys-memStats.HeapReleased > memLimitU64 {
 			lastDump = time.Now()
 
+			logger := blog.Get()
 			err := writeProfile(logger, "heap")
 			if err != nil {
 				logger.Errf("writing heap profile: %s", err)
@@ -60,7 +60,7 @@ func memoryMonitor() {
 
 func writeProfile(logger blog.Logger, typ string) error {
 	datestamp := time.Now().Format("20060102T150405")
-	profileFile, err := os.CreateTemp("", fmt.Sprintf("boulder-profile-%s-%s", typ, datestamp))
+	profileFile, err := os.CreateTemp("", fmt.Sprintf("boulder-profile-%s-%s.pprof", typ, datestamp))
 	if err != nil {
 		return fmt.Errorf("creating profile file: %s", err)
 	}

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,11 @@
+# Profiling
+
+Boulder components expose profiling endpoints on the port specified
+by their --debug-addr flag. An index of available endpoints can be
+found at /debug/pprof/ on each service.
+
+Additionally, if the environment variable $GOMEMLIMIT is set, Boulder
+components will automatically write a heap and goroutine dump when
+it's hit. Note that $GOMEMLIMIT also sets a soft memory limit for
+the runtime. See https://pkg.go.dev/runtime#hdr-Environment_Variables.
+The dump will happen at most once per hour.


### PR DESCRIPTION
We've been observing spikes in memory usage in the WFE. To track them down, we'd like to automatically trigger writing profiles to disk when memory usage is high.

This is controlled by two environment variables:

 - If $GOMEMLIMIT is unset, the profile dumping does not happen. This value is also used by the Go runtime to set a soft limit, and we intend to set it to something below where the OS will kill the process. https://pkg.go.dev/runtime#hdr-Environment_Variables
 - Files are written with os.CreateTemp(), so their location can be controlled with $TMPDIR.

~~Draft to seek feedback about logging. The current version gets run from `cmd/boulder/main.go`, before a logger is built. It uses `fmt.Println()` for errors. To use a real logger, we'd need to make `memoryMonitor()` exported and call it from each of the Boulder components after their config is parsed and the logger is built. Thoughts?~~