### PR TITLE
web: Log problem details on failed requests

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -247,6 +247,10 @@ func (th *TopHandler) logEvent(ctx context.Context, logEvent *RequestEvent) {
 		attrs = append(attrs, slog.Any(k, v))
 	}
 
+	if logEvent.Error != "" {
+		attrs = append(attrs, slog.String("problem", logEvent.Error))
+	}
+
 	// There's a long-standing TODO to treat IgnoredRateLimitError the same as
 	// other InternalErrors, so just join them together here.
 	errs := logEvent.InternalErrors

--- a/web/context_test.go
+++ b/web/context_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/letsencrypt/boulder/blog"
 	"github.com/letsencrypt/boulder/features"
+	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
 )
 
@@ -178,5 +179,30 @@ func TestPropagateCancel(t *testing.T) {
 	result := <-res
 	if result != "context canceled" {
 		t.Errorf("expected 'context canceled', got %q", result)
+	}
+}
+
+type problemHandler struct{}
+
+func (ph problemHandler) ServeHTTP(e *RequestEvent, w http.ResponseWriter, r *http.Request) {
+	e.Endpoint = "/endpoint"
+	SendError(blog.NewMock(), w, e, probs.Unauthorized("you shall not pass"), nil)
+}
+
+// TestLogProblem tests that the client-visible problem details recorded by
+// SendError appear in the request completion log line.
+func TestLogProblem(t *testing.T) {
+	mockLog := blog.NewMock()
+	th := NewTopHandler(mockLog, problemHandler{})
+	req, err := http.NewRequest("GET", "/thisisignored", &bytes.Reader{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	th.ServeHTTP(httptest.NewRecorder(), req)
+
+	matching := mockLog.GetAllMatching(`problem="403 :: unauthorized :: you shall not pass"`)
+	if len(matching) != 1 {
+		t.Errorf("Expected exactly one log line containing the problem details. Got \n%s",
+			strings.Join(mockLog.GetAll(), "\n"))
 	}
 }


### PR DESCRIPTION
The slog migration (#8606) dropped RequestEvent.Error from the request completion log: web.SendError still recorded the client-visible problem details on the event, but logEvent() never emitted them, so failed ACME requests logged only their status code. Emit the field under the key "problem" ("error" is reserved for the blog.Error helper).

This PR was generated as part of an audit of https://github.com/letsencrypt/boulder/pull/8606 using Claude Fable 5.
