### PR TITLE
trees/cosignature: Sign and verify MTC checkpoint cosignatures

### DIFF
--- a/trees/cosignature/cosignature.go
+++ b/trees/cosignature/cosignature.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/mod/sumdb/tlog"
@@ -196,8 +194,8 @@ func (c *Cosigner) CosignatureLine(tree tlog.Tree) (string, error) {
 	return signatureLineFor(c.name, c.keyID, signature), nil
 }
 
-// Verifier is a note.Verifier that verifies ML-DSA-44 cosignatures over
-// checkpoints.
+// Verifier is a note.Verifier that verifies an MTC cosigner's ML-DSA-44
+// cosignatures over checkpoints.
 //
 //   - https://c2sp.org/tlog-cosignature
 //   - https://c2sp.org/mtc-tlog
@@ -275,29 +273,30 @@ func (v *Verifier) Verify(text, signature []byte) bool {
 	return v.VerifyCheckpoint(parsed.Origin, parsed.Tree, signature) == nil
 }
 
-// TimestampedSignature extracts verifier's timestamped_signature from n. It
-// returns false when verifier did not sign n or the signature is malformed. n
-// must come from note.Open with verifier in its verifier list.
-func TimestampedSignature(n *note.Note, verifier note.Verifier) ([]byte, bool) {
-	for _, signature := range n.Sigs {
-		if signature.Name != verifier.Name() || signature.Hash != verifier.KeyHash() {
-			continue
-		}
-		idSignature, err := base64.StdEncoding.DecodeString(signature.Base64)
-		if err != nil || len(idSignature) != keyIDSize+timestampedSignatureSize {
-			return nil, false
-		}
-		return idSignature[keyIDSize:], true
+// TimestampedSignature verifies line against the checkpoint note text with
+// verifier and returns the timestamped_signature by verifier's cosigner. An
+// error is returned if text and line do not form a well-formed note or if
+// verifier rejects the signature. Signatures from unknown keys are ignored.
+func TimestampedSignature(text, line string, verifier *Verifier) ([]byte, error) {
+	n, err := note.Open([]byte(text+"\n"+line), note.VerifierList(verifier))
+	if err != nil {
+		return nil, fmt.Errorf("opening the cosigned note: %s", err)
 	}
-	return nil, false
+	// verifier is the only verifier in the list, so every signature in n.Sigs
+	// is the cosigner's, verified and length-checked.
+	idSignature, err := base64.StdEncoding.DecodeString(n.Sigs[0].Base64)
+	if err != nil {
+		return nil, fmt.Errorf("decoding the signature by %s: %s", verifier.name, err)
+	}
+	return idSignature[keyIDSize:], nil
 }
 
-// Signature returns the ML-DSA-44 signature of a timestamped_signature, the
-// form certificates embed. It errors on a wrong length or a non-zero timestamp,
-// which certificates cannot carry.
+// RawSignature returns the ML-DSA-44 signature from a timestamped_signature,
+// the form certificates embed. It errors if the input has the wrong length or a
+// non-zero timestamp, which certificates cannot carry.
 //
 // https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#section-6.2
-func Signature(timestampedSignature []byte) ([]byte, error) {
+func RawSignature(timestampedSignature []byte) ([]byte, error) {
 	if len(timestampedSignature) != timestampedSignatureSize {
 		return nil, fmt.Errorf("timestamped signature is %d bytes, want %d", len(timestampedSignature), timestampedSignatureSize)
 	}
@@ -306,34 +305,4 @@ func Signature(timestampedSignature []byte) ([]byte, error) {
 		return nil, fmt.Errorf("timestamp is %d, want 0 for a cosignature used in certificates", timestamp)
 	}
 	return timestampedSignature[timestampSize:], nil
-}
-
-// Line rebuilds the signature line for a timestamped_signature, recomputing the
-// key ID from name and pubKey. It does not verify the signature.
-func Line(name string, pubKey *mldsa.PublicKey, timestampedSignature []byte) (string, error) {
-	if name == "" {
-		return "", errors.New("empty cosigner name")
-	}
-	if len(name) > 255 {
-		return "", fmt.Errorf("cosigner name %q is %d bytes, want at most 255", name, len(name))
-	}
-	if !utf8.ValidString(name) {
-		return "", fmt.Errorf("cosigner name %q is not valid UTF-8", name)
-	}
-	if strings.ContainsFunc(name, func(r rune) bool { return r < 0x20 }) {
-		return "", fmt.Errorf("cosigner name %q contains a control character", name)
-	}
-	if strings.IndexFunc(name, unicode.IsSpace) >= 0 {
-		return "", fmt.Errorf("cosigner name %q contains a space", name)
-	}
-	if strings.Contains(name, "+") {
-		return "", fmt.Errorf("cosigner name %q contains a plus sign", name)
-	}
-	if pubKey.Parameters().PublicKeySize() != mldsa.MLDSA44PublicKeySize {
-		return "", errors.New("public key must be ML-DSA-44")
-	}
-	if len(timestampedSignature) != timestampedSignatureSize {
-		return "", fmt.Errorf("timestamped signature is %d bytes, want %d", len(timestampedSignature), timestampedSignatureSize)
-	}
-	return signatureLineFor(name, keyIDFor(name, pubKey), timestampedSignature), nil
 }

--- a/trees/cosignature/cosignature.go
+++ b/trees/cosignature/cosignature.go
@@ -1,0 +1,339 @@
+//go:build go1.27
+
+package cosignature
+
+import (
+	"crypto"
+	"crypto/mldsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/mod/sumdb/note"
+	"golang.org/x/mod/sumdb/tlog"
+
+	"github.com/letsencrypt/boulder/trees/checkpoint"
+	"github.com/letsencrypt/boulder/trees/cosigned"
+)
+
+// cosignatureAlg is the ML-DSA-44 algorithm byte in the key ID computation.
+const cosignatureAlg = 0x06
+
+// keyIDSize is the length of the key ID that begins a note signature, a prefix
+// of the key hash.
+const keyIDSize = 4
+
+// timestampSize is the length of the big-endian timestamp that begins a
+// timestamped_signature.
+const timestampSize = 8
+
+// timestampedSignatureSize is the length of an ML-DSA-44 timestamped_signature:
+// the timestamp followed by the signature.
+const timestampedSignatureSize = timestampSize + mldsa.MLDSA44SignatureSize
+
+// noteSignatureLinePrefix is the U+2014 and space that begin a signature line.
+const noteSignatureLinePrefix = "— "
+
+// oidPrefix begins every mtc-tlog cosigner name and log origin: the IANA
+// private enterprise arc an MTC ID is relative to.
+const oidPrefix = "oid/1.3.6.1.4.1."
+
+// keyIDFor returns the key ID of an ML-DSA-44 cosigner: SHA-256(name || "\n" ||
+// 0x06 || pubkey)[:4] as a big-endian uint32.
+//
+// https://c2sp.org/tlog-cosignature
+func keyIDFor(name string, pubKey *mldsa.PublicKey) uint32 {
+	h := sha256.New()
+	h.Write([]byte(name))
+	h.Write([]byte{'\n', cosignatureAlg})
+	h.Write(pubKey.Bytes())
+	return binary.BigEndian.Uint32(h.Sum(nil)[:keyIDSize])
+}
+
+// marshalCosignedMessage serializes the cosigned.Message for a checkpoint
+// cosignature, with start 0 and end the tree size as the MTC draft section
+// 5.3.1 requires for checkpoints. It rejects a non-positive end.
+func marshalCosignedMessage(name string, timestamp uint64, origin string, end int64, hash tlog.Hash) ([]byte, error) {
+	if end <= 0 {
+		return nil, fmt.Errorf("non-positive end %d", end)
+	}
+	cosignedMessage := cosigned.Message{
+		CosignerName: name,
+		Timestamp:    timestamp,
+		LogOrigin:    origin,
+		Start:        0,
+		End:          uint64(end),
+		SubtreeHash:  hash,
+	}
+	return cosignedMessage.Marshal()
+}
+
+// signatureLineFor assembles the signature line "— <name> base64(keyID ||
+// timestamped_signature)\n".
+func signatureLineFor(name string, keyID uint32, timestampedSignature []byte) string {
+	idSignature := make([]byte, keyIDSize+len(timestampedSignature))
+	binary.BigEndian.PutUint32(idSignature[:keyIDSize], keyID)
+	copy(idSignature[keyIDSize:], timestampedSignature)
+	return noteSignatureLinePrefix + name + " " + base64.StdEncoding.EncodeToString(idSignature) + "\n"
+}
+
+// checkRelativeOID returns an error if id is not a dotted decimal OID like
+// "32473.2", nil otherwise.
+func checkRelativeOID(id string) error {
+	if id == "" {
+		return errors.New("empty")
+	}
+	for _, arc := range strings.Split(id, ".") {
+		if arc == "" {
+			return errors.New("empty arc")
+		}
+		if len(arc) > 1 && arc[0] == '0' {
+			return fmt.Errorf("arc %q has a leading zero", arc)
+		}
+		for _, r := range arc {
+			if r < '0' || r > '9' {
+				return fmt.Errorf("arc %q is not decimal", arc)
+			}
+		}
+	}
+	return nil
+}
+
+// Origin returns the log origin derived from the log ID per mtc-tlog: log ID
+// "32473.2.0.42" has origin "oid/1.3.6.1.4.1.32473.2.0.42". It errors if logID
+// is not a dotted decimal OID.
+//
+// https://c2sp.org/mtc-tlog
+func Origin(logID string) (string, error) {
+	err := checkRelativeOID(logID)
+	if err != nil {
+		return "", fmt.Errorf("invalid log ID %q: %w", logID, err)
+	}
+	return oidPrefix + logID, nil
+}
+
+// Cosigner produces cosignatures over checkpoints as an MTC cosigner for a
+// single log: the timestamp is zero, as required for cosignatures used in
+// certificates, and the key is a crypto.Signer so it may be stored in an HSM.
+// Both the CA cosigner and a mirror cosigning the CA's log take this role.
+//
+//   - https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#section-5.3.1
+//   - https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#section-6.2
+//   - https://c2sp.org/mtc-tlog
+type Cosigner struct {
+	name   string
+	origin string
+	keyID  uint32
+	signer crypto.Signer
+}
+
+// NewCosigner returns a Cosigner for the cosigner and log with the given IDs,
+// deriving its cosigner name and log origin per mtc-tlog: cosigner ID "32473.2"
+// signs as "oid/1.3.6.1.4.1.32473.2". It errors if either ID is not a dotted
+// decimal OID or signer's public key is not ML-DSA-44.
+func NewCosigner(cosignerID, logID string, signer crypto.Signer) (*Cosigner, error) {
+	err := checkRelativeOID(cosignerID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cosigner ID %q: %w", cosignerID, err)
+	}
+	origin, err := Origin(logID)
+	if err != nil {
+		return nil, err
+	}
+	pubKey, ok := signer.Public().(*mldsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("cosigner public key is %T, must be ML-DSA-44", signer.Public())
+	}
+	if pubKey.Parameters().PublicKeySize() != mldsa.MLDSA44PublicKeySize {
+		return nil, errors.New("cosigner key must be ML-DSA-44")
+	}
+	return &Cosigner{
+		name:   oidPrefix + cosignerID,
+		origin: origin,
+		keyID:  keyIDFor(oidPrefix+cosignerID, pubKey),
+		signer: signer,
+	}, nil
+}
+
+// Origin returns the log origin derived from the log ID.
+func (c *Cosigner) Origin() string {
+	return c.origin
+}
+
+// CosignCheckpoint cosigns the checkpoint described by tree and returns the
+// cosignature as a timestamped_signature.
+func (c *Cosigner) CosignCheckpoint(tree tlog.Tree) ([]byte, error) {
+	message, err := marshalCosignedMessage(c.name, 0, c.origin, tree.N, tree.Hash)
+	if err != nil {
+		return nil, err
+	}
+	signature, err := c.signer.Sign(nil, message, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(signature) != mldsa.MLDSA44SignatureSize {
+		return nil, fmt.Errorf("signer returned %d bytes, want %d", len(signature), mldsa.MLDSA44SignatureSize)
+	}
+	out := make([]byte, timestampedSignatureSize)
+	copy(out[timestampSize:], signature)
+	return out, nil
+}
+
+// CosignatureLine cosigns the checkpoint described by tree and returns the
+// cosignature as a signature line, trailing newline included. For a
+// timestamped_signature, use CosignCheckpoint.
+func (c *Cosigner) CosignatureLine(tree tlog.Tree) (string, error) {
+	signature, err := c.CosignCheckpoint(tree)
+	if err != nil {
+		return "", err
+	}
+	return signatureLineFor(c.name, c.keyID, signature), nil
+}
+
+// Verifier is a note.Verifier that verifies ML-DSA-44 cosignatures over
+// checkpoints.
+//
+//   - https://c2sp.org/tlog-cosignature
+//   - https://c2sp.org/mtc-tlog
+type Verifier struct {
+	name      string
+	keyID     uint32
+	publicKey *mldsa.PublicKey
+}
+
+var _ note.Verifier = (*Verifier)(nil)
+
+// NewVerifier returns a Verifier for the MTC cosigner with the given ID,
+// deriving its name per mtc-tlog like NewCosigner. It errors if cosignerID is
+// not a dotted decimal OID or pubKey is not ML-DSA-44.
+func NewVerifier(cosignerID string, pubKey *mldsa.PublicKey) (*Verifier, error) {
+	err := checkRelativeOID(cosignerID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cosigner ID %q: %w", cosignerID, err)
+	}
+	if pubKey.Parameters().PublicKeySize() != mldsa.MLDSA44PublicKeySize {
+		return nil, errors.New("public key must be ML-DSA-44")
+	}
+	return &Verifier{
+		name:      oidPrefix + cosignerID,
+		keyID:     keyIDFor(oidPrefix+cosignerID, pubKey),
+		publicKey: pubKey,
+	}, nil
+}
+
+// Name satisfies note.Verifier.
+func (v *Verifier) Name() string {
+	return v.name
+}
+
+// KeyHash satisfies note.Verifier.
+func (v *Verifier) KeyHash() uint32 {
+	return v.keyID
+}
+
+// VerifyCheckpoint returns nil if signature is a valid cosignature by this
+// cosigner over the checkpoint described by origin and tree, and an error
+// naming the failure otherwise. For a checkpoint note text, use Verify.
+//
+//   - https://c2sp.org/tlog-cosignature
+//   - https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#section-5.3.1
+func (v *Verifier) VerifyCheckpoint(origin string, tree tlog.Tree, signature []byte) error {
+	if len(signature) != timestampedSignatureSize {
+		return fmt.Errorf("timestamped signature is %d bytes, want %d", len(signature), timestampedSignatureSize)
+	}
+	timestamp := binary.BigEndian.Uint64(signature[:timestampSize])
+	if timestamp > math.MaxInt64 {
+		return fmt.Errorf("timestamp %d exceeds 2^63-1", timestamp)
+	}
+	cosignedMessage, err := marshalCosignedMessage(v.name, timestamp, origin, tree.N, tree.Hash)
+	if err != nil {
+		return err
+	}
+	err = mldsa.Verify(v.publicKey, cosignedMessage, signature[timestampSize:], nil)
+	if err != nil {
+		return fmt.Errorf("verifying cosignature: %s", err)
+	}
+	return nil
+}
+
+// Verify reports whether signature is a valid cosignature by this cosigner over
+// the checkpoint in text. The signed message covers the origin, tree size, and
+// root hash from text, so extension lines do not affect the result. Verify is
+// the note.Verifier entry point. For an already parsed checkpoint, use
+// VerifyCheckpoint.
+func (v *Verifier) Verify(text, signature []byte) bool {
+	parsed, err := checkpoint.Unmarshal(string(text))
+	if err != nil {
+		return false
+	}
+	return v.VerifyCheckpoint(parsed.Origin, parsed.Tree, signature) == nil
+}
+
+// TimestampedSignature extracts verifier's timestamped_signature from n. It
+// returns false when verifier did not sign n or the signature is malformed. n
+// must come from note.Open with verifier in its verifier list.
+func TimestampedSignature(n *note.Note, verifier note.Verifier) ([]byte, bool) {
+	for _, signature := range n.Sigs {
+		if signature.Name != verifier.Name() || signature.Hash != verifier.KeyHash() {
+			continue
+		}
+		idSignature, err := base64.StdEncoding.DecodeString(signature.Base64)
+		if err != nil || len(idSignature) != keyIDSize+timestampedSignatureSize {
+			return nil, false
+		}
+		return idSignature[keyIDSize:], true
+	}
+	return nil, false
+}
+
+// Signature returns the ML-DSA-44 signature of a timestamped_signature, the
+// form certificates embed. It errors on a wrong length or a non-zero timestamp,
+// which certificates cannot carry.
+//
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#section-6.2
+func Signature(timestampedSignature []byte) ([]byte, error) {
+	if len(timestampedSignature) != timestampedSignatureSize {
+		return nil, fmt.Errorf("timestamped signature is %d bytes, want %d", len(timestampedSignature), timestampedSignatureSize)
+	}
+	timestamp := binary.BigEndian.Uint64(timestampedSignature[:timestampSize])
+	if timestamp != 0 {
+		return nil, fmt.Errorf("timestamp is %d, want 0 for a cosignature used in certificates", timestamp)
+	}
+	return timestampedSignature[timestampSize:], nil
+}
+
+// Line rebuilds the signature line for a timestamped_signature, recomputing the
+// key ID from name and pubKey. It does not verify the signature.
+func Line(name string, pubKey *mldsa.PublicKey, timestampedSignature []byte) (string, error) {
+	if name == "" {
+		return "", errors.New("empty cosigner name")
+	}
+	if len(name) > 255 {
+		return "", fmt.Errorf("cosigner name %q is %d bytes, want at most 255", name, len(name))
+	}
+	if !utf8.ValidString(name) {
+		return "", fmt.Errorf("cosigner name %q is not valid UTF-8", name)
+	}
+	if strings.ContainsFunc(name, func(r rune) bool { return r < 0x20 }) {
+		return "", fmt.Errorf("cosigner name %q contains a control character", name)
+	}
+	if strings.IndexFunc(name, unicode.IsSpace) >= 0 {
+		return "", fmt.Errorf("cosigner name %q contains a space", name)
+	}
+	if strings.Contains(name, "+") {
+		return "", fmt.Errorf("cosigner name %q contains a plus sign", name)
+	}
+	if pubKey.Parameters().PublicKeySize() != mldsa.MLDSA44PublicKeySize {
+		return "", errors.New("public key must be ML-DSA-44")
+	}
+	if len(timestampedSignature) != timestampedSignatureSize {
+		return "", fmt.Errorf("timestamped signature is %d bytes, want %d", len(timestampedSignature), timestampedSignatureSize)
+	}
+	return signatureLineFor(name, keyIDFor(name, pubKey), timestampedSignature), nil
+}

--- a/trees/cosignature/cosignature.go
+++ b/trees/cosignature/cosignature.go
@@ -46,18 +46,18 @@ const oidPrefix = "oid/1.3.6.1.4.1."
 // 0x06 || pubkey)[:4] as a big-endian uint32.
 //
 // https://c2sp.org/tlog-cosignature
-func keyIDFor(name string, pubKey *mldsa.PublicKey) uint32 {
+func keyIDFor(name string, publicKey *mldsa.PublicKey) uint32 {
 	h := sha256.New()
 	h.Write([]byte(name))
 	h.Write([]byte{'\n', cosignatureAlg})
-	h.Write(pubKey.Bytes())
+	h.Write(publicKey.Bytes())
 	return binary.BigEndian.Uint32(h.Sum(nil)[:keyIDSize])
 }
 
 // marshalCosignedMessage serializes the cosigned.Message for a checkpoint
 // cosignature, with start 0 and end the tree size as the MTC draft section
 // 5.3.1 requires for checkpoints. It rejects a non-positive end.
-func marshalCosignedMessage(name string, timestamp uint64, origin string, end int64, hash tlog.Hash) ([]byte, error) {
+func marshalCosignedMessage(name string, timestamp uint64, origin string, end int64, rootHash tlog.Hash) ([]byte, error) {
 	if end <= 0 {
 		return nil, fmt.Errorf("non-positive end %d", end)
 	}
@@ -67,7 +67,7 @@ func marshalCosignedMessage(name string, timestamp uint64, origin string, end in
 		LogOrigin:    origin,
 		Start:        0,
 		End:          uint64(end),
-		SubtreeHash:  hash,
+		SubtreeHash:  rootHash,
 	}
 	return cosignedMessage.Marshal()
 }
@@ -209,19 +209,19 @@ var _ note.Verifier = (*Verifier)(nil)
 
 // NewVerifier returns a Verifier for the MTC cosigner with the given ID,
 // deriving its name per mtc-tlog like NewCosigner. It errors if cosignerID is
-// not a dotted decimal OID or pubKey is not ML-DSA-44.
-func NewVerifier(cosignerID string, pubKey *mldsa.PublicKey) (*Verifier, error) {
+// not a dotted decimal OID or publicKey is not ML-DSA-44.
+func NewVerifier(cosignerID string, publicKey *mldsa.PublicKey) (*Verifier, error) {
 	err := checkRelativeOID(cosignerID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid cosigner ID %q: %w", cosignerID, err)
 	}
-	if pubKey.Parameters().PublicKeySize() != mldsa.MLDSA44PublicKeySize {
+	if publicKey.Parameters().PublicKeySize() != mldsa.MLDSA44PublicKeySize {
 		return nil, errors.New("public key must be ML-DSA-44")
 	}
 	return &Verifier{
 		name:      oidPrefix + cosignerID,
-		keyID:     keyIDFor(oidPrefix+cosignerID, pubKey),
-		publicKey: pubKey,
+		keyID:     keyIDFor(oidPrefix+cosignerID, publicKey),
+		publicKey: publicKey,
 	}, nil
 }
 
@@ -235,17 +235,17 @@ func (v *Verifier) KeyHash() uint32 {
 	return v.keyID
 }
 
-// VerifyCheckpoint returns nil if signature is a valid cosignature by this
-// cosigner over the checkpoint described by origin and tree, and an error
-// naming the failure otherwise. For a checkpoint note text, use Verify.
+// VerifyCheckpoint returns nil if timestampedSignature is a valid cosignature
+// by this cosigner over the checkpoint described by origin and tree, and an
+// error naming the failure otherwise. For a checkpoint note text, use Verify.
 //
 //   - https://c2sp.org/tlog-cosignature
 //   - https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#section-5.3.1
-func (v *Verifier) VerifyCheckpoint(origin string, tree tlog.Tree, signature []byte) error {
-	if len(signature) != timestampedSignatureSize {
-		return fmt.Errorf("timestamped signature is %d bytes, want %d", len(signature), timestampedSignatureSize)
+func (v *Verifier) VerifyCheckpoint(origin string, tree tlog.Tree, timestampedSignature []byte) error {
+	if len(timestampedSignature) != timestampedSignatureSize {
+		return fmt.Errorf("timestamped signature is %d bytes, want %d", len(timestampedSignature), timestampedSignatureSize)
 	}
-	timestamp := binary.BigEndian.Uint64(signature[:timestampSize])
+	timestamp := binary.BigEndian.Uint64(timestampedSignature[:timestampSize])
 	if timestamp > math.MaxInt64 {
 		return fmt.Errorf("timestamp %d exceeds 2^63-1", timestamp)
 	}
@@ -253,7 +253,7 @@ func (v *Verifier) VerifyCheckpoint(origin string, tree tlog.Tree, signature []b
 	if err != nil {
 		return err
 	}
-	err = mldsa.Verify(v.publicKey, cosignedMessage, signature[timestampSize:], nil)
+	err = mldsa.Verify(v.publicKey, cosignedMessage, timestampedSignature[timestampSize:], nil)
 	if err != nil {
 		return fmt.Errorf("verifying cosignature: %s", err)
 	}
@@ -261,24 +261,24 @@ func (v *Verifier) VerifyCheckpoint(origin string, tree tlog.Tree, signature []b
 }
 
 // Verify reports whether signature is a valid cosignature by this cosigner over
-// the checkpoint in text. The signed message covers the origin, tree size, and
-// root hash from text, so extension lines do not affect the result. Verify is
-// the note.Verifier entry point. For an already parsed checkpoint, use
-// VerifyCheckpoint.
-func (v *Verifier) Verify(text, signature []byte) bool {
-	parsed, err := checkpoint.Unmarshal(string(text))
+// the checkpoint in noteText. The signed message covers the origin, tree size,
+// and root hash from noteText, so extension lines do not affect the result.
+// Verify is the note.Verifier entry point. For an already parsed checkpoint,
+// use VerifyCheckpoint.
+func (v *Verifier) Verify(noteText, signature []byte) bool {
+	parsed, err := checkpoint.Unmarshal(string(noteText))
 	if err != nil {
 		return false
 	}
 	return v.VerifyCheckpoint(parsed.Origin, parsed.Tree, signature) == nil
 }
 
-// TimestampedSignature verifies line against the checkpoint note text with
-// verifier and returns the timestamped_signature by verifier's cosigner. An
-// error is returned if text and line do not form a well-formed note or if
+// TimestampedSignature verifies signatureLine against noteText with verifier
+// and returns the timestamped_signature by verifier's cosigner. An error is
+// returned if noteText and signatureLine do not form a well-formed note or if
 // verifier rejects the signature. Signatures from unknown keys are ignored.
-func TimestampedSignature(text, line string, verifier *Verifier) ([]byte, error) {
-	n, err := note.Open([]byte(text+"\n"+line), note.VerifierList(verifier))
+func TimestampedSignature(noteText, signatureLine string, verifier *Verifier) ([]byte, error) {
+	n, err := note.Open([]byte(noteText+"\n"+signatureLine), note.VerifierList(verifier))
 	if err != nil {
 		return nil, fmt.Errorf("opening the cosigned note: %s", err)
 	}

--- a/trees/cosignature/cosignature_test.go
+++ b/trees/cosignature/cosignature_test.go
@@ -1,0 +1,579 @@
+//go:build go1.27
+
+package cosignature
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/mldsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/letsencrypt/boulder/trees/checkpoint"
+	"golang.org/x/mod/sumdb/note"
+	"golang.org/x/mod/sumdb/tlog"
+)
+
+// exampleCheckpoint is a canonical tlog-checkpoint note body the cosignature
+// tests sign and verify over.
+const exampleHashB64 = "CsUYapGGPo4dkMgIAUqom/Xajj7h2fB2MPA3j2jxq2I="
+
+// exampleCheckpoint is a tlog-checkpoint note body, including the trailing
+// newline and no signature lines.
+const exampleCheckpoint = "example.com/behind-the-sofa\n20852163\n" + exampleHashB64 + "\n"
+
+const cosignerID = "32473.9"
+const cosignerName = oidPrefix + cosignerID
+
+// testKey returns a deterministic ML-DSA-44 key, so cosignature tests are
+// reproducible.
+func testKey(t *testing.T) *mldsa.PrivateKey {
+	t.Helper()
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	key, err := mldsa.NewPrivateKey(mldsa.MLDSA44(), seed)
+	if err != nil {
+		t.Fatalf("NewPrivateKey: %s", err)
+	}
+	return key
+}
+
+func testPubKey(t *testing.T) *mldsa.PublicKey {
+	t.Helper()
+	return testKey(t).PublicKey()
+}
+
+func newVerifier(t *testing.T) *Verifier {
+	t.Helper()
+	v, err := NewVerifier(cosignerID, testPubKey(t))
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	return v
+}
+
+// TestKeyID pins keyIDFor to SHA-256(name || 0x0A || 0x06 || pubkey)[:4],
+// derived independently from the spec text. No published vector ships a key and
+// ID together, and an internal round-trip cannot catch a shared misreading.
+func TestKeyID(t *testing.T) {
+	pub := testPubKey(t)
+
+	h := sha256.New()
+	h.Write([]byte(cosignerName))
+	h.Write([]byte{0x0A, 0x06})
+	h.Write(pub.Bytes())
+	expect := binary.BigEndian.Uint32(h.Sum(nil)[:4])
+
+	got := keyIDFor(cosignerName, pub)
+	if got != expect {
+		t.Errorf("keyIDFor = %#x, want %#x", got, expect)
+	}
+
+	v := newVerifier(t)
+	if v.KeyHash() != expect {
+		t.Errorf("KeyHash() = %#x, want %#x", v.KeyHash(), expect)
+	}
+	if v.Name() != cosignerName {
+		t.Errorf("Name() = %q, want %q", v.Name(), cosignerName)
+	}
+}
+
+func TestVerifyRejectsMalformedSignature(t *testing.T) {
+	v := newVerifier(t)
+	for _, length := range []int{0, 7, 8, timestampedSignatureSize - 1, timestampedSignatureSize + 1} {
+		if v.Verify([]byte(exampleCheckpoint), make([]byte, length)) {
+			t.Errorf("Verify accepted a %d-byte signature", length)
+		}
+	}
+}
+
+func TestNewVerifierRejects(t *testing.T) {
+	pub := testPubKey(t)
+	for _, id := range []string{"", "has space", "32473..2", "32473.x", ".32473", "32473.", "32473.02"} {
+		_, err := NewVerifier(id, pub)
+		if err == nil {
+			t.Errorf("NewVerifier(%q) = nil error, want error", id)
+		}
+	}
+
+	// An ML-DSA-65 key is the wrong size for an ML-DSA-44 cosigner.
+	wrong, err := mldsa.GenerateKey(mldsa.MLDSA65())
+	if err != nil {
+		t.Fatalf("GenerateKey(MLDSA65): %s", err)
+	}
+	_, err = NewVerifier(cosignerID, wrong.PublicKey())
+	if err == nil {
+		t.Error("NewVerifier with a non-ML-DSA-44 key = nil error, want error")
+	}
+}
+
+// TestVerifyRejectsOversizeTimestamp checks that even a correctly-signed
+// timestamped_signature is rejected when its timestamp exceeds the spec's
+// 2^63-1 bound.
+func TestVerifyRejectsOversizeTimestamp(t *testing.T) {
+	key := testKey(t)
+	v := newVerifier(t)
+	parsed, err := checkpoint.Unmarshal(exampleCheckpoint)
+	if err != nil {
+		t.Fatalf("Unmarshal: %s", err)
+	}
+
+	timestamped := func(ts uint64) []byte {
+		message, err := marshalCosignedMessage(cosignerName, ts, parsed.Origin, parsed.Tree.N, parsed.Tree.Hash)
+		if err != nil {
+			t.Fatalf("marshalCosignedMessage: %s", err)
+		}
+		signature, err := key.SignDeterministic(message, nil)
+		if err != nil {
+			t.Fatalf("Sign: %s", err)
+		}
+		out := make([]byte, timestampedSignatureSize)
+		binary.BigEndian.PutUint64(out[:8], ts)
+		copy(out[8:], signature)
+		return out
+	}
+
+	for _, ts := range []uint64{1 << 63, ^uint64(0)} {
+		if v.Verify([]byte(exampleCheckpoint), timestamped(ts)) {
+			t.Errorf("Verify accepted timestamp %d > 2^63-1", ts)
+		}
+	}
+	// The boundary value 2^63-1 is conformant and must verify.
+	if !v.Verify([]byte(exampleCheckpoint), timestamped(1<<63-1)) {
+		t.Error("Verify rejected the boundary timestamp 2^63-1")
+	}
+}
+
+// TestVerifyCheckpointErrors checks that each VerifyCheckpoint failure names
+// the check that rejected it.
+func TestVerifyCheckpointErrors(t *testing.T) {
+	v := newVerifier(t)
+	parsed, err := checkpoint.Unmarshal(exampleCheckpoint)
+	if err != nil {
+		t.Fatalf("Unmarshal: %s", err)
+	}
+
+	oversize := make([]byte, timestampedSignatureSize)
+	binary.BigEndian.PutUint64(oversize[:8], 1<<63)
+
+	cases := []struct {
+		name            string
+		tree            tlog.Tree
+		signature       []byte
+		expectSubstring string
+	}{
+		{"Short signature", parsed.Tree, make([]byte, 10), "10 bytes"},
+		{"Oversize timestamp", parsed.Tree, oversize, "2^63-1"},
+		{"Empty tree", tlog.Tree{N: 0, Hash: parsed.Tree.Hash}, make([]byte, timestampedSignatureSize), "non-positive end"},
+		{"Garbage signature", parsed.Tree, make([]byte, timestampedSignatureSize), "verifying cosignature"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := v.VerifyCheckpoint(parsed.Origin, tc.tree, tc.signature)
+			if err == nil {
+				t.Fatal("VerifyCheckpoint = nil error, want error")
+			}
+			if !strings.Contains(err.Error(), tc.expectSubstring) {
+				t.Errorf("VerifyCheckpoint = %s, want substring %q", err, tc.expectSubstring)
+			}
+		})
+	}
+}
+
+func TestOrigin(t *testing.T) {
+	origin, err := Origin("32473.2.0.42")
+	if err != nil {
+		t.Fatalf("Origin: %s", err)
+	}
+	if origin != "oid/1.3.6.1.4.1.32473.2.0.42" {
+		t.Errorf("Origin = %q, want %q", origin, "oid/1.3.6.1.4.1.32473.2.0.42")
+	}
+
+	_, err = Origin("32473..2")
+	if err == nil {
+		t.Error("Origin with a malformed log ID = nil error, want error")
+	}
+}
+
+// TestCosignerRoundTrip covers the cosigner round trip: an MTC cosigner derives
+// its name and origin from the CA and log IDs (mtc-tlog's own examples), and
+// its timestamped_signature carries a zero timestamp, verifies through the note
+// verifier against the matching checkpoint text, and reassembles into a
+// signature line that opens.
+func TestCosignerRoundTrip(t *testing.T) {
+	ca, err := NewCosigner("32473.2", "32473.2.0.42", testKey(t))
+	if err != nil {
+		t.Fatalf("NewCosigner: %s", err)
+	}
+	if ca.Origin() != "oid/1.3.6.1.4.1.32473.2.0.42" {
+		t.Errorf("Origin() = %q, want %q", ca.Origin(), "oid/1.3.6.1.4.1.32473.2.0.42")
+	}
+
+	text := ca.origin + "\n20852163\n" + exampleHashB64 + "\n"
+	parsed, err := checkpoint.Unmarshal(text)
+	if err != nil {
+		t.Fatalf("checkpoint.Unmarshal: %s", err)
+	}
+
+	signature, err := ca.CosignCheckpoint(parsed.Tree)
+	if err != nil {
+		t.Fatalf("CosignCheckpoint: %s", err)
+	}
+	if len(signature) != timestampedSignatureSize {
+		t.Fatalf("CosignCheckpoint returned %d bytes, want %d", len(signature), timestampedSignatureSize)
+	}
+	if binary.BigEndian.Uint64(signature[:8]) != 0 {
+		t.Errorf("timestamp = %d, want 0", binary.BigEndian.Uint64(signature[:8]))
+	}
+
+	v, err := NewVerifier("32473.2", testPubKey(t))
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	if !v.Verify([]byte(text), signature) {
+		t.Error("Verify rejected an MTC checkpoint cosignature")
+	}
+	err = v.VerifyCheckpoint(ca.Origin(), parsed.Tree, signature)
+	if err != nil {
+		t.Errorf("VerifyCheckpoint rejected an MTC checkpoint cosignature: %s", err)
+	}
+
+	// The cosignature binds the origin and tree: a change to any of them must
+	// fail verification.
+	err = v.VerifyCheckpoint(ca.Origin(), tlog.Tree{N: parsed.Tree.N + 1, Hash: parsed.Tree.Hash}, signature)
+	if err == nil {
+		t.Error("VerifyCheckpoint accepted a cosignature over a different tree size")
+	}
+	tamperedHash := parsed.Tree.Hash
+	tamperedHash[0] ^= 1
+	err = v.VerifyCheckpoint(ca.Origin(), tlog.Tree{N: parsed.Tree.N, Hash: tamperedHash}, signature)
+	if err == nil {
+		t.Error("VerifyCheckpoint accepted a cosignature over a different root hash")
+	}
+	err = v.VerifyCheckpoint("oid/1.3.6.1.4.1.32473.2.0.43", parsed.Tree, signature)
+	if err == nil {
+		t.Error("VerifyCheckpoint accepted a cosignature over a different origin")
+	}
+
+	// ML-DSA signing through a crypto.Signer may be hedged, so
+	// CosignatureLine's line carries a fresh signature. Line must rebuild that
+	// line byte for byte from the signature extracted out of it.
+	line, err := ca.CosignatureLine(parsed.Tree)
+	if err != nil {
+		t.Fatalf("CosignatureLine: %s", err)
+	}
+	if !strings.HasPrefix(line, noteSignatureLinePrefix+ca.name+" ") {
+		t.Errorf("line %q has unexpected prefix", line)
+	}
+
+	signed := []byte(text + "\n" + line)
+	n, err := note.Open(signed, note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("note.Open of a reassembled MTC-cosigned note: %s", err)
+	}
+	extracted, ok := TimestampedSignature(n, v)
+	if !ok {
+		t.Fatal("TimestampedSignature = false for a reassembled note")
+	}
+	if !v.Verify([]byte(text), extracted) {
+		t.Error("Verify rejected an extracted cosignature")
+	}
+	rebuilt, err := Line(ca.name, testPubKey(t), extracted)
+	if err != nil {
+		t.Fatalf("Line: %s", err)
+	}
+	if rebuilt != line {
+		t.Errorf("Line = %q, want %q", rebuilt, line)
+	}
+}
+
+func TestCosignerRejects(t *testing.T) {
+	key := testKey(t)
+
+	for _, id := range []string{"", "has space", "32473..2", "32473.x", ".32473", "32473.", "32473.02"} {
+		_, err := NewCosigner(id, "32473.2.0.42", key)
+		if err == nil {
+			t.Errorf("NewCosigner with cosigner ID %q = nil error, want error", id)
+		}
+		_, err = NewCosigner("32473.2", id, key)
+		if err == nil {
+			t.Errorf("NewCosigner with log ID %q = nil error, want error", id)
+		}
+	}
+
+	// An ML-DSA-65 key has an mldsa public key of the wrong size.
+	wrong, err := mldsa.GenerateKey(mldsa.MLDSA65())
+	if err != nil {
+		t.Fatalf("GenerateKey(MLDSA65): %s", err)
+	}
+	_, err = NewCosigner("32473.2", "32473.2.0.42", wrong)
+	if err == nil {
+		t.Error("NewCosigner with an ML-DSA-65 key = nil error, want error")
+	}
+
+	// An Ed25519 key is not an mldsa public key at all.
+	_, edKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %s", err)
+	}
+	_, err = NewCosigner("32473.2", "32473.2.0.42", edKey)
+	if err == nil {
+		t.Error("NewCosigner with an Ed25519 key = nil error, want error")
+	}
+
+	ca, err := NewCosigner("32473.2", "32473.2.0.42", key)
+	if err != nil {
+		t.Fatalf("NewCosigner: %s", err)
+	}
+	_, err = ca.CosignCheckpoint(tlog.Tree{N: -1})
+	if err == nil {
+		t.Error("CosignCheckpoint with a negative tree size = nil error, want error")
+	}
+
+	// An empty tree [0, 0) is not a valid subtree.
+	_, err = ca.CosignCheckpoint(tlog.Tree{N: 0})
+	if err == nil {
+		t.Error("CosignCheckpoint with an empty tree = nil error, want error")
+	}
+}
+
+// shortSigner is a crypto.Signer with a valid ML-DSA-44 public key that returns
+// a truncated signature, standing in for a misbehaving external signer such as
+// an HSM wrapper.
+type shortSigner struct {
+	pubKey *mldsa.PublicKey
+}
+
+func (s shortSigner) Public() crypto.PublicKey {
+	return s.pubKey
+}
+
+func (s shortSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
+	return []byte("short"), nil
+}
+
+func TestCosignerRejectsShortSignature(t *testing.T) {
+	ca, err := NewCosigner("32473.2", "32473.2.0.42", shortSigner{pubKey: testPubKey(t)})
+	if err != nil {
+		t.Fatalf("NewCosigner: %s", err)
+	}
+	_, err = ca.CosignCheckpoint(tlog.Tree{N: 1})
+	if err == nil {
+		t.Error("CosignCheckpoint with a truncated signature = nil error, want error")
+	}
+}
+
+// TestLineRejects enforces signed-note's key name rules, for which Line is the
+// only gate now that cosigner and verifier names derive from validated OIDs.
+func TestLineRejects(t *testing.T) {
+	pub := testPubKey(t)
+	wrong, err := mldsa.GenerateKey(mldsa.MLDSA65())
+	if err != nil {
+		t.Fatalf("GenerateKey(MLDSA65): %s", err)
+	}
+	good := make([]byte, timestampedSignatureSize)
+
+	for _, name := range []string{
+		"",
+		"has space",
+		"has\ttab",
+		"has+plus",
+		"has\x01control",
+		"bad\xffutf8",
+		strings.Repeat("a", 256),
+	} {
+		_, err := Line(name, pub, good)
+		if err == nil {
+			t.Errorf("Line(%q) = nil error, want error", name)
+		}
+	}
+
+	cases := []struct {
+		name      string
+		signer    string
+		pub       *mldsa.PublicKey
+		signature []byte
+	}{
+		{"Wrong key type", cosignerName, wrong.PublicKey(), good},
+		{"Short signature", cosignerName, pub, good[:10]},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Line(tc.signer, tc.pub, tc.signature)
+			if err == nil {
+				t.Error("want error")
+			}
+		})
+	}
+}
+
+// TestSignature checks that Signature returns the trailing signature bytes and
+// refuses lengths and timestamps that certificates cannot carry.
+func TestSignature(t *testing.T) {
+	timestampedSignature := make([]byte, timestampedSignatureSize)
+	for i := range timestampedSignature[8:] {
+		timestampedSignature[8+i] = byte(i)
+	}
+	signature, err := Signature(timestampedSignature)
+	if err != nil {
+		t.Fatalf("Signature: %s", err)
+	}
+	if !bytes.Equal(signature, timestampedSignature[8:]) {
+		t.Error("Signature did not return the trailing signature bytes")
+	}
+
+	_, err = Signature(timestampedSignature[:10])
+	if err == nil {
+		t.Error("Signature with a short input = nil error, want error")
+	}
+
+	nonzero := bytes.Clone(timestampedSignature)
+	nonzero[7] = 1
+	_, err = Signature(nonzero)
+	if err == nil {
+		t.Error("Signature with a non-zero timestamp = nil error, want error")
+	}
+}
+
+// TestTimestampedSignature checks that the timestamped_signature extracted from
+// an opened note verifies on its own, and that extraction fails for a verifier
+// that did not sign.
+func TestTimestampedSignature(t *testing.T) {
+	ca, err := NewCosigner("32473.2", "32473.2.0.42", testKey(t))
+	if err != nil {
+		t.Fatalf("NewCosigner: %s", err)
+	}
+	text := ca.origin + "\n20852163\n" + exampleHashB64 + "\n"
+	parsed, err := checkpoint.Unmarshal(text)
+	if err != nil {
+		t.Fatalf("checkpoint.Unmarshal: %s", err)
+	}
+	line, err := ca.CosignatureLine(parsed.Tree)
+	if err != nil {
+		t.Fatalf("CosignatureLine: %s", err)
+	}
+
+	v, err := NewVerifier("32473.2", testPubKey(t))
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	n, err := note.Open([]byte(text+"\n"+line), note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("note.Open: %s", err)
+	}
+
+	timestampedSignature, ok := TimestampedSignature(n, v)
+	if !ok {
+		t.Fatal("TimestampedSignature = false for the cosigner that signed the note")
+	}
+	if !v.Verify([]byte(text), timestampedSignature) {
+		t.Fatal("Verify rejected an extracted cosignature")
+	}
+
+	other, err := NewVerifier(cosignerID, testPubKey(t))
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	_, dup := TimestampedSignature(n, other)
+	if dup {
+		t.Error("TimestampedSignature = true for a cosigner that did not sign the note")
+	}
+}
+
+// TestTimestampedSignatureRejectsForeignFormat covers a signature verified by
+// x/mod's standard signer (alg 0x01, 64-byte payload). It is not a
+// timestamped_signature, so TimestampedSignature must refuse it even though the
+// note opened.
+func TestTimestampedSignatureRejectsForeignFormat(t *testing.T) {
+	skey, vkey, err := note.GenerateKey(rand.Reader, "log.example")
+	if err != nil {
+		t.Fatalf("GenerateKey: %s", err)
+	}
+	signer, err := note.NewSigner(skey)
+	if err != nil {
+		t.Fatalf("NewSigner: %s", err)
+	}
+	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, signer)
+	if err != nil {
+		t.Fatalf("note.Sign: %s", err)
+	}
+	verifier, err := note.NewVerifier(vkey)
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	n, err := note.Open(signed, note.VerifierList(verifier))
+	if err != nil {
+		t.Fatalf("note.Open: %s", err)
+	}
+
+	if len(n.Sigs) != 1 {
+		t.Fatalf("Sigs = %+v, want the standard signer's verified signature", n.Sigs)
+	}
+	_, ok := TimestampedSignature(n, verifier)
+	if ok {
+		t.Error("TimestampedSignature = true for a non-cosignature-format signature")
+	}
+}
+
+// TestOpenIgnoresUnknownSignatures covers signed-note's "verifiers MUST ignore
+// signatures from unknown keys" with a note cosigned for one log by two MTC
+// cosigners and opened by one verifier, the shape of every real exchange.
+func TestOpenIgnoresUnknownSignatures(t *testing.T) {
+	known, err := NewCosigner("32473.2", "32473.2.0.42", testKey(t))
+	if err != nil {
+		t.Fatalf("NewCosigner: %s", err)
+	}
+
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = byte(255 - i)
+	}
+	otherKey, err := mldsa.NewPrivateKey(mldsa.MLDSA44(), seed)
+	if err != nil {
+		t.Fatalf("NewPrivateKey: %s", err)
+	}
+	unknown, err := NewCosigner("32473.9", "32473.2.0.42", otherKey)
+	if err != nil {
+		t.Fatalf("NewCosigner: %s", err)
+	}
+
+	text := known.origin + "\n20852163\n" + exampleHashB64 + "\n"
+	parsed, err := checkpoint.Unmarshal(text)
+	if err != nil {
+		t.Fatalf("checkpoint.Unmarshal: %s", err)
+	}
+	knownLine, err := known.CosignatureLine(parsed.Tree)
+	if err != nil {
+		t.Fatalf("CosignatureLine: %s", err)
+	}
+	unknownLine, err := unknown.CosignatureLine(parsed.Tree)
+	if err != nil {
+		t.Fatalf("CosignatureLine: %s", err)
+	}
+	signed := []byte(text + "\n" + knownLine + unknownLine)
+
+	v, err := NewVerifier("32473.2", testPubKey(t))
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	cp, n, err := checkpoint.Open(signed, note.VerifierList(v))
+	if err != nil {
+		t.Fatalf("checkpoint.Open: %s", err)
+	}
+	if cp.Origin != known.origin {
+		t.Errorf("Origin = %q, want %q", cp.Origin, known.origin)
+	}
+	if len(n.Sigs) != 1 || n.Sigs[0].Name != known.name {
+		t.Fatalf("Sigs = %+v, want only the known cosigner's", n.Sigs)
+	}
+	if len(n.UnverifiedSigs) != 1 || n.UnverifiedSigs[0].Name != unknown.name {
+		t.Errorf("UnverifiedSigs = %+v, want the unknown cosigner's", n.UnverifiedSigs)
+	}
+}

--- a/trees/cosignature/cosignature_test.go
+++ b/trees/cosignature/cosignature_test.go
@@ -9,7 +9,9 @@ import (
 	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -85,12 +87,16 @@ func TestKeyID(t *testing.T) {
 	}
 }
 
-func TestVerifyRejectsMalformedSignature(t *testing.T) {
+func TestVerifyRejectsMalformedInput(t *testing.T) {
 	v := newVerifier(t)
 	for _, length := range []int{0, 7, 8, timestampedSignatureSize - 1, timestampedSignatureSize + 1} {
 		if v.Verify([]byte(exampleCheckpoint), make([]byte, length)) {
 			t.Errorf("Verify accepted a %d-byte signature", length)
 		}
+	}
+
+	if v.Verify([]byte("not a checkpoint"), make([]byte, timestampedSignatureSize)) {
+		t.Error("Verify accepted malformed checkpoint text")
 	}
 }
 
@@ -263,8 +269,8 @@ func TestCosignerRoundTrip(t *testing.T) {
 	}
 
 	// ML-DSA signing through a crypto.Signer may be hedged, so
-	// CosignatureLine's line carries a fresh signature. Line must rebuild that
-	// line byte for byte from the signature extracted out of it.
+	// CosignatureLine's line carries a fresh signature. signatureLineFor must
+	// rebuild that line byte for byte from the signature extracted out of it.
 	line, err := ca.CosignatureLine(parsed.Tree)
 	if err != nil {
 		t.Fatalf("CosignatureLine: %s", err)
@@ -273,24 +279,16 @@ func TestCosignerRoundTrip(t *testing.T) {
 		t.Errorf("line %q has unexpected prefix", line)
 	}
 
-	signed := []byte(text + "\n" + line)
-	n, err := note.Open(signed, note.VerifierList(v))
+	extracted, err := TimestampedSignature(text, line, v)
 	if err != nil {
-		t.Fatalf("note.Open of a reassembled MTC-cosigned note: %s", err)
-	}
-	extracted, ok := TimestampedSignature(n, v)
-	if !ok {
-		t.Fatal("TimestampedSignature = false for a reassembled note")
+		t.Fatalf("TimestampedSignature on a reassembled note: %s", err)
 	}
 	if !v.Verify([]byte(text), extracted) {
 		t.Error("Verify rejected an extracted cosignature")
 	}
-	rebuilt, err := Line(ca.name, testPubKey(t), extracted)
-	if err != nil {
-		t.Fatalf("Line: %s", err)
-	}
+	rebuilt := signatureLineFor(ca.name, ca.keyID, extracted)
 	if rebuilt != line {
-		t.Errorf("Line = %q, want %q", rebuilt, line)
+		t.Errorf("signatureLineFor = %q, want %q", rebuilt, line)
 	}
 }
 
@@ -368,83 +366,68 @@ func TestCosignerRejectsShortSignature(t *testing.T) {
 	if err == nil {
 		t.Error("CosignCheckpoint with a truncated signature = nil error, want error")
 	}
+	_, err = ca.CosignatureLine(tlog.Tree{N: 1})
+	if err == nil {
+		t.Error("CosignatureLine with a truncated signature = nil error, want error")
+	}
 }
 
-// TestLineRejects enforces signed-note's key name rules, for which Line is the
-// only gate now that cosigner and verifier names derive from validated OIDs.
-func TestLineRejects(t *testing.T) {
-	pub := testPubKey(t)
-	wrong, err := mldsa.GenerateKey(mldsa.MLDSA65())
+// errSigner is a crypto.Signer with a valid ML-DSA-44 public key whose Sign
+// always fails, standing in for an unavailable external signer such as an HSM.
+type errSigner struct {
+	pubKey *mldsa.PublicKey
+}
+
+func (s errSigner) Public() crypto.PublicKey {
+	return s.pubKey
+}
+
+func (s errSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
+	return nil, errors.New("signer unavailable")
+}
+
+func TestCosignerPropagatesSignerError(t *testing.T) {
+	ca, err := NewCosigner("32473.2", "32473.2.0.42", errSigner{pubKey: testPubKey(t)})
 	if err != nil {
-		t.Fatalf("GenerateKey(MLDSA65): %s", err)
+		t.Fatalf("NewCosigner: %s", err)
 	}
-	good := make([]byte, timestampedSignatureSize)
-
-	for _, name := range []string{
-		"",
-		"has space",
-		"has\ttab",
-		"has+plus",
-		"has\x01control",
-		"bad\xffutf8",
-		strings.Repeat("a", 256),
-	} {
-		_, err := Line(name, pub, good)
-		if err == nil {
-			t.Errorf("Line(%q) = nil error, want error", name)
-		}
-	}
-
-	cases := []struct {
-		name      string
-		signer    string
-		pub       *mldsa.PublicKey
-		signature []byte
-	}{
-		{"Wrong key type", cosignerName, wrong.PublicKey(), good},
-		{"Short signature", cosignerName, pub, good[:10]},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := Line(tc.signer, tc.pub, tc.signature)
-			if err == nil {
-				t.Error("want error")
-			}
-		})
+	_, err = ca.CosignCheckpoint(tlog.Tree{N: 1})
+	if err == nil {
+		t.Error("CosignCheckpoint with a failing signer = nil error, want error")
 	}
 }
 
-// TestSignature checks that Signature returns the trailing signature bytes and
-// refuses lengths and timestamps that certificates cannot carry.
-func TestSignature(t *testing.T) {
+// TestRawSignature checks that RawSignature returns the trailing signature
+// bytes and refuses lengths and timestamps that certificates cannot carry.
+func TestRawSignature(t *testing.T) {
 	timestampedSignature := make([]byte, timestampedSignatureSize)
 	for i := range timestampedSignature[8:] {
 		timestampedSignature[8+i] = byte(i)
 	}
-	signature, err := Signature(timestampedSignature)
+	signature, err := RawSignature(timestampedSignature)
 	if err != nil {
-		t.Fatalf("Signature: %s", err)
+		t.Fatalf("RawSignature: %s", err)
 	}
 	if !bytes.Equal(signature, timestampedSignature[8:]) {
-		t.Error("Signature did not return the trailing signature bytes")
+		t.Error("RawSignature did not return the trailing signature bytes")
 	}
 
-	_, err = Signature(timestampedSignature[:10])
+	_, err = RawSignature(timestampedSignature[:10])
 	if err == nil {
-		t.Error("Signature with a short input = nil error, want error")
+		t.Error("RawSignature with a short input = nil error, want error")
 	}
 
 	nonzero := bytes.Clone(timestampedSignature)
 	nonzero[7] = 1
-	_, err = Signature(nonzero)
+	_, err = RawSignature(nonzero)
 	if err == nil {
-		t.Error("Signature with a non-zero timestamp = nil error, want error")
+		t.Error("RawSignature with a non-zero timestamp = nil error, want error")
 	}
 }
 
-// TestTimestampedSignature checks that the timestamped_signature extracted from
-// an opened note verifies on its own, and that extraction fails for a verifier
-// that did not sign.
+// TestTimestampedSignature checks that the extracted timestamped_signature
+// verifies on its own, and that extraction errors for a verifier that did not
+// sign.
 func TestTimestampedSignature(t *testing.T) {
 	ca, err := NewCosigner("32473.2", "32473.2.0.42", testKey(t))
 	if err != nil {
@@ -464,14 +447,9 @@ func TestTimestampedSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewVerifier: %s", err)
 	}
-	n, err := note.Open([]byte(text+"\n"+line), note.VerifierList(v))
+	timestampedSignature, err := TimestampedSignature(text, line, v)
 	if err != nil {
-		t.Fatalf("note.Open: %s", err)
-	}
-
-	timestampedSignature, ok := TimestampedSignature(n, v)
-	if !ok {
-		t.Fatal("TimestampedSignature = false for the cosigner that signed the note")
+		t.Fatalf("TimestampedSignature for the cosigner that signed the note: %s", err)
 	}
 	if !v.Verify([]byte(text), timestampedSignature) {
 		t.Fatal("Verify rejected an extracted cosignature")
@@ -481,44 +459,24 @@ func TestTimestampedSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewVerifier: %s", err)
 	}
-	_, dup := TimestampedSignature(n, other)
-	if dup {
-		t.Error("TimestampedSignature = true for a cosigner that did not sign the note")
+	_, err = TimestampedSignature(text, line, other)
+	if err == nil {
+		t.Error("TimestampedSignature for a cosigner that did not sign the note = nil error, want error")
 	}
 }
 
-// TestTimestampedSignatureRejectsForeignFormat covers a signature verified by
-// x/mod's standard signer (alg 0x01, 64-byte payload). It is not a
-// timestamped_signature, so TimestampedSignature must refuse it even though the
-// note opened.
+// TestTimestampedSignatureRejectsForeignFormat checks that a signature line
+// whose body is not keyID || timestamped_signature (such as x/mod's standard
+// 64-byte Ed25519 form) fails verification even when its name and key ID match
+// the verifier's.
 func TestTimestampedSignatureRejectsForeignFormat(t *testing.T) {
-	skey, vkey, err := note.GenerateKey(rand.Reader, "log.example")
-	if err != nil {
-		t.Fatalf("GenerateKey: %s", err)
-	}
-	signer, err := note.NewSigner(skey)
-	if err != nil {
-		t.Fatalf("NewSigner: %s", err)
-	}
-	signed, err := note.Sign(&note.Note{Text: exampleCheckpoint}, signer)
-	if err != nil {
-		t.Fatalf("note.Sign: %s", err)
-	}
-	verifier, err := note.NewVerifier(vkey)
-	if err != nil {
-		t.Fatalf("NewVerifier: %s", err)
-	}
-	n, err := note.Open(signed, note.VerifierList(verifier))
-	if err != nil {
-		t.Fatalf("note.Open: %s", err)
-	}
-
-	if len(n.Sigs) != 1 {
-		t.Fatalf("Sigs = %+v, want the standard signer's verified signature", n.Sigs)
-	}
-	_, ok := TimestampedSignature(n, verifier)
-	if ok {
-		t.Error("TimestampedSignature = true for a non-cosignature-format signature")
+	v := newVerifier(t)
+	idSignature := make([]byte, keyIDSize+64)
+	binary.BigEndian.PutUint32(idSignature[:keyIDSize], v.KeyHash())
+	line := noteSignatureLinePrefix + v.Name() + " " + base64.StdEncoding.EncodeToString(idSignature) + "\n"
+	_, err := TimestampedSignature(exampleCheckpoint, line, v)
+	if err == nil {
+		t.Error("TimestampedSignature with a 64-byte signature body = nil error, want error")
 	}
 }
 


### PR DESCRIPTION
Implement ML-DSA-44 cosignatures over log checkpoints. [tlog-cosignature](https://c2sp.org/tlog-cosignature) specifies the cosignature format, and [mtc-tlog](https://c2sp.org/mtc-tlog) specifies how MTC uses it. This package is written to both: it derives cosigner names and log origins as mtc-tlog requires, accepts only ML-DSA-44 keys, and signs with a zero timestamp, which [section 6.2](https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#section-6.2) of the MTC draft requires for cosignatures used in certificates.

Export the following:

- `Cosigner` cosigns checkpoints for a single log, through a `crypto.Signer` so the key may be stored in an HSM. `.CosignCheckpoint()` returns the cosignature as a `timestamped_signature`, which is how the MTCA signs the checkpoints it stores, and `.CosignatureLine()` performs the same signing but returns the cosignature as a note signature line, which is what a mirror hands back to the `mtpublisher`.
- `Verifier` is a `note.Verifier` for a cosigner's public key. `.Verify()` satisfies the interface, checking a cosignature against checkpoint note text, and `.VerifyCheckpoint()` checks one against an already parsed origin and tree, which is how the MTCA verifies each cosignature before storing it.
- `Origin` derives a log origin from a log ID.
- `TimestampedSignature` verifies a signature line against checkpoint note text and returns the cosigner's `timestamped_signature`, which is how the `mtpublisher` turns a mirror's line into the bytes it stores.
- `RawSignature` returns the bare ML-DSA-44 signature necessary for an `MTCSignature`, refusing non-zero timestamps. The MTCA and mtpublisher will both have a `timestamped_signature` in hand, they will use this to extract a raw signature to store in the database. 