### PR TITLE
trees/mirror: Add mirror wire protocol

### DIFF
--- a/trees/mirror/mirror.go
+++ b/trees/mirror/mirror.go
@@ -1,0 +1,217 @@
+package mirror
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/mod/sumdb/tlog"
+)
+
+// maxProofLines is the most consistency proof lines a client may send in an
+// add-checkpoint request per c2sp.org/tlog-witness.
+const maxProofLines = 63
+
+// maxPackageProofHashes is the most subtree consistency proof hashes an entry
+// package may carry per c2sp.org/tlog-mirror.
+const maxPackageProofHashes = 63
+
+// MaxPackagesPerRequest is the most entry packages a client should send in one
+// add-entries request per c2sp.org/tlog-mirror.
+const MaxPackagesPerRequest = 32
+
+// packageWidth is the entry package alignment, matching the tiled log
+// interface's entry bundles.
+const packageWidth = 256
+
+// AddCheckpointRequest builds the add-checkpoint request body per
+// c2sp.org/tlog-witness. The proof must be a Merkle consistency proof from
+// oldSize to the checkpoint's size, empty when oldSize is zero.
+func AddCheckpointRequest(oldSize int64, proof []tlog.Hash, signedCheckpoint []byte) ([]byte, error) {
+	if oldSize < 0 {
+		return nil, fmt.Errorf("negative old size %d", oldSize)
+	}
+	if oldSize == 0 && len(proof) > 0 {
+		return nil, errors.New("non-empty consistency proof with old size zero")
+	}
+	if len(proof) > maxProofLines {
+		return nil, fmt.Errorf("consistency proof has %d lines, want at most %d", len(proof), maxProofLines)
+	}
+	if len(signedCheckpoint) == 0 {
+		return nil, errors.New("empty checkpoint")
+	}
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "old %d\n", oldSize)
+	for _, h := range proof {
+		b.WriteString(h.String())
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')
+	b.Write(signedCheckpoint)
+	return b.Bytes(), nil
+}
+
+// parseDecimal parses an ASCII decimal string, accepting leading zeroes since
+// the specs require canonical decimals only in request bodies.
+func parseDecimal(s string) (int64, error) {
+	if s == "" || s[0] == '+' || s[0] == '-' {
+		return 0, fmt.Errorf("malformed decimal %q", s)
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("malformed decimal %q", s)
+	}
+	return n, nil
+}
+
+// ParseSizeResponse parses the text/x.tlog.size body of a "409 Conflict"
+// add-checkpoint response, which carries the tree size of the mirror's latest
+// pending checkpoint.
+func ParseSizeResponse(body []byte) (int64, error) {
+	line, ok := strings.CutSuffix(string(body), "\n")
+	if !ok || strings.Contains(line, "\n") {
+		return 0, fmt.Errorf("malformed size response %q", body)
+	}
+	return parseDecimal(line)
+}
+
+// MirrorInfo is a parsed text/x.tlog.mirror-info body from a "409 Conflict" or
+// "202 Accepted" add-entries response.
+type MirrorInfo struct {
+	// TreeSize is the tree size to use as upload_end in the next request. The
+	// mirror repeats the request's upload_end if it is still a pending
+	// checkpoint, otherwise it sends its current pending checkpoint's size.
+	TreeSize int64
+	// NextEntry is the entry to use as upload_start in the next request. It is
+	// the first entry the mirror does not hold.
+	NextEntry int64
+	// Ticket is an opaque ticket value to send back in the next request.
+	Ticket []byte
+}
+
+// ParseMirrorInfo parses a text/x.tlog.mirror-info response body.
+func ParseMirrorInfo(body []byte) (MirrorInfo, error) {
+	content, ok := strings.CutSuffix(string(body), "\n")
+	if !ok {
+		return MirrorInfo{}, fmt.Errorf("malformed mirror-info response %q", body)
+	}
+	lines := strings.Split(content, "\n")
+	if len(lines) != 3 {
+		return MirrorInfo{}, fmt.Errorf("mirror-info response has %d lines, want 3", len(lines))
+	}
+	treeSize, err := parseDecimal(lines[0])
+	if err != nil {
+		return MirrorInfo{}, fmt.Errorf("mirror-info tree size: %s", err)
+	}
+	nextEntry, err := parseDecimal(lines[1])
+	if err != nil {
+		return MirrorInfo{}, fmt.Errorf("mirror-info next entry: %s", err)
+	}
+	ticket, err := base64.StdEncoding.DecodeString(lines[2])
+	if err != nil {
+		return MirrorInfo{}, fmt.Errorf("mirror-info ticket: %s", err)
+	}
+	return MirrorInfo{TreeSize: treeSize, NextEntry: nextEntry, Ticket: ticket}, nil
+}
+
+// Package holds the boundaries of one entry package of an add-entries upload.
+type Package struct {
+	// SubtreeStart begins the subtree consistency proof's interval,
+	// [SubtreeStart, End).
+	SubtreeStart int64
+	// EntriesStart begins the carried entries, [EntriesStart, End), exceeding
+	// SubtreeStart only for the first package of an upload that does not begin
+	// on a package boundary.
+	EntriesStart int64
+	// End is the exclusive end of both intervals.
+	End int64
+}
+
+// Packages returns the first maxPackages packages of the canonical sequence for
+// an upload of the entries in [uploadStart, uploadEnd). The sequence is empty
+// when uploadStart equals uploadEnd.
+func Packages(uploadStart, uploadEnd, maxPackages int64) ([]Package, error) {
+	if uploadStart < 0 || uploadStart > uploadEnd || uploadEnd >= 1<<62 {
+		return nil, fmt.Errorf("invalid upload interval [%d, %d)", uploadStart, uploadEnd)
+	}
+	if maxPackages < 1 {
+		return nil, fmt.Errorf("non-positive maxPackages %d", maxPackages)
+	}
+	if uploadStart == uploadEnd {
+		return nil, nil
+	}
+	roundedStart := uploadStart / packageWidth * packageWidth
+	roundedEnd := (uploadEnd + packageWidth - 1) / packageWidth * packageWidth
+	numPackages := min((roundedEnd-roundedStart)/packageWidth, maxPackages)
+	packages := make([]Package, 0, numPackages)
+	for i := range numPackages {
+		subtreeStart := roundedStart + i*packageWidth
+		packages = append(packages, Package{
+			SubtreeStart: subtreeStart,
+			EntriesStart: max(uploadStart, subtreeStart),
+			End:          min(uploadEnd, subtreeStart+packageWidth),
+		})
+	}
+	return packages, nil
+}
+
+// EntryPackage builds the wire form of one entry package.
+func EntryPackage(entries [][]byte, proof []tlog.Hash) ([]byte, error) {
+	if len(entries) == 0 {
+		return nil, errors.New("entry package with no entries")
+	}
+	if len(proof) > maxPackageProofHashes {
+		return nil, fmt.Errorf("entry package has %d proof hashes, want at most %d", len(proof), maxPackageProofHashes)
+	}
+	var b bytes.Buffer
+	for _, entry := range entries {
+		if len(entry) > 0xFFFF {
+			return nil, fmt.Errorf("entry is %d bytes, want at most %d", len(entry), 0xFFFF)
+		}
+		var length [2]byte
+		binary.BigEndian.PutUint16(length[:], uint16(len(entry))) //nolint:gosec // G115: the check above rejects entries over 0xFFFF bytes.
+		b.Write(length[:])
+		b.Write(entry)
+	}
+	b.WriteByte(byte(len(proof)))
+	for _, h := range proof {
+		b.Write(h[:])
+	}
+	return b.Bytes(), nil
+}
+
+// AddEntriesRequest builds the add-entries request body. The packages must be a
+// prefix of the canonical sequence for [uploadStart, uploadEnd), marshaled by
+// EntryPackage.
+func AddEntriesRequest(logOrigin string, uploadStart, uploadEnd int64, ticket []byte, packages [][]byte) ([]byte, error) {
+	if logOrigin == "" || len(logOrigin) > 0xFFFF {
+		return nil, fmt.Errorf("invalid log origin length %d", len(logOrigin))
+	}
+	if uploadStart < 0 || uploadStart > uploadEnd {
+		return nil, fmt.Errorf("invalid upload interval [%d, %d)", uploadStart, uploadEnd)
+	}
+	if len(ticket) > 0xFFFF {
+		return nil, fmt.Errorf("ticket is %d bytes, want at most %d", len(ticket), 0xFFFF)
+	}
+	var b bytes.Buffer
+	var length [2]byte
+	binary.BigEndian.PutUint16(length[:], uint16(len(logOrigin))) //nolint:gosec // G115: the check above rejects origins over 0xFFFF bytes.
+	b.Write(length[:])
+	b.WriteString(logOrigin)
+	var index [8]byte
+	binary.BigEndian.PutUint64(index[:], uint64(uploadStart))
+	b.Write(index[:])
+	binary.BigEndian.PutUint64(index[:], uint64(uploadEnd)) //nolint:gosec // G115: the check above leaves uploadEnd >= uploadStart >= 0.
+	b.Write(index[:])
+	binary.BigEndian.PutUint16(length[:], uint16(len(ticket))) //nolint:gosec // G115: the check above rejects tickets over 0xFFFF bytes.
+	b.Write(length[:])
+	b.Write(ticket)
+	for _, p := range packages {
+		b.Write(p)
+	}
+	return b.Bytes(), nil
+}

