### PR TITLE
tlog: Add shared primitives for MTC transparency logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.52.0
+	golang.org/x/mod v0.35.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
@@ -85,7 +86,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/tlog/checkpoint.go
+++ b/tlog/checkpoint.go
@@ -1,0 +1,146 @@
+package tlog
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/mod/sumdb/note"
+	xtlog "golang.org/x/mod/sumdb/tlog"
+)
+
+// Checkpoint is a parsed tlog-checkpoint note body. Hand-constructed values
+// are unvalidated; serialize them with Marshal. ParseCheckpoint only returns
+// values satisfying the tlog-checkpoint rules.
+type Checkpoint struct {
+	Origin     string
+	Tree       xtlog.Tree
+	Extensions []string
+}
+
+// String returns the tlog-checkpoint note body, including the trailing
+// newline and no signature lines. It does not validate c; producers should
+// use Marshal.
+func (c Checkpoint) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n%d\n%s\n", c.Origin, c.Tree.N, c.Tree.Hash)
+	for _, e := range c.Extensions {
+		b.WriteString(e)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// Marshal validates c against the structural tlog-checkpoint rules and
+// returns the canonical note body; the encoding rules hold by construction
+// in String.
+func (c Checkpoint) Marshal() (string, error) {
+	if c.Origin == "" {
+		return "", errors.New("empty checkpoint origin")
+	}
+	if !validNoteLine(c.Origin) {
+		return "", errors.New("checkpoint origin contains a control character or invalid UTF-8")
+	}
+	if c.Tree.N < 0 {
+		return "", fmt.Errorf("negative checkpoint tree size %d", c.Tree.N)
+	}
+	for _, e := range c.Extensions {
+		if e == "" {
+			return "", errors.New("empty checkpoint extension line")
+		}
+		if !validNoteLine(e) {
+			return "", errors.New("checkpoint extension line contains a control character or invalid UTF-8")
+		}
+	}
+	return c.String(), nil
+}
+
+// validNoteLine reports whether s can appear as one line of a signed note:
+// valid UTF-8 with no ASCII control characters (per signed-note), including
+// no newline, since s is a single line.
+func validNoteLine(s string) bool {
+	if !utf8.ValidString(s) {
+		return false
+	}
+	for _, r := range s {
+		if r < 0x20 {
+			return false
+		}
+	}
+	return true
+}
+
+// ParseCheckpoint parses a tlog-checkpoint note body. It rejects
+// non-canonical encodings such as a leading-zero tree size, so parsing then
+// String round-trips exactly. Tree sizes at or above 2^63 are rejected as
+// unrepresentable in the int64 sizes used throughout.
+func ParseCheckpoint(text string) (Checkpoint, error) {
+	if !strings.HasSuffix(text, "\n") {
+		return Checkpoint{}, errors.New("checkpoint does not end in newline")
+	}
+	lines := strings.Split(strings.TrimSuffix(text, "\n"), "\n")
+	if len(lines) < 3 {
+		return Checkpoint{}, errors.New("checkpoint has too few lines")
+	}
+
+	origin := lines[0]
+	if origin == "" {
+		return Checkpoint{}, errors.New("empty checkpoint origin")
+	}
+	// note.Open enforces the character rules on notes it parses, but
+	// ParseCheckpoint also gates Ed25519Cosigner.Sign on raw bodies, which
+	// would otherwise cosign bodies no conformant note parser accepts.
+	if !validNoteLine(origin) {
+		return Checkpoint{}, errors.New("checkpoint origin contains a control character or invalid UTF-8")
+	}
+
+	n, err := strconv.ParseInt(lines[1], 10, 64)
+	if err != nil || n < 0 || strconv.FormatInt(n, 10) != lines[1] {
+		return Checkpoint{}, errors.New("malformed checkpoint tree size")
+	}
+
+	hb, err := base64.StdEncoding.DecodeString(lines[2])
+	if err != nil || len(hb) != xtlog.HashSize || base64.StdEncoding.EncodeToString(hb) != lines[2] {
+		return Checkpoint{}, errors.New("malformed checkpoint root hash")
+	}
+	var hash xtlog.Hash
+	copy(hash[:], hb)
+
+	extensions := lines[3:]
+	for _, e := range extensions {
+		if e == "" {
+			return Checkpoint{}, errors.New("empty checkpoint extension line")
+		}
+		if !validNoteLine(e) {
+			return Checkpoint{}, errors.New("checkpoint extension line contains a control character or invalid UTF-8")
+		}
+	}
+	if len(extensions) == 0 {
+		extensions = nil
+	}
+
+	return Checkpoint{Origin: origin, Tree: xtlog.Tree{N: n, Hash: hash}, Extensions: extensions}, nil
+}
+
+// VerifyCheckpoint opens a signed checkpoint note against the given verifiers
+// and parses its body. It returns the opened note so the caller can inspect
+// which signatures verified.
+//
+// Known upstream divergence: note.Open skips a duplicate (name, key ID)
+// signature before verifying it, so a note carrying a valid and an invalid
+// signature from the same known key opens, against signed-note's SHOULD
+// reject.
+func VerifyCheckpoint(signedNote []byte, verifiers note.Verifiers) (Checkpoint, *note.Note, error) {
+	n, err := note.Open(signedNote, verifiers)
+	if err != nil {
+		return Checkpoint{}, nil, err
+	}
+	c, err := ParseCheckpoint(n.Text)
+	if err != nil {
+		return Checkpoint{}, nil, err
+	}
+	return c, n, nil
+}

--- a/tlog/checkpoint_test.go
+++ b/tlog/checkpoint_test.go
@@ -1,0 +1,258 @@
+package tlog
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"slices"
+	"testing"
+
+	"golang.org/x/mod/sumdb/note"
+)
+
+const exampleHashB64 = "CsUYapGGPo4dkMgIAUqom/Xajj7h2fB2MPA3j2jxq2I="
+
+func TestParseCheckpointRoundTrip(t *testing.T) {
+	cases := []struct {
+		name       string
+		text       string
+		origin     string
+		size       int64
+		extensions []string
+	}{
+		{
+			name:   "No extensions",
+			text:   "example.com/log\n20852163\n" + exampleHashB64 + "\n",
+			origin: "example.com/log",
+			size:   20852163,
+		},
+		{
+			name:       "With extensions",
+			text:       "example.com/log\n20852163\n" + exampleHashB64 + "\nfoo extension\nbar extension\n",
+			origin:     "example.com/log",
+			size:       20852163,
+			extensions: []string{"foo extension", "bar extension"},
+		},
+		{
+			name:   "Zero size",
+			text:   "example.com/log\n0\n" + exampleHashB64 + "\n",
+			origin: "example.com/log",
+			size:   0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := ParseCheckpoint(tc.text)
+			if err != nil {
+				t.Fatalf("ParseCheckpoint: %s", err)
+			}
+			if c.Origin != tc.origin {
+				t.Errorf("Origin = %q, want %q", c.Origin, tc.origin)
+			}
+			if c.Tree.N != tc.size {
+				t.Errorf("Tree.N = %d, want %d", c.Tree.N, tc.size)
+			}
+			if !slices.Equal(c.Extensions, tc.extensions) {
+				t.Errorf("Extensions = %v, want %v", c.Extensions, tc.extensions)
+			}
+			got := c.String()
+			if got != tc.text {
+				t.Errorf("String() = %q, want %q", got, tc.text)
+			}
+		})
+	}
+}
+
+func TestParseCheckpointRejects(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"No trailing newline", "example.com/log\n1\n" + exampleHashB64},
+		{"Too few lines", "example.com/log\n1\n"},
+		{"Empty origin", "\n1\n" + exampleHashB64 + "\n"},
+		{"Leading zero size", "example.com/log\n01\n" + exampleHashB64 + "\n"},
+		{"Negative size", "example.com/log\n-1\n" + exampleHashB64 + "\n"},
+		{"Non-numeric size", "example.com/log\nx\n" + exampleHashB64 + "\n"},
+		{"Bad base64 hash", "example.com/log\n1\n!!!notbase64!!!\n"},
+		{"Non-canonical base64 hash", "example.com/log\n1\nCsUYapGGPo4dkMgIAUqom/Xajj7h2fB2MPA3j2jxq2J=\n"},
+		{"Short hash", "example.com/log\n1\nAAAA\n"},
+		{"Empty extension line", "example.com/log\n1\n" + exampleHashB64 + "\n\n"},
+		// signed-note bans ASCII control characters other than newline;
+		// ParseCheckpoint must enforce it itself because it gates Sign on
+		// raw bodies that never pass through note.Open.
+		{"Carriage return in origin", "example.com/log\r\n1\n" + exampleHashB64 + "\n"},
+		{"Control character in origin", "example.com/\x01log\n1\n" + exampleHashB64 + "\n"},
+		{"Invalid UTF-8 in origin", "example.com/\xff\n1\n" + exampleHashB64 + "\n"},
+		{"Control character in extension", "example.com/log\n1\n" + exampleHashB64 + "\next\x01ension\n"},
+		{"Carriage return in extension", "example.com/log\n1\n" + exampleHashB64 + "\nextension\r\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseCheckpoint(tc.text)
+			if err == nil {
+				t.Error("ParseCheckpoint = nil error, want error")
+			}
+		})
+	}
+}
+
+// TestCheckpointMarshal covers the validating serialization path for
+// hand-constructed Checkpoints, which String deliberately does not validate.
+func TestCheckpointMarshal(t *testing.T) {
+	valid, err := ParseCheckpoint(exampleCheckpoint)
+	if err != nil {
+		t.Fatalf("ParseCheckpoint: %s", err)
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		got, err := valid.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal: %s", err)
+		}
+		if got != valid.String() {
+			t.Errorf("Marshal = %q, want %q", got, valid.String())
+		}
+	})
+
+	cases := []struct {
+		name   string
+		mutate func(Checkpoint) Checkpoint
+	}{
+		{"Empty origin", func(c Checkpoint) Checkpoint { c.Origin = ""; return c }},
+		{"Newline in origin", func(c Checkpoint) Checkpoint { c.Origin = "two\nlines"; return c }},
+		{"Carriage return in origin", func(c Checkpoint) Checkpoint { c.Origin = "cr\rorigin"; return c }},
+		{"Invalid UTF-8 in origin", func(c Checkpoint) Checkpoint { c.Origin = "bad\xff"; return c }},
+		{"Negative tree size", func(c Checkpoint) Checkpoint { c.Tree.N = -1; return c }},
+		{"Empty extension", func(c Checkpoint) Checkpoint { c.Extensions = []string{""}; return c }},
+		{"Newline in extension", func(c Checkpoint) Checkpoint { c.Extensions = []string{"two\nlines"}; return c }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.mutate(valid).Marshal()
+			if err == nil {
+				t.Error("Marshal = nil error, want error")
+			}
+		})
+	}
+}
+
+func TestVerifyCheckpoint(t *testing.T) {
+	key := testKey(t)
+	pub := key.Public().(ed25519.PublicKey)
+
+	c, err := NewEd25519Cosigner(cosignerName, key, fixedClock())
+	if err != nil {
+		t.Fatalf("NewEd25519Cosigner: %s", err)
+	}
+	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, c)
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+	v, err := NewCosignatureVerifier(cosignerName, pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		cp, n, err := VerifyCheckpoint(signed, note.VerifierList(v))
+		if err != nil {
+			t.Fatalf("VerifyCheckpoint: %s", err)
+		}
+		if cp.Origin != "example.com/behind-the-sofa" {
+			t.Errorf("Origin = %q, want %q", cp.Origin, "example.com/behind-the-sofa")
+		}
+		if cp.Tree.N != 20852163 {
+			t.Errorf("Tree.N = %d, want %d", cp.Tree.N, 20852163)
+		}
+		if len(n.Sigs) != 1 {
+			t.Errorf("len(Sigs) = %d, want 1", len(n.Sigs))
+		}
+	})
+
+	t.Run("Wrong key", func(t *testing.T) {
+		otherKey := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+		otherV, err := NewCosignatureVerifier(cosignerName, otherKey.Public().(ed25519.PublicKey))
+		if err != nil {
+			t.Fatalf("NewCosignatureVerifier: %s", err)
+		}
+		_, _, err = VerifyCheckpoint(signed, note.VerifierList(otherV))
+		if err == nil {
+			t.Error("VerifyCheckpoint with wrong key = nil error, want error")
+		}
+	})
+}
+
+// TestVerifyCheckpointRejectsNonCheckpointBody covers the branch where the note
+// signature verifies but its body does not parse as a checkpoint.
+func TestVerifyCheckpointRejectsNonCheckpointBody(t *testing.T) {
+	skey, vkey, err := note.GenerateKey(rand.Reader, "log.example")
+	if err != nil {
+		t.Fatalf("GenerateKey: %s", err)
+	}
+	signer, err := note.NewSigner(skey)
+	if err != nil {
+		t.Fatalf("NewSigner: %s", err)
+	}
+	signed, err := note.Sign(&note.Note{Text: "not a checkpoint\n"}, signer)
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+	verifier, err := note.NewVerifier(vkey)
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	_, _, err = VerifyCheckpoint(signed, note.VerifierList(verifier))
+	if err == nil {
+		t.Error("VerifyCheckpoint of a verified non-checkpoint note = nil error, want error")
+	}
+}
+
+// TestVerifyCheckpointIgnoresUnknownSignatures covers signed-note's
+// "verifiers MUST ignore signatures from unknown keys" with a two-cosigner
+// note opened by one verifier, the shape of every real exchange.
+func TestVerifyCheckpointIgnoresUnknownSignatures(t *testing.T) {
+	key := testKey(t)
+	pub := key.Public().(ed25519.PublicKey)
+
+	known, err := NewEd25519Cosigner(cosignerName, key, fixedClock())
+	if err != nil {
+		t.Fatalf("NewEd25519Cosigner: %s", err)
+	}
+	otherKey := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+	unknown, err := NewEd25519Cosigner("other.test/m2", otherKey, fixedClock())
+	if err != nil {
+		t.Fatalf("NewEd25519Cosigner: %s", err)
+	}
+	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, known, unknown)
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+
+	v, err := NewCosignatureVerifier(cosignerName, pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+	cp, n, err := VerifyCheckpoint(signed, note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("VerifyCheckpoint: %s", err)
+	}
+	if cp.Origin != "example.com/behind-the-sofa" {
+		t.Errorf("Origin = %q, want %q", cp.Origin, "example.com/behind-the-sofa")
+	}
+	if len(n.Sigs) != 1 || n.Sigs[0].Name != cosignerName {
+		t.Fatalf("Sigs = %+v, want only the known cosigner's", n.Sigs)
+	}
+	if len(n.UnverifiedSigs) != 1 || n.UnverifiedSigs[0].Name != "other.test/m2" {
+		t.Errorf("UnverifiedSigs = %+v, want the unknown cosigner's", n.UnverifiedSigs)
+	}
+	if !CosignedBy(n, v) {
+		t.Error("CosignedBy = false for the known cosigner")
+	}
+	blob, ok := Cosignature(n, v)
+	if !ok {
+		t.Fatal("Cosignature = false for the known cosigner")
+	}
+	if _, ok := VerifyCosignature(pub, []byte(exampleCheckpoint), blob); !ok {
+		t.Error("extracted cosignature does not verify")
+	}
+}

