### PR TITLE
ra: call MTCA when profile indicates MTC

### DIFF
--- a/cmd/boulder-ra/main.go
+++ b/cmd/boulder-ra/main.go
@@ -3,6 +3,7 @@ package notmain
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/letsencrypt/boulder/goodkey/sagoodkey"
 	bgrpc "github.com/letsencrypt/boulder/grpc"
 	"github.com/letsencrypt/boulder/issuance"
+	mtcapb "github.com/letsencrypt/boulder/mtca/proto"
 	"github.com/letsencrypt/boulder/policy"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	"github.com/letsencrypt/boulder/ra"
@@ -40,6 +42,8 @@ type Config struct {
 		RateLimitPoliciesFilename string
 
 		MaxContactsPerRegistration int
+
+		ProfileToMTCA map[string]*cmd.GRPCClientConfig
 
 		SAService        *cmd.GRPCClientConfig
 		VAService        *cmd.GRPCClientConfig
@@ -79,8 +83,7 @@ type Config struct {
 
 		// ValidationProfiles is a map of validation profiles to their
 		// respective issuance allow lists. If a profile is not included in this
-		// mapping, it cannot be used by any account. If this field is left
-		// empty, all profiles are open to all accounts.
+		// mapping, it cannot be used by any account.
 		ValidationProfiles map[string]*ra.ValidationProfileConfig `validate:"required"`
 
 		// DefaultProfileName sets the profile to use if one wasn't provided by the
@@ -182,6 +185,14 @@ func main() {
 	vac := vapb.NewVAClient(vaConn)
 	caaClient := vapb.NewCAAClient(vaConn)
 
+	profileToMTCA := make(map[string]mtcapb.MTCAClient)
+	for profile, clientConfig := range c.RA.ProfileToMTCA {
+		mtcaConn, err := bgrpc.ClientSetup(clientConfig, tlsConfig, scope, clk)
+		cmd.FailOnError(err, fmt.Sprintf("Unable to create MTCA client for profile %s", profile))
+		mtcaClient := mtcapb.NewMTCAClient(mtcaConn)
+		profileToMTCA[profile] = mtcaClient
+	}
+
 	caConn, err := bgrpc.ClientSetup(c.RA.CAService, tlsConfig, scope, clk)
 	cmd.FailOnError(err, "Unable to create CA client")
 	cac := capb.NewCertificateAuthorityClient(caConn)
@@ -228,6 +239,11 @@ func main() {
 		cmd.Fail("At least one profile must be configured")
 	}
 
+	for name, profile := range c.RA.ValidationProfiles {
+		if profile.MTC && c.RA.ProfileToMTCA[name] == nil {
+			cmd.Fail(fmt.Sprintf("profile %q is configured for MTC but has no MTCA backend", name))
+		}
+	}
 	validationProfiles, err := ra.NewValidationProfiles(c.RA.DefaultProfileName, c.RA.ValidationProfiles)
 	cmd.FailOnError(err, "Failed to load validation profiles")
 
@@ -279,6 +295,7 @@ func main() {
 		c.RA.FinalizeTimeout.Duration,
 		ctp,
 		issuerCerts,
+		profileToMTCA,
 	)
 	defer rai.Drain()
 

--- a/mtca/mtca.go
+++ b/mtca/mtca.go
@@ -2,6 +2,7 @@ package mtca
 
 import (
 	"context"
+	"encoding/asn1"
 	"fmt"
 	"sync"
 
@@ -12,9 +13,17 @@ import (
 var _ mtcapb.MTCAServer = &mtca{}
 
 func New(issuer *issuance.Issuer) *mtca {
+	var mtcaID string
+	testingTrustAnchorIDOID := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 44363, 47, 1}
+	for _, attribute := range issuer.Cert.Subject.Names {
+		if attribute.Type.Equal(testingTrustAnchorIDOID) {
+			mtcaID, _ = attribute.Value.(string)
+			break
+		}
+	}
 	return &mtca{
 		issuer: issuer,
-		mtcaID: issuer.Cert.Subject.String(),
+		mtcaID: mtcaID,
 		// TODO: collect this from config
 		logNumber:        0,
 		latestEntryIndex: 0,
@@ -34,6 +43,9 @@ type mtca struct {
 	sequencing sync.Mutex
 }
 
+// mtcLogID returns the string-formatted relative OID for this log.
+// The .0. arc relative to the MTCA ID contains log numbers.
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#ca-ids
 func (m *mtca) mtcLogID() string {
 	return fmt.Sprintf("%s.0.%d", m.mtcaID, m.logNumber)
 }

--- a/mtca/mtca.go
+++ b/mtca/mtca.go
@@ -2,6 +2,7 @@ package mtca
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/letsencrypt/boulder/issuance"
@@ -13,27 +14,37 @@ var _ mtcapb.MTCAServer = &mtca{}
 func New(issuer *issuance.Issuer) *mtca {
 	return &mtca{
 		issuer: issuer,
-		logID:  issuer.Cert.Subject.String(),
+		mtcaID: issuer.Cert.Subject.String(),
+		// TODO: collect this from config
+		logNumber:        0,
+		latestEntryIndex: 0,
 	}
 }
 
 type mtca struct {
 	mtcapb.UnimplementedMTCAServer
 
-	issuer     *issuance.Issuer
-	logID      string
-	entryIndex int64
+	issuer    *issuance.Issuer
+	mtcaID    string
+	logNumber uint16
+
+	// This is just a dummy for testing; in reality this will come from the DB.
+	latestEntryIndex int64
 
 	sequencing sync.Mutex
+}
+
+func (m *mtca) mtcLogID() string {
+	return fmt.Sprintf("%s.0.%d", m.mtcaID, m.logNumber)
 }
 
 func (m *mtca) Issue(ctx context.Context, req *mtcapb.IssueRequest) (*mtcapb.IssueResponse, error) {
 	m.sequencing.Lock()
 	defer m.sequencing.Unlock()
-	m.entryIndex++
+	m.latestEntryIndex++
 
 	return &mtcapb.IssueResponse{
-		MtcLogID:      m.logID,
-		MtcEntryIndex: m.entryIndex,
+		MtcLogID:      m.mtcLogID(),
+		MtcEntryIndex: m.latestEntryIndex,
 	}, nil
 }

--- a/mtca/mtca.go
+++ b/mtca/mtca.go
@@ -2,7 +2,7 @@ package mtca
 
 import (
 	"context"
-	"fmt"
+	"sync"
 
 	"github.com/letsencrypt/boulder/issuance"
 	mtcapb "github.com/letsencrypt/boulder/mtca/proto"
@@ -13,14 +13,27 @@ var _ mtcapb.MTCAServer = &mtca{}
 func New(issuer *issuance.Issuer) *mtca {
 	return &mtca{
 		issuer: issuer,
+		logID:  issuer.Cert.Subject.String(),
 	}
 }
 
 type mtca struct {
 	mtcapb.UnimplementedMTCAServer
-	issuer *issuance.Issuer
+
+	issuer     *issuance.Issuer
+	logID      string
+	entryIndex int64
+
+	sequencing sync.Mutex
 }
 
 func (m *mtca) Issue(ctx context.Context, req *mtcapb.IssueRequest) (*mtcapb.IssueResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+	m.sequencing.Lock()
+	defer m.sequencing.Unlock()
+	m.entryIndex++
+
+	return &mtcapb.IssueResponse{
+		MtcLogID:      m.logID,
+		MtcEntryIndex: m.entryIndex,
+	}, nil
 }

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -40,6 +40,7 @@ import (
 	"github.com/letsencrypt/boulder/issuance"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
+	mtcapb "github.com/letsencrypt/boulder/mtca/proto"
 	"github.com/letsencrypt/boulder/probs"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
@@ -70,11 +71,12 @@ var (
 type RegistrationAuthorityImpl struct {
 	rapb.UnsafeRegistrationAuthorityServer
 	rapb.UnsafeSCTProviderServer
-	CA        capb.CertificateAuthorityClient
-	VA        va.RemoteClients
-	SA        sapb.StorageAuthorityClient
-	PA        core.PolicyAuthority
-	publisher pubpb.PublisherClient
+	CA            capb.CertificateAuthorityClient
+	VA            va.RemoteClients
+	SA            sapb.StorageAuthorityClient
+	PA            core.PolicyAuthority
+	publisher     pubpb.PublisherClient
+	profileToMTCA map[string]mtcapb.MTCAClient
 
 	clk               clock.Clock
 	log               blog.Logger
@@ -126,6 +128,7 @@ func NewRegistrationAuthorityImpl(
 	finalizeTimeout time.Duration,
 	ctp *ctpolicy.CTPolicy,
 	issuers []*issuance.Certificate,
+	profileToMTCA map[string]mtcapb.MTCAClient,
 ) *RegistrationAuthorityImpl {
 	ctpolicyResults := promauto.With(stats).NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -215,6 +218,7 @@ func NewRegistrationAuthorityImpl(
 		limiter:                 limiter,
 		txnBuilder:              txnBuilder,
 		publisher:               pubc,
+		profileToMTCA:           profileToMTCA,
 		finalizeTimeout:         finalizeTimeout,
 		ctpolicy:                ctp,
 		ctpolicyResults:         ctpolicyResults,
@@ -262,6 +266,9 @@ type ValidationProfileConfig struct {
 	// specified, the profile is open to all accounts. If the file
 	// exists but is empty, the profile is closed to all accounts.
 	AllowList string `validate:"omitempty"`
+	// MTC indicates that orders with this profile should be sent to an
+	// MTCA instance for issuance.
+	MTC bool `validate:"omitempty"`
 	// IdentifierTypes is a list of identifier types that may be issued under
 	// this profile.
 	IdentifierTypes []identifier.IdentifierType `validate:"required,dive,oneof=dns ip"`
@@ -292,6 +299,9 @@ type validationProfile struct {
 	// identifierTypes is a list of identifier types that may be issued under
 	// this profile.
 	identifierTypes []identifier.IdentifierType
+	// MTC indicates that orders with this profile should be sent to an
+	// MTCA instance for issuance.
+	mtc bool
 }
 
 // validationProfiles provides access to the set of configured profiles,
@@ -359,6 +369,7 @@ func NewValidationProfiles(defaultName string, configs map[string]*ValidationPro
 			maxNames:             config.MaxNames,
 			allowList:            allowList,
 			identifierTypes:      config.IdentifierTypes,
+			mtc:                  config.MTC,
 		}
 	}
 
@@ -923,7 +934,10 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 
 	// Steps 3 (issuance) and 4 (cleanup) are done inside a helper function so
 	// that we can control whether or not that work happens asynchronously.
-	if features.Get().AsyncFinalize {
+	// For MTC issuance we don't immediately go async: we wait on the MTCA
+	// sequencing an entry. This allows us to quickly return errors if sequencing
+	// is unavailable for any reason.
+	if features.Get().AsyncFinalize && !ra.isMTC(order) {
 		// We do this work in a goroutine so that we can better handle latency from
 		// getting SCTs and writing the (pre)certificate to the database. This lets
 		// us return the order in the Processing state to the client immediately,
@@ -952,6 +966,31 @@ func (ra *RegistrationAuthorityImpl) FinalizeOrder(ctx context.Context, req *rap
 	} else {
 		return ra.issueCertificateOuter(ctx, order, csr, authzs, logEvent)
 	}
+}
+
+func (ra *RegistrationAuthorityImpl) issueMTC(
+	ctx context.Context,
+	order *corepb.Order,
+	subjectPublicKeyInfo []byte,
+) error {
+	profileName := ra.profileName(order)
+	mtca := ra.profileToMTCA[profileName]
+	if mtca == nil {
+		return fmt.Errorf("no MTCA configured for MTC profile %q", profileName)
+	}
+
+	resp, err := mtca.Issue(ctx, &mtcapb.IssueRequest{
+		Pubkey:      subjectPublicKeyInfo,
+		Identifiers: order.Identifiers,
+		Profile:     profileName,
+	})
+
+	if err != nil {
+		return fmt.Errorf("issuing MTC: %s", err)
+	}
+
+	ra.log.Infof("issued MTC from %s: %d", resp.MtcLogID, resp.MtcEntryIndex)
+	return nil
 }
 
 // containsMustStaple returns true if the provided set of extensions includes
@@ -1128,12 +1167,19 @@ func (ra *RegistrationAuthorityImpl) issueCertificateOuter(
 		logEvent.PreviousCertificateIssued = timestamps.Timestamps[0].AsTime()
 	}
 
-	profileName := order.CertificateProfileName
-	if profileName == "" {
-		profileName = ra.profiles.defaultName
+	if ra.isMTC(order) {
+		err := ra.issueMTC(ctx, order, csr.RawSubjectPublicKeyInfo)
+		if err != nil {
+			ra.failOrder(ctx, order, web.ProblemDetailsForError(err, "Error finalizing order"))
+			return nil, err
+		}
+
+		ra.countCertificateIssued(ctx, order.RegistrationID, idents, isRenewal)
+		return order, nil
 	}
 
 	// Step 3: Issue the Certificate
+	profileName := ra.profileName(order)
 	cert, err := ra.issueCertificateInner(
 		ctx, csr, authzs, isRenewal, profileName, accountID(order.RegistrationID), orderID(order.Id))
 
@@ -1174,6 +1220,19 @@ func (ra *RegistrationAuthorityImpl) issueCertificateOuter(
 	ra.log.AuditInfo(fmt.Sprintf("Certificate request - %s", result), logEvent)
 
 	return order, err
+}
+
+func (ra *RegistrationAuthorityImpl) profileName(order *corepb.Order) string {
+	if order.CertificateProfileName == "" {
+		return ra.profiles.defaultName
+	}
+	return order.CertificateProfileName
+}
+
+func (ra *RegistrationAuthorityImpl) isMTC(order *corepb.Order) bool {
+	profileName := ra.profileName(order)
+	profile := ra.profiles.byName[profileName]
+	return profile != nil && profile.mtc
 }
 
 // countCertificateIssued increments the certificates (per domain and per

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -52,6 +52,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/mocks"
+	mtcapb "github.com/letsencrypt/boulder/mtca/proto"
 	"github.com/letsencrypt/boulder/policy"
 	pubpb "github.com/letsencrypt/boulder/publisher/proto"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
@@ -379,10 +380,12 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 	})
 	test.AssertNotError(t, err, "making validation profiles")
 
+	profileToMTCA := make(map[string]mtcapb.MTCAClient)
+
 	ra := NewRegistrationAuthorityImpl(
 		fc, log, stats,
 		1, testKeyPolicy, limiter, txnBuilder,
-		profiles, nil, 5*time.Minute, ctp, nil)
+		profiles, nil, 5*time.Minute, ctp, nil, profileToMTCA)
 	ra.SA = sa
 	ra.VA = va
 	ra.CA = ca

--- a/sa/db/01-boulder_sa_next.sql
+++ b/sa/db/01-boulder_sa_next.sql
@@ -249,6 +249,5 @@ ALTER TABLE `certificateStatus` DROP COLUMN `LockCol`;
 ALTER TABLE `revokedCertificates` ADD KEY `serial` (`serial`);
 
 ALTER TABLE `orders`
-  ADD COLUMN `isMTC` bool NOT NULL DEFAULT FALSE,
   ADD COLUMN `mtcLogID` varchar(255) DEFAULT NULL,
   ADD COLUMN `mtcSerialNumber` bigint(20) unsigned DEFAULT NULL;

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -64,6 +64,17 @@
 					"dns",
 					"ip"
 				]
+			},
+			"mtcshortlived": {
+				"mtc": true,
+				"pendingAuthzLifetime": "7h",
+				"validAuthzLifetime": "7h",
+				"orderLifetime": "7h",
+				"maxNames": 10,
+				"identifierTypes": [
+					"dns",
+					"ip"
+				]
 			}
 		},
 		"defaultProfileName": "legacy",
@@ -71,6 +82,18 @@
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/ra.boulder/cert.pem",
 			"keyFile": "test/certs/ipki/ra.boulder/key.pem"
+		},
+		"profileToMTCA": {
+			"mtcshortlived": {
+				"dnsAuthority": "consul.service.consul",
+				"srvLookup": {
+					"service": "mtca",
+					"domain": "service.consul"
+				},
+				"timeout": "20s",
+				"noWaitForReady": false,
+				"hostOverride": "mtca.boulder"
+			}
 		},
 		"vaService": {
 			"dnsAuthority": "consul.service.consul",

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -141,7 +141,8 @@
 		"certProfiles": {
 			"legacy": "The normal profile you know and love",
 			"modern": "Profile 2: Electric Boogaloo",
-			"shortlived": "Like modern, but smaller"
+			"shortlived": "Like modern, but smaller",
+			"mtcshortlived": "Like shortlived, but MTC"
 		},
 		"unpause": {
 			"hmacKey": {

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 
@@ -169,6 +170,33 @@ func TestIssuanceProfiles(t *testing.T) {
 
 	test.AssertEquals(t, len(legacy.SubjectKeyId), 20)
 	test.AssertEquals(t, len(modern.SubjectKeyId), 0)
+}
+
+// TestIssuanceMTC issues from an MTC profile.
+func TestIssuanceMTC(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
+		t.Skip("MTC issuance only available in config-next")
+	}
+
+	client, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating acme client: %s", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating keypair: %s", err)
+	}
+
+	idents := []acme.Identifier{{Type: "dns", Value: random_domain()}}
+
+	_, err = authAndIssue(client, key, idents, true, "mtcshortlived")
+	// "finalized order timeout" is as far as we get for now. Once we are collecting
+	// signatures and constructing standalone certificates, we'll expect this to succeed.
+	if err == nil || !strings.Contains(err.Error(), "finalized order timeout") {
+		t.Fatalf("issuing certificate: expected 'finalized order timeout', got %q", err)
+	}
 }
 
 // TestIPShortLived verifies that we will allow IP address identifiers only in


### PR DESCRIPTION
Since we're going to be using profiles to decide whether an issuance uses MTC, remove the isMTC field from the orders table in boulder_sa_next.