### PR TITLE
test: run unittests under gotip when appropriate

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,13 +21,14 @@ INTEGRATION_FLAGS=()
 FILTER=()
 COVERAGE="false"
 COVERAGE_DIR="test/coverage/$(date +%Y-%m-%d_%H-%M-%S)"
+GO=go
 
 #
 # Cleanup Functions
 #
 
 function flush_redis() {
-  go run ./test/boulder-tools/flushredis/main.go
+  "${GO}" run ./test/boulder-tools/flushredis/main.go
 }
 
 #
@@ -105,7 +106,7 @@ function run_unit_tests() {
 # Run `go test` on a given set of packages.
 #
 function go_test() {
-  go test "${UNIT_FLAGS[@]}" "${FILTER[@]}" "$@"
+  "${GO}" test "${UNIT_FLAGS[@]}" "${FILTER[@]}" "$@"
 }
 
 #
@@ -165,7 +166,7 @@ while getopts luvwecisgnhbd:p:f:-: OPT; do
     f | filter )                     check_arg; FILTER+=("${OPTARG}") ;;
     s | start-py )                   RUN+=("start") ;;
     g | generate )                   RUN+=("generate") ;;
-    n | config-next )                BOULDER_CONFIG_DIR="test/config-next" ;;
+    n | config-next )                BOULDER_CONFIG_DIR="test/config-next"; GO=gotip ;;
     c | coverage )                   COVERAGE="true" ;;
     d | coverage-dir )               check_arg; COVERAGE_DIR="${OPTARG}" ;;
     h | help )                       print_usage_exit ;;
@@ -208,7 +209,7 @@ trap "print_outcome" EXIT
 settings="$(cat -- <<-EOM
     RUN:                ${RUN[@]}
     BOULDER_CONFIG_DIR: $BOULDER_CONFIG_DIR
-    GOCACHE:            $(go env GOCACHE)
+    GOCACHE:            $("${GO}" env GOCACHE)
     UNIT_PACKAGES:      ${UNIT_PACKAGES[@]}
     UNIT_FLAGS:         ${UNIT_FLAGS[@]}
     FILTER:             ${FILTER[@]}
@@ -317,8 +318,8 @@ if [[ "${RUN[@]}" =~ "$STAGE" ]] ; then
   #   stringer: checking package: grpc/bcodes.go:6:2: could not import
   #     github.com/letsencrypt/boulder/probs (can't find import:
   #     github.com/letsencrypt/boulder/probs)
-  go install ./probs
-  go install ./vendor/google.golang.org/grpc/codes
+  "${GO}" install ./probs
+  "${GO}" install ./vendor/google.golang.org/grpc/codes
   run_and_expect_silence go generate ./...
   run_and_expect_silence git diff --exit-code .
 fi

--- a/tn.sh
+++ b/tn.sh
@@ -12,4 +12,4 @@ fi
 # Generate the test keys and certs necessary for the integration tests.
 docker compose run --rm bsetup
 
-exec docker compose -f docker-compose.yml -f docker-compose.next.yml run -e USE_VITESS --rm --name boulder_tests boulder ./test.sh "$@"
+exec docker compose -f docker-compose.yml -f docker-compose.next.yml run -e USE_VITESS --rm --name boulder_tests boulder ./test.sh -n "$@"


### PR DESCRIPTION
For the unittests that depend on mldsa, we have a build constraint for go1.27. Make sure we run those under tn.sh / test.sh -n.