### PR TITLE
Use DialerRetries from config file in redis RingOptions.

### DIFF
--- a/redis/config.go
+++ b/redis/config.go
@@ -60,6 +60,9 @@ type Config struct {
 	// PoolFIFO uses FIFO mode for each node connection pool GET/PUT (default LIFO).
 	PoolFIFO bool
 
+	// Maximum number of retry attempts when dialing fails.
+	// Default is 5 attempts.
+	DialerRetries int `validate:"min=0"`
 	// Maximum number of retries before giving up.
 	// Default is to not retry failed commands.
 	MaxRetries int `validate:"min=0"`
@@ -138,6 +141,7 @@ func NewRingFromConfig(c Config, stats prometheus.Registerer, log blog.Logger) (
 		Password:  password,
 		TLSConfig: tlsConfig,
 
+		DialerRetries:   c.DialerRetries,
 		MaxRetries:      c.MaxRetries,
 		MinRetryBackoff: c.MinRetryBackoff.Duration,
 		MaxRetryBackoff: c.MaxRetryBackoff.Duration,

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -11,6 +11,7 @@
 					}
 				],
 				"lookupDNSAuthority": "consul.service.consul",
+				"dialerRetries": 1,
 				"readTimeout": "250ms",
 				"writeTimeout": "250ms",
 				"poolSize": 100,

--- a/test/config-next/sfe.json
+++ b/test/config-next/sfe.json
@@ -39,6 +39,7 @@
 					}
 				],
 				"lookupDNSAuthority": "consul.service.consul",
+				"dialerRetries": 1,
 				"readTimeout": "250ms",
 				"writeTimeout": "250ms",
 				"poolSize": 100,

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -122,6 +122,7 @@
 					}
 				],
 				"lookupDNSAuthority": "consul.service.consul",
+				"dialerRetries": 1,
 				"readTimeout": "250ms",
 				"writeTimeout": "250ms",
 				"poolSize": 100,


### PR DESCRIPTION
The redis RingOptions config knob for DialerRetries was introduced by a recent `go-redis` vendored library update (#8815).

This change allows for the value of the option to be loaded from component config files. 