### PR TITLE
linter: check that CRL issuers match issuer subjects byte-for-byte

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -253,5 +253,12 @@ func makeLintCRL(tbs *x509.RevocationList, issuer *x509.Certificate, signer cryp
 	if err != nil {
 		return nil, err
 	}
+	// Baseline Requirements, Section 7.2
+	//
+	// The CRL issuer field MUST be byte-for-byte identical to the
+	// subject field of the Issuing CA.
+	if !bytes.Equal(issuer.RawSubject, lintCRL.RawIssuer) {
+		return nil, fmt.Errorf("mismatch between issuer RawSubject and lint CRL RawIssuer DER bytes: \"%x\" != \"%x\"", issuer.RawSubject, lintCRL.RawIssuer)
+	}
 	return lintCRL, nil
 }

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -258,7 +258,7 @@ func makeLintCRL(tbs *x509.RevocationList, issuer *x509.Certificate, signer cryp
 	// The CRL issuer field MUST be byte-for-byte identical to the
 	// subject field of the Issuing CA.
 	if !bytes.Equal(issuer.RawSubject, lintCRL.RawIssuer) {
-		return nil, fmt.Errorf("mismatch between issuer RawSubject and lint CRL RawIssuer DER bytes: \"%x\" != \"%x\"", issuer.RawSubject, lintCRL.RawIssuer)
+		return nil, fmt.Errorf("mismatch between lint issuer RawSubject and lintCRL.RawIssuer DER bytes: \"%x\" != \"%x\"", issuer.RawSubject, lintCRL.RawIssuer)
 	}
 	return lintCRL, nil
 }


### PR DESCRIPTION
Like certificates, CRLs are required to have an issuer field that matches the issuer's subject field DER byte-for-byte. This change adds a check in `makeLintCRL` similar to the one in `makeLintCert`, ensuring a CRL with a non-matching subject field cannot be issued.