### PR TITLE
ceremony: Remove unused parseOID function

### DIFF
--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"math/big"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -161,21 +159,6 @@ func (profile *certProfile) verifyProfile(ct certType) error {
 	}
 
 	return nil
-}
-
-func parseOID(oidStr string) (asn1.ObjectIdentifier, error) {
-	var oid asn1.ObjectIdentifier
-	for a := range strings.SplitSeq(oidStr, ".") {
-		i, err := strconv.Atoi(a)
-		if err != nil {
-			return nil, err
-		}
-		if i <= 0 {
-			return nil, errors.New("OID components must be >= 1")
-		}
-		oid = append(oid, i)
-	}
-	return oid, nil
 }
 
 var stringToKeyUsage = map[string]x509.KeyUsage{

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -37,18 +36,6 @@ func realRand(_ pkcs11.SessionHandle, length int) ([]byte, error) {
 	r := make([]byte, length)
 	_, err := rand.Read(r)
 	return r, err
-}
-
-func TestParseOID(t *testing.T) {
-	_, err := parseOID("")
-	test.AssertError(t, err, "parseOID accepted an empty OID")
-	_, err = parseOID("a.b.c")
-	test.AssertError(t, err, "parseOID accepted an OID containing non-ints")
-	_, err = parseOID("1.0.2")
-	test.AssertError(t, err, "parseOID accepted an OID containing zero")
-	oid, err := parseOID("1.2.3")
-	test.AssertNotError(t, err, "parseOID failed with a valid OID")
-	test.Assert(t, oid.Equal(asn1.ObjectIdentifier{1, 2, 3}), "parseOID returned incorrect OID")
 }
 
 func TestMakeSubject(t *testing.T) {


### PR DESCRIPTION
This is a followup to a [previous cleanup](https://github.com/letsencrypt/boulder/pull/7969).