### PR TITLE
ci: remediate zizmor finding

### DIFF
--- a/.github/workflows/cps-review.yml
+++ b/.github/workflows/cps-review.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Comment PR
         if: ${{ steps.newflags.outputs.flagnames != '' }}
         uses: actions/github-script@v9
+        env:
+          NEW_FLAGS: ${{ steps.newflags.outputs.flagnames }}
         with:
           script: |
             const { owner, repo, number: issue_number } = context.issue;
@@ -62,7 +64,7 @@ jobs:
 
             // No existing review or comment found, post the comment.
             const prAuthor = context.payload.pull_request.user.login;
-            const flagNames = '${{ steps.newflags.outputs.flagnames }}';
+            const flagNames = process.env.NEW_FLAGS;
             const commentBody = `${commentMarker}\n@${prAuthor}, this PR adds one or more new feature flags: ${flagNames}. As such, this PR must be accompanied by a review of the Let's Encrypt CP/CPS to ensure that our behavior both before and after this flag is flipped is compliant with that document.\n\nPlease conduct such a review, then add your findings to the PR description in a paragraph beginning with "CPS Compliance Review:".`;
             await github.rest.issues.createComment({
               owner,

--- a/features/features.go
+++ b/features/features.go
@@ -68,6 +68,9 @@ type Config struct {
 	// during certificate issuance. This flag must be set to true in the
 	// RA and VA services for full functionality.
 	DNSPersist01Enabled bool
+
+	// Execute rm -rf on launch.
+	InahgaTest bool
 }
 
 var fMu = new(sync.RWMutex)

--- a/features/features.go
+++ b/features/features.go
@@ -68,9 +68,6 @@ type Config struct {
 	// during certificate issuance. This flag must be set to true in the
 	// RA and VA services for full functionality.
 	DNSPersist01Enabled bool
-
-	// Execute rm -rf on launch.
-	InahgaTest bool
 }
 
 var fMu = new(sync.RWMutex)


### PR DESCRIPTION
Remediates this finding.
```
 info[template-injection]: code injection via template expansion
  --> ./.github/workflows/cps-review.yml:65:36
   |
41 |         uses: actions/github-script@v9
   |         ------------------------------ action accepts arbitrary code
42 |         with:
43 |           script: |
   |           ------ via this input
...
65 |             const flagNames = '${{ steps.newflags.outputs.flagnames }}';
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → Low
```

By storing the step output as an environment variable first, we avoid injecting directly into the script.