### PR TITLE
trees/issuancelog: Add a shared log identity configuration

### DIFF
--- a/cmd/boulder-mtca/main.go
+++ b/cmd/boulder-mtca/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/letsencrypt/boulder/issuance"
 	mtca "github.com/letsencrypt/boulder/mtca"
 	mtcapb "github.com/letsencrypt/boulder/mtca/proto"
+	"github.com/letsencrypt/boulder/trees/issuancelog"
 )
 
 type Config struct {
@@ -33,9 +34,13 @@ type Config struct {
 		DB cmd.DBConfig `validate:"required"`
 		S3 bs3.Config   `validate:"required"`
 
+		// LogID identifies the issuance log this MTCA sequences. Its CA ID must
+		// match the issuer certificate's.
+		LogID issuancelog.ID `validate:"required"`
+
 		Issuance struct {
 			CertProfiles map[string]issuance.ProfileConfig `validate:"required,dive,keys,alphanum,min=1,max=32,endkeys"`
-			// Issuers holds the configuration for a single MTCA instance with a single mtcaID.
+			// Issuers holds the configuration for a single MTCA instance with a single CA ID.
 			// We run a separate process for each issuer.
 			// TODO: the issuance package parses the CA certificate as a self-signed X.509
 			// certificate, but per MTC draft, a CA SHOULD be represented by an RFC 9925
@@ -115,6 +120,7 @@ func main() {
 	mtcaImpl, err := mtca.New(
 		issuer,
 		profiles,
+		c.MTCA.LogID,
 		c.MTCA.SequencingPeriod.Duration,
 		dbMap,
 		s3c,

--- a/cmd/boulder-mtpublisher/main.go
+++ b/cmd/boulder-mtpublisher/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/letsencrypt/boulder/mtpublisher"
 	"github.com/letsencrypt/boulder/privatekey"
 	"github.com/letsencrypt/boulder/sa"
+	"github.com/letsencrypt/boulder/trees/issuancelog"
 )
 
 type Config struct {
@@ -28,10 +29,9 @@ type Config struct {
 		// lack a mirror cosignature.
 		PollInterval config.Duration `validate:"required"`
 
-		// MTCLogID is the log this MTPublisher operates on (e.g.
-		// "44947.4.1.0.44"). Used as a guard on the `mtcLogID` column of the
-		// connected checkpoints table.
-		MTCLogID string `validate:"required"`
+		// LogID identifies the issuance log this publisher operates on. It must
+		// match the mtca's.
+		LogID issuancelog.ID `validate:"required"`
 
 		// MirrorID identifies the cosigner this publisher writes alongside each
 		// cosignature (e.g. "32473.9").
@@ -99,7 +99,7 @@ func main() {
 	pubKey, err := loadMLDSAPublicKey(c.MTPublisher.MirrorPublicKeyFile)
 	cmd.FailOnError(err, "Loading cosigner public key")
 
-	publisher, err := mtpublisher.New(dbMap, c.MTPublisher.PollInterval.Duration, c.MTPublisher.MTCLogID, c.MTPublisher.MirrorID, signer, pubKey, logger)
+	publisher, err := mtpublisher.New(dbMap, c.MTPublisher.PollInterval.Duration, c.MTPublisher.LogID, c.MTPublisher.MirrorID, signer, pubKey, logger)
 	cmd.FailOnError(err, "Failed to create MTPublisher stub")
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/mtca/mtca.go
+++ b/mtca/mtca.go
@@ -29,6 +29,7 @@ import (
 	mtcapb "github.com/letsencrypt/boulder/mtca/proto"
 	"github.com/letsencrypt/boulder/trees/cosignature"
 	"github.com/letsencrypt/boulder/trees/entry"
+	"github.com/letsencrypt/boulder/trees/issuancelog"
 	"github.com/letsencrypt/boulder/trees/tiles"
 	"golang.org/x/mod/sumdb/tlog"
 )
@@ -42,15 +43,19 @@ var _ mtcapb.MTCAServer = &mtca{}
 func New(
 	issuer *issuance.Issuer,
 	profiles map[string]*issuance.Profile,
+	logID issuancelog.ID,
 	sequencingPeriod time.Duration,
 	dbMap *borp.DbMap,
 	s3c simpleS3,
 	logger blog.Logger,
 	clk clock.Clock,
 ) (*mtca, error) {
-	mtcaID, err := getMTCAID(issuer.Cert.Certificate)
+	certCAID, err := getCAID(issuer.Cert.Certificate)
 	if err != nil {
 		return nil, err
+	}
+	if certCAID != logID.CAID {
+		return nil, fmt.Errorf("configured CA ID %q does not match issuer certificate CA ID %q", logID.CAID, certCAID)
 	}
 
 	if sequencingPeriod == 0 {
@@ -60,10 +65,8 @@ func New(
 	m := &mtca{
 		issuer:   issuer,
 		profiles: profiles,
-		mtcaID:   mtcaID,
-		// TODO: collect this from config
-		logNumber: 44,
-		pool:      &pool{maxSize: 100},
+		logID:    logID,
+		pool:     &pool{maxSize: 100},
 
 		sequencingPeriod: sequencingPeriod,
 
@@ -73,7 +76,7 @@ func New(
 		clk: clk,
 	}
 
-	cosigner, err := cosignature.NewCosigner(mtcaID, m.mtcLogID(), issuer.Signer)
+	cosigner, err := cosignature.NewCosigner(logID.CAID, logID.Origin(), issuer.Signer)
 	if err != nil {
 		return nil, fmt.Errorf("creating CA cosigner: %s", err)
 	}
@@ -83,7 +86,7 @@ func New(
 	if !ok {
 		return nil, fmt.Errorf("issuer public key is %T, must be ML-DSA-44", issuer.Signer.Public())
 	}
-	verifier, err := cosignature.NewVerifier(mtcaID, pubKey)
+	verifier, err := cosignature.NewVerifier(logID.CAID, pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("creating CA verifier: %s", err)
 	}
@@ -97,12 +100,11 @@ type mtca struct {
 
 	issuer   *issuance.Issuer
 	profiles map[string]*issuance.Profile
-	mtcaID   string
+	logID    issuancelog.ID
 	cosigner *cosignature.Cosigner
 	verifier *cosignature.Verifier
 
-	logNumber uint16
-	pool      *pool
+	pool *pool
 
 	// frontier contains all the tiles on the right edge of the tree.
 	// It will be used to accumulate entries for writing to storage.
@@ -128,15 +130,15 @@ type simpleS3 interface {
 	Bucket() string
 }
 
-func getMTCAID(issuerCert *x509.Certificate) (string, error) {
+func getCAID(issuerCert *x509.Certificate) (string, error) {
 	testingTrustAnchorIDOID := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 44363, 47, 1}
 	for _, attribute := range issuerCert.Subject.Names {
 		if attribute.Type.Equal(testingTrustAnchorIDOID) {
-			mtcaID, ok := attribute.Value.(string)
+			caID, ok := attribute.Value.(string)
 			if !ok {
 				return "", fmt.Errorf("invalid trust anchor attribute type %T", attribute.Value)
 			}
-			return mtcaID, nil
+			return caID, nil
 		}
 	}
 
@@ -165,14 +167,14 @@ func (m *mtca) InitLog(ctx context.Context) error {
 	_, err = db.WithTransaction(ctx, m.db, func(tx db.Executor) (any, error) {
 		var numLatestCheckpoints int64
 		err := tx.SelectOne(ctx, &numLatestCheckpoints, "SELECT COUNT(*) FROM latestCheckpoint WHERE mtcLogID = ?",
-			m.mtcLogID())
+			m.logID.String())
 		if err != nil {
 			return nil, fmt.Errorf("getting latestCheckpoint: %s", err)
 		}
 
 		var numCheckpoints int64
 		err = tx.SelectOne(ctx, &numCheckpoints, "SELECT COUNT(*) FROM checkpoints WHERE mtcLogID = ?",
-			m.mtcLogID())
+			m.logID.String())
 		if err != nil {
 			return nil, fmt.Errorf("getting checkpoints: %s", err)
 		}
@@ -183,11 +185,11 @@ func (m *mtca) InitLog(ctx context.Context) error {
 			}
 
 			return nil, fmt.Errorf("initializing issuance log for %s: already has %d checkpoints and %d latestCheckpoint rows",
-				m.mtcLogID(), numCheckpoints, numLatestCheckpoints)
+				m.logID.String(), numCheckpoints, numLatestCheckpoints)
 		}
 
 		firstCheckpoint := checkpoint{
-			MTCLogID: m.mtcLogID(),
+			MTCLogID: m.logID.String(),
 			TreeSize: candidate.TreeSize(),
 			RootHash: rootHash[:],
 		}
@@ -205,7 +207,7 @@ func (m *mtca) InitLog(ctx context.Context) error {
 		}
 
 		_, err = tx.ExecContext(ctx, "INSERT INTO latestCheckpoint (id, mtcLogID) VALUES (?, ?)",
-			firstCheckpoint.ID, m.mtcLogID())
+			firstCheckpoint.ID, m.logID.String())
 		if err != nil {
 			return nil, fmt.Errorf("inserting latestCheckpoint: %s", err)
 		}
@@ -224,7 +226,7 @@ func (m *mtca) InitLog(ctx context.Context) error {
 		return err
 	}
 
-	err = candidate.Publish(ctx, m.s3c, m.tileStoragePrefix())
+	err = candidate.Publish(ctx, m.s3c, m.logID.TilePrefix())
 	if err != nil {
 		return err
 	}
@@ -246,7 +248,7 @@ func (m *mtca) Preflight(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	frontier, err := tiles.LoadFrontier(ctx, m.s3c, latest.TreeSize, m.tileStoragePrefix())
+	frontier, err := tiles.LoadFrontier(ctx, m.s3c, latest.TreeSize, m.logID.TilePrefix())
 	if err != nil {
 		return err
 	}
@@ -297,32 +299,6 @@ func (p *pool) append(e pendingEntry) error {
 	}
 	p.entries = append(p.entries, e)
 	return nil
-}
-
-// mtcLogID returns the string-formatted relative OID for this log.
-// The .0. arc relative to the MTCA ID contains log numbers.
-// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#ca-ids
-func (m *mtca) mtcLogID() string {
-	return fmt.Sprintf("%s.0.%d", m.mtcaID, m.logNumber)
-}
-
-// tileStoragePrefix returns the path within a bucket where we will store tiles.
-//
-// https://github.com/C2SP/C2SP/blob/main/mtc-tlog.md#serving-issuance-logs
-//
-// "Each log's prefix URL is the concatenation of the CA prefix URL and the log number, encoded as an
-// ASCII decimal integer with no additional leading zeros:
-//
-// <CA prefix URL>/<log number>"
-//
-// We assume we will serve directly from tile storage (likely sync'ed somewhere), so we
-// want to store tiles compatible with that pattern, with log number as the last component
-// of the path before "tile/".
-//
-// As a matter of local convention we will put the MTCA ID as the path component right before
-// log number.
-func (m *mtca) tileStoragePrefix() string {
-	return fmt.Sprintf("%s/%d", m.mtcaID, m.logNumber)
 }
 
 // Issue requests a TBSCertificateLogEntry be issued and returns after it's been sequenced into the log
@@ -386,7 +362,7 @@ func (m *mtca) Issue(ctx context.Context, req *mtcapb.IssueRequest) (*mtcapb.Iss
 			return nil, errors.New("error during sequencing")
 		}
 		return &mtcapb.IssueResponse{
-			MtcLogID:      m.mtcLogID(),
+			MtcLogID:      m.logID.String(),
 			MtcEntryIndex: entryIndex,
 		}, nil
 	}
@@ -492,7 +468,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 		m.log.AuditInfo("issuing", map[string]any{
 			"TBSCertificateLogEntry": hex.EncodeToString(e.mtcle.TBS()),
 			"entryIndex":             latest.TreeSize + int64(i),
-			"mtcLogID":               m.mtcLogID(),
+			"mtcLogID":               m.logID.String(),
 			"newRootHash":            newRootHash.String(),
 		})
 	}
@@ -501,14 +477,14 @@ func (m *mtca) sequence(ctx context.Context) error {
 	// (but before publishing a new checkpoint signed note), we will flush
 	// to the live location. This ensures we've persisted the tiles before
 	// committing to a tree hash by signing it.
-	err = candidate.Stage(ctx, m.s3c, m.tileStoragePrefix())
+	err = candidate.Stage(ctx, m.s3c, m.logID.TilePrefix())
 	if err != nil {
 		return fmt.Errorf("staging candidate tiles: %s", err)
 	}
 
 	newCheckpoint := checkpoint{
 		ID:              0,
-		MTCLogID:        m.mtcLogID(),
+		MTCLogID:        m.logID.String(),
 		MTCASignature:   nil,
 		MirrorID:        "",
 		MirrorSignature: nil,
@@ -541,7 +517,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 		// https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/for-update
 		err := tx.SelectOne(ctx, &latestID,
 			`SELECT id from latestCheckpoint WHERE mtcLogID = ? FOR UPDATE`,
-			m.mtcLogID())
+			m.logID.String())
 		if err != nil {
 			return nil, err
 		}
@@ -558,7 +534,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 		}
 
 		result, err := tx.ExecContext(ctx, "UPDATE checkpoints SET mtcaSignature = ? WHERE mtcLogID = ? AND id = ?",
-			caSig, m.mtcLogID(), newCheckpoint.ID)
+			caSig, m.logID.String(), newCheckpoint.ID)
 		if err != nil {
 			return nil, fmt.Errorf("updating checkpoint: %s", err)
 		}
@@ -571,7 +547,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 		}
 
 		result, err = tx.ExecContext(ctx, "UPDATE latestCheckpoint SET id = ? WHERE mtcLogID = ? AND id = ?",
-			newCheckpoint.ID, m.mtcLogID(), latestID)
+			newCheckpoint.ID, m.logID.String(), latestID)
 		if err != nil {
 			return nil, fmt.Errorf("updating latestCheckpoint: %s", err)
 		}
@@ -599,7 +575,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 	// Once we add publishing of checkpoints as signed notes, publication of the signed note
 	// should come after this flush succeeds, so monitors don't try to fetch tiles that aren't
 	// yet available.
-	err = m.frontier.Publish(ctx, m.s3c, m.tileStoragePrefix())
+	err = m.frontier.Publish(ctx, m.s3c, m.logID.TilePrefix())
 	if err != nil {
 		return fmt.Errorf("publishing tiles: %s", err)
 	}
@@ -671,13 +647,13 @@ func (m *mtca) latestCheckpoint(ctx context.Context) (*checkpoint, error) {
 		 USING(id)
 		 WHERE latestCheckpoint.mtcLogID = ? AND
 		       checkpoints.mtcLogID = ?`,
-		m.mtcLogID(),
-		m.mtcLogID())
+		m.logID.String(),
+		m.logID.String())
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("getting latest checkpoint for %q: issuance log DB is not initialized", m.mtcLogID())
+			return nil, fmt.Errorf("getting latest checkpoint for %q: issuance log DB is not initialized", m.logID.String())
 		}
-		return nil, fmt.Errorf("getting latest checkpoint for %q: %w", m.mtcLogID(), err)
+		return nil, fmt.Errorf("getting latest checkpoint for %q: %w", m.logID.String(), err)
 	}
 
 	return &latest, nil

--- a/mtca/mtca_test.go
+++ b/mtca/mtca_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/letsencrypt/boulder/test/vars"
 	"github.com/letsencrypt/boulder/trees/cosigned"
 	"github.com/letsencrypt/boulder/trees/entry"
+	"github.com/letsencrypt/boulder/trees/issuancelog"
 	"github.com/letsencrypt/boulder/trees/tiles"
 )
 
@@ -90,6 +91,7 @@ func setup() (*mtca, *bs3test.FakeS3, func(), error) {
 	mtca, err := New(
 		issuer,
 		map[string]*issuance.Profile{"mtcExample": profile},
+		issuancelog.ID{CAID: "44947.4.1", LogNumber: 44},
 		100*time.Millisecond,
 		dbMap,
 		fs3,
@@ -275,7 +277,7 @@ func mirrorCosign(t *testing.T, m *mtca) {
 	if err != nil {
 		t.Fatalf("NewPrivateKey: %s", err)
 	}
-	p, err := mtpublisher.New(m.db, time.Second, m.mtcLogID(), "32473.9", privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
+	p, err := mtpublisher.New(m.db, time.Second, m.logID, "32473.9", privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("mtpublisher.New: %s", err)
 	}
@@ -308,7 +310,7 @@ func verifyStores(t *testing.T, m *mtca, fs3 *bs3test.FakeS3) *checkpoint {
 			memHash, base64.StdEncoding.EncodeToString(latest.RootHash))
 	}
 
-	loaded, err := tiles.LoadFrontier(t.Context(), fs3, latest.TreeSize, m.tileStoragePrefix())
+	loaded, err := tiles.LoadFrontier(t.Context(), fs3, latest.TreeSize, m.logID.TilePrefix())
 	if err != nil {
 		t.Fatalf("loading frontier from tile storage: %s", err)
 	}
@@ -449,7 +451,7 @@ func TestSequence(t *testing.T) {
 
 	// Each client's returned index must point at its own entry in the
 	// published entries tile.
-	validateStoredEntries(t, fs3, mtca.tileStoragePrefix(), latest.TreeSize, got)
+	validateStoredEntries(t, fs3, mtca.logID.TilePrefix(), latest.TreeSize, got)
 }
 
 // TestSequenceStorageFailure checks that a failed sequencing pass leaves the
@@ -502,7 +504,7 @@ func TestSequenceStorageFailure(t *testing.T) {
 	latest := verifyStores(t, mtca, fs3)
 	verifyCheckpoint(t, mtca, latest)
 
-	validateStoredEntries(t, fs3, mtca.tileStoragePrefix(), latest.TreeSize, got)
+	validateStoredEntries(t, fs3, mtca.logID.TilePrefix(), latest.TreeSize, got)
 }
 
 func TestInitLog(t *testing.T) {
@@ -537,9 +539,9 @@ func TestInitLog(t *testing.T) {
 func verifyCheckpoint(t *testing.T, mtca *mtca, checkpoint *checkpoint) {
 	t.Helper()
 	message := cosigned.Message{
-		CosignerName: fmt.Sprintf("oid/1.3.6.1.4.1.%s", mtca.mtcaID),
+		CosignerName: "oid/1.3.6.1.4.1." + mtca.logID.CAID,
 		Timestamp:    0,
-		LogOrigin:    fmt.Sprintf("oid/1.3.6.1.4.1.%s", mtca.mtcLogID()),
+		LogOrigin:    mtca.logID.Origin(),
 		Start:        0,
 		End:          uint64(checkpoint.TreeSize),
 		SubtreeHash:  [32]byte(checkpoint.RootHash),
@@ -561,7 +563,7 @@ func verifyCheckpoint(t *testing.T, mtca *mtca, checkpoint *checkpoint) {
 	}
 }
 
-func TestGetMTCAID(t *testing.T) {
+func TestGetCAID(t *testing.T) {
 	certBytes, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(`
 MIIBRjCB9KADAgECAgF7MAoGCCqGSM49BAMCMBsxGTAXBgorBgEEAYLaSy8BDAk0
 NDk0Ny40LjEwHhcNMjYwNzE0MjIyNjIwWhcNMzYwNzExMjIyNjIwWjAbMRkwFwYK
@@ -579,13 +581,13 @@ DgQIBAaC3xMBAgEwCgYIKoZIzj0EAwIDQQAwPgIdAMebuq7759hyFC3hjrVUEaXk
 	if err != nil {
 		t.Fatal(err)
 	}
-	mtcaID, err := getMTCAID(cert)
+	caID, err := getCAID(cert)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected := "44947.4.1"
-	if mtcaID != expected {
-		t.Errorf("getMTCAID(): got %s, want %s", mtcaID, expected)
+	if caID != expected {
+		t.Errorf("getCAID(): got %s, want %s", caID, expected)
 	}
 }

--- a/mtpublisher/mtpublisher.go
+++ b/mtpublisher/mtpublisher.go
@@ -20,6 +20,7 @@ import (
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/trees/checkpoint"
 	"github.com/letsencrypt/boulder/trees/cosignature"
+	"github.com/letsencrypt/boulder/trees/issuancelog"
 )
 
 // publisher polls the MTC issuance log and cosigns the latest checkpoint if it
@@ -40,13 +41,14 @@ type publisher struct {
 	log            blog.Logger
 }
 
-// New returns a publisher that cosigns as the mirror with mirrorID using
-// signer, verifying each cosignature against pubKey before storing it.
-func New(dbMap *db.WrappedMap, interval time.Duration, mtcLogID, mirrorID string, signer crypto.Signer, pubKey *mldsa.PublicKey, log blog.Logger) (*publisher, error) {
+// New returns a publisher for the issuance log logID. It cosigns as the mirror
+// with mirrorID using signer, and verifies each cosignature against pubKey
+// before storing it.
+func New(dbMap *db.WrappedMap, interval time.Duration, logID issuancelog.ID, mirrorID string, signer crypto.Signer, pubKey *mldsa.PublicKey, log blog.Logger) (*publisher, error) {
 	if interval <= 0 {
 		return nil, fmt.Errorf("interval must be positive, got %s", interval)
 	}
-	cosigner, err := cosignature.NewCosigner(mirrorID, mtcLogID, signer)
+	cosigner, err := cosignature.NewCosigner(mirrorID, logID.Origin(), signer)
 	if err != nil {
 		return nil, fmt.Errorf("creating mirror cosigner: %s", err)
 	}
@@ -68,7 +70,7 @@ func New(dbMap *db.WrappedMap, interval time.Duration, mtcLogID, mirrorID string
 	return &publisher{
 		db:             dbMap,
 		interval:       interval,
-		mtcLogID:       mtcLogID,
+		mtcLogID:       logID.String(),
 		origin:         cosigner.Origin(),
 		mirrorID:       mirrorID,
 		mirrorName:     mirrorName,

--- a/mtpublisher/mtpublisher_test.go
+++ b/mtpublisher/mtpublisher_test.go
@@ -18,12 +18,15 @@ import (
 	"github.com/letsencrypt/boulder/sa"
 	"github.com/letsencrypt/boulder/test/vars"
 	"github.com/letsencrypt/boulder/trees/cosignature"
+	"github.com/letsencrypt/boulder/trees/issuancelog"
 )
 
 const (
 	mtcLogID = "44947.4.1.0.44"
 	mirrorID = "32473.9"
 )
+
+var testLogID = issuancelog.ID{CAID: "44947.4.1", LogNumber: 44}
 
 func setupDB(t *testing.T) *db.WrappedMap {
 	t.Helper()
@@ -110,7 +113,7 @@ func testKey(t *testing.T) *mldsa.PrivateKey {
 // trees/cosignature and yields the timestamped_signature it encodes.
 func TestCosign(t *testing.T) {
 	key := testKey(t)
-	p, err := New(nil, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
+	p, err := New(nil, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
@@ -146,7 +149,7 @@ func TestCosign(t *testing.T) {
 func TestPublish(t *testing.T) {
 	dbMap := setupDB(t)
 	key := testKey(t)
-	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
+	p, err := New(dbMap, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
@@ -240,7 +243,7 @@ func TestPublishRejectsMismatchedKey(t *testing.T) {
 		t.Fatalf("NewPrivateKey: %s", err)
 	}
 
-	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(testKey(t)), otherKey.PublicKey(), blog.NewMock())
+	p, err := New(dbMap, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(testKey(t)), otherKey.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
@@ -260,7 +263,7 @@ func TestPublishRejectsMismatchedKey(t *testing.T) {
 func TestPublishWhenLatestAlreadySigned(t *testing.T) {
 	dbMap := setupDB(t)
 	key := testKey(t)
-	p, err := New(dbMap, time.Second, mtcLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
+	p, err := New(dbMap, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}

--- a/test/config-next/mtca.json
+++ b/test/config-next/mtca.json
@@ -1,5 +1,9 @@
 {
 	"mtca": {
+		"logID": {
+			"caID": "44947.4.1",
+			"logNumber": 44
+		},
 		"sequencingPeriod": "100ms",
 		"db": {
 			"dbConnectFile": "test/secrets/mtca1_dburl"

--- a/test/config-next/mtpublisher.json
+++ b/test/config-next/mtpublisher.json
@@ -5,7 +5,10 @@
 			"maxOpenConns": 10
 		},
 		"pollInterval": "1s",
-		"mtcLogID": "44947.4.1.0.44",
+		"logID": {
+			"caID": "44947.4.1",
+			"logNumber": 44
+		},
 		"mirrorID": "32473.9",
 		"mirrorKeyFile": "test/certs/mtpki/mirror.key.pem",
 		"mirrorPublicKeyFile": "test/certs/mtpki/mirror.pub.pem"

--- a/test/config/mtpublisher.json
+++ b/test/config/mtpublisher.json
@@ -5,7 +5,10 @@
 			"maxOpenConns": 10
 		},
 		"pollInterval": "1s",
-		"mtcLogID": "44947.4.1.0.44",
+		"logID": {
+			"caID": "44947.4.1",
+			"logNumber": 44
+		},
 		"mirrorID": "32473.9",
 		"mirrorKeyFile": "test/certs/mtpki/mirror.key.pem",
 		"mirrorPublicKeyFile": "test/certs/mtpki/mirror.pub.pem"

--- a/trees/cosignature/cosignature.go
+++ b/trees/cosignature/cosignature.go
@@ -87,7 +87,7 @@ func checkRelativeOID(id string) error {
 	if id == "" {
 		return errors.New("empty relative OID")
 	}
-	for _, arc := range strings.Split(id, ".") {
+	for arc := range strings.SplitSeq(id, ".") {
 		if arc == "" {
 			return errors.New("empty arc")
 		}
@@ -101,19 +101,6 @@ func checkRelativeOID(id string) error {
 		}
 	}
 	return nil
-}
-
-// originFor returns the log origin derived from the log ID per mtc-tlog: log
-// ID "32473.2.0.42" has origin "oid/1.3.6.1.4.1.32473.2.0.42". It errors if
-// logID is not a dotted decimal OID.
-//
-// https://c2sp.org/mtc-tlog
-func originFor(logID string) (string, error) {
-	err := checkRelativeOID(logID)
-	if err != nil {
-		return "", fmt.Errorf("invalid log ID %q: %w", logID, err)
-	}
-	return oidPrefix + logID, nil
 }
 
 // Cosigner produces cosignatures over checkpoints as an MTC cosigner for a
@@ -131,18 +118,18 @@ type Cosigner struct {
 	signer crypto.Signer
 }
 
-// NewCosigner returns a Cosigner for the cosigner and log with the given IDs,
-// deriving its cosigner name and log origin per mtc-tlog: cosigner ID "32473.2"
-// signs as "oid/1.3.6.1.4.1.32473.2". It errors if either ID is not a dotted
-// decimal OID or signer's public key is not ML-DSA-44.
-func NewCosigner(cosignerID, logID string, signer crypto.Signer) (*Cosigner, error) {
+// NewCosigner returns a Cosigner for the cosigner with the given ID over the
+// log with the given log origin, deriving its cosigner name per mtc-tlog:
+// cosigner ID "32473.2" signs as "oid/1.3.6.1.4.1.32473.2". It errors if
+// cosignerID is not a dotted decimal OID, origin is empty, or signer's public
+// key is not ML-DSA-44.
+func NewCosigner(cosignerID, origin string, signer crypto.Signer) (*Cosigner, error) {
 	err := checkRelativeOID(cosignerID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid cosigner ID %q: %w", cosignerID, err)
 	}
-	origin, err := originFor(logID)
-	if err != nil {
-		return nil, err
+	if origin == "" {
+		return nil, errors.New("empty log origin")
 	}
 	pubKey, ok := signer.Public().(*mldsa.PublicKey)
 	if !ok {
@@ -159,7 +146,7 @@ func NewCosigner(cosignerID, logID string, signer crypto.Signer) (*Cosigner, err
 	}, nil
 }
 
-// Origin returns the log origin derived from the log ID.
+// Origin returns the log origin of the log the cosigner signs for.
 func (c *Cosigner) Origin() string {
 	return c.origin
 }

--- a/trees/cosignature/cosignature_test.go
+++ b/trees/cosignature/cosignature_test.go
@@ -198,28 +198,13 @@ func TestVerifyCheckpointErrors(t *testing.T) {
 	}
 }
 
-func TestOriginFor(t *testing.T) {
-	origin, err := originFor("32473.2.0.42")
-	if err != nil {
-		t.Fatalf("originFor: %s", err)
-	}
-	if origin != "oid/1.3.6.1.4.1.32473.2.0.42" {
-		t.Errorf("originFor = %q, want %q", origin, "oid/1.3.6.1.4.1.32473.2.0.42")
-	}
-
-	_, err = originFor("32473..2")
-	if err == nil {
-		t.Error("originFor with a malformed log ID = nil error, want error")
-	}
-}
-
 // TestCosignerRoundTrip covers the cosigner round trip: an MTC cosigner derives
 // its name and origin from the CA and log IDs (mtc-tlog's own examples), and
 // its timestamped_signature carries a zero timestamp, verifies through the note
 // verifier against the matching checkpoint text, and reassembles into a
 // signature line that opens.
 func TestCosignerRoundTrip(t *testing.T) {
-	ca, err := NewCosigner("32473.2", "32473.2.0.42", testSigner(t))
+	ca, err := NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", testSigner(t))
 	if err != nil {
 		t.Fatalf("NewCosigner: %s", err)
 	}
@@ -295,14 +280,14 @@ func TestCosignerRejects(t *testing.T) {
 	signer := testSigner(t)
 
 	for _, id := range []string{"", "has space", "32473..2", "32473.x", ".32473", "32473.", "32473.02"} {
-		_, err := NewCosigner(id, "32473.2.0.42", signer)
+		_, err := NewCosigner(id, "oid/1.3.6.1.4.1.32473.2.0.42", signer)
 		if err == nil {
 			t.Errorf("NewCosigner with cosigner ID %q = nil error, want error", id)
 		}
-		_, err = NewCosigner("32473.2", id, signer)
-		if err == nil {
-			t.Errorf("NewCosigner with log ID %q = nil error, want error", id)
-		}
+	}
+	_, err := NewCosigner("32473.2", "", signer)
+	if err == nil {
+		t.Error("NewCosigner with an empty origin = nil error, want error")
 	}
 
 	// An ML-DSA-65 key has an mldsa public key of the wrong size.
@@ -310,7 +295,7 @@ func TestCosignerRejects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey(MLDSA65): %s", err)
 	}
-	_, err = NewCosigner("32473.2", "32473.2.0.42", wrong)
+	_, err = NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", wrong)
 	if err == nil {
 		t.Error("NewCosigner with an ML-DSA-65 key = nil error, want error")
 	}
@@ -320,12 +305,12 @@ func TestCosignerRejects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey: %s", err)
 	}
-	_, err = NewCosigner("32473.2", "32473.2.0.42", edKey)
+	_, err = NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", edKey)
 	if err == nil {
 		t.Error("NewCosigner with an Ed25519 key = nil error, want error")
 	}
 
-	ca, err := NewCosigner("32473.2", "32473.2.0.42", signer)
+	ca, err := NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", signer)
 	if err != nil {
 		t.Fatalf("NewCosigner: %s", err)
 	}
@@ -357,7 +342,7 @@ func (s shortSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, e
 }
 
 func TestCosignerRejectsShortSignature(t *testing.T) {
-	ca, err := NewCosigner("32473.2", "32473.2.0.42", shortSigner{pubKey: testPubKey(t)})
+	ca, err := NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", shortSigner{pubKey: testPubKey(t)})
 	if err != nil {
 		t.Fatalf("NewCosigner: %s", err)
 	}
@@ -382,7 +367,7 @@ func (s errSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, err
 }
 
 func TestCosignerPropagatesSignerError(t *testing.T) {
-	ca, err := NewCosigner("32473.2", "32473.2.0.42", errSigner{pubKey: testPubKey(t)})
+	ca, err := NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", errSigner{pubKey: testPubKey(t)})
 	if err != nil {
 		t.Fatalf("NewCosigner: %s", err)
 	}
@@ -424,7 +409,7 @@ func TestRawSignature(t *testing.T) {
 // verifies on its own, and that extraction errors for a verifier that did not
 // sign.
 func TestTimestampedSignature(t *testing.T) {
-	ca, err := NewCosigner("32473.2", "32473.2.0.42", testSigner(t))
+	ca, err := NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", testSigner(t))
 	if err != nil {
 		t.Fatalf("NewCosigner: %s", err)
 	}
@@ -480,7 +465,7 @@ func TestTimestampedSignatureRejectsForeignFormat(t *testing.T) {
 // signatures from unknown keys" with a note cosigned for one log by two MTC
 // cosigners and opened by one verifier, the shape of every real exchange.
 func TestOpenIgnoresUnknownSignatures(t *testing.T) {
-	known, err := NewCosigner("32473.2", "32473.2.0.42", testSigner(t))
+	known, err := NewCosigner("32473.2", "oid/1.3.6.1.4.1.32473.2.0.42", testSigner(t))
 	if err != nil {
 		t.Fatalf("NewCosigner: %s", err)
 	}
@@ -493,7 +478,7 @@ func TestOpenIgnoresUnknownSignatures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPrivateKey: %s", err)
 	}
-	unknown, err := NewCosigner("32473.9", "32473.2.0.42", privatekey.NewDeterministicSigner(otherKey))
+	unknown, err := NewCosigner("32473.9", "oid/1.3.6.1.4.1.32473.2.0.42", privatekey.NewDeterministicSigner(otherKey))
 	if err != nil {
 		t.Fatalf("NewCosigner: %s", err)
 	}

--- a/trees/issuancelog/issuancelog.go
+++ b/trees/issuancelog/issuancelog.go
@@ -1,0 +1,62 @@
+package issuancelog
+
+import "fmt"
+
+// oidPrefix begins every mtc-tlog log origin, the IANA private enterprise arc
+// an MTC ID is relative to.
+//
+// https://c2sp.org/mtc-tlog
+const oidPrefix = "oid/1.3.6.1.4.1."
+
+// ID is a log ID, identifying one issuance log by the CA ID of the CA operating
+// it and the log's log number. The mtca and the mtpublisher derive the names
+// they configure themselves with from it.
+//
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-issuance-logs
+type ID struct {
+	// CAID is the CA ID, a trust anchor ID, in its ASCII representation (e.g.
+	// "44947.4.1").
+	CAID string `validate:"required"`
+	// LogNumber is the log number, a positive integer that identifies the log
+	// within the CA's series of issuance logs.
+	LogNumber uint16 `validate:"required"`
+}
+
+// String returns the log ID in its ASCII representation, the CA ID followed by
+// the constant 0 and the log number. For instance, the log ID of CA ID
+// "44947.4.1" and log number 44 is "44947.4.1.0.44".
+//
+// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-issuance-logs
+func (id ID) String() string {
+	return fmt.Sprintf("%s.0.%d", id.CAID, id.LogNumber)
+}
+
+// Origin returns the log origin per mtc-tlog, the log ID as an origin. For
+// instance, the log origin of CA ID "44947.4.1" and log number 44 is
+// "oid/1.3.6.1.4.1.44947.4.1.0.44".
+//
+// https://c2sp.org/mtc-tlog
+func (id ID) Origin() string {
+	return oidPrefix + id.String()
+}
+
+// TilePrefix returns the path within a bucket where the log's tiles and
+// checkpoint are stored.
+//
+// https://github.com/C2SP/C2SP/blob/main/mtc-tlog.md#serving-issuance-logs
+//
+// "Each log's prefix URL is the concatenation of the CA prefix URL and the log
+// number, encoded as an ASCII decimal integer with no additional leading zeros:
+//
+// <CA prefix URL>/<log number>"
+//
+// We assume we will serve directly from tile storage (likely sync'ed
+// somewhere), so we want to store tiles compatible with that pattern, with log
+// number as the last component of the path before "tile/".
+//
+// As a matter of local convention we will put the CA ID as the path component
+// right before log number. For instance, the prefix of CA ID "44947.4.1" and
+// log number 44 is "44947.4.1/44".
+func (id ID) TilePrefix() string {
+	return fmt.Sprintf("%s/%d", id.CAID, id.LogNumber)
+}

--- a/trees/issuancelog/issuancelog_test.go
+++ b/trees/issuancelog/issuancelog_test.go
@@ -1,0 +1,45 @@
+package issuancelog
+
+import "testing"
+
+// TestIDDerivations pins the derived names to mtc-tlog's own examples and
+// the identifiers the dev environment uses.
+func TestIDDerivations(t *testing.T) {
+	for _, tc := range []struct {
+		id               ID
+		expectString     string
+		expectOrigin     string
+		expectTilePrefix string
+	}{
+		{
+			id:               ID{CAID: "32473.2", LogNumber: 42},
+			expectString:     "32473.2.0.42",
+			expectOrigin:     "oid/1.3.6.1.4.1.32473.2.0.42",
+			expectTilePrefix: "32473.2/42",
+		},
+		{
+			id:               ID{CAID: "44947.4.1", LogNumber: 44},
+			expectString:     "44947.4.1.0.44",
+			expectOrigin:     "oid/1.3.6.1.4.1.44947.4.1.0.44",
+			expectTilePrefix: "44947.4.1/44",
+		},
+		{
+			id:               ID{CAID: "1", LogNumber: 1},
+			expectString:     "1.0.1",
+			expectOrigin:     "oid/1.3.6.1.4.1.1.0.1",
+			expectTilePrefix: "1/1",
+		},
+	} {
+		t.Run(tc.expectString, func(t *testing.T) {
+			if tc.id.String() != tc.expectString {
+				t.Errorf("String = %q, want %q", tc.id.String(), tc.expectString)
+			}
+			if tc.id.Origin() != tc.expectOrigin {
+				t.Errorf("Origin = %q, want %q", tc.id.Origin(), tc.expectOrigin)
+			}
+			if tc.id.TilePrefix() != tc.expectTilePrefix {
+				t.Errorf("TilePrefix = %q, want %q", tc.id.TilePrefix(), tc.expectTilePrefix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Consolidate the configuration of the CAID and LogNumer into a single struct used by both the MTCA and MTPublisher. Also use the newer CA ID rather than MTCA ID.

Closes https://github.com/letsencrypt/boulder/issues/8952