### PR TITLE
tiles: add Frontier to read/write tiles

### DIFF
--- a/trees/subtree/subtree.go
+++ b/trees/subtree/subtree.go
@@ -267,7 +267,9 @@ func VerifyConsistency(start, end, n int64, proof []tlog.Hash, nodeHash, rootHas
 	return tn == 0 && fr == nodeHash && sr == rootHash
 }
 
-// MTH implements MTH(D[start:end]) from RFC 9162 section 2.1.1.
+// MTH emits the Merkle Tree Hash of its inputs, as defined in RFC 9162 section 2.1.1.
+//
+// https://www.rfc-editor.org/info/rfc9162/#name-definition-of-the-merkle-tr
 func MTH(leaves []tlog.Hash) tlog.Hash {
 	switch len(leaves) {
 	case 0:

--- a/trees/subtree/subtree.go
+++ b/trees/subtree/subtree.go
@@ -1,6 +1,7 @@
 package subtree
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"math/bits"
 
@@ -264,4 +265,18 @@ func VerifyConsistency(start, end, n int64, proof []tlog.Hash, nodeHash, rootHas
 		tn >>= 1
 	}
 	return tn == 0 && fr == nodeHash && sr == rootHash
+}
+
+// MTH implements MTH(D[start:end]) from RFC 9162 section 2.1.1.
+func MTH(leaves []tlog.Hash) tlog.Hash {
+	switch len(leaves) {
+	case 0:
+		return tlog.Hash(sha256.Sum256(nil))
+	case 1:
+		return leaves[0]
+	default:
+		// RFC 6962: split at the largest power of two smaller than n.
+		k := 1 << (bits.Len(uint(len(leaves)-1)) - 1) //nolint:gosec // G115: the default case means len(leaves) >= 2, so len(leaves)-1 is positive.
+		return tlog.NodeHash(MTH(leaves[:k]), MTH(leaves[k:]))
+	}
 }

--- a/trees/subtree/subtree_test.go
+++ b/trees/subtree/subtree_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/bits"
 	"slices"
 	"testing"
 
@@ -29,20 +28,6 @@ func leafHashes(entries [][]byte) []tlog.Hash {
 		hs[i] = tlog.RecordHash(e)
 	}
 	return hs
-}
-
-// mth implements MTH(D[start:end]) from RFC 9162 section 2.1.1.
-func mth(leaves []tlog.Hash) tlog.Hash {
-	switch len(leaves) {
-	case 0:
-		return tlog.Hash(sha256.Sum256(nil))
-	case 1:
-		return leaves[0]
-	default:
-		// RFC 6962: split at the largest power of two smaller than n.
-		k := 1 << (bits.Len(uint(len(leaves)-1)) - 1) //nolint:gosec // G115: the default case means len(leaves) >= 2, so len(leaves)-1 is positive.
-		return tlog.NodeHash(mth(leaves[:k]), mth(leaves[k:]))
-	}
 }
 
 // inmemHashReader is an in-memory tlog.HashReader indexed by stored hash index.
@@ -122,7 +107,7 @@ func TestMTHAppendixVector(t *testing.T) {
 			if !valid(start, end) {
 				continue
 			}
-			subtree := mth(leaves[start:end])
+			subtree := MTH(leaves[start:end])
 			fmt.Fprintf(h, "[%d, %d) %s\n", start, end, hex.EncodeToString(subtree[:]))
 		}
 	}
@@ -141,9 +126,9 @@ func TestMTHMatchesTreeHash(t *testing.T) {
 		if err != nil {
 			t.Fatalf("TreeHash(%d): %s", n, err)
 		}
-		got := mth(leafHashes(entries))
+		got := MTH(leafHashes(entries))
 		if got != want {
-			t.Errorf("mth(%d leaves) = %x, want %x from x/mod TreeHash", n, got, want)
+			t.Errorf("MTH(%d leaves) = %x, want %x from x/mod TreeHash", n, got, want)
 		}
 	}
 }
