### PR TITLE
Allow dependabot to manage container versions in docker-compose file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
       day: "wednesday"
     open-pull-requests-limit: 1
     cooldown:
-      default-days: 1
+      default-days: 7
     allow:
       - dependency-name: "ghcr.io/pkimetal/pkimetal"
       - dependency-name: "jaegertracing/all-in-one"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,5 +29,10 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 1
+    cooldown:
+      default-days: 1
     allow:
       - dependency-name: "ghcr.io/pkimetal/pkimetal"
+      - dependency-name: "jaegertracing/all-in-one"
+      - dependency-name: "minio/minio"
+      - dependency-name: "minio/mc"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,16 @@ updates:
       default-days: 30
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule: 
+    schedule:
       interval: monthly
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "ghcr.io/pkimetal/pkimetal"


### PR DESCRIPTION
Adds a weekly scan similar to how we do it for `gomod`, but specifically for dev containers such as pkimetal. Unmonitored containers are attempted to be kept lockstep with staging/production infrastructure.