### PR TITLE
blog: Stop mutating caller-owned attr slices

### DIFF
--- a/blog/logger.go
+++ b/blog/logger.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"log/syslog"
 	"os"
+	"slices"
 
 	"github.com/letsencrypt/boulder/core"
 )
@@ -91,7 +92,7 @@ func (l *logger) Error(ctx context.Context, msg string, err error, attrs ...slog
 	// We attach these attrs to the context, rather than passing them directly to
 	// LogAttrs, to ensure that they come last in the log line. See
 	// contextHandler.Handle() for more information.
-	ctx = ContextWith(ctx, append(attrs, Error(err))...)
+	ctx = ContextWith(ctx, append(slices.Clip(attrs), Error(err))...)
 	l.inner.LogAttrs(ctx, slog.LevelError, msg)
 }
 
@@ -117,13 +118,13 @@ func (l *logger) Debug(ctx context.Context, msg string, attrs ...slog.Attr) {
 // level and with the audit tag. The error will be included in the attrs under
 // the key "error".
 func (l *logger) AuditError(ctx context.Context, msg string, err error, attrs ...slog.Attr) {
-	ctx = ContextWith(ctx, append(attrs, auditAttr, Error(err))...)
+	ctx = ContextWith(ctx, append(slices.Clip(attrs), auditAttr, Error(err))...)
 	l.inner.LogAttrs(ctx, slog.LevelError, msg)
 }
 
 // AuditInfo logs the given message and other key-value pairs at info level and
 // with the audit tag.
 func (l *logger) AuditInfo(ctx context.Context, msg string, attrs ...slog.Attr) {
-	ctx = ContextWith(ctx, append(attrs, auditAttr)...)
+	ctx = ContextWith(ctx, append(slices.Clip(attrs), auditAttr)...)
 	l.inner.LogAttrs(ctx, slog.LevelInfo, msg)
 }

--- a/blog/logger_test.go
+++ b/blog/logger_test.go
@@ -188,3 +188,55 @@ func TestLoggerChecksum(t *testing.T) {
 		t.Errorf("checksum prefix %q does not match LogLineChecksum of remainder %q", parts[0], want)
 	}
 }
+
+func TestLoggerDoesNotMutateCallerAttrs(t *testing.T) {
+	t.Parallel()
+
+	// These methods append internal attrs (error, audit) to the caller's
+	// variadic attr slice. If that append reuses the caller's backing array,
+	// the caller's slice is corrupted for any later use.
+	testCases := []struct {
+		name string
+		log  func(l Logger, attrs ...slog.Attr)
+	}{
+		{
+			name: "Error",
+			log: func(l Logger, attrs ...slog.Attr) {
+				l.Error(context.Background(), "oops", errors.New("boom"), attrs...)
+			},
+		},
+		{
+			name: "AuditError",
+			log: func(l Logger, attrs ...slog.Attr) {
+				l.AuditError(context.Background(), "oops", errors.New("boom"), attrs...)
+			},
+		},
+		{
+			name: "AuditInfo",
+			log: func(l Logger, attrs ...slog.Attr) {
+				l.AuditInfo(context.Background(), "note", attrs...)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			attrs := make([]slog.Attr, 0, 4)
+			attrs = append(attrs, slog.String("k1", "v1"))
+
+			tc.log(NewMock(), attrs...)
+
+			if len(attrs) != 1 || attrs[0].String() != "k1=v1" {
+				t.Errorf("caller's attr slice was mutated: %v", attrs)
+			}
+			leaked := attrs[:cap(attrs)]
+			for i := 1; i < len(leaked); i++ {
+				if !leaked[i].Equal(slog.Attr{}) {
+					t.Errorf("caller's backing array index %d contains leaked attr %v", i, leaked[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Error, AuditError, and AuditInfo appended internal attrs (error, audit) directly to the caller's variadic slice. When a caller passes a slice with spare capacity, that append writes into the caller's backing array, leaking a stray attr into any later use of the slice. Clip the slice first so the append always allocates. (ContextWith was given the equivalent fix during #8606 review, but these methods were missed.)

This PR was generated as part of an audit of https://github.com/letsencrypt/boulder/pull/8606 using Claude Fable 5.
