### PR TITLE
issuance: make digitalSignature optional

### DIFF
--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -246,15 +246,12 @@ func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk
 	}
 
 	// We require that all of our issuers be capable of both issuing certs and
-	// providing revocation information.
+	// providing CRL revocation information.
 	if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
 		return nil, errors.New("end-entity signing cert does not have keyUsage certSign")
 	}
 	if cert.KeyUsage&x509.KeyUsageCRLSign == 0 {
 		return nil, errors.New("end-entity signing cert does not have keyUsage crlSign")
-	}
-	if cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
-		return nil, errors.New("end-entity signing cert does not have keyUsage digitalSignature")
 	}
 
 	lintSigner, err := linter.New(cert.Certificate, signer)

--- a/issuance/issuer_test.go
+++ b/issuance/issuer_test.go
@@ -178,7 +178,6 @@ func TestNewIssuerKeyUsage(t *testing.T) {
 	}{
 		{"missing certSign", x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature, "does not have keyUsage certSign"},
 		{"missing crlSign", x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature, "does not have keyUsage crlSign"},
-		{"missing digitalSignature", x509.KeyUsageCertSign | x509.KeyUsageCRLSign, "does not have keyUsage digitalSignature"},
 		{"all three", x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature, ""},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
This is required for intermediates that do OCSP signing, but we don't do OCSP signing anymore.