### PR TITLE
wfe: add MaxCumulativeIdentifierLength

### DIFF
--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -149,8 +149,8 @@ type Config struct {
 		// contacts than this are rejected. Default: 10.
 		MaxContactsPerRegistration int `validate:"omitempty,min=1"`
 
-		// MaxCumulativeIdentifierLength rejects new-order requests if the cumulative length of all identifiers
-		// is greater than its value.
+		// MaxCumulativeIdentifierLength is the maximum allowed total bytes of
+		// all identifier values in a new-order request. Default (0) means no limit.
 		MaxCumulativeIdentifierLength int `validate:"omitempty,min=1"`
 
 		AccountCache *CacheConfig

--- a/cmd/boulder-wfe2/main.go
+++ b/cmd/boulder-wfe2/main.go
@@ -149,6 +149,10 @@ type Config struct {
 		// contacts than this are rejected. Default: 10.
 		MaxContactsPerRegistration int `validate:"omitempty,min=1"`
 
+		// MaxCumulativeIdentifierLength rejects new-order requests if the cumulative length of all identifiers
+		// is greater than its value.
+		MaxCumulativeIdentifierLength int `validate:"omitempty,min=1"`
+
 		AccountCache *CacheConfig
 
 		Limiter struct {
@@ -463,6 +467,7 @@ func main() {
 		c.WFE.Timeout.Duration,
 		c.WFE.StaleTimeout.Duration,
 		c.WFE.MaxContactsPerRegistration,
+		c.WFE.MaxCumulativeIdentifierLength,
 		rac,
 		sac,
 		eec,

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -14,6 +14,7 @@
 		"accountURIPrefix": "http://boulder.service.consul:4001/acme/acct/",
 		"goodkey": {},
 		"maxContactsPerRegistration": 3,
+		"maxCumulativeIdentifierLength": 10000,
 		"tls": {
 			"caCertFile": "test/certs/ipki/minica.pem",
 			"certFile": "test/certs/ipki/wfe.boulder/cert.pem",

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -2401,8 +2401,8 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		totalIdentifierLen += len(ident.Value)
 		if wfe.maxCumulativeIdentifierLength != 0 && totalIdentifierLen > wfe.maxCumulativeIdentifierLength {
 			wfe.sendError(response, logEvent,
-				probs.Malformed("Cumulative length of all identifiers was greater than %d", wfe.maxCumulativeIdentifierLength),
-				nil)
+				probs.Malformed("Cumulative length of all identifier values was greater than %d bytes",
+					wfe.maxCumulativeIdentifierLength), nil)
 			return
 		}
 	}

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -154,6 +154,10 @@ type WebFrontEndImpl struct {
 	// How many contacts to allow in a single NewAccount request.
 	maxContactsPerReg int
 
+	// maxCumulativeIdentifierLength rejects new-order requests if the cumulative length of all identifiers
+	// is greater than its value.
+	maxCumulativeIdentifierLength int
+
 	// requestTimeout is the per-request overall timeout.
 	requestTimeout time.Duration
 
@@ -205,6 +209,7 @@ func NewWebFrontEndImpl(
 	requestTimeout time.Duration,
 	staleTimeout time.Duration,
 	maxContactsPerReg int,
+	maxCumulativeIdentifierLength int,
 	rac rapb.RegistrationAuthorityClient,
 	sac sapb.StorageAuthorityReadOnlyClient,
 	eec emailpb.ExporterClient,
@@ -249,31 +254,32 @@ func NewWebFrontEndImpl(
 	}
 
 	wfe := WebFrontEndImpl{
-		log:                   logger,
-		clk:                   clk,
-		keyPolicy:             keyPolicy,
-		certificateChains:     certificateChains,
-		issuerCertificates:    issuerCertificates,
-		stats:                 initStats(stats),
-		requestTimeout:        requestTimeout,
-		staleTimeout:          staleTimeout,
-		maxContactsPerReg:     maxContactsPerReg,
-		ra:                    rac,
-		sa:                    sac,
-		ee:                    eec,
-		gnc:                   gnc,
-		rnc:                   rnc,
-		rncKey:                rncKey,
-		accountGetter:         accountGetter,
-		limiter:               limiter,
-		txnBuilder:            txnBuilder,
-		certProfiles:          certProfiles,
-		unpauseSigner:         unpauseSigner,
-		unpauseJWTLifetime:    unpauseJWTLifetime,
-		unpauseURL:            unpauseURL,
-		blockedOnDemandLabels: blockedLabels,
-		accountBlocker:        accountBlocker,
-		DirectoryCAAIdentity:  normalizedCAAIdentity,
+		log:                           logger,
+		clk:                           clk,
+		keyPolicy:                     keyPolicy,
+		certificateChains:             certificateChains,
+		issuerCertificates:            issuerCertificates,
+		stats:                         initStats(stats),
+		requestTimeout:                requestTimeout,
+		staleTimeout:                  staleTimeout,
+		maxContactsPerReg:             maxContactsPerReg,
+		maxCumulativeIdentifierLength: maxCumulativeIdentifierLength,
+		ra:                            rac,
+		sa:                            sac,
+		ee:                            eec,
+		gnc:                           gnc,
+		rnc:                           rnc,
+		rncKey:                        rncKey,
+		accountGetter:                 accountGetter,
+		limiter:                       limiter,
+		txnBuilder:                    txnBuilder,
+		certProfiles:                  certProfiles,
+		unpauseSigner:                 unpauseSigner,
+		unpauseJWTLifetime:            unpauseJWTLifetime,
+		unpauseURL:                    unpauseURL,
+		blockedOnDemandLabels:         blockedLabels,
+		accountBlocker:                accountBlocker,
+		DirectoryCAAIdentity:          normalizedCAAIdentity,
 	}
 
 	return wfe, nil
@@ -2379,6 +2385,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	}
 
 	idents := newOrderRequest.Identifiers
+	var totalIdentifierLen int
 	for _, ident := range idents {
 		if !ident.Type.IsValid() {
 			wfe.sendError(response, logEvent,
@@ -2391,7 +2398,15 @@ func (wfe *WebFrontEndImpl) NewOrder(
 			wfe.sendError(response, logEvent, probs.Malformed("NewOrder request included empty identifier"), nil)
 			return
 		}
+		totalIdentifierLen += len(ident.Value)
+		if wfe.maxCumulativeIdentifierLength != 0 && totalIdentifierLen > wfe.maxCumulativeIdentifierLength {
+			wfe.sendError(response, logEvent,
+				probs.Malformed("Cumulative length of all identifiers was greater than %d", wfe.maxCumulativeIdentifierLength),
+				nil)
+			return
+		}
 	}
+
 	idents = identifier.Normalize(idents)
 	logEvent.Identifiers = idents
 

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -4594,11 +4594,11 @@ func TestMaxCumulativeIdentifierLength(t *testing.T) {
 	var errorResp1 map[string]any
 	err = json.Unmarshal(responseWriter.Body.Bytes(), &errorResp1)
 	if err != nil {
-		t.Fatalf("newOrder with blocked account: got error unmarshaling response: %s", err)
+		t.Fatalf("newOrder with too long identifiers: got error unmarshaling response: %s", err)
 	}
 	detail := errorResp1["detail"]
-	expected := "Cumulative length of all identifiers was greater than 1000"
+	expected := "Cumulative length of all identifier values was greater than 1000 bytes"
 	if detail != expected {
-		t.Errorf("newOrder with blocked account: got %q, want %q", detail, expected)
+		t.Errorf("newOrder with too long identifiers: got %q, want %q", detail, expected)
 	}
 }

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -429,6 +429,7 @@ func setupWFE(t *testing.T) (WebFrontEndImpl, clock.FakeClock, requestSigner) {
 		10*time.Second,
 		10*time.Second,
 		2,
+		1000,
 		&MockRegistrationAuthority{clk: fc},
 		mockSA,
 		nil,
@@ -4553,6 +4554,50 @@ func TestAccountBlocker(t *testing.T) {
 	}
 	detail := errorResp1["detail"]
 	expected := "Account blocked :: oh no"
+	if detail != expected {
+		t.Errorf("newOrder with blocked account: got %q, want %q", detail, expected)
+	}
+}
+
+func TestMaxCumulativeIdentifierLength(t *testing.T) {
+	t.Parallel()
+	wfe, _, signer := setupWFE(t)
+	mux := wfe.Handler(metrics.NoopRegisterer)
+
+	// Test that the newOrder endpoint returns no error if the valid profile is specified.
+	responseWriter := httptest.NewRecorder()
+
+	order := struct {
+		Identifiers []identifier.ACMEIdentifier
+	}{}
+
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+	for i := 0; i < 25; i++ {
+		order.Identifiers = append(order.Identifiers,
+			identifier.NewDNS(
+				fmt.Sprintf("%d.%s.%s.%s.%s.example.com", i,
+					alphabet, alphabet, alphabet, alphabet)))
+	}
+
+	orderBytes, err := json.Marshal(order)
+	if err != nil {
+		t.Fatalf("marshaling JSON: %s", err)
+	}
+
+	r := signAndPost(signer, newOrderPath, "http://localhost"+newOrderPath, string(orderBytes))
+	mux.ServeHTTP(responseWriter, r)
+	if responseWriter.Code != http.StatusBadRequest {
+		t.Fatalf("newOrder with too long identifiers: got %d, want %d; %s", responseWriter.Code, http.StatusBadRequest,
+			responseWriter.Body.String())
+	}
+	var errorResp1 map[string]any
+	err = json.Unmarshal(responseWriter.Body.Bytes(), &errorResp1)
+	if err != nil {
+		t.Fatalf("newOrder with blocked account: got error unmarshaling response: %s", err)
+	}
+	detail := errorResp1["detail"]
+	expected := "Cumulative length of all identifiers was greater than 1000"
 	if detail != expected {
 		t.Errorf("newOrder with blocked account: got %q, want %q", detail, expected)
 	}


### PR DESCRIPTION
This allows blocking new-orders that have too many super long SANs. Pre-existing limits:

 - maxRequestSize in verify.go: 50,000 bytes
 - maxDNSIdentifierLength in policy/pa.go: 253 bytes (* 100 SANs = 25,300 bytes).