### PR TITLE
Pivot WFE around the string(authzID) to int64(authzID) type change.

### DIFF
--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1202,7 +1202,7 @@ func (wfe *WebFrontEndImpl) Challenge(
 	}
 
 	// Ensure gRPC response is complete.
-	if core.IsAnyNilOrZero(authzPB.Id, authzPB.Identifier, authzPB.Status, authzPB.Expires) {
+	if core.IsAnyNilOrZero(authzPB.IdInt, authzPB.Identifier, authzPB.Status, authzPB.Expires) {
 		wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), errIncompleteGRPCResponse)
 		return
 	}
@@ -1401,7 +1401,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			Authz:          authzPB,
 			ChallengeIndex: int64(challengeIndex),
 		})
-		if err != nil || core.IsAnyNilOrZero(authzPB.Id, authzPB.Identifier, authzPB.Status, authzPB.Expires) {
+		if err != nil || core.IsAnyNilOrZero(authzPB.IdInt, authzPB.Identifier, authzPB.Status, authzPB.Expires) {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
 			return
 		}
@@ -1622,7 +1622,7 @@ func (wfe *WebFrontEndImpl) Authorization(
 	ident := identifier.FromProto(authzPB.Identifier)
 
 	// Ensure gRPC response is complete.
-	if core.IsAnyNilOrZero(authzPB.Id, ident, authzPB.Status, authzPB.Expires) {
+	if core.IsAnyNilOrZero(authzPB.IdInt, ident, authzPB.Status, authzPB.Expires) {
 		wfe.sendError(response, logEvent, probs.ServerInternal("Problem getting authorization"), errIncompleteGRPCResponse)
 		return
 	}

--- a/wfe2/wfe_test.go
+++ b/wfe2/wfe_test.go
@@ -230,7 +230,7 @@ func (ra *MockRegistrationAuthority) GetAuthorization(_ context.Context, in *rap
 	switch in.Id {
 	case 1: // Return a valid authorization with a single valid challenge.
 		return &corepb.Authorization{
-			Id:             "1",
+			IdInt:          1,
 			RegistrationID: 1,
 			Identifier:     identifier.NewDNS("not-an-example.com").ToProto(),
 			Status:         string(core.StatusValid),
@@ -241,7 +241,7 @@ func (ra *MockRegistrationAuthority) GetAuthorization(_ context.Context, in *rap
 		}, nil
 	case 2: // Return a pending authorization with three pending challenges.
 		return &corepb.Authorization{
-			Id:             "2",
+			IdInt:          2,
 			RegistrationID: 1,
 			Identifier:     identifier.NewDNS("not-an-example.com").ToProto(),
 			Status:         string(core.StatusPending),
@@ -254,7 +254,7 @@ func (ra *MockRegistrationAuthority) GetAuthorization(_ context.Context, in *rap
 		}, nil
 	case 3: // Return an expired authorization with three pending (but expired) challenges.
 		return &corepb.Authorization{
-			Id:             "3",
+			IdInt:          3,
 			RegistrationID: 1,
 			Identifier:     identifier.NewDNS("not-an-example.com").ToProto(),
 			Status:         string(core.StatusPending),
@@ -269,7 +269,7 @@ func (ra *MockRegistrationAuthority) GetAuthorization(_ context.Context, in *rap
 		return nil, fmt.Errorf("unspecified error")
 	case 5: // Return a pending authorization as above, but associated with RegID 2.
 		return &corepb.Authorization{
-			Id:             "5",
+			IdInt:          5,
 			RegistrationID: 2,
 			Identifier:     identifier.NewDNS("not-an-example.com").ToProto(),
 			Status:         string(core.StatusPending),
@@ -1871,7 +1871,7 @@ type RAWithFailedChallenge struct {
 
 func (ra *RAWithFailedChallenge) GetAuthorization(ctx context.Context, id *rapb.GetAuthorizationRequest, _ ...grpc.CallOption) (*corepb.Authorization, error) {
 	return &corepb.Authorization{
-		Id:             "6",
+		IdInt:          6,
 		RegistrationID: 1,
 		Identifier:     identifier.NewDNS("not-an-example.com").ToProto(),
 		Status:         string(core.StatusInvalid),


### PR DESCRIPTION
I missed these checks in the WFE in stage 1, while making sure that all components exchanged _both_ string-type Authz IDs _and_ int64-type Authz IDs.

Because stage 1 has been deployed for a while, this pivots only the WFE around the type change so that a follow-up change ( and deployment cycle ) can successfully remove the string-type ID support.