--- a/trees/mirror/mirror.go
+++ b/trees/mirror/mirror.go
@@ -3,12 +3,12 @@ package mirror
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/mod/sumdb/tlog"
 )
 
@@ -167,21 +167,20 @@ func EntryPackage(entries [][]byte, proof []tlog.Hash) ([]byte, error) {
 	if len(proof) > maxPackageProofHashes {
 		return nil, fmt.Errorf("entry package has %d proof hashes, want at most %d", len(proof), maxPackageProofHashes)
 	}
-	var b bytes.Buffer
+	var b cryptobyte.Builder
 	for _, entry := range entries {
 		if len(entry) > 0xFFFF {
 			return nil, fmt.Errorf("entry is %d bytes, want at most %d", len(entry), 0xFFFF)
 		}
-		var length [2]byte
-		binary.BigEndian.PutUint16(length[:], uint16(len(entry))) //nolint:gosec // G115: the check above rejects entries over 0xFFFF bytes.
-		b.Write(length[:])
-		b.Write(entry)
+		b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+			child.AddBytes(entry)
+		})
 	}
-	b.WriteByte(byte(len(proof)))
+	b.AddUint8(uint8(len(proof))) //nolint:gosec // G115: the check above rejects proofs over maxPackageProofHashes hashes.
 	for _, h := range proof {
-		b.Write(h[:])
+		b.AddBytes(h[:])
 	}
