### PR TITLE
wfe: fix test comment

### DIFF
--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -4533,7 +4533,6 @@ func TestAccountBlocker(t *testing.T) {
 
 	wfe.accountBlocker = new(acctBlock)
 
-	// Test that the newOrder endpoint returns no error if the valid profile is specified.
 	responseWriter := httptest.NewRecorder()
 	r := signAndPost(signer, newOrderPath, "http://localhost"+newOrderPath, `
 	{


### PR DESCRIPTION
@beautifulentropy correctly pointed out at https://github.com/letsencrypt/boulder/pull/8797/changes#r3414678404 that I had a leftover copy-pasted comment from another test case. I missed this when responding to feedback. Sorry all! I could swear the GitHub UI didn't show me when I first looked (but I did get an email notification).