### PR TITLE
crl/storer: Include issuerNameID in CRL upload logs

### DIFF
--- a/crl/storer/storer.go
+++ b/crl/storer/storer.go
@@ -142,6 +142,7 @@ func (cs *crlStorer) UploadCRL(stream grpc.ClientStreamingServer[cspb.UploadCRLR
 
 	ctx := blog.ContextWith(stream.Context(),
 		slog.String("issuer", issuer.Subject.CommonName),
+		slog.Int64("issuerNameID", int64(issuer.NameID())),
 		slog.Int64("shard", shardIdx),
 		slog.String("number", crlNumber.String()),
 	)


### PR DESCRIPTION
The crl-updater attaches issuerNameID to all its log lines (added during #8606 review), but the storer's "CRL uploaded" line carried only the issuer CN. Since the S3 object key is {nameID}/{shardIdx}.crl, tying an upload log line to its object required an out-of-band CN to NameID mapping. Log the NameID too.

This PR was generated as part of an audit of https://github.com/letsencrypt/boulder/pull/8606 using Claude Fable 5.
