### PR TITLE
ci: run zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,3 @@ updates:
     schedule: 
       interval: monthly
     open-pull-requests-limit: 1
-    cooldown:
-      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
     schedule: 
       interval: monthly
     open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -71,7 +71,7 @@ jobs:
     # Sequence of tasks that will be executed as part of the job.
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -104,17 +104,18 @@ jobs:
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           # When Go produces a security release, we want govulncheck to run
           # against the most recently released Go version.
           check-latest: true
           go-version: "stable"
+          cache: false
 
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -129,14 +130,15 @@ jobs:
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
 
       - name: Verify vendor
         shell: bash

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -71,7 +71,7 @@ jobs:
     # Sequence of tasks that will be executed as part of the job.
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -104,18 +104,17 @@ jobs:
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@v6
         with:
           # When Go produces a security release, we want govulncheck to run
           # against the most recently released Go version.
           check-latest: true
           go-version: "stable"
-          cache: false
 
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -130,15 +129,14 @@ jobs:
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-          cache: false
 
       - name: Verify vendor
         shell: bash

--- a/.github/workflows/boulder-ci.yml
+++ b/.github/workflows/boulder-ci.yml
@@ -71,7 +71,7 @@ jobs:
     # Sequence of tasks that will be executed as part of the job.
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -104,17 +104,18 @@ jobs:
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           # When Go produces a security release, we want govulncheck to run
           # against the most recently released Go version.
           check-latest: true
           go-version: "stable"
+          cache: false
 
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -129,14 +130,15 @@ jobs:
 
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
 
       - name: Verify vendor
         shell: bash

--- a/.github/workflows/check-iana-registries.yml
+++ b/.github/workflows/check-iana-registries.yml
@@ -15,8 +15,8 @@ jobs:
 
     steps:
       - name: Checkout iana/data from main branch
-        uses: actions/checkout@v6
-        with:
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with: # zizmor: ignore[artipacked] gh credentials must be persisted so we can open a PR
           sparse-checkout: iana/data
 
       # If the branch already exists, this will fail, which will remind us about

--- a/.github/workflows/check-iana-registries.yml
+++ b/.github/workflows/check-iana-registries.yml
@@ -15,9 +15,10 @@ jobs:
 
     steps:
       - name: Checkout iana/data from main branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: iana/data
+          persist-credentials: false
 
       # If the branch already exists, this will fail, which will remind us about
       # the outstanding PR.

--- a/.github/workflows/check-iana-registries.yml
+++ b/.github/workflows/check-iana-registries.yml
@@ -15,8 +15,8 @@ jobs:
 
     steps:
       - name: Checkout iana/data from main branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with: # zizmor: ignore[artipacked] gh credentials must be persisted so we can open a PR