-	return b.Bytes(), nil
+	return b.Bytes()
 }
 
 // AddEntriesRequest builds the add-entries request body. The packages must be a
@@ -197,21 +196,17 @@ func AddEntriesRequest(logOrigin string, uploadStart, uploadEnd int64, ticket []
 	if len(ticket) > 0xFFFF {
 		return nil, fmt.Errorf("ticket is %d bytes, want at most %d", len(ticket), 0xFFFF)
 	}
-	var b bytes.Buffer
-	var length [2]byte
-	binary.BigEndian.PutUint16(length[:], uint16(len(logOrigin))) //nolint:gosec // G115: the check above rejects origins over 0xFFFF bytes.
-	b.Write(length[:])
-	b.WriteString(logOrigin)
-	var index [8]byte
-	binary.BigEndian.PutUint64(index[:], uint64(uploadStart))
-	b.Write(index[:])
-	binary.BigEndian.PutUint64(index[:], uint64(uploadEnd)) //nolint:gosec // G115: the check above leaves uploadEnd >= uploadStart >= 0.
-	b.Write(index[:])
-	binary.BigEndian.PutUint16(length[:], uint16(len(ticket))) //nolint:gosec // G115: the check above rejects tickets over 0xFFFF bytes.
-	b.Write(length[:])
-	b.Write(ticket)
+	var b cryptobyte.Builder
+	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes([]byte(logOrigin))
+	})
+	b.AddUint64(uint64(uploadStart))
+	b.AddUint64(uint64(uploadEnd)) //nolint:gosec // G115: the check above leaves uploadEnd >= uploadStart >= 0.
+	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes(ticket)
+	})
 	for _, p := range packages {
-		b.Write(p)
+		b.AddBytes(p)
 	}
