### PR TITLE
sa: use tx object in AddPrecertificate

### DIFF
--- a/sa/sa.go
+++ b/sa/sa.go
@@ -264,7 +264,7 @@ func (ssa *SQLStorageAuthority) AddPrecertificate(ctx context.Context, req *sapb
 			IsExpired:             false,
 			IssuerID:              req.IssuerNameID,
 		}
-		err = ssa.dbMap.Insert(ctx, cs)
+		err = tx.Insert(ctx, cs)
 		if err != nil {
 			return nil, err
 		}
@@ -1601,7 +1601,7 @@ func (ssa *SQLStorageAuthority) updateRateLimitOverride(
 				UPDATE overrides
 				SET comment = :comment,
 					periodNS = :periodNS,
-					count = :count,		
+					count = :count,
 					burst = :burst,
 					updatedAt = :updatedAt,
 					enabled = :enabled


### PR DESCRIPTION
Most of the body of this WithTransaction call used `tx` for manipulating the database, but the call to insert the certificateStatus row accidentally used sa.dbMap, meaning that call did not participate in transactional guarantees.

Wrote a similar bug while working on #8826, asked Claude to find the same pattern elsewhere in the codebase and came up with this one.