### PR TITLE
test: run unittests in parallel

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -82,6 +82,10 @@ function run_and_expect_silence() {
 # Testing Helpers
 #
 function run_unit_tests() {
+  # Sleep 50ms instead of 1000ms at the end of each package's unittests.
+  # Speeds up running lots of small unittests.
+  # https://go.dev/doc/articles/race_detector#Options
+  export atexit_sleep_ms=50
   # If unit test packages are not specified: set flags to run unit tests
   # for all boulder packages
   if [ -z "${UNIT_PACKAGES[@]+x}" ]

--- a/test.sh
+++ b/test.sh
@@ -85,7 +85,7 @@ function run_unit_tests() {
   # Sleep 50ms instead of 1000ms at the end of each package's unittests.
   # Speeds up running lots of small unittests.
   # https://go.dev/doc/articles/race_detector#Options
-  export atexit_sleep_ms=50
+  export GORACE="atexit_sleep_ms=50"
   # If unit test packages are not specified: set flags to run unit tests
   # for all boulder packages
   if [ -z "${UNIT_PACKAGES[@]+x}" ]
@@ -93,12 +93,19 @@ function run_unit_tests() {
     # The ra and sa unittests conflict because they both mutate the database.
     # Exclude the ra from our first test run, then run on its own.
     # https://github.com/letsencrypt/boulder/issues/1499
-    go test "${UNIT_FLAGS[@]}" $(go list ./... | grep -v boulder/ra)
-    go test ./ra
+    go_test $(go list ./... | grep -v boulder/ra)
+    go_test ./ra
   else
-    go test "${UNIT_FLAGS[@]}" "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
+    go_test "${UNIT_PACKAGES[@]}"
   fi
 
+}
+
+#
+# Run `go test` on a given set of packages.
+#
+function go_test() {
+  go test "${UNIT_FLAGS[@]}" "${FILTER[@]}" "$@"
 }
 
 #

--- a/test.sh
+++ b/test.sh
@@ -82,7 +82,19 @@ function run_and_expect_silence() {
 # Testing Helpers
 #
 function run_unit_tests() {
-  go test "${UNIT_FLAGS[@]}" "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
+  # If unit test packages are not specified: set flags to run unit tests
+  # for all boulder packages
+  if [ -z "${UNIT_PACKAGES[@]+x}" ]
+  then
+    # The ra and sa unittests conflict because they both mutate the database.
+    # Exclude the ra from our first test run, then run on its own.
+    # https://github.com/letsencrypt/boulder/issues/1499
+    go test "${UNIT_FLAGS[@]}" $(go list ./... | grep -v boulder/ra)
+    go test ./ra
+  else
+    go test "${UNIT_FLAGS[@]}" "${UNIT_PACKAGES[@]}" "${FILTER[@]}"
+  fi
+
 }
 
 #
@@ -174,21 +186,6 @@ fi
 if [[ "${RUN[@]}" =~ integration ]] && [[ -n "${FILTER[@]+x}" ]]
 then
   FILTER=(--filter "${FILTER[@]}")
-fi
-
-# If unit test packages are not specified: set flags to run unit tests
-# for all boulder packages
-if [ -z "${UNIT_PACKAGES[@]+x}" ]
-then
-  # '-p=1' configures unit tests to run serially, rather than in parallel. Our
-  # unit tests depend on mutating a database and then cleaning up after
-  # themselves. If these test were run in parallel, they could fail spuriously
-  # due to one test modifying a table (especially registrations) while another
-  # test is reading from it.
-  # https://github.com/letsencrypt/boulder/issues/1499
-  # https://pkg.go.dev/cmd/go#hdr-Testing_flags
-  UNIT_FLAGS+=("-p=1")
-  UNIT_PACKAGES+=("./...")
 fi
 
 print_heading "Boulder Test Suite CLI"


### PR DESCRIPTION
We have been using `go test -p=1` to avoid conflicts between unittests in different packages that both modify the database. However, this significantly slows down running tests.

Since it's really on the the sa and ra packages that conflict, and some logic to just handle those.

Also, the race detector sleeps for 1s before a process exits. Since each package's test are run as a single process, this costs us a second per package. Lower that to 50ms.

In CI, this takes us from 7m25s for the unittest job to 4m19s.