-	return b.Bytes(), nil
+	return b.Bytes()
 }

--- a/trees/mirror/mirror_test.go
+++ b/trees/mirror/mirror_test.go
@@ -1,0 +1,245 @@
+package mirror
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/mod/sumdb/tlog"
+)
+
+func mustHash(t *testing.T, s string) tlog.Hash {
+	t.Helper()
+	h, err := tlog.ParseHash(s)
+	if err != nil {
+		t.Fatalf("ParseHash(%q): %s", s, err)
+	}
+	return h
+}
+
+// TestAddCheckpointRequest pins the request body to the worked example in
+// c2sp.org/tlog-witness.
+func TestAddCheckpointRequest(t *testing.T) {
+	checkpoint := "example.com/behind-the-sofa\n" +
+		"20852163\n" +
+		"CsUYapGGPo4dkMgIAUqom/Xajj7h2fB2MPA3j2jxq2I=\n" +
+		"\n" +
+		"— example.com/behind-the-sofa Az3grlgtzPICa5OS8npVmf1Myq/5IZniMp+ZJurmRDeOoRDe4URYN7u5/Zhcyv2q1gGzGku9nTo+zyWE+xeMcTOAYQ8=\n"
+	proof := []tlog.Hash{
+		mustHash(t, "PlRNCrwHpqhGrupue0L7gxbjbMiKA9temvuZZDDpkaw="),
+		mustHash(t, "jrJZDmY8Y7SyJE0MWLpLozkIVMSMZcD5kvuKxPC3swk="),
+		mustHash(t, "5+pKlUdi2LeF/BcMHBn+Ku6yhPGNCswZZD1X/6QgPd8="),
+		mustHash(t, "/6WVhPs2CwSsb5rYBH5cjHV/wSmA79abXAwhXw3Kj/0="),
+	}
+
+	body, err := AddCheckpointRequest(20852014, proof, []byte(checkpoint))
+	if err != nil {
+		t.Fatalf("AddCheckpointRequest: %s", err)
+	}
+	expect := "old 20852014\n" +
+		"PlRNCrwHpqhGrupue0L7gxbjbMiKA9temvuZZDDpkaw=\n" +
+		"jrJZDmY8Y7SyJE0MWLpLozkIVMSMZcD5kvuKxPC3swk=\n" +
+		"5+pKlUdi2LeF/BcMHBn+Ku6yhPGNCswZZD1X/6QgPd8=\n" +
+		"/6WVhPs2CwSsb5rYBH5cjHV/wSmA79abXAwhXw3Kj/0=\n" +
+		"\n" +
+		checkpoint
+	if string(body) != expect {
+		t.Errorf("AddCheckpointRequest = %q, want %q", body, expect)
+	}
+}
+
+func TestAddCheckpointRequestRejects(t *testing.T) {
+	checkpoint := []byte("origin\n1\nhash\n")
+	_, err := AddCheckpointRequest(-1, nil, checkpoint)
+	if err == nil {
+		t.Error("AddCheckpointRequest with a negative old size = nil error, want error")
+	}
+	_, err = AddCheckpointRequest(0, make([]tlog.Hash, 1), checkpoint)
+	if err == nil {
+		t.Error("AddCheckpointRequest with a proof and old size zero = nil error, want error")
+	}
+	_, err = AddCheckpointRequest(1, make([]tlog.Hash, 64), checkpoint)
+	if err == nil {
+		t.Error("AddCheckpointRequest with 64 proof lines = nil error, want error")
+	}
+	_, err = AddCheckpointRequest(1, nil, nil)
+	if err == nil {
+		t.Error("AddCheckpointRequest with an empty checkpoint = nil error, want error")
+	}
+}
+
+func TestParseSizeResponse(t *testing.T) {
+	size, err := ParseSizeResponse([]byte("20852014\n"))
+	if err != nil {
+		t.Fatalf("ParseSizeResponse: %s", err)
+	}
+	if size != 20852014 {
+		t.Errorf("ParseSizeResponse = %d, want 20852014", size)
+	}
+
+	size, err = ParseSizeResponse([]byte("0512\n"))
+	if err != nil {
+		t.Fatalf("ParseSizeResponse with a leading zero: %s", err)
+	}
+	if size != 512 {
+		t.Errorf("ParseSizeResponse = %d, want 512", size)
+	}
+
+	for _, malformed := range []string{"", "512", "512\n\n", "+1\n", "-1\n", "1 2\n"} {
+		_, err := ParseSizeResponse([]byte(malformed))
+		if err == nil {
+			t.Errorf("ParseSizeResponse(%q) = nil error, want error", malformed)
+		}
+	}
+}
+
+func TestParseMirrorInfo(t *testing.T) {
+	info, err := ParseMirrorInfo([]byte("512\n300\ndGlja2V0\n"))
+	if err != nil {
+		t.Fatalf("ParseMirrorInfo: %s", err)
+	}
+	expect := MirrorInfo{TreeSize: 512, NextEntry: 300, Ticket: []byte("ticket")}
+	if !reflect.DeepEqual(info, expect) {
+		t.Errorf("ParseMirrorInfo = %+v, want %+v", info, expect)
+	}
+
+	// A zero length ticket is valid, and parses to an empty ticket.
+	info, err = ParseMirrorInfo([]byte("512\n300\n\n"))
+	if err != nil {
+		t.Fatalf("ParseMirrorInfo with an empty ticket: %s", err)
+	}
+	if len(info.Ticket) != 0 {
+		t.Errorf("Ticket = %q, want empty", info.Ticket)
+	}
+
+	for _, malformed := range []string{"", "512\n300\n", "512\n300\ndGlja2V0", "512\n300\n!!!\n", "512\n-1\n\n", "512\n300\n\n\n"} {
+		_, err := ParseMirrorInfo([]byte(malformed))
+		if err == nil {
+			t.Errorf("ParseMirrorInfo(%q) = nil error, want error", malformed)
+		}
+	}
+}
+
+func TestPackages(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		start  int64
+		end    int64
+		max    int64
+		expect []Package
+	}{
+		{"empty", 5, 5, 32, nil},
+		{"single aligned", 0, 256, 32, []Package{{0, 0, 256}}},
+		{"single short", 0, 5, 32, []Package{{0, 0, 5}}},
+		{"unaligned start", 300, 700, 32, []Package{{256, 300, 512}, {512, 512, 700}}},
+		{"aligned interior", 256, 768, 32, []Package{{256, 256, 512}, {512, 512, 768}}},
+		{"start and end in same package", 300, 400, 32, []Package{{256, 300, 400}}},
+		{"truncated to max", 0, 1000, 2, []Package{{0, 0, 256}, {256, 256, 512}}},
+		{"unaligned truncated to max", 300, 2000, 2, []Package{{256, 300, 512}, {512, 512, 768}}},
+		{"exactly max", 0, 512, 2, []Package{{0, 0, 256}, {256, 256, 512}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			packages, err := Packages(tc.start, tc.end, tc.max)
+			if err != nil {
+				t.Fatalf("Packages(%d, %d, %d): %s", tc.start, tc.end, tc.max, err)
+			}
+			if !reflect.DeepEqual(packages, tc.expect) {
+				t.Errorf("Packages(%d, %d, %d) = %+v, want %+v", tc.start, tc.end, tc.max, packages, tc.expect)
+			}
+		})
+	}
+
+	_, err := Packages(-1, 5, 32)
+	if err == nil {
+		t.Error("Packages(-1, 5, 32) = nil error, want error")
+	}
+	_, err = Packages(6, 5, 32)
+	if err == nil {
+		t.Error("Packages(6, 5, 32) = nil error, want error")
+	}
+	_, err = Packages(0, 1<<62, 32)
+	if err == nil {
+		t.Error("Packages(0, 1<<62, 32) = nil error, want error")
+	}
+	_, err = Packages(0, 5, 0)
+	if err == nil {
+		t.Error("Packages(0, 5, 0) = nil error, want error")
+	}
+}
+
+func TestEntryPackage(t *testing.T) {
+	proof := []tlog.Hash{mustHash(t, "PlRNCrwHpqhGrupue0L7gxbjbMiKA9temvuZZDDpkaw=")}
+	body, err := EntryPackage([][]byte{[]byte("abc"), []byte("de")}, proof)
+	if err != nil {
+		t.Fatalf("EntryPackage: %s", err)
+	}
+	var expect bytes.Buffer
+	expect.Write([]byte{0, 3})
+	expect.WriteString("abc")
+	expect.Write([]byte{0, 2})
+	expect.WriteString("de")
+	expect.WriteByte(1)
+	expect.Write(proof[0][:])
+	if !bytes.Equal(body, expect.Bytes()) {
+		t.Errorf("EntryPackage = %x, want %x", body, expect.Bytes())
+	}
+
+	_, err = EntryPackage(nil, proof)
+	if err == nil {
+		t.Error("EntryPackage with no entries = nil error, want error")
+	}
+	_, err = EntryPackage([][]byte{make([]byte, 0x10000)}, proof)
+	if err == nil {
+		t.Error("EntryPackage with an oversize entry = nil error, want error")
+	}
+	_, err = EntryPackage([][]byte{[]byte("abc")}, make([]tlog.Hash, 64))
+	if err == nil {
+		t.Error("EntryPackage with 64 proof hashes = nil error, want error")
+	}
+}
+
+func TestAddEntriesRequest(t *testing.T) {
+	origin := "oid/1.3.6.1.4.1.44947.4.1.0.44"
+	pkg := []byte{0, 1, 'x', 0}
+	body, err := AddEntriesRequest(origin, 300, 700, []byte("ticket"), [][]byte{pkg})
+	if err != nil {
+		t.Fatalf("AddEntriesRequest: %s", err)
+	}
+
+	var expect bytes.Buffer
+	var u16 [2]byte
+	var u64 [8]byte
+	binary.BigEndian.PutUint16(u16[:], uint16(len(origin))) //nolint:gosec // G115: origin is a short constant.
+	expect.Write(u16[:])
+	expect.WriteString(origin)
+	binary.BigEndian.PutUint64(u64[:], 300)
+	expect.Write(u64[:])
+	binary.BigEndian.PutUint64(u64[:], 700)
+	expect.Write(u64[:])
+	binary.BigEndian.PutUint16(u16[:], 6)
+	expect.Write(u16[:])
+	expect.WriteString("ticket")
+	expect.Write(pkg)
+	if !bytes.Equal(body, expect.Bytes()) {
+		t.Errorf("AddEntriesRequest = %x, want %x", body, expect.Bytes())
+	}
+
+	_, err = AddEntriesRequest("", 0, 1, nil, nil)
+	if err == nil {
+		t.Error("AddEntriesRequest with an empty origin = nil error, want error")
+	}
+	_, err = AddEntriesRequest(origin, 2, 1, nil, nil)
+	if err == nil {
+		t.Error("AddEntriesRequest with an inverted interval = nil error, want error")
+	}
+	_, err = AddEntriesRequest(strings.Repeat("a", 0x10000), 0, 1, nil, nil)
+	if err == nil {
+		t.Error("AddEntriesRequest with an oversize origin = nil error, want error")
+	}
+	_, err = AddEntriesRequest(origin, 0, 1, make([]byte, 0x10000), nil)
+	if err == nil {
+		t.Error("AddEntriesRequest with an oversize ticket = nil error, want error")
+	}
+}

