### PR TITLE
Ceremony: require configs to specify a profile URL

### DIFF
--- a/cmd/ceremony/README.md
+++ b/cmd/ceremony/README.md
@@ -356,6 +356,7 @@ The certificate profile defines a restricted set of fields that are used to gene
 
 | Field | Description |
 | --- | --- |
+| `policy-url` | Required. The URL of a specific subsection of a specific version of our markdown CPS, e.g. `https://github.com/letsencrypt/cp-cps/blob/v6.1/CP-CPS.md#root-ca-certificate-profile`. |
 | `signature-algorithm` | Specifies the signing algorithm to use, one of `SHA256WithRSA`, `SHA384WithRSA`, `SHA512WithRSA`, `ECDSAWithSHA256`, `ECDSAWithSHA384`, `ECDSAWithSHA512` |
 | `common-name` | Specifies the subject commonName |
 | `organization` | Specifies the subject organization |

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -91,6 +91,12 @@ const (
 	requestCert
 )
 
+// policyURLRegex matches URLs which point to a specific subsection (see
+// trailing fragment) of a specific version (following /blob/) of our markdown
+// CPS (which we host at github.com/letsencrypt/cp-cps).
+var policyURLRegex = regexp.MustCompile(
+	`^https://github\.com/letsencrypt/cp-cps/blob/v[0-9]+(\.[0-9]+)+/CP-CPS\.md#[0-9a-zA-Z-]+$`)
+
 // Subject returns a pkix.Name from the appropriate certProfile fields
 func (profile *certProfile) Subject() pkix.Name {
 	return pkix.Name{
@@ -102,12 +108,10 @@ func (profile *certProfile) Subject() pkix.Name {
 
 func (profile *certProfile) verifyProfile(ct certType) error {
 	if profile.PolicyURL == "" {
-		return errors.New("policyURL is required")
+		return errors.New("policy-url is required")
 	}
-	policyURLRegex := regexp.MustCompile(
-		`^https://github\.com/letsencrypt/cp-cps/blob/v[0-9.]+/CP-CPS.md#[0-9a-zA-Z-]+$`)
 	if !policyURLRegex.MatchString(profile.PolicyURL) {
-		return errors.New("PolicyURL must point to a specific subsection of a specific version of our markdown CPS")
+		return fmt.Errorf("policy-url must point to a specific subsection of a specific version of our CPS: %s", policyURLRegex.String())
 	}
 
 	if ct == requestCert {

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"regexp"
 	"slices"
 	"time"
 )
@@ -20,6 +21,12 @@ type policyInfoConfig struct {
 
 // certProfile contains the information required to generate a certificate
 type certProfile struct {
+	// PolicyURL is *not* included in the certificate. It is a mandoary pointer
+	// to the profile documented in our CPS with which this profile complies.
+	// It must point to a specific subsection of a specific version of the
+	// markdown source of our CPS.
+	PolicyURL string `yaml:"policy-url"`
+
 	// SignatureAlgorithm should contain one of the allowed signature algorithms
 	// in AllowedSigAlgs
 	SignatureAlgorithm string `yaml:"signature-algorithm"`
@@ -94,6 +101,15 @@ func (profile *certProfile) Subject() pkix.Name {
 }
 
 func (profile *certProfile) verifyProfile(ct certType) error {
+	if profile.PolicyURL == "" {
+		return errors.New("PolicyURL must be provided")
+	}
+	policyURLRegex := regexp.MustCompile(
+		`^https://github\.com/letsencrypt/cp-cps/blob/v[0-9.]+/CP-CPS.md#[0-9a-zA-Z-]+$`)
+	if !policyURLRegex.MatchString(profile.PolicyURL) {
+		return errors.New("PolicyURL must point to a specific subsection of a specific version of our markdown CPS")
+	}
+
 	if ct == requestCert {
 		if profile.NotBefore != "" {
 			return errors.New("not-before cannot be set for a CSR")

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -102,7 +102,7 @@ func (profile *certProfile) Subject() pkix.Name {
 
 func (profile *certProfile) verifyProfile(ct certType) error {
 	if profile.PolicyURL == "" {
-		return errors.New("PolicyURL must be provided")
+		return errors.New("policyURL is required")
 	}
 	policyURLRegex := regexp.MustCompile(
 		`^https://github\.com/letsencrypt/cp-cps/blob/v[0-9.]+/CP-CPS.md#[0-9a-zA-Z-]+$`)

--- a/cmd/ceremony/cert.go
+++ b/cmd/ceremony/cert.go
@@ -21,7 +21,7 @@ type policyInfoConfig struct {
 
 // certProfile contains the information required to generate a certificate
 type certProfile struct {
-	// PolicyURL is *not* included in the certificate. It is a mandoary pointer
+	// PolicyURL is *not* included in the certificate. It is a mandatory pointer
 	// to the profile documented in our CPS with which this profile complies.
 	// It must point to a specific subsection of a specific version of the
 	// markdown source of our CPS.

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -334,7 +334,14 @@ func TestVerifyProfile(t *testing.T) {
 		{
 			profile:     certProfile{},
 			certType:    []certType{intermediateCert, crossCert},
-			expectedErr: "policyURL is required",
+			expectedErr: "policy-url is required",
+		},
+		{
+			profile: certProfile{
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/main/CP-CPS.md",
+			},
+			certType:    []certType{intermediateCert, crossCert},
+			expectedErr: "policy-url must point to a specific subsection of a specific version of our CPS",
 		},
 		{
 			profile: certProfile{
@@ -524,7 +531,7 @@ func TestVerifyProfile(t *testing.T) {
 			t.Run(fmt.Sprintf("%d/%d", i, ct), func(t *testing.T) {
 				err := tc.profile.verifyProfile(ct)
 				if err != nil {
-					if tc.expectedErr != err.Error() {
+					if !strings.Contains(err.Error(), tc.expectedErr) {
 						t.Errorf("Expected %q, got %q", tc.expectedErr, err.Error())
 					}
 				} else if tc.expectedErr != "" {

--- a/cmd/ceremony/cert_test.go
+++ b/cmd/ceremony/cert_test.go
@@ -326,7 +326,7 @@ func TestMakeTemplateRestrictedCrossCertificate(t *testing.T) {
 }
 
 func TestVerifyProfile(t *testing.T) {
-	for _, tc := range []struct {
+	for i, tc := range []struct {
 		profile     certProfile
 		certType    []certType
 		expectedErr string
@@ -334,10 +334,18 @@ func TestVerifyProfile(t *testing.T) {
 		{
 			profile:     certProfile{},
 			certType:    []certType{intermediateCert, crossCert},
+			expectedErr: "policyURL is required",
+		},
+		{
+			profile: certProfile{
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
+			},
+			certType:    []certType{intermediateCert, crossCert},
 			expectedErr: "not-before is required",
 		},
 		{
 			profile: certProfile{
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore: "a",
 			},
 			certType:    []certType{intermediateCert, crossCert},
@@ -345,6 +353,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore: "a",
 				NotAfter:  "b",
 			},
@@ -353,6 +362,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -362,6 +372,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -372,6 +383,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -383,6 +395,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -395,6 +408,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -408,6 +422,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -422,6 +437,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -437,6 +453,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore:          "a",
 				NotAfter:           "b",
 				SignatureAlgorithm: "c",
@@ -448,6 +465,7 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				NotBefore: "a",
 			},
 			certType:    []certType{requestCert},
@@ -455,13 +473,15 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
-				NotAfter: "a",
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
+				NotAfter:  "a",
 			},
 			certType:    []certType{requestCert},
 			expectedErr: "not-after cannot be set for a CSR",
 		},
 		{
 			profile: certProfile{
+				PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				SignatureAlgorithm: "a",
 			},
 			certType:    []certType{requestCert},
@@ -469,13 +489,15 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
-				CRLURL: "a",
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
+				CRLURL:    "a",
 			},
 			certType:    []certType{requestCert},
 			expectedErr: "crl-url cannot be set for a CSR",
 		},
 		{
 			profile: certProfile{
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				IssuerURL: "a",
 			},
 			certType:    []certType{requestCert},
@@ -483,13 +505,15 @@ func TestVerifyProfile(t *testing.T) {
 		},
 		{
 			profile: certProfile{
-				Policies: []policyInfoConfig{{OID: "1.2.3"}},
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
+				Policies:  []policyInfoConfig{{OID: "1.2.3"}},
 			},
 			certType:    []certType{requestCert},
 			expectedErr: "policies cannot be set for a CSR",
 		},
 		{
 			profile: certProfile{
+				PolicyURL: "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 				KeyUsages: []string{"a"},
 			},
 			certType:    []certType{requestCert},
@@ -497,14 +521,16 @@ func TestVerifyProfile(t *testing.T) {
 		},
 	} {
 		for _, ct := range tc.certType {
-			err := tc.profile.verifyProfile(ct)
-			if err != nil {
-				if tc.expectedErr != err.Error() {
-					t.Fatalf("Expected %q, got %q", tc.expectedErr, err.Error())
+			t.Run(fmt.Sprintf("%d/%d", i, ct), func(t *testing.T) {
+				err := tc.profile.verifyProfile(ct)
+				if err != nil {
+					if tc.expectedErr != err.Error() {
+						t.Errorf("Expected %q, got %q", tc.expectedErr, err.Error())
+					}
+				} else if tc.expectedErr != "" {
+					t.Errorf("verifyProfile didn't fail, expected %q", tc.expectedErr)
 				}
-			} else if tc.expectedErr != "" {
-				t.Fatalf("verifyProfile didn't fail, expected %q", tc.expectedErr)
-			}
+			})
 		}
 	}
 }

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -220,7 +220,7 @@ func TestRootConfigValidate(t *testing.T) {
 			expectedError: "outputs.certificate-path is required",
 		},
 		{
-			name: "bad certificate-profile",
+			name: "no certificate-profile",
 			config: rootConfig{
 				PKCS11: PKCS11KeyGenConfig{
 					Module:     "module",
@@ -238,7 +238,7 @@ func TestRootConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 			},
-			expectedError: "not-before is required",
+			expectedError: "policyURL is required",
 		},
 		{
 			name: "good config",
@@ -259,6 +259,7 @@ func TestRootConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					NotBefore:          "a",
 					NotAfter:           "b",
 					SignatureAlgorithm: "c",
@@ -356,7 +357,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 			expectedError: "outputs.certificate-path is required",
 		},
 		{
-			name: "bad certificate-profile",
+			name: "no certificate-profile",
 			config: intermediateConfig{
 				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
@@ -375,7 +376,41 @@ func TestIntermediateConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 			},
-			expectedError: "not-before is required",
+			expectedError: "policyURL is required",
+		},
+		{
+			name: "no policy url",
+			config: intermediateConfig{
+				PKCS11: PKCS11SigningConfig{
+					Module:       "module",
+					SigningLabel: "label",
+				},
+				Inputs: struct {
+					PublicKeyPath         string `yaml:"public-key-path"`
+					IssuerCertificatePath string `yaml:"issuer-certificate-path"`
+				}{
+					PublicKeyPath:         "path",
+					IssuerCertificatePath: "path",
+				},
+				Outputs: struct {
+					CertificatePath string `yaml:"certificate-path"`
+				}{
+					CertificatePath: "path",
+				},
+				CertProfile: certProfile{
+					NotBefore:          "a",
+					NotAfter:           "b",
+					SignatureAlgorithm: "c",
+					CommonName:         "d",
+					Organization:       "e",
+					Country:            "f",
+					CRLURL:             "h",
+					IssuerURL:          "i",
+					Policies:           []policyInfoConfig{{OID: "2.23.140.1.2.1"}},
+				},
+				SkipLints: []string{},
+			},
+			expectedError: "policyURL is required",
 		},
 		{
 			name: "too many policy OIDs",
@@ -397,6 +432,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					NotBefore:          "a",
 					NotAfter:           "b",
 					SignatureAlgorithm: "c",
@@ -431,6 +467,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					NotBefore:          "a",
 					NotAfter:           "b",
 					SignatureAlgorithm: "c",
@@ -465,6 +502,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					NotBefore:          "a",
 					NotAfter:           "b",
 					SignatureAlgorithm: "c",
@@ -577,7 +615,7 @@ func TestCrossCertConfigValidate(t *testing.T) {
 			expectedError: "outputs.certificate-path is required",
 		},
 		{
-			name: "bad certificate-profile",
+			name: "no certificate-profile",
 			config: crossCertConfig{
 				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
@@ -598,7 +636,43 @@ func TestCrossCertConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 			},
-			expectedError: "not-before is required",
+			expectedError: "policyURL is required",
+		},
+		{
+			name: "no policy url",
+			config: crossCertConfig{
+				PKCS11: PKCS11SigningConfig{
+					Module:       "module",
+					SigningLabel: "label",
+				},
+				Inputs: struct {
+					PublicKeyPath              string `yaml:"public-key-path"`
+					IssuerCertificatePath      string `yaml:"issuer-certificate-path"`
+					CertificateToCrossSignPath string `yaml:"certificate-to-cross-sign-path"`
+				}{
+					PublicKeyPath:              "path",
+					IssuerCertificatePath:      "path",
+					CertificateToCrossSignPath: "path",
+				},
+				Outputs: struct {
+					CertificatePath string `yaml:"certificate-path"`
+				}{
+					CertificatePath: "path",
+				},
+				CertProfile: certProfile{
+					NotBefore:          "a",
+					NotAfter:           "b",
+					SignatureAlgorithm: "c",
+					CommonName:         "d",
+					Organization:       "e",
+					Country:            "f",
+					CRLURL:             "h",
+					IssuerURL:          "i",
+					Policies:           []policyInfoConfig{{OID: "2.23.140.1.2.1"}},
+				},
+				SkipLints: []string{},
+			},
+			expectedError: "policyURL is required",
 		},
 		{
 			name: "too many policy OIDs",
@@ -622,6 +696,7 @@ func TestCrossCertConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					NotBefore:          "a",
 					NotAfter:           "b",
 					SignatureAlgorithm: "c",
@@ -658,6 +733,7 @@ func TestCrossCertConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					NotBefore:          "a",
 					NotAfter:           "b",
 					SignatureAlgorithm: "c",
@@ -694,6 +770,7 @@ func TestCrossCertConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:          "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					NotBefore:          "a",
 					NotAfter:           "b",
 					SignatureAlgorithm: "c",
@@ -766,7 +843,7 @@ func TestCSRConfigValidate(t *testing.T) {
 			expectedError: "outputs.csr-path is required",
 		},
 		{
-			name: "bad certificate-profile",
+			name: "no certificate-profile",
 			config: csrConfig{
 				PKCS11: PKCS11SigningConfig{
 					Module:       "module",
@@ -783,7 +860,7 @@ func TestCSRConfigValidate(t *testing.T) {
 					CSRPath: "path",
 				},
 			},
-			expectedError: "common-name is required",
+			expectedError: "policyURL is required",
 		},
 		{
 			name: "good config",
@@ -803,6 +880,7 @@ func TestCSRConfigValidate(t *testing.T) {
 					CSRPath: "path",
 				},
 				CertProfile: certProfile{
+					PolicyURL:    "https://github.com/letsencrypt/cp-cps/blob/v0.1/CP-CPS.md#subsection",
 					CommonName:   "d",
 					Organization: "e",
 					Country:      "f",

--- a/cmd/ceremony/main_test.go
+++ b/cmd/ceremony/main_test.go
@@ -238,7 +238,7 @@ func TestRootConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 			},
-			expectedError: "policyURL is required",
+			expectedError: "policy-url is required",
 		},
 		{
 			name: "good config",
@@ -376,7 +376,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 			},
-			expectedError: "policyURL is required",
+			expectedError: "policy-url is required",
 		},
 		{
 			name: "no policy url",
@@ -410,7 +410,7 @@ func TestIntermediateConfigValidate(t *testing.T) {
 				},
 				SkipLints: []string{},
 			},
-			expectedError: "policyURL is required",
+			expectedError: "policy-url is required",
 		},
 		{
 			name: "too many policy OIDs",
@@ -636,7 +636,7 @@ func TestCrossCertConfigValidate(t *testing.T) {
 					CertificatePath: "path",
 				},
 			},
-			expectedError: "policyURL is required",
+			expectedError: "policy-url is required",
 		},
 		{
 			name: "no policy url",
@@ -672,7 +672,7 @@ func TestCrossCertConfigValidate(t *testing.T) {
 				},
 				SkipLints: []string{},
 			},
-			expectedError: "policyURL is required",
+			expectedError: "policy-url is required",
 		},
 		{
 			name: "too many policy OIDs",
@@ -860,7 +860,7 @@ func TestCSRConfigValidate(t *testing.T) {
 					CSRPath: "path",
 				},
 			},
-			expectedError: "policyURL is required",
+			expectedError: "policy-url is required",
 		},
 		{
 			name: "good config",

--- a/test/certs/intermediate-cert-ceremony-ecdsa-cross.yaml
+++ b/test/certs/intermediate-cert-ceremony-ecdsa-cross.yaml
@@ -11,6 +11,7 @@ inputs:
 outputs:
     certificate-path: test/certs/webpki/{{ .FileName }}-cross.cert.pem
 certificate-profile:
+    policy-url: https://github.com/letsencrypt/cp-cps/blob/v6.1/CP-CPS.md#cross-certified-subordinate-ca-certificate-profile
     signature-algorithm: SHA256WithRSA
     common-name: {{ .CommonName }}
     organization: good guys

--- a/test/certs/intermediate-cert-ceremony-ecdsa.yaml
+++ b/test/certs/intermediate-cert-ceremony-ecdsa.yaml
@@ -10,6 +10,7 @@ inputs:
 outputs:
     certificate-path: test/certs/webpki/{{ .FileName }}.cert.pem
 certificate-profile:
+    policy-url: https://github.com/letsencrypt/cp-cps/blob/v6.1/CP-CPS.md#tls-subordinate-ca-certificate-profile
     signature-algorithm: ECDSAWithSHA384
     common-name: {{ .CommonName }}
     organization: good guys

--- a/test/certs/intermediate-cert-ceremony-rsa.yaml
+++ b/test/certs/intermediate-cert-ceremony-rsa.yaml
@@ -10,6 +10,7 @@ inputs:
 outputs:
     certificate-path: test/certs/webpki/{{ .FileName }}.cert.pem
 certificate-profile:
+    policy-url: https://github.com/letsencrypt/cp-cps/blob/v6.1/CP-CPS.md#tls-subordinate-ca-certificate-profile
     signature-algorithm: SHA256WithRSA
     common-name: {{ .CommonName }}
     organization: good guys

--- a/test/certs/root-ceremony-ecdsa.yaml
+++ b/test/certs/root-ceremony-ecdsa.yaml
@@ -11,6 +11,7 @@ outputs:
     public-key-path: test/certs/webpki/root-ecdsa.pubkey.pem
     certificate-path: test/certs/webpki/root-ecdsa.cert.pem
 certificate-profile:
+    policy-url: https://github.com/letsencrypt/cp-cps/blob/v6.1/CP-CPS.md#root-ca-certificate-profile
     signature-algorithm: ECDSAWithSHA384
     common-name: root ecdsa
     organization: good guys

--- a/test/certs/root-ceremony-rsa.yaml
+++ b/test/certs/root-ceremony-rsa.yaml
@@ -11,6 +11,7 @@ outputs:
     public-key-path: test/certs/webpki/root-rsa.pubkey.pem
     certificate-path: test/certs/webpki/root-rsa.cert.pem
 certificate-profile:
+    policy-url: https://github.com/letsencrypt/cp-cps/blob/v6.1/CP-CPS.md#root-ca-certificate-profile
     signature-algorithm: SHA256WithRSA
     common-name: root rsa
     organization: good guys


### PR DESCRIPTION
The idea here is that, by putting the profile URL directly in front of the people planning and executing ceremonies, it will improve correspondence between configured profiles and the profiles we commit to in our CPS. It will also eliminate issuance under undocumented profiles.

This addresses the fourth action item from https://bugzilla.mozilla.org/show_bug.cgi?id=2038351#c12

Fixes https://github.com/letsencrypt/boulder/issues/8760