### PR TITLE
Dependabot docker-compose should group changes into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7
+    groups:
+      docker-compose:
+        patterns:
+          - "*"
     allow:
       - dependency-name: "ghcr.io/pkimetal/pkimetal"
       - dependency-name: "jaegertracing/all-in-one"


### PR DESCRIPTION
#8807 was deficient because it would open one PR for a single container instead of grouping all of the potential updates into a single PR. See #8809 for the unintended outcome.