--- a/trees/mirror/mirror_test.go
+++ b/trees/mirror/mirror_test.go
@@ -2,11 +2,11 @@ package mirror
 
 import (
 	"bytes"
-	"encoding/binary"
 	"reflect"
 	"strings"
 	"testing"
 
+	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/mod/sumdb/tlog"
 )
 
@@ -175,15 +175,17 @@ func TestEntryPackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EntryPackage: %s", err)
 	}
-	var expect bytes.Buffer
-	expect.Write([]byte{0, 3})
-	expect.WriteString("abc")
-	expect.Write([]byte{0, 2})
-	expect.WriteString("de")
-	expect.WriteByte(1)
-	expect.Write(proof[0][:])
-	if !bytes.Equal(body, expect.Bytes()) {
-		t.Errorf("EntryPackage = %x, want %x", body, expect.Bytes())
+	var expect cryptobyte.Builder
+	expect.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes([]byte("abc"))
+	})
+	expect.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes([]byte("de"))
+	})
+	expect.AddUint8(1)
+	expect.AddBytes(proof[0][:])
+	if !bytes.Equal(body, expect.BytesOrPanic()) {
+		t.Errorf("EntryPackage = %x, want %x", body, expect.BytesOrPanic())
 	}
 
 	_, err = EntryPackage(nil, proof)
