### PR TITLE
Add conversation resolution requirement to CONTRIBUTING.md.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,15 +32,8 @@ guidelines for Boulder contributions.
   functionality in the patch, including error cases?
 * Are there new RPCs or config fields? Make sure the patch meets the
   Deployability rules below.
-* [All review conversations must be
-  resolved](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-conversation-resolution-before-merging).
-  This helps to ensure that review feedback has been fully addressed. This is
-  additionally leveraged as one more layer of control on pull request merges.
-  Pull request authors and reviewers can describe external requirements (like
-  ad-hoc blockers _beyond_ our workflows and `CODEOWNERS`) as review comments,
-  and github will not allow the pull request to be merged until someone declares
-  that the conditions of the comment have been met by marking the conversation
-  as resolved.
+* All review conversations must be resolved. This helps to ensure that review
+  feedback has been fully addressed. This is enforced by GitHub itself.
 
 # Merge Requirements
 
@@ -54,6 +47,15 @@ These may require either a CP/CPS review or filing of a ticket to make matching 
 in production. It is the responsibility of the person merging the PR to make sure
 the required action has been performed before merging. Usually this will be confirmed
 in a comment or in the PR description.
+
+When creating a pull request that has external dependencies, like another pull
+request being merged or deployed to production, or approval from SRE, the author
+should leave a review comment on the pull request (a "conversation") noting what
+the pull request is blocked on. The comment should include instructions to only
+resolve that conversation once the external conditions are met. Since our
+repository is configured to require all conversations be resolved before
+merging, this acts as a protection against early merges.
+
 
 # Patch Guidelines
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,6 +32,15 @@ guidelines for Boulder contributions.
   functionality in the patch, including error cases?
 * Are there new RPCs or config fields? Make sure the patch meets the
   Deployability rules below.
+* [All review conversations are
+  resolved](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-conversation-resolution-before-merging).
+  This helps to ensure that review feedback has been fully addressed. This is
+  additionally leveraged as one more layer of control on pull request merges.
+  Pull request authors and reviewers can describe external requirements (like
+  ad-hoc blockers _beyond_ our workflows and `CODEOWNERS`) as review comments,
+  and github will not allow the pull request to be merged until someone declares
+  that the conditions of the comment have been met by marking the conversation
+  as resolved.
 
 # Merge Requirements
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -56,7 +56,6 @@ resolve that conversation once the external conditions are met. Since our
 repository is configured to require all conversations be resolved before
 merging, this acts as a protection against early merges.
 
-
 # Patch Guidelines
 
 * Please include helpful comments. No need to gratuitously comment clear code,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@ in a comment or in the PR description.
 
 When creating a pull request that has external dependencies, like another pull
 request being merged or deployed to production, or approval from SRE, the author
-should leave a review comment on the pull request (a "conversation") noting what
+should leave a review comment on the pull request (i.e. create a "conversation" by commenting on a specific file or line of a file) noting what
 the pull request is blocked on. The comment should include instructions to only
 resolve that conversation once the external conditions are met. Since our
 repository is configured to require all conversations be resolved before

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,11 +50,12 @@ in a comment or in the PR description.
 
 When creating a pull request that has external dependencies, like another pull
 request being merged or deployed to production, or approval from SRE, the author
-should leave a review comment on the pull request (i.e. create a "conversation" by commenting on a specific file or line of a file) noting what
-the pull request is blocked on. The comment should include instructions to only
-resolve that conversation once the external conditions are met. Since our
-repository is configured to require all conversations be resolved before
-merging, this acts as a protection against early merges.
+should leave a review comment on the pull request (i.e. create a "conversation"
+by commenting on a specific file or line of a file) noting what the pull request
+is blocked on. The comment should include instructions to only resolve that
+conversation once the external conditions are met. Since our repository is
+configured to require all conversations be resolved before merging, this acts as
+a protection against early merges.
 
 # Patch Guidelines
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,7 +32,7 @@ guidelines for Boulder contributions.
   functionality in the patch, including error cases?
 * Are there new RPCs or config fields? Make sure the patch meets the
   Deployability rules below.
-* [All review conversations are
+* [All review conversations must be
   resolved](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-conversation-resolution-before-merging).
   This helps to ensure that review feedback has been fully addressed. This is
   additionally leveraged as one more layer of control on pull request merges.


### PR DESCRIPTION
This adds a description of our use of review comments to represent external blockers to CONTRIBUTING.md.