### PR TITLE
docs: Correct stale logging documentation

### DIFF
--- a/blog/config.go
+++ b/blog/config.go
@@ -21,9 +21,7 @@ import (
 // numbers documented above (e.g. 1) have the same effect as the next larger
 // value (e.g. 3).
 type Config struct {
-	// When absent or zero, this causes no logs to be emitted on stdout/stderr.
-	// Errors and warnings will be emitted on stderr if the configured level
-	// allows.
+	// When absent or zero, this causes no logs to be emitted on stdout.
 	StdoutLevel int `validate:"min=-1,max=7"`
 	// When absent or zero, this defaults to logging all messages of level 6
 	// or below. To disable syslog logging entirely, set this to -1.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -46,7 +46,7 @@ consumed by cmd/log-validator.
 
 All lines logged via `blog.AuditInfo` or `blog.AuditError` are prefixed by the constant string `[AUDIT]`. This is used by internal infrastructure to ensure that audit-level logs have extra persistence and durability.
 
-All log lines have attributes for the datacenter, host, program, and pid. These are replicating information usually prepended to log lines by syslog. In the integration test environment, these attributes are suppressed for readability.
+In production, log lines do not carry attributes identifying the datacenter, host, program, or pid: that information is added by syslog and our log collection infrastructure, so repeating it in every line would only cost storage. In the unit and integration test environments (where there is no syslog), lines carry a `prog` attribute so that interleaved output from multiple components can be told apart.
 
 In production, all lines are logged in JSON format. This is to optimize for machine-readability in our log analysis systems. In the unit and integration tests, all lines are logged in text format, to optimize for human readability.
 


### PR DESCRIPTION
docs/logging.md claimed all log lines carry datacenter/host/program/pid attributes. Those were deliberately removed from prod during #8606 review (collectors add them), with only prog retained in test builds. blog.Config's StdoutLevel comment still described a stdout/stderr split that no longer exists.

This PR was generated as part of an audit of https://github.com/letsencrypt/boulder/pull/8606 using Claude Fable 5.