### PR TITLE
admin: close files after reading

### DIFF
--- a/cmd/admin/cert.go
+++ b/cmd/admin/cert.go
@@ -204,6 +204,7 @@ func (a *admin) serialsFromFile(_ context.Context, filePath string) ([]string, e
 	if err != nil {
 		return nil, fmt.Errorf("opening serials file: %w", err)
 	}
+	defer file.Close()
 
 	var serials []string
 	scanner := bufio.NewScanner(file)
@@ -213,6 +214,10 @@ func (a *admin) serialsFromFile(_ context.Context, filePath string) ([]string, e
 			continue
 		}
 		serials = append(serials, serial)
+	}
+	err = scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("error while reading serials file: %w", err)
 	}
 
 	return serials, nil

--- a/cmd/admin/key.go
+++ b/cmd/admin/key.go
@@ -133,6 +133,7 @@ func (a *admin) spkiHashesFromFile(filePath string) ([][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening spki hashes file: %w", err)
 	}
+	defer file.Close()
 
 	var spkiHashes [][]byte
 	scanner := bufio.NewScanner(file)
@@ -151,6 +152,10 @@ func (a *admin) spkiHashesFromFile(filePath string) ([][]byte, error) {
 		}
 
 		spkiHashes = append(spkiHashes, spkiHash)
+	}
+	err = scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("error while reading spki hashes file: %w", err)
 	}
 
 	return spkiHashes, nil


### PR DESCRIPTION
Abide by best practices to avoid leaking file descriptors or papering over errors reading files.