### PR TITLE
minio: self-initialize container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,8 @@ services:
         condition: service_started
       bpkimetal:
         condition: service_started
-      bminio-init:
-        condition: service_completed_successfully
+      bminio:
+        condition: service_healthy
     entrypoint: test/entrypoint.sh
     working_dir: &boulder_working_dir /boulder
 
@@ -155,37 +155,23 @@ services:
 
   bminio:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    command: server /data
+    volumes:
+      - ./test/minio:/boulder/test/minio/
+    entrypoint:
+      - /boulder/test/minio/entrypoint.sh
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
+    healthcheck:
+      test: [ "CMD", "curl", "-s", "-O", "/dev/null",
+        "http://localhost:9000/boulder-mtc-tiles/index.html" ]
+      interval: 0.05s
+      timeout: 1s
+      retries: 100
     networks:
       bouldernet:
         aliases:
           - boulder-minio
-
-  bminio-init:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
-    depends_on:
-      bminio:
-        condition: service_started
-    networks:
-      - bouldernet
-    # Idempotently create the tile storage bucket, then exit. `mc` is the MinIO
-    # command-line client; it addresses servers by registered aliases not URLs,
-    # so we must register the server as an alias before running `mc mb` (make
-    # bucket).
-    #
-    # `mc alias set` probes the server and exits nonzero if it's unreachable, so
-    # our retry loop also doubles as a readiness check. For more information see:
-    #
-    # - https://docs.min.io/aistor/reference/cli/mc-mb/#alias
-    # - https://docs.min.io/aistor/reference/cli/mc-alias/mc-alias-set/
-    entrypoint: >
-      /bin/sh -c "
-      until mc alias set local http://boulder-minio:9000 minioadmin minioadmin >/dev/null 2>&1; do sleep 1; done;
-      mc mb --ignore-existing local/boulder-mtc-tiles
-      "
 
   bvitess:
     # The `letsencrypt/boulder-vtcomboserver:latest` tag is automatically built

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,11 +163,13 @@ services:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
     healthcheck:
-      test: [ "CMD", "curl", "-s", "-O", "/dev/null",
+      test: [ "CMD", "curl", "-fs", "-o", "/dev/null",
         "http://localhost:9000/boulder-mtc-tiles/index.html" ]
-      interval: 0.1s
-      timeout: 1s
-      retries: 200
+      start_period: 30s
+      start_interval: 0.1s
+      interval: 30s
+      timeout: 2s
+      retries: 3
     networks:
       bouldernet:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,9 +165,9 @@ services:
     healthcheck:
       test: [ "CMD", "curl", "-s", "-O", "/dev/null",
         "http://localhost:9000/boulder-mtc-tiles/index.html" ]
-      interval: 0.05s
+      interval: 0.1s
       timeout: 1s
-      retries: 100
+      retries: 200
     networks:
       bouldernet:
         aliases:

--- a/test/minio/entrypoint.sh
+++ b/test/minio/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -feuo pipefail
+
+# If a command was passed, run that instead of the minio server.
+if [[ $# -ne 0 ]]; then
+    exec "$@"
+fi
+
+# Otherwise, start and init minio.
+minio server /data &
+MINIO_PID="$!"
+
+# Idempotently create the tile storage bucket, then exit. `mc` is the MinIO
+# command-line client; it addresses servers by registered aliases not URLs,
+# so we must register the server as an alias before running `mc mb` (make
+# bucket).
+#
+# `mc alias set` probes the server and exits nonzero if it's unreachable, so
+# our retry loop also doubles as a readiness check. For more information see:
+#
+# - https://docs.min.io/aistor/reference/cli/mc-mb/#alias
+# - https://docs.min.io/aistor/reference/cli/mc-alias/mc-alias-set/
+until mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" ; do
+  sleep 1
+done;
+mc mb -q --ignore-existing local/boulder-mtc-tiles
+# Allow HTTP fetches of the tiles.
+mc anonymous -q set download local/boulder-mtc-tiles
+
+# Put a simple file at the root of the bucket. This is useful for health checking.
+# Once this file exists, the bucket is fully initialized.
+echo "Boulder's MTCA keeps its tiles here" > /tmp/index.html
+mc cp -q /tmp/index.html local/boulder-mtc-tiles
+
+wait "$MINIO_PID"


### PR DESCRIPTION
Previously we had `bminio-init` to help set up our bucket. However, it's nice to have fewer containers to worry about. In particular it's nice to be able to `up`/`down` bminio and its volume separately from the rest of our Docker setup, and not have to remember to also run `bminio-init`.

This creates an entrypoint.sh for our `bminio` container that starts the server in the background, does the initialization steps, and then waits on the server to exit.

Also, this sets permissions on our boulder-mtc-tiles to allow unauthenticated HTTP fetch (`mc anonymous set download`). This makes it easier to interact with the tiles in the same way we would interact with a public log. It also makes it nice and simple to write a health check for the `bminio` container.

The upstream Dockerfile and docker-entrypoint.sh are pretty simple. I've read them and don't think we're missing any special initialization steps they do. For reference:

https://github.com/minio/minio/blob/master/Dockerfile
https://github.com/minio/minio/blob/master/dockerscripts/docker-entrypoint.sh