### PR TITLE
trees/checkpoint, trees/cosignature: Accept and return bytes

### DIFF
--- a/mtpublisher/mtpublisher_test.go
+++ b/mtpublisher/mtpublisher_test.go
@@ -128,7 +128,7 @@ func TestCosign(t *testing.T) {
 		t.Fatalf("NewVerifier: %s", err)
 	}
 	text := p.origin + "\n512\n" + base64.StdEncoding.EncodeToString(make([]byte, 32)) + "\n"
-	timestampedSignature, err := cosignature.TimestampedSignature(text, line, verifier)
+	timestampedSignature, err := cosignature.TimestampedSignature([]byte(text), line, verifier)
 	if err != nil {
 		t.Fatalf("TimestampedSignature: %s", err)
 	}

--- a/trees/checkpoint/checkpoint.go
+++ b/trees/checkpoint/checkpoint.go
@@ -1,6 +1,7 @@
 package checkpoint
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -24,12 +25,12 @@ type Checkpoint struct {
 // checkNoteText returns an error if text cannot be a signed note's text, nil
 // otherwise. https://c2sp.org/signed-note requires note text to be valid UTF-8
 // with no ASCII control characters (those below U+0020) other than newline.
-func checkNoteText(text string) error {
+func checkNoteText(text []byte) error {
 	switch {
-	case !utf8.ValidString(text):
+	case !utf8.Valid(text):
 		return errors.New("not valid UTF-8")
 
-	case strings.ContainsFunc(text, func(r rune) bool { return r < 0x20 && r != '\n' }):
+	case bytes.ContainsFunc(text, func(r rune) bool { return r < 0x20 && r != '\n' }):
 		return errors.New("contains an ASCII control character other than newline")
 
 	default:
@@ -77,24 +78,24 @@ func (c *Checkpoint) validate() error {
 //
 //   - https://c2sp.org/tlog-checkpoint
 //   - https://c2sp.org/signed-note
-func (c *Checkpoint) Marshal() (string, error) {
+func (c *Checkpoint) Marshal() ([]byte, error) {
 	err := c.validate()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	var b strings.Builder
+	var b bytes.Buffer
 	fmt.Fprintf(&b, "%s\n%d\n%s\n", c.Origin, c.Tree.N, c.Tree.Hash)
 	for _, ext := range c.Extensions {
 		b.WriteString(ext)
 		b.WriteByte('\n')
 	}
-	text := b.String()
-	err = checkNoteText(text)
+	noteText := b.Bytes()
+	err = checkNoteText(noteText)
 	if err != nil {
-		return "", fmt.Errorf("validating checkpoint note text: %w", err)
+		return nil, fmt.Errorf("validating checkpoint note text: %w", err)
 	}
-	return text, nil
+	return noteText, nil
 }
 
 // Unmarshal parses a checkpoint note text. The text must not have any signature
@@ -102,11 +103,12 @@ func (c *Checkpoint) Marshal() (string, error) {
 //
 //   - https://c2sp.org/tlog-checkpoint
 //   - https://c2sp.org/signed-note
-func Unmarshal(text string) (*Checkpoint, error) {
-	err := checkNoteText(text)
+func Unmarshal(noteText []byte) (*Checkpoint, error) {
+	err := checkNoteText(noteText)
 	if err != nil {
 		return nil, fmt.Errorf("validating checkpoint note text: %w", err)
 	}
+	text := string(noteText)
 	if !strings.HasSuffix(text, "\n") {
 		return nil, errors.New("checkpoint does not end in newline")
 	}
@@ -156,7 +158,7 @@ func Open(signedNote []byte, verifiers note.Verifiers) (*Checkpoint, *note.Note,
 	if err != nil {
 		return nil, nil, err
 	}
-	c, err := Unmarshal(n.Text)
+	c, err := Unmarshal([]byte(n.Text))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/trees/checkpoint/checkpoint_test.go
+++ b/trees/checkpoint/checkpoint_test.go
@@ -59,7 +59,7 @@ func TestCheckpointUnmarshalRoundTrip(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := Unmarshal(tc.text)
+			c, err := Unmarshal([]byte(tc.text))
 			if err != nil {
 				t.Fatalf("Unmarshal: %s", err)
 			}
@@ -76,7 +76,7 @@ func TestCheckpointUnmarshalRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Marshal: %s", err)
 			}
-			if got != tc.text {
+			if string(got) != tc.text {
 				t.Errorf("Marshal = %q, want %q", got, tc.text)
 			}
 		})
@@ -110,7 +110,7 @@ func TestCheckpointUnmarshalRejects(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := Unmarshal(tc.text)
+			_, err := Unmarshal([]byte(tc.text))
 			if err == nil {
 				t.Error("Unmarshal = nil error, want error")
 			}
@@ -121,7 +121,7 @@ func TestCheckpointUnmarshalRejects(t *testing.T) {
 // TestCheckpointMarshal covers Marshal's validation of hand-constructed
 // Checkpoints, which bypass Unmarshal's checks.
 func TestCheckpointMarshal(t *testing.T) {
-	valid, err := Unmarshal(exampleCheckpoint)
+	valid, err := Unmarshal([]byte(exampleCheckpoint))
 	if err != nil {
 		t.Fatalf("Unmarshal: %s", err)
 	}
@@ -131,7 +131,7 @@ func TestCheckpointMarshal(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Marshal: %s", err)
 		}
-		if got != exampleCheckpoint {
+		if string(got) != exampleCheckpoint {
 			t.Errorf("Marshal = %q, want %q", got, exampleCheckpoint)
 		}
 	})

--- a/trees/cosignature/cosignature.go
+++ b/trees/cosignature/cosignature.go
@@ -255,7 +255,7 @@ func (v *Verifier) VerifyCheckpoint(origin string, tree tlog.Tree, timestampedSi
 // Verify is the note.Verifier entry point. For an already parsed checkpoint,
 // use VerifyCheckpoint.
 func (v *Verifier) Verify(noteText, signature []byte) bool {
-	parsed, err := checkpoint.Unmarshal(string(noteText))
+	parsed, err := checkpoint.Unmarshal(noteText)
 	if err != nil {
 		return false
 	}
@@ -266,8 +266,8 @@ func (v *Verifier) Verify(noteText, signature []byte) bool {
 // and returns the timestamped_signature by verifier's cosigner. An error is
 // returned if noteText and signatureLine do not form a well-formed note or if
 // verifier rejects the signature. Signatures from unknown keys are ignored.
-func TimestampedSignature(noteText, signatureLine string, verifier *Verifier) ([]byte, error) {
-	n, err := note.Open([]byte(noteText+"\n"+signatureLine), note.VerifierList(verifier))
+func TimestampedSignature(noteText []byte, signatureLine string, verifier *Verifier) ([]byte, error) {
+	n, err := note.Open(fmt.Appendf(nil, "%s\n%s", noteText, signatureLine), note.VerifierList(verifier))
 	if err != nil {
 		return nil, fmt.Errorf("opening the cosigned note: %s", err)
 	}

--- a/trees/cosignature/cosignature_test.go
+++ b/trees/cosignature/cosignature_test.go
@@ -131,7 +131,7 @@ func TestNewVerifierRejects(t *testing.T) {
 func TestVerifyRejectsOversizeTimestamp(t *testing.T) {
 	signer := testSigner(t)
 	v := newVerifier(t)
-	parsed, err := checkpoint.Unmarshal(exampleCheckpoint)
+	parsed, err := checkpoint.Unmarshal([]byte(exampleCheckpoint))
 	if err != nil {
 		t.Fatalf("Unmarshal: %s", err)
 	}
@@ -166,7 +166,7 @@ func TestVerifyRejectsOversizeTimestamp(t *testing.T) {
 // the check that rejected it.
 func TestVerifyCheckpointErrors(t *testing.T) {
 	v := newVerifier(t)
-	parsed, err := checkpoint.Unmarshal(exampleCheckpoint)
+	parsed, err := checkpoint.Unmarshal([]byte(exampleCheckpoint))
 	if err != nil {
 		t.Fatalf("Unmarshal: %s", err)
 	}
@@ -228,7 +228,7 @@ func TestCosignerRoundTrip(t *testing.T) {
 	}
 
 	text := ca.origin + "\n20852163\n" + exampleHashB64 + "\n"
-	parsed, err := checkpoint.Unmarshal(text)
+	parsed, err := checkpoint.Unmarshal([]byte(text))
 	if err != nil {
 		t.Fatalf("checkpoint.Unmarshal: %s", err)
 	}
@@ -278,7 +278,7 @@ func TestCosignerRoundTrip(t *testing.T) {
 		t.Errorf("line %q has unexpected prefix", line)
 	}
 
-	extracted, err := TimestampedSignature(text, line, v)
+	extracted, err := TimestampedSignature([]byte(text), line, v)
 	if err != nil {
 		t.Fatalf("TimestampedSignature on a reassembled note: %s", err)
 	}
@@ -429,7 +429,7 @@ func TestTimestampedSignature(t *testing.T) {
 		t.Fatalf("NewCosigner: %s", err)
 	}
 	text := ca.origin + "\n20852163\n" + exampleHashB64 + "\n"
-	parsed, err := checkpoint.Unmarshal(text)
+	parsed, err := checkpoint.Unmarshal([]byte(text))
 	if err != nil {
 		t.Fatalf("checkpoint.Unmarshal: %s", err)
 	}
@@ -443,7 +443,7 @@ func TestTimestampedSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewVerifier: %s", err)
 	}
-	timestampedSignature, err := TimestampedSignature(text, line, v)
+	timestampedSignature, err := TimestampedSignature([]byte(text), line, v)
 	if err != nil {
 		t.Fatalf("TimestampedSignature for the cosigner that signed the note: %s", err)
 	}
@@ -455,7 +455,7 @@ func TestTimestampedSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewVerifier: %s", err)
 	}
-	_, err = TimestampedSignature(text, line, other)
+	_, err = TimestampedSignature([]byte(text), line, other)
 	if err == nil {
 		t.Error("TimestampedSignature for a cosigner that did not sign the note = nil error, want error")
 	}
@@ -470,7 +470,7 @@ func TestTimestampedSignatureRejectsForeignFormat(t *testing.T) {
 	idSignature := make([]byte, keyIDSize+64)
 	binary.BigEndian.PutUint32(idSignature[:keyIDSize], v.KeyHash())
 	line := noteSignatureLinePrefix + v.Name() + " " + base64.StdEncoding.EncodeToString(idSignature) + "\n"
-	_, err := TimestampedSignature(exampleCheckpoint, line, v)
+	_, err := TimestampedSignature([]byte(exampleCheckpoint), line, v)
 	if err == nil {
 		t.Error("TimestampedSignature with a 64-byte signature body = nil error, want error")
 	}
@@ -499,7 +499,7 @@ func TestOpenIgnoresUnknownSignatures(t *testing.T) {
 	}
 
 	text := known.origin + "\n20852163\n" + exampleHashB64 + "\n"
-	parsed, err := checkpoint.Unmarshal(text)
+	parsed, err := checkpoint.Unmarshal([]byte(text))
 	if err != nil {
 		t.Fatalf("checkpoint.Unmarshal: %s", err)
 	}


### PR DESCRIPTION
When working with data on the wire, bytes is the correct shape of inputs/outputs.

Part of https://github.com/letsencrypt/boulder/issues/8944