--- a/tlog/cosignature.go
+++ b/tlog/cosignature.go
@@ -1,0 +1,258 @@
+package tlog
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/jmhodges/clock"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// cosignatureAlg is the tlog-cosignature signature type byte for Ed25519
+// cosignatures, used in the key ID computation.
+const cosignatureAlg = 0x04
+
+// noteSigPrefix is the leading U+2014 and space that begin a signed-note
+// signature line.
+const noteSigPrefix = "— "
+
+// isValidCosignerName reports whether name is usable as a signed-note key
+// name: non-empty, valid UTF-8, no Unicode spaces, no "+" (mirroring x/mod's
+// unexported note.isValidName). Cosign builds signature lines by hand rather
+// than through note.Sign, so this is our only gate.
+func isValidCosignerName(name string) bool {
+	return name != "" && utf8.ValidString(name) && strings.IndexFunc(name, unicode.IsSpace) < 0 && !strings.Contains(name, "+")
+}
+
+// CosignatureKeyID returns the tlog-cosignature Ed25519 key ID:
+// SHA-256(name || "\n" || 0x04 || pubkey)[:4], as a big-endian uint32.
+func CosignatureKeyID(name string, pub ed25519.PublicKey) uint32 {
+	h := sha256.New()
+	h.Write([]byte(name))
+	h.Write([]byte{'\n', cosignatureAlg})
+	h.Write(pub)
+	return binary.BigEndian.Uint32(h.Sum(nil)[:4])
+}
+
+// cosignatureMessage builds the tlog-cosignature Ed25519 signed message: the
+// "cosignature/v1" header line, the timestamp line, and the cosigned checkpoint
+// body (which must include its trailing newline and no signature lines).
+func cosignatureMessage(timestamp uint64, body []byte) []byte {
+	var b bytes.Buffer
+	b.WriteString("cosignature/v1\n")
+	b.WriteString("time ")
+	b.WriteString(strconv.FormatUint(timestamp, 10))
+	b.WriteByte('\n')
+	b.Write(body)
+	return b.Bytes()
+}
+
+// Ed25519Cosigner produces tlog-cosignature Ed25519 cosignatures over
+// checkpoints, as a note.Signer. Checkpoint cosignatures only: cosigners
+// whose signatures appear in MTC standalone certificates MUST be ML-DSA-44
+// MTC cosigners (mtc-tlog, Cosigners), a different format that will land
+// alongside this type.
+type Ed25519Cosigner struct {
+	name  string
+	key   ed25519.PrivateKey
+	keyID uint32
+	clk   clock.Clock
+}
+
+// NewEd25519Cosigner returns a cosigner that signs as name with key, drawing
+// cosignature timestamps from clk.
+func NewEd25519Cosigner(name string, key ed25519.PrivateKey, clk clock.Clock) (*Ed25519Cosigner, error) {
+	if !isValidCosignerName(name) {
+		return nil, fmt.Errorf("invalid cosigner name %q: must be non-empty UTF-8 with no spaces or plus signs", name)
+	}
+	if len(key) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("ed25519 private key must be %d bytes, got %d", ed25519.PrivateKeySize, len(key))
+	}
+	pub, ok := key.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("ed25519 private key has unexpected public key type")
+	}
+	return &Ed25519Cosigner{
+		name:  name,
+		key:   key,
+		keyID: CosignatureKeyID(name, pub),
+		clk:   clk,
+	}, nil
+}
+
+// Name returns the key name that identifies this cosigner in note signature
+// lines.
+func (c *Ed25519Cosigner) Name() string {
+	return c.name
+}
+
+// KeyHash returns the cosigner's note key hash, the four-byte key ID from
+// CosignatureKeyID.
+func (c *Ed25519Cosigner) KeyHash() uint32 {
+	return c.keyID
+}
+
+// Sign returns the timestamped_signature for the cosigned checkpoint body: the
+// big-endian timestamp followed by the Ed25519 signature. It refuses to sign
+// anything but a canonically-encoded checkpoint, so a malformed or
+// non-canonical note can never be cosigned.
+func (c *Ed25519Cosigner) Sign(body []byte) ([]byte, error) {
+	parsed, err := ParseCheckpoint(string(body))
+	if err != nil {
+		return nil, fmt.Errorf("refusing to cosign non-checkpoint message: %w", err)
+	}
+	if parsed.String() != string(body) {
+		return nil, errors.New("refusing to cosign non-canonical checkpoint")
+	}
+	// tlog-cosignature: the timestamp MUST NOT exceed 2^63-1. A pre-epoch
+	// clock would wrap the uint64 conversion into that forbidden range.
+	now := c.clk.Now().Unix()
+	if now < 0 {
+		return nil, errors.New("refusing to cosign: clock reads before the Unix epoch")
+	}
+	timestamp := uint64(now)
+	sig := ed25519.Sign(c.key, cosignatureMessage(timestamp, body))
+	out := make([]byte, 8+ed25519.SignatureSize)
+	binary.BigEndian.PutUint64(out[:8], timestamp)
+	copy(out[8:], sig)
+	return out, nil
+}
+
+// Cosign returns the complete signed-note signature line cosigning the given
+// checkpoint body, including its trailing newline.
+func (c *Ed25519Cosigner) Cosign(body []byte) (string, error) {
+	sig, err := c.Sign(body)
+	if err != nil {
+		return "", err
+	}
+	return cosignatureLineFor(c.name, c.keyID, sig), nil
+}
+
+var _ note.Signer = (*Ed25519Cosigner)(nil)
+
+// cosignatureLineFor assembles "— <name> base64(keyID || sig)\n", the one
+// place the signature line layout is written.
+func cosignatureLineFor(name string, keyID uint32, timestampedSig []byte) string {
+	idSig := make([]byte, 4+len(timestampedSig))
+	binary.BigEndian.PutUint32(idSig[:4], keyID)
+	copy(idSig[4:], timestampedSig)
+	return noteSigPrefix + name + " " + base64.StdEncoding.EncodeToString(idSig) + "\n"
+}
+
+// CosignatureLine renders a stored timestamped_signature as its signed-note
+// signature line, recomputing the key ID from the name and public key so no
+// signing key is needed. It is the inverse of Cosignature, for consumers
+// that persist cosignatures as raw blobs.
+func CosignatureLine(name string, pub ed25519.PublicKey, timestampedSig []byte) (string, error) {
+	if !isValidCosignerName(name) {
+		return "", fmt.Errorf("invalid cosigner name %q: must be non-empty UTF-8 with no spaces or plus signs", name)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("ed25519 public key must be %d bytes, got %d", ed25519.PublicKeySize, len(pub))
+	}
+	if len(timestampedSig) != 8+ed25519.SignatureSize {
+		return "", fmt.Errorf("timestamped signature must be %d bytes, got %d", 8+ed25519.SignatureSize, len(timestampedSig))
+	}
+	// Sign cannot produce a timestamp above 2^63-1, so one here means
+	// corrupt or foreign storage.
+	if binary.BigEndian.Uint64(timestampedSig[:8]) > math.MaxInt64 {
+		return "", errors.New("timestamped signature has a timestamp above 2^63-1")
+	}
+	return cosignatureLineFor(name, CosignatureKeyID(name, pub), timestampedSig), nil
+}
+
+// Cosignature returns the raw timestamped_signature of v's verified
+// signature on n, reporting false when v did not sign n or the signature is
+// not a timestamped_signature. As with CosignedBy, v must be one of the
+// verifiers that opened n.
+func Cosignature(n *note.Note, v note.Verifier) ([]byte, bool) {
+	for _, sig := range n.Sigs {
+		if sig.Name != v.Name() || sig.Hash != v.KeyHash() {
+			continue
+		}
+		idSig, err := base64.StdEncoding.DecodeString(sig.Base64)
+		if err != nil || len(idSig) != 4+8+ed25519.SignatureSize {
+			return nil, false
+		}
+		return idSig[4:], true
+	}
+	return nil, false
+}
+
+// VerifyCosignature verifies a tlog-cosignature Ed25519 timestamped_signature
+// over the given checkpoint body, returning the embedded timestamp.
+func VerifyCosignature(pub ed25519.PublicKey, body, sig []byte) (timestamp uint64, ok bool) {
+	if len(sig) != 8+ed25519.SignatureSize {
+		return 0, false
+	}
+	timestamp = binary.BigEndian.Uint64(sig[:8])
+	// tlog-cosignature: the timestamp MUST NOT exceed 2^63-1.
+	if timestamp > math.MaxInt64 {
+		return 0, false
+	}
+	return timestamp, ed25519.Verify(pub, cosignatureMessage(timestamp, body), sig[8:])
+}
+
+// CosignatureVerifier verifies tlog-cosignature Ed25519 cosignatures, as a
+// note.Verifier.
+type CosignatureVerifier struct {
+	name  string
+	keyID uint32
+	pub   ed25519.PublicKey
+}
+
+// NewCosignatureVerifier returns a verifier for cosignatures from name with the
+// given public key.
+func NewCosignatureVerifier(name string, pub ed25519.PublicKey) (*CosignatureVerifier, error) {
+	if !isValidCosignerName(name) {
+		return nil, fmt.Errorf("invalid cosigner name %q: must be non-empty UTF-8 with no spaces or plus signs", name)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("ed25519 public key must be %d bytes, got %d", ed25519.PublicKeySize, len(pub))
+	}
+	return &CosignatureVerifier{name: name, keyID: CosignatureKeyID(name, pub), pub: pub}, nil
+}
+
+// Name returns the key name that identifies this cosigner in note signature
+// lines.
+func (v *CosignatureVerifier) Name() string {
+	return v.name
+}
+
+// KeyHash returns the cosigner's note key hash, the four-byte key ID from
+// CosignatureKeyID.
+func (v *CosignatureVerifier) KeyHash() uint32 {
+	return v.keyID
+}
+
+// Verify reports whether sig is a valid cosignature by this cosigner over the
+// checkpoint body msg.
+func (v *CosignatureVerifier) Verify(msg, sig []byte) bool {
+	_, ok := VerifyCosignature(v.pub, msg, sig)
+	return ok
+}
+
+var _ note.Verifier = (*CosignatureVerifier)(nil)
+
+// CosignedBy reports whether the opened note carries a verified signature
+// from the cosigner identified by v. The (name, key ID) match is only
+// meaningful when v was among the verifiers that opened n: n.Sigs holds only
+// verified signatures, and the 4-byte key ID is not collision resistant.
+func CosignedBy(n *note.Note, v note.Verifier) bool {
+	for _, sig := range n.Sigs {
+		if sig.Name == v.Name() && sig.Hash == v.KeyHash() {
+			return true
+		}
+	}
+	return false
+}

--- a/tlog/cosignature_test.go
+++ b/tlog/cosignature_test.go
@@ -1,0 +1,425 @@
+package tlog
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"golang.org/x/mod/sumdb/note"
+)
+
+const cosignerName = "mirror.test/m1"
+
+// exampleCheckpoint is a tlog-checkpoint note body, including the trailing
+// newline and no signature lines.
+const exampleCheckpoint = "example.com/behind-the-sofa\n20852163\nCsUYapGGPo4dkMgIAUqom/Xajj7h2fB2MPA3j2jxq2I=\n"
+
+// fixedClock returns a fake clock set to the example cosignature timestamp.
+func fixedClock() clock.Clock {
+	clk := clock.NewFake()
+	clk.Set(time.Unix(1679315147, 0))
+	return clk
+}
+
+func testKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}
+
+func newCosigner(t *testing.T) *Ed25519Cosigner {
+	t.Helper()
+	c, err := NewEd25519Cosigner(cosignerName, testKey(t), fixedClock())
+	if err != nil {
+		t.Fatalf("NewEd25519Cosigner: %s", err)
+	}
+	return c
+}
+
+// TestCosignatureKeyID derives SHA-256(name || 0x0A || 0x04 || pubkey)[:4]
+// independently from the spec text; no published vector ships a key and ID
+// together, and an internal round-trip cannot catch a shared misreading.
+func TestCosignatureKeyID(t *testing.T) {
+	pub := testKey(t).Public().(ed25519.PublicKey)
+
+	h := sha256.New()
+	h.Write([]byte(cosignerName))
+	h.Write([]byte{0x0A, 0x04})
+	h.Write(pub)
+	expect := binary.BigEndian.Uint32(h.Sum(nil)[:4])
+
+	if got := CosignatureKeyID(cosignerName, pub); got != expect {
+		t.Errorf("CosignatureKeyID = %#x, want %#x", got, expect)
+	}
+
+	c := newCosigner(t)
+	if c.KeyHash() != expect {
+		t.Errorf("KeyHash() = %#x, want %#x", c.KeyHash(), expect)
+	}
+	if c.Name() != cosignerName {
+		t.Errorf("Name() = %q, want %q", c.Name(), cosignerName)
+	}
+}
+
+func TestCosignMessageFormat(t *testing.T) {
+	got := string(cosignatureMessage(1679315147, []byte(exampleCheckpoint)))
+	want := "cosignature/v1\ntime 1679315147\n" + exampleCheckpoint
+	if got != want {
+		t.Errorf("cosignatureMessage = %q, want %q", got, want)
+	}
+}
+
+// TestCosignRoundTrip cosigns, parses the resulting note signature line by hand,
+// and verifies it, checking the wire layout of the timestamped signature.
+func TestCosignRoundTrip(t *testing.T) {
+	pub := testKey(t).Public().(ed25519.PublicKey)
+	c := newCosigner(t)
+
+	line, err := c.Cosign([]byte(exampleCheckpoint))
+	if err != nil {
+		t.Fatalf("Cosign: %s", err)
+	}
+	if !strings.HasPrefix(line, noteSigPrefix+cosignerName+" ") {
+		t.Errorf("line %q has unexpected prefix", line)
+	}
+	if !strings.HasSuffix(line, "\n") {
+		t.Errorf("line %q is missing a trailing newline", line)
+	}
+
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) != 3 || fields[1] != cosignerName {
+		t.Fatalf("line fields = %q, want [— %s <sig>]", fields, cosignerName)
+	}
+	idSig, err := base64.StdEncoding.DecodeString(fields[2])
+	if err != nil {
+		t.Fatalf("decoding signature: %s", err)
+	}
+	if len(idSig) != 4+8+ed25519.SignatureSize {
+		t.Fatalf("signature is %d bytes, want %d", len(idSig), 4+8+ed25519.SignatureSize)
+	}
+	gotID := binary.BigEndian.Uint32(idSig[:4])
+	if gotID != CosignatureKeyID(cosignerName, pub) {
+		t.Errorf("embedded key ID = %d, want %d", gotID, CosignatureKeyID(cosignerName, pub))
+	}
+
+	ts, ok := VerifyCosignature(pub, []byte(exampleCheckpoint), idSig[4:])
+	if !ok {
+		t.Fatal("VerifyCosignature rejected a valid cosignature")
+	}
+	if ts != 1679315147 {
+		t.Errorf("timestamp = %d, want 1679315147", ts)
+	}
+	_, ok = VerifyCosignature(pub, []byte("example.com/other\n1\nAAAA\n"), idSig[4:])
+	if ok {
+		t.Error("VerifyCosignature accepted a cosignature over the wrong checkpoint")
+	}
+}
+
+// TestCosignerNoteRoundTrip drives the cosigner and verifier through the real
+// note.Sign/note.Open, confirming Ed25519Cosigner is a usable note.Signer and
+// CosignatureVerifier a usable note.Verifier.
+func TestCosignerNoteRoundTrip(t *testing.T) {
+	pub := testKey(t).Public().(ed25519.PublicKey)
+
+	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, newCosigner(t))
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+	v, err := NewCosignatureVerifier(cosignerName, pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+	n, err := note.Open(signed, note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("note.Open: %s", err)
+	}
+	if n.Text != exampleCheckpoint {
+		t.Errorf("note text = %q, want %q", n.Text, exampleCheckpoint)
+	}
+	if len(n.Sigs) != 1 || n.Sigs[0].Name != cosignerName {
+		t.Errorf("Sigs = %+v, want one from %q", n.Sigs, cosignerName)
+	}
+}
+
+func TestCosignedBy(t *testing.T) {
+	pub := testKey(t).Public().(ed25519.PublicKey)
+	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, newCosigner(t))
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+	v, err := NewCosignatureVerifier(cosignerName, pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+	n, err := note.Open(signed, note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("note.Open: %s", err)
+	}
+
+	if !CosignedBy(n, v) {
+		t.Error("CosignedBy = false for the cosigner that signed the note")
+	}
+	other, err := NewCosignatureVerifier("other.test/x", pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+	if CosignedBy(n, other) {
+		t.Error("CosignedBy = true for a cosigner that did not sign the note")
+	}
+}
+
+func TestVerifyCosignatureRejectsMalformedSig(t *testing.T) {
+	pub := testKey(t).Public().(ed25519.PublicKey)
+	for _, length := range []int{0, 7, 8, 8 + ed25519.SignatureSize - 1, 8 + ed25519.SignatureSize + 1} {
+		_, ok := VerifyCosignature(pub, []byte(exampleCheckpoint), make([]byte, length))
+		if ok {
+			t.Errorf("VerifyCosignature accepted a %d-byte signature", length)
+		}
+	}
+}
+
+func TestCosignRefusesNonCanonical(t *testing.T) {
+	c := newCosigner(t)
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"Not a checkpoint", "not a checkpoint"},
+		{"Leading zero size", "example.com/log\n01\n" + exampleHashB64 + "\n"},
+		{"No trailing newline", "example.com/log\n1\n" + exampleHashB64},
+	}
+	for _, tc := range cases {
+		_, err := c.Cosign([]byte(tc.body))
+		if err == nil {
+			t.Errorf("Cosign(%s) = nil error, want error", tc.name)
+		}
+	}
+}
+
+func TestConstructorsRejectBadKey(t *testing.T) {
+	_, err := NewEd25519Cosigner(cosignerName, ed25519.PrivateKey("short"), clock.NewFake())
+	if err == nil {
+		t.Error("NewEd25519Cosigner with a short key = nil error, want error")
+	}
+	_, err = NewCosignatureVerifier(cosignerName, ed25519.PublicKey("short"))
+	if err == nil {
+		t.Error("NewCosignatureVerifier with a short key = nil error, want error")
+	}
+}
+
+// TestConstructorsRejectBadName enforces signed-note's key name rules; the
+// constructors are the only gate since Cosign builds lines by hand.
+func TestConstructorsRejectBadName(t *testing.T) {
+	key := testKey(t)
+	pub := key.Public().(ed25519.PublicKey)
+	for _, name := range []string{
+		"",
+		"has space",
+		"has\ttab",
+		"has+plus",
+		"bad\xffutf8",
+	} {
+		_, err := NewEd25519Cosigner(name, key, clock.NewFake())
+		if err == nil {
+			t.Errorf("NewEd25519Cosigner(%q) = nil error, want error", name)
+		}
+		_, err = NewCosignatureVerifier(name, pub)
+		if err == nil {
+			t.Errorf("NewCosignatureVerifier(%q) = nil error, want error", name)
+		}
+	}
+}
+
+// TestVerifyCosignatureRejectsOversizeTimestamp: even a correctly-signed
+// timestamped_signature is rejected when its timestamp exceeds the spec's
+// 2^63-1 bound.
+func TestVerifyCosignatureRejectsOversizeTimestamp(t *testing.T) {
+	key := testKey(t)
+	pub := key.Public().(ed25519.PublicKey)
+
+	for _, ts := range []uint64{1 << 63, ^uint64(0)} {
+		sig := ed25519.Sign(key, cosignatureMessage(ts, []byte(exampleCheckpoint)))
+		timestamped := make([]byte, 8+ed25519.SignatureSize)
+		binary.BigEndian.PutUint64(timestamped[:8], ts)
+		copy(timestamped[8:], sig)
+
+		_, ok := VerifyCosignature(pub, []byte(exampleCheckpoint), timestamped)
+		if ok {
+			t.Errorf("VerifyCosignature accepted timestamp %d > 2^63-1", ts)
+		}
+	}
+
+	// The boundary value 2^63-1 is conformant and must verify.
+	ts := uint64(1<<63 - 1)
+	sig := ed25519.Sign(key, cosignatureMessage(ts, []byte(exampleCheckpoint)))
+	timestamped := make([]byte, 8+ed25519.SignatureSize)
+	binary.BigEndian.PutUint64(timestamped[:8], ts)
+	copy(timestamped[8:], sig)
+	got, ok := VerifyCosignature(pub, []byte(exampleCheckpoint), timestamped)
+	if !ok || got != ts {
+		t.Errorf("VerifyCosignature(ts=2^63-1) = (%d, %v), want (%d, true)", got, ok, ts)
+	}
+}
+
+// TestSignRejectsPreEpochClock: a pre-epoch clock would wrap into the
+// forbidden timestamp range, so Sign must refuse.
+func TestSignRejectsPreEpochClock(t *testing.T) {
+	clk := clock.NewFake()
+	clk.Set(time.Unix(-1, 0))
+	c, err := NewEd25519Cosigner(cosignerName, testKey(t), clk)
+	if err != nil {
+		t.Fatalf("NewEd25519Cosigner: %s", err)
+	}
+	_, err = c.Sign([]byte(exampleCheckpoint))
+	if err == nil {
+		t.Error("Sign with a pre-epoch clock = nil error, want error")
+	}
+}
+
+// TestCosignatureLine: a stored blob plus name and public key must
+// reproduce the original signature line byte for byte, and the reassembled
+// note must open.
+func TestCosignatureLine(t *testing.T) {
+	key := testKey(t)
+	pub := key.Public().(ed25519.PublicKey)
+	c := newCosigner(t)
+
+	// The blob a consumer would have persisted.
+	blob, err := c.Sign([]byte(exampleCheckpoint))
+	if err != nil {
+		t.Fatalf("Sign: %s", err)
+	}
+	want, err := c.Cosign([]byte(exampleCheckpoint))
+	if err != nil {
+		t.Fatalf("Cosign: %s", err)
+	}
+
+	got, err := CosignatureLine(cosignerName, pub, blob)
+	if err != nil {
+		t.Fatalf("CosignatureLine: %s", err)
+	}
+	if got != want {
+		t.Errorf("CosignatureLine = %q, want %q", got, want)
+	}
+
+	// The reassembled signed note opens against the matching verifier.
+	v, err := NewCosignatureVerifier(cosignerName, pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+	signed := []byte(exampleCheckpoint + "\n" + got)
+	n, err := note.Open(signed, note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("note.Open of a reassembled note: %s", err)
+	}
+	if !CosignedBy(n, v) {
+		t.Error("CosignedBy = false for a reassembled note")
+	}
+}
+
+func TestCosignatureLineRejects(t *testing.T) {
+	pub := testKey(t).Public().(ed25519.PublicKey)
+	good := make([]byte, 8+ed25519.SignatureSize)
+
+	oversize := make([]byte, 8+ed25519.SignatureSize)
+	binary.BigEndian.PutUint64(oversize[:8], 1<<63)
+
+	cases := []struct {
+		name   string
+		signer string
+		pub    ed25519.PublicKey
+		sig    []byte
+	}{
+		{"Bad name", "has space", pub, good},
+		{"Short key", cosignerName, pub[:5], good},
+		{"Short signature", cosignerName, pub, good[:10]},
+		{"Oversize timestamp", cosignerName, pub, oversize},
+	}
+	for _, tc := range cases {
+		_, err := CosignatureLine(tc.signer, tc.pub, tc.sig)
+		if err == nil {
+			t.Errorf("%s: want error", tc.name)
+		}
+	}
+}
+
+// TestCosignature: the blob extracted from an opened note must verify on
+// its own.
+func TestCosignature(t *testing.T) {
+	pub := testKey(t).Public().(ed25519.PublicKey)
+	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, newCosigner(t))
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+	v, err := NewCosignatureVerifier(cosignerName, pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+	n, err := note.Open(signed, note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("note.Open: %s", err)
+	}
+
+	blob, ok := Cosignature(n, v)
+	if !ok {
+		t.Fatal("Cosignature = false for the cosigner that signed the note")
+	}
+	ts, ok := VerifyCosignature(pub, []byte(exampleCheckpoint), blob)
+	if !ok {
+		t.Fatal("VerifyCosignature rejected an extracted cosignature")
+	}
+	if ts != 1679315147 {
+		t.Errorf("timestamp = %d, want 1679315147", ts)
+	}
+
+	other, err := NewCosignatureVerifier("other.test/x", pub)
+	if err != nil {
+		t.Fatalf("NewCosignatureVerifier: %s", err)
+	}
+	_, ok = Cosignature(n, other)
+	if ok {
+		t.Error("Cosignature = true for a cosigner that did not sign the note")
+	}
+}
+
+// TestCosignatureRejectsForeignFormat: a signature verified by x/mod's
+// standard signer (alg 0x01, 64-byte payload) satisfies CosignedBy but is
+// not a timestamped_signature, so Cosignature must refuse it.
+func TestCosignatureRejectsForeignFormat(t *testing.T) {
+	skey, vkey, err := note.GenerateKey(rand.Reader, "log.example")
+	if err != nil {
+		t.Fatalf("GenerateKey: %s", err)
+	}
+	signer, err := note.NewSigner(skey)
+	if err != nil {
+		t.Fatalf("NewSigner: %s", err)
+	}
+	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, signer)
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+	verifier, err := note.NewVerifier(vkey)
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	n, err := note.Open([]byte(signed), note.VerifierList(verifier))
+	if err != nil {
+		t.Fatalf("note.Open: %s", err)
+	}
+
+	if !CosignedBy(n, verifier) {
+		t.Error("CosignedBy = false for the standard signer that signed the note")
+	}
+	if _, ok := Cosignature(n, verifier); ok {
+		t.Error("Cosignature = true for a non-cosignature-format signature")
+	}
+}

