### PR TITLE
mtpublisher: ML-DSA signatures using trees/cosignature

### DIFF
--- a/cmd/boulder-mtpublisher/main.go
+++ b/cmd/boulder-mtpublisher/main.go
@@ -1,15 +1,20 @@
+//go:build go1.27
+
 package notmain
 
 import (
 	"context"
+	"crypto/mldsa"
+	"crypto/x509"
+	"encoding/pem"
 	"flag"
+	"fmt"
 	"os"
-
-	"github.com/jmhodges/clock"
 
 	"github.com/letsencrypt/boulder/cmd"
 	"github.com/letsencrypt/boulder/config"
 	"github.com/letsencrypt/boulder/mtpublisher"
+	"github.com/letsencrypt/boulder/privatekey"
 	"github.com/letsencrypt/boulder/sa"
 )
 
@@ -31,9 +36,38 @@ type Config struct {
 		// MirrorID identifies the cosigner this publisher writes alongside each
 		// cosignature (e.g. "32473.9").
 		MirrorID string `validate:"required"`
+
+		// MirrorPublicKeyFile holds the PEM-encoded ML-DSA-44 public key used
+		// to verify cosignatures.
+		MirrorPublicKeyFile string `validate:"required"`
+
+		// MirrorKeyFile holds the PEM-encoded ML-DSA-44 private key used to
+		// cosign checkpoints.
+		MirrorKeyFile string `validate:"required"`
 	}
 	Syslog        cmd.SyslogConfig
 	OpenTelemetry cmd.OpenTelemetryConfig
