### PR TITLE
test: give more retries to bvitess health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,7 +212,7 @@ services:
                 "-e", "SELECT 1 FROM serials"]
       interval: 2s
       timeout: 30s
-      retries: 3
+      retries: 10
       start_period: 10s
       start_interval: 2s
     networks:


### PR DESCRIPTION
start_period is 10s; after that we do checks every 2s with 10 retries, so this should give bvitess plenty of time to start up, even in CI where it's slower than on our dev machines.

I spotted a bvitess failure in CI and downloaded the attached container logs. They didn't show any errors, and appeared to be in the middle of applying the SQL files. That leads me to believe we have a too-aggressive failure for the health check.