--- a/tlog/doc.go
+++ b/tlog/doc.go
@@ -1,0 +1,28 @@
+// Package tlog provides the primitives shared by a tiled transparency log
+// and its cosigners: the C2SP tlog-checkpoint and entry-bundle codecs, the
+// tlog-tiles path encoding, the Ed25519 tlog-cosignature signer and
+// verifier, and the MTC subtree consistency proof and verifier. It is a thin
+// layer over golang.org/x/mod/sumdb/tlog (RFC 6962 hashing, proofs, and tile
+// reading) and golang.org/x/mod/sumdb/note (signed notes).
+//
+// Validated against C2SP/C2SP@01194db, davidben/C2SP@96b748a (mtc-tlog),
+// and ietf-plants-wg/merkle-tree-certs@0b45981.
+//
+// Parsers enforce the specs strictly (canonical encodings, signed-note's
+// character rules), so parse-then-serialize round-trips exactly and two
+// encoded forms never name one value. Producers validate symmetrically:
+// Checkpoint.Marshal checks before serializing, and the cosigner refuses
+// non-canonical bodies.
+//
+// Signing lives behind note.Signer, so verification paths are keyless.
+// Cosignatures cross storage as raw timestamped_signature blobs:
+// CosignatureLine rebuilds a signature line from a stored blob, and
+// Cosignature extracts one from a verified note. Index and size types are
+// int64 and hashes are tlog.Hash, matching x/mod; alias that import to
+// xtlog:
+//
+//	import (
+//		"github.com/letsencrypt/boulder/tlog"
+//		xtlog "golang.org/x/mod/sumdb/tlog"
+//	)
+package tlog

--- a/tlog/entrybundle.go
+++ b/tlog/entrybundle.go
@@ -1,0 +1,53 @@
+package tlog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// TileWidth is the number of entries in a full entry bundle and the number of
+// hashes in a full tile: 2^TileHeight.
+const TileWidth = 1 << TileHeight
+
+// AppendEntry appends entry to an entry bundle with a big-endian uint16
+// length prefix, per tlog-tiles, erroring if entry exceeds 65535 bytes.
+// Bundles hold at most TileWidth entries; counting them on every append
+// would be quadratic, so the cap is the caller's to respect, and
+// ParseEntryBundle enforces it on read.
+func AppendEntry(bundle, entry []byte) ([]byte, error) {
+	if len(entry) > math.MaxUint16 {
+		return nil, fmt.Errorf("entry of %d bytes exceeds the %d-byte limit", len(entry), math.MaxUint16)
+	}
+	bundle = binary.BigEndian.AppendUint16(bundle, uint16(len(entry))) //nolint:gosec // G115: len(entry) is bounded by the math.MaxUint16 check above.
+	return append(bundle, entry...), nil
+}
+
+// ParseEntryBundle splits an entry bundle into its entries, each a copy. A
+// bundle is the entry form of a tile of width 1 through TileWidth, so it
+// must hold at least one entry ("Empty tiles MUST NOT be served") and at
+// most TileWidth.
+func ParseEntryBundle(data []byte) ([][]byte, error) {
+	var entries [][]byte
+	for len(data) > 0 {
+		if len(entries) == TileWidth {
+			return nil, fmt.Errorf("entry bundle has more than %d entries", TileWidth)
+		}
+		if len(data) < 2 {
+			return nil, errors.New("truncated entry length prefix")
+		}
+		n := int(binary.BigEndian.Uint16(data))
+		data = data[2:]
+		if len(data) < n {
+			return nil, errors.New("truncated entry")
+		}
+		entries = append(entries, bytes.Clone(data[:n]))
+		data = data[n:]
+	}
+	if len(entries) == 0 {
+		return nil, errors.New("empty entry bundle")
+	}
+	return entries, nil
+}

--- a/tlog/entrybundle_test.go
+++ b/tlog/entrybundle_test.go
@@ -1,0 +1,109 @@
+package tlog
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEntryBundleRoundTrip(t *testing.T) {
+	entries := [][]byte{{}, {0x01}, []byte("hello"), bytes.Repeat([]byte{0xab}, 1000)}
+	var bundle []byte
+	for _, e := range entries {
+		var err error
+		bundle, err = AppendEntry(bundle, e)
+		if err != nil {
+			t.Fatalf("AppendEntry: %s", err)
+		}
+	}
+
+	got, err := ParseEntryBundle(bundle)
+	if err != nil {
+		t.Fatalf("ParseEntryBundle: %s", err)
+	}
+	if len(got) != len(entries) {
+		t.Fatalf("ParseEntryBundle returned %d entries, want %d", len(got), len(entries))
+	}
+	for i := range entries {
+		if !bytes.Equal(got[i], entries[i]) {
+			t.Errorf("entry %d = %x, want %x", i, got[i], entries[i])
+		}
+	}
+}
+
+// TestParseEntryBundleCopies confirms parsed entries do not alias the input
+// buffer, so mutating the buffer afterward cannot corrupt them.
+func TestParseEntryBundleCopies(t *testing.T) {
+	bundle, err := AppendEntry(nil, []byte("entry"))
+	if err != nil {
+		t.Fatalf("AppendEntry: %s", err)
+	}
+	got, err := ParseEntryBundle(bundle)
+	if err != nil {
+		t.Fatalf("ParseEntryBundle: %s", err)
+	}
+	for i := range bundle {
+		bundle[i] = 0xff
+	}
+	if !bytes.Equal(got[0], []byte("entry")) {
+		t.Errorf("parsed entry changed after mutating the bundle: %x", got[0])
+	}
+}
+
+func TestParseEntryBundleRejects(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"Truncated length prefix", []byte{0x00}},
+		// Length says 5, only 1 byte follows
+		{"Truncated entry", []byte{0x00, 0x05, 0x01}},
+		// A bundle is the entry form of a tile of width 1..TileWidth, and
+		// tlog-tiles says empty tiles MUST NOT be served, so an empty
+		// bundle is not a valid resource.
+		{"Empty bundle", nil},
+		{"Empty bundle (non-nil)", []byte{}},
+	}
+	for _, tc := range cases {
+		_, err := ParseEntryBundle(tc.data)
+		if err == nil {
+			t.Errorf("ParseEntryBundle(%s) = nil error, want error", tc.name)
+		}
+	}
+}
+
+// TestParseEntryBundleEntryCount pins the tlog-tiles bundle width bounds: a
+// full bundle of TileWidth entries parses, one more entry is rejected.
+func TestParseEntryBundleEntryCount(t *testing.T) {
+	var bundle []byte
+	var err error
+	for range TileWidth {
+		bundle, err = AppendEntry(bundle, []byte{0xaa})
+		if err != nil {
+			t.Fatalf("AppendEntry: %s", err)
+		}
+	}
+
+	got, err := ParseEntryBundle(bundle)
+	if err != nil {
+		t.Fatalf("ParseEntryBundle of a full bundle: %s", err)
+	}
+	if len(got) != TileWidth {
+		t.Fatalf("ParseEntryBundle returned %d entries, want %d", len(got), TileWidth)
+	}
+
+	bundle, err = AppendEntry(bundle, []byte{0xbb})
+	if err != nil {
+		t.Fatalf("AppendEntry: %s", err)
+	}
+	_, err = ParseEntryBundle(bundle)
+	if err == nil {
+		t.Errorf("ParseEntryBundle of a %d-entry bundle = nil error, want error", TileWidth+1)
+	}
+}
+
+func TestAppendEntryRejectsOversize(t *testing.T) {
+	_, err := AppendEntry(nil, make([]byte, 65536))
+	if err == nil {
+		t.Error("AppendEntry of a 65536-byte entry = nil error, want error")
+	}
+}

--- a/tlog/helpers_test.go
+++ b/tlog/helpers_test.go
@@ -1,0 +1,55 @@
+package tlog
+
+import (
+	"fmt"
+	"testing"
+
+	xtlog "golang.org/x/mod/sumdb/tlog"
+)
+
+// seqLeaves returns n distinct entries for round-trip tests.
+func seqLeaves(n int) [][]byte {
+	entries := make([][]byte, n)
+	for i := range entries {
+		entries[i] = []byte{byte(i), byte(i >> 8), byte(i >> 16)}
+	}
+	return entries
+}
+
+// leafHashes returns the RFC 6962 leaf hashes of the given entries.
+func leafHashes(entries [][]byte) []xtlog.Hash {
+	hs := make([]xtlog.Hash, len(entries))
+	for i, e := range entries {
+		hs[i] = xtlog.RecordHash(e)
+	}
+	return hs
+}
+
+// memHashReader is an in-memory tlog.HashReader indexed by stored hash index.
+type memHashReader []xtlog.Hash
+
+func (m memHashReader) ReadHashes(indexes []int64) ([]xtlog.Hash, error) {
+	out := make([]xtlog.Hash, len(indexes))
+	for i, x := range indexes {
+		if x < 0 || x >= int64(len(m)) {
+			return nil, fmt.Errorf("stored hash index %d out of range [0, %d)", x, len(m))
+		}
+		out[i] = m[x]
+	}
+	return out, nil
+}
+
+// buildHashReader builds an in-memory HashReader over the given entries by
+// accumulating their stored hashes in storage order.
+func buildHashReader(t *testing.T, entries [][]byte) memHashReader {
+	t.Helper()
+	var m memHashReader
+	for n, e := range entries {
+		hashes, err := xtlog.StoredHashes(int64(n), e, m)
+		if err != nil {
+			t.Fatalf("StoredHashes(%d): %s", n, err)
+		}
+		m = append(m, hashes...)
+	}
+	return m
+}

--- a/tlog/subtree.go
+++ b/tlog/subtree.go
@@ -1,0 +1,222 @@
+package tlog
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math/bits"
+
+	xtlog "golang.org/x/mod/sumdb/tlog"
+)
+
+// SubtreeHash returns the RFC 6962 Merkle Tree Hash over leaves treated as an
+// independent list. The leaves must correspond to a ValidSubtree range for the
+// result to be a meaningful subtree hash; SubtreeHash does not check that.
+func SubtreeHash(leaves []xtlog.Hash) xtlog.Hash {
+	switch len(leaves) {
+	case 0:
+		return xtlog.Hash(sha256.Sum256(nil))
+	case 1:
+		return leaves[0]
+	}
+	k := largestPowerOfTwoSmallerThan(int64(len(leaves)))
+	return xtlog.NodeHash(SubtreeHash(leaves[:k]), SubtreeHash(leaves[k:]))
+}
+
+// largestPowerOfTwoSmallerThan returns the largest power of two strictly less
+// than n, for n > 1.
+func largestPowerOfTwoSmallerThan(n int64) int64 {
+	return int64(1) << (bits.Len64(uint64(n-1)) - 1) //nolint:gosec // G115: n > 1, so n-1 is positive.
+}
+
+// ValidSubtree reports whether [start, end) is a valid subtree per the MTC
+// draft: 0 <= start < end and start is a multiple of BIT_CEIL(end - start).
+// Callers must separately check end <= tree size.
+func ValidSubtree(start, end int64) bool {
+	if start < 0 || start >= end {
+		return false
+	}
+	// BIT_CEIL(end-start) is 2^Len64(end-start-1), and start is a multiple
+	// of 2^k exactly when its low k bits are zero; testing trailing zeros
+	// avoids materializing 2^k, which overflows for sizes near 2^63.
+	return start == 0 || bits.TrailingZeros64(uint64(start)) >= bits.Len64(uint64(end-start-1)) //nolint:gosec // G115: 0 < start < end here, so both conversions are of non-negative values.
+}
+
+// rangeHash returns MTH(D[lo:hi)), the RFC 6962 Merkle Tree Hash over the leaves
+// in [lo, hi) as an independent list, read through r. It decomposes [lo, hi)
+// into its maximal aligned perfect subtrees and reads all of their roots in a
+// single ReadHashes call before folding them together.
+func rangeHash(lo, hi int64, r xtlog.HashReader) (xtlog.Hash, error) {
+	indexes := perfectSubtreeIndexes(lo, hi, nil)
+	hashes, err := r.ReadHashes(indexes)
+	if err != nil {
+		return xtlog.Hash{}, err
+	}
+	// r is caller-supplied; folding without this check would index out of
+	// range on a reader returning a short slice.
+	if len(hashes) != len(indexes) {
+		return xtlog.Hash{}, fmt.Errorf("ReadHashes returned %d hashes for %d indexes", len(hashes), len(indexes))
+	}
+	h, _ := foldRangeHash(lo, hi, hashes)
+	return h, nil
+}
+
+// perfectSubtree reports whether [lo, hi) is an aligned perfect subtree
+// (power-of-two size, start aligned to that size), and if so its level.
+func perfectSubtree(lo, hi int64) (level int, ok bool) {
+	size := hi - lo
+	if bits.OnesCount64(uint64(size)) != 1 || lo&(size-1) != 0 { //nolint:gosec // G115: callers pass lo < hi, so size is positive.
+		return 0, false
+	}
+	return bits.TrailingZeros64(uint64(size)), true //nolint:gosec // G115: callers pass lo < hi, so size is positive.
+}
+
+// perfectSubtreeIndexes appends, in left-to-right order, the stored hash
+// index of each subtree in the maximal aligned perfect decomposition of
+// [lo, hi).
+func perfectSubtreeIndexes(lo, hi int64, indexes []int64) []int64 {
+	level, ok := perfectSubtree(lo, hi)
+	if ok {
+		return append(indexes, xtlog.StoredHashIndex(level, lo>>level))
+	}
+	k := largestPowerOfTwoSmallerThan(hi - lo)
+	indexes = perfectSubtreeIndexes(lo, lo+k, indexes)
+	return perfectSubtreeIndexes(lo+k, hi, indexes)
+}
+
+// foldRangeHash folds subtree roots, in the order perfectSubtreeIndexes lists
+// them, into MTH(D[lo:hi)). It returns the hash and the unconsumed remainder.
+func foldRangeHash(lo, hi int64, hashes []xtlog.Hash) (xtlog.Hash, []xtlog.Hash) {
+	_, ok := perfectSubtree(lo, hi)
+	if ok {
+		return hashes[0], hashes[1:]
+	}
+	k := largestPowerOfTwoSmallerThan(hi - lo)
+	left, rest := foldRangeHash(lo, lo+k, hashes)
+	right, rest := foldRangeHash(lo+k, hi, rest)
+	return xtlog.NodeHash(left, right), rest
+}
+
+// SubtreeConsistencyProof returns SUBTREE_PROOF(start, end, D_n) for the tree of
+// size treeSize, reading stored hashes through r, per the MTC draft. [start,
+// end) must be a valid subtree with end <= treeSize.
+func SubtreeConsistencyProof(start, end, treeSize int64, r xtlog.HashReader) ([]xtlog.Hash, error) {
+	if !ValidSubtree(start, end) || end > treeSize {
+		return nil, fmt.Errorf("[%d, %d) is not a valid subtree of a tree of size %d", start, end, treeSize)
+	}
+	var proof []xtlog.Hash
+	err := subtreeSubProof(start, end, 0, treeSize, true, r, &proof)
+	if err != nil {
+		return nil, err
+	}
+	return proof, nil
+}
+
+// subtreeSubProof implements SUBTREE_SUBPROOF(start, end, D_n, b) from the draft,
+// where start and end are relative to the current subtree of size n rooted at
+// absolute offset base, appending emitted hashes to proof.
+func subtreeSubProof(start, end, base, n int64, known bool, r xtlog.HashReader, proof *[]xtlog.Hash) error {
+	if start == 0 && end == n {
+		if known {
+			return nil
+		}
+		h, err := rangeHash(base, base+n, r)
+		if err != nil {
+			return err
+		}
+		*proof = append(*proof, h)
+		return nil
+	}
+	k := largestPowerOfTwoSmallerThan(n)
+	switch {
+	case end <= k:
+		err := subtreeSubProof(start, end, base, k, known, r, proof)
+		if err != nil {
+			return err
+		}
+		return appendRangeHash(base+k, base+n, r, proof)
+	case k <= start:
+		err := subtreeSubProof(start-k, end-k, base+k, n-k, known, r, proof)
+		if err != nil {
+			return err
+		}
+		return appendRangeHash(base, base+k, r, proof)
+	default:
+		// start < k < end implies start == 0 for a valid subtree (draft case
+		// 3); SubtreeConsistencyProof's gate enforces validity.
+		err := subtreeSubProof(0, end-k, base+k, n-k, false, r, proof)
+		if err != nil {
+			return err
+		}
+		return appendRangeHash(base, base+k, r, proof)
+	}
+}
+
+func appendRangeHash(lo, hi int64, r xtlog.HashReader, proof *[]xtlog.Hash) error {
+	h, err := rangeHash(lo, hi, r)
+	if err != nil {
+		return err
+	}
+	*proof = append(*proof, h)
+	return nil
+}
+
+// VerifySubtreeConsistency verifies a subtree consistency proof for the subtree
+// [start, end) of a tree of size n, given the subtree hash nodeHash and the tree
+// root rootHash, following the "Verifying a Subtree Consistency Proof" procedure
+// in the MTC draft.
+func VerifySubtreeConsistency(start, end, n int64, proof []xtlog.Hash, nodeHash, rootHash xtlog.Hash) bool {
+	if !ValidSubtree(start, end) || end > n {
+		return false
+	}
+
+	fn, sn, tn := start, end-1, n-1
+	if sn == tn {
+		for fn != sn {
+			fn >>= 1
+			sn >>= 1
+			tn >>= 1
+		}
+	} else {
+		for fn != sn && sn&1 == 1 {
+			fn >>= 1
+			sn >>= 1
+			tn >>= 1
+		}
+	}
+
+	var fr, sr xtlog.Hash
+	var rest []xtlog.Hash
+	if fn == sn {
+		fr, sr = nodeHash, nodeHash
+		rest = proof
+	} else {
+		if len(proof) == 0 {
+			return false
+		}
+		fr, sr = proof[0], proof[0]
+		rest = proof[1:]
+	}
+
+	for _, c := range rest {
+		if tn == 0 {
+			return false
+		}
+		if sn&1 == 1 || sn == tn {
+			if fn < sn {
+				fr = xtlog.NodeHash(c, fr)
+			}
+			sr = xtlog.NodeHash(c, sr)
+			for sn&1 == 0 {
+				fn >>= 1
+				sn >>= 1
+				tn >>= 1
+			}
+		} else {
+			sr = xtlog.NodeHash(sr, c)
+		}
+		fn >>= 1
+		sn >>= 1
+		tn >>= 1
+	}
+	return tn == 0 && fr == nodeHash && sr == rootHash
+}

