### PR TITLE
Remove the ability to issue id-kp-clientAuth certificates

### DIFF
--- a/issuance/cert.go
+++ b/issuance/cert.go
@@ -39,6 +39,7 @@ type ProfileConfig struct {
 	OmitKeyEncipherment bool
 	// OmitClientAuth causes the id-kp-clientAuth OID (TLS Client Authentication)
 	// to be omitted from the EKU extension.
+	// Deprecated: This has no effect, and we always omit the clientAuth EKU.
 	OmitClientAuth bool
 	// OmitSKID causes the Subject Key Identifier extension to be omitted.
 	OmitSKID bool
@@ -68,7 +69,6 @@ type ProfileConfig struct {
 type Profile struct {
 	omitCommonName      bool
 	omitKeyEncipherment bool
-	omitClientAuth      bool
 	omitSKID            bool
 	mtc                 bool
 
@@ -94,12 +94,6 @@ func NewProfile(profileConfig ProfileConfig) (*Profile, error) {
 		return nil, fmt.Errorf("validity period %q is too large", profileConfig.MaxValidityPeriod.Duration)
 	}
 
-	// CQRP: clientAuth is MUST NOT.
-	// https://docs.google.com/document/d/1bC958-AaZ7ePCPFVyP9Sg2VZ3DcC2-PqwsMly8oIJSU/edit?tab=t.0#heading=h.kbidyave6lzr
-	if profileConfig.MTC {
-		profileConfig.OmitClientAuth = true
-	}
-
 	lints, err := linter.NewRegistry(profileConfig.IgnoredLints)
 	cmd.FailOnError(err, "Failed to create zlint registry")
 	if profileConfig.LintConfig != "" {
@@ -111,7 +105,6 @@ func NewProfile(profileConfig ProfileConfig) (*Profile, error) {
 	sp := &Profile{
 		omitCommonName:      profileConfig.OmitCommonName,
 		omitKeyEncipherment: profileConfig.OmitKeyEncipherment,
-		omitClientAuth:      profileConfig.OmitClientAuth,
 		omitSKID:            profileConfig.OmitSKID,
 		mtc:                 profileConfig.MTC,
 		maxBackdate:         profileConfig.MaxValidityBackdate.Duration,
@@ -199,6 +192,7 @@ func (i *Issuer) generateTemplate() *x509.Certificate {
 		SignatureAlgorithm:    i.sigAlg,
 		IssuingCertificateURL: []string{i.issuerURL},
 		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		// Baseline Requirements, Section 7.1.6.1: domain-validated
 		Policies: []x509.OID{domainValidatedOID},
 	}
@@ -317,17 +311,6 @@ func (i *Issuer) Prepare(prof *Profile, req *IssuanceRequest) ([]byte, *issuance
 
 	// generate template from the issuer's data
 	template := i.generateTemplate()
-
-	ekus := []x509.ExtKeyUsage{
-		x509.ExtKeyUsageServerAuth,
-		x509.ExtKeyUsageClientAuth,
-	}
-	if prof.omitClientAuth {
-		ekus = []x509.ExtKeyUsage{
-			x509.ExtKeyUsageServerAuth,
-		}
-	}
-	template.ExtKeyUsage = ekus
 
 	// populate template from the issuance request
 	template.NotBefore, template.NotAfter = req.NotBefore, req.NotAfter

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -679,7 +679,6 @@ func TestIssueOmissions(t *testing.T) {
 	pc := defaultProfileConfig()
 	pc.OmitCommonName = true
 	pc.OmitKeyEncipherment = true
-	pc.OmitClientAuth = true
 	pc.OmitSKID = true
 	pc.IgnoredLints = []string{
 		// Reduce the lint ignores to just the minimal (SCT-related) set.

--- a/issuance/cert_test.go
+++ b/issuance/cert_test.go
@@ -322,6 +322,7 @@ func TestGenerateTemplate(t *testing.T) {
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		IssuingCertificateURL: []string{"http://issuer"},
 		Policies:              []x509.OID{domainValidatedOID},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		// This field is computed based on the serial, so is not included in the template.
 		CRLDistributionPoints: nil,
 	}

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -79,7 +79,7 @@
 					"omitCommonName": true,
 					"omitKeyEncipherment": true,
 					"omitSKID": true,
-					"maxValidityPeriod": "583200s",
+					"maxValidityPeriod": "1080h",
 					"maxValidityBackdate": "1h5m",
 					"maxCertificateSize": 10000,
 					"lintConfig": "test/config-next/zlint.toml",

--- a/test/config-next/ca.json
+++ b/test/config-next/ca.json
@@ -51,7 +51,6 @@
 				"legacy": {
 					"omitCommonName": false,
 					"omitKeyEncipherment": false,
-					"omitClientAuth": false,
 					"omitSKID": false,
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m",
@@ -66,7 +65,6 @@
 				"shortlived": {
 					"omitCommonName": true,
 					"omitKeyEncipherment": true,
-					"omitClientAuth": true,
 					"omitSKID": true,
 					"maxValidityPeriod": "160h",
 					"maxValidityBackdate": "1h5m",
@@ -80,7 +78,6 @@
 				"modern": {
 					"omitCommonName": true,
 					"omitKeyEncipherment": true,
-					"omitClientAuth": true,
 					"omitSKID": true,
 					"maxValidityPeriod": "583200s",
 					"maxValidityBackdate": "1h5m",

--- a/test/config-next/cert-checker.json
+++ b/test/config-next/cert-checker.json
@@ -11,7 +11,7 @@
 		"checkPeriod": "72h",
 		"acceptableValidityDurations": [
 			"7776000s",
-			"583200s",
+			"1080h",
 			"160h"
 		],
 		"lintConfig": "test/config-next/zlint.toml",

--- a/test/config-next/mtca.json
+++ b/test/config-next/mtca.json
@@ -36,7 +36,6 @@
 					"mtc": true,
 					"omitCommonName": true,
 					"omitKeyEncipherment": true,
-					"omitClientAuth": true,
 					"omitSKID": true,
 					"maxValidityPeriod": "160h",
 					"maxValidityBackdate": "1h5m",

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -81,7 +81,7 @@
 					"omitKeyEncipherment": true,
 					"omitClientAuth": true,
 					"omitSKID": true,
-					"maxValidityPeriod": "583200s",
+					"maxValidityPeriod": "1080h",
 					"maxValidityBackdate": "1h5m",
 					"lintConfig": "test/config-next/zlint.toml",
 					"ignoredLints": [

--- a/test/config/ca.json
+++ b/test/config/ca.json
@@ -52,7 +52,7 @@
 				"legacy": {
 					"omitCommonName": false,
 					"omitKeyEncipherment": false,
-					"omitClientAuth": false,
+					"omitClientAuth": true,
 					"omitSKID": false,
 					"maxValidityPeriod": "7776000s",
 					"maxValidityBackdate": "1h5m",

--- a/test/config/cert-checker.json
+++ b/test/config/cert-checker.json
@@ -10,7 +10,7 @@
 		"checkPeriod": "72h",
 		"acceptableValidityDurations": [
 			"7776000s",
-			"583200s",
+			"1080h",
 			"160h"
 		],
 		"ignoredLints": [

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eggsampler/acme/v3"
 
@@ -145,31 +146,38 @@ func TestIssuanceProfiles(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	test.AssertNotError(t, err, "creating random cert key")
 
-	// Create a set of identifiers to request.
-	idents := []acme.Identifier{
-		{Type: "dns", Value: random_domain()},
-	}
-
 	// Get one cert for each profile that we know the test server advertises.
-	res, err := authAndIssue(client, key, idents, true, "legacy")
+	res, err := authAndIssue(client, key, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "legacy")
 	test.AssertNotError(t, err, "failed to issue under legacy profile")
 	test.AssertEquals(t, res.Order.Profile, "legacy")
 	legacy := res.certs[0]
 
-	res, err = authAndIssue(client, key, idents, true, "modern")
+	res, err = authAndIssue(client, key, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "modern")
 	test.AssertNotError(t, err, "failed to issue under modern profile")
 	test.AssertEquals(t, res.Order.Profile, "modern")
 	modern := res.certs[0]
 
-	// Check that each profile worked as expected.
-	test.AssertEquals(t, legacy.Subject.CommonName, idents[0].Value)
-	test.AssertEquals(t, modern.Subject.CommonName, "")
+	res, err = authAndIssue(client, key, []acme.Identifier{{Type: "dns", Value: random_domain()}}, true, "shortlived")
+	test.AssertNotError(t, err, "failed to issue under shortlived profile")
+	test.AssertEquals(t, res.Order.Profile, "shortlived")
+	shortlived := res.certs[0]
 
-	test.AssertDeepEquals(t, legacy.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+	// Check that each profile worked as expected.
+	test.Assert(t, len(legacy.Subject.CommonName) > 0, "legacy profile should have CN")
+	test.AssertEquals(t, modern.Subject.CommonName, "")
+	test.AssertEquals(t, shortlived.Subject.CommonName, "")
+
+	test.AssertDeepEquals(t, legacy.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
 	test.AssertDeepEquals(t, modern.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+	test.AssertDeepEquals(t, shortlived.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
 
 	test.AssertEquals(t, len(legacy.SubjectKeyId), 20)
 	test.AssertEquals(t, len(modern.SubjectKeyId), 0)
+	test.AssertEquals(t, len(shortlived.SubjectKeyId), 0)
+
+	test.AssertEquals(t, legacy.NotAfter.Add(time.Second).Sub(legacy.NotBefore), 90*24*time.Hour)
+	test.AssertEquals(t, modern.NotAfter.Add(time.Second).Sub(modern.NotBefore), 45*24*time.Hour)
+	test.AssertEquals(t, shortlived.NotAfter.Add(time.Second).Sub(shortlived.NotBefore), 160*time.Hour)
 }
 
 // TestIssuanceMTC issues from an MTC profile.


### PR DESCRIPTION
All production profiles configure `OmitClientAuth: true`, and the Chrome Root Program Requirements prevent us from issuing certs with the id-kp-clientAuth EKU ever again. Remove the code which could produce clientAuth certificates, and deprecate the config field.

IN-12197 tracked the SRE-side changes which made this config field redundant.