@@ -154,9 +139,9 @@ func TestMTHMatchesTreeHash(t *testing.T) {
 func TestSubtreeProofExamples(t *testing.T) {
 	leaves := leafHashes(seqLeaves(14))
 	reader := buildHashReader(t, seqLeaves(14))
-	root := mth(leaves)
+	root := MTH(leaves)
 	mthAt := func(start, end int64) tlog.Hash {
-		return mth(leaves[start:end])
+		return MTH(leaves[start:end])
 	}
 
 	cases := []struct {
@@ -201,7 +186,7 @@ func TestSubtreeConsistencyProofAppendixVector(t *testing.T) {
 
 	h := sha256.New()
 	for n := int64(0); n <= 130; n++ {
-		root := mth(leaves[:n])
+		root := MTH(leaves[:n])
 		for end := int64(1); end <= n; end++ {
 			for start := int64(0); start < end; start++ {
 				if !valid(start, end) {
@@ -211,7 +196,7 @@ func TestSubtreeConsistencyProofAppendixVector(t *testing.T) {
 				if err != nil {
 					t.Fatalf("ConsistencyProof(%d, %d, %d): %s", start, end, n, err)
 				}
-				node := mth(leaves[start:end])
+				node := MTH(leaves[start:end])
 				if !VerifyConsistency(start, end, n, proof, node, root) {
 					t.Errorf("VerifyConsistency(%d, %d, %d) rejected a valid proof", start, end, n)
 				}
@@ -321,8 +306,8 @@ func TestSubtreeConsistencyProofBatchesReads(t *testing.T) {
 func TestVerifySubtreeConsistencyRejectsBadInput(t *testing.T) {
 	leaves := leafHashes(seqLeaves(14))
 	reader := buildHashReader(t, seqLeaves(14))
-	root := mth(leaves)
-	node := mth(leaves[8:13])
+	root := MTH(leaves)
+	node := MTH(leaves[8:13])
 	proof, err := ConsistencyProof(8, 13, 14, reader)
 	if err != nil {
 		t.Fatalf("ConsistencyProof(8, 13, 14): %s", err)
@@ -369,9 +354,9 @@ func TestVerifySubtreeConsistencyMatchesXtlogCheckTree(t *testing.T) {
 		entries := seqLeaves(int(n))
 		reader := buildHashReader(t, entries)
 		leaves := leafHashes(entries)
-		root := mth(leaves)
+		root := MTH(leaves)
 		for end := int64(1); end < n; end++ {
-			subRoot := mth(leaves[:end])
+			subRoot := MTH(leaves[:end])
 			proof, err := ConsistencyProof(0, end, n, reader)
 			if err != nil {
 				t.Fatalf("ConsistencyProof(0, %d, %d): %s", end, n, err)
@@ -399,9 +384,9 @@ func TestVerifySubtreeConsistencyMatchesXtlogCheckTree(t *testing.T) {
 func TestVerifySubtreeConsistencyRejectsMismatchedProof(t *testing.T) {
 	leaves := leafHashes(seqLeaves(14))
 	reader := buildHashReader(t, seqLeaves(14))
-	root := mth(leaves)
+	root := MTH(leaves)
 	mthAt := func(start, end int64) tlog.Hash {
-		return mth(leaves[start:end])
+		return MTH(leaves[start:end])
 	}
 
 	proof, err := ConsistencyProof(8, 13, 14, reader)
@@ -416,8 +401,8 @@ func TestVerifySubtreeConsistencyRejectsMismatchedProof(t *testing.T) {
 	for i := range otherEntries {
 		otherEntries[i] = []byte{0xa1, byte(i)}
 	}
-	rootAt13 := mth(leafHashes(seqLeaves(13)))
-	otherRoot := mth(leafHashes(otherEntries))
+	rootAt13 := MTH(leafHashes(seqLeaves(13)))
+	otherRoot := MTH(leafHashes(otherEntries))
 
 	cases := []struct {
 		name     string
@@ -447,14 +432,14 @@ func TestSubtreeRoundTrip(t *testing.T) {
 		entries := seqLeaves(int(n))
 		leaves := leafHashes(entries)
 		reader := buildHashReader(t, entries)
-		root := mth(leaves)
+		root := MTH(leaves)
 
 		for start := int64(0); start < n; start++ {
 			for end := start + 1; end <= n; end++ {
 				if !valid(start, end) {
 					continue
 				}
-				node := mth(leaves[start:end])
+				node := MTH(leaves[start:end])
 				proof, err := ConsistencyProof(start, end, n, reader)
 				if err != nil {
 					t.Fatalf("ConsistencyProof(%d, %d, %d): %s", start, end, n, err)

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"slices"
 	"strings"
 
@@ -370,7 +371,7 @@ func writeTile(
 		return nil
 	}
 
-	path := prefix + tilePath(coords)
+	key := path.Join(prefix, tilePath(coords))
 
 	var contentEncoding *string
 	if compress {
@@ -398,7 +399,7 @@ func writeTile(
 	bucket := s3c.Bucket()
 	_, err := s3c.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:          &bucket,
-		Key:             &path,
+		Key:             &key,
 		ContentEncoding: contentEncoding,
 		ContentType:     &contentType,
 		CacheControl:    &cacheControl,
@@ -414,9 +415,9 @@ func writeTile(
 		// Partial tiles are written at different paths based on width.
 		// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-412-precondition-failed.html
 		if ok && respErr.HTTPStatusCode() == http.StatusPreconditionFailed {
-			return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), path, ErrFileExists)
+			return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), key, ErrFileExists)
 		}
-		return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), path, err)
+		return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), key, err)
 	}
 	return nil
 }
@@ -479,11 +480,11 @@ func getTile(ctx context.Context, s3c simpleS3, coords tlog.Tile, prefix string)
 		return nil, nil
 	}
 
-	path := prefix + tilePath(coords)
+	key := path.Join(prefix, tilePath(coords))
 	bucket := s3c.Bucket()
 	resp, err := s3c.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &bucket,
-		Key:    &path,
+		Key:    &key,
 	})
 	if err != nil {
 		return nil, err

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -1,0 +1,483 @@
+package tiles
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/mod/sumdb/tlog"
+
+	"github.com/letsencrypt/boulder/trees/entry"
+	"github.com/letsencrypt/boulder/trees/subtree"
+)
+
+var ErrFileExists = errors.New("file exists")
+
+// simpleS3 matches the subset of the s3.Client interface which we use, to allow
+// simpler mocking in tests.
+type simpleS3 interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	Bucket() string
+}
+
+// Frontier contains all the tiles on the right edge of the tree,
+// partial and full. It keeps track of which tiles have been
+// modified and need to be written to storage.
+//
+// When we need to append a hash to a level with a full tile, the
+// full tile gets moved into a holding list of tiles that are not
+// on the right edge but need to be written.
+type Frontier struct {
+	// The rightmost hash tiles in the tree, ordered from level 0
+	// (leaf hashes) to level N (containing the root hash).
+	// Will be empty only on an empty tree (i.e. NewFrontier())
+	hashesTiles []*hashesTile
+
+	// entryTile contains the rightmost tile in the entries layer.
+	// Will be empty only on an empty tree (i.e. NewFrontier())
+	entryTile *entryTile
+
+	// This level of hashes and all below it need writing to storage
+	// (including entries).
+	//
+	// -1 means nothing needs writing.
+	dirtyLevel int
+
+	// Tiles pushed off the frontier are stored here to be written. No particular order.
+	fullHashesTiles []*hashesTile
+	fullEntryTiles  []*entryTile
+
+	treeSize int64
+}
+
+// hashesTile represents a tile containing hashes.
+type hashesTile struct {
+	// Note we don't bother setting H because it's not encoded
+	// in paths for tlog-tiles.
+	coords tlog.Tile
+	data   []tlog.Hash
+}
+
+// entryTile represent a tile containing entries.
+type entryTile struct {
+	coords tlog.Tile
+	data   []byte
+}
+
+// NewFrontier returns a frontier object representing an empty tree,
+// suitable for initializing a tree for the first time.
+func NewFrontier() *Frontier {
+	return &Frontier{
+		entryTile: &entryTile{
+			coords: tlog.Tile{
+				L: -1, // entries layer is represented as -1.
+			},
+		},
+		dirtyLevel: -1,
+	}
+}
+
+// Load loads the current frontier from storage, given the current tree size.
+func Load(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Frontier, error) {
+	if treeSize == 0 {
+		return nil, fmt.Errorf("can't load an empty tree")
+	}
+
+	tileIndex := treeSize / 256
+	width := int(treeSize % 256)
+	// If the tile would be empty get the full tile to its left instead.
+	if width == 0 {
+		tileIndex--
+		width = 256
+	}
+
+	coords := tlog.Tile{
+		L: -1, // entries layer is represented as -1.
+		N: tileIndex,
+		W: width,
+	}
+
+	entryData, err := getTile(ctx, s3c, coords, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	br := entry.NewBundleReader(entryData)
+	var entriesCount int
+	for ; ; entriesCount++ {
+		_, _, err = br.ReadEntry()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("parsing entries: %s", err)
+		}
+	}
+	if entriesCount != coords.W {
+		return nil, fmt.Errorf("reading entries from %q: got %d entries, want %d",
+			tilePath(coords), entriesCount, coords.W)
+	}
+
+	entryTile := &entryTile{
+		coords: coords,
+		data:   entryData,
+	}
+
+	var hashesTiles []*hashesTile
+	// Iterate up the tree. layerSize is the number of hashes (not tiles)
+	// in a layer.
+	for layerSize := treeSize; layerSize > 0; layerSize /= 256 {
+		level := len(hashesTiles)
+		tileIndex = layerSize / 256
+
+		width := int(layerSize % 256)
+		// If the tile would be empty get the full tile to its left instead.
+		if width == 0 {
+			tileIndex--
+			width = 256
+		}
+
+		coords := tlog.Tile{
+			L: level,
+			N: tileIndex,
+			W: width,
+		}
+
+		body, err := getTile(ctx, s3c, coords, prefix)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(body) != width*tlog.HashSize {
+			return nil, fmt.Errorf("%q: got %d bytes, expected %d",
+				tilePath(coords), len(body), width*tlog.HashSize)
+		}
+
+		var data []tlog.Hash
+		for i := 0; i < width; i++ {
+			var hash tlog.Hash
+			copy(hash[:], body[:tlog.HashSize])
+			data = append(data, hash)
+			body = body[tlog.HashSize:]
+		}
+
+		hashesTiles = append(hashesTiles, &hashesTile{
+			coords: coords,
+			data:   data,
+		})
+	}
+
+	return &Frontier{
+		hashesTiles: hashesTiles,
+		entryTile:   entryTile,
+		treeSize:    treeSize,
+		dirtyLevel:  -1,
+	}, nil
+}
+
+// TreeSize returns the current tree size.
+func (f *Frontier) TreeSize() int64 {
+	return f.treeSize
+}
+
+// AppendEntry appends a single MTCLogEntry to the entries tile and a
+// corresponding hash to the level-0 hashes tile, updating any higher
+// levels as needed.
+func (f *Frontier) AppendEntry(mtcle *entry.MTCLogEntry) error {
+	mtcleBytes, err := mtcle.Marshal()
+	if err != nil {
+		return err
+	}
+
+	// TODO: this serializes the MTCLogEntry again, which is a bit silly.
+	// Refactor?
+	bb := entry.NewBundleBuilder(nil)
+	bb.Add(mtcle)
+	bundleBytes, err := bb.Bytes()
+	if err != nil {
+		return err
+	}
+
+	if f.entryTile.coords.W == 256 {
+		// Existing tile is full. Queue it for writing (if it's dirty).
+		if f.dirtyLevel >= 0 {
+			f.fullEntryTiles = append(f.fullEntryTiles, f.entryTile)
+		}
+		f.entryTile = &entryTile{
+			coords: tlog.Tile{
+				L: -1, // entries layer is represented as -1.
+				N: f.treeSize / 256,
+			},
+		}
+	}
+
+	f.entryTile.data = append(f.entryTile.data, bundleBytes...)
+	f.entryTile.coords.W++
+
+	f.appendHash(tlog.RecordHash(mtcleBytes), 0)
+
+	f.treeSize++
+
+	return nil
+}
+
+// appendHash appends a single hash to the given level, updating any levels
+// above as needed.
+//
+// Panics if asked to append more than one level above the top of the tree
+// (in other words, if level > len(hashesTiles)).
+func (f *Frontier) appendHash(val tlog.Hash, level int) {
+	if level == len(f.hashesTiles) {
+		// Add a level to the top of the tree by expanding hashesTiles.
+		f.hashesTiles = append(f.hashesTiles, &hashesTile{
+			coords: tlog.Tile{L: level},
+		})
+	} else if level > len(f.hashesTiles) {
+		panic(fmt.Sprintf("tried to write a level %d tile to a frontier with %d levels",
+			level, len(f.hashesTiles)))
+	}
+
+	currentTile := f.hashesTiles[level]
+	if currentTile.coords.W != 256 {
+		currentTile.data = append(currentTile.data, val)
+		currentTile.coords.W++
+
+		if currentTile.coords.W == 256 {
+			// We finished a tile. Now we get to append that tile's hash
+			// to the tile above it.
+			fullTileHash := subtree.MTH(currentTile.data)
+			f.appendHash(fullTileHash, level+1)
+		}
+	} else {
+		// Move the full tile to the holding area and create
+		// a new one with one entry. Only if the full tile
+		// needs to be written.
+		if f.dirtyLevel >= level {
+			f.fullHashesTiles = append(f.fullHashesTiles, currentTile)
+		}
+
+		newCoords := currentTile.coords
+		newCoords.N++
+		newCoords.W = 1
+
+		f.hashesTiles[level] = &hashesTile{
+			coords: newCoords,
+			data:   []tlog.Hash{val},
+		}
+	}
+
+	f.dirtyLevel = max(f.dirtyLevel, level)
+}
+
+// Flush writes all dirty tiles to storage and clears their dirty status.
+//
+// If it errors partway, dirty status is not reset but subsequent flushes
+// will likely fail (duplicate writes).
+//
+// Errors if the tree is empty (i.e. NewFrontier() without appending any entries).
+func (f *Frontier) Flush(ctx context.Context, s3c simpleS3, prefix string) error {
+	if f.treeSize == 0 {
+		return fmt.Errorf("an empty tree has nothing to write")
+	}
+
+	if f.dirtyLevel == -1 {
+		// Nothing's dirty!
+		return nil
+	}
+
+	for _, t := range f.fullEntryTiles {
+		err := writeTile(ctx, s3c, prefix, t.coords, t.data, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := writeTile(ctx, s3c, prefix, f.entryTile.coords, f.entryTile.data, true)
+	if err != nil {
+		return err
+	}
+
+	dirtyHashTiles := append(f.fullHashesTiles, f.hashesTiles[:f.dirtyLevel+1]...)
+	for _, dt := range dirtyHashTiles {
+		if len(dt.data) == 0 {
+			return fmt.Errorf("shouldn't happen: empty hash tile %v", dt.coords)
+		}
+		// Transform our slice of 32-byte arrays into a contiguous byte slice.
+		body := make([]byte, 0, len(dt.data)*tlog.HashSize)
+		for i := range len(dt.data) {
+			body = append(body, dt.data[i][:]...)
+		}
+		err := writeTile(ctx, s3c, prefix, dt.coords, body, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	f.fullHashesTiles = nil
+	f.fullEntryTiles = nil
+	f.dirtyLevel = -1
+	return nil
+}
+
+// writeTile writes a single tile. Handles hash tiles and entry tiles, using coords.L to distinguish.
+//
+// If compress is true, compresses the data before storing.
+func writeTile(
+	ctx context.Context,
+	s3c simpleS3,
+	prefix string,
+	coords tlog.Tile,
+	body []byte,
+	compress bool,
+) error {
+	path := prefix + tilePath(coords)
+	if len(body) == 0 {
+		return fmt.Errorf("shouldn't happen: attempted to write empty tile to %q", path)
+	}
+
+	var contentEncoding *string
+	if compress {
+		gzipStr := "gzip"
+		contentEncoding = &gzipStr
+		var buf bytes.Buffer
+		gzipWriter := gzip.NewWriter(&buf)
+		_, err := gzipWriter.Write(body)
+		if err != nil {
+			return err
+		}
+
+		err = gzipWriter.Close()
+		if err != nil {
+			return err
+		}
+
+		body = buf.Bytes()
+	}
+
+	contentType := "application/octet-stream"
+	cacheControl := "public, max-age=604800, immutable"
+	star := "*"
+
+	bucket := s3c.Bucket()
+	_, err := s3c.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:          &bucket,
+		Key:             &path,
+		ContentEncoding: contentEncoding,
+		ContentType:     &contentType,
+		CacheControl:    &cacheControl,
+		Body:            bytes.NewReader(body),
+		// Error if the file exists
+		IfNoneMatch: &star,
+	})
+	if err != nil {
+		respErr, ok := errors.AsType[*awshttp.ResponseError](err)
+		// PreconditionFailed, in this case, means our IfNoneMatch: "*"
+		// failed, which in turn means the file already existed. By the
+		// way the spec is designed, we should never write a tile twice.
+		// Partial tiles are written at different paths based on width.
+		// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-412-precondition-failed.html
+		if ok && respErr.HTTPStatusCode() == http.StatusPreconditionFailed {
+			return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), path, ErrFileExists)
+		}
+		return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), path, err)
+	}
+	return nil
+}
+
+// tilePath returns a  tile path like tile/0/x001/x234/067.p/23.
+//
+// tileIndex is the index of a tile within a level, or in other words an
+// entry index divided by 256.
+//
+// If tileLevel is -1, the path starts with tile/entries/ instead of tile/L.
+//
+// Produces invalid results when treeSize is 0 or if the tileIndex is
+// beyond the treeSize.
+//
+// Note: this is similar to tlog.Tile.Path(), but Path() uses "tile/" and "tile/<H>/data/"
+// where we need "tile/" and "tile/entries/" (and don't use <H>).
+//
+// https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md
+func tilePath(coords tlog.Tile) string {
+	var out strings.Builder
+	if coords.L == -1 {
+		out.WriteString("tile/entries/")
+	} else {
+		fmt.Fprintf(&out, "tile/%d/", coords.L)
+	}
+
+	tileIndexString := fmt.Sprintf("%d", coords.N)
+	for len(tileIndexString)%3 != 0 {
+		tileIndexString = "0" + tileIndexString
+	}
+
+	// Construct the 3-digit-chunked form of tileIndex.
+	// https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree
+	//
+	// Example: N(1234067) = "x001/x234/067"
+	for remaining := tileIndexString; len(remaining) != 0; {
+		var chunk string
+		remaining, chunk = remaining[3:], remaining[:3]
+		// "x" for each path component but the last.
+		if len(remaining) > 0 {
+			out.WriteString("x")
+		}
+		out.WriteString(chunk)
+		if len(remaining) >= 3 {
+			out.WriteString("/")
+		}
+	}
+
+	if coords.W != 256 {
+		// We're at the right edge and the last tile is partial.
+		fmt.Fprintf(&out, ".p/%d", coords.W)
+	}
+
+	return out.String()
+}
+
+func getTile(ctx context.Context, s3c simpleS3, coords tlog.Tile, prefix string) ([]byte, error) {
+	path := prefix + tilePath(coords)
+	bucket := s3c.Bucket()
+	resp, err := s3c.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &path,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.ContentEncoding != nil && *resp.ContentEncoding == "gzip" {
+		gzipReader, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+
+		decompressed, err := io.ReadAll(gzipReader)
+		if err != nil {
+			return nil, err
+		}
+
+		err = gzipReader.Close()
+		if err != nil {
+			return nil, err
+		}
+		return decompressed, nil
+	}
+
+	return body, nil
+
+}

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -54,6 +54,11 @@ type simpleS3 interface {
 // When a tile becomes full, it gets moved into a holding list of
 // tiles that are not on the right edge but need to be written and
 // its MTH gets appended to the tile above it.
+//
+// The zero value of Frontier represents an empty tree. Empty trees
+// cannot be loaded or flushed.
+//
+// Frontier is not safe for concurrent access.
 type Frontier struct {
 	// The rightmost hash tiles in the tree, ordered from level 0
 	// (leaf hashes) to the top of the tree.

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -3,7 +3,7 @@
 // Entry tiles contain up to 256 MTCLogEntry objects and are stored as compressed entry bundles.
 //
 // Hash tiles contain up to 256 32-byte SHA-256 hashes, concatenated. The tile represents up to
-// 8 layers of the Merkle Tree, but only the bottom of those layers is actually stored. Higher
+// 8 layers of the Merkle Tree, but only the bottom-most of those layers is actually stored. Higher
 // layers are calculated from the tile contents as needed.
 //
 // Invariants:
@@ -58,7 +58,7 @@ type Frontier struct {
 	// The rightmost hash tiles in the tree, ordered from level 0
 	// (leaf hashes) to the top of the tree.
 	//
-	// Will be empty only on an empty tree (i.e. NewFrontier()).
+	// Will be empty only on an empty tree.
 	//
 	// Tiles in this list may be empty (coords.W == 0) but never
 	// full (coords.W == 256).
@@ -113,34 +113,21 @@ func (e *entryTile) append(val []byte) {
 	e.data = append(e.data, val...)
 }
 
-// NewFrontier returns a frontier object representing an empty tree,
-// suitable for initializing a tree for the first time.
-func NewFrontier() *Frontier {
-	return &Frontier{
-		entryTile: &entryTile{
-			coords: tlog.Tile{
-				L: -1, // entries layer is represented as -1.
-			},
-		},
-		dirtyLevel: -1,
-	}
-}
-
-// Load loads the current frontier from storage, given the current tree size.
+// LoadFrontier loads the current frontier from storage, given the current tree size.
 //
 // Succeeds only if all the frontier tiles for that tree size exist in storage.
-func Load(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Frontier, error) {
+func LoadFrontier(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Frontier, error) {
 	if treeSize == 0 {
 		return nil, fmt.Errorf("can't load an empty tree")
 	}
 
-	coords := tlog.Tile{
+	entryCoords := tlog.Tile{
 		L: -1, // entries layer is represented as -1.
 		N: treeSize / 256,
 		W: int(treeSize % 256),
 	}
 
-	entryData, err := getTile(ctx, s3c, coords, prefix)
+	entryData, err := getTile(ctx, s3c, entryCoords, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -156,13 +143,13 @@ func Load(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Fr
 			return nil, fmt.Errorf("parsing entries: %s", err)
 		}
 	}
-	if entriesCount != coords.W {
+	if entriesCount != entryCoords.W {
 		return nil, fmt.Errorf("reading entries from %q: got %d entries, want %d",
-			tilePath(coords), entriesCount, coords.W)
+			tilePath(entryCoords), entriesCount, entryCoords.W)
 	}
 
 	entryTile := &entryTile{
-		coords: coords,
+		coords: entryCoords,
 		data:   entryData,
 	}
 
@@ -220,9 +207,9 @@ func (f *Frontier) RootHash() tlog.Hash {
 	}
 
 	// Intuition:
-	//  A leaf tile's MTH is the MTH of its nodes, whether it's partial or full.
+	//  A leaf (L=0) tile's MTH is the MTH of its nodes, whether it's partial or full.
 	//
-	//  At level L, a tile contains hashes of _complete_ subtrees from level L-1.
+	//  At level L > 0, a tile contains hashes of _complete_ subtrees from level L-1.
 	//  Imagine an empty spot at the end where the next hash will go when it's complete.
 	//  We temporarily put one more hash there - the MTH of the partial subtree below
 	//  (if there is one). Then we calculate MTH of the level L tile including that
@@ -266,6 +253,16 @@ func (f *Frontier) RootHash() tlog.Hash {
 //
 // On error, the Frontier is unchanged.
 func (f *Frontier) AppendEntry(mtcle *entry.MTCLogEntry) error {
+	// First time appending to a zero Frontier, initialize it.
+	if f.entryTile == nil {
+		f.entryTile = &entryTile{
+			coords: tlog.Tile{
+				L: -1, // entries layer is represented as -1.
+			},
+		}
+		f.dirtyLevel = -1
+	}
+
 	mtcleBytes, err := mtcle.Marshal()
 	if err != nil {
 		return err
@@ -348,7 +345,7 @@ func (f *Frontier) appendHash(val tlog.Hash, level int) {
 // If it errors partway, dirty status is not reset but subsequent flushes
 // will likely fail (duplicate writes).
 //
-// Errors if the tree is empty (i.e. NewFrontier() without appending any entries).
+// Errors if the tree is empty.
 func (f *Frontier) Flush(ctx context.Context, s3c simpleS3, prefix string) error {
 	if f.treeSize == 0 {
 		return fmt.Errorf("an empty tree has nothing to write")

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -1,3 +1,18 @@
+// Package tiles implements https://c2sp.org/tlog-tiles.
+//
+// Entry tiles contain up to 256 MTCLogEntry objects and are stored as compressed entry bundles.
+//
+// Hash tiles contain up to 256 32-byte SHA-256 hashes, concatenated. The tile represents up to
+// 8 layers of the Merkle Tree, but only the bottom of those layers is actually stored. Higher
+// layers are calculated from the tile contents as needed.
+//
+// Invariants:
+//   - Tiles in storage are never empty.
+//   - Tiles in storage are immutable.
+//   - A hash is only appended to a tile when it will be permanent. Equivalently: a hash is only
+//     appended to a tile when the subtree it represents is complete.
+//   - Any hash stored in a level L tile is equal to MTH(c), where c is a list of exactly 256
+//     hashes stored in a child tile at level L-1 (for L > 0).
 package tiles
 
 import (
@@ -20,9 +35,10 @@ import (
 	"github.com/letsencrypt/boulder/trees/subtree"
 )
 
-var ErrFileExists = errors.New("file exists")
+// ErrTileExists is returned when trying to write a tile that already exists in storage.
+var ErrTileExists = errors.New("tile exists")
 
-// simpleS3 matches the subset of the s3.Client interface which we use, to allow
+// simpleS3 matches the subset of the bs3.Client interface which we use, to allow
 // simpler mocking in tests.
 type simpleS3 interface {
 	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
@@ -40,7 +56,8 @@ type simpleS3 interface {
 // its MTH gets appended to the tile above it.
 type Frontier struct {
 	// The rightmost hash tiles in the tree, ordered from level 0
-	// (leaf hashes) to level N (containing the root hash).
+	// (leaf hashes) to the top of the tree.
+	//
 	// Will be empty only on an empty tree (i.e. NewFrontier()).
 	//
 	// Tiles in this list may be empty (coords.W == 0) but never
@@ -58,9 +75,11 @@ type Frontier struct {
 	dirtyLevel int
 
 	// Tiles pushed off the frontier are stored here to be written. No particular order.
+	// These have entries if and only if dirtyLevel > 0.
 	fullHashesTiles []*hashesTile
 	fullEntryTiles  []*entryTile
 
+	// treeSize is the current size of the tree.
 	treeSize int64
 }
 
@@ -71,15 +90,27 @@ type hashesTile struct {
 	// Note we don't bother setting H because it's not encoded
 	// in paths for tlog-tiles.
 	coords tlog.Tile
-	data   []tlog.Hash
+	// Invariant: len(data) == coords.W
+	data []tlog.Hash
 }
 
-// entryTile represent a tile containing entries.
+func (h *hashesTile) append(val tlog.Hash) {
+	h.coords.W++
+	h.data = append(h.data, val)
+}
+
+// entryTile represents a tile containing entries.
 // It may be empty, partial or full. If it's full it can only be
 // part of fullEntryTiles.
 type entryTile struct {
 	coords tlog.Tile
-	data   []byte
+	// data contains an entry bundle with coords.W entries.
+	data []byte
+}
+
+func (e *entryTile) append(val []byte) {
+	e.coords.W++
+	e.data = append(e.data, val...)
 }
 
 // NewFrontier returns a frontier object representing an empty tree,
@@ -96,6 +127,8 @@ func NewFrontier() *Frontier {
 }
 
 // Load loads the current frontier from storage, given the current tree size.
+//
+// Succeeds only if all the frontier tiles for that tree size exist in storage.
 func Load(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Frontier, error) {
 	if treeSize == 0 {
 		return nil, fmt.Errorf("can't load an empty tree")
@@ -195,10 +228,12 @@ func (f *Frontier) RootHash() tlog.Hash {
 	//  (if there is one). Then we calculate MTH of the level L tile including that
 	//  temporary hash.
 	//
+	// Since MTH([x]) == x, appending a hash to an empty tile and then taking its MTH is
+	// equivalent to simply skipping the tile.
+	//
 	// That lets us calculate the root hash like so:
 	//
-	//  - Climb from level 0.
-	//  - Skip any empty tiles (a parent or grandparent will incorporate the hashes from below).
+	//  - Climb from level 0, skipping any empty tiles.
 	//  - If we don't have a hash yet, calculate MTH of the current tile.
 	//  - Otherwise, calculate MTH of the current tile, with the previous tile's MTH appended.
 	var currentHash tlog.Hash
@@ -228,6 +263,8 @@ func (f *Frontier) RootHash() tlog.Hash {
 // AppendEntry appends a single MTCLogEntry to the entries tile and a
 // corresponding hash to the level-0 hashes tile, updating any higher
 // levels as needed.
+//
+// On error, the Frontier is unchanged.
 func (f *Frontier) AppendEntry(mtcle *entry.MTCLogEntry) error {
 	mtcleBytes, err := mtcle.Marshal()
 	if err != nil {
@@ -243,8 +280,7 @@ func (f *Frontier) AppendEntry(mtcle *entry.MTCLogEntry) error {
 		return err
 	}
 
-	f.entryTile.data = append(f.entryTile.data, bundleBytes...)
-	f.entryTile.coords.W++
+	f.entryTile.append(bundleBytes)
 
 	if f.entryTile.coords.W == 256 {
 		// Tile is full. Queue it for writing.
@@ -285,8 +321,7 @@ func (f *Frontier) appendHash(val tlog.Hash, level int) {
 	}
 
 	currentTile := f.hashesTiles[level]
-	currentTile.data = append(currentTile.data, val)
-	currentTile.coords.W++
+	currentTile.append(val)
 
 	if currentTile.coords.W == 256 {
 		// Move the full tile to the holding area and create a new empty one.
@@ -355,7 +390,9 @@ func (f *Frontier) Flush(ctx context.Context, s3c simpleS3, prefix string) error
 	return nil
 }
 
-// writeTile writes a single tile. Handles hash tiles and entry tiles, using coords.L to distinguish.
+// writeTile writes a single tile (hash tile or entry tile).
+//
+// If coords.W is 0, returns nil without writing anything.
 //
 // If compress is true, compresses the data before storing.
 func writeTile(
@@ -415,22 +452,16 @@ func writeTile(
 		// Partial tiles are written at different paths based on width.
 		// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-412-precondition-failed.html
 		if ok && respErr.HTTPStatusCode() == http.StatusPreconditionFailed {
-			return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), key, ErrFileExists)
+			return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), key, ErrTileExists)
 		}
 		return fmt.Errorf("writing s3://%s/%s: %w", s3c.Bucket(), key, err)
 	}
 	return nil
 }
 
-// tilePath returns a  tile path like tile/0/x001/x234/067.p/23.
+// tilePath returns a tile path like tile/0/x001/x234/067.p/23.
 //
-// tileIndex is the index of a tile within a level, or in other words an
-// entry index divided by 256.
-//
-// If tileLevel is -1, the path starts with tile/entries/ instead of tile/L.
-//
-// Produces invalid results when treeSize is 0 or if the tileIndex is
-// beyond the treeSize.
+// If coords.L is -1, the path starts with tile/entries/ instead of tile/L.
 //
 // Note: this is similar to tlog.Tile.Path(), but Path() uses "tile/" and "tile/<H>/data/"
 // where we need "tile/" and "tile/entries/" (and don't use <H>).
@@ -474,6 +505,9 @@ func tilePath(coords tlog.Tile) string {
 	return out.String()
 }
 
+// getTile fetches a single tile from storage, transparently decompressing if needed.
+//
+// If coords.W is zero, returns an empty tile without reading from storage.
 func getTile(ctx context.Context, s3c simpleS3, coords tlog.Tile, prefix string) ([]byte, error) {
 	if coords.W == 0 {
 		// Neither write nor read an empty tile. They do not exist in storage.

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
@@ -29,20 +30,24 @@ type simpleS3 interface {
 }
 
 // Frontier contains all the tiles on the right edge of the tree,
-// partial and full. It keeps track of which tiles have been
-// modified and need to be written to storage.
+// which may be partial or empty (but not full). It keeps track
+// of which tiles have been modified and need to be written to
+// storage.
 //
-// When we need to append a hash to a level with a full tile, the
-// full tile gets moved into a holding list of tiles that are not
-// on the right edge but need to be written.
+// When a tile becomes full, it gets moved into a holding list of
+// tiles that are not on the right edge but need to be written and
+// its MTH gets appended to the tile above it.
 type Frontier struct {
 	// The rightmost hash tiles in the tree, ordered from level 0
 	// (leaf hashes) to level N (containing the root hash).
-	// Will be empty only on an empty tree (i.e. NewFrontier())
+	// Will be empty only on an empty tree (i.e. NewFrontier()).
+	//
+	// Tiles in this list may be empty (coords.W == 0) but never
+	// full (coords.W == 256).
 	hashesTiles []*hashesTile
 
 	// entryTile contains the rightmost tile in the entries layer.
-	// Will be empty only on an empty tree (i.e. NewFrontier())
+	// May be empty but never full.
 	entryTile *entryTile
 
 	// This level of hashes and all below it need writing to storage
@@ -59,6 +64,8 @@ type Frontier struct {
 }
 
 // hashesTile represents a tile containing hashes.
+// It may be empty, partial, or full. If it's full it can only
+// be part of fullHashesTiles.
 type hashesTile struct {
 	// Note we don't bother setting H because it's not encoded
 	// in paths for tlog-tiles.
@@ -67,6 +74,8 @@ type hashesTile struct {
 }
 
 // entryTile represent a tile containing entries.
+// It may be empty, partial or full. If it's full it can only be
+// part of fullEntryTiles.
 type entryTile struct {
 	coords tlog.Tile
 	data   []byte
@@ -91,18 +100,10 @@ func Load(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Fr
 		return nil, fmt.Errorf("can't load an empty tree")
 	}
 
-	tileIndex := treeSize / 256
-	width := int(treeSize % 256)
-	// If the tile would be empty get the full tile to its left instead.
-	if width == 0 {
-		tileIndex--
-		width = 256
-	}
-
 	coords := tlog.Tile{
 		L: -1, // entries layer is represented as -1.
-		N: tileIndex,
-		W: width,
+		N: treeSize / 256,
+		W: int(treeSize % 256),
 	}
 
 	entryData, err := getTile(ctx, s3c, coords, prefix)
@@ -135,20 +136,10 @@ func Load(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Fr
 	// Iterate up the tree. layerSize is the number of hashes (not tiles)
 	// in a layer.
 	for layerSize := treeSize; layerSize > 0; layerSize /= 256 {
-		level := len(hashesTiles)
-		tileIndex = layerSize / 256
-
-		width := int(layerSize % 256)
-		// If the tile would be empty get the full tile to its left instead.
-		if width == 0 {
-			tileIndex--
-			width = 256
-		}
-
 		coords := tlog.Tile{
-			L: level,
-			N: tileIndex,
-			W: width,
+			L: len(hashesTiles),
+			N: layerSize / 256,
+			W: int(layerSize % 256),
 		}
 
 		body, err := getTile(ctx, s3c, coords, prefix)
@@ -156,13 +147,13 @@ func Load(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Fr
 			return nil, err
 		}
 
-		if len(body) != width*tlog.HashSize {
+		if len(body) != coords.W*tlog.HashSize {
 			return nil, fmt.Errorf("%q: got %d bytes, expected %d",
-				tilePath(coords), len(body), width*tlog.HashSize)
+				tilePath(coords), len(body), coords.W*tlog.HashSize)
 		}
 
 		var data []tlog.Hash
-		for i := 0; i < width; i++ {
+		for i := 0; i < coords.W; i++ {
 			var hash tlog.Hash
 			copy(hash[:], body[:tlog.HashSize])
 			data = append(data, hash)
@@ -188,6 +179,51 @@ func (f *Frontier) TreeSize() int64 {
 	return f.treeSize
 }
 
+// RootHash calculates and returns the current root hash.
+func (f *Frontier) RootHash() tlog.Hash {
+	if len(f.hashesTiles) == 0 {
+		return subtree.MTH(nil)
+	}
+
+	// Intuition:
+	//  A leaf tile's MTH is the MTH of its nodes, whether it's partial or full.
+	//
+	//  At level L, a tile contains hashes of _complete_ subtrees from level L-1.
+	//  Imagine an empty spot at the end where the next hash will go when it's complete.
+	//  We temporarily put one more hash there - the MTH of the partial subtree below
+	//  (if there is one). Then we calculate MTH of the level L tile including that
+	//  temporary hash.
+	//
+	// That lets us calculate the root hash like so:
+	//
+	//  - Climb from level 0.
+	//  - Skip any empty tiles (a parent or grandparent will incorporate the hashes from below).
+	//  - If we don't have a hash yet, calculate MTH of the current tile.
+	//  - Otherwise, calculate MTH of the current tile, with the previous tile's MTH appended.
+	var currentHash tlog.Hash
+	var currentHashInitialized bool
+	for level := 0; level < len(f.hashesTiles); level++ {
+		if f.hashesTiles[level].coords.W == 0 {
+			continue
+		}
+		hashes := f.hashesTiles[level].data
+		if !currentHashInitialized {
+			currentHash = subtree.MTH(hashes)
+			currentHashInitialized = true
+		} else {
+			currentHash = subtree.MTH(append(slices.Clone(hashes), currentHash))
+		}
+	}
+
+	if !currentHashInitialized {
+		// This shouldn't happen because the top tile is never empty.
+		// When we add a layer we immediately put a hash in it.
+		panic("shouldn't happen: all tiles on frontier are empty")
+	}
+
+	return currentHash
+}
+
 // AppendEntry appends a single MTCLogEntry to the entries tile and a
 // corresponding hash to the level-0 hashes tile, updating any higher
 // levels as needed.
@@ -206,22 +242,24 @@ func (f *Frontier) AppendEntry(mtcle *entry.MTCLogEntry) error {
 		return err
 	}
 
-	if f.entryTile.coords.W == 256 {
-		// Existing tile is full. Queue it for writing (if it's dirty).
-		if f.dirtyLevel >= 0 {
-			f.fullEntryTiles = append(f.fullEntryTiles, f.entryTile)
-		}
-		f.entryTile = &entryTile{
-			coords: tlog.Tile{
-				L: -1, // entries layer is represented as -1.
-				N: f.treeSize / 256,
-			},
-		}
-	}
-
 	f.entryTile.data = append(f.entryTile.data, bundleBytes...)
 	f.entryTile.coords.W++
 
+	if f.entryTile.coords.W == 256 {
+		// Tile is full. Queue it for writing.
+		f.fullEntryTiles = append(f.fullEntryTiles, f.entryTile)
+		// And set up a new, empty tile.
+		f.entryTile = &entryTile{
+			coords: tlog.Tile{
+				L: -1, // entries layer is represented as -1.
+				N: (f.treeSize + 1) / 256,
+				W: 0,
+			},
+			data: nil,
+		}
+	}
+
+	// Add the corresponding hash to level 0 (leaf hashes).
 	f.appendHash(tlog.RecordHash(mtcleBytes), 0)
 
 	f.treeSize++
@@ -246,32 +284,24 @@ func (f *Frontier) appendHash(val tlog.Hash, level int) {
 	}
 
 	currentTile := f.hashesTiles[level]
-	if currentTile.coords.W != 256 {
-		currentTile.data = append(currentTile.data, val)
-		currentTile.coords.W++
+	currentTile.data = append(currentTile.data, val)
+	currentTile.coords.W++
 
-		if currentTile.coords.W == 256 {
-			// We finished a tile. Now we get to append that tile's hash
-			// to the tile above it.
-			fullTileHash := subtree.MTH(currentTile.data)
-			f.appendHash(fullTileHash, level+1)
-		}
-	} else {
-		// Move the full tile to the holding area and create
-		// a new one with one entry. Only if the full tile
-		// needs to be written.
-		if f.dirtyLevel >= level {
-			f.fullHashesTiles = append(f.fullHashesTiles, currentTile)
-		}
-
-		newCoords := currentTile.coords
-		newCoords.N++
-		newCoords.W = 1
+	if currentTile.coords.W == 256 {
+		// Move the full tile to the holding area and create a new empty one.
+		f.fullHashesTiles = append(f.fullHashesTiles, currentTile)
 
 		f.hashesTiles[level] = &hashesTile{
-			coords: newCoords,
-			data:   []tlog.Hash{val},
+			coords: tlog.Tile{
+				L: level,
+				N: currentTile.coords.N + 1,
+				W: 0,
+			},
+			data: nil,
 		}
+
+		// Append the full tile's hash to the tile above it.
+		f.appendHash(subtree.MTH(currentTile.data), level+1)
 	}
 
 	f.dirtyLevel = max(f.dirtyLevel, level)
@@ -307,9 +337,6 @@ func (f *Frontier) Flush(ctx context.Context, s3c simpleS3, prefix string) error
 
 	dirtyHashTiles := append(f.fullHashesTiles, f.hashesTiles[:f.dirtyLevel+1]...)
 	for _, dt := range dirtyHashTiles {
-		if len(dt.data) == 0 {
-			return fmt.Errorf("shouldn't happen: empty hash tile %v", dt.coords)
-		}
 		// Transform our slice of 32-byte arrays into a contiguous byte slice.
 		body := make([]byte, 0, len(dt.data)*tlog.HashSize)
 		for i := range len(dt.data) {
@@ -338,10 +365,12 @@ func writeTile(
 	body []byte,
 	compress bool,
 ) error {
-	path := prefix + tilePath(coords)
-	if len(body) == 0 {
-		return fmt.Errorf("shouldn't happen: attempted to write empty tile to %q", path)
+	if coords.W == 0 {
+		// Neither write nor read an empty tile. They do not exist in storage.
+		return nil
 	}
+
+	path := prefix + tilePath(coords)
 
 	var contentEncoding *string
 	if compress {
@@ -445,6 +474,11 @@ func tilePath(coords tlog.Tile) string {
 }
 
 func getTile(ctx context.Context, s3c simpleS3, coords tlog.Tile, prefix string) ([]byte, error) {
+	if coords.W == 0 {
+		// Neither write nor read an empty tile. They do not exist in storage.
+		return nil, nil
+	}
+
 	path := prefix + tilePath(coords)
 	bucket := s3c.Bucket()
 	resp, err := s3c.GetObject(ctx, &s3.GetObjectInput{
@@ -475,9 +509,12 @@ func getTile(ctx context.Context, s3c simpleS3, coords tlog.Tile, prefix string)
 		if err != nil {
 			return nil, err
 		}
-		return decompressed, nil
+		body = decompressed
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("shouldn't happen: read empty tile body")
 	}
 
 	return body, nil
-
 }

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -9,8 +9,8 @@
 // Invariants:
 //   - Tiles in storage are never empty.
 //   - Tiles in storage are immutable.
-//   - A hash is only appended to a tile when it will be permanent. Equivalently: a hash is only
-//     appended to a tile when the subtree it represents is complete.
+//   - A hash is only appended to a tile when it will be permanent. Equivalently: only the hashes
+//     of complete subtrees are appended to a tile.
 //   - Any hash stored in a level L tile is equal to MTH(c), where c is a list of exactly 256
 //     hashes stored in a child tile at level L-1 (for L > 0).
 package tiles

--- a/trees/tiles/tiles_test.go
+++ b/trees/tiles/tiles_test.go
@@ -468,12 +468,30 @@ func TestFlushClean(t *testing.T) {
 	}
 }
 
+// TestRootHash checks RootHash against an MTH computed directly over the
+// leaf hashes at a variety of interesting sizes, including sizes that are
+// three tiles high.
 func TestRootHash(t *testing.T) {
-	f := NewFrontier()
-	got := f.RootHash()
-	want := subtree.MTH(nil)
-	if !bytes.Equal(got[:], want[:]) {
-		t.Errorf("NewFrontier().RootHash()=%s, want %s", got, want)
-	}
+	n := 65792
+	const checkAllUpTo = 600
+	spotSizes := map[int]bool{65535: true, 65536: true, 65537: true, 65791: true, 65792: true}
 
+	var leafHashes []tlog.Hash
+	f := NewFrontier()
+	for i := 0; i < n; i++ {
+		mtcle := testEntry(i)
+		leafHashes = append(leafHashes, tlog.RecordHash(testEntryBody(i)))
+
+		err := f.AppendEntry(mtcle)
+		if err != nil {
+			t.Fatalf("AppendEntry(%d): %s", i, err)
+		}
+
+		n := i + 1
+		if n <= checkAllUpTo || spotSizes[n] {
+			if got, want := f.RootHash(), subtree.MTH(leafHashes); got != want {
+				t.Errorf("RootHash at size %d: got %s, want %s", n, got, want)
+			}
+		}
+	}
 }

--- a/trees/tiles/tiles_test.go
+++ b/trees/tiles/tiles_test.go
@@ -5,13 +5,17 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"reflect"
 	"slices"
 	"testing"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/mod/sumdb/tlog"
 
@@ -70,7 +74,12 @@ func newFakeS3() *fakeS3 {
 func (f *fakeS3) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	_, ok := f.objects[*params.Key]
 	if ok {
-		return nil, fmt.Errorf("duplicate PUT: %q", *params.Key)
+		return nil, &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusPreconditionFailed}},
+				Err:      errors.New("PreconditionFailed"),
+			},
+		}
 	}
 	body, err := io.ReadAll(params.Body)
 	if err != nil {
@@ -493,5 +502,21 @@ func TestRootHash(t *testing.T) {
 				t.Errorf("RootHash at size %d: got %s, want %s", n, got, want)
 			}
 		}
+	}
+}
+
+func TestWriteTileThatAlreadyExists(t *testing.T) {
+	fs3 := newFakeS3()
+	coords := tlog.Tile{L: 0, N: 0, W: 1}
+	body := bytes.Repeat([]byte{'h'}, tlog.HashSize)
+
+	err := writeTile(t.Context(), fs3, "", coords, body, false)
+	if err != nil {
+		t.Fatalf("first writeTile: %s", err)
+	}
+
+	err = writeTile(t.Context(), fs3, "", coords, body, false)
+	if !errors.Is(err, ErrTileExists) {
+		t.Errorf("second writeTile: got %s, want ErrTileExists", err)
 	}
 }

--- a/trees/tiles/tiles_test.go
+++ b/trees/tiles/tiles_test.go
@@ -147,7 +147,7 @@ func appendEntries(t *testing.T, f *Frontier, fs3 *fakeS3, start, end int, prefi
 // `flushEvery` appends and once at the end.
 func buildFrontier(t *testing.T, fs3 *fakeS3, n int, prefix string, flushEvery int) *Frontier {
 	t.Helper()
-	f := NewFrontier()
+	f := &Frontier{}
 	appendEntries(t, f, fs3, 0, n, prefix, flushEvery)
 	return f
 }
@@ -249,7 +249,7 @@ func TestRoundTrip(t *testing.T) {
 			prefix := "p/"
 			f := buildFrontier(t, fs3, n, prefix, 100)
 
-			loaded, err := Load(t.Context(), fs3, int64(n), prefix)
+			loaded, err := LoadFrontier(t.Context(), fs3, int64(n), prefix)
 			if err != nil {
 				t.Fatalf("Load(%d): %s", n, err)
 			}
@@ -287,7 +287,7 @@ func TestStorageCorrectness(t *testing.T) {
 	fs3 := newFakeS3()
 	buildFrontier(t, fs3, reloadAt, prefix, 999)
 
-	f, err := Load(t.Context(), fs3, reloadAt, prefix)
+	f, err := LoadFrontier(t.Context(), fs3, reloadAt, prefix)
 	if err != nil {
 		t.Fatalf("Load at %d: %s", reloadAt, err)
 	}
@@ -357,7 +357,7 @@ func TestStorageCorrectness(t *testing.T) {
 	}
 
 	// Load and check equality with the in-memory copy one last time.
-	loaded, err := Load(t.Context(), fs3, n, prefix)
+	loaded, err := LoadFrontier(t.Context(), fs3, n, prefix)
 	if err != nil {
 		t.Fatalf("Load: %s", err)
 	}
@@ -375,7 +375,7 @@ func TestLoadBadHashTile(t *testing.T) {
 	o.data = o.data[:len(o.data)-1]
 	fs3.objects["tile/0/000.p/1"] = o
 
-	_, err := Load(t.Context(), fs3, 1, "")
+	_, err := LoadFrontier(t.Context(), fs3, 1, "")
 	if err == nil {
 		t.Errorf("Load with truncated hash tile: got nil, want error")
 	}
@@ -407,7 +407,7 @@ func TestLoadBadEntryTile(t *testing.T) {
 			// ContentEncoding).
 			fs3.objects["tile/entries/000.p/2"] = fakeS3Object{data: tc.body}
 
-			_, err := Load(t.Context(), fs3, 2, "")
+			_, err := LoadFrontier(t.Context(), fs3, 2, "")
 			if err == nil {
 				t.Errorf("Load with %s in entry tile: got nil, want error", tc.name)
 			}
@@ -416,7 +416,7 @@ func TestLoadBadEntryTile(t *testing.T) {
 }
 
 func TestLoadEmptyTree(t *testing.T) {
-	_, err := Load(t.Context(), newFakeS3(), 0, "")
+	_, err := LoadFrontier(t.Context(), newFakeS3(), 0, "")
 	if err == nil {
 		t.Errorf("Load(0): got nil, want error")
 	}
@@ -430,7 +430,7 @@ func TestAppendMaxSizeEntry(t *testing.T) {
 		t.Fatalf("parsing max-size entry: %s", err)
 	}
 
-	f := NewFrontier()
+	f := &Frontier{}
 	err = f.AppendEntry(mtcle)
 	if err != nil {
 		t.Fatalf("AppendEntry(65535-byte entry): %s", err)
@@ -445,7 +445,7 @@ func TestAppendMaxSizeEntry(t *testing.T) {
 }
 
 func TestFlushEmptyTree(t *testing.T) {
-	f := NewFrontier()
+	f := &Frontier{}
 	err := f.Flush(t.Context(), newFakeS3(), "")
 	if err == nil {
 		t.Errorf("Flush of empty tree: got nil, want error")
@@ -477,7 +477,7 @@ func TestRootHash(t *testing.T) {
 	spotSizes := map[int]bool{65535: true, 65536: true, 65537: true, 65791: true, 65792: true}
 
 	var leafHashes []tlog.Hash
-	f := NewFrontier()
+	f := &Frontier{}
 	for i := 0; i < n; i++ {
 		mtcle := testEntry(i)
 		leafHashes = append(leafHashes, tlog.RecordHash(testEntryBody(i)))

--- a/trees/tiles/tiles_test.go
+++ b/trees/tiles/tiles_test.go
@@ -1,0 +1,456 @@
+package tiles
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/mod/sumdb/tlog"
+
+	"github.com/letsencrypt/boulder/trees/entry"
+	"github.com/letsencrypt/boulder/trees/subtree"
+)
+
+func TestPath(t *testing.T) {
+	type testCase struct {
+		name   string
+		coords tlog.Tile
+		want   string
+	}
+
+	// Note: our code always ignores H; we leave it unset
+	testCases := []testCase{
+		{"zero one", tlog.Tile{L: -1, N: 0, W: 1}, "tile/entries/000.p/1"},
+		{"zero 255", tlog.Tile{L: -1, N: 0, W: 255}, "tile/entries/000.p/255"},
+		{"zero 256", tlog.Tile{L: -1, N: 0, W: 256}, "tile/entries/000"},
+		{"ten 1000", tlog.Tile{L: -1, N: 10, W: 256}, "tile/entries/010"},
+		{"example", tlog.Tile{L: -1, N: 1234067, W: 256}, "tile/entries/x001/x234/067"},
+		{"example partial", tlog.Tile{L: -1, N: 1234067, W: 6}, "tile/entries/x001/x234/067.p/6"},
+		{"level 2 zero one", tlog.Tile{L: 2, N: 0, W: 1}, "tile/2/000.p/1"},
+		{"level 2 zero 255", tlog.Tile{L: 2, N: 0, W: 255}, "tile/2/000.p/255"},
+		{"level 2 zero 256", tlog.Tile{L: 2, N: 0, W: 256}, "tile/2/000"},
+		{"level 2 ten 1000", tlog.Tile{L: 2, N: 10, W: 256}, "tile/2/010"},
+		{"level 2 example", tlog.Tile{L: 2, N: 1234067, W: 256}, "tile/2/x001/x234/067"},
+		{"level 2 example partial", tlog.Tile{L: 2, N: 1234067, W: 6}, "tile/2/x001/x234/067.p/6"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := tilePath(tc.coords)
+			if p != tc.want {
+				t.Errorf("tilePath(%#v): got %s, want %s",
+					tc.coords, p, tc.want)
+			}
+		})
+	}
+}
+
+type fakeS3Object struct {
+	data            []byte
+	contentEncoding *string
+}
+
+type fakeS3 struct {
+	objects map[string]fakeS3Object
+	puts    int
+}
+
+func newFakeS3() *fakeS3 {
+	return &fakeS3{objects: make(map[string]fakeS3Object)}
+}
+
+func (f *fakeS3) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	_, ok := f.objects[*params.Key]
+	if ok {
+		return nil, fmt.Errorf("duplicate PUT: %q", *params.Key)
+	}
+	body, err := io.ReadAll(params.Body)
+	if err != nil {
+		return nil, err
+	}
+	f.objects[*params.Key] = fakeS3Object{data: body, contentEncoding: params.ContentEncoding}
+	f.puts++
+	return nil, nil
+}
+
+func (f *fakeS3) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	o, ok := f.objects[*params.Key]
+	if ok {
+		return &s3.GetObjectOutput{
+			Body:            io.NopCloser(bytes.NewReader(o.data)),
+			ContentEncoding: o.contentEncoding,
+		}, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (f *fakeS3) Bucket() string {
+	return "fakebucket"
+}
+
+// testEntryBody returns the marshaled MTCLogEntry bytes for index i: empty
+// extensions, type tbs_cert_entry, and a unique value with length varying by
+// index (not a real TBSCertificateLogEntry).
+func testEntryBody(i int) []byte {
+	return fmt.Appendf(nil, "\x00\x00\x00\x01entry-%d-%s", i, bytes.Repeat([]byte{'x'}, i%37))
+}
+
+// bundledEntry returns a body with length framing (entry bundle format).
+func bundledEntry(body []byte) []byte {
+	b := cryptobyte.NewBuilder(nil)
+	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes(body)
+	})
+	return b.BytesOrPanic()
+}
+
+// testEntry returns a unique MTCLogEntry for index `i`.
+func testEntry(i int) *entry.MTCLogEntry {
+	mtcle, _, err := entry.NewBundleReader(bundledEntry(testEntryBody(i))).ReadEntry()
+	if err != nil {
+		panic(err)
+	}
+	return mtcle
+}
+
+// appendEntries appends test entries [start, end) to `f`, flushing every
+// `flushEvery“ appends and once at the end.
+func appendEntries(t *testing.T, f *Frontier, fs3 *fakeS3, start, end int, prefix string, flushEvery int) {
+	t.Helper()
+	for i := start; i < end; i++ {
+		err := f.AppendEntry(testEntry(i))
+		if err != nil {
+			t.Fatalf("AppendEntry(%d): %s", i, err)
+		}
+		if (i+1)%flushEvery == 0 {
+			err := f.Flush(t.Context(), fs3, prefix)
+			if err != nil {
+				t.Fatalf("Flush after %d entries: %s", i+1, err)
+			}
+		}
+	}
+	err := f.Flush(t.Context(), fs3, prefix)
+	if err != nil {
+		t.Fatalf("final Flush: %s", err)
+	}
+}
+
+// buildFrontier appends `n` test entries to a new Frontier, flushing every
+// `flushEvery` appends and once at the end.
+func buildFrontier(t *testing.T, fs3 *fakeS3, n int, prefix string, flushEvery int) *Frontier {
+	t.Helper()
+	f := NewFrontier()
+	appendEntries(t, f, fs3, 0, n, prefix, flushEvery)
+	return f
+}
+
+// parseEntries splits an entries tile body into MTCLogEntry bytes
+func parseEntries(t *testing.T, body []byte) [][]byte {
+	t.Helper()
+	var out [][]byte
+	in := cryptobyte.String(body)
+	for len(in) > 0 {
+		var mtcleBytes cryptobyte.String
+		if !in.ReadUint16LengthPrefixed(&mtcleBytes) {
+			t.Fatalf("bad length")
+		}
+		out = append(out, mtcleBytes)
+	}
+	return out
+}
+
+func TestGetTile(t *testing.T) {
+	fs3 := newFakeS3()
+	gzipStr := "gzip"
+
+	gz := func(data []byte) []byte {
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		_, err := w.Write(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = w.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+
+	raw := []byte("raw tile bytes")
+
+	t.Run("missing tile", func(t *testing.T) {
+		_, err := getTile(t.Context(), fs3, tlog.Tile{L: -1, N: 99, W: 1}, "")
+		if err == nil {
+			t.Errorf("getTile of nonexistent tile: got nil, want error")
+		}
+	})
+
+	t.Run("no content encoding", func(t *testing.T) {
+		fs3.objects["tile/0/000.p/1"] = fakeS3Object{data: raw}
+		got, err := getTile(t.Context(), fs3, tlog.Tile{L: 0, N: 0, W: 1}, "")
+		if err != nil {
+			t.Fatalf("getTile: %s", err)
+		}
+		if !bytes.Equal(got, raw) {
+			t.Errorf("getTile: got %q, want %q", got, raw)
+		}
+	})
+
+	t.Run("gzip", func(t *testing.T) {
+		fs3.objects["tile/entries/000.p/1"] = fakeS3Object{data: gz([]byte("compressed tile bytes")), contentEncoding: &gzipStr}
+		got, err := getTile(t.Context(), fs3, tlog.Tile{L: -1, N: 0, W: 1}, "")
+		if err != nil {
+			t.Fatalf("getTile: %s", err)
+		}
+		if !bytes.Equal(got, []byte("compressed tile bytes")) {
+			t.Errorf("getTile: got %q, want %q", got, "compressed tile bytes")
+		}
+	})
+
+	t.Run("corrupt gzip", func(t *testing.T) {
+		fs3.objects["tile/entries/000.p/2"] = fakeS3Object{data: []byte("not gzip"), contentEncoding: &gzipStr}
+		_, err := getTile(t.Context(), fs3, tlog.Tile{L: -1, N: 0, W: 2}, "")
+		if err == nil {
+			t.Errorf("getTile of corrupt gzip body: got nil, want error")
+		}
+	})
+
+	t.Run("prefix", func(t *testing.T) {
+		fs3.objects["pre/tile/entries/000.p/3"] = fakeS3Object{data: gz([]byte("prefixed")), contentEncoding: &gzipStr}
+		got, err := getTile(t.Context(), fs3, tlog.Tile{L: -1, N: 0, W: 3}, "pre/")
+		if err != nil {
+			t.Fatalf("getTile with prefix: %s", err)
+		}
+		if !bytes.Equal(got, []byte("prefixed")) {
+			t.Errorf("getTile: got %q, want %q", got, "prefixed")
+		}
+		_, err = getTile(t.Context(), fs3, tlog.Tile{L: -1, N: 0, W: 3}, "")
+		if err == nil {
+			t.Errorf("getTile without prefix of prefixed tile: got nil, want error")
+		}
+	})
+}
+
+// TestRoundTrip builds a Frontier, writes it, reads it, and checks for equality.
+func TestRoundTrip(t *testing.T) {
+	sizes := []int{1, 2, 100, 255, 256, 257, 511, 512, 513, 767, 768, 1000}
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("size %d", n), func(t *testing.T) {
+			fs3 := newFakeS3()
+			prefix := "p/"
+			f := buildFrontier(t, fs3, n, prefix, 100)
+
+			loaded, err := Load(t.Context(), fs3, int64(n), prefix)
+			if err != nil {
+				t.Fatalf("Load(%d): %s", n, err)
+			}
+			if !reflect.DeepEqual(f, loaded) {
+				t.Errorf("Load(%d): loaded frontier differs from flushed frontier:\ngot  %#v\nwant %#v",
+					n, loaded, f)
+			}
+		})
+	}
+}
+
+// TestStorageCorrectness verifies every tile written to storage against
+// hashes computed in the test.
+//
+// Entry tiles must contain the appended entries, and the hash at each level
+// must equal the MTH of all entries that the hash represents.
+//
+// Partway through, it simulates a restart: it reloads the frontier from
+// storage and continues appending on the loaded frontier. The storage
+// checks below therefore also check that appending to partial tiles
+// loaded from storage works properly.
+func TestStorageCorrectness(t *testing.T) {
+	// Enough for three levels of hash tiles (n > 256*256).
+	const n = 66000
+	const reloadAt = 33333
+	prefix := "tree/"
+
+	bodies := make([][]byte, n)
+	leafHashes := make([]tlog.Hash, n)
+	for i := range bodies {
+		bodies[i] = testEntryBody(i)
+		leafHashes[i] = tlog.RecordHash(bodies[i])
+	}
+
+	fs3 := newFakeS3()
+	buildFrontier(t, fs3, reloadAt, prefix, 999)
+
+	f, err := Load(t.Context(), fs3, reloadAt, prefix)
+	if err != nil {
+		t.Fatalf("Load at %d: %s", reloadAt, err)
+	}
+	appendEntries(t, f, fs3, reloadAt, n, prefix, 999)
+
+	if f.TreeSize() != n {
+		t.Errorf("TreeSize: got %d, want %d", f.TreeSize(), n)
+	}
+
+	// Verify the entry tiles.
+	for tileIndex := 0; tileIndex*256 < n; tileIndex++ {
+		width := min(256, n-tileIndex*256)
+		coords := tlog.Tile{L: -1, N: int64(tileIndex), W: width}
+		body, err := getTile(t.Context(), fs3, coords, prefix)
+		if err != nil {
+			t.Fatalf("reading entry tile %d: %s", tileIndex, err)
+		}
+		got := parseEntries(t, body)
+		want := bodies[tileIndex*256 : tileIndex*256+width]
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("entry tile %d: entries don't match appended entries", tileIndex)
+		}
+	}
+
+	// Verify the hash tiles. Read each tile that we expect to exist at final size.
+	// For each hash in a tile, directly calculate the MTH of the leaves it represents
+	// and compare.
+	level := 0
+	for layerSize := n; layerSize > 0; layerSize /= 256 {
+		for tileIndex := 0; tileIndex*256 < layerSize; tileIndex++ {
+			width := min(256, layerSize-tileIndex*256)
+			coords := tlog.Tile{L: level, N: int64(tileIndex), W: width}
+			body, err := getTile(t.Context(), fs3, coords, prefix)
+			if err != nil {
+				t.Fatalf("reading hash tile L=%d N=%d: %s", level, tileIndex, err)
+			}
+			if len(body) != width*tlog.HashSize {
+				t.Fatalf("hash tile L=%d N=%d: got %d bytes, want %d", level, tileIndex, len(body), width*tlog.HashSize)
+			}
+			leavesPerHash := 1 << (8 * level)
+			i := 0
+			for got := range slices.Chunk(body, tlog.HashSize) {
+				leafStart := (tileIndex*256 + i) * leavesPerHash
+				leafEnd := leafStart + leavesPerHash
+				want := subtree.MTH(leafHashes[leafStart:leafEnd])
+				if !bytes.Equal(got, want[:]) {
+					t.Errorf("hash tile L=%d N=%d index %d: got %s, want %s",
+						level, tileIndex, i, base64.StdEncoding.EncodeToString(got), want)
+				}
+				i++
+			}
+		}
+		level++
+	}
+
+	// Load and check equality with the in-memory copy one last time.
+	loaded, err := Load(t.Context(), fs3, n, prefix)
+	if err != nil {
+		t.Fatalf("Load: %s", err)
+	}
+	if !reflect.DeepEqual(f, loaded) {
+		t.Errorf("Load: loaded frontier differs from flushed frontier")
+	}
+}
+
+func TestLoadBadHashTile(t *testing.T) {
+	fs3 := newFakeS3()
+	buildFrontier(t, fs3, 1, "", 100)
+
+	// Corrupt the level-0 hash tile so its length no longer matches its width.
+	o := fs3.objects["tile/0/000.p/1"]
+	o.data = o.data[:len(o.data)-1]
+	fs3.objects["tile/0/000.p/1"] = o
+
+	_, err := Load(t.Context(), fs3, 1, "")
+	if err == nil {
+		t.Errorf("Load with truncated hash tile: got nil, want error")
+	}
+}
+
+// TestLoadBadEntryTile checks that Load rejects entry tiles whose contents
+// don't parse as MTCLogEntries or don't match the tile width.
+func TestLoadBadEntryTile(t *testing.T) {
+	// A single validly-bundled test entry.
+	bundled := bundledEntry(testEntryBody(0))
+
+	testCases := []struct {
+		name string
+		body []byte
+	}{
+		{"garbage framing", []byte{0xff}},
+		{"truncated entry", bundled[:len(bundled)-1]},
+		{"unknown entry type", append([]byte{0x00, 0x04, 0x00, 0x00, 0x00, 0x02}, bundled...)},
+		{"fewer entries than width", bundled},
+		{"more entries than width", bytes.Repeat(bundled, 3)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs3 := newFakeS3()
+			buildFrontier(t, fs3, 2, "", 100)
+
+			// Replace the entry tile with the bad body (uncompressed, so no
+			// ContentEncoding).
+			fs3.objects["tile/entries/000.p/2"] = fakeS3Object{data: tc.body}
+
+			_, err := Load(t.Context(), fs3, 2, "")
+			if err == nil {
+				t.Errorf("Load with %s in entry tile: got nil, want error", tc.name)
+			}
+		})
+	}
+}
+
+func TestLoadEmptyTree(t *testing.T) {
+	_, err := Load(t.Context(), newFakeS3(), 0, "")
+	if err == nil {
+		t.Errorf("Load(0): got nil, want error")
+	}
+}
+
+// TestAppendMaxSizeEntry checks that a 65535-byte MTCLogEntry can be written.
+func TestAppendMaxSizeEntry(t *testing.T) {
+	body := append([]byte{0x00, 0x00, 0x00, 0x01}, bytes.Repeat([]byte{'v'}, 0xFFFF-4)...)
+	mtcle, _, err := entry.NewBundleReader(bundledEntry(body)).ReadEntry()
+	if err != nil {
+		t.Fatalf("parsing max-size entry: %s", err)
+	}
+
+	f := NewFrontier()
+	err = f.AppendEntry(mtcle)
+	if err != nil {
+		t.Fatalf("AppendEntry(65535-byte entry): %s", err)
+	}
+	err = f.Flush(t.Context(), newFakeS3(), "")
+	if err != nil {
+		t.Fatalf("Flush: %s", err)
+	}
+	if f.TreeSize() != 1 {
+		t.Errorf("TreeSize: got %d, want 1", f.TreeSize())
+	}
+}
+
+func TestFlushEmptyTree(t *testing.T) {
+	f := NewFrontier()
+	err := f.Flush(t.Context(), newFakeS3(), "")
+	if err == nil {
+		t.Errorf("Flush of empty tree: got nil, want error")
+	}
+}
+
+// TestFlushClean checks the dirtyLevel behavior. After a Flush,
+// a re-Flush should write nothing.
+func TestFlushClean(t *testing.T) {
+	fs3 := newFakeS3()
+	f := buildFrontier(t, fs3, 10, "", 100)
+
+	putsBefore := fs3.puts
+	err := f.Flush(t.Context(), fs3, "")
+	if err != nil {
+		t.Fatalf("second Flush: %s", err)
+	}
+	if fs3.puts != putsBefore {
+		t.Errorf("second Flush wrote %d objects, want 0", fs3.puts-putsBefore)
+	}
+}

--- a/trees/tiles/tiles_test.go
+++ b/trees/tiles/tiles_test.go
@@ -343,6 +343,19 @@ func TestStorageCorrectness(t *testing.T) {
 		level++
 	}
 
+	rootHash := f.RootHash()
+	want, err := base64.StdEncoding.DecodeString("+AWMUCk19n0KCYumG1DKQ4dW3hcS8C/ygvZB7mP5NOU=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	calculated := subtree.MTH(leafHashes)
+	if !bytes.Equal(calculated[:], want) {
+		t.Errorf("test assumptions failed: MTH(leafHashes) = %s, want %s", calculated, want)
+	}
+	if !bytes.Equal(rootHash[:], want) {
+		t.Errorf("f.RootHash(): got %s, want %s", rootHash, want)
+	}
+
 	// Load and check equality with the in-memory copy one last time.
 	loaded, err := Load(t.Context(), fs3, n, prefix)
 	if err != nil {
@@ -453,4 +466,14 @@ func TestFlushClean(t *testing.T) {
 	if fs3.puts != putsBefore {
 		t.Errorf("second Flush wrote %d objects, want 0", fs3.puts-putsBefore)
 	}
+}
+
+func TestRootHash(t *testing.T) {
+	f := NewFrontier()
+	got := f.RootHash()
+	want := subtree.MTH(nil)
+	if !bytes.Equal(got[:], want[:]) {
+		t.Errorf("NewFrontier().RootHash()=%s, want %s", got, want)
+	}
+
 }


### PR DESCRIPTION
Frontier is loaded at MTCA startup, tracks appended entries and hash tiles, and writes them to storage.

Implementation is written by me. The unittest in tiles_test.go was written by Claude and reviewed and lightly edited by me (including rewriting the comments in my own words).

Move subtree's `mth()` function out from the unittest and export it, since it's needed to calculate a hash to append to a parent tile once its child tile becomes full.

Fixes #8894 