### PR TITLE
ra: remove deprecated OCSPService config

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -46,10 +46,6 @@ type Config struct {
 		CAService        *cmd.GRPCClientConfig
 		PublisherService *cmd.GRPCClientConfig
 
-		// Deprecated: TODO(#8349): Remove this when removing the corresponding
-		// service from the CA.
-		OCSPService *cmd.GRPCClientConfig
-
 		Limiter struct {
 			// Redis contains the configuration necessary to connect to Redis
 			// for rate limiting. This field is required to enable rate


### PR DESCRIPTION
Follow-up to #8349.

I've checked that this field is not set in prod configs.