### PR TITLE
va: Preserve internal error in CAA check audit line

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -123,7 +123,7 @@ func (va *ValidationAuthorityImpl) DoCAA(ctx context.Context, req *vapb.IsCAAVal
 	localLatency = va.clk.Since(start)
 
 	if err != nil {
-		logAttrs = append(logAttrs, blog.Error(err))
+		logAttrs = append(logAttrs, slog.String("internalErr", err.Error()))
 		prob = detailedError(err)
 		prob.Detail = fmt.Sprintf("While processing CAA for %s: %s", ident.Value, prob.Detail)
 	}


### PR DESCRIPTION
On a failed local CAA check, the "CAA check result" audit line attached the internal error under blog.Error's "error" key, which the deferred logger also uses for the client-visible problem, producing duplicate keys in one JSON record. Parsers keep only one of the two values. Key the internal error as internalErr, matching the equivalent code in DoDCV.

This PR was generated as part of an audit of https://github.com/letsencrypt/boulder/pull/8606 using Claude Fable 5.