--- a/tlog/subtree_test.go
+++ b/tlog/subtree_test.go
@@ -1,0 +1,420 @@
+package tlog
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"slices"
+	"testing"
+
+	xtlog "golang.org/x/mod/sumdb/tlog"
+)
+
+// validSubtreeRef is the MTC-draft validity rule computed in arbitrary
+// precision, independent of the package's int64 bit math: start must be a
+// multiple of BIT_CEIL(end-start), the smallest power of two greater than
+// or equal to the size.
+func validSubtreeRef(start, end int64) bool {
+	if start < 0 || start >= end {
+		return false
+	}
+	bitCeil := big.NewInt(1)
+	for bitCeil.Cmp(big.NewInt(end-start)) < 0 {
+		bitCeil.Lsh(bitCeil, 1)
+	}
+	return new(big.Int).Mod(big.NewInt(start), bitCeil).Sign() == 0
+}
+
+// largestPow2LessThanRef returns the largest power of two strictly less than n
+// (n > 1) in arbitrary precision.
+func largestPow2LessThanRef(n int64) *big.Int {
+	p := big.NewInt(1)
+	for new(big.Int).Lsh(p, 1).Cmp(big.NewInt(n)) < 0 {
+		p.Lsh(p, 1)
+	}
+	return p
+}
+
+// TestSubtreeBitMathMatchesSpec checks the int64 bit math against an
+// arbitrary-precision reference in the large and overflow region the math/bits
+// forms were introduced to handle. Small sizes are already covered transitively
+// by the SubtreeHash vector and round-trip tests.
+func TestSubtreeBitMathMatchesSpec(t *testing.T) {
+	for _, n := range []int64{1 << 40, 1 << 61, 1 << 62, (1 << 62) + 1, math.MaxInt64 - 1, math.MaxInt64} {
+		got := big.NewInt(largestPowerOfTwoSmallerThan(n))
+		want := largestPow2LessThanRef(n)
+		if got.Cmp(want) != 0 {
+			t.Errorf("largestPowerOfTwoSmallerThan(%d) = %s, want %s", n, got, want)
+		}
+	}
+
+	sizes := []int64{1 << 40, 1 << 61, 1 << 62, (1 << 62) + 1, math.MaxInt64}
+	for _, size := range sizes {
+		candidates := []int64{0, 1, size - 1, size, size + 1}
+		if size <= math.MaxInt64/8 {
+			candidates = append(candidates, 8*size, 8*size+1)
+		}
+		for _, start := range candidates {
+			if start < 0 || start > math.MaxInt64-size {
+				continue
+			}
+			end := start + size
+			got := ValidSubtree(start, end)
+			want := validSubtreeRef(start, end)
+			if got != want {
+				t.Errorf("ValidSubtree(%d, %d) = %v, want %v (size %d)", start, end, got, want, size)
+			}
+		}
+	}
+}
+
+// failingHashReader is a tlog.HashReader whose every read fails, used to check
+// that read errors propagate out of proof generation.
+type failingHashReader struct{}
+
+func (failingHashReader) ReadHashes([]int64) ([]xtlog.Hash, error) {
+	return nil, errors.New("read failed")
+}
+
+// countingHashReader counts ReadHashes calls, to check read batching.
+type countingHashReader struct {
+	inner xtlog.HashReader
+	calls int
+}
+
+func (c *countingHashReader) ReadHashes(indexes []int64) ([]xtlog.Hash, error) {
+	c.calls++
+	return c.inner.ReadHashes(indexes)
+}
+
+func TestValidSubtree(t *testing.T) {
+	cases := []struct {
+		start, end int64
+		expect     bool
+	}{
+		{0, 1, true},
+		{3, 4, true},
+		{4, 8, true},
+		{8, 12, true},
+		{8, 13, true},
+		{0, 14, true},
+		{2, 4, true},
+		{1, 3, false},
+		{7, 9, false},
+		{4, 4, false},
+		{5, 4, false},
+		// Large intervals must terminate (no overflow hang) and stay correct:
+		// start 0 is always aligned, a non-zero start is not aligned to a 2^63
+		// ceil.
+		{0, math.MaxInt64, true},
+		{1, math.MaxInt64, false},
+	}
+	for _, tc := range cases {
+		got := ValidSubtree(tc.start, tc.end)
+		if got != tc.expect {
+			t.Errorf("ValidSubtree(%d, %d) = %v, want %v", tc.start, tc.end, got, tc.expect)
+		}
+	}
+}
+
+// TestSubtreeProofExamples checks the two worked examples from the MTC draft:
+// the subtree consistency proofs for [4, 8) and [8, 13) in a tree of size 14.
+func TestSubtreeProofExamples(t *testing.T) {
+	leaves := leafHashes(seqLeaves(14))
+	r := buildHashReader(t, seqLeaves(14))
+	root := SubtreeHash(leaves)
+	mth := func(start, end int64) xtlog.Hash { return SubtreeHash(leaves[start:end]) }
+
+	cases := []struct {
+		start, end int64
+		expect     []xtlog.Hash
+	}{
+		{4, 8, []xtlog.Hash{mth(0, 4), mth(8, 14)}},
+		{8, 13, []xtlog.Hash{mth(12, 13), mth(13, 14), mth(8, 12), mth(0, 8)}},
+	}
+	for _, tc := range cases {
+		proof, err := SubtreeConsistencyProof(tc.start, tc.end, 14, r)
+		if err != nil {
+			t.Fatalf("SubtreeConsistencyProof(%d, %d, 14): %s", tc.start, tc.end, err)
+		}
+		if !slices.Equal(proof, tc.expect) {
+			t.Errorf("SubtreeConsistencyProof(%d, %d, 14) = %x, want %x", tc.start, tc.end, proof, tc.expect)
+		}
+		if !VerifySubtreeConsistency(tc.start, tc.end, 14, proof, mth(tc.start, tc.end), root) {
+			t.Errorf("VerifySubtreeConsistency(%d, %d, 14) rejected a valid proof", tc.start, tc.end)
+		}
+	}
+}
+
+// TestSubtreeProofIsConsistencyProof checks the draft identity SUBTREE_PROOF(0,
+// end, D_n) = PROOF(end, D_n) by verifying the start=0 subtree proof with the
+// x/mod/sumdb/tlog consistency verifier.
+func TestSubtreeProofIsConsistencyProof(t *testing.T) {
+	for n := int64(2); n <= 33; n++ {
+		entries := seqLeaves(int(n))
+		r := buildHashReader(t, entries)
+		root := SubtreeHash(leafHashes(entries))
+		for end := int64(1); end < n; end++ {
+			proof, err := SubtreeConsistencyProof(0, end, n, r)
+			if err != nil {
+				t.Fatalf("SubtreeConsistencyProof(0, %d, %d): %s", end, n, err)
+			}
+			subRoot := SubtreeHash(leafHashes(entries)[:end])
+			err = xtlog.CheckTree(proof, n, root, end, subRoot)
+			if err != nil {
+				t.Errorf("CheckTree for subtree proof (0, %d, %d): %s", end, n, err)
+			}
+		}
+	}
+}
+
+// TestVerifySubtreeConsistencyRejectsBadInput covers the input gate that
+// protects add-entries against adversarial proofs.
+func TestVerifySubtreeConsistencyRejectsBadInput(t *testing.T) {
+	leaves := leafHashes(seqLeaves(14))
+	r := buildHashReader(t, seqLeaves(14))
+	root := SubtreeHash(leaves)
+	node := SubtreeHash(leaves[8:13])
+	proof, err := SubtreeConsistencyProof(8, 13, 14, r)
+	if err != nil {
+		t.Fatalf("SubtreeConsistencyProof(8, 13, 14): %s", err)
+	}
+
+	cases := []struct {
+		name          string
+		start, end, n int64
+		proof         []xtlog.Hash
+	}{
+		{"End past tree size", 8, 13, 12, proof},
+		{"Misaligned subtree", 1, 3, 14, proof},
+		{"Empty proof where one is required", 8, 13, 14, nil},
+		{"Over-long proof", 8, 13, 14, append(slices.Clone(proof), proof...)},
+	}
+	for _, tc := range cases {
+		if VerifySubtreeConsistency(tc.start, tc.end, tc.n, tc.proof, node, root) {
+			t.Errorf("VerifySubtreeConsistency accepted bad input: %s", tc.name)
+		}
+	}
+}
+
+// TestSubtreeConsistencyProofRejectsBadInput covers the generation-side input
+// gate.
+func TestSubtreeConsistencyProofRejectsBadInput(t *testing.T) {
+	r := buildHashReader(t, seqLeaves(14))
+	cases := []struct {
+		name             string
+		start, end, size int64
+	}{
+		{"Misaligned subtree", 1, 3, 14},
+		{"End past tree size", 0, 5, 4},
+		{"Empty interval", 4, 4, 14},
+	}
+	for _, tc := range cases {
+		_, err := SubtreeConsistencyProof(tc.start, tc.end, tc.size, r)
+		if err == nil {
+			t.Errorf("SubtreeConsistencyProof(%s) = nil error, want error", tc.name)
+		}
+	}
+}
+
+// TestSubtreeConsistencyProofPropagatesReadError checks that a HashReader error
+// surfaces from generation rather than being swallowed.
+func TestSubtreeConsistencyProofPropagatesReadError(t *testing.T) {
+	_, err := SubtreeConsistencyProof(4, 8, 14, failingHashReader{})
+	if err == nil {
+		t.Error("SubtreeConsistencyProof with a failing reader = nil error, want error")
+	}
+}
+
+// TestSubtreeConsistencyProofBatchesReads: each emitted proof hash costs at
+// most one ReadHashes call, even spanning several perfect subtrees. The
+// bound is one-sided so more aggressive batching cannot fail it.
+func TestSubtreeConsistencyProofBatchesReads(t *testing.T) {
+	r := &countingHashReader{inner: buildHashReader(t, seqLeaves(14))}
+	proof, err := SubtreeConsistencyProof(4, 8, 14, r)
+	if err != nil {
+		t.Fatalf("SubtreeConsistencyProof(4, 8, 14): %s", err)
+	}
+	if r.calls > len(proof) {
+		t.Errorf("ReadHashes calls = %d, want at most %d (one per emitted hash)", r.calls, len(proof))
+	}
+}
+
+func TestSubtreeRoundTrip(t *testing.T) {
+	for n := int64(1); n <= 48; n++ {
+		entries := seqLeaves(int(n))
+		leaves := leafHashes(entries)
+		r := buildHashReader(t, entries)
+		root := SubtreeHash(leaves)
+
+		for start := int64(0); start < n; start++ {
+			for end := start + 1; end <= n; end++ {
+				if !ValidSubtree(start, end) {
+					continue
+				}
+				node := SubtreeHash(leaves[start:end])
+				proof, err := SubtreeConsistencyProof(start, end, n, r)
+				if err != nil {
+					t.Fatalf("SubtreeConsistencyProof(%d, %d, %d): %s", start, end, n, err)
+				}
+
+				if !VerifySubtreeConsistency(start, end, n, proof, node, root) {
+					t.Errorf("VerifySubtreeConsistency(%d, %d, %d) rejected a valid proof", start, end, n)
+				}
+				if node != root && VerifySubtreeConsistency(start, end, n, proof, root, root) {
+					t.Errorf("VerifySubtreeConsistency(%d, %d, %d) accepted a wrong subtree hash", start, end, n)
+				}
+				if len(proof) > 0 {
+					bad := slices.Clone(proof)
+					bad[0][0] ^= 0xff
+					if VerifySubtreeConsistency(start, end, n, bad, node, root) {
+						t.Errorf("VerifySubtreeConsistency(%d, %d, %d) accepted a tampered proof", start, end, n)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestSubtreeHashVectors checks SubtreeHash against the RFC 6962 reference
+// Merkle Tree Hash roots for trees of size 0 through 8.
+func TestSubtreeHashVectors(t *testing.T) {
+	entryHexes := []string{
+		"",
+		"00",
+		"10",
+		"2021",
+		"3031",
+		"40414243",
+		"5051525354555657",
+		"606162636465666768696a6b6c6d6e6f",
+	}
+	entries := make([][]byte, len(entryHexes))
+	for i, h := range entryHexes {
+		var err error
+		entries[i], err = hex.DecodeString(h)
+		if err != nil {
+			t.Fatalf("decoding entry %q: %s", h, err)
+		}
+	}
+	leaves := leafHashes(entries)
+	expect := []string{
+		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+		"fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125",
+		"aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77",
+		"d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7",
+		"4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4",
+		"76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef",
+		"ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c",
+		"5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328",
+	}
+	for size := 0; size <= 8; size++ {
+		got := SubtreeHash(leaves[:size])
+		if hex.EncodeToString(got[:]) != expect[size] {
+			t.Errorf("SubtreeHash(size %d) = %x, want %s", size, got, expect[size])
+		}
+	}
+}
+
+// TestTreeHashMatchesOracle checks that the in-memory HashReader feeds
+// tlog.TreeHash the same roots SubtreeHash computes, validating the test
+// scaffolding used by the subtree generation tests.
+func TestTreeHashMatchesOracle(t *testing.T) {
+	for n := 1; n <= 32; n++ {
+		entries := seqLeaves(n)
+		got, err := xtlog.TreeHash(int64(n), buildHashReader(t, entries))
+		if err != nil {
+			t.Fatalf("TreeHash(%d): %s", n, err)
+		}
+		want := SubtreeHash(leafHashes(entries))
+		if got != want {
+			t.Errorf("TreeHash(%d) = %x, want %x", n, got, want)
+		}
+	}
+}
+
+// TestSubtreeHashSpecVector pins SubtreeHash to the accumulated vector in
+// the MTC draft appendix "Subtree Hashes" (draft revision 0b45981): every
+// valid subtree to size 130, leaf i the single byte i, rolled into one
+// SHA-256. It also pins ValidSubtree via the iteration gate.
+func TestSubtreeHashSpecVector(t *testing.T) {
+	const want = "94a95384a8c69acea9b50d035a58285b3a777cb7a724005faa5e1f1e1190007f"
+	entries := make([][]byte, 130)
+	for i := range entries {
+		entries[i] = []byte{byte(i)}
+	}
+	leaves := leafHashes(entries)
+
+	h := sha256.New()
+	for end := int64(1); end <= 130; end++ {
+		for start := int64(0); start < end; start++ {
+			if !ValidSubtree(start, end) {
+				continue
+			}
+			subtree := SubtreeHash(leaves[start:end])
+			fmt.Fprintf(h, "[%d, %d) %s\n", start, end, hex.EncodeToString(subtree[:]))
+		}
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != want {
+		t.Errorf("subtree hash accumulator:\n got  %s\n want %s", got, want)
+	}
+}
+
+// TestSubtreeConsistencyProofSpecVector pins SubtreeConsistencyProof to the
+// accumulated vector in the MTC draft appendix "Subtree Consistency Proofs"
+// (draft revision 0b45981): every valid subtree of every tree to size 130,
+// rolled into one SHA-256.
+func TestSubtreeConsistencyProofSpecVector(t *testing.T) {
+	const want = "c586ebbb73a5621baf2140095d87dde934e3b6503a562a1a5215b8209edd083d"
+	entries := make([][]byte, 130)
+	for i := range entries {
+		entries[i] = []byte{byte(i)}
+	}
+	r := buildHashReader(t, entries)
+
+	h := sha256.New()
+	for n := int64(0); n <= 130; n++ {
+		for end := int64(1); end <= n; end++ {
+			for start := int64(0); start < end; start++ {
+				if !ValidSubtree(start, end) {
+					continue
+				}
+				proof, err := SubtreeConsistencyProof(start, end, n, r)
+				if err != nil {
+					t.Fatalf("SubtreeConsistencyProof(%d, %d, %d): %s", start, end, n, err)
+				}
+				fmt.Fprintf(h, "[%d, %d) %d", start, end, n)
+				for _, p := range proof {
+					fmt.Fprintf(h, " %s", hex.EncodeToString(p[:]))
+				}
+				h.Write([]byte{'\n'})
+			}
+		}
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != want {
+		t.Errorf("subtree consistency proof accumulator:\n got  %s\n want %s", got, want)
+	}
+}
+
+// shortHashReader violates the HashReader contract by returning fewer
+// hashes than requested.
+type shortHashReader struct{}
+
+func (shortHashReader) ReadHashes(indexes []int64) ([]xtlog.Hash, error) {
+	return nil, nil
+}
+
+func TestSubtreeConsistencyProofShortReader(t *testing.T) {
+	// [0, 4) of a tree of size 8 forces a rangeHash over [4, 8), which asks
+	// the reader for at least one stored hash.
+	_, err := SubtreeConsistencyProof(0, 4, 8, shortHashReader{})
+	if err == nil {
+		t.Error("SubtreeConsistencyProof with a short HashReader = nil error, want error")
+	}
+}

--- a/tlog/tiles.go
+++ b/tlog/tiles.go
@@ -1,0 +1,97 @@
+package tlog
+
+import (
+	"fmt"
+	"strings"
+
+	xtlog "golang.org/x/mod/sumdb/tlog"
+)
+
+// TileHeight is the tlog-tiles tile height: tiles span subtrees of height 8.
+const TileHeight = 8
+
+// TilePath returns the tlog-tiles path for t relative to a log prefix, such
+// as "tile/0/x001/x234/067" for a Merkle tile or "tile/entries/000" for an
+// entry bundle.
+//
+// The wire format encodes neither the height nor out-of-range coordinates,
+// so a tile that cannot round-trip through ParseTilePath panics rather than
+// silently naming a different tile: t.H must be TileHeight, t.L in [-1, 63]
+// (-1 is x/mod's entry bundle sentinel; the spec caps L at 63), t.W in
+// [1, TileWidth] (the spec caps partial widths at 255), and t.N must be
+// non-negative.
+func TilePath(t xtlog.Tile) string {
+	if t.H != TileHeight {
+		panic(fmt.Sprintf("tlog.TilePath: tile height is %d, want %d", t.H, TileHeight))
+	}
+	if t.L < -1 || t.L > 63 {
+		panic(fmt.Sprintf("tlog.TilePath: tile level %d out of range [-1, 63]", t.L))
+	}
+	if t.W < 1 || t.W > TileWidth {
+		panic(fmt.Sprintf("tlog.TilePath: tile width %d out of range [1, %d]", t.W, TileWidth))
+	}
+	if t.N < 0 {
+		panic(fmt.Sprintf("tlog.TilePath: negative index %d", t.N))
+	}
+
+	var b strings.Builder
+	if t.L == -1 {
+		b.WriteString("tile/entries/")
+	} else {
+		fmt.Fprintf(&b, "tile/%d/", t.L)
+	}
+	// The index is zero-padded 3-digit groups separated by "/", with "x"
+	// prefixing every group except the last.
+	var groups []string
+	for n := t.N; ; n /= 1000 {
+		groups = append(groups, fmt.Sprintf("%03d", n%1000))
+		if n < 1000 {
+			break
+		}
+	}
+	for i := len(groups) - 1; i > 0; i-- {
+		b.WriteString("x")
+		b.WriteString(groups[i])
+		b.WriteString("/")
+	}
+	b.WriteString(groups[0])
+	if t.W != TileWidth {
+		fmt.Fprintf(&b, ".p/%d", t.W)
+	}
+	return b.String()
+}
+
+// ParseTilePath parses a tlog-tiles path produced by TilePath into a
+// height-TileHeight tlog.Tile (the spec encoding has no height field).
+// x/mod's parser enforces canonicality by re-serializing and comparing; on
+// top of that, the level must be plain ASCII digits (x/mod would accept its
+// internal "data" marker, aliasing tile/data/<N> to an entry bundle) and at
+// most 63 per the spec.
+func ParseTilePath(path string) (xtlog.Tile, error) {
+	rest, ok := strings.CutPrefix(path, "tile/entries/")
+	if ok {
+		t, err := xtlog.ParseTilePath(fmt.Sprintf("tile/%d/data/%s", TileHeight, rest))
+		if err != nil {
+			// Name the caller's path, not the rewritten height-qualified one.
+			return xtlog.Tile{}, fmt.Errorf("malformed tile path %q", path)
+		}
+		return t, nil
+	}
+	rest, ok = strings.CutPrefix(path, "tile/")
+	if !ok {
+		return xtlog.Tile{}, fmt.Errorf("malformed tile path %q", path)
+	}
+	level, _, ok := strings.Cut(rest, "/")
+	if !ok || level == "" || strings.ContainsFunc(level, func(r rune) bool { return r < '0' || r > '9' }) {
+		return xtlog.Tile{}, fmt.Errorf("malformed tile path %q", path)
+	}
+	t, err := xtlog.ParseTilePath(fmt.Sprintf("tile/%d/%s", TileHeight, rest))
+	if err != nil {
+		return xtlog.Tile{}, fmt.Errorf("malformed tile path %q", path)
+	}
+	// x/mod has no upper bound on L; the spec caps it at 63.
+	if t.L > 63 {
+		return xtlog.Tile{}, fmt.Errorf("tile level %d exceeds spec maximum 63", t.L)
+	}
+	return t, nil
+}

--- a/tlog/tiles_test.go
+++ b/tlog/tiles_test.go
@@ -1,0 +1,158 @@
+package tlog
+
+import (
+	"strings"
+	"testing"
+
+	xtlog "golang.org/x/mod/sumdb/tlog"
+)
+
+func TestTilePath(t *testing.T) {
+	t.Run("Vectors", func(t *testing.T) {
+		cases := []struct {
+			tile   xtlog.Tile
+			expect string
+		}{
+			{xtlog.Tile{H: 8, L: 0, N: 0, W: 256}, "tile/0/000"},
+			{xtlog.Tile{H: 8, L: 0, N: 1234067, W: 256}, "tile/0/x001/x234/067"},
+			{xtlog.Tile{H: 8, L: 1, N: 1, W: 1}, "tile/1/001.p/1"},
+			{xtlog.Tile{H: 8, L: -1, N: 0, W: 256}, "tile/entries/000"},
+			{xtlog.Tile{H: 8, L: -1, N: 273, W: 112}, "tile/entries/273.p/112"},
+		}
+		for _, tc := range cases {
+			got := TilePath(tc.tile)
+			if got != tc.expect {
+				t.Errorf("TilePath(%+v) = %q, want %q", tc.tile, got, tc.expect)
+			}
+			parsed, err := ParseTilePath(got)
+			if err != nil {
+				t.Fatalf("ParseTilePath(%q): %s", got, err)
+			}
+			if parsed != tc.tile {
+				t.Errorf("ParseTilePath(%q) = %+v, want %+v", got, parsed, tc.tile)
+			}
+		}
+	})
+
+	// Every tile x/mod/sumdb/tlog computes for a tree must round-trip through
+	// TilePath and ParseTilePath.
+	t.Run("NewTiles round-trip", func(t *testing.T) {
+		tiles := xtlog.NewTiles(TileHeight, 0, 70000)
+		if len(tiles) == 0 {
+			t.Fatal("NewTiles returned no tiles for a non-empty tree")
+		}
+		for _, tile := range tiles {
+			parsed, err := ParseTilePath(TilePath(tile))
+			if err != nil {
+				t.Fatalf("ParseTilePath(%q): %s", TilePath(tile), err)
+			}
+			if parsed != tile {
+				t.Errorf("round-trip of %+v = %+v", tile, parsed)
+			}
+		}
+	})
+
+	t.Run("Rejects unknown prefix", func(t *testing.T) {
+		_, err := ParseTilePath("not/a/tile")
+		if err == nil {
+			t.Error("ParseTilePath(\"not/a/tile\") = nil error, want error")
+		}
+	})
+
+	// The wire format has no height field, so a non-TileHeight tile (e.g.
+	// the zero value) cannot round-trip and must be rejected at the source.
+	t.Run("Rejects non-TileHeight input", func(t *testing.T) {
+		for _, tile := range []xtlog.Tile{
+			{H: 0, L: 0, N: 5, W: 256},
+			{H: 4, L: 0, N: 5, W: 16},
+			{H: 16, L: 0, N: 5, W: 65536},
+		} {
+			func() {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("TilePath(%+v) returned without panicking", tile)
+					}
+				}()
+				_ = TilePath(tile)
+			}()
+		}
+	})
+
+	// c2sp.org/tlog-tiles: L MUST be in [0, 63]. x/mod's parser does not
+	// enforce the upper bound, so we enforce it ourselves on both sides.
+	t.Run("Rejects L out of range", func(t *testing.T) {
+		for _, tile := range []xtlog.Tile{
+			{H: 8, L: 64, N: 0, W: 256},
+			{H: 8, L: 70, N: 0, W: 256},
+			{H: 8, L: -2, N: 0, W: 256},
+		} {
+			func() {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("TilePath(%+v) returned without panicking", tile)
+					}
+				}()
+				_ = TilePath(tile)
+			}()
+		}
+		// ParseTilePath rejects tile/64/000 even though x/mod's parser
+		// would accept it.
+		_, err := ParseTilePath("tile/64/000")
+		if err == nil {
+			t.Error("ParseTilePath(\"tile/64/000\") = nil error, want error")
+		}
+	})
+
+	// c2sp.org/tlog-tiles: a partial width is between 1 and 255; W ==
+	// TileWidth is the full tile. Out-of-range widths would format into
+	// paths no conformant parser accepts, so TilePath refuses them the same
+	// way it refuses bad H and L.
+	t.Run("Rejects W or N out of range", func(t *testing.T) {
+		for _, tile := range []xtlog.Tile{
+			{H: 8, L: 0, N: 0, W: 0},
+			{H: 8, L: 0, N: 0, W: -3},
+			{H: 8, L: 0, N: 0, W: 257},
+			{H: 8, L: -1, N: 0, W: 300},
+			{H: 8, L: 0, N: -1, W: 256},
+		} {
+			func() {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("TilePath(%+v) returned without panicking", tile)
+					}
+				}()
+				_ = TilePath(tile)
+			}()
+		}
+	})
+
+	// Without the digits-only level check, x/mod's "data" marker would let
+	// the non-spec alias tile/data/<N> parse as an entry bundle.
+	t.Run("Rejects non-spec paths", func(t *testing.T) {
+		for _, path := range []string{
+			"tile/data/000",
+			"tile/data/000.p/5",
+			"tile/-1/000",
+			"tile//000",
+			"tile/0/000.p/0",
+			"tile/0/000.p/256",
+			"tile/entries/000.p/256",
+		} {
+			_, err := ParseTilePath(path)
+			if err == nil {
+				t.Errorf("ParseTilePath(%q) = nil error, want error", path)
+			}
+		}
+	})
+
+	// Errors must name the caller's path, not the rewritten x/mod form.
+	t.Run("Error names the original path", func(t *testing.T) {
+		_, err := ParseTilePath("tile/01/000")
+		if err == nil {
+			t.Fatal("ParseTilePath(\"tile/01/000\") = nil error, want error")
+		}
+		if !strings.Contains(err.Error(), `"tile/01/000"`) {
+			t.Errorf("error %q does not name the original path", err)
+		}
+	})
+}

--- a/vendor/golang.org/x/mod/sumdb/note/note.go
+++ b/vendor/golang.org/x/mod/sumdb/note/note.go
@@ -1,0 +1,667 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package note defines the notes signed by the Go module database server.
+//
+// A note is text signed by one or more server keys.
+// The text should be ignored unless the note is signed by
+// a trusted server key and the signature has been verified
+// using the server's public key.
+//
+// A server's public key is identified by a name, typically the "host[/path]"
+// giving the base URL of the server's transparency log.
+// The syntactic restrictions on a name are that it be non-empty,
+// well-formed UTF-8 containing neither Unicode spaces nor plus (U+002B).
+//
+// A Go module database server signs texts using public key cryptography.
+// A given server may have multiple public keys, each
+// identified by a 32-bit hash of the public key.
+//
+// # Verifying Notes
+//
+// A [Verifier] allows verification of signatures by one server public key.
+// It can report the name of the server and the uint32 hash of the key,
+// and it can verify a purported signature by that key.
+//
+// The standard implementation of a Verifier is constructed
+// by [NewVerifier] starting from a verifier key, which is a
+// plain text string of the form "<name>+<hash>+<keydata>".
+//
+// A [Verifiers] allows looking up a Verifier by the combination
+// of server name and key hash.
+//
+// The standard implementation of a Verifiers is constructed
+// by VerifierList from a list of known verifiers.
+//
+// A [Note] represents a text with one or more signatures.
+// An implementation can reject a note with too many signatures
+// (for example, more than 100 signatures).
+//
+// A [Signature] represents a signature on a note, verified or not.
+//
+// The [Open] function takes as input a signed message
+// and a set of known verifiers. It decodes and verifies
+// the message signatures and returns a [Note] structure
+// containing the message text and (verified or unverified) signatures.
+//
+// # Signing Notes
+//
+// A [Signer] allows signing a text with a given key.
+// It can report the name of the server and the hash of the key
+// and can sign a raw text using that key.
+//
+// The standard implementation of a Signer is constructed
+// by [NewSigner] starting from an encoded signer key, which is a
+// plain text string of the form "PRIVATE+KEY+<name>+<hash>+<keydata>".
+// Anyone with an encoded signer key can sign messages using that key,
+// so it must be kept secret. The encoding begins with the literal text
+// "PRIVATE+KEY" to avoid confusion with the public server key.
+//
+// The [Sign] function takes as input a Note and a list of Signers
+// and returns an encoded, signed message.
+//
+// # Signed Note Format
+//
+// A signed note consists of a text ending in newline (U+000A),
+// followed by a blank line (only a newline),
+// followed by one or more signature lines of this form:
+// em dash (U+2014), space (U+0020),
+// server name, space, base64-encoded signature, newline.
+//
+// Signed notes must be valid UTF-8 and must not contain any
+// ASCII control characters (those below U+0020) other than newline.
+//
+// A signature is a base64 encoding of 4+n bytes.
+//
+// The first four bytes in the signature are the uint32 key hash
+// stored in big-endian order.
+//
+// The remaining n bytes are the result of using the specified key
+// to sign the note text (including the final newline but not the
+// separating blank line).
+//
+// # Generating Keys
+//
+// There is only one key type, Ed25519 with algorithm identifier 1.
+// New key types may be introduced in the future as needed,
+// although doing so will require deploying the new algorithms to all clients
+// before starting to depend on them for signatures.
+//
+// The [GenerateKey] function generates and returns a new signer
+// and corresponding verifier.
+//
+// # Example
+//
+// Here is a well-formed signed note:
+//
+//	If you think cryptography is the answer to your problem,
+//	then you don't know what your problem is.
+//
+//	— PeterNeumann x08go/ZJkuBS9UG/SffcvIAQxVBtiFupLLr8pAcElZInNIuGUgYN1FFYC2pZSNXgKvqfqdngotpRZb6KE6RyyBwJnAM=
+//
+// It can be constructed and displayed using:
+//
+//	skey := "PRIVATE+KEY+PeterNeumann+c74f20a3+AYEKFALVFGyNhPJEMzD1QIDr+Y7hfZx09iUvxdXHKDFz"
+//	text := "If you think cryptography is the answer to your problem,\n" +
+//		"then you don't know what your problem is.\n"
+//
+//	signer, err := note.NewSigner(skey)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	msg, err := note.Sign(&note.Note{Text: text}, signer)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	os.Stdout.Write(msg)
+//
+// The note's text is two lines, including the final newline,
+// and the text is purportedly signed by a server named
+// "PeterNeumann". (Although server names are canonically
+// base URLs, the only syntactic requirement is that they
+// not contain spaces or newlines).
+//
+// If [Open] is given access to a [Verifiers] including the
+// [Verifier] for this key, then it will succeed at verifying
+// the encoded message and returning the parsed [Note]:
+//
+//	vkey := "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW"
+//	msg := []byte("If you think cryptography is the answer to your problem,\n" +
+//		"then you don't know what your problem is.\n" +
+//		"\n" +
+//		"— PeterNeumann x08go/ZJkuBS9UG/SffcvIAQxVBtiFupLLr8pAcElZInNIuGUgYN1FFYC2pZSNXgKvqfqdngotpRZb6KE6RyyBwJnAM=\n")
+//
+//	verifier, err := note.NewVerifier(vkey)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	verifiers := note.VerifierList(verifier)
+//
+//	n, err := note.Open([]byte(msg), verifiers)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	fmt.Printf("%s (%08x):\n%s", n.Sigs[0].Name, n.Sigs[0].Hash, n.Text)
+//
+// You can add your own signature to this message by re-signing the note:
+//
+//	skey, vkey, err := note.GenerateKey(rand.Reader, "EnochRoot")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	_ = vkey // give to verifiers
+//
+//	me, err := note.NewSigner(skey)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	msg, err := note.Sign(n, me)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	os.Stdout.Write(msg)
+//
+// This will print a doubly-signed message, like:
+//
+//	If you think cryptography is the answer to your problem,
+//	then you don't know what your problem is.
+//
+//	— PeterNeumann x08go/ZJkuBS9UG/SffcvIAQxVBtiFupLLr8pAcElZInNIuGUgYN1FFYC2pZSNXgKvqfqdngotpRZb6KE6RyyBwJnAM=
+//	— EnochRoot rwz+eBzmZa0SO3NbfRGzPCpDckykFXSdeX+MNtCOXm2/5n2tiOHp+vAF1aGrQ5ovTG01oOTGwnWLox33WWd1RvMc+QQ=
+package note
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// A Verifier verifies messages signed with a specific key.
+type Verifier interface {
+	// Name returns the server name associated with the key.
+	Name() string
+
+	// KeyHash returns the key hash.
+	KeyHash() uint32
+
+	// Verify reports whether sig is a valid signature of msg.
+	Verify(msg, sig []byte) bool
+}
+
+// A Signer signs messages using a specific key.
+type Signer interface {
+	// Name returns the server name associated with the key.
+	Name() string
+
+	// KeyHash returns the key hash.
+	KeyHash() uint32
+
+	// Sign returns a signature for the given message.
+	Sign(msg []byte) ([]byte, error)
+}
+
+// keyHash computes the key hash for the given server name and encoded public key.
+func keyHash(name string, key []byte) uint32 {
+	h := sha256.New()
+	h.Write([]byte(name))
+	h.Write([]byte("\n"))
+	h.Write(key)
+	sum := h.Sum(nil)
+	return binary.BigEndian.Uint32(sum)
+}
+
+var (
+	errVerifierID   = errors.New("malformed verifier id")
+	errVerifierAlg  = errors.New("unknown verifier algorithm")
+	errVerifierHash = errors.New("invalid verifier hash")
+)
+
+const (
+	algEd25519 = 1
+)
+
+// isValidName reports whether name is valid.
+// It must be non-empty and not have any Unicode spaces or pluses.
+func isValidName(name string) bool {
+	return name != "" && utf8.ValidString(name) && strings.IndexFunc(name, unicode.IsSpace) < 0 && !strings.Contains(name, "+")
+}
+
+// NewVerifier construct a new [Verifier] from an encoded verifier key.
+func NewVerifier(vkey string) (Verifier, error) {
+	name, vkey, _ := strings.Cut(vkey, "+")
+	hash16, key64, _ := strings.Cut(vkey, "+")
+	hash, err1 := strconv.ParseUint(hash16, 16, 32)
+	key, err2 := base64.StdEncoding.DecodeString(key64)
+	if len(hash16) != 8 || err1 != nil || err2 != nil || !isValidName(name) || len(key) == 0 {
+		return nil, errVerifierID
+	}
+	if uint32(hash) != keyHash(name, key) {
+		return nil, errVerifierHash
+	}
+
+	v := &verifier{
+		name: name,
+		hash: uint32(hash),
+	}
+
+	alg, key := key[0], key[1:]
+	switch alg {
+	default:
+		return nil, errVerifierAlg
+
+	case algEd25519:
+		if len(key) != 32 {
+			return nil, errVerifierID
+		}
+		v.verify = func(msg, sig []byte) bool {
+			return ed25519.Verify(key, msg, sig)
+		}
+	}
+
+	return v, nil
+}
+
+// verifier is a trivial Verifier implementation.
+type verifier struct {
+	name   string
+	hash   uint32
+	verify func([]byte, []byte) bool
+}
+
+func (v *verifier) Name() string                { return v.name }
+func (v *verifier) KeyHash() uint32             { return v.hash }
+func (v *verifier) Verify(msg, sig []byte) bool { return v.verify(msg, sig) }
+
+// NewSigner constructs a new [Signer] from an encoded signer key.
+func NewSigner(skey string) (Signer, error) {
+	priv1, skey, _ := strings.Cut(skey, "+")
+	priv2, skey, _ := strings.Cut(skey, "+")
+	name, skey, _ := strings.Cut(skey, "+")
+	hash16, key64, _ := strings.Cut(skey, "+")
+	hash, err1 := strconv.ParseUint(hash16, 16, 32)
+	key, err2 := base64.StdEncoding.DecodeString(key64)
+	if priv1 != "PRIVATE" || priv2 != "KEY" || len(hash16) != 8 || err1 != nil || err2 != nil || !isValidName(name) || len(key) == 0 {
+		return nil, errSignerID
+	}
+
+	// Note: hash is the hash of the public key and we have the private key.
+	// Must verify hash after deriving public key.
+
+	s := &signer{
+		name: name,
+		hash: uint32(hash),
+	}
+
+	var pubkey []byte
+
+	alg, key := key[0], key[1:]
+	switch alg {
+	default:
+		return nil, errSignerAlg
+
+	case algEd25519:
+		if len(key) != 32 {
+			return nil, errSignerID
+		}
+		key = ed25519.NewKeyFromSeed(key)
+		pubkey = append([]byte{algEd25519}, key[32:]...)
+		s.sign = func(msg []byte) ([]byte, error) {
+			return ed25519.Sign(key, msg), nil
+		}
+	}
+
+	if uint32(hash) != keyHash(name, pubkey) {
+		return nil, errSignerHash
+	}
+
+	return s, nil
+}
+
+var (
+	errSignerID   = errors.New("malformed verifier id")
+	errSignerAlg  = errors.New("unknown verifier algorithm")
+	errSignerHash = errors.New("invalid verifier hash")
+)
+
+// signer is a trivial Signer implementation.
+type signer struct {
+	name string
+	hash uint32
+	sign func([]byte) ([]byte, error)
+}
+
+func (s *signer) Name() string                    { return s.name }
+func (s *signer) KeyHash() uint32                 { return s.hash }
+func (s *signer) Sign(msg []byte) ([]byte, error) { return s.sign(msg) }
+
+// GenerateKey generates a signer and verifier key pair for a named server.
+// The signer key skey is private and must be kept secret.
+func GenerateKey(rand io.Reader, name string) (skey, vkey string, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand)
+	if err != nil {
+		return "", "", err
+	}
+	pubkey := append([]byte{algEd25519}, pub...)
+	privkey := append([]byte{algEd25519}, priv.Seed()...)
+	h := keyHash(name, pubkey)
+
+	skey = fmt.Sprintf("PRIVATE+KEY+%s+%08x+%s", name, h, base64.StdEncoding.EncodeToString(privkey))
+	vkey = fmt.Sprintf("%s+%08x+%s", name, h, base64.StdEncoding.EncodeToString(pubkey))
+	return skey, vkey, nil
+}
+
+// NewEd25519VerifierKey returns an encoded verifier key using the given name
+// and Ed25519 public key.
+func NewEd25519VerifierKey(name string, key ed25519.PublicKey) (string, error) {
+	if len(key) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("invalid public key size %d, expected %d", len(key), ed25519.PublicKeySize)
+	}
+
+	pubkey := append([]byte{algEd25519}, key...)
+	hash := keyHash(name, pubkey)
+
+	b64Key := base64.StdEncoding.EncodeToString(pubkey)
+	return fmt.Sprintf("%s+%08x+%s", name, hash, b64Key), nil
+}
+
+// A Verifiers is a collection of known verifier keys.
+type Verifiers interface {
+	// Verifier returns the Verifier associated with the key
+	// identified by the name and hash.
+	// If the name, hash pair is unknown, Verifier should return
+	// an UnknownVerifierError.
+	Verifier(name string, hash uint32) (Verifier, error)
+}
+
+// An UnknownVerifierError indicates that the given key is not known.
+// The Open function records signatures without associated verifiers as
+// unverified signatures.
+type UnknownVerifierError struct {
+	Name    string
+	KeyHash uint32
+}
+
+func (e *UnknownVerifierError) Error() string {
+	return fmt.Sprintf("unknown key %s+%08x", e.Name, e.KeyHash)
+}
+
+// An ambiguousVerifierError indicates that the given name and hash
+// match multiple keys passed to [VerifierList].
+// (If this happens, some malicious actor has taken control of the
+// verifier list, at which point we may as well give up entirely,
+// but we diagnose the problem instead.)
+type ambiguousVerifierError struct {
+	name string
+	hash uint32
+}
+
+func (e *ambiguousVerifierError) Error() string {
+	return fmt.Sprintf("ambiguous key %s+%08x", e.name, e.hash)
+}
+
+// VerifierList returns a [Verifiers] implementation that uses the given list of verifiers.
+func VerifierList(list ...Verifier) Verifiers {
+	m := make(verifierMap)
+	for _, v := range list {
+		k := nameHash{v.Name(), v.KeyHash()}
+		m[k] = append(m[k], v)
+	}
+	return m
+}
+
+type nameHash struct {
+	name string
+	hash uint32
+}
+
+type verifierMap map[nameHash][]Verifier
+
+func (m verifierMap) Verifier(name string, hash uint32) (Verifier, error) {
+	v, ok := m[nameHash{name, hash}]
+	if !ok {
+		return nil, &UnknownVerifierError{name, hash}
+	}
+	if len(v) > 1 {
+		return nil, &ambiguousVerifierError{name, hash}
+	}
+	return v[0], nil
+}
+
+// A Note is a text and signatures.
+type Note struct {
+	Text           string      // text of note
+	Sigs           []Signature // verified signatures
+	UnverifiedSigs []Signature // unverified signatures
+}
+
+// A Signature is a single signature found in a note.
+type Signature struct {
+	// Name and Hash give the name and key hash
+	// for the key that generated the signature.
+	Name string
+	Hash uint32
+
+	// Base64 records the base64-encoded signature bytes.
+	Base64 string
+}
+
+// An UnverifiedNoteError indicates that the note
+// successfully parsed but had no verifiable signatures.
+type UnverifiedNoteError struct {
+	Note *Note
+}
+
+func (e *UnverifiedNoteError) Error() string {
+	return "note has no verifiable signatures"
+}
+
+// An InvalidSignatureError indicates that the given key was known
+// and the associated Verifier rejected the signature.
+type InvalidSignatureError struct {
+	Name string
+	Hash uint32
+}
+
+func (e *InvalidSignatureError) Error() string {
+	return fmt.Sprintf("invalid signature for key %s+%08x", e.Name, e.Hash)
+}
+
+var (
+	errMalformedNote      = errors.New("malformed note")
+	errInvalidSigner      = errors.New("invalid signer")
+	errMismatchedVerifier = errors.New("verifier name or hash doesn't match signature")
+
+	sigSplit  = []byte("\n\n")
+	sigPrefix = []byte("— ")
+)
+
+// Open opens and parses the message msg, checking signatures from the known verifiers.
+//
+// For each signature in the message, Open calls known.Verifier to find a verifier.
+// If known.Verifier returns a verifier and the verifier accepts the signature,
+// Open records the signature in the returned note's Sigs field.
+// If known.Verifier returns a verifier but the verifier rejects the signature,
+// Open returns an InvalidSignatureError.
+// If known.Verifier returns an UnknownVerifierError,
+// Open records the signature in the returned note's UnverifiedSigs field.
+// If known.Verifier returns any other error, Open returns that error.
+//
+// If no known verifier has signed an otherwise valid note,
+// Open returns an [UnverifiedNoteError].
+// In this case, the unverified note can be fetched from inside the error.
+func Open(msg []byte, known Verifiers) (*Note, error) {
+	if known == nil {
+		// Treat nil Verifiers as empty list, to produce useful error instead of crash.
+		known = VerifierList()
+	}
+
+	// Must have valid UTF-8 with no non-newline ASCII control characters.
+	for i := 0; i < len(msg); {
+		r, size := utf8.DecodeRune(msg[i:])
+		if r < 0x20 && r != '\n' || r == utf8.RuneError && size == 1 {
+			return nil, errMalformedNote
+		}
+		i += size
+	}
+
+	// Must end with signature block preceded by blank line.
+	split := bytes.LastIndex(msg, sigSplit)
+	if split < 0 {
+		return nil, errMalformedNote
+	}
+	text, sigs := msg[:split+1], msg[split+2:]
+	if len(sigs) == 0 || sigs[len(sigs)-1] != '\n' {
+		return nil, errMalformedNote
+	}
+
+	n := &Note{
+		Text: string(text),
+	}
+
+	// Parse and verify signatures.
+	// Ignore duplicate signatures.
+	seen := make(map[nameHash]bool)
+	seenUnverified := make(map[string]bool)
+	numSig := 0
+	for len(sigs) > 0 {
+		// Pull out next signature line.
+		// We know sigs[len(sigs)-1] == '\n', so IndexByte always finds one.
+		i := bytes.IndexByte(sigs, '\n')
+		line := sigs[:i]
+		sigs = sigs[i+1:]
+
+		if !bytes.HasPrefix(line, sigPrefix) {
+			return nil, errMalformedNote
+		}
+		line = line[len(sigPrefix):]
+		name, b64, _ := strings.Cut(string(line), " ")
+		sig, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil || !isValidName(name) || b64 == "" || len(sig) < 5 {
+			return nil, errMalformedNote
+		}
+		hash := binary.BigEndian.Uint32(sig[0:4])
+		sig = sig[4:]
+
+		if numSig++; numSig > 100 {
+			// Avoid spending forever parsing a note with many signatures.
+			return nil, errMalformedNote
+		}
+
+		v, err := known.Verifier(name, hash)
+		if _, ok := err.(*UnknownVerifierError); ok {
+			// Drop repeated identical unverified signatures.
+			if seenUnverified[string(line)] {
+				continue
+			}
+			seenUnverified[string(line)] = true
+			n.UnverifiedSigs = append(n.UnverifiedSigs, Signature{Name: name, Hash: hash, Base64: b64})
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Check that known.Verifier returned the right verifier.
+		if v.Name() != name || v.KeyHash() != hash {
+			return nil, errMismatchedVerifier
+		}
+
+		// Drop repeated signatures by a single verifier.
+		if seen[nameHash{name, hash}] {
+			continue
+		}
+		seen[nameHash{name, hash}] = true
+
+		ok := v.Verify(text, sig)
+		if !ok {
+			return nil, &InvalidSignatureError{name, hash}
+		}
+
+		n.Sigs = append(n.Sigs, Signature{Name: name, Hash: hash, Base64: b64})
+	}
+
+	// Parsed and verified all the signatures.
+	if len(n.Sigs) == 0 {
+		return nil, &UnverifiedNoteError{n}
+	}
+	return n, nil
+}
+
+// Sign signs the note with the given signers and returns the encoded message.
+// The new signatures from signers are listed in the encoded message after
+// the existing signatures already present in n.Sigs.
+// If any signer uses the same key as an existing signature,
+// the existing signature is elided from the output.
+func Sign(n *Note, signers ...Signer) ([]byte, error) {
+	var buf bytes.Buffer
+	if !strings.HasSuffix(n.Text, "\n") {
+		return nil, errMalformedNote
+	}
+	buf.WriteString(n.Text)
+
+	// Prepare signatures.
+	var sigs bytes.Buffer
+	have := make(map[nameHash]bool)
+	for _, s := range signers {
+		name := s.Name()
+		hash := s.KeyHash()
+		have[nameHash{name, hash}] = true
+		if !isValidName(name) {
+			return nil, errInvalidSigner
+		}
+
+		sig, err := s.Sign(buf.Bytes()) // buf holds n.Text
+		if err != nil {
+			return nil, err
+		}
+
+		var hbuf [4]byte
+		binary.BigEndian.PutUint32(hbuf[:], hash)
+		b64 := base64.StdEncoding.EncodeToString(append(hbuf[:], sig...))
+		sigs.WriteString("— ")
+		sigs.WriteString(name)
+		sigs.WriteString(" ")
+		sigs.WriteString(b64)
+		sigs.WriteString("\n")
+	}
+
+	buf.WriteString("\n")
+
+	// Emit existing signatures not replaced by new ones.
+	for _, list := range [][]Signature{n.Sigs, n.UnverifiedSigs} {
+		for _, sig := range list {
+			name, hash := sig.Name, sig.Hash
+			if !isValidName(name) {
+				return nil, errMalformedNote
+			}
+			if have[nameHash{name, hash}] {
+				continue
+			}
+			// Double-check hash against base64.
+			raw, err := base64.StdEncoding.DecodeString(sig.Base64)
+			if err != nil || len(raw) < 4 || binary.BigEndian.Uint32(raw) != hash {
+				return nil, errMalformedNote
+			}
+			buf.WriteString("— ")
+			buf.WriteString(sig.Name)
+			buf.WriteString(" ")
+			buf.WriteString(sig.Base64)
+			buf.WriteString("\n")
+		}
+	}
+	buf.Write(sigs.Bytes())
+
+	return buf.Bytes(), nil
+}

--- a/vendor/golang.org/x/mod/sumdb/tlog/note.go
+++ b/vendor/golang.org/x/mod/sumdb/tlog/note.go
@@ -1,0 +1,138 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tlog
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// A Tree is a tree description, to be signed by a go.sum database server.
+type Tree struct {
+	N    int64
+	Hash Hash
+}
+
+// FormatTree formats a tree description for inclusion in a note.
+//
+// The encoded form is three lines, each ending in a newline (U+000A):
+//
+//	go.sum database tree
+//	N
+//	Hash
+//
+// where N is in decimal and Hash is in base64.
+//
+// A future backwards-compatible encoding may add additional lines,
+// which the parser can ignore.
+// A future backwards-incompatible encoding would use a different
+// first line (for example, "go.sum database tree v2").
+func FormatTree(tree Tree) []byte {
+	return fmt.Appendf(nil, "go.sum database tree\n%d\n%s\n", tree.N, tree.Hash)
+}
+
+var errMalformedTree = errors.New("malformed tree note")
+var treePrefix = []byte("go.sum database tree\n")
+
+// ParseTree parses a formatted tree root description.
+func ParseTree(text []byte) (tree Tree, err error) {
+	// The message looks like:
+	//
+	//	go.sum database tree
+	//	2
+	//	nND/nri/U0xuHUrYSy0HtMeal2vzD9V4k/BO79C+QeI=
+	//
+	// For forwards compatibility, extra text lines after the encoding are ignored.
+	if !bytes.HasPrefix(text, treePrefix) || bytes.Count(text, []byte("\n")) < 3 || len(text) > 1e6 {
+		return Tree{}, errMalformedTree
+	}
+
+	lines := strings.SplitN(string(text), "\n", 4)
+	n, err := strconv.ParseInt(lines[1], 10, 64)
+	if err != nil || n < 0 || lines[1] != strconv.FormatInt(n, 10) {
+		return Tree{}, errMalformedTree
+	}
+
+	h, err := base64.StdEncoding.DecodeString(lines[2])
+	if err != nil || len(h) != HashSize {
+		return Tree{}, errMalformedTree
+	}
+
+	var hash Hash
+	copy(hash[:], h)
+	return Tree{n, hash}, nil
+}
+
+var errMalformedRecord = errors.New("malformed record data")
+
+// FormatRecord formats a record for serving to a client
+// in a lookup response.
+//
+// The encoded form is the record ID as a single number,
+// then the text of the record, and then a terminating blank line.
+// Record text must be valid UTF-8 and must not contain any ASCII control
+// characters (those below U+0020) other than newline (U+000A).
+// It must end in a terminating newline and not contain any blank lines.
+//
+// Responses to data tiles consist of concatenated formatted records from each of
+// which the first line, with the record ID, is removed.
+func FormatRecord(id int64, text []byte) (msg []byte, err error) {
+	if !isValidRecordText(text) {
+		return nil, errMalformedRecord
+	}
+	msg = fmt.Appendf(nil, "%d\n", id)
+	msg = append(msg, text...)
+	msg = append(msg, '\n')
+	return msg, nil
+}
+
+// isValidRecordText reports whether text is syntactically valid record text.
+func isValidRecordText(text []byte) bool {
+	var last rune
+	for i := 0; i < len(text); {
+		r, size := utf8.DecodeRune(text[i:])
+		if r < 0x20 && r != '\n' || r == utf8.RuneError && size == 1 || last == '\n' && r == '\n' {
+			return false
+		}
+		i += size
+		last = r
+	}
+	if last != '\n' {
+		return false
+	}
+	return true
+}
+
+// ParseRecord parses a record description at the start of text,
+// stopping immediately after the terminating blank line.
+// It returns the record id, the record text, and the remainder of text.
+func ParseRecord(msg []byte) (id int64, text, rest []byte, err error) {
+	// Leading record id.
+	i := bytes.IndexByte(msg, '\n')
+	if i < 0 {
+		return 0, nil, nil, errMalformedRecord
+	}
+	id, err = strconv.ParseInt(string(msg[:i]), 10, 64)
+	if err != nil {
+		return 0, nil, nil, errMalformedRecord
+	}
+	msg = msg[i+1:]
+
+	// Record text.
+	i = bytes.Index(msg, []byte("\n\n"))
+	if i < 0 {
+		return 0, nil, nil, errMalformedRecord
+	}
+	text, rest = msg[:i+1], msg[i+2:]
+	if !isValidRecordText(text) {
+		return 0, nil, nil, errMalformedRecord
+	}
+	return id, text, rest, nil
+}

--- a/vendor/golang.org/x/mod/sumdb/tlog/tile.go
+++ b/vendor/golang.org/x/mod/sumdb/tlog/tile.go
@@ -1,0 +1,433 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tlog
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// A Tile is a description of a transparency log tile.
+// A tile of height H at level L offset N lists W consecutive hashes
+// at level H*L of the tree starting at offset N*(2**H).
+// A complete tile lists 2**H hashes; a partial tile lists fewer.
+// Note that a tile represents the entire subtree of height H
+// with those hashes as the leaves. The levels above H*L
+// can be reconstructed by hashing the leaves.
+//
+// Each Tile can be encoded as a “tile coordinate path”
+// of the form tile/H/L/NNN[.p/W].
+// The .p/W suffix is present only for partial tiles, meaning W < 2**H.
+// The NNN element is an encoding of N into 3-digit path elements.
+// All but the last path element begins with an "x".
+// For example,
+// Tile{H: 3, L: 4, N: 1234067, W: 1}'s path
+// is tile/3/4/x001/x234/067.p/1, and
+// Tile{H: 3, L: 4, N: 1234067, W: 8}'s path
+// is tile/3/4/x001/x234/067.
+// See the [Tile.Path] method and the [ParseTilePath] function.
+//
+// The special level L=-1 holds raw record data instead of hashes.
+// In this case, the level encodes into a tile path as the path element
+// "data" instead of "-1".
+//
+// See also https://golang.org/design/25530-sumdb#checksum-database
+// and https://research.swtch.com/tlog#tiling_a_log.
+type Tile struct {
+	H int   // height of tile (1 ≤ H ≤ 30)
+	L int   // level in tiling (-1 ≤ L ≤ 63)
+	N int64 // number within level (0 ≤ N, unbounded)
+	W int   // width of tile (1 ≤ W ≤ 2**H; 2**H is complete tile)
+}
+
+// TileForIndex returns the tile of fixed height h ≥ 1
+// and least width storing the given hash storage index.
+//
+// If h ≤ 0, [TileForIndex] panics.
+func TileForIndex(h int, index int64) Tile {
+	if h <= 0 {
+		panic(fmt.Sprintf("TileForIndex: invalid height %d", h))
+	}
+	t, _, _ := tileForIndex(h, index)
+	return t
+}
+
+// tileForIndex returns the tile of height h ≥ 1
+// storing the given hash index, which can be
+// reconstructed using tileHash(data[start:end]).
+func tileForIndex(h int, index int64) (t Tile, start, end int) {
+	level, n := SplitStoredHashIndex(index)
+	t.H = h
+	t.L = level / h
+	level -= t.L * h // now level within tile
+	t.N = n << uint(level) >> uint(t.H)
+	n -= t.N << uint(t.H) >> uint(level) // now n within tile at level
+	t.W = int((n + 1) << uint(level))
+	return t, int(n<<uint(level)) * HashSize, int((n+1)<<uint(level)) * HashSize
+}
+
+// HashFromTile returns the hash at the given storage index,
+// provided that t == TileForIndex(t.H, index) or a wider version,
+// and data is t's tile data (of length at least t.W*HashSize).
+func HashFromTile(t Tile, data []byte, index int64) (Hash, error) {
+	if t.H < 1 || t.H > 30 || t.L < 0 || t.L >= 64 || t.W < 1 || t.W > 1<<uint(t.H) {
+		return Hash{}, fmt.Errorf("invalid tile %v", t.Path())
+	}
+	if len(data) < t.W*HashSize {
+		return Hash{}, fmt.Errorf("data len %d too short for tile %v", len(data), t.Path())
+	}
+	t1, start, end := tileForIndex(t.H, index)
+	if t.L != t1.L || t.N != t1.N || t.W < t1.W {
+		return Hash{}, fmt.Errorf("index %v is in %v not %v", index, t1.Path(), t.Path())
+	}
+	return tileHash(data[start:end]), nil
+}
+
+// tileHash computes the subtree hash corresponding to the (2^K)-1 hashes in data.
+func tileHash(data []byte) Hash {
+	if len(data) == 0 {
+		panic("bad math in tileHash")
+	}
+	if len(data) == HashSize {
+		var h Hash
+		copy(h[:], data)
+		return h
+	}
+	n := len(data) / 2
+	return NodeHash(tileHash(data[:n]), tileHash(data[n:]))
+}
+
+// NewTiles returns the coordinates of the tiles of height h ≥ 1
+// that must be published when publishing from a tree of
+// size newTreeSize to replace a tree of size oldTreeSize.
+// (No tiles need to be published for a tree of size zero.)
+//
+// If h ≤ 0, NewTiles panics.
+func NewTiles(h int, oldTreeSize, newTreeSize int64) []Tile {
+	if h <= 0 {
+		panic(fmt.Sprintf("NewTiles: invalid height %d", h))
+	}
+	H := uint(h)
+	var tiles []Tile
+	for level := uint(0); newTreeSize>>(H*level) > 0; level++ {
+		oldN := oldTreeSize >> (H * level)
+		newN := newTreeSize >> (H * level)
+		if oldN == newN {
+			continue
+		}
+		for n := oldN >> H; n < newN>>H; n++ {
+			tiles = append(tiles, Tile{H: h, L: int(level), N: n, W: 1 << H})
+		}
+		n := newN >> H
+		if w := int(newN - n<<H); w > 0 {
+			tiles = append(tiles, Tile{H: h, L: int(level), N: n, W: w})
+		}
+	}
+	return tiles
+}
+
+// ReadTileData reads the hashes for tile t from r
+// and returns the corresponding tile data.
+func ReadTileData(t Tile, r HashReader) ([]byte, error) {
+	size := t.W
+	if size == 0 {
+		size = 1 << uint(t.H)
+	}
+	start := t.N << uint(t.H)
+	indexes := make([]int64, size)
+	for i := 0; i < size; i++ {
+		indexes[i] = StoredHashIndex(t.H*t.L, start+int64(i))
+	}
+
+	hashes, err := r.ReadHashes(indexes)
+	if err != nil {
+		return nil, err
+	}
+	if len(hashes) != len(indexes) {
+		return nil, fmt.Errorf("tlog: ReadHashes(%d indexes) = %d hashes", len(indexes), len(hashes))
+	}
+
+	tile := make([]byte, size*HashSize)
+	for i := 0; i < size; i++ {
+		copy(tile[i*HashSize:], hashes[i][:])
+	}
+	return tile, nil
+}
+
+// To limit the size of any particular directory listing,
+// we encode the (possibly very large) number N
+// by encoding three digits at a time.
+// For example, 123456789 encodes as x123/x456/789.
+// Each directory has at most 1000 each xNNN, NNN, and NNN.p children,
+// so there are at most 3000 entries in any one directory.
+const pathBase = 1000
+
+// Path returns a tile coordinate path describing t.
+func (t Tile) Path() string {
+	n := t.N
+	nStr := fmt.Sprintf("%03d", n%pathBase)
+	for n >= pathBase {
+		n /= pathBase
+		nStr = fmt.Sprintf("x%03d/%s", n%pathBase, nStr)
+	}
+	pStr := ""
+	if t.W != 1<<uint(t.H) {
+		pStr = fmt.Sprintf(".p/%d", t.W)
+	}
+	var L string
+	if t.L == -1 {
+		L = "data"
+	} else {
+		L = fmt.Sprintf("%d", t.L)
+	}
+	return fmt.Sprintf("tile/%d/%s/%s%s", t.H, L, nStr, pStr)
+}
+
+// ParseTilePath parses a tile coordinate path.
+func ParseTilePath(path string) (Tile, error) {
+	f := strings.Split(path, "/")
+	if len(f) < 4 || f[0] != "tile" {
+		return Tile{}, &badPathError{path}
+	}
+	h, err1 := strconv.Atoi(f[1])
+	isData := false
+	if f[2] == "data" {
+		isData = true
+		f[2] = "0"
+	}
+	l, err2 := strconv.Atoi(f[2])
+	if err1 != nil || err2 != nil || h < 1 || l < 0 || h > 30 {
+		return Tile{}, &badPathError{path}
+	}
+	w := 1 << uint(h)
+	if dotP := f[len(f)-2]; strings.HasSuffix(dotP, ".p") {
+		ww, err := strconv.Atoi(f[len(f)-1])
+		if err != nil || ww <= 0 || ww >= w {
+			return Tile{}, &badPathError{path}
+		}
+		w = ww
+		f[len(f)-2] = dotP[:len(dotP)-len(".p")]
+		f = f[:len(f)-1]
+	}
+	f = f[3:]
+	n := int64(0)
+	for _, s := range f {
+		nn, err := strconv.Atoi(strings.TrimPrefix(s, "x"))
+		if err != nil || nn < 0 || nn >= pathBase {
+			return Tile{}, &badPathError{path}
+		}
+		n = n*pathBase + int64(nn)
+	}
+	if isData {
+		l = -1
+	}
+	t := Tile{H: h, L: l, N: n, W: w}
+	if path != t.Path() {
+		return Tile{}, &badPathError{path}
+	}
+	return t, nil
+}
+
+type badPathError struct {
+	path string
+}
+
+func (e *badPathError) Error() string {
+	return fmt.Sprintf("malformed tile path %q", e.path)
+}
+
+// A TileReader reads tiles from a go.sum database log.
+type TileReader interface {
+	// Height returns the height of the available tiles.
+	Height() int
+
+	// ReadTiles returns the data for each requested tile.
+	// If ReadTiles returns err == nil, it must also return
+	// a data record for each tile (len(data) == len(tiles))
+	// and each data record must be the correct length
+	// (len(data[i]) == tiles[i].W*HashSize).
+	//
+	// An implementation of ReadTiles typically reads
+	// them from an on-disk cache or else from a remote
+	// tile server. Tile data downloaded from a server should
+	// be considered suspect and not saved into a persistent
+	// on-disk cache before returning from ReadTiles.
+	// When the client confirms the validity of the tile data,
+	// it will call SaveTiles to signal that they can be safely
+	// written to persistent storage.
+	// See also https://research.swtch.com/tlog#authenticating_tiles.
+	ReadTiles(tiles []Tile) (data [][]byte, err error)
+
+	// SaveTiles informs the TileReader that the tile data
+	// returned by ReadTiles has been confirmed as valid
+	// and can be saved in persistent storage (on disk).
+	SaveTiles(tiles []Tile, data [][]byte)
+}
+
+// TileHashReader returns a HashReader that satisfies requests
+// by loading tiles of the given tree.
+//
+// The returned [HashReader] checks that loaded tiles are
+// valid for the given tree. Therefore, any hashes returned
+// by the HashReader are already proven to be in the tree.
+func TileHashReader(tree Tree, tr TileReader) HashReader {
+	return &tileHashReader{tree: tree, tr: tr}
+}
+
+type tileHashReader struct {
+	tree Tree
+	tr   TileReader
+}
+
+// tileParent returns t's k'th tile parent in the tiles for a tree of size n.
+// If there is no such parent, tileParent returns Tile{}.
+func tileParent(t Tile, k int, n int64) Tile {
+	t.L += k
+	t.N >>= uint(k * t.H)
+	t.W = 1 << uint(t.H)
+	if max := n >> uint(t.L*t.H); t.N<<uint(t.H)+int64(t.W) >= max {
+		if t.N<<uint(t.H) >= max {
+			return Tile{}
+		}
+		t.W = int(max - t.N<<uint(t.H))
+	}
+	return t
+}
+
+func (r *tileHashReader) ReadHashes(indexes []int64) ([]Hash, error) {
+	h := r.tr.Height()
+
+	tileOrder := make(map[Tile]int) // tileOrder[tileKey(tiles[i])] = i
+	var tiles []Tile
+
+	// Plan to fetch tiles necessary to recompute tree hash.
+	// If it matches, those tiles are authenticated.
+	stx := subTreeIndex(0, r.tree.N, nil)
+	stxTileOrder := make([]int, len(stx))
+	for i, x := range stx {
+		tile, _, _ := tileForIndex(h, x)
+		tile = tileParent(tile, 0, r.tree.N)
+		if j, ok := tileOrder[tile]; ok {
+			stxTileOrder[i] = j
+			continue
+		}
+		stxTileOrder[i] = len(tiles)
+		tileOrder[tile] = len(tiles)
+		tiles = append(tiles, tile)
+	}
+
+	// Plan to fetch tiles containing the indexes,
+	// along with any parent tiles needed
+	// for authentication. For most calls,
+	// the parents are being fetched anyway.
+	indexTileOrder := make([]int, len(indexes))
+	for i, x := range indexes {
+		if x >= StoredHashIndex(0, r.tree.N) {
+			return nil, fmt.Errorf("indexes not in tree")
+		}
+
+		tile, _, _ := tileForIndex(h, x)
+
+		// Walk up parent tiles until we find one we've requested.
+		// That one will be authenticated.
+		k := 0
+		for ; ; k++ {
+			p := tileParent(tile, k, r.tree.N)
+			if j, ok := tileOrder[p]; ok {
+				if k == 0 {
+					indexTileOrder[i] = j
+				}
+				break
+			}
+		}
+
+		// Walk back down recording child tiles after parents.
+		// This loop ends by revisiting the tile for this index
+		// (tileParent(tile, 0, r.tree.N)) unless k == 0, in which
+		// case the previous loop did it.
+		for k--; k >= 0; k-- {
+			p := tileParent(tile, k, r.tree.N)
+			if p.W != 1<<uint(p.H) {
+				// Only full tiles have parents.
+				// This tile has a parent, so it must be full.
+				return nil, fmt.Errorf("bad math in tileHashReader: %d %d %v", r.tree.N, x, p)
+			}
+			tileOrder[p] = len(tiles)
+			if k == 0 {
+				indexTileOrder[i] = len(tiles)
+			}
+			tiles = append(tiles, p)
+		}
+	}
+
+	// Fetch all the tile data.
+	data, err := r.tr.ReadTiles(tiles)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) != len(tiles) {
+		return nil, fmt.Errorf("TileReader returned bad result slice (len=%d, want %d)", len(data), len(tiles))
+	}
+	for i, tile := range tiles {
+		if len(data[i]) != tile.W*HashSize {
+			return nil, fmt.Errorf("TileReader returned bad result slice (%v len=%d, want %d)", tile.Path(), len(data[i]), tile.W*HashSize)
+		}
+	}
+
+	// Authenticate the initial tiles against the tree hash.
+	// They are arranged so that parents are authenticated before children.
+	// First the tiles needed for the tree hash.
+	th, err := HashFromTile(tiles[stxTileOrder[len(stx)-1]], data[stxTileOrder[len(stx)-1]], stx[len(stx)-1])
+	if err != nil {
+		return nil, err
+	}
+	for i := len(stx) - 2; i >= 0; i-- {
+		h, err := HashFromTile(tiles[stxTileOrder[i]], data[stxTileOrder[i]], stx[i])
+		if err != nil {
+			return nil, err
+		}
+		th = NodeHash(h, th)
+	}
+	if th != r.tree.Hash {
+		// The tiles do not support the tree hash.
+		// We know at least one is wrong, but not which one.
+		return nil, fmt.Errorf("downloaded inconsistent tile")
+	}
+
+	// Authenticate full tiles against their parents.
+	for i := len(stx); i < len(tiles); i++ {
+		tile := tiles[i]
+		p := tileParent(tile, 1, r.tree.N)
+		j, ok := tileOrder[p]
+		if !ok {
+			return nil, fmt.Errorf("bad math in tileHashReader %d %v: lost parent of %v", r.tree.N, indexes, tile)
+		}
+		h, err := HashFromTile(p, data[j], StoredHashIndex(p.L*p.H, tile.N))
+		if err != nil {
+			return nil, fmt.Errorf("bad math in tileHashReader %d %v: lost hash of %v: %v", r.tree.N, indexes, tile, err)
+		}
+		if h != tileHash(data[i]) {
+			return nil, fmt.Errorf("downloaded inconsistent tile")
+		}
+	}
+
+	// Now we have all the tiles needed for the requested hashes,
+	// and we've authenticated the full tile set against the trusted tree hash.
+	r.tr.SaveTiles(tiles, data)
+
+	// Pull out the requested hashes.
+	hashes := make([]Hash, len(indexes))
+	for i, x := range indexes {
+		j := indexTileOrder[i]
+		h, err := HashFromTile(tiles[j], data[j], x)
+		if err != nil {
+			return nil, fmt.Errorf("bad math in tileHashReader %d %v: lost hash %v: %v", r.tree.N, indexes, x, err)
+		}
+		hashes[i] = h
+	}
+
+	return hashes, nil
+}

