### PR TITLE
Expose retry-after in CORS Access-Control-Expose-Headers

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1934,7 +1934,7 @@ func (wfe *WebFrontEndImpl) setCORSHeaders(response http.ResponseWriter, request
 	// is an allowed header. See MDN for more details:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
 	response.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-	response.Header().Set("Access-Control-Expose-Headers", "Link, Replay-Nonce, Location")
+	response.Header().Set("Access-Control-Expose-Headers", "Link, Replay-Nonce, Location, Retry-After")
 	response.Header().Set("Access-Control-Max-Age", "86400")
 }
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -627,7 +627,7 @@ func TestHandleFunc(t *testing.T) {
 	test.AssertEquals(t, rw.Header().Get("Access-Control-Allow-Methods"), "")
 	test.AssertEquals(t, rw.Header().Get("Access-Control-Allow-Origin"), "*")
 	test.AssertEquals(t, rw.Header().Get("Access-Control-Allow-Headers"), "Content-Type")
-	test.AssertEquals(t, sortHeader(rw.Header().Get("Access-Control-Expose-Headers")), "Link, Location, Replay-Nonce")
+	test.AssertEquals(t, sortHeader(rw.Header().Get("Access-Control-Expose-Headers")), "Link, Location, Replay-Nonce, Retry-After")
 
 	// CORS preflight request for disallowed method
 	runWrappedHandler(&http.Request{
@@ -657,7 +657,7 @@ func TestHandleFunc(t *testing.T) {
 	test.AssertEquals(t, rw.Header().Get("Access-Control-Allow-Headers"), "Content-Type")
 	test.AssertEquals(t, rw.Header().Get("Access-Control-Max-Age"), "86400")
 	test.AssertEquals(t, sortHeader(rw.Header().Get("Access-Control-Allow-Methods")), "GET, HEAD, POST")
-	test.AssertEquals(t, sortHeader(rw.Header().Get("Access-Control-Expose-Headers")), "Link, Location, Replay-Nonce")
+	test.AssertEquals(t, sortHeader(rw.Header().Get("Access-Control-Expose-Headers")), "Link, Location, Replay-Nonce, Retry-After")
 
 	// OPTIONS request without an Origin header (i.e., not a CORS
 	// preflight request)


### PR DESCRIPTION
I have some HTML/Javascript pages for interacting with ACME, and having Retry-After exposed to content would be useful to me and any other browser based tools.