### PR TITLE
entry: add MTCLogEntry, TBSCertificateLogEntry

### DIFF
--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -196,9 +196,26 @@ func unmarshalMTCE(input []byte) (MerkleTreeCertEntry, error) {
 // FromX509 takes a DER-encoded X.509 certificate and transforms it into a TBSCertificateLogEntry,
 // then returns a MerkleTreeCertEntry wrapping that TBSCertificateLogEntry.
 func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
-	tbsCertificateDER, err := tbsDERFromCertDER(in)
-	if err != nil {
-		return MerkleTreeCertEntry{}, err
+	var inner cryptobyte.String
+	input := cryptobyte.String(in)
+
+	// https://datatracker.ietf.org/doc/html/rfc5280#page-116
+	//
+	//		Certificate  ::=  SEQUENCE  {
+	//		    tbsCertificate       TBSCertificate,
+	//		    ...
+	//
+	//		TBSCertificate  ::=  SEQUENCE  {
+	//		    version         [0]  Version DEFAULT v1,
+	//		    serialNumber         CertificateSerialNumber,
+	//	     ...
+	if !input.ReadASN1(&inner, asn1.SEQUENCE) {
+		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read outer sequence")
+	}
+
+	var tbsCertificate cryptobyte.String
+	if !inner.ReadASN1(&tbsCertificate, asn1.SEQUENCE) {
+		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read tbsCertificate")
 	}
 
 	// https://datatracker.ietf.org/doc/html/rfc5280#page-117
@@ -223,7 +240,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 		var fieldElement cryptobyte.String
 		var fieldTag asn1.Tag
 
-		if !tbsCertificateDER.ReadAnyASN1Element(&fieldElement, &fieldTag) {
+		if !tbsCertificate.ReadAnyASN1Element(&fieldElement, &fieldTag) {
 			return MerkleTreeCertEntry{}, fmt.Errorf("failed to read field")
 		}
 
@@ -243,7 +260,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// Use ReadASN1Element, not ReadASN1, so spki contains the tag and
 	// length bytes, which should be included in the hash.
 	var spki cryptobyte.String
-	if !tbsCertificateDER.ReadASN1Element(&spki, asn1.SEQUENCE) {
+	if !tbsCertificate.ReadASN1Element(&spki, asn1.SEQUENCE) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 
@@ -270,7 +287,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// which has an encoding instruction of [3].
 	var extensions cryptobyte.String
 	extensionsTag := asn1.Tag(3).Constructed().ContextSpecific()
-	if !tbsCertificateDER.ReadASN1Element(&extensions, extensionsTag) {
+	if !tbsCertificate.ReadASN1Element(&extensions, extensionsTag) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("error reading extensions")
 	}
 
@@ -310,33 +327,4 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 		Type:  typeTBSCertEntry,
 		Value: tbsCertificateLogEntryBytes,
 	}, nil
-}
-
-// tbsDERFromCertDER takes a Certificate object encoded as DER, and parses
-// away the outermost two sequences to get the inner bytes of the TBSCertificate.
-//
-// https://datatracker.ietf.org/doc/html/rfc5280#page-116
-//
-//		Certificate  ::=  SEQUENCE  {
-//		    tbsCertificate       TBSCertificate,
-//		    ...
-//
-//		TBSCertificate  ::=  SEQUENCE  {
-//		    version         [0]  Version DEFAULT v1,
-//		    serialNumber         CertificateSerialNumber,
-//	     ...
-func tbsDERFromCertDER(certDER []byte) (cryptobyte.String, error) {
-	var inner cryptobyte.String
-	input := cryptobyte.String(certDER)
-
-	if !input.ReadASN1(&inner, asn1.SEQUENCE) {
-		return nil, fmt.Errorf("failed to read outer sequence")
-	}
-
-	var tbsCertificate cryptobyte.String
-	if !inner.ReadASN1(&tbsCertificate, asn1.SEQUENCE) {
-		return nil, fmt.Errorf("failed to read tbsCertificate")
-	}
-
-	return tbsCertificate, nil
 }

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -85,12 +85,12 @@ func (br *BundleReader) Read() (MTCLogEntry, []byte, error) {
 		return MTCLogEntry{}, nil, fmt.Errorf("malformed length")
 	}
 
-	mtce, err := unmarshalMTCE(body)
+	mtcle, err := unmarshalMTCLE(body)
 	if err != nil {
 		return MTCLogEntry{}, nil, err
 	}
 
-	return mtce, body, nil
+	return mtcle, body, nil
 }
 
 const typeNullEntry = 0
@@ -117,9 +117,9 @@ type MTCLogEntry struct {
 }
 
 // TBS returns the TBSCertificateLogEntry bytes if Type is tbs_cert_entry, or nil otherwise.
-func (mtce MTCLogEntry) TBS() []byte {
-	if mtce.Type == typeTBSCertEntry {
-		return mtce.Value
+func (mtcle MTCLogEntry) TBS() []byte {
+	if mtcle.Type == typeTBSCertEntry {
+		return mtcle.Value
 	}
 	return nil
 }
@@ -127,13 +127,13 @@ func (mtce MTCLogEntry) TBS() []byte {
 // Marshal returns the encoding of its receiver.
 //
 // Rejects unknown MTCLogEntryTypes.
-func (mtce MTCLogEntry) Marshal() ([]byte, error) {
+func (mtcle MTCLogEntry) Marshal() ([]byte, error) {
 	var builder cryptobyte.Builder
 	builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-		child.AddBytes(mtce.Extensions)
+		child.AddBytes(mtcle.Extensions)
 	})
-	builder.AddUint16(mtce.Type)
-	switch mtce.Type {
+	builder.AddUint16(mtcle.Type)
+	switch mtcle.Type {
 	case typeTBSCertEntry:
 		// We don't encode a length prefix for Value. Per the spec:
 		//      opaque tbs_cert_entry_data[N];
@@ -143,22 +143,22 @@ func (mtce MTCLogEntry) Marshal() ([]byte, error) {
 		//
 		// In other words, per TLS presentation syntax (https://datatracker.ietf.org/doc/html/rfc8446#section-3.4),
 		// this is a fixed-length vector of size N, where N is known externally.
-		builder.AddBytes(mtce.Value)
+		builder.AddBytes(mtcle.Value)
 	case typeNullEntry:
-		if len(mtce.Value) != 0 {
+		if len(mtcle.Value) != 0 {
 			return nil, fmt.Errorf("non-empty value for null_entry MTCLogEntry")
 		}
 		// Append nothing; the encoding of the null entry is Empty.
 	default:
-		return nil, fmt.Errorf("unknown MTCLogEntryType %d", mtce.Type)
+		return nil, fmt.Errorf("unknown MTCLogEntryType %d", mtcle.Type)
 	}
 	return builder.Bytes()
 }
 
-// unmarshalMTCE parses a MTCLogEntry and returns it.
+// unmarshalMTCLE parses a MTCLogEntry and returns it.
 //
 // Rejects unknown MTCLogEntryType.
-func unmarshalMTCE(input []byte) (MTCLogEntry, error) {
+func unmarshalMTCLE(input []byte) (MTCLogEntry, error) {
 	val := cryptobyte.String(input)
 
 	var extensions cryptobyte.String

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"math"
 
-	"github.com/zmap/zcrypto/cryptobyte"
-	"github.com/zmap/zcrypto/cryptobyte/asn1"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
 )
 
 // BundleWriter writes a sequence of MerkleTreeCertEntry to the underlying writer

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -1,92 +1,87 @@
-// Package entry defines types related TBSCertificateLogEntry and MerkleTreeCertEntry from
+// Package entry defines types related to TBSCertificateLogEntry and MerkleTreeCertEntry from
 // https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries,
 // and the entry bundle encoding from https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries
+//
+// The concepts fit together like so:
+//
+// Entry bundles contain MerkleTreeCertEntry. MerkleTreeCertEntry contains (typically) TBSCertificateLogEntry.
+//
+// TBSCertificateLogEntry is part of the X.509 layer. It will be used to build certificates
+// (TODO: implement TBSCertificateLogEntry.ToX509).
+//
+// MerkleTreeCertEntry is part of the Merkle Tree layer and is what gets hashed. It provides type switching
+// (needed for null_entry) and extensibility.
+//
+// Entry bundles are part of the tile storage layer. They provide a simple length-prefixed framing so that
+// MerkleTreeCertEntries can be concatenated unambiguously.
+//
+// Note that neither TBSCertificateLogEntry nor MerkleTreeCertEntry carries its own length, since they will
+// always be wrapped or converted into a format that has length information: entry bundles or X.509 certificate.
 package entry
 
 import (
 	"bytes"
 	"crypto"
-	"encoding/binary"
 	"fmt"
 	"io"
-	"math"
 
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
 
-// BundleWriter writes a sequence of MerkleTreeCertEntry to the underlying writer
-// as entry bundles.
-type BundleWriter struct {
-	w io.WriteCloser
+// BundleBuilder appends a sequence of MerkleTreeCertEntry to a buffer as an entry bundle.
+type BundleBuilder struct {
+	b cryptobyte.Builder
 }
 
-// NewBundleWriter returns a BundleWriter with given underlying writer.
-func NewBundleWriter(w io.WriteCloser) BundleWriter {
-	return BundleWriter{w}
+// NewBundleBuilder returns a BundleBuilder that appends to the given buffer. Like
+// cryptobyte.Builder, the slice will be reallocated if its capacity is exceeded.
+// Use Bytes to get the final buffer.
+func NewBundleBuilder(buf []byte) *BundleBuilder {
+	return &BundleBuilder{*cryptobyte.NewBuilder(buf)}
 }
 
-func (bw BundleWriter) Close() error {
-	return bw.w.Close()
+func (b *BundleBuilder) Bytes() ([]byte, error) {
+	return b.b.Bytes()
 }
 
-// Write writes a single MerkleTreeLogEntry, with its length prefix, to the underlying
-// writer.
-func (bw BundleWriter) Write(merkleTreeCertificateEntry MerkleTreeCertEntry) error {
+// Add appends a single MerkleTreeCertEntry, with its length prefix, to the builder.
+func (b *BundleBuilder) Add(merkleTreeCertificateEntry MerkleTreeCertEntry) {
 	out, err := merkleTreeCertificateEntry.Marshal()
 	if err != nil {
-		return err
+		b.b.SetError(err)
+		return
 	}
 
-	return bw.writeLengthPrefixed(out)
+	b.b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes(out)
+	})
 }
 
-// writeLengthPrefixed writes to the underlying writer a byte sequence with a two-byte length prefix.
-func (bw BundleWriter) writeLengthPrefixed(in []byte) error {
-	prefix := len(in)
-	if prefix > math.MaxUint16 {
-		return fmt.Errorf("input too long: %d bytes", len(in))
-	}
-	var prefixBytes [2]byte
-	binary.BigEndian.PutUint16(prefixBytes[:], uint16(prefix))
-	_, err := bw.w.Write(prefixBytes[:])
-	if err != nil {
-		return err
-	}
-
-	_, err = bw.w.Write(in)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// BundleReader reads records of MerkleTreeCertEntry from the underlying reader in the
+// BundleReader reads records of MerkleTreeCertEntry from the underlying buffer in the
 // entry bundle format.
 type BundleReader struct {
-	r io.Reader
+	r cryptobyte.String
 }
 
 // NewBundleReader returns a new BundleReader.
-func NewBundleReader(r io.Reader) BundleReader {
-	return BundleReader{r}
+func NewBundleReader(buf []byte) *BundleReader {
+	return &BundleReader{cryptobyte.String(buf)}
 }
 
-// Read reads the bytes of a single entry from the underlying reader.
+// Read reads the bytes of a single entry.
 //
-// Returns the parsed MerkleTreeCertEntry as well as its bytes.
-func (br BundleReader) Read() (MerkleTreeCertEntry, []byte, error) {
-	var buf [2]byte
-	_, err := io.ReadFull(br.r, buf[:])
-	if err != nil {
-		return MerkleTreeCertEntry{}, nil, err
+// Returns the parsed MerkleTreeCertEntry as well as its bytes, both of which
+// reference the same memory as the original buffer.
+//
+// Returns MerkleTreeCertEntry{}, nil, io.EOF when there is no more to read.
+func (br *BundleReader) Read() (MerkleTreeCertEntry, []byte, error) {
+	if br.r.Empty() {
+		return MerkleTreeCertEntry{}, nil, io.EOF
 	}
-	entryLen := binary.BigEndian.Uint16(buf[:])
-	body := make([]byte, entryLen)
-	_, err = io.ReadFull(br.r, body)
-	if err != nil {
-		return MerkleTreeCertEntry{}, nil, err
+	var body cryptobyte.String
+	if !br.r.ReadUint16LengthPrefixed(&body) {
+		return MerkleTreeCertEntry{}, nil, fmt.Errorf("malformed length")
 	}
 
 	mtce, err := unmarshalMTCE(body)
@@ -243,6 +238,8 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	if !tbsCertificate.ReadASN1(&version, asn1.Tag(0).Constructed().ContextSpecific()) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read version")
 	}
+	// Version should always be v3, which is represented as an ASN.1 INTEGER 2.
+	// That's tag 2, length 1, value 2.
 	if !bytes.Equal(version, []byte{2, 1, 2}) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("invalid X.509 version")
 	}
@@ -324,17 +321,22 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// and `signature`, and encodes subjectPublicKeyInfo as its hash.
 	var builder cryptobyte.Builder
 
+	// version
 	builder.AddASN1(asn1.Tag(0).Constructed().ContextSpecific(), func(child *cryptobyte.Builder) {
 		child.AddASN1Int64(2)
 	})
 
+	// issuer, validity, subject
 	for _, f := range fields {
 		// The fields were read with ReadASN1Element so they still include
-		// their tag and length. Add them straight to
+		// their tag and length. Add them straight to the builder.
 		builder.AddBytes(f)
 	}
+	// subjectPublicKeyAlgorithm
 	builder.AddBytes(algID)
+	// subjectPublicKeyInfoHash
 	builder.AddASN1OctetString(spkiHash)
+	// extensions
 	builder.AddBytes(extensions)
 
 	tbsCertificateLogEntryBytes, err := builder.Bytes()

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -1,17 +1,103 @@
-// Package entry defines types for the MerkleTreeCertEntry structure in
-// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
+// Package entry defines types related TBSCertificateLogEntry and MerkleTreeCertEntry from
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries,
+// and the entry bundle encoding from https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries
 package entry
 
 import (
 	"crypto"
+	"encoding/binary"
 	"fmt"
+	"io"
+	"math"
 
 	"github.com/zmap/zcrypto/cryptobyte"
 	"github.com/zmap/zcrypto/cryptobyte/asn1"
 )
 
-const TYPE_NULL_ENTRY = 0
-const TYPE_TBS_CERT_ENTRY = 1
+// BundleWriter writes a sequence of MerkleTreeCertEntry to the underlying writer
+// as entry bundles.
+type BundleWriter struct {
+	w io.WriteCloser
+}
+
+// NewBundleWriter returns a BundleWriter with given underlying writer.
+func NewBundleWriter(w io.WriteCloser) BundleWriter {
+	return BundleWriter{w}
+}
+
+func (bw BundleWriter) Close() error {
+	return bw.w.Close()
+}
+
+// Write writes a single MerkleTreeLogEntry, with its length prefix, to the underlying
+// writer.
+func (bw BundleWriter) Write(merkleTreeCertificateEntry MerkleTreeCertEntry) error {
+	out, err := merkleTreeCertificateEntry.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return bw.writeLengthPrefixed(out)
+}
+
+// writeLengthPrefixed writes to the underlying writer a byte sequence with a two-byte length prefix.
+func (bw BundleWriter) writeLengthPrefixed(in []byte) error {
+	prefix := len(in)
+	if prefix > math.MaxUint16 {
+		return fmt.Errorf("input too long: %d bytes", len(in))
+	}
+	var prefixBytes [2]byte
+	binary.BigEndian.PutUint16(prefixBytes[:], uint16(prefix))
+	_, err := bw.w.Write(prefixBytes[:])
+	if err != nil {
+		return err
+	}
+
+	_, err = bw.w.Write(in)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BundleReader reads records of MerkleTreeCertEntry from the underlying reader in the
+// entry bundle format.
+type BundleReader struct {
+	r io.Reader
+}
+
+// NewBundleReader returns a new BundleReader.
+func NewBundleReader(r io.Reader) BundleReader {
+	return BundleReader{r}
+}
+
+// Read reads the bytes of a single entry from the underlying reader.
+//
+// Returns the parsed MerkleTreeCertEntry as well as its bytes.
+func (br BundleReader) Read() (MerkleTreeCertEntry, []byte, error) {
+	var buf [2]byte
+	_, err := io.ReadFull(br.r, buf[:])
+	if err != nil {
+		return MerkleTreeCertEntry{}, nil, err
+	}
+	entryLen := binary.BigEndian.Uint16(buf[:])
+	body := make([]byte, entryLen)
+	_, err = io.ReadFull(br.r, body)
+	if err != nil {
+		return MerkleTreeCertEntry{}, nil, err
+	}
+
+	mtce, err := unmarshalMTCE(body)
+	if err != nil {
+		return MerkleTreeCertEntry{}, nil, err
+	}
+
+	return mtce, body, nil
+}
+
+const typeNullEntry = 0
+const typeTBSCertEntry = 1
 
 // MerkleTreeCertEntry implements the corresponding structure from
 // https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
@@ -25,6 +111,8 @@ const TYPE_TBS_CERT_ENTRY = 1
 //	       /* May be extended with future types. */
 //	    }
 //	} MerkleTreeCertEntry;
+//
+// The zero value represents a null_entry.
 type MerkleTreeCertEntry struct {
 	Extensions []byte
 	Type       uint16
@@ -34,14 +122,14 @@ type MerkleTreeCertEntry struct {
 // Marshal returns the encoding of its receiver.
 //
 // Rejects unknown MerkleTreeCertEntryTypes.
-func (mtce *MerkleTreeCertEntry) Marshal() ([]byte, error) {
+func (mtce MerkleTreeCertEntry) Marshal() ([]byte, error) {
 	var builder cryptobyte.Builder
 	builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
 		child.AddBytes(mtce.Extensions)
 	})
 	builder.AddUint16(mtce.Type)
 	switch mtce.Type {
-	case TYPE_TBS_CERT_ENTRY:
+	case typeTBSCertEntry:
 		// We don't encode a length prefix for Value. Per the spec:
 		//      opaque tbs_cert_entry_data[N];
 		//      ...
@@ -51,7 +139,7 @@ func (mtce *MerkleTreeCertEntry) Marshal() ([]byte, error) {
 		// In other words, per TLS presentation syntax (https://datatracker.ietf.org/doc/html/rfc8446#section-3.4),
 		// this is a fixed-length vector of size N, where N is known externally.
 		builder.AddBytes(mtce.Value)
-	case TYPE_NULL_ENTRY:
+	case typeNullEntry:
 		if len(mtce.Value) != 0 {
 			return nil, fmt.Errorf("non-empty value for null_entry MerkleTreeCertEntry")
 		}
@@ -62,49 +150,47 @@ func (mtce *MerkleTreeCertEntry) Marshal() ([]byte, error) {
 	return builder.Bytes()
 }
 
-// Unmarshal parses a MerkleTreeCertEntry and returns it.
+// unmarshalMTCE parses a MerkleTreeCertEntry and returns it.
 //
 // Rejects unknown MerkleTreeCertEntryTypes.
-func Unmarshal(input []byte) (*MerkleTreeCertEntry, error) {
+func unmarshalMTCE(input []byte) (MerkleTreeCertEntry, error) {
 	val := cryptobyte.String(input)
 
 	var extensions cryptobyte.String
 	if !val.ReadUint16LengthPrefixed(&extensions) {
-		return nil, fmt.Errorf("malformed extensions")
+		return MerkleTreeCertEntry{}, fmt.Errorf("malformed extensions")
 	}
 
 	var typ uint16
 	if !val.ReadUint16(&typ) {
-		return nil, fmt.Errorf("malformed type")
+		return MerkleTreeCertEntry{}, fmt.Errorf("malformed type")
 	}
 
 	switch typ {
-	case TYPE_TBS_CERT_ENTRY:
-	case TYPE_NULL_ENTRY:
+	case typeTBSCertEntry:
+	case typeNullEntry:
 		if len(val) > 0 {
-			return nil, fmt.Errorf("null_entry with non-empty value")
+			return MerkleTreeCertEntry{}, fmt.Errorf("null_entry with non-empty value")
 		}
 	default:
-		return nil, fmt.Errorf("unknown MerkleTreeCertEntryType %d", typ)
+		return MerkleTreeCertEntry{}, fmt.Errorf("unknown MerkleTreeCertEntryType %d", typ)
 	}
 
 	// Per the spec, value is not length-prefixed. It's a fixed-length vector, where
 	// the length is known externally. So it just consists of the rest of the bytes.
-	return &MerkleTreeCertEntry{
+	return MerkleTreeCertEntry{
 		Extensions: []byte(extensions),
 		Type:       typ,
 		Value:      []byte(val),
 	}, nil
 }
 
-// TBSCertificateLogEntry represents the corresponding encoded structure from
-// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#log-entries.
-type TBSCertificateLogEntry []byte
-
-func TBSCertificateLogEntryFromX509(in []byte, hash crypto.Hash) (TBSCertificateLogEntry, error) {
+// FromX509 takes a DER-encoded X.509 certificate and transforms it into a TBSCertificateLogEntry,
+// then returns a MerkleTreeCertEntry wrapping that TBSCertificateLogEntry.
+func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	tbsCertificateDER, err := tbsDERFromCertDER(in)
 	if err != nil {
-		return nil, err
+		return MerkleTreeCertEntry{}, err
 	}
 
 	// https://datatracker.ietf.org/doc/html/rfc5280#page-117
@@ -134,7 +220,7 @@ func TBSCertificateLogEntryFromX509(in []byte, hash crypto.Hash) (TBSCertificate
 		var fieldTag asn1.Tag
 
 		if !tbsCertificateDER.ReadAnyASN1Element(&fieldInner, &fieldTag) {
-			return nil, fmt.Errorf("failed to read field")
+			return MerkleTreeCertEntry{}, fmt.Errorf("failed to read field")
 		}
 
 		switch i {
@@ -154,7 +240,7 @@ func TBSCertificateLogEntryFromX509(in []byte, hash crypto.Hash) (TBSCertificate
 	// length bytes, which should be included in the hash.
 	var spki cryptobyte.String
 	if !tbsCertificateDER.ReadASN1Element(&spki, asn1.SEQUENCE) {
-		return nil, fmt.Errorf("malformed subjectPublicKeyInfo")
+		return MerkleTreeCertEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 
 	h := hash.New()
@@ -165,11 +251,11 @@ func TBSCertificateLogEntryFromX509(in []byte, hash crypto.Hash) (TBSCertificate
 	// subjectPublicKeyAlgorithm.
 	var spkiInner cryptobyte.String
 	if !spki.ReadASN1(&spkiInner, asn1.SEQUENCE) {
-		return nil, fmt.Errorf("malformed subjectPublicKeyInfo")
+		return MerkleTreeCertEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 	var algID cryptobyte.String
 	if !spkiInner.ReadASN1(&algID, asn1.SEQUENCE) {
-		return nil, fmt.Errorf("malformed algorithmIdentifier")
+		return MerkleTreeCertEntry{}, fmt.Errorf("malformed algorithmIdentifier")
 	}
 
 	// Read the extensions.
@@ -181,7 +267,7 @@ func TBSCertificateLogEntryFromX509(in []byte, hash crypto.Hash) (TBSCertificate
 	var extensions cryptobyte.String
 	extensionsTag := asn1.Tag(3).Constructed().ContextSpecific()
 	if !tbsCertificateDER.ReadASN1(&extensions, extensionsTag) {
-		return nil, fmt.Errorf("error reading extensions")
+		return MerkleTreeCertEntry{}, fmt.Errorf("error reading extensions")
 	}
 
 	// TBSCertificateLogEntry ::= SEQUENCE {
@@ -215,7 +301,15 @@ func TBSCertificateLogEntryFromX509(in []byte, hash crypto.Hash) (TBSCertificate
 		child.AddBytes(extensions)
 	})
 
-	return builder.Bytes()
+	tbsCertificateLogEntryBytes, err := builder.Bytes()
+	if err != nil {
+		return MerkleTreeCertEntry{}, err
+	}
+
+	return MerkleTreeCertEntry{
+		Type:  typeTBSCertEntry,
+		Value: tbsCertificateLogEntryBytes,
+	}, nil
 }
 
 // tbsDERFromCertDER takes a Certificate object encoded as DER, and parses

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -30,69 +30,6 @@ import (
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
 
-// BundleBuilder appends a sequence of MTCLogEntry to a buffer as an entry bundle.
-type BundleBuilder struct {
-	builder cryptobyte.Builder
-}
-
-// NewBundleBuilder returns a BundleBuilder that appends to the given buffer. Like
-// cryptobyte.Builder, the slice will be reallocated if its capacity is exceeded.
-// Use Bytes to get the final buffer.
-func NewBundleBuilder(buf []byte) *BundleBuilder {
-	return &BundleBuilder{*cryptobyte.NewBuilder(buf)}
-}
-
-func (b *BundleBuilder) Bytes() ([]byte, error) {
-	return b.builder.Bytes()
-}
-
-// Add appends a single MTCLogEntry, with its length prefix, to the builder.
-func (b *BundleBuilder) Add(mtcLogEntry MTCLogEntry) {
-	out, err := mtcLogEntry.Marshal()
-	if err != nil {
-		b.builder.SetError(err)
-		return
-	}
-
-	b.builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-		child.AddBytes(out)
-	})
-}
-
-// BundleReader reads records of MTCLogEntry from the underlying buffer in the
-// entry bundle format.
-type BundleReader struct {
-	reader cryptobyte.String
-}
-
-// NewBundleReader returns a new BundleReader.
-func NewBundleReader(buf []byte) *BundleReader {
-	return &BundleReader{cryptobyte.String(buf)}
-}
-
-// Read reads the bytes of a single entry.
-//
-// Returns the parsed MTCLogEntry as well as its bytes, both of which
-// reference the same memory as the original buffer.
-//
-// Returns MTCLogEntry{}, nil, io.EOF when there is no more to read.
-func (br *BundleReader) Read() (*MTCLogEntry, []byte, error) {
-	if br.reader.Empty() {
-		return nil, nil, io.EOF
-	}
-	var body cryptobyte.String
-	if !br.reader.ReadUint16LengthPrefixed(&body) {
-		return nil, nil, fmt.Errorf("malformed length")
-	}
-
-	mtcle, err := unmarshalMTCLE(body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return mtcle, body, nil
-}
-
 const typeNullEntry = 0
 const typeTBSCertEntry = 1
 
@@ -349,4 +286,67 @@ func FromX509(in []byte, hash crypto.Hash) (*MTCLogEntry, error) {
 		typ:   typeTBSCertEntry,
 		value: tbsCertificateLogEntryBytes,
 	}, nil
+}
+
+// BundleBuilder appends a sequence of MTCLogEntry to a buffer as an entry bundle.
+type BundleBuilder struct {
+	builder cryptobyte.Builder
+}
+
+// NewBundleBuilder returns a BundleBuilder that appends to the given buffer. Like
+// cryptobyte.Builder, the slice will be reallocated if its capacity is exceeded.
+// Use Bytes to get the final buffer.
+func NewBundleBuilder(buf []byte) *BundleBuilder {
+	return &BundleBuilder{*cryptobyte.NewBuilder(buf)}
+}
+
+func (b *BundleBuilder) Bytes() ([]byte, error) {
+	return b.builder.Bytes()
+}
+
+// Add appends a single MTCLogEntry, with its length prefix, to the builder.
+func (b *BundleBuilder) Add(mtcLogEntry MTCLogEntry) {
+	out, err := mtcLogEntry.Marshal()
+	if err != nil {
+		b.builder.SetError(err)
+		return
+	}
+
+	b.builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes(out)
+	})
+}
+
+// BundleReader reads records of MTCLogEntry from the underlying buffer in the
+// entry bundle format.
+type BundleReader struct {
+	reader cryptobyte.String
+}
+
+// NewBundleReader returns a new BundleReader.
+func NewBundleReader(buf []byte) *BundleReader {
+	return &BundleReader{cryptobyte.String(buf)}
+}
+
+// Read reads the bytes of a single entry.
+//
+// Returns the parsed MTCLogEntry as well as its bytes, both of which
+// reference the same memory as the original buffer.
+//
+// Returns MTCLogEntry{}, nil, io.EOF when there is no more to read.
+func (br *BundleReader) Read() (*MTCLogEntry, []byte, error) {
+	if br.reader.Empty() {
+		return nil, nil, io.EOF
+	}
+	var body cryptobyte.String
+	if !br.reader.ReadUint16LengthPrefixed(&body) {
+		return nil, nil, fmt.Errorf("malformed length")
+	}
+
+	mtcle, err := unmarshalMTCLE(body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return mtcle, body, nil
 }

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -47,8 +47,8 @@ func (b *BundleBuilder) Bytes() ([]byte, error) {
 }
 
 // Add appends a single MTCLogEntry, with its length prefix, to the builder.
-func (b *BundleBuilder) Add(merkleTreeCertificateEntry MTCLogEntry) {
-	out, err := merkleTreeCertificateEntry.Marshal()
+func (b *BundleBuilder) Add(mtcLogEntry MTCLogEntry) {
+	out, err := mtcLogEntry.Marshal()
 	if err != nil {
 		b.b.SetError(err)
 		return

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -1,22 +1,23 @@
-// Package entry defines types related to TBSCertificateLogEntry and MerkleTreeCertEntry from
+// Package entry defines types related to TBSCertificateLogEntry and MTCLogEntry from
 // https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries,
 // and the entry bundle encoding from https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries
 //
 // The concepts fit together like so:
 //
-// Entry bundles contain MerkleTreeCertEntry. MerkleTreeCertEntry contains (typically) TBSCertificateLogEntry.
+// Entry bundles contain MTCLogEntry. MTCLogEntry contains (typically) TBSCertificateLogEntry.
 //
 // TBSCertificateLogEntry is part of the X.509 layer. It will be used to build certificates
 // (TODO: implement TBSCertificateLogEntry.ToX509).
 //
-// MerkleTreeCertEntry is part of the Merkle Tree layer and is what gets hashed. It provides type switching
+// MTCLogEntry is part of the Merkle tree layer and is what gets hashed. It provides type switching
 // (needed for null_entry) and extensibility.
 //
 // Entry bundles are part of the tile storage layer. They provide a simple length-prefixed framing so that
-// MerkleTreeCertEntries can be concatenated unambiguously.
+// MTCLogEntries can be concatenated unambiguously.
 //
-// Note that neither TBSCertificateLogEntry nor MerkleTreeCertEntry carries its own length, since they will
-// always be wrapped or converted into a format that has length information: entry bundles or X.509 certificate.
+// Note that neither TBSCertificateLogEntry nor MTCLogEntry carries its own length, since they will
+// always be wrapped or converted into a format that has length information: an entry bundle or an
+// X.509 certificate.
 package entry
 
 import (
@@ -29,7 +30,7 @@ import (
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
 
-// BundleBuilder appends a sequence of MerkleTreeCertEntry to a buffer as an entry bundle.
+// BundleBuilder appends a sequence of MTCLogEntry to a buffer as an entry bundle.
 type BundleBuilder struct {
 	b cryptobyte.Builder
 }
@@ -45,8 +46,8 @@ func (b *BundleBuilder) Bytes() ([]byte, error) {
 	return b.b.Bytes()
 }
 
-// Add appends a single MerkleTreeCertEntry, with its length prefix, to the builder.
-func (b *BundleBuilder) Add(merkleTreeCertificateEntry MerkleTreeCertEntry) {
+// Add appends a single MTCLogEntry, with its length prefix, to the builder.
+func (b *BundleBuilder) Add(merkleTreeCertificateEntry MTCLogEntry) {
 	out, err := merkleTreeCertificateEntry.Marshal()
 	if err != nil {
 		b.b.SetError(err)
@@ -58,7 +59,7 @@ func (b *BundleBuilder) Add(merkleTreeCertificateEntry MerkleTreeCertEntry) {
 	})
 }
 
-// BundleReader reads records of MerkleTreeCertEntry from the underlying buffer in the
+// BundleReader reads records of MTCLogEntry from the underlying buffer in the
 // entry bundle format.
 type BundleReader struct {
 	r cryptobyte.String
@@ -71,22 +72,22 @@ func NewBundleReader(buf []byte) *BundleReader {
 
 // Read reads the bytes of a single entry.
 //
-// Returns the parsed MerkleTreeCertEntry as well as its bytes, both of which
+// Returns the parsed MTCLogEntry as well as its bytes, both of which
 // reference the same memory as the original buffer.
 //
-// Returns MerkleTreeCertEntry{}, nil, io.EOF when there is no more to read.
-func (br *BundleReader) Read() (MerkleTreeCertEntry, []byte, error) {
+// Returns MTCLogEntry{}, nil, io.EOF when there is no more to read.
+func (br *BundleReader) Read() (MTCLogEntry, []byte, error) {
 	if br.r.Empty() {
-		return MerkleTreeCertEntry{}, nil, io.EOF
+		return MTCLogEntry{}, nil, io.EOF
 	}
 	var body cryptobyte.String
 	if !br.r.ReadUint16LengthPrefixed(&body) {
-		return MerkleTreeCertEntry{}, nil, fmt.Errorf("malformed length")
+		return MTCLogEntry{}, nil, fmt.Errorf("malformed length")
 	}
 
 	mtce, err := unmarshalMTCE(body)
 	if err != nil {
-		return MerkleTreeCertEntry{}, nil, err
+		return MTCLogEntry{}, nil, err
 	}
 
 	return mtce, body, nil
@@ -95,28 +96,28 @@ func (br *BundleReader) Read() (MerkleTreeCertEntry, []byte, error) {
 const typeNullEntry = 0
 const typeTBSCertEntry = 1
 
-// MerkleTreeCertEntry implements the corresponding structure from
+// MTCLogEntry implements the corresponding structure from
 // https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
 //
 //	struct {
-//	    MerkleTreeCertEntryExtension extensions<0..2^16-1>;
-//	    MerkleTreeCertEntryType type;
+//	    MTCLogEntryExtension extensions<0..2^16-1>;
+//	    MTCLogEntryType type;
 //	    select (type) {
 //	       case null_entry: Empty;
 //	       case tbs_cert_entry: opaque tbs_cert_entry_data[N];
 //	       /* May be extended with future types. */
 //	    }
-//	} MerkleTreeCertEntry;
+//	} MTCLogEntry;
 //
 // The zero value represents a null_entry.
-type MerkleTreeCertEntry struct {
+type MTCLogEntry struct {
 	Extensions []byte
 	Type       uint16
 	Value      []byte
 }
 
 // TBS returns the TBSCertificateLogEntry bytes if Type is tbs_cert_entry, or nil otherwise.
-func (mtce MerkleTreeCertEntry) TBS() []byte {
+func (mtce MTCLogEntry) TBS() []byte {
 	if mtce.Type == typeTBSCertEntry {
 		return mtce.Value
 	}
@@ -125,8 +126,8 @@ func (mtce MerkleTreeCertEntry) TBS() []byte {
 
 // Marshal returns the encoding of its receiver.
 //
-// Rejects unknown MerkleTreeCertEntryTypes.
-func (mtce MerkleTreeCertEntry) Marshal() ([]byte, error) {
+// Rejects unknown MTCLogEntryTypes.
+func (mtce MTCLogEntry) Marshal() ([]byte, error) {
 	var builder cryptobyte.Builder
 	builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
 		child.AddBytes(mtce.Extensions)
@@ -145,44 +146,44 @@ func (mtce MerkleTreeCertEntry) Marshal() ([]byte, error) {
 		builder.AddBytes(mtce.Value)
 	case typeNullEntry:
 		if len(mtce.Value) != 0 {
-			return nil, fmt.Errorf("non-empty value for null_entry MerkleTreeCertEntry")
+			return nil, fmt.Errorf("non-empty value for null_entry MTCLogEntry")
 		}
 		// Append nothing; the encoding of the null entry is Empty.
 	default:
-		return nil, fmt.Errorf("unknown MerkleTreeCertEntryType %d", mtce.Type)
+		return nil, fmt.Errorf("unknown MTCLogEntryType %d", mtce.Type)
 	}
 	return builder.Bytes()
 }
 
-// unmarshalMTCE parses a MerkleTreeCertEntry and returns it.
+// unmarshalMTCE parses a MTCLogEntry and returns it.
 //
-// Rejects unknown MerkleTreeCertEntryTypes.
-func unmarshalMTCE(input []byte) (MerkleTreeCertEntry, error) {
+// Rejects unknown MTCLogEntryType.
+func unmarshalMTCE(input []byte) (MTCLogEntry, error) {
 	val := cryptobyte.String(input)
 
 	var extensions cryptobyte.String
 	if !val.ReadUint16LengthPrefixed(&extensions) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("malformed extensions")
+		return MTCLogEntry{}, fmt.Errorf("malformed extensions")
 	}
 
 	var typ uint16
 	if !val.ReadUint16(&typ) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("malformed type")
+		return MTCLogEntry{}, fmt.Errorf("malformed type")
 	}
 
 	switch typ {
 	case typeTBSCertEntry:
 	case typeNullEntry:
 		if len(val) > 0 {
-			return MerkleTreeCertEntry{}, fmt.Errorf("null_entry with non-empty value")
+			return MTCLogEntry{}, fmt.Errorf("null_entry with non-empty value")
 		}
 	default:
-		return MerkleTreeCertEntry{}, fmt.Errorf("unknown MerkleTreeCertEntryType %d", typ)
+		return MTCLogEntry{}, fmt.Errorf("unknown MTCLogEntryType %d", typ)
 	}
 
 	// Per the spec, value is not length-prefixed. It's a fixed-length vector, where
 	// the length is known externally. So it just consists of the rest of the bytes.
-	return MerkleTreeCertEntry{
+	return MTCLogEntry{
 		Extensions: []byte(extensions),
 		Type:       typ,
 		Value:      []byte(val),
@@ -190,8 +191,8 @@ func unmarshalMTCE(input []byte) (MerkleTreeCertEntry, error) {
 }
 
 // FromX509 takes a DER-encoded X.509 certificate and transforms it into a TBSCertificateLogEntry,
-// then returns a MerkleTreeCertEntry wrapping that TBSCertificateLogEntry.
-func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
+// then returns a MTCLogEntry wrapping that TBSCertificateLogEntry.
+func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 	var inner cryptobyte.String
 	input := cryptobyte.String(in)
 
@@ -206,15 +207,15 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	//		    serialNumber         CertificateSerialNumber,
 	//	     ...
 	if !input.ReadASN1(&inner, asn1.SEQUENCE) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read outer sequence")
+		return MTCLogEntry{}, fmt.Errorf("failed to read outer sequence")
 	}
 	if !input.Empty() {
-		return MerkleTreeCertEntry{}, fmt.Errorf("extra bytes at end")
+		return MTCLogEntry{}, fmt.Errorf("extra bytes at end")
 	}
 
 	var tbsCertificate cryptobyte.String
 	if !inner.ReadASN1(&tbsCertificate, asn1.SEQUENCE) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read tbsCertificate")
+		return MTCLogEntry{}, fmt.Errorf("failed to read tbsCertificate")
 	}
 
 	// https://datatracker.ietf.org/doc/html/rfc5280#page-117
@@ -236,12 +237,12 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
 	var version cryptobyte.String
 	if !tbsCertificate.ReadASN1(&version, asn1.Tag(0).Constructed().ContextSpecific()) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read version")
+		return MTCLogEntry{}, fmt.Errorf("failed to read version")
 	}
 	// Version should always be v3, which is represented as an ASN.1 INTEGER 2.
 	// That's tag 2, length 1, value 2.
 	if !bytes.Equal(version, []byte{2, 1, 2}) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("invalid X.509 version")
+		return MTCLogEntry{}, fmt.Errorf("invalid X.509 version")
 	}
 	var fields []cryptobyte.String
 	for i := range 5 {
@@ -249,7 +250,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 		var fieldTag asn1.Tag
 
 		if !tbsCertificate.ReadAnyASN1Element(&fieldElement, &fieldTag) {
-			return MerkleTreeCertEntry{}, fmt.Errorf("failed to read field")
+			return MTCLogEntry{}, fmt.Errorf("failed to read field")
 		}
 
 		switch i {
@@ -269,7 +270,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// length bytes, which should be included in the hash.
 	var spki cryptobyte.String
 	if !tbsCertificate.ReadASN1Element(&spki, asn1.SEQUENCE) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
+		return MTCLogEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 
 	h := hash.New()
@@ -280,11 +281,11 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// subjectPublicKeyAlgorithm.
 	var spkiInner cryptobyte.String
 	if !spki.ReadASN1(&spkiInner, asn1.SEQUENCE) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
+		return MTCLogEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 	var algID cryptobyte.String
 	if !spkiInner.ReadASN1Element(&algID, asn1.SEQUENCE) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("malformed algorithmIdentifier")
+		return MTCLogEntry{}, fmt.Errorf("malformed algorithmIdentifier")
 	}
 
 	// Read the extensions.
@@ -296,11 +297,11 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	var extensions cryptobyte.String
 	extensionsTag := asn1.Tag(3).Constructed().ContextSpecific()
 	if !tbsCertificate.ReadASN1Element(&extensions, extensionsTag) {
-		return MerkleTreeCertEntry{}, fmt.Errorf("error reading extensions")
+		return MTCLogEntry{}, fmt.Errorf("error reading extensions")
 	}
 
 	if !tbsCertificate.Empty() {
-		return MerkleTreeCertEntry{}, fmt.Errorf("extra bytes at end")
+		return MTCLogEntry{}, fmt.Errorf("extra bytes at end")
 	}
 
 	// TBSCertificateLogEntry ::= SEQUENCE {
@@ -341,10 +342,10 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 
 	tbsCertificateLogEntryBytes, err := builder.Bytes()
 	if err != nil {
-		return MerkleTreeCertEntry{}, err
+		return MTCLogEntry{}, err
 	}
 
-	return MerkleTreeCertEntry{
+	return MTCLogEntry{
 		Type:  typeTBSCertEntry,
 		Value: tbsCertificateLogEntryBytes,
 	}, nil

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -63,12 +63,14 @@ func (mtcle *MTCLogEntry) TBS() []byte {
 
 // Marshal returns the encoding of its receiver.
 //
-// Rejects unknown MTCLogEntryTypes.
+// Rejects unknown MTCLogEntryTypes. Rejects non-empty MTCLogEntry.extensions.
 func (mtcle *MTCLogEntry) Marshal() ([]byte, error) {
 	var builder cryptobyte.Builder
-	builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-		child.AddBytes(mtcle.extensions)
-	})
+	// Extensions are always empty in this implementation.
+	if len(mtcle.extensions) != 0 {
+		builder.SetError(fmt.Errorf("extensions not supported"))
+	}
+	builder.AddUint16(0)
 	builder.AddUint16(mtcle.typ)
 	switch mtcle.typ {
 	case typeTBSCertEntry:
@@ -300,6 +302,7 @@ func NewBundleBuilder(buf []byte) *BundleBuilder {
 	return &BundleBuilder{*cryptobyte.NewBuilder(buf)}
 }
 
+// Bytes returns the bundle's bytes.
 func (b *BundleBuilder) Bytes() ([]byte, error) {
 	return b.builder.Bytes()
 }
@@ -328,13 +331,13 @@ func NewBundleReader(buf []byte) *BundleReader {
 	return &BundleReader{cryptobyte.String(buf)}
 }
 
-// Read reads the bytes of a single entry.
+// ReadEntry reads the bytes of a single entry.
 //
 // Returns the parsed MTCLogEntry as well as its bytes, both of which
 // reference the same memory as the original buffer.
 //
 // Returns MTCLogEntry{}, nil, io.EOF when there is no more to read.
-func (br *BundleReader) Read() (*MTCLogEntry, []byte, error) {
+func (br *BundleReader) ReadEntry() (*MTCLogEntry, []byte, error) {
 	if br.reader.Empty() {
 		return nil, nil, io.EOF
 	}

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -32,7 +32,7 @@ import (
 
 // BundleBuilder appends a sequence of MTCLogEntry to a buffer as an entry bundle.
 type BundleBuilder struct {
-	b cryptobyte.Builder
+	builder cryptobyte.Builder
 }
 
 // NewBundleBuilder returns a BundleBuilder that appends to the given buffer. Like
@@ -43,18 +43,18 @@ func NewBundleBuilder(buf []byte) *BundleBuilder {
 }
 
 func (b *BundleBuilder) Bytes() ([]byte, error) {
-	return b.b.Bytes()
+	return b.builder.Bytes()
 }
 
 // Add appends a single MTCLogEntry, with its length prefix, to the builder.
 func (b *BundleBuilder) Add(mtcLogEntry MTCLogEntry) {
 	out, err := mtcLogEntry.Marshal()
 	if err != nil {
-		b.b.SetError(err)
+		b.builder.SetError(err)
 		return
 	}
 
-	b.b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+	b.builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
 		child.AddBytes(out)
 	})
 }
@@ -62,7 +62,7 @@ func (b *BundleBuilder) Add(mtcLogEntry MTCLogEntry) {
 // BundleReader reads records of MTCLogEntry from the underlying buffer in the
 // entry bundle format.
 type BundleReader struct {
-	r cryptobyte.String
+	reader cryptobyte.String
 }
 
 // NewBundleReader returns a new BundleReader.
@@ -76,18 +76,18 @@ func NewBundleReader(buf []byte) *BundleReader {
 // reference the same memory as the original buffer.
 //
 // Returns MTCLogEntry{}, nil, io.EOF when there is no more to read.
-func (br *BundleReader) Read() (MTCLogEntry, []byte, error) {
-	if br.r.Empty() {
-		return MTCLogEntry{}, nil, io.EOF
+func (br *BundleReader) Read() (*MTCLogEntry, []byte, error) {
+	if br.reader.Empty() {
+		return nil, nil, io.EOF
 	}
 	var body cryptobyte.String
-	if !br.r.ReadUint16LengthPrefixed(&body) {
-		return MTCLogEntry{}, nil, fmt.Errorf("malformed length")
+	if !br.reader.ReadUint16LengthPrefixed(&body) {
+		return nil, nil, fmt.Errorf("malformed length")
 	}
 
 	mtcle, err := unmarshalMTCLE(body)
 	if err != nil {
-		return MTCLogEntry{}, nil, err
+		return nil, nil, err
 	}
 
 	return mtcle, body, nil
@@ -111,15 +111,15 @@ const typeTBSCertEntry = 1
 //
 // The zero value represents a null_entry.
 type MTCLogEntry struct {
-	Extensions []byte
-	Type       uint16
-	Value      []byte
+	extensions []byte
+	typ        uint16
+	value      []byte
 }
 
 // TBS returns the TBSCertificateLogEntry bytes if Type is tbs_cert_entry, or nil otherwise.
 func (mtcle MTCLogEntry) TBS() []byte {
-	if mtcle.Type == typeTBSCertEntry {
-		return mtcle.Value
+	if mtcle.typ == typeTBSCertEntry {
+		return mtcle.value
 	}
 	return nil
 }
@@ -130,10 +130,10 @@ func (mtcle MTCLogEntry) TBS() []byte {
 func (mtcle MTCLogEntry) Marshal() ([]byte, error) {
 	var builder cryptobyte.Builder
 	builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-		child.AddBytes(mtcle.Extensions)
+		child.AddBytes(mtcle.extensions)
 	})
-	builder.AddUint16(mtcle.Type)
-	switch mtcle.Type {
+	builder.AddUint16(mtcle.typ)
+	switch mtcle.typ {
 	case typeTBSCertEntry:
 		// We don't encode a length prefix for Value. Per the spec:
 		//      opaque tbs_cert_entry_data[N];
@@ -143,14 +143,14 @@ func (mtcle MTCLogEntry) Marshal() ([]byte, error) {
 		//
 		// In other words, per TLS presentation syntax (https://datatracker.ietf.org/doc/html/rfc8446#section-3.4),
 		// this is a fixed-length vector of size N, where N is known externally.
-		builder.AddBytes(mtcle.Value)
+		builder.AddBytes(mtcle.value)
 	case typeNullEntry:
-		if len(mtcle.Value) != 0 {
+		if len(mtcle.value) != 0 {
 			return nil, fmt.Errorf("non-empty value for null_entry MTCLogEntry")
 		}
 		// Append nothing; the encoding of the null entry is Empty.
 	default:
-		return nil, fmt.Errorf("unknown MTCLogEntryType %d", mtcle.Type)
+		return nil, fmt.Errorf("unknown MTCLogEntryType %d", mtcle.typ)
 	}
 	return builder.Bytes()
 }
@@ -158,41 +158,41 @@ func (mtcle MTCLogEntry) Marshal() ([]byte, error) {
 // unmarshalMTCLE parses a MTCLogEntry and returns it.
 //
 // Rejects unknown MTCLogEntryType.
-func unmarshalMTCLE(input []byte) (MTCLogEntry, error) {
+func unmarshalMTCLE(input []byte) (*MTCLogEntry, error) {
 	val := cryptobyte.String(input)
 
 	var extensions cryptobyte.String
 	if !val.ReadUint16LengthPrefixed(&extensions) {
-		return MTCLogEntry{}, fmt.Errorf("malformed extensions")
+		return nil, fmt.Errorf("malformed extensions")
 	}
 
 	var typ uint16
 	if !val.ReadUint16(&typ) {
-		return MTCLogEntry{}, fmt.Errorf("malformed type")
+		return nil, fmt.Errorf("malformed type")
 	}
 
 	switch typ {
 	case typeTBSCertEntry:
 	case typeNullEntry:
 		if len(val) > 0 {
-			return MTCLogEntry{}, fmt.Errorf("null_entry with non-empty value")
+			return nil, fmt.Errorf("null_entry with non-empty value")
 		}
 	default:
-		return MTCLogEntry{}, fmt.Errorf("unknown MTCLogEntryType %d", typ)
+		return nil, fmt.Errorf("unknown MTCLogEntryType %d", typ)
 	}
 
 	// Per the spec, value is not length-prefixed. It's a fixed-length vector, where
 	// the length is known externally. So it just consists of the rest of the bytes.
-	return MTCLogEntry{
-		Extensions: []byte(extensions),
-		Type:       typ,
-		Value:      []byte(val),
+	return &MTCLogEntry{
+		extensions: []byte(extensions),
+		typ:        typ,
+		value:      []byte(val),
 	}, nil
 }
 
 // FromX509 takes a DER-encoded X.509 certificate and transforms it into a TBSCertificateLogEntry,
 // then returns a MTCLogEntry wrapping that TBSCertificateLogEntry.
-func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
+func FromX509(in []byte, hash crypto.Hash) (*MTCLogEntry, error) {
 	var inner cryptobyte.String
 	input := cryptobyte.String(in)
 
@@ -207,15 +207,15 @@ func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 	//		    serialNumber         CertificateSerialNumber,
 	//	     ...
 	if !input.ReadASN1(&inner, asn1.SEQUENCE) {
-		return MTCLogEntry{}, fmt.Errorf("failed to read outer sequence")
+		return nil, fmt.Errorf("failed to read outer sequence")
 	}
 	if !input.Empty() {
-		return MTCLogEntry{}, fmt.Errorf("extra bytes at end")
+		return nil, fmt.Errorf("extra bytes at end")
 	}
 
 	var tbsCertificate cryptobyte.String
 	if !inner.ReadASN1(&tbsCertificate, asn1.SEQUENCE) {
-		return MTCLogEntry{}, fmt.Errorf("failed to read tbsCertificate")
+		return nil, fmt.Errorf("failed to read tbsCertificate")
 	}
 
 	// https://datatracker.ietf.org/doc/html/rfc5280#page-117
@@ -237,12 +237,12 @@ func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 	// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
 	var version cryptobyte.String
 	if !tbsCertificate.ReadASN1(&version, asn1.Tag(0).Constructed().ContextSpecific()) {
-		return MTCLogEntry{}, fmt.Errorf("failed to read version")
+		return nil, fmt.Errorf("failed to read version")
 	}
 	// Version should always be v3, which is represented as an ASN.1 INTEGER 2.
 	// That's tag 2, length 1, value 2.
 	if !bytes.Equal(version, []byte{2, 1, 2}) {
-		return MTCLogEntry{}, fmt.Errorf("invalid X.509 version")
+		return nil, fmt.Errorf("invalid X.509 version")
 	}
 	var fields []cryptobyte.String
 	for i := range 5 {
@@ -250,7 +250,7 @@ func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 		var fieldTag asn1.Tag
 
 		if !tbsCertificate.ReadAnyASN1Element(&fieldElement, &fieldTag) {
-			return MTCLogEntry{}, fmt.Errorf("failed to read field")
+			return nil, fmt.Errorf("failed to read field")
 		}
 
 		switch i {
@@ -270,7 +270,7 @@ func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 	// length bytes, which should be included in the hash.
 	var spki cryptobyte.String
 	if !tbsCertificate.ReadASN1Element(&spki, asn1.SEQUENCE) {
-		return MTCLogEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
+		return nil, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 
 	h := hash.New()
@@ -281,11 +281,11 @@ func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 	// subjectPublicKeyAlgorithm.
 	var spkiInner cryptobyte.String
 	if !spki.ReadASN1(&spkiInner, asn1.SEQUENCE) {
-		return MTCLogEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
+		return nil, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 	var algID cryptobyte.String
 	if !spkiInner.ReadASN1Element(&algID, asn1.SEQUENCE) {
-		return MTCLogEntry{}, fmt.Errorf("malformed algorithmIdentifier")
+		return nil, fmt.Errorf("malformed algorithmIdentifier")
 	}
 
 	// Read the extensions.
@@ -297,11 +297,11 @@ func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 	var extensions cryptobyte.String
 	extensionsTag := asn1.Tag(3).Constructed().ContextSpecific()
 	if !tbsCertificate.ReadASN1Element(&extensions, extensionsTag) {
-		return MTCLogEntry{}, fmt.Errorf("error reading extensions")
+		return nil, fmt.Errorf("error reading extensions")
 	}
 
 	if !tbsCertificate.Empty() {
-		return MTCLogEntry{}, fmt.Errorf("extra bytes at end")
+		return nil, fmt.Errorf("extra bytes at end")
 	}
 
 	// TBSCertificateLogEntry ::= SEQUENCE {
@@ -342,11 +342,11 @@ func FromX509(in []byte, hash crypto.Hash) (MTCLogEntry, error) {
 
 	tbsCertificateLogEntryBytes, err := builder.Bytes()
 	if err != nil {
-		return MTCLogEntry{}, err
+		return nil, err
 	}
 
-	return MTCLogEntry{
-		Type:  typeTBSCertEntry,
-		Value: tbsCertificateLogEntryBytes,
+	return &MTCLogEntry{
+		typ:   typeTBSCertEntry,
+		value: tbsCertificateLogEntryBytes,
 	}, nil
 }

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -1,0 +1,248 @@
+// Package entry defines types for the MerkleTreeCertEntry structure in
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
+package entry
+
+import (
+	"crypto"
+	"fmt"
+
+	"github.com/zmap/zcrypto/cryptobyte"
+	"github.com/zmap/zcrypto/cryptobyte/asn1"
+)
+
+const TYPE_NULL_ENTRY = 0
+const TYPE_TBS_CERT_ENTRY = 1
+
+// MerkleTreeCertEntry implements the corresponding structure from
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
+//
+//	struct {
+//	    MerkleTreeCertEntryExtension extensions<0..2^16-1>;
+//	    MerkleTreeCertEntryType type;
+//	    select (type) {
+//	       case null_entry: Empty;
+//	       case tbs_cert_entry: opaque tbs_cert_entry_data[N];
+//	       /* May be extended with future types. */
+//	    }
+//	} MerkleTreeCertEntry;
+type MerkleTreeCertEntry struct {
+	Extensions []byte
+	Type       uint16
+	Value      []byte
+}
+
+// Marshal returns the encoding of its receiver.
+//
+// Rejects unknown MerkleTreeCertEntryTypes.
+func (mtce *MerkleTreeCertEntry) Marshal() ([]byte, error) {
+	var builder cryptobyte.Builder
+	builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes(mtce.Extensions)
+	})
+	builder.AddUint16(mtce.Type)
+	switch mtce.Type {
+	case TYPE_TBS_CERT_ENTRY:
+		// We don't encode a length prefix for Value. Per the spec:
+		//      opaque tbs_cert_entry_data[N];
+		//      ...
+		//      When type is tbs_cert_entry, N is the number of bytes needed to
+		//      consume the rest of the input.
+		//
+		// In other words, per TLS presentation syntax (https://datatracker.ietf.org/doc/html/rfc8446#section-3.4),
+		// this is a fixed-length vector of size N, where N is known externally.
+		builder.AddBytes(mtce.Value)
+	case TYPE_NULL_ENTRY:
+		if len(mtce.Value) != 0 {
+			return nil, fmt.Errorf("non-empty value for null_entry MerkleTreeCertEntry")
+		}
+		// Append nothing; the encoding of the null entry is Empty.
+	default:
+		return nil, fmt.Errorf("unknown MerkleTreeCertEntryType %d", mtce.Type)
+	}
+	return builder.Bytes()
+}
+
+// Unmarshal parses a MerkleTreeCertEntry and returns it.
+//
+// Rejects unknown MerkleTreeCertEntryTypes.
+func Unmarshal(input []byte) (*MerkleTreeCertEntry, error) {
+	val := cryptobyte.String(input)
+
+	var extensions cryptobyte.String
+	if !val.ReadUint16LengthPrefixed(&extensions) {
+		return nil, fmt.Errorf("malformed extensions")
+	}
+
+	var typ uint16
+	if !val.ReadUint16(&typ) {
+		return nil, fmt.Errorf("malformed type")
+	}
+
+	switch typ {
+	case TYPE_TBS_CERT_ENTRY:
+	case TYPE_NULL_ENTRY:
+		if len(val) > 0 {
+			return nil, fmt.Errorf("null_entry with non-empty value")
+		}
+	default:
+		return nil, fmt.Errorf("unknown MerkleTreeCertEntryType %d", typ)
+	}
+
+	// Per the spec, value is not length-prefixed. It's a fixed-length vector, where
+	// the length is known externally. So it just consists of the rest of the bytes.
+	return &MerkleTreeCertEntry{
+		Extensions: []byte(extensions),
+		Type:       typ,
+		Value:      []byte(val),
+	}, nil
+}
+
+// TBSCertificateLogEntry represents the corresponding encoded structure from
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#log-entries.
+type TBSCertificateLogEntry []byte
+
+func TBSCertificateLogEntryFromX509(in []byte, hash crypto.Hash) (TBSCertificateLogEntry, error) {
+	tbsCertificateDER, err := tbsDERFromCertDER(in)
+	if err != nil {
+		return nil, err
+	}
+
+	// https://datatracker.ietf.org/doc/html/rfc5280#page-117
+	// TBSCertificate  ::=  SEQUENCE  {
+	//      version         [0]  Version DEFAULT v1,
+	//      serialNumber         CertificateSerialNumber,
+	//      signature            AlgorithmIdentifier,
+	//      issuer               Name,
+	//      validity             Validity,
+	//      subject              Name,
+	//      subjectPublicKeyInfo SubjectPublicKeyInfo,
+	//      issuerUniqueID  [1]  IMPLICIT UniqueIdentifier OPTIONAL,
+	//      					 -- If present, version MUST be v2 or v3
+	//      subjectUniqueID [2]  IMPLICIT UniqueIdentifier OPTIONAL,
+	//      					 -- If present, version MUST be v2 or v3
+	//      extensions      [3]  Extensions OPTIONAL
+	//      					 -- If present, version MUST be v3 --  }
+	//
+	// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
+	type pair struct {
+		tag   asn1.Tag
+		value cryptobyte.String
+	}
+	var fields []pair
+	for i := range 6 {
+		var fieldInner cryptobyte.String
+		var fieldTag asn1.Tag
+
+		if !tbsCertificateDER.ReadAnyASN1Element(&fieldInner, &fieldTag) {
+			return nil, fmt.Errorf("failed to read field")
+		}
+
+		switch i {
+		case 0, 3, 4, 5: // version, issuer, validity, subject from the TBSCertificate.
+			fields = append(fields, pair{fieldTag, fieldInner})
+		}
+	}
+
+	// Read and transform SubjectPublicKeyInfo from the input.
+	//
+	// It gets written as two fields in the output:
+	//    subjectPublicKeyAlgorithm AlgorithmIdentifier{PUBLIC-KEY,
+	//								{PublicKeyAlgorithms}},
+	//    subjectPublicKeyInfoHash  OCTET STRING,
+	//
+	// Use ReadASN1Element, not ReadASN1, so spki contains the tag and
+	// length bytes, which should be included in the hash.
+	var spki cryptobyte.String
+	if !tbsCertificateDER.ReadASN1Element(&spki, asn1.SEQUENCE) {
+		return nil, fmt.Errorf("malformed subjectPublicKeyInfo")
+	}
+
+	h := hash.New()
+	h.Write(spki)
+	spkiHash := h.Sum(nil)
+
+	// Remove the tag and length from subjectPublicKeyInfo and then parse
+	// subjectPublicKeyAlgorithm.
+	var spkiInner cryptobyte.String
+	if !spki.ReadASN1(&spkiInner, asn1.SEQUENCE) {
+		return nil, fmt.Errorf("malformed subjectPublicKeyInfo")
+	}
+	var algID cryptobyte.String
+	if !spkiInner.ReadASN1(&algID, asn1.SEQUENCE) {
+		return nil, fmt.Errorf("malformed algorithmIdentifier")
+	}
+
+	// Read the extensions.
+	//
+	// Note that we've ignored issuerUniqueID and subjectUniqueID, which are OPTIONAL and
+	// forbidden by the BRs. Since those fields have encoding instructions ([1] and [2]),
+	// if by some chance they are present we will error when trying to read extensions,
+	// which has an encoding instruction of [3].
+	var extensions cryptobyte.String
+	extensionsTag := asn1.Tag(3).Constructed().ContextSpecific()
+	if !tbsCertificateDER.ReadASN1(&extensions, extensionsTag) {
+		return nil, fmt.Errorf("error reading extensions")
+	}
+
+	// TBSCertificateLogEntry ::= SEQUENCE {
+	//      version               [0] EXPLICIT Version DEFAULT v1,
+	//      issuer                    Name,
+	//      validity                  Validity,
+	//      subject                   Name,
+	//      subjectPublicKeyAlgorithm AlgorithmIdentifier{PUBLIC-KEY,
+	//      							{PublicKeyAlgorithms}},
+	//      subjectPublicKeyInfoHash  OCTET STRING,
+	//      issuerUniqueID        [1] IMPLICIT UniqueIdentifier OPTIONAL,
+	//      subjectUniqueID       [2] IMPLICIT UniqueIdentifier OPTIONAL,
+	//      extensions            [3] EXPLICIT Extensions{{CertExtensions}}
+	//      									OPTIONAL
+	// }
+	//
+	// TBSCertificateLogEntry, relative to TBSCertificate, lacks `serialNumber`
+	// and `signature`, and encodes subjectPublicKeyInfo as its hash.
+	var builder cryptobyte.Builder
+
+	for _, f := range fields {
+		builder.AddASN1(f.tag, func(child *cryptobyte.Builder) {
+			child.AddBytes(f.value)
+		})
+	}
+	builder.AddASN1(asn1.SEQUENCE, func(child *cryptobyte.Builder) {
+		child.AddBytes(algID)
+	})
+	builder.AddASN1OctetString(spkiHash)
+	builder.AddASN1(extensionsTag, func(child *cryptobyte.Builder) {
+		child.AddBytes(extensions)
+	})
+
+	return builder.Bytes()
+}
+
+// tbsDERFromCertDER takes a Certificate object encoded as DER, and parses
+// away the outermost two sequences to get the inner bytes of the TBSCertificate.
+//
+// https://datatracker.ietf.org/doc/html/rfc5280#page-116
+//
+//		Certificate  ::=  SEQUENCE  {
+//		    tbsCertificate       TBSCertificate,
+//		    ...
+//
+//		TBSCertificate  ::=  SEQUENCE  {
+//		    version         [0]  Version DEFAULT v1,
+//		    serialNumber         CertificateSerialNumber,
+//	     ...
+func tbsDERFromCertDER(certDER []byte) (cryptobyte.String, error) {
+	var inner cryptobyte.String
+	input := cryptobyte.String(certDER)
+
+	if !input.ReadASN1(&inner, asn1.SEQUENCE) {
+		return nil, fmt.Errorf("failed to read outer sequence")
+	}
+
+	var tbsCertificate cryptobyte.String
+	if !inner.ReadASN1(&tbsCertificate, asn1.SEQUENCE) {
+		return nil, fmt.Errorf("failed to read tbsCertificate")
+	}
+
+	return tbsCertificate, nil
+}

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -54,7 +54,7 @@ type MTCLogEntry struct {
 }
 
 // TBS returns the TBSCertificateLogEntry bytes if Type is tbs_cert_entry, or nil otherwise.
-func (mtcle MTCLogEntry) TBS() []byte {
+func (mtcle *MTCLogEntry) TBS() []byte {
 	if mtcle.typ == typeTBSCertEntry {
 		return mtcle.value
 	}
@@ -64,7 +64,7 @@ func (mtcle MTCLogEntry) TBS() []byte {
 // Marshal returns the encoding of its receiver.
 //
 // Rejects unknown MTCLogEntryTypes.
-func (mtcle MTCLogEntry) Marshal() ([]byte, error) {
+func (mtcle *MTCLogEntry) Marshal() ([]byte, error) {
 	var builder cryptobyte.Builder
 	builder.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
 		child.AddBytes(mtcle.extensions)
@@ -305,7 +305,7 @@ func (b *BundleBuilder) Bytes() ([]byte, error) {
 }
 
 // Add appends a single MTCLogEntry, with its length prefix, to the builder.
-func (b *BundleBuilder) Add(mtcLogEntry MTCLogEntry) {
+func (b *BundleBuilder) Add(mtcLogEntry *MTCLogEntry) {
 	out, err := mtcLogEntry.Marshal()
 	if err != nil {
 		b.builder.SetError(err)

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -218,22 +218,18 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	//      					 -- If present, version MUST be v3 --  }
 	//
 	// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
-	type pair struct {
-		tag   asn1.Tag
-		value cryptobyte.String
-	}
-	var fields []pair
+	var fields []cryptobyte.String
 	for i := range 6 {
-		var fieldInner cryptobyte.String
+		var fieldElement cryptobyte.String
 		var fieldTag asn1.Tag
 
-		if !tbsCertificateDER.ReadAnyASN1Element(&fieldInner, &fieldTag) {
+		if !tbsCertificateDER.ReadAnyASN1Element(&fieldElement, &fieldTag) {
 			return MerkleTreeCertEntry{}, fmt.Errorf("failed to read field")
 		}
 
 		switch i {
 		case 0, 3, 4, 5: // version, issuer, validity, subject from the TBSCertificate.
-			fields = append(fields, pair{fieldTag, fieldInner})
+			fields = append(fields, fieldElement)
 		}
 	}
 
@@ -262,7 +258,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("malformed subjectPublicKeyInfo")
 	}
 	var algID cryptobyte.String
-	if !spkiInner.ReadASN1(&algID, asn1.SEQUENCE) {
+	if !spkiInner.ReadASN1Element(&algID, asn1.SEQUENCE) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("malformed algorithmIdentifier")
 	}
 
@@ -274,7 +270,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// which has an encoding instruction of [3].
 	var extensions cryptobyte.String
 	extensionsTag := asn1.Tag(3).Constructed().ContextSpecific()
-	if !tbsCertificateDER.ReadASN1(&extensions, extensionsTag) {
+	if !tbsCertificateDER.ReadASN1Element(&extensions, extensionsTag) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("error reading extensions")
 	}
 
@@ -297,17 +293,13 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	var builder cryptobyte.Builder
 
 	for _, f := range fields {
-		builder.AddASN1(f.tag, func(child *cryptobyte.Builder) {
-			child.AddBytes(f.value)
-		})
+		// The fields were read with ReadASN1Element so they still include
+		// their tag and length. Add them straight to
+		builder.AddBytes(f)
 	}
-	builder.AddASN1(asn1.SEQUENCE, func(child *cryptobyte.Builder) {
-		child.AddBytes(algID)
-	})
+	builder.AddBytes(algID)
 	builder.AddASN1OctetString(spkiHash)
-	builder.AddASN1(extensionsTag, func(child *cryptobyte.Builder) {
-		child.AddBytes(extensions)
-	})
+	builder.AddBytes(extensions)
 
 	tbsCertificateLogEntryBytes, err := builder.Bytes()
 	if err != nil {

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -119,6 +119,14 @@ type MerkleTreeCertEntry struct {
 	Value      []byte
 }
 
+// TBS returns the TBSCertificateLogEntry bytes if Type is tbs_cert_entry, or nil otherwise.
+func (mtce MerkleTreeCertEntry) TBS() []byte {
+	if mtce.Type == typeTBSCertEntry {
+		return mtce.Value
+	}
+	return nil
+}
+
 // Marshal returns the encoding of its receiver.
 //
 // Rejects unknown MerkleTreeCertEntryTypes.

--- a/trees/entry/entry.go
+++ b/trees/entry/entry.go
@@ -4,6 +4,7 @@
 package entry
 
 import (
+	"bytes"
 	"crypto"
 	"encoding/binary"
 	"fmt"
@@ -212,6 +213,9 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	if !input.ReadASN1(&inner, asn1.SEQUENCE) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read outer sequence")
 	}
+	if !input.Empty() {
+		return MerkleTreeCertEntry{}, fmt.Errorf("extra bytes at end")
+	}
 
 	var tbsCertificate cryptobyte.String
 	if !inner.ReadASN1(&tbsCertificate, asn1.SEQUENCE) {
@@ -235,8 +239,15 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	//      					 -- If present, version MUST be v3 --  }
 	//
 	// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-log-entries
+	var version cryptobyte.String
+	if !tbsCertificate.ReadASN1(&version, asn1.Tag(0).Constructed().ContextSpecific()) {
+		return MerkleTreeCertEntry{}, fmt.Errorf("failed to read version")
+	}
+	if !bytes.Equal(version, []byte{2, 1, 2}) {
+		return MerkleTreeCertEntry{}, fmt.Errorf("invalid X.509 version")
+	}
 	var fields []cryptobyte.String
-	for i := range 6 {
+	for i := range 5 {
 		var fieldElement cryptobyte.String
 		var fieldTag asn1.Tag
 
@@ -245,7 +256,7 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 		}
 
 		switch i {
-		case 0, 3, 4, 5: // version, issuer, validity, subject from the TBSCertificate.
+		case 2, 3, 4: // issuer, validity, subject from the TBSCertificate.
 			fields = append(fields, fieldElement)
 		}
 	}
@@ -291,6 +302,10 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 		return MerkleTreeCertEntry{}, fmt.Errorf("error reading extensions")
 	}
 
+	if !tbsCertificate.Empty() {
+		return MerkleTreeCertEntry{}, fmt.Errorf("extra bytes at end")
+	}
+
 	// TBSCertificateLogEntry ::= SEQUENCE {
 	//      version               [0] EXPLICIT Version DEFAULT v1,
 	//      issuer                    Name,
@@ -308,6 +323,10 @@ func FromX509(in []byte, hash crypto.Hash) (MerkleTreeCertEntry, error) {
 	// TBSCertificateLogEntry, relative to TBSCertificate, lacks `serialNumber`
 	// and `signature`, and encodes subjectPublicKeyInfo as its hash.
 	var builder cryptobyte.Builder
+
+	builder.AddASN1(asn1.Tag(0).Constructed().ContextSpecific(), func(child *cryptobyte.Builder) {
+		child.AddASN1Int64(2)
+	})
 
 	for _, f := range fields {
 		// The fields were read with ReadASN1Element so they still include

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -177,7 +177,7 @@ func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			mtce, err := unmarshalMTCE(val)
+			mtcle, err := unmarshalMTCLE(val)
 			if tc.expectErr && err == nil {
 				t.Errorf("expected error")
 			}
@@ -185,14 +185,14 @@ func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Unmarshal(): %s", err)
 				}
-				if !bytes.Equal(mtce.Extensions, tc.expectVal.Extensions) {
-					t.Errorf("Unmarshal() extensions: got %#v, want %#v", mtce.Extensions, tc.expectVal.Extensions)
+				if !bytes.Equal(mtcle.Extensions, tc.expectVal.Extensions) {
+					t.Errorf("Unmarshal() extensions: got %#v, want %#v", mtcle.Extensions, tc.expectVal.Extensions)
 				}
-				if mtce.Type != tc.expectVal.Type {
-					t.Errorf("Unmarshal() type: got %#v, want %#v", mtce.Type, tc.expectVal.Type)
+				if mtcle.Type != tc.expectVal.Type {
+					t.Errorf("Unmarshal() type: got %#v, want %#v", mtcle.Type, tc.expectVal.Type)
 				}
-				if !bytes.Equal(mtce.Value, tc.expectVal.Value) {
-					t.Errorf("Unmarshal() value: got %#v, want %#v", mtce.Value, tc.expectVal.Value)
+				if !bytes.Equal(mtcle.Value, tc.expectVal.Value) {
+					t.Errorf("Unmarshal() value: got %#v, want %#v", mtcle.Value, tc.expectVal.Value)
 				}
 			}
 		})

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -41,16 +41,18 @@ YhKuXQo=`, "\n", ""))
 	}
 
 	expectedOutput, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(`
-oAWgAwIBAjAiMCAxHjAcBgNVBAMTFW1pbmljYSByb290IGNhIDRlNGIxZDAgMB4X
-DTI2MDYyOTA1NDUyNloXDTI4MDcyOTA1NDUyNlowGDAWMRQwEgYDVQQDEwt3ZmUu
-Ym91bGRlcjAQBgcqhkjOPQIBBgUrgQQAIgQgxIsfmHTOfbAsqyQDsdDEYHnn4pV2
-rljEOusgCGD1mQmjeDB2MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEF
-BQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBSA+ZfinkHd
-xJDZuRo1zJ7mHOmaCDAWBgNVHREEDzANggt3ZmUuYm91bGRlcg==
+oAMCAQIwIDEeMBwGA1UEAxMVbWluaWNhIHJvb3QgY2EgNGU0YjFkMB4XDTI2MDYy
+OTA1NDUyNloXDTI4MDcyOTA1NDUyNlowFjEUMBIGA1UEAxMLd2ZlLmJvdWxkZXIw
+EAYHKoZIzj0CAQYFK4EEACIEIMSLH5h0zn2wLKskA7HQxGB55+KVdq5YxDrrIAhg
+9ZkJo3gwdjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG
+AQUFBwMCMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUgPmX4p5B3cSQ2bkaNcye
+5hzpmggwFgYDVR0RBA8wDYILd2ZlLmJvdWxkZXI=
 `, "\n", ""))
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(base64.StdEncoding.EncodeToString(mtce.Value))
+	t.Log(base64.StdEncoding.EncodeToString(sequenceWrap(mtce.Value)))
 
 	if !bytes.Equal(mtce.Value, expectedOutput) {
 		// Since TBSCertificateLogEntry is encoded as DER without a tag or length,

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -8,9 +8,6 @@ import (
 	"encoding/hex"
 	"strings"
 	"testing"
-
-	"github.com/zmap/zcrypto/cryptobyte"
-	"github.com/zmap/zcrypto/cryptobyte/asn1"
 )
 
 func TestTBSCertificateLogEntryFromX509(t *testing.T) {
@@ -51,16 +48,11 @@ AQUFBwMCMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUgPmX4p5B3cSQ2bkaNcye
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(base64.StdEncoding.EncodeToString(mtce.Value))
-	t.Log(base64.StdEncoding.EncodeToString(sequenceWrap(mtce.Value)))
 
 	if !bytes.Equal(mtce.Value, expectedOutput) {
-		// Since TBSCertificateLogEntry is encoded as DER without a tag or length,
-		// it's not readily parseable by off-the-shelf DER parsers like lapo.it/asn1js.
-		// For convenience of investigating, wrap both values in a SEQUENCE before output.
-		t.Errorf("sequenceWrap(TBSCertificateLogEntryFromX509()): got %s, want %s",
-			base64.StdEncoding.EncodeToString(sequenceWrap(mtce.Value)),
-			base64.StdEncoding.EncodeToString(sequenceWrap(expectedOutput)))
+		t.Errorf("TBSCertificateLogEntryFromX509(): got %s, want %s",
+			base64.StdEncoding.EncodeToString(mtce.Value),
+			base64.StdEncoding.EncodeToString(expectedOutput))
 	}
 }
 
@@ -157,17 +149,6 @@ func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
 			}
 		})
 	}
-}
-
-func sequenceWrap(in []byte) []byte {
-	// TBSCertificateLogEntry is DER encoded with the length and tag stripped, or equivalently
-	// the concatenated fields. That means DER parsers like https://lapo.it/asn1js/ can't parse
-	// it. For convenience, spit out a version that is wrapped in a SEQUENCE.
-	var b cryptobyte.Builder
-	b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
-		b.AddBytes(in)
-	})
-	return b.BytesOrPanic()
 }
 
 func TestBundleWriterReader(t *testing.T) {

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -284,11 +284,11 @@ func TestBundleReaderSuccess(t *testing.T) {
 	}
 
 	br = NewBundleReader(input)
-	entry, entryBytes, err = br.Read()
-	if err != nil && !errors.Is(err, io.EOF) {
+	_, _, err = br.Read()
+	if err != nil {
 		t.Error(err)
 	}
-	entry, entryBytes, err = br.Read()
+	_, _, err = br.Read()
 	if !errors.Is(err, io.EOF) {
 		t.Errorf("second read on a 1-element bundle: want EOF, got %v", err)
 	}

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -2,7 +2,6 @@ package entry
 
 import (
 	"bytes"
-	"compress/gzip"
 	"crypto"
 	"encoding/base64"
 	"encoding/hex"
@@ -151,25 +150,20 @@ func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
 	}
 }
 
-func TestBundleWriterReader(t *testing.T) {
-	var buf bytes.Buffer
-	w := gzip.NewWriter(&buf)
-	bw := NewBundleWriter(w)
+func TestBundleBuildAndRead(t *testing.T) {
+	var buf []byte
+	bw := NewBundleBuilder(buf)
 
 	for range 10 {
-		err := bw.Write(MerkleTreeCertEntry{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		bw.Add(MerkleTreeCertEntry{})
 	}
-	bw.Close()
 
-	r, err := gzip.NewReader(&buf)
+	tile, err := bw.Bytes()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	br := NewBundleReader(r)
+	br := NewBundleReader(tile)
 
 	for range 10 {
 		mtce, raw, err := br.Read()

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -1,9 +1,8 @@
-//go:build go1.27
-
 package entry
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto"
 	"encoding/base64"
 	"encoding/hex"
@@ -16,7 +15,7 @@ import (
 
 func TestTBSCertificateLogEntryFromX509(t *testing.T) {
 	// Bytes from an example generated test/certs/ipki/wfe.boulder/cert.pem
-	input, err := base64.StdEncoding.DecodeString(strings.Replace(`
+	input, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(`
 MIIB4TCCAWegAwIBAgIIJuDkMteShO8wCgYIKoZIzj0EAwMwIDEeMBwGA1UEAxMV
 bWluaWNhIHJvb3QgY2EgNGU0YjFkMB4XDTI2MDYyOTA1NDUyNloXDTI4MDcyOTA1
 NDUyNlowFjEUMBIGA1UEAxMLd2ZlLmJvdWxkZXIwdjAQBgcqhkjOPQIBBgUrgQQA
@@ -27,34 +26,38 @@ KwYBBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBSA+ZfinkHdxJDZuRo1
 zJ7mHOmaCDAWBgNVHREEDzANggt3ZmUuYm91bGRlcjAKBggqhkjOPQQDAwNoADBl
 AjEApE8cwaAQ6hnGtUM/TWAb54E5/29ZVy5E/UY8mEzoE021pl3tq1fEof5qz5n/
 KrL4AjAuEpVOjRrRWWMnRJxd05Pfxq7gZmxgwppjnE9JZ9P6WRP7ZWqZcc9p8YLM
-YhKuXQo=`, "\n", "", -1))
+YhKuXQo=`, "\n", ""))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	output, err := TBSCertificateLogEntryFromX509(input, crypto.SHA256)
+	mtce, err := FromX509(input, crypto.SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expectedOutput, err := base64.StdEncoding.DecodeString(strings.Replace(`
+	if mtce.Type != typeTBSCertEntry {
+		t.Errorf("mtce.Type: got %d, want tbs_cert_entry (1)", mtce.Type)
+	}
+
+	expectedOutput, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(`
 oAWgAwIBAjAiMCAxHjAcBgNVBAMTFW1pbmljYSByb290IGNhIDRlNGIxZDAgMB4X
 DTI2MDYyOTA1NDUyNloXDTI4MDcyOTA1NDUyNlowGDAWMRQwEgYDVQQDEwt3ZmUu
 Ym91bGRlcjAQBgcqhkjOPQIBBgUrgQQAIgQgxIsfmHTOfbAsqyQDsdDEYHnn4pV2
 rljEOusgCGD1mQmjeDB2MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEF
 BQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBSA+ZfinkHd
 xJDZuRo1zJ7mHOmaCDAWBgNVHREEDzANggt3ZmUuYm91bGRlcg==
-`, "\n", "", -1))
+`, "\n", ""))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(output, expectedOutput) {
+	if !bytes.Equal(mtce.Value, expectedOutput) {
 		// Since TBSCertificateLogEntry is encoded as DER without a tag or length,
 		// it's not readily parseable by off-the-shelf DER parsers like lapo.it/asn1js.
 		// For convenience of investigating, wrap both values in a SEQUENCE before output.
 		t.Errorf("sequenceWrap(TBSCertificateLogEntryFromX509()): got %s, want %s",
-			base64.StdEncoding.EncodeToString(sequenceWrap(output)),
+			base64.StdEncoding.EncodeToString(sequenceWrap(mtce.Value)),
 			base64.StdEncoding.EncodeToString(sequenceWrap(expectedOutput)))
 	}
 }
@@ -69,7 +72,7 @@ func TestMerkleTreeCertEntryMarshal(t *testing.T) {
 	}
 
 	nonEmptyNullEntry := MerkleTreeCertEntry{
-		Type:  TYPE_NULL_ENTRY,
+		Type:  typeNullEntry,
 		Value: []byte("abc"),
 	}
 	_, err = nonEmptyNullEntry.Marshal()
@@ -78,7 +81,7 @@ func TestMerkleTreeCertEntryMarshal(t *testing.T) {
 	}
 
 	validNullEntry := MerkleTreeCertEntry{
-		Type: TYPE_NULL_ENTRY,
+		Type: typeNullEntry,
 	}
 	output, err := validNullEntry.Marshal()
 	if err != nil {
@@ -90,7 +93,7 @@ func TestMerkleTreeCertEntryMarshal(t *testing.T) {
 	}
 
 	validTBSCertificateLogEntry := MerkleTreeCertEntry{
-		Type:  TYPE_TBS_CERT_ENTRY,
+		Type:  typeTBSCertEntry,
 		Value: []byte("abc"),
 	}
 	output, err = validTBSCertificateLogEntry.Marshal()
@@ -113,11 +116,11 @@ func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
 
 	testCases := []testCase{
 		{"valid TBS", "00000001616263", false, &MerkleTreeCertEntry{
-			Type:  TYPE_TBS_CERT_ENTRY,
+			Type:  typeTBSCertEntry,
 			Value: []byte("abc"),
 		}},
 		{"valid null_entry", "00000000", false, &MerkleTreeCertEntry{
-			Type: TYPE_NULL_ENTRY,
+			Type: typeNullEntry,
 		}},
 		{"too short", "000000", true, nil},
 		{"way too short", "00", true, nil},
@@ -132,7 +135,7 @@ func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			mtce, err := Unmarshal(val)
+			mtce, err := unmarshalMTCE(val)
 			if tc.expectErr && err == nil {
 				t.Errorf("expected error")
 			}
@@ -163,4 +166,45 @@ func sequenceWrap(in []byte) []byte {
 		b.AddBytes(in)
 	})
 	return b.BytesOrPanic()
+}
+
+func TestBundleWriterReader(t *testing.T) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	bw := NewBundleWriter(w)
+
+	for range 10 {
+		err := bw.Write(MerkleTreeCertEntry{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	bw.Close()
+
+	r, err := gzip.NewReader(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	br := NewBundleReader(r)
+
+	for range 10 {
+		mtce, raw, err := br.Read()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mtce.Type != typeNullEntry {
+			t.Errorf("mtce.Type: got %d, want %d", mtce.Type, typeNullEntry)
+		}
+		if len(mtce.Extensions) != 0 {
+			t.Errorf("mtce.Extensions: got %v, want nil", mtce.Extensions)
+		}
+		if len(mtce.Value) != 0 {
+			t.Errorf("mtce.Value: got %v, want nil", mtce.Value)
+		}
+		expected := []byte{0, 0, 0, 0}
+		if !bytes.Equal(raw, expected) {
+			t.Errorf("raw mtce: got %x, want %x", raw, expected)
+		}
+	}
 }

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -205,10 +205,10 @@ func TestBundleBuildAndRead(t *testing.T) {
 	var buf []byte
 	bb := NewBundleBuilder(buf)
 
-	bb.Add(MTCLogEntry{})
+	bb.Add(&MTCLogEntry{})
 
 	for range 10 {
-		bb.Add(MTCLogEntry{
+		bb.Add(&MTCLogEntry{
 			typ:   typeTBSCertEntry,
 			value: []byte{0x55, 0x55, 0x55, 0x55, 0x55},
 		})

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -27,13 +29,13 @@ YhKuXQo=`, "\n", ""))
 		t.Fatal(err)
 	}
 
-	mtce, err := FromX509(input, crypto.SHA256)
+	mtcle, err := FromX509(input, crypto.SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if mtce.Type != typeTBSCertEntry {
-		t.Errorf("mtce.Type: got %d, want tbs_cert_entry (1)", mtce.Type)
+	if mtcle.typ != typeTBSCertEntry {
+		t.Errorf("mtcle.Type: got %d, want tbs_cert_entry (1)", mtcle.typ)
 	}
 
 	expectedOutput, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(`
@@ -48,9 +50,9 @@ AQUFBwMCMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUgPmX4p5B3cSQ2bkaNcye
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(mtce.Value, expectedOutput) {
-		t.Errorf("TBSCertificateLogEntryFromX509(): got %s, want %s",
-			base64.StdEncoding.EncodeToString(mtce.Value),
+	if !bytes.Equal(mtcle.value, expectedOutput) {
+		t.Errorf("FromX509(): got %s, want %s",
+			base64.StdEncoding.EncodeToString(mtcle.value),
 			base64.StdEncoding.EncodeToString(expectedOutput))
 	}
 }
@@ -106,7 +108,7 @@ YhKuXQo=`, "\n", ""))
 
 func TestMarshalMTCLE(t *testing.T) {
 	invalidType := MTCLogEntry{
-		Type: 99,
+		typ: 99,
 	}
 	_, err := invalidType.Marshal()
 	if err == nil {
@@ -114,8 +116,8 @@ func TestMarshalMTCLE(t *testing.T) {
 	}
 
 	nonEmptyNullEntry := MTCLogEntry{
-		Type:  typeNullEntry,
-		Value: []byte("abc"),
+		typ:   typeNullEntry,
+		value: []byte("abc"),
 	}
 	_, err = nonEmptyNullEntry.Marshal()
 	if err == nil {
@@ -123,7 +125,7 @@ func TestMarshalMTCLE(t *testing.T) {
 	}
 
 	validNullEntry := MTCLogEntry{
-		Type: typeNullEntry,
+		typ: typeNullEntry,
 	}
 	output, err := validNullEntry.Marshal()
 	if err != nil {
@@ -135,8 +137,8 @@ func TestMarshalMTCLE(t *testing.T) {
 	}
 
 	validTBSCertificateLogEntry := MTCLogEntry{
-		Type:  typeTBSCertEntry,
-		Value: []byte("abc"),
+		typ:   typeTBSCertEntry,
+		value: []byte("abc"),
 	}
 	output, err = validTBSCertificateLogEntry.Marshal()
 	if err != nil {
@@ -158,11 +160,11 @@ func TestUnmarshalMTCLE(t *testing.T) {
 
 	testCases := []testCase{
 		{"valid TBS", "00000001616263", false, &MTCLogEntry{
-			Type:  typeTBSCertEntry,
-			Value: []byte("abc"),
+			typ:   typeTBSCertEntry,
+			value: []byte("abc"),
 		}},
 		{"valid null_entry", "00000000", false, &MTCLogEntry{
-			Type: typeNullEntry,
+			typ: typeNullEntry,
 		}},
 		{"too short", "000000", true, nil},
 		{"way too short", "00", true, nil},
@@ -185,14 +187,14 @@ func TestUnmarshalMTCLE(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Unmarshal(): %s", err)
 				}
-				if !bytes.Equal(mtcle.Extensions, tc.expectVal.Extensions) {
-					t.Errorf("Unmarshal() extensions: got %#v, want %#v", mtcle.Extensions, tc.expectVal.Extensions)
+				if !bytes.Equal(mtcle.extensions, tc.expectVal.extensions) {
+					t.Errorf("Unmarshal() extensions: got %#v, want %#v", mtcle.extensions, tc.expectVal.extensions)
 				}
-				if mtcle.Type != tc.expectVal.Type {
-					t.Errorf("Unmarshal() type: got %#v, want %#v", mtcle.Type, tc.expectVal.Type)
+				if mtcle.typ != tc.expectVal.typ {
+					t.Errorf("Unmarshal() type: got %#v, want %#v", mtcle.typ, tc.expectVal.typ)
 				}
-				if !bytes.Equal(mtcle.Value, tc.expectVal.Value) {
-					t.Errorf("Unmarshal() value: got %#v, want %#v", mtcle.Value, tc.expectVal.Value)
+				if !bytes.Equal(mtcle.value, tc.expectVal.value) {
+					t.Errorf("Unmarshal() value: got %#v, want %#v", mtcle.value, tc.expectVal.value)
 				}
 			}
 		})
@@ -201,36 +203,142 @@ func TestUnmarshalMTCLE(t *testing.T) {
 
 func TestBundleBuildAndRead(t *testing.T) {
 	var buf []byte
-	bw := NewBundleBuilder(buf)
+	bb := NewBundleBuilder(buf)
+
+	bb.Add(MTCLogEntry{})
 
 	for range 10 {
-		bw.Add(MTCLogEntry{})
+		bb.Add(MTCLogEntry{
+			typ:   typeTBSCertEntry,
+			value: []byte{0x55, 0x55, 0x55, 0x55, 0x55},
+		})
 	}
 
-	tile, err := bw.Bytes()
+	tile, err := bb.Bytes()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	br := NewBundleReader(tile)
 
+	mtcle, raw, err := br.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mtcle.typ != typeNullEntry {
+		t.Errorf("mtcle.Type: got %d, want %d", mtcle.typ, typeNullEntry)
+	}
+	if len(mtcle.extensions) != 0 {
+		t.Errorf("mtcle.Extensions: got %v, want nil", mtcle.extensions)
+	}
+	if len(mtcle.value) != 0 {
+		t.Errorf("mtcle.Value: got %v, want nil", mtcle.value)
+	}
+	expected := []byte{0, 0, 0, 0}
+	if !bytes.Equal(raw, expected) {
+		t.Errorf("raw mtcle: got %x, want %x", raw, expected)
+	}
+
 	for range 10 {
-		mtce, raw, err := br.Read()
+		mtcle, raw, err := br.Read()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if mtce.Type != typeNullEntry {
-			t.Errorf("mtce.Type: got %d, want %d", mtce.Type, typeNullEntry)
+		if mtcle.typ != typeTBSCertEntry {
+			t.Errorf("mtcle.Type: got %d, want %d", mtcle.typ, typeTBSCertEntry)
 		}
-		if len(mtce.Extensions) != 0 {
-			t.Errorf("mtce.Extensions: got %v, want nil", mtce.Extensions)
+		if len(mtcle.extensions) != 0 {
+			t.Errorf("mtcle.Extensions: got %v, want nil", mtcle.extensions)
 		}
-		if len(mtce.Value) != 0 {
-			t.Errorf("mtce.Value: got %v, want nil", mtce.Value)
+		wantValue := []byte{0x55, 0x55, 0x55, 0x55, 0x55}
+		if !bytes.Equal(mtcle.value, wantValue) {
+			t.Errorf("mtcle.Value: got %x, want %x", mtcle.value, wantValue)
 		}
-		expected := []byte{0, 0, 0, 0}
-		if !bytes.Equal(raw, expected) {
-			t.Errorf("raw mtce: got %x, want %x", raw, expected)
+		wantMTCLEBytes := append([]byte{0, 0, 0, 1}, wantValue...)
+		if !bytes.Equal(raw, wantMTCLEBytes) {
+			t.Errorf("raw MTCLogEntry: got %x, want %x", raw, expected)
 		}
+	}
+}
+
+func TestBundleReaderSuccess(t *testing.T) {
+	br := NewBundleReader(nil)
+	entry, entryBytes, err := br.Read()
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Error(err)
+	}
+	if entry != nil {
+		t.Errorf("empty reader: got %v, want nil entry", entry)
+	}
+	if len(entryBytes) != 0 {
+		t.Errorf("empty reader: got %x, want empty bytes", entryBytes)
+	}
+
+	// - 9 bytes of data
+	// - empty extensions (0000);
+	// - type = TBSCertificateLogEntry (0001)
+	// - fake TBSCertificateLogEntry (5 bytes of 55)
+	input, err := hex.DecodeString("0009000000015555555555")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	br = NewBundleReader(input)
+	entry, entryBytes, err = br.Read()
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Error(err)
+	}
+	entry, entryBytes, err = br.Read()
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("second read on a 1-element bundle: want EOF, got %v", err)
+	}
+
+	br = NewBundleReader(bytes.Repeat(input, 256))
+	var count int64
+	for count = 0; ; count++ {
+		_, _, err := br.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+	}
+
+	if count != 256 {
+		t.Errorf("reading many bundles: got %d values, want %d", count, 256)
+	}
+}
+
+func TestBundleReaderMalformed(t *testing.T) {
+	type testCase struct {
+		name, input string
+	}
+
+	testCases := []testCase{
+		{"short length", "09"},
+		{"short body", "0001"},
+		{"max length, short body", "FFFF"},
+		{"two records, short length on second", "0001FF09"},
+		{"two records, short body on second", "0001FF0001"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := hex.DecodeString(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			br := NewBundleReader(in)
+			for {
+				_, _, err = br.Read()
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						t.Error("got nil error, want error")
+					}
+					break
+				}
+			}
+		})
 	}
 }

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -221,7 +221,7 @@ func TestBundleBuildAndRead(t *testing.T) {
 
 	br := NewBundleReader(tile)
 
-	mtcle, raw, err := br.Read()
+	mtcle, raw, err := br.ReadEntry()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestBundleBuildAndRead(t *testing.T) {
 	}
 
 	for range 10 {
-		mtcle, raw, err := br.Read()
+		mtcle, raw, err := br.ReadEntry()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -263,7 +263,7 @@ func TestBundleBuildAndRead(t *testing.T) {
 
 func TestBundleReaderSuccess(t *testing.T) {
 	br := NewBundleReader(nil)
-	entry, entryBytes, err := br.Read()
+	entry, entryBytes, err := br.ReadEntry()
 	if err != nil && !errors.Is(err, io.EOF) {
 		t.Error(err)
 	}
@@ -284,11 +284,11 @@ func TestBundleReaderSuccess(t *testing.T) {
 	}
 
 	br = NewBundleReader(input)
-	_, _, err = br.Read()
+	_, _, err = br.ReadEntry()
 	if err != nil {
 		t.Error(err)
 	}
-	_, _, err = br.Read()
+	_, _, err = br.ReadEntry()
 	if !errors.Is(err, io.EOF) {
 		t.Errorf("second read on a 1-element bundle: want EOF, got %v", err)
 	}
@@ -296,7 +296,7 @@ func TestBundleReaderSuccess(t *testing.T) {
 	br = NewBundleReader(bytes.Repeat(input, 256))
 	var count int64
 	for count = 0; ; count++ {
-		_, _, err := br.Read()
+		_, _, err := br.ReadEntry()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -331,7 +331,7 @@ func TestBundleReaderMalformed(t *testing.T) {
 
 			br := NewBundleReader(in)
 			for {
-				_, _, err = br.Read()
+				_, _, err = br.ReadEntry()
 				if err != nil {
 					if errors.Is(err, io.EOF) {
 						t.Error("got nil error, want error")

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -1,0 +1,166 @@
+//go:build go1.27
+
+package entry
+
+import (
+	"bytes"
+	"crypto"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/zmap/zcrypto/cryptobyte"
+	"github.com/zmap/zcrypto/cryptobyte/asn1"
+)
+
+func TestTBSCertificateLogEntryFromX509(t *testing.T) {
+	// Bytes from an example generated test/certs/ipki/wfe.boulder/cert.pem
+	input, err := base64.StdEncoding.DecodeString(strings.Replace(`
+MIIB4TCCAWegAwIBAgIIJuDkMteShO8wCgYIKoZIzj0EAwMwIDEeMBwGA1UEAxMV
+bWluaWNhIHJvb3QgY2EgNGU0YjFkMB4XDTI2MDYyOTA1NDUyNloXDTI4MDcyOTA1
+NDUyNlowFjEUMBIGA1UEAxMLd2ZlLmJvdWxkZXIwdjAQBgcqhkjOPQIBBgUrgQQA
+IgNiAATLkY1wBrGl9+jhR4+HSycRv5kvVV8LUO3xY1styu8+q9kaSi03wrdH7LUf
+rJkRE6S60XzVXkeqL9N//jOXFsaM9JbsbeHFRoAx+mBEV68Vu69dblxtXIAKNlMM
+5dav5XOjeDB2MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYI
+KwYBBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBSA+ZfinkHdxJDZuRo1
+zJ7mHOmaCDAWBgNVHREEDzANggt3ZmUuYm91bGRlcjAKBggqhkjOPQQDAwNoADBl
+AjEApE8cwaAQ6hnGtUM/TWAb54E5/29ZVy5E/UY8mEzoE021pl3tq1fEof5qz5n/
+KrL4AjAuEpVOjRrRWWMnRJxd05Pfxq7gZmxgwppjnE9JZ9P6WRP7ZWqZcc9p8YLM
+YhKuXQo=`, "\n", "", -1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := TBSCertificateLogEntryFromX509(input, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutput, err := base64.StdEncoding.DecodeString(strings.Replace(`
+oAWgAwIBAjAiMCAxHjAcBgNVBAMTFW1pbmljYSByb290IGNhIDRlNGIxZDAgMB4X
+DTI2MDYyOTA1NDUyNloXDTI4MDcyOTA1NDUyNlowGDAWMRQwEgYDVQQDEwt3ZmUu
+Ym91bGRlcjAQBgcqhkjOPQIBBgUrgQQAIgQgxIsfmHTOfbAsqyQDsdDEYHnn4pV2
+rljEOusgCGD1mQmjeDB2MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEF
+BQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBSA+ZfinkHd
+xJDZuRo1zJ7mHOmaCDAWBgNVHREEDzANggt3ZmUuYm91bGRlcg==
+`, "\n", "", -1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(output, expectedOutput) {
+		// Since TBSCertificateLogEntry is encoded as DER without a tag or length,
+		// it's not readily parseable by off-the-shelf DER parsers like lapo.it/asn1js.
+		// For convenience of investigating, wrap both values in a SEQUENCE before output.
+		t.Errorf("sequenceWrap(TBSCertificateLogEntryFromX509()): got %s, want %s",
+			base64.StdEncoding.EncodeToString(sequenceWrap(output)),
+			base64.StdEncoding.EncodeToString(sequenceWrap(expectedOutput)))
+	}
+}
+
+func TestMerkleTreeCertEntryMarshal(t *testing.T) {
+	invalidType := MerkleTreeCertEntry{
+		Type: 99,
+	}
+	_, err := invalidType.Marshal()
+	if err == nil {
+		t.Errorf("invalid type: got nil err, want error")
+	}
+
+	nonEmptyNullEntry := MerkleTreeCertEntry{
+		Type:  TYPE_NULL_ENTRY,
+		Value: []byte("abc"),
+	}
+	_, err = nonEmptyNullEntry.Marshal()
+	if err == nil {
+		t.Errorf("non-empty null_entry: got nil err, want error")
+	}
+
+	validNullEntry := MerkleTreeCertEntry{
+		Type: TYPE_NULL_ENTRY,
+	}
+	output, err := validNullEntry.Marshal()
+	if err != nil {
+		t.Errorf("marshaling valid null_entry: %s", err)
+	}
+	expected := []byte{0, 0, 0, 0}
+	if !bytes.Equal(output, expected) {
+		t.Errorf("marshaling valid null_entry: got %x, want %x", output, expected)
+	}
+
+	validTBSCertificateLogEntry := MerkleTreeCertEntry{
+		Type:  TYPE_TBS_CERT_ENTRY,
+		Value: []byte("abc"),
+	}
+	output, err = validTBSCertificateLogEntry.Marshal()
+	if err != nil {
+		t.Errorf("marshaling valid tbs_cert_entry: %s", err)
+	}
+	expected = []byte{0, 0, 0, 1, 'a', 'b', 'c'}
+	if !bytes.Equal(output, expected) {
+		t.Errorf("marshaling valid tbs_cert_entry: got %x, want %x", output, expected)
+	}
+}
+
+func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
+	type testCase struct {
+		name      string
+		input     string
+		expectErr bool
+		expectVal *MerkleTreeCertEntry
+	}
+
+	testCases := []testCase{
+		{"valid TBS", "00000001616263", false, &MerkleTreeCertEntry{
+			Type:  TYPE_TBS_CERT_ENTRY,
+			Value: []byte("abc"),
+		}},
+		{"valid null_entry", "00000000", false, &MerkleTreeCertEntry{
+			Type: TYPE_NULL_ENTRY,
+		}},
+		{"too short", "000000", true, nil},
+		{"way too short", "00", true, nil},
+		{"way way too short", "", true, nil},
+		{"null_entry with value", "0000000099", true, nil},
+		{"invalid type", "00000102616263", true, nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := hex.DecodeString(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mtce, err := Unmarshal(val)
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error")
+			}
+			if tc.expectVal != nil {
+				if err != nil {
+					t.Fatalf("Unmarshal(): %s", err)
+				}
+				if !bytes.Equal(mtce.Extensions, tc.expectVal.Extensions) {
+					t.Errorf("Unmarshal() extensions: got %#v, want %#v", mtce.Extensions, tc.expectVal.Extensions)
+				}
+				if mtce.Type != tc.expectVal.Type {
+					t.Errorf("Unmarshal() type: got %#v, want %#v", mtce.Type, tc.expectVal.Type)
+				}
+				if !bytes.Equal(mtce.Value, tc.expectVal.Value) {
+					t.Errorf("Unmarshal() value: got %#v, want %#v", mtce.Value, tc.expectVal.Value)
+				}
+			}
+		})
+	}
+}
+
+func sequenceWrap(in []byte) []byte {
+	// TBSCertificateLogEntry is DER encoded with the length and tag stripped, or equivalently
+	// the concatenated fields. That means DER parsers like https://lapo.it/asn1js/ can't parse
+	// it. For convenience, spit out a version that is wrapped in a SEQUENCE.
+	var b cryptobyte.Builder
+	b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+		b.AddBytes(in)
+	})
+	return b.BytesOrPanic()
+}

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -56,7 +56,7 @@ AQUFBwMCMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUgPmX4p5B3cSQ2bkaNcye
 }
 
 func TestMerkleTreeCertEntryMarshal(t *testing.T) {
-	invalidType := MerkleTreeCertEntry{
+	invalidType := MTCLogEntry{
 		Type: 99,
 	}
 	_, err := invalidType.Marshal()
@@ -64,7 +64,7 @@ func TestMerkleTreeCertEntryMarshal(t *testing.T) {
 		t.Errorf("invalid type: got nil err, want error")
 	}
 
-	nonEmptyNullEntry := MerkleTreeCertEntry{
+	nonEmptyNullEntry := MTCLogEntry{
 		Type:  typeNullEntry,
 		Value: []byte("abc"),
 	}
@@ -73,7 +73,7 @@ func TestMerkleTreeCertEntryMarshal(t *testing.T) {
 		t.Errorf("non-empty null_entry: got nil err, want error")
 	}
 
-	validNullEntry := MerkleTreeCertEntry{
+	validNullEntry := MTCLogEntry{
 		Type: typeNullEntry,
 	}
 	output, err := validNullEntry.Marshal()
@@ -85,7 +85,7 @@ func TestMerkleTreeCertEntryMarshal(t *testing.T) {
 		t.Errorf("marshaling valid null_entry: got %x, want %x", output, expected)
 	}
 
-	validTBSCertificateLogEntry := MerkleTreeCertEntry{
+	validTBSCertificateLogEntry := MTCLogEntry{
 		Type:  typeTBSCertEntry,
 		Value: []byte("abc"),
 	}
@@ -104,15 +104,15 @@ func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
 		name      string
 		input     string
 		expectErr bool
-		expectVal *MerkleTreeCertEntry
+		expectVal *MTCLogEntry
 	}
 
 	testCases := []testCase{
-		{"valid TBS", "00000001616263", false, &MerkleTreeCertEntry{
+		{"valid TBS", "00000001616263", false, &MTCLogEntry{
 			Type:  typeTBSCertEntry,
 			Value: []byte("abc"),
 		}},
-		{"valid null_entry", "00000000", false, &MerkleTreeCertEntry{
+		{"valid null_entry", "00000000", false, &MTCLogEntry{
 			Type: typeNullEntry,
 		}},
 		{"too short", "000000", true, nil},
@@ -155,7 +155,7 @@ func TestBundleBuildAndRead(t *testing.T) {
 	bw := NewBundleBuilder(buf)
 
 	for range 10 {
-		bw.Add(MerkleTreeCertEntry{})
+		bw.Add(MTCLogEntry{})
 	}
 
 	tile, err := bw.Bytes()

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -104,7 +104,7 @@ YhKuXQo=`, "\n", ""))
 	}
 }
 
-func TestMerkleTreeCertEntryMarshal(t *testing.T) {
+func TestMarshalMTCLE(t *testing.T) {
 	invalidType := MTCLogEntry{
 		Type: 99,
 	}
@@ -148,7 +148,7 @@ func TestMerkleTreeCertEntryMarshal(t *testing.T) {
 	}
 }
 
-func TestMerkleTreeCertEntryUnmarshal(t *testing.T) {
+func TestUnmarshalMTCLE(t *testing.T) {
 	type testCase struct {
 		name      string
 		input     string

--- a/trees/entry/entry_test.go
+++ b/trees/entry/entry_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestTBSCertificateLogEntryFromX509(t *testing.T) {
+func TestFromX509(t *testing.T) {
 	// Bytes from an example generated test/certs/ipki/wfe.boulder/cert.pem
 	input, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(`
 MIIB4TCCAWegAwIBAgIIJuDkMteShO8wCgYIKoZIzj0EAwMwIDEeMBwGA1UEAxMV
@@ -52,6 +52,55 @@ AQUFBwMCMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUgPmX4p5B3cSQ2bkaNcye
 		t.Errorf("TBSCertificateLogEntryFromX509(): got %s, want %s",
 			base64.StdEncoding.EncodeToString(mtce.Value),
 			base64.StdEncoding.EncodeToString(expectedOutput))
+	}
+}
+
+func TestFromX509Malformed(t *testing.T) {
+	valid, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(`
+MIIB4TCCAWegAwIBAgIIJuDkMteShO8wCgYIKoZIzj0EAwMwIDEeMBwGA1UEAxMV
+bWluaWNhIHJvb3QgY2EgNGU0YjFkMB4XDTI2MDYyOTA1NDUyNloXDTI4MDcyOTA1
+NDUyNlowFjEUMBIGA1UEAxMLd2ZlLmJvdWxkZXIwdjAQBgcqhkjOPQIBBgUrgQQA
+IgNiAATLkY1wBrGl9+jhR4+HSycRv5kvVV8LUO3xY1styu8+q9kaSi03wrdH7LUf
+rJkRE6S60XzVXkeqL9N//jOXFsaM9JbsbeHFRoAx+mBEV68Vu69dblxtXIAKNlMM
+5dav5XOjeDB2MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYI
+KwYBBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBSA+ZfinkHdxJDZuRo1
+zJ7mHOmaCDAWBgNVHREEDzANggt3ZmUuYm91bGRlcjAKBggqhkjOPQQDAwNoADBl
+AjEApE8cwaAQ6hnGtUM/TWAb54E5/29ZVy5E/UY8mEzoE021pl3tq1fEof5qz5n/
+KrL4AjAuEpVOjRrRWWMnRJxd05Pfxq7gZmxgwppjnE9JZ9P6WRP7ZWqZcc9p8YLM
+YhKuXQo=`, "\n", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shortValid := valid[:len(valid)-2]
+	longValid := append(valid, 0)
+
+	wrongVersion := bytes.Clone(valid)
+	copy(wrongVersion[10:13], []byte{2, 1, 1})
+
+	type testCase struct {
+		name, hex string
+	}
+	testCases := []testCase{
+		{"empty", ""},
+		{"tag only", "30"},
+		{"nothing inside", "300100"},
+		{"too short", hex.EncodeToString(shortValid)},
+		{"too long", hex.EncodeToString(longValid)},
+		{"wrong version", hex.EncodeToString(wrongVersion)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := hex.DecodeString(tc.hex)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = FromX509(val, crypto.SHA256)
+			if err == nil {
+				t.Errorf("FromX509(): got nil err, want error")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Implements:

 - MTCLogEntry
   - FromX509
   - TBS
 - BundleReader
 - BundleWriter

Note: going the other way and generating an X.509 certificate from a TBSCertificateLogEntry is not yet implemented.

Note for reviewers: FromX509 transforms X.509 Certificate bytes directly into TBSCertificateLogEntry (and then wraps). I didn't implement parsing to a struct then serializing the struct because (a) we want to make sure there is byte-for-byte equality between applicable fields, and (b) we don't necessarily want to reinvent `*x509.Certificate`'s setup with `Subject` / `RawSubject`, etc. It's possible we'll want to change this decision later and have an intermediate struct that carries, for instance, the raw bytes of fields.

Fixes #8857