### PR TITLE
wfe: block accounts from YAML config file

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -21,12 +21,14 @@ import (
 	"github.com/letsencrypt/boulder/grpc/noncebalancer"
 	noncebalancerv1 "github.com/letsencrypt/boulder/grpc/noncebalancerv1"
 	"github.com/letsencrypt/boulder/issuance"
+	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/nonce"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/ratelimits"
 	bredis "github.com/letsencrypt/boulder/redis"
 	sapb "github.com/letsencrypt/boulder/sa/proto"
 	emailpb "github.com/letsencrypt/boulder/salesforce/email/proto"
+	"github.com/letsencrypt/boulder/strictyaml"
 	"github.com/letsencrypt/boulder/unpause"
 	"github.com/letsencrypt/boulder/web"
 	"github.com/letsencrypt/boulder/wfe2"
@@ -210,6 +212,11 @@ type Config struct {
 		// repeats. We don't want to issue certs for names that look like they
 		// result from this process.
 		BlockedOnDemandLabels []string `validate:"omitempty"`
+
+		// BlockedAccountsFile is the path to a YAML file listing regIDs which are
+		// blocked from requesting issuance of new certificates. If empty, no
+		// accounts are blocked.
+		BlockedAccountsFile string `validate:"omitempty"`
 	}
 
 	Syslog        cmd.SyslogConfig
@@ -222,6 +229,36 @@ type Config struct {
 type CacheConfig struct {
 	Size int
 	TTL  config.Duration
+}
+
+type blockedAccountsPolicy struct {
+	BlockedAccountIDs []int64 `yaml:"BlockedAccountIDs"`
+}
+
+// loadBlockedAccountsFile parses the YAML file at the given path and returns
+// the set of blocked account IDs it contains.
+// TODO: Update the schema etc to handle multiple lists each with their own
+// message string, so we don't have to hardcode the message in the WFE.
+func loadBlockedAccountsFile(f string, logger blog.Logger) (map[int64]bool, error) {
+	configBytes, err := os.ReadFile(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var policy blockedAccountsPolicy
+	err = strictyaml.Unmarshal(configBytes, &policy)
+	if err != nil {
+		return nil, err
+	}
+
+	blocked := make(map[int64]bool, 0)
+	for _, id := range policy.BlockedAccountIDs {
+		if id <= 0 {
+			return nil, fmt.Errorf("malformed BlockedAccountIDs entry, not a positive integer: %d", id)
+		}
+		blocked[id] = true
+	}
+	return blocked, nil
 }
 
 // loadChain takes a list of filenames containing pem-formatted certificates,
@@ -380,6 +417,12 @@ func main() {
 		overridesRefresherShutdown = txnBuilder.NewRefresher(30 * time.Minute)
 	}
 
+	var blockedAccounts map[int64]bool
+	if c.WFE.BlockedAccountsFile != "" {
+		blockedAccounts, err = loadBlockedAccountsFile(c.WFE.BlockedAccountsFile, logger)
+		cmd.FailOnError(err, "Couldn't load blocked accounts file")
+	}
+
 	var accountGetter wfe2.AccountGetter
 	if c.WFE.AccountCache != nil {
 		accountGetter = wfe2.NewAccountCache(sac,
@@ -414,6 +457,7 @@ func main() {
 		c.WFE.Unpause.JWTLifetime.Duration,
 		c.WFE.Unpause.URL,
 		c.WFE.BlockedOnDemandLabels,
+		blockedAccounts,
 		c.WFE.DirectoryCAAIdentity,
 	)
 	cmd.FailOnError(err, "Unable to create WFE")

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/config"
+	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/goodkey"
 	"github.com/letsencrypt/boulder/goodkey/sagoodkey"
@@ -21,7 +22,6 @@ import (
 	"github.com/letsencrypt/boulder/grpc/noncebalancer"
 	noncebalancerv1 "github.com/letsencrypt/boulder/grpc/noncebalancerv1"
 	"github.com/letsencrypt/boulder/issuance"
-	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/nonce"
 	rapb "github.com/letsencrypt/boulder/ra/proto"
 	"github.com/letsencrypt/boulder/ratelimits"
@@ -233,13 +233,29 @@ type CacheConfig struct {
 
 type blockedAccountsPolicy struct {
 	BlockedAccountIDs []int64 `yaml:"BlockedAccountIDs"`
+	Message           string  `yaml:"Message"`
+}
+
+// accountBlocker implements wfe2.AccountBlocker.
+type accountBlocker struct {
+	message string
+	blocked map[int64]bool
+}
+
+var _ wfe2.AccountBlocker = new(accountBlocker)
+
+func (b *accountBlocker) CheckAccountID(id int64) error {
+	if b.blocked[id] {
+		return berrors.UnauthorizedError("%s", b.message)
+	}
+	return nil
 }
 
 // loadBlockedAccountsFile parses the YAML file at the given path and returns
 // the set of blocked account IDs it contains.
-// TODO: Update the schema etc to handle multiple lists each with their own
-// message string, so we don't have to hardcode the message in the WFE.
-func loadBlockedAccountsFile(f string, logger blog.Logger) (map[int64]bool, error) {
+// TODO: Update the schema to handle multiple lists each with their own
+// message string.
+func loadBlockedAccountsFile(f string) (*accountBlocker, error) {
 	configBytes, err := os.ReadFile(f)
 	if err != nil {
 		return nil, err
@@ -258,7 +274,11 @@ func loadBlockedAccountsFile(f string, logger blog.Logger) (map[int64]bool, erro
 		}
 		blocked[id] = true
 	}
-	return blocked, nil
+
+	return &accountBlocker{
+		message: policy.Message,
+		blocked: blocked,
+	}, nil
 }
 
 // loadChain takes a list of filenames containing pem-formatted certificates,
@@ -417,9 +437,9 @@ func main() {
 		overridesRefresherShutdown = txnBuilder.NewRefresher(30 * time.Minute)
 	}
 
-	var blockedAccounts map[int64]bool
+	var accountBlocker wfe2.AccountBlocker
 	if c.WFE.BlockedAccountsFile != "" {
-		blockedAccounts, err = loadBlockedAccountsFile(c.WFE.BlockedAccountsFile, logger)
+		accountBlocker, err = loadBlockedAccountsFile(c.WFE.BlockedAccountsFile)
 		cmd.FailOnError(err, "Couldn't load blocked accounts file")
 	}
 
@@ -457,7 +477,7 @@ func main() {
 		c.WFE.Unpause.JWTLifetime.Duration,
 		c.WFE.Unpause.URL,
 		c.WFE.BlockedOnDemandLabels,
-		blockedAccounts,
+		accountBlocker,
 		c.WFE.DirectoryCAAIdentity,
 	)
 	cmd.FailOnError(err, "Unable to create WFE")

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -437,9 +437,9 @@ func main() {
 		overridesRefresherShutdown = txnBuilder.NewRefresher(30 * time.Minute)
 	}
 
-	var accountBlocker wfe2.AccountBlocker
+	var acctBlocker wfe2.AccountBlocker
 	if c.WFE.BlockedAccountsFile != "" {
-		accountBlocker, err = loadBlockedAccountsFile(c.WFE.BlockedAccountsFile)
+		acctBlocker, err = loadBlockedAccountsFile(c.WFE.BlockedAccountsFile)
 		cmd.FailOnError(err, "Couldn't load blocked accounts file")
 	}
 
@@ -477,7 +477,7 @@ func main() {
 		c.WFE.Unpause.JWTLifetime.Duration,
 		c.WFE.Unpause.URL,
 		c.WFE.BlockedOnDemandLabels,
-		accountBlocker,
+		acctBlocker,
 		c.WFE.DirectoryCAAIdentity,
 	)
 	cmd.FailOnError(err, "Unable to create WFE")

--- a/test/config-next/blocked-accounts.yaml
+++ b/test/config-next/blocked-accounts.yaml
@@ -1,0 +1,3 @@
+Message: "your account has been blocked due to excessive traffic"
+BlockedAccountIDs:
+  - 1234

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -150,6 +150,7 @@
 			"jwtLifetime": "336h",
 			"url": "https://boulder.service.consul:4003"
 		},
+		"blockedAccountsFile": "test/config-next/blocked-accounts.yaml",
 		"blockedOnDemandLabels": [
 			"asdf"
 		]

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -179,6 +179,11 @@ type WebFrontEndImpl struct {
 	// given request counts as a renewal or not.
 	blockedOnDemandLabels []string `validate:"omitempty"`
 
+	// blockedAccounts is the set of account (registration) IDs which have been
+	// administratively blocked from requesting issuance of new certificates,
+	// loaded once at process startup from a YAML file.
+	blockedAccounts map[int64]bool
+
 	// certProfiles is a map of acceptable certificate profile names to
 	// descriptions (perhaps including URLs) of those profiles. NewOrder
 	// Requests with a profile name not present in this map will be rejected.
@@ -210,6 +215,7 @@ func NewWebFrontEndImpl(
 	unpauseJWTLifetime time.Duration,
 	unpauseURL string,
 	blockedOnDemandLabels []string,
+	blockedAccounts map[int64]bool,
 	caaIdentity string,
 ) (WebFrontEndImpl, error) {
 	if len(issuerCertificates) == 0 {
@@ -262,6 +268,7 @@ func NewWebFrontEndImpl(
 		unpauseJWTLifetime:    unpauseJWTLifetime,
 		unpauseURL:            unpauseURL,
 		blockedOnDemandLabels: blockedLabels,
+		blockedAccounts:       blockedAccounts,
 		DirectoryCAAIdentity:  normalizedCAAIdentity,
 	}
 
@@ -2325,6 +2332,12 @@ func (wfe *WebFrontEndImpl) checkIdentifiersPaused(ctx context.Context, orderIde
 	return pausedValues, nil
 }
 
+// checkAccountPaused returns true if the given account ID is in the WFE's
+// administratively-configured set of blocked accounts.
+func (wfe *WebFrontEndImpl) checkAccountPaused(regID int64) bool {
+	return wfe.blockedAccounts[regID]
+}
+
 // NewOrder is used by clients to create a new order object and a set of
 // authorizations to fulfill for issuance.
 func (wfe *WebFrontEndImpl) NewOrder(
@@ -2391,6 +2404,11 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	}
 
 	if features.Get().CheckIdentifiersPaused {
+		if wfe.checkAccountPaused(acct.ID) {
+			wfe.sendError(response, logEvent, probs.Unauthorized("Your account is prevented from requesting certificates due to abusive request patterns."), nil)
+			return
+		}
+
 		pausedValues, err := wfe.checkIdentifiersPaused(ctx, idents, acct.ID)
 		if err != nil {
 			wfe.sendError(response, logEvent, probs.ServerInternal("Failure while checking pause status of identifiers"), err)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -179,15 +179,19 @@ type WebFrontEndImpl struct {
 	// given request counts as a renewal or not.
 	blockedOnDemandLabels []string `validate:"omitempty"`
 
-	// blockedAccounts is the set of account (registration) IDs which have been
-	// administratively blocked from requesting issuance of new certificates,
-	// loaded once at process startup from a YAML file.
-	blockedAccounts map[int64]bool
+	// accountBlocker checks whether accounts are blocked and returns errors if so.
+	accountBlocker AccountBlocker
 
 	// certProfiles is a map of acceptable certificate profile names to
 	// descriptions (perhaps including URLs) of those profiles. NewOrder
 	// Requests with a profile name not present in this map will be rejected.
 	certProfiles map[string]string
+}
+
+// AccountBlocker defines an interface that can check whether a given ID is
+// blocked, and return an error if so.
+type AccountBlocker interface {
+	CheckAccountID(id int64) error
 }
 
 // NewWebFrontEndImpl constructs a web service for Boulder
@@ -215,7 +219,7 @@ func NewWebFrontEndImpl(
 	unpauseJWTLifetime time.Duration,
 	unpauseURL string,
 	blockedOnDemandLabels []string,
-	blockedAccounts map[int64]bool,
+	accountBlocker AccountBlocker,
 	caaIdentity string,
 ) (WebFrontEndImpl, error) {
 	if len(issuerCertificates) == 0 {
@@ -268,7 +272,7 @@ func NewWebFrontEndImpl(
 		unpauseJWTLifetime:    unpauseJWTLifetime,
 		unpauseURL:            unpauseURL,
 		blockedOnDemandLabels: blockedLabels,
-		blockedAccounts:       blockedAccounts,
+		accountBlocker:        accountBlocker,
 		DirectoryCAAIdentity:  normalizedCAAIdentity,
 	}
 
@@ -2332,12 +2336,6 @@ func (wfe *WebFrontEndImpl) checkIdentifiersPaused(ctx context.Context, orderIde
 	return pausedValues, nil
 }
 
-// checkAccountPaused returns true if the given account ID is in the WFE's
-// administratively-configured set of blocked accounts.
-func (wfe *WebFrontEndImpl) checkAccountPaused(regID int64) bool {
-	return wfe.blockedAccounts[regID]
-}
-
 // NewOrder is used by clients to create a new order object and a set of
 // authorizations to fulfill for issuance.
 func (wfe *WebFrontEndImpl) NewOrder(
@@ -2403,12 +2401,15 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		return
 	}
 
-	if features.Get().CheckIdentifiersPaused {
-		if wfe.checkAccountPaused(acct.ID) {
-			wfe.sendError(response, logEvent, probs.Unauthorized("Your account is prevented from requesting certificates due to abusive request patterns."), nil)
+	if wfe.accountBlocker != nil {
+		err = wfe.accountBlocker.CheckAccountID(acct.ID)
+		if err != nil {
+			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Account blocked"), err)
 			return
 		}
+	}
 
+	if features.Get().CheckIdentifiersPaused {
 		pausedValues, err := wfe.checkIdentifiersPaused(ctx, idents, acct.ID)
 		if err != nil {
 			wfe.sendError(response, logEvent, probs.ServerInternal("Failure while checking pause status of identifiers"), err)

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -443,6 +443,7 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 		unpauseLifetime,
 		unpauseURL,
 		[]string{"asdf"},
+		nil,
 		"letsencrypt.org",
 	)
 	test.AssertNotError(t, err, "Unable to create WFE")

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -4519,3 +4519,41 @@ func TestLooksLikeRecursiveOnDemandRequest(t *testing.T) {
 		})
 	}
 }
+
+type acctBlock struct{}
+
+func (ab *acctBlock) CheckAccountID(id int64) error {
+	return berrors.UnauthorizedError("oh no")
+}
+
+func TestAccountBlocker(t *testing.T) {
+	t.Parallel()
+	wfe, _, signer := setupWFE(t)
+	mux := wfe.Handler(metrics.NoopRegisterer)
+
+	wfe.accountBlocker = new(acctBlock)
+
+	// Test that the newOrder endpoint returns no error if the valid profile is specified.
+	responseWriter := httptest.NewRecorder()
+	r := signAndPost(signer, newOrderPath, "http://localhost"+newOrderPath, `
+	{
+		"Identifiers": [
+		  {"type": "dns", "value": "example.com"}
+		]
+	}`)
+	mux.ServeHTTP(responseWriter, r)
+	if responseWriter.Code != http.StatusForbidden {
+		t.Fatalf("newOrder with blocked account: got %d, want %d; %s", responseWriter.Code, http.StatusForbidden,
+			responseWriter.Body.String())
+	}
+	var errorResp1 map[string]any
+	err := json.Unmarshal(responseWriter.Body.Bytes(), &errorResp1)
+	if err != nil {
+		t.Fatalf("newOrder with blocked account: got error unmarshaling response: %s", err)
+	}
+	detail := errorResp1["detail"]
+	expected := "Account blocked :: oh no"
+	if detail != expected {
+		t.Errorf("newOrder with blocked account: got %q, want %q", detail, expected)
+	}
+}


### PR DESCRIPTION
This allows us to configure a list of accounts to be blocked from newOrder requests, along with a custom message. The message users will see is "Account blocked :: <custom message>".

First commit is by @aarongable. I built on that with a light refactoring, addition of a custom error message, and a unittest.

This includes a sample config file that is loaded in test/config-next. However, since we don't have a way to know in advance which account IDs will be created during integration tests, we don't actually exercise the blocking code during integration testing, only in unittests.