+}
+
+// loadMLDSAPublicKey reads a PEM-encoded PKIX ML-DSA-44 public key.
+func loadMLDSAPublicKey(filename string) (*mldsa.PublicKey, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil, fmt.Errorf("no PUBLIC KEY PEM block in %s", filename)
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	pubKey, ok := parsed.(*mldsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("key in %s is %T, must be ML-DSA-44", filename, parsed)
+	}
+	return pubKey, nil
 }
 
 func main() {
@@ -56,12 +90,16 @@ func main() {
 	scope, logger, oTelShutdown := cmd.StatsAndLogging(c.Syslog, c.OpenTelemetry, c.MTPublisher.DebugAddr)
 	defer oTelShutdown(context.Background())
 	cmd.LogStartup(logger)
-	clk := clock.New()
 
 	dbMap, err := sa.InitWrappedDb(c.MTPublisher.DB, scope, logger)
 	cmd.FailOnError(err, "While initializing dbMap")
 
-	publisher, err := mtpublisher.New(dbMap, c.MTPublisher.PollInterval.Duration, c.MTPublisher.MTCLogID, c.MTPublisher.MirrorID, clk, logger)
+	signer, _, err := privatekey.Load(c.MTPublisher.MirrorKeyFile)
+	cmd.FailOnError(err, "Loading cosigner key")
+	pubKey, err := loadMLDSAPublicKey(c.MTPublisher.MirrorPublicKeyFile)
+	cmd.FailOnError(err, "Loading cosigner public key")
+
+	publisher, err := mtpublisher.New(dbMap, c.MTPublisher.PollInterval.Duration, c.MTPublisher.MTCLogID, c.MTPublisher.MirrorID, signer, pubKey, logger)
 	cmd.FailOnError(err, "Failed to create MTPublisher stub")
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/mtpublisher/mtpublisher.go
+++ b/mtpublisher/mtpublisher.go
@@ -1,71 +1,122 @@
+//go:build go1.27
+
 package mtpublisher
 
 import (
 	"context"
-	"crypto/ed25519"
+	"crypto"
+	"crypto/mldsa"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"time"
 
-	"github.com/jmhodges/clock"
+	"golang.org/x/mod/sumdb/tlog"
 
 	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/trees/checkpoint"
+	"github.com/letsencrypt/boulder/trees/cosignature"
 )
 
-// MTPublisher polls the MTC issuance log and adds a dummy cosignature to the
-// latest checkpoint if it lacks one. It is a stub for the real MTPublisher.
-type MTPublisher struct {
-	db       *db.WrappedMap
-	interval time.Duration
-	mtcLogID string
-	mirrorID string
-	clk      clock.Clock
-	log      blog.Logger
+// publisher polls the MTC issuance log and cosigns the latest checkpoint if it
+// lacks a mirror cosignature, playing both halves of the future exchange: it
+// signs a signature line as the mirror, then ingests it through the note layer
+// as the publisher will once the mirror is a separate server. It is a stub for
+// the real MTPublisher.
+type publisher struct {
+	db             *db.WrappedMap
+	interval       time.Duration
+	mtcLogID       string
+	origin         string
+	mirrorID       string
+	mirrorName     string
+	mirrorKeyID    uint32
+	mirrorCosigner *cosignature.Cosigner
+	verifier       *cosignature.Verifier
+	log            blog.Logger
 }
 
-// New returns a new *MTPublisher.
-func New(dbMap *db.WrappedMap, interval time.Duration, mtcLogID, mirrorID string, clk clock.Clock, log blog.Logger) (*MTPublisher, error) {
+// New returns a publisher that cosigns as the mirror with mirrorID using
+// signer, verifying each cosignature against pubKey before storing it.
+func New(dbMap *db.WrappedMap, interval time.Duration, mtcLogID, mirrorID string, signer crypto.Signer, pubKey *mldsa.PublicKey, log blog.Logger) (*publisher, error) {
 	if interval <= 0 {
 		return nil, fmt.Errorf("interval must be positive, got %s", interval)
 	}
-	if mtcLogID == "" {
-		return nil, errors.New("mtcLogID must not be empty")
+	cosigner, err := cosignature.NewCosigner(mirrorID, mtcLogID, signer)
+	if err != nil {
+		return nil, fmt.Errorf("creating mirror cosigner: %s", err)
 	}
-	if mirrorID == "" {
-		return nil, errors.New("mirrorID must not be empty")
+	verifier, err := cosignature.NewVerifier(mirrorID, pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating mirror verifier: %s", err)
 	}
-	return &MTPublisher{
-		db:       dbMap,
-		interval: interval,
-		mtcLogID: mtcLogID,
-		mirrorID: mirrorID,
-		clk:      clk,
-		log:      log,
+
+	// The mirror's key ID per c2sp.org/tlog-cosignature, repeated from
+	// trees/cosignature for the stub's mirror half like the line encoding in
+	// cosignatureLine.
+	mirrorName := "oid/1.3.6.1.4.1." + mirrorID
+	h := sha256.New()
+	h.Write([]byte(mirrorName))
+	h.Write([]byte{'\n', 0x06})
+	h.Write(pubKey.Bytes())
+	mirrorKeyID := binary.BigEndian.Uint32(h.Sum(nil)[:4])
+
+	return &publisher{
+		db:             dbMap,
+		interval:       interval,
+		mtcLogID:       mtcLogID,
+		origin:         cosigner.Origin(),
+		mirrorID:       mirrorID,
+		mirrorName:     mirrorName,
+		mirrorKeyID:    mirrorKeyID,
+		mirrorCosigner: cosigner,
+		verifier:       verifier,
+		log:            log,
 	}, nil
 }
 
 type checkpointEntry struct {
 	ID              int64  `db:"id"`
 	MTCLogID        string `db:"mtcLogID"`
-	TreeSize        int64  `db:"treeSize"`
+	MTCASignature   []byte `db:"mtcaSignature"`
+	MirrorID        string `db:"mirrorID"`
 	MirrorSignature []byte `db:"mirrorSignature"`
+	TreeSize        int64  `db:"treeSize"`
+	RootHash        []byte `db:"rootHash"`
 }
 
-// dummyCosignature returns a dummy Ed25519 tlog-cosignature: a big-endian
-// uint64 timestamp followed by the Ed25519 signature.
-func (p *MTPublisher) dummyCosignature() []byte {
-	out := make([]byte, 8+ed25519.SignatureSize)
-	binary.BigEndian.PutUint64(out[:8], uint64(p.clk.Now().Unix())) //nolint:gosec // G115: a Unix timestamp is non-negative.
-	return out
+// cosign cosigns the checkpoint described by tree as the mirror and returns the
+// signature line it would send to the publisher.
+//
+//   - https://c2sp.org/tlog-cosignature
+//   - https://c2sp.org/tlog-mirror
+func (p *publisher) cosign(tree tlog.Tree) (string, error) {
+	timestampedCosignature, err := p.mirrorCosigner.CosignCheckpoint(tree)
+	if err != nil {
+		return "", err
+	}
+	idSignature := make([]byte, 4+len(timestampedCosignature))
+	binary.BigEndian.PutUint32(idSignature[:4], p.mirrorKeyID)
+	copy(idSignature[4:], timestampedCosignature)
+	return "— " + p.mirrorName + " " + base64.StdEncoding.EncodeToString(idSignature) + "\n", nil
 }
 
-func (p *MTPublisher) publish(ctx context.Context) error {
+// publish cosigns the latest checkpoint in the database if it lacks a mirror
+// cosignature and stores the raw signature in the database.
+func (p *publisher) publish(ctx context.Context) error {
 	var latest checkpointEntry
 	err := p.db.SelectOne(ctx, &latest,
-		"SELECT id, mtcLogID, treeSize, mirrorSignature FROM checkpoints WHERE mtcLogID = ? ORDER BY treeSize DESC LIMIT 1",
+		`SELECT id, checkpoints.mtcLogID, mtcaSignature, mirrorID,
+		        mirrorSignature, treeSize, rootHash
+		 FROM latestCheckpoint JOIN checkpoints
+		 USING(id)
+		 WHERE latestCheckpoint.mtcLogID = ? AND
+		       checkpoints.mtcLogID = ?`,
+		p.mtcLogID,
 		p.mtcLogID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
@@ -77,19 +128,45 @@ func (p *MTPublisher) publish(ctx context.Context) error {
 		return nil
 	}
 
-	_, err = p.db.ExecContext(ctx,
-		"UPDATE checkpoints SET mirrorID = ?, mirrorSignature = ? WHERE id = ? AND mtcLogID = ?",
-		p.mirrorID, p.dummyCosignature(), latest.ID, p.mtcLogID)
+	if len(latest.RootHash) != tlog.HashSize {
+		return fmt.Errorf("checkpoint %d root hash is %d bytes, want %d", latest.ID, len(latest.RootHash), tlog.HashSize)
+	}
+	tree := tlog.Tree{N: latest.TreeSize, Hash: tlog.Hash(latest.RootHash)}
+
+	// The mirror's half of the exchange.
+	cosigLine, err := p.cosign(tree)
 	if err != nil {
 		return fmt.Errorf("cosigning checkpoint %d (%s size %d): %w", latest.ID, latest.MTCLogID, latest.TreeSize, err)
 	}
 	p.log.Infof("Cosigned checkpoint %d (%s size %d)", latest.ID, latest.MTCLogID, latest.TreeSize)
+
+	// The publisher's half of the exchange.
+	cp := checkpoint.Checkpoint{Origin: p.origin, Tree: tree}
+	text, err := cp.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshaling checkpoint %d (%s size %d): %w", latest.ID, latest.MTCLogID, latest.TreeSize, err)
+	}
+	timestampedMirrorCosig, err := cosignature.TimestampedSignature(text, cosigLine, p.verifier)
+	if err != nil {
+		return fmt.Errorf("checkpoint %d cosignature failed verification before storage: %w", latest.ID, err)
+	}
+	mirrorCosig, err := cosignature.RawSignature(timestampedMirrorCosig)
+	if err != nil {
+		return fmt.Errorf("checkpoint %d cosignature: %w", latest.ID, err)
+	}
+	_, err = p.db.ExecContext(ctx,
+		"UPDATE checkpoints SET mirrorID = ?, mirrorSignature = ? WHERE id = ? AND mtcLogID = ?",
+		p.mirrorID, mirrorCosig, latest.ID, p.mtcLogID)
+	if err != nil {
+		return fmt.Errorf("storing checkpoint %d cosignature (%s size %d): %w", latest.ID, latest.MTCLogID, latest.TreeSize, err)
+	}
+	p.log.Infof("Stored mirror cosignature for checkpoint %d (%s size %d)", latest.ID, latest.MTCLogID, latest.TreeSize)
 	return nil
 }
 
 // Start attempts to cosign the latest checkpoint at each interval until ctx is
 // cancelled.
-func (p *MTPublisher) Start(ctx context.Context) {
+func (p *publisher) Start(ctx context.Context) {
 	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
 	for {

--- a/mtpublisher/mtpublisher_test.go
+++ b/mtpublisher/mtpublisher_test.go
@@ -1,17 +1,23 @@
+//go:build go1.27
+
 package mtpublisher
 
 import (
 	"context"
-	"crypto/ed25519"
+	"crypto/mldsa"
+	"encoding/base64"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/jmhodges/clock"
+	"golang.org/x/mod/sumdb/tlog"
 
 	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/privatekey"
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test/vars"
+	"github.com/letsencrypt/boulder/trees/cosignature"
 )
 
 const (
@@ -26,17 +32,36 @@ func setupDB(t *testing.T) *db.WrappedMap {
 	if err != nil {
 		t.Fatalf("opening mtcmeta dbMap: %s", err)
 	}
-	_, err = dbMap.ExecContext(t.Context(), "TRUNCATE TABLE checkpoints")
+	truncate := func(ctx context.Context) error {
+		_, err := dbMap.ExecContext(ctx, "TRUNCATE TABLE checkpoints")
+		if err != nil {
+			return err
+		}
+		_, err = dbMap.ExecContext(ctx, "TRUNCATE TABLE latestCheckpoint")
+		return err
+	}
+	err = truncate(t.Context())
 	if err != nil {
-		t.Fatalf("truncating checkpoints: %s", err)
+		t.Fatalf("truncating tables: %s", err)
 	}
 	t.Cleanup(func() {
-		_, err := dbMap.ExecContext(context.Background(), "TRUNCATE TABLE checkpoints")
+		err := truncate(context.Background())
 		if err != nil {
-			t.Logf("cleaning up checkpoints: %s", err)
+			t.Logf("cleaning up tables: %s", err)
 		}
 	})
 	return dbMap
+}
+
+// setLatest points latestCheckpoint at the checkpoint with the given id, as the
+// sequencer does when it adopts a checkpoint.
+func setLatest(t *testing.T, dbMap *db.WrappedMap, logID string, id int64) {
+	t.Helper()
+	_, err := dbMap.ExecContext(t.Context(),
+		"REPLACE INTO latestCheckpoint (mtcLogID, id) VALUES (?, ?)", logID, id)
+	if err != nil {
+		t.Fatalf("pointing latestCheckpoint at %d: %s", id, err)
+	}
 }
 
 func insertCheckpoint(t *testing.T, dbMap *db.WrappedMap, logID string, treeSize int64) int64 {
@@ -66,15 +91,67 @@ func lacksCosignature(t *testing.T, dbMap *db.WrappedMap, id int64) bool {
 	return count == 1
 }
 
-func TestPublish(t *testing.T) {
-	dbMap := setupDB(t)
-	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, clock.NewFake(), blog.NewMock())
+// testKey returns a deterministic ML-DSA-44 key so the test can verify the
+// cosignatures the publisher stores.
+func testKey(t *testing.T) *mldsa.PrivateKey {
+	t.Helper()
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	key, err := mldsa.NewPrivateKey(mldsa.MLDSA44(), seed)
+	if err != nil {
+		t.Fatalf("NewPrivateKey: %s", err)
+	}
+	return key
+}
+
+// TestCosign checks that the mirror's cosignature line verifies through
+// trees/cosignature and yields the timestamped_signature it encodes.
+func TestCosign(t *testing.T) {
+	key := testKey(t)
+	p, err := New(nil, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
 
-	// When there are no checkpoints at all, p.publish() should return without
-	// error.
+	line, err := p.cosign(tlog.Tree{N: 512})
+	if err != nil {
+		t.Fatalf("cosign: %s", err)
+	}
+	if !strings.HasPrefix(line, "— oid/1.3.6.1.4.1."+mirrorID+" ") || !strings.HasSuffix(line, "\n") {
+		t.Errorf("line %q is not a cosignature line for the mirror", line)
+	}
+
+	verifier, err := cosignature.NewVerifier(mirrorID, key.PublicKey())
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	text := p.origin + "\n512\n" + base64.StdEncoding.EncodeToString(make([]byte, 32)) + "\n"
+	timestampedSignature, err := cosignature.TimestampedSignature(text, line, verifier)
+	if err != nil {
+		t.Fatalf("TimestampedSignature: %s", err)
+	}
+	_, err = cosignature.RawSignature(timestampedSignature)
+	if err != nil {
+		t.Errorf("RawSignature: %s", err)
+	}
+
+	_, err = p.cosign(tlog.Tree{})
+	if err == nil {
+		t.Error("cosign with an empty tree = nil error, want error")
+	}
+}
+
+func TestPublish(t *testing.T) {
+	dbMap := setupDB(t)
+	key := testKey(t)
+	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
+	if err != nil {
+		t.Fatalf("New: %s", err)
+	}
+
+	// A pass over an empty table is a no-op.
 	err = p.publish(t.Context())
 	if err != nil {
 		t.Fatalf("p.publish() on an empty table: %s", err)
@@ -85,17 +162,31 @@ func TestPublish(t *testing.T) {
 
 	// The latest checkpoint, which we expect to be cosigned by p.publish().
 	latestCheckpointID := insertCheckpoint(t, dbMap, mtcLogID, 512)
+	setLatest(t, dbMap, mtcLogID, latestCheckpointID)
 
 	// A checkpoint for another log that was somehow inserted into this table,
 	// which must be left untouched thanks to the mtcLogID guard.
-	otherLogID := insertCheckpoint(t, dbMap, "44947.4.2.0.99", 1024)
+	otherLogCheckpointID := insertCheckpoint(t, dbMap, "44947.4.2.0.99", 1024)
+
+	// A precommitted checkpoint the CA has not signed yet, which must be left
+	// untouched because latestCheckpoint does not reference it, even though its
+	// tree is the largest.
+	res, err := dbMap.ExecContext(t.Context(),
+		"INSERT INTO checkpoints (mtcLogID, treeSize, rootHash) VALUES (?, ?, ?)",
+		mtcLogID, int64(2048), make([]byte, 32))
+	if err != nil {
+		t.Fatalf("inserting precommitted checkpoint: %s", err)
+	}
+	precommitID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("reading insert id: %s", err)
+	}
 
 	err = p.publish(t.Context())
 	if err != nil {
 		t.Fatalf("p.publish(): %s", err)
 	}
 
-	// Fetch the latest checkpoint.
 	type row struct {
 		MirrorID  string `db:"mirrorID"`
 		MirrorSig []byte `db:"mirrorSignature"`
@@ -111,32 +202,82 @@ func TestPublish(t *testing.T) {
 	if cosigned.MirrorID != mirrorID {
 		t.Errorf("mirrorID = %q, want %q", cosigned.MirrorID, mirrorID)
 	}
-	if len(cosigned.MirrorSig) != 8+ed25519.SignatureSize {
-		t.Errorf("latest checkpoint's mirrorSignature is %d bytes, want %d", len(cosigned.MirrorSig), 8+ed25519.SignatureSize)
+	if len(cosigned.MirrorSig) != mldsa.MLDSA44SignatureSize {
+		t.Fatalf("latest checkpoint's mirrorSignature is %d bytes, want %d", len(cosigned.MirrorSig), mldsa.MLDSA44SignatureSize)
+	}
+
+	verifier, err := cosignature.NewVerifier(mirrorID, key.PublicKey())
+	if err != nil {
+		t.Fatalf("NewVerifier: %s", err)
+	}
+	text := "oid/1.3.6.1.4.1." + mtcLogID + "\n512\n" + base64.StdEncoding.EncodeToString(make([]byte, 32)) + "\n"
+	timestampedSignature := append(make([]byte, 8), cosigned.MirrorSig...)
+	if !verifier.Verify([]byte(text), timestampedSignature) {
+		t.Error("stored mirror cosignature does not verify against the checkpoint text")
 	}
 	if !lacksCosignature(t, dbMap, olderCheckpointID) {
 		t.Error("older checkpoint was cosigned, only the latest should be")
 	}
-	if !lacksCosignature(t, dbMap, otherLogID) {
-		t.Errorf("otherLogID checkpoint (id=%d), despite guard on mtcLogID", otherLogID)
+	if !lacksCosignature(t, dbMap, otherLogCheckpointID) {
+		t.Errorf("another log's checkpoint (id=%d) was cosigned, despite the mtcLogID guard", otherLogCheckpointID)
+	}
+	if !lacksCosignature(t, dbMap, precommitID) {
+		t.Error("precommitted checkpoint was cosigned before the CA signed it")
+	}
+}
+
+// TestPublishRejectsMismatchedKey checks that a cosignature that fails to
+// verify against the configured public key is not stored.
+func TestPublishRejectsMismatchedKey(t *testing.T) {
+	dbMap := setupDB(t)
+
+	otherSeed := make([]byte, 32)
+	for i := range otherSeed {
+		otherSeed[i] = byte(255 - i)
+	}
+	otherKey, err := mldsa.NewPrivateKey(mldsa.MLDSA44(), otherSeed)
+	if err != nil {
+		t.Fatalf("NewPrivateKey: %s", err)
+	}
+
+	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(testKey(t)), otherKey.PublicKey(), blog.NewMock())
+	if err != nil {
+		t.Fatalf("New: %s", err)
+	}
+
+	id := insertCheckpoint(t, dbMap, mtcLogID, 512)
+	setLatest(t, dbMap, mtcLogID, id)
+
+	err = p.publish(t.Context())
+	if err == nil {
+		t.Error("publish with a mismatched public key = nil error, want error")
+	}
+	if !lacksCosignature(t, dbMap, id) {
+		t.Error("cosignature was stored despite failing verification")
 	}
 }
 
 func TestPublishWhenLatestAlreadySigned(t *testing.T) {
 	dbMap := setupDB(t)
-	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, clock.NewFake(), blog.NewMock())
+	key := testKey(t)
+	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
 
 	// Insert a checkpoint that is already cosigned, which must be left
 	// untouched.
-	_, err = dbMap.ExecContext(t.Context(),
+	res, err := dbMap.ExecContext(t.Context(),
 		"INSERT INTO checkpoints (mtcLogID, mtcaSignature, treeSize, rootHash, mirrorID, mirrorSignature) VALUES (?, ?, ?, ?, ?, ?)",
 		mtcLogID, []byte("mtca-signature"), int64(512), make([]byte, 32), "existing.cosigner", []byte("already-signed-bruh"))
 	if err != nil {
 		t.Fatalf("inserting cosigned checkpoint: %s", err)
 	}
+	cosignedID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("reading insert id: %s", err)
+	}
+	setLatest(t, dbMap, mtcLogID, cosignedID)
 
 	// Insert an older (non-latest) checkpoint that is not cosigned, which must
 	// be left untouched.
@@ -147,16 +288,17 @@ func TestPublishWhenLatestAlreadySigned(t *testing.T) {
 		t.Fatalf("p.publish(): %s", err)
 	}
 
-	// The latest checkpoint is already cosigned and the older checkpoint is left untouched.
+	// The latest checkpoint is already cosigned, so the pass must leave both
+	// checkpoints untouched.
 	if !lacksCosignature(t, dbMap, olderID) {
 		t.Error("older checkpoint was cosigned, the pass should have stopped at the signed latest")
 	}
-	var cosignature []byte
-	err = dbMap.SelectOne(t.Context(), &cosignature, "SELECT mirrorSignature FROM checkpoints WHERE mtcLogID = ? AND treeSize = 512", mtcLogID)
+	var mirrorCosignature []byte
+	err = dbMap.SelectOne(t.Context(), &mirrorCosignature, "SELECT mirrorSignature FROM checkpoints WHERE mtcLogID = ? AND treeSize = 512", mtcLogID)
 	if err != nil {
 		t.Fatalf("selecting the cosigned checkpoint: %s", err)
 	}
-	if string(cosignature) != "already-signed-bruh" {
-		t.Errorf("existing cosignature was replaced: %q", cosignature)
+	if string(mirrorCosignature) != "already-signed-bruh" {
+		t.Errorf("existing cosignature was replaced: %q", mirrorCosignature)
 	}
 }

--- a/sa/db/02-users.sql
+++ b/sa/db/02-users.sql
@@ -99,8 +99,10 @@ USE mtcmeta_44947_4_1_0_44;
 
 CREATE USER IF NOT EXISTS 'mtpublisher'@'%';
 
--- MTPublisher stub: reads checkpoints awaiting a cosignature and writes one.
+-- mtpublisher stub: follows the latestCheckpoint pointer to a checkpoint
+-- awaiting a cosignature and writes one.
 GRANT SELECT,UPDATE ON checkpoints TO 'mtpublisher'@'%';
+GRANT SELECT ON latestCheckpoint TO 'mtpublisher'@'%';
 
 -- Test setup and teardown
 GRANT ALL PRIVILEGES ON * to 'test_setup'@'%';

--- a/sa/db/02-users_next.sql
+++ b/sa/db/02-users_next.sql
@@ -100,8 +100,10 @@ USE mtcmeta_44947_4_1_0_44;
 CREATE USER IF NOT EXISTS 'mtpublisher'@'%';
 CREATE USER IF NOT EXISTS 'mtca'@'%';
 
--- MTPublisher stub: reads checkpoints awaiting a cosignature and writes one.
+-- mtpublisher stub: follows the latestCheckpoint pointer to a checkpoint
+-- awaiting a cosignature and writes one.
 GRANT SELECT,UPDATE ON checkpoints TO 'mtpublisher'@'%';
+GRANT SELECT ON latestCheckpoint TO 'mtpublisher'@'%';
 
 -- MTCA
 GRANT SELECT,INSERT,UPDATE ON checkpoints TO 'mtca'@'%';

--- a/test/certs/genmtpki/genmtpki.go
+++ b/test/certs/genmtpki/genmtpki.go
@@ -108,6 +108,43 @@ func main2() error {
 		return err
 	}
 
+	mirrorKey, err := mldsa.GenerateKey(mldsa.MLDSA44())
+	if err != nil {
+		return err
+	}
+
+	mirrorPKCS8, err := x509.MarshalPKCS8PrivateKey(mirrorKey)
+	if err != nil {
+		return err
+	}
+
+	mirrorKeyFile, err := os.OpenFile(path.Join(*outputDir, "mirror.key.pem"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer mirrorKeyFile.Close()
+
+	err = pem.Encode(mirrorKeyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: mirrorPKCS8})
+	if err != nil {
+		return err
+	}
+
+	mirrorSPKI, err := x509.MarshalPKIXPublicKey(mirrorKey.PublicKey())
+	if err != nil {
+		return err
+	}
+
+	mirrorPubFile, err := os.OpenFile(path.Join(*outputDir, "mirror.pub.pem"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer mirrorPubFile.Close()
+
+	err = pem.Encode(mirrorPubFile, &pem.Block{Type: "PUBLIC KEY", Bytes: mirrorSPKI})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/test/config-next/mtpublisher.json
+++ b/test/config-next/mtpublisher.json
@@ -6,7 +6,9 @@
 		},
 		"pollInterval": "1s",
 		"mtcLogID": "44947.4.1.0.44",
-		"mirrorID": "32473.9"
+		"mirrorID": "32473.9",
+		"mirrorKeyFile": "test/certs/mtpki/mirror.key.pem",
+		"mirrorPublicKeyFile": "test/certs/mtpki/mirror.pub.pem"
 	},
 	"syslog": {
 		"stdoutlevel": 6,

--- a/test/config/mtpublisher.json
+++ b/test/config/mtpublisher.json
@@ -6,7 +6,9 @@
 		},
 		"pollInterval": "1s",
 		"mtcLogID": "44947.4.1.0.44",
-		"mirrorID": "32473.9"
+		"mirrorID": "32473.9",
+		"mirrorKeyFile": "test/certs/mtpki/mirror.key.pem",
+		"mirrorPublicKeyFile": "test/certs/mtpki/mirror.pub.pem"
 	},
 	"syslog": {
 		"stdoutlevel": 6,


### PR DESCRIPTION
Generate the mirror key pair in `genmtpki`, load the mirror key through `privatekey.Load()`, and load the mirror public key through a new `loadMLDSAPublicKey()`. Grant the mtpublisher user `SELECT` on `latestCheckpoint`. The mtpublisher's checkpoint query is now identical to the mtca's and will soon replace it.

Part of https://github.com/letsencrypt/boulder/issues/8738