### PR TITLE
Don't exit on failure if cert-checker finds bad certs

### DIFF
--- a/cmd/cert-checker/main.go
+++ b/cmd/cert-checker/main.go
@@ -756,10 +756,6 @@ func main() {
 			}
 		}
 	}
-
-	if checker.issuedReport.BadCerts > 0 {
-		os.Exit(1)
-	}
 }
 
 func init() {

--- a/test/integration-test.py
+++ b/test/integration-test.py
@@ -140,7 +140,18 @@ def check_balance():
                 % address)
 
 def run_cert_checker():
-    run(["./bin/boulder", "cert-checker", "-config", "%s/cert-checker.json" % config_dir])
+    # cert-checker no longer exits non-zero when it finds bad certs, so capture
+    # its output and inspect the report it logs when it finishes.
+    output = subprocess.check_output(
+        ["./bin/boulder", "cert-checker", "-config", "%s/cert-checker.json" % config_dir],
+        stderr=subprocess.STDOUT).decode()
+    print(output)
+
+    match = re.search(r'Finished processing certificates JSON=.*"bad-certs":(\d+)', output)
+    if match is None:
+        raise(Exception("cert-checker did not emit a final report"))
+    if int(match.group(1)) > 0:
+        raise(Exception("cert-checker found %s bad certs" % match.group(1)))
 
 def process_covdata(coverage_dir):
     """Process coverage data and generate reports."""


### PR DESCRIPTION
Cert-checker failing when it finds bad certs has undesirable behavior on the deploy side (e.g. job failure due to bad cert discovery leads to unnecessary redeployment of the job and re-firing of associated alerts) and IMO finding bad certs is not a failure of the cert-checker (in fact, it did it's job, woohoo!)