+        uses: actions/checkout@v6
+        with:
           sparse-checkout: iana/data
 
       # If the branch already exists, this will fail, which will remind us about

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/init@v4
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/autobuild@v4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/.github/workflows/cps-review.yml
+++ b/.github/workflows/cps-review.yml
@@ -13,12 +13,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "stable"
 
       - name: Checkout Upstream
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.ref }}
@@ -26,7 +26,7 @@ jobs:
         run: go run ./test/list-features/list-features.go | sort >| /tmp/currflags.txt
 
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Get PR Flags
@@ -38,7 +38,7 @@ jobs:
 
       - name: Comment PR
         if: ${{ steps.newflags.outputs.flagnames != '' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           NEW_FLAGS: ${{ steps.newflags.outputs.flagnames }}
         with:

--- a/.github/workflows/cps-review.yml
+++ b/.github/workflows/cps-review.yml
@@ -13,12 +13,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
       - name: Checkout Upstream
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.ref }}
@@ -26,7 +26,7 @@ jobs:
         run: go run ./test/list-features/list-features.go | sort >| /tmp/currflags.txt
 
       - name: Checkout PR
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Get PR Flags
@@ -38,7 +38,7 @@ jobs:
 
       - name: Comment PR
         if: ${{ steps.newflags.outputs.flagnames != '' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           NEW_FLAGS: ${{ steps.newflags.outputs.flagnames }}
         with:

--- a/.github/workflows/cps-review.yml
+++ b/.github/workflows/cps-review.yml
@@ -13,12 +13,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "stable"
 
       - name: Checkout Upstream
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.ref }}
@@ -26,7 +26,7 @@ jobs:
         run: go run ./test/list-features/list-features.go | sort >| /tmp/currflags.txt
 
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Get PR Flags
@@ -38,7 +38,7 @@ jobs:
 
       - name: Comment PR
         if: ${{ steps.newflags.outputs.flagnames != '' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { owner, repo, number: issue_number } = context.issue;

--- a/.github/workflows/issue-for-sre-handoff.yml
+++ b/.github/workflows/issue-for-sre-handoff.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment PR
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           script: |
             const commentMarker = '<!-- deployment_ticket_check -->';

--- a/.github/workflows/issue-for-sre-handoff.yml
+++ b/.github/workflows/issue-for-sre-handoff.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const commentMarker = '<!-- deployment_ticket_check -->';

--- a/.github/workflows/issue-for-sre-handoff.yml
+++ b/.github/workflows/issue-for-sre-handoff.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const commentMarker = '<!-- deployment_ticket_check -->';

--- a/.github/workflows/merged-to-main-or-release-branch.yml
+++ b/.github/workflows/merged-to-main-or-release-branch.yml
@@ -14,6 +14,6 @@ jobs:
     name: Merged to main (or hotfix)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false

--- a/.github/workflows/merged-to-main-or-release-branch.yml
+++ b/.github/workflows/merged-to-main-or-release-branch.yml
@@ -14,6 +14,6 @@ jobs:
     name: Merged to main (or hotfix)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/merged-to-main-or-release-branch.yml
+++ b/.github/workflows/merged-to-main-or-release-branch.yml
@@ -14,6 +14,6 @@ jobs:
     name: Merged to main (or hotfix)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
@@ -41,7 +41,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
@@ -87,7 +87,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
@@ -41,7 +41,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
@@ -87,7 +87,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
@@ -41,7 +41,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           fetch-depth: '0' # Needed for verify-release-ancestry.sh to see origin/main
@@ -87,7 +87,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -23,7 +23,7 @@ jobs:
           - "1.26.3"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -23,7 +23,7 @@ jobs:
           - "1.26.3"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/try-release.yml
+++ b/.github/workflows/try-release.yml
@@ -23,7 +23,7 @@ jobs:
           - "1.26.3"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,46 @@
+name:  Lint GitHub Actions
+
+on:
+  push:
+    branches:
+      - main
+      - release-branch-*
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      # Used by zizmor's online audits to query workflow run metadata.
+      # See https://docs.zizmor.sh/audits/
+      actions: read
+
+    env:
+      ZIZMOR_VERSION: 1.25.2
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download and verify zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          url="https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          curl --fail --location --show-error --silent --output zizmor.tar.gz "${url}"
+          gh attestation verify zizmor.tar.gz --repo zizmorcore/zizmor
+          tar -xzf zizmor.tar.gz zizmor
+          ./zizmor --version | grep -Fq "zizmor ${ZIZMOR_VERSION}"
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./zizmor .

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,6 +10,8 @@ on:
       - '**'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   zizmor:
     runs-on: ubuntu-24.04

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      ZIZMOR_VERSION: 1.25.2
+      ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.25.2@sha256:14ea7f5cc7c67933394a35b5a38a277397818d232602635edb2010b313afb110
 
     steps:
       - name: Checkout repository
@@ -25,18 +25,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download and verify zizmor
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          url="https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz"
-          curl --fail --location --show-error --silent --output zizmor.tar.gz "${url}"
-          gh attestation verify zizmor.tar.gz --repo zizmorcore/zizmor
-          tar -xzf zizmor.tar.gz zizmor
-          ./zizmor --version | grep -Fq "zizmor ${ZIZMOR_VERSION}"
-
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./zizmor .
+        run: |
+          docker run \
+            --volume "${GITHUB_WORKSPACE}:/src:ro" \
+            --workdir "/src" \
+            --env "GH_TOKEN" \
+            "$ZIZMOR_IMAGE" -- /src

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,12 +14,6 @@ jobs:
   zizmor:
     runs-on: ubuntu-24.04
 
-    permissions:
-      contents: read
-      # Used by zizmor's online audits to query workflow run metadata.
-      # See https://docs.zizmor.sh/audits/
-      actions: read
-
     env:
       ZIZMOR_VERSION: 1.25.2
 


### PR DESCRIPTION
[Zizmor](https://github.com/zizmorcore/zizmor) is a GitHub Actions linter. The state of the GHA ecosystem is such that static analysis of GHA workflows is mandatory IMO.

I have deliberately avoided use of https://github.com/zizmorcore/zizmor-action since it lacks stability, and I generally think it's better just to avoid third-party actions if we can (ack that the maintainers of the action and the linter are the same people).

This PR also autofixes some trivial findings.

Upon merging, an admin on this repo should make this workflow required to pass. For that reason I have not restricted the workflow to run on `.github/workflows` paths, since otherwise unrelated PRs will block when it doesn't run.