### PR TITLE
publisher: Log serials in hex

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -265,7 +265,7 @@ func (pub *Impl) SubmitToSingleCTWithResult(ctx context.Context, req *pubpb.Requ
 			body = string(rspErr.Body)
 		}
 		pub.log.Info(ctx, "Failed to submit certificate to CT log",
-			blog.Serial(cert.SerialNumber.String()),
+			blog.Serial(core.SerialToString(cert.SerialNumber)),
 			slog.String("issuer", cert.Issuer.CommonName),
 			slog.String("log", ctLog.uri),
 			slog.String("body", body),


### PR DESCRIPTION
blog.Serial documents that its argument should be the hex-encoded form, and every other call site uses core.SerialToString. This one logged the big.Int decimal form, which matches nothing else in the system when searching or joining on serial.

This PR was generated as part of an audit of https://github.com/letsencrypt/boulder/pull/8606 using Claude Fable 5.
