### PR TITLE
mtpki: use ML-DSA

### DIFF
--- a/cmd/boulder-ca/main.go
+++ b/cmd/boulder-ca/main.go
@@ -194,7 +194,7 @@ func main() {
 		}
 
 		issuer, err := issuance.LoadIssuer(issuerConfig, clk)
-		cmd.FailOnError(err, "Loading issuer")
+		cmd.FailOnError(err, fmt.Sprintf("Loading issuer %q", issuerConfig.Location.CertFile))
 		issuers = append(issuers, issuer)
 	}
 

--- a/issuance/issuer.go
+++ b/issuance/issuer.go
@@ -2,9 +2,6 @@ package issuance
 
 import (
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -209,24 +206,9 @@ type Issuer struct {
 // newIssuer constructs a new Issuer from the in-memory certificate and signer.
 // It exists as a helper for LoadIssuer to make testing simpler.
 func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk clock.Clock) (*Issuer, error) {
-	var keyAlg x509.PublicKeyAlgorithm
-	var sigAlg x509.SignatureAlgorithm
-	switch k := cert.PublicKey.(type) {
-	case *rsa.PublicKey:
-		keyAlg = x509.RSA
-		sigAlg = x509.SHA256WithRSA
-	case *ecdsa.PublicKey:
-		keyAlg = x509.ECDSA
-		switch k.Curve {
-		case elliptic.P256():
-			sigAlg = x509.ECDSAWithSHA256
-		case elliptic.P384():
-			sigAlg = x509.ECDSAWithSHA384
-		default:
-			return nil, fmt.Errorf("unsupported ECDSA curve: %q", k.Curve.Params().Name)
-		}
-	default:
-		return nil, errors.New("unsupported issuer key type")
+	keyAlg, sigAlg, err := pubkeyParams(cert.PublicKey)
+	if err != nil {
+		return nil, err
 	}
 
 	if config.IssuerURL == "" {
@@ -274,8 +256,8 @@ func newIssuer(config IssuerConfig, cert *Certificate, signer crypto.Signer, clk
 	return i, nil
 }
 
-// KeyType returns either x509.RSA or x509.ECDSA, depending on whether the
-// issuer has an RSA or ECDSA keypair. This is useful for determining which
+// KeyType returns x509.RSA, x509.ECDSA, or x509.MLDSA depending on the
+// keypair of the issuer. This is useful for determining which
 // issuance requests should be routed to this issuer.
 func (i *Issuer) KeyType() x509.PublicKeyAlgorithm {
 	return i.keyAlg

--- a/issuance/pubkeyparams.go
+++ b/issuance/pubkeyparams.go
@@ -1,0 +1,32 @@
+//go:build !go1.27
+
+package issuance
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+)
+
+func pubkeyParams(pubkey any) (x509.PublicKeyAlgorithm, x509.SignatureAlgorithm, error) {
+	switch k := pubkey.(type) {
+	case *rsa.PublicKey:
+		return x509.RSA, x509.SHA256WithRSA, nil
+	case *ecdsa.PublicKey:
+		switch k.Curve {
+		case elliptic.P256():
+			return x509.ECDSA, x509.ECDSAWithSHA256, nil
+		case elliptic.P384():
+			return x509.ECDSA, x509.ECDSAWithSHA384, nil
+		default:
+			return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm,
+				fmt.Errorf("unsupported ECDSA curve: %q", k.Curve.Params().Name)
+		}
+	default:
+		return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm,
+			errors.New("unsupported issuer key type")
+	}
+}

--- a/issuance/pubkeyparams_go127.go
+++ b/issuance/pubkeyparams_go127.go
@@ -1,0 +1,35 @@
+//go:build go1.27
+
+package issuance
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/mldsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+)
+
+func pubkeyParams(pubkey any) (x509.PublicKeyAlgorithm, x509.SignatureAlgorithm, error) {
+	switch k := pubkey.(type) {
+	case *mldsa.PublicKey:
+		return x509.MLDSA, x509.MLDSA44, nil
+	case *rsa.PublicKey:
+		return x509.RSA, x509.SHA256WithRSA, nil
+	case *ecdsa.PublicKey:
+		switch k.Curve {
+		case elliptic.P256():
+			return x509.ECDSA, x509.ECDSAWithSHA256, nil
+		case elliptic.P384():
+			return x509.ECDSA, x509.ECDSAWithSHA384, nil
+		default:
+			return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm,
+				fmt.Errorf("unsupported ECDSA curve: %q", k.Curve.Params().Name)
+		}
+	default:
+		return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm,
+			errors.New("unsupported issuer key type")
+	}
+}

--- a/issuance/pubkeyparams_go127.go
+++ b/issuance/pubkeyparams_go127.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 )
 
+// pubkeyParams returns a PublicKeyAlgorithm and SignatureAlgorithm for the input pubkey.
+// TODO(#8812): Move this back to issuer.go.
 func pubkeyParams(pubkey any) (x509.PublicKeyAlgorithm, x509.SignatureAlgorithm, error) {
 	switch k := pubkey.(type) {
 	case *mldsa.PublicKey:

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -3,9 +3,7 @@ package linter
 import (
 	"bytes"
 	"crypto"
-	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"strings"
@@ -134,26 +132,6 @@ func (l *Linter) CheckCRL(tbs *x509.RevocationList, reg lint.Registry) error {
 	}
 	lintRes := zlint.LintRevocationListEx(crl, reg)
 	return ProcessResultSet(lintRes)
-}
-
-func makeSigner(realSigner crypto.Signer) (crypto.Signer, error) {
-	var lintSigner crypto.Signer
-	var err error
-	switch k := realSigner.Public().(type) {
-	case *rsa.PublicKey:
-		lintSigner, err = rsa.GenerateKey(rand.Reader, k.Size()*8)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create RSA lint signer: %w", err)
-		}
-	case *ecdsa.PublicKey:
-		lintSigner, err = ecdsa.GenerateKey(k.Curve, rand.Reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create ECDSA lint signer: %w", err)
-		}
-	default:
-		return nil, fmt.Errorf("unsupported lint signer type: %T", k)
-	}
-	return lintSigner, nil
 }
 
 func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.Certificate, error) {

--- a/linter/makesigner.go
+++ b/linter/makesigner.go
@@ -1,0 +1,31 @@
+//go:build !go1.27
+
+package linter
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+)
+
+func makeSigner(realSigner crypto.Signer) (crypto.Signer, error) {
+	var lintSigner crypto.Signer
+	var err error
+	switch k := realSigner.Public().(type) {
+	case *rsa.PublicKey:
+		lintSigner, err = rsa.GenerateKey(rand.Reader, k.Size()*8)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create RSA lint signer: %w", err)
+		}
+	case *ecdsa.PublicKey:
+		lintSigner, err = ecdsa.GenerateKey(k.Curve, rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create ECDSA lint signer: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported lint signer type: %T", k)
+	}
+	return lintSigner, nil
+}

--- a/linter/makesigner_go127.go
+++ b/linter/makesigner_go127.go
@@ -28,7 +28,7 @@ func makeSigner(realSigner crypto.Signer) (crypto.Signer, error) {
 	case *mldsa.PublicKey:
 		lintSigner, err = mldsa.GenerateKey(k.Parameters())
 		if err != nil {
-			return nil, fmt.Errorf("failed to create MLDSA lint signer: %w", err)
+			return nil, fmt.Errorf("failed to create ML-DSA lint signer: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported lint signer type: %T", k)

--- a/linter/makesigner_go127.go
+++ b/linter/makesigner_go127.go
@@ -1,0 +1,37 @@
+//go:build go1.27
+
+package linter
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/mldsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+)
+
+func makeSigner(realSigner crypto.Signer) (crypto.Signer, error) {
+	var lintSigner crypto.Signer
+	var err error
+	switch k := realSigner.Public().(type) {
+	case *rsa.PublicKey:
+		lintSigner, err = rsa.GenerateKey(rand.Reader, k.Size()*8)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create RSA lint signer: %w", err)
+		}
+	case *ecdsa.PublicKey:
+		lintSigner, err = ecdsa.GenerateKey(k.Curve, rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create ECDSA lint signer: %w", err)
+		}
+	case *mldsa.PublicKey:
+		lintSigner, err = mldsa.GenerateKey(k.Parameters())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create MLDSA lint signer: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported lint signer type: %T", k)
+	}
+	return lintSigner, nil
+}

--- a/linter/makesigner_go127.go
+++ b/linter/makesigner_go127.go
@@ -11,6 +11,9 @@ import (
 	"fmt"
 )
 
+// makeSigner makes a signer with a throwaway key that matches `realSigner`'s type.
+//
+// TODO(#8812): Move this back to linter.go, above makeIssuer.
 func makeSigner(realSigner crypto.Signer) (crypto.Signer, error) {
 	var lintSigner crypto.Signer
 	var err error

--- a/privatekey/privatekey.go
+++ b/privatekey/privatekey.go
@@ -57,29 +57,6 @@ func verifyECDSA(privKey *ecdsa.PrivateKey, pubKey *ecdsa.PublicKey, msgHash has
 	return privKey, privKey.Public(), nil
 }
 
-// verify ensures that the embedded PublicKey of the provided privateKey is
-// actually a match for the private key. For an example of private keys
-// embedding a mismatched public key, see:
-// https://blog.hboeck.de/archives/888-How-I-tricked-Symantec-with-a-Fake-Private-Key.html.
-func verify(privateKey crypto.Signer) (crypto.Signer, crypto.PublicKey, error) {
-	verifyHash, err := makeVerifyHash()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	switch k := privateKey.(type) {
-	case *rsa.PrivateKey:
-		return verifyRSA(k, &k.PublicKey, verifyHash)
-
-	case *ecdsa.PrivateKey:
-		return verifyECDSA(k, &k.PublicKey, verifyHash)
-
-	default:
-		// This should never happen.
-		return nil, nil, errors.New("the provided private key could not be asserted to ECDSA or RSA")
-	}
-}
-
 // Load decodes and parses a private key from the provided file path and returns
 // the private key as crypto.Signer. keyPath is expected to be a PEM formatted
 // RSA or ECDSA private key in a PKCS #1, PKCS# 8, or SEC 1 container. The

--- a/privatekey/verify.go
+++ b/privatekey/verify.go
@@ -1,0 +1,33 @@
+//go:build !go1.27
+
+package privatekey
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"errors"
+)
+
+// verify ensures that the embedded PublicKey of the provided privateKey is
+// actually a match for the private key. For an example of private keys
+// embedding a mismatched public key, see:
+// https://blog.hboeck.de/archives/888-How-I-tricked-Symantec-with-a-Fake-Private-Key.html.
+func verify(privateKey crypto.Signer) (crypto.Signer, crypto.PublicKey, error) {
+	verifyHash, err := makeVerifyHash()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch k := privateKey.(type) {
+	case *rsa.PrivateKey:
+		return verifyRSA(k, &k.PublicKey, verifyHash)
+
+	case *ecdsa.PrivateKey:
+		return verifyECDSA(k, &k.PublicKey, verifyHash)
+
+	default:
+		// This should never happen.
+		return nil, nil, errors.New("the provided private key could not be asserted to ECDSA or RSA")
+	}
+}

--- a/privatekey/verify_go127.go
+++ b/privatekey/verify_go127.go
@@ -16,6 +16,8 @@ import (
 // actually a match for the private key. For an example of private keys
 // embedding a mismatched public key, see:
 // https://blog.hboeck.de/archives/888-How-I-tricked-Symantec-with-a-Fake-Private-Key.html.
+//
+// TODO(#8812): move this back to privatekey.go, above Load().
 func verify(privateKey crypto.Signer) (crypto.Signer, crypto.PublicKey, error) {
 	verifyHash, err := makeVerifyHash()
 	if err != nil {
@@ -34,7 +36,7 @@ func verify(privateKey crypto.Signer) (crypto.Signer, crypto.PublicKey, error) {
 
 	default:
 		// This should never happen.
-		return nil, nil, errors.New("the provided private key could not be asserted to ECDSA or RSA")
+		return nil, nil, errors.New("the provided private key was not *rsa.PrivateKey, *ecdsa.PrivateKey, or *mldsa.PrivateKey")
 	}
 }
 

--- a/privatekey/verify_go127.go
+++ b/privatekey/verify_go127.go
@@ -1,0 +1,53 @@
+//go:build go1.27
+
+package privatekey
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/mldsa"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"hash"
+)
+
+// verify ensures that the embedded PublicKey of the provided privateKey is
+// actually a match for the private key. For an example of private keys
+// embedding a mismatched public key, see:
+// https://blog.hboeck.de/archives/888-How-I-tricked-Symantec-with-a-Fake-Private-Key.html.
+func verify(privateKey crypto.Signer) (crypto.Signer, crypto.PublicKey, error) {
+	verifyHash, err := makeVerifyHash()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch k := privateKey.(type) {
+	case *rsa.PrivateKey:
+		return verifyRSA(k, &k.PublicKey, verifyHash)
+
+	case *ecdsa.PrivateKey:
+		return verifyECDSA(k, &k.PublicKey, verifyHash)
+
+	case *mldsa.PrivateKey:
+		return verifyMLDSA(k, k.PublicKey(), verifyHash)
+
+	default:
+		// This should never happen.
+		return nil, nil, errors.New("the provided private key could not be asserted to ECDSA or RSA")
+	}
+}
+
+// verifyMLDSA verifies MLDSA private keys.
+func verifyMLDSA(privKey *mldsa.PrivateKey, pubKey *mldsa.PublicKey, msgHash hash.Hash) (crypto.Signer, crypto.PublicKey, error) {
+	sig, err := privKey.Sign(nil, msgHash.Sum(nil), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to sign using the provided MLDSA private key: %s", err)
+	}
+
+	err = mldsa.Verify(pubKey, msgHash.Sum(nil), sig, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("the provided MLDSA private key failed signature verification: %s", err)
+	}
+	return privKey, privKey.Public(), nil
+}

--- a/privatekey/verify_go127.go
+++ b/privatekey/verify_go127.go
@@ -38,16 +38,16 @@ func verify(privateKey crypto.Signer) (crypto.Signer, crypto.PublicKey, error) {
 	}
 }
 
-// verifyMLDSA verifies MLDSA private keys.
+// verifyMLDSA verifies ML-DSA private keys.
 func verifyMLDSA(privKey *mldsa.PrivateKey, pubKey *mldsa.PublicKey, msgHash hash.Hash) (crypto.Signer, crypto.PublicKey, error) {
 	sig, err := privKey.Sign(nil, msgHash.Sum(nil), nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to sign using the provided MLDSA private key: %s", err)
+		return nil, nil, fmt.Errorf("failed to sign using the provided ML-DSA private key: %s", err)
 	}
 
 	err = mldsa.Verify(pubKey, msgHash.Sum(nil), sig, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("the provided MLDSA private key failed signature verification: %s", err)
+		return nil, nil, fmt.Errorf("the provided ML-DSA private key failed signature verification: %s", err)
 	}
 	return privKey, privKey.Public(), nil
 }

--- a/test/certs/generate.sh
+++ b/test/certs/generate.sh
@@ -79,5 +79,5 @@ fi
 if ! [ -d test/certs/mtpki ]; then
   echo "Generating mtpki/..."
   mkdir -p test/certs/mtpki
-  gotip run ./test/certs/genmtpki/genmtpki.go
+  gotip run ./test/certs/genmtpki/genmtpki.go -output-dir test/certs/mtpki
 fi

--- a/test/certs/genmtpki/genmtpki.go
+++ b/test/certs/genmtpki/genmtpki.go
@@ -9,8 +9,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
+	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"math/big"
 	"os"
@@ -32,7 +32,7 @@ func main2() error {
 	flag.Parse()
 
 	if *outputDir == "" {
-		return fmt.Errorf("-output-dir flag required")
+		return errors.New("-output-dir flag required")
 	}
 
 	basepath := path.Join(*outputDir, basename)

--- a/test/certs/genmtpki/genmtpki.go
+++ b/test/certs/genmtpki/genmtpki.go
@@ -3,16 +3,18 @@
 package main
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
+	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
+	"flag"
+	"fmt"
 	"log"
 	"math/big"
 	"os"
+	"path"
 	"time"
 )
 
@@ -23,10 +25,19 @@ func main() {
 	}
 }
 
-const basename = "test/certs/mtpki/mtca1"
+const basename = "mtca1"
 
 func main2() error {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), nil)
