### PR TITLE
ceremony: defer closing filehandle in writeFile

### DIFF
--- a/cmd/ceremony/file.go
+++ b/cmd/ceremony/file.go
@@ -9,6 +9,7 @@ func writeFile(filename string, bytes []byte) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	_, err = f.Write(bytes)
 	return err
 }


### PR DESCRIPTION
Fixes #8824