### PR TITLE
linter: pass through RawSubject

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -147,6 +147,12 @@ func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.C
 		// realIssuer, which could be either an intermediate or cross-signed
 		// intermediate, the SignatureAlgorithm of that certificate may differ
 		// from the root certificate that had signed it.
+		//
+		// RawSubject is used internally by x509.CreateCertificate to copy the issuer's
+		// Subject into the signed certificate's Issuer. Without it, only recognized fields
+		// from Subject will be passed through.
+		// For instance, correctly processing MTC's id-rdna-trustAnchorID or its temporary
+		// experimentation equivalent require this.
 		AuthorityKeyId:              realIssuer.AuthorityKeyId,
 		BasicConstraintsValid:       realIssuer.BasicConstraintsValid,
 		CRLDistributionPoints:       realIssuer.CRLDistributionPoints,
@@ -173,17 +179,12 @@ func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.C
 		PermittedIPRanges:           realIssuer.PermittedIPRanges,
 		PermittedURIDomains:         realIssuer.PermittedURIDomains,
 		Policies:                    realIssuer.Policies,
+		RawSubject:                  realIssuer.RawSubject,
 		SerialNumber:                realIssuer.SerialNumber,
 		Subject:                     realIssuer.Subject,
-		// RawSubject is used internally by x509.CreateCertificate to copy the issuer's
-		// Subject into the signed certificate's Issuer. Without it, only recognized fields
-		// from Subject will be passed through.
-		// For instance, correctly processing MTC's id-rdna-trustAnchorID or its temporary
-		// experimentation equivalent require this.
-		RawSubject:         realIssuer.RawSubject,
-		SubjectKeyId:       realIssuer.SubjectKeyId,
-		URIs:               realIssuer.URIs,
-		UnknownExtKeyUsage: realIssuer.UnknownExtKeyUsage,
+		SubjectKeyId:                realIssuer.SubjectKeyId,
+		URIs:                        realIssuer.URIs,
+		UnknownExtKeyUsage:          realIssuer.UnknownExtKeyUsage,
 	}
 	lintIssuerBytes, err := x509.CreateCertificate(rand.Reader, lintIssuerTBS, lintIssuerTBS, lintSigner.Public(), lintSigner)
 	if err != nil {

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -175,9 +175,15 @@ func makeIssuer(realIssuer *x509.Certificate, lintSigner crypto.Signer) (*x509.C
 		Policies:                    realIssuer.Policies,
 		SerialNumber:                realIssuer.SerialNumber,
 		Subject:                     realIssuer.Subject,
-		SubjectKeyId:                realIssuer.SubjectKeyId,
-		URIs:                        realIssuer.URIs,
-		UnknownExtKeyUsage:          realIssuer.UnknownExtKeyUsage,
+		// RawSubject is used internally by x509.CreateCertificate to copy the issuer's
+		// Subject into the signed certificate's Issuer. Without it, only recognized fields
+		// from Subject will be passed through.
+		// For instance, correctly processing MTC's id-rdna-trustAnchorID or its temporary
+		// experimentation equivalent require this.
+		RawSubject:         realIssuer.RawSubject,
+		SubjectKeyId:       realIssuer.SubjectKeyId,
+		URIs:               realIssuer.URIs,
+		UnknownExtKeyUsage: realIssuer.UnknownExtKeyUsage,
 	}
 	lintIssuerBytes, err := x509.CreateCertificate(rand.Reader, lintIssuerTBS, lintIssuerTBS, lintSigner.Public(), lintSigner)
 	if err != nil {

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1,10 +1,16 @@
 package linter
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
 	"math/big"
 	"strings"
 	"testing"
@@ -45,5 +51,63 @@ func TestMakeSigner_Unsupported(t *testing.T) {
 }
 
 func TestMakeIssuer(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	idRDNATrustAnchorIDExperimental := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 44363, 47, 1}
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			ExtraNames: []pkix.AttributeTypeAndValue{
+				{
+					Type:  idRDNATrustAnchorIDExperimental,
+					Value: asn1.RawValue{Tag: asn1.TagUTF8String, Bytes: []byte("44947.4.2.1")},
+				},
+			},
+		},
+	}
+	realIssuerBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	realIssuer, err := x509.ParseCertificate(realIssuerBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSubject, err := hex.DecodeString("301d311b3019060a2b0601040182da4b2f010c0b34343934372e342e322e31")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(realIssuer.RawSubject, expectedSubject) {
+		t.Fatalf("realIssuer Subject: got %x, want %x", realIssuer.RawSubject, expectedSubject)
+	}
+
+	linter, err := New(realIssuer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eeKey, err := ecdsa.GenerateKey(elliptic.P256(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ee := &x509.Certificate{}
+
+	lintCertBytes, err := linter.Check(ee, eeKey.Public(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lintCert, err := x509.ParseCertificate(lintCertBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(lintCert.RawIssuer, realIssuer.RawSubject) {
+		t.Errorf("linting certificate issuer: got %x, want %x", lintCert.RawIssuer, realIssuer.RawSubject)
+	}
 }


### PR DESCRIPTION
x509.CreateCertificate copies the issuer's Subject into the signed certificate's Issuer. If the RawSubject bytes are available, it copies those. Otherwise it copies only known fields and ExtraNames from the Subject.

Since the name types used in MTC aren't recognized, we have to make sure RawSubject is available. Otherwise end-entity certificates would get an empty Issuer.

References:
https://cs.opensource.google/go/go/+/refs/tags/go1.26.3:src/crypto/x509/x509.go;l=1732
https://cs.opensource.google/go/go/+/refs/tags/go1.26.3:src/crypto/x509/x509.go;l=1523-1529
https://pkg.go.dev/crypto/x509/pkix#Name.ToRDNSequence