+	outputDir := flag.String("output-dir", "", "Directory to write outputs to")
+	flag.Parse()
+
+	if *outputDir == "" {
+		return fmt.Errorf("-output-dir flag required")
+	}
+
+	basepath := path.Join(*outputDir, basename)
+
+	key, err := mldsa.GenerateKey(mldsa.MLDSA44())
 	if err != nil {
 		return err
 	}
@@ -36,7 +47,7 @@ func main2() error {
 		return err
 	}
 
-	keyFile, err := os.OpenFile(basename+".key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyFile, err := os.OpenFile(basepath+".key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
@@ -79,7 +90,7 @@ func main2() error {
 		return err
 	}
 
-	certFile, err := os.OpenFile(basename+".cert.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	certFile, err := os.OpenFile(basepath+".cert.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
@@ -124,7 +135,8 @@ func mtcaExtension() (pkix.Extension, error) {
 
 	// Copied from https://cs.opensource.google/go/go/+/refs/tags/go1.26.3:src/crypto/x509/x509.go;l=345-350
 	oidSHA256 := asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
-	oidSignatureECDSAWithSHA256 := asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
+	// https://www.rfc-editor.org/info/rfc9881/
+	oidSignatureMLDSA44 := asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 3, 17}
 
 	extnMarshaled, err := asn1.Marshal(struct {
 		LogHash   pkix.AlgorithmIdentifier
@@ -132,7 +144,7 @@ func mtcaExtension() (pkix.Extension, error) {
 		MinSerial int64
 	}{
 		LogHash: pkix.AlgorithmIdentifier{Algorithm: oidSHA256},
-		SigAlg:  pkix.AlgorithmIdentifier{Algorithm: oidSignatureECDSAWithSHA256},
+		SigAlg:  pkix.AlgorithmIdentifier{Algorithm: oidSignatureMLDSA44},
 		// Just for fun, exercise MinSerial functionality.
 		MinSerial: 999,
 	})


### PR DESCRIPTION
genmtpki now outputs a ML-DSA certificate and private key.

Our various loading functions had some type switches that accounted for RSA and ECDSA, but errored on ML-DSA keys. Factored out those functions into versions for go1.27 and for !go1.27.

As a quality of life improvement, add a `-output-dir` flag for genmtpki to allow writing it in different places while iterating.

Fixes #8787