@@ -208,22 +210,18 @@ func TestAddEntriesRequest(t *testing.T) {
 		t.Fatalf("AddEntriesRequest: %s", err)
 	}
 
-	var expect bytes.Buffer
-	var u16 [2]byte
-	var u64 [8]byte
-	binary.BigEndian.PutUint16(u16[:], uint16(len(origin))) //nolint:gosec // G115: origin is a short constant.
-	expect.Write(u16[:])
-	expect.WriteString(origin)
-	binary.BigEndian.PutUint64(u64[:], 300)
-	expect.Write(u64[:])
-	binary.BigEndian.PutUint64(u64[:], 700)
-	expect.Write(u64[:])
-	binary.BigEndian.PutUint16(u16[:], 6)
-	expect.Write(u16[:])
-	expect.WriteString("ticket")
-	expect.Write(pkg)
-	if !bytes.Equal(body, expect.Bytes()) {
-		t.Errorf("AddEntriesRequest = %x, want %x", body, expect.Bytes())
+	var expect cryptobyte.Builder
+	expect.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes([]byte(origin))
+	})
+	expect.AddUint64(300)
+	expect.AddUint64(700)
+	expect.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes([]byte("ticket"))
+	})
+	expect.AddBytes(pkg)
+	if !bytes.Equal(body, expect.BytesOrPanic()) {
+		t.Errorf("AddEntriesRequest = %x, want %x", body, expect.BytesOrPanic())
 	}
 
 	_, err = AddEntriesRequest("", 0, 1, nil, nil)


### PR DESCRIPTION
Implement the wire protocol specified in the https://c2sp.org/tlog-witness and  https://c2sp.org/tlog-mirror.

Closes https://github.com/letsencrypt/boulder/issues/8945