--- a/vendor/golang.org/x/mod/sumdb/tlog/tlog.go
+++ b/vendor/golang.org/x/mod/sumdb/tlog/tlog.go
@@ -1,0 +1,605 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package tlog implements a tamper-evident log
+// used in the Go module go.sum database server.
+//
+// This package follows the design of Certificate Transparency (RFC 6962)
+// and its proofs are compatible with that system.
+// See TestCertificateTransparency.
+package tlog
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math/bits"
+)
+
+// A Hash is a hash identifying a log record or tree root.
+type Hash [HashSize]byte
+
+// HashSize is the size of a Hash in bytes.
+const HashSize = 32
+
+// String returns a base64 representation of the hash for printing.
+func (h Hash) String() string {
+	return base64.StdEncoding.EncodeToString(h[:])
+}
+
+// MarshalJSON marshals the hash as a JSON string containing the base64-encoded hash.
+func (h Hash) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + h.String() + `"`), nil
+}
+
+// UnmarshalJSON unmarshals a hash from JSON string containing the a base64-encoded hash.
+func (h *Hash) UnmarshalJSON(data []byte) error {
+	if len(data) != 1+44+1 || data[0] != '"' || data[len(data)-2] != '=' || data[len(data)-1] != '"' {
+		return errors.New("cannot decode hash")
+	}
+
+	// As of Go 1.12, base64.StdEncoding.Decode insists on
+	// slicing into target[33:] even when it only writes 32 bytes.
+	// Since we already checked that the hash ends in = above,
+	// we can use base64.RawStdEncoding with the = removed;
+	// RawStdEncoding does not exhibit the same bug.
+	// We decode into a temporary to avoid writing anything to *h
+	// unless the entire input is well-formed.
+	var tmp Hash
+	n, err := base64.RawStdEncoding.Decode(tmp[:], data[1:len(data)-2])
+	if err != nil || n != HashSize {
+		return errors.New("cannot decode hash")
+	}
+	*h = tmp
+	return nil
+}
+
+// ParseHash parses the base64-encoded string form of a hash.
+func ParseHash(s string) (Hash, error) {
+	data, err := base64.StdEncoding.DecodeString(s)
+	if err != nil || len(data) != HashSize {
+		return Hash{}, fmt.Errorf("malformed hash")
+	}
+	var h Hash
+	copy(h[:], data)
+	return h, nil
+}
+
+// maxpow2 returns k, the maximum power of 2 smaller than n,
+// as well as l = log₂ k (so k = 1<<l).
+func maxpow2(n int64) (k int64, l int) {
+	l = 0
+	for 1<<uint(l+1) < n {
+		l++
+	}
+	return 1 << uint(l), l
+}
+
+var zeroPrefix = []byte{0x00}
+
+// RecordHash returns the content hash for the given record data.
+func RecordHash(data []byte) Hash {
+	// SHA256(0x00 || data)
+	// https://tools.ietf.org/html/rfc6962#section-2.1
+	h := sha256.New()
+	h.Write(zeroPrefix)
+	h.Write(data)
+	var h1 Hash
+	h.Sum(h1[:0])
+	return h1
+}
+
+// NodeHash returns the hash for an interior tree node with the given left and right hashes.
+func NodeHash(left, right Hash) Hash {
+	// SHA256(0x01 || left || right)
+	// https://tools.ietf.org/html/rfc6962#section-2.1
+	// We use a stack buffer to assemble the hash input
+	// to avoid allocating a hash struct with sha256.New.
+	var buf [1 + HashSize + HashSize]byte
+	buf[0] = 0x01
+	copy(buf[1:], left[:])
+	copy(buf[1+HashSize:], right[:])
+	return sha256.Sum256(buf[:])
+}
+
+// For information about the stored hash index ordering,
+// see section 3.3 of Crosby and Wallach's paper
+// "Efficient Data Structures for Tamper-Evident Logging".
+// https://www.usenix.org/legacy/event/sec09/tech/full_papers/crosby.pdf
+
+// StoredHashIndex maps the tree coordinates (level, n)
+// to a dense linear ordering that can be used for hash storage.
+// Hash storage implementations that store hashes in sequential
+// storage can use this function to compute where to read or write
+// a given hash.
+func StoredHashIndex(level int, n int64) int64 {
+	// Level L's n'th hash is written right after level L+1's 2n+1'th hash.
+	// Work our way down to the level 0 ordering.
+	// We'll add back the original level count at the end.
+	for l := level; l > 0; l-- {
+		n = 2*n + 1
+	}
+
+	// Level 0's n'th hash is written at n+n/2+n/4+... (eventually n/2ⁱ hits zero).
+	i := int64(0)
+	for ; n > 0; n >>= 1 {
+		i += n
+	}
+
+	return i + int64(level)
+}
+
+// SplitStoredHashIndex is the inverse of [StoredHashIndex].
+// That is, SplitStoredHashIndex(StoredHashIndex(level, n)) == level, n.
+func SplitStoredHashIndex(index int64) (level int, n int64) {
+	// Determine level 0 record before index.
+	// StoredHashIndex(0, n) < 2*n,
+	// so the n we want is in [index/2, index/2+log₂(index)].
+	n = index / 2
+	indexN := StoredHashIndex(0, n)
+	if indexN > index {
+		panic("bad math")
+	}
+	for {
+		// Each new record n adds 1 + trailingZeros(n) hashes.
+		x := indexN + 1 + int64(bits.TrailingZeros64(uint64(n+1)))
+		if x > index {
+			break
+		}
+		n++
+		indexN = x
+	}
+	// The hash we want was committed with record n,
+	// meaning it is one of (0, n), (1, n/2), (2, n/4), ...
+	level = int(index - indexN)
+	return level, n >> uint(level)
+}
+
+// StoredHashCount returns the number of stored hashes
+// that are expected for a tree with n records.
+func StoredHashCount(n int64) int64 {
+	if n == 0 {
+		return 0
+	}
+	// The tree will have the hashes up to the last leaf hash.
+	numHash := StoredHashIndex(0, n-1) + 1
+	// And it will have any hashes for subtrees completed by that leaf.
+	for i := uint64(n - 1); i&1 != 0; i >>= 1 {
+		numHash++
+	}
+	return numHash
+}
+
+// StoredHashes returns the hashes that must be stored when writing
+// record n with the given data. The hashes should be stored starting
+// at StoredHashIndex(0, n). The result will have at most 1 + log₂ n hashes,
+// but it will average just under two per call for a sequence of calls for n=1..k.
+//
+// StoredHashes may read up to log n earlier hashes from r
+// in order to compute hashes for completed subtrees.
+func StoredHashes(n int64, data []byte, r HashReader) ([]Hash, error) {
+	return StoredHashesForRecordHash(n, RecordHash(data), r)
+}
+
+// StoredHashesForRecordHash is like [StoredHashes] but takes
+// as its second argument RecordHash(data) instead of data itself.
+func StoredHashesForRecordHash(n int64, h Hash, r HashReader) ([]Hash, error) {
+	// Start with the record hash.
+	hashes := []Hash{h}
+
+	// Build list of indexes needed for hashes for completed subtrees.
+	// Each trailing 1 bit in the binary representation of n completes a subtree
+	// and consumes a hash from an adjacent subtree.
+	m := int(bits.TrailingZeros64(uint64(n + 1)))
+	indexes := make([]int64, m)
+	for i := range m {
+		// We arrange indexes in sorted order.
+		// Note that n>>i is always odd.
+		indexes[m-1-i] = StoredHashIndex(i, n>>uint(i)-1)
+	}
+
+	// Fetch hashes.
+	old, err := r.ReadHashes(indexes)
+	if err != nil {
+		return nil, err
+	}
+	if len(old) != len(indexes) {
+		return nil, fmt.Errorf("tlog: ReadHashes(%d indexes) = %d hashes", len(indexes), len(old))
+	}
+
+	// Build new hashes.
+	for i := range m {
+		h = NodeHash(old[m-1-i], h)
+		hashes = append(hashes, h)
+	}
+	return hashes, nil
+}
+
+// A HashReader can read hashes for nodes in the log's tree structure.
+type HashReader interface {
+	// ReadHashes returns the hashes with the given stored hash indexes
+	// (see StoredHashIndex and SplitStoredHashIndex).
+	// ReadHashes must return a slice of hashes the same length as indexes,
+	// or else it must return a non-nil error.
+	// ReadHashes may run faster if indexes is sorted in increasing order.
+	ReadHashes(indexes []int64) ([]Hash, error)
+}
+
+// A HashReaderFunc is a function implementing [HashReader].
+type HashReaderFunc func([]int64) ([]Hash, error)
+
+func (f HashReaderFunc) ReadHashes(indexes []int64) ([]Hash, error) {
+	return f(indexes)
+}
+
+// emptyHash is the hash of the empty tree, per RFC 6962, Section 2.1.
+// It is the hash of the empty string.
+var emptyHash = Hash{
+	0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+	0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+	0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+	0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+}
+
+// TreeHash computes the hash for the root of the tree with n records,
+// using the HashReader to obtain previously stored hashes
+// (those returned by StoredHashes during the writes of those n records).
+// TreeHash makes a single call to ReadHash requesting at most 1 + log₂ n hashes.
+func TreeHash(n int64, r HashReader) (Hash, error) {
+	if n == 0 {
+		return emptyHash, nil
+	}
+	indexes := subTreeIndex(0, n, nil)
+	hashes, err := r.ReadHashes(indexes)
+	if err != nil {
+		return Hash{}, err
+	}
+	if len(hashes) != len(indexes) {
+		return Hash{}, fmt.Errorf("tlog: ReadHashes(%d indexes) = %d hashes", len(indexes), len(hashes))
+	}
+	hash, hashes := subTreeHash(0, n, hashes)
+	if len(hashes) != 0 {
+		panic("tlog: bad index math in TreeHash")
+	}
+	return hash, nil
+}
+
+// subTreeIndex returns the storage indexes needed to compute
+// the hash for the subtree containing records [lo, hi),
+// appending them to need and returning the result.
+// See https://tools.ietf.org/html/rfc6962#section-2.1
+func subTreeIndex(lo, hi int64, need []int64) []int64 {
+	// See subTreeHash below for commentary.
+	for lo < hi {
+		k, level := maxpow2(hi - lo + 1)
+		if lo&(k-1) != 0 {
+			panic("tlog: bad math in subTreeIndex")
+		}
+		need = append(need, StoredHashIndex(level, lo>>uint(level)))
+		lo += k
+	}
+	return need
+}
+
+// subTreeHash computes the hash for the subtree containing records [lo, hi),
+// assuming that hashes are the hashes corresponding to the indexes
+// returned by subTreeIndex(lo, hi).
+// It returns any leftover hashes.
+func subTreeHash(lo, hi int64, hashes []Hash) (Hash, []Hash) {
+	// Repeatedly partition the tree into a left side with 2^level nodes,
+	// for as large a level as possible, and a right side with the fringe.
+	// The left hash is stored directly and can be read from storage.
+	// The right side needs further computation.
+	numTree := 0
+	for lo < hi {
+		k, _ := maxpow2(hi - lo + 1)
+		if lo&(k-1) != 0 || lo >= hi {
+			panic("tlog: bad math in subTreeHash")
+		}
+		numTree++
+		lo += k
+	}
+
+	if len(hashes) < numTree {
+		panic("tlog: bad index math in subTreeHash")
+	}
+
+	// Reconstruct hash.
+	h := hashes[numTree-1]
+	for i := numTree - 2; i >= 0; i-- {
+		h = NodeHash(hashes[i], h)
+	}
+	return h, hashes[numTree:]
+}
+
+// A RecordProof is a verifiable proof that a particular log root contains a particular record.
+// RFC 6962 calls this a “Merkle audit path.”
+type RecordProof []Hash
+
+// ProveRecord returns the proof that the tree of size t contains the record with index n.
+func ProveRecord(t, n int64, r HashReader) (RecordProof, error) {
+	if t < 0 || n < 0 || n >= t {
+		return nil, fmt.Errorf("tlog: invalid inputs in ProveRecord")
+	}
+	indexes := leafProofIndex(0, t, n, nil)
+	if len(indexes) == 0 {
+		return RecordProof{}, nil
+	}
+	hashes, err := r.ReadHashes(indexes)
+	if err != nil {
+		return nil, err
+	}
+	if len(hashes) != len(indexes) {
+		return nil, fmt.Errorf("tlog: ReadHashes(%d indexes) = %d hashes", len(indexes), len(hashes))
+	}
+
+	p, hashes := leafProof(0, t, n, hashes)
+	if len(hashes) != 0 {
+		panic("tlog: bad index math in ProveRecord")
+	}
+	return p, nil
+}
+
+// leafProofIndex builds the list of indexes needed to construct the proof
+// that leaf n is contained in the subtree with leaves [lo, hi).
+// It appends those indexes to need and returns the result.
+// See https://tools.ietf.org/html/rfc6962#section-2.1.1
+func leafProofIndex(lo, hi, n int64, need []int64) []int64 {
+	// See leafProof below for commentary.
+	if !(lo <= n && n < hi) {
+		panic("tlog: bad math in leafProofIndex")
+	}
+	if lo+1 == hi {
+		return need
+	}
+	if k, _ := maxpow2(hi - lo); n < lo+k {
+		need = leafProofIndex(lo, lo+k, n, need)
+		need = subTreeIndex(lo+k, hi, need)
+	} else {
+		need = subTreeIndex(lo, lo+k, need)
+		need = leafProofIndex(lo+k, hi, n, need)
+	}
+	return need
+}
+
+// leafProof constructs the proof that leaf n is contained in the subtree with leaves [lo, hi).
+// It returns any leftover hashes as well.
+// See https://tools.ietf.org/html/rfc6962#section-2.1.1
+func leafProof(lo, hi, n int64, hashes []Hash) (RecordProof, []Hash) {
+	// We must have lo <= n < hi or else the code here has a bug.
+	if !(lo <= n && n < hi) {
+		panic("tlog: bad math in leafProof")
+	}
+
+	if lo+1 == hi { // n == lo
+		// Reached the leaf node.
+		// The verifier knows what the leaf hash is, so we don't need to send it.
+		return RecordProof{}, hashes
+	}
+
+	// Walk down the tree toward n.
+	// Record the hash of the path not taken (needed for verifying the proof).
+	var p RecordProof
+	var th Hash
+	if k, _ := maxpow2(hi - lo); n < lo+k {
+		// n is on left side
+		p, hashes = leafProof(lo, lo+k, n, hashes)
+		th, hashes = subTreeHash(lo+k, hi, hashes)
+	} else {
+		// n is on right side
+		th, hashes = subTreeHash(lo, lo+k, hashes)
+		p, hashes = leafProof(lo+k, hi, n, hashes)
+	}
+	return append(p, th), hashes
+}
+
+var errProofFailed = errors.New("invalid transparency proof")
+
+// CheckRecord verifies that p is a valid proof that the tree of size t
+// with hash th has an n'th record with hash h.
+func CheckRecord(p RecordProof, t int64, th Hash, n int64, h Hash) error {
+	if t < 0 || n < 0 || n >= t {
+		return fmt.Errorf("tlog: invalid inputs in CheckRecord")
+	}
+	th2, err := runRecordProof(p, 0, t, n, h)
+	if err != nil {
+		return err
+	}
+	if th2 == th {
+		return nil
+	}
+	return errProofFailed
+}
+
+// runRecordProof runs the proof p that leaf n is contained in the subtree with leaves [lo, hi).
+// Running the proof means constructing and returning the implied hash of that
+// subtree.
+func runRecordProof(p RecordProof, lo, hi, n int64, leafHash Hash) (Hash, error) {
+	// We must have lo <= n < hi or else the code here has a bug.
+	if !(lo <= n && n < hi) {
+		panic("tlog: bad math in runRecordProof")
+	}
+
+	if lo+1 == hi { // m == lo
+		// Reached the leaf node.
+		// The proof must not have any unnecessary hashes.
+		if len(p) != 0 {
+			return Hash{}, errProofFailed
+		}
+		return leafHash, nil
+	}
+
+	if len(p) == 0 {
+		return Hash{}, errProofFailed
+	}
+
+	k, _ := maxpow2(hi - lo)
+	if n < lo+k {
+		th, err := runRecordProof(p[:len(p)-1], lo, lo+k, n, leafHash)
+		if err != nil {
+			return Hash{}, err
+		}
+		return NodeHash(th, p[len(p)-1]), nil
+	} else {
+		th, err := runRecordProof(p[:len(p)-1], lo+k, hi, n, leafHash)
+		if err != nil {
+			return Hash{}, err
+		}
+		return NodeHash(p[len(p)-1], th), nil
+	}
+}
+
+// A TreeProof is a verifiable proof that a particular log tree contains
+// as a prefix all records present in an earlier tree.
+// RFC 6962 calls this a “Merkle consistency proof.”
+type TreeProof []Hash
+
+// ProveTree returns the proof that the tree of size t contains
+// as a prefix all the records from the tree of smaller size n.
+func ProveTree(t, n int64, h HashReader) (TreeProof, error) {
+	if t < 1 || n < 1 || n > t {
+		return nil, fmt.Errorf("tlog: invalid inputs in ProveTree")
+	}
+	indexes := treeProofIndex(0, t, n, nil)
+	if len(indexes) == 0 {
+		return TreeProof{}, nil
+	}
+	hashes, err := h.ReadHashes(indexes)
+	if err != nil {
+		return nil, err
+	}
+	if len(hashes) != len(indexes) {
+		return nil, fmt.Errorf("tlog: ReadHashes(%d indexes) = %d hashes", len(indexes), len(hashes))
+	}
+
+	p, hashes := treeProof(0, t, n, hashes)
+	if len(hashes) != 0 {
+		panic("tlog: bad index math in ProveTree")
+	}
+	return p, nil
+}
+
+// treeProofIndex builds the list of indexes needed to construct
+// the sub-proof related to the subtree containing records [lo, hi).
+// See https://tools.ietf.org/html/rfc6962#section-2.1.2.
+func treeProofIndex(lo, hi, n int64, need []int64) []int64 {
+	// See treeProof below for commentary.
+	if !(lo < n && n <= hi) {
+		panic("tlog: bad math in treeProofIndex")
+	}
+
+	if n == hi {
+		if lo == 0 {
+			return need
+		}
+		return subTreeIndex(lo, hi, need)
+	}
+
+	if k, _ := maxpow2(hi - lo); n <= lo+k {
+		need = treeProofIndex(lo, lo+k, n, need)
+		need = subTreeIndex(lo+k, hi, need)
+	} else {
+		need = subTreeIndex(lo, lo+k, need)
+		need = treeProofIndex(lo+k, hi, n, need)
+	}
+	return need
+}
+
+// treeProof constructs the sub-proof related to the subtree containing records [lo, hi).
+// It returns any leftover hashes as well.
+// See https://tools.ietf.org/html/rfc6962#section-2.1.2.
+func treeProof(lo, hi, n int64, hashes []Hash) (TreeProof, []Hash) {
+	// We must have lo < n <= hi or else the code here has a bug.
+	if !(lo < n && n <= hi) {
+		panic("tlog: bad math in treeProof")
+	}
+
+	// Reached common ground.
+	if n == hi {
+		if lo == 0 {
+			// This subtree corresponds exactly to the old tree.
+			// The verifier knows that hash, so we don't need to send it.
+			return TreeProof{}, hashes
+		}
+		th, hashes := subTreeHash(lo, hi, hashes)
+		return TreeProof{th}, hashes
+	}
+
+	// Interior node for the proof.
+	// Decide whether to walk down the left or right side.
+	var p TreeProof
+	var th Hash
+	if k, _ := maxpow2(hi - lo); n <= lo+k {
+		// m is on left side
+		p, hashes = treeProof(lo, lo+k, n, hashes)
+		th, hashes = subTreeHash(lo+k, hi, hashes)
+	} else {
+		// m is on right side
+		th, hashes = subTreeHash(lo, lo+k, hashes)
+		p, hashes = treeProof(lo+k, hi, n, hashes)
+	}
+	return append(p, th), hashes
+}
+
+// CheckTree verifies that p is a valid proof that the tree of size t with hash th
+// contains as a prefix the tree of size n with hash h.
+func CheckTree(p TreeProof, t int64, th Hash, n int64, h Hash) error {
+	if t < 1 || n < 1 || n > t {
+		return fmt.Errorf("tlog: invalid inputs in CheckTree")
+	}
+	h2, th2, err := runTreeProof(p, 0, t, n, h)
+	if err != nil {
+		return err
+	}
+	if th2 == th && h2 == h {
+		return nil
+	}
+	return errProofFailed
+}
+
+// runTreeProof runs the sub-proof p related to the subtree containing records [lo, hi),
+// where old is the hash of the old tree with n records.
+// Running the proof means constructing and returning the implied hashes of that
+// subtree in both the old and new tree.
+func runTreeProof(p TreeProof, lo, hi, n int64, old Hash) (Hash, Hash, error) {
+	// We must have lo < n <= hi or else the code here has a bug.
+	if !(lo < n && n <= hi) {
+		panic("tlog: bad math in runTreeProof")
+	}
+
+	// Reached common ground.
+	if n == hi {
+		if lo == 0 {
+			if len(p) != 0 {
+				return Hash{}, Hash{}, errProofFailed
+			}
+			return old, old, nil
+		}
+		if len(p) != 1 {
+			return Hash{}, Hash{}, errProofFailed
+		}
+		return p[0], p[0], nil
+	}
+
+	if len(p) == 0 {
+		return Hash{}, Hash{}, errProofFailed
+	}
+
+	// Interior node for the proof.
+	k, _ := maxpow2(hi - lo)
+	if n <= lo+k {
+		oh, th, err := runTreeProof(p[:len(p)-1], lo, lo+k, n, old)
+		if err != nil {
+			return Hash{}, Hash{}, err
+		}
+		return oh, NodeHash(th, p[len(p)-1]), nil
+	} else {
+		oh, th, err := runTreeProof(p[:len(p)-1], lo+k, hi, n, old)
+		if err != nil {
+			return Hash{}, Hash{}, err
+		}
+		return NodeHash(p[len(p)-1], oh), NodeHash(p[len(p)-1], th), nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -396,6 +396,8 @@ golang.org/x/crypto/ocsp
 # golang.org/x/mod v0.35.0
 ## explicit; go 1.25.0
 golang.org/x/mod/semver
+golang.org/x/mod/sumdb/note
+golang.org/x/mod/sumdb/tlog
 # golang.org/x/net v0.55.0
 ## explicit; go 1.25.0
 golang.org/x/net/bpf


### PR DESCRIPTION
Add tlog, a library that three forthcoming components will share: the MTCA, which writes the tree; the MTPublisher, which reads it and pushes it to mirrors; and the tlog-mirror-test-srv, which receives it and provides cosignatures. It implements the common parts of the C2SP tlog-tiles, tlog-checkpoint, and tlog-cosignature specifications, plus the Merkle Tree Certificate subtree extension.

Most of the primitives come from golang.org/x/mod/sumdb/tlog and golang.org/x/mod/sumdb/note, which already cover RFC 6962 hashing, proofs, tile reading, and signed notes. This package adds the rest:

- Parse, format, and verify checkpoints
- Sign and verify (Ed25519) tlog-cosignatures
- Generate and verify MTC subtree consistency proofs
- Frame entry bundles
- Convert tile coordinates to and from tlog-tiles paths

Proof generation reads hashes through a caller-supplied tlog.HashReader, verification takes only public keys, and signing goes through a caller-supplied note.Signer.